### PR TITLE
ci(smoke): skip preview smoke on fork PRs (no secret access)

### DIFF
--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -37,22 +37,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      # Fork PRs and Dependabot runs execute without access to repo Actions
+      # secrets, so VERCEL_AUTOMATION_BYPASS_SECRET is empty and the protected
+      # preview redirects to SSO — the smoke spec can never reach it. Detect
+      # both and short-circuit cleanly; these PRs still get coverage from Build,
+      # Unit Tests, Quality, and CodeQL, plus the post-promote production smoke.
+      NO_SECRETS: ${{ github.actor == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Dependabot PR runs do not have access to repo Actions secrets, including
-      # VERCEL_AUTOMATION_BYPASS_SECRET — so the preview will return 401 and the
-      # smoke spec cannot run. Short-circuit cleanly: dep bumps still get
-      # coverage from Build, Unit Tests, Quality, and CodeQL.
-      - name: Skip — Dependabot PR
-        if: github.actor == 'dependabot[bot]'
+      - name: Skip — no secret access (fork or Dependabot PR)
+        if: env.NO_SECRETS == 'true'
         run: |
-          echo "::warning::Dependabot PR — VERCEL_AUTOMATION_BYPASS_SECRET unavailable; preview smoke is N/A."
+          echo "::warning::Fork or Dependabot PR — VERCEL_AUTOMATION_BYPASS_SECRET unavailable; preview smoke is N/A."
           echo "Coverage for this PR comes from CI Build, Unit Tests, Quality, and CodeQL."
 
       - name: Resolve Vercel preview URL
         id: preview
-        if: github.actor != 'dependabot[bot]'
+        if: env.NO_SECRETS == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## What

Fork PRs (e.g. #2652, #2653, #2654 from external contributors) fail the **PWA Smoke Test** for a structural reason, not a code defect.

## Why

The smoke job triggers on `pull_request` and reads `VERCEL_AUTOMATION_BYPASS_SECRET` to get past Vercel deployment protection. GitHub withholds repo secrets from fork-PR runs, so that secret is empty, the protected preview 302-redirects to Vercel SSO, and the spec's `fetch('/version.json')` lands on an HTML login page — the `SyntaxError: Unexpected token '<'` seen on every fork PR.

This is the **same limitation already conceded for Dependabot**, which the workflow skips cleanly. External human contributors just hit the same wall.

## Change

Generalize the Dependabot-only skip into a `NO_SECRETS` guard that also matches fork PRs (`head.repo.full_name != github.repository`). Those PRs now short-circuit with a warning instead of a spurious red check.

Coverage for fork PRs still comes from **Build, Unit Tests, Quality, CodeQL**, plus the **post-promote production smoke** (`smoke-postpromote.yml`) after merge.

## Note

`head.repo.full_name` is used only inside an `env:` boolean comparison feeding `if:` conditions — never interpolated into a `run:` shell command, so there's no workflow-injection surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the preview PWA smoke test on fork PRs and `dependabot[bot]` runs where secrets are unavailable, preventing false failures on protected Vercel previews.

- **Bug Fixes**
  - Add `NO_SECRETS` guard in `smoke-preview.yml` to detect forks (`head.repo.full_name != github.repository`) or `dependabot[bot]`.
  - Short-circuit the job with a warning when secrets are missing; run preview steps only when `NO_SECRETS == 'false'`.
  - CI coverage remains via Build, Unit Tests, Quality, CodeQL, and post-promote production smoke.

<sup>Written for commit 09a4c5b52d10b4939a081e39f42de06beba61606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

