### PR TITLE
fix(bin-designer): keep cutout labels visible on narrow cutouts

### DIFF
--- a/src/shared/utils/cutoutLabel.test.ts
+++ b/src/shared/utils/cutoutLabel.test.ts
@@ -53,7 +53,8 @@ describe('cutoutLabelPlacement', () => {
     expect(p).not.toBeNull();
     expect(p?.centerX).toBeCloseTo(50); // (40+60)/2
     expect(p?.centerY).toBeCloseTo(75); // (50 + 100)/2
-    expect(p?.availW).toBeCloseTo(20); // cutout width
+    // Spanned axis grows symmetrically into the interior: 2·min(50, 100-50).
+    expect(p?.availW).toBeCloseTo(100);
     expect(p?.availD).toBeCloseTo(50); // 100 - 50
   });
 
@@ -69,7 +70,8 @@ describe('cutoutLabelPlacement', () => {
     expect(p?.centerX).toBeCloseTo(20); // (0 + 40)/2
     expect(p?.centerY).toBeCloseTo(45); // (40 + 50)/2
     expect(p?.availW).toBeCloseTo(40);
-    expect(p?.availD).toBeCloseTo(10); // cutout depth
+    // Spanned axis grows into the interior: 2·min(45, 100-45).
+    expect(p?.availD).toBeCloseTo(90);
   });
 
   it('places a right label in the gap to the right', () => {
@@ -110,8 +112,29 @@ describe('cutoutLabelPlacement', () => {
     const p = cutoutLabelPlacement({ ...base, textAnchor: 'center' }, W, D);
     expect(p?.centerX).toBeCloseTo(50);
     expect(p?.centerY).toBeCloseTo(45);
-    expect(p?.availW).toBeCloseTo(20); // cutout width
-    expect(p?.availD).toBeCloseTo(10); // cutout depth
+    // Both axes are spanned, so both grow symmetrically into the interior.
+    expect(p?.availW).toBeCloseTo(100); // 2·min(50, 100-50)
+    expect(p?.availD).toBeCloseTo(90); // 2·min(45, 100-45)
+  });
+
+  it('gives a narrow cutout a band far wider than its own width (#2583)', () => {
+    // A 7.5mm-wide cutout centered in the interior used to cap the label to
+    // 7.5mm, dropping it below the legibility floor. The band now spans the
+    // room around the center instead of the cutout footprint.
+    const narrow = { ...base, x: 50 - 3.75, width: 7.5, textSide: 'top' as const };
+    const p = cutoutLabelPlacement(narrow, W, D);
+    expect(p?.centerX).toBeCloseTo(50);
+    expect(p?.availW).toBeCloseTo(100); // 2·min(50, 100-50), not 7.5
+    expect(p?.availW ?? 0).toBeGreaterThan(7.5);
+  });
+
+  it('keeps the band symmetric when the cutout hugs an interior edge', () => {
+    // Cutout centered near the left wall: the band can only borrow the smaller
+    // side so it never crosses the interior edge.
+    const nearEdge = { ...base, x: 0, width: 8, textSide: 'top' as const };
+    const p = cutoutLabelPlacement(nearEdge, W, D);
+    expect(p?.centerX).toBeCloseTo(4); // (0 + 8)/2
+    expect(p?.availW).toBeCloseTo(8); // 2·min(4, 100-4)
   });
 
   it('on-face center always has room even flush against a wall', () => {

--- a/src/shared/utils/cutoutLabel.test.ts
+++ b/src/shared/utils/cutoutLabel.test.ts
@@ -62,6 +62,8 @@ describe('cutoutLabelPlacement', () => {
     const p = cutoutLabelPlacement({ ...base, textSide: 'bottom' }, W, D);
     expect(p?.centerX).toBeCloseTo(50);
     expect(p?.centerY).toBeCloseTo(20); // (0 + 40)/2
+    // Spanned axis grows symmetrically into the interior: 2·min(50, 100-50).
+    expect(p?.availW).toBeCloseTo(100);
     expect(p?.availD).toBeCloseTo(40);
   });
 
@@ -78,6 +80,8 @@ describe('cutoutLabelPlacement', () => {
     const p = cutoutLabelPlacement({ ...base, textSide: 'right' }, W, D);
     expect(p?.centerX).toBeCloseTo(80); // (60 + 100)/2
     expect(p?.availW).toBeCloseTo(40); // 100 - 60
+    // Spanned axis grows symmetrically into the interior: 2·min(45, 100-45).
+    expect(p?.availD).toBeCloseTo(90);
   });
 
   it('defaults to the top side when textSide is missing', () => {

--- a/src/shared/utils/cutoutLabel.ts
+++ b/src/shared/utils/cutoutLabel.ts
@@ -114,8 +114,16 @@ function axisBand(zone: Zone, lo: number, hi: number, iLo: number, iHi: number) 
       return { avail: lo - iLo, center: (iLo + lo) / 2 };
     case 'high':
       return { avail: iHi - hi, center: (hi + iHi) / 2 };
-    case 'center':
-      return { avail: hi - lo, center: (lo + hi) / 2 };
+    case 'center': {
+      // A label centered on the cutout may extend past the cutout's own span
+      // into the surrounding interior, kept symmetric about the center so it
+      // never crosses an interior edge. Capping to `hi - lo` starved narrow
+      // cutouts: the auto-fit font fell below the legibility floor and the
+      // label was silently dropped from both the editor and the engraving
+      // (#2583). The label overflowing a neighboring cutout is accepted.
+      const center = (lo + hi) / 2;
+      return { avail: 2 * Math.min(center - iLo, iHi - center), center };
+    }
   }
 }
 
@@ -123,9 +131,12 @@ function axisBand(zone: Zone, lo: number, hi: number, iLo: number, iHi: number) 
  * Where a cutout's engraved label sits, and how much room it has, for the
  * resolved 9-point anchor (see {@link resolveCutoutTextAnchor}). The eight
  * outer anchors land in the gap between the cutout's rotation-aware AABB and the
- * bin interior; `center` sits over the cutout footprint itself. A `textOffset`
- * then nudges the center freely (and may push it past the band — by design, for
- * fine-tuning and drag).
+ * bin interior; `center` sits over the cutout footprint itself. On the axis a
+ * label spans (X for top/bottom, Y for left/right, both for center) the band is
+ * not clamped to the cutout's own span — it grows symmetrically into the
+ * interior so a narrow cutout can't shrink the label below the legibility floor
+ * and drop it (#2583). A `textOffset` then nudges the center freely (and may
+ * push it past the band — by design, for fine-tuning and drag).
  *
  * The anchor is interpreted in WORLD coordinates (top = +Y, right = +X, …); the
  * label text reads left-to-right regardless of cutout rotation, so `availW` is


### PR DESCRIPTION
## What

Custom cut-out labels vanished after a couple of characters on narrow cutouts (issue #2583). Now the label stays visible and extends beyond the cutout's edges, matching what actually gets engraved.

## Why it happened

The label's auto-fit band was capped to the cutout's **own span** on the axis the text runs along. On a narrow cutout (the reporter's 7.5mm example), a few characters forced the auto-fit font below the 3mm legibility floor, so the label was dropped entirely. That drop was intentional (illegibly-tiny text is skipped rather than shrunk), but the width constraint was wrong: a `top`-anchored label sits in the empty band *above* the cutout, where there is far more room than the cutout's own width.

The 2D editor preview and the generation worker share one placement helper (`cutoutLabelPlacement`), so the label was correctly hidden in the editor because it genuinely would not have engraved either.

## The fix

For the axis a label spans (X for top/bottom, Y for left/right, both for center), the band now grows **symmetrically into the surrounding interior** instead of being capped to the cutout footprint. Symmetric growth keeps the label centered on its cutout and guarantees it never crosses the bin interior edge; near a wall it self-limits to the smaller side.

Because the change lives in the shared helper, the editor preview and the engraved output stay in lockstep: the label that now shows is the label that now prints. A label may visually overlap a neighboring cutout, which was the accepted trade-off.

## Tests

- Updated `cutoutLabel` placement tests for the widened center-axis bands.
- Added regression tests: a narrow cutout now gets a band far wider than its own width, and a cutout hugging an interior edge stays symmetric.
- `pnpm run typecheck` clean; helper + label-renderer + fit-font tests green.

Closes #2583

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disappearing cutout labels on narrow cutouts by letting the label band extend symmetrically into the interior along the spanned axis. Labels now stay visible in the editor and on the engraving (fixes #2583).

- **Bug Fixes**
  - Grow the spanned-axis band beyond the cutout while staying centered; never cross the interior edge and self-limit near walls.
  - Use the shared `cutoutLabelPlacement` so preview and engraving match.
  - Update placement tests to verify widened bands for top/bottom/left/right and center; add regressions for narrow and near-edge cases.

<sup>Written for commit 1df46575e4ce9173f802ce78f543a78ccf851598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

