### PR TITLE
fix(bin-designer): stop parameter panel from scrolling the whole page

### DIFF
--- a/src/design-system/Checkbox/Checkbox.tsx
+++ b/src/design-system/Checkbox/Checkbox.tsx
@@ -241,7 +241,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       <label
         htmlFor={id}
         className={cn(
-          'inline-flex items-center gap-2',
+          // `relative` contains the sr-only (position:absolute) input below so it
+          // can't resolve its containing block to the ICB and leak its static
+          // position into the document scroll height inside static scroll containers.
+          'relative inline-flex items-center gap-2',
           disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
           className
         )}

--- a/src/design-system/Switch/Switch.tsx
+++ b/src/design-system/Switch/Switch.tsx
@@ -153,7 +153,10 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
       <label
         htmlFor={id}
         className={cn(
-          'inline-flex items-center gap-2',
+          // `relative` contains the sr-only (position:absolute) input below so it
+          // can't resolve its containing block to the ICB and leak its static
+          // position into the document scroll height inside static scroll containers.
+          'relative inline-flex items-center gap-2',
           disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
           className
         )}

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -91,7 +91,11 @@ function BinParameterPanel() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex-1 overflow-y-scroll scrollbar-thin">
+      {/* `relative` makes this the containing block for `sr-only` (position:absolute)
+          toggle inputs inside; without it their CB is the ICB, so their static
+          position deep in the scroll area extends the document and lets the whole
+          page scroll into blank space below the panel. */}
+      <div className="relative flex-1 overflow-y-scroll scrollbar-thin">
         {/* Shape group */}
         <StickyGroupHeader
           title={t('binDesigner.group.shape')}

--- a/src/features/bin-designer/components/panel/ToolRackSection/ToolRackParameterPanel.tsx
+++ b/src/features/bin-designer/components/panel/ToolRackSection/ToolRackParameterPanel.tsx
@@ -73,7 +73,11 @@ export function ToolRackParameterPanel() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex-1 overflow-y-scroll scrollbar-thin">
+      {/* `relative` keeps this scroll container a positioning context so `sr-only`
+          (position:absolute) descendants — e.g. Switch/Checkbox inputs — can't
+          leak their static position into the document scroll height. See the
+          matching note in ParameterPanel. */}
+      <div className="relative flex-1 overflow-y-scroll scrollbar-thin">
         <div className="flex items-center justify-between px-4 py-3 border-b border-stroke-subtle">
           <Button variant="ghost" onClick={() => newDesign('bin')} className="text-sm">
             {`← ${t('binDesigner.newBin')}`}


### PR DESCRIPTION
## What

In the bin designer you could scroll the whole page down and reveal blank space below the parameter panel and 3D preview. This removes that stray scroll.

## Why

The parameter panel's scroll container was `position: static`. The `sr-only` (`position: absolute`) checkbox inputs inside its toggle Switches therefore resolved their containing block all the way up to the initial containing block (`<html>`) rather than the panel. An `overflow: hidden`/`scroll` ancestor only clips an absolutely-positioned descendant when that ancestor *is* the descendant's containing block, so all the layout clips were bypassed. A hidden input's static position deep in the tall scroll area (~1818px down) leaked into `<html>`'s scroll height and made the entire document scrollable.

This is why it was intermittent — it only appeared once the panel grew tall enough (expanded sections / added compartments) that a hidden toggle input's static position fell below the viewport.

## Fix

Add `relative` to the panel's scroll container so it is the containing block for those absolutely-positioned descendants. `overflow-y: scroll` then clips them and the document no longer overflows.

## Verification

Measured the real dev build with Playwright at 5 viewport sizes (desktop, short desktop, landscape, tablet-portrait stacked, mobile). Before: `documentElement.scrollHeight` 1818 vs 1000 viewport, page scrolled 818px. After: scroll height equals viewport height and the page cannot scroll in any layout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the bin designer from scrolling into blank space below the parameter panel and 3D preview. Sets the panel scroll containers and `Switch`/`Checkbox` labels to `relative` so sr-only inputs are clipped, fixing overflow in both panels and app‑wide.

<sup>Written for commit 5e712b56916f345ee29b5ec86ede0fcf58c90eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

