### PR TITLE
fix(bin-designer): wire label color swatches into the swap-colors tool

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelColorControls.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelColorControls.test.tsx
@@ -32,6 +32,19 @@ describe('LabelColorControls', () => {
     expect(screen.getByRole('button', { name: /Engraved Text:/ })).toBeDefined();
   });
 
+  it('picks the zone for the swap tool instead of opening the picker when swap is active', () => {
+    setColors({ enabled: true });
+    useDesignerStore.setState((s) => ({ ui: { ...s.ui, colorTool: 'swap-pick-first' } }));
+    render(<LabelColorControls />);
+    fireEvent.click(screen.getByRole('button', { name: /Label Tab:/ }));
+
+    // The picker stays closed; the click registered the tab as the first swap pick.
+    expect(screen.queryByText('Presets')).toBeNull();
+    const { ui } = useDesignerStore.getState();
+    expect(ui.swapFirstZone).toBe('labelTab');
+    expect(ui.colorTool).toBe('swap-pick-second');
+  });
+
   it('enables multi-color and sets the tab color when a non-body color is picked', () => {
     render(<LabelColorControls />);
     fireEvent.click(screen.getByRole('button', { name: /Label Tab:/ }));

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelColorControls.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelColorControls.tsx
@@ -16,6 +16,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_FEATURE_COLOR_CONFIG } from '@/features/bin-designer/constants/defaults';
 import { normalizeHex } from '@/features/bin-designer/types/featureColors';
 import { useTranslation } from '@/i18n';
+import { useSwapZoneWithToast } from '@/features/bin-designer/hooks/useSwapZoneWithToast';
 import { ColorZoneRow } from '../ColorsSection/ColorZoneRow';
 
 const RECENT_COLORS_LIMIT = 8;
@@ -38,16 +39,23 @@ export function LabelColorControls() {
   const t = useTranslation();
   const [recentColors, setRecentColors] = useState<readonly string[]>([]);
 
-  const { featureColors } = useDesignerStore(
+  const { featureColors, colorTool } = useDesignerStore(
     useShallow((s) => ({
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
       featureColors: s.params.featureColors ?? DEFAULT_FEATURE_COLOR_CONFIG,
+      colorTool: s.ui.colorTool,
     }))
   );
   const updateFeatureColors = useDesignerStore((s) => s.updateFeatureColors);
   const setHoveredColorZone = useDesignerStore((s) => s.setHoveredColorZone);
   const startTransaction = useDesignerStore((s) => s.startTransaction);
   const commitTransaction = useDesignerStore((s) => s.commitTransaction);
+  const swapZoneWithToast = useSwapZoneWithToast();
+
+  // While the swap-colors tool is active (entered from the Colors section), a
+  // row click should pick the zone for the swap rather than open the picker —
+  // same contract as ColorsSection so the label swatches participate too.
+  const swapActive = colorTool === 'swap-pick-first' || colorTool === 'swap-pick-second';
 
   // Release the preview glow if this section unmounts while a row is hovered.
   useEffect(() => () => setHoveredColorZone(null), [setHoveredColorZone]);
@@ -93,6 +101,7 @@ export function LabelColorControls() {
           onHover={setHoveredColorZone}
           onGestureStart={startTransaction}
           onGestureEnd={commitTransaction}
+          onClickOverride={swapActive ? () => swapZoneWithToast('labelTab') : undefined}
         />
         <ColorZoneRow
           zone="text"
@@ -106,6 +115,7 @@ export function LabelColorControls() {
           onHover={setHoveredColorZone}
           onGestureStart={startTransaction}
           onGestureEnd={commitTransaction}
+          onClickOverride={swapActive ? () => swapZoneWithToast('text') : undefined}
         />
       </div>
     </div>


### PR DESCRIPTION
Small follow-up to #2465 (already merged).

When the swap-colors tool is active, clicking a swatch is supposed to *pick* that zone for the swap rather than open the picker. The Colors section wires this via `onClickOverride`, but the new Label-section swatches (#2465) didn't — so entering swap mode from the Colors section and then clicking a label swatch opened the picker instead of completing the swap (flagged in Copilot review of #2465).

This passes `onClickOverride` on both label rows, reusing `useSwapZoneWithToast`, so the Label swatches participate in the swap flow exactly like the Colors section.

## Testing
- Added a test: with `colorTool === 'swap-pick-first'`, clicking the Label Tab row records `swapFirstZone === 'labelTab'` and advances to `swap-pick-second` without opening the picker.
- `pnpm run typecheck`, lint, and the LabelColorControls suite green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Label section color swatches now work with the swap-colors tool: clicking a label swatch picks that zone and advances the swap instead of opening the picker. Matches the Colors section behavior.

- **Bug Fixes**
  - Passes onClickOverride for Label Tab and Engraved Text rows to call useSwapZoneWithToast when swap is active.
  - Adds a test to verify clicking Label Tab in swap-pick-first sets swapFirstZone, advances to swap-pick-second, and keeps the picker closed.

<sup>Written for commit a64f149963cef67eb11b5d67ceeb515c9e947096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

