### PR TITLE
fix(baseplate): widen 0.6mm magnet pad margin to a full 3 perimeters

### DIFF
--- a/src/shared/printSettings/gridfinityGeometry.test.ts
+++ b/src/shared/printSettings/gridfinityGeometry.test.ts
@@ -82,7 +82,7 @@ describe('gridfinityGeometry', () => {
   describe('magnetPadMarginForNozzle', () => {
     it.each([
       [0.4, 1],
-      [0.6, 1.8],
+      [0.6, 1.9],
       [0.8, 2.5],
       [1.0, 2.0],
     ])('for a %smm nozzle, returns %smm margin', (nozzle, margin) => {

--- a/src/shared/printSettings/gridfinityGeometry.ts
+++ b/src/shared/printSettings/gridfinityGeometry.ts
@@ -88,13 +88,14 @@ export const NOZZLE_WALL_COUNTS: Partial<Record<number, number>> = {
 /**
  * Minimum solid pad margin around a magnet hole, keyed by standard nozzle.
  *
- * Sized to clear whole perimeters at the slicer's line width (≈ nozzle × 1.05),
- * not a bare multiple of nozzle diameter: at 0.8mm the line width is ~0.82mm, so
- * 3 perimeters need 2.46mm — 2.5mm clears them where 2.4mm left a partial-bead
- * gap (issue #2559).
+ * Sized to clear whole perimeters at the slicer's line width (≈ nozzle × 1.025,
+ * measured from a Bambu profile), not a bare multiple of nozzle diameter, so the
+ * wall around the hole prints as solid perimeters instead of a partial-bead gap
+ * (issue #2559). 3 perimeters at 0.8mm (line width ~0.82mm) need 2.46mm → 2.5mm;
+ * at 0.6mm (~0.615mm) need 1.85mm → 1.9mm.
  */
 const MAGNET_PAD_MARGINS: Partial<Record<number, number>> = {
-  0.6: 1.8,
+  0.6: 1.9,
   0.8: 2.5,
   1.0: 2.0,
 };


### PR DESCRIPTION
## What

Follow-up to #2561. Applies the same 3-perimeter sizing to the 0.6mm nozzle magnet pad margin.

## Why

#2561 fixed the 0.8mm margin (2.4 → 2.5mm) so the wall around a magnet hole clears 3 full slicer perimeters instead of a partial bead. The 0.6mm entry has the identical wrinkle: at a 0.6mm nozzle the slicer line width is ~0.615mm (the same ~1.025× ratio measured from the 0.8mm profile), so 3 perimeters need ~1.85mm. The prior **1.8mm** fell just short and could leave a partial-bead gap.

## Change

Bump the 0.6mm pad margin **1.8 → 1.9mm** so it clears 3 full perimeters. Updated the parametrized helper test.

Typecheck and lint clean; margin + geometry tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the 0.6mm nozzle magnet pad margin from 1.8mm to 1.9mm to clear three full perimeters and prevent partial-bead gaps around magnet holes. Mirrors the 0.8mm fix and updates the geometry test accordingly.

<sup>Written for commit f37d14b32067943300ebd175ade21971b05e32c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

