### PR TITLE
fix(print-export): stop zeroing acceleration in multi-color 3MF exports

### DIFF
--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -635,11 +635,9 @@ describe('threemfExporter', () => {
       expect(config.layer_change_gcode).toMatch(/^\s*G92\s*E0\b/);
     });
 
-    // Pin acceleration to "use machine default" so Orca doesn't inherit
-    // Bambu's profile defaults (via our BambuStudio identity claim) and
-    // surface a false-positive comparison warning when the inherited travel
-    // value exceeds the user's printer's machine_max_acceleration_extruding.
-    it('pins acceleration to machine defaults to silence Orca comparison warning', () => {
+    // Regression for #2622: pinning acceleration hid the user's tuned profile
+    // and inflated multi-color print time (see buildProjectSettingsConfig).
+    it('does not pin acceleration (would strip the user profile and slow the print)', () => {
       const { vertices, normals } = createTwoTriangles();
       const buffer = build3MFBuffer(vertices, normals, {
         name: 'accel',
@@ -649,8 +647,8 @@ describe('threemfExporter', () => {
         },
       });
       const config = JSON.parse(strFromU8(unzipSync(buffer)['Metadata/project_settings.config']));
-      expect(config.default_acceleration).toBe('0');
-      expect(config.travel_acceleration).toBe('0');
+      expect(config.default_acceleration).toBeUndefined();
+      expect(config.travel_acceleration).toBeUndefined();
     });
 
     it('omits project_settings.config when no colorConfig is provided', () => {

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -304,20 +304,15 @@ function buildProjectSettingsConfig(palette: readonly string[]): string {
       use_relative_e_distances: '1',
       layer_change_gcode: 'G92 E0 ; Reset extruder for accurate multi-material\n',
 
-      // Defer all acceleration values to the user's printer profile rather
-      // than inheriting whatever Bambu defaults Orca picks up from our
-      // BambuStudio identity claim. Without these, Orca's GCodeWriter caps
-      // travel acceleration against `machine_max_acceleration_extruding` and
-      // surfaces a comparison warning when the inherited Bambu travel value
-      // exceeds the user's printer's extruding limit (a near-certain
-      // mismatch on Marlin/Klipper printers with conservative max accels).
-      // Setting `default_acceleration=0` is the canonical "use machine
-      // default" signal — Orca's `have_default_acceleration =
-      // default_acceleration > 0` gate (slic3r/GUI/ConfigManipulation.cpp)
-      // then hides every per-feature acceleration override in the loaded
-      // config, so the warning never fires.
-      default_acceleration: '0',
-      travel_acceleration: '0',
+      // Deliberately no acceleration keys. Do not re-add
+      // `default_acceleration` / `travel_acceleration`: pinning them to '0'
+      // (to silence Orca's "travel acceleration exceeds
+      // machine_max_acceleration_extruding" warning) trips Orca's
+      // `have_default_acceleration = default_acceleration > 0` gate, which
+      // hides every per-feature acceleration override in the loaded profile.
+      // On import (Bambu included) that drops the user's tuned accelerations
+      // to machine defaults and inflates multi-color print time several-fold
+      // (#2615, #2622). The warning it silenced is non-blocking.
     },
     null,
     2


### PR DESCRIPTION
## What this fixes

Multi-color bins printed several times slower than the same bin painted by hand in the slicer, with no benefit. A user reported a bin that sliced at ~4h48m when hand-painted but ~18h24m when colored in the tool, despite identical material, purge, and filament-change counts (discussion #2615).

## Root cause

Colored exports embed a `Metadata/project_settings.config` sidecar (single-color exports do not). That sidecar pinned `default_acceleration` and `travel_acceleration` to `"0"` to silence a non-blocking Orca "travel acceleration exceeds machine_max_acceleration_extruding" warning on non-Bambu printers.

`default_acceleration = 0` trips Orca's `have_default_acceleration = default_acceleration > 0` gate, which hides every per-feature acceleration override in the loaded profile. On import (Bambu included) the user's tuned wall/infill accelerations drop to conservative machine defaults, inflating print time several-fold. It does not change material, flush, or color-change count, which is exactly the signature the reporter saw.

## The change

- Remove `default_acceleration` and `travel_acceleration` from `buildProjectSettingsConfig` so the user's own accelerations stand.
- Keep the slice-critical keys `use_relative_e_distances` and `layer_change_gcode` (these prevent an actual slice failure on non-Bambu printers, not just a warning).
- Accept the non-blocking Orca warning as the trade for correct print speed, documented inline as a do-not-re-add footgun.

## Verification

- Confirmed empirically: exporting the same mesh single-color vs multi-color, the single-color 3MF has no `project_settings.config`; the multi-color one had the two acceleration keys and nothing else speed-related.
- Regression test flips to assert both keys are absent while the palette and slice-critical keys remain. 78/78 exporter tests pass; typecheck clean.

## Still needs a real slice before merge

I could not run a BambuStudio/Orca CLI slice in my environment. Please slice a multi-color export from this branch and confirm print time returns to the single-color baseline, and that it still slices (warning is acceptable) on a non-Bambu profile.

Closes #2622.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-color 3MF exports that were zeroing acceleration, so user profiles keep their tuned per-feature acceleration and print times return to normal. We keep only slice-critical settings and accept Orca’s non-blocking warning.

- **Bug Fixes**
  - Removed `default_acceleration` and `travel_acceleration` from `buildProjectSettingsConfig`.
  - Preserved `use_relative_e_distances` and `layer_change_gcode`.
  - Updated tests to assert acceleration keys are absent.

<sup>Written for commit 31c5e9cbc8a270c30a22920c0e28523269102100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

