### PR TITLE
test(api): cover ML telemetry aggregators and validators

### DIFF
--- a/api/lib/mlTelemetry/aggregators.test.ts
+++ b/api/lib/mlTelemetry/aggregators.test.ts
@@ -47,6 +47,20 @@ function freshInc(): Increments {
   return {};
 }
 
+/**
+ * Assert that running `call` twice on the same Increments object doubles the
+ * value at inc[key][field]. Requires the counter to be > 0 after the first
+ * call, so callers must pass an event that actually writes to that counter.
+ */
+function assertAdditive(call: (inc: Increments) => void, key: string, field: string): void {
+  const inc = freshInc();
+  call(inc);
+  const once = inc[key]?.[field] ?? 0;
+  expect(once).toBeGreaterThan(0);
+  call(inc);
+  expect(inc[key]?.[field]).toBe(once * 2);
+}
+
 // ─────────────────────────────────────────────
 // aggregateBinPlacement
 // ─────────────────────────────────────────────
@@ -268,6 +282,15 @@ describe('aggregateLabelUpdate', () => {
     aggregateLabelUpdate({ ...baseEvent, new_label_embedding_bucket: 'ff00' }, inc);
     expect(inc['ml:embed:ff00']?.['1x2x3']).toBe(1);
   });
+
+  it('is additive — label_hash counter doubles on second call', () => {
+    // Use a non-null field so the aggregator actually writes something
+    assertAdditive(
+      (inc) => aggregateLabelUpdate({ ...baseEvent, new_label_hash: 'deadbeef' }, inc),
+      'ml:label_hash:deadbeef',
+      '1x2x3'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -465,6 +488,10 @@ describe('aggregateLayoutSnapshot', () => {
     expect(inc['ml:cluster_archetypes:12345678']?.['mixed']).toBe(1);
     expect(inc['ml:clusters:12345678']?.['2x2x3']).toBe(3);
   });
+
+  it('is additive — trigger counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateLayoutSnapshot(baseEvent, inc), 'ml:triggers', 'save');
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -560,6 +587,10 @@ describe('aggregateQualitySignal', () => {
     aggregateQualitySignal({ ...baseEvent, time_since_last_edit_ms: 1_800_000 }, inc);
     expect(inc['ml:quality_dormancy']?.['dormant']).toBe(1);
   });
+
+  it('is additive — quality signal counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateQualitySignal(baseEvent, inc), 'ml:quality', 'shared');
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -642,6 +673,10 @@ describe('aggregateCategoryChange', () => {
     aggregateCategoryChange({ ...baseEvent, label_domain: 'tools' }, inc);
     expect(inc['ml:domain_cat:tools']?.['abcd1234']).toBe(1);
   });
+
+  it('is additive — total category change counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateCategoryChange(baseEvent, inc), 'ml:cat_changes', 'total');
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -716,6 +751,10 @@ describe('aggregateBinResize', () => {
     aggregateBinResize({ ...baseEvent, area_delta: 20 }, inc);
     expect(inc['ml:resize_delta']?.['+9+']).toBe(1);
   });
+
+  it('is additive — total resize counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateBinResize(baseEvent, inc), 'ml:resizes', 'total');
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -777,6 +816,10 @@ describe('aggregateBinDeletion', () => {
     aggregateBinDeletion(baseEvent, inc);
     expect(inc['ml:neg:deletions']?.['total']).toBe(1);
   });
+
+  it('is additive — total deletion counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateBinDeletion(baseEvent, inc), 'ml:neg:deletions', 'total');
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -835,6 +878,10 @@ describe('aggregateBinMove', () => {
     aggregateBinMove(baseEvent, inc);
     expect(inc['ml:moves']?.['total']).toBe(1);
   });
+
+  it('is additive — total move counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateBinMove(baseEvent, inc), 'ml:moves', 'total');
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -885,6 +932,10 @@ describe('aggregateDrawerResize', () => {
     const inc = freshInc();
     aggregateDrawerResize(baseEvent, inc);
     expect(inc['ml:drawer_resize_results']?.['6x6x6']).toBe(1);
+  });
+
+  it('is additive — total drawer resize counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateDrawerResize(baseEvent, inc), 'ml:drawer_resizes', 'total');
   });
 });
 
@@ -950,6 +1001,10 @@ describe('aggregateFillOperation', () => {
     aggregateFillOperation(baseEvent, inc);
     expect(inc['ml:fills']?.['total']).toBe(1);
   });
+
+  it('is additive — total fill counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateFillOperation(baseEvent, inc), 'ml:fills', 'total');
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -1007,6 +1062,10 @@ describe('aggregateLayerMove', () => {
     const inc = freshInc();
     aggregateLayerMove(baseEvent, inc);
     expect(inc['ml:layer_moves']?.['total']).toBe(1);
+  });
+
+  it('is additive — total layer move counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateLayerMove(baseEvent, inc), 'ml:layer_moves', 'total');
   });
 });
 
@@ -1092,6 +1151,10 @@ describe('aggregatePlacementRejection', () => {
     expect(inc['ml:reject_sizes']?.['2x3']).toBe(1);
     expect(inc['ml:neg:reject_by_drawer:6x8x6']?.['2x3']).toBe(1);
   });
+
+  it('is additive — total rejection counter doubles on second call', () => {
+    assertAdditive((inc) => aggregatePlacementRejection(baseEvent, inc), 'ml:rejections', 'total');
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -1153,6 +1216,10 @@ describe('aggregateUndo', () => {
     const inc = freshInc();
     aggregateUndo({ ...baseEvent, bins_affected: 21 }, inc);
     expect(inc['ml:neg:undo_scale']?.['bulk']).toBe(1);
+  });
+
+  it('is additive — total undo counter doubles on second call', () => {
+    assertAdditive((inc) => aggregateUndo(baseEvent, inc), 'ml:neg:undos', 'total');
   });
 });
 
@@ -1223,6 +1290,14 @@ describe('aggregateQuickCorrection', () => {
     aggregateQuickCorrection(baseEvent, inc);
     expect(inc['ml:neg:quick_corrections']?.['total']).toBe(1);
   });
+
+  it('is additive — total quick correction counter doubles on second call', () => {
+    assertAdditive(
+      (inc) => aggregateQuickCorrection(baseEvent, inc),
+      'ml:neg:quick_corrections',
+      'total'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────
@@ -1286,6 +1361,14 @@ describe('aggregateBinAbandonment', () => {
     const inc = freshInc();
     aggregateBinAbandonment(baseEvent, inc);
     expect(inc['ml:neg:abandonment_total']?.['total']).toBe(1);
+  });
+
+  it('is additive — total abandonment counter doubles on second call', () => {
+    assertAdditive(
+      (inc) => aggregateBinAbandonment(baseEvent, inc),
+      'ml:neg:abandonment_total',
+      'total'
+    );
   });
 });
 

--- a/api/lib/mlTelemetry/aggregators.test.ts
+++ b/api/lib/mlTelemetry/aggregators.test.ts
@@ -1,0 +1,1552 @@
+import { describe, it, expect } from 'vitest';
+import type { Increments } from './aggregators.js';
+import {
+  aggregateBinAbandonment,
+  aggregateBinDeletion,
+  aggregateBinMove,
+  aggregateBinPlacement,
+  aggregateBinResize,
+  aggregateBinRotation,
+  aggregateCategoryChange,
+  aggregateCrossLayoutPattern,
+  aggregateDrawerPurpose,
+  aggregateDrawerResize,
+  aggregateFillOperation,
+  aggregateLabelUpdate,
+  aggregateLayerMove,
+  aggregateLayoutSnapshot,
+  aggregatePlacementRejection,
+  aggregateQualitySignal,
+  aggregateQuickCorrection,
+  aggregateSessionSummary,
+  aggregateUndo,
+} from './aggregators.js';
+import type {
+  AbandonedBinEvent,
+  BinDeletedEvent,
+  BinMovedEvent,
+  BinPlacementEvent,
+  BinResizeEvent,
+  BinRotatedEvent,
+  CategoryChangeEvent,
+  CrossLayoutPatternEvent,
+  DrawerPurposeEvent,
+  DrawerResizedEvent,
+  FillOperationEvent,
+  LabelUpdateEvent,
+  LayerMoveEvent,
+  LayoutQualityEvent,
+  LayoutSnapshotEvent,
+  PlacementRejectedEvent,
+  QuickCorrectionEvent,
+  SessionSummaryEvent,
+  UndoEvent,
+} from './types.js';
+
+function freshInc(): Increments {
+  return {};
+}
+
+// ─────────────────────────────────────────────
+// aggregateBinPlacement
+// ─────────────────────────────────────────────
+describe('aggregateBinPlacement', () => {
+  const baseEvent: BinPlacementEvent = {
+    type: 'bin_placed',
+    bin_size: '2x3x4',
+    prev_bin_size: null,
+    drawer_size: '6x8x6',
+    position: '0,0',
+    layer_index: 0,
+    largest_gap: '4x5',
+    fill_pct: 50,
+    gap_fit: 'exact',
+    label_hash: null,
+    label_normalized: null,
+    label_domain: null,
+    label_embedding_bucket: null,
+    category_id: 'cat-01',
+    adjacent_label_hashes: [],
+    adjacent_sizes: [],
+    adjacent_count: 0,
+    recent_sizes: [],
+    time_since_last_ms: null,
+    is_first_of_label: false,
+    method: 'draw',
+    session_index: 0,
+    vocab_version: 'v1',
+  };
+
+  it('increments global size frequency', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(baseEvent, inc);
+    expect(inc['ml:sizes']?.['2x3x4']).toBe(1);
+  });
+
+  it('increments drawer correlation', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(baseEvent, inc);
+    expect(inc['ml:drawer:6x8x6']?.['2x3x4']).toBe(1);
+  });
+
+  it('increments gap_fit bucket', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(baseEvent, inc);
+    expect(inc['ml:gapfit:exact']?.['2x3x4']).toBe(1);
+  });
+
+  it('increments placement method', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(baseEvent, inc);
+    expect(inc['ml:method:draw']?.['2x3x4']).toBe(1);
+  });
+
+  it('does not add transition matrix entry when prev_bin_size is null', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(baseEvent, inc);
+    const transKeys = Object.keys(inc).filter((k) => k.startsWith('ml:trans:'));
+    expect(transKeys).toHaveLength(0);
+  });
+
+  it('adds transition matrix entry when prev_bin_size is set', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, prev_bin_size: '1x1x1' }, inc);
+    expect(inc['ml:trans:1x1x1']?.['2x3x4']).toBe(1);
+  });
+
+  it('tracks unknown hash when label_hash set but no label_normalized', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, label_hash: 'abcd1234', label_normalized: null }, inc);
+    expect(inc['ml:unknown_hashes']?.['abcd1234']).toBe(1);
+    expect(inc['ml:label_hash:abcd1234']?.['2x3x4']).toBe(1);
+  });
+
+  it('does not add unknown_hashes when label_hash and label_normalized are both set', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(
+      { ...baseEvent, label_hash: 'abcd1234', label_normalized: 'screws' },
+      inc
+    );
+    expect(inc['ml:unknown_hashes']).toBeUndefined();
+    expect(inc['ml:label_hash:abcd1234']?.['2x3x4']).toBe(1);
+    expect(inc['ml:label:screws']?.['2x3x4']).toBe(1);
+  });
+
+  it('tracks label_domain when set', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, label_domain: 'tools' }, inc);
+    expect(inc['ml:label_domain:tools']?.['2x3x4']).toBe(1);
+  });
+
+  it('tracks embedding bucket when set', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, label_embedding_bucket: 'a1b2' }, inc);
+    expect(inc['ml:embed:a1b2']?.['2x3x4']).toBe(1);
+  });
+
+  it('increments adjacent_count bucket for count < 4', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, adjacent_count: 2 }, inc);
+    expect(inc['ml:adjacent_counts']?.['2']).toBe(1);
+  });
+
+  it('uses "4+" bucket for adjacent_count >= 4', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, adjacent_count: 4 }, inc);
+    expect(inc['ml:adjacent_counts']?.['4+']).toBe(1);
+  });
+
+  it('tracks co-occurrence for adjacent label hashes in lexicographic order', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(
+      {
+        ...baseEvent,
+        label_hash: 'abcd1234',
+        adjacent_label_hashes: ['zzzz9999'],
+      },
+      inc
+    );
+    // lexicographic: 'abcd1234' < 'zzzz9999', so key is 'ml:cooccur:abcd1234' → 'zzzz9999'
+    expect(inc['ml:cooccur:abcd1234']?.['zzzz9999']).toBe(1);
+  });
+
+  it('does not track co-occurrence when label_hash is null', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(
+      { ...baseEvent, label_hash: null, adjacent_label_hashes: ['abcd1234'] },
+      inc
+    );
+    const coKeys = Object.keys(inc).filter((k) => k.startsWith('ml:cooccur:'));
+    expect(coKeys).toHaveLength(0);
+  });
+
+  it('tracks first-of-label when is_first_of_label is true and label_hash set', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, is_first_of_label: true, label_hash: 'abcd1234' }, inc);
+    expect(inc['ml:first_label:abcd1234']?.['2x3x4']).toBe(1);
+  });
+
+  it('does not track first_label when is_first_of_label is false', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, is_first_of_label: false, label_hash: 'abcd1234' }, inc);
+    expect(inc['ml:first_label:abcd1234']).toBeUndefined();
+  });
+
+  it('tracks recent size sequence when non-empty', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, recent_sizes: ['1x1x1', '2x2x2'] }, inc);
+    expect(inc['ml:sequences']?.['1x1x1>2x2x2']).toBe(1);
+  });
+
+  it('does not track sequences when recent_sizes is empty', () => {
+    const inc = freshInc();
+    aggregateBinPlacement({ ...baseEvent, recent_sizes: [] }, inc);
+    expect(inc['ml:sequences']).toBeUndefined();
+  });
+
+  it('is additive — calling twice doubles ml:sizes counter', () => {
+    const inc = freshInc();
+    aggregateBinPlacement(baseEvent, inc);
+    aggregateBinPlacement(baseEvent, inc);
+    expect(inc['ml:sizes']?.['2x3x4']).toBe(2);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateLabelUpdate
+// ─────────────────────────────────────────────
+describe('aggregateLabelUpdate', () => {
+  const baseEvent: LabelUpdateEvent = {
+    type: 'label_updated',
+    bin_size: '1x2x3',
+    old_label_hash: null,
+    old_label_normalized: null,
+    new_label_hash: null,
+    new_label_normalized: null,
+    new_label_domain: null,
+    new_label_embedding_bucket: null,
+    vocab_version: 'v1',
+  };
+
+  it('does not throw or increment anything when all new fields are null', () => {
+    const inc = freshInc();
+    aggregateLabelUpdate(baseEvent, inc);
+    expect(Object.keys(inc)).toHaveLength(0);
+  });
+
+  it('tracks new_label_hash and unknown_hashes when no normalized label', () => {
+    const inc = freshInc();
+    aggregateLabelUpdate({ ...baseEvent, new_label_hash: 'deadbeef' }, inc);
+    expect(inc['ml:label_hash:deadbeef']?.['1x2x3']).toBe(1);
+    expect(inc['ml:unknown_hashes']?.['deadbeef']).toBe(1);
+  });
+
+  it('tracks new_label_hash without unknown_hashes when normalized label is set', () => {
+    const inc = freshInc();
+    aggregateLabelUpdate(
+      { ...baseEvent, new_label_hash: 'deadbeef', new_label_normalized: 'bolts' },
+      inc
+    );
+    expect(inc['ml:label_hash:deadbeef']?.['1x2x3']).toBe(1);
+    expect(inc['ml:unknown_hashes']).toBeUndefined();
+  });
+
+  it('tracks normalized label', () => {
+    const inc = freshInc();
+    aggregateLabelUpdate({ ...baseEvent, new_label_normalized: 'bolts' }, inc);
+    expect(inc['ml:label:bolts']?.['1x2x3']).toBe(1);
+  });
+
+  it('tracks domain', () => {
+    const inc = freshInc();
+    aggregateLabelUpdate({ ...baseEvent, new_label_domain: 'fasteners' }, inc);
+    expect(inc['ml:label_domain:fasteners']?.['1x2x3']).toBe(1);
+  });
+
+  it('tracks embedding bucket', () => {
+    const inc = freshInc();
+    aggregateLabelUpdate({ ...baseEvent, new_label_embedding_bucket: 'ff00' }, inc);
+    expect(inc['ml:embed:ff00']?.['1x2x3']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateLayoutSnapshot
+// ─────────────────────────────────────────────
+describe('aggregateLayoutSnapshot', () => {
+  const baseEvent: LayoutSnapshotEvent = {
+    type: 'layout_snapshot',
+    trigger: 'save',
+    layout_hash: 'aabbccdd',
+    snapshot_index: 0,
+    drawer_size: '6x8x6',
+    layer_count: 1,
+    purpose: null,
+    bin_count: 5,
+    size_distribution: { '2x2x3': 3, '1x1x1': 2 },
+    category_distribution: { 'cat-01': 5 },
+    domain_distribution: { tools: 3, misc: 2 },
+    top_label_hashes: [],
+    fill_percentage: 50,
+    labeled_percentage: 60,
+    session_duration_ms: 120000,
+    edit_count: 10,
+    quality_tier: 'medium',
+    archetype: 'mixed',
+    spatial_patterns: ['corner_start'],
+    uniformity_score: 0.5,
+    edge_usage: { left: true, right: false, top: true, bottom: false },
+    hour_of_day: 14,
+    day_of_week: 3,
+    is_weekend: false,
+    structure_hash: '12345678',
+    vocab_version: 'v1',
+  };
+
+  it('tracks size distribution entries with counts', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:drawer_sizes:6x8x6']?.['2x2x3']).toBe(3);
+    expect(inc['ml:drawer_sizes:6x8x6']?.['1x1x1']).toBe(2);
+  });
+
+  it('tracks domain distribution entries', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:domains:6x8x6']?.['tools']).toBe(3);
+    expect(inc['ml:domains:6x8x6']?.['misc']).toBe(2);
+  });
+
+  it('tracks snapshot trigger', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:triggers']?.['save']).toBe(1);
+  });
+
+  it('does not increment purpose when purpose is null', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:purpose']).toBeUndefined();
+  });
+
+  it('tracks purpose and purpose_sizes when purpose is set', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot({ ...baseEvent, purpose: 'workshop' }, inc);
+    expect(inc['ml:purpose']?.['workshop']).toBe(1);
+    expect(inc['ml:purpose_sizes:workshop']?.['2x2x3']).toBe(3);
+  });
+
+  it('places fill_percentage=0 in bucket 0', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot({ ...baseEvent, fill_percentage: 0 }, inc);
+    expect(inc['ml:fill_bucket:0']?.['6x8x6']).toBe(1);
+  });
+
+  it('places fill_percentage=100 in bucket 3 (capped)', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot({ ...baseEvent, fill_percentage: 100 }, inc);
+    expect(inc['ml:fill_bucket:3']?.['6x8x6']).toBe(1);
+  });
+
+  it('tracks quality_tier', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:quality_tier']?.['medium']).toBe(1);
+  });
+
+  it('populates tier_sizes for medium quality', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:tier_sizes:medium']?.['2x2x3']).toBe(3);
+  });
+
+  it('does not populate tier_sizes for low quality', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot({ ...baseEvent, quality_tier: 'low' }, inc);
+    expect(inc['ml:tier_sizes:low']).toBeUndefined();
+  });
+
+  it('populates label_hash_high only for high quality with label_size_pairs', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(
+      {
+        ...baseEvent,
+        quality_tier: 'high',
+        label_size_pairs: [{ hash: 'abcd1234', size: '2x2x3' }],
+      },
+      inc
+    );
+    expect(inc['ml:label_hash_high:abcd1234']?.['2x2x3']).toBe(1);
+  });
+
+  it('does not populate label_hash_high for medium quality', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(
+      {
+        ...baseEvent,
+        quality_tier: 'medium',
+        label_size_pairs: [{ hash: 'abcd1234', size: '2x2x3' }],
+      },
+      inc
+    );
+    expect(inc['ml:label_hash_high:abcd1234']).toBeUndefined();
+  });
+
+  it('builds bidirectional co-occurrence matrix from top_label_hashes', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(
+      { ...baseEvent, top_label_hashes: ['aaaa1111', 'bbbb2222', 'cccc3333'] },
+      inc
+    );
+    expect(inc['ml:cooccur:aaaa1111']?.['bbbb2222']).toBe(1);
+    expect(inc['ml:cooccur:bbbb2222']?.['aaaa1111']).toBe(1);
+    expect(inc['ml:cooccur:aaaa1111']?.['cccc3333']).toBe(1);
+  });
+
+  it('tracks archetype', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:archetype']?.['mixed']).toBe(1);
+    expect(inc['ml:archetype:6x8x6']?.['mixed']).toBe(1);
+  });
+
+  it('tracks spatial patterns', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:patterns']?.['corner_start']).toBe(1);
+    expect(inc['ml:patterns:mixed']?.['corner_start']).toBe(1);
+  });
+
+  it('tracks uniformity bucket from score', () => {
+    const inc = freshInc();
+    // uniformity_score=0.5 → Math.floor(0.5 * 4) = 2 → 'bucket_2'
+    aggregateLayoutSnapshot({ ...baseEvent, uniformity_score: 0.5 }, inc);
+    expect(inc['ml:uniformity']?.['bucket_2']).toBe(1);
+  });
+
+  it('tracks edge count from edge_usage', () => {
+    const inc = freshInc();
+    // left=true, right=false, top=true, bottom=false → 2 edges
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:edge_count']?.['edges_2']).toBe(1);
+    expect(inc['ml:edge_combo']?.['LT']).toBe(1);
+  });
+
+  it('uses "none" edge combo when no edges are active', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(
+      { ...baseEvent, edge_usage: { left: false, right: false, top: false, bottom: false } },
+      inc
+    );
+    expect(inc['ml:edge_combo']?.['none']).toBe(1);
+  });
+
+  it('tracks hour and day of week', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:temporal:hour:14']?.['count']).toBe(1);
+    expect(inc['ml:temporal:day:3']?.['count']).toBe(1);
+  });
+
+  it('tracks weekday vs weekend', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:temporal:weekday']?.['weekday']).toBe(1);
+
+    const inc2 = freshInc();
+    aggregateLayoutSnapshot({ ...baseEvent, is_weekend: true }, inc2);
+    expect(inc2['ml:temporal:weekday']?.['weekend']).toBe(1);
+  });
+
+  it('tracks structure hash cluster distribution', () => {
+    const inc = freshInc();
+    aggregateLayoutSnapshot(baseEvent, inc);
+    expect(inc['ml:cluster_distribution']?.['12345678']).toBe(1);
+    expect(inc['ml:cluster_archetypes:12345678']?.['mixed']).toBe(1);
+    expect(inc['ml:clusters:12345678']?.['2x2x3']).toBe(3);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateQualitySignal
+// ─────────────────────────────────────────────
+describe('aggregateQualitySignal', () => {
+  const baseEvent: LayoutQualityEvent = {
+    type: 'layout_quality',
+    layout_hash: 'aabbccdd',
+    signal: 'shared',
+    days_since_creation: 0,
+    abandonment_type: null,
+    time_since_last_edit_ms: 0,
+  };
+
+  it('tracks quality signal', () => {
+    const inc = freshInc();
+    aggregateQualitySignal(baseEvent, inc);
+    expect(inc['ml:quality']?.['shared']).toBe(1);
+  });
+
+  it('places days_since_creation=0 in day1 bucket', () => {
+    const inc = freshInc();
+    aggregateQualitySignal(baseEvent, inc);
+    expect(inc['ml:quality_age:shared']?.['day1']).toBe(1);
+  });
+
+  it('places days_since_creation=7 in week1 bucket', () => {
+    const inc = freshInc();
+    aggregateQualitySignal({ ...baseEvent, days_since_creation: 7 }, inc);
+    expect(inc['ml:quality_age:shared']?.['week1']).toBe(1);
+  });
+
+  it('places days_since_creation=31 in older bucket', () => {
+    const inc = freshInc();
+    aggregateQualitySignal({ ...baseEvent, days_since_creation: 31 }, inc);
+    expect(inc['ml:quality_age:shared']?.['older']).toBe(1);
+  });
+
+  it('skips confidence tracking when confidence_breakdown is absent', () => {
+    const inc = freshInc();
+    aggregateQualitySignal(baseEvent, inc);
+    expect(inc['ml:quality_confidence']).toBeUndefined();
+  });
+
+  it('tracks confidence bucket from combined score', () => {
+    const inc = freshInc();
+    const breakdown = {
+      undo_score: 0.8,
+      completion_score: 0.8,
+      session_score: 0.8,
+      correction_score: 0.8,
+      combined: 0.8,
+    };
+    aggregateQualitySignal({ ...baseEvent, confidence_breakdown: breakdown }, inc);
+    expect(inc['ml:quality_confidence']?.['high']).toBe(1);
+    expect(inc['ml:quality_conf_by_signal:shared']?.['high']).toBe(1);
+  });
+
+  it('maps combined=0.1 to very_low confidence', () => {
+    const inc = freshInc();
+    const breakdown = {
+      undo_score: 0.1,
+      completion_score: 0.1,
+      session_score: 0.1,
+      correction_score: 0.1,
+      combined: 0.1,
+    };
+    aggregateQualitySignal({ ...baseEvent, confidence_breakdown: breakdown }, inc);
+    expect(inc['ml:quality_confidence']?.['very_low']).toBe(1);
+  });
+
+  it('skips abandonment tracking when abandonment_type is null', () => {
+    const inc = freshInc();
+    aggregateQualitySignal(baseEvent, inc);
+    expect(inc['ml:abandonment']).toBeUndefined();
+  });
+
+  it('tracks abandonment type when set', () => {
+    const inc = freshInc();
+    aggregateQualitySignal({ ...baseEvent, abandonment_type: 'incomplete' }, inc);
+    expect(inc['ml:abandonment']?.['incomplete']).toBe(1);
+  });
+
+  it('classifies dormancy: active (<60s)', () => {
+    const inc = freshInc();
+    aggregateQualitySignal({ ...baseEvent, time_since_last_edit_ms: 30000 }, inc);
+    expect(inc['ml:quality_dormancy']?.['active']).toBe(1);
+  });
+
+  it('classifies dormancy: dormant (>=30min)', () => {
+    const inc = freshInc();
+    aggregateQualitySignal({ ...baseEvent, time_since_last_edit_ms: 1_800_000 }, inc);
+    expect(inc['ml:quality_dormancy']?.['dormant']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateDrawerPurpose
+// ─────────────────────────────────────────────
+describe('aggregateDrawerPurpose', () => {
+  const baseEvent: DrawerPurposeEvent = {
+    type: 'drawer_purpose',
+    layout_hash: 'aabbccdd',
+    purpose: 'workshop',
+    is_custom: false,
+  };
+
+  it('tracks purpose frequency', () => {
+    const inc = freshInc();
+    aggregateDrawerPurpose(baseEvent, inc);
+    expect(inc['ml:purpose']?.['workshop']).toBe(1);
+  });
+
+  it('marks predefined when is_custom is false', () => {
+    const inc = freshInc();
+    aggregateDrawerPurpose(baseEvent, inc);
+    expect(inc['ml:purpose_type']?.['predefined']).toBe(1);
+  });
+
+  it('marks custom when is_custom is true', () => {
+    const inc = freshInc();
+    aggregateDrawerPurpose({ ...baseEvent, is_custom: true }, inc);
+    expect(inc['ml:purpose_type']?.['custom']).toBe(1);
+  });
+
+  it('is additive', () => {
+    const inc = freshInc();
+    aggregateDrawerPurpose(baseEvent, inc);
+    aggregateDrawerPurpose(baseEvent, inc);
+    expect(inc['ml:purpose']?.['workshop']).toBe(2);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateCategoryChange
+// ─────────────────────────────────────────────
+describe('aggregateCategoryChange', () => {
+  const baseEvent: CategoryChangeEvent = {
+    type: 'category_changed',
+    bin_size: '2x2x3',
+    category_name_hash: 'abcd1234',
+    batch_size: 1,
+    label_hash: null,
+    label_domain: null,
+    vocab_version: 'v1',
+  };
+
+  it('tracks cat_sizes by category_name_hash', () => {
+    const inc = freshInc();
+    aggregateCategoryChange(baseEvent, inc);
+    expect(inc['ml:cat_sizes:abcd1234']?.['2x2x3']).toBe(1);
+  });
+
+  it('tracks total category change events', () => {
+    const inc = freshInc();
+    aggregateCategoryChange(baseEvent, inc);
+    expect(inc['ml:cat_changes']?.['total']).toBe(1);
+  });
+
+  it('skips label_cat when label_hash is null', () => {
+    const inc = freshInc();
+    aggregateCategoryChange(baseEvent, inc);
+    expect(inc['ml:label_cat:abcd1234']).toBeUndefined();
+  });
+
+  it('tracks label_cat when label_hash is set', () => {
+    const inc = freshInc();
+    aggregateCategoryChange({ ...baseEvent, label_hash: 'deadbeef' }, inc);
+    expect(inc['ml:label_cat:deadbeef']?.['abcd1234']).toBe(1);
+  });
+
+  it('tracks domain_cat when label_domain is set', () => {
+    const inc = freshInc();
+    aggregateCategoryChange({ ...baseEvent, label_domain: 'tools' }, inc);
+    expect(inc['ml:domain_cat:tools']?.['abcd1234']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateBinResize
+// ─────────────────────────────────────────────
+describe('aggregateBinResize', () => {
+  const baseEvent: BinResizeEvent = {
+    type: 'bin_resized',
+    old_size: '1x1x3',
+    new_size: '2x1x3',
+    dimensions_changed: ['width'],
+    batch_size: 1,
+    fill_pct: 40,
+    resize_direction: 'grow',
+    area_delta: 1,
+  };
+
+  it('tracks resize transition', () => {
+    const inc = freshInc();
+    aggregateBinResize(baseEvent, inc);
+    expect(inc['ml:resize:1x1x3']?.['2x1x3']).toBe(1);
+  });
+
+  it('tracks resize_results', () => {
+    const inc = freshInc();
+    aggregateBinResize(baseEvent, inc);
+    expect(inc['ml:resize_results']?.['2x1x3']).toBe(1);
+  });
+
+  it('tracks each changed dimension', () => {
+    const inc = freshInc();
+    aggregateBinResize({ ...baseEvent, dimensions_changed: ['width', 'depth'] }, inc);
+    expect(inc['ml:resize_dims']?.['width']).toBe(1);
+    expect(inc['ml:resize_dims']?.['depth']).toBe(1);
+  });
+
+  it('tracks total resizes', () => {
+    const inc = freshInc();
+    aggregateBinResize(baseEvent, inc);
+    expect(inc['ml:resizes']?.['total']).toBe(1);
+  });
+
+  it('tracks resize direction', () => {
+    const inc = freshInc();
+    aggregateBinResize(baseEvent, inc);
+    expect(inc['ml:resize_direction']?.['grow']).toBe(1);
+  });
+
+  it('encodes positive area_delta with "+" prefix', () => {
+    const inc = freshInc();
+    // area_delta=1, abs=1, bucket='0-1', prefix='+'
+    aggregateBinResize({ ...baseEvent, area_delta: 1 }, inc);
+    expect(inc['ml:resize_delta']?.['+0-1']).toBe(1);
+  });
+
+  it('encodes negative area_delta with "-" prefix', () => {
+    const inc = freshInc();
+    // area_delta=-5, abs=5, bucket='4-9', prefix='-'
+    aggregateBinResize({ ...baseEvent, area_delta: -5 }, inc);
+    expect(inc['ml:resize_delta']?.['-4-9']).toBe(1);
+  });
+
+  it('encodes zero area_delta with no prefix', () => {
+    const inc = freshInc();
+    // area_delta=0, abs=0, bucket='0', prefix=''
+    aggregateBinResize({ ...baseEvent, area_delta: 0 }, inc);
+    expect(inc['ml:resize_delta']?.['0']).toBe(1);
+  });
+
+  it('places large area_delta in "9+" bucket', () => {
+    const inc = freshInc();
+    aggregateBinResize({ ...baseEvent, area_delta: 20 }, inc);
+    expect(inc['ml:resize_delta']?.['+9+']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateBinDeletion
+// ─────────────────────────────────────────────
+describe('aggregateBinDeletion', () => {
+  const baseEvent: BinDeletedEvent = {
+    type: 'bin_deleted',
+    bin_size: '2x2x3',
+    position: '1,2',
+    layer_index: 0,
+    had_label: false,
+    label_domain: null,
+    age_ms: null,
+    batch_size: 1,
+    fill_pct: 30,
+    method: 'key',
+  };
+
+  it('tracks deleted size', () => {
+    const inc = freshInc();
+    aggregateBinDeletion(baseEvent, inc);
+    expect(inc['ml:neg:deleted_sizes']?.['2x2x3']).toBe(1);
+  });
+
+  it('tracks delete method', () => {
+    const inc = freshInc();
+    aggregateBinDeletion(baseEvent, inc);
+    expect(inc['ml:neg:delete_methods']?.['key']).toBe(1);
+  });
+
+  it('marks unlabeled when had_label is false', () => {
+    const inc = freshInc();
+    aggregateBinDeletion(baseEvent, inc);
+    expect(inc['ml:neg:delete_labeled']?.['unlabeled']).toBe(1);
+  });
+
+  it('marks labeled when had_label is true', () => {
+    const inc = freshInc();
+    aggregateBinDeletion({ ...baseEvent, had_label: true }, inc);
+    expect(inc['ml:neg:delete_labeled']?.['labeled']).toBe(1);
+  });
+
+  it('skips domain tracking when label_domain is null', () => {
+    const inc = freshInc();
+    aggregateBinDeletion(baseEvent, inc);
+    const domainKeys = Object.keys(inc).filter((k) => k.startsWith('ml:neg:delete_domain:'));
+    expect(domainKeys).toHaveLength(0);
+  });
+
+  it('tracks domain deletion when label_domain is set', () => {
+    const inc = freshInc();
+    aggregateBinDeletion({ ...baseEvent, label_domain: 'tools' }, inc);
+    expect(inc['ml:neg:delete_domain:tools']?.['2x2x3']).toBe(1);
+  });
+
+  it('tracks total deletions', () => {
+    const inc = freshInc();
+    aggregateBinDeletion(baseEvent, inc);
+    expect(inc['ml:neg:deletions']?.['total']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateBinMove
+// ─────────────────────────────────────────────
+describe('aggregateBinMove', () => {
+  const baseEvent: BinMovedEvent = {
+    type: 'bin_moved',
+    bin_size: '2x2x3',
+    old_position: '0,0',
+    new_position: '2,2',
+    distance: 1,
+    layer_index: 0,
+    batch_size: 1,
+    method: 'drag',
+  };
+
+  it('tracks moved size', () => {
+    const inc = freshInc();
+    aggregateBinMove(baseEvent, inc);
+    expect(inc['ml:moved_sizes']?.['2x2x3']).toBe(1);
+  });
+
+  it('tracks move method', () => {
+    const inc = freshInc();
+    aggregateBinMove(baseEvent, inc);
+    expect(inc['ml:move_methods']?.['drag']).toBe(1);
+  });
+
+  it('classifies distance=1 as micro', () => {
+    const inc = freshInc();
+    aggregateBinMove({ ...baseEvent, distance: 1 }, inc);
+    expect(inc['ml:move_distances']?.['micro']).toBe(1);
+  });
+
+  it('classifies distance=2 as short', () => {
+    const inc = freshInc();
+    aggregateBinMove({ ...baseEvent, distance: 2 }, inc);
+    expect(inc['ml:move_distances']?.['short']).toBe(1);
+  });
+
+  it('classifies distance=9 as medium', () => {
+    const inc = freshInc();
+    aggregateBinMove({ ...baseEvent, distance: 9 }, inc);
+    expect(inc['ml:move_distances']?.['medium']).toBe(1);
+  });
+
+  it('classifies distance=10 as long', () => {
+    const inc = freshInc();
+    aggregateBinMove({ ...baseEvent, distance: 10 }, inc);
+    expect(inc['ml:move_distances']?.['long']).toBe(1);
+  });
+
+  it('tracks total moves', () => {
+    const inc = freshInc();
+    aggregateBinMove(baseEvent, inc);
+    expect(inc['ml:moves']?.['total']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateDrawerResize
+// ─────────────────────────────────────────────
+describe('aggregateDrawerResize', () => {
+  const baseEvent: DrawerResizedEvent = {
+    type: 'drawer_resized',
+    old_size: '4x4x6',
+    new_size: '6x6x6',
+    dimensions_changed: ['width', 'depth'],
+    bins_staged: 0,
+    fill_pct: 20,
+  };
+
+  it('tracks drawer resize transition', () => {
+    const inc = freshInc();
+    aggregateDrawerResize(baseEvent, inc);
+    expect(inc['ml:drawer_resize:4x4x6']?.['6x6x6']).toBe(1);
+  });
+
+  it('tracks changed dimensions', () => {
+    const inc = freshInc();
+    aggregateDrawerResize(baseEvent, inc);
+    expect(inc['ml:drawer_resize_dims']?.['width']).toBe(1);
+    expect(inc['ml:drawer_resize_dims']?.['depth']).toBe(1);
+  });
+
+  it('marks no_bins when bins_staged is 0', () => {
+    const inc = freshInc();
+    aggregateDrawerResize(baseEvent, inc);
+    expect(inc['ml:drawer_resize_staged']?.['no_bins']).toBe(1);
+  });
+
+  it('marks with_bins when bins_staged > 0', () => {
+    const inc = freshInc();
+    aggregateDrawerResize({ ...baseEvent, bins_staged: 3 }, inc);
+    expect(inc['ml:drawer_resize_staged']?.['with_bins']).toBe(1);
+  });
+
+  it('tracks total drawer resizes', () => {
+    const inc = freshInc();
+    aggregateDrawerResize(baseEvent, inc);
+    expect(inc['ml:drawer_resizes']?.['total']).toBe(1);
+  });
+
+  it('tracks resulting drawer size', () => {
+    const inc = freshInc();
+    aggregateDrawerResize(baseEvent, inc);
+    expect(inc['ml:drawer_resize_results']?.['6x6x6']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateFillOperation
+// ─────────────────────────────────────────────
+describe('aggregateFillOperation', () => {
+  const baseEvent: FillOperationEvent = {
+    type: 'fill_operation',
+    method: 'uniform',
+    fill_size: '2x2',
+    bins_created: 5,
+    layer_index: 0,
+    fill_pct: 80,
+    drawer_size: '6x8x6',
+  };
+
+  it('tracks fill method', () => {
+    const inc = freshInc();
+    aggregateFillOperation(baseEvent, inc);
+    expect(inc['ml:fill_methods']?.['uniform']).toBe(1);
+  });
+
+  it('tracks fill_size and fill_by_drawer when fill_size is set', () => {
+    const inc = freshInc();
+    aggregateFillOperation(baseEvent, inc);
+    expect(inc['ml:fill_sizes']?.['2x2']).toBe(1);
+    expect(inc['ml:fill_by_drawer:6x8x6']?.['2x2']).toBe(1);
+  });
+
+  it('skips fill_sizes when fill_size is null', () => {
+    const inc = freshInc();
+    aggregateFillOperation({ ...baseEvent, fill_size: null }, inc);
+    expect(inc['ml:fill_sizes']).toBeUndefined();
+  });
+
+  it('classifies bins_created <= 10 as small', () => {
+    const inc = freshInc();
+    aggregateFillOperation({ ...baseEvent, bins_created: 5 }, inc);
+    expect(inc['ml:fill_bins']?.['small']).toBe(1);
+  });
+
+  it('classifies bins_created <= 50 as medium', () => {
+    const inc = freshInc();
+    aggregateFillOperation({ ...baseEvent, bins_created: 25 }, inc);
+    expect(inc['ml:fill_bins']?.['medium']).toBe(1);
+  });
+
+  it('classifies bins_created <= 100 as large', () => {
+    const inc = freshInc();
+    aggregateFillOperation({ ...baseEvent, bins_created: 75 }, inc);
+    expect(inc['ml:fill_bins']?.['large']).toBe(1);
+  });
+
+  it('classifies bins_created > 100 as xlarge', () => {
+    const inc = freshInc();
+    aggregateFillOperation({ ...baseEvent, bins_created: 200 }, inc);
+    expect(inc['ml:fill_bins']?.['xlarge']).toBe(1);
+  });
+
+  it('tracks total fills', () => {
+    const inc = freshInc();
+    aggregateFillOperation(baseEvent, inc);
+    expect(inc['ml:fills']?.['total']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateLayerMove
+// ─────────────────────────────────────────────
+describe('aggregateLayerMove', () => {
+  const baseEvent: LayerMoveEvent = {
+    type: 'layer_move',
+    bin_size: '1x2x3',
+    from_layer_index: 0,
+    to_layer_index: 1,
+    batch_size: 1,
+    method: 'drag',
+  };
+
+  it('tracks layer transition from->to', () => {
+    const inc = freshInc();
+    aggregateLayerMove(baseEvent, inc);
+    expect(inc['ml:layer_trans:layer0']?.['layer1']).toBe(1);
+  });
+
+  it('tracks layer_moved_sizes', () => {
+    const inc = freshInc();
+    aggregateLayerMove(baseEvent, inc);
+    expect(inc['ml:layer_moved_sizes']?.['1x2x3']).toBe(1);
+  });
+
+  it('tracks layer move method', () => {
+    const inc = freshInc();
+    aggregateLayerMove(baseEvent, inc);
+    expect(inc['ml:layer_move_methods']?.['drag']).toBe(1);
+  });
+
+  it('uses "staging" key for from_layer_index=-1 and tracks staging_out', () => {
+    const inc = freshInc();
+    aggregateLayerMove({ ...baseEvent, from_layer_index: -1 }, inc);
+    expect(inc['ml:layer_trans:staging']?.['layer1']).toBe(1);
+    expect(inc['ml:staging_out']?.['layer1']).toBe(1);
+  });
+
+  it('uses "staging" key for to_layer_index=-1 and tracks staging_in', () => {
+    const inc = freshInc();
+    aggregateLayerMove({ ...baseEvent, to_layer_index: -1 }, inc);
+    expect(inc['ml:layer_trans:layer0']?.['staging']).toBe(1);
+    expect(inc['ml:staging_in']?.['layer0']).toBe(1);
+  });
+
+  it('does not set staging_out for normal layer moves', () => {
+    const inc = freshInc();
+    aggregateLayerMove(baseEvent, inc);
+    expect(inc['ml:staging_out']).toBeUndefined();
+  });
+
+  it('tracks total layer moves', () => {
+    const inc = freshInc();
+    aggregateLayerMove(baseEvent, inc);
+    expect(inc['ml:layer_moves']?.['total']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateBinRotation
+// ─────────────────────────────────────────────
+describe('aggregateBinRotation', () => {
+  const baseEvent: BinRotatedEvent = {
+    type: 'bin_rotated',
+    old_size: '1x3x4',
+    new_size: '3x1x4',
+    batch_size: 1,
+  };
+
+  it('tracks rotation transition', () => {
+    const inc = freshInc();
+    aggregateBinRotation(baseEvent, inc);
+    expect(inc['ml:rotate:1x3x4']?.['3x1x4']).toBe(1);
+  });
+
+  it('tracks total rotations', () => {
+    const inc = freshInc();
+    aggregateBinRotation(baseEvent, inc);
+    expect(inc['ml:rotations']?.['total']).toBe(1);
+  });
+
+  it('tracks rotated_sizes by old_size', () => {
+    const inc = freshInc();
+    aggregateBinRotation(baseEvent, inc);
+    expect(inc['ml:rotated_sizes']?.['1x3x4']).toBe(1);
+  });
+
+  it('is additive', () => {
+    const inc = freshInc();
+    aggregateBinRotation(baseEvent, inc);
+    aggregateBinRotation(baseEvent, inc);
+    expect(inc['ml:rotations']?.['total']).toBe(2);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregatePlacementRejection
+// ─────────────────────────────────────────────
+describe('aggregatePlacementRejection', () => {
+  const baseEvent: PlacementRejectedEvent = {
+    type: 'placement_rejected',
+    rejection_reason: 'cancelled',
+    intended_size: null,
+    intended_position: null,
+    layer_index: 0,
+    drawer_size: '6x8x6',
+    fill_pct: 50,
+    mode: 'draw',
+  };
+
+  it('tracks rejection reason in ml:rejections', () => {
+    const inc = freshInc();
+    aggregatePlacementRejection(baseEvent, inc);
+    expect(inc['ml:rejections']?.['cancelled']).toBe(1);
+  });
+
+  it('increments ml:rejections total on every call', () => {
+    const inc = freshInc();
+    aggregatePlacementRejection(baseEvent, inc);
+    expect(inc['ml:rejections']?.['total']).toBe(1);
+  });
+
+  it('tracks reject mode', () => {
+    const inc = freshInc();
+    aggregatePlacementRejection(baseEvent, inc);
+    expect(inc['ml:reject_modes']?.['draw']).toBe(1);
+  });
+
+  it('skips reject_sizes when intended_size is null', () => {
+    const inc = freshInc();
+    aggregatePlacementRejection(baseEvent, inc);
+    expect(inc['ml:reject_sizes']).toBeUndefined();
+  });
+
+  it('tracks reject_sizes and neg:reject_by_drawer when intended_size is set', () => {
+    const inc = freshInc();
+    aggregatePlacementRejection({ ...baseEvent, intended_size: '2x3' }, inc);
+    expect(inc['ml:reject_sizes']?.['2x3']).toBe(1);
+    expect(inc['ml:neg:reject_by_drawer:6x8x6']?.['2x3']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateUndo
+// ─────────────────────────────────────────────
+describe('aggregateUndo', () => {
+  const baseEvent: UndoEvent = {
+    type: 'undo',
+    action_undone: 'placement',
+    bins_affected: 1,
+    time_since_action_ms: 500,
+    drawer_size: '6x8x6',
+  };
+
+  it('tracks the undone action', () => {
+    const inc = freshInc();
+    aggregateUndo(baseEvent, inc);
+    expect(inc['ml:neg:undos']?.['placement']).toBe(1);
+  });
+
+  it('tracks total undos', () => {
+    const inc = freshInc();
+    aggregateUndo(baseEvent, inc);
+    expect(inc['ml:neg:undos']?.['total']).toBe(1);
+  });
+
+  it('classifies time < 2000ms as immediate', () => {
+    const inc = freshInc();
+    aggregateUndo({ ...baseEvent, time_since_action_ms: 1500 }, inc);
+    expect(inc['ml:neg:undo_timing']?.['immediate']).toBe(1);
+    expect(inc['ml:neg:undo_action_timing']?.['placement_immediate']).toBe(1);
+  });
+
+  it('classifies time between 2000ms and 9999ms as quick', () => {
+    const inc = freshInc();
+    aggregateUndo({ ...baseEvent, time_since_action_ms: 5000 }, inc);
+    expect(inc['ml:neg:undo_timing']?.['quick']).toBe(1);
+  });
+
+  it('classifies time >= 10000ms as delayed', () => {
+    const inc = freshInc();
+    aggregateUndo({ ...baseEvent, time_since_action_ms: 15000 }, inc);
+    expect(inc['ml:neg:undo_timing']?.['delayed']).toBe(1);
+  });
+
+  it('classifies bins_affected=1 as single', () => {
+    const inc = freshInc();
+    aggregateUndo({ ...baseEvent, bins_affected: 1 }, inc);
+    expect(inc['ml:neg:undo_scale']?.['single']).toBe(1);
+  });
+
+  it('classifies bins_affected=5 as few', () => {
+    const inc = freshInc();
+    aggregateUndo({ ...baseEvent, bins_affected: 5 }, inc);
+    expect(inc['ml:neg:undo_scale']?.['few']).toBe(1);
+  });
+
+  it('classifies bins_affected=21 as bulk', () => {
+    const inc = freshInc();
+    aggregateUndo({ ...baseEvent, bins_affected: 21 }, inc);
+    expect(inc['ml:neg:undo_scale']?.['bulk']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateQuickCorrection
+// ─────────────────────────────────────────────
+describe('aggregateQuickCorrection', () => {
+  const baseEvent: QuickCorrectionEvent = {
+    type: 'quick_correction',
+    correction_type: 'delete',
+    original_size: '2x2x3',
+    new_size: null,
+    placement_method: 'draw',
+    time_to_correction_ms: 2000,
+    layer_index: 0,
+  };
+
+  it('tracks correction type', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection(baseEvent, inc);
+    expect(inc['ml:neg:quick_corrections']?.['delete']).toBe(1);
+  });
+
+  it('tracks corrected size as negative signal', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection(baseEvent, inc);
+    expect(inc['ml:neg:corrected_sizes']?.['2x2x3']).toBe(1);
+  });
+
+  it('tracks correct_by_method', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection(baseEvent, inc);
+    expect(inc['ml:neg:correct_by_method:draw']?.['delete']).toBe(1);
+  });
+
+  it('classifies time < 5000ms as very_quick', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection({ ...baseEvent, time_to_correction_ms: 2000 }, inc);
+    expect(inc['ml:neg:correction_timing']?.['very_quick']).toBe(1);
+  });
+
+  it('classifies time between 5000ms and 14999ms as quick', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection({ ...baseEvent, time_to_correction_ms: 10000 }, inc);
+    expect(inc['ml:neg:correction_timing']?.['quick']).toBe(1);
+  });
+
+  it('classifies time >= 15000ms as considered', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection({ ...baseEvent, time_to_correction_ms: 20000 }, inc);
+    expect(inc['ml:neg:correction_timing']?.['considered']).toBe(1);
+  });
+
+  it('tracks resize_correct transition when correction_type=resize and new_size set', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection({ ...baseEvent, correction_type: 'resize', new_size: '3x3x3' }, inc);
+    expect(inc['ml:neg:resize_correct:2x2x3']?.['3x3x3']).toBe(1);
+  });
+
+  it('does not track resize_correct for delete correction', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection(baseEvent, inc);
+    expect(inc['ml:neg:resize_correct:2x2x3']).toBeUndefined();
+  });
+
+  it('tracks total quick corrections', () => {
+    const inc = freshInc();
+    aggregateQuickCorrection(baseEvent, inc);
+    expect(inc['ml:neg:quick_corrections']?.['total']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateBinAbandonment
+// ─────────────────────────────────────────────
+describe('aggregateBinAbandonment', () => {
+  const baseEvent: AbandonedBinEvent = {
+    type: 'bin_abandoned',
+    bin_size: '1x1x3',
+    position: '3,4',
+    layer_index: 0,
+    lifetime_ms: 30000,
+    creation_method: 'draw',
+    fill_pct: 20,
+    drawer_size: '6x8x6',
+  };
+
+  it('tracks abandoned size as negative signal', () => {
+    const inc = freshInc();
+    aggregateBinAbandonment(baseEvent, inc);
+    expect(inc['ml:neg:abandoned_sizes']?.['1x1x3']).toBe(1);
+  });
+
+  it('tracks abandoned_by_method', () => {
+    const inc = freshInc();
+    aggregateBinAbandonment(baseEvent, inc);
+    expect(inc['ml:neg:abandoned_by_method:draw']?.['1x1x3']).toBe(1);
+  });
+
+  it('classifies lifetime < 60000ms as <1min', () => {
+    const inc = freshInc();
+    aggregateBinAbandonment({ ...baseEvent, lifetime_ms: 30000 }, inc);
+    expect(inc['ml:neg:abandon_lifetime']?.['<1min']).toBe(1);
+  });
+
+  it('classifies lifetime between 60000ms and 299999ms as 1-5min', () => {
+    const inc = freshInc();
+    aggregateBinAbandonment({ ...baseEvent, lifetime_ms: 120000 }, inc);
+    expect(inc['ml:neg:abandon_lifetime']?.['1-5min']).toBe(1);
+  });
+
+  it('classifies lifetime between 300000ms and 1799999ms as 5-30min', () => {
+    const inc = freshInc();
+    aggregateBinAbandonment({ ...baseEvent, lifetime_ms: 600000 }, inc);
+    expect(inc['ml:neg:abandon_lifetime']?.['5-30min']).toBe(1);
+  });
+
+  it('classifies lifetime >= 1800000ms as >30min', () => {
+    const inc = freshInc();
+    aggregateBinAbandonment({ ...baseEvent, lifetime_ms: 1800000 }, inc);
+    expect(inc['ml:neg:abandon_lifetime']?.['>30min']).toBe(1);
+  });
+
+  it('tracks abandoned_by_drawer', () => {
+    const inc = freshInc();
+    aggregateBinAbandonment(baseEvent, inc);
+    expect(inc['ml:neg:abandoned_by_drawer:6x8x6']?.['1x1x3']).toBe(1);
+  });
+
+  it('tracks abandonment_total', () => {
+    const inc = freshInc();
+    aggregateBinAbandonment(baseEvent, inc);
+    expect(inc['ml:neg:abandonment_total']?.['total']).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateCrossLayoutPattern
+// ─────────────────────────────────────────────
+describe('aggregateCrossLayoutPattern', () => {
+  const baseEvent: CrossLayoutPatternEvent = {
+    type: 'cross_layout_pattern',
+    user_hash: 'anonymous',
+    label_size_consistency: [],
+    inferred_purpose: null,
+    inferred_purpose_confidence: 0.5,
+    drawer_size: '6x8x6',
+  };
+
+  it('does not add inferred_purpose key when inferred_purpose is null', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern(baseEvent, inc);
+    expect(inc['ml:inferred_purpose:6x8x6']).toBeUndefined();
+  });
+
+  it('tracks inferred_purpose by drawer_size when set', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern({ ...baseEvent, inferred_purpose: 'workshop' }, inc);
+    expect(inc['ml:inferred_purpose:6x8x6']?.['workshop']).toBe(1);
+  });
+
+  it('classifies confidence < 0.4 as low', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern({ ...baseEvent, inferred_purpose_confidence: 0.3 }, inc);
+    expect(inc['ml:purpose_confidence']?.['low']).toBe(1);
+  });
+
+  it('classifies confidence 0.5 as medium', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern(baseEvent, inc);
+    expect(inc['ml:purpose_confidence']?.['medium']).toBe(1);
+  });
+
+  it('classifies confidence >= 0.7 as high', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern({ ...baseEvent, inferred_purpose_confidence: 0.9 }, inc);
+    expect(inc['ml:purpose_confidence']?.['high']).toBe(1);
+  });
+
+  it('counts consistent and inconsistent labels', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern(
+      {
+        ...baseEvent,
+        label_size_consistency: [
+          { label_hash: 'aaaa1111', sizes_used: ['1x1x3'], is_consistent: true },
+          { label_hash: 'bbbb2222', sizes_used: ['2x2x3', '1x1x3'], is_consistent: false },
+        ],
+      },
+      inc
+    );
+    expect(inc['ml:label_consistency']?.['consistent']).toBe(1);
+    expect(inc['ml:label_consistency']?.['inconsistent']).toBe(1);
+  });
+
+  it('tracks sizes_used for inconsistent labels', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern(
+      {
+        ...baseEvent,
+        label_size_consistency: [
+          { label_hash: 'bbbb2222', sizes_used: ['2x2x3', '1x1x3'], is_consistent: false },
+        ],
+      },
+      inc
+    );
+    expect(inc['ml:inconsistent_sizes']?.['2x2x3']).toBe(1);
+    expect(inc['ml:inconsistent_sizes']?.['1x1x3']).toBe(1);
+  });
+
+  it('does not track inconsistent_sizes for consistent labels', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern(
+      {
+        ...baseEvent,
+        label_size_consistency: [
+          { label_hash: 'aaaa1111', sizes_used: ['1x1x3'], is_consistent: true },
+        ],
+      },
+      inc
+    );
+    expect(inc['ml:inconsistent_sizes']).toBeUndefined();
+  });
+
+  it('increments cross_layout_total', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern(baseEvent, inc);
+    expect(inc['ml:cross_layout_total']?.['total']).toBe(1);
+  });
+
+  it('is additive for cross_layout_total', () => {
+    const inc = freshInc();
+    aggregateCrossLayoutPattern(baseEvent, inc);
+    aggregateCrossLayoutPattern(baseEvent, inc);
+    expect(inc['ml:cross_layout_total']?.['total']).toBe(2);
+  });
+});
+
+// ─────────────────────────────────────────────
+// aggregateSessionSummary
+// ─────────────────────────────────────────────
+describe('aggregateSessionSummary', () => {
+  const baseEvent: SessionSummaryEvent = {
+    type: 'session_summary',
+    bins_placed: 5,
+    bins_deleted: 1,
+    edits_total: 8,
+    time_to_first_bin_ms: 5000,
+    session_duration_ms: 180000,
+    size_sequence: ['1x1x3', '2x2x3', '1x1x3'],
+    edit_to_done_ratio: 0.4,
+    undo_count: 1,
+    confidence_score: 0.7,
+    drawer_size: '6x8x6',
+    final_fill_pct: 60,
+  };
+
+  it('tracks bins_placed in correct bucket', () => {
+    const inc = freshInc();
+    aggregateSessionSummary(baseEvent, inc);
+    expect(inc['ml:session:bins_placed']?.['1-5']).toBe(1);
+  });
+
+  it('bins_placed=0 goes in "0" bucket', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, bins_placed: 0 }, inc);
+    expect(inc['ml:session:bins_placed']?.['0']).toBe(1);
+  });
+
+  it('bins_placed=51 goes in "51+" bucket', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, bins_placed: 51 }, inc);
+    expect(inc['ml:session:bins_placed']?.['51+']).toBe(1);
+  });
+
+  it('tracks edit_to_done_ratio=0 in "zero" bucket', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, edit_to_done_ratio: 0 }, inc);
+    expect(inc['ml:session:edit_ratio']?.['zero']).toBe(1);
+  });
+
+  it('tracks edit_to_done_ratio=0.4 in "medium" bucket', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, edit_to_done_ratio: 0.4 }, inc);
+    expect(inc['ml:session:edit_ratio']?.['medium']).toBe(1);
+  });
+
+  it('tracks edit_to_done_ratio=0.7 in "high" bucket', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, edit_to_done_ratio: 0.7 }, inc);
+    expect(inc['ml:session:edit_ratio']?.['high']).toBe(1);
+  });
+
+  it('classifies time_to_first_bin_ms=5000 as quick', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, time_to_first_bin_ms: 5000 }, inc);
+    expect(inc['ml:session:time_to_first']?.['quick']).toBe(1);
+  });
+
+  it('classifies time_to_first_bin_ms=60000 as slow', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, time_to_first_bin_ms: 60000 }, inc);
+    expect(inc['ml:session:time_to_first']?.['slow']).toBe(1);
+  });
+
+  it('skips time_to_first tracking when time_to_first_bin_ms is null', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, time_to_first_bin_ms: null }, inc);
+    expect(inc['ml:session:time_to_first']).toBeUndefined();
+  });
+
+  it('classifies confidence_score=0.7 as high', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, confidence_score: 0.7 }, inc);
+    expect(inc['ml:session:confidence']?.['high']).toBe(1);
+  });
+
+  it('classifies confidence_score=0.1 as very_low', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, confidence_score: 0.1 }, inc);
+    expect(inc['ml:session:confidence']?.['very_low']).toBe(1);
+  });
+
+  it('classifies confidence_score=0.9 as very_high', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, confidence_score: 0.9 }, inc);
+    expect(inc['ml:session:confidence']?.['very_high']).toBe(1);
+  });
+
+  it('classifies session_duration_ms < 60s as <1min', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, session_duration_ms: 30000 }, inc);
+    expect(inc['ml:session:duration']?.['<1min']).toBe(1);
+  });
+
+  it('classifies session_duration_ms >= 1800s as 30min+', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, session_duration_ms: 1_800_000 }, inc);
+    expect(inc['ml:session:duration']?.['30min+']).toBe(1);
+  });
+
+  it('tracks size sequence when >= 2 sizes', () => {
+    const inc = freshInc();
+    aggregateSessionSummary(baseEvent, inc);
+    expect(inc['ml:size_seq:6x8x6']?.['1x1x3>2x2x3>1x1x3']).toBe(1);
+  });
+
+  it('skips size sequence when < 2 sizes', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, size_sequence: ['1x1x3'] }, inc);
+    expect(inc['ml:size_seq:6x8x6']).toBeUndefined();
+  });
+
+  it('limits sequence to first 5 sizes', () => {
+    const inc = freshInc();
+    aggregateSessionSummary(
+      {
+        ...baseEvent,
+        size_sequence: ['1x1x3', '2x2x3', '3x3x3', '4x4x3', '5x5x3', '6x6x3'],
+      },
+      inc
+    );
+    // Only first 5 are used
+    expect(inc['ml:size_seq:6x8x6']?.['1x1x3>2x2x3>3x3x3>4x4x3>5x5x3']).toBe(1);
+  });
+
+  it('classifies undo_count=0 in "0" bucket', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, undo_count: 0 }, inc);
+    expect(inc['ml:session:undo_count']?.['0']).toBe(1);
+  });
+
+  it('classifies undo_count=6 in "6+" bucket', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, undo_count: 6 }, inc);
+    expect(inc['ml:session:undo_count']?.['6+']).toBe(1);
+  });
+
+  it('tracks confidence by drawer', () => {
+    const inc = freshInc();
+    aggregateSessionSummary({ ...baseEvent, confidence_score: 0.7 }, inc);
+    expect(inc['ml:session:conf_by_drawer:6x8x6']?.['high']).toBe(1);
+  });
+
+  it('tracks total sessions', () => {
+    const inc = freshInc();
+    aggregateSessionSummary(baseEvent, inc);
+    expect(inc['ml:session:totals']?.['total']).toBe(1);
+  });
+
+  it('is additive for total sessions', () => {
+    const inc = freshInc();
+    aggregateSessionSummary(baseEvent, inc);
+    aggregateSessionSummary(baseEvent, inc);
+    expect(inc['ml:session:totals']?.['total']).toBe(2);
+  });
+});

--- a/api/lib/mlTelemetry/validators.test.ts
+++ b/api/lib/mlTelemetry/validators.test.ts
@@ -175,9 +175,12 @@ describe('validateEvent — bin_placed', () => {
 // are left unchecked. These tests document the CURRENT leniency so that any
 // future tightening is a conscious, explicitly-reviewed change.
 //
-// Each per-field test starts from `completeValid` — a complete bin_placed
-// object including all five unvalidated fields — and omits ONLY the field
-// under test, so the test genuinely isolates that specific field.
+// Absence tests: each starts from `completeValid` and omits ONLY the field
+// under test — genuinely isolating that specific field's absence.
+//
+// Content tests: each starts from `completeValid` and sets the field to a
+// bogus value of the wrong type — documenting that the validator ignores
+// the field's content entirely, not just its presence.
 // ─────────────────────────────────────────────
 describe('validateEvent — bin_placed (documented validator leniency)', () => {
   // All checked fields present, PLUS all five currently-unvalidated fields.
@@ -245,6 +248,26 @@ describe('validateEvent — bin_placed (documented validator leniency)', () => {
   it('passes when only vocab_version is absent (field not validated)', () => {
     const { vocab_version: _vv, ...rest } = completeValid;
     expect(validateEvent(rest)).toBe(true);
+  });
+
+  it('ignores a bogus position value (field content not validated)', () => {
+    expect(validateEvent({ ...completeValid, position: 'not-a-position' })).toBe(true);
+  });
+
+  it('ignores a bogus layer_index value (field content not validated)', () => {
+    expect(validateEvent({ ...completeValid, layer_index: 'x' })).toBe(true);
+  });
+
+  it('ignores a bogus largest_gap value (field content not validated)', () => {
+    expect(validateEvent({ ...completeValid, largest_gap: {} })).toBe(true);
+  });
+
+  it('ignores a bogus fill_pct value (field content not validated)', () => {
+    expect(validateEvent({ ...completeValid, fill_pct: 'high' })).toBe(true);
+  });
+
+  it('ignores a bogus vocab_version value (field content not validated)', () => {
+    expect(validateEvent({ ...completeValid, vocab_version: [] })).toBe(true);
   });
 });
 

--- a/api/lib/mlTelemetry/validators.test.ts
+++ b/api/lib/mlTelemetry/validators.test.ts
@@ -167,6 +167,80 @@ describe('validateEvent — bin_placed', () => {
 });
 
 // ─────────────────────────────────────────────
+// bin_placed — documented validator leniency
+//
+// validateEvent() deliberately skips several BinPlacementEvent fields.
+// The validator focuses on fields used as Redis keys (injection-sensitive)
+// and routing fields. Numeric/positional fields that don't reach Redis keys
+// are left unchecked. These tests document the CURRENT leniency so that any
+// future tightening is a conscious, explicitly-reviewed change.
+// ─────────────────────────────────────────────
+describe('validateEvent — bin_placed (documented validator leniency)', () => {
+  // Minimal object that satisfies all CHECKED fields; unchecked fields are omitted.
+  const minimalValid = {
+    type: 'bin_placed',
+    bin_size: BIN_SIZE,
+    prev_bin_size: null,
+    drawer_size: DRAWER_SIZE,
+    gap_fit: 'exact',
+    method: 'draw',
+    session_index: 0,
+    label_hash: null,
+    label_normalized: null,
+    label_domain: null,
+    label_embedding_bucket: null,
+    category_id: CATEGORY_ID,
+    adjacent_label_hashes: [],
+    adjacent_sizes: [],
+    adjacent_count: 0,
+    recent_sizes: [],
+    time_since_last_ms: null,
+    is_first_of_label: false,
+  };
+
+  it('passes when position is absent (field not validated)', () => {
+    // position is used by the aggregator but not checked by the validator
+    expect(validateEvent(minimalValid)).toBe(true);
+  });
+
+  it('passes when position has an arbitrary value (field not validated)', () => {
+    expect(validateEvent({ ...minimalValid, position: 'not-a-position' })).toBe(true);
+  });
+
+  it('passes when layer_index is absent (field not validated)', () => {
+    expect(validateEvent(minimalValid)).toBe(true);
+  });
+
+  it('passes when layer_index is out of range (field not validated)', () => {
+    expect(validateEvent({ ...minimalValid, layer_index: 9999 })).toBe(true);
+  });
+
+  it('passes when largest_gap is absent (field not validated)', () => {
+    expect(validateEvent(minimalValid)).toBe(true);
+  });
+
+  it('passes when largest_gap has an arbitrary value (field not validated)', () => {
+    expect(validateEvent({ ...minimalValid, largest_gap: 'anything' })).toBe(true);
+  });
+
+  it('passes when fill_pct is absent (field not validated)', () => {
+    expect(validateEvent(minimalValid)).toBe(true);
+  });
+
+  it('passes when fill_pct is out of range (field not validated)', () => {
+    expect(validateEvent({ ...minimalValid, fill_pct: 9999 })).toBe(true);
+  });
+
+  it('passes when vocab_version is absent (field not validated)', () => {
+    expect(validateEvent(minimalValid)).toBe(true);
+  });
+
+  it('passes when vocab_version has an arbitrary value (field not validated)', () => {
+    expect(validateEvent({ ...minimalValid, vocab_version: 12345 })).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────
 // label_updated
 // ─────────────────────────────────────────────
 describe('validateEvent — label_updated', () => {

--- a/api/lib/mlTelemetry/validators.test.ts
+++ b/api/lib/mlTelemetry/validators.test.ts
@@ -174,10 +174,14 @@ describe('validateEvent — bin_placed', () => {
 // and routing fields. Numeric/positional fields that don't reach Redis keys
 // are left unchecked. These tests document the CURRENT leniency so that any
 // future tightening is a conscious, explicitly-reviewed change.
+//
+// Each per-field test starts from `completeValid` — a complete bin_placed
+// object including all five unvalidated fields — and omits ONLY the field
+// under test, so the test genuinely isolates that specific field.
 // ─────────────────────────────────────────────
 describe('validateEvent — bin_placed (documented validator leniency)', () => {
-  // Minimal object that satisfies all CHECKED fields; unchecked fields are omitted.
-  const minimalValid = {
+  // All checked fields present, PLUS all five currently-unvalidated fields.
+  const completeValid = {
     type: 'bin_placed',
     bin_size: BIN_SIZE,
     prev_bin_size: null,
@@ -196,47 +200,51 @@ describe('validateEvent — bin_placed (documented validator leniency)', () => {
     recent_sizes: [],
     time_since_last_ms: null,
     is_first_of_label: false,
+    // The five currently-unvalidated fields:
+    position: POSITION,
+    layer_index: 0,
+    largest_gap: FILL_SIZE,
+    fill_pct: 50,
+    vocab_version: 'v1',
   };
 
-  it('passes when position is absent (field not validated)', () => {
-    // position is used by the aggregator but not checked by the validator
-    expect(validateEvent(minimalValid)).toBe(true);
+  it('passes when all five unvalidated fields are absent at once', () => {
+    // Baseline: confirm that leaving out ALL five still satisfies the validator.
+    const {
+      position: _pos,
+      layer_index: _li,
+      largest_gap: _lg,
+      fill_pct: _fp,
+      vocab_version: _vv,
+      ...withoutAll
+    } = completeValid;
+    expect(validateEvent(withoutAll)).toBe(true);
   });
 
-  it('passes when position has an arbitrary value (field not validated)', () => {
-    expect(validateEvent({ ...minimalValid, position: 'not-a-position' })).toBe(true);
+  it('passes when only position is absent (field not validated)', () => {
+    // position is stored on the event but never interpolated into a Redis key.
+    const { position: _pos, ...rest } = completeValid;
+    expect(validateEvent(rest)).toBe(true);
   });
 
-  it('passes when layer_index is absent (field not validated)', () => {
-    expect(validateEvent(minimalValid)).toBe(true);
+  it('passes when only layer_index is absent (field not validated)', () => {
+    const { layer_index: _li, ...rest } = completeValid;
+    expect(validateEvent(rest)).toBe(true);
   });
 
-  it('passes when layer_index is out of range (field not validated)', () => {
-    expect(validateEvent({ ...minimalValid, layer_index: 9999 })).toBe(true);
+  it('passes when only largest_gap is absent (field not validated)', () => {
+    const { largest_gap: _lg, ...rest } = completeValid;
+    expect(validateEvent(rest)).toBe(true);
   });
 
-  it('passes when largest_gap is absent (field not validated)', () => {
-    expect(validateEvent(minimalValid)).toBe(true);
+  it('passes when only fill_pct is absent (field not validated)', () => {
+    const { fill_pct: _fp, ...rest } = completeValid;
+    expect(validateEvent(rest)).toBe(true);
   });
 
-  it('passes when largest_gap has an arbitrary value (field not validated)', () => {
-    expect(validateEvent({ ...minimalValid, largest_gap: 'anything' })).toBe(true);
-  });
-
-  it('passes when fill_pct is absent (field not validated)', () => {
-    expect(validateEvent(minimalValid)).toBe(true);
-  });
-
-  it('passes when fill_pct is out of range (field not validated)', () => {
-    expect(validateEvent({ ...minimalValid, fill_pct: 9999 })).toBe(true);
-  });
-
-  it('passes when vocab_version is absent (field not validated)', () => {
-    expect(validateEvent(minimalValid)).toBe(true);
-  });
-
-  it('passes when vocab_version has an arbitrary value (field not validated)', () => {
-    expect(validateEvent({ ...minimalValid, vocab_version: 12345 })).toBe(true);
+  it('passes when only vocab_version is absent (field not validated)', () => {
+    const { vocab_version: _vv, ...rest } = completeValid;
+    expect(validateEvent(rest)).toBe(true);
   });
 });
 

--- a/api/lib/mlTelemetry/validators.test.ts
+++ b/api/lib/mlTelemetry/validators.test.ts
@@ -1,0 +1,1070 @@
+import { describe, it, expect } from 'vitest';
+import { validateEvent } from './validators.js';
+import type { MLTelemetryEvent } from './types.js';
+
+// ─────────────────────────────────────────────
+// Shared valid field values
+// ─────────────────────────────────────────────
+const BIN_SIZE = '2x3x4'; // matches VALID_BIN_SIZE_REGEX
+const DRAWER_SIZE = '6x8x6'; // matches VALID_DRAWER_SIZE_REGEX
+const FILL_SIZE = '2x3'; // matches VALID_FILL_SIZE_REGEX (WxD, no height)
+const LABEL_HASH = 'abcd1234'; // 8-char hex
+const LAYOUT_HASH = '12345678'; // 8-char hex
+const STRUCTURE_HASH = 'aabbccdd'; // 8-char hex
+const POSITION = '3,5'; // matches VALID_POSITION_REGEX
+const CATEGORY_ID = 'cat-01'; // matches VALID_CATEGORY_ID_REGEX
+const NORMALIZED_LABEL = 'screws'; // matches VALID_NORMALIZED_LABEL_REGEX
+const EMBEDDING_BUCKET = 'a1b2'; // 4-char hex
+
+// ─────────────────────────────────────────────
+// Structural guard
+// ─────────────────────────────────────────────
+describe('validateEvent — structural guard', () => {
+  it('rejects null', () => {
+    expect(validateEvent(null)).toBe(false);
+  });
+
+  it('rejects undefined', () => {
+    expect(validateEvent(undefined)).toBe(false);
+  });
+
+  it('rejects a string', () => {
+    expect(validateEvent('bin_placed')).toBe(false);
+  });
+
+  it('rejects a number', () => {
+    expect(validateEvent(42)).toBe(false);
+  });
+
+  it('rejects an empty object (no type)', () => {
+    expect(validateEvent({})).toBe(false);
+  });
+
+  it('rejects an object with an unknown type', () => {
+    expect(validateEvent({ type: 'unknown_event' })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// TypeScript narrowing
+// ─────────────────────────────────────────────
+describe('validateEvent — TypeScript narrowing', () => {
+  it('narrows unknown to MLTelemetryEvent inside the guard', () => {
+    const raw: unknown = {
+      type: 'bin_rotated',
+      old_size: BIN_SIZE,
+      new_size: '3x2x4',
+      batch_size: 1,
+    };
+    if (validateEvent(raw)) {
+      // TypeScript accepts this assignment — the guard narrowed the type
+      const typed: MLTelemetryEvent = raw;
+      expect(typed.type).toBe('bin_rotated');
+    } else {
+      expect.fail('Expected validateEvent to return true');
+    }
+  });
+});
+
+// ─────────────────────────────────────────────
+// bin_placed
+// ─────────────────────────────────────────────
+describe('validateEvent — bin_placed', () => {
+  const valid = {
+    type: 'bin_placed',
+    bin_size: BIN_SIZE,
+    prev_bin_size: null,
+    drawer_size: DRAWER_SIZE,
+    position: POSITION,
+    layer_index: 0,
+    largest_gap: FILL_SIZE,
+    fill_pct: 50,
+    gap_fit: 'exact',
+    label_hash: null,
+    label_normalized: null,
+    label_domain: null,
+    label_embedding_bucket: null,
+    category_id: CATEGORY_ID,
+    adjacent_label_hashes: [],
+    adjacent_sizes: [],
+    adjacent_count: 0,
+    recent_sizes: [],
+    time_since_last_ms: null,
+    is_first_of_label: false,
+    method: 'draw',
+    session_index: 0,
+    vocab_version: 'v1',
+  };
+
+  it('accepts a fully valid bin_placed event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with prev_bin_size set', () => {
+    expect(validateEvent({ ...valid, prev_bin_size: BIN_SIZE })).toBe(true);
+  });
+
+  it('accepts with optional label fields set', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        label_hash: LABEL_HASH,
+        label_normalized: NORMALIZED_LABEL,
+        label_domain: 'tools',
+        label_embedding_bucket: EMBEDDING_BUCKET,
+      })
+    ).toBe(true);
+  });
+
+  it('accepts time_since_last_ms as a valid number', () => {
+    expect(validateEvent({ ...valid, time_since_last_ms: 5000 })).toBe(true);
+  });
+
+  it('rejects invalid bin_size format', () => {
+    expect(validateEvent({ ...valid, bin_size: 'bad_size' })).toBe(false);
+  });
+
+  it('rejects invalid gap_fit value', () => {
+    expect(validateEvent({ ...valid, gap_fit: 'perfect' })).toBe(false);
+  });
+
+  it('rejects invalid method value', () => {
+    expect(validateEvent({ ...valid, method: 'teleport' })).toBe(false);
+  });
+
+  it('rejects invalid category_id with special chars', () => {
+    expect(validateEvent({ ...valid, category_id: '../../etc' })).toBe(false);
+  });
+
+  it('rejects label_hash that is not 8-char hex', () => {
+    expect(validateEvent({ ...valid, label_hash: 'tooshort' })).toBe(false);
+  });
+
+  it('rejects label_domain that is not in the allowed set', () => {
+    expect(validateEvent({ ...valid, label_domain: 'malicious_domain' })).toBe(false);
+  });
+
+  it('rejects adjacent_label_hashes with more than 8 entries', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        adjacent_label_hashes: Array.from({ length: 9 }, () => LABEL_HASH),
+      })
+    ).toBe(false);
+  });
+
+  it('rejects is_first_of_label that is not a boolean', () => {
+    expect(validateEvent({ ...valid, is_first_of_label: 1 })).toBe(false);
+  });
+
+  it('rejects time_since_last_ms >= 86400000', () => {
+    expect(validateEvent({ ...valid, time_since_last_ms: 86400000 })).toBe(false);
+  });
+
+  it('rejects negative session_index', () => {
+    expect(validateEvent({ ...valid, session_index: -1 })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// label_updated
+// ─────────────────────────────────────────────
+describe('validateEvent — label_updated', () => {
+  const valid = {
+    type: 'label_updated',
+    bin_size: BIN_SIZE,
+    old_label_hash: null,
+    old_label_normalized: null,
+    new_label_hash: null,
+    new_label_normalized: null,
+    new_label_domain: null,
+    new_label_embedding_bucket: null,
+    vocab_version: 'v1',
+  };
+
+  it('accepts a valid label_updated event with all nulls', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with label fields set', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        new_label_hash: LABEL_HASH,
+        new_label_normalized: NORMALIZED_LABEL,
+        new_label_domain: 'tools',
+        new_label_embedding_bucket: EMBEDDING_BUCKET,
+      })
+    ).toBe(true);
+  });
+
+  it('rejects invalid bin_size', () => {
+    expect(validateEvent({ ...valid, bin_size: '2x3' })).toBe(false);
+  });
+
+  it('rejects new_label_hash not matching hex pattern', () => {
+    expect(validateEvent({ ...valid, new_label_hash: 'ABCDEFGH' })).toBe(false);
+  });
+
+  it('rejects new_label_domain not in allowed set', () => {
+    expect(validateEvent({ ...valid, new_label_domain: 'weapons' })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// layout_snapshot
+// ─────────────────────────────────────────────
+describe('validateEvent — layout_snapshot', () => {
+  const valid = {
+    type: 'layout_snapshot',
+    trigger: 'save',
+    layout_hash: LAYOUT_HASH,
+    snapshot_index: 0,
+    drawer_size: DRAWER_SIZE,
+    layer_count: 1,
+    purpose: null,
+    bin_count: 5,
+    size_distribution: { [BIN_SIZE]: 3 },
+    category_distribution: { [CATEGORY_ID]: 5 },
+    domain_distribution: { tools: 3 },
+    top_label_hashes: [],
+    fill_percentage: 50,
+    labeled_percentage: 60,
+    session_duration_ms: 120000,
+    edit_count: 10,
+    quality_tier: 'medium',
+    archetype: 'mixed',
+    spatial_patterns: ['corner_start'],
+    uniformity_score: 0.5,
+    edge_usage: { left: true, right: false, top: true, bottom: false },
+    hour_of_day: 14,
+    day_of_week: 3,
+    is_weekend: false,
+    structure_hash: STRUCTURE_HASH,
+    vocab_version: 'v1',
+  };
+
+  it('accepts a valid layout_snapshot event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with optional label_size_pairs', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        label_size_pairs: [{ hash: LABEL_HASH, size: BIN_SIZE }],
+      })
+    ).toBe(true);
+  });
+
+  it('accepts with purpose set to a known value', () => {
+    expect(validateEvent({ ...valid, purpose: 'workshop' })).toBe(true);
+  });
+
+  it('accepts with a custom purpose matching the regex', () => {
+    expect(validateEvent({ ...valid, purpose: 'my_custom_purpose' })).toBe(true);
+  });
+
+  it('rejects invalid trigger', () => {
+    expect(validateEvent({ ...valid, trigger: 'random' })).toBe(false);
+  });
+
+  it('rejects invalid layout_hash format', () => {
+    expect(validateEvent({ ...valid, layout_hash: 'not-a-hash' })).toBe(false);
+  });
+
+  it('rejects invalid archetype', () => {
+    expect(validateEvent({ ...valid, archetype: 'chaotic' })).toBe(false);
+  });
+
+  it('rejects spatial_patterns with more than 10 entries', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        spatial_patterns: Array.from({ length: 11 }, () => 'corner_start'),
+      })
+    ).toBe(false);
+  });
+
+  it('rejects invalid spatial_pattern value', () => {
+    expect(validateEvent({ ...valid, spatial_patterns: ['diagonal_fill'] })).toBe(false);
+  });
+
+  it('rejects uniformity_score > 1', () => {
+    expect(validateEvent({ ...valid, uniformity_score: 1.1 })).toBe(false);
+  });
+
+  it('rejects edge_usage with missing field', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        edge_usage: { left: true, right: false, top: true },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects hour_of_day > 23', () => {
+    expect(validateEvent({ ...valid, hour_of_day: 24 })).toBe(false);
+  });
+
+  it('rejects day_of_week > 6', () => {
+    expect(validateEvent({ ...valid, day_of_week: 7 })).toBe(false);
+  });
+
+  it('rejects structure_hash not matching 8-char hex', () => {
+    expect(validateEvent({ ...valid, structure_hash: 'gggggggg' })).toBe(false);
+  });
+
+  it('rejects size_distribution with a negative value', () => {
+    expect(validateEvent({ ...valid, size_distribution: { [BIN_SIZE]: -1 } })).toBe(false);
+  });
+
+  it('rejects label_size_pairs with more than 500 entries', () => {
+    const pairs = Array.from({ length: 501 }, () => ({ hash: LABEL_HASH, size: BIN_SIZE }));
+    expect(validateEvent({ ...valid, label_size_pairs: pairs })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// layout_quality
+// ─────────────────────────────────────────────
+describe('validateEvent — layout_quality', () => {
+  const valid = {
+    type: 'layout_quality',
+    layout_hash: LAYOUT_HASH,
+    signal: 'shared',
+    days_since_creation: 3,
+    abandonment_type: null,
+    time_since_last_edit_ms: 5000,
+  };
+
+  it('accepts a valid layout_quality event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with optional confidence_breakdown', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        confidence_breakdown: {
+          undo_score: 0.8,
+          completion_score: 0.9,
+          session_score: 0.7,
+          correction_score: 1.0,
+          combined: 0.85,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('accepts with abandonment_type set', () => {
+    expect(validateEvent({ ...valid, abandonment_type: 'incomplete' })).toBe(true);
+  });
+
+  it('rejects invalid signal', () => {
+    expect(validateEvent({ ...valid, signal: 'liked' })).toBe(false);
+  });
+
+  it('rejects invalid abandonment_type', () => {
+    expect(validateEvent({ ...valid, abandonment_type: 'maybe' })).toBe(false);
+  });
+
+  it('rejects confidence_breakdown with score > 1', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        confidence_breakdown: {
+          undo_score: 1.5,
+          completion_score: 0.9,
+          session_score: 0.7,
+          correction_score: 1.0,
+          combined: 0.85,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects confidence_breakdown with missing field', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        confidence_breakdown: {
+          undo_score: 0.8,
+          completion_score: 0.9,
+          session_score: 0.7,
+          correction_score: 1.0,
+          // missing combined
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects time_since_last_edit_ms >= 86400000', () => {
+    expect(validateEvent({ ...valid, time_since_last_edit_ms: 86400000 })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// drawer_purpose
+// ─────────────────────────────────────────────
+describe('validateEvent — drawer_purpose', () => {
+  const valid = {
+    type: 'drawer_purpose',
+    layout_hash: LAYOUT_HASH,
+    purpose: 'workshop',
+    is_custom: false,
+  };
+
+  it('accepts a valid drawer_purpose event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts a custom purpose matching the regex', () => {
+    expect(validateEvent({ ...valid, purpose: 'my_workshop_v2', is_custom: true })).toBe(true);
+  });
+
+  it('rejects purpose that is not in allowed set and not a valid custom string', () => {
+    expect(validateEvent({ ...valid, purpose: 'WORKSHOP' })).toBe(false);
+  });
+
+  it('rejects invalid layout_hash', () => {
+    expect(validateEvent({ ...valid, layout_hash: 'too-long-hash-value' })).toBe(false);
+  });
+
+  it('rejects non-boolean is_custom', () => {
+    expect(validateEvent({ ...valid, is_custom: 'true' })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// category_changed
+// ─────────────────────────────────────────────
+describe('validateEvent — category_changed', () => {
+  const valid = {
+    type: 'category_changed',
+    bin_size: BIN_SIZE,
+    category_name_hash: LABEL_HASH,
+    batch_size: 1,
+    label_hash: null,
+    label_domain: null,
+    vocab_version: 'v1',
+  };
+
+  it('accepts a valid category_changed event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with optional label_hash and domain', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        label_hash: LABEL_HASH,
+        label_domain: 'tools',
+      })
+    ).toBe(true);
+  });
+
+  it('rejects batch_size of 0', () => {
+    expect(validateEvent({ ...valid, batch_size: 0 })).toBe(false);
+  });
+
+  it('rejects batch_size >= 1000', () => {
+    expect(validateEvent({ ...valid, batch_size: 1000 })).toBe(false);
+  });
+
+  it('rejects category_name_hash not matching 8-char hex', () => {
+    expect(validateEvent({ ...valid, category_name_hash: 'ABCD1234' })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// bin_resized
+// ─────────────────────────────────────────────
+describe('validateEvent — bin_resized', () => {
+  const valid = {
+    type: 'bin_resized',
+    old_size: BIN_SIZE,
+    new_size: '3x3x4',
+    dimensions_changed: ['width'],
+    batch_size: 1,
+    fill_pct: 40,
+    resize_direction: 'grow',
+    area_delta: 3,
+  };
+
+  it('accepts a valid bin_resized event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts both dimensions changed', () => {
+    expect(validateEvent({ ...valid, dimensions_changed: ['width', 'depth'] })).toBe(true);
+  });
+
+  it('rejects empty dimensions_changed array', () => {
+    expect(validateEvent({ ...valid, dimensions_changed: [] })).toBe(false);
+  });
+
+  it('rejects invalid dimension value', () => {
+    expect(validateEvent({ ...valid, dimensions_changed: ['height'] })).toBe(false);
+  });
+
+  it('rejects invalid resize_direction', () => {
+    expect(validateEvent({ ...valid, resize_direction: 'sideways' })).toBe(false);
+  });
+
+  it('rejects area_delta >= 10000', () => {
+    expect(validateEvent({ ...valid, area_delta: 10000 })).toBe(false);
+  });
+
+  it('rejects fill_pct > 100', () => {
+    expect(validateEvent({ ...valid, fill_pct: 101 })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// bin_deleted
+// ─────────────────────────────────────────────
+describe('validateEvent — bin_deleted', () => {
+  const valid = {
+    type: 'bin_deleted',
+    bin_size: BIN_SIZE,
+    position: POSITION,
+    layer_index: 0,
+    had_label: false,
+    label_domain: null,
+    age_ms: null,
+    batch_size: 1,
+    fill_pct: 30,
+    method: 'key',
+  };
+
+  it('accepts a valid bin_deleted event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with optional age_ms set', () => {
+    expect(validateEvent({ ...valid, age_ms: 5000 })).toBe(true);
+  });
+
+  it('rejects invalid method', () => {
+    expect(validateEvent({ ...valid, method: 'swipe' })).toBe(false);
+  });
+
+  it('rejects invalid position format', () => {
+    expect(validateEvent({ ...valid, position: '3-5' })).toBe(false);
+  });
+
+  it('rejects layer_index > 20', () => {
+    expect(validateEvent({ ...valid, layer_index: 21 })).toBe(false);
+  });
+
+  it('rejects non-boolean had_label', () => {
+    expect(validateEvent({ ...valid, had_label: 1 })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// bin_moved
+// ─────────────────────────────────────────────
+describe('validateEvent — bin_moved', () => {
+  const valid = {
+    type: 'bin_moved',
+    bin_size: BIN_SIZE,
+    old_position: POSITION,
+    new_position: '5,7',
+    distance: 4,
+    layer_index: 0,
+    batch_size: 1,
+    method: 'drag',
+  };
+
+  it('accepts a valid bin_moved event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts nudge method', () => {
+    expect(validateEvent({ ...valid, method: 'nudge' })).toBe(true);
+  });
+
+  it('rejects invalid move method', () => {
+    expect(validateEvent({ ...valid, method: 'teleport' })).toBe(false);
+  });
+
+  it('rejects distance >= 1000', () => {
+    expect(validateEvent({ ...valid, distance: 1000 })).toBe(false);
+  });
+
+  it('rejects invalid position format', () => {
+    expect(validateEvent({ ...valid, old_position: 'x,y' })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// drawer_resized
+// ─────────────────────────────────────────────
+describe('validateEvent — drawer_resized', () => {
+  const valid = {
+    type: 'drawer_resized',
+    old_size: DRAWER_SIZE,
+    new_size: '8x10x6',
+    dimensions_changed: ['width'],
+    bins_staged: 0,
+    fill_pct: 20,
+  };
+
+  it('accepts a valid drawer_resized event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts height as a changed dimension', () => {
+    expect(validateEvent({ ...valid, dimensions_changed: ['height'] })).toBe(true);
+  });
+
+  it('rejects empty dimensions_changed', () => {
+    expect(validateEvent({ ...valid, dimensions_changed: [] })).toBe(false);
+  });
+
+  it('rejects invalid dimension value', () => {
+    expect(validateEvent({ ...valid, dimensions_changed: ['diagonal'] })).toBe(false);
+  });
+
+  it('rejects bins_staged < 0', () => {
+    expect(validateEvent({ ...valid, bins_staged: -1 })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// fill_operation
+// ─────────────────────────────────────────────
+describe('validateEvent — fill_operation', () => {
+  const valid = {
+    type: 'fill_operation',
+    method: 'uniform',
+    fill_size: FILL_SIZE,
+    bins_created: 5,
+    layer_index: 0,
+    fill_pct: 80,
+    drawer_size: DRAWER_SIZE,
+  };
+
+  it('accepts a valid fill_operation event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts gaps method with null fill_size', () => {
+    expect(validateEvent({ ...valid, method: 'gaps', fill_size: null })).toBe(true);
+  });
+
+  it('rejects bins_created = 0', () => {
+    expect(validateEvent({ ...valid, bins_created: 0 })).toBe(false);
+  });
+
+  it('rejects invalid fill method', () => {
+    expect(validateEvent({ ...valid, method: 'random' })).toBe(false);
+  });
+
+  it('rejects fill_size with wrong format (3D instead of 2D)', () => {
+    expect(validateEvent({ ...valid, fill_size: BIN_SIZE })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// layer_move
+// ─────────────────────────────────────────────
+describe('validateEvent — layer_move', () => {
+  const valid = {
+    type: 'layer_move',
+    bin_size: BIN_SIZE,
+    from_layer_index: 0,
+    to_layer_index: 1,
+    batch_size: 1,
+    method: 'drag',
+  };
+
+  it('accepts a valid layer_move event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts from_layer_index = -1 (staging)', () => {
+    expect(validateEvent({ ...valid, from_layer_index: -1 })).toBe(true);
+  });
+
+  it('accepts to_layer_index = -1 (staging)', () => {
+    expect(validateEvent({ ...valid, to_layer_index: -1 })).toBe(true);
+  });
+
+  it('rejects from_layer_index < -1', () => {
+    expect(validateEvent({ ...valid, from_layer_index: -2 })).toBe(false);
+  });
+
+  it('rejects from_layer_index > 20', () => {
+    expect(validateEvent({ ...valid, from_layer_index: 21 })).toBe(false);
+  });
+
+  it('rejects invalid method', () => {
+    expect(validateEvent({ ...valid, method: 'slide' })).toBe(false);
+  });
+
+  it('accepts all valid layer move methods', () => {
+    for (const method of ['inspector', 'drag', 'keyboard', 'context_menu']) {
+      expect(validateEvent({ ...valid, method })).toBe(true);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────
+// bin_rotated
+// ─────────────────────────────────────────────
+describe('validateEvent — bin_rotated', () => {
+  const valid = {
+    type: 'bin_rotated',
+    old_size: BIN_SIZE,
+    new_size: '3x2x4',
+    batch_size: 1,
+  };
+
+  it('accepts a valid bin_rotated event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('rejects invalid old_size', () => {
+    expect(validateEvent({ ...valid, old_size: '2x3' })).toBe(false);
+  });
+
+  it('rejects batch_size of 0', () => {
+    expect(validateEvent({ ...valid, batch_size: 0 })).toBe(false);
+  });
+
+  it('rejects batch_size >= 1000', () => {
+    expect(validateEvent({ ...valid, batch_size: 1000 })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// placement_rejected
+// ─────────────────────────────────────────────
+describe('validateEvent — placement_rejected', () => {
+  const valid = {
+    type: 'placement_rejected',
+    rejection_reason: 'cancelled',
+    intended_size: null,
+    intended_position: null,
+    layer_index: 0,
+    drawer_size: DRAWER_SIZE,
+    fill_pct: 50,
+    mode: 'draw',
+  };
+
+  it('accepts a valid placement_rejected event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with optional intended_size and intended_position', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        intended_size: FILL_SIZE,
+        intended_position: POSITION,
+      })
+    ).toBe(true);
+  });
+
+  it('rejects invalid rejection_reason', () => {
+    expect(validateEvent({ ...valid, rejection_reason: 'nope' })).toBe(false);
+  });
+
+  it('rejects invalid mode', () => {
+    expect(validateEvent({ ...valid, mode: 'sketch' })).toBe(false);
+  });
+
+  it('accepts all valid rejection reasons', () => {
+    for (const reason of ['cancelled', 'second_touch', 'outside_bounds', 'too_small']) {
+      expect(validateEvent({ ...valid, rejection_reason: reason })).toBe(true);
+    }
+  });
+
+  it('rejects intended_size with 3D format', () => {
+    // intended_size must be 2D (WxD), not 3D
+    expect(validateEvent({ ...valid, intended_size: BIN_SIZE })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// undo
+// ─────────────────────────────────────────────
+describe('validateEvent — undo', () => {
+  const valid = {
+    type: 'undo',
+    action_undone: 'placement',
+    bins_affected: 1,
+    time_since_action_ms: 1000,
+    drawer_size: DRAWER_SIZE,
+  };
+
+  it('accepts a valid undo event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts all valid action_undone values', () => {
+    const actions = [
+      'placement',
+      'deletion',
+      'move',
+      'resize',
+      'fill',
+      'layer_change',
+      'drawer_resize',
+      'other',
+    ];
+    for (const action of actions) {
+      expect(validateEvent({ ...valid, action_undone: action })).toBe(true);
+    }
+  });
+
+  it('rejects invalid action_undone', () => {
+    expect(validateEvent({ ...valid, action_undone: 'redo' })).toBe(false);
+  });
+
+  it('rejects bins_affected < 0', () => {
+    expect(validateEvent({ ...valid, bins_affected: -1 })).toBe(false);
+  });
+
+  it('rejects time_since_action_ms < 0', () => {
+    expect(validateEvent({ ...valid, time_since_action_ms: -1 })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// quick_correction
+// ─────────────────────────────────────────────
+describe('validateEvent — quick_correction', () => {
+  const valid = {
+    type: 'quick_correction',
+    correction_type: 'delete',
+    original_size: BIN_SIZE,
+    new_size: null,
+    placement_method: 'draw',
+    time_to_correction_ms: 2000,
+    layer_index: 0,
+  };
+
+  it('accepts a valid quick_correction event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with new_size set for resize correction', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        correction_type: 'resize',
+        new_size: '3x3x4',
+      })
+    ).toBe(true);
+  });
+
+  it('rejects invalid correction_type', () => {
+    expect(validateEvent({ ...valid, correction_type: 'undo' })).toBe(false);
+  });
+
+  it('rejects invalid placement_method', () => {
+    expect(validateEvent({ ...valid, placement_method: 'magical' })).toBe(false);
+  });
+
+  it('rejects time_to_correction_ms >= 600000', () => {
+    expect(validateEvent({ ...valid, time_to_correction_ms: 600000 })).toBe(false);
+  });
+
+  it('accepts all valid correction types', () => {
+    for (const correction_type of ['delete', 'resize', 'move']) {
+      expect(validateEvent({ ...valid, correction_type })).toBe(true);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────
+// bin_abandoned
+// ─────────────────────────────────────────────
+describe('validateEvent — bin_abandoned', () => {
+  const valid = {
+    type: 'bin_abandoned',
+    bin_size: BIN_SIZE,
+    position: POSITION,
+    layer_index: 0,
+    lifetime_ms: 30000,
+    creation_method: 'draw',
+    fill_pct: 20,
+    drawer_size: DRAWER_SIZE,
+  };
+
+  it('accepts a valid bin_abandoned event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('rejects lifetime_ms >= 86400000', () => {
+    expect(validateEvent({ ...valid, lifetime_ms: 86400000 })).toBe(false);
+  });
+
+  it('rejects invalid creation_method', () => {
+    expect(validateEvent({ ...valid, creation_method: 'wish' })).toBe(false);
+  });
+
+  it('accepts all valid creation methods', () => {
+    for (const creation_method of ['draw', 'fill', 'duplicate', 'staging', 'paint']) {
+      expect(validateEvent({ ...valid, creation_method })).toBe(true);
+    }
+  });
+
+  it('rejects invalid position format', () => {
+    expect(validateEvent({ ...valid, position: 'a,b' })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// session_summary
+// ─────────────────────────────────────────────
+describe('validateEvent — session_summary', () => {
+  const valid = {
+    type: 'session_summary',
+    bins_placed: 5,
+    bins_deleted: 1,
+    edits_total: 8,
+    time_to_first_bin_ms: 5000,
+    session_duration_ms: 180000,
+    size_sequence: [BIN_SIZE, '1x1x3'],
+    edit_to_done_ratio: 0.4,
+    undo_count: 1,
+    confidence_score: 0.7,
+    drawer_size: DRAWER_SIZE,
+    final_fill_pct: 60,
+  };
+
+  it('accepts a valid session_summary event', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts with time_to_first_bin_ms null', () => {
+    expect(validateEvent({ ...valid, time_to_first_bin_ms: null })).toBe(true);
+  });
+
+  it('accepts empty size_sequence', () => {
+    expect(validateEvent({ ...valid, size_sequence: [] })).toBe(true);
+  });
+
+  it('rejects bins_placed < 0', () => {
+    expect(validateEvent({ ...valid, bins_placed: -1 })).toBe(false);
+  });
+
+  it('rejects confidence_score > 1', () => {
+    expect(validateEvent({ ...valid, confidence_score: 1.1 })).toBe(false);
+  });
+
+  it('rejects confidence_score < 0', () => {
+    expect(validateEvent({ ...valid, confidence_score: -0.1 })).toBe(false);
+  });
+
+  it('rejects size_sequence with more than 100 entries', () => {
+    const sizes = Array.from({ length: 101 }, () => BIN_SIZE);
+    expect(validateEvent({ ...valid, size_sequence: sizes })).toBe(false);
+  });
+
+  it('rejects size_sequence with invalid bin size entry', () => {
+    expect(validateEvent({ ...valid, size_sequence: ['bad'] })).toBe(false);
+  });
+
+  it('rejects edits_total >= 100000', () => {
+    expect(validateEvent({ ...valid, edits_total: 100000 })).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// cross_layout_pattern
+// ─────────────────────────────────────────────
+describe('validateEvent — cross_layout_pattern', () => {
+  const valid = {
+    type: 'cross_layout_pattern',
+    user_hash: 'anonymous',
+    label_size_consistency: [],
+    inferred_purpose: null,
+    inferred_purpose_confidence: 0.5,
+    drawer_size: DRAWER_SIZE,
+  };
+
+  it('accepts a valid cross_layout_pattern event with anonymous user', () => {
+    expect(validateEvent(valid)).toBe(true);
+  });
+
+  it('accepts a UUID-format user_hash', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        user_hash: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      })
+    ).toBe(true);
+  });
+
+  it('accepts with inferred_purpose set to known value', () => {
+    expect(validateEvent({ ...valid, inferred_purpose: 'workshop' })).toBe(true);
+  });
+
+  it('accepts with label_size_consistency entries', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        label_size_consistency: [
+          { label_hash: LABEL_HASH, sizes_used: [BIN_SIZE], is_consistent: true },
+          { label_hash: 'bbbb2222', sizes_used: [BIN_SIZE, '1x1x3'], is_consistent: false },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it('rejects invalid user_hash format', () => {
+    expect(validateEvent({ ...valid, user_hash: 'sh' })).toBe(false);
+  });
+
+  it('rejects user_hash with uppercase letters', () => {
+    // Uppercase is not in [a-z0-9-] and is not 'anonymous'
+    expect(validateEvent({ ...valid, user_hash: 'ABCDEFGH' })).toBe(false);
+  });
+
+  it('rejects label_size_consistency with more than 20 entries', () => {
+    const entries = Array.from({ length: 21 }, () => ({
+      label_hash: LABEL_HASH,
+      sizes_used: [BIN_SIZE],
+      is_consistent: true,
+    }));
+    expect(validateEvent({ ...valid, label_size_consistency: entries })).toBe(false);
+  });
+
+  it('rejects label_size_consistency entry with empty sizes_used', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        label_size_consistency: [{ label_hash: LABEL_HASH, sizes_used: [], is_consistent: true }],
+      })
+    ).toBe(false);
+  });
+
+  it('rejects label_size_consistency entry with invalid label_hash', () => {
+    expect(
+      validateEvent({
+        ...valid,
+        label_size_consistency: [
+          { label_hash: 'ZZZZ9999', sizes_used: [BIN_SIZE], is_consistent: true },
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it('rejects inferred_purpose_confidence > 1', () => {
+    expect(validateEvent({ ...valid, inferred_purpose_confidence: 1.5 })).toBe(false);
+  });
+
+  it('rejects inferred_purpose_confidence < 0', () => {
+    expect(validateEvent({ ...valid, inferred_purpose_confidence: -0.1 })).toBe(false);
+  });
+
+  it('rejects non-null inferred_purpose that does not match allowed set or regex', () => {
+    expect(validateEvent({ ...valid, inferred_purpose: 'INVALID PURPOSE!' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds colocated unit tests for two large, **pure, previously-untested** server-side modules under `api/lib/mlTelemetry/` (the whole subdir had no tests):

- **`aggregators.test.ts`** (181 tests) — each of the 19 `aggregate*()` functions increments the expected `Increments` counters for a representative event; additivity (calling twice doubles); robustness to missing/zero/undefined optional fields (no NaN/throw). Covers the dual-writes to `ml:rejections` and `ml:neg:undos` (per-field + `total`).
- **`validators.test.ts`** (137 tests) — `validateEvent()` accepts a valid event of **every** `type` and rejects null / non-object / missing required fields / wrong field types / out-of-range enums; asserts the subtle **2D fill-size vs 3D bin-size** regex distinction that injection-prevention relies on.

**Test-only — zero production changes**, so regression risk is ~nil. 318 tests, all green; ESLint + typecheck clean.

First of the zero-risk test-coverage PRs from the tech-debt audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add colocated unit tests for `api/lib/mlTelemetry` aggregators and validators, covering all 19 `aggregate*()` functions and `validateEvent` across every event type; tests assert correct counter increments (including dual-writes to `ml:rejections` and `ml:neg:undos`), full additivity via a reusable `assertAdditive()` helper, resilience to missing fields, and strict regex rules (2D fill-size vs 3D bin-size).
Validator leniency for `bin_placed` is now documented with per-field absence AND wrong-type value tests — `position`, `layer_index`, `largest_gap`, `fill_pct`, and `vocab_version` are intentionally not validated; test-only, no production code changes.

<sup>Written for commit 1b8d2f269e2167950885df8f9c65c9f36690b427. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

