### PR TITLE
fix(designer): flare v1-compat channel ends on 1U label plates (#2666)

### DIFF
--- a/src/features/generation/worker/generators/labelPlateBuilder.test.ts
+++ b/src/features/generation/worker/generators/labelPlateBuilder.test.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, it, expect, beforeAll } from 'vitest';
-import { isErr, loadFont, mesh } from 'brepjs';
+import { isErr, isOk, loadFont, measureVolume, mesh } from 'brepjs';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { boundingBox } from './__kernel-tests__/meshAssertions';
 import { DEFAULT_TEXT_STYLE_DEFAULTS } from '@/features/bin-designer/types/text';
@@ -51,6 +51,28 @@ describe('labelPlateBuilder', () => {
     expect(bbox.maxY - bbox.minY).toBeCloseTo(LABEL_PLATE_HEIGHT_MM, 1);
     expect(bbox.maxZ - bbox.minZ).toBeCloseTo(LABEL_PLATE_THICKNESS_MM, 1);
     expect(bbox.minZ).toBeCloseTo(0, 3);
+  });
+
+  it('flares the v1 channel ends with the standard r0.5 lead-in', () => {
+    const withChannels = buildLabelPlate({ widthU: 1, text: '' }, OPTS);
+    const without = buildLabelPlate({ widthU: 1, text: '' }, { ...OPTS, v1Channels: false });
+    try {
+      const volOf = (s: typeof withChannels): number => {
+        const r = measureVolume(s);
+        if (!isOk(r)) throw new Error('measureVolume failed');
+        return r.value;
+      };
+      const removed = volOf(without) - volOf(withChannels);
+      // Sharp T-channels remove exactly 3 × (1.0·0.2·11 + 2.0·0.6·10.6)
+      // = 44.76mm³; the four r0.5 end flares per layer add
+      // 3 × 4 × (1−π/4)·0.5² × (0.2 + 0.6) ≈ 0.52mm³ on top. A sharp-cornered
+      // regression lands at 44.76 and fails the lower bound.
+      expect(removed).toBeGreaterThan(45.1);
+      expect(removed).toBeLessThan(45.45);
+    } finally {
+      withChannels.delete();
+      without.delete();
+    }
   });
 
   it('builds 2U and 3U plates without v1 channels', () => {

--- a/src/features/generation/worker/generators/labelPlateBuilder.ts
+++ b/src/features/generation/worker/generators/labelPlateBuilder.ts
@@ -74,6 +74,43 @@ const PLATE_GAP = 4;
 /** Keep text clear of the latch flanges. */
 const TEXT_MARGIN = 1.6;
 
+/**
+ * Plan-view cutter for one v1 channel layer: a slot of width `w` centered at
+ * `cx` spanning ±`flareY`, flaring outward with radius `r` at both ends and
+ * continuing at the flared width to ±`earY` (past the plate, so the cut
+ * always exits cleanly). The flare reproduces the r0.5 segment-corner
+ * rounding of the standard's v1 plate.
+ */
+function flaredSlot(cx: number, w: number, flareY: number, earY: number, r: number): Drawing {
+  // The ear must extend past the fillet tangent point (which sits exactly r
+  // from the wall) or the corner fillet consumes its whole neighbor segment
+  // and degenerates. The slack region only ever overlaps already-void space
+  // (outside the plate / inside the latch groove).
+  const slack = r;
+  const wallR = cx + w / 2;
+  const earR = wallR + r + slack;
+  const wallL = cx - w / 2;
+  const earL = wallL - r - slack;
+  return draw([cx, -earY])
+    .lineTo([earR, -earY])
+    .lineTo([earR, -flareY])
+    .lineTo([wallR, -flareY])
+    .customCorner(r)
+    .lineTo([wallR, flareY])
+    .customCorner(r)
+    .lineTo([earR, flareY])
+    .lineTo([earR, earY])
+    .lineTo([earL, earY])
+    .lineTo([earL, flareY])
+    .lineTo([wallL, flareY])
+    .customCorner(r)
+    .lineTo([wallL, -flareY])
+    .customCorner(r)
+    .lineTo([earL, -flareY])
+    .lineTo([earL, -earY])
+    .close();
+}
+
 function roundedRect(w: number, h: number, r: number): Drawing {
   const x0 = -w / 2;
   const x1 = w / 2;
@@ -126,26 +163,39 @@ export function buildLabelPlate(spec: LabelPlateSpec, opts: LabelPlateBuildOptio
     const ring = scope.register(unwrap(cut(outerBand as ValidSolid, innerBand as ValidSolid)));
     solid = scope.register(unwrap(cut(solid as ValidSolid, ring)));
 
-    // v1 backward-compat channels (1U only): T-profile in the XZ plane cut
-    // through the full plate depth. Mouth at the bottom face widening into
-    // the cavity — the profile the legacy sockets' bottom tabs ride in.
+    // v1 backward-compat channels (1U only): the profile the legacy sockets'
+    // bottom tabs ride in — a narrow mouth at the bottom face widening into
+    // the cavity. Cut as two stacked plan-view prisms per channel so the
+    // channel ends can flare r0.5 like the standard's rounded segments
+    // (Cullenect.scad builds the v1 plate from RoundedCubes; the flare
+    // doubles as a lead-in for the tabs). The mouth spans the full plate
+    // depth and flares at the outline; the cavity ends at the latch inset
+    // and flares there, opening into the perimeter latch groove.
     if (opts.v1Channels && spec.widthU === 1) {
-      const cutters = LABEL_PLATE_V1_CHANNEL_XS_MM.map((cx) => {
-        const mouthHalf = LABEL_PLATE_V1_MOUTH_WIDTH_MM / 2;
-        const cavityHalf = LABEL_PLATE_V1_CAVITY_WIDTH_MM / 2;
-        const profile = draw([cx - mouthHalf, -COPLANAR_MARGIN])
-          .lineTo([cx - mouthHalf, LABEL_PLATE_V1_MOUTH_HEIGHT_MM])
-          .lineTo([cx - cavityHalf, LABEL_PLATE_V1_MOUTH_HEIGHT_MM])
-          .lineTo([cx - cavityHalf, LABEL_PLATE_V1_CAVITY_TOP_MM])
-          .lineTo([cx + cavityHalf, LABEL_PLATE_V1_CAVITY_TOP_MM])
-          .lineTo([cx + cavityHalf, LABEL_PLATE_V1_MOUTH_HEIGHT_MM])
-          .lineTo([cx + mouthHalf, LABEL_PLATE_V1_MOUTH_HEIGHT_MM])
-          .lineTo([cx + mouthHalf, -COPLANAR_MARGIN])
-          .close();
-        const prism = sketch(profile, 'XZ', -(h / 2 + COPLANAR_MARGIN)).extrude(
-          h + 2 * COPLANAR_MARGIN
-        );
-        return scope.register(prism);
+      const flareR = LABEL_PLATE_CORNER_RADIUS_MM;
+      const earY = h / 2 + COPLANAR_MARGIN;
+      const cutters = LABEL_PLATE_V1_CHANNEL_XS_MM.flatMap((cx) => {
+        // The mouth prism runs up to the cavity top: its plan silhouette is
+        // strictly inside the cavity's, so everything above the mouth zone
+        // is already removed by the cavity cut — no separate top margin
+        // needed, and the mouth/cavity boundary can't leave a coplanar seam.
+        const mouth = sketch(
+          flaredSlot(cx, LABEL_PLATE_V1_MOUTH_WIDTH_MM, h / 2, earY, flareR),
+          'XY',
+          -COPLANAR_MARGIN
+        ).extrude(LABEL_PLATE_V1_CAVITY_TOP_MM + COPLANAR_MARGIN);
+        const cavity = sketch(
+          flaredSlot(
+            cx,
+            LABEL_PLATE_V1_CAVITY_WIDTH_MM,
+            h / 2 - LABEL_PLATE_LATCH_INSET_MM,
+            earY,
+            flareR
+          ),
+          'XY',
+          LABEL_PLATE_V1_MOUTH_HEIGHT_MM
+        ).extrude(LABEL_PLATE_V1_CAVITY_TOP_MM - LABEL_PLATE_V1_MOUTH_HEIGHT_MM);
+        return [scope.register(mouth), scope.register(cavity)];
       });
       solid = scope.register(unwrap(cutAll(solid as ValidSolid, cutters as ValidSolid[])));
     }


### PR DESCRIPTION
Follow-up from #2666 noted in PR #2673: the v1-compat channels on 1U plates were sharp-cornered; the standard rounds them.

## What's in here

`Cullenect.scad` builds the v1 plate as a union of r0.5 `RoundedCube` segments, so the channels between segments flare open at their ends. Our subtractive T-prisms (XZ profile, full-depth extrude) reproduced the straight walls but left the ends square.

The channels now cut as two stacked plan-view prisms per channel (`flaredSlot`, drawn with `customCorner` fillets — no 3D fillet ops):
- **Mouth** (1.0mm, bottom layer) flares r0.5 at the plate outline, matching the bottom segments' corners.
- **Cavity** (2.0mm, mid layer) ends and flares at the latch inset (±5.3mm), matching the inset mid segments — opening into the perimeter latch groove exactly like the standard.
- The mouth prism runs up to the cavity top; its plan silhouette is strictly inside the cavity's, so the stacked pair is exactly the old T-profile plus flares (no coplanar seams).

Channel positions, widths, and straight-wall geometry are unchanged — this only rounds the ends, which doubles as a lead-in for the legacy sockets' tabs.

## Verification

- New volume-pinned kernel test: channels remove 3 × (mouth + cavity) + the analytic flare volume (≈45.3mm³); a sharp-cornered regression measures 44.76 and fails the lower bound.
- All existing plate tests (footprint, latch, text, layout, STL) green; the fit-calibration card scenario (watertight STL including a v1-channel plate) green against the new geometry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flared the v1-compat channel ends on 1U label plates to match the standard’s r0.5 rounded segments and improve tab lead-in. Only the end geometry changes; channel positions, widths, and straight walls stay the same.

- **Bug Fixes**
  - Replaced the full-depth T-prism with stacked plan-view cutters: `flaredSlot` mouth (flares at the plate outline) and cavity (flares at the latch inset), both with r0.5 ends.
  - Added a volume-pinned test using `measureVolume` from `brepjs` to catch sharp-corner regressions; all existing plate tests remain green.

<sup>Written for commit d867b0e9337953c993ef85e1c4e719b1f4cd1e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

