### PR TITLE
feat(baseplate): split shaped plates with outline-aware pieces

### DIFF
--- a/src/features/baseplate/types/tiling.ts
+++ b/src/features/baseplate/types/tiling.ts
@@ -55,16 +55,14 @@ export interface BaseplatePiece {
    */
   readonly placementRotationDeg: 0 | 180;
   /**
-   * Set when the plate outline crosses this piece's window: the piece's
-   * generation params carry a piece-local outline and its mesh is not a plain
-   * rectangle. Fully-inside pieces omit this and stay pure rectangles —
-   * keeping their fingerprints, dedup, and connector behavior identical to an
-   * unshaped plate.
+   * Present exactly when the plate outline crosses this piece's window: the
+   * plate-local mm origin of the window (bottom-left), from which
+   * `pieceToBaseplateParams` derives the piece-local outline. Absent =
+   * fully-inside piece, a pure rectangle whose fingerprints, dedup, and
+   * connector behavior are identical to an unshaped plate. One field carries
+   * both the "partial" flag and its data so they can't drift apart.
    */
-  readonly outlineClass?: 'partial';
-  /** Plate-local mm origin of this piece's window (bottom-left), recorded so
-   * `pieceToBaseplateParams` can translate the outline without re-deriving. */
-  readonly windowOriginMm?: { readonly x: number; readonly y: number };
+  readonly outlineWindowOriginMm?: { readonly x: number; readonly y: number };
 }
 
 /** Hint suggesting a padding reduction that would eliminate a split. */

--- a/src/features/baseplate/types/tiling.ts
+++ b/src/features/baseplate/types/tiling.ts
@@ -54,6 +54,17 @@ export interface BaseplatePiece {
    * its dovetails end up on the correct world-space sides.
    */
   readonly placementRotationDeg: 0 | 180;
+  /**
+   * Set when the plate outline crosses this piece's window: the piece's
+   * generation params carry a piece-local outline and its mesh is not a plain
+   * rectangle. Fully-inside pieces omit this and stay pure rectangles —
+   * keeping their fingerprints, dedup, and connector behavior identical to an
+   * unshaped plate.
+   */
+  readonly outlineClass?: 'partial';
+  /** Plate-local mm origin of this piece's window (bottom-left), recorded so
+   * `pieceToBaseplateParams` can translate the outline without re-deriving. */
+  readonly windowOriginMm?: { readonly x: number; readonly y: number };
 }
 
 /** Hint suggesting a padding reduction that would eliminate a split. */

--- a/src/features/baseplate/utils/fileNaming.ts
+++ b/src/features/baseplate/utils/fileNaming.ts
@@ -28,6 +28,8 @@ interface BaseplateNamingParams {
   readonly paddingFront: number;
   readonly paddingBack: number;
   readonly connectorNubs?: boolean;
+  /** Non-rectangular plate (drawer outline applied). */
+  readonly shaped?: boolean;
 }
 
 /**
@@ -83,6 +85,9 @@ function collectFeatures(params: BaseplateNamingParams): string[] {
     features.push('padded');
   }
 
+  if (params.shaped === true) {
+    features.push('shaped');
+  }
   if (params.connectorNubs) {
     features.push('connectors');
   }
@@ -104,5 +109,6 @@ export function toNamingParams(params: ResolvedBaseplateParams): BaseplateNaming
     paddingFront: params.paddingFront,
     paddingBack: params.paddingBack,
     connectorNubs: params.connectorNubs,
+    shaped: params.outline !== undefined,
   };
 }

--- a/src/features/baseplate/utils/pieceFingerprint.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+import { hashOutline } from '@/shared/utils/drawerOutline';
 import { exteriorCorners, type CornerKey } from '@/shared/generation/baseplateCorners';
 import type { BaseplatePiece } from '../types/tiling';
 import { pieceToBaseplateParams } from './splitPlanner';
@@ -53,6 +54,11 @@ export function computePieceFingerprint(params: ResolvedBaseplateParams): string
     `sf:${params.solidFloor ? 1 : 0}`,
     `sft:${params.solidFloor ? (params.solidFloorThickness ?? '') : ''}`,
     params.cornerRadius === undefined ? 'cr:default' : `cr:${params.cornerRadius}`,
+    // Piece-local outline hash: partial pieces are unique per boundary shape,
+    // but two windows with an identical local view of the boundary (already
+    // translated to piece frame) still dedupe. Fully-inside pieces carry no
+    // outline and keep sharing entries with plain rectangles.
+    params.outline === undefined ? '' : `ol:${hashOutline(params.outline)}`,
   ];
 
   // Edge classification (exterior vs join) affects geometry through two

--- a/src/features/baseplate/utils/pieceFingerprint.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.ts
@@ -54,12 +54,18 @@ export function computePieceFingerprint(params: ResolvedBaseplateParams): string
     `sf:${params.solidFloor ? 1 : 0}`,
     `sft:${params.solidFloor ? (params.solidFloorThickness ?? '') : ''}`,
     params.cornerRadius === undefined ? 'cr:default' : `cr:${params.cornerRadius}`,
-    // Piece-local outline hash: partial pieces are unique per boundary shape,
-    // but two windows with an identical local view of the boundary (already
-    // translated to piece frame) still dedupe. Fully-inside pieces carry no
-    // outline and keep sharing entries with plain rectangles.
-    params.outline === undefined ? '' : `ol:${hashOutline(params.outline)}`,
   ];
+
+  // Piece-local outline hash. Deliberately conservative: it hashes the WHOLE
+  // translated loop, so two windows only dedupe when their entire local view
+  // of the boundary matches — windows whose in-slab geometry is identical but
+  // whose far-away loop parts differ regenerate separately. Correctness is
+  // unaffected (only generation time); a window-clipped canonical form would
+  // need the 2D polygon clipping this design avoids. Fully-inside pieces
+  // carry no outline and keep sharing entries with plain rectangles.
+  if (params.outline !== undefined) {
+    parts.push(`ol:${hashOutline(params.outline)}`);
+  }
 
   // Edge classification (exterior vs join) affects geometry through two
   // independent channels — and keying on the raw labels over-distinguishes

--- a/src/features/baseplate/utils/printGuide.ts
+++ b/src/features/baseplate/utils/printGuide.ts
@@ -259,6 +259,7 @@ function generateHeader(
   uniqueCount: number
 ): string {
   const features: string[] = [];
+  if (params.outline !== undefined) features.push('custom drawer shape');
   if (params.magnetHoles) features.push('magnets');
   const hasPadding =
     params.paddingLeft > 0 ||
@@ -289,6 +290,15 @@ function generateHeader(
     `  Total pieces: ${totalPieces}${totalPieces > 1 ? ` (${uniqueCount} unique)` : ''}`,
     `  Build-plate loads: ${tiling.bedLoads}`,
   ];
+
+  if (params.outline !== undefined && tiling.pieces.length > 1) {
+    lines.push(
+      '',
+      '  Shaped plate: grid positions outside the drawer shape are not',
+      '  printed (their labels are skipped below). Seams the shape crosses',
+      '  have no connectors — align those pieces by their outline instead.'
+    );
+  }
 
   // Surface the connector fit offset whenever connectors are on and the user
   // has dialed it off-nominal — applies to the integral dovetail (which has no

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1643,9 +1643,8 @@ describe('shaped plates (outline-aware splitting)', () => {
     expect(tiling.pieces).toHaveLength(4);
     const a1 = byLabel.get('A1');
     const b2 = byLabel.get('B2');
-    expect(a1?.outlineClass).toBeUndefined();
-    expect(b2?.outlineClass).toBe('partial');
-    expect(b2?.windowOriginMm).toEqual({ x: 4 * U, y: 4 * U });
+    expect(a1?.outlineWindowOriginMm).toBeUndefined();
+    expect(b2?.outlineWindowOriginMm).toEqual({ x: 4 * U, y: 4 * U });
 
     const parent = shapedParams(CHAMFER_OUTLINE);
     const a1Params = pieceToBaseplateParams(a1 as BaseplatePiece, parent);
@@ -1685,6 +1684,6 @@ describe('shaped plates (outline-aware splitting)', () => {
     const a1 = pieceToBaseplateParams(byLabel.get('A1') as BaseplatePiece, parent);
     const b2 = pieceToBaseplateParams(byLabel.get('B2') as BaseplatePiece, parent);
     expect(computePieceFingerprint(b2)).not.toBe(computePieceFingerprint(a1));
-    expect(computePieceFingerprint(b2)).toBe(computePieceFingerprint({ ...b2 }));
+    expect(computePieceFingerprint(b2)).toBe(computePieceFingerprint(b2));
   });
 });

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -9,6 +9,8 @@ import { bodyCenterYMm } from './stackPrint';
 import { TONGUE_PROTRUSION } from '@/features/generation/worker/generators/generatorConstants';
 import { computeConnectorPositions } from '@/features/generation/worker/generators/connectorUtils';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+import type { BaseplatePiece } from '../types/tiling';
+import { computePieceFingerprint } from './pieceFingerprint';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -1568,46 +1570,121 @@ describe('margin-seam connector edge assignment (#2414)', () => {
   });
 });
 
-describe('shaped plates (interim single-piece gate)', () => {
-  const L_SHAPE = {
+describe('shaped plates (outline-aware splitting)', () => {
+  const U = 42;
+  // 189mm bed → 4-unit chunks: an 8×8 plate tiles deterministically 2×2.
+  const BED = 4.5 * U;
+  const shapedParams = (
+    outline: ResolvedBaseplateParams['outline'],
+    overrides: Partial<ResolvedBaseplateParams> = {}
+  ): ResolvedBaseplateParams =>
+    makeParams({
+      width: 8,
+      depth: 8,
+      paddingLeft: 0,
+      paddingRight: 0,
+      paddingFront: 0,
+      paddingBack: 0,
+      connectorNubs: true,
+      outline,
+      ...overrides,
+    });
+
+  /** L: the top-right 4×4 quadrant (exactly piece B2's window) is notched. */
+  const L_OUTLINE = {
     vertices: [
       { x: 0, y: 0 },
-      { x: 16 * 42, y: 0 },
-      { x: 16 * 42, y: 8 * 42 },
-      { x: 8 * 42, y: 8 * 42 },
-      { x: 8 * 42, y: 16 * 42 },
-      { x: 0, y: 16 * 42 },
+      { x: 8 * U, y: 0 },
+      { x: 8 * U, y: 4 * U },
+      { x: 4 * U, y: 4 * U },
+      { x: 4 * U, y: 8 * U },
+      { x: 0, y: 8 * U },
     ],
   };
 
-  it('never splits a shaped plate, even when it exceeds the bed', () => {
-    // 16×16 would normally split on a 256mm bed.
-    const rectTiling = computeBaseplateTiling(makeParams({ width: 16, depth: 16 }), 256);
-    expect(rectTiling.isSplit).toBe(true);
+  /** Diagonal chamfer across the top-right quadrant (x + y = 12u). */
+  const CHAMFER_OUTLINE = {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: 8 * U, y: 0 },
+      { x: 8 * U, y: 4 * U },
+      { x: 4 * U, y: 8 * U },
+      { x: 0, y: 8 * U },
+    ],
+  };
 
-    const shaped = computeBaseplateTiling(
-      makeParams({
-        width: 16,
-        depth: 16,
-        paddingLeft: 0,
-        paddingRight: 0,
-        paddingFront: 0,
-        paddingBack: 0,
-        outline: L_SHAPE,
-      }),
-      256
+  it('drops fully-outside pieces, keeping positional labels', () => {
+    const tiling = computeBaseplateTiling(shapedParams(L_OUTLINE), BED);
+    expect(tiling.isSplit).toBe(true);
+    expect(tiling.pieces.map((p) => p.label).sort()).toEqual(['A1', 'A2', 'B1']);
+    expect(tiling.bedLoads).toBe(3);
+    expect(tiling.paddingReductionHint).toBeNull();
+  });
+
+  it('keeps connectors on full seams, butts seams facing dropped pieces', () => {
+    const tiling = computeBaseplateTiling(shapedParams(L_OUTLINE), BED);
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+    const a1 = byLabel.get('A1');
+    const b1 = byLabel.get('B1');
+    const a2 = byLabel.get('A2');
+    // Both seams into the body are full → connectors survive.
+    expect(a1?.edges.right).toBe('join');
+    expect(a1?.edges.back).toBe('join');
+    expect(b1?.edges.left).toBe('join');
+    expect(a2?.edges.front).toBe('join');
+    // Seams facing the dropped B2 become plain exteriors.
+    expect(b1?.edges.back).toBe('exterior');
+    expect(a2?.edges.right).toBe('exterior');
+  });
+
+  it('inside pieces stay pure rectangles; partial pieces carry a local outline', () => {
+    const tiling = computeBaseplateTiling(shapedParams(CHAMFER_OUTLINE), BED);
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+    expect(tiling.pieces).toHaveLength(4);
+    const a1 = byLabel.get('A1');
+    const b2 = byLabel.get('B2');
+    expect(a1?.outlineClass).toBeUndefined();
+    expect(b2?.outlineClass).toBe('partial');
+    expect(b2?.windowOriginMm).toEqual({ x: 4 * U, y: 4 * U });
+
+    const parent = shapedParams(CHAMFER_OUTLINE);
+    const a1Params = pieceToBaseplateParams(a1 as BaseplatePiece, parent);
+    const b2Params = pieceToBaseplateParams(b2 as BaseplatePiece, parent);
+    // Pure rectangle: identical fingerprint inputs to an unshaped piece.
+    expect(a1Params.outline).toBeUndefined();
+    // Piece-local frame: the diagonal's endpoints translate by the window origin.
+    expect(b2Params.outline?.vertices).toContainEqual({ x: 4 * U, y: 0 });
+    expect(b2Params.outline?.vertices).toContainEqual({ x: 0, y: 4 * U });
+  });
+
+  it('butts a seam the outline crosses (partial seam)', () => {
+    const tiling = computeBaseplateTiling(shapedParams(CHAMFER_OUTLINE), BED);
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+    // The diagonal crosses both of B2's join seams → butt joints on both sides.
+    expect(byLabel.get('B2')?.edges.left).toBe('exterior');
+    expect(byLabel.get('B2')?.edges.front).toBe('exterior');
+    expect(byLabel.get('A2')?.edges.right).toBe('exterior');
+    expect(byLabel.get('B1')?.edges.back).toBe('exterior');
+    // The body seams away from the diagonal keep connectors.
+    expect(byLabel.get('A1')?.edges.right).toBe('join');
+    expect(byLabel.get('A1')?.edges.back).toBe('join');
+  });
+
+  it('forces placement rotation off for shaped tilings', () => {
+    const tiling = computeBaseplateTiling(
+      shapedParams(L_OUTLINE, { preferIdenticalPieces: true }),
+      BED
     );
-    expect(shaped.isSplit).toBe(false);
-    expect(shaped.pieces).toHaveLength(1);
-    expect(shaped.pieces[0].widthUnits).toBe(16);
-    expect(shaped.pieces[0].edges).toEqual({
-      left: 'exterior',
-      right: 'exterior',
-      front: 'exterior',
-      back: 'exterior',
-    });
-    expect(shaped.margins).toHaveLength(0);
-    expect(shaped.bedLoads).toBe(1);
-    expect(shaped.paddingReductionHint).toBeNull();
+    expect(tiling.pieces.every((p) => p.placementRotationDeg === 0)).toBe(true);
+  });
+
+  it('shaped partial pieces fingerprint apart from rectangles, congruent windows together', () => {
+    const parent = shapedParams(CHAMFER_OUTLINE);
+    const tiling = computeBaseplateTiling(parent, BED);
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+    const a1 = pieceToBaseplateParams(byLabel.get('A1') as BaseplatePiece, parent);
+    const b2 = pieceToBaseplateParams(byLabel.get('B2') as BaseplatePiece, parent);
+    expect(computePieceFingerprint(b2)).not.toBe(computePieceFingerprint(a1));
+    expect(computePieceFingerprint(b2)).toBe(computePieceFingerprint({ ...b2 }));
   });
 });

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -1018,14 +1018,25 @@ function applyOutlineToTiling(
       ...piece,
       edges,
       placementRotationDeg: 0,
-      ...(cls === 'partial'
-        ? { outlineClass: 'partial' as const, windowOriginMm: { x: w.x0, y: w.y0 } }
-        : {}),
+      ...(cls === 'partial' ? { outlineWindowOriginMm: { x: w.x0, y: w.y0 } } : {}),
     });
   }
 
+  // Bed-load footprints budget the male tongue protrusion on surviving join
+  // edges, mirroring the axis search's own bed math — otherwise a piece whose
+  // tongues push it past the bed would undercount loads.
+  const tongue = params.connectorNubs === true ? TONGUE_PROTRUSION : 0;
   const bedLoads = estimateBedLoads(
-    survivors.map((piece) => ({ w: piece.widthUnits * u, d: piece.depthUnits * u })),
+    survivors.map((piece) => ({
+      w:
+        piece.widthUnits * u +
+        (piece.edges.left === 'join' ? tongue : 0) +
+        (piece.edges.right === 'join' ? tongue : 0),
+      d:
+        piece.depthUnits * u +
+        (piece.edges.front === 'join' ? tongue : 0) +
+        (piece.edges.back === 'join' ? tongue : 0),
+    })),
     printBedWidthMm,
     printBedDepthMm
   );
@@ -1103,10 +1114,12 @@ export function pieceToBaseplateParams(
   // the window), so no 2D clipping is needed here. Fully-inside pieces carry
   // no outline and stay byte-identical to unshaped rectangles.
   const pieceOutline =
-    parentParams.outline !== undefined &&
-    piece.outlineClass === 'partial' &&
-    piece.windowOriginMm !== undefined
-      ? translateOutline(parentParams.outline, -piece.windowOriginMm.x, -piece.windowOriginMm.y)
+    parentParams.outline !== undefined && piece.outlineWindowOriginMm !== undefined
+      ? translateOutline(
+          parentParams.outline,
+          -piece.outlineWindowOriginMm.x,
+          -piece.outlineWindowOriginMm.y
+        )
       : undefined;
 
   return {

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -33,6 +33,9 @@ import type {
   PieceEdges,
 } from '../types/tiling';
 import { estimateBedLoads, type Footprint } from './bedPacking';
+import type { DrawerOutline } from '@/core/types';
+import { translateOutline } from '@/shared/utils/drawerOutline';
+import { classifyRect, type RegionClass } from '@/shared/utils/drawerOutlineGeometry';
 import { FRACTIONAL_THRESHOLD, isFractional, reorderForDisplay } from './splitReorder';
 
 /**
@@ -747,58 +750,11 @@ function emitMargins(params: ResolvedBaseplateParams, layout: MarginLayout): Mar
  * If the baseplate fits on a single bed, returns a single-piece tiling with
  * `isSplit: false`.
  */
-/**
- * Single whole-plate tiling for shapes the planner can't partition yet.
- * Shaped plates carry zero padding (sanitized), no margins, and no split, so
- * every derived field is the trivial one.
- */
-function computeSinglePieceTiling(params: ResolvedBaseplateParams): BaseplateTiling {
-  const { width, depth, fractionalEdgeX, fractionalEdgeY } = params;
-  return {
-    isSplit: false,
-    pieces: [
-      {
-        label: 'A1',
-        col: 0,
-        row: 0,
-        widthUnits: width,
-        depthUnits: depth,
-        gridOffsetX: 0,
-        gridOffsetY: 0,
-        paddingLeft: params.paddingLeft,
-        paddingRight: params.paddingRight,
-        paddingFront: params.paddingFront,
-        paddingBack: params.paddingBack,
-        fractionalEdgeX: isFractional(width) ? fractionalEdgeX : 'none',
-        fractionalEdgeY: isFractional(depth) ? fractionalEdgeY : 'none',
-        edges: { left: 'exterior', right: 'exterior', front: 'exterior', back: 'exterior' },
-        placementRotationDeg: 0,
-      },
-    ],
-    margins: [],
-    cols: 1,
-    rows: 1,
-    totalWidthUnits: width,
-    totalDepthUnits: depth,
-    bedLoads: 1,
-    stackCount: 1,
-    stackSeparatorThickness: 0,
-    paddingReductionHint: null,
-  };
-}
-
 export function computeBaseplateTiling(
   params: ResolvedBaseplateParams,
   printBedWidthMm: number,
   printBedDepthMm: number = printBedWidthMm
 ): BaseplateTiling {
-  // Interim gate: the planner tiles rectangles only, so splitting a shaped
-  // plate would emit rectangular tiles that include material outside the
-  // drawer boundary. Shaped plates stay single-piece until the planner learns
-  // per-piece outline windows (PR3 of #2528).
-  if (params.outline !== undefined) {
-    return computeSinglePieceTiling(params);
-  }
   const {
     width,
     depth,
@@ -954,7 +910,7 @@ export function computeBaseplateTiling(
     pieceCount
   );
 
-  return {
+  const tiling: BaseplateTiling = {
     isSplit,
     pieces,
     margins: emitMargins(params, { colSizes, rowSizes, colOffsets, rowOffsets }),
@@ -966,6 +922,120 @@ export function computeBaseplateTiling(
     stackCount: 1,
     stackSeparatorThickness: 0,
     paddingReductionHint,
+  };
+  return params.outline !== undefined
+    ? applyOutlineToTiling(tiling, params, printBedWidthMm, printBedDepthMm)
+    : tiling;
+}
+
+/**
+ * Shape a rectangular tiling with the plate outline (issue #2528):
+ *
+ * - pieces whose window is fully OUTSIDE are dropped (their grid labels stay
+ *   positional, so gaps like "A1, A3" read as the shape in the print guide);
+ * - fully-INSIDE pieces stay pure rectangles — no outline on their params, so
+ *   fingerprints, dedup, and connectors behave exactly as on unshaped plates;
+ * - PARTIAL pieces are tagged with their window origin; their generation
+ *   params get a piece-local outline and the 3D intersect performs the window
+ *   clip (the piece slab IS the window).
+ *
+ * Seams keep connectors only when FULL: the one-grid-unit band on each side
+ * of the whole shared span must be fully inside. Partial seams (and seams to
+ * dropped neighbors) become plain butt joints — both facing edges 'exterior'.
+ *
+ * `placementRotationDeg` is forced to 0: the preferIdenticalPieces 180° mesh
+ * sharing pairs opposite corners of a SYMMETRIC tiling, which dropping and
+ * reclassification break. Congruent pieces still dedupe via identical
+ * fingerprints.
+ *
+ * Shaped plates carry zero padding (sanitized upstream), so windows are pure
+ * grid extents and margins are always empty.
+ */
+function applyOutlineToTiling(
+  tiling: BaseplateTiling,
+  params: ResolvedBaseplateParams,
+  printBedWidthMm: number,
+  printBedDepthMm: number
+): BaseplateTiling {
+  const outline = params.outline as DrawerOutline;
+  const u = params.gridUnitMm;
+
+  const windowOf = (piece: BaseplatePiece): { x0: number; y0: number; x1: number; y1: number } => ({
+    x0: piece.gridOffsetX * u,
+    y0: piece.gridOffsetY * u,
+    x1: (piece.gridOffsetX + piece.widthUnits) * u,
+    y1: (piece.gridOffsetY + piece.depthUnits) * u,
+  });
+
+  const classByKey = new Map<string, RegionClass>();
+  for (const piece of tiling.pieces) {
+    const w = windowOf(piece);
+    classByKey.set(`${piece.col},${piece.row}`, classifyRect(outline, w.x0, w.y0, w.x1, w.y1));
+  }
+  const classAt = (col: number, row: number): RegionClass =>
+    classByKey.get(`${col},${row}`) ?? 'outside';
+
+  // A seam keeps its connector only when the one-cell band on BOTH sides of
+  // the entire shared span is fully inside the outline.
+  const fullSeam = (piece: BaseplatePiece, side: 'left' | 'right' | 'front' | 'back'): boolean => {
+    const w = windowOf(piece);
+    if (side === 'left' || side === 'right') {
+      const xB = side === 'left' ? w.x0 : w.x1;
+      return (
+        classifyRect(outline, xB - u, w.y0, xB, w.y1) === 'inside' &&
+        classifyRect(outline, xB, w.y0, xB + u, w.y1) === 'inside'
+      );
+    }
+    const yB = side === 'front' ? w.y0 : w.y1;
+    return (
+      classifyRect(outline, w.x0, yB - u, w.x1, yB) === 'inside' &&
+      classifyRect(outline, w.x0, yB, w.x1, yB + u) === 'inside'
+    );
+  };
+
+  const NEIGHBOR: Record<'left' | 'right' | 'front' | 'back', readonly [number, number]> = {
+    left: [-1, 0],
+    right: [1, 0],
+    front: [0, -1],
+    back: [0, 1],
+  };
+
+  const survivors: BaseplatePiece[] = [];
+  for (const piece of tiling.pieces) {
+    const cls = classAt(piece.col, piece.row);
+    if (cls === 'outside') continue;
+
+    const edges = { ...piece.edges };
+    for (const side of ['left', 'right', 'front', 'back'] as const) {
+      if (edges[side] !== 'join') continue;
+      const [dc, dr] = NEIGHBOR[side];
+      const neighborDropped = classAt(piece.col + dc, piece.row + dr) === 'outside';
+      if (neighborDropped || !fullSeam(piece, side)) edges[side] = 'exterior';
+    }
+
+    const w = windowOf(piece);
+    survivors.push({
+      ...piece,
+      edges,
+      placementRotationDeg: 0,
+      ...(cls === 'partial'
+        ? { outlineClass: 'partial' as const, windowOriginMm: { x: w.x0, y: w.y0 } }
+        : {}),
+    });
+  }
+
+  const bedLoads = estimateBedLoads(
+    survivors.map((piece) => ({ w: piece.widthUnits * u, d: piece.depthUnits * u })),
+    printBedWidthMm,
+    printBedDepthMm
+  );
+
+  return {
+    ...tiling,
+    isSplit: survivors.length > 1,
+    pieces: survivors,
+    bedLoads: Math.max(1, bedLoads),
+    paddingReductionHint: null,
   };
 }
 
@@ -1028,10 +1098,22 @@ export function pieceToBaseplateParams(
   } else {
     cornerRadii = rot && pr ? { tl: pr.br, tr: pr.bl, bl: pr.tr, br: pr.tl } : pr;
   }
+  // Partial pieces get the plate outline translated into their local frame;
+  // the generator's 3D intersect performs the window clip (the piece slab IS
+  // the window), so no 2D clipping is needed here. Fully-inside pieces carry
+  // no outline and stay byte-identical to unshaped rectangles.
+  const pieceOutline =
+    parentParams.outline !== undefined &&
+    piece.outlineClass === 'partial' &&
+    piece.windowOriginMm !== undefined
+      ? translateOutline(parentParams.outline, -piece.windowOriginMm.x, -piece.windowOriginMm.y)
+      : undefined;
+
   return {
     width: piece.widthUnits,
     depth: piece.depthUnits,
     gridUnitMm: parentParams.gridUnitMm,
+    outline: pieceOutline,
     magnetHoles: parentParams.magnetHoles,
     magnetDiameter: parentParams.magnetDiameter,
     magnetDepth: parentParams.magnetDepth,

--- a/src/features/generation/worker/generators/__kernel-tests__/sagittaArcConvention.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/sagittaArcConvention.test.ts
@@ -55,6 +55,30 @@ describe(`sagittaArcTo convention on ${getKernelName()}`, () => {
     expect(volume).toBeLessThan(expected * 1.01);
   });
 
+  it('closes an outline whose closing segment is an arc', async () => {
+    // The pen returns to the start via sagittaArcTo before close(). All three
+    // kernels accept this (close() tolerates an already-closed pen) — pinned
+    // because a reviewer plausibly flagged it as a degenerate-edge risk.
+    const { measureVolume, unwrap } = await import('brepjs');
+    const outline: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100, bulge: -0.5 },
+      ],
+    };
+    const drawing = buildOutlineDrawing(outline, { totalW: 100, totalD: 100, gridUnitMm: 50 });
+    const solid = (drawing.sketchOnPlane('XY') as unknown as Extrudable).extrude(5);
+    const volume = unwrap(measureVolume(solid as never));
+    const sweep = 4 * Math.atan(0.5);
+    const r = (100 * 1.25) / 2;
+    const segmentArea = ((r * r) / 2) * (sweep - Math.sin(sweep));
+    const expected = (100 * 100 - segmentArea) * 5;
+    expect(volume).toBeGreaterThan(expected * 0.99);
+    expect(volume).toBeLessThan(expected * 1.01);
+  });
+
   it('handles semicircle bulges via the arc split', async () => {
     const { measureVolume, unwrap } = await import('brepjs');
     // Full semicircular bite out of the back edge: bulge -1 traveling −x

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
@@ -222,6 +222,40 @@ describe('baseplate outline geometry', () => {
     expect(countVerticesIn(result.vertices, 12.5, 2, 71.5, 82)).toBe(0);
   });
 
+  it('generates a partial split piece with a connectored full seam', { timeout: 240_000 }, () => {
+    // What pieceToBaseplateParams emits for a shaped split piece whose
+    // boundary crossing is away from the seam: piece-local outline (1×1
+    // notch at the top-right) + a join edge with connectors on the left.
+    // Tongue fusion happens after the outline intersect, so both must
+    // coexist in one valid solid.
+    const gen = getGenerateBaseplate();
+    const outline: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 3 * U },
+        { x: 3 * U, y: 3 * U },
+        { x: 3 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const result = gen(
+      defaults({
+        outline,
+        connectorNubs: true,
+        edges: { left: 'join', right: 'exterior', front: 'exterior', back: 'exterior' },
+      }),
+      NO_OP,
+      true
+    );
+    assertStructurallyValid(result, 'partial piece + join seam');
+    // Notch empty: plate-local [3u,4u]² → mesh [42,84]².
+    expect(countVerticesIn(result.vertices, 44, 44, 82, 82)).toBe(0);
+    // The join-edge tongues protrude past the piece's left face.
+    const bb = boundingBox(result.vertices);
+    expect(bb.minX).toBeLessThan(-2 * U - 0.5);
+  });
+
   it.skipIf(BREPKIT_CORNER_NOTCH_INTERSECT_BROKEN)(
     'scales with a non-standard grid unit',
     { timeout: 240_000 },


### PR DESCRIPTION
## Summary

Third PR toward #2528: shaped plates (drawer outlines, #2532) now split across print beds instead of being forced single-piece. The reporter's ⊓-shaped drawer larger than one bed prints as correctly-shaped pieces with connectors where they belong.

## Design

The axis search runs unchanged on the bounding grid; a post-pass (`applyOutlineToTiling`) then shapes the result:

- **Fully-outside pieces are dropped.** Grid labels stay positional, so gaps like "A1, A3" read as the shape in the print guide and exploded preview.
- **Fully-inside pieces stay pure rectangles** — no outline on their params, so their fingerprints, dedup, connectors, and caches are byte-identical to unshaped plates. On a big shaped drawer only the boundary ring becomes unique; the interior keeps full mesh sharing.
- **Partial pieces** are tagged with their window origin; `pieceToBaseplateParams` translates the plate outline into the piece-local frame and the generator's existing 3D intersect performs the window clip — the piece slab IS the window, so no 2D polygon clipping exists anywhere.
- **Connectors survive only on full seams**: the one-grid-unit band on each side of the entire shared span must classify fully inside. Partial seams and seams facing dropped pieces become plain butt joints (both facing edges exterior — no tongue, no groove).
- **`placementRotationDeg` is forced off for shaped tilings**: the `preferIdenticalPieces` 180° mesh sharing pairs opposite corners of symmetric tilings, which dropping and seam reclassification break. Congruent pieces still dedupe via identical fingerprints (including congruent partial windows — the outline hash is piece-local).
- `bedLoads` recomputes from surviving pieces; `paddingReductionHint` is null (shaped plates carry zero padding by contract). Print guide gains a shaped-plate note (skipped labels + butt-seam alignment); descriptive file names gain a `shaped` token.

Also in this PR: verification of two post-merge review comments on #2532 — the double-JSDoc is resolved by this branch's helper removal, and the suspected closing-arc `close()` degeneracy **does not reproduce** (exact volumes on all three kernels; now pinned in `sagittaArcConvention.test.ts`).

## Testing

- 6 new `splitPlanner` cases on a deterministic 2×2 tiling: piece dropping with label gaps, full-seam connectors vs butt joints (dropped-neighbor and diagonal-crossed variants), piece-local outline translation, rotation-off, fingerprint separation/dedup.
- New scenario: a partial split piece with a connectored full seam — tongue fusion and outline intersect coexisting in one valid solid (occt-wasm + manifold).
- `pnpm run quality` clean; full outline scenario domain 10/10 on occt-wasm and manifold (brepkit skips documented in #2532).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split shaped baseplates across print beds with outline-aware pieces. Third step toward #2528: outside tiles are dropped, interior tiles stay rectangles, partial tiles carry local outlines; connectors appear only on full seams.

- **New Features**
  - Outline-aware post-pass on the rectangular tiling: drop fully-outside pieces; keep fully-inside as pure rectangles; tag partial pieces with `outlineWindowOriginMm` for piece-local outlines.
  - Connectors only on full seams; seams crossed by the outline or facing dropped neighbors become butt joints.
  - Force `placementRotationDeg` to 0 for shaped tilings; congruent pieces still dedupe via fingerprints that now include a piece-local outline hash (whole translated loop; fully-inside pieces push no outline term).
  - Recompute `bedLoads` from surviving pieces with tongue protrusion budgeted on join edges; `paddingReductionHint` is null (shaped plates have zero padding).
  - Print guide notes shaped behavior; file names add a `shaped` token.

<sup>Written for commit 099b15dd78c771b445313a05c81b89bc377ddbea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

