### PR TITLE
fix(wall-cutouts): sync divider cutout alignment/offset/mm with outer walls

### DIFF
--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -496,6 +496,11 @@ export function buildOverrideLookup(
 export interface InteriorDividerSegment {
   /** Axis-projected segment length (mm) — not the longer true diagonal. */
   readonly segLen: number;
+  /** True wall length along the (possibly tilted) segment — equals `segLen`
+   *  for straight dividers, longer for tilted ones. Features that measure
+   *  distance ALONG the wall (cutout width, alignment) must use this, not the
+   *  projected `segLen`. */
+  readonly wallLen: number;
   readonly x: number;
   readonly y: number;
   /** In-plane rotation (deg) aligned to the wall: 90 for straight vertical
@@ -555,11 +560,12 @@ export function interiorDividerSegments(
         ov
           ? {
               segLen,
+              wallLen: Math.hypot(segLen, ov.offsetEnd - ov.offsetStart),
               x: xPos + (ov.offsetStart + ov.offsetEnd) / 2,
               y: midY,
               rotateZ: Math.atan2(segLen, ov.offsetEnd - ov.offsetStart) * RAD2DEG,
             }
-          : { segLen, x: xPos, y: midY, rotateZ: 90 }
+          : { segLen, wallLen: segLen, x: xPos, y: midY, rotateZ: 90 }
       );
     }
   }
@@ -580,11 +586,12 @@ export function interiorDividerSegments(
         ov
           ? {
               segLen,
+              wallLen: Math.hypot(segLen, ov.offsetEnd - ov.offsetStart),
               x: midX,
               y: yPos + (ov.offsetStart + ov.offsetEnd) / 2,
               rotateZ: Math.atan2(ov.offsetEnd - ov.offsetStart, segLen) * RAD2DEG,
             }
-          : { segLen, x: midX, y: yPos, rotateZ: 0 }
+          : { segLen, wallLen: segLen, x: midX, y: yPos, rotateZ: 0 }
       );
     }
   }

--- a/src/features/generation/worker/generators/scenarios/wallCutouts.ts
+++ b/src/features/generation/worker/generators/scenarios/wallCutouts.ts
@@ -60,6 +60,36 @@ export const wallCutouts: ScenarioCase[] = [
     },
     timeout: 60_000,
   }),
+  defineScenario('wall cutouts', 'interior divider cutout honours alignment + offset (#2323)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 2,
+      height: 5,
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+      walls: {
+        enabled: true,
+        shape: 'u-shape',
+        width: 0,
+        depth: 0,
+        // Reporter's linked config: left + right outer walls and the divider all
+        // share a left-aligned, +5mm-offset window.
+        front: DISABLED_WALL_CUTOUT,
+        back: DISABLED_WALL_CUTOUT,
+        left: { enabled: true, width: 40, depth: 50, alignment: 'left', offset: 5, widthMm: null },
+        right: { enabled: true, width: 40, depth: 50, alignment: 'left', offset: 5, widthMm: null },
+        interior: {
+          enabled: true,
+          width: 40,
+          depth: 50,
+          alignment: 'left',
+          offset: 5,
+          widthMm: null,
+        },
+      },
+    },
+    timeout: 60_000,
+  }),
   defineScenario('wall cutouts', 'left-aligned cutout with offset and absolute mm width', {
     assert: 'structural',
     params: {

--- a/src/features/generation/worker/generators/scenarios/wallCutouts.ts
+++ b/src/features/generation/worker/generators/scenarios/wallCutouts.ts
@@ -90,6 +90,42 @@ export const wallCutouts: ScenarioCase[] = [
     },
     timeout: 60_000,
   }),
+  defineScenario('wall cutouts', 'tilted interior divider cutout with alignment (#2323)', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 2,
+      height: 5,
+      compartments: {
+        cols: 2,
+        rows: 1,
+        cells: [0, 1],
+        thickness: 1.2,
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: -15, offsetEnd: 15 }],
+      },
+      walls: {
+        enabled: true,
+        shape: 'u-shape',
+        width: 0,
+        depth: 0,
+        front: DISABLED_WALL_CUTOUT,
+        back: DISABLED_WALL_CUTOUT,
+        left: DISABLED_WALL_CUTOUT,
+        right: DISABLED_WALL_CUTOUT,
+        // Right-aligned window on a tilted divider exercises the true-length
+        // span + the along-wall offset projection.
+        interior: {
+          enabled: true,
+          width: 50,
+          depth: 50,
+          alignment: 'right',
+          offset: 0,
+          widthMm: null,
+        },
+      },
+    },
+    timeout: 60_000,
+  }),
   defineScenario('wall cutouts', 'left-aligned cutout with offset and absolute mm width', {
     assert: 'structural',
     params: {

--- a/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
@@ -190,6 +190,26 @@ describe('computeInteriorDividerCutouts', () => {
     expect(offset.y).toBeCloseTo(centered.y, 6);
   });
 
+  it('sizes a tilted divider cutout by its true diagonal length, not the projected span', () => {
+    // Symmetric ±20mm tilt on a segLen=40 vertical divider → 45° wall whose
+    // true length is hypot(40, 40). A 70% window must scale to that length.
+    const override: DividerOverride = {
+      compartmentA: 0,
+      compartmentB: 1,
+      offsetStart: -20,
+      offsetEnd: 20,
+    };
+    const base = makeParams({ cols: 2, rows: 1, cells: [0, 1] }, [override]);
+    const [cut] = computeInteriorDividerCutouts(
+      withInterior(base, { width: 70, alignment: 'center', offset: 0 }),
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    expect(cut.rotateZ).toBeCloseTo(45, 4);
+    expect(cut.cutW).toBeCloseTo(Math.hypot(40, 40) * 0.7, 4);
+  });
+
   it('honours an absolute mm width override instead of the percentage', () => {
     const base = makeParams({ cols: 2, rows: 1, cells: [0, 1] });
     // Percentage default (70%) would give 0.7 * segLen; the mm override wins.

--- a/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
@@ -127,4 +127,78 @@ describe('computeInteriorDividerCutouts', () => {
     expect(cut.rotateZ).toBeCloseTo(expected, 4);
     expect(cut.rotateZ).not.toBe(0); // the regression: it used to stay axis-aligned
   });
+
+  // ─── Alignment / offset / mm parity with outer walls (discussion #2323) ──
+  // A linked outer config (e.g. left-aligned + offset) is copied onto the
+  // interior cutout, so the divider window must track it instead of staying
+  // centred on the divider midpoint.
+  const withInterior = (
+    params: BinParams,
+    patch: Partial<BinParams['walls']['left']>
+  ): BinParams => ({
+    ...params,
+    walls: { ...params.walls, interior: { ...params.walls.interior, ...patch } },
+  });
+
+  it('shifts a vertical divider cutout along Y for left vs right alignment', () => {
+    const base = makeParams({ cols: 2, rows: 1, cells: [0, 1] });
+    const [left] = computeInteriorDividerCutouts(
+      withInterior(base, { alignment: 'left', offset: 0 }),
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    const [center] = computeInteriorDividerCutouts(
+      withInterior(base, { alignment: 'center', offset: 0 }),
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    const [right] = computeInteriorDividerCutouts(
+      withInterior(base, { alignment: 'right', offset: 0 }),
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    // Vertical divider runs along Y (rotateZ 90): alignment moves the window
+    // along Y, never off the grid line in X.
+    expect(center.y).toBeCloseTo(0, 6);
+    expect(left.y).toBeLessThan(center.y);
+    expect(right.y).toBeGreaterThan(center.y);
+    expect(left.y).toBeCloseTo(-right.y, 6);
+    expect(left.x).toBeCloseTo(0, 6);
+    expect(right.x).toBeCloseTo(0, 6);
+  });
+
+  it('shifts a horizontal divider cutout along X for the offset', () => {
+    const base = makeParams({ cols: 1, rows: 2, cells: [0, 1] });
+    const [centered] = computeInteriorDividerCutouts(
+      withInterior(base, { alignment: 'center', offset: 0 }),
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    const [offset] = computeInteriorDividerCutouts(
+      withInterior(base, { alignment: 'center', offset: 3 }),
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    // Horizontal divider runs along X (rotateZ 0): a +offset slides it +X.
+    expect(centered.x).toBeCloseTo(0, 6);
+    expect(offset.x).toBeCloseTo(3, 6);
+    expect(offset.y).toBeCloseTo(centered.y, 6);
+  });
+
+  it('honours an absolute mm width override instead of the percentage', () => {
+    const base = makeParams({ cols: 2, rows: 1, cells: [0, 1] });
+    // Percentage default (70%) would give 0.7 * segLen; the mm override wins.
+    const [cut] = computeInteriorDividerCutouts(
+      withInterior(base, { widthMm: 10 }),
+      INNER_W,
+      INNER_D,
+      WALL_HEIGHT
+    );
+    expect(cut.cutW).toBeCloseTo(10, 6);
+  });
 });

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -233,17 +233,19 @@ export function computeInteriorDividerCutouts(
   const interiorH = wallHeight - params.wallThickness;
   const out: InteriorDividerCutout[] = [];
   for (const seg of interiorDividerSegments(params, innerW, innerD)) {
-    // Match outer walls: absolute mm override clamps to the segment, otherwise
-    // percentage of the segment span.
+    // Width and alignment are measured ALONG the wall, so use the true wall
+    // length (`wallLen`), which exceeds the axis-projected `segLen` on tilted
+    // dividers. Match outer walls: absolute mm override clamps to the span,
+    // otherwise percentage of it.
     const cutW =
-      cfg.widthMm !== null ? Math.min(cfg.widthMm, seg.segLen) : seg.segLen * (cfg.width / 100);
+      cfg.widthMm !== null ? Math.min(cfg.widthMm, seg.wallLen) : seg.wallLen * (cfg.width / 100);
     const cutH = interiorH * (cfg.depth / 100);
     if (cutW < 0.1 || cutH < 0.1) continue;
     // Honour alignment + offset like outer walls. The cutout's span axis points
     // along the (possibly tilted) divider, so project the along-wall centre
     // offset onto the segment direction (cos/sin of its in-plane rotation).
     const centerOffset = computeCutoutCenter(
-      seg.segLen,
+      seg.wallLen,
       cutW,
       params.wallThickness,
       cfg.alignment,

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -233,10 +233,30 @@ export function computeInteriorDividerCutouts(
   const interiorH = wallHeight - params.wallThickness;
   const out: InteriorDividerCutout[] = [];
   for (const seg of interiorDividerSegments(params, innerW, innerD)) {
-    const cutW = seg.segLen * (cfg.width / 100);
+    // Match outer walls: absolute mm override clamps to the segment, otherwise
+    // percentage of the segment span.
+    const cutW =
+      cfg.widthMm !== null ? Math.min(cfg.widthMm, seg.segLen) : seg.segLen * (cfg.width / 100);
     const cutH = interiorH * (cfg.depth / 100);
     if (cutW < 0.1 || cutH < 0.1) continue;
-    out.push({ cutW, cutH, x: seg.x, y: seg.y, rotateZ: seg.rotateZ });
+    // Honour alignment + offset like outer walls. The cutout's span axis points
+    // along the (possibly tilted) divider, so project the along-wall centre
+    // offset onto the segment direction (cos/sin of its in-plane rotation).
+    const centerOffset = computeCutoutCenter(
+      seg.segLen,
+      cutW,
+      params.wallThickness,
+      cfg.alignment,
+      cfg.offset
+    );
+    const rad = (seg.rotateZ * Math.PI) / 180;
+    out.push({
+      cutW,
+      cutH,
+      x: seg.x + centerOffset * Math.cos(rad),
+      y: seg.y + centerOffset * Math.sin(rad),
+      rotateZ: seg.rotateZ,
+    });
   }
   return out;
 }


### PR DESCRIPTION
## Problem

Reported in discussion #2323: *"The center divider cutout does not sync with the outer wall cutouts."*

With **Linked** mode on, a multi-compartment bin whose outer walls use a non-centered cutout (the reporter's case: Left+Right walls, **Left-aligned, +5 mm offset**, 40% span) renders the interior **divider** cutout stuck in the *center* — it doesn't track the outer windows.

## Root cause

`computeInteriorDividerCutouts` (`wallCutoutBuilder.ts`) placed each divider window at the segment **midpoint** and sized it by **percentage only**. It ignored three fields that outer walls honour via the shared `computeCutoutCenter` helper:

- `alignment` (left / center / right)
- `offset` (mm)
- `widthMm` (absolute-width override)

In linked mode those fields *are* copied onto `walls.interior`, but the geometry never read them — so the divider cut and the outer cuts diverged.

## Fix

Resolve the along-wall center offset with the same `computeCutoutCenter` the outer walls (and ghost preview) already use, then project it onto the divider segment's in-plane axis (`cos/sin` of its rotation). At 0°/90° this reduces exactly to the outer-wall behaviour; the projection also keeps **tilted** dividers (`dividerOverrides`) tracking correctly. Absolute mm widths now clamp to the segment span, matching outer walls.

The change is isolated to that one pure function:
- Divider walls are **not** hex-pattern targets, so there's no pattern-clip window to keep in lockstep (gotcha #5 doesn't apply here).
- Ramp/junction blend zones key off the divider's *perpendicular* position along the outer wall, not the cutout's alignment *along* the divider — unaffected.
- No ghost-preview overlay exists for interior cuts.
- The feature cache key already serialises the full `walls` object (incl. interior alignment/offset/widthMm).

## Tests

- 3 new unit tests on `computeInteriorDividerCutouts`: vertical-divider left/right alignment shifts along Y (symmetric about center), horizontal-divider offset shifts along X, and the mm-width override wins over the percentage.
- New real-WASM **structural** scenario reproducing the reporter's linked left-aligned + offset config on a 2-compartment bin (asserts watertight/manifold output).
- All existing wall-cutout unit + scenario tests still pass; typecheck and lint clean.