### PR TITLE
feat(baseplate): hide shape-subsumed controls and explain shaped drawers in the panel

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -944,6 +944,21 @@ describe('BaseplatePanel', () => {
 });
 
 describe('shaped drawer (outline present)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLayoutState = {
+      layout: {
+        drawer: { width: 4, depth: 6 },
+        gridUnitMm: 42,
+        printBedSize: 256,
+        baseplateParams: { ...DEFAULT_BASEPLATE_PARAMS },
+      },
+      setBaseplateParams: mockSetBaseplateParams,
+      setPrintBedSize: mockSetPrintBedSize,
+    };
+    mockExportFormat = 'stl';
+  });
+
   const U = 42;
   const L_OUTLINE = {
     vertices: [
@@ -982,5 +997,18 @@ describe('shaped drawer (outline present)', () => {
     } as never;
     render(<BaseplatePanel />);
     expect(screen.queryByText('baseplate.shapedDrawerNotice')).toBeNull();
+  });
+
+  it('shows the shaped notice for STEP even with stacking stored on', () => {
+    // STEP clears stackPrint before buildFullParams, so the exported solid IS
+    // shaped — the panel must follow the format-aware stackEnabled signal.
+    mockLayoutState.layout.drawer = { width: 4, depth: 6, outline: L_OUTLINE } as never;
+    mockLayoutState.layout.baseplateParams = {
+      ...DEFAULT_BASEPLATE_PARAMS,
+      stackPrint: { enabled: true, gapMm: 0.2 },
+    } as never;
+    mockExportFormat = 'step';
+    render(<BaseplatePanel />);
+    expect(screen.getByText('baseplate.shapedDrawerNotice')).toBeInTheDocument();
   });
 });

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -942,3 +942,45 @@ describe('BaseplatePanel', () => {
     });
   });
 });
+
+describe('shaped drawer (outline present)', () => {
+  const U = 42;
+  const L_OUTLINE = {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: 4 * U, y: 0 },
+      { x: 4 * U, y: 3 * U },
+      { x: 2 * U, y: 3 * U },
+      { x: 2 * U, y: 6 * U },
+      { x: 0, y: 6 * U },
+    ],
+  };
+
+  it('hides padding controls and shows the shaped notice', () => {
+    mockLayoutState.layout.drawer = { width: 4, depth: 6, outline: L_OUTLINE } as never;
+    render(<BaseplatePanel />);
+    expect(screen.getByText('baseplate.shapedDrawerNotice')).toBeInTheDocument();
+    expect(screen.queryByText('baseplate.padding')).toBeNull();
+  });
+
+  it('keeps padding controls for unsynced (custom-size) plates', () => {
+    mockLayoutState.layout.drawer = { width: 4, depth: 6, outline: L_OUTLINE } as never;
+    mockLayoutState.layout.baseplateParams = {
+      ...DEFAULT_BASEPLATE_PARAMS,
+      syncWithLayout: false,
+    };
+    render(<BaseplatePanel />);
+    expect(screen.queryByText('baseplate.shapedDrawerNotice')).toBeNull();
+    expect(screen.getByText('baseplate.padding')).toBeInTheDocument();
+  });
+
+  it('keeps padding controls when stack printing wins over the shape', () => {
+    mockLayoutState.layout.drawer = { width: 4, depth: 6, outline: L_OUTLINE } as never;
+    mockLayoutState.layout.baseplateParams = {
+      ...DEFAULT_BASEPLATE_PARAMS,
+      stackPrint: { enabled: true, gapMm: 0.2 },
+    } as never;
+    render(<BaseplatePanel />);
+    expect(screen.queryByText('baseplate.shapedDrawerNotice')).toBeNull();
+  });
+});

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -92,6 +92,7 @@ export function BaseplatePanel() {
   const {
     drawerWidth,
     drawerDepth,
+    drawerOutline,
     drawerFractionalEdgeX,
     drawerFractionalEdgeY,
     gridUnitMm,
@@ -102,6 +103,7 @@ export function BaseplatePanel() {
     useShallow((state) => ({
       drawerWidth: state.layout.drawer.width,
       drawerDepth: state.layout.drawer.depth,
+      drawerOutline: state.layout.drawer.outline,
       drawerFractionalEdgeX: state.layout.drawer.fractionalEdgeX ?? 'end',
       drawerFractionalEdgeY: state.layout.drawer.fractionalEdgeY ?? 'end',
       gridUnitMm: state.layout.gridUnitMm,
@@ -254,6 +256,11 @@ export function BaseplatePanel() {
   // Mutually exclusive with stack-print (stacking wins) — keyed on the stored
   // flag, not the export-format-aware `stackEnabled` above.
   const stackPrintOn = baseplateParams.stackPrint?.enabled === true;
+  // Mirrors buildFullParams's outline gate: the drawer shape subsumes padding,
+  // corner rounding, and detached margins (margins are emergent from
+  // outline ∩ grid), so those controls hide. Stacking wins over the shape
+  // (uniform rectangular tiles), so the stack section stays functional.
+  const shapedOn = drawerOutline !== undefined && synced && !stackPrintOn;
   const canDetach =
     baseplateParams.paddingLeft >= MARGIN_MIN_DETACH_MM ||
     baseplateParams.paddingRight >= MARGIN_MIN_DETACH_MM ||
@@ -413,139 +420,149 @@ export function BaseplatePanel() {
               )}
             </div>
 
+            {/* Shaped drawer: padding/rounding/margins are subsumed by the
+                outline — point at the Layout tab instead of dead controls. */}
+            {shapedOn && (
+              <p className="border-t border-stroke-subtle pt-3 text-[11px] leading-relaxed text-content-tertiary">
+                {t('baseplate.shapedDrawerNotice')}
+              </p>
+            )}
+
             {/* Padding — spatial schematic */}
-            <div className="space-y-2 border-t border-stroke-subtle pt-3">
-              <div className="text-[11px] font-medium uppercase tracking-wide text-content-tertiary">
-                {t('baseplate.padding')}
-              </div>
-              <PaddingSchematic
-                baseplateParams={baseplateParams}
-                updateParam={updateParam}
-                updateParams={updateParams}
-              />
-              {hasPadding && (
-                <div className="border-t border-stroke-subtle pt-3">
-                  <FeatureToggle
-                    label={t('baseplate.overTile')}
-                    checked={fillOn}
-                    onChange={() => setMarginFillMode(fillOn ? 'solid' : 'tile')}
-                    disabledReason={
-                      !fillOn && !overTileStatus.canOverTile
-                        ? t('baseplate.overTileTooSmall')
-                        : undefined
-                    }
-                    primaryControls={
-                      <div className="space-y-1.5">
-                        {overTileStatus.canOverTile ? (
-                          <>
+            {!shapedOn && (
+              <div className="space-y-2 border-t border-stroke-subtle pt-3">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-content-tertiary">
+                  {t('baseplate.padding')}
+                </div>
+                <PaddingSchematic
+                  baseplateParams={baseplateParams}
+                  updateParam={updateParam}
+                  updateParams={updateParams}
+                />
+                {hasPadding && (
+                  <div className="border-t border-stroke-subtle pt-3">
+                    <FeatureToggle
+                      label={t('baseplate.overTile')}
+                      checked={fillOn}
+                      onChange={() => setMarginFillMode(fillOn ? 'solid' : 'tile')}
+                      disabledReason={
+                        !fillOn && !overTileStatus.canOverTile
+                          ? t('baseplate.overTileTooSmall')
+                          : undefined
+                      }
+                      primaryControls={
+                        <div className="space-y-1.5">
+                          {overTileStatus.canOverTile ? (
+                            <>
+                              <CheckboxRow
+                                label={t('baseplate.preferHalfGrid')}
+                                checked={halfGridOn}
+                                onChange={(checked) =>
+                                  setMarginFillMode(checked ? 'halfGrid' : 'tile')
+                                }
+                                indent
+                              />
+                              {halfGridOn && (
+                                <div className="ml-4 flex items-center justify-between gap-2 border-l border-stroke-subtle pl-3">
+                                  <span className="text-xs text-content-secondary">
+                                    {t('baseplate.leftoverLabel')}
+                                  </span>
+                                  <SegmentedControl
+                                    aria-label={t('baseplate.leftoverLabel')}
+                                    size="sm"
+                                    options={[
+                                      { value: 'grid', label: t('baseplate.leftoverGrid') },
+                                      { value: 'solid', label: t('baseplate.leftoverSolid') },
+                                    ]}
+                                    value={leftoverMode}
+                                    onChange={setLeftoverMode}
+                                  />
+                                </div>
+                              )}
+                              <div className="space-y-1 text-[11px] leading-relaxed">
+                                <p className="text-content-tertiary">
+                                  {t(
+                                    halfGridOn
+                                      ? leftoverMode === 'solid'
+                                        ? 'baseplate.halfGridHintSolid'
+                                        : 'baseplate.halfGridHint'
+                                      : 'baseplate.overTileHint'
+                                  )}
+                                </p>
+                                {overTileStatus.tiled.length > 0 && (
+                                  <p className="text-content-secondary">
+                                    {t('baseplate.overTileFills', {
+                                      sides: overTileStatus.tiled
+                                        .map((e) => t(e.labelKey))
+                                        .join(', '),
+                                    })}
+                                  </p>
+                                )}
+                                {overTileStatus.tooSmall.length > 0 && (
+                                  <p className="text-content-tertiary">
+                                    {t('baseplate.overTileKeptSolid', {
+                                      sides: overTileStatus.tooSmall
+                                        .map((e) => t(e.labelKey))
+                                        .join(', '),
+                                    })}
+                                  </p>
+                                )}
+                              </div>
+                            </>
+                          ) : (
+                            // Fill is on but no edge can fit a tile right now — keep the
+                            // toggle enabled (so it can be turned off) and explain why.
+                            <p className="text-[11px] leading-relaxed text-content-tertiary">
+                              {t('baseplate.overTileTooSmall')}
+                            </p>
+                          )}
+                        </div>
+                      }
+                    />
+                  </div>
+                )}
+                {hasPadding && (
+                  <div className="border-t border-stroke-subtle pt-3">
+                    <FeatureToggle
+                      label={t('baseplate.detachMargins')}
+                      checked={detachStored}
+                      onChange={() => updateParam('detachMargins', !detachStored)}
+                      disabledReason={
+                        stackPrintOn
+                          ? t('baseplate.detachMarginsStackConflict')
+                          : !detachStored && !canDetach
+                            ? t('baseplate.detachMarginsTooSmall')
+                            : undefined
+                      }
+                      primaryControls={
+                        // On but nothing meets the threshold → no rails are emitted,
+                        // so say so rather than imply they will.
+                        !canDetach ? (
+                          <p className="text-[11px] leading-relaxed text-content-tertiary">
+                            {t('baseplate.detachMarginsTooSmall')}
+                          </p>
+                        ) : (
+                          <div className="space-y-1">
                             <CheckboxRow
-                              label={t('baseplate.preferHalfGrid')}
-                              checked={halfGridOn}
-                              onChange={(checked) =>
-                                setMarginFillMode(checked ? 'halfGrid' : 'tile')
-                              }
+                              label={t('baseplate.detachMarginConnector')}
+                              checked={marginConnectorStored && marginConnectorStyleOk}
+                              onChange={(checked) => updateParam('detachMarginConnector', checked)}
+                              disabled={!marginConnectorStyleOk}
                               indent
                             />
-                            {halfGridOn && (
-                              <div className="ml-4 flex items-center justify-between gap-2 border-l border-stroke-subtle pl-3">
-                                <span className="text-xs text-content-secondary">
-                                  {t('baseplate.leftoverLabel')}
-                                </span>
-                                <SegmentedControl
-                                  aria-label={t('baseplate.leftoverLabel')}
-                                  size="sm"
-                                  options={[
-                                    { value: 'grid', label: t('baseplate.leftoverGrid') },
-                                    { value: 'solid', label: t('baseplate.leftoverSolid') },
-                                  ]}
-                                  value={leftoverMode}
-                                  onChange={setLeftoverMode}
-                                />
-                              </div>
-                            )}
-                            <div className="space-y-1 text-[11px] leading-relaxed">
-                              <p className="text-content-tertiary">
-                                {t(
-                                  halfGridOn
-                                    ? leftoverMode === 'solid'
-                                      ? 'baseplate.halfGridHintSolid'
-                                      : 'baseplate.halfGridHint'
-                                    : 'baseplate.overTileHint'
-                                )}
-                              </p>
-                              {overTileStatus.tiled.length > 0 && (
-                                <p className="text-content-secondary">
-                                  {t('baseplate.overTileFills', {
-                                    sides: overTileStatus.tiled
-                                      .map((e) => t(e.labelKey))
-                                      .join(', '),
-                                  })}
-                                </p>
-                              )}
-                              {overTileStatus.tooSmall.length > 0 && (
-                                <p className="text-content-tertiary">
-                                  {t('baseplate.overTileKeptSolid', {
-                                    sides: overTileStatus.tooSmall
-                                      .map((e) => t(e.labelKey))
-                                      .join(', '),
-                                  })}
-                                </p>
-                              )}
-                            </div>
-                          </>
-                        ) : (
-                          // Fill is on but no edge can fit a tile right now — keep the
-                          // toggle enabled (so it can be turned off) and explain why.
-                          <p className="text-[11px] leading-relaxed text-content-tertiary">
-                            {t('baseplate.overTileTooSmall')}
-                          </p>
-                        )}
-                      </div>
-                    }
-                  />
-                </div>
-              )}
-              {hasPadding && (
-                <div className="border-t border-stroke-subtle pt-3">
-                  <FeatureToggle
-                    label={t('baseplate.detachMargins')}
-                    checked={detachStored}
-                    onChange={() => updateParam('detachMargins', !detachStored)}
-                    disabledReason={
-                      stackPrintOn
-                        ? t('baseplate.detachMarginsStackConflict')
-                        : !detachStored && !canDetach
-                          ? t('baseplate.detachMarginsTooSmall')
-                          : undefined
-                    }
-                    primaryControls={
-                      // On but nothing meets the threshold → no rails are emitted,
-                      // so say so rather than imply they will.
-                      !canDetach ? (
-                        <p className="text-[11px] leading-relaxed text-content-tertiary">
-                          {t('baseplate.detachMarginsTooSmall')}
-                        </p>
-                      ) : (
-                        <div className="space-y-1">
-                          <CheckboxRow
-                            label={t('baseplate.detachMarginConnector')}
-                            checked={marginConnectorStored && marginConnectorStyleOk}
-                            onChange={(checked) => updateParam('detachMarginConnector', checked)}
-                            disabled={!marginConnectorStyleOk}
-                            indent
-                          />
-                          <p className="text-[11px] leading-relaxed text-content-tertiary pl-6">
-                            {marginConnectorStyleOk
-                              ? t('baseplate.detachMarginConnectorHint')
-                              : t('baseplate.detachMarginConnectorStyle')}
-                          </p>
-                        </div>
-                      )
-                    }
-                  />
-                </div>
-              )}
-            </div>
+                            <p className="text-[11px] leading-relaxed text-content-tertiary pl-6">
+                              {marginConnectorStyleOk
+                                ? t('baseplate.detachMarginConnectorHint')
+                                : t('baseplate.detachMarginConnectorStyle')}
+                            </p>
+                          </div>
+                        )
+                      }
+                    />
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </StickyGroupHeader>
 
@@ -703,31 +720,33 @@ export function BaseplatePanel() {
                       }
                     />
                   </div>
-                  <div className="border-t border-stroke-subtle pt-3">
-                    <CornerRadiusControl
-                      cornerRadius={baseplateParams.cornerRadius}
-                      cornerRadii={baseplateParams.cornerRadii}
-                      maxRadius={
-                        gridUnitMm / 2 +
-                        Math.min(
-                          Math.min(baseplateParams.paddingLeft, baseplateParams.paddingRight),
-                          Math.min(baseplateParams.paddingFront, baseplateParams.paddingBack)
-                        )
-                      }
-                      onUniformChange={(r) => {
-                        updateParam('cornerRadius', mm(r));
-                        updateParam('cornerRadii', undefined);
-                      }}
-                      onPerCornerChange={(radii) => {
-                        updateParam('cornerRadii', {
-                          tl: mm(radii.tl),
-                          tr: mm(radii.tr),
-                          bl: mm(radii.bl),
-                          br: mm(radii.br),
-                        });
-                      }}
-                    />
-                  </div>
+                  {!shapedOn && (
+                    <div className="border-t border-stroke-subtle pt-3">
+                      <CornerRadiusControl
+                        cornerRadius={baseplateParams.cornerRadius}
+                        cornerRadii={baseplateParams.cornerRadii}
+                        maxRadius={
+                          gridUnitMm / 2 +
+                          Math.min(
+                            Math.min(baseplateParams.paddingLeft, baseplateParams.paddingRight),
+                            Math.min(baseplateParams.paddingFront, baseplateParams.paddingBack)
+                          )
+                        }
+                        onUniformChange={(r) => {
+                          updateParam('cornerRadius', mm(r));
+                          updateParam('cornerRadii', undefined);
+                        }}
+                        onPerCornerChange={(radii) => {
+                          updateParam('cornerRadii', {
+                            tl: mm(radii.tl),
+                            tr: mm(radii.tr),
+                            bl: mm(radii.bl),
+                            br: mm(radii.br),
+                          });
+                        }}
+                      />
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -259,8 +259,11 @@ export function BaseplatePanel() {
   // Mirrors buildFullParams's outline gate: the drawer shape subsumes padding,
   // corner rounding, and detached margins (margins are emergent from
   // outline ∩ grid), so those controls hide. Stacking wins over the shape
-  // (uniform rectangular tiles), so the stack section stays functional.
-  const shapedOn = drawerOutline !== undefined && synced && !stackPrintOn;
+  // (uniform rectangular tiles), so the stack section stays functional — but
+  // via the export-format-aware `stackEnabled`: STEP clears stackPrint before
+  // buildFullParams, so a STEP export of a stacked shaped drawer IS shaped and
+  // the panel must say so.
+  const shapedOn = drawerOutline !== undefined && synced && !stackEnabled;
   const canDetach =
     baseplateParams.paddingLeft >= MARGIN_MIN_DETACH_MM ||
     baseplateParams.paddingRight >= MARGIN_MIN_DETACH_MM ||

--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
@@ -81,3 +81,39 @@ describe('DrawerMargin', () => {
     expect(band.style.right).toBe('-17px');
   });
 });
+
+describe('shaped drawer', () => {
+  it('renders nothing when the drawer has an outline (padding is stripped)', () => {
+    const layout = createDefaultLayout();
+    useLayoutStore.setState({
+      layout: {
+        ...layout,
+        gridUnitMm: 42,
+        drawer: {
+          ...layout.drawer,
+          outline: {
+            vertices: [
+              { x: 0, y: 0 },
+              { x: 168, y: 0 },
+              { x: 168, y: 84 },
+              { x: 84, y: 84 },
+              { x: 84, y: 168 },
+              { x: 0, y: 168 },
+            ],
+          },
+        },
+        baseplateParams: {
+          magnetHoles: false,
+          magnetDiameter: 6,
+          magnetDepth: 2,
+          paddingLeft: 10,
+          paddingRight: 10,
+          paddingFront: 10,
+          paddingBack: 10,
+        },
+      } as never,
+    });
+    const { container } = render(<DrawerMargin cellSize={40} gap={2} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
@@ -83,6 +83,10 @@ describe('DrawerMargin', () => {
 });
 
 describe('shaped drawer', () => {
+  beforeEach(() => {
+    resetAllStores();
+  });
+
   it('renders nothing when the drawer has an outline (padding is stripped)', () => {
     const layout = createDefaultLayout();
     useLayoutStore.setState({

--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.tsx
@@ -24,23 +24,31 @@ interface DrawerMarginProps {
  */
 export function DrawerMargin({ cellSize, gap }: DrawerMarginProps) {
   const t = useTranslation();
-  const { gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack } = useLayoutStore(
-    useShallow((s) => ({
-      gridUnitMm: s.layout.gridUnitMm,
-      paddingLeft: s.layout.baseplateParams?.paddingLeft ?? 0,
-      paddingRight: s.layout.baseplateParams?.paddingRight ?? 0,
-      paddingFront: s.layout.baseplateParams?.paddingFront ?? 0,
-      paddingBack: s.layout.baseplateParams?.paddingBack ?? 0,
-    }))
-  );
+  const { gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack, shaped } =
+    useLayoutStore(
+      useShallow((s) => ({
+        gridUnitMm: s.layout.gridUnitMm,
+        paddingLeft: s.layout.baseplateParams?.paddingLeft ?? 0,
+        paddingRight: s.layout.baseplateParams?.paddingRight ?? 0,
+        paddingFront: s.layout.baseplateParams?.paddingFront ?? 0,
+        paddingBack: s.layout.baseplateParams?.paddingBack ?? 0,
+        // Shaped drawers strip padding functionally (buildFullParams), so the
+        // margin band would show space the plate doesn't actually have.
+        shaped:
+          s.layout.drawer.outline !== undefined &&
+          s.layout.baseplateParams?.syncWithLayout !== false &&
+          s.layout.baseplateParams?.stackPrint?.enabled !== true,
+      }))
+    );
 
   const left = Math.max(0, paddingLeft);
   const right = Math.max(0, paddingRight);
   const front = Math.max(0, paddingFront);
   const back = Math.max(0, paddingBack);
 
-  // Nothing to show without a configured margin.
-  if (left + right + front + back <= 0) return null;
+  // Nothing to show without a configured margin — or when the drawer shape
+  // subsumes it (padding is functionally stripped for shaped plates).
+  if (shaped || left + right + front + back <= 0) return null;
 
   // One grid unit spans `cellSize + gap` px (holds in half-grid mode too — the
   // per-unit pitch is invariant). Padding is a fraction of a unit in mm.

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "Der Verbinder erfordert den Nahtstil Schwalbenschwanz oder Puzzle.",
   "baseplate.overTileTooSmall": "Die Polsterung ist an jeder Kante zu klein für eine Rasterkachel.",
   "baseplate.padding": "Polsterung",
+  "baseplate.shapedDrawerNotice": "Diese Schublade hat eine individuelle Form. Rand, Eckenrundung und abnehmbare Ränder ergeben sich aus der Form — bearbeite sie im Layout-Tab.",
   "baseplate.paddingAnchor.bc": "Bins vorne mittig verankern",
   "baseplate.paddingAnchor.bl": "Bins vorne-links verankern",
   "baseplate.paddingAnchor.br": "Bins vorne-rechts verankern",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2357,6 +2357,8 @@ const en: Record<string, string> = {
   'baseplate.sectionDimensions': 'Dimensions',
   'baseplate.syncWithLayout': 'Sync with layout',
   'baseplate.padding': 'Padding',
+  'baseplate.shapedDrawerNotice':
+    'This drawer has a custom shape. Padding, corner rounding, and detached margins are set by the shape — edit it in the Layout tab.',
   'baseplate.overTile': 'Fill padding with grid tiles',
   'baseplate.preferHalfGrid': 'Prefer half-grid cells',
   'baseplate.overTileHint':

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "El conector requiere el estilo de unión Cola de milano o Puzzle.",
   "baseplate.overTileTooSmall": "El margen es demasiado pequeño en todos los bordes para una celda de rejilla.",
   "baseplate.padding": "Relleno",
+  "baseplate.shapedDrawerNotice": "Este cajón tiene una forma personalizada. El relleno, el redondeo de esquinas y los márgenes desmontables los define la forma — edítala en la pestaña Diseño.",
   "baseplate.paddingAnchor.bc": "Anclar bins frente-centro",
   "baseplate.paddingAnchor.bl": "Anclar bins frente-izquierda",
   "baseplate.paddingAnchor.br": "Anclar bins frente-derecha",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "Le connecteur nécessite le style de jointure Queue d'aronde ou Puzzle.",
   "baseplate.overTileTooSmall": "La marge est trop petite sur chaque bord pour une tuile de grille.",
   "baseplate.padding": "Marge",
+  "baseplate.shapedDrawerNotice": "Ce tiroir a une forme personnalisée. La marge, l’arrondi des coins et les marges détachables sont définis par la forme — modifiez-la dans l’onglet Disposition.",
   "baseplate.paddingAnchor.bc": "Ancrer les bacs avant-centre",
   "baseplate.paddingAnchor.bl": "Ancrer les bacs avant-gauche",
   "baseplate.paddingAnchor.br": "Ancrer les bacs avant-droite",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "コネクタには継ぎ目スタイル「アリ継ぎ」または「パズル」が必要です。",
   "baseplate.overTileTooSmall": "すべての辺で余白が小さすぎて、グリッドタイルが入りません。",
   "baseplate.padding": "余白",
+  "baseplate.shapedDrawerNotice": "この引き出しはカスタム形状です。パディング、角の丸み、分離マージンは形状によって決まります。レイアウトタブで編集してください。",
   "baseplate.paddingAnchor.bc": "ビンを手前中央に配置",
   "baseplate.paddingAnchor.bl": "ビンを手前左に配置",
   "baseplate.paddingAnchor.br": "ビンを手前右に配置",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "Koblingen krever sømstilen Svalehale eller Puslespill.",
   "baseplate.overTileTooSmall": "Polstringen er for liten på hver kant for en ruteflis.",
   "baseplate.padding": "Polstring",
+  "baseplate.shapedDrawerNotice": "Denne skuffen har en tilpasset form. Polstring, hjørneavrunding og avtakbare kanter bestemmes av formen — rediger den i Oppsett-fanen.",
   "baseplate.paddingAnchor.bc": "Forankre bins foran-midten",
   "baseplate.paddingAnchor.bl": "Forankre bins foran-venstre",
   "baseplate.paddingAnchor.br": "Forankre bins foran-høyre",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "De verbinding vereist de naadstijl Zwaluwstaart of Puzzel.",
   "baseplate.overTileTooSmall": "De marge is op elke rand te klein voor een rastertegel.",
   "baseplate.padding": "Vulling",
+  "baseplate.shapedDrawerNotice": "Deze lade heeft een aangepaste vorm. Opvulling, hoekafronding en losse randen worden door de vorm bepaald — bewerk deze in het tabblad Indeling.",
   "baseplate.paddingAnchor.bc": "Bins voor-midden verankeren",
   "baseplate.paddingAnchor.bl": "Bins voor-links verankeren",
   "baseplate.paddingAnchor.br": "Bins voor-rechts verankeren",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "O conector requer o estilo de emenda Rabo de andorinha ou Quebra-cabeça.",
   "baseplate.overTileTooSmall": "A margem é pequena demais em todas as bordas para um ladrilho de grade.",
   "baseplate.padding": "Preenchimento",
+  "baseplate.shapedDrawerNotice": "Esta gaveta tem um formato personalizado. O preenchimento, o arredondamento de cantos e as margens destacáveis são definidos pelo formato — edite-o na aba Layout.",
   "baseplate.paddingAnchor.bc": "Ancorar bins frente-centro",
   "baseplate.paddingAnchor.bl": "Ancorar bins frente-esquerda",
   "baseplate.paddingAnchor.br": "Ancorar bins frente-direita",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "Kopplingen kräver fogstilen Laxstjärt eller Pussel.",
   "baseplate.overTileTooSmall": "Utfyllnaden är för liten på varje kant för en rutnätsplatta.",
   "baseplate.padding": "Utfyllnad",
+  "baseplate.shapedDrawerNotice": "Den här lådan har en anpassad form. Utfyllnad, hörnavrundning och avtagbara kanter bestäms av formen — redigera den på fliken Layout.",
   "baseplate.paddingAnchor.bc": "Förankra bins fram-mitten",
   "baseplate.paddingAnchor.bl": "Förankra bins fram-vänster",
   "baseplate.paddingAnchor.br": "Förankra bins fram-höger",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -120,6 +120,7 @@
   "baseplate.detachMarginConnectorStyle": "З'єднувач потребує стилю шва «Ластівчин хвіст» або «Пазл».",
   "baseplate.overTileTooSmall": "Відступ замалий на кожному краю для плитки сітки.",
   "baseplate.padding": "Відступи",
+  "baseplate.shapedDrawerNotice": "Ця шухляда має власну форму. Відступи, заокруглення кутів і знімні краї визначаються формою — редагуйте її на вкладці «Макет».",
   "baseplate.paddingAnchor.bc": "Прив'язати бункери до передньої центральної",
   "baseplate.paddingAnchor.bl": "Прив'язати бункери до передньої лівої",
   "baseplate.paddingAnchor.br": "Прив'язати бункери до передньої правої",


### PR DESCRIPTION
## Summary

Sixth PR toward #2528: the baseplate panel's read side for shaped drawers. When `drawer.outline` is set (and the plate syncs with the layout, and stack printing is off), padding, over-tile fill, detached margins, and corner rounding are functionally subsumed by the shape — this PR hides those controls and shows a notice pointing at the Layout tab, instead of leaving dead knobs whose stored values the generator ignores.

## Decisions encoded

- **`shapedOn` mirrors `buildFullParams`'s gate exactly** (`outline && synced && !stacking`), so the panel can never disagree with generation about which params are live.
- **Stack printing stays visible and functional**: stacking wins over the shape (it needs uniform rectangular tiles — established in #2532), so a shaped drawer with stacking enabled generates the rectangular plate, and the notice does not appear in that mode.
- **Unsynced (custom-size) plates ignore the outline entirely** — full controls remain.
- The grid editor's `DrawerMargin` band hides for shaped drawers: padding is stripped, so the band would visualize space the plate doesn't actually have.
- Camera/dimension-overlay framing needs no change: shaped plates carry zero padding, so the outer bbox equals the grid extent and the outline is always inside it.

## Testing

- Panel: notice + hidden padding when shaped; controls retained for unsynced plates; controls retained when stacking wins (3 new cases, 78 total green).
- DrawerMargin: renders nothing for shaped drawers even with stored padding.
- `pnpm run quality` clean; i18n checks pass (notice in all 10 locales).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide shape-subsumed controls in the Baseplate panel when a drawer outline is present and synced (not stacking), and show a short notice that points to the Layout tab. Also hide the `DrawerMargin` band in the grid editor for shaped drawers to avoid showing space that won’t be printed.

- **New Features**
  - Gate matches generation and export format: controls hide when `outline && syncWithLayout && !stackEnabled` (STEP clears stacking, so exports are shaped).
  - Notice explains that padding, corner rounding, and detached margins come from the shape; edit in Layout.
  - Stack printing stays available and overrides the shape; unsynced (custom-size) plates keep full controls.
  - Grid editor: `DrawerMargin` renders nothing for shaped drawers.
  - Added localized notice in all supported locales.

<sup>Written for commit 075541cc468b285e8d4b36f0aa3df9f7f5851338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

