### PR TITLE
feat(drawer): add drawer outline model for non-rectangular drawers

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -234,12 +234,79 @@ export interface StoredBaseplateParams {
 /** Position of fractional edge when drawer has half-unit dimensions */
 export type FractionalEdge = 'start' | 'end';
 
+/**
+ * One cut applied to a drawer corner — authoring parameters for the
+ * corner-cuts editor, echoed inside {@link DrawerOutline.authoring} so the
+ * editor can round-trip. Dimensions in mm.
+ */
+export type CornerCut =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'chamfer'; readonly size: number }
+  | { readonly kind: 'radius'; readonly r: number }
+  | { readonly kind: 'notch'; readonly w: number; readonly d: number };
+
+/** Per-corner cuts (tl/tr = back-left/back-right in grid coords, y up). */
+export interface CornerCutParams {
+  readonly tl: CornerCut;
+  readonly tr: CornerCut;
+  readonly bl: CornerCut;
+  readonly br: CornerCut;
+}
+
+/** Which authoring surface produced an outline (round-trip hint only). */
+export type OutlineAuthoringKind = 'cells' | 'corners' | 'trace' | 'pen';
+
+/**
+ * Vertex of a drawer outline. Coordinates are drawer-local mm — origin at the
+ * grid's bottom-left, spanning `[0, width·gridUnitMm] × [0, depth·gridUnitMm]`.
+ */
+export interface OutlineVertex {
+  readonly x: number;
+  readonly y: number;
+  /**
+   * Arc bulge for the segment from this vertex to the next (DXF LWPOLYLINE
+   * convention: `tan(sweep/4)`). 0/omitted = straight line. Positive = CCW
+   * sweep, bowing the arc RIGHT of the travel direction — on this CCW loop,
+   * away from the interior. `|bulge| ≤ 1` (arcs capped at 180°).
+   */
+  readonly bulge?: number;
+}
+
+/**
+ * Non-rectangular drawer boundary: a single closed CCW loop of line segments
+ * and circular arcs (implicitly closed last→first). Absent = full rectangle.
+ *
+ * The loop must be simple (non-self-intersecting), lie within the drawer's
+ * grid extent, and enclose at least one grid cell of area. Interior holes are
+ * unrepresentable by design (single loop). Everything downstream — placement
+ * validation, hatching, baseplate generation — derives from this one field;
+ * cell painting, bin-footprint tracing, corner cuts, and the pen editor are
+ * authoring surfaces that write it.
+ */
+export interface DrawerOutline {
+  /**
+   * Typed as a mutable array so Immer's `WritableDraft<Layout>` keeps working
+   * in store slices (the `CellMask.cells` precedent) — but callers MUST NOT
+   * mutate in place: geometry helpers memoize on the outline reference.
+   * Always construct a fresh outline.
+   */
+  readonly vertices: OutlineVertex[];
+  /** Which editor wrote this outline + its params, so it can reopen in the
+   * same mode. Never trusted for geometry; sanitized server-side. */
+  readonly authoring?: {
+    readonly kind: OutlineAuthoringKind;
+    readonly corners?: CornerCutParams;
+  };
+}
+
 export interface Drawer {
   width: GridUnits; // 1-50
   depth: GridUnits; // 1-50
   height: HeightUnits; // >= sum of layer heights
   fractionalEdgeX?: FractionalEdge; // 'start' = left, 'end' = right (default)
   fractionalEdgeY?: FractionalEdge; // 'start' = bottom, 'end' = top (default)
+  /** Non-rectangular boundary. Absent = full `width × depth` rectangle. */
+  outline?: DrawerOutline;
 }
 
 export interface Category {

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DrawerOutline, Layout } from '@/core/types';
+import { gridUnits, mm } from '@/core/types';
+import { createTestLayout } from '@/test/testUtils';
+import {
+  hashOutline,
+  normalizeDrawerOutline,
+  OUTLINE_MAX_VERTICES,
+  quantizeOutline,
+  resizeDrawerOutline,
+  rotateOutline180,
+  snapOutlineToBounds,
+  translateOutline,
+  validateOutline,
+} from './drawerOutline';
+import { outlineSignedArea } from './drawerOutlineGeometry';
+
+const U = 42;
+
+const L_SHAPE: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 4 * U, y: 0 },
+    { x: 4 * U, y: 2 * U },
+    { x: 2 * U, y: 2 * U },
+    { x: 2 * U, y: 4 * U },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+const CURVED_BACK: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 4 * U, y: 0 },
+    { x: 4 * U, y: 4 * U, bulge: -0.25 },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+describe('validateOutline', () => {
+  it('accepts valid shapes', () => {
+    expect(validateOutline(L_SHAPE, 4 * U, 4 * U, U)).toBeNull();
+    expect(validateOutline(CURVED_BACK, 4 * U, 4 * U, U)).toBeNull();
+  });
+
+  it('rejects too few and too many vertices', () => {
+    expect(
+      validateOutline(
+        {
+          vertices: [
+            { x: 0, y: 0 },
+            { x: U, y: 0 },
+          ],
+        },
+        U,
+        U,
+        U
+      )?.kind
+    ).toBe('too_few_vertices');
+    const many: DrawerOutline = {
+      vertices: Array.from({ length: OUTLINE_MAX_VERTICES + 1 }, (_, i) => ({
+        x: Math.cos((i / (OUTLINE_MAX_VERTICES + 1)) * 2 * Math.PI) * U + 2 * U,
+        y: Math.sin((i / (OUTLINE_MAX_VERTICES + 1)) * 2 * Math.PI) * U + 2 * U,
+      })),
+    };
+    expect(validateOutline(many, 4 * U, 4 * U, U)?.kind).toBe('too_many_vertices');
+  });
+
+  it('rejects non-finite coordinates and out-of-range bulges', () => {
+    expect(
+      validateOutline(
+        {
+          vertices: [
+            { x: 0, y: 0 },
+            { x: NaN, y: 0 },
+            { x: U, y: U },
+          ],
+        },
+        4 * U,
+        4 * U,
+        U
+      )?.kind
+    ).toBe('non_finite');
+    expect(
+      validateOutline(
+        {
+          vertices: [
+            { x: 0, y: 0, bulge: 2 },
+            { x: 4 * U, y: 0 },
+            { x: 0, y: 4 * U },
+          ],
+        },
+        4 * U,
+        4 * U,
+        U
+      )?.kind
+    ).toBe('bad_bulge');
+  });
+
+  it('rejects coincident consecutive vertices', () => {
+    expect(
+      validateOutline(
+        {
+          vertices: [
+            { x: 0, y: 0 },
+            { x: 0, y: 0.0001 },
+            { x: 4 * U, y: 0 },
+            { x: 0, y: 4 * U },
+          ],
+        },
+        4 * U,
+        4 * U,
+        U
+      )?.kind
+    ).toBe('degenerate_segment');
+  });
+
+  it('rejects outlines leaving the drawer extent, including arc bellies', () => {
+    expect(
+      validateOutline(
+        {
+          vertices: [
+            { x: 0, y: 0 },
+            { x: 5 * U, y: 0 },
+            { x: 0, y: 4 * U },
+          ],
+        },
+        4 * U,
+        4 * U,
+        U
+      )?.kind
+    ).toBe('out_of_bounds');
+    // Endpoints in-bounds but the arc bellies below the bbox (positive bulge
+    // bows right of +x travel = downward).
+    expect(
+      validateOutline(
+        {
+          vertices: [
+            { x: 0, y: 0, bulge: 0.5 },
+            { x: 4 * U, y: 0 },
+            { x: 4 * U, y: 4 * U },
+            { x: 0, y: 4 * U },
+          ],
+        },
+        4 * U,
+        4 * U,
+        U
+      )?.kind
+    ).toBe('out_of_bounds');
+  });
+
+  it('rejects clockwise winding', () => {
+    const cw: DrawerOutline = { vertices: [...L_SHAPE.vertices].reverse() };
+    expect(validateOutline(cw, 4 * U, 4 * U, U)?.kind).toBe('not_ccw');
+  });
+
+  it('rejects self-intersection', () => {
+    const bowtie: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 4 * U },
+        { x: 4 * U, y: 0 },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    expect(validateOutline(bowtie, 4 * U, 4 * U, U)?.kind).toBe('self_intersecting');
+  });
+
+  it('rejects areas below one grid cell', () => {
+    const tiny: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: U / 2, y: 0 },
+        { x: U / 2, y: U },
+      ],
+    };
+    expect(validateOutline(tiny, 4 * U, 4 * U, U)?.kind).toBe('too_small');
+  });
+});
+
+describe('quantize and snap', () => {
+  it('quantizes coordinates to 0.01mm', () => {
+    const q = quantizeOutline({
+      vertices: [
+        { x: 0.004, y: 0.006 },
+        { x: 41.999, y: 0 },
+        { x: 0, y: 42.0049 },
+      ],
+    });
+    expect(q.vertices[0]).toEqual({ x: 0, y: 0.01 });
+    expect(q.vertices[1].x).toBeCloseTo(42, 5);
+    expect(q.vertices[2].y).toBeCloseTo(42, 5);
+  });
+
+  it('snaps near-boundary vertices onto the bbox', () => {
+    const s = snapOutlineToBounds(
+      {
+        vertices: [
+          { x: 0.03, y: -0.02 },
+          { x: 4 * U - 0.04, y: 0 },
+          { x: 0, y: 4 * U + 0.01 },
+        ],
+      },
+      4 * U,
+      4 * U
+    );
+    expect(s.vertices[0]).toEqual({ x: 0, y: 0 });
+    expect(s.vertices[1].x).toBe(4 * U);
+    expect(s.vertices[2].y).toBe(4 * U);
+  });
+});
+
+describe('transforms', () => {
+  it('translates vertices and preserves bulges', () => {
+    const t = translateOutline(CURVED_BACK, 10, -5);
+    expect(t.vertices[1]).toEqual({ x: 4 * U + 10, y: -5 });
+    expect(t.vertices[2].bulge).toBe(-0.25);
+  });
+
+  it('rotateOutline180 twice is the identity and preserves winding', () => {
+    const once = rotateOutline180(L_SHAPE, 4 * U, 4 * U);
+    expect(outlineSignedArea(once)).toBeCloseTo(outlineSignedArea(L_SHAPE));
+    const twice = rotateOutline180(once, 4 * U, 4 * U);
+    expect(twice.vertices).toEqual(L_SHAPE.vertices);
+  });
+});
+
+describe('hashOutline', () => {
+  it('is stable under sub-quantum jitter and geometry-only', () => {
+    const jittered: DrawerOutline = {
+      vertices: L_SHAPE.vertices.map((v) => ({ x: v.x + 0.002, y: v.y - 0.002 })),
+      authoring: { kind: 'cells' },
+    };
+    expect(hashOutline(jittered)).toBe(hashOutline(L_SHAPE));
+  });
+
+  it('differs for different shapes', () => {
+    expect(hashOutline(L_SHAPE)).not.toBe(hashOutline(CURVED_BACK));
+    const shifted: DrawerOutline = {
+      vertices: L_SHAPE.vertices.map((v) => ({ x: v.x + U, y: v.y })),
+    };
+    expect(hashOutline(shifted)).not.toBe(hashOutline(L_SHAPE));
+  });
+});
+
+describe('resizeDrawerOutline', () => {
+  it('returns the same outline when dims are unchanged', () => {
+    expect(resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 4 * U, 4 * U, U)).toBe(L_SHAPE);
+  });
+
+  it('crops on shrink, preserving the notch', () => {
+    const shrunk = resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 3 * U, 4 * U, U);
+    expect(shrunk).toBeDefined();
+    const o = shrunk as DrawerOutline;
+    expect(validateOutline(o, 3 * U, 4 * U, U)).toBeNull();
+    expect(outlineSignedArea(o)).toBeCloseTo(3 * 4 * U * U - 1 * 2 * U * U);
+  });
+
+  it('resets to rectangle when the shrink consumes the notch', () => {
+    expect(resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 2 * U, 4 * U, U)).toBeUndefined();
+  });
+
+  it('extends across a grown edge with the new area inside', () => {
+    const grown = resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 5 * U, 4 * U, U);
+    expect(grown).toBeDefined();
+    const o = grown as DrawerOutline;
+    expect(validateOutline(o, 5 * U, 4 * U, U)).toBeNull();
+    expect(outlineSignedArea(o)).toBeCloseTo(16 * U * U - 4 * U * U + 4 * U * U);
+  });
+
+  it('grows both axes sequentially', () => {
+    // Notch at the bottom-right, away from both grown edges.
+    const bottomNotch: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 2 * U, y: 0 },
+        { x: 2 * U, y: 2 * U },
+        { x: 4 * U, y: 2 * U },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const grown = resizeDrawerOutline(bottomNotch, 4 * U, 4 * U, 5 * U, 5 * U, U);
+    expect(grown).toBeDefined();
+    const o = grown as DrawerOutline;
+    expect(validateOutline(o, 5 * U, 5 * U, U)).toBeNull();
+    // L area + right strip (1×4) + top strip (5×1).
+    expect(outlineSignedArea(o)).toBeCloseTo((12 + 4 + 5) * U * U);
+  });
+
+  it('grows depth past an edge-touching notch, keeping it open', () => {
+    const grown = resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 4 * U, 5 * U, U);
+    expect(grown).toBeDefined();
+    const o = grown as DrawerOutline;
+    expect(validateOutline(o, 4 * U, 5 * U, U)).toBeNull();
+    // L area + top strip over the body only (the notch mouth stays open at
+    // the right drawer edge — no hole).
+    expect(outlineSignedArea(o)).toBeCloseTo((12 + 4) * U * U);
+  });
+
+  it('resets when sequential growth would trap the notch as a hole', () => {
+    // Width growth welds a strip along the notch's right side; the later
+    // depth growth would then need to weld across two separate runs.
+    expect(resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 5 * U, 5 * U, U)).toBeUndefined();
+  });
+
+  it('resets when the outline never touches the grown edge', () => {
+    const inset: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 3 * U, y: 0 },
+        { x: 3 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    expect(resizeDrawerOutline(inset, 4 * U, 4 * U, 5 * U, 4 * U, U)).toBeUndefined();
+  });
+
+  it('resets when growth would enclose a hole (two edge runs)', () => {
+    const sideNotch: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: U },
+        { x: 2 * U, y: U },
+        { x: 2 * U, y: 3 * U },
+        { x: 4 * U, y: 3 * U },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    expect(validateOutline(sideNotch, 4 * U, 4 * U, U)).toBeNull();
+    expect(resizeDrawerOutline(sideNotch, 4 * U, 4 * U, 5 * U, 4 * U, U)).toBeUndefined();
+  });
+
+  it('resets when a shrink would split the shape into two components', () => {
+    const bridge: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: U, y: 0 },
+        { x: U, y: 3 * U },
+        { x: 3 * U, y: 3 * U },
+        { x: 3 * U, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    expect(validateOutline(bridge, 4 * U, 4 * U, U)).toBeNull();
+    expect(resizeDrawerOutline(bridge, 4 * U, 4 * U, 4 * U, 2 * U, U)).toBeUndefined();
+  });
+
+  it('resets when the crop removes the whole curved region', () => {
+    // CURVED_BACK's arc only dips to y = 3.5u; cropping to 3u leaves a plain
+    // rectangle, which must normalize back to "no outline".
+    expect(resizeDrawerOutline(CURVED_BACK, 4 * U, 4 * U, 4 * U, 3 * U, U)).toBeUndefined();
+  });
+
+  it('crops through arcs without breaking validity', () => {
+    // Deeper bow (sagitta 1u): the clip line at 3.5u crosses the arc twice.
+    const deepCurve: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 4 * U, bulge: -0.5 },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const shrunk = resizeDrawerOutline(deepCurve, 4 * U, 4 * U, 4 * U, 3.5 * U, U);
+    expect(shrunk).toBeDefined();
+    const o = shrunk as DrawerOutline;
+    expect(validateOutline(o, 4 * U, 3.5 * U, U)).toBeNull();
+    expect(o.vertices.some((v) => (v.bulge ?? 0) !== 0)).toBe(true);
+    expect(outlineSignedArea(o)).toBeLessThan(4 * 3.5 * U * U);
+  });
+
+  it('drops the authoring annotation when geometry changes', () => {
+    const annotated: DrawerOutline = { ...L_SHAPE, authoring: { kind: 'cells' } };
+    const shrunk = resizeDrawerOutline(annotated, 4 * U, 4 * U, 3 * U, 4 * U, U);
+    expect((shrunk as DrawerOutline).authoring).toBeUndefined();
+  });
+});
+
+describe('normalizeDrawerOutline', () => {
+  function layoutWith(outline: DrawerOutline | undefined, width = 4, depth = 4): Layout {
+    const layout = createTestLayout();
+    layout.gridUnitMm = mm(U);
+    layout.drawer = {
+      ...layout.drawer,
+      width: gridUnits(width),
+      depth: gridUnits(depth),
+    };
+    if (outline !== undefined) layout.drawer.outline = outline;
+    return layout;
+  }
+
+  it('passes through layouts without an outline', () => {
+    const layout = layoutWith(undefined);
+    expect(normalizeDrawerOutline(layout)).toBe(layout);
+  });
+
+  it('passes through valid outlines unchanged', () => {
+    const layout = layoutWith(L_SHAPE);
+    expect(normalizeDrawerOutline(layout)).toBe(layout);
+  });
+
+  it('crops an outline that exceeds the drawer extent (stale after resize)', () => {
+    const layout = layoutWith(L_SHAPE, 3, 4);
+    const normalized = normalizeDrawerOutline(layout);
+    expect(normalized).not.toBe(layout);
+    const outline = normalized.drawer.outline as DrawerOutline;
+    expect(validateOutline(outline, 3 * U, 4 * U, U)).toBeNull();
+  });
+
+  it('drops rectangle-equivalent outlines', () => {
+    const rect: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const normalized = normalizeDrawerOutline(layoutWith(rect));
+    expect(normalized.drawer.outline).toBeUndefined();
+  });
+
+  it('drops invalid outlines', () => {
+    const bowtie: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 4 * U },
+        { x: 4 * U, y: 0 },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const normalized = normalizeDrawerOutline(layoutWith(bowtie));
+    expect(normalized.drawer.outline).toBeUndefined();
+  });
+});

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -426,6 +426,35 @@ describe('normalizeDrawerOutline', () => {
     expect(normalized.drawer.outline).toBeUndefined();
   });
 
+  it('drops rectangles with redundant collinear vertices', () => {
+    const rect: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 2 * U, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    expect(normalizeDrawerOutline(layoutWith(rect)).drawer.outline).toBeUndefined();
+  });
+
+  it('keeps a small corner chamfer in a large drawer', () => {
+    // A 5mm chamfer removes 12.5mm² — far below any perimeter-scaled area
+    // epsilon on a 10-unit drawer. Must survive as intentional geometry.
+    const chamfered: DrawerOutline = {
+      vertices: [
+        { x: 5, y: 0 },
+        { x: 10 * U, y: 0 },
+        { x: 10 * U, y: 10 * U },
+        { x: 0, y: 10 * U },
+        { x: 0, y: 5 },
+      ],
+    };
+    const layout = layoutWith(chamfered, 10, 10);
+    expect(normalizeDrawerOutline(layout)).toBe(layout);
+  });
+
   it('drops invalid outlines', () => {
     const bowtie: DrawerOutline = {
       vertices: [

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -125,6 +125,12 @@ function segmentsTouch(
   return false;
 }
 
+/**
+ * Chord-approximate: runs on the flattened polyline, so an arc-arc crossing
+ * shallower than ~2× ARC_FLATTEN_TOLERANCE (≈0.1mm) can slip through. Such a
+ * graze is below print resolution and the BREP boolean handles it; exact
+ * arc-arc intersection isn't worth the complexity here.
+ */
 function isSelfIntersecting(pts: readonly OutlinePoint[]): boolean {
   const n = pts.length;
   for (let i = 0; i < n; i++) {
@@ -432,14 +438,28 @@ function growAxis(
   return [...rotated, ...detour];
 }
 
+/**
+ * Topology test, not an area tolerance: the loop traces the full rectangle
+ * exactly when every segment is straight and hugs one of the four boundary
+ * lines. A corner-cutting edge (e.g. a small chamfer) has its endpoints on
+ * two DIFFERENT lines, so even cuts far smaller than any area epsilon are
+ * preserved as intentional geometry.
+ */
 function isFullRectangle(outline: DrawerOutline, widthMm: number, depthMm: number): boolean {
-  for (const v of outline.vertices) {
-    const onX = Math.abs(v.x) <= OUTLINE_SNAP_EPS || Math.abs(v.x - widthMm) <= OUTLINE_SNAP_EPS;
-    const onY = Math.abs(v.y) <= OUTLINE_SNAP_EPS || Math.abs(v.y - depthMm) <= OUTLINE_SNAP_EPS;
-    if (!onX && !onY) return false;
+  const n = outline.vertices.length;
+  for (let i = 0; i < n; i++) {
+    const a = outline.vertices[i];
+    const b = outline.vertices[(i + 1) % n];
+    if (Math.abs(a.bulge ?? 0) >= BULGE_EPS) return false;
+    const onCommonLine =
+      (Math.abs(a.x) <= OUTLINE_SNAP_EPS && Math.abs(b.x) <= OUTLINE_SNAP_EPS) ||
+      (Math.abs(a.x - widthMm) <= OUTLINE_SNAP_EPS &&
+        Math.abs(b.x - widthMm) <= OUTLINE_SNAP_EPS) ||
+      (Math.abs(a.y) <= OUTLINE_SNAP_EPS && Math.abs(b.y) <= OUTLINE_SNAP_EPS) ||
+      (Math.abs(a.y - depthMm) <= OUTLINE_SNAP_EPS && Math.abs(b.y - depthMm) <= OUTLINE_SNAP_EPS);
+    if (!onCommonLine) return false;
   }
-  const area = polylineSignedArea(flattenOutline(outline));
-  return area >= widthMm * depthMm - OUTLINE_SNAP_EPS * 2 * (widthMm + depthMm);
+  return true;
 }
 
 function dropCoincident(verts: MutableVertex[]): MutableVertex[] {

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -1,0 +1,562 @@
+/**
+ * Model operations for `DrawerOutline`: validation, transforms, hashing,
+ * resize (crop/extend), and read-side normalization.
+ *
+ * Everything here is brepjs/WASM-free and pure. The geometry math (arcs,
+ * flattening, classification) lives in `drawerOutlineGeometry.ts`; this module
+ * owns the outline's invariants: single closed CCW simple loop, within the
+ * drawer's grid extent, enclosing at least one grid cell.
+ */
+
+import type { DrawerOutline, Layout, OutlineVertex } from '@/core/types';
+import {
+  arcGeometry,
+  arcPointAt,
+  BULGE_EPS,
+  bulgeForSweep,
+  flattenOutline,
+  polylineSignedArea,
+  type OutlinePoint,
+} from './drawerOutlineGeometry';
+
+/** Coordinates are quantized to this (mm) — keeps hashes and caches stable
+ * under float jitter from unit conversions. */
+export const OUTLINE_QUANTUM_MM = 0.01;
+
+/** Hard cap on vertices — bounds server validation and worker pen-building. */
+export const OUTLINE_MAX_VERTICES = 256;
+
+/** Vertices within this distance (mm) of the drawer bbox snap onto it, so
+ * boundary-following outline edges are exactly boundary-coincident. */
+export const OUTLINE_SNAP_EPS = 0.05;
+
+const COINCIDENT_EPS = 1e-3;
+const LINE_EPS = 1e-6;
+
+export type OutlineValidationErrorKind =
+  | 'too_few_vertices'
+  | 'too_many_vertices'
+  | 'non_finite'
+  | 'bad_bulge'
+  | 'degenerate_segment'
+  | 'out_of_bounds'
+  | 'self_intersecting'
+  | 'not_ccw'
+  | 'too_small';
+
+export interface OutlineValidationError {
+  readonly kind: OutlineValidationErrorKind;
+  readonly message: string;
+}
+
+function err(kind: OutlineValidationErrorKind, message: string): OutlineValidationError {
+  return { kind, message };
+}
+
+function quantize(value: number): number {
+  return Math.round(value / OUTLINE_QUANTUM_MM) * OUTLINE_QUANTUM_MM;
+}
+
+/** Round coordinates to {@link OUTLINE_QUANTUM_MM} and bulges to 1e-6. */
+export function quantizeOutline(outline: DrawerOutline): DrawerOutline {
+  return {
+    ...outline,
+    vertices: outline.vertices.map((v) => {
+      const bulge = v.bulge === undefined ? undefined : Math.round(v.bulge * 1e6) / 1e6;
+      return bulge === undefined || bulge === 0
+        ? { x: quantize(v.x), y: quantize(v.y) }
+        : { x: quantize(v.x), y: quantize(v.y), bulge };
+    }),
+  };
+}
+
+/** Snap vertices within {@link OUTLINE_SNAP_EPS} of the drawer bbox onto it. */
+export function snapOutlineToBounds(
+  outline: DrawerOutline,
+  widthMm: number,
+  depthMm: number
+): DrawerOutline {
+  const snapAxis = (value: number, max: number): number => {
+    if (Math.abs(value) <= OUTLINE_SNAP_EPS) return 0;
+    if (Math.abs(value - max) <= OUTLINE_SNAP_EPS) return max;
+    return value;
+  };
+  return {
+    ...outline,
+    vertices: outline.vertices.map((v) => {
+      const x = snapAxis(v.x, widthMm);
+      const y = snapAxis(v.y, depthMm);
+      if (x === v.x && y === v.y) return v;
+      return v.bulge === undefined ? { x, y } : { x, y, bulge: v.bulge };
+    }),
+  };
+}
+
+function orient(a: OutlinePoint, b: OutlinePoint, c: OutlinePoint): number {
+  const v = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+  if (Math.abs(v) < 1e-9) return 0;
+  return Math.sign(v);
+}
+
+function onSegment(a: OutlinePoint, b: OutlinePoint, p: OutlinePoint): boolean {
+  return (
+    Math.min(a.x, b.x) - LINE_EPS <= p.x &&
+    p.x <= Math.max(a.x, b.x) + LINE_EPS &&
+    Math.min(a.y, b.y) - LINE_EPS <= p.y &&
+    p.y <= Math.max(a.y, b.y) + LINE_EPS
+  );
+}
+
+function segmentsTouch(
+  a: OutlinePoint,
+  b: OutlinePoint,
+  c: OutlinePoint,
+  d: OutlinePoint
+): boolean {
+  const o1 = orient(a, b, c);
+  const o2 = orient(a, b, d);
+  const o3 = orient(c, d, a);
+  const o4 = orient(c, d, b);
+  if (o1 !== o2 && o3 !== o4) return true;
+  if (o1 === 0 && onSegment(a, b, c)) return true;
+  if (o2 === 0 && onSegment(a, b, d)) return true;
+  if (o3 === 0 && onSegment(c, d, a)) return true;
+  if (o4 === 0 && onSegment(c, d, b)) return true;
+  return false;
+}
+
+function isSelfIntersecting(pts: readonly OutlinePoint[]): boolean {
+  const n = pts.length;
+  for (let i = 0; i < n; i++) {
+    const a = pts[i];
+    const b = pts[(i + 1) % n];
+    for (let j = i + 1; j < n; j++) {
+      // Adjacent segments legitimately share an endpoint.
+      if (j === i || (j + 1) % n === i || (i + 1) % n === j) continue;
+      if (segmentsTouch(a, b, pts[j], pts[(j + 1) % n])) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check every outline invariant. Returns null when valid.
+ * `widthMm`/`depthMm` are the drawer's grid extent; `gridUnitMm` sets the
+ * minimum-area rule (one grid cell).
+ */
+export function validateOutline(
+  outline: DrawerOutline,
+  widthMm: number,
+  depthMm: number,
+  gridUnitMm: number
+): OutlineValidationError | null {
+  const verts = outline.vertices;
+  if (verts.length < 3) return err('too_few_vertices', 'outline needs at least 3 vertices');
+  if (verts.length > OUTLINE_MAX_VERTICES) {
+    return err('too_many_vertices', `outline exceeds ${OUTLINE_MAX_VERTICES} vertices`);
+  }
+  for (const v of verts) {
+    if (!Number.isFinite(v.x) || !Number.isFinite(v.y)) {
+      return err('non_finite', 'outline has non-finite coordinates');
+    }
+    if (v.bulge !== undefined && (!Number.isFinite(v.bulge) || Math.abs(v.bulge) > 1 + 1e-9)) {
+      return err('bad_bulge', 'outline bulge must be finite with |bulge| <= 1');
+    }
+  }
+  for (let i = 0; i < verts.length; i++) {
+    const a = verts[i];
+    const b = verts[(i + 1) % verts.length];
+    if (Math.hypot(b.x - a.x, b.y - a.y) < COINCIDENT_EPS) {
+      return err('degenerate_segment', 'outline has coincident consecutive vertices');
+    }
+  }
+  const pts = flattenOutline(outline);
+  for (const p of pts) {
+    if (
+      p.x < -OUTLINE_SNAP_EPS ||
+      p.x > widthMm + OUTLINE_SNAP_EPS ||
+      p.y < -OUTLINE_SNAP_EPS ||
+      p.y > depthMm + OUTLINE_SNAP_EPS
+    ) {
+      return err('out_of_bounds', 'outline leaves the drawer extent');
+    }
+  }
+  if (isSelfIntersecting(pts)) {
+    return err('self_intersecting', 'outline crosses itself');
+  }
+  const area = polylineSignedArea(pts);
+  if (area <= 0) return err('not_ccw', 'outline must wind counter-clockwise');
+  if (area < gridUnitMm * gridUnitMm) {
+    return err('too_small', 'outline must enclose at least one grid cell');
+  }
+  return null;
+}
+
+/** Translate all vertices. Drops the authoring annotation (pipeline-only op). */
+export function translateOutline(outline: DrawerOutline, dx: number, dy: number): DrawerOutline {
+  return {
+    vertices: outline.vertices.map((v) =>
+      v.bulge === undefined
+        ? { x: v.x + dx, y: v.y + dy }
+        : { x: v.x + dx, y: v.y + dy, bulge: v.bulge }
+    ),
+  };
+}
+
+/**
+ * Rotate 180° about the extent center: (x,y) → (W−x, D−y). Rotation preserves
+ * winding and sweep direction, so vertex order and bulges are unchanged.
+ * Drops the authoring annotation (pipeline-only op).
+ */
+export function rotateOutline180(
+  outline: DrawerOutline,
+  widthMm: number,
+  depthMm: number
+): DrawerOutline {
+  return {
+    vertices: outline.vertices.map((v) =>
+      v.bulge === undefined
+        ? { x: widthMm - v.x, y: depthMm - v.y }
+        : { x: widthMm - v.x, y: depthMm - v.y, bulge: v.bulge }
+    ),
+  };
+}
+
+/**
+ * Stable short hash of the outline GEOMETRY (vertices quantized to 0.01mm,
+ * bulges to 1e-6; `authoring` excluded) — for cache keys and fingerprints.
+ * 32-bit FNV-1a in base36, mirroring `hashMask`.
+ */
+export function hashOutline(outline: DrawerOutline): string {
+  let h = 2166136261;
+  const mix = (value: number): void => {
+    // Two rounds so 32-bit-truncated ints keep their high bits' influence.
+    h = Math.imul(h ^ (value | 0), 16777619);
+    h = Math.imul(h ^ ((value / 4294967296) | 0), 16777619);
+  };
+  for (const v of outline.vertices) {
+    mix(Math.round(v.x / OUTLINE_QUANTUM_MM));
+    mix(Math.round(v.y / OUTLINE_QUANTUM_MM));
+    mix(Math.round((v.bulge ?? 0) * 1e6));
+  }
+  return (h >>> 0).toString(36);
+}
+
+interface MutableVertex {
+  x: number;
+  y: number;
+  bulge: number;
+}
+
+function toMutable(vertices: readonly OutlineVertex[]): MutableVertex[] {
+  return vertices.map((v) => ({ x: v.x, y: v.y, bulge: v.bulge ?? 0 }));
+}
+
+function toVertices(verts: readonly MutableVertex[]): OutlineVertex[] {
+  return verts.map((v) =>
+    Math.abs(v.bulge) < BULGE_EPS ? { x: v.x, y: v.y } : { x: v.x, y: v.y, bulge: v.bulge }
+  );
+}
+
+type Axis = 'x' | 'y';
+
+function coord(p: OutlinePoint, axis: Axis): number {
+  return axis === 'x' ? p.x : p.y;
+}
+
+/** Which side of the clip line to keep: 'min' = `coord ≤ k`, 'max' = `coord ≥ k`. */
+type KeepSide = 'min' | 'max';
+
+/**
+ * Clip the loop against an axis-aligned half-plane, splitting arcs at the
+ * clip line (sub-arc bulges recomputed from the sub-sweep). Gaps between kept
+ * pieces close with straight connectors, which necessarily lie on the clip
+ * line. Returns null when fewer than 3 vertices survive.
+ */
+function clipHalfPlane(
+  verts: readonly MutableVertex[],
+  axis: Axis,
+  k: number,
+  keep: KeepSide = 'min'
+): MutableVertex[] | null {
+  const inside = (p: OutlinePoint): boolean =>
+    keep === 'min' ? coord(p, axis) <= k + LINE_EPS : coord(p, axis) >= k - LINE_EPS;
+  const out: MutableVertex[] = [];
+
+  const append = (p: OutlinePoint, bulge: number): void => {
+    const last = out.at(-1);
+    if (last !== undefined && Math.hypot(last.x - p.x, last.y - p.y) < COINCIDENT_EPS) {
+      last.bulge = bulge;
+      return;
+    }
+    out.push({ x: p.x, y: p.y, bulge });
+  };
+
+  const n = verts.length;
+  for (let i = 0; i < n; i++) {
+    const a = verts[i];
+    const b = verts[(i + 1) % n];
+    const arc = arcGeometry(a, b, a.bulge);
+
+    if (arc === null) {
+      const aIn = inside(a);
+      const bIn = inside(b);
+      if (aIn && bIn) {
+        append(a, a.bulge);
+        append(b, 0);
+      } else if (aIn !== bIn) {
+        const t = (k - coord(a, axis)) / (coord(b, axis) - coord(a, axis));
+        const ix = a.x + (b.x - a.x) * t;
+        const iy = a.y + (b.y - a.y) * t;
+        if (aIn) {
+          append(a, a.bulge);
+          append({ x: ix, y: iy }, 0);
+        } else {
+          append({ x: ix, y: iy }, 0);
+          append(b, 0);
+        }
+      }
+      continue;
+    }
+
+    // Arc: find clip-line crossings as sweep parameters, then keep the
+    // sub-arcs whose midpoints are inside. An arc can dip out and back in
+    // even when both endpoints are inside.
+    const center = axis === 'x' ? arc.cx : arc.cy;
+    const dist = k - center;
+    const cuts: number[] = [];
+    if (Math.abs(dist) < arc.r) {
+      const off = Math.sqrt(arc.r * arc.r - dist * dist);
+      const angles =
+        axis === 'x'
+          ? [Math.atan2(off, dist), Math.atan2(-off, dist)]
+          : [Math.atan2(dist, off), Math.atan2(dist, -off)];
+      for (const angle of angles) {
+        let delta = angle - arc.startAngle;
+        const tau = 2 * Math.PI;
+        delta = arc.sweep > 0 ? ((delta % tau) + tau) % tau : -(((-delta % tau) + tau) % tau);
+        const t = delta / arc.sweep;
+        if (t > 1e-6 && t < 1 - 1e-6) cuts.push(t);
+      }
+      cuts.sort((p, q) => p - q);
+    }
+    const bounds = [0, ...cuts, 1];
+    for (let s = 0; s < bounds.length - 1; s++) {
+      const t0 = bounds[s];
+      const t1 = bounds[s + 1];
+      if (!inside(arcPointAt(arc, (t0 + t1) / 2))) continue;
+      const p0 = t0 === 0 ? a : arcPointAt(arc, t0);
+      const p1 = t1 === 1 ? b : arcPointAt(arc, t1);
+      append(p0, bulgeForSweep(arc.sweep * (t1 - t0)));
+      append(p1, 0);
+    }
+  }
+
+  while (
+    out.length > 1 &&
+    Math.hypot(out[out.length - 1].x - out[0].x, out[out.length - 1].y - out[0].y) < COINCIDENT_EPS
+  ) {
+    out.pop();
+  }
+  return out.length >= 3 ? out : null;
+}
+
+/**
+ * Extend the loop across a grown drawer edge. The grown strip
+ * (`newRect \ oldRect` on this axis) defaults to inside, welded to the shape
+ * along the segment run the outline shares with the moved edge. Exactly one
+ * maximal run must exist: zero means the strip would be disconnected, two or
+ * more would enclose a hole — both unrepresentable, so the caller resets to a
+ * full rectangle (returns null).
+ */
+function growAxis(
+  verts: readonly MutableVertex[],
+  axis: Axis,
+  oldK: number,
+  newK: number,
+  crossExtent: number
+): MutableVertex[] | null {
+  const n = verts.length;
+  const onEdge = (i: number): boolean => {
+    const a = verts[i];
+    const b = verts[(i + 1) % n];
+    return (
+      Math.abs(a.bulge) < BULGE_EPS &&
+      Math.abs(coord(a, axis) - oldK) <= LINE_EPS &&
+      Math.abs(coord(b, axis) - oldK) <= LINE_EPS
+    );
+  };
+
+  const runStarts: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (onEdge(i) && !onEdge((i - 1 + n) % n)) runStarts.push(i);
+  }
+  if (runStarts.length !== 1) return null;
+
+  let runEnd = runStarts[0];
+  while (onEdge(runEnd)) runEnd = (runEnd + 1) % n;
+
+  // Rotate so the run's interior vertices sit at the end of the array:
+  // rotated[0] follows the run, rotated[last] starts it.
+  const start = runStarts[0];
+  const rotated: MutableVertex[] = [];
+  for (let i = runEnd; i !== start; i = (i + 1) % n) rotated.push(verts[i]);
+  const runStartVertex = verts[start];
+  const runEndVertex = verts[runEnd];
+
+  // Walk the strip's boundary from weld start to weld end (CCW, interior
+  // left). X axis: down the old edge, around the strip; Y axis mirrored.
+  const detour: MutableVertex[] = [{ ...runStartVertex, bulge: 0 }];
+  const push = (x: number, y: number): void => {
+    const last = detour[detour.length - 1];
+    if (Math.hypot(last.x - x, last.y - y) >= COINCIDENT_EPS) {
+      detour.push({ x, y, bulge: 0 });
+    }
+  };
+  if (axis === 'x') {
+    push(oldK, 0);
+    push(newK, 0);
+    push(newK, crossExtent);
+    push(oldK, crossExtent);
+  } else {
+    push(crossExtent, oldK);
+    push(crossExtent, newK);
+    push(0, newK);
+    push(0, oldK);
+  }
+  const last = detour[detour.length - 1];
+  if (Math.hypot(last.x - runEndVertex.x, last.y - runEndVertex.y) < COINCIDENT_EPS) {
+    detour.pop();
+  }
+
+  return [...rotated, ...detour];
+}
+
+function isFullRectangle(outline: DrawerOutline, widthMm: number, depthMm: number): boolean {
+  for (const v of outline.vertices) {
+    const onX = Math.abs(v.x) <= OUTLINE_SNAP_EPS || Math.abs(v.x - widthMm) <= OUTLINE_SNAP_EPS;
+    const onY = Math.abs(v.y) <= OUTLINE_SNAP_EPS || Math.abs(v.y - depthMm) <= OUTLINE_SNAP_EPS;
+    if (!onX && !onY) return false;
+  }
+  const area = polylineSignedArea(flattenOutline(outline));
+  return area >= widthMm * depthMm - OUTLINE_SNAP_EPS * 2 * (widthMm + depthMm);
+}
+
+function dropCoincident(verts: MutableVertex[]): MutableVertex[] {
+  const out: MutableVertex[] = [];
+  for (const v of verts) {
+    const prev = out.at(-1);
+    if (prev !== undefined && Math.hypot(prev.x - v.x, prev.y - v.y) < COINCIDENT_EPS) {
+      prev.bulge = v.bulge;
+      continue;
+    }
+    out.push(v);
+  }
+  while (
+    out.length > 1 &&
+    Math.hypot(out[out.length - 1].x - out[0].x, out[out.length - 1].y - out[0].y) < COINCIDENT_EPS
+  ) {
+    out.pop();
+  }
+  return out;
+}
+
+/**
+ * Adapt an outline to resized drawer dims (mm): cropped where the drawer
+ * shrank, extended (new area inside) where it grew. Returns:
+ * - the same outline when dims are unchanged,
+ * - a new outline when the crop/extend succeeded,
+ * - `undefined` when the result is the full rectangle OR degenerate/invalid —
+ *   the caller must fall back to a plain rectangular drawer (drop the field).
+ *
+ * The authoring annotation is dropped whenever geometry changes; editors
+ * re-derive their state from geometry.
+ */
+export function resizeDrawerOutline(
+  outline: DrawerOutline,
+  oldWidthMm: number,
+  oldDepthMm: number,
+  newWidthMm: number,
+  newDepthMm: number,
+  gridUnitMm: number
+): DrawerOutline | undefined {
+  const sameW = Math.abs(newWidthMm - oldWidthMm) < OUTLINE_QUANTUM_MM;
+  const sameD = Math.abs(newDepthMm - oldDepthMm) < OUTLINE_QUANTUM_MM;
+  if (sameW && sameD) return outline;
+
+  let verts: MutableVertex[] | null = toMutable(outline.vertices);
+  if (!sameW) {
+    verts =
+      newWidthMm < oldWidthMm
+        ? clipHalfPlane(verts, 'x', newWidthMm)
+        : growAxis(verts, 'x', oldWidthMm, newWidthMm, oldDepthMm);
+  }
+  if (verts !== null && !sameD) {
+    verts =
+      newDepthMm < oldDepthMm
+        ? clipHalfPlane(verts, 'y', newDepthMm)
+        : growAxis(verts, 'y', oldDepthMm, newDepthMm, newWidthMm);
+  }
+  if (verts === null) return undefined;
+
+  verts = dropCoincident(verts);
+  if (verts.length < 3) return undefined;
+
+  const candidate = snapOutlineToBounds(
+    quantizeOutline({ vertices: toVertices(verts) }),
+    newWidthMm,
+    newDepthMm
+  );
+  if (isFullRectangle(candidate, newWidthMm, newDepthMm)) return undefined;
+  if (validateOutline(candidate, newWidthMm, newDepthMm, gridUnitMm) !== null) return undefined;
+  return candidate;
+}
+
+/**
+ * Read-side ingress guard: never trust a stored outline. Crops it to the
+ * current drawer extent (an old client may have resized the drawer without
+ * touching the outline), quantizes/snaps, and drops it entirely when invalid
+ * or rectangle-equivalent. Returns the input layout when nothing changes.
+ */
+export function normalizeDrawerOutline(layout: Layout): Layout {
+  const outline = layout.drawer.outline;
+  if (outline === undefined) return layout;
+
+  const widthMm = (layout.drawer.width as number) * (layout.gridUnitMm as number);
+  const depthMm = (layout.drawer.depth as number) * (layout.gridUnitMm as number);
+
+  const drop = (): Layout => {
+    const drawer = { ...layout.drawer };
+    delete drawer.outline;
+    return { ...layout, drawer };
+  };
+
+  let verts: MutableVertex[] | null = toMutable(outline.vertices);
+  verts = clipHalfPlane(verts, 'x', widthMm, 'min');
+  if (verts !== null) verts = clipHalfPlane(verts, 'y', depthMm, 'min');
+  if (verts !== null) verts = clipHalfPlane(verts, 'x', 0, 'max');
+  if (verts !== null) verts = clipHalfPlane(verts, 'y', 0, 'max');
+  if (verts === null) return drop();
+
+  verts = dropCoincident(verts);
+  if (verts.length < 3) return drop();
+
+  const candidate = snapOutlineToBounds(
+    quantizeOutline({ vertices: toVertices(verts), authoring: outline.authoring }),
+    widthMm,
+    depthMm
+  );
+  if (isFullRectangle(candidate, widthMm, depthMm)) return drop();
+  if (validateOutline(candidate, widthMm, depthMm, layout.gridUnitMm) !== null) {
+    return drop();
+  }
+
+  const unchanged =
+    candidate.vertices.length === outline.vertices.length &&
+    candidate.vertices.every((v, i) => {
+      const o = outline.vertices[i];
+      return v.x === o.x && v.y === o.y && (v.bulge ?? 0) === (o.bulge ?? 0);
+    });
+  if (unchanged) return layout;
+  return { ...layout, drawer: { ...layout.drawer, outline: candidate } };
+}

--- a/src/shared/utils/drawerOutlineCells.test.ts
+++ b/src/shared/utils/drawerOutlineCells.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DrawerOutline } from '@/core/types';
+import { gridUnits, heightUnits } from '@/core/types';
+import { getOutsideCellSet } from './drawerOutlineCells';
+
+const U = 42;
+
+const L_SHAPE: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 4 * U, y: 0 },
+    { x: 4 * U, y: 2 * U },
+    { x: 2 * U, y: 2 * U },
+    { x: 2 * U, y: 4 * U },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+const CHAMFER: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 4 * U, y: 0 },
+    { x: 4 * U, y: 2 * U },
+    { x: 2 * U, y: 4 * U },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+function drawer(width: number, depth: number): Parameters<typeof getOutsideCellSet>[1] {
+  return { width: gridUnits(width), depth: gridUnits(depth), height: heightUnits(6) };
+}
+
+describe('getOutsideCellSet', () => {
+  it('marks exactly the notch cells at whole-cell step', () => {
+    const outside = getOutsideCellSet(L_SHAPE, drawer(4, 4), U, 1);
+    expect(outside).toEqual(new Set(['2,2', '3,2', '2,3', '3,3']));
+  });
+
+  it('marks the notch at half-grid step', () => {
+    const outside = getOutsideCellSet(L_SHAPE, drawer(4, 4), U, 0.5);
+    expect(outside.size).toBe(16);
+    expect(outside.has('2,2')).toBe(true);
+    expect(outside.has('3.5,3.5')).toBe(true);
+    expect(outside.has('1.5,1.5')).toBe(false);
+  });
+
+  it('includes partial (diagonal-crossed) cells — hatched iff placement fails', () => {
+    const outside = getOutsideCellSet(CHAMFER, drawer(4, 4), U, 1);
+    expect(outside).toEqual(new Set(['3,2', '2,3', '3,3']));
+  });
+
+  it('memoizes per outline reference and params', () => {
+    const a = getOutsideCellSet(L_SHAPE, drawer(4, 4), U, 1);
+    expect(getOutsideCellSet(L_SHAPE, drawer(4, 4), U, 1)).toBe(a);
+    expect(getOutsideCellSet(L_SHAPE, drawer(4, 4), U, 0.5)).not.toBe(a);
+  });
+
+  it('respects fractional drawer edges', () => {
+    const halfCol: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 3.5 * U, y: 0 },
+        { x: 3.5 * U, y: 2 * U },
+        { x: 2 * U, y: 2 * U },
+        { x: 2 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const outsideEnd = getOutsideCellSet(
+      halfCol,
+      { ...drawer(3.5, 4), fractionalEdgeX: 'end' },
+      U,
+      1
+    );
+    // Columns at x=0,1,2 plus the trailing half column at x=3.
+    expect(outsideEnd).toEqual(new Set(['2,2', '3,2', '2,3', '3,3']));
+    const outsideStart = getOutsideCellSet(
+      halfCol,
+      { ...drawer(3.5, 4), fractionalEdgeX: 'start' },
+      U,
+      1
+    );
+    // Leading half column at x=0, full columns at 0.5, 1.5, 2.5.
+    expect(outsideStart).toEqual(new Set(['1.5,2', '2.5,2', '1.5,3', '2.5,3']));
+  });
+});

--- a/src/shared/utils/drawerOutlineCells.ts
+++ b/src/shared/utils/drawerOutlineCells.ts
@@ -1,0 +1,85 @@
+/**
+ * Cell-level view of a `DrawerOutline` for the grid editor: which cells are
+ * NOT fully inside the shape. Rendering (hatching) and fill tools consume the
+ * cell set; exact placement validation uses `isFootprintInsideOutline` — both
+ * derive from the same `classifyRect` predicate, so a hatched cell is exactly
+ * a cell placement would reject.
+ */
+
+import type { Drawer, DrawerOutline, FractionalEdge } from '@/core/types';
+import { classifyRect } from './drawerOutlineGeometry';
+
+/** One cell along an axis: start coordinate and size, both in grid units. */
+interface AxisCell {
+  readonly start: number;
+  readonly size: number;
+}
+
+/**
+ * Decompose an axis into cells of `step` grid units, with any fractional
+ * remainder placed per the drawer's fractional edge ('start' = leading).
+ */
+function axisCells(units: number, step: number, fractionalEdge: FractionalEdge): AxisCell[] {
+  const cells: AxisCell[] = [];
+  const fullCount = Math.floor(units / step + 1e-9);
+  const remainder = units - fullCount * step;
+  const hasRemainder = remainder > 1e-9;
+  let pos = 0;
+  if (hasRemainder && fractionalEdge === 'start') {
+    cells.push({ start: 0, size: remainder });
+    pos = remainder;
+  }
+  for (let i = 0; i < fullCount; i++) {
+    cells.push({ start: pos, size: step });
+    pos += step;
+  }
+  if (hasRemainder && fractionalEdge === 'end') {
+    cells.push({ start: pos, size: remainder });
+  }
+  return cells;
+}
+
+const cellSetCache = new WeakMap<DrawerOutline, Map<string, ReadonlySet<string>>>();
+
+/**
+ * Keys (`"x,y"`, grid units, matching the fill/occupancy convention) of every
+ * cell not fully inside the outline. Memoized per outline reference.
+ *
+ * @param step - 1 for whole cells, 0.5 for half-grid mode.
+ */
+export function getOutsideCellSet(
+  outline: DrawerOutline,
+  drawer: Pick<Drawer, 'width' | 'depth' | 'fractionalEdgeX' | 'fractionalEdgeY'>,
+  gridUnitMm: number,
+  step: 0.5 | 1
+): ReadonlySet<string> {
+  const width = drawer.width as number;
+  const depth = drawer.depth as number;
+  const fx = drawer.fractionalEdgeX ?? 'end';
+  const fy = drawer.fractionalEdgeY ?? 'end';
+  const cacheKey = `${width},${depth},${gridUnitMm},${step},${fx},${fy}`;
+
+  let byParams = cellSetCache.get(outline);
+  if (byParams === undefined) {
+    byParams = new Map();
+    cellSetCache.set(outline, byParams);
+  }
+  const cached = byParams.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const outside = new Set<string>();
+  for (const cx of axisCells(width, step, fx)) {
+    for (const cy of axisCells(depth, step, fy)) {
+      const cls = classifyRect(
+        outline,
+        cx.start * gridUnitMm,
+        cy.start * gridUnitMm,
+        (cx.start + cx.size) * gridUnitMm,
+        (cy.start + cy.size) * gridUnitMm
+      );
+      if (cls !== 'inside') outside.add(`${cx.start},${cy.start}`);
+    }
+  }
+  byParams.set(cacheKey, outside);
+  return outside;
+}

--- a/src/shared/utils/drawerOutlineGeometry.test.ts
+++ b/src/shared/utils/drawerOutlineGeometry.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DrawerOutline } from '@/core/types';
+import {
+  arcGeometry,
+  arcPointAt,
+  classifyRect,
+  flattenOutline,
+  insideAreaFraction,
+  isFootprintInsideOutline,
+  outlineSignedArea,
+  pointInOutline,
+} from './drawerOutlineGeometry';
+
+const U = 42;
+
+/** 4×4-unit drawer with the top-right 2×2 cells notched out (L-shape). */
+const L_SHAPE: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 4 * U, y: 0 },
+    { x: 4 * U, y: 2 * U },
+    { x: 2 * U, y: 2 * U },
+    { x: 2 * U, y: 4 * U },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+/** 4×4-unit drawer with the top-right corner chamfered along the diagonal. */
+const CHAMFER: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 4 * U, y: 0 },
+    { x: 4 * U, y: 2 * U },
+    { x: 2 * U, y: 4 * U },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+/** 4×4-unit drawer whose back edge bows inward as a circular arc.
+ * Traveling −x along the back edge, a negative bulge bows left = into the
+ * drawer (DXF: positive bulge bows right of travel). */
+const CURVED_BACK: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 4 * U, y: 0 },
+    { x: 4 * U, y: 4 * U, bulge: -0.25 },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+describe('arcGeometry', () => {
+  it('computes a semicircle from bulge 1, bowing right of travel', () => {
+    const arc = arcGeometry({ x: 0, y: 0 }, { x: 10, y: 0 }, 1);
+    expect(arc).not.toBeNull();
+    expect(arc?.r).toBeCloseTo(5);
+    expect(arc?.cx).toBeCloseTo(5);
+    expect(arc?.cy).toBeCloseTo(0);
+    expect(arc?.sweep).toBeCloseTo(Math.PI);
+    const apex = arcPointAt(arc as NonNullable<typeof arc>, 0.5);
+    expect(apex.x).toBeCloseTo(5);
+    expect(apex.y).toBeCloseTo(-5);
+  });
+
+  it('bulge sign flips the arc side', () => {
+    const arc = arcGeometry({ x: 0, y: 0 }, { x: 10, y: 0 }, -1);
+    const apex = arcPointAt(arc as NonNullable<typeof arc>, 0.5);
+    expect(apex.y).toBeCloseTo(5);
+  });
+
+  it('lands on the end point for non-semicircle bulges', () => {
+    for (const bulge of [0.5, -0.5, 0.25, -0.8]) {
+      const arc = arcGeometry({ x: 2, y: 3 }, { x: 12, y: 7 }, bulge);
+      const end = arcPointAt(arc as NonNullable<typeof arc>, 1);
+      expect(end.x).toBeCloseTo(12);
+      expect(end.y).toBeCloseTo(7);
+      const start = arcPointAt(arc as NonNullable<typeof arc>, 0);
+      expect(start.x).toBeCloseTo(2);
+      expect(start.y).toBeCloseTo(3);
+    }
+  });
+
+  it('returns null for straight and degenerate segments', () => {
+    expect(arcGeometry({ x: 0, y: 0 }, { x: 10, y: 0 }, 0)).toBeNull();
+    expect(arcGeometry({ x: 3, y: 3 }, { x: 3, y: 3 }, 0.5)).toBeNull();
+  });
+});
+
+describe('flattenOutline', () => {
+  it('keeps straight outlines as their vertices', () => {
+    expect(flattenOutline(L_SHAPE)).toHaveLength(6);
+  });
+
+  it('subdivides arcs within chord tolerance and memoizes on reference', () => {
+    const pts = flattenOutline(CURVED_BACK);
+    expect(pts.length).toBeGreaterThan(4);
+    expect(flattenOutline(CURVED_BACK)).toBe(pts);
+    const arc = arcGeometry(
+      CURVED_BACK.vertices[2],
+      CURVED_BACK.vertices[3],
+      CURVED_BACK.vertices[2].bulge as number
+    );
+    const a = arc as NonNullable<typeof arc>;
+    const originals = new Set(CURVED_BACK.vertices.map((v) => `${v.x},${v.y}`));
+    const subdivided = pts.filter((p) => !originals.has(`${p.x},${p.y}`));
+    expect(subdivided.length).toBeGreaterThan(0);
+    for (const p of subdivided) {
+      expect(Math.hypot(p.x - a.cx, p.y - a.cy)).toBeCloseTo(a.r, 5);
+    }
+  });
+});
+
+describe('outlineSignedArea', () => {
+  it('is positive for CCW loops and matches known areas', () => {
+    expect(outlineSignedArea(L_SHAPE)).toBeCloseTo(16 * U * U - 4 * U * U);
+    expect(outlineSignedArea(CHAMFER)).toBeCloseTo(16 * U * U - 2 * U * U);
+  });
+});
+
+describe('pointInOutline', () => {
+  it('distinguishes body from notch', () => {
+    expect(pointInOutline(L_SHAPE, U, U)).toBe(true);
+    expect(pointInOutline(L_SHAPE, 3 * U, 3 * U)).toBe(false);
+    expect(pointInOutline(L_SHAPE, 5 * U, U)).toBe(false);
+  });
+});
+
+describe('classifyRect', () => {
+  const cell = (cx: number, cy: number): [number, number, number, number] => [
+    cx * U,
+    cy * U,
+    (cx + 1) * U,
+    (cy + 1) * U,
+  ];
+
+  it('classifies L-shape cells inside/outside', () => {
+    expect(classifyRect(L_SHAPE, ...cell(0, 0))).toBe('inside');
+    expect(classifyRect(L_SHAPE, ...cell(3, 1))).toBe('inside');
+    expect(classifyRect(L_SHAPE, ...cell(2, 2))).toBe('outside');
+    expect(classifyRect(L_SHAPE, ...cell(3, 3))).toBe('outside');
+  });
+
+  it('treats boundary-on-gridline cells as fully covered, not partial', () => {
+    // The notch edges lie exactly on grid lines: the abutting body cells must
+    // classify 'inside' so rectilinear shapes get full pockets everywhere.
+    expect(classifyRect(L_SHAPE, ...cell(1, 2))).toBe('inside');
+    expect(classifyRect(L_SHAPE, ...cell(3, 1))).toBe('inside');
+    expect(classifyRect(L_SHAPE, ...cell(1, 3))).toBe('inside');
+  });
+
+  it('marks diagonal-crossed cells partial', () => {
+    expect(classifyRect(CHAMFER, ...cell(3, 2))).toBe('partial');
+    expect(classifyRect(CHAMFER, ...cell(2, 3))).toBe('partial');
+    expect(classifyRect(CHAMFER, ...cell(3, 3))).toBe('outside');
+    expect(classifyRect(CHAMFER, ...cell(0, 0))).toBe('inside');
+  });
+
+  it('marks arc-crossed cells partial', () => {
+    expect(classifyRect(CURVED_BACK, ...cell(1, 3))).toBe('partial');
+    expect(classifyRect(CURVED_BACK, ...cell(1, 0))).toBe('inside');
+  });
+
+  it('classifies a rect that fully contains the outline as partial', () => {
+    expect(classifyRect(L_SHAPE, -U, -U, 10 * U, 10 * U)).toBe('partial');
+  });
+});
+
+describe('insideAreaFraction', () => {
+  it('is 1 inside, 0 in the notch, ~0.5 on the diagonal', () => {
+    expect(insideAreaFraction(L_SHAPE, 0, 0, U, U)).toBe(1);
+    expect(insideAreaFraction(L_SHAPE, 3 * U, 3 * U, 4 * U, 4 * U)).toBe(0);
+    const diag = insideAreaFraction(CHAMFER, 3 * U, 2 * U, 4 * U, 3 * U);
+    expect(diag).toBeGreaterThan(0.25);
+    expect(diag).toBeLessThan(0.75);
+  });
+});
+
+describe('isFootprintInsideOutline', () => {
+  it('accepts boundary-flush footprints and rejects notch overlap', () => {
+    expect(isFootprintInsideOutline({ x: 0, y: 0, width: 2, depth: 4 }, L_SHAPE, U)).toBe(true);
+    expect(isFootprintInsideOutline({ x: 0, y: 0, width: 4, depth: 2 }, L_SHAPE, U)).toBe(true);
+    expect(isFootprintInsideOutline({ x: 1, y: 1, width: 2, depth: 2 }, L_SHAPE, U)).toBe(false);
+    expect(isFootprintInsideOutline({ x: 2, y: 2, width: 1, depth: 1 }, L_SHAPE, U)).toBe(false);
+  });
+
+  it('supports half-grid footprints', () => {
+    expect(isFootprintInsideOutline({ x: 1.5, y: 1.5, width: 0.5, depth: 0.5 }, L_SHAPE, U)).toBe(
+      true
+    );
+    expect(isFootprintInsideOutline({ x: 1.5, y: 1.5, width: 1, depth: 1 }, L_SHAPE, U)).toBe(
+      false
+    );
+  });
+});

--- a/src/shared/utils/drawerOutlineGeometry.ts
+++ b/src/shared/utils/drawerOutlineGeometry.ts
@@ -26,7 +26,12 @@ export const ARC_FLATTEN_TOLERANCE = 0.05;
 /** Bulges smaller than this are treated as straight segments. */
 export const BULGE_EPS = 1e-9;
 
-const MAX_ARC_STEPS = 64;
+/**
+ * With |bulge| ≤ 1 (sweep ≤ 180°) inside a 50-unit drawer, the largest valid
+ * radius is ~half the bbox diagonal (~1485mm), which needs ~192 steps to hold
+ * ARC_FLATTEN_TOLERANCE — so 256 never truncates a valid outline's accuracy.
+ */
+const MAX_ARC_STEPS = 256;
 
 export interface ArcGeometry {
   readonly cx: number;
@@ -181,8 +186,10 @@ export type RegionClass = 'inside' | 'outside' | 'partial';
 /**
  * Classify an axis-aligned rect (drawer-local mm) against the outline.
  * The rect is inset by {@link BOUNDARY_EPS} first, so boundary-coincident
- * geometry counts as covered. 'partial' = the outline's boundary passes
- * through the (inset) rect; otherwise the center point decides in/out.
+ * geometry counts as covered. 'partial' = any part of the outline's boundary
+ * lies within the (inset) rect — whether passing through or fully contained
+ * (a rect enclosing the whole outline is 'partial'); otherwise the center
+ * point decides in/out.
  */
 export function classifyRect(
   outline: DrawerOutline,

--- a/src/shared/utils/drawerOutlineGeometry.ts
+++ b/src/shared/utils/drawerOutlineGeometry.ts
@@ -1,0 +1,256 @@
+/**
+ * Analytic geometry for `DrawerOutline` — flattening, region classification,
+ * and arc math. Deliberately brepjs/WASM-free so the same classifier runs on
+ * the main thread (placement validation, hatching, split planning) and inside
+ * the generation worker (pocket selection); a single implementation is what
+ * keeps those decisions from drifting (the `cellMask.ts` precedent).
+ */
+
+import type { DrawerOutline } from '@/core/types';
+
+export interface OutlinePoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * Rects are inset by this (mm) before boundary tests so an outline segment
+ * lying exactly on a grid line or the drawer bbox classifies the abutting
+ * cell 'inside' — rectilinear cell-paint outlines must yield full pockets.
+ */
+export const BOUNDARY_EPS = 0.05;
+
+/** Max chord deviation (mm) when flattening arcs. Far below print tolerance. */
+export const ARC_FLATTEN_TOLERANCE = 0.05;
+
+/** Bulges smaller than this are treated as straight segments. */
+export const BULGE_EPS = 1e-9;
+
+const MAX_ARC_STEPS = 64;
+
+export interface ArcGeometry {
+  readonly cx: number;
+  readonly cy: number;
+  readonly r: number;
+  /** Angle of the segment start point around the center. */
+  readonly startAngle: number;
+  /** Signed sweep (radians), positive = CCW. `4·atan(bulge)`. */
+  readonly sweep: number;
+}
+
+/**
+ * Circle parameters for an arc segment given its endpoints and bulge
+ * (`bulge = tan(sweep/4)`). Returns null for straight/degenerate segments.
+ */
+export function arcGeometry(p0: OutlinePoint, p1: OutlinePoint, bulge: number): ArcGeometry | null {
+  if (Math.abs(bulge) < BULGE_EPS) return null;
+  const dx = p1.x - p0.x;
+  const dy = p1.y - p0.y;
+  const chord = Math.hypot(dx, dy);
+  if (chord < BULGE_EPS) return null;
+  const sweep = 4 * Math.atan(bulge);
+  const r = (chord * (1 + bulge * bulge)) / (4 * Math.abs(bulge));
+  // DXF convention: positive bulge sweeps CCW around the center, bowing the
+  // arc to the RIGHT of the travel direction. The center then sits on the
+  // LEFT normal at signed distance c(1−b²)/(4b) from the chord midpoint.
+  const nx = -dy / chord;
+  const ny = dx / chord;
+  const centerOffset = (chord * (1 - bulge * bulge)) / (4 * bulge);
+  const cx = (p0.x + p1.x) / 2 + nx * centerOffset;
+  const cy = (p0.y + p1.y) / 2 + ny * centerOffset;
+  return { cx, cy, r, startAngle: Math.atan2(p0.y - cy, p0.x - cx), sweep };
+}
+
+/** Point on an arc at parameter `t` ∈ [0,1] along the sweep. */
+export function arcPointAt(arc: ArcGeometry, t: number): OutlinePoint {
+  const a = arc.startAngle + arc.sweep * t;
+  return { x: arc.cx + arc.r * Math.cos(a), y: arc.cy + arc.r * Math.sin(a) };
+}
+
+/** Bulge value for an arc spanning `sweep` radians (sign preserved). */
+export function bulgeForSweep(sweep: number): number {
+  return Math.tan(sweep / 4);
+}
+
+const flattenCache = new WeakMap<DrawerOutline, readonly OutlinePoint[]>();
+
+/**
+ * Flatten an outline to a closed polyline (no duplicated closing point).
+ * Arcs are subdivided to ≤{@link ARC_FLATTEN_TOLERANCE} chord error.
+ * Memoized on the outline reference — outlines are immutable by contract.
+ */
+export function flattenOutline(outline: DrawerOutline): readonly OutlinePoint[] {
+  const cached = flattenCache.get(outline);
+  if (cached !== undefined) return cached;
+
+  const pts: OutlinePoint[] = [];
+  const n = outline.vertices.length;
+  for (let i = 0; i < n; i++) {
+    const v = outline.vertices[i];
+    pts.push({ x: v.x, y: v.y });
+    const bulge = v.bulge ?? 0;
+    if (Math.abs(bulge) < BULGE_EPS) continue;
+    const next = outline.vertices[(i + 1) % n];
+    const arc = arcGeometry(v, next, bulge);
+    if (arc === null) continue;
+    const maxStep =
+      arc.r > ARC_FLATTEN_TOLERANCE
+        ? 2 * Math.acos(Math.max(0, 1 - ARC_FLATTEN_TOLERANCE / arc.r))
+        : Math.PI;
+    const steps = Math.min(MAX_ARC_STEPS, Math.max(1, Math.ceil(Math.abs(arc.sweep) / maxStep)));
+    for (let s = 1; s < steps; s++) {
+      pts.push(arcPointAt(arc, s / steps));
+    }
+  }
+  flattenCache.set(outline, pts);
+  return pts;
+}
+
+/** Signed area of the outline (positive = CCW), via the flattened polyline. */
+export function outlineSignedArea(outline: DrawerOutline): number {
+  return polylineSignedArea(flattenOutline(outline));
+}
+
+export function polylineSignedArea(pts: readonly OutlinePoint[]): number {
+  let area = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const a = pts[i];
+    const b = pts[(i + 1) % pts.length];
+    area += a.x * b.y - b.x * a.y;
+  }
+  return area / 2;
+}
+
+/** Even-odd ray-cast point-in-polygon on a closed polyline. */
+export function pointInPolyline(pts: readonly OutlinePoint[], x: number, y: number): boolean {
+  let inside = false;
+  for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+    const pi = pts[i];
+    const pj = pts[j];
+    if (pi.y > y !== pj.y > y && x < ((pj.x - pi.x) * (y - pi.y)) / (pj.y - pi.y) + pi.x) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+export function pointInOutline(outline: DrawerOutline, x: number, y: number): boolean {
+  return pointInPolyline(flattenOutline(outline), x, y);
+}
+
+/** Liang–Barsky: does segment a→b intersect the axis-aligned rect? */
+function segmentIntersectsRect(
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+): boolean {
+  const dx = bx - ax;
+  const dy = by - ay;
+  let t0 = 0;
+  let t1 = 1;
+  const clips: ReadonlyArray<readonly [number, number]> = [
+    [-dx, ax - x0],
+    [dx, x1 - ax],
+    [-dy, ay - y0],
+    [dy, y1 - ay],
+  ];
+  for (const [p, q] of clips) {
+    if (p === 0) {
+      if (q < 0) return false;
+      continue;
+    }
+    const t = q / p;
+    if (p < 0) {
+      if (t > t1) return false;
+      if (t > t0) t0 = t;
+    } else {
+      if (t < t0) return false;
+      if (t < t1) t1 = t;
+    }
+  }
+  return t0 <= t1;
+}
+
+export type RegionClass = 'inside' | 'outside' | 'partial';
+
+/**
+ * Classify an axis-aligned rect (drawer-local mm) against the outline.
+ * The rect is inset by {@link BOUNDARY_EPS} first, so boundary-coincident
+ * geometry counts as covered. 'partial' = the outline's boundary passes
+ * through the (inset) rect; otherwise the center point decides in/out.
+ */
+export function classifyRect(
+  outline: DrawerOutline,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+): RegionClass {
+  const pts = flattenOutline(outline);
+  const cx = (x0 + x1) / 2;
+  const cy = (y0 + y1) / 2;
+  const ix0 = x0 + BOUNDARY_EPS;
+  const iy0 = y0 + BOUNDARY_EPS;
+  const ix1 = x1 - BOUNDARY_EPS;
+  const iy1 = y1 - BOUNDARY_EPS;
+  if (ix0 < ix1 && iy0 < iy1) {
+    for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
+      if (segmentIntersectsRect(pts[j].x, pts[j].y, pts[i].x, pts[i].y, ix0, iy0, ix1, iy1)) {
+        return 'partial';
+      }
+    }
+  }
+  return pointInPolyline(pts, cx, cy) ? 'inside' : 'outside';
+}
+
+const AREA_SAMPLES = 4;
+
+/**
+ * Coarse fraction of the rect inside the outline (AREA_SAMPLES² point grid).
+ * Used for sliver rules (e.g. "no pocket when a partial cell keeps <X% of its
+ * area"), where a rough estimate is sufficient.
+ */
+export function insideAreaFraction(
+  outline: DrawerOutline,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+): number {
+  const pts = flattenOutline(outline);
+  let hits = 0;
+  for (let i = 0; i < AREA_SAMPLES; i++) {
+    for (let j = 0; j < AREA_SAMPLES; j++) {
+      const sx = x0 + ((i + 0.5) / AREA_SAMPLES) * (x1 - x0);
+      const sy = y0 + ((j + 0.5) / AREA_SAMPLES) * (y1 - y0);
+      if (pointInPolyline(pts, sx, sy)) hits++;
+    }
+  }
+  return hits / (AREA_SAMPLES * AREA_SAMPLES);
+}
+
+/**
+ * Exact placement test: is the footprint rect (grid units) fully inside the
+ * outline? Boundary-coincident footprints count as inside (a bin flush
+ * against the drawer wall is valid), courtesy of the classify inset.
+ */
+export function isFootprintInsideOutline(
+  rect: { readonly x: number; readonly y: number; readonly width: number; readonly depth: number },
+  outline: DrawerOutline,
+  gridUnitMm: number
+): boolean {
+  return (
+    classifyRect(
+      outline,
+      rect.x * gridUnitMm,
+      rect.y * gridUnitMm,
+      (rect.x + rect.width) * gridUnitMm,
+      (rect.y + rect.depth) * gridUnitMm
+    ) === 'inside'
+  );
+}


### PR DESCRIPTION
## Summary

First PR toward #2528 (non-rectangular baseplates for L/⊓-shaped drawers). Instead of the issue's rectilinear-mask framing, the design models the **drawer outline** as a first-class concept — a single closed CCW loop of line segments + circular arcs (DXF vertex+bulge encoding, drawer-local mm) — so diagonal corner cuts and curved fronts are covered by the same mechanism as rectilinear notches. Cell painting, bin-footprint tracing, corner cuts, and a pen editor become authoring surfaces that all write this one field.

This PR is the pure-TS foundation: types + shared geometry/model modules + tests. Nothing user-visible; no behavior change for layouts without an outline.

## Changes

- `core/types.ts`: `DrawerOutline` / `OutlineVertex` / `CornerCut(Params)` + optional `Drawer.outline`. Vertices array typed mutable for Immer draft compatibility (the `CellMask.cells` precedent) with an immutability contract.
- `shared/utils/drawerOutlineGeometry.ts`: brepjs-free analytic engine — arc math (`bulge = tan(sweep/4)`, positive = CCW sweep bowing right of travel), memoized flattening (≤0.05mm chord error), `classifyRect` → inside/outside/partial with a 0.05mm boundary inset so grid-aligned rectilinear outlines classify abutting cells as fully covered, `insideAreaFraction` (sliver rules), `isFootprintInsideOutline` (placement test). One shared classifier for main thread AND worker so pocket selection, hatching, and split planning can never drift.
- `shared/utils/drawerOutline.ts`: validation (closed/simple/CCW/in-bounds incl. arc bellies/min one grid cell/≤256 vertices), quantization (0.01mm) + bbox snapping, translate/rotate180, FNV-1a geometry hash for cache keys, `resizeDrawerOutline` (arc-aware half-plane crop on shrink; single-weld strip splice on grow; resets to full rectangle when the result would be degenerate, disconnected, or would trap a notch as an interior hole), `normalizeDrawerOutline` read-side ingress guard (crops stale outlines, drops invalid ones).
- `shared/utils/drawerOutlineCells.ts`: memoized outside-cell set for grid hatching/fills, honoring fractional drawer edges; invariant: hatched ⇔ placement fails (same predicate).

## Follow-ups (per the multi-PR plan)

Generation (outline prism ∩ socket grid via the existing corner-rounding intersect slot), split planner support, CQRS command + server validation, layout-tab gating, then the authoring UI behind a labs flag.

## Testing

- 53 unit tests across the three modules: arc conventions pinned (incl. non-semicircle endpoint round-trip), boundary-on-gridline classification, crop-through-arc validity, grow-weld hole detection, hash jitter stability, fractional-edge cell sets, ingress normalization.
- `pnpm run quality` clean (typecheck, lint, knip).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a first-class `Drawer.outline` model (CCW loop of lines + arcs) to support non-rectangular drawers (L/⊓, diagonal, curved) with a single shared classifier. Foundation for Linear #2528; no UI or behavior changes for rectangular layouts.

- **New Features**
  - Added `DrawerOutline`, `OutlineVertex`, `CornerCut(Params)`, and optional `Drawer.outline` in `core/types.ts`.
  - Implemented `shared/utils/drawerOutlineGeometry.ts`: bulge-based arc math, flattening (≤0.05mm), `classifyRect`, `insideAreaFraction`, `isFootprintInsideOutline`, shared by main thread and worker.
  - Added `shared/utils/drawerOutline.ts`: validation (closed/simple/CCW/in-bounds/area), quantization (0.01mm) and bbox snapping, translate/rotate180, geometry-only FNV-1a hash, `resizeDrawerOutline` (crop/grow with arc-aware logic), and `normalizeDrawerOutline`.
  - Added `shared/utils/drawerOutlineCells.ts`: memoized outside-cell set for hatching/fills, honors fractional edges; invariant aligns with placement checks.
  - 53 unit tests pin conventions and edge cases; `pnpm run quality` passes.

- **Bug Fixes**
  - `isFullRectangle` now uses a topology check (segments hug boundary lines) so small corner chamfers are preserved instead of being dropped by an area tolerance.
  - Increased arc flattening cap to 256 steps to keep the ≤0.05mm chord-error guarantee for large-radius arcs; clarified docs for the chord-approximate self-intersection check and `classifyRect` containment semantics.

<sup>Written for commit fa0fb1086c76d267855afd07d1e7c1970f04266a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

