### PR TITLE
feat(designer): gate wall and lid text behind toggles

### DIFF
--- a/src/features/bin-designer/components/panel/LidSection/LidSection.test.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.test.tsx
@@ -208,20 +208,44 @@ describe('LidSection', () => {
   });
 
   describe('lid text (#2695)', () => {
-    it('renders the text input when the lid is enabled', () => {
+    it('reveals the text input only after the toggle is switched on', () => {
       resetStore({ lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true } });
       render(<LidSection />);
       expect(screen.getByText('Lid text')).toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: 'Lid text' })).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Lid text' }));
+      expect(screen.getByRole('textbox', { name: 'Lid text' })).toBeInTheDocument();
+    });
+
+    it('opens expanded when the design already has lid text', () => {
+      resetStore({
+        lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
+        surfaceText: { lidText: 'Cables' },
+      });
+      render(<LidSection />);
       expect(screen.getByRole('textbox', { name: 'Lid text' })).toBeInTheDocument();
     });
 
     it('commits the typed text to surfaceText.lidText on blur', () => {
       resetStore({ lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true } });
       render(<LidSection />);
+      fireEvent.click(screen.getByRole('switch', { name: 'Lid text' }));
       const input = screen.getByRole('textbox', { name: 'Lid text' });
       fireEvent.change(input, { target: { value: 'Cables' } });
       fireEvent.blur(input);
       expect(useDesignerStore.getState().params.surfaceText?.lidText).toBe('Cables');
+    });
+
+    it('clears lid text and collapses when toggled off', () => {
+      resetStore({
+        lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
+        surfaceText: { lidText: 'Cables' },
+      });
+      render(<LidSection />);
+      fireEvent.click(screen.getByRole('switch', { name: 'Lid text' }));
+      expect(useDesignerStore.getState().params.surfaceText?.lidText).toBeUndefined();
+      expect(screen.queryByRole('textbox', { name: 'Lid text' })).not.toBeInTheDocument();
     });
 
     it('shows the mode picker only when text is present', () => {

--- a/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
@@ -303,7 +303,7 @@ export function LidSection() {
           </section>
 
           {/* ── Lid text (#2695) — gated behind a toggle to match wall text. */}
-          <section>
+          <section className="space-y-2">
             <FeatureToggle
               label={t('binDesigner.lid.section.text')}
               checked={state.isLidTextOpen}

--- a/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
@@ -28,6 +28,7 @@ import { LID_RAIL_SIDES, LID_ATTACHMENTS } from '@/features/bin-designer/types';
 import type { TextMode } from '@/features/bin-designer/types';
 import type { useTranslation } from '@/i18n';
 import { CompartmentTextInput } from '../LabelTabsSection/CompartmentTextInput';
+import { FeatureToggle } from '../FeatureToggle';
 import { useLidSection, LID_TOP_SURFACES } from './useLidSection';
 
 /** Mode options for the lid-text picker, in the shared textMode order. */
@@ -301,45 +302,48 @@ export function LidSection() {
             )}
           </section>
 
-          {/* ── Lid text (#2695) ─────────────────────────────────────── */}
-          <section className="space-y-2">
-            <SubHeader>{t('binDesigner.lid.section.text')}</SubHeader>
-            {state.textDisabledReason ? (
-              <Hint>{state.textDisabledReason}</Hint>
-            ) : (
-              <>
-                {/* Deferred-commit input shared with compartment labels so
-                    typing doesn't regenerate the lid per keystroke; the id
-                    slot is unused for the lid. */}
-                <CompartmentTextInput
-                  committedValue={state.lidText}
-                  compartmentId={0}
-                  placeholder={t('binDesigner.lid.text.placeholder')}
-                  ariaLabel={t('binDesigner.lid.text.aria')}
-                  onCommit={handlers.commitLidText}
-                />
-                {state.lidText.trim() !== '' && (
-                  <>
-                    <SegmentedControl
-                      aria-label={t('binDesigner.textMode')}
-                      activeStyle="accent"
-                      fullWidth
-                      size="sm"
-                      value={state.textMode}
-                      onChange={handlers.setTextMode}
-                      options={TEXT_MODE_OPTIONS.map((mode) => ({
-                        value: mode,
-                        label: t(`binDesigner.textMode.${mode}`),
-                      }))}
-                    />
-                    {state.textMode === 'through-cut' && (
-                      <Hint>{t('binDesigner.textMode.throughCutStencilNote')}</Hint>
-                    )}
-                    {state.textOnTrayFloor && <Hint>{t('binDesigner.lid.text.trayHint')}</Hint>}
-                  </>
-                )}
-              </>
-            )}
+          {/* ── Lid text (#2695) — gated behind a toggle to match wall text. */}
+          <section>
+            <FeatureToggle
+              label={t('binDesigner.lid.section.text')}
+              checked={state.isLidTextOpen}
+              onChange={handlers.toggleLidText}
+              disabledReason={state.textDisabledReason}
+              primaryControls={
+                <>
+                  {/* Deferred-commit input shared with compartment labels so
+                      typing doesn't regenerate the lid per keystroke; the id
+                      slot is unused for the lid. */}
+                  <CompartmentTextInput
+                    committedValue={state.lidText}
+                    compartmentId={0}
+                    placeholder={t('binDesigner.lid.text.placeholder')}
+                    ariaLabel={t('binDesigner.lid.text.aria')}
+                    onCommit={handlers.commitLidText}
+                  />
+                  {state.lidText.trim() !== '' && (
+                    <>
+                      <SegmentedControl
+                        aria-label={t('binDesigner.textMode')}
+                        activeStyle="accent"
+                        fullWidth
+                        size="sm"
+                        value={state.textMode}
+                        onChange={handlers.setTextMode}
+                        options={TEXT_MODE_OPTIONS.map((mode) => ({
+                          value: mode,
+                          label: t(`binDesigner.textMode.${mode}`),
+                        }))}
+                      />
+                      {state.textMode === 'through-cut' && (
+                        <Hint>{t('binDesigner.textMode.throughCutStencilNote')}</Hint>
+                      )}
+                      {state.textOnTrayFloor && <Hint>{t('binDesigner.lid.text.trayHint')}</Hint>}
+                    </>
+                  )}
+                </>
+              }
+            />
           </section>
 
           {/* ── Extra height (folded in) ─────────────────────────────── */}

--- a/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
+++ b/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
@@ -440,6 +440,21 @@ export function useLidSection() {
     [params.surfaceText, setSurfaceTextStyle]
   );
 
+  // Lid text is gated behind a toggle like wall text and the sibling feature
+  // sections. Open state is UI-only, derived as `local || hasText` so a loaded
+  // design with saved lid text opens expanded and survives design switches.
+  const hasLidText = lidText.trim() !== '';
+  const [lidTextOpen, setLidTextOpen] = useState(false);
+  const isLidTextOpen = lidTextOpen || hasLidText;
+  const toggleLidText = useCallback(() => {
+    if (isLidTextOpen) {
+      setLidText('');
+      setLidTextOpen(false);
+    } else {
+      setLidTextOpen(true);
+    }
+  }, [isLidTextOpen, setLidText]);
+
   // Lid outer footprint mirrors `lidBuilder.resolveLidInputs` so the panel
   // readout matches the generated geometry. Floor thickness is dynamic
   // (grows when magnets need a deeper pocket) so we mirror
@@ -637,6 +652,7 @@ export function useLidSection() {
       textMode,
       textDisabledReason,
       textOnTrayFloor: topSurface === 'tray',
+      isLidTextOpen,
     },
     handlers: {
       toggleEnabled,
@@ -654,6 +670,7 @@ export function useLidSection() {
       fixIssue,
       commitLidText,
       setTextMode,
+      toggleLidText,
     },
     t,
   };

--- a/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
+++ b/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
@@ -221,6 +221,7 @@ export function useLidSection() {
     setParam,
     setLidText,
     setSurfaceTextStyle,
+    currentDesignId,
   } = useDesignerStore(
     useShallow((s) => ({
       lid: s.params.lid,
@@ -234,6 +235,7 @@ export function useLidSection() {
       setParam: s.setParam,
       setLidText: s.setLidText,
       setSurfaceTextStyle: s.setSurfaceTextStyle,
+      currentDesignId: s.currentDesignId,
     }))
   );
 
@@ -445,6 +447,15 @@ export function useLidSection() {
   // design with saved lid text opens expanded and survives design switches.
   const hasLidText = lidText.trim() !== '';
   const [lidTextOpen, setLidTextOpen] = useState(false);
+  // Reset the local open flag on design switch so an opened-but-empty toggle
+  // doesn't carry to the next design (the hook isn't remounted). React's
+  // "adjust state during render" pattern — no effect. `local || hasText` still
+  // auto-opens a design that ships with saved lid text.
+  const [lidTextDesignId, setLidTextDesignId] = useState(currentDesignId);
+  if (lidTextDesignId !== currentDesignId) {
+    setLidTextDesignId(currentDesignId);
+    setLidTextOpen(false);
+  }
   const isLidTextOpen = lidTextOpen || hasLidText;
   const toggleLidText = useCallback(() => {
     if (isLidTextOpen) {

--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { WallsSection } from './WallsSection';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
@@ -75,6 +75,17 @@ describe('WallsSection', () => {
       fireEvent.change(input, { target: { value: 'Cables' } });
       fireEvent.blur(input);
       expect(useDesignerStore.getState().params.surfaceText?.walls?.front).toBe('Cables');
+    });
+
+    it('collapses an opened-but-empty toggle when the active design switches', () => {
+      render(<WallsSection />);
+      fireEvent.click(screen.getByRole('switch', { name: 'Wall text' }));
+      expect(screen.getByRole('textbox', { name: 'Front wall text' })).toBeInTheDocument();
+
+      act(() => {
+        useDesignerStore.setState({ currentDesignId: 'another-design' });
+      });
+      expect(screen.queryByRole('textbox', { name: 'Front wall text' })).not.toBeInTheDocument();
     });
 
     it('clears all wall text and collapses when toggled off', () => {

--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.test.tsx
@@ -48,20 +48,49 @@ describe('WallsSection', () => {
   });
 
   describe('wall text (#2695)', () => {
-    it('renders one input per wall', () => {
+    it('hides the inputs until the toggle is switched on', () => {
       render(<WallsSection />);
       expect(screen.getByText('Wall text')).toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: 'Front wall text' })).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Wall text' }));
       for (const side of ['Front', 'Back', 'Left', 'Right']) {
         expect(screen.getByRole('textbox', { name: `${side} wall text` })).toBeInTheDocument();
       }
     });
 
+    it('opens expanded when the design already has wall text', () => {
+      useDesignerStore.setState({
+        params: { ...DEFAULT_BIN_PARAMS, surfaceText: { walls: { front: 'Cables' } } },
+        ui: { ...DEFAULT_UI_STATE },
+      });
+      render(<WallsSection />);
+      expect(screen.getByRole('textbox', { name: 'Front wall text' })).toBeInTheDocument();
+    });
+
     it('commits a wall string on blur', () => {
       render(<WallsSection />);
+      fireEvent.click(screen.getByRole('switch', { name: 'Wall text' }));
       const input = screen.getByRole('textbox', { name: 'Front wall text' });
       fireEvent.change(input, { target: { value: 'Cables' } });
       fireEvent.blur(input);
       expect(useDesignerStore.getState().params.surfaceText?.walls?.front).toBe('Cables');
+    });
+
+    it('clears all wall text and collapses when toggled off', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          surfaceText: { walls: { front: 'Cables', left: 'USB' }, wallAlign: 'top' },
+        },
+        ui: { ...DEFAULT_UI_STATE },
+      });
+      render(<WallsSection />);
+      // Auto-opened because text exists; toggling off clears every wall.
+      fireEvent.click(screen.getByRole('switch', { name: 'Wall text' }));
+      expect(useDesignerStore.getState().params.surfaceText?.walls).toBeUndefined();
+      expect(useDesignerStore.getState().params.surfaceText?.wallAlign).toBeUndefined();
+      expect(screen.queryByRole('textbox', { name: 'Front wall text' })).not.toBeInTheDocument();
     });
 
     it('shows mode + alignment pickers only when text is present', () => {

--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
@@ -15,6 +15,7 @@ import { useWallsSection } from './useWallsSection';
 import { PatternSelector } from './PatternSelector';
 import { WallCutoutsSection } from '../WallCutoutsSection';
 import { HandleSection } from '../HandleSection';
+import { FeatureToggle } from '../FeatureToggle';
 import { CompartmentTextInput } from '../LabelTabsSection/CompartmentTextInput';
 
 /** Mode options for the wall-text picker, in the shared textMode order. */
@@ -62,18 +63,16 @@ export function WallsSection() {
           </div>
         )}
       </div>
-      {/* ── Wall text (#2695) — auto-fit surface text on the outer walls.
-          Sits next to the pattern selector because the pattern is cleared
-          behind the text; per-wall gates (slots) apply in the worker. */}
-      <div className="space-y-2">
-        <span className="block text-xs font-medium text-content-secondary">
-          {t('binDesigner.walls.text.heading')}
-        </span>
-        {state.wallTextDisabledReason ? (
-          <p className="text-[11px] leading-relaxed text-content-tertiary">
-            {state.wallTextDisabledReason}
-          </p>
-        ) : (
+      {/* ── Wall text (#2695) — auto-fit surface text on the outer walls,
+          gated behind a toggle like the sibling cutout/handle sections.
+          The pattern is cleared behind the text; per-wall gates (slots)
+          apply in the worker. */}
+      <FeatureToggle
+        label={t('binDesigner.walls.text.heading')}
+        checked={state.isWallTextOpen}
+        onChange={handlers.toggleWallText}
+        disabledReason={state.wallTextDisabledReason}
+        primaryControls={
           <>
             <div className="grid grid-cols-2 gap-2">
               {WALL_TEXT_SIDES.map((side, index) => (
@@ -130,8 +129,8 @@ export function WallsSection() {
               </>
             )}
           </>
-        )}
-      </div>
+        }
+      />
       <WallCutoutsSection />
       <HandleSection />
     </div>

--- a/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
+++ b/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
@@ -24,6 +24,7 @@ export function useWallsSection() {
     clearWallText,
     setWallTextAlign,
     setSurfaceTextStyle,
+    currentDesignId,
   } = useDesignerStore(
     useShallow((s) => ({
       wallThickness: s.params.wallThickness,
@@ -35,6 +36,7 @@ export function useWallsSection() {
       clearWallText: s.clearWallText,
       setWallTextAlign: s.setWallTextAlign,
       setSurfaceTextStyle: s.setSurfaceTextStyle,
+      currentDesignId: s.currentDesignId,
     }))
   );
   const t = useTranslation();
@@ -105,6 +107,16 @@ export function useWallsSection() {
   // means a loaded design with saved wall text opens expanded without a
   // migration, and stays in sync when the active design switches (no remount).
   const [wallTextOpen, setWallTextOpen] = useState(false);
+  // Reset the local open flag when the active design changes so an opened-but-
+  // empty toggle on one design doesn't carry into the next (the panel hook
+  // isn't remounted on design switch). React's "adjust state during render"
+  // pattern — no effect. `local || hasText` still auto-opens a design that
+  // ships with saved wall text.
+  const [wallTextDesignId, setWallTextDesignId] = useState(currentDesignId);
+  if (wallTextDesignId !== currentDesignId) {
+    setWallTextDesignId(currentDesignId);
+    setWallTextOpen(false);
+  }
   const isWallTextOpen = wallTextOpen || hasAnyWallText;
   const toggleWallText = useCallback(() => {
     if (isWallTextOpen) {

--- a/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
+++ b/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { WALL_THICKNESS_OPTIONS } from '@/features/bin-designer/constants';
@@ -21,6 +21,7 @@ export function useWallsSection() {
     setParam,
     updateWallPattern,
     setWallText,
+    clearWallText,
     setWallTextAlign,
     setSurfaceTextStyle,
   } = useDesignerStore(
@@ -31,6 +32,7 @@ export function useWallsSection() {
       setParam: s.setParam,
       updateWallPattern: s.updateWallPattern,
       setWallText: s.setWallText,
+      clearWallText: s.clearWallText,
       setWallTextAlign: s.setWallTextAlign,
       setSurfaceTextStyle: s.setSurfaceTextStyle,
     }))
@@ -98,6 +100,23 @@ export function useWallsSection() {
       ? t('binDesigner.walls.text.disabledSolid')
       : undefined;
 
+  // Wall-text is gated behind a toggle (matching the sibling cutout/handle
+  // sections). The open state is UI-only — deriving it as `local || hasText`
+  // means a loaded design with saved wall text opens expanded without a
+  // migration, and stays in sync when the active design switches (no remount).
+  const [wallTextOpen, setWallTextOpen] = useState(false);
+  const isWallTextOpen = wallTextOpen || hasAnyWallText;
+  const toggleWallText = useCallback(() => {
+    if (isWallTextOpen) {
+      // Off clears every wall (and align) so the geometry matches the toggle —
+      // same semantics as the other FeatureToggle-gated sections.
+      clearWallText();
+      setWallTextOpen(false);
+    } else {
+      setWallTextOpen(true);
+    }
+  }, [isWallTextOpen, clearWallText]);
+
   // Adapter matching the deferred-commit input's (id, value) signature; the
   // id slot carries the wall side index into WALL_TEXT_SIDES.
   const commitWallTextAt = useCallback(
@@ -127,6 +146,7 @@ export function useWallsSection() {
       wallTextMode,
       hasAnyWallText,
       wallTextDisabledReason,
+      isWallTextOpen,
     },
     handlers: {
       handleChange,
@@ -135,6 +155,7 @@ export function useWallsSection() {
       commitWallTextAt,
       setWallTextAlign,
       setTextMode,
+      toggleWallText,
     },
     t,
   };

--- a/src/features/bin-designer/store/designer.scenario.lid.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.lid.test.ts
@@ -287,6 +287,22 @@ describe('DesignerStore - lid actions', () => {
       undo();
       expect(useDesignerStore.getState().params.surfaceText).toBeUndefined();
     });
+
+    it('clearWallText drops a dangling wallAlign even with no wall strings', () => {
+      const { setWallText, setWallTextAlign, clearWallText } = useDesignerStore.getState();
+      // Reach the walls-less-but-aligned state a programmatic/legacy caller can
+      // produce: set an alignment, then clear the only wall string.
+      setWallText('front', 'Cables');
+      setWallTextAlign('top');
+      setWallText('front', '');
+      // setWallText already dropped wallAlign with the last wall, so re-inject a
+      // dangling alignment directly to exercise the guard.
+      useDesignerStore.setState((s) => ({
+        params: { ...s.params, surfaceText: { wallAlign: 'top' } },
+      }));
+      clearWallText();
+      expect(useDesignerStore.getState().params.surfaceText).toBeUndefined();
+    });
   });
 
   describe('compatibility checks', () => {

--- a/src/features/bin-designer/store/designer.scenario.lid.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.lid.test.ts
@@ -247,6 +247,46 @@ describe('DesignerStore - lid actions', () => {
       setWallText('front', '');
       expect(useDesignerStore.getState().params.surfaceText).toBeUndefined();
     });
+
+    it('clearWallText removes every wall and the alignment in one history entry', () => {
+      const { setWallText, setWallTextAlign, clearWallText, undo } = useDesignerStore.getState();
+      setWallText('front', 'Cables');
+      setWallText('left', 'Chargers');
+      setWallTextAlign('top');
+
+      clearWallText();
+      expect(useDesignerStore.getState().params.surfaceText).toBeUndefined();
+
+      // A single undo restores all walls and the alignment together.
+      undo();
+      expect(useDesignerStore.getState().params.surfaceText?.walls).toEqual({
+        front: 'Cables',
+        left: 'Chargers',
+      });
+      expect(useDesignerStore.getState().params.surfaceText?.wallAlign).toBe('top');
+    });
+
+    it('clearWallText keeps lid text and shared style intact', () => {
+      const { setWallText, setLidText, setSurfaceTextStyle, clearWallText } =
+        useDesignerStore.getState();
+      setWallText('front', 'Cables');
+      setLidText('Lid');
+      setSurfaceTextStyle({ mode: 'emboss' });
+
+      clearWallText();
+      const { surfaceText } = useDesignerStore.getState().params;
+      expect(surfaceText?.walls).toBeUndefined();
+      expect(surfaceText?.lidText).toBe('Lid');
+      expect(surfaceText?.style).toEqual({ mode: 'emboss' });
+    });
+
+    it('clearWallText is a no-op when no wall text exists', () => {
+      const { clearWallText, undo } = useDesignerStore.getState();
+      clearWallText();
+      // Nothing pushed, so undo falls through to the empty baseline.
+      undo();
+      expect(useDesignerStore.getState().params.surfaceText).toBeUndefined();
+    });
   });
 
   describe('compatibility checks', () => {

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -610,8 +610,12 @@ export function createParamSlice(set: Set, get: Get) {
 
     clearWallText: () => {
       const { params } = get();
-      // No-op guard: nothing to clear keeps undo/regeneration quiet.
-      if (params.surfaceText?.walls === undefined) return;
+      // No-op guard: nothing to clear keeps undo/regeneration quiet. Checks
+      // `wallAlign` too — a programmatic/legacy state can hold an alignment
+      // without any wall strings, and clearing must still drop it.
+      if (params.surfaceText?.walls === undefined && params.surfaceText?.wallAlign === undefined) {
+        return;
+      }
 
       set((state) => {
         pushHistoryEntry(state);

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -608,6 +608,20 @@ export function createParamSlice(set: Set, get: Get) {
       });
     },
 
+    clearWallText: () => {
+      const { params } = get();
+      // No-op guard: nothing to clear keeps undo/regeneration quiet.
+      if (params.surfaceText?.walls === undefined) return;
+
+      set((state) => {
+        pushHistoryEntry(state);
+        // Drop `walls` AND `wallAlign` (meaningless without wall text); keep any
+        // other surface-text keys (lid text, shared style) intact.
+        const { walls: _walls, wallAlign: _align, ...rest } = state.params.surfaceText ?? {};
+        state.params.surfaceText = Object.keys(rest).length > 0 ? rest : undefined;
+      });
+    },
+
     setWallTextAlign: (align: WallTextVerticalAlign) => {
       const { params } = get();
       // 'center' is the implicit default — stored as an absent field.

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -1227,6 +1227,8 @@ export interface DesignerState {
   // Surface text actions (lid top + outer walls)
   setLidText: (text: string) => void;
   setWallText: (side: WallTextSide, text: string) => void;
+  /** Remove text from every wall in one history entry (drops `wallAlign` too). */
+  clearWallText: () => void;
   setWallTextAlign: (align: WallTextVerticalAlign) => void;
   setSurfaceTextStyle: (overrides: TextStyleOverride | null) => void;
 


### PR DESCRIPTION
## What

Wall text and lid text now sit behind on/off toggles, matching the sibling **Wall cutouts** and **Handles** sections. The panel no longer shows text inputs (and mode/alignment controls) until you actually turn the feature on.

## Behavior

- **Open state is UI-only**, derived as `local || hasText` — so a saved design that already has wall/lid text opens expanded, and it stays correct when the active design switches (no remount needed). No data-model or server-validation change.
- **Toggling off clears the text** in a single undo step, so the toggle state and the rendered geometry always agree (same semantics as every other `FeatureToggle` section). New `clearWallText` store action clears all four walls + alignment in one history entry; the lid uses `setLidText('')`.
- **Mode + alignment still reveal only after typing** — the two-stage disclosure is preserved.

## Audit sweep

Wall text and lid text were the only non-core always-open features using bare headings. Wall Pattern and Interior-mode are multi-choice dropdowns with an explicit off-state (not binary toggles), and core controls (dimensions, physical units) correctly stay open — left as-is.

## Tests

- Added toggle behavior + clear-on-off coverage for both sections and the `clearWallText` store action.
- 1578 bin-designer panel/store tests pass; typecheck + lint clean; both toggles visually verified (collapsed / expanded / typed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate wall and lid text behind on/off toggles to declutter the panel and match cutouts/handles. Toggles reset per active design, and turning one off clears the text in a single undo step.

- **New Features**
  - Wall and lid text controls sit behind `FeatureToggle`; inputs show only when on or when a design already has text.
  - Open state is UI-only (local-or-hasText) and resets on design switch so opened-but-empty toggles don’t carry over.
  - Toggling off clears text in one step: `clearWallText` drops all wall strings and `wallAlign` (even dangling) in a single history entry; lid uses `setLidText('')` and no-ops if already empty.
  - Two-stage reveal preserved: mode/alignment appear only after typing; tests cover toggles, design-switch reset, and clear/history behavior.

<sup>Written for commit 7e0c9c39563fa6e1fcd4efb9d9a8471af24c4b43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

