### PR TITLE
chore(deps): bump brepjs to 18.100.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.4.0",
     "arctic": "^3.7.0",
-    "brepjs": "18.100.0",
+    "brepjs": "18.100.1",
     "brepkit-wasm": "^2.115.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       brepjs:
-        specifier: 18.100.0
-        version: 18.100.0(brepkit-wasm@2.115.8)(occt-wasm@3.4.0)
+        specifier: 18.100.1
+        version: 18.100.1(brepkit-wasm@2.115.8)(occt-wasm@3.4.0)
       brepkit-wasm:
         specifier: ^2.115.8
         version: 2.115.8
@@ -3040,8 +3040,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  brepjs@18.100.0:
-    resolution: {integrity: sha512-YkJ5v3eLzy89GSWwZI+WpyPd+F+5eT+DfgstoXoFpxKYQJ6SzMUC5hkWQF1tHF3Y+9aFa0OMCBiOjmQt3LoKaA==}
+  brepjs@18.100.1:
+    resolution: {integrity: sha512-IsEXjqCK+3m6/ty91HEH71HIZSBOFr5+EwYw8NqB0OzhzSDZN8Cqtt82w/E9PuZL3t9zIY19ykQl9r+tjs4gGA==}
     engines: {node: '>=24'}
     peerDependencies:
       brepjs-manifold: ^0.1.0
@@ -3655,8 +3655,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatbush@4.6.0:
-    resolution: {integrity: sha512-oeEuOY/SieR/ZxYVx3WGYRBihhaaqPYVqae9fjUflBCq4fm76wSrk/A0zSv3cVhzc600hd3DW3W2IJ+hg8KYhw==}
+  flatbush@4.6.2:
+    resolution: {integrity: sha512-nNT7MFJ58Q4IAm3aYsEg+zgZGpdRcmR1i4U+aa8c+r91jmYZg7FTQwNnIMC0FyBqVZTbClKdAnrJkKkfp1BOvw==}
 
   flatqueue@3.1.0:
     resolution: {integrity: sha512-Ia4qIYrrsEqIRx3c3XhkT+QDLQuUV5ovsr6ah1rIgKT5wclhoGK3lAMS1bWRAWxlx7wtlTBpV7QXB5d9fOSRxA==}
@@ -8424,9 +8424,9 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.100.0(brepkit-wasm@2.115.8)(occt-wasm@3.4.0):
+  brepjs@18.100.1(brepkit-wasm@2.115.8)(occt-wasm@3.4.0):
     dependencies:
-      flatbush: 4.6.0
+      flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
       brepkit-wasm: 2.115.8
@@ -9111,7 +9111,7 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
-  flatbush@4.6.0:
+  flatbush@4.6.2:
     dependencies:
       flatqueue: 3.1.0
 


### PR DESCRIPTION
## Summary

Bumps `brepjs` 18.100.0 → 18.100.1, which includes **brepjs#1579** — the brepkit adapter now forwards `angularTolerance` to `meshEdges`/`meshEdgesAll`.

Combined with **brepkit-wasm 2.115.8** (already on main via #2308, includes brepkit#953), this completes the cross-repo chain: brepkit draft-preview curved edges (rounded corners, lip rims, scoop arcs) now refine with the requested angular tolerance instead of the kernel's fixed ~20° default — closing the edge-smoothness gap vs occt-wasm.

Chain: brepkit#953 (kernel param) → brepjs#1579 (adapter forwards it) → this bump (app picks it up). The app already passes `edgeAngular ≈ 4°` into `meshEdges`, so no app code change is needed.

## Verification

- `tsc -b --noEmit` clean.
- Full test suite green: 14,020 passed / 7 skipped, including the CAD-kernel geometry scenario probes.