### PR TITLE
fix(baseplate): margin connector must engage on the default dovetail style

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -54,6 +54,7 @@ import {
 } from '@/shared/constants/connectors';
 import type { StoredBaseplateParams } from '@/core/types';
 import { gridUnits, mm } from '@/core/types';
+import { isSeamConnectorStyle } from '@/shared/types/bin';
 
 /** How the drawer-fit padding margin is filled. */
 type MarginFillMode = 'solid' | 'tile' | 'halfGrid';
@@ -258,8 +259,8 @@ export function BaseplatePanel() {
   const marginConnectorStored = baseplateParams.detachMarginConnector === true;
   // The seam connector reuses the body's tongue/groove; snapClip/dovetailKey
   // seams would need a separate clip part, so they stay friction-fit (#2414).
-  const marginConnectorStyleOk =
-    baseplateParams.connectorStyle === 'dovetail' || baseplateParams.connectorStyle === 'puzzle';
+  // `undefined` is the stored default for dovetail, so it counts.
+  const marginConnectorStyleOk = isSeamConnectorStyle(baseplateParams.connectorStyle);
 
   const hasFractionalWidth = effectiveWidth % 1 !== 0;
   const hasFractionalDepth = effectiveDepth % 1 !== 0;

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1488,6 +1488,14 @@ describe('margin-seam connector edge assignment (#2414)', () => {
     expect(frontEdges(p)).toEqual(new Set(['marginSeam']));
   });
 
+  it('engages on the default (undefined) connector style, which is dovetail', () => {
+    // The ConnectorPicker persists dovetail as an absent connectorStyle, so the
+    // seam must engage when it's undefined (the common default case).
+    const p = makeParams({ detachMargins: true, detachMarginConnector: true, paddingFront: P });
+    expect(p.connectorStyle).toBeUndefined();
+    expect(frontEdges(p)).toEqual(new Set(['marginSeam']));
+  });
+
   it('leaves the seam a plain exterior edge when the connector is off', () => {
     const p = makeParams({ detachMargins: true, paddingFront: P });
     expect(frontEdges(p)).toEqual(new Set(['exterior']));

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -17,7 +17,7 @@
  */
 
 import type { BaseplateEdgeKind, ResolvedBaseplateParams } from '@/shared/types/bin';
-import { isExteriorEdge } from '@/shared/types/bin';
+import { isExteriorEdge, isSeamConnectorStyle } from '@/shared/types/bin';
 // The fit checker subtracts the tongue protrusion from the bed budget on male
 // join edges — otherwise pieces that compute to exactly the bed width on paper
 // exceed it as STLs (#1498).
@@ -789,9 +789,10 @@ export function computeBaseplateTiling(
   // matters when a SPLIT body chunk sits within 1.5mm of the bed on a detached
   // seam side — a rare compound case. Precise per-side seam budgeting is a
   // follow-up; deferred to avoid destabilizing the split math for all plates.
-  const seamStyleOk = params.connectorStyle === 'dovetail' || params.connectorStyle === 'puzzle';
   const seamOn =
-    params.detachMargins === true && params.detachMarginConnector === true && seamStyleOk;
+    params.detachMargins === true &&
+    params.detachMarginConnector === true &&
+    isSeamConnectorStyle(params.connectorStyle);
   const longAxisX = det.front || det.back;
   const seam = {
     left: seamOn && det.left && !longAxisX,

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -35,6 +35,7 @@
 import { draw, rotate, translate, intersect, cutAll, clone } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing } from 'brepjs';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+import { isSeamConnectorStyle } from '@/shared/types/bin';
 import { isOk, unwrap } from '@/core/result';
 import {
   TONGUE_PROTRUSION,
@@ -180,9 +181,8 @@ export function buildConnectors(
   // without split-piece dovetails. Only the integral tongue/groove styles carry
   // a seam; snapClip/dovetailKey stay friction-fit (splitPlanner enforces this,
   // and this guard keeps the function self-consistent if called directly).
-  const seamStyleOk = params.connectorStyle === 'dovetail' || params.connectorStyle === 'puzzle';
   const hasMarginSeam =
-    seamStyleOk &&
+    isSeamConnectorStyle(params.connectorStyle) &&
     (edges.left === 'marginSeam' ||
       edges.right === 'marginSeam' ||
       edges.front === 'marginSeam' ||

--- a/src/features/generation/worker/generators/baseplateMargin.ts
+++ b/src/features/generation/worker/generators/baseplateMargin.ts
@@ -20,6 +20,7 @@
 import { mesh, meshEdges, translate, getKernelCapabilities, exportSTEP, unwrap } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { ResolvedBaseplateParams, MarginPiece } from '@/shared/types/bin';
+import { isSeamConnectorStyle } from '@/shared/types/bin';
 import type { MeshData, ExportFormat } from '../../bridge/types';
 import {
   SOCKET_HEIGHT,
@@ -143,8 +144,11 @@ function buildMarginSolid(
   // face to receive the body's tongue. Long rails are exactly the seam sides
   // (splitPlanner marks the matching body edge `marginSeam`); short rails stay
   // friction-fit. Only dovetail/puzzle styles carry a seam.
-  const seamStyleOk = params.connectorStyle === 'dovetail' || params.connectorStyle === 'puzzle';
-  if (params.detachMarginConnector === true && seamStyleOk && margin.role === 'long') {
+  if (
+    params.detachMarginConnector === true &&
+    isSeamConnectorStyle(params.connectorStyle) &&
+    margin.role === 'long'
+  ) {
     const groove = buildMarginSeamGroove(
       margin.side,
       railW,

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -127,8 +127,9 @@ export function isExteriorEdge(kind: BaseplateEdgeKind): boolean {
   return kind === 'exterior' || kind === 'marginSeam';
 }
 
-/** Baseplate split-connector styles. */
-export type BaseplateConnectorStyle = 'dovetail' | 'puzzle' | 'dovetailKey' | 'snapClip';
+/** Baseplate split-connector styles — derived from the param definition below
+ *  so it can't drift when a style is added. */
+export type BaseplateConnectorStyle = NonNullable<ResolvedBaseplateParams['connectorStyle']>;
 
 /**
  * Whether the margin-seam connector (#2414) engages for a given connector

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -127,6 +127,20 @@ export function isExteriorEdge(kind: BaseplateEdgeKind): boolean {
   return kind === 'exterior' || kind === 'marginSeam';
 }
 
+/** Baseplate split-connector styles. */
+export type BaseplateConnectorStyle = 'dovetail' | 'puzzle' | 'dovetailKey' | 'snapClip';
+
+/**
+ * Whether the margin-seam connector (#2414) engages for a given connector
+ * style. Scoped to the integral tongue/groove families — dovetail and puzzle —
+ * because snapClip/dovetailKey would need a separate printed part the seam must
+ * not emit. `undefined` is the stored default for dovetail (the ConnectorPicker
+ * persists dovetail as absent), so it counts as a tongue/groove style.
+ */
+export function isSeamConnectorStyle(style: BaseplateConnectorStyle | undefined): boolean {
+  return style === undefined || style === 'dovetail' || style === 'puzzle';
+}
+
 /** Per-side edge classification for split baseplate pieces. */
 export interface BaseplateEdges {
   readonly left: BaseplateEdgeKind;


### PR DESCRIPTION
Follow-up to #2420 (#2414). **Caught during visual verification** of the margin connector.

## The bug

The ConnectorPicker persists the default **Dovetail** style as an *absent* `connectorStyle` (`undefined`) — clicking "Dovetail" stores `connectorStyle: undefined`, since it's the implicit default. But the margin-seam gate I shipped required the literal `'dovetail'` or `'puzzle'`:

```ts
connectorStyle === 'dovetail' || connectorStyle === 'puzzle'  // undefined → false
```

So on the **default style** the seam never engaged and the "Add connector" checkbox was **disabled** — the connector only worked if the user explicitly switched to Puzzle. That's the common case broken.

## The fix

A shared `isSeamConnectorStyle` helper in `@/shared/types/bin` that treats `undefined` (= default dovetail) as valid and excludes only snapClip/dovetailKey, applied at all four gates that were checking the style:

- `splitPlanner` edge assignment
- rail groove cut (`baseplateMargin`)
- the `buildConnectors` defensive guard
- the panel's checkbox-enable predicate

Adds a planner test for the `undefined`-default case.

## Verification

Confirmed live: on the default style, with padding + "Detach margins" on, the **"Add connector" checkbox is enabled and the connector engages** (previously disabled). The existing CSG mate test and the rest of the #2414 suite still pass; typecheck / lint / knip / all 4 i18n checks green.

Screenshot captured locally showing the exploded split baseplate with detached front/back rails and the connector enabled (split-piece connectors set to "None", demonstrating the connector's independent gating).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the margin-seam connector so it engages when the default Dovetail style is selected (stored as `undefined`). The “Add connector” checkbox is now enabled by default and connectors generate as expected.

- **Bug Fixes**
  - Added `isSeamConnectorStyle` helper that treats `undefined` as dovetail and excludes `snapClip`/`dovetailKey`.
  - Applied the helper in split planning, margin rail groove generation, connector building, and the panel’s enable check.
  - Added a planner test for the `undefined` default case.

- **Refactors**
  - Derived `BaseplateConnectorStyle` from `NonNullable<ResolvedBaseplateParams['connectorStyle']>` to avoid drift.

<sup>Written for commit 96849dec7fa91b5d8d50b3aee7864a5499b777c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

