### PR TITLE
chore(ci): group coupled dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,11 @@ updates:
           - 'eslint-*'
           - 'typescript-eslint'
           - 'prettier'
+      # @liveblocks/* packages share an internal [kInternal] type brand that
+      # must match exactly across client/react/node, so bump them together.
+      liveblocks:
+        patterns:
+          - '@liveblocks/*'
     ignore:
       # Ignore major version updates for critical deps (review manually)
       - dependency-name: 'react'
@@ -68,11 +73,9 @@ updates:
       # minor/patch bump forces a fresh ~120MB browser download on the next
       # `playwright install`. Bump manually so the browser cache is stable.
       - dependency-name: 'playwright'
-        update-types:
-          ['version-update:semver-minor', 'version-update:semver-patch']
+        update-types: ['version-update:semver-minor', 'version-update:semver-patch']
       - dependency-name: '@playwright/*'
-        update-types:
-          ['version-update:semver-minor', 'version-update:semver-patch']
+        update-types: ['version-update:semver-minor', 'version-update:semver-patch']
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -87,3 +90,9 @@ updates:
     # Action tag-retag defense — see SECURITY.md.
     cooldown:
       default-days: 7
+    groups:
+      # codeql-action/{init,autobuild,analyze} must pin the same version or the
+      # Analyze job fails with a config version mismatch, so bump them together.
+      codeql-action:
+        patterns:
+          - 'github/codeql-action*'


### PR DESCRIPTION
Adds Dependabot `groups` so tightly-coupled dependencies are bumped in a single PR instead of one-per-package.

- **liveblocks** (npm): `@liveblocks/*` share an internal `[kInternal]` type brand that must match across `client`/`react`/`node`; splitting them broke the required Build typecheck (see #2580).
- **codeql-action** (github-actions): `init`/`autobuild`/`analyze` must pin the same version or the Analyze job fails with a config version mismatch (see #2579).

Both cases required manual consolidation this cycle; grouping prevents the repeat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group tightly coupled Dependabot updates so related packages bump together. Prevents CI/typecheck failures and cuts manual PR consolidation.

- **Dependencies**
  - `@liveblocks/*` (npm): added `liveblocks` group to bump packages together so the shared `[kInternal]` type brand stays in sync across `client`/`react`/`node`, avoiding build typecheck breaks.
  - `github/codeql-action*` (GitHub Actions): added `codeql-action` group so `init`/`autobuild`/`analyze` versions update together, preventing Analyze job config mismatches.

<sup>Written for commit 1f9984fdef7ccbce8fceaee30e3c532f623d1aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

