### PR TITLE
fix(deps): bump dompurify to 3.4.11 for GHSA-cmwh-pvxp-8882

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
   '@vercel/static-config>ajv': ^8.18.0
   glob>minimatch: ^10.2.3
   flatted: ^3.4.2
-  dompurify: ^3.4.9
+  dompurify: ^3.4.11
   '@babel/core@<7.29.6': ^7.29.6
   js-yaml@<4.2.0: ^4.2.0
   protobufjs: ^7.6.3
@@ -2851,6 +2851,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -3324,8 +3329,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
@@ -4919,6 +4924,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   serialize-javascript@7.0.5:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
@@ -4964,6 +4974,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -6596,7 +6610,7 @@ snapshots:
       '@zip.js/zip.js': 2.8.26
       autolinker: 4.1.5
       bitmap-sdf: 1.0.4
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       draco3d: 1.5.7
       earcut: 3.0.2
       grapheme-splitter: 1.0.4
@@ -8219,6 +8233,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  acorn@8.17.0: {}
+
   agent-base@7.1.4: {}
 
   ajv@6.15.0:
@@ -8668,7 +8684,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10083,7 +10099,7 @@ snapshots:
       '@posthog/core': 1.30.10
       '@posthog/types': 1.382.0
       core-js: 3.49.0
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       fflate: 0.4.8
       preact: 10.29.2
       query-selector-shadow-dom: 1.0.1
@@ -10384,6 +10400,8 @@ snapshots:
 
   semver@7.8.3: {}
 
+  semver@7.8.4: {}
+
   serialize-javascript@7.0.5: {}
 
   set-blocking@2.0.0: {}
@@ -10414,7 +10432,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.3
+      semver: 7.8.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -10468,6 +10486,14 @@ snapshots:
       side-channel-map: 1.0.1
 
   side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -10589,7 +10615,7 @@ snapshots:
       internal-slot: 1.1.0
       regexp.prototype.flags: 1.5.4
       set-function-name: 2.0.2
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   string.prototype.trim@1.2.10:
     dependencies:
@@ -10678,7 +10704,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,11 +26,12 @@ minimumReleaseAgeExclude:
   # TODO: remove after 2026-06-18 once 0.28.1 has aged past the window.
   - esbuild
   - '@esbuild/*'
-  # dompurify >=3.4.9 patches GHSA-vxr8-fq34-vvx9 (Trusted Types policy
-  # survives clearConfig); the override resolves to the latest 3.4.x. Excluded
-  # so the patched release can land before its 7-day cooldown elapses.
+  # dompurify >=3.4.11 patches GHSA-cmwh-pvxp-8882 (permanent ALLOWED_ATTR
+  # pollution via setConfig, incomplete fix of the 3.4.7 hook-pollution patch);
+  # the override resolves to the latest 3.4.x. Excluded so the patched release
+  # can land before its 7-day cooldown elapses.
   # TODO: remove once the resolved dompurify version has aged past the window
-  # (3.4.10 published 2026-06-12 -> 2026-06-19).
+  # (3.4.11 published 2026-06-17 -> 2026-06-24).
   - dompurify
 
 # Blocks Shai-Hulud-class worms that spread via npm lifecycle scripts.
@@ -64,7 +65,7 @@ overrides:
   '@vercel/static-config>ajv': '^8.18.0'
   'glob>minimatch': '^10.2.3'
   flatted: '^3.4.2'
-  dompurify: '^3.4.9'
+  dompurify: '^3.4.11'
   '@babel/core@<7.29.6': '^7.29.6'
   'js-yaml@<4.2.0': '^4.2.0'
   protobufjs: '^7.6.3'


### PR DESCRIPTION
## What

Raises the `dompurify` override floor from `^3.4.9` to `^3.4.11` in `pnpm-workspace.yaml`, pulling the patch for **GHSA-cmwh-pvxp-8882** (medium): permanent `ALLOWED_ATTR` pollution via `setConfig()`, an incomplete fix of the 3.4.7 hook-pollution patch.

## Why

dompurify is a transitive dependency via `posthog-js` (client runtime) and `gltf-pipeline` (devDep). It's already on the `minimumReleaseAgeExclude` list, so 3.4.11 (published 2026-06-17) lands before its 7-day supply-chain cooldown elapses. The dated TODO comment was refreshed to cite the new advisory and window (-> 2026-06-24).

Clears Dependabot alert #87 and code-scanning alert #35.

## Not included

The 3 open **undici** alerts (CVE-2026-9697 high, CVE-2026-9678 medium) are intentionally left to age out: patched 7.28.0 is only 3 days old and its cooldown elapses ~2026-06-22, after which Dependabot's auto-PR lands it. Real exposure is low — one path is `jsdom` (test-only), the other is `@vercel/node` and the CVE requires SOCKS5 ProxyAgent use (not used here). undici 6.25.0 (`@vercel/blob`) is outside the vulnerable range.

## Verification

- `pnpm why dompurify` -> single version 3.4.11
- `pnpm install --frozen-lockfile` passes (lockfile consistent)
- Lockfile + workspace manifest only; no source changes