### PR TITLE
fix(generation): pass radian angular tolerance to brepkit edge sampling

### DIFF
--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -70,6 +70,7 @@ import {
 import { snapClipLevels } from '@/shared/constants/connectors';
 import { creaseEdges } from './utils';
 import { buildBaseplateSTL } from './baseplateSTL';
+import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
 
 export {
   clearBaseplateCaches,
@@ -151,11 +152,10 @@ export function generateBaseplate(
     const meshResult = mesh(baseplate, { tolerance, angularTolerance });
     // Edge extraction mirrors tessellateStage.ts: analytic B-rep edges on
     // extract-time kernels, dihedral creases on build-time (manifold) kernels.
-    const edgeAngular = angularTolerance * 0.5;
     const edgeVerts: ArrayLike<number> =
       getKernelCapabilities().tessellationModel === 'build-time'
         ? creaseEdges(meshResult)
-        : meshEdges(baseplate, { tolerance, angularTolerance: edgeAngular }).lines;
+        : meshEdges(baseplate, { tolerance, angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD }).lines;
 
     onProgress('base', 1);
 

--- a/src/features/generation/worker/generators/lidOrchestrator.ts
+++ b/src/features/generation/worker/generators/lidOrchestrator.ts
@@ -13,6 +13,7 @@ import type { LidMeshData, ExportFormat } from '../../bridge/types';
 import type { ProgressFn } from './generatorTypes';
 import { buildLid } from './lidBuilder';
 import { toIndexedMeshData, creaseEdges } from './utils';
+import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
 import { computeTessellationTolerances } from './utils/tolerances';
 import { checkCancelled } from './meshUtils';
 import { shouldGenerateLid } from '@/shared/types/bin';
@@ -77,7 +78,7 @@ export function generateLid(
     const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
     const edgeLines = buildTime
       ? creaseEdges(shapeMesh)
-      : meshEdges(solid, { tolerance, angularTolerance: angularTolerance * 0.5 }).lines;
+      : meshEdges(solid, { tolerance, angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD }).lines;
     onProgress?.('merge', 1.0);
 
     return toIndexedMeshData(shapeMesh, edgeLines, originToTag);

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
@@ -16,6 +16,7 @@ import { computeTessellationTolerances } from '../../utils/tolerances';
 import { setLastSolid } from '../../shapeCache';
 import { getSocketMesh, setSocketMesh, socketMeshKey } from '../../socketMeshCache';
 import { keepOuterShell } from '../../utils/outerShell';
+import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
 
 export const tessellateStage: PipelineStage = {
   name: 'merge',
@@ -65,7 +66,6 @@ export const tessellateStage: PipelineStage = {
       dim.maxDimension
     );
 
-    const edgeAngular = angularTolerance * 0.5;
     let shapeMesh = mesh(solid, { tolerance, angularTolerance });
 
     // Build-time kernels (manifold draft) have no B-rep topology, so their
@@ -75,7 +75,7 @@ export const tessellateStage: PipelineStage = {
     const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
     let edgeLines: ArrayLike<number> = buildTime
       ? creaseEdges(shapeMesh)
-      : meshEdges(solid, { tolerance, angularTolerance: edgeAngular }).lines;
+      : meshEdges(solid, { tolerance, angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD }).lines;
 
     // Socket still deferred — the preview path (which skips the expensive
     // socket↔body fuse) or an export whose fuse failed above. Tessellate it
@@ -97,7 +97,8 @@ export const tessellateStage: PipelineStage = {
           const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });
           const socketEdges = buildTime
             ? creaseEdges(socketMesh)
-            : meshEdges(deferredSolid, { tolerance, angularTolerance: edgeAngular }).lines;
+            : meshEdges(deferredSolid, { tolerance, angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD })
+                .lines;
           cached = { mesh: socketMesh, edgeLines: socketEdges };
           if (cacheKey) setSocketMesh(cacheKey, cached);
         }

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -26,6 +26,7 @@ import { buildSTLBufferFromIndexed } from '@/features/generation/export/stlExpor
 import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
 import { toIndexedMeshData } from './utils/mesh';
 import { creaseEdges } from './utils';
+import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
 import { buildTopShape } from './boxBuilder';
 import { generateBin } from './binOrchestrator';
 import { getLastSolid, setLastSolid } from './shapeCache';
@@ -565,7 +566,7 @@ function tessellatePiece(
         ? creaseEdges(shapeMesh)
         : meshEdges(centeredPiece, {
             tolerance: PREVIEW_TOLERANCE,
-            angularTolerance: PREVIEW_ANGULAR_TOLERANCE * 0.5,
+            angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD,
           }).lines;
       meshData = toIndexedMeshData(shapeMesh, edgeLines);
     } finally {

--- a/src/features/generation/worker/generators/toolRackGenerator.ts
+++ b/src/features/generation/worker/generators/toolRackGenerator.ts
@@ -35,6 +35,7 @@ import { COPLANAR_OVERLAP } from './generatorConstants';
 import { buildBaseSocket } from './socketBuilder';
 import { sketch } from './meshUtils';
 import { creaseEdges } from './utils';
+import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
 import { keepOuterShell } from './utils/outerShell';
 import { buildBaseplateSTL } from './baseplateSTL';
 
@@ -184,7 +185,7 @@ export function generateToolRack(
     const edgeVerts: ArrayLike<number> =
       getKernelCapabilities().tessellationModel === 'build-time'
         ? creaseEdges(meshResult)
-        : meshEdges(rack, { tolerance, angularTolerance: angularTolerance * 0.5 }).lines;
+        : meshEdges(rack, { tolerance, angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD }).lines;
     onProgress('base', 1);
     return toIndexedMeshData(meshResult, edgeVerts);
   } finally {

--- a/src/shared/constants/tessellation.test.ts
+++ b/src/shared/constants/tessellation.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { CREASE_ANGLE_DEG, CREASE_ANGLE_RAD, DRAFT_MIN_CIRCULAR_ANGLE_DEG } from './tessellation';
+import {
+  CREASE_ANGLE_DEG,
+  CREASE_ANGLE_RAD,
+  DRAFT_MIN_CIRCULAR_ANGLE_DEG,
+  EDGE_ANGULAR_TOLERANCE_RAD,
+} from './tessellation';
 
 describe('tessellation constants', () => {
   it('exposes the crease threshold in degrees and radians', () => {
@@ -11,5 +16,14 @@ describe('tessellation constants', () => {
     // Invariant: a draft facet step at/above the crease angle would make the
     // worker emit a line at every curve facet (longitudinal wireframe noise).
     expect(DRAFT_MIN_CIRCULAR_ANGLE_DEG).toBeLessThan(CREASE_ANGLE_DEG);
+  });
+
+  it('keeps the edge angular tolerance a small radian value, not a degrees magnitude', () => {
+    // Units guard: brepkit's meshEdges reads this as RADIANS (kernel default
+    // ~0.35 rad ≈ 20°). A degrees-magnitude value (e.g. 4) would read as ~229°
+    // and disable curve refinement — the exact bug this constant fixed. Must
+    // stay well under the kernel default to actually refine curved edges.
+    expect(EDGE_ANGULAR_TOLERANCE_RAD).toBeGreaterThan(0);
+    expect(EDGE_ANGULAR_TOLERANCE_RAD).toBeLessThan(0.35);
   });
 });

--- a/src/shared/constants/tessellation.ts
+++ b/src/shared/constants/tessellation.ts
@@ -19,3 +19,13 @@ export const CREASE_ANGLE_RAD = (CREASE_ANGLE_DEG * Math.PI) / 180;
 /** Manifold draft min circular angle (degrees per facet). Lower = rounder
  *  curves, slower draft. MUST stay below CREASE_ANGLE_DEG (see COUPLING). */
 export const DRAFT_MIN_CIRCULAR_ANGLE_DEG = 20;
+
+/** Angular tolerance (RADIANS) for analytic edge-line sampling via `meshEdges`
+ *  on extract-time kernels. UNITS MATTER: the brepkit kernel reads this as
+ *  radians (its own default is ~0.35 rad ≈ 20°), so a degrees-magnitude value
+ *  (e.g. 4) reads as ~229° and disables curve refinement entirely. ~0.02 rad
+ *  (≈1.1°) keeps rounded corners / lip rims / scoop arcs smooth, ≈ OCCT curve
+ *  density. OCCT ignores this arg (its edges follow the linear tolerance), so
+ *  it only affects brepkit. Build-time (manifold) edges use creaseEdges instead
+ *  and are unaffected. */
+export const EDGE_ANGULAR_TOLERANCE_RAD = 0.02;


### PR DESCRIPTION
## Summary

Completes the brepkit edge-smoothness fix. The kernel (brepkit#953) and adapter (brepjs#1579) plumbing landed, but **it was a no-op in practice** because of a units mismatch:

`meshEdges()` was passed `edgeAngular ≈ 4` — a **degrees**-magnitude value — but brepkit's kernel reads angular tolerance in **radians** (its default ≈ 0.35 rad ≈ 20°). `4 rad ≈ 229°` is *looser* than the default, so brepkit's analytic curved edge-lines never refined.

Introduces `EDGE_ANGULAR_TOLERANCE_RAD = 0.02` (≈1.1°) and applies it at every `meshEdges` call site (whole bin + deferred socket, split pieces, baseplate, tool rack, lid).

## Measured effect (default 2×2 bin, brepkit edge segments)

| | before | after | vs OCCT |
|---|---|---|---|
| plain bin | 696 | **2,160** | 0.10× → **0.32×** (≈ OCCT body density) |

- **OCCT** ignores the arg (edges follow linear tolerance) → unchanged at 6,680.
- **manifold** uses `creaseEdges` (dihedral) → unaffected.
- **scoop bins** unaffected — the scoop boolean splits their curved edges into line segments, so there's nothing for the angular tolerance to refine (pre-existing kernel limitation, not a regression).

## Tests

- New units guard in `tessellation.test.ts`: `EDGE_ANGULAR_TOLERANCE_RAD` must be a small radian value (< 0.35), catching any future degrees-magnitude regression.
- `tsc -b --noEmit` clean; full suite green (14,021 passed).

Caps the chain: brepkit#953 → brepjs#1579 → gridfinity#2308/#2309 → **this** (the actual visible improvement).