### PR TITLE
feat(grid): gate bin placement and render the drawer outline in the layout tab

### DIFF
--- a/src/core/result/errors.ts
+++ b/src/core/result/errors.ts
@@ -71,7 +71,8 @@ export type ValidationFailureReason =
   | 'exceeds_height'
   | 'invalid_layer'
   | 'collision'
-  | 'blocked_zone';
+  | 'blocked_zone'
+  | 'outside_drawer';
 
 /**
  * Base interface for all application errors.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -466,7 +466,8 @@ export type ValidationReason =
   | 'exceeds_height'
   | 'invalid_layer'
   | 'collision'
-  | 'blocked_zone';
+  | 'blocked_zone'
+  | 'outside_drawer';
 
 /** Info about what's blocking a placement (for user feedback) */
 export interface BlockingInfo {

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
@@ -49,7 +49,8 @@ describe('DrawerOutlineOverlay', () => {
     const paths = container.querySelectorAll('path');
     expect(paths).toHaveLength(2);
     // Even-odd outside fill references the hatch pattern.
-    expect(paths[0].getAttribute('fill')).toBe('url(#drawer-outline-hatch)');
+    const patternIdAttr = container.querySelector('pattern')?.getAttribute('id');
+    expect(paths[0].getAttribute('fill')).toBe(`url(#${patternIdAttr})`);
     expect(paths[0].getAttribute('fill-rule')).toBe('evenodd');
     // The boundary path is stroked, not filled.
     expect(paths[1].getAttribute('fill')).toBe('none');

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useLayoutStore } from '@/core/store';
+import { resetAllStores } from '@/test/testUtils';
+import { gridUnits } from '@/core/types';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+import type { DrawerOutline } from '@/core/types';
+import { DrawerOutlineOverlay } from './DrawerOutlineOverlay';
+
+const U = 42;
+
+const L_SHAPE: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 6 * U, y: 0 },
+    { x: 6 * U, y: 2 * U },
+    { x: 4 * U, y: 2 * U },
+    { x: 4 * U, y: 4 * U },
+    { x: 0, y: 4 * U },
+  ],
+};
+
+function renderOverlay() {
+  return render(<DrawerOutlineOverlay cellSize={40} gap={2} />);
+}
+
+describe('DrawerOutlineOverlay', () => {
+  beforeEach(() => {
+    resetAllStores();
+  });
+
+  it('renders nothing for rectangular drawers', () => {
+    renderOverlay();
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+
+  it('renders the hatch and boundary for a shaped drawer', () => {
+    useLayoutStore.setState((s) => ({
+      layout: {
+        ...s.layout,
+        drawer: { ...s.layout.drawer, width: gridUnits(6), depth: gridUnits(4), outline: L_SHAPE },
+      },
+    }));
+    const { container } = renderOverlay();
+    expect(screen.getByRole('img')).toBeInTheDocument();
+    const paths = container.querySelectorAll('path');
+    expect(paths).toHaveLength(2);
+    // Even-odd outside fill references the hatch pattern.
+    expect(paths[0].getAttribute('fill')).toBe('url(#drawer-outline-hatch)');
+    expect(paths[0].getAttribute('fill-rule')).toBe('evenodd');
+    // The boundary path is stroked, not filled.
+    expect(paths[1].getAttribute('fill')).toBe('none');
+  });
+});

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useLayoutStore } from '@/core/store';
+import { useTranslation } from '@/i18n';
+import { flattenOutline } from '@/shared/utils/drawerOutlineGeometry';
+
+interface DrawerOutlineOverlayProps {
+  cellSize: number;
+  gap: number;
+}
+
+/**
+ * Visual overlay for a non-rectangular drawer (issue #2528): hatches the
+ * region outside the outline and strokes the boundary. One SVG with an
+ * even-odd path (grid rect + outline subpath) — no per-cell elements, so a
+ * 50×50 grid costs the same as a 2×2.
+ *
+ * Purely visual and `pointer-events: none`: placement truth lives in
+ * `canPlaceBin` (same geometry predicate), so a hatched cell is exactly a
+ * cell placement would reject.
+ */
+export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProps) {
+  const t = useTranslation();
+  const { outline, width, depth, gridUnitMm } = useLayoutStore(
+    useShallow((s) => ({
+      outline: s.layout.drawer.outline,
+      width: s.layout.drawer.width,
+      depth: s.layout.drawer.depth,
+      gridUnitMm: s.layout.gridUnitMm,
+    }))
+  );
+
+  const unitPx = cellSize + gap;
+  const totalW = width * unitPx - gap;
+  const totalD = depth * unitPx - gap;
+
+  const path = useMemo(() => {
+    if (outline === undefined) return null;
+    // Grid px space: origin top-left, outline mm space: origin bottom-left.
+    // Interior unit boundaries sit mid-gap; the half-gap offset is invisible
+    // at typical 2-4px gaps and irrelevant to placement (visual only).
+    const px = (mm: number): number => Math.min(totalW, Math.max(0, (mm / gridUnitMm) * unitPx));
+    const py = (mm: number): number =>
+      totalD - Math.min(totalD, Math.max(0, (mm / gridUnitMm) * unitPx));
+    const pts = flattenOutline(outline);
+    const loop = pts
+      .map((p, i) => `${i === 0 ? 'M' : 'L'}${px(p.x).toFixed(2)} ${py(p.y).toFixed(2)}`)
+      .join(' ');
+    return {
+      outside: `M0 0 H${totalW.toFixed(2)} V${totalD.toFixed(2)} H0 Z ${loop} Z`,
+      boundary: `${loop} Z`,
+    };
+  }, [outline, gridUnitMm, unitPx, totalW, totalD]);
+
+  if (path === null) return null;
+
+  return (
+    <svg
+      aria-label={t('grid.drawerOutlineAria')}
+      role="img"
+      className="pointer-events-none absolute text-neutral-500 dark:text-neutral-400"
+      style={{ left: gap, top: gap, zIndex: 6 }}
+      width={totalW}
+      height={totalD}
+    >
+      <defs>
+        <pattern
+          id="drawer-outline-hatch"
+          width="8"
+          height="8"
+          patternUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <line x1="0" y1="0" x2="0" y2="8" stroke="currentColor" strokeWidth="1.5" />
+        </pattern>
+      </defs>
+      <path d={path.outside} fill="url(#drawer-outline-hatch)" fillRule="evenodd" opacity={0.35} />
+      <path
+        d={path.boundary}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        opacity={0.6}
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
@@ -21,6 +21,7 @@ interface DrawerOutlineOverlayProps {
  */
 export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProps) {
   const t = useTranslation();
+  const patternId = useId();
   const { outline, width, depth, gridUnitMm } = useLayoutStore(
     useShallow((s) => ({
       outline: s.layout.drawer.outline,
@@ -65,7 +66,7 @@ export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProp
     >
       <defs>
         <pattern
-          id="drawer-outline-hatch"
+          id={patternId}
           width="8"
           height="8"
           patternUnits="userSpaceOnUse"
@@ -74,7 +75,7 @@ export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProp
           <line x1="0" y1="0" x2="0" y2="8" stroke="currentColor" strokeWidth="1.5" />
         </pattern>
       </defs>
-      <path d={path.outside} fill="url(#drawer-outline-hatch)" fillRule="evenodd" opacity={0.35} />
+      <path d={path.outside} fill={`url(#${patternId})`} fillRule="evenodd" opacity={0.35} />
       <path
         d={path.boundary}
         fill="none"

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/index.ts
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/index.ts
@@ -1,0 +1,1 @@
+export { DrawerOutlineOverlay } from './DrawerOutlineOverlay';

--- a/src/features/grid-editor/components/Grid/GridCanvas/GridCanvas.tsx
+++ b/src/features/grid-editor/components/Grid/GridCanvas/GridCanvas.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_CATEGORY_COLOR } from '@/core/constants';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import type { Coord, ResizeHandle, BinId, LayerId } from '@/core/types';
 import { useTranslation } from '@/i18n';
+import { DrawerOutlineOverlay } from '../DrawerOutlineOverlay';
 
 // Amber paintbrush cursor shown while a brush size is loaded (falls back to the
 // cell cursor if the inline SVG can't be loaded). Built from the shared brush
@@ -408,6 +409,9 @@ export function GridCanvas({
         {/* Brush footprint preview that follows the cursor in paint mode */}
         <BrushHoverGhost gridRef={gridRef} cellSize={cellSize} gap={gap} />
       </div>
+
+      {/* Non-rectangular drawer: hatch outside the outline (issue #2528) */}
+      <DrawerOutlineOverlay cellSize={cellSize} gap={gap} />
     </div>
   );
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "In Stash verschieben",
   "grid.noBinsYet": "Noch keine Bins",
   "grid.outOfBounds": "Außerhalb der Grenzen",
+  "grid.outsideDrawerShape": "Außerhalb der Schubladenform",
+  "grid.drawerOutlineAria": "Begrenzung der Schubladenform",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "Platzieren Sie Bins auf dem Raster, um Ihr 3D-Layout zu sehen",
   "grid.preview.close": "Vorschau schließen",
   "grid.preview.collapse": "Vorschau einklappen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1377,6 +1377,8 @@ const en: Record<string, string> = {
   'grid.collision': 'Collides with existing bin',
   'grid.invalidLayer': 'Invalid layer',
   'grid.outOfBounds': 'Out of bounds',
+  'grid.outsideDrawerShape': 'Outside the drawer shape',
+  'grid.drawerOutlineAria': 'Drawer shape boundary',
   'grid.collapse': 'Collapse',
   'grid.dragToAddRemoveColumns': 'Drag to add/remove columns',
   'grid.dragToAddRemoveRows': 'Drag to add/remove rows',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "Mover a la reserva",
   "grid.noBinsYet": "Aún no hay bins",
   "grid.outOfBounds": "Fuera de los límites",
+  "grid.outsideDrawerShape": "Fuera de la forma del cajón",
+  "grid.drawerOutlineAria": "Límite de la forma del cajón",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "Coloca bins en la cuadrícula para ver tu diseño 3D",
   "grid.preview.close": "Cerrar vista previa",
   "grid.preview.collapse": "Contraer vista previa",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "Déplacer vers la réserve",
   "grid.noBinsYet": "Aucun bin encore",
   "grid.outOfBounds": "Hors limites",
+  "grid.outsideDrawerShape": "En dehors de la forme du tiroir",
+  "grid.drawerOutlineAria": "Limite de la forme du tiroir",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "Placer des bins sur la grille pour voir votre layout 3D",
   "grid.preview.close": "Fermer l'aperçu",
   "grid.preview.collapse": "Réduire l'aperçu",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "ステージングへ移動",
   "grid.noBinsYet": "ビンはまだありません",
   "grid.outOfBounds": "範囲外",
+  "grid.outsideDrawerShape": "引き出しの形状の外側",
+  "grid.drawerOutlineAria": "引き出し形状の境界",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "グリッドにビンを配置すると3Dレイアウトが表示されます",
   "grid.preview.close": "プレビューを閉じる",
   "grid.preview.collapse": "プレビューを折りたたむ",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "Flytt til stash",
   "grid.noBinsYet": "Ingen bins ennå",
   "grid.outOfBounds": "Utenfor grenser",
+  "grid.outsideDrawerShape": "Utenfor skuffeformen",
+  "grid.drawerOutlineAria": "Skuffeformens grense",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "Plasser bins på rutenettet for å se din 3D-layout",
   "grid.preview.close": "Lukk forhåndsvisning",
   "grid.preview.collapse": "Skjul forhåndsvisning",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "Naar stash verplaatsen",
   "grid.noBinsYet": "Nog geen bins",
   "grid.outOfBounds": "Buiten bereik",
+  "grid.outsideDrawerShape": "Buiten de ladevorm",
+  "grid.drawerOutlineAria": "Grens van de ladevorm",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "Plaats bins op het grid om je 3D layout te zien",
   "grid.preview.close": "Preview sluiten",
   "grid.preview.collapse": "Preview invouwen",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "Mover para a área de espera",
   "grid.noBinsYet": "Nenhum bin ainda",
   "grid.outOfBounds": "Fora dos limites",
+  "grid.outsideDrawerShape": "Fora do formato da gaveta",
+  "grid.drawerOutlineAria": "Limite do formato da gaveta",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "Posicione bins na grade para ver seu layout 3D",
   "grid.preview.close": "Fechar pré-visualização",
   "grid.preview.collapse": "Recolher pré-visualização",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "Flytta till stash",
   "grid.noBinsYet": "Inga fack ännu",
   "grid.outOfBounds": "Utanför gränserna",
+  "grid.outsideDrawerShape": "Utanför lådans form",
+  "grid.drawerOutlineAria": "Gräns för lådans form",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "Placera fack på rutnätet för att se din 3D-layout",
   "grid.preview.close": "Stäng förhandsvisning",
   "grid.preview.collapse": "Komprimera förhandsvisning",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1403,6 +1403,8 @@
   "grid.moveToStashConfirm": "Перемістити в архів",
   "grid.noBinsYet": "Бінів ще немає",
   "grid.outOfBounds": "Поза межами",
+  "grid.outsideDrawerShape": "Поза формою шухляди",
+  "grid.drawerOutlineAria": "Межа форми шухляди",
   "grid.placeBinsOnTheGridToSeeYour3dLayout": "Розмістіть біни на сітці, щоб побачити 3D-розкладку",
   "grid.preview.close": "Закрити перегляд",
   "grid.preview.collapse": "Згорнути перегляд",

--- a/src/shared/utils/fill.ts
+++ b/src/shared/utils/fill.ts
@@ -1,19 +1,32 @@
 import type { Bin, GridUnits, Layout, LayerId, CategoryId } from '@/core/types';
 import { generateBinId, CONSTRAINTS } from '@/core/constants';
 import { getBlockedZones } from './collision';
+import { getOutsideCellSet } from './drawerOutlineCells';
 
 /**
  * Create a Set of blocked cell keys for O(1) lookup.
  * Key format: "x,y"
  * @param step - Iteration step size (0.5 for half-bin mode, 1 for normal)
  */
-function createOccupiedCellSet(
+export function createOccupiedCellSet(
   bins: Bin[],
   layerId: LayerId,
   layout: Layout,
   step: number = 1
 ): Set<string> {
   const occupied = new Set<string>();
+
+  // Cells outside a non-rectangular drawer are unplaceable — mark them
+  // occupied so fill tools skip them (same predicate as canPlaceBin).
+  if (layout.drawer.outline !== undefined) {
+    const outside = getOutsideCellSet(
+      layout.drawer.outline,
+      layout.drawer,
+      layout.gridUnitMm,
+      step === 0.5 ? 0.5 : 1
+    );
+    for (const key of outside) occupied.add(key);
+  }
 
   // Add cells from existing bins on this layer
   for (const bin of bins) {

--- a/src/shared/utils/fill.ts
+++ b/src/shared/utils/fill.ts
@@ -12,7 +12,7 @@ export function createOccupiedCellSet(
   bins: Bin[],
   layerId: LayerId,
   layout: Layout,
-  step: number = 1
+  step: 0.5 | 1 = 1
 ): Set<string> {
   const occupied = new Set<string>();
 
@@ -23,7 +23,7 @@ export function createOccupiedCellSet(
       layout.drawer.outline,
       layout.drawer,
       layout.gridUnitMm,
-      step === 0.5 ? 0.5 : 1
+      step
     );
     for (const key of outside) occupied.add(key);
   }
@@ -112,7 +112,7 @@ export function fillAllWithSize(
   }
 
   // Step size for collision detection (0.5 in half-bin mode, 1 in normal)
-  const step = halfGridMode ? 0.5 : 1;
+  const step: 0.5 | 1 = halfGridMode ? 0.5 : 1;
 
   // Pre-compute occupied cells (existing bins + blocked zones)
   const occupied = createOccupiedCellSet(layout.bins, layerId, layout, step);
@@ -177,7 +177,7 @@ export function fillGaps(
   }
 
   // Step size for iteration and collision detection (0.5 in half-bin mode, 1 in normal)
-  const step = halfGridMode ? 0.5 : 1;
+  const step: 0.5 | 1 = halfGridMode ? 0.5 : 1;
   const minSize = halfGridMode ? 0.5 : 1;
 
   // Pre-compute occupied cells (existing bins + blocked zones)

--- a/src/shared/utils/rotation.ts
+++ b/src/shared/utils/rotation.ts
@@ -46,6 +46,9 @@ export function validateRotationInPlace(bin: Bin, layout: Layout): RotationResul
       case 'blocked_zone':
         message = 'Cannot rotate: space is blocked by a bin below';
         break;
+      case 'outside_drawer':
+        message = 'Cannot rotate: bin would leave the drawer shape';
+        break;
     }
     return { valid: false, message };
   }

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -99,5 +99,8 @@ export function getPlacementErrorMessage(
   if (reason === 'invalid_layer') {
     return t('grid.invalidLayer');
   }
+  if (reason === 'outside_drawer') {
+    return t('grid.outsideDrawerShape');
+  }
   return t('grid.outOfBounds');
 }

--- a/src/shared/utils/validationImport.ts
+++ b/src/shared/utils/validationImport.ts
@@ -40,6 +40,7 @@ export const PLACEMENT_REASON_MESSAGE: Record<ValidationReason, string> = {
   invalid_layer: 'references invalid layer',
   blocked_zone: 'overlaps with blocked zone from upper layer',
   collision: 'collides with another bin',
+  outside_drawer: 'is outside the drawer shape',
 };
 
 export type ValidationSuccess = { valid: true; errors: readonly []; layout: Layout };

--- a/src/shared/utils/validationPlacement.test.ts
+++ b/src/shared/utils/validationPlacement.test.ts
@@ -157,3 +157,59 @@ describe('canPlaceBin', () => {
     expect(result.blockingInfo?.layerName).toBe('Layer 1');
   });
 });
+
+describe('canPlaceBin with a drawer outline', () => {
+  const U = 42;
+  // 10×8 drawer with the right 4×4 corner (top) notched out.
+  const L_OUTLINE = {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: 10 * U, y: 0 },
+      { x: 10 * U, y: 4 * U },
+      { x: 6 * U, y: 4 * U },
+      { x: 6 * U, y: 8 * U },
+      { x: 0, y: 8 * U },
+    ],
+  };
+  function makeShapedLayout(): Layout {
+    const layout = makeSingleLayerLayout();
+    layout.drawer.outline = L_OUTLINE;
+    return layout;
+  }
+
+  it('rejects placements in the notch with outside_drawer', () => {
+    const result = canPlaceBin(
+      { x: 7, y: 5, width: 1, depth: 1, height: 3 },
+      'layer1',
+      makeShapedLayout()
+    );
+    expect(result).toMatchObject({ valid: false, reason: 'outside_drawer' });
+  });
+
+  it('rejects footprints straddling the outline boundary', () => {
+    const result = canPlaceBin(
+      { x: 5, y: 5, width: 2, depth: 1, height: 3 },
+      'layer1',
+      makeShapedLayout()
+    );
+    expect(result).toMatchObject({ valid: false, reason: 'outside_drawer' });
+  });
+
+  it('accepts boundary-flush placements inside the shape', () => {
+    const result = canPlaceBin(
+      { x: 4, y: 4, width: 2, depth: 4, height: 3 },
+      'layer1',
+      makeShapedLayout()
+    );
+    expect(result).toMatchObject({ valid: true });
+  });
+
+  it('bounds checks still take precedence over the outline', () => {
+    const result = canPlaceBin(
+      { x: 9, y: 0, width: 3, depth: 1, height: 3 },
+      'layer1',
+      makeShapedLayout()
+    );
+    expect(result).toMatchObject({ valid: false, reason: 'exceeds_width' });
+  });
+});

--- a/src/shared/utils/validationPlacement.ts
+++ b/src/shared/utils/validationPlacement.ts
@@ -20,6 +20,7 @@ import type {
   BinId,
   LayerId,
 } from '@/core/types';
+import { isFootprintInsideOutline } from './drawerOutlineGeometry';
 import { binId as toBinId, categoryId as toCategoryId } from '@/core/types';
 import { STAGING_ID } from '@/core/constants';
 import { isOk } from '@/core/result';
@@ -53,6 +54,16 @@ export function canPlaceBin(
   }
   if (rect.y + rect.depth > drawer.depth) {
     return { valid: false, reason: 'exceeds_depth' };
+  }
+
+  // Non-rectangular drawers: the footprint must sit fully inside the outline
+  // (boundary-flush placements count as inside). One check here covers every
+  // interaction — draw, drag, resize, staging drop, paint, fill, import.
+  if (
+    drawer.outline !== undefined &&
+    !isFootprintInsideOutline(rect, drawer.outline, layout.gridUnitMm)
+  ) {
+    return { valid: false, reason: 'outside_drawer' };
   }
 
   const layer = layers.find((l) => l.id === layerId);


### PR DESCRIPTION
## Summary

Fifth PR toward #2528: the Layout tab now respects a non-rectangular drawer. A ⊓-shaped drawer's notch is hatched, bins can't be drawn/dragged/resized/painted/filled into it, and the shared invariant holds: **a hatched cell is exactly a cell placement would reject** — both derive from the same `classifyRect` predicate.

## Changes

- **`canPlaceBin`** gains an `'outside_drawer'` rejection when the footprint isn't fully inside `drawer.outline` (boundary-flush placements count as inside, so bins sit flush against shaped walls). One check covers every interaction, since draw/drag/resize/staging-drop/paint/fill/import all route through this validator. `ValidationReason` and `ValidationFailureReason` unions extended, with rotation messages, import-reason suffixes, and `getPlacementErrorMessage` covering the new case.
- **Fill tools** (`fillAllWithSize`/`fillGaps`) skip outside cells for free: `createOccupiedCellSet` (now exported) unions the memoized outside-cell set from PR #2530's shared module.
- **`DrawerOutlineOverlay`**: one SVG with an even-odd path (grid rect + flattened outline subpath) hatches the outside region and strokes the boundary — a 50×50 grid costs the same as 2×2, no per-cell elements. `pointer-events: none` (placement truth lives in the validator), theme-aware via `currentColor`, mounted in `GridCanvas`. Interior unit boundaries sit mid-gap, so the half-gap visual offset at 2–4px gaps is imperceptible and irrelevant to placement.
- i18n: `grid.outsideDrawerShape` + `grid.drawerOutlineAria` in all 10 locales.

Nothing user-visible changes until an outline exists — the authoring UI (next PRs, behind a labs flag) is the only writer.

## Testing

- `canPlaceBin`: notch rejection, boundary-straddling rejection, boundary-flush acceptance, bounds-check precedence.
- Overlay: renders nothing for rectangles; hatch pattern + even-odd fill + stroked boundary for shapes.
- Full sweep of placement/fill/rotation/import/validation suites green (127); `pnpm run quality` clean; i18n checks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Layout now supports non-rectangular drawer outlines: the outside area is hatched and all bin actions must stay inside the shape. This advances #2528 and has no effect until a drawer outline is defined.

- **New Features**
  - Placement: `canPlaceBin` returns `outside_drawer` when a footprint isn’t fully inside `drawer.outline` (boundary‑flush is allowed). This gates draw, drag, resize, staging drop, paint, fill, import, and rotate.
  - Fill tools: `createOccupiedCellSet` marks outside cells so `fillAllWithSize` and `fillGaps` skip them.
  - UI: `DrawerOutlineOverlay` hatches the outside region and strokes the boundary with a single even‑odd SVG; mounted in `GridCanvas` with `pointer-events: none` and an ARIA label.
  - Messaging/i18n/tests: Added `grid.outsideDrawerShape` and `grid.drawerOutlineAria` in all locales; rotation/import messages handle `outside_drawer`; tests cover placement and the overlay.

- **Bug Fixes**
  - Overlay: use a per-instance hatch pattern ID to avoid collisions when multiple overlays are rendered.
  - Fill: tighten `createOccupiedCellSet`’s `step` type to `0.5 | 1` for consistent half-grid handling.

<sup>Written for commit 13aa7d79ab3326f2c927c75d17bf61c298dfe29f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

