### PR TITLE
feat(labels): scale label sockets to the print nozzle (#2690)

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useSettingsStore } from '@/core/store';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
 import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
 import { useTranslation } from '@/i18n';
@@ -50,6 +51,7 @@ export function useLabelTabsSection() {
     }))
   );
   const t = useTranslation();
+  const nozzleSizeMm = useSettingsStore((s) => s.settings.printSettings.nozzleSizeMm);
 
   const labelStatus = getFeatureStatus(params, 'label');
 
@@ -419,9 +421,12 @@ export function useLabelTabsSection() {
 
   const socketPlan = useMemo(() => {
     const { innerW } = binDimensions(params);
-    const clearanceMm = effectiveLabelSocketClearance(undefined, label.plateFitOffset);
+    // Nozzle-scaled to match the worker's cut so pickers/warnings can never
+    // disagree with the geometry (a wider nozzle can drop a compartment from
+    // a 2U plate to 1U).
+    const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, label.plateFitOffset);
     return planLabelSockets(compartments, innerW, clearanceMm);
-  }, [params, compartments, label.plateFitOffset]);
+  }, [params, compartments, label.plateFitOffset, nozzleSizeMm]);
 
   // Socket segment disabled when no standard plate fits anywhere, even
   // bin-spanning \u2014 sockets are never emitted at nonstandard widths.

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -30,6 +30,7 @@ import { useToastStore } from '@/core/store/toast';
 import { calcMaxGridUnits } from '@/core/constants';
 import { DEFAULT_PATTERN_SCALE } from '@/features/bin-designer/types';
 import { getActiveBridge, bridgeManager } from '@/shared/generation/bridge';
+import { withSocketNozzle } from '@/shared/generation/socketNozzle';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
 import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
 import { getSplitPieceCount, getSplitPlanePositionsMm } from '@/shared/utils/splitPositions';
@@ -340,6 +341,12 @@ export function useExport(): UseExportReturn {
 
       try {
         const fileName = generateFileName(params, format, config, designName);
+        // Scale a socket bin's pocket to the live nozzle at export (transient —
+        // never persisted into the design). No-op for non-socket bins.
+        const exportParams = withSocketNozzle(
+          params,
+          useSettingsStore.getState().settings.printSettings.nozzleSizeMm
+        );
         // Worker exports BREP only as 'stl' or 'step'; 3MF is packaged on the
         // main thread from the STL output.
         const workerFormat = format === 'step' ? 'step' : 'stl';
@@ -349,7 +356,9 @@ export function useExport(): UseExportReturn {
           // Reset per attempt so a resilience retry restarts the bar at 0
           // rather than jumping backwards from where the failed attempt left off.
           setExportProgress(0);
-          return bridge.exportCombined(params, workerFormat, { onProgress: setExportProgress });
+          return bridge.exportCombined(exportParams, workerFormat, {
+            onProgress: setExportProgress,
+          });
         });
         retryCount = exportResult.retryCount;
         restartCount = exportResult.restartCount;
@@ -444,6 +453,9 @@ export function useExport(): UseExportReturn {
           ...(params.splitConnectors ?? DEFAULT_SPLIT_CONNECTOR_CONFIG),
           nozzleSizeMm: useSettingsStore.getState().settings.printSettings.nozzleSizeMm,
         };
+        // Scale a socket bin's pocket to the same nozzle the connectors use
+        // (transient — never persisted). No-op for non-socket bins.
+        const splitParams = withSocketNozzle(params, connectorConfig.nozzleSizeMm);
         const totalPieceCount = getSplitPieceCount(
           params.width,
           params.depth,
@@ -456,7 +468,7 @@ export function useExport(): UseExportReturn {
         // thing as a single retryable operation.
         const splitExport = await exportWithResilience(() =>
           runSplitBinExport(
-            params,
+            splitParams,
             cutPlanesX,
             cutPlanesY,
             totalPieceCount,
@@ -481,7 +493,7 @@ export function useExport(): UseExportReturn {
           const combined = await exportWithResilience(() => {
             const bridge = getActiveBridge();
             if (!bridge) throw new Error('Bridge not available');
-            return bridge.exportCombined(params, 'stl');
+            return bridge.exportCombined(splitParams, 'stl');
           });
           // Companion retries roll into the totals.
           retryCount += combined.retryCount;

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -489,13 +489,17 @@ export function useGeneration(): void {
 
   // Re-generate when the print nozzle changes. Nozzle is not part of the design
   // (so it doesn't bump the epoch), but a socket bin's pocket clearance scales
-  // with it — only socket-mode bins need the regen; every other design is
-  // nozzle-invariant on this path.
+  // with it. Gate on `withSocketNozzle` itself (the single source of truth for
+  // "does the nozzle change geometry here") so we skip regen when it wouldn't —
+  // labels disabled, non-socket, or both nozzles at/below the 0.4mm baseline.
   useEffect(() => {
-    if (prevNozzleRef.current === nozzleSizeMm) return;
+    const prevNozzle = prevNozzleRef.current;
+    if (prevNozzle === nozzleSizeMm) return;
     prevNozzleRef.current = nozzleSizeMm;
-    if (!initializedRef.current) return;
-    if (itemKind !== 'bin' || params.label.mode !== 'socket') return;
+    if (!initializedRef.current || itemKind !== 'bin') return;
+    const before = withSocketNozzle(params, prevNozzle).nozzleSizeMm;
+    const after = withSocketNozzle(params, nozzleSizeMm).nozzleSizeMm;
+    if (before === after) return;
     void runGeneration(params);
   }, [nozzleSizeMm, itemKind, params, runGeneration]);
 }

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -2,10 +2,12 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { isErr } from '@/core/result';
 import { useDesignerStore } from '../store';
+import { useSettingsStore } from '@/core/store';
 import { bridgeManager, createDraftSkipGate } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
 import { generateBinDirect, canBinUseDirectMesh } from '@/shared/generation/directMesh';
 import { handleWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
+import { withSocketNozzle } from '@/shared/generation/socketNozzle';
 import {
   binMeshCacheKey,
   loadPersistedBinMesh,
@@ -144,6 +146,12 @@ export function useGeneration(): void {
     }))
   );
 
+  // Nozzle is a live print SETTING, not part of the persisted design. Socket-mode
+  // bins scale their pocket clearance to it (`withSocketNozzle`), so a nozzle
+  // change must regenerate even though it doesn't bump the design epoch.
+  const nozzleSizeMm = useSettingsStore((state) => state.settings.printSettings.nozzleSizeMm);
+  const prevNozzleRef = useRef(nozzleSizeMm);
+
   const setGenerationStatus = useDesignerStore((state) => state.setGenerationStatus);
   const setGenerationResult = useDesignerStore((state) => state.setGenerationResult);
   const setDraftResult = useDesignerStore((state) => state.setDraftResult);
@@ -153,7 +161,13 @@ export function useGeneration(): void {
   const dispatchDraft = useCallback(
     (preview: GenerationBridge, currentParams: BinParams, token: number) => {
       void preview
-        .generateImmediate(currentParams, () => {})
+        .generateImmediate(
+          withSocketNozzle(
+            currentParams,
+            useSettingsStore.getState().settings.printSettings.nozzleSizeMm
+          ),
+          () => {}
+        )
         .then((draft) => {
           if (token !== genTokenRef.current || token <= finalizedTokenRef.current) return;
           // Draft perf is intentionally not pushed to perfHistory — the overlay
@@ -206,15 +220,24 @@ export function useGeneration(): void {
       }
       setGenerationStatus('generating');
 
+      // Merge the live nozzle setting into a throwaway params object for every
+      // generation-affecting call below (worker, direct mesh, estimate, cache
+      // key, export warm) so a socket's clearance scales with the nozzle. The
+      // persisted design (autosave) keeps using `currentParams` — nozzle-free.
+      const genParams = withSocketNozzle(
+        currentParams,
+        useSettingsStore.getState().settings.printSettings.nozzleSizeMm
+      );
+
       // Instant synchronous draft (best-effort): for the common rectangular bin,
       // emit a procedural mesh on the main thread — no kernel, no WASM round-trip
       // — so something paints on the leading edge of an edit before the worker
       // even starts. Gated to bins the direct path renders faithfully; a throw
       // (degenerate input) silently degrades to the async paths below.
-      if (canBinUseDirectMesh(currentParams)) {
+      if (canBinUseDirectMesh(genParams)) {
         try {
           const start = performance.now();
-          const mesh = generateBinDirect(currentParams);
+          const mesh = generateBinDirect(genParams);
           if (token === genTokenRef.current && token > finalizedTokenRef.current) {
             setDraftResult(directMeshToPayload(mesh, performance.now() - start));
             directShownTokenRef.current = token;
@@ -235,15 +258,15 @@ export function useGeneration(): void {
       const skipBelowMs = draftSkipGate();
       const preview = previewBridgeRef.current;
       if (preview && !preview.isDestroyed && directShownTokenRef.current !== token) {
-        void bridge.estimateGenerate(currentParams).then((predictedMs) => {
+        void bridge.estimateGenerate(genParams).then((predictedMs) => {
           if (predictedMs !== null && predictedMs < skipBelowMs) return;
           if (token !== genTokenRef.current || token <= finalizedTokenRef.current) return;
-          dispatchDraft(preview, currentParams, token);
+          dispatchDraft(preview, genParams, token);
         });
       }
 
       try {
-        const result = await bridge.generate(currentParams, () => {});
+        const result = await bridge.generate(genParams, () => {});
 
         // A newer edit superseded this one; let its results win instead.
         if (token !== genTokenRef.current) return;
@@ -257,14 +280,14 @@ export function useGeneration(): void {
         // Persist the exact preview mesh so reopening this design next session
         // paints instantly (pre-draft) instead of re-paying the cold start.
         // Fire-and-forget; refreshes LRU freshness even when the entry exists.
-        savePersistedBinMesh(binMeshCacheKey(currentParams), result.mesh);
+        savePersistedBinMesh(binMeshCacheKey(genParams), result.mesh);
 
         // Once the user pauses, speculatively warm the export-quality shell so
         // the first export skips the deferred socket↔body fuse. (Any prior timer
         // was already cleared at the start of this generation.)
         warmTimerRef.current = setTimeout(() => {
           warmTimerRef.current = null;
-          bridgeRef.current?.warmExport(currentParams);
+          bridgeRef.current?.warmExport(genParams);
         }, EXPORT_WARM_IDLE_MS);
       } catch (e) {
         // Cancelled requests are expected during rapid param changes
@@ -338,7 +361,10 @@ export function useGeneration(): void {
     // arbitration, the same way the Manifold pre-draft does. Not for generic items.
     const initialState = useDesignerStore.getState();
     if (initialState.itemKind === 'bin') {
-      const initialKey = binMeshCacheKey(initialState.params);
+      // Match the nozzle-merged key the exact mesh was persisted under, so a
+      // socket bin on a wide nozzle still finds its saved pre-draft.
+      const nozzle = useSettingsStore.getState().settings.printSettings.nozzleSizeMm;
+      const initialKey = binMeshCacheKey(withSocketNozzle(initialState.params, nozzle));
       void loadPersistedBinMesh(initialKey).then((cached) => {
         if (cancelled || !cached) return;
         if (genTokenRef.current !== 0 || finalizedTokenRef.current > 0) return;
@@ -346,7 +372,11 @@ export function useGeneration(): void {
         // the bridge is ready, so the token stays 0). Don't paint a pre-draft
         // for params the user has already moved on from.
         const now = useDesignerStore.getState();
-        if (now.itemKind !== 'bin' || binMeshCacheKey(now.params) !== initialKey) return;
+        if (
+          now.itemKind !== 'bin' ||
+          binMeshCacheKey(withSocketNozzle(now.params, nozzle)) !== initialKey
+        )
+          return;
         // Claim the generation token before painting. The Manifold pre-draft
         // fires only while the token is still 0, so without this a slower
         // Manifold draft would overwrite this exact-quality cached mesh with a
@@ -456,4 +486,16 @@ export function useGeneration(): void {
       void runGeneration(params);
     }
   }, [epoch, params, itemKind, structure, envelope, runGeneration, runItemGeneration]);
+
+  // Re-generate when the print nozzle changes. Nozzle is not part of the design
+  // (so it doesn't bump the epoch), but a socket bin's pocket clearance scales
+  // with it — only socket-mode bins need the regen; every other design is
+  // nozzle-invariant on this path.
+  useEffect(() => {
+    if (prevNozzleRef.current === nozzleSizeMm) return;
+    prevNozzleRef.current = nozzleSizeMm;
+    if (!initializedRef.current) return;
+    if (itemKind !== 'bin' || params.label.mode !== 'socket') return;
+    void runGeneration(params);
+  }, [nozzleSizeMm, itemKind, params, runGeneration]);
 }

--- a/src/features/bin-designer/hooks/useLabelFitSampleExport.test.ts
+++ b/src/features/bin-designer/hooks/useLabelFitSampleExport.test.ts
@@ -77,7 +77,8 @@ describe('useLabelFitSampleExport', () => {
     });
 
     expect(ok).toBe(true);
-    expect(exportLabelFitSample).toHaveBeenCalledWith('stl');
+    // Nozzle (default 0.4) threaded through so coupons scale like real sockets.
+    expect(exportLabelFitSample).toHaveBeenCalledWith('stl', 0.4);
     expect(triggerDownload).toHaveBeenCalledWith(expect.any(Blob), 'label-fit-sample.stl');
   });
 
@@ -94,7 +95,7 @@ describe('useLabelFitSampleExport', () => {
     });
 
     expect(ok).toBe(true);
-    expect(exportLabelFitSample).toHaveBeenCalledWith('stl');
+    expect(exportLabelFitSample).toHaveBeenCalledWith('stl', 0.4);
     expect(triggerDownload).toHaveBeenCalledWith(expect.any(Blob), 'my-card.3mf');
   });
 

--- a/src/features/bin-designer/hooks/useLabelFitSampleExport.ts
+++ b/src/features/bin-designer/hooks/useLabelFitSampleExport.ts
@@ -3,9 +3,10 @@
  * calibration print sweeping the socket clearance across a fit-offset ladder,
  * plus a nominal reference plate to click into each socket.
  *
- * The card is fully standard-defined — no design parameters ride along — so
- * the winning coupon's embossed offset maps 1:1 onto the design's
- * fit-offset field.
+ * No design parameters ride along, so the winning coupon's embossed offset
+ * maps 1:1 onto the design's fit-offset field. The one print SETTING that does
+ * ride along is the nozzle (#2690): coupons scale their nominal clearance to it
+ * just like real sockets, so the offset transfers on that same nozzle.
  */
 
 import { useCallback, useState } from 'react';
@@ -44,8 +45,9 @@ export function useLabelFitSampleExport(): UseLabelFitSampleExportReturn {
 
       setIsExporting(true);
       try {
+        const nozzleSizeMm = useSettingsStore.getState().settings.printSettings.nozzleSizeMm;
         if (format === '3mf') {
-          const stlResult = await bridge.exportLabelFitSample('stl');
+          const stlResult = await bridge.exportLabelFitSample('stl', nozzleSizeMm);
           const parseResult = parseSTLBinary(stlResult.data);
           if (isErr(parseResult)) throw new Error(getUserMessage(parseResult.error));
           const printSettings = useSettingsStore.getState().settings.printSettings;
@@ -62,7 +64,7 @@ export function useLabelFitSampleExport(): UseLabelFitSampleExportReturn {
           });
           triggerDownload(blob, `${baseName}${FORMAT_EXTENSIONS['3mf']}`);
         } else {
-          const result = await bridge.exportLabelFitSample(format);
+          const result = await bridge.exportLabelFitSample(format, nozzleSizeMm);
           const blob = new Blob([result.data], { type: FORMAT_MIME_TYPES[format] });
           triggerDownload(blob, `${baseName}${FORMAT_EXTENSIONS[format]}`);
         }

--- a/src/features/bin-designer/hooks/useLabelPlateExport.ts
+++ b/src/features/bin-designer/hooks/useLabelPlateExport.ts
@@ -61,12 +61,16 @@ export function useLabelPlateExport(): UseLabelPlateExportReturn {
   const [isExporting, setIsExporting] = useState(false);
   const canExport = getActiveBridge() !== null;
 
+  const nozzleSizeMm = useSettingsStore((s) => s.settings.printSettings.nozzleSizeMm);
+
   const plates = useMemo(() => {
     if (!label.enabled || (label.mode ?? 'text') !== 'socket') return [];
     const { innerW } = binDimensions(params);
-    const clearanceMm = effectiveLabelSocketClearance(undefined, label.plateFitOffset);
+    // Same nozzle-scaled clearance the worker cuts with, so the widths planned
+    // here match the sockets — never offer a plate the widened pocket rejects.
+    const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, label.plateFitOffset);
     return planLabelPlates(compartments, innerW, clearanceMm, '');
-  }, [params, compartments, label]);
+  }, [params, compartments, label, nozzleSizeMm]);
 
   const buildRequest = useCallback((): {
     specs: LabelPlateExportSpec[];

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -717,6 +717,14 @@ export interface BinParams {
    * ⇒ 'edge', the corner-tracking default; only observable at `gridUnitMm > 42`.
    */
   readonly magnetAnchor?: MagnetAnchor;
+  /**
+   * Print nozzle (mm) a label socket's pocket clearance scales to (#2690).
+   * Like {@link magnetAnchor}, this is INJECTED transiently at generation time
+   * (`withSocketNozzle`, from the live print setting) and never persisted — the
+   * store's params stay nozzle-free so a printer's nozzle never syncs to other
+   * devices or rides along in a shared design. Undefined ⇒ 0.4mm baseline.
+   */
+  readonly nozzleSizeMm?: number;
   /** Height unit size in mm (default 7mm per Gridfinity spec) */
   readonly heightUnitMm: number;
   /** Wall thickness in mm (default 1.2) */

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -541,8 +541,11 @@ export class GenerationBridge {
     return exportLabelPlatesImpl(this, plates, options, format);
   }
 
-  exportLabelFitSample(format: ExportFormat): Promise<BaseplateExportResult> {
-    return exportLabelFitSampleImpl(this, format);
+  exportLabelFitSample(
+    format: ExportFormat,
+    nozzleSizeMm?: number
+  ): Promise<BaseplateExportResult> {
+    return exportLabelFitSampleImpl(this, format, nozzleSizeMm);
   }
 
   /** Whether the bridge has been destroyed */

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -420,7 +420,8 @@ export function exportLabelPlates(
  */
 export function exportLabelFitSample(
   ctx: BridgeExportContext,
-  format: ExportFormat
+  format: ExportFormat,
+  nozzleSizeMm?: number
 ): Promise<BaseplateExportResult> {
   return runExport<BaseplateExportResult>(
     ctx,
@@ -428,7 +429,7 @@ export function exportLabelFitSample(
     CONNECTOR_SAMPLE_TIMEOUT_MS,
     (requestId) => ({
       type: 'EXPORT_LABEL_FIT_SAMPLE',
-      payload: { requestId, format },
+      payload: { requestId, format, nozzleSizeMm },
     })
   );
 }

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -291,6 +291,8 @@ export interface ExportLabelFitSampleMessage {
 export interface ExportLabelFitSamplePayload {
   readonly requestId: string;
   readonly format: ExportFormat;
+  /** Live print nozzle (mm) so coupons scale like the sockets they calibrate. */
+  readonly nozzleSizeMm?: number;
 }
 
 export interface ExportMessage {

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelSockets.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelSockets.test.ts.snap
@@ -11,3 +11,5 @@ exports[`label sockets > 2×1 two compartments, two 1U sockets 1`] = `2176`;
 exports[`label sockets > 3×1 override forces a 1U plate 1`] = `1384`;
 
 exports[`label sockets > 3×1 socket auto-quantizes to 3U 1`] = `1384`;
+
+exports[`label sockets > 3×1 socket on a 0.6mm nozzle widens the pocket 1`] = `1384`;

--- a/src/features/generation/worker/generators/labelFitSample.ts
+++ b/src/features/generation/worker/generators/labelFitSample.ts
@@ -13,6 +13,11 @@
  * 1:1 to bins. The offsets are absolute (the ladder is NOT centered on the
  * design's current fit offset), matching how the field is entered.
  *
+ * The nominal clearance the ladder sweeps around scales with the caller's
+ * live nozzle (`nozzleSizeMm`), exactly as real sockets do (#2690), so the
+ * winning offset a maker records on a wide-nozzle print transfers to their
+ * bins printed on that same nozzle. Undefined = the 0.4mm baseline.
+ *
  * Export mirrors `connectorSample.ts`: pieces → compound → one
  * ready-to-slice STL/STEP.
  */
@@ -106,10 +111,10 @@ function roundedRect(cx: number, cy: number, w: number, h: number, r: number): D
  * on the strip in front of the socket. The socket cut is required (a card
  * without sockets is useless); the label degrades best-effort.
  */
-function buildCoupon(cy: number, offset: number): Shape3D {
+function buildCoupon(cy: number, offset: number, nozzleSizeMm: number | undefined): Shape3D {
   return withScope((scope: DisposalScope): Shape3D => {
     const t = LABEL_SOCKET_SHELF_THICKNESS_MM;
-    const clearanceMm = effectiveLabelSocketClearance(undefined, offset);
+    const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, offset);
     const pocketD = LABEL_PLATE_HEIGHT_MM + clearanceMm;
 
     let solid: Shape3D = scope.register(
@@ -158,12 +163,12 @@ function buildCoupon(cy: number, offset: number): Shape3D {
  * Build all card pieces as separate, bed-resting solids (Z≥0). Caller owns
  * the returned shapes (frees them after compounding).
  */
-export function buildLabelFitSampleCard(): Shape3D[] {
+export function buildLabelFitSampleCard(nozzleSizeMm?: number): Shape3D[] {
   const n = LABEL_FIT_SAMPLE_OFFSETS.length;
   const originY = ((n - 1) * ROW_PITCH) / 2;
 
   const pieces: Shape3D[] = LABEL_FIT_SAMPLE_OFFSETS.map((offset, i) =>
-    buildCoupon(originY - i * ROW_PITCH, offset)
+    buildCoupon(originY - i * ROW_PITCH, offset, nozzleSizeMm)
   );
 
   // One nominal blank reference plate beside the column: the offsets ride
@@ -183,10 +188,11 @@ export function buildLabelFitSampleCard(): Shape3D[] {
 /** Export the fit-calibration card as a single STL or STEP file. */
 export async function exportLabelFitSample(
   format: ExportFormat,
+  nozzleSizeMm?: number,
   tolerance?: number,
   angularTolerance?: number
 ): Promise<{ data: ArrayBuffer; fileName: string }> {
-  const pieces = buildLabelFitSampleCard();
+  const pieces = buildLabelFitSampleCard(nozzleSizeMm);
   let assembled: Shape3D;
   try {
     assembled = compound(pieces);

--- a/src/features/generation/worker/generators/labelTabBuilder.cacheKey.test.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.cacheKey.test.ts
@@ -51,4 +51,15 @@ describe('labelTabsFeature.cacheKey', () => {
     const base = withCompartments({});
     expect(keyFor(base)).not.toBe(keyFor({ ...base, label: { ...base.label, mode: 'socket' } }));
   });
+
+  it('changes with the nozzle in socket mode but not in text mode (#2690)', () => {
+    // The socket pocket clearance scales to the nozzle, so two nozzles must
+    // never share a feature-cache entry; text-mode geometry is nozzle-invariant.
+    const socket = { ...DEFAULT_BIN_PARAMS.label, enabled: true, mode: 'socket' as const };
+    const socketBase = { ...withCompartments({}), label: socket };
+    expect(keyFor(socketBase)).not.toBe(keyFor({ ...socketBase, nozzleSizeMm: 0.6 }));
+
+    const textBase = withCompartments({});
+    expect(keyFor(textBase)).toBe(keyFor({ ...textBase, nozzleSizeMm: 0.6 }));
+  });
 });

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -180,12 +180,15 @@ function buildLabelTabsInScope(
   let socket: SocketBuildInfo | null = null;
   let spanningWidthU: LabelPlateWidthU | null = null;
   if (mode === 'socket') {
-    // Nozzle passed as undefined (baseline): the bin worker receives only the
-    // persisted BinParams — no settings seam exists on this path, and baking
-    // the printer's nozzle into a synced design would be wrong on the user's
-    // other devices. `plateFitOffset`'s range covers wide-nozzle calibration
-    // manually until such a seam exists.
-    const clearanceMm = effectiveLabelSocketClearance(undefined, params.label.plateFitOffset);
+    // `nozzleSizeMm` is merged onto these params transiently at each generation
+    // boundary (`withSocketNozzle`) from the live print setting — it is never
+    // persisted into the synced design. Undefined here = the 0.4mm baseline
+    // (geometry unchanged). The user's `plateFitOffset` still stacks on top for
+    // per-printer calibration beyond the nozzle scaling.
+    const clearanceMm = effectiveLabelSocketClearance(
+      params.nozzleSizeMm,
+      params.label.plateFitOffset
+    );
     const plan = planLabelSockets(params.compartments, innerW, clearanceMm);
     spanningWidthU = plan.spanningWidthU;
     const plateByCompartment = new Map<number, LabelPlateWidthU>();

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -44,6 +44,7 @@ import {
   labelPlateWidthMm,
 } from '@/shared/constants/labelPlates';
 import type { LabelPlateWidthU, LabelSocketStyle } from '@/shared/constants/labelPlates';
+import { NOZZLE_BASELINE } from '@/shared/printSettings/connectorScaling';
 import { planLabelSockets } from '@/shared/utils/labelSocketPlan';
 import { sketch } from './meshUtils';
 import { buildFilletProfile } from './filletProfile';
@@ -960,11 +961,15 @@ export const labelTabsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     // Socket mode (#2666): geometry additionally depends on the
     // per-compartment width overrides (mode + plateFitOffset already ride in
-    // `stableSerialize(params.label)` below). Keyed only in socket mode so
-    // text-mode tabs don't churn when overrides linger in the config.
+    // `stableSerialize(params.label)` below) AND the print nozzle (#2690 — the
+    // pocket clearance scales to it, so two nozzles with identical overrides
+    // must not share a cache entry). Keyed only in socket mode so text-mode
+    // tabs don't churn when overrides/nozzle linger in the config.
     const socketKeyPart =
       (params.label.mode ?? 'text') === 'socket'
-        ? stableSerialize(params.compartments.labelPlateWidths ?? [])
+        ? `${stableSerialize(params.compartments.labelPlateWidths ?? [])}|n${quantize(
+            params.nozzleSizeMm ?? NOZZLE_BASELINE
+          )}`
         : 'text';
     return compactKey(
       buildCacheKey(

--- a/src/features/generation/worker/generators/scenarios/labelSockets.ts
+++ b/src/features/generation/worker/generators/scenarios/labelSockets.ts
@@ -14,11 +14,11 @@
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import {
   LABEL_PLATE_HEIGHT_MM,
-  LABEL_SOCKET_CLEARANCE_MM,
   LABEL_SOCKET_POCKET_DEPTH_MM,
   LABEL_SOCKET_RIB_HEIGHT_MM,
   LABEL_SOCKET_RIB_START_MM,
   LABEL_SOCKET_WALL_MM,
+  effectiveLabelSocketClearance,
   labelPlateWidthMm,
 } from '@/shared/constants/labelPlates';
 import type { LabelPlateWidthU } from '@/shared/constants/labelPlates';
@@ -53,8 +53,14 @@ interface PocketExpectation {
  */
 function assertSocketPocket(result: MeshData, params: BinParams, exp: PocketExpectation): void {
   const { vertices } = result;
-  const pocketW = labelPlateWidthMm(exp.plateWidthU) + LABEL_SOCKET_CLEARANCE_MM;
-  const pocketD = LABEL_PLATE_HEIGHT_MM + LABEL_SOCKET_CLEARANCE_MM;
+  // Derive the expected clearance the SAME way the worker does, so a wide-nozzle
+  // scenario proves the generator actually read `params.nozzleSizeMm` (#2690).
+  const clearanceMm = effectiveLabelSocketClearance(
+    params.nozzleSizeMm,
+    params.label.plateFitOffset
+  );
+  const pocketW = labelPlateWidthMm(exp.plateWidthU) + clearanceMm;
+  const pocketD = LABEL_PLATE_HEIGHT_MM + clearanceMm;
 
   const outerD = params.depth * params.gridUnitMm - 0.5;
   const innerD = outerD - 2 * params.wallThickness;
@@ -147,6 +153,22 @@ export const labelSockets: ScenarioCase[] = [
     },
     customAssert: (result, params) =>
       assertSocketPocket(result, params, { plateWidthU: 3, label: '3x1-auto' }),
+  }),
+
+  // Wide nozzle (#2690): the pocket clearance scales up, so the measured pocket
+  // is wider than the 0.4mm baseline. The assert derives the expected width from
+  // `params.nozzleSizeMm`, so this fails if the generator ignores the nozzle.
+  defineScenario('label sockets', '3×1 socket on a 0.6mm nozzle widens the pocket', {
+    params: {
+      width: 3,
+      depth: 1,
+      height: 5,
+      base: NO_LIP_BASE,
+      label: SOCKET_LABEL,
+      nozzleSizeMm: 0.6,
+    },
+    customAssert: (result, params) =>
+      assertSocketPocket(result, params, { plateWidthU: 3, label: '3x1-nozzle-0.6' }),
   }),
 
   defineScenario('label sockets', '3×1 override forces a 1U plate', {

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -169,7 +169,7 @@ export async function handleExportLabelFitSample(
     payload.requestId,
     'BASEPLATE_EXPORT_RESULT',
     async () => {
-      const result = await exportLabelFitSample(payload.format);
+      const result = await exportLabelFitSample(payload.format, payload.nozzleSizeMm);
       return { data: result.data, format: payload.format, fileName: result.fileName };
     },
     'Label fit sample export failed',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1695,14 +1695,14 @@ const en: Record<string, string> = {
   'binDesigner.fitSample.button': 'Print fit test',
   'binDesigner.fitSample.dialogTitle': 'Export fit test card',
   'binDesigner.fitSample.dialogDescription':
-    'A small calibration card: five sockets stepping the fit offset from −0.10 to +0.10 mm, plus one standard blank plate. Find the socket that clicks best and enter its offset in the plate fit field.',
+    'A calibration card sized to your current nozzle: five sockets stepping the fit offset from −0.10 to +0.10 mm around the nominal clearance, plus one standard blank plate. Print it, find the socket that clicks best, and enter its offset in the plate fit field.',
   'binDesigner.fitSample.exportComplete': 'Fit test card exported',
   'binDesigner.fitSample.exportFailed': 'Fit test card export failed',
   'binDesigner.fitSample.tipsTitle': 'How to use',
   'binDesigner.fitSample.tip1':
-    'Print flat, no supports, with the same material and settings as your bins.',
+    'Print flat, no supports, using the same nozzle, material, and settings as your bins — the fit depends on all three.',
   'binDesigner.fitSample.tip2':
-    'Click the included plate into each socket; pick the one that snaps in firmly and releases cleanly.',
+    'Click the included plate — or any Cullenect / gflabel plate you already own — into each socket, and pick the one that snaps in firmly and releases cleanly.',
   'binDesigner.fitSample.tip3': 'Enter that socket’s embossed value in the plate fit offset field.',
   'binDesigner.angledDividers.title': 'Diagonal dividers',
   'binDesigner.angledDividers.toggleLabel': 'Enable diagonal divider editing',

--- a/src/shared/generation/socketNozzle.test.ts
+++ b/src/shared/generation/socketNozzle.test.ts
@@ -38,6 +38,22 @@ describe('withSocketNozzle', () => {
     expect(withSocketNozzle(merged, 0.6)).toBe(merged);
   });
 
+  it('strips a stale injected nozzle when re-wrapped at the baseline', () => {
+    // A draft path can re-wrap an already-merged object; dropping back to 0.4
+    // must revert the pocket, not keep the wide-nozzle value.
+    const merged = withSocketNozzle(socketBin, 0.6);
+    const reverted = withSocketNozzle(merged, 0.4);
+    expect(reverted.nozzleSizeMm).toBeUndefined();
+  });
+
+  it('does not inject for a socket bin whose label is disabled', () => {
+    const disabled: BinParams = {
+      ...socketBin,
+      label: { ...socketBin.label, enabled: false },
+    };
+    expect(withSocketNozzle(disabled, 0.6)).toBe(disabled);
+  });
+
   it('ignores a non-finite nozzle', () => {
     expect(withSocketNozzle(socketBin, Number.NaN)).toBe(socketBin);
     expect(withSocketNozzle(socketBin, Number.POSITIVE_INFINITY)).toBe(socketBin);

--- a/src/shared/generation/socketNozzle.test.ts
+++ b/src/shared/generation/socketNozzle.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams } from '@/shared/types/bin';
+import { withSocketNozzle } from './socketNozzle';
+
+const textBin: BinParams = {
+  ...DEFAULT_BIN_PARAMS,
+  label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, mode: 'text' },
+};
+
+const socketBin: BinParams = {
+  ...DEFAULT_BIN_PARAMS,
+  label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, mode: 'socket' },
+};
+
+describe('withSocketNozzle', () => {
+  it('leaves a non-socket bin untouched at any nozzle (same reference)', () => {
+    expect(withSocketNozzle(textBin, 0.8)).toBe(textBin);
+    expect(withSocketNozzle(textBin, 0.4)).toBe(textBin);
+  });
+
+  it('leaves a socket bin untouched at or below the 0.4mm baseline', () => {
+    // Same reference so the mesh cache key stays byte-identical to pre-#2690.
+    expect(withSocketNozzle(socketBin, 0.4)).toBe(socketBin);
+    expect(withSocketNozzle(socketBin, 0.3)).toBe(socketBin);
+  });
+
+  it('injects the nozzle for a socket bin above baseline', () => {
+    const merged = withSocketNozzle(socketBin, 0.6);
+    expect(merged).not.toBe(socketBin);
+    expect(merged.nozzleSizeMm).toBe(0.6);
+    // Never mutates the input — persistence keeps writing nozzle-free params.
+    expect(socketBin.nozzleSizeMm).toBeUndefined();
+  });
+
+  it('is idempotent when the nozzle is already set', () => {
+    const merged = withSocketNozzle(socketBin, 0.6);
+    expect(withSocketNozzle(merged, 0.6)).toBe(merged);
+  });
+
+  it('ignores a non-finite nozzle', () => {
+    expect(withSocketNozzle(socketBin, Number.NaN)).toBe(socketBin);
+    expect(withSocketNozzle(socketBin, Number.POSITIVE_INFINITY)).toBe(socketBin);
+  });
+});

--- a/src/shared/generation/socketNozzle.ts
+++ b/src/shared/generation/socketNozzle.ts
@@ -21,8 +21,22 @@ import type { BinParams } from '@/shared/types/bin';
 import { NOZZLE_BASELINE } from '@/shared/printSettings/connectorScaling';
 
 export function withSocketNozzle(params: BinParams, nozzleSizeMm: number): BinParams {
-  if (params.label.mode !== 'socket') return params;
-  if (!Number.isFinite(nozzleSizeMm) || nozzleSizeMm <= NOZZLE_BASELINE) return params;
-  if (params.nozzleSizeMm === nozzleSizeMm) return params;
-  return { ...params, nozzleSizeMm };
+  // Nozzle only changes geometry for an ENABLED socket tab above baseline;
+  // keying it in otherwise is pure cache churn.
+  const wanted =
+    params.label.enabled &&
+    params.label.mode === 'socket' &&
+    Number.isFinite(nozzleSizeMm) &&
+    nozzleSizeMm > NOZZLE_BASELINE
+      ? nozzleSizeMm
+      : undefined;
+  if (params.nozzleSizeMm === wanted) return params;
+  // Strip a stale injected nozzle when reverting to baseline so re-wrapping an
+  // already-merged params object (e.g. a draft path) can't carry a wide-nozzle
+  // pocket back into a 0.4mm generation.
+  if (wanted === undefined) {
+    const { nozzleSizeMm: _drop, ...rest } = params;
+    return rest;
+  }
+  return { ...params, nozzleSizeMm: wanted };
 }

--- a/src/shared/generation/socketNozzle.ts
+++ b/src/shared/generation/socketNozzle.ts
@@ -1,0 +1,28 @@
+/**
+ * The bin GENERATE path's settings seam for nozzle-aware label sockets (#2690).
+ *
+ * A label socket's pocket clearance grows with a wider nozzle
+ * (`effectiveLabelSocketClearance`) so plates still click in when printed on a
+ * 0.6/0.8mm nozzle. The nozzle lives in `settings.printSettings.nozzleSizeMm`,
+ * NOT in the persisted design: baking it into `BinParams` would sync a
+ * printer's nozzle to the user's other devices and ride along in shared /
+ * exported designs. So the value is merged in transiently, at each generation
+ * boundary, onto a throwaway params object — the store keeps persisting
+ * nozzle-free params.
+ *
+ * Because the merged object also feeds `binMeshCacheKey`, the nozzle enters the
+ * mesh cache key (a nozzle change is a cache miss → correct regen) without ever
+ * entering persistence. Returns the input UNCHANGED — same reference — for
+ * non-socket designs and at/below the 0.4mm baseline, so those hashes stay
+ * byte-identical to the pre-#2690 keys and no cached mesh is needlessly evicted.
+ */
+
+import type { BinParams } from '@/shared/types/bin';
+import { NOZZLE_BASELINE } from '@/shared/printSettings/connectorScaling';
+
+export function withSocketNozzle(params: BinParams, nozzleSizeMm: number): BinParams {
+  if (params.label.mode !== 'socket') return params;
+  if (!Number.isFinite(nozzleSizeMm) || nozzleSizeMm <= NOZZLE_BASELINE) return params;
+  if (params.nozzleSizeMm === nozzleSizeMm) return params;
+  return { ...params, nozzleSizeMm };
+}

--- a/src/shared/hooks/useLabelPlateCounts.ts
+++ b/src/shared/hooks/useLabelPlateCounts.ts
@@ -99,7 +99,9 @@ export function useLabelPlateCounts(bins: Bin[]): ReadonlyMap<DesignId, DesignPl
     for (const bin of bins) {
       if (bin.linkedDesignId === undefined || refs.has(bin.linkedDesignId)) continue;
       const ref = registryById.get(bin.linkedDesignId);
-      if (ref) refs.set(bin.linkedDesignId, `${ref.id}:${ref.updatedAt}:n${nozzleSizeMm}`);
+      // Quantize the nozzle so float noise can't fragment the cache key.
+      if (ref)
+        refs.set(bin.linkedDesignId, `${ref.id}:${ref.updatedAt}:n${nozzleSizeMm.toFixed(3)}`);
     }
     return refs;
   }, [bins, registry, nozzleSizeMm]);

--- a/src/shared/hooks/useLabelPlateCounts.ts
+++ b/src/shared/hooks/useLabelPlateCounts.ts
@@ -20,6 +20,7 @@ import {
 } from '@/features/bin-designer';
 import { effectiveLabelSocketClearance } from '@/shared/constants/labelPlates';
 import type { LabelPlateWidthU } from '@/shared/constants/labelPlates';
+import { useSettingsStore } from '@/core/store';
 import { planLabelPlates } from '@/shared/utils/labelSocketPlan';
 
 /** The plates one placed bin of a socket-mode design needs. */
@@ -47,10 +48,10 @@ export function clearLabelPlateCountCache(): void {
   inFlight.clear();
 }
 
-function computePlateSet(design: SavedDesign): DesignPlateSet | null {
+function computePlateSet(design: SavedDesign, nozzleSizeMm: number): DesignPlateSet | null {
   const params = design.params;
   if (!params?.label.enabled || (params.label.mode ?? 'text') !== 'socket') return null;
-  const clearanceMm = effectiveLabelSocketClearance(undefined, params.label.plateFitOffset);
+  const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, params.label.plateFitOffset);
   const planned = planLabelPlates(
     params.compartments,
     binDimensions(params).innerW,
@@ -61,12 +62,15 @@ function computePlateSet(design: SavedDesign): DesignPlateSet | null {
   return { perBin: planned.length, widthsU: planned.map((p) => p.widthU) };
 }
 
-function enqueueLoad(id: DesignId, key: string, onSettled: () => void): void {
+function enqueueLoad(id: DesignId, key: string, nozzleSizeMm: number, onSettled: () => void): void {
   if (inFlight.has(key)) return;
   inFlight.add(key);
   void loadDesign(id)
     .then((result) => {
-      plateSetCache.set(id, { key, plateSet: isOk(result) ? computePlateSet(result.value) : null });
+      plateSetCache.set(id, {
+        key,
+        plateSet: isOk(result) ? computePlateSet(result.value, nozzleSizeMm) : null,
+      });
     })
     .catch(() => {
       plateSetCache.set(id, { key, plateSet: null });
@@ -85,6 +89,9 @@ function enqueueLoad(id: DesignId, key: string, onSettled: () => void): void {
 export function useLabelPlateCounts(bins: Bin[]): ReadonlyMap<DesignId, DesignPlateSet> {
   const registry = useCustomBins();
   const [loadTick, setLoadTick] = useState(0);
+  // In the cache key so a nozzle change recomputes plate widths at the new
+  // socket clearance (a wider nozzle can drop a compartment from 2U to 1U).
+  const nozzleSizeMm = useSettingsStore((s) => s.settings.printSettings.nozzleSizeMm);
 
   const linkedRefs = useMemo(() => {
     const registryById = new Map(registry.map((ref) => [ref.id, ref]));
@@ -92,10 +99,10 @@ export function useLabelPlateCounts(bins: Bin[]): ReadonlyMap<DesignId, DesignPl
     for (const bin of bins) {
       if (bin.linkedDesignId === undefined || refs.has(bin.linkedDesignId)) continue;
       const ref = registryById.get(bin.linkedDesignId);
-      if (ref) refs.set(bin.linkedDesignId, `${ref.id}:${ref.updatedAt}`);
+      if (ref) refs.set(bin.linkedDesignId, `${ref.id}:${ref.updatedAt}:n${nozzleSizeMm}`);
     }
     return refs;
-  }, [bins, registry]);
+  }, [bins, registry, nozzleSizeMm]);
 
   useEffect(() => {
     let cancelled = false;
@@ -103,12 +110,12 @@ export function useLabelPlateCounts(bins: Bin[]): ReadonlyMap<DesignId, DesignPl
       if (!cancelled) setLoadTick((tick) => tick + 1);
     };
     for (const [id, key] of linkedRefs) {
-      if (plateSetCache.get(id)?.key !== key) enqueueLoad(id, key, onSettled);
+      if (plateSetCache.get(id)?.key !== key) enqueueLoad(id, key, nozzleSizeMm, onSettled);
     }
     return () => {
       cancelled = true;
     };
-  }, [linkedRefs]);
+  }, [linkedRefs, nozzleSizeMm]);
 
   return useMemo(() => {
     // loadTick re-runs this memo when async loads land in the cache.

--- a/src/shared/hooks/useLinkedDesignMeshes.test.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.test.ts
@@ -75,7 +75,7 @@ function makeBinDesign(): SavedDesign {
   return {
     id: D1,
     name: 'Test Design',
-    params: { width: 2, depth: 1 } as unknown as BinParams,
+    params: { width: 2, depth: 1, label: { enabled: false } } as unknown as BinParams,
     thumbnail: null,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',

--- a/src/shared/hooks/useLinkedDesignMeshes.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.ts
@@ -194,7 +194,10 @@ export function useLinkedDesignMeshes(bins: Bin[]): Map<DesignId, LinkedDesignMe
     for (const bin of bins) {
       if (bin.linkedDesignId === undefined || refs.has(bin.linkedDesignId)) continue;
       const ref = registryById.get(bin.linkedDesignId);
-      if (ref) refs.set(bin.linkedDesignId, `${ref.id}:${ref.updatedAt}:n${nozzleSizeMm}`);
+      // Quantize the nozzle so float noise (e.g. 0.6000000000000001) can't
+      // fragment the cache key into avoidable misses.
+      if (ref)
+        refs.set(bin.linkedDesignId, `${ref.id}:${ref.updatedAt}:n${nozzleSizeMm.toFixed(3)}`);
     }
     return refs;
   }, [bins, registry, nozzleSizeMm]);

--- a/src/shared/hooks/useLinkedDesignMeshes.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.ts
@@ -29,6 +29,8 @@ import {
   savePersistedBinMesh,
 } from '@/shared/generation/meshPersistence';
 import { bridgeManager } from '@/shared/generation/bridge';
+import { withSocketNozzle } from '@/shared/generation/socketNozzle';
+import { useSettingsStore } from '@/core/store';
 import type { MeshData } from '@/shared/types/generation';
 
 /** A resolved design mesh ready for layout preview rendering. */
@@ -99,7 +101,8 @@ function centerImportedVertices(
 
 async function resolveDesignMesh(
   design: SavedDesign,
-  sig: string
+  sig: string,
+  nozzleSizeMm: number
 ): Promise<LinkedDesignMesh | null> {
   const structure = design.structure;
   if (structure?.kind === 'importedMesh' && design.envelope) {
@@ -124,7 +127,10 @@ async function resolveDesignMesh(
   const params = design.params;
   if (!params) return null;
 
-  const persistKey = binMeshCacheKey(params);
+  // Nozzle-merged (transient) so a socket bin's pocket matches the live print
+  // setting and shares the same cache key the designer preview persists under.
+  const genParams = withSocketNozzle(params, nozzleSizeMm);
+  const persistKey = binMeshCacheKey(genParams);
   const persisted = await loadPersistedBinMesh(persistKey);
   if (persisted) {
     return { sig, mesh: persisted, width: params.width, depth: params.depth };
@@ -134,7 +140,7 @@ async function resolveDesignMesh(
   // background thumbnail regeneration) and persist it for future sessions.
   const bridge = await bridgeManager.acquire();
   try {
-    const result = await bridge.generateImmediate(params);
+    const result = await bridge.generateImmediate(genParams);
     if (result.mesh.vertices.length === 0) return null;
     savePersistedBinMesh(persistKey, result.mesh);
     return { sig, mesh: result.mesh, width: params.width, depth: params.depth };
@@ -143,13 +149,20 @@ async function resolveDesignMesh(
   }
 }
 
-function enqueueResolve(id: DesignId, key: string, onSettled: () => void): void {
+function enqueueResolve(
+  id: DesignId,
+  key: string,
+  nozzleSizeMm: number,
+  onSettled: () => void
+): void {
   if (inFlight.has(key)) return;
   inFlight.add(key);
   resolveChain = resolveChain.then(async () => {
     try {
       const designResult = await loadDesign(id);
-      const entry = isOk(designResult) ? await resolveDesignMesh(designResult.value, key) : null;
+      const entry = isOk(designResult)
+        ? await resolveDesignMesh(designResult.value, key, nozzleSizeMm)
+        : null;
       setCachedMesh(key, entry);
     } catch {
       // Worker init/generation failure — cache the miss so we don't retry
@@ -170,6 +183,10 @@ function enqueueResolve(id: DesignId, key: string, onSettled: () => void): void 
 export function useLinkedDesignMeshes(bins: Bin[]): Map<DesignId, LinkedDesignMesh> {
   const registry = useCustomBins();
   const [loadTick, setLoadTick] = useState(0);
+  // Part of the cache key so a nozzle change re-resolves socket-bin meshes at the
+  // new pocket clearance. Non-socket designs re-resolve too but hit the persisted
+  // mesh cache (their key is nozzle-invariant), so it stays cheap.
+  const nozzleSizeMm = useSettingsStore((state) => state.settings.printSettings.nozzleSizeMm);
 
   const linkedRefs = useMemo(() => {
     const registryById = new Map(registry.map((ref) => [ref.id, ref]));
@@ -177,10 +194,10 @@ export function useLinkedDesignMeshes(bins: Bin[]): Map<DesignId, LinkedDesignMe
     for (const bin of bins) {
       if (bin.linkedDesignId === undefined || refs.has(bin.linkedDesignId)) continue;
       const ref = registryById.get(bin.linkedDesignId);
-      if (ref) refs.set(bin.linkedDesignId, `${ref.id}:${ref.updatedAt}`);
+      if (ref) refs.set(bin.linkedDesignId, `${ref.id}:${ref.updatedAt}:n${nozzleSizeMm}`);
     }
     return refs;
-  }, [bins, registry]);
+  }, [bins, registry, nozzleSizeMm]);
 
   useEffect(() => {
     let cancelled = false;
@@ -188,12 +205,12 @@ export function useLinkedDesignMeshes(bins: Bin[]): Map<DesignId, LinkedDesignMe
       if (!cancelled) setLoadTick((tick) => tick + 1);
     };
     for (const [id, key] of linkedRefs) {
-      if (!meshCache.has(key)) enqueueResolve(id, key, onSettled);
+      if (!meshCache.has(key)) enqueueResolve(id, key, nozzleSizeMm, onSettled);
     }
     return () => {
       cancelled = true;
     };
-  }, [linkedRefs]);
+  }, [linkedRefs, nozzleSizeMm]);
 
   return useMemo(() => {
     // loadTick re-runs this memo when async resolutions land in the cache

--- a/src/shell/layoutExport/planLabelPlateExport.test.ts
+++ b/src/shell/layoutExport/planLabelPlateExport.test.ts
@@ -49,7 +49,7 @@ describe('planLabelPlateExport', () => {
         }),
       },
     ];
-    const plan = planLabelPlateExport([linkedBin('d1')], loaded, BED, BED);
+    const plan = planLabelPlateExport([linkedBin('d1')], loaded, BED, BED, 0.4);
     expect(plan.groups).toHaveLength(0);
     expect(plan.totalPlates).toBe(0);
   });
@@ -70,7 +70,7 @@ describe('planLabelPlateExport', () => {
         }),
       },
     ];
-    const plan = planLabelPlateExport([linkedBin('d1')], loaded, BED, BED);
+    const plan = planLabelPlateExport([linkedBin('d1')], loaded, BED, BED, 0.4);
     expect(plan.groups[0].manifestPlates).toHaveLength(2);
     const icons = plan.groups[0].manifestPlates.map((p) => p.icon).sort();
     expect(icons).toEqual(['bolt', 'nut']);
@@ -90,7 +90,7 @@ describe('planLabelPlateExport', () => {
     const loaded: LoadedDesign[] = [
       { id: designId('d1'), design: socketDesign('d1', 'Colored', coloredParams) },
     ];
-    const plan = planLabelPlateExport([linkedBin('d1')], loaded, BED, BED);
+    const plan = planLabelPlateExport([linkedBin('d1')], loaded, BED, BED, 0.4);
     expect(plan.groups).toHaveLength(1);
     expect(plan.groups[0].featureColors?.enabled).toBe(true);
     expect(plan.groups[0].featureColors?.labelTab).toBe('#112233');
@@ -103,7 +103,7 @@ describe('planLabelPlateExport', () => {
       { ...linkedBin('d1'), id: createTestBin({ x: 3 }).id, x: 3 },
     ] as Bin[];
 
-    const plan = planLabelPlateExport(bins, loaded, BED, BED);
+    const plan = planLabelPlateExport(bins, loaded, BED, BED, 0.4);
     expect(plan.totalPlates).toBe(4);
     expect(plan.groups).toHaveLength(1);
     expect(plan.groups[0].manifestPlates).toEqual(
@@ -134,7 +134,7 @@ describe('planLabelPlateExport', () => {
       { ...linkedBin('d1', { label: '' }), id: createTestBin({ x: 3 }).id, x: 3 },
     ] as Bin[];
 
-    const plan = planLabelPlateExport(bins, loaded, BED, BED);
+    const plan = planLabelPlateExport(bins, loaded, BED, BED, 0.4);
     expect(plan.totalPlates).toBe(2);
     expect(plan.groups[0].manifestPlates).toEqual(
       expect.arrayContaining([
@@ -152,7 +152,7 @@ describe('planLabelPlateExport', () => {
       x: i,
     })) as Bin[];
 
-    const plan = planLabelPlateExport(bins, loaded, BED, BED);
+    const plan = planLabelPlateExport(bins, loaded, BED, BED, 0.4);
     const sheets = plan.groups[0].sheets;
     expect(sheets.length).toBeGreaterThan(0);
     const placed = sheets.flat();
@@ -173,7 +173,7 @@ describe('planLabelPlateExport', () => {
     })) as Bin[];
 
     // Tiny 60mm bed: one 1U plate per row, few rows per sheet.
-    const plan = planLabelPlateExport(bins, loaded, 60, 60);
+    const plan = planLabelPlateExport(bins, loaded, 60, 60, 0.4);
     expect(plan.groups[0].sheets.length).toBeGreaterThan(1);
     const placed = plan.groups[0].sheets.flat();
     expect(placed).toHaveLength(20);
@@ -196,7 +196,7 @@ describe('planLabelPlateExport', () => {
         }),
       },
     ];
-    const plan = planLabelPlateExport([linkedBin('d1')], loaded, 60, 60);
+    const plan = planLabelPlateExport([linkedBin('d1')], loaded, 60, 60, 0.4);
     expect(plan.totalPlates).toBe(0);
     expect(plan.groups).toHaveLength(1);
     expect(plan.groups[0].sheets).toHaveLength(0);

--- a/src/shell/layoutExport/planLabelPlateExport.ts
+++ b/src/shell/layoutExport/planLabelPlateExport.ts
@@ -140,7 +140,8 @@ export function planLabelPlateExport(
   bins: Bin[],
   loaded: readonly LoadedDesign[],
   bedWidthMm: number,
-  bedDepthMm: number
+  bedDepthMm: number,
+  nozzleSizeMm: number
 ): LabelPlateExportPlan {
   const designById = new Map(
     loaded.filter((l) => l.design?.params).map((l) => [l.id, l.design] as const)
@@ -157,7 +158,7 @@ export function planLabelPlateExport(
     const linkedBins = bins.filter((b) => b.linkedDesignId === id);
     if (linkedBins.length === 0) continue;
 
-    const clearanceMm = effectiveLabelSocketClearance(undefined, params.label.plateFitOffset);
+    const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, params.label.plateFitOffset);
     const planned = planLabelPlates(
       params.compartments,
       binDimensions(params).innerW,

--- a/src/shell/layoutExport/useLayoutExport.ts
+++ b/src/shell/layoutExport/useLayoutExport.ts
@@ -21,6 +21,7 @@ import { trackEvent } from '@/shared/analytics/posthog';
 import { getErrorMessage } from '@/shared/utils/errors';
 import { bridgeManager, workerPoolManager } from '@/shared/generation/bridge';
 import type { ExportFormat, CombinedExportResult } from '@/shared/generation/bridge';
+import { withSocketNozzle } from '@/shared/generation/socketNozzle';
 import { export3MF } from '@/shared/generation/export';
 import type { FaceGroupData } from '@/shared/types/generation';
 import type { FeatureColorConfig } from '@/shared/types/bin';
@@ -227,7 +228,9 @@ export function useLayoutExport(): UseLayoutExportReturn {
         let done = 0;
 
         if (simple.length > 0) {
-          const params = simple.map((e) => e.params);
+          // Scale each socket bin's pocket to the live nozzle (transient — never
+          // persisted). No-op for non-socket designs.
+          const params = simple.map((e) => withSocketNozzle(e.params, printSettings.nozzleSizeMm));
           let bytes: ArrayBuffer[];
           if (pool && !pool.isDestroyed && pool.size > 1) {
             const results = await pool.exportBins(params, workerFormat, (c) =>
@@ -253,7 +256,10 @@ export function useLayoutExport(): UseLayoutExportReturn {
         }
 
         for (const e of companions) {
-          const result = await bridge.exportCombined(e.params, workerFormat);
+          const result = await bridge.exportCombined(
+            withSocketNozzle(e.params, printSettings.nozzleSizeMm),
+            workerFormat
+          );
           binFiles.push(...(await combinedFiles(result, format, e.path, e.params, printSettings)));
           done++;
           setExportProgress({ current: done, total: binTotal, label: binLabel(done) });
@@ -287,7 +293,8 @@ export function useLayoutExport(): UseLayoutExportReturn {
           bins,
           loaded,
           layout.printBedSize,
-          layout.printBedDepth ?? layout.printBedSize
+          layout.printBedDepth ?? layout.printBedSize,
+          printSettings.nozzleSizeMm
         );
         const labelFiles: ZipBinaryFile[] = [];
         const manifestLabels: ManifestLabelGroup[] = [];


### PR DESCRIPTION
## What & why

Swappable-label sockets (#2666) were tuned for a 0.4mm nozzle. On a wider nozzle the pocket clearance stayed the same, so plates fit too tight to click in. This scales a socket's pocket clearance to the active print nozzle automatically, so plates keep clicking in on 0.6/0.8mm nozzles.

Addresses the nozzle-scaling follow-up in #2690.

## How it works

The nozzle (`settings.printSettings.nozzleSizeMm`) is merged into generation **transiently** (`withSocketNozzle`) and folded into the mesh cache key, but is **never persisted** into the design — so a printer's nozzle doesn't sync to your other devices or ride along in a shared/exported design. `withSocketNozzle` returns the input unchanged for non-socket bins and at/below the 0.4mm baseline, so nothing that doesn't need new geometry is affected and no existing cached mesh is invalidated.

Applied consistently across every boundary that shows or cuts a socket, so the width picker can never offer a plate the widened socket rejects:

- Live designer preview (+ draft, cache key, export-warm, and a regen on nozzle change)
- Layout 3D linked-design preview
- Bin export (single + split) and whole-layout ZIP export
- Plate-width / plate-count / fit-warning math
- The fit-calibration card scales to the nozzle too, so its winning offset transfers to bins printed on that same nozzle

The fit-test dialog copy was refined to explain the nozzle/material dependency and that you can test against a real Cullenect/gflabel plate you already own.

## Verification

- New mesh-measuring scenario: a 3×1 socket on a 0.6mm nozzle produces a measurably wider pocket (the assert derives the expected clearance from the nozzle, so it fails if generation ignores it). No existing geometry snapshot changed.
- New unit tests for the settings seam.
- typecheck, lint, knip, module boundaries, and all i18n checks pass.

## Still open in #2690 (not in this PR)

Physical click-fit verification against a printed Cullenect/gflabel plate — a print test, not a code change. If nominal (+0.00) isn't the best fit, the next step is shifting the baseline `LABEL_SOCKET_CLEARANCE_MM`. #2690 stays open to track it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scales swappable‑label socket pocket clearance to the active print nozzle so plates keep clicking in on 0.6/0.8mm, without persisting the nozzle in designs. Regenerates only when the nozzle changes geometry and quantizes nozzle values in cache keys to avoid misses. Addresses Linear #2690.

- **New Features**
  - Introduced `withSocketNozzle` to inject `settings.printSettings.nozzleSizeMm` transiently into generation and the bin mesh cache key; never persisted in `BinParams`.
  - Applied nozzle scaling across live preview/draft/cache key/export warm, linked-design previews, single/split/ZIP exports, plate width/count/fit-warning math, and layout plate export; socket bins auto‑regenerate on nozzle changes.
  - Fit test card now takes the nozzle and scales nominal clearance; updated help copy; added unit tests and a 0.6mm scenario that measures a wider pocket.

- **Bug Fixes**
  - Worker feature cache now keys sockets by nozzle in socket mode to avoid stale narrow sockets after a nozzle change; text mode remains nozzle‑invariant.
  - Hardened `withSocketNozzle`: ignores disabled labels, strips a stale injected nozzle when reverting to the 0.4mm baseline, and is idempotent; added regression tests.
  - Nozzle-change regeneration now gates on `withSocketNozzle`, so bins only re-generate when the nozzle affects geometry (labels disabled, non-socket, or ≤0.4mm baseline skip).
  - Quantized nozzle folded into linked-design and plate-count cache keys to avoid float-noise fragmentation and stale/missed entries.

<sup>Written for commit 8882d9f49a846114cb20ff32c0cbed0bf1f0332a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

