### PR TITLE
feat(designer): batch label plate export in the layout ZIP (#2666)

### DIFF
--- a/src/features/bin-designer/hooks/useLabelPlateExport.ts
+++ b/src/features/bin-designer/hooks/useLabelPlateExport.ts
@@ -25,23 +25,18 @@ import {
   triggerDownload,
 } from '@/shared/generation/exportUtils';
 import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
-import { effectiveLabelSocketClearance } from '@/shared/constants/labelPlates';
+import {
+  effectiveLabelSocketClearance,
+  snapTextDepthToLayers,
+} from '@/shared/constants/labelPlates';
+
+export { snapTextDepthToLayers } from '@/shared/constants/labelPlates';
 import { planLabelPlates } from '@/shared/utils/labelSocketPlan';
 import type { LabelPlatePlanEntry } from '@/shared/utils/labelSocketPlan';
 import type { LabelPlateExportOptions, LabelPlateExportSpec } from '@/shared/generation/bridge';
 import type { ExportFileFormat } from '@/shared/types/bin';
 
 export const LABEL_PLATES_BASE_NAME = 'label-plates';
-
-/**
- * Snap the configured text depth to a whole multiple of the layer height,
- * clamped to the spec's 1-layer..0.4mm band — the filament-swap contract.
- */
-export function snapTextDepthToLayers(depthMm: number, layerHeightMm: number): number {
-  if (!Number.isFinite(layerHeightMm) || layerHeightMm <= 0) return Math.min(0.4, depthMm);
-  const snapped = Math.round(depthMm / layerHeightMm) * layerHeightMm;
-  return Math.round(Math.min(0.4, Math.max(layerHeightMm, snapped)) * 100) / 100;
-}
 
 interface UseLabelPlateExportReturn {
   readonly plates: readonly LabelPlatePlanEntry[];

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -238,6 +238,12 @@ export interface ExportConnectorSampleMessage {
 export interface LabelPlateExportSpec {
   readonly widthU: 1 | 2 | 3;
   readonly text: string;
+  /**
+   * Plate center on the bed (mm). When absent the builder stacks plates in
+   * a single centered column; the layout batch export passes packed sheet
+   * positions instead.
+   */
+  readonly position?: readonly [number, number];
 }
 
 /**

--- a/src/features/generation/worker/generators/labelPlateBuilder.test.ts
+++ b/src/features/generation/worker/generators/labelPlateBuilder.test.ts
@@ -77,6 +77,27 @@ describe('labelPlateBuilder', () => {
     }
   });
 
+  it('honors explicit sheet positions', () => {
+    const pieces = buildLabelPlates(
+      [
+        { widthU: 1, text: '', position: [-50, 20] },
+        { widthU: 1, text: '', position: [50, -20] },
+      ],
+      OPTS
+    );
+    try {
+      const boxes = pieces.map((p) => {
+        const m = mesh(p, { tolerance: 0.05, angularTolerance: 10 });
+        return boundingBox(new Float32Array(m.vertices));
+      });
+      expect((boxes[0].minX + boxes[0].maxX) / 2).toBeCloseTo(-50, 1);
+      expect((boxes[0].minY + boxes[0].maxY) / 2).toBeCloseTo(20, 1);
+      expect((boxes[1].minX + boxes[1].maxX) / 2).toBeCloseTo(50, 1);
+    } finally {
+      for (const p of pieces) p.delete();
+    }
+  });
+
   it('lays out multiple plates without overlap', () => {
     const pieces = buildLabelPlates(
       [

--- a/src/features/generation/worker/generators/labelPlateBuilder.ts
+++ b/src/features/generation/worker/generators/labelPlateBuilder.ts
@@ -52,6 +52,8 @@ import { buildBaseplateSTL } from './baseplateSTL';
 export interface LabelPlateSpec {
   readonly widthU: LabelPlateWidthU;
   readonly text: string;
+  /** Plate center on the bed (mm); absent = single centered column layout. */
+  readonly position?: readonly [number, number];
 }
 
 export interface LabelPlateBuildOptions {
@@ -193,8 +195,8 @@ export function buildLabelPlates(
   const totalY = specs.length * pitch - PLATE_GAP;
   return specs.map((spec, i) => {
     const plate = buildLabelPlate(spec, opts);
-    const y = -totalY / 2 + LABEL_PLATE_HEIGHT_MM / 2 + i * pitch;
-    const placed = translate(plate, [0, y, 0]);
+    const [x, y] = spec.position ?? [0, -totalY / 2 + LABEL_PLATE_HEIGHT_MM / 2 + i * pitch];
+    const placed = translate(plate, [x, y, 0]);
     plate.delete();
     return placed;
   });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Etikettenplatten exportieren",
   "binDesigner.plates.dialogDescription": "Eine druckbare Datei mit einer Platte pro Aufnahme, jeweils mit dem Beschriftungstext des Fachs. Die Texttiefe rastet auf ganze Schichten ein — ein einziger Filamentwechsel druckt zweifarbige Etiketten.",
   "binDesigner.plates.previewTitle": "Vorschau der Etikettenplatten",
-  "binDesigner.plates.previewLoading": "Vorschau wird erstellt…"
+  "binDesigner.plates.previewLoading": "Vorschau wird erstellt…",
+  "layoutExport.progress.labels": "Etikettenplatten werden exportiert ({current}/{total})"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -337,6 +337,7 @@ const en: Record<string, string> = {
   'layoutExport.success': 'Layout exported.',
   'layoutExport.progress.bins': 'Exporting bins ({current}/{total})',
   'layoutExport.progress.baseplate': 'Exporting baseplate ({current}/{total})',
+  'layoutExport.progress.labels': 'Exporting label plates ({current}/{total})',
   'rightPanel.customPropertiesCount': '{count} custom properties',
   'rightPanel.expandRightPanel': 'Expand right panel',
   'rightPanel.filamentAbbrev': 'Fil.',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Exportar placas de etiqueta",
   "binDesigner.plates.dialogDescription": "Un archivo imprimible con una placa por alojamiento, con el texto de etiqueta de su compartimento. La profundidad del texto se ajusta a capas completas: un solo cambio de filamento imprime etiquetas a dos colores.",
   "binDesigner.plates.previewTitle": "Vista previa de placas de etiqueta",
-  "binDesigner.plates.previewLoading": "Generando vista previa…"
+  "binDesigner.plates.previewLoading": "Generando vista previa…",
+  "layoutExport.progress.labels": "Exportando placas de etiqueta ({current}/{total})"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Exporter les plaques d'étiquette",
   "binDesigner.plates.dialogDescription": "Un fichier imprimable avec une plaque par logement, portant le texte d'étiquette de son compartiment. La profondeur du texte s'aligne sur des couches entières : un seul changement de filament imprime des étiquettes bicolores.",
   "binDesigner.plates.previewTitle": "Aperçu des plaques d'étiquette",
-  "binDesigner.plates.previewLoading": "Génération de l'aperçu…"
+  "binDesigner.plates.previewLoading": "Génération de l'aperçu…",
+  "layoutExport.progress.labels": "Export des plaques d'étiquette ({current}/{total})"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Esporta targhette etichetta",
   "binDesigner.plates.dialogDescription": "Un file stampabile con una targhetta per ogni sede, con il testo di etichetta del suo scomparto. La profondità del testo si allinea a layer interi: un solo cambio filamento stampa etichette bicolore.",
   "binDesigner.plates.previewTitle": "Anteprima targhette etichetta",
-  "binDesigner.plates.previewLoading": "Generazione anteprima…"
+  "binDesigner.plates.previewLoading": "Generazione anteprima…",
+  "layoutExport.progress.labels": "Esportazione targhette etichetta ({current}/{total})"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "ラベルプレートの書き出し",
   "binDesigner.plates.dialogDescription": "各ソケットに1枚ずつ、コンパートメントのラベルテキストを載せたプレートをまとめた印刷用ファイルです。文字の深さはレイヤー単位にスナップされるため、フィラメント交換1回で2色のラベルが印刷できます。",
   "binDesigner.plates.previewTitle": "ラベルプレートのプレビュー",
-  "binDesigner.plates.previewLoading": "プレビューを生成中…"
+  "binDesigner.plates.previewLoading": "プレビューを生成中…",
+  "layoutExport.progress.labels": "ラベルプレートを書き出し中（{current}/{total}）"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Eksporter etikettplater",
   "binDesigner.plates.dialogDescription": "Én utskriftsklar fil med en plate per sokkel, med rommets etikettekst. Tekstdybden festes til hele lag — ett filamentbytte gir tofargede etiketter.",
   "binDesigner.plates.previewTitle": "Forhåndsvisning av etikettplater",
-  "binDesigner.plates.previewLoading": "Genererer forhåndsvisning…"
+  "binDesigner.plates.previewLoading": "Genererer forhåndsvisning…",
+  "layoutExport.progress.labels": "Eksporterer etikettplater ({current}/{total})"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Labelplaatjes exporteren",
   "binDesigner.plates.dialogDescription": "Eén printbaar bestand met per houder een plaatje, met de labeltekst van het vak. De tekstdiepte klikt vast op hele lagen — één filamentwissel print tweekleurige labels.",
   "binDesigner.plates.previewTitle": "Voorbeeld labelplaatjes",
-  "binDesigner.plates.previewLoading": "Voorbeeld genereren…"
+  "binDesigner.plates.previewLoading": "Voorbeeld genereren…",
+  "layoutExport.progress.labels": "Labelplaatjes exporteren ({current}/{total})"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Exportar placas de rótulo",
   "binDesigner.plates.dialogDescription": "Um arquivo imprimível com uma placa por encaixe, com o texto de rótulo do compartimento. A profundidade do texto se alinha a camadas inteiras: uma única troca de filamento imprime rótulos em duas cores.",
   "binDesigner.plates.previewTitle": "Prévia das placas de rótulo",
-  "binDesigner.plates.previewLoading": "Gerando prévia…"
+  "binDesigner.plates.previewLoading": "Gerando prévia…",
+  "layoutExport.progress.labels": "Exportando placas de rótulo ({current}/{total})"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Exportera etikettplattor",
   "binDesigner.plates.dialogDescription": "En utskrivbar fil med en platta per fäste, med fackets etikettext. Textdjupet snäpper till hela lager — ett enda filamentbyte ger tvåfärgade etiketter.",
   "binDesigner.plates.previewTitle": "Förhandsgranskning av etikettplattor",
-  "binDesigner.plates.previewLoading": "Genererar förhandsgranskning…"
+  "binDesigner.plates.previewLoading": "Genererar förhandsgranskning…",
+  "layoutExport.progress.labels": "Exporterar etikettplattor ({current}/{total})"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2809,5 +2809,6 @@
   "binDesigner.plates.dialogTitle": "Експорт пластин етикеток",
   "binDesigner.plates.dialogDescription": "Один файл для друку з пластиною для кожного гнізда з текстом етикетки відсіку. Глибина тексту вирівнюється за цілими шарами — одна заміна філаменту друкує двоколірні етикетки.",
   "binDesigner.plates.previewTitle": "Перегляд пластин етикеток",
-  "binDesigner.plates.previewLoading": "Створення перегляду…"
+  "binDesigner.plates.previewLoading": "Створення перегляду…",
+  "layoutExport.progress.labels": "Експорт пластин етикеток ({current}/{total})"
 }

--- a/src/shared/constants/labelPlates.ts
+++ b/src/shared/constants/labelPlates.ts
@@ -128,6 +128,16 @@ export function effectiveLabelSocketClearance(
   return Math.max(0, scaled + offset);
 }
 
+/**
+ * Snap a text depth to a whole multiple of the layer height, clamped to the
+ * 1-layer..0.4mm band — the filament-swap two-color contract for plates.
+ */
+export function snapTextDepthToLayers(depthMm: number, layerHeightMm: number): number {
+  if (!Number.isFinite(layerHeightMm) || layerHeightMm <= 0) return Math.min(0.4, depthMm);
+  const snapped = Math.round(depthMm / layerHeightMm) * layerHeightMm;
+  return Math.round(Math.min(0.4, Math.max(layerHeightMm, snapped)) * 100) / 100;
+}
+
 /** Outer X span a socket needs for a given plate width (pocket + walls). */
 export function labelSocketOuterWidthMm(widthU: LabelPlateWidthU, clearanceMm: number): number {
   return labelPlateWidthMm(widthU) + clearanceMm + 2 * LABEL_SOCKET_WALL_MM;

--- a/src/shell/layoutExport/buildLayoutManifest.test.ts
+++ b/src/shell/layoutExport/buildLayoutManifest.test.ts
@@ -93,4 +93,30 @@ describe('buildLayoutManifest', () => {
     expect(text).toContain('(no linked bin designs to export)');
     expect(text).not.toContain('─── Baseplate ───');
   });
+
+  it('renders the label plates section with quantities and sheet paths', () => {
+    const text = buildLayoutManifest(
+      base({
+        labels: [
+          {
+            designName: 'Hardware',
+            sheetPaths: ['labels/hardware_plates_1.stl'],
+            plates: [
+              { widthU: 1, text: 'SCREWS', quantity: 2 },
+              { widthU: 2, text: '', quantity: 1 },
+            ],
+          },
+        ],
+      })
+    );
+    expect(text).toContain('Label plates');
+    expect(text).toContain('labels/hardware_plates_1.stl');
+    expect(text).toContain('2\u00d7 1U "SCREWS"');
+    expect(text).toContain('1\u00d7 2U (blank)');
+  });
+
+  it('omits the label plates section when absent', () => {
+    expect(buildLayoutManifest(base())).not.toContain('Label plates');
+    expect(buildLayoutManifest(base({ labels: null }))).not.toContain('Label plates');
+  });
 });

--- a/src/shell/layoutExport/buildLayoutManifest.ts
+++ b/src/shell/layoutExport/buildLayoutManifest.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ExportFileFormat } from '@/shared/types/bin';
+import type { LabelPlateWidthU } from '@/shared/constants/labelPlates';
 
 export interface ManifestBinEntry {
   /** Path inside the ZIP, e.g. `bins/box_1x1x6.stl`. */
@@ -39,10 +40,12 @@ export interface ManifestLabelGroup {
   readonly sheetPaths: readonly string[];
   /** Unique plates with physical quantities (identical plates collapsed). */
   readonly plates: readonly {
-    readonly widthU: number;
+    readonly widthU: LabelPlateWidthU;
     readonly text: string;
     readonly quantity: number;
   }[];
+  /** Plates skipped because they exceed the usable print bed width. */
+  readonly oversizedCount?: number;
 }
 
 export interface LayoutManifestInput {
@@ -143,6 +146,11 @@ export function buildLayoutManifest(input: LayoutManifestInput): string {
       for (const p of group.plates) {
         const label = p.text.length > 0 ? `"${p.text}"` : '(blank)';
         lines.push(`      ${p.quantity}× ${p.widthU}U ${label}`);
+      }
+      if (group.oversizedCount !== undefined && group.oversizedCount > 0) {
+        lines.push(
+          `      ${group.oversizedCount} ${plural(group.oversizedCount, 'plate')} skipped (wider than the print bed).`
+        );
       }
       lines.push('');
     }

--- a/src/shell/layoutExport/buildLayoutManifest.ts
+++ b/src/shell/layoutExport/buildLayoutManifest.ts
@@ -33,6 +33,18 @@ export interface ManifestSkipped {
   readonly meshDesignsStepSkipped?: number;
 }
 
+/** One swappable-label sheet family in the labels/ folder (#2666). */
+export interface ManifestLabelGroup {
+  readonly designName: string;
+  readonly sheetPaths: readonly string[];
+  /** Unique plates with physical quantities (identical plates collapsed). */
+  readonly plates: readonly {
+    readonly widthU: number;
+    readonly text: string;
+    readonly quantity: number;
+  }[];
+}
+
 export interface LayoutManifestInput {
   readonly layoutName: string;
   /** The per-file format inside the ZIP. */
@@ -40,6 +52,8 @@ export interface LayoutManifestInput {
   readonly bins: readonly ManifestBinEntry[];
   /** Present when a baseplate is included; guidePath is set when it ships a guide. */
   readonly baseplate?: { readonly pieceCount: number; readonly guidePath?: string } | null;
+  /** Present when socket-mode designs shipped swappable label plates. */
+  readonly labels?: readonly ManifestLabelGroup[] | null;
   readonly skipped: ManifestSkipped;
   readonly totals: { readonly filamentGrams: number; readonly printTimeMinutes: number };
 }
@@ -109,6 +123,29 @@ export function buildLayoutManifest(input: LayoutManifestInput): string {
       lines.push(`  See ${baseplate.guidePath} for the assembly map and per-piece details.`);
     }
     lines.push('');
+  }
+
+  const labels = input.labels ?? [];
+  if (labels.length > 0) {
+    lines.push('─── Label plates ────────────────────────────────', '');
+    lines.push(
+      '  Swappable label plates for socket-mode bins, packed onto bed-sized',
+      '  sheets in the labels/ folder. Print each sheet once (flat, no',
+      '  supports); a single filament swap at the text layers prints',
+      '  two-color labels.',
+      ''
+    );
+    for (const group of labels) {
+      lines.push(`  Design: ${group.designName}`);
+      for (const path of group.sheetPaths) {
+        lines.push(`    ${path}`);
+      }
+      for (const p of group.plates) {
+        const label = p.text.length > 0 ? `"${p.text}"` : '(blank)';
+        lines.push(`      ${p.quantity}× ${p.widthU}U ${label}`);
+      }
+      lines.push('');
+    }
   }
 
   const skippedLines: string[] = [];

--- a/src/shell/layoutExport/planLabelPlateExport.test.ts
+++ b/src/shell/layoutExport/planLabelPlateExport.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { designId } from '@/core/types';
+import type { Bin } from '@/core/types';
+import { createTestBin } from '@/test/testUtils';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import type { SavedDesign, BinParams } from '@/features/bin-designer';
+import { LABEL_PLATE_HEIGHT_MM, labelPlateWidthMm } from '@/shared/constants/labelPlates';
+import { planLabelPlateExport } from './planLabelPlateExport';
+import type { LoadedDesign } from './planLayoutBinExport';
+
+const BED = 256;
+
+function socketDesign(id: string, name: string, params: Partial<BinParams> = {}): SavedDesign {
+  return {
+    id: designId(id),
+    name,
+    params: {
+      ...DEFAULT_BIN_PARAMS,
+      width: 2,
+      depth: 1,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, mode: 'socket', depth: 14 },
+      compartments: {
+        ...DEFAULT_BIN_PARAMS.compartments,
+        cols: 2,
+        rows: 1,
+        cells: [0, 1],
+        compartmentTexts: ['SCREWS', 'BOLTS'],
+      },
+      ...params,
+    },
+    thumbnail: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    exportFileNameConfig: null,
+  };
+}
+
+function linkedBin(idStr: string, overrides: Partial<Bin> = {}): Bin {
+  return createTestBin({ linkedDesignId: designId(idStr), ...overrides });
+}
+
+describe('planLabelPlateExport', () => {
+  it('ignores designs without socket-mode labels', () => {
+    const loaded: LoadedDesign[] = [
+      {
+        id: designId('d1'),
+        design: socketDesign('d1', 'Text tabs', {
+          label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+        }),
+      },
+    ];
+    const plan = planLabelPlateExport([linkedBin('d1')], loaded, BED, BED);
+    expect(plan.groups).toHaveLength(0);
+    expect(plan.totalPlates).toBe(0);
+  });
+
+  it('multiplies per-compartment plates by placed-bin quantity and collapses manifest duplicates', () => {
+    const loaded: LoadedDesign[] = [{ id: designId('d1'), design: socketDesign('d1', 'Hardware') }];
+    const bins = [
+      linkedBin('d1'),
+      { ...linkedBin('d1'), id: createTestBin({ x: 3 }).id, x: 3 },
+    ] as Bin[];
+
+    const plan = planLabelPlateExport(bins, loaded, BED, BED);
+    expect(plan.totalPlates).toBe(4);
+    expect(plan.groups).toHaveLength(1);
+    expect(plan.groups[0].manifestPlates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'SCREWS', quantity: 2 }),
+        expect.objectContaining({ text: 'BOLTS', quantity: 2 }),
+      ])
+    );
+  });
+
+  it('uses per-bin labels (falling back to the design name) for spanning sockets', () => {
+    // 4 narrow columns → no per-compartment socket fits → spanning socket.
+    const loaded: LoadedDesign[] = [
+      {
+        id: designId('d1'),
+        design: socketDesign('d1', 'Spanner', {
+          compartments: {
+            ...DEFAULT_BIN_PARAMS.compartments,
+            cols: 4,
+            rows: 1,
+            cells: [0, 1, 2, 3],
+          },
+        }),
+      },
+    ];
+    const bins = [
+      linkedBin('d1', { label: 'Nails' }),
+      { ...linkedBin('d1', { label: '' }), id: createTestBin({ x: 3 }).id, x: 3 },
+    ] as Bin[];
+
+    const plan = planLabelPlateExport(bins, loaded, BED, BED);
+    expect(plan.totalPlates).toBe(2);
+    expect(plan.groups[0].manifestPlates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Nails', quantity: 1 }),
+        expect.objectContaining({ text: 'Spanner', quantity: 1 }),
+      ])
+    );
+  });
+
+  it('packs plates within the usable bed and centers each sheet', () => {
+    const loaded: LoadedDesign[] = [{ id: designId('d1'), design: socketDesign('d1', 'Hardware') }];
+    const bins = Array.from({ length: 6 }, (_, i) => ({
+      ...linkedBin('d1'),
+      id: createTestBin({ x: i }).id,
+      x: i,
+    })) as Bin[];
+
+    const plan = planLabelPlateExport(bins, loaded, BED, BED);
+    const sheets = plan.groups[0].sheets;
+    expect(sheets.length).toBeGreaterThan(0);
+    const placed = sheets.flat();
+    expect(placed).toHaveLength(12);
+    for (const p of placed) {
+      const halfW = labelPlateWidthMm(p.widthU) / 2;
+      expect(Math.abs(p.position[0]) + halfW).toBeLessThanOrEqual(BED / 2);
+      expect(Math.abs(p.position[1]) + LABEL_PLATE_HEIGHT_MM / 2).toBeLessThanOrEqual(BED / 2);
+    }
+  });
+
+  it('splits onto multiple sheets when the bed is small', () => {
+    const loaded: LoadedDesign[] = [{ id: designId('d1'), design: socketDesign('d1', 'Hardware') }];
+    const bins = Array.from({ length: 10 }, (_, i) => ({
+      ...linkedBin('d1'),
+      id: createTestBin({ x: i }).id,
+      x: i,
+    })) as Bin[];
+
+    // Tiny 60mm bed: one 1U plate per row, few rows per sheet.
+    const plan = planLabelPlateExport(bins, loaded, 60, 60);
+    expect(plan.groups[0].sheets.length).toBeGreaterThan(1);
+    const placed = plan.groups[0].sheets.flat();
+    expect(placed).toHaveLength(20);
+  });
+});

--- a/src/shell/layoutExport/planLabelPlateExport.test.ts
+++ b/src/shell/layoutExport/planLabelPlateExport.test.ts
@@ -136,4 +136,28 @@ describe('planLabelPlateExport', () => {
     const placed = plan.groups[0].sheets.flat();
     expect(placed).toHaveLength(20);
   });
+
+  it('skips plates wider than the usable bed and reports the count', () => {
+    // Single-compartment 2U design → 2U plates (78mm). A 60mm bed has only
+    // 40mm usable width, so nothing can ship — but the skip is surfaced.
+    const loaded: LoadedDesign[] = [
+      {
+        id: designId('d1'),
+        design: socketDesign('d1', 'Wide', {
+          compartments: {
+            ...DEFAULT_BIN_PARAMS.compartments,
+            cols: 1,
+            rows: 1,
+            cells: [0],
+            compartmentTexts: ['BIG'],
+          },
+        }),
+      },
+    ];
+    const plan = planLabelPlateExport([linkedBin('d1')], loaded, 60, 60);
+    expect(plan.totalPlates).toBe(0);
+    expect(plan.groups).toHaveLength(1);
+    expect(plan.groups[0].sheets).toHaveLength(0);
+    expect(plan.groups[0].oversizedCount).toBe(1);
+  });
 });

--- a/src/shell/layoutExport/planLabelPlateExport.ts
+++ b/src/shell/layoutExport/planLabelPlateExport.ts
@@ -45,6 +45,8 @@ export interface LabelPlateDesignGroup {
   readonly textDefaults: TextStyleDefaults;
   readonly sheets: readonly (readonly PlacedLabelPlate[])[];
   readonly manifestPlates: readonly LabelPlateManifestEntry[];
+  /** Plates skipped because they are wider than the usable print bed. */
+  readonly oversizedCount: number;
 }
 
 export interface LabelPlateExportPlan {
@@ -59,8 +61,8 @@ const SHEET_GAP = 4;
 /**
  * Shelf-pack plates (already expanded to physical quantities) onto sheets of
  * `bedW × bedD` mm, widest-first so long plates anchor rows. Returns sheets
- * of centered plate positions. Plates wider than the usable bed are dropped
- * by the caller's fit test before this runs (standard widths cap at 120mm).
+ * of centered plate positions. Callers must pre-filter plates to the usable
+ * bed width — the packer places whatever it is given.
  */
 function packSheets(
   plates: readonly { widthU: LabelPlateWidthU; text: string }[],
@@ -148,12 +150,20 @@ export function planLabelPlateExport(
     // Expand to physical plates: per-compartment plates repeat per placed
     // bin; a spanning plate instead takes each bin's own label text.
     const spanning = planned.length === 1 && planned[0].compartmentId === null;
-    const physical: { widthU: LabelPlateWidthU; text: string }[] = spanning
+    const expanded: { widthU: LabelPlateWidthU; text: string }[] = spanning
       ? linkedBins.map((b) => ({
           widthU: planned[0].widthU,
           text: (b.label ?? '').trim() || design.name,
         }))
       : linkedBins.flatMap(() => planned.map((p) => ({ widthU: p.widthU, text: p.text })));
+
+    // Bed-fit guard: a plate wider than the usable bed (e.g. a 3U plate on
+    // a small printer) cannot ship on any sheet — skip it and surface the
+    // count so the manifest can say so instead of packing out of bounds.
+    const usableW = bedWidthMm - 2 * SHEET_MARGIN;
+    const physical = expanded.filter((p) => labelPlateWidthMm(p.widthU) <= usableW);
+    const oversizedCount = expanded.length - physical.length;
+    if (physical.length === 0 && oversizedCount === 0) continue;
 
     // Manifest quantities collapse identical (width, text) plates.
     const counts = new Map<string, LabelPlateManifestEntry>();
@@ -173,6 +183,7 @@ export function planLabelPlateExport(
       textDefaults: params.textDefaults,
       sheets: packSheets(physical, bedWidthMm, bedDepthMm),
       manifestPlates: [...counts.values()],
+      oversizedCount,
     });
   }
 

--- a/src/shell/layoutExport/planLabelPlateExport.ts
+++ b/src/shell/layoutExport/planLabelPlateExport.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure planning step for the swappable-label-plate half of a whole-layout
+ * export (#2666, PR 3).
+ *
+ * Enumerates socket-mode linked designs, derives their plate sets via the
+ * same plan math that cut the sockets, multiplies by placed-bin quantities
+ * (each socket wants its own plate), and shelf-packs everything onto
+ * bed-sized sheets. Sheets never mix designs — text style options ride
+ * per-request, and different designs may use different fonts/modes.
+ *
+ * Spanning-socket designs label whole bins, so their plate text comes from
+ * each placed bin's label (falling back to the design name) rather than
+ * from compartment texts.
+ */
+
+import type { Bin } from '@/core/types';
+import type { TextStyleDefaults } from '@/shared/types/bin';
+// Deep import (not the barrel): this code only runs inside the lazy
+// layout-export chunk (same rationale as planLayoutBinExport's deep imports).
+import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
+import {
+  LABEL_PLATE_HEIGHT_MM,
+  effectiveLabelSocketClearance,
+  labelPlateWidthMm,
+} from '@/shared/constants/labelPlates';
+import type { LabelPlateWidthU } from '@/shared/constants/labelPlates';
+import { planLabelPlates } from '@/shared/utils/labelSocketPlan';
+import type { LoadedDesign } from './planLayoutBinExport';
+
+/** One plate placed on a sheet, center coordinates in mm (sheet-centered). */
+export interface PlacedLabelPlate {
+  readonly widthU: LabelPlateWidthU;
+  readonly text: string;
+  readonly position: readonly [number, number];
+}
+
+export interface LabelPlateManifestEntry {
+  readonly widthU: LabelPlateWidthU;
+  readonly text: string;
+  readonly quantity: number;
+}
+
+export interface LabelPlateDesignGroup {
+  readonly designName: string;
+  readonly textDefaults: TextStyleDefaults;
+  readonly sheets: readonly (readonly PlacedLabelPlate[])[];
+  readonly manifestPlates: readonly LabelPlateManifestEntry[];
+}
+
+export interface LabelPlateExportPlan {
+  readonly groups: readonly LabelPlateDesignGroup[];
+  readonly totalPlates: number;
+}
+
+/** Border kept clear around each sheet and gap between plates (mm). */
+const SHEET_MARGIN = 10;
+const SHEET_GAP = 4;
+
+/**
+ * Shelf-pack plates (already expanded to physical quantities) onto sheets of
+ * `bedW × bedD` mm, widest-first so long plates anchor rows. Returns sheets
+ * of centered plate positions. Plates wider than the usable bed are dropped
+ * by the caller's fit test before this runs (standard widths cap at 120mm).
+ */
+function packSheets(
+  plates: readonly { widthU: LabelPlateWidthU; text: string }[],
+  bedW: number,
+  bedD: number
+): (readonly PlacedLabelPlate[])[] {
+  const usableW = bedW - 2 * SHEET_MARGIN;
+  const usableD = bedD - 2 * SHEET_MARGIN;
+  const rowPitch = LABEL_PLATE_HEIGHT_MM + SHEET_GAP;
+  const sorted = [...plates].sort((a, b) => b.widthU - a.widthU);
+
+  const sheets: PlacedLabelPlate[][] = [];
+  let current: { plates: { widthU: LabelPlateWidthU; text: string; x: number; y: number }[] } = {
+    plates: [],
+  };
+  let cursorX = 0;
+  let cursorY = 0;
+
+  const flush = (): void => {
+    if (current.plates.length === 0) return;
+    // Center the packed extent on the origin.
+    const maxX = Math.max(...current.plates.map((p) => p.x + labelPlateWidthMm(p.widthU)));
+    const maxY = Math.max(...current.plates.map((p) => p.y + LABEL_PLATE_HEIGHT_MM));
+    sheets.push(
+      current.plates.map((p) => ({
+        widthU: p.widthU,
+        text: p.text,
+        position: [
+          p.x + labelPlateWidthMm(p.widthU) / 2 - maxX / 2,
+          p.y + LABEL_PLATE_HEIGHT_MM / 2 - maxY / 2,
+        ] as const,
+      }))
+    );
+    current = { plates: [] };
+    cursorX = 0;
+    cursorY = 0;
+  };
+
+  for (const plate of sorted) {
+    const w = labelPlateWidthMm(plate.widthU);
+    if (cursorX > 0 && cursorX + w > usableW) {
+      cursorX = 0;
+      cursorY += rowPitch;
+    }
+    if (cursorY + LABEL_PLATE_HEIGHT_MM > usableD) {
+      flush();
+    }
+    current.plates.push({ widthU: plate.widthU, text: plate.text, x: cursorX, y: cursorY });
+    cursorX += w + SHEET_GAP;
+  }
+  flush();
+  return sheets;
+}
+
+export function planLabelPlateExport(
+  bins: Bin[],
+  loaded: readonly LoadedDesign[],
+  bedWidthMm: number,
+  bedDepthMm: number
+): LabelPlateExportPlan {
+  const designById = new Map(
+    loaded.filter((l) => l.design?.params).map((l) => [l.id, l.design] as const)
+  );
+
+  const groups: LabelPlateDesignGroup[] = [];
+  let totalPlates = 0;
+
+  for (const [id, design] of designById) {
+    const params = design?.params;
+    if (!design || !params) continue;
+    if (!params.label.enabled || (params.label.mode ?? 'text') !== 'socket') continue;
+
+    const linkedBins = bins.filter((b) => b.linkedDesignId === id);
+    if (linkedBins.length === 0) continue;
+
+    const clearanceMm = effectiveLabelSocketClearance(undefined, params.label.plateFitOffset);
+    const planned = planLabelPlates(
+      params.compartments,
+      binDimensions(params).innerW,
+      clearanceMm,
+      ''
+    );
+    if (planned.length === 0) continue;
+
+    // Expand to physical plates: per-compartment plates repeat per placed
+    // bin; a spanning plate instead takes each bin's own label text.
+    const spanning = planned.length === 1 && planned[0].compartmentId === null;
+    const physical: { widthU: LabelPlateWidthU; text: string }[] = spanning
+      ? linkedBins.map((b) => ({
+          widthU: planned[0].widthU,
+          text: (b.label ?? '').trim() || design.name,
+        }))
+      : linkedBins.flatMap(() => planned.map((p) => ({ widthU: p.widthU, text: p.text })));
+
+    // Manifest quantities collapse identical (width, text) plates.
+    const counts = new Map<string, LabelPlateManifestEntry>();
+    for (const p of physical) {
+      const key = `${p.widthU}|${p.text}`;
+      const existing = counts.get(key);
+      if (existing) {
+        counts.set(key, { ...existing, quantity: existing.quantity + 1 });
+      } else {
+        counts.set(key, { widthU: p.widthU, text: p.text, quantity: 1 });
+      }
+    }
+
+    totalPlates += physical.length;
+    groups.push({
+      designName: design.name,
+      textDefaults: params.textDefaults,
+      sheets: packSheets(physical, bedWidthMm, bedDepthMm),
+      manifestPlates: [...counts.values()],
+    });
+  }
+
+  return { groups, totalPlates };
+}

--- a/src/shell/layoutExport/useLayoutExport.ts
+++ b/src/shell/layoutExport/useLayoutExport.ts
@@ -42,7 +42,12 @@ import {
 import { getLinkedDesignIds } from '@/features/design-linking';
 import { planLayoutBinExport } from './planLayoutBinExport';
 import type { LoadedDesign } from './planLayoutBinExport';
+import { planLabelPlateExport } from './planLabelPlateExport';
+import { dedupeFileNames } from './dedupeFileNames';
+import { snapTextDepthToLayers } from '@/shared/constants/labelPlates';
+import type { LabelPlateExportSpec } from '@/shared/generation/bridge';
 import { buildLayoutManifest } from './buildLayoutManifest';
+import type { ManifestLabelGroup } from './buildLayoutManifest';
 
 type Progress = { current: number; total: number; label?: string } | null;
 
@@ -255,6 +260,81 @@ export function useLayoutExport(): UseLayoutExportReturn {
           setExportProgress({ current: done, total: binTotal, label: binLabel(done) });
         }
 
+        // Phase 1.7 — swappable label plates for socket-mode designs (#2666):
+        // per-design bed-sized sheets in labels/. A plate failure must not
+        // lose a good bin export, so it degrades to an archive without labels.
+        const platePlan = planLabelPlateExport(
+          bins,
+          loaded,
+          layout.printBedSize,
+          layout.printBedDepth ?? layout.printBedSize
+        );
+        const labelFiles: ZipBinaryFile[] = [];
+        const manifestLabels: ManifestLabelGroup[] = [];
+        if (platePlan.totalPlates > 0) {
+          try {
+            const sheetNames = dedupeFileNames(
+              platePlan.groups.flatMap((g) =>
+                g.sheets.map(
+                  (_, si) =>
+                    `${
+                      g.designName
+                        .toLowerCase()
+                        .replace(/[^a-z0-9]+/g, '-')
+                        .replace(/^-+|-+$/g, '') || 'design'
+                    }_plates_${si + 1}.${format}`
+                )
+              )
+            );
+            let nameIndex = 0;
+            const sheetTotal = platePlan.groups.reduce((sum, g) => sum + g.sheets.length, 0);
+            for (const group of platePlan.groups) {
+              const options = {
+                textMode:
+                  group.textDefaults.mode === 'emboss' ? ('emboss' as const) : ('deboss' as const),
+                textDepthMm: snapTextDepthToLayers(
+                  group.textDefaults.depth,
+                  printSettings.layerHeightMm
+                ),
+                textDefaults: group.textDefaults,
+                v1Channels: true,
+              };
+              const sheetPaths: string[] = [];
+              for (const sheet of group.sheets) {
+                setExportProgress({
+                  current: nameIndex,
+                  total: sheetTotal,
+                  label: t('layoutExport.progress.labels', {
+                    current: nameIndex + 1,
+                    total: sheetTotal,
+                  }),
+                });
+                const path = `labels/${sheetNames[nameIndex++]}`;
+                const specs: LabelPlateExportSpec[] = sheet.map((p) => ({
+                  widthU: p.widthU,
+                  text: p.text,
+                  position: p.position,
+                }));
+                const result = await bridge.exportLabelPlates(specs, options, workerFormat);
+                const data =
+                  format === '3mf'
+                    ? await stlTo3mf(result.data, baseNameOf(path), printSettings)
+                    : result.data;
+                labelFiles.push({ path, data });
+                sheetPaths.push(path);
+              }
+              manifestLabels.push({
+                designName: group.designName,
+                sheetPaths,
+                plates: group.manifestPlates,
+              });
+            }
+          } catch {
+            labelFiles.length = 0;
+            manifestLabels.length = 0;
+          }
+        }
+
         // Phase 2 — baseplate. A baseplate failure (e.g. a degenerate drawer)
         // must not lose a good bin export, so it degrades to a bins-only archive.
         const bp = await buildBaseplateExportPieces(bridge, pool, {
@@ -301,6 +381,7 @@ export function useLayoutExport(): UseLayoutExportReturn {
         // Assemble the archive.
         const binaryFiles: ZipBinaryFile[] = [
           ...binFiles,
+          ...labelFiles,
           ...(bp
             ? bp.pieces.map((p) => ({
                 path: `baseplate/${p.label ? `${bp.baseNameNoExt}_${p.label}` : bp.baseNameNoExt}${bp.extension}`,
@@ -319,6 +400,7 @@ export function useLayoutExport(): UseLayoutExportReturn {
                 guidePath: bp.guideText ? 'baseplate/print-guide.txt' : undefined,
               }
             : null,
+          labels: manifestLabels.length > 0 ? manifestLabels : null,
           skipped: plan.skipped,
           totals: plan.totals,
         });

--- a/src/shell/layoutExport/useLayoutExport.ts
+++ b/src/shell/layoutExport/useLayoutExport.ts
@@ -271,7 +271,7 @@ export function useLayoutExport(): UseLayoutExportReturn {
         );
         const labelFiles: ZipBinaryFile[] = [];
         const manifestLabels: ManifestLabelGroup[] = [];
-        if (platePlan.totalPlates > 0) {
+        if (platePlan.groups.length > 0) {
           try {
             const sheetNames = dedupeFileNames(
               platePlan.groups.flatMap((g) =>
@@ -287,7 +287,13 @@ export function useLayoutExport(): UseLayoutExportReturn {
               )
             );
             let nameIndex = 0;
+            let sheetsDone = 0;
             const sheetTotal = platePlan.groups.reduce((sum, g) => sum + g.sheets.length, 0);
+            const sheetLabel = (current: number): string =>
+              t('layoutExport.progress.labels', { current, total: sheetTotal });
+            if (sheetTotal > 0) {
+              setExportProgress({ current: 0, total: sheetTotal, label: sheetLabel(0) });
+            }
             for (const group of platePlan.groups) {
               const options = {
                 textMode:
@@ -301,14 +307,6 @@ export function useLayoutExport(): UseLayoutExportReturn {
               };
               const sheetPaths: string[] = [];
               for (const sheet of group.sheets) {
-                setExportProgress({
-                  current: nameIndex,
-                  total: sheetTotal,
-                  label: t('layoutExport.progress.labels', {
-                    current: nameIndex + 1,
-                    total: sheetTotal,
-                  }),
-                });
                 const path = `labels/${sheetNames[nameIndex++]}`;
                 const specs: LabelPlateExportSpec[] = sheet.map((p) => ({
                   widthU: p.widthU,
@@ -322,11 +320,18 @@ export function useLayoutExport(): UseLayoutExportReturn {
                     : result.data;
                 labelFiles.push({ path, data });
                 sheetPaths.push(path);
+                sheetsDone++;
+                setExportProgress({
+                  current: sheetsDone,
+                  total: sheetTotal,
+                  label: sheetLabel(sheetsDone),
+                });
               }
               manifestLabels.push({
                 designName: group.designName,
                 sheetPaths,
                 plates: group.manifestPlates,
+                oversizedCount: group.oversizedCount,
               });
             }
           } catch {


### PR DESCRIPTION
PR 3 of #2666 — the final slice: the whole-layout ZIP export gains a `labels/` folder with every swappable label plate the layout's socket-mode bins need, packed onto bed-sized sheets.

## What's in here

**Pure sheet planner** (`planLabelPlateExport.ts`, mirroring `planLayoutBinExport`'s pure-planning pattern): enumerates socket-mode linked designs, derives each design's plate set via the same `planLabelPlates` math that cut its sockets, and expands to physical quantities — every placed bin's socket wants its own plate, so per-compartment plates multiply by bin count, while **spanning-socket designs take each placed bin's own label text** (falling back to the design name), which is the "bin labels" half of the issue's text sourcing. Identical (width, text) plates collapse in the manifest listing with quantities.

**Shelf packing**: widest-first rows inside a 10mm bed border with 4mm gaps, wrapping to new sheets when the bed depth runs out; each sheet's extent is centered. Sheets never mix designs — text style options (font, emboss/deboss, layer-snapped depth) ride per worker request and can differ per design.

**Worker**: `LabelPlateExportSpec` gains an optional `position` (mm, plate center); the builder places packed sheets or falls back to the existing single-column layout. Covered by a kernel test asserting placed bounding-box centers.

**Orchestration** (`useLayoutExport`): a new phase between bins and baseplate exports one file per sheet (`labels/<design>_plates_N.<format>`, deduped via `dedupeFileNames`), with progress reporting and the same failure containment as the baseplate — a plate failure degrades to an archive without labels rather than losing a good bin export. The manifest gains a "Label plates" section: per-design sheet paths plus `N× 2U "TEXT"` quantity lines and the filament-swap note.

Also: `snapTextDepthToLayers` moved from the PR 2 hook to `shared/constants/labelPlates.ts` (the layout exporter is a second consumer); the hook re-exports it.

## Verification

- Planner tests: socket-mode filtering, quantity multiplication, manifest dedupe, spanning per-bin labels with design-name fallback, packing stays within bed bounds on a 256mm bed, multi-sheet split on a 60mm bed.
- Manifest section rendering + omission tests; worker sheet-position kernel test.
- `pnpm run quality` clean, boundaries clean, i18n parity across all 10 locales, full suite green locally.

Completes the #2666 MVP. Remaining follow-ups tracked there: fit-calibration coupon, `paint_color` zones for plates, hardware icons, physical click-fit verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds batch export of swappable label plates to the whole-layout ZIP for #2666. Packs per‑design plates onto bed‑sized sheets in `labels/`, updates the manifest, skips oversized plates, and doesn’t block the export if plate generation fails.

- New Features
  - Planner (`planLabelPlateExport.ts`): enumerates socket‑mode designs, multiplies per‑compartment plates by placed‑bin count, and for spanning sockets uses each bin’s label text (fallback to design name). Collapses identical (width, text) plates and skips plates wider than the usable bed, surfacing the skipped count.
  - Packing + Worker: per‑design sheets with centered plate positions; no mixed designs. Worker `LabelPlateExportSpec` accepts `position` to place packed plates; keeps single‑column default when absent.
  - Orchestration (`useLayoutExport`): exports one file per sheet (`labels/<design>_plates_N.<format>`), names deduped via `dedupeFileNames`, progress via `layoutExport.progress.labels` (1‑based like bins/baseplate), and failure containment (labels omitted instead of failing the whole export).
  - Manifest: adds a “Label plates” section with per‑design sheet paths and quantity lines (e.g., `2× 1U "SCREWS"`, `1× 2U (blank)`), plus a note when oversized plates were skipped.

- Refactors
  - Moved `snapTextDepthToLayers` to `shared/constants/labelPlates.ts` and re‑exported from the hook.

<sup>Written for commit 10c398838cf78b55c57082212d79d1c3623cbdde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

