### PR TITLE
fix(baseplate): key mesh cache on nozzle for lightweight magnet pads

### DIFF
--- a/src/features/generation/worker/generators/baseplateCacheKeys.test.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.test.ts
@@ -78,6 +78,42 @@ describe('meshCacheKey — draft preview', () => {
   });
 });
 
+describe('meshCacheKey — nozzle-dependent floor pads (issue #2559)', () => {
+  // #2544 made the lightweight-floor magnet pad margin depend on nozzle size, so
+  // the key must track nozzle for magnet+lightweight plates even with connectors
+  // off — otherwise a wider nozzle serves the stale narrow-pad mesh.
+  const floor = (nozzleSizeMm: number) =>
+    meshCacheKey(base({ connectorNubs: false, magnetHoles: true, nozzleSizeMm }), false);
+
+  it('keys on nozzle when the lightweight floor cut runs, connectors off', () => {
+    expect(floor(0.4)).not.toBe(floor(0.8));
+  });
+
+  it('shares a key across nozzles when no floor cut consumes the pad margin', () => {
+    // No magnets ⇒ no lightweight floor ⇒ nozzle has no geometric effect (and
+    // connectors are off), so the plate keeps one entry across nozzle changes.
+    const noMag = (nozzleSizeMm: number) =>
+      meshCacheKey(base({ connectorNubs: false, magnetHoles: false, nozzleSizeMm }), false);
+    expect(noMag(0.4)).toBe(noMag(0.8));
+
+    // Lightweight explicitly off ⇒ the floor stays solid, so no nozzle-scaled pad.
+    const noLw = (nozzleSizeMm: number) =>
+      meshCacheKey(
+        base({ connectorNubs: false, magnetHoles: true, lightweight: false, nozzleSizeMm }),
+        false
+      );
+    expect(noLw(0.4)).toBe(noLw(0.8));
+
+    // A solid floor suppresses the lightweight cut too.
+    const solid = (nozzleSizeMm: number) =>
+      meshCacheKey(
+        base({ connectorNubs: false, magnetHoles: true, solidFloor: true, nozzleSizeMm }),
+        false
+      );
+    expect(solid(0.4)).toBe(solid(0.8));
+  });
+});
+
 describe('cache keys with outlines (issue #2528)', () => {
   const L_SHAPE = {
     vertices: [

--- a/src/features/generation/worker/generators/baseplateCacheKeys.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.ts
@@ -63,12 +63,15 @@ export function meshCacheKey(
   // Nozzle scales two independent geometry features: connector feature sizes
   // (snap-clip barb/leg) and the lightweight-floor magnet pad margin (#2544,
   // #2559). It must key the cache whenever either is active, or wider-nozzle
-  // geometry would alias onto the 0.4mm build and serve a stale mesh. Folded to
-  // 0 when neither applies so those plates keep sharing one entry across nozzles.
-  const featureNozzle =
-    (params.connectorNubs ?? false) || lightweightFloorActive
-      ? quantize(params.nozzleSizeMm ?? NOZZLE_BASELINE)
-      : 0;
+  // geometry would alias onto the 0.4mm build and serve a stale mesh. The draft
+  // fast-path skips the floor cut, so the pad margin has no effect there —
+  // fold that contribution out under draft so drafts keep one entry across
+  // nozzles. Folded to 0 when neither applies for the same reason.
+  const nozzleAffectsGeometry =
+    (params.connectorNubs ?? false) || (lightweightFloorActive && !draft);
+  const featureNozzle = nozzleAffectsGeometry
+    ? quantize(params.nozzleSizeMm ?? NOZZLE_BASELINE)
+    : 0;
   return buildCacheKey(
     // v3: outline term for non-rectangular plates (empty = rectangle, so
     // existing rectangular plates keep their cache identity within v3)

--- a/src/features/generation/worker/generators/baseplateCacheKeys.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.ts
@@ -43,12 +43,14 @@ export function meshCacheKey(
   const connectorClearance = params.connectorNubs
     ? effectiveClearance(baseClearance, params.connectorFitOffset ?? 0, params.nozzleSizeMm)
     : 0;
-  // Draft only changes geometry when there's a lightweight floor cut to skip
-  // (magnets on AND lightweight not disabled). Otherwise the draft mesh is
-  // byte-identical to the full build, so folding `draft` to false keeps both
-  // sharing one LRU entry instead of fragmenting it.
-  const geometryAffectingDraft =
-    draft && params.magnetHoles && params.lightweight !== false && !params.solidFloor;
+  // The lightweight floor cut (cross-hollowed underside keeping only magnet
+  // pads) runs with magnets on, lightweight not disabled, and no solid floor.
+  const lightweightFloorActive =
+    params.magnetHoles && params.lightweight !== false && !(params.solidFloor ?? false);
+  // Draft only changes geometry when there's a lightweight floor cut to skip.
+  // Otherwise the draft mesh is byte-identical to the full build, so folding
+  // `draft` to false keeps both sharing one LRU entry instead of fragmenting it.
+  const geometryAffectingDraft = draft && lightweightFloorActive;
   // Legacy 'center' magnet anchor only shifts holes on a grid larger than the
   // standard 42mm; at ≤42mm (or with magnets off) it's byte-identical to the
   // default 'edge'. Fold to 'edge' in those cases so every existing plate keeps
@@ -58,13 +60,15 @@ export function meshCacheKey(
     params.magnetHoles && params.magnetAnchor === 'center' && params.gridUnitMm > SIZE
       ? 'center'
       : 'edge';
-  // Nozzle scales connector feature sizes (snap-clip barb/leg) independently of
-  // the clearance term, so it must key the cache or wider-nozzle geometry would
-  // alias onto the 0.4mm build. Only meaningful when connectors are on; folded to
-  // 0 otherwise so connector-off plates keep sharing one entry across nozzles.
-  const connectorNozzle = params.connectorNubs
-    ? quantize(params.nozzleSizeMm ?? NOZZLE_BASELINE)
-    : 0;
+  // Nozzle scales two independent geometry features: connector feature sizes
+  // (snap-clip barb/leg) and the lightweight-floor magnet pad margin (#2544,
+  // #2559). It must key the cache whenever either is active, or wider-nozzle
+  // geometry would alias onto the 0.4mm build and serve a stale mesh. Folded to
+  // 0 when neither applies so those plates keep sharing one entry across nozzles.
+  const featureNozzle =
+    (params.connectorNubs ?? false) || lightweightFloorActive
+      ? quantize(params.nozzleSizeMm ?? NOZZLE_BASELINE)
+      : 0;
   return buildCacheKey(
     // v3: outline term for non-rectangular plates (empty = rectangle, so
     // existing rectangular plates keep their cache identity within v3)
@@ -103,7 +107,7 @@ export function meshCacheKey(
     params.preferIdenticalPieces ?? false,
     params.connectorStyle ?? 'dovetail',
     quantize(connectorClearance),
-    connectorNozzle,
+    featureNozzle,
     params.lightweight ?? true,
     quantize(params.cornerRadius ?? -1),
     quantize(params.cornerRadii?.tl ?? -1),

--- a/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
@@ -167,14 +167,14 @@ describe('planPartialCellFloorCuts (over-tile margin hollowing)', () => {
     expect(cross.padHalfX).toBeLessThan(13 - MAGNET_R - 1);
   });
 
-  it('keeps three nozzle-widths around magnet holes for a 0.8mm nozzle', async () => {
+  it('keeps a 3-perimeter pad margin around magnet holes for a 0.8mm nozzle', async () => {
     const { planPartialCellFloorCuts } = await import('./lightweightFloorCutter');
     const cuts = planPartialCellFloorCuts(cell(1, 1), MAGNET_R, GRID, 0.8);
     expect(cuts).toHaveLength(1);
     expect(cuts[0]).toMatchObject({
       kind: 'cross',
-      padHalfX: 13 - MAGNET_R - 2.4,
-      padHalfY: 13 - MAGNET_R - 2.4,
+      padHalfX: 13 - MAGNET_R - 2.5,
+      padHalfY: 13 - MAGNET_R - 2.5,
     });
   });
 

--- a/src/shared/printSettings/gridfinityGeometry.test.ts
+++ b/src/shared/printSettings/gridfinityGeometry.test.ts
@@ -83,7 +83,7 @@ describe('gridfinityGeometry', () => {
     it.each([
       [0.4, 1],
       [0.6, 1.8],
-      [0.8, 2.4],
+      [0.8, 2.5],
       [1.0, 2.0],
     ])('for a %smm nozzle, returns %smm margin', (nozzle, margin) => {
       expect(magnetPadMarginForNozzle(nozzle)).toBe(margin);

--- a/src/shared/printSettings/gridfinityGeometry.ts
+++ b/src/shared/printSettings/gridfinityGeometry.ts
@@ -85,10 +85,17 @@ export const NOZZLE_WALL_COUNTS: Partial<Record<number, number>> = {
   1.0: 1,
 };
 
-/** Minimum solid pad margin around a magnet hole, keyed by standard nozzle. */
+/**
+ * Minimum solid pad margin around a magnet hole, keyed by standard nozzle.
+ *
+ * Sized to clear whole perimeters at the slicer's line width (≈ nozzle × 1.05),
+ * not a bare multiple of nozzle diameter: at 0.8mm the line width is ~0.82mm, so
+ * 3 perimeters need 2.46mm — 2.5mm clears them where 2.4mm left a partial-bead
+ * gap (issue #2559).
+ */
 const MAGNET_PAD_MARGINS: Partial<Record<number, number>> = {
   0.6: 1.8,
-  0.8: 2.4,
+  0.8: 2.5,
   1.0: 2.0,
 };
 


### PR DESCRIPTION
## What

Wider-nozzle magnet holes on lightweight baseplates were still printing with a thin, gap-prone wall around each magnet, even after #2544. This makes #2544's larger pad margin actually take effect, and sizes the 0.8mm margin to clear whole perimeters.

## Root cause

#2544 made the lightweight-floor magnet pad margin depend on nozzle size (`magnetPadMarginForNozzle`), and its unit tests pass. But `meshCacheKey` only folded the nozzle into the cache key when split connectors were enabled:

```ts
const connectorNozzle = params.connectorNubs
  ? quantize(params.nozzleSizeMm ?? NOZZLE_BASELINE)
  : 0;
```

With connectors off (the common case for a plain magnet baseplate), bumping the nozzle from 0.4mm to 0.8mm produced the **same** cache key, so the in-memory mesh LRU returned the stale narrow-pad geometry. The reporter saw a ~1mm wall and reasonably concluded the fix wasn't a fix (#2559). The geometry function was right; the memoization key just didn't list its new input.

## Changes

1. **Cache key** — include the quantized nozzle in `meshCacheKey` whenever the lightweight floor cut actually runs (magnets on, lightweight not disabled, no solid floor), in addition to when connectors are on. Gated out under `draft` (the draft fast-path skips the floor cut, so nozzle has no effect there). Folds to `0` when the nozzle can't affect geometry, so unaffected plates keep sharing one entry. In-memory LRU, so no persisted cache to migrate.

2. **Margin value** — bump the 0.8mm pad margin from 2.4mm to **2.5mm**. At a 0.8mm nozzle the slicer line width is ~0.82mm, so 3 perimeters need 2.46mm; 2.4mm (3 × nozzle diameter) fell just short and left a partial-bead gap. 2.5mm clears 3 full perimeters, matching the value the reporter validated.

## Tests

- `baseplateCacheKeys.test.ts`: magnet + lightweight, connectors off → distinct keys across nozzles; no-magnet / lightweight-off / solid-floor → still one key across nozzles.
- Updated `gridfinityGeometry.test.ts` and `lightweightFloorCutter.test.ts` for the 2.5mm value.
- Typecheck and lint clean.

Fixes #2559