### PR TITLE
fix(design-system): center Input left icon vertically

### DIFF
--- a/src/design-system/Input/Input.tsx
+++ b/src/design-system/Input/Input.tsx
@@ -62,23 +62,6 @@ const inputVariants = cva(
   }
 );
 
-const iconWrapperVariants = cva(['flex-shrink-0', 'text-content-tertiary'], {
-  variants: {
-    size: {
-      sm: 'w-3.5 h-3.5',
-      md: 'w-4 h-4',
-      lg: 'w-5 h-5',
-    },
-    position: {
-      left: 'ml-2',
-      right: 'mr-2',
-    },
-  },
-  defaultVariants: {
-    size: 'md',
-  },
-});
-
 type InputVariantProps = VariantProps<typeof inputWrapperVariants>;
 
 export interface InputProps
@@ -188,7 +171,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         className={cn(inputWrapperVariants({ size, error, disabled, fullWidth }), wrapperClassName)}
       >
         {leftIcon && (
-          <span className={iconWrapperVariants({ size, position: 'left' })} aria-hidden="true">
+          <span
+            className="ml-2 inline-flex flex-shrink-0 items-center text-content-tertiary"
+            aria-hidden="true"
+          >
             {leftIcon}
           </span>
         )}


### PR DESCRIPTION
## Summary

The settings modal search icon sat ~4px below the input's vertical centerline (reported as "search icon in settings modal is misaligned").

Root cause is in the DS `Input`, not the settings modal: the left-icon wrapper used a fixed size-variant box (`w-3.5 h-3.5` = 14px for `sm` inputs) with no flex centering. The wrapper box can't resize the child SVG (icons carry their own `w/h` classes), so the 16px search icon overflowed the 14px box, and as an inline-block on the text baseline it rendered below center. #2229 shrank the icon 20px → 16px but couldn't fix the baseline placement.

Fix mirrors the right-icon wrapper (fixed the same way previously): size the wrapper to its content and center with `inline-flex items-center`, making the icon prop the single source of truth for size. The now-unused `iconWrapperVariants` cva is removed.

Also quietly corrects the same subtle droop in the other two `Input` left-icon call sites (layout library search, STL search dropdown) — both pass 16px icons.

## Verification

Measured in the running app (Playwright, dark theme):

| | icon y-center | input y-center |
|---|---|---|
| before | 183.5 (4px low, 16px svg in 14px box) | 179.5 |
| after | 179.5 | 179.5 |

Full unit + dom suite green locally (14,517 tests / 1,095 files). Typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the left icon in the design system `Input` so icons align vertically across sizes. Fixes the drooping search icon in the settings modal and other inputs using 16px icons.

- **Bug Fixes**
  - Replaced the fixed-size left-icon wrapper with `inline-flex items-center` sized to content for consistent centering.
  - Removed `iconWrapperVariants` and mirrored right-icon behavior; icon size now comes solely from the passed `leftIcon`.

<sup>Written for commit 0d76138117d0d2e5bcda4068816c9ec67acef729. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

