### PR TITLE
feat(seo): de-cannibalize generator titles and rework underperforming snippets

### DIFF
--- a/content/gridfinity-baseplate-generator.md
+++ b/content/gridfinity-baseplate-generator.md
@@ -1,6 +1,6 @@
 ---
 title: Gridfinity Baseplate Generator — Free Online STL Creator
-description: Gridfinity baseplate generator with real-time 3D preview. Configure grid size, magnet holes, connector nubs, and edge padding. Export STL, STEP, or 3MF. Free browser tool.
+description: Generate a custom Gridfinity baseplate sized to your drawer — set the grid, add magnet holes and connectors, and it auto-splits to fit your print bed. 3D preview, free STL/STEP/3MF export, no account.
 keywords: gridfinity baseplate generator, gridfinity baseplate, custom gridfinity baseplate, gridfinity STL, drawer baseplate, magnet baseplate
 schema: HowTo
 breadcrumbs:

--- a/content/gridfinity-sizes.md
+++ b/content/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
-title: Gridfinity Sizes — Bin Dimensions & Unit Guide
-description: How big is a Gridfinity unit? 42mm grid, 7mm height increments. Quick-reference tables for bin sizes, drawer conversions, and what fits where.
+title: Gridfinity Sizes & Dimensions — 42mm Grid + 7mm Heights
+description: Every Gridfinity dimension in one place — the 42mm grid, 7mm height units, and full bin-size tables in mm and inches, plus how to convert your drawer measurements into grid units. Free quick reference.
 keywords: gridfinity sizes, gridfinity dimensions, gridfinity bin sizes, gridfinity height units, gridfinity 42mm, gridfinity grid size, standard gridfinity size, why is gridfinity 42mm
 schema: Article
 breadcrumbs:

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-    <title>Gridfinity Planner & Layout Tool — Free Bin Generator</title>
+    <title>Gridfinity Planner & Layout Tool — Free Online Drawer Organizer</title>
 
     <!-- SEO Meta Tags -->
     <meta name="application-name" content="Gridfinity Layout Tool">
@@ -32,7 +32,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://gridfinitylayouttool.com/">
-    <meta property="og:title" content="Gridfinity Planner & Layout Tool — Free Bin Generator">
+    <meta property="og:title" content="Gridfinity Planner & Layout Tool — Free Online Drawer Organizer">
     <meta property="og:description" content="Plan drawer layouts and generate custom bins and baseplates to the official Gridfinity spec. 3D preview, STL/STEP/3MF export. Free, in your browser, no account.">
     <meta property="og:image" content="https://gridfinitylayouttool.com/og/home.png">
     <meta property="og:image:width" content="1200">
@@ -44,7 +44,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://gridfinitylayouttool.com/">
-    <meta name="twitter:title" content="Gridfinity Planner & Layout Tool — Free Bin Generator">
+    <meta name="twitter:title" content="Gridfinity Planner & Layout Tool — Free Online Drawer Organizer">
     <meta name="twitter:description" content="Plan drawer layouts and generate custom bins and baseplates to the official Gridfinity spec. 3D preview, STL/STEP/3MF export. Free, in your browser, no account.">
     <meta name="twitter:image" content="https://gridfinitylayouttool.com/og/home.png">
     <meta name="twitter:image:alt" content="Gridfinity Layout Tool — drag-and-drop drawer planner showing a tool drawer with labeled, color-coded bins">

--- a/scripts/build-route-entries.ts
+++ b/scripts/build-route-entries.ts
@@ -110,7 +110,7 @@ function breadcrumbs(slug: string, name: string): object {
 const ROUTES: RouteEntry[] = [
   {
     slug: 'designer',
-    title: 'Gridfinity Bin Designer — Free Custom Bin Generator',
+    title: 'Gridfinity Bin Designer — Free Custom Bin Builder',
     description:
       'Design custom Gridfinity bins in your browser: dimensions, compartments, label tabs, wall cutouts, and base styles with a real-time 3D preview. Export STL, STEP, or 3MF. Free, no account.',
     keywords:
@@ -139,7 +139,7 @@ const ROUTES: RouteEntry[] = [
   },
   {
     slug: 'baseplate',
-    title: 'Gridfinity Baseplate Maker — Free Custom Baseplate Generator',
+    title: 'Gridfinity Baseplate Maker — Free Custom Baseplate Builder',
     description:
       'Make custom Gridfinity baseplates in your browser: any grid size, magnet holes, edge padding, and automatic print-bed splitting. Export STL, STEP, or 3MF. Free, no account.',
     keywords:

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -44,16 +44,16 @@ const fallback: Translations = {
   'errorBoundary.backupDone': 'Backup downloaded.',
   'errorBoundary.backupError': "Couldn't create a backup. Try refreshing the page.",
   'common.loading': 'Loading...',
-  'seo.title': 'Gridfinity Planner & Layout Tool — Free Bin Generator',
+  'seo.title': 'Gridfinity Planner & Layout Tool — Free Online Drawer Organizer',
   'seo.description':
     'Plan Gridfinity drawer layouts in your browser. Drag-and-drop bins, custom bin generator, 3D preview, STL/STEP/3MF export. Free, no account.',
   'seo.h1': 'Gridfinity Planner & Layout Tool',
-  'seo.designer.title': 'Gridfinity Bin Generator — Free Online STL Creator',
+  'seo.designer.title': 'Gridfinity Bin Designer — Free Custom Bin Generator',
   'seo.designer.description':
-    'Gridfinity bin generator with visual editor and real-time 3D preview. Set dimensions, add compartments and cutouts, export STL, STEP, or 3MF. Free browser tool.',
-  'seo.baseplate.title': 'Gridfinity Baseplate Generator — Free Online STL Creator',
+    'Design custom Gridfinity bins in your browser: dimensions, compartments, label tabs, wall cutouts, and base styles with a real-time 3D preview. Export STL, STEP, or 3MF. Free, no account.',
+  'seo.baseplate.title': 'Gridfinity Baseplate Maker — Free Custom Baseplate Generator',
   'seo.baseplate.description':
-    'Gridfinity baseplate generator with real-time 3D preview. Configure grid size, magnet holes, connector nubs, and edge padding. Export STL, STEP, or 3MF. Free browser tool.',
+    'Make custom Gridfinity baseplates in your browser: any grid size, magnet holes, edge padding, and automatic print-bed splitting. Export STL, STEP, or 3MF. Free, no account.',
 };
 
 /**

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -48,10 +48,10 @@ const fallback: Translations = {
   'seo.description':
     'Plan Gridfinity drawer layouts in your browser. Drag-and-drop bins, custom bin generator, 3D preview, STL/STEP/3MF export. Free, no account.',
   'seo.h1': 'Gridfinity Planner & Layout Tool',
-  'seo.designer.title': 'Gridfinity Bin Designer — Free Custom Bin Generator',
+  'seo.designer.title': 'Gridfinity Bin Designer — Free Custom Bin Builder',
   'seo.designer.description':
     'Design custom Gridfinity bins in your browser: dimensions, compartments, label tabs, wall cutouts, and base styles with a real-time 3D preview. Export STL, STEP, or 3MF. Free, no account.',
-  'seo.baseplate.title': 'Gridfinity Baseplate Maker — Free Custom Baseplate Generator',
+  'seo.baseplate.title': 'Gridfinity Baseplate Maker — Free Custom Baseplate Builder',
   'seo.baseplate.description':
     'Make custom Gridfinity baseplates in your browser: any grid size, magnet holes, edge padding, and automatic print-bed splitting. Export STL, STEP, or 3MF. Free, no account.',
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -16,19 +16,20 @@
 const en: Record<string, string> = {
   // SEO Meta Tags (dynamically injected into document head)
   'seo.h1': 'Gridfinity Planner & Layout Tool',
-  'seo.title': 'Gridfinity Planner & Layout Tool — Free Bin Generator',
+  'seo.title': 'Gridfinity Planner & Layout Tool — Free Online Drawer Organizer',
   'seo.description':
     'Plan Gridfinity drawer layouts in your browser. Drag-and-drop bins, custom bin generator, 3D preview, STL/STEP/3MF export. Free, no account.',
-  // Per-route title overrides — mirror the content-page titles so direct
-  // landings on /designer and /baseplate get the same SEO signal as the
-  // content-page equivalents at /gridfinity-bin-generator and
-  // /gridfinity-baseplate-generator.
-  'seo.designer.title': 'Gridfinity Bin Generator — Free Online STL Creator',
+  // Per-route title overrides for the /designer and /baseplate app routes.
+  // These deliberately use the "Designer"/"Maker" framing (matching the static
+  // route entries in build-route-entries.ts) so the interactive tool routes
+  // stay distinct from the content landing pages at /gridfinity-bin-generator
+  // and /gridfinity-baseplate-generator, which own the "Generator" queries.
+  'seo.designer.title': 'Gridfinity Bin Designer — Free Custom Bin Generator',
   'seo.designer.description':
-    'Gridfinity bin generator with visual editor and real-time 3D preview. Set dimensions, add compartments and cutouts, export STL, STEP, or 3MF. Free browser tool.',
-  'seo.baseplate.title': 'Gridfinity Baseplate Generator — Free Online STL Creator',
+    'Design custom Gridfinity bins in your browser: dimensions, compartments, label tabs, wall cutouts, and base styles with a real-time 3D preview. Export STL, STEP, or 3MF. Free, no account.',
+  'seo.baseplate.title': 'Gridfinity Baseplate Maker — Free Custom Baseplate Generator',
   'seo.baseplate.description':
-    'Gridfinity baseplate generator with real-time 3D preview. Configure grid size, magnet holes, connector nubs, and edge padding. Export STL, STEP, or 3MF. Free browser tool.',
+    'Make custom Gridfinity baseplates in your browser: any grid size, magnet holes, edge padding, and automatic print-bed splitting. Export STL, STEP, or 3MF. Free, no account.',
 
   // Common / Shared
   'common.save': 'Save',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -24,10 +24,10 @@ const en: Record<string, string> = {
   // route entries in build-route-entries.ts) so the interactive tool routes
   // stay distinct from the content landing pages at /gridfinity-bin-generator
   // and /gridfinity-baseplate-generator, which own the "Generator" queries.
-  'seo.designer.title': 'Gridfinity Bin Designer — Free Custom Bin Generator',
+  'seo.designer.title': 'Gridfinity Bin Designer — Free Custom Bin Builder',
   'seo.designer.description':
     'Design custom Gridfinity bins in your browser: dimensions, compartments, label tabs, wall cutouts, and base styles with a real-time 3D preview. Export STL, STEP, or 3MF. Free, no account.',
-  'seo.baseplate.title': 'Gridfinity Baseplate Maker — Free Custom Baseplate Generator',
+  'seo.baseplate.title': 'Gridfinity Baseplate Maker — Free Custom Baseplate Builder',
   'seo.baseplate.description':
     'Make custom Gridfinity baseplates in your browser: any grid size, magnet holes, edge padding, and automatic print-bed splitting. Export STL, STEP, or 3MF. Free, no account.',
 


### PR DESCRIPTION
## Context

Phase 2 of the SEO audit (title de-cannibalization + CTR snippet rework). No new pages — that work stays gated on the indexation re-check of the pages shipped in #2260.

### Title cannibalization (the core fix)

The audit found duplicate/competing `<title>`s across the generator family:

| Surface | Before |
| --- | --- |
| `/designer` (app, runtime `seo.designer.title`) | `Gridfinity Bin Generator — Free Online STL Creator` |
| `/gridfinity-bin-generator` (content) | `Gridfinity Bin Generator — Free Online STL Creator` ← **verbatim duplicate** |
| `/baseplate` (app, runtime `seo.baseplate.title`) | `Gridfinity Baseplate Generator — Free Online STL Creator` |
| `/gridfinity-baseplate-generator` (content) | `Gridfinity Baseplate Generator — Free Online STL Creator` ← **verbatim duplicate** |

The app routes' *runtime* titles also mismatched their own crawler-visible **static** titles (`build-route-entries.ts` already used "Bin **Designer**" / "Baseplate **Maker**"). 

**Fix:** align the app routes to their existing "Designer"/"Maker" framing so the content pages cleanly **own the "Generator" queries**. Updated `seo.designer.*` / `seo.baseplate.*` in `en.ts` and the hardcoded fallback map in `i18n/context.tsx` in lockstep.

### Homepage

Dropped the `Free Bin Generator` tail (competed with the dedicated bin pages) for `Free Online Drawer Organizer`, reinforcing the homepage's proven strength — it ranks #1-ish for `gridfinity planner` (282 clicks) and `gridfinity drawer planner` (45% CTR), all planner/drawer intent. Updated `<title>`, `og:title`, `twitter:title`, `seo.title`, and the context fallback.

### CTR reworks (CTR low for their rank)

- **`/gridfinity-sizes`** (pos ~5.5, **2.86%** CTR): answer-forward title (`Gridfinity Sizes & Dimensions — 42mm Grid + 7mm Heights`) + a description promising the full tables and the drawer conversion.
- **`/gridfinity-baseplate-generator`** (pos ~6.7, **1.64%** CTR): benefit-led snippet ("sized to your drawer… auto-splits to fit your print bed").

## Out of scope / follow-ups
- Localized `seo.designer/baseplate` translations still mirror the old wording in the 9 locale JSONs (low SEO impact — localized SERPs are served by the `/de/...` content pages, not the app routes). Can sync later.
- German `/de/gridfinity-calculator` + new target pages remain gated on the indexation re-check (~2–3 weeks).

## Verification
- `build:content` regenerates pages with the new titles/snippets; `build:en-locale` regenerates `en.json`.
- All 4 i18n checks pass (key parity, values, interpolation, unused); typecheck + ESLint clean.
- No code references the old literal title strings except the two i18n sources, both updated.