### PR TITLE
feat(a11y): support Windows High Contrast Mode (forced-colors)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1197,7 +1197,7 @@ input[type='range']:hover::-moz-range-thumb {
 
 /* ===========================================
    HIGH CONTRAST (in-app setting)
-   An app-level override — independent of the OS forced-colors block above —
+   An app-level override — independent of the OS forced-colors block below —
    toggled by the Accessibility settings tab (html[data-high-contrast]). It
    strengthens the semantic border/text tokens and the focus ring so the UI
    stays legible for low-vision users. Theme-aware: "more contrast" means
@@ -1227,6 +1227,44 @@ html[data-theme='light'][data-high-contrast='true'] {
 /* Thicker keyboard focus ring so it reads at a glance in high-contrast mode. */
 html[data-high-contrast='true'] :focus-visible {
   outline-width: 3px;
+}
+
+/* ===========================================
+   FORCED COLORS (Windows High Contrast Mode)
+   In forced-colors mode the UA replaces author colors with the user's system
+   palette and drops box-shadow entirely. Several states here are conveyed only
+   via box-shadow (bin selection/focus rings, elevation), so they must be
+   re-expressed with borders/outlines that forced-colors preserves. System
+   color keywords (Highlight, CanvasText) resolve to the user's chosen scheme.
+   =========================================== */
+@media (forced-colors: active) {
+  /* Pin keyboard focus to the system highlight so it survives regardless of the
+     (now-overridden) --focus-ring custom property. */
+  :focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  [role='button']:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+
+  /* Bins encode category (fill), selection and focus via background + box-shadow
+     — all flattened by forced-colors. Force a border on every bin so it stays a
+     distinguishable block (overrides the inline `border: none` on selected bins,
+     hence !important), and re-express selection/focus with a system outline.
+     Category differentiation in WHCM is handled separately by the pattern
+     overlay. */
+  [data-bin-id] {
+    border: 1px solid CanvasText !important;
+  }
+
+  [data-bin-id][aria-pressed='true'],
+  [data-bin-id]:focus-visible {
+    outline: 3px solid Highlight;
+    outline-offset: -3px;
+  }
 }
 
 /* ===========================================

--- a/src/index.css
+++ b/src/index.css
@@ -1239,14 +1239,20 @@ html[data-high-contrast='true'] :focus-visible {
    =========================================== */
 @media (forced-colors: active) {
   /* Pin keyboard focus to the system highlight so it survives regardless of the
-     (now-overridden) --focus-ring custom property. */
+     (now-overridden) --focus-ring custom property. `!important` is required
+     because some controls suppress the outline with `outline: none` /
+     Tailwind's `outline-none` utility and rely on a box-shadow ring — which
+     forced-colors drops — so without it those elements (notably the command
+     palette input, whose `[cmdk-input]:focus-visible` rule is more specific)
+     would have no visible focus indicator in WHCM. */
   :focus-visible,
   button:focus-visible,
   input:focus-visible,
   select:focus-visible,
   textarea:focus-visible,
-  [role='button']:focus-visible {
-    outline: 2px solid Highlight;
+  [role='button']:focus-visible,
+  [cmdk-input]:focus-visible {
+    outline: 2px solid Highlight !important;
     outline-offset: -2px;
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1266,9 +1266,12 @@ html[data-high-contrast='true'] :focus-visible {
     border: 1px solid CanvasText !important;
   }
 
+  /* !important so the thicker bin ring wins over the generic focus rule above
+     (which is also !important); specificity then breaks the tie in favor of
+     these bin-specific selectors. */
   [data-bin-id][aria-pressed='true'],
   [data-bin-id]:focus-visible {
-    outline: 3px solid Highlight;
+    outline: 3px solid Highlight !important;
     outline-offset: -3px;
   }
 }


### PR DESCRIPTION
## What & why

In **Windows High Contrast Mode** (`forced-colors: active`), the UA replaces author colors with the user's system palette and **drops `box-shadow` entirely**. This app signals bin **selection** and **focus** exclusively through inline `box-shadow` rings — so in WHCM, selected and keyboard-focused bins had *no visible indicator at all*, and the selected bin even sets `border: none`. Keyboard/low-vision users navigating the grid were flying blind.

## Changes

A single `@media (forced-colors: active)` block in `index.css`:
- **Selection & focus** → re-expressed as a 3px `Highlight` **outline** (`[aria-pressed='true']` and `:focus-visible`), since box-shadow is gone.
- **Bin borders** → every `[data-bin-id]` gets a `1px solid CanvasText` border (with `!important` to override the inline `border: none` on selected bins) so bins stay distinguishable blocks when all fills collapse to `Canvas`.
- **Focus rings** → pinned to system `Highlight` so they survive the overridden `--focus-ring` custom property.

Category differentiation in WHCM (all fills flatten to one color) is intentionally left to the upcoming pattern-overlay PR.

## Verification

Playwright `forcedColors: 'active'` emulation, bin drawn + selected:

| Normal | Forced-colors (WHCM) |
|---|---|
| Coral fill, gold box-shadow selection ring — **unchanged** | Fill/box-shadow flattened by the UA; selection now shown by a bright system `Highlight` outline |

Normal rendering is byte-for-byte unaffected (the rule is scoped entirely to `forced-colors: active`). Screenshots captured locally; the Vercel preview can be checked directly in Windows HCM.

## Notes

Visual PR — **holding for your review** before merge (no auto-merge armed). Part 3 of the accessibility series (#2503, #2504).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows High Contrast Mode support by replacing box-shadow cues with system outlines so selection and keyboard focus stay visible. Keeps the 3px bin ring and leaves normal rendering unchanged.

- **New Features**
  - Add `@media (forced-colors: active)` styles to re-express selection/focus with `Highlight` outlines.
  - Pin focus rings for all controls (including `[cmdk-input]`) with `!important` so they survive `outline: none`/`outline-none`.
  - Give bins a `1px solid CanvasText` border and mark the 3px bin outline `!important` to win over the generic rule.

<sup>Written for commit 5363757ecb983069d4e787dd0b410c57c23b1f6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

