### PR TITLE
feat(designer): interlocking dividers for both directions at once

### DIFF
--- a/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.test.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.test.tsx
@@ -166,4 +166,64 @@ describe('SlotConfigurator', () => {
       expect(setParam).toHaveBeenCalled();
     }
   });
+
+  it('shows a both-directions toggle button', () => {
+    render(<SlotConfigurator />);
+    expect(screen.getByText(/both/i)).toBeInTheDocument();
+  });
+
+  it('enables both axes when both is clicked', () => {
+    const setParam = vi.fn();
+    useDesignerStore.setState({ setParam });
+
+    render(<SlotConfigurator />);
+    fireEvent.click(screen.getByText(/both/i));
+
+    expect(setParam).toHaveBeenCalledWith(
+      'slotConfig',
+      expect.objectContaining({
+        x: expect.objectContaining({ enabled: true }),
+        y: expect.objectContaining({ enabled: true }),
+      })
+    );
+  });
+
+  it('shows a spacing control per direction when both axes are enabled', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        slotConfig: {
+          x: { enabled: true, pitch: 20 },
+          y: { enabled: true, pitch: 30 },
+        },
+      },
+    });
+    render(<SlotConfigurator />);
+
+    const bothButton = screen.getByText(/both/i);
+    expect(bothButton).toHaveClass('bg-accent');
+
+    const spinbuttons = screen.getAllByRole('spinbutton');
+    const pitchControls = spinbuttons.filter((el) =>
+      el.getAttribute('aria-label')?.includes('Compartment width')
+    );
+    expect(pitchControls).toHaveLength(2);
+  });
+
+  it('shows divider dimensions for both pieces when both axes are enabled', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        width: 2,
+        depth: 3,
+        slotConfig: {
+          x: { enabled: true, pitch: 20 },
+          y: { enabled: true, pitch: 20 },
+        },
+      },
+    });
+    const { container } = render(<SlotConfigurator />);
+    const text = container.textContent ?? '';
+    expect(text).toMatch(/vertical.*×.*mm.*horizontal.*×.*mm/is);
+  });
 });

--- a/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.test.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.test.tsx
@@ -193,6 +193,7 @@ describe('SlotConfigurator', () => {
       params: {
         ...DEFAULT_BIN_PARAMS,
         slotConfig: {
+          ...DEFAULT_BIN_PARAMS.slotConfig,
           x: { enabled: true, pitch: 20 },
           y: { enabled: true, pitch: 30 },
         },
@@ -217,6 +218,7 @@ describe('SlotConfigurator', () => {
         width: 2,
         depth: 3,
         slotConfig: {
+          ...DEFAULT_BIN_PARAMS.slotConfig,
           x: { enabled: true, pitch: 20 },
           y: { enabled: true, pitch: 20 },
         },

--- a/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
@@ -24,7 +24,8 @@ import { clamp } from '@/shared/utils/math';
 import { useTranslation } from '@/i18n';
 import type { DividerPieceConfig } from '../../types';
 
-type SlotDirection = 'vertical' | 'horizontal';
+type SlotDirection = 'vertical' | 'horizontal' | 'both';
+type SlotAxis = 'x' | 'y';
 
 export function SlotConfigurator() {
   const { params, setParam } = useDesignerStore(
@@ -44,42 +45,53 @@ export function SlotConfigurator() {
   const lipOverhang = stackingLip ? Math.max(0, lipTaperWidth - params.wallThickness) : 0;
 
   // ── Slot direction / count ──────────────────────────────────────────
-  const activeDirection: SlotDirection = slotConfig.y.enabled ? 'vertical' : 'horizontal';
-  const activeAxis = activeDirection === 'vertical' ? 'y' : 'x';
-  const activePitch = slotConfig[activeAxis].pitch;
-  const activeInnerDim = activeAxis === 'x' ? innerD : innerW;
+  const activeDirection: SlotDirection =
+    slotConfig.x.enabled && slotConfig.y.enabled
+      ? 'both'
+      : slotConfig.y.enabled
+        ? 'vertical'
+        : 'horizontal';
+  const enabledAxes = useMemo<SlotAxis[]>(
+    () =>
+      activeDirection === 'both' ? ['y', 'x'] : activeDirection === 'vertical' ? ['y'] : ['x'],
+    [activeDirection]
+  );
+
+  // X-axis slots sit on the left/right walls, spaced along the depth;
+  // Y-axis slots sit on the front/back walls, spaced along the width.
+  const axisInnerDim = useCallback(
+    (axis: SlotAxis) => (axis === 'x' ? innerD : innerW),
+    [innerD, innerW]
+  );
 
   const slotCount = useMemo(() => {
-    return calculateSlotPositions(activeInnerDim, activePitch, lipOverhang).length;
-  }, [activeInnerDim, activePitch, lipOverhang]);
+    return enabledAxes.reduce(
+      (sum, axis) =>
+        sum +
+        calculateSlotPositions(axisInnerDim(axis), slotConfig[axis].pitch, lipOverhang).length,
+      0
+    );
+  }, [enabledAxes, slotConfig, axisInnerDim, lipOverhang]);
 
   const setDirection = useCallback(
     (direction: SlotDirection) => {
-      if (direction === 'vertical') {
-        setParam('slotConfig', {
-          ...slotConfig,
-          x: { ...slotConfig.x, enabled: false },
-          y: { ...slotConfig.y, enabled: true },
-        });
-      } else {
-        setParam('slotConfig', {
-          ...slotConfig,
-          x: { ...slotConfig.x, enabled: true },
-          y: { ...slotConfig.y, enabled: false },
-        });
-      }
+      setParam('slotConfig', {
+        ...slotConfig,
+        x: { ...slotConfig.x, enabled: direction !== 'vertical' },
+        y: { ...slotConfig.y, enabled: direction !== 'horizontal' },
+      });
     },
     [slotConfig, setParam]
   );
 
-  const updateActivePitch = useCallback(
-    (pitch: number) => {
+  const updateAxisPitch = useCallback(
+    (axis: SlotAxis, pitch: number) => {
       setParam('slotConfig', {
         ...slotConfig,
-        [activeAxis]: { ...slotConfig[activeAxis], pitch },
+        [axis]: { ...slotConfig[axis], pitch },
       });
     },
-    [slotConfig, setParam, activeAxis]
+    [slotConfig, setParam]
   );
 
   const clampPitch = useCallback(
@@ -115,20 +127,36 @@ export function SlotConfigurator() {
     dividerPieces.clearance
   ).slotDepth;
 
-  const dividerLength = useMemo(() => {
-    if (!slotConfig.x.enabled && !slotConfig.y.enabled) return null;
-    const dim = slotConfig.y.enabled ? innerD : innerW;
-    return calculateDividerLength(dim, effectiveSlotDepth, dividerPieces.clearance);
-  }, [
-    slotConfig.x.enabled,
-    slotConfig.y.enabled,
-    innerW,
-    innerD,
-    effectiveSlotDepth,
-    dividerPieces.clearance,
-  ]);
+  // Divider length per enabled axis: X-axis dividers span the width,
+  // Y-axis dividers span the depth.
+  const dividerLengths = useMemo(
+    () =>
+      enabledAxes.map((axis) => ({
+        axis,
+        length: calculateDividerLength(
+          axis === 'x' ? innerW : innerD,
+          effectiveSlotDepth,
+          dividerPieces.clearance
+        ),
+      })),
+    [enabledAxes, innerW, innerD, effectiveSlotDepth, dividerPieces.clearance]
+  );
 
-  const directions: SlotDirection[] = ['vertical', 'horizontal'];
+  const directions: SlotDirection[] = ['vertical', 'horizontal', 'both'];
+  const directionLabel = useCallback(
+    (direction: SlotDirection) =>
+      direction === 'vertical'
+        ? t('binDesigner.slotVertical')
+        : direction === 'horizontal'
+          ? t('binDesigner.slotHorizontal')
+          : t('binDesigner.slotBoth'),
+    [t]
+  );
+  const axisLabel = useCallback(
+    (axis: SlotAxis) =>
+      axis === 'y' ? t('binDesigner.slotVertical') : t('binDesigner.slotHorizontal'),
+    [t]
+  );
   const wallTooThin = params.wallThickness < MIN_WALL_FOR_SLOTS;
 
   return (
@@ -154,9 +182,7 @@ export function SlotConfigurator() {
                   : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
               }`}
             >
-              {direction === 'vertical'
-                ? t('binDesigner.slotVertical')
-                : t('binDesigner.slotHorizontal')}
+              {directionLabel(direction)}
             </Button>
           ))}
         </div>
@@ -167,27 +193,34 @@ export function SlotConfigurator() {
         {t('binDesigner.slotCount', { count: slotCount })}
       </div>
 
-      {/* Compartment width */}
-      <div>
-        <span className="mb-1 block text-xs text-content-tertiary">
-          {t('binDesigner.slotSpacing')}
-        </span>
-        <Stepper
-          value={activePitch}
-          onChange={(v) => updateActivePitch(clampPitch(v))}
-          onStep={(delta) =>
-            updateActivePitch(
-              clampPitch(activePitch + delta * DESIGNER_CONSTRAINTS.SLOT_PITCH_STEP)
-            )
-          }
-          min={DESIGNER_CONSTRAINTS.MIN_SLOT_PITCH}
-          max={DESIGNER_CONSTRAINTS.MAX_SLOT_PITCH}
-          step={DESIGNER_CONSTRAINTS.SLOT_PITCH_STEP}
-          size="md"
-          fullWidth
-          aria-label={t('binDesigner.slotSpacing')}
-        />
-      </div>
+      {/* Compartment width (one control per enabled direction) */}
+      {enabledAxes.map((axis) => {
+        const label =
+          enabledAxes.length > 1
+            ? `${t('binDesigner.slotSpacing')} — ${axisLabel(axis)}`
+            : t('binDesigner.slotSpacing');
+        return (
+          <div key={axis}>
+            <span className="mb-1 block text-xs text-content-tertiary">{label}</span>
+            <Stepper
+              value={slotConfig[axis].pitch}
+              onChange={(v) => updateAxisPitch(axis, clampPitch(v))}
+              onStep={(delta) =>
+                updateAxisPitch(
+                  axis,
+                  clampPitch(slotConfig[axis].pitch + delta * DESIGNER_CONSTRAINTS.SLOT_PITCH_STEP)
+                )
+              }
+              min={DESIGNER_CONSTRAINTS.MIN_SLOT_PITCH}
+              max={DESIGNER_CONSTRAINTS.MAX_SLOT_PITCH}
+              step={DESIGNER_CONSTRAINTS.SLOT_PITCH_STEP}
+              size="md"
+              fullWidth
+              aria-label={label}
+            />
+          </div>
+        );
+      })}
 
       {/* ── Divider piece settings ─────────────────────────────────── */}
 
@@ -316,11 +349,16 @@ export function SlotConfigurator() {
       <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
         <RulerIcon size="xs" />
         <span className="tabular-nums">
-          {dividerLength !== null
-            ? t('binDesigner.dividerDimensions', {
-                length: String(Math.round(dividerLength * 10) / 10),
-                height: String(Math.round(dividerHeight * 10) / 10),
-              })
+          {dividerLengths.length > 0
+            ? dividerLengths
+                .map(({ axis, length }) => {
+                  const dims = t('binDesigner.dividerDimensions', {
+                    length: String(Math.round(length * 10) / 10),
+                    height: String(Math.round(dividerHeight * 10) / 10),
+                  });
+                  return dividerLengths.length > 1 ? `${axisLabel(axis)}: ${dims}` : dims;
+                })
+                .join(' · ')
             : t('binDesigner.dividerHeightOnly', {
                 height: String(Math.round(dividerHeight * 10) / 10),
               })}

--- a/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
@@ -6,9 +6,9 @@
  * (not just during generation), so users can see divider placement
  * without waiting for mesh regeneration.
  *
- * Also renders a single reference divider piece offset from the bin,
- * showing the T-shaped cross-section (wall + edge tabs) so users can
- * visualize the actual divider geometry without exporting.
+ * Also renders a reference divider piece per enabled axis offset from
+ * the bin — including cross-lap notches when both directions are on —
+ * so users can visualize the actual divider geometry without exporting.
  *
  * Pattern matches GhostLabelTabs.tsx (batched geometry with matrix transforms).
  */

--- a/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
@@ -44,7 +44,8 @@ export function GhostDividerPieces() {
     width,
     depth,
     height,
-    gridUnitMm, gridUnitMmY,
+    gridUnitMm,
+    gridUnitMmY,
     heightUnitMm,
     wallThickness,
     style,
@@ -212,51 +213,147 @@ export function GhostDividerPieces() {
 
   const ghostVisible = shouldShow && geometry !== null && geometry !== hiddenGeometry;
 
-  // ── Reference divider: single box offset from the bin ──────────────────
+  // ── Reference dividers: one piece per enabled axis, offset from the bin ──
   // Tab thickness simplifies to exactly `thickness` (slotWidth - 2*clearance
-  // = thickness + 2*clearance - 2*clearance), so the divider is a plain
-  // rectangular wall — one BoxGeometry suffices.
-  const referenceGeometry = useMemo(() => {
-    if (!shouldShow) return null;
-
-    const { thickness, clearance } = dividerPieces;
-    const { slotDepth } = getEffectiveSlotDimensions(wallThickness, thickness, clearance);
-    const dividerHeight = calculateDividerHeight(dividerPieces, wallHeight, hasLip);
-
-    const isXFirst = slotConfig.x.enabled;
-    const divLength = isXFirst
-      ? calculateDividerLength(innerW, slotDepth, clearance)
-      : calculateDividerLength(innerD, slotDepth, clearance);
-
-    if (divLength <= 0 || dividerHeight <= 0) return null;
-
-    return new THREE.BoxGeometry(divLength, thickness, dividerHeight);
-  }, [shouldShow, slotConfig, dividerPieces, innerW, innerD, wallThickness, wallHeight, hasLip]);
-
-  // Position: offset from the bin, raised so bottom sits at bin floor level
+  // = thickness + 2*clearance - 2*clearance), so a single-direction divider
+  // is a plain rectangular wall. With both directions enabled, each piece
+  // carries cross-lap notches (X pieces notched from the top, Y from the
+  // bottom) — modeled here as merged box segments to match the export.
   const dividerHeight = useMemo(() => {
     if (!shouldShow) return 0;
     return calculateDividerHeight(dividerPieces, wallHeight, hasLip);
   }, [shouldShow, dividerPieces, wallHeight, hasLip]);
 
-  const referencePosition = useMemo<[number, number, number]>(() => {
-    if (!shouldShow) return [0, 0, 0];
+  const referencePieces = useMemo(() => {
+    if (!shouldShow) return [];
 
-    const isXFirst = slotConfig.x.enabled;
-    if (isXFirst) {
-      // X-axis divider spans X direction → place offset in +Y (behind bin)
-      return [0, outerD / 2 + REFERENCE_GAP, floorZ + dividerHeight / 2];
+    const { thickness, clearance } = dividerPieces;
+    const { slotWidth, slotDepth } = getEffectiveSlotDimensions(
+      wallThickness,
+      thickness,
+      clearance
+    );
+    if (dividerHeight <= 0) return [];
+
+    const bothAxes = slotConfig.x.enabled && slotConfig.y.enabled;
+    const notchDepth = dividerHeight / 2 + clearance;
+
+    // Build a reference piece as merged boxes: full-height wall when there
+    // are no notches, otherwise an intact half plus segments between notches.
+    // Local space matches the rendered mesh: X = length, Y = thickness,
+    // Z = installed height (centered).
+    const buildPieceGeometry = (
+      length: number,
+      notchPositions: number[],
+      notchFromTop: boolean
+    ): THREE.BufferGeometry => {
+      if (notchPositions.length === 0) {
+        return new THREE.BoxGeometry(length, thickness, dividerHeight);
+      }
+
+      const intactH = dividerHeight - notchDepth;
+      const segments: { x: number; z: number; w: number; h: number }[] = [
+        // Intact strip: bottom for top-notched pieces, top for bottom-notched
+        {
+          x: 0,
+          z: notchFromTop ? -notchDepth / 2 : notchDepth / 2,
+          w: length,
+          h: intactH,
+        },
+      ];
+
+      const sorted = [...notchPositions].sort((a, b) => a - b);
+      const edges = [
+        -length / 2,
+        ...sorted.flatMap((p) => [p - slotWidth / 2, p + slotWidth / 2]),
+        length / 2,
+      ];
+      const segZ = notchFromTop
+        ? (dividerHeight - notchDepth) / 2
+        : -(dividerHeight - notchDepth) / 2;
+      for (let i = 0; i < edges.length; i += 2) {
+        const w = edges[i + 1] - edges[i];
+        if (w <= 0) continue;
+        segments.push({ x: (edges[i] + edges[i + 1]) / 2, z: segZ, w, h: notchDepth });
+      }
+
+      const positions: number[] = [];
+      const indices: number[] = [];
+      for (const seg of segments) {
+        const boxGeo = new THREE.BoxGeometry(seg.w, thickness, seg.h);
+        const pos = boxGeo.getAttribute('position');
+        const index = boxGeo.getIndex();
+        if (!index) {
+          boxGeo.dispose();
+          continue;
+        }
+        const offset = positions.length / 3;
+        for (let v = 0; v < pos.count; v++) {
+          positions.push(pos.getX(v) + seg.x, pos.getY(v), pos.getZ(v) + seg.z);
+        }
+        for (let j = 0; j < index.count; j++) {
+          indices.push(index.array[j] + offset);
+        }
+        boxGeo.dispose();
+      }
+      const merged = new THREE.BufferGeometry();
+      merged.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+      merged.setIndex(indices);
+      merged.computeVertexNormals();
+      return merged;
+    };
+
+    const pieces: {
+      geometry: THREE.BufferGeometry;
+      position: [number, number, number];
+      rotation: [number, number, number];
+    }[] = [];
+
+    if (slotConfig.x.enabled) {
+      const length = calculateDividerLength(innerW, slotDepth, clearance);
+      const notches = bothAxes
+        ? calculateSlotPositions(innerW, slotConfig.y.pitch, lipOverhang)
+        : [];
+      if (length > 0) {
+        // X-axis divider spans X → place offset in +Y (behind bin)
+        pieces.push({
+          geometry: buildPieceGeometry(length, notches, true),
+          position: [0, outerD / 2 + REFERENCE_GAP, floorZ + dividerHeight / 2],
+          rotation: [0, 0, 0],
+        });
+      }
     }
-    // Y-axis divider spans Y direction → place offset in +X (right of bin),
-    // rotated 90° around Z so its length runs along Y
-    return [outerW / 2 + REFERENCE_GAP, 0, floorZ + dividerHeight / 2];
-  }, [shouldShow, slotConfig, outerW, outerD, floorZ, dividerHeight]);
 
-  // Rotation: Y-axis dividers need 90° Z rotation so they span the Y direction
-  const referenceRotation = useMemo<[number, number, number]>(() => {
-    if (!shouldShow) return [0, 0, 0];
-    return slotConfig.x.enabled ? [0, 0, 0] : [0, 0, Math.PI / 2];
-  }, [shouldShow, slotConfig]);
+    if (slotConfig.y.enabled) {
+      const length = calculateDividerLength(innerD, slotDepth, clearance);
+      const notches = bothAxes
+        ? calculateSlotPositions(innerD, slotConfig.x.pitch, lipOverhang)
+        : [];
+      if (length > 0) {
+        // Y-axis divider spans Y → place offset in +X (right of bin),
+        // rotated 90° around Z so its length runs along Y
+        pieces.push({
+          geometry: buildPieceGeometry(length, notches, false),
+          position: [outerW / 2 + REFERENCE_GAP, 0, floorZ + dividerHeight / 2],
+          rotation: [0, 0, Math.PI / 2],
+        });
+      }
+    }
+
+    return pieces;
+  }, [
+    shouldShow,
+    slotConfig,
+    dividerPieces,
+    innerW,
+    innerD,
+    outerW,
+    outerD,
+    wallThickness,
+    dividerHeight,
+    floorZ,
+    lipOverhang,
+  ]);
 
   const material = useMemo(() => {
     if (!shouldShow) return null;
@@ -288,14 +385,14 @@ export function GhostDividerPieces() {
     return () => {
       geometry?.dispose();
       material?.dispose();
-      referenceGeometry?.dispose();
+      for (const piece of referencePieces) piece.geometry.dispose();
       referenceMaterial?.dispose();
     };
-  }, [geometry, material, referenceGeometry, referenceMaterial]);
+  }, [geometry, material, referencePieces, referenceMaterial]);
 
   useEffect(() => {
-    if (geometry || referenceGeometry) invalidate();
-  }, [geometry, material, referenceGeometry, referenceMaterial, ghostVisible, invalidate]);
+    if (geometry || referencePieces.length > 0) invalidate();
+  }, [geometry, material, referencePieces, referenceMaterial, ghostVisible, invalidate]);
 
   if (!shouldShow) return null;
 
@@ -304,15 +401,17 @@ export function GhostDividerPieces() {
       {ghostVisible && material && (
         <mesh geometry={geometry} material={material} position={[0, 0, 0]} renderOrder={1} />
       )}
-      {referenceGeometry && referenceMaterial && (
-        <mesh
-          geometry={referenceGeometry}
-          material={referenceMaterial}
-          position={referencePosition}
-          rotation={referenceRotation}
-          renderOrder={1}
-        />
-      )}
+      {referenceMaterial &&
+        referencePieces.map((piece, i) => (
+          <mesh
+            key={i}
+            geometry={piece.geometry}
+            material={referenceMaterial}
+            position={piece.position}
+            rotation={piece.rotation}
+            renderOrder={1}
+          />
+        ))}
     </>
   );
 }

--- a/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
+++ b/src/features/bin-designer/components/preview/GhostDividerPieces/GhostDividerPieces.tsx
@@ -304,6 +304,7 @@ export function GhostDividerPieces() {
     };
 
     const pieces: {
+      axis: 'x' | 'y';
       geometry: THREE.BufferGeometry;
       position: [number, number, number];
       rotation: [number, number, number];
@@ -317,6 +318,7 @@ export function GhostDividerPieces() {
       if (length > 0) {
         // X-axis divider spans X → place offset in +Y (behind bin)
         pieces.push({
+          axis: 'x',
           geometry: buildPieceGeometry(length, notches, true),
           position: [0, outerD / 2 + REFERENCE_GAP, floorZ + dividerHeight / 2],
           rotation: [0, 0, 0],
@@ -333,6 +335,7 @@ export function GhostDividerPieces() {
         // Y-axis divider spans Y → place offset in +X (right of bin),
         // rotated 90° around Z so its length runs along Y
         pieces.push({
+          axis: 'y',
           geometry: buildPieceGeometry(length, notches, false),
           position: [outerW / 2 + REFERENCE_GAP, 0, floorZ + dividerHeight / 2],
           rotation: [0, 0, Math.PI / 2],
@@ -402,9 +405,9 @@ export function GhostDividerPieces() {
         <mesh geometry={geometry} material={material} position={[0, 0, 0]} renderOrder={1} />
       )}
       {referenceMaterial &&
-        referencePieces.map((piece, i) => (
+        referencePieces.map((piece) => (
           <mesh
-            key={i}
+            key={piece.axis}
             geometry={piece.geometry}
             material={referenceMaterial}
             position={piece.position}

--- a/src/features/generation/worker/generators/__kernel-tests__/dividerCrossLap.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/dividerCrossLap.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+/**
+ * Real-kernel verification of cross-lap divider notching: when both slot
+ * axes are enabled, each divider piece must lose exactly the notch volume
+ * to the boolean cut, and the mesh must stay finite and manifold-clean.
+ *
+ * Run:
+ *   pnpm exec vitest run --config vitest.profile.config.ts dividerCrossLap --reporter=verbose
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getKernelName } from './wasmInit';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import {
+  calculateDividerLength,
+  calculateSlotPositions,
+  getEffectiveSlotDimensions,
+} from '@/shared/utils/slotMath';
+
+const INNER_W = 80;
+const INNER_D = 60;
+const WALL_HEIGHT = 30;
+
+function makeParams(overrides: Partial<BinParams> = {}): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    style: 'slotted',
+    slotConfig: {
+      ...DEFAULT_BIN_PARAMS.slotConfig,
+      x: { enabled: true, pitch: 20 },
+      y: { enabled: true, pitch: 20 },
+    },
+    dividerPieces: { height: 'auto', thickness: 1.6, clearance: 0.25 },
+    ...overrides,
+  };
+}
+
+/** Signed volume of a triangle mesh via the divergence theorem. */
+function meshVolume(vertices: ArrayLike<number>, triangles: ArrayLike<number>): number {
+  let vol = 0;
+  for (let i = 0; i < triangles.length; i += 3) {
+    const a = triangles[i] * 3;
+    const b = triangles[i + 1] * 3;
+    const c = triangles[i + 2] * 3;
+    vol +=
+      (vertices[a] * (vertices[b + 1] * vertices[c + 2] - vertices[b + 2] * vertices[c + 1]) -
+        vertices[a + 1] * (vertices[b] * vertices[c + 2] - vertices[b + 2] * vertices[c]) +
+        vertices[a + 2] * (vertices[b] * vertices[c + 1] - vertices[b + 1] * vertices[c])) /
+      6;
+  }
+  return Math.abs(vol);
+}
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+describe(`cross-lap divider pieces on ${getKernelName()}`, () => {
+  it('cuts exactly the notch volume from each piece and stays finite', async () => {
+    const { mesh } = await import('brepjs');
+    const { buildUniqueDividerPieces } = await import('../dividerBuilder');
+
+    const params = makeParams();
+    const { thickness, clearance } = params.dividerPieces;
+    const { slotWidth, slotDepth } = getEffectiveSlotDimensions(
+      params.wallThickness,
+      thickness,
+      clearance
+    );
+    const dividerHeight = WALL_HEIGHT; // height 'auto', no lip
+    const notchDepth = dividerHeight / 2 + clearance;
+
+    const pieces = buildUniqueDividerPieces(params, INNER_W, INNER_D, WALL_HEIGHT, false);
+    expect(pieces).toHaveLength(2);
+
+    const expected = [
+      // X piece spans innerW, notched at Y-axis positions
+      {
+        length: calculateDividerLength(INNER_W, slotDepth, clearance),
+        notches: calculateSlotPositions(INNER_W, params.slotConfig.y.pitch, 0).length,
+      },
+      // Y piece spans innerD, notched at X-axis positions
+      {
+        length: calculateDividerLength(INNER_D, slotDepth, clearance),
+        notches: calculateSlotPositions(INNER_D, params.slotConfig.x.pitch, 0).length,
+      },
+    ];
+    expect(expected[0].notches).toBeGreaterThan(0);
+    expect(expected[1].notches).toBeGreaterThan(0);
+
+    try {
+      for (let i = 0; i < pieces.length; i++) {
+        const m = mesh(pieces[i], { tolerance: 0.01, angularTolerance: 5, cache: false });
+        for (const v of m.vertices) expect(Number.isFinite(v)).toBe(true);
+
+        const vol = meshVolume(m.vertices, m.triangles);
+        const solid = expected[i].length * dividerHeight * thickness;
+        const notchVol = expected[i].notches * slotWidth * notchDepth * thickness;
+        expect(vol).toBeGreaterThan(0);
+        expect(vol).toBeCloseTo(solid - notchVol, 0);
+      }
+    } finally {
+      for (const p of pieces) p.delete();
+    }
+  });
+
+  it('leaves single-axis pieces uncut', async () => {
+    const { mesh } = await import('brepjs');
+    const { buildUniqueDividerPieces } = await import('../dividerBuilder');
+
+    const params = makeParams({
+      slotConfig: {
+        ...DEFAULT_BIN_PARAMS.slotConfig,
+        x: { enabled: true, pitch: 20 },
+        y: { enabled: false, pitch: 20 },
+      },
+    });
+    const { thickness, clearance } = params.dividerPieces;
+    const { slotDepth } = getEffectiveSlotDimensions(params.wallThickness, thickness, clearance);
+
+    const pieces = buildUniqueDividerPieces(params, INNER_W, INNER_D, WALL_HEIGHT, false);
+    expect(pieces).toHaveLength(1);
+
+    try {
+      const m = mesh(pieces[0], { tolerance: 0.01, angularTolerance: 5, cache: false });
+      const vol = meshVolume(m.vertices, m.triangles);
+      const solid = calculateDividerLength(INNER_W, slotDepth, clearance) * WALL_HEIGHT * thickness;
+      expect(vol).toBeCloseTo(solid, 0);
+    } finally {
+      for (const p of pieces) p.delete();
+    }
+  });
+});

--- a/src/features/generation/worker/generators/dividerBuilder.test.ts
+++ b/src/features/generation/worker/generators/dividerBuilder.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { BinParams } from '@/shared/types/bin';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import { buildDividerPiece, buildUniqueDividerPieces } from './dividerBuilder';
+import { box, cut, fuseAll } from 'brepjs';
 
 // Mock brepjs — dividerBuilder imports it at module level.
 // Vitest hoists vi.mock calls above imports automatically.
@@ -11,6 +12,9 @@ vi.mock('brepjs', () => {
   return {
     box: vi.fn(() => makeShape()),
     translate: vi.fn(() => makeShape()),
+    cut: vi.fn(() => makeShape()),
+    fuseAll: vi.fn(() => makeShape()),
+    unwrap: vi.fn((v: unknown) => v),
   };
 });
 
@@ -21,6 +25,10 @@ function makeSlottedParams(overrides: Partial<BinParams> = {}): BinParams {
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('buildDividerPiece', () => {
   it('creates a divider piece with correct dimensions', () => {
@@ -38,6 +46,7 @@ describe('buildUniqueDividerPieces', () => {
   it('returns one piece when only X-axis is enabled', () => {
     const params = makeSlottedParams({
       slotConfig: {
+        ...DEFAULT_BIN_PARAMS.slotConfig,
         x: { enabled: true, pitch: 40 },
         y: { enabled: false, pitch: 40 },
       },
@@ -49,11 +58,83 @@ describe('buildUniqueDividerPieces', () => {
   it('returns two pieces when both axes are enabled', () => {
     const params = makeSlottedParams({
       slotConfig: {
+        ...DEFAULT_BIN_PARAMS.slotConfig,
         x: { enabled: true, pitch: 40 },
         y: { enabled: true, pitch: 40 },
       },
     });
     const pieces = buildUniqueDividerPieces(params, 80, 80, 30, false);
     expect(pieces).toHaveLength(2);
+  });
+
+  it('cuts no cross-lap notches when a single axis is enabled', () => {
+    const params = makeSlottedParams({
+      slotConfig: {
+        ...DEFAULT_BIN_PARAMS.slotConfig,
+        x: { enabled: true, pitch: 40 },
+        y: { enabled: false, pitch: 40 },
+      },
+    });
+    buildUniqueDividerPieces(params, 80, 80, 30, false);
+    expect(cut).not.toHaveBeenCalled();
+  });
+
+  it('cuts cross-lap notches into both pieces when both axes are enabled', () => {
+    const params = makeSlottedParams({
+      slotConfig: {
+        ...DEFAULT_BIN_PARAMS.slotConfig,
+        x: { enabled: true, pitch: 40 },
+        y: { enabled: true, pitch: 40 },
+      },
+    });
+    buildUniqueDividerPieces(params, 80, 80, 30, false);
+    // 80mm interior at 40mm pitch → 2 compartments → 1 crossing per piece
+    expect(cut).toHaveBeenCalledTimes(2);
+    // Single crossing per piece → cutter used directly, no fuse needed
+    expect(fuseAll).not.toHaveBeenCalled();
+  });
+
+  it('notches X pieces from the top and Y pieces from the bottom', () => {
+    const params = makeSlottedParams({
+      slotConfig: {
+        ...DEFAULT_BIN_PARAMS.slotConfig,
+        x: { enabled: true, pitch: 40 },
+        y: { enabled: true, pitch: 40 },
+      },
+      dividerPieces: { height: 'auto', thickness: 1.6, clearance: 0.25 },
+    });
+    buildUniqueDividerPieces(params, 80, 80, 30, false);
+
+    // box calls: [0] X piece, [1] X notch cutter, [2] Y piece, [3] Y notch cutter
+    const calls = vi.mocked(box).mock.calls;
+    expect(calls).toHaveLength(4);
+
+    const xCutterAt = (calls[1][3] as { at: [number, number, number] }).at;
+    const yCutterAt = (calls[3][3] as { at: [number, number, number] }).at;
+    // dividerHeight = wallHeight (30, no lip); notch centers mirror across mid-height
+    expect(xCutterAt[1]).toBeGreaterThan(0);
+    expect(yCutterAt[1]).toBeLessThan(0);
+    expect(xCutterAt[1]).toBeCloseTo(-yCutterAt[1], 5);
+
+    // Notch opening matches the wall slot width (thickness + 2×clearance)
+    expect(calls[1][0]).toBeCloseTo(1.6 + 2 * 0.25, 5);
+    // Notch reaches just past half height: depth = h/2 + clearance (+overlap)
+    const notchCutterDepth = calls[1][1];
+    expect(notchCutterDepth).toBeGreaterThan(15);
+    expect(notchCutterDepth).toBeLessThan(15.5);
+  });
+
+  it('fuses notch cutters when a piece has multiple crossings', () => {
+    const params = makeSlottedParams({
+      slotConfig: {
+        ...DEFAULT_BIN_PARAMS.slotConfig,
+        x: { enabled: true, pitch: 40 },
+        y: { enabled: true, pitch: 20 },
+      },
+    });
+    // 80mm at 20mm pitch → 4 compartments → 3 crossings on the X piece
+    buildUniqueDividerPieces(params, 80, 80, 30, false);
+    expect(fuseAll).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fuseAll).mock.calls[0][0]).toHaveLength(3);
   });
 });

--- a/src/features/generation/worker/generators/dividerBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBuilder.ts
@@ -3,14 +3,22 @@
  *
  * Generates removable divider pieces — flat rectangular walls whose
  * length includes tab engagement depth on each end so they slot into
- * the wall cuts. Single extrusion per piece (no boolean fuse needed).
+ * the wall cuts. When both axes are enabled, cross-lap notches are cut
+ * at every crossing position so X and Y dividers interlock egg-crate
+ * style: X dividers are notched from the top, Y dividers from the
+ * bottom, each to just past half height.
  */
 
-import { box, translate } from 'brepjs';
-import type { Shape3D } from 'brepjs';
+import { box, cut, fuseAll, translate, unwrap } from 'brepjs';
+import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
-import { calculateDividerHeight, calculateDividerLength } from '@/shared/utils/slotMath';
+import {
+  calculateDividerHeight,
+  calculateDividerLength,
+  calculateSlotPositions,
+} from '@/shared/utils/slotMath';
 import { getEffectiveSlotDimensions } from './slotBuilder';
+import { COPLANAR_OVERLAP, LIP_TAPER_WIDTH } from './generatorConstants';
 
 // Re-export shared math so existing imports from generation internals still work
 export { calculateDividerHeight, calculateDividerLength };
@@ -32,6 +40,56 @@ export function buildDividerPiece(length: number, thickness: number, height: num
 }
 
 /**
+ * Cut cross-lap notches into a flat divider piece.
+ *
+ * In flat orientation the piece is centered at the origin: length along X,
+ * installed height along Y (+Y = installed top), thickness along Z. Cross
+ * positions are relative to the interior center, which coincides with the
+ * piece center, so they map directly to X coordinates.
+ *
+ * @param piece Flat divider piece (consumed — disposed after the cut)
+ * @param positions Crossing centers along the length, relative to center
+ * @param notchWidth Notch opening along the length (matches wall slot width)
+ * @param notchDepth How far the notch reaches from the edge toward mid-height
+ * @param height Divider height in mm
+ * @param thickness Divider thickness in mm
+ * @param fromTop true → notch from the installed top edge, false → bottom
+ */
+function cutCrossLapNotches(
+  piece: Shape3D,
+  positions: number[],
+  notchWidth: number,
+  notchDepth: number,
+  height: number,
+  thickness: number,
+  fromTop: boolean
+): Shape3D {
+  if (positions.length === 0) return piece;
+
+  // Extend past the edge (Y) and through the thickness (Z) so the cutter
+  // never leaves coplanar faces with the piece.
+  const cutterDepth = notchDepth + COPLANAR_OVERLAP;
+  const cutterHeight = thickness + 2 * COPLANAR_OVERLAP;
+  const edgeY = fromTop
+    ? height / 2 - notchDepth / 2 + COPLANAR_OVERLAP / 2
+    : -(height / 2 - notchDepth / 2 + COPLANAR_OVERLAP / 2);
+
+  const cutters: Shape3D[] = positions.map((x) =>
+    box(notchWidth, cutterDepth, cutterHeight, { at: [x, edgeY, thickness / 2] })
+  );
+
+  const compound = cutters.length === 1 ? cutters[0] : unwrap(fuseAll(cutters as ValidSolid[]));
+  const notched = unwrap(cut(piece, compound));
+
+  piece.delete();
+  compound.delete();
+  if (cutters.length > 1) {
+    for (const c of cutters) c.delete();
+  }
+  return notched;
+}
+
+/**
  * Build one divider piece per unique shape for a slotted bin.
  *
  * X-axis and Y-axis dividers may differ in length (they span different
@@ -50,23 +108,57 @@ export function buildUniqueDividerPieces(
   if (params.style !== 'slotted') return [];
 
   const { slotConfig, dividerPieces } = params;
-  const { slotDepth } = getEffectiveSlotDimensions(params);
+  const { slotWidth, slotDepth } = getEffectiveSlotDimensions(params);
   const { thickness, clearance } = dividerPieces;
 
   const dividerHeight = calculateDividerHeight(dividerPieces, wallHeight, hasLip);
 
+  const bothAxes = slotConfig.x.enabled && slotConfig.y.enabled;
+  // Cross positions must match the wall slot positions, which the pipeline
+  // computes with the lip overhang as edge inset (see buildSlotCutsInScope).
+  const edgeInset = hasLip ? Math.max(0, LIP_TAPER_WIDTH - params.wallThickness) : 0;
+  // Half height per side leaves the crossing flush; add the fit clearance so
+  // over-extrusion can't hold the upper divider proud of the rim.
+  const notchDepth = dividerHeight / 2 + clearance;
+
   const pieces: Shape3D[] = [];
 
-  // One X-axis divider (spans width)
+  // One X-axis divider (spans width) — notched from the top at each
+  // Y-divider position so bottom-notched Y dividers drop over it
   if (slotConfig.x.enabled) {
     const length = calculateDividerLength(innerW, slotDepth, clearance);
-    pieces.push(buildDividerPiece(length, thickness, dividerHeight));
+    let piece = buildDividerPiece(length, thickness, dividerHeight);
+    if (bothAxes) {
+      const crossings = calculateSlotPositions(innerW, slotConfig.y.pitch, edgeInset);
+      piece = cutCrossLapNotches(
+        piece,
+        crossings,
+        slotWidth,
+        notchDepth,
+        dividerHeight,
+        thickness,
+        true
+      );
+    }
+    pieces.push(piece);
   }
 
   // One Y-axis divider (spans depth) — offset in Y if both axes enabled
   if (slotConfig.y.enabled) {
     const length = calculateDividerLength(innerD, slotDepth, clearance);
-    const piece = buildDividerPiece(length, thickness, dividerHeight);
+    let piece = buildDividerPiece(length, thickness, dividerHeight);
+    if (bothAxes) {
+      const crossings = calculateSlotPositions(innerD, slotConfig.x.pitch, edgeInset);
+      piece = cutCrossLapNotches(
+        piece,
+        crossings,
+        slotWidth,
+        notchDepth,
+        dividerHeight,
+        thickness,
+        false
+      );
+    }
     const yOffset = pieces.length > 0 ? dividerHeight + 5 : 0;
     // translate() creates a new shape — dispose the pre-translation piece
     // to prevent leaking its intermediate handle across regenerations.

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} Trennwände",
   "binDesigner.slotDirection": "Richtung",
   "binDesigner.slotHorizontal": "Horizontal",
+  "binDesigner.slotBoth": "Beide",
   "binDesigner.slotSpacing": "Fachbreite",
   "binDesigner.slotVertical": "Vertikal",
   "binDesigner.slotWallTooThin": "Wandstärke muss mindestens {min}mm für Schlitze sein",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1564,6 +1564,7 @@ const en: Record<string, string> = {
   'binDesigner.slotDirection': 'Direction',
   'binDesigner.slotVertical': 'Vertical',
   'binDesigner.slotHorizontal': 'Horizontal',
+  'binDesigner.slotBoth': 'Both',
   'binDesigner.slotSpacing': 'Compartment width',
   'binDesigner.slotCount': '{count} dividers',
   'binDesigner.slotWallTooThin': 'Wall thickness must be at least {min}mm for slots',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} divisores",
   "binDesigner.slotDirection": "Dirección",
   "binDesigner.slotHorizontal": "Horizontal",
+  "binDesigner.slotBoth": "Ambas",
   "binDesigner.slotSpacing": "Ancho de compartimento",
   "binDesigner.slotVertical": "Vertical",
   "binDesigner.slotWallTooThin": "El grosor de la pared debe ser al menos {min}mm para las ranuras",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} séparateurs",
   "binDesigner.slotDirection": "Direction",
   "binDesigner.slotHorizontal": "Horizontal",
+  "binDesigner.slotBoth": "Les deux",
   "binDesigner.slotSpacing": "Largeur de compartiment",
   "binDesigner.slotVertical": "Vertical",
   "binDesigner.slotWallTooThin": "L'épaisseur de paroi doit être d'au moins {min}mm pour les fentes",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} divisori",
   "binDesigner.slotDirection": "Direzione",
   "binDesigner.slotHorizontal": "Orizzontale",
+  "binDesigner.slotBoth": "Entrambe",
   "binDesigner.slotSpacing": "Larghezza scomparto",
   "binDesigner.slotVertical": "Verticale",
   "binDesigner.slotWallTooThin": "Lo spessore delle pareti deve essere di almeno {min}mm per le fessure",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count}個の仕切り板",
   "binDesigner.slotDirection": "方向",
   "binDesigner.slotHorizontal": "水平",
+  "binDesigner.slotBoth": "両方",
   "binDesigner.slotSpacing": "区画の幅",
   "binDesigner.slotVertical": "垂直",
   "binDesigner.slotWallTooThin": "スロット使用時は壁厚を{min}mm以上にしてください",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} skillevegger",
   "binDesigner.slotDirection": "Retning",
   "binDesigner.slotHorizontal": "Horisontal",
+  "binDesigner.slotBoth": "Begge",
   "binDesigner.slotSpacing": "Rombredde",
   "binDesigner.slotVertical": "Vertikal",
   "binDesigner.slotWallTooThin": "Veggtykkelse må være minst {min}mm for spor",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} scheidingswanden",
   "binDesigner.slotDirection": "Richting",
   "binDesigner.slotHorizontal": "Horizontaal",
+  "binDesigner.slotBoth": "Beide",
   "binDesigner.slotSpacing": "Vakbreedte",
   "binDesigner.slotVertical": "Verticaal",
   "binDesigner.slotWallTooThin": "Wanddikte moet minstens {min}mm voor slots zijn",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} divisórias",
   "binDesigner.slotDirection": "Direção",
   "binDesigner.slotHorizontal": "Horizontal",
+  "binDesigner.slotBoth": "Ambas",
   "binDesigner.slotSpacing": "Largura do compartimento",
   "binDesigner.slotVertical": "Vertical",
   "binDesigner.slotWallTooThin": "A espessura da parede deve ser de pelo menos {min}mm para slots",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} avdelare",
   "binDesigner.slotDirection": "Riktning",
   "binDesigner.slotHorizontal": "Horisontell",
+  "binDesigner.slotBoth": "Båda",
   "binDesigner.slotSpacing": "Fackbredd",
   "binDesigner.slotVertical": "Vertikal",
   "binDesigner.slotWallTooThin": "Väggtjockleken måste vara minst {min}mm för slitsar",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -853,6 +853,7 @@
   "binDesigner.slotCount": "{count} розділювачів",
   "binDesigner.slotDirection": "Напрямок",
   "binDesigner.slotHorizontal": "Горизонтальний",
+  "binDesigner.slotBoth": "Обидва",
   "binDesigner.slotSpacing": "Ширина відсіку",
   "binDesigner.slotVertical": "Вертикальний",
   "binDesigner.slotWallTooThin": "Товщина стінки має бути не менше {min}мм для слотів",


### PR DESCRIPTION
Closes #2631

Slotted bins could already cut wall slots on both axes, but the designer forced a single direction and the divider pieces were plain rectangles that would collide at crossings. This adds true bidirectional removable dividers:

- **Both direction mode** in the slot configurator, with a spacing control per direction and per-piece dimension readouts
- **Egg-crate cross-lap notches** cut into the divider pieces when both directions are enabled — X-spanning pieces notched from the top, Y-spanning pieces from the bottom, at the cross-axis slot positions. Notch opening matches the wall slot width (thickness + 2× fit tolerance) and each notch reaches just past half height so the crossing can't sit proud; either family can still slide in from the top
- **3D preview** shows a reference piece per enabled axis, with the notches modeled

Verification:
- Real-kernel test (`dividerCrossLap.test.ts`): OCCT boolean cut removes exactly the analytic notch volume from each piece; single-axis pieces stay uncut; meshes finite
- Full bin generator scenario suite passes (906 tests) — wall slot geometry unchanged
- i18n key added across all 12 locales, `check:i18n` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Both direction mode to the slot configurator and generates interlocking divider pieces on both axes. Cross-lap notches let X and Y dividers slide together cleanly, with per-axis previews and dimension readouts; preview meshes now use stable axis keys.

- **New Features**
  - Both mode toggle with per-axis spacing controls and per-axis divider dimensions.
  - Divider pieces get egg-crate notches at cross-axis slot positions (X notched from top, Y from bottom); notch width = slot width, depth just past half height.
  - 3D preview shows a notched reference piece per enabled axis.
  - Tests: kernel test checks exact notch volume removal and single-axis uncut pieces; unit tests cover notch orientation, multi-notch `fuseAll`, and single-axis no-cut; added `binDesigner.slotBoth` i18n key in all locales.

- **Bug Fixes**
  - Stable axis-based keys for reference divider meshes to prevent flicker when toggling directions.

<sup>Written for commit 0d19c17967f61977a5df24b55600766f8097730c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

