### PR TITLE
fix(bin-designer): accept solid style on design import (#2444)

### DIFF
--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -99,8 +99,11 @@ export function isScrewStyle(style: BaseStyle): boolean {
   return style === 'screw' || style === 'magnet_and_screw';
 }
 
+/** Bin wall/style variants — single source of truth for the `BinStyle` union. */
+export const BIN_STYLES = ['standard', 'slotted', 'solid'] as const;
+
 /** Bin wall/style variant */
-export type BinStyle = 'standard' | 'slotted' | 'solid';
+export type BinStyle = (typeof BIN_STYLES)[number];
 
 /** Slot configuration for one axis */
 export interface AxisSlotConfig {

--- a/src/features/bin-designer/utils/designJson.test.ts
+++ b/src/features/bin-designer/utils/designJson.test.ts
@@ -310,6 +310,9 @@ describe('validateImportedBinParams', () => {
     expect(validateImportedBinParams({ ...DEFAULT_BIN_PARAMS, style: 'slotted' }, t).valid).toBe(
       true
     );
+    expect(validateImportedBinParams({ ...DEFAULT_BIN_PARAMS, style: 'solid' }, t).valid).toBe(
+      true
+    );
   });
 
   it('should validate compartments structure', () => {

--- a/src/features/bin-designer/utils/designJson.test.ts
+++ b/src/features/bin-designer/utils/designJson.test.ts
@@ -300,7 +300,9 @@ describe('validateImportedBinParams', () => {
     const result = validateImportedBinParams({ ...DEFAULT_BIN_PARAMS, style: 'invalid' }, t);
 
     expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.includes('style'))).toBe(true);
+    // The error lists every valid style, including 'solid', so it can't drift
+    // from the accepted set (GH #2444).
+    expect(result.errors.some((e) => e.includes('style') && e.includes('solid'))).toBe(true);
   });
 
   it('should accept valid style values', () => {

--- a/src/features/bin-designer/utils/designJson.ts
+++ b/src/features/bin-designer/utils/designJson.ts
@@ -7,6 +7,7 @@
 
 import type { BinParams } from '../types';
 import type { TFunction } from '@/i18n';
+import { BIN_STYLES } from '../types';
 import { DESIGNER_CONSTRAINTS } from '../constants/gridfinity';
 import { migrateParams } from '../constants/defaults';
 import { sanitizeFileName } from './fileNaming';
@@ -253,7 +254,7 @@ export function validateImportedBinParams(params: unknown, t: TFunction): Valida
   }
 
   // Validate style
-  if (typeof p.style !== 'string' || !['standard', 'slotted'].includes(p.style)) {
+  if (typeof p.style !== 'string' || !(BIN_STYLES as readonly string[]).includes(p.style)) {
     errors.push(t('binDesigner.designJson.error.styleInvalid'));
   }
 

--- a/src/features/bin-designer/utils/designJson.ts
+++ b/src/features/bin-designer/utils/designJson.ts
@@ -255,7 +255,7 @@ export function validateImportedBinParams(params: unknown, t: TFunction): Valida
 
   // Validate style
   if (typeof p.style !== 'string' || !(BIN_STYLES as readonly string[]).includes(p.style)) {
-    errors.push(t('binDesigner.designJson.error.styleInvalid'));
+    errors.push(t('binDesigner.designJson.error.styleInvalid', { styles: BIN_STYLES.join(', ') }));
   }
 
   // Validate compartments config

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "Bitte eine JSON-Datei ablegen",
   "binDesigner.designJson.error.paramsNotObject": "params muss ein Objekt sein",
   "binDesigner.designJson.error.rootNotObject": "Ungültige Designdatei: Stamm muss ein Objekt sein",
-  "binDesigner.designJson.error.styleInvalid": "style muss einer von folgenden sein: standard, slotted",
+  "binDesigner.designJson.error.styleInvalid": "style muss einer von folgenden sein: {styles}",
   "binDesigner.designJson.error.widthInvalid": "width muss eine positive endliche Zahl sein",
   "binDesigner.designName": "Design-Name",
   "binDesigner.designs": "Designs",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2861,7 +2861,7 @@ const en: Record<string, string> = {
     'heightUnitMm must be a positive finite number',
   'binDesigner.designJson.error.baseNotObject': 'base must be an object',
   'binDesigner.designJson.error.baseStyleNotString': 'base.style must be a string',
-  'binDesigner.designJson.error.styleInvalid': 'style must be one of: standard, slotted',
+  'binDesigner.designJson.error.styleInvalid': 'style must be one of: {styles}',
   'binDesigner.designJson.error.compartmentsNotObject': 'compartments must be an object',
   'binDesigner.designJson.error.compartmentsCellsNotArray': 'compartments.cells must be an array',
   'binDesigner.designJson.error.compartmentsColsRange':

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "Suelta un archivo JSON",
   "binDesigner.designJson.error.paramsNotObject": "params debe ser un objeto",
   "binDesigner.designJson.error.rootNotObject": "Archivo de diseño no válido: la raíz debe ser un objeto",
-  "binDesigner.designJson.error.styleInvalid": "style debe ser uno de: standard, slotted",
+  "binDesigner.designJson.error.styleInvalid": "style debe ser uno de: {styles}",
   "binDesigner.designJson.error.widthInvalid": "width debe ser un número finito positivo",
   "binDesigner.designName": "Nombre del diseño",
   "binDesigner.designs": "Diseños",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "Déposez un fichier JSON",
   "binDesigner.designJson.error.paramsNotObject": "params doit être un objet",
   "binDesigner.designJson.error.rootNotObject": "Fichier de design non valide : la racine doit être un objet",
-  "binDesigner.designJson.error.styleInvalid": "style doit être : standard ou slotted",
+  "binDesigner.designJson.error.styleInvalid": "style doit être l'un de : {styles}",
   "binDesigner.designJson.error.widthInvalid": "width doit être un nombre fini positif",
   "binDesigner.designName": "Nom du design",
   "binDesigner.designs": "Designs",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "JSONファイルをドロップしてください",
   "binDesigner.designJson.error.paramsNotObject": "paramsはオブジェクトである必要があります",
   "binDesigner.designJson.error.rootNotObject": "無効なデザインファイル：ルートはオブジェクトである必要があります",
-  "binDesigner.designJson.error.styleInvalid": "styleはstandardまたはslottedのいずれかである必要があります",
+  "binDesigner.designJson.error.styleInvalid": "styleは次のいずれかである必要があります: {styles}",
   "binDesigner.designJson.error.widthInvalid": "widthは正の有限数である必要があります",
   "binDesigner.designName": "デザイン名",
   "binDesigner.designs": "デザイン",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "Slipp en JSON-fil",
   "binDesigner.designJson.error.paramsNotObject": "params må være et objekt",
   "binDesigner.designJson.error.rootNotObject": "Ugyldig designfil: rot må være et objekt",
-  "binDesigner.designJson.error.styleInvalid": "style må være en av: standard, slotted",
+  "binDesigner.designJson.error.styleInvalid": "style må være en av: {styles}",
   "binDesigner.designJson.error.widthInvalid": "width må være et positivt endelig tall",
   "binDesigner.designName": "Designnavn",
   "binDesigner.designs": "Design",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "Sleep een JSON-bestand",
   "binDesigner.designJson.error.paramsNotObject": "params moet een object zijn",
   "binDesigner.designJson.error.rootNotObject": "Ongeldig ontwerpbestand: root moet een object zijn",
-  "binDesigner.designJson.error.styleInvalid": "style moet een van zijn: standard, slotted",
+  "binDesigner.designJson.error.styleInvalid": "style moet een van zijn: {styles}",
   "binDesigner.designJson.error.widthInvalid": "width moet een positief eindig getal zijn",
   "binDesigner.designName": "Design naam",
   "binDesigner.designs": "Ontwerpen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "Solte um arquivo JSON",
   "binDesigner.designJson.error.paramsNotObject": "params deve ser um objeto",
   "binDesigner.designJson.error.rootNotObject": "Arquivo de design inválido: a raiz deve ser um objeto",
-  "binDesigner.designJson.error.styleInvalid": "style deve ser um de: standard, slotted",
+  "binDesigner.designJson.error.styleInvalid": "style deve ser um de: {styles}",
   "binDesigner.designJson.error.widthInvalid": "width deve ser um número finito positivo",
   "binDesigner.designName": "Nome do design",
   "binDesigner.designs": "Designs",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "Släpp en JSON-fil",
   "binDesigner.designJson.error.paramsNotObject": "params måste vara ett objekt",
   "binDesigner.designJson.error.rootNotObject": "Ogiltig designfil: rot måste vara ett objekt",
-  "binDesigner.designJson.error.styleInvalid": "style måste vara: standard eller slotted",
+  "binDesigner.designJson.error.styleInvalid": "style måste vara en av: {styles}",
   "binDesigner.designJson.error.widthInvalid": "width måste vara ett positivt ändligt tal",
   "binDesigner.designName": "Designnamn",
   "binDesigner.designs": "Designer",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -549,7 +549,7 @@
   "binDesigner.designJson.error.mustBeJsonFile": "Перетягніть файл JSON",
   "binDesigner.designJson.error.paramsNotObject": "params має бути об’єктом",
   "binDesigner.designJson.error.rootNotObject": "Недійсний файл дизайну: корінь має бути об’єктом",
-  "binDesigner.designJson.error.styleInvalid": "style має бути одним з: standard, slotted",
+  "binDesigner.designJson.error.styleInvalid": "style має бути одним з: {styles}",
   "binDesigner.designJson.error.widthInvalid": "width має бути додатним скінченним числом",
   "binDesigner.designName": "Назва дизайну",
   "binDesigner.designs": "Дизайни",


### PR DESCRIPTION
Fixes #2444.

## Problem

Importing a design JSON exported from the tool fails with a validation error whenever the bin is **solid**. The importer validated `params.style` against `['standard', 'slotted']`, but `BinStyle` is `'standard' | 'slotted' | 'solid'` and the exporter writes `"style": "solid"` for solid bins. So the tool rejected designs it had itself exported (the reporter's "6GT Sizing Die").

## Fix

- Introduce a single `BIN_STYLES` const tuple and derive `BinStyle` from it.
- Validate imported `style` against `BIN_STYLES` instead of a hard-coded subset, so the exported union and the import allow-list can't drift apart again.

## Tests

- Added `'solid'` to the "accepts valid style values" case in `designJson.test.ts` (the gap that let this ship).
- Verified the reporter's exact payload now imports with zero errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow importing solid-style bins by validating the style against a single source of truth, fixing rejected re-imports of designs the app exported. Fixes #2444.

- **Bug Fixes**
  - Added `BIN_STYLES` and derived `BinStyle` from it; validator checks `style` against it (includes `'solid'`), and the error message now lists valid styles from `BIN_STYLES`.
  - Extended tests to cover `'solid'` and assert the error lists `'solid'`; verified the reported payload imports without errors.

<sup>Written for commit 1cc3736941b55a2d759165262ff7433087b379a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

