### PR TITLE
fix(export): align export dialog bottom padding to design-system token

### DIFF
--- a/src/features/print-export/components/PrintModal/PrintModal.tsx
+++ b/src/features/print-export/components/PrintModal/PrintModal.tsx
@@ -455,7 +455,7 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-end gap-3 p-4 pb-6 border-t border-stroke-subtle print-modal-footer">
+          <div className="flex items-center justify-end gap-3 p-4 pb-[var(--space-2xl)] border-t border-stroke-subtle print-modal-footer">
             {noLayersSelected && (
               <span className="text-xs text-warning mr-auto">
                 {t('print.selectAtLeastOneLayerToPrint')}

--- a/src/features/print-export/components/PrintModal/PrintModal.tsx
+++ b/src/features/print-export/components/PrintModal/PrintModal.tsx
@@ -455,7 +455,7 @@ export function PrintModal({ isOpen, onClose }: PrintModalProps) {
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-end gap-3 p-4 border-t border-stroke-subtle print-modal-footer">
+          <div className="flex items-center justify-end gap-3 p-4 pb-6 border-t border-stroke-subtle print-modal-footer">
             {noLayersSelected && (
               <span className="text-xs text-warning mr-auto">
                 {t('print.selectAtLeastOneLayerToPrint')}

--- a/src/shared/components/ExportDialog/ExportDialog.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.tsx
@@ -203,7 +203,7 @@ export function ExportDialog({
         {exported && successContent ? (
           successContent
         ) : (
-          <div className="pb-2">
+          <div className="pb-[var(--space-2xl)]">
             {/* Section Title */}
             {sectionTitle && (
               <>

--- a/src/shared/components/ExportDialog/ExportSupportPrompt.tsx
+++ b/src/shared/components/ExportDialog/ExportSupportPrompt.tsx
@@ -39,7 +39,7 @@ export function ExportSupportPrompt({ fileName, onDone, source }: ExportSupportP
   };
 
   return (
-    <div className="flex flex-col items-center px-2 pb-2 pt-2 text-center">
+    <div className="flex flex-col items-center px-2 pb-[var(--space-2xl)] pt-2 text-center">
       <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-success-muted">
         <svg
           className="h-6 w-6 text-success"


### PR DESCRIPTION
## Problem

The export modals had inconsistent bottom padding:

| Surface | Before | After |
|---|---|---|
| Model export dialog (bin designer, baseplate, connector/stack samples) | 8px (`pb-2`) | **24px** |
| Post-export support prompt (success view) | 8px (`pb-2`) | **24px** |
| Print Layout modal footer | 16px (`p-4`) | **24px** |

The shared `ExportDialog` places its action button inside `Dialog.Body` (which is `py-0`) instead of using `Dialog.Footer`, so it only got 8px at the bottom while its header carries 24px on top — visually lopsided. The hand-rolled `PrintModal` (not the `Dialog` primitive) used a flat 16px footer.

## Fix

Align all three export surfaces to the design-system standard **24px (`--space-2xl`)** — the value every `Dialog.Footer` already uses and which mirrors each dialog's header top padding.

- `ExportDialog.tsx` — form wrapper `pb-2` → `pb-[var(--space-2xl)]`
- `ExportSupportPrompt.tsx` — success wrapper `pb-2` → `pb-[var(--space-2xl)]`
- `PrintModal.tsx` — footer `p-4` → `p-4 pb-6` (24px, kept in the modal's own `p-*` idiom)

## Verification

- Rendered both modals via Playwright — confirmed matching ~24px bottom gaps below the action buttons.
- Export-dialog unit tests pass; ESLint clean on all three files.

No new i18n keys; pure className changes.