### PR TITLE
fix(lint): re-arm eslint-plugin-boundaries after silent v7 breakage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -203,8 +203,9 @@ export default defineConfig([
       //      application-level layer (`feature`, `shell`, `shared`, `core`).
       //
       // This is a STRICTER superset of the bash mirror in
-      // scripts/check-module-boundaries.sh — it also inspects dynamic
-      // imports (see `boundaries/dependency-nodes` above).
+      // scripts/check-module-boundaries.sh — it also inspects exports,
+      // require calls, and dynamic imports (the plugin's default
+      // dependency-nodes; deliberately not pinned in settings above).
       // Remaining edges (shared→feature, feature→shell) are intentionally
       // unrestricted today; tightening them needs a per-violator cleanup pass.
       'boundaries/dependencies': ['error', {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -173,22 +173,29 @@ export default defineConfig([
           alwaysTryTypes: true,
         },
       },
+      // Whole-folder patterns (not `src/core/*`): with subfolder globs, files
+      // sitting directly at a layer root (e.g. src/core/types.ts) belong to no
+      // element and their imports silently escape every policy.
       'boundaries/elements': [
-        { type: 'core', pattern: ['src/core/*'] },
-        { type: 'shared', pattern: ['src/shared/*'] },
-        { type: 'design-system', pattern: ['src/design-system/*'] },
+        { type: 'core', pattern: ['src/core'] },
+        { type: 'shared', pattern: ['src/shared'] },
+        { type: 'design-system', pattern: ['src/design-system'] },
         { type: 'feature', pattern: ['src/features/*'], capture: ['featureName'] },
-        { type: 'shell', pattern: ['src/shell/*'] },
-        { type: 'i18n', pattern: ['src/i18n/*'] },
-        { type: 'test-infra', pattern: ['src/test/*'] },
+        { type: 'shell', pattern: ['src/shell'] },
+        { type: 'i18n', pattern: ['src/i18n'] },
+        { type: 'test-infra', pattern: ['src/test'] },
       ],
-      'boundaries/dependency-nodes': ['import', 'dynamic-import'],
+      // Default dependency-nodes (import, export, require, dynamicImport).
+      // Do not pin this to a list: the pre-v6 value `dynamic-import` was
+      // silently ignored after the rename to `dynamicImport`, which is how
+      // dynamic-import violations escaped the rule for months.
     },
     rules: {
       // Layer rules. Three kinds of constraint coexist:
       //   1. Cross-feature: features cannot import from OTHER features (with
-      //      named exceptions for design-linking -> bin-designer and
-      //      bin-inspector -> design-linking integration layers).
+      //      named exceptions for design-linking -> bin-designer,
+      //      bin-inspector -> design-linking, and
+      //      bin-inspector -> bin-recommender integration layers).
       //   2. `core/` is infrastructure: disallowed from `feature` and `shell`.
       //      (`core/` -> `shared/` stays allowed; several `core/storage/*`
       //      modules consume shared utilities/analytics by design.)
@@ -202,45 +209,63 @@ export default defineConfig([
       // unrestricted today; tightening them needs a per-violator cleanup pass.
       'boundaries/dependencies': ['error', {
         default: 'allow',
-        rules: [
+        policies: [
           // Features: disallow importing other features (cross-feature coupling)
-          { from: [{ type: 'feature' }], disallow: [{ to: { type: 'feature' } }] },
+          {
+            from: { element: { type: 'feature' } },
+            disallow: [{ to: { element: { type: 'feature' } } }],
+          },
           // Same feature is OK
           {
-            from: [{ type: 'feature' }],
-            allow: [{ to: { type: 'feature', captured: { featureName: '{{ from.captured.featureName }}' } } }],
+            from: { element: { type: 'feature' } },
+            allow: [
+              {
+                to: {
+                  element: {
+                    type: 'feature',
+                    captured: { featureName: '{{ from.captured.featureName }}' },
+                  },
+                },
+              },
+            ],
           },
           // Exception: design-linking -> bin-designer (integration layer)
           {
-            from: [{ type: 'feature', captured: { featureName: 'design-linking' } }],
-            allow: [{ to: { type: 'feature', captured: { featureName: 'bin-designer' } } }],
+            from: { element: { type: 'feature', captured: { featureName: 'design-linking' } } },
+            allow: [{ to: { element: { type: 'feature', captured: { featureName: 'bin-designer' } } } }],
           },
           // Exception: bin-inspector -> design-linking (lazy-loaded linked design section)
           {
-            from: [{ type: 'feature', captured: { featureName: 'bin-inspector' } }],
-            allow: [{ to: { type: 'feature', captured: { featureName: 'design-linking' } } }],
+            from: { element: { type: 'feature', captured: { featureName: 'bin-inspector' } } },
+            allow: [{ to: { element: { type: 'feature', captured: { featureName: 'design-linking' } } } }],
           },
           // Exception: bin-inspector -> bin-recommender (lazy-loaded size suggestion)
           {
-            from: [{ type: 'feature', captured: { featureName: 'bin-inspector' } }],
-            allow: [{ to: { type: 'feature', captured: { featureName: 'bin-recommender' } } }],
+            from: { element: { type: 'feature', captured: { featureName: 'bin-inspector' } } },
+            allow: [{ to: { element: { type: 'feature', captured: { featureName: 'bin-recommender' } } } }],
           },
           // `core/` is infrastructure — it must not depend on features or the
           // app shell. (`core/` -> `shared/` is intentionally allowed; many
           // `core/storage/*` modules use shared utilities/analytics.)
-          { from: [{ type: 'core' }], disallow: [{ to: { type: 'feature' } }, { to: { type: 'shell' } }] },
+          {
+            from: { element: { type: 'core' } },
+            disallow: [
+              { to: { element: { type: 'feature' } } },
+              { to: { element: { type: 'shell' } } },
+            ],
+          },
           // `design-system/` is UI primitives — it must not depend on any
           // application-level layer. UI primitives take strings via props;
           // they never read translations themselves, so `i18n` is in the
           // disallow list alongside the app layers.
           {
-            from: [{ type: 'design-system' }],
+            from: { element: { type: 'design-system' } },
             disallow: [
-              { to: { type: 'feature' } },
-              { to: { type: 'shell' } },
-              { to: { type: 'i18n' } },
-              { to: { type: 'shared' } },
-              { to: { type: 'core' } },
+              { to: { element: { type: 'feature' } } },
+              { to: { element: { type: 'shell' } } },
+              { to: { element: { type: 'i18n' } } },
+              { to: { element: { type: 'shared' } } },
+              { to: { element: { type: 'core' } } },
             ],
           },
         ],

--- a/scripts/check-module-boundaries.sh
+++ b/scripts/check-module-boundaries.sh
@@ -28,8 +28,9 @@ NC='\033[0m' # No Color
 ALLOWED_CROSS_FEATURE=(
   "design-linking:bin-designer" # Integration layer; imports must use @/features/bin-designer barrel only
   # The next two are dynamic imports today (invisible to this static grep) but
-  # are sanctioned in eslint.config.js — listed here so converting one to a
-  # static import doesn't create a bash-vs-eslint verdict split.
+  # are sanctioned in eslint.config.js — listed here so a future conversion to
+  # a static BARREL import (the only form this allowlist accepts) doesn't
+  # create a bash-vs-eslint verdict split. Deep static imports stay violations.
   "bin-inspector:design-linking" # Lazy-loaded linked design section
   "bin-inspector:bin-recommender" # Lazy-loaded size suggestion
 )

--- a/scripts/check-module-boundaries.sh
+++ b/scripts/check-module-boundaries.sh
@@ -27,6 +27,11 @@ NC='\033[0m' # No Color
 # Add entries here (with explanation) when intentional coupling is required.
 ALLOWED_CROSS_FEATURE=(
   "design-linking:bin-designer" # Integration layer; imports must use @/features/bin-designer barrel only
+  # The next two are dynamic imports today (invisible to this static grep) but
+  # are sanctioned in eslint.config.js — listed here so converting one to a
+  # static import doesn't create a bash-vs-eslint verdict split.
+  "bin-inspector:design-linking" # Lazy-loaded linked design section
+  "bin-inspector:bin-recommender" # Lazy-loaded size suggestion
 )
 
 VIOLATIONS_FOUND=0


### PR DESCRIPTION
## Summary

The `boundaries/dependencies` rule — the eslint side of our architectural enforcement — has been a **silent no-op** since the plugin's v7 upgrade. The plugin fails open: unmatched config falls through to `default: 'allow'`, lint stays green, and only stderr deprecation warnings (which nothing watches) hinted at it. During that window the only live enforcement was the bash mirror, which covers static cross-feature imports only.

Three independent breakages, each fixed:

1. **`rules` → `policies` rename (v7)**: the entire rule block matched nothing. Migrated to v7 entity selectors (`from: { element: { type } }`). Last-match-wins evaluation is unchanged in v7, so the disallow-then-allow-exceptions structure carries over with identical semantics.
2. **`dependency-nodes` value rename (v6)**: the pinned `'dynamic-import'` value was silently ignored after the rename to `'dynamicImport'` — dynamic imports escaped analysis *even after re-arming the rules*. Dropped the pin entirely; the default analyzes import/export/require/dynamicImport.
3. **Layer-root element gap**: element patterns like `src/core/*` assign subfolders to elements but leave files at the layer root (`src/core/types.ts`, `src/core/constants.ts`) in **no element**, so their imports escaped every policy. Switched to whole-folder patterns (`src/core`), keeping per-feature capture for `src/features/*`.

Also:
- Synced the bash mirror allowlist with the two dynamic-import exceptions already sanctioned in eslint config (`bin-inspector → design-linking`, `bin-inspector → bin-recommender`) so converting one to a static import can't produce a bash-vs-eslint verdict split
- Corrected the stale "two exceptions" comment (there are three)

## What surfaces now

Full-repo lint after re-arming: **zero new errors**. The three pre-existing `core → features/bin-designer` dynamic imports (`ShareService.ts` ×2, `BulkArchiveService.ts` ×1) already carry targeted `eslint-disable-next-line boundaries/dependencies` comments from when the rule was live — those suppressions are functional again and grep-able. The proper fix (a core-owned storage port that bin-designer registers) is deliberately out of scope for this PR.

## Testing

- Synthetic-violation probes (created, linted, deleted): static import, `await import()`, `@/` alias, layer-root file, subfolder file — all now error for `core → feature` and `design-system → core`
- Plugin deprecation warnings gone from lint output
- `./scripts/check-module-boundaries.sh` passes (1867 files, 0 violations)
- Full `eslint .` run: 0 errors, warning set identical to main's baseline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-armed the `boundaries/dependencies` rule after `eslint-plugin-boundaries` v7 made it a silent no-op. Also clarified comments to name the default node set and state the barrel-only rule for the allowlist.

- **Bug Fixes**
  - Switched from `rules` to `policies` with v7 entity selectors to match elements.
  - Removed pinned `dependency-nodes`; default now checks import/export/require/dynamicImport.
  - Used whole-folder patterns (`src/core`, not `src/core/*`) so layer-root files are enforced.
  - Updated `scripts/check-module-boundaries.sh` allowlist to match ESLint exceptions and clarified it only allows barrel-form static imports (`bin-inspector` -> `design-linking`/`bin-recommender`).

<sup>Written for commit 675ffef2e9a020b2880685be783d9290f2dd83a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

