### PR TITLE
feat(designer): support-free tapered magnet pads with rounded corners

### DIFF
--- a/src/features/generation/worker/generators/lidRetentionMagnets.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidRetentionMagnets.scenario.test.ts
@@ -107,13 +107,17 @@ describe('magnetic-retention lid geometry', () => {
     // Sum downward-facing triangle area inside the corner-pad window: inboard
     // of the walls and lip (3mm) but within the pads' reach of the corners
     // (16mm), above the base/floor plate and below the rim. In this window
-    // the pads are the only geometry on a default bin, so a flat pad
-    // underside (the pre-#2712 shape, |nz| ≈ 1) is cleanly separable from
-    // the 45° taper (|nz| ≈ 0.707).
-    const downFacingAreas = (mesh: MeshData): { flat: number; sloped: number } => {
+    // the pads are the only geometry on a default bin. A face needs supports
+    // when it is closer to horizontal than the 45° FDM limit: nz below
+    // -cos(45°) ≈ -0.707. The threshold sits at -0.72 so the taper's exact
+    // 45° plane (nz = -0.7071) stays on the printable side while ANY steeper
+    // overhang — the pre-#2712 flat underside (nz ≈ -1) or a partial
+    // transition anywhere in between — counts as a violation, with no
+    // unclassified gap.
+    const downFacingAreas = (mesh: MeshData): { unsupported: number; taper: number } => {
       const bb = boundingBox(mesh.vertices);
-      let flat = 0;
-      let sloped = 0;
+      let unsupported = 0;
+      let taper = 0;
       for (let i = 0; i < mesh.indices.length; i += 3) {
         const a = mesh.indices[i];
         const b = mesh.indices[i + 1];
@@ -137,21 +141,21 @@ describe('magnetic-retention lid geometry', () => {
         // before and would silently blind this check.
         const nz = triangleNormalZ(mesh.vertices, a, b, c);
         const area = triangleArea(mesh.vertices, a, b, c);
-        if (nz < -0.95) flat += area;
-        else if (nz < -0.6 && nz > -0.8) sloped += area;
+        if (nz < -0.72) unsupported += area;
+        else if (nz < -0.65) taper += area;
       }
-      return { flat, sloped };
+      return { unsupported, taper };
     };
 
     const pads = downFacingAreas(magnetic);
-    // No flat downward faces: the taper meets the pad bottom at the tongue
-    // tip, so only sub-mm² tessellation slivers may register.
-    expect(pads.flat).toBeLessThan(2);
+    // No support-requiring downward faces: the taper meets the pad bottom at
+    // the tongue tip, so only sub-mm² tessellation slivers may register.
+    expect(pads.unsupported).toBeLessThan(2);
     // The 45° underside itself must be present in force (4 pads' worth).
-    expect(pads.sloped).toBeGreaterThan(100);
+    expect(pads.taper).toBeGreaterThan(100);
     // Control: the window really isolates the pads — a plain bin has nothing
-    // sloping down there, so the sloped signal above comes from the taper.
-    expect(downFacingAreas(plain).sloped).toBeLessThan(5);
+    // sloping down there, so the taper signal above comes from the pads.
+    expect(downFacingAreas(plain).taper).toBeLessThan(5);
   });
 
   it('leaves the bin footprint unchanged (posts grow inward)', async () => {

--- a/src/features/generation/worker/generators/lidRetentionMagnets.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidRetentionMagnets.scenario.test.ts
@@ -12,9 +12,15 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
-import { assertStructurallyValid, boundingBox } from './__kernel-tests__/meshAssertions';
+import {
+  assertStructurallyValid,
+  boundingBox,
+  triangleArea,
+  triangleNormalZ,
+} from './__kernel-tests__/meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams, LidConfig } from '@/features/bin-designer/types';
+import type { MeshData } from '@/features/generation/bridge/types';
 
 beforeAll(async () => {
   await initBrepjs();
@@ -67,10 +73,13 @@ describe('magnetic-retention lid geometry', () => {
 
   it('pads are top overhangs, not full-height columns (height-independent)', async () => {
     const generateBin = getGenerateBin();
-    // The gusset pads live at the top rim, so the geometry they ADD over a
-    // plain bin must not scale with bin height. A returning full-column bug
-    // would make the delta grow with height. Compare the magnetic-vs-plain
-    // triangle delta at height 3 and height 6 — they should be close.
+    // The gusset pads (plus their fixed-depth 45° taper) live at the top rim,
+    // so the geometry they ADD over a plain bin must not scale with bin
+    // height. A returning full-column bug would make the delta grow with
+    // height. Compare the magnetic-vs-plain triangle delta at height 4 and
+    // height 7 — both tall enough that the taper floats above the floor (on
+    // shorter bins it clamps to the floor by design, which would skew the
+    // comparison).
     const deltaAt = (height: number): number => {
       const plain = generateBin(
         makeParams({ attachment: 'clickRails' }, { width: 2, depth: 2, height })
@@ -80,12 +89,69 @@ describe('magnetic-retention lid geometry', () => {
       );
       return magnetic.triangleCount - plain.triangleCount;
     };
-    const d3 = deltaAt(3);
-    const d6 = deltaAt(6);
-    expect(d3).toBeGreaterThan(0);
+    const d4 = deltaAt(4);
+    const d7 = deltaAt(7);
+    expect(d4).toBeGreaterThan(0);
     // Allow tessellation jitter but reject height-scaling (a column would
-    // roughly double the added side-wall triangles from height 3 to 6).
-    expect(Math.abs(d6 - d3)).toBeLessThan(d3 * 0.5);
+    // roughly double the added side-wall triangles from height 4 to 7).
+    expect(Math.abs(d7 - d4)).toBeLessThan(d4 * 0.5);
+  });
+
+  it('pad undersides taper at 45° — no flat overhang needing supports (#2712)', async () => {
+    const generateBin = getGenerateBin();
+    const base = { width: 2, depth: 2, height: 4 };
+    const magnetic = generateBin(makeParams({ attachment: 'magnetic' }, base));
+    const plain = generateBin(makeParams({ attachment: 'clickRails' }, base));
+    assertStructurallyValid(magnetic, '2x2 bin with tapered gusset pads');
+
+    // Sum downward-facing triangle area inside the corner-pad window: inboard
+    // of the walls and lip (3mm) but within the pads' reach of the corners
+    // (16mm), above the base/floor plate and below the rim. In this window
+    // the pads are the only geometry on a default bin, so a flat pad
+    // underside (the pre-#2712 shape, |nz| ≈ 1) is cleanly separable from
+    // the 45° taper (|nz| ≈ 0.707).
+    const downFacingAreas = (mesh: MeshData): { flat: number; sloped: number } => {
+      const bb = boundingBox(mesh.vertices);
+      let flat = 0;
+      let sloped = 0;
+      for (let i = 0; i < mesh.indices.length; i += 3) {
+        const a = mesh.indices[i];
+        const b = mesh.indices[i + 1];
+        const c = mesh.indices[i + 2];
+        const cx = (mesh.vertices[a * 3] + mesh.vertices[b * 3] + mesh.vertices[c * 3]) / 3;
+        const cy =
+          (mesh.vertices[a * 3 + 1] + mesh.vertices[b * 3 + 1] + mesh.vertices[c * 3 + 1]) / 3;
+        const cz =
+          (mesh.vertices[a * 3 + 2] + mesh.vertices[b * 3 + 2] + mesh.vertices[c * 3 + 2]) / 3;
+        const inCornerZone =
+          Math.abs(cx) > bb.maxX - 16 &&
+          Math.abs(cx) < bb.maxX - 3 &&
+          Math.abs(cy) > bb.maxY - 16 &&
+          Math.abs(cy) < bb.maxY - 3 &&
+          cz > 8 &&
+          cz < bb.maxZ - 0.5;
+        if (!inCornerZone) continue;
+        // Winding-based geometric normal, not the stored vertex normals: the
+        // index winding is consistently outward-oriented (bin floor bottoms
+        // read -1), while stored normals have flipped on boolean-result faces
+        // before and would silently blind this check.
+        const nz = triangleNormalZ(mesh.vertices, a, b, c);
+        const area = triangleArea(mesh.vertices, a, b, c);
+        if (nz < -0.95) flat += area;
+        else if (nz < -0.6 && nz > -0.8) sloped += area;
+      }
+      return { flat, sloped };
+    };
+
+    const pads = downFacingAreas(magnetic);
+    // No flat downward faces: the taper meets the pad bottom at the tongue
+    // tip, so only sub-mm² tessellation slivers may register.
+    expect(pads.flat).toBeLessThan(2);
+    // The 45° underside itself must be present in force (4 pads' worth).
+    expect(pads.sloped).toBeGreaterThan(100);
+    // Control: the window really isolates the pads — a plain bin has nothing
+    // sloping down there, so the sloped signal above comes from the taper.
+    expect(downFacingAreas(plain).sloped).toBeLessThan(5);
   });
 
   it('leaves the bin footprint unchanged (posts grow inward)', async () => {

--- a/src/features/generation/worker/generators/pipeline/stages/lidRetentionStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/lidRetentionStage.ts
@@ -3,10 +3,19 @@
  *
  * When the design's lid uses magnetic retention, each corner of the bin grows a
  * gusset pad: a solid that anchors to the two interior corner walls near the top
- * and cantilevers inward (an overhang) to house a vertical magnet pocket opening
- * UPWARD. The mating lid boss hangs down to meet it — the pad top sits one
+ * and cantilevers inward to house a vertical magnet pocket opening UPWARD. The
+ * mating lid boss hangs down to meet it — the pad top sits one
  * `LID_MAGNET_SEAT_GAP` below the lid boss's bottom face when the lid is seated,
  * so the two magnets mate across a thin gap.
+ *
+ * The pad prints support-free (issue #2712): its underside is a single 45°
+ * plane rising along the corner diagonal, from the wall corner up to the pad
+ * bottom at the tip. Each layer overhangs the one below by at most the layer
+ * height, so the slicer never asks for supports inside the bin. On bins too
+ * short for the full taper it clamps to the interior floor and welds in. The
+ * pad's inward-pointing corner is rounded at the boss radius (a tongue wrapping
+ * the pocket) so contents can't snag on it; the other three corners stay square
+ * because they sit buried inside the walls.
  *
  * The magnet mating plane is recessed just below the rim so the lid magnet fits
  * entirely under the lid's top surface (no bump); this stage derives that plane
@@ -19,7 +28,7 @@
  * so the pads line up with the lid's bosses.
  */
 
-import { cylinder, drawRoundedRectangle, translate, unwrap, fuse, cutAll } from 'brepjs';
+import { cylinder, draw, rotate, translate, unwrap, fuse, cut, cutAll } from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { shouldGenerateLid } from '@/shared/types/bin';
@@ -28,6 +37,7 @@ import {
   LID_COPLANAR_MARGIN,
   LID_MAGNET_POST_FLOOR,
   LID_MAGNET_SEAT_GAP,
+  LID_MIN_CORNER_RADIUS,
 } from '../../lidConstants';
 import { resolveLidInputs } from '../../lidInputs';
 import {
@@ -95,16 +105,19 @@ export const lidRetentionStage: PipelineStage = {
     );
     const pocketDepth = Math.min(depth, availableForPocket);
     const padBottomZ = Math.max(floorTopZ, magnetTopZ - pocketDepth - LID_MAGNET_POST_FLOOR);
-    const padHeight = magnetTopZ - padBottomZ;
 
     const innerHalfW = dim.innerW / 2;
     const innerHalfD = dim.innerD / 2;
 
     let body: Shape3D = ctx.solid;
 
-    // 1. Fuse a gusset pad into each corner. The pad spans from the interior
-    //    wall corner (with a small overlap for a solid weld) inward past the
-    //    magnet, as a rounded box at the recessed pad height.
+    // 1. Fuse a gusset pad into each corner. The pad's footprint spans from the
+    //    interior wall corner (with a small overlap for a solid weld) inward
+    //    past the magnet; its inward corner is rounded at the boss radius so
+    //    the pad ends in a smooth tongue wrapping the pocket (#2712). Below
+    //    `padBottomZ` the pad continues down as a 45° taper: a single plane
+    //    rising along the corner diagonal from the wall corner to the tongue
+    //    tip, so the underside prints support-free.
     for (const [px, py] of positions) {
       const sx = Math.sign(px);
       const sy = Math.sign(py);
@@ -112,19 +125,84 @@ export const lidRetentionStage: PipelineStage = {
       const wallY = sy * (innerHalfD + GUSSET_WALL_OVERLAP);
       const innerX = px - sx * bossRadius;
       const innerY = py - sy * bossRadius;
-      const centerX = (wallX + innerX) / 2;
-      const centerY = (wallY + innerY) / 2;
       const sizeX = Math.abs(wallX - innerX);
       const sizeY = Math.abs(wallY - innerY);
-      const cornerR = Math.max(0.1, Math.min(1.5, sizeX / 2 - 0.1, sizeY / 2 - 0.1));
+      const tongueR = Math.max(
+        LID_MIN_CORNER_RADIUS,
+        Math.min(bossRadius, sizeX - LID_MIN_CORNER_RADIUS, sizeY - LID_MIN_CORNER_RADIUS)
+      );
 
-      const pad = drawRoundedRectangle(sizeX, sizeY, cornerR)
-        .sketchOnPlane('XY', padBottomZ)
-        .extrude(padHeight);
-      const positioned = translate(pad, [centerX, centerY, 0]);
+      // Taper depth along the diagonal: chosen so the 45° plane meets the pad
+      // bottom exactly at the rounded tongue's tip — no residual flat overhang.
+      // (A sharp corner would need (sizeX+sizeY)/√2; the rounding pulls the
+      // tip back by (2−√2)·tongueR of diagonal travel.)
+      const taperDepth = (sizeX + sizeY - (2 - Math.SQRT2) * tongueR) / Math.SQRT2;
+      const taperBottomZ = padBottomZ - taperDepth;
+      // Clamp to the interior floor, welding in by a coplanar margin so a
+      // truncated taper never leaves a boolean-hostile face-on-face contact.
+      const flatBottomZ =
+        taperBottomZ < floorTopZ + LID_COPLANAR_MARGIN
+          ? floorTopZ - LID_COPLANAR_MARGIN
+          : taperBottomZ;
+
+      // Footprint: three square corners buried in the walls, one rounded
+      // tongue. Positive sagitta bows left of travel (see
+      // sagittaArcConvention.test.ts); the arc must bow toward the removed
+      // corner. Every corner is drawn COUNTER-clockwise — mirroring one path
+      // template across the corners would flip the winding on half of them,
+      // which inverts the extruded solid's face orientation and ships flipped
+      // shading normals in the tessellated mesh.
+      const sagitta = -sx * sy * tongueR * (1 - Math.SQRT1_2);
+      const footprint =
+        sx * sy > 0
+          ? draw([wallX, wallY])
+              .lineTo([innerX, wallY])
+              .lineTo([innerX, innerY + sy * tongueR])
+              .sagittaArcTo([innerX + sx * tongueR, innerY], sagitta)
+              .lineTo([wallX, innerY])
+              .close()
+          : draw([wallX, wallY])
+              .lineTo([wallX, innerY])
+              .lineTo([innerX + sx * tongueR, innerY])
+              .sagittaArcTo([innerX, innerY + sy * tongueR], -sagitta)
+              .lineTo([innerX, wallY])
+              .close();
+      const padExt = footprint.sketchOnPlane('XY', flatBottomZ).extrude(magnetTopZ - flatBottomZ);
+
+      // Wedge cutter for the 45° underside, built in a canonical frame where
+      // +X is the diagonal rise direction (u = distance along the diagonal
+      // from the wall corner) and the prism spans Y symmetrically, then
+      // rotated onto the corner diagonal and moved to the wall corner. Only
+      // the sloped top face matters; the rest sits clear of the pad.
+      const zLow = Math.min(flatBottomZ, taperBottomZ) - 2;
+      const spanL = sizeX + sizeY + 4;
+      // 'XZ' extrudes toward -Y (same convention wallPatternClips relies on),
+      // so center the prism with an explicit +spanL/2 shift before rotating.
+      // Wound so the cutter solid's faces are outward-oriented — the sloped
+      // face it carves into the pad inherits this orientation, and a reversed
+      // winding would ship a flipped shading normal on the visible taper.
+      const wedgeRaw = draw([-1, taperBottomZ - 1])
+        .lineTo([-1, zLow])
+        .lineTo([taperDepth + 1, zLow])
+        .lineTo([taperDepth + 1, padBottomZ + 1])
+        .close()
+        .sketchOnPlane('XZ')
+        .extrude(spanL);
+      const wedgeCentered = translate(wedgeRaw, [0, spanL / 2, 0]);
+      wedgeRaw.delete();
+      const wedgeRotated = rotate(wedgeCentered, (Math.atan2(-sy, -sx) * 180) / Math.PI, {
+        axis: [0, 0, 1],
+      });
+      wedgeCentered.delete();
+      const wedge = translate(wedgeRotated, [wallX, wallY, 0]);
+      wedgeRotated.delete();
+
+      const pad = unwrap(cut(padExt as ValidSolid, wedge as ValidSolid));
+      padExt.delete();
+      wedge.delete();
+
+      const fused = unwrap(fuse(body as ValidSolid, pad));
       pad.delete();
-      const fused = unwrap(fuse(body as ValidSolid, positioned as ValidSolid));
-      positioned.delete();
       body.delete();
       body = fused;
     }
@@ -141,10 +219,10 @@ export const lidRetentionStage: PipelineStage = {
       );
     }
 
-    const cut = unwrap(cutAll(body as ValidSolid, cutters as ValidSolid[]));
+    const pocketed = unwrap(cutAll(body as ValidSolid, cutters as ValidSolid[]));
     for (const c of cutters) c.delete();
     body.delete();
 
-    return { ...ctx, solid: cut };
+    return { ...ctx, solid: pocketed };
   },
 };


### PR DESCRIPTION
## Summary

Fixes #2712 — the bin-side magnetic-lid gusset pads (from #2694) had flat undersides floating in mid-air, a 90° overhang that made slicers demand supports inside the bin, plus a sharp inward corner that snagged contents.

### Support-free 45° taper

Each pad now continues downward as a taper whose underside is a **single 45° plane rising along the corner diagonal**, from the wall corner up to the pad bottom. Every layer overhangs the one below by at most the layer height, so the pad prints support-free on any FDM printer. Details:

- The taper depth is sized so the plane meets the pad bottom **exactly at the rounded tongue's tip** — no residual flat overhang anywhere.
- A single diagonal plane (rather than two wall-anchored 45° planes) avoids the valley crease of the two-plane variant, whose intersection line only climbs at ~35° from horizontal.
- On bins too short for the full taper, it clamps to the interior floor and welds in by a coplanar margin (becoming a solid corner column — still support-free).
- Built as one wedge-prism cut per pad on the standalone pad solid before fusing, so the cutter can never touch the bin body.

### Rounded tongue

The pad's inward-pointing corner (previously rounded at most 1.5mm) is now **fully rounded at the boss radius**, so the pad ends in a smooth tongue wrapping the magnet pocket with a uniform `LID_MAGNET_BOSS_WALL` of material. The three wall-side corners stay square — they sit buried inside the walls, and square corners there maximize the weld.

No new parameters: the taper and rounding are always-on, consistent with the lid geometry's no-knobs philosophy. The lid side is unchanged (lids print top-face-down, so their bosses rise as columns).

### Winding fix for shading normals

Both the footprint profiles and the wedge cutter are wound consistently counter-clockwise. Mirroring one path template across the four corners flipped the winding on half of them, which shipped flipped shading normals on the pad tops and on every carved taper face (verified empirically: stored normals read +0.707 on physically downward 45° faces before the fix, −0.707 after).

## Tests

- New scenario test measures **winding-based geometric triangle normals** in the corner-pad zone: asserts zero flat downward-facing area (the pre-fix shape reads ~500mm²), ≥100mm² of 45° underside, and a plain-bin control proving the window isolates the pads. It deliberately avoids the stored vertex normals, which had flipped on boolean-result faces and would blind the check.
- Height-independence test moved from heights 3/6 to 4/7 so both samples have free-floating tapers (height 3 clamps to the floor by design).
- Validated locally: lidRetentionMagnets scenarios 12/12, all binGenerator scenarios 934/934, lidGenerator scenarios 45/45, typecheck, lint, full unit+dom suite 14,434 passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make bin-side magnetic-lid gusset pads print support-free by adding a 45° diagonal taper and rounding the inward corner into a smooth tongue. Fixes #2712 to stop slicers from adding internal supports and to reduce snagging.

- **New Features**
  - Pads now taper at 45° along the corner diagonal from wall corner to tongue tip; support-free and clamps to the floor on short bins with a coplanar margin.
  - Inward corner is fully rounded at the boss radius to form a smooth tongue around the magnet pocket; wall-side corners stay square. No new parameters.

- **Bug Fixes**
  - Fixed flipped shading normals by enforcing counter-clockwise winding for pad footprints and the wedge cutter.
  - Tightened taper test: flags any downward face steeper than 45° (nz < -0.72), asserts strong 45° underside signal, and keeps height-independence checks at 4/7.

<sup>Written for commit a6296b0617439b3176f8a8e954b5721ec64ce3d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

