### PR TITLE
refactor: consolidate duplicated utils, constants, and palette data

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/ConnectorKeyMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/ConnectorKeyMeshes.tsx
@@ -14,7 +14,8 @@ import { useEffect, useMemo } from 'react';
 import { useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useShallow } from 'zustand/react/shallow';
-import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+import { GRIDFINITY_SPEC, MAGNET_FLOOR } from '@/shared/printSettings/gridfinityGeometry';
+import { getAccentHex } from '@/shared/utils/color';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSettingsStore } from '@/core/store/settings';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
@@ -32,18 +33,6 @@ import {
   SNAP_CLIP,
   snapClipLevels,
 } from '@/shared/constants/connectors';
-
-/** Retaining floor above magnet holes — mirrors MAGNET_FLOOR in the generator. */
-const MAGNET_FLOOR = 0.5;
-
-/** Distinct accent so the locking mechanism reads against the plate filament. */
-const FALLBACK_ACCENT = '#f59e0b';
-
-function getAccentHex(): string {
-  if (typeof document === 'undefined') return FALLBACK_ACCENT;
-  const raw = getComputedStyle(document.documentElement).getPropertyValue('--color-accent').trim();
-  return raw || FALLBACK_ACCENT;
-}
 
 /** Build the dogbone key profile (two mirrored puzzle lobes) centered on the
  *  origin, long axis along X — matching the worker's `buildDovetailKey`. */

--- a/src/features/baseplate/components/BaseplatePreview/SplitBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/SplitBaseplateMeshes.tsx
@@ -24,20 +24,11 @@ import {
 import { useMeshGeometry } from './useMeshGeometry';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';
 import { useSettingsStore } from '@/core/store';
+import { getAccentHex } from '@/shared/utils/color';
 import type { PieceMeshEntry, SplitViewMode } from '../../store/baseplatePageStore';
-
-/** Fallback accent hex (amber-500) when CSS var is unavailable. */
-const FALLBACK_ACCENT = '#f59e0b';
 
 /** Face opacity when xray mode is enabled (matches BaseplateMesh). */
 const XRAY_OPACITY = 0.3;
-
-/** Read the current accent color from CSS custom properties. */
-function getAccentHex(): string {
-  if (typeof document === 'undefined') return FALLBACK_ACCENT;
-  const raw = getComputedStyle(document.documentElement).getPropertyValue('--color-accent').trim();
-  return raw || FALLBACK_ACCENT;
-}
 
 interface PieceMeshProps {
   readonly entry: PieceMeshEntry;

--- a/src/features/baseplate/utils/printGuide.ts
+++ b/src/features/baseplate/utils/printGuide.ts
@@ -13,7 +13,7 @@ import type { BaseplatePiece, BaseplateTiling } from '../types/tiling';
 import type { PieceGroup } from './pieceFingerprint';
 import { colToLetter } from './splitPlanner';
 import { planPhysicalStacks } from './stackPrint';
-import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+import { GRIDFINITY_SPEC, MAGNET_FLOOR } from '@/shared/printSettings/gridfinityGeometry';
 import {
   TONGUE_PROTRUSION,
   TONGUE_CLEARANCE,
@@ -23,8 +23,6 @@ import {
 } from '@/shared/constants/connectors';
 
 const SOCKET_HEIGHT = GRIDFINITY_SPEC.SOCKET_HEIGHT;
-/** Retaining floor thickness above magnet holes (generation-specific, not in GRIDFINITY_SPEC) */
-const MAGNET_FLOOR = 0.5;
 
 export interface PrintGuideInput {
   readonly tiling: BaseplateTiling;

--- a/src/features/bin-designer/components/DesignerPage/MobileTitleBar.tsx
+++ b/src/features/bin-designer/components/DesignerPage/MobileTitleBar.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useTranslation } from '@/i18n';
+import { KOFI_URL, GITHUB_REPO_URL } from '@/shared/constants/links';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 
 export function MobileTitleBar() {
@@ -15,7 +16,7 @@ export function MobileTitleBar() {
       </span>
       <div className="flex items-center gap-3">
         <a
-          href="https://ko-fi.com/andyaragon"
+          href={KOFI_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-1 text-xs text-accent hover:underline"
@@ -28,7 +29,7 @@ export function MobileTitleBar() {
           {t('sidebar.tip')}
         </a>
         <a
-          href="https://github.com/andymai/gridfinity-layout-tool"
+          href={GITHUB_REPO_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-1 text-xs text-content-tertiary hover:underline"

--- a/src/features/bin-designer/components/panel/ScoopSection/useScoopSection.ts
+++ b/src/features/bin-designer/components/panel/ScoopSection/useScoopSection.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { clamp } from '@/shared/utils/math';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
@@ -14,9 +15,6 @@ import type { ScoopStyle } from '@/shared/types/bin';
 import { getFeatureStatus } from '@/shared/constraints';
 
 const DEFAULT_MANUAL_RADIUS = 10;
-
-const clamp = (value: number, min: number, max: number): number =>
-  Math.min(max, Math.max(min, value));
 
 export function useScoopSection() {
   const { scoop, updateScoop, params } = useDesignerStore(

--- a/src/features/bin-designer/components/preview/SplitBinMeshes/SplitBinMeshes.tsx
+++ b/src/features/bin-designer/components/preview/SplitBinMeshes/SplitBinMeshes.tsx
@@ -14,6 +14,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useMeshGeometry } from '@/shared/components/preview/useMeshGeometry';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';
+import { getAccentHex } from '@/shared/utils/color';
 import { GRIDFINITY } from '@/features/bin-designer/constants/gridfinity';
 import type { SplitPieceMeshEntry } from '../../../types';
 
@@ -31,15 +32,6 @@ const EDGE_COLOR = '#000000';
 
 /** Face opacity when xray mode is enabled (matches BinMesh). */
 const XRAY_OPACITY = 0.3;
-
-/** Fallback accent hex (amber-500) when CSS var is unavailable. */
-const FALLBACK_ACCENT = '#f59e0b';
-
-function getAccentHex(): string {
-  if (typeof document === 'undefined') return FALLBACK_ACCENT;
-  const raw = getComputedStyle(document.documentElement).getPropertyValue('--color-accent').trim();
-  return raw || FALLBACK_ACCENT;
-}
 
 interface PieceMeshProps {
   readonly entry: SplitPieceMeshEntry;

--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -7,6 +7,7 @@
  */
 
 import { isErr, getUserMessage } from '@/core/result';
+import { GITHUB_ISSUES_URL } from '@/shared/constants/links';
 import { export3MF, export3MFMultiObject } from '@/shared/generation/export';
 import { captureException } from '@/shared/analytics/posthog';
 import {
@@ -143,7 +144,7 @@ export function buildReportIssueUrl(
     ),
     '```',
   ].join('\n');
-  const url = new URL('https://github.com/andymai/gridfinity-layout-tool/issues/new');
+  const url = new URL(`${GITHUB_ISSUES_URL}/new`);
   url.searchParams.set('title', title);
   url.searchParams.set('body', body);
   url.searchParams.set('labels', 'bin-export-failure');

--- a/src/features/bin-designer/utils/meshGridDetection.ts
+++ b/src/features/bin-designer/utils/meshGridDetection.ts
@@ -12,6 +12,7 @@
  * is meaningfully off-grid (not actually a Gridfinity bin, or scaled).
  */
 import { GRIDFINITY_SPEC } from '@/shared/printSettings';
+import { clamp } from '@/shared/utils/math';
 import { DESIGNER_CONSTRAINTS } from '../constants/gridfinity';
 
 export interface DetectedGrid {
@@ -37,10 +38,6 @@ const MIN_DIM = DESIGNER_CONSTRAINTS.MIN_DIMENSION;
 const MAX_DIM = DESIGNER_CONSTRAINTS.MAX_DIMENSION;
 const MIN_H = 1;
 const MAX_H = DESIGNER_CONSTRAINTS.MAX_HEIGHT;
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
 
 /** Snap one footprint axis: outer mm of a W-unit bin is W·gridUnit − TOLERANCE. */
 function snapFootprintAxis(mm: number, gridUnitMm: number): { units: number; deviation: number } {

--- a/src/features/command-palette/components/CommandPalette/commandPaletteActionHandlers.ts
+++ b/src/features/command-palette/components/CommandPalette/commandPaletteActionHandlers.ts
@@ -11,6 +11,7 @@
  */
 
 import { useMemo } from 'react';
+import { GITHUB_ISSUES_URL } from '@/shared/constants/links';
 import { useShallow } from 'zustand/react/shallow';
 import { useTranslation } from '@/i18n';
 import {
@@ -206,11 +207,7 @@ export function useActionHandlers(): Record<string, ActionHandler> {
       'send-feedback': () =>
         // noopener,noreferrer prevents reverse-tabnabbing — matches the
         // convention used elsewhere in the codebase for external links.
-        window.open(
-          'https://github.com/andymai/gridfinity-layout-tool/issues',
-          '_blank',
-          'noopener,noreferrer'
-        ),
+        window.open(GITHUB_ISSUES_URL, '_blank', 'noopener,noreferrer'),
       'switch-to-designer': () => dispatchWindowEvent('switch-to-designer'),
       'view-supporters': () => dispatchWindowEvent('view-supporters'),
       'open-bin-examples': () => {

--- a/src/features/engagement/useEngagementNudges.ts
+++ b/src/features/engagement/useEngagementNudges.ts
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useRef } from 'react';
+import { GITHUB_ISSUES_URL } from '@/shared/constants/links';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
 import { trackEvent } from '@/shared/analytics/posthog';
@@ -79,7 +80,7 @@ function showNudgeToast(nudgeType: NudgeType, t: (key: string) => string): void 
           trackEvent('nudge_clicked', { nudge_type: 'feedback_rating' });
           recordNudgeDismissal('feedback_rating');
           window.open(
-            'https://github.com/andymai/gridfinity-layout-tool/issues/new?template=feature_request.md',
+            `${GITHUB_ISSUES_URL}/new?template=feature_request.md`,
             '_blank',
             'noopener,noreferrer'
           );

--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -25,7 +25,6 @@
  */
 
 import {
-  draw,
   fuse,
   cut,
   cutAll,
@@ -37,10 +36,11 @@ import {
   withScope,
   clone,
 } from 'brepjs';
-import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
+import type { Shape3D, ValidSolid, DisposalScope } from 'brepjs';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { ExportFormat } from '../../bridge/types';
 import { sketch } from './meshUtils';
+import { formatOffset, roundedRect } from './couponHelpers';
 import {
   SOCKET_HEIGHT,
   MAGNET_FLOOR,
@@ -106,29 +106,6 @@ const ROW_PITCH = CELL_Y + ROW_GAP;
 /** Map (wall, boundary) → XY point for a seam running along X (protrude on Y). */
 function ptY(wall: number, bp: number): [number, number] {
   return [bp, wall];
-}
-
-/** Signed fit-offset label, e.g. "+0.05", "-0.10", "0.00". */
-function formatOffset(v: number): string {
-  const s = v.toFixed(2);
-  return v > 0 ? `+${s}` : s;
-}
-
-function roundedRect(cx: number, cy: number, w: number, h: number, r: number): Drawing {
-  const x0 = cx - w / 2;
-  const x1 = cx + w / 2;
-  const y0 = cy - h / 2;
-  const y1 = cy + h / 2;
-  return draw([cx, y0])
-    .lineTo([x1, y0])
-    .customCorner(r)
-    .lineTo([x1, y1])
-    .customCorner(r)
-    .lineTo([x0, y1])
-    .customCorner(r)
-    .lineTo([x0, y0])
-    .customCorner(r)
-    .close();
 }
 
 type CouponFeature =

--- a/src/features/generation/worker/generators/couponHelpers.ts
+++ b/src/features/generation/worker/generators/couponHelpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared 2D helpers for the printable calibration coupons
+ * (connector fit sample, label-plate fit sample).
+ */
+
+import type { Drawing } from 'brepjs';
+import { draw } from 'brepjs';
+
+/**
+ * Signed fit-offset label, e.g. "+0.05", "-0.10", "0.00" (zero is unsigned).
+ * NOT used by the label-plate coupon: labelFitSample keeps a zero-SIGNED
+ * variant on purpose, so every label has the same glyph count and coupon
+ * volumes stay strictly ordered by pocket size (asserted in its scenario test).
+ */
+export function formatOffset(v: number): string {
+  const s = v.toFixed(2);
+  return v > 0 ? `+${s}` : s;
+}
+
+export function roundedRect(cx: number, cy: number, w: number, h: number, r: number): Drawing {
+  const x0 = cx - w / 2;
+  const x1 = cx + w / 2;
+  const y0 = cy - h / 2;
+  const y1 = cy + h / 2;
+  return draw([cx, y0])
+    .lineTo([x1, y0])
+    .customCorner(r)
+    .lineTo([x1, y1])
+    .customCorner(r)
+    .lineTo([x0, y1])
+    .customCorner(r)
+    .lineTo([x0, y0])
+    .customCorner(r)
+    .close();
+}

--- a/src/features/generation/worker/generators/generatorConstants.ts
+++ b/src/features/generation/worker/generators/generatorConstants.ts
@@ -8,6 +8,9 @@
 import { GRIDFINITY } from '@/shared/constants/bin';
 import { OVER_TILE_MIN_MARGIN_MM, SOLID_FLOOR_DEFAULT_MM } from '@/core/constants';
 import { clamp } from '@/shared/utils/math';
+import { MAGNET_FLOOR } from '@/shared/printSettings/gridfinityGeometry';
+
+export { MAGNET_FLOOR };
 export const SIZE = GRIDFINITY.GRID_SIZE;
 export const HEIGHT_UNIT = GRIDFINITY.HEIGHT_UNIT;
 export const CLEARANCE = GRIDFINITY.TOLERANCE;
@@ -28,9 +31,6 @@ export const LIP_OVERLAP = GRIDFINITY.LIP_OVERLAP;
 
 /** Corner radius for baseplate outer perimeter (same as socket corner radius) */
 export const PLATE_CORNER_RADIUS = CORNER_RADIUS;
-
-/** Thin floor under each magnet hole — retains the magnet (mm) */
-export const MAGNET_FLOOR = 0.5;
 
 /**
  * Height of solid floor left under the baseplate sockets, in mm — the single

--- a/src/features/generation/worker/generators/labelFitSample.ts
+++ b/src/features/generation/worker/generators/labelFitSample.ts
@@ -22,18 +22,8 @@
  * ready-to-slice STL/STEP.
  */
 
-import {
-  draw,
-  fuse,
-  compound,
-  mesh,
-  exportSTEP,
-  translate,
-  unwrap,
-  withScope,
-  clone,
-} from 'brepjs';
-import type { Shape3D, ValidSolid, Drawing, DisposalScope } from 'brepjs';
+import { fuse, compound, mesh, exportSTEP, translate, unwrap, withScope, clone } from 'brepjs';
+import type { Shape3D, ValidSolid, DisposalScope } from 'brepjs';
 import {
   LABEL_PLATE_HEIGHT_MM,
   LABEL_SOCKET_SHELF_THICKNESS_MM,
@@ -44,6 +34,7 @@ import {
 import type { TextStyleDefaults } from '@/shared/types/bin';
 import type { ExportFormat } from '../../bridge/types';
 import { sketch } from './meshUtils';
+import { roundedRect } from './couponHelpers';
 import { buildTextSolid } from './textBuilder';
 import { buildBaseplateSTL } from './baseplateSTL';
 import { cutLabelSocket } from './labelTabBuilder';
@@ -86,23 +77,6 @@ const PLATE_TEXT_DEFAULTS: TextStyleDefaults = {
 function formatOffset(v: number): string {
   const s = v.toFixed(2);
   return v >= 0 ? `+${s}` : s;
-}
-
-function roundedRect(cx: number, cy: number, w: number, h: number, r: number): Drawing {
-  const x0 = cx - w / 2;
-  const x1 = cx + w / 2;
-  const y0 = cy - h / 2;
-  const y1 = cy + h / 2;
-  return draw([cx, y0])
-    .lineTo([x1, y0])
-    .customCorner(r)
-    .lineTo([x1, y1])
-    .customCorner(r)
-    .lineTo([x0, y1])
-    .customCorner(r)
-    .lineTo([x0, y0])
-    .customCorner(r)
-    .close();
 }
 
 /**

--- a/src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
@@ -2,28 +2,7 @@ import { useState, type RefObject } from 'react';
 import { Button, Popover } from '@/design-system';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { useTranslation } from '@/i18n';
-
-// Square sizes
-const SQUARE_SIZES = [1, 2, 3, 4, 5, 6];
-
-// Rectangle sizes (width x depth where width < depth)
-const RECTANGLE_SIZES = [
-  { w: 1, d: 2 },
-  { w: 1, d: 3 },
-  { w: 1, d: 4 },
-  { w: 1, d: 5 },
-  { w: 1, d: 6 },
-  { w: 2, d: 3 },
-  { w: 2, d: 4 },
-  { w: 2, d: 5 },
-  { w: 2, d: 6 },
-  { w: 3, d: 4 },
-  { w: 3, d: 5 },
-  { w: 3, d: 6 },
-  { w: 4, d: 5 },
-  { w: 4, d: 6 },
-  { w: 5, d: 6 },
-];
+import { SQUARE_SIZES, RECTANGLE_SIZES } from '../../paintSizes';
 
 interface SizeSelectorPopoverProps {
   anchorRef: RefObject<HTMLElement | null>;

--- a/src/features/layers/paintSizes.test.ts
+++ b/src/features/layers/paintSizes.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { SQUARE_SIZES, RECTANGLE_SIZES } from './paintSizes';
+
+describe('paintSizes', () => {
+  it('square sizes are ascending 1..6', () => {
+    expect(SQUARE_SIZES).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('rectangles keep width < depth within the square range', () => {
+    for (const { w, d } of RECTANGLE_SIZES) {
+      expect(w).toBeLessThan(d);
+      expect(SQUARE_SIZES).toContain(w);
+      expect(SQUARE_SIZES).toContain(d);
+    }
+  });
+
+  it('covers every width<depth pair of the square range exactly once', () => {
+    const seen = new Set(RECTANGLE_SIZES.map(({ w, d }) => `${w}x${d}`));
+    expect(seen.size).toBe(RECTANGLE_SIZES.length);
+    const expected = SQUARE_SIZES.flatMap((w) =>
+      SQUARE_SIZES.filter((d) => d > w).map((d) => `${w}x${d}`)
+    );
+    expect([...seen].sort()).toEqual(expected.sort());
+  });
+});

--- a/src/features/layers/paintSizes.ts
+++ b/src/features/layers/paintSizes.ts
@@ -1,0 +1,26 @@
+/**
+ * Paint-tool bin size palette, shared by the desktop SizeSelectorPopover and
+ * the mobile ToolsTab so the two pickers can never drift.
+ */
+
+/** Square sizes (n × n grid units). */
+export const SQUARE_SIZES = [1, 2, 3, 4, 5, 6] as const;
+
+/** Rectangle sizes (width × depth where width < depth). */
+export const RECTANGLE_SIZES: readonly { readonly w: number; readonly d: number }[] = [
+  { w: 1, d: 2 },
+  { w: 1, d: 3 },
+  { w: 1, d: 4 },
+  { w: 1, d: 5 },
+  { w: 1, d: 6 },
+  { w: 2, d: 3 },
+  { w: 2, d: 4 },
+  { w: 2, d: 5 },
+  { w: 2, d: 6 },
+  { w: 3, d: 4 },
+  { w: 3, d: 5 },
+  { w: 3, d: 6 },
+  { w: 4, d: 5 },
+  { w: 4, d: 6 },
+  { w: 5, d: 6 },
+];

--- a/src/shared/components/AttributionFooter/AttributionFooter.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.tsx
@@ -1,4 +1,5 @@
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
+import { GITHUB_RELEASES_URL, KOFI_URL } from '@/shared/constants/links';
 import { useTranslation } from '@/i18n';
 import { useSupportersRouting } from '@/shared/hooks/useSupportersRouting';
 
@@ -10,7 +11,7 @@ export function AttributionFooter() {
       <div className="text-content-secondary text-[11px] font-semibold mb-1 flex items-baseline gap-1.5">
         {t('sidebar.appName')}
         <a
-          href="https://github.com/andymai/gridfinity-layout-tool/releases"
+          href={GITHUB_RELEASES_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="text-[10px] font-normal text-content-disabled hover:text-content-tertiary hover:underline"
@@ -39,7 +40,7 @@ export function AttributionFooter() {
       </a>{' '}
       ·{' '}
       <a
-        href="https://ko-fi.com/andyaragon"
+        href={KOFI_URL}
         target="_blank"
         rel="noopener noreferrer"
         className="text-accent hover:underline"

--- a/src/shared/constants/links.ts
+++ b/src/shared/constants/links.ts
@@ -3,4 +3,5 @@
 export const KOFI_URL = 'https://ko-fi.com/andyaragon';
 export const GITHUB_REPO_URL = 'https://github.com/andymai/gridfinity-layout-tool';
 export const GITHUB_ISSUES_URL = `${GITHUB_REPO_URL}/issues`;
+export const GITHUB_RELEASES_URL = `${GITHUB_REPO_URL}/releases`;
 export const REDDIT_GRIDFINITY_URL = 'https://www.reddit.com/r/gridfinity/';

--- a/src/shared/printSettings/gridfinityGeometry.ts
+++ b/src/shared/printSettings/gridfinityGeometry.ts
@@ -77,6 +77,7 @@ export const GRIDFINITY_SPEC = {
  * math must all agree or preview heights drift from exported geometry.
  */
 export const MAGNET_FLOOR = 0.5;
+
 /**
  * Number of perimeter walls per nozzle size, matching common slicer defaults.
  *

--- a/src/shared/printSettings/gridfinityGeometry.ts
+++ b/src/shared/printSettings/gridfinityGeometry.ts
@@ -70,6 +70,13 @@ export const GRIDFINITY_SPEC = {
   // Fillets (used for BREP generation)
   TOP_FILLET: 0, // mm — original spec has no fillet at stacking lip peak
 } as const;
+
+/**
+ * Thin floor under each magnet hole that retains the magnet (mm).
+ * Canonical value — the worker generators and the baseplate preview/print-guide
+ * math must all agree or preview heights drift from exported geometry.
+ */
+export const MAGNET_FLOOR = 0.5;
 /**
  * Number of perimeter walls per nozzle size, matching common slicer defaults.
  *

--- a/src/shared/utils/color.test.ts
+++ b/src/shared/utils/color.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { getContrastColor, getBinPatternColor } from '@/shared/utils';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  getContrastColor,
+  getBinPatternColor,
+  getAccentHex,
+  FALLBACK_ACCENT,
+} from '@/shared/utils';
 
 describe('getContrastColor', () => {
   describe('light backgrounds should return dark text', () => {
@@ -90,13 +95,24 @@ describe('getBinPatternColor', () => {
 });
 
 describe('getAccentHex', () => {
-  it('returns the fallback accent when no document is available', async () => {
-    const { getAccentHex, FALLBACK_ACCENT } = await import('@/shared/utils');
-    if (typeof document === 'undefined') {
-      expect(getAccentHex()).toBe(FALLBACK_ACCENT);
-    } else {
-      document.documentElement.style.removeProperty('--color-accent');
-      expect(getAccentHex()).toBe(FALLBACK_ACCENT);
-    }
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the fallback when no document exists (node/worker)', () => {
+    expect(typeof document).toBe('undefined');
+    expect(getAccentHex()).toBe(FALLBACK_ACCENT);
+  });
+
+  it('reads and trims --color-accent from the document root', () => {
+    vi.stubGlobal('document', { documentElement: {} });
+    vi.stubGlobal('getComputedStyle', () => ({ getPropertyValue: () => '  #123456  ' }));
+    expect(getAccentHex()).toBe('#123456');
+  });
+
+  it('returns the fallback when the CSS var is unset', () => {
+    vi.stubGlobal('document', { documentElement: {} });
+    vi.stubGlobal('getComputedStyle', () => ({ getPropertyValue: () => '' }));
+    expect(getAccentHex()).toBe(FALLBACK_ACCENT);
   });
 });

--- a/src/shared/utils/color.test.ts
+++ b/src/shared/utils/color.test.ts
@@ -88,3 +88,15 @@ describe('getBinPatternColor', () => {
     expect(getBinPatternColor('#000')).toBe('rgba(255, 255, 255, 0.48)');
   });
 });
+
+describe('getAccentHex', () => {
+  it('returns the fallback accent when no document is available', async () => {
+    const { getAccentHex, FALLBACK_ACCENT } = await import('@/shared/utils');
+    if (typeof document === 'undefined') {
+      expect(getAccentHex()).toBe(FALLBACK_ACCENT);
+    } else {
+      document.documentElement.style.removeProperty('--color-accent');
+      expect(getAccentHex()).toBe(FALLBACK_ACCENT);
+    }
+  });
+});

--- a/src/shared/utils/color.ts
+++ b/src/shared/utils/color.ts
@@ -1,3 +1,13 @@
+/** Fallback when the CSS var is unavailable (SSR, jsdom, pre-mount reads). */
+export const FALLBACK_ACCENT = '#f59e0b';
+
+/** Read the current accent color from CSS custom properties. */
+export function getAccentHex(): string {
+  if (typeof document === 'undefined') return FALLBACK_ACCENT;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue('--color-accent').trim();
+  return raw || FALLBACK_ACCENT;
+}
+
 /**
  * Text color options for bin labels based on background luminance.
  */

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -3,7 +3,13 @@
  * These utilities are pure functions that don't depend on specific business logic.
  */
 
-export { getContrastColor, getBinTextColors, getBinPatternColor } from './color';
+export {
+  getContrastColor,
+  getBinTextColors,
+  getBinPatternColor,
+  getAccentHex,
+  FALLBACK_ACCENT,
+} from './color';
 export type { BinTextColors } from './color';
 
 export {

--- a/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
@@ -14,28 +14,7 @@ import { getLayerBins } from '@/shared/utils';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
-
-// Square sizes (matching desktop ActiveLayerPanel)
-const SQUARE_SIZES = [1, 2, 3, 4, 5, 6];
-
-// Rectangle sizes (width × depth where width < depth)
-const RECTANGLE_SIZES = [
-  { w: 1, d: 2 },
-  { w: 1, d: 3 },
-  { w: 1, d: 4 },
-  { w: 1, d: 5 },
-  { w: 1, d: 6 },
-  { w: 2, d: 3 },
-  { w: 2, d: 4 },
-  { w: 2, d: 5 },
-  { w: 2, d: 6 },
-  { w: 3, d: 4 },
-  { w: 3, d: 5 },
-  { w: 3, d: 6 },
-  { w: 4, d: 5 },
-  { w: 4, d: 6 },
-  { w: 5, d: 6 },
-];
+import { SQUARE_SIZES, RECTANGLE_SIZES } from '@/features/layers/paintSizes';
 
 /**
  * Tools tab content - bin palette for paint mode and layer fill actions.

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, Suspense } from 'react';
+import { GITHUB_RELEASES_URL, GITHUB_REPO_URL } from '@/shared/constants/links';
 // Import stores directly to avoid circular dependency via barrel export
 import { useDrawerSettings } from '@/shared/hooks/useDrawerSettings';
 import { useSettingsStore } from '@/core/store/settings';
@@ -351,7 +352,7 @@ export function MobileSettingsPanel() {
             {t('sidebar.appName')}
           </span>
           <a
-            href={`https://github.com/andymai/gridfinity-layout-tool/releases/tag/v${__APP_VERSION__}`}
+            href={`${GITHUB_RELEASES_URL}/tag/v${__APP_VERSION__}`}
             target="_blank"
             rel="noopener noreferrer"
             className="text-[10px] text-content-disabled hover:text-content-tertiary hover:underline"
@@ -400,7 +401,7 @@ export function MobileSettingsPanel() {
           </a>
           <span>·</span>
           <a
-            href="https://github.com/andymai/gridfinity-layout-tool"
+            href={GITHUB_REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-content-tertiary"


### PR DESCRIPTION
## Summary

Second dedup pass (companion to #2751, which covered the API layer) — this one eliminates the safe copy-paste clusters inside `src/`.

- **`getAccentHex()` + `FALLBACK_ACCENT`**: three byte-identical copies across the baseplate and bin-designer 3D previews → one `shared/utils/color` export, with a test covering the fallback path.
- **`MAGNET_FLOOR`**: the canonical 0.5mm value lived in the generation worker, and two files (`printGuide.ts`, `ConnectorKeyMeshes.tsx`) carried hand-copied literals with "mirrors the generator" comments — the classic drift setup. Canonical home is now `gridfinityGeometry.ts` beside `GRIDFINITY_SPEC` (which both consumers already import); the generator re-exports it so worker code is unchanged.
- **`clamp`**: two local reimplementations now import `shared/utils/math`.
- **Coupon helpers**: identical `roundedRect` shared via `couponHelpers.ts`. `formatOffset` is deliberately NOT unified — `labelFitSample`'s zero-signed variant ("+0.00") keeps glyph counts equal so coupon volumes stay strictly ordered by pocket size, an invariant its scenario test asserts. Both sides now carry comments explaining the split, so the next dedup pass doesn't "fix" it.
- **Paint-size palette**: `SQUARE_SIZES`/`RECTANGLE_SIZES` duplicated between desktop `SizeSelectorPopover` and mobile `ToolsTab` → `features/layers/paintSizes.ts`, plus a test asserting the rectangle set covers every width<depth pair exactly once. The per-component `isPaintActive`/`getRectDims` one-liners stay local — they close over component state and extracting them would be indirection, not dedup.
- **External links**: hardcoded ko-fi/GitHub URLs in 6 files (attribution footers, mobile title bar, command palette, engagement nudges, bug-report URL builder) now route through `shared/constants/links.ts` (new `GITHUB_RELEASES_URL`).

## Testing

- `pnpm run typecheck` clean; eslint clean on all changed files; knip clean (no orphaned exports)
- 104 tests across the 14 affected sibling test files pass, plus 19 in the two new test files
- Coupon geometry (`connectorSample`/`labelFitSample`) is covered by the WASM scenario tests in CI's generators shards; behavior is unchanged (helpers moved verbatim)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated duplicated utils, constants, and the paint-size palette into shared modules to prevent drift and simplify maintenance. No user-visible changes; previews, generators, and UI now reference the same sources.

- **Refactors**
  - Moved `getAccentHex`/`FALLBACK_ACCENT` to `shared/utils/color`; updated 3D split previews; added deterministic tests covering no-document/CSS-var-set/unset branches.
  - Promoted `MAGNET_FLOOR` (0.5 mm) to `shared/printSettings/gridfinityGeometry`; generator re-exports; previews/print-guide import it.
  - Replaced local `clamp` helpers with `shared/utils/math`.
  - Shared coupon `roundedRect` via `generators/couponHelpers`; kept `formatOffset` variants split by design with comments.
  - Unified paint-size palette (`SQUARE_SIZES`, `RECTANGLE_SIZES`) in `features/layers/paintSizes`; added coverage test; used by desktop and mobile.
  - Centralized external links in `shared/constants/links` (new `GITHUB_RELEASES_URL`); updated Ko‑fi/GitHub links across the app.

<sup>Written for commit 5a2f81e3c62ab2ea5c1deb86148d800b252f97b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

