### PR TITLE
feat(bin-designer): choose which side the half-unit foot sits on

### DIFF
--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -90,6 +90,8 @@ const ALLOWED_PARAM_KEYS = new Set<string>([
   'width',
   'depth',
   'height',
+  'fractionalEdgeX',
+  'fractionalEdgeY',
   'gridUnitMm',
   'heightUnitMm',
   'wallThickness',

--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -81,6 +81,21 @@ graph TB
   `paramsNeedHalfGridMode` (fractional dimensions OR `hasHalfBinDetail(mask)`),
   so reopening a design or undoing past a dimension change never leaves the
   UI toggles out of sync with the underlying shape.
+- **Fractional foot edge** (`params.fractionalEdgeX` / `fractionalEdgeY`): for a
+  bin with a fractional dimension (e.g. 2.5u), which side the half-unit foot
+  column/row sits on — `'end'` (default) = right/back, `'start'` = left/front.
+  Mirrors the baseplate's drawer-level option and lets a 2.5×2 bin place its
+  half foot on either side **without** rotating the print (rotation would move
+  the front-facing finger scoop to the back). Default `'end'` keeps existing
+  geometry byte-identical (the socket cache key appends `frac:x:y` only when
+  non-default). The setting is threaded through every cell iterator that must
+  agree on foot placement — base sockets + their magnet/screw holes, the
+  lightweight base, and lid magnets — so they never drift apart. **No effect with
+  `base.halfSockets`** (every foot is already a uniform 0.5u cell, so there's no
+  single half foot to move) — the `DimensionsSection` toggle hides in that mode.
+  Overhang gap-fill feet keep the default decomposition since they don't mate
+  with baseplate sockets. `migrateParams` backfills `'end'` for legacy designs;
+  `handleSwapDimensions` swaps the two edges along with width/depth.
 - **Click-lock lid**: optional companion piece generated alongside the bin
   when `params.lid.enabled && params.base.stackingLip`. Source of truth lives
   in the worker (`generation/worker/generators/lidBuilder.ts` +

--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.test.tsx
@@ -18,4 +18,21 @@ describe('DimensionsSection', () => {
     expect(screen.getByLabelText('Depth')).toBeInTheDocument();
     expect(screen.getByLabelText('Height')).toBeInTheDocument();
   });
+
+  it('hides the half-unit edge controls for whole-unit bins', () => {
+    render(<DimensionsSection />);
+    expect(screen.queryByText('Half-unit edge position')).not.toBeInTheDocument();
+  });
+
+  it('shows the half-unit edge control only for the fractional axis', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, width: 2.5, depth: 2 },
+    });
+    render(<DimensionsSection />);
+    expect(screen.getByText('Half-unit edge position')).toBeInTheDocument();
+    expect(screen.getByText('Left')).toBeInTheDocument();
+    expect(screen.getByText('Right')).toBeInTheDocument();
+    // Depth is whole — no front/back (bottom/top) toggle.
+    expect(screen.queryByText('Bottom')).not.toBeInTheDocument();
+  });
 });

--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.test.tsx
@@ -35,4 +35,17 @@ describe('DimensionsSection', () => {
     // Depth is whole — no front/back (bottom/top) toggle.
     expect(screen.queryByText('Bottom')).not.toBeInTheDocument();
   });
+
+  it('hides the edge control in half-sockets mode', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        width: 2.5,
+        depth: 2,
+        base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+      },
+    });
+    render(<DimensionsSection />);
+    expect(screen.queryByText('Half-unit edge position')).not.toBeInTheDocument();
+  });
 });

--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
@@ -9,6 +9,7 @@
 import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
 import { Checkbox, IconButton, Stepper } from '@/design-system';
 import { ArrowLeftRightIcon, RulerIcon } from '@/design-system/Icon';
+import { FractionalEdgeToggle } from '@/shared/components/FractionalEdgeToggle';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { useDimensionsSection } from './useDimensionsSection';
 
@@ -73,6 +74,40 @@ export function DimensionsSection() {
           {state.widthMm.toFixed(0)} × {state.depthMm.toFixed(0)} × {state.heightMm.toFixed(0)} mm
         </span>
       </div>
+
+      {/* Half-unit foot placement — shown when a dimension is fractional. Lets a
+          2.5×2 bin put its half foot on either side without rotating the print. */}
+      {(state.hasFractionalWidth || state.hasFractionalDepth) && (
+        <div className="space-y-1.5 text-xs">
+          <div className="text-content-tertiary text-[10px]">
+            {t('sidebar.halfUnitEdgePosition')}
+          </div>
+          {state.hasFractionalWidth && (
+            <FractionalEdgeToggle
+              axis="x"
+              label={t('common.width')}
+              value={state.fractionalEdgeX}
+              onChange={handlers.handleFractionalEdgeChange}
+              startTitle={t('sidebar.halfBinLeft')}
+              startLabel={t('sidebar.left')}
+              endTitle={t('sidebar.halfBinRight')}
+              endLabel={t('sidebar.right')}
+            />
+          )}
+          {state.hasFractionalDepth && (
+            <FractionalEdgeToggle
+              axis="y"
+              label={t('common.depth')}
+              value={state.fractionalEdgeY}
+              onChange={handlers.handleFractionalEdgeChange}
+              startTitle={t('sidebar.halfBinBottom')}
+              startLabel={t('sidebar.bottom')}
+              endTitle={t('sidebar.halfBinTop')}
+              endLabel={t('sidebar.top')}
+            />
+          )}
+        </div>
+      )}
 
       {/* Height */}
       <div>

--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
@@ -142,4 +142,31 @@ describe('useDimensionsSection', () => {
     expect(useDesignerStore.getState().ui.halfGridMode).toBe(true);
     expect(useDesignerStore.getState().params.width).toBe(1.5);
   });
+
+  it('flags fractional dimensions so the edge toggles can show', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, width: 2.5, depth: 2 },
+    });
+    const { result } = renderHook(() => useDimensionsSection());
+
+    expect(result.current.state.hasFractionalWidth).toBe(true);
+    expect(result.current.state.hasFractionalDepth).toBe(false);
+  });
+
+  it('handleFractionalEdgeChange writes the chosen edge to the store', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, width: 2.5 },
+    });
+    const { result } = renderHook(() => useDimensionsSection());
+
+    act(() => {
+      result.current.handlers.handleFractionalEdgeChange('x', 'start');
+    });
+    expect(useDesignerStore.getState().params.fractionalEdgeX).toBe('start');
+
+    act(() => {
+      result.current.handlers.handleFractionalEdgeChange('y', 'start');
+    });
+    expect(useDesignerStore.getState().params.fractionalEdgeY).toBe('start');
+  });
 });

--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.test.ts
@@ -153,6 +153,45 @@ describe('useDimensionsSection', () => {
     expect(result.current.state.hasFractionalDepth).toBe(false);
   });
 
+  it('hides the edge toggles in half-sockets mode (uniform half feet)', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        width: 2.5,
+        depth: 1.5,
+        base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
+      },
+    });
+    const { result } = renderHook(() => useDimensionsSection());
+
+    expect(result.current.state.hasFractionalWidth).toBe(false);
+    expect(result.current.state.hasFractionalDepth).toBe(false);
+  });
+
+  it('swaps the fractional edge with its axis when dimensions are swapped', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        width: 2.5,
+        depth: 1,
+        fractionalEdgeX: 'start',
+        fractionalEdgeY: 'end',
+      },
+    });
+    const { result } = renderHook(() => useDimensionsSection());
+
+    act(() => {
+      result.current.handlers.handleSwapDimensions();
+    });
+
+    const params = useDesignerStore.getState().params;
+    expect(params.width).toBe(1);
+    expect(params.depth).toBe(2.5);
+    // The 'start' preference followed width → depth.
+    expect(params.fractionalEdgeX).toBe('end');
+    expect(params.fractionalEdgeY).toBe('start');
+  });
+
   it('handleFractionalEdgeChange writes the chosen edge to the store', () => {
     useDesignerStore.setState({
       params: { ...DEFAULT_BIN_PARAMS, width: 2.5 },

--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.ts
@@ -13,6 +13,7 @@ export function useDimensionsSection() {
     height,
     fractionalEdgeX,
     fractionalEdgeY,
+    baseHalfSockets,
     gridUnitMm,
     heightUnitMm,
     halfGridMode,
@@ -26,6 +27,7 @@ export function useDimensionsSection() {
       height: s.params.height,
       fractionalEdgeX: s.params.fractionalEdgeX,
       fractionalEdgeY: s.params.fractionalEdgeY,
+      baseHalfSockets: s.params.base.halfSockets,
       gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       halfGridMode: s.ui.halfGridMode,
@@ -76,8 +78,15 @@ export function useDimensionsSection() {
   );
 
   const handleSwapDimensions = useCallback(() => {
-    setParams({ width: depth, depth: width });
-  }, [width, depth, setParams]);
+    // Transpose the grid: the half-foot edge preference must travel with its
+    // axis, else swapping a 2.5×1 'left' bin would silently move the half foot.
+    setParams({
+      width: depth,
+      depth: width,
+      fractionalEdgeX: fractionalEdgeY,
+      fractionalEdgeY: fractionalEdgeX,
+    });
+  }, [width, depth, fractionalEdgeX, fractionalEdgeY, setParams]);
 
   const handleSetParam = useCallback(
     <K extends keyof BinParams>(key: K, value: BinParams[K]) => {
@@ -110,8 +119,10 @@ export function useDimensionsSection() {
       minDepth,
       fractionalEdgeX,
       fractionalEdgeY,
-      hasFractionalWidth: isFractional(width),
-      hasFractionalDepth: isFractional(depth),
+      // Half-sockets mode decomposes every cell into uniform 0.5u feet, so there
+      // is no single half foot to reposition — hide the edge controls then.
+      hasFractionalWidth: isFractional(width) && !baseHalfSockets,
+      hasFractionalDepth: isFractional(depth) && !baseHalfSockets,
     },
     handlers: {
       setParam: handleSetParam,

--- a/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.ts
+++ b/src/features/bin-designer/components/panel/DimensionsSection/useDimensionsSection.ts
@@ -11,6 +11,8 @@ export function useDimensionsSection() {
     width,
     depth,
     height,
+    fractionalEdgeX,
+    fractionalEdgeY,
     gridUnitMm,
     heightUnitMm,
     halfGridMode,
@@ -22,6 +24,8 @@ export function useDimensionsSection() {
       width: s.params.width,
       depth: s.params.depth,
       height: s.params.height,
+      fractionalEdgeX: s.params.fractionalEdgeX,
+      fractionalEdgeY: s.params.fractionalEdgeY,
       gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
       halfGridMode: s.ui.halfGridMode,
@@ -85,6 +89,13 @@ export function useDimensionsSection() {
     [halfGridMode, toggleHalfGridMode, setParam]
   );
 
+  const handleFractionalEdgeChange = useCallback(
+    (axis: 'x' | 'y', position: 'start' | 'end') => {
+      setParam(axis === 'x' ? 'fractionalEdgeX' : 'fractionalEdgeY', position);
+    },
+    [setParam]
+  );
+
   return {
     state: {
       width,
@@ -97,6 +108,10 @@ export function useDimensionsSection() {
       dimensionStep,
       minWidth,
       minDepth,
+      fractionalEdgeX,
+      fractionalEdgeY,
+      hasFractionalWidth: isFractional(width),
+      hasFractionalDepth: isFractional(depth),
     },
     handlers: {
       setParam: handleSetParam,
@@ -105,6 +120,7 @@ export function useDimensionsSection() {
       handleHeightStep,
       handleSwapDimensions,
       toggleHalfGridMode,
+      handleFractionalEdgeChange,
     },
     t,
   };

--- a/src/features/bin-designer/constants/defaults.test.ts
+++ b/src/features/bin-designer/constants/defaults.test.ts
@@ -148,6 +148,18 @@ describe('migrateParams', () => {
     expectOk(validateBinParams(result));
   });
 
+  it('backfills fractional edge defaults to "end" for legacy designs', () => {
+    const result = migrateParams({ width: 2.5 });
+    expect(result.fractionalEdgeX).toBe('end');
+    expect(result.fractionalEdgeY).toBe('end');
+  });
+
+  it('preserves an explicit fractional edge choice', () => {
+    const result = migrateParams({ width: 2.5, fractionalEdgeX: 'start' } as any);
+    expect(result.fractionalEdgeX).toBe('start');
+    expect(result.fractionalEdgeY).toBe('end');
+  });
+
   it('should produce valid params from legacy format', () => {
     const result = migrateParams({
       width: 2,

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -273,6 +273,8 @@ export const DEFAULT_BIN_PARAMS: BinParams = {
   width: 2,
   depth: 2,
   height: 3,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
   gridUnitMm: 42,
   heightUnitMm: 7,
   wallThickness: 1.2,

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -504,6 +504,10 @@ export interface BinParams {
   readonly width: number;
   readonly depth: number;
   readonly height: number;
+  /** Side the half-unit foot column sits on for fractional `width`: `'end'` (default) = right, `'start'` = left. Lets a 2.5×2 bin pick the side without rotating the print (which moves the front scoop). */
+  readonly fractionalEdgeX: 'start' | 'end';
+  /** Side the half-unit foot row sits on for fractional `depth`: `'end'` (default) = back, `'start'` = front. */
+  readonly fractionalEdgeY: 'start' | 'end';
   /** Grid unit size in mm (default 42mm per Gridfinity spec) */
   readonly gridUnitMm: number;
   /** Height unit size in mm (default 7mm per Gridfinity spec) */

--- a/src/features/generation/worker/generators/lidInputs.ts
+++ b/src/features/generation/worker/generators/lidInputs.ts
@@ -38,6 +38,13 @@ export interface LidInputs {
   readonly magnetDepth: number;
   readonly cellsX: number;
   readonly cellsY: number;
+  /**
+   * Which side the half-unit cell sits on for fractional bins. Mirrors the
+   * bin's base-socket placement so the lid's magnet holes line up with the
+   * feet of the bin stacked on top. See {@link BinParams.fractionalEdgeX}.
+   */
+  readonly fractionalEdgeX: 'start' | 'end';
+  readonly fractionalEdgeY: 'start' | 'end';
   readonly gridUnitMm: number;
   readonly heightUnitMm: number;
   /**
@@ -145,6 +152,8 @@ export function resolveLidInputs(params: BinParams): LidInputs {
     magnetDepth: params.base.magnetDepth,
     cellsX: params.width,
     cellsY: params.depth,
+    fractionalEdgeX: params.fractionalEdgeX,
+    fractionalEdgeY: params.fractionalEdgeY,
     gridUnitMm,
     heightUnitMm,
     // Per-side rail skips derived from feature conflicts (label tabs,

--- a/src/features/generation/worker/generators/lidMagnets.ts
+++ b/src/features/generation/worker/generators/lidMagnets.ts
@@ -18,8 +18,17 @@ import { isCellFilled } from './lidStackGrid';
 import type { LidInputs } from './lidInputs';
 
 export function cutMagnetHoles(scope: DisposalScope, body: Shape3D, inputs: LidInputs): Shape3D {
-  const { cellsX, cellsY, gridUnitMm, magnetDiameter, magnetDepth, topThickness, cellMask } =
-    inputs;
+  const {
+    cellsX,
+    cellsY,
+    fractionalEdgeX,
+    fractionalEdgeY,
+    gridUnitMm,
+    magnetDiameter,
+    magnetDepth,
+    topThickness,
+    cellMask,
+  } = inputs;
   const radius = magnetDiameter / 2;
 
   // Capping at `topThickness - ceiling` is defensive in case `topThickness`
@@ -60,7 +69,7 @@ export function cutMagnetHoles(scope: DisposalScope, body: Shape3D, inputs: LidI
         );
       }
     },
-    { gridUnitMm }
+    { gridUnitMm, fractionalEdgeX, fractionalEdgeY }
   );
 
   if (cutters.length === 0) return body;

--- a/src/features/generation/worker/generators/lightweightBaseBuilder.ts
+++ b/src/features/generation/worker/generators/lightweightBaseBuilder.ts
@@ -43,6 +43,8 @@ import {
   buildSingleCellSocket,
   buildSimplifiedCellSocket,
   forEachSocketCell,
+  DEFAULT_FRACTIONAL_EDGE,
+  type FractionalEdge,
 } from './socketBuilder';
 import { isPartialMask, isRegionFilled, type CellMask } from '@/shared/utils/cellMask';
 
@@ -124,7 +126,8 @@ export function buildLightweightBase(
   halfSockets = false,
   gridUnitMm: number = SIZE,
   cellMask?: CellMask,
-  openFloorDrawings?: readonly Drawing[]
+  openFloorDrawings?: readonly Drawing[],
+  fractionalEdge: FractionalEdge = DEFAULT_FRACTIONAL_EDGE
 ): LightweightBase {
   const usingMask = isPartialMask(cellMask);
   const cellInMask = (
@@ -186,37 +189,45 @@ export function buildLightweightBase(
     const voids: Shape3D[] = [];
     const openingTools: Shape3D[] = [];
 
-    forEachSocketCell(gridW, gridD, cellMask, gridUnitMm, halfSockets, (cell) => {
-      if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
-      const cellW_mm = cell.widthUnits * gridUnitMm - CLEARANCE;
-      const cellD_mm = cell.depthUnits * gridUnitMm - CLEARANCE;
-      feet.push(
-        translate(scope.register(buildFoot(cellW_mm, cellD_mm)), [cell.centerX, cell.centerY, 0])
-      );
-
-      const innerW = cellW_mm - 2 * wallThickness;
-      const innerD = cellD_mm - 2 * wallThickness;
-      // Wall thickness too large for this cell — keep the solid foot (no cavity,
-      // best-effort) so the base never collapses to nothing.
-      if (innerW <= 0.2 || innerD <= 0.2) return;
-
-      // Inner foot shifted by ±wt: a uniform-wt offset of the foot (socket insets
-      // are absolute). The shift leaves a wt floor at the closed end; for 'up' it
-      // also pokes a slug above the foot top, reused as the floor-opening tool.
-      const innerFoot = scope.register(buildFoot(innerW, innerD));
-      voids.push(
-        translate(scope.register(unwrap(clone(innerFoot))), [cell.centerX, cell.centerY, zShift])
-      );
-      if (openDir === 'up') {
-        openingTools.push(
-          translate(scope.register(unwrap(clone(innerFoot))), [
-            cell.centerX,
-            cell.centerY,
-            wallThickness,
-          ])
+    forEachSocketCell(
+      gridW,
+      gridD,
+      cellMask,
+      gridUnitMm,
+      halfSockets,
+      (cell) => {
+        if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
+        const cellW_mm = cell.widthUnits * gridUnitMm - CLEARANCE;
+        const cellD_mm = cell.depthUnits * gridUnitMm - CLEARANCE;
+        feet.push(
+          translate(scope.register(buildFoot(cellW_mm, cellD_mm)), [cell.centerX, cell.centerY, 0])
         );
-      }
-    });
+
+        const innerW = cellW_mm - 2 * wallThickness;
+        const innerD = cellD_mm - 2 * wallThickness;
+        // Wall thickness too large for this cell — keep the solid foot (no cavity,
+        // best-effort) so the base never collapses to nothing.
+        if (innerW <= 0.2 || innerD <= 0.2) return;
+
+        // Inner foot shifted by ±wt: a uniform-wt offset of the foot (socket insets
+        // are absolute). The shift leaves a wt floor at the closed end; for 'up' it
+        // also pokes a slug above the foot top, reused as the floor-opening tool.
+        const innerFoot = scope.register(buildFoot(innerW, innerD));
+        voids.push(
+          translate(scope.register(unwrap(clone(innerFoot))), [cell.centerX, cell.centerY, zShift])
+        );
+        if (openDir === 'up') {
+          openingTools.push(
+            translate(scope.register(unwrap(clone(innerFoot))), [
+              cell.centerX,
+              cell.centerY,
+              wallThickness,
+            ])
+          );
+        }
+      },
+      fractionalEdge
+    );
 
     if (feet.length === 0) {
       throw new Error('Lightweight base: at least one cell required');
@@ -245,32 +256,40 @@ export function buildLightweightBase(
         (withMagnet ? magnetDepth : SOCKET_HEIGHT) + (withMagnet ? MAGNET_FLOOR : 0);
       const pads: Shape3D[] = [];
       const drills: Shape3D[] = [];
-      forEachSocketCell(gridW, gridD, cellMask, gridUnitMm, false, (cell) => {
-        if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
-        if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
-        const cellPads = buildCellPads(scope, holeRadius, floorDepth, openDir);
-        for (const p of cellPads) pads.push(translate(p, [cell.centerX, cell.centerY, 0]));
-        for (const [dx, dy] of MAGNET_OFFSETS) {
-          if (withMagnet) {
-            drills.push(
-              translate(scope.register(cylinder(magnetRadius, magnetDepth)), [
-                cell.centerX + dx,
-                cell.centerY + dy,
-                -SOCKET_HEIGHT,
-              ])
-            );
+      forEachSocketCell(
+        gridW,
+        gridD,
+        cellMask,
+        gridUnitMm,
+        false,
+        (cell) => {
+          if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+          if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
+          const cellPads = buildCellPads(scope, holeRadius, floorDepth, openDir);
+          for (const p of cellPads) pads.push(translate(p, [cell.centerX, cell.centerY, 0]));
+          for (const [dx, dy] of MAGNET_OFFSETS) {
+            if (withMagnet) {
+              drills.push(
+                translate(scope.register(cylinder(magnetRadius, magnetDepth)), [
+                  cell.centerX + dx,
+                  cell.centerY + dy,
+                  -SOCKET_HEIGHT,
+                ])
+              );
+            }
+            if (withScrew) {
+              drills.push(
+                translate(scope.register(cylinder(screwRadius, SOCKET_HEIGHT + 0.01)), [
+                  cell.centerX + dx,
+                  cell.centerY + dy,
+                  -SOCKET_HEIGHT,
+                ])
+              );
+            }
           }
-          if (withScrew) {
-            drills.push(
-              translate(scope.register(cylinder(screwRadius, SOCKET_HEIGHT + 0.01)), [
-                cell.centerX + dx,
-                cell.centerY + dy,
-                -SOCKET_HEIGHT,
-              ])
-            );
-          }
-        }
-      });
+        },
+        fractionalEdge
+      );
       if (pads.length > 0) {
         const padUnion = scope.register(unwrap(fuseAll(pads as ValidSolid[])));
         const padded = unwrap(fuse(base, padUnion));

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -84,7 +84,8 @@ export const shellStage: PipelineStage = {
         dim.halfSockets,
         params.gridUnitMm,
         params.cellMask,
-        openFloorDrawings
+        openFloorDrawings,
+        { x: params.fractionalEdgeX, y: params.fractionalEdgeY }
       );
       floorOpenings = liteBase.floorOpenings;
     }
@@ -235,7 +236,8 @@ export const shellStage: PipelineStage = {
           true, // Always use full 5-section socket profile (OCCT v8 is fast enough)
           dim.halfSockets,
           params.gridUnitMm,
-          params.cellMask
+          params.cellMask,
+          { x: params.fractionalEdgeX, y: params.fractionalEdgeY }
         );
     // `withScope` can't wrap this section (it must yield TWO survivors — body
     // and socket — on the preview path), so dispose manually on any throw to
@@ -245,6 +247,10 @@ export const shellStage: PipelineStage = {
     let feetFused = false;
     try {
       if (dim.overhang.feet && hasOverhang(dim.overhang)) {
+        // Overhang feet are gap-fill tiling around the nominal grid (they don't
+        // mate with baseplate sockets), so they keep the default 'end'
+        // decomposition regardless of fractionalEdge — only the seam tiling at a
+        // fractional edge differs cosmetically, never the socket mating.
         feet = buildOverhangFeet(params.width, params.depth, dim.overhang, params.gridUnitMm, true);
         if (feet) {
           const withFeet = unwrap(fuse(socket, feet));
@@ -284,7 +290,8 @@ export const shellStage: PipelineStage = {
             true,
             dim.halfSockets,
             params.gridUnitMm,
-            params.cellMask
+            params.cellMask,
+            { x: params.fractionalEdgeX, y: params.fractionalEdgeY }
           )}|${feetFused ? overhangKey(dim.overhang) : 'nofeet'}`;
 
       return { ...ctx, solid: body, deferredSolid: socket, deferredSolidKey };

--- a/src/features/generation/worker/generators/shapeCache.test.ts
+++ b/src/features/generation/worker/generators/shapeCache.test.ts
@@ -59,6 +59,64 @@ describe('socketCacheKey', () => {
     expect(a).not.toBe(b);
   });
 
+  it('default fractional edge ("end") leaves the key unchanged', () => {
+    // Positional args: ..., gridUnitMm, maskHash, fractionalEdgeX, fractionalEdgeY
+    const withDefault = socketCacheKey(2.5, 2, false, false, 3.1, 2.0, 1.5, false, false);
+    const explicitEnd = socketCacheKey(
+      2.5,
+      2,
+      false,
+      false,
+      3.1,
+      2.0,
+      1.5,
+      false,
+      false,
+      undefined,
+      undefined,
+      'end',
+      'end'
+    );
+    expect(explicitEnd).toBe(withDefault);
+  });
+
+  it('differs when the fractional edge changes', () => {
+    const end = socketCacheKey(2.5, 2, false, false, 3.1, 2.0, 1.5, false, false);
+    const startX = socketCacheKey(
+      2.5,
+      2,
+      false,
+      false,
+      3.1,
+      2.0,
+      1.5,
+      false,
+      false,
+      undefined,
+      undefined,
+      'start',
+      'end'
+    );
+    const startY = socketCacheKey(
+      2.5,
+      2,
+      false,
+      false,
+      3.1,
+      2.0,
+      1.5,
+      false,
+      false,
+      undefined,
+      undefined,
+      'end',
+      'start'
+    );
+    expect(startX).not.toBe(end);
+    expect(startY).not.toBe(end);
+    expect(startX).not.toBe(startY);
+  });
+
   it('includes all parameters in key', () => {
     const key = socketCacheKey(1.5, 2.5, true, true, 3.1, 2.4, 1.75, true, true);
     expect(key).toMatch(/^v2\|/);

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -111,8 +111,16 @@ export function socketCacheKey(
   forExport: boolean,
   halfSockets: boolean,
   gridUnitMm: number = GRIDFINITY.GRID_SIZE,
-  maskHash?: string
+  maskHash?: string,
+  fractionalEdgeX: 'start' | 'end' = 'end',
+  fractionalEdgeY: 'start' | 'end' = 'end'
 ): string {
+  // Only append when non-default so 'end'/'end' keys stay byte-identical to
+  // pre-feature keys (no needless cache invalidation; existing tests stable).
+  const fracSegments =
+    fractionalEdgeX === 'end' && fractionalEdgeY === 'end'
+      ? []
+      : [`frac:${fractionalEdgeX}:${fractionalEdgeY}`];
   return compactKey(
     buildCacheKey(
       'v2',
@@ -126,7 +134,8 @@ export function socketCacheKey(
       quantize(screwRadius),
       forExport,
       halfSockets,
-      maskHash ?? 'rect'
+      maskHash ?? 'rect',
+      ...fracSegments
     )
   );
 }

--- a/src/features/generation/worker/generators/socketBuilder.test.ts
+++ b/src/features/generation/worker/generators/socketBuilder.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { Shape3D } from 'brepjs';
+import type * as SocketBuilder from './socketBuilder';
 import { initTestKernel } from '@/test/initTestKernel';
 
 type BuildCellSocketFn = (cellW_mm: number, cellD_mm: number) => Shape3D;
@@ -19,6 +20,7 @@ type BuildBaseSocketFn = (
 let buildBaseSocket: BuildBaseSocketFn;
 let buildSingleCellSocket: BuildCellSocketFn;
 let buildSimplifiedCellSocket: BuildCellSocketFn;
+let forEachSocketCell: typeof SocketBuilder.forEachSocketCell;
 
 let meshShape: (shape: unknown) => { vertices: ArrayLike<number>; triangles: ArrayLike<number> };
 
@@ -30,9 +32,37 @@ beforeAll(async () => {
   buildBaseSocket = mod.buildBaseSocket;
   buildSingleCellSocket = mod.buildSingleCellSocket;
   buildSimplifiedCellSocket = mod.buildSimplifiedCellSocket;
+  forEachSocketCell = mod.forEachSocketCell;
 
   meshShape = (shape) => meshFn(shape as never, { tolerance: 1, angularTolerance: 30 });
 }, 30000);
+
+describe('forEachSocketCell fractional edge', () => {
+  // Collect the emitted cells for a 2.5×1 grid and locate the 0.5u sliver.
+  const collect = (edge?: { x: 'start' | 'end'; y: 'start' | 'end' }) => {
+    const cells: { widthUnits: number; centerX: number }[] = [];
+    forEachSocketCell(2.5, 1, undefined, 42, false, (c) => cells.push(c), edge);
+    return cells;
+  };
+  const halfCellX = (cells: { widthUnits: number; centerX: number }[]) =>
+    cells.find((c) => Math.abs(c.widthUnits - 0.5) < 1e-6)?.centerX;
+
+  it('defaults the half foot to the positive (right) side', () => {
+    const x = halfCellX(collect());
+    expect(x).toBeDefined();
+    expect(x as number).toBeGreaterThan(0);
+  });
+
+  it('places the half foot on the negative (left) side when edge.x is "start"', () => {
+    const x = halfCellX(collect({ x: 'start', y: 'end' }));
+    expect(x).toBeDefined();
+    expect(x as number).toBeLessThan(0);
+  });
+
+  it('emits the same number of cells regardless of edge', () => {
+    expect(collect().length).toBe(collect({ x: 'start', y: 'end' }).length);
+  });
+});
 
 describe('buildSingleCellSocket', () => {
   it('builds a valid solid for a full-size cell', () => {

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -85,6 +85,9 @@ export function forEachSocketCell(
   fractionalEdge: FractionalEdge = DEFAULT_FRACTIONAL_EDGE
 ): void {
   if (globalHalfSockets) {
+    // Half-sockets decomposes every cell into uniform 0.5u feet, so the grid is
+    // symmetric and `fractionalEdge` has no foot to reposition — intentionally
+    // omitted (the UI hides the edge controls in this mode).
     forEachCell(gridW, gridD, callback, { halfSockets: true, gridUnitMm });
     return;
   }

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -64,13 +64,25 @@ import {
  */
 export const MIN_FOOT_TILE_MM = MIN_PRINTABLE_TILE_MM;
 
+/**
+ * Which side a fractional (half-unit) foot column/row sits on. `'end'` (default)
+ * places it at the positive coordinate side; `'start'` at the negative side.
+ */
+export interface FractionalEdge {
+  readonly x: 'start' | 'end';
+  readonly y: 'start' | 'end';
+}
+
+export const DEFAULT_FRACTIONAL_EDGE: FractionalEdge = { x: 'end', y: 'end' };
+
 export function forEachSocketCell(
   gridW: number,
   gridD: number,
   mask: CellMask | undefined,
   gridUnitMm: number,
   globalHalfSockets: boolean,
-  callback: (cell: CellInfo) => void
+  callback: (cell: CellInfo) => void,
+  fractionalEdge: FractionalEdge = DEFAULT_FRACTIONAL_EDGE
 ): void {
   if (globalHalfSockets) {
     forEachCell(gridW, gridD, callback, { halfSockets: true, gridUnitMm });
@@ -88,6 +100,8 @@ export function forEachSocketCell(
       gridUnitMm,
       fractional: true,
       minFractionUnits: MIN_FOOT_TILE_MM / gridUnitMm,
+      fractionalEdgeX: fractionalEdge.x,
+      fractionalEdgeY: fractionalEdge.y,
     });
     return;
   }
@@ -134,7 +148,7 @@ export function forEachSocketCell(
         });
       }
     },
-    { gridUnitMm }
+    { gridUnitMm, fractionalEdgeX: fractionalEdge.x, fractionalEdgeY: fractionalEdge.y }
   );
 }
 /**
@@ -265,7 +279,8 @@ export function baseSocketShapeKey(
   forExport: boolean,
   halfSockets: boolean,
   gridUnitMm: number,
-  cellMask?: CellMask
+  cellMask?: CellMask,
+  fractionalEdge: FractionalEdge = DEFAULT_FRACTIONAL_EDGE
 ): string {
   const usingMask = isPartialMask(cellMask);
   return socketCacheKey(
@@ -279,7 +294,9 @@ export function baseSocketShapeKey(
     forExport,
     halfSockets,
     gridUnitMm,
-    usingMask ? hashMask(cellMask) : undefined
+    usingMask ? hashMask(cellMask) : undefined,
+    fractionalEdge.x,
+    fractionalEdge.y
   );
 }
 
@@ -294,7 +311,8 @@ export function buildBaseSocket(
   forExport = false,
   halfSockets = false,
   gridUnitMm: number = SIZE,
-  cellMask?: CellMask
+  cellMask?: CellMask,
+  fractionalEdge: FractionalEdge = DEFAULT_FRACTIONAL_EDGE
 ): Shape3D {
   // Treat a fully-filled mask as a rectangle so the cache key and iteration
   // path match the existing rectangular code.
@@ -312,7 +330,8 @@ export function buildBaseSocket(
     forExport,
     halfSockets,
     gridUnitMm,
-    cellMask
+    cellMask,
+    fractionalEdge
   );
   const cached = getSocketCache(key);
   if (cached) {
@@ -342,23 +361,31 @@ export function buildBaseSocket(
     // Build and position each cell socket
     const cellSockets: Shape3D[] = [];
 
-    forEachSocketCell(gridW, gridD, cellMask, gridUnitMm, halfSockets, (cell) => {
-      if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
-      const cellW_mm = cell.widthUnits * gridUnitMm - CLEARANCE;
-      const cellD_mm = cell.depthUnits * gridUnitMm - CLEARANCE;
-      // Use simplified 3-section socket for preview, full 5-section for export
-      // NOTE: cellSockets are NOT scope-registered because fuseAll may return
-      // one of its inputs when given a single element. They're deleted manually.
-      const cellSocket = translate(
-        scope.register(
-          forExport
-            ? buildSingleCellSocket(cellW_mm, cellD_mm)
-            : buildSimplifiedCellSocket(cellW_mm, cellD_mm)
-        ),
-        [cell.centerX, cell.centerY, 0]
-      );
-      cellSockets.push(cellSocket);
-    });
+    forEachSocketCell(
+      gridW,
+      gridD,
+      cellMask,
+      gridUnitMm,
+      halfSockets,
+      (cell) => {
+        if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
+        const cellW_mm = cell.widthUnits * gridUnitMm - CLEARANCE;
+        const cellD_mm = cell.depthUnits * gridUnitMm - CLEARANCE;
+        // Use simplified 3-section socket for preview, full 5-section for export
+        // NOTE: cellSockets are NOT scope-registered because fuseAll may return
+        // one of its inputs when given a single element. They're deleted manually.
+        const cellSocket = translate(
+          scope.register(
+            forExport
+              ? buildSingleCellSocket(cellW_mm, cellD_mm)
+              : buildSimplifiedCellSocket(cellW_mm, cellD_mm)
+          ),
+          [cell.centerX, cell.centerY, 0]
+        );
+        cellSockets.push(cellSocket);
+      },
+      fractionalEdge
+    );
 
     if (cellSockets.length === 0) {
       throw new Error('Invalid grid dimensions: at least one cell required');
@@ -402,7 +429,7 @@ export function buildBaseSocket(
             );
           }
         },
-        { gridUnitMm }
+        { gridUnitMm, fractionalEdgeX: fractionalEdge.x, fractionalEdgeY: fractionalEdge.y }
       );
     }
 


### PR DESCRIPTION
## What

Adds `fractionalEdgeX` / `fractionalEdgeY` to `BinParams` so a bin with a fractional dimension (e.g. a 2.5×2 bin) can place its half-unit foot on **either** side, mirroring the baseplate's existing fractional-edge option. Default `'end'` preserves current geometry.

## Why

From discussion #2271: with a 2.5×2 bin the half-unit segment is hardcoded to one side. The only workaround — print and rotate — fails because the finger scoop always generates on the front face, so rotating moves the scoop to the back. Letting users pick the half-foot side removes the need to rotate, keeping the scoop where they want it.

## How

The underlying `forEachCell` already supported the reversal; this PR propagates one setting to every cell iterator that must agree on foot placement:

- base sockets **and** their magnet/screw holes (`socketBuilder`)
- lightweight base cups + pad/drill loops (`lightweightBaseBuilder`)
- lid magnets, via `LidInputs` (`lidInputs` → `lidMagnets`)
- both socket cache keys (`socketCacheKey`, `baseSocketShapeKey`) — the `frac:x:y` token is appended **only when non-default**, so existing `'end'` designs keep byte-identical keys
- API share allowlist (`ALLOWED_PARAM_KEYS`) so the setting survives cloud share/sync
- UI: reuses `FractionalEdgeToggle` in `DimensionsSection`, shown only when an axis is fractional (no new i18n strings)
- `migrateParams` backfills `'end'` for existing designs

### Scope note
Overhang gap-fill feet keep the default `'end'` tiling — they don't mate with baseplate sockets, so only a cosmetic seam differs at a fractional edge, never socket mating. Documented in a code comment.

## Testing

- `tsc -b` clean, ESLint 0 errors
- New tests: foot placement (`forEachSocketCell`), cache-key behavior, migration defaults, UI visibility/wiring
- Existing `fractional-feet` scenario still passes

Closes #2271