### PR TITLE
test(baseplate): drop flaky 8×8 wall-clock assertion

### DIFF
--- a/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
@@ -178,13 +178,12 @@ describe('baseplateDirectMesh', () => {
   });
 
   // ─── Performance ────────────────────────────────────────────────────────
-  it('generates 8×8 mesh in under 200ms', () => {
-    const start = performance.now();
+  // Absolute wall-clock timing is asserted by the load-independent
+  // "direct is at least 10x faster than BREP" ratio test below; an absolute
+  // threshold here only flaked on main's coverage-instrumented full run.
+  it('generates a non-empty 8×8 mesh', () => {
     const mesh = generateDirect(defaults({ width: 8, depth: 8, magnetHoles: true }), noop);
-    const elapsed = performance.now() - start;
     expect(mesh.vertices.length).toBeGreaterThan(0);
-    // Relaxed from 50ms — under full-suite load with WASM contention, timings vary
-    expect(elapsed).toBeLessThan(200);
   });
 
   // ─── Comparison: bounding boxes ─────────────────────────────────────────


### PR DESCRIPTION
## Problem

CI on `main` has been failing intermittently on `baseplateDirectMesh.test.ts > generates 8×8 mesh in under 200ms` — observed at 281ms, 316ms, 344ms, 437ms, 459ms across recent runs, interleaved with passes.

## Root cause

Not a code regression — `baseplateDirectMesh.ts` is unchanged since #2160 and main has been green many times since. The failures are an artifact of the test environment:

- **Main-only coverage:** the CI script runs `pnpm vitest run --coverage -u` on `refs/heads/main`, but `--project=generators --shard` (no coverage) on PR branches. v8 coverage instrumentation adds real per-call overhead, so PR validation never sees it.
- **Shared-runner contention:** the 281–459ms spread on identical code is the signature of CPU contention, not an algorithmic slowdown.

An absolute wall-clock threshold is inherently flaky here — the comment shows it was already relaxed once (50ms → 200ms).

## Fix

Drop the absolute-time assertion (keep the non-empty mesh check). Real perf regressions are still caught by the load-independent **`direct is at least 10x faster than BREP`** ratio test, which stays stable under contention because both paths run on the same machine.

All 28 tests in the file pass locally.