### PR TITLE
test(worker): kernel-specific scenario snapshot baselines

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/scenarioRunner.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/scenarioRunner.ts
@@ -29,6 +29,11 @@ function runScenario(scenario: ScenarioCase, timings: TimingEntry[]): void {
     if (scenario.assert === 'snapshot') {
       expect(result.vertices.length).toBeGreaterThan(0);
       expect(result.triangleCount).toBeGreaterThan(0);
+      // Triangle counts are kernel-specific (each kernel tessellates to its
+      // own density). The vitest config's `resolveSnapshotPath` routes each
+      // non-default kernel to its own `.<kernel>.snap` file, so occt-wasm and
+      // brepkit pin separate baselines instead of sharing one that only the
+      // default kernel can match. See vitest.config.ts.
       expect(result.triangleCount).toMatchSnapshot();
     } else {
       assertStructurallyValid(result, scenario.name);

--- a/src/features/generation/worker/generators/__snapshots__/baseplateGenerator.scenario.magnetOversized.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/baseplateGenerator.scenario.magnetOversized.test.ts.brepkit.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 1`] = `16004`;
+
+exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 with the legacy 'center' anchor 1`] = `16004`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.brepkit.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`base styles > flat base no lip 1`] = `300`;
+
+exports[`base styles > flat base with lip 1`] = `1500`;
+
+exports[`base styles > magnet base no lip 1`] = `960`;
+
+exports[`base styles > magnet base with lip 1`] = `2552`;
+
+exports[`base styles > magnet+screw base no lip 1`] = `1136`;
+
+exports[`base styles > magnet+screw base with lip 1`] = `2824`;
+
+exports[`base styles > screw base no lip 1`] = `896`;
+
+exports[`base styles > screw base with lip 1`] = `2440`;
+
+exports[`base styles > standard base no lip 1`] = `720`;
+
+exports[`base styles > standard base with lip 1`] = `2168`;
+
+exports[`base styles > weighted base no lip 1`] = `720`;
+
+exports[`base styles > weighted base with lip 1`] = `2168`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.brepkit.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`bin styles > 2×2 slotted 1`] = `4676`;
+
+exports[`bin styles > 2×2 solid 1`] = `3732`;
+
+exports[`bin styles > 2×2 standard 1`] = `4172`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.brepkit.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `2004`;
+
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `4484`;
+
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4633`;
+
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `4523`;
+
+exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `26268`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.brepkit.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `4172`;
+
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `4344`;
+
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `4030`;
+
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `4792`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.brepkit.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `3671`;
+
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `7013`;
+
+exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `5628`;
+
+exports[`custom-shape > 3×3 L flat base no lip 1`] = `508`;
+
+exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `7137`;
+
+exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `7778`;
+
+exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `22353`;
+
+exports[`custom-shape > 3×3 L with lip 1`] = `6947`;
+
+exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `8386`;
+
+exports[`custom-shape > 3×3 T with lip 1`] = `5651`;
+
+exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `4708`;
+
+exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `4708`;
+
+exports[`custom-shape > 3×3 U with lip 1`] = `4708`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.brepkit.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`dimensions > 0.5×0.5 no lip 1`] = `848`;
+
+exports[`dimensions > 0.5×0.5 with lip 1`] = `2288`;
+
+exports[`dimensions > 1.5×2 fractional no lip 1`] = `1980`;
+
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `4172`;
+
+exports[`dimensions > 1×1 no lip 1`] = `720`;
+
+exports[`dimensions > 1×1 with lip 1`] = `2168`;
+
+exports[`dimensions > 2×2 no lip 1`] = `1980`;
+
+exports[`dimensions > 2×2 with lip 1`] = `4172`;
+
+exports[`dimensions > 4×4 no lip 1`] = `6124`;
+
+exports[`dimensions > 4×4 with lip 1`] = `11666`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.brepkit.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `4036`;
+
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `6900`;
+
+exports[`large bin > 8×8 standard 1`] = `31692`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.brepkit.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `7512`;
+
+exports[`half-sockets > 1×1 with half sockets 1`] = `4172`;
+
+exports[`half-sockets > 2×2 with half sockets 1`] = `12188`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.brepkit.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`height > 2×2 height minimum (2u) 1`] = `4172`;
+
+exports[`height > 2×2 height tall (10u) 1`] = `4172`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.brepkit.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5416`;
+
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `5268`;
+
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `5340`;
+
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `5340`;
+
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `5767`;
+
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `5460`;
+
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `5232`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.brepkit.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`inserts > 2×2 with circle insert 1`] = `4576`;
+
+exports[`inserts > 2×2 with hexagon insert 1`] = `4576`;
+
+exports[`inserts > 2×2 with rectangle insert 1`] = `4192`;
+
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `4432`;
+
+exports[`inserts > 2×2 with slot insert 1`] = `4472`;
+
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `4704`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.brepkit.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`label tabs > 1×1 label both collision drops front 1`] = `2168`;
+
+exports[`label tabs > 2×2 label bracket center 1`] = `4364`;
+
+exports[`label tabs > 2×2 label bracket left 1`] = `4364`;
+
+exports[`label tabs > 2×2 label bracket right 1`] = `4364`;
+
+exports[`label tabs > 2×2 label disabled 1`] = `4172`;
+
+exports[`label tabs > 2×2 label front edge 1`] = `4364`;
+
+exports[`label tabs > 2×2 label solid left 1`] = `4196`;
+
+exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `4284`;
+
+exports[`label tabs > 2×2×4 label both edges 1`] = `4556`;
+
+exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `4388`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.brepkit.snap
@@ -1,0 +1,19 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4007`;
+
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4151`;
+
+exports[`scoop > 2×2 scoop auto radius 1`] = `4007`;
+
+exports[`scoop > 2×2 scoop disabled 1`] = `4172`;
+
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4029`;
+
+exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `4023`;
+
+exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4033`;
+
+exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3853`;
+
+exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `3927`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.brepkit.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`slotted variations > slotted with Y-axis slots 1`] = `4676`;
+
+exports[`slotted variations > slotted with both axes 1`] = `5180`;
+
+exports[`slotted variations > slotted without lip 1`] = `2096`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.brepkit.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3972`;
+
+exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `4012`;
+
+exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `4116`;
+
+exports[`solid cutouts > 2×2 solid with chamfered ellipse cutout 1`] = `3952`;
+
+exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `3818`;
+
+exports[`solid cutouts > 2×2 solid with chamfered path cutout 1`] = `3756`;
+
+exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `3633`;
+
+exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `4485`;
+
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3862`;
+
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `3884`;
+
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3996`;
+
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `3810`;
+
+exports[`solid cutouts > 2×2 solid with hexagon (polygon) cutout 1`] = `3780`;
+
+exports[`solid cutouts > 2×2 solid with hexagon cutout + insertion clearance 1`] = `3798`;
+
+exports[`solid cutouts > 2×2 solid with path cutout + insertion clearance 1`] = `3748`;
+
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `3924`;
+
+exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `4596`;
+
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `3810`;
+
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `4184`;
+
+exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `3656`;
+
+exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `3868`;
+
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `3794`;
+
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `4008`;
+
+exports[`solid cutouts > 2×2 solid with scooped path cutout 1`] = `3586`;
+
+exports[`solid cutouts > 2×2 solid with slot (stadium) cutout 1`] = `4088`;
+
+exports[`solid cutouts > 2×2 solid with staggered hex array 1`] = `3564`;
+
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `3844`;
+
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `3744`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.brepkit.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `4204`;
+
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `4180`;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -54,6 +54,23 @@ export default defineConfig({
   test: {
     globals: true,
     testTimeout: 30000,
+    // Kernel-specific snapshot files: scenario triangle counts depend on the
+    // active kernel's tessellation density, so route each non-default kernel to
+    // its own `.<kernel>.snap`. The default (occt-wasm) keeps the plain `.snap`
+    // files, so existing baselines are untouched; BREPJS_KERNEL=brepkit
+    // reads/writes `.brepkit.snap`. Without this a single shared snapshot could
+    // only ever match one kernel. (resolveSnapshotPath is a root-only vitest
+    // option — it cannot live in a project config.)
+    resolveSnapshotPath: (testPath: string, snapExtension: string): string => {
+      const raw = process.env.BREPJS_KERNEL ?? '';
+      const kernel = raw === 'wasm' ? 'brepkit' : raw;
+      const suffix = kernel && kernel !== 'occt-wasm' ? `.${kernel}` : '';
+      return path.join(
+        path.dirname(testPath),
+        '__snapshots__',
+        `${path.basename(testPath)}${suffix}${snapExtension}`
+      );
+    },
     pool: 'threads',
     maxWorkers: process.env.CI ? '100%' : '75%',
     coverage: {


### PR DESCRIPTION
Scenario snapshot assertions pin `triangleCount`, which depends on the active kernel's tessellation density — a single shared `.snap` could only ever match one kernel.

## Changes

- `vitest.config.ts`: `resolveSnapshotPath` routes each non-default kernel to its own `.<kernel>.snap` file. The default (occt-wasm) keeps the existing plain `.snap` baselines byte-for-byte untouched. This is a root-only vitest option, so it can't live in a project config.
- 17 `.brepkit.snap` baselines pinned for `BREPJS_KERNEL=brepkit`, pairing 1:1 with the existing default snapshots.
- A pointer comment in `scenarioRunner.ts` at the `toMatchSnapshot` site.

## Verified

- Default run passes against plain `.snap`
- `BREPJS_KERNEL=brepkit` passes against `.brepkit.snap` with no snapshot writes
- The `wasm` env alias resolves to `.brepkit.snap` (matches `ENV_TO_KERNEL` in `wasmInit.ts`) instead of minting a `.wasm.snap`
- ESLint + `tsc --noEmit` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make scenario snapshots kernel-specific so triangle-count assertions match the active kernel. Default `occt-wasm` keeps existing `.snap` files; `BREPJS_KERNEL=brepkit` now reads `.<kernel>.snap` baselines.

- New Features
  - Added `resolveSnapshotPath` in root `vitest.config.ts` to route non-default kernels to `.<kernel>.snap`; maps `wasm` -> `brepkit`.
  - Pinned 17 `.brepkit.snap` baselines for parity with existing scenarios.
  - Added a pointer comment at the snapshot assertion in `scenarioRunner.ts`.

<sup>Written for commit 465e29241ee09a292fdbdea25f5db5282cff34d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

