### PR TITLE
fix(deps): bump transitive undici to patched 6.27.0/7.28.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@vercel/node>undici': ^7.28.0
-  undici@<6.27.0: ^6.27.0
+  undici@>=6.0.0 <6.27.0: ^6.27.0
   undici@>=7.0.0 <7.28.0: ^7.28.0
   path-to-regexp: 6.3.0
   '@rollup/plugin-replace>magic-string': 0.30.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@vercel/node>undici': ^7.20.0
+  '@vercel/node>undici': ^7.28.0
+  undici@<6.27.0: ^6.27.0
+  undici@>=7.0.0 <7.28.0: ^7.28.0
   path-to-regexp: 6.3.0
   '@rollup/plugin-replace>magic-string': 0.30.21
   '@surma/rollup-plugin-off-main-thread>magic-string': 0.30.21
@@ -5361,16 +5363,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -8062,7 +8060,7 @@ snapshots:
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 6.25.0
+      undici: 6.27.0
 
   '@vercel/build-utils@13.27.1':
     dependencies:
@@ -8114,7 +8112,7 @@ snapshots:
       ts-morph: 12.0.0
       tsx: 4.21.0
       typescript: 5.9.3
-      undici: 7.27.2
+      undici: 7.28.0
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -9563,7 +9561,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -10896,11 +10894,9 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.25.0: {}
+  undici@6.27.0: {}
 
-  undici@7.25.0: {}
-
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,7 +56,7 @@ peerDependencyRules:
 
 overrides:
   '@vercel/node>undici': '^7.28.0'
-  'undici@<6.27.0': '^6.27.0'
+  'undici@>=6.0.0 <6.27.0': '^6.27.0'
   'undici@>=7.0.0 <7.28.0': '^7.28.0'
   path-to-regexp: '6.3.0'
   '@rollup/plugin-replace>magic-string': '0.30.21'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,12 @@ minimumReleaseAgeExclude:
   # TODO: remove once the resolved dompurify version has aged past the window
   # (3.4.11 published 2026-06-17 -> 2026-06-24).
   - dompurify
+  # undici 7.28.0 / 6.27.0 (2026-06-15) are the first versions patched against
+  # the SOCKS5 TLS-bypass + cross-origin routing (GHSA-vmh5-mc38-953g,
+  # GHSA-hm92-r4w5-c3mj, GHSA-vxpw-j846-p89q) and Set-Cookie injection cluster;
+  # allow them through before the 7-day window elapses.
+  # TODO: remove after 2026-06-22 once both have aged past the window.
+  - undici
 
 # Blocks Shai-Hulud-class worms that spread via npm lifecycle scripts.
 # Packages that need to build are listed in allowBuilds.
@@ -49,7 +55,9 @@ peerDependencyRules:
     vite-plugin-pwa>vite: '^8.0.0'
 
 overrides:
-  '@vercel/node>undici': '^7.20.0'
+  '@vercel/node>undici': '^7.28.0'
+  'undici@<6.27.0': '^6.27.0'
+  'undici@>=7.0.0 <7.28.0': '^7.28.0'
   path-to-regexp: '6.3.0'
   '@rollup/plugin-replace>magic-string': '0.30.21'
   '@surma/rollup-plugin-off-main-thread>magic-string': '0.30.21'


### PR DESCRIPTION
## What

Bumps all three vulnerable transitive `undici` copies to their patched floors, clearing **10 Dependabot alerts** and **18 osv-scanner code-scanning alerts** — every open security alert on the repo. All 28 trace to the same root cause.

| Dependent | Was | Now | Patch line |
|---|---|---|---|
| `@vercel/blob` (runtime) | 6.25.0 | **6.27.0** | ≥6.27.0 |
| `@vercel/node` (build) | 7.27.2 | **7.28.0** | ≥7.28.0 |
| `jsdom` (test env) | 7.25.0 | **7.28.0** | ≥7.28.0 |

## CVEs cleared

- **High:** SOCKS5 TLS-cert-validation bypass + cross-origin routing via proxy pool reuse (GHSA-vmh5-mc38-953g, GHSA-hm92-r4w5-c3mj, GHSA-vxpw-j846-p89q), WebSocket fragment-count DoS
- **Moderate:** shared-cache whitespace bypass, Set-Cookie percent-decoding header injection
- **Low:** keep-alive response-queue poisoning, Set-Cookie SameSite downgrade

## How

- Version-range overrides bump **each major line to its own patch floor** (`undici@<6.27.0` → `^6.27.0`, `undici@>=7.0.0 <7.28.0` → `^7.28.0`) — no forced major-version jump.
- Keeps the maintainer's deliberate `@vercel/node` v7 pin, raised from `^7.20.0` to `^7.28.0`. (Removing it silently reverts `@vercel/node` to its native v6 range, so the scoped override stays.)
- undici 7.28.0/6.27.0 published 2026-06-15 — inside the 7-day `minimumReleaseAge` cooldown — so `undici` is added to `minimumReleaseAgeExclude` with a dated TODO (remove after 2026-06-22), matching the esbuild/dompurify precedent.

## Verification

- `pnpm install` regenerates the lockfile; supply-chain policy check passes.
- All three dependents confirmed resolving to patched versions in `pnpm-lock.yaml`.
- `pnpm run typecheck` clean.