### PR TITLE
refactor(shared): consolidate the clamp helper (17 local redefs → one)

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/EditableDimensions.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/design-system';
 import { PencilIcon } from '@/design-system/Icon';
+import { clamp as clampRange } from '@/shared/utils/math';
 
 /** Format mm for display: minimum needed decimals, no trailing zeros. */
 function formatMm(v: number): string {
@@ -84,7 +85,7 @@ export function EditableDimensions({
     }
   }, [editing]);
 
-  const clamp = useCallback((v: number) => Math.max(minMm, Math.min(maxMm, v)), [minMm, maxMm]);
+  const clamp = useCallback((v: number) => clampRange(v, minMm, maxMm), [minMm, maxMm]);
 
   const commit = useCallback(() => {
     const w = parseFloat(localWidth);

--- a/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
+++ b/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/design-system/cn';
 import { AlertTriangleIcon, ArrowLeftIcon } from '@/design-system/Icon';
 import { focusRing, interactiveTransition } from '@/design-system/variants';
 import { useTranslation } from '@/i18n';
+import { clamp } from '@/shared/utils/math';
 import type { PaddingAnchor as PaddingAnchorValue } from '@/core/types';
 
 type ConcreteAnchor = Exclude<PaddingAnchorValue, 'custom'>;
@@ -42,7 +43,7 @@ const ARROW_ROTATION: Record<ConcreteAnchor, string | null> = {
 };
 
 function clampToGrid(v: number): number {
-  return Math.max(0, Math.min(2, v));
+  return clamp(v, 0, 2);
 }
 
 function neighbour(current: ConcreteAnchor, dx: number, dy: number): ConcreteAnchor {

--- a/src/features/baseplate/utils/computeAnchoredPaddings.ts
+++ b/src/features/baseplate/utils/computeAnchoredPaddings.ts
@@ -1,4 +1,5 @@
 import { mm, type Mm, type PaddingAnchor } from '@/core/types';
+import { clamp } from '@/shared/utils/math';
 import {
   PADDING_MAX,
   PADDING_MIN,
@@ -40,7 +41,7 @@ function splitAxis(total: number, startWeight: number): { start: number; end: nu
 }
 
 function clampMm(v: number): number {
-  return Math.max(PADDING_MIN, Math.min(PADDING_MAX, v));
+  return clamp(v, PADDING_MIN, PADDING_MAX);
 }
 
 interface PaddingSums {

--- a/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
@@ -20,6 +20,7 @@ import {
   getEffectiveSlotDimensions,
   MIN_WALL_FOR_SLOTS,
 } from '@/shared/utils/slotMath';
+import { clamp } from '@/shared/utils/math';
 import { useTranslation } from '@/i18n';
 import type { DividerPieceConfig } from '../../types';
 
@@ -81,12 +82,11 @@ export function SlotConfigurator() {
     [slotConfig, setParam, activeAxis]
   );
 
-  const clampPitch = useCallback((value: number) => {
-    return Math.min(
-      DESIGNER_CONSTRAINTS.MAX_SLOT_PITCH,
-      Math.max(DESIGNER_CONSTRAINTS.MIN_SLOT_PITCH, value)
-    );
-  }, []);
+  const clampPitch = useCallback(
+    (value: number) =>
+      clamp(value, DESIGNER_CONSTRAINTS.MIN_SLOT_PITCH, DESIGNER_CONSTRAINTS.MAX_SLOT_PITCH),
+    []
+  );
 
   // ── Divider piece calculations ──────────────────────────────────────
   const updateDividerPieces = useCallback(

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.tsx
@@ -15,6 +15,7 @@ import {
 import { useTranslation } from '@/i18n';
 import { Button, Checkbox, Stepper } from '@/design-system';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
+import { clamp } from '@/shared/utils/math';
 
 interface CutoutArrayControlsProps {
   readonly cutout: Cutout;
@@ -272,7 +273,7 @@ function ArrayStepRow({
   unit,
   disabled,
 }: ArrayStepRowProps) {
-  const clamp = (v: number): number => Math.min(max, Math.max(min, Number(v.toFixed(3))));
+  const clampArray = (v: number): number => clamp(Number(v.toFixed(3)), min, max);
   return (
     <div className="flex items-center justify-between gap-2">
       <span className="text-xs text-content-secondary">
@@ -282,8 +283,8 @@ function ArrayStepRow({
       <Stepper
         size="sm"
         value={value}
-        onChange={(v) => onChange(clamp(v))}
-        onStep={(delta) => onChange(clamp(value + delta * step))}
+        onChange={(v) => onChange(clampArray(v))}
+        onStep={(delta) => onChange(clampArray(value + delta * step))}
         min={min}
         max={max}
         step={step}

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutFitControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutFitControls.tsx
@@ -11,6 +11,7 @@ import type { Cutout } from '@/features/bin-designer/types';
 import { CLEARANCE_SHAPES, CHAMFER_SHAPES, maxEntryChamfer } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { Stepper } from '@/design-system';
+import { clamp } from '@/shared/utils/math';
 import type { FitCue } from './cutoutSectionVisibility';
 
 /** Stepper increment for fit fields — coarse enough to tune by clicking, while
@@ -109,7 +110,7 @@ function FitStepRow({
   disabled,
   ...cueHandlers
 }: FitStepRowProps) {
-  const clamp = (v: number): number => Math.min(max, Math.max(min, Number(v.toFixed(3))));
+  const clampFit = (v: number): number => clamp(Number(v.toFixed(3)), min, max);
   return (
     <div className="flex items-center justify-between gap-2" title={info} {...cueHandlers}>
       <span className="text-xs text-content-secondary">
@@ -119,8 +120,8 @@ function FitStepRow({
       <Stepper
         size="sm"
         value={value}
-        onChange={(v) => onChange(clamp(v))}
-        onStep={(delta) => onChange(clamp(value + delta * FIT_STEP))}
+        onChange={(v) => onChange(clampFit(v))}
+        onStep={(delta) => onChange(clampFit(value + delta * FIT_STEP))}
         min={min}
         max={max}
         step={FIT_STEP}

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathDrawingHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathDrawingHandler.ts
@@ -8,6 +8,7 @@
  */
 
 import type { PathPoint } from '@/features/bin-designer/types';
+import { clamp } from '@/shared/utils/math';
 import type { PointerMoveEvent, BinBounds, SnapFn } from './types';
 import {
   cornerPoint,
@@ -78,9 +79,8 @@ export function handlePathDrawingPointerDown(
   snap: SnapFn,
   setters: PathDrawingSetters
 ): void {
-  const clamp = (v: number, max: number) => Math.max(0, Math.min(v, max));
-  let x = snap(clamp(mmX, bounds.binWidth));
-  let y = snap(clamp(mmY, bounds.binDepth));
+  let x = snap(clamp(mmX, 0, bounds.binWidth));
+  let y = snap(clamp(mmY, 0, bounds.binDepth));
 
   if (mode === null || mode.points.length === 0) {
     setters.setMode({
@@ -97,8 +97,8 @@ export function handlePathDrawingPointerDown(
 
   if (shiftKey) {
     const snapped = snapAngle45(lastPt.x, lastPt.y, x, y);
-    x = snap(clamp(snapped.x, bounds.binWidth));
-    y = snap(clamp(snapped.y, bounds.binDepth));
+    x = snap(clamp(snapped.x, 0, bounds.binWidth));
+    y = snap(clamp(snapped.y, 0, bounds.binDepth));
   }
 
   if (
@@ -155,9 +155,8 @@ export function handlePathDrawingPointerMove(
   const { points, activePointDrag, repositionIndex } = mode;
   if (points.length === 0) return;
 
-  const clamp = (v: number, max: number) => Math.max(0, Math.min(v, max));
-  const cursorX = clamp(event.mmX, bounds.binWidth);
-  const cursorY = clamp(event.mmY, bounds.binDepth);
+  const cursorX = clamp(event.mmX, 0, bounds.binWidth);
+  const cursorY = clamp(event.mmY, 0, bounds.binDepth);
 
   // Repositioning an existing vertex
   if (repositionIndex !== null) {
@@ -166,8 +165,8 @@ export function handlePathDrawingPointerMove(
     if (event.shiftKey && repositionIndex > 0) {
       const prev = points[repositionIndex - 1];
       const snapped = snapAngle45(prev.x, prev.y, x, y);
-      x = clamp(snapped.x, bounds.binWidth);
-      y = clamp(snapped.y, bounds.binDepth);
+      x = clamp(snapped.x, 0, bounds.binWidth);
+      y = clamp(snapped.y, 0, bounds.binDepth);
     }
 
     const nextPoints = points.map((pt, i) => (i === repositionIndex ? { ...pt, x, y } : pt));

--- a/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
+++ b/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
@@ -19,6 +19,7 @@ import {
 } from '../shared';
 import { RulerIcon } from '@/design-system/Icon';
 import { Button } from '@/design-system';
+import { clamp } from '@/shared/utils/math';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
 import { useHandleSection, HANDLE_SIDES } from './useHandleSection';
 import type { HandleCutoutShape, HandleWallSide } from '@/features/bin-designer/types';
@@ -30,8 +31,6 @@ const SHAPE_OPTIONS: readonly { value: HandleCutoutShape; labelKey: string }[] =
   { value: 'oval', labelKey: 'binDesigner.handles.shape.oval' },
   { value: 'scoop', labelKey: 'binDesigner.handles.shape.scoop' },
 ];
-
-const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
 export function HandleSection() {
   const { state, handlers, meta, t } = useHandleSection();

--- a/src/features/bin-designer/components/panel/ToolRackSection/ToolRackParameterPanel.tsx
+++ b/src/features/bin-designer/components/panel/ToolRackSection/ToolRackParameterPanel.tsx
@@ -5,6 +5,7 @@
  */
 import { useShallow } from 'zustand/react/shallow';
 import { Button, Stepper, Switch } from '@/design-system';
+import { clamp } from '@/shared/utils/math';
 import { useTranslation } from '@/i18n';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { StickyGroupHeader } from '../StickyGroupHeader';
@@ -26,14 +27,13 @@ interface FieldProps {
 }
 
 function NumberField({ label, value, min, max, step, onChange }: FieldProps) {
-  const clamp = (v: number): number => Math.min(max, Math.max(min, v));
   return (
     <div>
       <span className="mb-1 block text-xs text-content-tertiary">{label}</span>
       <Stepper
         value={value}
-        onChange={(v) => onChange(clamp(v))}
-        onStep={(delta) => onChange(clamp(value + delta * step))}
+        onChange={(v) => onChange(clamp(v, min, max))}
+        onStep={(delta) => onChange(clamp(value + delta * step, min, max))}
         min={min}
         max={max}
         step={step}

--- a/src/features/bin-designer/utils/dividerAngle.ts
+++ b/src/features/bin-designer/utils/dividerAngle.ts
@@ -15,6 +15,7 @@
 
 import { GRIDFINITY, DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants/gridfinity';
 import type { CompartmentConfig } from '@/features/bin-designer/types';
+import { clamp } from '@/shared/utils/math';
 import { getCompartmentBounds, type EligibleDivider } from './compartments';
 
 /** The subset of bin parameters needed to derive interior dimensions in mm. */
@@ -143,8 +144,10 @@ export function angleShiftToOffsets(value: AngleShift, segmentLengthMm: number):
 }
 
 function clampOffsets(offsets: DividerOffsets, geom: DividerGeometry): DividerOffsets {
-  const clamp = (v: number): number => Math.max(geom.offsetMin, Math.min(geom.offsetMax, v));
-  return { offsetStart: clamp(offsets.offsetStart), offsetEnd: clamp(offsets.offsetEnd) };
+  return {
+    offsetStart: clamp(offsets.offsetStart, geom.offsetMin, geom.offsetMax),
+    offsetEnd: clamp(offsets.offsetEnd, geom.offsetMin, geom.offsetMax),
+  };
 }
 
 /**

--- a/src/features/generation/worker/generators/baseplateSlab.ts
+++ b/src/features/generation/worker/generators/baseplateSlab.ts
@@ -6,6 +6,7 @@ import { drawRectangle, drawRoundedRectangle, draw } from 'brepjs';
 import type { Drawing } from 'brepjs';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { CONSTRAINTS } from '@/core/constants';
+import { clamp } from '@/shared/utils/math';
 import { exteriorCorners } from '@/shared/generation/baseplateCorners';
 
 /**
@@ -96,17 +97,17 @@ export function sanitizeParams(params: ResolvedBaseplateParams): ResolvedBasepla
     );
   }
 
-  const clamp = (v: number, min: number, max: number): number =>
-    Number.isFinite(v) ? Math.max(min, Math.min(max, v)) : min;
+  const clampFinite = (v: number, min: number, max: number): number =>
+    Number.isFinite(v) ? clamp(v, min, max) : min;
 
   return {
     ...params,
-    gridUnitMm: clamp(params.gridUnitMm, 1, 200),
-    magnetDiameter: clamp(params.magnetDiameter, 0.5, 20),
-    magnetDepth: clamp(params.magnetDepth, 0.5, 10),
-    paddingLeft: clamp(params.paddingLeft, 0, 100),
-    paddingRight: clamp(params.paddingRight, 0, 100),
-    paddingFront: clamp(params.paddingFront, 0, 100),
-    paddingBack: clamp(params.paddingBack, 0, 100),
+    gridUnitMm: clampFinite(params.gridUnitMm, 1, 200),
+    magnetDiameter: clampFinite(params.magnetDiameter, 0.5, 20),
+    magnetDepth: clampFinite(params.magnetDepth, 0.5, 10),
+    paddingLeft: clampFinite(params.paddingLeft, 0, 100),
+    paddingRight: clampFinite(params.paddingRight, 0, 100),
+    paddingFront: clampFinite(params.paddingFront, 0, 100),
+    paddingBack: clampFinite(params.paddingBack, 0, 100),
   };
 }

--- a/src/features/generation/worker/generators/generatorConstants.ts
+++ b/src/features/generation/worker/generators/generatorConstants.ts
@@ -7,6 +7,7 @@
 
 import { GRIDFINITY } from '@/shared/constants/bin';
 import { OVER_TILE_MIN_MARGIN_MM } from '@/core/constants';
+import { clamp } from '@/shared/utils/math';
 export const SIZE = GRIDFINITY.GRID_SIZE;
 export const HEIGHT_UNIT = GRIDFINITY.HEIGHT_UNIT;
 export const CLEARANCE = GRIDFINITY.TOLERANCE;
@@ -84,12 +85,11 @@ export function resolveCornerRadii(
 ): { tl: number; tr: number; bl: number; br: number } {
   const defaultR = params.cornerRadius ?? PLATE_CORNER_RADIUS;
   const radii = params.cornerRadii ?? { tl: defaultR, tr: defaultR, bl: defaultR, br: defaultR };
-  const clamp = (r: number): number => Math.max(0, Math.min(r, maxRadius));
   return {
-    tl: clamp(radii.tl),
-    tr: clamp(radii.tr),
-    bl: clamp(radii.bl),
-    br: clamp(radii.br),
+    tl: clamp(radii.tl, 0, maxRadius),
+    tr: clamp(radii.tr, 0, maxRadius),
+    bl: clamp(radii.bl, 0, maxRadius),
+    br: clamp(radii.br, 0, maxRadius),
   };
 }
 

--- a/src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
+++ b/src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import type { KeyboardEvent } from 'react';
 import type { Layer, LayerId } from '@/core/types';
 import { CONSTRAINTS } from '@/core/constants';
+import { clamp } from '@/shared/utils/math';
 import { IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
@@ -32,10 +33,6 @@ interface HeightCrossSectionDiagramProps {
   onEditingStart: (layerId: LayerId) => void;
   onEditingEnd: () => void;
   layerStats: Partial<Record<string, LayerStat>>;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
 }
 
 function GripIcon({ className }: { className?: string }) {

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -10,6 +10,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { Button } from '@/design-system';
 import { cn } from '@/design-system/cn';
+import { clamp as clampRange } from '@/shared/utils/math';
 
 interface CompactNumberInputProps {
   readonly label: string;
@@ -61,7 +62,7 @@ export function CompactNumberInput({
   const [scrubbing, setScrubbing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const clamp = useCallback((v: number) => Math.max(min, Math.min(max, v)), [min, max]);
+  const clamp = useCallback((v: number) => clampRange(v, min, max), [min, max]);
 
   const formatValue = useCallback((v: number) => {
     const rounded = Math.round(v * 100) / 100;

--- a/src/shared/utils/cutoutArray.ts
+++ b/src/shared/utils/cutoutArray.ts
@@ -12,6 +12,7 @@
 
 import type { Cutout, CutoutArrayConfig } from '@/features/bin-designer/types';
 import { MAX_ARRAY_INSTANCES, MAX_ARRAY_COUNT } from '@/features/bin-designer/types';
+import { clamp } from './math';
 
 /** Absolute editor caps for array spacing (mm), independent of bin size. */
 export const ARRAY_MIN_PITCH = 1;
@@ -144,7 +145,6 @@ export interface ArrayFieldBounds {
   readonly maxRadius: number;
 }
 
-const clampNum = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v));
 const floorToHalf = (v: number): number => Math.floor(v * 2) / 2;
 
 /**
@@ -174,12 +174,12 @@ export function arrayFieldBounds(
   // How many extra steps fit at the current pitch, plus the master itself.
   const stepsX = config.pitchX > 0 ? Math.floor((availX - stagger) / config.pitchX) : 0;
   const stepsY = config.pitchY > 0 ? Math.floor(availY / config.pitchY) : 0;
-  const maxCols = clampNum(
+  const maxCols = clamp(
     Math.min(1 + Math.max(0, stepsX), Math.floor(MAX_ARRAY_INSTANCES / rows)),
     1,
     MAX_ARRAY_COUNT
   );
-  const maxRows = clampNum(
+  const maxRows = clamp(
     Math.min(1 + Math.max(0, stepsY), Math.floor(MAX_ARRAY_INSTANCES / cols)),
     1,
     MAX_ARRAY_COUNT
@@ -188,12 +188,12 @@ export function arrayFieldBounds(
   // Largest pitch that keeps the current counts inside the bin.
   const colSpan = cols - 1 + colExtraSpan;
   const rowSpan = rows - 1;
-  const maxPitchX = clampNum(
+  const maxPitchX = clamp(
     floorToHalf(colSpan > 0 ? availX / colSpan : ARRAY_MAX_PITCH),
     ARRAY_MIN_PITCH,
     ARRAY_MAX_PITCH
   );
-  const maxPitchY = clampNum(
+  const maxPitchY = clamp(
     floorToHalf(rowSpan > 0 ? availY / rowSpan : ARRAY_MAX_PITCH),
     ARRAY_MIN_PITCH,
     ARRAY_MAX_PITCH
@@ -208,7 +208,7 @@ export function arrayFieldBounds(
     binWidth - (cutout.x + w),
     binDepth - (cutout.y + d)
   );
-  const maxRadius = clampNum(floorToHalf(edgeClearance), ARRAY_MIN_RADIUS, ARRAY_MAX_RADIUS);
+  const maxRadius = clamp(floorToHalf(edgeClearance), ARRAY_MIN_RADIUS, ARRAY_MAX_RADIUS);
 
   // Minimum pitch that preserves at least ARRAY_MIN_WALL_GAP of material between instances.
   const minPitchX = Math.max(ARRAY_MIN_PITCH, floorToHalf(w) + ARRAY_MIN_WALL_GAP);

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -32,6 +32,8 @@ export {
 } from './bins';
 export type { VisibleBinsOptions } from './bins';
 
+export { clamp } from './math';
+
 export {
   isValidDrawer,
   isValidLayer,
@@ -42,7 +44,6 @@ export {
   validateImport,
   validateLayoutIntegrity,
   validateCustomProperties,
-  clamp,
   truncate,
   formatDimension,
 } from './validation';

--- a/src/shared/utils/math.test.ts
+++ b/src/shared/utils/math.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { clamp } from '@/shared/utils/math';
+
+describe('clamp', () => {
+  it('returns the value when within range', () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+
+  it('clamps to min when below range', () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+  });
+
+  it('clamps to max when above range', () => {
+    expect(clamp(15, 0, 10)).toBe(10);
+  });
+
+  it('handles min === max', () => {
+    expect(clamp(3, 5, 5)).toBe(5);
+    expect(clamp(7, 5, 5)).toBe(5);
+    expect(clamp(5, 5, 5)).toBe(5);
+  });
+
+  it('handles negative ranges', () => {
+    expect(clamp(-7, -10, -2)).toBe(-7);
+    expect(clamp(-15, -10, -2)).toBe(-10);
+    expect(clamp(0, -10, -2)).toBe(-2);
+  });
+});

--- a/src/shared/utils/math.test.ts
+++ b/src/shared/utils/math.test.ts
@@ -27,4 +27,11 @@ describe('clamp', () => {
     expect(clamp(-15, -10, -2)).toBe(-10);
     expect(clamp(0, -10, -2)).toBe(-2);
   });
+
+  it('propagates NaN — clamp has no finite guard', () => {
+    // Documented contract: clamp does NOT sanitize non-finite input. Callers
+    // that need NaN/Infinity coerced (e.g. baseplateSlab's clampFinite) must
+    // guard before/around the clamp call.
+    expect(clamp(NaN, 0, 10)).toBeNaN();
+  });
 });

--- a/src/shared/utils/math.ts
+++ b/src/shared/utils/math.ts
@@ -1,0 +1,10 @@
+/**
+ * Pure numeric helpers with no domain coupling.
+ */
+
+/**
+ * Clamp a value to a range.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/shared/utils/validation.test.ts
+++ b/src/shared/utils/validation.test.ts
@@ -3,7 +3,6 @@ import {
   canPlaceBin,
   validateImport,
   salvageImport,
-  clamp,
   truncate,
   validateLayoutIntegrity,
   validateCustomProperties,
@@ -421,14 +420,6 @@ describe('salvageImport', () => {
     const stagedBins = result.layout.bins.filter((b) => b.layerId === STAGING_ID);
     expect(stagedBins).toHaveLength(1);
     expect(stagedBins[0].id).toBe('staged');
-  });
-});
-
-describe('clamp', () => {
-  it('clamps values to range', () => {
-    expect(clamp(5, 0, 10)).toBe(5);
-    expect(clamp(-5, 0, 10)).toBe(0);
-    expect(clamp(15, 0, 10)).toBe(10);
   });
 });
 

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -3,9 +3,9 @@
  *
  * The implementation lives in focused sibling modules; this file
  * re-exports the public surface and houses small formatting helpers
- * (`clamp`, `truncate`, `formatDimension`, `getPlacementErrorMessage`,
+ * (`truncate`, `formatDimension`, `getPlacementErrorMessage`,
  * `validateLayoutIntegrity`) that don't belong with the heavier
- * validators.
+ * validators. `clamp` is re-exported from `./math` for back-compat.
  *
  * Sibling modules:
  *   - `validationGuards`     — type guards + raw shape interfaces
@@ -19,6 +19,7 @@ import type { Layout, ValidationReason, BlockingInfo } from '@/core/types';
 import type { TFunction } from '@/i18n';
 import { STAGING_ID } from '@/core/constants';
 
+export { clamp } from './math';
 export { isValidDrawer, isValidLayer, isValidBin, isValidCategory } from './validationGuards';
 export { canPlaceBin } from './validationPlacement';
 export { validateCustomProperties } from './validationProperties';
@@ -64,13 +65,6 @@ export function validateLayoutIntegrity(layout: Layout): { valid: boolean; error
   }
 
   return { valid: true };
-}
-
-/**
- * Clamp a value to a range.
- */
-export function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
 }
 
 /**

--- a/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
@@ -7,12 +7,11 @@ import { PrintBedInput } from '@/shared/components/PrintBedInput';
 import { SettingsRow } from '@/shared/components/SettingsRow';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { useDrawerSettings } from '@/shared/hooks/useDrawerSettings';
+import { clamp } from '@/shared/utils/math';
 import { Button, Stepper } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { SettingSection } from '../../components/SettingSection/SettingSection';
 import type { UserSettings } from '@/core/store/settings';
-
-const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
 
 const LAYOUT_DEFAULT_KEYS: (keyof UserSettings)[] = [
   'defaultDrawerWidth',

--- a/src/shell/Modals/SettingsModal/tabs/PrintTab/PrintTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/PrintTab/PrintTab.tsx
@@ -4,6 +4,7 @@ import { PRINT_SETTINGS_CONSTRAINTS } from '@/shared/printSettings';
 import type { PrintSettings } from '@/shared/printSettings';
 import { SettingsRow } from '@/shared/components/SettingsRow';
 import { Stepper } from '@/design-system';
+import { clamp } from '@/shared/utils/math';
 import { useTranslation } from '@/i18n';
 import { SettingSection } from '../../components/SettingSection/SettingSection';
 
@@ -62,7 +63,7 @@ const PRINT_FIELDS: PrintFieldConfig[] = [
 // (e.g. 0.08 + 0.04) doesn't accumulate floating-point drift.
 const clampRound = (value: number, min: number, max: number, decimals: number): number => {
   const rounded = Number(value.toFixed(decimals));
-  return Math.max(min, Math.min(max, rounded));
+  return clamp(rounded, min, max);
 };
 
 export function PrintTab() {


### PR DESCRIPTION
## What

A canonical `clamp(value, min, max)` already existed (oddly, inside `validation.ts`) and was imported by ~16 files — yet **17 more files re-implemented an identical local clamp** under various names (`clampNum`, `clampMm`, `clampToGrid`, `clampRound`, inline closures…).

- **New `src/shared/utils/math.ts`** holds the canonical `clamp` (moved verbatim). `validation.ts` re-exports it (`export { clamp } from './math'`) so the ~16 existing importers are untouched; the barrel re-exports it too.
- **17 local redefinitions deleted**, each call site now uses the shared `clamp` (argument order normalized to `(value, min, max)`).
- **Composites kept as thin wrappers** (`clampRound`, `clampFit`, `clampArray`, `clampMm`, `clampToGrid`) — clamp + round/snap, with **exact** rounding/snap behavior preserved.

## Behavior preservation (careful bits)
- `baseplateSlab.ts`'s local clamp had a `Number.isFinite` guard (returns `min` for NaN/Inf) that the shared `clamp` does **not** replicate — kept as `clampFinite` delegating only the clamp portion.
- Argument-order variants (`Math.min(hi, Math.max(lo, v))`, `(v, max)` implicit-min-0, `Math.min(r, maxRadius)`) all verified equivalent to `clamp(value, min, max)`. **No numeric result changes.**

## Scope
Only the **named** local redefinitions. The ~40 bare inline `Math.max(min, Math.min(max, x))` sites are intentionally left (high-churn / low-value).

New `math.test.ts` (5). `pnpm run typecheck` 0 errors; ESLint clean; affected suites green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated the numeric clamp helper into `@/shared/utils/math` and removed 17 local reimplementations across the app. Behavior is unchanged; existing imports continue to work via re-export.

- **Refactors**
  - Moved `clamp(value, min, max)` from `src/shared/utils/validation.ts` to `src/shared/utils/math.ts`, and re-exported from `validation.ts` and `src/shared/utils/index.ts`.
  - Replaced local clamps with the shared helper and normalized arg order to `(value, min, max)`.
  - Kept composites as thin wrappers (e.g., `clampRound`, `clampFit`, `clampArray`, `clampMm`, `clampToGrid`); retained baseplate’s finite guard as `clampFinite`.
  - Added `src/shared/utils/math.test.ts` (including an explicit NaN-propagation contract); removed duplicate clamp tests from `validation.test.ts`.

<sup>Written for commit a58bf8e4fd0c17c9f19649d0e8e1a4b6f721c93c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

