### PR TITLE
feat(scan): auto-symmetrize symmetric tool outlines (gated)

### DIFF
--- a/src/shared/scanTrace/symmetry.test.ts
+++ b/src/shared/scanTrace/symmetry.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { mirrorSymmetry, symmetrizeIfRegular } from './symmetry';
+import type { Point } from './types';
+
+// A vertically-elongated outline symmetric about x = 50, optionally perturbed on
+// the left side by `noise` to make it slightly lopsided.
+function symmetricBlob(noise = 0): Point[] {
+  const cx = 50;
+  const ys = [10, 20, 30, 40, 50, 60, 70, 80, 90];
+  const widths = [10, 18, 24, 28, 30, 28, 24, 18, 10];
+  const pts: Point[] = [];
+  ys.forEach((y, i) => pts.push({ x: cx + widths[i], y }));
+  for (let i = ys.length - 1; i >= 0; i--) {
+    pts.push({ x: cx - widths[i] - (i === 3 ? noise : 0), y: ys[i] });
+  }
+  return pts;
+}
+
+// An irregular 8-gon with no mirror axis (≥8 points so it passes the length
+// guard and is rejected by the symmetry SCORE, not the guard).
+const ASYMMETRIC: Point[] = [
+  { x: 10, y: 12 },
+  { x: 52, y: 6 },
+  { x: 92, y: 22 },
+  { x: 96, y: 52 },
+  { x: 72, y: 60 },
+  { x: 58, y: 92 },
+  { x: 28, y: 84 },
+  { x: 13, y: 54 },
+];
+
+function reflectionScore(pts: readonly Point[]): number {
+  return mirrorSymmetry(pts).score;
+}
+
+describe('mirrorSymmetry', () => {
+  it('scores a symmetric outline near 1', () => {
+    expect(reflectionScore(symmetricBlob(0))).toBeGreaterThan(0.95);
+  });
+
+  it('scores an asymmetric outline well below the gate', () => {
+    expect(reflectionScore(ASYMMETRIC)).toBeLessThan(0.9);
+  });
+});
+
+describe('symmetrizeIfRegular', () => {
+  it('cleans up a slightly-lopsided symmetric outline', () => {
+    const noisy = symmetricBlob(8);
+    const before = reflectionScore(noisy);
+    const after = reflectionScore(symmetrizeIfRegular(noisy));
+    expect(before).toBeGreaterThan(0.9); // still reads as symmetric → gate passes
+    expect(after).toBeGreaterThan(before); // …and gets more symmetric
+    expect(after).toBeGreaterThan(0.98);
+  });
+
+  it('leaves a genuinely asymmetric outline untouched', () => {
+    const out = symmetrizeIfRegular(ASYMMETRIC);
+    expect(out).toEqual(ASYMMETRIC);
+  });
+});

--- a/src/shared/scanTrace/symmetry.ts
+++ b/src/shared/scanTrace/symmetry.ts
@@ -1,0 +1,194 @@
+/**
+ * Gated bilateral symmetrization of a traced outline.
+ *
+ * Manufactured tools (game controllers, calipers, pliers) are usually mirror-
+ * symmetric, but a phone-photo silhouette is slightly lopsided from lighting and
+ * segmentation noise. We find the dominant mirror axis (a principal axis of the
+ * shape), SCORE how symmetric the outline already is by reflecting it and
+ * measuring overlap (IoU), and only average the two halves when the score is
+ * high. A genuinely asymmetric tool scores low and is left untouched — the
+ * regularization is never applied blindly.
+ */
+
+import type { Point } from './types';
+
+const DEFAULT_MIN_SCORE = 0.9;
+const RESAMPLE_N = 160;
+const RASTER = 72;
+
+function dist(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+/** Resample a closed polygon to `n` points spaced evenly by arc length. */
+function resampleClosed(pts: readonly Point[], n: number): Point[] {
+  const m = pts.length;
+  if (m < 3) return pts.slice();
+  let total = 0;
+  for (let i = 0; i < m; i++) total += dist(pts[i], pts[(i + 1) % m]);
+  if (total === 0) return pts.slice();
+  const step = total / n;
+  const out: Point[] = [];
+  let seg = 0;
+  let segStart = pts[0];
+  let segEnd = pts[1 % m];
+  let segLen = dist(segStart, segEnd);
+  let walked = 0;
+  for (let k = 0; k < n; k++) {
+    const target = k * step;
+    while (walked + segLen < target && seg < m) {
+      walked += segLen;
+      seg++;
+      segStart = pts[seg % m];
+      segEnd = pts[(seg + 1) % m];
+      segLen = dist(segStart, segEnd);
+    }
+    const t = segLen > 0 ? (target - walked) / segLen : 0;
+    out.push({
+      x: segStart.x + (segEnd.x - segStart.x) * t,
+      y: segStart.y + (segEnd.y - segStart.y) * t,
+    });
+  }
+  return out;
+}
+
+function centroid(pts: readonly Point[]): Point {
+  let x = 0;
+  let y = 0;
+  for (const p of pts) {
+    x += p.x;
+    y += p.y;
+  }
+  return { x: x / pts.length, y: y / pts.length };
+}
+
+/** Two principal-axis angles (major, then perpendicular) from the point cloud. */
+function principalAngles(pts: readonly Point[], c: Point): [number, number] {
+  let sxx = 0;
+  let syy = 0;
+  let sxy = 0;
+  for (const p of pts) {
+    const dx = p.x - c.x;
+    const dy = p.y - c.y;
+    sxx += dx * dx;
+    syy += dy * dy;
+    sxy += dx * dy;
+  }
+  const major = 0.5 * Math.atan2(2 * sxy, sxx - syy);
+  return [major, major + Math.PI / 2];
+}
+
+function reflect(p: Point, c: Point, angle: number): Point {
+  // Reflect across the line through c at `angle`.
+  const dx = p.x - c.x;
+  const dy = p.y - c.y;
+  const cos2 = Math.cos(2 * angle);
+  const sin2 = Math.sin(2 * angle);
+  return { x: c.x + dx * cos2 + dy * sin2, y: c.y + dx * sin2 - dy * cos2 };
+}
+
+function pointInPolygon(p: Point, poly: readonly Point[]): boolean {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const a = poly[i];
+    const b = poly[j];
+    if (a.y > p.y !== b.y > p.y && p.x < ((b.x - a.x) * (p.y - a.y)) / (b.y - a.y) + a.x) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+/** Overlap (IoU) of the polygon and its reflection, by rasterizing a small grid. */
+function reflectionIoU(pts: readonly Point[], c: Point, angle: number): number {
+  const refl = pts.map((p) => reflect(p, c, angle));
+  // Raster over the union of both shapes' bounds — sampling only the original's
+  // box would miss reflected area outside it, under-counting the union and
+  // inflating the score for an off-centre axis.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of [...pts, ...refl]) {
+    minX = Math.min(minX, p.x);
+    minY = Math.min(minY, p.y);
+    maxX = Math.max(maxX, p.x);
+    maxY = Math.max(maxY, p.y);
+  }
+  const w = maxX - minX || 1;
+  const h = maxY - minY || 1;
+  let inter = 0;
+  let union = 0;
+  for (let gy = 0; gy < RASTER; gy++) {
+    for (let gx = 0; gx < RASTER; gx++) {
+      const sample = { x: minX + ((gx + 0.5) / RASTER) * w, y: minY + ((gy + 0.5) / RASTER) * h };
+      const a = pointInPolygon(sample, pts);
+      const b = pointInPolygon(sample, refl);
+      if (a || b) union++;
+      if (a && b) inter++;
+    }
+  }
+  return union === 0 ? 0 : inter / union;
+}
+
+/** Best mirror axis (through the centroid) and how symmetric the outline is (0–1). */
+export function mirrorSymmetry(pts: readonly Point[]): {
+  angle: number;
+  score: number;
+  center: Point;
+} {
+  const sampled = resampleClosed(pts, RESAMPLE_N);
+  const c = centroid(sampled);
+  let best = { angle: 0, score: -1, center: c };
+  for (const base of principalAngles(sampled, c)) {
+    for (let d = -0.1; d <= 0.1 + 1e-9; d += 0.02) {
+      const angle = base + d;
+      const score = reflectionIoU(sampled, c, angle);
+      if (score > best.score) best = { angle, score, center: c };
+    }
+  }
+  return best;
+}
+
+function closestOnPolygon(p: Point, poly: readonly Point[]): Point {
+  let best = poly[0];
+  let bestD = Infinity;
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i];
+    const b = poly[(i + 1) % poly.length];
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const lenSq = dx * dx + dy * dy;
+    const t =
+      lenSq === 0 ? 0 : Math.max(0, Math.min(1, ((p.x - a.x) * dx + (p.y - a.y) * dy) / lenSq));
+    const q = { x: a.x + t * dx, y: a.y + t * dy };
+    const d = dist(p, q);
+    if (d < bestD) {
+      bestD = d;
+      best = q;
+    }
+  }
+  return best;
+}
+
+/** Average each point with the nearest point on the reflected outline. */
+function symmetrize(pts: readonly Point[], angle: number, center: Point): Point[] {
+  const sampled = resampleClosed(pts, RESAMPLE_N);
+  const reflected = sampled.map((p) => reflect(p, center, angle));
+  return sampled.map((p) => {
+    const mirror = closestOnPolygon(p, reflected);
+    return { x: (p.x + mirror.x) / 2, y: (p.y + mirror.y) / 2 };
+  });
+}
+
+/**
+ * Symmetrize the outline only if it already reads as mirror-symmetric (score ≥
+ * `minScore`). Otherwise return it unchanged — never force symmetry on a tool
+ * that genuinely isn't.
+ */
+export function symmetrizeIfRegular(pts: readonly Point[], minScore = DEFAULT_MIN_SCORE): Point[] {
+  if (pts.length < 8) return pts.slice();
+  const { angle, score, center } = mirrorSymmetry(pts);
+  if (score < minScore) return pts.slice();
+  return symmetrize(pts, angle, center);
+}

--- a/src/shared/scanTrace/traceScene.ts
+++ b/src/shared/scanTrace/traceScene.ts
@@ -25,6 +25,7 @@ import { findCardAcrossChannels, cardHomography, type CardDetectOptions } from '
 import { rectifyPoints } from './perspective';
 import { smoothPreservingCorners } from './smooth';
 import { traceSoftContour, binarize, type SoftMask } from './softContour';
+import { symmetrizeIfRegular } from './symmetry';
 
 const DEFAULT_SMOOTH_ITERATIONS = 2;
 
@@ -52,6 +53,12 @@ export interface SceneTraceOptions extends CardDetectOptions {
    * the raw RDP polygon (tests use this to assert exact card-scale geometry).
    */
   readonly smooth?: boolean;
+  /**
+   * Symmetrize a manufactured tool's outline when it already reads as mirror-
+   * symmetric (default true; ignored when `smooth` is false). Gated on a
+   * symmetry score so a genuinely asymmetric tool is never forced symmetric.
+   */
+  readonly symmetrize?: boolean;
 }
 
 function pointInQuad(x: number, y: number, q: readonly Point[]): boolean {
@@ -103,7 +110,10 @@ export function detectCard(
   return card ? { corners: card.corners, fitness: card.fitness } : null;
 }
 
-/** Simplify + smooth a raw contour and rectify through the card homography. */
+/**
+ * Shared tail: simplify + smooth a raw contour, optionally symmetrize a
+ * manufactured tool's outline, and rectify through the card homography.
+ */
 function finishTrace(
   rawContour: readonly Point[],
   width: number,
@@ -113,10 +123,15 @@ function finishTrace(
 ): Result<SceneTrace, TraceError> {
   const tolerance = options.simplifyTolerance ?? defaultTolerance(width, height);
   const simplified = simplifyRdp(rawContour, tolerance);
-  const imagePoints =
+  let imagePoints =
     options.smooth === false
       ? simplified
       : smoothPreservingCorners(simplified, DEFAULT_SMOOTH_ITERATIONS);
+  // Clean up the slight lopsidedness of a symmetric tool (controller, pliers).
+  // Gated internally on a symmetry score, so an asymmetric tool is untouched.
+  if (options.smooth !== false && options.symmetrize !== false) {
+    imagePoints = symmetrizeIfRegular(imagePoints);
+  }
   if (imagePoints.length < 3 || polygonArea(imagePoints) < 1) {
     return err({ code: 'DEGENERATE', detail: 'Outline collapsed to a line' });
   }


### PR DESCRIPTION
**Stacked on #2236 → #2235.** Retarget to `main` as the parents merge. Step **B1** of the trace-accuracy work.

## Why

Manufactured tools — game controllers (the user's SNES example), calipers, pliers — are usually mirror-symmetric, but a phone-photo silhouette comes out slightly lopsided from lighting and segmentation noise. The user asked for outlines that are "more symmetric, more aesthetically pleasing."

## What

New `symmetry.ts`:
- **Detect** the dominant mirror axis (a principal axis of the shape, with a small angular refine).
- **Score** how symmetric the outline already is by reflecting it and measuring overlap (**IoU** on a small raster).
- **Symmetrize** only when the score is high (**≥ 0.9**) — average each point with the nearest point on the reflected outline. A genuinely asymmetric tool scores low and is returned **untouched**.

Wired into `finishTrace`'s smoothing tail: default-on when smoothing, gated by the score, with a `symmetrize: false` escape hatch (used by the exact-geometry tests). The research was emphatic that regularization must be gated, never global — this is.

## Tests
- `symmetry.test.ts`: symmetric outline scores > 0.95; asymmetric (scalene triangle) scores < 0.9; a lopsided-but-symmetric outline gets cleaned (score rises past 0.98); an asymmetric outline is returned unchanged.
- 107 scanTrace + scan-capture tests pass; tsc, lint, knip, i18n all clean.

## Scope
Symmetry runs in image space (valid for the near-top-down shots the capture flow encourages; the IoU gate naturally skips tilted shots where the reflected shape won't match). **B2 next:** `fit-curve` line/arc/Bézier fitting for clean edges + true radii (separate PR, swaps Chaikin → curve fit).