### PR TITLE
fix(baseplate): align margin seam connector on corner rail segments (#2427)

### DIFF
--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1425,6 +1425,37 @@ describe('detachMargins emits margin rails', () => {
     for (const seg of front.slice(1, -1)) expect(seg.ownedCorners).toEqual([]);
   });
 
+  it('offsets the seam connector on corner segments back onto the body tongue (#2427)', () => {
+    // Corner-owning end segments extend over the detached left/right padding, so
+    // their center no longer sits on the body wall they join. seamTongueOffsetMm
+    // must cancel that shift so the groove lands on the (grid-centered) tongue.
+    const tiling = computeBaseplateTiling(
+      makeParams({
+        width: 10,
+        depth: 3,
+        detachMargins: true,
+        paddingLeft: P,
+        paddingRight: P,
+        paddingFront: P,
+        paddingBack: P,
+      }),
+      256
+    );
+    const front = tiling.margins.filter((m) => m.side === 'front').sort((a, b) => a.col - b.col);
+    // First column extends over the left padding (center shifted −P/2), so the
+    // groove shifts +P/2 back; last column mirrors it; middle columns are centered.
+    expect(front[0].seamTongueOffsetMm).toBeCloseTo(P / 2, 6);
+    expect(front[front.length - 1].seamTongueOffsetMm).toBeCloseTo(-P / 2, 6);
+    for (const seg of front.slice(1, -1)) expect(seg.seamTongueOffsetMm).toBeCloseTo(0, 6);
+    // The offset places the groove exactly on the body piece's grid center.
+    for (const seg of front) {
+      const piece = tiling.pieces.find((p) => p.col === seg.col && p.row === seg.row)!;
+      const pieceCenterX =
+        piece.gridOffsetX * U + (piece.widthUnits * U) / 2 - tiling.totalWidthUnits * U * 0.5;
+      expect(seg.worldOffsetMm.x + (seg.seamTongueOffsetMm ?? 0)).toBeCloseTo(pieceCenterX, 6);
+    }
+  });
+
   it('extends a rail over an integral (sub-threshold) perpendicular side to reach its corner', () => {
     // left detaches; front padding (5mm) stays integral on the body. The left
     // rail must extend over that 5mm so the front-left corner has no gap.

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -578,7 +578,8 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
     lengthMm: number,
     bandThicknessMm: number,
     ownedCorners: MarginCorner[],
-    worldOffsetMm: { x: number; y: number }
+    worldOffsetMm: { x: number; y: number },
+    seamTongueOffsetMm: number = 0
   ): void => {
     margins.push({
       id,
@@ -590,6 +591,7 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
       bandThicknessMm,
       ownedCorners,
       worldOffsetMm,
+      seamTongueOffsetMm,
       ...fill,
     });
   };
@@ -608,23 +610,45 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
       const extR = c === colLast ? pr : 0;
       const len = colSizes[c] * gridUnitMm + extL + extR;
       const cx = colCenter(c) - extL / 2 + extR / 2;
+      // The connector groove must line up with the body's tongue, which sits at
+      // the body wall's center (the piece's grid center shifted by any integral
+      // left/right padding it still carries), not the corner-extended rail center.
+      const bodyPadL = c === 0 && !det.left ? pl : 0;
+      const bodyPadR = c === colLast && !det.right ? pr : 0;
+      const seamOffset = (bodyPadR - bodyPadL) / 2 + extL / 2 - extR / 2;
       if (det.front) {
         const owned: MarginCorner[] = [];
         if (c === 0) owned.push('bl');
         if (c === colLast) owned.push('br');
-        push(`margin-front-${colToLetter(c)}`, 'front', 'long', c, 0, len, pf, owned, {
-          x: cx,
-          y: -halfD - pf / 2,
-        });
+        push(
+          `margin-front-${colToLetter(c)}`,
+          'front',
+          'long',
+          c,
+          0,
+          len,
+          pf,
+          owned,
+          { x: cx, y: -halfD - pf / 2 },
+          seamOffset
+        );
       }
       if (det.back) {
         const owned: MarginCorner[] = [];
         if (c === 0) owned.push('tl');
         if (c === colLast) owned.push('tr');
-        push(`margin-back-${colToLetter(c)}`, 'back', 'long', c, rowLast, len, pb, owned, {
-          x: cx,
-          y: halfD + pb / 2,
-        });
+        push(
+          `margin-back-${colToLetter(c)}`,
+          'back',
+          'long',
+          c,
+          rowLast,
+          len,
+          pb,
+          owned,
+          { x: cx, y: halfD + pb / 2 },
+          seamOffset
+        );
       }
     }
     // Short left/right rails, segmented per row, fit between the long rails but

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -467,23 +467,27 @@ export function buildMarginSeamGroove(
   totalHeight: number,
   connectorStyle: ResolvedBaseplateParams['connectorStyle'],
   fitOffset: number,
-  nozzleSizeMm?: number
+  nozzleSizeMm?: number,
+  tongueOffsetMm: number = 0
 ): Shape3D {
   const horizontal = side === 'front' || side === 'back';
   const seamSign: -1 | 1 = side === 'front' || side === 'left' ? 1 : -1;
   const seamPos = seamSign * (horizontal ? railD / 2 : railW / 2);
   // Rail seam runs along X for front/back rails (wall coord on Y) and along Y
-  // for left/right rails (wall coord on X). Tongue is centered → bp = 0.
-  const pt: (wall: number, bp: number) => [number, number] = horizontal
-    ? (wall, bp) => [bp, wall]
-    : (wall, bp) => [wall, bp];
+  // for left/right rails (wall coord on X). `tongueOffsetMm` slides the groove
+  // along that axis onto the mating body tongue — nonzero on a corner-owning end
+  // segment whose rail center no longer sits on the body wall it joins (#2427).
+  const bp = tongueOffsetMm;
+  const pt: (wall: number, b: number) => [number, number] = horizontal
+    ? (wall, b) => [b, wall]
+    : (wall, b) => [wall, b];
   const cl = effectiveClearance(TONGUE_CLEARANCE, fitOffset, nozzleSizeMm);
   return connectorStyle === 'puzzle'
-    ? makePuzzleGroove(pt, seamPos, 0, seamSign, cl, COPLANAR_MARGIN, totalHeight)
+    ? makePuzzleGroove(pt, seamPos, bp, seamSign, cl, COPLANAR_MARGIN, totalHeight)
     : makeGroove(
         pt,
         seamPos,
-        0,
+        bp,
         seamSign,
         TONGUE_PROTRUSION,
         TONGUE_BASE_HALF,

--- a/src/features/generation/worker/generators/baseplateMargin.ts
+++ b/src/features/generation/worker/generators/baseplateMargin.ts
@@ -156,7 +156,8 @@ function buildMarginSolid(
       totalHeight,
       params.connectorStyle,
       params.connectorFitOffset ?? 0,
-      params.nozzleSizeMm
+      params.nozzleSizeMm,
+      margin.seamTongueOffsetMm ?? 0
     );
     rail = cutInBatches(rail, [groove]);
   }

--- a/src/features/generation/worker/generators/baseplateMarginConnector.scenario.test.ts
+++ b/src/features/generation/worker/generators/baseplateMarginConnector.scenario.test.ts
@@ -145,6 +145,64 @@ describe('margin-seam connector geometry (#2414)', () => {
     expect(conn.vertices.length).toBe(plain.vertices.length);
   });
 
+  it('a corner segment groove seats the body tongue via seamTongueOffsetMm (#2427)', () => {
+    // A long rail's corner-owning end segment extends over the perpendicular
+    // padding, so its center is shifted OFF the body wall it joins. Without the
+    // offset the groove misses the (grid-centered) tongue entirely; with it, the
+    // groove slides back onto the tongue. Model column 0 of a split: the front
+    // rail extends left over PL and its center sits −PL/2 from the body center.
+    const PL = 20;
+    const body = buildConnectors(
+      baseParams({ edges: frontSeamEdges }),
+      SOCKET_HEIGHT,
+      WIDTH * GU,
+      DEPTH * GU,
+      0,
+      0,
+      true
+    );
+    const tongue = body.nubs[0];
+    const tongueVol = vol(tongue);
+
+    const railW = WIDTH * GU + PL; // extended over the left padding
+    const grooveNoOffset = buildMarginSeamGroove(
+      'front',
+      railW,
+      PF,
+      SOCKET_HEIGHT,
+      'dovetail',
+      0,
+      0.4
+    );
+    const grooveWithOffset = buildMarginSeamGroove(
+      'front',
+      railW,
+      PF,
+      SOCKET_HEIGHT,
+      'dovetail',
+      0,
+      0.4,
+      PL / 2 // cancels the −PL/2 rail-center shift
+    );
+    // Rail center world-x = body-center − PL/2 (extended over the left corner).
+    const railWorldX = -PL / 2;
+    const seat = (groove: typeof grooveNoOffset): number => {
+      const world = translate(groove, [railWorldX, -(DEPTH * GU) / 2 - PF / 2, 0]);
+      const inter = intersect(tongue, world);
+      const overlap = isOk(inter) ? vol(inter.value) : 0;
+      if (isOk(inter)) inter.value.delete();
+      world.delete();
+      return overlap / tongueVol;
+    };
+
+    expect(seat(grooveNoOffset), 'un-offset groove misses the tongue').toBeLessThan(0.1);
+    expect(seat(grooveWithOffset), 'offset groove seats the tongue').toBeGreaterThan(0.9);
+
+    tongue.delete();
+    grooveNoOffset.delete();
+    grooveWithOffset.delete();
+  });
+
   it('the body tongue seats inside the rail groove in world space', () => {
     // Body tongue (body frame, centered): front wall at y = -DEPTH*GU/2.
     const { nubs } = buildConnectors(

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -185,6 +185,15 @@ export interface MarginPiece {
   readonly ownedCorners: readonly MarginCorner[];
   /** Rail-center position in the plate-centered world frame (mm). */
   readonly worldOffsetMm: { readonly x: number; readonly y: number };
+  /**
+   * Signed along-length offset (mm) from the rail center to the mating body
+   * wall's center — where the opt-in seam groove must be cut so it lines up with
+   * the body's tongue (#2427). Nonzero on a long rail's corner-owning end
+   * segment, which extends over the perpendicular padding to reach the outer
+   * corner and so is no longer centered on the body wall it joins. Only meaningful
+   * for `long` rails; absent (→ 0) on short/friction-fit rails.
+   */
+  readonly seamTongueOffsetMm?: number;
   readonly overTile: boolean;
   readonly overTileHalfGrid: boolean;
   readonly overTileHalfGridSolidLeftover: boolean;


### PR DESCRIPTION
Fixes #2427.

## Problem

With **Detach margins** + **Add connector** + **Dovetail**, the dovetail joints between the detached long rails and the body render in the wrong places, with many missing entirely (see the issue screenshot).

## Root cause

The margin-seam connector is a two-part joint split across two independently-generated meshes:

- the **body** carries the tongue, placed at the body piece's **grid center**;
- the **rail** carries the groove, placed at the rail's **own center** (`bp = 0`).

These centers coincide for interior rail segments — but a long rail's **end segment deliberately extends over the perpendicular padding to own the plate's rounded outer corner**, shifting the rail center outward by `perpendicularPadding / 2`. The groove rides along with it; the tongue doesn't. So every corner-owning segment misses its tongue by half the perpendicular padding.

On the reported 2-column split, *both* columns are end columns, so *every* connector is broken.

## Fix

`emitMargins` now computes `seamTongueOffsetMm` — the along-length offset from the rail center to the mating body-wall center — and `buildMarginSeamGroove` slides the groove by it. Interior segments and integral-perpendicular-padding cases resolve to `0` (unchanged behavior); only corner segments shift.

## Verification

On the real BREP solids for the repro (8×5 grid, 256mm bed, all margins detached, over-tile half-grid solid-leftover, dovetail), all four long-rail seams go from **0.00 → 1.00** tongue-in-groove overlap.

Tests added:
- planner unit test asserting the offset values (±P/2 on end columns, 0 in the middle) and that offset+rail-center lands on the body grid center;
- geometry scenario test proving a corner-segment groove seats the body tongue (and that the un-offset groove misses it).

## Scope note

The `preferIdenticalPieces` + split-piece-connectors + detached-connector compound case is not addressed here (it was already non-functional pre-fix); this strictly fixes the common path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2427. Aligns the seam groove on corner long-rail segments with the body’s tongue when margins are detached with dovetail connectors, so corner seams no longer miss or disappear.

- **Bug Fixes**
  - Compute `seamTongueOffsetMm` in `emitMargins` for long rails; interior segments resolve to 0.
  - Slide the groove by this offset in `buildMarginSeamGroove` and pass it through `baseplateMargin`.
  - Tests added: planner checks ±P/2 on end columns and 0 in the middle; scenario test shows corner groove seats the tongue (0.00 → ~1.00 overlap).
  - Extend `MarginPiece` with optional `seamTongueOffsetMm`.

<sup>Written for commit 0acc6bb919f28734673b5fcb2cd39c7ee27cbe58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

