### PR TITLE
chore(deps): bump @liveblocks/* to 3.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,9 +106,9 @@
   ],
   "dependencies": {
     "@gridfinity/branded-types": "workspace:*",
-    "@liveblocks/client": "^3.21.0",
-    "@liveblocks/node": "^3.21.0",
-    "@liveblocks/react": "^3.21.0",
+    "@liveblocks/client": "^3.22.0",
+    "@liveblocks/node": "^3.22.0",
+    "@liveblocks/react": "^3.22.0",
     "@mediapipe/tasks-vision": "0.10.35",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,14 +41,14 @@ importers:
         specifier: workspace:*
         version: link:packages/branded-types
       '@liveblocks/client':
-        specifier: ^3.21.0
-        version: 3.21.0(@types/json-schema@7.0.15)
+        specifier: ^3.22.0
+        version: 3.22.0(@types/json-schema@7.0.15)
       '@liveblocks/node':
-        specifier: ^3.21.0
-        version: 3.21.0(@types/json-schema@7.0.15)
+        specifier: ^3.22.0
+        version: 3.22.0(@types/json-schema@7.0.15)
       '@liveblocks/react':
-        specifier: ^3.21.0
-        version: 3.21.0(@types/json-schema@7.0.15)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react@19.2.7)
+        specifier: ^3.22.0
+        version: 3.22.0(@types/json-schema@7.0.15)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react@19.2.7)
       '@mediapipe/tasks-vision':
         specifier: 0.10.35
         version: 0.10.35
@@ -1415,19 +1415,19 @@ packages:
   '@jscadui/3mf-export@0.5.0':
     resolution: {integrity: sha512-y5vZktqCjyi7wA38zqNlLIdZUIRZoOO9vCjLzwmL4bR0hk7B/Zm1IeffzJPFe1vFc0C1IEv3hm8caDv3doRk9g==}
 
-  '@liveblocks/client@3.21.0':
-    resolution: {integrity: sha512-dxPzW2OTXFtKWsbYpjR5N2qpVYtjEeFXYul0TRRtwKkwF161to+8in/6VCd7H3MtD0B0TvN6gM0yedjMhk98oQ==}
+  '@liveblocks/client@3.22.0':
+    resolution: {integrity: sha512-kKUMQjvyESFiut0DoKKu/IdfXoDIP7IfxkMcCBuJ46tIi0Li6qFLPPVmWgUbLHkGANK+KjMhDN1U74bty4t34w==}
 
-  '@liveblocks/core@3.21.0':
-    resolution: {integrity: sha512-3z1Lu5Kg0hQFxZWsAzp/qqmE+aSTV4ca67h7s5LsZPO3CRnEzpUSXiHtxpx8lVPj/ndXt7itikmFWsc8nCkw5g==}
+  '@liveblocks/core@3.22.0':
+    resolution: {integrity: sha512-w0bE14c67UfP+fR0waQB+Kxol3A+fbMsU/cceaAGVr/LiRIYi/wE76UbF+4716Hnglc+VhOBhyzAr9cFsgTlNA==}
     peerDependencies:
       '@types/json-schema': ^7
 
-  '@liveblocks/node@3.21.0':
-    resolution: {integrity: sha512-YGV014c6S5SrjOV7wAnSx1QKTyd0pyOpcKE8yohUuiy4LBCASHHAGeQI/iCU4XFHYCuQWqjx3yx6CFHoYohqwA==}
+  '@liveblocks/node@3.22.0':
+    resolution: {integrity: sha512-qYwKZTgz8/ZnSt9pbufv0er27L2OlxXfM0f7bmrjYlK4HodmDIGc5ytk9umSPh3FMGb81rr39XIqWSU0vSeX2g==}
 
-  '@liveblocks/react@3.21.0':
-    resolution: {integrity: sha512-yMipwcJIqjDyrcKMYyNbjiQDSmR7u/g34FQvp34VjimVBUshkowEI696K+GKrh7STmcTJdhA/cKs4lZuOiWPhg==}
+  '@liveblocks/react@3.22.0':
+    resolution: {integrity: sha512-ZUqtS66CSrSIofe8wlPITF1D7lVHEfnQTP1vFROhvSTi6ioF59O5TCVaMZ+hPVN1VD0gcG1kNASVwMp0LevCQg==}
     peerDependencies:
       '@types/react': ^18 || ^19
       '@types/react-dom': ^18 || ^19
@@ -7146,19 +7146,19 @@ snapshots:
 
   '@jscadui/3mf-export@0.5.0': {}
 
-  '@liveblocks/client@3.21.0(@types/json-schema@7.0.15)':
+  '@liveblocks/client@3.22.0(@types/json-schema@7.0.15)':
     dependencies:
-      '@liveblocks/core': 3.21.0(@types/json-schema@7.0.15)
+      '@liveblocks/core': 3.22.0(@types/json-schema@7.0.15)
     transitivePeerDependencies:
       - '@types/json-schema'
 
-  '@liveblocks/core@3.21.0(@types/json-schema@7.0.15)':
+  '@liveblocks/core@3.22.0(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@liveblocks/node@3.21.0(@types/json-schema@7.0.15)':
+  '@liveblocks/node@3.22.0(@types/json-schema@7.0.15)':
     dependencies:
-      '@liveblocks/core': 3.21.0(@types/json-schema@7.0.15)
+      '@liveblocks/core': 3.22.0(@types/json-schema@7.0.15)
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
       marked: 15.0.12
@@ -7167,10 +7167,10 @@ snapshots:
       - '@types/json-schema'
       - encoding
 
-  '@liveblocks/react@3.21.0(@types/json-schema@7.0.15)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react@19.2.7)':
+  '@liveblocks/react@3.22.0(@types/json-schema@7.0.15)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@liveblocks/client': 3.21.0(@types/json-schema@7.0.15)
-      '@liveblocks/core': 3.21.0(@types/json-schema@7.0.15)
+      '@liveblocks/client': 3.22.0(@types/json-schema@7.0.15)
+      '@liveblocks/core': 3.22.0(@types/json-schema@7.0.15)
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17


### PR DESCRIPTION
Consolidates Dependabot #2572, #2573, #2574 into a single bump of `@liveblocks/client`, `@liveblocks/react`, and `@liveblocks/node` to 3.22.0.

The `@liveblocks/*` packages share an internal `[kInternal]` type brand that must match exactly across packages. Bumping `client`/`react` alone broke the required Build check with `Property '[kInternal]' is missing in type 'Client<...>'` in `src/liveblocks.config.ts`. With all three on 3.22.0, typecheck passes locally.

Closes #2572, closes #2573, closes #2574.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade all `@liveblocks/*` deps to 3.22.0 to align internal types and restore passing builds. This prevents the `[kInternal]` brand mismatch that caused typecheck failures.

- **Dependencies**
  - Bumped `@liveblocks/client`, `@liveblocks/react`, and `@liveblocks/node` to 3.22.0.
  - Fixes TS error in `src/liveblocks.config.ts`: Property '[kInternal]' is missing in type 'Client<...>'.

<sup>Written for commit 661fe94154b390ec203029bc9bf0eb2409895d00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

