### PR TITLE
test(a11y): extend axe coverage to modals and command palette

### DIFF
--- a/src/shell/AppShell.scenario.accessibility.test.tsx
+++ b/src/shell/AppShell.scenario.accessibility.test.tsx
@@ -44,10 +44,32 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 // jsdom does not implement scrollIntoView, which cmdk (command palette) calls
-// on mount when a list item becomes active. Shim it so the open palette renders.
+// on mount when a list item becomes active. Shim it only when absent so a real
+// implementation (future jsdom, or another test) is never clobbered.
 beforeEach(() => {
-  HTMLElement.prototype.scrollIntoView = vi.fn();
+  if (typeof HTMLElement.prototype.scrollIntoView !== 'function') {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+  }
 });
+
+// Critical axe rules — the single source of truth for every surface below.
+// Kept intentionally narrow so the gate doesn't retroactively fail on
+// pre-existing debt from rules we haven't remediated yet.
+const CRITICAL_RULES = {
+  'color-contrast': { enabled: true },
+  'button-name': { enabled: true },
+  'image-alt': { enabled: true },
+  label: { enabled: true },
+  'link-name': { enabled: true },
+} as const;
+
+async function expectNoCriticalViolations(container: HTMLElement, label: string) {
+  const results = await axe(container, { rules: CRITICAL_RULES });
+  if (results.violations.length > 0) {
+    console.warn(`${label} violations:`, JSON.stringify(results.violations, null, 2));
+  }
+  expect(results).toHaveNoViolations();
+}
 
 // Reset stores before each test
 beforeEach(() => {
@@ -82,36 +104,12 @@ beforeEach(() => {
 describe('Accessibility - Critical Issues', () => {
   it('Header has no critical accessibility violations', async () => {
     const { container } = render(<Header saveStatus="idle" />);
-    const results = await axe(container, {
-      rules: {
-        // Focus on critical issues
-        'color-contrast': { enabled: true },
-        'button-name': { enabled: true },
-        'image-alt': { enabled: true },
-        label: { enabled: true },
-        'link-name': { enabled: true },
-      },
-    });
-
-    // Log violations for debugging
-    if (results.violations.length > 0) {
-      console.warn('Header violations:', JSON.stringify(results.violations, null, 2));
-    }
-
-    expect(results).toHaveNoViolations();
+    await expectNoCriticalViolations(container, 'Header');
   }, 15_000);
 
   it('Sidebar has no critical accessibility violations', async () => {
     const { container } = render(<Sidebar />);
-    const results = await axe(container, {
-      rules: {
-        'color-contrast': { enabled: true },
-        'button-name': { enabled: true },
-        'image-alt': { enabled: true },
-        label: { enabled: true },
-        'link-name': { enabled: true },
-      },
-    });
+    const results = await axe(container, { rules: CRITICAL_RULES });
 
     // Layer rows intentionally nest interactive controls (rename span, height
     // steppers) inside a selectable container — accepted UX trade-off.
@@ -133,63 +131,18 @@ describe('Accessibility - Critical Issues', () => {
 
   it('RightPanel has no critical accessibility violations', async () => {
     const { container } = render(<RightPanel />);
-    const results = await axe(container, {
-      rules: {
-        'color-contrast': { enabled: true },
-        'button-name': { enabled: true },
-        'image-alt': { enabled: true },
-        label: { enabled: true },
-        'link-name': { enabled: true },
-      },
-    });
-
-    if (results.violations.length > 0) {
-      console.warn('RightPanel violations:', JSON.stringify(results.violations, null, 2));
-    }
-
-    expect(results).toHaveNoViolations();
+    await expectNoCriticalViolations(container, 'RightPanel');
   }, 15_000);
 
   it('Staging has no critical accessibility violations', async () => {
     const { container } = render(<Staging />);
-    const results = await axe(container, {
-      rules: {
-        'color-contrast': { enabled: true },
-        'button-name': { enabled: true },
-        'image-alt': { enabled: true },
-        label: { enabled: true },
-        'link-name': { enabled: true },
-      },
-    });
-
-    if (results.violations.length > 0) {
-      console.warn('Staging violations:', JSON.stringify(results.violations, null, 2));
-    }
-
-    expect(results).toHaveNoViolations();
+    await expectNoCriticalViolations(container, 'Staging');
   }, 15_000);
 });
 
 // Overlay surfaces (modals + command palette) trap focus and present dense
 // interactive content, so they are prime places for missing labels / unnamed
-// controls. Same critical rule set as the shell surfaces above so the gate
-// stays consistent and doesn't retroactively fail on pre-existing debt.
-const CRITICAL_RULES = {
-  'color-contrast': { enabled: true },
-  'button-name': { enabled: true },
-  'image-alt': { enabled: true },
-  label: { enabled: true },
-  'link-name': { enabled: true },
-} as const;
-
-async function expectNoCriticalViolations(container: HTMLElement, label: string) {
-  const results = await axe(container, { rules: CRITICAL_RULES });
-  if (results.violations.length > 0) {
-    console.warn(`${label} violations:`, JSON.stringify(results.violations, null, 2));
-  }
-  expect(results).toHaveNoViolations();
-}
-
+// controls. Same critical rule set as the shell surfaces above.
 describe('Accessibility - Overlays', () => {
   it('HelpModal (open) has no critical accessibility violations', async () => {
     const { container } = render(<HelpModal isOpen={true} onClose={vi.fn()} />);

--- a/src/shell/AppShell.scenario.accessibility.test.tsx
+++ b/src/shell/AppShell.scenario.accessibility.test.tsx
@@ -15,6 +15,9 @@ import { Header } from '@/shell/Header';
 import { Sidebar } from '@/shell/Sidebar';
 import { RightPanel } from '@/shell/RightPanel';
 import { Staging } from '@/features/staging/components/Staging';
+import { HelpModal } from '@/shell/Modals/HelpModal';
+import { ImportModal } from '@/shell/Modals/ImportModal';
+import { CommandPalette } from '@/features/command-palette';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSelectionStore } from '@/core/store/selection';
 import { useViewStore } from '@/core/store/view';
@@ -38,6 +41,12 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
   })),
+});
+
+// jsdom does not implement scrollIntoView, which cmdk (command palette) calls
+// on mount when a list item becomes active. Shim it so the open palette renders.
+beforeEach(() => {
+  HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 // Reset stores before each test
@@ -158,5 +167,44 @@ describe('Accessibility - Critical Issues', () => {
     }
 
     expect(results).toHaveNoViolations();
+  }, 15_000);
+});
+
+// Overlay surfaces (modals + command palette) trap focus and present dense
+// interactive content, so they are prime places for missing labels / unnamed
+// controls. Same critical rule set as the shell surfaces above so the gate
+// stays consistent and doesn't retroactively fail on pre-existing debt.
+const CRITICAL_RULES = {
+  'color-contrast': { enabled: true },
+  'button-name': { enabled: true },
+  'image-alt': { enabled: true },
+  label: { enabled: true },
+  'link-name': { enabled: true },
+} as const;
+
+async function expectNoCriticalViolations(container: HTMLElement, label: string) {
+  const results = await axe(container, { rules: CRITICAL_RULES });
+  if (results.violations.length > 0) {
+    console.warn(`${label} violations:`, JSON.stringify(results.violations, null, 2));
+  }
+  expect(results).toHaveNoViolations();
+}
+
+describe('Accessibility - Overlays', () => {
+  it('HelpModal (open) has no critical accessibility violations', async () => {
+    const { container } = render(<HelpModal isOpen={true} onClose={vi.fn()} />);
+    await expectNoCriticalViolations(container, 'HelpModal');
+  }, 15_000);
+
+  it('ImportModal (open) has no critical accessibility violations', async () => {
+    const { container } = render(
+      <ImportModal isOpen={true} onClose={vi.fn()} onImport={vi.fn()} />
+    );
+    await expectNoCriticalViolations(container, 'ImportModal');
+  }, 15_000);
+
+  it('CommandPalette (open) has no critical accessibility violations', async () => {
+    const { container } = render(<CommandPalette open={true} onOpenChange={vi.fn()} />);
+    await expectNoCriticalViolations(container, 'CommandPalette');
   }, 15_000);
 });


### PR DESCRIPTION
## What & why

The automated `vitest-axe` gate covered only four shell surfaces (Header, Sidebar, RightPanel, Staging). Overlays — modals and the command palette — trap focus and pack dense interactive content, which makes them the likeliest place for unnamed controls, missing labels, and contrast regressions to slip in.

## Changes

Extends `AppShell.scenario.accessibility.test.tsx` with axe checks for three overlay surfaces in their **open** state:
- Help modal
- Import modal
- Command palette

All use the **same critical rule set** as the existing surfaces (`color-contrast`, `button-name`, `image-alt`, `label`, `link-name`) — per the plan, we gate the new surfaces without turning on broader rules that would retroactively fail on pre-existing debt. Factored the shared config into a small `expectNoCriticalViolations` helper.

Also shims `HTMLElement.prototype.scrollIntoView` (a jsdom gap that `cmdk` calls on mount) — a missing-DOM-method polyfill, not a mocked runtime dependency.

## Verification

`pnpm test:run` on the file → **7/7 pass** (4 existing + 3 new). `pnpm typecheck` + `eslint` clean. All three overlays are already violation-free under the critical rules, so the gate passes today and guards against future regressions.

## Notes

Non-visual (tests only). Part 4 of the accessibility series.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends axe a11y tests to overlays (Help, Import, Command palette) in their open state, using the same critical rules as shell checks.
Centralizes rules via `CRITICAL_RULES` and a shared `expectNoCriticalViolations` (Sidebar still filters nested-interactive); also guards the jsdom `scrollIntoView` shim for `cmdk`.

<sup>Written for commit a82a8fc9c92576f6420bd7080a26f3f618617b03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

