### PR TITLE
feat(baseplate): capture preview thumbnails for the library manager

### DIFF
--- a/e2e/baseplate-thumbnail.spec.ts
+++ b/e2e/baseplate-thumbnail.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, clearAllStorage, resetViewport, getActiveDialog } from './fixtures';
+
+/**
+ * Baseplate library thumbnails.
+ *
+ * The active baseplate design captures a 3D preview thumbnail once its mesh
+ * settles (backfilled on open when absent, refreshed on every edit). The
+ * library manager renders it as an <img>; without one it shows a "No preview"
+ * placeholder. This asserts a real WebP data URL lands in storage and the card
+ * shows the image, guarding the capture pipeline end to end.
+ */
+test.describe('Baseplate Library Thumbnails', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/baseplate');
+    await expect(page.getByRole('spinbutton', { name: 'Left', exact: true })).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await clearAllStorage(page);
+    await resetViewport(page);
+    const dialogs = getActiveDialog(page);
+    if ((await dialogs.count()) > 0) {
+      await page.keyboard.press('Escape');
+      await dialogs.waitFor({ state: 'detached', timeout: 1000 }).catch(() => {});
+    }
+  });
+
+  test('captures a thumbnail for the active design and shows it in the manager', async ({
+    page,
+  }) => {
+    // The mount backfill writes a data-URL thumbnail once the mesh settles.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async () => {
+            const db: IDBDatabase = await new Promise((resolve, reject) => {
+              const req = indexedDB.open('gridfinity-baseplate-v1');
+              req.onsuccess = () => resolve(req.result);
+              req.onerror = () => reject(req.error);
+            });
+            const designs: { thumbnail: string | null }[] = await new Promise((resolve, reject) => {
+              const req = db.transaction('designs').objectStore('designs').getAll();
+              req.onsuccess = () => resolve(req.result);
+              req.onerror = () => reject(req.error);
+            });
+            db.close();
+            return designs.some((d) => typeof d.thumbnail === 'string' && d.thumbnail.length > 0);
+          }),
+        { timeout: 40_000, intervals: [1000] }
+      )
+      .toBe(true);
+
+    // Open the library manager and confirm the card renders the image, not the
+    // "No preview" placeholder.
+    await page.getByRole('button', { name: 'Open baseplate list' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Baseplate Library' });
+    await expect(dialog).toBeVisible();
+
+    const activeCard = dialog.getByRole('option', { selected: true });
+    await expect(activeCard).toBeVisible();
+    await expect(activeCard.locator('img')).toBeVisible();
+    await expect(activeCard.getByText('No preview')).toHaveCount(0);
+  });
+});

--- a/e2e/baseplate-thumbnail.spec.ts
+++ b/e2e/baseplate-thumbnail.spec.ts
@@ -35,15 +35,29 @@ test.describe('Baseplate Library Thumbnails', () => {
       .poll(
         () =>
           page.evaluate(async () => {
-            const db: IDBDatabase = await new Promise((resolve, reject) => {
+            // Only inspect the DB the app already created — opening it here must
+            // never create an empty, store-less DB (that would break the app's
+            // own versioned open). Return false so the poll keeps retrying until
+            // the app has written its first design.
+            const dbs = await indexedDB.databases();
+            if (!dbs.some((d) => d.name === 'gridfinity-baseplate-v1')) return false;
+            const db = await new Promise<IDBDatabase | null>((resolve) => {
               const req = indexedDB.open('gridfinity-baseplate-v1');
               req.onsuccess = () => resolve(req.result);
-              req.onerror = () => reject(req.error);
+              req.onerror = () => resolve(null);
             });
-            const designs: { thumbnail: string | null }[] = await new Promise((resolve, reject) => {
-              const req = db.transaction('designs').objectStore('designs').getAll();
-              req.onsuccess = () => resolve(req.result);
-              req.onerror = () => reject(req.error);
+            if (!db || !db.objectStoreNames.contains('designs')) {
+              db?.close();
+              return false;
+            }
+            const designs = await new Promise<{ thumbnail: string | null }[]>((resolve) => {
+              try {
+                const req = db.transaction('designs').objectStore('designs').getAll();
+                req.onsuccess = () => resolve(req.result);
+                req.onerror = () => resolve([]);
+              } catch {
+                resolve([]);
+              }
             });
             db.close();
             return designs.some((d) => typeof d.thumbnail === 'string' && d.thumbnail.length > 0);

--- a/src/features/baseplate/README.md
+++ b/src/features/baseplate/README.md
@@ -29,7 +29,8 @@ graph TB
 - `store/baseplatePageStore.ts` — ephemeral UI state (generation status, tiling, piece selection)
 - `components/BaseplateSelector.tsx` — header identity: the active design's name (click to rename) + a button opening the library. **No Save / Save As / New** — see "Design management" below
 - `hooks/useBaseplateInit.ts` — guarantees an active design exists
-- `hooks/useBaseplateAutoSave.ts` — debounced write-back to the active library design; also the source of the header's save status
+- `hooks/useBaseplateAutoSave.ts` — debounced write-back to the active library design; also the source of the header's save status. After the mesh settles it captures a preview thumbnail (`utils/thumbnail.ts`) into the library entry — on every edit, plus a one-time backfill when an opened design has none yet
+- `utils/thumbnail.ts` — captures the live `BaseplatePreview` canvas at a canonical steep-isometric angle and downscales to a WebP data URL for the library cards. `BaseplatePreview` registers its renderer/scene/camera here (`setPreviewContext`) and needs `preserveDrawingBuffer` on its `<Canvas>` so the framebuffer stays readable
 - `components/BaseplatePanel/StackPrintSection.tsx` — "Stack for printing" panel section
 - `components/BaseplatePreview/StackedBaseplateMeshes.tsx` + `StackSeparationSlider.tsx` — flipped-tower preview + explode slider
 - `utils/splitPlanner.ts` — 2D optimal tiling: partitions grid into print-bed-sized pieces, minimizing **build-plate loads** (see Key Concepts)

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -57,12 +57,12 @@ import { setPreviewCanvas, setPreviewContext, clearPreviewCanvas } from '../../u
  * while the user is in ortho mode.
  */
 function BaseplatePreviewContextSync() {
-  const { gl, scene, camera } = useThree();
+  const { gl, scene, camera, invalidate } = useThree();
   useEffect(() => {
     if (camera instanceof PerspectiveCamera) {
-      setPreviewContext(gl, scene, camera);
+      setPreviewContext(gl, scene, camera, invalidate);
     }
-  }, [gl, scene, camera]);
+  }, [gl, scene, camera, invalidate]);
   return null;
 }
 

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -9,9 +9,10 @@
  */
 
 import { useRef, useCallback, useEffect, useMemo, useState } from 'react';
-import { Canvas } from '@react-three/fiber';
+import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { useShallow } from 'zustand/react/shallow';
+import { PerspectiveCamera } from 'three';
 import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { FootprintGrid } from '@/shared/components/preview/FootprintGrid';
@@ -42,6 +43,28 @@ import { useGenerationElapsed } from './useGenerationElapsed';
 import { useBaseplateKeyboard } from '../../hooks/useBaseplateKeyboard';
 import { PanelErrorBoundary } from '@/shell/PanelErrorBoundary';
 import { detectWebGL, WebGLFallback, WebGLErrorBoundary } from '@/shared/webgl';
+import { setPreviewCanvas, setPreviewContext, clearPreviewCanvas } from '../../utils/thumbnail';
+
+/**
+ * Publishes the live renderer/scene/camera to the thumbnail-capture util.
+ *
+ * `Canvas.onCreated` fires against R3F's transient default camera, which
+ * `CameraRig` immediately replaces via `makeDefault`, so we resync through
+ * `useThree().camera`. Only the perspective camera is published: the capture
+ * math reads `camera.fov`, which is `undefined` on the orthographic camera and
+ * would yield NaN-positioned (blank) frames. Drei's `<PerspectiveCamera>` stays
+ * mounted across projection toggles, so the last-published reference stays valid
+ * while the user is in ortho mode.
+ */
+function BaseplatePreviewContextSync() {
+  const { gl, scene, camera } = useThree();
+  useEffect(() => {
+    if (camera instanceof PerspectiveCamera) {
+      setPreviewContext(gl, scene, camera);
+    }
+  }, [gl, scene, camera]);
+  return null;
+}
 
 interface BaseplatePreviewProps {
   width: number;
@@ -68,6 +91,9 @@ export function BaseplatePreview({
   const { isDesktop } = useResponsive();
   const filamentColor = useSettingsStore((s) => s.settings.baseplateFilamentColor);
   const webgl = detectWebGL();
+
+  // Release the thumbnail-capture references when the preview unmounts.
+  useEffect(() => () => clearPreviewCanvas(), []);
 
   const {
     wasmStatus,
@@ -282,9 +308,13 @@ export function BaseplatePreview({
             <WebGLErrorBoundary component="baseplate">
               <Canvas
                 frameloop="demand"
-                gl={{ antialias: true }}
+                // preserveDrawingBuffer keeps the framebuffer readable after
+                // compositing so the library thumbnail can be captured from it.
+                gl={{ antialias: true, preserveDrawingBuffer: true }}
+                onCreated={({ gl }) => setPreviewCanvas(gl.domElement)}
                 onPointerMissed={handlePointerMissed}
               >
+                <BaseplatePreviewContextSync />
                 <CameraRig
                   projection={projection}
                   initialPosition={[100, -100, 80]}

--- a/src/features/baseplate/hooks/useBaseplateAutoSave.ts
+++ b/src/features/baseplate/hooks/useBaseplateAutoSave.ts
@@ -17,14 +17,75 @@ import { useShallow } from 'zustand/react/shallow';
 import { isOk } from '@/core/result';
 import type { SaveStatus } from '@/shared/types/saveStatus';
 import { useLayoutStore } from '@/core/store/layout';
+import { useSettingsStore } from '@/core/store/settings';
 import type { BaseplateDesignId, StoredBaseplateParams } from '@/core/types';
 import {
   updateDesignParams,
+  updateDesignThumbnail,
+  loadDesign,
   setActiveDesignId,
 } from '@/features/baseplate/storage/BaseplateStorage';
 import { upsertRegistryEntry } from '@/features/baseplate/store/baseplateRegistry';
+import { useBaseplatePageStore } from '@/features/baseplate/store/baseplatePageStore';
+import { buildFullParams } from '@/features/baseplate/utils/buildFullParams';
+import {
+  captureBaseplateThumbnailAtPreset,
+  type BaseplateThumbnailFraming,
+} from '@/features/baseplate/utils/thumbnail';
 
 const AUTO_SAVE_DELAY_MS = 1000;
+
+/** Cap on how long a save waits for the mesh to settle before capturing. */
+const GENERATION_WAIT_MAX_MS = 5000;
+
+/**
+ * Resolve the plate framing (grid units + per-side mm padding) the thumbnail
+ * capture needs to place its isometric camera. Reads the same layout + settings
+ * inputs the generation pipeline uses, so the framing matches what's on screen.
+ */
+function resolveThumbnailFraming(stored: StoredBaseplateParams): BaseplateThumbnailFraming {
+  const { layout } = useLayoutStore.getState();
+  const nozzleSizeMm = useSettingsStore.getState().settings.printSettings.nozzleSizeMm;
+  const full = buildFullParams(
+    stored,
+    layout.drawer.width,
+    layout.drawer.depth,
+    layout.gridUnitMm,
+    layout.drawer.fractionalEdgeX ?? 'end',
+    layout.drawer.fractionalEdgeY ?? 'end',
+    nozzleSizeMm,
+    layout.drawer.outline
+  );
+  return {
+    width: full.width,
+    depth: full.depth,
+    gridUnitMm: full.gridUnitMm,
+    paddingLeft: full.paddingLeft,
+    paddingRight: full.paddingRight,
+    paddingFront: full.paddingFront,
+    paddingBack: full.paddingBack,
+  };
+}
+
+/**
+ * Resolve once mesh generation reaches a terminal state (`complete`/`error`) so
+ * the thumbnail captures the settled geometry, not a mid-edit draft. `idle` is
+ * treated as non-terminal (pre-generation); the timeout captures anyway if the
+ * worker is stuck. Bails early via `isCancelled` when the active design changes.
+ */
+function waitForGenerationSettled(isCancelled: () => boolean): Promise<void> {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const check = (): void => {
+      if (isCancelled()) return resolve();
+      const status = useBaseplatePageStore.getState().generation.status;
+      if (status === 'complete' || status === 'error') return resolve();
+      if (Date.now() - start > GENERATION_WAIT_MAX_MS) return resolve();
+      setTimeout(check, 150);
+    };
+    check();
+  });
+}
 
 export function useBaseplateAutoSave(): SaveStatus {
   const { params, activeBaseplateId } = useLayoutStore(
@@ -54,14 +115,27 @@ export function useBaseplateAutoSave(): SaveStatus {
 
   const performSave = useCallback(
     async (paramsToSave: StoredBaseplateParams, designId: BaseplateDesignId): Promise<void> => {
-      // TODO(Phase 1 follow-up): capture a baseplate preview thumbnail here once
-      // an offscreen capture util exists (BaseplatePreview has none today). Until
-      // then the thumbnail is left unchanged.
       setStatus('saving');
-      const result = await updateDesignParams(designId, paramsToSave);
-      // The active design can switch while IndexedDB awaits. Reporting this
-      // save's outcome now would flash a status belonging to the old design.
-      if (useLayoutStore.getState().layout.activeBaseplateId !== designId) return;
+
+      // The active design can switch while any await below is in flight.
+      // Reporting or persisting this save's outcome then would flash a status —
+      // or a thumbnail — belonging to the old design.
+      const superseded = (): boolean =>
+        useLayoutStore.getState().layout.activeBaseplateId !== designId;
+
+      // Wait for the mesh to settle, then let R3F flush the final frame, so the
+      // capture reads the finished geometry rather than a ghost wireframe.
+      await waitForGenerationSettled(superseded);
+      if (superseded()) return;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      if (superseded()) return;
+
+      // `null` (capture unavailable — e.g. WebGL context lost) leaves the stored
+      // thumbnail untouched rather than clearing it; a data URL replaces it.
+      const thumbnail = captureBaseplateThumbnailAtPreset(resolveThumbnailFraming(paramsToSave));
+
+      const result = await updateDesignParams(designId, paramsToSave, thumbnail ?? undefined);
+      if (superseded()) return;
       if (!isOk(result)) {
         // Surfaced in the header rather than swallowed — the edit is still in
         // the layout, but it is no longer in the library.
@@ -79,6 +153,50 @@ export function useBaseplateAutoSave(): SaveStatus {
     },
     []
   );
+
+  // Backfill a thumbnail for the active design when it has none yet (e.g. it was
+  // created before capture existed, or on a device that never edited it). Runs
+  // once per design, silently (no save-status flicker) and only when the stored
+  // thumbnail is absent — edits are handled by performSave above. A data URL is
+  // ~tens of KB, so this fills the library gradually as designs are opened
+  // rather than regenerating every entry up front.
+  const thumbnailBackfilledFor = useRef<BaseplateDesignId | null>(null);
+  useEffect(() => {
+    if (!activeBaseplateId || thumbnailBackfilledFor.current === activeBaseplateId) return;
+    const designId = activeBaseplateId;
+    thumbnailBackfilledFor.current = designId;
+
+    let cancelled = false;
+    const stale = (): boolean =>
+      cancelled || useLayoutStore.getState().layout.activeBaseplateId !== designId;
+
+    void (async () => {
+      const existing = await loadDesign(designId);
+      if (stale() || !isOk(existing) || existing.value.thumbnail) return;
+
+      await waitForGenerationSettled(stale);
+      if (stale()) return;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      if (stale()) return;
+
+      const stored = useLayoutStore.getState().layout.baseplateParams;
+      if (!stored) return;
+      const thumbnail = captureBaseplateThumbnailAtPreset(resolveThumbnailFraming(stored));
+      if (!thumbnail || stale()) return;
+
+      const result = await updateDesignThumbnail(designId, thumbnail);
+      if (stale() || !isOk(result)) return;
+      upsertRegistryEntry({
+        id: result.value.id,
+        name: result.value.name,
+        updatedAt: result.value.updatedAt,
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeBaseplateId]);
 
   useEffect(() => {
     // Skip first render (initial mount shouldn't trigger save)

--- a/src/features/baseplate/hooks/useBaseplateAutoSave.ts
+++ b/src/features/baseplate/hooks/useBaseplateAutoSave.ts
@@ -112,16 +112,30 @@ export function useBaseplateAutoSave(): SaveStatus {
   const isFirstRender = useRef(true);
   const lastSavedParams = useRef<StoredBaseplateParams | undefined>(undefined);
   const lastActiveId = useRef<BaseplateDesignId | null>(null);
+  // Since a save now awaits generation-settle + a delay, two saves for the same
+  // design can overlap. Each save carries a token; scheduling a newer one flips
+  // the previous token so the older save bails before its read-modify-write can
+  // land stale params/thumbnail (or flash a stale "saved" status). Same shape as
+  // the designer's `useAutoSave`.
+  const abortTokenRef = useRef<{ current: boolean }>({ current: false });
+  // The one-time backfill is likewise superseded by any real edit (its own save
+  // captures) — flipped from the save effect so a slow backfill can't overwrite
+  // the edit's params with a thumbnail-only write.
+  const backfillAbortRef = useRef<{ current: boolean }>({ current: false });
 
   const performSave = useCallback(
-    async (paramsToSave: StoredBaseplateParams, designId: BaseplateDesignId): Promise<void> => {
+    async (
+      paramsToSave: StoredBaseplateParams,
+      designId: BaseplateDesignId,
+      abortToken: { current: boolean }
+    ): Promise<void> => {
       setStatus('saving');
 
-      // The active design can switch while any await below is in flight.
-      // Reporting or persisting this save's outcome then would flash a status —
-      // or a thumbnail — belonging to the old design.
+      // Bail when a newer save superseded this one (token flipped) or the active
+      // design switched — either way, reporting or persisting this save's
+      // outcome would clobber newer data or flash a stale status/thumbnail.
       const superseded = (): boolean =>
-        useLayoutStore.getState().layout.activeBaseplateId !== designId;
+        abortToken.current || useLayoutStore.getState().layout.activeBaseplateId !== designId;
 
       // Wait for the mesh to settle, then let R3F flush the final frame, so the
       // capture reads the finished geometry rather than a ghost wireframe.
@@ -133,6 +147,7 @@ export function useBaseplateAutoSave(): SaveStatus {
       // `null` (capture unavailable — e.g. WebGL context lost) leaves the stored
       // thumbnail untouched rather than clearing it; a data URL replaces it.
       const thumbnail = captureBaseplateThumbnailAtPreset(resolveThumbnailFraming(paramsToSave));
+      if (superseded()) return;
 
       const result = await updateDesignParams(designId, paramsToSave, thumbnail ?? undefined);
       if (superseded()) return;
@@ -166,9 +181,10 @@ export function useBaseplateAutoSave(): SaveStatus {
     const designId = activeBaseplateId;
     thumbnailBackfilledFor.current = designId;
 
-    let cancelled = false;
+    const token = { current: false };
+    backfillAbortRef.current = token;
     const stale = (): boolean =>
-      cancelled || useLayoutStore.getState().layout.activeBaseplateId !== designId;
+      token.current || useLayoutStore.getState().layout.activeBaseplateId !== designId;
 
     void (async () => {
       const existing = await loadDesign(designId);
@@ -194,7 +210,7 @@ export function useBaseplateAutoSave(): SaveStatus {
     })();
 
     return () => {
-      cancelled = true;
+      token.current = true;
     };
   }, [activeBaseplateId]);
 
@@ -225,17 +241,25 @@ export function useBaseplateAutoSave(): SaveStatus {
       return;
     }
 
+    // This edit is now the authority for the design's params and thumbnail:
+    // supersede any in-flight save and the one-time backfill so neither can land
+    // a stale write after it.
+    abortTokenRef.current.current = true;
+    backfillAbortRef.current.current = true;
     if (timerRef.current) {
       clearTimeout(timerRef.current);
     }
 
+    const abortToken = { current: false };
+    abortTokenRef.current = abortToken;
     const designId = activeBaseplateId;
     const paramsToSave = params;
     timerRef.current = setTimeout(() => {
-      void performSave(paramsToSave, designId);
+      void performSave(paramsToSave, designId, abortToken);
     }, AUTO_SAVE_DELAY_MS);
 
     return () => {
+      abortToken.current = true;
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }

--- a/src/features/baseplate/utils/thumbnail.test.ts
+++ b/src/features/baseplate/utils/thumbnail.test.ts
@@ -155,4 +155,51 @@ describe('captureBaseplateThumbnailAtPreset', () => {
     // Restored after capture so the live preview keeps its overlay.
     expect(ghost.visible).toBe(true);
   });
+
+  it('restores the camera and overlays even when render throws (context loss)', () => {
+    const renderCalls = vi.fn();
+    const renderer = {
+      render: vi.fn(() => {
+        // First render (the preset frame) throws, e.g. GL context loss.
+        if (renderCalls.mock.calls.length === 0) {
+          renderCalls();
+          throw new Error('context lost');
+        }
+        renderCalls();
+      }),
+    } as unknown as WebGLRenderer;
+    const scene = new Scene();
+    const ghost = new Mesh();
+    ghost.renderOrder = 3;
+    scene.add(ghost);
+    const camera = new PerspectiveCamera(45, 1, 0.1, 20_000);
+    camera.position.set(100, -100, 80);
+    camera.lookAt(0, 0, 0);
+    const originalPosition = camera.position.clone();
+    const originalQuaternion = camera.quaternion.clone();
+
+    setPreviewCanvas(mockCanvas);
+    setPreviewContext(renderer, scene, camera);
+
+    // Falls back to a current-view capture rather than throwing.
+    expect(captureBaseplateThumbnailAtPreset(FRAMING)).toBe('data:image/webp;base64,mockThumb');
+    // The live preview must not be left mutated by the aborted capture.
+    expect(ghost.visible).toBe(true);
+    expect(camera.position.distanceTo(originalPosition)).toBeLessThan(1e-6);
+    expect(camera.quaternion.angleTo(originalQuaternion)).toBeLessThan(1e-6);
+  });
+
+  it('invalidates so R3F repaints with the active camera after restoring', () => {
+    const renderer = { render: vi.fn() } as unknown as WebGLRenderer;
+    const scene = new Scene();
+    const camera = new PerspectiveCamera(45, 1, 0.1, 20_000);
+    const invalidate = vi.fn();
+
+    setPreviewCanvas(mockCanvas);
+    setPreviewContext(renderer, scene, camera, invalidate);
+
+    captureBaseplateThumbnailAtPreset(FRAMING);
+
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/features/baseplate/utils/thumbnail.test.ts
+++ b/src/features/baseplate/utils/thumbnail.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PerspectiveCamera, Scene, Mesh, type WebGLRenderer } from 'three';
+import {
+  captureThumbnail,
+  captureBaseplateThumbnailAtPreset,
+  setPreviewCanvas,
+  setPreviewContext,
+  clearPreviewCanvas,
+  type BaseplateThumbnailFraming,
+} from './thumbnail';
+
+const FRAMING: BaseplateThumbnailFraming = {
+  width: 4,
+  depth: 4,
+  gridUnitMm: 42,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+};
+
+describe('captureThumbnail', () => {
+  let mockCanvas: HTMLCanvasElement;
+  let mockCtx: CanvasRenderingContext2D;
+
+  beforeEach(() => {
+    mockCanvas = document.createElement('canvas');
+    mockCanvas.width = 800;
+    mockCanvas.height = 600;
+
+    mockCtx = { drawImage: vi.fn() } as unknown as CanvasRenderingContext2D;
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(function (
+      this: HTMLCanvasElement,
+      contextId: string
+    ) {
+      if (contextId === '2d' && this !== mockCanvas) return mockCtx;
+      return null;
+    } as typeof HTMLCanvasElement.prototype.getContext);
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+      'data:image/webp;base64,mockThumb'
+    );
+  });
+
+  afterEach(() => {
+    clearPreviewCanvas();
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when no canvas is registered', () => {
+    expect(captureThumbnail()).toBeNull();
+  });
+
+  it('returns null after clearPreviewCanvas', () => {
+    setPreviewCanvas(mockCanvas);
+    clearPreviewCanvas();
+    expect(captureThumbnail()).toBeNull();
+  });
+
+  it('captures a WebP data URL center-cropped to 384x384', () => {
+    setPreviewCanvas(mockCanvas);
+
+    expect(captureThumbnail()).toBe('data:image/webp;base64,mockThumb');
+    // 800x600 → 600x600 centered crop (srcX = 100)
+    expect(mockCtx.drawImage).toHaveBeenCalledWith(mockCanvas, 100, 0, 600, 600, 0, 0, 384, 384);
+    expect(HTMLCanvasElement.prototype.toDataURL).toHaveBeenCalledWith('image/webp', 0.9);
+  });
+});
+
+describe('captureBaseplateThumbnailAtPreset', () => {
+  let mockCanvas: HTMLCanvasElement;
+  let mockCtx: CanvasRenderingContext2D;
+
+  beforeEach(() => {
+    mockCanvas = document.createElement('canvas');
+    mockCanvas.width = 500;
+    mockCanvas.height = 500;
+    mockCtx = { drawImage: vi.fn() } as unknown as CanvasRenderingContext2D;
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(function (
+      this: HTMLCanvasElement,
+      contextId: string
+    ) {
+      if (contextId === '2d' && this !== mockCanvas) return mockCtx;
+      return null;
+    } as typeof HTMLCanvasElement.prototype.getContext);
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+      'data:image/webp;base64,mockThumb'
+    );
+  });
+
+  afterEach(() => {
+    clearPreviewCanvas();
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to current-view capture when no Three.js context is registered', () => {
+    setPreviewCanvas(mockCanvas);
+    // No setPreviewContext — should still capture via the fallback path.
+    expect(captureBaseplateThumbnailAtPreset(FRAMING)).toBe('data:image/webp;base64,mockThumb');
+  });
+
+  it('returns null when nothing is registered at all', () => {
+    expect(captureBaseplateThumbnailAtPreset(FRAMING)).toBeNull();
+  });
+
+  it('renders one preset frame, captures, then restores the original camera pose', () => {
+    const renderer = { render: vi.fn() } as unknown as WebGLRenderer;
+    const scene = new Scene();
+    scene.add(new Mesh());
+    const camera = new PerspectiveCamera(45, 1, 0.1, 20_000);
+    camera.position.set(100, -100, 80);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld();
+    const originalPosition = camera.position.clone();
+    const originalQuaternion = camera.quaternion.clone();
+
+    setPreviewCanvas(mockCanvas);
+    setPreviewContext(renderer, scene, camera);
+
+    const result = captureBaseplateThumbnailAtPreset(FRAMING);
+
+    expect(result).toBe('data:image/webp;base64,mockThumb');
+    // One render at the preset angle + one to restore the visible frame.
+    expect(renderer.render).toHaveBeenCalledTimes(2);
+    // Camera pose is restored exactly so the user's orbit is untouched.
+    expect(camera.position.distanceTo(originalPosition)).toBeLessThan(1e-6);
+    expect(camera.quaternion.angleTo(originalQuaternion)).toBeLessThan(1e-6);
+  });
+
+  it('hides transient overlays (renderOrder >= 2) during capture and restores them', () => {
+    const renderer = { render: vi.fn() } as unknown as WebGLRenderer;
+    const scene = new Scene();
+    const ghost = new Mesh();
+    ghost.renderOrder = 3;
+    let visibleAtRender = true;
+    (renderer.render as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      // Capture the ghost's visibility as seen by the first (preset) render.
+      if ((renderer.render as ReturnType<typeof vi.fn>).mock.calls.length === 1) {
+        visibleAtRender = ghost.visible;
+      }
+    });
+    scene.add(ghost);
+    const camera = new PerspectiveCamera(45, 1, 0.1, 20_000);
+
+    setPreviewCanvas(mockCanvas);
+    setPreviewContext(renderer, scene, camera);
+
+    captureBaseplateThumbnailAtPreset(FRAMING);
+
+    expect(visibleAtRender).toBe(false);
+    // Restored after capture so the live preview keeps its overlay.
+    expect(ghost.visible).toBe(true);
+  });
+});

--- a/src/features/baseplate/utils/thumbnail.ts
+++ b/src/features/baseplate/utils/thumbnail.ts
@@ -36,21 +36,29 @@ let previewCanvasEl: HTMLCanvasElement | null = null;
 let previewRenderer: WebGLRenderer | null = null;
 let previewScene: Scene | null = null;
 let previewCamera: PerspectiveCamera | null = null;
+let previewInvalidate: (() => void) | null = null;
 
 /** Register the DOM canvas used as the capture source. */
 export function setPreviewCanvas(canvas: HTMLCanvasElement): void {
   previewCanvasEl = canvas;
 }
 
-/** Register the Three.js context for preset-angle captures. */
+/**
+ * Register the Three.js context for preset-angle captures. `invalidate` is
+ * R3F's demand-frame trigger: after a capture restores the camera we call it so
+ * R3F repaints with whatever camera is actually active (e.g. the orthographic
+ * one), rather than leaving our manual perspective frame on screen.
+ */
 export function setPreviewContext(
   renderer: WebGLRenderer,
   scene: Scene,
-  camera: PerspectiveCamera
+  camera: PerspectiveCamera,
+  invalidate?: () => void
 ): void {
   previewRenderer = renderer;
   previewScene = scene;
   previewCamera = camera;
+  previewInvalidate = invalidate ?? null;
 }
 
 /** Clear all registered references (on preview unmount). */
@@ -59,6 +67,7 @@ export function clearPreviewCanvas(): void {
   previewRenderer = null;
   previewScene = null;
   previewCamera = null;
+  previewInvalidate = null;
 }
 
 export interface ThumbnailCaptureOptions {
@@ -123,9 +132,20 @@ export function captureBaseplateThumbnailAtPreset(
   framing: BaseplateThumbnailFraming,
   options?: ThumbnailCaptureOptions
 ): string | null {
-  if (!previewRenderer || !previewScene || !previewCamera) {
+  const renderer = previewRenderer;
+  const scene = previewScene;
+  const camera = previewCamera;
+  if (!renderer || !scene || !camera) {
     return captureThumbnail(options);
   }
+
+  // Saved outside the try so restoration in `finally` always runs — even if
+  // `render()` throws on context loss, the live preview must not be left at the
+  // capture pose with overlays hidden.
+  const savedPosition = camera.position.clone();
+  const savedUp = camera.up.clone();
+  const savedQuaternion = camera.quaternion.clone();
+  const hidden: { visible: boolean }[] = [];
 
   try {
     const { width, depth, gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack } =
@@ -143,47 +163,47 @@ export function captureBaseplateThumbnailAtPreset(
       paddingRight,
       paddingFront,
       paddingBack,
-      previewCamera.fov
+      camera.fov
     );
 
-    const savedPosition = previewCamera.position.clone();
-    const savedUp = previewCamera.up.clone();
-    const savedQuaternion = previewCamera.quaternion.clone();
-
-    previewCamera.position.copy(
+    camera.position.copy(
       new Vector3(CAPTURE_DIRECTION[0], CAPTURE_DIRECTION[1], CAPTURE_DIRECTION[2])
         .multiplyScalar(idealDistance)
         .add(center)
     );
-    previewCamera.up.set(0, 0, 1);
-    previewCamera.lookAt(center);
-    previewCamera.updateProjectionMatrix();
+    camera.up.set(0, 0, 1);
+    camera.lookAt(center);
+    camera.updateProjectionMatrix();
 
     // Hide transient overlays (ghost outline sits at renderOrder 3) so a
     // mid-edit wireframe never bleeds into the saved image.
-    const hidden: { obj: { visible: boolean } }[] = [];
-    previewScene.traverse((obj) => {
+    scene.traverse((obj) => {
       if (obj.renderOrder >= 2 && obj.visible) {
-        hidden.push({ obj });
+        hidden.push(obj);
         obj.visible = false;
       }
     });
 
-    previewRenderer.render(previewScene, previewCamera);
-    const result = captureThumbnail(options);
-
-    for (const { obj } of hidden) {
-      obj.visible = true;
-    }
-
-    previewCamera.position.copy(savedPosition);
-    previewCamera.up.copy(savedUp);
-    previewCamera.quaternion.copy(savedQuaternion);
-    previewCamera.updateProjectionMatrix();
-    previewRenderer.render(previewScene, previewCamera);
-
-    return result;
+    renderer.render(scene, camera);
+    return captureThumbnail(options);
   } catch {
     return captureThumbnail(options);
+  } finally {
+    for (const obj of hidden) {
+      obj.visible = true;
+    }
+    camera.position.copy(savedPosition);
+    camera.up.copy(savedUp);
+    camera.quaternion.copy(savedQuaternion);
+    camera.updateProjectionMatrix();
+    // Repaint the restored pose. `render()` can throw on context loss, so guard
+    // it; `invalidate()` then lets R3F redraw with the actually-active camera
+    // (perspective or orthographic) on its next demand frame.
+    try {
+      renderer.render(scene, camera);
+    } catch {
+      // Context lost — nothing to restore onto; R3F's error boundary handles it.
+    }
+    previewInvalidate?.();
   }
 }

--- a/src/features/baseplate/utils/thumbnail.ts
+++ b/src/features/baseplate/utils/thumbnail.ts
@@ -1,0 +1,189 @@
+/**
+ * Thumbnail capture utility for the standalone Baseplate page.
+ *
+ * Mirrors the bin designer's `utils/thumbnail.ts` (module boundaries forbid
+ * importing it across features). Captures the live Three.js preview canvas at a
+ * canonical isometric angle and downscales it to a WebP data URL for storage in
+ * the baseplate library (IndexedDB).
+ *
+ * The BaseplatePreview `<Canvas>` registers its renderer/scene/camera here via
+ * `setPreviewContext` (and the DOM canvas via `setPreviewCanvas`); capture reads
+ * those module-level refs. Requires the page to be mounted.
+ */
+
+import type { WebGLRenderer, Scene, PerspectiveCamera } from 'three';
+import { Vector3 } from 'three';
+import { calculateIdealDistance } from '../components/BaseplatePreview/cameraUtils';
+
+/** Thumbnail edge length for IndexedDB storage (crisp at any card size). */
+const THUMBNAIL_SIZE = 384;
+
+/**
+ * Capture eye direction (normalized). Steeper than the interactive `isometric`
+ * preset (~48° vs ~30° elevation): a baseplate is a flat plate, so a shallow
+ * angle drops the whole plate below the horizon and wastes the top half of the
+ * frame. Normalized inline with plain math so this module makes no Three.js call
+ * at import time — `new Vector3` is deferred to the capture function so tests can
+ * mock `three`.
+ */
+const CAPTURE_DIRECTION: readonly [number, number, number] = (() => {
+  const [x, y, z] = [0.5, -0.5, 0.8];
+  const len = Math.hypot(x, y, z);
+  return [x / len, y / len, z / len];
+})();
+
+let previewCanvasEl: HTMLCanvasElement | null = null;
+let previewRenderer: WebGLRenderer | null = null;
+let previewScene: Scene | null = null;
+let previewCamera: PerspectiveCamera | null = null;
+
+/** Register the DOM canvas used as the capture source. */
+export function setPreviewCanvas(canvas: HTMLCanvasElement): void {
+  previewCanvasEl = canvas;
+}
+
+/** Register the Three.js context for preset-angle captures. */
+export function setPreviewContext(
+  renderer: WebGLRenderer,
+  scene: Scene,
+  camera: PerspectiveCamera
+): void {
+  previewRenderer = renderer;
+  previewScene = scene;
+  previewCamera = camera;
+}
+
+/** Clear all registered references (on preview unmount). */
+export function clearPreviewCanvas(): void {
+  previewCanvasEl = null;
+  previewRenderer = null;
+  previewScene = null;
+  previewCamera = null;
+}
+
+export interface ThumbnailCaptureOptions {
+  /** Output edge length in pixels. Defaults to THUMBNAIL_SIZE. */
+  readonly size?: number;
+  /** Encoder quality. Defaults to 0.9. */
+  readonly quality?: number;
+}
+
+/**
+ * Capture a centered square WebP data URL of the current preview canvas.
+ *
+ * Returns `null` if the canvas or a 2D context is unavailable, or the source
+ * canvas is tainted.
+ */
+export function captureThumbnail(options?: ThumbnailCaptureOptions): string | null {
+  if (!previewCanvasEl) return null;
+
+  const size = options?.size ?? THUMBNAIL_SIZE;
+  const quality = options?.quality ?? 0.9;
+
+  try {
+    const offscreen = document.createElement('canvas');
+    offscreen.width = size;
+    offscreen.height = size;
+    const ctx = offscreen.getContext('2d');
+    if (!ctx) return null;
+
+    const src = previewCanvasEl;
+    const srcSize = Math.min(src.width, src.height);
+    const srcX = (src.width - srcSize) / 2;
+    const srcY = (src.height - srcSize) / 2;
+
+    ctx.drawImage(src, srcX, srcY, srcSize, srcSize, 0, 0, size, size);
+    return offscreen.toDataURL('image/webp', quality);
+  } catch {
+    return null;
+  }
+}
+
+/** Plate framing dimensions (grid units + per-side mm padding). */
+export interface BaseplateThumbnailFraming {
+  readonly width: number;
+  readonly depth: number;
+  readonly gridUnitMm: number;
+  readonly paddingLeft: number;
+  readonly paddingRight: number;
+  readonly paddingFront: number;
+  readonly paddingBack: number;
+}
+
+/**
+ * Capture a thumbnail from a canonical isometric angle, independent of the
+ * user's current camera pose. Temporarily reframes the camera onto the plate,
+ * renders one frame, captures, then restores the exact prior pose so the user's
+ * orbit is untouched.
+ *
+ * Falls back to `captureThumbnail()` (current view) when the Three.js context
+ * isn't registered.
+ */
+export function captureBaseplateThumbnailAtPreset(
+  framing: BaseplateThumbnailFraming,
+  options?: ThumbnailCaptureOptions
+): string | null {
+  if (!previewRenderer || !previewScene || !previewCamera) {
+    return captureThumbnail(options);
+  }
+
+  try {
+    const { width, depth, gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack } =
+      framing;
+    // The plate is thin and centered on the origin (pockets align to the
+    // FootprintGrid), so framing on (0,0,0) is exact enough for a thumbnail.
+    const center = new Vector3(0, 0, 0);
+    // Top-down framing distance; the isometric angle foreshortens the flat
+    // plate, so this over-frames slightly rather than clipping.
+    const idealDistance = calculateIdealDistance(
+      width,
+      depth,
+      gridUnitMm,
+      paddingLeft,
+      paddingRight,
+      paddingFront,
+      paddingBack,
+      previewCamera.fov
+    );
+
+    const savedPosition = previewCamera.position.clone();
+    const savedUp = previewCamera.up.clone();
+    const savedQuaternion = previewCamera.quaternion.clone();
+
+    previewCamera.position.copy(
+      new Vector3(CAPTURE_DIRECTION[0], CAPTURE_DIRECTION[1], CAPTURE_DIRECTION[2])
+        .multiplyScalar(idealDistance)
+        .add(center)
+    );
+    previewCamera.up.set(0, 0, 1);
+    previewCamera.lookAt(center);
+    previewCamera.updateProjectionMatrix();
+
+    // Hide transient overlays (ghost outline sits at renderOrder 3) so a
+    // mid-edit wireframe never bleeds into the saved image.
+    const hidden: { obj: { visible: boolean } }[] = [];
+    previewScene.traverse((obj) => {
+      if (obj.renderOrder >= 2 && obj.visible) {
+        hidden.push({ obj });
+        obj.visible = false;
+      }
+    });
+
+    previewRenderer.render(previewScene, previewCamera);
+    const result = captureThumbnail(options);
+
+    for (const { obj } of hidden) {
+      obj.visible = true;
+    }
+
+    previewCamera.position.copy(savedPosition);
+    previewCamera.up.copy(savedUp);
+    previewCamera.quaternion.copy(savedQuaternion);
+    previewCamera.updateProjectionMatrix();
+    previewRenderer.render(previewScene, previewCamera);
+
+    return result;
+  } catch {
+    return captureThumbnail(options);
+  }
+}


### PR DESCRIPTION
## What & why

Baseplate library cards always showed a **"No preview" placeholder**. Thumbnail
capture was never implemented (a documented Phase 1 TODO in `useBaseplateAutoSave`),
so every saved baseplate design stored `thumbnail: null`. This wires up capture so
the manager shows real 3D previews, matching the bin designer.

## How

Mirrors the bin designer's proven capture pipeline:

- **`utils/thumbnail.ts`** (new) captures the live preview canvas at a canonical
  steep-isometric angle (~48deg, so a flat plate fills the frame rather than
  sitting below the horizon), downscaled to a WebP data URL. The camera pose is
  saved and restored, so the user's orbit is untouched, and transient overlays
  are hidden during capture.
- **`BaseplatePreview`** publishes its renderer/scene/camera (perspective-only,
  since the capture math needs `fov`) and sets `preserveDrawingBuffer` so the
  framebuffer stays readable.
- **`useBaseplateAutoSave`** captures on every edit once the mesh settles, plus a
  one-time backfill when an opened design has no thumbnail yet, so pre-existing
  designs populate on open rather than only after an edit.

## Testing

- New unit tests for the capture util (fallback, camera-restore, overlay hiding)
- New e2e (`baseplate-thumbnail.spec.ts`): asserts a real data-URL thumbnail lands
  in storage and the card renders an `<img>` instead of the placeholder
- Verified visually via headless Playwright screenshot

## Known follow-up

Stack-print previews frame to the single-plate dims, so those thumbnails may sit
low (the capture over-frames rather than clips). Worth a follow-up if stack
designs prove common.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds preview thumbnail capture for Baseplate library cards so designs show real 3D previews instead of “No preview.” Captures a 384x384 WebP at a steep-isometric angle on save and backfills existing designs; robust to WebGL context loss and avoids stale saves.

- New Features
  - Added `src/features/baseplate/utils/thumbnail.ts` to capture the live canvas at a canonical angle, center-crop to 384x384 WebP, hide transient overlays, and restore the camera pose.
  - Wired into preview and autosave: `BaseplatePreview` sets `preserveDrawingBuffer` and publishes renderer/scene/camera via `setPreviewCanvas`/`setPreviewContext` (cleared on unmount); `useBaseplateAutoSave` waits for mesh settle, captures on edits, and one-time backfills; falls back to current-view capture when context is unavailable.

- Bug Fixes
  - Restores camera and overlays in a finally block and calls `invalidate()` after capture; handles render failures/context loss by falling back without mutating the live view.
  - Prevents stale writes with per-save abort tokens and by cancelling the one-time backfill on edits; hardens the e2e IndexedDB poll; adds unit tests for render-failure restoration and `invalidate()`.

<sup>Written for commit 6ff9f737775910b4377cc44cf5d64dabc68a2ebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

