### PR TITLE
chore(supporters): backfill the 5 supporters the webhook couldn't see

### DIFF
--- a/src/features/supporters/data/supporters.json
+++ b/src/features/supporters/data/supporters.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Backfilled from the Ko-fi supporter export on 2026-07-08 (45 unique supporters: 27 named, 18 who gave no name). Display names only — NEVER store emails or amounts here. New supporters can be appended to `named`, or `anonymousCount` incremented for people who gave no name. Order is randomized at render, so append anywhere.",
+  "_comment": "Reconciled against the Ko-fi transaction export on 2026-07-15 (50 unique supporters: 31 named, 19 who gave no name). Covers everyone up to the Ko-fi webhook going live on 2026-07-15; from then on `/api/kofi-webhook` records new supporters into Redis automatically and this file is only the offline fallback + the one-time seed source (`pnpm seed-supporters`). Display names only — NEVER store emails or amounts here. Ko-fi writes 'Supporter'/'Ko-fi Supporter' when someone gives no name; those are anonymous, not people, and belong in `anonymousCount`. Append new names to the end so the seed:named:N field mapping stays stable. Order is randomized at render.",
   "named": [
     "unpossible",
     "Jürgen",
@@ -27,7 +27,11 @@
     "Mawi",
     "ChrisV",
     "Bram",
-    "Allison Lee"
+    "Allison Lee",
+    "Rob",
+    "Bandit 6",
+    "Carl",
+    "Dave"
   ],
-  "anonymousCount": 18
+  "anonymousCount": 19
 }


### PR DESCRIPTION
`supporters.json` was a snapshot from **2026-07-08**; the Ko-fi webhook went live **2026-07-15**. Ko-fi has no replay, so anyone who tipped in that window was in neither source. Reconciled against a fresh export — it was exactly **5 people**.

| | before | after |
| --- | ---: | ---: |
| named | 27 | **31** |
| anonymous | 18 | **19** |
| total | 45 | **50** |

New: **Rob, Bandit 6, Carl, Dave** + 1 anonymous. Every one first appears between **07-12 and 07-15** — after the backfill date — which independently confirms the 07-08 snapshot was sound and nothing else drifted.

The totals reconcile exactly: 31 + 19 = **50 unique buyers in the export**, asserted in the reconciliation rather than eyeballed.

## Two traps the export sets

**1. "Supporter" is not a person.** It appears **16 times**, plus "Ko-fi Supporter" 3 times — Ko-fi's placeholder when no name is given. Taking the export at face value would have published a wall of identical `Supporter` bins. They're anonymous, and they're why the naive count said "47 named" against a curated 27.

**2. The 07-08 backfill was curated, not dumped.** The export's raw `unpossible (t4r876rd6m-jpg)` is `unpossible` in the JSON. Names are **appended, never regenerated**, so that curation survives — and appending also keeps the `seed:named:N` field mapping stable, so re-seeding rewrites the first 27 fields to identical values.

Both are now recorded in the file's `_comment` so the next person reconciling doesn't rediscover them.

## Privacy

Uniqueness is by buyer email — the same rule the webhook's salted donor hash enforces — but **only display names land here**. No emails, amounts, or messages. The CSV stays in `~/Downloads` and is never committed; the diff was checked for `@` before commit (only hunk headers matched).

## Verified in production

Seeded: `supporters:donors` **45 → 50**. Dry run showed only the intended delta (`seed:named:27–30`, `seed:anon:18`); the first 27 fields keep their mapping.

```
$ curl /api/supporters
31 named + 19 anon = 50
new names present: ['Rob', 'Bandit 6', 'Carl', 'Dave']
```

The page is already serving all 50 — this PR brings the committed fallback in line with Redis. From here the webhook keeps it current on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfilled five Ko‑fi supporters missed between the 2026‑07‑08 snapshot and the 2026‑07‑15 webhook go-live to align the committed fallback with Redis. Adds four names (Rob, Bandit 6, Carl, Dave) and one anonymous; totals are now 31 named + 19 anonymous = 50.

- **Bug Fixes**
  - Reconciled against the 2026‑07‑15 export; appended 4 names and incremented `anonymousCount` to 19.
  - Updated `_comment` to document: treat "Supporter"/"Ko‑fi Supporter" as anonymous; append to keep seed field mapping stable; store display names only.
  - Verified in prod: seed ran 45 → 50; `/api/supporters` returns 31 named + 19 anonymous.

<sup>Written for commit fee8e23eb5ffaeca637fba888f3268f37c9ab201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

