### PR TITLE
chore(deps): bump brepkit-wasm to 2.115.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@vercel/blob": "^2.4.0",
     "arctic": "^3.7.0",
     "brepjs": "18.100.0",
-    "brepkit-wasm": "^2.115.7",
+    "brepkit-wasm": "^2.115.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,10 +69,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.100.0
-        version: 18.100.0(brepkit-wasm@2.115.7)(occt-wasm@3.4.0)
+        version: 18.100.0(brepkit-wasm@2.115.8)(occt-wasm@3.4.0)
       brepkit-wasm:
-        specifier: ^2.115.7
-        version: 2.115.7
+        specifier: ^2.115.8
+        version: 2.115.8
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3058,8 +3058,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@2.115.7:
-    resolution: {integrity: sha512-81XNxeNU1/u5lE2lfceYrTsuqtUxuHfPLji7CGPxuUU8dNPHHXTijrFKpgUUNmCJG2AomqhFIktA6VI88GPRjg==}
+  brepkit-wasm@2.115.8:
+    resolution: {integrity: sha512-/dhTfYtSwtgVcImfEQGqrzOMUaXYzAFTAXpt+VX8WzVXjb5XehrRV/IoQTfVqwZB7Zk3zf479+fj+nfWly4egA==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -8424,15 +8424,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.100.0(brepkit-wasm@2.115.7)(occt-wasm@3.4.0):
+  brepjs@18.100.0(brepkit-wasm@2.115.8)(occt-wasm@3.4.0):
     dependencies:
       flatbush: 4.6.0
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 2.115.7
+      brepkit-wasm: 2.115.8
       occt-wasm: 3.4.0
 
-  brepkit-wasm@2.115.7: {}
+  brepkit-wasm@2.115.8: {}
 
   browserslist@4.28.2:
     dependencies:


### PR DESCRIPTION
## Summary

Bumps `brepkit-wasm` 2.115.7 → 2.115.8 (within the existing caret range; lockfile + floor).

2.115.8 picks up **brepkit#953** — `meshEdges`/`meshEdgesAll` now accept an optional `angularTolerance`. Kernel-internal and backward compatible; **no behavior change in this app yet** — the brepkit adapter that forwards the arg ships in **brepjs#1579**, which gridfinity will pick up via a later brepjs bump.

## Verification

- `tsc -b --noEmit` clean.
- Patch-level kernel bump, no API change for this app's usage.