### PR TITLE
fix(bin-designer): paint the lid its zone color in the multi-color preview

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -43,7 +43,9 @@ graph TB
 - `utils/zoneLabels.ts` — ColorZone → i18n key + flat `updateFeatureColors` patch helpers
 - `hooks/useSwapZoneWithToast.ts` — wraps `pickSwapZone` with a localized success toast
 - `components/preview/LidMesh/` — renders the lid mesh in the preview, with explode-aware
-  positioning, opacity interpolation, and mutual hover highlight pairing with `BinMesh`
+  positioning, opacity interpolation, and mutual hover highlight pairing with `BinMesh`. In
+  multi-color mode it paints the lid with its zone color (`featureColors.lid`) to match the
+  exporter, rather than the body color
 - `components/preview/LidGuideLine/` — visual cue connecting bin and lid in exploded views
 - `components/preview/LidExplodeSlider/` — slider that lifts the lid off the bin (replaces view-mode pills)
 - `store/designer.ts` — design state and parameter mutations (composed from slices)

--- a/src/features/bin-designer/components/preview/LidMesh/LidMesh.test.tsx
+++ b/src/features/bin-designer/components/preview/LidMesh/LidMesh.test.tsx
@@ -28,11 +28,15 @@ vi.mock('three', () => {
     setAttribute = vi.fn();
     setIndex = vi.fn();
     computeVertexNormals = vi.fn();
+    clearGroups = vi.fn();
+    addGroup = vi.fn();
     dispose = vi.fn();
   }
   return {
     BufferGeometry: MockBufferGeometry,
+    EdgesGeometry: MockBufferGeometry,
     BufferAttribute: vi.fn(),
+    Float32BufferAttribute: vi.fn(),
     Color: vi.fn(),
     DoubleSide: 'DoubleSide',
     FrontSide: 'FrontSide',
@@ -59,6 +63,54 @@ describe('LidMesh', () => {
   it('renders nothing when no mesh is generated yet (regardless of offset)', () => {
     const { container } = render(<LidMesh color="#cccccc" lidOffsetMm={15} wireframe={false} />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('LidMesh color (#1654)', () => {
+  const tri = {
+    vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    edgeVertices: new Float32Array([0, 0, 0, 1, 0, 0]),
+  };
+
+  function seedLidMesh(): void {
+    useDesignerStore.setState({
+      generation: {
+        status: 'complete',
+        mesh: { ...tri, error: null, timingMs: 1, lidMesh: { ...tri, triangleCount: 1 } },
+        progress: 0,
+        epoch: 0,
+      },
+    });
+  }
+
+  const lidMaterialColor = (container: HTMLElement): string | null | undefined =>
+    container.querySelector('meshStandardMaterial')?.getAttribute('color');
+
+  it('paints the lid with the lid zone color when multi-color is enabled', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        featureColors: { ...DEFAULT_BIN_PARAMS.featureColors, enabled: true, lid: '#ff0000' },
+      },
+    });
+    seedLidMesh();
+    const { container } = render(<LidMesh color="#cccccc" lidOffsetMm={0} wireframe={false} />);
+    // Body fallback ("#cccccc") would be the bug; the lid must follow its zone.
+    expect(lidMaterialColor(container)).toBe('#ff0000');
+  });
+
+  it('falls back to the body color when multi-color is disabled', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        featureColors: { ...DEFAULT_BIN_PARAMS.featureColors, enabled: false, lid: '#ff0000' },
+      },
+    });
+    seedLidMesh();
+    const { container } = render(<LidMesh color="#cccccc" lidOffsetMm={0} wireframe={false} />);
+    expect(lidMaterialColor(container)).toBe('#cccccc');
   });
 });
 

--- a/src/features/bin-designer/components/preview/LidMesh/LidMesh.tsx
+++ b/src/features/bin-designer/components/preview/LidMesh/LidMesh.tsx
@@ -25,6 +25,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { useShallow } from 'zustand/react/shallow';
 import { useMeshGeometry } from '@/shared/components/preview/useMeshGeometry';
 import { LID_FIT_CLEARANCE } from '@/features/bin-designer/types';
+import { getZoneColor } from '@/features/bin-designer/types/featureColors';
 import { binLipTopWorldZ, lidAnchorZ } from './lidAnchorZ';
 
 /** Opacity bands for closed vs exploded views. */
@@ -62,13 +63,15 @@ interface LidMeshProps {
 export function LidMesh({ color, lidOffsetMm, wireframe = false, xray = false }: LidMeshProps) {
   const { invalidate } = useThree();
 
-  const { lidMesh, lidGroupZ } = useDesignerStore(
+  const { lidMesh, lidGroupZ, featureColors } = useDesignerStore(
     useShallow((s) => {
       const { height, heightUnitMm, base } = s.params;
       const lipTopZ = binLipTopWorldZ(height, heightUnitMm, base.stackingLip);
       const anchorZ = lidAnchorZ(heightUnitMm, LID_FIT_CLEARANCE);
       return {
         lidMesh: s.generation.mesh?.lidMesh ?? null,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
+        featureColors: s.params.featureColors ?? null,
         // Mated position: lid local Z = anchorZ aligns with the bin's
         // lip top. The lid group (where local Z=0 lands) is then
         // lipTopZ - anchorZ; anchorZ is negative, so the lid floor sits
@@ -86,10 +89,16 @@ export function LidMesh({ color, lidOffsetMm, wireframe = false, xray = false }:
     edgeVertices: lidMesh?.edgeVertices ?? null,
   });
 
+  // In multi-color mode the lid is a single zone (`featureColors.lid`); the
+  // exporter already paints the whole lid object that color, so the preview
+  // must match instead of falling back to the body material (GH #1654).
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is null-coalesced upstream (legacy persisted configs); runtime guard kept as belt-and-suspenders.
+  const lidColor = featureColors?.enabled ? getZoneColor(featureColors, 'lid') : color;
+
   const baseOpacity = opacityForOffset(lidOffsetMm);
   const matProps = useMemo(
     () => ({
-      color,
+      color: lidColor,
       roughness: 0.45,
       metalness: 0,
       wireframe,
@@ -109,7 +118,7 @@ export function LidMesh({ color, lidOffsetMm, wireframe = false, xray = false }:
       polygonOffsetFactor: 4,
       polygonOffsetUnits: 4,
     }),
-    [color, wireframe, hasPrecomputedNormals, baseOpacity, xray]
+    [lidColor, wireframe, hasPrecomputedNormals, baseOpacity, xray]
   );
 
   // Invalidate the R3F frame when any visual input changes.

--- a/src/features/bin-designer/components/preview/LidMesh/LidMesh.tsx
+++ b/src/features/bin-designer/components/preview/LidMesh/LidMesh.tsx
@@ -51,7 +51,8 @@ function opacityForOffset(offsetMm: number): number {
 }
 
 interface LidMeshProps {
-  /** Base color for the lid (matches bin material). */
+  /** Fallback lid color (the bin's body material), used only when multi-color
+   *  mode is off; in multi-color mode the lid follows `featureColors.lid`. */
   color: string;
   /** Distance the lid is lifted above its mated position, in mm. 0 = closed. */
   lidOffsetMm: number;


### PR DESCRIPTION
Refs #1654.

## The bug
On a multi-color bin, the 3D preview shows the **lid in body color** even when a distinct lid color is set. Reported by @gavinmcfall while testing the multi-color feature ("Lid isn't getting colour").

`LidMesh` rendered the lid with the single body/material `color` prop and never consulted `featureColors` — unlike `BinMesh`, which builds per-zone color groups. Meanwhile the **exporter already paints the lid object `featureColors.lid`** (`uniformColorConfig` in `buildMultiObject3MF`), so the preview and the printed/exported result disagreed.

## The fix
When multi-color is enabled, color the lid with its zone color (`getZoneColor(featureColors, 'lid')`); otherwise keep the existing body-color fallback. The lid is a single color zone (both `LID_BODY` and `LID_RAIL` map to `'lid'`), so a uniform color matches the exporter exactly.

One-file behavior change in `LidMesh.tsx`; no generator or export changes.

## Tests
`LidMesh.test.tsx`: lid uses its zone color (`#ff0000`) when multi-color is enabled, and falls back to the body color (`#cccccc`) when disabled. `tsc -b` and ESLint clean.

## Scope note
This fixes the lid preview color only. The other items in #1654 (label-tab top showing body color, scoop top color on thin walls, lip color uniformity) are separate and not addressed here.