### PR TITLE
chore(lint): resolve brep-parts parse errors and clear safe warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 import noInitTimeImportedCall from './eslint-rules/no-init-time-imported-call.js'
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage', 'e2e', 'scripts', 'benchmarks', 'reports', 'playwright.config.ts', 'playwright.smoke.config.ts', 'playwright-ct.config.ts', 'playwright', '**/*.visual.tsx']),
+  globalIgnores(['dist', 'coverage', 'e2e', 'scripts', 'benchmarks', 'reports', 'brep-parts', 'playwright.config.ts', 'playwright.smoke.config.ts', 'playwright-ct.config.ts', 'playwright', '**/*.visual.tsx']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
@@ -67,7 +67,7 @@ export function CameraController({
   const fov = 45;
   const aspect = size.width > 0 && size.height > 0 ? size.width / size.height : 1;
 
-  const stackActive = stackEnabled && stackBounds !== null && (stackBounds?.heightMm ?? 0) > 0;
+  const stackActive = stackEnabled && stackBounds !== null && stackBounds.heightMm > 0;
   const totalH = stackActive && stackBounds ? stackBounds.heightMm : GRIDFINITY_SPEC.SOCKET_HEIGHT;
   const binCenter = useMemo(() => new THREE.Vector3(0, 0, totalH / 2), [totalH]);
   const idealDistance = useMemo(() => {

--- a/src/features/generation/worker/generators/meshUtils.ts
+++ b/src/features/generation/worker/generators/meshUtils.ts
@@ -20,10 +20,9 @@ export type ProgressFn = (stage: string, progress: number) => void;
 export type BooleanOpts = BooleanOptions;
 
 /**
- * Sketch a drawing on a plane, narrowing to SketchInterface.
- * All our drawings are single closed wires, so SketchInterface is always the
- * correct runtime type. This eliminates repeated `as SketchInterface` casts.
+ * Sketch a drawing on a plane. Centralizes the `sketchOnPlane` call and its
+ * default plane/origin so callers share one typed entry point.
  */
 export function sketch(drawing: Drawing, plane?: PlaneName, origin?: number): SketchInterface {
-  return drawing.sketchOnPlane(plane, origin) as SketchInterface;
+  return drawing.sketchOnPlane(plane, origin);
 }


### PR DESCRIPTION
First of a series of behavior-preserving tech-debt cleanups.

## What

- **`brep-parts/` → ESLint `globalIgnores`.** The standalone brepjs gauge/coupon scripts in `brep-parts/` live outside every tsconfig project (`tsconfig.app.json` only includes `src`), so type-aware ESLint raised **4 hard parse errors** (`file not found in any of the provided project(s)`) on every run. They're not part of any build graph, so ignoring them is the correct fix — `eslint` now exits with **0 errors**.
- **`meshUtils.sketch`** — dropped the now-unnecessary `as SketchInterface` cast (`sketchOnPlane` already returns that type) — `no-unnecessary-type-assertion`.
- **`CameraController`** — `stackBounds` is already narrowed non-null on that line, so the `?.` + `?? 0` were redundant — `no-unnecessary-condition`.

## Result

Lint: **4 errors → 0**, 17 → 14 warnings. No behavior change. Typecheck + touched-area tests (19 files, 67 tests) green.

Remaining warnings are pre-existing `max-lines` (file-size) and a couple of defensive guards intentionally kept; those are tracked for later thematic PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `eslint` parse errors by ignoring `brep-parts/` and removes two redundant checks. Lint errors drop from 4 to 0 with no behavior change.

- **Refactors**
  - Add `brep-parts/` to `eslint` `globalIgnores` to stop type-aware parse errors (files sit outside `tsconfig` projects and aren’t built).
  - `meshUtils.sketch`: remove unnecessary `as SketchInterface` cast; `sketchOnPlane` already returns it.
  - `CameraController`: simplify `stackActive` by removing redundant optional/nullish checks.

<sup>Written for commit 947c1795176aa6f5102c2141e653741e27d66e3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

