### PR TITLE
fix(scan): detect color-neutral cards via chroma channel sweep

### DIFF
--- a/src/shared/scanTrace/cardDetect.test.ts
+++ b/src/shared/scanTrace/cardDetect.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { detectCardQuad, cardPerspectiveSkew, STEEP_CARD_SKEW } from './cardDetect';
+import {
+  detectCardQuad,
+  findBestCardComponent,
+  cardPerspectiveSkew,
+  STEEP_CARD_SKEW,
+} from './cardDetect';
+import { buildMask } from './mask';
+import { labelComponents } from './components';
 import { rectifyPoints } from './perspective';
 import type { ImageDataLike, Point } from './types';
 
@@ -89,6 +96,35 @@ function render(
   return { width, height, data };
 }
 
+type Rgb = readonly [number, number, number];
+
+/** Like `render`, but each layer carries an RGB color over a colored background. */
+function renderRgb(
+  layers: Array<{ poly: Point[]; rgb: Rgb }>,
+  background: Rgb,
+  width = 360,
+  height = 260
+): ImageDataLike {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const o = (y * width + x) * 4;
+      let rgb = background;
+      for (const layer of layers) {
+        if (pointInPolygon({ x, y }, layer.poly)) {
+          rgb = layer.rgb;
+          break;
+        }
+      }
+      data[o] = rgb[0];
+      data[o + 1] = rgb[1];
+      data[o + 2] = rgb[2];
+      data[o + 3] = 255;
+    }
+  }
+  return { width, height, data };
+}
+
 function bbox(points: readonly Point[]): { w: number; h: number } {
   const xs = points.map((p) => p.x);
   const ys = points.map((p) => p.y);
@@ -133,6 +169,39 @@ describe('detectCardQuad (end-to-end, pinhole projection)', () => {
       const nearCard = card.some((e) => Math.hypot(c.x - e.x, c.y - e.y) < 4);
       expect(nearCard).toBe(true);
     });
+  });
+});
+
+describe('detectCardQuad on a color-neutral card (the silver-card-on-wood case)', () => {
+  // A brushed-metal card on warm wood: near-identical *luminance* (so a grayscale
+  // threshold can't separate them) but very different *chroma*. Both ~116 luma;
+  // wood is saturated (chroma 90), the card is neutral (chroma 0).
+  const WOOD: Rgb = [150, 110, 60];
+  const CARD: Rgb = [116, 116, 116];
+
+  it('luma alone cannot find the card (regression guard)', () => {
+    const image = renderRgb([{ poly: project(CARD_MM), rgb: CARD }], WOOD);
+    const labeled = labelComponents(buildMask(image)); // default channel: luma
+    expect(findBestCardComponent(labeled, image.width, image.height)).toBeNull();
+  });
+
+  it('the chroma sweep recovers the card and rectifies the tool to true mm', () => {
+    const image = renderRgb(
+      [
+        { poly: project(CARD_MM), rgb: CARD },
+        { poly: project(TOOL_MM), rgb: [40, 40, 40] },
+      ],
+      WOOD
+    );
+
+    const detection = detectCardQuad(image);
+    expect(detection).not.toBeNull();
+    if (!detection) return;
+    expect(detection.fitness).toBeGreaterThan(0.9);
+
+    const out = bbox(rectifyPoints(project(TOOL_MM), detection.homography));
+    expect(Math.abs(out.w - 25)).toBeLessThan(2.5);
+    expect(Math.abs(out.h - 45)).toBeLessThan(2.5);
   });
 });
 

--- a/src/shared/scanTrace/cardDetect.ts
+++ b/src/shared/scanTrace/cardDetect.ts
@@ -155,12 +155,12 @@ export function findCardAcrossChannels(
   image: ImageDataLike,
   options: CardDetectOptions = {}
 ): CardComponent | null {
-  for (const channel of CARD_CHANNELS) {
+  // An alpha-driven mask ignores `channel`, so every pass is identical — sweep once.
+  const channels = usesAlphaMask(image) ? (['luma'] as const) : CARD_CHANNELS;
+  for (const channel of channels) {
     const labeled = labelComponents(buildMask(image, { channel }));
     const card = findBestCardComponent(labeled, image.width, image.height, options);
     if (card) return card;
-    // An alpha-driven mask ignores `channel`, so further passes are identical.
-    if (usesAlphaMask(image)) break;
   }
   return null;
 }

--- a/src/shared/scanTrace/cardDetect.ts
+++ b/src/shared/scanTrace/cardDetect.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ImageDataLike, Point } from './types';
-import { buildMask } from './mask';
+import { buildMask, usesAlphaMask } from './mask';
 import { labelComponents, maskFromLabel, type LabeledComponents } from './components';
 import { traceContour } from './contour';
 import { contourToQuad, estimateRectAspect } from './quad';
@@ -141,12 +141,35 @@ export function findBestCardComponent(
   return best;
 }
 
+/**
+ * The card is a clean quad in whichever channel happens to separate it from its
+ * background — brightness for a dark card on a pale desk, colorfulness for a
+ * neutral metal card on wood. Sweep luma first, then chroma, taking the first
+ * channel that yields an accepted card. Luma-first keeps the chroma pass purely
+ * additive: any photo a brightness threshold already solved is untouched, so
+ * adding chroma can only recover cards luma missed, never regress a working one.
+ */
+const CARD_CHANNELS = ['luma', 'chroma'] as const;
+
+export function findCardAcrossChannels(
+  image: ImageDataLike,
+  options: CardDetectOptions = {}
+): CardComponent | null {
+  for (const channel of CARD_CHANNELS) {
+    const labeled = labelComponents(buildMask(image, { channel }));
+    const card = findBestCardComponent(labeled, image.width, image.height, options);
+    if (card) return card;
+    // An alpha-driven mask ignores `channel`, so further passes are identical.
+    if (usesAlphaMask(image)) break;
+  }
+  return null;
+}
+
 export function detectCardQuad(
   image: ImageDataLike,
   options: CardDetectOptions = {}
 ): CardDetection | null {
-  const labeled = labelComponents(buildMask(image));
-  const card = findBestCardComponent(labeled, image.width, image.height, options);
+  const card = findCardAcrossChannels(image, options);
   if (!card) return null;
 
   const homography = cardHomography(card.corners, options.widthMm, options.heightMm);

--- a/src/shared/scanTrace/mask.test.ts
+++ b/src/shared/scanTrace/mask.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toGrayscale, computeOtsuThreshold, buildMask } from './mask';
+import { toGrayscale, toChroma, computeOtsuThreshold, buildMask, usesAlphaMask } from './mask';
 import type { ImageDataLike } from './types';
 
 function img(
@@ -33,6 +33,14 @@ describe('toGrayscale', () => {
   });
 });
 
+describe('toChroma', () => {
+  it('scores a neutral grey ~0 and a saturated color high', () => {
+    expect(toChroma(img(1, 1, () => true, [128, 128, 128, 255]))[0]).toBe(0);
+    // Warm wood: max−min = 150 − 60.
+    expect(toChroma(img(1, 1, () => true, [150, 110, 60, 255]))[0]).toBe(90);
+  });
+});
+
 describe('computeOtsuThreshold', () => {
   it('separates a bimodal distribution', () => {
     const gray = new Uint8Array(100);
@@ -61,6 +69,13 @@ describe('buildMask', () => {
     // Opaque object, transparent background — color identical so only alpha distinguishes.
     const mask = buildMask(img(10, 10, inBlock, [120, 120, 120, 255], [120, 120, 120, 0]));
     expect(countOnes(mask)).toBe(16);
+  });
+
+  it('detects when alpha drives the mask (channel choice then moot)', () => {
+    expect(usesAlphaMask(img(10, 10, inBlock, [120, 120, 120, 255], [120, 120, 120, 0]))).toBe(
+      true
+    );
+    expect(usesAlphaMask(img(10, 10, inBlock))).toBe(false);
   });
 
   it('honors an explicit invert', () => {

--- a/src/shared/scanTrace/mask.ts
+++ b/src/shared/scanTrace/mask.ts
@@ -25,6 +25,26 @@ export function toGrayscale(img: ImageDataLike): Uint8Array {
   return gray;
 }
 
+/**
+ * Per-pixel colorfulness: max−min of the RGB channels (already 0–255). A neutral
+ * grey/metal surface scores ~0; a saturated one scores high. Lets the tracer
+ * separate a color-neutral card from a colored background that matches it in
+ * brightness — invisible to {@link toGrayscale}.
+ */
+export function toChroma(img: ImageDataLike): Uint8Array {
+  const { data } = img;
+  const n = img.width * img.height;
+  const chroma = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const o = i * 4;
+    const r = data[o];
+    const g = data[o + 1];
+    const b = data[o + 2];
+    chroma[i] = Math.max(r, g, b) - Math.min(r, g, b);
+  }
+  return chroma;
+}
+
 /** Otsu's method: the 0–255 cutoff maximizing between-class variance. */
 export function computeOtsuThreshold(gray: Uint8Array): number {
   const hist = new Uint32Array(256);
@@ -75,6 +95,14 @@ function fractionTranslucent(img: ImageDataLike): number {
   return n === 0 ? 0 : translucent / n;
 }
 
+/**
+ * True when the image carries enough real transparency that alpha drives the
+ * mask outright — in which case the luma/chroma `channel` choice is moot.
+ */
+export function usesAlphaMask(img: ImageDataLike): boolean {
+  return fractionTranslucent(img) > ALPHA_MODE_FRACTION;
+}
+
 /** True when border pixels are, on balance, darker than the threshold. */
 function borderIsDark(gray: Uint8Array, width: number, height: number, threshold: number): boolean {
   let dark = 0;
@@ -100,7 +128,7 @@ export function buildMask(img: ImageDataLike, options: TraceOptions = {}): Mask 
   const data = new Uint8Array(n);
 
   // Alpha-driven mask when the image carries real transparency.
-  if (fractionTranslucent(img) > ALPHA_MODE_FRACTION) {
+  if (usesAlphaMask(img)) {
     const cutoff = options.alphaThreshold ?? DEFAULT_ALPHA_THRESHOLD;
     for (let i = 0; i < n; i++) {
       const fg = img.data[i * 4 + 3] >= cutoff;
@@ -109,13 +137,13 @@ export function buildMask(img: ImageDataLike, options: TraceOptions = {}): Mask 
     return { width, height, data };
   }
 
-  const gray = toGrayscale(img);
-  const threshold = options.threshold ?? computeOtsuThreshold(gray);
+  const channel = options.channel === 'chroma' ? toChroma(img) : toGrayscale(img);
+  const threshold = options.threshold ?? computeOtsuThreshold(channel);
   // The object is whichever side the border is NOT.
-  const foregroundIsDark = !borderIsDark(gray, width, height, threshold);
+  const foregroundIsDark = !borderIsDark(channel, width, height, threshold);
 
   for (let i = 0; i < n; i++) {
-    const isDark = gray[i] < threshold;
+    const isDark = channel[i] < threshold;
     const fg = foregroundIsDark ? isDark : !isDark;
     data[i] = (options.invert ? !fg : fg) ? 1 : 0;
   }

--- a/src/shared/scanTrace/traceScene.ts
+++ b/src/shared/scanTrace/traceScene.ts
@@ -17,11 +17,11 @@ import type { Result } from '@/core/result';
 import { ok, err } from '@/core/result';
 import type { ImageDataLike, Mask, Point, TraceError } from './types';
 import { buildMask } from './mask';
-import { labelComponents, largestComponent } from './components';
+import { largestComponent } from './components';
 import { traceContour } from './contour';
 import { simplifyRdp } from './simplify';
 import { polygonArea } from './traceImage';
-import { findBestCardComponent, cardHomography, type CardDetectOptions } from './cardDetect';
+import { findCardAcrossChannels, cardHomography, type CardDetectOptions } from './cardDetect';
 import { rectifyPoints } from './perspective';
 import { smoothPreservingCorners } from './smooth';
 
@@ -97,9 +97,7 @@ export function detectCard(
   image: ImageDataLike,
   options: SceneTraceOptions = {}
 ): SceneCard | null {
-  const { width, height } = image;
-  const labeled = labelComponents(buildMask(image));
-  const card = findBestCardComponent(labeled, width, height, options);
+  const card = findCardAcrossChannels(image, options);
   return card ? { corners: card.corners, fitness: card.fitness } : null;
 }
 

--- a/src/shared/scanTrace/types.ts
+++ b/src/shared/scanTrace/types.ts
@@ -40,10 +40,10 @@ export interface TraceOptions {
   /** Smallest foreground area (in pixels) accepted as a real object. */
   readonly minAreaPx?: number;
   /**
-   * Which per-pixel signal to threshold. `luma` (default) separates by
+   * Which per-pixel signal `buildMask` thresholds. `luma` (default) separates by
    * brightness; `chroma` by colorfulness — a color-neutral object (a metal/grey
    * card) on a saturated surface (wood) is invisible in luma but stands out in
-   * chroma. Card detection sweeps both.
+   * chroma. Card detection doesn't read this field; it sweeps both channels itself.
    */
   readonly channel?: 'luma' | 'chroma';
 }

--- a/src/shared/scanTrace/types.ts
+++ b/src/shared/scanTrace/types.ts
@@ -39,6 +39,13 @@ export interface TraceOptions {
   readonly simplifyTolerance?: number;
   /** Smallest foreground area (in pixels) accepted as a real object. */
   readonly minAreaPx?: number;
+  /**
+   * Which per-pixel signal to threshold. `luma` (default) separates by
+   * brightness; `chroma` by colorfulness — a color-neutral object (a metal/grey
+   * card) on a saturated surface (wood) is invisible in luma but stands out in
+   * chroma. Card detection sweeps both.
+   */
+  readonly channel?: 'luma' | 'chroma';
 }
 
 export type TraceErrorCode = 'NO_OBJECT' | 'DEGENERATE';


### PR DESCRIPTION
## Problem

A user photographed a brushed-metal Charles Schwab card next to their tool and the scanner reported **"No card detected."** I reproduced it by running the real `detectCardQuad` pipeline on the photo (ImageMagick RGBA dump → tsx): detection returned `null`.

**Root cause:** card detection thresholds **luminance only** (`buildMask` → `toGrayscale` Rec.601 → global Otsu). A silver card and warm wood share nearly identical *brightness* (both ~116/255), so the global Otsu mask fragments and merges the card into the wood grain — no card-shaped quad ever forms. Tuning `minFitness`/`aspectTolerance` can't help because the card blob never exists. (Sobel edges fail too — the card's outer border barely gradients against wood.)

The discriminating signal is **chroma**, not luma: the card is color-neutral, the surface is saturated. In a colorfulness channel the card is a crisp rectangle.

## Fix

- Add `toChroma` (`max−min` of RGB) to `mask.ts`; `buildMask` takes a `channel: 'luma' | 'chroma'` option. The existing `borderIsDark` polarity inference generalizes for free — a saturated background reads as high-chroma, so the low-chroma card becomes foreground.
- `findCardAcrossChannels` sweeps **luma first, then chroma**, taking the first channel that yields an accepted card. Wired into both `detectCardQuad` and `traceScene`'s `detectCard`.

**Why luma-first / first-match-wins:** it makes the chroma pass *strictly additive* — any photo a brightness threshold already solved is byte-identical, so chroma can only recover cards luma missed, never regress a working scan. (Considered "best-fitness across channels" but declined: fitness is an unreliable cross-channel comparator — a clean neutral non-card rectangle can out-score the real card — so it adds regression risk for no proven gain.)

- Chroma pass is skipped when alpha already drives the mask (transparent cutouts), where the channel choice is moot (`usesAlphaMask`).

## Verification

- On the real photo: card now detected at **fitness 1.000**, correct aspect (~1.58) and location.
- New regression tests: a color-neutral card on a saturated background that asserts **luma alone returns `null`** and the **chroma sweep recovers** it + rectifies the tool to true mm; `toChroma` and `usesAlphaMask` unit tests.
- Detection runs on a ≤1280px downscale, so the second pass is cheap.
- 60 scanTrace tests pass; typecheck, lint, knip all clean.

## Out of scope

The classical *fallback* tool mask is still luma-only (the primary tool path is ML-segmented, so a neutral tool on a colored surface is only at risk in the rare fallback). Deferred.