### PR TITLE
fix(baseplate): half-grid draft preview no longer caps half-sockets (#2380)

### DIFF
--- a/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
@@ -619,4 +619,20 @@ describe('direct mesh — over-tile margin pockets', () => {
     // 3mm margins are below the printable threshold → no frame pockets either way.
     expect(generateDirect(on, noop).triangleCount).toBe(generateDirect(off, noop).triangleCount);
   });
+
+  it('half-grid keeps half-sockets open when a margin leaves a sub-threshold sliver (#2380)', () => {
+    // 25mm margin = a 21mm half-socket + a 4mm sub-printable sliver. The solid
+    // ring must fill only the sliver, not cap the half-socket: the open socket
+    // removes top-face area that the (old) full-margin ring would have capped.
+    const SOCKET_HEIGHT = 5;
+    const solid = generateDirect(defaults({ paddingLeft: 25 }), noop);
+    const halfGrid = generateDirect(
+      defaults({ paddingLeft: 25, overTile: true, overTileHalfGrid: true }),
+      noop
+    );
+    const solidTop = horizontalFaceArea(solid, 1, SOCKET_HEIGHT);
+    const halfGridTop = horizontalFaceArea(halfGrid, 1, SOCKET_HEIGHT);
+    // Two nominal rows each expose a ~21×42mm half-socket; well over 500mm² total.
+    expect(halfGridTop).toBeLessThan(solidTop - 500);
+  });
 });

--- a/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
@@ -624,14 +624,16 @@ describe('direct mesh — over-tile margin pockets', () => {
     // 25mm margin = a 21mm half-socket + a 4mm sub-printable sliver. The solid
     // ring must fill only the sliver, not cap the half-socket: the open socket
     // removes top-face area that the (old) full-margin ring would have capped.
-    const SOCKET_HEIGHT = 5;
     const solid = generateDirect(defaults({ paddingLeft: 25 }), noop);
     const halfGrid = generateDirect(
       defaults({ paddingLeft: 25, overTile: true, overTileHalfGrid: true }),
       noop
     );
-    const solidTop = horizontalFaceArea(solid, 1, SOCKET_HEIGHT);
-    const halfGridTop = horizontalFaceArea(halfGrid, 1, SOCKET_HEIGHT);
+    // Top face sits at the slab height; derive it from the mesh so the assertion
+    // doesn't depend on the generator's socket-height constant.
+    const topZ = computeBounds(solid.vertices).maxZ;
+    const solidTop = horizontalFaceArea(solid, 1, topZ);
+    const halfGridTop = horizontalFaceArea(halfGrid, 1, topZ);
     // Two nominal rows each expose a ~21×42mm half-socket; well over 500mm² total.
     expect(halfGridTop).toBeLessThan(solidTop - 500);
   });

--- a/src/features/generation/worker/generators/baseplateDirectMesh.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.ts
@@ -33,6 +33,7 @@ import {
   SOCKET_HEIGHT,
   forEachCell,
   frameCells,
+  marginPocketDepthMm,
   checkCancelled,
   MAGNET_FLOOR,
   MIN_PRINTABLE_TILE_MM,
@@ -116,13 +117,16 @@ export function generateBaseplateDirect(
   const cellOpts: ForEachCellOptions = { fractionalEdgeX, fractionalEdgeY, gridUnitMm };
 
   // Collect all cells. Over-tile adds clipped pockets in the padding margins
-  // (same frameCells layout as the BREP build). The solid padding ring is then
-  // suppressed so the margin reads as grid — but ONLY when every padded side is
-  // fully tiled (margin 0 or >= threshold). A sub-threshold margin keeps its
-  // solid padding, so the ring must stay (the BREP pass renders the exact mix).
+  // (same frameCells layout as the BREP build). The solid padding ring then
+  // fills only the band beyond each side's pockets, so tiled pockets — including
+  // 21mm half-grid cells — are never capped; a fully tiled side contributes no
+  // ring, while a sub-threshold sliver keeps its solid fill (#2380).
   const cells: CellInfo[] = [];
   forEachCell(width, depth, (cell) => cells.push(cell), cellOpts);
-  let tiledMargin = false;
+  // Plain solid padding fills the whole margin ring (no pockets); over-tile
+  // restricts the ring to the un-pocketed outer band via per-side pocket depths.
+  let drawRing = !overTile;
+  let pocketDepths: { left: number; right: number; front: number; back: number } | undefined;
   if (overTile) {
     const margins: SideMargins = {
       left: paddingLeft,
@@ -133,17 +137,20 @@ export function generateBaseplateDirect(
     cells.push(
       ...frameCells(width, depth, margins, gridUnitMm, MIN_PRINTABLE_TILE_MM, overTileHalfGrid)
     );
-    // The solid padding ring can be dropped only when every padded side is
-    // fully covered by cells. Plain over-tile covers a side with one clip
-    // whenever it clears the threshold. Half-grid packs 21mm cells first, so a
-    // side can still leave a sub-threshold solid sliver at its outer edge — keep
-    // the ring unless that leftover is zero or itself printable.
-    tiledMargin = [paddingLeft, paddingRight, paddingFront, paddingBack].every((p) => {
-      if (p < 1e-6) return true;
-      if (!overTileHalfGrid) return p >= MIN_PRINTABLE_TILE_MM;
-      const leftover = p - Math.floor((p + 1e-9) / (gridUnitMm / 2)) * (gridUnitMm / 2);
-      return leftover < 1e-6 || leftover >= MIN_PRINTABLE_TILE_MM;
-    });
+    const depthOf = (p: number): number =>
+      marginPocketDepthMm(p, gridUnitMm, MIN_PRINTABLE_TILE_MM, overTileHalfGrid === true);
+    pocketDepths = {
+      left: depthOf(paddingLeft),
+      right: depthOf(paddingRight),
+      front: depthOf(paddingFront),
+      back: depthOf(paddingBack),
+    };
+    // Ring is needed only where a side leaves a solid (un-pocketed) band.
+    drawRing =
+      paddingLeft - pocketDepths.left > 1e-6 ||
+      paddingRight - pocketDepths.right > 1e-6 ||
+      paddingFront - pocketDepths.front > 1e-6 ||
+      paddingBack - pocketDepths.back > 1e-6;
   }
 
   onProgress('base', 0.1);
@@ -176,7 +183,8 @@ export function generateBaseplateDirect(
     cells,
     totalHeight,
     true,
-    !tiledMargin
+    drawRing,
+    pocketDepths
   );
 
   onProgress('base', 0.6);
@@ -201,7 +209,8 @@ export function generateBaseplateDirect(
       cells,
       0,
       false,
-      !tiledMargin
+      drawRing,
+      pocketDepths
     );
   }
 

--- a/src/features/generation/worker/generators/cellDecomposition.test.ts
+++ b/src/features/generation/worker/generators/cellDecomposition.test.ts
@@ -5,6 +5,7 @@ import {
   forEachCell,
   frameCells,
   computeCellBoundariesMm,
+  marginPocketDepthMm,
 } from './cellDecomposition';
 import type { CellInfo } from './cellDecomposition';
 import { SIZE } from './generatorConstants';
@@ -309,5 +310,36 @@ describe('frameCells half-grid', () => {
     expect(corner).toHaveLength(1);
     expect(corner[0].centerX).toBeLessThan(-42);
     expect(corner[0].centerY).toBeLessThan(-42);
+  });
+});
+
+describe('marginPocketDepthMm', () => {
+  it('over-tile: whole margin is pocketed once it clears the threshold, else solid', () => {
+    expect(marginPocketDepthMm(12, 42, 8, false)).toBeCloseTo(12, 9);
+    expect(marginPocketDepthMm(5, 42, 8, false)).toBe(0);
+    expect(marginPocketDepthMm(0, 42, 8, false)).toBe(0);
+  });
+
+  it('half-grid: packs 21mm cells, drops a sub-threshold sliver', () => {
+    // 25mm -> one 21mm cell pocketed, 4mm sliver solid.
+    expect(marginPocketDepthMm(25, 42, 8, true)).toBeCloseTo(21, 9);
+    // 30mm -> 21mm cell + printable 9mm clip, fully pocketed.
+    expect(marginPocketDepthMm(30, 42, 8, true)).toBeCloseTo(30, 9);
+    // Exactly 21mm -> one clean half-cell, no sliver.
+    expect(marginPocketDepthMm(21, 42, 8, true)).toBeCloseTo(21, 9);
+    // 50mm -> two 21mm cells + 8mm clip, fully pocketed.
+    expect(marginPocketDepthMm(50, 42, 8, true)).toBeCloseTo(50, 9);
+    // 15mm (< 21) -> degrades to a single printable clip, fully pocketed.
+    expect(marginPocketDepthMm(15, 42, 8, true)).toBeCloseTo(15, 9);
+  });
+
+  it('agrees with frameCells on which margins leave a solid sliver', () => {
+    // Pocket depth < padding exactly when frameCells leaves a dropped sliver.
+    for (const p of [5, 12, 21, 25, 30, 46, 50]) {
+      const depth = marginPocketDepthMm(p, 42, 8, true);
+      const cells = frameCells(1, 1, { left: p, right: 0, front: 0, back: 0 }, 42, 8, true);
+      const pocketedMm = cells.reduce((sum, c) => sum + c.widthUnits * 42, 0);
+      expect(depth).toBeCloseTo(pocketedMm, 6);
+    }
   });
 });

--- a/src/features/generation/worker/generators/cellDecomposition.ts
+++ b/src/features/generation/worker/generators/cellDecomposition.ts
@@ -331,3 +331,29 @@ export function frameCells(
   }
   return cells;
 }
+
+/**
+ * How far (mm) {@link frameCells} pockets reach into a margin of width
+ * `paddingMm` — the part filled with cells rather than left as a dropped
+ * sub-threshold sliver. The leftover (`paddingMm - result`) is solid plastic at
+ * the margin's outer edge.
+ *
+ * Mirrors the drop rule in {@link frameCells}: over-tile fills the whole margin
+ * with one clip once it clears `minStripMm` (otherwise nothing); half-grid packs
+ * 0.5-unit cells from the grid edge first and keeps only a printable remainder.
+ * Used by the direct-mesh draft to fill solid bands without capping pockets.
+ */
+export function marginPocketDepthMm(
+  paddingMm: number,
+  gridUnitMm: number,
+  minStripMm: number,
+  halfGrid: boolean
+): number {
+  if (paddingMm < FRACTION_EPS) return 0;
+  if (!halfGrid) return paddingMm >= minStripMm ? paddingMm : 0;
+  const halfMm = gridUnitMm / 2;
+  const halfCount = Math.floor((paddingMm + FRACTION_EPS) / halfMm);
+  const leftover = paddingMm - halfCount * halfMm;
+  const keptLeftover = leftover >= minStripMm - FRACTION_EPS ? leftover : 0;
+  return halfCount * halfMm + keptLeftover;
+}

--- a/src/features/generation/worker/generators/directMeshFaces.ts
+++ b/src/features/generation/worker/generators/directMeshFaces.ts
@@ -40,11 +40,18 @@ export function addPlateFace(
   z: number,
   faceUp: boolean,
   /**
-   * Whether to fill the padding margin with a solid ring. False for over-tile,
-   * where the margin is tiled with frame pockets (passed in `cells`) instead —
-   * their openings + corner gussets cover the margin, so a ring would hide them.
+   * Whether to fill solid (un-pocketed) padding margin with a ring. False for a
+   * fully over-tiled margin, where frame pockets (passed in `cells`) plus their
+   * corner gussets cover the margin, so a ring would hide them.
    */
-  drawRing = true
+  drawRing = true,
+  /**
+   * How far frame pockets reach into each side's margin (mm). Expands the ring's
+   * inner edge per side so the ring fills only the outer solid band beyond the
+   * pockets — never capping a tiled (e.g. 21mm half-grid) pocket opening. Omit
+   * for plain solid padding, where the ring fills the whole margin to the grid.
+   */
+  pocketDepths?: { left: number; right: number; front: number; back: number }
 ): void {
   const nz = faceUp ? 1 : -1;
   const gridHalfW = (gridW * gridUnitMm) / 2;
@@ -61,7 +68,23 @@ export function addPlateFace(
   });
 
   if (drawRing && hasPadding) {
-    addRingFace(mb, outerPts, offsetX, offsetY, gridHalfW, gridHalfD, z, 0, 0, nz, faceUp);
+    const innerMinX = -(gridHalfW + (pocketDepths?.left ?? 0));
+    const innerMaxX = gridHalfW + (pocketDepths?.right ?? 0);
+    const innerMinY = -(gridHalfD + (pocketDepths?.front ?? 0));
+    const innerMaxY = gridHalfD + (pocketDepths?.back ?? 0);
+    addRingFace(
+      mb,
+      outerPts,
+      offsetX,
+      offsetY,
+      innerMinX,
+      innerMaxX,
+      innerMinY,
+      innerMaxY,
+      z,
+      nz,
+      faceUp
+    );
   }
 
   for (const cell of cells) {
@@ -162,11 +185,11 @@ function addRingFace(
   outerPts: ReadonlyArray<readonly [number, number]>,
   offsetX: number,
   offsetY: number,
-  innerHalfW: number,
-  innerHalfD: number,
+  innerMinX: number,
+  innerMaxX: number,
+  innerMinY: number,
+  innerMaxY: number,
   z: number,
-  fnx: number,
-  fny: number,
   fnz: number,
   faceUp: boolean
 ): void {
@@ -178,10 +201,10 @@ function addRingFace(
   for (const pt of outerPts) {
     const ox = pt[0] + offsetX;
     const oy = pt[1] + offsetY;
-    const ix = Math.max(-innerHalfW, Math.min(innerHalfW, ox));
-    const iy = Math.max(-innerHalfD, Math.min(innerHalfD, oy));
-    outerVerts.push(mb.pushVertex(ox, oy, z, fnx, fny, fnz));
-    innerVerts.push(mb.pushVertex(ix, iy, z, fnx, fny, fnz));
+    const ix = Math.max(innerMinX, Math.min(innerMaxX, ox));
+    const iy = Math.max(innerMinY, Math.min(innerMaxY, oy));
+    outerVerts.push(mb.pushVertex(ox, oy, z, 0, 0, fnz));
+    innerVerts.push(mb.pushVertex(ix, iy, z, 0, 0, fnz));
   }
 
   for (let i = 0; i < n; i++) {

--- a/src/features/generation/worker/generators/generatorTypes.ts
+++ b/src/features/generation/worker/generators/generatorTypes.ts
@@ -59,7 +59,13 @@ export {
   HOLE_DEPTH,
   NUB_CIRCLE_SEGMENTS,
 } from './generatorConstants';
-export { decomposeCells, decomposeHalfCells, forEachCell, frameCells } from './cellDecomposition';
+export {
+  decomposeCells,
+  decomposeHalfCells,
+  forEachCell,
+  frameCells,
+  marginPocketDepthMm,
+} from './cellDecomposition';
 export type { CellInfo, ForEachCellOptions, SideMargins } from './cellDecomposition';
 export { sketch, checkCancelled, toIndexedMeshData } from './meshUtils';
 export type { ProgressFn, BooleanOpts } from './meshUtils';


### PR DESCRIPTION
Closes #2380. Follow-up from PR #2379.

## Problem

The direct-mesh **draft preview** filled the entire padding margin with a single solid ring (`addPlateFace(..., drawRing = !tiledMargin)`) whenever *any* side left a sub-printable leftover. In half-grid mode this capped the valid 21mm half-sockets — e.g. a 25mm margin (a 21mm half-socket + a 4mm sliver) rendered as solid plastic until the BREP pass caught up. The same all-or-nothing ring also capped a tiled side's pockets in plain over-tile whenever a *different* side was sub-threshold.

Export/BREP were already correct; this was draft-only.

## Fix

Make the ring **per-side** instead of all-or-nothing. The ring's inner edge is expanded by how far frame pockets actually reach into each margin, so it fills only the outer solid band *beyond* the pockets and never caps a pocket opening:

- A fully tiled side contributes **no** ring.
- A sub-threshold sliver keeps its solid fill (just the outer strip).
- Corners fall out correctly — a corner pocket is inside the inner box on both axes, so the ring (outside the box) never reaches it.

This also fixes the pre-existing plain-over-tile mixed-margin case.

## Changes

- **`marginPocketDepthMm`** (new, in `cellDecomposition.ts`): pure fn mirroring the `frameCells` drop rule — how far pockets reach into a margin vs. the solid sliver left over. Unit-tested across over-tile/half-grid cases and cross-checked against `frameCells` output.
- **`addRingFace`** now takes a 4-bound inner box (`innerMinX/MaxX/MinY/MaxY`) instead of symmetric half-extents.
- **`addPlateFace`** gains an optional `pocketDepths` param; plain solid padding omits it (full ring, unchanged).
- **`baseplateDirectMesh`** computes per-side pocket depths and draws the ring only where a solid band remains.

## Testing

- Unit: `marginPocketDepthMm` cases + a consistency check that it agrees with `frameCells` on which margins leave a sliver.
- **Regression** (`baseplateDirectMesh.test.ts`): a 25mm half-grid margin leaves meaningfully less top-face area than solid padding — i.e. the half-socket is open. Fails on the old all-or-nothing ring, passes now.
- Full generator suite (151 files / 1686 tests), typecheck, lint, and the over-tile E2E all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the direct-mesh draft preview so half-grid margins no longer cap 21mm half-sockets. The padding ring is now per-side and only fills the solid sliver, matching export behavior. Fixes #2380.

- **Bug Fixes**
  - Replaced the all-or-nothing margin ring with a per-side ring that expands past pocketed depth, so pocket openings (including half-grid) stay open.
  - Fully tiled sides draw no ring; sub-threshold sides fill only the outer solid band; corners stay clear. Also fixes mixed-margin plain over-tile.
  - Tests: unit tests for pocket depth; a 25mm half-grid regression; regression now derives top-face Z from mesh bounds to avoid hard-coded heights.

- **Refactors**
  - Introduced `marginPocketDepthMm` mirroring `frameCells` drop rules (unit-tested).
  - Updated `addRingFace` to use inner box bounds; `addPlateFace` accepts optional `pocketDepths`.
  - `baseplateDirectMesh` computes per-side pocket depths and draws the ring only where solid remains.

<sup>Written for commit c612d96004ee3101cdca5627ac9a9a9995bdee3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

