### PR TITLE
test(bin-designer): cover cutout path geometry (bezier/segments/triangulation/svg)

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometryBezier.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometryBezier.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import type { PathPoint } from '@/features/bin-designer/types';
+import { cubicBezier, flattenPath, type Point2D } from './pathGeometryBezier';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function corner(x: number, y: number): PathPoint {
+  return { x, y, handleIn: null, handleOut: null, symmetric: true };
+}
+
+function withHandles(
+  x: number,
+  y: number,
+  outDx: number,
+  outDy: number,
+  inDx: number,
+  inDy: number
+): PathPoint {
+  return {
+    x,
+    y,
+    handleOut: { dx: outDx, dy: outDy },
+    handleIn: { dx: inDx, dy: inDy },
+    symmetric: false,
+  };
+}
+
+const allFinite = (pts: Point2D[]): boolean =>
+  pts.every((p) => Number.isFinite(p.x) && Number.isFinite(p.y));
+
+// ─── cubicBezier ─────────────────────────────────────────────────────────────
+
+describe('cubicBezier', () => {
+  const p0 = { x: 0, y: 0 };
+  const cp1 = { x: 0, y: 50 };
+  const cp2 = { x: 100, y: 50 };
+  const p1 = { x: 100, y: 0 };
+
+  it('returns p0 exactly at t=0', () => {
+    const r = cubicBezier(p0, cp1, cp2, p1, 0);
+    expect(r.x).toBeCloseTo(0, 10);
+    expect(r.y).toBeCloseTo(0, 10);
+  });
+
+  it('returns p1 exactly at t=1', () => {
+    const r = cubicBezier(p0, cp1, cp2, p1, 1);
+    expect(r.x).toBeCloseTo(100, 10);
+    expect(r.y).toBeCloseTo(0, 10);
+  });
+
+  it('midpoint of symmetric arch lies strictly above the chord and at x-center', () => {
+    const mid = cubicBezier(p0, cp1, cp2, p1, 0.5);
+    // Chord is at y=0; arch control points peak at y=50
+    expect(mid.y).toBeGreaterThan(0);
+    expect(mid.y).toBeLessThanOrEqual(50);
+    // Symmetric arch: midpoint x = average of endpoints
+    expect(mid.x).toBeCloseTo(50, 5);
+  });
+
+  it('all sampled t values produce finite coordinates', () => {
+    for (let i = 0; i <= 20; i++) {
+      const r = cubicBezier(p0, cp1, cp2, p1, i / 20);
+      expect(Number.isFinite(r.x)).toBe(true);
+      expect(Number.isFinite(r.y)).toBe(true);
+    }
+  });
+
+  it('degenerate: all four points identical returns that point for any t', () => {
+    const q = { x: 7, y: 13 };
+    for (const t of [0, 0.33, 0.67, 1]) {
+      const r = cubicBezier(q, q, q, q, t);
+      expect(r.x).toBeCloseTo(7, 10);
+      expect(r.y).toBeCloseTo(13, 10);
+    }
+  });
+
+  it('collinear control points: mid-curve point lies on the segment', () => {
+    // p0=(0,0), cp1=(5,0), cp2=(15,0), p1=(20,0) — all on x-axis
+    const r = cubicBezier({ x: 0, y: 0 }, { x: 5, y: 0 }, { x: 15, y: 0 }, { x: 20, y: 0 }, 0.5);
+    expect(r.y).toBeCloseTo(0, 10);
+    expect(r.x).toBeGreaterThan(0);
+    expect(r.x).toBeLessThan(20);
+  });
+});
+
+// ─── flattenPath ─────────────────────────────────────────────────────────────
+
+describe('flattenPath', () => {
+  it('returns empty array for empty input', () => {
+    expect(flattenPath([])).toEqual([]);
+  });
+
+  it('returns single mapped point for one-element input', () => {
+    const result = flattenPath([corner(3, 7)]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ x: 3, y: 7 });
+  });
+
+  it('straight three-point closed path produces exactly three vertices', () => {
+    const result = flattenPath([corner(0, 0), corner(10, 0), corner(5, 10)]);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ x: 0, y: 0 });
+  });
+
+  it('bezier path produces more points than anchor count', () => {
+    const pts: PathPoint[] = [withHandles(0, 0, 0, 40, 0, -40), withHandles(80, 0, 0, 40, 0, -40)];
+    const result = flattenPath(pts);
+    expect(result.length).toBeGreaterThan(2);
+  });
+
+  it('all output coordinates are finite for a strongly curved bezier path', () => {
+    const pts: PathPoint[] = [withHandles(0, 0, 0, 40, 0, -40), withHandles(80, 0, 0, 40, 0, -40)];
+    expect(allFinite(flattenPath(pts))).toBe(true);
+  });
+
+  it('tight tolerance produces more sample points than loose tolerance', () => {
+    const pts: PathPoint[] = [withHandles(0, 0, 0, 60, 0, -60), withHandles(100, 0, 0, 60, 0, -60)];
+    const loose = flattenPath(pts, 10);
+    const tight = flattenPath(pts, 0.01);
+    expect(tight.length).toBeGreaterThan(loose.length);
+  });
+
+  it('open path (closed=false) ends at the last anchor', () => {
+    const pts = [corner(0, 0), corner(50, 0), corner(100, 50)];
+    const result = flattenPath(pts, 0.1, false);
+    expect(result[0]).toEqual({ x: 0, y: 0 });
+    expect(result[result.length - 1]).toEqual({ x: 100, y: 50 });
+  });
+
+  it('closed path does not duplicate the first point as the last', () => {
+    const pts = [corner(0, 0), corner(10, 0), corner(5, 10)];
+    const result = flattenPath(pts);
+    expect(result[0]).not.toEqual(result[result.length - 1]);
+  });
+
+  it('drops coincident consecutive vertices in a straight path', () => {
+    const result = flattenPath([corner(0, 0), corner(10, 0), corner(10, 0), corner(5, 10)]);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).not.toEqual(result[i - 1]);
+    }
+  });
+
+  it('zero-handle bezier (degenerate cp=anchor) produces finite, non-empty output', () => {
+    // handleOut with dx=dy=0: cp1 coincides with anchor, making a near-straight bezier
+    const pts: PathPoint[] = [
+      { x: 0, y: 0, handleIn: null, handleOut: { dx: 0, dy: 0 }, symmetric: false },
+      { x: 20, y: 0, handleIn: { dx: 0, dy: 0 }, handleOut: null, symmetric: false },
+    ];
+    const result = flattenPath(pts);
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    expect(allFinite(result)).toBe(true);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometrySegments.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometrySegments.test.ts
@@ -68,7 +68,8 @@ describe('findNearestSegment', () => {
 
   it('finds the nearest bezier segment', () => {
     const pts = [withHandles(0, 0, 0, 15, 0, -15), corner(30, 0)];
-    // Query very close to the curve's midpoint (approximately at 15, ~7)
+    // Query a point near the curve's interior (within the 5px threshold) — the
+    // exact bezier midpoint isn't what matters, only that segment 0 is nearest.
     const r = findNearestSegment(15, 7, pts, 5);
     expect(r).not.toBeNull();
     expect(r?.segmentIndex).toBe(0);

--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometrySegments.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometrySegments.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import type { PathPoint } from '@/features/bin-designer/types';
+import { cubicBezier } from './pathGeometryBezier';
+import {
+  findNearestSegment,
+  evaluateSegmentPoint,
+  flattenSegment,
+  splitBezierSegment,
+  isSelfIntersecting,
+} from './pathGeometrySegments';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function corner(x: number, y: number): PathPoint {
+  return { x, y, handleIn: null, handleOut: null, symmetric: true };
+}
+
+function withHandles(
+  x: number,
+  y: number,
+  outDx: number,
+  outDy: number,
+  inDx: number,
+  inDy: number
+): PathPoint {
+  return {
+    x,
+    y,
+    handleOut: { dx: outDx, dy: outDy },
+    handleIn: { dx: inDx, dy: inDy },
+    symmetric: false,
+  };
+}
+
+// ─── findNearestSegment ───────────────────────────────────────────────────────
+
+describe('findNearestSegment', () => {
+  it('returns null for fewer than 2 points', () => {
+    expect(findNearestSegment(5, 5, [], 10)).toBeNull();
+    expect(findNearestSegment(5, 5, [corner(0, 0)], 10)).toBeNull();
+  });
+
+  it('identifies the correct segment index for a point on a known segment', () => {
+    // Square: segment 1 is (10,0)→(10,10); query near its midpoint
+    const pts = [corner(0, 0), corner(10, 0), corner(10, 10), corner(0, 10)];
+    const r = findNearestSegment(10, 5, pts, 1);
+    expect(r).not.toBeNull();
+    expect(r?.segmentIndex).toBe(1);
+    expect(r?.t).toBeCloseTo(0.5, 1);
+  });
+
+  it('segmentIndex is within [0, n-1] and t is within [0, 1]', () => {
+    const pts = [corner(0, 0), corner(20, 0), corner(20, 20), corner(0, 20)];
+    const r = findNearestSegment(10, 0, pts, 5);
+    expect(r).not.toBeNull();
+    if (r !== null) {
+      expect(r.segmentIndex).toBeGreaterThanOrEqual(0);
+      expect(r.segmentIndex).toBeLessThan(pts.length);
+      expect(r.t).toBeGreaterThanOrEqual(0);
+      expect(r.t).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('returns null when nearest point is beyond the threshold', () => {
+    const pts = [corner(0, 0), corner(10, 0)];
+    expect(findNearestSegment(5, 20, pts, 5)).toBeNull();
+  });
+
+  it('finds the nearest bezier segment', () => {
+    const pts = [withHandles(0, 0, 0, 15, 0, -15), corner(30, 0)];
+    // Query very close to the curve's midpoint (approximately at 15, ~7)
+    const r = findNearestSegment(15, 7, pts, 5);
+    expect(r).not.toBeNull();
+    expect(r?.segmentIndex).toBe(0);
+  });
+});
+
+// ─── evaluateSegmentPoint ────────────────────────────────────────────────────
+
+describe('evaluateSegmentPoint', () => {
+  it('returns p0 at t=0 for a straight segment', () => {
+    const pts = [corner(3, 5), corner(13, 15)];
+    expect(evaluateSegmentPoint(pts, 0, 0)).toEqual({ x: 3, y: 5 });
+  });
+
+  it('returns p1 at t=1 for a straight segment', () => {
+    const pts = [corner(3, 5), corner(13, 15)];
+    expect(evaluateSegmentPoint(pts, 0, 1)).toEqual({ x: 13, y: 15 });
+  });
+
+  it('returns the midpoint at t=0.5 for a straight segment', () => {
+    const pts = [corner(0, 0), corner(20, 10)];
+    const r = evaluateSegmentPoint(pts, 0, 0.5);
+    expect(r.x).toBeCloseTo(10, 5);
+    expect(r.y).toBeCloseTo(5, 5);
+  });
+
+  it('closing segment (last index) wraps around to the first point at t=1', () => {
+    const pts = [corner(0, 0), corner(10, 0), corner(5, 10)];
+    // Segment index 2 goes from pts[2]=(5,10) back to pts[0]=(0,0)
+    const r = evaluateSegmentPoint(pts, 2, 1);
+    expect(r.x).toBeCloseTo(0, 5);
+    expect(r.y).toBeCloseTo(0, 5);
+  });
+
+  it('bezier segment at t=0 returns the segment start point', () => {
+    const pts = [withHandles(0, 0, 0, 20, 0, -20), corner(40, 0)];
+    const r = evaluateSegmentPoint(pts, 0, 0);
+    expect(r.x).toBeCloseTo(0, 5);
+    expect(r.y).toBeCloseTo(0, 5);
+  });
+});
+
+// ─── flattenSegment ──────────────────────────────────────────────────────────
+
+describe('flattenSegment', () => {
+  it('returns exactly 2 points for a straight segment', () => {
+    const pts = [corner(0, 0), corner(30, 0), corner(30, 30)];
+    expect(flattenSegment(pts, 0)).toHaveLength(2);
+  });
+
+  it('returns steps+1 points for a bezier segment with explicit step count', () => {
+    const pts = [withHandles(0, 0, 0, 20, 0, -20), corner(40, 0)];
+    expect(flattenSegment(pts, 0, 8)).toHaveLength(9);
+  });
+
+  it('default step count is 20, yielding 21 points', () => {
+    const pts = [withHandles(0, 0, 0, 20, 0, -20), corner(40, 0)];
+    expect(flattenSegment(pts, 0)).toHaveLength(21);
+  });
+
+  it('all output coordinates are finite', () => {
+    const pts = [withHandles(0, 0, 0, 50, 0, -50), corner(100, 0)];
+    const r = flattenSegment(pts, 0, 20);
+    for (const p of r) {
+      expect(Number.isFinite(p.x)).toBe(true);
+      expect(Number.isFinite(p.y)).toBe(true);
+    }
+  });
+
+  it('first point of flattened segment matches the start anchor', () => {
+    const pts = [withHandles(5, 7, 0, 20, 0, -20), corner(50, 7)];
+    const r = flattenSegment(pts, 0);
+    expect(r[0].x).toBeCloseTo(5, 8);
+    expect(r[0].y).toBeCloseTo(7, 8);
+  });
+});
+
+// ─── splitBezierSegment ──────────────────────────────────────────────────────
+
+describe('splitBezierSegment', () => {
+  // Curved segment: p0=(0,0) with handleOut=(0,20); p1=(40,0) with handleIn=(-15,0)
+  // Absolute control points: cp1=(0,20), cp2=(25,0)
+  const p0: PathPoint = {
+    x: 0,
+    y: 0,
+    handleIn: null,
+    handleOut: { dx: 0, dy: 20 },
+    symmetric: false,
+  };
+  const p1: PathPoint = {
+    x: 40,
+    y: 0,
+    handleIn: { dx: -15, dy: 0 },
+    handleOut: null,
+    symmetric: false,
+  };
+
+  it('mid position matches the original cubic bezier evaluated at t=0.5', () => {
+    const { mid } = splitBezierSegment(p0, p1, 0.5);
+    const orig = cubicBezier(
+      { x: 0, y: 0 },
+      { x: 0, y: 20 },
+      { x: 25, y: 0 },
+      { x: 40, y: 0 },
+      0.5
+    );
+    expect(mid.x).toBeCloseTo(orig.x, 8);
+    expect(mid.y).toBeCloseTo(orig.y, 8);
+  });
+
+  it('first sub-curve at t=0.5 matches the original curve at t=0.25', () => {
+    const { before, mid } = splitBezierSegment(p0, p1, 0.5);
+    const sub1cp1 = {
+      x: before.x + (before.handleOut?.dx ?? 0),
+      y: before.y + (before.handleOut?.dy ?? 0),
+    };
+    const sub1cp2 = {
+      x: mid.x + (mid.handleIn?.dx ?? 0),
+      y: mid.y + (mid.handleIn?.dy ?? 0),
+    };
+    const subMid = cubicBezier(
+      { x: before.x, y: before.y },
+      sub1cp1,
+      sub1cp2,
+      { x: mid.x, y: mid.y },
+      0.5
+    );
+    const origQuarter = cubicBezier(
+      { x: 0, y: 0 },
+      { x: 0, y: 20 },
+      { x: 25, y: 0 },
+      { x: 40, y: 0 },
+      0.25
+    );
+    expect(subMid.x).toBeCloseTo(origQuarter.x, 8);
+    expect(subMid.y).toBeCloseTo(origQuarter.y, 8);
+  });
+
+  it('before.position equals original p0 and after.position equals original p1', () => {
+    const { before, after } = splitBezierSegment(p0, p1, 0.5);
+    expect(before.x).toBe(p0.x);
+    expect(before.y).toBe(p0.y);
+    expect(after.x).toBe(p1.x);
+    expect(after.y).toBe(p1.y);
+  });
+
+  it('mid.symmetric is false for a curve split', () => {
+    const { mid } = splitBezierSegment(p0, p1, 0.5);
+    expect(mid.symmetric).toBe(false);
+  });
+
+  it('mid has non-null handleIn and handleOut after splitting a curved segment', () => {
+    const { mid } = splitBezierSegment(p0, p1, 0.5);
+    expect(mid.handleIn).not.toBeNull();
+    expect(mid.handleOut).not.toBeNull();
+  });
+
+  it('splitting a straight segment at t=0.5 gives the geometric midpoint', () => {
+    const a = corner(0, 0);
+    const b = corner(20, 10);
+    const { mid } = splitBezierSegment(a, b, 0.5);
+    expect(mid.x).toBeCloseTo(10, 8);
+    expect(mid.y).toBeCloseTo(5, 8);
+  });
+});
+
+// ─── isSelfIntersecting ──────────────────────────────────────────────────────
+
+describe('isSelfIntersecting', () => {
+  it('returns false for fewer than 3 points', () => {
+    expect(isSelfIntersecting([])).toBe(false);
+    expect(isSelfIntersecting([corner(0, 0), corner(5, 5)])).toBe(false);
+  });
+
+  it('returns false for a convex triangle', () => {
+    expect(isSelfIntersecting([corner(0, 0), corner(10, 0), corner(5, 8)])).toBe(false);
+  });
+
+  it('returns false for a convex quad (square)', () => {
+    const pts = [corner(0, 0), corner(10, 0), corner(10, 10), corner(0, 10)];
+    expect(isSelfIntersecting(pts)).toBe(false);
+  });
+
+  it('returns true for a figure-8 with crossing straight segments', () => {
+    // (0,0)→(10,10)→(10,0)→(0,10) traces an X shape
+    const pts = [corner(0, 0), corner(10, 10), corner(10, 0), corner(0, 10)];
+    expect(isSelfIntersecting(pts)).toBe(true);
+  });
+
+  it('returns false for a concave but non-self-intersecting polygon', () => {
+    const pts = [corner(0, 0), corner(10, 0), corner(10, 10), corner(5, 5), corner(0, 10)];
+    expect(isSelfIntersecting(pts)).toBe(false);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometryTriangulation.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometryTriangulation.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { triangulatePath } from './pathGeometryTriangulation';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function p(x: number, y: number): { x: number; y: number } {
+  return { x, y };
+}
+
+function regularPolygon(n: number, r: number): Array<{ x: number; y: number }> {
+  return Array.from({ length: n }, (_, i) => ({
+    x: r * Math.cos((2 * Math.PI * i) / n),
+    y: r * Math.sin((2 * Math.PI * i) / n),
+  }));
+}
+
+// ─── triangulatePath ─────────────────────────────────────────────────────────
+
+describe('triangulatePath', () => {
+  it('returns empty array for fewer than 3 points', () => {
+    expect(triangulatePath([])).toEqual([]);
+    expect(triangulatePath([p(0, 0)])).toEqual([]);
+    expect(triangulatePath([p(0, 0), p(5, 0)])).toEqual([]);
+  });
+
+  it('output length is always a multiple of 3', () => {
+    for (const n of [3, 4, 5, 6, 7]) {
+      const result = triangulatePath(regularPolygon(n, 10));
+      expect(result.length % 3).toBe(0);
+    }
+  });
+
+  it('all indices are within [0, n-1]', () => {
+    // Use a regular pentagon — earclip reliably triangulates convex regular polygons
+    const pts = regularPolygon(5, 10);
+    const result = triangulatePath(pts);
+    expect(result.length).toBeGreaterThan(0);
+    for (const idx of result) {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(pts.length);
+    }
+  });
+
+  it('triangle produces exactly 3 indices', () => {
+    expect(triangulatePath([p(0, 0), p(10, 0), p(5, 8)])).toHaveLength(3);
+  });
+
+  it('convex quad produces 6 indices (2 triangles)', () => {
+    expect(triangulatePath([p(0, 0), p(10, 0), p(10, 10), p(0, 10)])).toHaveLength(6);
+  });
+
+  it('convex hexagon produces 12 indices (4 triangles)', () => {
+    // (n-2) triangles × 3 indices = (6-2)*3 = 12
+    expect(triangulatePath(regularPolygon(6, 10))).toHaveLength(12);
+  });
+
+  it('CW-wound polygon triangulates to same index count as CCW', () => {
+    const ccw = triangulatePath([p(0, 0), p(10, 0), p(10, 10), p(0, 10)]);
+    const cw = triangulatePath([p(0, 0), p(0, 10), p(10, 10), p(10, 0)]);
+    expect(cw).toHaveLength(ccw.length);
+    expect(cw).toHaveLength(6);
+  });
+
+  it('collinear points (zero-area polygon) return empty array', () => {
+    expect(triangulatePath([p(0, 0), p(5, 0), p(10, 0)])).toEqual([]);
+  });
+
+  it('index validity holds for a larger convex polygon', () => {
+    const n = 12;
+    const pts = regularPolygon(n, 20);
+    const result = triangulatePath(pts);
+    expect(result).toHaveLength((n - 2) * 3);
+    for (const idx of result) {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(n);
+    }
+  });
+
+  it('near-degenerate thin triangle does not throw', () => {
+    // Very thin but non-zero area — result is either valid or empty, never throws
+    const result = triangulatePath([p(0, 0), p(100, 0), p(50, 0.001)]);
+    expect(result.length % 3).toBe(0);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertPath.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertPath.test.ts
@@ -38,7 +38,12 @@ describe('convertPath', () => {
   it('all path point coordinates are Number.isFinite', () => {
     const result = convertPath(makePath('M 0 0 L 10 0 L 5 10 Z'), IDENTITY, VIEW_BOX);
     expect(result).not.toBeNull();
-    for (const pt of result![0].path ?? []) {
+    const path = result![0].path;
+    // Assert path exists/non-empty so the finite checks can't pass vacuously
+    // (a path spec without a `path` array would otherwise skip the loop).
+    expect(path).toBeDefined();
+    expect(path?.length).toBeGreaterThan(0);
+    for (const pt of path ?? []) {
       expect(Number.isFinite(pt.x)).toBe(true);
       expect(Number.isFinite(pt.y)).toBe(true);
     }

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertPath.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/svgConvertPath.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { convertPath } from './svgConvertPath';
+import { IDENTITY } from './svgTransform';
+import type { Matrix } from './svgTransform';
+import type { ViewBox } from './types';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const VIEW_BOX: ViewBox = { minX: 0, minY: 0, width: 100, height: 100 };
+
+function makePath(d: string): Element {
+  const el = document.createElement('path');
+  el.setAttribute('d', d);
+  return el;
+}
+
+// ─── convertPath ─────────────────────────────────────────────────────────────
+
+describe('convertPath', () => {
+  it('returns null when the element has no d attribute', () => {
+    const el = document.createElement('path');
+    expect(convertPath(el, IDENTITY, VIEW_BOX)).toBeNull();
+  });
+
+  it('returns null for a move-only path (no drawable geometry)', () => {
+    // "M 5 5" produces a contour with only 1 command — convertContour returns null
+    expect(convertPath(makePath('M 5 5'), IDENTITY, VIEW_BOX)).toBeNull();
+  });
+
+  it('simple M L L Z triangle produces one path spec with 3 points', () => {
+    const result = convertPath(makePath('M 10 10 L 90 10 L 50 80 Z'), IDENTITY, VIEW_BOX);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].shape).toBe('path');
+    expect(result![0].path).toHaveLength(3);
+  });
+
+  it('all path point coordinates are Number.isFinite', () => {
+    const result = convertPath(makePath('M 0 0 L 10 0 L 5 10 Z'), IDENTITY, VIEW_BOX);
+    expect(result).not.toBeNull();
+    for (const pt of result![0].path ?? []) {
+      expect(Number.isFinite(pt.x)).toBe(true);
+      expect(Number.isFinite(pt.y)).toBe(true);
+    }
+  });
+
+  it('Y axis is flipped: M 10 10 maps to y = viewHeight - 10', () => {
+    // transformPoint(10, 10, IDENTITY, {0,0,100,100}) → (10, 100-10) = (10, 90)
+    const result = convertPath(makePath('M 10 10 L 90 10 L 50 80 Z'), IDENTITY, VIEW_BOX);
+    expect(result).not.toBeNull();
+    const pt = result![0].path![0];
+    expect(pt.x).toBeCloseTo(10, 5);
+    expect(pt.y).toBeCloseTo(90, 5);
+  });
+
+  it('translate matrix shifts all path point x-coordinates by the translation', () => {
+    const tx: Matrix = [1, 0, 0, 1, 20, 0];
+    const base = convertPath(makePath('M 10 10 L 90 10 L 50 80 Z'), IDENTITY, VIEW_BOX);
+    const shifted = convertPath(makePath('M 10 10 L 90 10 L 50 80 Z'), tx, VIEW_BOX);
+    expect(base).not.toBeNull();
+    expect(shifted).not.toBeNull();
+    for (let i = 0; i < 3; i++) {
+      expect(shifted![0].path![i].x).toBeCloseTo(base![0].path![i].x + 20, 5);
+      // Y coordinates are unaffected by a pure x-translate
+      expect(shifted![0].path![i].y).toBeCloseTo(base![0].path![i].y, 5);
+    }
+  });
+
+  it('two M sub-paths produce two specs', () => {
+    const d = 'M 0 0 L 10 0 L 5 10 Z M 20 0 L 30 0 L 25 10 Z';
+    const result = convertPath(makePath(d), IDENTITY, VIEW_BOX);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0].shape).toBe('path');
+    expect(result![1].shape).toBe('path');
+  });
+
+  it('C (cubic bezier) command adds handles to the adjacent path points', () => {
+    // M 0 0 C 0 50 100 50 100 0 — a smooth arch
+    const result = convertPath(makePath('M 0 0 C 0 50 100 50 100 0'), IDENTITY, VIEW_BOX);
+    expect(result).not.toBeNull();
+    const path = result![0].path ?? [];
+    expect(path.length).toBeGreaterThanOrEqual(2);
+    const hasHandle = path.some((pt) => pt.handleOut !== null || pt.handleIn !== null);
+    expect(hasHandle).toBe(true);
+  });
+
+  it('C command assigns correct handleOut on the preceding point', () => {
+    // M 0 0 C 0 50 100 50 100 0
+    // cp1=(0,50) in SVG → transformPoint → (0, 50) in cutout space
+    // prev=(0,0) in SVG → transformPoint → (0, 100) in cutout space
+    // handleOut.dx = 0-0=0, handleOut.dy = 50-100=-50
+    const result = convertPath(makePath('M 0 0 C 0 50 100 50 100 0'), IDENTITY, VIEW_BOX);
+    expect(result).not.toBeNull();
+    const pt0 = result![0].path![0];
+    expect(pt0.handleOut).not.toBeNull();
+    expect(pt0.handleOut!.dx).toBeCloseTo(0, 5);
+    expect(pt0.handleOut!.dy).toBeCloseTo(-50, 5);
+  });
+
+  it('Z deduplication: closing a path whose last point coincides with the first shrinks point count', () => {
+    // Explicitly place last point at same position as M to trigger dedup in CLOSE_PATH
+    const withDup = 'M 0 0 L 10 0 L 5 10 L 0 0 Z';
+    const result = convertPath(makePath(withDup), IDENTITY, VIEW_BOX);
+    expect(result).not.toBeNull();
+    // The duplicate endpoint at (0,0) should be removed; we should have 3 points, not 4
+    expect(result![0].path).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## What

Colocated unit tests for **four pure 2D path-geometry modules** in the cutout editor (previously untested; a sibling `pathGeometry.test.ts` already covered the straight-segment cases):

- **`pathGeometryBezier.test.ts`** (15) — `cubicBezier` endpoints/midpoint; `flattenPath` finite-output, subdivision count, coincident-point dropping.
- **`pathGeometrySegments.test.ts`** (20) — `findNearestSegment`; `splitBezierSegment` **De Casteljau roundtrip** (first sub-curve at t=0.5 == original at t=0.25, the real split contract); `isSelfIntersecting` true on a figure-eight / false on a convex quad.
- **`pathGeometryTriangulation.test.ts`** (9) — index count a multiple of 3, all in range, non-empty for a simple polygon, degenerate `<3`-point handled.
- **`svgConvertPath.test.ts`** (9) — `M/L/Z`, transform matrix, and the `C`-handle **Y-flip** value pinned.

All assert geometry-validity invariants (every coord `Number.isFinite`, no NaN/Infinity). **Test-only — zero production changes.** 62 tests, all green; ESLint + typecheck clean.

> Surfaced (not a regression): earclip `triangulatePath` is sensitive to vertex ordering — a "house" pentagon that looks convex fails to fully triangulate. Tests use regular polygons to stay deterministic; worth a follow-up if arbitrary concave paths need robust triangulation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add colocated unit tests for `pathGeometryBezier`, `pathGeometrySegments`, `pathGeometryTriangulation`, and `svgConvertPath` to validate cutout path geometry; no production changes.
Covers Bezier eval/flattening, segment nearest/evaluate/split + self-intersection, triangulation index/count invariants, and SVG M/L/C/Z with transform Y-flip and Z dedup; adds a guard so finite-coordinate checks don’t pass on empty/missing paths; `triangulatePath` sensitivity to vertex order noted for follow-up.

<sup>Written for commit 0ac10d9cc82e1c811476a07652f411a2bd8ae3bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

