### PR TITLE
feat(drawer): setOutline command, resize adaptation, and outline persistence guards

### DIFF
--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -727,9 +727,39 @@ describe('drawer outline validation (issue #2528)', () => {
     expect(outline.authoring).toEqual({ kind: 'cells' });
   });
 
-  it('rejects unknown authoring kinds', () => {
+  it('accepts unknown authoring kinds (newer client) but drops the annotation', () => {
+    const result = validateShareLayout(
+      layoutWithOutline({ ...validOutline, authoring: { kind: 'holo-editor-2030' } })
+    );
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    const outline = (result.layout.drawer as Record<string, unknown>).outline as Record<
+      string,
+      unknown
+    >;
+    expect(outline.authoring).toBeUndefined();
+  });
+
+  it('rejects non-string authoring kinds', () => {
     expect(
-      validateShareLayout(layoutWithOutline({ ...validOutline, authoring: { kind: 'evil' } })).valid
+      validateShareLayout(layoutWithOutline({ ...validOutline, authoring: { kind: 42 } })).valid
     ).toBe(false);
+  });
+
+  it('rejects collinear-overlap self-touching outlines', () => {
+    // Two horizontal non-adjacent edges overlapping on y = 0.
+    const overlapping = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 50 },
+        { x: 60, y: 50 },
+        { x: 60, y: 0 },
+        { x: 20, y: 0 },
+        { x: 20, y: 80 },
+        { x: 0, y: 80 },
+      ],
+    };
+    expect(validateShareLayout(layoutWithOutline(overlapping)).valid).toBe(false);
   });
 });

--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -600,3 +600,136 @@ describe('custom properties validation', () => {
     expect(result).toBeDefined();
   });
 });
+
+describe('drawer outline validation (issue #2528)', () => {
+  const U = 42;
+  const validOutline = {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: 10 * U, y: 0 },
+      { x: 10 * U, y: 4 * U },
+      { x: 4 * U, y: 4 * U },
+      { x: 4 * U, y: 8 * U },
+      { x: 0, y: 8 * U },
+    ],
+  };
+
+  function layoutWithOutline(outline: unknown) {
+    const layout = createValidLayout();
+    (layout.drawer as Record<string, unknown>).outline = outline;
+    return layout;
+  }
+
+  it('accepts and preserves a valid outline', () => {
+    const result = validateShareLayout(layoutWithOutline(validOutline));
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    const drawer = result.layout.drawer as Record<string, unknown>;
+    expect(drawer.outline).toEqual(validOutline);
+  });
+
+  it('rebuilds the drawer explicitly — junk keys do not survive', () => {
+    const layout = createValidLayout();
+    (layout.drawer as Record<string, unknown>).evil = '<script>';
+    const result = validateShareLayout(layout);
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect('evil' in (result.layout.drawer as Record<string, unknown>)).toBe(false);
+  });
+
+  it('preserves fractional edges through the rebuild', () => {
+    const layout = createValidLayout();
+    (layout.drawer as Record<string, unknown>).fractionalEdgeX = 'start';
+    const result = validateShareLayout(layout);
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect((result.layout.drawer as Record<string, unknown>).fractionalEdgeX).toBe('start');
+  });
+
+  it('rejects outlines with too few or too many vertices', () => {
+    expect(
+      validateShareLayout(
+        layoutWithOutline({
+          vertices: [
+            { x: 0, y: 0 },
+            { x: 42, y: 0 },
+          ],
+        })
+      ).valid
+    ).toBe(false);
+    const many = {
+      vertices: Array.from({ length: 257 }, (_, i) => ({ x: i, y: i % 2 })),
+    };
+    expect(validateShareLayout(layoutWithOutline(many)).valid).toBe(false);
+  });
+
+  it('rejects non-finite coordinates, out-of-bounds values, and bad bulges', () => {
+    expect(
+      validateShareLayout(
+        layoutWithOutline({
+          vertices: [
+            { x: NaN, y: 0 },
+            { x: 42, y: 0 },
+            { x: 0, y: 42 },
+          ],
+        })
+      ).valid
+    ).toBe(false);
+    expect(
+      validateShareLayout(
+        layoutWithOutline({
+          vertices: [
+            { x: 0, y: 0 },
+            { x: 99999, y: 0 },
+            { x: 0, y: 42 },
+          ],
+        })
+      ).valid
+    ).toBe(false);
+    expect(
+      validateShareLayout(
+        layoutWithOutline({
+          vertices: [
+            { x: 0, y: 0, bulge: 3 },
+            { x: 42, y: 0 },
+            { x: 0, y: 42 },
+          ],
+        })
+      ).valid
+    ).toBe(false);
+  });
+
+  it('rejects self-intersecting outlines', () => {
+    const bowtie = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 100, y: 100 },
+        { x: 100, y: 0 },
+        { x: 0, y: 100 },
+      ],
+    };
+    expect(validateShareLayout(layoutWithOutline(bowtie)).valid).toBe(false);
+  });
+
+  it('sanitizes the authoring annotation to the kind enum only', () => {
+    const result = validateShareLayout(
+      layoutWithOutline({
+        ...validOutline,
+        authoring: { kind: 'cells', corners: { evil: 'payload' }, junk: 1 },
+      })
+    );
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    const outline = (result.layout.drawer as Record<string, unknown>).outline as Record<
+      string,
+      unknown
+    >;
+    expect(outline.authoring).toEqual({ kind: 'cells' });
+  });
+
+  it('rejects unknown authoring kinds', () => {
+    expect(
+      validateShareLayout(layoutWithOutline({ ...validOutline, authoring: { kind: 'evil' } })).valid
+    ).toBe(false);
+  });
+});

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -396,27 +396,36 @@ function isValidDrawerOutline(value: unknown): value is DrawerOutlineShape {
     }
     if (v.bulge !== undefined && (!isNumber(v.bulge) || !inRange(v.bulge, -1, 1))) return false;
   }
+  // `authoring` is non-geometric editor metadata: reject only structural
+  // garbage. An unknown kind (a NEWER client's editor) must not invalidate
+  // the layout — sanitizeDrawer drops unrecognized kinds instead.
   if (value.authoring !== undefined) {
-    if (!isObject(value.authoring)) return false;
-    if (
-      typeof value.authoring.kind !== 'string' ||
-      !OUTLINE_AUTHORING_KINDS.includes(value.authoring.kind)
-    ) {
-      return false;
-    }
+    if (!isObject(value.authoring) || typeof value.authoring.kind !== 'string') return false;
   }
   const pts = vertices as OutlineVertexShape[];
   return !outlineChordsSelfIntersect(pts);
 }
 
 /** O(n²) chord test — arcs approximated by their chords; good enough to bound
- * pathological payloads (exact arc checks run client-side). */
+ * pathological payloads (exact arc checks run client-side). Detects proper
+ * crossings AND degenerate touches: collinear overlaps and endpoint-on-segment
+ * contacts between non-adjacent chords (mirrors segmentsTouch in
+ * src/shared/utils/drawerOutline.ts). */
 function outlineChordsSelfIntersect(pts: OutlineVertexShape[]): boolean {
   const n = pts.length;
   const orient = (a: OutlineVertexShape, b: OutlineVertexShape, c: OutlineVertexShape): number => {
     const v = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
     return Math.abs(v) < 1e-9 ? 0 : Math.sign(v);
   };
+  const onSegment = (
+    a: OutlineVertexShape,
+    b: OutlineVertexShape,
+    p: OutlineVertexShape
+  ): boolean =>
+    Math.min(a.x, b.x) - 1e-6 <= p.x &&
+    p.x <= Math.max(a.x, b.x) + 1e-6 &&
+    Math.min(a.y, b.y) - 1e-6 <= p.y &&
+    p.y <= Math.max(a.y, b.y) + 1e-6;
   for (let i = 0; i < n; i++) {
     const a = pts[i];
     const b = pts[(i + 1) % n];
@@ -424,7 +433,15 @@ function outlineChordsSelfIntersect(pts: OutlineVertexShape[]): boolean {
       if (j === i || (j + 1) % n === i || (i + 1) % n === j) continue;
       const c = pts[j];
       const d = pts[(j + 1) % n];
-      if (orient(a, b, c) !== orient(a, b, d) && orient(c, d, a) !== orient(c, d, b)) return true;
+      const o1 = orient(a, b, c);
+      const o2 = orient(a, b, d);
+      const o3 = orient(c, d, a);
+      const o4 = orient(c, d, b);
+      if (o1 !== o2 && o3 !== o4) return true;
+      if (o1 === 0 && onSegment(a, b, c)) return true;
+      if (o2 === 0 && onSegment(a, b, d)) return true;
+      if (o3 === 0 && onSegment(c, d, a)) return true;
+      if (o4 === 0 && onSegment(c, d, b)) return true;
     }
   }
   return false;
@@ -454,7 +471,8 @@ function sanitizeDrawer(drawer: DrawerShape): DrawerShape {
           ? { x: v.x, y: v.y }
           : { x: v.x, y: v.y, bulge: v.bulge }
       ),
-      ...(drawer.outline.authoring !== undefined
+      ...(drawer.outline.authoring !== undefined &&
+      OUTLINE_AUTHORING_KINDS.includes(drawer.outline.authoring.kind)
         ? { authoring: { kind: drawer.outline.authoring.kind } }
         : {}),
     };

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -51,10 +51,24 @@ const RESERVED_PROPERTY_KEYS = [
 
 export type ValidExpiration = (typeof SHARE_CONSTRAINTS.VALID_EXPIRATIONS)[number];
 
+interface OutlineVertexShape {
+  x: number;
+  y: number;
+  bulge?: number;
+}
+
+interface DrawerOutlineShape {
+  vertices: OutlineVertexShape[];
+  authoring?: { kind: string; corners?: unknown };
+}
+
 interface DrawerShape {
   width: number;
   depth: number;
   height: number;
+  fractionalEdgeX?: 'start' | 'end';
+  fractionalEdgeY?: 'start' | 'end';
+  outline?: DrawerOutlineShape;
 }
 
 interface LayerShape {
@@ -104,8 +118,7 @@ export interface ValidationError {
 }
 
 export type ValidationResult =
-  | { valid: true; layout: LayoutShape }
-  | { valid: false; error: ValidationError };
+  { valid: true; layout: LayoutShape } | { valid: false; error: ValidationError };
 
 /**
  * Type guard for validation failure.
@@ -314,7 +327,7 @@ export function validateShareLayout(data: unknown, jsonSize: number): Validation
     layout: {
       version: sanitizeString(String(layout.version), 10),
       name: sanitizeString(String(layout.name), SHARE_CONSTRAINTS.NAME_MAX_LENGTH),
-      drawer,
+      drawer: sanitizeDrawer(drawer),
       layers: validatedLayers,
       bins: validatedBins,
       categories: validatedCategories,
@@ -339,6 +352,7 @@ export function validateExpiration(days: unknown): days is ValidExpiration {
 // Type guards
 function isValidDrawer(value: unknown): value is DrawerShape {
   if (!isObject(value)) return false;
+  if (value.outline !== undefined && !isValidDrawerOutline(value.outline)) return false;
   return (
     isNumber(value.width) &&
     isNumber(value.depth) &&
@@ -349,6 +363,103 @@ function isValidDrawer(value: unknown): value is DrawerShape {
     // can't sync absurd values to other devices.
     inRange(value.height, SHARE_CONSTRAINTS.HEIGHT_MIN, SHARE_CONSTRAINTS.GRID_MAX)
   );
+}
+
+/** Mirrors OUTLINE_MAX_VERTICES in src/shared/utils/drawerOutline.ts. */
+const OUTLINE_MAX_VERTICES = 256;
+/** 50 units × up to 52mm grid, with slack — mirrors the client Zod schema. */
+const OUTLINE_COORD_MIN = -1;
+const OUTLINE_COORD_MAX = 2600;
+const OUTLINE_AUTHORING_KINDS = ['cells', 'corners', 'trace', 'pen'];
+
+/**
+ * Structural gate for a drawer outline (issue #2528): vertex/coordinate/bulge
+ * bounds and no self-intersection of the straight-chord approximation. The
+ * geometric invariants that need the drawer's mm extent (CCW, min area,
+ * in-bounds) are enforced client-side and re-checked at read time by
+ * normalizeDrawerOutline — the server's job is to bound the data so a
+ * hand-crafted payload can't sync junk or pathological geometry.
+ */
+function isValidDrawerOutline(value: unknown): value is DrawerOutlineShape {
+  if (!isObject(value) || !Array.isArray(value.vertices)) return false;
+  const vertices = value.vertices as unknown[];
+  if (vertices.length < 3 || vertices.length > OUTLINE_MAX_VERTICES) return false;
+  for (const v of vertices) {
+    if (!isObject(v)) return false;
+    if (
+      !isNumber(v.x) ||
+      !isNumber(v.y) ||
+      !inRange(v.x, OUTLINE_COORD_MIN, OUTLINE_COORD_MAX) ||
+      !inRange(v.y, OUTLINE_COORD_MIN, OUTLINE_COORD_MAX)
+    ) {
+      return false;
+    }
+    if (v.bulge !== undefined && (!isNumber(v.bulge) || !inRange(v.bulge, -1, 1))) return false;
+  }
+  if (value.authoring !== undefined) {
+    if (!isObject(value.authoring)) return false;
+    if (
+      typeof value.authoring.kind !== 'string' ||
+      !OUTLINE_AUTHORING_KINDS.includes(value.authoring.kind)
+    ) {
+      return false;
+    }
+  }
+  const pts = vertices as OutlineVertexShape[];
+  return !outlineChordsSelfIntersect(pts);
+}
+
+/** O(n²) chord test — arcs approximated by their chords; good enough to bound
+ * pathological payloads (exact arc checks run client-side). */
+function outlineChordsSelfIntersect(pts: OutlineVertexShape[]): boolean {
+  const n = pts.length;
+  const orient = (a: OutlineVertexShape, b: OutlineVertexShape, c: OutlineVertexShape): number => {
+    const v = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+    return Math.abs(v) < 1e-9 ? 0 : Math.sign(v);
+  };
+  for (let i = 0; i < n; i++) {
+    const a = pts[i];
+    const b = pts[(i + 1) % n];
+    for (let j = i + 1; j < n; j++) {
+      if (j === i || (j + 1) % n === i || (i + 1) % n === j) continue;
+      const c = pts[j];
+      const d = pts[(j + 1) % n];
+      if (orient(a, b, c) !== orient(a, b, d) && orient(c, d, a) !== orient(c, d, b)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Rebuild the drawer field-by-field. The drawer previously passed through
+ * raw, which let arbitrary junk keys survive sanitization; an explicit
+ * rebuild keeps exactly the validated shape.
+ */
+function sanitizeDrawer(drawer: DrawerShape): DrawerShape {
+  const out: DrawerShape = {
+    width: drawer.width,
+    depth: drawer.depth,
+    height: drawer.height,
+  };
+  if (drawer.fractionalEdgeX === 'start' || drawer.fractionalEdgeX === 'end') {
+    out.fractionalEdgeX = drawer.fractionalEdgeX;
+  }
+  if (drawer.fractionalEdgeY === 'start' || drawer.fractionalEdgeY === 'end') {
+    out.fractionalEdgeY = drawer.fractionalEdgeY;
+  }
+  if (drawer.outline !== undefined) {
+    out.outline = {
+      vertices: drawer.outline.vertices.map((v) =>
+        v.bulge === undefined || v.bulge === 0
+          ? { x: v.x, y: v.y }
+          : { x: v.x, y: v.y, bulge: v.bulge }
+      ),
+      ...(drawer.outline.authoring !== undefined
+        ? { authoring: { kind: drawer.outline.authoring.kind } }
+        : {}),
+    };
+  }
+  return out;
 }
 
 function isValidLayer(value: unknown): value is LayerShape {

--- a/src/core/cqrs/commandDescriptions.ts
+++ b/src/core/cqrs/commandDescriptions.ts
@@ -25,6 +25,7 @@ const DESCRIPTIONS: Readonly<Partial<Record<CommandType, string>>> = {
   'category.update': 'undo.categoryUpdated',
   'category.delete': 'undo.categoryDeleted',
   'drawer.update': 'undo.drawerUpdated',
+  'drawer.setOutline': 'undo.drawerOutlineSet',
   'layout.setName': 'undo.nameChanged',
   'layout.setPrintBedSize': 'undo.printBedSizeChanged',
   'layout.setGridUnitMm': 'undo.gridUnitChanged',

--- a/src/core/cqrs/commands/drawerCommands.ts
+++ b/src/core/cqrs/commands/drawerCommands.ts
@@ -3,9 +3,15 @@
  */
 
 import type { BaseCommand } from '../types';
-import type { BaseplateDesignId, Drawer, StoredBaseplateParams } from '@/core/types';
+import type { BaseplateDesignId, Drawer, DrawerOutline, StoredBaseplateParams } from '@/core/types';
 
 export type UpdateDrawerCommand = BaseCommand<'drawer.update', Partial<Drawer>>;
+
+/** Set or clear (null) the drawer's non-rectangular boundary. */
+export type SetDrawerOutlineCommand = BaseCommand<
+  'drawer.setOutline',
+  { readonly outline: DrawerOutline | null }
+>;
 
 export type SetNameCommand = BaseCommand<'layout.setName', { readonly name: string }>;
 
@@ -30,6 +36,7 @@ export type SetActiveBaseplateCommand = BaseCommand<
 
 export type DrawerCommand =
   | UpdateDrawerCommand
+  | SetDrawerOutlineCommand
   | SetNameCommand
   | SetPrintBedSizeCommand
   | SetGridUnitMmCommand

--- a/src/core/cqrs/events/drawerEvents.ts
+++ b/src/core/cqrs/events/drawerEvents.ts
@@ -3,7 +3,13 @@
  */
 
 import type { BaseDomainEvent } from '../types';
-import type { BaseplateDesignId, BinId, Drawer, StoredBaseplateParams } from '@/core/types';
+import type {
+  BaseplateDesignId,
+  BinId,
+  Drawer,
+  DrawerOutline,
+  StoredBaseplateParams,
+} from '@/core/types';
 
 // `displacedBinIds` records the exact set of bins displaced by a
 // drawer-shrink cascade. Optional only for back-compat with persisted
@@ -16,6 +22,17 @@ export type DrawerUpdatedEvent = BaseDomainEvent<
     readonly previous: Partial<Drawer>;
     readonly binsDisplacedToStaging: number;
     readonly displacedBinIds?: ReadonlyArray<BinId>;
+  }
+>;
+
+export type DrawerOutlineSetEvent = BaseDomainEvent<
+  'drawer.outlineSet',
+  {
+    /** undefined = shape cleared back to the plain rectangle. */
+    readonly outline: DrawerOutline | undefined;
+    readonly previousOutline: DrawerOutline | undefined;
+    readonly binsDisplacedToStaging: number;
+    readonly displacedBinIds: ReadonlyArray<BinId>;
   }
 >;
 
@@ -61,6 +78,7 @@ export type ActiveBaseplateSetEvent = BaseDomainEvent<
 
 export type DrawerEvent =
   | DrawerUpdatedEvent
+  | DrawerOutlineSetEvent
   | LayoutNameSetEvent
   | PrintBedSizeSetEvent
   | GridUnitMmSetEvent

--- a/src/core/cqrs/integration/mutationsAdapter.ts
+++ b/src/core/cqrs/integration/mutationsAdapter.ts
@@ -19,6 +19,7 @@ import type {
   CloudShareInfo,
   StoredBaseplateParams,
   BaseplateDesignId,
+  DrawerOutline,
 } from '@/core/types';
 import type { Result, ValidationError, LayoutError } from '@/core/result';
 import { ok, err, isOk } from '@/core/result';
@@ -107,6 +108,11 @@ export function createCqrsMutations(bus: CommandBus): Mutations {
 
     updateDrawer(updates: Partial<Drawer>): void {
       bus.dispatch(createCommand('drawer.update', updates));
+    },
+
+    setDrawerOutline(outline: DrawerOutline | null): Result<void, LayoutError> {
+      const result = bus.dispatch(createCommand('drawer.setOutline', { outline }));
+      return extractResult(result);
     },
 
     addCategory(category: Omit<Category, 'id'>): Result<CategoryId, LayoutError> {

--- a/src/core/cqrs/middleware/middlewareConfig.ts
+++ b/src/core/cqrs/middleware/middlewareConfig.ts
@@ -45,6 +45,7 @@ const COMMAND_PROFILES: Readonly<Record<CommandType, MiddlewareProfile>> = {
   'category.update': 'domain',
   'category.delete': 'domain',
   'drawer.update': 'domain',
+  'drawer.setOutline': 'domain',
   'layout.setName': 'domain',
   'layout.setPrintBedSize': 'domain',
   'layout.setGridUnitMm': 'domain',

--- a/src/core/cqrs/projection/replay.ts
+++ b/src/core/cqrs/projection/replay.ts
@@ -130,6 +130,21 @@ export function applyEvent(layout: Layout, event: DomainEvent): Layout {
       Object.assign(next.drawer, event.payload.changes);
       break;
 
+    case 'drawer.outlineSet': {
+      if (event.payload.outline === undefined) {
+        delete next.drawer.outline;
+      } else {
+        next.drawer.outline = event.payload.outline;
+      }
+      const displaced = new Set(event.payload.displacedBinIds);
+      if (displaced.size > 0) {
+        next.bins = next.bins.map((bin) =>
+          displaced.has(bin.id) ? { ...bin, layerId: STAGING_ID } : bin
+        );
+      }
+      break;
+    }
+
     case 'layout.nameSet':
       next.name = event.payload.name;
       break;

--- a/src/core/cqrs/projection/replay.ts
+++ b/src/core/cqrs/projection/replay.ts
@@ -128,6 +128,12 @@ export function applyEvent(layout: Layout, event: DomainEvent): Layout {
 
     case 'drawer.updated':
       Object.assign(next.drawer, event.payload.changes);
+      // Mirror updateDrawer.apply(): a reset-to-rectangle rides as an
+      // explicitly-undefined outline; the key must end up absent, not
+      // present-undefined, or replayed state diverges from live state.
+      if ('outline' in event.payload.changes && event.payload.changes.outline === undefined) {
+        delete next.drawer.outline;
+      }
       break;
 
     case 'drawer.outlineSet': {

--- a/src/core/cqrs/v2/domain/drawer/displacement.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/displacement.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { gridUnits } from '@/core/types';
+import type { DrawerOutline } from '@/core/types';
+import { STAGING_ID } from '@/core/constants';
+import { computeDisplacedBins } from './displacement';
+import { makeBin } from './_testHelpers';
+
+const U = 42;
+
+const L_OUTLINE: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 6 * U, y: 0 },
+    { x: 6 * U, y: 2 * U },
+    { x: 4 * U, y: 2 * U },
+    { x: 4 * U, y: 4 * U },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+const drawer = { width: gridUnits(6), depth: gridUnits(4) };
+
+describe('computeDisplacedBins', () => {
+  it('displaces out-of-bounds bins without an outline', () => {
+    const bins = [makeBin('bin_out', 5, 3), makeBin('bin_in', 0, 0)];
+    expect(computeDisplacedBins(bins, { ...drawer, width: gridUnits(4) }, U)).toEqual(['bin_out']);
+  });
+
+  it('displaces bins outside the outline even when in bounds', () => {
+    const bins = [makeBin('bin_notch', 5, 3), makeBin('bin_body', 0, 0)];
+    expect(computeDisplacedBins(bins, { ...drawer, outline: L_OUTLINE }, U)).toEqual(['bin_notch']);
+  });
+
+  it('keeps boundary-flush bins', () => {
+    // Footprint ending exactly on the notch wall (x: 3..4) is inside.
+    const bins = [makeBin('bin_flush', 3, 3)];
+    expect(computeDisplacedBins(bins, { ...drawer, outline: L_OUTLINE }, U)).toEqual([]);
+  });
+
+  it('never displaces staged bins', () => {
+    const bins = [makeBin('bin_staged', 5, 3, STAGING_ID)];
+    expect(computeDisplacedBins(bins, { ...drawer, outline: L_OUTLINE }, U)).toEqual([]);
+  });
+});

--- a/src/core/cqrs/v2/domain/drawer/displacement.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/displacement.test.ts
@@ -37,6 +37,11 @@ describe('computeDisplacedBins', () => {
     expect(computeDisplacedBins(bins, { ...drawer, outline: L_OUTLINE }, U)).toEqual([]);
   });
 
+  it('displaces bins with negative coordinates', () => {
+    const bins = [makeBin('bin_neg', -1, 0)];
+    expect(computeDisplacedBins(bins, drawer, U)).toEqual(['bin_neg']);
+  });
+
   it('never displaces staged bins', () => {
     const bins = [makeBin('bin_staged', 5, 3, STAGING_ID)];
     expect(computeDisplacedBins(bins, { ...drawer, outline: L_OUTLINE }, U)).toEqual([]);

--- a/src/core/cqrs/v2/domain/drawer/displacement.ts
+++ b/src/core/cqrs/v2/domain/drawer/displacement.ts
@@ -21,6 +21,8 @@ export function computeDisplacedBins(
     .filter((bin) => {
       if (bin.layerId === STAGING_ID) return false;
       if (
+        (bin.x as number) < 0 ||
+        (bin.y as number) < 0 ||
         (bin.x as number) + (bin.width as number) > width ||
         (bin.y as number) + (bin.depth as number) > depth
       ) {

--- a/src/core/cqrs/v2/domain/drawer/displacement.ts
+++ b/src/core/cqrs/v2/domain/drawer/displacement.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared displacement rule for drawer-boundary changes: a bin is displaced to
+ * staging when its footprint no longer fits the drawer — out of the W×D
+ * bounds, or outside the outline when one is set. Used by `drawer.update`
+ * (resize) and `drawer.setOutline` so the two commands can never disagree,
+ * and mirrored by the legacy store action.
+ */
+
+import type { Bin, BinId, Drawer } from '@/core/types';
+import { STAGING_ID } from '@/core/constants';
+import { isFootprintInsideOutline } from '@/shared/utils/drawerOutlineGeometry';
+
+export function computeDisplacedBins(
+  bins: readonly Bin[],
+  drawer: Pick<Drawer, 'width' | 'depth' | 'outline'>,
+  gridUnitMm: number
+): BinId[] {
+  const width = drawer.width as number;
+  const depth = drawer.depth as number;
+  return bins
+    .filter((bin) => {
+      if (bin.layerId === STAGING_ID) return false;
+      if (
+        (bin.x as number) + (bin.width as number) > width ||
+        (bin.y as number) + (bin.depth as number) > depth
+      ) {
+        return true;
+      }
+      return (
+        drawer.outline !== undefined &&
+        !isFootprintInsideOutline(
+          { x: bin.x, y: bin.y, width: bin.width, depth: bin.depth },
+          drawer.outline,
+          gridUnitMm
+        )
+      );
+    })
+    .map((b) => b.id);
+}

--- a/src/core/cqrs/v2/domain/drawer/setDrawerOutline.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/setDrawerOutline.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { produce } from 'immer';
+import { isOk } from '@/core/result';
+import { STAGING_ID } from '@/core/constants';
+import { binId } from '@/core/types';
+import type { DrawerOutline } from '@/core/types';
+import { setDrawerOutline } from './setDrawerOutline';
+import { makeLayout, makeBin } from './_testHelpers';
+
+const U = 42;
+
+/** 6×4 drawer with the right 2×2 corner (top) notched out. */
+const L_OUTLINE: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 6 * U, y: 0 },
+    { x: 6 * U, y: 2 * U },
+    { x: 4 * U, y: 2 * U },
+    { x: 4 * U, y: 4 * U },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+describe('v2 drawer.setOutline', () => {
+  it('sets a valid outline and displaces bins outside it', () => {
+    // bin_a sits in the notch (5,3); bin_b is in the body.
+    const layout = makeLayout({ bins: [makeBin('bin_a', 5, 3), makeBin('bin_b', 0, 0)] });
+    const result = setDrawerOutline.handle({ outline: L_OUTLINE }, { aggregate: layout });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.outline).toBeDefined();
+    expect(result.value.event.payload.previousOutline).toBeUndefined();
+    expect(result.value.event.payload.displacedBinIds).toEqual([binId('bin_a')]);
+  });
+
+  it('apply() installs the outline and stages displaced bins', () => {
+    const layout = makeLayout({ bins: [makeBin('bin_a', 5, 3)] });
+    const result = setDrawerOutline.handle({ outline: L_OUTLINE }, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+
+    const event = { payload: result.value.event.payload } as never;
+    const next = produce(layout, (draft) => {
+      setDrawerOutline.apply(event, draft);
+    });
+    expect(next.drawer.outline?.vertices).toHaveLength(6);
+    expect(next.bins[0].layerId).toBe(STAGING_ID);
+  });
+
+  it('clears the outline with null and records the previous shape for undo', () => {
+    const base = makeLayout();
+    const withOutline = { ...base, drawer: { ...base.drawer, outline: L_OUTLINE } };
+    const result = setDrawerOutline.handle({ outline: null }, { aggregate: withOutline });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.outline).toBeUndefined();
+    expect(result.value.event.payload.previousOutline).toBe(L_OUTLINE);
+
+    const event = { payload: result.value.event.payload } as never;
+    const next = produce(withOutline, (draft) => {
+      setDrawerOutline.apply(event, draft);
+    });
+    expect('outline' in next.drawer).toBe(false);
+  });
+
+  it('normalizes a rectangle-equivalent outline to no outline', () => {
+    const rect: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 6 * U, y: 0 },
+        { x: 6 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const result = setDrawerOutline.handle({ outline: rect }, { aggregate: makeLayout() });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.outline).toBeUndefined();
+  });
+
+  it('rejects invalid outlines (self-intersecting)', () => {
+    const bowtie: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 6 * U, y: 4 * U },
+        { x: 6 * U, y: 0 },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const result = setDrawerOutline.handle({ outline: bowtie }, { aggregate: makeLayout() });
+    expect(isOk(result)).toBe(false);
+  });
+
+  it('rejects outlines exceeding the drawer extent', () => {
+    const tooWide: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 10 * U, y: 0 },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const result = setDrawerOutline.handle({ outline: tooWide }, { aggregate: makeLayout() });
+    expect(isOk(result)).toBe(false);
+  });
+
+  it('snaps near-boundary vertices before validating', () => {
+    const nearlySnapped: DrawerOutline = {
+      vertices: [
+        { x: 0.03, y: -0.02 },
+        { x: 6 * U, y: 0 },
+        { x: 6 * U, y: 2 * U },
+        { x: 4 * U, y: 2 * U },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U + 0.04 },
+      ],
+    };
+    const result = setDrawerOutline.handle({ outline: nearlySnapped }, { aggregate: makeLayout() });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.outline?.vertices[0]).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/src/core/cqrs/v2/domain/drawer/setDrawerOutline.ts
+++ b/src/core/cqrs/v2/domain/drawer/setDrawerOutline.ts
@@ -1,0 +1,121 @@
+/**
+ * drawer.setOutline — set or clear the drawer's non-rectangular boundary
+ * (issue #2528). The single write path for every shape-authoring surface
+ * (cell paint, bin-footprint trace, corner cuts, pen editor).
+ *
+ * `handle()` validates the outline against the current drawer extent,
+ * normalizes rectangle-equivalent shapes to "no outline", and precomputes the
+ * displacement set (bins whose footprint falls outside the new shape move to
+ * staging) so `apply()` and replay stay deterministic.
+ */
+
+import * as z from 'zod';
+import type { Result, LayoutError } from '@/core/result';
+import { ok, err, layoutInvalidOperation } from '@/core/result';
+import type { BinId, DrawerOutline } from '@/core/types';
+import { STAGING_ID } from '@/core/constants';
+import {
+  quantizeOutline,
+  snapOutlineToBounds,
+  validateOutline,
+} from '@/shared/utils/drawerOutline';
+import { defineCommand } from '../../defineCommand';
+import { computeDisplacedBins } from './displacement';
+import { drawerOutlineSchema } from '../../../validation/outlineSchema';
+
+const payloadSchema = z.object({
+  outline: drawerOutlineSchema.nullable(),
+});
+
+/** True when the outline traces the full rectangle (every segment straight
+ * and hugging a boundary line) — stored as "no outline". */
+function isRectangleEquivalent(outline: DrawerOutline, widthMm: number, depthMm: number): boolean {
+  const eps = 0.05;
+  const n = outline.vertices.length;
+  for (let i = 0; i < n; i++) {
+    const a = outline.vertices[i];
+    const b = outline.vertices[(i + 1) % n];
+    if (Math.abs(a.bulge ?? 0) >= 1e-9) return false;
+    const onCommonLine =
+      (Math.abs(a.x) <= eps && Math.abs(b.x) <= eps) ||
+      (Math.abs(a.x - widthMm) <= eps && Math.abs(b.x - widthMm) <= eps) ||
+      (Math.abs(a.y) <= eps && Math.abs(b.y) <= eps) ||
+      (Math.abs(a.y - depthMm) <= eps && Math.abs(b.y - depthMm) <= eps);
+    if (!onCommonLine) return false;
+  }
+  return true;
+}
+
+export const setDrawerOutline = defineCommand({
+  type: 'drawer.setOutline',
+  aggregate: 'layout',
+  aggregateId: () => 'layout',
+  payload: payloadSchema,
+  emitted: 'drawer.outlineSet',
+  schemaVersion: 1,
+  descriptionKey: 'undo.action.drawerSetOutline',
+  middleware: { undoCapture: true, validate: true, analytics: true },
+  handle: (
+    payload,
+    ctx
+  ): Result<
+    {
+      value: undefined;
+      event: {
+        payload: {
+          outline: DrawerOutline | undefined;
+          previousOutline: DrawerOutline | undefined;
+          binsDisplacedToStaging: number;
+          displacedBinIds: ReadonlyArray<BinId>;
+        };
+      };
+    },
+    LayoutError
+  > => {
+    const layout = ctx.aggregate;
+    const drawer = layout.drawer;
+    const widthMm = (drawer.width as number) * (layout.gridUnitMm as number);
+    const depthMm = (drawer.depth as number) * (layout.gridUnitMm as number);
+
+    let outline: DrawerOutline | undefined;
+    if (payload.outline !== null) {
+      const cleaned = snapOutlineToBounds(quantizeOutline(payload.outline), widthMm, depthMm);
+      const invalid = validateOutline(cleaned, widthMm, depthMm, layout.gridUnitMm);
+      if (invalid !== null) {
+        return err(layoutInvalidOperation('setDrawerOutline', invalid.message));
+      }
+      outline = isRectangleEquivalent(cleaned, widthMm, depthMm) ? undefined : cleaned;
+    }
+
+    const displacedBinIds = computeDisplacedBins(
+      layout.bins,
+      { width: drawer.width, depth: drawer.depth, outline },
+      layout.gridUnitMm
+    );
+
+    return ok({
+      value: undefined,
+      event: {
+        payload: {
+          outline,
+          previousOutline: drawer.outline,
+          binsDisplacedToStaging: displacedBinIds.length,
+          displacedBinIds,
+        },
+      },
+    });
+  },
+  apply: (event, draft) => {
+    if (event.payload.outline === undefined) {
+      delete draft.drawer.outline;
+    } else {
+      draft.drawer.outline = event.payload.outline;
+    }
+    if (event.payload.displacedBinIds.length > 0) {
+      const idSet = new Set(event.payload.displacedBinIds);
+      for (const bin of draft.bins) {
+        if (idSet.has(bin.id)) bin.layerId = STAGING_ID;
+      }
+    }
+  },
+});

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
@@ -5,6 +5,7 @@ import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { binId, gridUnits, heightUnits } from '@/core/types';
 import { updateDrawer } from './updateDrawer';
 import { makeLayout, makeBin } from './_testHelpers';
+import { applyEvent } from '../../../projection/replay';
 
 describe('v2 drawer.update', () => {
   it('clamps width to GRID_MAX', () => {
@@ -119,6 +120,17 @@ describe('v2 drawer.update with an outline', () => {
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) return;
     expect(result.value.event.payload.displacedBinIds).toEqual([binId('bin_notch')]);
+  });
+
+  it('replay deletes the outline key on reset, matching apply()', () => {
+    const result = updateDrawer.handle({ width: 4 }, { aggregate: withOutline() });
+    if (!isOk(result)) throw new Error('handle failed');
+    const event = {
+      type: 'drawer.updated',
+      payload: result.value.event.payload,
+    } as never;
+    const replayed = applyEvent(withOutline(), event);
+    expect('outline' in replayed.drawer).toBe(false);
   });
 
   it('leaves the outline untouched when only height changes', () => {

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
@@ -67,3 +67,64 @@ describe('v2 drawer.update', () => {
     expect(applied.bins.find((b) => b.id === binId('bin_b'))?.layerId).not.toBe(STAGING_ID);
   });
 });
+
+describe('v2 drawer.update with an outline', () => {
+  const U = 42;
+  const L_OUTLINE = {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: 6 * U, y: 0 },
+      { x: 6 * U, y: 2 * U },
+      { x: 4 * U, y: 2 * U },
+      { x: 4 * U, y: 4 * U },
+      { x: 0, y: 4 * U },
+    ],
+  };
+  const withOutline = () => {
+    const base = makeLayout();
+    return { ...base, drawer: { ...base.drawer, outline: L_OUTLINE } };
+  };
+
+  it('crops the outline on shrink and records it in changes', () => {
+    const result = updateDrawer.handle({ width: 5 }, { aggregate: withOutline() });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const changes = result.value.event.payload.changes;
+    expect(changes.outline).toBeDefined();
+    expect(changes.outline?.vertices.every((v) => v.x <= 5 * U + 0.01)).toBe(true);
+    expect(result.value.event.payload.previous.outline).toBe(L_OUTLINE);
+  });
+
+  it('resets to a plain rectangle when the shrink consumes the notch', () => {
+    // Shrinking to width 4 removes everything right of the notch — the
+    // remaining region is the full 4×4 rectangle.
+    const result = updateDrawer.handle({ width: 4 }, { aggregate: withOutline() });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const payload = result.value.event.payload;
+    expect('outline' in payload.changes).toBe(true);
+    expect(payload.changes.outline).toBeUndefined();
+
+    const next = produce(withOutline(), (draft) => {
+      updateDrawer.apply({ payload } as never, draft);
+    });
+    expect('outline' in next.drawer).toBe(false);
+  });
+
+  it('displaces bins that fall outside the adapted outline', () => {
+    // Growing depth to 6 extends the shape upward except over the notch;
+    // a bin in the notch column stays displaced.
+    const layout = { ...withOutline(), bins: [makeBin('bin_notch', 5, 3)] };
+    const result = updateDrawer.handle({ depth: 6 }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.displacedBinIds).toEqual([binId('bin_notch')]);
+  });
+
+  it('leaves the outline untouched when only height changes', () => {
+    const result = updateDrawer.handle({ height: 9 }, { aggregate: withOutline() });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect('outline' in result.value.event.payload.changes).toBe(false);
+  });
+});

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
@@ -17,9 +17,11 @@ import type { Result, LayoutError } from '@/core/result';
 import { ok } from '@/core/result';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
+import { resizeDrawerOutline } from '@/shared/utils/drawerOutline';
 import type { BinId, Drawer, GridUnits } from '@/core/types';
 import { gridUnits, heightUnits } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
+import { computeDisplacedBins } from './displacement';
 
 const payloadSchema = z
   .object({
@@ -84,18 +86,33 @@ export const updateDrawer = defineCommand({
     if (payload.fractionalEdgeX !== undefined) changes.fractionalEdgeX = payload.fractionalEdgeX;
     if (payload.fractionalEdgeY !== undefined) changes.fractionalEdgeY = payload.fractionalEdgeY;
 
-    // Compute the displacement set against the post-update drawer dims.
     const newWidth: GridUnits = changes.width ?? drawer.width;
     const newDepth: GridUnits = changes.depth ?? drawer.depth;
-    const displacedBinIds = layout.bins
-      .filter((bin) => {
-        if (bin.layerId === STAGING_ID) return false;
-        return (
-          (bin.x as number) + (bin.width as number) > (newWidth as number) ||
-          (bin.y as number) + (bin.depth as number) > (newDepth as number)
-        );
-      })
-      .map((b) => b.id);
+
+    // A resize adapts the outline (cropped where the drawer shrank, extended
+    // where it grew); a degenerate result falls back to the full rectangle.
+    // The derived change rides in the event so replay stays deterministic.
+    const dimsChanged = newWidth !== drawer.width || newDepth !== drawer.depth;
+    let newOutline = drawer.outline;
+    if (drawer.outline !== undefined && dimsChanged) {
+      const u = layout.gridUnitMm as number;
+      newOutline = resizeDrawerOutline(
+        drawer.outline,
+        (drawer.width as number) * u,
+        (drawer.depth as number) * u,
+        (newWidth as number) * u,
+        (newDepth as number) * u,
+        u
+      );
+      changes.outline = newOutline;
+    }
+
+    // Displacement against the post-update drawer (dims AND adapted outline).
+    const displacedBinIds = computeDisplacedBins(
+      layout.bins,
+      { width: newWidth, depth: newDepth, outline: newOutline },
+      layout.gridUnitMm
+    );
 
     const previous = capturePrevious(drawer, changes);
 
@@ -113,6 +130,12 @@ export const updateDrawer = defineCommand({
   },
   apply: (event, draft) => {
     Object.assign(draft.drawer, event.payload.changes);
+    // Object.assign keeps an explicitly-undefined outline as a present key;
+    // reset-to-rectangle must delete it so downstream `!== undefined` guards
+    // and serialization see a truly absent field.
+    if ('outline' in event.payload.changes && event.payload.changes.outline === undefined) {
+      delete draft.drawer.outline;
+    }
     if (event.payload.displacedBinIds.length > 0) {
       const idSet = new Set(event.payload.displacedBinIds);
       for (const bin of draft.bins) {

--- a/src/core/cqrs/v2/registry.ts
+++ b/src/core/cqrs/v2/registry.ts
@@ -29,6 +29,7 @@ import { addCategory } from './domain/category/addCategory';
 import { updateCategory } from './domain/category/updateCategory';
 import { deleteCategory } from './domain/category/deleteCategory';
 import { updateDrawer } from './domain/drawer/updateDrawer';
+import { setDrawerOutline } from './domain/drawer/setDrawerOutline';
 import { setName } from './domain/layout/setName';
 import { setPrintBedSize } from './domain/layout/setPrintBedSize';
 import { setGridUnitMm } from './domain/layout/setGridUnitMm';
@@ -81,6 +82,7 @@ export const v2HandlerOverrides: Record<string, V2HandlerFn> = {
   [updateCategory.type]: wrapV2Handler(updateCategory) as V2HandlerFn,
   [deleteCategory.type]: wrapV2Handler(deleteCategory) as V2HandlerFn,
   [updateDrawer.type]: wrapV2Handler(updateDrawer) as V2HandlerFn,
+  [setDrawerOutline.type]: wrapV2Handler(setDrawerOutline) as V2HandlerFn,
   [setName.type]: wrapV2Handler(setName) as V2HandlerFn,
   [setPrintBedSize.type]: wrapV2Handler(setPrintBedSize) as V2HandlerFn,
   [setGridUnitMm.type]: wrapV2Handler(setGridUnitMm) as V2HandlerFn,
@@ -119,6 +121,7 @@ export const v2Commands = [
   updateCategory,
   deleteCategory,
   updateDrawer,
+  setDrawerOutline,
   setName,
   setPrintBedSize,
   setGridUnitMm,

--- a/src/core/cqrs/validation/outlineSchema.ts
+++ b/src/core/cqrs/validation/outlineSchema.ts
@@ -1,0 +1,47 @@
+/**
+ * Zod schema for `DrawerOutline` payloads. Structural bounds only — the
+ * geometric invariants (closed CCW simple loop, min area, within the drawer
+ * extent) are checked by `validateOutline` in the command handler, which
+ * knows the drawer dims. Coordinate bounds cover the largest drawer (50 units
+ * × up to 52mm grid) with slack.
+ */
+
+import * as z from 'zod';
+import { OUTLINE_MAX_VERTICES } from '@/shared/utils/drawerOutline';
+
+const OUTLINE_COORD_MIN = -1;
+const OUTLINE_COORD_MAX = 2600;
+
+const outlineVertexSchema = z.object({
+  x: z.number().finite().gte(OUTLINE_COORD_MIN).lte(OUTLINE_COORD_MAX),
+  y: z.number().finite().gte(OUTLINE_COORD_MIN).lte(OUTLINE_COORD_MAX),
+  bulge: z.number().finite().gte(-1).lte(1).optional(),
+});
+
+const cornerCutSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('none') }),
+  z.object({ kind: z.literal('chamfer'), size: z.number().finite().gt(0).lte(500) }),
+  z.object({ kind: z.literal('radius'), r: z.number().finite().gt(0).lte(500) }),
+  z.object({
+    kind: z.literal('notch'),
+    w: z.number().finite().gt(0).lte(2600),
+    d: z.number().finite().gt(0).lte(2600),
+  }),
+]);
+
+export const drawerOutlineSchema = z.object({
+  vertices: z.array(outlineVertexSchema).min(3).max(OUTLINE_MAX_VERTICES),
+  authoring: z
+    .object({
+      kind: z.enum(['cells', 'corners', 'trace', 'pen']),
+      corners: z
+        .object({
+          tl: cornerCutSchema,
+          tr: cornerCutSchema,
+          bl: cornerCutSchema,
+          br: cornerCutSchema,
+        })
+        .optional(),
+    })
+    .optional(),
+});

--- a/src/core/cqrs/validation/schemas.test.ts
+++ b/src/core/cqrs/validation/schemas.test.ts
@@ -43,9 +43,9 @@ describe('COMMAND_SCHEMAS', () => {
     }
   });
 
-  it('has exactly 35 schemas', () => {
+  it('has exactly 36 schemas', () => {
     const registeredCount = Object.keys(COMMAND_SCHEMAS).length;
-    expect(registeredCount).toBe(35);
+    expect(registeredCount).toBe(36);
   });
 });
 

--- a/src/core/cqrs/validation/schemas.ts
+++ b/src/core/cqrs/validation/schemas.ts
@@ -25,6 +25,7 @@ import {
   libraryImportLayoutSchema,
 } from './librarySchemas';
 import { designerSaveSchema } from './designerSchemas';
+import { drawerOutlineSchema } from './outlineSchema';
 /** Branded string IDs are strings at runtime */
 const binIdSchema = z.string().min(1);
 const layerIdSchema = z.string().min(1);
@@ -286,6 +287,7 @@ export const COMMAND_SCHEMAS: Readonly<Partial<Record<CommandType, z.ZodType>>> 
 
   // Drawer/layout commands (6)
   'drawer.update': drawerUpdateSchema,
+  'drawer.setOutline': z.object({ outline: drawerOutlineSchema.nullable() }),
   'layout.setName': layoutSetNameSchema,
   'layout.setPrintBedSize': layoutSetPrintBedSizeSchema,
   'layout.setGridUnitMm': layoutSetGridUnitMmSchema,

--- a/src/core/cqrs/versioning/eventVersions.ts
+++ b/src/core/cqrs/versioning/eventVersions.ts
@@ -32,7 +32,10 @@ export const CURRENT_EVENT_VERSIONS: Record<DomainEventType, number> = {
   'category.deleted': 1,
 
   // Drawer / layout metadata events
+  // Still v1: `changes`/`previous` may now carry the additive optional
+  // `outline` field, which old and new decoders both handle — no migration.
   'drawer.updated': 1,
+  'drawer.outlineSet': 1,
   'layout.nameSet': 1,
   'layout.printBedSizeSet': 1,
   'layout.gridUnitMmSet': 1,

--- a/src/core/cqrs/versioning/migrations.test.ts
+++ b/src/core/cqrs/versioning/migrations.test.ts
@@ -185,6 +185,7 @@ describe('CURRENT_EVENT_VERSIONS registry completeness', () => {
     'category.deleted',
     // Drawer / layout events
     'drawer.updated',
+    'drawer.outlineSet',
     'layout.nameSet',
     'layout.printBedSizeSet',
     'layout.gridUnitMmSet',

--- a/src/core/store/layout/drawerActions.ts
+++ b/src/core/store/layout/drawerActions.ts
@@ -1,6 +1,8 @@
 import type { Drawer, GridUnits, HeightUnits } from '@/core/types';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
+import { resizeDrawerOutline } from '@/shared/utils/drawerOutline';
+import { computeDisplacedBins } from '@/core/cqrs/v2/domain/drawer/displacement';
 import type { SetLocal } from './types';
 
 export function createDrawerActions(setLocal: SetLocal) {
@@ -8,6 +10,8 @@ export function createDrawerActions(setLocal: SetLocal) {
     updateDrawer: (updates: Partial<Drawer>): void => {
       setLocal((state) => {
         const drawer = state.layout.drawer;
+        const oldWidth = drawer.width as number;
+        const oldDepth = drawer.depth as number;
 
         if (updates.width !== undefined) {
           drawer.width = clamp(
@@ -34,15 +38,40 @@ export function createDrawerActions(setLocal: SetLocal) {
           drawer.fractionalEdgeY = updates.fractionalEdgeY;
         }
 
-        // Move out-of-bounds bins to staging
-        state.layout.bins = state.layout.bins.map((bin) => {
-          if (bin.layerId === STAGING_ID) return bin;
-
-          if (bin.x + bin.width > drawer.width || bin.y + bin.depth > drawer.depth) {
-            return { ...bin, layerId: STAGING_ID };
+        // Adapt the outline to the new dims (crop/extend; degenerate result →
+        // back to the plain rectangle) — same rule as the CQRS updateDrawer
+        // command, shared via resizeDrawerOutline.
+        if (
+          drawer.outline !== undefined &&
+          ((drawer.width as number) !== oldWidth || (drawer.depth as number) !== oldDepth)
+        ) {
+          const u = state.layout.gridUnitMm as number;
+          const resized = resizeDrawerOutline(
+            drawer.outline,
+            oldWidth * u,
+            oldDepth * u,
+            (drawer.width as number) * u,
+            (drawer.depth as number) * u,
+            u
+          );
+          if (resized === undefined) {
+            delete drawer.outline;
+          } else {
+            drawer.outline = resized;
           }
-          return bin;
-        });
+        }
+
+        // Move bins that no longer fit (bounds or outline) to staging.
+        const displaced = new Set(
+          computeDisplacedBins(state.layout.bins, drawer, state.layout.gridUnitMm)
+        );
+        if (displaced.size > 0) {
+          state.layout.bins = state.layout.bins.map((bin) =>
+            displaced.has(bin.id) && bin.layerId !== STAGING_ID
+              ? { ...bin, layerId: STAGING_ID }
+              : bin
+          );
+        }
       });
     },
   };

--- a/src/core/store/layout/drawerActions.ts
+++ b/src/core/store/layout/drawerActions.ts
@@ -61,7 +61,12 @@ export function createDrawerActions(setLocal: SetLocal) {
           }
         }
 
-        // Move bins that no longer fit (bounds or outline) to staging.
+        // Move bins that no longer fit (bounds or outline) to staging. Planar
+        // fit only depends on width/depth/outline — skip the geometry pass for
+        // height/fractional-edge updates (this action runs per pointermove).
+        const planarChanged =
+          (drawer.width as number) !== oldWidth || (drawer.depth as number) !== oldDepth;
+        if (!planarChanged) return;
         const displaced = new Set(
           computeDisplacedBins(state.layout.bins, drawer, state.layout.gridUnitMm)
         );

--- a/src/core/sync/adapters/layoutAdapter.ts
+++ b/src/core/sync/adapters/layoutAdapter.ts
@@ -1,6 +1,7 @@
 import { isErr } from '@/core/result';
 import { useLayoutStore, useLibraryStore } from '@/core/store';
 import type { Bin, Layout, LayoutEntry, LayoutId, LayoutLibrary } from '@/core/types';
+import { normalizeDrawerOutline } from '@/shared/utils/drawerOutline';
 import {
   computePreview,
   loadLayoutAsync,
@@ -24,17 +25,19 @@ type IncomingLayout = Omit<Layout, 'bins'> & { bins: IncomingBin[] };
 export function normalizeIncomingLayout(layout: Layout): Layout {
   const bins = (layout as IncomingLayout).bins;
   const needsHealing = bins.some((b) => typeof b.notes !== 'string' || typeof b.label !== 'string');
-  if (!needsHealing) return layout;
-  return {
-    ...layout,
-    bins: bins.map(
-      (b): Bin => ({
-        ...b,
-        notes: typeof b.notes === 'string' ? b.notes : '',
-        label: typeof b.label === 'string' ? b.label : '',
-      })
-    ),
-  };
+  const healed = needsHealing
+    ? {
+        ...layout,
+        bins: bins.map((b): Bin => ({
+          ...b,
+          notes: typeof b.notes === 'string' ? b.notes : '',
+          label: typeof b.label === 'string' ? b.label : '',
+        })),
+      }
+    : layout;
+  // A remote device may have resized the drawer without adapting the outline
+  // (older client); crop/drop it before it reaches local storage.
+  return normalizeDrawerOutline(healed);
 }
 
 /**

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "Kategorie gelöscht",
   "undo.categoryUpdated": "Kategorie aktualisiert",
   "undo.drawerUpdated": "Drawer aktualisiert",
+  "undo.drawerOutlineSet": "Schubladenform geändert",
   "undo.gapsFilled": "Lücken gefüllt",
   "undo.gridUnitChanged": "Grid Unit geändert",
   "undo.heightUnitChanged": "Height Unit geändert",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2919,6 +2919,7 @@ const en: Record<string, string> = {
   'undo.categoryUpdated': 'Updated category',
   'undo.categoryDeleted': 'Deleted category',
   'undo.drawerUpdated': 'Updated drawer',
+  'undo.drawerOutlineSet': 'Changed drawer shape',
   'undo.nameChanged': 'Changed name',
   'undo.printBedSizeChanged': 'Changed print bed size',
   'undo.gridUnitChanged': 'Changed grid unit',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "Categoria eliminada",
   "undo.categoryUpdated": "Categoria actualizada",
   "undo.drawerUpdated": "Drawer actualizado",
+  "undo.drawerOutlineSet": "Forma del cajón cambiada",
   "undo.gapsFilled": "Espacios rellenados",
   "undo.gridUnitChanged": "Grid unit cambiada",
   "undo.heightUnitChanged": "Height unit cambiada",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "Catégorie supprimée",
   "undo.categoryUpdated": "Catégorie mise à jour",
   "undo.drawerUpdated": "Drawer mis à jour",
+  "undo.drawerOutlineSet": "Forme du tiroir modifiée",
   "undo.gapsFilled": "Espaces remplis",
   "undo.gridUnitChanged": "Grid unit modifiée",
   "undo.heightUnitChanged": "Height unit modifiée",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "カテゴリーを削除",
   "undo.categoryUpdated": "カテゴリーを更新",
   "undo.drawerUpdated": "ドロワーを更新",
+  "undo.drawerOutlineSet": "引き出しの形状を変更しました",
   "undo.gapsFilled": "隙間を埋める",
   "undo.gridUnitChanged": "グリッドユニットを変更",
   "undo.heightUnitChanged": "高さユニットを変更",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "Kategori slettet",
   "undo.categoryUpdated": "Kategori oppdatert",
   "undo.drawerUpdated": "Drawer oppdatert",
+  "undo.drawerOutlineSet": "Skuffeform endret",
   "undo.gapsFilled": "Hull fylt",
   "undo.gridUnitChanged": "Grid unit endret",
   "undo.heightUnitChanged": "Height unit endret",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "Categorie verwijderd",
   "undo.categoryUpdated": "Categorie bijgewerkt",
   "undo.drawerUpdated": "Drawer bijgewerkt",
+  "undo.drawerOutlineSet": "Ladevorm gewijzigd",
   "undo.gapsFilled": "Gaten gevuld",
   "undo.gridUnitChanged": "Grid unit gewijzigd",
   "undo.heightUnitChanged": "Height unit gewijzigd",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "Categoria excluída",
   "undo.categoryUpdated": "Categoria atualizada",
   "undo.drawerUpdated": "Drawer atualizado",
+  "undo.drawerOutlineSet": "Formato da gaveta alterado",
   "undo.gapsFilled": "Lacunas preenchidas",
   "undo.gridUnitChanged": "Grid unit alterada",
   "undo.heightUnitChanged": "Height unit alterada",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "Raderade kategori",
   "undo.categoryUpdated": "Uppdaterade kategori",
   "undo.drawerUpdated": "Uppdaterade låda",
+  "undo.drawerOutlineSet": "Lådans form ändrad",
   "undo.gapsFilled": "Fyllde luckor",
   "undo.gridUnitChanged": "Ändrade rutnätsenhet",
   "undo.heightUnitChanged": "Ändrade höjdenhet",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2562,6 +2562,7 @@
   "undo.categoryDeleted": "Видалено категорію",
   "undo.categoryUpdated": "Оновлено категорію",
   "undo.drawerUpdated": "Оновлено шухляду",
+  "undo.drawerOutlineSet": "Змінено форму шухляди",
   "undo.gapsFilled": "Заповнено проміжки",
   "undo.gridUnitChanged": "Змінено одиницю сітки",
   "undo.heightUnitChanged": "Змінено одиницю висоти",

--- a/src/shared/contexts/MutationsContext.tsx
+++ b/src/shared/contexts/MutationsContext.tsx
@@ -32,6 +32,7 @@ import type {
   CloudShareInfo,
   StoredBaseplateParams,
   BaseplateDesignId,
+  DrawerOutline,
 } from '@/core/types';
 import type { Result, ValidationError, LayoutError } from '@/core/result';
 
@@ -62,6 +63,7 @@ export interface Mutations {
 
   // Drawer operations
   updateDrawer: (updates: Partial<Drawer>) => void;
+  setDrawerOutline: (outline: DrawerOutline | null) => Result<void, LayoutError>;
 
   // Category operations
   addCategory: (category: Omit<Category, 'id'>) => Result<CategoryId, LayoutError>;

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -455,6 +455,14 @@ describe('normalizeDrawerOutline', () => {
     expect(normalizeDrawerOutline(layout)).toBe(layout);
   });
 
+  it('drops malformed outline values without crashing (untrusted ingress)', () => {
+    for (const garbage of [null, 42, 'shape', {}, { vertices: 'nope' }, { vertices: [{}] }]) {
+      const layout = layoutWith(undefined);
+      (layout.drawer as { outline?: unknown }).outline = garbage;
+      expect(normalizeDrawerOutline(layout).drawer.outline).toBeUndefined();
+    }
+  });
+
   it('drops invalid outlines', () => {
     const bowtie: DrawerOutline = {
       vertices: [

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -538,9 +538,24 @@ export function resizeDrawerOutline(
  * touching the outline), quantizes/snaps, and drops it entirely when invalid
  * or rectangle-equivalent. Returns the input layout when nothing changes.
  */
+/** Structural check for untrusted outline data: an object with an array of
+ * ≥3 vertex objects carrying finite numeric coordinates. */
+function isStructurallyOutline(value: unknown): value is DrawerOutline {
+  if (typeof value !== 'object' || value === null) return false;
+  const vertices = (value as { vertices?: unknown }).vertices;
+  if (!Array.isArray(vertices) || vertices.length < 3) return false;
+  return vertices.every(
+    (v: unknown) =>
+      typeof v === 'object' &&
+      v !== null &&
+      Number.isFinite((v as { x?: unknown }).x) &&
+      Number.isFinite((v as { y?: unknown }).y)
+  );
+}
+
 export function normalizeDrawerOutline(layout: Layout): Layout {
   // Tolerate malformed payloads (ingress guard runs before full validation).
-  const outline = (layout.drawer as Layout['drawer'] | undefined)?.outline;
+  const outline = (layout.drawer as Layout['drawer'] | undefined)?.outline as unknown;
   if (outline === undefined) return layout;
 
   const widthMm = (layout.drawer.width as number) * (layout.gridUnitMm as number);
@@ -551,6 +566,10 @@ export function normalizeDrawerOutline(layout: Layout): Layout {
     delete drawer.outline;
     return { ...layout, drawer };
   };
+
+  // null / non-object / vertex-less garbage from corrupted storage or
+  // hand-edited JSON: drop rather than crash ingestion.
+  if (!isStructurallyOutline(outline)) return drop();
 
   let verts: MutableVertex[] | null = toMutable(outline.vertices);
   verts = clipHalfPlane(verts, 'x', widthMm, 'min');

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -539,7 +539,8 @@ export function resizeDrawerOutline(
  * or rectangle-equivalent. Returns the input layout when nothing changes.
  */
 export function normalizeDrawerOutline(layout: Layout): Layout {
-  const outline = layout.drawer.outline;
+  // Tolerate malformed payloads (ingress guard runs before full validation).
+  const outline = (layout.drawer as Layout['drawer'] | undefined)?.outline;
   if (outline === undefined) return layout;
 
   const widthMm = (layout.drawer.width as number) * (layout.gridUnitMm as number);

--- a/src/shared/utils/validationImport.ts
+++ b/src/shared/utils/validationImport.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Bin, Layout, ValidationReason } from '@/core/types';
+import { normalizeDrawerOutline } from './drawerOutline';
 import {
   binId as toBinId,
   layerId as toLayerId,
@@ -219,5 +220,8 @@ export function validateImport(data: unknown): ImportValidationResult {
     return { valid: false, errors };
   }
 
-  return { valid: true, errors: [], layout: data as Layout };
+  // Never trust a stored outline: crop it to the current drawer extent (an
+  // old client may have resized the drawer without adapting the shape) and
+  // drop it when invalid or rectangle-equivalent.
+  return { valid: true, errors: [], layout: normalizeDrawerOutline(data as Layout) };
 }

--- a/src/shared/utils/validationSalvage.ts
+++ b/src/shared/utils/validationSalvage.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Bin, Layout } from '@/core/types';
+import { normalizeDrawerOutline } from './drawerOutline';
 import {
   binId as toBinId,
   layerId as toLayerId,
@@ -179,5 +180,5 @@ export function salvageImport(data: unknown): SalvageResult {
     bins: resultBins,
   };
 
-  return { valid: true, layout: salvageLayout, salvaged };
+  return { valid: true, layout: normalizeDrawerOutline(salvageLayout), salvaged };
 }


### PR DESCRIPTION
## Summary

Fourth PR toward #2528: the state/persistence layer for drawer outlines. Everything the authoring UI (next PRs) will call is now in place, plus the trust boundaries that keep outlines sane across share, sync, and old clients.

## Changes

**CQRS**
- New `drawer.setOutline` v2 command — the single write path for every shape-authoring surface. `handle()` quantizes/snaps, validates against the drawer's mm extent, normalizes rectangle-equivalent shapes back to "no outline", and precomputes the displacement set (bins outside the shape → staging) so `apply()` and replay stay deterministic. Full registry wiring per the CQRS checklist (command/event unions, versions, middleware profile, undo toast key, Zod schema, replay case).
- `drawer.update` adapts an existing outline on resize: cropped where the drawer shrank (arc-aware), extended (new area inside) where it grew, reset to the plain rectangle when the result would be degenerate or trap a hole. The derived outline change rides in the event; undo restores dims + shape atomically.
- `drawer.updated` stays schema v1 deliberately: the payload picked up an additive optional field with unchanged shape, so a version bump would only add no-op migration machinery.
- Shared `computeDisplacedBins` (bounds OR outline, boundary-flush footprints stay) used by both commands **and** the legacy high-frequency drag path (`drawerActions`), so the three write paths can never disagree.

**Server (`api/lib/validation.ts`)**
- The drawer was previously passed through sanitization **raw** — junk keys survived. It's now rebuilt field-by-field ({width, depth, height, fractionalEdgeX/Y, outline}).
- New structural gate for outlines: 3–256 vertices, finite coords in [-1, 2600]mm, |bulge| ≤ 1, chord-level self-intersection rejection; `authoring` sanitized to the kind enum (the `corners` params are dropped server-side — round-trip sugar the editor re-derives).

**Read-side (never trust a stored outline)**
- `normalizeDrawerOutline` runs on every layout ingress — import validation, salvage, and sync pull — cropping outlines stale from an old client's resize and dropping invalid or rectangle-equivalent ones. Forward-compat is additive: old clients preserve the field inertly and no layout version bump is needed.

**Mutations API** — `mutations.setDrawerOutline(outline | null)` exposed through the adapter and context; undo toast localized in all 10 locales.

## Testing

- `setDrawerOutline`: set/displace/apply, clear-with-undo, rectangle normalization, self-intersection and extent rejection, boundary snapping.
- `updateDrawer`: shrink-crop with `previous` capture, notch-consuming reset (including the delete-on-apply path), outline-aware displacement on grow, height-only no-op.
- `computeDisplacedBins`: bounds, outline, boundary-flush, staged-bin exclusion.
- Server: preservation round-trip, junk-key rejection via the rebuild, fractional-edge preservation, vertex/coord/bulge bounds, self-intersection, authoring sanitization (8 new cases).
- Full CQRS suite green (429) including the schema-count and event-registry completeness pins; `pnpm run quality` clean; i18n checks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single, safe write path for non‑rectangular drawer shapes and keeps them consistent across resize, share, sync, and older clients. Implements v2 `drawer.setOutline`, adapts outlines on `drawer.update`, and hardens outline trust boundaries and event replay (Linear #2528).

- **New Features**
  - v2 `drawer.setOutline`: snaps and validates against the drawer extent, normalizes rectangle‑equivalent shapes to no outline, and stages displaced bins with deterministic replay.
  - `drawer.update`: adapts an existing outline on resize (crop/extend; degenerate resets to rectangle) and carries the derived change in the event.
  - Shared bin displacement (bounds or outline) used by both commands and the legacy drag path; mutations expose `setDrawerOutline(outline | null)` with an undo toast in all locales.

- **Bug Fixes**
  - Server validation tightened: chord self‑intersection now catches collinear overlaps and endpoint‑on‑segment touches; junk keys removed; unknown authoring kinds no longer reject the layout (annotation dropped).
  - Read‑side `normalizeDrawerOutline` runs on import/salvage/sync, now also tolerates malformed values (null/non‑object/vertex‑less), crops stale outlines, and drops invalid or rectangle‑equivalent ones.
  - Replay correctness: `drawer.updated` now deletes the outline key on reset‑to‑rectangle to avoid divergence; displacement covers negative‑coordinate bins, and the legacy drag path skips the displacement pass for non‑planar updates.

<sup>Written for commit dae1690efa582ecb9660eba8fafe605ad5c4e98d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

