### PR TITLE
fix(baseplate): apply connector fit offset to split-piece geometry

### DIFF
--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -834,6 +834,28 @@ describe('pieceToBaseplateParams', () => {
     }
   });
 
+  it('propagates connectorFitOffset and nozzleSizeMm to every piece so the groove clearance responds to tolerance (#2554)', () => {
+    // Regression: pieceToBaseplateParams dropped both fields, so split pieces cut
+    // their female groove at nominal clearance regardless of the user's tolerance
+    // — identical STL bytes for -0.3 vs +0.3, while the print guide (which reads
+    // the parent params) still changed. Both feed effectiveClearance.
+    const parent = makeParams({
+      width: 10,
+      depth: 8,
+      connectorNubs: true,
+      connectorStyle: 'puzzle',
+      connectorFitOffset: 0.3,
+      nozzleSizeMm: 0.6,
+    });
+    const tiling = computeBaseplateTiling(parent, 256);
+    expect(tiling.isSplit).toBe(true);
+    for (const piece of tiling.pieces) {
+      const gen = pieceToBaseplateParams(piece, parent);
+      expect(gen.connectorFitOffset).toBe(0.3);
+      expect(gen.nozzleSizeMm).toBe(0.6);
+    }
+  });
+
   it('swaps front/back padding for rotated pieces so the body centre negates (stack-print preview relies on this)', () => {
     // The stack-print preview derives a flipped plate's body centre from the
     // SAME params the mesh was generated with. For a preferIdenticalPieces 180°

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -1149,6 +1149,12 @@ export function pieceToBaseplateParams(
     // Dovetail key seams are symmetric, so connectorStyle is rotation-invariant —
     // copy it straight through (unlike padding/edges, which rotate with `rot`).
     connectorStyle: parentParams.connectorStyle,
+    // The fit offset and nozzle both size the female groove clearance
+    // (effectiveClearance), so they must reach every split piece — otherwise the
+    // groove is cut at nominal regardless of the user's tolerance (issue #2554).
+    // Per-side clearance is symmetric, so both are rotation-invariant.
+    connectorFitOffset: parentParams.connectorFitOffset,
+    nozzleSizeMm: parentParams.nozzleSizeMm,
     invertDovetails: parentParams.invertDovetails,
     preferIdenticalPieces: parentParams.preferIdenticalPieces,
     lightweight: parentParams.lightweight,


### PR DESCRIPTION
## What

Changing the Puzzle (and any) connector tolerance now actually changes the generated STL geometry for **split** baseplates — not just the print guide.

Fixes #2554.

## Why it was broken

`pieceToBaseplateParams()` rebuilds each split piece's generation params field-by-field from the parent plate, and it silently **omitted `connectorFitOffset` and `nozzleSizeMm`** — the two fields that feed `effectiveClearance()` when sizing the female groove.

So for a split baseplate:

- The worker cut every groove at **nominal** clearance regardless of the tolerance the user dialed in.
- The cross-session export cache key (a stringification of the piece params) was **identical** for `-0.3` and `+0.3`, so the two exports returned byte-for-byte identical files.
- The **print guide** reads the parent params directly, so it *did* reflect the tolerance change — exactly the asymmetry in the bug report (`-0.30 mm → 0.000 mm`, `+0.30 mm → 0.450 mm`, but identical meshes).

Single (un-split) plates export straight from the full params, which is why they always worked and the existing fit-offset scenario test passed.

## The fix

Propagate `connectorFitOffset` and `nozzleSizeMm` to every piece. Per-side groove clearance is symmetric, so both are rotation-invariant and copy straight through (like `connectorStyle`). This also corrects the split-piece **3D preview**, which shares the same path and was likewise rendering nominal grooves — preview and export now agree.

## Verification

- New regression test in `splitPlanner.test.ts` asserts both fields reach every split piece (Puzzle style, `+0.3` offset, `0.6 mm` nozzle).
- End-to-end response of the geometry to `connectorFitOffset` is already covered by `baseplateGenerator.scenario.fit-offset.test.ts`; this PR closes the gap between that and the split-piece param derivation.
- `typecheck` + `splitPlanner`, `pieceFingerprint`, and `buildFullParams` suites all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply connector tolerance to split-piece geometry so STL and 3D preview reflect the user’s setting, not nominal. Fixes #2554.

- **Bug Fixes**
  - Propagate `connectorFitOffset` and `nozzleSizeMm` to each split piece in `pieceToBaseplateParams` (feeds `effectiveClearance`).
  - Align split-piece preview and export with parent params; cache keys now differ by tolerance (no more identical meshes for -0.3 vs +0.3).
  - Add regression test in `splitPlanner.test.ts` for Puzzle style with +0.3 offset and 0.6 mm nozzle.

<sup>Written for commit ff1bc0aa1e43b893890a6fbb728d2d7e7e1afc89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

