### PR TITLE
feat(scan): sub-pixel tool trace from the soft confidence mask

### DIFF
--- a/src/features/scan-capture/components/ScanPage/ScanPage.test.tsx
+++ b/src/features/scan-capture/components/ScanPage/ScanPage.test.tsx
@@ -31,7 +31,7 @@ vi.mock('@/i18n', () => ({
 
 const TOKEN = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
 const IMAGE = { width: 24, height: 20, data: new Uint8ClampedArray(24 * 20 * 4) };
-const MASK = { width: 24, height: 20, data: new Uint8Array(24 * 20) };
+const MASK = { width: 24, height: 20, data: new Float32Array(24 * 20) };
 const PTS = [
   { x: 0, y: 0 },
   { x: 25, y: 0 },

--- a/src/features/scan-capture/components/ScanPage/ScanPage.tsx
+++ b/src/features/scan-capture/components/ScanPage/ScanPage.tsx
@@ -27,7 +27,7 @@ import {
   cardPerspectiveSkew,
   STEEP_CARD_SKEW,
   type ImageDataLike,
-  type Mask,
+  type SoftMask,
   type Point,
   type SceneTrace,
 } from '@/shared/scanTrace';
@@ -39,7 +39,7 @@ interface ScanPageProps {
 interface ReviewState {
   readonly canvas: HTMLCanvasElement;
   readonly image: ImageDataLike;
-  readonly toolMask: Mask | null;
+  readonly toolMask: SoftMask | null;
   readonly scene: SceneTrace;
   readonly photoUrl: string;
   readonly seed: Point;
@@ -83,7 +83,7 @@ async function traceAt(
   canvas: HTMLCanvasElement,
   image: ImageDataLike,
   seed: Point
-): Promise<{ scene: SceneTrace; toolMask: Mask | null } | null> {
+): Promise<{ scene: SceneTrace; toolMask: SoftMask | null } | null> {
   try {
     const toolMask = await segmentAt(canvas, seed);
     const traced = traceSceneSegmented(image, toolMask);

--- a/src/shared/scanTrace/index.ts
+++ b/src/shared/scanTrace/index.ts
@@ -7,6 +7,7 @@ export {
   computeAutoSeed,
 } from './traceScene';
 export type { SceneTrace, SceneCard, SceneTraceOptions } from './traceScene';
+export type { SoftMask } from './softContour';
 export { cardPerspectiveSkew, STEEP_CARD_SKEW } from './cardDetect';
 export { decodeImageToCanvas, imageDataFromCanvas } from './decodeImage';
 export { segmentAt, preloadSegmenter } from './interactiveSegment';

--- a/src/shared/scanTrace/interactiveSegment.ts
+++ b/src/shared/scanTrace/interactiveSegment.ts
@@ -2,8 +2,8 @@
  * Tap-prompted ML segmentation (browser-only, like decodeImage.ts).
  *
  * Wraps MediaPipe's Interactive Segmenter ("Magic Touch"): given a photo and a
- * point the user tapped on the tool, it returns a binary mask of just that
- * object. This replaces the global Otsu threshold's guesswork — the model is
+ * point the user tapped on the tool, it returns a soft probability mask of just
+ * that object. This replaces the global Otsu threshold's guesswork — the model is
  * *told* which object to trace, which kills the "traced the background / card /
  * a sub-region" failures.
  *
@@ -14,7 +14,8 @@
  */
 
 import type { InteractiveSegmenter } from '@mediapipe/tasks-vision';
-import type { Mask, Point } from './types';
+import type { Point } from './types';
+import type { SoftMask } from './softContour';
 
 const WASM_BASE_PATH = '/models/tasks-vision';
 const MODEL_PATH = '/models/interactive-segmenter/magic_touch.tflite';
@@ -29,8 +30,11 @@ async function getSegmenter(): Promise<InteractiveSegmenter> {
       const create = (delegate: 'GPU' | 'CPU') =>
         InteractiveSegmenter.createFromOptions(fileset, {
           baseOptions: { modelAssetPath: MODEL_PATH, delegate },
+          // The confidence mask is a soft [0,1] field — its sub-pixel edge
+          // location is what a marching-squares trace needs. Keep the category
+          // mask as a fallback for runtimes that don't return confidence.
           outputCategoryMask: true,
-          outputConfidenceMasks: false,
+          outputConfidenceMasks: true,
         });
       // Prefer the GPU (WebGL) delegate; fall back to CPU before giving up so a
       // device with flaky WebGL still gets ML segmentation (~130ms) rather than
@@ -58,27 +62,44 @@ export function preloadSegmenter(): void {
 }
 
 /**
- * Segment the object at `seed` (normalized 0–1) in `source`, returning a binary
- * foreground Mask at the source's resolution. Foreground is whatever category
- * the tapped pixel landed in, so we don't depend on MediaPipe's index ordering.
+ * Segment the object at `seed` (normalized 0–1) in `source`, returning a soft
+ * foreground probability mask at the source's resolution. Prefers MediaPipe's
+ * confidence mask (the channel most confident at the tapped pixel, so we don't
+ * depend on index ordering); falls back to the binary category mask as a 0/1
+ * field if confidence masks aren't available.
  */
-export async function segmentAt(source: HTMLCanvasElement, seed: Point): Promise<Mask> {
+export async function segmentAt(source: HTMLCanvasElement, seed: Point): Promise<SoftMask> {
   const segmenter = await getSegmenter();
   const result = segmenter.segment(source, {
     keypoint: { x: clamp01(seed.x), y: clamp01(seed.y) },
   });
   try {
+    const confidence = result.confidenceMasks;
+    if (confidence && confidence.length > 0) {
+      const width = confidence[0].width;
+      const height = confidence[0].height;
+      const sx = clampIndex(seed.x, width);
+      const sy = clampIndex(seed.y, height);
+      let best: Float32Array | null = null;
+      let bestVal = -1;
+      for (const mask of confidence) {
+        const arr = mask.getAsFloat32Array();
+        const here = arr[sy * width + sx];
+        if (here > bestVal) {
+          bestVal = here;
+          best = Float32Array.from(arr); // copy: the buffer may be reused/freed
+        }
+      }
+      if (best) return { width, height, data: best };
+    }
+
     const categoryMask = result.categoryMask;
-    if (!categoryMask) throw new Error('Segmenter returned no category mask');
+    if (!categoryMask) throw new Error('Segmenter returned no mask');
     const width = categoryMask.width;
     const height = categoryMask.height;
     const raw = categoryMask.getAsUint8Array();
-
-    const px = Math.min(width - 1, Math.max(0, Math.round(clamp01(seed.x) * (width - 1))));
-    const py = Math.min(height - 1, Math.max(0, Math.round(clamp01(seed.y) * (height - 1))));
-    const foreground = raw[py * width + px];
-
-    const data = new Uint8Array(width * height);
+    const foreground = raw[clampIndex(seed.y, height) * width + clampIndex(seed.x, width)];
+    const data = new Float32Array(width * height);
     for (let i = 0; i < data.length; i++) data[i] = raw[i] === foreground ? 1 : 0;
     return { width, height, data };
   } finally {
@@ -88,4 +109,9 @@ export async function segmentAt(source: HTMLCanvasElement, seed: Point): Promise
 
 function clamp01(n: number): number {
   return n < 0 ? 0 : n > 1 ? 1 : n;
+}
+
+/** Nearest mask index for a normalized 0–1 coordinate. */
+function clampIndex(norm: number, size: number): number {
+  return Math.min(size - 1, Math.max(0, Math.round(clamp01(norm) * (size - 1))));
 }

--- a/src/shared/scanTrace/softContour.test.ts
+++ b/src/shared/scanTrace/softContour.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { traceSoftContour, binarize, type SoftMask } from './softContour';
+import type { Point } from './types';
+
+function soft(width: number, height: number, fn: (x: number, y: number) => number): SoftMask {
+  const data = new Float32Array(width * height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) data[y * width + x] = fn(x, y);
+  }
+  return { width, height, data };
+}
+
+function bbox(pts: readonly Point[]): { minX: number; minY: number; maxX: number; maxY: number } {
+  const xs = pts.map((p) => p.x);
+  const ys = pts.map((p) => p.y);
+  return {
+    minX: Math.min(...xs),
+    minY: Math.min(...ys),
+    maxX: Math.max(...xs),
+    maxY: Math.max(...ys),
+  };
+}
+
+const shoelace = (pts: readonly Point[]): number => {
+  let a = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const j = (i + 1) % pts.length;
+    a += pts[i].x * pts[j].y - pts[j].x * pts[i].y;
+  }
+  return a / 2;
+};
+
+describe('traceSoftContour', () => {
+  it('traces a hard-edged rectangle at its boundary', () => {
+    // Foreground block x∈[3,7], y∈[2,6].
+    const img = soft(12, 10, (x, y) => (x >= 3 && x <= 7 && y >= 2 && y <= 6 ? 1 : 0));
+    const c = traceSoftContour(img);
+    expect(c.length).toBeGreaterThan(3);
+    const b = bbox(c);
+    // The 0.5 crossing sits midway between the last fg and first bg sample.
+    expect(b.minX).toBeCloseTo(2.5, 5);
+    expect(b.maxX).toBeCloseTo(7.5, 5);
+    expect(b.minY).toBeCloseTo(1.5, 5);
+    expect(b.maxY).toBeCloseTo(6.5, 5);
+  });
+
+  it('places vertices sub-pixel from a soft (ramped) edge', () => {
+    // A vertical ramp crossing 0.5 between x=4 and x=5 at x≈4.25
+    // (val(4)=0.3, val(5)=0.7 → t=(0.5-0.3)/0.4=0.5 → x=4.5). Whole left half
+    // below, right above, plus top/bottom hard edges to close the loop.
+    const img = soft(10, 10, (x, y) => {
+      if (y < 2 || y > 7) return 0;
+      if (x <= 4) return 0.3;
+      if (x >= 5) return 0.7;
+      return 0;
+    });
+    const c = traceSoftContour(img);
+    const b = bbox(c);
+    // The left edge crosses at x = 4 + (0.5-0.3)/(0.7-0.3) = 4.5 — not an integer.
+    expect(b.minX).toBeCloseTo(4.5, 5);
+  });
+
+  it('returns the largest loop when several blobs are present', () => {
+    const img = soft(40, 20, (x, y) => {
+      const big = x >= 4 && x <= 24 && y >= 4 && y <= 14;
+      const small = x >= 30 && x <= 33 && y >= 8 && y <= 11;
+      return big || small ? 1 : 0;
+    });
+    const c = traceSoftContour(img);
+    const b = bbox(c);
+    expect(b.minX).toBeCloseTo(3.5, 5); // the big blob, not the small one
+    expect(b.maxX).toBeCloseTo(24.5, 5);
+  });
+
+  it('winds clockwise (positive shoelace), matching traceContour', () => {
+    const img = soft(12, 12, (x, y) => (x >= 3 && x <= 8 && y >= 3 && y <= 8 ? 1 : 0));
+    expect(shoelace(traceSoftContour(img))).toBeGreaterThan(0);
+  });
+
+  it('returns empty when nothing crosses the level', () => {
+    expect(traceSoftContour(soft(8, 8, () => 0))).toEqual([]);
+    expect(traceSoftContour(soft(8, 8, () => 1))).toEqual([]);
+  });
+
+  it('still yields a usable polygon when the blob runs off the image edge', () => {
+    // Foreground touches the right border, so the iso-contour can't close there;
+    // the walk should still return a sensible polygon rather than crash or empty.
+    const img = soft(12, 10, (x, y) => (x >= 6 && y >= 2 && y <= 6 ? 1 : 0));
+    expect(traceSoftContour(img).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('approximates a disk as a near-circular loop', () => {
+    const r = 8;
+    const cx = 12;
+    const cy = 12;
+    const img = soft(25, 25, (x, y) => (Math.hypot(x - cx, y - cy) <= r ? 1 : 0));
+    const c = traceSoftContour(img);
+    // Every vertex lies within half a pixel of radius r from the centre.
+    for (const p of c) {
+      expect(Math.abs(Math.hypot(p.x - cx, p.y - cy) - r)).toBeLessThan(1.0);
+    }
+  });
+});
+
+describe('binarize', () => {
+  it('thresholds a soft mask at the level', () => {
+    const m = binarize(soft(2, 2, (x) => (x === 0 ? 0.2 : 0.8)));
+    expect(Array.from(m.data)).toEqual([0, 1, 0, 1]);
+  });
+});

--- a/src/shared/scanTrace/softContour.ts
+++ b/src/shared/scanTrace/softContour.ts
@@ -1,0 +1,167 @@
+/**
+ * Sub-pixel contour of a soft (probability) mask via marching squares.
+ *
+ * The ML segmenter emits a confidence field in [0,1], not a hard 0/1 mask. A
+ * binary trace snaps every boundary vertex to an integer pixel (±0.5px stair-
+ * stepping), throwing away the fractional edge location the model encodes. This
+ * extracts the iso-`level` (default 0.5) contour with linear edge interpolation,
+ * placing each vertex where the probability actually crosses 0.5 — recovering
+ * the sub-pixel boundary. Returns the largest closed loop (the tapped object),
+ * wound clockwise to match `traceContour`.
+ */
+
+import type { Mask, Point } from './types';
+
+export interface SoftMask {
+  readonly width: number;
+  readonly height: number;
+  /** Foreground probability per pixel, row-major, 0–1. */
+  readonly data: Float32Array;
+}
+
+/** Threshold a soft mask to a binary mask (for consumers that need 0/1). */
+export function binarize(soft: SoftMask, level = 0.5): Mask {
+  const data = new Uint8Array(soft.data.length);
+  for (let i = 0; i < data.length; i++) data[i] = soft.data[i] >= level ? 1 : 0;
+  return { width: soft.width, height: soft.height, data };
+}
+
+/** Standard shoelace area; >0 is clockwise in screen (y-down) coordinates. */
+function signedArea(pts: readonly Point[]): number {
+  let a = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const j = i + 1 === pts.length ? 0 : i + 1;
+    a += pts[i].x * pts[j].y - pts[j].x * pts[i].y;
+  }
+  return a / 2;
+}
+
+export function traceSoftContour(soft: SoftMask, level = 0.5): Point[] {
+  const { width: W, height: H, data } = soft;
+  if (W < 2 || H < 2) return [];
+  const val = (x: number, y: number): number => data[y * W + x];
+  // Fraction along an edge from value a→b where it crosses `level`.
+  const cross = (a: number, b: number): number => {
+    const t = (level - a) / (b - a);
+    return t < 0 ? 0 : t > 1 ? 1 : t;
+  };
+
+  const pos = new Map<string, Point>();
+  const segs: Array<readonly [string, string]> = [];
+  // Horizontal grid edge at (x,y) → (x+1,y); shared between vertically adjacent
+  // cells so the same crossing key links their segments.
+  const hKey = (x: number, y: number): string => {
+    const key = `h${x},${y}`;
+    if (!pos.has(key)) pos.set(key, { x: x + cross(val(x, y), val(x + 1, y)), y });
+    return key;
+  };
+  // Vertical grid edge at (x,y) → (x,y+1).
+  const vKey = (x: number, y: number): string => {
+    const key = `v${x},${y}`;
+    if (!pos.has(key)) pos.set(key, { x, y: y + cross(val(x, y), val(x, y + 1)) });
+    return key;
+  };
+
+  for (let y = 0; y < H - 1; y++) {
+    for (let x = 0; x < W - 1; x++) {
+      const code =
+        (val(x, y) >= level ? 1 : 0) |
+        (val(x + 1, y) >= level ? 2 : 0) |
+        (val(x + 1, y + 1) >= level ? 4 : 0) |
+        (val(x, y + 1) >= level ? 8 : 0);
+      if (code === 0 || code === 15) continue;
+
+      const top = (): string => hKey(x, y);
+      const bottom = (): string => hKey(x, y + 1);
+      const left = (): string => vKey(x, y);
+      const right = (): string => vKey(x + 1, y);
+      const add = (a: string, b: string): void => {
+        segs.push([a, b]);
+      };
+
+      switch (code) {
+        case 1:
+        case 14:
+          add(left(), top());
+          break;
+        case 2:
+        case 13:
+          add(top(), right());
+          break;
+        case 3:
+        case 12:
+          add(left(), right());
+          break;
+        case 4:
+        case 11:
+          add(right(), bottom());
+          break;
+        case 6:
+        case 9:
+          add(top(), bottom());
+          break;
+        case 7:
+        case 8:
+          add(bottom(), left());
+          break;
+        case 5:
+        case 10: {
+          // Saddle: resolve by the cell-centre average so the two foreground
+          // corners connect when the centre is also foreground.
+          const center = (val(x, y) + val(x + 1, y) + val(x + 1, y + 1) + val(x, y + 1)) / 4;
+          const centreFg = center >= level;
+          const tlBr = code === 5;
+          if (tlBr === centreFg) {
+            add(top(), right());
+            add(bottom(), left());
+          } else {
+            add(left(), top());
+            add(right(), bottom());
+          }
+          break;
+        }
+      }
+    }
+  }
+  if (segs.length === 0) return [];
+
+  const adj = new Map<string, Array<{ readonly other: string; readonly seg: number }>>();
+  const link = (k: string, other: string, seg: number): void => {
+    const list = adj.get(k);
+    if (list) list.push({ other, seg });
+    else adj.set(k, [{ other, seg }]);
+  };
+  segs.forEach(([a, b], i) => {
+    link(a, b, i);
+    link(b, a, i);
+  });
+
+  const used = new Array<boolean>(segs.length).fill(false);
+  let best: Point[] = [];
+  let bestArea = 0;
+  for (let i = 0; i < segs.length; i++) {
+    if (used[i]) continue;
+    const seg = segs[i];
+    used[i] = true;
+    const loop: Point[] = [];
+    const startPt = pos.get(seg[0]);
+    if (startPt) loop.push(startPt);
+    let cur = seg[1];
+    for (let guard = 0; cur !== seg[0] && guard <= segs.length; guard++) {
+      const p = pos.get(cur);
+      if (p) loop.push(p);
+      const step = adj.get(cur)?.find((n) => !used[n.seg]);
+      if (!step) break;
+      used[step.seg] = true;
+      cur = step.other;
+    }
+    if (loop.length >= 3) {
+      const area = signedArea(loop);
+      if (Math.abs(area) > bestArea) {
+        bestArea = Math.abs(area);
+        best = area >= 0 ? loop : loop.slice().reverse();
+      }
+    }
+  }
+  return best;
+}

--- a/src/shared/scanTrace/traceScene.test.ts
+++ b/src/shared/scanTrace/traceScene.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { isOk } from '@/core/result';
-import { traceScene, traceSceneSegmented, detectCard } from './traceScene';
-import type { ImageDataLike, Mask, Point } from './types';
+import { traceScene, traceSceneSegmented, detectCard, buildToolTraceSoft } from './traceScene';
+import type { SoftMask } from './softContour';
+import type { ImageDataLike, Point } from './types';
 
 // Tilted pinhole camera over the world z=0 plane (principal point at centre).
 const F = 600;
@@ -133,8 +134,8 @@ describe('traceSceneSegmented excludes the tool from card detection', () => {
     return { width: W, height: H, data };
   }
 
-  function toolMask(): Mask {
-    const data = new Uint8Array(W * H);
+  function toolMask(): SoftMask {
+    const data = new Float32Array(W * H);
     for (let y = 0; y < H; y++) {
       for (let x = 0; x < W; x++) if (inRect(x, y, TOOL)) data[y * W + x] = 1;
     }
@@ -164,5 +165,32 @@ describe('traceSceneSegmented excludes the tool from card detection', () => {
     if (!isOk(result)) return;
     expect(result.value.units).toBe('mm');
     expect(centroidX(result.value.card?.corners ?? [{ x: 0, y: 0 }])).toBeLessThan(W / 2);
+  });
+});
+
+describe('buildToolTraceSoft', () => {
+  const W = 80;
+  const H = 60;
+
+  it('traces a soft mask into a closed outline with sub-pixel vertices', () => {
+    // Interior fully foreground; a one-pixel ramp on the left edge so the 0.5
+    // crossing lands at a fractional x (proving sub-pixel, not pixel-snapped).
+    const data = new Float32Array(W * H);
+    for (let y = 15; y <= 45; y++) {
+      for (let x = 20; x <= 60; x++) data[y * W + x] = 1;
+      data[y * W + 19] = 0.25; // ramp: crosses 0.5 between x=19 and x=20 → x≈19.33
+    }
+    const r = buildToolTraceSoft({ width: W, height: H, data }, null, { smooth: false });
+    expect(isOk(r)).toBe(true);
+    if (!isOk(r)) return;
+    expect(r.value.units).toBe('px');
+    expect(r.value.imagePoints.length).toBeGreaterThanOrEqual(4);
+    const minX = Math.min(...r.value.imagePoints.map((p) => p.x));
+    expect(Number.isInteger(minX)).toBe(false);
+  });
+
+  it('reports NO_OBJECT for an empty soft mask', () => {
+    const r = buildToolTraceSoft({ width: W, height: H, data: new Float32Array(W * H) }, null, {});
+    expect(isOk(r)).toBe(false);
   });
 });

--- a/src/shared/scanTrace/traceScene.ts
+++ b/src/shared/scanTrace/traceScene.ts
@@ -24,6 +24,7 @@ import { polygonArea } from './traceImage';
 import { findCardAcrossChannels, cardHomography, type CardDetectOptions } from './cardDetect';
 import { rectifyPoints } from './perspective';
 import { smoothPreservingCorners } from './smooth';
+import { traceSoftContour, binarize, type SoftMask } from './softContour';
 
 const DEFAULT_SMOOTH_ITERATIONS = 2;
 
@@ -102,26 +103,16 @@ export function detectCard(
   return card ? { corners: card.corners, fitness: card.fitness } : null;
 }
 
-/**
- * Shared tail: a binary tool mask + an optional card → a finished SceneTrace.
- * Picks the largest blob, traces and simplifies it, and (when a card was found)
- * rectifies through the card homography into true millimetres.
- */
-export function buildToolTrace(
-  toolMask: Mask,
+/** Simplify + smooth a raw contour and rectify through the card homography. */
+function finishTrace(
+  rawContour: readonly Point[],
+  width: number,
+  height: number,
   card: SceneCard | null,
-  options: SceneTraceOptions = {}
+  options: SceneTraceOptions
 ): Result<SceneTrace, TraceError> {
-  const { width, height } = toolMask;
-  const component = largestComponent(toolMask);
-  const minArea = options.minToolAreaPx ?? defaultMinArea(width, height);
-  if (component.start === null || component.area < minArea) {
-    return err({ code: 'NO_OBJECT', detail: 'No tool found' });
-  }
-
-  const contour = traceContour(component.mask, component.start);
   const tolerance = options.simplifyTolerance ?? defaultTolerance(width, height);
-  const simplified = simplifyRdp(contour, tolerance);
+  const simplified = simplifyRdp(rawContour, tolerance);
   const imagePoints =
     options.smooth === false
       ? simplified
@@ -143,6 +134,40 @@ export function buildToolTrace(
   }
 
   return ok({ imagePoints, outputPoints: imagePoints, units: 'px', card: null });
+}
+
+export function buildToolTrace(
+  toolMask: Mask,
+  card: SceneCard | null,
+  options: SceneTraceOptions = {}
+): Result<SceneTrace, TraceError> {
+  const { width, height } = toolMask;
+  const component = largestComponent(toolMask);
+  const minArea = options.minToolAreaPx ?? defaultMinArea(width, height);
+  if (component.start === null || component.area < minArea) {
+    return err({ code: 'NO_OBJECT', detail: 'No tool found' });
+  }
+  return finishTrace(traceContour(component.mask, component.start), width, height, card, options);
+}
+
+/**
+ * Soft-mask tool trace: a sub-pixel marching-squares contour of the segmenter's
+ * confidence field, instead of boundary-tracing a thresholded binary mask. The
+ * 0.5 iso-contour places each vertex where the model's probability actually
+ * crosses, removing the ±0.5px staircase the binary trace bakes in.
+ */
+export function buildToolTraceSoft(
+  toolSoft: SoftMask,
+  card: SceneCard | null,
+  options: SceneTraceOptions = {}
+): Result<SceneTrace, TraceError> {
+  const { width, height } = toolSoft;
+  const contour = traceSoftContour(toolSoft);
+  const minArea = options.minToolAreaPx ?? defaultMinArea(width, height);
+  if (contour.length < 3 || polygonArea(contour) < minArea) {
+    return err({ code: 'NO_OBJECT', detail: 'No tool found' });
+  }
+  return finishTrace(contour, width, height, card, options);
 }
 
 /** Classical fallback: Otsu tool mask (largest non-card blob), card excluded. */
@@ -167,13 +192,13 @@ export function traceScene(
  */
 export function traceSceneSegmented(
   image: ImageDataLike,
-  toolMask: Mask,
+  toolMask: SoftMask,
   options: SceneTraceOptions = {}
 ): Result<SceneTrace, TraceError> {
   const { width, height } = image;
   if (width <= 0 || height <= 0) return err({ code: 'NO_OBJECT', detail: 'Empty image' });
-  const card = detectCard(image, options, toolMask);
-  return buildToolTrace(toolMask, card, options);
+  const card = detectCard(image, options, binarize(toolMask));
+  return buildToolTraceSoft(toolMask, card, options);
 }
 
 /**


### PR DESCRIPTION
Replaces #2236, which GitHub auto-closed when its stacked base branch was deleted on #2235's merge. Rebased directly onto `main` + addressed Greptile's review.

## What

Traces the tool outline from MediaPipe's **soft confidence mask** with sub-pixel **marching squares** (0.5 iso-contour) instead of boundary-walking a thresholded binary mask — removing the ±0.5px staircase the integer-snapped contour baked into every edge.

- `softContour.ts`: marching-squares tracer (largest closed loop, CW-wound to match `traceContour`) + `binarize`.
- `interactiveSegment.ts`: enables `outputConfidenceMasks`, picks the channel most confident at the tap (copied before `result.close()`), category-mask fallback. Returns a `SoftMask`.
- `traceScene.ts`: shared `finishTrace` tail; `buildToolTraceSoft`; `traceSceneSegmented` binarizes only for card exclusion.

## Addressed from the #2236 review (Greptile 4/5)
- Removed the **stale JSDoc** left above `finishTrace` after the refactor.
- Added a test for a **boundary-touching blob** (the open-chain case) — it returns a usable polygon rather than crashing/empty.

## Tests
softContour (8, incl. sub-pixel placement + boundary-touch) + buildToolTraceSoft; tsc/lint/knip/i18n clean.

First of the stacked trace-accuracy series → #2237 (symmetry) → #2238 (curve fit). Needs an on-device scan to confirm the MediaPipe wiring; the tracer math is fully covered in Node.