### PR TITLE
feat(a11y): add screen-reader text alternative for the 3D preview

### DIFF
--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
@@ -18,6 +18,7 @@ import { useExplodedLayerView } from '@/shared/hooks/useExplodedLayerView';
 import { useTranslation } from '@/i18n';
 import { useSettingsStore } from '@/core/store/settings';
 import { useBinsToRender } from './useBinsToRender';
+import { getPreviewSummary } from './previewSummary';
 import { usePreviewSize } from './usePreviewSize';
 import { IsometricPreviewControls } from './IsometricPreviewControls';
 import { BinOverlayGroup } from './BinOverlayGroup';
@@ -115,6 +116,19 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
   // Calculate height-to-grid scale from user settings
   const heightToGridScale = heightUnitMm / gridUnitMm;
   const activeLayerId = useSelectionStore((state) => state.activeLayerId);
+
+  // Text alternative for the WebGL canvas, which is opaque to assistive tech.
+  const previewSummaryText = useMemo(() => {
+    const summary = getPreviewSummary({ bins, layers, drawer });
+    return summary.isEmpty
+      ? t('grid.preview.summaryEmpty')
+      : t('grid.preview.summary', {
+          binCount: summary.binCount,
+          layerCount: summary.layerCount,
+          drawerWidth: summary.drawerWidth,
+          drawerDepth: summary.drawerDepth,
+        });
+  }, [bins, layers, drawer, t]);
 
   // Keyboard shortcuts for 3D preview navigation (after layout store so `layers` is available)
   use3DPreviewKeyboard({
@@ -271,6 +285,10 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
         zIndex: isPreviewExpanded ? undefined : inline ? undefined : 20,
       }}
     >
+      {/* Screen-reader description of the 3D scene; the canvas itself exposes no
+          accessible content. Not aria-live — read on demand, not announced on
+          every edit. */}
+      <p className="sr-only">{previewSummaryText}</p>
       <Canvas
         orthographic
         camera={{

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
@@ -285,11 +285,14 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
         zIndex: isPreviewExpanded ? undefined : inline ? undefined : 20,
       }}
     >
-      {/* Screen-reader description of the 3D scene; the canvas itself exposes no
-          accessible content. Not aria-live — read on demand, not announced on
-          every edit. */}
-      <p className="sr-only">{previewSummaryText}</p>
+      {/* Label the canvas region itself (react-three-fiber spreads these onto its
+          container element) so a screen reader that lands on the otherwise
+          content-less canvas hears the layout description. role="img" keeps it a
+          single labeled node rather than exposing an empty canvas. Not aria-live
+          — read on demand, not announced on every edit. */}
       <Canvas
+        role="img"
+        aria-label={previewSummaryText}
         orthographic
         camera={{
           position: [10, 10, 10],

--- a/src/features/grid-editor/components/Grid/IsometricPreview/previewSummary.test.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/previewSummary.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getPreviewSummary } from './previewSummary';
+import { STAGING_ID } from '@/core/constants';
 import { createTestLayout, createTestBin } from '@/test/testUtils';
 
 describe('getPreviewSummary', () => {
@@ -28,5 +29,29 @@ describe('getPreviewSummary', () => {
     });
     expect(summary.drawerWidth).toBe(10);
     expect(summary.drawerDepth).toBe(8);
+  });
+
+  it('excludes staging (off-grid stash) bins, which the preview does not render', () => {
+    const layout = createTestLayout({
+      bins: [
+        createTestBin({ id: 'placed' }),
+        createTestBin({ id: 'stashed-1', layerId: STAGING_ID }),
+        createTestBin({ id: 'stashed-2', layerId: STAGING_ID }),
+      ],
+    });
+
+    const summary = getPreviewSummary(layout);
+    expect(summary.binCount).toBe(1);
+    expect(summary.isEmpty).toBe(false);
+  });
+
+  it('reports empty when only staging bins exist', () => {
+    const layout = createTestLayout({
+      bins: [createTestBin({ id: 'stashed', layerId: STAGING_ID })],
+    });
+
+    const summary = getPreviewSummary(layout);
+    expect(summary.binCount).toBe(0);
+    expect(summary.isEmpty).toBe(true);
   });
 });

--- a/src/features/grid-editor/components/Grid/IsometricPreview/previewSummary.test.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/previewSummary.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { getPreviewSummary } from './previewSummary';
+import { createTestLayout, createTestBin } from '@/test/testUtils';
+
+describe('getPreviewSummary', () => {
+  it('reports empty when no bins are placed', () => {
+    const layout = createTestLayout({ bins: [] });
+    const summary = getPreviewSummary(layout);
+
+    expect(summary.isEmpty).toBe(true);
+    expect(summary.binCount).toBe(0);
+  });
+
+  it('counts bins and layers and reads drawer dimensions', () => {
+    // createTestLayout defaults: 10x8 drawer, one layer.
+    const layout = createTestLayout({
+      bins: [createTestBin({ id: 'a' }), createTestBin({ id: 'b' }), createTestBin({ id: 'c' })],
+    });
+
+    const summary = getPreviewSummary(layout);
+
+    expect(summary).toEqual({
+      isEmpty: false,
+      binCount: 3,
+      layerCount: layout.layers.length,
+      drawerWidth: layout.drawer.width,
+      drawerDepth: layout.drawer.depth,
+    });
+    expect(summary.drawerWidth).toBe(10);
+    expect(summary.drawerDepth).toBe(8);
+  });
+});

--- a/src/features/grid-editor/components/Grid/IsometricPreview/previewSummary.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/previewSummary.ts
@@ -1,3 +1,4 @@
+import { STAGING_ID } from '@/core/constants';
 import type { Layout } from '@/core/types';
 
 /**
@@ -18,9 +19,16 @@ export interface PreviewSummary {
 export function getPreviewSummary(
   layout: Pick<Layout, 'bins' | 'layers' | 'drawer'>
 ): PreviewSummary {
+  // Staging bins live in the off-grid stash and are not rendered in the 3D
+  // preview, so they must not be counted in its description.
+  const placedBinCount = layout.bins.reduce(
+    (count, bin) => (bin.layerId === STAGING_ID ? count : count + 1),
+    0
+  );
+
   return {
-    isEmpty: layout.bins.length === 0,
-    binCount: layout.bins.length,
+    isEmpty: placedBinCount === 0,
+    binCount: placedBinCount,
     layerCount: layout.layers.length,
     drawerWidth: layout.drawer.width,
     drawerDepth: layout.drawer.depth,

--- a/src/features/grid-editor/components/Grid/IsometricPreview/previewSummary.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/previewSummary.ts
@@ -1,0 +1,28 @@
+import type { Layout } from '@/core/types';
+
+/**
+ * Interpolation values for the screen-reader description of the 3D preview.
+ * The WebGL canvas is opaque to assistive tech, so this feeds a visually
+ * hidden text alternative that conveys the same gestalt (how full the drawer
+ * is, how many layers, how big the grid). Describes the whole layout rather
+ * than the currently-rendered layer subset so the overview stays stable.
+ */
+export interface PreviewSummary {
+  isEmpty: boolean;
+  binCount: number;
+  layerCount: number;
+  drawerWidth: number;
+  drawerDepth: number;
+}
+
+export function getPreviewSummary(
+  layout: Pick<Layout, 'bins' | 'layers' | 'drawer'>
+): PreviewSummary {
+  return {
+    isEmpty: layout.bins.length === 0,
+    binCount: layout.bins.length,
+    layerCount: layout.layers.length,
+    drawerWidth: layout.drawer.width,
+    drawerDepth: layout.drawer.depth,
+  };
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "Vorschau schließen",
   "grid.preview.collapse": "Vorschau einklappen",
   "grid.preview.expand": "Vorschau ausklappen",
+  "grid.preview.summary": "3D-Layout-Vorschau: {binCount} Bins über {layerCount} Ebenen, Schublade {drawerWidth} mal {drawerDepth} Rastereinheiten",
+  "grid.preview.summaryEmpty": "3D-Layout-Vorschau: leer, noch keine Bins platziert",
   "grid.resizeGrid": "Raster anpassen",
   "grid.resizeWillStashBins": "{count} Bin(s) werden in den Stash verschoben. Fortfahren?",
   "grid.side": "Seite",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1389,6 +1389,9 @@ const en: Record<string, string> = {
   'grid.preview.close': 'Close preview',
   'grid.preview.collapse': 'Collapse preview',
   'grid.preview.expand': 'Expand preview',
+  'grid.preview.summary':
+    '3D layout preview: {binCount} bins across {layerCount} layers, drawer {drawerWidth} by {drawerDepth} grid units',
+  'grid.preview.summaryEmpty': '3D layout preview: empty, no bins placed yet',
   'grid.resizeGrid': 'Resize grid',
   'grid.side': 'Side',
   'grid.sideView': 'Side view',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "Cerrar vista previa",
   "grid.preview.collapse": "Contraer vista previa",
   "grid.preview.expand": "Expandir vista previa",
+  "grid.preview.summary": "Vista previa 3D del diseño: {binCount} bins en {layerCount} capas, cajón de {drawerWidth} por {drawerDepth} unidades de cuadrícula",
+  "grid.preview.summaryEmpty": "Vista previa 3D del diseño: vacía, aún no hay bins colocados",
   "grid.resizeGrid": "Redimensionar cuadrícula",
   "grid.resizeWillStashBins": "{count} bin(s) se moverán a la reserva. ¿Continuar?",
   "grid.side": "Lateral",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "Fermer l'aperçu",
   "grid.preview.collapse": "Réduire l'aperçu",
   "grid.preview.expand": "Développer l'aperçu",
+  "grid.preview.summary": "Aperçu 3D de la disposition : {binCount} bins sur {layerCount} couches, tiroir de {drawerWidth} par {drawerDepth} unités de grille",
+  "grid.preview.summaryEmpty": "Aperçu 3D de la disposition : vide, aucun bin placé pour le moment",
   "grid.resizeGrid": "Redimensionner la grille",
   "grid.resizeWillStashBins": "{count} bin(s) seront déplacés vers la réserve. Continuer ?",
   "grid.side": "Côté",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "プレビューを閉じる",
   "grid.preview.collapse": "プレビューを折りたたむ",
   "grid.preview.expand": "プレビューを展開",
+  "grid.preview.summary": "3Dレイアウトプレビュー: {layerCount}レイヤーにわたる{binCount}個のビン、引き出し {drawerWidth}×{drawerDepth} グリッド単位",
+  "grid.preview.summaryEmpty": "3Dレイアウトプレビュー: 空、ビンはまだ配置されていません",
   "grid.resizeGrid": "グリッドをリサイズ",
   "grid.resizeWillStashBins": "{count}個のビンがステージングに移動されます。続行しますか?",
   "grid.side": "側面",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "Lukk forhåndsvisning",
   "grid.preview.collapse": "Skjul forhåndsvisning",
   "grid.preview.expand": "Utvid forhåndsvisning",
+  "grid.preview.summary": "3D-layoutforhåndsvisning: {binCount} bins over {layerCount} lag, skuff på {drawerWidth} ganger {drawerDepth} rutenettenheter",
+  "grid.preview.summaryEmpty": "3D-layoutforhåndsvisning: tom, ingen bins plassert ennå",
   "grid.resizeGrid": "Endre størrelse på rutenett",
   "grid.resizeWillStashBins": "{count} bin(s) flyttes til stash. Fortsette?",
   "grid.side": "Side",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "Preview sluiten",
   "grid.preview.collapse": "Preview invouwen",
   "grid.preview.expand": "Preview uitvouwen",
+  "grid.preview.summary": "3D-lay-outvoorbeeld: {binCount} bins over {layerCount} lagen, lade van {drawerWidth} bij {drawerDepth} rastereenheden",
+  "grid.preview.summaryEmpty": "3D-lay-outvoorbeeld: leeg, nog geen bins geplaatst",
   "grid.resizeGrid": "Grid formaat wijzigen",
   "grid.resizeWillStashBins": "{count} bin(s) worden naar stash verplaatst. Doorgaan?",
   "grid.side": "Zijkant",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "Fechar pré-visualização",
   "grid.preview.collapse": "Recolher pré-visualização",
   "grid.preview.expand": "Expandir pré-visualização",
+  "grid.preview.summary": "Pré-visualização 3D do layout: {binCount} bins em {layerCount} camadas, gaveta de {drawerWidth} por {drawerDepth} unidades de grade",
+  "grid.preview.summaryEmpty": "Pré-visualização 3D do layout: vazia, nenhum bin colocado ainda",
   "grid.resizeGrid": "Redimensionar grade",
   "grid.resizeWillStashBins": "{count} bin(s) serão movidos para a área de espera. Continuar?",
   "grid.side": "Lateral",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "Stäng förhandsvisning",
   "grid.preview.collapse": "Komprimera förhandsvisning",
   "grid.preview.expand": "Expandera förhandsvisning",
+  "grid.preview.summary": "3D-layoutförhandsvisning: {binCount} fack över {layerCount} lager, låda på {drawerWidth} gånger {drawerDepth} rutnätsenheter",
+  "grid.preview.summaryEmpty": "3D-layoutförhandsvisning: tom, inga fack placerade ännu",
   "grid.resizeGrid": "Ändra storlek på rutnät",
   "grid.resizeWillStashBins": "{count} bin(s) flyttas till stash. Fortsätt?",
   "grid.side": "Sida",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1398,6 +1398,8 @@
   "grid.preview.close": "Закрити перегляд",
   "grid.preview.collapse": "Згорнути перегляд",
   "grid.preview.expand": "Розгорнути перегляд",
+  "grid.preview.summary": "3D-перегляд розкладки: {binCount} бінів у {layerCount} шарах, шухляда {drawerWidth} на {drawerDepth} одиниць сітки",
+  "grid.preview.summaryEmpty": "3D-перегляд розкладки: порожньо, біни ще не розміщені",
   "grid.resizeGrid": "Змінити розмір сітки",
   "grid.resizeWillStashBins": "{count} бін(ів) буде переміщено в архів. Продовжити?",
   "grid.side": "Збоку",


### PR DESCRIPTION
## What & why

The isometric 3D preview renders into a bare WebGL `<canvas>`, which exposes **no accessible content** — screen-reader users got nothing from it. This gives the canvas a text alternative conveying the same gestalt (how full the drawer is, how many layers, how big the grid).

## Changes

- **`previewSummary.ts`** — pure `getPreviewSummary(layout)` helper returning `{ isEmpty, binCount, layerCount, drawerWidth, drawerDepth }`. Counts only **placed** bins (excludes off-grid `__staging__` stash, which the preview doesn't render) and describes the whole layout so the overview stays stable across view modes.
- **`IsometricPreview.tsx`** — labels the canvas region itself via `role="img"` + `aria-label={summary}` on the react-three-fiber `<Canvas>` (r3f spreads these onto its container element), so a screen reader that lands on the otherwise content-less canvas hears the description. Uses `grid.preview.summary` / `…summaryEmpty`. **Not `aria-live`** — read on demand, no chatter on every edit.
- **i18n** — 2 new keys across all 9 locales.

## Verification

- `previewSummary.test.ts` (empty, populated, staging-only, mixed-staging) → pass; typecheck + all 4 i18n checks clean.
- **End-to-end** via Playwright: enabled the preview and confirmed a `role="img"` node with accessible name `"3D layout preview: empty, no bins placed yet"`; after drawing a bin it reads `"3D layout preview: 1 bins across 1 layers, drawer 10 by 8 grid units"`.

## Notes

Visually non-visual (assistive-tech only) — no on-screen change. "1 bins" plural imperfection intentionally matches the repo's existing non-ICU convention (`staging.binCount`). Part 5 of the accessibility series.