### PR TITLE
feat(baseplate): distribute margin seam connectors one per grid cell (#2427)

### DIFF
--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1425,10 +1425,11 @@ describe('detachMargins emits margin rails', () => {
     for (const seg of front.slice(1, -1)) expect(seg.ownedCorners).toEqual([]);
   });
 
-  it('offsets the seam connector on corner segments back onto the body tongue (#2427)', () => {
+  it('anchors the seam connector on the body grid center, offsetting corner segments (#2427/#2428)', () => {
     // Corner-owning end segments extend over the detached left/right padding, so
-    // their center no longer sits on the body wall they join. seamTongueOffsetMm
-    // must cancel that shift so the groove lands on the (grid-centered) tongue.
+    // their center no longer sits on the body wall they join. seamConnector
+    // records the mating wall's grid width and its center offset so the rail can
+    // recompute per-boundary groove positions that land on the body tongues.
     const tiling = computeBaseplateTiling(
       makeParams({
         width: 10,
@@ -1443,16 +1444,22 @@ describe('detachMargins emits margin rails', () => {
     );
     const front = tiling.margins.filter((m) => m.side === 'front').sort((a, b) => a.col - b.col);
     // First column extends over the left padding (center shifted −P/2), so the
-    // groove shifts +P/2 back; last column mirrors it; middle columns are centered.
-    expect(front[0].seamTongueOffsetMm).toBeCloseTo(P / 2, 6);
-    expect(front[front.length - 1].seamTongueOffsetMm).toBeCloseTo(-P / 2, 6);
-    for (const seg of front.slice(1, -1)) expect(seg.seamTongueOffsetMm).toBeCloseTo(0, 6);
-    // The offset places the groove exactly on the body piece's grid center.
+    // grooves shift +P/2 back; last column mirrors it; middle columns are centered.
+    expect(front[0].seamConnector?.centerOffsetMm).toBeCloseTo(P / 2, 6);
+    expect(front[front.length - 1].seamConnector?.centerOffsetMm).toBeCloseTo(-P / 2, 6);
+    for (const seg of front.slice(1, -1))
+      expect(seg.seamConnector?.centerOffsetMm).toBeCloseTo(0, 6);
+    // The offset places the body grid center exactly on the piece's grid center,
+    // and cellUnits mirrors the mating body piece's width.
     for (const seg of front) {
       const piece = tiling.pieces.find((p) => p.col === seg.col && p.row === seg.row)!;
       const pieceCenterX =
         piece.gridOffsetX * U + (piece.widthUnits * U) / 2 - tiling.totalWidthUnits * U * 0.5;
-      expect(seg.worldOffsetMm.x + (seg.seamTongueOffsetMm ?? 0)).toBeCloseTo(pieceCenterX, 6);
+      expect(seg.worldOffsetMm.x + (seg.seamConnector?.centerOffsetMm ?? 0)).toBeCloseTo(
+        pieceCenterX,
+        6
+      );
+      expect(seg.seamConnector?.cellUnits).toBe(piece.widthUnits);
     }
   });
 

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1428,8 +1428,8 @@ describe('detachMargins emits margin rails', () => {
   it('anchors the seam connector on the body grid center, offsetting corner segments (#2427/#2428)', () => {
     // Corner-owning end segments extend over the detached left/right padding, so
     // their center no longer sits on the body wall they join. seamConnector
-    // records the mating wall's grid width and its center offset so the rail can
-    // recompute per-boundary groove positions that land on the body tongues.
+    // records the mating wall's grid width and center offset so the rail can
+    // recompute per-cell groove positions that land on the body tongues.
     const tiling = computeBaseplateTiling(
       makeParams({
         width: 10,

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -551,6 +551,8 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
     paddingFront: pf,
     paddingBack: pb,
     gridUnitMm,
+    fractionalEdgeX,
+    fractionalEdgeY,
   } = params;
   const { colSizes, rowSizes, colOffsets, rowOffsets } = layout;
   const halfW = (params.width * gridUnitMm) / 2;
@@ -579,7 +581,7 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
     bandThicknessMm: number,
     ownedCorners: MarginCorner[],
     worldOffsetMm: { x: number; y: number },
-    seamTongueOffsetMm: number = 0
+    seamConnector?: MarginPiece['seamConnector']
   ): void => {
     margins.push({
       id,
@@ -591,10 +593,23 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
       bandThicknessMm,
       ownedCorners,
       worldOffsetMm,
-      seamTongueOffsetMm,
+      seamConnector,
       ...fill,
     });
   };
+  // Seam-connector layout for a long rail: the mating body wall's grid width and
+  // its center offset from the rail center (nonzero on corner-owning end segments
+  // that extend over the perpendicular padding). Both body and rail recompute the
+  // per-boundary connector positions from this, so they stay in lockstep.
+  const seamFor = (
+    cellUnits: number,
+    centerOffsetMm: number,
+    frac: 'start' | 'end'
+  ): MarginPiece['seamConnector'] => ({
+    cellUnits,
+    centerOffsetMm,
+    fractionalEdge: isFractional(cellUnits) ? frac : 'end',
+  });
 
   // Prefer front/back as the long (corner-owning) axis; fall back to left/right
   // when neither front nor back detaches.
@@ -610,12 +625,10 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
       const extR = c === colLast ? pr : 0;
       const len = colSizes[c] * gridUnitMm + extL + extR;
       const cx = colCenter(c) - extL / 2 + extR / 2;
-      // The connector groove must line up with the body's tongue, which sits at
-      // the body wall's center (the piece's grid center shifted by any integral
-      // left/right padding it still carries), not the corner-extended rail center.
-      const bodyPadL = c === 0 && !det.left ? pl : 0;
-      const bodyPadR = c === colLast && !det.right ? pr : 0;
-      const seamOffset = (bodyPadR - bodyPadL) / 2 + extL / 2 - extR / 2;
+      // The connectors track the body wall's grid cells, centered on the piece's
+      // grid center — which the corner-extended rail center no longer coincides
+      // with, so record that shift for the rail to re-anchor its grooves (#2427).
+      const seam = seamFor(colSizes[c], colCenter(c) - cx, fractionalEdgeX);
       if (det.front) {
         const owned: MarginCorner[] = [];
         if (c === 0) owned.push('bl');
@@ -630,7 +643,7 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
           pf,
           owned,
           { x: cx, y: -halfD - pf / 2 },
-          seamOffset
+          seam
         );
       }
       if (det.back) {
@@ -647,7 +660,7 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
           pb,
           owned,
           { x: cx, y: halfD + pb / 2 },
-          seamOffset
+          seam
         );
       }
     }
@@ -687,23 +700,40 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
       const extB = r === rowLast ? pb : 0;
       const len = rowSizes[r] * gridUnitMm + extF + extB;
       const cy = rowCenter(r) - extF / 2 + extB / 2;
+      const seam = seamFor(rowSizes[r], rowCenter(r) - cy, fractionalEdgeY);
       if (det.left) {
         const owned: MarginCorner[] = [];
         if (r === 0) owned.push('bl');
         if (r === rowLast) owned.push('tl');
-        push(`margin-left-${r + 1}`, 'left', 'long', 0, r, len, pl, owned, {
-          x: -halfW - pl / 2,
-          y: cy,
-        });
+        push(
+          `margin-left-${r + 1}`,
+          'left',
+          'long',
+          0,
+          r,
+          len,
+          pl,
+          owned,
+          { x: -halfW - pl / 2, y: cy },
+          seam
+        );
       }
       if (det.right) {
         const owned: MarginCorner[] = [];
         if (r === 0) owned.push('br');
         if (r === rowLast) owned.push('tr');
-        push(`margin-right-${r + 1}`, 'right', 'long', colLast, r, len, pr, owned, {
-          x: halfW + pr / 2,
-          y: cy,
-        });
+        push(
+          `margin-right-${r + 1}`,
+          'right',
+          'long',
+          colLast,
+          r,
+          len,
+          pr,
+          owned,
+          { x: halfW + pr / 2, y: cy },
+          seam
+        );
       }
     }
   }

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -599,8 +599,7 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
   };
   // Seam-connector layout for a long rail: the mating body wall's grid width and
   // its center offset from the rail center (nonzero on corner-owning end segments
-  // that extend over the perpendicular padding). Both body and rail recompute the
-  // per-boundary connector positions from this, so they stay in lockstep.
+  // that extend over the perpendicular padding). See MarginPiece.seamConnector.
   const seamFor = (
     cellUnits: number,
     centerOffsetMm: number,

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -385,18 +385,20 @@ export function buildConnectors(
     }
   }
 
-  // Opt-in body↔long-rail connector (#2414): one male tongue centered on the
-  // detached exterior wall, protruding into the rail. The rail carries the
-  // matching groove (`buildMarginSeamGroove`). Rails are solid (no sockets), so
-  // no relief is needed; a centered tongue is 180°-rotation-safe under paired
-  // mode. `hasMarginSeam` already requires a dovetail/puzzle style, so a stray
-  // snapClip/dovetailKey `marginSeam` edge produces no mismatched tongue.
+  // Opt-in body↔long-rail connector (#2414): one male tongue per mating cell
+  // boundary along the detached exterior wall, protruding into the rail — the
+  // same cadence as split-piece dovetails, so a long rail is anchored along its
+  // length rather than at a single point (#2428). The rail carries the matching
+  // grooves (`buildMarginSeamGroove` at the same boundaries). Rails are solid (no
+  // sockets), so no relief is needed. A single-cell wall has no interior boundary,
+  // so it falls back to one centered tongue. `hasMarginSeam` already requires a
+  // dovetail/puzzle style, so a stray snapClip/dovetailKey edge emits no tongue.
   if (hasMarginSeam) {
     for (const def of edgeDefs) {
       if (edges[def.side] !== 'marginSeam') continue;
       const pt = ptFor(def);
-      const center = def.protrudeAxis === 'x' ? slabOffsetY : slabOffsetX;
-      tongues.push(mkTongue(pt, def.wallPos, center, def.protrudeDir));
+      const positions = def.boundaries.length > 0 ? def.boundaries : [0];
+      for (const bp of positions) tongues.push(mkTongue(pt, def.wallPos, bp, def.protrudeDir));
     }
   }
 

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -397,8 +397,8 @@ export function buildConnectors(
 
   // Opt-in body↔long-rail connector (#2414): one male tongue per mating grid
   // cell along the detached exterior wall, protruding into the rail — so a long
-  // rail is anchored evenly along its length (one connector per cell) rather than
-  // at a single point (#2428). The rail carries the matching grooves
+  // rail is anchored evenly along its length rather than at a single point
+  // (#2428). The rail carries the matching grooves
   // (`buildMarginSeamGroove` at the same cell centers). Rails are solid (no
   // sockets), so no relief is needed. `hasMarginSeam` already requires a
   // dovetail/puzzle style, so a stray snapClip/dovetailKey edge emits no tongue.
@@ -462,14 +462,14 @@ export function makeGroove(
 }
 
 /**
- * Groove carved into a detached long rail's seam face to receive the body's
- * margin-seam tongue (#2414). Mirrors the single centered tongue that
- * {@link buildConnectors} fuses onto the body's `marginSeam` wall, using the
- * same profile/clearance so they mate. Built in the rail's own origin-centered
- * frame (see `baseplateMargin.buildMarginSolid`): the seam face is the rail's
- * inner long edge (+railD/2 front, −railD/2 back, +railW/2 left, −railW/2
- * right), and the groove cuts inward from it — `d` equals that face's sign.
- * Only `dovetail`/`puzzle` styles reach here.
+ * Groove carved into a detached long rail's seam face to receive one of the
+ * body's margin-seam tongues (#2414). Uses the same profile/clearance the tongue
+ * does so they mate, positioned along the seam by `tongueOffsetMm` (the caller
+ * cuts one per cell). Built in the rail's own origin-centered frame (see
+ * `baseplateMargin.buildMarginSolid`): the seam face is the rail's inner long
+ * edge (+railD/2 front, −railD/2 back, +railW/2 left, −railW/2 right), and the
+ * groove cuts inward from it — `d` equals that face's sign. Only `dovetail`/
+ * `puzzle` styles reach here.
  */
 export function buildMarginSeamGroove(
   side: 'left' | 'right' | 'front' | 'back',
@@ -488,17 +488,16 @@ export function buildMarginSeamGroove(
   // for left/right rails (wall coord on X). `tongueOffsetMm` slides the groove
   // along that axis onto the mating body tongue — nonzero on a corner-owning end
   // segment whose rail center no longer sits on the body wall it joins (#2427).
-  const bp = tongueOffsetMm;
-  const pt: (wall: number, b: number) => [number, number] = horizontal
-    ? (wall, b) => [b, wall]
-    : (wall, b) => [wall, b];
+  const pt: (wall: number, bp: number) => [number, number] = horizontal
+    ? (wall, bp) => [bp, wall]
+    : (wall, bp) => [wall, bp];
   const cl = effectiveClearance(TONGUE_CLEARANCE, fitOffset, nozzleSizeMm);
   return connectorStyle === 'puzzle'
-    ? makePuzzleGroove(pt, seamPos, bp, seamSign, cl, COPLANAR_MARGIN, totalHeight)
+    ? makePuzzleGroove(pt, seamPos, tongueOffsetMm, seamSign, cl, COPLANAR_MARGIN, totalHeight)
     : makeGroove(
         pt,
         seamPos,
-        bp,
+        tongueOffsetMm,
         seamSign,
         TONGUE_PROTRUSION,
         TONGUE_BASE_HALF,

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -58,7 +58,7 @@ import {
   sketch,
 } from './generatorTypes';
 import type { SnapClipLevels } from '@/shared/constants/connectors';
-import { computeCellBoundariesMm, decomposeCells } from './cellDecomposition';
+import { computeCellBoundariesMm, computeCellCentersMm, decomposeCells } from './cellDecomposition';
 import { buildSingleCellSocket } from './socketBuilder';
 import { getPocketTemplate } from './baseplatePockets';
 
@@ -232,6 +232,11 @@ export function buildConnectors(
   const yBoundaries = computeCellBoundariesMm(params.depth, gridUnit, params.fractionalEdgeY);
   const xBoundaries = computeCellBoundariesMm(params.width, gridUnit, params.fractionalEdgeX);
 
+  // Cell centers along each axis — where the margin-seam connector places one
+  // tongue per cell (unlike the split-piece dovetails, which sit on boundaries).
+  const yCenters = computeCellCentersMm(params.depth, gridUnit, params.fractionalEdgeY);
+  const xCenters = computeCellCentersMm(params.width, gridUnit, params.fractionalEdgeX);
+
   // Cell layout along each edge's boundary axis — used to subtract the
   // neighbouring piece's sockets from each tongue (the grid is continuous across
   // the seam, so the neighbour column shares this piece's boundary-axis cells).
@@ -260,6 +265,7 @@ export function buildConnectors(
     maleOffsetSign: -1 | 1;
     wallPos: number;
     boundaries: readonly number[];
+    centers: readonly number[];
     boundaryCells: readonly CellSpan[];
     protrudeAxis: 'x' | 'y';
     protrudeDir: -1 | 1;
@@ -270,6 +276,7 @@ export function buildConnectors(
       maleOffsetSign: 1,
       wallPos: -halfW + slabOffsetX,
       boundaries: yBoundaries,
+      centers: yCenters,
       boundaryCells: yCellSpans,
       protrudeAxis: 'x',
       protrudeDir: -1,
@@ -280,6 +287,7 @@ export function buildConnectors(
       maleOffsetSign: -1,
       wallPos: halfW + slabOffsetX,
       boundaries: yBoundaries,
+      centers: yCenters,
       boundaryCells: yCellSpans,
       protrudeAxis: 'x',
       protrudeDir: 1,
@@ -290,6 +298,7 @@ export function buildConnectors(
       maleOffsetSign: -1,
       wallPos: -halfD + slabOffsetY,
       boundaries: xBoundaries,
+      centers: xCenters,
       boundaryCells: xCellSpans,
       protrudeAxis: 'y',
       protrudeDir: -1,
@@ -300,6 +309,7 @@ export function buildConnectors(
       maleOffsetSign: 1,
       wallPos: halfD + slabOffsetY,
       boundaries: xBoundaries,
+      centers: xCenters,
       boundaryCells: xCellSpans,
       protrudeAxis: 'y',
       protrudeDir: 1,
@@ -385,19 +395,18 @@ export function buildConnectors(
     }
   }
 
-  // Opt-in body↔long-rail connector (#2414): one male tongue per mating cell
-  // boundary along the detached exterior wall, protruding into the rail — the
-  // same cadence as split-piece dovetails, so a long rail is anchored along its
-  // length rather than at a single point (#2428). The rail carries the matching
-  // grooves (`buildMarginSeamGroove` at the same boundaries). Rails are solid (no
-  // sockets), so no relief is needed. A single-cell wall has no interior boundary,
-  // so it falls back to one centered tongue. `hasMarginSeam` already requires a
+  // Opt-in body↔long-rail connector (#2414): one male tongue per mating grid
+  // cell along the detached exterior wall, protruding into the rail — so a long
+  // rail is anchored evenly along its length (one connector per cell) rather than
+  // at a single point (#2428). The rail carries the matching grooves
+  // (`buildMarginSeamGroove` at the same cell centers). Rails are solid (no
+  // sockets), so no relief is needed. `hasMarginSeam` already requires a
   // dovetail/puzzle style, so a stray snapClip/dovetailKey edge emits no tongue.
   if (hasMarginSeam) {
     for (const def of edgeDefs) {
       if (edges[def.side] !== 'marginSeam') continue;
       const pt = ptFor(def);
-      const positions = def.boundaries.length > 0 ? def.boundaries : [0];
+      const positions = def.centers.length > 0 ? def.centers : [0];
       for (const bp of positions) tongues.push(mkTongue(pt, def.wallPos, bp, def.protrudeDir));
     }
   }

--- a/src/features/generation/worker/generators/baseplateMargin.ts
+++ b/src/features/generation/worker/generators/baseplateMargin.ts
@@ -33,6 +33,7 @@ import {
 import type { SideMargins } from './generatorTypes';
 import { buildSlabProfile } from './baseplateSlab';
 import { buildMarginSeamGroove } from './baseplateConnectors';
+import { computeCellBoundariesMm } from './cellDecomposition';
 import { cutInBatches } from './baseplateBatchOps';
 import { getPocketTemplate } from './baseplatePockets';
 import { buildBaseplateSTL } from './baseplateSTL';
@@ -140,26 +141,36 @@ function buildMarginSolid(
     if (pockets.length > 0) rail = cutInBatches(rail, pockets);
   }
 
-  // Opt-in connector (#2414): carve the seam groove into a LONG rail's inner
-  // face to receive the body's tongue. Long rails are exactly the seam sides
+  // Opt-in connector (#2414): carve seam grooves into a LONG rail's inner face
+  // to receive the body's tongues. Long rails are exactly the seam sides
   // (splitPlanner marks the matching body edge `marginSeam`); short rails stay
-  // friction-fit. Only dovetail/puzzle styles carry a seam.
+  // friction-fit. Only dovetail/puzzle styles carry a seam. One groove per mating
+  // cell boundary (#2428) — recomputed from the same `cellUnits`/`fractionalEdge`
+  // the body used, then shifted by `centerOffsetMm` onto the corner-extended rail.
   if (
     params.detachMarginConnector === true &&
     isSeamConnectorStyle(params.connectorStyle) &&
     margin.role === 'long'
   ) {
-    const groove = buildMarginSeamGroove(
-      margin.side,
-      railW,
-      railD,
-      totalHeight,
-      params.connectorStyle,
-      params.connectorFitOffset ?? 0,
-      params.nozzleSizeMm,
-      margin.seamTongueOffsetMm ?? 0
+    const seam = margin.seamConnector;
+    const boundaries = seam
+      ? computeCellBoundariesMm(seam.cellUnits, params.gridUnitMm, seam.fractionalEdge)
+      : [];
+    const centerOffset = seam?.centerOffsetMm ?? 0;
+    const positions = (boundaries.length > 0 ? boundaries : [0]).map((b) => b + centerOffset);
+    const grooves = positions.map((pos) =>
+      buildMarginSeamGroove(
+        margin.side,
+        railW,
+        railD,
+        totalHeight,
+        params.connectorStyle,
+        params.connectorFitOffset ?? 0,
+        params.nozzleSizeMm,
+        pos
+      )
     );
-    rail = cutInBatches(rail, [groove]);
+    rail = cutInBatches(rail, grooves);
   }
 
   // Shift up so Z=0 is the bottom face, matching the body's final transform.

--- a/src/features/generation/worker/generators/baseplateMargin.ts
+++ b/src/features/generation/worker/generators/baseplateMargin.ts
@@ -33,7 +33,7 @@ import {
 import type { SideMargins } from './generatorTypes';
 import { buildSlabProfile } from './baseplateSlab';
 import { buildMarginSeamGroove } from './baseplateConnectors';
-import { computeCellBoundariesMm } from './cellDecomposition';
+import { computeCellCentersMm } from './cellDecomposition';
 import { cutInBatches } from './baseplateBatchOps';
 import { getPocketTemplate } from './baseplatePockets';
 import { buildBaseplateSTL } from './baseplateSTL';
@@ -145,19 +145,19 @@ function buildMarginSolid(
   // to receive the body's tongues. Long rails are exactly the seam sides
   // (splitPlanner marks the matching body edge `marginSeam`); short rails stay
   // friction-fit. Only dovetail/puzzle styles carry a seam. One groove per mating
-  // cell boundary (#2428) — recomputed from the same `cellUnits`/`fractionalEdge`
-  // the body used, then shifted by `centerOffsetMm` onto the corner-extended rail.
+  // grid cell (#2428) — recomputed from the same `cellUnits`/`fractionalEdge` the
+  // body used, then shifted by `centerOffsetMm` onto the corner-extended rail.
   if (
     params.detachMarginConnector === true &&
     isSeamConnectorStyle(params.connectorStyle) &&
     margin.role === 'long'
   ) {
     const seam = margin.seamConnector;
-    const boundaries = seam
-      ? computeCellBoundariesMm(seam.cellUnits, params.gridUnitMm, seam.fractionalEdge)
+    const cellCenters = seam
+      ? computeCellCentersMm(seam.cellUnits, params.gridUnitMm, seam.fractionalEdge)
       : [];
     const centerOffset = seam?.centerOffsetMm ?? 0;
-    const positions = (boundaries.length > 0 ? boundaries : [0]).map((b) => b + centerOffset);
+    const positions = (cellCenters.length > 0 ? cellCenters : [0]).map((b) => b + centerOffset);
     const grooves = positions.map((pos) =>
       buildMarginSeamGroove(
         margin.side,

--- a/src/features/generation/worker/generators/baseplateMarginConnector.scenario.test.ts
+++ b/src/features/generation/worker/generators/baseplateMarginConnector.scenario.test.ts
@@ -115,9 +115,14 @@ function frontGrooveUnion(rail: MarginPiece): Shape3D {
       union = world;
     } else {
       const f = fuse(union, world);
-      union.delete();
-      world.delete();
-      union = isOk(f) ? (f.value as Shape3D) : union;
+      if (isOk(f)) {
+        union.delete();
+        world.delete();
+        union = f.value;
+      } else {
+        // Keep the running union; drop only the piece that failed to merge.
+        world.delete();
+      }
     }
   }
   return union!;
@@ -279,5 +284,36 @@ describe('margin-seam connector geometry (#2414)', () => {
     nubs.forEach((n) => n.delete());
     offsetGrooves.delete();
     misalignedGrooves.delete();
+  });
+
+  it('every tongue seats on a fractional-width wall', () => {
+    // A fractional column (e.g. 2.5u → cells [1,1,0.5]) is the one place the
+    // body and rail could disagree on cell centers if their fractionalEdge
+    // diverged. Both derive from the same 'end' anchor, so all tongues must seat.
+    const FW = 2.5;
+    const { nubs } = buildConnectors(
+      baseParams({ width: FW, fractionalEdgeX: 'end', edges: frontSeamEdges }),
+      SOCKET_HEIGHT,
+      FW * GU,
+      DEPTH * GU,
+      0,
+      0,
+      true
+    );
+    expect(nubs.length, 'one tongue per cell incl. the half-cell').toBe(frontCenters(FW).length);
+    const grooveWorld = frontGrooveUnion(
+      frontRail({
+        lengthMm: FW * GU,
+        seamConnector: { cellUnits: FW, centerOffsetMm: 0, fractionalEdge: 'end' },
+      })
+    );
+    for (const tongue of nubs) {
+      const inter = intersect(tongue, grooveWorld);
+      const overlap = isOk(inter) ? vol(inter.value) : 0;
+      if (isOk(inter)) inter.value.delete();
+      expect(overlap / vol(tongue), 'fractional-cell tongue seated').toBeGreaterThan(0.9);
+    }
+    nubs.forEach((n) => n.delete());
+    grooveWorld.delete();
   });
 });

--- a/src/features/generation/worker/generators/baseplateMarginConnector.scenario.test.ts
+++ b/src/features/generation/worker/generators/baseplateMarginConnector.scenario.test.ts
@@ -11,7 +11,7 @@ import { isOk } from '@/core/result';
 import type { ResolvedBaseplateParams, MarginPiece, BaseplateEdges } from '@/shared/types/bin';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { buildConnectors, buildMarginSeamGroove } from './baseplateConnectors';
-import { computeCellBoundariesMm } from './cellDecomposition';
+import { computeCellCentersMm } from './cellDecomposition';
 import { generateMargin } from './baseplateMargin';
 import { SOCKET_HEIGHT } from './generatorTypes';
 
@@ -79,20 +79,20 @@ function frontRail(over: Partial<MarginPiece> = {}): MarginPiece {
   };
 }
 
-/** Interior cell-boundary positions along a `units`-wide front seam. */
-function frontBoundaries(units: number): number[] {
-  const b = computeCellBoundariesMm(units, GU, 'end');
-  return b.length > 0 ? b : [0];
+/** Cell-center positions along a `units`-wide front seam (one per cell). */
+function frontCenters(units: number): number[] {
+  const c = computeCellCentersMm(units, GU, 'end');
+  return c.length > 0 ? c : [0];
 }
 
 /**
- * Fuse all seam grooves for a front rail (one per boundary, shifted by
+ * Fuse all seam grooves for a front rail (one per cell, shifted by
  * `centerOffsetMm`) into the rail's world frame — the same set
  * `buildMarginSolid` carves.
  */
 function frontGrooveUnion(rail: MarginPiece): Shape3D {
   const seam = rail.seamConnector!;
-  const positions = frontBoundaries(seam.cellUnits).map((p) => p + seam.centerOffsetMm);
+  const positions = frontCenters(seam.cellUnits).map((p) => p + seam.centerOffsetMm);
   const railW =
     rail.side === 'front' || rail.side === 'back' ? rail.lengthMm : rail.bandThicknessMm;
   const railD =
@@ -124,7 +124,7 @@ function frontGrooveUnion(rail: MarginPiece): Shape3D {
 }
 
 describe('margin-seam connector geometry (#2414)', () => {
-  it('builds one body tongue per mating cell boundary, independent of connectorNubs', () => {
+  it('builds one body tongue per mating grid cell, independent of connectorNubs', () => {
     const { nubs, holes } = buildConnectors(
       baseParams({ edges: frontSeamEdges }),
       SOCKET_HEIGHT,
@@ -134,15 +134,14 @@ describe('margin-seam connector geometry (#2414)', () => {
       0,
       true
     );
-    // A WIDTH-wide seam has WIDTH-1 interior boundaries → that many tongues, the
-    // same cadence as split-piece dovetails (#2428).
-    expect(nubs.length, 'one tongue per cell boundary').toBe(frontBoundaries(WIDTH).length);
+    // A WIDTH-wide seam gets one tongue per cell (#2428).
+    expect(nubs.length, 'one tongue per cell').toBe(WIDTH);
     expect(holes.length, 'no grooves on the body').toBe(0);
     for (const n of nubs) expect(vol(n), 'tongue has volume').toBeGreaterThan(0);
     nubs.forEach((n) => n.delete());
   });
 
-  it('falls back to a single centered tongue on a single-cell wall', () => {
+  it('places a single tongue on a single-cell wall', () => {
     const { nubs } = buildConnectors(
       baseParams({ width: 1, edges: frontSeamEdges }),
       SOCKET_HEIGHT,

--- a/src/features/generation/worker/generators/baseplateMarginConnector.scenario.test.ts
+++ b/src/features/generation/worker/generators/baseplateMarginConnector.scenario.test.ts
@@ -5,11 +5,13 @@
  * in world space. Verified on the real BREP solids.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { measureVolume, translate, intersect } from 'brepjs';
+import { measureVolume, translate, intersect, fuse } from 'brepjs';
+import type { Shape3D } from 'brepjs';
 import { isOk } from '@/core/result';
 import type { ResolvedBaseplateParams, MarginPiece, BaseplateEdges } from '@/shared/types/bin';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { buildConnectors, buildMarginSeamGroove } from './baseplateConnectors';
+import { computeCellBoundariesMm } from './cellDecomposition';
 import { generateMargin } from './baseplateMargin';
 import { SOCKET_HEIGHT } from './generatorTypes';
 
@@ -69,6 +71,7 @@ function frontRail(over: Partial<MarginPiece> = {}): MarginPiece {
     bandThicknessMm: PF,
     ownedCorners: [],
     worldOffsetMm: { x: 0, y: -(DEPTH * GU) / 2 - PF / 2 },
+    seamConnector: { cellUnits: WIDTH, centerOffsetMm: 0, fractionalEdge: 'end' },
     overTile: false,
     overTileHalfGrid: false,
     overTileHalfGridSolidLeftover: false,
@@ -76,8 +79,52 @@ function frontRail(over: Partial<MarginPiece> = {}): MarginPiece {
   };
 }
 
+/** Interior cell-boundary positions along a `units`-wide front seam. */
+function frontBoundaries(units: number): number[] {
+  const b = computeCellBoundariesMm(units, GU, 'end');
+  return b.length > 0 ? b : [0];
+}
+
+/**
+ * Fuse all seam grooves for a front rail (one per boundary, shifted by
+ * `centerOffsetMm`) into the rail's world frame — the same set
+ * `buildMarginSolid` carves.
+ */
+function frontGrooveUnion(rail: MarginPiece): Shape3D {
+  const seam = rail.seamConnector!;
+  const positions = frontBoundaries(seam.cellUnits).map((p) => p + seam.centerOffsetMm);
+  const railW =
+    rail.side === 'front' || rail.side === 'back' ? rail.lengthMm : rail.bandThicknessMm;
+  const railD =
+    rail.side === 'front' || rail.side === 'back' ? rail.bandThicknessMm : rail.lengthMm;
+  let union: Shape3D | null = null;
+  for (const pos of positions) {
+    const g = buildMarginSeamGroove(
+      rail.side,
+      railW,
+      railD,
+      SOCKET_HEIGHT,
+      'dovetail',
+      0,
+      0.4,
+      pos
+    );
+    const world = translate(g, [rail.worldOffsetMm.x, rail.worldOffsetMm.y, 0]);
+    g.delete();
+    if (!union) {
+      union = world;
+    } else {
+      const f = fuse(union, world);
+      union.delete();
+      world.delete();
+      union = isOk(f) ? (f.value as Shape3D) : union;
+    }
+  }
+  return union!;
+}
+
 describe('margin-seam connector geometry (#2414)', () => {
-  it('builds exactly one body tongue on a marginSeam wall, independent of connectorNubs', () => {
+  it('builds one body tongue per mating cell boundary, independent of connectorNubs', () => {
     const { nubs, holes } = buildConnectors(
       baseParams({ edges: frontSeamEdges }),
       SOCKET_HEIGHT,
@@ -87,9 +134,25 @@ describe('margin-seam connector geometry (#2414)', () => {
       0,
       true
     );
-    expect(nubs.length, 'one seam tongue').toBe(1);
+    // A WIDTH-wide seam has WIDTH-1 interior boundaries → that many tongues, the
+    // same cadence as split-piece dovetails (#2428).
+    expect(nubs.length, 'one tongue per cell boundary').toBe(frontBoundaries(WIDTH).length);
     expect(holes.length, 'no grooves on the body').toBe(0);
-    expect(vol(nubs[0]), 'tongue has volume').toBeGreaterThan(0);
+    for (const n of nubs) expect(vol(n), 'tongue has volume').toBeGreaterThan(0);
+    nubs.forEach((n) => n.delete());
+  });
+
+  it('falls back to a single centered tongue on a single-cell wall', () => {
+    const { nubs } = buildConnectors(
+      baseParams({ width: 1, edges: frontSeamEdges }),
+      SOCKET_HEIGHT,
+      1 * GU,
+      DEPTH * GU,
+      0,
+      0,
+      true
+    );
+    expect(nubs.length).toBe(1);
     nubs.forEach((n) => n.delete());
   });
 
@@ -145,66 +208,8 @@ describe('margin-seam connector geometry (#2414)', () => {
     expect(conn.vertices.length).toBe(plain.vertices.length);
   });
 
-  it('a corner segment groove seats the body tongue via seamTongueOffsetMm (#2427)', () => {
-    // A long rail's corner-owning end segment extends over the perpendicular
-    // padding, so its center is shifted OFF the body wall it joins. Without the
-    // offset the groove misses the (grid-centered) tongue entirely; with it, the
-    // groove slides back onto the tongue. Model column 0 of a split: the front
-    // rail extends left over PL and its center sits −PL/2 from the body center.
-    const PL = 20;
-    const body = buildConnectors(
-      baseParams({ edges: frontSeamEdges }),
-      SOCKET_HEIGHT,
-      WIDTH * GU,
-      DEPTH * GU,
-      0,
-      0,
-      true
-    );
-    const tongue = body.nubs[0];
-    const tongueVol = vol(tongue);
-
-    const railW = WIDTH * GU + PL; // extended over the left padding
-    const grooveNoOffset = buildMarginSeamGroove(
-      'front',
-      railW,
-      PF,
-      SOCKET_HEIGHT,
-      'dovetail',
-      0,
-      0.4
-    );
-    const grooveWithOffset = buildMarginSeamGroove(
-      'front',
-      railW,
-      PF,
-      SOCKET_HEIGHT,
-      'dovetail',
-      0,
-      0.4,
-      PL / 2 // cancels the −PL/2 rail-center shift
-    );
-    // Rail center world-x = body-center − PL/2 (extended over the left corner).
-    const railWorldX = -PL / 2;
-    const seat = (groove: typeof grooveNoOffset): number => {
-      const world = translate(groove, [railWorldX, -(DEPTH * GU) / 2 - PF / 2, 0]);
-      const inter = intersect(tongue, world);
-      const overlap = isOk(inter) ? vol(inter.value) : 0;
-      if (isOk(inter)) inter.value.delete();
-      world.delete();
-      return overlap / tongueVol;
-    };
-
-    expect(seat(grooveNoOffset), 'un-offset groove misses the tongue').toBeLessThan(0.1);
-    expect(seat(grooveWithOffset), 'offset groove seats the tongue').toBeGreaterThan(0.9);
-
-    tongue.delete();
-    grooveNoOffset.delete();
-    grooveWithOffset.delete();
-  });
-
-  it('the body tongue seats inside the rail groove in world space', () => {
-    // Body tongue (body frame, centered): front wall at y = -DEPTH*GU/2.
+  it('every body tongue seats in the matching rail groove in world space', () => {
+    // Body tongues (body frame): front wall at y = -DEPTH*GU/2, one per boundary.
     const { nubs } = buildConnectors(
       baseParams({ edges: frontSeamEdges }),
       SOCKET_HEIGHT,
@@ -214,32 +219,66 @@ describe('margin-seam connector geometry (#2414)', () => {
       0,
       true
     );
-    const tongue = nubs[0];
-    const tongueVol = vol(tongue);
-
-    // Groove cutter in the rail's local frame, then placed at the rail's world
-    // offset — the same transform `buildMarginSolid` applies before lifting.
-    const groove = buildMarginSeamGroove(
-      'front',
-      WIDTH * GU,
-      PF,
-      SOCKET_HEIGHT,
-      'dovetail',
-      0,
-      0.4
-    );
-    const off = frontRail().worldOffsetMm;
-    const grooveWorld = translate(groove, [off.x, off.y, 0]);
-
-    const inter = intersect(tongue, grooveWorld);
-    const overlap = isOk(inter) ? vol(inter.value) : 0;
-    if (isOk(inter)) inter.value.delete();
-
-    // The tongue must sit almost entirely inside the (clearance-grown) groove.
-    expect(overlap / tongueVol, 'tongue seated in groove').toBeGreaterThan(0.9);
-
-    tongue.delete();
-    groove.delete();
+    // The rail carves the same boundary set; every tongue must seat in the union.
+    const grooveWorld = frontGrooveUnion(frontRail());
+    for (const tongue of nubs) {
+      const inter = intersect(tongue, grooveWorld);
+      const overlap = isOk(inter) ? vol(inter.value) : 0;
+      if (isOk(inter)) inter.value.delete();
+      expect(overlap / vol(tongue), 'tongue seated in groove').toBeGreaterThan(0.9);
+    }
+    nubs.forEach((n) => n.delete());
     grooveWorld.delete();
+  });
+
+  it('every tongue still seats on a corner-owning end segment (#2427)', () => {
+    // Model column 0 of a split: the front rail extends left over PL to own the
+    // corner, so its center sits −PL/2 from the body grid center. The rail's
+    // grooves recenter via centerOffsetMm = +PL/2; without it they'd all miss.
+    const PL = 20;
+    const { nubs } = buildConnectors(
+      baseParams({ edges: frontSeamEdges }),
+      SOCKET_HEIGHT,
+      WIDTH * GU,
+      DEPTH * GU,
+      0,
+      0,
+      true
+    );
+    const cornerRail = frontRail({
+      lengthMm: WIDTH * GU + PL, // extended over the left padding
+      worldOffsetMm: { x: -PL / 2, y: -(DEPTH * GU) / 2 - PF / 2 },
+      seamConnector: { cellUnits: WIDTH, centerOffsetMm: PL / 2, fractionalEdge: 'end' },
+    });
+    const offsetGrooves = frontGrooveUnion(cornerRail);
+    const misalignedGrooves = frontGrooveUnion(
+      frontRail({
+        lengthMm: WIDTH * GU + PL,
+        worldOffsetMm: { x: -PL / 2, y: -(DEPTH * GU) / 2 - PF / 2 },
+        seamConnector: { cellUnits: WIDTH, centerOffsetMm: 0, fractionalEdge: 'end' },
+      })
+    );
+
+    let seatedOffset = 0;
+    let seatedMisaligned = 0;
+    for (const tongue of nubs) {
+      const tv = vol(tongue);
+      const a = intersect(tongue, offsetGrooves);
+      if (isOk(a)) {
+        if (vol(a.value) / tv > 0.9) seatedOffset++;
+        a.value.delete();
+      }
+      const b = intersect(tongue, misalignedGrooves);
+      if (isOk(b)) {
+        if (vol(b.value) / tv > 0.9) seatedMisaligned++;
+        b.value.delete();
+      }
+    }
+    expect(seatedOffset, 'all tongues seat with the corner offset').toBe(nubs.length);
+    expect(seatedMisaligned, 'without the offset the grooves miss').toBe(0);
+
+    nubs.forEach((n) => n.delete());
+    offsetGrooves.delete();
+    misalignedGrooves.delete();
   });
 });

--- a/src/features/generation/worker/generators/cellDecomposition.test.ts
+++ b/src/features/generation/worker/generators/cellDecomposition.test.ts
@@ -5,6 +5,7 @@ import {
   forEachCell,
   frameCells,
   computeCellBoundariesMm,
+  computeCellCentersMm,
   marginPocketDepthMm,
 } from './cellDecomposition';
 import type { CellInfo } from './cellDecomposition';
@@ -227,6 +228,38 @@ describe('computeCellBoundariesMm', () => {
     // depth=2.5, grid=50 → cells [1,1,0.5] frac=end. Boundaries at 50, 100.
     // Centered at 62.5 → -12.5, 37.5.
     expect(computeCellBoundariesMm(2.5, 50, 'end')).toEqual([-12.5, 37.5]);
+  });
+});
+
+describe('computeCellCentersMm', () => {
+  it('returns one center per cell (never empty for a non-zero axis)', () => {
+    expect(computeCellCentersMm(1, 42)).toEqual([0]);
+    expect(computeCellCentersMm(0.5, 42)).toEqual([0]);
+  });
+
+  it('integer axis: centers are evenly spaced regardless of fractional edge', () => {
+    // width=4 → cells [1,1,1,1]. Centers at 21, 63, 105, 147 (mm from start).
+    // Centered at totalMm/2 = 84 → -63, -21, 21, 63.
+    expect(computeCellCentersMm(4, 42, 'end')).toEqual([-63, -21, 21, 63]);
+    expect(computeCellCentersMm(4, 42, 'start')).toEqual([-63, -21, 21, 63]);
+  });
+
+  it('fractional axis, end-side: half cell trails the full cells', () => {
+    // width=2.5 → cells [1,1,0.5]. Centers at 21, 63, 94.5 (mm from start).
+    // Centered at totalMm/2 = 52.5 → -31.5, 10.5, 42.
+    expect(computeCellCentersMm(2.5, 42, 'end')).toEqual([-31.5, 10.5, 42]);
+  });
+
+  it('fractional axis, start-side: half cell leads the full cells', () => {
+    // width=2.5 → cells reversed to [0.5,1,1]. Centers at 10.5, 52.5, 94.5.
+    // Centered at 52.5 → -42, -10.5, 31.5.
+    expect(computeCellCentersMm(2.5, 42, 'start')).toEqual([-42, -10.5, 31.5]);
+  });
+
+  it('centers sit halfway between consecutive boundaries (and the edges)', () => {
+    // depth=3 → boundaries [-21, 21]; centers [-42, 0, 42] (span half-cells at ±63).
+    expect(computeCellCentersMm(3, 42, 'end')).toEqual([-42, 0, 42]);
+    expect(computeCellBoundariesMm(3, 42, 'end')).toEqual([-21, 21]);
   });
 });
 

--- a/src/features/generation/worker/generators/cellDecomposition.ts
+++ b/src/features/generation/worker/generators/cellDecomposition.ts
@@ -100,6 +100,32 @@ export function computeCellBoundariesMm(
 }
 
 /**
+ * Compute the mm-positions of cell centers along an axis, relative to the piece
+ * center (axis spans `[-axisUnits*gridUnitMm/2, +axisUnits*gridUnitMm/2]`).
+ *
+ * Mirrors {@link computeCellBoundariesMm} but returns one position per cell (its
+ * midpoint), so it is never empty for a non-zero axis. `fractionalEdge` places
+ * the half-cell at the start or end, shifting the full cells accordingly.
+ */
+export function computeCellCentersMm(
+  axisUnits: number,
+  gridUnitMm: number,
+  fractionalEdge: 'start' | 'end' = 'end'
+): number[] {
+  const cells = decomposeCells(axisUnits);
+  if (fractionalEdge === 'start') cells.reverse();
+  const totalMm = axisUnits * gridUnitMm;
+  const centers: number[] = [];
+  let pos = 0;
+  for (const cell of cells) {
+    const size = cell * gridUnitMm;
+    centers.push(pos + size / 2 - totalMm / 2);
+    pos += size;
+  }
+  return centers;
+}
+
+/**
  * Decompose a grid dimension into all 0.5-unit cells (half sockets mode).
  * Each 1-unit cell becomes two 0.5-unit cells; trailing half-cells stay 0.5.
  *

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -186,14 +186,26 @@ export interface MarginPiece {
   /** Rail-center position in the plate-centered world frame (mm). */
   readonly worldOffsetMm: { readonly x: number; readonly y: number };
   /**
-   * Signed along-length offset (mm) from the rail center to the mating body
-   * wall's center — where the opt-in seam groove must be cut so it lines up with
-   * the body's tongue (#2427). Nonzero on a long rail's corner-owning end
-   * segment, which extends over the perpendicular padding to reach the outer
-   * corner and so is no longer centered on the body wall it joins. Only meaningful
-   * for `long` rails; absent (→ 0) on short/friction-fit rails.
+   * Layout of the opt-in tongue-and-groove seam connector for a `long` rail
+   * (absent on short/friction-fit rails). The body grows one tongue per mating
+   * cell boundary and the rail carves matching grooves; both sides recompute the
+   * same boundary set from `cellUnits`/`fractionalEdge` so they can't drift, and
+   * `centerOffsetMm` re-anchors them onto the body wall on a corner-owning end
+   * segment (which extends over the perpendicular padding and so is no longer
+   * centered on the wall it joins — #2427/#2428).
    */
-  readonly seamTongueOffsetMm?: number;
+  readonly seamConnector?: {
+    /** Grid units of the mating body wall along the rail's running axis. */
+    readonly cellUnits: number;
+    /**
+     * Rail-local position (mm) of the body grid center along the running axis —
+     * i.e. how far the mating wall's center sits from the rail center. Nonzero
+     * only on corner-owning end segments.
+     */
+    readonly centerOffsetMm: number;
+    /** Resolved fractional-edge anchor for the cell-boundary computation. */
+    readonly fractionalEdge: 'start' | 'end';
+  };
   readonly overTile: boolean;
   readonly overTileHalfGrid: boolean;
   readonly overTileHalfGridSolidLeftover: boolean;

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -188,8 +188,8 @@ export interface MarginPiece {
   /**
    * Layout of the opt-in tongue-and-groove seam connector for a `long` rail
    * (absent on short/friction-fit rails). The body grows one tongue per mating
-   * cell boundary and the rail carves matching grooves; both sides recompute the
-   * same boundary set from `cellUnits`/`fractionalEdge` so they can't drift, and
+   * grid cell and the rail carves matching grooves; both sides recompute the same
+   * cell-center set from `cellUnits`/`fractionalEdge` so they can't drift, and
    * `centerOffsetMm` re-anchors them onto the body wall on a corner-owning end
    * segment (which extends over the perpendicular padding and so is no longer
    * centered on the wall it joins — #2427/#2428).

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -197,13 +197,8 @@ export interface MarginPiece {
   readonly seamConnector?: {
     /** Grid units of the mating body wall along the rail's running axis. */
     readonly cellUnits: number;
-    /**
-     * Rail-local position (mm) of the body grid center along the running axis —
-     * i.e. how far the mating wall's center sits from the rail center. Nonzero
-     * only on corner-owning end segments.
-     */
+    /** Rail-local position (mm) of the body grid center along the running axis. */
     readonly centerOffsetMm: number;
-    /** Resolved fractional-edge anchor for the cell-boundary computation. */
     readonly fractionalEdge: 'start' | 'end';
   };
   readonly overTile: boolean;


### PR DESCRIPTION
Prototype follow-up to #2428 (stacked on it — **base is the #2428 branch**, so this diff shows only the multi-connector delta; GitHub auto-retargets it to `main` once #2428 merges).

## Motivation

The opt-in detach-margin connector (#2414) placed **a single tongue at the center of each long rail**. A multi-cell rail is then anchored at one point and can pivot or bow at its ends. This distributes the connectors: **one dovetail per grid cell** along the seam.

## What changed

- **Body** (`buildConnectors`): a `marginSeam` wall grows one tongue at each grid **cell center** along the seam (via the new shared `computeCellCentersMm`), falling back to a single centered tongue on a one-cell wall.
- **Rail** (`buildMarginSeamGroove` via `baseplateMargin`): carves a matching groove at each cell center.
- **Coordination**: the scalar `seamTongueOffsetMm` from #2428 becomes a `seamConnector` descriptor — `{ cellUnits, centerOffsetMm, fractionalEdge }`. Both sides recompute the same cell-center set from it via `computeCellCentersMm`, so they can't drift; `centerOffsetMm` preserves the #2428 corner-segment re-anchoring.

## Why cell centers (not boundaries)

Split-baseplate dovetails sit on the N−1 interior cell *boundaries*. For a retention rail, cell *centers* are a better fit: they yield one connector per cell (always ≥1, so the boundary path's empty-set fallback is effectively dead), distribute evenly, and sit ~½ cell closer to each end — which is what actually resists a long rail pivoting or bowing.

## Verification

On the repro's real BREP solids (8×5 grid, 256mm bed, all margins detached, over-tile half-grid, dovetail): each 4-unit rail carves **4 dovetails**, and **every** body tongue seats >0.9 in its groove — including on corner-owning end segments and on a fractional-width (2.5u) wall.

Tests: planner asserts `seamConnector` values + `cellUnits`; scenario tests assert one tongue per cell, the single-cell fallback, full-set world-space seating, corner-segment seating (with the offset, and misses without it), and fractional-width seating; a `computeCellCentersMm` unit test locks the cell-center math.

## Review

A multi-agent review pass (implementation gaps, correctness, comments, simplify) found the feature complete and internally consistent. Actionable items addressed: fixed a use-after-free in a test helper, added the fractional-width test, refreshed a stale docstring, trimmed redundant comments, removed a redundant alias.

## Deferred / out of scope

- Short rails and corners remain friction-fit (unchanged).
- End anchoring: connectors sit at cell centers, so a very long segment still has < ½ cell of unanchored overhang at each tip.
- `preferIdenticalPieces` compound case remains out of scope (unchanged from #2428); the cell-center *set* is 180°-rotation-invariant, so it doesn't desync there.