### PR TITLE
fix(supporters): also guard against empty indices in bake

### DIFF
--- a/scripts/gen-supporters-meshes.ts
+++ b/scripts/gen-supporters-meshes.ts
@@ -245,7 +245,7 @@ function buildGlb(
 ): Buffer {
   // Empty inputs would serialize Infinity accessor bounds — invalid glTF, and
   // a bake without geometry or edge lines is broken anyway. Fail loud.
-  if (positions.length === 0 || edgePositions.length === 0) {
+  if (positions.length === 0 || indices.length === 0 || edgePositions.length === 0) {
     throw new Error('buildGlb: mesh produced no triangles or no edge lines');
   }
   const posBuf = Buffer.from(positions.buffer, positions.byteOffset, positions.byteLength);


### PR DESCRIPTION
Follow-up to #2496 addressing Copilot's inline comment: the empty-bake guard checked `positions` but triangles are defined by `indices` — a non-empty vertex buffer with zero indices would still serialize a triangle primitive that draws nothing. The guard now checks both (plus edge lines, as before).

Script-only change; `pnpm run gen:supporters-meshes` output unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent empty GLB triangle primitives by guarding against empty index buffers during supporters mesh bake. The script now throws if positions, indices, or edge lines are empty; no changes to generated meshes.

<sup>Written for commit 0602f63f001a8a17c404c3d56419d211f12e7cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

