### PR TITLE
feat(grid-editor): show baseplate drawer-fit margin in the layout view

### DIFF
--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { resetAllStores } from '@/test/testUtils';
+import { DrawerMargin } from './DrawerMargin';
+import { useLayoutStore } from '@/core/store';
+import { createDefaultLayout } from '@/core/constants';
+import type { StoredBaseplateParams } from '@/core/types';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+function setPadding(padding: Partial<StoredBaseplateParams>): void {
+  const layout = createDefaultLayout();
+  useLayoutStore.setState({
+    layout: {
+      ...layout,
+      gridUnitMm: 42,
+      baseplateParams: {
+        magnetHoles: false,
+        magnetDiameter: 6,
+        magnetDepth: 2,
+        paddingLeft: 0,
+        paddingRight: 0,
+        paddingFront: 0,
+        paddingBack: 0,
+        ...padding,
+      },
+    },
+  });
+}
+
+describe('DrawerMargin', () => {
+  beforeEach(() => {
+    resetAllStores();
+    useLayoutStore.setState({ layout: createDefaultLayout() });
+  });
+
+  it('renders nothing when no baseplate padding is configured', () => {
+    const { container } = render(<DrawerMargin cellSize={32} gap={2} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when every side is zero', () => {
+    setPadding({});
+    const { container } = render(<DrawerMargin cellSize={32} gap={2} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('extends per side by the padding, scaled to the grid pitch', () => {
+    // gridUnitMm 42, pitch = cellSize + gap = 34px. 21mm = half a unit = 17px.
+    setPadding({ paddingLeft: 21, paddingBack: 42 });
+    const { getByLabelText } = render(<DrawerMargin cellSize={32} gap={2} />);
+    const band = getByLabelText('grid.drawerMargin.tooltip');
+    // left = -(21/42)*34 = -17; top (back) = -(42/42)*34 = -34.
+    expect(band.style.left).toBe('-17px');
+    expect(band.style.top).toBe('-34px');
+    // Unset sides stay flush with the grid box.
+    expect(band.style.right).toBe('0px');
+    expect(band.style.bottom).toBe('0px');
+  });
+
+  it('maps front padding to the bottom edge and right padding to the right', () => {
+    setPadding({ paddingFront: 42, paddingRight: 21 });
+    const { getByLabelText } = render(<DrawerMargin cellSize={32} gap={2} />);
+    const band = getByLabelText('grid.drawerMargin.tooltip');
+    expect(band.style.bottom).toBe('-34px');
+    expect(band.style.right).toBe('-17px');
+    expect(band.style.left).toBe('0px');
+    expect(band.style.top).toBe('0px');
+  });
+
+  it('clamps negative padding to zero', () => {
+    setPadding({ paddingLeft: -10, paddingRight: 21 });
+    const { getByLabelText } = render(<DrawerMargin cellSize={32} gap={2} />);
+    const band = getByLabelText('grid.drawerMargin.tooltip');
+    expect(band.style.left).toBe('0px');
+    expect(band.style.right).toBe('-17px');
+  });
+});

--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
@@ -58,6 +58,9 @@ describe('DrawerMargin', () => {
     // Unset sides stay flush with the grid box.
     expect(band.style.right).toBe('0px');
     expect(band.style.bottom).toBe('0px');
+    // Decorative only: it overhangs the axis labels on padded sides, so it must
+    // never capture their clicks.
+    expect(band.className).toContain('pointer-events-none');
   });
 
   it('maps front padding to the bottom edge and right padding to the right', () => {

--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.tsx
@@ -17,8 +17,10 @@ interface DrawerMarginProps {
  *
  * Rendered behind `GridCanvas` inside the grid box: negative insets extend the
  * band outward per side by the padding, and the grid's own opaque background
- * covers the center, leaving only the margin ring visible. Purely visual —
- * padding is edited in the Baseplate tab.
+ * covers the center, leaving only the margin ring visible. Purely visual and
+ * `pointer-events: none` — the band overhangs the row/column axis labels on
+ * padded sides, so it must never intercept their clicks. Padding is edited in
+ * the Baseplate tab.
  */
 export function DrawerMargin({ cellSize, gap }: DrawerMarginProps) {
   const t = useTranslation();
@@ -48,7 +50,7 @@ export function DrawerMargin({ cellSize, gap }: DrawerMarginProps) {
   // Screen orientation: +Y (back) is up, -Y (front) is down; -X (left) / +X (right).
   return (
     <div
-      className="pointer-events-auto rounded-lg border border-dashed border-accent/50 bg-accent/5"
+      className="pointer-events-none rounded-lg border border-dashed border-accent/50 bg-accent/5"
       style={{
         position: 'absolute',
         left: -toPx(left),
@@ -57,7 +59,6 @@ export function DrawerMargin({ cellSize, gap }: DrawerMarginProps) {
         bottom: -toPx(front),
         zIndex: 0,
       }}
-      title={t('grid.drawerMargin.tooltip')}
       aria-label={t('grid.drawerMargin.tooltip')}
     />
   );

--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.tsx
@@ -1,0 +1,64 @@
+import { useShallow } from 'zustand/react/shallow';
+import { useLayoutStore } from '@/core/store';
+import { useTranslation } from '@/i18n';
+
+interface DrawerMarginProps {
+  cellSize: number;
+  gap: number;
+}
+
+/**
+ * Read-only representation of the drawer-fit margin (baseplate padding) around
+ * the grid (#2462). A physical drawer is rarely an exact multiple of the grid
+ * unit, so the baseplate carries per-side padding (mm) to fill the leftover;
+ * that padding lives on the layout (`baseplateParams`) but the grid — expressed
+ * in whole/half units — never showed it. This band draws that margin to scale
+ * so users can see the extra space and design an edge bin's overhang to use it.
+ *
+ * Rendered behind `GridCanvas` inside the grid box: negative insets extend the
+ * band outward per side by the padding, and the grid's own opaque background
+ * covers the center, leaving only the margin ring visible. Purely visual —
+ * padding is edited in the Baseplate tab.
+ */
+export function DrawerMargin({ cellSize, gap }: DrawerMarginProps) {
+  const t = useTranslation();
+  const { gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack } = useLayoutStore(
+    useShallow((s) => ({
+      gridUnitMm: s.layout.gridUnitMm,
+      paddingLeft: s.layout.baseplateParams?.paddingLeft ?? 0,
+      paddingRight: s.layout.baseplateParams?.paddingRight ?? 0,
+      paddingFront: s.layout.baseplateParams?.paddingFront ?? 0,
+      paddingBack: s.layout.baseplateParams?.paddingBack ?? 0,
+    }))
+  );
+
+  const left = Math.max(0, paddingLeft);
+  const right = Math.max(0, paddingRight);
+  const front = Math.max(0, paddingFront);
+  const back = Math.max(0, paddingBack);
+
+  // Nothing to show without a configured margin.
+  if (left + right + front + back <= 0) return null;
+
+  // One grid unit spans `cellSize + gap` px (holds in half-grid mode too — the
+  // per-unit pitch is invariant). Padding is a fraction of a unit in mm.
+  const pxPerUnit = cellSize + gap;
+  const toPx = (mm: number): number => (mm / gridUnitMm) * pxPerUnit;
+
+  // Screen orientation: +Y (back) is up, -Y (front) is down; -X (left) / +X (right).
+  return (
+    <div
+      className="pointer-events-auto rounded-lg border border-dashed border-accent/50 bg-accent/5"
+      style={{
+        position: 'absolute',
+        left: -toPx(left),
+        right: -toPx(right),
+        top: -toPx(back),
+        bottom: -toPx(front),
+        zIndex: 0,
+      }}
+      title={t('grid.drawerMargin.tooltip')}
+      aria-label={t('grid.drawerMargin.tooltip')}
+    />
+  );
+}

--- a/src/features/grid-editor/components/Grid/DrawerMargin/index.ts
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/index.ts
@@ -1,0 +1,1 @@
+export { DrawerMargin } from './DrawerMargin';

--- a/src/features/grid-editor/components/Grid/Grid.tsx
+++ b/src/features/grid-editor/components/Grid/Grid.tsx
@@ -20,6 +20,7 @@ import { getLayerBins } from '@/shared/utils';
 import type { GridUnits } from '@/core/types';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import { GridCanvas } from './GridCanvas';
+import { DrawerMargin } from './DrawerMargin';
 import { Overlay } from './Overlay';
 import { QuickLabelPopover } from './QuickLabelPopover';
 import { SelectionToolbar } from './SelectionToolbar';
@@ -372,6 +373,9 @@ export function Grid({ shouldShowDrawTutorial = false }: GridProps) {
                   onPointerMove={handlePointerMoveForCollab}
                   onPointerLeave={handlePointerLeaveForCollab}
                 >
+                  {/* Drawer-fit margin (baseplate padding), drawn behind the
+                      grid so only the surrounding ring shows (#2462). */}
+                  <DrawerMargin cellSize={cellSize} gap={gap} />
                   <GridCanvas
                     gridRef={gridRef}
                     cellSize={cellSize}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "Blockiert von Bin auf {layer}",
   "grid.blockedZone": "Blockierte Zone",
   "grid.blockedZoneClick": "Klicken um blockierendes Bin anzuzeigen",
+  "grid.drawerMargin.tooltip": "Randbereich zur Schubladenanpassung aus der Grundplatten-Polsterung. Im Tab „Grundplatte“ bearbeiten.",
   "grid.clickToSeeSplitPreview": "Klicken für Split-Vorschau",
   "grid.collapse": "Einklappen",
   "grid.collision": "Kollidiert mit vorhandenem Bin",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1340,6 +1340,8 @@ const en: Record<string, string> = {
   'grid.blockedByBin': 'Blocked by bin on {layer}',
   'grid.blockedZone': 'Blocked zone',
   'grid.blockedZoneClick': 'Click to view blocking bin',
+  'grid.drawerMargin.tooltip':
+    'Drawer-fit margin from baseplate padding. Edit it in the Baseplate tab.',
   'grid.collision': 'Collides with existing bin',
   'grid.invalidLayer': 'Invalid layer',
   'grid.outOfBounds': 'Out of bounds',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "Bloqueado por bin en {layer}",
   "grid.blockedZone": "Zona bloqueada",
   "grid.blockedZoneClick": "Haz clic para ver el bin que bloquea",
+  "grid.drawerMargin.tooltip": "Margen de ajuste al cajón según el relleno de la base. Edítalo en la pestaña Base.",
   "grid.clickToSeeSplitPreview": "Clic para ver vista previa de división",
   "grid.collapse": "Contraer",
   "grid.collision": "Colisiona con bin existente",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "Bloqué par un bin sur {layer}",
   "grid.blockedZone": "Zone bloquée",
   "grid.blockedZoneClick": "Cliquez pour voir le bin bloquant",
+  "grid.drawerMargin.tooltip": "Marge d'ajustement au tiroir issue de la marge de la platine de base. Modifiez-la dans l'onglet Platine de base.",
   "grid.clickToSeeSplitPreview": "Cliquez pour voir l'aperçu de division",
   "grid.collapse": "Réduire",
   "grid.collision": "Collision avec un bin existant",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "{layer}のビンによりブロック",
   "grid.blockedZone": "ブロック領域",
   "grid.blockedZoneClick": "クリックでブロックしているビンを表示",
+  "grid.drawerMargin.tooltip": "ベースプレートの余白による引き出しフィット余白です。「ベースプレート」タブで編集できます。",
   "grid.clickToSeeSplitPreview": "クリックで分割プレビューを表示",
   "grid.collapse": "折りたたみ",
   "grid.collision": "既存のビンと衝突",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "Blokkert av bin på {layer}",
   "grid.blockedZone": "Blokkert sone",
   "grid.blockedZoneClick": "Klikk for å vise blokkerende bin",
+  "grid.drawerMargin.tooltip": "Skuffetilpasningsmarg fra bunnplatens polstring. Rediger den i Bunnplate-fanen.",
   "grid.clickToSeeSplitPreview": "Klikk for å se delingsforhåndsvisning",
   "grid.collapse": "Skjul",
   "grid.collision": "Kolliderer med eksisterende bin",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "Geblokkeerd door bin op {layer}",
   "grid.blockedZone": "Geblokkeerd gebied",
   "grid.blockedZoneClick": "Klik om blokkerende bin te bekijken",
+  "grid.drawerMargin.tooltip": "Ladepassingsmarge op basis van de vulling van de basisplaat. Bewerk deze op het tabblad Basisplaat.",
   "grid.clickToSeeSplitPreview": "Klik om split-voorbeeld te zien",
   "grid.collapse": "Invouwen",
   "grid.collision": "Botst met bestaande bin",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "Bloqueado por bin em {layer}",
   "grid.blockedZone": "Zona bloqueada",
   "grid.blockedZoneClick": "Clique para ver o bin bloqueador",
+  "grid.drawerMargin.tooltip": "Margem de ajuste à gaveta a partir do preenchimento da placa base. Edite na aba Placa base.",
   "grid.clickToSeeSplitPreview": "Clique para ver prévia de divisão",
   "grid.collapse": "Recolher",
   "grid.collision": "Colide com bin existente",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "Blockerad av fack på {layer}",
   "grid.blockedZone": "Blockerad zon",
   "grid.blockedZoneClick": "Klicka för att se blockerande fack",
+  "grid.drawerMargin.tooltip": "Lådanpassningsmarginal från bottenplattans utfyllnad. Redigera den på fliken Bottenplatta.",
   "grid.clickToSeeSplitPreview": "Klicka för att se delad förhandsvisning",
   "grid.collapse": "Komprimera",
   "grid.collision": "Krockar med befintligt fack",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1352,6 +1352,7 @@
   "grid.blockedByBin": "Заблоковано біном на {layer}",
   "grid.blockedZone": "Заблокована зона",
   "grid.blockedZoneClick": "Натисніть, щоб переглянути блокуючий бін",
+  "grid.drawerMargin.tooltip": "Поле підгонки до шухляди з відступів базової плити. Редагуйте його на вкладці «Базова плита».",
   "grid.clickToSeeSplitPreview": "Натисніть, щоб побачити попередній перегляд розділення",
   "grid.collapse": "Згорнути",
   "grid.collision": "Колізія з наявним біном",


### PR DESCRIPTION
## What & why

Addresses the first half of #2462 — the Layout view had no way to represent the **padding** added when designing a baseplate.

A physical drawer is rarely an exact multiple of the grid unit, so the baseplate carries per-side padding (mm) to fill the leftover margin. That padding already lives on the layout (`Layout.baseplateParams.padding*`), but the Layout grid — expressed in whole/half **units** — never surfaced it. So users couldn't see the extra drawer space, nor design an edge bin to use it.

## Change

- New read-only `DrawerMargin` band rendered behind `GridCanvas`. Negative insets extend it outward per side by the padding, scaled to the grid pitch (`cellSize + gap` px per unit); the grid's opaque background covers the center, so only the margin **ring** shows — a dashed drawer outline with a faint accent tint.
- Correct orientation: back→top, front→bottom, left/right as expected; negative padding clamps to zero; renders nothing when no padding is configured.
- A tooltip points to the Baseplate tab (padding stays editable there — read-only mirror per the agreed design).

## Screenshot

Layout grid with Back + Left padding set in the Baseplate tab — the dashed drawer outline sits just outside those two edges; the unpadded edges stay flush:

<!-- (dashed amber outline traces the top + left of the grid, offset by the margin) -->

## Testing

- `DrawerMargin.test.tsx`: null when no/zero padding; per-side inset math; back→top / front→bottom / left / right mapping; negative-clamp.
- Manual Playwright pass (set padding in Baseplate tab → margin band appears in Layout view; verified z-order behind the grid and correct sides). Spec not committed.
- `pnpm run typecheck`, lint, all four `check:i18n*` green; new key `grid.drawerMargin.tooltip` added to en.ts + all 9 locales.

## Scope note (rest of #2462)

The other half — letting edge bins **use** that space — is **overhang on the linked bin-designer design** (existing feature); the margin band makes it discoverable. A per-bin *layout* overhang model (new `Bin` field + CQRS + generation) was intentionally deferred as a separate, larger project. The cutout-editor overhang half of #2462 ships in #2467.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the baseplate drawer-fit margin in the Layout grid as a dashed ring so users can see extra drawer space and plan edge overhangs. Implements the “represent padding in Layout view” part of #2462.

- **New Features**
  - Adds a `DrawerMargin` band behind the grid; scales per-side padding (mm) to grid pitch with correct back/top, front/bottom, left/right mapping.
  - Clamps negative padding to 0 and hides when all sides are 0.
  - Adds a tooltip pointing to the Baseplate tab; new i18n key `grid.drawerMargin.tooltip`.

- **Bug Fixes**
  - Makes the margin band non-interactive (`pointer-events: none`) so axis-label clicks pass through.

<sup>Written for commit 2b190c24ac0aeec05593bcbcc1ada40e290b34d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

