### PR TITLE
fix: serve /supporters instead of 404ing it

### DIFF
--- a/scripts/check-spa-routes.test.ts
+++ b/scripts/check-spa-routes.test.ts
@@ -1,0 +1,63 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(import.meta.dirname, '..');
+const HOOKS_DIR = join(ROOT, 'src', 'shared', 'hooks');
+
+interface VercelRewrite {
+  source: string;
+  destination: string;
+}
+
+/**
+ * Client-side routes, read from the routing hooks that own them.
+ *
+ * Each `use*Routing` hook decides it is active by comparing
+ * `window.location.pathname` against a literal. That literal is the route, so
+ * deriving it here means a new page can't be added without this check seeing it.
+ */
+function spaRoutesFromHooks(): string[] {
+  const routes = new Set<string>();
+  for (const file of readdirSync(HOOKS_DIR)) {
+    if (!/^use.*Routing\.ts$/.test(file) || file.endsWith('.test.ts')) continue;
+    const src = readFileSync(join(HOOKS_DIR, file), 'utf8');
+    for (const m of src.matchAll(/window\.location\.pathname === '(\/[^']*)'/g)) {
+      const route = m[1].replace(/\/$/, '');
+      if (route) routes.add(route);
+    }
+  }
+  return [...routes].sort();
+}
+
+function vercelRewrites(): VercelRewrite[] {
+  const config = JSON.parse(readFileSync(join(ROOT, 'vercel.json'), 'utf8')) as {
+    rewrites?: VercelRewrite[];
+  };
+  return config.rewrites ?? [];
+}
+
+/**
+ * Every SPA route needs a Vercel rewrite to `/`.
+ *
+ * Without one, the route only works via `history.pushState` from inside the
+ * app. A direct visit, a refresh, a Cmd-click, or a shared link hits Vercel,
+ * finds no file, and 404s — while in-app navigation keeps working, which is
+ * exactly why `/supporters` shipped broken and stayed unnoticed.
+ */
+describe('SPA routes are served by Vercel', () => {
+  const routes = spaRoutesFromHooks();
+
+  it('finds the routing hooks', () => {
+    // Guards the derivation itself: if the hooks are renamed and this silently
+    // returns nothing, the checks below would all vacuously pass.
+    expect(routes.length).toBeGreaterThanOrEqual(3);
+    expect(routes).toContain('/supporters');
+  });
+
+  it.each(spaRoutesFromHooks())('%s rewrites to the SPA', (route) => {
+    const rewrite = vercelRewrites().find((r) => r.source === route);
+    expect(rewrite, `vercel.json needs { "source": "${route}", "destination": "/" }`).toBeDefined();
+    expect(rewrite?.destination).toBe('/');
+  });
+});

--- a/scripts/check-spa-routes.test.ts
+++ b/scripts/check-spa-routes.test.ts
@@ -45,9 +45,10 @@ function vercelRewrites(): VercelRewrite[] {
  * finds no file, and 404s — while in-app navigation keeps working, which is
  * exactly why `/supporters` shipped broken and stayed unnoticed.
  */
-describe('SPA routes are served by Vercel', () => {
-  const routes = spaRoutesFromHooks();
+const routes = spaRoutesFromHooks();
+const rewrites = vercelRewrites();
 
+describe('SPA routes are served by Vercel', () => {
   it('finds the routing hooks', () => {
     // Guards the derivation itself: if the hooks are renamed and this silently
     // returns nothing, the checks below would all vacuously pass.
@@ -55,8 +56,8 @@ describe('SPA routes are served by Vercel', () => {
     expect(routes).toContain('/supporters');
   });
 
-  it.each(spaRoutesFromHooks())('%s rewrites to the SPA', (route) => {
-    const rewrite = vercelRewrites().find((r) => r.source === route);
+  it.each(routes)('%s rewrites to the SPA', (route) => {
+    const rewrite = rewrites.find((r) => r.source === route);
     expect(rewrite, `vercel.json needs { "source": "${route}", "destination": "/" }`).toBeDefined();
     expect(rewrite?.destination).toBe('/');
   });

--- a/vercel.json
+++ b/vercel.json
@@ -319,6 +319,7 @@
     },
     { "source": "/designer", "destination": "/" },
     { "source": "/baseplate", "destination": "/" },
+    { "source": "/supporters", "destination": "/" },
     { "source": "/s/:id([a-zA-Z0-9]{12})", "destination": "/" },
     { "source": "/l/:id([a-zA-Z0-9]{12})", "destination": "/" },
     { "source": "/l/:id([a-zA-Z0-9]{12})/:slug*", "destination": "/" },


### PR DESCRIPTION
**The `/supporters` page has been unreachable in production since it shipped in #2476.**

```
$ curl -o /dev/null -w '%{http_code}' https://gridfinitylayouttool.com/supporters
404
```

## Cause

`vercel.json` rewrites `/designer`, `/baseplate`, `/s/:id`, `/l/:id` and `/scan/:token` to the SPA. Nothing covers `/supporters`, so Vercel looks for a file, finds none, and 404s.

## Why nobody noticed

In-app navigation never touches the server. The footer link intercepts a plain left-click and calls `history.pushState`; the command palette does the same. So clicking through to the page works perfectly — while:

- a direct visit to `/supporters`
- a refresh once you're on it
- a Cmd/Ctrl-click or "open in new tab" (which the footer link deliberately leaves alone, by design)
- **any link shared with anyone**

all 404. For a page whose entire job is being linked to, that's the bug. It also renders fine on `pnpm dev`, because the dev server serves `index.html` for any path — so local testing could never surface it.

Found by loading the production URL while verifying the Ko-fi ingest end-to-end.

## Fix

One line, next to its two siblings:

```json
{ "source": "/supporters", "destination": "/" },
```

## Guard

`scripts/check-spa-routes.test.ts` derives the routes from the `use*Routing` hooks that own them — each hook decides it's active by comparing `window.location.pathname` against a literal, so that literal *is* the route — and asserts every one has a rewrite to `/`. There are exactly three; two had rewrites.

Confirmed to fail on `/supporters` without the `vercel.json` line and pass with it, so it would have caught #2476. The derivation is guarded too: if the hooks are renamed and nothing is found, that fails rather than vacuously passing.

## Blast radius

Not in `sitemap.xml`, so no crawler hit the 404 and there's no SEO damage to undo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the `/supporters` page by rewriting it to the SPA, fixing 404s on direct visits, refreshes, and shared links. Adds a test to ensure all SPA routes have rewrites and prevents regressions.

- **Bug Fixes**
  - Add `{ "source": "/supporters", "destination": "/" }` to `vercel.json`.
  - Add `scripts/check-spa-routes.test.ts` to derive routes from `use*Routing` hooks and assert each rewrites to `/`.

- **Refactors**
  - Hoist route and rewrite reads to module scope in `scripts/check-spa-routes.test.ts` to avoid recomputation.

<sup>Written for commit d42e15cfd710556778dfd32a5a28b2f78c4eddc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

