### PR TITLE
fix(layout): scale custom drawer shapes by the Y grid pitch on non-square grids

### DIFF
--- a/src/core/cqrs/v2/domain/drawer/displacement.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/displacement.test.ts
@@ -46,4 +46,23 @@ describe('computeDisplacedBins', () => {
     const bins = [makeBin('bin_staged', 5, 3, STAGING_ID)];
     expect(computeDisplacedBins(bins, { ...drawer, outline: L_OUTLINE }, U)).toEqual([]);
   });
+
+  it('measures footprints with the per-axis pitch on a non-square grid (#2733)', () => {
+    const UX = 48;
+    const UY = 42;
+    const lNs: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 6 * UX, y: 0 },
+        { x: 6 * UX, y: 2 * UY },
+        { x: 4 * UX, y: 2 * UY },
+        { x: 4 * UX, y: 4 * UY },
+        { x: 0, y: 4 * UY },
+      ],
+    };
+    // bin_back sits flush against the drawer's back edge (4 × UY) — using the
+    // X pitch on Y would wrongly displace it.
+    const bins = [makeBin('bin_back', 0, 3), makeBin('bin_notch', 5, 3)];
+    expect(computeDisplacedBins(bins, { ...drawer, outline: lNs }, UX, UY)).toEqual(['bin_notch']);
+  });
 });

--- a/src/core/cqrs/v2/domain/drawer/displacement.ts
+++ b/src/core/cqrs/v2/domain/drawer/displacement.ts
@@ -13,7 +13,9 @@ import { isFootprintInsideOutline } from '@/shared/utils/drawerOutlineGeometry';
 export function computeDisplacedBins(
   bins: readonly Bin[],
   drawer: Pick<Drawer, 'width' | 'depth' | 'outline'>,
-  gridUnitMm: number
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
 ): BinId[] {
   const width = drawer.width as number;
   const depth = drawer.depth as number;
@@ -33,7 +35,8 @@ export function computeDisplacedBins(
         !isFootprintInsideOutline(
           { x: bin.x, y: bin.y, width: bin.width, depth: bin.depth },
           drawer.outline,
-          gridUnitMm
+          gridUnitMm,
+          gridUnitMmY
         )
       );
     })

--- a/src/core/cqrs/v2/domain/drawer/setDrawerOutline.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/setDrawerOutline.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { produce } from 'immer';
 import { isOk } from '@/core/result';
 import { STAGING_ID } from '@/core/constants';
-import { binId } from '@/core/types';
+import { binId, mm } from '@/core/types';
 import type { DrawerOutline } from '@/core/types';
 import { setDrawerOutline } from './setDrawerOutline';
 import { makeLayout, makeBin } from './_testHelpers';
@@ -32,6 +32,51 @@ describe('v2 drawer.setOutline', () => {
     expect(result.value.event.payload.outline).toBeDefined();
     expect(result.value.event.payload.previousOutline).toBeUndefined();
     expect(result.value.event.payload.displacedBinIds).toEqual([binId('bin_a')]);
+  });
+
+  it('validates and displaces with the per-axis pitch on a non-square grid (#2733)', () => {
+    const UX = 48;
+    const UY = 42;
+    const lNs: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 6 * UX, y: 0 },
+        { x: 6 * UX, y: 2 * UY },
+        { x: 4 * UX, y: 2 * UY },
+        { x: 4 * UX, y: 4 * UY },
+        { x: 0, y: 4 * UY },
+      ],
+    };
+    const layout = makeLayout({
+      gridUnitMm: mm(UX),
+      gridUnitMmY: mm(UY),
+      // bin_back is flush against the back edge (y ends at 4 × UY) — the X
+      // pitch on Y would wrongly displace it.
+      bins: [makeBin('bin_back', 0, 3), makeBin('bin_notch', 5, 3)],
+    });
+    const result = setDrawerOutline.handle({ outline: lNs }, { aggregate: layout });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.outline).toBeDefined();
+    expect(result.value.event.payload.displacedBinIds).toEqual([binId('bin_notch')]);
+  });
+
+  it('normalizes a rectangle-equivalent outline on a non-square grid (#2733)', () => {
+    const rect: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 6 * 48, y: 0 },
+        { x: 6 * 48, y: 4 * 42 },
+        { x: 0, y: 4 * 42 },
+      ],
+    };
+    const layout = makeLayout({ gridUnitMm: mm(48), gridUnitMmY: mm(42) });
+    const result = setDrawerOutline.handle({ outline: rect }, { aggregate: layout });
+
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.outline).toBeUndefined();
   });
 
   it('apply() installs the outline and stages displaced bins', () => {

--- a/src/core/cqrs/v2/domain/drawer/setDrawerOutline.ts
+++ b/src/core/cqrs/v2/domain/drawer/setDrawerOutline.ts
@@ -13,6 +13,7 @@ import * as z from 'zod';
 import type { Result, LayoutError } from '@/core/result';
 import { ok, err, layoutInvalidOperation } from '@/core/result';
 import type { BinId, DrawerOutline } from '@/core/types';
+import { effectiveGridUnitMmY } from '@/core/types';
 import { STAGING_ID } from '@/core/constants';
 import {
   quantizeOutline,
@@ -74,13 +75,14 @@ export const setDrawerOutline = defineCommand({
   > => {
     const layout = ctx.aggregate;
     const drawer = layout.drawer;
+    const gridUnitMmY = effectiveGridUnitMmY(layout) as number;
     const widthMm = (drawer.width as number) * (layout.gridUnitMm as number);
-    const depthMm = (drawer.depth as number) * (layout.gridUnitMm as number);
+    const depthMm = (drawer.depth as number) * gridUnitMmY;
 
     let outline: DrawerOutline | undefined;
     if (payload.outline !== null) {
       const cleaned = snapOutlineToBounds(quantizeOutline(payload.outline), widthMm, depthMm);
-      const invalid = validateOutline(cleaned, widthMm, depthMm, layout.gridUnitMm);
+      const invalid = validateOutline(cleaned, widthMm, depthMm, layout.gridUnitMm, gridUnitMmY);
       if (invalid !== null) {
         return err(layoutInvalidOperation('setDrawerOutline', invalid.message));
       }
@@ -90,7 +92,8 @@ export const setDrawerOutline = defineCommand({
     const displacedBinIds = computeDisplacedBins(
       layout.bins,
       { width: drawer.width, depth: drawer.depth, outline },
-      layout.gridUnitMm
+      layout.gridUnitMm,
+      gridUnitMmY
     );
 
     return ok({

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
@@ -19,7 +19,7 @@ import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
 import { resizeDrawerOutline } from '@/shared/utils/drawerOutline';
 import type { BinId, Drawer, GridUnits, MeasuredDrawerMm } from '@/core/types';
-import { gridUnits, heightUnits } from '@/core/types';
+import { effectiveGridUnitMmY, gridUnits, heightUnits } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 import { computeDisplacedBins } from './displacement';
 
@@ -124,13 +124,15 @@ export const updateDrawer = defineCommand({
     let newOutline = drawer.outline;
     if (drawer.outline !== undefined && dimsChanged) {
       const u = layout.gridUnitMm as number;
+      const uy = effectiveGridUnitMmY(layout) as number;
       newOutline = resizeDrawerOutline(
         drawer.outline,
         (drawer.width as number) * u,
-        (drawer.depth as number) * u,
+        (drawer.depth as number) * uy,
         (newWidth as number) * u,
-        (newDepth as number) * u,
-        u
+        (newDepth as number) * uy,
+        u,
+        uy
       );
       changes.outline = newOutline;
     }
@@ -139,7 +141,8 @@ export const updateDrawer = defineCommand({
     const displacedBinIds = computeDisplacedBins(
       layout.bins,
       { width: newWidth, depth: newDepth, outline: newOutline },
-      layout.gridUnitMm
+      layout.gridUnitMm,
+      effectiveGridUnitMmY(layout)
     );
 
     const previous = capturePrevious(drawer, changes);

--- a/src/core/store/layout/drawerActions.ts
+++ b/src/core/store/layout/drawerActions.ts
@@ -1,4 +1,5 @@
 import type { Drawer, GridUnits, HeightUnits } from '@/core/types';
+import { effectiveGridUnitMmY } from '@/core/types';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
 import { resizeDrawerOutline } from '@/shared/utils/drawerOutline';
@@ -46,13 +47,15 @@ export function createDrawerActions(setLocal: SetLocal) {
           ((drawer.width as number) !== oldWidth || (drawer.depth as number) !== oldDepth)
         ) {
           const u = state.layout.gridUnitMm as number;
+          const uy = effectiveGridUnitMmY(state.layout) as number;
           const resized = resizeDrawerOutline(
             drawer.outline,
             oldWidth * u,
-            oldDepth * u,
+            oldDepth * uy,
             (drawer.width as number) * u,
-            (drawer.depth as number) * u,
-            u
+            (drawer.depth as number) * uy,
+            u,
+            uy
           );
           if (resized === undefined) {
             delete drawer.outline;
@@ -68,7 +71,12 @@ export function createDrawerActions(setLocal: SetLocal) {
           (drawer.width as number) !== oldWidth || (drawer.depth as number) !== oldDepth;
         if (!planarChanged) return;
         const displaced = new Set(
-          computeDisplacedBins(state.layout.bins, drawer, state.layout.gridUnitMm)
+          computeDisplacedBins(
+            state.layout.bins,
+            drawer,
+            state.layout.gridUnitMm,
+            effectiveGridUnitMmY(state.layout)
+          )
         );
         if (displaced.size > 0) {
           state.layout.bins = state.layout.bins.map((bin) =>

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -24,6 +24,7 @@ let mockLayoutState = {
   layout: {
     drawer: { width: 4, depth: 6 },
     gridUnitMm: 42,
+    gridUnitMmY: undefined as number | undefined,
     magnetAnchor: undefined as 'edge' | 'center' | undefined,
     printBedSize: 256,
     baseplateParams: { ...DEFAULT_BASEPLATE_PARAMS },
@@ -151,6 +152,7 @@ describe('BaseplatePanel', () => {
       layout: {
         drawer: { width: 4, depth: 6 },
         gridUnitMm: 42,
+        gridUnitMmY: undefined,
         magnetAnchor: undefined,
         printBedSize: 256,
         baseplateParams: { ...DEFAULT_BASEPLATE_PARAMS },
@@ -662,6 +664,32 @@ describe('BaseplatePanel', () => {
       expect(editBtn).toHaveTextContent(/176\s*×\s*252\s*mm/);
     });
 
+    it('snaps depth by the Y pitch on a non-square grid (#2733)', () => {
+      mockLayoutState.layout.gridUnitMm = 48;
+      mockLayoutState.layout.gridUnitMmY = 42;
+      render(<BaseplatePanel />);
+      fireEvent.click(screen.getByRole('button', { name: 'baseplate.editDimensions' }));
+      const widthInput = screen.getByLabelText('baseplate.editDimensionsWidth');
+      const depthInput = screen.getByLabelText('baseplate.editDimensionsDepth');
+      // 480 / 48 = exactly 10 units; 168 / 42 = exactly 4 units — snapping
+      // depth by the X pitch would floor 168/48 = 3.5 to 3 and leak 24mm
+      // of remainder into padding.
+      fireEvent.change(widthInput, { target: { value: '480' } });
+      fireEvent.change(depthInput, { target: { value: '168' } });
+      fireEvent.keyDown(depthInput, { key: 'Enter' });
+
+      expect(mockSetBaseplateParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseplateWidth: 10,
+          baseplateDepth: 4,
+          paddingLeft: 0,
+          paddingRight: 0,
+          paddingFront: 0,
+          paddingBack: 0,
+        })
+      );
+    });
+
     it('exact grid multiple produces zero padding', () => {
       // 420 / 42 = exactly 10 units → no remainder
       render(<BaseplatePanel />);
@@ -1020,6 +1048,7 @@ describe('shaped drawer (outline present)', () => {
       layout: {
         drawer: { width: 4, depth: 6 },
         gridUnitMm: 42,
+        gridUnitMmY: undefined,
         magnetAnchor: undefined,
         printBedSize: 256,
         baseplateParams: { ...DEFAULT_BASEPLATE_PARAMS },
@@ -1129,6 +1158,7 @@ describe('corner-cut shaped drawer (padding composes, issue #2612)', () => {
       layout: {
         drawer: { width: 4, depth: 6 },
         gridUnitMm: 42,
+        gridUnitMmY: undefined,
         magnetAnchor: undefined,
         printBedSize: 256,
         baseplateParams: { ...DEFAULT_BASEPLATE_PARAMS },

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -340,7 +340,7 @@ export function BaseplatePanel() {
       // Derive entirely from the fresh store read — mixing in the captured
       // gridUnitMm could compute padding against a stale drawer size.
       const drawerWidthMm = cornerShapeState.drawer.width * cornerShapeState.gridUnitMm;
-      const drawerDepthMm = cornerShapeState.drawer.depth * cornerShapeState.gridUnitMm;
+      const drawerDepthMm = cornerShapeState.drawer.depth * effectiveGridUnitMmY(cornerShapeState);
       if (
         cornerShapeParams.syncWithLayout !== false &&
         outline !== undefined &&

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -364,7 +364,7 @@ export function BaseplatePanel() {
       const step = halfGridMode ? 0.5 : 1;
 
       const rawWidthUnits = targetWidthMm / gridUnitMm;
-      const rawDepthUnits = targetDepthMm / gridUnitMm;
+      const rawDepthUnits = targetDepthMm / gridUnitMmY;
 
       // Floor so the grid never exceeds the target — remainder becomes positive padding
       const snappedWidth = Math.max(
@@ -377,7 +377,7 @@ export function BaseplatePanel() {
       );
 
       const remainderWidth = Math.max(0, targetWidthMm - snappedWidth * gridUnitMm);
-      const remainderDepth = Math.max(0, targetDepthMm - snappedDepth * gridUnitMm);
+      const remainderDepth = Math.max(0, targetDepthMm - snappedDepth * gridUnitMmY);
 
       const halfPadWidth = Math.floor((remainderWidth / 2) * 100) / 100;
       const halfPadDepth = Math.floor((remainderDepth / 2) * 100) / 100;
@@ -397,7 +397,7 @@ export function BaseplatePanel() {
         paddingBack: mm(halfPadDepth),
       });
     },
-    [gridUnitMm, halfGridMode]
+    [gridUnitMm, gridUnitMmY, halfGridMode]
   );
 
   return (

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1699,6 +1699,35 @@ describe('shaped plates (outline-aware splitting)', () => {
     expect(tiling.pieces.every((p) => p.placementRotationDeg === 0)).toBe(true);
   });
 
+  it('measures seam bands with the per-axis pitch on a non-square grid (#2733)', () => {
+    const UX = 48;
+    const UY = 42;
+    const lNs = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 8 * UX, y: 0 },
+        { x: 8 * UX, y: 4 * UY },
+        { x: 4 * UX, y: 4 * UY },
+        { x: 4 * UX, y: 8 * UY },
+        { x: 0, y: 8 * UY },
+      ],
+    };
+    // Bed fits 4 units on both axes (4 × 48 = 192, 4 × 42 = 168 ≤ 205 < 5 × 42).
+    const tiling = computeBaseplateTiling(
+      shapedParams(lNs, { gridUnitMm: UX, gridUnitMmY: UY }),
+      205
+    );
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+    expect(tiling.pieces.map((p) => p.label).sort()).toEqual(['A1', 'A2', 'B1']);
+    // Seams into the body are full: the one-cell band beside A1's right seam
+    // spans y 0..4 × UY — measuring it with the X pitch would cross the notch
+    // boundary and wrongly butt the seam.
+    expect(byLabel.get('A1')?.edges.right).toBe('join');
+    expect(byLabel.get('A1')?.edges.back).toBe('join');
+    expect(byLabel.get('B1')?.edges.left).toBe('join');
+    expect(byLabel.get('A2')?.edges.front).toBe('join');
+  });
+
   it('shaped partial pieces fingerprint apart from rectangles, congruent windows together', () => {
     const parent = shapedParams(CHAMFER_OUTLINE);
     const tiling = computeBaseplateTiling(parent, BED);

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -976,8 +976,8 @@ function applyOutlineToTiling(
   const fullSeam = (piece: BaseplatePiece, side: 'left' | 'right' | 'front' | 'back'): boolean => {
     const gx0 = padL + piece.gridOffsetX * u;
     const gx1 = padL + (piece.gridOffsetX + piece.widthUnits) * u;
-    const gy0 = padF + piece.gridOffsetY * u;
-    const gy1 = padF + (piece.gridOffsetY + piece.depthUnits) * u;
+    const gy0 = padF + piece.gridOffsetY * uy;
+    const gy1 = padF + (piece.gridOffsetY + piece.depthUnits) * uy;
     if (side === 'left' || side === 'right') {
       const xB = side === 'left' ? gx0 : gx1;
       return (
@@ -987,8 +987,8 @@ function applyOutlineToTiling(
     }
     const yB = side === 'front' ? gy0 : gy1;
     return (
-      classifyRect(outline, gx0, yB - u, gx1, yB) === 'inside' &&
-      classifyRect(outline, gx0, yB, gx1, yB + u) === 'inside'
+      classifyRect(outline, gx0, yB - uy, gx1, yB) === 'inside' &&
+      classifyRect(outline, gx0, yB, gx1, yB + uy) === 'inside'
     );
   };
 

--- a/src/features/drawer-shape/README.md
+++ b/src/features/drawer-shape/README.md
@@ -21,8 +21,9 @@ hatching, baseplate generation/splitting) derives from it.
   grid from the union of non-staged bin footprints.
 - `utils/drawerMask.ts` — editor grid ↔ outline conversion. The grid maps to
   the bin designer's half-resolution `CellMask` so `maskToPolygon` traces the
-  boundary; the outer loop scales by `gridUnitMm` into outline mm. Enclosed
-  holes are filled (single-loop model); empty/disconnected grids error.
+  boundary; the outer loop scales by the per-axis grid pitch (`gridUnitMm` /
+  `gridUnitMmY`, issue #2733) into outline mm. Enclosed holes are filled
+  (single-loop model); empty/disconnected grids error.
 - `utils/traceBinFootprint.ts` — bins → editor grid (all layers, staging
   excluded).
 

--- a/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.tsx
+++ b/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.tsx
@@ -9,6 +9,7 @@ import { isOk } from '@/core/result';
 import { computeDisplacedBins } from '@/core/cqrs/v2/domain/drawer/displacement';
 import { trackDrawerShapeApplied } from '@/shared/analytics/posthog';
 import type { CornerCut, CornerCutParams } from '@/core/types';
+import { effectiveGridUnitMmY } from '@/core/types';
 import { cornersToOutline, maxCutExtentMm, NO_CUTS } from '../../utils/cornersToOutline';
 
 interface CornerCutsDialogProps {
@@ -55,7 +56,12 @@ export function CornerCutsDialog({ open, onClose }: CornerCutsDialogProps) {
   const t = useTranslation();
   const mutations = useMutations();
   const addToast = useToastStore((s) => s.addToast);
-  const { layout } = useLayoutStore(useShallow((s) => ({ layout: s.layout })));
+  const { layout, gridUnitMmY } = useLayoutStore(
+    useShallow((s) => ({
+      layout: s.layout,
+      gridUnitMmY: effectiveGridUnitMmY(s.layout),
+    }))
+  );
 
   const existing = layout.drawer.outline;
   const seeded: CornerCutParams =
@@ -66,7 +72,7 @@ export function CornerCutsDialog({ open, onClose }: CornerCutsDialogProps) {
   const [confirmReplace, setConfirmReplace] = useState(false);
   const active = cuts ?? seeded;
 
-  const maxMm = maxCutExtentMm(layout.drawer, layout.gridUnitMm);
+  const maxMm = maxCutExtentMm(layout.drawer, layout.gridUnitMm, gridUnitMmY);
   // A shape drawn with another editor — or a corners shape whose annotation
   // was stripped by an older server (params lost) — must confirm before this
   // dialog replaces it; the seeded pickers don't represent it.
@@ -82,16 +88,20 @@ export function CornerCutsDialog({ open, onClose }: CornerCutsDialogProps) {
   );
 
   const outline = useMemo(
-    () => cornersToOutline(layout.drawer, active, layout.gridUnitMm),
-    [layout.drawer, active, layout.gridUnitMm]
+    () => cornersToOutline(layout.drawer, active, layout.gridUnitMm, gridUnitMmY),
+    [layout.drawer, active, layout.gridUnitMm, gridUnitMmY]
   );
 
   const doApply = useCallback(() => {
     const displaced =
       outline === null
         ? 0
-        : computeDisplacedBins(layout.bins, { ...layout.drawer, outline }, layout.gridUnitMm)
-            .length;
+        : computeDisplacedBins(
+            layout.bins,
+            { ...layout.drawer, outline },
+            layout.gridUnitMm,
+            gridUnitMmY
+          ).length;
     const result = mutations.setDrawerOutline(outline);
     if (!isOk(result)) return;
     trackDrawerShapeApplied({
@@ -105,7 +115,7 @@ export function CornerCutsDialog({ open, onClose }: CornerCutsDialogProps) {
     }
     setCuts(null);
     onClose();
-  }, [outline, layout, mutations, addToast, t, onClose]);
+  }, [outline, layout, gridUnitMmY, mutations, addToast, t, onClose]);
 
   const handleApply = useCallback(() => {
     if (replacesForeignShape) {

--- a/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
+++ b/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import type { PointerEvent } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { Dialog, Button } from '@/design-system';
+import { effectiveGridUnitMmY } from '@/core/types';
 import { useLayoutStore, useToastStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
 import { useMutations } from '@/shared/contexts/MutationsContext';
@@ -30,7 +31,12 @@ interface ShapeEditorDialogProps {
 export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
   const t = useTranslation();
   const mutations = useMutations();
-  const { layout } = useLayoutStore(useShallow((s) => ({ layout: s.layout })));
+  const { layout, gridUnitMmY } = useLayoutStore(
+    useShallow((s) => ({
+      layout: s.layout,
+      gridUnitMmY: effectiveGridUnitMmY(s.layout),
+    }))
+  );
   const addToast = useToastStore((s) => s.addToast);
 
   const [grid, setGrid] = useState<DrawerMaskGrid | null>(null);
@@ -43,7 +49,7 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
   const seeded = useMemo(() => {
     if (!open) return null;
     return layout.drawer.outline !== undefined
-      ? outlineToDrawerMask(layout.drawer.outline, layout.drawer, layout.gridUnitMm)
+      ? outlineToDrawerMask(layout.drawer.outline, layout.drawer, layout.gridUnitMm, gridUnitMmY)
       : buildFullDrawerMask(layout.drawer);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- reseed only on open
   }, [open]);
@@ -98,8 +104,11 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
   }, []);
 
   const conversion = useMemo(
-    () => (active === null ? null : drawerMaskToOutline(active, layout.gridUnitMm as number)),
-    [active, layout.gridUnitMm]
+    () =>
+      active === null
+        ? null
+        : drawerMaskToOutline(active, layout.gridUnitMm as number, gridUnitMmY),
+    [active, layout.gridUnitMm, gridUnitMmY]
   );
 
   const handleTrace = useCallback(() => {
@@ -112,7 +121,8 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
     const displaced = computeDisplacedBins(
       layout.bins,
       { ...layout.drawer, outline: conversion.outline },
-      layout.gridUnitMm
+      layout.gridUnitMm,
+      gridUnitMmY
     ).length;
     const result = mutations.setDrawerOutline(conversion.outline);
     if (!isOk(result)) return;
@@ -131,7 +141,7 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
     setGrid(null);
     usedTraceRef.current = false;
     onClose();
-  }, [conversion, layout, mutations, addToast, t, onClose]);
+  }, [conversion, layout, gridUnitMmY, mutations, addToast, t, onClose]);
 
   const handleClose = useCallback(() => {
     setGrid(null);

--- a/src/features/drawer-shape/utils/cornersToOutline.test.ts
+++ b/src/features/drawer-shape/utils/cornersToOutline.test.ts
@@ -97,3 +97,26 @@ describe('cornersToOutline', () => {
     expect(validateOutline(outline, 4 * U, 6 * U, U)).toBeNull();
   });
 });
+
+describe('non-square grids (#2733)', () => {
+  const UX = 48;
+  const UY = 42;
+
+  it('spans the depth axis with the Y pitch', () => {
+    const outline = cornersToOutline(
+      drawer(8, 7),
+      { ...NO_CUTS, tr: { kind: 'chamfer', size: 30 } },
+      UX,
+      UY
+    );
+    expect(outline).not.toBeNull();
+    if (outline === null) return;
+    expect(validateOutline(outline, 8 * UX, 7 * UY, UX, UY)).toBeNull();
+    expect(Math.max(...outline.vertices.map((v) => v.y))).toBe(7 * UY);
+    expect(outlineSignedArea(outline)).toBeCloseTo(8 * UX * 7 * UY - (30 * 30) / 2);
+  });
+
+  it('caps cuts by the true shorter extent', () => {
+    expect(maxCutExtentMm(drawer(8, 7), UX, UY)).toBe(Math.floor((7 * UY) / 2 - 1));
+  });
+});

--- a/src/features/drawer-shape/utils/cornersToOutline.ts
+++ b/src/features/drawer-shape/utils/cornersToOutline.ts
@@ -19,9 +19,14 @@ export const NO_CUTS: CornerCutParams = {
 };
 
 /** Largest chamfer/radius/notch extent (mm) that keeps cuts from meeting. */
-export function maxCutExtentMm(drawer: Drawer, gridUnitMm: number): number {
+export function maxCutExtentMm(
+  drawer: Drawer,
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
+): number {
   const widthMm = (drawer.width as number) * gridUnitMm;
-  const depthMm = (drawer.depth as number) * gridUnitMm;
+  const depthMm = (drawer.depth as number) * gridUnitMmY;
   return Math.floor(Math.min(widthMm, depthMm) / 2 - 1);
 }
 
@@ -33,13 +38,15 @@ export function maxCutExtentMm(drawer: Drawer, gridUnitMm: number): number {
 export function cornersToOutline(
   drawer: Drawer,
   cuts: CornerCutParams,
-  gridUnitMm: number
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
 ): DrawerOutline | null {
   if (!hasAnyCut(cuts)) {
     return null;
   }
   const W = (drawer.width as number) * gridUnitMm;
-  const D = (drawer.depth as number) * gridUnitMm;
+  const D = (drawer.depth as number) * gridUnitMmY;
 
   return {
     vertices: cornerCutVertices(W, D, cuts),

--- a/src/features/drawer-shape/utils/drawerMask.test.ts
+++ b/src/features/drawer-shape/utils/drawerMask.test.ts
@@ -100,6 +100,38 @@ describe('outlineToDrawerMask round-trip', () => {
   });
 });
 
+describe('non-square grids (#2733)', () => {
+  const UX = 48;
+  const UY = 42;
+
+  function notchedGrid() {
+    const grid = buildFullDrawerMask(drawer(8, 7));
+    // Notch out the back-right 2×2 cells.
+    setCell(grid, 6, 5, 0);
+    setCell(grid, 7, 5, 0);
+    setCell(grid, 6, 6, 0);
+    setCell(grid, 7, 6, 0);
+    return grid;
+  }
+
+  it('scales the depth axis by the Y pitch', () => {
+    const result = drawerMaskToOutline(notchedGrid(), UX, UY);
+    expect('outline' in result).toBe(true);
+    if (!('outline' in result)) return;
+    expect(Math.max(...result.outline.vertices.map((v) => v.x))).toBe(8 * UX);
+    expect(Math.max(...result.outline.vertices.map((v) => v.y))).toBe(7 * UY);
+    expect(result.outline.vertices.map((v) => `${v.x},${v.y}`)).toContain(`${6 * UX},${5 * UY}`);
+  });
+
+  it('round-trips through the editor grid at per-axis pitches', () => {
+    const grid = notchedGrid();
+    const result = drawerMaskToOutline(grid, UX, UY);
+    if (!('outline' in result)) throw new Error('expected outline');
+    const back = outlineToDrawerMask(result.outline, drawer(8, 7), UX, UY);
+    expect(Array.from(back.cells)).toEqual(Array.from(grid.cells));
+  });
+});
+
 describe('drawer-scale masks (beyond the bin designer cap)', () => {
   it('converts a 16×16 drawer (32×32 half-cells) correctly', () => {
     const grid = buildFullDrawerMask(drawer(16, 16));

--- a/src/features/drawer-shape/utils/drawerMask.ts
+++ b/src/features/drawer-shape/utils/drawerMask.ts
@@ -5,8 +5,8 @@
  * cell of an x.5 drawer), but the underlying mask reuses the half-resolution
  * `CellMask` from the bin designer so `maskToPolygon` can trace the boundary:
  * one drawer cell = a 2×2 block of mask cells (1×2 for a fractional edge
- * cell). Polygon coordinates come back in grid units and scale by
- * `gridUnitMm` into the drawer-local mm the outline model expects.
+ * cell). Polygon coordinates come back in grid units and scale by the
+ * per-axis grid pitch into the drawer-local mm the outline model expects.
  */
 
 import type { Drawer, DrawerOutline, FractionalEdge } from '@/core/types';
@@ -63,10 +63,12 @@ export function buildFullDrawerMask(drawer: Drawer): DrawerMaskGrid {
 export function outlineToDrawerMask(
   outline: DrawerOutline,
   drawer: Drawer,
-  gridUnitMm: number
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
 ): DrawerMaskGrid {
   const grid = buildFullDrawerMask(drawer);
-  const outside = getOutsideCellSet(outline, drawer, gridUnitMm, 1);
+  const outside = getOutsideCellSet(outline, drawer, gridUnitMm, 1, gridUnitMmY);
   for (let r = 0; r < grid.rows.length; r++) {
     for (let c = 0; c < grid.cols.length; c++) {
       if (outside.has(`${grid.cols[c].start},${grid.rows[r].start}`)) {
@@ -87,7 +89,9 @@ export type DrawerMaskError = 'empty' | 'disconnected';
  */
 export function drawerMaskToOutline(
   grid: DrawerMaskGrid,
-  gridUnitMm: number
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
 ): { outline: DrawerOutline } | { error: DrawerMaskError } {
   // maskToPolygon's real preconditions (0/1 values, non-empty, single
   // 4-connected region) are enforced here; the bin designer's validateMask
@@ -122,10 +126,9 @@ export function drawerMaskToOutline(
   // that IS the hole-filling behavior. Loop points are already in grid units
   // (maskToPolygon applies MASK_CELL_SIZE), so only the mm scale remains.
   const [outer] = maskToPolygon(mask);
-  const scale = gridUnitMm;
   return {
     outline: {
-      vertices: outer.map((p) => ({ x: p.x * scale, y: p.y * scale })),
+      vertices: outer.map((p) => ({ x: p.x * gridUnitMm, y: p.y * gridUnitMmY })),
       authoring: { kind: 'cells' },
     },
   };

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -177,6 +177,21 @@ describe('validateOutline', () => {
     };
     expect(validateOutline(tiny, 4 * U, 4 * U, U)?.kind).toBe('too_small');
   });
+
+  it('sizes the one-cell minimum by both pitches (#2733)', () => {
+    const cell: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 48, y: 0 },
+        { x: 48, y: 42 },
+        { x: 0, y: 42 },
+      ],
+    };
+    // One true cell (48 × 42 = 2016mm²) passes; the square-pitch rule
+    // (48² = 2304mm²) would wrongly reject it.
+    expect(validateOutline(cell, 4 * 48, 4 * 42, 48, 42)).toBeNull();
+    expect(validateOutline(cell, 4 * 48, 4 * 42, 48)?.kind).toBe('too_small');
+  });
 });
 
 describe('quantize and snap', () => {
@@ -411,6 +426,25 @@ describe('normalizeDrawerOutline', () => {
     expect(normalized).not.toBe(layout);
     const outline = normalized.drawer.outline as DrawerOutline;
     expect(validateOutline(outline, 3 * U, 4 * U, U)).toBeNull();
+  });
+
+  it('measures the depth extent with the Y pitch on a non-square grid (#2733)', () => {
+    const UY = 48;
+    const tall: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 2 * UY },
+        { x: 2 * U, y: 2 * UY },
+        { x: 2 * U, y: 4 * UY },
+        { x: 0, y: 4 * UY },
+      ],
+    };
+    const layout = layoutWith(tall);
+    layout.gridUnitMmY = mm(UY);
+    // The outline legitimately reaches 4 × UY deep; cropping it against the
+    // square extent (4 × U) would mangle the shape.
+    expect(normalizeDrawerOutline(layout)).toBe(layout);
   });
 
   it('drops rectangle-equivalent outlines', () => {

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -9,6 +9,7 @@
  */
 
 import type { DrawerOutline, Layout, OutlineVertex } from '@/core/types';
+import { effectiveGridUnitMmY } from '@/core/types';
 import {
   arcGeometry,
   arcPointAt,
@@ -154,7 +155,9 @@ export function validateOutline(
   outline: DrawerOutline,
   widthMm: number,
   depthMm: number,
-  gridUnitMm: number
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
 ): OutlineValidationError | null {
   const verts = outline.vertices;
   if (verts.length < 3) return err('too_few_vertices', 'outline needs at least 3 vertices');
@@ -192,7 +195,7 @@ export function validateOutline(
   }
   const area = polylineSignedArea(pts);
   if (area <= 0) return err('not_ccw', 'outline must wind counter-clockwise');
-  if (area < gridUnitMm * gridUnitMm) {
+  if (area < gridUnitMm * gridUnitMmY) {
     return err('too_small', 'outline must enclose at least one grid cell');
   }
   return null;
@@ -498,7 +501,9 @@ export function resizeDrawerOutline(
   oldDepthMm: number,
   newWidthMm: number,
   newDepthMm: number,
-  gridUnitMm: number
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
 ): DrawerOutline | undefined {
   const sameW = Math.abs(newWidthMm - oldWidthMm) < OUTLINE_QUANTUM_MM;
   const sameD = Math.abs(newDepthMm - oldDepthMm) < OUTLINE_QUANTUM_MM;
@@ -528,7 +533,9 @@ export function resizeDrawerOutline(
     newDepthMm
   );
   if (isFullRectangle(candidate, newWidthMm, newDepthMm)) return undefined;
-  if (validateOutline(candidate, newWidthMm, newDepthMm, gridUnitMm) !== null) return undefined;
+  if (validateOutline(candidate, newWidthMm, newDepthMm, gridUnitMm, gridUnitMmY) !== null) {
+    return undefined;
+  }
   return candidate;
 }
 
@@ -558,8 +565,9 @@ export function normalizeDrawerOutline(layout: Layout): Layout {
   const outline = (layout.drawer as Layout['drawer'] | undefined)?.outline as unknown;
   if (outline === undefined) return layout;
 
+  const gridUnitMmY = effectiveGridUnitMmY(layout) as number;
   const widthMm = (layout.drawer.width as number) * (layout.gridUnitMm as number);
-  const depthMm = (layout.drawer.depth as number) * (layout.gridUnitMm as number);
+  const depthMm = (layout.drawer.depth as number) * gridUnitMmY;
 
   const drop = (): Layout => {
     const drawer = { ...layout.drawer };
@@ -587,7 +595,7 @@ export function normalizeDrawerOutline(layout: Layout): Layout {
     depthMm
   );
   if (isFullRectangle(candidate, widthMm, depthMm)) return drop();
-  if (validateOutline(candidate, widthMm, depthMm, layout.gridUnitMm) !== null) {
+  if (validateOutline(candidate, widthMm, depthMm, layout.gridUnitMm, gridUnitMmY) !== null) {
     return drop();
   }
 

--- a/src/shared/utils/drawerOutlineCells.test.ts
+++ b/src/shared/utils/drawerOutlineCells.test.ts
@@ -84,4 +84,30 @@ describe('getOutsideCellSet', () => {
     // Leading half column at x=0, full columns at 0.5, 1.5, 2.5.
     expect(outsideStart).toEqual(new Set(['1.5,2', '2.5,2', '1.5,3', '2.5,3']));
   });
+
+  describe('non-square grids (#2733)', () => {
+    const UX = 48;
+    const UY = 42;
+    const L_NS: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * UX, y: 0 },
+        { x: 4 * UX, y: 2 * UY },
+        { x: 2 * UX, y: 2 * UY },
+        { x: 2 * UX, y: 4 * UY },
+        { x: 0, y: 4 * UY },
+      ],
+    };
+
+    it('classifies cells with the per-axis pitch', () => {
+      const outside = getOutsideCellSet(L_NS, drawer(4, 4), UX, 1, UY);
+      expect(outside).toEqual(new Set(['2,2', '3,2', '2,3', '3,3']));
+    });
+
+    it('keys the memo cache on the Y pitch', () => {
+      const a = getOutsideCellSet(L_NS, drawer(4, 4), UX, 1, UY);
+      expect(getOutsideCellSet(L_NS, drawer(4, 4), UX, 1, UY)).toBe(a);
+      expect(getOutsideCellSet(L_NS, drawer(4, 4), UX, 1, UX)).not.toBe(a);
+    });
+  });
 });

--- a/src/shared/utils/drawerOutlineCells.ts
+++ b/src/shared/utils/drawerOutlineCells.ts
@@ -51,13 +51,15 @@ export function getOutsideCellSet(
   outline: DrawerOutline,
   drawer: Pick<Drawer, 'width' | 'depth' | 'fractionalEdgeX' | 'fractionalEdgeY'>,
   gridUnitMm: number,
-  step: 0.5 | 1
+  step: 0.5 | 1,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
 ): ReadonlySet<string> {
   const width = drawer.width as number;
   const depth = drawer.depth as number;
   const fx = drawer.fractionalEdgeX ?? 'end';
   const fy = drawer.fractionalEdgeY ?? 'end';
-  const cacheKey = `${width},${depth},${gridUnitMm},${step},${fx},${fy}`;
+  const cacheKey = `${width},${depth},${gridUnitMm},${gridUnitMmY},${step},${fx},${fy}`;
 
   let byParams = cellSetCache.get(outline);
   if (byParams === undefined) {
@@ -73,9 +75,9 @@ export function getOutsideCellSet(
       const cls = classifyRect(
         outline,
         cx.start * gridUnitMm,
-        cy.start * gridUnitMm,
+        cy.start * gridUnitMmY,
         (cx.start + cx.size) * gridUnitMm,
-        (cy.start + cy.size) * gridUnitMm
+        (cy.start + cy.size) * gridUnitMmY
       );
       if (cls !== 'inside') outside.add(`${cx.start},${cy.start}`);
     }

--- a/src/shared/utils/drawerOutlineGeometry.test.ts
+++ b/src/shared/utils/drawerOutlineGeometry.test.ts
@@ -191,4 +191,24 @@ describe('isFootprintInsideOutline', () => {
       false
     );
   });
+
+  it('scales footprints by the per-axis pitch on a non-square grid (#2733)', () => {
+    const UX = 48;
+    const UY = 42;
+    const lNs: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * UX, y: 0 },
+        { x: 4 * UX, y: 2 * UY },
+        { x: 2 * UX, y: 2 * UY },
+        { x: 2 * UX, y: 4 * UY },
+        { x: 0, y: 4 * UY },
+      ],
+    };
+    // Back-flush in the tall body: y ends exactly at the drawer's back edge
+    // (4 × UY) — using the X pitch on Y would push it out of the outline.
+    expect(isFootprintInsideOutline({ x: 0, y: 2, width: 2, depth: 2 }, lNs, UX, UY)).toBe(true);
+    expect(isFootprintInsideOutline({ x: 2, y: 0, width: 2, depth: 2 }, lNs, UX, UY)).toBe(true);
+    expect(isFootprintInsideOutline({ x: 2, y: 2, width: 1, depth: 1 }, lNs, UX, UY)).toBe(false);
+  });
 });

--- a/src/shared/utils/drawerOutlineGeometry.ts
+++ b/src/shared/utils/drawerOutlineGeometry.ts
@@ -249,15 +249,17 @@ export function insideAreaFraction(
 export function isFootprintInsideOutline(
   rect: { readonly x: number; readonly y: number; readonly width: number; readonly depth: number },
   outline: DrawerOutline,
-  gridUnitMm: number
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
 ): boolean {
   return (
     classifyRect(
       outline,
       rect.x * gridUnitMm,
-      rect.y * gridUnitMm,
+      rect.y * gridUnitMmY,
       (rect.x + rect.width) * gridUnitMm,
-      (rect.y + rect.depth) * gridUnitMm
+      (rect.y + rect.depth) * gridUnitMmY
     ) === 'inside'
   );
 }

--- a/src/shared/utils/fill.ts
+++ b/src/shared/utils/fill.ts
@@ -1,4 +1,5 @@
 import type { Bin, GridUnits, Layout, LayerId, CategoryId } from '@/core/types';
+import { effectiveGridUnitMmY } from '@/core/types';
 import { generateBinId, CONSTRAINTS } from '@/core/constants';
 import { getBlockedZones } from './collision';
 import { getOutsideCellSet } from './drawerOutlineCells';
@@ -23,7 +24,8 @@ export function createOccupiedCellSet(
       layout.drawer.outline,
       layout.drawer,
       layout.gridUnitMm,
-      step
+      step,
+      effectiveGridUnitMmY(layout)
     );
     for (const key of outside) occupied.add(key);
   }

--- a/src/shared/utils/validationPlacement.test.ts
+++ b/src/shared/utils/validationPlacement.test.ts
@@ -212,4 +212,31 @@ describe('canPlaceBin with a drawer outline', () => {
     );
     expect(result).toMatchObject({ valid: false, reason: 'exceeds_width' });
   });
+
+  it('scales the footprint by the per-axis pitch on a non-square grid (#2733)', () => {
+    const UX = 48;
+    const UY = 42;
+    const layout = makeSingleLayerLayout();
+    layout.gridUnitMm = UX as Layout['gridUnitMm'];
+    layout.gridUnitMmY = UY as Layout['gridUnitMmY'];
+    // Same L shape scaled to the true per-axis pitches.
+    layout.drawer.outline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 10 * UX, y: 0 },
+        { x: 10 * UX, y: 4 * UY },
+        { x: 6 * UX, y: 4 * UY },
+        { x: 6 * UX, y: 8 * UY },
+        { x: 0, y: 8 * UY },
+      ],
+    };
+    // Back-flush in the tall body (y ends at 8 × UY) — the X pitch on Y
+    // would push the footprint past the outline.
+    expect(
+      canPlaceBin({ x: 0, y: 6, width: 2, depth: 2, height: 3 }, 'layer1', layout)
+    ).toMatchObject({ valid: true });
+    expect(
+      canPlaceBin({ x: 7, y: 5, width: 1, depth: 1, height: 3 }, 'layer1', layout)
+    ).toMatchObject({ valid: false, reason: 'outside_drawer' });
+  });
 });

--- a/src/shared/utils/validationPlacement.test.ts
+++ b/src/shared/utils/validationPlacement.test.ts
@@ -3,6 +3,7 @@ import { canPlaceBin } from './validationPlacement';
 import { createTestLayout, createTestBin } from '@/test/testUtils';
 import { STAGING_ID } from '@/core/constants';
 import type { Layout } from '@/core/types';
+import { mm } from '@/core/types';
 
 function makeSingleLayerLayout(): Layout {
   return createTestLayout({
@@ -217,8 +218,8 @@ describe('canPlaceBin with a drawer outline', () => {
     const UX = 48;
     const UY = 42;
     const layout = makeSingleLayerLayout();
-    layout.gridUnitMm = UX as Layout['gridUnitMm'];
-    layout.gridUnitMmY = UY as Layout['gridUnitMmY'];
+    layout.gridUnitMm = mm(UX);
+    layout.gridUnitMmY = mm(UY);
     // Same L shape scaled to the true per-axis pitches.
     layout.drawer.outline = {
       vertices: [

--- a/src/shared/utils/validationPlacement.ts
+++ b/src/shared/utils/validationPlacement.ts
@@ -21,7 +21,7 @@ import type {
   LayerId,
 } from '@/core/types';
 import { isFootprintInsideOutline } from './drawerOutlineGeometry';
-import { binId as toBinId, categoryId as toCategoryId } from '@/core/types';
+import { binId as toBinId, categoryId as toCategoryId, effectiveGridUnitMmY } from '@/core/types';
 import { STAGING_ID } from '@/core/constants';
 import { isOk } from '@/core/result';
 import {
@@ -61,7 +61,7 @@ export function canPlaceBin(
   // interaction — draw, drag, resize, staging drop, paint, fill, import.
   if (
     drawer.outline !== undefined &&
-    !isFootprintInsideOutline(rect, drawer.outline, layout.gridUnitMm)
+    !isFootprintInsideOutline(rect, drawer.outline, layout.gridUnitMm, effectiveGridUnitMmY(layout))
   ) {
     return { valid: false, reason: 'outside_drawer' };
   }


### PR DESCRIPTION
Fixes #2733

## Problem

On a non-square grid (e.g. X = 48mm, Y = 42mm), the custom drawer shape cutout used the X pitch for both axes. The cell-paint editor authored outline Y coordinates at 48mm per cell, so the void overshot the grid lines vertically (48/42 ≈ 1.14 cells per cell), and every consumer that converts grid rects to mm measured the depth axis the same wrong way.

The renderer (`DrawerOutlineOverlay`) and the baseplate generator were already per-axis correct — which is exactly why the mis-authored outline showed up visually.

## Fix

Thread the depth-axis pitch (resolved via `effectiveGridUnitMmY`, trailing `gridUnitMmY = gridUnitMm` param per the existing convention) through the whole outline pipeline:

**Authoring**
- `drawerMaskToOutline` / `outlineToDrawerMask` (cell-paint editor)
- `cornersToOutline` / `maxCutExtentMm` (corner cuts)

**Consumption**
- `isFootprintInsideOutline` (placement), `getOutsideCellSet` (hatch/fill occupancy, incl. memo key)
- `computeDisplacedBins`, `canPlaceBin`, `createOccupiedCellSet`
- `validateOutline` (one-cell minimum area is now X·Y, not X²), `normalizeDrawerOutline` (ingress crop extent), `resizeDrawerOutline`
- `drawer.setOutline` / `drawer.update` command handlers + the legacy `updateDrawer` store action

**Adjacent same-class bugs**
- `splitPlanner.fullSeam` measured Y seam bands with the X pitch (the `windowOf` right above it was already correct)
- `BaseplatePanel.handleDimensionCommit` computed `drawerDepthMm` with the X pitch, breaking corner-shape detection on non-square grids

## Existing data

Outlines authored under the bug store inflated/deflated Y coordinates. The ingress guard (`normalizeDrawerOutline`) now crops them against the true depth extent, and reopening + re-applying the shape editor re-authors correct mm. No migration needed — the shapes were visibly broken already.

## Tests

Non-square regression tests (using the issue's 48/42 pitches) at every layer: mask↔outline round-trip, corner cuts, cell classification + memo key, footprint scaling, displacement, placement validation, outline min-area + ingress crop, the `setDrawerOutline` command (incl. rectangle-equivalence normalization), and split-planner seam bands. The seam-band test was mutation-verified (fails against the old code). Full unit+dom suite: 14,527 tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly scale custom drawer outlines by the Y grid pitch on non-square grids so shapes and footprints are measured per axis. Fixes Linear #2733 and prevents vertical overshoot, wrong displacement, and outline validation issues.

- **Bug Fixes**
  - Threaded `gridUnitMmY` through outline authoring (`drawerMaskToOutline`, `outlineToDrawerMask`) and corner cuts (`cornersToOutline`, `maxCutExtentMm`).
  - Measured consumers per axis: `isFootprintInsideOutline`, `canPlaceBin`, `getOutsideCellSet` (incl. memo key) + `createOccupiedCellSet`, `computeDisplacedBins`, `validateOutline` (min area uses X·Y), `normalizeDrawerOutline`, `resizeDrawerOutline`.
  - Updated `setDrawerOutline` / `updateDrawer` command handlers and legacy store action to use `effectiveGridUnitMmY`.
  - Fixed `splitPlanner` seam-band calculations and BaseplatePanel dimension snapping (unsynced commits) to use the Y pitch on non-square grids.
  - Added 48/42 grid regression tests across authoring, consumption, placement, displacement, and normalization.

<sup>Written for commit 9fb264edd9cadd1a07ee753ba3c4b5dc96f7259f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

