### PR TITLE
feat(designer): precise scanned-STL outlines, 5mm clearance cap, free import rotation

### DIFF
--- a/api/lib/designerValidationConstants.ts
+++ b/api/lib/designerValidationConstants.ts
@@ -49,7 +49,7 @@ export const CONSTRAINTS = {
   MESH_MAX_PAYLOAD_BYTES: 2_000_000,
   MAX_MESH_ASSETS: 8,
   MAX_MESH_ASSET_TRIANGLES: 50_000,
-  MAX_MESH_OUTLINE_POINTS: 2000,
+  MAX_MESH_OUTLINE_POINTS: 4000,
   MAX_MESH_NAME_LENGTH: 64,
   // Compressed+base64 payload per asset. Typical 50k-tri assets land at
   // 200-500KB; this bounds a crafted blob without pinching real imports.

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -374,7 +374,7 @@ export function CutoutWorkspace() {
         <StlImportDialog
           pending={stlImport.pending}
           importing={stlImport.importing}
-          onFlip={stlImport.flip}
+          onRotate={stlImport.setAxisRotation}
           onPlace={stlImport.place}
           onCancel={stlImport.cancel}
         />

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
@@ -472,7 +472,7 @@ export function CutoutEditor() {
       <StlImportDialog
         pending={stlImport.pending}
         importing={stlImport.importing}
-        onFlip={stlImport.flip}
+        onRotate={stlImport.setAxisRotation}
         onPlace={stlImport.place}
         onCancel={stlImport.cancel}
       />

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutFitControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutFitControls.tsx
@@ -8,7 +8,12 @@
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
-import { CLEARANCE_SHAPES, CHAMFER_SHAPES, maxEntryChamfer } from '@/features/bin-designer/types';
+import {
+  CLEARANCE_SHAPES,
+  CHAMFER_SHAPES,
+  MAX_CUTOUT_CLEARANCE,
+  maxEntryChamfer,
+} from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { Stepper } from '@/design-system';
 import { clamp } from '@/shared/utils/math';
@@ -57,7 +62,7 @@ export function CutoutFitControls({
           value={cutout.clearance ?? 0}
           onChange={(clearance) => onUpdate({ clearance })}
           min={0}
-          max={2}
+          max={MAX_CUTOUT_CLEARANCE}
           disabled={disabled}
         />
       )}

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import type { PendingStlImport } from './useStlImport';
 
 // jsdom has no WebGL — stub the 3D viewer internals.
@@ -34,7 +34,7 @@ const pending: PendingStlImport = {
   indices: new Uint32Array(3),
   suggestedCutDepth: 5,
   fileName: 'wrench.stl',
-  flips: { x: 0, y: 0, z: 0 },
+  rotation: { x: 0, y: 0, z: 30 },
   oversized: false,
 };
 
@@ -46,7 +46,7 @@ describe('StlImportDialog', () => {
       <StlImportDialog
         pending={null}
         importing={false}
-        onFlip={noop}
+        onRotate={noop}
         onPlace={noop}
         onCancel={noop}
       />
@@ -54,19 +54,41 @@ describe('StlImportDialog', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('shows the asset details and flip controls', () => {
+  it('shows the asset details and rotation controls', () => {
     render(
       <StlImportDialog
         pending={pending}
         importing={false}
-        onFlip={noop}
+        onRotate={noop}
         onPlace={noop}
         onCancel={noop}
       />
     );
     expect(screen.getByText('wrench')).toBeInTheDocument();
     expect(screen.getByText(/20\.0 × 10\.0 × 5\.0 mm/)).toBeInTheDocument();
+    for (const axis of ['X', 'Y', 'Z']) {
+      expect(screen.getByLabelText(`Rotate ${axis} (degrees)`)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: `Flip ${axis}` })).toBeInTheDocument();
+    }
+    expect(screen.getByLabelText('Rotate Z (degrees)')).toHaveValue(30);
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('reports rotation changes from steppers and quarter-turn buttons', () => {
+    const onRotate = vi.fn();
+    render(
+      <StlImportDialog
+        pending={pending}
+        importing={false}
+        onRotate={onRotate}
+        onPlace={noop}
+        onCancel={noop}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Increase Rotate Z (degrees)' }));
+    expect(onRotate).toHaveBeenCalledWith('z', 45);
+    fireEvent.click(screen.getByRole('button', { name: 'Flip X' }));
+    expect(onRotate).toHaveBeenCalledWith('x', 90);
   });
 
   it('warns when the mesh exceeds the bin interior', () => {
@@ -74,7 +96,7 @@ describe('StlImportDialog', () => {
       <StlImportDialog
         pending={{ ...pending, oversized: true }}
         importing={false}
-        onFlip={noop}
+        onRotate={noop}
         onPlace={noop}
         onCancel={noop}
       />

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.tsx
@@ -2,8 +2,9 @@
  * Orientation confirmation dialog for STL mesh imprint import.
  *
  * Shows the decimated, auto-laid-flat tool mesh in a small 3D viewer with
- * quarter-turn flip buttons (each flip re-runs the worker pipeline on the
- * retained file buffer), the footprint dimensions, and an oversize warning
+ * per-axis rotation controls — free degrees via stepper/typed input plus a
+ * quarter-turn button (every change re-runs the worker pipeline on the
+ * retained file buffer) — the footprint dimensions, and an oversize warning
  * when the tool won't fit the current bin interior. mm are physical — the
  * mesh is never scaled.
  */
@@ -12,17 +13,18 @@ import { useEffect, useMemo } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Center, OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
-import { Dialog, Button } from '@/design-system';
+import { Dialog, Button, Stepper } from '@/design-system';
 import { useTranslation } from '@/i18n';
-import type { MeshImportFlips } from '@/shared/generation/meshAsset';
+import type { MeshImportRotation } from '@/shared/generation/meshAsset';
 import type { PendingStlImport } from './useStlImport';
 
-const FLIP_AXES: readonly (keyof MeshImportFlips)[] = ['x', 'y', 'z'];
+const ROTATION_AXES: readonly (keyof MeshImportRotation)[] = ['x', 'y', 'z'];
+const ROTATION_STEP_DEG = 15;
 
 interface StlImportDialogProps {
   readonly pending: PendingStlImport | null;
   readonly importing: boolean;
-  readonly onFlip: (axis: keyof MeshImportFlips) => void;
+  readonly onRotate: (axis: keyof MeshImportRotation, degrees: number) => void;
   readonly onPlace: () => void;
   readonly onCancel: () => void;
 }
@@ -55,7 +57,7 @@ function ToolMesh({ pending }: { readonly pending: PendingStlImport }) {
 export function StlImportDialog({
   pending,
   importing,
-  onFlip,
+  onRotate,
   onPlace,
   onCancel,
 }: StlImportDialogProps) {
@@ -96,22 +98,43 @@ export function StlImportDialog({
                 })}
               </div>
             </div>
-            <div className="flex gap-1.5">
-              {FLIP_AXES.map((axis) => (
-                <Button
-                  key={axis}
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  disabled={importing}
-                  onClick={() => onFlip(axis)}
-                  aria-label={t('binDesigner.cutouts.stlImport.flipAxis', {
-                    axis: axis.toUpperCase(),
-                  })}
-                >
-                  {t('binDesigner.cutouts.stlImport.flipAxis', { axis: axis.toUpperCase() })}
-                </Button>
-              ))}
+            <div className="flex flex-col gap-1.5">
+              {ROTATION_AXES.map((axis) => {
+                const degrees = pending.rotation[axis];
+                return (
+                  <div key={axis} className="flex items-center justify-end gap-1.5">
+                    <span className="w-3 text-xs font-medium text-content-secondary">
+                      {axis.toUpperCase()}
+                    </span>
+                    <Stepper
+                      size="sm"
+                      value={degrees}
+                      onChange={(v) => onRotate(axis, v)}
+                      onStep={(delta) => onRotate(axis, degrees + delta * ROTATION_STEP_DEG)}
+                      min={-360}
+                      max={360}
+                      step={ROTATION_STEP_DEG}
+                      inputDecimals={1}
+                      disabled={importing}
+                      aria-label={t('binDesigner.cutouts.stlImport.rotateAxis', {
+                        axis: axis.toUpperCase(),
+                      })}
+                    />
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      disabled={importing}
+                      onClick={() => onRotate(axis, degrees + 90)}
+                      aria-label={t('binDesigner.cutouts.stlImport.flipAxis', {
+                        axis: axis.toUpperCase(),
+                      })}
+                    >
+                      {t('binDesigner.cutouts.stlImport.flipAxis', { axis: axis.toUpperCase() })}
+                    </Button>
+                  </div>
+                );
+              })}
             </div>
           </div>
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.tsx
@@ -38,7 +38,7 @@ function ToolMesh({ pending }: { readonly pending: PendingStlImport }) {
     return geo;
   }, [pending]);
 
-  // Each flip replaces the geometry — dispose the old GPU buffers.
+  // Each rotation change replaces the geometry — dispose the old GPU buffers.
   useEffect(() => {
     return () => {
       geometry.dispose();

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/useStlImport.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/useStlImport.test.ts
@@ -141,6 +141,41 @@ describe('useStlImport', () => {
     expect(useToastStore.getState().toasts).toHaveLength(0);
   });
 
+  it('re-runs the import with a normalized axis rotation', async () => {
+    importMesh.mockResolvedValue({
+      ok: true,
+      asset,
+      positions: new Float32Array(9),
+      indices: new Uint32Array(3),
+      suggestedCutDepth: 5,
+    });
+    const { result } = renderHook(() => useStlImport());
+
+    act(() => {
+      feedFile(makeFile());
+    });
+    await waitFor(() => {
+      expect(result.current.pending).not.toBeNull();
+    });
+    expect(importMesh).toHaveBeenLastCalledWith(expect.anything(), 'tool.stl', {
+      x: 0,
+      y: 0,
+      z: 0,
+    });
+
+    act(() => {
+      result.current.setAxisRotation('z', -15);
+    });
+    await waitFor(() => {
+      expect(result.current.pending?.rotation).toEqual({ x: 0, y: 0, z: 345 });
+    });
+    expect(importMesh).toHaveBeenLastCalledWith(expect.anything(), 'tool.stl', {
+      x: 0,
+      y: 0,
+      z: 345,
+    });
+  });
+
   it('places the pending mesh as a centered cutout with its asset', async () => {
     importMesh.mockResolvedValue({
       ok: true,

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/useStlImport.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/useStlImport.ts
@@ -69,7 +69,7 @@ export function useStlImport(): UseStlImportReturn {
 
   const [pending, setPending] = useState<PendingStlImport | null>(null);
   const [importing, setImporting] = useState(false);
-  /** Raw file bytes retained while the dialog is open, for flip re-runs. */
+  /** Raw file bytes retained while the dialog is open, for rotation re-runs. */
   const bufferRef = useRef<ArrayBuffer | null>(null);
   const fileNameRef = useRef<string>('');
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/useStlImport.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/useStlImport.ts
@@ -3,9 +3,9 @@
  *
  * Owns: file input, worker round-trip (parse/repair/lay-flat/decimate happen
  * in the generation worker via `bridge.importMesh`), the pending orientation
- * dialog state, flip re-runs, and final placement via `addMeshCutout`.
+ * dialog state, rotation re-runs, and final placement via `addMeshCutout`.
  *
- * The raw file buffer is kept for the dialog's lifetime so 90° flip
+ * The raw file buffer is kept for the dialog's lifetime so orientation
  * corrections can re-run the worker pipeline (each run transfers a copy —
  * the worker detaches its input).
  */
@@ -19,7 +19,7 @@ import { bridgeManager } from '@/shared/generation/bridge';
 import type {
   MeshAsset,
   MeshImportErrorReason,
-  MeshImportFlips,
+  MeshImportRotation,
 } from '@/shared/generation/meshAsset';
 import { MAX_MESH_ASSETS_PER_DESIGN, MAX_MESH_FILE_BYTES } from '@/shared/generation/meshAsset';
 import { defaultEntryChamfer } from '@/features/bin-designer/types';
@@ -42,7 +42,7 @@ export interface PendingStlImport {
   readonly indices: Uint32Array;
   readonly suggestedCutDepth: number;
   readonly fileName: string;
-  readonly flips: MeshImportFlips;
+  readonly rotation: MeshImportRotation;
   /** True when the footprint exceeds the bin interior (warn, never scale). */
   readonly oversized: boolean;
 }
@@ -54,8 +54,8 @@ export interface UseStlImportReturn {
   readonly pending: PendingStlImport | null;
   /** True while the worker is parsing/repairing/decimating. */
   readonly importing: boolean;
-  /** Re-run the import with an extra quarter-turn about the given axis. */
-  readonly flip: (axis: keyof MeshImportFlips) => void;
+  /** Re-run the import with the given axis set to an absolute angle (degrees). */
+  readonly setAxisRotation: (axis: keyof MeshImportRotation, degrees: number) => void;
   /** Place the pending mesh as a cutout at the interior center. */
   readonly place: () => void;
   /** Discard the pending import. */
@@ -74,7 +74,7 @@ export function useStlImport(): UseStlImportReturn {
   const fileNameRef = useRef<string>('');
 
   const runImport = useCallback(
-    async (flips: MeshImportFlips): Promise<void> => {
+    async (rotation: MeshImportRotation): Promise<void> => {
       const buffer = bufferRef.current;
       if (!buffer) return;
       // cancel() nulls bufferRef; a resolving in-flight run must then discard
@@ -85,7 +85,7 @@ export function useStlImport(): UseStlImportReturn {
         const bridge = await bridgeManager.acquire();
         try {
           // slice(): importMesh transfers its input; keep our copy intact.
-          const outcome = await bridge.importMesh(buffer.slice(0), fileNameRef.current, flips);
+          const outcome = await bridge.importMesh(buffer.slice(0), fileNameRef.current, rotation);
           if (isCancelled()) return;
           if (!outcome.ok) {
             addToast(t(ERROR_TOAST_KEYS[outcome.reason]), 'error');
@@ -102,7 +102,7 @@ export function useStlImport(): UseStlImportReturn {
             indices: outcome.indices,
             suggestedCutDepth: outcome.suggestedCutDepth,
             fileName: fileNameRef.current,
-            flips,
+            rotation,
             oversized: asset.sizeMm.x > innerW || asset.sizeMm.y > innerD,
           });
         } finally {
@@ -145,11 +145,12 @@ export function useStlImport(): UseStlImportReturn {
     [addToast, t, runImport]
   );
 
-  const flip = useCallback(
-    (axis: keyof MeshImportFlips) => {
+  const setAxisRotation = useCallback(
+    (axis: keyof MeshImportRotation, degrees: number) => {
       if (!pending || importing) return;
-      const flips = { ...pending.flips, [axis]: (pending.flips[axis] + 1) % 4 };
-      void runImport(flips);
+      const normalized = Number.isFinite(degrees) ? ((degrees % 360) + 360) % 360 : 0;
+      if (normalized === pending.rotation[axis]) return;
+      void runImport({ ...pending.rotation, [axis]: normalized });
     },
     [pending, importing, runImport]
   );
@@ -226,5 +227,5 @@ export function useStlImport(): UseStlImportReturn {
     fileInputRef.current?.click();
   }, []);
 
-  return { triggerImport, pending, importing, flip, place, cancel };
+  return { triggerImport, pending, importing, setAxisRotation, place, cancel };
 }

--- a/src/features/bin-designer/types/cutout.ts
+++ b/src/features/bin-designer/types/cutout.ts
@@ -61,6 +61,10 @@ export const CLEARANCE_SHAPES: readonly CutoutShape[] = [
   'mesh',
 ];
 
+/** Largest insertion clearance (mm) the editor allows. Sized for hand-scanned
+ *  meshes whose surfaces wobble a few mm; parametric shapes rarely need >0.5. */
+export const MAX_CUTOUT_CLEARANCE = 5;
+
 /** Largest entry-chamfer width (mm) the editor allows. */
 export const MAX_CUTOUT_CHAMFER = 5;
 

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -713,6 +713,7 @@ export {
   CLEARANCE_SHAPES,
   defaultEntryChamfer,
   maxEntryChamfer,
+  MAX_CUTOUT_CLEARANCE,
   MAX_CUTOUT_CHAMFER,
   CHAMFER_SHAPES,
   CUTOUT_ARRAY_MODES,

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -52,7 +52,7 @@ import {
   type PendingExportMap,
   type MeshImportOutcome,
 } from './bridgeTypes';
-import type { MeshImportFlips } from '@/shared/generation/meshAsset';
+import type { MeshImportRotation } from '@/shared/generation/meshAsset';
 import { extractThreadingInfo, createDedupCache } from './bridgeHelpers';
 import { installMessageHandler } from './bridgeMessageHandler';
 import {
@@ -262,7 +262,7 @@ export class GenerationBridge {
   importMesh(
     buffer: ArrayBuffer,
     fileName: string,
-    flips?: MeshImportFlips
+    rotation?: MeshImportRotation
   ): Promise<MeshImportOutcome> {
     if (this.isDestroyed || !this.worker) {
       return Promise.reject(new Error('Bridge not initialized'));
@@ -271,7 +271,7 @@ export class GenerationBridge {
     return new Promise((resolve, reject) => {
       this.pendingImports.set(requestId, { resolve, reject });
       this.worker?.postMessage(
-        { type: 'IMPORT_MESH', payload: { requestId, buffer, fileName, flips } },
+        { type: 'IMPORT_MESH', payload: { requestId, buffer, fileName, rotation } },
         [buffer]
       );
     });

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -15,7 +15,7 @@ import type { GridfinityItem } from '@/shared/types/item';
 import type {
   MeshAsset,
   MeshImportErrorReason,
-  MeshImportFlips,
+  MeshImportRotation,
 } from '@/shared/generation/meshAsset';
 
 /** Geometry kernel backend for BREP operations */
@@ -83,8 +83,8 @@ export interface ImportMeshPayload {
   /** Raw STL file contents (transferred, not copied). */
   readonly buffer: ArrayBuffer;
   readonly fileName: string;
-  /** Quarter-turn corrections applied after auto lay-flat. */
-  readonly flips?: MeshImportFlips;
+  /** Per-axis rotation (degrees) applied after auto lay-flat. */
+  readonly rotation?: MeshImportRotation;
 }
 
 export interface InitMessage {

--- a/src/features/generation/worker/generators/meshImport.test.ts
+++ b/src/features/generation/worker/generators/meshImport.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import type { ManifoldToplevel } from 'manifold-3d';
+import type { Manifold, ManifoldToplevel } from 'manifold-3d';
 import { importMeshFromStl } from './meshImport';
 import {
   decodeMeshData,
@@ -141,11 +141,11 @@ describe('importMeshFromStl', () => {
     expect(footprint[1]).toBeCloseTo(20, 3);
   });
 
-  it('applies quarter-turn flips after lay-flat', async () => {
+  it('applies quarter-turn rotation after lay-flat', async () => {
     const result = await importMeshFromStl(
       soupToBinarySTL(boxSoup(20, 10, 5)),
       'flipped.stl',
-      { x: 1, y: 0, z: 0 },
+      { x: 90, y: 0, z: 0 },
       module
     );
     expect(isOk(result)).toBe(true);
@@ -153,6 +153,35 @@ describe('importMeshFromStl', () => {
     // 90° about X swaps the lay-flat Y (10) into Z
     expect(result.value.asset.sizeMm.z).toBeCloseTo(10, 3);
     expect(result.value.suggestedCutDepth).toBeCloseTo(10, 3);
+  });
+
+  it('applies free-angle rotation (45° about Z grows the footprint to the diagonal)', async () => {
+    const result = await importMeshFromStl(
+      soupToBinarySTL(boxSoup(20, 10, 5)),
+      'tilted.stl',
+      { x: 0, y: 0, z: 45 },
+      module
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const { sizeMm } = result.value.asset;
+    const diagonal = (20 + 10) / Math.SQRT2;
+    expect(sizeMm.x).toBeCloseTo(diagonal, 2);
+    expect(sizeMm.y).toBeCloseTo(diagonal, 2);
+    expect(sizeMm.z).toBeCloseTo(5, 3);
+  });
+
+  it('normalizes rotation angles modulo 360', async () => {
+    const result = await importMeshFromStl(
+      soupToBinarySTL(boxSoup(20, 10, 5)),
+      'wrapped.stl',
+      { x: -270, y: 720, z: 0 },
+      module
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    // -270 ≡ 90 about X swaps the lay-flat Y (10) into Z; 720 ≡ 0 is a no-op
+    expect(result.value.asset.sizeMm.z).toBeCloseTo(10, 3);
   });
 
   it('imports ASCII STL through the same pipeline', async () => {
@@ -215,6 +244,62 @@ describe('importMeshFromStl', () => {
       expect(result.value.asset.sizeMm.z).toBeCloseTo(40, 0);
     } finally {
       sphere.delete();
+    }
+  }, 60_000);
+
+  it('keeps scanned-silhouette detail while filtering speck rings', async () => {
+    // Synthetic "scan": a detailed round tool, one real small feature (a 3mm
+    // prong), and 60 sub-mm noise islands scattered around them.
+    const scratch: Manifold[] = [];
+    const track = (m: Manifold): Manifold => {
+      scratch.push(m);
+      return m;
+    };
+    const parts = [
+      track(module.Manifold.cylinder(5, 30, 30, 128)),
+      track(track(module.Manifold.cube([3, 3, 5])).translate([40, 0, 0])),
+    ];
+    for (let i = 0; i < 60; i++) {
+      const angle = (i / 60) * Math.PI * 2;
+      parts.push(
+        track(
+          track(module.Manifold.cube([0.5, 0.5, 0.5])).translate([
+            50 * Math.cos(angle),
+            50 * Math.sin(angle),
+            0,
+          ])
+        )
+      );
+    }
+    const noisy = track(module.Manifold.union(parts));
+    try {
+      const mesh = noisy.getMesh();
+      const soup = new Float32Array(mesh.triVerts.length * 3);
+      for (let i = 0; i < mesh.triVerts.length; i++) {
+        const vi = mesh.triVerts[i];
+        soup[i * 3] = mesh.vertProperties[vi * mesh.numProp];
+        soup[i * 3 + 1] = mesh.vertProperties[vi * mesh.numProp + 1];
+        soup[i * 3 + 2] = mesh.vertProperties[vi * mesh.numProp + 2];
+      }
+
+      const result = await importMeshFromStl(soupToBinarySTL(soup), 'scan.stl', undefined, module);
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      const { outlines } = result.value.asset;
+
+      // Specks (0.25mm² each) are filtered; the tool and its 9mm² prong survive.
+      expect(outlines).toHaveLength(2);
+      const areas = outlines.map(ringArea).sort((a, b) => b - a);
+      expect(areas[0]).toBeCloseTo(Math.PI * 30 * 30, -2);
+      expect(areas[1]).toBeCloseTo(9, 0);
+
+      // The main silhouette keeps real detail instead of collapsing to a box.
+      const mainRing = outlines.reduce((a, b) => (ringArea(a) >= ringArea(b) ? a : b));
+      expect(mainRing.length).toBeGreaterThanOrEqual(40);
+      const total = outlines.reduce((sum, ring) => sum + ring.length, 0);
+      expect(total).toBeLessThanOrEqual(4000);
+    } finally {
+      for (const m of scratch) m.delete();
     }
   }, 60_000);
 

--- a/src/features/generation/worker/generators/meshImport.test.ts
+++ b/src/features/generation/worker/generators/meshImport.test.ts
@@ -79,6 +79,18 @@ function soupToAsciiSTL(soup: Float32Array): ArrayBuffer {
   return encoded.buffer.slice(0, encoded.byteLength);
 }
 
+function manifoldToSoup(manifold: Manifold): Float32Array {
+  const mesh = manifold.getMesh();
+  const soup = new Float32Array(mesh.triVerts.length * 3);
+  for (let i = 0; i < mesh.triVerts.length; i++) {
+    const vi = mesh.triVerts[i];
+    soup[i * 3] = mesh.vertProperties[vi * mesh.numProp];
+    soup[i * 3 + 1] = mesh.vertProperties[vi * mesh.numProp + 1];
+    soup[i * 3 + 2] = mesh.vertProperties[vi * mesh.numProp + 2];
+  }
+  return soup;
+}
+
 function ringArea(ring: ReadonlyArray<MeshOutlinePoint>): number {
   let area = 0;
   for (let i = 0; i < ring.length; i++) {
@@ -220,15 +232,8 @@ describe('importMeshFromStl', () => {
     // it through STL as the "user upload"
     const sphere = module.Manifold.sphere(20, 360);
     try {
-      const mesh = sphere.getMesh();
-      const soup = new Float32Array(mesh.triVerts.length * 3);
-      for (let i = 0; i < mesh.triVerts.length; i++) {
-        const vi = mesh.triVerts[i];
-        soup[i * 3] = mesh.vertProperties[vi * mesh.numProp];
-        soup[i * 3 + 1] = mesh.vertProperties[vi * mesh.numProp + 1];
-        soup[i * 3 + 2] = mesh.vertProperties[vi * mesh.numProp + 2];
-      }
-      expect(mesh.triVerts.length / 3).toBeGreaterThan(MAX_MESH_ASSET_TRIANGLES);
+      const soup = manifoldToSoup(sphere);
+      expect(soup.length / 9).toBeGreaterThan(MAX_MESH_ASSET_TRIANGLES);
 
       const result = await importMeshFromStl(
         soupToBinarySTL(soup),
@@ -273,14 +278,7 @@ describe('importMeshFromStl', () => {
     }
     const noisy = track(module.Manifold.union(parts));
     try {
-      const mesh = noisy.getMesh();
-      const soup = new Float32Array(mesh.triVerts.length * 3);
-      for (let i = 0; i < mesh.triVerts.length; i++) {
-        const vi = mesh.triVerts[i];
-        soup[i * 3] = mesh.vertProperties[vi * mesh.numProp];
-        soup[i * 3 + 1] = mesh.vertProperties[vi * mesh.numProp + 1];
-        soup[i * 3 + 2] = mesh.vertProperties[vi * mesh.numProp + 2];
-      }
+      const soup = manifoldToSoup(noisy);
 
       const result = await importMeshFromStl(soupToBinarySTL(soup), 'scan.stl', undefined, module);
       expect(isOk(result)).toBe(true);
@@ -298,6 +296,90 @@ describe('importMeshFromStl', () => {
       expect(mainRing.length).toBeGreaterThanOrEqual(40);
       const total = outlines.reduce((sum, ring) => sum + ring.length, 0);
       expect(total).toBeLessThanOrEqual(4000);
+    } finally {
+      for (const m of scratch) m.delete();
+    }
+  }, 60_000);
+
+  it('keeps a sub-4mm² feature on a small tool (relative speck threshold binds)', async () => {
+    // Small tool: largest ring ~314mm², so the relative threshold (0.63mm²)
+    // binds instead of the 4mm² absolute cap. A 1mm² prong must survive it
+    // while 0.25mm² specks are still filtered.
+    const scratch: Manifold[] = [];
+    const track = (m: Manifold): Manifold => {
+      scratch.push(m);
+      return m;
+    };
+    const parts = [
+      track(module.Manifold.cylinder(5, 10, 10, 64)),
+      track(track(module.Manifold.cube([1, 1, 5])).translate([15, 0, 0])),
+      track(track(module.Manifold.cube([0.5, 0.5, 0.5])).translate([20, 0, 0])),
+      track(track(module.Manifold.cube([0.5, 0.5, 0.5])).translate([0, 20, 0])),
+    ];
+    const noisy = track(module.Manifold.union(parts));
+    try {
+      const soup = manifoldToSoup(noisy);
+
+      const result = await importMeshFromStl(
+        soupToBinarySTL(soup),
+        'small-tool.stl',
+        undefined,
+        module
+      );
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      const areas = result.value.asset.outlines.map(ringArea).sort((a, b) => b - a);
+      expect(areas).toHaveLength(2);
+      expect(areas[0]).toBeCloseTo(Math.PI * 10 * 10, -1);
+      expect(areas[1]).toBeCloseTo(1, 1);
+    } finally {
+      for (const m of scratch) m.delete();
+    }
+  }, 60_000);
+
+  it('drops smallest rings (never main-outline detail) when the point budget overflows', async () => {
+    // 500 real (well above speck size) small rings alongside one main ring
+    // overflow the 4000-point cap even after per-ring simplification.
+    const scratch: Manifold[] = [];
+    const track = (m: Manifold): Manifold => {
+      scratch.push(m);
+      return m;
+    };
+    const parts = [track(module.Manifold.cylinder(5, 30, 30, 128))];
+    for (let i = 0; i < 500; i++) {
+      parts.push(
+        track(
+          track(module.Manifold.cylinder(5, 4, 4, 24)).translate([
+            40 + (i % 23) * 12,
+            Math.floor(i / 23) * 12,
+            0,
+          ])
+        )
+      );
+    }
+    const crowded = track(module.Manifold.union(parts));
+    try {
+      const soup = manifoldToSoup(crowded);
+
+      const result = await importMeshFromStl(
+        soupToBinarySTL(soup),
+        'crowded.stl',
+        undefined,
+        module
+      );
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      const { outlines } = result.value.asset;
+
+      const total = outlines.reduce((sum, ring) => sum + ring.length, 0);
+      expect(total).toBeLessThanOrEqual(4000);
+      // Some small rings were dropped, but never all of them…
+      expect(outlines.length).toBeGreaterThan(1);
+      expect(outlines.length).toBeLessThan(501);
+      // …and the main ring survives with its detail intact (rings are stored
+      // largest-first).
+      expect(ringArea(outlines[0])).toBeCloseTo(Math.PI * 30 * 30, -2);
+      expect(outlines[0].length).toBeGreaterThanOrEqual(24);
     } finally {
       for (const m of scratch) m.delete();
     }

--- a/src/features/generation/worker/generators/meshImport.ts
+++ b/src/features/generation/worker/generators/meshImport.ts
@@ -113,7 +113,7 @@ function simplifyRingToBudget(
   let epsilon = OUTLINE_EPSILON_MM;
   let out = simplifyRdp(ring, epsilon);
   while (out.length > budget && epsilon < OUTLINE_EPSILON_SOFT_MAX_MM) {
-    epsilon *= 2;
+    epsilon = Math.min(epsilon * 2, OUTLINE_EPSILON_SOFT_MAX_MM);
     out = simplifyRdp(ring, epsilon);
   }
   return out;
@@ -161,7 +161,7 @@ function extractOutlines(oriented: Manifold): MeshOutlinePoint[][] {
       while (outlines.length > 1 && total() > MAX_MESH_OUTLINE_POINTS) outlines.pop();
       let epsilon = OUTLINE_EPSILON_SOFT_MAX_MM;
       while (total() > MAX_MESH_OUTLINE_POINTS && epsilon < OUTLINE_EPSILON_HARD_MAX_MM) {
-        epsilon *= 2;
+        epsilon = Math.min(epsilon * 2, OUTLINE_EPSILON_HARD_MAX_MM);
         outlines = [simplifyRdp(kept[0], epsilon)];
       }
       return outlines.filter((ring) => ring.length >= 3);

--- a/src/features/generation/worker/generators/meshImport.ts
+++ b/src/features/generation/worker/generators/meshImport.ts
@@ -150,9 +150,10 @@ function extractOutlines(oriented: Manifold): MeshOutlinePoint[][] {
         .sort((a, b) => b.area - a.area)
         .map(({ ring }) => ring.map(([x, y]): MeshOutlinePoint => ({ x, y })));
 
-      const totalPerimeter = kept.reduce((sum, ring) => sum + ringPerimeter(ring), 0);
-      let outlines = kept.map((ring) => {
-        const share = totalPerimeter > 0 ? ringPerimeter(ring) / totalPerimeter : 0;
+      const perimeters = kept.map(ringPerimeter);
+      const totalPerimeter = perimeters.reduce((sum, length) => sum + length, 0);
+      let outlines = kept.map((ring, i) => {
+        const share = totalPerimeter > 0 ? perimeters[i] / totalPerimeter : 0;
         const budget = Math.max(MIN_RING_BUDGET, Math.floor(MAX_MESH_OUTLINE_POINTS * share));
         return simplifyRingToBudget(ring, budget);
       });

--- a/src/features/generation/worker/generators/meshImport.ts
+++ b/src/features/generation/worker/generators/meshImport.ts
@@ -106,7 +106,10 @@ function ringPerimeter(ring: ReadonlyArray<MeshOutlinePoint>): number {
 
 /** Epsilon ladder from {@link OUTLINE_EPSILON_MM}, doubling while the ring is
  *  over budget — but never past the soft cap: fidelity beats budget share. */
-function simplifyRingToBudget(ring: ReadonlyArray<MeshOutlinePoint>, budget: number) {
+function simplifyRingToBudget(
+  ring: ReadonlyArray<MeshOutlinePoint>,
+  budget: number
+): MeshOutlinePoint[] {
   let epsilon = OUTLINE_EPSILON_MM;
   let out = simplifyRdp(ring, epsilon);
   while (out.length > budget && epsilon < OUTLINE_EPSILON_SOFT_MAX_MM) {
@@ -140,7 +143,7 @@ function extractOutlines(oriented: Manifold): MeshOutlinePoint[][] {
         .filter(({ area }) => area > 0);
       if (outer.length === 0) return [];
 
-      const largestArea = Math.max(...outer.map(({ area }) => area));
+      const largestArea = outer.reduce((max, { area }) => (area > max ? area : max), 0);
       const speckThreshold = Math.min(largestArea * SPECK_RELATIVE_AREA, SPECK_KEEP_AREA_MM2);
       const kept = outer
         .filter(({ area }) => area >= speckThreshold)
@@ -291,12 +294,12 @@ export async function importMeshFromStl(
       normalizeDeg(rotation.z),
     ];
     const laid = solid.rotate([...layFlat]);
-    const flipped = laid.rotate([...userRotation]);
+    const rotated = laid.rotate([...userRotation]);
     laid.delete();
 
-    const box = flipped.boundingBox();
-    oriented = flipped.translate([-box.min[0], -box.min[1], -box.min[2]]);
-    flipped.delete();
+    const box = rotated.boundingBox();
+    oriented = rotated.translate([-box.min[0], -box.min[1], -box.min[2]]);
+    rotated.delete();
 
     const finalBox = oriented.boundingBox();
     const sizeMm = {

--- a/src/features/generation/worker/generators/meshImport.ts
+++ b/src/features/generation/worker/generators/meshImport.ts
@@ -1,7 +1,7 @@
 /**
  * STL → MeshAsset import pipeline (worker-side).
  *
- * parse → weld/merge (repair) → manifold-check → auto lay-flat → user flips →
+ * parse → weld/merge (repair) → manifold-check → auto lay-flat → user rotation →
  * decimate to budget → silhouette outlines → quantize+compress.
  *
  * Runs on the raw manifold-3d module (independent of the worker's brepjs
@@ -22,7 +22,7 @@ import {
 import type {
   MeshAsset,
   MeshImportErrorReason,
-  MeshImportFlips,
+  MeshImportRotation,
   MeshOutlinePoint,
 } from '@/shared/generation/meshAsset';
 import { simplifyRdp } from '@/shared/scanTrace/simplify';
@@ -58,6 +58,20 @@ const LAY_FLAT_CANDIDATES: ReadonlyArray<readonly [number, number, number]> = [
 
 const DECIMATE_TOLERANCES_MM = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2] as const;
 const OUTLINE_EPSILON_MM = 0.05;
+/** Simplification stops coarsening here so a detailed silhouette is never
+ *  crushed to a blob just to fit its budget share — overflow is resolved by
+ *  dropping the smallest rings instead. */
+const OUTLINE_EPSILON_SOFT_MAX_MM = 0.5;
+/** Last-resort ceiling when a single ring alone overflows the total cap. */
+const OUTLINE_EPSILON_HARD_MAX_MM = 5;
+/** Rings below this share of the largest ring's area are scan-noise specks… */
+const SPECK_RELATIVE_AREA = 0.002;
+/** …unless they clear this absolute area — a real small feature (a 3mm probe
+ *  tip) must survive no matter how large the tool it belongs to. */
+const SPECK_KEEP_AREA_MM2 = 4;
+/** Floor of the shared point budget per kept ring, so small real features
+ *  stay round-ish instead of collapsing to triangles. */
+const MIN_RING_BUDGET = 16;
 
 function sanitizeName(fileName: string): string {
   return (
@@ -80,32 +94,74 @@ function signedArea(ring: ReadonlyArray<readonly [number, number]>): number {
   return area / 2;
 }
 
+function ringPerimeter(ring: ReadonlyArray<MeshOutlinePoint>): number {
+  let length = 0;
+  for (let i = 0; i < ring.length; i++) {
+    const a = ring[i];
+    const b = ring[(i + 1) % ring.length];
+    length += Math.hypot(b.x - a.x, b.y - a.y);
+  }
+  return length;
+}
+
+/** Epsilon ladder from {@link OUTLINE_EPSILON_MM}, doubling while the ring is
+ *  over budget — but never past the soft cap: fidelity beats budget share. */
+function simplifyRingToBudget(ring: ReadonlyArray<MeshOutlinePoint>, budget: number) {
+  let epsilon = OUTLINE_EPSILON_MM;
+  let out = simplifyRdp(ring, epsilon);
+  while (out.length > budget && epsilon < OUTLINE_EPSILON_SOFT_MAX_MM) {
+    epsilon *= 2;
+    out = simplifyRdp(ring, epsilon);
+  }
+  return out;
+}
+
 /**
  * Extract simplified outer silhouette rings from the oriented manifold.
  * Holes (negative-area rings) are dropped: the footprint, clearance offset,
  * and chamfer rim all operate on the insertion opening, which is the outer
- * boundary. Point count is capped by re-simplifying with a doubled epsilon.
+ * boundary.
+ *
+ * Scanned meshes project with speck rings (noise islands) and dense, noisy
+ * contours, so the point cap is enforced without sacrificing the outline the
+ * user actually cares about: specks are filtered by area first, the shared
+ * budget is split across the surviving rings by perimeter, and each ring's
+ * epsilon stops coarsening at a soft cap. If the total still overflows, the
+ * smallest rings are dropped whole — never the main outline's detail.
  */
 function extractOutlines(oriented: Manifold): MeshOutlinePoint[][] {
   const projected: CrossSection = oriented.project();
   try {
     const simplified = projected.simplify(0.02);
     try {
-      const rings = simplified
+      const outer = simplified
         .toPolygons()
-        .filter((ring) => signedArea(ring) > 0)
-        .map((ring) => ring.map(([x, y]) => ({ x, y })));
+        .map((ring) => ({ ring, area: signedArea(ring) }))
+        .filter(({ area }) => area > 0);
+      if (outer.length === 0) return [];
 
-      let epsilon = OUTLINE_EPSILON_MM;
-      let outlines = rings.map((ring) => simplifyRdp(ring, epsilon));
-      while (
-        outlines.reduce((total, ring) => total + ring.length, 0) > MAX_MESH_OUTLINE_POINTS &&
-        epsilon < 5
-      ) {
+      const largestArea = Math.max(...outer.map(({ area }) => area));
+      const speckThreshold = Math.min(largestArea * SPECK_RELATIVE_AREA, SPECK_KEEP_AREA_MM2);
+      const kept = outer
+        .filter(({ area }) => area >= speckThreshold)
+        .sort((a, b) => b.area - a.area)
+        .map(({ ring }) => ring.map(([x, y]): MeshOutlinePoint => ({ x, y })));
+
+      const totalPerimeter = kept.reduce((sum, ring) => sum + ringPerimeter(ring), 0);
+      let outlines = kept.map((ring) => {
+        const share = totalPerimeter > 0 ? ringPerimeter(ring) / totalPerimeter : 0;
+        const budget = Math.max(MIN_RING_BUDGET, Math.floor(MAX_MESH_OUTLINE_POINTS * share));
+        return simplifyRingToBudget(ring, budget);
+      });
+
+      const total = (): number => outlines.reduce((sum, ring) => sum + ring.length, 0);
+      while (outlines.length > 1 && total() > MAX_MESH_OUTLINE_POINTS) outlines.pop();
+      let epsilon = OUTLINE_EPSILON_SOFT_MAX_MM;
+      while (total() > MAX_MESH_OUTLINE_POINTS && epsilon < OUTLINE_EPSILON_HARD_MAX_MM) {
         epsilon *= 2;
-        outlines = rings.map((ring) => simplifyRdp(ring, epsilon));
+        outlines = [simplifyRdp(kept[0], epsilon)];
       }
-      return outlines;
+      return outlines.filter((ring) => ring.length >= 3);
     } finally {
       simplified.delete();
     }
@@ -164,14 +220,14 @@ function decimateToBudget(manifold: Manifold): Manifold | null {
 /**
  * Full import: STL buffer → compressed MeshAsset + preview arrays.
  *
- * `flips` compose AFTER the deterministic auto lay-flat, so re-running with
- * different flips is stable (the auto orientation never changes for a given
- * file).
+ * `rotation` (degrees per axis, any angle) composes AFTER the deterministic
+ * auto lay-flat, so re-running with a different rotation is stable (the auto
+ * orientation never changes for a given file).
  */
 export async function importMeshFromStl(
   buffer: ArrayBuffer,
   fileName: string,
-  flips: MeshImportFlips = { x: 0, y: 0, z: 0 },
+  rotation: MeshImportRotation = { x: 0, y: 0, z: 0 },
   // Node tests inject an fs-instantiated module; the worker's fetch-based
   // loader can't run outside the browser.
   moduleOverride?: ManifoldToplevel
@@ -227,13 +283,15 @@ export async function importMeshFromStl(
     solid = decimated;
 
     const layFlat = pickLayFlatRotation(solid);
-    const flipRotation: readonly [number, number, number] = [
-      (((flips.x % 4) + 4) % 4) * 90,
-      (((flips.y % 4) + 4) % 4) * 90,
-      (((flips.z % 4) + 4) % 4) * 90,
+    const normalizeDeg = (deg: number): number =>
+      Number.isFinite(deg) ? ((deg % 360) + 360) % 360 : 0;
+    const userRotation: readonly [number, number, number] = [
+      normalizeDeg(rotation.x),
+      normalizeDeg(rotation.y),
+      normalizeDeg(rotation.z),
     ];
     const laid = solid.rotate([...layFlat]);
-    const flipped = laid.rotate([...flipRotation]);
+    const flipped = laid.rotate([...userRotation]);
     laid.delete();
 
     const box = flipped.boundingBox();

--- a/src/features/generation/worker/handlers/importMeshHandler.ts
+++ b/src/features/generation/worker/handlers/importMeshHandler.ts
@@ -13,9 +13,9 @@ import { importMeshFromStl } from '../generators/meshImport';
 import { formatError } from './workerContext';
 
 export async function handleImportMesh(message: ImportMeshMessage): Promise<void> {
-  const { requestId, buffer, fileName, flips } = message.payload;
+  const { requestId, buffer, fileName, rotation } = message.payload;
   try {
-    const result = await importMeshFromStl(buffer, fileName, flips);
+    const result = await importMeshFromStl(buffer, fileName, rotation);
     if (isErr(result)) {
       const response: ImportMeshErrorResponse = {
         type: 'IMPORT_MESH_ERROR',

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Mesh wird verarbeitet…",
   "binDesigner.cutouts.stlImport.triangles": "{count} Dreiecke",
   "binDesigner.cutouts.stlImport.flipAxis": "{axis} drehen",
+  "binDesigner.cutouts.stlImport.rotateAxis": "{axis}-Rotation (Grad)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Dieses Modell ist größer als der Behälterinnenraum. Es wird trotzdem platziert — vergrößere den Behälter oder nutze ein kleineres Modell für eine vollständige Tasche.",
   "binDesigner.cutouts.stlImport.place": "In Behälter platzieren",
   "binDesigner.cutouts.shapeName.mesh": "STL-Abdruck",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2029,6 +2029,7 @@ const en: Record<string, string> = {
   'binDesigner.cutouts.stlImport.processing': 'Processing mesh…',
   'binDesigner.cutouts.stlImport.triangles': '{count} triangles',
   'binDesigner.cutouts.stlImport.flipAxis': 'Flip {axis}',
+  'binDesigner.cutouts.stlImport.rotateAxis': 'Rotate {axis} (degrees)',
   'binDesigner.cutouts.stlImport.oversizeWarning':
     'This model is larger than the bin interior. It will be placed anyway — enlarge the bin or use a smaller model for a full pocket.',
   'binDesigner.cutouts.stlImport.place': 'Place in bin',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Procesando malla…",
   "binDesigner.cutouts.stlImport.triangles": "{count} triángulos",
   "binDesigner.cutouts.stlImport.flipAxis": "Girar {axis}",
+  "binDesigner.cutouts.stlImport.rotateAxis": "Rotar {axis} (grados)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Este modelo es más grande que el interior del contenedor. Se colocará de todos modos: amplía el contenedor o usa un modelo más pequeño para una cavidad completa.",
   "binDesigner.cutouts.stlImport.place": "Colocar en el contenedor",
   "binDesigner.cutouts.shapeName.mesh": "Huella STL",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Traitement du maillage…",
   "binDesigner.cutouts.stlImport.triangles": "{count} triangles",
   "binDesigner.cutouts.stlImport.flipAxis": "Pivoter {axis}",
+  "binDesigner.cutouts.stlImport.rotateAxis": "Rotation {axis} (degrés)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Ce modèle est plus grand que l'intérieur du bac. Il sera placé quand même — agrandissez le bac ou utilisez un modèle plus petit pour une empreinte complète.",
   "binDesigner.cutouts.stlImport.place": "Placer dans le bac",
   "binDesigner.cutouts.shapeName.mesh": "Empreinte STL",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Elaborazione della mesh…",
   "binDesigner.cutouts.stlImport.triangles": "{count} triangoli",
   "binDesigner.cutouts.stlImport.flipAxis": "Ruota {axis}",
+  "binDesigner.cutouts.stlImport.rotateAxis": "Rotazione {axis} (gradi)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Questo modello è più grande dell'interno del contenitore. Verrà comunque posizionato: ingrandisci il contenitore o usa un modello più piccolo per una tasca completa.",
   "binDesigner.cutouts.stlImport.place": "Posiziona nel contenitore",
   "binDesigner.cutouts.shapeName.mesh": "Impronta STL",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "メッシュを処理中…",
   "binDesigner.cutouts.stlImport.triangles": "{count} 三角形",
   "binDesigner.cutouts.stlImport.flipAxis": "{axis} 回転",
+  "binDesigner.cutouts.stlImport.rotateAxis": "{axis} 回転（度）",
   "binDesigner.cutouts.stlImport.oversizeWarning": "このモデルはビンの内寸より大きいです。そのまま配置されますが、完全なポケットにはビンを大きくするか、より小さいモデルを使用してください。",
   "binDesigner.cutouts.stlImport.place": "ビンに配置",
   "binDesigner.cutouts.shapeName.mesh": "STLインプリント",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Behandler mesh…",
   "binDesigner.cutouts.stlImport.triangles": "{count} trekanter",
   "binDesigner.cutouts.stlImport.flipAxis": "Roter {axis}",
+  "binDesigner.cutouts.stlImport.rotateAxis": "Roter {axis} (grader)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Denne modellen er større enn innsiden av boksen. Den plasseres likevel — gjør boksen større eller bruk en mindre modell for en full lomme.",
   "binDesigner.cutouts.stlImport.place": "Plasser i boksen",
   "binDesigner.cutouts.shapeName.mesh": "STL-avtrykk",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Mesh verwerken…",
   "binDesigner.cutouts.stlImport.triangles": "{count} driehoeken",
   "binDesigner.cutouts.stlImport.flipAxis": "{axis} draaien",
+  "binDesigner.cutouts.stlImport.rotateAxis": "{axis} roteren (graden)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Dit model is groter dan de binnenkant van de bak. Het wordt toch geplaatst — vergroot de bak of gebruik een kleiner model voor een volledige uitsparing.",
   "binDesigner.cutouts.stlImport.place": "In bak plaatsen",
   "binDesigner.cutouts.shapeName.mesh": "STL-afdruk",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Processando malha…",
   "binDesigner.cutouts.stlImport.triangles": "{count} triângulos",
   "binDesigner.cutouts.stlImport.flipAxis": "Girar {axis}",
+  "binDesigner.cutouts.stlImport.rotateAxis": "Rotação {axis} (graus)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Este modelo é maior que o interior da caixa. Ele será posicionado mesmo assim — aumente a caixa ou use um modelo menor para um encaixe completo.",
   "binDesigner.cutouts.stlImport.place": "Posicionar na caixa",
   "binDesigner.cutouts.shapeName.mesh": "Molde STL",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Bearbetar mesh…",
   "binDesigner.cutouts.stlImport.triangles": "{count} trianglar",
   "binDesigner.cutouts.stlImport.flipAxis": "Rotera {axis}",
+  "binDesigner.cutouts.stlImport.rotateAxis": "Rotera {axis} (grader)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Modellen är större än lådans insida. Den placeras ändå — förstora lådan eller använd en mindre modell för en komplett ficka.",
   "binDesigner.cutouts.stlImport.place": "Placera i lådan",
   "binDesigner.cutouts.shapeName.mesh": "STL-avtryck",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2712,6 +2712,7 @@
   "binDesigner.cutouts.stlImport.processing": "Обробка сітки…",
   "binDesigner.cutouts.stlImport.triangles": "{count} трикутників",
   "binDesigner.cutouts.stlImport.flipAxis": "Повернути {axis}",
+  "binDesigner.cutouts.stlImport.rotateAxis": "Обертання {axis} (градуси)",
   "binDesigner.cutouts.stlImport.oversizeWarning": "Ця модель більша за внутрішній простір контейнера. Її все одно буде розміщено — збільште контейнер або використайте меншу модель для повної кишені.",
   "binDesigner.cutouts.stlImport.place": "Розмістити в контейнері",
   "binDesigner.cutouts.shapeName.mesh": "STL-відбиток",

--- a/src/shared/generation/meshAsset.ts
+++ b/src/shared/generation/meshAsset.ts
@@ -49,8 +49,8 @@ export interface MeshAsset {
 /** Why a mesh import failed — drives the user-facing toast + analytics reason. */
 export type MeshImportErrorReason = 'too_large' | 'parse_failed' | 'not_manifold' | 'empty';
 
-/** Quarter-turn counts (0–3) applied about each axis AFTER auto lay-flat. */
-export interface MeshImportFlips {
+/** Rotation in degrees applied about each axis AFTER auto lay-flat. */
+export interface MeshImportRotation {
   readonly x: number;
   readonly y: number;
   readonly z: number;
@@ -63,7 +63,7 @@ export const MAX_MESH_ASSET_TRIANGLES = 50_000;
 /** Max mesh assets per design. */
 export const MAX_MESH_ASSETS_PER_DESIGN = 8;
 /** Max total silhouette points across all outlines of one asset. */
-export const MAX_MESH_OUTLINE_POINTS = 2000;
+export const MAX_MESH_OUTLINE_POINTS = 4000;
 
 const MAGIC = 0x314d4741; // 'GMA1'
 const HEADER_BYTES = 4 + 4 + 4 + 6 * 4;


### PR DESCRIPTION
Addresses user feedback on the STL imprint feature (#2618).

## Squares instead of precise outlines (scanned STLs)

Self-scanned meshes project with dozens of speck rings (scan-noise islands) and dense, noisy contours. The old outline extraction shared one point budget and one epsilon across every ring, doubling epsilon up to 6.4mm until the total fit — so the specks ate the budget and the *main* silhouette collapsed to a near-square. Since every imported cutout carries a default clearance, the degraded outline's clearance prism then carved that square into the printed bin.

Now:
- Speck rings are filtered by area first: a ring survives if it clears 0.2% of the largest ring's area or 4mm² absolute, so a real 3mm prong on a 300mm tool is never dropped.
- The point budget (raised 2000 → 4000, server mirror updated) is split across surviving rings by perimeter, largest first.
- Per-ring epsilon soft-caps at 0.5mm — overflow drops the smallest rings whole instead of crushing the main outline.

Existing imported assets have their outlines baked in; re-uploading the STL picks up the fix.

## Clearance cap 2mm → 5mm

The cap was a hardcoded UI prop; scans need more slack than machined parts. Now `MAX_CUTOUT_CLEARANCE = 5` (all clearance shapes).

## Free rotation at import

The orientation dialog's quarter-turn-only flips become per-axis degree rotation: 15° stepper buttons, typed values, and the existing quarter-turn buttons. Rotation still composes after the deterministic auto lay-flat, so re-runs stay stable. (Rotation about the vertical axis was already free in the 2D editor via the rotate handle — unchanged.)

## Verification

- New real-WASM fixture test: a detailed round tool + 3mm prong + 60 sub-mm noise islands → specks filtered, prong kept, main ring ≥40 points, total under cap.
- Free-angle (45°) and modulo-360 rotation tests through the real pipeline.
- Dialog/hook tests for the new rotation controls; typecheck, lint, i18n checks, and the CutoutsSection/bridge/handlers/shared-generation suites (901 tests) all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves STL import outlines for scanned meshes, adds free per-axis rotation at import, and raises the cutout clearance cap to 5 mm for better fit.

- **Bug Fixes**
  - Preserve scanned-silhouette detail: filter speck rings by area; split a 4000-point cap by perimeter; soft-cap simplification at 0.5 mm and clamp epsilon ladders to the 0.5/5 mm caps; if over budget, drop the smallest rings instead of flattening the main outline.
  - Reliability and consistency: add real-WASM tests for budget-overflow ring-drop and relative speck thresholds; normalize rotation angles modulo 360; align bridge/worker APIs and tests to degrees.
  - Performance: compute ring perimeters once in outline extraction.

- **New Features**
  - Increase max insertion clearance from 2 mm to 5 mm across all clearance shapes.
  - Import dialog now supports per-axis rotation in degrees (15° stepper, typed values, plus quarter-turn buttons), composed after auto lay-flat for stable re-runs.

<sup>Written for commit 612c392cdaaf1c9fb1ba3307758c8252596fc65f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

