### PR TITLE
fix(generation): only blend divider ends genuinely adjacent to wall cutouts

### DIFF
--- a/src/features/generation/worker/generators/dividerBlendBuilder.test.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.test.ts
@@ -200,16 +200,16 @@ describe('computeRampZones', () => {
     expect(computeRampZones('back', BASE_PARAMS, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
   });
 
-  it('returns ramp zones for adjacent dividers (#1345 note: junction zones handle non-cutout case)', () => {
+  it('returns ramp zones only for dividers genuinely at a cutout edge', () => {
     // 3×1 grid: dividers at ±INNER_W/3 (~±13.6mm).
-    // Narrow cutout (15% width = 12.24mm): edges at ±6.12mm.
-    // Distance from cutout edge to divider1: 13.6 - 6.12 = 7.48mm.
-    // userCutHeight at 80% depth: (21-1.2)*0.8 = 15.84mm > 7.48mm → adjacent!
+    // Wide cutout (30% width = 24.48mm): edges at ±12.24mm.
+    // Gap from cutout edge to nearest divider: 13.6 - 12.24 = 1.36mm — a
+    // sub-wall sliver → the ramp blends the divider end.
     const params = makeParams({
       compartments: { enabled: true, rows: 1, cols: 3, thickness: 1.2, cells: [0, 1, 2] },
       walls: {
         ...BASE_PARAMS.walls,
-        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 15, depth: 80 },
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 30, depth: 80 },
       },
     });
     const zones = computeRampZones('front', params, INNER_W, INNER_D, WALL_HEIGHT);
@@ -223,6 +223,22 @@ describe('computeRampZones', () => {
         })
       );
     }
+  });
+
+  it('does NOT ramp a divider that is clear of the opening (#2276)', () => {
+    // Same 3×1 grid, dividers at ±13.6mm. Narrow cutout (15% = 12.24mm) with
+    // edges at ±6.12mm leaves a 7.48mm gap of clear wall to the nearest
+    // divider. The old code ramped it anyway because 7.48 < userCutHeight
+    // (15.84mm at 80% depth) — a tall cutout slanting a straight divider a
+    // whole compartment away. A tall/narrow cutout must not change this.
+    const params = makeParams({
+      compartments: { enabled: true, rows: 1, cols: 3, thickness: 1.2, cells: [0, 1, 2] },
+      walls: {
+        ...BASE_PARAMS.walls,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 15, depth: 80 },
+      },
+    });
+    expect(computeRampZones('front', params, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
   });
 });
 

--- a/src/features/generation/worker/generators/dividerBlendBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBlendBuilder.ts
@@ -26,6 +26,7 @@ import {
   dividerTouchesWall,
   getWallFaceInfo,
   isPerpendicular,
+  isRampAdjacent,
   type DividerInfo,
   type OuterWallCutoutInfo,
 } from './dividerBlendTypes';
@@ -92,7 +93,7 @@ export function buildDividerBlends(
           const distToLeft = cutout.cutLeft - dividerPos;
           const distToRight = dividerPos - cutout.cutRight;
 
-          if (distToLeft > -halfThick && distToLeft < cutout.userCutHeight) {
+          if (isRampAdjacent(distToLeft, divider.thickness)) {
             try {
               const cut = buildRampCut(divider, cutout, wallHeight);
               if (cut) cuts.push(cut);
@@ -100,7 +101,7 @@ export function buildDividerBlends(
               /* graceful degradation */
             }
           }
-          if (distToRight > -halfThick && distToRight < cutout.userCutHeight) {
+          if (isRampAdjacent(distToRight, divider.thickness)) {
             try {
               const cut = buildRampCut(divider, cutout, wallHeight);
               if (cut) cuts.push(cut);
@@ -194,12 +195,11 @@ export function computeRampZones(
     if (!dividerTouchesWall(divider, wallCutout)) continue;
 
     const dividerPos = divider.posAlongPerp;
-    const halfThick = divider.thickness / 2;
     const distToLeft = wallCutout.cutLeft - dividerPos;
     const distToRight = dividerPos - wallCutout.cutRight;
 
     // Left-adjacent ramp
-    if (distToLeft > -halfThick && distToLeft < wallCutout.userCutHeight) {
+    if (isRampAdjacent(distToLeft, divider.thickness)) {
       const rampLen = Math.min(wallCutout.userCutHeight, (divider.spanEnd - divider.spanStart) / 2);
       if (rampLen >= MIN_DIM) {
         zones.push({
@@ -211,7 +211,7 @@ export function computeRampZones(
     }
 
     // Right-adjacent ramp
-    if (distToRight > -halfThick && distToRight < wallCutout.userCutHeight) {
+    if (isRampAdjacent(distToRight, divider.thickness)) {
       const rampLen = Math.min(wallCutout.userCutHeight, (divider.spanEnd - divider.spanStart) / 2);
       if (rampLen >= MIN_DIM) {
         zones.push({

--- a/src/features/generation/worker/generators/dividerBlendTypes.ts
+++ b/src/features/generation/worker/generators/dividerBlendTypes.ts
@@ -46,6 +46,28 @@ export interface DividerInfo {
 /** Minimum geometry dimension to avoid degenerate shapes (mm). */
 export const MIN_DIM = 0.5;
 
+/**
+ * Whether a perpendicular divider sits close enough to a cutout edge for the
+ * Case 2 blend ramp to apply.
+ *
+ * `distToEdge` is the along-wall distance from the divider centre to the cutout
+ * edge (positive when the divider is OUTSIDE the span). The ramp only smooths a
+ * divider sitting RIGHT at the opening edge — i.e. with at most one wall
+ * thickness of clear wall ("sliver") between the divider face and the cutout.
+ * A divider with more clear wall than that is its own structure and must stay
+ * full height (GH #2276).
+ *
+ * The previous test used `cutout.userCutHeight` — a VERTICAL dimension — as this
+ * horizontal gap, so a tall cutout ramped dividers a whole compartment away,
+ * producing the reported "slant at the end" on a straight divider.
+ */
+export function isRampAdjacent(distToEdge: number, thickness: number): boolean {
+  const halfThick = thickness / 2;
+  // Outside the span, but the remaining wall sliver (distToEdge - halfThick) is
+  // thinner than one wall thickness.
+  return distToEdge > -halfThick && distToEdge < halfThick + thickness;
+}
+
 /** Tolerance for matching divider endpoints to wall face coordinates (mm). */
 export const WALL_TOUCH_TOL = 0.01;
 

--- a/src/features/generation/worker/generators/dividerBlendTypes.ts
+++ b/src/features/generation/worker/generators/dividerBlendTypes.ts
@@ -52,8 +52,8 @@ export const MIN_DIM = 0.5;
  *
  * `distToEdge` is the along-wall distance from the divider centre to the cutout
  * edge (positive when the divider is OUTSIDE the span). The ramp only smooths a
- * divider sitting RIGHT at the opening edge — i.e. with at most one wall
- * thickness of clear wall ("sliver") between the divider face and the cutout.
+ * divider sitting RIGHT at the opening edge — i.e. with strictly less than one
+ * wall thickness of clear wall ("sliver") between the divider face and the cutout.
  * A divider with more clear wall than that is its own structure and must stay
  * full height (GH #2276).
  *


### PR DESCRIPTION
Closes #2276.

## The bug
A user reported a compartment divider that "can't go fully across — slant at the end with the opening" (a straight divider whose end ramps down beside an outer-wall cutout).

**Root cause:** the Case 2 divider–cutout blend (`buildRampCut`) decides whether a *perpendicular* divider is "adjacent" to an outer-wall cutout using `cutout.userCutHeight` — a **vertical** dimension — as the **horizontal** along-wall gap threshold:

```js
if (distToLeft > -halfThick && distToLeft < cutout.userCutHeight) { ramp }
```

So a **tall** cutout ramps dividers that are a large horizontal distance away. In the repro a straight divider **7.48 mm clear** of a 15%-wide / 80%-deep cutout still gets its end slanted, because `7.48 < userCutHeight (15.84 mm)`. The screenshot in #2276 shows exactly this: a divider parallel to its neighbours (not tilted) with a sloped top at the opening.

## The fix
Replace the bogus threshold with a single pure predicate `isRampAdjacent(distToEdge, thickness)` in `dividerBlendTypes.ts`. The ramp now fires only when at most **one wall thickness of clear wall** (a sub-wall "sliver") remains between the divider face and the cutout edge — i.e. the divider genuinely sits at the opening edge. A divider with more clear wall than that stays full height.

Both `buildDividerBlends` (the cut solid) and `computeRampZones` (the hex-pattern clip) call the shared predicate so the cut and the pattern clip can't drift (CLAUDE.md wall-pattern border rule).

The legitimate blend — a divider bounding the edge of a wide cutout — is preserved.

## Tests
- `dividerBlendBuilder.test.ts`: the old test that asserted a 7.48 mm-clear divider gets ramped is replaced by **(a)** a divider genuinely at a wide cutout's edge (1.36 mm gap) still ramps, and **(b)** a divider clear of a tall/narrow cutout does **not** ramp (#2276 regression).
- Verified the full wall-cutout pipeline (`binGenerator.scenario.wallCutouts.test.ts`) and wall-pattern suites still pass; `tsc -b` and ESLint clean.

## Relationship to #2282
#2282 ("align wall cutouts and handles to tilted dividers") fixes a separate bug — interior-cutout/handle alignment on a **tilted** (`dividerOverrides`) divider — and is a no-op for the straight divider in this report. This PR is the actual fix for #2276; #2282's `Closes #2276` should be dropped.