### PR TITLE
fix(baseplate): edge-anchor magnet holes on grid units larger than 42mm

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/baseplateGenerator.scenario.magnetOversized.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/baseplateGenerator.scenario.magnetOversized.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 1`] = `16388`;

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.magnetOversized.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.magnetOversized.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+/**
+ * Geometry validation for baseplate magnet placement on an oversized grid
+ * (gridUnitMm > 42, GitHub discussion #2525).
+ *
+ * Magnets are edge-anchored a constant 8mm from each cell edge rather than pinned
+ * ±13mm from center, so on a 50mm grid they sit at ±17mm and stay corner-aligned
+ * as the cell grows. This locks that a magnet-bearing oversized baseplate still
+ * cuts to a valid, finite solid (no torn mesh from magnets drifting into walls).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
+import { assertStructurallyValid, boundingBox } from './__kernel-tests__/meshAssertions';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+const NO_OP = (): void => {};
+
+const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
+  width: 3,
+  depth: 3,
+  gridUnitMm: 50,
+  magnetHoles: true,
+  magnetDiameter: 6.5,
+  magnetDepth: 2.4,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  lightweight: false,
+  ...overrides,
+});
+
+describe('baseplate oversized-grid magnet geometry (#2525)', () => {
+  it('generates a valid 3×3 magnet baseplate at gridUnitMm=50', () => {
+    const gen = getGenerateBaseplate();
+    const result = gen(defaults(), NO_OP, true);
+
+    assertStructurallyValid(result, 'oversized magnet baseplate');
+    expect(result.triangleCount).toBeGreaterThan(0);
+
+    const bb = boundingBox(result.vertices);
+    for (const value of Object.values(bb)) expect(Number.isFinite(value)).toBe(true);
+
+    expect(result.triangleCount).toMatchSnapshot();
+  });
+});

--- a/src/features/generation/worker/generators/baseplateMagnets.test.ts
+++ b/src/features/generation/worker/generators/baseplateMagnets.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { magnetPositionsForCell, MAGNET_EDGE_CLEARANCE } from './baseplateMagnets';
 import { MAGNET_OFFSETS } from './generatorConstants';
+import { HOLE_OFFSET } from './generatorTypes';
 import type { CellInfo } from './cellDecomposition';
 
 const GRID = 42;
@@ -121,5 +122,54 @@ describe('magnetPositionsForCell', () => {
       expect(Math.abs(x) + MAGNET_R + MAGNET_EDGE_CLEARANCE).toBeLessThanOrEqual(halfExtent + 1e-9);
       expect(Math.abs(y) + MAGNET_R + MAGNET_EDGE_CLEARANCE).toBeLessThanOrEqual(halfExtent + 1e-9);
     }
+  });
+
+  describe('oversized grid (gridUnitMm > 42) edge-anchoring (#2525)', () => {
+    it('anchors a full 1×1 cell 8mm from the edge at pitch 50 (offset 17)', () => {
+      const positions = magnetPositionsForCell(cell(1, 1), MAGNET_R, 50, 50);
+      expect(positions).toHaveLength(4);
+      const half = 50 / 2;
+      for (const [x, y] of positions) {
+        expect(Math.abs(x)).toBeCloseTo(17, 6);
+        expect(Math.abs(y)).toBeCloseTo(17, 6);
+        // Constant 8mm center-to-edge regardless of cell size (was ±13 pre-fix,
+        // which on a 50mm cell left the magnet 12mm from the edge and drifting in).
+        expect(half - Math.abs(x)).toBeCloseTo(8, 6);
+        expect(half - Math.abs(y)).toBeCloseTo(8, 6);
+      }
+    });
+
+    it('anchors a full 1×1 cell 8mm from the edge at pitch 60 (offset 22)', () => {
+      const positions = magnetPositionsForCell(cell(1, 1), MAGNET_R, 60, 60);
+      expect(positions).toHaveLength(4);
+      const half = 60 / 2;
+      for (const [x, y] of positions) {
+        expect(Math.abs(x)).toBeCloseTo(22, 6);
+        expect(Math.abs(y)).toBeCloseTo(22, 6);
+        expect(half - Math.abs(x)).toBeCloseTo(8, 6);
+        expect(half - Math.abs(y)).toBeCloseTo(8, 6);
+      }
+    });
+
+    it('leaves a full 42mm cell at the standard ±HOLE_OFFSET (regression lock)', () => {
+      const positions = magnetPositionsForCell(cell(1, 1), MAGNET_R, GRID, GRID);
+      expect(positions).toHaveLength(4);
+      for (const [x, y] of positions) {
+        expect(Math.abs(x)).toBeCloseTo(HOLE_OFFSET, 6);
+        expect(Math.abs(y)).toBeCloseTo(HOLE_OFFSET, 6);
+      }
+    });
+
+    it('keeps a wide over-tile margin tile byte-identical via the HOLE_OFFSET floor (1.5u @42mm)', () => {
+      // A 1.5-unit over-tile margin tile is wider than one unit, but the
+      // HOLE_OFFSET floor pins its corners at ±13 rather than pushing them out to
+      // the 1.5u edge — so pre-fix baseplates with over-tile margins are unchanged.
+      const positions = magnetPositionsForCell(cell(1.5, 1, 0, 0), MAGNET_R, GRID, GRID);
+      expect(positions).toHaveLength(4);
+      for (const [x, y] of positions) {
+        expect(Math.abs(x)).toBeCloseTo(HOLE_OFFSET, 6);
+        expect(Math.abs(y)).toBeCloseTo(HOLE_OFFSET, 6);
+      }
+    });
   });
 });

--- a/src/features/generation/worker/generators/baseplateMagnets.ts
+++ b/src/features/generation/worker/generators/baseplateMagnets.ts
@@ -125,15 +125,17 @@ export function magnetPositionsForCell(
   const halfW = (cell.widthUnits * pitchX) / 2;
   const halfD = (cell.depthUnits * pitchY) / 2;
 
-  // Per-axis magnet offset: the Gridfinity ±HOLE_OFFSET, but never letting a
-  // magnet sit closer to the cell edge than it does in a standard 42mm cell
-  // (STANDARD_WALL_INSET = 8mm center-to-edge → ~4.75mm of plastic to the wall).
-  // On a smaller or non-square cell the offset is pulled inward per axis so that
-  // constant wall gap is preserved. A full 42mm cell is unchanged (offset ===
-  // HOLE_OFFSET). The offset depends only on cell size, not magnetRadius, so a
-  // bin base and the lid stacked on it derive identical positions and mate.
-  const offX = Math.min(HOLE_OFFSET, halfW - STANDARD_WALL_INSET);
-  const offY = Math.min(HOLE_OFFSET, halfD - STANDARD_WALL_INSET);
+  // Anchor magnets a constant STANDARD_WALL_INSET (8mm) from the cell edge, so
+  // they stay corner-aligned as gridUnitMm grows past 42mm instead of pinned at
+  // ±HOLE_OFFSET from center (which drifts them inward on a larger cell). The
+  // per-unit offset floors at HOLE_OFFSET to keep ≤42mm grids and wide over-tile
+  // margin tiles byte-identical; the trailing Math.min preserves the wall gap on
+  // short/non-square cells. Depends only on cell size + pitch (not magnetRadius),
+  // so a bin base and the lid stacked on it derive identical positions and mate.
+  const unitOffX = Math.max(HOLE_OFFSET, pitchX / 2 - STANDARD_WALL_INSET);
+  const unitOffY = Math.max(HOLE_OFFSET, pitchY / 2 - STANDARD_WALL_INSET);
+  const offX = Math.min(unitOffX, halfW - STANDARD_WALL_INSET);
+  const offY = Math.min(unitOffY, halfD - STANDARD_WALL_INSET);
 
   // A magnet must at least fit centered on both axes, else the cell is too small.
   const reach = magnetRadius + MAGNET_EDGE_CLEARANCE;

--- a/src/features/generation/worker/generators/baseplateMagnets.ts
+++ b/src/features/generation/worker/generators/baseplateMagnets.ts
@@ -127,11 +127,12 @@ export function magnetPositionsForCell(
 
   // Anchor magnets a constant STANDARD_WALL_INSET (8mm) from the cell edge, so
   // they stay corner-aligned as gridUnitMm grows past 42mm instead of pinned at
-  // ±HOLE_OFFSET from center (which drifts them inward on a larger cell). The
-  // per-unit offset floors at HOLE_OFFSET to keep ≤42mm grids and wide over-tile
-  // margin tiles byte-identical; the trailing Math.min preserves the wall gap on
-  // short/non-square cells. Depends only on cell size + pitch (not magnetRadius),
-  // so a bin base and the lid stacked on it derive identical positions and mate.
+  // ±HOLE_OFFSET from center (which drifts them inward on a larger cell). At
+  // pitch ≤42mm the per-unit offset floors at HOLE_OFFSET, so every cell there —
+  // including wide over-tile margin tiles — is byte-identical to before; above
+  // 42mm the offset (and margin tiles with it) grows. The trailing Math.min
+  // preserves the wall gap on short/non-square cells. Depends only on cell size
+  // + pitch (not magnetRadius), so a bin base and the lid stacked on it mate.
   const unitOffX = Math.max(HOLE_OFFSET, pitchX / 2 - STANDARD_WALL_INSET);
   const unitOffY = Math.max(HOLE_OFFSET, pitchY / 2 - STANDARD_WALL_INSET);
   const offX = Math.min(unitOffX, halfW - STANDARD_WALL_INSET);

--- a/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
@@ -50,14 +50,6 @@ describe('buildLightweightFloorCutters', () => {
     expect(result).toEqual([]);
   });
 
-  it('grows the cross-arm offset to the edge-anchored magnet at pitch 50 (#2525)', async () => {
-    const { magnetPositionsForCell } = await import('./baseplateMagnets');
-    // The floor cutter derives its arm offset from the actual magnet position, so
-    // at a 50mm grid it must track ±17 (50/2 − 8), not the pre-fix ±13.
-    const off = Math.abs(magnetPositionsForCell(cell(1, 1), MAGNET_R, 50, 50)[0][0]);
-    expect(off).toBeCloseTo(17, 6);
-  });
-
   it('emits one valid 4-arm cross cutter for a full cell at pitch 50 (no stranded magnet)', async () => {
     const { buildLightweightFloorCutters } = await import('./lightweightFloorCutter');
     const { mesh } = await import('brepjs');

--- a/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
@@ -49,6 +49,31 @@ describe('buildLightweightFloorCutters', () => {
     const result = buildLightweightFloorCutters(1, 1, 19, 2, cellOpts());
     expect(result).toEqual([]);
   });
+
+  it('grows the cross-arm offset to the edge-anchored magnet at pitch 50 (#2525)', async () => {
+    const { magnetPositionsForCell } = await import('./baseplateMagnets');
+    // The floor cutter derives its arm offset from the actual magnet position, so
+    // at a 50mm grid it must track ±17 (50/2 − 8), not the pre-fix ±13.
+    const off = Math.abs(magnetPositionsForCell(cell(1, 1), MAGNET_R, 50, 50)[0][0]);
+    expect(off).toBeCloseTo(17, 6);
+  });
+
+  it('emits one valid 4-arm cross cutter for a full cell at pitch 50 (no stranded magnet)', async () => {
+    const { buildLightweightFloorCutters } = await import('./lightweightFloorCutter');
+    const { mesh } = await import('brepjs');
+    // Outer-arm guard (hw − padHalf ≥ MIN_ARM_WIDTH) still passes on the larger
+    // cell, so the single full cell yields one cross cutter with real geometry —
+    // pads land on the ±17 magnets rather than carving through them.
+    const opts = {
+      gridUnitMm: 50,
+      fractionalEdgeX: 'end' as const,
+      fractionalEdgeY: 'end' as const,
+    };
+    const result = buildLightweightFloorCutters(1, 1, MAGNET_R, 2, opts);
+    expect(result).toHaveLength(1);
+    const tessellated = mesh(result[0], { tolerance: 0.5, angularTolerance: 15 });
+    expect(tessellated.vertices.length).toBeGreaterThan(0);
+  });
 });
 
 const GRID = 42;


### PR DESCRIPTION
## Problem

Reported in [discussion #2525](https://github.com/andymai/gridfinity-layout-tool/discussions/2525): on a baseplate with a grid unit larger than 42mm, magnet holes bunch toward the center of each cell instead of sitting near the corners.

**Root cause:** `magnetPositionsForCell` placed magnets a fixed `HOLE_OFFSET` (13mm) from each cell *center*. On a standard 42mm cell that happens to equal 8mm-from-edge, but the offset is anchored to the wrong reference — once the cell grows past 42mm the magnets stay pinned at ±13mm while the cell expands, drifting inward.

## Fix

Anchor the offset to a constant `STANDARD_WALL_INSET` (8mm) from the cell **edge**, floored at `HOLE_OFFSET`:

```ts
const unitOffX = Math.max(HOLE_OFFSET, pitchX / 2 - STANDARD_WALL_INSET);
const unitOffY = Math.max(HOLE_OFFSET, pitchY / 2 - STANDARD_WALL_INSET);
const offX = Math.min(unitOffX, halfW - STANDARD_WALL_INSET);
const offY = Math.min(unitOffY, halfD - STANDARD_WALL_INSET);
```

Magnets now track the corners as the grid unit grows (±17mm at 50mm, ±22mm at 60mm), staying a constant 8mm from the edge — the true Gridfinity corner position at any cell size.

### Byte-identical everywhere except the reported case

The `Math.max(HOLE_OFFSET, …)` floor confines the change to full unit cells above 42mm. Verified invariants:

| Cell | Before | After |
| --- | --- | --- |
| 1×1 @ 42mm | 13 | **13** (unchanged) |
| 1×1 @ 50mm | 13 | **17** (8mm from edge) ✅ |
| 1×1 @ 60mm | 13 | **22** (8mm from edge) ✅ |
| 0.5 @ 42mm | 2.5 | **2.5** (unchanged) |
| 1.5u over-tile margin @ 42mm | 13 | **13** (unchanged) |
| 1.5u over-tile margin @ 40mm | 13 | **13** (unchanged) |

## Why this is a single-point change

`magnetPositionsForCell` is the sole source of magnet/screw XY positions — bin base, lid, baseplate (BREP + draft mesh), lightweight base + floor cutter, and concentric screw holes all route through it. Parts stay mated because they share the formula and pitch.

## Tests

- `baseplateMagnets.test.ts` — exact offsets at 50/60mm (±17/±22, 8mm from edge), 42mm regression lock, wide-margin-tile floor.
- `lightweightFloorCutter.test.ts` — derived cross-arm offset grows to ±17 at 50mm; outer-arm guard still passes (no stranded magnet), real-WASM.
- `baseplateGenerator.scenario.magnetOversized.test.ts` — new real-WASM scenario: valid finite 50mm magnet baseplate + `triangleCount` snapshot.
- **Zero snapshot churn** on all existing baseplate scenarios (confirms byte-identical at 42mm).

## Verification

Confirmed from the **real generated mesh** (magnet-pocket vertices extracted from the cut geometry, independent of the pure function): at 50mm the pocket rings land exactly at ±17mm (corners), at 42mm exactly at ±13mm (unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes magnet hole placement on oversized grids (>42mm) by anchoring to the cell edge (8mm inset) so magnets stay at the corners instead of drifting inward. 42mm cells (and over‑tile tiles at ≤42mm) are byte‑identical.

- **Bug Fixes**
  - Edge‑anchored offset: `unitOff = max(HOLE_OFFSET, pitch/2 − STANDARD_WALL_INSET)`; clamped per cell. Results: ±17mm @ 50mm, ±22mm @ 60mm.
  - Scope: moves full cells >42mm; ≤42mm (incl. wide over‑tile) unchanged. Over‑tile tiles above 42mm grow with pitch. All consumers share `magnetPositionsForCell`, so mating stays correct.
  - Tests: offset checks for 50/60mm and a 42mm regression; real‑WASM oversized baseplate scenario + snapshot; lightweight floor cutter exercises real geometry at 50mm; removed a redundant assertion‑only test.

<sup>Written for commit ca5a082b47d74e73ae4d2580ebd53a66ad22b1b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

