### PR TITLE
fix(sidebar): make baseplate, drawer shape, and stack solver match the sidebar

### DIFF
--- a/src/features/baseplate/components/ActiveBaseplatePanel/ActiveBaseplatePanel.tsx
+++ b/src/features/baseplate/components/ActiveBaseplatePanel/ActiveBaseplatePanel.tsx
@@ -1,14 +1,16 @@
 /**
- * Compact "Active baseplate" switcher for the planner sidebar.
+ * Compact "Baseplate" switcher for the planner sidebar: a Select bound to the
+ * global baseplate library plus a "Manage…" affordance that opens the library
+ * modal.
  *
- * Mirrors the ActiveLayerPanel slot: a Select bound to the global baseplate
- * library plus a "Manage…" affordance that opens the library modal.
+ * Built on `Collapsible size="md"` with the manage button in `actions` so this
+ * slot reads as a peer of Layers and Categories rather than a lone label.
  */
 
 import { useCallback } from 'react';
 import { useViewStore } from '@/core/store/view';
 import { useTranslation } from '@/i18n';
-import { Button, Select } from '@/design-system';
+import { Button, Collapsible, Select } from '@/design-system';
 import { baseplateDesignId } from '@/core/types';
 import { useBaseplateLibrary } from '@/features/baseplate/hooks/useBaseplateLibrary';
 
@@ -26,29 +28,29 @@ export function ActiveBaseplatePanel() {
     [activeBaseplateId, switchActive]
   );
 
+  const manageButton = (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={() => setShowBaseplateLibrary(true)}
+      className="text-xs text-content-tertiary hover:text-content"
+    >
+      {t('baseplate.library.manage')}
+    </Button>
+  );
+
   return (
-    <div className="px-4 py-3">
-      <div className="mb-1.5 text-xs font-medium uppercase tracking-wide text-content-tertiary">
-        {t('baseplate.library.activeLabel')}
-      </div>
-      <div className="flex items-center gap-2">
-        <Select
-          value={activeBaseplateId ?? ''}
-          onValueChange={handleChange}
-          options={list.map((ref) => ({ id: ref.id, name: ref.name }))}
-          placeholder={t('baseplate.library.draftName')}
-          aria-label={t('baseplate.library.selectLabel')}
-          size="sm"
-          className="flex-1 text-sm"
-        />
-        <Button
-          variant="secondary"
-          onClick={() => setShowBaseplateLibrary(true)}
-          className="shrink-0 px-2.5 py-1.5 text-sm"
-        >
-          {t('baseplate.library.manage')}
-        </Button>
-      </div>
-    </div>
+    <Collapsible title={t('baseplate.title')} size="md" actions={manageButton}>
+      <Select
+        value={activeBaseplateId ?? ''}
+        onValueChange={handleChange}
+        options={list.map((ref) => ({ id: ref.id, name: ref.name }))}
+        placeholder={t('baseplate.library.draftName')}
+        aria-label={t('baseplate.library.selectLabel')}
+        size="sm"
+        fullWidth
+        className="text-sm"
+      />
+    </Collapsible>
   );
 }

--- a/src/features/drawer-shape/README.md
+++ b/src/features/drawer-shape/README.md
@@ -8,8 +8,12 @@ hatching, baseplate generation/splitting) derives from it.
 
 ## Key Files
 
-- `components/DrawerShapeSection` — Sidebar `FeatureToggle` entry: toggle
-  on opens the editor; toggle off resets to a rectangle after a confirm.
+- `components/DrawerShapeSection` — Sidebar entry: toggle on opens the editor;
+  toggle off resets to a rectangle after a confirm. Uses the shared
+  `ToggleRow` (a `Checkbox`), **not** `FeatureToggle` — the sidebar's boolean
+  rows are checkboxes, and this sits directly under Half-grid mode. Corner
+  cuts stay reachable with no outline: they build one from the plain
+  rectangle. Takes `variant` so the mobile settings sheet gets `lg` hit areas.
 - `components/ShapeEditorDialog` — cell-paint editor. Whole drawer cells
   (plus the fractional-edge cell of an x.5 drawer) toggle in/out; drag paints
   with the state of the first cell touched via ONE container pointer handler

--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.test.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.test.tsx
@@ -59,6 +59,16 @@ describe('DrawerShapeSection', () => {
     expect(screen.getByRole('button', { name: 'drawerShape.corners.open' })).toBeInTheDocument();
   });
 
+  it('gives the mobile variant a 44px action touch target', () => {
+    render(<DrawerShapeSection variant="mobile" />);
+    expect(screen.getByRole('button', { name: 'drawerShape.corners.open' })).toHaveClass('h-11');
+  });
+
+  it('keeps the compact action height on desktop', () => {
+    render(<DrawerShapeSection />);
+    expect(screen.getByRole('button', { name: 'drawerShape.corners.open' })).toHaveClass('h-8');
+  });
+
   it('confirms before resetting an existing shape', () => {
     useLayoutStore.setState((s) => ({
       layout: { ...s.layout, drawer: { ...s.layout.drawer, outline: L_OUTLINE } },

--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.test.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.test.tsx
@@ -35,13 +35,28 @@ describe('DrawerShapeSection', () => {
 
   it('shows the toggle unchecked for rectangular drawers', () => {
     render(<DrawerShapeSection />);
-    expect(screen.getByRole('switch', { name: 'drawerShape.toggle' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'drawerShape.toggle' })).not.toBeChecked();
   });
 
   it('opens the editor when toggling on', () => {
     render(<DrawerShapeSection />);
-    fireEvent.click(screen.getByRole('switch', { name: 'drawerShape.toggle' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'drawerShape.toggle' }));
     expect(screen.getByText('drawerShape.editor.title')).toBeInTheDocument();
+  });
+
+  it('offers corner cuts even with no outline drawn', () => {
+    render(<DrawerShapeSection />);
+    expect(screen.getByRole('button', { name: 'drawerShape.corners.open' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'drawerShape.edit' })).not.toBeInTheDocument();
+  });
+
+  it('offers editing the shape once an outline exists', () => {
+    useLayoutStore.setState((s) => ({
+      layout: { ...s.layout, drawer: { ...s.layout.drawer, outline: L_OUTLINE } },
+    }));
+    render(<DrawerShapeSection />);
+    expect(screen.getByRole('button', { name: 'drawerShape.edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'drawerShape.corners.open' })).toBeInTheDocument();
   });
 
   it('confirms before resetting an existing shape', () => {
@@ -49,7 +64,7 @@ describe('DrawerShapeSection', () => {
       layout: { ...s.layout, drawer: { ...s.layout.drawer, outline: L_OUTLINE } },
     }));
     render(<DrawerShapeSection />);
-    const toggle = screen.getByRole('switch', { name: 'drawerShape.toggle' });
+    const toggle = screen.getByRole('checkbox', { name: 'drawerShape.toggle' });
     expect(toggle).toBeChecked();
     fireEvent.click(toggle);
     expect(screen.getByText('drawerShape.resetConfirmTitle')).toBeInTheDocument();

--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
@@ -1,21 +1,28 @@
 import { useCallback, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { Button } from '@/design-system';
-import { ConfirmDialog } from '@/shared/components';
-import { FeatureToggle } from '@/shared/components/FeatureToggle/FeatureToggle';
+import { ConfirmDialog, ToggleRow } from '@/shared/components';
 import { useLayoutStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
 import { useMutations } from '@/shared/contexts/MutationsContext';
 import { ShapeEditorDialog } from '../ShapeEditorDialog/ShapeEditorDialog';
 import { CornerCutsDialog } from '../CornerCutsDialog/CornerCutsDialog';
 
+interface DrawerShapeSectionProps {
+  /** Platform variant, forwarded to the toggle row's sizing. */
+  variant?: 'desktop' | 'mobile';
+}
+
 /**
  * Sidebar entry for non-rectangular drawers (issue #2528). The toggle reflects
  * whether an outline exists; enabling opens the cell-paint editor, disabling
  * clears the shape (with a confirm — clearing displaces nothing but discards
  * drawn geometry).
+ *
+ * Corner cuts stay reachable whether or not a custom shape exists: they're a
+ * shortcut that *creates* an outline from the plain rectangle.
  */
-export function DrawerShapeSection() {
+export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionProps = {}) {
   const t = useTranslation();
   const mutations = useMutations();
   const { hasOutline } = useLayoutStore(
@@ -38,41 +45,39 @@ export function DrawerShapeSection() {
   }, [mutations]);
 
   return (
-    <div className="border-t border-stroke-subtle pt-2" data-help-target="drawer-shape">
-      <FeatureToggle
+    <>
+      <ToggleRow
         label={t('drawerShape.toggle')}
         checked={hasOutline}
         onChange={handleToggle}
-        primaryControls={
-          hasOutline ? (
-            <div className="flex gap-1.5">
-              <Button
-                variant="secondary"
-                size="sm"
-                type="button"
-                onClick={() => setEditorOpen(true)}
-              >
-                {t('drawerShape.edit')}
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                type="button"
-                onClick={() => setCornersOpen(true)}
-              >
-                {t('drawerShape.corners.open')}
-              </Button>
-            </div>
-          ) : undefined
-        }
+        helpTarget="drawer-shape"
+        variant={variant}
       />
-      {!hasOutline && (
-        <div className="pl-6 pt-1">
-          <Button variant="ghost" size="sm" type="button" onClick={() => setCornersOpen(true)}>
-            {t('drawerShape.corners.open')}
+      {/* Full-width action buttons, matching the ActiveLayerPanel toolbar rather
+          than floating a lone ghost link. Corner cuts stay available with no
+          outline — they build one from the plain rectangle. */}
+      <div className="flex gap-1.5 pt-2">
+        <Button
+          variant="secondary"
+          fullWidth
+          type="button"
+          onClick={() => setCornersOpen(true)}
+          className="text-xs h-8"
+        >
+          {t('drawerShape.corners.open')}
+        </Button>
+        {hasOutline && (
+          <Button
+            variant="secondary"
+            fullWidth
+            type="button"
+            onClick={() => setEditorOpen(true)}
+            className="text-xs h-8"
+          >
+            {t('drawerShape.edit')}
           </Button>
-        </div>
-      )}
+        )}
+      </div>
       <ShapeEditorDialog open={editorOpen} onClose={() => setEditorOpen(false)} />
       <CornerCutsDialog open={cornersOpen} onClose={() => setCornersOpen(false)} />
       <ConfirmDialog
@@ -84,6 +89,6 @@ export function DrawerShapeSection() {
         onConfirm={handleReset}
         onCancel={() => setConfirmReset(false)}
       />
-    </div>
+    </>
   );
 }

--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
@@ -44,6 +44,9 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
     mutations.setDrawerOutline(null);
   }, [mutations]);
 
+  // 44px on mobile to match the touch target the rest of the settings sheet uses.
+  const actionClass = variant === 'mobile' ? 'text-sm h-11' : 'text-xs h-8';
+
   return (
     <>
       <ToggleRow
@@ -62,7 +65,7 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
           fullWidth
           type="button"
           onClick={() => setCornersOpen(true)}
-          className="text-xs h-8"
+          className={actionClass}
         >
           {t('drawerShape.corners.open')}
         </Button>
@@ -72,7 +75,7 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
             fullWidth
             type="button"
             onClick={() => setEditorOpen(true)}
-            className="text-xs h-8"
+            className={actionClass}
           >
             {t('drawerShape.edit')}
           </Button>

--- a/src/shared/components/HeightUnitSolver/HeightUnitSolver.tsx
+++ b/src/shared/components/HeightUnitSolver/HeightUnitSolver.tsx
@@ -3,6 +3,8 @@ import { CONSTRAINTS } from '@/core/constants';
 import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { solveHeightUnitMm, stackedTotalMm, STACK_LIP_MM } from '@/shared/utils/heightUnits';
+// Relative, not via the '@/shared/components' barrel — this file is inside it.
+import { SettingsRow } from '../SettingsRow';
 
 interface HeightUnitSolverProps {
   /** Current height unit in mm — the value Apply overwrites. */
@@ -53,17 +55,16 @@ export function HeightUnitSolver({
     variant === 'mobile'
       ? 'input w-20 h-10 text-center'
       : 'input w-14 py-0.5 px-1 text-xs text-right';
-  const labelClass = 'text-content-secondary';
 
+  // Raw inputs rather than DeferredNumberInput: the solve previews live as you
+  // type, and `target` starts empty (no suggestion until asked), neither of
+  // which a commit-on-blur numeric input can express.
   return (
     <div className="space-y-2 text-xs">
       <p className="text-content-tertiary">
         {t('stackSolver.description', { lip: round2(STACK_LIP_MM) })}
       </p>
-      <div className="flex items-center justify-between gap-2">
-        <label htmlFor={`${uid}-target`} className={labelClass}>
-          {t('stackSolver.targetLabel')}
-        </label>
+      <SettingsRow label={t('stackSolver.targetLabel')} htmlFor={`${uid}-target`} variant={variant}>
         <input
           id={`${uid}-target`}
           type="number"
@@ -75,11 +76,8 @@ export function HeightUnitSolver({
           className={inputClass}
           aria-label={t('stackSolver.targetLabel')}
         />
-      </div>
-      <div className="flex items-center justify-between gap-2">
-        <label htmlFor={`${uid}-bins`} className={labelClass}>
-          {t('stackSolver.binsLabel')}
-        </label>
+      </SettingsRow>
+      <SettingsRow label={t('stackSolver.binsLabel')} htmlFor={`${uid}-bins`} variant={variant}>
         <input
           id={`${uid}-bins`}
           type="number"
@@ -90,11 +88,12 @@ export function HeightUnitSolver({
           className={inputClass}
           aria-label={t('stackSolver.binsLabel')}
         />
-      </div>
-      <div className="flex items-center justify-between gap-2">
-        <label htmlFor={`${uid}-units`} className={labelClass}>
-          {t('stackSolver.unitsPerBinLabel')}
-        </label>
+      </SettingsRow>
+      <SettingsRow
+        label={t('stackSolver.unitsPerBinLabel')}
+        htmlFor={`${uid}-units`}
+        variant={variant}
+      >
         <input
           id={`${uid}-units`}
           type="number"
@@ -105,7 +104,7 @@ export function HeightUnitSolver({
           className={inputClass}
           aria-label={t('stackSolver.unitsPerBinLabel')}
         />
-      </div>
+      </SettingsRow>
 
       {suggested !== null && (
         <div className="space-y-1 pt-1">

--- a/src/shared/components/ToggleRow/ToggleRow.test.tsx
+++ b/src/shared/components/ToggleRow/ToggleRow.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToggleRow } from './ToggleRow';
+
+describe('ToggleRow', () => {
+  it('exposes the label as an accessible checkbox', () => {
+    render(<ToggleRow label="Half-grid mode" checked={false} onChange={vi.fn()} />);
+    expect(screen.getByRole('checkbox', { name: 'Half-grid mode' })).not.toBeChecked();
+  });
+
+  it('reflects the checked state', () => {
+    render(<ToggleRow label="Half-grid mode" checked onChange={vi.fn()} />);
+    expect(screen.getByRole('checkbox', { name: 'Half-grid mode' })).toBeChecked();
+  });
+
+  it('prefers ariaLabel over label for the accessible name', () => {
+    render(
+      <ToggleRow
+        label="Half-grid mode"
+        ariaLabel="Toggle half-grid mode"
+        checked
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('checkbox', { name: 'Toggle half-grid mode' })).toBeInTheDocument();
+    expect(screen.getByText('Half-grid mode')).toBeInTheDocument();
+  });
+
+  it('fires onChange when the row is clicked', () => {
+    const onChange = vi.fn();
+    render(<ToggleRow label="Custom drawer shape" checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([' ', 'Enter'])('fires onChange on %s key', (key) => {
+    const onChange = vi.fn();
+    render(<ToggleRow label="Custom drawer shape" checked={false} onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('checkbox'), { key });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unrelated keys', () => {
+    const onChange = vi.fn();
+    render(<ToggleRow label="Custom drawer shape" checked={false} onChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('checkbox'), { key: 'Tab' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('renders the shortcut hint when given', () => {
+    render(<ToggleRow label="Half-grid mode" checked={false} onChange={vi.fn()} shortcut="H" />);
+    expect(screen.getByText('H')).toBeInTheDocument();
+  });
+
+  it('omits the shortcut hint by default', () => {
+    render(<ToggleRow label="Custom drawer shape" checked={false} onChange={vi.fn()} />);
+    expect(screen.queryByText('H')).not.toBeInTheDocument();
+  });
+
+  it('applies the help target to the row so deep-link pulses land on it', () => {
+    const { container } = render(
+      <ToggleRow
+        label="Half-grid mode"
+        checked={false}
+        onChange={vi.fn()}
+        helpTarget="half-bin-mode"
+      />
+    );
+    expect(container.querySelector('[data-help-target="half-bin-mode"]')).toHaveAttribute(
+      'role',
+      'checkbox'
+    );
+  });
+});

--- a/src/shared/components/ToggleRow/ToggleRow.tsx
+++ b/src/shared/components/ToggleRow/ToggleRow.tsx
@@ -1,0 +1,75 @@
+import { Checkbox } from '@/design-system';
+
+interface ToggleRowProps {
+  /** Label text displayed on the left. */
+  label: string;
+  /** Whether the toggle is on. */
+  checked: boolean;
+  /** Called when the row is clicked or activated via keyboard. */
+  onChange: () => void;
+  /** Optional tooltip shown on hover over the label. */
+  tooltip?: string;
+  /** Optional keyboard hint rendered as a <kbd> next to the label (e.g. "H"). */
+  shortcut?: string;
+  /** Accessible name; falls back to `label`. */
+  ariaLabel?: string;
+  /** Help-modal deep-link target, applied to the row itself so the pulse lands on it. */
+  helpTarget?: string;
+  /** Platform variant affects text size and checkbox hit area. */
+  variant?: 'desktop' | 'mobile';
+}
+
+/**
+ * Sidebar boolean row: label on the left, Checkbox on the right, whole row
+ * clickable.
+ *
+ * The sidebar deliberately uses checkboxes rather than the Settings modal's
+ * FeatureToggle pill — the column is 288px wide and a pill is 28px tall per
+ * row. Reach for this instead of hand-rolling the row so every sidebar boolean
+ * shares one keyboard and ARIA implementation.
+ */
+export function ToggleRow({
+  label,
+  checked,
+  onChange,
+  tooltip,
+  shortcut,
+  ariaLabel,
+  helpTarget,
+  variant = 'desktop',
+}: ToggleRowProps) {
+  const isMobile = variant === 'mobile';
+
+  return (
+    <div
+      data-help-target={helpTarget}
+      className={`flex items-center justify-between cursor-pointer ${isMobile ? 'py-2 text-sm' : 'pt-2'}`}
+      onClick={onChange}
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={ariaLabel ?? label}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault();
+          onChange();
+        }
+      }}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          className={`leading-none ${checked ? 'text-content' : 'text-content-tertiary'}`}
+          title={tooltip}
+        >
+          {label}
+        </span>
+        {shortcut && (
+          <kbd className="text-[9px] leading-none text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">
+            {shortcut}
+          </kbd>
+        )}
+      </div>
+      <Checkbox checked={checked} size={isMobile ? 'lg' : 'md'} />
+    </div>
+  );
+}

--- a/src/shared/components/ToggleRow/index.ts
+++ b/src/shared/components/ToggleRow/index.ts
@@ -1,0 +1,1 @@
+export { ToggleRow } from './ToggleRow';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -14,6 +14,7 @@ export { LoadingFallback } from './LoadingFallback';
 // Layout primitives
 export { SectionHeader } from './SectionHeader';
 export { SettingsRow } from './SettingsRow';
+export { ToggleRow } from './ToggleRow';
 export { BulkIncrementControl } from './BulkIncrementControl';
 export { ToolSwitcher } from './ToolSwitcher';
 export { ViewModeToggle } from './ViewModeToggle';

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -177,7 +177,7 @@ export function MobileSettingsPanel() {
         </div>
 
         {/* Non-rectangular drawer shape (issue #2528) */}
-        <DrawerShapeSection />
+        <DrawerShapeSection variant="mobile" />
       </section>
 
       {/* Grid Settings */}

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -4,7 +4,7 @@ import { useViewStore } from '@/core/store/view';
 import { useDrawerSettings } from '@/shared/hooks/useDrawerSettings';
 import { DrawerShapeSection } from '@/features/drawer-shape';
 import { CONSTRAINTS } from '@/core/constants';
-import { Button, Checkbox, Collapsible, IconButton, Stepper } from '@/design-system';
+import { Button, Collapsible, IconButton, Stepper } from '@/design-system';
 import { RulerIcon } from '@/design-system/Icon';
 import type { SettingsTabId } from '@/shell/Modals/SettingsModal/types';
 import { ActiveLayerPanel } from '@/features/layers/components/ActiveLayerPanel';
@@ -18,6 +18,7 @@ import { LoadingFallback } from '@/shared/components/LoadingFallback';
 import { useResponsive } from '@/shared/hooks';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { SettingsRow } from '@/shared/components/SettingsRow';
+import { ToggleRow } from '@/shared/components/ToggleRow';
 import { HeightUnitSolver } from '@/shared/components/HeightUnitSolver';
 import { FractionalEdgeToggle } from '@/shared/components/FractionalEdgeToggle';
 import { UserDock } from '@/shared/components/UserDock';
@@ -398,34 +399,15 @@ export function Sidebar() {
                   </div>
 
                   {/* Half-bin mode toggle */}
-                  <div
-                    data-help-target="half-bin-mode"
-                    className="flex items-center justify-between pt-2 cursor-pointer"
-                    onClick={handleHalfBinToggle}
-                    role="checkbox"
-                    aria-checked={halfGridMode}
-                    aria-label={t('sidebar.toggleHalfBinMode')}
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                      if (e.key === ' ' || e.key === 'Enter') {
-                        e.preventDefault();
-                        handleHalfBinToggle();
-                      }
-                    }}
-                  >
-                    <div className="flex items-center gap-1.5">
-                      <span
-                        className={`leading-none ${halfGridMode ? 'text-content' : 'text-content-tertiary'}`}
-                        title={t('sidebar.halfBinTooltip')}
-                      >
-                        {t('sidebar.halfBinMode')}
-                      </span>
-                      <kbd className="text-[9px] leading-none text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">
-                        H
-                      </kbd>
-                    </div>
-                    <Checkbox checked={halfGridMode} size="md" />
-                  </div>
+                  <ToggleRow
+                    label={t('sidebar.halfBinMode')}
+                    checked={halfGridMode}
+                    onChange={handleHalfBinToggle}
+                    tooltip={t('sidebar.halfBinTooltip')}
+                    shortcut="H"
+                    ariaLabel={t('sidebar.toggleHalfBinMode')}
+                    helpTarget="half-bin-mode"
+                  />
 
                   {/* Fractional edge position toggles - only shown when dimensions are fractional */}
                   {(hasFractionalWidth || hasFractionalDepth) && (
@@ -543,11 +525,12 @@ export function Sidebar() {
                   >
                     {t('settings.resetGridfinityStandard')}
                   </Button>
+                  {/* Occasional-use calculator — nested `size="sm"` section,
+                      collapsed by default so it costs nothing until asked for. */}
                   <div className="pt-2 mt-1 border-t border-stroke-subtle">
-                    <div className="text-[11px] font-medium text-content-secondary mb-1.5">
-                      {t('stackSolver.title')}
-                    </div>
-                    <HeightUnitSolver heightUnitMm={heightUnitMm} onApply={setHeightUnitMm} />
+                    <Collapsible title={t('stackSolver.title')} size="sm" defaultExpanded={false}>
+                      <HeightUnitSolver heightUnitMm={heightUnitMm} onApply={setHeightUnitMm} />
+                    </Collapsible>
                   </div>
                 </div>
               </Collapsible>


### PR DESCRIPTION
The Active baseplate, Custom drawer shape, and Fit unit to stack sections each looked out of place next to the panels around them. Each had opted out of the sidebar's established patterns in a different direction, leaving **four heading tiers and two different controls for the same boolean** in a 288px column.

## What changed

| Section | Before | After |
| --- | --- | --- |
| Active baseplate | Bare uppercase micro-label, no chevron, inline "Manage…" | `Collapsible size="md"` with Manage in `actions` — a peer of Layers/Categories |
| Custom drawer shape | `FeatureToggle` pill directly below Half-grid mode's checkbox | Shared `ToggleRow` checkbox; actions are full-width buttons |
| Fit unit to stack | Inline `text-[11px]` heading, always expanded, brighter labels | Nested `size="sm"` section, collapsed by default, `SettingsRow` rows |

Headings now resolve to the two tiers the design system already defines: `size="md"` for sections, `size="sm"` for nested ones. No new heading styles, no new i18n keys.

## Notable details

- **`ToggleRow` is new** (`src/shared/components/ToggleRow`). Half-grid mode previously hand-rolled a `role="checkbox"` div with its own keyboard handling; rather than copy that into the drawer-shape section, both now share one implementation. It takes `variant` so the mobile settings sheet keeps `lg` hit areas.
- **Label brightness was a real bug.** `HeightUnitSolver` set its own `labelClass = 'text-content-secondary'`, so "Target height (mm)" rendered a step brighter than "Grid unit" 40px above it. `SettingsRow` (already used by its neighbours) fixes it.
- **The solver's inputs stay raw**, not `DeferredNumberInput`: the solve previews live as you type and `target` starts empty, neither of which a commit-on-blur numeric input can express. That hand-rolling was justified; the row structure wasn't.
- **Corner cuts are now always reachable.** Previously they were a `pl-6` ghost link aligned to nothing when no outline existed. They build an outline from the plain rectangle, so they belong at both states.
- Drops the only intra-section divider in the sidebar, and reclaims ~120px by collapsing the solver.

## Verification

- `pnpm run typecheck`, `pnpm run quality` (0 errors, knip clean), 197 tests across the affected trees.
- Playwright spot check at 1400×1000 desktop and 390×844 mobile. Caught one real bug in the process: `Select`'s wrapper is `inline-flex`, so it needs `fullWidth` rather than a `w-full` class — otherwise it collapses to content width once it's no longer inside a `flex-1` parent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Baseplate, Drawer Shape, and Stack Solver with the sidebar’s patterns to improve consistency, accessibility, and save space. Introduces a shared checkbox row (`ToggleRow`) and standardizes headers and row styles.

- **Refactors**
  - Baseplate: `Collapsible size="md"` with Manage in `actions`; Select uses `fullWidth`.
  - Drawer Shape: replace `FeatureToggle` with `ToggleRow`; actions are full-width buttons; corner cuts always available; supports `variant="mobile"` with 44px touch targets; removes the extra divider.
  - Stack Solver: rows use `SettingsRow`; moved into a nested `Collapsible size="sm"` collapsed by default; keeps raw inputs for live previews.
  - Sidebar: Half-bin mode now uses `ToggleRow`.
  - Added `src/shared/components/ToggleRow` with tests; updated Drawer Shape tests to use `role="checkbox"`.

- **Bug Fixes**
  - Fixed label brightness in the solver by using `SettingsRow`.
  - Prevented Select width collapse by switching to `fullWidth`.

<sup>Written for commit 763e2d59fc0257521a5340772713d5eb078cf857. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

