### PR TITLE
docs(scan): fix traceScene docstring + test-comment typo

### DIFF
--- a/src/shared/scanTrace/softContour.test.ts
+++ b/src/shared/scanTrace/softContour.test.ts
@@ -45,7 +45,7 @@ describe('traceSoftContour', () => {
   });
 
   it('places vertices sub-pixel from a soft (ramped) edge', () => {
-    // A vertical ramp crossing 0.5 between x=4 and x=5 at x≈4.25
+    // A vertical ramp crossing 0.5 between x=4 and x=5 at x=4.5
     // (val(4)=0.3, val(5)=0.7 → t=(0.5-0.3)/0.4=0.5 → x=4.5). Whole left half
     // below, right above, plus top/bottom hard edges to close the loop.
     const img = soft(10, 10, (x, y) => {

--- a/src/shared/scanTrace/traceScene.ts
+++ b/src/shared/scanTrace/traceScene.ts
@@ -7,10 +7,14 @@
  *  - `traceSceneSegmented` — the tool mask comes from the tap-prompted ML
  *    segmenter; we trust it (plus the user's tap) to have isolated the object.
  *
- * Both detect the card on the classical auto threshold, then run the shared
- * `buildToolTrace` tail (largest component → contour → simplify → optional card
- * homography). With a card present the outline is rectified to true millimetres;
- * without one it stays in pixels and the desktop asks for a real dimension.
+ * Both detect the card on the classical auto threshold and share the
+ * `finishTrace` tail (simplify → curve-fit smooth → optional symmetry → optional
+ * card homography). They differ in how the tool contour is obtained:
+ * `traceScene` traces the largest component of a binary mask (`buildToolTrace`),
+ * while `traceSceneSegmented` traces the soft confidence mask sub-pixel via
+ * marching squares (`buildToolTraceSoft`). With a card present the outline is
+ * rectified to true millimetres; without one it stays in pixels and the desktop
+ * asks for a real dimension.
  */
 
 import type { Result } from '@/core/result';


### PR DESCRIPTION
Follow-up to the trace-accuracy stack (#2240 / #2237 / #2238). Addresses the two documentation-only nits Greptile flagged on #2240 that were deferred to keep the stack moving:

- **Module docstring** in `traceScene.ts` still said both paths run the `buildToolTrace` tail (largest component → contour). It now distinguishes the soft sub-pixel ML path (`buildToolTraceSoft`, marching squares) from the classical binary path (`buildToolTrace`) and names the shared `finishTrace` tail.
- **Test comment** in `softContour.test.ts` said the ramp crosses at `x≈4.25`; the actual (and asserted) crossing is `4.5`.

Docs/comments only — no behavior change.