### PR TITLE
feat(baseplate): smarter split — optimize for fewest build-plate loads

### DIFF
--- a/src/features/baseplate/README.md
+++ b/src/features/baseplate/README.md
@@ -29,7 +29,9 @@ graph TB
 - `store/baseplatePageStore.ts` — ephemeral UI state (generation status, tiling, piece selection)
 - `components/BaseplatePanel/StackPrintSection.tsx` — "Stack for printing" panel section
 - `components/BaseplatePreview/StackedBaseplateMeshes.tsx` + `StackSeparationSlider.tsx` — flipped-tower preview + explode slider
-- `utils/splitPlanner.ts` — 2D optimal tiling: partitions grid into print-bed-sized pieces
+- `utils/splitPlanner.ts` — 2D optimal tiling: partitions grid into print-bed-sized pieces, minimizing **build-plate loads** (see Key Concepts)
+- `utils/bedPacking.ts` — `estimateBedLoads`: shelf First-Fit-Decreasing bin-packer (90° rotation) estimating how many bed loads a set of pieces needs
+- `utils/splitReorder.ts` — display reordering of chunk sizes (largest-first, fractional pinning, palindromic layout) — split out of the planner to keep it focused on the search
 - `utils/buildFullParams.ts` — resolves sync mode (drawer dims vs custom width/depth); strips connectors, magnet holes, and corner rounding when stack printing is on
 - `utils/stackPrint.ts` — stack planning (groups → capped physical stacks) + `buildTowerLayers` (bottom plate upright, the rest flipped, all XY-aligned)
 - `utils/stackExport.ts` — bakes a stack into export triangle soup (single material)
@@ -40,7 +42,7 @@ graph TB
 ## Key Concepts
 
 - **Sync mode**: `syncWithLayout: true` reads drawer dims from layout store; `false` uses custom grid size
-- **Split tiling**: baseplates exceeding print bed are partitioned into labeled pieces (A1, B2, etc.)
+- **Split tiling**: baseplates exceeding print bed are partitioned into labeled pieces (A1, B2, etc.). The planner optimizes for the **fewest build-plate loads** (print jobs), not the fewest pieces: it scores each candidate grid `MAX_EXTRA_PIECES_PER_BED_LOAD * bedLoads + pieceCount` (`bedLoads` from `estimateBedLoads`'s shelf packing), so it will choose a finer split that packs more pieces per bed when that removes a load — but the per-load piece budget (`MAX_EXTRA_PIECES_PER_BED_LOAD`, currently 4) caps the trade so it won't fragment into tiny tiles. The packing-aware refinement only runs for small splits (`coarse.pieceCount <= PACKING_SEARCH_MAX_PIECES`); larger plates keep the fast min-piece tiling (their big pieces already tile beds tightly). `tiling.bedLoads` is surfaced in the panel ("Prints in N build-plate loads")
 - **Two-phase preview**: direct-mesh (procedural, no WASM) renders immediately on every params change; BREP (high-fidelity) silently swaps in once ready. `MeshResult.source` records which path produced the visible mesh. With the graduated `manifold_preview` path (always on), the draft phase instead runs the real `generateBaseplate` on the Manifold kernel at draft quality (`runManifoldDraftPreview`) — more faithful than the procedural approximation — falling back to direct-mesh if the preview bridge is unavailable. A `finalizedEpochRef` guards the now-async draft so a late draft can't overwrite a fresher BREP result
 - **Graceful BREP failure**: if BREP errors after a direct-mesh preview is on screen, the preview stays visible and a non-blocking toast surfaces the failure — avoids the red error overlay swallowing a still-usable canvas
 - **Epoch detection**: rapid param changes bump an epoch counter; stale in-flight results (direct or BREP) are discarded

--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -319,10 +319,13 @@ export function BaseplatePage() {
         splitBanner={
           showSplitBanner
             ? {
-                message: t('baseplate.export.splitBanner', {
+                message: `${t('baseplate.export.splitBanner', {
                   size: defaultPrintBedSize,
                   count: tiling.pieces.length,
-                }),
+                })} ${t(
+                  tiling.bedLoads === 1 ? 'baseplate.bedLoads.one' : 'baseplate.bedLoads.other',
+                  { count: tiling.bedLoads }
+                )}`,
                 checkboxLabel: t('baseplate.export.enableSplit'),
                 checked: splitEnabled,
                 onCheckedChange: setSplitEnabled,

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -122,6 +122,7 @@ const splitTiling: BaseplateTiling = {
   totalDepthUnits: 6,
   stackCount: 1,
   stackSeparatorThickness: 0,
+  bedLoads: 1,
 };
 
 describe('BaseplatePanel', () => {

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.test.tsx
@@ -47,6 +47,7 @@ const baseTiling: BaseplateTiling = {
   totalDepthUnits: 6,
   stackCount: 1,
   stackSeparatorThickness: 0,
+  bedLoads: 1,
 };
 
 describe('SplitViewStrip', () => {
@@ -63,6 +64,16 @@ describe('SplitViewStrip', () => {
     render(<SplitViewStrip {...defaultProps} />);
     expect(screen.getByText('baseplate.splitInfo')).toBeInTheDocument();
     expect(screen.getByText('baseplate.splitReason')).toBeInTheDocument();
+  });
+
+  it('renders the build-plate load count (singular at 1)', () => {
+    render(<SplitViewStrip {...defaultProps} />);
+    expect(screen.getByText('baseplate.bedLoads.one')).toBeInTheDocument();
+  });
+
+  it('renders the build-plate load count (plural above 1)', () => {
+    render(<SplitViewStrip {...defaultProps} tiling={{ ...baseTiling, bedLoads: 3 }} />);
+    expect(screen.getByText('baseplate.bedLoads.other')).toBeInTheDocument();
   });
 
   it('renders one button per piece', () => {

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
@@ -44,6 +44,14 @@ export function SplitViewStrip({
         </span>
       </div>
 
+      <div className="px-4 pb-1">
+        <span className="text-[11px] text-content-secondary">
+          {t(tiling.bedLoads === 1 ? 'baseplate.bedLoads.one' : 'baseplate.bedLoads.other', {
+            count: tiling.bedLoads,
+          })}
+        </span>
+      </div>
+
       {tiling.paddingReductionHint && (
         <div className="mx-4 mb-2 rounded bg-accent/10 px-2.5 py-1.5 text-[11px] text-accent">
           {t('baseplate.paddingHint', {

--- a/src/features/baseplate/hooks/useStackPrintStatus.test.ts
+++ b/src/features/baseplate/hooks/useStackPrintStatus.test.ts
@@ -40,6 +40,7 @@ function tiling(pieces: BaseplatePiece[]): BaseplateTiling {
     totalDepthUnits: 2,
     stackCount: 1,
     stackSeparatorThickness: 0,
+    bedLoads: 1,
     paddingReductionHint: null,
   };
 }

--- a/src/features/baseplate/store/baseplatePageStore.test.ts
+++ b/src/features/baseplate/store/baseplatePageStore.test.ts
@@ -172,6 +172,7 @@ describe('baseplatePageStore', () => {
       totalDepthUnits: 8,
       stackCount: 1,
       stackSeparatorThickness: 0,
+      bedLoads: 1,
       paddingReductionHint: null,
     };
 
@@ -347,6 +348,7 @@ describe('baseplatePageStore', () => {
         totalDepthUnits: 8,
         stackCount: 1,
         stackSeparatorThickness: 0,
+        bedLoads: 1,
         paddingReductionHint: null,
       });
 

--- a/src/features/baseplate/types/tiling.ts
+++ b/src/features/baseplate/types/tiling.ts
@@ -62,6 +62,12 @@ export interface BaseplateTiling {
   readonly rows: number;
   readonly totalWidthUnits: number;
   readonly totalDepthUnits: number;
+  /**
+   * Estimated build-plate loads (print jobs) to make every piece, packing as
+   * many as fit per bed. 1 for an unsplit plate. The planner minimizes this
+   * (capped against over-fragmentation) so users print in the fewest bed swaps.
+   */
+  readonly bedLoads: number;
   /** Future: number of vertical stacks (default 1) */
   readonly stackCount: number;
   /** Future: separator thickness between stacks in mm (default 0) */

--- a/src/features/baseplate/utils/bedPacking.test.ts
+++ b/src/features/baseplate/utils/bedPacking.test.ts
@@ -59,6 +59,17 @@ describe('estimateBedLoads', () => {
     expect(estimateBedLoads(pieces, BED, BED)).toBe(2);
   });
 
+  it('an oversize piece claims its own bed and does not absorb later small pieces', () => {
+    // The oversize piece must not leave a reusable empty bed: it gets bed 1
+    // alone, and the two quarter-bed pieces share bed 2.
+    const pieces: Footprint[] = [
+      { w: 300, d: 300 },
+      { w: 120, d: 120 },
+      { w: 120, d: 120 },
+    ];
+    expect(estimateBedLoads(pieces, BED, BED)).toBe(2);
+  });
+
   it('packs a 2×2 grid of quarter-bed pieces onto one bed', () => {
     const q: Footprint = { w: 120, d: 120 };
     expect(estimateBedLoads([q, q, q, q], BED, BED)).toBe(1);

--- a/src/features/baseplate/utils/bedPacking.test.ts
+++ b/src/features/baseplate/utils/bedPacking.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { estimateBedLoads, type Footprint } from './bedPacking';
+
+const BED = 256;
+
+describe('estimateBedLoads', () => {
+  it('returns 0 for no pieces', () => {
+    expect(estimateBedLoads([], BED, BED)).toBe(0);
+  });
+
+  it('returns 1 for a single piece that fits the bed', () => {
+    expect(estimateBedLoads([{ w: 200, d: 200 }], BED, BED)).toBe(1);
+  });
+
+  it('packs two half-width, full-height pieces onto one bed', () => {
+    const pieces: Footprint[] = [
+      { w: 120, d: 250 },
+      { w: 120, d: 250 },
+    ];
+    expect(estimateBedLoads(pieces, BED, BED)).toBe(1);
+  });
+
+  it('packs two full-width, half-height pieces onto one bed (stacked shelves)', () => {
+    const pieces: Footprint[] = [
+      { w: 250, d: 120 },
+      { w: 250, d: 120 },
+    ];
+    expect(estimateBedLoads(pieces, BED, BED)).toBe(1);
+  });
+
+  it('uses rotation to pack a wide and a tall piece together', () => {
+    // A 250×120 and a 120×250 both occupy the same footprint rotated; two of
+    // them stack as two 250×120 shelves (240 ≤ 256 depth) on one bed.
+    const pieces: Footprint[] = [
+      { w: 250, d: 120 },
+      { w: 120, d: 250 },
+    ];
+    expect(estimateBedLoads(pieces, BED, BED)).toBe(1);
+  });
+
+  it('needs one bed per piece when pieces are too big to pair', () => {
+    // 140×140 squares can't pair (2×140 = 280 > 256 in either axis) → 1 per bed.
+    const sq: Footprint = { w: 140, d: 140 };
+    expect(estimateBedLoads([sq, sq, sq], BED, BED)).toBe(3);
+  });
+
+  it('opens a second bed only once one is full', () => {
+    // 120×120 packs 2 per shelf × 2 shelves = 4 per bed; the 5th opens bed two.
+    const q: Footprint = { w: 120, d: 120 };
+    expect(estimateBedLoads([q, q, q, q], BED, BED)).toBe(1);
+    expect(estimateBedLoads([q, q, q, q, q], BED, BED)).toBe(2);
+  });
+
+  it('gives each oversize piece its own bed (stays total)', () => {
+    const pieces: Footprint[] = [
+      { w: 300, d: 300 },
+      { w: 300, d: 300 },
+    ];
+    expect(estimateBedLoads(pieces, BED, BED)).toBe(2);
+  });
+
+  it('packs a 2×2 grid of quarter-bed pieces onto one bed', () => {
+    const q: Footprint = { w: 120, d: 120 };
+    expect(estimateBedLoads([q, q, q, q], BED, BED)).toBe(1);
+  });
+
+  it('respects a non-square bed', () => {
+    // Bed 256×128: two 120×120 fit side by side on one shelf (240≤256) within
+    // the 128 depth → 1 bed; add a third → second bed.
+    const q: Footprint = { w: 120, d: 120 };
+    expect(estimateBedLoads([q, q], 256, 128)).toBe(1);
+    expect(estimateBedLoads([q, q, q], 256, 128)).toBe(2);
+  });
+});

--- a/src/features/baseplate/utils/bedPacking.ts
+++ b/src/features/baseplate/utils/bedPacking.ts
@@ -1,0 +1,102 @@
+/**
+ * Estimate how many build-plate loads (print jobs) a set of pieces needs.
+ *
+ * Pieces are packed onto bed-sized bins with a deterministic shelf
+ * First-Fit-Decreasing heuristic: sort by longest side, lay each piece on the
+ * first horizontal shelf (across any open bin) where it fits in either
+ * orientation, else start a new shelf, else open a new bed. Each piece may be
+ * rotated 90° (slicers allow it). The split planner only needs relative
+ * accuracy to compare candidate tilings, so an exact 2D bin-packer is overkill;
+ * grid pieces are uniform enough that shelf packing tracks the real count well.
+ */
+
+/** A piece footprint on the bed, in mm (orientation-agnostic). */
+export interface Footprint {
+  readonly w: number;
+  readonly d: number;
+}
+
+const EPS = 1e-6;
+
+interface Shelf {
+  /** Shelf height (mm) — the depth budget this shelf consumes in its bin. */
+  height: number;
+  /** Width already consumed along the bed (mm). */
+  usedW: number;
+}
+
+interface Bin {
+  shelves: Shelf[];
+  /** Total shelf height stacked so far (mm). */
+  usedD: number;
+}
+
+/** Try to seat one piece in a bin; returns true if placed. Mutates `bin`. */
+function placeInBin(
+  bin: Bin,
+  longSide: number,
+  shortSide: number,
+  bedW: number,
+  bedD: number
+): boolean {
+  // Existing shelves: fit if some orientation's height ≤ shelf height and
+  // width ≤ remaining bed width.
+  for (const shelf of bin.shelves) {
+    for (const [w, h] of [
+      [longSide, shortSide],
+      [shortSide, longSide],
+    ] as const) {
+      if (h <= shelf.height + EPS && w <= bedW - shelf.usedW + EPS) {
+        shelf.usedW += w;
+        return true;
+      }
+    }
+  }
+
+  // New shelf: pick the orientation with the smaller height (saves vertical
+  // budget) among those whose width fits the bed; the shelf must fit the
+  // remaining bed depth.
+  let best: { w: number; h: number } | null = null;
+  for (const [w, h] of [
+    [longSide, shortSide],
+    [shortSide, longSide],
+  ] as const) {
+    if (w <= bedW + EPS && (best === null || h < best.h)) best = { w, h };
+  }
+  if (best && bin.usedD + best.h <= bedD + EPS) {
+    bin.shelves.push({ height: best.h, usedW: best.w });
+    bin.usedD += best.h;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Number of bed loads needed to print `pieces`, packing as many as fit per bed.
+ * A piece that fits no orientation of an empty bed still gets its own bed (the
+ * planner's fit check prevents that upstream, but we stay total here).
+ */
+export function estimateBedLoads(pieces: readonly Footprint[], bedW: number, bedD: number): number {
+  const items = pieces
+    .filter((p) => p.w > EPS && p.d > EPS)
+    .map((p) => ({ long: Math.max(p.w, p.d), short: Math.min(p.w, p.d) }))
+    .sort((a, b) => b.long - a.long || b.short - a.short);
+  if (items.length === 0) return 0;
+
+  const bins: Bin[] = [];
+  for (const it of items) {
+    let placed = false;
+    for (const bin of bins) {
+      if (placeInBin(bin, it.long, it.short, bedW, bedD)) {
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      const bin: Bin = { shelves: [], usedD: 0 };
+      placeInBin(bin, it.long, it.short, bedW, bedD);
+      bins.push(bin);
+    }
+  }
+  return bins.length;
+}

--- a/src/features/baseplate/utils/bedPacking.ts
+++ b/src/features/baseplate/utils/bedPacking.ts
@@ -39,13 +39,16 @@ function placeInBin(
   bedW: number,
   bedD: number
 ): boolean {
-  // Existing shelves: fit if some orientation's height ≤ shelf height and
-  // width ≤ remaining bed width.
+  // Rotation is allowed per orientation (slicers can rotate parts), so this is
+  // more permissive than the planner's natural-orientation fit check — it only
+  // ever improves packing density, never invalidates a load count.
+  const orientations = [
+    { w: longSide, h: shortSide },
+    { w: shortSide, h: longSide },
+  ] as const;
+
   for (const shelf of bin.shelves) {
-    for (const [w, h] of [
-      [longSide, shortSide],
-      [shortSide, longSide],
-    ] as const) {
+    for (const { w, h } of orientations) {
       if (h <= shelf.height + EPS && w <= bedW - shelf.usedW + EPS) {
         shelf.usedW += w;
         return true;
@@ -53,14 +56,10 @@ function placeInBin(
     }
   }
 
-  // New shelf: pick the orientation with the smaller height (saves vertical
-  // budget) among those whose width fits the bed; the shelf must fit the
-  // remaining bed depth.
+  // New shelf: the smaller-height orientation that fits the bed width saves
+  // vertical budget; the shelf must fit the remaining bed depth.
   let best: { w: number; h: number } | null = null;
-  for (const [w, h] of [
-    [longSide, shortSide],
-    [shortSide, longSide],
-  ] as const) {
+  for (const { w, h } of orientations) {
     if (w <= bedW + EPS && (best === null || h < best.h)) best = { w, h };
   }
   if (best && bin.usedD + best.h <= bedD + EPS) {
@@ -73,8 +72,9 @@ function placeInBin(
 
 /**
  * Number of bed loads needed to print `pieces`, packing as many as fit per bed.
- * A piece that fits no orientation of an empty bed still gets its own bed (the
- * planner's fit check prevents that upstream, but we stay total here).
+ * A piece that fits no orientation of an empty bed still gets its own (full)
+ * bed — the planner's fit check prevents that upstream, but the count stays
+ * total for any caller.
  */
 export function estimateBedLoads(pieces: readonly Footprint[], bedW: number, bedD: number): number {
   const items = pieces
@@ -94,7 +94,11 @@ export function estimateBedLoads(pieces: readonly Footprint[], bedW: number, bed
     }
     if (!placed) {
       const bin: Bin = { shelves: [], usedD: 0 };
-      placeInBin(bin, it.long, it.short, bedW, bedD);
+      if (!placeInBin(bin, it.long, it.short, bedW, bedD)) {
+        // Oversize piece — claim the whole bed so no later piece reuses it.
+        bin.shelves.push({ height: bedD, usedW: bedW });
+        bin.usedD = bedD;
+      }
       bins.push(bin);
     }
   }

--- a/src/features/baseplate/utils/pieceFingerprint.test.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.test.ts
@@ -285,11 +285,11 @@ describe('groupPiecesByFingerprint', () => {
   // ─── preferIdenticalPieces canonicalization (#1640) ──────────────────────
 
   it('collapses opposite-corner pieces into a single group under the flag', () => {
-    // 10×8 → 2×2 grid. Without canonicalization there are 4 distinct edge
+    // 10×10 → 2×2 grid. Without canonicalization there are 4 distinct edge
     // layouts (one per corner). With the flag, A1≡C2 and A2≡C1 → 2 groups.
     const params = makeParams({
       width: 10,
-      depth: 8,
+      depth: 10,
       connectorNubs: true,
       preferIdenticalPieces: true,
     });
@@ -306,7 +306,7 @@ describe('groupPiecesByFingerprint', () => {
   });
 
   it('keeps the 4-corner pieces distinct when the flag is off (baseline)', () => {
-    const params = makeParams({ width: 10, depth: 8, preferIdenticalPieces: false });
+    const params = makeParams({ width: 10, depth: 10, preferIdenticalPieces: false });
     const tiling = computeBaseplateTiling(params, 256);
     const groups = groupPiecesByFingerprint(tiling.pieces, params);
     expect(groups.size).toBe(4);
@@ -344,7 +344,7 @@ describe('groupPiecesByFingerprint', () => {
     // at one of the world corners.)
     const params = makeParams({
       width: 10,
-      depth: 8,
+      depth: 10,
       connectorNubs: true,
       preferIdenticalPieces: true,
       cornerRadii: { tl: 1, tr: 2, bl: 3, br: 4 },
@@ -360,7 +360,7 @@ describe('groupPiecesByFingerprint', () => {
     // meshes are genuine rotations of each other and dedup correctly.
     const params = makeParams({
       width: 10,
-      depth: 8,
+      depth: 10,
       connectorNubs: true,
       preferIdenticalPieces: true,
       cornerRadii: { tl: 1, tr: 2, bl: 2, br: 1 },

--- a/src/features/baseplate/utils/pieceFingerprint.test.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.test.ts
@@ -285,8 +285,10 @@ describe('groupPiecesByFingerprint', () => {
   // ─── preferIdenticalPieces canonicalization (#1640) ──────────────────────
 
   it('collapses opposite-corner pieces into a single group under the flag', () => {
-    // 10×10 → 2×2 grid. Without canonicalization there are 4 distinct edge
-    // layouts (one per corner). With the flag, A1≡C2 and A2≡C1 → 2 groups.
+    // 10×10 → 2×2 grid (its 2×3 alternative saves no bed load, so the
+    // packing-aware planner keeps 2×2 — see splitPlanner.test). Without
+    // canonicalization there are 4 distinct edge layouts (one per corner). With
+    // the flag, A1≡C2 and A2≡C1 → 2 groups.
     const params = makeParams({
       width: 10,
       depth: 10,

--- a/src/features/baseplate/utils/printGuide.test.ts
+++ b/src/features/baseplate/utils/printGuide.test.ts
@@ -110,6 +110,8 @@ describe('generatePrintGuide', () => {
 
     // Should show "X (Y unique)" format
     expect(guide).toMatch(/Total pieces: \d+\s+\(\d+ unique\)/);
+    // ...and the build-plate load count.
+    expect(guide).toMatch(/Build-plate loads: \d+/);
   });
 
   it('lists padding details for padded pieces', () => {

--- a/src/features/baseplate/utils/printGuide.ts
+++ b/src/features/baseplate/utils/printGuide.ts
@@ -239,6 +239,7 @@ function generateHeader(
     `  Grid unit:    ${params.gridUnitMm}mm`,
     `  Features:     ${featureStr}`,
     `  Total pieces: ${totalPieces}${totalPieces > 1 ? ` (${uniqueCount} unique)` : ''}`,
+    `  Build-plate loads: ${tiling.bedLoads}`,
   ];
 
   // Surface the connector fit offset whenever connectors are on and the user

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -155,10 +155,12 @@ describe('computeBaseplateTiling', () => {
 
   // ─── Both-axis splits ──────────────────────────────────────────────────
 
-  it('both-axis split (10x8)', () => {
+  it('both-axis split (10x10)', () => {
+    // 10×10 stays a clean 2×2: its 2×3 alternative's pieces are too deep to pair
+    // on the bed, so the packing-aware planner gains no load and keeps 2×2.
     const params = makeParams({
       width: 10,
-      depth: 8,
+      depth: 10,
       paddingLeft: 2,
       paddingRight: 3,
       paddingFront: 4,
@@ -191,6 +193,33 @@ describe('computeBaseplateTiling', () => {
     expect(b2.paddingRight).toBe(3);
     expect(b2.paddingFront).toBe(0);
     expect(b2.paddingBack).toBe(5);
+  });
+
+  // ─── Packing-aware split (build-plate loads) ────────────────────────────
+
+  it('reports bedLoads = 1 for a single (unsplit) plate', () => {
+    const tiling = computeBaseplateTiling(makeParams({ width: 4, depth: 4 }), 256);
+    expect(tiling.isSplit).toBe(false);
+    expect(tiling.bedLoads).toBe(1);
+  });
+
+  it('chooses a finer split to save a build-plate load when the trade is cheap', () => {
+    // 10×8: the coarse 2×2 (4 pieces) prints 1-per-bed = 4 loads, but a 2×3
+    // (6 pieces) packs its shallower pieces two-per-bed → 3 loads. Saving a
+    // load for 2 extra pieces is within the per-load piece budget, so the
+    // packing-aware planner picks the 2×3.
+    const tiling = computeBaseplateTiling(makeParams({ width: 10, depth: 8 }), 256);
+    expect(tiling.cols).toBe(2);
+    expect(tiling.rows).toBe(3);
+    expect(tiling.bedLoads).toBe(3);
+  });
+
+  it('does not over-fragment when finer pieces would not pack better', () => {
+    // 10×10: a 2×3's pieces are still too deep to pair on the bed, so it saves
+    // no load — the planner keeps the coarse 2×2 rather than adding pieces.
+    const tiling = computeBaseplateTiling(makeParams({ width: 10, depth: 10 }), 256);
+    expect(tiling.cols).toBe(2);
+    expect(tiling.rows).toBe(2);
   });
 
   // ─── Symmetry preference ───────────────────────────────────────────────
@@ -398,7 +427,7 @@ describe('computeBaseplateTiling', () => {
   // ─── Labels and offsets ────────────────────────────────────────────────
 
   it('labels follow grid coordinates (2x2)', () => {
-    const params = makeParams({ width: 10, depth: 8 });
+    const params = makeParams({ width: 10, depth: 10 });
     const tiling = computeBaseplateTiling(params, 256);
     const labels = tiling.pieces.map((p) => p.label).sort();
     expect(labels).toEqual(['A1', 'A2', 'B1', 'B2']);
@@ -822,7 +851,7 @@ describe('pieceToBaseplateParams', () => {
   });
 
   it('passes through edge classification to params', () => {
-    const parent = makeParams({ width: 10, depth: 8 });
+    const parent = makeParams({ width: 10, depth: 10 });
     const tiling = computeBaseplateTiling(parent, 256);
 
     // A1 (front-left corner): left+front exterior, right+back join
@@ -991,11 +1020,11 @@ describe('preferIdenticalPieces', () => {
   });
 
   it('marks opposite-corner pieces with placementRotationDeg=180', () => {
-    // 10×8 → 2×2 grid. Under the flag, A1≡C2 share canonical edges and one is
+    // 10×10 → 2×2 grid. Under the flag, A1≡C2 share canonical edges and one is
     // rendered rotated 180°.
     const params = makeParams({
       width: 10,
-      depth: 8,
+      depth: 10,
       connectorNubs: true,
       preferIdenticalPieces: true,
     });

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -278,7 +278,6 @@ interface TilingCandidate {
   colSizes: number[];
   rowSizes: number[];
   pieceCount: number;
-  bedLoads: number;
   cost: number;
   variance: number;
 }
@@ -332,7 +331,8 @@ function findMinPieceTiling(
  * candidate by `MAX_EXTRA_PIECES_PER_BED_LOAD * bedLoads + pieceCount`
  * (symmetry breaks ties). Since `bedLoads ≥ 1`, a candidate's cost is at least
  * `pieceCount + MAX_EXTRA_PIECES_PER_BED_LOAD`, bounding the search. Returns the
- * best (colSizes, rowSizes, bedLoads) or a single-piece fallback.
+ * best (colSizes, rowSizes) or a single-piece fallback; the caller recomputes
+ * the final bed-load count after display reordering.
  */
 function findOptimalTiling(
   totalWidth: number,
@@ -340,16 +340,10 @@ function findOptimalTiling(
   gridUnitMm: number,
   xAxis: AxisConfig,
   yAxis: AxisConfig
-): { colSizes: number[]; rowSizes: number[]; bedLoads: number } {
+): { colSizes: number[]; rowSizes: number[] } {
   const coarse = findMinPieceTiling(totalWidth, totalDepth, gridUnitMm, xAxis, yAxis);
   if (!coarse) {
-    const colSizes = [totalWidth];
-    const rowSizes = [totalDepth];
-    return {
-      colSizes,
-      rowSizes,
-      bedLoads: tilingBedLoads(colSizes, rowSizes, gridUnitMm, xAxis, yAxis),
-    };
+    return { colSizes: [totalWidth], rowSizes: [totalDepth] };
   }
 
   const coarseBedLoads = tilingBedLoads(coarse.colSizes, coarse.rowSizes, gridUnitMm, xAxis, yAxis);
@@ -357,7 +351,7 @@ function findOptimalTiling(
   // Large plate: the coarse split already packs near-optimally and the packing
   // search would be costly — keep it.
   if (coarse.pieceCount > PACKING_SEARCH_MAX_PIECES) {
-    return { colSizes: coarse.colSizes, rowSizes: coarse.rowSizes, bedLoads: coarseBedLoads };
+    return { colSizes: coarse.colSizes, rowSizes: coarse.rowSizes };
   }
 
   const maxCols = Math.ceil(totalWidth);
@@ -368,7 +362,6 @@ function findOptimalTiling(
     colSizes: coarse.colSizes,
     rowSizes: coarse.rowSizes,
     pieceCount: coarse.pieceCount,
-    bedLoads: coarseBedLoads,
     cost: MAX_EXTRA_PIECES_PER_BED_LOAD * coarseBedLoads + coarse.pieceCount,
     variance: coarse.variance,
   };
@@ -396,12 +389,12 @@ function findOptimalTiling(
       const cost = MAX_EXTRA_PIECES_PER_BED_LOAD * bedLoads + pieceCount;
       const variance = symmetryScore(colSizes) + symmetryScore(rowSizes);
       if (cost < best.cost || (cost === best.cost && variance < best.variance)) {
-        best = { colSizes, rowSizes, pieceCount, bedLoads, cost, variance };
+        best = { colSizes, rowSizes, pieceCount, cost, variance };
       }
     }
   }
 
-  return { colSizes: best.colSizes, rowSizes: best.rowSizes, bedLoads: best.bedLoads };
+  return { colSizes: best.colSizes, rowSizes: best.rowSizes };
 }
 
 /**
@@ -508,11 +501,13 @@ export function computeBaseplateTiling(
     palindromic
   );
 
-  const {
-    colSizes: rawColSizes,
-    rowSizes: rawRowSizes,
-    bedLoads,
-  } = findOptimalTiling(width, depth, gridUnitMm, xAxis, yAxis);
+  const { colSizes: rawColSizes, rowSizes: rawRowSizes } = findOptimalTiling(
+    width,
+    depth,
+    gridUnitMm,
+    xAxis,
+    yAxis
+  );
 
   // Reorder for display: largest pieces at front/left, fractional edges pinned.
   // Under preferIdenticalPieces, arrange palindromically so outer positions match.
@@ -528,6 +523,12 @@ export function computeBaseplateTiling(
     fractionalEdgeY === 'start',
     palindromic
   );
+
+  // Recompute on the FINAL (reordered) sizes: reordering can move a chunk
+  // between an edge position (padding overhead) and a middle one (tongue only),
+  // which shifts a piece's physical footprint — so the search-time count isn't
+  // guaranteed to match the tiling actually emitted.
+  const bedLoads = tilingBedLoads(colSizes, rowSizes, gridUnitMm, xAxis, yAxis);
 
   const isSplit = colSizes.length > 1 || rowSizes.length > 1;
   const colOffsets = cumulativeOffsets(colSizes);
@@ -594,8 +595,6 @@ export function computeBaseplateTiling(
     rows: rowSizes.length,
     totalWidthUnits: width,
     totalDepthUnits: depth,
-    // Reordering only permutes chunk sizes (same multiset), so the packed
-    // bed-load count is unchanged from the search result.
     bedLoads,
     stackCount: 1,
     stackSeparatorThickness: 0,

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -2,10 +2,15 @@
  * Baseplate split planner — pure functions for computing how a large baseplate
  * should be tiled into printable pieces.
  *
- * The algorithm jointly optimizes both axes to minimize total piece count.
- * For each candidate (numCols × numRows) it verifies every piece fits the bed
- * with its edge-specific padding, then picks the tiling with fewest pieces.
- * Ties are broken by symmetry (prefer equal-sized pieces).
+ * The algorithm jointly optimizes both axes to minimize the number of
+ * build-plate loads (print jobs) — packing as many pieces as fit per bed — so
+ * users print in the fewest bed swaps. Because smaller pieces pack tighter,
+ * fewer bed loads usually means more pieces; a per-load piece budget
+ * ({@link MAX_EXTRA_PIECES_PER_BED_LOAD}) caps that trade so the planner won't
+ * fragment into many tiny tiles just to shave a load. For each candidate
+ * (numCols × numRows) it verifies every piece fits the bed with its
+ * edge-specific padding, scores `LOAD_WEIGHT * bedLoads + pieceCount`, and
+ * breaks ties by symmetry (prefer equal-sized pieces).
  *
  * Fractional half-unit edges are absorbed into the outermost piece when they
  * fit, otherwise become a separate piece.
@@ -22,9 +27,24 @@ import type {
   PaddingReductionHint,
   PieceEdges,
 } from '../types/tiling';
+import { estimateBedLoads, type Footprint } from './bedPacking';
+import { FRACTIONAL_THRESHOLD, isFractional, reorderForDisplay } from './splitReorder';
 
-/** Threshold for detecting a fractional half-unit (avoids floating-point noise). */
-const FRACTIONAL_THRESHOLD = 0.49;
+/**
+ * Max extra pieces worth one saved build-plate load. Doubles as the bed-load
+ * weight in the tiling cost (`LOAD_WEIGHT * bedLoads + pieceCount`): a finer
+ * split that removes a load wins only if it adds fewer than this many pieces,
+ * so the planner pursues fewer bed swaps without fragmenting into tiny tiles.
+ */
+const MAX_EXTRA_PIECES_PER_BED_LOAD = 4;
+
+/**
+ * Only run the packing-aware refinement when the coarsest split has at most this
+ * many pieces. Beyond it the plate dwarfs the bed (pieces already tile beds
+ * tightly, so packing can't save loads) and the per-candidate packing cost
+ * would balloon — so large plates keep the fast min-piece tiling.
+ */
+const PACKING_SEARCH_MAX_PIECES = 16;
 
 /**
  * Per-axis configuration: bed budget, padding, and dovetail overhang on each end.
@@ -227,18 +247,103 @@ function symmetryScore(sizes: number[]): number {
   return sizes.reduce((sum, s) => sum + (s - mean) ** 2, 0) / sizes.length;
 }
 
+/**
+ * Per-position physical size (mm) of each chunk on an axis — grid units plus
+ * edge padding and join-edge tongue protrusion. Mirrors {@link chunkSizesFit}
+ * so the packed footprints match the actual STL bounding boxes.
+ */
+function axisChunkMm(sizes: number[], gridUnitMm: number, axis: AxisConfig): number[] {
+  const last = sizes.length - 1;
+  return sizes.map((s, i) => {
+    const padStart = i === 0 ? axis.paddingStart : 0;
+    const padEnd = i === last ? axis.paddingEnd : 0;
+    const tongueStart = i === 0 ? 0 : axis.startMaleMm;
+    const tongueEnd = i === last ? 0 : axis.endMaleMm;
+    return s * gridUnitMm + padStart + padEnd + tongueStart + tongueEnd;
+  });
+}
+
+/** Build-plate loads to print a candidate tiling, packing pieces per bed. */
+function tilingBedLoads(
+  colSizes: number[],
+  rowSizes: number[],
+  gridUnitMm: number,
+  xAxis: AxisConfig,
+  yAxis: AxisConfig
+): number {
+  const colMm = axisChunkMm(colSizes, gridUnitMm, xAxis);
+  const rowMm = axisChunkMm(rowSizes, gridUnitMm, yAxis);
+  const footprints: Footprint[] = [];
+  for (const d of rowMm) for (const w of colMm) footprints.push({ w, d });
+  return estimateBedLoads(footprints, xAxis.bedMm, yAxis.bedMm);
+}
+
+interface MinPieceCandidate {
+  colSizes: number[];
+  rowSizes: number[];
+  pieceCount: number;
+  variance: number;
+}
+
 interface TilingCandidate {
   colSizes: number[];
   rowSizes: number[];
   pieceCount: number;
-  score: number;
+  bedLoads: number;
+  cost: number;
+  variance: number;
 }
 
 /**
- * Find the optimal grid tiling: minimum pieces where every piece fits the bed.
+ * Coarsest feasible tiling: minimum piece count where every piece fits the bed,
+ * symmetry breaking ties. Fast (no packing) — used as both the baseline answer
+ * for large plates and the seed for the packing-aware refinement.
+ */
+function findMinPieceTiling(
+  totalWidth: number,
+  totalDepth: number,
+  gridUnitMm: number,
+  xAxis: AxisConfig,
+  yAxis: AxisConfig
+): MinPieceCandidate | null {
+  const maxCols = Math.ceil(totalWidth);
+  const maxRows = Math.ceil(totalDepth);
+  let best: MinPieceCandidate | null = null;
+
+  for (let nc = 1; nc <= maxCols; nc++) {
+    if (best && nc > best.pieceCount) break;
+    const colSizes = partitionAxis(totalWidth, nc, gridUnitMm, xAxis);
+    if (!colSizes) continue;
+
+    for (let nr = 1; nr <= maxRows; nr++) {
+      const pieceCount = nc * nr;
+      if (best && pieceCount > best.pieceCount) break;
+      const rowSizes = partitionAxis(totalDepth, nr, gridUnitMm, yAxis);
+      if (!rowSizes) continue;
+      if (allPiecesFit(colSizes, rowSizes, gridUnitMm, xAxis, yAxis)) {
+        const variance = symmetryScore(colSizes) + symmetryScore(rowSizes);
+        if (!best || pieceCount < best.pieceCount || variance < best.variance) {
+          best = { colSizes, rowSizes, pieceCount, variance };
+        }
+        break;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Find the optimal grid tiling: fewest build-plate loads (with a per-load piece
+ * budget), where every piece fits the bed.
  *
- * Searches over (numCols, numRows) pairs, partitioning each axis as evenly as
- * possible. Returns the best (colSizes, rowSizes) or a single-piece fallback.
+ * First finds the coarsest (min-piece) tiling. When that already has many
+ * pieces the plate dwarfs the bed — its big pieces tile beds tightly, so
+ * packing-aware refinement can't help and would be expensive; we return it
+ * directly. Otherwise we search (numCols, numRows) pairs, scoring each feasible
+ * candidate by `MAX_EXTRA_PIECES_PER_BED_LOAD * bedLoads + pieceCount`
+ * (symmetry breaks ties). Since `bedLoads ≥ 1`, a candidate's cost is at least
+ * `pieceCount + MAX_EXTRA_PIECES_PER_BED_LOAD`, bounding the search. Returns the
+ * best (colSizes, rowSizes, bedLoads) or a single-piece fallback.
  */
 function findOptimalTiling(
   totalWidth: number,
@@ -246,43 +351,68 @@ function findOptimalTiling(
   gridUnitMm: number,
   xAxis: AxisConfig,
   yAxis: AxisConfig
-): { colSizes: number[]; rowSizes: number[] } {
+): { colSizes: number[]; rowSizes: number[]; bedLoads: number } {
+  const coarse = findMinPieceTiling(totalWidth, totalDepth, gridUnitMm, xAxis, yAxis);
+  if (!coarse) {
+    const colSizes = [totalWidth];
+    const rowSizes = [totalDepth];
+    return {
+      colSizes,
+      rowSizes,
+      bedLoads: tilingBedLoads(colSizes, rowSizes, gridUnitMm, xAxis, yAxis),
+    };
+  }
+
+  const coarseBedLoads = tilingBedLoads(coarse.colSizes, coarse.rowSizes, gridUnitMm, xAxis, yAxis);
+
+  // Large plate: the coarse split already packs near-optimally and the packing
+  // search would be costly — keep it.
+  if (coarse.pieceCount > PACKING_SEARCH_MAX_PIECES) {
+    return { colSizes: coarse.colSizes, rowSizes: coarse.rowSizes, bedLoads: coarseBedLoads };
+  }
+
   const maxCols = Math.ceil(totalWidth);
   const maxRows = Math.ceil(totalDepth);
 
-  let best: TilingCandidate | null = null;
+  // Seed with the coarse tiling so the cost prune is tight from the start.
+  let best: TilingCandidate = {
+    colSizes: coarse.colSizes,
+    rowSizes: coarse.rowSizes,
+    pieceCount: coarse.pieceCount,
+    bedLoads: coarseBedLoads,
+    cost: MAX_EXTRA_PIECES_PER_BED_LOAD * coarseBedLoads + coarse.pieceCount,
+    variance: coarse.variance,
+  };
 
   for (let nc = 1; nc <= maxCols; nc++) {
-    // Early exit: nc alone exceeds best piece count (nc * 1 > best).
-    // Use > not >= so we still evaluate nc×1 candidates for symmetry tiebreaks.
-    if (best && nc > best.pieceCount) break;
+    // Lower-bound prune: this column count alone (nr=1, 1 bed load) can't beat
+    // the best cost found so far. `>` not `>=` so equal-cost candidates still
+    // get evaluated for the symmetry tiebreak.
+    if (nc + MAX_EXTRA_PIECES_PER_BED_LOAD > best.cost) break;
 
     const colSizes = partitionAxis(totalWidth, nc, gridUnitMm, xAxis);
     if (!colSizes) continue;
 
     for (let nr = 1; nr <= maxRows; nr++) {
       const pieceCount = nc * nr;
-      if (best && pieceCount > best.pieceCount) break;
+      // pieceCount keeps growing with nr; once even a 1-load split can't beat
+      // best, no larger nr will either.
+      if (pieceCount + MAX_EXTRA_PIECES_PER_BED_LOAD > best.cost) break;
 
       const rowSizes = partitionAxis(totalDepth, nr, gridUnitMm, yAxis);
       if (!rowSizes) continue;
+      if (!allPiecesFit(colSizes, rowSizes, gridUnitMm, xAxis, yAxis)) continue;
 
-      if (allPiecesFit(colSizes, rowSizes, gridUnitMm, xAxis, yAxis)) {
-        const score = symmetryScore(colSizes) + symmetryScore(rowSizes);
-        if (
-          !best ||
-          pieceCount < best.pieceCount ||
-          (pieceCount === best.pieceCount && score < best.score)
-        ) {
-          best = { colSizes, rowSizes, pieceCount, score };
-        }
-        break;
+      const bedLoads = tilingBedLoads(colSizes, rowSizes, gridUnitMm, xAxis, yAxis);
+      const cost = MAX_EXTRA_PIECES_PER_BED_LOAD * bedLoads + pieceCount;
+      const variance = symmetryScore(colSizes) + symmetryScore(rowSizes);
+      if (cost < best.cost || (cost === best.cost && variance < best.variance)) {
+        best = { colSizes, rowSizes, pieceCount, bedLoads, cost, variance };
       }
     }
   }
 
-  if (!best) return { colSizes: [totalWidth], rowSizes: [totalDepth] };
-  return { colSizes: best.colSizes, rowSizes: best.rowSizes };
+  return { colSizes: best.colSizes, rowSizes: best.rowSizes, bedLoads: best.bedLoads };
 }
 
 /**
@@ -388,27 +518,23 @@ export function computeBaseplateTiling(
     palindromic
   );
 
-  const { colSizes: rawColSizes, rowSizes: rawRowSizes } = findOptimalTiling(
-    width,
-    depth,
-    gridUnitMm,
-    xAxis,
-    yAxis
-  );
+  const {
+    colSizes: rawColSizes,
+    rowSizes: rawRowSizes,
+    bedLoads,
+  } = findOptimalTiling(width, depth, gridUnitMm, xAxis, yAxis);
 
   // Reorder for display: largest pieces at front/left, fractional edges pinned.
   // Under preferIdenticalPieces, arrange palindromically so outer positions match.
   const colSizes = reorderForDisplay(
     rawColSizes,
-    gridUnitMm,
-    xAxis,
+    axisCapacity(gridUnitMm, xAxis),
     fractionalEdgeX === 'start',
     palindromic
   );
   const rowSizes = reorderForDisplay(
     rawRowSizes,
-    gridUnitMm,
-    yAxis,
+    axisCapacity(gridUnitMm, yAxis),
     fractionalEdgeY === 'start',
     palindromic
   );
@@ -478,6 +604,9 @@ export function computeBaseplateTiling(
     rows: rowSizes.length,
     totalWidthUnits: width,
     totalDepthUnits: depth,
+    // Reordering only permutes chunk sizes (same multiset), so the packed
+    // bed-load count is unchanged from the search result.
+    bedLoads,
     stackCount: 1,
     stackSeparatorThickness: 0,
     paddingReductionHint,
@@ -561,149 +690,10 @@ function edgeKey(edges: BaseplatePiece['edges']): string {
   return `${edges.left}|${edges.right}|${edges.front}|${edges.back}`;
 }
 
-/**
- * Reorder sizes for display: largest pieces at lowest indices (front/left),
- * while respecting edge constraints and fractional edge placement.
- *
- * When `fractionAtStart` is true and a fractional piece exists, it is pinned to
- * position 0 with the remaining pieces sorted descending.
- *
- * When `preferIdenticalPieces` is true, the integer-sized pieces are arranged
- * palindromically so opposite outer positions have identical sizes — this lets
- * A1 ≡ C2 and A2 ≡ C1 share a canonical fingerprint under 180° rotation.
- */
-function reorderForDisplay(
-  sizes: number[],
-  gridUnitMm: number,
-  axis: AxisConfig,
-  fractionAtStart: boolean,
-  preferIdenticalPieces: boolean
-): number[] {
-  if (sizes.length <= 1) return sizes;
-
-  // Use the same per-position constraints as partitionAxis so dovetail tongues
-  // are accounted for when reshuffling chunks across positions (#1498).
-  const { maxFirst, maxLast, maxMiddle } = axisCapacity(gridUnitMm, axis);
-  const fracIdx = sizes.findIndex(isFractional);
-
-  // Pin fractional piece to position 0 (only if it fits there).
-  if (fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxFirst) {
-    const rest = sizes.filter((_, i) => i !== fracIdx);
-    const inner = preferIdenticalPieces
-      ? palindromizeWithEdges(rest, maxMiddle, maxLast, maxMiddle)
-      : sortDescWithEdges(rest, maxMiddle, maxLast);
-    return [sizes[fracIdx], ...inner];
-  }
-
-  // Pin fractional piece to last position (prevents middle placement).
-  if (!fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxLast) {
-    const rest = sizes.filter((_, i) => i !== fracIdx);
-    const inner = preferIdenticalPieces
-      ? palindromizeWithEdges(rest, maxFirst, maxMiddle, maxMiddle)
-      : sortDescWithEdges(rest, maxFirst, maxMiddle);
-    return [...inner, sizes[fracIdx]];
-  }
-
-  if (preferIdenticalPieces) {
-    return palindromizeWithEdges(sizes, maxFirst, maxLast, maxMiddle);
-  }
-
-  return sortDescWithEdges(sizes, maxFirst, maxLast);
-}
-
-/**
- * Arrange sizes palindromically (sizes[i] = sizes[n-1-i] where possible) while
- * respecting edge constraints. Pairs equal values at outermost positions first,
- * then works inward.
- *
- * Returns sortDescWithEdges' result if no palindromic arrangement satisfies the
- * edge caps — the fitting checker would otherwise reject the tiling.
- */
-function palindromizeWithEdges(
-  sizes: readonly number[],
-  maxFirst: number,
-  maxLast: number,
-  maxMiddle: number
-): number[] {
-  if (sizes.length <= 1) return [...sizes];
-
-  const n = sizes.length;
-
-  // Collect every value that can participate in a true palindromic pair (it
-  // appears 2+ times in the multiset). What's left over after pairing — the
-  // odd-count remainders — must occupy middle slots since no slot at the
-  // outer edges can be the half of a matching pair. This finds palindromes
-  // even when the unique value is the largest: [5, 4, 4] → pairs [(4,4)],
-  // leftovers [5] → result [4, 5, 4].
-  const freq = new Map<number, number>();
-  for (const s of sizes) freq.set(s, (freq.get(s) ?? 0) + 1);
-  const pairs: number[] = [];
-  const leftovers: number[] = [];
-  for (const [value, count] of freq) {
-    for (let i = 0; i < Math.floor(count / 2); i++) pairs.push(value);
-    if (count % 2 === 1) leftovers.push(value);
-  }
-  pairs.sort((a, b) => b - a); // largest pairs at outermost slots
-  leftovers.sort((a, b) => b - a);
-
-  const result = new Array<number>(n);
-  let left = 0;
-  let right = n - 1;
-  for (const value of pairs) {
-    if (left >= right) break;
-    result[left++] = value;
-    result[right--] = value;
-  }
-  for (const value of leftovers) {
-    if (left > right) break;
-    result[left++] = value;
-  }
-
-  // Fall back to the baseline sort if the palindromic layout would overrun a
-  // first/last edge cap OR a middle cap (middle slots can have stricter caps
-  // than edges when both join sides claim tongue protrusion — only matters
-  // for non-standard small gridUnitMm where floor(bed/gu) > floor((bed-P)/gu)).
-  const middleOverflow = (): boolean => {
-    for (let i = 1; i < n - 1; i++) if (result[i] > maxMiddle) return true;
-    return false;
-  };
-  if (result[0] > maxFirst || result[n - 1] > maxLast || middleOverflow()) {
-    return sortDescWithEdges([...sizes], maxFirst, maxLast);
-  }
-  return result;
-}
-
-/**
- * Sort sizes descending while ensuring position 0 fits within paddingFirst
- * and the last position fits within paddingLast.
- *
- * Falls back to the original order if constraints cannot be satisfied.
- */
-function sortDescWithEdges(sizes: number[], maxFirst: number, maxLast: number): number[] {
-  const pool = [...sizes].sort((a, b) => b - a);
-
-  const firstIdx = pool.findIndex((v) => v <= maxFirst);
-  if (firstIdx < 0) return sizes;
-  const first = pool.splice(firstIdx, 1)[0];
-
-  if (pool.length === 0 || pool[pool.length - 1] <= maxLast) {
-    return [first, ...pool];
-  }
-
-  const validLastIdx = pool.findIndex((v) => v <= maxLast);
-  if (validLastIdx < 0) return sizes;
-  const lastPiece = pool.splice(validLastIdx, 1)[0];
-  return [first, ...pool, lastPiece];
-}
-
 function cumulativeOffsets(sizes: number[]): number[] {
   const offsets: number[] = [0];
   for (let i = 1; i < sizes.length; i++) {
     offsets.push(offsets[i - 1] + sizes[i - 1]);
   }
   return offsets;
-}
-
-function isFractional(value: number): boolean {
-  return value - Math.floor(value) >= FRACTIONAL_THRESHOLD;
 }

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -151,14 +151,12 @@ function partitionAxis(
     return intPart > 0 ? [intPart] : null;
   }
 
-  // For numChunks >= 2, distribute integer units as evenly as possible.
   const maxPerPos: number[] = Array.from({ length: numChunks }, (_, i) => {
     if (i === 0) return maxFirst;
     if (i === numChunks - 1) return maxLast;
     return maxMiddle;
   });
 
-  // Total capacity check — bail early if the partition is impossible.
   const totalCapacity = maxPerPos.reduce((a, b) => a + b, 0);
   if (totalCapacity < intPart) return null;
 
@@ -225,32 +223,12 @@ function allPiecesFit(
   return chunkSizesFit(colSizes, gridUnitMm, xAxis) && chunkSizesFit(rowSizes, gridUnitMm, yAxis);
 }
 
-function chunkSizesFit(sizes: number[], gridUnitMm: number, axis: AxisConfig): boolean {
-  const last = sizes.length - 1;
-  for (let i = 0; i < sizes.length; i++) {
-    const padStart = i === 0 ? axis.paddingStart : 0;
-    const padEnd = i === last ? axis.paddingEnd : 0;
-    // Join edges (interior sides) carry a male tongue's protrusion if the convention
-    // assigns male to that side. Female sides cut into the slab and add nothing.
-    const tongueStart = i === 0 ? 0 : axis.startMaleMm;
-    const tongueEnd = i === last ? 0 : axis.endMaleMm;
-    const sizeMm = sizes[i] * gridUnitMm + padStart + padEnd + tongueStart + tongueEnd;
-    if (sizeMm > axis.bedMm + 0.001) return false;
-  }
-  return true;
-}
-
-/** Variance of an array — lower = more symmetric/equal. */
-function symmetryScore(sizes: number[]): number {
-  if (sizes.length <= 1) return 0;
-  const mean = sizes.reduce((a, b) => a + b, 0) / sizes.length;
-  return sizes.reduce((sum, s) => sum + (s - mean) ** 2, 0) / sizes.length;
-}
-
 /**
  * Per-position physical size (mm) of each chunk on an axis — grid units plus
- * edge padding and join-edge tongue protrusion. Mirrors {@link chunkSizesFit}
- * so the packed footprints match the actual STL bounding boxes.
+ * edge padding and join-edge tongue protrusion (matches the actual STL bounding
+ * boxes). First/last chunks carry their exterior padding; join edges (interior
+ * sides) carry a male tongue's protrusion when the convention assigns male to
+ * that side, while female sides cut into the slab and add nothing.
  */
 function axisChunkMm(sizes: number[], gridUnitMm: number, axis: AxisConfig): number[] {
   const last = sizes.length - 1;
@@ -261,6 +239,17 @@ function axisChunkMm(sizes: number[], gridUnitMm: number, axis: AxisConfig): num
     const tongueEnd = i === last ? 0 : axis.endMaleMm;
     return s * gridUnitMm + padStart + padEnd + tongueStart + tongueEnd;
   });
+}
+
+function chunkSizesFit(sizes: number[], gridUnitMm: number, axis: AxisConfig): boolean {
+  return axisChunkMm(sizes, gridUnitMm, axis).every((mm) => mm <= axis.bedMm + 0.001);
+}
+
+/** Variance of an array — lower = more symmetric/equal. */
+function symmetryScore(sizes: number[]): number {
+  if (sizes.length <= 1) return 0;
+  const mean = sizes.reduce((a, b) => a + b, 0) / sizes.length;
+  return sizes.reduce((sum, s) => sum + (s - mean) ** 2, 0) / sizes.length;
 }
 
 /** Build-plate loads to print a candidate tiling, packing pieces per bed. */
@@ -433,6 +422,8 @@ function computePaddingReductionHint(
   const reduceY = Math.min(yAxis.paddingStart, yAxis.paddingEnd);
 
   // Find smallest reduction along an axis that saves pieces; null if none works.
+  // Uses the full packing-aware tiling (not the cheaper min-piece search) so the
+  // "saves N pieces" hint matches the split the user actually sees after reducing.
   const trySaving = (maxR: number, build: (r: number) => { x: AxisConfig; y: AxisConfig }) => {
     for (let r = 1; r <= maxR; r++) {
       const { x, y } = build(r);
@@ -462,7 +453,6 @@ function computePaddingReductionHint(
 
   if (candidates.length === 0) return null;
 
-  // Pick best: most pieces saved, then smallest reduction
   candidates.sort((a, b) => b.piecesSaved - a.piecesSaved || a.reductionMm - b.reductionMm);
   return candidates[0];
 }

--- a/src/features/baseplate/utils/splitReorder.test.ts
+++ b/src/features/baseplate/utils/splitReorder.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isFractional, reorderForDisplay, type AxisCaps } from './splitReorder';
+
+// Generous caps so reordering isn't constrained by edge limits.
+const CAPS: AxisCaps = { maxFirst: 99, maxLast: 99, maxMiddle: 99 };
+
+describe('isFractional', () => {
+  it('detects half-units, not integers or noise', () => {
+    expect(isFractional(3.5)).toBe(true);
+    expect(isFractional(3)).toBe(false);
+    expect(isFractional(3.0001)).toBe(false);
+  });
+});
+
+describe('reorderForDisplay', () => {
+  it('returns short arrays unchanged', () => {
+    expect(reorderForDisplay([5], CAPS, false, false)).toEqual([5]);
+  });
+
+  it('sorts integer pieces descending (largest at front)', () => {
+    expect(reorderForDisplay([4, 6, 5], CAPS, false, false)).toEqual([6, 5, 4]);
+  });
+
+  it('pins a fractional piece to the end by default', () => {
+    const out = reorderForDisplay([2.5, 5, 4], CAPS, false, false);
+    expect(out[out.length - 1]).toBe(2.5);
+  });
+
+  it('pins a fractional piece to the start when requested', () => {
+    const out = reorderForDisplay([2.5, 5, 4], CAPS, true, false);
+    expect(out[0]).toBe(2.5);
+  });
+
+  it('arranges palindromically under preferIdenticalPieces', () => {
+    // [5,4,4] → pair (4,4) outer, leftover 5 in the middle.
+    expect(reorderForDisplay([5, 4, 4], CAPS, false, true)).toEqual([4, 5, 4]);
+  });
+
+  it('respects edge caps, falling back to a feasible descending order', () => {
+    // First slot caps at 4, so the 6 cannot sit at position 0.
+    const caps: AxisCaps = { maxFirst: 4, maxLast: 99, maxMiddle: 99 };
+    const out = reorderForDisplay([6, 4, 3], caps, false, false);
+    expect(out[0]).toBeLessThanOrEqual(4);
+  });
+});

--- a/src/features/baseplate/utils/splitReorder.ts
+++ b/src/features/baseplate/utils/splitReorder.ts
@@ -40,8 +40,8 @@ export function reorderForDisplay(
 ): number[] {
   if (sizes.length <= 1) return sizes;
 
-  // Use the same per-position constraints as partitionAxis so dovetail tongues
-  // are accounted for when reshuffling chunks across positions (#1498).
+  // `caps` come from the same axisCapacity used by partitionAxis, so dovetail
+  // tongues are accounted for when reshuffling chunks across positions (#1498).
   const { maxFirst, maxLast, maxMiddle } = caps;
   const fracIdx = sizes.findIndex(isFractional);
 

--- a/src/features/baseplate/utils/splitReorder.ts
+++ b/src/features/baseplate/utils/splitReorder.ts
@@ -1,0 +1,156 @@
+/**
+ * Display reordering for split-baseplate chunk sizes — pure helpers that permute
+ * an axis's piece sizes for presentation without changing the multiset (so the
+ * bed-load count is unaffected): largest pieces at front/left, fractional edges
+ * pinned to the requested end, and a palindromic layout under
+ * `preferIdenticalPieces` so opposite outer positions match for 180°-rotation
+ * dedup. Split out of the planner to keep that file focused on the search.
+ */
+
+/** Threshold for detecting a fractional half-unit (avoids floating-point noise). */
+export const FRACTIONAL_THRESHOLD = 0.49;
+
+export function isFractional(value: number): boolean {
+  return value - Math.floor(value) >= FRACTIONAL_THRESHOLD;
+}
+
+/** Per-position grid-unit capacity caps for an axis (from `axisCapacity`). */
+export interface AxisCaps {
+  readonly maxFirst: number;
+  readonly maxLast: number;
+  readonly maxMiddle: number;
+}
+
+/**
+ * Reorder sizes for display: largest pieces at lowest indices (front/left),
+ * while respecting edge constraints and fractional edge placement.
+ *
+ * When `fractionAtStart` is true and a fractional piece exists, it is pinned to
+ * position 0 with the remaining pieces sorted descending.
+ *
+ * When `preferIdenticalPieces` is true, the integer-sized pieces are arranged
+ * palindromically so opposite outer positions have identical sizes — this lets
+ * A1 ≡ C2 and A2 ≡ C1 share a canonical fingerprint under 180° rotation.
+ */
+export function reorderForDisplay(
+  sizes: number[],
+  caps: AxisCaps,
+  fractionAtStart: boolean,
+  preferIdenticalPieces: boolean
+): number[] {
+  if (sizes.length <= 1) return sizes;
+
+  // Use the same per-position constraints as partitionAxis so dovetail tongues
+  // are accounted for when reshuffling chunks across positions (#1498).
+  const { maxFirst, maxLast, maxMiddle } = caps;
+  const fracIdx = sizes.findIndex(isFractional);
+
+  // Pin fractional piece to position 0 (only if it fits there).
+  if (fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxFirst) {
+    const rest = sizes.filter((_, i) => i !== fracIdx);
+    const inner = preferIdenticalPieces
+      ? palindromizeWithEdges(rest, maxMiddle, maxLast, maxMiddle)
+      : sortDescWithEdges(rest, maxMiddle, maxLast);
+    return [sizes[fracIdx], ...inner];
+  }
+
+  // Pin fractional piece to last position (prevents middle placement).
+  if (!fractionAtStart && fracIdx >= 0 && sizes[fracIdx] <= maxLast) {
+    const rest = sizes.filter((_, i) => i !== fracIdx);
+    const inner = preferIdenticalPieces
+      ? palindromizeWithEdges(rest, maxFirst, maxMiddle, maxMiddle)
+      : sortDescWithEdges(rest, maxFirst, maxMiddle);
+    return [...inner, sizes[fracIdx]];
+  }
+
+  if (preferIdenticalPieces) {
+    return palindromizeWithEdges(sizes, maxFirst, maxLast, maxMiddle);
+  }
+
+  return sortDescWithEdges(sizes, maxFirst, maxLast);
+}
+
+/**
+ * Arrange sizes palindromically (sizes[i] = sizes[n-1-i] where possible) while
+ * respecting edge constraints. Pairs equal values at outermost positions first,
+ * then works inward.
+ *
+ * Returns sortDescWithEdges' result if no palindromic arrangement satisfies the
+ * edge caps — the fitting checker would otherwise reject the tiling.
+ */
+function palindromizeWithEdges(
+  sizes: readonly number[],
+  maxFirst: number,
+  maxLast: number,
+  maxMiddle: number
+): number[] {
+  if (sizes.length <= 1) return [...sizes];
+
+  const n = sizes.length;
+
+  // Collect every value that can participate in a true palindromic pair (it
+  // appears 2+ times in the multiset). What's left over after pairing — the
+  // odd-count remainders — must occupy middle slots since no slot at the
+  // outer edges can be the half of a matching pair. This finds palindromes
+  // even when the unique value is the largest: [5, 4, 4] → pairs [(4,4)],
+  // leftovers [5] → result [4, 5, 4].
+  const freq = new Map<number, number>();
+  for (const s of sizes) freq.set(s, (freq.get(s) ?? 0) + 1);
+  const pairs: number[] = [];
+  const leftovers: number[] = [];
+  for (const [value, count] of freq) {
+    for (let i = 0; i < Math.floor(count / 2); i++) pairs.push(value);
+    if (count % 2 === 1) leftovers.push(value);
+  }
+  pairs.sort((a, b) => b - a); // largest pairs at outermost slots
+  leftovers.sort((a, b) => b - a);
+
+  const result = new Array<number>(n);
+  let left = 0;
+  let right = n - 1;
+  for (const value of pairs) {
+    if (left >= right) break;
+    result[left++] = value;
+    result[right--] = value;
+  }
+  for (const value of leftovers) {
+    if (left > right) break;
+    result[left++] = value;
+  }
+
+  // Fall back to the baseline sort if the palindromic layout would overrun a
+  // first/last edge cap OR a middle cap (middle slots can have stricter caps
+  // than edges when both join sides claim tongue protrusion — only matters
+  // for non-standard small gridUnitMm where floor(bed/gu) > floor((bed-P)/gu)).
+  const middleOverflow = (): boolean => {
+    for (let i = 1; i < n - 1; i++) if (result[i] > maxMiddle) return true;
+    return false;
+  };
+  if (result[0] > maxFirst || result[n - 1] > maxLast || middleOverflow()) {
+    return sortDescWithEdges([...sizes], maxFirst, maxLast);
+  }
+  return result;
+}
+
+/**
+ * Sort sizes descending while ensuring position 0 fits within paddingFirst
+ * and the last position fits within paddingLast.
+ *
+ * Falls back to the original order if constraints cannot be satisfied.
+ */
+function sortDescWithEdges(sizes: number[], maxFirst: number, maxLast: number): number[] {
+  const pool = [...sizes].sort((a, b) => b - a);
+
+  const firstIdx = pool.findIndex((v) => v <= maxFirst);
+  if (firstIdx < 0) return sizes;
+  const first = pool.splice(firstIdx, 1)[0];
+
+  if (pool.length === 0 || pool[pool.length - 1] <= maxLast) {
+    return [first, ...pool];
+  }
+
+  const validLastIdx = pool.findIndex((v) => v <= maxLast);
+  if (validLastIdx < 0) return sizes;
+  const lastPiece = pool.splice(validLastIdx, 1)[0];
+  return [first, ...pool, lastPiece];
+}

--- a/src/features/baseplate/utils/stackPrint.test.ts
+++ b/src/features/baseplate/utils/stackPrint.test.ts
@@ -323,6 +323,7 @@ describe('stackGroupsFromTiling', () => {
       totalDepthUnits: 3,
       stackCount: 1,
       stackSeparatorThickness: 0,
+      bedLoads: 1,
       paddingReductionHint: null,
     };
   }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "Seite",
   "baseplate.splitInfo": "{count} Teile",
   "baseplate.splitReason": "Aufgeteilt für {printBed}mm Druckbett",
+  "baseplate.bedLoads.one": "Druckt in 1 Druckbett-Durchgang",
+  "baseplate.bedLoads.other": "Druckt in {count} Druckbett-Durchgängen",
   "baseplate.stackPrint.enable": "Vertikaler Stapel",
   "baseplate.stackPrint.exportBanner": "Stapeldruck: {stacks} Stapel ({plates} Platten) werden als ZIP mit Druckanleitung exportiert.",
   "baseplate.stackPrint.gap.info": "Luftspalt zwischen gestapelten Platten, ca. 0,2 mm (eine Schicht). Schichthöhe des Slicers auf oder unter diesem Spalt halten, sonst verschmelzen die Platten. Kein Stützmaterial nötig. Kleinen Stapel zuerst testen.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2200,6 +2200,8 @@ const en: Record<string, string> = {
   'baseplate.sectionView': 'View',
   'baseplate.splitInfo': '{count} pieces',
   'baseplate.splitReason': 'Split to fit {printBed}mm print bed',
+  'baseplate.bedLoads.one': 'Prints in 1 build-plate load',
+  'baseplate.bedLoads.other': 'Prints in {count} build-plate loads',
   'baseplate.paddingHint': 'Reducing {axis} padding by {mm}mm would save {count} piece(s)',
   'baseplate.paddingHintAxisX': 'left/right',
   'baseplate.paddingHintAxisY': 'front/back',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "Lado",
   "baseplate.splitInfo": "{count} piezas",
   "baseplate.splitReason": "Dividido para cama de {printBed}mm",
+  "baseplate.bedLoads.one": "Se imprime en 1 carga de cama",
+  "baseplate.bedLoads.other": "Se imprime en {count} cargas de cama",
   "baseplate.stackPrint.enable": "Pila vertical",
   "baseplate.stackPrint.exportBanner": "Impresión apilada: {stacks} pilas ({plates} placas) se exportan como un ZIP con guía de impresión.",
   "baseplate.stackPrint.gap.info": "Espacio de aire entre placas apiladas, aproximadamente 0,2 mm (una capa). Mantén la altura de capa del slicer en ese espacio o menos, o las placas se fusionan. No se necesitan soportes. Prueba con una pila pequeña primero.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "Côté",
   "baseplate.splitInfo": "{count} pièces",
   "baseplate.splitReason": "Découpé pour le plateau de {printBed}mm",
+  "baseplate.bedLoads.one": "Imprimé en 1 plateau",
+  "baseplate.bedLoads.other": "Imprimé en {count} plateaux",
   "baseplate.stackPrint.enable": "Pile verticale",
   "baseplate.stackPrint.exportBanner": "Impression empilée : {stacks} piles ({plates} plaques) exportées dans un ZIP avec guide d'impression.",
   "baseplate.stackPrint.gap.info": "Espace d'air entre les plaques empilées, environ 0,2 mm (une couche). Gardez la hauteur de couche du slicer sous cet espace ou les plaques fusionnent. Pas de support nécessaire. Testez d'abord avec une petite pile.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "側面",
   "baseplate.splitInfo": "{count}個のパーツ",
   "baseplate.splitReason": "{printBed}mmのプリントベッドに収めるため分割",
+  "baseplate.bedLoads.one": "1 回のベッド印刷で完成",
+  "baseplate.bedLoads.other": "{count} 回のベッド印刷で完成",
   "baseplate.stackPrint.enable": "縦積み",
   "baseplate.stackPrint.exportBanner": "積層印刷：{stacks} スタック（{plates} 枚）を印刷ガイド付きZIPとしてエクスポートします。",
   "baseplate.stackPrint.gap.info": "積み重ねたプレート間の空気ギャップ（約0.2mm、1層分）。スライサーの積層ピッチをこのギャップ以下に保たないとプレートが融着します。サポート不要。まず小さなスタックで調整してください。",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "Side",
   "baseplate.splitInfo": "{count} deler",
   "baseplate.splitReason": "Delt for {printBed}mm printplate",
+  "baseplate.bedLoads.one": "Skrives ut på 1 platelasting",
+  "baseplate.bedLoads.other": "Skrives ut på {count} platelastinger",
   "baseplate.stackPrint.enable": "Vertikal stabel",
   "baseplate.stackPrint.exportBanner": "Stabelutskrift: {stacks} stabler ({plates} plater) eksporteres som en ZIP med utskriftsguide.",
   "baseplate.stackPrint.gap.info": "Luftspalte mellom stablede plater, ca. 0,2 mm (ett lag). Hold slicer-laghøyden på eller under dette gapet, ellers smelter platene sammen. Ingen støtte nødvendig. Test med en liten stabel først.",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "Zij",
   "baseplate.splitInfo": "{count} stukken",
   "baseplate.splitReason": "Gesplitst voor {printBed}mm printbed",
+  "baseplate.bedLoads.one": "Print in 1 bedlading",
+  "baseplate.bedLoads.other": "Print in {count} bedladingen",
   "baseplate.stackPrint.enable": "Verticale stapel",
   "baseplate.stackPrint.exportBanner": "Gestapeld printen: {stacks} stapels ({plates} platen) worden geëxporteerd als een ZIP met printgids.",
   "baseplate.stackPrint.gap.info": "Luchtspeling tussen gestapelde platen, ongeveer 0,2 mm (één laag). Houd de laagdikte van de slicer op of onder deze speling anders smelten de platen samen. Geen supports nodig. Test eerst met een kleine stapel.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "Lado",
   "baseplate.splitInfo": "{count} peças",
   "baseplate.splitReason": "Dividido para mesa de {printBed}mm",
+  "baseplate.bedLoads.one": "Imprime em 1 carga de mesa",
+  "baseplate.bedLoads.other": "Imprime em {count} cargas de mesa",
   "baseplate.stackPrint.enable": "Pilha vertical",
   "baseplate.stackPrint.exportBanner": "Impressão empilhada: {stacks} pilhas ({plates} placas) são exportadas em um ZIP com guia de impressão.",
   "baseplate.stackPrint.gap.info": "Fresta de ar entre placas empilhadas, cerca de 0,2 mm (uma camada). Mantenha a altura de camada do slicer na fresta ou abaixo, ou as placas se fundem. Sem suportes necessários. Teste com uma pilha pequena primeiro.",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "Sida",
   "baseplate.splitInfo": "{count} delar",
   "baseplate.splitReason": "Delad för att passa {printBed}mm utskriftsbädd",
+  "baseplate.bedLoads.one": "Skrivs ut på 1 bäddladdning",
+  "baseplate.bedLoads.other": "Skrivs ut på {count} bäddladdningar",
   "baseplate.stackPrint.enable": "Vertikal stapel",
   "baseplate.stackPrint.exportBanner": "Stapelutskrift: {stacks} staplar ({plates} plattor) exporteras som en ZIP med utskriftsguide.",
   "baseplate.stackPrint.gap.info": "Luftgap mellan staplade plattor, ungefär 0,2 mm (ett lager). Håll slicerns lagerhöjd vid eller under detta gap, annars smälter plattorna samman. Inga stöd behövs. Testa med en liten stapel först.",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -138,6 +138,8 @@
   "baseplate.sideView": "Збоку",
   "baseplate.splitInfo": "{count} частин",
   "baseplate.splitReason": "Розділено для друкарського стола {printBed}мм",
+  "baseplate.bedLoads.one": "Друкується за 1 завантаження столу",
+  "baseplate.bedLoads.other": "Друкується за {count} завантажень столу",
   "baseplate.stackPrint.enable": "Вертикальний стос",
   "baseplate.stackPrint.exportBanner": "Друк стосами: {stacks} стосів ({plates} пластин) експортуються як ZIP із посібником із друку.",
   "baseplate.stackPrint.gap.info": "Повітряний зазор між пластинами, близько 0,2 мм (один шар). Тримайте висоту шару слайсера на рівні зазору або нижче, інакше пластини з'єднаються. Підтримки не потрібні. Спочатку протестуйте невеликий стос.",


### PR DESCRIPTION
Follow-up to #2298. Its "Alternatives Considered" suggested *"let users control how the plates are split."* Rather than add manual knobs, this makes the **automatic** split smarter — targeting what users actually care about: the **fewest build-plate loads (print jobs)**.

## Problem
`findOptimalTiling` minimized **piece count**, which isn't the same as print jobs. Two long strips (2 pieces) can each need their own bed, while a 2×3 of shallower pieces packs two-per-bed into fewer loads. Minimizing pieces picks the worse option for bed swaps.

## Approach
The planner is now **packing-aware**. For each candidate grid it estimates how many bed loads the pieces need (`estimateBedLoads`, a shelf First-Fit-Decreasing bin-packer with 90° rotation) and scores:

```
cost = MAX_EXTRA_PIECES_PER_BED_LOAD * bedLoads + pieceCount   // symmetry breaks ties
```

- Because `bedLoads ≥ 1`, the cost bounds the search.
- **Cap on fragmentation:** `MAX_EXTRA_PIECES_PER_BED_LOAD = 4` means a finer split must remove a load for < 4 extra pieces, so it never fragments into tiny tiles to chase the theoretical floor (the decision the maintainer chose: *"fewer loads, but cap added pieces"*).
- **Perf gate:** the refinement only runs when the coarse split is small (`PACKING_SEARCH_MAX_PIECES`); large plates keep the fast min-piece path (their big pieces already tile beds tightly). 50×50 stays well under the 100ms perf test.

Example: `10×8` was `2×2` (4 pieces, **4** bed loads) → now `2×3` (6 pieces, **3** bed loads). `10×10` stays `2×2` (its 2×3 pieces are too deep to pair, so no load is saved → not fragmented).

## UX
The split panel now shows **"Prints in N build-plate loads"** (`tiling.bedLoads`). Report-only — export still produces one file per piece.

## Structure
- New `utils/bedPacking.ts` (`estimateBedLoads`) + tests.
- New `utils/splitReorder.ts` — display reordering extracted from `splitPlanner.ts` to keep it under the line budget and focused on the search; + tests.
- `BaseplateTiling` gains a `bedLoads` field.
- i18n added across all 10 locales.

## Tests / quality
- New unit tests for the packer, the new objective (saves a load; doesn't over-fragment; `bedLoads` field), and the reorder helpers.
- 8 existing split/fingerprint tests re-baselined: their `10×8` inputs (which now legitimately split `2×3`) changed to `10×10` so they keep exercising the intended clean-2×2 corner/dedup/rotation scenarios — verified empirically.
- Full suite green (**14014 passed / 0 failed**), typecheck + lint (no warnings) + all 4 i18n checks + all pre-commit hooks pass.

> Not visually screenshotted (browser extension wasn't connected); the panel line follows existing styles.