### PR TITLE
fix(ui): settings search icon sizing + cutout inspector hint spacing

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutBoardSettings.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutBoardSettings.tsx
@@ -35,7 +35,7 @@ export function CutoutBoardSettings({
 }: CutoutBoardSettingsProps) {
   const t = useTranslation();
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 pt-3">
       {/* Selection guidance — kept distinct from the board settings below. */}
       <p className="text-[11px] leading-relaxed text-content-tertiary">
         {t('binDesigner.cutoutEditor.inspectorEmptyHint')}

--- a/src/index.css
+++ b/src/index.css
@@ -543,9 +543,11 @@ input[type='number'] {
   -moz-appearance: textfield;
 }
 
-/* Hide native search clear button; inputs provide their own clear control */
-input[type='search']::-webkit-search-cancel-button,
-input[type='search']::-webkit-search-decoration {
+/* Hide native search clear button only where a custom clear control exists
+   (the combobox search inputs). Plain type="search" fields keep the browser's
+   native clear affordance. */
+input[type='search'][role='combobox']::-webkit-search-cancel-button,
+input[type='search'][role='combobox']::-webkit-search-decoration {
   -webkit-appearance: none;
   appearance: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -543,6 +543,13 @@ input[type='number'] {
   -moz-appearance: textfield;
 }
 
+/* Hide native search clear button; inputs provide their own clear control */
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 /* Custom scrollbar */
 .scrollbar-thin {
   scrollbar-width: thin;

--- a/src/shell/Modals/SettingsModal/components/SettingsSearch/SettingsSearch.tsx
+++ b/src/shell/Modals/SettingsModal/components/SettingsSearch/SettingsSearch.tsx
@@ -71,7 +71,7 @@ export function SettingsSearch({ query, onQueryChange }: SettingsSearchProps) {
         fullWidth
         size="sm"
         className="pl-2"
-        leftIcon={<SearchIcon />}
+        leftIcon={<SearchIcon size="sm" />}
         rightIcon={
           query ? (
             <IconButton


### PR DESCRIPTION
## Summary

Three small UI fixes in the Settings modal and cutout editor inspector.

- **Settings search icon was oversized.** `<SearchIcon />` had no `size` prop so it defaulted to `md` (20px) inside a small (`h-7`) input — the `<Icon>` SVG's own width/height classes override the input's icon-slot sizing. Now passes `size="sm"` to match the input and the clear (`XIcon`) button.
- **Search input "weird selected state."** Because the field is `type="search"`, WebKit renders its own native × clear button next to the custom one whenever there's a value. Added a global reset for `::-webkit-search-cancel-button` / `::-webkit-search-decoration` (alongside the existing number-spinner reset) so only the design-system clear button shows.
- **Cutout inspector empty-state hint clipped by header.** The dock's scroll body uses `pt-0` on purpose so the single-cutout inspector's full-bleed banded sections butt against the header. The board-settings/no-selection view is plain text with no band, so its "Select a shape to edit its properties" hint sat flush under the header border. Added `pt-3` to that surface only.

## Test plan

- [ ] Open Settings → search icon is appropriately sized; typing shows a single clear button.
- [ ] Open cutout editor with nothing selected → hint text clears the inspector header.
- [ ] Select a single cutout → banded sections still sit flush against the header (unchanged).