### PR TITLE
fix(worker): recover the brepkit kernel after a borrow-flag poison

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
@@ -59,7 +59,14 @@ let poisoned = false;
  * all later brepjs ops (they resolve getKernel() per call).
  */
 async function recoverBrepkitKernel(): Promise<void> {
-  clearAllCaches();
+  // Best-effort: dispose calls shape.delete() on the dead arena (brepkit's
+  // dispose is a no-op, safe while poisoned), but never let a throwing disposer
+  // block the fresh kernel below — that recreation is what actually recovers.
+  try {
+    clearAllCaches();
+  } catch {
+    /* fresh kernel below restores health regardless */
+  }
   const { registerKernel, BrepkitAdapter } = await import('brepjs');
   const brepkitWasm = await import('brepkit-wasm');
   const kernel = new brepkitWasm.BrepKernel();

--- a/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.export-integrity.test.ts
@@ -24,16 +24,64 @@ import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { buildParams } from './__kernel-tests__/scenarioTypes';
 import { ALL_SCENARIOS } from './scenarios';
-import { setLastSolid } from './shapeCache';
+import { setLastSolid, clearAllCaches } from './shapeCache';
 import type * as BinExporterModule from './binExporter';
 
 let exportBin: typeof BinExporterModule.exportBin;
+
+// ── brepkit kernel-poison recovery ─────────────────────────────────────────
+// The brepkit WASM kernel is a per-worker singleton whose arena grows across
+// every scenario. Two distinct bugs strand its wasm-bindgen borrow flag once
+// enough state accumulates (see brepkit task #14):
+//   1. a `raw_vec` "capacity overflow" Rust panic (panic=abort → the trap never
+//      releases the &mut self borrow), first observed on the magnet+halfSockets
+//      scenario;
+//   2. a NON-panic stranding (a JS exception unwinding through a &mut self wasm
+//      method leaves the BorrowMut guard undropped), observed on honeycomb
+//      custom shapes — this one recurs as the arena regrows.
+// Either strands the kernel so EVERY later scenario throws "recursive use of an
+// object detected which would lead to unsafe aliasing in rust" in ~0ms — a
+// cascade that masked ~180 scenarios behind the FIRST victim. catch_unwind is
+// inert on wasm (panic=abort) and Rust cannot reset the flag; the only recovery
+// is a NEW BrepKernel. This harness detects the poison signature and recreates
+// the kernel so each later scenario runs healthy, revealing the true pass/fail.
+const KERNEL_IS_BREPKIT = ['brepkit', 'wasm'].includes(process.env['BREPJS_KERNEL'] ?? '');
+const POISON_RE = /recursive use of an object|unsafe aliasing/i;
+let lastPanicMessage: (() => string | undefined) | null = null;
+let clearLastPanicMessage: (() => void) | null = null;
+let poisoned = false;
+
+/**
+ * Recreate the poisoned singleton BrepKernel. Cached socket/lip/box/shell solids
+ * (and lastSolid) index the DEAD arena, so clearAllCaches() must drop them first
+ * — brepkit's dispose is a no-op, so that is safe even while poisoned. A fresh
+ * BrepKernel has a fresh borrow flag; re-registering it as the default reroutes
+ * all later brepjs ops (they resolve getKernel() per call).
+ */
+async function recoverBrepkitKernel(): Promise<void> {
+  clearAllCaches();
+  const { registerKernel, BrepkitAdapter } = await import('brepjs');
+  const brepkitWasm = await import('brepkit-wasm');
+  const kernel = new brepkitWasm.BrepKernel();
+  registerKernel('brepkit', new BrepkitAdapter(kernel as any));
+  clearLastPanicMessage?.();
+  poisoned = false;
+}
 
 beforeAll(async () => {
   const { initBrepjs } = await import('./__kernel-tests__/wasmInit');
   await initBrepjs();
   exportBin = (await import('./binExporter')).exportBin;
-}, 60_000);
+  if (KERNEL_IS_BREPKIT) {
+    const bkw = (await import('brepkit-wasm')) as unknown as {
+      lastPanicMessage?: () => string | undefined;
+      clearLastPanicMessage?: () => void;
+    };
+    lastPanicMessage = bkw.lastPanicMessage ?? null;
+    clearLastPanicMessage = bkw.clearLastPanicMessage ?? null;
+    clearLastPanicMessage?.();
+  }
+}, 120_000);
 
 interface ManifoldStats {
   triangleCount: number;
@@ -127,8 +175,15 @@ describe('export integrity: full scenario matrix → binary STL', () => {
   // production a preview pass (forExport=false) clears the flag on every param
   // change; this loop never previews, so we clear it explicitly. The
   // param-keyed intermediate LRU caches (socket/lip/box) stay warm for speed.
-  beforeEach(() => {
+  beforeEach(async () => {
     setLastSolid(null);
+    // Recover if the prior scenario stranded the kernel — detected by the
+    // borrow-flag poison signature in its error (`poisoned`, covers both the
+    // panic-abort and non-panic stranding) OR by a recorded Rust panic that
+    // left no catchable JS error on this scenario yet (lastPanicMessage).
+    if (KERNEL_IS_BREPKIT && (poisoned || lastPanicMessage?.())) {
+      await recoverBrepkitKernel();
+    }
   });
 
   for (const scenario of ALL_SCENARIOS) {
@@ -137,42 +192,51 @@ describe('export integrity: full scenario matrix → binary STL', () => {
     it(
       label,
       async () => {
-        const params = buildParams(scenario.params);
-        const result = await exportBin(params, 'stl');
+        try {
+          const params = buildParams(scenario.params);
+          const result = await exportBin(params, 'stl');
 
-        // 1. Buffer is well-formed and parseable (the occt-wasm STL bug).
-        const stats = analyze(result.data, scenario.name);
+          // 1. Buffer is well-formed and parseable (the occt-wasm STL bug).
+          const stats = analyze(result.data, scenario.name);
 
-        // 2. Non-empty printable solid (the compound-cut empty-result bug).
-        expect(stats.triangleCount, `${scenario.name}: triangle count`).toBeGreaterThan(0);
+          // 2. Non-empty printable solid (the compound-cut empty-result bug).
+          expect(stats.triangleCount, `${scenario.name}: triangle count`).toBeGreaterThan(0);
 
-        // 3. No NaN/Infinity coordinates.
-        expect(stats.minFinite, `${scenario.name}: finite coordinates`).toBe(true);
+          // 3. No NaN/Infinity coordinates.
+          expect(stats.minFinite, `${scenario.name}: finite coordinates`).toBe(true);
 
-        // 4. Hole-free: no boundary edges. This is the real printable-watertight
-        //    guarantee and holds for EVERY scenario, including the measure-zero
-        //    self-contact cases.
-        expect(stats.boundaryEdges, `${scenario.name}: boundary edges`).toBe(0);
+          // 4. Hole-free: no boundary edges. This is the real printable-watertight
+          //    guarantee and holds for EVERY scenario, including the measure-zero
+          //    self-contact cases.
+          expect(stats.boundaryEdges, `${scenario.name}: boundary edges`).toBe(0);
 
-        // 5. Fully 2-manifold (no edge shared by >2 triangles) — required of
-        //    every scenario except the documented measure-zero self-contact
-        //    cases (see MEASURE_ZERO_SELF_CONTACT_SCENARIOS). Those are bounded
-        //    on BOTH sides rather than left unchecked: a lower bound of >0 makes
-        //    the carve-out self-expiring — if a kernel upgrade ever resolves the
-        //    pinch, this fails and signals the scenario can rejoin the strict
-        //    tier — and the upper cap catches a hole-free-but-manifold-broken
-        //    regression that the boundary-edge check (4) alone would miss.
-        if (measureZeroSelfContact) {
-          expect(
-            stats.nonManifoldEdges,
-            `${scenario.name}: non-manifold edges (self-contact must persist)`
-          ).toBeGreaterThan(0);
-          expect(
-            stats.nonManifoldEdges,
-            `${scenario.name}: non-manifold edges (must stay bounded)`
-          ).toBeLessThanOrEqual(MAX_MEASURE_ZERO_CONTACT_EDGES);
-        } else {
-          expect(stats.nonManifoldEdges, `${scenario.name}: non-manifold edges`).toBe(0);
+          // 5. Fully 2-manifold (no edge shared by >2 triangles) — required of
+          //    every scenario except the documented measure-zero self-contact
+          //    cases (see MEASURE_ZERO_SELF_CONTACT_SCENARIOS). Those are bounded
+          //    on BOTH sides rather than left unchecked: a lower bound of >0 makes
+          //    the carve-out self-expiring — if a kernel upgrade ever resolves the
+          //    pinch, this fails and signals the scenario can rejoin the strict
+          //    tier — and the upper cap catches a hole-free-but-manifold-broken
+          //    regression that the boundary-edge check (4) alone would miss.
+          if (measureZeroSelfContact) {
+            expect(
+              stats.nonManifoldEdges,
+              `${scenario.name}: non-manifold edges (self-contact must persist)`
+            ).toBeGreaterThan(0);
+            expect(
+              stats.nonManifoldEdges,
+              `${scenario.name}: non-manifold edges (must stay bounded)`
+            ).toBeLessThanOrEqual(MAX_MEASURE_ZERO_CONTACT_EDGES);
+          } else {
+            expect(stats.nonManifoldEdges, `${scenario.name}: non-manifold edges`).toBe(0);
+          }
+        } catch (e) {
+          // Flag borrow-flag poison so beforeEach recreates the kernel before
+          // the next scenario — stops one stranding from cascading into ~0ms
+          // "recursive use" failures across every later scenario.
+          const msg = e instanceof Error ? e.message : String(e);
+          if (KERNEL_IS_BREPKIT && POISON_RE.test(msg)) poisoned = true;
+          throw e;
         }
       },
       scenario.timeout

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -72,11 +72,23 @@ const POISON_RE = /recursive use of an object|unsafe aliasing/i;
 function maybeRecoverPoisonedKernel(errorMsg: string): void {
   if (activeKernel !== 'brepkit') return;
   if (!POISON_RE.test(errorMsg) && !getLastBrepkitPanic()) return;
-  clearAllCaches();
-  clearBaseplateCaches();
-  clearMeshImprintCache();
-  if (recoverBrepkitKernel()) {
-    console.warn('[Worker] brepkit kernel was poisoned; recreated it for the next request.');
+  // Best-effort cache eviction: disposal calls shape.delete() on the poisoned
+  // kernel. brepkit's dispose is a no-op (safe even while poisoned), but guard
+  // anyway so a throwing disposer can't prevent the essential step — recreating
+  // the kernel — from running.
+  for (const clear of [clearAllCaches, clearBaseplateCaches, clearMeshImprintCache]) {
+    try {
+      clear();
+    } catch (err) {
+      console.warn('[Worker] cache eviction during kernel recovery failed (continuing):', err);
+    }
+  }
+  try {
+    if (recoverBrepkitKernel()) {
+      console.warn('[Worker] brepkit kernel was poisoned; recreated it for the next request.');
+    }
+  } catch (err) {
+    console.error('[Worker] brepkit kernel recovery failed:', err);
   }
 }
 

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -9,8 +9,18 @@
 import { getPerformanceStats, resetPerformanceStats } from 'brepjs';
 import type { WorkerResponse, MeshData, KernelName, ExportErrorCode } from '../../bridge/types';
 import { stageStats } from './stageStats';
-import { getAllShapeCacheStats, resetAllShapeCacheStats } from '../generators/shapeCache';
-import { getBaseplateCacheStats, resetBaseplateCacheStats } from '../generators/baseplateGenerator';
+import {
+  getAllShapeCacheStats,
+  resetAllShapeCacheStats,
+  clearAllCaches,
+} from '../generators/shapeCache';
+import {
+  getBaseplateCacheStats,
+  resetBaseplateCacheStats,
+  clearBaseplateCaches,
+} from '../generators/baseplateGenerator';
+import { clearMeshImprintCache } from '../generators/meshImprint';
+import { recoverBrepkitKernel, getLastBrepkitPanic } from '../wasmInstantiator';
 import {
   getBooleanFallbackStats,
   resetBooleanFallbackStats,
@@ -44,6 +54,30 @@ export function reportProgress(
 /** Format an error message from an unknown thrown value */
 export function formatError(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
+}
+
+/** Borrow-flag poison signature thrown by every op after the kernel is stranded. */
+const POISON_RE = /recursive use of an object|unsafe aliasing/i;
+
+/**
+ * brepkit kernel-poison recovery. A stranded wasm borrow flag (brepkit task #14:
+ * a `raw_vec` capacity-overflow panic-abort, or a JS exception unwinding through
+ * a `&mut self` method) makes every later request throw "recursive use / unsafe
+ * aliasing"; left unhandled the worker stays bricked until the page reloads. When
+ * the active kernel is brepkit and this error is the poison signature (or
+ * brepkit's panic hook recorded a trap on the poisoning request itself), drop the
+ * now-stale cache handles that index the dead arena and recreate the kernel so the
+ * NEXT request runs on a fresh borrow flag. No-op for occt-wasm/manifold.
+ */
+function maybeRecoverPoisonedKernel(errorMsg: string): void {
+  if (activeKernel !== 'brepkit') return;
+  if (!POISON_RE.test(errorMsg) && !getLastBrepkitPanic()) return;
+  clearAllCaches();
+  clearBaseplateCaches();
+  clearMeshImprintCache();
+  if (recoverBrepkitKernel()) {
+    console.warn('[Worker] brepkit kernel was poisoned; recreated it for the next request.');
+  }
 }
 
 /** Check kernel init state, responding with error if not ready. */
@@ -258,8 +292,12 @@ export function runGeneration(
     }
   } catch (e) {
     if (isAbortError(e)) return;
-    if (activeRequestId !== requestId) return;
     const errorMsg = formatError(e);
+    // Recreate the kernel if this failure stranded brepkit's borrow flag, so the
+    // next request isn't cascaded into "recursive use" — even when this request
+    // was already superseded (the poison is global to the kernel).
+    maybeRecoverPoisonedKernel(errorMsg);
+    if (activeRequestId !== requestId) return;
 
     console.error(`[${logPrefix}] Generation failed:`, errorMsg);
     if (e instanceof Error && e.stack) {
@@ -355,6 +393,9 @@ export async function runExport<TPayload extends Record<string, unknown>>(
     const response = { type: responseType, requestId, ...payload };
     self.postMessage(response, { transfer: transferFn(payload) });
   } catch (e) {
+    // Recreate the kernel if this export stranded brepkit's borrow flag, so the
+    // next request isn't cascaded into "recursive use".
+    maybeRecoverPoisonedKernel(formatError(e));
     const errorCode = classifyError?.(e);
     respond({
       type: 'ERROR',

--- a/src/features/generation/worker/wasmInstantiator.test.ts
+++ b/src/features/generation/worker/wasmInstantiator.test.ts
@@ -44,6 +44,11 @@ vi.mock('manifold-3d/manifold.wasm?url', () => ({ default: '/mocked/manifold.was
 vi.mock('brepkit-wasm', () => ({
   // eslint-disable-next-line @typescript-eslint/no-extraneous-class -- Mock class for BrepKernel constructor
   BrepKernel: class MockBrepKernel {},
+  // Panic-hook surface used by loadBrepkit / recoverBrepkitKernel. Vitest throws
+  // on access of any named export the factory omits, so these must be present
+  // even though the module accesses them via optional chaining.
+  lastPanicMessage: (): string | undefined => undefined,
+  clearLastPanicMessage: (): void => undefined,
 }));
 
 /** A minimal valid WASM binary: the 4-byte magic `\0asm` + version word. */

--- a/src/features/generation/worker/wasmInstantiator.test.ts
+++ b/src/features/generation/worker/wasmInstantiator.test.ts
@@ -5,6 +5,11 @@ import { DRAFT_MIN_CIRCULAR_ANGLE_DEG } from '@/shared/constants/tessellation';
 // Spy for the manifold kernel's raw-module circular-angle override.
 const mockSetMinCircularAngle = vi.fn();
 
+// Spies for brepkit's panic-hook surface. Named `mock*` so vitest permits the
+// hoisted `vi.mock('brepkit-wasm')` factory to reference them.
+const mockLastPanicMessage = vi.fn<() => string | undefined>(() => undefined);
+const mockClearLastPanicMessage = vi.fn<() => void>();
+
 // Mock all heavy dependencies before importing the module under test
 vi.mock('brepjs', () => ({
   registerKernel: vi.fn(),
@@ -47,8 +52,8 @@ vi.mock('brepkit-wasm', () => ({
   // Panic-hook surface used by loadBrepkit / recoverBrepkitKernel. Vitest throws
   // on access of any named export the factory omits, so these must be present
   // even though the module accesses them via optional chaining.
-  lastPanicMessage: (): string | undefined => undefined,
-  clearLastPanicMessage: (): void => undefined,
+  lastPanicMessage: mockLastPanicMessage,
+  clearLastPanicMessage: mockClearLastPanicMessage,
 }));
 
 /** A minimal valid WASM binary: the 4-byte magic `\0asm` + version word. */
@@ -165,6 +170,51 @@ describe('wasmInstantiator', () => {
       expect(registerKernel).toHaveBeenCalledWith('brepkit', expect.anything());
       expect(result.isThreaded).toBe(false);
       expect(result.hardwareConcurrency).toBeGreaterThan(0);
+    });
+
+    it('clears any stale panic message on load', async () => {
+      const { loadBrepkit } = await import('./wasmInstantiator');
+      await loadBrepkit();
+      expect(mockClearLastPanicMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('recoverBrepkitKernel', () => {
+    it('returns false and does nothing when brepkit was never loaded', async () => {
+      const { registerKernel } = await import('brepjs');
+      const { recoverBrepkitKernel } = await import('./wasmInstantiator');
+
+      expect(recoverBrepkitKernel()).toBe(false);
+      expect(registerKernel).not.toHaveBeenCalled();
+    });
+
+    it('recreates and re-registers the kernel after load', async () => {
+      const { registerKernel, BrepkitAdapter } = await import('brepjs');
+      const { loadBrepkit, recoverBrepkitKernel } = await import('./wasmInstantiator');
+
+      await loadBrepkit();
+      vi.mocked(registerKernel).mockClear();
+      vi.mocked(BrepkitAdapter).mockClear();
+      mockClearLastPanicMessage.mockClear();
+
+      expect(recoverBrepkitKernel()).toBe(true);
+      expect(BrepkitAdapter).toHaveBeenCalledTimes(1);
+      expect(registerKernel).toHaveBeenCalledWith('brepkit', expect.anything());
+      expect(mockClearLastPanicMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('getLastBrepkitPanic', () => {
+    it('returns undefined before brepkit is loaded', async () => {
+      const { getLastBrepkitPanic } = await import('./wasmInstantiator');
+      expect(getLastBrepkitPanic()).toBeUndefined();
+    });
+
+    it('surfaces the panic hook value after load', async () => {
+      const { loadBrepkit, getLastBrepkitPanic } = await import('./wasmInstantiator');
+      await loadBrepkit();
+      mockLastPanicMessage.mockReturnValue('capacity overflow');
+      expect(getLastBrepkitPanic()).toBe('capacity overflow');
     });
   });
 });

--- a/src/features/generation/worker/wasmInstantiator.ts
+++ b/src/features/generation/worker/wasmInstantiator.ts
@@ -108,19 +108,71 @@ async function loadEmbeddedFonts(): Promise<void> {
  * wraps it with brepjs's `BrepkitAdapter`, and registers it as the active kernel.
  * Brepkit does not support threading, so `isThreaded` is always false.
  */
+/**
+ * Minimal shape of brepkit-wasm's module surface used for kernel creation and
+ * panic capture, cached so {@link recoverBrepkitKernel} can recreate the kernel
+ * without re-importing.
+ */
+interface BrepkitModule {
+  BrepKernel: new () => unknown;
+  /** Root panic text captured by brepkit's panic hook (`crates/wasm/src/panics.rs`). */
+  lastPanicMessage?: () => string | undefined;
+  clearLastPanicMessage?: () => void;
+}
+
+/** Set once brepkit is loaded; drives in-place kernel recovery. */
+let brepkitModule: BrepkitModule | null = null;
+
 export async function loadBrepkit(): Promise<WasmLoadResult> {
   const hardwareConcurrency = getHardwareConcurrency();
 
   // Dynamic import to keep the brepkit WASM out of the main chunk.
   // brepkit-wasm's entry JS handles its own WASM instantiation internally.
-  const { BrepKernel } = await import('brepkit-wasm');
-  const kernel = new BrepKernel();
+  const bkw = (await import('brepkit-wasm')) as unknown as BrepkitModule;
+  brepkitModule = bkw;
+  const kernel = new bkw.BrepKernel();
   // BrepkitAdapter accepts KernelInstance (typed as `any` in brepjs)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelInstance is typed as any in brepjs
   const adapter = new BrepkitAdapter(kernel as any);
   registerKernel('brepkit', adapter);
+  bkw.clearLastPanicMessage?.();
 
   return { isThreaded: false, hardwareConcurrency };
+}
+
+/**
+ * Recreate the brepkit kernel after a borrow-flag POISON.
+ *
+ * The brepkit WASM kernel is a per-worker singleton whose wasm-bindgen borrow
+ * flag can be permanently stranded (brepkit task #14): a `raw_vec` capacity-
+ * overflow Rust panic (wasm is `panic=abort`, so the trap never releases the
+ * `&mut self` borrow), or a JS exception unwinding through a `&mut self` method
+ * that leaves the `BorrowMut` guard undropped. Once stranded, EVERY later call
+ * throws "recursive use of an object detected ... unsafe aliasing", and no Rust
+ * code can reset the flag — the only recovery is a NEW `BrepKernel`.
+ *
+ * A fresh kernel re-registered as the default reroutes all subsequent brepjs ops
+ * (they resolve `getKernel()` per call). The CALLER must first drop cache
+ * handles that index the now-dead arena (socket/lip/box/shell/lastSolid,
+ * baseplate, mesh-imprint) — brepkit's `dispose` is a no-op, so that is safe even
+ * while poisoned. Returns `false` (no-op) if brepkit was never loaded.
+ */
+export function recoverBrepkitKernel(): boolean {
+  if (!brepkitModule) return false;
+  const kernel = new brepkitModule.BrepKernel();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelInstance is typed as any in brepjs
+  registerKernel('brepkit', new BrepkitAdapter(kernel as any));
+  brepkitModule.clearLastPanicMessage?.();
+  return true;
+}
+
+/**
+ * Root panic text captured by brepkit's panic hook if the last op trapped, else
+ * `undefined`. Used to detect a panic-abort poison that left no catchable JS
+ * error on the poisoning request itself.
+ */
+export function getLastBrepkitPanic(): string | undefined {
+  return brepkitModule?.lastPanicMessage?.();
 }
 
 /**


### PR DESCRIPTION
## Problem

The brepkit WASM kernel is a per-worker singleton whose wasm-bindgen borrow flag can be **permanently stranded** (brepkit task #14). Two distinct bugs do it:
1. a `raw_vec` **"capacity overflow"** Rust panic — wasm is `panic=abort`, so the trap never releases the `&mut self` borrow;
2. a **non-panic stranding** — a JS exception unwinding through a `&mut self` method leaves the `BorrowMut` guard undropped (this one recurs as the arena regrows).

Once stranded, every later kernel call throws `recursive use of an object detected ... unsafe aliasing`, and no Rust code can reset the flag — the worker stays bricked until the page reloads. In the export-integrity matrix, one victim cascaded across ~180 scenarios, masking the true results.

## Fix

- **`wasmInstantiator.recoverBrepkitKernel()`** — recreates the kernel; a fresh `BrepKernel` re-registered as the default reroutes all later brepjs ops (they resolve `getKernel()` per call). `getLastBrepkitPanic()` exposes brepkit's panic-hook text to detect a panic-abort poison that left no catchable JS error on the poisoning request.
- **`workerContext`** — the central `runGeneration`/`runExport` catch paths detect the poison signature (the "recursive use" message, or a recorded trap), drop the now-stale cache handles that index the dead arena (bin/baseplate/mesh-imprint), and recreate the kernel so the **next request runs healthy**. Guarded to the brepkit kernel; occt-wasm/manifold untouched.
- **export-integrity harness** — the same recovery in `beforeEach`, which unmasks the true matrix.

## Impact

Unmasks the export-integrity matrix: **241 pass / 137 fail** (was a masked **165 / 213**) — **+76 scenarios recovered**, revealing the real geometry backlog that the cascade had hidden. The ~137 real failures are the known deferred parity families (scoop, screw base, solid cutouts, …), now visible and workable.

Verified: tsc clean, eslint clean on all three files, export-integrity smoke green. brepkit-side foils are unaffected (this is entirely tool-side).

Note: root-fixing the underlying `capacity overflow` in brepkit is tracked separately — recovery is still required regardless because bug #2 (the non-panic stranding) recurs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover the `brepkit` WASM kernel after a borrow-flag poison to stop worker bricking and cascading "recursive use" failures. The kernel is recreated and stale caches are cleared so the next request runs clean; export-integrity now shows 241 pass / 137 fail (+76 recovered). Hardened recovery and added tests.

- **Bug Fixes**
  - Detect poison via "recursive use"/"unsafe aliasing" errors or `getLastBrepkitPanic()`.
  - Add `recoverBrepkitKernel()` and `getLastBrepkitPanic()` in `wasmInstantiator`; cache `brepkit-wasm` and clear its panic-hook on load; recreate and re-register via `brepjs`.
  - Clear stale caches on recovery: `clearAllCaches`, `clearBaseplateCaches`, `clearMeshImprintCache`.
  - Apply recovery in `workerContext` catch paths for generation/export, and in export-integrity `beforeEach`.
  - Scoped to the `brepkit` kernel; `occt-wasm` and `manifold` unchanged.
  - Hardened recovery: guard cache eviction/recovery so disposers can’t block kernel recreation; add unit tests for `recoverBrepkitKernel` and `getLastBrepkitPanic`; ensure `loadBrepkit` clears stale panic; update `brepkit-wasm` mock.

<sup>Written for commit 1627d7ba8ac3875c51dc48c0c250d95f521ac65f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

