### PR TITLE
fix: strengthen magnet hole pads for wide nozzles

### DIFF
--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -517,7 +517,8 @@ export function buildBaseplateSolid(
       magnetDepth,
       cellOpts,
       params.lightweight,
-      floorCellFilter
+      floorCellFilter,
+      params.nozzleSizeMm
     );
     const floorFrame =
       floorCellFilter === undefined ? overTileFrame : overTileFrame.filter(floorCellFilter);
@@ -528,7 +529,8 @@ export function buildBaseplateSolid(
           magnetDiameter / 2,
           magnetDepth,
           gridUnitMm,
-          params.lightweight
+          params.lightweight,
+          params.nozzleSizeMm
         )
       );
     }

--- a/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
@@ -167,6 +167,17 @@ describe('planPartialCellFloorCuts (over-tile margin hollowing)', () => {
     expect(cross.padHalfX).toBeLessThan(13 - MAGNET_R - 1);
   });
 
+  it('keeps three nozzle-widths around magnet holes for a 0.8mm nozzle', async () => {
+    const { planPartialCellFloorCuts } = await import('./lightweightFloorCutter');
+    const cuts = planPartialCellFloorCuts(cell(1, 1), MAGNET_R, GRID, 0.8);
+    expect(cuts).toHaveLength(1);
+    expect(cuts[0]).toMatchObject({
+      kind: 'cross',
+      padHalfX: 13 - MAGNET_R - 2.4,
+      padHalfY: 13 - MAGNET_R - 2.4,
+    });
+  });
+
   it('a full 42mm tile keeps the standard cross pad (byte-identical)', async () => {
     const { planPartialCellFloorCuts } = await import('./lightweightFloorCutter');
     const cuts = planPartialCellFloorCuts(cell(1, 1), MAGNET_R, GRID);

--- a/src/features/generation/worker/generators/lightweightFloorCutter.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.ts
@@ -16,9 +16,7 @@ import type { ForEachCellOptions, CellInfo } from './cellDecomposition';
 import { resolvePitch, type GridUnitInput } from './gridPitch';
 import { magnetPositionsForCell } from './baseplateMagnets';
 import { sketch } from './meshUtils';
-
-/** Margin around each magnet hole center that defines the pad extent (mm). */
-const PAD_MARGIN = 1;
+import { magnetPadMarginForNozzle } from '@/shared/printSettings';
 
 /** Minimum arm width for the cross cutout (mm). Skip cell if arms too narrow. */
 const MIN_ARM_WIDTH = 2;
@@ -86,13 +84,15 @@ export function buildLightweightFloorCutters(
   magnetDepth: number,
   cellOpts: ForEachCellOptions & { gridUnitMm: GridUnitInput },
   lightweight?: boolean,
-  cellFilter?: (cell: CellInfo) => boolean
+  cellFilter?: (cell: CellInfo) => boolean,
+  nozzleSizeMm?: number
 ): Shape3D[] {
   if (lightweight === false) return [];
 
   const { x: unitX, y: unitY } = resolvePitch(cellOpts.gridUnitMm);
   const cutterZ = -SOCKET_HEIGHT + COPLANAR_MARGIN;
   const cutterDepth = MAGNET_FLOOR + magnetDepth + 2 * COPLANAR_MARGIN;
+  const padMargin = magnetPadMarginForNozzle(nozzleSizeMm);
 
   const cutters: Shape3D[] = [];
   const templates = new Map<string, Shape3D>();
@@ -146,8 +146,8 @@ export function buildLightweightFloorCutters(
         if (positions.length !== 4) return;
         const offX = Math.abs(positions[0][0] - cell.centerX);
         const offY = Math.abs(positions[0][1] - cell.centerY);
-        const padHalfX = offX - magnetRadius - PAD_MARGIN;
-        const padHalfY = offY - magnetRadius - PAD_MARGIN;
+        const padHalfX = offX - magnetRadius - padMargin;
+        const padHalfY = offY - magnetRadius - padMargin;
         if (padHalfX < MIN_ARM_WIDTH || padHalfY < MIN_ARM_WIDTH) return;
         if (hw - padHalfX < MIN_ARM_WIDTH || hd - padHalfY < MIN_ARM_WIDTH) return;
 
@@ -222,10 +222,12 @@ export type PartialFloorCut =
 export function planPartialCellFloorCuts(
   cell: CellInfo,
   magnetRadius: number,
-  gridUnitMm: GridUnitInput
+  gridUnitMm: GridUnitInput,
+  nozzleSizeMm?: number
 ): PartialFloorCut[] {
   const { x: unitX, y: unitY } = resolvePitch(gridUnitMm);
   const positions = magnetPositionsForCell(cell, magnetRadius, unitX, unitY);
+  const padMargin = magnetPadMarginForNozzle(nozzleSizeMm);
   if (positions.length === 0) return []; // too small for a magnet — leave solid
 
   const halfW = (cell.widthUnits * unitX) / 2;
@@ -242,8 +244,8 @@ export function planPartialCellFloorCuts(
   if (positions.length === 4) {
     const offX = Math.abs(positions[0][0] - cell.centerX);
     const offY = Math.abs(positions[0][1] - cell.centerY);
-    const padHalfX = offX - magnetRadius - PAD_MARGIN;
-    const padHalfY = offY - magnetRadius - PAD_MARGIN;
+    const padHalfX = offX - magnetRadius - padMargin;
+    const padHalfY = offY - magnetRadius - padMargin;
     if (
       padHalfX < MIN_ARM_WIDTH ||
       padHalfY < MIN_ARM_WIDTH ||
@@ -257,7 +259,7 @@ export function planPartialCellFloorCuts(
     ];
   }
 
-  const keepHalf = magnetRadius + PAD_MARGIN; // material kept around each magnet
+  const keepHalf = magnetRadius + padMargin; // material kept around each magnet
 
   // Lone centered magnet (small corner tile, e.g. 25×13): no spread to bridge, so
   // hollow the roomier axis's two sides while keeping a pad that spans the tighter
@@ -389,7 +391,8 @@ export function buildPartialCellFloorCutters(
   magnetRadius: number,
   magnetDepth: number,
   gridUnitMm: GridUnitInput,
-  lightweight?: boolean
+  lightweight?: boolean,
+  nozzleSizeMm?: number
 ): Shape3D[] {
   if (lightweight === false) return [];
 
@@ -399,7 +402,7 @@ export function buildPartialCellFloorCutters(
   const cutters: Shape3D[] = [];
   try {
     for (const cell of cells) {
-      for (const cut of planPartialCellFloorCuts(cell, magnetRadius, gridUnitMm)) {
+      for (const cut of planPartialCellFloorCuts(cell, magnetRadius, gridUnitMm, nozzleSizeMm)) {
         const profile =
           cut.kind === 'cross'
             ? crossProfile(cut.hw, cut.hd, cut.padHalfX, cut.padHalfY)

--- a/src/shared/printSettings/gridfinityGeometry.test.ts
+++ b/src/shared/printSettings/gridfinityGeometry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   GRIDFINITY_SPEC,
   NOZZLE_WALL_COUNTS,
+  magnetPadMarginForNozzle,
   wallThicknessForNozzle,
 } from '@/shared/printSettings/gridfinityGeometry';
 
@@ -75,6 +76,21 @@ describe('gridfinityGeometry', () => {
       expect(NOZZLE_WALL_COUNTS[0.6]).toBeDefined();
       expect(NOZZLE_WALL_COUNTS[0.8]).toBeDefined();
       expect(NOZZLE_WALL_COUNTS[1.0]).toBeDefined();
+    });
+  });
+
+  describe('magnetPadMarginForNozzle', () => {
+    it.each([
+      [0.4, 1],
+      [0.6, 1.8],
+      [0.8, 2.4],
+      [1.0, 2.0],
+    ])('for a %smm nozzle, returns %smm margin', (nozzle, margin) => {
+      expect(magnetPadMarginForNozzle(nozzle)).toBe(margin);
+    });
+
+    it('keeps omitted nozzle settings on the legacy margin', () => {
+      expect(magnetPadMarginForNozzle()).toBe(1);
     });
   });
 });

--- a/src/shared/printSettings/gridfinityGeometry.ts
+++ b/src/shared/printSettings/gridfinityGeometry.ts
@@ -85,6 +85,13 @@ export const NOZZLE_WALL_COUNTS: Partial<Record<number, number>> = {
   1.0: 1,
 };
 
+/** Minimum solid pad margin around a magnet hole, keyed by standard nozzle. */
+const MAGNET_PAD_MARGINS: Partial<Record<number, number>> = {
+  0.6: 1.8,
+  0.8: 2.4,
+  1.0: 2.0,
+};
+
 /**
  * Compute wall thickness for a given nozzle size.
  *
@@ -100,4 +107,19 @@ export function wallThicknessForNozzle(nozzleSizeMm: number): number {
     return nozzleSizeMm * count;
   }
   return GRIDFINITY_SPEC.WALL_THICKNESS;
+}
+
+/**
+ * Minimum solid pad margin around a magnet hole.
+ *
+ * Values are tuned to retain a printable bridge around the hole while keeping
+ * the legacy 0.4mm geometry unchanged. Unknown nozzle sizes use the resolved
+ * wall thickness plus one bead as a conservative fallback.
+ */
+export function magnetPadMarginForNozzle(nozzleSizeMm?: number): number {
+  if (nozzleSizeMm === undefined || nozzleSizeMm <= 0.4) return 1;
+  return (
+    MAGNET_PAD_MARGINS[nozzleSizeMm] ??
+    Math.max(1, wallThicknessForNozzle(nozzleSizeMm) + nozzleSizeMm)
+  );
 }

--- a/src/shared/printSettings/index.ts
+++ b/src/shared/printSettings/index.ts
@@ -110,7 +110,11 @@ export function scalePrintTime(baseMinutes: number, settings: PrintSettings): nu
   const infillScale = 1 + 0.003 * (settings.infillPercent - BASELINE_INFILL);
   return baseMinutes * nozzleSpeedFactor * layerScale * infillScale;
 }
-export { GRIDFINITY_SPEC, wallThicknessForNozzle } from './gridfinityGeometry';
+export {
+  GRIDFINITY_SPEC,
+  magnetPadMarginForNozzle,
+  wallThicknessForNozzle,
+} from './gridfinityGeometry';
 export type { StandardBinEstimate, StandardBinComponents } from './standardBinVolume';
 export {
   estimateStandardBinVolume,


### PR DESCRIPTION
## Summary

**Type**: fix 


## Context

Why this change? Link issue/task. If AI-generated, include the prompt or goal.

#2543

Increase magnet-hole pad margins for wider nozzles and add regression coverage.

## Changes

- Added nozzle-aware magnet pad margins:
  - 0.4 mm → 1.0 mm
  - 0.6 mm → 1.8 mm
  - 0.8 mm → 2.4 mm
  - 1.0 mm → 2.0 mm

- Applied margins to regular and over-tile lightweight baseplate floor relief.
- Added shared magnetPadMarginForNozzle() helper.
- Passed nozzleSizeMm through baseplate generation.
- Added regression tests for all supported nozzle sizes and 0.8 mm geometry.
- Preserved legacy behavior when nozzle size is omitted.

## Architecture

- **Stores**: layout 
- **Features**: grid-editor
- **New types**: none
- **i18n keys**: none
- **Storage/schema changes**: none?

## Test plan

- [x] `pnpm run test:coverage`
- [x] `pnpm run build`
- [x] New code has colocated sibling tests
- [x] i18n: `pnpm run check:i18n`
- [x] No `console.log`, `any`, `var`, `==`, `!` introduced
- [ ] CLAUDE.md updated if conventions changed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens magnet‑hole pads in lightweight baseplates by making pad margins nozzle‑aware to prevent weak bridges with wider nozzles. Addresses #2543 while keeping legacy geometry for 0.4 mm.

- **Bug Fixes**
  - Made pad margins nozzle‑aware: 0.4→1.0 mm, 0.6→1.8 mm, 0.8→2.4 mm, 1.0→2.0 mm.
  - Applied margins to regular and over‑tile lightweight floor relief by passing `nozzleSizeMm` through baseplate generation.
  - Added `magnetPadMarginForNozzle()` in shared print settings and exported it for reuse.
  - Added regression tests for supported nozzle sizes, including a 0.8 mm case.
  - Preserves legacy behavior when `nozzleSizeMm` is omitted.

<sup>Written for commit 5caba6b55c912be8f887e13557c00108d487d56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

