### PR TITLE
test: cover designer-compartment, placement, and custom-property validators

### DIFF
--- a/api/lib/designerCompartmentValidation.test.ts
+++ b/api/lib/designerCompartmentValidation.test.ts
@@ -1,0 +1,521 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateDividers,
+  validateCellMask,
+  validateCompartments,
+} from './designerCompartmentValidation.js';
+import { CONSTRAINTS } from './designerValidationConstants.js';
+
+// ---------------------------------------------------------------------------
+// validateDividers
+// ---------------------------------------------------------------------------
+
+describe('validateDividers', () => {
+  it('accepts a valid dividers object', () => {
+    expect(validateDividers({ x: 2, y: 3, thickness: 1.2 })).toBeNull();
+  });
+
+  it('accepts minimum boundary values', () => {
+    expect(
+      validateDividers({ x: 0, y: 0, thickness: CONSTRAINTS.MIN_DIVIDER_THICKNESS })
+    ).toBeNull();
+  });
+
+  it('accepts maximum boundary values', () => {
+    expect(
+      validateDividers({
+        x: CONSTRAINTS.MAX_DIVIDERS,
+        y: CONSTRAINTS.MAX_DIVIDERS,
+        thickness: CONSTRAINTS.MAX_DIVIDER_THICKNESS,
+      })
+    ).toBeNull();
+  });
+
+  it('rejects null', () => {
+    expect(validateDividers(null)).toBe('dividers must be an object');
+  });
+
+  it('rejects an array', () => {
+    expect(validateDividers([])).toBe('dividers must be an object');
+  });
+
+  it('rejects a string', () => {
+    expect(validateDividers('dividers')).toBe('dividers must be an object');
+  });
+
+  it('rejects x below 0', () => {
+    expect(validateDividers({ x: -1, y: 0, thickness: 1.2 })).toBe(
+      `dividers.x must be 0-${CONSTRAINTS.MAX_DIVIDERS}`
+    );
+  });
+
+  it('rejects x above MAX_DIVIDERS', () => {
+    expect(validateDividers({ x: CONSTRAINTS.MAX_DIVIDERS + 1, y: 0, thickness: 1.2 })).toBe(
+      `dividers.x must be 0-${CONSTRAINTS.MAX_DIVIDERS}`
+    );
+  });
+
+  it('rejects non-numeric x', () => {
+    expect(validateDividers({ x: '5', y: 0, thickness: 1.2 })).toBe(
+      `dividers.x must be 0-${CONSTRAINTS.MAX_DIVIDERS}`
+    );
+  });
+
+  it('rejects NaN x', () => {
+    expect(validateDividers({ x: NaN, y: 0, thickness: 1.2 })).toBe(
+      `dividers.x must be 0-${CONSTRAINTS.MAX_DIVIDERS}`
+    );
+  });
+
+  it('rejects y below 0', () => {
+    expect(validateDividers({ x: 0, y: -1, thickness: 1.2 })).toBe(
+      `dividers.y must be 0-${CONSTRAINTS.MAX_DIVIDERS}`
+    );
+  });
+
+  it('rejects y above MAX_DIVIDERS', () => {
+    expect(validateDividers({ x: 0, y: CONSTRAINTS.MAX_DIVIDERS + 1, thickness: 1.2 })).toBe(
+      `dividers.y must be 0-${CONSTRAINTS.MAX_DIVIDERS}`
+    );
+  });
+
+  it('rejects thickness below MIN_DIVIDER_THICKNESS', () => {
+    expect(validateDividers({ x: 0, y: 0, thickness: 0.5 })).toBe(
+      `dividers.thickness must be ${CONSTRAINTS.MIN_DIVIDER_THICKNESS}-${CONSTRAINTS.MAX_DIVIDER_THICKNESS}`
+    );
+  });
+
+  it('rejects thickness above MAX_DIVIDER_THICKNESS', () => {
+    expect(validateDividers({ x: 0, y: 0, thickness: 3.0 })).toBe(
+      `dividers.thickness must be ${CONSTRAINTS.MIN_DIVIDER_THICKNESS}-${CONSTRAINTS.MAX_DIVIDER_THICKNESS}`
+    );
+  });
+
+  it('rejects non-numeric thickness', () => {
+    expect(validateDividers({ x: 0, y: 0, thickness: 'medium' })).toBe(
+      `dividers.thickness must be ${CONSTRAINTS.MIN_DIVIDER_THICKNESS}-${CONSTRAINTS.MAX_DIVIDER_THICKNESS}`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCellMask
+// ---------------------------------------------------------------------------
+
+describe('validateCellMask', () => {
+  it('accepts a structurally valid mask', () => {
+    expect(validateCellMask({ cols: 4, rows: 4, cells: new Array(16).fill(1) })).toBeNull();
+  });
+
+  it('accepts minimum-dimension mask (1×1)', () => {
+    expect(validateCellMask({ cols: 1, rows: 1, cells: [0] })).toBeNull();
+  });
+
+  it('accepts maximum-dimension mask', () => {
+    expect(
+      validateCellMask({
+        cols: CONSTRAINTS.MAX_MASK_DIMENSION,
+        rows: CONSTRAINTS.MAX_MASK_DIMENSION,
+        cells: new Array(CONSTRAINTS.MAX_MASK_DIMENSION ** 2).fill(1),
+      })
+    ).toBeNull();
+  });
+
+  it('accepts mixed 0 and 1 cell values', () => {
+    expect(validateCellMask({ cols: 2, rows: 2, cells: [1, 0, 0, 1] })).toBeNull();
+  });
+
+  it('rejects null', () => {
+    expect(validateCellMask(null)).toBe('cellMask must be an object');
+  });
+
+  it('rejects an array', () => {
+    expect(validateCellMask([])).toBe('cellMask must be an object');
+  });
+
+  it('rejects cols = 0 (below minimum)', () => {
+    expect(validateCellMask({ cols: 0, rows: 2, cells: [] })).toBe(
+      `cellMask.cols must be integer 1-${CONSTRAINTS.MAX_MASK_DIMENSION}`
+    );
+  });
+
+  it('rejects cols above MAX_MASK_DIMENSION', () => {
+    expect(
+      validateCellMask({
+        cols: CONSTRAINTS.MAX_MASK_DIMENSION + 1,
+        rows: 2,
+        cells: new Array((CONSTRAINTS.MAX_MASK_DIMENSION + 1) * 2).fill(1),
+      })
+    ).toBe(`cellMask.cols must be integer 1-${CONSTRAINTS.MAX_MASK_DIMENSION}`);
+  });
+
+  it('rejects non-integer cols', () => {
+    expect(validateCellMask({ cols: 2.5, rows: 2, cells: new Array(5).fill(1) })).toBe(
+      `cellMask.cols must be integer 1-${CONSTRAINTS.MAX_MASK_DIMENSION}`
+    );
+  });
+
+  it('rejects non-numeric cols', () => {
+    expect(validateCellMask({ cols: '4', rows: 2, cells: [] })).toBe(
+      `cellMask.cols must be integer 1-${CONSTRAINTS.MAX_MASK_DIMENSION}`
+    );
+  });
+
+  it('rejects rows = 0', () => {
+    expect(validateCellMask({ cols: 2, rows: 0, cells: [] })).toBe(
+      `cellMask.rows must be integer 1-${CONSTRAINTS.MAX_MASK_DIMENSION}`
+    );
+  });
+
+  it('rejects rows above MAX_MASK_DIMENSION', () => {
+    expect(validateCellMask({ cols: 2, rows: CONSTRAINTS.MAX_MASK_DIMENSION + 1, cells: [] })).toBe(
+      `cellMask.rows must be integer 1-${CONSTRAINTS.MAX_MASK_DIMENSION}`
+    );
+  });
+
+  it('rejects non-integer rows', () => {
+    expect(validateCellMask({ cols: 2, rows: 1.5, cells: [1, 1, 1] })).toBe(
+      `cellMask.rows must be integer 1-${CONSTRAINTS.MAX_MASK_DIMENSION}`
+    );
+  });
+
+  it('rejects cells that is not an array', () => {
+    expect(validateCellMask({ cols: 2, rows: 2, cells: 'data' })).toBe(
+      'cellMask.cells must be an array'
+    );
+  });
+
+  it('rejects cells with wrong length (too short)', () => {
+    expect(validateCellMask({ cols: 4, rows: 4, cells: [1, 1, 1] })).toBe(
+      'cellMask.cells length must be cols × rows (16)'
+    );
+  });
+
+  it('rejects cells with wrong length (too long)', () => {
+    expect(validateCellMask({ cols: 2, rows: 2, cells: [1, 0, 1, 0, 1] })).toBe(
+      'cellMask.cells length must be cols × rows (4)'
+    );
+  });
+
+  it('rejects cell value of 2', () => {
+    expect(validateCellMask({ cols: 2, rows: 2, cells: [1, 1, 1, 2] })).toBe(
+      'cellMask.cells[3] must be 0 or 1'
+    );
+  });
+
+  it('rejects negative cell value', () => {
+    expect(validateCellMask({ cols: 2, rows: 2, cells: [-1, 1, 1, 1] })).toBe(
+      'cellMask.cells[0] must be 0 or 1'
+    );
+  });
+
+  it('rejects null cell value', () => {
+    expect(validateCellMask({ cols: 2, rows: 2, cells: [1, null, 1, 1] })).toBe(
+      'cellMask.cells[1] must be 0 or 1'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCompartments
+// ---------------------------------------------------------------------------
+
+function validCompartments() {
+  return { cols: 1, rows: 1, thickness: 1.2, cells: [0] };
+}
+
+describe('validateCompartments', () => {
+  it('accepts a minimal valid compartments object', () => {
+    expect(validateCompartments(validCompartments())).toBeNull();
+  });
+
+  it('accepts boundary values (max cols/rows, min thickness)', () => {
+    expect(
+      validateCompartments({
+        cols: CONSTRAINTS.MAX_COMPARTMENT_GRID,
+        rows: CONSTRAINTS.MAX_COMPARTMENT_GRID,
+        thickness: CONSTRAINTS.MIN_COMPARTMENT_THICKNESS,
+        cells: new Array(CONSTRAINTS.MAX_COMPARTMENT_GRID ** 2).fill(0),
+      })
+    ).toBeNull();
+  });
+
+  it('rejects null', () => {
+    expect(validateCompartments(null)).toBe('compartments must be an object');
+  });
+
+  it('rejects an array', () => {
+    expect(validateCompartments([])).toBe('compartments must be an object');
+  });
+
+  it('rejects cols = 0', () => {
+    expect(validateCompartments({ cols: 0, rows: 1, thickness: 1.2, cells: [] })).toBe(
+      `compartments.cols must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+    );
+  });
+
+  it('rejects cols above MAX_COMPARTMENT_GRID', () => {
+    expect(
+      validateCompartments({
+        cols: CONSTRAINTS.MAX_COMPARTMENT_GRID + 1,
+        rows: 1,
+        thickness: 1.2,
+        cells: [],
+      })
+    ).toBe(
+      `compartments.cols must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+    );
+  });
+
+  it('rejects rows = 0', () => {
+    expect(validateCompartments({ cols: 1, rows: 0, thickness: 1.2, cells: [] })).toBe(
+      `compartments.rows must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+    );
+  });
+
+  it('rejects rows above MAX_COMPARTMENT_GRID', () => {
+    expect(
+      validateCompartments({
+        cols: 1,
+        rows: CONSTRAINTS.MAX_COMPARTMENT_GRID + 1,
+        thickness: 1.2,
+        cells: [],
+      })
+    ).toBe(
+      `compartments.rows must be ${CONSTRAINTS.MIN_COMPARTMENT_GRID}-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`
+    );
+  });
+
+  it('rejects thickness below MIN_COMPARTMENT_THICKNESS', () => {
+    expect(validateCompartments({ cols: 1, rows: 1, thickness: 0.3, cells: [0] })).toBe(
+      `compartments.thickness must be ${CONSTRAINTS.MIN_COMPARTMENT_THICKNESS}-${CONSTRAINTS.MAX_COMPARTMENT_THICKNESS}`
+    );
+  });
+
+  it('rejects thickness above MAX_COMPARTMENT_THICKNESS', () => {
+    expect(validateCompartments({ cols: 1, rows: 1, thickness: 3.0, cells: [0] })).toBe(
+      `compartments.thickness must be ${CONSTRAINTS.MIN_COMPARTMENT_THICKNESS}-${CONSTRAINTS.MAX_COMPARTMENT_THICKNESS}`
+    );
+  });
+
+  it('rejects cells that is not an array', () => {
+    expect(validateCompartments({ cols: 1, rows: 1, thickness: 1.2, cells: 'none' })).toBe(
+      'compartments.cells must be an array'
+    );
+  });
+
+  it('rejects cells with wrong length', () => {
+    expect(validateCompartments({ cols: 2, rows: 2, thickness: 1.2, cells: [0, 1] })).toBe(
+      'compartments.cells length must be cols × rows (4)'
+    );
+  });
+
+  it('rejects fractional cell IDs', () => {
+    expect(validateCompartments({ cols: 1, rows: 1, thickness: 1.2, cells: [0.5] })).toBe(
+      'compartments.cells[0] must be a non-negative integer'
+    );
+  });
+
+  it('rejects negative cell IDs', () => {
+    expect(validateCompartments({ cols: 1, rows: 1, thickness: 1.2, cells: [-1] })).toBe(
+      'compartments.cells[0] must be a non-negative integer'
+    );
+  });
+
+  it('rejects string cell IDs', () => {
+    expect(validateCompartments({ cols: 1, rows: 1, thickness: 1.2, cells: ['0'] })).toBe(
+      'compartments.cells[0] must be a non-negative integer'
+    );
+  });
+
+  describe('compartmentTexts', () => {
+    it('accepts valid compartmentTexts', () => {
+      expect(
+        validateCompartments({ ...validCompartments(), compartmentTexts: ['SCREWS'] })
+      ).toBeNull();
+    });
+
+    it('accepts compartmentTexts with exactly 50 chars (boundary)', () => {
+      expect(
+        validateCompartments({ ...validCompartments(), compartmentTexts: ['x'.repeat(50)] })
+      ).toBeNull();
+    });
+
+    it('rejects compartmentTexts that is not an array', () => {
+      expect(validateCompartments({ ...validCompartments(), compartmentTexts: 'oops' })).toBe(
+        'compartments.compartmentTexts must be an array'
+      );
+    });
+
+    it('rejects compartmentTexts longer than cols × rows', () => {
+      // cols=1, rows=1 → max 1 entry
+      expect(validateCompartments({ ...validCompartments(), compartmentTexts: ['A', 'B'] })).toBe(
+        'compartments.compartmentTexts length must not exceed cols × rows (1)'
+      );
+    });
+
+    it('rejects non-string compartmentTexts entry', () => {
+      expect(validateCompartments({ ...validCompartments(), compartmentTexts: [123] })).toBe(
+        'compartments.compartmentTexts[0] must be a string'
+      );
+    });
+
+    it('rejects compartmentTexts entry exceeding 50 characters', () => {
+      expect(
+        validateCompartments({ ...validCompartments(), compartmentTexts: ['x'.repeat(51)] })
+      ).toBe('compartments.compartmentTexts[0] must not exceed 50 characters');
+    });
+  });
+
+  describe('dividerHeight', () => {
+    it('accepts the literal "auto"', () => {
+      expect(validateCompartments({ ...validCompartments(), dividerHeight: 'auto' })).toBeNull();
+    });
+
+    it('accepts 0 (minimum numeric)', () => {
+      expect(validateCompartments({ ...validCompartments(), dividerHeight: 0 })).toBeNull();
+    });
+
+    it('accepts 140 (maximum numeric)', () => {
+      expect(validateCompartments({ ...validCompartments(), dividerHeight: 140 })).toBeNull();
+    });
+
+    it('rejects a negative dividerHeight', () => {
+      expect(validateCompartments({ ...validCompartments(), dividerHeight: -1 })).toBe(
+        "compartments.dividerHeight must be 'auto' or a number 0-140"
+      );
+    });
+
+    it('rejects dividerHeight above 140', () => {
+      expect(validateCompartments({ ...validCompartments(), dividerHeight: 141 })).toBe(
+        "compartments.dividerHeight must be 'auto' or a number 0-140"
+      );
+    });
+
+    it('rejects an arbitrary non-"auto" string', () => {
+      expect(validateCompartments({ ...validCompartments(), dividerHeight: 'manual' })).toBe(
+        "compartments.dividerHeight must be 'auto' or a number 0-140"
+      );
+    });
+  });
+
+  describe('dividerOverrides', () => {
+    function adjacentCells() {
+      // 1 col × 2 rows → cells [0, 1], IDs 0 and 1 are vertically adjacent
+      return { cols: 1, rows: 2, thickness: 1.2, cells: [0, 1] };
+    }
+
+    it('accepts a well-formed dividerOverrides array', () => {
+      expect(
+        validateCompartments({
+          ...adjacentCells(),
+          dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: -8 }],
+        })
+      ).toBeNull();
+    });
+
+    it('rejects dividerOverrides that is not an array', () => {
+      expect(validateCompartments({ ...adjacentCells(), dividerOverrides: 'bad' })).toBe(
+        'compartments.dividerOverrides must be an array'
+      );
+    });
+
+    it('rejects a non-object entry in dividerOverrides', () => {
+      expect(validateCompartments({ ...adjacentCells(), dividerOverrides: ['nope'] })).toBe(
+        'compartments.dividerOverrides[0] must be an object'
+      );
+    });
+
+    it('rejects non-integer compartmentA', () => {
+      expect(
+        validateCompartments({
+          ...adjacentCells(),
+          dividerOverrides: [{ compartmentA: 0.5, compartmentB: 1, offsetStart: 0, offsetEnd: 0 }],
+        })
+      ).toBe('compartments.dividerOverrides[0].compartmentA must be a non-negative integer');
+    });
+
+    it('rejects negative compartmentB', () => {
+      expect(
+        validateCompartments({
+          ...adjacentCells(),
+          dividerOverrides: [{ compartmentA: 0, compartmentB: -1, offsetStart: 0, offsetEnd: 0 }],
+        })
+      ).toBe('compartments.dividerOverrides[0].compartmentB must be a non-negative integer');
+    });
+
+    it('rejects unordered pair (compartmentA >= compartmentB)', () => {
+      expect(
+        validateCompartments({
+          ...adjacentCells(),
+          dividerOverrides: [{ compartmentA: 1, compartmentB: 0, offsetStart: 0, offsetEnd: 0 }],
+        })
+      ).toBe('compartments.dividerOverrides[0] must have compartmentA < compartmentB');
+    });
+
+    it('rejects override referencing an unknown compartment ID', () => {
+      expect(
+        validateCompartments({
+          ...adjacentCells(),
+          dividerOverrides: [{ compartmentA: 0, compartmentB: 99, offsetStart: 0, offsetEnd: 0 }],
+        })
+      ).toBe('compartments.dividerOverrides[0] references unknown compartment ID');
+    });
+
+    it('rejects non-adjacent compartment pair', () => {
+      // 1 col × 3 rows → [0, 1, 2]; 0 and 2 are not adjacent
+      expect(
+        validateCompartments({
+          cols: 1,
+          rows: 3,
+          thickness: 1.2,
+          cells: [0, 1, 2],
+          dividerOverrides: [{ compartmentA: 0, compartmentB: 2, offsetStart: 0, offsetEnd: 0 }],
+        })
+      ).toBe('compartments.dividerOverrides[0] compartments are not adjacent');
+    });
+
+    it('rejects offsetStart out of -200..200 range', () => {
+      expect(
+        validateCompartments({
+          ...adjacentCells(),
+          dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 9999, offsetEnd: 0 }],
+        })
+      ).toBe('compartments.dividerOverrides[0].offsetStart must be -200..200');
+    });
+
+    it('rejects offsetEnd out of range', () => {
+      expect(
+        validateCompartments({
+          ...adjacentCells(),
+          dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: 0, offsetEnd: -999 }],
+        })
+      ).toBe('compartments.dividerOverrides[0].offsetEnd must be -200..200');
+    });
+
+    it('rejects duplicate compartment pair in dividerOverrides', () => {
+      expect(
+        validateCompartments({
+          ...adjacentCells(),
+          dividerOverrides: [
+            { compartmentA: 0, compartmentB: 1, offsetStart: 5, offsetEnd: 0 },
+            { compartmentA: 0, compartmentB: 1, offsetStart: 10, offsetEnd: 0 },
+          ],
+        })
+      ).toBe('compartments.dividerOverrides has duplicate pair 0|1');
+    });
+
+    it('rejects oversized dividerOverrides array', () => {
+      // cols=1, rows=2, expectedLength=2 → max 4 entries (2*2)
+      const overrides = Array.from({ length: 5 }, () => ({
+        compartmentA: 0,
+        compartmentB: 1,
+        offsetStart: 0,
+        offsetEnd: 0,
+      }));
+      expect(validateCompartments({ ...adjacentCells(), dividerOverrides: overrides })).toBe(
+        'compartments.dividerOverrides length is unreasonably large'
+      );
+    });
+  });
+});

--- a/src/shared/utils/validationPlacement.test.ts
+++ b/src/shared/utils/validationPlacement.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { canPlaceBin } from './validationPlacement';
+import { createTestLayout, createTestBin } from '@/test/testUtils';
+import { STAGING_ID } from '@/core/constants';
+import type { Layout } from '@/core/types';
+
+function makeSingleLayerLayout(): Layout {
+  return createTestLayout({
+    drawer: { width: 10, depth: 8, height: 12 },
+    layers: [{ id: 'layer1', name: 'Layer 1', height: 3 }],
+  });
+}
+
+function makeTwoLayerLayout(): Layout {
+  return createTestLayout({
+    drawer: { width: 10, depth: 8, height: 12 },
+    layers: [
+      { id: 'layer1', name: 'Layer 1', height: 3 },
+      { id: 'layer2', name: 'Layer 2', height: 6 },
+    ],
+  });
+}
+
+describe('canPlaceBin', () => {
+  it('returns valid for a bin that fits in the drawer with no obstacles', () => {
+    const layout = makeSingleLayerLayout();
+    const result = canPlaceBin({ x: 0, y: 0, width: 2, depth: 2, height: 3 }, 'layer1', layout);
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('returns valid at the exact right/bottom boundary', () => {
+    const layout = makeSingleLayerLayout();
+    // x + width = 10 = drawer.width, y + depth = 8 = drawer.depth — exact fit
+    const result = canPlaceBin({ x: 8, y: 6, width: 2, depth: 2, height: 3 }, 'layer1', layout);
+    expect(result).toEqual({ valid: true });
+  });
+
+  describe('out_of_bounds', () => {
+    it('returns out_of_bounds when x is negative', () => {
+      const layout = makeSingleLayerLayout();
+      const result = canPlaceBin({ x: -1, y: 0, width: 2, depth: 2, height: 3 }, 'layer1', layout);
+      expect(result).toEqual({ valid: false, reason: 'out_of_bounds' });
+    });
+
+    it('returns out_of_bounds when y is negative', () => {
+      const layout = makeSingleLayerLayout();
+      const result = canPlaceBin({ x: 0, y: -1, width: 2, depth: 2, height: 3 }, 'layer1', layout);
+      expect(result).toEqual({ valid: false, reason: 'out_of_bounds' });
+    });
+  });
+
+  it('returns exceeds_width when x + width exceeds drawer width', () => {
+    const layout = makeSingleLayerLayout();
+    // 9 + 2 = 11 > 10
+    const result = canPlaceBin({ x: 9, y: 0, width: 2, depth: 2, height: 3 }, 'layer1', layout);
+    expect(result).toEqual({ valid: false, reason: 'exceeds_width' });
+  });
+
+  it('returns exceeds_depth when y + depth exceeds drawer depth', () => {
+    const layout = makeSingleLayerLayout();
+    // 7 + 2 = 9 > 8
+    const result = canPlaceBin({ x: 0, y: 7, width: 2, depth: 2, height: 3 }, 'layer1', layout);
+    expect(result).toEqual({ valid: false, reason: 'exceeds_depth' });
+  });
+
+  it('returns invalid_layer for an unknown layer id', () => {
+    const layout = makeSingleLayerLayout();
+    const result = canPlaceBin(
+      { x: 0, y: 0, width: 2, depth: 2, height: 3 },
+      'nonexistent',
+      layout
+    );
+    expect(result).toEqual({ valid: false, reason: 'invalid_layer' });
+  });
+
+  it('returns exceeds_height when bin height exceeds remaining drawer capacity', () => {
+    const layout = makeTwoLayerLayout();
+    // layer2 starts at z = layer1.height = 3; drawer.height = 12; maxHeight = 9
+    const result = canPlaceBin({ x: 0, y: 0, width: 2, depth: 2, height: 10 }, 'layer2', layout);
+    expect(result).toEqual({ valid: false, reason: 'exceeds_height' });
+  });
+
+  it('returns blocked_zone when a tall lower-layer bin protrudes into the target layer', () => {
+    const layout = makeTwoLayerLayout();
+    // layer1 height = 3; bin with height = 5 extends to z = 5 > layer2 start (3)
+    layout.bins = [createTestBin({ id: 'tall', x: 0, y: 0, width: 3, depth: 3, height: 5 })];
+    const result = canPlaceBin({ x: 1, y: 1, width: 2, depth: 2, height: 3 }, 'layer2', layout);
+    expect(result).toMatchObject({ valid: false, reason: 'blocked_zone' });
+    expect(result.blockingInfo).toMatchObject({
+      binId: 'tall',
+      layerId: 'layer1',
+      layerName: 'Layer 1',
+    });
+  });
+
+  it('returns collision when bin footprints overlap on the same layer', () => {
+    const layout = makeSingleLayerLayout();
+    layout.bins = [createTestBin({ id: 'existing', x: 0, y: 0, width: 3, depth: 3 })];
+    const result = canPlaceBin({ x: 1, y: 1, width: 2, depth: 2, height: 3 }, 'layer1', layout);
+    expect(result).toMatchObject({ valid: false, reason: 'collision' });
+    expect(result.blockingInfo).toMatchObject({
+      binId: 'existing',
+      layerId: 'layer1',
+      layerName: 'Layer 1',
+    });
+  });
+
+  it('excludes a single bin from collision checks via excludeBinId', () => {
+    const layout = makeSingleLayerLayout();
+    layout.bins = [createTestBin({ id: 'moving', x: 0, y: 0, width: 3, depth: 3 })];
+    const result = canPlaceBin(
+      { x: 0, y: 0, width: 3, depth: 3, height: 3 },
+      'layer1',
+      layout,
+      'moving'
+    );
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('excludes a set of bins from collision checks via excludeBinIds', () => {
+    const layout = makeSingleLayerLayout();
+    layout.bins = [
+      createTestBin({ id: 'bin1', x: 0, y: 0, width: 2, depth: 2 }),
+      createTestBin({ id: 'bin2', x: 2, y: 0, width: 2, depth: 2 }),
+    ];
+    const result = canPlaceBin(
+      { x: 0, y: 0, width: 4, depth: 2, height: 3 },
+      'layer1',
+      layout,
+      undefined,
+      new Set(['bin1', 'bin2'])
+    );
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('does not collide with staging bins', () => {
+    const layout = makeSingleLayerLayout();
+    layout.bins = [
+      createTestBin({ id: 'staged', layerId: STAGING_ID, x: 0, y: 0, width: 5, depth: 5 }),
+    ];
+    const result = canPlaceBin({ x: 0, y: 0, width: 3, depth: 3, height: 3 }, 'layer1', layout);
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('allows a bin shorter than the layer default height (layer height is not a constraint)', () => {
+    const layout = makeTwoLayerLayout();
+    // layer2 has height 6, but bins can be shorter
+    const result = canPlaceBin({ x: 0, y: 0, width: 2, depth: 2, height: 3 }, 'layer2', layout);
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('includes blockingInfo.layerName as layer name, not id, when the layer is found', () => {
+    const layout = makeSingleLayerLayout();
+    layout.bins = [createTestBin({ id: 'blocker', x: 0, y: 0, width: 3, depth: 3 })];
+    const result = canPlaceBin({ x: 1, y: 1, width: 2, depth: 2, height: 3 }, 'layer1', layout);
+    expect(result).toMatchObject({ valid: false, reason: 'collision' });
+    expect(result.blockingInfo?.layerName).toBe('Layer 1');
+  });
+});

--- a/src/shared/utils/validationProperties.test.ts
+++ b/src/shared/utils/validationProperties.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { validateCustomProperties } from './validationProperties';
+import { isOk, isErr } from '@/core/result';
+import { CONSTRAINTS, RESERVED_PROPERTY_KEYS } from '@/core/constants';
+
+describe('validateCustomProperties', () => {
+  describe('ok paths', () => {
+    it('returns ok for undefined (treated as no custom properties)', () => {
+      const result = validateCustomProperties(undefined as unknown as Record<string, string>);
+      expect(isOk(result)).toBe(true);
+    });
+
+    it('returns ok for null', () => {
+      const result = validateCustomProperties(null as unknown as Record<string, string>);
+      expect(isOk(result)).toBe(true);
+    });
+
+    it('returns ok for an empty object', () => {
+      expect(isOk(validateCustomProperties({}))).toBe(true);
+    });
+
+    it('returns ok for valid key/value pairs', () => {
+      const result = validateCustomProperties({ SKU: 'ABC123', Qty: '5', Location: 'Shelf A' });
+      expect(isOk(result)).toBe(true);
+    });
+
+    it('returns ok at exactly CUSTOM_PROPERTY_MAX_COUNT entries', () => {
+      const props: Record<string, string> = {};
+      for (let i = 0; i < CONSTRAINTS.CUSTOM_PROPERTY_MAX_COUNT; i++) {
+        props[`key${i}`] = 'v';
+      }
+      expect(isOk(validateCustomProperties(props))).toBe(true);
+    });
+
+    it('returns ok for a key at exactly CUSTOM_PROPERTY_KEY_MAX_LENGTH', () => {
+      const key = 'a'.repeat(CONSTRAINTS.CUSTOM_PROPERTY_KEY_MAX_LENGTH);
+      expect(isOk(validateCustomProperties({ [key]: 'value' }))).toBe(true);
+    });
+
+    it('returns ok for a value at exactly CUSTOM_PROPERTY_VALUE_MAX_LENGTH', () => {
+      const value = 'a'.repeat(CONSTRAINTS.CUSTOM_PROPERTY_VALUE_MAX_LENGTH);
+      expect(isOk(validateCustomProperties({ key: value }))).toBe(true);
+    });
+  });
+
+  describe('err paths — input shape', () => {
+    it('returns err for an array input', () => {
+      const result = validateCustomProperties(['value1', 'value2'] as unknown as Record<
+        string,
+        string
+      >);
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+        if (result.error.code === 'VALIDATION_IMPORT_FAILED') {
+          expect(result.error.errors[0]).toContain('plain object');
+        }
+      }
+    });
+
+    it('returns err for a string input', () => {
+      const result = validateCustomProperties('not-an-object' as unknown as Record<string, string>);
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('plain object');
+      }
+    });
+  });
+
+  describe('err paths — property count', () => {
+    it('returns err when count exceeds CUSTOM_PROPERTY_MAX_COUNT', () => {
+      const props: Record<string, string> = {};
+      for (let i = 0; i <= CONSTRAINTS.CUSTOM_PROPERTY_MAX_COUNT; i++) {
+        props[`key${i}`] = 'v';
+      }
+      const result = validateCustomProperties(props);
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain(`${CONSTRAINTS.CUSTOM_PROPERTY_MAX_COUNT}`);
+        expect(result.error.errors[0]).toContain('custom properties');
+      }
+    });
+  });
+
+  describe('err paths — key validation', () => {
+    it('returns err for an empty key', () => {
+      const result = validateCustomProperties({ '': 'value' });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('empty');
+      }
+    });
+
+    it('returns err for a whitespace-only key', () => {
+      const result = validateCustomProperties({ '   ': 'value' });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('empty');
+      }
+    });
+
+    it('returns err for a key exceeding CUSTOM_PROPERTY_KEY_MAX_LENGTH', () => {
+      const longKey = 'a'.repeat(CONSTRAINTS.CUSTOM_PROPERTY_KEY_MAX_LENGTH + 1);
+      const result = validateCustomProperties({ [longKey]: 'value' });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('exceeds maximum length');
+        expect(result.error.errors[0]).toContain(`${CONSTRAINTS.CUSTOM_PROPERTY_KEY_MAX_LENGTH}`);
+      }
+    });
+  });
+
+  describe('err paths — reserved keys', () => {
+    it('returns err for the "id" reserved key', () => {
+      const result = validateCustomProperties({ id: 'bin-1' });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('reserved');
+      }
+    });
+
+    it('returns err for the "label" reserved key', () => {
+      const result = validateCustomProperties({ label: 'My Bin' });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('reserved');
+      }
+    });
+
+    it('returns err for the "__proto__" reserved key (prototype pollution guard)', () => {
+      // Use computed property syntax — { __proto__: v } is the special prototype-setting form
+      // and does NOT create an own property. { ['__proto__']: v } creates an own property.
+      const result = validateCustomProperties({ ['__proto__']: '{}' });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('reserved');
+      }
+    });
+
+    it('returns err for every key in RESERVED_PROPERTY_KEYS', () => {
+      for (const key of RESERVED_PROPERTY_KEYS) {
+        const result = validateCustomProperties({ [key]: 'value' });
+        expect(isErr(result)).toBe(true);
+      }
+    });
+  });
+
+  describe('err paths — value validation', () => {
+    it('returns err when a value is not a string', () => {
+      const result = validateCustomProperties({ key: 42 as unknown as string });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('must be a string');
+      }
+    });
+
+    it('returns err when a value exceeds CUSTOM_PROPERTY_VALUE_MAX_LENGTH', () => {
+      const longValue = 'a'.repeat(CONSTRAINTS.CUSTOM_PROPERTY_VALUE_MAX_LENGTH + 1);
+      const result = validateCustomProperties({ key: longValue });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors[0]).toContain('exceeds maximum length');
+        expect(result.error.errors[0]).toContain(`${CONSTRAINTS.CUSTOM_PROPERTY_VALUE_MAX_LENGTH}`);
+      }
+    });
+  });
+
+  describe('error shape', () => {
+    it('error has kind "ValidationError" and code "VALIDATION_IMPORT_FAILED"', () => {
+      const result = validateCustomProperties({ id: 'will-fail' });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.kind).toBe('ValidationError');
+        expect(result.error.code).toBe('VALIDATION_IMPORT_FAILED');
+      }
+    });
+
+    it('error.errors array contains the failure message', () => {
+      const result = validateCustomProperties({ '': 'value' });
+      if (isErr(result) && result.error.code === 'VALIDATION_IMPORT_FAILED') {
+        expect(result.error.errors).toHaveLength(1);
+        expect(typeof result.error.errors[0]).toBe('string');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Colocated unit tests for **three untested pure validation modules** (Result/error-path coverage from the tech-debt audit):

- **`designerCompartmentValidation.test.ts`** (75) — `validateDividers` / `validateCellMask` / `validateCompartments`: boundary values, out-of-range counts, non-integer/negative cells, mask-dimension mismatches, and the optional `compartmentTexts` / `dividerHeight` / `dividerOverrides` branches.
- **`validationPlacement.test.ts`** (13) — `canPlaceBin` across **every** failure reason (`out_of_bounds` including the previously-uncovered **y<0** path, `exceeds_width/depth/height`, `invalid_layer`, `blocked_zone`, `collision`), plus `excludeBinId(s)` and staging-skip.
- **`validationProperties.test.ts`** (21) — `validateCustomProperties` ok + **Result err** paths: all 15 `RESERVED_PROPERTY_KEYS` (via computed-key form, so `__proto__` is a real own property — see note), count/length limits, and error-shape assertions (`ValidationError` / `VALIDATION_IMPORT_FAILED`).

**Test-only — zero production changes.** 109 tests, all green; ESLint + typecheck clean.

> Note: `{ __proto__: x }` in an object literal sets the prototype (0 own keys), so the reserved-key tests use `{ [key]: x }` computed form to actually exercise the guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add colocated unit tests for three validation modules to close coverage gaps: designer compartments (dividers, cell mask, compartments incl. compartmentTexts/dividerHeight/dividerOverrides), bin placement (`canPlaceBin` across all failure reasons incl. y<0, exclude id(s), and staging skip), and custom properties (reserved keys incl. `__proto__`, count/length limits, and error shape).
Test-only; no production changes.

<sup>Written for commit 10084b66954a64297cb69d9d2d6ab248bb1e3a58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

