### PR TITLE
test: share the i18n echo mock via src/test/mocks/i18nEcho

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseSection.test.tsx
@@ -5,14 +5,7 @@ import { useLayoutStore } from '@/core/store/layout';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string, params?: Record<string, unknown>) => {
-    if (params) {
-      return Object.entries(params).reduce((str, [k, v]) => str.replace(`{${k}}`, String(v)), key);
-    }
-    return key;
-  },
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('BaseSection', () => {
   beforeEach(() => {

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -6,15 +6,7 @@ import type { BaseplateTiling } from '../../types/tiling';
 import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
 import type { CornerCutParams } from '@/core/types';
 
-// Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string, params?: Record<string, unknown>) => {
-    if (params) {
-      return Object.entries(params).reduce((str, [k, v]) => str.replace(`{${k}}`, String(v)), key);
-    }
-    return key;
-  },
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Mock layout store
 const mockSetBaseplateParams = vi.fn();

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
@@ -4,14 +4,7 @@ import { DimensionsSection } from './DimensionsSection';
 import { useLayoutStore } from '@/core/store/layout';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string, params?: Record<string, unknown>) => {
-    if (params) {
-      return Object.entries(params).reduce((str, [k, v]) => str.replace(`{${k}}`, String(v)), key);
-    }
-    return key;
-  },
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('DimensionsSection', () => {
   beforeEach(() => {

--- a/src/features/baseplate/components/BaseplatePanel/PhysicalUnitsSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PhysicalUnitsSection.test.tsx
@@ -4,14 +4,7 @@ import { PhysicalUnitsSection } from './PhysicalUnitsSection';
 import { useSettingsStore } from '@/core/store/settings';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string, params?: Record<string, unknown>) => {
-    if (params) {
-      return Object.entries(params).reduce((str, [k, v]) => str.replace(`{${k}}`, String(v)), key);
-    }
-    return key;
-  },
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('PhysicalUnitsSection', () => {
   beforeEach(() => {

--- a/src/test/mocks/i18nEcho.ts
+++ b/src/test/mocks/i18nEcho.ts
@@ -1,0 +1,16 @@
+/**
+ * Standard echo mock for `@/i18n` in component tests: `t(key)` returns the
+ * key itself, with `{param}` interpolation applied, so assertions target
+ * stable keys instead of English copy. Use as:
+ *
+ *   vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+ */
+
+export function useTranslation() {
+  return (key: string, params?: Record<string, unknown>): string => {
+    if (params) {
+      return Object.entries(params).reduce((str, [k, v]) => str.replace(`{${k}}`, String(v)), key);
+    }
+    return key;
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to greptile's post-merge P2 on #2757: the identical `vi.mock('@/i18n', …)` echo factory was copy-pasted verbatim into the three new BaseplatePanel section tests — and into `BaseplatePanel.test.tsx` before them. The factory now lives once in `src/test/mocks/i18nEcho.ts` (per the `src/test/` shared-infrastructure convention), and the four byte-identical copies become:

```ts
vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
```

Scope note: ~28 more test files carry *variant* i18n mocks (extra mocked members, slightly different shapes). Those need per-file review to converge on the shared module and are deliberately left for the planned test-fixture-consolidation pass rather than bulk-replaced here.

## Testing

- All 148 BaseplatePanel tests pass with the shared mock
- `pnpm run typecheck` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated the i18n echo mock into `src/test/mocks/i18nEcho.ts` and updated the four BaseplatePanel tests to import it via `vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'))`. This removes duplicated mock code and standardizes translation behavior in these tests.

<sup>Written for commit c16dc6c58cd19396df4253d7f4de5019c7e66b1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

