### PR TITLE
feat(labs): graduate custom drawer shapes out of labs

### DIFF
--- a/e2e/drawer-shape.spec.ts
+++ b/e2e/drawer-shape.spec.ts
@@ -65,11 +65,14 @@ test.describe('Custom Drawer Shapes (#2528)', () => {
     await expect(page.getByRole('img', { name: /drawer shape boundary/i })).toHaveCount(1);
     await page.screenshot({ path: testInfo.outputPath('drawer-shape-notch-2d.png') });
 
-    // Switch to the Baseplate tool (client-side nav via the ToolSwitcher — keeps
-    // the in-memory outline; a full reload would drop it, since a never-saved
-    // default layout isn't persisted). The baseplate consumes the same outline:
-    // its padding controls give way to the shaped-drawer notice (plain React — a
-    // non-WebGL signal the baseplate is driven by the shape, not the bounding box).
+    // Switch to the Baseplate tool via the ToolSwitcher — client-side nav
+    // (history.pushState), so the in-memory outline survives. A full page reload
+    // would not: useAutoSave persists a layout only once it is registered in the
+    // library (has an activeLayoutId), which this test's pristine default layout
+    // never triggers, so a reload would start from a blank rectangular drawer.
+    // The baseplate consumes the same outline: its padding controls give way to
+    // the shaped-drawer notice (plain React — a non-WebGL signal the baseplate is
+    // driven by the shape, not the bounding box).
     await page.getByRole('tab', { name: 'Baseplate', exact: true }).click();
     await expect(page.getByText(/this drawer has a custom shape/i)).toBeVisible({
       timeout: 30_000,

--- a/e2e/drawer-shape.spec.ts
+++ b/e2e/drawer-shape.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Full-flow verification for Custom Drawer Shapes (issue #2528): author a
+ * non-rectangular drawer from either surface (paint a notch, or trace the bin
+ * layout) → the layout renders the shape → the baseplate follows it exactly.
+ *
+ * Not part of CI — a manual verification spec (WebGL). Run with:
+ *   pnpm exec playwright test e2e/drawer-shape.spec.ts --project=chromium
+ */
+
+import {
+  test,
+  expect,
+  drawBinOnGrid,
+  getActiveDialog,
+  clearAllStorage,
+  resetViewport,
+} from './fixtures';
+
+test.use({
+  viewport: { width: 1440, height: 900 },
+  launchOptions: {
+    args: ['--use-gl=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist'],
+  },
+});
+
+test.describe('Custom Drawer Shapes (#2528)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('application', { name: /drawer grid/i })).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    // The applied outline autosaves — clear it so it can't bleed into the next test.
+    await clearAllStorage(page);
+    await resetViewport(page);
+  });
+
+  test('paint a corner notch → baseplate follows the shape', async ({ page }, testInfo) => {
+    test.setTimeout(120_000);
+
+    // Open the shape editor from the sidebar (FeatureToggle renders role="switch").
+    const toggle = page.getByRole('switch', { name: /custom drawer shape/i });
+    await expect(toggle).toBeVisible({ timeout: 15_000 });
+    await toggle.click();
+
+    const dialog = getActiveDialog(page);
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('grid', { name: /drawer shape cells/i })).toBeVisible();
+
+    // The editor seeds as the full rectangle — every cell filled. Cell index 0 is
+    // the front-left corner (index = row * cols + col). Removing one corner leaves
+    // a connected, non-rectangular shape (a notch), so Apply stays valid.
+    const corner = dialog.locator('[data-cell-index="0"]');
+    await expect(corner).toHaveAttribute('aria-selected', 'true');
+    await corner.click();
+    await expect(corner).toHaveAttribute('aria-selected', 'false');
+
+    await dialog.getByRole('button', { name: /apply shape/i }).click();
+    await expect(dialog).toBeHidden();
+
+    // The layout now strokes the shape boundary — this overlay renders only when
+    // an outline exists, so its presence proves the outline reached the store.
+    await expect(page.getByRole('img', { name: /drawer shape boundary/i })).toHaveCount(1);
+    await page.screenshot({ path: testInfo.outputPath('drawer-shape-notch-2d.png') });
+
+    // Switch to the Baseplate tool (client-side nav via the ToolSwitcher — keeps
+    // the in-memory outline; a full reload would drop it, since a never-saved
+    // default layout isn't persisted). The baseplate consumes the same outline:
+    // its padding controls give way to the shaped-drawer notice (plain React — a
+    // non-WebGL signal the baseplate is driven by the shape, not the bounding box).
+    await page.getByRole('tab', { name: 'Baseplate', exact: true }).click();
+    await expect(page.getByText(/this drawer has a custom shape/i)).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByRole('spinbutton', { name: 'Left', exact: true })).toHaveCount(0);
+    await page.screenshot({ path: testInfo.outputPath('drawer-shape-baseplate.png') });
+  });
+
+  test('trace bin layout derives the drawer shape', async ({ page }, testInfo) => {
+    test.setTimeout(120_000);
+
+    // Draw a bin near the front-left corner so "Trace bin layout" has a footprint
+    // to derive the shape from — the exact flow requested in #2528.
+    const grid = page.getByRole('application', { name: /drawer grid/i });
+    const box = await grid.boundingBox();
+    if (!box) throw new Error('no grid box');
+    await drawBinOnGrid(page, 24, box.height - 24, 70, box.height - 70);
+
+    const toggle = page.getByRole('switch', { name: /custom drawer shape/i });
+    await toggle.click();
+
+    const dialog = getActiveDialog(page);
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: /trace bin layout/i }).click();
+
+    // Tracing seeds a valid, connected shape from the bin footprint, so Apply is
+    // enabled (it disables only on an empty or disconnected shape).
+    const apply = dialog.getByRole('button', { name: /apply shape/i });
+    await expect(apply).toBeEnabled();
+    await apply.click();
+    await expect(dialog).toBeHidden();
+
+    await expect(page.getByRole('img', { name: /drawer shape boundary/i })).toHaveCount(1);
+    await page.screenshot({ path: testInfo.outputPath('drawer-shape-traced-2d.png') });
+  });
+});

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -13,11 +13,10 @@ export const FEATURE_FLAGS = [
     name: 'Custom Drawer Shapes',
     description:
       'Design non-rectangular drawers — L-shapes, notches, and cut corners. Paint the drawer shape cell by cell or trace it from your bin layout, and the baseplate follows it exactly.',
-    status: 'experimental',
+    status: 'graduated',
     risk: 'medium',
-    warning:
-      'Shaped baseplates disable padding, corner rounding, and detached margins (the shape defines the edge). Stack printing prints the rectangular plate.',
     addedAt: '2026-07',
+    graduatedAt: '2026-07',
     requiresRefresh: false,
   },
   {

--- a/src/features/drawer-shape/README.md
+++ b/src/features/drawer-shape/README.md
@@ -1,7 +1,7 @@
 # Drawer Shape
 
-Authoring surfaces for non-rectangular drawers (issue #2528), behind the
-`drawer_shapes` labs flag. All surfaces write ONE field — `Drawer.outline`
+Authoring surfaces for non-rectangular drawers (issue #2528). All surfaces
+write ONE field — `Drawer.outline`
 (closed CCW loop of line segments + arcs, drawer-local mm) — via the
 `drawer.setOutline` command; everything downstream (placement gating,
 hatching, baseplate generation/splitting) derives from it.

--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.test.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.test.tsx
@@ -10,11 +10,6 @@ vi.mock('@/i18n', () => ({
     params ? `${key}:${JSON.stringify(params)}` : key,
 }));
 
-let mockFlagEnabled = true;
-vi.mock('@/shared/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: () => mockFlagEnabled,
-}));
-
 const mockSetDrawerOutline = vi.fn(() => ({ ok: true, value: undefined }));
 vi.mock('@/shared/contexts/MutationsContext', () => ({
   useMutations: () => ({ setDrawerOutline: mockSetDrawerOutline }),
@@ -36,13 +31,6 @@ describe('DrawerShapeSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetAllStores();
-    mockFlagEnabled = true;
-  });
-
-  it('renders nothing when the labs flag is off', () => {
-    mockFlagEnabled = false;
-    const { container } = render(<DrawerShapeSection />);
-    expect(container.firstChild).toBeNull();
   });
 
   it('shows the toggle unchecked for rectangular drawers', () => {

--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
@@ -6,19 +6,17 @@ import { FeatureToggle } from '@/shared/components/FeatureToggle/FeatureToggle';
 import { useLayoutStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
 import { useMutations } from '@/shared/contexts/MutationsContext';
-import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { ShapeEditorDialog } from '../ShapeEditorDialog/ShapeEditorDialog';
 import { CornerCutsDialog } from '../CornerCutsDialog/CornerCutsDialog';
 
 /**
- * Sidebar entry for non-rectangular drawers (issue #2528), behind the
- * `drawer_shapes` labs flag. The toggle reflects whether an outline exists;
- * enabling opens the cell-paint editor, disabling clears the shape (with a
- * confirm — clearing displaces nothing but discards drawn geometry).
+ * Sidebar entry for non-rectangular drawers (issue #2528). The toggle reflects
+ * whether an outline exists; enabling opens the cell-paint editor, disabling
+ * clears the shape (with a confirm — clearing displaces nothing but discards
+ * drawn geometry).
  */
 export function DrawerShapeSection() {
   const t = useTranslation();
-  const enabled = useFeatureFlag('drawer_shapes');
   const mutations = useMutations();
   const { hasOutline } = useLayoutStore(
     useShallow((s) => ({ hasOutline: s.layout.drawer.outline !== undefined }))
@@ -38,8 +36,6 @@ export function DrawerShapeSection() {
   const handleReset = useCallback(() => {
     mutations.setDrawerOutline(null);
   }, [mutations]);
-
-  if (!enabled) return null;
 
   return (
     <div className="border-t border-stroke-subtle pt-2" data-help-target="drawer-shape">

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -176,7 +176,7 @@ export function MobileSettingsPanel() {
           <Checkbox checked={halfGridMode} size="lg" />
         </div>
 
-        {/* Non-rectangular drawer shape (labs: drawer_shapes) */}
+        {/* Non-rectangular drawer shape (issue #2528) */}
         <DrawerShapeSection />
       </section>
 

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -460,7 +460,7 @@ export function Sidebar() {
                     </div>
                   )}
 
-                  {/* Non-rectangular drawer shape (labs: drawer_shapes) */}
+                  {/* Non-rectangular drawer shape (issue #2528) */}
                   <DrawerShapeSection />
                 </div>
               </Collapsible>


### PR DESCRIPTION
## What

Graduates the **Custom Drawer Shapes** feature (`drawer_shapes`) out of Labs to always-on. Everyone can now design non-rectangular drawers — L-shapes, notches, and cut corners — by painting the shape cell by cell or tracing it from their bin layout, and the baseplate follows the shape exactly instead of its bounding rectangle. This ships the fix for the request in #2528.

## Why now

The feature is fully wired end to end — one field (`Drawer.outline`) drives placement gating, the layout hatching overlay, baseplate generation, and print-bed splitting — and is covered by ~2,700 lines of unit tests plus the new full-flow e2e below. Nothing about it remained gated behind "experimental" except the flag itself.

## Changes

- **`features.ts`** — flip `drawer_shapes` `experimental → graduated`, add `graduatedAt`, drop the experimental-only `warning`. The padding/rounding trade-off it described is already surfaced inline by the baseplate's shaped-drawer notice.
- **`DrawerShapeSection`** — remove the now-dead `useFeatureFlag('drawer_shapes')` guard (graduated flags return `true` unconditionally) and its "renders nothing when the flag is off" test, which now covered an unreachable state. Same pattern as the last graduation (#2474).
- Drop the stale `labs: drawer_shapes` comments in the section, `Sidebar`, and `MobileSettingsPanel`; refresh the feature README.
- **`e2e/drawer-shape.spec.ts`** (new) — manual full-flow verification spec (not in CI — WebGL), one test per authoring surface:
  - *paint a corner notch* → the layout renders the shape boundary and the Baseplate tool switches to shape mode (padding controls give way to the shaped-drawer notice).
  - *trace bin layout* → a drawn bin's footprint becomes the drawer outline (the exact flow requested in #2528).

## Verification

- `pnpm run typecheck` — clean
- Affected unit tests (`DrawerShapeSection`, `features`) — 53 passing
- `pnpm exec playwright test e2e/drawer-shape.spec.ts --project=chromium` — 2 passing (run with the flag injection removed, confirming the toggle is genuinely always-on)

Addresses #2528 (leaving it open until the reporter confirms the fit on their drawer).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates Custom Drawer Shapes (`drawer_shapes`) out of Labs and makes it always on. Users can paint or trace non-rectangular drawers, and the baseplate follows the outline exactly (closes #2528).

- **New Features**
  - Graduated `drawer_shapes` to always-on; added `graduatedAt` and removed the labs warning.

- **Refactors**
  - Removed dead `useFeatureFlag('drawer_shapes')` guard and its unreachable test; refreshed README and comments.
  - Added manual e2e `e2e/drawer-shape.spec.ts` covering paint-a-notch and trace-bin; clarified why a full reload drops the outline in this spec.

<sup>Written for commit 8a08b523bbb6337d1442807dc436e8301f1569b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

