### PR TITLE
docs(deps): correct dompurify override comment to match ^3.4.11 semantics

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,8 +28,8 @@ minimumReleaseAgeExclude:
   - '@esbuild/*'
   # dompurify >=3.4.11 patches GHSA-cmwh-pvxp-8882 (permanent ALLOWED_ATTR
   # pollution via setConfig, incomplete fix of the 3.4.7 hook-pollution patch);
-  # the override resolves to the latest 3.4.x. Excluded so the patched release
-  # can land before its 7-day cooldown elapses.
+  # the override (^3.4.11) resolves to the latest 3.x at or above the patch.
+  # Excluded so the patched release can land before its 7-day cooldown elapses.
   # TODO: remove once the resolved dompurify version has aged past the window
   # (3.4.11 published 2026-06-17 -> 2026-06-24).
   - dompurify


### PR DESCRIPTION
## What

Corrects a code-comment imprecision in `pnpm-workspace.yaml`: the comment said the dompurify override "resolves to the latest 3.4.x", but `^3.4.11` actually resolves to the latest **3.x** at or above the patch (`>=3.4.11 <4.0.0`).

## Why

Comment-only; no behavior change. Addresses a [Copilot review note](https://github.com/andymai/gridfinity-layout-tool/pull/2268) on #2268 (the dompurify GHSA-cmwh-pvxp-8882 bump) that landed too late — auto-merge fired on that PR's first commit before the fix was pushed, so it never merged. This is the trailing follow-up.