### PR TITLE
fix(designer): engrave cutout labels on the recess floor (#2726)

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.cutout-floor-label.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.cutout-floor-label.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+/**
+ * A center-anchored cutout label must survive into the final mesh (#2726).
+ *
+ * The label used to engrave at the un-recessed fill top, so its shallow cut sat
+ * entirely inside the volume the cavity removes — the boolean stage subtracted
+ * both and the text vanished from the model and every export. Tool-level tests
+ * can't prove the end result, so this asserts at mesh level: the labeled bin
+ * gains glyph geometry in the engrave band just below the recess floor.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { loadFont, isErr } from 'brepjs';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+
+beforeAll(async () => {
+  await initBrepjs();
+  const buffer = readFileSync(
+    resolve(__dirname, '../assets/fonts/AtkinsonHyperlegible-Regular.ttf')
+  );
+  const result = await loadFont(
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+    'atkinson'
+  );
+  if (isErr(result)) throw new Error(`Font load failed: ${result.error.message}`);
+}, 60000);
+
+const CUT_DEPTH = 5;
+
+function solidBinWithRecessedLabel(label: string): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: 1,
+    depth: 1,
+    height: 3,
+    style: 'solid',
+    base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+    cutoutConfig: { topOffset: 0 },
+    cutouts: [
+      {
+        id: 'c1',
+        shape: 'rectangle',
+        x: 10,
+        y: 10,
+        width: 20,
+        depth: 20,
+        cutDepth: CUT_DEPTH,
+        rotation: 0,
+        cornerRadius: 0,
+        label,
+        engraveLabel: true,
+        textAnchor: 'center',
+        groupId: null,
+      },
+    ],
+  };
+}
+
+function verticesInBand(vertices: Float32Array, lo: number, hi: number): number {
+  let count = 0;
+  for (let i = 2; i < vertices.length; i += 3) {
+    if (vertices[i] > lo && vertices[i] < hi) count++;
+  }
+  return count;
+}
+
+describe('recessed cutout label (#2726)', () => {
+  it('engraves the center-anchored label into the recess floor of the final mesh', () => {
+    const generateBin = getGenerateBin();
+    const labeled = generateBin(solidBinWithRecessedLabel('HI'));
+    const plain = generateBin(solidBinWithRecessedLabel(''));
+
+    expect(labeled.triangleCount).toBeGreaterThan(plain.triangleCount + 50);
+
+    // The engraving's bottom faces sit `textDefaults.depth` below the recess
+    // floor — a z-slab the unlabeled bin has no geometry in (its first surface
+    // below the floor is the socket region much further down). Glyph wall
+    // vertices land exactly at floor and floor − depth, so the band includes
+    // the engrave bottom but stays clear of the floor plane itself.
+    let topZ = -Infinity;
+    for (let i = 2; i < plain.vertices.length; i += 3) {
+      if (plain.vertices[i] > topZ) topZ = plain.vertices[i];
+    }
+    const floorZ = topZ - CUT_DEPTH;
+    const engraveDepth = DEFAULT_BIN_PARAMS.textDefaults.depth;
+    const lo = floorZ - engraveDepth - 0.1;
+    const hi = floorZ - 0.05;
+    expect(verticesInBand(plain.vertices, lo, hi)).toBe(0);
+    expect(verticesInBand(labeled.vertices, lo, hi)).toBeGreaterThan(0);
+  }, 180000);
+});

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -32,7 +32,7 @@ import {
   transformCopy,
   setShapeOrigin,
 } from 'brepjs';
-import type { TransformOp } from 'brepjs';
+import type { TransformOp, Bounds3D } from 'brepjs';
 import type { Shape3D, ValidSolid, Edge, Dimension, DisposalScope, Drawing, Sketch } from 'brepjs';
 import type { BinParams, Cutout, PathPoint, GroupOp } from '@/shared/types/bin';
 import {
@@ -49,6 +49,7 @@ import {
 } from '@/shared/utils/cutoutPolygon';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
 import { dropCoincidentPoints } from '@/shared/utils/polyline';
+import { pointInPolyline } from '@/shared/utils/drawerOutlineGeometry';
 import { cutoutLabelPlacement } from '@/shared/utils/cutoutLabel';
 import { combineGroupSolids } from './cutoutGroupOps';
 import {
@@ -1068,12 +1069,25 @@ export function buildCutoutCuts(
   // bin-top text through the floor is meaningless. Engraved text joins the cut
   // pile; top-surface embossed text is collected separately for fusing; floor
   // embossed text is carved out of its cavity tool.
+  // Group op per groupId, keyed off the first member in cutouts order — the
+  // same member buildGroupedCutouts reads it from.
+  const groupOps = new Map<string, GroupOp>();
+  for (const c of params.cutouts) {
+    if (c.groupId !== null && !groupOps.has(c.groupId)) {
+      groupOps.set(c.groupId, c.groupOp ?? DEFAULT_GROUP_OP);
+    }
+  }
+
   const rawFuseShapes: Shape3D[] = [];
   for (const cutout of params.cutouts) {
     if (cutout.hidden === true) continue;
     if (cutout.engraveLabel !== true) continue;
     const label = cutout.label.trim();
     if (label === '') continue;
+    // Non-union groups (subtract/intersect/exclude) can hollow a member's
+    // footprint out of the final cavity, so a member-footprint floor guess may
+    // point at solid material. Only union cavities keep member floors intact.
+    const allowFloor = cutout.groupId === null || groupOps.get(cutout.groupId) === 'union';
     const textShape = buildCutoutLabel(
       cutout,
       label,
@@ -1082,7 +1096,8 @@ export function buildCutoutCuts(
       originX,
       originY,
       innerW,
-      innerD
+      innerD,
+      allowFloor
     );
     if (!textShape) continue;
     // Label text is its own color zone — tag it TEXT so an engraved label
@@ -1174,6 +1189,57 @@ interface CutoutLabelShape {
   readonly op: 'cut' | 'fuse' | 'carve';
 }
 
+/** Point-in-rounded-rect for a `2·hw × 2·hd` rect with corner radius `r`,
+ *  centered at the origin. */
+function roundedRectContains(lx: number, ly: number, hw: number, hd: number, r: number): boolean {
+  const ax = Math.abs(lx);
+  const ay = Math.abs(ly);
+  if (ax > hw || ay > hd) return false;
+  if (r <= 0) return true;
+  const ex = ax - (hw - r);
+  const ey = ay - (hd - r);
+  if (ex <= 0 || ey <= 0) return true;
+  return ex * ex + ey * ey <= r * r;
+}
+
+/**
+ * Whether a point (in the cutout's local, unrotated frame, origin at its
+ * center) lies inside the actual cavity footprint. Shape-aware so a label near
+ * a bounding-box corner of a circle/polygon/path isn't mistaken for "over the
+ * recess" and engraved at floor depth under solid fill. Degenerate polygons and
+ * paths extrude as their bounding box (see the shape builders), so their
+ * containment tests fall back to the same box.
+ */
+function labelCenterInFootprint(cutout: Cutout, lx: number, ly: number): boolean {
+  const hw = cutout.width / 2;
+  const hd = cutout.depth / 2;
+  switch (cutout.shape) {
+    case 'circle':
+      return hw > 0 && hd > 0 && (lx / hw) ** 2 + (ly / hd) ** 2 <= 1;
+    case 'polygon': {
+      const pts = regularPolygonPoints(
+        clampPolygonSides(cutout.sides ?? DEFAULT_POLYGON_SIDES),
+        cutout.width,
+        cutout.depth
+      );
+      if (pts.length < 3) return Math.abs(lx) <= hw && Math.abs(ly) <= hd;
+      return pointInPolyline(pts, lx, ly);
+    }
+    case 'slot':
+      return roundedRectContains(lx, ly, hw, hd, slotCornerRadius(cutout.width, cutout.depth));
+    case 'path': {
+      const outline = pathOutline(cutout);
+      if (!outline) return Math.abs(lx) <= hw && Math.abs(ly) <= hd;
+      return pointInPolyline(outline, lx, ly);
+    }
+    case 'mesh':
+      // Mesh imprints are filtered out before the label loop; unreachable.
+      return false;
+    case 'rectangle':
+      return roundedRectContains(lx, ly, hw, hd, Math.min(cutout.cornerRadius, hw, hd));
+  }
+}
+
 /**
  * Z of the surface a cutout label lands on: the recess floor when the placed
  * center sits inside the cutout's rotated footprint (the `center` anchor, or an
@@ -1199,8 +1265,7 @@ function labelSurfaceZ(
   const s = Math.sin(theta);
   const lx = dx * c - dy * s;
   const ly = dx * s + dy * c;
-  const inside = Math.abs(lx) <= cutout.width / 2 && Math.abs(ly) <= cutout.depth / 2;
-  if (!inside) return solidSurfaceZ;
+  if (!labelCenterInFootprint(cutout, lx, ly)) return solidSurfaceZ;
   return solidSurfaceZ - Math.min(cutout.cutDepth, solidSurfaceZ);
 }
 
@@ -1213,14 +1278,35 @@ function labelSurfaceZ(
  * carve keeps the uncarved cavity and silently drops the label (matching
  * {@link buildCutoutLabel}'s silent-skip contract).
  */
+function boundsOverlap(a: Bounds3D, b: Bounds3D): boolean {
+  return (
+    a.xMin <= b.xMax &&
+    a.xMax >= b.xMin &&
+    a.yMin <= b.yMax &&
+    a.yMax >= b.yMin &&
+    a.zMin <= b.zMax &&
+    a.zMax >= b.zMin
+  );
+}
+
 function carveLabelFromCavities(
   text: Shape3D,
   indices: readonly number[] | undefined,
   rawShapes: Shape3D[]
 ): void {
   try {
+    const textBounds = getBounds(text);
     for (const i of indices ?? []) {
+      // Array instances all register under the master's id, but the glyphs
+      // occupy a single world location — skip tools the text can't touch so
+      // spaced instances don't pay (or risk) a pointless boolean. Every
+      // OVERLAPPING tool must be carved, though: an uncarved overlapping
+      // cavity would erase the standing text when it is subtracted.
+      if (!boundsOverlap(textBounds, getBounds(rawShapes[i]))) continue;
       try {
+        // brepjs `cut` never consumes its operands (callers delete inputs
+        // themselves — see lightweightBaseBuilder), so reusing `text` across
+        // iterations is safe.
         const carved = unwrap(cut(rawShapes[i] as ValidSolid, text as ValidSolid));
         if (carved !== rawShapes[i]) {
           rawShapes[i].delete();
@@ -1238,6 +1324,8 @@ function carveLabelFromCavities(
 /**
  * Label text for a cutout: on the bin top beside it (outer anchors) or on the
  * recess floor inside it (`center` anchor, see {@link labelSurfaceZ}).
+ * `allowFloor` gates the floor branch — callers pass false for members of
+ * non-union groups, whose final cavity may not contain the member's footprint.
  *
  * The side picker is interpreted in WORLD coordinates (top = +Y, etc.); text
  * reads left-to-right in world XY regardless of cutout rotation. The cutout
@@ -1263,7 +1351,8 @@ function buildCutoutLabel(
   originX: number,
   originY: number,
   innerW: number,
-  innerD: number
+  innerD: number,
+  allowFloor: boolean
 ): CutoutLabelShape | null {
   const placement = cutoutLabelPlacement(cutout, innerW, innerD, originX, originY);
   if (!placement) return null;
@@ -1278,7 +1367,9 @@ function buildCutoutLabel(
   // degrades to engrave.
   const mode = style.mode === 'emboss' ? 'emboss' : 'engrave';
 
-  const surfaceZ = labelSurfaceZ(cutout, centerX, centerY, solidSurfaceZ, originX, originY);
+  const surfaceZ = allowFloor
+    ? labelSurfaceZ(cutout, centerX, centerY, solidSurfaceZ, originX, originY)
+    : solidSurfaceZ;
   // A recess consuming the full fill depth leaves no floor to engrave into —
   // the interior clip stops at z=0 to protect the base, so skip the label.
   if (mode === 'engrave' && surfaceZ <= 0) return null;

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -20,6 +20,7 @@ import {
   translate,
   fillet,
   intersect,
+  cut,
   rotate,
   edgeFinder,
   getBounds,
@@ -1012,9 +1013,17 @@ export function buildCutoutCuts(
   // cutout is tagged (colored or not), so recoloring stays a pure read-side
   // change that never regenerates geometry.
   const rawTags: number[] = [];
+  // Cavity tool indices per cutout id — floor-embossed labels are carved OUT
+  // of their owning cavity tool rather than fused (see carveLabelFromCavities).
+  const cavityIndices = new Map<string, number[]>();
   const cavityTag = (cutout: Cutout): number =>
     cutoutColorTag(colorOrdinal.get(cutoutUnitKey(cutout)) ?? 0);
-  const pushRaw = (shape: Shape3D, tag: number): void => {
+  const pushRaw = (shape: Shape3D, tag: number, ownerId?: string): void => {
+    if (ownerId !== undefined) {
+      const list = cavityIndices.get(ownerId);
+      if (list) list.push(rawShapes.length);
+      else cavityIndices.set(ownerId, [rawShapes.length]);
+    }
     rawShapes.push(shape);
     rawTags.push(tag);
   };
@@ -1026,11 +1035,11 @@ export function buildCutoutCuts(
     if (cutout.groupId === null) {
       if (cutout.array) {
         for (const s of buildArrayUngroupedCutouts(cutout, solidSurfaceZ, originX, originY)) {
-          pushRaw(s, cavityTag(cutout));
+          pushRaw(s, cavityTag(cutout), cutout.id);
         }
       } else {
         const shape = buildUngroupedCutout(cutout, solidSurfaceZ, originX, originY);
-        if (shape) pushRaw(shape, cavityTag(cutout));
+        if (shape) pushRaw(shape, cavityTag(cutout), cutout.id);
       }
     } else {
       const list = groups.get(cutout.groupId);
@@ -1044,15 +1053,21 @@ export function buildCutoutCuts(
 
   for (const [, groupMembers] of groups) {
     const shape = buildGroupedCutouts(groupMembers, solidSurfaceZ, originX, originY);
-    // All members share a groupId -> one unit, one color for the merged cavity.
-    if (shape) pushRaw(shape, cavityTag(groupMembers[0]));
+    if (shape) {
+      const idx = rawShapes.length;
+      // All members share a groupId -> one unit, one color for the merged cavity.
+      pushRaw(shape, cavityTag(groupMembers[0]));
+      for (const m of groupMembers) cavityIndices.set(m.id, [idx]);
+    }
   }
 
-  // Per-cutout label text on the bin top, adjacent to each cutout in the
-  // user-picked side direction. The design-level mode picks engrave (cut into
-  // the surface) or emboss (raised above it); through-cut falls back to engrave
-  // since punching bin-top text through the floor is meaningless. Engraved text
-  // joins the cut pile; embossed text is collected separately for fusing.
+  // Per-cutout label text, placed by the 9-point anchor: the outer anchors
+  // land on the bin top beside the cutout, `center` lands on the recess floor
+  // inside it. The design-level mode picks engrave (cut into the surface) or
+  // emboss (raised above it); through-cut falls back to engrave since punching
+  // bin-top text through the floor is meaningless. Engraved text joins the cut
+  // pile; top-surface embossed text is collected separately for fusing; floor
+  // embossed text is carved out of its cavity tool.
   const rawFuseShapes: Shape3D[] = [];
   for (const cutout of params.cutouts) {
     if (cutout.hidden === true) continue;
@@ -1073,6 +1088,8 @@ export function buildCutoutCuts(
     // Label text is its own color zone — tag it TEXT so an engraved label
     // sharing the cut pile doesn't inherit its cutout's cavity color.
     if (textShape.op === 'fuse') rawFuseShapes.push(textShape.solid);
+    else if (textShape.op === 'carve')
+      carveLabelFromCavities(textShape.solid, cavityIndices.get(cutout.id), rawShapes);
     else pushRaw(textShape.solid, FeatureTag.TEXT);
   }
 
@@ -1149,11 +1166,78 @@ function clipToInterior(
 /** A cutout label solid plus how it must be applied to the bin. */
 interface CutoutLabelShape {
   readonly solid: Shape3D;
-  readonly op: 'cut' | 'fuse';
+  /**
+   * `cut` engraves (bin top or recess floor), `fuse` embosses on the bin top,
+   * `carve` embosses on a recess floor: the solid must be subtracted from the
+   * owning cavity tool instead of fused (see {@link carveLabelFromCavities}).
+   */
+  readonly op: 'cut' | 'fuse' | 'carve';
 }
 
 /**
- * Label text adjacent to a cutout, on the bin top surface.
+ * Z of the surface a cutout label lands on: the recess floor when the placed
+ * center sits inside the cutout's rotated footprint (the `center` anchor, or an
+ * offset drag ending over the cavity), the un-recessed fill top otherwise.
+ * Labels used to engrave at the fill top unconditionally, so a center-anchored
+ * label's shallow cut sat entirely inside the volume the cavity removes and
+ * vanished from the model (#2726).
+ */
+function labelSurfaceZ(
+  cutout: Cutout,
+  centerX: number,
+  centerY: number,
+  solidSurfaceZ: number,
+  originX: number,
+  originY: number
+): number {
+  const dx = centerX - (originX + cutout.x + cutout.width / 2);
+  const dy = centerY - (originY + cutout.y + cutout.depth / 2);
+  // Localize with the inverse of the shape's world rotation —
+  // buildUngroupedCutout rotates by -cutout.rotation, so invert with +rotation.
+  const theta = (cutout.rotation * Math.PI) / 180;
+  const c = Math.cos(theta);
+  const s = Math.sin(theta);
+  const lx = dx * c - dy * s;
+  const ly = dx * s + dy * c;
+  const inside = Math.abs(lx) <= cutout.width / 2 && Math.abs(ly) <= cutout.depth / 2;
+  if (!inside) return solidSurfaceZ;
+  return solidSurfaceZ - Math.min(cutout.cutDepth, solidSurfaceZ);
+}
+
+/**
+ * Subtract a floor-embossed label from its cutout's cavity tools, leaving the
+ * glyphs standing on the recess floor once the cavity is cut from the bin.
+ * Raised text inside a recess cannot go through the fuse pile: the boolean
+ * stage fuses BEFORE it cuts, so fused glyphs would sit inside still-solid
+ * fill and the cavity cut would shear them away. Consumes `text`; a failed
+ * carve keeps the uncarved cavity and silently drops the label (matching
+ * {@link buildCutoutLabel}'s silent-skip contract).
+ */
+function carveLabelFromCavities(
+  text: Shape3D,
+  indices: readonly number[] | undefined,
+  rawShapes: Shape3D[]
+): void {
+  try {
+    for (const i of indices ?? []) {
+      try {
+        const carved = unwrap(cut(rawShapes[i] as ValidSolid, text as ValidSolid));
+        if (carved !== rawShapes[i]) {
+          rawShapes[i].delete();
+          rawShapes[i] = carved;
+        }
+      } catch {
+        // Keep the uncarved cavity; this label is silently skipped.
+      }
+    }
+  } finally {
+    text.delete();
+  }
+}
+
+/**
+ * Label text for a cutout: on the bin top beside it (outer anchors) or on the
+ * recess floor inside it (`center` anchor, see {@link labelSurfaceZ}).
  *
  * The side picker is interpreted in WORLD coordinates (top = +Y, etc.); text
  * reads left-to-right in world XY regardless of cutout rotation. The cutout
@@ -1162,8 +1246,9 @@ interface CutoutLabelShape {
  * and takes their min/max.
  *
  * The design-level mode selects `engrave` (recessed, returned with `op: 'cut'`)
- * or `emboss` (raised, returned with `op: 'fuse'`). `through-cut` falls back to
- * engrave — punching bin-top text through the floor is meaningless.
+ * or `emboss` (raised, returned with `op: 'fuse'` on the bin top, `op: 'carve'`
+ * on a recess floor). `through-cut` falls back to engrave — punching bin-top
+ * text through the floor is meaningless.
  *
  * Placement (side gap + rotation-aware AABB) is delegated to
  * `cutoutLabelPlacement` so the 2D editor preview tracks this engraving.
@@ -1193,6 +1278,11 @@ function buildCutoutLabel(
   // degrades to engrave.
   const mode = style.mode === 'emboss' ? 'emboss' : 'engrave';
 
+  const surfaceZ = labelSurfaceZ(cutout, centerX, centerY, solidSurfaceZ, originX, originY);
+  // A recess consuming the full fill depth leaves no floor to engrave into —
+  // the interior clip stops at z=0 to protect the base, so skip the label.
+  if (mode === 'engrave' && surfaceZ <= 0) return null;
+
   return withScope((scope: DisposalScope): CutoutLabelShape | null => {
     const result = buildTextSolid(scope, {
       text: label,
@@ -1202,9 +1292,9 @@ function buildCutoutLabel(
       availD,
       centerX,
       centerY,
-      topZ: solidSurfaceZ,
+      topZ: surfaceZ,
       depth: style.depth,
-      hostThickness: solidSurfaceZ,
+      hostThickness: surfaceZ,
       margin: style.margin,
       minFontSize: style.minFontSize,
       maxFontSize: style.maxFontSize,
@@ -1212,6 +1302,9 @@ function buildCutoutLabel(
       angleDeg: cutout.textAngle ?? 0,
     });
     if (!result) return null;
-    return { solid: unwrap(clone(result.solid)), op: result.op };
+    // Emboss below the fill top means "inside a recess" — reroute from the
+    // fuse pile to the cavity carve so the raised text survives the cut pass.
+    const op = result.op === 'fuse' && surfaceZ < solidSurfaceZ ? 'carve' : result.op;
+    return { solid: unwrap(clone(result.solid)), op };
   });
 }

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -21,7 +21,7 @@ type BuildCutoutCutsFn = (
   innerW: number,
   innerD: number,
   wallHeight: number
-) => Shape3D | null;
+) => { cutTools: Shape3D[]; fuseTools: Shape3D[] };
 type BuildLabelTabsFn = (
   params: BinParams,
   innerW: number,
@@ -52,9 +52,11 @@ let buildScoopRamps: BuildScoopRampsFn;
 let buildWallCutoutCuts: BuildWallCutoutCutsFn;
 
 let meshShape: (shape: unknown) => { vertices: ArrayLike<number>; triangles: ArrayLike<number> };
+let shapeBounds: (shape: unknown) => { zMin: number; zMax: number };
+let shapeVolume: (shape: unknown) => number;
 
 beforeAll(async () => {
-  const { mesh: meshFn } = await import('brepjs');
+  const { mesh: meshFn, getBounds, measureVolume, unwrap } = await import('brepjs');
   await initTestKernel();
 
   // Cutout-label tests need the bundled Atkinson font (the textDefaults default);
@@ -77,6 +79,8 @@ beforeAll(async () => {
   buildWallCutoutCuts = mod.buildWallCutoutCuts;
 
   meshShape = (shape) => meshFn(shape as never, { tolerance: 1, angularTolerance: 30 });
+  shapeBounds = (shape) => getBounds(shape as never);
+  shapeVolume = (shape) => unwrap(measureVolume(shape as never));
 }, 30000);
 
 describe('buildCompartmentWalls', () => {
@@ -359,6 +363,73 @@ describe('buildCutoutCuts', () => {
     expect(fuseTools).toHaveLength(1);
     const meshed = meshShape(fuseTools[0]);
     expect(meshed.vertices.length).toBeGreaterThan(0);
+  }, 30000);
+
+  const recessedLabelCutout: BinParams['cutouts'][number] = {
+    id: 'c1',
+    shape: 'rectangle',
+    width: 40,
+    depth: 30,
+    cutDepth: 5,
+    x: 20,
+    y: 25,
+    rotation: 0,
+    cornerRadius: 0,
+    label: 'HI',
+    engraveLabel: true,
+    textAnchor: 'center',
+    groupId: null,
+  };
+
+  it('engraves a center-anchored label at the recess floor, not the bin top (#2726)', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      cutoutConfig: { topOffset: 0 },
+      cutouts: [recessedLabelCutout],
+    };
+    const { cutTools, fuseTools } = buildCutoutCuts(params, 80, 80, 16);
+    expect(fuseTools).toHaveLength(0);
+    expect(cutTools).toHaveLength(2);
+    // Fill top = 16, cavity floor = 11. The glyph cut must cap at the floor —
+    // a top-surface engraving would sit inside the cavity volume and vanish.
+    const zMaxes = cutTools.map((t) => shapeBounds(t).zMax).sort((a, b) => a - b);
+    expect(zMaxes[0]).toBeLessThan(11.5);
+    expect(zMaxes[1]).toBeGreaterThan(15.5);
+  }, 30000);
+
+  it('carves a floor-embossed center label out of the cavity instead of fusing it (#2726)', () => {
+    const emboss: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      cutoutConfig: { topOffset: 0 },
+      textDefaults: { ...DEFAULT_BIN_PARAMS.textDefaults, mode: 'emboss' },
+      cutouts: [recessedLabelCutout],
+    };
+    const labeled = buildCutoutCuts(emboss, 80, 80, 16);
+    // No fuse tool: the pipeline fuses before it cuts, so fused floor text
+    // would be sheared off by the cavity cut. Instead the glyphs are carved
+    // out of the cavity tool and stand on the floor once it's subtracted.
+    expect(labeled.fuseTools).toHaveLength(0);
+    expect(labeled.cutTools).toHaveLength(1);
+
+    const plain = buildCutoutCuts(
+      { ...emboss, cutouts: [{ ...recessedLabelCutout, label: '' }] },
+      80,
+      80,
+      16
+    );
+    expect(shapeVolume(labeled.cutTools[0])).toBeLessThan(shapeVolume(plain.cutTools[0]) - 1);
+  }, 30000);
+
+  it('drops an engraved center label when the recess consumes the full fill depth', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      cutoutConfig: { topOffset: 0 },
+      cutouts: [{ ...recessedLabelCutout, cutDepth: 16 }],
+    };
+    const { cutTools, fuseTools } = buildCutoutCuts(params, 80, 80, 16);
+    // Cavity only — no floor is left to engrave into.
+    expect(cutTools).toHaveLength(1);
+    expect(fuseTools).toHaveLength(0);
   }, 30000);
 });
 

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -431,6 +431,59 @@ describe('buildCutoutCuts', () => {
     expect(cutTools).toHaveLength(1);
     expect(fuseTools).toHaveLength(0);
   }, 30000);
+
+  it('keeps a label at the bin top when its center is outside a circle cutout footprint', () => {
+    // Offset drags the center to (13.5, 13.5) from the cutout center — inside
+    // the 30×30 bounding box but outside the circle, so the surface there is
+    // un-recessed fill and the engraving must stay at the top.
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      cutoutConfig: { topOffset: 0 },
+      cutouts: [
+        {
+          ...recessedLabelCutout,
+          shape: 'circle',
+          width: 30,
+          depth: 30,
+          textOffset: { x: 13.5, y: 13.5 },
+        },
+      ],
+    };
+    const { cutTools } = buildCutoutCuts(params, 80, 80, 16);
+    expect(cutTools).toHaveLength(2);
+    for (const tool of cutTools) {
+      expect(shapeBounds(tool).zMax).toBeGreaterThan(15.5);
+    }
+  }, 30000);
+
+  it('keeps a label at the bin top for members of non-union groups', () => {
+    // A subtract group's final cavity may not contain the member's footprint,
+    // so the floor branch is disabled and the label engraves at the top.
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      cutoutConfig: { topOffset: 0 },
+      cutouts: [
+        { ...recessedLabelCutout, groupId: 'g1', groupOp: 'subtract' },
+        {
+          ...recessedLabelCutout,
+          id: 'c2',
+          x: 30,
+          y: 35,
+          width: 20,
+          depth: 10,
+          label: '',
+          engraveLabel: false,
+          groupId: 'g1',
+        },
+      ],
+    };
+    const { cutTools } = buildCutoutCuts(params, 80, 80, 16);
+    // One merged group cavity + one label tool, both reaching the bin top.
+    expect(cutTools).toHaveLength(2);
+    for (const tool of cutTools) {
+      expect(shapeBounds(tool).zMax).toBeGreaterThan(15.5);
+    }
+  }, 30000);
 });
 
 describe('buildLabelTabs', () => {


### PR DESCRIPTION
## Summary

Fixes #2726 — a label on a recessed cutout ("engrave" mode, center anchor) showed in the 2D editor but never appeared in the 3D model or the exported STL/3MF.

**Root cause:** cutout labels were always built at the un-recessed fill top (`topZ = solidSurfaceZ`). A center-anchored label sits over the cutout footprint, so its shallow engrave cut (0.4mm) lived entirely inside the volume the cavity cut (6mm in the report's design) removes. Subtracting both is identical to subtracting just the cavity — the text was a geometric no-op.

**Fix** (`cutoutBuilder.ts`):
- `labelSurfaceZ()` resolves the surface a label lands on: the recess floor when the placed center (anchor + offset drag, rotation-aware) is inside the cutout footprint, the fill top otherwise.
- **Engrave** on a recess floor: the text cut tool is built at the floor Z, joining the cut pile as before.
- **Emboss** on a recess floor: the boolean stage fuses *before* it cuts, so a fused floor emboss would be sheared away by the cavity cut. Instead the text solid is carved **out of the owning cavity tool** (`carveLabelFromCavities`, keyed by a new cutout-id → cavity-tool index map covering ungrouped, array, and grouped cutouts), leaving the glyphs standing on the floor once the cavity is subtracted.
- A recess consuming the full fill depth has no floor left; the engraved label is skipped (the interior clip stops at z=0 to protect the base).
- Outer-anchor labels on the bin top are unchanged.

## Tests
- `featureBuilder.test.ts`: engrave lands at the floor Z (tool `zMax` at the floor, not the top); floor emboss produces **no** fuse tool and a smaller-volume cavity (carve verified via `measureVolume`); full-depth recess drops the label. Also fixed the stale `BuildCutoutCutsFn` return type.
- `binGenerator.scenario.cutout-floor-label.test.ts` (new, end-to-end): the final mesh gains glyph geometry in the z-band just below the recess floor — the only level that proves the engraving survives the boolean stage, where the original bug lived.
- All 4 new tests fail without the fix.
- Full runs green: unit+dom (14,506), binGenerator scenario matrix (944), typecheck, lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Engraves center-anchored cutout labels on the recess floor so they appear in the 3D model and STL/3MF exports. Floor emboss is carved from the owning cavity so raised text survives the boolean order.

- **Bug Fixes**
  - Added shape-aware `labelSurfaceZ()` to place labels on the recess floor only when the placed center lies inside the actual footprint (circle/ellipse, polygon, slot, path, rounded rect); otherwise keep at the fill top. Non-union groups always keep top placement.
  - Engrave on floor: build the text cut at the floor Z; skip when the recess consumes the full fill depth.
  - Emboss on floor: carve text out of the owning cavity tool (cutout-id → cavity index map), skipping cavity tools whose bounds cannot touch the glyphs; ensures raised text remains after the cavity cut.
  - Outer-anchor (bin-top) labels unchanged.
  - Tests cover floor engrave placement, floor emboss carve, circle-outside-footprint top placement, non-union group gating, and full-depth recess; an end-to-end mesh test confirms glyphs survive in the final model.

<sup>Written for commit 40a6cc1c0ef0039fd80da7df91fa3b8e097f0818. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

