### PR TITLE
perf(generation): instant direct-mesh draft for the bin preview (#2334)

### DIFF
--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -37,6 +37,11 @@ vi.mock('@/shared/generation/bridge', () => ({
   createDraftSkipGate: () => () => 1000,
 }));
 
+// Pristine default params, captured before any test mutates the store singleton.
+// Tests that toggle a feature (e.g. scoop, to force a fallback path) must not
+// leak it into the next test, so beforeEach restores this.
+const PRISTINE_PARAMS = useDesignerStore.getState().params;
+
 describe('useGeneration', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -71,10 +76,12 @@ describe('useGeneration', () => {
     (mockBridge.estimateGenerate as ReturnType<typeof vi.fn>).mockReset();
     (mockBridge.estimateGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
-    // Full store reset
+    // Full store reset — including params, so a feature toggled by one test
+    // (forcing a fallback) can't change the next test's direct-mesh eligibility.
     useDesignerStore.setState({
       wasmStatus: 'unloaded',
       generation: { status: 'idle', mesh: null, isDraft: false, progress: 0 },
+      params: PRISTINE_PARAMS,
     });
   });
 
@@ -231,8 +238,14 @@ describe('useGeneration', () => {
     expect(useDesignerStore.getState().generation.isDraft).toBe(false);
 
     // Edit now that the preview bridge is live → draft on the leading edge.
+    // Enable a scoop so the bin is NOT direct-mesh-eligible: that forces the
+    // async Manifold draft path this test exercises (a simple bin would instead
+    // paint the synchronous direct mesh — covered separately below).
     await act(async () => {
-      useDesignerStore.setState((s) => ({ generation: { ...s.generation, epoch: 1 } }));
+      useDesignerStore.setState((s) => ({
+        params: { ...s.params, scoop: { ...s.params.scoop, enabled: true } },
+        generation: { ...s.generation, epoch: 1 },
+      }));
       await vi.advanceTimersByTimeAsync(1);
     });
 
@@ -248,6 +261,79 @@ describe('useGeneration', () => {
       await vi.advanceTimersByTimeAsync(1);
     });
 
+    gen = useDesignerStore.getState().generation;
+    expect(gen.isDraft).toBe(false);
+    expect(gen.mesh?.vertices).toBe(exactVerts);
+    expect(gen.status).toBe('complete');
+  });
+
+  it('paints a synchronous direct-mesh draft for a simple bin, suppressing the Manifold draft', async () => {
+    const draftVerts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const exactVerts = new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0]);
+    const meshOf = (vertices: Float32Array, timingMs = 1) => ({
+      mesh: {
+        vertices,
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        indices: new Uint32Array([0, 1, 2]),
+        edgeVertices: new Float32Array(0),
+        triangleCount: 1,
+      },
+      timingMs,
+    });
+
+    const generateImmediate = vi.fn().mockResolvedValue(meshOf(draftVerts));
+    const previewBridge = {
+      isDestroyed: false,
+      generateImmediate,
+      destroy: vi.fn(),
+    } as unknown as GenerationBridge;
+    mockAcquirePreview.mockResolvedValue(previewBridge);
+
+    let resolveExact: (v: unknown) => void = () => {};
+    (mockBridge.generate as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(meshOf(exactVerts, 5000))
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveExact = r;
+        })
+      );
+
+    renderHook(() => useGeneration());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    // Edit on the default (direct-mesh-eligible) bin. The procedural mesh paints
+    // synchronously before the worker runs and the slower Manifold draft is
+    // suppressed, so a detailed draft — not the single-triangle Manifold mock —
+    // is on screen while the exact result is held open.
+    generateImmediate.mockClear();
+    await act(async () => {
+      useDesignerStore.setState((s) => ({ generation: { ...s.generation, epoch: 1 } }));
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    let gen = useDesignerStore.getState().generation;
+    expect(gen.isDraft).toBe(true);
+    expect(gen.status).toBe('generating');
+    // The detailed direct mesh is on screen (hundreds of vertices) — never the
+    // 3-vertex Manifold draft, which is suppressed once the direct mesh paints,
+    // so the user sees a single draft→exact swap, not draft→draft→exact.
+    expect(gen.mesh?.vertices).not.toBe(draftVerts);
+    expect(gen.mesh?.vertices?.length ?? 0).toBeGreaterThan(100);
+
+    // The Manifold draft stays suppressed even after timers flush — it must
+    // never overwrite the direct mesh with its own (draftVerts) result.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(useDesignerStore.getState().generation.mesh?.vertices).not.toBe(draftVerts);
+
+    // Exact lands and supersedes the direct-mesh draft.
+    await act(async () => {
+      resolveExact(meshOf(exactVerts));
+      await vi.advanceTimersByTimeAsync(1);
+    });
     gen = useDesignerStore.getState().generation;
     expect(gen.isDraft).toBe(false);
     expect(gen.mesh?.vertices).toBe(exactVerts);

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -4,6 +4,7 @@ import { isErr } from '@/core/result';
 import { useDesignerStore } from '../store';
 import { bridgeManager, createDraftSkipGate } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
+import { generateBinDirect, canBinUseDirectMesh } from '@/shared/generation/directMesh';
 import { handleWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
 import { validateCompartmentSizes } from '../utils/validation';
 import {
@@ -45,6 +46,25 @@ function toMeshPayload(result: BridgeResult): GenerationResult {
 }
 
 /**
+ * Map a synchronous direct-mesh draft to the store's mesh payload. The arrays
+ * are freshly allocated by the procedural generator (no worker transfer), so
+ * they're referenced as-is; the draft carries no face groups or LOD.
+ */
+function directMeshToPayload(
+  mesh: ReturnType<typeof generateBinDirect>,
+  timingMs: number
+): GenerationResult {
+  return {
+    vertices: mesh.vertices,
+    normals: mesh.normals,
+    indices: mesh.indices,
+    edgeVertices: mesh.edgeVertices,
+    error: null,
+    timingMs,
+  };
+}
+
+/**
  * Manages the GenerationBridge lifecycle and epoch-based auto-regeneration.
  *
  * Initializes the bridge on mount, triggers generation when epoch changes,
@@ -70,6 +90,10 @@ export function useGeneration(): void {
   // Highest token whose exact result has been applied — drafts at or below it
   // are stale and dropped (covers the exact-resolves-before-draft race).
   const finalizedTokenRef = useRef(0);
+  // Highest token for which a synchronous direct-mesh draft already painted —
+  // suppresses the slower Manifold draft so a simple bin doesn't flash
+  // direct → manifold → exact (two visible swaps).
+  const directShownTokenRef = useRef(0);
   const draftSkipGate = useRef(createDraftSkipGate()).current;
   // After the exact result settles, idle-warm the export-quality (fused) shell
   // so the first export skips the deferred socket↔body fuse. Cancelled (timer
@@ -147,16 +171,35 @@ export function useGeneration(): void {
       }
       setGenerationStatus('generating');
 
+      // Instant synchronous draft (best-effort): for the common rectangular bin,
+      // emit a procedural mesh on the main thread — no kernel, no WASM round-trip
+      // — so something paints on the leading edge of an edit before the worker
+      // even starts. Gated to bins the direct path renders faithfully; a throw
+      // (degenerate input) silently degrades to the async paths below.
+      if (canBinUseDirectMesh(currentParams)) {
+        try {
+          const start = performance.now();
+          const mesh = generateBinDirect(currentParams);
+          if (token === genTokenRef.current && token > finalizedTokenRef.current) {
+            setDraftResult(directMeshToPayload(mesh, performance.now() - start));
+            directShownTokenRef.current = token;
+          }
+        } catch {
+          // No instant draft for this edit; the async draft/exact still run.
+        }
+      }
+
       // Fast draft on the leading edge (best-effort): renders while the exact
       // geometry computes. Skipped when the exact worker's cache-aware estimate
       // predicts a build faster than the gate's threshold — a draft replaced
       // almost immediately is just flicker, and the threshold drops during a
       // scrub (see draftPolicy). The estimate resolves in a few ms when the
       // worker is idle; null (no history / worker busy mid-generation /
-      // timeout) means slow, so the draft proceeds.
+      // timeout) means slow, so the draft proceeds. Suppressed when the
+      // synchronous direct mesh already painted this edit.
       const skipBelowMs = draftSkipGate();
       const preview = previewBridgeRef.current;
-      if (preview && !preview.isDestroyed) {
+      if (preview && !preview.isDestroyed && directShownTokenRef.current !== token) {
         void bridge.estimateGenerate(currentParams).then((predictedMs) => {
           if (predictedMs !== null && predictedMs < skipBelowMs) return;
           if (token !== genTokenRef.current || token <= finalizedTokenRef.current) return;
@@ -200,7 +243,14 @@ export function useGeneration(): void {
         setGenerationStatus('error');
       }
     },
-    [setGenerationStatus, setGenerationResult, dispatchDraft, pushPerfSnapshot, draftSkipGate]
+    [
+      setGenerationStatus,
+      setGenerationResult,
+      setDraftResult,
+      dispatchDraft,
+      pushPerfSnapshot,
+      draftSkipGate,
+    ]
   );
 
   // Generate a non-bin item mesh via the generic GENERATE_ITEM path. No draft /

--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -57,9 +57,10 @@ graph TB
 - `worker/generators/splitConnectorBuilder.ts` — split-piece joints: floor scarf lap + optional press-together wall-locking keys (#1869)
 - `worker/generators/baseplateGenerator.ts` — baseplate BREP generation
 - `worker/generators/baseplateDirectMesh.ts` — direct mesh generation orchestrator for baseplate preview (procedural, no BREP)
+- `worker/generators/binDirectMesh.ts` — direct mesh generation for the bin preview (`generateBinDirect`: hollow body + stacking lip + tapered feet) plus `canBinUseDirectMesh`, the allowlist that gates which bins the procedural path may render (procedural, no BREP)
 - `worker/generators/directMeshBuilder.ts` — `MeshBuilder` class + `faceNormal`, `tangentVectors`, segment-count constants
 - `worker/generators/directMeshShapes.ts` — 2D primitives shared across emitters: rounded rectangles, circles, point-in-polygon
-- `worker/generators/directMeshWalls.ts` — pocket walls (with optional floor) and outer perimeter walls
+- `worker/generators/directMeshWalls.ts` — pocket walls (with optional floor) and outer perimeter walls (`addOuterWalls` takes a `zBot` so the bin body can start at the socket interface)
 - `worker/generators/directMeshFaces.ts` — top/bottom slab face = padding ring + per-cell corner gussets; closed bottom for magnet variants
 - `worker/generators/directMeshMagnets.ts` — magnet hole emitter (cancel + cylinder + floor pattern)
 - `worker/generators/directMeshConnectors.ts` — connector nub (male) and connector hole (female) emitters
@@ -106,6 +107,12 @@ Requests tagged with `requestId`; cancelled requests ignored.
 ## Manifold Draft Preview (`manifold_preview`, graduated)
 
 A second `GenerationBridge('manifold')` runs the Manifold mesh-CSG kernel at pinned draft quality in its own worker, acquired via `BridgeManager.acquirePreview()` / `releasePreview()` (ref-counted, idle-kept, independent of the exact bridge; init failure is non-fatal). Consumers render a fast coarse draft on the leading edge of an edit, then the exact occt-wasm result supersedes it. `worker/wasmInstantiator.ts:loadManifold()` dynamically imports `manifold-3d` + its WASM (`?url` for the Vite worker) and registers the kernel via brepjs `initFromManifold`. `KernelName` gains `'manifold'`. Graduated out of Labs (always on) — the flag id remains as the runtime gate (`isFeatureEnabled('manifold_preview')`, now always true) and a draft init failure degrades gracefully to the exact-only path; exports always use the exact kernel.
+
+### Synchronous direct-mesh draft (bin + baseplate)
+
+Ahead of the Manifold draft there is an even faster tier: a **synchronous, brepjs-free** procedural mesh built on the main thread (no worker, no WASM round-trip). The baseplate uses `generateBaseplateDirect`; the bin uses `generateBinDirect` (both re-exported from `@/shared/generation/directMesh`). `useGeneration` paints it on the leading edge of an edit before the worker even starts, then the exact B-rep supersedes it — and when the direct mesh paints, the slower Manifold draft is **suppressed** (via `directShownTokenRef`) so a simple bin swaps once (direct→exact), not twice.
+
+The bin path is gated by `canBinUseDirectMesh` — an **allowlist** that returns true only for bins the procedural emitters render faithfully (rectangular footprint, standard/lip base, plain feet). **Gotcha:** any new bin feature that changes the rendered shape (a base style, a cut, an interior structure, a footprint modifier) MUST be added to this gate as a fallback, or its draft will silently omit the feature. The caller also try/catches `generateBinDirect`, so a missed case degrades to "no instant draft," never a wrong mesh. The export path always uses the exact kernel.
 
 ## Patterns System
 

--- a/src/features/generation/worker/generators/binDirectMesh.parity.test.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.parity.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+/**
+ * Draft/exact parity guard for the direct-mesh bin preview.
+ *
+ * The direct mesh is shown instantly and then replaced by the exact B-rep
+ * result, so the two must line up — a footprint, foot, or lip-rim mismatch
+ * would make the bin visibly jump on the swap. Visual parity isn't
+ * snapshot-verifiable, so this measures the dimensional invariants that a
+ * CLEARANCE / corner-radius / lip drift would break: bounding box, lip-rim
+ * height, and triangle-count order of magnitude. The exact path runs at preview
+ * quality (`forExport = false`), the same profile the draft targets.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import { initBrepjs, getGenerateBin, type GenerateBinFn } from './__kernel-tests__/wasmInit';
+import { buildParams } from './__kernel-tests__/scenarioTypes';
+import { generateBinDirect } from './binDirectMesh';
+
+let generateBin: GenerateBinFn;
+
+beforeAll(async () => {
+  await initBrepjs();
+  generateBin = getGenerateBin();
+}, 30_000);
+
+const noop = (): void => {};
+
+interface Bounds {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  minZ: number;
+  maxZ: number;
+}
+
+function bounds(vertices: Float32Array): Bounds {
+  const b: Bounds = {
+    minX: Infinity,
+    maxX: -Infinity,
+    minY: Infinity,
+    maxY: -Infinity,
+    minZ: Infinity,
+    maxZ: -Infinity,
+  };
+  for (let i = 0; i < vertices.length; i += 3) {
+    b.minX = Math.min(b.minX, vertices[i]);
+    b.maxX = Math.max(b.maxX, vertices[i]);
+    b.minY = Math.min(b.minY, vertices[i + 1]);
+    b.maxY = Math.max(b.maxY, vertices[i + 1]);
+    b.minZ = Math.min(b.minZ, vertices[i + 2]);
+    b.maxZ = Math.max(b.maxZ, vertices[i + 2]);
+  }
+  return b;
+}
+
+/** Assert each bounding-box face aligns within the given tolerances. */
+function expectBoundsMatch(direct: Bounds, brep: Bounds, xyTol: number, zTol: number): void {
+  expect(Math.abs(direct.minX - brep.minX)).toBeLessThan(xyTol);
+  expect(Math.abs(direct.maxX - brep.maxX)).toBeLessThan(xyTol);
+  expect(Math.abs(direct.minY - brep.minY)).toBeLessThan(xyTol);
+  expect(Math.abs(direct.maxY - brep.maxY)).toBeLessThan(xyTol);
+  expect(Math.abs(direct.minZ - brep.minZ)).toBeLessThan(zTol);
+  expect(Math.abs(direct.maxZ - brep.maxZ)).toBeLessThan(zTol);
+}
+
+const cases: ReadonlyArray<readonly [string, Partial<BinParams>]> = [
+  ['2×2×3 standard + lip', { width: 2, depth: 2, height: 3 }],
+  [
+    '2×2×3 no lip',
+    { width: 2, depth: 2, height: 3, base: { ...buildParams({}).base, stackingLip: false } },
+  ],
+  ['3×2×4 standard + lip', { width: 3, depth: 2, height: 4 }],
+  ['2.5×2×3 fractional + lip', { width: 2.5, depth: 2, height: 3 }],
+];
+
+describe('binDirectMesh — draft/exact parity', () => {
+  for (const [label, overrides] of cases) {
+    it(`${label}: bounding box matches the exact preview mesh`, () => {
+      const params = buildParams(overrides);
+      const brep = generateBin(params, noop, false);
+      const direct = generateBinDirect(params, noop);
+
+      // XY within 1mm (corner-arc tessellation differs); Z within 0.2mm
+      // (the lip rim is the tight constraint — it must not visibly shift).
+      expectBoundsMatch(bounds(direct.vertices), bounds(brep.vertices), 1, 0.2);
+    });
+
+    it(`${label}: triangle count stays within an order of magnitude`, () => {
+      const params = buildParams(overrides);
+      const brep = generateBin(params, noop, false);
+      const direct = generateBinDirect(params, noop);
+
+      const ratio = direct.triangleCount / brep.triangleCount;
+      expect(ratio).toBeGreaterThan(0.1);
+      expect(ratio).toBeLessThan(10);
+    });
+  }
+});

--- a/src/features/generation/worker/generators/binDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.test.ts
@@ -128,8 +128,21 @@ describe('binDirectMesh — geometry sanity', () => {
       bin(),
       bin({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } }),
       bin({ base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true } }),
+      // wallThickness === LIP_TAPER_WIDTH: the lip overhang collapses; the mesh
+      // must stay consistently oriented (no inverted/zero-area underside ring).
+      bin({ wallThickness: 2.6 }),
     ]) {
       expect(signedVolume(generateBinDirect(params, noop))).toBeLessThan(-1000);
+    }
+  });
+
+  it('handles a thick wall (lip overhang collapses) without degenerate faces', () => {
+    // wallThickness ≥ LIP_TAPER_WIDTH (2.6mm) makes the lip base meet the cavity
+    // edge — the overhang ring is skipped rather than emitted inverted.
+    const mesh = generateBinDirect(bin({ wallThickness: 2.6 }), noop);
+    expect(mesh.triangleCount).toBeGreaterThan(0);
+    for (let i = 0; i < mesh.vertices.length; i++) {
+      expect(Number.isFinite(mesh.vertices[i])).toBe(true);
     }
   });
 

--- a/src/features/generation/worker/generators/binDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.test.ts
@@ -1,0 +1,266 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { generateBinDirect, canBinUseDirectMesh } from './binDirectMesh';
+import { CORNER_SEGMENTS } from './directMeshBuilder';
+import { LIP_HEIGHT, LIP_OVERLAP, CLEARANCE } from './generatorConstants';
+
+const bin = (overrides: Partial<BinParams> = {}): BinParams => ({
+  ...DEFAULT_BIN_PARAMS,
+  ...overrides,
+});
+
+const noop = (): void => {};
+
+interface BoundingBox {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  minZ: number;
+  maxZ: number;
+}
+
+function computeBounds(vertices: Float32Array): BoundingBox {
+  const bb: BoundingBox = {
+    minX: Infinity,
+    maxX: -Infinity,
+    minY: Infinity,
+    maxY: -Infinity,
+    minZ: Infinity,
+    maxZ: -Infinity,
+  };
+  for (let i = 0; i < vertices.length; i += 3) {
+    const x = vertices[i],
+      y = vertices[i + 1],
+      z = vertices[i + 2];
+    if (x < bb.minX) bb.minX = x;
+    if (x > bb.maxX) bb.maxX = x;
+    if (y < bb.minY) bb.minY = y;
+    if (y > bb.maxY) bb.maxY = y;
+    if (z < bb.minZ) bb.minZ = z;
+    if (z > bb.maxZ) bb.maxZ = z;
+  }
+  return bb;
+}
+
+/** Count downward-facing (−Z) triangles whose three vertices all lie at z≈0 —
+ *  i.e. foot undersides (the body bottom cap sits at z=SOCKET_HEIGHT, not 0). */
+function footBottomTriangles(mesh: { vertices: Float32Array; indices: Uint32Array }): number {
+  const { vertices, indices } = mesh;
+  let count = 0;
+  for (let i = 0; i < indices.length; i += 3) {
+    const za = vertices[indices[i] * 3 + 2];
+    const zb = vertices[indices[i + 1] * 3 + 2];
+    const zc = vertices[indices[i + 2] * 3 + 2];
+    if (Math.abs(za) < 1e-3 && Math.abs(zb) < 1e-3 && Math.abs(zc) < 1e-3) count++;
+  }
+  return count;
+}
+
+/** Triangles per fan cap = ring vertex count = 4 quarter-arcs of (segments+1). */
+const CAP_TRIS = 4 * (CORNER_SEGMENTS + 1);
+
+/**
+ * Signed volume from triangle winding (divergence theorem). Its magnitude is the
+ * enclosed volume only when every face is consistently oriented; a flipped or
+ * inconsistent face makes contributions cancel, collapsing the magnitude. The
+ * codebase's `roundedRectPoints` winding makes the "outward" convention yield a
+ * NEGATIVE signed volume (verified against the proven baseplate direct mesh), so
+ * a correct bin mesh is large-and-negative. Catches winding bugs that
+ * bounding-box/parity checks can't.
+ */
+function signedVolume(mesh: { vertices: Float32Array; indices: Uint32Array }): number {
+  const { vertices, indices } = mesh;
+  let v6 = 0;
+  for (let i = 0; i < indices.length; i += 3) {
+    const a = indices[i] * 3;
+    const b = indices[i + 1] * 3;
+    const c = indices[i + 2] * 3;
+    const ax = vertices[a],
+      ay = vertices[a + 1],
+      az = vertices[a + 2];
+    const bx = vertices[b],
+      by = vertices[b + 1],
+      bz = vertices[b + 2];
+    const cx = vertices[c],
+      cy = vertices[c + 1],
+      cz = vertices[c + 2];
+    // a · (b × c)
+    v6 += ax * (by * cz - bz * cy) - ay * (bx * cz - bz * cx) + az * (bx * cy - by * cx);
+  }
+  return v6 / 6;
+}
+
+describe('binDirectMesh — geometry sanity', () => {
+  it('generates a non-empty mesh for the default bin (lip on)', () => {
+    const mesh = generateBinDirect(bin(), noop);
+    expect(mesh.vertices.length).toBeGreaterThan(0);
+    expect(mesh.indices.length).toBeGreaterThan(0);
+    expect(mesh.triangleCount).toBeGreaterThan(0);
+    expect(mesh.edgeVertices.length).toBeGreaterThan(0);
+  });
+
+  it('generates a non-empty mesh with the lip disabled', () => {
+    const mesh = generateBinDirect(
+      bin({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } }),
+      noop
+    );
+    expect(mesh.triangleCount).toBeGreaterThan(0);
+  });
+
+  it('produces no NaN/Infinity in positions or normals', () => {
+    const mesh = generateBinDirect(bin(), noop);
+    for (let i = 0; i < mesh.vertices.length; i++) {
+      expect(Number.isFinite(mesh.vertices[i])).toBe(true);
+    }
+    for (let i = 0; i < mesh.normals.length; i++) {
+      expect(Number.isFinite(mesh.normals[i])).toBe(true);
+    }
+  });
+
+  it('winds every face consistently outward (large negative signed volume)', () => {
+    // Lip on, no lip, and half sockets all exercise different emitters. A flipped
+    // or inconsistent face would push the volume toward zero (cancellation) or
+    // positive (global flip); a correct mesh is large-and-negative (≈ −solid mm³).
+    for (const params of [
+      bin(),
+      bin({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } }),
+      bin({ base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true } }),
+    ]) {
+      expect(signedVolume(generateBinDirect(params, noop))).toBeLessThan(-1000);
+    }
+  });
+
+  it('bounding box matches the nominal outer footprint and height (lip on)', () => {
+    const params = bin({ width: 2, depth: 2, height: 3 });
+    const bb = computeBounds(generateBinDirect(params, noop).vertices);
+    const outerW = 2 * 42 - CLEARANCE;
+    const outerD = 2 * 42 - CLEARANCE;
+    expect(bb.minX).toBeCloseTo(-outerW / 2, 1);
+    expect(bb.maxX).toBeCloseTo(outerW / 2, 1);
+    expect(bb.minY).toBeCloseTo(-outerD / 2, 1);
+    expect(bb.maxY).toBeCloseTo(outerD / 2, 1);
+    expect(bb.minZ).toBeCloseTo(0, 2);
+    // 3U body (21mm) + lip peak (4.4 − 0.1mm overlap).
+    expect(bb.maxZ).toBeCloseTo(3 * 7 + LIP_HEIGHT - LIP_OVERLAP, 2);
+  });
+
+  it('top sits at the body wall when the lip is disabled', () => {
+    const params = bin({
+      width: 2,
+      depth: 2,
+      height: 3,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+    });
+    const bb = computeBounds(generateBinDirect(params, noop).vertices);
+    expect(bb.maxZ).toBeCloseTo(3 * 7, 2);
+  });
+
+  it('emits one foot per full cell on a 2×2 bin', () => {
+    const mesh = generateBinDirect(bin({ width: 2, depth: 2 }), noop);
+    expect(footBottomTriangles(mesh)).toBe(4 * CAP_TRIS);
+  });
+
+  it('emits one foot per full cell on a 3×2 bin', () => {
+    const mesh = generateBinDirect(bin({ width: 3, depth: 2 }), noop);
+    expect(footBottomTriangles(mesh)).toBe(6 * CAP_TRIS);
+  });
+
+  it('subdivides into half sockets (16 feet on a 2×2) when enabled', () => {
+    const mesh = generateBinDirect(
+      bin({ width: 2, depth: 2, base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true } }),
+      noop
+    );
+    expect(footBottomTriangles(mesh)).toBe(16 * CAP_TRIS);
+  });
+
+  it('places a fractional edge foot for a 2.5×2 bin', () => {
+    // width 2.5 → cells [1,1,0.5] × [1,1] = 6 feet.
+    const mesh = generateBinDirect(bin({ width: 2.5, depth: 2 }), noop);
+    expect(footBottomTriangles(mesh)).toBe(6 * CAP_TRIS);
+    const bb = computeBounds(mesh.vertices);
+    expect(bb.maxX - bb.minX).toBeCloseTo(2.5 * 42 - CLEARANCE, 1);
+  });
+
+  it('generates an 8×8 bin in under 200ms', () => {
+    const start = performance.now();
+    const mesh = generateBinDirect(bin({ width: 8, depth: 8, height: 6 }), noop);
+    const elapsed = performance.now() - start;
+    expect(mesh.triangleCount).toBeGreaterThan(0);
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it('throws on degenerate dimensions', () => {
+    expect(() => generateBinDirect(bin({ width: 0 }), noop)).toThrow();
+    expect(() => generateBinDirect(bin({ depth: -1 }), noop)).toThrow();
+    expect(() => generateBinDirect(bin({ height: 0 }), noop)).toThrow();
+    expect(() => generateBinDirect(bin({ width: 999 }), noop)).toThrow();
+  });
+
+  it('aborts when the signal is already aborted', () => {
+    const controller = new AbortController();
+    controller.abort();
+    expect(() => generateBinDirect(bin(), noop, controller.signal)).toThrow();
+  });
+});
+
+describe('binDirectMesh — canBinUseDirectMesh gate', () => {
+  it('allows the default bin (standard + lip)', () => {
+    expect(canBinUseDirectMesh(DEFAULT_BIN_PARAMS)).toBe(true);
+  });
+
+  it('allows a no-lip standard bin', () => {
+    expect(
+      canBinUseDirectMesh(bin({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } }))
+    ).toBe(true);
+  });
+
+  it('allows half sockets', () => {
+    expect(
+      canBinUseDirectMesh(bin({ base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true } }))
+    ).toBe(true);
+  });
+
+  const base = DEFAULT_BIN_PARAMS.base;
+  const fallbackCases: ReadonlyArray<readonly [string, Partial<BinParams>]> = [
+    ['magnet base', { base: { ...base, style: 'magnet' } }],
+    ['screw base', { base: { ...base, style: 'screw' } }],
+    ['weighted base', { base: { ...base, style: 'weighted' } }],
+    ['flat base', { base: { ...base, style: 'flat' } }],
+    ['solid base', { base: { ...base, solid: true } }],
+    ['lightweight base', { base: { ...base, lightweight: true } }],
+    ['slotted body', { style: 'slotted' }],
+    ['solid body', { style: 'solid' }],
+    [
+      'compartments',
+      { compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, cells: [0, 1] } },
+    ],
+    ['scoop', { scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true } }],
+    ['label', { label: { ...DEFAULT_BIN_PARAMS.label, enabled: true } }],
+    ['wall cutouts', { walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: true } }],
+    ['handles', { handles: { ...DEFAULT_BIN_PARAMS.handles, enabled: true } }],
+    ['wall pattern', { wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true } }],
+    ['lid', { lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true } }],
+    ['overhang', { overhang: { left: 2, right: 0, front: 0, back: 0 } }],
+  ];
+
+  for (const [label, override] of fallbackCases) {
+    it(`falls back for ${label}`, () => {
+      expect(canBinUseDirectMesh(bin(override))).toBe(false);
+    });
+  }
+
+  it('falls back when an insert is present', () => {
+    const params = bin();
+    const withInsert = { ...params, inserts: [{} as never] };
+    expect(canBinUseDirectMesh(withInsert)).toBe(false);
+  });
+
+  it('falls back when a cutout is present', () => {
+    const params = bin();
+    const withCutout = { ...params, cutouts: [{} as never] };
+    expect(canBinUseDirectMesh(withCutout)).toBe(false);
+  });
+});

--- a/src/features/generation/worker/generators/binDirectMesh.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.ts
@@ -220,14 +220,23 @@ function addBinBody(mb: MeshBuilder, dims: BinBodyDims): void {
   // Stacking lip: the outer face is flush (already extended to the peak). The
   // lip's inner profile starts inset by LIP_TAPER_WIDTH at the rim and tapers
   // back to flush at the peak, where it meets the outer wall in a sharp ridge.
-  const lipBaseW = Math.max(outerW - 2 * LIP_TAPER_WIDTH, MIN_RING_DIM);
-  const lipBaseD = Math.max(outerD - 2 * LIP_TAPER_WIDTH, MIN_RING_DIM);
-  const lipBaseR = Math.max(BOX_CORNER_RADIUS - LIP_TAPER_WIDTH, 0.1);
+  // The inner inset can't sit outside the cavity wall — when wallThickness
+  // reaches LIP_TAPER_WIDTH (2.6mm is a valid wall option) the lip base lands
+  // on the cavity edge and the overhang vanishes, so clamp to wallThickness to
+  // avoid an inverted/zero-area underside ring (matches the exact path, which
+  // can't overhang past its own wall either).
+  const lipInnerInset = Math.max(LIP_TAPER_WIDTH, wallThickness);
+  const lipBaseW = Math.max(outerW - 2 * lipInnerInset, MIN_RING_DIM);
+  const lipBaseD = Math.max(outerD - 2 * lipInnerInset, MIN_RING_DIM);
+  const lipBaseR = Math.max(BOX_CORNER_RADIUS - lipInnerInset, 0.1);
   const lipBasePts = roundedRectPoints(lipBaseW, lipBaseD, lipBaseR, CORNER_SEGMENTS);
 
   // Underside of the lip overhang: from the cavity edge (inset wallThickness)
-  // inward to the lip base (inset LIP_TAPER_WIDTH), facing down into the cavity.
-  addRingCap(mb, 0, 0, innerPts, lipBasePts, zWallTop, false);
+  // inward to the lip base (inset lipInnerInset), facing down into the cavity.
+  // Skipped when there's no real overhang (lip base on the cavity edge).
+  if (lipInnerInset > wallThickness + 1e-3) {
+    addRingCap(mb, 0, 0, innerPts, lipBasePts, zWallTop, false);
+  }
   // Lip inner taper rising from the base ring to the flush peak.
   addTaperedTube(mb, 0, 0, outerPts, lipBasePts, zOuterTop, zWallTop, false);
 }

--- a/src/features/generation/worker/generators/binDirectMesh.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.ts
@@ -1,0 +1,367 @@
+/**
+ * Direct mesh generation for Gridfinity bins (instant draft preview).
+ *
+ * Emits bin geometry procedurally — vertices and triangles computed
+ * mathematically — without the brepjs B-rep kernel (solid modelling, boolean
+ * fuse/cut, tessellation). This is the bin-side counterpart to
+ * `baseplateDirectMesh.ts`: it runs synchronously on the main thread so the
+ * designer can paint a draft in <50ms while the worker computes the exact
+ * B-rep mesh that replaces it. The export path is untouched (full B-rep).
+ *
+ * Scope (first slice): the common rectangular bin — hollow body, optional
+ * stacking lip, and the per-cell tapered gridfinity feet. Anything the
+ * procedural path can't render faithfully (compartments, scoops, label tabs,
+ * wall cutouts, handles, cutouts, inserts, wall patterns, lids, custom masks,
+ * overhang, magnet/screw holes, non-standard base/body styles) forces a
+ * fallback via `canBinUseDirectMesh` — a draft that silently dropped a visible
+ * feature would be a regression, so the gate is an allowlist.
+ *
+ * Coordinate system (matches the exact mesh after `translateStage`):
+ * - Z=0: foot underside (absolute bottom).
+ * - Z=SOCKET_HEIGHT: foot top / socket interface (mates with the body).
+ * - Z=SOCKET_HEIGHT + wallThickness: interior cavity floor.
+ * - Z=totalHeight (= SOCKET_HEIGHT + wallHeight): body wall top.
+ * - With a lip: the outer wall extends to totalHeight + LIP_HEIGHT − LIP_OVERLAP.
+ * - XY centered at the origin; per-cell feet are CLEARANCE smaller than the
+ *   nominal cell so they seat in a baseplate pocket.
+ */
+
+import type { BinParams } from '@/shared/types/bin';
+import { CONSTRAINTS } from '@/core/constants';
+import { isPartialMask } from '@/shared/utils/cellMask';
+import type { MeshData } from '../../bridge/types';
+import type { ProgressFn } from './meshUtils';
+import { MeshBuilder, CORNER_SEGMENTS } from './directMeshBuilder';
+import { roundedRectPoints } from './directMeshShapes';
+import { addOuterWalls } from './directMeshWalls';
+import { creaseEdges } from './utils/creaseEdges';
+import { forEachCell } from './cellDecomposition';
+import {
+  SIZE,
+  HEIGHT_UNIT,
+  CLEARANCE,
+  CORNER_RADIUS,
+  BOX_CORNER_RADIUS,
+  SOCKET_HEIGHT,
+  SOCKET_TAPER_WIDTH,
+  LIP_HEIGHT,
+  LIP_TAPER_WIDTH,
+  LIP_OVERLAP,
+  MIN_PRINTABLE_TILE_MM,
+} from './generatorConstants';
+
+type Pt = readonly [number, number];
+
+/** Smallest ring half-dimension we keep; below this the rounded-rect sampler
+ *  collapses to sharp corners and the top/bottom rings stop matching. */
+const MIN_RING_DIM = 0.5;
+
+/** Inset of the foot bottom ring from the cell edge — matches `socketBuilder`'s
+ *  simplified (preview) profile so the draft lines up with the on-screen exact. */
+const FOOT_BOTTOM_INSET = SOCKET_TAPER_WIDTH - CLEARANCE / 2; // 2.95mm
+
+function abortIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new Error('Generation cancelled');
+}
+
+/**
+ * Tapered tube between an upper ring (`topPts` @ `zTop`) and a lower ring
+ * (`botPts` @ `zBot`). The two rings must have the same vertex count. `outward`
+ * selects the winding so face normals point away from (`cx`,`cy`) for exterior
+ * walls/feet, or toward the axis for interior cavity/lip walls. Ring vertices
+ * are shared across adjacent quads so `computeVertexNormals` smooths the rounded
+ * corners while the crease threshold keeps arc→flat transitions crisp.
+ */
+function addTaperedTube(
+  mb: MeshBuilder,
+  cx: number,
+  cy: number,
+  topPts: readonly Pt[],
+  botPts: readonly Pt[],
+  zTop: number,
+  zBot: number,
+  outward: boolean
+): void {
+  const n = topPts.length;
+  const topRing = new Array<number>(n);
+  const botRing = new Array<number>(n);
+  for (let i = 0; i < n; i++) {
+    topRing[i] = mb.pushVertex(topPts[i][0] + cx, topPts[i][1] + cy, zTop, 0, 0, 0);
+    botRing[i] = mb.pushVertex(botPts[i][0] + cx, botPts[i][1] + cy, zBot, 0, 0, 0);
+  }
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    if (outward) {
+      mb.pushQuad(topRing[i], topRing[j], botRing[j], botRing[i]);
+    } else {
+      mb.pushQuad(topRing[j], topRing[i], botRing[i], botRing[j]);
+    }
+  }
+}
+
+/** Solid disc/cap over one ring at height `z`, facing +Z (`faceUp`) or −Z. */
+function addSolidCap(
+  mb: MeshBuilder,
+  cx: number,
+  cy: number,
+  pts: readonly Pt[],
+  z: number,
+  faceUp: boolean
+): void {
+  const nz = faceUp ? 1 : -1;
+  const center = mb.pushVertex(cx, cy, z, 0, 0, nz);
+  const verts = pts.map((p) => mb.pushVertex(p[0] + cx, p[1] + cy, z, 0, 0, nz));
+  const n = verts.length;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    if (faceUp) mb.pushTriangle(center, verts[i], verts[j]);
+    else mb.pushTriangle(center, verts[j], verts[i]);
+  }
+}
+
+/**
+ * Flat annulus between an outer ring and an inner ring at the same height `z`.
+ * Both rings must share a vertex count. `faceUp` selects the normal direction.
+ */
+function addRingCap(
+  mb: MeshBuilder,
+  cx: number,
+  cy: number,
+  outerPts: readonly Pt[],
+  innerPts: readonly Pt[],
+  z: number,
+  faceUp: boolean
+): void {
+  const nz = faceUp ? 1 : -1;
+  const n = outerPts.length;
+  const outer = new Array<number>(n);
+  const inner = new Array<number>(n);
+  for (let i = 0; i < n; i++) {
+    outer[i] = mb.pushVertex(outerPts[i][0] + cx, outerPts[i][1] + cy, z, 0, 0, nz);
+    inner[i] = mb.pushVertex(innerPts[i][0] + cx, innerPts[i][1] + cy, z, 0, 0, nz);
+  }
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    if (faceUp) mb.pushQuad(outer[i], outer[j], inner[j], inner[i]);
+    else mb.pushQuad(outer[i], inner[i], inner[j], outer[j]);
+  }
+}
+
+/** Clamp a cell-socket corner radius to fit the cell and stay in the rounded
+ *  sampler regime (so every ring has the same vertex count). */
+function footCornerRadius(cellW: number, cellD: number): number {
+  return Math.max(Math.min(CORNER_RADIUS, Math.min(cellW, cellD) / 2 - 0.1), 0.1);
+}
+
+/**
+ * One gridfinity foot: a closed tapered frustum from the cell footprint at
+ * Z=SOCKET_HEIGHT down to the inset bottom ring at Z=0. Built as its own closed
+ * solid; its top cap sits coincident with the body's bottom cap (an interior,
+ * non-visible join) so the overlap never z-fights.
+ */
+function addBaseFoot(mb: MeshBuilder, cx: number, cy: number, cellW: number, cellD: number): void {
+  const cornerR = footCornerRadius(cellW, cellD);
+  const botW = Math.max(cellW - 2 * FOOT_BOTTOM_INSET, MIN_RING_DIM);
+  const botD = Math.max(cellD - 2 * FOOT_BOTTOM_INSET, MIN_RING_DIM);
+  const botR = Math.max(cornerR - FOOT_BOTTOM_INSET, 0.1);
+
+  const topPts = roundedRectPoints(cellW, cellD, cornerR, CORNER_SEGMENTS);
+  const botPts = roundedRectPoints(botW, botD, botR, CORNER_SEGMENTS);
+
+  addTaperedTube(mb, cx, cy, topPts, botPts, SOCKET_HEIGHT, 0, true);
+  addSolidCap(mb, cx, cy, botPts, 0, false); // underside
+  addSolidCap(mb, cx, cy, topPts, SOCKET_HEIGHT, true); // interface with body
+}
+
+interface BinBodyDims {
+  readonly outerW: number;
+  readonly outerD: number;
+  readonly wallThickness: number;
+  readonly totalHeight: number;
+  readonly hasLip: boolean;
+}
+
+/**
+ * The hollow bin body: outer walls (rising from the socket interface), a closed
+ * bottom slab, the interior cavity walls + floor, and either a flat top rim
+ * (no lip) or a tapered stacking-lip collar.
+ */
+function addBinBody(mb: MeshBuilder, dims: BinBodyDims): void {
+  const { outerW, outerD, wallThickness, totalHeight, hasLip } = dims;
+
+  const innerW = Math.max(outerW - 2 * wallThickness, MIN_RING_DIM);
+  const innerD = Math.max(outerD - 2 * wallThickness, MIN_RING_DIM);
+  const innerR = Math.max(BOX_CORNER_RADIUS - wallThickness, 0.1);
+
+  const outerPts = roundedRectPoints(outerW, outerD, BOX_CORNER_RADIUS, CORNER_SEGMENTS);
+  const innerPts = roundedRectPoints(innerW, innerD, innerR, CORNER_SEGMENTS);
+
+  const zBodyBot = SOCKET_HEIGHT;
+  const zFloorTop = SOCKET_HEIGHT + wallThickness;
+  const zWallTop = totalHeight; // = SOCKET_HEIGHT + wallHeight
+  const zOuterTop = hasLip ? totalHeight + LIP_HEIGHT - LIP_OVERLAP : zWallTop;
+
+  // Outer wall: flush from the socket interface up to the wall top (or lip peak).
+  addOuterWalls(mb, outerPts, 0, 0, zOuterTop, zBodyBot);
+  // Closed underside at the socket interface (the foot top caps overlap here,
+  // hidden inside the join — no visible coincident faces).
+  addSolidCap(mb, 0, 0, outerPts, zBodyBot, false);
+  // Interior cavity wall (vertical, inward-facing) from the floor to the rim.
+  addTaperedTube(mb, 0, 0, innerPts, innerPts, zWallTop, zFloorTop, false);
+  // Interior floor.
+  addSolidCap(mb, 0, 0, innerPts, zFloorTop, true);
+
+  if (!hasLip) {
+    // Flat rim ring closing the wall top between the outer and inner edges.
+    addRingCap(mb, 0, 0, outerPts, innerPts, zWallTop, true);
+    return;
+  }
+
+  // Stacking lip: the outer face is flush (already extended to the peak). The
+  // lip's inner profile starts inset by LIP_TAPER_WIDTH at the rim and tapers
+  // back to flush at the peak, where it meets the outer wall in a sharp ridge.
+  const lipBaseW = Math.max(outerW - 2 * LIP_TAPER_WIDTH, MIN_RING_DIM);
+  const lipBaseD = Math.max(outerD - 2 * LIP_TAPER_WIDTH, MIN_RING_DIM);
+  const lipBaseR = Math.max(BOX_CORNER_RADIUS - LIP_TAPER_WIDTH, 0.1);
+  const lipBasePts = roundedRectPoints(lipBaseW, lipBaseD, lipBaseR, CORNER_SEGMENTS);
+
+  // Underside of the lip overhang: from the cavity edge (inset wallThickness)
+  // inward to the lip base (inset LIP_TAPER_WIDTH), facing down into the cavity.
+  addRingCap(mb, 0, 0, innerPts, lipBasePts, zWallTop, false);
+  // Lip inner taper rising from the base ring to the flush peak.
+  addTaperedTube(mb, 0, 0, outerPts, lipBasePts, zOuterTop, zWallTop, false);
+}
+
+/**
+ * Generate bin draft mesh data procedurally, without the B-rep kernel.
+ *
+ * Caller must gate with {@link canBinUseDirectMesh} first; this still validates
+ * and throws on degenerate input so the caller can fall back to the async path.
+ */
+export function generateBinDirect(
+  params: BinParams,
+  onProgress?: ProgressFn,
+  signal?: AbortSignal
+): MeshData {
+  const { width, depth, height } = params;
+  if (
+    !Number.isFinite(width) ||
+    width <= 0 ||
+    !Number.isFinite(depth) ||
+    depth <= 0 ||
+    !Number.isFinite(height) ||
+    height <= 0
+  ) {
+    throw new Error(`Invalid bin dimensions: ${width}x${depth}x${height}`);
+  }
+  if (width > CONSTRAINTS.GRID_MAX || depth > CONSTRAINTS.GRID_MAX) {
+    throw new Error(`Bin dimensions ${width}x${depth} exceed maximum ${CONSTRAINTS.GRID_MAX}`);
+  }
+
+  onProgress?.('base', 0);
+  abortIfCancelled(signal);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- legacy designs may lack gridUnitMm/heightUnitMm
+  const gridUnit = params.gridUnitMm ?? SIZE;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- legacy designs may lack heightUnitMm
+  const heightUnit = params.heightUnitMm ?? HEIGHT_UNIT;
+  const totalHeight = height * heightUnit;
+
+  const mb = new MeshBuilder();
+
+  addBinBody(mb, {
+    outerW: width * gridUnit - CLEARANCE,
+    outerD: depth * gridUnit - CLEARANCE,
+    wallThickness: params.wallThickness,
+    totalHeight,
+    hasLip: params.base.stackingLip,
+  });
+
+  onProgress?.('base', 0.5);
+  abortIfCancelled(signal);
+
+  // Per-cell feet — replicates `socketBuilder`'s non-mask cell walk (half
+  // sockets, or fractional feet dropping sub-printable slivers) so foot count
+  // and placement match the exact path bit-for-bit. Masked bins fall back.
+  const footOpts = params.base.halfSockets
+    ? ({ halfSockets: true, gridUnitMm: gridUnit } as const)
+    : ({
+        gridUnitMm: gridUnit,
+        fractional: true,
+        minFractionUnits: MIN_PRINTABLE_TILE_MM / gridUnit,
+        fractionalEdgeX: params.fractionalEdgeX,
+        fractionalEdgeY: params.fractionalEdgeY,
+      } as const);
+
+  forEachCell(
+    width,
+    depth,
+    (cell) => {
+      addBaseFoot(
+        mb,
+        cell.centerX,
+        cell.centerY,
+        cell.widthUnits * gridUnit - CLEARANCE,
+        cell.depthUnits * gridUnit - CLEARANCE
+      );
+    },
+    footOpts
+  );
+
+  onProgress?.('base', 0.9);
+  abortIfCancelled(signal);
+
+  const built = mb.build();
+  // Recover OCCT-style feature edges from the assembled mesh so the draft gets
+  // the same crisp edge overlay as the BREP render (the builder omits edges).
+  const result: MeshData = {
+    ...built,
+    edgeVertices: creaseEdges({ vertices: built.vertices, triangles: built.indices }),
+  };
+  onProgress?.('base', 1);
+  return result;
+}
+
+/**
+ * Whether `generateBinDirect` can faithfully render `params`. This is an
+ * allowlist: it returns true only for the rectangular bins the first slice
+ * covers (hollow body, optional lip, plain feet) and falls back for every
+ * feature the procedural path does not yet emit. Erring toward fallback keeps a
+ * dropped feature from ever reaching the screen — a fallback only costs the
+ * instant draft, never correctness.
+ */
+export function canBinUseDirectMesh(params: BinParams): boolean {
+  const { base } = params;
+
+  // Base: only the plain standard foot is emitted. Magnet/screw holes,
+  // weighted/flat bases, solid bodies and lightweight shells all change the
+  // base topology and are deferred to a follow-up slice.
+  if (base.style !== 'standard') return false;
+  if (base.solid || base.lightweight) return false;
+
+  // Body style: slotted/solid change the walls and floor.
+  if (params.style !== 'standard') return false;
+
+  // Interior features.
+  if (params.compartments.cols !== 1 || params.compartments.rows !== 1) return false;
+  if (params.scoop.enabled) return false;
+  if (params.label.enabled) return false;
+  if (params.walls.enabled) return false;
+  if (params.handles.enabled) return false;
+  // slotConfig is inert unless the body style is 'slotted' (already rejected
+  // above), so it needs no separate gate — and it defaults to x.enabled = true.
+  if (params.inserts.length > 0) return false;
+  if (params.cutouts.length > 0) return false;
+  if (params.wallPattern.enabled) return false;
+  if (params.lid.enabled) return false;
+
+  // Footprint / placement modifiers.
+  if (isPartialMask(params.cellMask)) return false;
+  if (params.splitConnectors?.enabled) return false;
+  const ov = params.overhang;
+  if (ov && (ov.feet || ov.left > 0 || ov.right > 0 || ov.front > 0 || ov.back > 0)) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/features/generation/worker/generators/directMeshWalls.ts
+++ b/src/features/generation/worker/generators/directMeshWalls.ts
@@ -81,19 +81,21 @@ export function addPocketWalls(
 }
 
 /**
- * Outer perimeter walls — vertical walls from Z=totalHeight down to Z=0
+ * Outer perimeter walls — vertical walls from Z=zTop down to Z=zBot
  * following the outer profile. Normals point OUTWARD (away from slab center).
+ *
+ * `zBot` defaults to 0 (baseplate slab bottom). The bin body passes the socket
+ * height so its outer wall starts at the socket interface, not Z=0.
  */
 export function addOuterWalls(
   mb: MeshBuilder,
   outerPts: ReadonlyArray<readonly [number, number]>,
   offsetX: number,
   offsetY: number,
-  totalHeight: number
+  zTop: number,
+  zBot = 0
 ): void {
   const n = outerPts.length;
-  const zTop = totalHeight;
-  const zBot = 0;
 
   // Shared top + bottom rings — adjacent wall quads reuse the same vertex
   // indices so `computeVertexNormals` averages face normals across the rounded

--- a/src/shared/generation/directMesh.ts
+++ b/src/shared/generation/directMesh.ts
@@ -10,3 +10,7 @@
  * orbitable preview while the BREP pipeline catches up.
  */
 export { generateBaseplateDirect } from '@/features/generation/worker/generators/baseplateDirectMesh';
+export {
+  generateBinDirect,
+  canBinUseDirectMesh,
+} from '@/features/generation/worker/generators/binDirectMesh';


### PR DESCRIPTION
## What

Adds a **synchronous, brepjs-free** procedural mesh for the bin draft preview — the bin-side counterpart to `generateBaseplateDirect`. `useGeneration` paints it on the leading edge of an edit (main thread, no worker, no WASM round-trip) before the kernel even starts, then the exact B-rep supersedes it.

Closes the last open child of the perf-cluster tracker #2335 (siblings #2332/#2333 already merged).

## Why

The bin draft previously ran the **full B-rep kernel** (socket lofts + magnet/screw cylinder cuts), so every dimension/param scrub waited seconds before anything rendered. The baseplate already solved this; this brings the bin to the same standard. Export path is unchanged (full B-rep).

## Scope (staged first slice)

- `generateBinDirect` covers the **common rectangular bin**: hollow body, **stacking lip** (so the *default* bin benefits), and per-cell tapered gridfinity feet (incl. half-sockets + fractional feet — grid walk reuses `forEachCell` so placement matches the exact path).
- `canBinUseDirectMesh` is an **allowlist gate**: it returns true only for bins the procedural emitters render faithfully and **falls back to the existing async path** for everything else (compartments, scoops, labels, wall cutouts, handles, cutouts, inserts, wall patterns, lids, custom masks, overhang, magnet/screw/weighted/flat bases, solid/slotted/lightweight). Belt-and-suspenders: the caller also try/catches `generateBinDirect`, so a missed case degrades to "no instant draft," never a wrong mesh.
- When the direct mesh paints, the slower **Manifold draft is suppressed** so a simple bin swaps once (direct→exact), not twice.
- **Deferred to a follow-up:** magnet/screw holes in the feet (the baseplate `addMagnetHoles` helper is Z-inverted vs the bin foot, so it needs its own emitter rather than a clean reuse).

## Verification

- **Parity** (`binDirectMesh.parity.test.ts`): draft bounding box + **lip-rim Z** + triangle-count vs the exact `generateBin` at preview quality, across 4 shapes (standard+lip, no-lip, 3×2, 2.5×2 fractional). This is what guards the CLEARANCE / two-corner-radii / lip drift.
- **Winding** (`binDirectMesh.test.ts`): signed-volume check confirms consistent outward orientation, matching the proven baseplate direct mesh's convention.
- **Sanity + gate**: non-empty mesh, no NaN/Inf, foot counts (full / half-socket / fractional), bbox/height, perf, and a table pinning every gated feature.
- **Hook integration** (`useGeneration.test.ts`): the direct mesh paints first, Manifold is suppressed, and the exact result supersedes; the Manifold path is still covered via a fallback (scoop) bin.
- `pnpm run build` + typecheck + lint + knip clean. Main bundle unchanged (~326 kB gzip) — the new generator pulls in no brepjs.

## Note for review

The rendering layer (`BinMesh.tsx`) is unchanged — the draft flows through the same `isDraft` / `useMeshGeometry` path as the exact mesh. A final **visual confirmation in the dev app** (scrub a default bin's dimensions; confirm the instant draft appears and the swap shows no footprint/foot/lip jump) is recommended before merge.