### PR TITLE
feat: legible cutout labels + emboss option

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
@@ -4,8 +4,14 @@
  * inside the docked InspectorDock; isolated here to keep files under the line cap.
  */
 
-import type { Cutout, CutoutArrayConfig, CutoutTextSide } from '@/features/bin-designer/types';
+import type {
+  Cutout,
+  CutoutArrayConfig,
+  CutoutTextSide,
+  TextMode,
+} from '@/features/bin-designer/types';
 import { TEXT_MAX_LENGTH } from '@/features/bin-designer/types';
+import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
@@ -25,6 +31,11 @@ import { arrayInstanceCount } from '@/shared/utils/cutoutArray';
 import { Button, Collapsible, Input, SliderInput } from '@/design-system';
 
 const SIDE_OPTIONS: readonly CutoutTextSide[] = ['top', 'bottom', 'left', 'right'] as const;
+/** Cutout labels support recessed + raised text; through-cut would punch the floor. */
+const CUTOUT_TEXT_MODES: readonly Extract<TextMode, 'engrave' | 'emboss'>[] = [
+  'engrave',
+  'emboss',
+] as const;
 
 /**
  * Compact at-a-glance array summary, e.g. `6×3 · 18` (grid) or `⟳ 8` (radial).
@@ -242,9 +253,10 @@ interface CutoutEngraveLabelControlsProps {
 }
 
 /**
- * Compact engraved-label controls: toggle, text input, and side picker. Mode +
- * font + depth use the design-level `textDefaults`; per-instance overrides are
- * deferred to a follow-up.
+ * Compact label controls: text input, style (engrave/emboss) picker, and side
+ * picker. Style + font + depth use the design-level `textDefaults`; per-instance
+ * overrides are deferred to a follow-up. Through-cut is omitted here — it would
+ * punch bin-top text through the floor, so the generator degrades it to engrave.
  */
 function CutoutEngraveLabelControls({
   cutout,
@@ -253,6 +265,11 @@ function CutoutEngraveLabelControls({
 }: CutoutEngraveLabelControlsProps) {
   const t = useTranslation();
   const side = cutout.textSide ?? 'top';
+  const textMode = useDesignerStore((s) => s.params.textDefaults.mode);
+  const setTextDefaults = useDesignerStore((s) => s.setTextDefaults);
+  // Through-cut isn't offered for cutouts; show it as engrave so the picker
+  // reflects what the generator will actually produce.
+  const effectiveMode: 'engrave' | 'emboss' = textMode === 'emboss' ? 'emboss' : 'engrave';
 
   const handleTextChange = (text: string) => {
     onUpdate({ label: text, engraveLabel: text.length > 0 });
@@ -270,6 +287,21 @@ function CutoutEngraveLabelControls({
         placeholder={t('binDesigner.cutoutEngraveLabelPlaceholder')}
         aria-label={t('binDesigner.cutoutEngraveLabel')}
       />
+      <div role="group" aria-label={t('binDesigner.textMode')} className={SEGMENT_GROUP_CLASS}>
+        {CUTOUT_TEXT_MODES.map((opt) => (
+          <Button
+            key={opt}
+            type="button"
+            variant="ghost"
+            disabled={disabled}
+            onClick={() => setTextDefaults({ mode: opt })}
+            aria-pressed={effectiveMode === opt}
+            className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(effectiveMode === opt)}`}
+          >
+            {t(`binDesigner.textMode.${opt}`)}
+          </Button>
+        ))}
+      </div>
       <div
         role="group"
         aria-label={t('binDesigner.cutoutTextSide')}
@@ -289,11 +321,6 @@ function CutoutEngraveLabelControls({
           </Button>
         ))}
       </div>
-      {cutout.engraveLabel && (
-        <p className="text-[10px] text-content-disabled">
-          {t('binDesigner.cutoutEngraveLabelEngraveOnly')}
-        </p>
-      )}
     </div>
   );
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.test.tsx
@@ -5,7 +5,7 @@ import { CutoutLabel3D } from './CutoutLabel3D';
  * CutoutLabel3D is an R3F component that renders drei <Text> and reads the
  * designer store. R3F components can't be rendered in jsdom, so we assert the
  * export contract here; placement logic is covered in
- * `@/shared/utils/cutoutLabel.test.ts`.
+ * `@/shared/utils/cutoutLabel.test.ts` and color logic in `cutoutLabelColor.test.ts`.
  */
 describe('CutoutLabel3D', () => {
   it('exports a function component', () => {

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
@@ -6,9 +6,9 @@
  * and side come from the shared `cutoutLabelPlacement` helper so the on-screen
  * text tracks the printed label. Font size is auto-fit to the available band
  * (approximated — the worker measures exact glyph metrics via brepjs). Text
- * color is chosen for contrast against the cutout fill (see
- * `contrastingTextColor`) rather than the theme, so a light filament color no
- * longer makes white labels vanish.
+ * color is chosen for contrast against the cutout fill (see `cutoutLabelColor`)
+ * rather than the theme, so a light filament color no longer makes white labels
+ * vanish.
  */
 
 import { useMemo } from 'react';

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
@@ -1,30 +1,37 @@
 /**
- * Engraved cutout labels drawn on the 2D editor surface.
+ * Cutout labels drawn on the 2D editor surface.
  *
- * Mirrors what the generation worker engraves into the bin top: one label per
- * cutout that has `engraveLabel` set and a non-empty label. Position and side
- * come from the shared `cutoutLabelPlacement` helper so the on-screen text
- * tracks the printed engraving. Font size is auto-fit to the available band
- * (approximated — the worker measures exact glyph metrics via brepjs).
+ * Mirrors what the generation worker engraves or embosses on the bin top: one
+ * label per cutout that has `engraveLabel` set and a non-empty label. Position
+ * and side come from the shared `cutoutLabelPlacement` helper so the on-screen
+ * text tracks the printed label. Font size is auto-fit to the available band
+ * (approximated — the worker measures exact glyph metrics via brepjs). Text
+ * color is chosen for contrast against the cutout fill (see
+ * `contrastingTextColor`) rather than the theme, so a light filament color no
+ * longer makes white labels vanish.
  */
 
+import { useMemo } from 'react';
 import { Text } from '@react-three/drei';
 import type { Cutout } from '@/features/bin-designer/types';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { cutoutLabelPlacement, type CutoutLabelPlacement } from '@/shared/utils/cutoutLabel';
-import { useThreeColors } from '@/shared/hooks/useThemeEffect';
 import type { TextStyleDefaults } from '@/features/bin-designer/types';
 import type { PreviewMap } from '../useCutoutInteraction';
+import { cutoutLabelColor } from './cutoutLabelColor';
 
 interface CutoutLabel3DProps {
   readonly cutouts: readonly Cutout[];
   readonly binWidth: number;
   readonly binDepth: number;
+  /** Bin surface color — the label sits on the darkened cutout fill derived
+   *  from it, so text contrast is computed against that, not the theme. */
+  readonly binColor: string;
   /** Live drag/resize overrides so labels follow their cutout mid-interaction. */
   readonly preview: PreviewMap;
 }
 
-const TEXT_OPACITY = 0.7;
+const TEXT_OPACITY = 0.85;
 /** Approximate width of a glyph relative to font size for drei's SDF font. */
 const CHAR_WIDTH_RATIO = 0.6;
 
@@ -47,9 +54,18 @@ function fitLabelFontSize(
   return Math.min(fitted, textDefaults.maxFontSize);
 }
 
-export function CutoutLabel3D({ cutouts, binWidth, binDepth, preview }: CutoutLabel3DProps) {
-  const colors = useThreeColors();
+export function CutoutLabel3D({
+  cutouts,
+  binWidth,
+  binDepth,
+  binColor,
+  preview,
+}: CutoutLabel3DProps) {
   const textDefaults = useDesignerStore((s) => s.params.textDefaults);
+
+  // The label floats over the darkened cutout fill, so derive its color from
+  // that fill's luminance — matching the darkening in `CutoutShapeMesh`.
+  const labelColor = useMemo(() => cutoutLabelColor(binColor), [binColor]);
 
   return (
     <>
@@ -72,7 +88,7 @@ export function CutoutLabel3D({ cutouts, binWidth, binDepth, preview }: CutoutLa
             key={`label-${cutout.id}`}
             position={[placement.centerX, placement.centerY, 0.05]}
             fontSize={fontSize}
-            color={colors.labelColor}
+            color={labelColor}
             fillOpacity={TEXT_OPACITY}
             anchorX="center"
             anchorY="middle"

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
@@ -369,7 +369,13 @@ export function SceneContent({
       })()}
 
       {/* Engraved labels mirroring the printed bin-top engraving */}
-      <CutoutLabel3D cutouts={cutouts} binWidth={binWidth} binDepth={binDepth} preview={preview} />
+      <CutoutLabel3D
+        cutouts={cutouts}
+        binWidth={binWidth}
+        binDepth={binDepth}
+        binColor={binColor}
+        preview={preview}
+      />
 
       {/* Lock badges on locked cutouts */}
       {cutouts

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
@@ -368,7 +368,7 @@ export function SceneContent({
         );
       })()}
 
-      {/* Engraved labels mirroring the printed bin-top engraving */}
+      {/* Engraved/embossed labels mirroring the printed bin-top text */}
       <CutoutLabel3D
         cutouts={cutouts}
         binWidth={binWidth}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/cutoutLabelColor.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/cutoutLabelColor.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { cutoutLabelColor } from './cutoutLabelColor';
+
+describe('cutoutLabelColor', () => {
+  it('uses dark text over a light filament color', () => {
+    // White filament → light cut floor → dark text stays readable. This is the
+    // regression: the label used to be white and vanished here.
+    expect(cutoutLabelColor('#ffffff')).toBe('#000000');
+    expect(cutoutLabelColor('#e8e4d8')).toBe('#000000');
+  });
+
+  it('uses white text over a dark filament color', () => {
+    expect(cutoutLabelColor('#000000')).toBe('#ffffff');
+    expect(cutoutLabelColor('#1a1a2e')).toBe('#ffffff');
+  });
+
+  it('accounts for the cut-floor darkening, not the raw bin color', () => {
+    // A mid-tone bin color darkens to ~0.7× before the label sits on it, so a
+    // color that looks borderline-light still resolves to white text.
+    expect(cutoutLabelColor('#8a8a8a')).toBe('#ffffff');
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/cutoutLabelColor.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/cutoutLabelColor.ts
@@ -1,0 +1,25 @@
+/**
+ * Contrast color for cutout labels drawn on the 2D editor surface.
+ *
+ * Lives apart from the `CutoutLabel3D` component so the renderer file only
+ * exports components (react-refresh / fast-refresh requirement).
+ */
+
+import * as THREE from 'three';
+
+/** Same darkening `CutoutShapeMesh` applies to the bin color for the cut floor. */
+const CUT_FILL_DARKEN = 0.7;
+
+/**
+ * Black or white label color for legibility against the cutout fill.
+ *
+ * The label renders on the darkened cutout floor (`binColor × CUT_FILL_DARKEN`,
+ * matching `CutoutShapeMesh`), so contrast is computed from that fill's relative
+ * luminance — NOT the theme. Keying off the theme is what made white labels
+ * vanish over a light filament color.
+ */
+export function cutoutLabelColor(binColor: string): string {
+  const fill = new THREE.Color(binColor).multiplyScalar(CUT_FILL_DARKEN);
+  const luminance = 0.2126 * fill.r + 0.7152 * fill.g + 0.0722 * fill.b;
+  return luminance > 0.5 ? '#000000' : '#ffffff';
+}

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -940,11 +940,27 @@ function buildArrayUngroupedCutouts(
 }
 
 /**
- * Build the list of cutout cavity cut tools for a solid bin.
- * Each entry is one logical cutout (an ungrouped cutout, a fused-and-scooped
+ * Cut and fuse tool sets for a solid bin's cutouts.
+ *
+ * `cutTools` are subtractive (cavities + engraved label text); `fuseTools` are
+ * additive (embossed label text raised above the bin top). They go to separate
+ * boolean passes — booleanStage fuses first, then cuts.
+ */
+export interface CutoutTools {
+  readonly cutTools: Shape3D[];
+  readonly fuseTools: Shape3D[];
+}
+
+/** Lift the emboss clip ceiling a hair above the raised text so it isn't grazed. */
+const CUTOUT_BOOLEAN_EPSILON = 0.1;
+
+/**
+ * Build the cut and fuse tool sets for a solid bin's cutouts.
+ * Each cut entry is one logical cutout (an ungrouped cutout, a fused-and-scooped
  * group, or an engraved label) clipped to the bin interior. The pipeline
  * subtracts them from the shell via the booleanStage's cutAllBisect, which
- * recovers individual tool failures instead of dropping the whole set.
+ * recovers individual tool failures instead of dropping the whole set. Embossed
+ * labels are returned as fuse tools instead, raised above the bin top.
  *
  * @param params - Bin configuration (reads cutouts array and cutoutConfig.topOffset)
  * @param innerW - Interior width in mm (outer - 2*wall)
@@ -956,8 +972,8 @@ export function buildCutoutCuts(
   innerW: number,
   innerD: number,
   wallHeight: number
-): Shape3D[] {
-  if (params.cutouts.length === 0) return [];
+): CutoutTools {
+  if (params.cutouts.length === 0) return { cutTools: [], fuseTools: [] };
 
   // Cutout x,y are relative to interior bottom-left corner (0,0).
   // The bin body is centered at model origin, so interior left/front is at -innerW/2, -innerD/2.
@@ -970,7 +986,7 @@ export function buildCutoutCuts(
 
   // Guard: if solidSurfaceZ is non-positive, there's no valid cutting surface
   // (the solid fill is at or below floor level). Skip all cutouts.
-  if (solidSurfaceZ <= 0) return [];
+  if (solidSurfaceZ <= 0) return { cutTools: [], fuseTools: [] };
 
   const rawShapes: Shape3D[] = [];
 
@@ -1000,16 +1016,18 @@ export function buildCutoutCuts(
     if (shape) rawShapes.push(shape);
   }
 
-  // Per-cutout engraved label text on the bin top, adjacent to each cutout in
-  // the user-picked side direction. Engrave-only (emboss requires a fuse-
-  // target pass which lives in a follow-up; through-cut is meaningless on
-  // bin-top text since it would punch through the bin floor).
+  // Per-cutout label text on the bin top, adjacent to each cutout in the
+  // user-picked side direction. The design-level mode picks engrave (cut into
+  // the surface) or emboss (raised above it); through-cut falls back to engrave
+  // since punching bin-top text through the floor is meaningless. Engraved text
+  // joins the cut pile; embossed text is collected separately for fusing.
+  const rawFuseShapes: Shape3D[] = [];
   for (const cutout of params.cutouts) {
     if (cutout.hidden === true) continue;
     if (cutout.engraveLabel !== true) continue;
     const label = cutout.label.trim();
     if (label === '') continue;
-    const textShape = buildCutoutLabelEngrave(
+    const textShape = buildCutoutLabel(
       cutout,
       label,
       params.textDefaults,
@@ -1019,25 +1037,57 @@ export function buildCutoutCuts(
       innerW,
       innerD
     );
-    if (textShape) rawShapes.push(textShape);
+    if (!textShape) continue;
+    if (textShape.op === 'fuse') rawFuseShapes.push(textShape.solid);
+    else rawShapes.push(textShape.solid);
   }
 
-  if (rawShapes.length === 0) return [];
+  if (rawShapes.length === 0 && rawFuseShapes.length === 0) {
+    return { cutTools: [], fuseTools: [] };
+  }
 
   // Clip each tool individually to the bin interior so cutouts extending past
   // the walls don't punch through them. Shapes that fail to clip are skipped
-  // rather than poisoning the whole set.
+  // rather than poisoning the whole set. Cut tools live at or below the bin top,
+  // so a box spanning the fill height contains them. Embossed text rises ABOVE
+  // the top, so its clip box must be tall enough to keep the raised geometry —
+  // an interior-height box would shear it off.
+  const cutTools = clipToInterior(rawShapes, innerW, innerD, solidSurfaceZ);
+  const fuseTools =
+    rawFuseShapes.length > 0
+      ? clipToInterior(
+          rawFuseShapes,
+          innerW,
+          innerD,
+          solidSurfaceZ + params.textDefaults.depth + CUTOUT_BOOLEAN_EPSILON
+        )
+      : [];
+  return { cutTools, fuseTools };
+}
+
+/**
+ * Intersect each shape with an interior box of the given height (bottom at
+ * z=0), consuming the inputs. Tools that fail to clip are dropped rather than
+ * poisoning the whole set.
+ */
+function clipToInterior(
+  shapes: Shape3D[],
+  innerW: number,
+  innerD: number,
+  boxHeight: number
+): Shape3D[] {
+  if (shapes.length === 0) return [];
   let clipBoundary: Shape3D;
   try {
-    clipBoundary = box(innerW, innerD, solidSurfaceZ, { at: [0, 0, solidSurfaceZ / 2] });
+    clipBoundary = box(innerW, innerD, boxHeight, { at: [0, 0, boxHeight / 2] });
   } catch (e) {
-    for (const s of rawShapes) s.delete();
+    for (const s of shapes) s.delete();
     throw e;
   }
 
   const clipped: Shape3D[] = [];
   try {
-    for (const shape of rawShapes) {
+    for (const shape of shapes) {
       try {
         clipped.push(unwrap(intersect(shape, clipBoundary)));
       } catch {
@@ -1052,8 +1102,14 @@ export function buildCutoutCuts(
   return clipped;
 }
 
+/** A cutout label solid plus how it must be applied to the bin. */
+interface CutoutLabelShape {
+  readonly solid: Shape3D;
+  readonly op: 'cut' | 'fuse';
+}
+
 /**
- * Engraved text adjacent to a cutout, on the bin top surface.
+ * Label text adjacent to a cutout, on the bin top surface.
  *
  * The side picker is interpreted in WORLD coordinates (top = +Y, etc.); text
  * reads left-to-right in world XY regardless of cutout rotation. The cutout
@@ -1061,12 +1117,16 @@ export function buildCutoutCuts(
  * cutout's footprint — `cutoutWorldAabb()` projects the four rotated corners
  * and takes their min/max.
  *
+ * The design-level mode selects `engrave` (recessed, returned with `op: 'cut'`)
+ * or `emboss` (raised, returned with `op: 'fuse'`). `through-cut` falls back to
+ * engrave — punching bin-top text through the floor is meaningless.
+ *
  * Placement (side gap + rotation-aware AABB) is delegated to
  * `cutoutLabelPlacement` so the 2D editor preview tracks this engraving.
  * Returns `null` when there's no room or the minimum font size won't fit —
  * better a silent skip than a visually broken engraving.
  */
-function buildCutoutLabelEngrave(
+function buildCutoutLabel(
   cutout: Cutout,
   label: string,
   textDefaults: BinParams['textDefaults'],
@@ -1075,19 +1135,20 @@ function buildCutoutLabelEngrave(
   originY: number,
   innerW: number,
   innerD: number
-): Shape3D | null {
+): CutoutLabelShape | null {
   const placement = cutoutLabelPlacement(cutout, innerW, innerD, originX, originY);
   if (!placement) return null;
   const { centerX, centerY, availW, availD } = placement;
 
-  return withScope((scope: DisposalScope): Shape3D | null => {
-    // Cutout text is engrave-only this PR. The design-level mode is
-    // intentionally ignored for cutouts (emboss-on-cutouts is a follow-up
-    // that needs a fuse-target builder; through-cut would punch the floor).
+  // Cutouts support engrave + emboss; through-cut would punch the floor, so it
+  // degrades to engrave.
+  const mode = textDefaults.mode === 'emboss' ? 'emboss' : 'engrave';
+
+  return withScope((scope: DisposalScope): CutoutLabelShape | null => {
     const result = buildTextSolid(scope, {
       text: label,
       fontFamily: textDefaults.font,
-      mode: 'engrave',
+      mode,
       availW,
       availD,
       centerX,
@@ -1099,6 +1160,7 @@ function buildCutoutLabelEngrave(
       minFontSize: textDefaults.minFontSize,
       maxFontSize: textDefaults.maxFontSize,
     });
-    return result ? unwrap(clone(result.solid)) : null;
+    if (!result) return null;
+    return { solid: unwrap(clone(result.solid)), op: result.op };
   });
 }

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -3,6 +3,10 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
 import type { BinParams } from '@/shared/types/bin';
 import type { Shape3D } from 'brepjs';
+import { loadFont } from 'brepjs';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { isErr } from '@/core/result';
 import { initTestKernel } from '@/test/initTestKernel';
 
 type BuildCompartmentWallsFn = (
@@ -52,6 +56,17 @@ let meshShape: (shape: unknown) => { vertices: ArrayLike<number>; triangles: Arr
 beforeAll(async () => {
   const { mesh: meshFn } = await import('brepjs');
   await initTestKernel();
+
+  // Cutout-label tests need the bundled Atkinson font (the textDefaults default);
+  // load from disk since the test env has no `fetch` for `?url` assets.
+  const buffer = readFileSync(
+    resolve(__dirname, '../assets/fonts/AtkinsonHyperlegible-Regular.ttf')
+  );
+  const fontResult = await loadFont(
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+    'atkinson'
+  );
+  if (isErr(fontResult)) throw new Error(`Font load failed: ${fontResult.error.message}`);
 
   const mod = await import('./featureBuilder');
   buildCompartmentWalls = mod.buildCompartmentWalls;
@@ -283,12 +298,12 @@ describe('buildInsertCuts', () => {
 });
 
 describe('buildCutoutCuts', () => {
-  it('returns an empty list when no cutouts are configured', () => {
+  it('returns empty cut and fuse lists when no cutouts are configured', () => {
     const params: BinParams = { ...DEFAULT_BIN_PARAMS, cutouts: [] };
-    expect(buildCutoutCuts(params, 80, 80, 16)).toEqual([]);
+    expect(buildCutoutCuts(params, 80, 80, 16)).toEqual({ cutTools: [], fuseTools: [] });
   });
 
-  it('returns one tool per logical cutout for boolean subtraction', () => {
+  it('returns one cut tool per logical cutout for boolean subtraction', () => {
     const params: BinParams = {
       ...DEFAULT_BIN_PARAMS,
       cutoutConfig: { topOffset: 0 },
@@ -308,9 +323,41 @@ describe('buildCutoutCuts', () => {
         },
       ],
     };
-    const tools = buildCutoutCuts(params, 80, 80, 16);
-    expect(tools).toHaveLength(1);
-    const meshed = meshShape(tools[0]);
+    const { cutTools, fuseTools } = buildCutoutCuts(params, 80, 80, 16);
+    expect(cutTools).toHaveLength(1);
+    expect(fuseTools).toHaveLength(0);
+    const meshed = meshShape(cutTools[0]);
+    expect(meshed.vertices.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it('returns an embossed label as a fuse tool, not a cut', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      cutoutConfig: { topOffset: 0 },
+      textDefaults: { ...DEFAULT_BIN_PARAMS.textDefaults, mode: 'emboss' },
+      cutouts: [
+        {
+          id: 'c1',
+          shape: 'rectangle',
+          width: 15,
+          depth: 15,
+          cutDepth: 5,
+          x: 10,
+          y: 30,
+          rotation: 0,
+          cornerRadius: 0,
+          label: 'HI',
+          engraveLabel: true,
+          textSide: 'top',
+          groupId: null,
+        },
+      ],
+    };
+    const { cutTools, fuseTools } = buildCutoutCuts(params, 80, 80, 16);
+    // One cavity cut + one emboss fuse; the cavity stays subtractive.
+    expect(cutTools).toHaveLength(1);
+    expect(fuseTools).toHaveLength(1);
+    const meshed = meshShape(fuseTools[0]);
     expect(meshed.vertices.length).toBeGreaterThan(0);
   }, 30000);
 });

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -43,18 +43,28 @@ export const featuresStage: PipelineStage = {
       // booleanStage early-returns when ctx.solid is null; building tools
       // we'd never apply would just leak their WASM shapes.
       if (!ctx.solid) return ctx;
-      const rawTools = buildCutoutCuts(params, dim.innerW, dim.innerD, dim.wallHeight);
+      const { cutTools, fuseTools } = buildCutoutCuts(
+        params,
+        dim.innerW,
+        dim.innerD,
+        dim.wallHeight
+      );
       const { innerOffsetX, innerOffsetY } = dim;
-      const cutoutTools = rawTools.map((tool) => {
+      const shiftToInterior = (tool: (typeof cutTools)[number]): (typeof cutTools)[number] => {
         if (innerOffsetX === 0 && innerOffsetY === 0) return tool;
         const shifted = translate(tool, [innerOffsetX, innerOffsetY, 0]);
         tool.delete();
         return shifted;
-      });
+      };
+      const cutoutTools = cutTools.map(shiftToInterior);
+      const embossTools = fuseTools.map(shiftToInterior);
       for (const tool of cutoutTools) {
         collectOrigins(tool, FeatureTag.CUTOUT, originToTag);
       }
-      return { ...ctx, cutTargets: cutoutTools };
+      for (const tool of embossTools) {
+        collectOrigins(tool, FeatureTag.TEXT, originToTag);
+      }
+      return { ...ctx, cutTargets: cutoutTools, fuseTargets: embossTools };
     }
 
     // For non-rectangular (cellMask) bins, run only builders that have

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "Vergrößern",
   "binDesigner.cutoutEditor.zoomOut": "Verkleinern",
   "binDesigner.cutoutEngraveLabel": "Beschriftung gravieren",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "Aussparungs-Beschriftungen werden immer in die Behälteroberseite graviert.",
   "binDesigner.cutoutEngraveLabelPlaceholder": "e.g. M4×20",
   "binDesigner.cutoutTextSide": "Beschriftungsposition",
   "binDesigner.cutoutTextSide.bottom": "Unten",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1491,8 +1491,6 @@ const en: Record<string, string> = {
   'binDesigner.textDepth': 'Text depth',
   'binDesigner.cutoutEngraveLabel': 'Engrave label',
   'binDesigner.cutoutEngraveLabelPlaceholder': 'e.g. M4×20',
-  'binDesigner.cutoutEngraveLabelEngraveOnly':
-    'Cutout labels are always engraved into the bin top.',
   'binDesigner.cutoutTextSide': 'Label position',
   'binDesigner.cutoutTextSide.top': 'Above',
   'binDesigner.cutoutTextSide.bottom': 'Below',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "Acercar",
   "binDesigner.cutoutEditor.zoomOut": "Alejar",
   "binDesigner.cutoutEngraveLabel": "Grabar etiqueta",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "Las etiquetas de los recortes siempre se graban en la parte superior.",
   "binDesigner.cutoutEngraveLabelPlaceholder": "e.g. M4×20",
   "binDesigner.cutoutTextSide": "Posición de la etiqueta",
   "binDesigner.cutoutTextSide.bottom": "Abajo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "Zoom avant",
   "binDesigner.cutoutEditor.zoomOut": "Zoom arrière",
   "binDesigner.cutoutEngraveLabel": "Graver l'étiquette",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "Les étiquettes de découpes sont toujours gravées dans le dessus du bac.",
   "binDesigner.cutoutEngraveLabelPlaceholder": "e.g. M4×20",
   "binDesigner.cutoutTextSide": "Position de l'étiquette",
   "binDesigner.cutoutTextSide.bottom": "En dessous",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "ズームイン",
   "binDesigner.cutoutEditor.zoomOut": "ズームアウト",
   "binDesigner.cutoutEngraveLabel": "ラベルを彫刻",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "切り欠きラベルは常にビン上部に彫刻されます。",
   "binDesigner.cutoutEngraveLabelPlaceholder": "例: M4×20",
   "binDesigner.cutoutTextSide": "ラベル位置",
   "binDesigner.cutoutTextSide.bottom": "下",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "Zoom inn",
   "binDesigner.cutoutEditor.zoomOut": "Zoom ut",
   "binDesigner.cutoutEngraveLabel": "Graver merkelapp",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "Utskjæringsmerkelapper graveres alltid inn i toppen.",
   "binDesigner.cutoutEngraveLabelPlaceholder": "e.g. M4×20",
   "binDesigner.cutoutTextSide": "Merkelapposisjon",
   "binDesigner.cutoutTextSide.bottom": "Under",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "Inzoomen",
   "binDesigner.cutoutEditor.zoomOut": "Uitzoomen",
   "binDesigner.cutoutEngraveLabel": "Label graveren",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "Uitsparingslabels worden altijd in de bovenkant gegraveerd.",
   "binDesigner.cutoutEngraveLabelPlaceholder": "e.g. M4×20",
   "binDesigner.cutoutTextSide": "Labelpositie",
   "binDesigner.cutoutTextSide.bottom": "Onder",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "Aumentar zoom",
   "binDesigner.cutoutEditor.zoomOut": "Diminuir zoom",
   "binDesigner.cutoutEngraveLabel": "Gravar etiqueta",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "As etiquetas de recortes são sempre gravadas no topo.",
   "binDesigner.cutoutEngraveLabelPlaceholder": "e.g. M4×20",
   "binDesigner.cutoutTextSide": "Posição da etiqueta",
   "binDesigner.cutoutTextSide.bottom": "Abaixo",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "Zooma in",
   "binDesigner.cutoutEditor.zoomOut": "Zooma ut",
   "binDesigner.cutoutEngraveLabel": "Gravera etikett",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "Urskärningsetiketter graveras alltid in i toppen.",
   "binDesigner.cutoutEngraveLabelPlaceholder": "e.g. M4×20",
   "binDesigner.cutoutTextSide": "Etikettposition",
   "binDesigner.cutoutTextSide.bottom": "Nedanför",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -278,7 +278,6 @@
   "binDesigner.cutoutEditor.zoomIn": "Збільшити",
   "binDesigner.cutoutEditor.zoomOut": "Зменшити",
   "binDesigner.cutoutEngraveLabel": "Гравірувати напис",
-  "binDesigner.cutoutEngraveLabelEngraveOnly": "Написи отворів завжди гравіруються у верхню частину.",
   "binDesigner.cutoutEngraveLabelPlaceholder": "e.g. M4×20",
   "binDesigner.cutoutTextSide": "Положення напису",
   "binDesigner.cutoutTextSide.bottom": "Знизу",


### PR DESCRIPTION
## Summary

Two related improvements to cutout labels in the bin designer:

1. **Legible canvas labels (fix).** Cutout label text on the 2D editor canvas was colored from the *theme* (white in dark mode), but the label floats over the darkened cutout fill (`binColor × 0.7`), which tracks the *filament* color, not the theme. A light filament in dark mode rendered white-on-light = invisible. Label color is now derived from the cutout fill's relative luminance (black or white for guaranteed contrast), and opacity bumped `0.7 → 0.85`.

2. **Emboss for cutout text (feat).** Cutout labels were hardcoded to `engrave`. They now follow the design-level `textDefaults.mode` — `engrave` (recessed/cut) or `emboss` (raised/fused). `through-cut` degrades to engrave (punching bin-top text through the floor is meaningless). An engrave/emboss picker was added to the cutout label inspector.

## Implementation notes

- `buildCutoutCuts` now returns `{ cutTools, fuseTools }`. Emboss text must be **fused**, not cut, so it leaves the cut pile and gets a taller interior clip box so the raised geometry isn't sheared. `featuresStage` routes fuse tools to `fuseTargets` (tagged `FeatureTag.TEXT`).
- The contrast helper lives in its own module (`cutoutLabelColor.ts`) so the renderer file only exports components (fast-refresh).
- Removed the now-false "engrave only" note + its i18n key across all 10 locales.

## Testing

- `pnpm run quality` (typecheck + lint + knip) — clean (0 errors)
- `buildCutoutCuts` unit tests incl. new emboss→fuse-tool assertion
- `cutoutLabelColor` contrast unit tests
- 48 solid-cutout scenario tests pass
- Component contract + inspector tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)