### PR TITLE
refactor(constants): centralize print-bed mm bounds and default

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -45,6 +45,13 @@ export const CONSTRAINTS = {
   HEIGHT_UNIT_MM_MIN: 3,
   HEIGHT_UNIT_MM_MAX: 20,
   HEIGHT_UNIT_MM_DEFAULT: 7,
+  // Print-bed dimension bounds (mm). The min doubles as the legacy grid-unit
+  // detector in storage migration: a stored printBedSize below it is grid
+  // units, not mm. Kept distinct from GRID_UNIT_MM_DEFAULT even though both
+  // are 42 — they're unrelated concepts that happen to share a value.
+  PRINT_BED_MM_MIN: 42,
+  PRINT_BED_MM_MAX: 500,
+  PRINT_BED_MM_DEFAULT: 256,
   // Layout library constraints
   LAYOUTS_MAX: 500, // Max layouts in library (IndexedDB storage)
   LAYOUTS_WARNING_THRESHOLD: 450, // Show warning at this count

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -466,7 +466,7 @@ export const createDefaultLayout = (): Layout => {
       depth: gridUnits(size.depth),
       height: heightUnits(size.height),
     },
-    printBedSize: mm(256), // mm - typical print bed size
+    printBedSize: mm(CONSTRAINTS.PRINT_BED_MM_DEFAULT),
     gridUnitMm: mm(42),
     heightUnitMm: mm(7),
     categories: [...DEFAULT_CATEGORIES],

--- a/src/core/cqrs/v2/domain/layout/setPrintBedSize.ts
+++ b/src/core/cqrs/v2/domain/layout/setPrintBedSize.ts
@@ -1,6 +1,7 @@
 /**
- * Set print-bed dimensions. Clamps both `size` and optional `depth` to
- * [42, 500] mm; captures `previousSize` and `previousDepth` for undo.
+ * Set print-bed dimensions. Clamps both `size` and optional `depth` to the
+ * configured print-bed bounds (CONSTRAINTS.PRINT_BED_MM_MIN/MAX); captures
+ * `previousSize` and `previousDepth` for undo.
  */
 
 import { z } from 'zod';

--- a/src/core/cqrs/v2/domain/layout/setPrintBedSize.ts
+++ b/src/core/cqrs/v2/domain/layout/setPrintBedSize.ts
@@ -6,6 +6,7 @@
 import { z } from 'zod';
 import { ok } from '@/core/result';
 import { clamp } from '@/shared/utils/validation';
+import { CONSTRAINTS } from '@/core/constants';
 import { mm } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 
@@ -13,9 +14,6 @@ const payloadSchema = z.object({
   size: z.number(),
   depth: z.number().optional(),
 });
-
-const MIN_PRINT_BED_MM = 42;
-const MAX_PRINT_BED_MM = 500;
 
 export const setPrintBedSize = defineCommand({
   type: 'layout.setPrintBedSize',
@@ -29,10 +27,10 @@ export const setPrintBedSize = defineCommand({
   handle: (payload, ctx) => {
     const previousSize = ctx.aggregate.printBedSize as number;
     const previousDepth = ctx.aggregate.printBedDepth as number | undefined;
-    const size = clamp(payload.size, MIN_PRINT_BED_MM, MAX_PRINT_BED_MM);
+    const size = clamp(payload.size, CONSTRAINTS.PRINT_BED_MM_MIN, CONSTRAINTS.PRINT_BED_MM_MAX);
     const depth =
       payload.depth !== undefined
-        ? clamp(payload.depth, MIN_PRINT_BED_MM, MAX_PRINT_BED_MM)
+        ? clamp(payload.depth, CONSTRAINTS.PRINT_BED_MM_MIN, CONSTRAINTS.PRINT_BED_MM_MAX)
         : undefined;
 
     return ok({

--- a/src/core/storage/LayoutService.ts
+++ b/src/core/storage/LayoutService.ts
@@ -17,6 +17,7 @@ import * as backend from './backend';
 import * as indexedDB from './backends/indexedDB';
 import { salvageImport } from '@/shared/utils/validation';
 import {
+  CONSTRAINTS,
   DEFAULT_LAYOUT_NAME,
   generateCategoryId,
   generateLayerId,
@@ -74,12 +75,16 @@ function migrateLayout(data: Record<string, unknown>): Record<string, unknown> {
     data.printBedSize = (data.maxPrintSize as number) * gridUnitMm;
     delete data.maxPrintSize;
   }
-  // Fix if printBedSize was saved in grid units (< 42 means it's probably not in mm)
-  if (data.printBedSize !== undefined && (data.printBedSize as number) < 42) {
+  // Fix if printBedSize was saved in grid units. A value below the minimum valid
+  // mm bed dimension can't be a real mm bed, so treat it as grid units.
+  if (
+    data.printBedSize !== undefined &&
+    (data.printBedSize as number) < CONSTRAINTS.PRINT_BED_MM_MIN
+  ) {
     data.printBedSize = (data.printBedSize as number) * gridUnitMm;
   }
   if (data.printBedSize === undefined) {
-    data.printBedSize = 256; // Default 256mm
+    data.printBedSize = CONSTRAINTS.PRINT_BED_MM_DEFAULT;
   }
   return data;
 }
@@ -564,7 +569,7 @@ export async function initializeLayoutLibrary(): Promise<{
       version: '1.0',
       name: DEFAULT_LAYOUT_NAME,
       drawer: { width: gridUnits(width), depth: gridUnits(depth), height: heightUnits(height) },
-      printBedSize: mm(256),
+      printBedSize: mm(CONSTRAINTS.PRINT_BED_MM_DEFAULT),
       gridUnitMm: mm(42),
       heightUnitMm: mm(7),
       categories: [
@@ -604,7 +609,7 @@ export async function initializeLayoutLibrary(): Promise<{
         version: '1.0',
         name: 'Recovered layout',
         drawer: { width: gridUnits(rw), depth: gridUnits(rd), height: heightUnits(rh) },
-        printBedSize: mm(256),
+        printBedSize: mm(CONSTRAINTS.PRINT_BED_MM_DEFAULT),
         gridUnitMm: mm(42),
         heightUnitMm: mm(7),
         categories: [{ id: generateCategoryId(), name: 'Default', color: '#6b7280' }],

--- a/src/core/store/layout/coreActions.ts
+++ b/src/core/store/layout/coreActions.ts
@@ -51,9 +51,15 @@ export function createCoreActions(setLocal: SetLocal, set: ImmerSet, _get: GetSt
 
     setPrintBedSize: (size: number, depth?: number): void => {
       setLocal((state) => {
-        state.layout.printBedSize = clamp(size, 42, 500) as Mm;
+        state.layout.printBedSize = clamp(
+          size,
+          CONSTRAINTS.PRINT_BED_MM_MIN,
+          CONSTRAINTS.PRINT_BED_MM_MAX
+        ) as Mm;
         state.layout.printBedDepth =
-          depth !== undefined ? (clamp(depth, 42, 500) as Mm) : undefined;
+          depth !== undefined
+            ? (clamp(depth, CONSTRAINTS.PRINT_BED_MM_MIN, CONSTRAINTS.PRINT_BED_MM_MAX) as Mm)
+            : undefined;
       });
     },
 

--- a/src/core/store/layout/index.ts
+++ b/src/core/store/layout/index.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import type { Layout, Mm, GridUnits, HeightUnits } from '@/core/types';
+import { CONSTRAINTS } from '@/core/constants';
 import { createBinActions } from './binActions';
 import { createLayerActions } from './layerActions';
 import { createCategoryActions } from './categoryActions';
@@ -28,7 +29,7 @@ const PLACEHOLDER_LAYOUT: Layout = {
   version: '1.0',
   name: '',
   drawer: { width: 0 as GridUnits, depth: 0 as GridUnits, height: 0 as HeightUnits },
-  printBedSize: 256 as Mm,
+  printBedSize: CONSTRAINTS.PRINT_BED_MM_DEFAULT as Mm,
   gridUnitMm: 42 as Mm,
   heightUnitMm: 7 as Mm,
   categories: [],

--- a/src/core/store/layout/index.ts
+++ b/src/core/store/layout/index.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import type { Layout, Mm, GridUnits, HeightUnits } from '@/core/types';
-import { CONSTRAINTS } from '@/core/constants';
 import { createBinActions } from './binActions';
 import { createLayerActions } from './layerActions';
 import { createCategoryActions } from './categoryActions';
@@ -29,7 +28,10 @@ const PLACEHOLDER_LAYOUT: Layout = {
   version: '1.0',
   name: '',
   drawer: { width: 0 as GridUnits, depth: 0 as GridUnits, height: 0 as HeightUnits },
-  printBedSize: CONSTRAINTS.PRINT_BED_MM_DEFAULT as Mm,
+  // Literal, not CONSTRAINTS.PRINT_BED_MM_DEFAULT: PLACEHOLDER_LAYOUT is built at
+  // module-init, and reading an imported @/core/constants binding at init risks
+  // the #1466 chunk static-import-cycle undefined read.
+  printBedSize: 256 as Mm,
   gridUnitMm: 42 as Mm,
   heightUnitMm: 7 as Mm,
   categories: [],

--- a/src/core/store/settings.types.ts
+++ b/src/core/store/settings.types.ts
@@ -2,7 +2,6 @@ import type { Locale } from '@/i18n/types';
 import type { Category } from '@/core/types';
 import type { PrintSettings } from '@/shared/printSettings';
 import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
-import { CONSTRAINTS } from '@/core/constants';
 
 // STL Search Sites Configuration
 
@@ -318,7 +317,10 @@ export const DEFAULT_SETTINGS: UserSettings = {
   defaultDrawerDepth: 8,
   defaultDrawerHeight: 12,
   defaultLayerHeight: 3, // Default to 3 (current hardcoded behavior)
-  defaultPrintBedSize: CONSTRAINTS.PRINT_BED_MM_DEFAULT,
+  // Literal, not CONSTRAINTS.PRINT_BED_MM_DEFAULT: DEFAULT_SETTINGS is read at
+  // module-init, and reading an imported @/core/constants binding at init risks
+  // the #1466 chunk static-import-cycle undefined read.
+  defaultPrintBedSize: 256,
   defaultGridUnitMm: 42,
   defaultHeightUnitMm: 7,
 

--- a/src/core/store/settings.types.ts
+++ b/src/core/store/settings.types.ts
@@ -2,6 +2,7 @@ import type { Locale } from '@/i18n/types';
 import type { Category } from '@/core/types';
 import type { PrintSettings } from '@/shared/printSettings';
 import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
+import { CONSTRAINTS } from '@/core/constants';
 
 // STL Search Sites Configuration
 
@@ -317,7 +318,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   defaultDrawerDepth: 8,
   defaultDrawerHeight: 12,
   defaultLayerHeight: 3, // Default to 3 (current hardcoded behavior)
-  defaultPrintBedSize: 256,
+  defaultPrintBedSize: CONSTRAINTS.PRINT_BED_MM_DEFAULT,
   defaultGridUnitMm: 42,
   defaultHeightUnitMm: 7,
 

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.ts
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.ts
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSettingsStore } from '@/core/store';
 import { CONSTRAINTS } from '@/core/constants';
+import { clamp } from '@/shared/utils/validation';
 import { useTranslation } from '@/i18n';
 import type { SectionMeta } from '../types';
 
@@ -35,14 +36,11 @@ export function usePhysicalUnitsSection() {
 
   const handlePrintBedChange = useCallback(
     (width: number, depth?: number) => {
-      const clampedWidth = Math.max(
-        CONSTRAINTS.PRINT_BED_MM_MIN,
-        Math.min(CONSTRAINTS.PRINT_BED_MM_MAX, width)
-      );
+      const clampedWidth = clamp(width, CONSTRAINTS.PRINT_BED_MM_MIN, CONSTRAINTS.PRINT_BED_MM_MAX);
       const clampedDepth =
         depth === undefined
           ? undefined
-          : Math.max(CONSTRAINTS.PRINT_BED_MM_MIN, Math.min(CONSTRAINTS.PRINT_BED_MM_MAX, depth));
+          : clamp(depth, CONSTRAINTS.PRINT_BED_MM_MIN, CONSTRAINTS.PRINT_BED_MM_MAX);
       updateSettings({
         defaultPrintBedSize: clampedWidth,
         defaultPrintBedDepth: clampedDepth,

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.ts
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSettingsStore } from '@/core/store';
+import { CONSTRAINTS } from '@/core/constants';
 import { useTranslation } from '@/i18n';
 import type { SectionMeta } from '../types';
 
@@ -34,8 +35,14 @@ export function usePhysicalUnitsSection() {
 
   const handlePrintBedChange = useCallback(
     (width: number, depth?: number) => {
-      const clampedWidth = Math.max(42, Math.min(500, width));
-      const clampedDepth = depth === undefined ? undefined : Math.max(42, Math.min(500, depth));
+      const clampedWidth = Math.max(
+        CONSTRAINTS.PRINT_BED_MM_MIN,
+        Math.min(CONSTRAINTS.PRINT_BED_MM_MAX, width)
+      );
+      const clampedDepth =
+        depth === undefined
+          ? undefined
+          : Math.max(CONSTRAINTS.PRINT_BED_MM_MIN, Math.min(CONSTRAINTS.PRINT_BED_MM_MAX, depth));
       updateSettings({
         defaultPrintBedSize: clampedWidth,
         defaultPrintBedDepth: clampedDepth,

--- a/src/shared/analytics/posthog/metrics.ts
+++ b/src/shared/analytics/posthog/metrics.ts
@@ -4,12 +4,7 @@
  */
 
 import type { Layout, CategoryId } from '@/core/types';
-import {
-  CONSTRAINTS,
-  DEFAULT_CATEGORIES,
-  calcMaxGridUnits,
-  hasFractionalDimensions,
-} from '@/core/constants';
+import { DEFAULT_CATEGORIES, calcMaxGridUnits, hasFractionalDimensions } from '@/core/constants';
 import { useLabsStore } from '@/core/store/labs';
 import { getFeature } from '@/core/labs';
 import { splitBinsByLocation } from '@/shared/utils';
@@ -100,7 +95,10 @@ export interface LayoutMetrics {
 // METRICS COMPUTATION
 
 export const DEFAULT_DRAWER = { width: 10, depth: 8, height: 12 };
-export const DEFAULT_PRINT_BED = CONSTRAINTS.PRINT_BED_MM_DEFAULT;
+// Intentionally a literal, not CONSTRAINTS.PRINT_BED_MM_DEFAULT: this is read at
+// module-init, and (per the #1466 note above) reading an imported @/core/constants
+// binding at init time can resolve to undefined under the chunk static-import cycle.
+export const DEFAULT_PRINT_BED = 256;
 
 // Lazily computed to avoid a top-level read of the imported DEFAULT_CATEGORIES
 // binding. In production, this module and src/core/constants land in chunks

--- a/src/shared/analytics/posthog/metrics.ts
+++ b/src/shared/analytics/posthog/metrics.ts
@@ -4,7 +4,12 @@
  */
 
 import type { Layout, CategoryId } from '@/core/types';
-import { DEFAULT_CATEGORIES, calcMaxGridUnits, hasFractionalDimensions } from '@/core/constants';
+import {
+  CONSTRAINTS,
+  DEFAULT_CATEGORIES,
+  calcMaxGridUnits,
+  hasFractionalDimensions,
+} from '@/core/constants';
 import { useLabsStore } from '@/core/store/labs';
 import { getFeature } from '@/core/labs';
 import { splitBinsByLocation } from '@/shared/utils';
@@ -95,7 +100,7 @@ export interface LayoutMetrics {
 // METRICS COMPUTATION
 
 export const DEFAULT_DRAWER = { width: 10, depth: 8, height: 12 };
-export const DEFAULT_PRINT_BED = 256;
+export const DEFAULT_PRINT_BED = CONSTRAINTS.PRINT_BED_MM_DEFAULT;
 
 // Lazily computed to avoid a top-level read of the imported DEFAULT_CATEGORIES
 // binding. In production, this module and src/core/constants land in chunks

--- a/src/shared/components/PrintBedInput/PrintBedInput.tsx
+++ b/src/shared/components/PrintBedInput/PrintBedInput.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Button } from '@/design-system';
 import { DeferredNumberInput } from '@/shared/components/DeferredNumberInput';
+import { CONSTRAINTS } from '@/core/constants';
 import { useTranslation } from '@/i18n';
 
 export interface PrintBedInputProps {
@@ -33,8 +34,8 @@ export function PrintBedInput({
   onChange,
   id,
   variant = 'compact',
-  min = 42,
-  max = 500,
+  min = CONSTRAINTS.PRINT_BED_MM_MIN,
+  max = CONSTRAINTS.PRINT_BED_MM_MAX,
   step = 10,
 }: PrintBedInputProps) {
   const t = useTranslation();

--- a/src/shared/utils/validationImport.ts
+++ b/src/shared/utils/validationImport.ts
@@ -142,7 +142,7 @@ export function validateImport(data: unknown): ImportValidationResult {
         })) as Layout['layers'],
         bins: validatedBins,
         categories: [] as Layout['categories'],
-        printBedSize: mm(256),
+        printBedSize: mm(CONSTRAINTS.PRINT_BED_MM_DEFAULT),
         gridUnitMm: mm(42),
         heightUnitMm: mm(7),
       };

--- a/src/shared/utils/validationSalvage.ts
+++ b/src/shared/utils/validationSalvage.ts
@@ -144,7 +144,7 @@ export function salvageImport(data: unknown): SalvageResult {
       })) as Layout['layers'],
       bins: validatedGridBins,
       categories: [] as Layout['categories'],
-      printBedSize: mm(256),
+      printBedSize: mm(CONSTRAINTS.PRINT_BED_MM_DEFAULT),
       gridUnitMm: mm(42),
       heightUnitMm: mm(7),
     };

--- a/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
@@ -177,10 +177,18 @@ export function DefaultsTab() {
               width={settings.defaultPrintBedSize}
               depth={settings.defaultPrintBedDepth ?? settings.defaultPrintBedSize}
               onChange={(w, d) => {
-                updateSetting('defaultPrintBedSize', Math.max(42, Math.min(500, w)));
+                updateSetting(
+                  'defaultPrintBedSize',
+                  Math.max(CONSTRAINTS.PRINT_BED_MM_MIN, Math.min(CONSTRAINTS.PRINT_BED_MM_MAX, w))
+                );
                 updateSetting(
                   'defaultPrintBedDepth',
-                  d !== undefined ? Math.max(42, Math.min(500, d)) : undefined
+                  d !== undefined
+                    ? Math.max(
+                        CONSTRAINTS.PRINT_BED_MM_MIN,
+                        Math.min(CONSTRAINTS.PRINT_BED_MM_MAX, d)
+                      )
+                    : undefined
                 );
               }}
               variant="compact"

--- a/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
@@ -179,15 +179,12 @@ export function DefaultsTab() {
               onChange={(w, d) => {
                 updateSetting(
                   'defaultPrintBedSize',
-                  Math.max(CONSTRAINTS.PRINT_BED_MM_MIN, Math.min(CONSTRAINTS.PRINT_BED_MM_MAX, w))
+                  clamp(w, CONSTRAINTS.PRINT_BED_MM_MIN, CONSTRAINTS.PRINT_BED_MM_MAX)
                 );
                 updateSetting(
                   'defaultPrintBedDepth',
                   d !== undefined
-                    ? Math.max(
-                        CONSTRAINTS.PRINT_BED_MM_MIN,
-                        Math.min(CONSTRAINTS.PRINT_BED_MM_MAX, d)
-                      )
+                    ? clamp(d, CONSTRAINTS.PRINT_BED_MM_MIN, CONSTRAINTS.PRINT_BED_MM_MAX)
                     : undefined
                 );
               }}


### PR DESCRIPTION
## What

The print-bed dimension bounds (`42`/`500`mm) and default (`256`mm) were bare literals duplicated across 6 files:

- `core/cqrs/v2/domain/layout/setPrintBedSize.ts` (local `MIN/MAX_PRINT_BED_MM` consts)
- `core/store/layout/coreActions.ts` (`clamp(size, 42, 500)`)
- `shell/.../DefaultsTab.tsx` and `bin-designer/.../usePhysicalUnitsSection.ts` (`Math.max(42, Math.min(500, …))`)
- `shared/components/PrintBedInput.tsx` (default props `min=42, max=500`)
- `core/storage/LayoutService.ts` (`< 42` grid-unit migration heuristic + three `256` defaults)

Adds `PRINT_BED_MM_MIN` / `PRINT_BED_MM_MAX` / `PRINT_BED_MM_DEFAULT` to `CONSTRAINTS` and references them everywhere.

## Notes

- Kept **distinct** from `GRID_UNIT_MM_DEFAULT` even though both are `42` — unrelated concepts that coincidentally share a value, so a future change to one can't silently move the other.
- The storage-migration heuristic (`printBedSize < 42` ⇒ stored in grid units) now reads as "below the minimum valid mm bed" via the named constant — semantically correct coupling.

Values unchanged; behavior-preserving. Typecheck + lint clean; setPrintBedSize / LayoutService / PrintBedInput tests (31) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized print‑bed bounds (42/500 mm) and default (256 mm) in `CONSTRAINTS` to remove duplicated literals and make the migration check explicit. Behavior unchanged.

- **Refactors**
  - Applied `PRINT_BED_MM_MIN/MAX/DEFAULT` across CQRS, store actions, settings UI and bin‑designer (both now use `clamp()`), `PrintBedInput`, storage migration, `createDefaultLayout`, and import/salvage.
  - Kept module‑init defaults as literals for `PLACEHOLDER_LAYOUT`, `DEFAULT_SETTINGS`, and analytics `DEFAULT_PRINT_BED` to avoid the `#1466` static‑import cycle; still distinct from `GRID_UNIT_MM_DEFAULT`, and migration uses the min constant.

<sup>Written for commit 26992bb3dae6b8fd1f399e2d4df9ccd7795e102f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

