### PR TITLE
test(sync): fix engine.test.ts in-flight serialization flake

### DIFF
--- a/src/core/sync/engine.test.ts
+++ b/src/core/sync/engine.test.ts
@@ -67,7 +67,11 @@ beforeEach(async () => {
   } catch {
     /* first test of the file — DB not yet open */
   }
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks): it also empties mockImplementationOnce
+  // queues, so a test that primes a hanging fetch and fails before consuming it
+  // can't leak that implementation into the next test as a 30s timeout. The
+  // adapter mocks are recreated below, and fetchMock is re-primed after.
+  vi.resetAllMocks();
   useSyncStatusStore.getState().reset();
   layoutsAdapter = makeMockAdapter();
   designsAdapter = makeMockAdapter();
@@ -362,7 +366,14 @@ describe('push: in-flight serialization', () => {
     // Trigger another change for the same id while the first push is in flight.
     layoutsAdapter.triggerChange({ kind: 'put', id: 'lay-1', modifiedAt: 2000 });
 
-    await new Promise((r) => setTimeout(r, 10));
+    // Wait until the first push has actually started (a fixed sleep raced the
+    // drain timer on loaded CI workers), then give the engine time to wrongly
+    // start a second one — it can't, because the first never resolves until we
+    // release it below.
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    await new Promise((r) => setTimeout(r, 25));
     // Only the first push should be in flight; second is queued.
     expect(fetchMock).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Summary

Fixes the CI flake that failed PR #2749's `Unit Tests (core 1/3)` shard (a docs-only PR — clean signal it was the test, not the code). Two compounding problems:

1. **Raced timing assertion**: the in-flight serialization test slept a fixed 10ms and then asserted exactly one fetch had started. On a loaded CI worker the engine's drain timer hadn't fired yet, so the count was 0. Now `vi.waitFor` waits for the first push to actually start, then a settle window verifies no second push begins while the first is held open — which is the actual invariant under test (the first fetch can't resolve until the test releases it).

2. **Leaked hanging mock**: `vi.clearAllMocks()` clears call history but **not** `mockImplementationOnce` queues. When the raced assertion failed before the held-open fetch was consumed, the never-resolving implementation leaked into the *next* test ("drops the outbox entry…"), which then timed out at 30s — the second failure in the same CI run. `beforeEach` now uses `vi.resetAllMocks()`; the adapter mocks are recreated after it and `fetchMock` is re-primed with its default, so nothing else changes.

## Testing

- `engine.test.ts`: 19/19 passing across 3 consecutive local runs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky test in the sync engine by removing a raced timing assertion and preventing mock leakage between tests, stabilizing CI. Test-only changes.

- **Bug Fixes**
  - Replaced fixed sleep with waiting for the first push to start, then a short settle window; verifies only one in-flight push in "push: in-flight serialization".
  - Switched `beforeEach` from `vi.clearAllMocks()` to `vi.resetAllMocks()` to clear `mockImplementationOnce` queues; adapter mocks are recreated and `fetchMock` is re-primed.

<sup>Written for commit 6b4b385f8878a78e86353084c468f5adc409e902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

