### PR TITLE
fix(bin-designer): make the Custom Cutouts editor overhang-aware

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -16,7 +16,7 @@
 import { useCallback, useState, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
+import { binDimensions, cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
 import { useCutoutInteraction } from '../panel/CutoutsSection/useCutoutInteraction';
 import {
   getOffBoardCutoutIds,
@@ -85,7 +85,12 @@ export function CutoutWorkspace() {
   );
 
   const { cutouts } = params;
-  const { innerW: binWidth, innerD: binDepth, wallHeight } = binDimensions(params);
+  // Cutouts live on the interior floor, which grows outward with overhang — use
+  // the overhang-expanded interior so cutouts can be placed/centered over that
+  // extra floor and land where the generator puts them (#2462). wallHeight is
+  // unaffected (overhang is outward-only).
+  const { wallHeight } = binDimensions(params);
+  const { innerW: binWidth, innerD: binDepth } = cutoutInterior(params);
   // See CutoutEditor for rationale — separate X/Y cell sizes keep validator and
   // polygon rendering aligned for non-square bins. Memoized so the off-board
   // hooks below keep a stable dependency across renders.

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
@@ -8,7 +8,7 @@
 import { useCallback, useState, useRef, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
+import { binDimensions, cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
 import { centerInBin, flipSelectionHorizontal, flipSelectionVertical } from './geometry';
 import { useCutoutInteraction } from './useCutoutInteraction';
 import { useTranslation } from '@/i18n';
@@ -77,7 +77,9 @@ export function CutoutEditor() {
   );
 
   const { cutouts } = params;
-  const { innerW: binWidth, innerD: binDepth, wallHeight } = binDimensions(params);
+  // Overhang-expanded interior lets cutouts use the extra floor (#2462).
+  const { wallHeight } = binDimensions(params);
+  const { innerW: binWidth, innerD: binDepth } = cutoutInterior(params);
   // Mm-per-mask-cell in the editor's interior coordinate system. X and Y differ
   // on non-square bins because the interior is shrunk by wall + tolerance (an
   // absolute mm amount) independently on each axis. Keeping validator and

--- a/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
@@ -20,6 +20,7 @@ import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeome
 import { useDesignerStore, useCutoutSelection } from '@/features/bin-designer/store';
 import { useLineMaterialResolution } from '../useLineMaterialResolution';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
+import { expandInteriorForOverhang } from '@/features/bin-designer/utils/binDimensions';
 import type { Cutout } from '@/features/bin-designer/types';
 import {
   flattenPath,
@@ -159,11 +160,14 @@ export function GhostCutouts() {
     width,
     depth,
     height,
-    gridUnitMm, gridUnitMmY,
+    gridUnitMm,
+    gridUnitMmY,
     heightUnitMm,
     wallThickness,
     cutouts,
     base,
+    overhang,
+    cellMask,
     generationStatus,
   } = useDesignerStore(
     useShallow((s) => ({
@@ -176,6 +180,8 @@ export function GhostCutouts() {
       wallThickness: s.params.wallThickness,
       cutouts: s.params.cutouts,
       base: s.params.base,
+      overhang: s.params.overhang,
+      cellMask: s.params.cellMask,
       generationStatus: s.generation.status,
     }))
   );
@@ -191,10 +197,17 @@ export function GhostCutouts() {
 
   const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
   const outerD = depth * (gridUnitMmY ?? gridUnitMm) - GRIDFINITY.TOLERANCE;
-  const innerW = outerW - 2 * wallThickness;
-  const innerD = outerD - 2 * wallThickness;
-  const originX = -innerW / 2;
-  const originY = -innerD / 2;
+  // Overhang grows the interior floor outward and, when asymmetric, shifts it
+  // within the body — match the generator so the ghost sits where the final
+  // cut lands (#2462).
+  const { innerW, innerD, offsetX, offsetY } = expandInteriorForOverhang(
+    outerW - 2 * wallThickness,
+    outerD - 2 * wallThickness,
+    overhang,
+    cellMask
+  );
+  const originX = -innerW / 2 + offsetX;
+  const originY = -innerD / 2 + offsetY;
 
   const hasSelection = selectedIds.size > 0;
   const isGenerating = generationStatus === 'generating';

--- a/src/features/bin-designer/utils/binDimensions.test.ts
+++ b/src/features/bin-designer/utils/binDimensions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { binDimensions } from './binDimensions';
+import { binDimensions, cutoutInterior } from './binDimensions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 
@@ -95,5 +95,69 @@ describe('binDimensions', () => {
     expect(dims.totalH).toBeCloseTo(32, 5);
     // wallHeight = 32 − 5 = 27 (socketed)
     expect(dims.wallHeight).toBeCloseTo(27, 5);
+  });
+});
+
+describe('cutoutInterior', () => {
+  // Default 2×2 bin: nominal innerW/innerD = 81.1.
+  const NOMINAL = 81.1;
+
+  it('returns the nominal interior when overhang is absent or all-zero', () => {
+    const ci = cutoutInterior(DEFAULT_BIN_PARAMS);
+    expect(ci.innerW).toBeCloseTo(NOMINAL, 5);
+    expect(ci.innerD).toBeCloseTo(NOMINAL, 5);
+    expect(ci.offsetX).toBe(0);
+    expect(ci.offsetY).toBe(0);
+  });
+
+  it('expands the interior by the summed per-side overhang (symmetric → no offset)', () => {
+    const ci = cutoutInterior({
+      ...DEFAULT_BIN_PARAMS,
+      overhang: { left: 3, right: 3, front: 2, back: 2 },
+    });
+    expect(ci.innerW).toBeCloseTo(NOMINAL + 6, 5);
+    expect(ci.innerD).toBeCloseTo(NOMINAL + 4, 5);
+    expect(ci.offsetX).toBeCloseTo(0, 5);
+    expect(ci.offsetY).toBeCloseTo(0, 5);
+  });
+
+  it('shifts the cavity center for asymmetric overhang', () => {
+    const ci = cutoutInterior({
+      ...DEFAULT_BIN_PARAMS,
+      overhang: { left: 0, right: 8, front: 4, back: 0 },
+    });
+    expect(ci.innerW).toBeCloseTo(NOMINAL + 8, 5);
+    expect(ci.innerD).toBeCloseTo(NOMINAL + 4, 5);
+    // offsetX = (right − left) / 2, offsetY = (back − front) / 2
+    expect(ci.offsetX).toBeCloseTo(4, 5);
+    expect(ci.offsetY).toBeCloseTo(-2, 5);
+  });
+
+  it('ignores overhang when explicitly disabled', () => {
+    const ci = cutoutInterior({
+      ...DEFAULT_BIN_PARAMS,
+      overhang: { enabled: false, left: 5, right: 5, front: 0, back: 0 },
+    });
+    expect(ci.innerW).toBeCloseTo(NOMINAL, 5);
+    expect(ci.offsetX).toBe(0);
+  });
+
+  it('clamps negative sides to zero', () => {
+    const ci = cutoutInterior({
+      ...DEFAULT_BIN_PARAMS,
+      overhang: { left: -5, right: 4, front: 0, back: 0 },
+    });
+    expect(ci.innerW).toBeCloseTo(NOMINAL + 4, 5);
+    expect(ci.offsetX).toBeCloseTo(2, 5);
+  });
+
+  it('suppresses overhang for polygon masks (the mask defines the footprint)', () => {
+    const ci = cutoutInterior({
+      ...DEFAULT_BIN_PARAMS,
+      overhang: { left: 5, right: 5, front: 0, back: 0 },
+      cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 0] },
+    });
+    expect(ci.innerW).toBeCloseTo(NOMINAL, 5);
+    expect(ci.innerD).toBeCloseTo(NOMINAL, 5);
   });
 });

--- a/src/features/bin-designer/utils/binDimensions.test.ts
+++ b/src/features/bin-designer/utils/binDimensions.test.ts
@@ -99,8 +99,9 @@ describe('binDimensions', () => {
 });
 
 describe('cutoutInterior', () => {
-  // Default 2×2 bin: nominal innerW/innerD = 81.1.
-  const NOMINAL = 81.1;
+  // Nominal interior of the default bin, derived (not hard-coded) so the tests
+  // track any change to the default grid pitch / wall thickness / tolerance.
+  const NOMINAL = binDimensions(DEFAULT_BIN_PARAMS).innerW;
 
   it('returns the nominal interior when overhang is absent or all-zero', () => {
     const ci = cutoutInterior(DEFAULT_BIN_PARAMS);

--- a/src/features/bin-designer/utils/binDimensions.ts
+++ b/src/features/bin-designer/utils/binDimensions.ts
@@ -93,10 +93,10 @@ export interface CutoutInterior {
  * bottom-left corner, exactly as the generator places them).
  *
  * Mirrors the generator's derivation in
- * `generation/worker/generators/pipeline/context.ts`: overhang is suppressed
- * for polygon masks (the mask defines its own footprint), negative/omitted
- * sides clamp to zero, and the asymmetry offset is `(right − left) / 2` /
- * `(back − front) / 2`.
+ * `generation/worker/generators/pipeline/context.ts`: an absent or disabled
+ * overhang leaves the interior nominal, overhang is suppressed for polygon
+ * masks (the mask defines its own footprint), negative side values clamp to
+ * zero, and the asymmetry offset is `(right − left) / 2` / `(back − front) / 2`.
  */
 export function cutoutInterior(params: BinParams): CutoutInterior {
   const { innerW, innerD } = binDimensions(params);

--- a/src/features/bin-designer/utils/binDimensions.ts
+++ b/src/features/bin-designer/utils/binDimensions.ts
@@ -14,7 +14,9 @@
  */
 
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
-import type { BinParams } from '@/features/bin-designer/types';
+import type { BinParams, OverhangConfig } from '@/features/bin-designer/types';
+import { isPartialMask } from '@/shared/utils/cellMask';
+import type { CellMask } from '@/shared/utils/cellMask';
 
 export interface BinDimensions {
   /** Outer bin width in mm (XY footprint, includes tolerance) */
@@ -63,4 +65,67 @@ export function binDimensions(params: BinParams): BinDimensions {
   const wallHeight = isFlat ? totalH : totalH - GRIDFINITY.SOCKET_HEIGHT;
   const floorZ = isFlat ? 0 : GRIDFINITY.SOCKET_HEIGHT;
   return { outerW, outerD, innerW, innerD, totalH, wallHeight, floorZ, isFlat };
+}
+
+export interface CutoutInterior {
+  /** Interior cavity width in mm, overhang folded in. */
+  readonly innerW: number;
+  /** Interior cavity depth in mm, overhang folded in. */
+  readonly innerD: number;
+  /**
+   * X shift (mm, +X) of the expanded cavity center inside the outer body when
+   * opposite overhang sides differ. Zero for symmetric/absent overhang. Only
+   * model-space consumers (the 3D ghost) need it; the flat 2D cutout editor
+   * works in the offset-free `[0, innerW]` in-cavity frame.
+   */
+  readonly offsetX: number;
+  /** Y shift (mm, +Y) of the expanded cavity center. See {@link offsetX}. */
+  readonly offsetY: number;
+}
+
+/**
+ * Interior cavity with any per-side {@link BinParams.overhang} folded in — the
+ * floor area cutouts can actually occupy.
+ *
+ * Overhang grows the bin body outward, so the interior floor grows in lockstep;
+ * the cutout coordinate frame runs `[0, innerW] × [0, innerD]` over that
+ * expanded floor (cutout `x`/`y` are relative to the expanded interior's
+ * bottom-left corner, exactly as the generator places them).
+ *
+ * Mirrors the generator's derivation in
+ * `generation/worker/generators/pipeline/context.ts`: overhang is suppressed
+ * for polygon masks (the mask defines its own footprint), negative/omitted
+ * sides clamp to zero, and the asymmetry offset is `(right − left) / 2` /
+ * `(back − front) / 2`.
+ */
+export function cutoutInterior(params: BinParams): CutoutInterior {
+  const { innerW, innerD } = binDimensions(params);
+  return expandInteriorForOverhang(innerW, innerD, params.overhang, params.cellMask);
+}
+
+/**
+ * Fold overhang into a nominal interior. Lower-level than {@link cutoutInterior}
+ * for callers that already hold the nominal `innerW`/`innerD` (e.g. the 3D ghost
+ * overlay, which derives them inline). Single source for the overhang math so
+ * the editor and the ghost can't drift.
+ */
+export function expandInteriorForOverhang(
+  innerW: number,
+  innerD: number,
+  overhang: OverhangConfig | undefined,
+  cellMask: CellMask | undefined
+): CutoutInterior {
+  if (!overhang || overhang.enabled === false || isPartialMask(cellMask)) {
+    return { innerW, innerD, offsetX: 0, offsetY: 0 };
+  }
+  const left = Math.max(0, overhang.left);
+  const right = Math.max(0, overhang.right);
+  const front = Math.max(0, overhang.front);
+  const back = Math.max(0, overhang.back);
+  return {
+    innerW: innerW + left + right,
+    innerD: innerD + front + back,
+    offsetX: (right - left) / 2,
+    offsetY: (back - front) / 2,
+  };
 }

--- a/src/features/bin-designer/utils/cutoutInterior.contract.test.ts
+++ b/src/features/bin-designer/utils/cutoutInterior.contract.test.ts
@@ -25,15 +25,30 @@ describe('cutoutInterior matches the generator pipeline dimensions', () => {
     ['explicitly disabled', { enabled: false, left: 5, right: 5, front: 0, back: 0 }],
   ];
 
+  function expectMatchesGenerator(params: BinParams): void {
+    const dim = createInitialContext(params).dimensions;
+    const ci = cutoutInterior(params);
+    expect(ci.innerW).toBeCloseTo(dim.innerW, 6);
+    expect(ci.innerD).toBeCloseTo(dim.innerD, 6);
+    expect(ci.offsetX).toBeCloseTo(dim.innerOffsetX, 6);
+    expect(ci.offsetY).toBeCloseTo(dim.innerOffsetY, 6);
+  }
+
   for (const [name, overhang] of cases) {
     it(name, () => {
-      const params = withOverhang(overhang);
-      const dim = createInitialContext(params).dimensions;
-      const ci = cutoutInterior(params);
-      expect(ci.innerW).toBeCloseTo(dim.innerW, 6);
-      expect(ci.innerD).toBeCloseTo(dim.innerD, 6);
-      expect(ci.offsetX).toBeCloseTo(dim.innerOffsetX, 6);
-      expect(ci.offsetY).toBeCloseTo(dim.innerOffsetY, 6);
+      expectMatchesGenerator(withOverhang(overhang));
     });
   }
+
+  it('suppresses overhang for a partial cell mask (matches the generator)', () => {
+    // Default bin is 2×2 grid units → 4×4 half-bin mask; one empty cell makes
+    // it partial, so both the helper and the generator ignore the overhang.
+    const cells = new Array(16).fill(1) as (0 | 1)[];
+    cells[0] = 0;
+    expectMatchesGenerator({
+      ...DEFAULT_BIN_PARAMS,
+      overhang: { left: 5, right: 5, front: 3, back: 3 },
+      cellMask: { cols: 4, rows: 4, cells },
+    });
+  });
 });

--- a/src/features/bin-designer/utils/cutoutInterior.contract.test.ts
+++ b/src/features/bin-designer/utils/cutoutInterior.contract.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Contract test: the cutout editor's interior frame ({@link cutoutInterior})
+ * must equal the generator pipeline's interior derivation, so cutouts land
+ * where the editor shows them (#2462). This imports the real generator context
+ * builder rather than re-deriving, so any future change to the pipeline's
+ * overhang math fails here instead of silently drifting the editor.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createInitialContext } from '@/features/generation/worker/generators/pipeline/context';
+import { cutoutInterior } from './binDimensions';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams } from '@/features/bin-designer/types';
+
+function withOverhang(overhang: BinParams['overhang']): BinParams {
+  return { ...DEFAULT_BIN_PARAMS, overhang };
+}
+
+describe('cutoutInterior matches the generator pipeline dimensions', () => {
+  const cases: Array<[string, BinParams['overhang']]> = [
+    ['no overhang', undefined],
+    ['symmetric', { left: 3, right: 3, front: 2, back: 2 }],
+    ['asymmetric', { left: 0, right: 8, front: 4, back: 0 }],
+    ['single side', { left: 6, right: 0, front: 0, back: 0 }],
+    ['explicitly disabled', { enabled: false, left: 5, right: 5, front: 0, back: 0 }],
+  ];
+
+  for (const [name, overhang] of cases) {
+    it(name, () => {
+      const params = withOverhang(overhang);
+      const dim = createInitialContext(params).dimensions;
+      const ci = cutoutInterior(params);
+      expect(ci.innerW).toBeCloseTo(dim.innerW, 6);
+      expect(ci.innerD).toBeCloseTo(dim.innerD, 6);
+      expect(ci.offsetX).toBeCloseTo(dim.innerOffsetX, 6);
+      expect(ci.offsetY).toBeCloseTo(dim.innerOffsetY, 6);
+    });
+  }
+});


### PR DESCRIPTION
## What & why

Addresses the second half of #2462 — the Custom Cutouts editor didn't recognize a bin's **overhang**.

A bin's `overhang` grows the walls (and interior floor) outward. The generator already places cutouts over that **expanded** interior, but the cutout editor derived its board from the **nominal** footprint (`binDimensions().innerW/innerD`). Two consequences on any bin with overhang:

- You couldn't place cutouts on the extra floor the overhang adds.
- "Center in bin" centered on the nominal rectangle, so cutouts didn't land where the editor showed them (the generator and editor used different frames).

## Change

- New `cutoutInterior(params)` next to `binDimensions`, plus a lower-level `expandInteriorForOverhang(innerW, innerD, overhang, cellMask)`. It folds per-side overhang into the interior and returns the asymmetry offset `(right−left)/2` / `(back−front)/2` — mirroring the generator's derivation in `generation/worker/generators/pipeline/context.ts`.
- Wired into the three surfaces that share the cutout coordinate frame so they stay in lockstep with the final mesh:
  - `CutoutWorkspace` (full editor) and `CutoutEditor` (sidebar) — expanded interior dims.
  - `GhostCutouts` (3D ghost during generation) — expanded dims **and** the model-space offset.
- Off-board detection and "center in bin" ride the editors' `binWidth`/`binDepth`, so they're corrected too.
- Overhang is suppressed for polygon (cellMask) footprints, matching the generator.
- Non-overhang bins are byte-for-byte unchanged (`addW/addD = 0`, `offset = 0`).

## Testing

- **Contract test** (`cutoutInterior.contract.test.ts`): asserts the helper equals the generator's own `deriveDimensions` (dims + offsets) across no/symmetric/asymmetric/single-side/disabled overhang — so the editor can't silently drift from the generator.
- Unit tests for `cutoutInterior` (expansion, offset, disabled, negative-clamp, mask suppression).
- `pnpm run typecheck`, lint, and the full bin-designer cutout/utils suites (1309 tests) green.

## Follow-up (Part A, not in this PR)

The other half of #2462 — representing baseplate **padding** in the **Layout view** and letting edge bins use that space — is a larger cross-tool feature (the Layout planner and Baseplate tool currently share no state). I'll bring a design proposal for that separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Custom Cutouts editor overhang-aware so cutouts can use the expanded interior and previews match the generated mesh. Fixes wrong centering and off-board detection on bins with overhang (part of #2462).

- **Bug Fixes**
  - Added `cutoutInterior(params)` (and `expandInteriorForOverhang`) to fold per-side overhang into the interior and expose asymmetric offsets.
  - Wired into `CutoutWorkspace` and `CutoutEditor` so bin width/depth, “center in bin,” and off-board checks use the expanded interior.
  - Updated `GhostCutouts` to apply expanded dims and model-space offset, aligning the 3D ghost with the final mesh.
  - Suppress overhang when a polygon `cellMask` is present, matching the generator.
  - No change for bins without overhang.
  - Added a contract test against the generator pipeline plus unit tests to lock the math.
  - Tightened tests and docs: derive nominal interior from `binDimensions(DEFAULT_BIN_PARAMS)`, add a partial `cellMask` contract case, and clarify the docstring (absent/disabled overhang is nominal; only negative sides clamp).

<sup>Written for commit cc18893dcf99166e51214e67f0c8db3185051676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

