### PR TITLE
fix(bin-designer): align wall cutouts and handles to tilted dividers

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.tilted-dividers.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.tilted-dividers.test.ts
@@ -60,6 +60,40 @@ describe('tilted dividers through full pipeline', () => {
     expect(Math.abs(sumAbsY(tilted.vertices) - sumAbsY(straight.vertices))).toBeGreaterThan(10);
   }, 60_000);
 
+  const TILT = [{ compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: -10 }];
+
+  const hasFiniteGeometry = (verts: Float32Array | null): boolean => {
+    if (!verts || verts.length === 0) return false;
+    for (let i = 0; i < verts.length; i++) {
+      if (!Number.isFinite(verts[i])) return false;
+    }
+    return true;
+  };
+
+  it('tilted divider + interior wall cutout builds valid geometry (#2276)', () => {
+    const generateBin = getGenerateBin();
+    const result = generateBin({
+      ...baseParams,
+      walls: {
+        ...baseParams.walls,
+        enabled: true,
+        interior: { ...baseParams.walls.left, enabled: true },
+      },
+      compartments: { ...baseParams.compartments, dividerOverrides: TILT },
+    });
+    expect(hasFiniteGeometry(result.vertices)).toBe(true);
+  }, 60_000);
+
+  it('tilted divider + interior handle holes build valid geometry (#2276)', () => {
+    const generateBin = getGenerateBin();
+    const result = generateBin({
+      ...baseParams,
+      handles: { ...baseParams.handles, enabled: true, interior: true },
+      compartments: { ...baseParams.compartments, dividerOverrides: TILT },
+    });
+    expect(hasFiniteGeometry(result.vertices)).toBe(true);
+  }, 60_000);
+
   it('cavity floor reflects the tilt — points exist only at off-axis Y positions', () => {
     const generateBin = getGenerateBin();
     const tilted = generateBin({

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -445,7 +445,7 @@ function buildTiltedWallSegment(
  * fused run that crosses pair changes would silently apply the first pair's
  * override to the entire wall.
  */
-function findPairAwareRuns(
+export function findPairAwareRuns(
   count: number,
   key: (i: number) => string | null
 ): Array<{ start: number; end: number; pairKey: string }> {
@@ -477,11 +477,11 @@ function findPairAwareRuns(
 }
 
 /** Canonical-pair key for an override lookup map. */
-function overrideKey(a: number, b: number): string {
+export function overrideKey(a: number, b: number): string {
   return a < b ? `${a}|${b}` : `${b}|${a}`;
 }
 
-function buildOverrideLookup(
+export function buildOverrideLookup(
   overrides: readonly DividerOverride[] | undefined
 ): Map<string, DividerOverride> {
   const lookup = new Map<string, DividerOverride>();
@@ -490,6 +490,91 @@ function buildOverrideLookup(
     lookup.set(overrideKey(o.compartmentA, o.compartmentB), o);
   }
   return lookup;
+}
+
+/** One interior divider wall segment, resolved to mm in bin-centered coords. */
+export interface InteriorDividerSegment {
+  /** Axis-projected segment length (mm). */
+  readonly segLen: number;
+  /** Midpoint X of the (possibly tilted) segment. */
+  readonly x: number;
+  /** Midpoint Y of the (possibly tilted) segment. */
+  readonly y: number;
+  /** In-plane rotation (deg) aligned to the wall: 90 for straight vertical
+   *  dividers, 0 for straight horizontal, tilted by the override otherwise. */
+  readonly rotateZ: number;
+}
+
+/**
+ * Enumerate every interior divider wall segment with its tilt-resolved
+ * placement, honouring `dividerOverrides`. Shared source of truth so features
+ * that decorate dividers (wall cutouts, handles) land ON the wall instead of at
+ * the original grid line when a divider is tilted (GH #2276). Pure — no WASM.
+ */
+export function interiorDividerSegments(
+  params: BinParams,
+  innerW: number,
+  innerD: number
+): InteriorDividerSegment[] {
+  const { cols, rows, cells } = params.compartments;
+  const out: InteriorDividerSegment[] = [];
+  if (cols <= 1 && rows <= 1) return out;
+
+  const cellW = innerW / cols;
+  const cellD = innerD / rows;
+  const lookup = buildOverrideLookup(params.compartments.dividerOverrides);
+  const RAD2DEG = 180 / Math.PI;
+
+  // Vertical dividers (between columns) run along Y; straight ⇒ rotateZ 90.
+  for (let boundary = 1; boundary < cols; boundary++) {
+    const xPos = -innerW / 2 + boundary * cellW;
+    const runs = findPairAwareRuns(rows, (row) => {
+      const leftId = cells[row * cols + (boundary - 1)];
+      const rightId = cells[row * cols + boundary];
+      return leftId !== rightId ? overrideKey(leftId, rightId) : null;
+    });
+    for (const { start, end, pairKey } of runs) {
+      const segLen = (end - start) * cellD;
+      const midY = -innerD / 2 + (start + (end - start) / 2) * cellD;
+      const ov = lookup.get(pairKey);
+      out.push(
+        ov
+          ? {
+              segLen,
+              x: xPos + (ov.offsetStart + ov.offsetEnd) / 2,
+              y: midY,
+              rotateZ: Math.atan2(segLen, ov.offsetEnd - ov.offsetStart) * RAD2DEG,
+            }
+          : { segLen, x: xPos, y: midY, rotateZ: 90 }
+      );
+    }
+  }
+
+  // Horizontal dividers (between rows) run along X; straight ⇒ rotateZ 0.
+  for (let boundary = 1; boundary < rows; boundary++) {
+    const yPos = -innerD / 2 + boundary * cellD;
+    const runs = findPairAwareRuns(cols, (col) => {
+      const topId = cells[(boundary - 1) * cols + col];
+      const bottomId = cells[boundary * cols + col];
+      return topId !== bottomId ? overrideKey(topId, bottomId) : null;
+    });
+    for (const { start, end, pairKey } of runs) {
+      const segLen = (end - start) * cellW;
+      const midX = -innerW / 2 + (start + (end - start) / 2) * cellW;
+      const ov = lookup.get(pairKey);
+      out.push(
+        ov
+          ? {
+              segLen,
+              x: midX,
+              y: yPos + (ov.offsetStart + ov.offsetEnd) / 2,
+              rotateZ: Math.atan2(ov.offsetEnd - ov.offsetStart, segLen) * RAD2DEG,
+            }
+          : { segLen, x: midX, y: yPos, rotateZ: 0 }
+      );
+    }
+  }
+  return out;
 }
 
 /**

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -494,11 +494,9 @@ export function buildOverrideLookup(
 
 /** One interior divider wall segment, resolved to mm in bin-centered coords. */
 export interface InteriorDividerSegment {
-  /** Axis-projected segment length (mm). */
+  /** Axis-projected segment length (mm) — not the longer true diagonal. */
   readonly segLen: number;
-  /** Midpoint X of the (possibly tilted) segment. */
   readonly x: number;
-  /** Midpoint Y of the (possibly tilted) segment. */
   readonly y: number;
   /** In-plane rotation (deg) aligned to the wall: 90 for straight vertical
    *  dividers, 0 for straight horizontal, tilted by the override otherwise. */
@@ -509,7 +507,7 @@ export interface InteriorDividerSegment {
  * Enumerate every interior divider wall segment with its tilt-resolved
  * placement, honouring `dividerOverrides`. Shared source of truth so features
  * that decorate dividers (wall cutouts, handles) land ON the wall instead of at
- * the original grid line when a divider is tilted (GH #2276). Pure — no WASM.
+ * the original grid line when a divider is tilted. Pure — no WASM.
  */
 export function interiorDividerSegments(
   params: BinParams,
@@ -525,10 +523,26 @@ export function interiorDividerSegments(
   const lookup = buildOverrideLookup(params.compartments.dividerOverrides);
   const RAD2DEG = 180 / Math.PI;
 
+  // Without overrides, merge contiguous wall cells into one run (historical
+  // behavior — one window per span). Only split per compartment pair when tilts
+  // exist, since each tilted pair is its own angled wall segment.
+  const hasOverrides = lookup.size > 0;
+  const runsFor = (
+    count: number,
+    pairOf: (i: number) => string | null
+  ): Array<{ start: number; end: number; pairKey: string }> =>
+    hasOverrides
+      ? findPairAwareRuns(count, pairOf)
+      : findWallSegments(count, (i) => pairOf(i) !== null).map(([start, end]) => ({
+          start,
+          end,
+          pairKey: '',
+        }));
+
   // Vertical dividers (between columns) run along Y; straight ⇒ rotateZ 90.
   for (let boundary = 1; boundary < cols; boundary++) {
     const xPos = -innerW / 2 + boundary * cellW;
-    const runs = findPairAwareRuns(rows, (row) => {
+    const runs = runsFor(rows, (row) => {
       const leftId = cells[row * cols + (boundary - 1)];
       const rightId = cells[row * cols + boundary];
       return leftId !== rightId ? overrideKey(leftId, rightId) : null;
@@ -553,7 +567,7 @@ export function interiorDividerSegments(
   // Horizontal dividers (between rows) run along X; straight ⇒ rotateZ 0.
   for (let boundary = 1; boundary < rows; boundary++) {
     const yPos = -innerD / 2 + boundary * cellD;
-    const runs = findPairAwareRuns(cols, (col) => {
+    const runs = runsFor(cols, (col) => {
       const topId = cells[(boundary - 1) * cols + col];
       const bottomId = cells[boundary * cols + col];
       return topId !== bottomId ? overrideKey(topId, bottomId) : null;

--- a/src/features/generation/worker/generators/dividerBlendBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.ts
@@ -294,7 +294,10 @@ export const dividerBlendFeature: FeatureBuilder = {
         quantize(dim.innerW),
         quantize(dim.innerD),
         quantize(dim.wallHeight),
-        dim.hasLip
+        dim.hasLip,
+        // Tilted dividers are excluded from blends, so a tilt change alters
+        // which junctions blend and must invalidate the cached cut.
+        stableSerialize(params.compartments.dividerOverrides ?? [])
       )
     );
   },

--- a/src/features/generation/worker/generators/dividerBlendResolvers.test.ts
+++ b/src/features/generation/worker/generators/dividerBlendResolvers.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { collectDividers } from './dividerBlendResolvers';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams, DividerOverride } from '@/features/bin-designer/types';
+
+const INNER_W = 80;
+const INNER_D = 80;
+
+function makeParams(
+  compartments: Partial<BinParams['compartments']>,
+  overrides?: DividerOverride[]
+): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    compartments: {
+      ...DEFAULT_BIN_PARAMS.compartments,
+      ...compartments,
+      ...(overrides ? { dividerOverrides: overrides } : {}),
+    },
+  };
+}
+
+describe('collectDividers tilt handling', () => {
+  it('collects a straight divider', () => {
+    const dividers = collectDividers(
+      makeParams({ cols: 1, rows: 2, cells: [0, 1] }),
+      INNER_W,
+      INNER_D
+    );
+    expect(dividers).toHaveLength(1);
+    expect(dividers[0].axis).toBe('horizontal');
+  });
+
+  it('skips a tilted divider (blends degrade gracefully on tilt)', () => {
+    const override: DividerOverride = {
+      compartmentA: 0,
+      compartmentB: 1,
+      offsetStart: 10,
+      offsetEnd: -10,
+    };
+    const dividers = collectDividers(
+      makeParams({ cols: 1, rows: 2, cells: [0, 1] }, [override]),
+      INNER_W,
+      INNER_D
+    );
+    expect(dividers).toEqual([]);
+  });
+
+  it('keeps straight dividers while skipping only the tilted pair', () => {
+    // 1×3 stack: boundaries 0|1 and 1|2. Tilt only 0|1.
+    const override: DividerOverride = {
+      compartmentA: 0,
+      compartmentB: 1,
+      offsetStart: 8,
+      offsetEnd: -8,
+    };
+    const dividers = collectDividers(
+      makeParams({ cols: 1, rows: 3, cells: [0, 1, 2] }, [override]),
+      INNER_W,
+      INNER_D
+    );
+    expect(dividers).toHaveLength(1); // only the straight 1|2 divider survives
+  });
+});

--- a/src/features/generation/worker/generators/dividerBlendResolvers.ts
+++ b/src/features/generation/worker/generators/dividerBlendResolvers.ts
@@ -12,7 +12,7 @@
 
 import type { BinParams } from '@/shared/types/bin';
 import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
-import { findWallSegments } from './compartmentBuilder';
+import { findWallSegments, buildOverrideLookup, overrideKey } from './compartmentBuilder';
 import type { DividerInfo, OuterWallCutoutInfo } from './dividerBlendTypes';
 
 /**
@@ -100,6 +100,11 @@ export function collectDividers(params: BinParams, innerW: number, innerD: numbe
   const canBuildVertical = effectiveCellW >= thickness * 2;
   const canBuildHorizontal = effectiveCellD >= thickness * 2;
 
+  // Tilted dividers don't fit DividerInfo's axis-aligned `posAlongPerp` model,
+  // so blends/junction clips skip them (matching label tabs/scoops/inserts,
+  // which also degrade gracefully on tilt). Non-overridden bins are unaffected.
+  const overrides = buildOverrideLookup(params.compartments.dividerOverrides);
+
   const dividers: DividerInfo[] = [];
 
   // Vertical dividers (between columns, run along Y)
@@ -109,7 +114,7 @@ export function collectDividers(params: BinParams, innerW: number, innerD: numbe
       const segments = findWallSegments(rows, (row) => {
         const leftId = cells[row * cols + (colBoundary - 1)];
         const rightId = cells[row * cols + colBoundary];
-        return leftId !== rightId;
+        return leftId !== rightId && !overrides.has(overrideKey(leftId, rightId));
       });
       for (const [start, end] of segments) {
         dividers.push({
@@ -129,7 +134,7 @@ export function collectDividers(params: BinParams, innerW: number, innerD: numbe
       const segments = findWallSegments(cols, (col) => {
         const topId = cells[(rowBoundary - 1) * cols + col];
         const bottomId = cells[rowBoundary * cols + col];
-        return topId !== bottomId;
+        return topId !== bottomId && !overrides.has(overrideKey(topId, bottomId));
       });
       for (const [start, end] of segments) {
         dividers.push({

--- a/src/features/generation/worker/generators/handleBuilder.ts
+++ b/src/features/generation/worker/generators/handleBuilder.ts
@@ -14,7 +14,7 @@ import { translate, rotate, withScope, clone, unwrap, fuseAll } from 'brepjs';
 import type { Shape3D, ValidSolid, DisposalScope } from 'brepjs';
 import type { BinParams, HandleCutoutShape } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
-import { findWallSegments } from './compartmentBuilder';
+import { interiorDividerSegments } from './compartmentBuilder';
 import {
   buildHandleWallDefs,
   computeHandleHoleGeometry,
@@ -234,80 +234,39 @@ function buildHandleHolesInScope(
   // Interior wall handles — skipped on polygon bins (compartment walls are
   // filtered out for custom shapes, so there's nothing to cut through).
   if (interior && !isPolygon) {
-    const { cols, rows, cells } = params.compartments;
+    const { cols, rows } = params.compartments;
     if (cols > 1 || rows > 1) {
-      const cellW = innerW / cols;
-      const cellD = innerD / rows;
       const geom = computeHandleHoleGeometry(interiorHeight, globalHeight, verticalPosition);
 
       if (geom.effectiveHeight >= 1) {
-        const addInteriorHandles = (
-          boundaryCount: number,
-          segCount: number,
-          getCellIds: (boundary: number, i: number) => [number, number],
-          getWallDef: (boundary: number, start: number, end: number) => HandleWallDef,
-          segCellSize: number
-        ): void => {
-          for (let boundary = 1; boundary < boundaryCount; boundary++) {
-            const segments = findWallSegments(segCount, (i) => {
-              const [id1, id2] = getCellIds(boundary, i);
-              return id1 !== id2;
-            });
-
-            for (const [start, end] of segments) {
-              const segSpan = (end - start) * segCellSize;
-              const handleW = segSpan * (globalWidth / 100);
-              const offsets = computeMultiHandleOffsets(count, segSpan, handleW);
-              const wallDef = getWallDef(boundary, start, end);
-
-              for (const offset of offsets) {
-                const hole = buildHoleCut(
-                  scope,
-                  shape,
-                  handleW,
-                  offset,
-                  geom.effectiveHeight,
-                  globalRadius,
-                  extrudeDepth,
-                  geom.centerZ,
-                  wallDef
-                );
-                if (hole) allHoles.push(hole);
-              }
-            }
+        // Placement honours tilted dividers (dividerOverrides) so handle holes
+        // distribute along the angled wall, not the original grid line (#2276).
+        for (const seg of interiorDividerSegments(params, innerW, innerD)) {
+          const handleW = seg.segLen * (globalWidth / 100);
+          const offsets = computeMultiHandleOffsets(count, seg.segLen, handleW);
+          // Interior walls always use global config — `side` is unused for lookups.
+          const wallDef: HandleWallDef = {
+            side: 'front',
+            wallSpan: seg.segLen,
+            x: seg.x,
+            y: seg.y,
+            rotateZ: seg.rotateZ,
+          };
+          for (const offset of offsets) {
+            const hole = buildHoleCut(
+              scope,
+              shape,
+              handleW,
+              offset,
+              geom.effectiveHeight,
+              globalRadius,
+              extrudeDepth,
+              geom.centerZ,
+              wallDef
+            );
+            if (hole) allHoles.push(hole);
           }
-        };
-
-        // Vertical dividers (between columns)
-        addInteriorHandles(
-          cols,
-          rows,
-          (boundary, row) => [cells[row * cols + (boundary - 1)], cells[row * cols + boundary]],
-          (boundary, start, end) => ({
-            // Interior walls always use global config — side field unused for lookups
-            side: 'front' as const,
-            wallSpan: (end - start) * cellD,
-            x: -innerW / 2 + boundary * cellW,
-            y: -innerD / 2 + (start + (end - start) / 2) * cellD,
-            rotateZ: 90,
-          }),
-          cellD
-        );
-
-        // Horizontal dividers (between rows)
-        addInteriorHandles(
-          rows,
-          cols,
-          (boundary, col) => [cells[(boundary - 1) * cols + col], cells[boundary * cols + col]],
-          (boundary, start, end) => ({
-            side: 'front' as const,
-            wallSpan: (end - start) * cellW,
-            x: -innerW / 2 + (start + (end - start) / 2) * cellW,
-            y: -innerD / 2 + boundary * cellD,
-            rotateZ: 0,
-          }),
-          cellW
-        );
+        }
       }
     }
   }
@@ -354,7 +313,9 @@ export const handlesFeature: FeatureBuilder = {
         dim.hasLip,
         params.handles.interior
           ? `${params.compartments.cols}x${params.compartments.rows}:${params.compartments.cells.join(',')}`
-          : ''
+          : '',
+        // Tilted dividers move interior handle holes off the grid line (#2276).
+        params.handles.interior ? stableSerialize(params.compartments.dividerOverrides ?? []) : ''
       )
     );
   },

--- a/src/features/generation/worker/generators/handleBuilder.ts
+++ b/src/features/generation/worker/generators/handleBuilder.ts
@@ -239,8 +239,8 @@ function buildHandleHolesInScope(
       const geom = computeHandleHoleGeometry(interiorHeight, globalHeight, verticalPosition);
 
       if (geom.effectiveHeight >= 1) {
-        // Placement honours tilted dividers (dividerOverrides) so handle holes
-        // distribute along the angled wall, not the original grid line (#2276).
+        // Placement honours tilted dividers so handle holes distribute along the
+        // angled wall, not the original grid line.
         for (const seg of interiorDividerSegments(params, innerW, innerD)) {
           const handleW = seg.segLen * (globalWidth / 100);
           const offsets = computeMultiHandleOffsets(count, seg.segLen, handleW);
@@ -314,7 +314,7 @@ export const handlesFeature: FeatureBuilder = {
         params.handles.interior
           ? `${params.compartments.cols}x${params.compartments.rows}:${params.compartments.cells.join(',')}`
           : '',
-        // Tilted dividers move interior handle holes off the grid line (#2276).
+        // Tilted dividers move interior handle holes off the grid line.
         params.handles.interior ? stableSerialize(params.compartments.dividerOverrides ?? []) : ''
       )
     );

--- a/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { computeInteriorDividerCutouts } from './wallCutoutBuilder';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams, DividerOverride } from '@/features/bin-designer/types';
+
+const INNER_W = 80;
+const INNER_D = 40;
+const WALL_HEIGHT = 21;
+
+/** Bin with the interior-divider cutout enabled and a given compartment grid. */
+function makeParams(
+  compartments: Partial<BinParams['compartments']>,
+  overrides?: DividerOverride[]
+): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    walls: {
+      ...DEFAULT_BIN_PARAMS.walls,
+      enabled: true,
+      // Reuse the enabled left-wall cutout shape (width/depth + position) for interior.
+      interior: { ...DEFAULT_BIN_PARAMS.walls.left, enabled: true },
+    },
+    compartments: {
+      ...DEFAULT_BIN_PARAMS.compartments,
+      ...compartments,
+      ...(overrides ? { dividerOverrides: overrides } : {}),
+    },
+  };
+}
+
+describe('computeInteriorDividerCutouts', () => {
+  it('returns nothing when there is only one compartment', () => {
+    const params = makeParams({ cols: 1, rows: 1, cells: [0] });
+    expect(computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
+  });
+
+  it('returns nothing when the interior cutout is disabled', () => {
+    const params = makeParams({ cols: 2, rows: 1, cells: [0, 1] });
+    const disabled: BinParams = {
+      ...params,
+      walls: { ...params.walls, interior: { ...params.walls.interior, enabled: false } },
+    };
+    expect(computeInteriorDividerCutouts(disabled, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
+  });
+
+  it('places a straight vertical divider cutout on the grid line (rotateZ 90)', () => {
+    const params = makeParams({ cols: 2, rows: 1, cells: [0, 1] });
+    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(cuts).toHaveLength(1);
+    expect(cuts[0].x).toBeCloseTo(0, 6); // boundary 1 of 2 → centre
+    expect(cuts[0].rotateZ).toBe(90);
+  });
+
+  it('translates the cutout when the divider is shifted (equal offsets)', () => {
+    const override: DividerOverride = {
+      compartmentA: 0,
+      compartmentB: 1,
+      offsetStart: 5,
+      offsetEnd: 5,
+    };
+    const params = makeParams({ cols: 2, rows: 1, cells: [0, 1] }, [override]);
+    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    // Pure translation: midpoint shifts by the offset, no rotation.
+    expect(cut.x).toBeCloseTo(5, 6);
+    expect(cut.rotateZ).toBeCloseTo(90, 6);
+  });
+
+  it('rotates the cutout to follow a tilted vertical divider', () => {
+    const override: DividerOverride = {
+      compartmentA: 0,
+      compartmentB: 1,
+      offsetStart: 5,
+      offsetEnd: -5,
+    };
+    const params = makeParams({ cols: 2, rows: 1, cells: [0, 1] }, [override]);
+    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    // segLen = 1 cell = INNER_D/1 = 40; dx = offsetEnd - offsetStart = -10.
+    const expected = (Math.atan2(40, -10) * 180) / Math.PI;
+    expect(cut.x).toBeCloseTo(0, 6); // symmetric tilt → midpoint unchanged
+    expect(cut.rotateZ).toBeCloseTo(expected, 4);
+    expect(cut.rotateZ).not.toBe(90); // the regression: it used to stay axis-aligned
+  });
+
+  it('rotates the cutout to follow a tilted horizontal divider', () => {
+    const override: DividerOverride = {
+      compartmentA: 0,
+      compartmentB: 1,
+      offsetStart: 4,
+      offsetEnd: -4,
+    };
+    const params = makeParams({ cols: 1, rows: 2, cells: [0, 1] }, [override]);
+    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    // Horizontal segLen = 1 cell = INNER_W/1 = 80; dy = -8.
+    const expected = (Math.atan2(-8, 80) * 180) / Math.PI;
+    expect(cut.y).toBeCloseTo(0, 6);
+    expect(cut.rotateZ).toBeCloseTo(expected, 4);
+    expect(cut.rotateZ).not.toBe(0); // the regression: it used to stay axis-aligned
+  });
+});

--- a/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
@@ -81,6 +81,37 @@ describe('computeInteriorDividerCutouts', () => {
     expect(cut.rotateZ).not.toBe(90); // the regression: it used to stay axis-aligned
   });
 
+  it('keeps a multi-pair boundary merged into one window when untilted (no regression)', () => {
+    // 2×2 grid: the vertical boundary spans pairs 0|1 and 2|3. With no overrides
+    // these stay merged into a single centered window per boundary (historical
+    // behavior), not one per pair.
+    const params = makeParams({ cols: 2, rows: 2, cells: [0, 1, 2, 3] });
+    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(cuts).toHaveLength(2); // one vertical + one horizontal
+    const vertical = cuts.filter((c) => c.rotateZ === 90);
+    const horizontal = cuts.filter((c) => c.rotateZ === 0);
+    expect(vertical).toHaveLength(1);
+    expect(horizontal).toHaveLength(1);
+    expect(vertical[0].x).toBeCloseTo(0, 6);
+    expect(vertical[0].y).toBeCloseTo(0, 6); // centered across both rows
+  });
+
+  it('splits a multi-pair boundary per pair once a tilt is present', () => {
+    // Tilting only pair 0|1 forces the pair-aware path: the vertical boundary
+    // now yields a tilted window for 0|1 and a straight one for 2|3.
+    const override: DividerOverride = {
+      compartmentA: 0,
+      compartmentB: 1,
+      offsetStart: 5,
+      offsetEnd: -5,
+    };
+    const params = makeParams({ cols: 2, rows: 2, cells: [0, 1, 2, 3] }, [override]);
+    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    expect(cuts).toHaveLength(4); // 2 vertical (per pair) + 2 horizontal (per pair)
+    const tilted = cuts.filter((c) => c.rotateZ !== 90 && c.rotateZ !== 0);
+    expect(tilted).toHaveLength(1); // only the 0|1 segment is angled
+  });
+
   it('rotates the cutout to follow a tilted horizontal divider', () => {
     const override: DividerOverride = {
       compartmentA: 0,

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -20,7 +20,7 @@ import type { Shape3D, Drawing, DisposalScope, ValidSolid } from 'brepjs';
 import type { BinParams, WallCutoutShape } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
 import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
-import { findWallSegments } from './compartmentBuilder';
+import { interiorDividerSegments } from './compartmentBuilder';
 import { resolvePolygonSideGeometry, type PolygonSideGeometry } from './maskPolygonEdges';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
@@ -199,6 +199,48 @@ export function buildWallCutoutCuts(
   });
 }
 
+/** A single interior-divider cutout window, resolved in bin-centered mm. */
+export interface InteriorDividerCutout {
+  /** Cut span along the divider's length. */
+  readonly cutW: number;
+  /** Cut depth (vertical, into the wall from its top). */
+  readonly cutH: number;
+  readonly x: number;
+  readonly y: number;
+  /** In-plane rotation (deg) so the window lies in the (possibly tilted) wall. */
+  readonly rotateZ: number;
+}
+
+/**
+ * Resolve the interior-divider cutout windows for a bin.
+ *
+ * Crucially, this honours `dividerOverrides` (tilted dividers): each window is
+ * translated to the tilted segment's midpoint and rotated to lie IN the wall.
+ * Without this the cutout is carved at the original grid line while the wall is
+ * tilted, so it slices the divider at a slant (GH #2276). Pure + exported so the
+ * geometry can be asserted without a WASM build.
+ */
+export function computeInteriorDividerCutouts(
+  params: BinParams,
+  innerW: number,
+  innerD: number,
+  wallHeight: number
+): InteriorDividerCutout[] {
+  const cfg = params.walls.interior;
+  if (!cfg.enabled || isPartialMask(params.cellMask)) return [];
+  if (cfg.width <= 0 || cfg.depth <= 0) return [];
+
+  const interiorH = wallHeight - params.wallThickness;
+  const out: InteriorDividerCutout[] = [];
+  for (const seg of interiorDividerSegments(params, innerW, innerD)) {
+    const cutW = seg.segLen * (cfg.width / 100);
+    const cutH = interiorH * (cfg.depth / 100);
+    if (cutW < 0.1 || cutH < 0.1) continue;
+    out.push({ cutW, cutH, x: seg.x, y: seg.y, rotateZ: seg.rotateZ });
+  }
+  return out;
+}
+
 function buildWallCutoutCutsInScope(
   scope: DisposalScope,
   params: BinParams,
@@ -284,82 +326,25 @@ function buildWallCutoutCutsInScope(
   // compartmentWallsFeature is filtered out for custom shapes and the
   // corresponding divider walls won't exist. Cutting where there's no
   // material would be wasted boolean work (and risks carving the shell
-  // if a cut crosses it).
-  if (params.walls.interior.enabled && !isPartialMask(params.cellMask)) {
-    const { effectiveWidth, effectiveDepth } = resolveEffective('interior');
-    if (effectiveWidth > 0 && effectiveDepth > 0) {
-      const { cols, rows, cells } = params.compartments;
-      if (cols > 1 || rows > 1) {
-        const cellW = innerW / cols;
-        const cellD = innerD / rows;
-        const interiorH = wallHeight - wallThickness;
-
-        const addDividerCutouts = (
-          boundaryCount: number,
-          segCount: number,
-          getCellIds: (boundary: number, i: number) => [number, number],
-          getPosition: (
-            boundary: number,
-            start: number,
-            end: number
-          ) => { x: number; y: number; rotateZ: number },
-          segCellSize: number
-        ): void => {
-          for (let boundary = 1; boundary < boundaryCount; boundary++) {
-            const segments = findWallSegments(segCount, (i) => {
-              const [id1, id2] = getCellIds(boundary, i);
-              return id1 !== id2;
-            });
-
-            for (const [start, end] of segments) {
-              const segLength = (end - start) * segCellSize;
-              const cutW = segLength * (effectiveWidth / 100);
-              const cutH = interiorH * (effectiveDepth / 100);
-              if (cutW < 0.1 || cutH < 0.1) continue;
-
-              cutShapes.push(
-                buildSingleCutoutInScope(
-                  scope,
-                  cutoutShape,
-                  cutW,
-                  cutH,
-                  overshoot,
-                  extrudeDepth,
-                  wallHeight,
-                  getPosition(boundary, start, end)
-                )
-              );
-            }
-          }
-        };
-
-        // Vertical divider walls (between columns)
-        addDividerCutouts(
-          cols,
-          rows,
-          (boundary, row) => [cells[row * cols + (boundary - 1)], cells[row * cols + boundary]],
-          (boundary, start, end) => ({
-            x: -innerW / 2 + boundary * cellW,
-            y: -innerD / 2 + (start + (end - start) / 2) * cellD,
-            rotateZ: 90,
-          }),
-          cellD
-        );
-
-        // Horizontal divider walls (between rows)
-        addDividerCutouts(
-          rows,
-          cols,
-          (boundary, col) => [cells[(boundary - 1) * cols + col], cells[boundary * cols + col]],
-          (boundary, start, end) => ({
-            x: -innerW / 2 + (start + (end - start) / 2) * cellW,
-            y: -innerD / 2 + boundary * cellD,
-            rotateZ: 0,
-          }),
-          cellW
-        );
-      }
-    }
+  // if a cut crosses it). Placement honours tilted dividers (dividerOverrides)
+  // so the window lands ON the angled wall instead of slicing it at a slant.
+  for (const c of computeInteriorDividerCutouts(params, innerW, innerD, wallHeight)) {
+    cutShapes.push(
+      buildSingleCutoutInScope(
+        scope,
+        cutoutShape,
+        c.cutW,
+        c.cutH,
+        overshoot,
+        extrudeDepth,
+        wallHeight,
+        {
+          x: c.x,
+          y: c.y,
+          rotateZ: c.rotateZ,
+        }
+      )
+    );
   }
 
   // Inline fuse so the fused intermediate is registered in `scope` — the
@@ -398,7 +383,10 @@ export const wallCutoutsFeature: FeatureBuilder = {
         dim.hasLip,
         params.compartments.cols,
         params.compartments.rows,
-        params.compartments.cells.join(',')
+        params.compartments.cells.join(','),
+        // Tilted dividers move interior cutouts off the grid line — without this
+        // a tilt change would reuse the stale grid-aligned cut (GH #2276).
+        stableSerialize(params.compartments.dividerOverrides ?? [])
       )
     );
   },

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -217,8 +217,8 @@ export interface InteriorDividerCutout {
  * Crucially, this honours `dividerOverrides` (tilted dividers): each window is
  * translated to the tilted segment's midpoint and rotated to lie IN the wall.
  * Without this the cutout is carved at the original grid line while the wall is
- * tilted, so it slices the divider at a slant (GH #2276). Pure + exported so the
- * geometry can be asserted without a WASM build.
+ * tilted, so it slices the divider at a slant. Pure + exported so the geometry
+ * can be asserted without a WASM build.
  */
 export function computeInteriorDividerCutouts(
   params: BinParams,
@@ -338,11 +338,7 @@ function buildWallCutoutCutsInScope(
         overshoot,
         extrudeDepth,
         wallHeight,
-        {
-          x: c.x,
-          y: c.y,
-          rotateZ: c.rotateZ,
-        }
+        c
       )
     );
   }
@@ -384,8 +380,8 @@ export const wallCutoutsFeature: FeatureBuilder = {
         params.compartments.cols,
         params.compartments.rows,
         params.compartments.cells.join(','),
-        // Tilted dividers move interior cutouts off the grid line — without this
-        // a tilt change would reuse the stale grid-aligned cut (GH #2276).
+        // Tilted dividers move interior cutouts off the grid line; omitting this
+        // would reuse the stale grid-aligned cut.
         stableSerialize(params.compartments.dividerOverrides ?? [])
       )
     );


### PR DESCRIPTION
Related to #2276, but **not** the fix for that report — see "Scope" below. The actual #2276 fix is #2283.

## The bug
A tilted ("tangent") interior divider wall built with `dividerOverrides`, combined with an **interior** wall cutout (or interior handle holes), is sliced at a slant: the cutout/handle window is positioned at the original **axis-aligned grid line**, ignoring the tilt — so it cuts across the angled wall instead of lying in it. Neither feature's cache key included `dividerOverrides`, so changing a tilt reused the stale grid-aligned cut.

## The fix
Extract one shared, pure helper — `interiorDividerSegments(params, innerW, innerD)` in `compartmentBuilder.ts` — that reuses the same pair-aware run splitting + override lookup the divider walls use, and resolves each segment's **tilted midpoint** and **in-plane rotation**. Both wall cutouts (`wallCutoutBuilder`) and interior handles (`handleBuilder`) now derive their placement from it, so the window/holes land on the angled wall. Added `dividerOverrides` to both cache keys.

This DRYs the tilt math into a single source of truth shared by the wall builder and its two decorators, so they can't drift.

## Tests
- **`wallCutoutBuilder.test.ts`** (new, pure): straight divider → grid line + `rotateZ` 90/0; equal offsets → pure translation; symmetric tilt → midpoint unchanged but `rotateZ` follows the wall (the regression: it used to stay axis-aligned). Vertical + horizontal.
- **`binGenerator.scenario.tilted-dividers.test.ts`** (new cases): tilted divider + interior wall cutout, and + interior handle, both build valid finite geometry.
- Existing tilted-divider / wall-cutout / handle / compartment scenario suites still pass (40 tests).

`tsc -b` clean, ESLint 0 errors.

## Scope (why this does not close #2276)
The #2276 screenshot shows a **straight** divider (parallel to its neighbours, not tilted) whose end is slanted by the **outer-wall** cutout blend ramp — a different code path (`buildRampCut`). This PR only changes behaviour when `dividerOverrides` is set, so it is a no-op for that report. The outer-cutout ramp over-fire is fixed in #2283.