### PR TITLE
fix(grid-editor): keep axis labels clear of the overhang margin band

### DIFF
--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.tsx
@@ -1,6 +1,5 @@
-import { useShallow } from 'zustand/react/shallow';
-import { useLayoutStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
+import { useDrawerMarginInsets } from './useDrawerMarginInsets';
 
 interface DrawerMarginProps {
   cellSize: number;
@@ -24,36 +23,12 @@ interface DrawerMarginProps {
  */
 export function DrawerMargin({ cellSize, gap }: DrawerMarginProps) {
   const t = useTranslation();
-  const { gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack, shaped } =
-    useLayoutStore(
-      useShallow((s) => ({
-        gridUnitMm: s.layout.gridUnitMm,
-        paddingLeft: s.layout.baseplateParams?.paddingLeft ?? 0,
-        paddingRight: s.layout.baseplateParams?.paddingRight ?? 0,
-        paddingFront: s.layout.baseplateParams?.paddingFront ?? 0,
-        paddingBack: s.layout.baseplateParams?.paddingBack ?? 0,
-        // Shaped drawers strip padding functionally (buildFullParams), so the
-        // margin band would show space the plate doesn't actually have.
-        shaped:
-          s.layout.drawer.outline !== undefined &&
-          s.layout.baseplateParams?.syncWithLayout !== false &&
-          s.layout.baseplateParams?.stackPrint?.enabled !== true,
-      }))
-    );
-
-  const left = Math.max(0, paddingLeft);
-  const right = Math.max(0, paddingRight);
-  const front = Math.max(0, paddingFront);
-  const back = Math.max(0, paddingBack);
+  const { left, right, front, back } = useDrawerMarginInsets(cellSize, gap);
 
   // Nothing to show without a configured margin — or when the drawer shape
-  // subsumes it (padding is functionally stripped for shaped plates).
-  if (shaped || left + right + front + back <= 0) return null;
-
-  // One grid unit spans `cellSize + gap` px (holds in half-grid mode too — the
-  // per-unit pitch is invariant). Padding is a fraction of a unit in mm.
-  const pxPerUnit = cellSize + gap;
-  const toPx = (mm: number): number => (mm / gridUnitMm) * pxPerUnit;
+  // subsumes it (padding is functionally stripped for shaped plates; the hook
+  // returns all-zero insets in that case).
+  if (left + right + front + back <= 0) return null;
 
   // Screen orientation: +Y (back) is up, -Y (front) is down; -X (left) / +X (right).
   return (
@@ -61,10 +36,10 @@ export function DrawerMargin({ cellSize, gap }: DrawerMarginProps) {
       className="pointer-events-none rounded-lg border border-dashed border-accent/50 bg-accent/5"
       style={{
         position: 'absolute',
-        left: -toPx(left),
-        right: -toPx(right),
-        top: -toPx(back),
-        bottom: -toPx(front),
+        left: -left,
+        right: -right,
+        top: -back,
+        bottom: -front,
         zIndex: 0,
       }}
       aria-label={t('grid.drawerMargin.tooltip')}

--- a/src/features/grid-editor/components/Grid/DrawerMargin/index.ts
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/index.ts
@@ -1,1 +1,3 @@
 export { DrawerMargin } from './DrawerMargin';
+export { useDrawerMarginInsets } from './useDrawerMarginInsets';
+export type { DrawerMarginInsets } from './useDrawerMarginInsets';

--- a/src/features/grid-editor/components/Grid/DrawerMargin/useDrawerMarginInsets.test.ts
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/useDrawerMarginInsets.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLayoutStore } from '@/core/store';
+import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
+import { mm } from '@/core/types';
+import type { DrawerOutline } from '@/core/types';
+import { resetAllStores, createTestLayout } from '@/test/testUtils';
+import { useDrawerMarginInsets } from './useDrawerMarginInsets';
+
+// cellSize + gap = 42px per grid unit → mm map 1:1 against the 42mm grid unit.
+const CELL = 41;
+const GAP = 1;
+
+function setPadding(overrides: Partial<Record<'left' | 'right' | 'front' | 'back', number>>) {
+  const layout = createTestLayout();
+  useLayoutStore.setState({
+    layout: {
+      ...layout,
+      gridUnitMm: mm(42),
+      baseplateParams: {
+        ...DEFAULT_BASEPLATE_PARAMS,
+        paddingLeft: mm(overrides.left ?? 0),
+        paddingRight: mm(overrides.right ?? 0),
+        paddingFront: mm(overrides.front ?? 0),
+        paddingBack: mm(overrides.back ?? 0),
+      },
+    },
+  });
+}
+
+describe('useDrawerMarginInsets', () => {
+  beforeEach(() => resetAllStores());
+
+  it('returns zero insets with no padding', () => {
+    setPadding({});
+    const { result } = renderHook(() => useDrawerMarginInsets(CELL, GAP));
+    expect(result.current).toEqual({ left: 0, right: 0, front: 0, back: 0 });
+  });
+
+  it('converts per-side padding (mm) to px at the grid pitch', () => {
+    setPadding({ left: 21, front: 42, back: 10.5 });
+    const { result } = renderHook(() => useDrawerMarginInsets(CELL, GAP));
+    // 42px per unit (=42mm): 21mm → 21px, 42mm → 42px, 10.5mm → 10.5px.
+    expect(result.current.left).toBeCloseTo(21, 6);
+    expect(result.current.front).toBeCloseTo(42, 6);
+    expect(result.current.back).toBeCloseTo(10.5, 6);
+    expect(result.current.right).toBe(0);
+  });
+
+  it('clamps negative padding to zero', () => {
+    setPadding({ left: -5 });
+    const { result } = renderHook(() => useDrawerMarginInsets(CELL, GAP));
+    expect(result.current.left).toBe(0);
+  });
+
+  it('returns zero insets for a shaped drawer (padding is functionally stripped)', () => {
+    const layout = createTestLayout();
+    const outline: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+      ],
+    };
+    useLayoutStore.setState({
+      layout: {
+        ...layout,
+        gridUnitMm: mm(42),
+        drawer: { ...layout.drawer, outline },
+        baseplateParams: {
+          ...DEFAULT_BASEPLATE_PARAMS,
+          paddingLeft: mm(21),
+          syncWithLayout: true,
+        },
+      },
+    });
+    const { result } = renderHook(() => useDrawerMarginInsets(CELL, GAP));
+    expect(result.current).toEqual({ left: 0, right: 0, front: 0, back: 0 });
+  });
+});

--- a/src/features/grid-editor/components/Grid/DrawerMargin/useDrawerMarginInsets.ts
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/useDrawerMarginInsets.ts
@@ -1,0 +1,54 @@
+import { useShallow } from 'zustand/react/shallow';
+import { useLayoutStore } from '@/core/store';
+
+export interface DrawerMarginInsets {
+  /** Left overhang in px (−X). */
+  readonly left: number;
+  /** Right overhang in px (+X). */
+  readonly right: number;
+  /** Front overhang in px (−Y, screen-down). */
+  readonly front: number;
+  /** Back overhang in px (+Y, screen-up). */
+  readonly back: number;
+}
+
+/**
+ * Per-side drawer-fit margin (baseplate padding) in px — the same geometry the
+ * {@link DrawerMargin} band renders. Insets are 0 when there is no padding or the
+ * drawer is shaped (padding is functionally stripped for shaped plates, so the
+ * band isn't drawn).
+ *
+ * Shared so the band and the axis-label offsets that clear it stay in lockstep:
+ * the row/column labels are opaque and sit above the band, so on padded sides
+ * they'd cover the overhang unless pushed out by exactly these amounts (#2549).
+ */
+export function useDrawerMarginInsets(cellSize: number, gap: number): DrawerMarginInsets {
+  const { gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack, shaped } =
+    useLayoutStore(
+      useShallow((s) => ({
+        gridUnitMm: s.layout.gridUnitMm,
+        paddingLeft: s.layout.baseplateParams?.paddingLeft ?? 0,
+        paddingRight: s.layout.baseplateParams?.paddingRight ?? 0,
+        paddingFront: s.layout.baseplateParams?.paddingFront ?? 0,
+        paddingBack: s.layout.baseplateParams?.paddingBack ?? 0,
+        shaped:
+          s.layout.drawer.outline !== undefined &&
+          s.layout.baseplateParams?.syncWithLayout !== false &&
+          s.layout.baseplateParams?.stackPrint?.enabled !== true,
+      }))
+    );
+
+  if (shaped) return { left: 0, right: 0, front: 0, back: 0 };
+
+  // One grid unit spans `cellSize + gap` px (holds in half-grid mode — the
+  // per-unit pitch is invariant). Padding is a fraction of a unit in mm.
+  const pxPerUnit = cellSize + gap;
+  const toPx = (mm: number): number => (Math.max(0, mm) / gridUnitMm) * pxPerUnit;
+
+  return {
+    left: toPx(paddingLeft),
+    right: toPx(paddingRight),
+    front: toPx(paddingFront),
+    back: toPx(paddingBack),
+  };
+}

--- a/src/features/grid-editor/components/Grid/Grid.tsx
+++ b/src/features/grid-editor/components/Grid/Grid.tsx
@@ -20,7 +20,7 @@ import { getLayerBins } from '@/shared/utils';
 import type { GridUnits } from '@/core/types';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import { GridCanvas } from './GridCanvas';
-import { DrawerMargin } from './DrawerMargin';
+import { DrawerMargin, useDrawerMarginInsets } from './DrawerMargin';
 import { Overlay } from './Overlay';
 import { QuickLabelPopover } from './QuickLabelPopover';
 import { SelectionToolbar } from './SelectionToolbar';
@@ -211,6 +211,11 @@ export function Grid({ shouldShowDrawTutorial = false }: GridProps) {
   // Calculate cellSize using zoom from zoomState (may differ slightly due to fit-to-screen)
   const cellSize = Math.round(baseCellSize * zoomState.zoom);
 
+  // Per-side overhang band (baseplate padding) in px. The row/column labels are
+  // opaque and sit above the band, so on the padded left/front sides they'd hide
+  // the overhang — push them out by the band's extent so both stay visible (#2549).
+  const marginInsets = useDrawerMarginInsets(cellSize, gap);
+
   // In half-bin mode, visual cells are smaller to fit 2x cells in the same space
   // Formula accounts for extra gaps: (cellSize - gap) / 2 keeps total grid size constant
   const visualCellSize = halfGridMode ? (cellSize - gap) / HALF_BIN_SCALE : cellSize;
@@ -341,7 +346,9 @@ export function Grid({ shouldShowDrawTutorial = false }: GridProps) {
               style={{
                 gridTemplateColumns: labelsState.axisLabelsVisible ? `auto 1fr` : '1fr',
                 gridTemplateRows: '1fr',
-                columnGap: labelsState.axisLabelsVisible ? 4 : 0,
+                // Widen the row-label gutter by the left overhang so the band
+                // sits between the labels and the grid instead of under them.
+                columnGap: labelsState.axisLabelsVisible ? 4 + marginInsets.left : 0,
               }}
             >
               {/* Row labels column - sticky to left edge */}
@@ -499,7 +506,9 @@ export function Grid({ shouldShowDrawTutorial = false }: GridProps) {
                     fullColSize={fullColSize}
                     fractionalColSize={fractionalColSize}
                     gap={gap}
-                    gridTop={gridHeight}
+                    // Drop the column labels below the front overhang band so it
+                    // isn't hidden behind them (#2549).
+                    gridTop={gridHeight + marginInsets.front}
                     onColumnClick={handleColumnClick}
                   />
                 )}


### PR DESCRIPTION
Fixes #2549.

## Problem

On the 2D Layout view, when the active baseplate has overhang (per-side padding), the drawer-fit margin band extends past the grid on the padded sides — but the row/column axis labels are opaque (`bg-surface`, `zIndex: 30`) and sit above the band (`zIndex: 0`), so on the **left** and **front** sides the labels covered the overhang instead of it showing next to them.

The `DrawerMargin` code already noted this: *"the band overhangs the row/column axis labels on padded sides."*

## Fix

Extract the band geometry into a shared `useDrawerMarginInsets(cellSize, gap)` hook (single source of truth), and offset the labels by exactly that amount so they can never drift from the band:

- **Row labels (Y-axis):** widen the label→grid gutter by the left overhang, so the band sits *between* the labels and the grid.
- **Column labels (X-axis):** drop them below the front overhang band.

`DrawerMargin` now consumes the same hook, so the band and the label offsets are computed from one place. No visual change when there's no padding (insets are all zero → gutter/positions unchanged), and shaped drawers still show nothing (padding is functionally stripped).

## Tests

- `useDrawerMarginInsets`: mm→px conversion at the grid pitch, negative-padding clamp, zero when unpadded, zero for shaped drawers.
- Existing `DrawerMargin` and `Grid` tests pass unchanged (no regression).

## Note

I could not do a live visual check in-browser (extension unavailable in this environment); the offset math is unit-tested and the layout reasoning is in the code comments, but a quick visual confirmation on a padded baseplate would be worth a look before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps axis labels clear of the overhang margin band in the 2D Layout so baseplate padding is visible; fixes #2549.

- **Bug Fixes**
  - Row labels: widened gutter by the left overhang.
  - Column labels: positioned below the front overhang.
  - No change when unpadded; shaped drawers still show no band.

- **Refactors**
  - Added shared `useDrawerMarginInsets(cellSize, gap)` hook used by `DrawerMargin` and for label offsets.
  - Added tests for mm→px conversion, negative clamp, and zero insets for unpadded/shaped drawers.

<sup>Written for commit 94f289382f1c5b614d4017b5d8912642f906c4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

