### PR TITLE
refactor(layers): share fill/clear actions between desktop and mobile

### DIFF
--- a/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
@@ -1,101 +1,51 @@
 import { useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { useLayoutStore } from '@/core/store';
 import { useMutations } from '@/shared/contexts';
 import { useSelectionStore } from '@/core/store/selection';
 import { useInteractionStore } from '@/core/store/interaction';
-import { useHalfGridModeStore } from '@/core/store/halfGridMode';
 import { useToastStore } from '@/core/store/toast';
 import { STAGING_ID } from '@/core/constants';
 import { gridUnits } from '@/core/types';
-import { getLayerBins } from '@/shared/utils';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { SizeSelectorPopover } from './SizeSelectorPopover';
+import { useLayerFillActions } from '../../hooks/useLayerFillActions';
 import { batch } from '@/core/cqrs';
 
 export function ActiveLayerPanel() {
   const t = useTranslation();
-  const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const sizeButtonRef = useRef<HTMLButtonElement>(null);
 
-  const layout = useLayoutStore((state) => state.layout);
-  const { fillLayer, fillLayerGaps, clearLayer, addBin } = useMutations();
+  const { addBin } = useMutations();
+  const activeCategoryId = useSelectionStore((state) => state.activeCategoryId);
 
-  const { activeLayerId, activeCategoryId, setSelectedBins } = useSelectionStore(
-    useShallow((state) => ({
-      activeLayerId: state.activeLayerId,
-      activeCategoryId: state.activeCategoryId,
-      setSelectedBins: state.setSelectedBins,
-    }))
-  );
-
-  const { paintSize, togglePaintSize, setPaintSize } = useInteractionStore(
+  const { paintSize, togglePaintSize } = useInteractionStore(
     useShallow((state) => ({
       paintSize: state.paintSize,
       togglePaintSize: state.togglePaintSize,
-      setPaintSize: state.setPaintSize,
     }))
   );
 
-  const halfGridMode = useHalfGridModeStore((state) => state.halfGridMode);
-
   const addToast = useToastStore((state) => state.addToast);
 
-  const activeLayer = layout.layers.find((l) => l.id === activeLayerId);
-  const layerBins = getLayerBins(layout.bins, activeLayerId);
+  const {
+    activeLayer,
+    layerBins,
+    emptyCells,
+    clearConfirmOpen,
+    setClearConfirmOpen,
+    fillGaps,
+    confirmClear,
+    fillWithSize,
+  } = useLayerFillActions();
   const hasBins = layerBins.length > 0;
 
-  // Calculate empty cells for Fill gaps button
-  const totalCells = layout.drawer.width * layout.drawer.depth;
-  const coveredCells = layerBins.reduce((sum, b) => sum + b.width * b.depth, 0);
-  const emptyCells = totalCells - coveredCells;
-
-  const handleFillGaps = () => {
-    if (!activeLayerId) return;
-    const beforeCount = layerBins.length;
-    batch(() => {
-      fillLayerGaps(activeLayerId, activeCategoryId, halfGridMode);
-    });
-    setTimeout(() => {
-      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
-      const added = afterCount - beforeCount;
-      if (added > 0) {
-        addToast(t('toast.fillComplete', { count: added }), 'success');
-      }
-    }, 0);
-  };
-
-  const handleClearLayer = () => {
-    if (!activeLayerId || layerBins.length === 0) return;
-    const count = layerBins.length;
-    batch(() => {
-      clearLayer(activeLayerId);
-      setSelectedBins([]);
-    });
-    addToast(t('toast.clearComplete', { count }), 'success');
-    setShowClearConfirm(false);
-  };
-
   const handleFill = () => {
-    if (!activeLayerId || !paintSize) return;
-    const { width, depth } = paintSize;
-    const beforeCount = layerBins.length;
-    batch(() => {
-      fillLayer(activeLayerId, width, depth, activeCategoryId, halfGridMode);
-    });
-    // Exit paint mode after filling
-    setPaintSize(null);
-    setTimeout(() => {
-      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
-      const added = afterCount - beforeCount;
-      if (added > 0) {
-        addToast(t('toast.fillWithSize', { count: added, width, depth }), 'success');
-      }
-    }, 0);
+    if (!paintSize) return;
+    fillWithSize(paintSize.width, paintSize.depth);
   };
 
   if (!activeLayer) return null;
@@ -208,7 +158,7 @@ export function ActiveLayerPanel() {
           <Button
             variant="secondary"
             fullWidth
-            onClick={handleFillGaps}
+            onClick={fillGaps}
             disabled={emptyCells === 0}
             className="text-sm h-8 gap-1.5"
             title={
@@ -233,7 +183,7 @@ export function ActiveLayerPanel() {
         <Button
           variant="ghost"
           fullWidth
-          onClick={() => setShowClearConfirm(true)}
+          onClick={() => setClearConfirmOpen(true)}
           disabled={!hasBins}
           className={`text-sm h-8 gap-1.5 ${
             hasBins ? 'text-error hover:bg-error/10 hover:text-error' : ''
@@ -270,13 +220,13 @@ export function ActiveLayerPanel() {
 
       {/* Clear confirmation dialog */}
       <ConfirmDialog
-        isOpen={showClearConfirm}
+        isOpen={clearConfirmOpen}
         title={t('layers.clearLayer.title')}
         message={t('layers.clearLayer.message', { count: layerBins.length })}
         confirmText={t('layers.clearLayer.confirm')}
         destructive
-        onConfirm={handleClearLayer}
-        onCancel={() => setShowClearConfirm(false)}
+        onConfirm={confirmClear}
+        onCancel={() => setClearConfirmOpen(false)}
       />
     </div>
   );

--- a/src/features/layers/hooks/index.ts
+++ b/src/features/layers/hooks/index.ts
@@ -1,2 +1,2 @@
-// Barrel export for layers hooks
-// (Currently no hooks exported - useAdvancedLayerMode was removed as unused)
+export { useLayerFillActions } from './useLayerFillActions';
+export type { LayerFillActions } from './useLayerFillActions';

--- a/src/features/layers/hooks/useLayerFillActions.test.ts
+++ b/src/features/layers/hooks/useLayerFillActions.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLayerFillActions } from './useLayerFillActions';
+import { useLayoutStore } from '@/core/store';
+import { useSelectionStore } from '@/core/store/selection';
+import { useInteractionStore } from '@/core/store/interaction';
+import { useToastStore } from '@/core/store/toast';
+import { resetAllStores, createTestBin } from '@/test/testUtils';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+const mutations = vi.hoisted(() => ({
+  fillLayer: vi.fn(),
+  fillLayerGaps: vi.fn(),
+  clearLayer: vi.fn(),
+}));
+
+vi.mock('@/shared/contexts', () => ({
+  useMutations: () => mutations,
+}));
+
+function activeLayerId(): string {
+  const id = useSelectionStore.getState().activeLayerId;
+  if (!id) throw new Error('no active layer in test setup');
+  return id;
+}
+
+describe('useLayerFillActions', () => {
+  beforeEach(() => {
+    resetAllStores();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    const firstLayer = useLayoutStore.getState().layout.layers[0];
+    useSelectionStore.getState().setActiveLayer(firstLayer.id);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('exposes the active layer and empty-cell count', () => {
+    const { result } = renderHook(() => useLayerFillActions());
+    expect(result.current.activeLayer?.id).toBe(activeLayerId());
+    const { drawer } = useLayoutStore.getState().layout;
+    expect(result.current.totalCells).toBe(drawer.width * drawer.depth);
+    expect(result.current.emptyCells).toBeLessThanOrEqual(result.current.totalCells);
+  });
+
+  it('fillGaps dispatches the mutation and runs onAfterAction synchronously', () => {
+    const onAfterAction = vi.fn();
+    const { result } = renderHook(() => useLayerFillActions({ onAfterAction }));
+    act(() => {
+      result.current.fillGaps();
+    });
+    expect(mutations.fillLayerGaps).toHaveBeenCalledWith(
+      activeLayerId(),
+      expect.anything(),
+      expect.any(Boolean)
+    );
+    expect(onAfterAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('toasts the added count after the batch commits', () => {
+    const layerId = activeLayerId();
+    mutations.fillLayerGaps.mockImplementation(() => {
+      const state = useLayoutStore.getState();
+      useLayoutStore.setState({
+        layout: {
+          ...state.layout,
+          bins: [...state.layout.bins, createTestBin({ layerId })],
+        },
+      });
+    });
+    const { result } = renderHook(() => useLayerFillActions());
+    act(() => {
+      result.current.fillGaps();
+      vi.runAllTimers();
+    });
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts.some((toast) => toast.message.startsWith('toast.fillComplete'))).toBe(true);
+  });
+
+  it('confirmClear clears, deselects, closes the dialog, then runs onAfterAction', () => {
+    const layerId = activeLayerId();
+    const state = useLayoutStore.getState();
+    useLayoutStore.setState({
+      layout: { ...state.layout, bins: [createTestBin({ layerId })] },
+    });
+    useSelectionStore.getState().setSelectedBins(['some-bin']);
+
+    const onAfterAction = vi.fn();
+    const { result } = renderHook(() => useLayerFillActions({ onAfterAction }));
+    act(() => {
+      result.current.setClearConfirmOpen(true);
+    });
+    act(() => {
+      result.current.confirmClear();
+    });
+    expect(mutations.clearLayer).toHaveBeenCalledWith(layerId);
+    expect(useSelectionStore.getState().selectedBinIds).toEqual([]);
+    expect(result.current.clearConfirmOpen).toBe(false);
+    expect(onAfterAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('confirmClear is a no-op on an empty layer', () => {
+    const { result } = renderHook(() => useLayerFillActions());
+    act(() => {
+      result.current.confirmClear();
+    });
+    expect(mutations.clearLayer).not.toHaveBeenCalled();
+  });
+
+  it('fillWithSize dispatches, exits paint mode, and runs onAfterAction', () => {
+    useInteractionStore.getState().setPaintSize({ width: 2, depth: 3 });
+    const onAfterAction = vi.fn();
+    const { result } = renderHook(() => useLayerFillActions({ onAfterAction }));
+    act(() => {
+      result.current.fillWithSize(2, 3);
+    });
+    expect(mutations.fillLayer).toHaveBeenCalledWith(
+      activeLayerId(),
+      2,
+      3,
+      expect.anything(),
+      expect.any(Boolean)
+    );
+    expect(useInteractionStore.getState().paintSize).toBeNull();
+    expect(onAfterAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/layers/hooks/useLayerFillActions.ts
+++ b/src/features/layers/hooks/useLayerFillActions.ts
@@ -1,0 +1,122 @@
+/**
+ * Fill/clear actions for the active layer, shared by the desktop
+ * ActiveLayerPanel and the mobile ToolsTab so the two surfaces can't drift.
+ *
+ * The added-count toasts read the store AFTER the batch commits (via
+ * setTimeout(0)) because fill mutations dispatch through CQRS — the bin list
+ * captured before the batch is the baseline, the post-commit read is the
+ * result. `onAfterAction` runs synchronously after each action's batch
+ * (mobile closes its panel there); the toast still fires afterwards.
+ */
+
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useLayoutStore } from '@/core/store';
+import { useMutations } from '@/shared/contexts';
+import { useSelectionStore } from '@/core/store/selection';
+import { useInteractionStore } from '@/core/store/interaction';
+import { useHalfGridModeStore } from '@/core/store/halfGridMode';
+import { useToastStore } from '@/core/store/toast';
+import { getLayerBins } from '@/shared/utils';
+import { useTranslation } from '@/i18n';
+import { batch } from '@/core/cqrs';
+import type { Bin, Layer } from '@/core/types';
+
+export interface LayerFillActions {
+  activeLayer: Layer | undefined;
+  layerBins: Bin[];
+  totalCells: number;
+  emptyCells: number;
+  clearConfirmOpen: boolean;
+  setClearConfirmOpen: (open: boolean) => void;
+  fillGaps: () => void;
+  /** Clears the layer and deselects; closes the confirm dialog. */
+  confirmClear: () => void;
+  /** Fills with the given size and exits paint mode. */
+  fillWithSize: (width: number, depth: number) => void;
+}
+
+export function useLayerFillActions(options?: { onAfterAction?: () => void }): LayerFillActions {
+  const t = useTranslation();
+  const onAfterAction = options?.onAfterAction;
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
+
+  const layout = useLayoutStore((state) => state.layout);
+  const { fillLayer, fillLayerGaps, clearLayer } = useMutations();
+
+  const { activeLayerId, activeCategoryId, setSelectedBins } = useSelectionStore(
+    useShallow((state) => ({
+      activeLayerId: state.activeLayerId,
+      activeCategoryId: state.activeCategoryId,
+      setSelectedBins: state.setSelectedBins,
+    }))
+  );
+  const setPaintSize = useInteractionStore((state) => state.setPaintSize);
+  const halfGridMode = useHalfGridModeStore((state) => state.halfGridMode);
+  const addToast = useToastStore((state) => state.addToast);
+
+  const activeLayer = layout.layers.find((l) => l.id === activeLayerId);
+  const layerBins = getLayerBins(layout.bins, activeLayerId);
+
+  const totalCells = layout.drawer.width * layout.drawer.depth;
+  const coveredCells = layerBins.reduce((sum, b) => sum + b.width * b.depth, 0);
+  const emptyCells = totalCells - coveredCells;
+
+  const fillGaps = () => {
+    if (!activeLayerId) return;
+    const beforeCount = layerBins.length;
+    batch(() => {
+      fillLayerGaps(activeLayerId, activeCategoryId, halfGridMode);
+    });
+    onAfterAction?.();
+    setTimeout(() => {
+      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
+      const added = afterCount - beforeCount;
+      if (added > 0) {
+        addToast(t('toast.fillComplete', { count: added }), 'success');
+      }
+    }, 0);
+  };
+
+  const confirmClear = () => {
+    if (!activeLayerId || layerBins.length === 0) return;
+    const count = layerBins.length;
+    batch(() => {
+      clearLayer(activeLayerId);
+      setSelectedBins([]);
+    });
+    addToast(t('toast.clearComplete', { count }), 'success');
+    setClearConfirmOpen(false);
+    onAfterAction?.();
+  };
+
+  const fillWithSize = (width: number, depth: number) => {
+    if (!activeLayerId) return;
+    const beforeCount = layerBins.length;
+    batch(() => {
+      fillLayer(activeLayerId, width, depth, activeCategoryId, halfGridMode);
+    });
+    // Exit paint mode after filling
+    setPaintSize(null);
+    onAfterAction?.();
+    setTimeout(() => {
+      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
+      const added = afterCount - beforeCount;
+      if (added > 0) {
+        addToast(t('toast.fillWithSize', { count: added, width, depth }), 'success');
+      }
+    }, 0);
+  };
+
+  return {
+    activeLayer,
+    layerBins,
+    totalCells,
+    emptyCells,
+    clearConfirmOpen,
+    setClearConfirmOpen,
+    fillGaps,
+    confirmClear,
+    fillWithSize,
+  };
+}

--- a/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.tsx
@@ -1,20 +1,11 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { useLayoutStore } from '@/core/store/layout';
-import {
-  useSelectionStore,
-  useInteractionStore,
-  useHalfGridModeStore,
-  useMobileStore,
-} from '@/core/store';
-import { batch } from '@/core/cqrs';
-import { useMutations } from '@/shared/contexts';
-import { useToastStore } from '@/core/store/toast';
-import { getLayerBins } from '@/shared/utils';
+import { useInteractionStore, useMobileStore } from '@/core/store';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { SQUARE_SIZES, RECTANGLE_SIZES } from '@/features/layers/paintSizes';
+import { useLayerFillActions } from '@/features/layers/hooks/useLayerFillActions';
 
 /**
  * Tools tab content - bin palette for paint mode and layer fill actions.
@@ -23,85 +14,27 @@ import { SQUARE_SIZES, RECTANGLE_SIZES } from '@/features/layers/paintSizes';
 export function ToolsTab() {
   const t = useTranslation();
   const [rotated, setRotated] = useState(false);
-  const [showClearConfirm, setShowClearConfirm] = useState(false);
 
-  const layout = useLayoutStore((state) => state.layout);
-  const { fillLayer, fillLayerGaps, clearLayer } = useMutations();
-
-  const { activeLayerId, activeCategoryId, setSelectedBins } = useSelectionStore(
-    useShallow((state) => ({
-      activeLayerId: state.activeLayerId,
-      activeCategoryId: state.activeCategoryId,
-      setSelectedBins: state.setSelectedBins,
-    }))
-  );
-  const { paintSize, togglePaintSize, setPaintSize } = useInteractionStore(
+  const { paintSize, togglePaintSize } = useInteractionStore(
     useShallow((state) => ({
       paintSize: state.paintSize,
       togglePaintSize: state.togglePaintSize,
-      setPaintSize: state.setPaintSize,
     }))
   );
-  const halfGridMode = useHalfGridModeStore((state) => state.halfGridMode);
   const closeMobilePanel = useMobileStore((state) => state.closeMobilePanel);
 
-  const addToast = useToastStore((state) => state.addToast);
-
-  const activeLayer = layout.layers.find((l) => l.id === activeLayerId);
-  const layerBins = getLayerBins(layout.bins, activeLayerId);
-
-  // Calculate empty cells for Fill Gaps button
-  const totalCells = layout.drawer.width * layout.drawer.depth;
-  const coveredCells = layerBins.reduce((sum, b) => sum + b.width * b.depth, 0);
-  const emptyCells = totalCells - coveredCells;
+  const {
+    activeLayer,
+    layerBins,
+    emptyCells,
+    clearConfirmOpen,
+    setClearConfirmOpen,
+    fillGaps,
+    confirmClear,
+    fillWithSize,
+  } = useLayerFillActions({ onAfterAction: closeMobilePanel });
 
   const isPaintActive = (w: number, d: number) => paintSize?.width === w && paintSize.depth === d;
-
-  const handleFillGaps = () => {
-    if (!activeLayerId) return;
-    const beforeCount = layerBins.length;
-    batch(() => {
-      fillLayerGaps(activeLayerId, activeCategoryId, halfGridMode);
-    });
-    closeMobilePanel();
-    setTimeout(() => {
-      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
-      const added = afterCount - beforeCount;
-      if (added > 0) {
-        addToast(t('toast.fillComplete', { count: added }), 'success');
-      }
-    }, 0);
-  };
-
-  const handleClearLayer = () => {
-    if (!activeLayerId || layerBins.length === 0) return;
-    const count = layerBins.length;
-    batch(() => {
-      clearLayer(activeLayerId);
-      setSelectedBins([]);
-    });
-    addToast(t('toast.clearComplete', { count }), 'success');
-    setShowClearConfirm(false);
-    closeMobilePanel();
-  };
-
-  const handleFill = (width: number, depth: number) => {
-    if (!activeLayerId) return;
-    const beforeCount = layerBins.length;
-    batch(() => {
-      fillLayer(activeLayerId, width, depth, activeCategoryId, halfGridMode);
-    });
-    // Exit paint mode after filling
-    setPaintSize(null);
-    closeMobilePanel();
-    setTimeout(() => {
-      const afterCount = getLayerBins(useLayoutStore.getState().layout.bins, activeLayerId).length;
-      const added = afterCount - beforeCount;
-      if (added > 0) {
-        addToast(t('toast.fillWithSize', { count: added, width, depth }), 'success');
-      }
-    }, 0);
-  };
 
   if (!activeLayer) return null;
 
@@ -199,7 +132,7 @@ export function ToolsTab() {
           <Button
             variant="primary"
             fullWidth
-            onClick={() => handleFill(paintSize.width, paintSize.depth)}
+            onClick={() => fillWithSize(paintSize.width, paintSize.depth)}
             className="h-11 justify-center"
           >
             {t('mobile.tools.fillWithSize', { width: paintSize.width, depth: paintSize.depth })}
@@ -210,7 +143,7 @@ export function ToolsTab() {
         <Button
           variant="secondary"
           fullWidth
-          onClick={handleFillGaps}
+          onClick={fillGaps}
           disabled={emptyCells === 0}
           className="h-11 justify-center"
           leftIcon={
@@ -233,7 +166,7 @@ export function ToolsTab() {
         <Button
           variant="ghost"
           fullWidth
-          onClick={() => setShowClearConfirm(true)}
+          onClick={() => setClearConfirmOpen(true)}
           disabled={layerBins.length === 0}
           className="h-11 justify-center text-error hover:bg-error/10 hover:text-error"
           leftIcon={
@@ -255,13 +188,13 @@ export function ToolsTab() {
 
       {/* Clear confirmation dialog */}
       <ConfirmDialog
-        isOpen={showClearConfirm}
+        isOpen={clearConfirmOpen}
         title={t('layers.clearLayer.title')}
         message={t('layers.clearLayer.message', { count: layerBins.length })}
         confirmText={t('layers.clearLayer.confirm')}
         destructive
-        onConfirm={handleClearLayer}
-        onCancel={() => setShowClearConfirm(false)}
+        onConfirm={confirmClear}
+        onCancel={() => setClearConfirmOpen(false)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

First of the desktop↔mobile logic-dedup clusters from the duplication audit. The active-layer **fill gaps / fill with size / clear** logic was duplicated verbatim between `ActiveLayerPanel` (desktop) and the mobile `ToolsTab` — same store wiring, same `batch()` + `setTimeout` added-count toast pattern, same confirm-dialog state. ToolsTab's own comments said "matching desktop ActiveLayerPanel".

Both now consume **`useLayerFillActions()`** from `features/layers/hooks`:

- The one behavioral difference — mobile closes its panel after each action — rides an `onAfterAction` callback invoked synchronously after each action's batch (before the deferred toast), exactly matching the old mobile ordering.
- Desktop's `paintSize` read stays in the component and feeds `fillWithSize(width, depth)` explicitly (mobile always passed explicit args).
- The after-commit toast pattern (baseline count before the batch, store re-read in `setTimeout(0)`) is now documented once in the hook instead of existing as two undocumented copies.

Both components shed ~90 lines of logic each and keep only their JSX. The remaining two clusters (layer-list controller, categories panel) follow separately.

## Testing

- New `useLayerFillActions.test.ts`: real stores + mocked mutations + fake timers — dispatch shapes, paint-mode exit, onAfterAction ordering, added-count toast, empty-layer no-op
- All 119 existing tests across `features/layers` and `MobileLayersPanel` pass unchanged — they exercise the fill/clear flows through both surfaces
- `pnpm run typecheck`, eslint, knip clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated layer fill/clear logic by adding a shared `useLayerFillActions` hook used by desktop `ActiveLayerPanel` and mobile `ToolsTab`. This keeps both surfaces in sync, preserves mobile panel closing, and centralizes the added-count toast logic.

- **Refactors**
  - New shared `useLayerFillActions` for fill gaps, fill with size, and clear.
  - `ActiveLayerPanel` and `ToolsTab` now consume the hook; mobile closes via `onAfterAction`.
  - Desktop reads `paintSize` locally and calls `fillWithSize(width, depth)`.
  - Added `useLayerFillActions.test.ts`; each component removes ~90 lines of logic.

<sup>Written for commit 368711b04e0c4db1ad385ce672e8d20495275540. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

