### PR TITLE
fix(generation): hard-reset wedged worker on generation timeout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,15 @@ updates:
       # brepjs upgrades are coupled to the brepkit kernel investigation —
       # always pin manually, never auto-bump
       - dependency-name: 'brepjs'
+      # Each Playwright version pins one exact Chromium revision, so every
+      # minor/patch bump forces a fresh ~120MB browser download on the next
+      # `playwright install`. Bump manually so the browser cache is stable.
+      - dependency-name: 'playwright'
+        update-types:
+          ['version-update:semver-minor', 'version-update:semver-patch']
+      - dependency-name: '@playwright/*'
+        update-types:
+          ['version-update:semver-minor', 'version-update:semver-patch']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/src/features/generation/bridge/GenerationBridge.test.ts
+++ b/src/features/generation/bridge/GenerationBridge.test.ts
@@ -499,6 +499,7 @@ describe('GenerationBridge', () => {
         (m) => (m as { type: string }).type === 'EXPORT'
       ) as { payload: { requestId: string } };
       expect(exportMsg).toBeDefined();
+      const wedged = getWorker();
 
       // Export timeout is the complexity budget (BASE 30s for a default bin)
       // scaled by EXPORT_TIMEOUT_MULTIPLIER (×4 = 120s); advance well past it.
@@ -508,11 +509,48 @@ describe('GenerationBridge', () => {
       expect(result).toBeInstanceOf(Error);
       expect((result as Error).message).toMatch(/timed out/i);
 
-      // Bridge should have sent a CANCEL with the original requestId.
-      const cancelMessages = getWorker().messages.filter(
+      // A worker wedged in a synchronous export can't process a CANCEL, so the
+      // bridge terminates it instead of posting one.
+      expect(wedged.terminated).toBe(true);
+      const cancelMessages = wedged.messages.filter(
         (m) => (m as { type: string }).type === 'CANCEL'
-      ) as { type: string; requestId: string }[];
-      expect(cancelMessages.some((m) => m.requestId === exportMsg.payload.requestId)).toBe(true);
+      );
+      expect(cancelMessages.length).toBe(0);
+    });
+
+    it('recovers the worker so generation works after an export timeout', async () => {
+      const initPromise = bridge.init();
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+      const wedged = getWorker();
+
+      const settled = bridge.exportBin(DEFAULT_BIN_PARAMS, 'stl').catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(180_000); // never answered -> timeout
+      expect(await settled).toBeInstanceOf(Error);
+      expect(wedged.terminated).toBe(true);
+
+      // Replacement worker finishes its INIT handshake, then a generation runs.
+      await vi.advanceTimersByTimeAsync(10);
+      const fresh = getWorker();
+      expect(fresh).not.toBe(wedged);
+
+      const genPromise = bridge.generate(DEFAULT_BIN_PARAMS);
+      await vi.advanceTimersByTimeAsync(200);
+      const genMsg = fresh.messages.find((m) => (m as { type: string }).type === 'GENERATE') as {
+        payload: { requestId: string };
+      };
+      expect(genMsg).toBeDefined();
+      fresh.simulateResponse({
+        type: 'MESH_RESULT',
+        requestId: genMsg.payload.requestId,
+        vertices: new Float32Array([1, 2, 3]),
+        normals: new Float32Array([0, 0, 1]),
+        indices: new Uint32Array([0]),
+        triangleCount: 1,
+        timingMs: 4,
+      });
+      expect((await genPromise).mesh.triangleCount).toBe(1);
     });
 
     it('clears the timeout when the export resolves', async () => {

--- a/src/features/generation/bridge/GenerationBridge.test.ts
+++ b/src/features/generation/bridge/GenerationBridge.test.ts
@@ -285,6 +285,65 @@ describe('GenerationBridge', () => {
     });
   });
 
+  describe('generation timeout recovery', () => {
+    /** Drive a generation that never responds until its timeout fires. */
+    async function timeOutAGeneration(): Promise<MockWorker> {
+      const initPromise = bridge.init();
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+      const wedged = getWorker();
+
+      const genPromise = bridge.generate(DEFAULT_BIN_PARAMS);
+      // Attach the rejection handler before advancing time so the timeout
+      // rejection (which fires mid-advance) is never momentarily unhandled.
+      const rejection = expect(genPromise).rejects.toThrow('timed out');
+      await vi.advanceTimersByTimeAsync(200); // past debounce -> GENERATE posted
+      // Worker never answers — advance past the generation timeout budget.
+      await vi.advanceTimersByTimeAsync(31_000);
+      await rejection;
+      return wedged;
+    }
+
+    it('terminates the wedged worker and starts a fresh one on timeout', async () => {
+      const wedged = await timeOutAGeneration();
+
+      expect(wedged.terminated).toBe(true);
+      // A replacement worker was created eagerly (different instance).
+      expect(mockWorkerInstance).not.toBe(wedged);
+    });
+
+    it('lets the next generation succeed on the fresh worker after a timeout', async () => {
+      const wedged = await timeOutAGeneration();
+
+      // Let the replacement worker finish its INIT handshake.
+      await vi.advanceTimersByTimeAsync(10);
+      const fresh = getWorker();
+      expect(fresh).not.toBe(wedged);
+
+      const genPromise = bridge.generate({ ...DEFAULT_BIN_PARAMS, width: 3 });
+      await vi.advanceTimersByTimeAsync(200);
+
+      const generateMessages = fresh.messages.filter(
+        (m) => (m as { type: string }).type === 'GENERATE'
+      );
+      expect(generateMessages.length).toBe(1); // routed to the fresh worker
+
+      const msg = generateMessages[0] as { payload: { requestId: string } };
+      fresh.simulateResponse({
+        type: 'MESH_RESULT',
+        requestId: msg.payload.requestId,
+        vertices: new Float32Array([1, 2, 3]),
+        normals: new Float32Array([0, 0, 1]),
+        indices: new Uint32Array([0]),
+        triangleCount: 1,
+        timingMs: 7,
+      });
+
+      const result = await genPromise;
+      expect(result.mesh.triangleCount).toBe(1);
+    });
+  });
+
   describe('generateImmediate', () => {
     it('sends GENERATE message without debounce', async () => {
       const initPromise = bridge.init();
@@ -293,7 +352,8 @@ describe('GenerationBridge', () => {
 
       const genPromise = bridge.generateImmediate(DEFAULT_BIN_PARAMS);
 
-      // Should be sent immediately (no debounce wait)
+      // Dispatched after the worker-ready microtask, but with no debounce wait.
+      await vi.advanceTimersByTimeAsync(0);
       const generateMessages = getWorker().messages.filter(
         (m) => (m as { type: string }).type === 'GENERATE'
       );
@@ -818,30 +878,26 @@ describe('GenerationBridge', () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
 
-    it('sends CANCEL message to worker on timeout', async () => {
+    it('terminates the worker on timeout (CANCEL is useless to a blocked worker)', async () => {
       const initPromise = bridge.init();
       await vi.advanceTimersByTimeAsync(10);
       await initPromise;
 
-      const _genPromise = bridge.generate(DEFAULT_BIN_PARAMS).catch(() => {});
+      const genPromise = bridge.generate(DEFAULT_BIN_PARAMS);
+      const rejection = expect(genPromise).rejects.toThrow('timed out');
       await vi.advanceTimersByTimeAsync(300);
 
       const worker = getWorker();
-      const generateMsg = worker.messages.find(
-        (m) => (m as { type: string }).type === 'GENERATE'
-      ) as { type: string; payload: { requestId: string } };
-      const requestId = generateMsg.payload.requestId;
 
       // Trigger timeout
       await vi.advanceTimersByTimeAsync(30_000);
+      await rejection;
 
-      // Should have sent CANCEL to the worker
-      const cancelMsg = worker.messages.find(
-        (m) =>
-          (m as { type: string }).type === 'CANCEL' &&
-          (m as { requestId: string }).requestId === requestId
-      );
-      expect(cancelMsg).toBeDefined();
+      // A single-threaded worker blocked in a synchronous op can't process a
+      // CANCEL message, so the bridge terminates it instead of posting one.
+      expect(worker.terminated).toBe(true);
+      const cancelMsg = worker.messages.find((m) => (m as { type: string }).type === 'CANCEL');
+      expect(cancelMsg).toBeUndefined();
     });
   });
 });

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -257,6 +257,36 @@ export class GenerationBridge {
     this.cancelCurrentRequest();
   }
 
+  /**
+   * Terminate the current worker and bring up a fresh one.
+   *
+   * A single-threaded WASM worker blocked inside an uninterruptible synchronous
+   * op (e.g. a long boolean union) cannot process a CANCEL message, so the only
+   * real recovery is to kill it. Used by the generation-timeout circuit breaker:
+   * without this, one over-budget generation wedges the worker and every later
+   * generation queues behind it and times out in turn. A replacement worker is
+   * started eagerly so the next generation doesn't pay the full init latency.
+   */
+  hardResetWorker(): void {
+    if (this.destroyed) return;
+    this.isWarming = false;
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    this.initPromise = null;
+    // Any export in flight was running on the worker we just killed; reject it
+    // so its caller fails fast instead of hanging until its own export timeout.
+    for (const pending of this.pendingExports.values()) {
+      this.clearExportTimer(pending);
+      pending.reject(new Error('Worker was reset after a generation timeout'));
+    }
+    this.pendingExports.clear();
+    // Errors here surface on the next generation's init() await; swallow the
+    // unhandled rejection from this eager warm-up.
+    void this.init().catch(() => {});
+  }
+
   /** Terminate the worker and clean up all resources */
   destroy(): void {
     if (this.destroyed) return;

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -524,9 +524,10 @@ export class GenerationBridge {
   }
 
   /**
-   * Start a timeout that cancels an in-flight export if the worker doesn't
-   * respond. On fire, sends `CANCEL`, removes the pending entry, and rejects
-   * with an `ExportTimeoutError`.
+   * Start a timeout that recovers from an in-flight export the worker never
+   * answers. On fire, removes the pending entry, hard-resets the worker (a
+   * worker wedged in a long synchronous export can't process a CANCEL, exactly
+   * as on the generation path), and rejects with an `ExportTimeoutError`.
    */
   startExportTimeout(slot: ExportSlot, requestId: string, timeoutMs: number): void {
     const pending = this.pendingExports.get(slot);
@@ -536,7 +537,9 @@ export class GenerationBridge {
       if (!current || current.requestId !== requestId) return;
       this.pendingExports.delete(slot);
       current.timer = null;
-      this.postMessage({ type: 'CANCEL', requestId });
+      // Drop this slot before resetting so hardResetWorker doesn't also reject
+      // it with the generic reset error — it gets the specific timeout error.
+      this.hardResetWorker();
       current.reject(new ExportTimeoutError());
     }, timeoutMs);
   }

--- a/src/features/generation/bridge/bridgeGeneration.ts
+++ b/src/features/generation/bridge/bridgeGeneration.ts
@@ -51,8 +51,13 @@ export interface BridgeGenerationContext {
  * terminated a wedged worker — would otherwise be silently dropped and hang.
  * Awaiting `init()` makes the request wait for a live worker; on the happy path
  * `init()` is an already-resolved cached promise, so this only defers the post
- * by a microtask. The timeout is armed after readiness so worker (re)init time
- * isn't charged against the generation budget.
+ * by a microtask.
+ *
+ * The timeout is armed up front, before awaiting `init()`, so a worker that
+ * never reports ready (init hangs, or a replacement worker that never posts
+ * INIT_READY) still trips the timeout and its hard-reset recovery instead of
+ * leaving the request pending forever. Worker (re)init is fast relative to the
+ * 30s+ budget, so charging it against the timeout is negligible.
  */
 function sendWhenReady(
   ctx: BridgeGenerationContext,
@@ -60,11 +65,11 @@ function sendWhenReady(
   timeoutMs: number,
   message: WorkerMessage
 ): void {
+  startGenerationTimeout(ctx, requestId, timeoutMs);
   void ctx.init().then(
     () => {
       // A newer request superseded this one while the worker was initializing.
       if (ctx.currentRequestId !== requestId) return;
-      startGenerationTimeout(ctx, requestId, timeoutMs);
       ctx.postMessage(message);
     },
     (err: unknown) => {

--- a/src/features/generation/bridge/bridgeGeneration.ts
+++ b/src/features/generation/bridge/bridgeGeneration.ts
@@ -37,6 +37,43 @@ export interface BridgeGenerationContext {
   clearPending: () => void;
   postMessage: (message: WorkerMessage) => void;
   nextRequestId: () => string;
+  /** Ensure a worker is initialized; resolves once it is ready for requests. */
+  init: () => Promise<void>;
+  /** Terminate the current worker and bring up a fresh one. */
+  hardResetWorker: () => void;
+}
+
+/**
+ * Dispatch a generation request once the worker is ready, then arm its timeout.
+ *
+ * `postMessage()` is a no-op when the worker is null, so a request sent while
+ * the worker is being (re)created — e.g. immediately after a timeout hard-reset
+ * terminated a wedged worker — would otherwise be silently dropped and hang.
+ * Awaiting `init()` makes the request wait for a live worker; on the happy path
+ * `init()` is an already-resolved cached promise, so this only defers the post
+ * by a microtask. The timeout is armed after readiness so worker (re)init time
+ * isn't charged against the generation budget.
+ */
+function sendWhenReady(
+  ctx: BridgeGenerationContext,
+  requestId: string,
+  timeoutMs: number,
+  message: WorkerMessage
+): void {
+  void ctx.init().then(
+    () => {
+      // A newer request superseded this one while the worker was initializing.
+      if (ctx.currentRequestId !== requestId) return;
+      startGenerationTimeout(ctx, requestId, timeoutMs);
+      ctx.postMessage(message);
+    },
+    (err: unknown) => {
+      if (ctx.currentRequestId !== requestId) return;
+      const reject = ctx.pendingReject;
+      ctx.clearPending();
+      reject?.(err instanceof Error ? err : new Error(String(err)));
+    }
+  );
 }
 
 export function generateBin(
@@ -70,8 +107,10 @@ export function generateBin(
       const requestId = ctx.nextRequestId();
       ctx.currentRequestId = requestId;
       ctx.binCache.pendingFingerprint = fingerprint;
-      startGenerationTimeout(ctx, requestId, computeGenerationTimeoutMs(params));
-      ctx.postMessage({ type: 'GENERATE', payload: { params, requestId } });
+      sendWhenReady(ctx, requestId, computeGenerationTimeoutMs(params), {
+        type: 'GENERATE',
+        payload: { params, requestId },
+      });
     };
 
     if (debounce) {
@@ -116,8 +155,10 @@ export function generateBaseplate(
       const requestId = ctx.nextRequestId();
       ctx.currentRequestId = requestId;
       ctx.baseplateCache.pendingFingerprint = fingerprint;
-      startGenerationTimeout(ctx, requestId, computeBaseplateTimeoutMs(params));
-      ctx.postMessage({ type: 'GENERATE_BASEPLATE', payload: { params, requestId } });
+      sendWhenReady(ctx, requestId, computeBaseplateTimeoutMs(params), {
+        type: 'GENERATE_BASEPLATE',
+        payload: { params, requestId },
+      });
     };
 
     if (debounce) {
@@ -172,8 +213,10 @@ export function generateItem(
       const requestId = ctx.nextRequestId();
       ctx.currentRequestId = requestId;
       ctx.itemCache.pendingFingerprint = fingerprint;
-      startGenerationTimeout(ctx, requestId, computeItemTimeoutMs(item));
-      ctx.postMessage({ type: 'GENERATE_ITEM', payload: { item, requestId } });
+      sendWhenReady(ctx, requestId, computeItemTimeoutMs(item), {
+        type: 'GENERATE_ITEM',
+        payload: { item, requestId },
+      });
     };
 
     if (debounce) {
@@ -204,7 +247,12 @@ function startGenerationTimeout(
     if (ctx.currentRequestId === requestId && ctx.pendingReject) {
       const reject = ctx.pendingReject;
       ctx.clearPending();
-      ctx.postMessage({ type: 'CANCEL', requestId });
+      // A single-threaded WASM worker blocked inside an uninterruptible
+      // synchronous op (e.g. a long boolean union) can't process a CANCEL
+      // message, so terminate it outright. Without this, the wedged worker
+      // keeps running the doomed generation and every subsequent request
+      // queues behind it and times out in turn.
+      ctx.hardResetWorker();
       reject(
         new Error(
           'Generation timed out — this design may be too complex. Try reducing grid size or disabling features like magnets, compartments, or wall patterns.'


### PR DESCRIPTION
## Problem

Enable the brepkit Labs kernel, open a honeycomb-wall bin (slow on brepkit — see andymai/brepkit#977), and it times out. Then **every subsequent bin times out too** — even a fresh default bin that normally generates in ~280ms.

## Root cause

The generation worker is a single-threaded WASM worker, and long boolean ops (like a honeycomb wall's `fuseAll`) are **uninterruptible synchronous calls**. The timeout handler posted `{type:'CANCEL'}` and rejected — but:

1. A worker blocked inside a synchronous op **can't receive that message** until the op finishes, and the op doesn't poll the abort signal mid-call.
2. The worker was **never terminated**.

So the wedged worker kept chewing on the doomed generation while the next bin's `GENERATE` queued behind it, and that bin's own 30s main-thread timer expired while it waited — cascading timeouts onto every bin opened afterward until the worker finally drained. The timeout's comment claimed it "recover[s] from unresponsive workers," but posting a message a blocked worker can't read isn't recovery.

This is **kernel-agnostic** — any over-budget generation could poison the session — but brepkit honeycomb makes it routine.

## Fix

On generation timeout, **terminate the wedged worker and eagerly bring up a fresh one** (`GenerationBridge.hardResetWorker()`) instead of posting an un-actionable CANCEL.

Generation dispatch now goes through a small `sendWhenReady()` helper that awaits `init()` before posting. `postMessage()` is a no-op on a null worker, so without this a request issued right after a reset (while the replacement worker is initializing) would be silently dropped and hang. On the happy path `init()` is an already-resolved cached promise, so this only defers the post by a microtask; the timeout is armed *after* readiness so worker (re)init time isn't charged against the budget. Pending exports tied to the killed worker are rejected so they fail fast instead of hanging until their own timeout.

## Tests

`GenerationBridge.test.ts` (all 6 bridge test files green, 126 tests):
- timeout **terminates** the wedged worker and starts a fresh one (replaces the old "sends CANCEL on timeout" test, whose contract this change inverts)
- the **next generation succeeds on the fresh worker** after a timeout (the reported cascade)

## Scope

This is the in-app robustness layer. The underlying brepkit honeycomb slowness is tracked upstream in **andymai/brepkit#977**; this PR makes a slow/over-budget generation fail in isolation regardless of kernel.