### PR TITLE
perf(generation): resume from a cached post-boolean body

### DIFF
--- a/src/features/generation/worker/generators/binResumeCache.test.ts
+++ b/src/features/generation/worker/generators/binResumeCache.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { buildParams } from './__kernel-tests__/scenarioTypes';
+import { clearAllCaches, resetAllShapeCacheStats, getAllShapeCacheStats } from './shapeCache';
+
+const binBodyStats = (): { hits: number; misses: number } => {
+  const s = getAllShapeCacheStats().find((c) => c.name === 'bin-body');
+  return { hits: s?.hits ?? 0, misses: s?.misses ?? 0 };
+};
+
+describe('post-boolean body resume cache (#2333)', () => {
+  beforeAll(async () => {
+    await initBrepjs();
+  }, 30_000);
+
+  it('skips the boolean on an identical re-generation and keeps geometry identical', () => {
+    const generateBin = getGenerateBin();
+    // Label-bracket tabs are additive fuse targets, so the boolean stage runs.
+    const params = buildParams({
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket', alignment: 'left' },
+    });
+
+    clearAllCaches();
+    resetAllShapeCacheStats();
+
+    const first = generateBin(params, undefined, false);
+    expect(binBodyStats()).toEqual({ hits: 0, misses: 1 }); // cold: boolean ran, body cached
+
+    const second = generateBin(params, undefined, false);
+    expect(binBodyStats().hits).toBe(1); // boolean stage skipped via resume cache
+    // Identical inputs ⇒ identical output.
+    expect(second.triangleCount).toBe(first.triangleCount);
+    expect(second.vertices.length).toBe(first.vertices.length);
+  }, 60_000);
+
+  it('keys export and preview bodies separately (forExport drives simplify)', () => {
+    const generateBin = getGenerateBin();
+    const params = buildParams({
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket', alignment: 'left' },
+    });
+
+    clearAllCaches();
+    resetAllShapeCacheStats();
+
+    generateBin(params, undefined, false); // preview → miss
+    generateBin(params, undefined, true); // export → separate key, miss (not a false hit)
+    expect(binBodyStats()).toEqual({ hits: 0, misses: 2 });
+  }, 60_000);
+
+  it('disables the resume cache for wall-pattern bins (featuresKey null)', () => {
+    const generateBin = getGenerateBin();
+    const params = buildParams({
+      wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true },
+    });
+
+    clearAllCaches();
+    resetAllShapeCacheStats();
+
+    generateBin(params, undefined, false);
+    generateBin(params, undefined, false);
+    // No bin-body cache activity at all — the resume path never engages.
+    expect(binBodyStats()).toEqual({ hits: 0, misses: 0 });
+  }, 60_000);
+});

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -202,6 +202,7 @@ export function createInitialContext(
     fuseTargets: [],
     cutTargets: [],
     patternCutTargets: [],
+    featuresKey: null,
     mesh: null,
     coarseMesh: null,
     perfCollector,

--- a/src/features/generation/worker/generators/pipeline/featureRunner.test.ts
+++ b/src/features/generation/worker/generators/pipeline/featureRunner.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { composeFeaturesKey } from './featureRunner';
+
+describe('composeFeaturesKey', () => {
+  it('is deterministic for identical input', () => {
+    const parts = [
+      ['labelTab', 'fuse', 'abc'],
+      ['compartmentWalls', 'cut', 'def'],
+    ];
+    expect(composeFeaturesKey(parts)).toBe(composeFeaturesKey(parts));
+  });
+
+  it('does NOT collide when a builder key embeds the delimiter characters', () => {
+    // These two distinct feature sets flatten to the same `name:target:key`
+    // pipe-join ("labelTab:fuse:a|labelTab:fuse:b" vs "labelTab:fuse:a|b" +
+    // "labelTab:fuse:" ...). JSON keeps them distinct — a regression guard for
+    // the false-resume-hit bug (#2333 review).
+    const a = composeFeaturesKey([
+      ['labelTab', 'fuse', 'a'],
+      ['labelTab', 'fuse', 'b'],
+    ]);
+    const b = composeFeaturesKey([['labelTab', 'fuse', 'a|labelTab:fuse:b']]);
+    expect(a).not.toBe(b);
+  });
+
+  it('distinguishes keys that differ only by a colon/pipe boundary', () => {
+    const a = composeFeaturesKey([['x', 'fuse', 'p:q']]);
+    const b = composeFeaturesKey([['x', 'fuse:p', 'q']]);
+    expect(a).not.toBe(b);
+  });
+
+  it('distinguishes the empty set from a builder with empty-string parts', () => {
+    expect(composeFeaturesKey([])).not.toBe(composeFeaturesKey([['', '', '']]));
+  });
+});

--- a/src/features/generation/worker/generators/pipeline/featureRunner.ts
+++ b/src/features/generation/worker/generators/pipeline/featureRunner.ts
@@ -35,6 +35,17 @@ export interface FeatureTargets {
 }
 
 /**
+ * Serialize the per-builder `[name, target, key]` triples into one composite
+ * key. Uses JSON so the result is injective: a builder key may embed user text
+ * (e.g. a label) containing `|` or `:`, and a flat delimiter join could collide
+ * two distinct feature sets into the same string — a false resume-cache hit
+ * that returns stale geometry. JSON's quoting/escaping makes that impossible.
+ */
+export function composeFeaturesKey(parts: ReadonlyArray<readonly string[]>): string {
+  return JSON.stringify(parts);
+}
+
+/**
  * Run all feature builders against the pipeline context.
  *
  * Each builder's shapes are cached, cloned, origin-tracked, and sorted
@@ -57,7 +68,11 @@ export function runFeatureBuilders(
   };
 
   const perf = ctx.perfCollector;
-  const keyParts: string[] = [];
+  // Each entry is a [name, target, key] triple. Kept structured (not a
+  // delimiter-joined string) so the JSON serialization below is injective —
+  // a builder key may embed user text (e.g. a label) containing `|` or `:`,
+  // which a flat join could collide across builders into a false cache hit.
+  const keyParts: string[][] = [];
 
   for (const builder of builders) {
     if (!builder.shouldBuild(ctx)) continue;
@@ -69,7 +84,7 @@ export function runFeatureBuilders(
     // shape — the post-boolean resume key must change if any input geometry
     // does. `target` distinguishes fuse vs cut so a builder that flips bucket
     // (same key, different op) still re-keys.
-    keyParts.push(`${builder.name}:${builder.target}:${key}`);
+    keyParts.push([builder.name, builder.target, key]);
 
     // getFeatureCache returns a clone (caller owns it), or null on miss.
     let shape = getFeatureCache(builder.name, key);
@@ -106,6 +121,6 @@ export function runFeatureBuilders(
     if (perf) perf.recordFeatureBuilder(builder.name, performance.now() - builderStart);
   }
 
-  targets.featuresKey = keyParts.join('|');
+  targets.featuresKey = composeFeaturesKey(keyParts);
   return targets;
 }

--- a/src/features/generation/worker/generators/pipeline/featureRunner.ts
+++ b/src/features/generation/worker/generators/pipeline/featureRunner.ts
@@ -26,6 +26,12 @@ export interface FeatureTargets {
   fuseTargets: Shape3D[];
   cutTargets: Shape3D[];
   patternCutTargets: Shape3D[];
+  /**
+   * Composite key over every built feature's own cache key, in builder order.
+   * Identifies the exact set of feature geometry produced this run so the
+   * post-boolean body can be cached/resumed (see booleanStage).
+   */
+  featuresKey: string;
 }
 
 /**
@@ -42,6 +48,7 @@ export function runFeatureBuilders(
     fuseTargets: [],
     cutTargets: [],
     patternCutTargets: [],
+    featuresKey: '',
   };
   const bucketMap: Record<string, Shape3D[]> = {
     fuse: targets.fuseTargets,
@@ -50,6 +57,7 @@ export function runFeatureBuilders(
   };
 
   const perf = ctx.perfCollector;
+  const keyParts: string[] = [];
 
   for (const builder of builders) {
     if (!builder.shouldBuild(ctx)) continue;
@@ -57,6 +65,11 @@ export function runFeatureBuilders(
 
     const builderStart = perf ? performance.now() : 0;
     const key = builder.cacheKey(ctx);
+    // Record the key for every builder that runs, whether or not it yields a
+    // shape — the post-boolean resume key must change if any input geometry
+    // does. `target` distinguishes fuse vs cut so a builder that flips bucket
+    // (same key, different op) still re-keys.
+    keyParts.push(`${builder.name}:${builder.target}:${key}`);
 
     // getFeatureCache returns a clone (caller owns it), or null on miss.
     let shape = getFeatureCache(builder.name, key);
@@ -93,5 +106,6 @@ export function runFeatureBuilders(
     if (perf) perf.recordFeatureBuilder(builder.name, performance.now() - builderStart);
   }
 
+  targets.featuresKey = keyParts.join('|');
   return targets;
 }

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
@@ -17,7 +17,7 @@ import type { PipelineContext, PipelineStage } from '../types';
 import type { BooleanOpts } from '../../meshUtils';
 import { checkCancelled } from '../../utils/abort';
 import { getBinBodyCache, setBinBodyCache } from '../../shapeCache';
-import { buildCacheKey, compactKey } from '../../cacheKeyUtils';
+import { compactKey } from '../../cacheKeyUtils';
 
 export type BooleanFallbackCategory = 'fuse' | 'cut' | 'pattern_cut';
 
@@ -106,9 +106,15 @@ export const booleanStage: PipelineStage = {
     // (which drives `simplify`), so it changes whenever the booleaned body
     // would. Disabled when `featuresKey` is null (solid mode / wall patterns,
     // whose tools aren't captured by the key — see featuresStage).
+    // JSON.stringify keeps the composition injective end-to-end: `shellKey` and
+    // `featuresKey` can both contain `|`, which a flat `buildCacheKey` join could
+    // collide across segment boundaries into a false hit (stale geometry).
+    // `compactKey` then hashes long keys, the same as every other cache here.
     const resumeKey =
       featuresKey !== null
-        ? compactKey(buildCacheKey('binbody-v1', ctx.dimensions.shellKey, forExport, featuresKey))
+        ? compactKey(
+            JSON.stringify(['binbody-v1', ctx.dimensions.shellKey, forExport, featuresKey])
+          )
         : null;
 
     if (resumeKey !== null) {

--- a/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/booleanStage.ts
@@ -11,11 +11,13 @@
  * for simpler fuse→cut chains where bisect's recovery would be wasted.
  */
 
-import { unwrap, fuseAllBisect, cutAllBisect } from 'brepjs';
+import { unwrap, fuseAllBisect, cutAllBisect, translate } from 'brepjs';
 import type { Shape3D, ValidSolid, BatchBisectTelemetry } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import type { BooleanOpts } from '../../meshUtils';
 import { checkCancelled } from '../../utils/abort';
+import { getBinBodyCache, setBinBodyCache } from '../../shapeCache';
+import { buildCacheKey, compactKey } from '../../cacheKeyUtils';
 
 export type BooleanFallbackCategory = 'fuse' | 'cut' | 'pattern_cut';
 
@@ -88,12 +90,39 @@ export const booleanStage: PipelineStage = {
   },
 
   execute(ctx: PipelineContext): PipelineContext {
-    const { signal, forExport } = ctx;
+    const { signal, forExport, featuresKey } = ctx;
     let bin = ctx.solid;
     if (!bin) return ctx;
     const originalSolid = bin;
 
     checkCancelled(signal);
+
+    const allTargets = [...ctx.fuseTargets, ...ctx.cutTargets, ...ctx.patternCutTargets];
+
+    // Resume cache: a metadata-only edit (label text, notes, category) leaves
+    // the shell and every feature's geometry key unchanged, so the post-boolean
+    // body is identical — skip the whole boolean stage. The key composes the
+    // shell identity, the feature geometry (`featuresKey`), and `forExport`
+    // (which drives `simplify`), so it changes whenever the booleaned body
+    // would. Disabled when `featuresKey` is null (solid mode / wall patterns,
+    // whose tools aren't captured by the key — see featuresStage).
+    const resumeKey =
+      featuresKey !== null
+        ? compactKey(buildCacheKey('binbody-v1', ctx.dimensions.shellKey, forExport, featuresKey))
+        : null;
+
+    if (resumeKey !== null) {
+      const cached = getBinBodyCache(resumeKey);
+      if (cached) {
+        // The cached body already has features fused/cut in and carries their
+        // face-origin tags (preserved by the metadata clone). Drop the shell
+        // and the now-unused feature tools; the freshly built deferredSolid
+        // (socket) flows through unchanged.
+        originalSolid.delete();
+        for (const t of allTargets) t.delete();
+        return { ...ctx, solid: cached, fuseTargets: [], cutTargets: [], patternCutTargets: [] };
+      }
+    }
 
     // Shared by fuse and cut passes — `simplify: forExport` merges
     // same-domain faces left behind by the n-way boolean, and `signal`
@@ -124,8 +153,14 @@ export const booleanStage: PipelineStage = {
     }
 
     if (bin !== originalSolid) originalSolid.delete();
-    const allTargets = [...ctx.fuseTargets, ...ctx.cutTargets, ...ctx.patternCutTargets];
     for (const t of allTargets) t.delete();
+
+    // Populate the resume cache and hand the pipeline a metadata-preserving
+    // clone — the cache owns `bin`, exactly like shellStage/getShellCache.
+    if (resumeKey !== null) {
+      setBinBodyCache(resumeKey, bin);
+      bin = translate(bin, [0, 0, 0]);
+    }
 
     return { ...ctx, solid: bin, fuseTargets: [], cutTargets: [], patternCutTargets: [] };
   },

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -64,7 +64,9 @@ export const featuresStage: PipelineStage = {
       for (const tool of embossTools) {
         collectOrigins(tool, FeatureTag.TEXT, originToTag);
       }
-      return { ...ctx, cutTargets: cutoutTools, fuseTargets: embossTools };
+      // Solid-mode cutout tools aren't keyed through feature builders, so the
+      // post-boolean resume cache can't safely identify them — disable it.
+      return { ...ctx, cutTargets: cutoutTools, fuseTargets: embossTools, featuresKey: null };
     }
 
     // For non-rectangular (cellMask) bins, run only builders that have
@@ -82,7 +84,8 @@ export const featuresStage: PipelineStage = {
     // Polygon bins enumerate outer polygon edges (see wallPatterns.ts) and
     // only bind clipping to the outermost edge per cardinal — non-outermost
     // step walls get pure pattern.
-    if (params.wallPattern.enabled) {
+    const wallPatternEnabled = params.wallPattern.enabled;
+    if (wallPatternEnabled) {
       const patternShapes = buildWallPatterns(ctx);
       targets.patternCutTargets.push(...patternShapes);
     }
@@ -92,6 +95,10 @@ export const featuresStage: PipelineStage = {
       fuseTargets: targets.fuseTargets,
       cutTargets: targets.cutTargets,
       patternCutTargets: targets.patternCutTargets,
+      // Wall-pattern cuts aren't keyed through feature builders, so their
+      // geometry isn't in `featuresKey` — disable the resume cache rather than
+      // risk a stale body when only the pattern changes.
+      featuresKey: wallPatternEnabled ? null : targets.featuresKey,
     };
   },
 };

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -103,6 +103,15 @@ export interface PipelineContext {
   readonly cutTargets: readonly Shape3D[];
   /** Pattern cut targets — applied in a separate boolean pass after cutTargets */
   readonly patternCutTargets: readonly Shape3D[];
+  /**
+   * Composite geometry-identity key for the feature targets this run, set by
+   * the features stage. Combined with `dimensions.shellKey` + `forExport` it
+   * keys the post-boolean body cache, so a metadata-only edit (no geometry
+   * change) skips the boolean stage. `null` disables that resume cache for
+   * paths whose targets aren't fully captured by feature builder keys (solid
+   * mode, wall patterns) — correctness over coverage.
+   */
+  readonly featuresKey: string | null;
   /** Final mesh output (set by tessellate stage) */
   readonly mesh: MeshData | null;
   /** Coarse LOD mesh for distance-based rendering (preview only) */

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -66,6 +66,12 @@ const socketCache = new LRUCache<Shape3D>('socket', 20, disposeShape);
 const lipCache = new LRUCache<Shape3D>('lip', 20, disposeShape);
 const boxCache = new LRUCache<Shape3D>('box', 20, disposeShape);
 const shellCache = new LRUCache<Shape3D>('shell', 15, disposeShape);
+// Post-boolean body (shell + features cut/fused in), keyed on shell + feature
+// geometry. Lets a metadata-only edit (label text, notes, category) reuse the
+// booleaned body and skip the whole boolean stage — mirrors the baseplate's
+// slabWithPocketsCache resume. Like shellCache it holds BASE/LIP/feature
+// face-origin tags, so reads must preserve metadata (see getBinBodyCache).
+const binBodyCache = new LRUCache<Shape3D>('bin-body', 12, disposeShape);
 
 // Per-cell-size loft templates. A uniform grid lofts one cell socket and clones
 // it per position instead of re-lofting every cell (mirrors the baseplate
@@ -104,13 +110,14 @@ function getOrCreateFeatureCache(name: string): LRUCache<Shape3D> {
   return cache;
 }
 
-/** Static LRU caches (socket, lip, box, shell, cell-socket template). */
+/** Static LRU caches (socket, lip, box, shell, cell-socket template, bin-body). */
 const staticLruCaches: readonly LRUCache<Shape3D>[] = [
   socketCache,
   lipCache,
   boxCache,
   shellCache,
   cellSocketTemplateCache,
+  binBodyCache,
 ];
 
 export function socketCacheKey(
@@ -181,6 +188,22 @@ export function getShellCache(key: string): Shape3D | null {
 
 export function setShellCache(key: string, shape: Shape3D): void {
   shellCache.set(key, shape);
+}
+
+/**
+ * Post-boolean body cache. Same metadata-preserving clone as `getShellCache`:
+ * `translate([0,0,0])` carries the BASE/LIP/feature face-origin tags that a bare
+ * `clone()` would drop (which would collapse the multi-color preview/export).
+ * Returns null on miss. The cache owns the stored shape; callers own the clone.
+ */
+export function getBinBodyCache(key: string): Shape3D | null {
+  const cached = binBodyCache.get(key);
+  if (cached === undefined) return null;
+  return translate(cached, [0, 0, 0]);
+}
+
+export function setBinBodyCache(key: string, shape: Shape3D): void {
+  binBodyCache.set(key, shape);
 }
 
 /** Returns raw shape (no clone) — caller uses transformCopy which is non-destructive. */


### PR DESCRIPTION
Closes #2333.

## Problem
The bin pipeline already reuses the shell (`shellCache`) and per-feature tools, but the **boolean stage re-fuses/re-cuts every feature into the body on every generation** (`booleanStage`, `fuseAllBisect`/`cutAllBisect`). A metadata-only edit (label text, notes, category) produces a byte-identical booleaned body yet still paid for the full boolean pass. There was no "resume from the assembled-but-not-yet-cut body" intermediate, unlike the baseplate's `slabWithPocketsCache`.

## Change
A resume cache for the post-boolean **body**, keyed on:
- `dimensions.shellKey` — the shell identity (box + lip + compartment-cut + lightweight + overhang), and
- `featuresKey` — a composite of **every feature builder's own geometry cache key**, collected in `runFeatureBuilders`, and
- `forExport` — which drives `simplify`.

When nothing geometry-affecting changed, `booleanStage` returns the cached body and skips the fuse/cut entirely.

### Why it's correct
The key is **composed from the exact keys that produced each boolean input**, so it changes whenever the booleaned body would — no hand-maintained "geometry vs metadata" param partition to drift out of sync. It's explicitly **disabled** (`featuresKey = null`) for paths whose tools aren't keyed through feature builders — **solid mode** and **wall patterns** — choosing correctness over coverage.

Reads use the same metadata-preserving clone as `getShellCache` (`translate([0,0,0])`), so BASE/LIP/feature face-origin tags survive the cache hit and multi-color stays correct (`setShapeOrigin` tags with the stable `FeatureTag`; `originToTag` is vestigial).

## Verification
- **Geometry unchanged across the full bin scenario suite: 61 files / 930 tests pass, snapshots intact.**
- New `binResumeCache.test.ts`: an identical re-generation hits the cache (boolean skipped); preview vs export key separately (no false hit); wall-pattern bins opt out (no cache activity).
- typecheck + lint clean.

## Scope / impact
- Win is on **metadata-only and no-op re-generations** — the boolean stage (often the dominant kernel cost after the socket) is skipped. Single-feature edits already resumed from the body via `shellCache`; this adds the post-boolean skip.