### PR TITLE
fix(size): measure Total JS for one locale, not all ten

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,10 +86,21 @@
       "limit": "260 kB"
     },
     {
-      "name": "Total JS (gzip)",
-      "path": "dist/assets/*.js",
+      "name": "Total JS (gzip, one locale)",
+      "path": [
+        "dist/assets/*.js",
+        "!dist/assets/de-*.js",
+        "!dist/assets/es-*.js",
+        "!dist/assets/fr-*.js",
+        "!dist/assets/ja-*.js",
+        "!dist/assets/nb-*.js",
+        "!dist/assets/nl-*.js",
+        "!dist/assets/pt-BR-*.js",
+        "!dist/assets/sv-*.js",
+        "!dist/assets/uk-*.js"
+      ],
       "gzip": true,
-      "limit": "2150 kB"
+      "limit": "1900 kB"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
## Problem

The `Total JS (gzip)` size-limit budget matched `dist/assets/*.js` — **every** JS chunk. That includes all **10 mutually-exclusive locale bundles (~437 kB gz combined)**, even though any single user downloads exactly one locale. So the metric counted ~9 locales' worth of translation weight that no user ever co-loads.

That double-counting — not real page weight — is what pushed the budget over its 2050 kB limit. The recent supporters redesign's temporary bump (2050 → 2150 kB) was masking a pre-existing measurement bug, not real bloat. The genuine code chunks (three ~327, brepjs ~241, route chunks) are unchanged.

## Fix

Exclude the 9 non-default locale chunks from the Total JS path so the budget reflects a realistic single-user download (shared code + lazy routes + one locale). Measured total drops to **~1.72 MB**. Set a tighter, meaningful limit of **1900 kB** (the old 2050 was calibrated for the inflated number).

Main bundle (190 kB) and Eager initial JS (260 kB) budgets are unchanged and unaffected.

## Verification

- `pnpm run size:check` passes: Main 92 kB / 190, Eager 160 kB / 260, **Total JS (one locale) 1.72 MB / 1.9 MB**.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measure Total JS for a single locale instead of all ten, fixing inflated bundle size metrics and tightening the budget to 1900 kB.

- **Bug Fixes**
  - Updated `size-limit` in `package.json` to exclude the 9 non-default locale bundles from `dist/assets/*.js`.
  - Renamed the budget to “Total JS (gzip, one locale)” and set the limit to 1900 kB (~1.72 MB measured).
  - Main and Eager JS budgets are unchanged; `pnpm run size:check` passes.

<sup>Written for commit 6c58f739869522144515d794cc665cd3718b78c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

