### PR TITLE
perf(bin-designer): persist preview meshes across sessions

### DIFF
--- a/.claude/skills/geometry-generation/SKILL.md
+++ b/.claude/skills/geometry-generation/SKILL.md
@@ -66,6 +66,7 @@ Clip geometry lives in `wallPatternClips.ts`, wired in `wallPatternBuilder.ts`. 
 2. Confirm `vite.config.ts` still lists `occt-wasm` in `optimizeDeps.exclude` and the kernel-wrapper pin against GC use-after-free is intact (`git show 6b45ec83b`).
 3. Re-verify the textBuilder linear-metrics assumption (README gotcha 6) and that `meshEdges` call sites pass `EDGE_ANGULAR_TOLERANCE_RAD` from `src/shared/constants/tessellation.ts` — RADIANS; a degrees-magnitude value silently disables edge refinement.
 4. Run the full generators project, `__kernel-tests__` diagnostics (`diagnoseBaseplateWinding`, `occtWasmKernelLifecycle`), `pnpm run bench` vs `__bench__/baseline.json`, and smoke-test Safari/iOS (kernel loads broke there twice).
+5. Bump `MESH_CACHE_VERSION` in `src/shared/generation/meshPersistence.ts` — it keys the cross-session IndexedDB cache of preview meshes; a stale value would serve last-build meshes from a returning user's disk. Any tessellation-tolerance change needs the same bump.
 
 ## Verification
 

--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -554,4 +554,57 @@ describe('useGeneration', () => {
       await vi.advanceTimersByTimeAsync(1);
     });
   });
+
+  it('the persisted pre-draft is not overwritten by the Manifold pre-draft', async () => {
+    const cachedVerts = new Float32Array([0, 0, 0, 3, 0, 0, 0, 3, 0]);
+    const manifoldVerts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    mockLoadPersisted.mockResolvedValue({
+      vertices: cachedVerts,
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      edgeVertices: new Float32Array(0),
+      triangleCount: 1,
+    });
+
+    // Manifold preview bridge is available (flag on). Its pre-draft only fires
+    // while the token is 0, so the cached mesh claiming the token must block it.
+    const previewGenerate = vi.fn().mockResolvedValue({
+      mesh: {
+        vertices: manifoldVerts,
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        indices: new Uint32Array([0, 1, 2]),
+        edgeVertices: new Float32Array(0),
+        triangleCount: 1,
+      },
+      timingMs: 1,
+    });
+    mockAcquirePreview.mockResolvedValue({
+      isDestroyed: false,
+      generateImmediate: previewGenerate,
+      destroy: vi.fn(),
+    } as unknown as GenerationBridge);
+
+    // Hold the exact bridge open so only the pre-drafts can paint.
+    let resolveAcquire: (bridge: GenerationBridge) => void = () => {};
+    mockAcquire.mockReturnValue(
+      new Promise<GenerationBridge>((r) => {
+        resolveAcquire = r;
+      })
+    );
+
+    renderHook(() => useGeneration());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5);
+    });
+
+    // The cached (exact-quality) mesh is on screen; the Manifold pre-draft was
+    // suppressed because the cache already claimed the token.
+    expect(useDesignerStore.getState().generation.mesh?.vertices).toBe(cachedVerts);
+    expect(previewGenerate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveAcquire(mockBridge);
+      await vi.advanceTimersByTimeAsync(1);
+    });
+  });
 });

--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useGeneration } from './useGeneration';
 import { useDesignerStore } from '../store';
 import type { GenerationBridge } from '@/shared/generation/bridge';
+import type { MeshData } from '@/shared/types/generation';
 
 // Mock bridgeManager to isolate tests from the singleton
 const mockBridge = {
@@ -35,6 +36,17 @@ vi.mock('@/shared/generation/bridge', () => ({
   FAST_EXACT_SKIP_MS: 1000,
   // Stable threshold — burst behavior is covered by draftPolicy's own tests.
   createDraftSkipGate: () => () => 1000,
+}));
+
+// Mock the cross-session mesh cache so pre-draft/persist behavior is
+// deterministic (real IndexedDB round-trips are covered in meshPersistence.test).
+const mockLoadPersisted = vi.fn<() => Promise<MeshData | null>>();
+const mockSavePersisted = vi.fn<(key: string, mesh: MeshData) => void>();
+
+vi.mock('@/shared/generation/meshPersistence', () => ({
+  binMeshCacheKey: () => 'test-key',
+  loadPersistedBinMesh: () => mockLoadPersisted(),
+  savePersistedBinMesh: (key: string, mesh: MeshData) => mockSavePersisted(key, mesh),
 }));
 
 // Pristine default params, captured before any test mutates the store singleton.
@@ -71,6 +83,9 @@ describe('useGeneration', () => {
     mockAcquirePreview.mockReset();
     mockAcquirePreview.mockResolvedValue(null); // preview off by default
     mockReleasePreview.mockReset();
+    mockLoadPersisted.mockReset();
+    mockLoadPersisted.mockResolvedValue(null); // no persisted mesh by default
+    mockSavePersisted.mockReset();
     // Unknown estimate = slow → the draft path stays active unless a test
     // explicitly predicts a fast exact.
     (mockBridge.estimateGenerate as ReturnType<typeof vi.fn>).mockReset();
@@ -428,5 +443,65 @@ describe('useGeneration', () => {
     const gen = useDesignerStore.getState().generation;
     expect(gen.isDraft).toBe(false);
     expect(gen.status).toBe('complete');
+  });
+
+  it('persists the exact preview mesh after generation completes', async () => {
+    renderHook(() => useGeneration());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(201);
+    });
+
+    expect(useDesignerStore.getState().generation.status).toBe('complete');
+    expect(mockSavePersisted).toHaveBeenCalledTimes(1);
+    const [key, mesh] = mockSavePersisted.mock.calls[0];
+    expect(key).toBe('test-key');
+    // The raw bridge mesh (not the store payload) is what gets persisted.
+    expect(mesh.vertices).toEqual(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]));
+  });
+
+  it('paints a persisted mesh as a pre-draft while the exact worker loads', async () => {
+    const cachedVerts = new Float32Array([0, 0, 0, 3, 0, 0, 0, 3, 0]);
+    mockLoadPersisted.mockResolvedValue({
+      vertices: cachedVerts,
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      edgeVertices: new Float32Array(0),
+      triangleCount: 1,
+    });
+
+    // Hold the exact bridge open so the persisted mesh is the only thing that
+    // can paint (preview bridge is off by default).
+    let resolveAcquire: (bridge: GenerationBridge) => void = () => {};
+    mockAcquire.mockReturnValue(
+      new Promise<GenerationBridge>((r) => {
+        resolveAcquire = r;
+      })
+    );
+
+    renderHook(() => useGeneration());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    // Persisted pre-draft on screen while the exact worker is still loading.
+    let state = useDesignerStore.getState();
+    expect(state.wasmStatus).toBe('loading');
+    expect(state.generation.isDraft).toBe(true);
+    expect(state.generation.mesh?.vertices).toBe(cachedVerts);
+
+    // Exact bridge arrives → initial generation supersedes the pre-draft.
+    await act(async () => {
+      resolveAcquire(mockBridge);
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(201);
+    });
+
+    state = useDesignerStore.getState();
+    expect(state.wasmStatus).toBe('ready');
+    expect(state.generation.isDraft).toBe(false);
+    expect(state.generation.status).toBe('complete');
+    expect(state.generation.mesh?.vertices).not.toBe(cachedVerts);
   });
 });

--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -44,7 +44,8 @@ const mockLoadPersisted = vi.fn<() => Promise<MeshData | null>>();
 const mockSavePersisted = vi.fn<(key: string, mesh: MeshData) => void>();
 
 vi.mock('@/shared/generation/meshPersistence', () => ({
-  binMeshCacheKey: () => 'test-key',
+  // Param-sensitive so the stale-params guard in the mount pre-draft is testable.
+  binMeshCacheKey: (p: { width: number }) => `test-key-${p.width}`,
   loadPersistedBinMesh: () => mockLoadPersisted(),
   savePersistedBinMesh: (key: string, mesh: MeshData) => mockSavePersisted(key, mesh),
 }));
@@ -456,7 +457,7 @@ describe('useGeneration', () => {
     expect(useDesignerStore.getState().generation.status).toBe('complete');
     expect(mockSavePersisted).toHaveBeenCalledTimes(1);
     const [key, mesh] = mockSavePersisted.mock.calls[0];
-    expect(key).toBe('test-key');
+    expect(key).toMatch(/^test-key-/);
     // The raw bridge mesh (not the store payload) is what gets persisted.
     expect(mesh.vertices).toEqual(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]));
   });
@@ -503,5 +504,49 @@ describe('useGeneration', () => {
     expect(state.generation.isDraft).toBe(false);
     expect(state.generation.status).toBe('complete');
     expect(state.generation.mesh?.vertices).not.toBe(cachedVerts);
+  });
+
+  it('does NOT paint a persisted pre-draft when params changed during WASM load', async () => {
+    const cachedVerts = new Float32Array([0, 0, 0, 3, 0, 0, 0, 3, 0]);
+    // Hold the persisted load open so we can change params before it resolves.
+    let resolveLoad: (mesh: MeshData) => void = () => {};
+    mockLoadPersisted.mockReturnValue(
+      new Promise<MeshData>((r) => {
+        resolveLoad = r;
+      })
+    );
+
+    // Hold the exact bridge open too — keeps the token at 0 (edits don't
+    // regenerate until the bridge is ready), which is exactly the window the
+    // guard protects.
+    let resolveAcquire: (bridge: GenerationBridge) => void = () => {};
+    mockAcquire.mockReturnValue(
+      new Promise<GenerationBridge>((r) => {
+        resolveAcquire = r;
+      })
+    );
+
+    renderHook(() => useGeneration());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    // User edits width while WASM is still loading, then the stale cache resolves.
+    await act(async () => {
+      useDesignerStore.setState((s) => ({ params: { ...s.params, width: s.params.width + 1 } }));
+      resolveLoad({
+        vertices: cachedVerts,
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        indices: new Uint32Array([0, 1, 2]),
+        edgeVertices: new Float32Array(0),
+        triangleCount: 1,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    // The cached mesh was for the pre-edit params — it must not paint.
+    expect(useDesignerStore.getState().generation.mesh?.vertices).not.toBe(cachedVerts);
+
+    resolveAcquire(mockBridge);
   });
 });

--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -547,6 +547,11 @@ describe('useGeneration', () => {
     // The cached mesh was for the pre-edit params — it must not paint.
     expect(useDesignerStore.getState().generation.mesh?.vertices).not.toBe(cachedVerts);
 
-    resolveAcquire(mockBridge);
+    // Resolve the held bridge inside act() so the mount effect's follow-on state
+    // updates don't emit spurious act() warnings.
+    await act(async () => {
+      resolveAcquire(mockBridge);
+      await vi.advanceTimersByTimeAsync(1);
+    });
   });
 });

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -6,6 +6,12 @@ import { bridgeManager, createDraftSkipGate } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
 import { generateBinDirect, canBinUseDirectMesh } from '@/shared/generation/directMesh';
 import { handleWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
+import {
+  binMeshCacheKey,
+  loadPersistedBinMesh,
+  savePersistedBinMesh,
+} from '@/shared/generation/meshPersistence';
+import type { MeshData } from '@/shared/types/generation';
 import { validateCompartmentSizes } from '../utils/validation';
 import {
   trackWasmThreadingStatus,
@@ -42,6 +48,30 @@ function toMeshPayload(result: BridgeResult): GenerationResult {
       : undefined,
     error: null,
     timingMs: result.timingMs,
+  };
+}
+
+/**
+ * Map a raw persisted `MeshData` (loaded from IndexedDB) to the store's mesh
+ * payload. Mirrors `toMeshPayload` but sources a bare mesh rather than a bridge
+ * result; the readonly faceGroups are spread into a mutable copy for Immer.
+ */
+function meshDataToPayload(mesh: MeshData): GenerationResult {
+  return {
+    vertices: mesh.vertices,
+    normals: mesh.normals,
+    indices: mesh.indices,
+    edgeVertices: mesh.edgeVertices,
+    faceGroups: mesh.faceGroups ? [...mesh.faceGroups] : undefined,
+    coarseLOD: mesh.coarseLOD,
+    lidMesh: mesh.lidMesh
+      ? {
+          ...mesh.lidMesh,
+          faceGroups: mesh.lidMesh.faceGroups ? [...mesh.lidMesh.faceGroups] : undefined,
+        }
+      : undefined,
+    error: null,
+    timingMs: 0,
   };
 }
 
@@ -219,6 +249,11 @@ export function useGeneration(): void {
         setGenerationResult(toMeshPayload(result));
         setGenerationStatus('complete');
 
+        // Persist the exact preview mesh so reopening this design next session
+        // paints instantly (pre-draft) instead of re-paying the cold start.
+        // Fire-and-forget; refreshes LRU freshness even when the entry exists.
+        savePersistedBinMesh(binMeshCacheKey(currentParams), result.mesh);
+
         // Once the user pauses, speculatively warm the export-quality shell so
         // the first export skips the deferred socket↔body fuse. (Any prior timer
         // was already cleared at the start of this generation.)
@@ -290,6 +325,20 @@ export function useGeneration(): void {
     let cancelled = false;
     let acquiredPreview = false;
     setWasmStatus('loading');
+
+    // Instant pre-draft from last session (best-effort): a saved bin's exact
+    // preview mesh persisted to IndexedDB paints in tens of ms while occt-wasm
+    // (~2-4s) loads. Only when nothing has painted yet — the first real
+    // generation (token 1) supersedes it through normal token arbitration, the
+    // same way the Manifold pre-draft does. Not run for generic items.
+    const initialState = useDesignerStore.getState();
+    if (initialState.itemKind === 'bin') {
+      void loadPersistedBinMesh(binMeshCacheKey(initialState.params)).then((cached) => {
+        if (cancelled || !cached) return;
+        if (genTokenRef.current !== 0 || finalizedTokenRef.current > 0) return;
+        setDraftResult(meshDataToPayload(cached));
+      });
+    }
 
     bridgeManager
       .acquire()
@@ -377,7 +426,7 @@ export function useGeneration(): void {
       bridgeManager.release();
       if (acquiredPreview) bridgeManager.releasePreview();
     };
-  }, [setWasmStatus, runGeneration, runItemGeneration, dispatchDraft]);
+  }, [setWasmStatus, setDraftResult, runGeneration, runItemGeneration, dispatchDraft]);
 
   // Re-generate when epoch changes (after initialization)
   useEffect(() => {

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -333,9 +333,15 @@ export function useGeneration(): void {
     // same way the Manifold pre-draft does. Not run for generic items.
     const initialState = useDesignerStore.getState();
     if (initialState.itemKind === 'bin') {
-      void loadPersistedBinMesh(binMeshCacheKey(initialState.params)).then((cached) => {
+      const initialKey = binMeshCacheKey(initialState.params);
+      void loadPersistedBinMesh(initialKey).then((cached) => {
         if (cancelled || !cached) return;
         if (genTokenRef.current !== 0 || finalizedTokenRef.current > 0) return;
+        // Params can change while occt-wasm loads (edits don't regenerate until
+        // the bridge is ready, so the token stays 0). Don't paint a pre-draft
+        // for params the user has already moved on from.
+        const now = useDesignerStore.getState();
+        if (now.itemKind !== 'bin' || binMeshCacheKey(now.params) !== initialKey) return;
         setDraftResult(meshDataToPayload(cached));
       });
     }

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -328,9 +328,9 @@ export function useGeneration(): void {
 
     // Instant pre-draft from last session (best-effort): a saved bin's exact
     // preview mesh persisted to IndexedDB paints in tens of ms while occt-wasm
-    // (~2-4s) loads. Only when nothing has painted yet — the first real
-    // generation (token 1) supersedes it through normal token arbitration, the
-    // same way the Manifold pre-draft does. Not run for generic items.
+    // (~2-4s) loads. Only when nothing has painted yet; it claims the token so
+    // the exact generation (and nothing else) supersedes it through normal
+    // arbitration, the same way the Manifold pre-draft does. Not for generic items.
     const initialState = useDesignerStore.getState();
     if (initialState.itemKind === 'bin') {
       const initialKey = binMeshCacheKey(initialState.params);
@@ -342,6 +342,12 @@ export function useGeneration(): void {
         // for params the user has already moved on from.
         const now = useDesignerStore.getState();
         if (now.itemKind !== 'bin' || binMeshCacheKey(now.params) !== initialKey) return;
+        // Claim the generation token before painting. The Manifold pre-draft
+        // fires only while the token is still 0, so without this a slower
+        // Manifold draft would overwrite this exact-quality cached mesh with a
+        // coarse approximation. The initial exact generation takes the next
+        // token and supersedes this through normal arbitration.
+        ++genTokenRef.current;
         setDraftResult(meshDataToPayload(cached));
       });
     }

--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -89,6 +89,10 @@ Composable stages in `pipeline/stages/`, orchestrated by `pipeline/runner.ts`:
 4. **Translate** (`translateStage`) — Z-offset for socket-based bins (applied to `solid` **and** `deferredSolid` so they stay aligned)
 5. **Tessellate** (`tessellateStage`) — dynamic quality mesh + edge extraction; meshes `deferredSolid` separately and concatenates via `mergeShapeMeshes` (visually identical to the fused shell — socket meets the body only at a hidden interface). The socket mesh is cached by geometry identity (`socketMeshCache`, keyed via `deferredSolidKey`) so non-dimension edits skip re-tessellating the base.
 
+## Cross-session mesh cache
+
+All the caches above are **in-memory only** — they vanish on reload. `src/shared/generation/meshPersistence.ts` (main thread) additionally persists the final bin-designer preview `MeshData` to IndexedDB, keyed by a hash of `BinParams` + `MESH_CACHE_VERSION`, so reopening a saved custom bin paints last session's exact mesh instantly (as a pre-draft in `useGeneration`) while the worker warms up and regenerates. Preview-only — exports always regenerate the watertight fused shell. **Bump `MESH_CACHE_VERSION` on any brepjs/occt-wasm or tessellation change** (see the geometry-generation skill).
+
 ## Worker Protocol
 
 | Message         | Purpose                                           |

--- a/src/shared/generation/meshPersistence.test.ts
+++ b/src/shared/generation/meshPersistence.test.ts
@@ -105,13 +105,15 @@ describe('persistence round-trip', () => {
 
   it('savePersistedBinMesh (fire-and-forget) also persists', async () => {
     savePersistedBinMesh('k-ff', makeMesh({ triangleCount: 7 }));
-    // Poll briefly for the detached write to land.
+    // Poll for the detached write to land — generous budget so a slow-CI
+    // IndexedDB tick doesn't flake the test (still returns as soon as it's set).
     let loaded = await loadPersistedBinMesh('k-ff');
-    for (let i = 0; i < 50 && !loaded; i++) {
-      await new Promise((r) => setTimeout(r, 2));
+    for (let i = 0; i < 200 && !loaded; i++) {
+      await new Promise((r) => setTimeout(r, 10));
       loaded = await loadPersistedBinMesh('k-ff');
     }
-    expect(loaded!.triangleCount).toBe(7);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.triangleCount).toBe(7);
   });
 });
 

--- a/src/shared/generation/meshPersistence.test.ts
+++ b/src/shared/generation/meshPersistence.test.ts
@@ -7,6 +7,7 @@ import {
   loadPersistedBinMesh,
   savePersistedBinMesh,
   __savePersistedBinMeshForTests as saveMesh,
+  __setMaxCacheBytesForTests,
   __resetMeshDbForTests,
 } from './meshPersistence';
 
@@ -40,6 +41,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   __resetMeshDbForTests();
+  __setMaxCacheBytesForTests(); // restore the 64MB default
 });
 
 describe('binMeshCacheKey', () => {
@@ -119,14 +121,16 @@ describe('persistence round-trip', () => {
 
 describe('eviction', () => {
   it('drops the oldest entries once the byte budget is exceeded', async () => {
-    // ~1MB per mesh; write enough to blow past the 64MB budget.
-    const big = () => makeMesh({ vertices: new Float32Array(256 * 1024) }); // 1MB
-    for (let i = 0; i < 70; i++) {
-      await saveMesh(`k${i}`, big());
+    // Tiny budget so the eviction path is exercised without writing ~70MB.
+    // Each mesh is ~64 bytes of vertices; a 400-byte budget holds only a few.
+    __setMaxCacheBytesForTests(400);
+    const small = () => makeMesh({ vertices: new Float32Array(16) }); // 64 bytes
+    for (let i = 0; i < 20; i++) {
+      await saveMesh(`k${i}`, small());
     }
 
     // The very first entries should have been evicted; recent ones survive.
     expect(await loadPersistedBinMesh('k0')).toBeNull();
-    expect(await loadPersistedBinMesh('k69')).not.toBeNull();
+    expect(await loadPersistedBinMesh('k19')).not.toBeNull();
   });
 });

--- a/src/shared/generation/meshPersistence.test.ts
+++ b/src/shared/generation/meshPersistence.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { MeshData } from '@/shared/types/generation';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import {
+  binMeshCacheKey,
+  loadPersistedBinMesh,
+  savePersistedBinMesh,
+  __savePersistedBinMeshForTests as saveMesh,
+  __resetMeshDbForTests,
+} from './meshPersistence';
+
+const DB_NAME = 'gridfinity-mesh-cache';
+
+function deleteDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(DB_NAME);
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+    req.onblocked = () => resolve();
+  });
+}
+
+/** Minimal deterministic mesh; `fill` makes byte content assertable. */
+function makeMesh(overrides: Partial<MeshData> = {}): MeshData {
+  return {
+    vertices: new Float32Array([0, 0, 0, 1, 1, 1]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    edgeVertices: new Float32Array([0, 0, 0, 1, 0, 0]),
+    triangleCount: 1,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  __resetMeshDbForTests();
+  await deleteDb();
+});
+
+afterEach(() => {
+  __resetMeshDbForTests();
+});
+
+describe('binMeshCacheKey', () => {
+  it('is stable regardless of param key order', () => {
+    const a = binMeshCacheKey({ ...DEFAULT_BIN_PARAMS });
+    const reordered = Object.fromEntries(
+      Object.entries(DEFAULT_BIN_PARAMS).reverse()
+    ) as typeof DEFAULT_BIN_PARAMS;
+    const b = binMeshCacheKey(reordered);
+    expect(a).toBe(b);
+  });
+
+  it('changes when any param changes', () => {
+    const base = binMeshCacheKey(DEFAULT_BIN_PARAMS);
+    const wider = binMeshCacheKey({ ...DEFAULT_BIN_PARAMS, width: DEFAULT_BIN_PARAMS.width + 1 });
+    expect(wider).not.toBe(base);
+  });
+
+  it('is prefixed with the cache version so a bump orphans old keys', () => {
+    expect(binMeshCacheKey(DEFAULT_BIN_PARAMS)).toMatch(/^v\d/);
+  });
+});
+
+describe('persistence round-trip', () => {
+  it('returns null on a miss', async () => {
+    expect(await loadPersistedBinMesh('nope')).toBeNull();
+  });
+
+  it('round-trips a mesh including face groups, coarse LOD, and lid', async () => {
+    const mesh = makeMesh({
+      faceGroups: [{ start: 0, count: 3, tag: 1 }],
+      coarseLOD: {
+        vertices: new Float32Array([2, 2, 2]),
+        indices: new Uint32Array([0]),
+        triangleCount: 1,
+      },
+      lidMesh: {
+        vertices: new Float32Array([9, 9, 9]),
+        normals: new Float32Array([1, 0, 0]),
+        indices: new Uint32Array([0]),
+        edgeVertices: new Float32Array([9, 9, 9]),
+        triangleCount: 1,
+      },
+    });
+
+    await saveMesh('k1', mesh);
+
+    const loaded = await loadPersistedBinMesh('k1');
+    expect(loaded).not.toBeNull();
+    expect(Array.from(loaded!.vertices)).toEqual([0, 0, 0, 1, 1, 1]);
+    expect(loaded!.faceGroups?.[0]).toMatchObject({ start: 0, count: 3, tag: 1 });
+    expect(Array.from(loaded!.coarseLOD!.vertices)).toEqual([2, 2, 2]);
+    expect(Array.from(loaded!.lidMesh!.vertices)).toEqual([9, 9, 9]);
+  });
+
+  it('overwrites an existing entry under the same key', async () => {
+    await saveMesh('k1', makeMesh({ triangleCount: 1 }));
+    await saveMesh('k1', makeMesh({ triangleCount: 42 }));
+
+    const loaded = await loadPersistedBinMesh('k1');
+    expect(loaded!.triangleCount).toBe(42);
+  });
+
+  it('savePersistedBinMesh (fire-and-forget) also persists', async () => {
+    savePersistedBinMesh('k-ff', makeMesh({ triangleCount: 7 }));
+    // Poll briefly for the detached write to land.
+    let loaded = await loadPersistedBinMesh('k-ff');
+    for (let i = 0; i < 50 && !loaded; i++) {
+      await new Promise((r) => setTimeout(r, 2));
+      loaded = await loadPersistedBinMesh('k-ff');
+    }
+    expect(loaded!.triangleCount).toBe(7);
+  });
+});
+
+describe('eviction', () => {
+  it('drops the oldest entries once the byte budget is exceeded', async () => {
+    // ~1MB per mesh; write enough to blow past the 64MB budget.
+    const big = () => makeMesh({ vertices: new Float32Array(256 * 1024) }); // 1MB
+    for (let i = 0; i < 70; i++) {
+      await saveMesh(`k${i}`, big());
+    }
+
+    // The very first entries should have been evicted; recent ones survive.
+    expect(await loadPersistedBinMesh('k0')).toBeNull();
+    expect(await loadPersistedBinMesh('k69')).not.toBeNull();
+  });
+});

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -41,7 +41,7 @@ const META_STORE = 'binMeshMeta';
 const MESH_CACHE_VERSION = 'v1-brepjs18.116.1';
 
 /** Evict oldest entries once the total stored mesh bytes exceed this budget. */
-const MAX_CACHE_BYTES = 64 * 1024 * 1024;
+let maxCacheBytes = 64 * 1024 * 1024;
 
 interface StoredMesh {
   readonly key: string;
@@ -52,7 +52,8 @@ interface StoredMesh {
 interface MeshMeta {
   readonly key: string;
   readonly byteSize: number;
-  readonly createdAt: number;
+  /** Monotonic recency stamp (updated on every write/touch, not creation time). */
+  readonly ts: number;
 }
 
 /** Whether IndexedDB is usable in this environment (absent in SSR / some test runs). */
@@ -62,7 +63,7 @@ function hasIndexedDb(): boolean {
 
 // Strictly-monotonic recency stamp: wall-clock when it advances, else +1, so
 // entries written in the same millisecond still order deterministically in the
-// `byCreatedAt` index (keeps LRU eviction "oldest-first" under bursty writes).
+// `byTs` index (keeps LRU eviction "oldest-first" under bursty writes).
 let lastStamp = 0;
 function nextStamp(): number {
   const now = Date.now();
@@ -81,7 +82,7 @@ async function openMeshDb(): Promise<IDBPDatabase> {
       }
       if (!db.objectStoreNames.contains(META_STORE)) {
         const meta = db.createObjectStore(META_STORE, { keyPath: 'key' });
-        meta.createIndex('byCreatedAt', 'createdAt', { unique: false });
+        meta.createIndex('byTs', 'ts', { unique: false });
       }
     },
   });
@@ -185,9 +186,10 @@ export async function loadPersistedBinMesh(key: string): Promise<MeshData | null
 }
 
 /**
- * Persist a preview mesh (fire-and-forget). Refreshes `createdAt` on repeats so
- * the entry stays LRU-fresh, then evicts oldest entries over the byte budget.
- * All failures are swallowed — persistence must never block generation.
+ * Persist a preview mesh (fire-and-forget). Refreshes the recency stamp on
+ * repeats so the entry stays LRU-fresh, then evicts oldest entries over the
+ * byte budget. All failures are swallowed — persistence must never block
+ * generation.
  */
 export function savePersistedBinMesh(key: string, mesh: MeshData): void {
   if (!hasIndexedDb()) return;
@@ -196,37 +198,40 @@ export function savePersistedBinMesh(key: string, mesh: MeshData): void {
 
 /**
  * Awaitable core of {@link savePersistedBinMesh}; resolves after eviction.
- * Writes the mesh and its metadata in one transaction and evicts within the
- * same transaction so the store never exceeds the budget between calls.
+ *
+ * Each IndexedDB transaction issues all its ops synchronously and awaits only
+ * `tx.done` — never an `await` *between* ops inside a live transaction. WebKit
+ * auto-commits a transaction as soon as its microtask queue drains, so an
+ * `await` gap mid-transaction throws `TransactionInactiveError` on iOS/Safari
+ * (see `src/core/cqrs/store/eventStore.ts`). Reads used to plan eviction happen
+ * in their own single-request calls (`getAllFromIndex`), outside any open write.
  */
 async function persistMesh(key: string, mesh: MeshData): Promise<void> {
   try {
     const db = await getDb();
-    const meta: MeshMeta = { key, byteSize: meshByteSize(mesh), createdAt: nextStamp() };
+    const meta: MeshMeta = { key, byteSize: meshByteSize(mesh), ts: nextStamp() };
 
-    const tx = db.transaction([BIN_MESHES_STORE, META_STORE], 'readwrite');
-    const meshes = tx.objectStore(BIN_MESHES_STORE);
-    const metas = tx.objectStore(META_STORE);
-    await Promise.all([meshes.put({ key, mesh } satisfies StoredMesh), metas.put(meta)]);
+    const writeTx = db.transaction([BIN_MESHES_STORE, META_STORE], 'readwrite');
+    void writeTx.objectStore(BIN_MESHES_STORE).put({ key, mesh } satisfies StoredMesh);
+    void writeTx.objectStore(META_STORE).put(meta);
+    await writeTx.done;
 
-    // Walk the metadata index only — its records carry no mesh buffers, so the
-    // cursor never materializes the large typed arrays in `binMeshes`.
-    let total = 0;
-    const ordered: MeshMeta[] = [];
-    for await (const cursor of metas.index('byCreatedAt').iterate()) {
-      const value = cursor.value as MeshMeta;
-      total += value.byteSize;
-      ordered.push(value);
-    }
+    // Plan eviction from the metadata store only (no mesh buffers), ascending by
+    // recency stamp — a single indexed read, not a cursor walk over a live tx.
+    const metas = (await db.getAllFromIndex(META_STORE, 'byTs')) as MeshMeta[];
+    let total = metas.reduce((sum, m) => sum + m.byteSize, 0);
+    if (total <= maxCacheBytes) return;
 
-    // `ordered` is ascending by createdAt (oldest first).
-    for (const entry of ordered) {
-      if (total <= MAX_CACHE_BYTES) break;
-      await Promise.all([meshes.delete(entry.key), metas.delete(entry.key)]);
+    const evictTx = db.transaction([BIN_MESHES_STORE, META_STORE], 'readwrite');
+    const meshes = evictTx.objectStore(BIN_MESHES_STORE);
+    const metaStore = evictTx.objectStore(META_STORE);
+    for (const entry of metas) {
+      if (total <= maxCacheBytes) break;
+      void meshes.delete(entry.key);
+      void metaStore.delete(entry.key);
       total -= entry.byteSize;
     }
-
-    await tx.done;
+    await evictTx.done;
   } catch (e) {
     logger.warn('Failed to persist mesh', { error: String(e) });
   }
@@ -235,6 +240,11 @@ async function persistMesh(key: string, mesh: MeshData): Promise<void> {
 /** Test-only: awaitable save (resolves after the write + eviction settle). */
 export function __savePersistedBinMeshForTests(key: string, mesh: MeshData): Promise<void> {
   return persistMesh(key, mesh);
+}
+
+/** Test-only: override the eviction byte budget (defaults back to 64 MB). */
+export function __setMaxCacheBytesForTests(bytes = 64 * 1024 * 1024): void {
+  maxCacheBytes = bytes;
 }
 
 /** Test-only: close and drop the cached connection so the DB can be deleted. */

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -60,6 +60,16 @@ function hasIndexedDb(): boolean {
   return typeof indexedDB !== 'undefined';
 }
 
+// Strictly-monotonic recency stamp: wall-clock when it advances, else +1, so
+// entries written in the same millisecond still order deterministically in the
+// `byCreatedAt` index (keeps LRU eviction "oldest-first" under bursty writes).
+let lastStamp = 0;
+function nextStamp(): number {
+  const now = Date.now();
+  lastStamp = now > lastStamp ? now : lastStamp + 1;
+  return lastStamp;
+}
+
 let dbInstance: IDBPDatabase | null = null;
 let openPromise: Promise<IDBPDatabase> | null = null;
 
@@ -192,7 +202,7 @@ export function savePersistedBinMesh(key: string, mesh: MeshData): void {
 async function persistMesh(key: string, mesh: MeshData): Promise<void> {
   try {
     const db = await getDb();
-    const meta: MeshMeta = { key, byteSize: meshByteSize(mesh), createdAt: Date.now() };
+    const meta: MeshMeta = { key, byteSize: meshByteSize(mesh), createdAt: nextStamp() };
 
     const tx = db.transaction([BIN_MESHES_STORE, META_STORE], 'readwrite');
     const meshes = tx.objectStore(BIN_MESHES_STORE);

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -27,6 +27,9 @@ const logger = createLogger('MeshPersistence');
 const DB_NAME = 'gridfinity-mesh-cache';
 const DB_VERSION = 1;
 const BIN_MESHES_STORE = 'binMeshes';
+// Size/timestamp metadata lives in its own store so eviction can walk it
+// without deserializing the (large) mesh buffers from `binMeshes`.
+const META_STORE = 'binMeshMeta';
 
 /**
  * Bumped whenever the generated mesh bytes can change for the same params —
@@ -43,6 +46,11 @@ const MAX_CACHE_BYTES = 64 * 1024 * 1024;
 interface StoredMesh {
   readonly key: string;
   readonly mesh: MeshData;
+}
+
+/** Lightweight per-entry metadata (no mesh buffers) used to drive LRU eviction. */
+interface MeshMeta {
+  readonly key: string;
   readonly byteSize: number;
   readonly createdAt: number;
 }
@@ -59,8 +67,11 @@ async function openMeshDb(): Promise<IDBPDatabase> {
   const db = await openDB(DB_NAME, DB_VERSION, {
     upgrade(db) {
       if (!db.objectStoreNames.contains(BIN_MESHES_STORE)) {
-        const store = db.createObjectStore(BIN_MESHES_STORE, { keyPath: 'key' });
-        store.createIndex('byCreatedAt', 'createdAt', { unique: false });
+        db.createObjectStore(BIN_MESHES_STORE, { keyPath: 'key' });
+      }
+      if (!db.objectStoreNames.contains(META_STORE)) {
+        const meta = db.createObjectStore(META_STORE, { keyPath: 'key' });
+        meta.createIndex('byCreatedAt', 'createdAt', { unique: false });
       }
     },
   });
@@ -167,48 +178,42 @@ export function savePersistedBinMesh(key: string, mesh: MeshData): void {
   void persistMesh(key, mesh);
 }
 
-/** Awaitable core of {@link savePersistedBinMesh}; resolves after eviction. */
+/**
+ * Awaitable core of {@link savePersistedBinMesh}; resolves after eviction.
+ * Writes the mesh and its metadata in one transaction and evicts within the
+ * same transaction so the store never exceeds the budget between calls.
+ */
 async function persistMesh(key: string, mesh: MeshData): Promise<void> {
   try {
     const db = await getDb();
-    const entry: StoredMesh = {
-      key,
-      mesh,
-      byteSize: meshByteSize(mesh),
-      createdAt: Date.now(),
-    };
-    await db.put(BIN_MESHES_STORE, entry);
-    await evictOverBudget(db);
+    const meta: MeshMeta = { key, byteSize: meshByteSize(mesh), createdAt: Date.now() };
+
+    const tx = db.transaction([BIN_MESHES_STORE, META_STORE], 'readwrite');
+    const meshes = tx.objectStore(BIN_MESHES_STORE);
+    const metas = tx.objectStore(META_STORE);
+    await Promise.all([meshes.put({ key, mesh } satisfies StoredMesh), metas.put(meta)]);
+
+    // Walk the metadata index only — its records carry no mesh buffers, so the
+    // cursor never materializes the large typed arrays in `binMeshes`.
+    let total = 0;
+    const ordered: MeshMeta[] = [];
+    for await (const cursor of metas.index('byCreatedAt').iterate()) {
+      const value = cursor.value as MeshMeta;
+      total += value.byteSize;
+      ordered.push(value);
+    }
+
+    // `ordered` is ascending by createdAt (oldest first).
+    for (const entry of ordered) {
+      if (total <= MAX_CACHE_BYTES) break;
+      await Promise.all([meshes.delete(entry.key), metas.delete(entry.key)]);
+      total -= entry.byteSize;
+    }
+
+    await tx.done;
   } catch (e) {
     logger.warn('Failed to persist mesh', { error: String(e) });
   }
-}
-
-/**
- * Evict oldest entries (by `createdAt`) until the total stored bytes fit the
- * budget. Runs after each write; the entry set is small (hundreds) and writes
- * are infrequent (once per settled edit), so the full cursor walk is cheap.
- */
-async function evictOverBudget(db: IDBPDatabase): Promise<void> {
-  const tx = db.transaction(BIN_MESHES_STORE, 'readwrite');
-  const index = tx.store.index('byCreatedAt');
-
-  let total = 0;
-  const entries: { key: string; byteSize: number }[] = [];
-  for await (const cursor of index.iterate()) {
-    const value = cursor.value as StoredMesh;
-    total += value.byteSize;
-    entries.push({ key: value.key, byteSize: value.byteSize });
-  }
-
-  // entries are in ascending createdAt order (oldest first)
-  for (const entry of entries) {
-    if (total <= MAX_CACHE_BYTES) break;
-    await tx.store.delete(entry.key);
-    total -= entry.byteSize;
-  }
-
-  await tx.done;
 }
 
 /** Test-only: awaitable save (resolves after the write + eviction settle). */

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -1,0 +1,224 @@
+/**
+ * Cross-session persistence for generated bin preview meshes.
+ *
+ * The bin-designer's in-memory caches (worker `shapeCache`, undo-history
+ * `meshCacheManager`) do not survive a page reload, so reopening a saved custom
+ * bin re-pays the full cold start: ~2-4s to load occt-wasm plus ~1-2s to run the
+ * generation pipeline. The tessellated preview mesh is deterministic for a given
+ * set of params (tolerance is a pure function of dimensions at `forExport=false`)
+ * and `MeshData` is structured-clone-serializable, so we persist it in IndexedDB
+ * keyed by a hash of the params. On the next open the exact mesh paints in tens
+ * of ms as a pre-draft while the worker warms up and regenerates to confirm it.
+ *
+ * This is a fast pre-paint only — never a source of truth. Exports always
+ * regenerate (they need the watertight fused shell), so a stale entry can never
+ * corrupt an exported model; the worst case is a momentary wrong preview that
+ * the background regeneration immediately replaces.
+ */
+
+import { openDB } from 'idb';
+import type { IDBPDatabase } from 'idb';
+import type { BinParams } from '@/features/bin-designer/types';
+import type { MeshData } from '@/shared/types/generation';
+import { createLogger } from '@/core/logger';
+
+const logger = createLogger('MeshPersistence');
+
+const DB_NAME = 'gridfinity-mesh-cache';
+const DB_VERSION = 1;
+const BIN_MESHES_STORE = 'binMeshes';
+
+/**
+ * Bumped whenever the generated mesh bytes can change for the same params —
+ * a brepjs/occt-wasm upgrade or a tessellation-tolerance change. A bump changes
+ * every key, so old entries never match again and are evicted by the LRU budget.
+ * Preview always uses the occt-wasm exact kernel at `forExport=false`, so the
+ * kernel and quality are folded into this constant rather than the per-entry key.
+ */
+const MESH_CACHE_VERSION = 'v1-brepjs18.116.1';
+
+/** Evict oldest entries once the total stored mesh bytes exceed this budget. */
+const MAX_CACHE_BYTES = 64 * 1024 * 1024;
+
+interface StoredMesh {
+  readonly key: string;
+  readonly mesh: MeshData;
+  readonly byteSize: number;
+  readonly createdAt: number;
+}
+
+/** Whether IndexedDB is usable in this environment (absent in SSR / some test runs). */
+function hasIndexedDb(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+let dbInstance: IDBPDatabase | null = null;
+let openPromise: Promise<IDBPDatabase> | null = null;
+
+async function openMeshDb(): Promise<IDBPDatabase> {
+  const db = await openDB(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(BIN_MESHES_STORE)) {
+        const store = db.createObjectStore(BIN_MESHES_STORE, { keyPath: 'key' });
+        store.createIndex('byCreatedAt', 'createdAt', { unique: false });
+      }
+    },
+  });
+
+  // Drop the cached handle if the browser closes the connection (tab eviction,
+  // a version change from another tab) so the next call reopens cleanly.
+  db.addEventListener('close', () => {
+    if (dbInstance === db) dbInstance = null;
+  });
+
+  return db;
+}
+
+async function getDb(): Promise<IDBPDatabase> {
+  if (dbInstance) return dbInstance;
+  openPromise ??= openMeshDb()
+    .then((db) => {
+      dbInstance = db;
+      return db;
+    })
+    .finally(() => {
+      openPromise = null;
+    });
+  return openPromise;
+}
+
+/**
+ * Stable JSON serialization: keys sorted at every level so params from Immer /
+ * undo (whose key order isn't guaranteed) hash identically. `undefined` values
+ * are dropped by `JSON.stringify` already; typed arrays don't appear in params.
+ */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val: unknown) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const obj = val as Record<string, unknown>;
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(obj).sort()) {
+        sorted[k] = obj[k];
+      }
+      return sorted;
+    }
+    return val;
+  });
+}
+
+/** djb2 string hash → unsigned 32-bit hex (matches useSnapshotAutoSave's pattern). */
+function djb2(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(16);
+}
+
+/** Content-addressed cache key for a bin's preview mesh. */
+export function binMeshCacheKey(params: BinParams): string {
+  return `${MESH_CACHE_VERSION}:${djb2(stableStringify(params))}`;
+}
+
+/** Sum the byte length of every typed array reachable from a mesh (incl. lid). */
+function meshByteSize(mesh: MeshData): number {
+  let bytes =
+    mesh.vertices.byteLength +
+    mesh.normals.byteLength +
+    mesh.indices.byteLength +
+    mesh.edgeVertices.byteLength;
+  if (mesh.coarseLOD) {
+    bytes += mesh.coarseLOD.vertices.byteLength + mesh.coarseLOD.indices.byteLength;
+  }
+  if (mesh.lidMesh) {
+    bytes +=
+      mesh.lidMesh.vertices.byteLength +
+      mesh.lidMesh.normals.byteLength +
+      mesh.lidMesh.indices.byteLength +
+      mesh.lidMesh.edgeVertices.byteLength;
+  }
+  return bytes;
+}
+
+/**
+ * Load a persisted preview mesh, or `null` on miss / unavailable store / error.
+ * Never throws — a failed read simply means "no pre-draft", and the worker still
+ * generates the exact mesh.
+ */
+export async function loadPersistedBinMesh(key: string): Promise<MeshData | null> {
+  if (!hasIndexedDb()) return null;
+  try {
+    const db = await getDb();
+    const stored = (await db.get(BIN_MESHES_STORE, key)) as StoredMesh | undefined;
+    return stored?.mesh ?? null;
+  } catch (e) {
+    logger.warn('Failed to load persisted mesh', { error: String(e) });
+    return null;
+  }
+}
+
+/**
+ * Persist a preview mesh (fire-and-forget). Refreshes `createdAt` on repeats so
+ * the entry stays LRU-fresh, then evicts oldest entries over the byte budget.
+ * All failures are swallowed — persistence must never block generation.
+ */
+export function savePersistedBinMesh(key: string, mesh: MeshData): void {
+  if (!hasIndexedDb()) return;
+  void persistMesh(key, mesh);
+}
+
+/** Awaitable core of {@link savePersistedBinMesh}; resolves after eviction. */
+async function persistMesh(key: string, mesh: MeshData): Promise<void> {
+  try {
+    const db = await getDb();
+    const entry: StoredMesh = {
+      key,
+      mesh,
+      byteSize: meshByteSize(mesh),
+      createdAt: Date.now(),
+    };
+    await db.put(BIN_MESHES_STORE, entry);
+    await evictOverBudget(db);
+  } catch (e) {
+    logger.warn('Failed to persist mesh', { error: String(e) });
+  }
+}
+
+/**
+ * Evict oldest entries (by `createdAt`) until the total stored bytes fit the
+ * budget. Runs after each write; the entry set is small (hundreds) and writes
+ * are infrequent (once per settled edit), so the full cursor walk is cheap.
+ */
+async function evictOverBudget(db: IDBPDatabase): Promise<void> {
+  const tx = db.transaction(BIN_MESHES_STORE, 'readwrite');
+  const index = tx.store.index('byCreatedAt');
+
+  let total = 0;
+  const entries: { key: string; byteSize: number }[] = [];
+  for await (const cursor of index.iterate()) {
+    const value = cursor.value as StoredMesh;
+    total += value.byteSize;
+    entries.push({ key: value.key, byteSize: value.byteSize });
+  }
+
+  // entries are in ascending createdAt order (oldest first)
+  for (const entry of entries) {
+    if (total <= MAX_CACHE_BYTES) break;
+    await tx.store.delete(entry.key);
+    total -= entry.byteSize;
+  }
+
+  await tx.done;
+}
+
+/** Test-only: awaitable save (resolves after the write + eviction settle). */
+export function __savePersistedBinMeshForTests(key: string, mesh: MeshData): Promise<void> {
+  return persistMesh(key, mesh);
+}
+
+/** Test-only: close and drop the cached connection so the DB can be deleted. */
+export function __resetMeshDbForTests(): void {
+  if (dbInstance) dbInstance.close();
+  dbInstance = null;
+  openPromise = null;
+}

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -18,7 +18,7 @@
 
 import { openDB } from 'idb';
 import type { IDBPDatabase } from 'idb';
-import type { BinParams } from '@/features/bin-designer/types';
+import type { BinParams } from '@/shared/types/bin';
 import type { MeshData } from '@/shared/types/generation';
 import { createLogger } from '@/core/logger';
 
@@ -131,7 +131,7 @@ export function binMeshCacheKey(params: BinParams): string {
   return `${MESH_CACHE_VERSION}:${djb2(stableStringify(params))}`;
 }
 
-/** Sum the byte length of every typed array reachable from a mesh (incl. lid). */
+/** Sum the byte length of every typed array reachable from a mesh (incl. lid + connector). */
 function meshByteSize(mesh: MeshData): number {
   let bytes =
     mesh.vertices.byteLength +
@@ -147,6 +147,12 @@ function meshByteSize(mesh: MeshData): number {
       mesh.lidMesh.normals.byteLength +
       mesh.lidMesh.indices.byteLength +
       mesh.lidMesh.edgeVertices.byteLength;
+  }
+  if (mesh.connectorKeyMesh) {
+    bytes +=
+      mesh.connectorKeyMesh.vertices.byteLength +
+      mesh.connectorKeyMesh.normals.byteLength +
+      mesh.connectorKeyMesh.indices.byteLength;
   }
   return bytes;
 }

--- a/src/shared/types/generation.ts
+++ b/src/shared/types/generation.ts
@@ -6,6 +6,7 @@
  * depend on these types without a cross-feature import violation.
  */
 export type {
+  MeshData,
   FaceGroupData,
   CoarseLODData,
   LidMeshData,


### PR DESCRIPTION
## What & why

Reopening a saved custom bin in the bin-designer re-paid the full cold start **every time** — ~2–4 s to load the occt-wasm kernel plus ~1–2 s to run the generation pipeline — because every mesh/shape cache is in-memory only and vanishes on reload. Returning users stared at a skeleton for seconds before their design painted.

This persists the generated **preview mesh** to IndexedDB, keyed by a hash of the bin params, and paints it as an **instant pre-draft** on the next open while the worker warms up in the background.

## How

- **New** `src/shared/generation/meshPersistence.ts` — an `idb`-backed store (`gridfinity-mesh-cache`) that saves the preview `MeshData` under `${MESH_CACHE_VERSION}:${djb2(stableStringify(params))}`, with LRU-by-bytes eviction (64 MB). Follows the `eventStore.ts` connection conventions.
- **`useGeneration.ts`** — two touch-points:
  - **Read:** on mount, load the cached mesh in parallel with WASM init and paint it via `setDraftResult`. It reuses the existing draft-token arbitration (the same mechanism as the Manifold pre-draft), so the background exact result supersedes it cleanly. Only paints if nothing else has yet.
  - **Write:** fire-and-forget after each settled generation.

## Safety

- **Preview-only.** Exports always regenerate the watertight *fused* shell (`forExport=true`), so a cached preview mesh can never affect an exported model.
- **Self-healing.** Regeneration is kept, not short-circuited — the worker's exact result silently confirms/replaces the cached mesh, so a subtly-stale entry corrects itself on the next paint.
- **Versioned invalidation.** `MESH_CACHE_VERSION` folds in the brepjs/occt-wasm + tessellation identity; bumping it orphans old entries (reminder added to the geometry-generation skill's "Bump brepjs" recipe + generation README).

## Scope note

The layout *drawer* preview (`IsometricPreview` / `useBinGeometry.ts`) is pure Three.js with zero brepjs, so reopening a saved *layout* was already instant. This targets the bin-designer, where brepjs cold-start is actually paid. Baseplate persistence and hit/miss analytics are natural follow-ups on the same store.

## Tests

- `meshPersistence.test.ts` (fake-indexeddb): round-trips `MeshData` including `faceGroups`/`coarseLOD`/`lidMesh`, key stability + param/version sensitivity, LRU eviction, miss → null.
- `useGeneration.test.ts`: persists on generation complete; paints a persisted mesh as a pre-draft on cold mount.
- typecheck / lint / knip / module-boundaries clean; 250 touched-area tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted bin-designer preview meshes to IndexedDB and render them instantly on reopen to remove cold-start flicker. Adds a param-drift guard, Safari-safe persistence, and deterministic LRU-by-bytes eviction with a monotonic recency stamp.

- **New Features**
  - Added `src/shared/generation/meshPersistence.ts` using `idb` (`gridfinity-mesh-cache`) with versioned keys (`MESH_CACHE_VERSION`), 64 MB LRU-by-bytes eviction that counts all mesh buffers (incl. `connectorKeyMesh`), a separate metadata store for eviction, and a monotonic recency stamp.
  - `useGeneration`: loads a persisted mesh as a pre-draft on mount with a param-drift guard and saves the exact preview after each generation; token arbitration ensures the exact result supersedes the cache. Preview-only safety: exports always regenerate the fused shell; keys include `MESH_CACHE_VERSION` tied to `brepjs`/`occt-wasm`/tessellation changes.

- **Bug Fixes**
  - The persisted pre-draft now claims a generation token so the Manifold pre-draft cannot overwrite it; tests cover the interaction.
  - Made IndexedDB writes/eviction Safari-safe by avoiding awaits inside live transactions and planning eviction via a single `getAllFromIndex` read; renamed meta timestamp to `ts` to reflect recency.

<sup>Written for commit dc25d636ed78273b6a7191c1d6879733db5f609a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

