### PR TITLE
feat(bin-designer): off-board arrays + concave-mask recovery

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -286,13 +286,19 @@ intersection`, not XOR** — they coincide for 2 members but diverge for
     stored in **absolute interior-mm and are never auto-rescaled**, so shrinking
     the footprint can leave a cutout past the new edge; the mesh builder then
     silently clips the overhang (`cutoutBuilder.clipToInterior`). `offBoardCutouts`
-    flags strays via `getRotatedBounds` (the same AABB the drag/resize handlers
-    clamp against, so the flag and the edge agree), the canvas frames them with a
-    red `OffBoardBounds3D`, and the inspector offers a one-click clamp-back
-    ("Bring back in") that translates each stray inside (oversized cutouts pin
-    their min corner to the origin). Detection keys off each cutout's master
-    footprint — an **array** whose instances spill past the edge isn't flagged,
-    consistent with the interaction clamps.
+    treats a cutout as its set of **expanded array instances** (`expandCutoutArray`,
+    just the cutout itself when there's no array) and flags it if **any** instance
+    falls outside, measuring each footprint with `getCutoutBounds` from `maskFit`
+    (true vertex bounds, rotation-aware for paths — the same primitive placement
+    validation uses). A **masked** (custom-shape) bin defers to `cutoutFitsInMask`
+    so an instance over an unfilled cell is caught, not just rectangle overhang.
+    `OffBoardFrames3D` frames each off-board _instance_ in red; the inspector's
+    one-click "Bring back in" translates the **master** (instances move with it):
+    for a plain bin it pulls the instances' union inside the rectangle (oversized
+    pins the min corner to the origin); for a masked bin it searches the nearest
+    cell-aligned placement where every instance fits the polygon, and leaves the
+    cutout flagged when none exists (translation can't fit an arbitrary concave
+    region — honest rather than a silent false-fix).
 
 ## Thumbnail Pipeline
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
@@ -33,6 +33,19 @@ const corner = (x: number, y: number): PathPoint => ({
   symmetric: true,
 });
 
+const gridArray = (cols: number, rows: number, pitchX: number, pitchY: number) =>
+  ({
+    mode: 'grid',
+    cols,
+    rows,
+    pitchX,
+    pitchY,
+    count: 1,
+    radius: 0,
+    startAngle: 0,
+    rotateToCenter: false,
+  }) as const;
+
 const BIN_W = 100;
 const BIN_D = 80;
 
@@ -100,6 +113,19 @@ describe('isCutoutOffBoard', () => {
     // …but it covers the unfilled cell, so the masked check flags it.
     expect(isCutoutOffBoard(overNotch, 100, 100, mask, cellSize)).toBe(true);
   });
+
+  it('flags an array whose outer instance spills past the edge', () => {
+    // Master fits at 70..90, but a 2-wide grid puts a second instance at 110..130.
+    const arr = createCutout({
+      x: 70,
+      y: 10,
+      width: 20,
+      depth: 20,
+      array: gridArray(2, 1, 40, 40),
+    });
+    expect(isCutoutOffBoard({ ...arr, array: undefined }, BIN_W, BIN_D)).toBe(false);
+    expect(isCutoutOffBoard(arr, BIN_W, BIN_D)).toBe(true);
+  });
 });
 
 describe('getOffBoardCutoutIds', () => {
@@ -154,6 +180,20 @@ describe('clampCutoutToBoard', () => {
     const after = { ...path, ...moved };
     expect(isCutoutOffBoard(after, BIN_W, BIN_D)).toBe(false);
   });
+
+  it('translates the master so every array instance fits', () => {
+    const arr = createCutout({
+      x: 70,
+      y: 10,
+      width: 20,
+      depth: 20,
+      array: gridArray(2, 1, 40, 40),
+    });
+    // Union spans 70..130 → shift -30 so instances land at 40..60 and 80..100.
+    expect(clampCutoutToBoard(arr, BIN_W, BIN_D)).toEqual({ x: 40, y: 10 });
+    const moved = { ...arr, ...clampCutoutToBoard(arr, BIN_W, BIN_D) };
+    expect(isCutoutOffBoard(moved, BIN_W, BIN_D)).toBe(false);
+  });
 });
 
 describe('clampOffBoardCutouts', () => {
@@ -169,14 +209,26 @@ describe('clampOffBoardCutouts', () => {
     expect(clampOffBoardCutouts([createCutout()], BIN_W, BIN_D).size).toBe(0);
   });
 
-  it('skips mask-only violations a translation cannot fix', () => {
-    // Inside the bounding rectangle but over an unfilled cell — flagged by
-    // detection, but a pure translation can't fit the concave polygon, so the
-    // clamp emits no move (the warning persists honestly).
+  it('relocates a mask-only violation into the nearest filled region', () => {
+    // Inside the bounding rectangle but over an unfilled cell — the clamp now
+    // searches for a valid cell-aligned placement and moves it there.
     const mask: CellMask = { cols: 2, rows: 2, cells: [1, 1, 1, 0] };
     const cellSize = { cellMmX: 50, cellMmY: 50 };
     const overNotch = createCutout({ id: 'notch', x: 60, y: 60, width: 30, depth: 30 });
     expect(getOffBoardCutoutIds([overNotch], 100, 100, mask, cellSize).has('notch')).toBe(true);
-    expect(clampOffBoardCutouts([overNotch], 100, 100, mask, cellSize).size).toBe(0);
+    const updates = clampOffBoardCutouts([overNotch], 100, 100, mask, cellSize);
+    expect(updates.size).toBe(1);
+    const moved = { ...overNotch, ...updates.get('notch') };
+    expect(isCutoutOffBoard(moved, 100, 100, mask, cellSize)).toBe(false);
+  });
+
+  it('leaves a cutout flagged when no valid mask placement exists', () => {
+    // 90×90 spans the whole 2×2 grid wherever placed, so it always hits the
+    // empty cell — no translation can fit it; the clamp emits nothing.
+    const mask: CellMask = { cols: 2, rows: 2, cells: [1, 1, 1, 0] };
+    const cellSize = { cellMmX: 50, cellMmY: 50 };
+    const tooBig = createCutout({ id: 'big', x: 5, y: 5, width: 90, depth: 90 });
+    expect(getOffBoardCutoutIds([tooBig], 100, 100, mask, cellSize).has('big')).toBe(true);
+    expect(clampOffBoardCutouts([tooBig], 100, 100, mask, cellSize).size).toBe(0);
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -6,21 +6,47 @@
  * board edge. The mesh builder silently clips that overhang, so the editor
  * surfaces it instead: flag the strays and offer a one-click clamp back in.
  *
- * Footprints are measured with the same `getCutoutBounds` placement validation
- * uses (true vertex bounds for paths), and a custom (masked) footprint defers
- * to the shared polygon-containment check so a cutout inside the bounding
- * rectangle but over an unfilled mask cell is still flagged.
+ * A cutout is treated as its set of expanded array instances (just itself when
+ * there is no array), so an array whose outer instances spill past the edge is
+ * flagged even when the master fits. Footprints use the same `getCutoutBounds`
+ * placement validation uses (true vertex bounds for paths), and a custom
+ * (masked) footprint defers to polygon containment.
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
 import type { CellMask } from '@/shared/utils/cellMask';
+import { expandCutoutArray } from '@/shared/utils/cutoutArray';
 import { translatePathPoints } from './pathGeometry';
-import { getCutoutBounds, cutoutFitsInMask, type MaskCellSize } from './maskFit';
+import { getCutoutBounds, cutoutFitsInMask, rectFitsInMask, type MaskCellSize } from './maskFit';
+import type { Bounds } from './geometryCore';
 
 /** Tolerance (mm) — mirrors the interaction clamps so a flush edge isn't flagged. */
 const EPSILON = 0.01;
 
-/** True when any part of the cutout falls outside the (optionally masked) board. */
+function boundsOutsideRect(b: Bounds, binWidth: number, binDepth: number): boolean {
+  return (
+    b.minX < -EPSILON ||
+    b.minY < -EPSILON ||
+    b.maxX > binWidth + EPSILON ||
+    b.maxY > binDepth + EPSILON
+  );
+}
+
+function unionBounds(boundsList: readonly Bounds[]): Bounds {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const b of boundsList) {
+    if (b.minX < minX) minX = b.minX;
+    if (b.minY < minY) minY = b.minY;
+    if (b.maxX > maxX) maxX = b.maxX;
+    if (b.maxY > maxY) maxY = b.maxY;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+/** True when any instance of the cutout falls outside the (optionally masked) board. */
 export function isCutoutOffBoard(
   cutout: Cutout,
   binWidth: number,
@@ -28,16 +54,11 @@ export function isCutoutOffBoard(
   mask?: CellMask,
   cellSize?: MaskCellSize
 ): boolean {
-  // Custom (masked) footprint: a cutout inside the bounding rectangle can still
-  // overhang the polygon, so defer to the same containment check placements use.
-  if (mask && cellSize) return !cutoutFitsInMask(cutout, mask, cellSize);
-  const b = getCutoutBounds(cutout);
-  return (
-    b.minX < -EPSILON ||
-    b.minY < -EPSILON ||
-    b.maxX > binWidth + EPSILON ||
-    b.maxY > binDepth + EPSILON
-  );
+  const instances = expandCutoutArray(cutout);
+  // Custom (masked) footprint: an instance inside the bounding rectangle can
+  // still overhang the polygon, so defer to the containment check placements use.
+  if (mask && cellSize) return instances.some((inst) => !cutoutFitsInMask(inst, mask, cellSize));
+  return instances.some((inst) => boundsOutsideRect(getCutoutBounds(inst), binWidth, binDepth));
 }
 
 /** Ids of every cutout stranded past the current board footprint. */
@@ -65,26 +86,70 @@ function fitAxis(min: number, max: number, extent: number): number {
   return 0;
 }
 
+/** Translation that fits the instances' union within the board rectangle. */
+function rectOffset(
+  instanceBounds: readonly Bounds[],
+  binWidth: number,
+  binDepth: number
+): { dx: number; dy: number } {
+  const u = unionBounds(instanceBounds);
+  return { dx: fitAxis(u.minX, u.maxX, binWidth), dy: fitAxis(u.minY, u.maxY, binDepth) };
+}
+
 /**
- * Translation that brings a stray cutout's footprint back inside the board's
- * bounding rectangle. Returns `null` when no move is needed.
- *
- * Best-effort for concave (masked) footprints: it pulls the cutout within the
- * bounding rectangle, but a remaining over-an-unfilled-cell overhang stays
- * flagged (and the generator clips it) — translation alone can't fit an
- * arbitrary polygon.
+ * Nearest cell-aligned translation that fits every instance within the filled
+ * mask region. Returns `null` when no such placement exists (e.g. the footprint
+ * is larger than any filled run). Candidates align the instances' union min
+ * corner to each mask cell, so a valid run is found whenever one exists.
+ */
+function maskOffset(
+  instanceBounds: readonly Bounds[],
+  mask: CellMask,
+  cellSize: MaskCellSize
+): { dx: number; dy: number } | null {
+  const u = unionBounds(instanceBounds);
+  let best: { dx: number; dy: number } | null = null;
+  let bestDist = Infinity;
+  for (let r = 0; r <= mask.rows; r++) {
+    for (let c = 0; c <= mask.cols; c++) {
+      const dx = c * cellSize.cellMmX - u.minX;
+      const dy = r * cellSize.cellMmY - u.minY;
+      const fits = instanceBounds.every((b) =>
+        rectFitsInMask(mask, b.minX + dx, b.minY + dy, b.maxX - b.minX, b.maxY - b.minY, cellSize)
+      );
+      if (!fits) continue;
+      const dist = dx * dx + dy * dy;
+      if (dist < bestDist) {
+        best = { dx, dy };
+        bestDist = dist;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Translation that brings a stray cutout (and all its array instances) back
+ * inside the board. Returns `null` when no move is needed or — for a masked
+ * footprint — no valid placement exists (the cutout stays flagged for manual
+ * repair). Path vertices move in lockstep with `x`/`y`.
  */
 export function clampCutoutToBoard(
   cutout: Cutout,
   binWidth: number,
-  binDepth: number
+  binDepth: number,
+  mask?: CellMask,
+  cellSize?: MaskCellSize
 ): Partial<Cutout> | null {
-  const b = getCutoutBounds(cutout);
-  const dx = fitAxis(b.minX, b.maxX, binWidth);
-  const dy = fitAxis(b.minY, b.maxY, binDepth);
-  if (dx === 0 && dy === 0) return null;
+  const instanceBounds = expandCutoutArray(cutout).map(getCutoutBounds);
+  const offset =
+    mask && cellSize
+      ? maskOffset(instanceBounds, mask, cellSize)
+      : rectOffset(instanceBounds, binWidth, binDepth);
+  if (!offset) return null;
+  const { dx, dy } = offset;
+  if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) return null;
   const moved: Partial<Cutout> = { x: cutout.x + dx, y: cutout.y + dy };
-  // Path vertices are absolute mm, so move them in lockstep with x/y.
   if (cutout.shape === 'path' && cutout.path) {
     return { ...moved, path: translatePathPoints(cutout.path, dx, dy) };
   }
@@ -102,7 +167,7 @@ export function clampOffBoardCutouts(
   const updates = new Map<string, Partial<Cutout>>();
   for (const c of cutouts) {
     if (!isCutoutOffBoard(c, binWidth, binDepth, mask, cellSize)) continue;
-    const moved = clampCutoutToBoard(c, binWidth, binDepth);
+    const moved = clampCutoutToBoard(c, binWidth, binDepth, mask, cellSize);
     if (moved) updates.set(c.id, moved);
   }
   return updates;

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -110,8 +110,10 @@ function maskOffset(
   const u = unionBounds(instanceBounds);
   let best: { dx: number; dy: number } | null = null;
   let bestDist = Infinity;
-  for (let r = 0; r <= mask.rows; r++) {
-    for (let c = 0; c <= mask.cols; c++) {
+  // Min-corner candidates only need cells [0, cols)×[0, rows): aligning the
+  // corner to the far boundary always overhangs (rectFitsInMask rejects it).
+  for (let r = 0; r < mask.rows; r++) {
+    for (let c = 0; c < mask.cols; c++) {
       const dx = c * cellSize.cellMmX - u.minX;
       const dy = r * cellSize.cellMmY - u.minY;
       const fits = instanceBounds.every((b) =>

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardBounds3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardBounds3D.tsx
@@ -1,17 +1,17 @@
 /**
- * Red frame around a cutout stranded past the board edge (e.g. after the bin
- * was shrunk). Drawn around the cutout's rotated bounds so the warning reads
- * the same for every shape type. World coordinates: mm, Y-up.
+ * Red frame around an off-board cutout footprint (e.g. after the bin was
+ * shrunk). Pure presentational — the caller supplies the bounds (computed with
+ * the same getCutoutBounds detection uses), so this stays free of shape, array,
+ * and mask logic. World coordinates: mm, Y-up.
  */
 
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
-import type { Cutout } from '@/features/bin-designer/types';
-import { getCutoutBounds } from '../maskFit';
+import type { Bounds } from '../geometryCore';
 import { RENDER_ORDER, OFF_BOARD_COLOR } from './constants';
 
 interface OffBoardBounds3DProps {
-  readonly cutout: Cutout;
+  readonly bounds: Bounds;
 }
 
 const frameColor = new THREE.Color(OFF_BOARD_COLOR);
@@ -19,15 +19,12 @@ const frameColor = new THREE.Color(OFF_BOARD_COLOR);
 /** mm the frame sits proud of the shape so it reads as a surrounding warning. */
 const MARGIN_MM = 0.75;
 
-export function OffBoardBounds3D({ cutout }: OffBoardBounds3DProps) {
+export function OffBoardBounds3D({ bounds }: OffBoardBounds3DProps) {
   const lineObj = useMemo(() => {
-    // Match the detection bounds exactly (vertex-based, rotation-aware for
-    // paths) so the frame sits on the real footprint, not stale width/depth.
-    const b = getCutoutBounds(cutout);
-    const x0 = b.minX - MARGIN_MM;
-    const y0 = b.minY - MARGIN_MM;
-    const x1 = b.maxX + MARGIN_MM;
-    const y1 = b.maxY + MARGIN_MM;
+    const x0 = bounds.minX - MARGIN_MM;
+    const y0 = bounds.minY - MARGIN_MM;
+    const x1 = bounds.maxX + MARGIN_MM;
+    const y1 = bounds.maxY + MARGIN_MM;
     const points = [
       new THREE.Vector3(x0, y0, 0.05),
       new THREE.Vector3(x1, y0, 0.05),
@@ -45,7 +42,7 @@ export function OffBoardBounds3D({ cutout }: OffBoardBounds3DProps) {
     const line = new THREE.Line(geometry, material);
     line.renderOrder = RENDER_ORDER.OFF_BOARD;
     return line;
-  }, [cutout]);
+  }, [bounds.minX, bounds.minY, bounds.maxX, bounds.maxY]);
 
   // <primitive> does not auto-dispose attached objects; release the GPU
   // resources when the line is replaced or the component unmounts.

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.test.tsx
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { OffBoardFrames3D } from './OffBoardFrames3D';
+
+describe('OffBoardFrames3D', () => {
+  it('exports a function', () => {
+    expect(typeof OffBoardFrames3D).toBe('function');
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.test.tsx
@@ -1,8 +1,83 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Bounds } from '../geometryCore';
+import type { Cutout } from '@/features/bin-designer/types';
 import { OffBoardFrames3D } from './OffBoardFrames3D';
 
+// Stub the R3F leaf so the framing/filtering logic can be asserted in jsdom
+// without a WebGL canvas.
+vi.mock('./OffBoardBounds3D', () => ({
+  OffBoardBounds3D: ({ bounds }: { bounds: Bounds }) => (
+    <div data-testid="frame" data-minx={bounds.minX} data-maxx={bounds.maxX} />
+  ),
+}));
+
+const createCutout = (overrides: Partial<Cutout> = {}): Cutout => ({
+  id: 'c',
+  shape: 'rectangle',
+  x: 10,
+  y: 10,
+  width: 20,
+  depth: 20,
+  cutDepth: 5,
+  rotation: 0,
+  cornerRadius: 0,
+  label: '',
+  groupId: null,
+  locked: false,
+  hidden: false,
+  ...overrides,
+});
+
+const gridArray = (cols: number, rows: number, pitchX: number, pitchY: number) =>
+  ({
+    mode: 'grid',
+    cols,
+    rows,
+    pitchX,
+    pitchY,
+    count: 1,
+    radius: 0,
+    startAngle: 0,
+    rotateToCenter: false,
+  }) as const;
+
+const BIN_W = 100;
+const BIN_D = 80;
+const EMPTY_PREVIEW = new Map<string, Partial<Cutout>>();
+
+const renderFrames = (cutouts: Cutout[], offBoardIds: Set<string>) =>
+  render(
+    <OffBoardFrames3D
+      cutouts={cutouts}
+      offBoardIds={offBoardIds}
+      preview={EMPTY_PREVIEW}
+      binWidth={BIN_W}
+      binDepth={BIN_D}
+    />
+  );
+
 describe('OffBoardFrames3D', () => {
-  it('exports a function', () => {
-    expect(typeof OffBoardFrames3D).toBe('function');
+  it('renders nothing when no cutouts are flagged', () => {
+    renderFrames([createCutout({ id: 'a', x: 95 })], new Set());
+    expect(screen.queryAllByTestId('frame')).toHaveLength(0);
+  });
+
+  it('frames a flagged single cutout but skips hidden ones', () => {
+    const visible = createCutout({ id: 'vis', x: 95, y: 10 });
+    const hidden = createCutout({ id: 'hid', x: 95, y: 40, hidden: true });
+    renderFrames([visible, hidden], new Set(['vis', 'hid']));
+    const frames = screen.getAllByTestId('frame');
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toHaveAttribute('data-maxx', '115');
+  });
+
+  it('frames only the off-board instances of an array, not the in-bounds master', () => {
+    // Master at 70..90 fits; the second grid instance lands at 110..130.
+    const arr = createCutout({ id: 'arr', x: 70, y: 10, array: gridArray(2, 1, 40, 40) });
+    renderFrames([arr], new Set(['arr']));
+    const frames = screen.getAllByTestId('frame');
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toHaveAttribute('data-minx', '110');
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.tsx
@@ -1,0 +1,50 @@
+/**
+ * Red warning frames for cutouts stranded past the board edge. Expands array
+ * masters into instances (just the cutout itself when there's no array) and
+ * frames each instance that is actually off-board, at its true footprint —
+ * keeping the visual in lockstep with `isCutoutOffBoard` detection.
+ */
+
+import type { Cutout } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { expandCutoutArray } from '@/shared/utils/cutoutArray';
+import type { PreviewMap } from '../useCutoutInteraction';
+import { isCutoutOffBoard } from '../offBoardCutouts';
+import { getCutoutBounds } from '../maskFit';
+import { OffBoardBounds3D } from './OffBoardBounds3D';
+
+interface OffBoardFrames3DProps {
+  readonly cutouts: readonly Cutout[];
+  readonly offBoardIds: ReadonlySet<string>;
+  readonly preview: PreviewMap;
+  readonly binWidth: number;
+  readonly binDepth: number;
+  readonly cellMask?: CellMask;
+}
+
+export function OffBoardFrames3D({
+  cutouts,
+  offBoardIds,
+  preview,
+  binWidth,
+  binDepth,
+  cellMask,
+}: OffBoardFrames3DProps) {
+  if (offBoardIds.size === 0) return null;
+  const maskCellSize = cellMask
+    ? { cellMmX: binWidth / cellMask.cols, cellMmY: binDepth / cellMask.rows }
+    : undefined;
+  return (
+    <>
+      {cutouts
+        .filter((c) => offBoardIds.has(c.id) && !c.hidden)
+        .flatMap((c) =>
+          expandCutoutArray({ ...c, ...preview.get(c.id) })
+            .filter((inst) => isCutoutOffBoard(inst, binWidth, binDepth, cellMask, maskCellSize))
+            .map((inst) => (
+              <OffBoardBounds3D key={`offboard-${inst.id}`} bounds={getCutoutBounds(inst)} />
+            ))
+        )}
+    </>
+  );
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
@@ -19,7 +19,7 @@ import type { SegmentHoverInfo } from '../handlers';
 import type { AlignmentGuide } from '../geometry';
 import { EditorBackground3D } from './EditorBackground3D';
 import { CutoutShapeMesh } from './CutoutShapeMesh';
-import { OffBoardBounds3D } from './OffBoardBounds3D';
+import { OffBoardFrames3D } from './OffBoardFrames3D';
 import { CutoutLabel3D } from './CutoutLabel3D';
 import { CutoutHandles3D } from './CutoutHandles3D';
 import { RotationHandle3D } from './RotationHandle3D';
@@ -409,13 +409,16 @@ export function SceneContent({
           return <LockBadge3D key={`lock-${cutout.id}`} worldX={worldX} worldY={worldY} />;
         })}
 
-      {/* Off-board warning frames for cutouts stranded past the board edge */}
-      {offBoardIds.size > 0 &&
-        cutouts
-          .filter((c) => offBoardIds.has(c.id) && !c.hidden)
-          .map((c) => (
-            <OffBoardBounds3D key={`offboard-${c.id}`} cutout={{ ...c, ...preview.get(c.id) }} />
-          ))}
+      {/* Off-board warning frames — one per stranded array instance, framed at
+          its true footprint (kept in lockstep with detection). */}
+      <OffBoardFrames3D
+        cutouts={cutouts}
+        offBoardIds={offBoardIds}
+        preview={preview}
+        binWidth={binWidth}
+        binDepth={binDepth}
+        cellMask={cellMask}
+      />
 
       {/* Smart guides during drag */}
       {isDragging && (


### PR DESCRIPTION
Follow-ups to #2354 (in-editor bin resize + off-board cutout detection/recovery), both flagged as known limitations there.

## 1. Array instances off-board

Detection treated a cutout as just its master footprint, so a parametric **array** whose outer instances spilled past the edge wasn't flagged. Now a cutout is treated as its set of **expanded instances** (`expandCutoutArray` — just the cutout itself when there's no array), and it's off-board if **any** instance falls outside. `OffBoardFrames3D` frames each off-board *instance* in red at its true footprint.

Recovery translates the **master** so the instances' union fits the board rectangle (instances move with it; oversized pins the min corner to the origin).

## 2. Concave-mask recovery

"Bring back in" previously only clamped to the bounding rectangle, so a cutout inside the rectangle but over an unfilled mask cell stayed stuck. Recovery now searches the **nearest cell-aligned placement where every instance fits the polygon** (`cutoutFitsInMask`). When no valid placement exists (footprint larger than any filled run), it leaves the cutout flagged for manual repair rather than emitting a no-op or a silent false-fix.

## Design

Both reduce to one reframing: a cutout = its set of instances. Single cutouts are the 1-instance case, so prior behavior falls out unchanged. Footprints use the shared `getCutoutBounds` (vertex-based, rotation-aware for paths) so detection, the red frame, and placement validation all agree.

Also extracted the off-board frame rendering into `OffBoardFrames3D` (SceneContent was over the 500-line cap).

## Testing

- New helper tests: array detection + recovery, mask relocation, and the no-valid-placement case; updated the obsolete "can't fix mask-only" test (it now relocates).
- Full suite green (1113 files, 14163 passed), typecheck + lint clean.