### PR TITLE
chore(deps): adopt TypeScript 7 native compiler (tsgo) for typecheck and build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "dev": "pnpm run build:content && pnpm run build:en-locale && vite",
-    "build": "pnpm run build:content && pnpm run build:en-locale && tsc -b && vite build && tsx scripts/build-route-entries.ts",
+    "build": "pnpm run build:content && pnpm run build:en-locale && tsgo -b && vite build && tsx scripts/build-route-entries.ts",
     "build:content": "tsx scripts/build-content.ts",
     "gen:seo-images": "tsx scripts/gen-seo-images.ts",
     "gen:supporters-meshes": "tsx --tsconfig tsconfig.app.json scripts/gen-supporters-meshes.ts",
@@ -64,7 +64,7 @@
     "bench:json": "vitest bench --outputJson benchmarks/latest.json",
     "knip": "knip",
     "knip:fix": "knip --fix",
-    "typecheck": "tsc -b --noEmit",
+    "typecheck": "tsgo -b --noEmit",
     "quality": "pnpm run typecheck && pnpm run lint && pnpm run knip",
     "test:profile": "pnpm run build:en-locale && tsx scripts/profile-tests.ts"
   },
@@ -166,6 +166,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.185.0",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@vercel/node": "^5.8.22",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@types/three':
         specifier: ^0.185.0
         version: 0.185.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
       '@vercel/node':
         specifier: ^5.8.22
         version: 5.8.22(rollup@2.80.0)
@@ -2594,6 +2597,53 @@ packages:
   '@typescript-eslint/visitor-keys@8.62.0':
     resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
@@ -8094,6 +8144,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.62.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,9 +15,10 @@ minimumReleaseAgeExclude:
   - '@types/*'
   - '@typescript-eslint/*'
   - typescript-eslint
-  # @typescript/native-preview (the tsgo native compiler) publishes dated dev
-  # builds daily, so a fixed cooldown would perpetually block the newest one.
-  - '@typescript/*'
+  # @typescript/native-preview (the tsgo native compiler, incl. its
+  # per-platform binary packages) publishes dated dev builds daily, so a fixed
+  # cooldown would perpetually block the newest one.
+  - '@typescript/native-preview*'
   - '@posthog/*'
   - posthog-js
   - '@vercel/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,9 @@ minimumReleaseAgeExclude:
   - '@types/*'
   - '@typescript-eslint/*'
   - typescript-eslint
+  # @typescript/native-preview (the tsgo native compiler) publishes dated dev
+  # builds daily, so a fixed cooldown would perpetually block the newest one.
+  - '@typescript/*'
   - '@posthog/*'
   - posthog-js
   - '@vercel/*'


### PR DESCRIPTION
## What

Adopts TypeScript 7 (the native Go compiler, `tsgo`) for type-checking and the build's type-check step, **side-by-side** with the existing `typescript@6` toolchain — rather than a wholesale swap.

## Why not a straight bump

TypeScript 7's package no longer exposes the classic JS Compiler API (`import * as ts` → `createProgram` / `TypeChecker`); its `.` export is just a version string, with a new `./unstable/*` API. Our type-aware lint stack (`typescript-eslint`, peer capped at `<6.1.0`) and `knip` both consume the classic API, so replacing `typescript@6` outright would break `lint`, `knip`, and the pre-commit hooks.

## The split

| Task | Compiler |
| --- | --- |
| `typecheck` (`tsgo -b --noEmit`), `build` (`tsgo -b`) | native TS7 via `@typescript/native-preview` |
| `lint`, `knip` | `typescript@6` (classic Compiler API, kept in devDeps) |

## Changes

- `package.json`: `typecheck` / `build` type-check step → `tsgo`; add `@typescript/native-preview`
- `pnpm-workspace.yaml`: exclude `@typescript/*` from the supply-chain release-age cooldown (native-preview ships dated dev builds daily, so a fixed cooldown would perpetually block the newest)

## Verification

- `typecheck`: exit 0, **~1.6s vs 12.8s** cold with tsc — parity confirmed (both compilers pass the codebase clean)
- `build`'s `tsgo -b`: emit mode works (composite `api` declarations)
- `lint`: 0 errors (unchanged, TS6 API); `knip`: clean

## Follow-up

Full migration to `typescript@7` (dropping TS6) waits on `typescript-eslint` and `knip` supporting the native port.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted TypeScript 7’s native compiler `tsgo` for type-checking and build while keeping `typescript@6` for tools that need the classic API. This speeds up typecheck (~1.6s vs 12.8s) with no changes to lints or code.

- **Refactors**
  - Switched `typecheck` and `build` scripts to `tsgo -b` (emit for composite declarations).
  - Kept `lint`/`knip` on `typescript@6` to support the classic Compiler API.

- **Dependencies**
  - Added `@typescript/native-preview` to dev dependencies.
  - Narrowed release-age cooldown exclusion in `pnpm-workspace.yaml` to `@typescript/native-preview*` so only the native preview (and its binaries) bypass the cooldown.

<sup>Written for commit 6dbf321c5c52bfa14ce692434ead2e33360e2a85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

