### PR TITLE
fix(designer): correct magnetic lid geometry and panel layout (#2694)

### DIFF
--- a/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
@@ -194,8 +194,121 @@ export function LidSection() {
       </div>
 
       {/* Attachment method (#2694) — how the lid retains onto the bin. One of
-          friction / click rails / magnetic; the sub-controls below key off it. */}
+          friction / click rails / magnetic. The mode's own controls render
+          directly below so they stay next to the selector. */}
       <AttachmentSelector value={state.attachment} onChange={handlers.setAttachment} t={t} />
+
+      {/* Magnetic retention (#2694) — dedicated corner magnets bond the lid to
+          the bin. Independent of the bin's base magnets. */}
+      {state.attachment === 'magnetic' && (
+        <div className="space-y-2">
+          <StepperField
+            label={t('binDesigner.lid.retentionMagnetDiameter')}
+            unit="mm"
+            value={state.retentionMagnetDiameter}
+            onChange={handlers.setRetentionMagnetDiameter}
+            onStep={(delta) =>
+              handlers.setRetentionMagnetDiameter(
+                state.retentionMagnetDiameter + delta * state.retentionMagnetStep
+              )
+            }
+            min={state.retentionMagnetDiameterMin}
+            max={state.retentionMagnetDiameterMax}
+            step={state.retentionMagnetStep}
+            size="md"
+            aria-label={t('binDesigner.lid.retentionMagnetDiameterAria')}
+            commitMode="deferred"
+          />
+          <StepperField
+            label={t('binDesigner.lid.retentionMagnetDepth')}
+            unit="mm"
+            value={state.retentionMagnetDepth}
+            onChange={handlers.setRetentionMagnetDepth}
+            onStep={(delta) =>
+              handlers.setRetentionMagnetDepth(
+                state.retentionMagnetDepth + delta * state.retentionMagnetStep
+              )
+            }
+            min={state.retentionMagnetDepthMin}
+            max={state.retentionMagnetDepthMax}
+            step={state.retentionMagnetStep}
+            size="md"
+            aria-label={t('binDesigner.lid.retentionMagnetDepthAria')}
+            commitMode="deferred"
+          />
+          <p className="ml-1 text-[11px] leading-relaxed text-content-tertiary">
+            {t('binDesigner.lid.retentionMagnetHint', {
+              diameter: state.retentionMagnetDiameter.toFixed(1),
+              depth: state.retentionMagnetDepth.toFixed(1),
+            })}
+          </p>
+        </div>
+      )}
+
+      {/* Click rails — per-side. Each chip is an independent toggle: a
+          user can ship a hinge-feel lid (one side only), a label-tab-
+          friendly L+R pair, or all four for symmetric snap. When a feature
+          conflict disables a side (label tab on back, wall cutout/handle on a
+          given side) the chip is greyed out with a tooltip — the user's
+          persisted intent is kept so the rail returns when the conflict is
+          resolved. Only shown in click-rails attachment mode. */}
+      {state.attachment === 'clickRails' && (
+        <div>
+          <span className="mb-1 block text-xs font-medium text-content-secondary">
+            {t('binDesigner.lid.clickRails')}
+          </span>
+          <div className="flex gap-1">
+            {LID_RAIL_SIDES.map((side) => {
+              const isActive = state.clickRails[side];
+              const isAutoDisabled = state.disabledRails.has(side);
+              const effectiveActive = isActive && !isAutoDisabled;
+              const tooltip = isAutoDisabled
+                ? t('binDesigner.lid.clickRailDisabledBySide', {
+                    side: t(`binDesigner.lid.side.${side}`),
+                  })
+                : undefined;
+              return (
+                <Button
+                  key={side}
+                  type="button"
+                  variant="ghost"
+                  role="switch"
+                  aria-checked={effectiveActive}
+                  aria-disabled={isAutoDisabled}
+                  disabled={isAutoDisabled}
+                  title={tooltip}
+                  onClick={() => handlers.toggleClickRailSide(side)}
+                  className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
+                    isAutoDisabled
+                      ? 'cursor-not-allowed border border-stroke-subtle bg-surface-secondary text-content-tertiary line-through opacity-60'
+                      : effectiveActive
+                        ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
+                        : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
+                  }`}
+                >
+                  {t(`binDesigner.lid.side.${side}`)}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {state.attachment === 'clickRails' && state.anyRail && (
+        <div className="space-y-1">
+          <SnappingSlider
+            label={t('binDesigner.lid.clickRailCoverage')}
+            value={state.clickRailCoverage}
+            onChange={handlers.setClickRailCoverage}
+            options={state.railCoverageOptions}
+            unit="%"
+          />
+          <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
+            <RulerIcon size="xs" />
+            <span className="tabular-nums">{state.railsReadout}</span>
+          </div>
+        </div>
+      )}
 
       {/* Extra lid height (issue #2482) — deepens the lid cavity above the
           bin's lip so contents that stick up out of a short bin (toothpicks,
@@ -314,120 +427,6 @@ export function LidSection() {
             aria-label={t('binDesigner.lid.trayWallAria')}
             commitMode="deferred"
           />
-        </div>
-      )}
-
-      {/* Magnetic retention (#2694) — dedicated corner magnets bond the lid to
-          the bin. Independent of the bin's base magnets. */}
-      {state.attachment === 'magnetic' && (
-        <div className="space-y-2">
-          <StepperField
-            label={t('binDesigner.lid.retentionMagnetDiameter')}
-            unit="mm"
-            value={state.retentionMagnetDiameter}
-            onChange={handlers.setRetentionMagnetDiameter}
-            onStep={(delta) =>
-              handlers.setRetentionMagnetDiameter(
-                state.retentionMagnetDiameter + delta * state.retentionMagnetStep
-              )
-            }
-            min={state.retentionMagnetDiameterMin}
-            max={state.retentionMagnetDiameterMax}
-            step={state.retentionMagnetStep}
-            size="md"
-            aria-label={t('binDesigner.lid.retentionMagnetDiameterAria')}
-            commitMode="deferred"
-          />
-          <StepperField
-            label={t('binDesigner.lid.retentionMagnetDepth')}
-            unit="mm"
-            value={state.retentionMagnetDepth}
-            onChange={handlers.setRetentionMagnetDepth}
-            onStep={(delta) =>
-              handlers.setRetentionMagnetDepth(
-                state.retentionMagnetDepth + delta * state.retentionMagnetStep
-              )
-            }
-            min={state.retentionMagnetDepthMin}
-            max={state.retentionMagnetDepthMax}
-            step={state.retentionMagnetStep}
-            size="md"
-            aria-label={t('binDesigner.lid.retentionMagnetDepthAria')}
-            commitMode="deferred"
-          />
-          <p className="ml-1 text-[11px] leading-relaxed text-content-tertiary">
-            {t('binDesigner.lid.retentionMagnetHint', {
-              diameter: state.retentionMagnetDiameter.toFixed(1),
-              depth: state.retentionMagnetDepth.toFixed(1),
-            })}
-          </p>
-        </div>
-      )}
-
-      {/* Click rails — per-side. Each chip is an independent toggle: a
-          user can ship a hinge-feel lid (one side only), a label-tab-
-          friendly L+R pair, or all four for symmetric snap. All four off
-          ⇒ friction-fit lid (mating cavity still wraps the lip; no
-          positive snap). When a feature conflict disables a side (label
-          tab on back, wall cutout/handle on a given side) the chip is
-          greyed out with a tooltip — the user's persisted intent is
-          kept so the rail returns when the conflict is resolved. Only shown
-          in click-rails attachment mode. */}
-      {state.attachment === 'clickRails' && (
-        <div>
-          <span className="mb-1 block text-xs font-medium text-content-secondary">
-            {t('binDesigner.lid.clickRails')}
-          </span>
-          <div className="flex gap-1">
-            {LID_RAIL_SIDES.map((side) => {
-              const isActive = state.clickRails[side];
-              const isAutoDisabled = state.disabledRails.has(side);
-              const effectiveActive = isActive && !isAutoDisabled;
-              const tooltip = isAutoDisabled
-                ? t('binDesigner.lid.clickRailDisabledBySide', {
-                    side: t(`binDesigner.lid.side.${side}`),
-                  })
-                : undefined;
-              return (
-                <Button
-                  key={side}
-                  type="button"
-                  variant="ghost"
-                  role="switch"
-                  aria-checked={effectiveActive}
-                  aria-disabled={isAutoDisabled}
-                  disabled={isAutoDisabled}
-                  title={tooltip}
-                  onClick={() => handlers.toggleClickRailSide(side)}
-                  className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                    isAutoDisabled
-                      ? 'cursor-not-allowed border border-stroke-subtle bg-surface-secondary text-content-tertiary line-through opacity-60'
-                      : effectiveActive
-                        ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
-                        : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-                  }`}
-                >
-                  {t(`binDesigner.lid.side.${side}`)}
-                </Button>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      {state.attachment === 'clickRails' && state.anyRail && (
-        <div className="space-y-1">
-          <SnappingSlider
-            label={t('binDesigner.lid.clickRailCoverage')}
-            value={state.clickRailCoverage}
-            onChange={handlers.setClickRailCoverage}
-            options={state.railCoverageOptions}
-            unit="%"
-          />
-          <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
-            <RulerIcon size="xs" />
-            <span className="tabular-nums">{state.railsReadout}</span>
-          </div>
         </div>
       )}
     </FeatureToggle>

--- a/src/features/bin-designer/utils/lidCompatibility.test.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.test.ts
@@ -640,6 +640,19 @@ describe('checkLidCompatibility — magnetic attachment (#2694)', () => {
     expect(issue?.severity).toBe('warning');
   });
 
+  it('blocks when the bin is too small to fit corner magnets', () => {
+    // A 0.5-unit-wide bin (half-width 10.5mm) can't hold the 6mm magnet's
+    // corner pads (need >= 5 + diameter = 11mm half-extent).
+    const params = magnetic({ width: 0.5 }, { retentionMagnet: { diameter: 6, depth: 2 } });
+    const issue = checkLidCompatibility(params).find((i) => i.id === 'magnetBinTooSmall');
+    expect(issue?.severity).toBe('blocker');
+  });
+
+  it('does not flag a normal 2x2 bin as too small', () => {
+    const params = magnetic({ width: 2, depth: 2 });
+    expect(checkLidCompatibility(params).some((i) => i.id === 'magnetBinTooSmall')).toBe(false);
+  });
+
   it('blocks when the retention magnet is deeper than the bin interior', () => {
     const params = magnetic({ height: 1 }, { retentionMagnet: { diameter: 6, depth: 6 } });
     const issues = checkLidCompatibility(params);

--- a/src/features/bin-designer/utils/lidCompatibility.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.ts
@@ -50,7 +50,8 @@ export type LidCompatibilityId =
   | 'topDownCutoutsAtLip'
   // Magnetic-retention (#2694) specific:
   | 'magnetsPolygonUnsupported'
-  | 'magnetTooDeepForBin';
+  | 'magnetTooDeepForBin'
+  | 'magnetBinTooSmall';
 
 export interface LidCompatibilityIssue {
   readonly id: LidCompatibilityId;
@@ -77,6 +78,16 @@ const TALL_LID_LEVERAGE_WARN_MM = 10;
  * constant across the feature boundary — the two must stay in sync by hand.
  */
 const MAGNET_POST_MIN_FLOOR = 0.6;
+
+/**
+ * Local mirrors of the worker's `LID_MAGNET_LIP_CLEARANCE` (3.5) and
+ * `LID_MAGNET_BOSS_WALL` (1.5), used to reject bins too small to place the four
+ * corner magnets. Duplicated as literals to avoid importing worker-side
+ * geometry constants across the feature boundary — keep in sync by hand with
+ * `retentionMagnetGeometry.ts` / `lidConstants.ts`.
+ */
+const MAGNET_LIP_CLEARANCE = 3.5;
+const MAGNET_BOSS_WALL = 1.5;
 
 /**
  * Interior wall height available for handle holes (mm). Mirrors the
@@ -294,16 +305,31 @@ export function checkLidCompatibility(params: BinParams): readonly LidCompatibil
     if (isPolygon) {
       issues.push({ id: 'magnetsPolygonUnsupported', severity: 'warning' });
     } else {
-      // The bin post houses the magnet between the lip top and a retaining
-      // floor. If the magnet is deeper than the interior can hold (minus a
-      // thin floor), the pocket would punch through the bin floor — blocker
-      // when it can't fit at all, warning when the floor gets marginal.
-      const interiorHeight = computeInteriorHeight(params);
-      const depth = params.lid.retentionMagnet.depth;
-      if (depth >= interiorHeight) {
-        issues.push({ id: 'magnetTooDeepForBin', severity: 'blocker' });
-      } else if (interiorHeight - depth < MAGNET_POST_MIN_FLOOR) {
-        issues.push({ id: 'magnetTooDeepForBin', severity: 'warning' });
+      const diameter = params.lid.retentionMagnet.diameter;
+      // XY bounds: the four corner pads are inset from each edge by
+      // `MAGNET_LIP_CLEARANCE + bossRadius`, and opposite pads must not overlap
+      // through the centre. That needs each half-extent >= inset + magnetRadius
+      // = MAGNET_LIP_CLEARANCE + MAGNET_BOSS_WALL + diameter. A too-small bin
+      // can't place the magnets at all — blocker.
+      const gridUnitMmY = params.gridUnitMmY ?? params.gridUnitMm;
+      const minHalfMm = MAGNET_LIP_CLEARANCE + MAGNET_BOSS_WALL + diameter;
+      const tooSmall =
+        (params.width * params.gridUnitMm) / 2 < minHalfMm ||
+        (params.depth * gridUnitMmY) / 2 < minHalfMm;
+      if (tooSmall) {
+        issues.push({ id: 'magnetBinTooSmall', severity: 'blocker' });
+      } else {
+        // Z bounds: the pad houses the magnet between the (recessed) lip top and
+        // a retaining floor. If the magnet is deeper than the interior can hold
+        // (minus a thin floor), the pocket would punch through the bin floor —
+        // blocker when it can't fit at all, warning when the floor gets marginal.
+        const interiorHeight = computeInteriorHeight(params);
+        const depth = params.lid.retentionMagnet.depth;
+        if (depth >= interiorHeight) {
+          issues.push({ id: 'magnetTooDeepForBin', severity: 'blocker' });
+        } else if (interiorHeight - depth < MAGNET_POST_MIN_FLOOR) {
+          issues.push({ id: 'magnetTooDeepForBin', severity: 'warning' });
+        }
       }
     }
   }

--- a/src/features/generation/worker/generators/lidConstants.ts
+++ b/src/features/generation/worker/generators/lidConstants.ts
@@ -158,12 +158,13 @@ export const LID_COPLANAR_MARGIN = 0.1;
 export const LID_MAGNET_BOSS_WALL = 1.5;
 
 /**
- * Extra inset (mm) of each corner post from the nominal grid corner, on top of
- * the boss radius. Keeps the post's outer edge inside the clearance-reduced
- * outer wall (~0.25mm/side) so the bin/lid footprint stays drawer-safe — the
- * "inward" placement decision from #2694.
+ * Radial gap (mm) kept between the lid's magnet boss and the stacking lip's
+ * inner face. The magnet centre is inset from the nominal corner by
+ * `LID_MAGNET_LIP_CLEARANCE + bossRadius`, so the boss hangs into the bin mouth
+ * clear of the lip when the lid seats, and the footprint stays drawer-safe (the
+ * magnets sit well inboard of every wall).
  */
-export const LID_MAGNET_EDGE_INSET = 0.6;
+export const LID_MAGNET_LIP_CLEARANCE = 3.5;
 
 /**
  * Vertical gap (mm) left between the lid boss's bottom face and the bin post's

--- a/src/features/generation/worker/generators/lidRetentionMagnets.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidRetentionMagnets.scenario.test.ts
@@ -55,14 +55,37 @@ describe('magnetic-retention lid geometry', () => {
     assertStructurallyValid(result!, '1x1 magnetic lid');
   });
 
-  it('grows corner posts on the mating bin', async () => {
+  it('grows corner gusset pads on the mating bin', async () => {
     const generateBin = getGenerateBin();
     const base = { width: 2, depth: 2, height: 3 };
     const plain = generateBin(makeParams({ attachment: 'clickRails' }, base));
     const magnetic = generateBin(makeParams({ attachment: 'magnetic' }, base));
-    assertStructurallyValid(magnetic, '2x2 bin with magnetic lid posts');
-    // Posts add solid material + pockets, so the magnetic bin has more geometry.
+    assertStructurallyValid(magnetic, '2x2 bin with magnetic lid gusset pads');
+    // Pads add solid material + pockets, so the magnetic bin has more geometry.
     expect(magnetic.triangleCount).toBeGreaterThan(plain.triangleCount);
+  });
+
+  it('pads are top overhangs, not full-height columns (height-independent)', async () => {
+    const generateBin = getGenerateBin();
+    // The gusset pads live at the top rim, so the geometry they ADD over a
+    // plain bin must not scale with bin height. A returning full-column bug
+    // would make the delta grow with height. Compare the magnetic-vs-plain
+    // triangle delta at height 3 and height 6 — they should be close.
+    const deltaAt = (height: number): number => {
+      const plain = generateBin(
+        makeParams({ attachment: 'clickRails' }, { width: 2, depth: 2, height })
+      );
+      const magnetic = generateBin(
+        makeParams({ attachment: 'magnetic' }, { width: 2, depth: 2, height })
+      );
+      return magnetic.triangleCount - plain.triangleCount;
+    };
+    const d3 = deltaAt(3);
+    const d6 = deltaAt(6);
+    expect(d3).toBeGreaterThan(0);
+    // Allow tessellation jitter but reject height-scaling (a column would
+    // roughly double the added side-wall triangles from height 3 to 6).
+    expect(Math.abs(d6 - d3)).toBeLessThan(d3 * 0.5);
   });
 
   it('leaves the bin footprint unchanged (posts grow inward)', async () => {

--- a/src/features/generation/worker/generators/lidRetentionMagnets.ts
+++ b/src/features/generation/worker/generators/lidRetentionMagnets.ts
@@ -1,27 +1,30 @@
 /**
  * Lid-side retention magnets (issue #2694).
  *
- * Fuses a corner boss into each of the lid's four corners, hanging from the
- * floor down to the seated interface (the bin's lip-top plane, at lid-local
- * `anchorZ`), then cuts a blind pocket that opens DOWNWARD so the magnet's
- * pole face meets the bin post's magnet across a thin seat gap.
+ * Fuses a corner boss into each of the lid's four corners, hanging DOWN from
+ * the floor into the mating cavity, and cuts a blind pocket that opens downward
+ * so the magnet's pole face meets the bin gusset's magnet across a thin gap.
  *
- * Coordinate frame is lid-local (see `lidConstants.ts`):
- *   Z = 0            top of the lid floor
- *   Z = anchorZ      the seated interface (bin lip top maps here)
- * The boss bottom sits `LID_MAGNET_SEAT_GAP` above `anchorZ` so the four posts
- * don't bottom out and lift the lid off its lip.
- *
- * Placement XY is shared with the bin via `retentionMagnetPositions`, so the
- * lid holes always line up with the bin's posts.
+ * Coordinate frame is lid-local (see `lidConstants.ts`, Z=0 is the top surface):
+ *   Z = 0                        top of the lid floor (the visible closed face)
+ *   Z = -(depth + ceiling) = Zi  boss bottom / magnet mating face
+ * The whole boss + magnet stay at or below Z=0, so the top face is flush — no
+ * bumps poke through it. The boss sits INBOARD of the lip (see
+ * `retentionMagnetInset`) so it drops into the bin mouth without fouling the
+ * lip, welding to the floor plate above it. Placement XY is shared with the bin
+ * via `retentionMagnetPositions`, keeping the magnets coaxial.
  */
 
 import { cylinder, unwrap, fuse, cutAll } from 'brepjs';
 import type { Shape3D, DisposalScope, ValidSolid } from 'brepjs';
 import { FeatureTag } from './featureTags';
 import { collectOrigins } from './pipeline/collectOrigins';
-import { LID_COPLANAR_MARGIN, LID_MAGNET_CEILING, LID_MAGNET_SEAT_GAP } from './lidConstants';
-import { retentionBossRadius, retentionMagnetPositions } from './retentionMagnetGeometry';
+import { LID_COPLANAR_MARGIN } from './lidConstants';
+import {
+  retentionBossRadius,
+  retentionMagnetInset,
+  retentionMagnetPositions,
+} from './retentionMagnetGeometry';
 import type { LidInputs } from './lidInputs';
 
 export function addLidRetentionMagnets(
@@ -37,27 +40,30 @@ export function addLidRetentionMagnets(
     gridUnitMmY,
     retentionMagnetDiameter,
     retentionMagnetDepth,
-    anchorZ,
+    topThickness,
   } = inputs;
 
   const magnetRadius = retentionMagnetDiameter / 2;
   const bossRadius = retentionBossRadius(retentionMagnetDiameter);
-  const positions = retentionMagnetPositions(cellsX, cellsY, gridUnitMm, gridUnitMmY, bossRadius);
+  const inset = retentionMagnetInset(retentionMagnetDiameter);
+  const positions = retentionMagnetPositions(cellsX, cellsY, gridUnitMm, gridUnitMmY, inset);
 
-  // Boss bottom sits a hair above the interface; the magnet pocket opens there
-  // and extends up. Boss top clears the pocket plus a sealed ceiling — reaching
-  // at least Z=0 so it always welds to the full floor plate (a small bump above
-  // 0 for deep magnets is acceptable and matches typical corner-holder lids).
-  const bossBottomZ = anchorZ + LID_MAGNET_SEAT_GAP;
-  const pocketTopZ = bossBottomZ + retentionMagnetDepth;
-  const bossTopZ = Math.max(0, pocketTopZ + LID_MAGNET_CEILING);
-  const bossHeight = bossTopZ - bossBottomZ;
+  // The magnet sits directly under the floor plate: its top face is the floor
+  // underside (Z = -topThickness), so the solid floor (>= LID_MAGNET_CEILING
+  // thick) hides it — the top surface stays perfectly smooth, no bumps or
+  // crease circles. The boss hangs BELOW the floor into the mating cavity to
+  // house the rest of the magnet, welding up into the floor by a coplanar
+  // margin. `interfaceZ` (magnet mating face) is what the bin gusset mates with.
+  const magnetTopZ = -topThickness;
+  const interfaceZ = magnetTopZ - retentionMagnetDepth;
+  const bossTopZ = magnetTopZ + LID_COPLANAR_MARGIN; // weld up into the floor
+  const bossHeight = bossTopZ - interfaceZ;
 
   // 1. Fuse the four bosses onto the floor (welds along the floor plate).
   let result = body;
   for (const [px, py] of positions) {
     const boss = scope.register(
-      cylinder(bossRadius, bossHeight, { at: [px, py, bossBottomZ], axis: [0, 0, 1] })
+      cylinder(bossRadius, bossHeight, { at: [px, py, interfaceZ], axis: [0, 0, 1] })
     );
     if (originToTag) {
       collectOrigins(boss, FeatureTag.LID_BODY, originToTag);
@@ -67,9 +73,9 @@ export function addLidRetentionMagnets(
   }
 
   // 2. Cut the downward-opening pockets in one batched pass. The cutter starts
-  //    `LID_COPLANAR_MARGIN` below the boss bottom so it bites cleanly through
-  //    the open (downward) face, and rises by the magnet depth.
-  const cutterZ = bossBottomZ - LID_COPLANAR_MARGIN;
+  //    `LID_COPLANAR_MARGIN` below the interface so it bites cleanly through the
+  //    open (downward) face, and rises by the magnet depth (leaving the ceiling).
+  const cutterZ = interfaceZ - LID_COPLANAR_MARGIN;
   const cutterHeight = retentionMagnetDepth + LID_COPLANAR_MARGIN;
   const cutters: Shape3D[] = [];
   for (const [px, py] of positions) {

--- a/src/features/generation/worker/generators/lidRetentionMagnets.ts
+++ b/src/features/generation/worker/generators/lidRetentionMagnets.ts
@@ -6,13 +6,15 @@
  * so the magnet's pole face meets the bin gusset's magnet across a thin gap.
  *
  * Coordinate frame is lid-local (see `lidConstants.ts`, Z=0 is the top surface):
- *   Z = 0                        top of the lid floor (the visible closed face)
- *   Z = -(depth + ceiling) = Zi  boss bottom / magnet mating face
- * The whole boss + magnet stay at or below Z=0, so the top face is flush — no
- * bumps poke through it. The boss sits INBOARD of the lip (see
- * `retentionMagnetInset`) so it drops into the bin mouth without fouling the
- * lip, welding to the floor plate above it. Placement XY is shared with the bin
- * via `retentionMagnetPositions`, keeping the magnets coaxial.
+ *   Z = 0               top of the lid floor (the visible closed face)
+ *   Z = -topThickness   floor underside = magnet TOP (the solid floor is the
+ *                       magnet's ceiling, so the top face stays smooth)
+ *   Z = -(topThickness + depth)   boss bottom / magnet mating face
+ * The whole boss + magnet stay below Z=0, so the top face is flush — no bumps or
+ * crease circles. The boss sits INBOARD of the lip (see `retentionMagnetInset`)
+ * so it drops into the bin mouth without fouling the lip, welding UP into the
+ * floor plate above it. Placement XY is shared with the bin via
+ * `retentionMagnetPositions`, keeping the magnets coaxial.
  */
 
 import { cylinder, unwrap, fuse, cutAll } from 'brepjs';

--- a/src/features/generation/worker/generators/pipeline/stages/lidRetentionStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/lidRetentionStage.ts
@@ -81,12 +81,20 @@ export const lidRetentionStage: PipelineStage = {
     const lidFaceWorldZ = -(lidInputs.topThickness + depth) + (dim.totalHeight - lidInputs.anchorZ);
     const magnetTopZ = lidFaceWorldZ - LID_MAGNET_SEAT_GAP;
 
-    // Keep at least POST_FLOOR of pad below the magnet, and never dig below the
-    // interior floor — clamp the pocket depth to what the recessed pad can hold.
+    // Cap the pocket at what the recessed pad can hold while keeping POST_FLOOR
+    // of pad below the magnet. `availableForPocket` is guaranteed positive when
+    // this stage runs (the `magnetTooDeepForBin` blocker rejects magnets that
+    // don't fit), but clamp to >= 0 defensively so a marginal design never
+    // inverts the pocket. The pad bottom is additionally clamped to the interior
+    // floor so a deep magnet can never dig a pocket through it.
+    const floorTopZ = dim.totalHeight - dim.interiorHeight;
     const recessDepth = dim.totalHeight - magnetTopZ;
-    const availableForPocket = dim.interiorHeight - recessDepth - LID_MAGNET_POST_FLOOR;
-    const pocketDepth = Math.max(0.4, Math.min(depth, availableForPocket));
-    const padBottomZ = magnetTopZ - pocketDepth - LID_MAGNET_POST_FLOOR;
+    const availableForPocket = Math.max(
+      0,
+      dim.interiorHeight - recessDepth - LID_MAGNET_POST_FLOOR
+    );
+    const pocketDepth = Math.min(depth, availableForPocket);
+    const padBottomZ = Math.max(floorTopZ, magnetTopZ - pocketDepth - LID_MAGNET_POST_FLOOR);
     const padHeight = magnetTopZ - padBottomZ;
 
     const innerHalfW = dim.innerW / 2;

--- a/src/features/generation/worker/generators/pipeline/stages/lidRetentionStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/lidRetentionStage.ts
@@ -1,29 +1,45 @@
 /**
- * Lid-retention stage — bin-side magnet posts (issue #2694).
+ * Lid-retention stage — bin-side magnet gusset pads (issue #2694).
  *
- * When the design's lid uses magnetic retention, each corner of the bin grows
- * a post rising from the interior floor to the stacking-lip top, with a blind
- * magnet pocket opening UPWARD. The mating lid boss meets it across the seated
- * interface (the lip-top plane). The physical bin needs these whether or not
- * the lid is exported in the same action, so this keys off `usesMagneticLid`
- * (not on the lid being emitted).
+ * When the design's lid uses magnetic retention, each corner of the bin grows a
+ * gusset pad: a solid that anchors to the two interior corner walls near the top
+ * and cantilevers inward (an overhang) to house a vertical magnet pocket opening
+ * UPWARD. The mating lid boss hangs down to meet it — the pad top sits one
+ * `LID_MAGNET_SEAT_GAP` below the lid boss's bottom face when the lid is seated,
+ * so the two magnets mate across a thin gap.
+ *
+ * The magnet mating plane is recessed just below the rim so the lid magnet fits
+ * entirely under the lid's top surface (no bump); this stage derives that plane
+ * from the lid's `anchorZ`, which the export assembly pins to the bin lip top.
+ * The physical bin needs the pads whether or not the lid is exported in the same
+ * action, so this keys off `usesMagneticLid` (not on the lid being emitted).
  *
  * Runs AFTER translate so the solid is in final world Z (lip top at
  * `dimensions.totalHeight`); XY comes from the shared `retentionMagnetPositions`
- * so the posts line up with the lid's holes.
+ * so the pads line up with the lid's bosses.
  */
 
-import { cylinder, unwrap, fuse, cutAll } from 'brepjs';
+import { cylinder, drawRoundedRectangle, translate, unwrap, fuse, cutAll } from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { shouldGenerateLid } from '@/shared/types/bin';
 import { checkCancelled } from '../../utils/abort';
-import { LID_COPLANAR_MARGIN, LID_MAGNET_POST_FLOOR } from '../../lidConstants';
+import {
+  LID_COPLANAR_MARGIN,
+  LID_MAGNET_POST_FLOOR,
+  LID_MAGNET_SEAT_GAP,
+} from '../../lidConstants';
+import { resolveLidInputs } from '../../lidInputs';
 import {
   retentionBossRadius,
+  retentionMagnetInset,
   retentionMagnetPositions,
   usesMagneticLid,
 } from '../../retentionMagnetGeometry';
+
+/** Volumetric overlap (mm) of the gusset into the interior walls, so the fuse
+ *  weld is solid rather than a boolean-hostile coplanar face. */
+const GUSSET_WALL_OVERLAP = 0.4;
 
 export const lidRetentionStage: PipelineStage = {
   name: 'merge',
@@ -34,7 +50,7 @@ export const lidRetentionStage: PipelineStage = {
     // rectangular); `shouldGenerateLid` additionally rejects blocking
     // compatibility issues (e.g. `magnetTooDeepForBin`). Both are required so a
     // blocked lid — which is never generated/exported — doesn't leave the bin
-    // with orphan posts, or cut a too-deep pocket through the floor.
+    // with orphan pads, or cut a too-deep pocket through the floor.
     return ctx.solid !== null && usesMagneticLid(ctx.params) && shouldGenerateLid(ctx.params);
   },
 
@@ -45,40 +61,70 @@ export const lidRetentionStage: PipelineStage = {
     const { params, dimensions: dim } = ctx;
     const { diameter, depth } = params.lid.retentionMagnet;
     const magnetRadius = diameter / 2;
-    // Never cut deeper than leaves `LID_MAGNET_POST_FLOOR` of solid below the
-    // pocket, so the post can't be punched through even if a design slips past
-    // the `magnetTooDeepForBin` warning band. Clamped to > 0 so a tiny interior
-    // still yields a real (if shallow) pocket rather than an inverted one.
-    const pocketDepth = Math.max(0.4, Math.min(depth, dim.interiorHeight - LID_MAGNET_POST_FLOOR));
     const bossRadius = retentionBossRadius(diameter);
+    const inset = retentionMagnetInset(diameter);
     const positions = retentionMagnetPositions(
       params.width,
       params.depth,
       dim.gridUnitMmX,
       dim.gridUnitMmY,
-      bossRadius
+      inset
     );
 
-    // Lip top = the seated interface. Post rises from the interior floor to it.
-    const interfaceZ = dim.totalHeight;
-    const floorTopZ = dim.totalHeight - dim.interiorHeight;
-    const postHeight = interfaceZ - floorTopZ;
+    // Derive the lid magnet's mating face from the SAME resolved lid inputs the
+    // lid builder uses, so the two never drift: it sits at lid-local
+    // -(topThickness + depth) (the magnet tucked under the lid floor). Map that
+    // to world via the seating transform (lid-local Z + (totalHeight - anchorZ),
+    // matching `exportHandler`'s lid lift); the bin magnet's upward face sits one
+    // seat gap below so the magnets mate.
+    const lidInputs = resolveLidInputs(params);
+    const lidFaceWorldZ = -(lidInputs.topThickness + depth) + (dim.totalHeight - lidInputs.anchorZ);
+    const magnetTopZ = lidFaceWorldZ - LID_MAGNET_SEAT_GAP;
+
+    // Keep at least POST_FLOOR of pad below the magnet, and never dig below the
+    // interior floor — clamp the pocket depth to what the recessed pad can hold.
+    const recessDepth = dim.totalHeight - magnetTopZ;
+    const availableForPocket = dim.interiorHeight - recessDepth - LID_MAGNET_POST_FLOOR;
+    const pocketDepth = Math.max(0.4, Math.min(depth, availableForPocket));
+    const padBottomZ = magnetTopZ - pocketDepth - LID_MAGNET_POST_FLOOR;
+    const padHeight = magnetTopZ - padBottomZ;
+
+    const innerHalfW = dim.innerW / 2;
+    const innerHalfD = dim.innerD / 2;
 
     let body: Shape3D = ctx.solid;
 
-    // 1. Fuse the four posts onto the body (welds to the floor + corner walls).
+    // 1. Fuse a gusset pad into each corner. The pad spans from the interior
+    //    wall corner (with a small overlap for a solid weld) inward past the
+    //    magnet, as a rounded box at the recessed pad height.
     for (const [px, py] of positions) {
-      const post = cylinder(bossRadius, postHeight, { at: [px, py, floorTopZ], axis: [0, 0, 1] });
-      const fused = unwrap(fuse(body as ValidSolid, post));
-      post.delete();
+      const sx = Math.sign(px);
+      const sy = Math.sign(py);
+      const wallX = sx * (innerHalfW + GUSSET_WALL_OVERLAP);
+      const wallY = sy * (innerHalfD + GUSSET_WALL_OVERLAP);
+      const innerX = px - sx * bossRadius;
+      const innerY = py - sy * bossRadius;
+      const centerX = (wallX + innerX) / 2;
+      const centerY = (wallY + innerY) / 2;
+      const sizeX = Math.abs(wallX - innerX);
+      const sizeY = Math.abs(wallY - innerY);
+      const cornerR = Math.max(0.1, Math.min(1.5, sizeX / 2 - 0.1, sizeY / 2 - 0.1));
+
+      const pad = drawRoundedRectangle(sizeX, sizeY, cornerR)
+        .sketchOnPlane('XY', padBottomZ)
+        .extrude(padHeight);
+      const positioned = translate(pad, [centerX, centerY, 0]);
+      pad.delete();
+      const fused = unwrap(fuse(body as ValidSolid, positioned as ValidSolid));
+      positioned.delete();
       body.delete();
       body = fused;
     }
 
     // 2. Cut the upward-opening pockets. Cutter starts `pocketDepth` below the
-    //    lip top and rises a hair past it so it bites cleanly through the top
-    //    face, leaving at least `LID_MAGNET_POST_FLOOR` of post material below.
-    const cutterZ = interfaceZ - pocketDepth;
+    //    pad top and rises a hair past it so it bites cleanly through the top
+    //    face, leaving POST_FLOOR of pad material below the magnet.
+    const cutterZ = magnetTopZ - pocketDepth;
     const cutterHeight = pocketDepth + LID_COPLANAR_MARGIN;
     const cutters: Shape3D[] = [];
     for (const [px, py] of positions) {

--- a/src/features/generation/worker/generators/retentionMagnetGeometry.test.ts
+++ b/src/features/generation/worker/generators/retentionMagnetGeometry.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   retentionBossRadius,
+  retentionMagnetInset,
   retentionMagnetPositions,
   usesMagneticLid,
 } from './retentionMagnetGeometry';
-import { LID_MAGNET_BOSS_WALL, LID_MAGNET_EDGE_INSET } from './lidConstants';
+import { LID_MAGNET_BOSS_WALL, LID_MAGNET_LIP_CLEARANCE } from './lidConstants';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams } from '@/shared/types/bin';
 import type { CellMask } from '@/shared/utils/cellMask';
@@ -23,12 +24,18 @@ describe('retentionBossRadius', () => {
   });
 });
 
+describe('retentionMagnetInset', () => {
+  it('keeps the boss clear of the lip (lip clearance + boss radius)', () => {
+    expect(retentionMagnetInset(6)).toBe(LID_MAGNET_LIP_CLEARANCE + retentionBossRadius(6));
+  });
+});
+
 describe('retentionMagnetPositions', () => {
-  it('places four symmetric corners inset by the boss radius + edge inset', () => {
-    const r = retentionBossRadius(6);
-    const positions = retentionMagnetPositions(2, 2, 42, 42, r);
+  it('places four symmetric corners inset from the nominal corner', () => {
+    const inset = retentionMagnetInset(6);
+    const positions = retentionMagnetPositions(2, 2, 42, 42, inset);
     expect(positions).toHaveLength(4);
-    const x = 42 - (r + LID_MAGNET_EDGE_INSET); // halfW (2*42/2 = 42) - inset
+    const x = 42 - inset; // halfW (2*42/2 = 42) - inset
     expect(positions).toEqual([
       [-x, -x],
       [x, -x],
@@ -37,15 +44,22 @@ describe('retentionMagnetPositions', () => {
     ]);
   });
 
+  it('keeps the magnet boss well inside the footprint (drawer-safe)', () => {
+    const inset = retentionMagnetInset(6);
+    const [, [x]] = retentionMagnetPositions(2, 2, 42, 42, inset);
+    // Boss outer edge (x + bossRadius) must stay inside the nominal half-width.
+    expect(x + retentionBossRadius(6)).toBeLessThan(42);
+  });
+
   it('stretches with a non-square grid pitch', () => {
-    const r = 4;
-    const [[, y0]] = retentionMagnetPositions(2, 2, 42, 50, r);
-    // halfD = 2*50/2 = 50, inset (r + edge) → keeps inside the footprint
-    expect(y0).toBeCloseTo(-(50 - (r + LID_MAGNET_EDGE_INSET)));
+    const inset = 8;
+    const [[, y0]] = retentionMagnetPositions(2, 2, 42, 50, inset);
+    // halfD = 2*50/2 = 50, inset keeps the magnet inboard.
+    expect(y0).toBeCloseTo(-(50 - inset));
   });
 
   it('is centred on the origin (matching bin + lid frames) so magnets mate', () => {
-    const positions = retentionMagnetPositions(3, 2, 42, 42, 4);
+    const positions = retentionMagnetPositions(3, 2, 42, 42, 8);
     const sumX = positions.reduce((a, [px]) => a + px, 0);
     const sumY = positions.reduce((a, [, py]) => a + py, 0);
     expect(sumX).toBeCloseTo(0);

--- a/src/features/generation/worker/generators/retentionMagnetGeometry.ts
+++ b/src/features/generation/worker/generators/retentionMagnetGeometry.ts
@@ -18,7 +18,7 @@
 
 import type { BinParams } from '@/shared/types/bin';
 import { isPartialMask } from '@/shared/utils/cellMask';
-import { LID_MAGNET_BOSS_WALL, LID_MAGNET_EDGE_INSET } from './lidConstants';
+import { LID_MAGNET_BOSS_WALL, LID_MAGNET_LIP_CLEARANCE } from './lidConstants';
 
 /** Radial material kept around the magnet in its post/boss (mm). */
 export function retentionBossRadius(magnetDiameter: number): number {
@@ -26,23 +26,33 @@ export function retentionBossRadius(magnetDiameter: number): number {
 }
 
 /**
- * The four corner magnet XY positions, centred on the origin like both the
- * bin body and the lid. Each post is inset from the NOMINAL footprint corner
- * by its own radius plus `LID_MAGNET_EDGE_INSET`, so its outer edge clears the
- * clearance-reduced outer wall (of both the slightly-larger bin body and the
- * slightly-smaller lid cavity) and the footprint stays drawer-safe. Posts weld
- * to the floor plates, not the walls, so they don't need wall tangency.
+ * Distance (mm) from the nominal footprint edge to the magnet centre.
+ *
+ * Set so the lid's boss (radius {@link retentionBossRadius}) sits fully INBOARD
+ * of the bin's stacking lip: `inset - bossRadius = LID_MAGNET_LIP_CLEARANCE`, so
+ * the boss can hang into the mouth without fouling the lip as the lid seats. The
+ * bin's corner gusset then reaches back OUT to the interior walls to anchor
+ * itself. Both parts use this same inset so their magnets stay coaxial.
+ */
+export function retentionMagnetInset(magnetDiameter: number): number {
+  return LID_MAGNET_LIP_CLEARANCE + retentionBossRadius(magnetDiameter);
+}
+
+/**
+ * The four corner magnet XY positions, centred on the origin like both the bin
+ * body and the lid, inset from the NOMINAL footprint corner by
+ * {@link retentionMagnetInset}. Nominal (not per-part) so the bin's slightly-
+ * larger body and the lid's slightly-smaller cavity keep the magnets coaxial.
  */
 export function retentionMagnetPositions(
   width: number,
   depth: number,
   gridUnitMmX: number,
   gridUnitMmY: number,
-  bossRadius: number
+  inset: number
 ): ReadonlyArray<readonly [number, number]> {
   const halfW = (width * gridUnitMmX) / 2;
   const halfD = (depth * gridUnitMmY) / 2;
-  const inset = bossRadius + LID_MAGNET_EDGE_INSET;
   const x = halfW - inset;
   const y = halfD - inset;
   return [

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Wandstärke des Fachrands in Millimetern",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Bei Sonderformen lassen sich keine Eckmagnete platzieren — der Deckel fällt auf Reibschluss ohne Magnete zurück.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "Der Rückhaltemagnet ist tiefer als der Innenraum des Behälters fassen kann — verringere die Tiefe oder verwende einen höheren Behälter.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "Rückhaltemagnet-Tiefe verringern"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "Rückhaltemagnet-Tiefe verringern",
+  "binDesigner.lid.compat.magnetBinTooSmall": "Der Behälter ist zu klein für Eckmagnete — verwende einen größeren Behälter oder einen kleineren Magnetdurchmesser.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "größeren Behälter oder kleineren Magneten verwenden"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1828,6 +1828,9 @@ const en: Record<string, string> = {
   'binDesigner.lid.compat.magnetTooDeepForBin':
     'The retention magnet is deeper than the bin interior can hold — reduce its depth or use a taller bin.',
   'binDesigner.lid.compat.fix.magnetTooDeepForBin': 'reduce retention magnet depth',
+  'binDesigner.lid.compat.magnetBinTooSmall':
+    'The bin is too small to fit corner magnets — use a larger bin or a smaller magnet diameter.',
+  'binDesigner.lid.compat.fix.magnetBinTooSmall': 'use a larger bin or a smaller magnet',
   'binDesigner.lid.compat.disabledOne': 'Resolve the conflict to enable lid: {detail}',
   'binDesigner.lid.compat.disabledMany': 'Resolve {count} conflicts to enable lid',
   'binDesigner.lid.compat.fix.wallCutoutsAllSides': 'disable some wall cutouts',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Grosor del borde de la bandeja en milímetros",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Las formas personalizadas no pueden colocar imanes en las esquinas — la tapa vuelve al ajuste por fricción sin imanes.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "El imán de retención es más profundo de lo que cabe en el interior de la caja — reduce su profundidad o usa una caja más alta.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "reducir la profundidad del imán de retención"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "reducir la profundidad del imán de retención",
+  "binDesigner.lid.compat.magnetBinTooSmall": "La caja es demasiado pequeña para imanes en las esquinas — usa una caja más grande o un imán de menor diámetro.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "usar una caja más grande o un imán más pequeño"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Épaisseur du rebord du plateau en millimètres",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Les formes personnalisées ne peuvent pas placer d'aimants d'angle — le couvercle revient à un ajustement par friction sans aimants.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "L'aimant de maintien est plus profond que ne peut le contenir l'intérieur du bac — réduisez sa profondeur ou utilisez un bac plus haut.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "réduire la profondeur de l'aimant de maintien"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "réduire la profondeur de l'aimant de maintien",
+  "binDesigner.lid.compat.magnetBinTooSmall": "Le bac est trop petit pour des aimants d'angle — utilisez un bac plus grand ou un aimant de plus petit diamètre.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "utiliser un bac plus grand ou un aimant plus petit"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Spessore del bordo del vassoio in millimetri",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Le forme personalizzate non possono ospitare magneti d'angolo — il coperchio torna all'attrito senza magneti.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "Il magnete di ritenzione è più profondo di quanto l'interno del contenitore possa contenere — riducine la profondità o usa un contenitore più alto.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "riduci la profondità del magnete di ritenzione"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "riduci la profondità del magnete di ritenzione",
+  "binDesigner.lid.compat.magnetBinTooSmall": "Il contenitore è troppo piccolo per i magneti d'angolo — usa un contenitore più grande o un magnete di diametro minore.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "usa un contenitore più grande o un magnete più piccolo"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "トレイの縁の壁厚（ミリメートル）",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "カスタム形状ではコーナーマグネットを配置できません — ふたはマグネットなしの摩擦ばめに戻ります。",
   "binDesigner.lid.compat.magnetTooDeepForBin": "保持マグネットがビン内部に収まらないほど深くなっています — 深さを減らすか、背の高いビンを使用してください。",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "保持マグネットの深さを減らす"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "保持マグネットの深さを減らす",
+  "binDesigner.lid.compat.magnetBinTooSmall": "ビンが小さすぎてコーナーマグネットが入りません — 大きいビンを使うか、マグネット直径を小さくしてください。",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "大きいビンか小さいマグネットを使う"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Veggtykkelse på brettkanten i millimeter",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Egendefinerte former kan ikke plassere hjørnemagneter — lokket faller tilbake til friksjonsfeste uten magneter.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "Festemagneten er dypere enn beholderens innside rommer — reduser dybden eller bruk en høyere beholder.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "reduser dybden på festemagneten"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "reduser dybden på festemagneten",
+  "binDesigner.lid.compat.magnetBinTooSmall": "Beholderen er for liten for hjørnemagneter — bruk en større beholder eller mindre magnetdiameter.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "bruk en større beholder eller mindre magnet"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Wanddikte van de dienbladrand in millimeters",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Bij aangepaste vormen kunnen geen hoekmagneten worden geplaatst — het deksel valt terug op klemvast zonder magneten.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "De retentiemagneet is dieper dan het binnenwerk van de bak aankan — verklein de diepte of gebruik een hogere bak.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "diepte van de retentiemagneet verkleinen"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "diepte van de retentiemagneet verkleinen",
+  "binDesigner.lid.compat.magnetBinTooSmall": "De bak is te klein voor hoekmagneten — gebruik een grotere bak of een kleinere magneetdiameter.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "gebruik een grotere bak of een kleinere magneet"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Espessura da borda da bandeja em milímetros",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Formas personalizadas não permitem ímãs de canto — a tampa volta ao encaixe por atrito sem ímãs.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "O ímã de retenção é mais profundo do que o interior do compartimento comporta — reduza a profundidade ou use um compartimento mais alto.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "reduzir a profundidade do ímã de retenção"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "reduzir a profundidade do ímã de retenção",
+  "binDesigner.lid.compat.magnetBinTooSmall": "O compartimento é pequeno demais para ímãs de canto — use um compartimento maior ou um ímã de menor diâmetro.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "use um compartimento maior ou um ímã menor"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Brickkantens väggtjocklek i millimeter",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Anpassade former kan inte placera hörnmagneter — locket återgår till friktionsfäste utan magneter.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "Fästmagneten är djupare än vad lådans insida rymmer — minska djupet eller använd en högre låda.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "minska fästmagnetens djup"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "minska fästmagnetens djup",
+  "binDesigner.lid.compat.magnetBinTooSmall": "Lådan är för liten för hörnmagneter — använd en större låda eller en mindre magnetdiameter.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "använd en större låda eller en mindre magnet"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2860,5 +2860,7 @@
   "binDesigner.lid.trayWallAria": "Товщина стінки бортика лотка в міліметрах",
   "binDesigner.lid.compat.magnetsPolygonUnsupported": "Для довільних форм не можна розмістити кутові магніти — кришка повертається до фрикційної посадки без магнітів.",
   "binDesigner.lid.compat.magnetTooDeepForBin": "Утримувальний магніт глибший, ніж уміщає внутрішній простір контейнера — зменшіть глибину або візьміть вищий контейнер.",
-  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "зменшити глибину утримувального магніту"
+  "binDesigner.lid.compat.fix.magnetTooDeepForBin": "зменшити глибину утримувального магніту",
+  "binDesigner.lid.compat.magnetBinTooSmall": "Контейнер замалий для кутових магнітів — візьміть більший контейнер або менший діаметр магніту.",
+  "binDesigner.lid.compat.fix.magnetBinTooSmall": "взяти більший контейнер або менший магніт"
 }


### PR DESCRIPTION
Follow-up to #2696, fixing three issues reported on the first magnetic-lid cut.

## Fixes

### 1. Bin holders were full-height columns → corner gusset pads
The bin's magnet holders rose as solid cylinders from the interior floor to the rim, eating the whole corner. They're now **gusset pads**: a solid anchored to the two interior corner walls at the top that cantilevers inward (a printable overhang) to house the magnet, leaving the interior clear.

### 2. Lid magnet bosses bumped through the top surface → magnets tucked under the floor
The lid bosses protruded above the top face as visible bumps. The magnet now sits **directly under the floor plate** (top surface is smooth, no bumps or crease circles), with the boss hanging into the mating cavity below.

The bin pad's **top** now mates with the lid boss's **bottom** across one seat gap. Both are derived from the *same* resolved lid inputs (`resolveLidInputs`), so the bin and lid planes can't drift.

### 3. Magnet controls were buried below the fold → regrouped under the selector
The magnet diameter/depth steppers rendered after the stackable/tray toggles, far from the attachment selector. They now render **directly beneath** the Friction/Click rails/Magnetic selector, next to the mode they belong to.

## Verification
Rendered before/after in the designer (screenshots below): bin now has flush corner gusset pads at the top instead of columns; lid top is smooth; pads are aligned to mate. Friction lids correctly have no pads.

- New regression test: the bin pads are **height-independent** (a returning full-column bug would scale the added geometry with bin height).
- All existing magnetic/tray scenario, compat, migration, validation, and panel tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes magnetic lid geometry so the top stays smooth and the bin interior stays clear, and moves magnet controls next to the attachment selector. Adds a blocker for bins too small to fit corner magnets and clamps pad pockets to avoid floor punch‑through.

- **Bug Fixes**
  - Lid magnets sit under the floor; bosses hang into the cavity. Top face is flush.
  - Bin holders changed from floor-to-rim columns to top corner gusset pads with upward pockets. Interior and footprint stay clean; added geometry is height‑independent.
  - Shared placement/inset logic keeps magnets coaxial and clear of the stacking lip; bin pad top mates with the lid boss bottom from the same resolved lid inputs.
  - Compatibility: blocks bins that can’t fit corner magnets (too small for the required inset).
  - Safety: clamps pocket depth to the recessed pad capacity and pads never cut through the floor.

<sup>Written for commit 3699698ee3d9917710e8411a4de6ced10e468935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

