### PR TITLE
feat(generation): stl import worker pipeline for mesh imprint cutouts

### DIFF
--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -327,7 +327,7 @@ export class GenerationBridge {
     }
     this.pendingExports.clear();
     for (const pending of this.pendingImports.values()) {
-      pending.reject(new Error('Worker was reset after a generation timeout'));
+      pending.reject(new Error('Worker was reset'));
     }
     this.pendingImports.clear();
     // Errors here surface on the next generation's init() await; swallow the

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -50,7 +50,9 @@ import {
   type ExportSlot,
   type PendingExport,
   type PendingExportMap,
+  type MeshImportOutcome,
 } from './bridgeTypes';
+import type { MeshImportFlips } from '@/shared/generation/meshAsset';
 import { extractThreadingInfo, createDedupCache } from './bridgeHelpers';
 import { installMessageHandler } from './bridgeMessageHandler';
 import {
@@ -85,6 +87,7 @@ export type {
   BooleanFallbackStatsPayload,
   BooleanFallbackStatsCallback,
   ThreadingInfo,
+  MeshImportOutcome,
 } from './bridgeTypes';
 export { ExportTimeoutError } from './bridgeTypes';
 
@@ -126,6 +129,16 @@ export class GenerationBridge {
   /** Pending cost-estimate requests keyed by their requestId. */
   readonly pendingEstimates = new Map<string, (predictedMs: number | null) => void>();
   private estimateSeq = 0;
+
+  /** Pending mesh-import requests keyed by their requestId. */
+  readonly pendingImports = new Map<
+    string,
+    {
+      readonly resolve: (result: MeshImportOutcome) => void;
+      readonly reject: (error: Error) => void;
+    }
+  >();
+  private importSeq = 0;
 
   constructor(kernel: KernelName = 'occt-wasm') {
     this.kernel = kernel;
@@ -241,6 +254,30 @@ export class GenerationBridge {
   }
 
   /**
+   * Parse + normalize an uploaded STL into a compressed `MeshAsset` in the
+   * worker. The file buffer is transferred (the caller's copy is detached).
+   * Import failures (broken mesh, bad format) resolve as `ok: false`; the
+   * promise rejects only on worker-lifecycle failures.
+   */
+  importMesh(
+    buffer: ArrayBuffer,
+    fileName: string,
+    flips?: MeshImportFlips
+  ): Promise<MeshImportOutcome> {
+    if (this.isDestroyed || !this.worker) {
+      return Promise.reject(new Error('Bridge not initialized'));
+    }
+    const requestId = `import-${++this.importSeq}`;
+    return new Promise((resolve, reject) => {
+      this.pendingImports.set(requestId, { resolve, reject });
+      this.worker?.postMessage(
+        { type: 'IMPORT_MESH', payload: { requestId, buffer, fileName, flips } },
+        [buffer]
+      );
+    });
+  }
+
+  /**
    * Speculatively build the export-quality (fused) shell during idle so a
    * subsequent export skips the deferred socket↔body fuse. Best-effort and
    * fire-and-forget: skipped when the worker is busy or already warming, and
@@ -289,6 +326,10 @@ export class GenerationBridge {
       pending.reject(new Error('Worker was reset after a generation timeout'));
     }
     this.pendingExports.clear();
+    for (const pending of this.pendingImports.values()) {
+      pending.reject(new Error('Worker was reset after a generation timeout'));
+    }
+    this.pendingImports.clear();
     // Errors here surface on the next generation's init() await; swallow the
     // unhandled rejection from this eager warm-up.
     void this.init().catch(() => {});
@@ -306,6 +347,10 @@ export class GenerationBridge {
       pending.reject(new Error('Bridge destroyed'));
     }
     this.pendingExports.clear();
+    for (const pending of this.pendingImports.values()) {
+      pending.reject(new Error('Bridge destroyed'));
+    }
+    this.pendingImports.clear();
 
     if (this.worker) {
       // terminate() frees the entire WASM heap — no explicit cleanup needed

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -93,6 +93,11 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
       pending.reject(new Error(message));
     }
     ctx.pendingExports.clear();
+
+    for (const pending of ctx.pendingImports.values()) {
+      pending.reject(new Error(message));
+    }
+    ctx.pendingImports.clear();
   });
 
   ctx.worker.addEventListener('message', (event: MessageEvent<WorkerResponse>) => {

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -23,6 +23,7 @@ import type {
   PendingExport,
   PendingExportMap,
   ThreadingInfo,
+  MeshImportOutcome,
 } from './bridgeTypes';
 
 export interface MessageHandlerContext {
@@ -43,6 +44,13 @@ export interface MessageHandlerContext {
   readonly itemCache: DedupCache;
   readonly pendingExports: PendingExportMap;
   readonly pendingEstimates: Map<string, (predictedMs: number | null) => void>;
+  readonly pendingImports: Map<
+    string,
+    {
+      readonly resolve: (result: MeshImportOutcome) => void;
+      readonly reject: (error: Error) => void;
+    }
+  >;
   clearPending: () => void;
   clearExportTimer: (pending: PendingExport<unknown>) => void;
   resolveExport: (slot: ExportSlot, requestId: string, result: unknown) => boolean;
@@ -114,6 +122,34 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
       case 'ESTIMATE_RESULT':
         ctx.pendingEstimates.get(response.requestId)?.(response.predictedMs);
         break;
+
+      case 'IMPORT_MESH_RESULT': {
+        const pendingImport = ctx.pendingImports.get(response.requestId);
+        if (pendingImport) {
+          ctx.pendingImports.delete(response.requestId);
+          pendingImport.resolve({
+            ok: true,
+            asset: response.asset,
+            positions: response.positions,
+            indices: response.indices,
+            suggestedCutDepth: response.suggestedCutDepth,
+          });
+        }
+        break;
+      }
+
+      case 'IMPORT_MESH_ERROR': {
+        const pendingImport = ctx.pendingImports.get(response.requestId);
+        if (pendingImport) {
+          ctx.pendingImports.delete(response.requestId);
+          pendingImport.resolve({
+            ok: false,
+            reason: response.reason,
+            message: response.error,
+          });
+        }
+        break;
+      }
 
       case 'MESH_RESULT':
         if (response.requestId === ctx.currentRequestId && ctx.pendingResolve) {

--- a/src/features/generation/bridge/bridgeTypes.ts
+++ b/src/features/generation/bridge/bridgeTypes.ts
@@ -18,6 +18,7 @@ import type {
   BooleanFallbackEntry,
   PerfSnapshot,
 } from './types';
+import type { MeshAsset, MeshImportErrorReason } from '@/shared/generation/meshAsset';
 
 /** Callback for progress updates during generation */
 export type ProgressCallback = (stage: GenerationStage, progress: number) => void;
@@ -43,6 +44,26 @@ export interface DividersExportResult {
   readonly data: ArrayBuffer;
   readonly fileName: string;
 }
+
+/**
+ * Outcome of a mesh (STL) import. Import failures are expected user-input
+ * conditions (broken mesh, wrong format), so they resolve as `ok: false`
+ * rather than rejecting — rejection is reserved for worker-lifecycle
+ * failures (destroyed/reset mid-request).
+ */
+export type MeshImportOutcome =
+  | {
+      readonly ok: true;
+      readonly asset: MeshAsset;
+      readonly positions: Float32Array;
+      readonly indices: Uint32Array;
+      readonly suggestedCutDepth: number;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: MeshImportErrorReason;
+      readonly message: string;
+    };
 
 /** Result from a combined bin + dividers export */
 export interface CombinedExportResult {

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -12,6 +12,11 @@ import type {
   MarginPiece,
 } from '@/shared/types/bin';
 import type { GridfinityItem } from '@/shared/types/item';
+import type {
+  MeshAsset,
+  MeshImportErrorReason,
+  MeshImportFlips,
+} from '@/shared/generation/meshAsset';
 
 /** Geometry kernel backend for BREP operations */
 export type KernelName = 'brepkit' | 'occt-wasm' | 'manifold';
@@ -60,7 +65,27 @@ export type WorkerMessage =
   | ExportDividersMessage
   | ExportCombinedMessage
   | ExportSplitMessage
-  | ExportSplitRangeMessage;
+  | ExportSplitRangeMessage
+  | ImportMeshMessage;
+
+/**
+ * Parse + normalize an uploaded STL into a compressed `MeshAsset` (mesh
+ * imprint import). Runs on the raw manifold-3d module, so it works on any
+ * kernel's worker without touching the active brepjs kernel.
+ */
+export interface ImportMeshMessage {
+  readonly type: 'IMPORT_MESH';
+  readonly payload: ImportMeshPayload;
+}
+
+export interface ImportMeshPayload {
+  readonly requestId: string;
+  /** Raw STL file contents (transferred, not copied). */
+  readonly buffer: ArrayBuffer;
+  readonly fileName: string;
+  /** Quarter-turn corrections applied after auto lay-flat. */
+  readonly flips?: MeshImportFlips;
+}
 
 export interface InitMessage {
   readonly type: 'INIT';
@@ -345,6 +370,8 @@ export type WorkerResponse =
   | DividersExportResultResponse
   | CombinedExportResultResponse
   | SplitExportResultResponse
+  | ImportMeshResultResponse
+  | ImportMeshErrorResponse
   | CacheStatsResponse
   | KernelPerfStatsResponse
   | BooleanFallbackStatsResponse
@@ -573,6 +600,24 @@ export interface SplitExportResultResponse {
   readonly type: 'SPLIT_EXPORT_RESULT';
   readonly requestId: string;
   readonly pieces: readonly SplitExportPiece[];
+}
+
+export interface ImportMeshResultResponse {
+  readonly type: 'IMPORT_MESH_RESULT';
+  readonly requestId: string;
+  readonly asset: MeshAsset;
+  /** Decimated, oriented preview mesh (transferred). */
+  readonly positions: Float32Array;
+  readonly indices: Uint32Array;
+  /** Default pocket depth: the oriented mesh height (mm). */
+  readonly suggestedCutDepth: number;
+}
+
+export interface ImportMeshErrorResponse {
+  readonly type: 'IMPORT_MESH_ERROR';
+  readonly requestId: string;
+  readonly reason: MeshImportErrorReason;
+  readonly error: string;
 }
 
 /** A single piece from a split preview (mesh data for Three.js rendering) */

--- a/src/features/generation/worker/generation.worker.ts
+++ b/src/features/generation/worker/generation.worker.ts
@@ -52,6 +52,7 @@ import {
   handleSplitExport,
   handleSplitExportRange,
 } from './handlers/splitHandler';
+import { handleImportMesh } from './handlers/importMeshHandler';
 
 /** Initialize the geometry kernel selected by the INIT message. */
 async function initKernel(kernel: KernelName = 'occt-wasm'): Promise<void> {
@@ -168,6 +169,10 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
 
       case 'EXPORT_SPLIT_RANGE':
         await handleSplitExportRange(message);
+        break;
+
+      case 'IMPORT_MESH':
+        await handleImportMesh(message);
         break;
 
       case 'CANCEL':

--- a/src/features/generation/worker/generators/meshImport.test.ts
+++ b/src/features/generation/worker/generators/meshImport.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Real-WASM tests for the STL → MeshAsset import pipeline. Instantiates the
+ * raw manifold-3d module from node_modules (the worker's fetch-based loader
+ * can't run in node) and injects it via the moduleOverride parameter.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { ManifoldToplevel } from 'manifold-3d';
+import { importMeshFromStl } from './meshImport';
+import {
+  decodeMeshData,
+  MAX_MESH_ASSET_TRIANGLES,
+  MAX_MESH_FILE_BYTES,
+} from '@/shared/generation/meshAsset';
+import type { MeshOutlinePoint } from '@/shared/generation/meshAsset';
+import { buildSTLBuffer } from '@/shared/generation/export';
+import { isOk, isErr, unwrap } from '@/core/result';
+
+let module: ManifoldToplevel;
+
+beforeAll(async () => {
+  const ManifoldModule = (await import('manifold-3d')).default;
+  const { readFileSync } = await import('fs');
+  const { join } = await import('path');
+  const wasmBinary = readFileSync(join(process.cwd(), 'node_modules/manifold-3d/manifold.wasm'));
+  module = await ManifoldModule({ wasmBinary } as unknown as { locateFile: () => string });
+  module.setup();
+});
+
+/** Triangle soup for an axis-aligned box with outward CCW winding. */
+function boxSoup(w: number, d: number, h: number): Float32Array {
+  const c = [
+    [0, 0, 0],
+    [w, 0, 0],
+    [w, d, 0],
+    [0, d, 0],
+    [0, 0, h],
+    [w, 0, h],
+    [w, d, h],
+    [0, d, h],
+  ];
+  const faces = [
+    [0, 2, 1],
+    [0, 3, 2], // bottom (-z)
+    [4, 5, 6],
+    [4, 6, 7], // top (+z)
+    [0, 1, 5],
+    [0, 5, 4], // front (-y)
+    [2, 3, 7],
+    [2, 7, 6], // back (+y)
+    [0, 4, 7],
+    [0, 7, 3], // left (-x)
+    [1, 2, 6],
+    [1, 6, 5], // right (+x)
+  ];
+  const soup = new Float32Array(faces.length * 9);
+  faces.forEach((face, f) => {
+    face.forEach((vi, v) => soup.set(c[vi], f * 9 + v * 3));
+  });
+  return soup;
+}
+
+function soupToBinarySTL(soup: Float32Array): ArrayBuffer {
+  return buildSTLBuffer(soup, new Float32Array(soup.length), 'fixture');
+}
+
+function soupToAsciiSTL(soup: Float32Array): ArrayBuffer {
+  let text = 'solid fixture\n';
+  for (let t = 0; t < soup.length / 9; t++) {
+    text += 'facet normal 0 0 0\n outer loop\n';
+    for (let v = 0; v < 3; v++) {
+      const i = t * 9 + v * 3;
+      text += `  vertex ${soup[i]} ${soup[i + 1]} ${soup[i + 2]}\n`;
+    }
+    text += ' endloop\nendfacet\n';
+  }
+  text += 'endsolid fixture\n';
+  const encoded = new TextEncoder().encode(text);
+  return encoded.buffer.slice(0, encoded.byteLength);
+}
+
+function ringArea(ring: ReadonlyArray<MeshOutlinePoint>): number {
+  let area = 0;
+  for (let i = 0; i < ring.length; i++) {
+    const a = ring[i];
+    const b = ring[(i + 1) % ring.length];
+    area += a.x * b.y - b.x * a.y;
+  }
+  return Math.abs(area / 2);
+}
+
+describe('importMeshFromStl', () => {
+  it('imports a watertight binary box end-to-end', async () => {
+    const result = await importMeshFromStl(
+      soupToBinarySTL(boxSoup(20, 10, 5)),
+      'Wrench Holder.stl',
+      undefined,
+      module
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const { asset, positions, indices, suggestedCutDepth } = result.value;
+
+    expect(asset.name).toBe('Wrench Holder');
+    expect(asset.triangleCount).toBe(12);
+    expect(asset.sizeMm.x).toBeCloseTo(20, 3);
+    expect(asset.sizeMm.y).toBeCloseTo(10, 3);
+    expect(asset.sizeMm.z).toBeCloseTo(5, 3);
+    expect(suggestedCutDepth).toBeCloseTo(5, 3);
+
+    expect(asset.outlines).toHaveLength(1);
+    expect(ringArea(asset.outlines[0])).toBeCloseTo(200, 0);
+
+    expect(positions.length).toBeGreaterThan(0);
+    expect(indices.length).toBe(36);
+    expect(Array.from(positions).every(Number.isFinite)).toBe(true);
+    // Origin-normalized: bbox min at (0,0,0)
+    let minX = Infinity;
+    let minZ = Infinity;
+    for (let i = 0; i < positions.length; i += 3) {
+      minX = Math.min(minX, positions[i]);
+      minZ = Math.min(minZ, positions[i + 2]);
+    }
+    expect(minX).toBeCloseTo(0, 4);
+    expect(minZ).toBeCloseTo(0, 4);
+  });
+
+  it('lays a standing box flat (min height orientation)', async () => {
+    const result = await importMeshFromStl(
+      soupToBinarySTL(boxSoup(5, 10, 20)),
+      'standing.stl',
+      undefined,
+      module
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const { sizeMm } = result.value.asset;
+    expect(sizeMm.z).toBeCloseTo(5, 3);
+    const footprint = [sizeMm.x, sizeMm.y].sort((a, b) => a - b);
+    expect(footprint[0]).toBeCloseTo(10, 3);
+    expect(footprint[1]).toBeCloseTo(20, 3);
+  });
+
+  it('applies quarter-turn flips after lay-flat', async () => {
+    const result = await importMeshFromStl(
+      soupToBinarySTL(boxSoup(20, 10, 5)),
+      'flipped.stl',
+      { x: 1, y: 0, z: 0 },
+      module
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    // 90° about X swaps the lay-flat Y (10) into Z
+    expect(result.value.asset.sizeMm.z).toBeCloseTo(10, 3);
+    expect(result.value.suggestedCutDepth).toBeCloseTo(10, 3);
+  });
+
+  it('imports ASCII STL through the same pipeline', async () => {
+    const result = await importMeshFromStl(
+      soupToAsciiSTL(boxSoup(20, 10, 5)),
+      'ascii.stl',
+      undefined,
+      module
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.asset.triangleCount).toBe(12);
+    expect(result.value.asset.sizeMm.z).toBeCloseTo(5, 3);
+  });
+
+  it('decodes the stored asset back to the preview geometry', async () => {
+    const result = await importMeshFromStl(
+      soupToBinarySTL(boxSoup(20, 10, 5)),
+      'roundtrip.stl',
+      undefined,
+      module
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+
+    const decoded = unwrap(await decodeMeshData(result.value.asset.data));
+    expect(decoded.indices).toEqual(result.value.indices);
+    expect(decoded.positions).toHaveLength(result.value.positions.length);
+    for (let i = 0; i < decoded.positions.length; i++) {
+      expect(Math.abs(decoded.positions[i] - result.value.positions[i])).toBeLessThan(0.01);
+    }
+  });
+
+  it('decimates a high-resolution mesh to the triangle budget', async () => {
+    // Generate a ~65k-triangle sphere with manifold itself, then round-trip
+    // it through STL as the "user upload"
+    const sphere = module.Manifold.sphere(20, 360);
+    try {
+      const mesh = sphere.getMesh();
+      const soup = new Float32Array(mesh.triVerts.length * 3);
+      for (let i = 0; i < mesh.triVerts.length; i++) {
+        const vi = mesh.triVerts[i];
+        soup[i * 3] = mesh.vertProperties[vi * mesh.numProp];
+        soup[i * 3 + 1] = mesh.vertProperties[vi * mesh.numProp + 1];
+        soup[i * 3 + 2] = mesh.vertProperties[vi * mesh.numProp + 2];
+      }
+      expect(mesh.triVerts.length / 3).toBeGreaterThan(MAX_MESH_ASSET_TRIANGLES);
+
+      const result = await importMeshFromStl(
+        soupToBinarySTL(soup),
+        'sphere.stl',
+        undefined,
+        module
+      );
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      expect(result.value.asset.triangleCount).toBeLessThanOrEqual(MAX_MESH_ASSET_TRIANGLES);
+      expect(result.value.asset.triangleCount).toBeGreaterThan(0);
+      expect(result.value.asset.sizeMm.x).toBeCloseTo(40, 0);
+      expect(result.value.asset.sizeMm.z).toBeCloseTo(40, 0);
+    } finally {
+      sphere.delete();
+    }
+  }, 60_000);
+
+  it('rejects a non-watertight mesh with a repair hint', async () => {
+    // Box soup missing one triangle: an open hole merge() cannot fix
+    const soup = boxSoup(20, 10, 5).slice(0, 11 * 9);
+    const result = await importMeshFromStl(
+      soupToBinarySTL(new Float32Array(soup)),
+      'holey.stl',
+      undefined,
+      module
+    );
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.reason).toBe('not_manifold');
+    expect(result.error.message).toMatch(/repair/i);
+  });
+
+  it('rejects garbage buffers as parse failures', async () => {
+    const junk = new TextEncoder().encode('this is not an stl file').buffer;
+    const result = await importMeshFromStl(junk, 'junk.stl', undefined, module);
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.reason).toBe('parse_failed');
+  });
+
+  it('rejects oversized files before parsing', async () => {
+    const oversized = new ArrayBuffer(MAX_MESH_FILE_BYTES + 1);
+    const result = await importMeshFromStl(oversized, 'huge.stl', undefined, module);
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.reason).toBe('too_large');
+  });
+});

--- a/src/features/generation/worker/generators/meshImport.ts
+++ b/src/features/generation/worker/generators/meshImport.ts
@@ -1,0 +1,291 @@
+/**
+ * STL → MeshAsset import pipeline (worker-side).
+ *
+ * parse → weld/merge (repair) → manifold-check → auto lay-flat → user flips →
+ * decimate to budget → silhouette outlines → quantize+compress.
+ *
+ * Runs on the raw manifold-3d module (independent of the worker's brepjs
+ * kernel): mesh CSG needs watertight input, which is exactly what this
+ * pipeline validates and normalizes for the later imprint subtract.
+ */
+
+import type { CrossSection, Manifold, ManifoldToplevel } from 'manifold-3d';
+import { err, isErr, ok } from '@/core/result';
+import type { Result } from '@/core/result';
+import { parseSTL } from '@/shared/generation/stlParser';
+import {
+  encodeMeshData,
+  MAX_MESH_ASSET_TRIANGLES,
+  MAX_MESH_FILE_BYTES,
+  MAX_MESH_OUTLINE_POINTS,
+} from '@/shared/generation/meshAsset';
+import type {
+  MeshAsset,
+  MeshImportErrorReason,
+  MeshImportFlips,
+  MeshOutlinePoint,
+} from '@/shared/generation/meshAsset';
+import { simplifyRdp } from '@/shared/scanTrace/simplify';
+import { getManifoldModule } from '../manifoldRuntime';
+
+export interface MeshImportError {
+  readonly reason: MeshImportErrorReason;
+  readonly message: string;
+}
+
+export interface MeshImportResult {
+  readonly asset: MeshAsset;
+  /** Decimated, oriented, origin-normalized mesh for the preview dialog. */
+  readonly positions: Float32Array;
+  readonly indices: Uint32Array;
+  /** Default pocket depth: the oriented mesh height (mm). */
+  readonly suggestedCutDepth: number;
+}
+
+/**
+ * Candidate "which face is down" rotations for lay-flat: the 6 axis-aligned
+ * down-faces. Z-spins are omitted — they never change height and the user
+ * rotates the footprint freely in the 2D editor anyway.
+ */
+const LAY_FLAT_CANDIDATES: ReadonlyArray<readonly [number, number, number]> = [
+  [0, 0, 0],
+  [180, 0, 0],
+  [90, 0, 0],
+  [270, 0, 0],
+  [0, 90, 0],
+  [0, 270, 0],
+];
+
+const DECIMATE_TOLERANCES_MM = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2] as const;
+const OUTLINE_EPSILON_MM = 0.05;
+
+function sanitizeName(fileName: string): string {
+  return (
+    fileName
+      .replace(/\.(stl)$/i, '')
+      // eslint-disable-next-line no-control-regex -- strip control chars from user file names
+      .replace(/[\x00-\x1f\x7f]/g, '')
+      .trim()
+      .slice(0, 64) || 'imported-mesh'
+  );
+}
+
+function signedArea(ring: ReadonlyArray<readonly [number, number]>): number {
+  let area = 0;
+  for (let i = 0; i < ring.length; i++) {
+    const [x1, y1] = ring[i];
+    const [x2, y2] = ring[(i + 1) % ring.length];
+    area += x1 * y2 - x2 * y1;
+  }
+  return area / 2;
+}
+
+/**
+ * Extract simplified outer silhouette rings from the oriented manifold.
+ * Holes (negative-area rings) are dropped: the footprint, clearance offset,
+ * and chamfer rim all operate on the insertion opening, which is the outer
+ * boundary. Point count is capped by re-simplifying with a doubled epsilon.
+ */
+function extractOutlines(oriented: Manifold): MeshOutlinePoint[][] {
+  const projected: CrossSection = oriented.project();
+  try {
+    const simplified = projected.simplify(0.02);
+    try {
+      const rings = simplified
+        .toPolygons()
+        .filter((ring) => signedArea(ring) > 0)
+        .map((ring) => ring.map(([x, y]) => ({ x, y })));
+
+      let epsilon = OUTLINE_EPSILON_MM;
+      let outlines = rings.map((ring) => simplifyRdp(ring, epsilon));
+      while (
+        outlines.reduce((total, ring) => total + ring.length, 0) > MAX_MESH_OUTLINE_POINTS &&
+        epsilon < 5
+      ) {
+        epsilon *= 2;
+        outlines = rings.map((ring) => simplifyRdp(ring, epsilon));
+      }
+      return outlines;
+    } finally {
+      simplified.delete();
+    }
+  } finally {
+    projected.delete();
+  }
+}
+
+function orientationScore(candidate: Manifold): { height: number; footprint: number } {
+  const box = candidate.boundingBox();
+  return {
+    height: box.max[2] - box.min[2],
+    footprint: (box.max[0] - box.min[0]) * (box.max[1] - box.min[1]),
+  };
+}
+
+/** Pick the lay-flat rotation: minimal height, tie-broken by max footprint. */
+function pickLayFlatRotation(manifold: Manifold): readonly [number, number, number] {
+  let best: readonly [number, number, number] = LAY_FLAT_CANDIDATES[0];
+  let bestHeight = Infinity;
+  let bestFootprint = -Infinity;
+  const HEIGHT_TIE_MM = 1e-6;
+  for (const rotation of LAY_FLAT_CANDIDATES) {
+    const rotated = manifold.rotate([...rotation]);
+    try {
+      const { height, footprint } = orientationScore(rotated);
+      if (
+        height < bestHeight - HEIGHT_TIE_MM ||
+        (Math.abs(height - bestHeight) <= HEIGHT_TIE_MM && footprint > bestFootprint)
+      ) {
+        best = rotation;
+        bestHeight = height;
+        bestFootprint = footprint;
+      }
+    } finally {
+      rotated.delete();
+    }
+  }
+  return best;
+}
+
+/** Decimate to the triangle budget by walking a tolerance ladder. */
+function decimateToBudget(manifold: Manifold): Manifold | null {
+  if (manifold.numTri() <= MAX_MESH_ASSET_TRIANGLES) return manifold;
+  for (const tolerance of DECIMATE_TOLERANCES_MM) {
+    const simplified = manifold.simplify(tolerance);
+    if (simplified.numTri() <= MAX_MESH_ASSET_TRIANGLES) {
+      manifold.delete();
+      return simplified;
+    }
+    simplified.delete();
+  }
+  return null;
+}
+
+/**
+ * Full import: STL buffer → compressed MeshAsset + preview arrays.
+ *
+ * `flips` compose AFTER the deterministic auto lay-flat, so re-running with
+ * different flips is stable (the auto orientation never changes for a given
+ * file).
+ */
+export async function importMeshFromStl(
+  buffer: ArrayBuffer,
+  fileName: string,
+  flips: MeshImportFlips = { x: 0, y: 0, z: 0 },
+  // Node tests inject an fs-instantiated module; the worker's fetch-based
+  // loader can't run outside the browser.
+  moduleOverride?: ManifoldToplevel
+): Promise<Result<MeshImportResult, MeshImportError>> {
+  if (buffer.byteLength > MAX_MESH_FILE_BYTES) {
+    return err({
+      reason: 'too_large',
+      message: `File is ${Math.round(buffer.byteLength / 1024 / 1024)}MB (max ${MAX_MESH_FILE_BYTES / 1024 / 1024}MB)`,
+    });
+  }
+
+  const parsed = parseSTL(buffer);
+  if (isErr(parsed)) {
+    return err({ reason: 'parse_failed', message: parsed.error.message });
+  }
+  if (parsed.value.vertices.length === 0) {
+    return err({ reason: 'empty', message: 'STL contains no triangles' });
+  }
+
+  const module: ManifoldToplevel = moduleOverride ?? (await getManifoldModule());
+
+  const soupVertexCount = parsed.value.vertices.length / 3;
+  const triVerts = new Uint32Array(soupVertexCount);
+  for (let i = 0; i < soupVertexCount; i++) triVerts[i] = i;
+  const inputMesh = new module.Mesh({
+    numProp: 3,
+    vertProperties: parsed.value.vertices,
+    triVerts,
+  });
+  inputMesh.merge();
+
+  let solid: Manifold;
+  try {
+    solid = new module.Manifold(inputMesh);
+  } catch {
+    return err({
+      reason: 'not_manifold',
+      message:
+        'Mesh is not watertight (has holes or self-intersections) — try repairing it in your slicer, then re-export',
+    });
+  }
+
+  let oriented: Manifold | null = null;
+  try {
+    const decimated = decimateToBudget(solid);
+    if (decimated === null) {
+      return err({
+        reason: 'too_large',
+        message: `Mesh is too complex to simplify below ${MAX_MESH_ASSET_TRIANGLES} triangles`,
+      });
+    }
+    // decimateToBudget consumed `solid` if it returned a new manifold
+    solid = decimated;
+
+    const layFlat = pickLayFlatRotation(solid);
+    const flipRotation: readonly [number, number, number] = [
+      (((flips.x % 4) + 4) % 4) * 90,
+      (((flips.y % 4) + 4) % 4) * 90,
+      (((flips.z % 4) + 4) % 4) * 90,
+    ];
+    const laid = solid.rotate([...layFlat]);
+    const flipped = laid.rotate([...flipRotation]);
+    laid.delete();
+
+    const box = flipped.boundingBox();
+    oriented = flipped.translate([-box.min[0], -box.min[1], -box.min[2]]);
+    flipped.delete();
+
+    const finalBox = oriented.boundingBox();
+    const sizeMm = {
+      x: finalBox.max[0],
+      y: finalBox.max[1],
+      z: finalBox.max[2],
+    };
+
+    const outlines = extractOutlines(oriented);
+    if (outlines.length === 0) {
+      return err({ reason: 'empty', message: 'Mesh has no projected footprint' });
+    }
+
+    const outputMesh = oriented.getMesh();
+    const positions =
+      outputMesh.numProp === 3
+        ? outputMesh.vertProperties
+        : extractPositions(outputMesh.vertProperties, outputMesh.numProp);
+    const indices = outputMesh.triVerts;
+
+    const encoded = await encodeMeshData(positions, indices);
+    if (isErr(encoded)) {
+      return err({ reason: 'parse_failed', message: encoded.error.message });
+    }
+
+    const asset: MeshAsset = {
+      name: sanitizeName(fileName),
+      data: encoded.value,
+      triangleCount: oriented.numTri(),
+      sizeMm,
+      outlines,
+    };
+
+    return ok({ asset, positions, indices, suggestedCutDepth: sizeMm.z });
+  } finally {
+    solid.delete();
+    oriented?.delete();
+  }
+}
+
+function extractPositions(vertProperties: Float32Array, numProp: number): Float32Array {
+  const vertexCount = vertProperties.length / numProp;
+  const positions = new Float32Array(vertexCount * 3);
+  for (let v = 0; v < vertexCount; v++) {
+    positions[v * 3] = vertProperties[v * numProp];
+    positions[v * 3 + 1] = vertProperties[v * numProp + 1];
+    positions[v * 3 + 2] = vertProperties[v * numProp + 2];
+  }
+  return positions;
+}

--- a/src/features/generation/worker/handlers/importMeshHandler.test.ts
+++ b/src/features/generation/worker/handlers/importMeshHandler.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ok, err } from '@/core/result';
+import type { ImportMeshMessage } from '../../bridge/types';
+
+const importMeshFromStl = vi.fn();
+vi.mock('../generators/meshImport', () => ({
+  importMeshFromStl: (...args: unknown[]) => importMeshFromStl(...args),
+}));
+
+import { handleImportMesh } from './importMeshHandler';
+
+const postMessage = vi.fn();
+
+function message(): ImportMeshMessage {
+  return {
+    type: 'IMPORT_MESH',
+    payload: { requestId: 'import-1', buffer: new ArrayBuffer(8), fileName: 'tool.stl' },
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('self', { postMessage });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('handleImportMesh', () => {
+  it('posts the result with transferred arrays on success', async () => {
+    const positions = new Float32Array([0, 0, 0]);
+    const indices = new Uint32Array([0, 1, 2]);
+    importMeshFromStl.mockResolvedValue(
+      ok({
+        asset: {
+          name: 'tool',
+          data: 'x',
+          triangleCount: 1,
+          sizeMm: { x: 1, y: 1, z: 1 },
+          outlines: [],
+        },
+        positions,
+        indices,
+        suggestedCutDepth: 1,
+      })
+    );
+
+    await handleImportMesh(message());
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const [response, options] = postMessage.mock.calls[0];
+    expect(response.type).toBe('IMPORT_MESH_RESULT');
+    expect(response.requestId).toBe('import-1');
+    expect(response.suggestedCutDepth).toBe(1);
+    expect(options.transfer).toEqual([positions.buffer, indices.buffer]);
+  });
+
+  it('posts a typed error when the pipeline reports one', async () => {
+    importMeshFromStl.mockResolvedValue(err({ reason: 'not_manifold', message: 'mesh has holes' }));
+
+    await handleImportMesh(message());
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'IMPORT_MESH_ERROR',
+      requestId: 'import-1',
+      reason: 'not_manifold',
+      error: 'mesh has holes',
+    });
+  });
+
+  it('converts unexpected throws into parse_failed errors', async () => {
+    importMeshFromStl.mockRejectedValue(new Error('wasm exploded'));
+
+    await handleImportMesh(message());
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'IMPORT_MESH_ERROR',
+      requestId: 'import-1',
+      reason: 'parse_failed',
+      error: 'wasm exploded',
+    });
+  });
+});

--- a/src/features/generation/worker/handlers/importMeshHandler.ts
+++ b/src/features/generation/worker/handlers/importMeshHandler.ts
@@ -1,0 +1,43 @@
+/**
+ * IMPORT_MESH handler — runs the STL → MeshAsset pipeline and posts the
+ * result with the preview arrays transferred (not copied).
+ *
+ * Deliberately does not require the brepjs kernel: the pipeline runs on the
+ * raw manifold-3d module, which loads independently, so imports work even
+ * before (or without) kernel init.
+ */
+
+import { isErr } from '@/core/result';
+import type { ImportMeshMessage, ImportMeshErrorResponse } from '../../bridge/types';
+import { importMeshFromStl } from '../generators/meshImport';
+import { formatError } from './workerContext';
+
+export async function handleImportMesh(message: ImportMeshMessage): Promise<void> {
+  const { requestId, buffer, fileName, flips } = message.payload;
+  try {
+    const result = await importMeshFromStl(buffer, fileName, flips);
+    if (isErr(result)) {
+      const response: ImportMeshErrorResponse = {
+        type: 'IMPORT_MESH_ERROR',
+        requestId,
+        reason: result.error.reason,
+        error: result.error.message,
+      };
+      self.postMessage(response);
+      return;
+    }
+    const { asset, positions, indices, suggestedCutDepth } = result.value;
+    self.postMessage(
+      { type: 'IMPORT_MESH_RESULT', requestId, asset, positions, indices, suggestedCutDepth },
+      { transfer: [positions.buffer, indices.buffer] }
+    );
+  } catch (e) {
+    const response: ImportMeshErrorResponse = {
+      type: 'IMPORT_MESH_ERROR',
+      requestId,
+      reason: 'parse_failed',
+      error: formatError(e),
+    };
+    self.postMessage(response);
+  }
+}

--- a/src/features/generation/worker/manifoldRuntime.ts
+++ b/src/features/generation/worker/manifoldRuntime.ts
@@ -1,0 +1,65 @@
+/**
+ * Singleton accessor for the raw manifold-3d WASM module inside a generation
+ * worker.
+ *
+ * Two consumers share this instance:
+ *  - `wasmInstantiator.loadManifold()` registers it as the brepjs draft kernel
+ *    (manifold draft-preview worker).
+ *  - Mesh import / mesh imprint code uses the module directly for mesh CSG,
+ *    independent of which brepjs kernel the worker runs — the occt exact
+ *    worker lazy-loads manifold only when a design actually uses mesh
+ *    cutouts, so the extra WASM never costs anything otherwise.
+ *
+ * Emscripten's own .wasm path detection fails in Vite ES module workers, so
+ * the binary is fetched via the ?url-resolved asset and validated (`\0asm`
+ * magic) before instantiation — a stale service-worker cache otherwise
+ * surfaces as an opaque CompileError deep in Emscripten.
+ */
+
+import type { ManifoldToplevel } from 'manifold-3d';
+
+let modulePromise: Promise<ManifoldToplevel> | null = null;
+
+async function instantiate(): Promise<ManifoldToplevel> {
+  const [{ default: ManifoldModule }, manifoldWasmUrlMod] = await Promise.all([
+    import('manifold-3d'),
+    import('manifold-3d/manifold.wasm?url'),
+  ]);
+
+  const url = manifoldWasmUrlMod.default;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Manifold WASM fetch failed: ${response.status} ${response.statusText} (${url})`
+    );
+  }
+  const wasmBinary = await response.arrayBuffer();
+  const header = new Uint8Array(wasmBinary, 0, Math.min(4, wasmBinary.byteLength));
+  const isWasm =
+    header[0] === 0x00 && header[1] === 0x61 && header[2] === 0x73 && header[3] === 0x6d;
+  if (!isWasm) {
+    const contentType = response.headers.get('content-type') ?? 'unknown';
+    throw new Error(
+      `Manifold WASM asset returned ${contentType}, not a WebAssembly binary (${url}). ` +
+        `A stale cache or service worker is likely serving a missing asset — hard-reload the page ` +
+        `(or clear the service worker) to fetch the current build.`
+    );
+  }
+
+  // The published manifold-3d types only expose `locateFile`, but the
+  // Emscripten runtime also honors `wasmBinary` (skips its own fetch).
+  const module = await ManifoldModule({ wasmBinary } as unknown as {
+    locateFile: () => string;
+  });
+  module.setup();
+  return module;
+}
+
+/** Load (once) and return the raw manifold-3d module for this worker. */
+export function getManifoldModule(): Promise<ManifoldToplevel> {
+  modulePromise ??= instantiate().catch((error: unknown) => {
+    modulePromise = null;
+    throw error;
+  });
+  return modulePromise;
+}

--- a/src/features/generation/worker/wasmInstantiator.ts
+++ b/src/features/generation/worker/wasmInstantiator.ts
@@ -11,6 +11,7 @@
 import { registerKernel, BrepkitAdapter, loadFont, initFromManifold, getKernel } from 'brepjs';
 
 import { DRAFT_MIN_CIRCULAR_ANGLE_DEG } from '@/shared/constants/tessellation';
+import { getManifoldModule } from './manifoldRuntime';
 import atkinsonFontUrl from './assets/fonts/AtkinsonHyperlegible-Regular.ttf?url';
 import jetbrainsMonoFontUrl from './assets/fonts/JetBrainsMono-Regular.ttf?url';
 import allertaStencilFontUrl from './assets/fonts/AllertaStencil-Regular.ttf?url';
@@ -135,23 +136,10 @@ export async function loadBrepkit(): Promise<WasmLoadResult> {
 export async function loadManifold(): Promise<WasmLoadResult> {
   const hardwareConcurrency = getHardwareConcurrency();
 
-  // Dynamic imports keep the manifold WASM out of the main worker chunk. The
-  // Emscripten factory locates its .wasm by environment detection, which fails
-  // in Vite ES module workers; fetch+validate the ?url-resolved binary ourselves
-  // and hand it to the factory so a stale-asset HTML response fails loud here
-  // rather than as an opaque WASM CompileError deep in Emscripten.
-  const [{ default: ManifoldModule }, manifoldWasmUrlMod] = await Promise.all([
-    import('manifold-3d'),
-    import('manifold-3d/manifold.wasm?url'),
-  ]);
-
-  const wasmBinary = await fetchWasmBinary(manifoldWasmUrlMod.default, 'Manifold');
-  // The published manifold-3d types only expose `locateFile`, but the Emscripten
-  // runtime also honors `wasmBinary` (skips its own fetch entirely).
-  const module = await ManifoldModule({ wasmBinary } as unknown as {
-    locateFile: () => string;
-  });
-  module.setup();
+  // The raw module lives in manifoldRuntime so mesh import/imprint code can
+  // share the same instance (and the occt worker can lazy-load it without
+  // registering a kernel).
+  const module = await getManifoldModule();
   initFromManifold(module);
   const manifoldKernel = getKernel('manifold');
   manifoldKernel.setQuality?.('draft');

--- a/src/shared/generation/meshAsset.test.ts
+++ b/src/shared/generation/meshAsset.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { encodeMeshData, decodeMeshData } from './meshAsset';
+import { isOk, isErr, unwrap } from '@/core/result';
+
+/** A unit tetrahedron scaled to tool-ish dimensions (mm). */
+function tetrahedron(scale = 40): { positions: Float32Array; indices: Uint32Array } {
+  const positions = new Float32Array([0, 0, 0, scale, 0, 0, 0, scale, 0, 0, 0, scale]);
+  const indices = new Uint32Array([0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3]);
+  return { positions, indices };
+}
+
+describe('meshAsset codec', () => {
+  it('round-trips positions within quantization tolerance', async () => {
+    const { positions, indices } = tetrahedron();
+    const encoded = unwrap(await encodeMeshData(positions, indices));
+    expect(typeof encoded).toBe('string');
+
+    const decoded = unwrap(await decodeMeshData(encoded));
+    expect(decoded.indices).toEqual(indices);
+    expect(decoded.positions).toHaveLength(positions.length);
+    // 40mm extent / 65535 steps ≈ 0.0006mm resolution; assert well within 0.01mm
+    for (let i = 0; i < positions.length; i++) {
+      expect(Math.abs(decoded.positions[i] - positions[i])).toBeLessThan(0.01);
+    }
+  });
+
+  it('round-trips negative and offset coordinates', async () => {
+    const positions = new Float32Array([-12.5, -3.25, 7.75, 30.5, -3.25, 7.75, -12.5, 44, 100.125]);
+    const indices = new Uint32Array([0, 1, 2]);
+    const decoded = unwrap(await decodeMeshData(unwrap(await encodeMeshData(positions, indices))));
+    for (let i = 0; i < positions.length; i++) {
+      expect(Math.abs(decoded.positions[i] - positions[i])).toBeLessThan(0.01);
+    }
+  });
+
+  it('handles a degenerate flat axis (zero extent) without NaN', async () => {
+    const positions = new Float32Array([0, 0, 5, 10, 0, 5, 0, 10, 5]);
+    const indices = new Uint32Array([0, 1, 2]);
+    const decoded = unwrap(await decodeMeshData(unwrap(await encodeMeshData(positions, indices))));
+    expect(decoded.positions[2]).toBeCloseTo(5);
+    expect(decoded.positions[5]).toBeCloseTo(5);
+    expect(Array.from(decoded.positions).every(Number.isFinite)).toBe(true);
+  });
+
+  it('rejects empty arrays', async () => {
+    const result = await encodeMeshData(new Float32Array(0), new Uint32Array(0));
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('rejects non-finite positions', async () => {
+    const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, NaN, 0]);
+    const result = await encodeMeshData(positions, new Uint32Array([0, 1, 2]));
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('rejects out-of-range indices on encode', async () => {
+    const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const result = await encodeMeshData(positions, new Uint32Array([0, 1, 9]));
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('rejects corrupt base64 on decode', async () => {
+    const result = await decodeMeshData('definitely-not-an-asset!!');
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('rejects a valid deflate stream with a wrong magic', async () => {
+    // Deflate arbitrary bytes so decompression succeeds but the header check fails
+    const junk = new Uint8Array(64);
+    const stream = new Blob([junk]).stream().pipeThrough(new CompressionStream('deflate'));
+    const compressed = new Uint8Array(await new Response(stream).arrayBuffer());
+    let binary = '';
+    for (const byte of compressed) binary += String.fromCharCode(byte);
+    const result = await decodeMeshData(btoa(binary));
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('compresses a repetitive mesh well below raw size', async () => {
+    // A grid of identical quads: 800 triangles with heavy structural repetition
+    const cols = 20;
+    const rows = 20;
+    const positions = new Float32Array((cols + 1) * (rows + 1) * 3);
+    for (let y = 0; y <= rows; y++) {
+      for (let x = 0; x <= cols; x++) {
+        const i = (y * (cols + 1) + x) * 3;
+        positions[i] = x * 2;
+        positions[i + 1] = y * 2;
+        positions[i + 2] = 0;
+      }
+    }
+    const indexList: number[] = [];
+    for (let y = 0; y < rows; y++) {
+      for (let x = 0; x < cols; x++) {
+        const a = y * (cols + 1) + x;
+        const b = a + 1;
+        const c = a + (cols + 1);
+        const d = c + 1;
+        indexList.push(a, b, c, b, d, c);
+      }
+    }
+    const indices = Uint32Array.from(indexList);
+
+    const result = await encodeMeshData(positions, indices);
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const rawBytes = positions.byteLength + indices.byteLength;
+    // base64 inflates by 4/3; still expect a large net win on structured data
+    expect(result.value.length).toBeLessThan(rawBytes / 2);
+  });
+});

--- a/src/shared/generation/meshAsset.ts
+++ b/src/shared/generation/meshAsset.ts
@@ -1,0 +1,217 @@
+/**
+ * Compressed mesh asset codec for imported STL imprint meshes.
+ *
+ * An imported tool mesh is decimated in the worker, then stored inside the
+ * design as a compact string: positions quantized to a uint16 grid over the
+ * mesh bounding box (≤0.01mm resolution at drawer-tool scale), deflated via
+ * CompressionStream, base64-encoded. The codec is symmetric and lossless
+ * apart from the quantization step.
+ *
+ * Binary layout before compression (little-endian):
+ *   magic   u32  'GMA1'
+ *   vCount  u32  vertex count
+ *   tCount  u32  triangle count
+ *   bbox    6×f32  minX minY minZ maxX maxY maxZ
+ *   pos     vCount×3 × u16  normalized to bbox per axis
+ *   idx     tCount×3 × u32
+ */
+
+import { err, ok, validationImportFailed } from '@/core/result';
+import type { Result, ValidationError } from '@/core/result';
+
+/** A 2D silhouette ring in mm, in the mesh's lay-flat XY frame. */
+export interface MeshOutlinePoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * A stored imprint mesh: decimated, lay-flat oriented, compressed. Lives in
+ * `BinParams.meshAssets`, referenced from cutouts with `shape: 'mesh'`.
+ */
+export interface MeshAsset {
+  /** Original file name (sanitized, extension stripped by the importer). */
+  readonly name: string;
+  /** base64(deflate(quantized mesh)) — see codec layout above. */
+  readonly data: string;
+  readonly triangleCount: number;
+  /** Oriented (lay-flat) bounding box size in mm. */
+  readonly sizeMm: { readonly x: number; readonly y: number; readonly z: number };
+  /**
+   * Top-down silhouette outer rings (holes dropped), simplified. Powers the 2D
+   * footprint render, clearance offset, and chamfer rim without decoding the
+   * mesh on the main thread.
+   */
+  readonly outlines: ReadonlyArray<ReadonlyArray<MeshOutlinePoint>>;
+}
+
+/** Why a mesh import failed — drives the user-facing toast + analytics reason. */
+export type MeshImportErrorReason = 'too_large' | 'parse_failed' | 'not_manifold' | 'empty';
+
+/** Quarter-turn counts (0–3) applied about each axis AFTER auto lay-flat. */
+export interface MeshImportFlips {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+/** Hard cap on the uploaded STL file size (bytes). */
+export const MAX_MESH_FILE_BYTES = 50 * 1024 * 1024;
+/** Triangle budget an imported mesh is decimated to fit. */
+export const MAX_MESH_ASSET_TRIANGLES = 50_000;
+/** Max mesh assets per design. */
+export const MAX_MESH_ASSETS_PER_DESIGN = 8;
+/** Max total silhouette points across all outlines of one asset. */
+export const MAX_MESH_OUTLINE_POINTS = 2000;
+
+const MAGIC = 0x314d4741; // 'GMA1'
+const HEADER_BYTES = 4 + 4 + 4 + 6 * 4;
+const QUANT_MAX = 65535;
+
+/** Decoded mesh arrays: indexed triangles, positions in mm. */
+export interface DecodedMeshData {
+  readonly positions: Float32Array;
+  readonly indices: Uint32Array;
+}
+
+async function pipeThrough(
+  input: Uint8Array,
+  stream: CompressionStream | DecompressionStream
+): Promise<Uint8Array> {
+  const src = new Blob([input as BlobPart]).stream().pipeThrough(stream);
+  const buffer = await new Response(src).arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(data: string): Uint8Array {
+  const binary = atob(data);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Encodes indexed mesh arrays (positions in mm) into the compressed asset
+ * string. Rejects empty or non-finite geometry.
+ */
+export async function encodeMeshData(
+  positions: Float32Array,
+  indices: Uint32Array
+): Promise<Result<string, ValidationError>> {
+  const vertexCount = positions.length / 3;
+  const triangleCount = indices.length / 3;
+  if (
+    vertexCount === 0 ||
+    triangleCount === 0 ||
+    !Number.isInteger(vertexCount) ||
+    !Number.isInteger(triangleCount)
+  ) {
+    return err(validationImportFailed(['Mesh encode failed: empty or malformed arrays']));
+  }
+
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < positions.length; i++) {
+    const v = positions[i];
+    if (!Number.isFinite(v)) {
+      return err(validationImportFailed(['Mesh encode failed: non-finite vertex position']));
+    }
+    const axis = i % 3;
+    if (v < min[axis]) min[axis] = v;
+    if (v > max[axis]) max[axis] = v;
+  }
+
+  const raw = new ArrayBuffer(HEADER_BYTES + vertexCount * 3 * 2 + triangleCount * 3 * 4);
+  const view = new DataView(raw);
+  view.setUint32(0, MAGIC, true);
+  view.setUint32(4, vertexCount, true);
+  view.setUint32(8, triangleCount, true);
+  for (let axis = 0; axis < 3; axis++) {
+    view.setFloat32(12 + axis * 4, min[axis], true);
+    view.setFloat32(24 + axis * 4, max[axis], true);
+  }
+
+  const extent = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+  const quantized = new Uint16Array(raw, HEADER_BYTES, vertexCount * 3);
+  for (let i = 0; i < positions.length; i++) {
+    const axis = i % 3;
+    quantized[i] =
+      extent[axis] > 0 ? Math.round(((positions[i] - min[axis]) / extent[axis]) * QUANT_MAX) : 0;
+  }
+
+  const idxOffset = HEADER_BYTES + vertexCount * 3 * 2;
+  const idxView = new DataView(raw, idxOffset);
+  for (let i = 0; i < indices.length; i++) {
+    if (indices[i] >= vertexCount) {
+      return err(validationImportFailed(['Mesh encode failed: index out of range']));
+    }
+    idxView.setUint32(i * 4, indices[i], true);
+  }
+
+  const compressed = await pipeThrough(new Uint8Array(raw), new CompressionStream('deflate'));
+  return ok(bytesToBase64(compressed));
+}
+
+/**
+ * Decodes an asset string back to indexed mesh arrays (positions in mm).
+ * Validates structure so a corrupted or foreign string never yields NaN
+ * geometry downstream.
+ */
+export async function decodeMeshData(
+  data: string
+): Promise<Result<DecodedMeshData, ValidationError>> {
+  let raw: Uint8Array;
+  try {
+    raw = await pipeThrough(base64ToBytes(data), new DecompressionStream('deflate'));
+  } catch {
+    return err(validationImportFailed(['Mesh decode failed: corrupt asset data']));
+  }
+
+  if (raw.byteLength < HEADER_BYTES) {
+    return err(validationImportFailed(['Mesh decode failed: truncated header']));
+  }
+  const view = new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
+  if (view.getUint32(0, true) !== MAGIC) {
+    return err(validationImportFailed(['Mesh decode failed: bad magic']));
+  }
+  const vertexCount = view.getUint32(4, true);
+  const triangleCount = view.getUint32(8, true);
+  const expected = HEADER_BYTES + vertexCount * 3 * 2 + triangleCount * 3 * 4;
+  if (raw.byteLength !== expected || vertexCount === 0 || triangleCount === 0) {
+    return err(validationImportFailed(['Mesh decode failed: size mismatch']));
+  }
+
+  const min = [view.getFloat32(12, true), view.getFloat32(16, true), view.getFloat32(20, true)];
+  const max = [view.getFloat32(24, true), view.getFloat32(28, true), view.getFloat32(32, true)];
+  if (![...min, ...max].every(Number.isFinite)) {
+    return err(validationImportFailed(['Mesh decode failed: non-finite bounds']));
+  }
+
+  const positions = new Float32Array(vertexCount * 3);
+  for (let i = 0; i < positions.length; i++) {
+    const axis = i % 3;
+    const q = view.getUint16(HEADER_BYTES + i * 2, true);
+    positions[i] = min[axis] + (q / QUANT_MAX) * (max[axis] - min[axis]);
+  }
+
+  const indices = new Uint32Array(triangleCount * 3);
+  const idxOffset = HEADER_BYTES + vertexCount * 3 * 2;
+  for (let i = 0; i < indices.length; i++) {
+    const idx = view.getUint32(idxOffset + i * 4, true);
+    if (idx >= vertexCount) {
+      return err(validationImportFailed(['Mesh decode failed: index out of range']));
+    }
+    indices[i] = idx;
+  }
+
+  return ok({ positions, indices });
+}

--- a/src/shared/generation/stlParser.test.ts
+++ b/src/shared/generation/stlParser.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { parseSTLBinary } from './stlParser';
+import { parseSTLBinary, parseSTLAscii, parseSTL } from './stlParser';
 import { isOk, isErr } from '@/core/result';
 import { buildSTLBuffer } from '@/shared/generation/export';
+
+function asciiSTL(body: string, name = 'test'): ArrayBuffer {
+  const text = `solid ${name}\n${body}endsolid ${name}\n`;
+  const encoded = new TextEncoder().encode(text);
+  return encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength);
+}
+
+const SINGLE_FACET = `facet normal 0 0 1
+  outer loop
+    vertex 0 0 0
+    vertex 1 0 0
+    vertex 0 1 0
+  endloop
+endfacet
+`;
 
 describe('parseSTLBinary', () => {
   /** Build a binary STL with known data for round-trip testing */
@@ -105,5 +120,125 @@ describe('parseSTLBinary', () => {
     if (!isOk(result)) return;
     expect(result.value.vertices).toHaveLength(0);
     expect(result.value.normals).toHaveLength(0);
+  });
+});
+
+describe('parseSTLAscii', () => {
+  it('parses a single facet with replicated normals', () => {
+    const result = parseSTLAscii(asciiSTL(SINGLE_FACET));
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+
+    expect(result.value.vertices).toHaveLength(9);
+    expect(Array.from(result.value.vertices)).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    for (let i = 0; i < 9; i += 3) {
+      expect(result.value.normals[i + 2]).toBeCloseTo(1);
+    }
+  });
+
+  it('parses multiple facets and scientific-notation coordinates', () => {
+    const body = `facet normal 0 0 1
+  outer loop
+    vertex 1.5e1 0 0
+    vertex 0 2.5E-1 0
+    vertex 0 0 -1e0
+  endloop
+endfacet
+${SINGLE_FACET}`;
+    const result = parseSTLAscii(asciiSTL(body));
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.vertices).toHaveLength(18);
+    expect(result.value.vertices[0]).toBeCloseTo(15);
+    expect(result.value.vertices[4]).toBeCloseTo(0.25);
+    expect(result.value.vertices[8]).toBeCloseTo(-1);
+  });
+
+  it('tolerates CRLF line endings and garbage normals', () => {
+    const body =
+      'facet normal foo bar baz\r\n outer loop\r\n vertex 0 0 0\r\n vertex 1 0 0\r\n vertex 0 1 0\r\n endloop\r\nendfacet\r\n';
+    const result = parseSTLAscii(asciiSTL(body));
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.vertices).toHaveLength(9);
+    expect(result.value.normals[0]).toBe(0);
+  });
+
+  it('returns Err on facet with wrong vertex count', () => {
+    const body = `facet normal 0 0 1
+  outer loop
+    vertex 0 0 0
+    vertex 1 0 0
+  endloop
+endfacet
+`;
+    const result = parseSTLAscii(asciiSTL(body));
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.errors[0]).toMatch(/2 vertices/);
+  });
+
+  it('returns Err on malformed vertex coordinates', () => {
+    const body = `facet normal 0 0 1
+  outer loop
+    vertex 0 0 zero
+    vertex 1 0 0
+    vertex 0 1 0
+  endloop
+endfacet
+`;
+    const result = parseSTLAscii(asciiSTL(body));
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.errors[0]).toMatch(/malformed vertex/);
+  });
+
+  it('returns Err on vertex outside a facet', () => {
+    const result = parseSTLAscii(asciiSTL('vertex 0 0 0\n'));
+    expect(isErr(result)).toBe(true);
+  });
+
+  it('returns Err when no facets are present', () => {
+    const result = parseSTLAscii(asciiSTL(''));
+    expect(isErr(result)).toBe(true);
+    if (!isErr(result)) return;
+    expect(result.error.errors[0]).toMatch(/no facets/);
+  });
+});
+
+describe('parseSTL format detection', () => {
+  it('routes binary buffers to the binary parser', () => {
+    const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    const result = parseSTL(buildSTLBuffer(vertices, normals, 'test'));
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.vertices).toHaveLength(9);
+  });
+
+  it('routes ASCII buffers to the ASCII parser', () => {
+    const result = parseSTL(asciiSTL(SINGLE_FACET));
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.vertices).toHaveLength(9);
+  });
+
+  it('prefers binary when the header starts with "solid" but sizes match binary layout', () => {
+    const vertices = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    const buffer = buildSTLBuffer(vertices, normals, 'test');
+    // Overwrite the 80-byte header so it begins with the ASCII keyword.
+    new Uint8Array(buffer).set(new TextEncoder().encode('solid binary-trap'), 0);
+    const result = parseSTL(buffer);
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.vertices).toHaveLength(9);
+    expect(result.value.vertices[3]).toBeCloseTo(1);
+  });
+
+  it('falls through to a binary error for unrecognizable buffers', () => {
+    const junk = new TextEncoder().encode('not an stl at all').buffer;
+    const result = parseSTL(junk);
+    expect(isErr(result)).toBe(true);
   });
 });

--- a/src/shared/generation/stlParser.test.ts
+++ b/src/shared/generation/stlParser.test.ts
@@ -154,6 +154,22 @@ ${SINGLE_FACET}`;
     expect(result.value.vertices[8]).toBeCloseTo(-1);
   });
 
+  it('parses uppercase keywords (case-insensitive exporters)', () => {
+    const body = `FACET NORMAL 0 0 1
+  OUTER LOOP
+    VERTEX 0 0 0
+    VERTEX 1.5E1 0 0
+    VERTEX 0 1 0
+  ENDLOOP
+ENDFACET
+`;
+    const result = parseSTLAscii(asciiSTL(body));
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.vertices).toHaveLength(9);
+    expect(result.value.vertices[3]).toBeCloseTo(15);
+  });
+
   it('tolerates CRLF line endings and garbage normals', () => {
     const body =
       'facet normal foo bar baz\r\n outer loop\r\n vertex 0 0 0\r\n vertex 1 0 0\r\n vertex 0 1 0\r\n endloop\r\nendfacet\r\n';

--- a/src/shared/generation/stlParser.ts
+++ b/src/shared/generation/stlParser.ts
@@ -137,7 +137,10 @@ export function parseSTLAscii(buffer: ArrayBuffer): Result<ParsedSTLMesh, Valida
   let facetVertexCount = -1;
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
+    // Keyword matching is case-insensitive (some exporters write FACET/VERTEX);
+    // lowercasing the whole line is safe for the numeric tokens too (only an
+    // exponent 'E' can change, and Number() accepts either case).
+    const line = lines[i].trim().toLowerCase();
     if (line.startsWith('vertex')) {
       if (facetVertexCount < 0) {
         return err(

--- a/src/shared/generation/stlParser.ts
+++ b/src/shared/generation/stlParser.ts
@@ -1,13 +1,18 @@
 /**
- * Binary STL parser for extracting mesh arrays.
+ * STL parser (binary + ASCII) for extracting mesh arrays.
  *
  * Used to convert worker-generated STL data into vertex/normal arrays
- * suitable for 3MF export via threemfExporter.
+ * suitable for 3MF export via threemfExporter, and to parse user-uploaded
+ * STL files for mesh imprint import.
  *
  * Binary STL format:
  *   Header:  80 bytes
  *   Count:   4 bytes (uint32 LE)
  *   Per tri: 50 bytes (normal 3×f32 + 3 vertices × 3×f32 + attr uint16)
+ *
+ * ASCII STL format:
+ *   solid <name> / facet normal nx ny nz / outer loop / vertex ×3 / endloop /
+ *   endfacet ... endsolid
  */
 
 import { err, ok, validationImportFailed } from '@/core/result';
@@ -97,4 +102,108 @@ export function parseSTLBinary(buffer: ArrayBuffer): Result<ParsedSTLMesh, Valid
   }
 
   return ok({ vertices, normals });
+}
+
+/**
+ * A buffer is treated as binary STL when the 84-byte header's triangle count
+ * exactly predicts the file size. This is checked BEFORE any text sniffing
+ * because binary files exported by some tools begin with the bytes "solid"
+ * in their free-form 80-byte header.
+ */
+function isBinarySTL(buffer: ArrayBuffer): boolean {
+  if (buffer.byteLength < MIN_FILE_SIZE) return false;
+  const count = new DataView(buffer).getUint32(COUNT_OFFSET, true);
+  return buffer.byteLength === MIN_FILE_SIZE + count * TRIANGLE_SIZE;
+}
+
+function looksLikeAsciiSTL(buffer: ArrayBuffer): boolean {
+  const head = new TextDecoder('utf-8', { fatal: false }).decode(
+    buffer.slice(0, Math.min(buffer.byteLength, 512))
+  );
+  return head.trimStart().toLowerCase().startsWith('solid');
+}
+
+/**
+ * Parses an ASCII STL buffer into the same flat triangle-soup arrays as the
+ * binary parser (face normal replicated per vertex).
+ */
+export function parseSTLAscii(buffer: ArrayBuffer): Result<ParsedSTLMesh, ValidationError> {
+  const text = new TextDecoder('utf-8', { fatal: false }).decode(buffer);
+  const lines = text.split('\n');
+
+  const vertices: number[] = [];
+  const normals: number[] = [];
+  let currentNormal: [number, number, number] = [0, 0, 0];
+  let facetVertexCount = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith('vertex')) {
+      if (facetVertexCount < 0) {
+        return err(
+          validationImportFailed([`Invalid ASCII STL: vertex outside facet (line ${i + 1})`])
+        );
+      }
+      if (facetVertexCount >= 3) {
+        return err(
+          validationImportFailed([
+            `Invalid ASCII STL: more than 3 vertices in facet (line ${i + 1})`,
+          ])
+        );
+      }
+      const parts = line.split(/\s+/);
+      const x = Number(parts[1]);
+      const y = Number(parts[2]);
+      const z = Number(parts[3]);
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+        return err(validationImportFailed([`Invalid ASCII STL: malformed vertex (line ${i + 1})`]));
+      }
+      vertices.push(x, y, z);
+      normals.push(currentNormal[0], currentNormal[1], currentNormal[2]);
+      facetVertexCount++;
+    } else if (line.startsWith('facet')) {
+      const parts = line.split(/\s+/);
+      // "facet normal nx ny nz" — tolerate missing/garbage normals (many
+      // exporters write zeros); downstream import recomputes them anyway.
+      const nx = Number(parts[2]);
+      const ny = Number(parts[3]);
+      const nz = Number(parts[4]);
+      currentNormal = [
+        Number.isFinite(nx) ? nx : 0,
+        Number.isFinite(ny) ? ny : 0,
+        Number.isFinite(nz) ? nz : 0,
+      ];
+      facetVertexCount = 0;
+    } else if (line.startsWith('endfacet')) {
+      if (facetVertexCount !== 3) {
+        return err(
+          validationImportFailed([
+            `Invalid ASCII STL: facet with ${facetVertexCount} vertices (line ${i + 1})`,
+          ])
+        );
+      }
+      facetVertexCount = -1;
+    }
+  }
+
+  if (facetVertexCount !== -1) {
+    return err(validationImportFailed(['Invalid ASCII STL: unterminated facet at end of file']));
+  }
+  if (vertices.length === 0) {
+    return err(validationImportFailed(['Invalid ASCII STL: no facets found']));
+  }
+
+  return ok({ vertices: Float32Array.from(vertices), normals: Float32Array.from(normals) });
+}
+
+/**
+ * Parses an STL buffer of either format. Binary detection (exact size match
+ * from the header's triangle count) wins over text sniffing, since binary
+ * headers may begin with "solid"; buffers that are neither fall through to
+ * the binary parser for its precise structural error messages.
+ */
+export function parseSTL(buffer: ArrayBuffer): Result<ParsedSTLMesh, ValidationError> {
+  if (isBinarySTL(buffer)) return parseSTLBinary(buffer);
+  if (looksLikeAsciiSTL(buffer)) return parseSTLAscii(buffer);
+  return parseSTLBinary(buffer);
 }


### PR DESCRIPTION
## Summary

First slice of STL-to-cutout imprints, requested in user feedback: upload a tool's STL directly instead of tracing it through the SVG/photo import. This PR adds the worker-side import pipeline that turns an uploaded STL into a compact, validated mesh asset; the data model, imprint generation, and UI land in follow-up PRs.

- **STL parsing**: the shared binary parser gains ASCII support with size-based format detection (binary wins when the 84-byte header predicts the file size exactly, so binary files whose header starts with "solid" don't mis-route)
- **Repair + validation**: vertex weld + `Mesh.merge()` via manifold-3d; non-watertight meshes get an actionable error instead of a downstream CSG failure
- **Auto lay-flat**: picks the minimal-height of the 6 axis-aligned orientations (tie-break: largest footprint), with quarter-turn flip overrides composed on top for the upcoming orientation dialog
- **Decimation**: tolerance-ladder `simplify()` to a 50k-triangle budget (~0.01-2mm error ceiling, invisible at printed-pocket scale)
- **Silhouette outlines**: top-down projection, outer rings simplified via the existing RDP pass — powers the 2D footprint, clearance, and chamfer without decoding the mesh on the main thread
- **Codec**: positions quantized to a uint16 grid over the bbox (≤0.01mm resolution), deflated and base64-encoded for inline design storage
- **Plumbing**: `IMPORT_MESH` worker message + `GenerationBridge.importMesh()`; the raw manifold-3d module moves to a shared singleton (`manifoldRuntime.ts`) so the occt worker can lazy-load it later for imprint subtraction without registering a kernel

## Test plan

- `stlParser`: ASCII parsing (CRLF, scientific notation, garbage normals), format detection incl. the "solid"-prefixed binary trap
- `meshAsset`: codec round-trip within quantization tolerance, corrupt-data rejection, compression ratio
- `meshImport` (real manifold WASM): end-to-end box import, lay-flat of a standing box, flip composition, ASCII path, asset decode round-trip, 65k-tri sphere decimated under budget, non-manifold rejection, oversize rejection
- `importMeshHandler`: result/error/throw message contracts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a worker-side STL import that turns an uploaded STL into a compressed, validated `MeshAsset` for mesh imprint cutouts. Includes `IMPORT_MESH` messaging and `GenerationBridge.importMesh()` to fetch the asset and a preview mesh.

- **New Features**
  - Binary + ASCII STL parsing with safe format detection.
  - Mesh repair/validation via `manifold-3d`; rejects non‑watertight meshes with clear errors.
  - Auto lay‑flat orientation with 90° flip overrides; suggested cut depth = mesh height.
  - Decimation ladder to ≤50k triangles; preview positions/indices transferred to the UI.
  - Silhouette outline extraction (outer rings only) with RDP simplify for fast 2D footprint.
  - Compact codec: positions quantized to `uint16` over bbox, deflated and base64 for inline storage.

- **Bug Fixes**
  - ASCII STL parser now accepts case‑insensitive keywords and CRLF line endings.
  - Pending `IMPORT_MESH` requests now reject if the worker crashes or resets, with clear, accurate error messages (no timeout wording).

<sup>Written for commit 3f8bf2fd7e9b653a3454b976c1c03ae160b42404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

