### PR TITLE
fix(bin-designer): gate label tab on wall height, not unit count (#2422)

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
@@ -81,7 +81,9 @@ describe('useLabelTabsSection', () => {
     expect(useDesignerStore.getState().params.label.alignment).toBe('center');
   });
 
-  it('disabledReason set when height is at minimum (2u)', () => {
+  it('disabledReason set when wall height is at the label-tab minimum (default 2u = 9mm)', () => {
+    // Default 7mm height unit, socketed: 2u → wallHeight = 2×7 − 5 = 9mm,
+    // which equals MIN_LABEL_TAB_HEIGHT, so the tab still cannot fit.
     useDesignerStore.setState({
       params: { ...DEFAULT_BIN_PARAMS, height: 2 },
     });
@@ -92,9 +94,24 @@ describe('useLabelTabsSection', () => {
     expect(result.current.meta.disabledReason).toBeDefined();
   });
 
-  it('no disabledReason when height is above minimum', () => {
+  it('no disabledReason when wall height clears the minimum (default 3u = 16mm)', () => {
     useDesignerStore.setState({
       params: { ...DEFAULT_BIN_PARAMS, height: 3 },
+    });
+
+    const { result } = renderHook(() => useLabelTabsSection());
+
+    expect(result.current.state.isUnavailable).toBe(false);
+    expect(result.current.meta.disabledReason).toBeUndefined();
+  });
+
+  it('available at a low unit count when heightUnitMm makes the wall tall enough (#2422)', () => {
+    // Reporter's case: gating is on physical wall height (mm), not unit count.
+    // 2u × 20mm height unit, socketed → wallHeight = 2×20 − 5 = 35mm, well
+    // above MIN_LABEL_TAB_HEIGHT (9mm). The old `height <= 2u` gate wrongly
+    // disabled this tall-but-few-units bin.
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, height: 2, heightUnitMm: 20 },
     });
 
     const { result } = renderHook(() => useLabelTabsSection());

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -19,7 +19,6 @@ export function useLabelTabsSection() {
     compartments,
     label,
     textDefaults,
-    height,
     updateLabel,
     setCompartmentText,
     setTextDefaults,
@@ -29,7 +28,6 @@ export function useLabelTabsSection() {
       compartments: s.params.compartments,
       label: s.params.label,
       textDefaults: s.params.textDefaults,
-      height: s.params.height,
       updateLabel: s.updateLabel,
       setCompartmentText: s.setCompartmentText,
       setTextDefaults: s.setTextDefaults,
@@ -39,16 +37,19 @@ export function useLabelTabsSection() {
   const t = useTranslation();
 
   const labelStatus = getFeatureStatus(params, 'label');
-  // Dimensional constraint: cavity too shallow for label tab support at min height.
-  // Handled here (not in constraint engine) because ConstraintRule.source requires a
-  // FeatureKey, and "height" is a dimension, not a toggleable feature.
-  const tooShort = height <= DESIGNER_CONSTRAINTS.MIN_HEIGHT;
-  const isUnavailable = !labelStatus.available || tooShort;
 
   // Interior cavity height — dynamic max for the tab-height stepper and
   // the cap for the `setTabDepth` height-clamp. Matches `wallHeight`
   // passed to the geometry builder.
   const wallHeightMm = useMemo(() => binDimensions(params).wallHeight, [params]);
+
+  // Dimensional constraint: cavity too shallow for a label tab. Gated on the
+  // physical wall height (mm), not the height unit count, so tall bins with a
+  // custom heightUnitMm (or flat bins) aren't wrongly disabled. Handled here
+  // (not in the constraint engine) because ConstraintRule.source requires a
+  // FeatureKey, and height is a dimension, not a toggleable feature.
+  const tooShort = wallHeightMm <= DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_HEIGHT;
+  const isUnavailable = !labelStatus.available || tooShort;
 
   const toggleLabelTabs = useCallback(() => {
     updateLabel({ enabled: !label.enabled });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "Tab-Höhe",
   "binDesigner.labelTabs.insetAria": "Tab-Versatz",
   "binDesigner.labelTabs.widthAria": "Tab-Breite",
-  "binDesigner.labelTabsUnavailableMinHeight": "Nicht genug Platz bei 2u Höhe",
+  "binDesigner.labelTabsUnavailableMinHeight": "Der Behälter ist zu flach für einen Etikettenhalter",
   "binDesigner.labelTabsUnavailableSlotted": "Nicht verfügbar für Schlitz-Bins",
   "binDesigner.lid": "Deckel",
   "binDesigner.lid.clickRailCoverage": "Schienenabdeckung",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1496,7 +1496,7 @@ const en: Record<string, string> = {
   'binDesigner.labelTabs': 'Label tabs',
   'binDesigner.compartmentsUnavailableSlotted': 'Not available for slotted bins',
   'binDesigner.labelTabsUnavailableSlotted': 'Not available for slotted bins',
-  'binDesigner.labelTabsUnavailableMinHeight': 'Not enough room at 2u height',
+  'binDesigner.labelTabsUnavailableMinHeight': 'Bin is too shallow for a label tab',
   'binDesigner.tabSupport': 'Support',
   'binDesigner.tabSupport.bracket': 'Bracket',
   'binDesigner.tabSupport.solid': 'Solid',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "Altura de la pestaña",
   "binDesigner.labelTabs.insetAria": "Margen de la pestaña",
   "binDesigner.labelTabs.widthAria": "Ancho de la pestaña",
-  "binDesigner.labelTabsUnavailableMinHeight": "No hay suficiente espacio a 2u de altura",
+  "binDesigner.labelTabsUnavailableMinHeight": "El contenedor es demasiado bajo para una pestaña de etiqueta",
   "binDesigner.labelTabsUnavailableSlotted": "No disponible para contenedores ranurados",
   "binDesigner.lid": "Tapa",
   "binDesigner.lid.clickRailCoverage": "Cobertura de los rieles",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "Hauteur de l'onglet",
   "binDesigner.labelTabs.insetAria": "Décalage de l'onglet",
   "binDesigner.labelTabs.widthAria": "Largeur de l'onglet",
-  "binDesigner.labelTabsUnavailableMinHeight": "Pas assez de place à 2u de hauteur",
+  "binDesigner.labelTabsUnavailableMinHeight": "Le bac est trop peu profond pour un onglet d'étiquette",
   "binDesigner.labelTabsUnavailableSlotted": "Non disponible pour les bacs à fentes",
   "binDesigner.lid": "Couvercle",
   "binDesigner.lid.clickRailCoverage": "Couverture des rails",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "タブの高さ",
   "binDesigner.labelTabs.insetAria": "タブのインセット",
   "binDesigner.labelTabs.widthAria": "タブの幅",
-  "binDesigner.labelTabsUnavailableMinHeight": "2u高では十分なスペースがありません",
+  "binDesigner.labelTabsUnavailableMinHeight": "ビンが浅すぎてラベルタブを配置できません",
   "binDesigner.labelTabsUnavailableSlotted": "スロット式ビンでは利用できません",
   "binDesigner.lid": "蓋",
   "binDesigner.lid.clickRailCoverage": "レール被覆率",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "Tab-høyde",
   "binDesigner.labelTabs.insetAria": "Tab-innfelling",
   "binDesigner.labelTabs.widthAria": "Tab-bredde",
-  "binDesigner.labelTabsUnavailableMinHeight": "Ikke nok plass ved 2u høyde",
+  "binDesigner.labelTabsUnavailableMinHeight": "Boksen er for grunn for en etikettfane",
   "binDesigner.labelTabsUnavailableSlotted": "Ikke tilgjengelig for spor-bokser",
   "binDesigner.lid": "Lokk",
   "binDesigner.lid.clickRailCoverage": "Skinnedekning",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "Tabhoogte",
   "binDesigner.labelTabs.insetAria": "Tabinzet",
   "binDesigner.labelTabs.widthAria": "Tabbreedte",
-  "binDesigner.labelTabsUnavailableMinHeight": "Niet genoeg ruimte bij 2u hoogte",
+  "binDesigner.labelTabsUnavailableMinHeight": "Bak is te ondiep voor een labeltab",
   "binDesigner.labelTabsUnavailableSlotted": "Niet beschikbaar voor bins met sleuven",
   "binDesigner.lid": "Deksel",
   "binDesigner.lid.clickRailCoverage": "Raildekking",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "Altura da aba",
   "binDesigner.labelTabs.insetAria": "Recuo da aba",
   "binDesigner.labelTabs.widthAria": "Largura da aba",
-  "binDesigner.labelTabsUnavailableMinHeight": "Espaço insuficiente a 2u de altura",
+  "binDesigner.labelTabsUnavailableMinHeight": "A caixa é rasa demais para uma aba de etiqueta",
   "binDesigner.labelTabsUnavailableSlotted": "Não disponível para caixas com ranhuras",
   "binDesigner.lid": "Tampa",
   "binDesigner.lid.clickRailCoverage": "Cobertura dos trilhos",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "Flikhöjd",
   "binDesigner.labelTabs.insetAria": "Flikinsättning",
   "binDesigner.labelTabs.widthAria": "Flikbredd",
-  "binDesigner.labelTabsUnavailableMinHeight": "Inte tillräckligt med plats vid 2u höjd",
+  "binDesigner.labelTabsUnavailableMinHeight": "Lådan är för grund för en etikettflik",
   "binDesigner.labelTabsUnavailableSlotted": "Inte tillgängligt för fack med slitsar",
   "binDesigner.lid": "Lock",
   "binDesigner.lid.clickRailCoverage": "Skenetäckning",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -653,7 +653,7 @@
   "binDesigner.labelTabs.heightAria": "Висота вкладки",
   "binDesigner.labelTabs.insetAria": "Відступ вкладки",
   "binDesigner.labelTabs.widthAria": "Ширина вкладки",
-  "binDesigner.labelTabsUnavailableMinHeight": "Недостатньо місця при висоті 2u",
+  "binDesigner.labelTabsUnavailableMinHeight": "Контейнер занадто мілкий для виступу для мітки",
   "binDesigner.labelTabsUnavailableSlotted": "Недоступно для бінів зі слотами",
   "binDesigner.lid": "Кришка",
   "binDesigner.lid.clickRailCoverage": "Покриття рейок",


### PR DESCRIPTION
Fixes #2422

## Problem

The label tab feature was gated by height **unit count** (`height <= 2u`) rather than the bin's physical wall height. A bin configured with a large `heightUnitMm` (Physical Units) but a low unit count has plenty of vertical wall to hold a tab, yet was wrongly marked unavailable — the reporter's "unavailable even with large height" case.

## Fix

Gate on the computed wall height in mm against `MIN_LABEL_TAB_HEIGHT` (9mm), using the `wallHeightMm` the hook already derives via `binDimensions()`. That value correctly accounts for `heightUnitMm`, the socket, and flat bins.

- **Default 7mm-unit bins are unchanged**: 2u socketed = 9mm wall stays disabled (`<= 9`); 3u = 16mm enabled.
- **Tall bins with custom unit sizes are now enabled** (e.g. 2u × 20mm = 35mm wall).

The disabled message is reworded to be height-agnostic ("Bin is too shallow for a label tab") across all 10 locales, since it no longer refers to a specific unit count.

## Tests

- Updated the two height gating tests to reflect mm-based reasoning.
- Added a `#2422` regression test: a 2u bin with `heightUnitMm: 20` (35mm wall) is now available.
- Full `useLabelTabsSection` suite: 34 passing. `typecheck` + `check:i18n` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix label tab availability by using the bin’s physical wall height (mm) instead of height unit count, so tall-but-low-unit bins are enabled. Fixes #2422 and updates the disabled message to be height-agnostic.

- **Bug Fixes**
  - Gate on computed `wallHeightMm` from `binDimensions()` against `MIN_LABEL_TAB_HEIGHT` (9mm) to determine availability.
  - Reworded `labelTabsUnavailableMinHeight` across locales to “Bin is too shallow for a label tab”.
  - Updated tests and added a regression case for a 2u × 20mm bin (now correctly available).

<sup>Written for commit 3ad1d420362bb207ccfc4b5d5f13b819daef80a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

