### PR TITLE
chore(ci): bump github/codeql-action to 4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,14 +29,14 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
Consolidates Dependabot #2575, #2576, #2577 into a single bump of `init`, `autobuild`, and `analyze` to v4.36.3.

CodeQL requires all three sub-actions on the same version; bumping them individually caused each PR to fail `Analyze` with `Loaded a configuration file for version '4.36.2', but running version '4.36.3'`. Merging together keeps the versions matched.

Closes #2575, closes #2576, closes #2577.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `github/codeql-action` to v4.36.3 and keeps all sub-actions in sync. Fixes CI Analyze step failures caused by a version mismatch.

- **Dependencies**
  - Bump `github/codeql-action/init`, `github/codeql-action/autobuild`, and `github/codeql-action/analyze` to v4.36.3.

<sup>Written for commit 79a6e8cef2d5adee2a5fa1020e0ae06721f0fcb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

