### PR TITLE
fix(designer): slim lid-retention magnet corner posts

### DIFF
--- a/src/features/bin-designer/utils/lidCompatibility.test.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.test.ts
@@ -653,15 +653,15 @@ describe('checkLidCompatibility — magnetic attachment (#2694)', () => {
     expect(checkLidCompatibility(params).some((i) => i.id === 'magnetBinTooSmall')).toBe(false);
   });
 
-  it('blocks a 1x1 bin whose corner pads would merge (large magnet)', () => {
-    // Half-width 21mm; a 15mm magnet needs half-extent >= 3.5 + 15 + 2*1.5 =
-    // 21.5mm for the gusset pads not to merge at the centre, so it's blocked.
+  it('allows a 1x1 bin with the max magnet now that the posts are slimmer', () => {
+    // Half-width 21mm; with the 1.0mm boss wall the gusset pads need only
+    // 3.5 + 15 + 2*1.0 = 20.5mm half-extent, so a full 1-unit bin clears even
+    // the largest magnet (it was blocked at the old 1.5mm wall).
     const params = magnetic(
       { width: 1, depth: 1 },
       { retentionMagnet: { diameter: 15, depth: 2 } }
     );
-    const issue = checkLidCompatibility(params).find((i) => i.id === 'magnetBinTooSmall');
-    expect(issue?.severity).toBe('blocker');
+    expect(checkLidCompatibility(params).some((i) => i.id === 'magnetBinTooSmall')).toBe(false);
   });
 
   it('blocks when the retention magnet is deeper than the bin interior', () => {

--- a/src/features/bin-designer/utils/lidCompatibility.ts
+++ b/src/features/bin-designer/utils/lidCompatibility.ts
@@ -81,13 +81,13 @@ const MAGNET_POST_MIN_FLOOR = 0.6;
 
 /**
  * Local mirrors of the worker's `LID_MAGNET_LIP_CLEARANCE` (3.5) and
- * `LID_MAGNET_BOSS_WALL` (1.5), used to reject bins too small to place the four
+ * `LID_MAGNET_BOSS_WALL` (1.0), used to reject bins too small to place the four
  * corner magnets. Duplicated as literals to avoid importing worker-side
  * geometry constants across the feature boundary — keep in sync by hand with
  * `retentionMagnetGeometry.ts` / `lidConstants.ts`.
  */
 const MAGNET_LIP_CLEARANCE = 3.5;
-const MAGNET_BOSS_WALL = 1.5;
+const MAGNET_BOSS_WALL = 1.0;
 
 /**
  * Interior wall height available for handle holes (mm). Mirrors the

--- a/src/features/generation/worker/generators/lidConstants.ts
+++ b/src/features/generation/worker/generators/lidConstants.ts
@@ -154,8 +154,12 @@ export const LID_COPLANAR_MARGIN = 0.1;
  * `retentionMagnetGeometry.ts`.
  * ──────────────────────────────────────────────────────────────────────── */
 
-/** Radial plastic kept around a retention magnet inside its post/boss (mm). */
-export const LID_MAGNET_BOSS_WALL = 1.5;
+/** Radial plastic kept around a retention magnet inside its post/boss (mm).
+ *  1.0mm (2–3 perimeters at a 0.4mm nozzle) keeps the corner post slim: because
+ *  the magnet inset is `LIP_CLEARANCE + bossRadius`, a thinner wall pulls the
+ *  post's cavity-facing edge inboard (~1mm per 0.5mm of wall) while the boss's
+ *  lip-side edge and the magnet mating stay put. */
+export const LID_MAGNET_BOSS_WALL = 1.0;
 
 /**
  * Radial gap (mm) kept between the lid's magnet boss and the stacking lip's

--- a/src/features/generation/worker/generators/lidConstants.ts
+++ b/src/features/generation/worker/generators/lidConstants.ts
@@ -156,7 +156,7 @@ export const LID_COPLANAR_MARGIN = 0.1;
 
 /** Radial plastic kept around a retention magnet inside its post/boss (mm).
  *  1.0mm (2–3 perimeters at a 0.4mm nozzle) keeps the corner post slim: because
- *  the magnet inset is `LIP_CLEARANCE + bossRadius`, a thinner wall pulls the
+ *  the magnet inset is `LID_MAGNET_LIP_CLEARANCE + bossRadius`, a thinner wall pulls the
  *  post's cavity-facing edge inboard (~1mm per 0.5mm of wall) while the boss's
  *  lip-side edge and the magnet mating stay put. */
 export const LID_MAGNET_BOSS_WALL = 1.0;


### PR DESCRIPTION
## What

On magnetic-lid bins, each bin corner grows a magnet-retention post (issue #2694). At the default ø6mm magnet those posts were bulkier than needed. This thins the boss wall from **1.5mm to 1.0mm**.

## Why this is the right lever

The post's footprint is dominated by the magnet boss itself — the ø9mm boss already sits nearly against the interior walls, so there's almost no solid "fill" to hollow out, and the gusset beneath it is already a minimal 45° support-free ramp. The boss wall is the one knob that actually shrinks the post.

## Effect

- Boss OD **9mm → 8mm**. Because the magnet inset is `LIP_CLEARANCE + bossRadius`, the boss's *outer* (lip-side) edge is pinned at the lip clearance regardless of size, so the full reduction lands on the **cavity-facing** side: each post's inner edge pulls ~1mm toward the corner.
- **Lip clearance and magnet mating are unchanged**; bin post and lid boss stay coaxial (both read the shared `retentionBossRadius`).
- **Exterior wall untouched** — only interior boss/inset geometry changes.
- Magnet pocket wall is now 1.0mm (2–3 perimeters). The magnets are press-fit **and** glued, so hold is unaffected.

## Tests

44 retention/lid geometry tests + 947 generator-scenario tests pass; rendered before/after (clean, watertight).

## Print check

Worth a quick physical print to confirm the thinner pocket wall presses/glues the magnet cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slims magnetic-lid corner posts by reducing the magnet boss wall from 1.5mm to 1.0mm. Keeps fit and magnet mating, and syncs the bin-size check to the slimmer wall.

- **Effect**
  - Boss OD 9mm → 8mm; inner edge moves ~1mm toward the corner; exterior wall unchanged.
  - Lip clearance and magnet mating unchanged; bin post and lid boss stay coaxial via `retentionBossRadius`. 1.0mm pocket wall supports press-fit + glue.
  - Compatibility check now mirrors the 1.0mm wall; a 1x1 bin accepts a 15mm magnet.

<sup>Written for commit 4d12bc472ec6f5fc64dae4ce3f61f2b12face602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

