### PR TITLE
fix(api): replace deprecated Liveblocks FULL_ACCESS/READ_ACCESS scopes

### DIFF
--- a/api/liveblocks-auth.test.ts
+++ b/api/liveblocks-auth.test.ts
@@ -7,8 +7,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Shared mock session that tests can inspect
 const mockSession = {
-  FULL_ACCESS: 'room:write',
-  READ_ACCESS: 'room:read',
   allow: vi.fn(),
   authorize: vi.fn().mockResolvedValue({ body: '{"token":"test"}', status: 200 }),
 };
@@ -192,7 +190,7 @@ describe('liveblocks-auth handler', () => {
     expect(res._body).toEqual(expect.objectContaining({ error: 'Share not found' }));
   });
 
-  it('grants FULL_ACCESS for edit permission', async () => {
+  it('grants write access for edit permission', async () => {
     const req = createMockRequest();
     const res = createMockResponse();
 
@@ -205,10 +203,10 @@ describe('liveblocks-auth handler', () => {
     await handler(req, res);
 
     expect(res._status).toBe(200);
-    expect(mockSession.allow).toHaveBeenCalledWith('gridfinity-abc123xyz789', 'room:write');
+    expect(mockSession.allow).toHaveBeenCalledWith('gridfinity-abc123xyz789', ['*:write']);
   });
 
-  it('grants READ_ACCESS for view permission', async () => {
+  it('grants read access for view permission', async () => {
     const req = createMockRequest();
     const res = createMockResponse();
 
@@ -221,7 +219,7 @@ describe('liveblocks-auth handler', () => {
     await handler(req, res);
 
     expect(res._status).toBe(200);
-    expect(mockSession.allow).toHaveBeenCalledWith('gridfinity-abc123xyz789', 'room:read');
+    expect(mockSession.allow).toHaveBeenCalledWith('gridfinity-abc123xyz789', ['*:read']);
   });
 
   it('uses userName when provided', async () => {

--- a/api/liveblocks-auth.ts
+++ b/api/liveblocks-auth.ts
@@ -169,7 +169,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Grant access based on share permission level. `['*:write']` / `['*:read']`
     // are the non-deprecated form of the old session.FULL_ACCESS / READ_ACCESS
     // constants (which were exactly these scope arrays).
-    session.allow(room, permission === 'edit' ? ['*:write'] : ['*:read']);
+    session.allow(room, permission === 'edit' ? (['*:write'] as const) : (['*:read'] as const));
 
     // Authorize and return session token
     const { body, status } = await session.authorize();

--- a/api/liveblocks-auth.ts
+++ b/api/liveblocks-auth.ts
@@ -11,8 +11,8 @@ import type { ShareData } from './lib/shared.js';
  *
  * This endpoint authenticates users for Liveblocks room access.
  * Permission is enforced by fetching share metadata from Vercel Blob:
- * - 'edit' permission grants FULL_ACCESS (read + write)
- * - 'view' permission grants READ_ACCESS (read only)
+ * - 'edit' permission grants write access (`['*:write']`)
+ * - 'view' permission grants read-only access (`['*:read']`)
  *
  * SECURITY — userId trust model:
  * `userId` is supplied by the client and only checked for non-empty string.
@@ -166,9 +166,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       },
     });
 
-    // Grant access based on share permission level
-    const accessLevel = permission === 'edit' ? session.FULL_ACCESS : session.READ_ACCESS;
-    session.allow(room, accessLevel);
+    // Grant access based on share permission level. `['*:write']` / `['*:read']`
+    // are the non-deprecated form of the old session.FULL_ACCESS / READ_ACCESS
+    // constants (which were exactly these scope arrays).
+    session.allow(room, permission === 'edit' ? ['*:write'] : ['*:read']);
 
     // Authorize and return session token
     const { body, status } = await session.authorize();

--- a/src/liveblocks.config.ts
+++ b/src/liveblocks.config.ts
@@ -69,8 +69,8 @@ export const isLiveblocksConfigured = Boolean(LIVEBLOCKS_PUBLIC_KEY);
  * Liveblocks client configuration.
  *
  * Uses server-side auth endpoint for permission enforcement:
- * - 'edit' shares grant FULL_ACCESS to all collaborators
- * - 'view' shares grant READ_ACCESS to non-owners
+ * - 'edit' shares grant write access to all collaborators
+ * - 'view' shares grant read-only access to non-owners
  *
  * Requires LIVEBLOCKS_SECRET_KEY on the server side.
  * Client is only created when the public key is available.


### PR DESCRIPTION
## What

`session.FULL_ACCESS` / `session.READ_ACCESS` are `@deprecated` in `@liveblocks/node`. The installed type defs declare them as **exactly** `readonly ["*:write"]` / `readonly ["*:read"]`, so this swaps the constants for those literal scope arrays passed straight to `session.allow(room, …)`.

- Behavior-identical (verified against `node_modules/@liveblocks/node` types — the constants *are* these arrays).
- Clears the 2 `@typescript-eslint/no-deprecated` warnings.
- Updates the test mock + assertions in lockstep (`'room:write'` → `['*:write']`, etc.) and refreshes the doc comments in `liveblocks-auth.ts` / `liveblocks.config.ts`.

Typecheck, lint, and `liveblocks-auth.test.ts` (14 tests) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced deprecated `session.FULL_ACCESS`/`session.READ_ACCESS` from `@liveblocks/node` with `['*:write']`/`['*:read']` to keep behavior identical and clear `@typescript-eslint/no-deprecated` warnings. Marked the scope arrays `as const` to preserve exact readonly tuple types and prevent string[] widening; updated tests (mocks/assertions) and inline docs.

<sup>Written for commit 3c27136f47084e8b72e5974b70315c5b5ee91bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

