### PR TITLE
perf(generation): cache one cell-socket template and clone per cell

### DIFF
--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -70,7 +70,7 @@ graph TB
 - `worker/generators/connectorUtils.ts` — legacy connector position computation
 - `worker/generators/generatorTypes.ts` — barrel re-export of constants/utilities
 - `worker/generators/hexGrid.ts` — hex grid layout calculations
-- `worker/generators/shapeCache.ts` — LRU cache for BREP solids
+- `worker/generators/shapeCache.ts` — LRU caches for BREP solids. Includes a per-cell-size **cell-socket template** cache: a uniform socket grid lofts one cell once and clones it per position (intrinsic-keyed, placement-invariant), turning a cold build from N lofts into 1 loft + (N−1) clones — the bin-side mirror of the baseplate `pocketTemplateCache`
 - `worker/generators/socketMeshCache.ts` — LRU cache for the deferred socket's tessellated mesh (triangles + edge lines), keyed by socket geometry identity + tolerance; reused across edits that don't change the base
 - `worker/generators/patterns/` — pattern system (honeycomb, registry)
 - `worker/generators/scenarios/` — test scenario data by category

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -67,9 +67,16 @@ const lipCache = new LRUCache<Shape3D>('lip', 20, disposeShape);
 const boxCache = new LRUCache<Shape3D>('box', 20, disposeShape);
 const shellCache = new LRUCache<Shape3D>('shell', 15, disposeShape);
 
+// Per-cell-size loft templates. A uniform grid lofts one cell socket and clones
+// it per position instead of re-lofting every cell (mirrors the baseplate
+// pocket template). Keyed on intrinsic cell size + profile detail, so it's
+// placement-invariant and shared across grids of any layout.
+const cellSocketTemplateCache = new LRUCache<Shape3D>('cell-socket-template', 16, disposeShape);
+
 const socket = createCloningAccessors(socketCache);
 const box = createCloningAccessors(boxCache);
 const lip = createCloningAccessors(lipCache);
+const cellSocketTemplate = createCloningAccessors(cellSocketTemplateCache);
 
 /** Single-entry caches — pattern template is cheap; lastSolid is always the latest */
 interface CacheEntry {
@@ -97,8 +104,14 @@ function getOrCreateFeatureCache(name: string): LRUCache<Shape3D> {
   return cache;
 }
 
-/** Static LRU caches (socket, lip, box, shell). */
-const staticLruCaches: readonly LRUCache<Shape3D>[] = [socketCache, lipCache, boxCache, shellCache];
+/** Static LRU caches (socket, lip, box, shell, cell-socket template). */
+const staticLruCaches: readonly LRUCache<Shape3D>[] = [
+  socketCache,
+  lipCache,
+  boxCache,
+  shellCache,
+  cellSocketTemplateCache,
+];
 
 export function socketCacheKey(
   gridW: number,
@@ -146,6 +159,14 @@ export const getBoxCache = box.get;
 export const setBoxCache = box.set;
 export const getLipCache = lip.get;
 export const setLipCache = lip.set;
+
+/**
+ * Get/set a per-cell-size socket loft template. `get` returns a clone the
+ * caller owns (register + translate it); `set` stores the original and returns
+ * a clone. Lets the socket grid clone one loft per cell instead of re-lofting.
+ */
+export const getCellSocketTemplateCache = cellSocketTemplate.get;
+export const setCellSocketTemplateCache = cellSocketTemplate.set;
 
 export function getShellCache(key: string): Shape3D | null {
   const cached = shellCache.get(key);

--- a/src/features/generation/worker/generators/socketBuilder.test.ts
+++ b/src/features/generation/worker/generators/socketBuilder.test.ts
@@ -125,4 +125,20 @@ describe('buildBaseSocket', () => {
       'at least one cell required'
     );
   });
+
+  // #2332: a uniform grid is one repeated cell loft. The template cache should
+  // loft it once and clone the rest, rather than re-lofting every cell.
+  it('lofts one cell-socket template and clones the rest for a uniform grid', async () => {
+    const { clearAllCaches, resetAllShapeCacheStats, getAllShapeCacheStats } =
+      await import('./shapeCache');
+    clearAllCaches(); // cold socketCache so the cell loop actually runs
+    resetAllShapeCacheStats();
+
+    // 3×3 uniform export grid → 9 identical full-size cells.
+    buildBaseSocket(3, 3, false, false, 3.1, 2, 1.25, true, false);
+
+    const stats = getAllShapeCacheStats().find((s) => s.name === 'cell-socket-template');
+    expect(stats?.misses).toBe(1); // one loft built
+    expect(stats?.hits).toBe(8); // remaining 8 cells cloned from it
+  }, 60000);
 });

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -37,7 +37,14 @@ import {
   type CellInfo,
 } from './generatorTypes';
 import { hasOverhang, type ResolvedOverhang } from './overhang';
-import { socketCacheKey, getSocketCache, setSocketCache } from './shapeCache';
+import {
+  socketCacheKey,
+  getSocketCache,
+  setSocketCache,
+  getCellSocketTemplateCache,
+  setCellSocketTemplateCache,
+} from './shapeCache';
+import { buildCacheKey, quantize } from './cacheKeyUtils';
 import {
   hasHalfBinDetail,
   hashMask,
@@ -238,6 +245,26 @@ export function buildSimplifiedCellSocket(cellW_mm: number, cellD_mm: number): S
 
   return s1.loftWith([s3], { ruled: true });
 }
+
+/**
+ * Get a single cell-socket solid for the given cell size, cloning a cached loft
+ * template instead of re-lofting. On a uniform grid every full cell is the same
+ * loft, so this turns a cold socket build from N lofts into 1 loft + (N−1)
+ * clones (mirrors the baseplate `getPocketTemplate`). The key is intrinsic
+ * (cell size + profile detail), so it's placement-invariant and shared across
+ * grids. The returned clone is owned by the caller — register + translate it;
+ * the cache keeps the original.
+ */
+function getCellSocketTemplate(cellW_mm: number, cellD_mm: number, forExport: boolean): Shape3D {
+  const key = buildCacheKey('cell-socket-v1', quantize(cellW_mm), quantize(cellD_mm), forExport);
+  const cached = getCellSocketTemplateCache(key);
+  if (cached) return cached;
+  const template = forExport
+    ? buildSingleCellSocket(cellW_mm, cellD_mm)
+    : buildSimplifiedCellSocket(cellW_mm, cellD_mm);
+  return setCellSocketTemplateCache(key, template);
+}
+
 /** Fuse all cell sockets, then cut all hole tools. Disposes replaced intermediates. */
 function batchFuseAndCut(cellSockets: Shape3D[], holeTools: Shape3D[]): Shape3D {
   let result = unwrap(fuseAll(cellSockets as ValidSolid[], { optimisation: 'commonFace' }));
@@ -374,15 +401,14 @@ export function buildBaseSocket(
         if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
         const cellW_mm = cell.widthUnits * gridUnitMm - CLEARANCE;
         const cellD_mm = cell.depthUnits * gridUnitMm - CLEARANCE;
-        // Use simplified 3-section socket for preview, full 5-section for export
-        // NOTE: cellSockets are NOT scope-registered because fuseAll may return
-        // one of its inputs when given a single element. They're deleted manually.
+        // Clone a cached cell-socket template (simplified for preview, full for
+        // export) instead of re-lofting every cell. The clone is registered so
+        // scope disposes it; `translate` returns the positioned socket.
+        // NOTE: cellSockets (the translated results) are NOT scope-registered
+        // because fuseAll may return one of its inputs when given a single
+        // element. They're deleted manually.
         const cellSocket = translate(
-          scope.register(
-            forExport
-              ? buildSingleCellSocket(cellW_mm, cellD_mm)
-              : buildSimplifiedCellSocket(cellW_mm, cellD_mm)
-          ),
+          scope.register(getCellSocketTemplate(cellW_mm, cellD_mm, forExport)),
           [cell.centerX, cell.centerY, 0]
         );
         cellSockets.push(cellSocket);
@@ -503,14 +529,11 @@ export function buildOverhangFeet(
     const sockets: Shape3D[] = frame.map((cell) => {
       const cellW_mm = cell.widthUnits * gridUnitMm - CLEARANCE;
       const cellD_mm = cell.depthUnits * gridUnitMm - CLEARANCE;
-      return translate(
-        scope.register(
-          forExport
-            ? buildSingleCellSocket(cellW_mm, cellD_mm)
-            : buildSimplifiedCellSocket(cellW_mm, cellD_mm)
-        ),
-        [cell.centerX, cell.centerY, 0]
-      );
+      return translate(scope.register(getCellSocketTemplate(cellW_mm, cellD_mm, forExport)), [
+        cell.centerX,
+        cell.centerY,
+        0,
+      ]);
     });
     const result = unwrap(fuseAll(sockets as ValidSolid[], { optimisation: 'commonFace' }));
     for (const s of sockets) {


### PR DESCRIPTION
Closes #2332.

## Problem
On a cold `socketCache` miss the bin socket grid lofts **every cell individually** inside the build loop, then fuses the array (`socketBuilder.ts`). For a uniform grid every cell socket is the *same* loft, so this repeats N identical lofts. The baseplate already solved the identical problem the right way — it caches **one** pocket template and clones it per position (`baseplatePockets.getPocketTemplate`).

## Change
- New `getCellSocketTemplate(cellW, cellD, forExport)` lofts one cell socket per unique cell size (full + simplified variants), caches it, and returns a clone the caller registers + translates per cell.
- Backed by a new intrinsic-keyed `cell-socket-template` LRU in `shapeCache.ts` (placement-invariant, shared across grids, disposed by `clearAllCaches`).
- Both grid loops (`buildBaseSocket` and `buildOverhangFeet`) clone the template instead of re-lofting.

Cold socket grid: **N lofts → 1 loft + (N−1) clones.**

## Scope / impact
- Only affects a **cold `socketCache` miss** (a new grid size, e.g. resizing a bin). Steady-state re-renders already hit the whole-grid cache. The win is first-render latency on resize, not steady state.
- Edge/half cells that differ in size still build individually; the template-clone covers the uniform majority.

## Verification
- Geometry unchanged — `clone()` + `translate()` is the exact pattern the baseplate pockets already use. Ran `socketBuilder` + 8 socket-heavy scenario suites (dimensions, halfSockets, fractional-feet, customShape/mask, overhang, gridunit, export-integrity, overtile) — **444 tests pass**.
- New assertion: a uniform 3×3 export grid issues exactly **1 loft + 8 clones** (via the cache's hit/miss stats).