### PR TITLE
fix(bin-designer): carry compartment labels on grid resize + read top-left first

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
+import { useToastStore } from '@/core/store/toast';
 import { DESIGNER_CONSTRAINTS, WALL_THICKNESS_OPTIONS } from '@/features/bin-designer/constants';
 import { Button, Stepper, InfoIcon } from '@/design-system';
 import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
@@ -108,6 +109,8 @@ export function CompartmentEditor() {
   // on-grid hit-target overlay hidden until the user enables editing so dense
   // grids stay legible (issue #2044).
   const angledDividersEnabled = useSettingsStore((s) => s.settings.angledDividersEnabled);
+
+  const addToast = useToastStore((s) => s.addToast);
 
   const { innerW: interiorW, innerD: interiorD } = getInteriorDims({
     width,
@@ -323,12 +326,28 @@ export function CompartmentEditor() {
     setSelection(new Set());
   }, [isDragging, selection, cols, cells, mergeCells, splitCompartment, compartmentCellCounts]);
 
-  const handleColsChange = useCallback(
-    (newCols: number) => {
-      setCompartmentGrid(newCols, rows);
+  // All grid-dimension changes funnel through here so the "N labels cleared"
+  // warning (#2337) is shown consistently and the selection is reset once.
+  const applyGrid = useCallback(
+    (newCols: number, newRows: number) => {
+      const droppedLabels = setCompartmentGrid(newCols, newRows);
+      if (droppedLabels > 0) {
+        addToast({
+          message: t('binDesigner.compartmentEditor.labelsCleared', { count: droppedLabels }),
+          type: 'info',
+          duration: 4000,
+        });
+      }
       setSelection(new Set());
     },
-    [rows, setCompartmentGrid]
+    [setCompartmentGrid, addToast, t]
+  );
+
+  const handleColsChange = useCallback(
+    (newCols: number) => {
+      applyGrid(newCols, rows);
+    },
+    [rows, applyGrid]
   );
 
   const handleColsStep = useCallback(
@@ -338,18 +357,16 @@ export function CompartmentEditor() {
         DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID,
         Math.max(DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID, next)
       );
-      setCompartmentGrid(clamped, rows);
-      setSelection(new Set());
+      applyGrid(clamped, rows);
     },
-    [cols, rows, setCompartmentGrid]
+    [cols, rows, applyGrid]
   );
 
   const handleRowsChange = useCallback(
     (newRows: number) => {
-      setCompartmentGrid(cols, newRows);
-      setSelection(new Set());
+      applyGrid(cols, newRows);
     },
-    [cols, setCompartmentGrid]
+    [cols, applyGrid]
   );
 
   const handleRowsStep = useCallback(
@@ -359,10 +376,9 @@ export function CompartmentEditor() {
         DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID,
         Math.max(DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID, next)
       );
-      setCompartmentGrid(cols, clamped);
-      setSelection(new Set());
+      applyGrid(cols, clamped);
     },
-    [cols, rows, setCompartmentGrid]
+    [cols, rows, applyGrid]
   );
 
   // Size-led entry (fit-guarantee): typing a minimum opening picks the largest
@@ -378,7 +394,7 @@ export function CompartmentEditor() {
         interiorW,
         Math.max(DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE, target)
       );
-      setCompartmentGrid(
+      applyGrid(
         solveCountForMinCavity(
           interiorW,
           thickness,
@@ -388,9 +404,8 @@ export function CompartmentEditor() {
         ),
         rows
       );
-      setSelection(new Set());
     },
-    [interiorW, thickness, rows, setCompartmentGrid]
+    [interiorW, thickness, rows, applyGrid]
   );
 
   const applyTargetDepth = useCallback(
@@ -399,7 +414,7 @@ export function CompartmentEditor() {
         interiorD,
         Math.max(DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_SIZE, target)
       );
-      setCompartmentGrid(
+      applyGrid(
         cols,
         solveCountForMinCavity(
           interiorD,
@@ -409,9 +424,8 @@ export function CompartmentEditor() {
           DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID
         )
       );
-      setSelection(new Set());
     },
-    [interiorD, thickness, cols, setCompartmentGrid]
+    [interiorD, thickness, cols, applyGrid]
   );
 
   const handleThicknessChange = useCallback(
@@ -422,9 +436,8 @@ export function CompartmentEditor() {
   );
 
   const handleReset = useCallback(() => {
-    setCompartmentGrid(cols, rows);
-    setSelection(new Set());
-  }, [cols, rows, setCompartmentGrid]);
+    applyGrid(cols, rows);
+  }, [cols, rows, applyGrid]);
 
   const hasMergedCompartments = compartmentCount < cols * rows;
 

--- a/src/features/bin-designer/components/CompartmentEditor/useCompartmentLabeling.test.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useCompartmentLabeling.test.ts
@@ -39,12 +39,14 @@ describe('useCompartmentLabeling', () => {
   });
 
   describe('mode + selection', () => {
-    it('entering label mode selects the first compartment', () => {
+    it('entering label mode selects the first compartment (visual top-left)', () => {
+      // 3x2 grid: data rows [0,1,2] (bottom) and [3,4,5] (top). Reading order is
+      // top-left first, so the first compartment is id 3 (#2338).
       const { result } = render(createUniformGrid(3, 2, 1.2));
       expect(result.current.editingId).toBeNull();
       act(() => result.current.setLabelMode(true));
       expect(result.current.labelMode).toBe(true);
-      expect(result.current.editingId).toBe(0);
+      expect(result.current.editingId).toBe(3);
     });
 
     it('refuses to enter label mode when labeling is unavailable', () => {
@@ -64,37 +66,39 @@ describe('useCompartmentLabeling', () => {
   });
 
   describe('display numbering', () => {
-    it('maps compartment ids to 1-based display order', () => {
+    it('maps compartment ids to 1-based display order (visual top-left first)', () => {
       const { result } = render(createUniformGrid(3, 2, 1.2));
-      expect(result.current.orderedIds).toEqual([0, 1, 2, 3, 4, 5]);
-      expect(result.current.displayNumberOf(0)).toBe(1);
-      expect(result.current.displayNumberOf(5)).toBe(6);
+      // Top row [3,4,5] reads before the bottom row [0,1,2] (#2338).
+      expect(result.current.orderedIds).toEqual([3, 4, 5, 0, 1, 2]);
+      expect(result.current.displayNumberOf(3)).toBe(1);
+      expect(result.current.displayNumberOf(2)).toBe(6);
     });
   });
 
   describe('navigation', () => {
     it('advance walks forward and clamps at the last compartment', () => {
+      // Reading order is [3,4,5,0,1,2]: first = id 3, last = id 2.
       const { result } = render(createUniformGrid(3, 2, 1.2));
       act(() => result.current.setLabelMode(true));
       act(() => result.current.advance('next'));
-      expect(result.current.editingId).toBe(1);
-      act(() => result.current.selectCompartment(5));
+      expect(result.current.editingId).toBe(4);
+      act(() => result.current.selectCompartment(2));
       act(() => result.current.advance('next'));
-      expect(result.current.editingId).toBe(5); // clamped
+      expect(result.current.editingId).toBe(2); // clamped at last
     });
 
     it('advance prev clamps at the first compartment', () => {
       const { result } = render(createUniformGrid(3, 2, 1.2));
       act(() => result.current.setLabelMode(true));
       act(() => result.current.advance('prev'));
-      expect(result.current.editingId).toBe(0); // clamped
+      expect(result.current.editingId).toBe(3); // clamped at first (top-left)
     });
 
     it('moveByGrid steps right and (visually) up to the adjacent compartment', () => {
       const { result } = render(createUniformGrid(3, 2, 1.2));
-      act(() => result.current.setLabelMode(true)); // id 0 at (col0,row0)
+      act(() => result.current.setLabelMode(true)); // first = id 3 at (col0,row1)
       act(() => result.current.moveByGrid('right'));
-      expect(result.current.editingId).toBe(1); // (col1,row0)
+      expect(result.current.editingId).toBe(4); // (col1,row1)
       act(() => result.current.selectCompartment(0));
       act(() => result.current.moveByGrid('up'));
       expect(result.current.editingId).toBe(3); // (col0,row1) — visual up = higher data row
@@ -102,9 +106,9 @@ describe('useCompartmentLabeling', () => {
 
     it('moveByGrid past the grid edge is a no-op', () => {
       const { result } = render(createUniformGrid(3, 2, 1.2));
-      act(() => result.current.setLabelMode(true));
+      act(() => result.current.setLabelMode(true)); // first = id 3 at (col0,row1)
       act(() => result.current.moveByGrid('left')); // already at col 0
-      expect(result.current.editingId).toBe(0);
+      expect(result.current.editingId).toBe(3);
     });
   });
 
@@ -127,9 +131,10 @@ describe('useCompartmentLabeling', () => {
       act(() => result.current.setLabelMode(true));
       act(() => result.current.selectCompartment(5));
       expect(result.current.editingId).toBe(5);
-      // Shrink the grid so id 5 no longer exists.
+      // Shrink the grid so id 5 no longer exists. The 2x2 reading order is
+      // [2,3,0,1], so the fallback is the top-left id 2.
       rerender({ c: createUniformGrid(2, 2, 1.2), s: 'standard' });
-      expect(result.current.editingId).toBe(0);
+      expect(result.current.editingId).toBe(2);
     });
   });
 });

--- a/src/features/bin-designer/components/CompartmentEditor/useCompartmentLabeling.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useCompartmentLabeling.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import {
-  getCompartmentIds,
+  getCompartmentReadingOrder,
   getCompartmentBounds,
   cellIndex,
 } from '@/features/bin-designer/utils/compartments';
@@ -53,7 +53,7 @@ export function useCompartmentLabeling(
 
   const canLabel = style === 'standard' && compartmentCount > 1;
 
-  const orderedIds = useMemo(() => getCompartmentIds(compartments), [compartments]);
+  const orderedIds = useMemo(() => getCompartmentReadingOrder(compartments), [compartments]);
 
   const displayNumbers = useMemo(() => {
     const map = new Map<number, number>();

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -5,7 +5,7 @@ import { DESIGNER_CONSTRAINTS } from '../../../constants';
 import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
 import { useTranslation } from '@/i18n';
 import { getFeatureStatus } from '@/shared/constraints';
-import { getCompartmentBounds, getCompartmentIds } from '../../../utils/compartments';
+import { getCompartmentBounds, getCompartmentReadingOrder } from '../../../utils/compartments';
 import type {
   LabelTabAlignment,
   LabelTabEdges,
@@ -367,7 +367,7 @@ export function useLabelTabsSection() {
   );
 
   const compartmentTextRows = useMemo(() => {
-    const ids = getCompartmentIds(compartments);
+    const ids = getCompartmentReadingOrder(compartments);
     const texts = compartments.compartmentTexts ?? [];
     // `displayNumber` is the source of truth for what the user sees AND what
     // the aria-label announces — keep them in lockstep so a future change

--- a/src/features/bin-designer/store/designer.scenario.compartments.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.compartments.test.ts
@@ -756,16 +756,33 @@ describe('DesignerStore - compartment actions', () => {
       expect(useDesignerStore.getState().history.past.length).toBe(beforeHistoryLength);
     });
 
-    it('is cleared when the grid is resized (avoids ghost text on regenerated IDs)', () => {
+    it('carries labels by position when the grid grows (best-effort, #2337)', () => {
       const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
       setCompartmentGrid(2, 2);
-      setCompartmentText(0, 'SCREWS');
-      setCompartmentText(3, 'WASHERS');
+      setCompartmentText(0, 'SCREWS'); // (col0,row0)
+      setCompartmentText(3, 'WASHERS'); // (col1,row1)
 
-      setCompartmentGrid(3, 3);
+      // Growing to 3x3 keeps both anchors in-bounds → nothing dropped.
+      const dropped = useDesignerStore.getState().setCompartmentGrid(3, 3);
 
       const { params } = useDesignerStore.getState();
-      expect(params.compartments.compartmentTexts).toBeUndefined();
+      expect(dropped).toBe(0);
+      expect(params.compartments.compartmentTexts?.[0]).toBe('SCREWS'); // (col0,row0) → id 0
+      expect(params.compartments.compartmentTexts?.[4]).toBe('WASHERS'); // (col1,row1) → id 4
+    });
+
+    it('reports labels dropped when the grid shrinks past their position (#2337)', () => {
+      const { setCompartmentGrid, setCompartmentText } = useDesignerStore.getState();
+      setCompartmentGrid(3, 1);
+      setCompartmentText(0, 'KEEP'); // (col0,row0)
+      setCompartmentText(2, 'LOSE'); // (col2,row0) — falls outside a 2-col grid
+
+      const dropped = useDesignerStore.getState().setCompartmentGrid(2, 1);
+
+      const { params } = useDesignerStore.getState();
+      expect(dropped).toBe(1);
+      expect(params.compartments.compartmentTexts?.[0]).toBe('KEEP');
+      expect(params.compartments.compartmentTexts ?? []).not.toContain('LOSE');
     });
 
     it('drops trailing empty slots from the stored array', () => {

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -29,6 +29,7 @@ import { mergeLipConfig, type LipColorConfig } from '../../types/featureColors';
 import { DEFAULT_BIN_PARAMS } from '../../constants';
 import { isErr } from '@/core/result';
 import {
+  carryCompartmentTextsByPosition,
   isRectangularSelection,
   normalizeIdsWithRemap,
   remapCompartmentTexts,
@@ -294,7 +295,7 @@ export function createParamSlice(set: Set, get: Get) {
     },
 
     // Compartment actions
-    setCompartmentGrid: (cols: number, rows: number) => {
+    setCompartmentGrid: (cols: number, rows: number): number => {
       const { params } = get();
       const result = validateCompartmentSizes(
         params.width,
@@ -305,28 +306,28 @@ export function createParamSlice(set: Set, get: Get) {
         params.compartments.thickness,
         params.gridUnitMm
       );
-      if (isErr(result)) return;
+      if (isErr(result)) return 0;
+
+      // Best-effort carry of labels by position; the rest are counted so the
+      // UI can warn instead of dropping them silently (#2337).
+      const carried = carryCompartmentTextsByPosition(params.compartments, cols, rows);
+      const hasCarried = carried.texts.some((text) => text.length > 0);
 
       set((state) => {
         pushHistoryEntry(state);
-        const cells: number[] = [];
-        for (let i = 0; i < rows * cols; i++) {
-          cells.push(i);
-        }
-        // Old per-compartment text and divider overrides would attach to
-        // unrelated cells once IDs regenerate — drop them.
-        const {
-          compartmentTexts: _dropTexts,
-          dividerOverrides: _dropOverrides,
-          ...keepCompartments
-        } = state.params.compartments;
+        const cells = Array.from({ length: rows * cols }, (_, i) => i);
+        // Divider overrides key on adjacencies the fresh uniform grid no longer
+        // has — drop them. Labels carry by position above where they fit.
+        const { compartmentTexts: _t, dividerOverrides: _o, ...keep } = state.params.compartments;
         state.params.compartments = {
-          ...keepCompartments,
+          ...keep,
           cols,
           rows,
           cells,
+          ...(hasCarried ? { compartmentTexts: carried.texts } : {}),
         };
       });
+      return carried.droppedCount;
     },
 
     mergeCells: (cellIndices: readonly number[]) => {

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -934,7 +934,9 @@ export interface DesignerState {
   updateEnvelope: (partial: Partial<ItemEnvelope>) => void;
 
   // Compartment actions
-  setCompartmentGrid: (cols: number, rows: number) => void;
+  /** Regenerate a uniform grid. Carries labels by position where they fit and
+   *  returns the count of labels that couldn't be preserved (#2337). */
+  setCompartmentGrid: (cols: number, rows: number) => number;
   mergeCells: (cellIndices: readonly number[]) => void;
   splitCompartment: (compartmentId: number) => void;
   resetCompartments: () => void;

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -5,6 +5,8 @@ import {
   getCellId,
   cellIndex,
   getCompartmentIds,
+  getCompartmentReadingOrder,
+  carryCompartmentTextsByPosition,
   getCellsForCompartment,
   getCompartmentBounds,
   getCompartmentCount,
@@ -167,6 +169,91 @@ describe('compartments', () => {
         cells: [5, 2, 8, 1],
       };
       expect(getCompartmentIds(config)).toEqual([1, 2, 5, 8]);
+    });
+  });
+
+  describe('getCompartmentReadingOrder', () => {
+    it('counts top-left first on a uniform grid (visual top = highest data row)', () => {
+      // 2 cols x 2 rows. Data layout (row-major): ids 0,1 (row0=bottom), 2,3 (row1=top).
+      // The grid renders flex-col-reverse, so the visual top row is data row 1.
+      // Reading order should therefore be top-left→right, then bottom-left→right.
+      const config = createUniformGrid(2, 2, 1.2);
+      expect(getCompartmentReadingOrder(config)).toEqual([2, 3, 0, 1]);
+    });
+
+    it('returns [0] for a single-cell grid', () => {
+      expect(getCompartmentReadingOrder(createSingleCell(1.2))).toEqual([0]);
+    });
+
+    it('anchors merged compartments at their visual top-left cell', () => {
+      // 3 cols x 2 rows; top row (data row 1) merged into one compartment.
+      const config: CompartmentConfig = {
+        cols: 3,
+        rows: 2,
+        thickness: 1.2,
+        cells: [1, 2, 3, 0, 0, 0], // row0 (bottom): 1,2,3 ; row1 (top): 0,0,0
+      };
+      // Top row first (the merged id 0), then the bottom cells left→right.
+      expect(getCompartmentReadingOrder(config)).toEqual([0, 1, 2, 3]);
+    });
+
+    it('returns the same set of ids as getCompartmentIds, only reordered', () => {
+      const config = createUniformGrid(3, 3, 1.2);
+      expect([...getCompartmentReadingOrder(config)].sort((a, b) => a - b)).toEqual(
+        getCompartmentIds(config)
+      );
+    });
+  });
+
+  describe('carryCompartmentTextsByPosition', () => {
+    it('carries labels to the same position when the grid is unchanged', () => {
+      const config: CompartmentConfig = {
+        ...createUniformGrid(2, 2, 1.2),
+        compartmentTexts: ['a', 'b', 'c', 'd'],
+      };
+      const { texts, droppedCount } = carryCompartmentTextsByPosition(config, 2, 2);
+      expect(texts).toEqual(['a', 'b', 'c', 'd']);
+      expect(droppedCount).toBe(0);
+    });
+
+    it('drops labels whose anchor falls outside a shrunken grid and counts them', () => {
+      // 3x1 grid with all three labelled, shrinking to 2x1 drops the last column.
+      const config: CompartmentConfig = {
+        ...createUniformGrid(3, 1, 1.2),
+        compartmentTexts: ['x', 'y', 'z'],
+      };
+      const { texts, droppedCount } = carryCompartmentTextsByPosition(config, 2, 1);
+      expect(texts).toEqual(['x', 'y']);
+      expect(droppedCount).toBe(1);
+    });
+
+    it('does not count empty labels as dropped', () => {
+      const config: CompartmentConfig = {
+        ...createUniformGrid(3, 1, 1.2),
+        compartmentTexts: ['x', '', ''],
+      };
+      const { texts, droppedCount } = carryCompartmentTextsByPosition(config, 2, 1);
+      expect(texts).toEqual(['x', '']);
+      expect(droppedCount).toBe(0);
+    });
+
+    it('carries a merged compartment label from its top-left anchor', () => {
+      const config: CompartmentConfig = {
+        cols: 2,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 0, 0, 0], // whole grid is one compartment, id 0
+        compartmentTexts: ['merged'],
+      };
+      // New uniform 2x2: the top-left anchor of old id 0 is (col 0, row 0) → new id 0.
+      const { texts, droppedCount } = carryCompartmentTextsByPosition(config, 2, 2);
+      expect(texts[0]).toBe('merged');
+      expect(droppedCount).toBe(0);
+    });
+
+    it('returns no texts when the source had none', () => {
+      const config = createUniformGrid(2, 2, 1.2);
+      expect(carryCompartmentTextsByPosition(config, 3, 3)).toEqual({ texts: [], droppedCount: 0 });
     });
   });
 

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -61,6 +61,29 @@ export function getCompartmentIds(config: CompartmentConfig): number[] {
   return [...new Set(config.cells)].sort((a, b) => a - b);
 }
 
+/**
+ * Compartment IDs in visual reading order: top-left first, then left-to-right
+ * and top-to-bottom — the order a user's eye scans when labeling.
+ *
+ * IDs are assigned in data-row order, but the 2D grid renders `flex-col-reverse`
+ * so data row 0 is the visual BOTTOM. Numeric `getCompartmentIds` therefore
+ * counts up from the bottom-left, which reads backwards (#2338). Here we anchor
+ * each compartment at its visual top-left cell (highest data row = `maxRow`,
+ * then leftmost `minCol`) and sort by that.
+ *
+ * Display-only: the "Comp. N" numbering on cells, the below-grid field, and the
+ * bulk list all consume this so they stay in lockstep. Validation and general
+ * iteration keep the cheaper numeric `getCompartmentIds`.
+ */
+export function getCompartmentReadingOrder(config: CompartmentConfig): number[] {
+  const entries = getCompartmentIds(config).map((id) => {
+    const bounds = getCompartmentBounds(config, id);
+    return { id, top: bounds ? bounds.maxRow : -1, left: bounds ? bounds.minCol : id };
+  });
+  entries.sort((a, b) => (a.top !== b.top ? b.top - a.top : a.left - b.left));
+  return entries.map((e) => e.id);
+}
+
 /** Get all cell indices belonging to a compartment */
 export function getCellsForCompartment(config: CompartmentConfig, compartmentId: number): number[] {
   const indices: number[] = [];
@@ -672,6 +695,44 @@ export function remapCompartmentTexts(
     if (typeof t === 'string') out[newId] = t;
   }
   return out;
+}
+
+/**
+ * Best-effort carry of per-compartment label text across a grid-DIMENSION
+ * change. `setCompartmentGrid` regenerates a fresh uniform grid, so the new
+ * IDs can't be remapped from the old ones (CLAUDE.md gotcha #6 — there is no
+ * `oldId → newId` correspondence). Instead we anchor each old compartment at
+ * its top-left cell (`minCol`, `minRow`) and carry its label to the new uniform
+ * cell at that same position — the one spatial mapping that's unambiguous.
+ *
+ * Labels whose anchor falls outside the new (smaller) grid have nowhere to land
+ * and are dropped; `droppedCount` reports how many non-empty labels were lost so
+ * the caller can warn instead of discarding them silently (#2337).
+ *
+ * Returns `texts` indexed by new compartment ID (`row * newCols + col`).
+ */
+export function carryCompartmentTextsByPosition(
+  oldConfig: CompartmentConfig,
+  newCols: number,
+  newRows: number
+): { texts: string[]; droppedCount: number } {
+  const oldTexts = oldConfig.compartmentTexts;
+  if (!oldTexts || oldTexts.length === 0) return { texts: [], droppedCount: 0 };
+
+  const texts = new Array<string>(newCols * newRows).fill('');
+  let droppedCount = 0;
+  for (const id of getCompartmentIds(oldConfig)) {
+    const label = oldTexts[id];
+    if (typeof label !== 'string' || label.length === 0) continue;
+    const bounds = getCompartmentBounds(oldConfig, id);
+    if (!bounds) continue;
+    if (bounds.minCol < newCols && bounds.minRow < newRows) {
+      texts[bounds.minRow * newCols + bounds.minCol] = label;
+    } else {
+      droppedCount++;
+    }
+  }
+  return { texts, droppedCount };
 }
 
 /**

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -701,9 +701,13 @@ export function remapCompartmentTexts(
  * Best-effort carry of per-compartment label text across a grid-DIMENSION
  * change. `setCompartmentGrid` regenerates a fresh uniform grid, so the new
  * IDs can't be remapped from the old ones (CLAUDE.md gotcha #6 — there is no
- * `oldId → newId` correspondence). Instead we anchor each old compartment at
- * its top-left cell (`minCol`, `minRow`) and carry its label to the new uniform
- * cell at that same position — the one spatial mapping that's unambiguous.
+ * `oldId → newId` correspondence). Instead we anchor each old compartment at its
+ * lowest cell in data coordinates (`minCol`, `minRow`) and carry its label to
+ * the new uniform cell at that same position — the one spatial mapping that's
+ * unambiguous. Row 0 is the visual BOTTOM (the grid renders `flex-col-reverse`),
+ * so `minRow` is the compartment's visual bottom; for the common single-cell
+ * case `minRow === maxRow` so it doesn't matter. (Display numbering instead
+ * anchors at the visual TOP — see `getCompartmentReadingOrder`, #2338.)
  *
  * Labels whose anchor falls outside the new (smaller) grid have nowhere to land
  * and are dropped; `droppedCount` reports how many non-empty labels were lost so

--- a/src/features/bin-designer/utils/index.ts
+++ b/src/features/bin-designer/utils/index.ts
@@ -4,6 +4,7 @@ export {
   getCellId,
   cellIndex,
   getCompartmentIds,
+  getCompartmentReadingOrder,
   getCellsForCompartment,
   getCompartmentBounds,
   getCompartmentCount,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "Gravierter Text",
   "binDesigner.columns": "Spalten",
   "binDesigner.compartmentEditor.cellAria": "Zelle {col}, {row}",
+  "binDesigner.compartmentEditor.labelsCleared": "{count} Fachbeschriftung(en) gelöscht",
   "binDesigner.compartmentEditor.clickToSplit": "Klicken zum Teilen",
   "binDesigner.compartmentEditor.compartmentAria": "Fach {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "Fach {n}",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2842,6 +2842,7 @@ const en: Record<string, string> = {
   'binDesigner.compartmentEditor.compartmentAriaLabeled': 'Compartment {n}, labeled {label}',
   'binDesigner.compartmentEditor.compartmentAriaNumber': 'Compartment {n}',
   'binDesigner.compartmentEditor.cellAria': 'Cell {col}, {row}',
+  'binDesigner.compartmentEditor.labelsCleared': 'Cleared {count} compartment label(s)',
   'binDesigner.compartmentEditor.modeLabel': 'Compartment edit mode',
   'binDesigner.compartmentEditor.modeDividers': 'Edit dividers',
   'binDesigner.compartmentEditor.modeLabels': 'Add labels',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "Texto grabado",
   "binDesigner.columns": "Columnas",
   "binDesigner.compartmentEditor.cellAria": "Celda {col}, {row}",
+  "binDesigner.compartmentEditor.labelsCleared": "Se borraron {count} etiqueta(s) de compartimento",
   "binDesigner.compartmentEditor.clickToSplit": "Clic para dividir",
   "binDesigner.compartmentEditor.compartmentAria": "Compartimento {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "Compartimento {n}",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "Texte gravé",
   "binDesigner.columns": "Colonnes",
   "binDesigner.compartmentEditor.cellAria": "Cellule {col}, {row}",
+  "binDesigner.compartmentEditor.labelsCleared": "{count} étiquette(s) de compartiment effacée(s)",
   "binDesigner.compartmentEditor.clickToSplit": "Cliquer pour diviser",
   "binDesigner.compartmentEditor.compartmentAria": "Compartiment {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "Compartiment {n}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "彫刻文字",
   "binDesigner.columns": "列数",
   "binDesigner.compartmentEditor.cellAria": "セル{col}、{row}",
+  "binDesigner.compartmentEditor.labelsCleared": "{count}個の区画ラベルをクリアしました",
   "binDesigner.compartmentEditor.clickToSplit": "クリックして分割",
   "binDesigner.compartmentEditor.compartmentAria": "区画{n}、{dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "区画{n}",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "Gravert tekst",
   "binDesigner.columns": "Kolonner",
   "binDesigner.compartmentEditor.cellAria": "Celle {col}, {row}",
+  "binDesigner.compartmentEditor.labelsCleared": "Fjernet {count} rometikett(er)",
   "binDesigner.compartmentEditor.clickToSplit": "Klikk for å dele",
   "binDesigner.compartmentEditor.compartmentAria": "Rom {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "Rom {n}",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "Gegraveerde tekst",
   "binDesigner.columns": "Kolommen",
   "binDesigner.compartmentEditor.cellAria": "Cel {col}, {row}",
+  "binDesigner.compartmentEditor.labelsCleared": "{count} compartimentlabel(s) gewist",
   "binDesigner.compartmentEditor.clickToSplit": "Klik om te splitsen",
   "binDesigner.compartmentEditor.compartmentAria": "Compartiment {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "Compartiment {n}",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "Texto gravado",
   "binDesigner.columns": "Colunas",
   "binDesigner.compartmentEditor.cellAria": "Célula {col}, {row}",
+  "binDesigner.compartmentEditor.labelsCleared": "{count} etiqueta(s) de compartimento removida(s)",
   "binDesigner.compartmentEditor.clickToSplit": "Clique para dividir",
   "binDesigner.compartmentEditor.compartmentAria": "Compartimento {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "Compartimento {n}",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "Graverad text",
   "binDesigner.columns": "Kolumner",
   "binDesigner.compartmentEditor.cellAria": "Cell {col}, {row}",
+  "binDesigner.compartmentEditor.labelsCleared": "Rensade {count} facketikett(er)",
   "binDesigner.compartmentEditor.clickToSplit": "Klicka för att dela",
   "binDesigner.compartmentEditor.compartmentAria": "Fack {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "Fack {n}",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -292,6 +292,7 @@
   "binDesigner.colors.zone.text": "Гравірований текст",
   "binDesigner.columns": "Стовпці",
   "binDesigner.compartmentEditor.cellAria": "Клітинка {col}, {row}",
+  "binDesigner.compartmentEditor.labelsCleared": "Очищено {count} підпис(ів) відсіків",
   "binDesigner.compartmentEditor.clickToSplit": "Натисніть, щоб розділити",
   "binDesigner.compartmentEditor.compartmentAria": "Відсік {n}, {dimension}",
   "binDesigner.compartmentEditor.compartmentAriaNumber": "Відсік {n}",


### PR DESCRIPTION
Two follow-ups surfaced during #2331 self-review.

## #2337 — labels silently dropped on grid-dimension change
Changing the compartment grid dimensions (Columns/Rows steppers, the "Set by size" solver, or **Reset**) discarded all per-compartment label text with no warning. `setCompartmentGrid` regenerates a fresh uniform grid, so the new compartment IDs have no correspondence to the old ones (CLAUDE.md gotcha #6) and the labels were dropped outright.

**Fix:** new `carryCompartmentTextsByPosition` anchors each old compartment at its top-left cell and carries its label to the new uniform cell at that same position — the one spatial mapping that's unambiguous. Labels whose anchor falls outside a shrunken grid can't be placed; they're counted and surfaced via an **"N labels cleared"** toast instead of vanishing silently. A same-size Reset now keeps all labels.

## #2338 — "Comp. N" numbering counted up from the visual bottom
Display numbers came from `getCompartmentIds` (numeric, first-occurrence data-row order) while the grid renders `flex-col-reverse`, so "Comp. 1" was the **bottom**-left cell — backwards when labeling top-to-bottom.

**Fix:** new `getCompartmentReadingOrder` (visual top-left first, then left-to-right, top-to-bottom). The grid cells, below-grid field, and bulk list all consume it, so they stay in lockstep. Numeric `getCompartmentIds` is untouched for validation/iteration.

## Tests / checks
- Unit tests for both new helpers (`compartments.test.ts`), updated `useCompartmentLabeling` + scenario tests to the new reading order / carry behavior.
- `typecheck`, `lint`, all 4 `check:i18n:*` pass. New `labelsCleared` key added across all 9 locales.

Closes #2337
Closes #2338