### PR TITLE
fix(designer): reject bins where magnet corner pads would merge (#2698)

### DIFF
--- a/src/features/bin-designer/utils/lidCompatibility.test.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.test.ts
@@ -653,6 +653,17 @@ describe('checkLidCompatibility — magnetic attachment (#2694)', () => {
     expect(checkLidCompatibility(params).some((i) => i.id === 'magnetBinTooSmall')).toBe(false);
   });
 
+  it('blocks a 1x1 bin whose corner pads would merge (large magnet)', () => {
+    // Half-width 21mm; a 15mm magnet needs half-extent >= 3.5 + 15 + 2*1.5 =
+    // 21.5mm for the gusset pads not to merge at the centre, so it's blocked.
+    const params = magnetic(
+      { width: 1, depth: 1 },
+      { retentionMagnet: { diameter: 15, depth: 2 } }
+    );
+    const issue = checkLidCompatibility(params).find((i) => i.id === 'magnetBinTooSmall');
+    expect(issue?.severity).toBe('blocker');
+  });
+
   it('blocks when the retention magnet is deeper than the bin interior', () => {
     const params = magnetic({ height: 1 }, { retentionMagnet: { diameter: 6, depth: 6 } });
     const issues = checkLidCompatibility(params);

--- a/src/features/bin-designer/utils/lidCompatibility.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.ts
@@ -306,13 +306,15 @@ export function checkLidCompatibility(params: BinParams): readonly LidCompatibil
       issues.push({ id: 'magnetsPolygonUnsupported', severity: 'warning' });
     } else {
       const diameter = params.lid.retentionMagnet.diameter;
-      // XY bounds: the four corner pads are inset from each edge by
-      // `MAGNET_LIP_CLEARANCE + bossRadius`, and opposite pads must not overlap
-      // through the centre. That needs each half-extent >= inset + magnetRadius
-      // = MAGNET_LIP_CLEARANCE + MAGNET_BOSS_WALL + diameter. A too-small bin
-      // can't place the magnets at all — blocker.
+      // XY bounds: the four corner gusset pads are inset from each edge by
+      // `MAGNET_LIP_CLEARANCE + bossRadius` and each extends inward by a further
+      // `bossRadius`, so opposite pads only stay apart when each half-extent >=
+      // inset + bossRadius = MAGNET_LIP_CLEARANCE + 2*bossRadius
+      // = MAGNET_LIP_CLEARANCE + diameter + 2*MAGNET_BOSS_WALL (bossRadius =
+      // diameter/2 + MAGNET_BOSS_WALL). A smaller bin would merge the pads at
+      // the centre, so block it — the design can't place four clean corners.
       const gridUnitMmY = params.gridUnitMmY ?? params.gridUnitMm;
-      const minHalfMm = MAGNET_LIP_CLEARANCE + MAGNET_BOSS_WALL + diameter;
+      const minHalfMm = MAGNET_LIP_CLEARANCE + diameter + 2 * MAGNET_BOSS_WALL;
       const tooSmall =
         (params.width * params.gridUnitMm) / 2 < minHalfMm ||
         (params.depth * gridUnitMmY) / 2 < minHalfMm;


### PR DESCRIPTION
Follow-up to #2698, tightening the `magnetBinTooSmall` bounds check (a Copilot note on that PR).

## What
The blocker measured the minimum bin half-extent against the magnet **radius**, but each corner **gusset pad** extends inward by the full **boss radius**. On a narrow band of small bins (e.g. a 1×1 bin with a large magnet) the four pads would merge at the centre — still valid geometry, and the magnet pockets never overlap, but not the clean four-corner design.

The minimum half-extent is now `inset + bossRadius = MAGNET_LIP_CLEARANCE + diameter + 2*MAGNET_BOSS_WALL`, so those bins are blocked with the existing "bin too small" message instead.

## Tests
Added a case: a 1×1 bin with a 15mm magnet (previously allowed, pads merged) is now blocked. Existing small-bin/normal-bin cases still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the magnet XY size check so corner gusset pads don’t merge. Small bins that would merge are now blocked with the existing “bin too small” (`magnetBinTooSmall`) error.

- **Bug Fixes**
  - Require half-extent >= `MAGNET_LIP_CLEARANCE + diameter + 2*MAGNET_BOSS_WALL` (inset + bossRadius) to prevent pad merging.
  - Add test: 1×1 bin with a 15 mm magnet is now blocked; existing cases remain unchanged.

<sup>Written for commit f7e6e888a023fcb01410ae0b7b4c5767cefbf8e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

