### PR TITLE
fix(generation): tighten brepkit edge angular tolerance to 0.01 rad

### DIFF
--- a/src/shared/constants/tessellation.ts
+++ b/src/shared/constants/tessellation.ts
@@ -23,9 +23,9 @@ export const DRAFT_MIN_CIRCULAR_ANGLE_DEG = 20;
 /** Angular tolerance (RADIANS) for analytic edge-line sampling via `meshEdges`
  *  on extract-time kernels. UNITS MATTER: the brepkit kernel reads this as
  *  radians (its own default is ~0.35 rad ≈ 20°), so a degrees-magnitude value
- *  (e.g. 4) reads as ~229° and disables curve refinement entirely. ~0.02 rad
- *  (≈1.1°) keeps rounded corners / lip rims / scoop arcs smooth, ≈ OCCT curve
- *  density. OCCT ignores this arg (its edges follow the linear tolerance), so
- *  it only affects brepkit. Build-time (manifold) edges use creaseEdges instead
- *  and are unaffected. */
-export const EDGE_ANGULAR_TOLERANCE_RAD = 0.02;
+ *  (e.g. 4) reads as ~229° and disables curve refinement entirely. ~0.01 rad
+ *  (≈0.57°) keeps rounded corners / lip rims / scoop arcs smooth, approaching
+ *  OCCT curve density. OCCT ignores this arg (its edges follow the linear
+ *  tolerance), so it only affects brepkit. Build-time (manifold) edges use
+ *  creaseEdges instead and are unaffected. */
+export const EDGE_ANGULAR_TOLERANCE_RAD = 0.01;


### PR DESCRIPTION
## Summary

Tightens `EDGE_ANGULAR_TOLERANCE_RAD` 0.02 → 0.01 rad (≈0.57°) for closer OCCT parity on brepkit curved edge-lines.

## Measured effect (default 2×2 bin, brepkit edge segments)

| angular tol | brepkit segments | vs OCCT (6,680) |
|---|---|---|
| pre-fix (~229°, no-op) | 696 | 0.10× |
| 0.02 rad | 2,160 | 0.32× |
| **0.01 rad (this PR)** | **3,740** | **0.56×** |

OCCT is unchanged (it ignores `angularTolerance`; its edges follow the linear tolerance). manifold uses `creaseEdges` and is unaffected. Trade-off: ~1.7× more edge-line segments in the brepkit preview wireframe vs 0.02.

The units guard in `tessellation.test.ts` (`< 0.35 rad`) still holds.