### PR TITLE
feat(analytics): instrument drawer shape editing and add shape metrics

### DIFF
--- a/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.tsx
+++ b/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from '@/i18n';
 import { useMutations } from '@/shared/contexts/MutationsContext';
 import { isOk } from '@/core/result';
 import { computeDisplacedBins } from '@/core/cqrs/v2/domain/drawer/displacement';
+import { trackDrawerShapeApplied } from '@/shared/analytics/posthog';
 import type { CornerCut, CornerCutParams } from '@/core/types';
 import { cornersToOutline, maxCutExtentMm, NO_CUTS } from '../../utils/cornersToOutline';
 
@@ -93,6 +94,12 @@ export function CornerCutsDialog({ open, onClose }: CornerCutsDialogProps) {
             .length;
     const result = mutations.setDrawerOutline(outline);
     if (!isOk(result)) return;
+    trackDrawerShapeApplied({
+      editor: 'corners',
+      displaced_bins: displaced,
+      used_trace: false,
+      cleared: outline === null,
+    });
     if (displaced > 0) {
       addToast(t('toast.binsDisplacedByShape', { count: displaced }), 'info');
     }

--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
@@ -5,6 +5,7 @@ import { ConfirmDialog, ToggleRow } from '@/shared/components';
 import { useLayoutStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
 import { useMutations } from '@/shared/contexts/MutationsContext';
+import { trackDrawerShapeEditorOpened, trackDrawerShapeReset } from '@/shared/analytics/posthog';
 import { ShapeEditorDialog } from '../ShapeEditorDialog/ShapeEditorDialog';
 import { CornerCutsDialog } from '../CornerCutsDialog/CornerCutsDialog';
 
@@ -36,11 +37,23 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
     if (hasOutline) {
       setConfirmReset(true);
     } else {
+      trackDrawerShapeEditorOpened('cells');
       setEditorOpen(true);
     }
   }, [hasOutline]);
 
+  const handleOpenCorners = useCallback(() => {
+    trackDrawerShapeEditorOpened('corners');
+    setCornersOpen(true);
+  }, []);
+
+  const handleOpenEditor = useCallback(() => {
+    trackDrawerShapeEditorOpened('cells');
+    setEditorOpen(true);
+  }, []);
+
   const handleReset = useCallback(() => {
+    trackDrawerShapeReset();
     mutations.setDrawerOutline(null);
   }, [mutations]);
 
@@ -64,7 +77,7 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
           variant="secondary"
           fullWidth
           type="button"
-          onClick={() => setCornersOpen(true)}
+          onClick={handleOpenCorners}
           className={actionClass}
         >
           {t('drawerShape.corners.open')}
@@ -74,7 +87,7 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
             variant="secondary"
             fullWidth
             type="button"
-            onClick={() => setEditorOpen(true)}
+            onClick={handleOpenEditor}
             className={actionClass}
           >
             {t('drawerShape.edit')}

--- a/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
+++ b/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from '@/i18n';
 import { useMutations } from '@/shared/contexts/MutationsContext';
 import { isOk } from '@/core/result';
 import { computeDisplacedBins } from '@/core/cqrs/v2/domain/drawer/displacement';
+import { trackDrawerShapeApplied } from '@/shared/analytics/posthog';
 import {
   buildFullDrawerMask,
   drawerMaskToOutline,
@@ -35,6 +36,7 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
   const [grid, setGrid] = useState<DrawerMaskGrid | null>(null);
   const paintValueRef = useRef<0 | 1>(0);
   const paintingRef = useRef(false);
+  const usedTraceRef = useRef(false);
 
   // Seed lazily each time the dialog opens: existing outline (rasterized) or
   // the full rectangle.
@@ -101,6 +103,7 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
   );
 
   const handleTrace = useCallback(() => {
+    usedTraceRef.current = true;
     setGrid(traceBinFootprint(layout));
   }, [layout]);
 
@@ -113,15 +116,23 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
     ).length;
     const result = mutations.setDrawerOutline(conversion.outline);
     if (!isOk(result)) return;
+    trackDrawerShapeApplied({
+      editor: 'cells',
+      displaced_bins: displaced,
+      used_trace: usedTraceRef.current,
+      cleared: false,
+    });
     if (displaced > 0) {
       addToast(t('toast.binsDisplacedByShape', { count: displaced }), 'info');
     }
     setGrid(null);
+    usedTraceRef.current = false;
     onClose();
   }, [conversion, layout, mutations, addToast, t, onClose]);
 
   const handleClose = useCallback(() => {
     setGrid(null);
+    usedTraceRef.current = false;
     onClose();
   }, [onClose]);
 

--- a/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
+++ b/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
@@ -116,11 +116,14 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
     ).length;
     const result = mutations.setDrawerOutline(conversion.outline);
     if (!isOk(result)) return;
+    // A full-rectangle paint is normalized to "no outline" by the mutation
+    // (isRectangleEquivalent) — read the post-commit store state so
+    // `cleared` reflects what actually landed.
     trackDrawerShapeApplied({
       editor: 'cells',
       displaced_bins: displaced,
       used_trace: usedTraceRef.current,
-      cleared: false,
+      cleared: useLayoutStore.getState().layout.drawer.outline === undefined,
     });
     if (displaced > 0) {
       addToast(t('toast.binsDisplacedByShape', { count: displaced }), 'info');

--- a/src/shared/analytics/posthog/events.ts
+++ b/src/shared/analytics/posthog/events.ts
@@ -29,9 +29,14 @@ export {
   trackFillOperation,
   trackPaintMode,
   trackBinCreated,
+  trackDrawerShapeEditorOpened,
+  trackDrawerShapeApplied,
+  trackDrawerShapeReset,
   MILESTONE_THRESHOLDS,
   type AnalyticsTrigger,
   type BinCreatedProperties,
+  type DrawerShapeAppliedProperties,
+  type DrawerShapeEditor,
 } from './eventsCore';
 export {
   getActivityContext,

--- a/src/shared/analytics/posthog/eventsCore.test.ts
+++ b/src/shared/analytics/posthog/eventsCore.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const trackEventMock = vi.fn();
+
+vi.mock('./trackEvent', () => ({
+  trackEvent: (name: string, properties?: Record<string, unknown>) => {
+    trackEventMock(name, properties);
+  },
+  getDeviceType: () => 'desktop',
+}));
+
+import {
+  trackDrawerShapeApplied,
+  trackDrawerShapeEditorOpened,
+  trackDrawerShapeReset,
+} from './eventsCore';
+
+beforeEach(() => {
+  trackEventMock.mockReset();
+});
+
+describe('trackDrawerShapeEditorOpened', () => {
+  it('emits the editor kind', () => {
+    trackDrawerShapeEditorOpened('corners');
+
+    expect(trackEventMock).toHaveBeenCalledWith('drawer_shape_editor_opened', {
+      editor: 'corners',
+    });
+  });
+});
+
+describe('trackDrawerShapeApplied', () => {
+  it('emits editor, displacement, trace, and cleared properties', () => {
+    trackDrawerShapeApplied({
+      editor: 'cells',
+      displaced_bins: 3,
+      used_trace: true,
+      cleared: false,
+    });
+
+    expect(trackEventMock).toHaveBeenCalledWith('drawer_shape_applied', {
+      editor: 'cells',
+      displaced_bins: 3,
+      used_trace: true,
+      cleared: false,
+    });
+  });
+
+  it('marks corner-cut applies that resolve back to the plain rectangle', () => {
+    trackDrawerShapeApplied({
+      editor: 'corners',
+      displaced_bins: 0,
+      used_trace: false,
+      cleared: true,
+    });
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      'drawer_shape_applied',
+      expect.objectContaining({ editor: 'corners', cleared: true })
+    );
+  });
+});
+
+describe('trackDrawerShapeReset', () => {
+  it('emits with no properties', () => {
+    trackDrawerShapeReset();
+
+    expect(trackEventMock).toHaveBeenCalledWith('drawer_shape_reset', {});
+  });
+});

--- a/src/shared/analytics/posthog/eventsCore.ts
+++ b/src/shared/analytics/posthog/eventsCore.ts
@@ -133,6 +133,34 @@ export function trackBinCreated(props: BinCreatedProperties): void {
   }
 }
 
+/** Which drawer-shape authoring surface an event refers to. */
+export type DrawerShapeEditor = 'cells' | 'corners';
+
+/** Track a drawer-shape editor being opened. */
+export function trackDrawerShapeEditorOpened(editor: DrawerShapeEditor): void {
+  trackEvent('drawer_shape_editor_opened', { editor });
+}
+
+export interface DrawerShapeAppliedProperties {
+  editor: DrawerShapeEditor;
+  /** Bins pushed to staging by the new shape. */
+  displaced_bins: number;
+  /** Cells editor only: the user seeded the grid from the bin layout. */
+  used_trace: boolean;
+  /** The apply resolved to the plain rectangle (corner cuts all 'none'). */
+  cleared: boolean;
+}
+
+/** Track a drawer shape being applied from one of the editors. */
+export function trackDrawerShapeApplied(props: DrawerShapeAppliedProperties): void {
+  trackEvent('drawer_shape_applied', { ...props });
+}
+
+/** Track the sidebar toggle resetting the drawer back to a rectangle. */
+export function trackDrawerShapeReset(): void {
+  trackEvent('drawer_shape_reset', {});
+}
+
 export const MILESTONE_THRESHOLDS: Array<{
   key: 'first_bin' | 'engaged' | 'substantial' | 'power_user';
   min: number;

--- a/src/shared/analytics/posthog/index.ts
+++ b/src/shared/analytics/posthog/index.ts
@@ -27,6 +27,8 @@ export { computeLabsMetrics, computeLayoutMetrics } from './metrics';
 export type {
   AnalyticsTrigger,
   BinCreatedProperties,
+  DrawerShapeAppliedProperties,
+  DrawerShapeEditor,
   ActivityContext,
   HeartbeatPayload,
 } from './events';
@@ -41,6 +43,9 @@ export {
   trackFillOperation,
   trackPaintMode,
   trackBinCreated,
+  trackDrawerShapeEditorOpened,
+  trackDrawerShapeApplied,
+  trackDrawerShapeReset,
   getActivityContext,
   buildHeartbeatPayload,
   trackHeartbeat,

--- a/src/shared/analytics/posthog/metrics.ts
+++ b/src/shared/analytics/posthog/metrics.ts
@@ -3,7 +3,7 @@
  * Pure functions that derive analytics data from Layout and store state.
  */
 
-import type { Layout, CategoryId } from '@/core/types';
+import type { Layout, CategoryId, OutlineAuthoringKind } from '@/core/types';
 import { DEFAULT_CATEGORIES, calcMaxGridUnits, hasFractionalDimensions } from '@/core/constants';
 import { useLabsStore } from '@/core/store/labs';
 import { getFeature } from '@/core/labs';
@@ -84,7 +84,7 @@ export interface LayoutMetrics {
   feature_asymmetric_bed: boolean;
 
   // Drawer shape
-  drawer_shape_kind: string;
+  drawer_shape_kind: OutlineAuthoringKind | 'rectangle' | 'custom';
 
   // Print readiness
   has_oversized_bins: boolean;

--- a/src/shared/analytics/posthog/metrics.ts
+++ b/src/shared/analytics/posthog/metrics.ts
@@ -79,8 +79,12 @@ export interface LayoutMetrics {
   feature_labels: boolean;
   feature_notes: boolean;
   feature_custom_drawer: boolean;
+  feature_shaped_drawer: boolean;
   feature_custom_print_bed: boolean;
   feature_asymmetric_bed: boolean;
+
+  // Drawer shape
+  drawer_shape_kind: string;
 
   // Print readiness
   has_oversized_bins: boolean;
@@ -190,6 +194,12 @@ export function computeLayoutMetrics(layout: Layout): LayoutMetrics {
     layout.drawer.depth === DEFAULT_DRAWER.depth &&
     layout.drawer.height === DEFAULT_DRAWER.height;
 
+  // Non-rectangular drawer shape. An outline can survive with its authoring
+  // annotation stripped (server sanitization) — report those as 'custom'.
+  const outline = layout.drawer.outline;
+  const drawerShapeKind =
+    outline === undefined ? 'rectangle' : (outline.authoring?.kind ?? 'custom');
+
   return {
     // Drawer
     drawer_width: layout.drawer.width,
@@ -231,8 +241,12 @@ export function computeLayoutMetrics(layout: Layout): LayoutMetrics {
     feature_labels: withLabels > 0,
     feature_notes: withNotes > 0,
     feature_custom_drawer: !isDefaultDrawer,
+    feature_shaped_drawer: outline !== undefined,
     feature_custom_print_bed: layout.printBedSize !== DEFAULT_PRINT_BED,
     feature_asymmetric_bed: printBedDepth !== layout.printBedSize,
+
+    // Drawer shape
+    drawer_shape_kind: drawerShapeKind,
 
     // Print
     has_oversized_bins: hasOversizedBins,

--- a/src/shared/analytics/posthog/posthog.test.ts
+++ b/src/shared/analytics/posthog/posthog.test.ts
@@ -89,6 +89,17 @@ describe('computeLayoutMetrics', () => {
       expect(metrics.drawer_shape_kind).toBe('rectangle');
     });
 
+    // A chamfered front-left corner — non-rectangular, so setDrawerOutline's
+    // isRectangleEquivalent normalization would NOT strip it. Exact-rectangle
+    // outlines never survive a write and would test an unreachable state.
+    const chamferedVertices = [
+      { x: 21, y: 0 },
+      { x: 420, y: 0 },
+      { x: 420, y: 336 },
+      { x: 0, y: 336 },
+      { x: 0, y: 21 },
+    ];
+
     it('captures the authoring kind of a shaped drawer', () => {
       const layout = createTestLayout({
         drawer: {
@@ -96,12 +107,7 @@ describe('computeLayoutMetrics', () => {
           depth: 8,
           height: 12,
           outline: {
-            vertices: [
-              { x: 0, y: 0 },
-              { x: 420, y: 0 },
-              { x: 420, y: 336 },
-              { x: 0, y: 336 },
-            ],
+            vertices: chamferedVertices,
             authoring: { kind: 'corners' },
           },
         },
@@ -119,12 +125,7 @@ describe('computeLayoutMetrics', () => {
           depth: 8,
           height: 12,
           outline: {
-            vertices: [
-              { x: 0, y: 0 },
-              { x: 420, y: 0 },
-              { x: 420, y: 336 },
-              { x: 0, y: 336 },
-            ],
+            vertices: chamferedVertices,
           },
         },
       });

--- a/src/shared/analytics/posthog/posthog.test.ts
+++ b/src/shared/analytics/posthog/posthog.test.ts
@@ -81,6 +81,56 @@ describe('computeLayoutMetrics', () => {
       });
       expect(computeLayoutMetrics(customLayout).drawer_is_default).toBe(false);
     });
+
+    it('reports rectangular drawers as unshaped', () => {
+      const metrics = computeLayoutMetrics(createTestLayout());
+
+      expect(metrics.feature_shaped_drawer).toBe(false);
+      expect(metrics.drawer_shape_kind).toBe('rectangle');
+    });
+
+    it('captures the authoring kind of a shaped drawer', () => {
+      const layout = createTestLayout({
+        drawer: {
+          width: 10,
+          depth: 8,
+          height: 12,
+          outline: {
+            vertices: [
+              { x: 0, y: 0 },
+              { x: 420, y: 0 },
+              { x: 420, y: 336 },
+              { x: 0, y: 336 },
+            ],
+            authoring: { kind: 'corners' },
+          },
+        },
+      });
+      const metrics = computeLayoutMetrics(layout);
+
+      expect(metrics.feature_shaped_drawer).toBe(true);
+      expect(metrics.drawer_shape_kind).toBe('corners');
+    });
+
+    it('reports outlines with a stripped authoring annotation as custom', () => {
+      const layout = createTestLayout({
+        drawer: {
+          width: 10,
+          depth: 8,
+          height: 12,
+          outline: {
+            vertices: [
+              { x: 0, y: 0 },
+              { x: 420, y: 0 },
+              { x: 420, y: 336 },
+              { x: 0, y: 336 },
+            ],
+          },
+        },
+      });
+
+      expect(computeLayoutMetrics(layout).drawer_shape_kind).toBe('custom');
+    });
   });
 
   describe('bin statistics', () => {


### PR DESCRIPTION
## Summary

The drawer shape editors (corner cuts + cell paint, graduated from Labs in #2557) ship with zero analytics, so we can't see adoption, editor preference, or how often shapes displace bins. This PR adds the instrumentation baseline before the upcoming drawer-dimension UX work builds on it.

## Events

- `drawer_shape_editor_opened` with `editor: 'cells' | 'corners'` (sidebar toggle-on, Edit button, Corner cuts button)
- `drawer_shape_applied` with `editor`, `displaced_bins`, `used_trace` (cells editor seeded from the bin layout), and `cleared` (corner apply that resolved back to the plain rectangle)
- `drawer_shape_reset` (sidebar toggle-off confirm)

## layout_snapshot metrics

- `feature_shaped_drawer`: whether a non-rectangular outline exists
- `drawer_shape_kind`: `rectangle`, the outline's authoring kind, or `custom` when the annotation was stripped server-side

## Testing

- New `eventsCore.test.ts` covering the three trackers (leaf-mock pattern from `eventsPerformance.test.ts`)
- `posthog.test.ts` gains shape-kind metric cases (rectangle / corners / stripped annotation)
- `pnpm run typecheck` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds analytics for the drawer shape editors and new layout metrics to measure adoption, editor usage, and bin displacement.

- **New Features**
  - Events: `drawer_shape_editor_opened` (editor: 'cells' | 'corners'), `drawer_shape_applied` (editor, displaced_bins, used_trace, cleared), and `drawer_shape_reset` (no props).
  - Metrics: `feature_shaped_drawer` (true when an outline exists) and `drawer_shape_kind` ('rectangle' | authoring kind | 'custom' when authoring was stripped).

- **Bug Fixes**
  - Marks rectangle-equivalent applies as `cleared` (cells editor reads post-commit state to reflect normalization).
  - Tests now use a non-rectangular outline in shaped-drawer fixtures to avoid modeling an unreachable state after normalization.

<sup>Written for commit a34f9b754605339409c48a60b14080c5c15360dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

