### PR TITLE
chore(deps): stop auto-bumping playwright to keep chromium cache stable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,15 @@ updates:
       # brepjs upgrades are coupled to the brepkit kernel investigation —
       # always pin manually, never auto-bump
       - dependency-name: 'brepjs'
+      # Each Playwright version pins one exact Chromium revision, so every
+      # minor/patch bump forces a fresh ~120MB browser download on the next
+      # `playwright install`. Bump manually so the browser cache is stable.
+      - dependency-name: 'playwright'
+        update-types:
+          ['version-update:semver-minor', 'version-update:semver-patch']
+      - dependency-name: '@playwright/*'
+        update-types:
+          ['version-update:semver-minor', 'version-update:semver-patch']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## Problem

Playwright re-downloads Chromium seemingly every time it's used. Root cause: **each Playwright release pins one exact Chromium revision** (1.60.0 → `chromium-1223`, 1.61.0 → `chromium-1228`), and the browser cache is keyed by that revision number. Dependabot's weekly schedule was auto-bumping Playwright (`1.57 → 1.58 → 1.59 → 1.60 → 1.61` in recent history), so the first `playwright install` after each bump found only the *old* revision on disk and pulled a fresh ~120MB browser.

## Fix

Add `playwright` and `@playwright/*` to Dependabot's `ignore` list for **minor/patch** updates, mirroring the existing `brepjs` "pin manually" precedent. Major bumps still surface a PR for manual review. `@axe-core/playwright` is left alone — it carries no Chromium revision.

With Playwright's version held steady between manual bumps, the installed Chromium keeps satisfying every run, so the recurring re-downloads stop.

## Notes

- Dependabot config only takes effect once merged to the default branch.
- Any currently-open Playwright bump PR won't auto-close; close it manually.