### PR TITLE
refactor(types): single-source the baseplate edge-kind union

### DIFF
--- a/src/features/baseplate/types/tiling.ts
+++ b/src/features/baseplate/types/tiling.ts
@@ -9,12 +9,16 @@
 // MarginPiece lives in shared so the generation worker can build a rail without
 // a cross-feature import; imported here for `BaseplateTiling` and re-exported
 // for baseplate-local consumers.
-import type { MarginCorner, MarginPiece } from '@/shared/types/bin';
+import type { BaseplateEdgeKind, MarginCorner, MarginPiece } from '@/shared/types/bin';
 
 export type { MarginCorner, MarginPiece };
 
-/** Whether an edge is exterior (outside of baseplate) or a join between pieces. */
-export type EdgeKind = 'join' | 'exterior';
+/**
+ * Whether an edge is exterior (outside of baseplate) or a join between pieces.
+ * Single-sourced from {@link BaseplateEdgeKind} so the union has one definition
+ * to extend — the two were maintained in lockstep and could silently diverge.
+ */
+export type EdgeKind = BaseplateEdgeKind;
 
 export interface PieceEdges {
   readonly left: EdgeKind;

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -105,7 +105,11 @@ export type {
   LidCompatibilitySide,
 } from '@/features/bin-designer/utils/lidCompatibility';
 
-/** Whether an edge is exterior (outside baseplate) or a join between split pieces. */
+/**
+ * Whether an edge is exterior (outside baseplate) or a join between split pieces.
+ * Canonical edge-kind union; the baseplate feature's `EdgeKind` aliases this, so
+ * extend the union here and both stay in sync.
+ */
 export type BaseplateEdgeKind = 'join' | 'exterior';
 
 /** Per-side edge classification for split baseplate pieces. */


### PR DESCRIPTION
## What

`EdgeKind` (`features/baseplate/types/tiling.ts`) and `BaseplateEdgeKind` (`shared/types/bin.ts`) were **two byte-identical `'join' | 'exterior'` unions**, maintained in lockstep and compared via `===` across ~10 files with no exhaustiveness gate. A member added to one and forgotten on the other would silently diverge the split/connector geometry (this is a documented gotcha in CLAUDE.md).

This aliases `EdgeKind = BaseplateEdgeKind` (the lower, shared layer is canonical), so there's **one definition to extend**.

## Why not add an exhaustiveness switch too

The union is only ever consumed via boolean `=== 'exterior'` / `=== 'join'` checks — there's no `switch` site, so an `assertNever` gate would be artificial. Single-sourcing removes the actual divergence risk (the dual definition).

Type-only, zero runtime change. Typecheck proves the equivalence across every consumer; touched-area tests (splitPlanner, pieceNaming — 93 tests) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-sourced the baseplate edge-kind union by aliasing `EdgeKind` to `BaseplateEdgeKind`, creating one canonical definition and removing drift risk. Type-only change; no runtime impact, and existing `'join'`/`'exterior'` comparisons stay the same.

<sup>Written for commit b4691fc7610ad770f4d0b1825920d963e5ea3b7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

