### PR TITLE
fix(generation): bump brepjs to 18.118.3 for overlapping-cutout color (#2443)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.4.1",
     "arctic": "^3.7.0",
-    "brepjs": "18.116.1",
+    "brepjs": "18.118.3",
     "brepkit-wasm": "^2.119.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       brepjs:
-        specifier: 18.116.1
-        version: 18.116.1(brepkit-wasm@2.119.2)(occt-wasm@3.6.0)
+        specifier: 18.118.3
+        version: 18.118.3(brepkit-wasm@2.119.2)(occt-wasm@3.6.0)
       brepkit-wasm:
         specifier: ^2.119.2
         version: 2.119.2
@@ -3062,8 +3062,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  brepjs@18.116.1:
-    resolution: {integrity: sha512-DIfNrO8XST9X9IpaMrsCwkASh+39hE80Qpg8fRsIAKp2cDRK9KU+Xx6i013bly6MGVkGDWan9lIqZOMgJ+fesA==}
+  brepjs@18.118.3:
+    resolution: {integrity: sha512-qBQGaaqdK+jx7+W1DKUvKK48HcFdIf23H+siQLLRZsj8u2akhtR+WeAYG1aF2GPw2aWJ8fZMeSqub/vKKq6uBg==}
     engines: {node: '>=24'}
     peerDependencies:
       brepjs-manifold: ^0.1.0
@@ -8558,7 +8558,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.116.1(brepkit-wasm@2.119.2)(occt-wasm@3.6.0):
+  brepjs@18.118.3(brepkit-wasm@2.119.2)(occt-wasm@3.6.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4

--- a/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
@@ -271,3 +271,41 @@ export function assertValidSplit(
     expect(pieceD, `${label}: piece ${piece.label} zero depth`).toBeGreaterThan(1);
   }
 }
+
+// ─── Per-triangle geometry ───────────────────────────────────────────────────
+
+/**
+ * Normalized z-component of triangle (a, b, c)'s geometric normal, from a flat
+ * vertex buffer indexed by vertex number. Floor faces read ≈±1, walls ≈0.
+ */
+export function triangleNormalZ(
+  vertices: ArrayLike<number>,
+  a: number,
+  b: number,
+  c: number
+): number {
+  const ux = vertices[b * 3] - vertices[a * 3];
+  const uy = vertices[b * 3 + 1] - vertices[a * 3 + 1];
+  const uz = vertices[b * 3 + 2] - vertices[a * 3 + 2];
+  const vx = vertices[c * 3] - vertices[a * 3];
+  const vy = vertices[c * 3 + 1] - vertices[a * 3 + 1];
+  const vz = vertices[c * 3 + 2] - vertices[a * 3 + 2];
+  const nx = uy * vz - uz * vy;
+  const ny = uz * vx - ux * vz;
+  const nz = ux * vy - uy * vx;
+  return nz / (Math.hypot(nx, ny, nz) || 1);
+}
+
+/** Area of triangle (a, b, c), from a flat vertex buffer indexed by vertex number. */
+export function triangleArea(vertices: ArrayLike<number>, a: number, b: number, c: number): number {
+  const ux = vertices[b * 3] - vertices[a * 3];
+  const uy = vertices[b * 3 + 1] - vertices[a * 3 + 1];
+  const uz = vertices[b * 3 + 2] - vertices[a * 3 + 2];
+  const vx = vertices[c * 3] - vertices[a * 3];
+  const vy = vertices[c * 3 + 1] - vertices[a * 3 + 1];
+  const vz = vertices[c * 3 + 2] - vertices[a * 3 + 2];
+  const nx = uy * vz - uz * vy;
+  const ny = uz * vx - ux * vz;
+  const nz = ux * vy - uy * vx;
+  return Math.hypot(nx, ny, nz) / 2;
+}

--- a/src/features/generation/worker/generators/binGenerator.scenario.cutoutColorTag.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.cutoutColorTag.test.ts
@@ -19,6 +19,7 @@
 import { describe, it, beforeAll, expect } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import { makeCutout } from './__kernel-tests__/scenarioTypes';
+import { triangleNormalZ } from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
 import {
   enumerateCutoutColorUnits,
@@ -30,21 +31,6 @@ import type { BinParams, Cutout } from '@/shared/types/bin';
 beforeAll(async () => {
   await initBrepjs();
 }, 30_000);
-
-/** Normalized z-component of a triangle's geometric normal (floor≈±1, wall≈0). */
-function triNz(verts: ArrayLike<number>, a: number, b: number, c: number): number {
-  const ux = verts[b * 3] - verts[a * 3];
-  const uy = verts[b * 3 + 1] - verts[a * 3 + 1];
-  const uz = verts[b * 3 + 2] - verts[a * 3 + 2];
-  const vx = verts[c * 3] - verts[a * 3];
-  const vy = verts[c * 3 + 1] - verts[a * 3 + 1];
-  const vz = verts[c * 3 + 2] - verts[a * 3 + 2];
-  const nx = uy * vz - uz * vy;
-  const ny = uz * vx - ux * vz;
-  const nz = ux * vy - uy * vx;
-  const len = Math.hypot(nx, ny, nz) || 1;
-  return nz / len;
-}
 
 interface TagCensus {
   readonly cutoutTags: Map<number, { floor: number; wall: number }>;
@@ -65,7 +51,7 @@ function census(params: BinParams): TagCensus {
       const a = idx[fg.start + t * 3];
       const b = idx[fg.start + t * 3 + 1];
       const c = idx[fg.start + t * 3 + 2];
-      const nz = Math.abs(triNz(verts, a, b, c));
+      const nz = Math.abs(triangleNormalZ(verts, a, b, c));
       const bucket = cutoutTags.get(ordinal) ?? { floor: 0, wall: 0 };
       if (nz > 0.8) bucket.floor++;
       else if (nz < 0.35) bucket.wall++;

--- a/src/features/generation/worker/generators/binGenerator.scenario.overlappingCutoutColor.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.overlappingCutoutColor.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+/**
+ * GH #2443 — overlapping shadow-board cutouts must keep their floor color.
+ *
+ * The reporter's "6GT Sizing Die": three ungrouped, same-color cutouts of
+ * different depths, two overlapping. A deep cutout overlapping a wide one used
+ * to strip the wide cutout's floor of its color tag (the boolean split it into
+ * pieces the kernel's origin fallback couldn't match), so that floor rendered
+ * in the body color. Fixed in brepjs 18.118.3's coplanar origin matching.
+ *
+ * Invariant: every up-facing face at a cutout's floor depth carries that
+ * cutout's color tag — no untagged (body-colored) floor at those depths.
+ */
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { makeCutout } from './__kernel-tests__/scenarioTypes';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { cutoutOrdinalFromTag } from '@/shared/generation/cutoutColorUnits';
+import type { BinParams, Cutout } from '@/shared/types/bin';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+function triNz(v: ArrayLike<number>, a: number, b: number, c: number): number {
+  const ux = v[b * 3] - v[a * 3];
+  const uy = v[b * 3 + 1] - v[a * 3 + 1];
+  const uz = v[b * 3 + 2] - v[a * 3 + 2];
+  const vx = v[c * 3] - v[a * 3];
+  const vy = v[c * 3 + 1] - v[a * 3 + 1];
+  const vz = v[c * 3 + 2] - v[a * 3 + 2];
+  const nx = uy * vz - uz * vy;
+  const ny = uz * vx - ux * vz;
+  const nz = ux * vy - uy * vx;
+  return nz / (Math.hypot(nx, ny, nz) || 1);
+}
+
+function triArea(v: ArrayLike<number>, a: number, b: number, c: number): number {
+  const ux = v[b * 3] - v[a * 3];
+  const uy = v[b * 3 + 1] - v[a * 3 + 1];
+  const uz = v[b * 3 + 2] - v[a * 3 + 2];
+  const vx = v[c * 3] - v[a * 3];
+  const vy = v[c * 3 + 1] - v[a * 3 + 1];
+  const vz = v[c * 3 + 2] - v[a * 3 + 2];
+  const nx = uy * vz - uz * vy;
+  const ny = uz * vx - ux * vz;
+  const nz = ux * vy - uy * vx;
+  return Math.hypot(nx, ny, nz) / 2;
+}
+
+const base: BinParams = {
+  ...DEFAULT_BIN_PARAMS,
+  width: 1,
+  depth: 3,
+  height: 4,
+  style: 'solid',
+  base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+  cutoutConfig: { topOffset: 0 },
+};
+
+const RED = '#ef4444';
+
+describe('GH #2443 overlapping cutout floor color', () => {
+  it('leaves no untagged floor at any cutout depth', () => {
+    const cutouts: Cutout[] = [
+      makeCutout({
+        id: '0a8fe52b-4737-492f-bf3c-207dd86255bc',
+        x: 6.775,
+        y: 45.375,
+        width: 25.55,
+        depth: 59.35,
+        cutDepth: 17.53,
+        color: RED,
+        colorScope: 'floorAndWalls',
+      }),
+      makeCutout({
+        id: '3fcc5493-e07c-46e7-a0fe-d0794ae90220',
+        x: 1.825,
+        y: 37.3,
+        width: 35.5,
+        depth: 8.6,
+        cutDepth: 21.15,
+        color: RED,
+        colorScope: 'floorAndWalls',
+      }),
+      makeCutout({
+        id: '07e7b910-9925-41e4-bfaf-a1036663b66c',
+        x: 6.775,
+        y: 6.3,
+        width: 25.55,
+        depth: 31,
+        cutDepth: 15.53,
+        color: RED,
+        colorScope: 'floorAndWalls',
+      }),
+    ];
+    // Floor plane z per cutout: solidSurfaceZ (28) − cutDepth.
+    const floorZs = cutouts.map((c) => 28 - c.cutDepth);
+
+    const m = getGenerateBin()({ ...base, cutouts });
+    const verts = m.vertices;
+    const idx = m.indices;
+    const fgs = m.faceGroups ?? [];
+    expect(verts.length).toBeGreaterThan(0);
+
+    let taggedFloorArea = 0;
+    let untaggedFloorArea = 0;
+    for (const fg of fgs) {
+      const tagged = cutoutOrdinalFromTag(fg.tag) !== null;
+      for (let t = 0; t < fg.count / 3; t++) {
+        const a = idx[fg.start + t * 3];
+        const b = idx[fg.start + t * 3 + 1];
+        const c = idx[fg.start + t * 3 + 2];
+        if (triNz(verts, a, b, c) <= 0.8) continue; // up-facing only
+        const cz = (verts[a * 3 + 2] + verts[b * 3 + 2] + verts[c * 3 + 2]) / 3;
+        // Restrict to the cutout floor planes (avoid the bin's own surfaces).
+        if (!floorZs.some((z) => Math.abs(cz - z) < 0.3)) continue;
+        const area = triArea(verts, a, b, c);
+        if (tagged) taggedFloorArea += area;
+        else untaggedFloorArea += area;
+      }
+    }
+
+    expect(taggedFloorArea).toBeGreaterThan(0);
+    // Before the brepjs fix, cutout A's ~1500 mm² floor was untagged. Allow a
+    // sliver for meshing noise; a real regression reintroduces hundreds of mm².
+    expect(untaggedFloorArea).toBeLessThan(5);
+  });
+});

--- a/src/features/generation/worker/generators/binGenerator.scenario.overlappingCutoutColor.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.overlappingCutoutColor.test.ts
@@ -8,12 +8,14 @@
  * pieces the kernel's origin fallback couldn't match), so that floor rendered
  * in the body color. Fixed in brepjs 18.118.3's coplanar origin matching.
  *
- * Invariant: every up-facing face at a cutout's floor depth carries that
- * cutout's color tag — no untagged (body-colored) floor at those depths.
+ * Invariants at each cutout's floor depth: (1) no untagged (body-colored)
+ * up-facing floor remains, and (2) each cutout contributes floor area under its
+ * own color ordinal — so no cutout loses its floor tag.
  */
 import { describe, it, beforeAll, expect } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import { makeCutout } from './__kernel-tests__/scenarioTypes';
+import { triangleNormalZ, triangleArea } from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
 import { cutoutOrdinalFromTag } from '@/shared/generation/cutoutColorUnits';
 import type { BinParams, Cutout } from '@/shared/types/bin';
@@ -21,32 +23,6 @@ import type { BinParams, Cutout } from '@/shared/types/bin';
 beforeAll(async () => {
   await initBrepjs();
 }, 30_000);
-
-function triNz(v: ArrayLike<number>, a: number, b: number, c: number): number {
-  const ux = v[b * 3] - v[a * 3];
-  const uy = v[b * 3 + 1] - v[a * 3 + 1];
-  const uz = v[b * 3 + 2] - v[a * 3 + 2];
-  const vx = v[c * 3] - v[a * 3];
-  const vy = v[c * 3 + 1] - v[a * 3 + 1];
-  const vz = v[c * 3 + 2] - v[a * 3 + 2];
-  const nx = uy * vz - uz * vy;
-  const ny = uz * vx - ux * vz;
-  const nz = ux * vy - uy * vx;
-  return nz / (Math.hypot(nx, ny, nz) || 1);
-}
-
-function triArea(v: ArrayLike<number>, a: number, b: number, c: number): number {
-  const ux = v[b * 3] - v[a * 3];
-  const uy = v[b * 3 + 1] - v[a * 3 + 1];
-  const uz = v[b * 3 + 2] - v[a * 3 + 2];
-  const vx = v[c * 3] - v[a * 3];
-  const vy = v[c * 3 + 1] - v[a * 3 + 1];
-  const vz = v[c * 3 + 2] - v[a * 3 + 2];
-  const nx = uy * vz - uz * vy;
-  const ny = uz * vx - ux * vz;
-  const nz = ux * vy - uy * vx;
-  return Math.hypot(nx, ny, nz) / 2;
-}
 
 const base: BinParams = {
   ...DEFAULT_BIN_PARAMS,
@@ -61,7 +37,7 @@ const base: BinParams = {
 const RED = '#ef4444';
 
 describe('GH #2443 overlapping cutout floor color', () => {
-  it('leaves no untagged floor at any cutout depth', () => {
+  it('keeps every cutout floor tagged, with none reverting to body color', () => {
     const cutouts: Cutout[] = [
       makeCutout({
         id: '0a8fe52b-4737-492f-bf3c-207dd86255bc',
@@ -94,8 +70,10 @@ describe('GH #2443 overlapping cutout floor color', () => {
         colorScope: 'floorAndWalls',
       }),
     ];
-    // Floor plane z per cutout: solidSurfaceZ (28) − cutDepth.
-    const floorZs = cutouts.map((c) => 28 - c.cutDepth);
+    // The solid fill surface a cutout is sunk into (cutoutBuilder.ts): wall
+    // height minus the global top offset. Each cutout floor sits cutDepth below.
+    const solidSurfaceZ = base.height * base.heightUnitMm - base.cutoutConfig.topOffset;
+    const floorZs = cutouts.map((c) => solidSurfaceZ - c.cutDepth);
 
     const m = getGenerateBin()({ ...base, cutouts });
     const verts = m.vertices;
@@ -103,26 +81,35 @@ describe('GH #2443 overlapping cutout floor color', () => {
     const fgs = m.faceGroups ?? [];
     expect(verts.length).toBeGreaterThan(0);
 
-    let taggedFloorArea = 0;
+    // Floor area per cutout ordinal, plus any up-facing floor with no cutout tag.
+    const taggedFloorByOrdinal = new Map<number, number>();
     let untaggedFloorArea = 0;
     for (const fg of fgs) {
-      const tagged = cutoutOrdinalFromTag(fg.tag) !== null;
+      const ordinal = cutoutOrdinalFromTag(fg.tag);
       for (let t = 0; t < fg.count / 3; t++) {
         const a = idx[fg.start + t * 3];
         const b = idx[fg.start + t * 3 + 1];
         const c = idx[fg.start + t * 3 + 2];
-        if (triNz(verts, a, b, c) <= 0.8) continue; // up-facing only
+        if (triangleNormalZ(verts, a, b, c) <= 0.8) continue; // up-facing only
         const cz = (verts[a * 3 + 2] + verts[b * 3 + 2] + verts[c * 3 + 2]) / 3;
         // Restrict to the cutout floor planes (avoid the bin's own surfaces).
         if (!floorZs.some((z) => Math.abs(cz - z) < 0.3)) continue;
-        const area = triArea(verts, a, b, c);
-        if (tagged) taggedFloorArea += area;
-        else untaggedFloorArea += area;
+        const area = triangleArea(verts, a, b, c);
+        if (ordinal === null) {
+          untaggedFloorArea += area;
+        } else {
+          taggedFloorByOrdinal.set(ordinal, (taggedFloorByOrdinal.get(ordinal) ?? 0) + area);
+        }
       }
     }
 
-    expect(taggedFloorArea).toBeGreaterThan(0);
-    // Before the brepjs fix, cutout A's ~1500 mm² floor was untagged. Allow a
+    // Every cutout (ordinals 0..2) keeps a tagged floor.
+    for (let ord = 0; ord < cutouts.length; ord++) {
+      expect(taggedFloorByOrdinal.get(ord) ?? 0, `cutout ${ord} tagged floor area`).toBeGreaterThan(
+        0
+      );
+    }
+    // Before the brepjs fix, cutout 0's ~1500 mm² floor was untagged. Allow a
     // sliver for meshing noise; a real regression reintroduces hundreds of mm².
     expect(untaggedFloorArea).toBeLessThan(5);
   });


### PR DESCRIPTION
Closes #2443.

## Problem

On the reporter's "6GT Sizing Die" — three ungrouped, same-color shadow-board cutouts of different depths, two overlapping — one cutout's floor rendered in the body color instead of the selected cutout color.

## Root cause (brepjs)

Not in the color logic. When a deep cutout overlaps a wide one, the boolean splits the wide cutout's floor into pieces whose centroids drift past brepjs's origin-matching cutoff, and a cut flips the cavity floor's normal versus its tool face — so the geometric origin fallback couldn't re-tag those pieces and they fell back to body color. Fixed in **brepjs 18.118.3** ([andymai/brepjs#1740](https://github.com/andymai/brepjs/pull/1740)) via a coplanar, orientation-agnostic, planar-gated match path.

## This PR

- Bump `brepjs` 18.116.1 → **18.118.3**.
- Add a scenario test over the exact three-cutout design asserting **no untagged floor** remains at any cutout depth (was ~1500 mm² untagged before the fix; now < 5 mm²).

## Verification

- New regression test passes against the published 18.118.3.
- Full generator scenario suite: **1768 passed / 7 skipped** — no geometry regressions from the version bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlapping cutout floor color by bumping `brepjs` to 18.118.3. Overlapping cutouts now keep their own floor color; fixes #2443.

- **Bug Fixes**
  - Hardened scenario test for the reporter’s three-cutout design: asserts no untagged (body-colored) floor at any cutout depth (<5 mm²) and that each cutout keeps its own floor tag; extracted shared `triangleNormalZ`/`triangleArea` helpers and derived floor planes from base params.

- **Dependencies**
  - Update `brepjs` from 18.116.1 to 18.118.3, which improves coplanar, orientation-agnostic origin matching for split floor pieces.

<sup>Written for commit 1a86009aeb7ffa1cd301fe0091068ce64cc8abf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

