### PR TITLE
fix(bin-designer): stop color-zones toggle from jumping the page to the bottom

### DIFF
--- a/src/features/bin-designer/components/DesignerPage/DesignerPage.test.tsx
+++ b/src/features/bin-designer/components/DesignerPage/DesignerPage.test.tsx
@@ -94,6 +94,15 @@ describe('DesignerPage', () => {
     expect(screen.getByTestId('preview-canvas')).toBeInTheDocument();
   });
 
+  it('caps the page at viewport height so only the inner panel scrolls', () => {
+    // Without overflow-hidden on the h-screen root, content bleeds past the
+    // viewport and the whole document scrolls instead of the parameter panel.
+    const { container } = render(<DesignerPage />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toContain('h-screen');
+    expect(root.className).toContain('overflow-hidden');
+  });
+
   it('renders header support links on desktop', () => {
     render(<DesignerPage />);
     expect(screen.getByTestId('header-support-links')).toBeInTheDocument();

--- a/src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
@@ -74,7 +74,7 @@ export function DesignerPage() {
   const shareLoading = useShareLoading();
 
   return (
-    <div className="flex h-screen flex-col bg-surface">
+    <div className="flex h-screen flex-col overflow-hidden bg-surface">
       {/* Mobile title bar */}
       {!isDesktop && <MobileTitleBar />}
 

--- a/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.test.tsx
@@ -59,6 +59,21 @@ describe('LipColorEditor', () => {
     ).toBeDefined();
   });
 
+  it('toggles the split by clicking the visible label text (no nested label)', () => {
+    // The Checkbox renders its own <label htmlFor>. Wrapping it in a second
+    // <label> nested two labels, making the visually-hidden input the labeled
+    // control — clicking it scrolled the panel to its bottom. Clicking the
+    // visible text must route through a single label and reveal the grid.
+    renderEditor({ lip: lip(1, 1) });
+    expect(
+      screen.queryByRole('radiogroup', { name: 'binDesigner.colors.lip.cornersLabel' })
+    ).toBeNull();
+    fireEvent.click(screen.getByText('binDesigner.colors.lip.splitZones'));
+    expect(
+      screen.getByRole('radiogroup', { name: 'binDesigner.colors.lip.cornersLabel' })
+    ).toBeDefined();
+  });
+
   it('auto-shows the grid for a design that already has multiple zones', () => {
     renderEditor({ lip: lip(2, 2) });
     // No opt-in needed — controls render and the toggle reads as enabled.

--- a/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.tsx
@@ -161,14 +161,16 @@ export function LipColorEditor({
         })}
       </div>
 
-      <label className="flex w-fit items-center gap-2 text-[11px] text-content-secondary">
-        <Checkbox
-          checked={showGrid}
-          onChange={handleToggleSplit}
-          aria-label={t('binDesigner.colors.lip.splitZones')}
-        />
-        {t('binDesigner.colors.lip.splitZones')}
-      </label>
+      {/* Checkbox supplies its own <label htmlFor>; wrapping it in another
+          <label> nests labels and makes the visually-hidden input the labeled
+          control, which scrolls the panel to its bottom on click. */}
+      <Checkbox
+        size="sm"
+        className="w-fit"
+        checked={showGrid}
+        onChange={handleToggleSplit}
+        label={t('binDesigner.colors.lip.splitZones')}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Why

Two bin-designer UI regressions surfaced while @gavinmcfall was testing the new stacking-lip color zones on #1654:

1. **Ticking "Split into color zones" throws the viewport to the bottom of the page** into a broken layout (both Firefox and Chrome).
2. **The whole page scrolls vertically** — the header and left panel don't stay pinned.

## Root causes & fixes

### 1. Color-zones toggle jump (regression from #2294)
`LipColorEditor` wrapped the design-system `<Checkbox>` in a plain `<label>`. But `Checkbox` already renders its **own** `<label htmlFor>` + a visually-hidden `sr-only` `<input>`. That nested two labels, making the hidden (absolutely-positioned) input the labeled control. Clicking it focused that input, whose containing block resolves to the canvas `<div>` *outside* the panel — so the browser scrolled the parameter panel to its maximum bottom trying to reveal it.

Fix: pass the text via the Checkbox `label` prop (single label, correct association). This is the **same nested-label pattern already fixed for the Corners/Bands segments in #2294** — the checkbox added in the final commit missed it.

### 2. Full-page scroll
`DesignerPage`'s root container used `h-screen flex flex-col` **without `overflow-hidden`**, so content bled past the viewport and the document scrolled instead of the inner parameter panel. Every other full-page layout in the app caps height with `overflow-hidden`. Adding it pins the header + left panel and confines scrolling to the panel — exactly what was requested.

## Tests
- `LipColorEditor.test.tsx`: new test clicks the **visible label text** and asserts the grid reveals — proving single-label association (the thing the nested label broke).
- `DesignerPage.test.tsx`: new test asserts the root caps height with `overflow-hidden`.
- Full suite green (13,982 passing), typecheck + lint clean.

## Not included
The finger-scoop "vertical triangles" also reported on #1654 is a separate, pre-existing **draft-preview-only** tessellation artifact (un-simplified Manifold fuse leaving T-junctions that `creaseEdges` renders as naked edges). It predates #2294, doesn't affect the exported STL, and needs a riskier generator change — tracked separately.

Refs #1654