### PR TITLE
chore(deps): bump brepkit-wasm to 2.119.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@vercel/blob": "^2.4.0",
     "arctic": "^3.7.0",
     "brepjs": "18.100.3",
-    "brepkit-wasm": "^2.116.1",
+    "brepkit-wasm": "^2.119.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,10 +69,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.100.3
-        version: 18.100.3(brepkit-wasm@2.116.1)(occt-wasm@3.4.0)
+        version: 18.100.3(brepkit-wasm@2.119.2)(occt-wasm@3.4.0)
       brepkit-wasm:
-        specifier: ^2.116.1
-        version: 2.116.1
+        specifier: ^2.119.2
+        version: 2.119.2
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3046,8 +3046,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@2.116.1:
-    resolution: {integrity: sha512-qQdbVtLI21tbvPSIhbvW9L0Kfw01X16RpQ6Cn7kDFCYt8OkpSGPAJA8pHPT0qpeAqS7ws++6TeTbo5YYn4UvvA==}
+  brepkit-wasm@2.119.2:
+    resolution: {integrity: sha512-oRvySc/36rIKY2hsW5Q2KZtQTHY9ttCmpNwzFb0BAWPJoVWhZZfHzs80mh2/xvgbmrMeAwZ1+L+DWj5bw2IWMQ==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -8407,15 +8407,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.100.3(brepkit-wasm@2.116.1)(occt-wasm@3.4.0):
+  brepjs@18.100.3(brepkit-wasm@2.119.2)(occt-wasm@3.4.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 2.116.1
+      brepkit-wasm: 2.119.2
       occt-wasm: 3.4.0
 
-  brepkit-wasm@2.116.1: {}
+  brepkit-wasm@2.119.2: {}
 
   browserslist@4.28.2:
     dependencies:


### PR DESCRIPTION
Routine kernel update: brepkit-wasm `^2.116.1` → `^2.119.2` (picks up 2.117–2.119, including the `fuseAll` disjoint-partition perf fix, brepkit#982).

## Honest scope note
This does **not** fix the brepkit-kernel honeycomb timeout, despite #982 landing in this range. Verified end-to-end: honeycomb generation time is byte-identical before/after (5×5 still ~14.5s). The eco-wall path builds the hex pattern with `compound()` + `cut` and deliberately avoids `fuseAll` (what #982 optimized). The real bottleneck is an **O(N²) many-holes-per-face cut** in the GFA, now tracked upstream in **andymai/brepkit#987** with a full repro + scaling/phase data.

So this is a plain dependency refresh that keeps us current and carries the fuseAll improvement for other callers (split-bin/feet disjoint unions) — not a behavior change for the default occt kernel.

## Verification
- Generation snapshot suite: **146 files / 1611 tests pass, 0 failures, no snapshot drift** — confirms no output change on the production occt kernel.
- occt-wasm stays pinned at 3.4.0; brepjs 18.100.3 peer range (`^2.x`) satisfied.