### PR TITLE
fix(generation): keep the label-tab shelf top tagged for multi-color

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -8,4 +8,4 @@ exports[`combined features > 2×2 label tabs with merged compartments 1`] = `438
 
 exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5540`;
 
-exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `17792`;
+exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `17804`;

--- a/src/features/generation/worker/generators/binGenerator.scenario.labelTabColorTag.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.labelTabColorTag.test.ts
@@ -48,7 +48,8 @@ describe('label tab shelf-top color tag (#1654)', () => {
         const zs = [0, 1, 2].map((k) => verts[idx[fg.start + t * 3 + k] * 3 + 2]);
         if (!zs.every((z) => z >= top)) continue;
         if (fg.tag === FeatureTag.LABEL_TAB) labelTop++;
-        else if (fg.tag === 255 || fg.tag === FeatureTag.BASE) bodyTop++;
+        // UNKNOWN (255) and BASE (0) both render as the body color.
+        else if (fg.tag === FeatureTag.UNKNOWN || fg.tag === FeatureTag.BASE) bodyTop++;
       }
     }
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.labelTabColorTag.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.labelTabColorTag.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+/**
+ * Regression for GH #1654: the label-tab shelf-top surface must carry the
+ * LABEL_TAB face tag so multi-color bins paint it the label color rather than
+ * the body color. The shelf top used to be coplanar with the bin wall top; the
+ * fuse merged the two faces and the merged face lost the LABEL_TAB origin. The
+ * fix extrudes the shelf COPLANAR_OVERLAP proud so its top face stays distinct.
+ */
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { FeatureTag } from './featureTags';
+import type { BinParams } from '@/shared/types/bin';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+describe('label tab shelf-top color tag (#1654)', () => {
+  it('tags the shelf top LABEL_TAB, not body', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 2,
+      depth: 1,
+      height: 3,
+      // No stacking lip so the highest faces are the label-tab shelf top.
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+      compartments: { cols: 1, rows: 1, cells: [0], thickness: 1.2 },
+    };
+
+    const m = getGenerateBin()(params);
+    const verts = m.vertices;
+    const idx = m.indices;
+    const fgs = m.faceGroups ?? [];
+    expect(verts.length).toBeGreaterThan(0);
+
+    let zmax = -Infinity;
+    for (let i = 2; i < verts.length; i += 3) if (verts[i] > zmax) zmax = verts[i];
+
+    // The shelf is COPLANAR_OVERLAP (0.01mm) proud of the wall top, so the
+    // absolute-top faces belong only to the shelf.
+    const top = zmax - 0.005;
+    let labelTop = 0;
+    let bodyTop = 0;
+    for (const fg of fgs) {
+      for (let t = 0; t < fg.count / 3; t++) {
+        const zs = [0, 1, 2].map((k) => verts[idx[fg.start + t * 3 + k] * 3 + 2]);
+        if (!zs.every((z) => z >= top)) continue;
+        if (fg.tag === FeatureTag.LABEL_TAB) labelTop++;
+        else if (fg.tag === 255 || fg.tag === FeatureTag.BASE) bodyTop++;
+      }
+    }
+
+    expect(labelTop).toBeGreaterThan(0);
+    expect(bodyTop).toBe(0);
+  }, 90_000);
+});

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -605,11 +605,10 @@ export const labelTabsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        // `v4`: #1898 added `edges` + `inset` to LabelTabConfig. The full
-        // config is already serialized via `stableSerialize(params.label)`,
-        // so the bump is belt-and-suspenders — invalidates any older entry
-        // a returning user might have in IndexedDB.
-        'v4',
+        // `v5`: #1654 extrudes the shelf COPLANAR_OVERLAP proud (geometry +
+        // face tags changed), so older IndexedDB entries must be invalidated.
+        // `v4`: #1898 added `edges` + `inset` to LabelTabConfig.
+        'v5',
         dim.shellKey,
         stableSerialize(params.label),
         quantize(dim.innerW),

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -18,7 +18,7 @@ import {
   clone,
 } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
-import { BOX_CORNER_RADIUS } from './generatorConstants';
+import { BOX_CORNER_RADIUS, COPLANAR_OVERLAP } from './generatorConstants';
 import type { BinParams, TextStyleDefaults, TextStyleOverride } from '@/shared/types/bin';
 import {
   compartmentHasTiltedBackWall,
@@ -424,7 +424,15 @@ function buildTabsAtRow(
       if (!touchesLeft) p = p.customCorner(cornerR);
       return p.close();
     };
-    const shelf = scope.register(sketch(buildOutline(), 'XY', tabHeight - wt).extrude(wt));
+    // Extrude the shelf COPLANAR_OVERLAP proud of its nominal top. When
+    // `shelfTopZ === wallHeight` (the default) the shelf top would otherwise be
+    // coplanar with the bin wall top; OCCT's fuse merges coplanar faces into one
+    // and the merged face loses the LABEL_TAB origin, so the shelf rendered in
+    // body color in multi-color mode (GH #1654). The 0.01mm proud lip is below
+    // slicer resolution but keeps the shelf-top face distinct so its tag survives.
+    const shelf = scope.register(
+      sketch(buildOutline(), 'XY', tabHeight - wt).extrude(wt + COPLANAR_OVERLAP)
+    );
 
     // -- Gussets: 45deg triangular supports under the shelf --
     // Free ends get edge gussets for structural support.


### PR DESCRIPTION
Refs #1654 (1 of the 3 remaining multi-color part-color bugs).

## The bug
On a multi-color bin, the **label tab's shelf top renders in the body color** — changing the label-tab color only recolors the gusset supports underneath. Reported by @gavinmcfall.

**Root cause:** the shelf top face sits exactly at the bin wall top (`Z = wallHeight` by default). OCCT's fuse merges the two **coplanar** faces (shelf top + wall-top ring) into one face with a new identity, and the merged face loses its `LABEL_TAB` origin → falls back to body color. The gusset supports aren't coplanar with anything, so they keep the label color — exactly the reported symptom. (`booleanStage.ts` already carried a TODO noting this label-tab follow-up.)

## The fix
Extrude the shelf `COPLANAR_OVERLAP` (0.01 mm) proud of the wall top so its top face stays a **distinct** face through the fuse and retains the `LABEL_TAB` tag. 0.01 mm is below slicer resolution. This is the same coplanarity-avoidance pattern used elsewhere in the generators.

## Tests
- New scenario regression `binGenerator.scenario.labelTabColorTag.test.ts`: generates a label-enabled bin and asserts the topmost (shelf-top) faces are tagged `LABEL_TAB` with **zero** body faces. Verified it fails on the old geometry and passes with the fix.
- Refreshed one `triangleCount` snapshot (17792 → 17804; +12 tris for the thin proud-shelf perimeter band).
- `tsc -b` + ESLint clean.

## Scope (the other two #1654 bugs)
- **Scoop top body-color**: different mechanism — the ramp↔wall seam faces are *generated* by the boolean and brepjs's `propagateOriginsFromEvolution` assigns generated faces origin 0 (body). The proper fix is in **brepjs** (generated faces should inherit their parent face's origin); not fixable cleanly in this repo.
- **Lip uniformity**: on the exact (OCCT) mesh the lip is correctly tagged/classified. The body-color appearance is the **Manifold draft preview** dropping all face tags (affects every feature transiently), not a lip-specific bug.