### PR TITLE
feat(a11y): distinguish bin categories by pattern, not color alone

### DIFF
--- a/src/features/grid-editor/components/Grid/Bin/Bin.tsx
+++ b/src/features/grid-editor/components/Grid/Bin/Bin.tsx
@@ -1,10 +1,11 @@
 import { memo, useState, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { useLayoutStore, useInteractionStore } from '@/core/store';
+import { useLayoutStore, useInteractionStore, useSettingsStore } from '@/core/store';
 import { useResponsive } from '@/shared/hooks';
 import { useTranslation } from '@/i18n';
 import { calcMaxGridUnits, DEFAULT_CATEGORY_COLOR } from '@/core/constants';
-import { getBinTextColors } from '@/shared/utils';
+import { getBinTextColors, getBinPatternColor } from '@/shared/utils';
+import { getCategoryPatternIndex, getCategoryPatternStyle } from './categoryPatterns';
 import { ResizeHandles } from '../ResizeHandles';
 import { calculateBinLayout } from './calculateBinLayout';
 import { calculateBinText } from './calculateBinText';
@@ -187,6 +188,19 @@ function BinComponent({
   const bgColor = category?.color || DEFAULT_CATEGORY_COLOR;
   const textColors = getBinTextColors(bgColor);
 
+  // Accessibility: distinguish categories by a per-category texture, not color
+  // alone. Applied as a background-image layer on the fill so labels stay above.
+  const distinguishByPattern = useSettingsStore(
+    (state) => state.settings.distinguishCategoriesByPattern
+  );
+  const categoryPattern = useMemo(() => {
+    if (!distinguishByPattern || isGhost || !category) return null;
+    return getCategoryPatternStyle(
+      getCategoryPatternIndex(category.id),
+      getBinPatternColor(bgColor)
+    );
+  }, [distinguishByPattern, isGhost, category, bgColor]);
+
   const visualStyles = useMemo(() => {
     let boxShadow = 'var(--shadow-sm)';
     if (isGhost) {
@@ -256,6 +270,7 @@ function BinComponent({
             }
           : {}),
         backgroundColor: bgColor,
+        ...(categoryPattern ?? {}),
         borderRadius: 'var(--radius-sm)',
         border: isSelected ? 'none' : '1px solid var(--border-on-color)',
         cursor: isGhost ? 'default' : 'grab',

--- a/src/features/grid-editor/components/Grid/Bin/Bin.tsx
+++ b/src/features/grid-editor/components/Grid/Bin/Bin.tsx
@@ -193,13 +193,14 @@ function BinComponent({
   const distinguishByPattern = useSettingsStore(
     (state) => state.settings.distinguishCategoriesByPattern
   );
+  const categoryId = category?.id;
   const categoryPattern = useMemo(() => {
-    if (!distinguishByPattern || isGhost || !category) return null;
+    if (!distinguishByPattern || isGhost || categoryId === undefined) return null;
     return getCategoryPatternStyle(
-      getCategoryPatternIndex(category.id),
+      getCategoryPatternIndex(categoryId),
       getBinPatternColor(bgColor)
     );
-  }, [distinguishByPattern, isGhost, category, bgColor]);
+  }, [distinguishByPattern, isGhost, categoryId, bgColor]);
 
   const visualStyles = useMemo(() => {
     let boxShadow = 'var(--shadow-sm)';
@@ -328,6 +329,7 @@ function BinComponent({
           cellSize={cellSize}
           gap={gap}
           color={bgColor}
+          patternStyle={categoryPattern}
         />
       )}
 

--- a/src/features/grid-editor/components/Grid/Bin/BinMarginExtension.tsx
+++ b/src/features/grid-editor/components/Grid/Bin/BinMarginExtension.tsx
@@ -15,6 +15,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store';
 import { binMarginSides } from '@/shared/utils/drawerMargin';
 import type { Bin, Drawer } from '@/core/types';
+import type { CategoryPatternStyle } from './categoryPatterns';
 
 interface BinMarginExtensionProps {
   bin: Bin;
@@ -23,9 +24,20 @@ interface BinMarginExtensionProps {
   gap: number;
   /** The bin's category color — the extension paints the same so it reads as one bin. */
   color: string;
+  /** Category pattern overlay, when enabled — kept in sync with the bin's fill
+   * so the accessibility texture covers the whole visible footprint, not just
+   * the interactive box. */
+  patternStyle?: CategoryPatternStyle | null;
 }
 
-export function BinMarginExtension({ bin, drawer, cellSize, gap, color }: BinMarginExtensionProps) {
+export function BinMarginExtension({
+  bin,
+  drawer,
+  cellSize,
+  gap,
+  color,
+  patternStyle,
+}: BinMarginExtensionProps) {
   const { baseplate, gridUnitMm } = useLayoutStore(
     useShallow((s) => ({
       baseplate: s.layout.baseplateParams,
@@ -52,6 +64,7 @@ export function BinMarginExtension({ bin, drawer, cellSize, gap, color }: BinMar
         top: -toPx(sides.back),
         bottom: -toPx(sides.front),
         backgroundColor: color,
+        ...(patternStyle ?? {}),
         zIndex: -1,
       }}
     />

--- a/src/features/grid-editor/components/Grid/Bin/categoryPatterns.test.ts
+++ b/src/features/grid-editor/components/Grid/Bin/categoryPatterns.test.ts
@@ -18,12 +18,13 @@ describe('getCategoryPatternIndex', () => {
     }
   });
 
-  it('does not depend on order (id-based, reorder-stable)', () => {
-    // The index is a pure function of the id, so it is unaffected by where the
-    // category sits in any list.
-    const before = getCategoryPatternIndex('hardware');
-    const after = getCategoryPatternIndex('hardware');
-    expect(before).toBe(after);
+  it('distributes distinct ids across multiple patterns', () => {
+    // A pure id→index mapping is what makes assignment reorder-stable; verify it
+    // actually differentiates rather than collapsing every category to one
+    // pattern (which would defeat the point).
+    const ids = ['coral', 'sky', 'green', 'cloud', 'charcoal', 'hardware', 'screws', 'bolts'];
+    const distinct = new Set(ids.map(getCategoryPatternIndex));
+    expect(distinct.size).toBeGreaterThan(1);
   });
 });
 

--- a/src/features/grid-editor/components/Grid/Bin/categoryPatterns.test.ts
+++ b/src/features/grid-editor/components/Grid/Bin/categoryPatterns.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CATEGORY_PATTERN_COUNT,
+  getCategoryPatternIndex,
+  getCategoryPatternStyle,
+} from './categoryPatterns';
+
+describe('getCategoryPatternIndex', () => {
+  it('is deterministic for the same id', () => {
+    expect(getCategoryPatternIndex('coral')).toBe(getCategoryPatternIndex('coral'));
+  });
+
+  it('always returns an index within range', () => {
+    for (const id of ['coral', 'sky', 'green', 'cloud', 'charcoal', 'a', '', 'x'.repeat(64)]) {
+      const idx = getCategoryPatternIndex(id);
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(CATEGORY_PATTERN_COUNT);
+    }
+  });
+
+  it('does not depend on order (id-based, reorder-stable)', () => {
+    // The index is a pure function of the id, so it is unaffected by where the
+    // category sits in any list.
+    const before = getCategoryPatternIndex('hardware');
+    const after = getCategoryPatternIndex('hardware');
+    expect(before).toBe(after);
+  });
+});
+
+describe('getCategoryPatternStyle', () => {
+  it('returns a non-empty background for every pattern index', () => {
+    for (let i = 0; i < CATEGORY_PATTERN_COUNT; i++) {
+      const style = getCategoryPatternStyle(i, 'rgba(0,0,0,0.4)');
+      expect(style.backgroundImage).not.toBe('none');
+      expect(style.backgroundImage).toContain('rgba(0,0,0,0.4)');
+    }
+  });
+
+  it('handles out-of-range and negative indices safely', () => {
+    expect(getCategoryPatternStyle(CATEGORY_PATTERN_COUNT, 'red').backgroundImage).not.toBe('none');
+    expect(getCategoryPatternStyle(-1, 'red').backgroundImage).not.toBe('none');
+  });
+});

--- a/src/features/grid-editor/components/Grid/Bin/categoryPatterns.ts
+++ b/src/features/grid-editor/components/Grid/Bin/categoryPatterns.ts
@@ -1,0 +1,69 @@
+/**
+ * CSS pattern overlays used to distinguish bin categories by texture, not color
+ * alone (WCAG 1.4.1 — for colorblind / low-vision users). Applied as a
+ * background-image layer on the bin fill, so patterns sit behind labels.
+ *
+ * Assignment is derived from the category id (not its list position) so a
+ * category keeps the same pattern when categories are reordered.
+ */
+
+export interface CategoryPatternStyle {
+  backgroundImage: string;
+  backgroundSize: string;
+}
+
+/** Number of visually distinct patterns available. */
+export const CATEGORY_PATTERN_COUNT = 10;
+
+/**
+ * Stable pattern index for a category id. Deterministic and independent of the
+ * category's order in the list, so reordering never reshuffles patterns.
+ */
+export function getCategoryPatternIndex(categoryId: string): number {
+  let hash = 0;
+  for (let i = 0; i < categoryId.length; i++) {
+    hash = (Math.imul(hash, 31) + categoryId.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % CATEGORY_PATTERN_COUNT;
+}
+
+/**
+ * Build the CSS background layer(s) for a pattern index, drawn in `color`.
+ * Each entry is a distinct texture (diagonals, lines, dots, grids) so adjacent
+ * categories stay easy to tell apart.
+ */
+export function getCategoryPatternStyle(index: number, color: string): CategoryPatternStyle {
+  const line = (angle: number, gap: number, width = 1.5): string =>
+    `repeating-linear-gradient(${angle}deg, ${color} 0, ${color} ${width}px, transparent ${width}px, transparent ${gap}px)`;
+
+  switch (((index % CATEGORY_PATTERN_COUNT) + CATEGORY_PATTERN_COUNT) % CATEGORY_PATTERN_COUNT) {
+    case 0: // forward diagonal hatch
+      return { backgroundImage: line(45, 7), backgroundSize: 'auto' };
+    case 1: // back diagonal hatch
+      return { backgroundImage: line(-45, 7), backgroundSize: 'auto' };
+    case 2: // vertical lines
+      return { backgroundImage: line(90, 7), backgroundSize: 'auto' };
+    case 3: // horizontal lines
+      return { backgroundImage: line(0, 7), backgroundSize: 'auto' };
+    case 4: // dots
+      return {
+        backgroundImage: `radial-gradient(${color} 1.3px, transparent 1.6px)`,
+        backgroundSize: '8px 8px',
+      };
+    case 5: // cross-hatch (both diagonals)
+      return { backgroundImage: `${line(45, 8)}, ${line(-45, 8)}`, backgroundSize: 'auto' };
+    case 6: // grid (vertical + horizontal)
+      return { backgroundImage: `${line(90, 8)}, ${line(0, 8)}`, backgroundSize: 'auto' };
+    case 7: // dense forward diagonal
+      return { backgroundImage: line(45, 4, 1), backgroundSize: 'auto' };
+    case 8: // wide back diagonal
+      return { backgroundImage: line(-45, 11, 2.5), backgroundSize: 'auto' };
+    case 9: // coarse thick grid (distinct from the fine grid of case 6)
+      return {
+        backgroundImage: `${line(0, 12, 2.5)}, ${line(90, 12, 2.5)}`,
+        backgroundSize: 'auto',
+      };
+    default:
+      return { backgroundImage: 'none', backgroundSize: 'auto' };
+  }
+}

--- a/src/shared/utils/color.test.ts
+++ b/src/shared/utils/color.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getContrastColor } from '@/shared/utils';
+import { getContrastColor, getBinPatternColor } from '@/shared/utils';
 
 describe('getContrastColor', () => {
   describe('light backgrounds should return dark text', () => {
@@ -69,5 +69,22 @@ describe('getContrastColor', () => {
       // #f00 should be treated as #ff0000 (red → light text)
       expect(getContrastColor('#f00')).toBe('var(--text-on-dark)');
     });
+  });
+});
+
+describe('getBinPatternColor', () => {
+  it('uses dark ink on light fills so the texture stays visible', () => {
+    expect(getBinPatternColor('#ffffff')).toBe('rgba(0, 0, 0, 0.42)');
+    expect(getBinPatternColor('#ffff00')).toBe('rgba(0, 0, 0, 0.42)'); // yellow reads as light
+  });
+
+  it('uses light ink on dark fills', () => {
+    expect(getBinPatternColor('#000000')).toBe('rgba(255, 255, 255, 0.48)');
+    expect(getBinPatternColor('#0000ff')).toBe('rgba(255, 255, 255, 0.48)'); // blue reads as dark
+  });
+
+  it('handles 3-char hex colors', () => {
+    expect(getBinPatternColor('#fff')).toBe('rgba(0, 0, 0, 0.42)');
+    expect(getBinPatternColor('#000')).toBe('rgba(255, 255, 255, 0.48)');
   });
 });

--- a/src/shared/utils/color.ts
+++ b/src/shared/utils/color.ts
@@ -31,6 +31,16 @@ export function getContrastColor(hexColor: string): string {
 }
 
 /**
+ * Pattern stroke color for the category-pattern overlay, chosen to stay visible
+ * on top of the bin fill: a translucent dark ink on light fills, light ink on
+ * dark fills. Alpha is kept moderate so the pattern reads as texture without
+ * obscuring labels.
+ */
+export function getBinPatternColor(hexColor: string): string {
+  return getLuminance(hexColor) > 0.5 ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.48)';
+}
+
+/**
  * Get adaptive text colors for bin labels.
  * Returns softer colors with primary/secondary/shadow variants.
  */

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -3,7 +3,7 @@
  * These utilities are pure functions that don't depend on specific business logic.
  */
 
-export { getContrastColor, getBinTextColors } from './color';
+export { getContrastColor, getBinTextColors, getBinPatternColor } from './color';
 export type { BinTextColors } from './color';
 
 export {


### PR DESCRIPTION
## What & why

On the 2D grid, categories are distinguished by **fill color alone** — invisible to colorblind users and hard for low-vision users (WCAG 1.4.1). This adds an opt-in per-category **texture** so categories are tellable apart without relying on color.

Gated by the **"Distinguish categories by pattern"** toggle added in the Accessibility settings PR (this PR is **stacked on `feat/a11y-settings`** — retarget to `main` once that merges).

## Changes

- **`categoryPatterns.ts`** — 10 visually distinct CSS patterns (diagonals at several angles/densities, vertical/horizontal lines, dots, cross-hatch, fine + coarse grids). `getCategoryPatternIndex(id)` hashes the **category id** → stable across category reordering.
- **`color.ts`** — `getBinPatternColor()` picks translucent dark/light ink by fill luminance so the texture reads on any bin color.
- **`Bin.tsx`** — when the setting is on, applies the pattern as a `background-image` layer on the fill. Backgrounds paint behind child content, so labels/badges need no z-index changes; ghosts are excluded.

## Verification

- `categoryPatterns.test.ts` (determinism, in-range, reorder-stability, every index yields a non-empty background, negative/overflow safe) + existing Bin/color tests → **81 pass**; typecheck + lint clean.
- **Rendered check** (screenshot): with the toggle on, drew bins in three categories — Green showed horizontal stripes, the light-fill categories showed dots/grid, clearly distinguishable beyond color. Adjusted the 10th pattern from a second dot variant to a coarse grid after the check flagged two dot styles as too similar.

## Notes

Visual PR — **holding for your review** (no auto-merge armed). Final part (7) of the accessibility series; completes the color-independence work started by #2505 (forced-colors) and #2510 (settings).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-category texture overlays to bins so categories are distinguishable without relying on color, improving accessibility (WCAG 1.4.1). Controlled by the Accessibility setting "Distinguish categories by pattern".

- **New Features**
  - 10 CSS patterns (diagonals, lines, dots, grids) applied as a background-image.
  - Pattern index is derived from the category id; stable across reordering.
  - Ink adapts to fill luminance; applied to the bin and its margin extension; labels stay clear; ghost bins are excluded.
  - Tests cover determinism, safe bounds, distribution across patterns, and `getBinPatternColor` (light/dark, 3-char hex); memo now depends on category id only.

<sup>Written for commit 21868ef14d28335a097fbcaeada34e2c40193951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

