### PR TITLE
fix(baseplate): keep half-grid margin fill on split plates

### DIFF
--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -808,6 +808,25 @@ describe('pieceToBaseplateParams', () => {
     ).toBeFalsy();
   });
 
+  it('propagates overTileHalfGrid to pieces so a split plate keeps half-grid cells (#2384)', () => {
+    // Regression: pieceToBaseplateParams copied overTile but dropped
+    // overTileHalfGrid, so a split plate silently rendered plain over-tile —
+    // half-grid output was identical to grid output.
+    const half = makeParams({
+      width: 10,
+      depth: 8,
+      paddingLeft: 25,
+      paddingRight: 25,
+      overTile: true,
+      overTileHalfGrid: true,
+    });
+    const tiling = computeBaseplateTiling(half, 256);
+    expect(tiling.isSplit).toBe(true);
+    for (const piece of tiling.pieces) {
+      expect(pieceToBaseplateParams(piece, half).overTileHalfGrid).toBe(true);
+    }
+  });
+
   it('swaps front/back padding for rotated pieces so the body centre negates (stack-print preview relies on this)', () => {
     // The stack-print preview derives a flipped plate's body centre from the
     // SAME params the mesh was generated with. For a preferIdenticalPieces 180°

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -647,8 +647,10 @@ export function pieceToBaseplateParams(
     // Over-tile is additive (clipped pockets in each piece's exterior padding
     // margin) and leaves the slab/grid/offset unchanged, so it propagates to
     // pieces cleanly: interior join edges have zero padding → no pockets, and
-    // exterior padded edges get the gap-filling tiles.
+    // exterior padded edges get the gap-filling tiles. Half-grid must ride along
+    // too, or a split plate silently falls back to plain over-tile per piece.
     overTile: parentParams.overTile,
+    overTileHalfGrid: parentParams.overTileHalfGrid,
     connectorNubs: parentParams.connectorNubs,
     // Dovetail key seams are symmetric, so connectorStyle is rotation-invariant —
     // copy it straight through (unlike padding/edges, which rotate with `rot`).


### PR DESCRIPTION
Fixes #2384.

## Symptom
Choosing the **half-grid** margin-fill option produced the same baseplate as **grid** (plain over-tile). The reporter's repro — a 375×235mm plate anchored in a corner — exceeds the print bed, so it tiles into multiple pieces.

## Root cause
`pieceToBaseplateParams` (the per-piece param builder used for split plates) copied `overTile` to each piece but **dropped `overTileHalfGrid`**. So every split piece generated with `halfGrid=false` → plain over-tile, identical to grid mode.

The whole-plate path (`buildFullParams`) forwards the flag correctly, which is why the bug only appeared once a plate was large enough to split — a single, undivided plate worked fine.

This is the same class of "new baseplate flag silently falls through a second param-assembly path" gotcha as the `selectGenerationTriggers` / `migrateBaseplateParams` cases noted when the feature landed (#2379).

## Fix
Propagate `overTileHalfGrid` alongside `overTile` in `pieceToBaseplateParams`. One field, no behavior change to non-split plates or to grid/solid modes.

The piece fingerprint and per-piece mesh cache key are unaffected: `overTileHalfGrid` is plate-global (uniform across all pieces), so it doesn't change intra-run dedup grouping, and the worker's `meshCacheKey` already includes it for cross-run correctness.

## Tests
- Added a regression test in `splitPlanner.test.ts` asserting every piece of a split, half-grid plate carries `overTileHalfGrid: true` (verified it fails without the fix).
- Existing `splitPlanner` / `pieceFingerprint` suites (105 tests) and the BREP over-tile scenario suite pass; typecheck + lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes half-grid margin fill on split baseplates. `pieceToBaseplateParams` now propagates `overTileHalfGrid` to each piece so split plates render half-grid instead of plain over-tile.

- **Bug Fixes**
  - Propagate `overTileHalfGrid` alongside `overTile` in `pieceToBaseplateParams`; whole-plate path already worked.
  - Add regression test in `splitPlanner.test.ts` verifying each split piece keeps `overTileHalfGrid: true`.

<sup>Written for commit 4dac66f72afb88d2b1dbb8962bfb3283eb596878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

