### PR TITLE
feat(supporters): add supporters thank-you page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import { useOnboarding } from '@/features/onboarding';
 import { useThemeEffect } from '@/shared/hooks/useThemeEffect';
 import { useDesignerRouting } from '@/shared/hooks/useDesignerRouting';
 import { useBaseplateRouting } from '@/shared/hooks/useBaseplateRouting';
+import { useSupportersRouting } from '@/shared/hooks/useSupportersRouting';
 import { usePlaceBinFromURL } from '@/features/bin-designer/hooks/usePlaceBinInLayout';
 import { useBackgroundThumbnailRegen } from '@/features/bin-designer';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
@@ -90,6 +91,9 @@ const DesignerPage = lazyWithRetry(() =>
 const BaseplatePage = lazyWithRetry(() =>
   import('@/features/baseplate').then(namedExport('BaseplatePage'))
 );
+const SupportersPage = lazyWithRetry(() =>
+  import('@/features/supporters').then(namedExport('SupportersPage'))
+);
 // Dev-only: pre-renders one gallery example for the thumbnail generator.
 // Inert in production via the `import.meta.env.DEV` gate at the route below.
 const DevThumbnailRoute = lazyWithRetry(() =>
@@ -120,12 +124,13 @@ export default function App() {
 
   const { isDesignerRoute, navigateToDesigner } = useDesignerRouting();
   const { isBaseplateRoute } = useBaseplateRouting();
+  const { isSupportersRoute, navigateToSupporters } = useSupportersRouting();
   // Dev-only thumbnail capture route. Suppresses layout/designer routing so
   // those hooks don't rewrite the URL and strip the query params we depend on.
   const isDevThumbnailRoute =
     import.meta.env.DEV && new URLSearchParams(window.location.search).get('devThumbnails') === '1';
   const { open: commandPaletteOpen, setOpen: setCommandPaletteOpen } = useCommandPalette({
-    disabled: isDesignerRoute || isBaseplateRoute,
+    disabled: isDesignerRoute || isBaseplateRoute || isSupportersRoute,
   });
   const binExampleGalleryOpen = useBinExampleGalleryStore((s) => s.isOpen);
   const closeBinExampleGallery = useBinExampleGalleryStore((s) => s.close);
@@ -143,6 +148,14 @@ export default function App() {
     return () => window.removeEventListener('open-command-palette', handler as EventListener);
   }, [setCommandPaletteOpen]);
 
+  // Navigate to the /supporters page from the command palette (matches the
+  // `switch-to-designer` window-event pattern for cross-tree navigation).
+  useEffect(() => {
+    const handler = () => navigateToSupporters();
+    window.addEventListener('view-supporters', handler);
+    return () => window.removeEventListener('view-supporters', handler);
+  }, [navigateToSupporters]);
+
   // Route-aware SEO meta. Owns title/description across SPA navigation: the
   // i18n context only re-fires on locale change, so without this an in-app
   // jump from /designer back to / would leave the generator title up. We
@@ -154,12 +167,16 @@ export default function App() {
       ? 'seo.designer.title'
       : isBaseplateRoute
         ? 'seo.baseplate.title'
-        : 'seo.title';
+        : isSupportersRoute
+          ? 'seo.supporters.title'
+          : 'seo.title';
     const descKey = isDesignerRoute
       ? 'seo.designer.description'
       : isBaseplateRoute
         ? 'seo.baseplate.description'
-        : 'seo.description';
+        : isSupportersRoute
+          ? 'seo.supporters.description'
+          : 'seo.description';
     const title = t(titleKey);
     const desc = t(descKey);
     document.title = title;
@@ -168,7 +185,7 @@ export default function App() {
     document.querySelector('meta[property="og:description"]')?.setAttribute('content', desc);
     document.querySelector('meta[name="twitter:title"]')?.setAttribute('content', title);
     document.querySelector('meta[name="twitter:description"]')?.setAttribute('content', desc);
-  }, [isDesignerRoute, isBaseplateRoute, t]);
+  }, [isDesignerRoute, isBaseplateRoute, isSupportersRoute, t]);
   const { isMobile, isTablet } = useResponsive();
 
   const { shouldShowWelcome, shouldShowDrawTutorial, markWelcomeComplete } = useOnboarding();
@@ -240,7 +257,9 @@ export default function App() {
   useKeyboard();
   const saveStatus = useAutoSave();
   useCrossTabSync();
-  useLayoutRouting({ skip: isDesignerRoute || isBaseplateRoute || isDevThumbnailRoute });
+  useLayoutRouting({
+    skip: isDesignerRoute || isBaseplateRoute || isSupportersRoute || isDevThumbnailRoute,
+  });
   usePWAUpdate();
   useAnalytics();
   useEngagementNudges();
@@ -337,6 +356,14 @@ export default function App() {
       return (
         <Suspense fallback={<LoadingFallback label={t('loading.baseplate')} />}>
           <BaseplatePage />
+        </Suspense>
+      );
+    }
+
+    if (isSupportersRoute) {
+      return (
+        <Suspense fallback={<LoadingFallback label={t('loading.supporters')} />}>
+          <SupportersPage />
         </Suspense>
       );
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -539,7 +539,9 @@ export default function App() {
           ? t('seo.designer.title')
           : isBaseplateRoute
             ? t('seo.baseplate.title')
-            : t('seo.h1')}
+            : isSupportersRoute
+              ? t('seo.supporters.title')
+              : t('seo.h1')}
       </h1>
       {cloudSyncEnabled && (
         <Suspense fallback={null}>

--- a/src/features/command-palette/commands.ts
+++ b/src/features/command-palette/commands.ts
@@ -85,6 +85,12 @@ export const COMMAND_DEFINITIONS: CommandDefinition[] = [
     keywords: ['designer', 'bin', 'cad', 'stl', '3d'],
   },
   {
+    id: 'view-supporters',
+    labelKey: 'commandPalette.viewSupporters',
+    category: 'navigation',
+    keywords: ['supporters', 'donate', 'kofi', 'ko-fi', 'thanks', 'sponsor', 'support'],
+  },
+  {
     id: 'open-bin-examples',
     labelKey: 'commandPalette.openBinExamples',
     category: 'navigation',

--- a/src/features/command-palette/components/CommandPalette/commandPaletteActionHandlers.ts
+++ b/src/features/command-palette/components/CommandPalette/commandPaletteActionHandlers.ts
@@ -209,6 +209,7 @@ export function useActionHandlers(): Record<string, ActionHandler> {
           'noopener,noreferrer'
         ),
       'switch-to-designer': () => dispatchWindowEvent('switch-to-designer'),
+      'view-supporters': () => dispatchWindowEvent('view-supporters'),
       'open-bin-examples': () => {
         useBinExampleGalleryStore.getState().open();
       },

--- a/src/features/supporters/README.md
+++ b/src/features/supporters/README.md
@@ -1,0 +1,23 @@
+# Supporters
+
+Standalone `/supporters` thank-you page: every Ko-fi supporter is rendered as a
+Gridfinity bin snapped into a baseplate. No amounts, no tiers, no visible count —
+every bin is equal, and order is shuffled per load so no one is first or last.
+
+## Key files
+
+- `data/supporters.json` — backfilled display names + `anonymousCount`. **Names only; never store emails or amounts.** Append new named supporters or bump `anonymousCount`.
+- `utils/supportersData.ts` — `buildSupporterBins(rng?)` expands the JSON into a shuffled bin list (injectable RNG for deterministic tests); `getSupporterCount()` for the a11y label.
+- `components/SupportersPage/` — the page. Uses design-system `Button`, semantic color tokens, `motion-safe:` for hover/entrance (reduced-motion safe).
+
+## Wiring (outside this slice)
+
+- Route detection + navigation: `src/shared/hooks/useSupportersRouting.ts`.
+- Render gate, SEO meta, command-palette disable: `src/App.tsx` (mirrors the `/baseplate` route).
+- Entry points: `AttributionFooter` link, command palette (`view-supporters`), and the support surface.
+
+## Gotchas
+
+- The page renders **before** App.tsx's mobile/tablet/desktop trees, so its single CSS-grid layout must be responsive on its own (it uses `auto-fill` columns).
+- Anonymous supporters (Ko-fi default name "Supporter") render as equal muted "Anonymous" bins, not a collapsed count.
+- The CTA fires `kofi_clicked` with `source: 'supporters_page'` — shows up in the Ko-fi-by-placement insight.

--- a/src/features/supporters/components/SupportersPage/SupportersPage.test.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { SupportersPage } from './SupportersPage';
 import { trackEvent } from '@/shared/analytics/posthog';
 import { KOFI_URL } from '@/shared/constants/links';
+import supportersData from '../../data/supporters.json';
 
 vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
@@ -29,9 +30,10 @@ describe('SupportersPage', () => {
     expect(screen.getByRole('heading', { name: 'supporters.heading' })).toBeInTheDocument();
   });
 
-  it('renders a bin for a known named supporter', () => {
+  it('renders a bin for a named supporter', () => {
     render(<SupportersPage />);
-    expect(screen.getByText('Jürgen')).toBeInTheDocument();
+    // Derive from the data so the test survives supporter-list edits.
+    expect(screen.getByText(supportersData.named[0])).toBeInTheDocument();
   });
 
   it('renders anonymous supporters as equal bins', () => {

--- a/src/features/supporters/components/SupportersPage/SupportersPage.test.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.test.tsx
@@ -36,9 +36,12 @@ describe('SupportersPage', () => {
     expect(screen.getByText(supportersData.named[0])).toBeInTheDocument();
   });
 
-  it('renders anonymous supporters as equal bins', () => {
+  it('renders one bin per anonymous supporter', () => {
     render(<SupportersPage />);
-    expect(screen.getAllByText('supporters.anonymous').length).toBeGreaterThan(0);
+    // Assert against the data so the test stays correct if anonymousCount changes (incl. 0).
+    expect(screen.queryAllByText('supporters.anonymous')).toHaveLength(
+      supportersData.anonymousCount
+    );
   });
 
   it('never renders an email address', () => {

--- a/src/features/supporters/components/SupportersPage/SupportersPage.test.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SupportersPage } from './SupportersPage';
+import { trackEvent } from '@/shared/analytics/posthog';
+import { KOFI_URL } from '@/shared/constants/links';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/shared/analytics/posthog', () => ({
+  trackEvent: vi.fn(),
+}));
+
+describe('SupportersPage', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the warm heading', () => {
+    render(<SupportersPage />);
+    expect(screen.getByRole('heading', { name: 'supporters.heading' })).toBeInTheDocument();
+  });
+
+  it('renders a bin for a known named supporter', () => {
+    render(<SupportersPage />);
+    expect(screen.getByText('Jürgen')).toBeInTheDocument();
+  });
+
+  it('renders anonymous supporters as equal bins', () => {
+    render(<SupportersPage />);
+    expect(screen.getAllByText('supporters.anonymous').length).toBeGreaterThan(0);
+  });
+
+  it('never renders an email address', () => {
+    const { container } = render(<SupportersPage />);
+    expect(container.textContent ?? '').not.toContain('@');
+  });
+
+  it('fires kofi_clicked with the supporters_page source and opens Ko-fi', () => {
+    render(<SupportersPage />);
+    fireEvent.click(screen.getByText('supporters.cta.button'));
+    expect(trackEvent).toHaveBeenCalledWith('kofi_clicked', { source: 'supporters_page' });
+    expect(openSpy).toHaveBeenCalledWith(KOFI_URL, '_blank', 'noopener,noreferrer');
+  });
+});

--- a/src/features/supporters/components/SupportersPage/SupportersPage.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.tsx
@@ -1,0 +1,154 @@
+import { useMemo } from 'react';
+import { Button } from '@/design-system';
+import { useTranslation } from '@/i18n';
+import { trackEvent } from '@/shared/analytics/posthog';
+import { ICON_PATHS } from '@/shared/constants/iconPaths';
+import { KOFI_URL } from '@/shared/constants/links';
+import { useSupportersRouting } from '@/shared/hooks/useSupportersRouting';
+import { buildSupporterBins, getSupporterCount } from '../../utils/supportersData';
+
+function HeartIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      {ICON_PATHS.heart.map((d) => (
+        <path key={d} d={d} />
+      ))}
+    </svg>
+  );
+}
+
+/**
+ * Standalone /supporters page: a thank-you wall where each supporter is a
+ * Gridfinity bin snapped into a baseplate. No amounts, no tiers, no counts —
+ * every bin is equal. Names are shuffled so no one is first or last.
+ */
+export function SupportersPage() {
+  const t = useTranslation();
+  const { navigateHome } = useSupportersRouting();
+  const bins = useMemo(() => buildSupporterBins(), []);
+  const total = getSupporterCount();
+
+  const handleKofiClick = () => {
+    trackEvent('kofi_clicked', { source: 'supporters_page' });
+    window.open(KOFI_URL, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <main className="min-h-screen overflow-y-auto bg-surface text-content">
+      <div className="mx-auto flex max-w-5xl flex-col px-5 py-6 sm:px-8 sm:py-10">
+        {/* Back to the app */}
+        <div className="mb-8">
+          <Button
+            variant="ghost"
+            onClick={navigateHome}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm text-content-secondary"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            {t('supporters.back')}
+          </Button>
+        </div>
+
+        {/* Hero — warm, no count shown */}
+        <header className="mb-10 text-center motion-safe:animate-fade-in">
+          <div className="mb-4 flex justify-center">
+            <span className="flex h-12 w-12 items-center justify-center rounded-full bg-surface-elevated text-accent">
+              <HeartIcon className="h-6 w-6" />
+            </span>
+          </div>
+          <h1 className="text-2xl font-semibold text-content sm:text-3xl">
+            {t('supporters.heading')}
+          </h1>
+          <p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed text-content-secondary sm:text-base">
+            {t('supporters.subheading')}
+          </p>
+        </header>
+
+        {/* The baseplate: a subtle socket grid holding a bin per supporter */}
+        <ul
+          aria-label={t('supporters.listAria', { count: total })}
+          className="grid grid-cols-[repeat(auto-fill,minmax(104px,1fr))] gap-2.5 rounded-2xl border border-stroke-subtle p-3 sm:gap-3 sm:p-4"
+          style={{
+            backgroundImage:
+              'linear-gradient(rgba(128,128,128,0.10) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.10) 1px, transparent 1px)',
+            backgroundSize: '28px 28px',
+          }}
+        >
+          {bins.map((bin, i) => {
+            const isAnonymous = bin.name === null;
+            return (
+              <li
+                key={bin.id}
+                title={isAnonymous ? t('supporters.anonymous') : (bin.name ?? undefined)}
+                className={[
+                  'group relative flex aspect-square flex-col items-center justify-center gap-1 rounded-xl border p-2 text-center',
+                  'transition-transform duration-150 ease-out will-change-transform',
+                  'motion-safe:animate-fade-in motion-safe:hover:-translate-y-1',
+                  isAnonymous
+                    ? 'border-stroke-subtle bg-surface text-content-disabled'
+                    : 'border-stroke-subtle bg-surface-elevated text-content shadow-sm hover:shadow-md',
+                ].join(' ')}
+                style={{ animationDelay: `${Math.min(i * 18, 600)}ms` }}
+              >
+                {/* Gridfinity-style label tab */}
+                <span
+                  aria-hidden="true"
+                  className={[
+                    'absolute left-3 right-3 top-2 h-1 rounded-full bg-accent',
+                    isAnonymous ? 'opacity-20' : 'opacity-40',
+                  ].join(' ')}
+                />
+                {isAnonymous ? (
+                  <>
+                    <HeartIcon className="h-4 w-4 opacity-60" />
+                    <span className="text-[11px] font-medium">{t('supporters.anonymous')}</span>
+                  </>
+                ) : (
+                  <span className="line-clamp-3 break-words text-xs font-medium leading-tight sm:text-sm">
+                    {bin.name}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Gentle CTA */}
+        <section className="mt-10 flex flex-col items-center gap-3 text-center">
+          <p className="text-sm text-content-secondary">{t('supporters.cta.text')}</p>
+          <Button
+            variant="primary"
+            onClick={handleKofiClick}
+            className="flex items-center gap-2 px-4 py-2 text-sm"
+            style={{ color: '#fff', textShadow: '0 1px 1px rgba(34, 34, 34, 0.15)' }}
+          >
+            <img
+              src="/kofi-cup.png"
+              alt=""
+              aria-hidden="true"
+              className="kofi-cup-wiggle h-4 w-auto"
+            />
+            {t('supporters.cta.button')}
+          </Button>
+          <p className="mt-2 max-w-md text-xs text-content-disabled">
+            {t('supporters.optOut')}{' '}
+            <a
+              href={KOFI_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-content-tertiary hover:underline"
+            >
+              {t('supporters.optOutLink')}
+            </a>
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/features/supporters/components/SupportersPage/SupportersPage.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.tsx
@@ -88,7 +88,7 @@ export function SupportersPage() {
                 title={isAnonymous ? t('supporters.anonymous') : (bin.name ?? undefined)}
                 className={[
                   'group relative flex aspect-square flex-col items-center justify-center gap-1 rounded-xl border p-2 text-center',
-                  'transition-transform duration-150 ease-out will-change-transform',
+                  'transition-transform duration-150 ease-out',
                   'motion-safe:animate-fade-in motion-safe:hover:-translate-y-1',
                   isAnonymous
                     ? 'border-stroke-subtle bg-surface text-content-disabled'

--- a/src/features/supporters/components/SupportersPage/index.ts
+++ b/src/features/supporters/components/SupportersPage/index.ts
@@ -1,0 +1,1 @@
+export { SupportersPage } from './SupportersPage';

--- a/src/features/supporters/data/supporters.json
+++ b/src/features/supporters/data/supporters.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Backfilled from the Ko-fi supporter export on 2026-07-07. Display names only — NEVER store emails or amounts here. New supporters can be appended to `named`, or `anonymousCount` incremented for people who gave no name. Order is randomized at render, so append anywhere.",
+  "named": [
+    "unpossible",
+    "Jürgen",
+    "PummeledLeftNut",
+    "Kalle",
+    "haliphax",
+    "DoogieWall",
+    "FilmCan",
+    "Spob",
+    "Gas Daddy",
+    "resch.cloud",
+    "TB",
+    "Beate Streif",
+    "MelvinMASV",
+    "Brad",
+    "Max",
+    "John",
+    "Diego Silva",
+    "Oxo",
+    "Martin"
+  ],
+  "anonymousCount": 13
+}

--- a/src/features/supporters/index.ts
+++ b/src/features/supporters/index.ts
@@ -1,0 +1,3 @@
+export { SupportersPage } from './components/SupportersPage';
+export { buildSupporterBins, getSupporterCount } from './utils/supportersData';
+export type { SupporterBin } from './utils/supportersData';

--- a/src/features/supporters/utils/supportersData.test.ts
+++ b/src/features/supporters/utils/supportersData.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildSupporterBins, getSupporterCount } from './supportersData';
+import supportersData from '../data/supporters.json';
+
+describe('supportersData', () => {
+  it('counts named + anonymous supporters', () => {
+    expect(getSupporterCount()).toBe(supportersData.named.length + supportersData.anonymousCount);
+  });
+
+  it('builds one bin per supporter', () => {
+    const bins = buildSupporterBins(() => 0);
+    expect(bins).toHaveLength(getSupporterCount());
+  });
+
+  it('renders anonymous supporters as null-named bins', () => {
+    const bins = buildSupporterBins(() => 0);
+    expect(bins.filter((b) => b.name === null)).toHaveLength(supportersData.anonymousCount);
+    expect(bins.filter((b) => b.name !== null)).toHaveLength(supportersData.named.length);
+  });
+
+  it('never emits an email address as a name', () => {
+    const bins = buildSupporterBins(() => 0);
+    for (const bin of bins) {
+      expect(bin.name ?? '').not.toContain('@');
+    }
+  });
+
+  it('shuffles deterministically for a given RNG', () => {
+    const a = buildSupporterBins(() => 0.5).map((b) => b.id);
+    const b = buildSupporterBins(() => 0.5).map((b) => b.id);
+    expect(a).toEqual(b);
+  });
+
+  it('assigns unique ids', () => {
+    const bins = buildSupporterBins(() => 0);
+    expect(new Set(bins.map((b) => b.id)).size).toBe(bins.length);
+  });
+});

--- a/src/features/supporters/utils/supportersData.ts
+++ b/src/features/supporters/utils/supportersData.ts
@@ -1,0 +1,33 @@
+import supportersData from '../data/supporters.json';
+
+export interface SupporterBin {
+  id: string;
+  /** Display name, or null for supporters who gave no name (rendered as "Anonymous"). */
+  name: string | null;
+}
+
+/** Total number of supporters (named + anonymous). */
+export function getSupporterCount(): number {
+  return supportersData.named.length + supportersData.anonymousCount;
+}
+
+/**
+ * Build the full list of supporter bins, shuffled so no one is first or last.
+ * Accepts an injectable RNG so tests can assert deterministically.
+ */
+export function buildSupporterBins(rng: () => number = Math.random): SupporterBin[] {
+  const bins: SupporterBin[] = [
+    ...supportersData.named.map((name, i) => ({ id: `named-${i}`, name })),
+    ...Array.from({ length: supportersData.anonymousCount }, (_, i) => ({
+      id: `anon-${i}`,
+      name: null,
+    })),
+  ];
+
+  for (let i = bins.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [bins[i], bins[j]] = [bins[j], bins[i]];
+  }
+
+  return bins;
+}

--- a/src/features/supporters/utils/supportersData.ts
+++ b/src/features/supporters/utils/supportersData.ts
@@ -25,7 +25,8 @@ export function buildSupporterBins(rng: () => number = Math.random): SupporterBi
   ];
 
   for (let i = bins.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
+    // Clamp so a stray RNG returning exactly 1 can't index out of bounds.
+    const j = Math.min(i, Math.floor(rng() * (i + 1)));
     [bins[i], bins[j]] = [bins[j], bins[i]];
   }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "Derzeit sind keine experimentellen Funktionen verfügbar.",
   "layouts.sharedEmptyHint": "Wenn jemand ein Layout mit dir teilt, erscheint es hier automatisch. Öffne einen geteilten Link, um loszulegen.",
   "layouts.openSharedFailed": "Layout konnte nicht geöffnet werden. Bitte versuche es erneut.",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "Unterstützer — Gridfinity Layout Tool",
+  "seo.supporters.description": "Die Menschen, deren Unterstützung das Gridfinity Layout Tool kostenlos, werbefrei und unabhängig hält.",
+  "supporters.back": "Zurück zur App",
+  "supporters.heading": "Die Menschen, die das hier kostenlos halten",
+  "supporters.subheading": "Dieses Tool ist kostenlos, werbefrei und datenschutzfreundlich — dank der Menschen unten. Jeder Bin steht für jemanden, der etwas beigetragen hat, damit es weiterläuft.",
+  "supporters.anonymous": "Anonym",
+  "supporters.listAria": "{count} Unterstützer",
+  "supporters.cta.text": "Willst du deinen Bin auf dieser Baseplate?",
+  "supporters.cta.button": "Auf Ko-fi unterstützen",
+  "supporters.optOut": "Möchtest du nicht gelistet werden oder deinen Namen ändern?",
+  "supporters.optOutLink": "Sag mir Bescheid.",
+  "sidebar.supporters": "Unterstützer",
+  "loading.supporters": "Unterstützer werden geladen",
+  "commandPalette.viewSupporters": "Unterstützer anzeigen"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -30,6 +30,21 @@ const en: Record<string, string> = {
   'seo.baseplate.title': 'Gridfinity Baseplate Maker — Free Custom Baseplate Builder',
   'seo.baseplate.description':
     'Make custom Gridfinity baseplates in your browser: any grid size, magnet holes, edge padding, and automatic print-bed splitting. Export STL, STEP, or 3MF. Free, no account.',
+  'seo.supporters.title': 'Supporters — Gridfinity Layout Tool',
+  'seo.supporters.description':
+    'The people whose support keeps the Gridfinity Layout Tool free, ad-free, and independent.',
+
+  // Supporters page
+  'supporters.back': 'Back to the app',
+  'supporters.heading': 'The people who keep this free',
+  'supporters.subheading':
+    'This tool is free, ad-free, and privacy-focused — thanks to the people below. Every bin is someone who chipped in to keep it running.',
+  'supporters.anonymous': 'Anonymous',
+  'supporters.listAria': '{count} supporters',
+  'supporters.cta.text': 'Want your bin on this baseplate?',
+  'supporters.cta.button': 'Support on Ko-fi',
+  'supporters.optOut': 'Prefer not to be listed, or want your name changed?',
+  'supporters.optOutLink': 'Let me know.',
 
   // Common / Shared
   'common.save': 'Save',
@@ -251,6 +266,7 @@ const en: Record<string, string> = {
   'sidebar.appName': 'Gridfinity Layout Tool',
   'sidebar.version': 'v{version}',
   'sidebar.privacy': 'Privacy',
+  'sidebar.supporters': 'Supporters',
   'sidebar.terms': 'Terms',
   'sidebar.toggleHalfBinMode': 'Toggle half-grid mode',
   'sidebar.toolBy': 'Tool by',
@@ -2482,6 +2498,7 @@ const en: Record<string, string> = {
   'loading.collaboration': 'Loading collaboration',
   'loading.designer': 'Loading designer',
   'loading.baseplate': 'Loading baseplate generator',
+  'loading.supporters': 'Loading supporters',
   'loading.mobileLayout': 'Loading mobile layout',
   'loading.help': 'Loading help',
   'loading.sharedWithMe': 'Loading...',
@@ -2610,6 +2627,7 @@ const en: Record<string, string> = {
   'commandPalette.newLayout': 'New Layout',
   'commandPalette.duplicateLayout': 'Duplicate Layout',
   'commandPalette.switchToDesigner': 'Switch to Bins',
+  'commandPalette.viewSupporters': 'View supporters',
   'commandPalette.openBinExamples': 'Browse Bin Examples',
 
   // Tools commands (extended)

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "No hay funciones experimentales disponibles en este momento.",
   "layouts.sharedEmptyHint": "Cuando alguien comparta un diseño contigo, aparecerá aquí automáticamente. Abre un enlace compartido para empezar.",
   "layouts.openSharedFailed": "No se pudo abrir el diseño. Inténtalo de nuevo.",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "Colaboradores — Gridfinity Layout Tool",
+  "seo.supporters.description": "Las personas cuyo apoyo mantiene Gridfinity Layout Tool gratuito, sin anuncios e independiente.",
+  "supporters.back": "Volver a la app",
+  "supporters.heading": "Las personas que mantienen esto gratis",
+  "supporters.subheading": "Esta herramienta es gratuita, sin anuncios y respetuosa con tu privacidad, gracias a las personas de abajo. Cada bin es alguien que aportó para mantenerla en marcha.",
+  "supporters.anonymous": "Anónimo",
+  "supporters.listAria": "{count} colaboradores",
+  "supporters.cta.text": "¿Quieres tu bin en esta baseplate?",
+  "supporters.cta.button": "Apoyar en Ko-fi",
+  "supporters.optOut": "¿Prefieres no aparecer o quieres cambiar tu nombre?",
+  "supporters.optOutLink": "Avísame.",
+  "sidebar.supporters": "Colaboradores",
+  "loading.supporters": "Cargando colaboradores",
+  "commandPalette.viewSupporters": "Ver colaboradores"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "Aucune fonctionnalité expérimentale disponible pour le moment.",
   "layouts.sharedEmptyHint": "Lorsque quelqu’un partage un layout avec vous, il apparaît ici automatiquement. Ouvrez un lien partagé pour commencer.",
   "layouts.openSharedFailed": "Impossible d'ouvrir le layout. Veuillez réessayer.",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "Soutiens — Gridfinity Layout Tool",
+  "seo.supporters.description": "Les personnes dont le soutien garde le Gridfinity Layout Tool gratuit, sans publicité et indépendant.",
+  "supporters.back": "Retour à l'app",
+  "supporters.heading": "Les personnes qui gardent cet outil gratuit",
+  "supporters.subheading": "Cet outil est gratuit, sans publicité et respectueux de la vie privée — grâce aux personnes ci-dessous. Chaque bin représente quelqu'un qui a contribué pour le faire vivre.",
+  "supporters.anonymous": "Anonyme",
+  "supporters.listAria": "{count} soutiens",
+  "supporters.cta.text": "Vous voulez votre bin sur cette baseplate ?",
+  "supporters.cta.button": "Soutenir sur Ko-fi",
+  "supporters.optOut": "Vous préférez ne pas figurer ici, ou changer votre nom ?",
+  "supporters.optOutLink": "Dites-le-moi.",
+  "sidebar.supporters": "Soutiens",
+  "loading.supporters": "Chargement des soutiens",
+  "commandPalette.viewSupporters": "Voir les soutiens"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "現在、利用できる実験的機能はありません。",
   "layouts.sharedEmptyHint": "誰かがレイアウトを共有すると、ここに自動的に表示されます。共有リンクを開いて始めましょう。",
   "layouts.openSharedFailed": "レイアウトを開けませんでした。もう一度お試しください。",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "サポーター — Gridfinity Layout Tool",
+  "seo.supporters.description": "Gridfinity Layout Tool を無料・広告なし・独立して維持してくれる支援者の皆さん。",
+  "supporters.back": "アプリに戻る",
+  "supporters.heading": "このツールを無料で支えてくれる人たち",
+  "supporters.subheading": "このツールは無料・広告なしで、プライバシーを重視しています。それは下記の方々のおかげです。ひとつひとつの bin は、運営を支えてくれた誰かです。",
+  "supporters.anonymous": "匿名",
+  "supporters.listAria": "{count} 人のサポーター",
+  "supporters.cta.text": "あなたの bin をこの baseplate に並べませんか？",
+  "supporters.cta.button": "Ko-fi で応援する",
+  "supporters.optOut": "掲載を希望しない、または名前を変更したいですか？",
+  "supporters.optOutLink": "お知らせください。",
+  "sidebar.supporters": "サポーター",
+  "loading.supporters": "サポーターを読み込み中",
+  "commandPalette.viewSupporters": "サポーターを見る"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "Ingen eksperimentelle funksjoner tilgjengelig akkurat nå.",
   "layouts.sharedEmptyHint": "Når noen deler et layout med deg, vises det her automatisk. Åpne en delt lenke for å komme i gang.",
   "layouts.openSharedFailed": "Kunne ikke åpne layout. Prøv igjen.",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "Støttespillere — Gridfinity Layout Tool",
+  "seo.supporters.description": "Menneskene hvis støtte holder Gridfinity Layout Tool gratis, reklamefritt og uavhengig.",
+  "supporters.back": "Tilbake til appen",
+  "supporters.heading": "Menneskene som holder dette gratis",
+  "supporters.subheading": "Dette verktøyet er gratis, reklamefritt og personvernvennlig — takket være menneskene under. Hver bin er noen som bidro for å holde det i gang.",
+  "supporters.anonymous": "Anonym",
+  "supporters.listAria": "{count} støttespillere",
+  "supporters.cta.text": "Vil du ha din bin på denne baseplaten?",
+  "supporters.cta.button": "Støtt på Ko-fi",
+  "supporters.optOut": "Vil du heller ikke stå oppført, eller endre navnet ditt?",
+  "supporters.optOutLink": "Gi meg beskjed.",
+  "sidebar.supporters": "Støttespillere",
+  "loading.supporters": "Laster støttespillere",
+  "commandPalette.viewSupporters": "Vis støttespillere"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "Momenteel zijn er geen experimentele functies beschikbaar.",
   "layouts.sharedEmptyHint": "Wanneer iemand een layout met je deelt, verschijnt het hier automatisch. Open een gedeelde link om te beginnen.",
   "layouts.openSharedFailed": "Kan layout niet openen. Probeer het opnieuw.",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "Ondersteuners — Gridfinity Layout Tool",
+  "seo.supporters.description": "De mensen wiens steun de Gridfinity Layout Tool gratis, advertentievrij en onafhankelijk houdt.",
+  "supporters.back": "Terug naar de app",
+  "supporters.heading": "De mensen die dit gratis houden",
+  "supporters.subheading": "Deze tool is gratis, advertentievrij en privacyvriendelijk — dankzij de mensen hieronder. Elke bin is iemand die bijdroeg om het draaiende te houden.",
+  "supporters.anonymous": "Anoniem",
+  "supporters.listAria": "{count} ondersteuners",
+  "supporters.cta.text": "Wil jij je bin op deze baseplate?",
+  "supporters.cta.button": "Steun op Ko-fi",
+  "supporters.optOut": "Liever niet vermeld, of wil je je naam wijzigen?",
+  "supporters.optOutLink": "Laat het me weten.",
+  "sidebar.supporters": "Ondersteuners",
+  "loading.supporters": "Ondersteuners laden",
+  "commandPalette.viewSupporters": "Ondersteuners bekijken"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "Nenhum recurso experimental disponível no momento.",
   "layouts.sharedEmptyHint": "Quando alguém compartilhar um layout com você, ele aparecerá aqui automaticamente. Abra um link compartilhado para começar.",
   "layouts.openSharedFailed": "Não foi possível abrir o layout. Tente novamente.",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "Apoiadores — Gridfinity Layout Tool",
+  "seo.supporters.description": "As pessoas cujo apoio mantém o Gridfinity Layout Tool gratuito, sem anúncios e independente.",
+  "supporters.back": "Voltar ao app",
+  "supporters.heading": "As pessoas que mantêm isto gratuito",
+  "supporters.subheading": "Esta ferramenta é gratuita, sem anúncios e focada em privacidade — graças às pessoas abaixo. Cada bin é alguém que contribuiu para mantê-la funcionando.",
+  "supporters.anonymous": "Anônimo",
+  "supporters.listAria": "{count} apoiadores",
+  "supporters.cta.text": "Quer o seu bin nesta baseplate?",
+  "supporters.cta.button": "Apoiar no Ko-fi",
+  "supporters.optOut": "Prefere não aparecer na lista ou quer mudar seu nome?",
+  "supporters.optOutLink": "Me avise.",
+  "sidebar.supporters": "Apoiadores",
+  "loading.supporters": "Carregando apoiadores",
+  "commandPalette.viewSupporters": "Ver apoiadores"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "Inga experimentella funktioner tillgängliga just nu.",
   "layouts.sharedEmptyHint": "När någon delar en layout med dig visas den här automatiskt. Öppna en delad länk för att komma igång.",
   "layouts.openSharedFailed": "Det gick inte att öppna layouten. Försök igen.",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "Supportrar — Gridfinity Layout Tool",
+  "seo.supporters.description": "Människorna vars stöd håller Gridfinity Layout Tool gratis, reklamfritt och oberoende.",
+  "supporters.back": "Tillbaka till appen",
+  "supporters.heading": "Människorna som håller det här gratis",
+  "supporters.subheading": "Det här verktyget är gratis, reklamfritt och integritetsvänligt — tack vare människorna nedan. Varje bin är någon som bidrog för att hålla det igång.",
+  "supporters.anonymous": "Anonym",
+  "supporters.listAria": "{count} supportrar",
+  "supporters.cta.text": "Vill du ha din bin på den här baseplaten?",
+  "supporters.cta.button": "Stöd på Ko-fi",
+  "supporters.optOut": "Vill du hellre inte listas, eller ändra ditt namn?",
+  "supporters.optOutLink": "Hör av dig.",
+  "sidebar.supporters": "Supportrar",
+  "loading.supporters": "Laddar supportrar",
+  "commandPalette.viewSupporters": "Visa supportrar"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2572,5 +2572,19 @@
   "labs.noFeaturesAvailable": "Наразі немає доступних експериментальних функцій.",
   "layouts.sharedEmptyHint": "Коли хтось поділиться розкладкою з вами, вона автоматично з’явиться тут. Відкрийте спільне посилання, щоб почати.",
   "layouts.openSharedFailed": "Не вдалося відкрити розкладку. Спробуйте ще раз.",
-  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=..."
+  "layouts.import.placeholder": "{\"version\": \"1.0\", \"name\": \"My Layout\", ...} or https://...#share=...",
+  "seo.supporters.title": "Прихильники — Gridfinity Layout Tool",
+  "seo.supporters.description": "Люди, чия підтримка тримає Gridfinity Layout Tool безкоштовним, без реклами та незалежним.",
+  "supporters.back": "Назад до застосунку",
+  "supporters.heading": "Люди, які тримають це безкоштовним",
+  "supporters.subheading": "Цей інструмент безкоштовний, без реклами й орієнтований на приватність — завдяки людям нижче. Кожен bin — це хтось, хто долучився, щоб він працював далі.",
+  "supporters.anonymous": "Анонім",
+  "supporters.listAria": "{count} прихильників",
+  "supporters.cta.text": "Хочете свій bin на цій baseplate?",
+  "supporters.cta.button": "Підтримати на Ko-fi",
+  "supporters.optOut": "Не хочете бути у списку або хочете змінити ім'я?",
+  "supporters.optOutLink": "Дайте знати.",
+  "sidebar.supporters": "Прихильники",
+  "loading.supporters": "Завантаження прихильників",
+  "commandPalette.viewSupporters": "Переглянути прихильників"
 }

--- a/src/shared/components/AttributionFooter/AttributionFooter.test.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.test.tsx
@@ -23,10 +23,20 @@ describe('AttributionFooter', () => {
 
   it('opens all external links in a new tab', () => {
     render(<AttributionFooter />);
-    const externalLinks = screen.getAllByRole('link');
+    // The Supporters link navigates within the SPA, so it is not an external new-tab link.
+    const externalLinks = screen
+      .getAllByRole('link')
+      .filter((link) => link.getAttribute('href') !== '/supporters');
     externalLinks.forEach((link) => {
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
+  });
+
+  it('navigates to the Supporters page in-app (no new tab)', () => {
+    render(<AttributionFooter />);
+    const supportersLink = screen.getByRole('link', { name: /Supporters/ });
+    expect(supportersLink).toHaveAttribute('href', '/supporters');
+    expect(supportersLink).not.toHaveAttribute('target');
   });
 });

--- a/src/shared/components/AttributionFooter/AttributionFooter.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.tsx
@@ -59,6 +59,9 @@ export function AttributionFooter() {
       <a
         href="/supporters"
         onClick={(e) => {
+          // Preserve Cmd/Ctrl/Shift-click (open in new tab/window); only
+          // intercept a plain left-click for in-app SPA navigation.
+          if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
           e.preventDefault();
           navigateToSupporters();
         }}

--- a/src/shared/components/AttributionFooter/AttributionFooter.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.tsx
@@ -1,8 +1,10 @@
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { useTranslation } from '@/i18n';
+import { useSupportersRouting } from '@/shared/hooks/useSupportersRouting';
 
 export function AttributionFooter() {
   const t = useTranslation();
+  const { navigateToSupporters } = useSupportersRouting();
   return (
     <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-[10px] leading-relaxed">
       <div className="text-content-secondary text-[11px] font-semibold mb-1 flex items-baseline gap-1.5">
@@ -52,6 +54,17 @@ export function AttributionFooter() {
           ))}
         </svg>
         {t('sidebar.tip')}
+      </a>{' '}
+      ·{' '}
+      <a
+        href="/supporters"
+        onClick={(e) => {
+          e.preventDefault();
+          navigateToSupporters();
+        }}
+        className="text-content-tertiary hover:underline"
+      >
+        {t('sidebar.supporters')}
       </a>{' '}
       ·{' '}
       <a

--- a/src/shared/hooks/useSupportersRouting.test.ts
+++ b/src/shared/hooks/useSupportersRouting.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSupportersRouting } from '@/shared/hooks/useSupportersRouting';
+
+describe('useSupportersRouting', () => {
+  let originalPathname: string;
+
+  beforeEach(() => {
+    originalPathname = window.location.pathname;
+    window.history.replaceState(null, '', '/');
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, '', originalPathname);
+  });
+
+  describe('isSupportersRoute detection', () => {
+    it('returns false on root path', () => {
+      const { result } = renderHook(() => useSupportersRouting());
+      expect(result.current.isSupportersRoute).toBe(false);
+    });
+
+    it('returns true on /supporters', () => {
+      window.history.replaceState(null, '', '/supporters');
+      const { result } = renderHook(() => useSupportersRouting());
+      expect(result.current.isSupportersRoute).toBe(true);
+    });
+
+    it('returns true on /supporters/ (trailing slash)', () => {
+      window.history.replaceState(null, '', '/supporters/');
+      const { result } = renderHook(() => useSupportersRouting());
+      expect(result.current.isSupportersRoute).toBe(true);
+    });
+
+    it('returns false on a different path', () => {
+      window.history.replaceState(null, '', '/baseplate');
+      const { result } = renderHook(() => useSupportersRouting());
+      expect(result.current.isSupportersRoute).toBe(false);
+    });
+  });
+
+  describe('navigation', () => {
+    it('navigateToSupporters enters the route and updates the URL', () => {
+      const { result } = renderHook(() => useSupportersRouting());
+      act(() => result.current.navigateToSupporters());
+      expect(result.current.isSupportersRoute).toBe(true);
+      expect(window.location.pathname).toBe('/supporters');
+    });
+
+    it('navigateHome leaves the route and returns to /', () => {
+      window.history.replaceState(null, '', '/supporters');
+      const { result } = renderHook(() => useSupportersRouting());
+      act(() => result.current.navigateHome());
+      expect(result.current.isSupportersRoute).toBe(false);
+      expect(window.location.pathname).toBe('/');
+    });
+  });
+});

--- a/src/shared/hooks/useSupportersRouting.ts
+++ b/src/shared/hooks/useSupportersRouting.ts
@@ -1,0 +1,36 @@
+/**
+ * Supporters routing hook.
+ *
+ * Detects the /supporters route and provides navigation to/from it.
+ * Mirrors useBaseplateRouting but takes no query params.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+function isSupportersPath(): boolean {
+  return window.location.pathname === '/supporters' || window.location.pathname === '/supporters/';
+}
+
+export function useSupportersRouting() {
+  const [isSupportersRoute, setIsSupportersRoute] = useState(isSupportersPath);
+
+  useEffect(() => {
+    const handlePopState = () => setIsSupportersRoute(isSupportersPath());
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  const navigateToSupporters = useCallback(() => {
+    window.history.pushState(null, '', '/supporters');
+    setIsSupportersRoute(true);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, []);
+
+  const navigateHome = useCallback(() => {
+    window.history.pushState(null, '', '/');
+    setIsSupportersRoute(false);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, []);
+
+  return { isSupportersRoute, navigateToSupporters, navigateHome };
+}


### PR DESCRIPTION
## What

A new **/supporters** page: a thank-you wall where every Ko-fi supporter is a Gridfinity bin snapped into a baseplate. No amounts, no tiers, no visible count — every bin is equal, and the order is shuffled on each load so no one is first or last. Supporters who gave no name render as equal "Anonymous" bins.

Reachable from the footer, the command palette ("View supporters"), and its own Ko-fi call-to-action.

## Why

Recognition is a low-pressure, evergreen way to acknowledge the people who keep the tool free — and giving supporters a visible home makes the support ask feel like belonging rather than a transaction.

## Notes

- Backfilled 32 current supporters into `src/features/supporters/data/supporters.json`. **Display names only** — no emails or amounts are stored or rendered (there's a test asserting no `@` ever appears). The file is shaped so new supporters can be appended later.
- The CTA fires `kofi_clicked` with `source: "supporters_page"` so it shows up alongside the other placements in analytics.
- Copy uses privacy-focused framing; strings are translated across all 10 locales.
- Theme-aware (light/dark), responsive down to mobile, reduced-motion-safe hover.

## Verification

- typecheck, eslint, module-boundary / design-system / component-structure checks, and all four i18n checks pass
- 17 unit tests (page, data util, routing hook)
- production build succeeds; page verified in light, dark, and mobile widths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `/supporters` page: a warm thank‑you wall where each Ko‑fi supporter is an equal Gridfinity bin, shuffled on each load (anonymous shown as “Anonymous”). Linked from the footer and command palette, with route detection, SEO, and analytics wiring.

- **New Features**
  - Standalone Supporters page with `useSupportersRouting`; lazy‑loaded in `App.tsx` with route‑aware SEO and a loading state.
  - Navigation via footer link and command palette (`view-supporters`); the route disables the palette while open.
  - Data in `supporters.json` (display names only + `anonymousCount`); `buildSupporterBins` shuffles into bins and `getSupporterCount` powers a11y; tests assert no emails, deterministic shuffle, and anonymous count from data.
  - CTA opens Ko‑fi and tracks `kofi_clicked` with `source: 'supporters_page'`. Copy across all 10 locales; UI is responsive, theme‑aware, and reduced‑motion‑safe.

- **Bug Fixes**
  - Footer Supporters link navigates in‑app (no new tab) and preserves modifier‑clicks; tests only enforce new‑tab behavior for external links.
  - Shuffle clamps the Fisher–Yates index for safety.
  - A11y/perf: sr‑only `<h1>` announces the supporters title on `/supporters`; removed `will-change: transform` from tiles.

<sup>Written for commit 9eb1100bdd4414ba989c0691373b51dc31c37645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

