### PR TITLE
refactor(shared): error helpers — drain unsafe casts + dedupe export catches

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateExport.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.ts
@@ -22,6 +22,7 @@ import { STACK_PRINT_DEFAULT_COPIES } from '@/core/types';
 import { packagePiecesAsZip } from '@/shared/generation/zipExport';
 import { isErr, getUserMessage } from '@/core/result';
 import { useToastStore } from '@/core/store/toast';
+import { reportExportFailure } from '@/shared/utils/errors';
 import { useTranslation } from '@/i18n';
 import { useBaseplatePageStore } from '../store/baseplatePageStore';
 import { buildFullParams } from '../utils/buildFullParams';
@@ -499,9 +500,7 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
 
         return true;
       } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : 'Export failed';
-        useToastStore.getState().addToast(message, 'error');
-        return false;
+        return reportExportFailure(error);
       } finally {
         setIsExporting(false);
         setExportProgress(null);

--- a/src/features/baseplate/hooks/useBaseplateExport.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.ts
@@ -22,7 +22,7 @@ import { STACK_PRINT_DEFAULT_COPIES } from '@/core/types';
 import { packagePiecesAsZip } from '@/shared/generation/zipExport';
 import { isErr, getUserMessage } from '@/core/result';
 import { useToastStore } from '@/core/store/toast';
-import { reportExportFailure } from '@/shared/utils/errors';
+import { getErrorMessage } from '@/shared/utils/errors';
 import { useTranslation } from '@/i18n';
 import { useBaseplatePageStore } from '../store/baseplatePageStore';
 import { buildFullParams } from '../utils/buildFullParams';
@@ -500,7 +500,8 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
 
         return true;
       } catch (error: unknown) {
-        return reportExportFailure(error);
+        useToastStore.getState().addToast(getErrorMessage(error, 'Export failed'), 'error');
+        return false;
       } finally {
         setIsExporting(false);
         setExportProgress(null);

--- a/src/features/baseplate/hooks/useConnectorSampleExport.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.ts
@@ -18,7 +18,7 @@ import { export3MF } from '@/shared/generation/export';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { isErr, getUserMessage } from '@/core/result';
 import { useToastStore } from '@/core/store/toast';
-import { reportExportFailure } from '@/shared/utils/errors';
+import { getErrorMessage } from '@/shared/utils/errors';
 import { useTranslation } from '@/i18n';
 import { buildFullParams } from '../utils/buildFullParams';
 import {
@@ -112,7 +112,8 @@ export function useConnectorSampleExport(): UseConnectorSampleExportReturn {
         }
         return true;
       } catch (error: unknown) {
-        return reportExportFailure(error);
+        useToastStore.getState().addToast(getErrorMessage(error, 'Export failed'), 'error');
+        return false;
       } finally {
         setIsExporting(false);
       }

--- a/src/features/baseplate/hooks/useConnectorSampleExport.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.ts
@@ -18,6 +18,7 @@ import { export3MF } from '@/shared/generation/export';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { isErr, getUserMessage } from '@/core/result';
 import { useToastStore } from '@/core/store/toast';
+import { reportExportFailure } from '@/shared/utils/errors';
 import { useTranslation } from '@/i18n';
 import { buildFullParams } from '../utils/buildFullParams';
 import {
@@ -111,9 +112,7 @@ export function useConnectorSampleExport(): UseConnectorSampleExportReturn {
         }
         return true;
       } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : 'Export failed';
-        useToastStore.getState().addToast(message, 'error');
-        return false;
+        return reportExportFailure(error);
       } finally {
         setIsExporting(false);
       }

--- a/src/features/baseplate/hooks/useStackSampleExport.ts
+++ b/src/features/baseplate/hooks/useStackSampleExport.ts
@@ -19,7 +19,7 @@ import { export3MF, buildSTLBuffer } from '@/shared/generation/export';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { isErr, getUserMessage } from '@/core/result';
 import { useToastStore } from '@/core/store/toast';
-import { reportExportFailure } from '@/shared/utils/errors';
+import { getErrorMessage } from '@/shared/utils/errors';
 import { useTranslation } from '@/i18n';
 import { buildFullParams } from '../utils/buildFullParams';
 import { buildStackExportSoup } from '../utils/stackExport';
@@ -115,7 +115,8 @@ export function useStackSampleExport(): UseStackSampleExportReturn {
         }
         return true;
       } catch (error: unknown) {
-        return reportExportFailure(error);
+        useToastStore.getState().addToast(getErrorMessage(error, 'Export failed'), 'error');
+        return false;
       } finally {
         setIsExporting(false);
       }

--- a/src/features/baseplate/hooks/useStackSampleExport.ts
+++ b/src/features/baseplate/hooks/useStackSampleExport.ts
@@ -19,6 +19,7 @@ import { export3MF, buildSTLBuffer } from '@/shared/generation/export';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { isErr, getUserMessage } from '@/core/result';
 import { useToastStore } from '@/core/store/toast';
+import { reportExportFailure } from '@/shared/utils/errors';
 import { useTranslation } from '@/i18n';
 import { buildFullParams } from '../utils/buildFullParams';
 import { buildStackExportSoup } from '../utils/stackExport';
@@ -114,9 +115,7 @@ export function useStackSampleExport(): UseStackSampleExportReturn {
         }
         return true;
       } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : 'Export failed';
-        useToastStore.getState().addToast(message, 'error');
-        return false;
+        return reportExportFailure(error);
       } finally {
         setIsExporting(false);
       }

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -32,6 +32,7 @@ import { getActiveBridge, bridgeManager } from '@/shared/generation/bridge';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
 import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
 import { getSplitPieceCount, getSplitPlanePositionsMm } from '@/shared/utils/splitPositions';
+import { getErrorCode } from '@/shared/utils/errors';
 import { packagePiecesAsZip } from '@/shared/generation/zipExport';
 import { triggerDownload } from '@/shared/generation/exportUtils';
 import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
@@ -230,8 +231,7 @@ export function useExport(): UseExportReturn {
       isSplit: boolean
     ) => {
       const error = err instanceof Error ? err : new Error(String(err));
-      const maybeCode = (error as unknown as { code?: unknown }).code;
-      const errorCode = typeof maybeCode === 'string' ? maybeCode : 'UNKNOWN';
+      const errorCode = getErrorCode(error) ?? 'UNKNOWN';
 
       trackBinExportFailure({
         ...buildExportTelemetry(format, durationMs, retryCount, restartCount, isSplit),

--- a/src/features/bin-designer/utils/exportWithResilience.ts
+++ b/src/features/bin-designer/utils/exportWithResilience.ts
@@ -22,6 +22,7 @@
 
 import { bridgeManager } from '@/shared/generation/bridge';
 import type { ExportErrorCode } from '@/shared/generation/bridge';
+import { getErrorCode } from '@/shared/utils/errors';
 
 /** Result wrapper that surfaces how many recovery attempts were needed. */
 export interface ResilientExportResult<T> {
@@ -52,8 +53,8 @@ function defaultIsRetryable(err: Error): boolean {
  * inspection so this works regardless of how the code arrives.
  */
 function extractErrorCode(err: Error): ExportErrorCode | undefined {
-  const maybe = (err as unknown as { code?: unknown }).code;
-  if (typeof maybe === 'string') return maybe as ExportErrorCode;
+  const code = getErrorCode(err);
+  if (code !== undefined) return code as ExportErrorCode;
   // Fallback: parse from message — the worker prepends "<phase> failed: <msg>"
   // and our classifier tags would surface as part of the original message.
   if (/invalid (param|argument)/i.test(err.message)) return 'INVALID_PARAMS';

--- a/src/shared/utils/errors.test.ts
+++ b/src/shared/utils/errors.test.ts
@@ -1,6 +1,5 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { getErrorCode, getErrorMessage, reportExportFailure } from './errors';
-import { useToastStore } from '@/core/store/toast';
+import { describe, expect, it } from 'vitest';
+import { getErrorCode, getErrorMessage } from './errors';
 
 describe('getErrorCode', () => {
   it('returns the code from an object with a string code', () => {
@@ -40,31 +39,5 @@ describe('getErrorMessage', () => {
   it('returns the fallback for a non-Error', () => {
     expect(getErrorMessage('nope', 'fallback')).toBe('fallback');
     expect(getErrorMessage(null, 'fallback')).toBe('fallback');
-  });
-});
-
-describe('reportExportFailure', () => {
-  beforeEach(() => {
-    useToastStore.setState({ toasts: [] });
-  });
-
-  it('returns false', () => {
-    expect(reportExportFailure(new Error('boom'))).toBe(false);
-  });
-
-  it('adds an error toast with the Error message', () => {
-    reportExportFailure(new Error('boom'));
-    const { toasts } = useToastStore.getState();
-    expect(toasts).toHaveLength(1);
-    expect(toasts[0].message).toBe('boom');
-    expect(toasts[0].type).toBe('error');
-  });
-
-  it("adds an error toast with the 'Export failed' fallback for a non-Error", () => {
-    reportExportFailure('nope');
-    const { toasts } = useToastStore.getState();
-    expect(toasts).toHaveLength(1);
-    expect(toasts[0].message).toBe('Export failed');
-    expect(toasts[0].type).toBe('error');
   });
 });

--- a/src/shared/utils/errors.test.ts
+++ b/src/shared/utils/errors.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getErrorCode, getErrorMessage, reportExportFailure } from './errors';
+import { useToastStore } from '@/core/store/toast';
+
+describe('getErrorCode', () => {
+  it('returns the code from an object with a string code', () => {
+    expect(getErrorCode({ code: 'INVALID_PARAMS' })).toBe('INVALID_PARAMS');
+  });
+
+  it('returns undefined for an object with a non-string code', () => {
+    expect(getErrorCode({ code: 42 })).toBeUndefined();
+    expect(getErrorCode({ code: null })).toBeUndefined();
+  });
+
+  it('returns the code off an Error subclass that carries one', () => {
+    const err = Object.assign(new Error('boom'), { code: 'EMPTY_GEOMETRY' });
+    expect(getErrorCode(err)).toBe('EMPTY_GEOMETRY');
+  });
+
+  it('returns undefined for null', () => {
+    expect(getErrorCode(null)).toBeUndefined();
+  });
+
+  it('returns undefined for a non-object', () => {
+    expect(getErrorCode('oops')).toBeUndefined();
+    expect(getErrorCode(7)).toBeUndefined();
+    expect(getErrorCode(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an object missing a code field', () => {
+    expect(getErrorCode({ message: 'no code here' })).toBeUndefined();
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('returns the message of an Error', () => {
+    expect(getErrorMessage(new Error('kaboom'), 'fallback')).toBe('kaboom');
+  });
+
+  it('returns the fallback for a non-Error', () => {
+    expect(getErrorMessage('nope', 'fallback')).toBe('fallback');
+    expect(getErrorMessage(null, 'fallback')).toBe('fallback');
+  });
+});
+
+describe('reportExportFailure', () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it('returns false', () => {
+    expect(reportExportFailure(new Error('boom'))).toBe(false);
+  });
+
+  it('adds an error toast with the Error message', () => {
+    reportExportFailure(new Error('boom'));
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toBe('boom');
+    expect(toasts[0].type).toBe('error');
+  });
+
+  it("adds an error toast with the 'Export failed' fallback for a non-Error", () => {
+    reportExportFailure('nope');
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].message).toBe('Export failed');
+    expect(toasts[0].type).toBe('error');
+  });
+});

--- a/src/shared/utils/errors.ts
+++ b/src/shared/utils/errors.ts
@@ -1,4 +1,8 @@
-import { useToastStore } from '@/core/store/toast';
+/**
+ * Pure helpers for working with caught `unknown` errors — no side effects and
+ * no store/UI coupling, so they're safe to re-export from the `@/shared/utils`
+ * barrel and import from core modules.
+ */
 
 /** Narrow a string `code` field off an unknown error without an unsafe cast. */
 export function getErrorCode(err: unknown): string | undefined {
@@ -9,12 +13,7 @@ export function getErrorCode(err: unknown): string | undefined {
   return undefined;
 }
 
+/** The error's message when it's an `Error`, else `fallback`. */
 export function getErrorMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
-}
-
-export function reportExportFailure(error: unknown): false {
-  const message = getErrorMessage(error, 'Export failed');
-  useToastStore.getState().addToast(message, 'error');
-  return false;
 }

--- a/src/shared/utils/errors.ts
+++ b/src/shared/utils/errors.ts
@@ -1,0 +1,20 @@
+import { useToastStore } from '@/core/store/toast';
+
+/** Narrow a string `code` field off an unknown error without an unsafe cast. */
+export function getErrorCode(err: unknown): string | undefined {
+  if (typeof err === 'object' && err !== null && 'code' in err) {
+    const code: unknown = err.code;
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
+export function getErrorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+export function reportExportFailure(error: unknown): false {
+  const message = getErrorMessage(error, 'Export failed');
+  useToastStore.getState().addToast(message, 'error');
+  return false;
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -65,3 +65,5 @@ export { snapPosition, snapGroupDelta, snapResizeRect, snapDrawRect, SNAP_RADIUS
 export type { SnapResult } from './snap';
 
 export { calculateResizeRect } from './resize';
+
+export { getErrorCode, getErrorMessage, reportExportFailure } from './errors';

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -66,4 +66,4 @@ export type { SnapResult } from './snap';
 
 export { calculateResizeRect } from './resize';
 
-export { getErrorCode, getErrorMessage, reportExportFailure } from './errors';
+export { getErrorCode, getErrorMessage } from './errors';


### PR DESCRIPTION
## What

Two tight, behavior-preserving cleanups from the tech-debt audit (deliberately **not** a broad 41-site sweep — that idiom is clear inline; this targets the genuine wins).

New `src/shared/utils/errors.ts` (+ barrel export, + 11 colocated tests):
- **`getErrorCode(err: unknown): string | undefined`** — narrows a string `code` field via `'code' in err`, **no cast**. Replaces the identical `(err as unknown as { code?: unknown }).code` **double-cast** in `exportWithResilience.ts` and `useExport.ts` (audit THEME 2).
- **`getErrorMessage(err, fallback)`** — `Error.message` else fallback.
- **`reportExportFailure(error): false`** — message + `'error'` toast + `return false`. Replaces the **byte-identical catch body** in the three baseplate export hooks (`useBaseplateExport`, `useStackSampleExport`, `useConnectorSampleExport`); their differing `finally` cleanup stays inline.

## Behavior parity (verified)
- `useExport`: `getErrorCode(error) ?? 'UNKNOWN'` == old `typeof === 'string' ? … : 'UNKNOWN'`.
- `exportWithResilience`: `code !== undefined` reached only for string codes (helper filters non-strings) == old guard; message-regex fallback unchanged.
- Baseplate hooks: identical message extraction, same `'error'` toast, same `false` return, `'Export failed'` fallback verbatim.

`@/shared/utils` → `@/core/store/toast` is within boundary rules (shared→core allowed, already precedented). Typecheck + ESLint clean; errors.test.ts (11) + affected export suites (51 + 8) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized error handling to remove unsafe casts and keep `@/shared/utils` pure. Export toasts are now inlined in hooks. No behavior changes.

- **Refactors**
  - Added `getErrorCode` and `getErrorMessage` in `@/shared/utils/errors` (+ barrel export). Removed `reportExportFailure`.
  - Replaced double-cast code reads in `useExport` and `exportWithResilience` with `getErrorCode`.
  - Updated `useBaseplateExport`, `useStackSampleExport`, `useConnectorSampleExport` to inline the toast and use `getErrorMessage` for the message (kept their `finally` logic).
  - Added tests for the helpers; affected suites remain green.

<sup>Written for commit b923512eff52f8eb544714a58d238f5733434bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

