### PR TITLE
refactor(types): split dual BaseplateParams into Stored/Resolved

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,7 +1,7 @@
 import type {
   Layout,
   Category,
-  BaseplateParams,
+  StoredBaseplateParams,
   PaddingAnchor,
   StackPrintParams,
   BinId,
@@ -253,7 +253,7 @@ export const OVER_TILE_MIN_MARGIN_MM = 8;
 export const MARGIN_MIN_DETACH_MM = OVER_TILE_MIN_MARGIN_MM;
 
 /** Default baseplate parameters: no magnets, no padding */
-export const DEFAULT_BASEPLATE_PARAMS: BaseplateParams = {
+export const DEFAULT_BASEPLATE_PARAMS: StoredBaseplateParams = {
   magnetHoles: false,
   magnetDiameter: mm(6.5),
   magnetDepth: mm(2),
@@ -269,7 +269,7 @@ export const DEFAULT_BASEPLATE_PARAMS: BaseplateParams = {
  * Returns DEFAULT_BASEPLATE_PARAMS if the stored data lacks paddingLeft,
  * preserving magnet settings when possible.
  */
-export function migrateBaseplateParams(stored: unknown): BaseplateParams {
+export function migrateBaseplateParams(stored: unknown): StoredBaseplateParams {
   if (!stored || typeof stored !== 'object') return DEFAULT_BASEPLATE_PARAMS;
   const obj = stored as Record<string, unknown>;
   // Current shape has paddingLeft — if missing, it's an old format

--- a/src/core/cqrs/commands/drawerCommands.ts
+++ b/src/core/cqrs/commands/drawerCommands.ts
@@ -3,7 +3,7 @@
  */
 
 import type { BaseCommand } from '../types';
-import type { Drawer, BaseplateParams } from '@/core/types';
+import type { Drawer, StoredBaseplateParams } from '@/core/types';
 
 export type UpdateDrawerCommand = BaseCommand<'drawer.update', Partial<Drawer>>;
 
@@ -20,7 +20,7 @@ export type SetHeightUnitMmCommand = BaseCommand<'layout.setHeightUnitMm', { rea
 
 export type SetBaseplateParamsCommand = BaseCommand<
   'layout.setBaseplateParams',
-  { readonly params: BaseplateParams }
+  { readonly params: StoredBaseplateParams }
 >;
 
 export type DrawerCommand =

--- a/src/core/cqrs/events/drawerEvents.ts
+++ b/src/core/cqrs/events/drawerEvents.ts
@@ -3,7 +3,7 @@
  */
 
 import type { BaseDomainEvent } from '../types';
-import type { BinId, Drawer, BaseplateParams } from '@/core/types';
+import type { BinId, Drawer, StoredBaseplateParams } from '@/core/types';
 
 // `displacedBinIds` records the exact set of bins displaced by a
 // drawer-shrink cascade. Optional only for back-compat with persisted
@@ -46,7 +46,7 @@ export type HeightUnitMmSetEvent = BaseDomainEvent<
 
 export type BaseplateParamsSetEvent = BaseDomainEvent<
   'layout.baseplateParamsSet',
-  { readonly params: BaseplateParams; readonly previousParams?: BaseplateParams }
+  { readonly params: StoredBaseplateParams; readonly previousParams?: StoredBaseplateParams }
 >;
 
 export type DrawerEvent =

--- a/src/core/cqrs/integration/mutationsAdapter.ts
+++ b/src/core/cqrs/integration/mutationsAdapter.ts
@@ -17,7 +17,7 @@ import type {
   Drawer,
   LayoutId,
   CloudShareInfo,
-  BaseplateParams,
+  StoredBaseplateParams,
 } from '@/core/types';
 import type { Result, ValidationError, LayoutError } from '@/core/result';
 import { ok, err, isOk } from '@/core/result';
@@ -167,7 +167,7 @@ export function createCqrsMutations(bus: CommandBus): Mutations {
       bus.dispatch(createCommand('layout.setHeightUnitMm', { mm }));
     },
 
-    setBaseplateParams(params: BaseplateParams): void {
+    setBaseplateParams(params: StoredBaseplateParams): void {
       bus.dispatch(createCommand('layout.setBaseplateParams', { params }));
     },
 

--- a/src/core/cqrs/v2/domain/layout/setBaseplateParams.test.ts
+++ b/src/core/cqrs/v2/domain/layout/setBaseplateParams.test.ts
@@ -1,26 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import { produce } from 'immer';
 import { isOk } from '@/core/result';
-import type { BaseplateParams } from '@/core/types';
+import type { StoredBaseplateParams } from '@/core/types';
 import { setBaseplateParams } from './setBaseplateParams';
 import { makeLayout } from './_testHelpers';
 
-const baseParams: BaseplateParams = {
+const baseParams: StoredBaseplateParams = {
   magnetHoles: false,
-  magnetDiameter: 6 as BaseplateParams['magnetDiameter'],
-  magnetDepth: 2 as BaseplateParams['magnetDepth'],
-  paddingLeft: 0 as BaseplateParams['paddingLeft'],
-  paddingRight: 0 as BaseplateParams['paddingRight'],
-  paddingFront: 0 as BaseplateParams['paddingFront'],
-  paddingBack: 0 as BaseplateParams['paddingBack'],
+  magnetDiameter: 6 as StoredBaseplateParams['magnetDiameter'],
+  magnetDepth: 2 as StoredBaseplateParams['magnetDepth'],
+  paddingLeft: 0 as StoredBaseplateParams['paddingLeft'],
+  paddingRight: 0 as StoredBaseplateParams['paddingRight'],
+  paddingFront: 0 as StoredBaseplateParams['paddingFront'],
+  paddingBack: 0 as StoredBaseplateParams['paddingBack'],
 };
 
 describe('v2 layout.setBaseplateParams', () => {
   it('clamps padding values to >= 0', () => {
     const layout = makeLayout();
-    const params: BaseplateParams = {
+    const params: StoredBaseplateParams = {
       ...baseParams,
-      paddingLeft: -5 as BaseplateParams['paddingLeft'],
+      paddingLeft: -5 as StoredBaseplateParams['paddingLeft'],
     };
     const result = setBaseplateParams.handle({ params }, { aggregate: layout });
     if (!isOk(result)) throw new Error('handle failed');
@@ -29,9 +29,9 @@ describe('v2 layout.setBaseplateParams', () => {
 
   it('clamps magnetDiameter to [0.5, 20]', () => {
     const layout = makeLayout();
-    const params: BaseplateParams = {
+    const params: StoredBaseplateParams = {
       ...baseParams,
-      magnetDiameter: 999 as BaseplateParams['magnetDiameter'],
+      magnetDiameter: 999 as StoredBaseplateParams['magnetDiameter'],
     };
     const result = setBaseplateParams.handle({ params }, { aggregate: layout });
     if (!isOk(result)) throw new Error('handle failed');
@@ -50,7 +50,7 @@ describe('v2 layout.setBaseplateParams', () => {
 
   it('preserves paddingAnchor through the handler', () => {
     const layout = makeLayout();
-    const params: BaseplateParams = { ...baseParams, paddingAnchor: 'tr' };
+    const params: StoredBaseplateParams = { ...baseParams, paddingAnchor: 'tr' };
     const result = setBaseplateParams.handle({ params }, { aggregate: layout });
     if (!isOk(result)) throw new Error('handle failed');
     expect(result.value.event.payload.params.paddingAnchor).toBe('tr');

--- a/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
+++ b/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
@@ -8,10 +8,10 @@
 import { z } from 'zod';
 import { ok } from '@/core/result';
 import { clamp } from '@/shared/utils/validation';
-import type { BaseplateParams, GridUnits, Mm } from '@/core/types';
+import type { StoredBaseplateParams, GridUnits, Mm } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 
-// BaseplateParams has many fields, most optional; the schema is permissive
+// StoredBaseplateParams has many fields, most optional; the schema is permissive
 // (passes shape through). Validation focuses on the required boolean +
 // numeric fields v1 always supplies.
 const payloadSchema = z.object({
@@ -62,7 +62,7 @@ export const setBaseplateParams = defineCommand({
       : undefined;
 
     const p = payload.params;
-    const params: BaseplateParams = {
+    const params: StoredBaseplateParams = {
       ...p,
       paddingLeft: Math.max(0, p.paddingLeft) as Mm,
       paddingRight: Math.max(0, p.paddingRight) as Mm,
@@ -76,7 +76,7 @@ export const setBaseplateParams = defineCommand({
       ...(p.baseplateDepth !== undefined
         ? { baseplateDepth: clamp(p.baseplateDepth, 0.5, 50) as GridUnits }
         : {}),
-    } as BaseplateParams;
+    } as StoredBaseplateParams;
 
     return ok({
       value: undefined,

--- a/src/core/store/layout/coreActions.ts
+++ b/src/core/store/layout/coreActions.ts
@@ -1,4 +1,4 @@
-import type { Layout, BaseplateParams, LayoutId, GridUnits, Mm } from '@/core/types';
+import type { Layout, StoredBaseplateParams, LayoutId, GridUnits, Mm } from '@/core/types';
 import { CONSTRAINTS, migrateBaseplateParams } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
 import type { EditSource, SetLocal, ImmerSet, GetState } from './types';
@@ -29,7 +29,7 @@ export function createCoreActions(setLocal: SetLocal, set: ImmerSet, _get: GetSt
       });
     },
 
-    setBaseplateParams: (params: BaseplateParams): void => {
+    setBaseplateParams: (params: StoredBaseplateParams): void => {
       setLocal((state) => {
         state.layout.baseplateParams = {
           ...params,

--- a/src/core/store/layout/types.ts
+++ b/src/core/store/layout/types.ts
@@ -1,6 +1,6 @@
 import type {
   Layout,
-  BaseplateParams,
+  StoredBaseplateParams,
   Bin,
   Layer,
   Category,
@@ -69,7 +69,7 @@ export interface LayoutState {
   setName: (name: string) => void;
 
   // Baseplate
-  setBaseplateParams: (params: BaseplateParams) => void;
+  setBaseplateParams: (params: StoredBaseplateParams) => void;
 
   setPrintBedSize: (size: number, depth?: number) => void;
   setGridUnitMm: (mm: number) => void;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -27,7 +27,7 @@ export interface Layout {
   layers: Layer[]; // 1-10 items, index 0 = bottom
   bins: Bin[];
   purpose?: string; // Optional drawer purpose (e.g., "workshop", "electronics")
-  baseplateParams?: BaseplateParams; // Per-layout baseplate configuration
+  baseplateParams?: StoredBaseplateParams; // Per-layout baseplate configuration
 }
 
 /** Nine-point padding distribution anchor. First letter = vertical (t/m/b),
@@ -78,11 +78,12 @@ export const STACK_PRINT_MAX_STACK_HEIGHT = 8;
 export const STACK_PRINT_MIN_GAP_MM = 0.1;
 export const STACK_PRINT_MAX_GAP_MM = 1.0;
 
-/** Baseplate generation parameters stored per-layout.
- * Width/depth/gridUnitMm are derived from the layout's drawer at generation time unless
- * syncWithLayout is false, in which case baseplateWidth/baseplateDepth override drawer dims.
- * Per-side padding in mm — user enters directly, total drawer = grid + padding. */
-export interface BaseplateParams {
+/** Stored (persisted) baseplate config saved per-layout.
+ * Padding is in mm; width/depth/gridUnitMm are NOT stored — they are derived from the
+ * layout's drawer at generation time unless syncWithLayout is false, in which case
+ * baseplateWidth/baseplateDepth override drawer dims. Bridged to the generation-time
+ * {@link ResolvedBaseplateParams} via buildFullParams. */
+export interface StoredBaseplateParams {
   readonly magnetHoles: boolean;
   readonly magnetDiameter: Mm;
   readonly magnetDepth: Mm;

--- a/src/features/baseplate/README.md
+++ b/src/features/baseplate/README.md
@@ -8,7 +8,7 @@ graph TB
         Sync[Layout drawer dims]
         Custom[Custom grid size]
     end
-    Input --> Params[BaseplateParams]
+    Input --> Params[ResolvedBaseplateParams]
     Params --> Tiling[splitPlanner]
     Tiling --> Direct[Direct mesh ~50ms]
     Direct --> Preview[3D Preview]

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -52,7 +52,7 @@ import {
   CONNECTOR_FIT_OFFSET_MAX,
   CONNECTOR_FIT_OFFSET_STEP,
 } from '@/shared/constants/connectors';
-import type { BaseplateParams } from '@/core/types';
+import type { StoredBaseplateParams } from '@/core/types';
 import { gridUnits, mm } from '@/core/types';
 
 /** How the drawer-fit padding margin is filled. */
@@ -127,13 +127,13 @@ export function BaseplatePanel() {
       .updateSetting('printSettings', { ...current, maxPrintHeightMm: value });
   }, []);
 
-  const updateParams = useCallback((patch: Partial<BaseplateParams>) => {
+  const updateParams = useCallback((patch: Partial<StoredBaseplateParams>) => {
     const current = useLayoutStore.getState().layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
     useLayoutStore.getState().setBaseplateParams({ ...current, ...patch });
   }, []);
 
   const updateParam = useCallback(
-    <K extends keyof BaseplateParams>(key: K, value: BaseplateParams[K]) => {
+    <K extends keyof StoredBaseplateParams>(key: K, value: StoredBaseplateParams[K]) => {
       updateParams({ [key]: value });
     },
     [updateParams]

--- a/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PaddingSchematic.tsx
@@ -2,19 +2,19 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from '@/i18n';
 import { PaddingStepper } from '../PaddingStepper';
 import { PaddingAnchor } from '../PaddingAnchor';
-import type { BaseplateParams, PaddingAnchor as PaddingAnchorValue } from '@/core/types';
+import type { StoredBaseplateParams, PaddingAnchor as PaddingAnchorValue } from '@/core/types';
 import { mm } from '@/core/types';
 import { computeAnchoredPaddings } from '@/features/baseplate/utils/computeAnchoredPaddings';
 
 type PaddingKey = 'paddingLeft' | 'paddingRight' | 'paddingFront' | 'paddingBack';
 
 interface PaddingSchematicProps {
-  readonly baseplateParams: BaseplateParams;
-  readonly updateParam: <K extends keyof BaseplateParams>(
+  readonly baseplateParams: StoredBaseplateParams;
+  readonly updateParam: <K extends keyof StoredBaseplateParams>(
     key: K,
-    value: BaseplateParams[K]
+    value: StoredBaseplateParams[K]
   ) => void;
-  readonly updateParams: (patch: Partial<BaseplateParams>) => void;
+  readonly updateParams: (patch: Partial<StoredBaseplateParams>) => void;
 }
 
 export function PaddingSchematic({

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -47,7 +47,7 @@ import { buildFullParams } from '../utils/buildFullParams';
 import { computeBaseplateTiling, bodyParamsForDetach } from '../utils/splitPlanner';
 import { shouldDeferBrepPreview } from '../utils/previewComplexity';
 import { groupPiecesByFingerprint } from '../utils/pieceFingerprint';
-import type { BaseplateParams as FullBaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { MarginMeshEntry, PieceMeshEntry } from '../store/baseplatePageStore';
 import type { GenerationResult } from '@/shared/generation/bridge';
 import type { BaseplateTiling } from '../types/tiling';
@@ -322,7 +322,7 @@ export function useBaseplateGeneration(): void {
    */
   const runDirectMeshPreview = useCallback(
     (
-      fullParams: FullBaseplateParams,
+      fullParams: ResolvedBaseplateParams,
       bedWidthMm: number,
       bedDepthMm: number,
       epoch: number,
@@ -411,7 +411,7 @@ export function useBaseplateGeneration(): void {
    */
   const runManifoldDraftPreview = useCallback(
     async (
-      fullParams: FullBaseplateParams,
+      fullParams: ResolvedBaseplateParams,
       tiling: BaseplateTiling,
       epoch: number
     ): Promise<boolean> => {
@@ -466,7 +466,7 @@ export function useBaseplateGeneration(): void {
    * a non-blocking retry message instead of replacing the preview.
    */
   const runBrepGeneration = useCallback(
-    async (fullParams: FullBaseplateParams, tiling: BaseplateTiling, epoch: number) => {
+    async (fullParams: ResolvedBaseplateParams, tiling: BaseplateTiling, epoch: number) => {
       const bridge = bridgeRef.current;
       if (!bridge || bridge.isDestroyed) return;
 
@@ -646,7 +646,7 @@ export function useBaseplateGeneration(): void {
    * and BREP kicks in once `bridgeManager.acquire()` resolves (mount effect).
    */
   const runGeneration = useCallback(
-    (fullParams: FullBaseplateParams, bedWidthMm: number, bedDepthMm: number) => {
+    (fullParams: ResolvedBaseplateParams, bedWidthMm: number, bedDepthMm: number) => {
       const epoch = ++generationEpochRef.current;
       // Track edit cadence on every regen, preview bridge or not, so a scrub
       // is recognized from its first rapid edit (see draftPolicy).

--- a/src/features/baseplate/utils/buildFullParams.ts
+++ b/src/features/baseplate/utils/buildFullParams.ts
@@ -4,21 +4,21 @@
  * With direct per-side padding, the conversion is a straightforward pass-through.
  */
 
-import type { BaseplateParams as CoreBaseplateParams } from '@/core/types';
-import type { BaseplateParams as FullBaseplateParams } from '@/shared/types/bin';
+import type { StoredBaseplateParams } from '@/core/types';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
 /**
  * Build full generation params from the stored per-layout config.
  */
 export function buildFullParams(
-  stored: CoreBaseplateParams,
+  stored: StoredBaseplateParams,
   drawerWidth: number,
   drawerDepth: number,
   gridUnitMm: number,
   fractionalEdgeX: 'start' | 'end',
   fractionalEdgeY: 'start' | 'end',
   nozzleSizeMm?: number
-): FullBaseplateParams {
+): ResolvedBaseplateParams {
   const synced = stored.syncWithLayout !== false;
   const width = synced ? drawerWidth : (stored.baseplateWidth ?? drawerWidth);
   const depth = synced ? drawerDepth : (stored.baseplateDepth ?? drawerDepth);

--- a/src/features/baseplate/utils/connectorKeys.test.ts
+++ b/src/features/baseplate/utils/connectorKeys.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { countConnectorKeys, computeSeamJunctions } from './connectorKeys';
 import { computeBaseplateTiling } from './splitPlanner';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
-function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+function makeParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
     width: 6,
     depth: 4,

--- a/src/features/baseplate/utils/connectorKeys.ts
+++ b/src/features/baseplate/utils/connectorKeys.ts
@@ -8,7 +8,7 @@
  * and the 3D preview never disagree.
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { BaseplateTiling } from '../types/tiling';
 
 /**
@@ -57,7 +57,7 @@ function interiorBoundaryOffsetsMm(
 }
 
 /** Styles that ship a separate part seated at every seam junction. */
-function hasSeatedConnector(params: BaseplateParams): boolean {
+function hasSeatedConnector(params: ResolvedBaseplateParams): boolean {
   return (
     params.connectorNubs === true &&
     (params.connectorStyle === 'dovetailKey' || params.connectorStyle === 'snapClip')
@@ -78,7 +78,7 @@ function hasSeatedConnector(params: BaseplateParams): boolean {
  */
 export function computeSeamJunctions(
   tiling: BaseplateTiling,
-  params: BaseplateParams
+  params: ResolvedBaseplateParams
 ): SeamJunction[] {
   if (!hasSeatedConnector(params)) return [];
 
@@ -115,6 +115,9 @@ export function computeSeamJunctions(
  * placements can never diverge. Returns 0 unless a seated-connector style
  * (dovetail key or snap clip) is active.
  */
-export function countConnectorKeys(tiling: BaseplateTiling, params: BaseplateParams): number {
+export function countConnectorKeys(
+  tiling: BaseplateTiling,
+  params: ResolvedBaseplateParams
+): number {
   return computeSeamJunctions(tiling, params).length;
 }

--- a/src/features/baseplate/utils/exportCache.test.ts
+++ b/src/features/baseplate/utils/exportCache.test.ts
@@ -8,9 +8,9 @@ import {
   clearExportCache,
   setExportCacheMaxBytesForTests,
 } from './exportCache';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
-const params = (over: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const params = (over: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 6,
   depth: 6,
   gridUnitMm: 42,
@@ -44,7 +44,7 @@ describe('buildExportCacheKey', () => {
   it('is stable for equal params regardless of key order', () => {
     const p = params({ width: 6, depth: 4 });
     // Same values, reversed property insertion order — stableStringify sorts keys.
-    const reordered = Object.fromEntries(Object.entries(p).reverse()) as BaseplateParams;
+    const reordered = Object.fromEntries(Object.entries(p).reverse()) as ResolvedBaseplateParams;
     expect(buildExportCacheKey(p, 'stl', 0.4)).toBe(buildExportCacheKey(reordered, 'stl', 0.4));
   });
 

--- a/src/features/baseplate/utils/exportCache.ts
+++ b/src/features/baseplate/utils/exportCache.ts
@@ -22,7 +22,7 @@
  */
 
 import { openDB, type IDBPDatabase } from 'idb';
-import type { BaseplateParams, ExportFileFormat } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams, ExportFileFormat } from '@/shared/types/bin';
 import { BASEPLATE_EXPORT_DB_NAME } from '@/core/storage/storageKeys';
 
 const DB_NAME = BASEPLATE_EXPORT_DB_NAME;
@@ -97,7 +97,7 @@ function stableStringify(value: unknown): string {
  * + session nozzle + the full param object that drives the worker output.
  */
 export function buildExportCacheKey(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: ExportFileFormat,
   nozzleSizeMm: number
 ): string {

--- a/src/features/baseplate/utils/fileNaming.ts
+++ b/src/features/baseplate/utils/fileNaming.ts
@@ -5,7 +5,11 @@
  * parameters and configuration.
  */
 
-import type { BaseplateParams, ExportFileNameConfig, ExportFileFormat } from '@/shared/types/bin';
+import type {
+  ResolvedBaseplateParams,
+  ExportFileNameConfig,
+  ExportFileFormat,
+} from '@/shared/types/bin';
 
 /** Characters not allowed in filenames (replaced with underscore) */
 // eslint-disable-next-line no-control-regex -- Intentionally matching control chars for filename sanitization
@@ -87,10 +91,10 @@ function collectFeatures(params: BaseplateNamingParams): string[] {
 }
 
 /**
- * Creates naming params from full BaseplateParams.
+ * Creates naming params from the resolved generation params.
  * Convenience adapter for the generation hook.
  */
-export function toNamingParams(params: BaseplateParams): BaseplateNamingParams {
+export function toNamingParams(params: ResolvedBaseplateParams): BaseplateNamingParams {
   return {
     width: params.width,
     depth: params.depth,

--- a/src/features/baseplate/utils/overTileStatus.test.ts
+++ b/src/features/baseplate/utils/overTileStatus.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { resolveOverTileStatus } from './overTileStatus';
 import { DEFAULT_BASEPLATE_PARAMS, OVER_TILE_MIN_MARGIN_MM } from '@/core/constants';
 import { mm } from '@/core/types';
-import type { BaseplateParams } from '@/core/types';
+import type { StoredBaseplateParams } from '@/core/types';
 
-const params = (o: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const params = (o: Partial<StoredBaseplateParams> = {}): StoredBaseplateParams => ({
   ...DEFAULT_BASEPLATE_PARAMS,
   ...o,
 });

--- a/src/features/baseplate/utils/overTileStatus.ts
+++ b/src/features/baseplate/utils/overTileStatus.ts
@@ -5,7 +5,7 @@
  * truth about what over-tile will produce.
  */
 import { OVER_TILE_MIN_MARGIN_MM } from '@/core/constants';
-import type { BaseplateParams } from '@/core/types';
+import type { StoredBaseplateParams } from '@/core/types';
 
 /** One padded edge, with its i18n label key (reuses the padding side labels). */
 export interface OverTileEdge {
@@ -26,7 +26,7 @@ export interface OverTileStatus {
   readonly canOverTile: boolean;
 }
 
-export function resolveOverTileStatus(params: BaseplateParams): OverTileStatus {
+export function resolveOverTileStatus(params: StoredBaseplateParams): OverTileStatus {
   const edges: OverTileEdge[] = [
     { labelKey: 'baseplate.paddingLeft', mm: params.paddingLeft },
     { labelKey: 'baseplate.paddingRight', mm: params.paddingRight },

--- a/src/features/baseplate/utils/pieceFingerprint.test.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { computePieceFingerprint, groupPiecesByFingerprint } from './pieceFingerprint';
 import { computeBaseplateTiling } from './splitPlanner';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
-function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+function makeParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
     width: 6,
     depth: 4,
@@ -418,7 +418,7 @@ describe('groupPiecesByFingerprint', () => {
 
     const cases: {
       name: string;
-      overrides: Partial<BaseplateParams>;
+      overrides: Partial<ResolvedBaseplateParams>;
       sameFingerprint: boolean;
     }[] = [
       {

--- a/src/features/baseplate/utils/pieceFingerprint.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.ts
@@ -2,11 +2,11 @@
  * Fingerprinting for baseplate split pieces.
  *
  * Computes a stable, deterministic string key from all geometry-affecting
- * BaseplateParams fields. Pieces with identical fingerprints produce
+ * ResolvedBaseplateParams fields. Pieces with identical fingerprints produce
  * byte-identical BREP output and can be cloned instead of regenerated.
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { exteriorCorners, type CornerKey } from '@/shared/generation/baseplateCorners';
 import type { BaseplatePiece } from '../types/tiling';
 import { pieceToBaseplateParams } from './splitPlanner';
@@ -17,7 +17,7 @@ import { pieceToBaseplateParams } from './splitPlanner';
  *
  * Uses `|` as field delimiter and `:` as key-value separator.
  * Field values must not contain these characters (safe for current
- * numeric, boolean, and short enum values in BaseplateParams).
+ * numeric, boolean, and short enum values in ResolvedBaseplateParams).
  *
  * Under `preferIdenticalPieces`, the edge classification is canonicalized so
  * pieces whose join/exterior layout is a 180° rotation of each other share a
@@ -25,7 +25,7 @@ import { pieceToBaseplateParams } from './splitPlanner';
  * itself 180° rotation invariant), this means A1 and C2 — and more generally
  * any opposite-corner pair in the tiling — produce the same canonical mesh.
  */
-export function computePieceFingerprint(params: BaseplateParams): string {
+export function computePieceFingerprint(params: ResolvedBaseplateParams): string {
   const parts = [
     `w:${params.width}`,
     `d:${params.depth}`,
@@ -103,8 +103,8 @@ export function computePieceFingerprint(params: BaseplateParams): string {
  * map to the same canonical string.
  */
 function canonicalizeEdges(
-  edges: NonNullable<BaseplateParams['edges']>
-): NonNullable<BaseplateParams['edges']> {
+  edges: NonNullable<ResolvedBaseplateParams['edges']>
+): NonNullable<ResolvedBaseplateParams['edges']> {
   const rotated = {
     left: edges.right,
     right: edges.left,
@@ -121,7 +121,7 @@ export interface PieceGroup {
   /** Indices into the original tiling.pieces array (mutable during grouping) */
   readonly indices: readonly number[];
   /** Generation params for this group (from first piece) */
-  readonly params: BaseplateParams;
+  readonly params: ResolvedBaseplateParams;
   /** The fingerprint key */
   readonly fingerprint: string;
 }
@@ -129,7 +129,7 @@ export interface PieceGroup {
 /** Mutable version used internally during grouping. */
 interface MutablePieceGroup {
   readonly indices: number[];
-  readonly params: BaseplateParams;
+  readonly params: ResolvedBaseplateParams;
   readonly fingerprint: string;
 }
 
@@ -137,12 +137,12 @@ interface MutablePieceGroup {
  * Group tiling pieces by their generation fingerprint.
  *
  * Returns a Map keyed by fingerprint string. Each value contains the
- * original piece indices that share that geometry, plus the BaseplateParams
+ * original piece indices that share that geometry, plus the ResolvedBaseplateParams
  * to use for generation (from the first piece in the group).
  */
 export function groupPiecesByFingerprint(
   pieces: readonly BaseplatePiece[],
-  parentParams: BaseplateParams
+  parentParams: ResolvedBaseplateParams
 ): Map<string, PieceGroup> {
   const groups = new Map<string, MutablePieceGroup>();
 

--- a/src/features/baseplate/utils/pieceNaming.test.ts
+++ b/src/features/baseplate/utils/pieceNaming.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { classifyPieceRole, assignGroupNames } from './pieceNaming';
 import { computeBaseplateTiling } from './splitPlanner';
 import { groupPiecesByFingerprint } from './pieceFingerprint';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
-function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+function makeParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
     width: 6,
     depth: 4,

--- a/src/features/baseplate/utils/previewComplexity.test.ts
+++ b/src/features/baseplate/utils/previewComplexity.test.ts
@@ -7,9 +7,9 @@ import {
   DEFER_LAST_BREP_MS,
 } from './previewComplexity';
 import { computeBaseplateTiling } from './splitPlanner';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
-function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+function makeParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
     width: 6,
     depth: 6,
@@ -27,7 +27,7 @@ function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
   };
 }
 
-const defer = (p: BaseplateParams, bed = 256, lastMs: number | null = null): boolean =>
+const defer = (p: ResolvedBaseplateParams, bed = 256, lastMs: number | null = null): boolean =>
   shouldDeferBrepPreview(computeBaseplateTiling(p, bed), p, lastMs);
 
 describe('estimatePreviewComplexity', () => {

--- a/src/features/baseplate/utils/previewComplexity.ts
+++ b/src/features/baseplate/utils/previewComplexity.ts
@@ -18,7 +18,7 @@
  * tilings whose total work is large — both captured below.
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { groupPiecesByFingerprint } from './pieceFingerprint';
 import type { BaseplateTiling } from '../types/tiling';
 
@@ -62,7 +62,7 @@ function pieceCells(widthUnits: number, depthUnits: number): number {
  */
 export function estimatePreviewComplexity(
   tiling: BaseplateTiling,
-  parentParams: BaseplateParams
+  parentParams: ResolvedBaseplateParams
 ): { maxPieceCells: number; totalCells: number } {
   const groups = groupPiecesByFingerprint(tiling.pieces, parentParams);
   let maxPieceCells = 0;
@@ -84,7 +84,7 @@ export function estimatePreviewComplexity(
  */
 export function shouldDeferBrepPreview(
   tiling: BaseplateTiling,
-  parentParams: BaseplateParams,
+  parentParams: ResolvedBaseplateParams,
   lastBrepMs: number | null
 ): boolean {
   if (!parentParams.magnetHoles) return false;

--- a/src/features/baseplate/utils/printGuide.test.ts
+++ b/src/features/baseplate/utils/printGuide.test.ts
@@ -4,9 +4,9 @@ import { computeBaseplateTiling } from './splitPlanner';
 import { groupPiecesByFingerprint } from './pieceFingerprint';
 import { assignGroupNames } from './pieceNaming';
 import { countConnectorKeys } from './connectorKeys';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
-function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+function makeParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
     width: 6,
     depth: 4,
@@ -25,9 +25,9 @@ function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
 }
 
 function buildGuide(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   printBed = 256,
-  stackPrint?: BaseplateParams['stackPrint']
+  stackPrint?: ResolvedBaseplateParams['stackPrint']
 ) {
   const tiling = computeBaseplateTiling(params, printBed);
   const groups = groupPiecesByFingerprint(tiling.pieces, params);

--- a/src/features/baseplate/utils/printGuide.ts
+++ b/src/features/baseplate/utils/printGuide.ts
@@ -7,7 +7,7 @@
  * - ASCII grid map: visual assembly layout, front at bottom
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { StackPrintParams } from '@/core/types';
 import type { BaseplatePiece, BaseplateTiling } from '../types/tiling';
 import type { PieceGroup } from './pieceFingerprint';
@@ -30,7 +30,7 @@ export interface PrintGuideInput {
   readonly tiling: BaseplateTiling;
   readonly groups: Map<string, PieceGroup>;
   readonly groupNames: Map<string, string>;
-  readonly parentParams: BaseplateParams;
+  readonly parentParams: ResolvedBaseplateParams;
   readonly fileExtension: string;
   readonly baseFileName: string;
   /** Dovetail key part, when present — printed `count` times. */
@@ -202,7 +202,7 @@ function buildEasierSeparation(gap: number): string[] {
 
 function generateConnectorKeySection(
   key: { fileName: string; count: number },
-  params: BaseplateParams
+  params: ResolvedBaseplateParams
 ): string {
   const copyText = key.count === 1 ? 'Print 1 copy' : `Print ${key.count} copies`;
   const offset = params.connectorFitOffset ?? 0;
@@ -255,7 +255,7 @@ function formatSignedMm(value: number): string {
 
 function generateHeader(
   tiling: BaseplateTiling,
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   uniqueCount: number
 ): string {
   const features: string[] = [];
@@ -313,7 +313,7 @@ function generateHeader(
 function generatePieceTable(
   groups: Map<string, PieceGroup>,
   names: Map<string, string>,
-  parentParams: BaseplateParams,
+  parentParams: ResolvedBaseplateParams,
   pieces: readonly BaseplatePiece[],
   ext: string,
   baseName: string,

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -8,11 +8,11 @@ import {
 import { bodyCenterYMm } from './stackPrint';
 import { TONGUE_PROTRUSION } from '@/features/generation/worker/generators/generatorConstants';
 import { computeConnectorPositions } from '@/features/generation/worker/generators/connectorUtils';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
-function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+function makeParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
     width: 6,
     depth: 4,
@@ -31,7 +31,7 @@ function makeParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
 }
 
 /** Helper to get piece widths in column order for a single row. */
-function colWidths(params: BaseplateParams, printBed = 256): number[] {
+function colWidths(params: ResolvedBaseplateParams, printBed = 256): number[] {
   const tiling = computeBaseplateTiling(params, printBed);
   return tiling.pieces
     .filter((p) => p.row === 0)
@@ -40,7 +40,7 @@ function colWidths(params: BaseplateParams, printBed = 256): number[] {
 }
 
 /** Helper to get piece depths in row order for a single column. */
-function rowDepths(params: BaseplateParams, printBed = 256): number[] {
+function rowDepths(params: ResolvedBaseplateParams, printBed = 256): number[] {
   const tiling = computeBaseplateTiling(params, printBed);
   return tiling.pieces
     .filter((p) => p.col === 0)
@@ -1200,7 +1200,7 @@ describe('preferIdenticalPieces × fractional dimensions — dovetail alignment 
    */
   it('aligns connectors across every shared join edge for 9.5×9.5', () => {
     const G = 42;
-    const parent: BaseplateParams = {
+    const parent: ResolvedBaseplateParams = {
       width: 9.5,
       depth: 9.5,
       gridUnitMm: G,
@@ -1300,7 +1300,7 @@ describe('detachMargins emits margin rails', () => {
   const gridD = D * U; // 126
   const P = 10; // ≥ MARGIN_MIN_DETACH_MM (8)
 
-  function margins(overrides: Partial<BaseplateParams>) {
+  function margins(overrides: Partial<ResolvedBaseplateParams>) {
     return computeBaseplateTiling(makeParams({ width: W, depth: D, ...overrides }), 256).margins;
   }
   function bySide(ms: ReturnType<typeof margins>, side: string) {

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -16,7 +16,7 @@
  * fit, otherwise become a separate piece.
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 // The fit checker subtracts the tongue protrusion from the bed budget on male
 // join edges — otherwise pieces that compute to exactly the bed width on paper
 // exceed it as STLs (#1498).
@@ -455,7 +455,7 @@ function computePaddingReductionHint(
 }
 
 /** Which sides detach into rails: padding ≥ threshold and the flag is on. */
-function detachedSides(params: BaseplateParams): {
+function detachedSides(params: ResolvedBaseplateParams): {
   left: boolean;
   right: boolean;
   front: boolean;
@@ -479,7 +479,7 @@ type CornerRadii = { tl: number; tr: number; bl: number; br: number };
  * curving away from the rail). A corner squares when either adjacent side detaches.
  */
 function squaredBodyCornerRadii(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   det: { left: boolean; right: boolean; front: boolean; back: boolean }
 ): CornerRadii {
   const base = (corner: keyof CornerRadii): number =>
@@ -500,7 +500,7 @@ function squaredBodyCornerRadii(
  * mesh only, AFTER `computeBaseplateTiling`/`emitMargins` (which need the true
  * padding).
  */
-export function bodyParamsForDetach(params: BaseplateParams): BaseplateParams {
+export function bodyParamsForDetach(params: ResolvedBaseplateParams): ResolvedBaseplateParams {
   if (!params.detachMargins) return params;
   const det = detachedSides(params);
   if (!det.left && !det.right && !det.front && !det.back) return params;
@@ -539,7 +539,7 @@ interface MarginLayout {
  * World positions are in the plate-centered, padding-free body frame (mm) so they
  * line up with how the preview/export place the body pieces.
  */
-function emitMargins(params: BaseplateParams, layout: MarginLayout): MarginPiece[] {
+function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): MarginPiece[] {
   if (!params.detachMargins) return [];
   const det = detachedSides(params);
   if (!det.left && !det.right && !det.front && !det.back) return [];
@@ -694,7 +694,7 @@ function emitMargins(params: BaseplateParams, layout: MarginLayout): MarginPiece
  * `isSplit: false`.
  */
 export function computeBaseplateTiling(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   printBedWidthMm: number,
   printBedDepthMm: number = printBedWidthMm
 ): BaseplateTiling {
@@ -851,8 +851,8 @@ export function computeBaseplateTiling(
  */
 export function pieceToBaseplateParams(
   piece: BaseplatePiece,
-  parentParams: BaseplateParams
-): BaseplateParams {
+  parentParams: ResolvedBaseplateParams
+): ResolvedBaseplateParams {
   // Default fractionalEdge to 'end' when this piece has no fraction.
   const fracX: 'start' | 'end' = piece.fractionalEdgeX === 'none' ? 'end' : piece.fractionalEdgeX;
   const fracY: 'start' | 'end' = piece.fractionalEdgeY === 'none' ? 'end' : piece.fractionalEdgeY;

--- a/src/features/baseplate/utils/stackGrouping.test.ts
+++ b/src/features/baseplate/utils/stackGrouping.test.ts
@@ -3,17 +3,17 @@ import { computeBaseplateTiling } from './splitPlanner';
 import { buildFullParams } from './buildFullParams';
 import { stackGroupsFromTiling, planPhysicalStacks } from './stackPrint';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
-import type { BaseplateParams as CoreBaseplateParams } from '@/core/types';
+import type { StoredBaseplateParams } from '@/core/types';
 
 /** Resolve groups + physical stacks for a drawer split on a given bed. */
-function plan(stored: CoreBaseplateParams, units: number, bedMm: number) {
+function plan(stored: StoredBaseplateParams, units: number, bedMm: number) {
   const full = buildFullParams(stored, units, units, 42, 'end', 'end');
   const tiling = computeBaseplateTiling(full, bedMm);
   const groups = stackGroupsFromTiling(tiling, full);
   return { tiling, groups, towers: planPhysicalStacks(groups) };
 }
 
-const stacking: CoreBaseplateParams = {
+const stacking: StoredBaseplateParams = {
   ...DEFAULT_BASEPLATE_PARAMS,
   stackPrint: { enabled: true, gapMm: 0.2 as never },
 };
@@ -36,7 +36,7 @@ describe('stack-print grouping', () => {
   });
 
   it('retains dovetail connectors while stacking; preferIdenticalPieces shrinks the group count', () => {
-    const connectored: CoreBaseplateParams = {
+    const connectored: StoredBaseplateParams = {
       ...DEFAULT_BASEPLATE_PARAMS,
       connectorNubs: true, // dovetail (default style) — kept while stacking now
       stackPrint: { enabled: true, gapMm: 0.2 as never },

--- a/src/features/baseplate/utils/stackPrint.ts
+++ b/src/features/baseplate/utils/stackPrint.ts
@@ -5,7 +5,7 @@
 
 import type { StackPrintParams } from '@/core/types';
 import { STACK_PRINT_MAX_STACK_HEIGHT } from '@/core/types';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { BaseplateTiling } from '../types/tiling';
 import { groupPiecesByFingerprint } from './pieceFingerprint';
 
@@ -132,7 +132,7 @@ export function evaluateStackPrint(
  */
 export function stackGroupsFromTiling(
   tiling: BaseplateTiling | null,
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   copies = 1
 ): StackGroup[] {
   const n = Math.max(1, Math.floor(copies));

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -19,7 +19,7 @@
 
 import type {
   BinParams,
-  BaseplateParams,
+  ResolvedBaseplateParams,
   SplitConnectorConfig,
   MarginPiece,
 } from '@/shared/types/bin';
@@ -405,7 +405,7 @@ export class GenerationBridge {
   }
 
   generateBaseplate(
-    params: BaseplateParams,
+    params: ResolvedBaseplateParams,
     onProgress?: ProgressCallback
   ): Promise<GenerationResult> {
     return generateBaseplateImpl(this, params, onProgress, true);
@@ -413,19 +413,19 @@ export class GenerationBridge {
 
   /** Used by the worker pool for parallel split piece generation. */
   generateBaseplateImmediate(
-    params: BaseplateParams,
+    params: ResolvedBaseplateParams,
     onProgress?: ProgressCallback
   ): Promise<GenerationResult> {
     return generateBaseplateImpl(this, params, onProgress, false);
   }
 
   /** Generate one detached margin rail (issue #2392). */
-  generateMargin(params: BaseplateParams, margin: MarginPiece): Promise<GenerationResult> {
+  generateMargin(params: ResolvedBaseplateParams, margin: MarginPiece): Promise<GenerationResult> {
     return generateMarginImpl(this, params, margin);
   }
 
   exportBaseplate(
-    params: BaseplateParams,
+    params: ResolvedBaseplateParams,
     format: ExportFormat,
     options?: { tolerance?: number; angularTolerance?: number }
   ): Promise<BaseplateExportResult> {
@@ -454,7 +454,7 @@ export class GenerationBridge {
   }
 
   exportConnectorKey(
-    params: BaseplateParams,
+    params: ResolvedBaseplateParams,
     format: ExportFormat,
     options?: { tolerance?: number; angularTolerance?: number }
   ): Promise<BaseplateExportResult> {
@@ -463,7 +463,7 @@ export class GenerationBridge {
 
   /** Export one detached margin rail (issue #2392). */
   exportMargin(
-    params: BaseplateParams,
+    params: ResolvedBaseplateParams,
     margin: MarginPiece,
     format: ExportFormat,
     options?: { tolerance?: number; angularTolerance?: number }
@@ -472,7 +472,7 @@ export class GenerationBridge {
   }
 
   exportConnectorSample(
-    params: BaseplateParams,
+    params: ResolvedBaseplateParams,
     format: ExportFormat,
     options?: { tolerance?: number; angularTolerance?: number }
   ): Promise<BaseplateExportResult> {

--- a/src/features/generation/bridge/WorkerPool.ts
+++ b/src/features/generation/bridge/WorkerPool.ts
@@ -18,7 +18,7 @@
 
 import { GenerationBridge } from './GenerationBridge';
 import type { GenerationResult, SplitPreviewResult, SplitExportResult } from './GenerationBridge';
-import type { BinParams, BaseplateParams, SplitConnectorConfig } from '@/shared/types/bin';
+import type { BinParams, ResolvedBaseplateParams, SplitConnectorConfig } from '@/shared/types/bin';
 import type { ExportFormat, KernelName } from './types';
 
 /** Maximum number of pool workers (caps memory usage from parallel WASM instances) */
@@ -218,7 +218,7 @@ export class WorkerPool {
    * Distributes pieces round-robin and returns results in original order.
    */
   async generateBaseplates(
-    pieces: readonly BaseplateParams[],
+    pieces: readonly ResolvedBaseplateParams[],
     onProgress?: (completed: number, total: number) => void,
     signal?: AbortSignal
   ): Promise<GenerationResult[]> {
@@ -254,7 +254,7 @@ export class WorkerPool {
    * Same round-robin dispatch as generateBaseplates.
    */
   async exportBaseplates(
-    pieces: readonly BaseplateParams[],
+    pieces: readonly ResolvedBaseplateParams[],
     format: ExportFormat,
     onProgress?: (completed: number, total: number) => void,
     signal?: AbortSignal

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -10,7 +10,7 @@
 
 import type {
   BinParams,
-  BaseplateParams,
+  ResolvedBaseplateParams,
   SplitConnectorConfig,
   MarginPiece,
 } from '@/shared/types/bin';
@@ -254,7 +254,7 @@ export function exportSplitBinRange(
 
 export function exportBaseplate(
   ctx: BridgeExportContext,
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: ExportFormat,
   options?: { tolerance?: number; angularTolerance?: number }
 ): Promise<BaseplateExportResult> {
@@ -303,7 +303,7 @@ export function exportItem(
  */
 export function exportConnectorKey(
   ctx: BridgeExportContext,
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: ExportFormat,
   options?: { tolerance?: number; angularTolerance?: number }
 ): Promise<BaseplateExportResult> {
@@ -330,7 +330,7 @@ export function exportConnectorKey(
  */
 export function exportMargin(
   ctx: BridgeExportContext,
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   margin: MarginPiece,
   format: ExportFormat,
   options?: { tolerance?: number; angularTolerance?: number }
@@ -365,7 +365,7 @@ const CONNECTOR_SAMPLE_TIMEOUT_MS = EXPORT_MAX_TIMEOUT_MS;
 
 export function exportConnectorSample(
   ctx: BridgeExportContext,
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: ExportFormat,
   options?: { tolerance?: number; angularTolerance?: number }
 ): Promise<BaseplateExportResult> {

--- a/src/features/generation/bridge/bridgeGeneration.ts
+++ b/src/features/generation/bridge/bridgeGeneration.ts
@@ -13,7 +13,7 @@
  * of the private fields it needs to mutate.
  */
 
-import type { BinParams, BaseplateParams, MarginPiece } from '@/shared/types/bin';
+import type { BinParams, ResolvedBaseplateParams, MarginPiece } from '@/shared/types/bin';
 import type { GridfinityItem } from '@/shared/types/item';
 import type { WorkerMessage } from './types';
 import type { AdaptiveDebounce } from './adaptiveDebounce';
@@ -131,7 +131,7 @@ export function generateBin(
 
 export function generateBaseplate(
   ctx: BridgeGenerationContext,
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   onProgress: ProgressCallback | undefined,
   debounce: boolean
 ): Promise<GenerationResult> {
@@ -185,7 +185,7 @@ export function generateBaseplate(
  */
 export function generateMargin(
   ctx: BridgeGenerationContext,
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   margin: MarginPiece
 ): Promise<GenerationResult> {
   if (ctx.isDestroyed) {

--- a/src/features/generation/bridge/generationTimeout.test.ts
+++ b/src/features/generation/bridge/generationTimeout.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
-import type { BaseplateParams, BinParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams, BinParams } from '@/shared/types/bin';
 import {
   BASE_TIMEOUT_MS,
   BASEPLATE_CONNECTOR_BONUS_MS,
@@ -28,7 +28,7 @@ function params(overrides: Partial<BinParams> = {}): BinParams {
   return { ...DEFAULT_BIN_PARAMS, ...overrides };
 }
 
-function bpParams(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+function bpParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   // lightweight defaults to `false` here so base-case assertions aren't
   // polluted by the implicit "undefined = on" bonus. Tests that care about
   // the lightweight bonus opt in explicitly.

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -10,7 +10,7 @@
  * capped so a runaway WASM loop can't hang the UI forever.
  */
 
-import type { BaseplateParams, BinParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams, BinParams } from '@/shared/types/bin';
 
 /** Minimum timeout for trivial bins (no heavy features). */
 export const BASE_TIMEOUT_MS = 30_000;
@@ -216,7 +216,7 @@ export const BASEPLATE_MAX_TIMEOUT_MS = 180_000;
  * + BASEPLATE_CONNECTOR_BONUS_MS  [if connectorNubs]
  * + BASEPLATE_LIGHTWEIGHT_BONUS_MS  [if lightweight]
  */
-function baseplateRawBudgetMs(params: BaseplateParams): number {
+function baseplateRawBudgetMs(params: ResolvedBaseplateParams): number {
   // Defensive against transient bad inputs — mid-edit UI state can briefly
   // present NaN/negative dimensions. The generator's sanitizeParams will
   // reject them, but the bridge computes this timeout first and setTimeout
@@ -248,7 +248,7 @@ function baseplateRawBudgetMs(params: BaseplateParams): number {
  * Compute the timeout budget for a live baseplate **preview** generation, in
  * milliseconds. Clamped to `[BASE_TIMEOUT_MS, BASEPLATE_MAX_TIMEOUT_MS]`.
  */
-export function computeBaseplateTimeoutMs(params: BaseplateParams): number {
+export function computeBaseplateTimeoutMs(params: ResolvedBaseplateParams): number {
   // The raw budget is finite by construction (guards in baseplateRawBudgetMs),
   // so this clamp also makes the documented contract self-enforcing.
   return Math.max(
@@ -263,7 +263,7 @@ export function computeBaseplateTimeoutMs(params: BaseplateParams): number {
  * {@link EXPORT_TIMEOUT_MULTIPLIER} for slower user hardware and clamped to
  * `[BASE_TIMEOUT_MS, EXPORT_MAX_TIMEOUT_MS]`.
  */
-export function computeBaseplateExportTimeoutMs(params: BaseplateParams): number {
+export function computeBaseplateExportTimeoutMs(params: ResolvedBaseplateParams): number {
   const scaled = baseplateRawBudgetMs(params) * EXPORT_TIMEOUT_MULTIPLIER;
   return Math.max(BASE_TIMEOUT_MS, Math.min(EXPORT_MAX_TIMEOUT_MS, scaled));
 }

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -7,7 +7,7 @@
 
 import type {
   BinParams,
-  BaseplateParams,
+  ResolvedBaseplateParams,
   SplitConnectorConfig,
   MarginPiece,
 } from '@/shared/types/bin';
@@ -111,7 +111,7 @@ export interface GenerateBaseplateMessage {
 }
 
 export interface GenerateBaseplatePayload {
-  readonly params: BaseplateParams;
+  readonly params: ResolvedBaseplateParams;
   readonly requestId: string;
 }
 
@@ -123,7 +123,7 @@ export interface GenerateBaseplateMarginMessage {
 }
 
 export interface GenerateBaseplateMarginPayload {
-  readonly params: BaseplateParams;
+  readonly params: ResolvedBaseplateParams;
   readonly margin: MarginPiece;
   readonly requestId: string;
 }
@@ -163,7 +163,7 @@ export interface ExportBaseplateMessage {
 }
 
 export interface ExportBaseplatePayload {
-  readonly params: BaseplateParams;
+  readonly params: ResolvedBaseplateParams;
   readonly requestId: string;
   readonly format: ExportFormat;
   readonly tolerance?: number;
@@ -189,7 +189,7 @@ export interface ExportBaseplateMarginMessage {
 }
 
 export interface ExportBaseplateMarginPayload {
-  readonly params: BaseplateParams;
+  readonly params: ResolvedBaseplateParams;
   readonly margin: MarginPiece;
   readonly requestId: string;
   readonly format: ExportFormat;

--- a/src/features/generation/worker/generators/__kernel-tests__/diagnoseBaseplateWinding.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/diagnoseBaseplateWinding.test.ts
@@ -34,7 +34,7 @@
 import { test, beforeAll, beforeEach } from 'vitest';
 import { mesh } from 'brepjs';
 import type { Shape3D } from 'brepjs';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { initBrepjs } from './wasmInit';
 import {
   buildBaseplateSolid,
@@ -112,7 +112,7 @@ function measureStep(label: string, shape: Shape3D): StepMetrics {
   };
 }
 
-function defaults(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
+function defaults(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
     width: 4.5,
     depth: 4.5,
@@ -133,7 +133,7 @@ function defaults(overrides: Partial<BaseplateParams> = {}): BaseplateParams {
 
 interface NamedConfig {
   readonly name: string;
-  readonly params: BaseplateParams;
+  readonly params: ResolvedBaseplateParams;
 }
 
 // Mirror the configs covered by the existing scenario winding test plus the

--- a/src/features/generation/worker/generators/__kernel-tests__/profileBin.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/profileBin.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { initBrepjs, getGenerateBin, getGenerateBaseplate, getKernelName } from './wasmInit';
 import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
-import type { BinParams, BaseplateParams } from '@/shared/types/bin';
+import type { BinParams, ResolvedBaseplateParams } from '@/shared/types/bin';
 
 interface ProfileEntry {
   readonly name: string;
@@ -51,7 +51,7 @@ function runBin(name: string, overrides: Partial<BinParams>, forExport = false):
   expect(result.triangleCount).toBeGreaterThan(0);
 }
 
-function runBaseplate(name: string, params: BaseplateParams, forExport = false): void {
+function runBaseplate(name: string, params: ResolvedBaseplateParams, forExport = false): void {
   const gen = getGenerateBaseplate();
   const start = performance.now();
   const result = gen(params, () => {}, forExport);
@@ -213,7 +213,7 @@ describe(`profile bins (${getKernelName()})`, () => {
 });
 
 describe(`profile baseplates (${getKernelName()})`, () => {
-  const BASE_PLATE: BaseplateParams = {
+  const BASE_PLATE: ResolvedBaseplateParams = {
     width: 2,
     depth: 2,
     gridUnitMm: 42,

--- a/src/features/generation/worker/generators/__kernel-tests__/wasmInit.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/wasmInit.ts
@@ -15,7 +15,7 @@
  * and gets imported by app-config-included scenario files. Without it, tsc
  * fails the app build because tsconfig.app.json doesn't include node types.
  */
-import type { BaseplateParams, BinParams, SplitConnectorConfig } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams, BinParams, SplitConnectorConfig } from '@/shared/types/bin';
 import type { MeshData } from '@/features/generation/bridge/types';
 
 // ─── Kernel selection ────────────────────────────────────────────────────────
@@ -58,7 +58,7 @@ export type GenerateBinFn = (
 // ─── Baseplate generation ────────────────────────────────────────────────────
 
 export type GenerateBaseplateFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   onProgress: (stage: string, progress: number) => void,
   forExport: boolean,
   signal?: AbortSignal,

--- a/src/features/generation/worker/generators/baseplateCacheKeys.test.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { meshCacheKey } from './baseplateCacheKeys';
 
-const base = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const base = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 4,
   depth: 4,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateCacheKeys.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.ts
@@ -11,7 +11,7 @@
  * after the cached intermediate, so toggling them reuses this cache.
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { NOZZLE_BASELINE } from '@/shared/printSettings/connectorScaling';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import {
@@ -22,7 +22,7 @@ import {
 } from './generatorConstants';
 
 export function meshCacheKey(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   forExport: boolean,
   draft: boolean = false
 ): string {
@@ -94,7 +94,7 @@ export function meshCacheKey(
   );
 }
 
-export function slabPocketsCacheKey(params: BaseplateParams, forExport: boolean): string {
+export function slabPocketsCacheKey(params: ResolvedBaseplateParams, forExport: boolean): string {
   return buildCacheKey(
     'v1',
     quantize(params.width),

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -34,7 +34,7 @@
 
 import { draw, rotate, translate, intersect, cutAll, clone } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing } from 'brepjs';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk, unwrap } from '@/core/result';
 import {
   TONGUE_PROTRUSION,
@@ -162,7 +162,7 @@ function relieveTongueForSockets(
 }
 
 export function buildConnectors(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   totalHeight: number,
   totalW: number,
   totalD: number,

--- a/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { pocketCornerRadius } from './generatorConstants';
 import { initTestKernel } from '@/test/initTestKernel';
 
 // BREP generator requires OpenCascade WASM init
 type BrepGenerateFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   onProgress: (stage: string, progress: number) => void,
   forExport: boolean,
   signal?: AbortSignal
@@ -19,7 +19,7 @@ type BrepGenerateFn = (
 
 // Direct mesh generator — pure TypeScript, no WASM
 type DirectGenerateFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   onProgress: (stage: string, progress: number) => void,
   signal?: AbortSignal
 ) => {
@@ -42,7 +42,7 @@ beforeAll(async () => {
   generateDirect = direct.generateBaseplateDirect;
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateDirectMesh.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.ts
@@ -24,7 +24,7 @@
  * shapes, builder, walls, faces, magnets, connectors.
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { CONSTRAINTS } from '@/core/constants';
 import { resolveCornerRadii } from './generatorConstants';
 import { creaseEdges } from './utils';
@@ -58,7 +58,7 @@ import { addConnectorNub, addConnectorHole } from './directMeshConnectors';
  * solid floor, and a rounded outer perimeter. Targets <50ms for any grid size.
  */
 export function generateBaseplateDirect(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   onProgress: ProgressFn,
   signal?: AbortSignal
 ): MeshData {

--- a/src/features/generation/worker/generators/baseplateGenerator.bench.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.bench.ts
@@ -13,7 +13,7 @@
  * real BREP + tessellation work on every iteration.
  */
 import { bench, describe, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
 import { clearBaseplateCaches } from './baseplateCaches';
 
@@ -24,7 +24,7 @@ const noop = (): void => {};
 // which changes the cache key but has negligible effect on geometry.
 let callCounter = 0;
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.draft.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.draft.test.ts
@@ -9,13 +9,13 @@
  * draft removes geometry on magnet plates and is a no-op without magnets.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
 import { clearBaseplateCaches } from './baseplateCaches';
 
 const noop = (): void => {};
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 4,
   depth: 4,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.dovetail.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.dovetail.test.ts
@@ -18,14 +18,14 @@
  * that most stress the dovetail fuse path.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { TONGUE_PROTRUSION } from './generatorConstants';
 
 type ExportFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: 'stl'
 ) => Promise<{ data: ArrayBuffer; fileName: string }>;
 
@@ -37,7 +37,7 @@ beforeAll(async () => {
   exportBaseplate = mod.exportBaseplate;
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.dovetailKey.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.dovetailKey.test.ts
@@ -11,14 +11,14 @@
  *      footprint — narrow waist at the seam, wide wings, key length = 2×P.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { TONGUE_PROTRUSION, TONGUE_BASE_HALF, TONGUE_TIP_HALF } from './generatorConstants';
 
 type ExportFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: 'stl'
 ) => Promise<{ data: ArrayBuffer; fileName: string }>;
 
@@ -32,7 +32,7 @@ beforeAll(async () => {
   exportConnectorKey = mod.exportConnectorKey;
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.fit-offset.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.fit-offset.test.ts
@@ -15,13 +15,13 @@
  *    2-manifold STL (geometry stays valid — no NaN, no boundary edges).
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 
 type ExportFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: 'stl'
 ) => Promise<{ data: ArrayBuffer; fileName: string }>;
 
@@ -33,7 +33,7 @@ beforeAll(async () => {
   exportBaseplate = mod.exportBaseplate;
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 4,
   depth: 4,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.overhangAudit.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.overhangAudit.test.ts
@@ -10,13 +10,13 @@
  * vertical AND it sits above the bed (bed-contact faces are supported).
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 
 type ExportFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: 'stl'
 ) => Promise<{ data: ArrayBuffer; fileName: string }>;
 
@@ -28,7 +28,7 @@ beforeAll(async () => {
   exportBaseplate = mod.exportBaseplate;
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,
@@ -112,7 +112,7 @@ function analyze(vertices: Float32Array, flip: boolean): OrientStats {
 const pct = (a: number, b: number): string => `${((100 * a) / b).toFixed(1)}%`;
 
 describe('stack-print overhang audit (upside-down printability)', () => {
-  const configs: { name: string; params: BaseplateParams }[] = [
+  const configs: { name: string; params: ResolvedBaseplateParams }[] = [
     { name: 'lightweight, no magnets', params: defaults() },
     { name: 'solid floor, no magnets', params: defaults({ lightweight: false }) },
     { name: 'magnets (2.4mm) + lightweight', params: defaults({ magnetHoles: true }) },

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.overtile.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.overtile.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
 import { assertStructurallyValid, boundingBox } from './__kernel-tests__/meshAssertions';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
 beforeAll(async () => {
   await initBrepjs();
@@ -18,7 +18,7 @@ beforeAll(async () => {
 
 const NO_OP = (): void => {};
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 3,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.puzzle.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.puzzle.test.ts
@@ -10,14 +10,14 @@
  * that the tongue actually protrudes past the wall (it locks, not flush).
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { TONGUE_PROTRUSION } from './generatorConstants';
 
 type ExportFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: 'stl'
 ) => Promise<{ data: ArrayBuffer; fileName: string }>;
 
@@ -31,7 +31,7 @@ beforeAll(async () => {
 
 const GRID = 42;
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 4,
   depth: 4,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.snapClip.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.snapClip.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { measureVolume } from 'brepjs';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
@@ -21,7 +21,7 @@ import { SNAP_CLIP } from './generatorConstants';
 import { buildSnapClip, buildSnapClipForPrint } from './baseplateConnectors';
 
 type ExportFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: 'stl'
 ) => Promise<{ data: ArrayBuffer; fileName: string }>;
 
@@ -35,7 +35,7 @@ beforeAll(async () => {
   exportConnectorKey = mod.exportConnectorKey;
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.split-stress.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.split-stress.test.ts
@@ -12,13 +12,13 @@
  * it through and the corruption surfaces as non-manifold STL geometry.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 
 type ExportFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: 'stl'
 ) => Promise<{ data: ArrayBuffer; fileName: string }>;
 
@@ -30,7 +30,7 @@ beforeAll(async () => {
   exportBaseplate = mod.exportBaseplate;
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.winding.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.winding.test.ts
@@ -22,13 +22,13 @@
  * directed-edge uniqueness alone wouldn't see.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 
 type ExportFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   format: 'stl'
 ) => Promise<{ data: ArrayBuffer; fileName: string }>;
 
@@ -40,7 +40,7 @@ beforeAll(async () => {
   exportBaseplate = mod.exportBaseplate;
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 4.5,
   depth: 4.5,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { MeshData } from '../../bridge/types';
 import { initTestKernel } from '@/test/initTestKernel';
 
 type GenerateFn = (
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   onProgress: (stage: string, progress: number) => void,
   forExport: boolean,
   signal?: AbortSignal
@@ -21,7 +21,7 @@ beforeAll(async () => {
 }, 30000);
 
 /** Default params matching the actual UI defaults from src/core/constants.ts */
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -41,7 +41,7 @@ import {
   drawRectangle,
 } from 'brepjs';
 import type { Shape3D, ValidSolid, BooleanPipelineStep } from 'brepjs';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { MeshData, ExportFormat, ConnectorKeyMeshData } from '../../bridge/types';
 import {
   SOCKET_HEIGHT,
@@ -96,7 +96,7 @@ export type BaseplateProbe = (label: string, shape: Shape3D) => void;
  * goes through `exportBaseplate`, which always builds full geometry.
  */
 export function generateBaseplate(
-  rawParams: BaseplateParams,
+  rawParams: ResolvedBaseplateParams,
   onProgress: ProgressFn,
   forExport: boolean,
   signal?: AbortSignal,
@@ -178,7 +178,9 @@ export function generateBaseplate(
  * The clip is the same regardless of which piece carries it; the main thread
  * keeps one copy and seats it at each junction.
  */
-function buildConnectorKeyMeshIfNeeded(params: BaseplateParams): ConnectorKeyMeshData | undefined {
+function buildConnectorKeyMeshIfNeeded(
+  params: ResolvedBaseplateParams
+): ConnectorKeyMeshData | undefined {
   if (!params.connectorNubs || params.connectorStyle !== 'snapClip') return undefined;
   const hasJoinEdge = params.edges ? Object.values(params.edges).some((e) => e === 'join') : false;
   if (!hasJoinEdge) return undefined;
@@ -204,7 +206,7 @@ function buildConnectorKeyMeshIfNeeded(params: BaseplateParams): ConnectorKeyMes
 
 /** Build the complete baseplate BREP solid. */
 export function buildBaseplateSolid(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   forExport: boolean = true,
   onProgress?: (progress: number) => void,
   probe?: BaseplateProbe,
@@ -431,7 +433,7 @@ export function buildBaseplateSolid(
 
 /** Export baseplate as STL or STEP file. */
 export async function exportBaseplate(
-  rawParams: BaseplateParams,
+  rawParams: ResolvedBaseplateParams,
   format: ExportFormat,
   tolerance?: number,
   angularTolerance?: number
@@ -476,7 +478,7 @@ export async function exportBaseplate(
  * every seam junction). Height matches the plate so the seated key is flush.
  */
 export async function exportConnectorKey(
-  rawParams: BaseplateParams,
+  rawParams: ResolvedBaseplateParams,
   format: ExportFormat,
   tolerance?: number,
   angularTolerance?: number

--- a/src/features/generation/worker/generators/baseplateMargin.scenario.test.ts
+++ b/src/features/generation/worker/generators/baseplateMargin.scenario.test.ts
@@ -7,13 +7,17 @@
  * a bounding box matching the planned rail footprint (length × band × height).
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { computeBaseplateTiling } from '@/features/baseplate/utils/splitPlanner';
 import type { MarginPiece } from '@/features/baseplate/types/tiling';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { SOCKET_HEIGHT, MAGNET_FLOOR } from './generatorTypes';
 
-let generateMargin: (p: BaseplateParams, m: MarginPiece, forExport: boolean) => MeshDataLike;
+let generateMargin: (
+  p: ResolvedBaseplateParams,
+  m: MarginPiece,
+  forExport: boolean
+) => MeshDataLike;
 
 interface MeshDataLike {
   vertices: ArrayLike<number>;
@@ -26,7 +30,7 @@ beforeAll(async () => {
   generateMargin = mod.generateMargin;
 }, 30000);
 
-const base = (o: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const base = (o: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 4,
   depth: 3,
   gridUnitMm: 42,
@@ -65,7 +69,7 @@ function bbox(verts: ArrayLike<number>) {
   return { dx: maxX - minX, dy: maxY - minY, minZ, maxZ };
 }
 
-function railOf(params: BaseplateParams, side: MarginPiece['side']): MarginPiece {
+function railOf(params: ResolvedBaseplateParams, side: MarginPiece['side']): MarginPiece {
   const m = computeBaseplateTiling(params, 256).margins.find((r) => r.side === side);
   if (!m) throw new Error(`no ${side} rail`);
   return m;

--- a/src/features/generation/worker/generators/baseplateMargin.ts
+++ b/src/features/generation/worker/generators/baseplateMargin.ts
@@ -19,7 +19,7 @@
 
 import { mesh, meshEdges, translate, getKernelCapabilities, exportSTEP, unwrap } from 'brepjs';
 import type { Shape3D } from 'brepjs';
-import type { BaseplateParams, MarginPiece } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams, MarginPiece } from '@/shared/types/bin';
 import type { MeshData, ExportFormat } from '../../bridge/types';
 import {
   SOCKET_HEIGHT,
@@ -44,7 +44,7 @@ interface RailDims {
 }
 
 /** Rail footprint in its own (origin-centered) frame and slab height. */
-function railDims(params: BaseplateParams, margin: MarginPiece): RailDims {
+function railDims(params: ResolvedBaseplateParams, margin: MarginPiece): RailDims {
   const horizontal = margin.side === 'front' || margin.side === 'back';
   const floorDepth = params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0;
   return {
@@ -56,7 +56,7 @@ function railDims(params: BaseplateParams, margin: MarginPiece): RailDims {
 
 /** Owned-corner radii, capped so the rail corner matches the integral plate. */
 function railCornerRadii(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   margin: MarginPiece,
   railW: number,
   railD: number
@@ -88,7 +88,7 @@ function railCornerRadii(
 
 /** Build a detached margin rail BREP solid, centered at the origin. */
 function buildMarginSolid(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   margin: MarginPiece,
   forExport: boolean = true
 ): Shape3D {
@@ -146,7 +146,7 @@ function buildMarginSolid(
 
 /** Mesh a margin rail for the live preview / split export. */
 export function generateMargin(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   margin: MarginPiece,
   forExport: boolean
 ): MeshData {
@@ -169,7 +169,7 @@ export function generateMargin(
 
 /** Export a margin rail as STL or STEP. */
 export async function exportMargin(
-  params: BaseplateParams,
+  params: ResolvedBaseplateParams,
   margin: MarginPiece,
   format: ExportFormat,
   tolerance?: number,

--- a/src/features/generation/worker/generators/baseplateSlab.ts
+++ b/src/features/generation/worker/generators/baseplateSlab.ts
@@ -4,7 +4,7 @@
 
 import { drawRectangle, drawRoundedRectangle, draw } from 'brepjs';
 import type { Drawing } from 'brepjs';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { CONSTRAINTS } from '@/core/constants';
 import { exteriorCorners } from '@/shared/generation/baseplateCorners';
 
@@ -24,7 +24,7 @@ export function buildSlabProfile(
   totalW: number,
   totalD: number,
   cornerRadii: { tl: number; tr: number; bl: number; br: number },
-  edges?: BaseplateParams['edges']
+  edges?: ResolvedBaseplateParams['edges']
 ): Drawing {
   const hw = totalW / 2;
   const hd = totalD / 2;
@@ -81,7 +81,7 @@ export function tagOp<T>(op: string, fn: () => T): T {
  * Throws on clearly invalid dimensions (NaN, zero, negative) to surface
  * upstream bugs. Clamps other fields to safe ranges to prevent OOM.
  */
-export function sanitizeParams(params: BaseplateParams): BaseplateParams {
+export function sanitizeParams(params: ResolvedBaseplateParams): ResolvedBaseplateParams {
   if (
     !Number.isFinite(params.width) ||
     params.width <= 0 ||

--- a/src/features/generation/worker/generators/connectorSample.scenario.test.ts
+++ b/src/features/generation/worker/generators/connectorSample.scenario.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { measureVolume } from 'brepjs';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
@@ -22,7 +22,7 @@ beforeAll(async () => {
   await initBrepjs();
 }, 30000);
 
-const defaults = (overrides: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -38,7 +38,7 @@ import {
   clone,
 } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { ExportFormat } from '../../bridge/types';
 import { sketch } from './meshUtils';
 import {
@@ -225,7 +225,7 @@ function buildCoupon(
   });
 }
 
-function couponHeight(params: BaseplateParams): number {
+function couponHeight(params: ResolvedBaseplateParams): number {
   const floorDepth = params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0;
   return SOCKET_HEIGHT + floorDepth;
 }
@@ -234,7 +234,7 @@ function couponHeight(params: BaseplateParams): number {
  * Build all fit-sample pieces as separate, bed-resting solids. Caller owns the
  * returned shapes (frees them after compounding).
  */
-export function buildConnectorSampleTray(rawParams: BaseplateParams): Shape3D[] {
+export function buildConnectorSampleTray(rawParams: ResolvedBaseplateParams): Shape3D[] {
   // Clamp grid unit / magnet depth (and reject non-finite values) the same way
   // every sibling exporter does — a bad magnetDepth would otherwise make
   // totalHeight NaN and corrupt every coupon, pocket, and clip.
@@ -311,7 +311,7 @@ export function buildConnectorSampleTray(rawParams: BaseplateParams): Shape3D[] 
 
 /** Export the connector fit-sample tray as a single STL or STEP file. */
 export async function exportConnectorSample(
-  rawParams: BaseplateParams,
+  rawParams: ResolvedBaseplateParams,
   format: ExportFormat,
   tolerance?: number,
   angularTolerance?: number

--- a/src/features/generation/worker/generators/directMeshShapes.ts
+++ b/src/features/generation/worker/generators/directMeshShapes.ts
@@ -6,7 +6,7 @@
  * direct-mesh and BREP variants render visually congruent.
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
 /**
  * Generate points for a rounded rectangle centered at origin.
@@ -68,7 +68,7 @@ export function roundedRectPointsSelective(
   d: number,
   r: number,
   segments: number,
-  edges?: BaseplateParams['edges']
+  edges?: ResolvedBaseplateParams['edges']
 ): ReadonlyArray<readonly [number, number]> {
   if (
     !edges ||

--- a/src/features/generation/worker/generators/dovetailSocketInterference.test.ts
+++ b/src/features/generation/worker/generators/dovetailSocketInterference.test.ts
@@ -20,7 +20,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { measureVolume, translate, intersect } from 'brepjs';
 import { isOk } from '@/core/result';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { buildConnectors } from './baseplateConnectors';
 import { buildSingleCellSocket } from './socketBuilder';
@@ -37,7 +37,7 @@ beforeAll(async () => {
   await initBrepjs();
 }, 30000);
 
-const defaults = (o: Partial<BaseplateParams> = {}): BaseplateParams => ({
+const defaults = (o: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 1,
   depth: 3,
   gridUnitMm: 42,
@@ -64,7 +64,10 @@ const defaults = (o: Partial<BaseplateParams> = {}): BaseplateParams => ({
  * cell-decomposition centres (so this holds for fractional depths too) and each
  * foot is sized to its cell (cell − CLEARANCE).
  */
-function tongueFootOverlap(params: BaseplateParams): { overlap: number; tongueVol: number } {
+function tongueFootOverlap(params: ResolvedBaseplateParams): {
+  overlap: number;
+  tongueVol: number;
+} {
   const GU = params.gridUnitMm;
   const totalHeight = SOCKET_HEIGHT + (params.magnetHoles ? MAGNET_FLOOR + params.magnetDepth : 0);
   const totalW = params.width * GU;

--- a/src/features/generation/worker/generators/snapClipLedgeBacking.test.ts
+++ b/src/features/generation/worker/generators/snapClipLedgeBacking.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { measureVolume, translate, intersect, cut, draw } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import { isOk } from '@/core/result';
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { buildBaseplateSolid } from './baseplateGenerator';
 import { buildConnectors } from './baseplateConnectors';
@@ -33,7 +33,7 @@ const box = (x0: number, x1: number, y0: number, y1: number, z0: number, z1: num
     .sketchOnPlane('XY', z0)
     .extrude(z1 - z0);
 
-const params: BaseplateParams = {
+const params: ResolvedBaseplateParams = {
   width: 2,
   depth: 2,
   gridUnitMm: 42,

--- a/src/shared/contexts/MutationsContext.tsx
+++ b/src/shared/contexts/MutationsContext.tsx
@@ -30,7 +30,7 @@ import type {
   CategoryId,
   LayoutId,
   CloudShareInfo,
-  BaseplateParams,
+  StoredBaseplateParams,
 } from '@/core/types';
 import type { Result, ValidationError, LayoutError } from '@/core/result';
 
@@ -83,7 +83,7 @@ export interface Mutations {
   setPrintBedSize: (size: number, depth?: number) => void;
   setGridUnitMm: (mm: number) => void;
   setHeightUnitMm: (mm: number) => void;
-  setBaseplateParams: (params: BaseplateParams) => void;
+  setBaseplateParams: (params: StoredBaseplateParams) => void;
 
   // Library cloud-share operations
   setCloudShare: (layoutId: LayoutId, share: CloudShareInfo) => void;

--- a/src/shared/generation/baseplateCorners.ts
+++ b/src/shared/generation/baseplateCorners.ts
@@ -12,7 +12,7 @@
  * fingerprint must change with it or pieces will be wrongly merged or split.
  */
 
-import type { BaseplateParams } from '@/shared/types/bin';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 
 export type CornerKey = 'tl' | 'tr' | 'bl' | 'br';
 
@@ -20,7 +20,9 @@ export type CornerKey = 'tl' | 'tr' | 'bl' | 'br';
  * Map each corner to whether both its adjacent edges are exterior. With no edge
  * classification (a standalone, unsplit plate) every corner is exterior.
  */
-export function exteriorCorners(edges: BaseplateParams['edges']): Record<CornerKey, boolean> {
+export function exteriorCorners(
+  edges: ResolvedBaseplateParams['edges']
+): Record<CornerKey, boolean> {
   if (!edges) return { tl: true, tr: true, bl: true, br: true };
   return {
     tl: edges.left === 'exterior' && edges.back === 'exterior',

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -161,12 +161,13 @@ export interface MarginPiece {
 }
 
 /**
- * Full baseplate parameter set for generation bridge.
+ * Resolved (generation-time) full baseplate parameter set for the generation bridge.
  *
- * Extends core BaseplateParams with drawer dimensions (width, depth, gridUnitMm)
- * and resolved per-side padding values computed from ratio at generation time.
+ * Extends the persisted {@link StoredBaseplateParams} with drawer dimensions
+ * (width, depth, gridUnitMm) and resolved per-side padding values computed at
+ * generation time. Produced from the stored config via buildFullParams.
  */
-export interface BaseplateParams {
+export interface ResolvedBaseplateParams {
   readonly width: number;
   readonly depth: number;
   readonly gridUnitMm: number;


### PR DESCRIPTION
## What

Two **different** interfaces both named `BaseplateParams` lived in different layers:
- `core/types.ts` — the **stored** per-layout config (padding as `Mm`, no dimensions)
- `shared/types/bin.ts` — the **resolved** generation-time full set (adds `width`/`depth`/`gridUnitMm`/`fractionalEdge*`)

Same identifier, different shapes → any file needing both had to alias them (`buildFullParams.ts` did), and a wrong-layer import **silently typechecked against the wrong shape** (the footgun behind earlier over-tile bugs).

Renamed to **`StoredBaseplateParams`** (core) and **`ResolvedBaseplateParams`** (shared); migrated **71 files** by import source. `buildFullParams` bridges the two and its doc comments now cross-reference.

## Why it's safe

Pure type-identifier rename, **zero runtime change**. Used `\bBaseplateParams\b` so the unrelated `setBaseplateParams` / `migrateBaseplateParams` / `DEFAULT_BASEPLATE_PARAMS` / `pieceToBaseplateParams` / the `baseplateParams` field were untouched. **`pnpm run typecheck` is at 0 errors** — since the two interfaces differ structurally, any mis-migrated site would fail to compile. ESLint clean; buildFullParams + splitPlanner suites (105) green.

Addresses architecture-audit finding #1 (dual `BaseplateParams`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the conflicting BaseplateParams into `StoredBaseplateParams` (persisted layout config) and `ResolvedBaseplateParams` (generation-time params). This removes wrong-layer imports and prevents silent type mismatches with no runtime changes.

- **Refactors**
  - Renamed core `BaseplateParams` → `StoredBaseplateParams` and shared/bin `BaseplateParams` → `ResolvedBaseplateParams`.
  - Updated imports across baseplate UI, split planner, generation bridge/worker, and tests; `buildFullParams` bridges stored → resolved with updated docs.
  - Typecheck and test suites pass; no logic changes.

- **Migration**
  - Replace prior `BaseplateParams` imports with `StoredBaseplateParams` from `@/core/types` or `ResolvedBaseplateParams` from `@/shared/types/bin`.

<sup>Written for commit b84386012646648d58ad2c6e36a9574402287795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

