### PR TITLE
fix(baseplate): export puzzle connector fit sample as puzzle, not dovetail

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.tsx
@@ -2,7 +2,7 @@
  * "Print fit sample" control for the baseplate connector section.
  *
  * Opens the shared ExportDialog to download a one-file calibration tray that
- * sweeps all three connector styles across a fit-offset ladder, so makers can
+ * sweeps the selected connector style across a fit-offset ladder, so makers can
  * dial in the fit that clicks before committing to a full split baseplate.
  */
 

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -565,7 +565,7 @@ function puzzleOutline(
  * cross-section, so the protrusion prints as a self-supported prism with no
  * overhang — in either orientation, so it stack-prints cleanly too.
  */
-function makePuzzleTongue(
+export function makePuzzleTongue(
   pt: (wall: number, bp: number) => [number, number],
   w: number,
   bp: number,
@@ -578,7 +578,7 @@ function makePuzzleTongue(
 
 /** Puzzle groove (female): the tongue outline grown by `cl` on every face, carved
  *  in `−d` (into the piece) and extended beyond the wall and in Z. */
-function makePuzzleGroove(
+export function makePuzzleGroove(
   pt: (wall: number, bp: number) => [number, number],
   w: number,
   bp: number,

--- a/src/features/generation/worker/generators/connectorSample.scenario.test.ts
+++ b/src/features/generation/worker/generators/connectorSample.scenario.test.ts
@@ -146,6 +146,27 @@ describe('connectorSample — fit-sample tray', () => {
   );
 
   it(
+    'exports a watertight puzzle tray at max nozzle (near-collapsed neck)',
+    async () => {
+      // Worst case for the puzzle groove: the 1.0mm nozzle grows the base
+      // clearance and the +0.10 column of the offset ladder rides on top, driving
+      // the neck→head transition (PUZZLE_NECK_PROTRUSION) toward the wall plane
+      // while the armpit fillets stay applied. The clamp in `puzzleOutline` must
+      // keep the groove a valid, watertight solid rather than degenerate.
+      const { data } = await exportConnectorSample(
+        defaults({ connectorStyle: 'puzzle', nozzleSizeMm: 1.0 }),
+        'stl'
+      );
+      const stats = analyze(data);
+      expect(stats.hasNaN, 'no NaN vertices').toBe(false);
+      expect(stats.triangleCount, 'non-empty mesh').toBeGreaterThan(0);
+      expect(stats.nonManifoldEdges, 'non-manifold edges').toBe(0);
+      expect(stats.boundaryEdges, 'boundary edges').toBe(0);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
     'exports a non-empty STEP tray',
     async () => {
       const { data, fileName } = await exportConnectorSample(defaults(), 'step');

--- a/src/features/generation/worker/generators/connectorSample.scenario.test.ts
+++ b/src/features/generation/worker/generators/connectorSample.scenario.test.ts
@@ -90,17 +90,20 @@ describe('connectorSample — fit-sample tray', () => {
   it(
     'builds only the selected style row of valid, positive-volume pieces',
     () => {
-      // Default integral dovetail: 5 offsets × 2 coupons, no loose part = 10.
-      const pieces = buildConnectorSampleTray(defaults());
-      try {
-        expect(pieces).toHaveLength(10);
-        for (const piece of pieces) {
-          const v = vol(piece);
-          expect(Number.isFinite(v)).toBe(true);
-          expect(v).toBeGreaterThan(0);
+      // Integral tongue/groove styles: 5 offsets × 2 coupons, no loose part = 10.
+      // `undefined` is the default integral dovetail.
+      for (const style of [undefined, 'dovetail', 'puzzle'] as const) {
+        const pieces = buildConnectorSampleTray(defaults({ connectorStyle: style }));
+        try {
+          expect(pieces, String(style)).toHaveLength(10);
+          for (const piece of pieces) {
+            const v = vol(piece);
+            expect(Number.isFinite(v)).toBe(true);
+            expect(v).toBeGreaterThan(0);
+          }
+        } finally {
+          for (const p of pieces) p.delete();
         }
-      } finally {
-        for (const p of pieces) p.delete();
       }
     },
     TEST_TIMEOUT_MS
@@ -123,10 +126,13 @@ describe('connectorSample — fit-sample tray', () => {
     TEST_TIMEOUT_MS
   );
 
-  it(
-    'exports a watertight, bed-resting STL tray',
-    async () => {
-      const { data, fileName } = await exportConnectorSample(defaults(), 'stl');
+  it.each([undefined, 'puzzle'] as const)(
+    'exports a watertight, bed-resting STL tray (%s)',
+    async (style) => {
+      const { data, fileName } = await exportConnectorSample(
+        defaults({ connectorStyle: style }),
+        'stl'
+      );
       const stats = analyze(data);
       expect(fileName).toBe('connector_fit_sample.stl');
       expect(stats.hasNaN, 'no NaN vertices').toBe(false);

--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -5,7 +5,7 @@
  * committing to a full split baseplate. It builds one row for the *selected*
  * connector style (the other styles would be wasted print):
  *
- *   row   = the selected connector style (dovetail / dovetailKey / snapClip)
+ *   row   = the selected connector style (dovetail / puzzle / dovetailKey / snapClip)
  *   cols  = a fit-offset ladder (-0.10 … +0.10 mm, centered on nominal)
  *
  * Each grid cell is a MATED PAIR of small abstract coupons carrying the real
@@ -57,6 +57,8 @@ import type { SnapClipLevels } from '@/shared/constants/connectors';
 import {
   makeTongue,
   makeGroove,
+  makePuzzleTongue,
+  makePuzzleGroove,
   makeSnapPocket,
   buildDovetailKey,
   buildSnapClipForPrint,
@@ -69,7 +71,7 @@ import { sanitizeParams } from './baseplateSlab';
 const SAMPLE_OFFSETS: readonly number[] = [-0.1, -0.05, 0, 0.05, 0.1];
 
 interface SampleStyle {
-  readonly key: 'dovetail' | 'dovetailKey' | 'snapClip';
+  readonly key: 'dovetail' | 'puzzle' | 'dovetailKey' | 'snapClip';
   readonly abbr: string;
   /** Shared loose part this row ships (inserted into each pair to feel the fit), if any. */
   readonly loose: 'key' | 'clip' | null;
@@ -77,6 +79,9 @@ interface SampleStyle {
 
 const SAMPLE_STYLES: readonly SampleStyle[] = [
   { key: 'dovetail', abbr: 'DT', loose: null },
+  // Puzzle is an integral tongue/groove like the dovetail (no loose part); it just
+  // carries the stronger jigsaw-lobe profile (issue #2241).
+  { key: 'puzzle', abbr: 'PZ', loose: null },
   { key: 'dovetailKey', abbr: 'DK', loose: 'key' },
   { key: 'snapClip', abbr: 'SC', loose: 'clip' },
 ];
@@ -127,8 +132,8 @@ function roundedRect(cx: number, cy: number, w: number, h: number, r: number): D
 }
 
 type CouponFeature =
-  | { readonly kind: 'tongue' }
-  | { readonly kind: 'groove'; readonly clearance: number }
+  | { readonly kind: 'tongue'; readonly puzzle: boolean }
+  | { readonly kind: 'groove'; readonly clearance: number; readonly puzzle: boolean }
   | { readonly kind: 'pocket'; readonly levels: SnapClipLevels };
 
 /**
@@ -154,34 +159,38 @@ function buildCoupon(
     switch (feature.kind) {
       case 'tongue': {
         const tongue = scope.register(
-          makeTongue(
-            ptY,
-            wallY,
-            cx,
-            d,
-            TONGUE_PROTRUSION,
-            TONGUE_BASE_HALF,
-            TONGUE_TIP_HALF,
-            totalHeight
-          )
+          feature.puzzle
+            ? makePuzzleTongue(ptY, wallY, cx, d, totalHeight)
+            : makeTongue(
+                ptY,
+                wallY,
+                cx,
+                d,
+                TONGUE_PROTRUSION,
+                TONGUE_BASE_HALF,
+                TONGUE_TIP_HALF,
+                totalHeight
+              )
         );
         solid = scope.register(unwrap(fuse(solid as ValidSolid, tongue as ValidSolid)));
         break;
       }
       case 'groove': {
         const groove = scope.register(
-          makeGroove(
-            ptY,
-            wallY,
-            cx,
-            d,
-            TONGUE_PROTRUSION,
-            TONGUE_BASE_HALF,
-            TONGUE_TIP_HALF,
-            feature.clearance,
-            COPLANAR_MARGIN,
-            totalHeight
-          )
+          feature.puzzle
+            ? makePuzzleGroove(ptY, wallY, cx, d, feature.clearance, COPLANAR_MARGIN, totalHeight)
+            : makeGroove(
+                ptY,
+                wallY,
+                cx,
+                d,
+                TONGUE_PROTRUSION,
+                TONGUE_BASE_HALF,
+                TONGUE_TIP_HALF,
+                feature.clearance,
+                COPLANAR_MARGIN,
+                totalHeight
+              )
         );
         solid = scope.register(unwrap(cut(solid as ValidSolid, groove as ValidSolid)));
         break;
@@ -276,14 +285,17 @@ export function buildConnectorSampleTray(rawParams: ResolvedBaseplateParams): Sh
         backFeature = { kind: 'pocket', levels };
       } else if (style.key === 'dovetailKey') {
         const clearance = effectiveClearance(DOVETAIL_KEY_CLEARANCE, offset, params.nozzleSizeMm);
-        frontFeature = { kind: 'groove', clearance };
-        backFeature = { kind: 'groove', clearance };
+        frontFeature = { kind: 'groove', clearance, puzzle: false };
+        backFeature = { kind: 'groove', clearance, puzzle: false };
       } else {
-        // Integral dovetail: nominal tongue, offset rides on the female groove.
-        frontFeature = { kind: 'tongue' };
+        // Integral tongue/groove (dovetail or puzzle): nominal tongue, offset rides
+        // on the female groove. Puzzle shares the dovetail's base groove clearance.
+        const puzzle = style.key === 'puzzle';
+        frontFeature = { kind: 'tongue', puzzle };
         backFeature = {
           kind: 'groove',
           clearance: effectiveClearance(TONGUE_CLEARANCE, offset, params.nozzleSizeMm),
+          puzzle,
         };
       }
 


### PR DESCRIPTION
## What

Selecting the **Puzzle** connector and exporting the baseplate **Print fit sample** produced a *dovetail* calibration tray instead of a puzzle one. Fixes #2481.

## Why

The connector fit-sample tray (`connectorSample.ts`) predates the Puzzle style (added in #2241 as its own `connectorStyle`). Its `SAMPLE_STYLES` table and union type only listed `dovetail` / `dovetailKey` / `snapClip`, and the builder degrades an unknown style to `SAMPLE_STYLES[0]`:

```ts
const matched = SAMPLE_STYLES.filter((s) => s.key === selectedKey); // [] for 'puzzle'
const styles = matched.length > 0 ? matched : [SAMPLE_STYLES[0]];    // → dovetail
```

So a maker calibrating a puzzle-jointed split baseplate got the wrong profile — useless for dialing in the fit.

## Fix

- Add `puzzle` as its own integral tongue/groove row in the sample tray, reusing the real plate geometry builders (`makePuzzleTongue` / `makePuzzleGroove`, now exported) so the printed coupon carries the **exact** female groove a full split baseplate produces. Puzzle shares the dovetail's base groove clearance; the fit offset rides on the groove.
- Corrected a stale comment on `ConnectorSampleButton` (it claimed the tray swept "all three" styles; it builds one row for the selected style).

Verified the sibling **stack** "Print fit sample" is unaffected — it strips all connectors for uniform tiles, so no style can leak.

## Tests

Extended `connectorSample.scenario.test.ts` (real OCCT kernel):
- piece-count assertion now covers `undefined` / `dovetail` / `puzzle` (all 10 pieces, no loose part)
- watertight/bed-resting STL export now runs for both dovetail **and** puzzle (the filleted lobe is the boolean-risky part)

All 6 scenario cases pass; `typecheck` and `eslint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the baseplate “Print fit sample” for the Puzzle connector so it exports a puzzle calibration tray, not a dovetail. Adds puzzle to supported styles and reuses real plate geometry for accurate fit tuning.

- **Bug Fixes**
  - Added `puzzle` to sample styles and built puzzle tongue/groove using exported `makePuzzleTongue` and `makePuzzleGroove`.
  - Kept dovetail-equivalent base groove clearance; fit offset applies on the groove.
  - Expanded tests to cover `undefined`/`dovetail`/`puzzle` piece counts, watertight STL export for dovetail and puzzle, and a 1.0 mm nozzle edge case for puzzle (near-collapsed neck).
  - Fixed a stale comment in `ConnectorSampleButton` about which styles the tray sweeps.

<sup>Written for commit 33f3ab324a23968c5945ab2c007021aa9776e352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

