### PR TITLE
chore(designer): tidy linked-grid internals and cover lid-text design switch

### DIFF
--- a/src/features/bin-designer/components/panel/LidSection/LidSection.test.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { LidSection } from './LidSection';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
@@ -245,6 +245,18 @@ describe('LidSection', () => {
       render(<LidSection />);
       fireEvent.click(screen.getByRole('switch', { name: 'Lid text' }));
       expect(useDesignerStore.getState().params.surfaceText?.lidText).toBeUndefined();
+      expect(screen.queryByRole('textbox', { name: 'Lid text' })).not.toBeInTheDocument();
+    });
+
+    it('collapses an opened-but-empty toggle when the active design switches', () => {
+      resetStore({ lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true } });
+      render(<LidSection />);
+      fireEvent.click(screen.getByRole('switch', { name: 'Lid text' }));
+      expect(screen.getByRole('textbox', { name: 'Lid text' })).toBeInTheDocument();
+
+      act(() => {
+        useDesignerStore.setState({ currentDesignId: 'another-design' });
+      });
       expect(screen.queryByRole('textbox', { name: 'Lid text' })).not.toBeInTheDocument();
     });
 

--- a/src/shared/components/LinkedDimensionInput/LinkedDimensionInput.tsx
+++ b/src/shared/components/LinkedDimensionInput/LinkedDimensionInput.tsx
@@ -55,13 +55,6 @@ export function LinkedDimensionInput({
   const isSquare = width === depth;
   const showSingleInput = isSquare && !expanded;
 
-  const handleLinkedChange = useCallback(
-    (value: number) => {
-      onChange(value);
-    },
-    [onChange]
-  );
-
   const handleWidthChange = useCallback(
     (value: number) => {
       onChange(value, depth !== value ? depth : undefined);
@@ -125,7 +118,7 @@ export function LinkedDimensionInput({
         <DeferredNumberInput
           id={id}
           value={width}
-          onChange={handleLinkedChange}
+          onChange={onChange}
           min={min}
           max={max}
           step={step}

--- a/src/shared/hooks/useDrawerSettings.ts
+++ b/src/shared/hooks/useDrawerSettings.ts
@@ -38,10 +38,6 @@ import { isOk, isErr } from '@/core/result';
 import { useTranslation } from '@/i18n';
 
 /**
- * Return type for useDrawerSettings hook.
- * Provides all drawer-related state and handlers needed by settings panels.
- */
-/**
  * A grid fit offered (never auto-applied) after a measured-mm commit. The user
  * opts in via the suggestion card; the grid never resizes on its own.
  * `isHalf` fits use a half-unit grid, so accepting also turns half-grid on.
@@ -286,8 +282,6 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
     updateDrawer,
     updateBin,
   } = useMutations();
-
-  // Undo support
 
   // Derive layers/categories from the `layout` already selected in the
   // useShallow above. Prior code opened two additional bare subscriptions


### PR DESCRIPTION
## What

A small quality sweep over the three most recently merged designer/settings features (#2736 linked X/Y grid control, #2737 wall/lid text toggles, #2738 magnet-boss wall). No behavior change; internal tidying plus one missing test.

## Changes

- **Fill a test-coverage gap.** `WallsSection` had a test asserting that switching the active design collapses an opened-but-empty wall-text toggle (the adjust-state-during-render reset). `LidSection` has the identical reset in `useLidSection` but no test guarding it. Added the parallel `LidSection` test so the lid-text version can't silently regress.
- **Remove dead comments in `useDrawerSettings.ts`.** A JSDoc block (`Return type for useDrawerSettings hook`) was orphaned directly above the unrelated `DrawerFitSuggestion` interface, and an `// Undo support` header sat over code that derives layers/categories. Both documented nothing at their location.
- **Drop a trivial wrapper in `LinkedDimensionInput`.** The single-input branch used a `useCallback` that just forwarded `onChange`; it now passes `onChange` directly. The relinked/square path (`onChange(width)` with no depth) is byte-identical.

## Verification

- `pnpm run typecheck` — clean
- Affected suites green: **235 tests** (LinkedDimensionInput, GridUnitInput, useDrawerSettings, PhysicalUnitsSection, LidSection, WallsSection, lid scenario, lidCompatibility)
- i18n key parity confirmed across all 10 locales

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Post-merge quality sweep for designer settings. Adds a missing lid-text reset test, removes dead comments, and simplifies `LinkedDimensionInput` with no behavior changes.

- **Refactors**
  - Add `LidSection` test to ensure lid-text toggle collapses on design switch (mirrors `WallsSection`).
  - Remove orphaned JSDoc and "Undo support" header in `useDrawerSettings.ts`.
  - Inline trivial pass-through `useCallback` in `LinkedDimensionInput` and pass `onChange` directly.

<sup>Written for commit c4cf4136459151c611054d2c56a0cdd15cdf3e2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

