### PR TITLE
feat(designer): non-square depth axis in the 3D layout preview (#2704)

### DIFF
--- a/src/features/grid-editor/components/Grid/IsometricPreview/AxisLabels/AxisLabels.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/AxisLabels/AxisLabels.tsx
@@ -7,6 +7,9 @@ import { useThreeColors } from '@/shared/hooks/useThemeEffect';
 interface AxisLabelsProps {
   width: number;
   depth: number;
+  /** Depth-axis world scale for a non-square grid (1 = square). Compresses the
+   * Y tick + label positions to match the scaled floor, without squashing text. */
+  depthScale?: number;
   fractionalEdgeX?: FractionalEdge;
   fractionalEdgeY?: FractionalEdge;
 }
@@ -29,6 +32,7 @@ const FRACTIONAL_LABEL = '+.5';
 export function AxisLabels({
   width,
   depth,
+  depthScale = 1,
   fractionalEdgeX = 'end',
   fractionalEdgeY = 'end',
 }: AxisLabelsProps) {
@@ -88,16 +92,17 @@ export function AxisLabels({
       positions.push(x, -TICK_SIZE, 0.01);
     }
 
-    // Y-axis ticks (along left edge)
+    // Y-axis ticks (along left edge) — Y positions compress by depthScale to
+    // track the scaled floor; the tick marks themselves (along X) stay square.
     // Integer ticks
     for (let i = 0; i <= integerDepth; i++) {
-      const y = yOffset + i;
+      const y = (yOffset + i) * depthScale;
       positions.push(0, y, 0.01);
       positions.push(-TICK_SIZE, y, 0.01);
     }
     // Fractional tick
     if (hasFractionalDepth) {
-      const y = fractionalEdgeY === 'start' ? fractionalDepthPart : depth;
+      const y = (fractionalEdgeY === 'start' ? fractionalDepthPart : depth) * depthScale;
       positions.push(0, y, 0.01);
       positions.push(-TICK_SIZE, y, 0.01);
     }
@@ -116,6 +121,7 @@ export function AxisLabels({
     fractionalDepthPart,
     xOffset,
     yOffset,
+    depthScale,
     fractionalEdgeX,
     fractionalEdgeY,
   ]);
@@ -178,7 +184,7 @@ export function AxisLabels({
         return (
           <Text
             key={`y-${idx}`}
-            position={[-0.28, yPos, 0.01]}
+            position={[-0.28, yPos * depthScale, 0.01]}
             fontSize={isFractional ? FRACTIONAL_FONT_SIZE : FONT_SIZE}
             color={colors.labelColor}
             fillOpacity={isFractional ? FRACTIONAL_LABEL_OPACITY : LABEL_OPACITY}

--- a/src/features/grid-editor/components/Grid/IsometricPreview/DrawerDimensions/DrawerDimensions.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/DrawerDimensions/DrawerDimensions.test.tsx
@@ -38,14 +38,28 @@ describe('DrawerDimensions', () => {
 
   it('renders without crashing', () => {
     const { container } = render(
-      <DrawerDimensions width={10} depth={8} height={21} gridUnitMm={42} heightUnitMm={7} />
+      <DrawerDimensions
+        width={10}
+        depth={8}
+        height={21}
+        gridUnitMm={42}
+        gridUnitMmY={42}
+        heightUnitMm={7}
+      />
     );
     expect(container).toBeTruthy();
   });
 
   it('renders dimension lines', () => {
     const { getAllByTestId } = render(
-      <DrawerDimensions width={10} depth={8} height={21} gridUnitMm={42} heightUnitMm={7} />
+      <DrawerDimensions
+        width={10}
+        depth={8}
+        height={21}
+        gridUnitMm={42}
+        gridUnitMmY={42}
+        heightUnitMm={7}
+      />
     );
     const lines = getAllByTestId('line');
     // Should have width, depth, and height dimension lines plus end caps (9 total)
@@ -54,7 +68,14 @@ describe('DrawerDimensions', () => {
 
   it('renders dimension text labels', () => {
     const { getAllByTestId } = render(
-      <DrawerDimensions width={10} depth={8} height={21} gridUnitMm={42} heightUnitMm={7} />
+      <DrawerDimensions
+        width={10}
+        depth={8}
+        height={21}
+        gridUnitMm={42}
+        gridUnitMmY={42}
+        heightUnitMm={7}
+      />
     );
     const textElements = getAllByTestId('r3f-text');
     // Should have width, depth, and height labels (3 total)
@@ -63,7 +84,14 @@ describe('DrawerDimensions', () => {
 
   it('calculates correct width in mm', () => {
     const { getAllByTestId } = render(
-      <DrawerDimensions width={10} depth={8} height={21} gridUnitMm={42} heightUnitMm={7} />
+      <DrawerDimensions
+        width={10}
+        depth={8}
+        height={21}
+        gridUnitMm={42}
+        gridUnitMmY={42}
+        heightUnitMm={7}
+      />
     );
     const textElements = getAllByTestId('r3f-text');
     // Width should be 10 * 42 = 420mm
@@ -72,16 +100,47 @@ describe('DrawerDimensions', () => {
 
   it('calculates correct depth in mm', () => {
     const { getAllByTestId } = render(
-      <DrawerDimensions width={10} depth={8} height={21} gridUnitMm={42} heightUnitMm={7} />
+      <DrawerDimensions
+        width={10}
+        depth={8}
+        height={21}
+        gridUnitMm={42}
+        gridUnitMmY={42}
+        heightUnitMm={7}
+      />
     );
     const textElements = getAllByTestId('r3f-text');
     // Depth should be 8 * 42 = 336mm
     expect(textElements[1].textContent).toBe('336mm');
   });
 
+  it('uses the Y pitch for the depth label on a non-square grid (#2704)', () => {
+    const { getAllByTestId } = render(
+      <DrawerDimensions
+        width={10}
+        depth={8}
+        height={21}
+        gridUnitMm={42}
+        gridUnitMmY={22}
+        heightUnitMm={7}
+      />
+    );
+    const textElements = getAllByTestId('r3f-text');
+    // Depth uses the Y pitch: 8 * 22 = 176mm (not 8 * 42). Width stays 420mm.
+    expect(textElements[0].textContent).toBe('420mm');
+    expect(textElements[1].textContent).toBe('176mm');
+  });
+
   it('calculates correct height in mm', () => {
     const { getAllByTestId } = render(
-      <DrawerDimensions width={10} depth={8} height={21} gridUnitMm={42} heightUnitMm={7} />
+      <DrawerDimensions
+        width={10}
+        depth={8}
+        height={21}
+        gridUnitMm={42}
+        gridUnitMmY={42}
+        heightUnitMm={7}
+      />
     );
     const textElements = getAllByTestId('r3f-text');
     // Height should be 21 * 7 = 147mm
@@ -90,14 +149,28 @@ describe('DrawerDimensions', () => {
 
   it('renders with fractional dimensions', () => {
     const { container } = render(
-      <DrawerDimensions width={10.5} depth={8.5} height={21} gridUnitMm={42} heightUnitMm={7} />
+      <DrawerDimensions
+        width={10.5}
+        depth={8.5}
+        height={21}
+        gridUnitMm={42}
+        gridUnitMmY={42}
+        heightUnitMm={7}
+      />
     );
     expect(container).toBeTruthy();
   });
 
   it('renders with different grid unit size', () => {
     const { getAllByTestId } = render(
-      <DrawerDimensions width={10} depth={8} height={21} gridUnitMm={50} heightUnitMm={7} />
+      <DrawerDimensions
+        width={10}
+        depth={8}
+        height={21}
+        gridUnitMm={50}
+        gridUnitMmY={50}
+        heightUnitMm={7}
+      />
     );
     const textElements = getAllByTestId('r3f-text');
     // Width should be 10 * 50 = 500mm

--- a/src/features/grid-editor/components/Grid/IsometricPreview/DrawerDimensions/DrawerDimensions.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/DrawerDimensions/DrawerDimensions.tsx
@@ -7,6 +7,10 @@ interface DrawerDimensionsProps {
   depth: number;
   height: number;
   gridUnitMm: number;
+  /** Depth-axis pitch (mm) — the true drawer depth for a non-square grid. */
+  gridUnitMmY: number;
+  /** Depth-axis world scale for a non-square grid (1 = square). */
+  depthScale?: number;
   heightUnitMm: number;
 }
 
@@ -26,15 +30,20 @@ export function DrawerDimensions({
   depth,
   height,
   gridUnitMm,
+  gridUnitMmY,
+  depthScale = 1,
   heightUnitMm,
 }: DrawerDimensionsProps) {
   const colors = useThreeColors();
   // Convert height from height-units to grid-units for 3D space
   const heightInGridUnits = height * (heightUnitMm / gridUnitMm);
+  // Depth axis is compressed in world space for a non-square grid; the mm label
+  // uses the true Y pitch.
+  const scaledDepth = depth * depthScale;
 
   // Calculate real-world dimensions in mm
   const widthMm = width * gridUnitMm;
-  const depthMm = depth * gridUnitMm;
+  const depthMm = depth * gridUnitMmY;
   const heightMm = height * heightUnitMm;
 
   const dimensions = useMemo(
@@ -56,11 +65,12 @@ export function DrawerDimensions({
           ] as [[number, number, number], [number, number, number]],
         },
       },
-      // Depth dimension - along left edge (X = -OFFSET)
+      // Depth dimension - along left edge (X = -OFFSET). Y positions compress by
+      // depthScale to track the scaled floor; the mm label is the true depth.
       depth: {
         start: [-OFFSET, 0, 0] as [number, number, number],
-        end: [-OFFSET, depth, 0] as [number, number, number],
-        labelPos: [-OFFSET - 0.3, depth / 2, 0] as [number, number, number],
+        end: [-OFFSET, scaledDepth, 0] as [number, number, number],
+        labelPos: [-OFFSET - 0.3, scaledDepth / 2, 0] as [number, number, number],
         label: `${depthMm}mm`,
         endCaps: {
           left: [
@@ -68,16 +78,16 @@ export function DrawerDimensions({
             [-OFFSET + END_CAP_SIZE, 0, 0],
           ] as [[number, number, number], [number, number, number]],
           right: [
-            [-OFFSET - END_CAP_SIZE, depth, 0],
-            [-OFFSET + END_CAP_SIZE, depth, 0],
+            [-OFFSET - END_CAP_SIZE, scaledDepth, 0],
+            [-OFFSET + END_CAP_SIZE, scaledDepth, 0],
           ] as [[number, number, number], [number, number, number]],
         },
       },
       // Height dimension - vertical along back-left corner
       height: {
-        start: [-OFFSET, depth + OFFSET, 0] as [number, number, number],
-        end: [-OFFSET, depth + OFFSET, heightInGridUnits] as [number, number, number],
-        labelPos: [-OFFSET - 0.3, depth + OFFSET, heightInGridUnits / 2] as [
+        start: [-OFFSET, scaledDepth + OFFSET, 0] as [number, number, number],
+        end: [-OFFSET, scaledDepth + OFFSET, heightInGridUnits] as [number, number, number],
+        labelPos: [-OFFSET - 0.3, scaledDepth + OFFSET, heightInGridUnits / 2] as [
           number,
           number,
           number,
@@ -85,17 +95,17 @@ export function DrawerDimensions({
         label: `${heightMm}mm`,
         endCaps: {
           left: [
-            [-OFFSET - END_CAP_SIZE, depth + OFFSET, 0],
-            [-OFFSET + END_CAP_SIZE, depth + OFFSET, 0],
+            [-OFFSET - END_CAP_SIZE, scaledDepth + OFFSET, 0],
+            [-OFFSET + END_CAP_SIZE, scaledDepth + OFFSET, 0],
           ] as [[number, number, number], [number, number, number]],
           right: [
-            [-OFFSET - END_CAP_SIZE, depth + OFFSET, heightInGridUnits],
-            [-OFFSET + END_CAP_SIZE, depth + OFFSET, heightInGridUnits],
+            [-OFFSET - END_CAP_SIZE, scaledDepth + OFFSET, heightInGridUnits],
+            [-OFFSET + END_CAP_SIZE, scaledDepth + OFFSET, heightInGridUnits],
           ] as [[number, number, number], [number, number, number]],
         },
       },
     }),
-    [width, depth, heightInGridUnits, widthMm, depthMm, heightMm]
+    [width, scaledDepth, heightInGridUnits, widthMm, depthMm, heightMm]
   );
 
   return (

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
@@ -2,6 +2,7 @@ import { useMemo, useCallback, useRef, useState, useEffect } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
+import { effectiveGridUnitMmY } from '@/core/types';
 import { useSelectionStore } from '@/core/store/selection';
 import { useViewStore } from '@/core/store/view';
 import { calcMaxGridUnits } from '@/core/constants';
@@ -104,6 +105,7 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
     printBedSize,
     printBedDepth,
     gridUnitMm,
+    gridUnitMmY,
     heightUnitMm,
     layoutName,
   } = useLayoutStore(
@@ -115,6 +117,7 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
       printBedSize: state.layout.printBedSize,
       printBedDepth: state.layout.printBedDepth,
       gridUnitMm: state.layout.gridUnitMm,
+      gridUnitMmY: effectiveGridUnitMmY(state.layout),
       heightUnitMm: state.layout.heightUnitMm,
       layoutName: state.layout.name,
     }))
@@ -333,6 +336,7 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
           drawerDepth={drawer.depth}
           drawerHeight={drawer.height}
           gridUnitMm={gridUnitMm}
+          gridUnitMmY={gridUnitMmY}
           heightUnitMm={heightUnitMm}
           layoutName={layoutName}
           isExpanded={isPreviewExpanded}

--- a/src/features/grid-editor/components/Grid/IsometricPreview/Scene/Scene.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/Scene/Scene.test.tsx
@@ -190,6 +190,7 @@ describe('Scene', () => {
         drawerDepth={8}
         drawerHeight={21}
         gridUnitMm={42}
+        gridUnitMmY={42}
         heightUnitMm={7}
         layoutName="Test Layout"
       >
@@ -206,6 +207,7 @@ describe('Scene', () => {
         drawerDepth={8}
         drawerHeight={21}
         gridUnitMm={42}
+        gridUnitMmY={42}
         heightUnitMm={7}
         layoutName="Test Layout"
       >
@@ -222,6 +224,7 @@ describe('Scene', () => {
         drawerDepth={8}
         drawerHeight={21}
         gridUnitMm={42}
+        gridUnitMmY={42}
         heightUnitMm={7}
         layoutName="Test Layout"
       >
@@ -238,6 +241,7 @@ describe('Scene', () => {
         drawerDepth={8}
         drawerHeight={21}
         gridUnitMm={42}
+        gridUnitMmY={42}
         heightUnitMm={7}
         layoutName="Test Layout"
       >
@@ -254,6 +258,7 @@ describe('Scene', () => {
         drawerDepth={12}
         drawerHeight={30}
         gridUnitMm={42}
+        gridUnitMmY={42}
         heightUnitMm={7}
         layoutName="Large Layout"
       >
@@ -270,6 +275,7 @@ describe('Scene', () => {
         drawerDepth={8}
         drawerHeight={21}
         gridUnitMm={42}
+        gridUnitMmY={42}
         heightUnitMm={7}
         layoutName="Test Layout"
         isExpanded={true}
@@ -287,6 +293,7 @@ describe('Scene', () => {
         drawerDepth={8.5}
         drawerHeight={21}
         gridUnitMm={42}
+        gridUnitMmY={42}
         heightUnitMm={7}
         layoutName="Test Layout"
         fractionalEdgeX="start"

--- a/src/features/grid-editor/components/Grid/IsometricPreview/Scene/Scene.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/Scene/Scene.tsx
@@ -21,6 +21,7 @@ interface SceneProps {
   drawerDepth: number;
   drawerHeight: number;
   gridUnitMm: number;
+  gridUnitMmY: number;
   heightUnitMm: number;
   layoutName: string;
   isExpanded?: boolean;
@@ -77,6 +78,7 @@ export const Scene = forwardRef<SceneHandle, SceneProps>(
       drawerDepth,
       drawerHeight,
       gridUnitMm,
+      gridUnitMmY,
       heightUnitMm,
       layoutName,
       isExpanded,
@@ -99,26 +101,31 @@ export const Scene = forwardRef<SceneHandle, SceneProps>(
 
     // Calculate height-to-grid scale from user settings
     const heightToGridScale = heightUnitMm / gridUnitMm;
+    // Depth-axis world scale for a non-square grid: 1 grid unit of depth is
+    // `gridUnitMmY/gridUnitMm` world units, so a 42×22 drawer renders shallow.
+    // Equals 1 for a square grid, leaving every existing preview unchanged.
+    const depthToGridScale = gridUnitMmY / gridUnitMm;
+    const scaledDepth = drawerDepth * depthToGridScale;
 
     // Calculate scene center for camera target
     const centerX = drawerWidth / 2;
-    const centerY = drawerDepth / 2;
+    const centerY = scaledDepth / 2;
     const centerZ = (drawerHeight * heightToGridScale) / 2;
 
     // Calculate default camera position - front-right view so FRONT is at bottom-left
     const defaultCameraPosition = useMemo(() => {
-      const maxDimension = Math.max(drawerWidth, drawerDepth);
+      const maxDimension = Math.max(drawerWidth, scaledDepth);
       const cameraDistance = maxDimension * 0.8;
       return [
         centerX + cameraDistance,
         centerY - cameraDistance,
         centerZ + cameraDistance * 0.7,
       ] as [number, number, number];
-    }, [drawerWidth, drawerDepth, centerX, centerY, centerZ]);
+    }, [drawerWidth, scaledDepth, centerX, centerY, centerZ]);
 
     // Calculate preset camera positions
     const cameraPresets = useMemo(() => {
-      const maxDimension = Math.max(drawerWidth, drawerDepth);
+      const maxDimension = Math.max(drawerWidth, scaledDepth);
       const distance = maxDimension * 0.8;
 
       return {
@@ -130,7 +137,7 @@ export const Scene = forwardRef<SceneHandle, SceneProps>(
         front: [centerX, centerY - distance * 1.2, centerZ] as [number, number, number],
         side: [centerX + distance * 1.2, centerY, centerZ] as [number, number, number],
       };
-    }, [drawerWidth, drawerDepth, centerX, centerY, centerZ]);
+    }, [drawerWidth, scaledDepth, centerX, centerY, centerZ]);
 
     // Set camera up vector to Z-up and position to default view (only on initial mount)
     useEffect(() => {
@@ -167,7 +174,7 @@ export const Scene = forwardRef<SceneHandle, SceneProps>(
       if (shouldFitZoom) {
         const fitZoom = calculateFitZoom(
           drawerWidth,
-          drawerDepth,
+          scaledDepth,
           drawerHeight,
           heightToGridScale,
           size.width,
@@ -180,7 +187,7 @@ export const Scene = forwardRef<SceneHandle, SceneProps>(
       }
 
       prevSizeRef.current = { width: size.width, height: size.height };
-    }, [size, camera, drawerWidth, drawerDepth, drawerHeight, heightToGridScale]);
+    }, [size, camera, drawerWidth, scaledDepth, drawerHeight, heightToGridScale]);
 
     // Track rotation in ref during interaction (no React re-renders)
     const rotationRef = useRef(0);
@@ -317,7 +324,7 @@ export const Scene = forwardRef<SceneHandle, SceneProps>(
         <ContactShadows
           position={[centerX, centerY, 0.01]}
           opacity={0.2}
-          scale={Math.max(drawerWidth, drawerDepth) * 1.2}
+          scale={Math.max(drawerWidth, scaledDepth) * 1.2}
           blur={3.5}
           far={drawerHeight * heightToGridScale}
           resolution={128}
@@ -325,16 +332,24 @@ export const Scene = forwardRef<SceneHandle, SceneProps>(
           frames={isInteracting ? 0 : Infinity}
         />
 
-        {/* Floor grid, axis labels, and front label */}
-        <FloorGrid
-          width={drawerWidth}
-          depth={drawerDepth}
-          fractionalEdgeX={fractionalEdgeX}
-          fractionalEdgeY={fractionalEdgeY}
-        />
+        {/* Geometry (floor grid + bins) is compressed on the depth axis for a
+            non-square grid. Annotations stay outside this group and scale their
+            Y positions directly, so their glyphs/ticks never squash. */}
+        <group scale={[1, depthToGridScale, 1]}>
+          <FloorGrid
+            width={drawerWidth}
+            depth={drawerDepth}
+            fractionalEdgeX={fractionalEdgeX}
+            fractionalEdgeY={fractionalEdgeY}
+          />
+          {/* Bins */}
+          {children}
+        </group>
+
         <AxisLabels
           width={drawerWidth}
           depth={drawerDepth}
+          depthScale={depthToGridScale}
           fractionalEdgeX={fractionalEdgeX}
           fractionalEdgeY={fractionalEdgeY}
         />
@@ -346,13 +361,12 @@ export const Scene = forwardRef<SceneHandle, SceneProps>(
           depth={drawerDepth}
           height={drawerHeight}
           gridUnitMm={gridUnitMm}
+          gridUnitMmY={gridUnitMmY}
+          depthScale={depthToGridScale}
           heightUnitMm={heightUnitMm}
         />
-        <ScaleIndicator gridUnitMm={gridUnitMm} drawerDepth={drawerDepth} />
-        {showBananaScale && <BananaScale drawerDepth={drawerDepth} gridUnitMm={gridUnitMm} />}
-
-        {/* Bins */}
-        {children}
+        <ScaleIndicator gridUnitMm={gridUnitMm} drawerDepth={scaledDepth} />
+        {showBananaScale && <BananaScale drawerDepth={scaledDepth} gridUnitMm={gridUnitMm} />}
       </>
     );
   }


### PR DESCRIPTION
## What this does

Follow-up to #2706. The layout's **3D isometric preview** now compresses its depth (Y) axis by `gridUnitMmY / gridUnitMm`, so a non-square grid (e.g. 42×22) renders a **shallow** drawer that matches the 2D canvas, the baseplate, and the exported geometry — instead of a square one.

Square grids are byte-identical (scale = 1).

## How

- **Scene:** bins + floor grid render inside a `group scale={[1, depthScale, 1]}`; camera framing, fit-zoom, contact shadows, and the orbit target all use the scaled depth. Bins and every geometry overlay are untouched — the group does the work.
- **Annotations stay outside the group** so their glyphs never squash: `AxisLabels` and `DrawerDimensions` compress only their Y tick/label *positions*; the depth dimension now reads the true depth (`depth × gridUnitMmY`). `ScaleIndicator`, `BananaScale`, and `FrontLabel` position off the scaled depth.

## Verification

Typecheck, lint, and the preview component tests pass. Visually verified with a headless Playwright screenshot of a seeded 42×22 layout: the drawer renders shallow and wide, the depth dimension reads `132mm` (6 × 22), the width `252mm` (6 × 42), and all labels stay crisp/unsquashed.

## Known minor gap

The exploded multi-layer view's per-layer text label sits inside the scaled group, so it would squash under an extreme non-square ratio (exploded + non-square is a rare combination). Filed as a small follow-up rather than expanding this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compresses the 3D preview’s depth (Y) axis by `gridUnitMmY / gridUnitMm` so non-square grids render shallow drawers that match the 2D canvas, baseplate, and exports. Square grids are unchanged. Aligns with Linear #2704.

- **New Features**
  - Scene: floor grid + bins render inside a depth-scaled group; camera framing, fit-zoom, contact shadows, and orbit target use the scaled depth.
  - AxisLabels/DrawerDimensions: compress Y tick/label positions without squashing text; depth label uses `gridUnitMmY` for true mm.
  - ScaleIndicator/BananaScale: position off the scaled depth; tests pass `gridUnitMmY` and cover the non-square depth label.

<sup>Written for commit a41805ad7f1a5273d7747b6a3e4c980815bc12d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

