### PR TITLE
test(generation): cold-cache benches for socket + baseplate grid builds

### DIFF
--- a/src/features/generation/worker/generators/baseplateGenerator.bench.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.bench.ts
@@ -106,6 +106,9 @@ describe('baseplate generation', () => {
   // Large-plate cold builds. The unique-paddingLeft cache-defeat above
   // quantizes away for these, so clear the baseplate caches each iteration to
   // time the real cold pocket cut across grid sizes; no magnets ⇒ through-cut.
+  // The clear must live INSIDE the timed fn — vitest's bench() ignores
+  // tinybench's per-iteration beforeEach and runs setup once per phase, so a
+  // hook would leave every iteration after the first warm.
   const coldPlate = (w: number, d: number, forExport: boolean) => () => {
     clearBaseplateCaches();
     getGenerateBaseplate()(defaults({ width: w, depth: d }), noop, forExport);

--- a/src/features/generation/worker/generators/baseplateGenerator.bench.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.bench.ts
@@ -15,6 +15,7 @@
 import { bench, describe, beforeAll } from 'vitest';
 import type { BaseplateParams } from '@/shared/types/bin';
 import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
+import { clearBaseplateCaches } from './baseplateCaches';
 
 const noop = (): void => {};
 
@@ -101,4 +102,20 @@ describe('baseplate generation', () => {
     },
     { iterations: 3, warmupIterations: 1 }
   );
+
+  // Large-plate cold builds. The unique-paddingLeft cache-defeat above
+  // quantizes away for these, so clear the baseplate caches each iteration to
+  // time the real cold pocket cut across grid sizes; no magnets ⇒ through-cut.
+  const coldPlate = (w: number, d: number, forExport: boolean) => () => {
+    clearBaseplateCaches();
+    getGenerateBaseplate()(defaults({ width: w, depth: d }), noop, forExport);
+  };
+
+  bench('6×6 no magnets (cold)', coldPlate(6, 6, false), { iterations: 4, warmupIterations: 1 });
+  bench('8×8 no magnets (cold)', coldPlate(8, 8, false), { iterations: 3, warmupIterations: 1 });
+  bench('12×12 no magnets (cold)', coldPlate(12, 12, false), {
+    iterations: 2,
+    warmupIterations: 1,
+  });
+  bench('8×8 export (cold)', coldPlate(8, 8, true), { iterations: 2, warmupIterations: 1 });
 });

--- a/src/features/generation/worker/generators/binGenerator.bench.ts
+++ b/src/features/generation/worker/generators/binGenerator.bench.ts
@@ -339,6 +339,10 @@ describe('export (forExport=true)', () => {
 // the cold socket-grid build itself (cell loft + fuse + hole cut) across grid
 // sizes — the lever for any future socket-fuse change.
 describe('socket grid (cold cache)', () => {
+  // The clear must live INSIDE the timed fn: vitest's bench() ignores
+  // tinybench's per-iteration beforeEach and runs setup/teardown only once per
+  // phase, so a hook would clear once → first iteration cold, rest warm. Clearing
+  // here keeps every iteration cold; the disposal cost is sub-ms vs the build.
   const cold = (gridW: number, gridD: number, magnet: boolean, forExport: boolean) => () => {
     clearAllCaches();
     buildBaseSocket(gridW, gridD, magnet, false, 3.1, 2, 1.25, forExport);

--- a/src/features/generation/worker/generators/binGenerator.bench.ts
+++ b/src/features/generation/worker/generators/binGenerator.bench.ts
@@ -12,6 +12,8 @@ import { bench, describe, beforeAll } from 'vitest';
 import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import { buildParams as params, makeInsert, makeCutout } from './__kernel-tests__/scenarioTypes';
+import { buildBaseSocket } from './socketBuilder';
+import { clearAllCaches } from './shapeCache';
 
 beforeAll(async () => {
   await initBrepjs();
@@ -328,4 +330,23 @@ describe('export (forExport=true)', () => {
     },
     { iterations: 3, warmupIterations: 1 }
   );
+});
+
+// ─── Socket grid (cold cache) ───────────────────────────────────────────────
+//
+// The whole-socket cache isn't keyed on bin height, so end-to-end bin benches
+// measure it warm after the first call. Clear all caches each iteration to time
+// the cold socket-grid build itself (cell loft + fuse + hole cut) across grid
+// sizes — the lever for any future socket-fuse change.
+describe('socket grid (cold cache)', () => {
+  const cold = (gridW: number, gridD: number, magnet: boolean, forExport: boolean) => () => {
+    clearAllCaches();
+    buildBaseSocket(gridW, gridD, magnet, false, 3.1, 2, 1.25, forExport);
+  };
+
+  bench('4×4 preview', cold(4, 4, false, false), { iterations: 10, warmupIterations: 2 });
+  bench('6×6 preview', cold(6, 6, false, false), { iterations: 10, warmupIterations: 2 });
+  bench('7×7 preview', cold(7, 7, false, false), { iterations: 8, warmupIterations: 2 });
+  bench('6×6 export', cold(6, 6, false, true), { iterations: 6, warmupIterations: 1 });
+  bench('6×6 export + magnets', cold(6, 6, true, true), { iterations: 4, warmupIterations: 1 });
 });


### PR DESCRIPTION
## What

Adds larger-grid, **cold-cache** benchmarks for the two repeated-cell grid builds:

- **Bin socket grid** (`buildBaseSocket`): 4×4 / 6×6 / 7×7 preview, 6×6 export, 6×6 export+magnets.
- **Baseplate pocket grid** (`generateBaseplate`): 6×6 / 8×8 / 12×12 cold, 8×8 export cold.

## Why

The existing end-to-end benches measured these grids **warm**:
- the whole-socket cache isn't keyed on bin height, so repeated `generateBin` calls hit it after the first iteration;
- the baseplate `paddingLeft` cache-defeat trick quantizes away in the cache key.

Clearing the relevant caches each iteration times the real **cold** grid build (cell loft + fuse + hole/pocket cut) across sizes — the lever for any future grid-fuse change. No production code changes.

## Context

Spun out of investigating #2346 (adopt brepjs `gridPattern` for these grids). The optimization itself measured as a **regression** on occt-wasm and was not adopted — see the findings on #2346 — but the cold-cache bench coverage I added while measuring is independently useful, so it lands here.

## Test

- `pnpm exec vitest bench binGenerator.bench -t "socket grid"`
- `pnpm exec vitest bench baseplateGenerator.bench -t "cold"`
- Both kernels via `BREPJS_KERNEL=wasm`.