### PR TITLE
fix(header): tint reddit support icon with currentColor to match row

### DIFF
--- a/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
+++ b/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
@@ -132,7 +132,7 @@ export function HeaderSupportLinks() {
         title={t('common.redditCommunityAria')}
         aria-label={t('common.redditCommunityAria')}
       >
-        <svg className="w-4 h-4" fill="#FF4500" viewBox="0 0 24 24" aria-hidden="true">
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path d={REDDIT_ICON_PATH} />
         </svg>
         <span className="hidden lg:inline">{t('common.redditCommunity')}</span>


### PR DESCRIPTION
## What

The r/gridfinity link in the desktop header support row hardcoded `fill="#FF4500"`, making it the only brightly-colored mark in a row of muted `currentColor` icons (Feedback, Help, GitHub). This single-line change tints it with `currentColor` like the GitHub mark.

## Why

The bright orange filled disc read as inconsistent and visually off next to the thin/muted neighbors. Matching `currentColor` makes the Snoo render at the same weight and sit visually centered alongside Help and GitHub.

## Verification

- Measured the rendered DOM: the Reddit `<svg>` is pixel-identical to GitHub's (`top 15.5, h 16, center 23.5`) — layout was never the issue, only the color.
- Confirmed in the real running header (Playwright screenshot) that Help / GitHub / r/gridfinity now match in size, weight, and vertical centering.
- `HeaderSupportLinks` tests pass (10/10); typecheck clean.

## Out of scope

A separate orange Reddit icon exists in `ExportDialog/ExportSupportPrompt.tsx` (post-export support card) — left untouched as it's a different, more decorative surface.