### PR TITLE
fix(baseplate): order stack preview to match assembled layout when not stacking

### DIFF
--- a/src/features/baseplate/README.md
+++ b/src/features/baseplate/README.md
@@ -35,7 +35,7 @@ graph TB
 - `utils/buildFullParams.ts` — resolves sync mode (drawer dims vs custom width/depth); strips connectors, magnet holes, and corner rounding when stack printing is on
 - `utils/stackPrint.ts` — stack planning (groups → capped physical stacks) + `buildTowerLayers` (bottom plate upright, the rest flipped, all XY-aligned)
 - `utils/stackExport.ts` — bakes a stack into export triangle soup (single material)
-- `utils/stackPreview.ts` — lays the towers out in a centered, roughly-square grid for the 3D preview. `TOWER_GAP_UNITS` (1) is the whole-unit clearance between adjacent towers — one grid unit (~42mm) reads as "separate printed pieces" while keeping every cell on the scene's integer footprint grid
+- `utils/stackPreview.ts` — lays the towers out for the 3D preview. Two modes: when every tower carries its tiling `col`/`row` (the "no stacks" case — each split piece is its own single-plate tower, no fingerprint dedup), towers sit on their real tiling grid in the same orientation as the assembled split view (row 0 at the front) so the preview reads in baseplate order; otherwise (deduped or genuinely stacked towers, which no longer map 1:1 to positions) they fall back to a centered, roughly-square grid. `TOWER_GAP_UNITS` (1) is the whole-unit clearance between adjacent towers — one grid unit (~42mm) reads as "separate printed pieces" while keeping every cell on the scene's integer footprint grid
 - `utils/fileNaming.ts` — descriptive/compact/custom filename generation
 - `constants.ts` — MAX_BASEPLATE_DIMENSION (16), EXPLODE_GAP_MM (10), piece color palette
 

--- a/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
@@ -22,6 +22,7 @@ import {
   planPhysicalStacks,
   stackHeightCap,
   bodyCenterYMm,
+  isUnstackedSplit,
   type StackMeshArrays,
 } from '../../utils/stackPrint';
 import { buildStackPreviewMeshes, type StackPreviewTower } from '../../utils/stackPreview';
@@ -142,13 +143,10 @@ export function StackedBaseplateMeshes({
     if (towers.length === 0) return null;
 
     // "No stacks": every tower is a single plate mapping 1:1 onto the split
-    // pieces (no fingerprint dedup, no height-cap split, copies === 1). Then the
-    // towers ARE the split pieces, so position each at its tiling slot and the
-    // preview reads in assembled order instead of a square grid.
-    const noStacks =
-      isSplit &&
-      filteredPlan.length === (tiling?.pieces.length ?? 0) &&
-      filteredPlan.every((p) => p.copies === 1);
+    // pieces (no fingerprint dedup, no height-cap split — see isUnstackedSplit).
+    // Then the towers ARE the split pieces, so position each at its tiling slot
+    // and the preview reads in assembled order instead of a square grid.
+    const noStacks = isSplit && isUnstackedSplit(filteredPlan, tiling?.pieces.length ?? 0);
     const positionedTowers = noStacks
       ? towers.map((tower, i) => {
           const piece = pieceByLabel.get(filteredPlan[i].label);

--- a/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
@@ -111,14 +111,19 @@ export function StackedBaseplateMeshes({
 
     const singleBodyY = bodyCenterYMm(fullParams.paddingFront, fullParams.paddingBack);
 
+    // Index pieces/meshes by label once: the loop and the spatial-positioning
+    // pass below both look up by label, so a per-tower find() would be O(n²).
+    const pieceByLabel = new Map(tiling?.pieces.map((p) => [p.label, p]) ?? []);
+    const meshByLabel = new Map(pieceMeshes.map((p) => [p.label, p.mesh]));
+
     const towers: StackPreviewTower[] = [];
     const filteredPlan: typeof plan = [];
     for (const physical of plan) {
       let source: Parameters<typeof toMeshArrays>[0] | null = singleMesh;
       let bodyY = singleBodyY;
       if (isSplit) {
-        source = pieceMeshes.find((p) => p.label === physical.label)?.mesh ?? null;
-        const piece = tiling?.pieces.find((p) => p.label === physical.label);
+        source = meshByLabel.get(physical.label) ?? null;
+        const piece = pieceByLabel.get(physical.label);
         if (piece) {
           // Derive the body centre from the SAME params the mesh was generated
           // with: pieceToBaseplateParams swaps front/back padding for
@@ -146,7 +151,7 @@ export function StackedBaseplateMeshes({
       filteredPlan.every((p) => p.copies === 1);
     const positionedTowers = noStacks
       ? towers.map((tower, i) => {
-          const piece = tiling?.pieces.find((p) => p.label === filteredPlan[i].label);
+          const piece = pieceByLabel.get(filteredPlan[i].label);
           return piece ? { ...tower, col: piece.col, row: piece.row } : tower;
         })
       : towers;

--- a/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
@@ -135,8 +135,24 @@ export function StackedBaseplateMeshes({
       }
     }
     if (towers.length === 0) return null;
+
+    // "No stacks": every tower is a single plate mapping 1:1 onto the split
+    // pieces (no fingerprint dedup, no height-cap split, copies === 1). Then the
+    // towers ARE the split pieces, so position each at its tiling slot and the
+    // preview reads in assembled order instead of a square grid.
+    const noStacks =
+      isSplit &&
+      filteredPlan.length === (tiling?.pieces.length ?? 0) &&
+      filteredPlan.every((p) => p.copies === 1);
+    const positionedTowers = noStacks
+      ? towers.map((tower, i) => {
+          const piece = tiling?.pieces.find((p) => p.label === filteredPlan[i].label);
+          return piece ? { ...tower, col: piece.col, row: piece.row } : tower;
+        })
+      : towers;
+
     return {
-      meshes: buildStackPreviewMeshes(towers, stack, separationMm, gridUnitMm),
+      meshes: buildStackPreviewMeshes(positionedTowers, stack, separationMm, gridUnitMm),
       plan: filteredPlan,
     };
   }, [

--- a/src/features/baseplate/utils/stackPreview.test.ts
+++ b/src/features/baseplate/utils/stackPreview.test.ts
@@ -119,4 +119,61 @@ describe('buildStackPreviewMeshes', () => {
       expect(b.minY).toBeCloseTo(-b.maxY, 3);
     });
   });
+
+  // "No stacks" case: each tower carries its tiling col/row, so the preview
+  // mirrors the assembled split view instead of collapsing to a square grid.
+  describe('spatial layout (matches assembled grid)', () => {
+    it('keeps a 4-wide × 1-deep split in one row, not a 2×2 square', () => {
+      const out = buildStackPreviewMeshes(
+        [0, 1, 2, 3].map((col) => ({
+          mesh: plate(),
+          copies: 1,
+          bodyCenterYMm: PLATE_BODY_Y,
+          col,
+          row: 0,
+        })),
+        airGap,
+        0,
+        42
+      );
+      // 4 cols × 1 row (the square-grid path would give 2×2 = 168×168).
+      expect(out.widthMm).toBeCloseTo(4 * 84, 4);
+      expect(out.depthMm).toBeCloseTo(1 * 84, 4);
+      // Columns increase strictly left→right; all towers share one row (Y≈0).
+      const xs = out.towerLayouts.map((l) => l.centerX);
+      expect(xs).toEqual([...xs].sort((a, b) => a - b));
+      expect(out.towerLayouts.every((l) => Math.abs(l.centerY) < 1e-6)).toBe(true);
+    });
+
+    it('orders rows front-to-back like the assembled view (row 0 at front)', () => {
+      // One column, two rows: A1 (row 0) must sit in front of A2 (row 1). The
+      // assembled view places row 0 at the smaller Y, so the preview must not
+      // flip it (the square-grid path puts row 0 on top = larger Y).
+      const out = buildStackPreviewMeshes(
+        [
+          { mesh: plate(), copies: 1, bodyCenterYMm: PLATE_BODY_Y, col: 0, row: 0 },
+          { mesh: plate(), copies: 1, bodyCenterYMm: PLATE_BODY_Y, col: 0, row: 1 },
+        ],
+        airGap,
+        0,
+        42
+      );
+      expect(out.towerLayouts[0].centerY).toBeLessThan(out.towerLayouts[1].centerY);
+    });
+
+    it('falls back to the square grid when any tower lacks a position', () => {
+      const out = buildStackPreviewMeshes(
+        [
+          { mesh: plate(), copies: 1, bodyCenterYMm: PLATE_BODY_Y, col: 0, row: 0 },
+          { mesh: plate(), copies: 1, bodyCenterYMm: PLATE_BODY_Y },
+        ],
+        airGap,
+        0,
+        42
+      );
+      // 2 towers, square grid → 2 cols × 1 row.
+      expect(out.widthMm).toBeCloseTo(2 * 84, 4);
+      expect(out.depthMm).toBeCloseTo(1 * 84, 4);
+    });
+  });
 });

--- a/src/features/baseplate/utils/stackPreview.ts
+++ b/src/features/baseplate/utils/stackPreview.ts
@@ -1,7 +1,16 @@
 /**
  * Build the 3D-preview geometry for a stack-print job: each tower (bottom plate
- * upright, the rest flipped) laid out in a centered, roughly-square grid, with
- * `separationMm` exploding copies apart without changing the exported gap.
+ * upright, the rest flipped) with `separationMm` exploding copies apart without
+ * changing the exported gap.
+ *
+ * Layout has two modes. When every tower carries its tiling `col`/`row` (the
+ * "no stacks" case — each split piece is its own single-plate tower, no
+ * fingerprint dedup), towers are placed on their real tiling grid in the same
+ * orientation as the assembled split view (row 0 at the front), so the preview
+ * reads in the same order as the baseplate. Otherwise — deduped or genuinely
+ * stacked towers, which no longer map 1:1 to spatial positions — they fall back
+ * to a centered, roughly-square grid (a single row reads as a confusing
+ * off-screen line once a drawer splits into many pieces).
  */
 
 import type { StackPrintParams } from '@/core/types';
@@ -28,6 +37,13 @@ export interface StackPreviewTower {
   readonly copies: number;
   /** Connector-free body-centre Y (mm) of the plate, for flip alignment. */
   readonly bodyCenterYMm: number;
+  /**
+   * Tiling grid position of the piece this tower prints. Set only when towers
+   * map 1:1 to split pieces ("no stacks"); when every tower carries both, the
+   * layout matches the assembled split view instead of the square grid.
+   */
+  readonly col?: number;
+  readonly row?: number;
 }
 
 export interface StackPreviewTowerLayout {
@@ -75,11 +91,16 @@ export function buildStackPreviewMeshes(
     };
   });
 
-  // Lay the towers in a roughly-square grid (a single row reads as a confusing
-  // off-screen line once a drawer splits into many pieces). Uniform cell size
-  // keeps the grid aligned; each tower is centered in its cell.
-  const cols = Math.ceil(Math.sqrt(measured.length));
-  const rows = Math.ceil(measured.length / cols);
+  // Spatial mode (every tower knows its tiling slot): place towers on their
+  // real grid so the preview matches the assembled split view. Otherwise tile
+  // into a roughly-square grid (see file header).
+  const spatial = measured.every((m) => m.tower.col !== undefined && m.tower.row !== undefined);
+  const cols = spatial
+    ? Math.max(...measured.map((m) => m.tower.col ?? 0)) + 1
+    : Math.ceil(Math.sqrt(measured.length));
+  const rows = spatial
+    ? Math.max(...measured.map((m) => m.tower.row ?? 0)) + 1
+    : Math.ceil(measured.length / cols);
   // Cell size = (largest tower footprint, rounded up to whole grid units) +
   // TOWER_GAP_UNITS, so every cell spans a whole number of grid cells and each
   // tower's edges fall on grid lines (see TOWER_GAP_UNITS).
@@ -94,10 +115,12 @@ export function buildStackPreviewMeshes(
 
   measured.forEach((m, idx) => {
     const stride = stackStrideMm(m.plateHeight, stack) + Math.max(0, separationMm);
-    const col = idx % cols;
-    const row = Math.floor(idx / cols);
+    const col = spatial ? (m.tower.col ?? 0) : idx % cols;
+    const row = spatial ? (m.tower.row ?? 0) : Math.floor(idx / cols);
     const centerX = (col - (cols - 1) / 2) * cellW;
-    const centerY = ((rows - 1) / 2 - row) * cellD;
+    // Spatial mode matches the assembled view, where row 0 sits at the front
+    // (smallest Y) and Y grows with row; the square grid keeps row 0 on top.
+    const centerY = spatial ? (row - (rows - 1) / 2) * cellD : ((rows - 1) / 2 - row) * cellD;
 
     // Build the tower (bottom upright, rest flipped, XY-aligned to the source
     // footprint, bottom at Z=0), then recenter it on its grid cell.

--- a/src/features/baseplate/utils/stackPrint.test.ts
+++ b/src/features/baseplate/utils/stackPrint.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
 import type { BaseplatePiece, BaseplateTiling } from '../types/tiling';
 import {
   planPhysicalStacks,
+  isUnstackedSplit,
   stackHeightCap,
   stackStrideMm,
   stackGroupsFromTiling,
@@ -113,6 +114,29 @@ describe('planPhysicalStacks', () => {
       const wantTotal = groups.reduce((s, g) => s + Math.max(0, Math.floor(g.quantity)), 0);
       expect(towers.reduce((s, t) => s + t.copies, 0)).toBe(wantTotal);
     });
+  });
+});
+
+describe('isUnstackedSplit', () => {
+  const plate = (label: string, copies: number) => ({ label, copies });
+
+  it('is true when every tower is a single plate with a distinct label', () => {
+    expect(isUnstackedSplit([plate('A1', 1), plate('B1', 1), plate('A2', 1)], 3)).toBe(true);
+  });
+
+  it('is false when a label repeats (height-cap split of a deduped group)', () => {
+    // planPhysicalStacks(cap=1) expands a quantity-2 group into two same-label
+    // single-plate stacks — count + copies look 1:1 but the pieces are deduped.
+    expect(isUnstackedSplit([plate('A1', 1), plate('A1', 1)], 2)).toBe(false);
+  });
+
+  it('is false when any tower stacks more than one plate', () => {
+    expect(isUnstackedSplit([plate('A1', 2), plate('B1', 1)], 2)).toBe(false);
+  });
+
+  it('is false when the plan size does not match the piece count', () => {
+    // Two pieces deduped into one tower → not a 1:1 mapping.
+    expect(isUnstackedSplit([plate('A1', 1)], 2)).toBe(false);
   });
 });
 

--- a/src/features/baseplate/utils/stackPrint.ts
+++ b/src/features/baseplate/utils/stackPrint.ts
@@ -55,6 +55,21 @@ export function planPhysicalStacks(
 }
 
 /**
+ * Whether a physical-stack plan maps 1:1 onto the tiling's split pieces: every
+ * tower is a single plate (`copies === 1`) carrying a distinct piece label. Only
+ * then do towers correspond to spatial piece positions (the "no stacks" preview
+ * layout). A deduped or height-capped plan fails this: `cap === 1` expands a
+ * quantity-N group into N same-label single-plate stacks, which satisfies the
+ * count/copies tests but repeats a label — so checking label distinctness (not
+ * just length) is what prevents the repeats from collapsing onto one position.
+ */
+export function isUnstackedSplit(plan: readonly PhysicalStack[], pieceCount: number): boolean {
+  if (plan.length !== pieceCount) return false;
+  if (!plan.every((s) => s.copies === 1)) return false;
+  return new Set(plan.map((s) => s.label)).size === plan.length;
+}
+
+/**
  * How many flipped tiles fit in one stack on a printer `maxZmm` tall. A stack of
  * n tiles is `n*tileHeight + (n-1)*gap` tall; returns the largest n that fits,
  * clamped to ≥1 (one tile always fits — it already fits the bed footprint).


### PR DESCRIPTION
## What

When stacking is enabled on a baseplate that **doesn't actually stack anything** (the split produces only unique pieces, so each is a single plate), the 3D preview laid the plates out in a strange order that didn't match the assembled baseplate. A depth-split into two distinct pieces, for example, appeared side-by-side instead of front-to-back, and a 4-wide row collapsed into a 2×2 block.

## Why

`buildStackPreviewMeshes` always tiled towers into an artificial `ceil(sqrt(n))` square grid with the row direction flipped (row 0 on top). That square grid exists for the real stacking case — where fingerprint dedup collapses many identical pieces into a few tall towers that no longer map 1:1 to grid positions, and a single long row would run off-screen. But in the "no stacks" case the towers _are_ the split pieces, so the square grid just scrambled their order.

## Fix

- `stackPreview.ts` gains a **spatial layout mode**: when every tower carries its tiling `col`/`row`, towers are placed on their real `cols × rows` grid in the **same orientation as the assembled split view** (row 0 at the front, Y growing with row).
- `StackedBaseplateMeshes` detects the no-stacks case (`isSplit && plan.length === pieces.length && every copies === 1`) and tags each tower with its piece's `col`/`row` to trigger spatial mode.
- Deduped or genuinely-stacked towers (no 1:1 spatial mapping) keep the existing square grid. If any position lookup fails (e.g. a piece mesh still generating), it safely falls back to the square grid too.

## Testing

- New `stackPreview.test.ts` cases: a 4×1 split stays one row (not 2×2), rows order front-to-back matching the assembled view, and a safe fallback when any position is missing.
- Full unit suite green; typecheck and lint clean.
- Verified visually: a 2×5 drawer bed-split into two distinct pieces now renders its two single-plate towers in the same front-to-back column as the assembled exploded view.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stack preview ordering for unstacked splits and prevents tower overlaps by requiring a true 1:1 tower→piece mapping before using spatial layout. The 3D preview now matches the assembled layout (row 0 at the front).

- **Bug Fixes**
  - Added spatial layout mode that places towers by real tiling `col`/`row` when each tower maps 1:1 to split pieces.
  - Replaced heuristic with `isUnstackedSplit` (plan length matches pieces, all `copies === 1`, and labels are distinct) to avoid overlaps from height-capped deduped plans.
  - Kept square grid for deduped or stacked towers; safe fallback if any position is missing.
  - Added tests for 4×1 row, correct front-to-back row order, fallback, and `isUnstackedSplit`; updated README.

- **Refactors**
  - Indexed pieces and meshes by label with Maps in `StackedBaseplateMeshes` to remove O(n²) finds.

<sup>Written for commit 07cf99b6e3ffb6c1e937ebf3ed4c30557f36b99c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

