### PR TITLE
fix(baseplate): flatten the generator header to match the designer

### DIFF
--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -243,7 +243,7 @@ export function BaseplatePage() {
             variant="ghost"
             onClick={() => setExportDialogOpen(true)}
             disabled={!canExport || isExporting}
-            className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm font-normal text-content-secondary transition-all bg-transparent hover:bg-surface-hover hover:text-content disabled:opacity-50 disabled:pointer-events-none"
+            className="flex h-8 items-center gap-1.5 px-2 text-sm font-normal text-content-secondary hover:text-content"
             title={t('common.export')}
             aria-label={t('common.export')}
           >

--- a/src/features/baseplate/components/BaseplateSelector/BaseplateSelector.tsx
+++ b/src/features/baseplate/components/BaseplateSelector/BaseplateSelector.tsx
@@ -5,8 +5,9 @@
  *
  * Header vocabulary: the Select is the only bordered control (it's an input);
  * every action beside it is a flat ghost button, matching Export and the
- * DesignerHeader cluster next door. Save on an unsaved draft is the one
- * exception — it's the primary action, so it keeps its fill.
+ * DesignerHeader cluster next door. The one filled button is the confirm inside
+ * the naming form — a form submit, not a resting header action, and it can't
+ * collide with the Ko-fi CTA because the cluster is replaced while naming.
  * - New starts a fresh unsaved draft (pointer null, default params).
  * - Save on a draft prompts a name, persists it to the library, and points the
  *   layout at the new design. When a design is already active, autosave keeps it
@@ -144,7 +145,7 @@ export function BaseplateSelector() {
         {t('baseplate.library.new')}
       </Button>
       {isDraft ? (
-        <Button variant="primary" onClick={startNaming} className="h-8 px-2.5 text-sm">
+        <Button variant="ghost" onClick={startNaming} className={HEADER_ACTION_CLASS}>
           {t('common.save')}
         </Button>
       ) : (

--- a/src/features/baseplate/components/BaseplateSelector/BaseplateSelector.tsx
+++ b/src/features/baseplate/components/BaseplateSelector/BaseplateSelector.tsx
@@ -2,6 +2,11 @@
  * Active-design selector cluster for the /baseplate page header.
  *
  * A dropdown of saved baseplate designs plus New / Save (or Save As) / Manage.
+ *
+ * Header vocabulary: the Select is the only bordered control (it's an input);
+ * every action beside it is a flat ghost button, matching Export and the
+ * DesignerHeader cluster next door. Save on an unsaved draft is the one
+ * exception — it's the primary action, so it keeps its fill.
  * - New starts a fresh unsaved draft (pointer null, default params).
  * - Save on a draft prompts a name, persists it to the library, and points the
  *   layout at the new design. When a design is already active, autosave keeps it
@@ -20,6 +25,10 @@ import { useTranslation } from '@/i18n';
 import { Button, Input, Select } from '@/design-system';
 import type { BaseplateRef } from '@/features/baseplate/store/baseplateRegistry';
 import { useBaseplateLibrary } from '@/features/baseplate/hooks/useBaseplateLibrary';
+
+/** Flat header action, shaped to sit beside Export rather than compete with it. */
+const HEADER_ACTION_CLASS =
+  'h-8 px-2 text-sm font-normal text-content-secondary hover:text-content';
 
 /** Next free "Baseplate N" name given the current library entries. */
 function nextBaseplateName(list: readonly BaseplateRef[]): string {
@@ -109,11 +118,11 @@ export function BaseplateSelector() {
         <Button
           variant="primary"
           onClick={() => void confirmNaming()}
-          className="px-2.5 py-1.5 text-sm"
+          className="h-8 px-2.5 text-sm"
         >
           {t('common.save')}
         </Button>
-        <Button variant="ghost" onClick={cancelNaming} className="px-2.5 py-1.5 text-sm">
+        <Button variant="ghost" onClick={cancelNaming} className={HEADER_ACTION_CLASS}>
           {t('common.cancel')}
         </Button>
       </div>
@@ -131,22 +140,22 @@ export function BaseplateSelector() {
         size="sm"
         className="min-w-40 text-sm"
       />
-      <Button variant="secondary" onClick={handleNew} className="px-2.5 py-1.5 text-sm">
+      <Button variant="ghost" onClick={handleNew} className={HEADER_ACTION_CLASS}>
         {t('baseplate.library.new')}
       </Button>
       {isDraft ? (
-        <Button variant="primary" onClick={startNaming} className="px-2.5 py-1.5 text-sm">
+        <Button variant="primary" onClick={startNaming} className="h-8 px-2.5 text-sm">
           {t('common.save')}
         </Button>
       ) : (
-        <Button variant="secondary" onClick={handleFork} className="px-2.5 py-1.5 text-sm">
+        <Button variant="ghost" onClick={handleFork} className={HEADER_ACTION_CLASS}>
           {t('baseplate.library.saveAs')}
         </Button>
       )}
       <Button
         variant="ghost"
         onClick={() => setShowBaseplateLibrary(true)}
-        className="px-2.5 py-1.5 text-sm"
+        className={HEADER_ACTION_CLASS}
       >
         {t('baseplate.library.manage')}
       </Button>


### PR DESCRIPTION
The `/baseplate` header looked out of place. It opens exactly like `/designer` — same `h-12` bar, same `ToolSwitcher`, same ghost `Export` — and then drops in a bordered CRUD cluster.

## The inconsistency

`New` and `Save As` were `variant="secondary"` (bordered, gradient fill) sitting next to `Manage…` as `variant="ghost"` (borderless). Two of three siblings bordered, one not, with no rule behind which. They were **the only bordered buttons in any header in the app** — `Export`, two controls to the left, was already flat.

`/designer` handles the same job (pick / save / manage designs) entirely with flat ghost controls.

## What changed

Actions are now flat ghost buttons sharing one `HEADER_ACTION_CLASS`, leaving the `Select` as the only bordered control in the cluster — it's an input, which is the rule `Export` already followed. `Save` on an unsaved draft keeps its primary fill: it's the single call to action in the bar.

Also drops the hand-rolled `px-2.5 py-1.5` sizing in favour of an explicit `h-8`, and stops `BaseplatePage`'s Export from re-implementing `variant="ghost"` (`bg-transparent`, `hover:bg-surface-hover`, `disabled:*`) in its className *on top of* already passing `variant="ghost"`.

Purely presentational — no logic touched.

## Verification

`pnpm run typecheck` clean, 759 baseplate tests pass, and a Playwright check at 1400×900 confirms the two headers now read as one family:

```
/baseplate  [Layout|Bins|Baseplate]  ⤓ Export  [Unsaved draft ▾]  New  Save  Manage…
/designer   [Layout|Bins|Baseplate]  Untitled Bin  ⧉ Designs  ⤓ Export  ✓ Saved
```

## Unrelated bug found while verifying

Driving this header surfaced a **pre-existing silent failure**, not touched by this PR: on a fresh layout, clicking `Save` on an unsaved draft prompts for a name and then silently discards it. `BaseplateSelector` guards on the raw store value:

```ts
const baseplateParams = useLayoutStore((s) => s.layout.baseplateParams);
if (!name || !baseplateParams) { cancelNaming(); return; }   // silent no-op
```

but `baseplateParams` is optional (`core/types.ts:69`) and unset until something writes it. `BaseplatePage` itself renders fine because it falls back (`baseplateParams ?? DEFAULT_BASEPLATE_PARAMS`, `BaseplatePage.tsx:83`); the selector has no such fallback, so Save does nothing and reports nothing. Filing separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened the /baseplate header to match /designer: all actions beside the Select are now flat ghost buttons, with only the Select bordered. The draft Save button is flattened too; the naming form confirm remains the sole filled action.

- **Refactors**
  - Added `HEADER_ACTION_CLASS`; switched New, Save (on drafts), Save As, and Manage to `variant="ghost"`; kept naming confirm as `variant="primary"`.
  - Standardized to `h-8` sizing and simplified Export styling in `BaseplatePage`; no logic changes.

<sup>Written for commit 0e979660dcdcdc65d587348100388878eda6a452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

