### PR TITLE
chore: resolve lint warnings and add it locale to size budget exclusions

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
         "!dist/assets/de-*.js",
         "!dist/assets/es-*.js",
         "!dist/assets/fr-*.js",
+        "!dist/assets/it-*.js",
         "!dist/assets/ja-*.js",
         "!dist/assets/nb-*.js",
         "!dist/assets/nl-*.js",

--- a/src/core/cqrs/validation/outlineSchema.ts
+++ b/src/core/cqrs/validation/outlineSchema.ts
@@ -13,19 +13,19 @@ const OUTLINE_COORD_MIN = -1;
 const OUTLINE_COORD_MAX = 2600;
 
 const outlineVertexSchema = z.object({
-  x: z.number().finite().gte(OUTLINE_COORD_MIN).lte(OUTLINE_COORD_MAX),
-  y: z.number().finite().gte(OUTLINE_COORD_MIN).lte(OUTLINE_COORD_MAX),
-  bulge: z.number().finite().gte(-1).lte(1).optional(),
+  x: z.number().gte(OUTLINE_COORD_MIN).lte(OUTLINE_COORD_MAX),
+  y: z.number().gte(OUTLINE_COORD_MIN).lte(OUTLINE_COORD_MAX),
+  bulge: z.number().gte(-1).lte(1).optional(),
 });
 
 const cornerCutSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('none') }),
-  z.object({ kind: z.literal('chamfer'), size: z.number().finite().gt(0).lte(500) }),
-  z.object({ kind: z.literal('radius'), r: z.number().finite().gt(0).lte(500) }),
+  z.object({ kind: z.literal('chamfer'), size: z.number().gt(0).lte(500) }),
+  z.object({ kind: z.literal('radius'), r: z.number().gt(0).lte(500) }),
   z.object({
     kind: z.literal('notch'),
-    w: z.number().finite().gt(0).lte(2600),
-    d: z.number().finite().gt(0).lte(2600),
+    w: z.number().gt(0).lte(2600),
+    d: z.number().gt(0).lte(2600),
   }),
 ]);
 

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
@@ -68,10 +68,10 @@ export function CameraController({
   const aspect = size.width > 0 && size.height > 0 ? size.width / size.height : 1;
 
   const stackActive = stackEnabled && stackBounds !== null && stackBounds.heightMm > 0;
-  const totalH = stackActive && stackBounds ? stackBounds.heightMm : GRIDFINITY_SPEC.SOCKET_HEIGHT;
+  const totalH = stackActive ? stackBounds.heightMm : GRIDFINITY_SPEC.SOCKET_HEIGHT;
   const binCenter = useMemo(() => new THREE.Vector3(0, 0, totalH / 2), [totalH]);
   const idealDistance = useMemo(() => {
-    if (stackActive && stackBounds) {
+    if (stackActive) {
       return calculateStackIdealDistance(
         stackBounds.widthMm,
         stackBounds.depthMm,

--- a/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
@@ -213,7 +213,7 @@ export function StackedBaseplateMeshes({
         </lineSegments>
       )}
       {meshResult.towerLayouts.map((layout, idx) => {
-        const entry = plan[idx];
+        const entry = plan.at(idx);
         if (!entry) return null;
         const label = `×${entry.copies}`;
         return (

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -534,7 +534,7 @@ function computeWallPatternReduction(
 
   // Pattern open-area fraction, modulated by scale (0.5 = neutral, factor 1.0).
   const scale = params.wallPattern.scale ?? DEFAULT_PATTERN_SCALE;
-  const base = PATTERN_VOID_FRACTION[params.wallPattern.pattern] ?? 0.5;
+  const base = PATTERN_VOID_FRACTION[params.wallPattern.pattern];
   const coverageFraction = Math.min(0.95, Math.max(0, base * (0.85 + 0.3 * scale)));
   const coverage = wallFaceArea * coverageFraction;
 

--- a/src/shared/pwa/staleRecovery.test.ts
+++ b/src/shared/pwa/staleRecovery.test.ts
@@ -20,11 +20,12 @@ beforeEach(() => {
   cacheDelete.mockClear();
   unregister.mockClear();
 
-  // Preserve the real Location shape (href/origin/...) and override only reload,
-  // so code reading other fields still works.
+  // Location's fields are prototype accessors, so a spread copies none of them —
+  // stub exactly the fields test subjects read (reload, plus href/origin for
+  // incidental readers).
   Object.defineProperty(window, 'location', {
     configurable: true,
-    value: { ...realLocation, href: realLocation.href, origin: realLocation.origin, reload },
+    value: { href: realLocation.href, origin: realLocation.origin, reload },
   });
 
   vi.stubGlobal('caches', {

--- a/src/shell/layoutExport/planLabelPlateExport.ts
+++ b/src/shell/layoutExport/planLabelPlateExport.ts
@@ -173,7 +173,7 @@ export function planLabelPlateExport(
     const expanded: { widthU: LabelPlateWidthU; text: string; icon?: LabelPlateIconId }[] = spanning
       ? linkedBins.map((b) => ({
           widthU: planned[0].widthU,
-          text: (b.label ?? '').trim() || design.name,
+          text: b.label.trim() || design.name,
         }))
       : linkedBins.flatMap(() =>
           planned.map((p) => ({


### PR DESCRIPTION
## Summary

Zeroes out the actionable ESLint warnings surfaced by `pnpm run quality` (34 → max-lines-only) and fixes a size-limit config gap.

- **Zod `.finite()`** (`outlineSchema.ts`, 7 call sites): deprecated no-op — Zod v4's `z.number()` already rejects non-finite values. Behavior unchanged.
- **`no-unnecessary-condition`**:
  - `CameraController.tsx`: `stackActive` is computed as `stackEnabled && stackBounds !== null && …`, and TypeScript's aliased-condition narrowing already proves `stackBounds` non-null wherever `stackActive` is truthy — the repeated `&& stackBounds` checks were dead.
  - `StackedBaseplateMeshes.tsx`: `plan[idx]` was typed always-defined, but `plan` (from `preview`) and `towerLayouts` (from `meshResult`) can genuinely desync across async updates — switched to `plan.at(idx)` so the guard is type-honest instead of deleting it.
  - `printEstimates.ts`: `PATTERN_VOID_FRACTION` is a `Record<WallPatternType, number>`, exhaustive at compile time — the `?? 0.5` fallback is unreachable.
  - `planLabelPlateExport.ts`: `Bin.label` is a required `string` — dropped the dead `?? ''`.
- **`no-misused-spread`** (`staleRecovery.test.ts`): spreading a `Location` instance copies nothing (its fields are prototype accessors) — replaced with an explicit `{href, origin, reload}` stub, which is what the spread was silently resolving to anyway.
- **size-limit**: the "Total JS (gzip, one locale)" budget excludes every locale chunk except `it-*.js` (missed when the Italian locale was added) — the budget was counting two locales. Added the exclusion; expect the measured number to drop slightly.

The remaining warnings are all `max-lines`, which will be resolved by upcoming structural refactor PRs rather than suppressed.

## Testing

- `pnpm run typecheck` clean; `eslint` clean on all touched files
- 58 tests across the five affected sibling test files pass; CQRS schema/middleware tests (65) pass
- Full unit suite green: 1285 files, 16,577 passed / 7 skipped (pre-existing tracked skips)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears actionable ESLint warnings and updates `size-limit` to exclude the Italian locale so the single-locale bundle budget is accurate. No runtime behavior changes.

- **Refactors**
  - Remove deprecated `zod` `.finite()` calls in schemas (v4 rejects non-finite by default).
  - Drop dead condition checks proven by TypeScript narrowing in `CameraController`.
  - Use `plan.at(idx)` to keep the desync guard accurate in `StackedBaseplateMeshes`.
  - Remove unreachable `??` fallbacks (exhaustive Record index, required `Bin.label`).
  - Replace no-op `Location` spread in PWA test with explicit `{href, origin, reload}` stub.

- **Bug Fixes**
  - `size-limit`: exclude `!dist/assets/it-*.js` from the "Total JS (gzip, one locale)" budget to avoid counting two locales; reported size will decrease slightly.

<sup>Written for commit 30d62d03bb8db5e07242ed321f593ad331b3fed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

