### PR TITLE
fix(supporters): fail bake loudly on empty mesh or edge data

### DIFF
--- a/scripts/gen-supporters-meshes.ts
+++ b/scripts/gen-supporters-meshes.ts
@@ -243,6 +243,11 @@ function buildGlb(
   indices: Uint32Array,
   edgePositions: Float32Array
 ): Buffer {
+  // Empty inputs would serialize Infinity accessor bounds — invalid glTF, and
+  // a bake without geometry or edge lines is broken anyway. Fail loud.
+  if (positions.length === 0 || edgePositions.length === 0) {
+    throw new Error('buildGlb: mesh produced no triangles or no edge lines');
+  }
   const posBuf = Buffer.from(positions.buffer, positions.byteOffset, positions.byteLength);
   const normBuf = Buffer.from(normals.buffer, normals.byteOffset, normals.byteLength);
   const idxBuf = Buffer.from(indices.buffer, indices.byteOffset, indices.byteLength);


### PR DESCRIPTION
Follow-up to #2494 addressing Copilot's post-merge inline comment: `bounds()` over an empty `Float32Array` returns `{min: [Infinity,…], max: [-Infinity,…]}`, which would serialize invalid glTF accessor bounds for the LINES primitive.

Since a bake with no triangles or no edge lines is a broken asset regardless, `buildGlb` now throws instead of silently writing invalid glTF.

Verified: `pnpm run gen:supporters-meshes` still succeeds with byte-identical GLB output (script-only change, no asset diff).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent invalid glTF by failing the supporters bake when mesh or edge data is empty. buildGlb now throws if positions or edgePositions are empty, avoiding Infinity accessor bounds; `pnpm run gen:supporters-meshes` still produces byte-identical GLBs.

<sup>Written for commit 71e32adcba74ac549fa938b0a13745150445599c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

