### PR TITLE
refactor(layers): share the layer-list controller between desktop and mobile

### DIFF
--- a/src/features/layers/components/LayerPanel/LayerPanel.tsx
+++ b/src/features/layers/components/LayerPanel/LayerPanel.tsx
@@ -1,53 +1,44 @@
-import { useState, useCallback, useMemo } from 'react';
-import { useShallow } from 'zustand/react/shallow';
+import { useState, useMemo } from 'react';
 import { useLayoutStore } from '@/core/store';
-import { useSelectionStore } from '@/core/store/selection';
-import { useMutations } from '@/shared/contexts';
-import { CONSTRAINTS } from '@/core/constants';
 import { getGridBins, getLayerBins } from '@/shared/utils';
-import { getDisplayLayers } from '@/shared/utils/collision';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { Collapsible, IconButton, PlusIcon } from '@/design-system';
-import { isOk, isErr } from '@/core/result';
-import { useToastStore } from '@/core/store';
-import { useResultToast } from '@/shared/hooks';
 import { useTranslation } from '@/i18n';
-import { calculateLayerAutoExpansion } from '@/features/layers/utils/layerAutoExpansion';
-import type { HeightUnits, LayerId } from '@/core/types';
+import { CONSTRAINTS } from '@/core/constants';
+import type { LayerId } from '@/core/types';
 import { HeightCrossSectionDiagram } from './HeightCrossSectionDiagram';
-import { batch } from '@/core/cqrs';
+import { useLayerListController } from '../../hooks/useLayerListController';
 
 export function LayerPanel() {
   const t = useTranslation();
-  const [deleteLayerId, setDeleteLayerId] = useState<LayerId | null>(null);
   const [editingLayerId, setEditingLayerId] = useState<LayerId | null>(null);
   const [hoveredLayerId, setHoveredLayerId] = useState<LayerId | null>(null);
 
   const layout = useLayoutStore((state) => state.layout);
-  const { addLayer, updateLayer, deleteLayer, reorderLayers } = useMutations();
+  const {
+    layers,
+    displayLayers,
+    activeLayerId,
+    activeLayer,
+    setActiveLayer,
+    totalLayerHeight,
+    canAddLayer,
+    heightFull,
+    addLayerWithAutoExpand,
+    deleteLayerId,
+    layerToDelete,
+    deletedLayerBinCount,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+    renameLayer,
+    changeLayerHeight,
+    reorderByDisplayIndex,
+  } = useLayerListController();
 
-  const { activeLayerId, setActiveLayer } = useSelectionStore(
-    useShallow((state) => ({
-      activeLayerId: state.activeLayerId,
-      setActiveLayer: state.setActiveLayer,
-    }))
-  );
-
-  const addToast = useToastStore((state) => state.addToast);
-  const { showErrorToast } = useResultToast();
-
-  const layers = layout.layers;
-  const activeLayer = layers.find((l) => l.id === activeLayerId);
-  const totalLayerHeight = layers.reduce((sum, l) => sum + l.height, 0);
   const drawerHeight = layout.drawer.height;
-  const canAddLayer = layers.length < CONSTRAINTS.LAYERS_MAX && totalLayerHeight < drawerHeight;
-  const heightFull = totalLayerHeight > drawerHeight;
-
   const totalCells = layout.drawer.width * layout.drawer.depth;
   const hasMultipleLayers = layers.length > 1;
-
-  const displayToArrayIndex = (displayIndex: number) => layers.length - 1 - displayIndex;
-  const displayLayers = getDisplayLayers(layers);
 
   const layerStats = useMemo(() => {
     const stats: Record<string, { coverage: number; binCount: number }> = {};
@@ -73,104 +64,6 @@ export function LayerPanel() {
   const effectiveCoverage = hasMultipleLayers ? totalCoverage : (activeStat?.coverage ?? 0);
   const effectiveBinCount = hasMultipleLayers ? totalBinCount : (activeStat?.binCount ?? 0);
 
-  const handleAddLayer = () => {
-    const topLayer = layers[layers.length - 1];
-
-    const expansion = calculateLayerAutoExpansion(
-      topLayer,
-      layout.bins,
-      totalLayerHeight,
-      drawerHeight
-    );
-
-    if (expansion.wouldExceedCapacity && expansion.smallestExceedingHeight !== undefined) {
-      addToast(
-        t('layers.cannotAddLayerTallBins', {
-          layerName: topLayer.name,
-          binHeight: expansion.smallestExceedingHeight,
-          layerHeight: topLayer.height,
-        }),
-        'error'
-      );
-      return;
-    }
-
-    if (expansion.needsExpansion && expansion.newHeight !== undefined) {
-      const newHeight = expansion.newHeight;
-      batch(() => {
-        const expandResult = updateLayer(topLayer.id, { height: newHeight as HeightUnits });
-        if (isErr(expandResult)) {
-          showErrorToast(expandResult.error);
-          return;
-        }
-        const addResult = addLayer();
-        if (isOk(addResult)) {
-          setActiveLayer(addResult.value);
-        } else {
-          showErrorToast(addResult.error);
-        }
-      });
-    } else {
-      batch(() => {
-        const result = addLayer();
-        if (isOk(result)) {
-          setActiveLayer(result.value);
-        }
-      });
-    }
-  };
-
-  const handleDeleteLayer = useCallback(() => {
-    if (!deleteLayerId) return;
-    batch(() => {
-      const result = deleteLayer(deleteLayerId);
-      if (isOk(result) && activeLayerId === deleteLayerId && layers.length > 0) {
-        const remaining = layers.filter((l) => l.id !== deleteLayerId);
-        if (remaining.length > 0) {
-          setActiveLayer(remaining[0].id);
-        }
-      }
-    });
-    setDeleteLayerId(null);
-  }, [deleteLayerId, deleteLayer, activeLayerId, layers, setActiveLayer]);
-
-  const handleNameChange = (layerId: LayerId, name: string) => {
-    batch(() => {
-      const result = updateLayer(layerId, {
-        name: name.slice(0, CONSTRAINTS.LABEL_MAX_LENGTH),
-      });
-      if (isErr(result)) {
-        showErrorToast(result.error);
-      }
-    });
-  };
-
-  const handleHeightChange = (layerId: LayerId, delta: number) => {
-    const layer = layers.find((l) => l.id === layerId);
-    if (!layer) return;
-    const newHeight = Math.max(CONSTRAINTS.MIN_LAYER_HEIGHT, layer.height + delta);
-    batch(() => {
-      const result = updateLayer(layerId, { height: newHeight as HeightUnits });
-      if (isErr(result)) {
-        showErrorToast(result.error);
-      }
-    });
-  };
-
-  const handleReorder = (fromDisplayIndex: number, toDisplayIndex: number) => {
-    const fromArrayIndex = displayToArrayIndex(fromDisplayIndex);
-    const toArrayIndex = displayToArrayIndex(toDisplayIndex);
-    batch(() => {
-      const result = reorderLayers(fromArrayIndex, toArrayIndex);
-      if (isErr(result)) {
-        showErrorToast(result.error);
-      }
-    });
-  };
-
-  const layerToDelete = deleteLayerId ? layers.find((l) => l.id === deleteLayerId) : null;
-  const deletedLayerBinCount = !deleteLayerId ? 0 : getLayerBins(layout.bins, deleteLayerId).length;
-
   if (!activeLayer) return null;
 
   const getAddLayerTitle = (): string => {
@@ -184,7 +77,7 @@ export function LayerPanel() {
     <IconButton
       size="sm"
       touchTarget={false}
-      onClick={handleAddLayer}
+      onClick={addLayerWithAutoExpand}
       disabled={!canAddLayer}
       className="w-7 h-7"
       title={getAddLayerTitle()}
@@ -207,11 +100,11 @@ export function LayerPanel() {
             editingLayerId={editingLayerId}
             onLayerClick={setActiveLayer}
             onLayerHover={setHoveredLayerId}
-            onAddLayer={handleAddLayer}
-            onReorder={handleReorder}
-            onNameChange={handleNameChange}
-            onHeightChange={handleHeightChange}
-            onDeleteLayer={setDeleteLayerId}
+            onAddLayer={addLayerWithAutoExpand}
+            onReorder={reorderByDisplayIndex}
+            onNameChange={renameLayer}
+            onHeightChange={changeLayerHeight}
+            onDeleteLayer={requestDelete}
             onEditingStart={(id) => {
               setActiveLayer(id);
               setEditingLayerId(id);
@@ -270,8 +163,8 @@ export function LayerPanel() {
         })}
         confirmText={t('common.delete')}
         destructive
-        onConfirm={handleDeleteLayer}
-        onCancel={() => setDeleteLayerId(null)}
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
       />
     </div>
   );

--- a/src/features/layers/hooks/useLayerListController.test.ts
+++ b/src/features/layers/hooks/useLayerListController.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLayerListController } from './useLayerListController';
+import { useLayoutStore } from '@/core/store';
+import { useSelectionStore } from '@/core/store/selection';
+import { resetAllStores } from '@/test/testUtils';
+import { ok, err } from '@/core/result';
+import { layerId } from '@/core/types';
+import type { Layer } from '@/core/types';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+const mutations = vi.hoisted(() => ({
+  addLayer: vi.fn(),
+  updateLayer: vi.fn(),
+  deleteLayer: vi.fn(),
+  reorderLayers: vi.fn(),
+}));
+
+vi.mock('@/shared/contexts', () => ({
+  useMutations: () => mutations,
+}));
+
+function seedLayers(layers: Layer[]): void {
+  const state = useLayoutStore.getState();
+  useLayoutStore.setState({ layout: { ...state.layout, layers } });
+}
+
+const layerA: Layer = { id: layerId('layer-a'), name: 'A', height: 3 as Layer['height'] };
+const layerB: Layer = { id: layerId('layer-b'), name: 'B', height: 3 as Layer['height'] };
+
+describe('useLayerListController', () => {
+  beforeEach(() => {
+    resetAllStores();
+    vi.clearAllMocks();
+    mutations.updateLayer.mockReturnValue(ok(undefined));
+    mutations.deleteLayer.mockReturnValue(ok(undefined));
+    mutations.reorderLayers.mockReturnValue(ok(undefined));
+    mutations.addLayer.mockReturnValue(ok(layerId('new-layer')));
+    seedLayers([layerA, layerB]);
+    useSelectionStore.getState().setActiveLayer(layerA.id);
+  });
+
+  it('reverses array order for display (top layer first)', () => {
+    const { result } = renderHook(() => useLayerListController());
+    expect(result.current.layers.map((l) => l.name)).toEqual(['A', 'B']);
+    expect(result.current.displayLayers.map((l) => l.name)).toEqual(['B', 'A']);
+  });
+
+  it('adds a layer and activates it', () => {
+    const { result } = renderHook(() => useLayerListController());
+    act(() => {
+      result.current.addLayerWithAutoExpand();
+    });
+    expect(mutations.addLayer).toHaveBeenCalledTimes(1);
+    expect(useSelectionStore.getState().activeLayerId).toBe(layerId('new-layer'));
+  });
+
+  it('maps display indices to array indices when reordering', () => {
+    const { result } = renderHook(() => useLayerListController());
+    act(() => {
+      // Move display-top (array index 1) to display-bottom (array index 0).
+      result.current.reorderByDisplayIndex(0, 1);
+    });
+    expect(mutations.reorderLayers).toHaveBeenCalledWith(1, 0);
+  });
+
+  it('ignores out-of-range reorder targets', () => {
+    const { result } = renderHook(() => useLayerListController());
+    act(() => {
+      result.current.reorderByDisplayIndex(0, -1);
+    });
+    expect(mutations.reorderLayers).not.toHaveBeenCalled();
+  });
+
+  it('routes reorder errors to onReorderError when provided', () => {
+    mutations.reorderLayers.mockReturnValue(err({ code: 'LAYOUT_LAYER_LIMIT' } as never));
+    const onReorderError = vi.fn();
+    const { result } = renderHook(() => useLayerListController({ onReorderError }));
+    act(() => {
+      result.current.reorderByDisplayIndex(0, 1);
+    });
+    expect(onReorderError).toHaveBeenCalledTimes(1);
+  });
+
+  it('delete flow: request opens, confirm deletes and reassigns the active layer', () => {
+    const { result } = renderHook(() => useLayerListController());
+    act(() => {
+      result.current.requestDelete(layerA.id);
+    });
+    expect(result.current.deleteLayerId).toBe(layerA.id);
+    expect(result.current.layerToDelete?.name).toBe('A');
+    act(() => {
+      result.current.confirmDelete();
+    });
+    expect(mutations.deleteLayer).toHaveBeenCalledWith(layerA.id);
+    expect(useSelectionStore.getState().activeLayerId).toBe(layerB.id);
+    expect(result.current.deleteLayerId).toBeNull();
+  });
+
+  it('requestDelete is a no-op at the minimum layer count', () => {
+    seedLayers([layerA]);
+    const { result } = renderHook(() => useLayerListController());
+    act(() => {
+      result.current.requestDelete(layerA.id);
+    });
+    expect(result.current.deleteLayerId).toBeNull();
+  });
+
+  it('clamps height changes at the minimum layer height', () => {
+    seedLayers([{ ...layerA, height: 2 as Layer['height'] }, layerB]);
+    const { result } = renderHook(() => useLayerListController());
+    act(() => {
+      result.current.changeLayerHeight(layerA.id, -1);
+    });
+    expect(mutations.updateLayer).toHaveBeenCalledWith(layerA.id, { height: 2 });
+  });
+
+  it('truncates renames to the label length limit', () => {
+    const { result } = renderHook(() => useLayerListController());
+    act(() => {
+      result.current.renameLayer(layerA.id, 'x'.repeat(500));
+    });
+    const [, patch] = mutations.updateLayer.mock.calls[0] as [unknown, { name: string }];
+    expect(patch.name.length).toBeLessThan(500);
+  });
+});

--- a/src/features/layers/hooks/useLayerListController.ts
+++ b/src/features/layers/hooks/useLayerListController.ts
@@ -1,0 +1,213 @@
+/**
+ * Layer-list state and actions shared by the desktop LayerPanel and the
+ * mobile LayersTab: add-with-auto-expansion, delete with active-layer
+ * reassignment, rename, height stepping, and display-order reordering.
+ *
+ * Display order is REVERSED from array order (layers[0] is the bottom layer,
+ * display index 0 is the top) — `reorderByDisplayIndex` owns that mapping so
+ * neither surface re-implements it. Reorder errors surface through
+ * `onReorderError` when provided (mobile shows an inline banner); otherwise
+ * through the shared error toast.
+ */
+
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useLayoutStore } from '@/core/store';
+import { useSelectionStore } from '@/core/store/selection';
+import { useMutations } from '@/shared/contexts';
+import { CONSTRAINTS } from '@/core/constants';
+import { getLayerBins } from '@/shared/utils';
+import { getDisplayLayers } from '@/shared/utils/collision';
+import { isOk, isErr, getUserMessage } from '@/core/result';
+import { useToastStore } from '@/core/store';
+import { useResultToast } from '@/shared/hooks';
+import { useTranslation } from '@/i18n';
+import { calculateLayerAutoExpansion } from '@/features/layers/utils/layerAutoExpansion';
+import type { HeightUnits, Layer, LayerId } from '@/core/types';
+import { batch } from '@/core/cqrs';
+
+export interface LayerListController {
+  layers: Layer[];
+  displayLayers: Layer[];
+  activeLayerId: LayerId;
+  activeLayer: Layer | undefined;
+  setActiveLayer: (id: LayerId) => void;
+  totalLayerHeight: number;
+  canAddLayer: boolean;
+  heightFull: boolean;
+  addLayerWithAutoExpand: () => void;
+  deleteLayerId: LayerId | null;
+  layerToDelete: Layer | null;
+  deletedLayerBinCount: number;
+  /** Opens the delete confirm; no-op at the minimum layer count. */
+  requestDelete: (id: LayerId) => void;
+  confirmDelete: () => void;
+  cancelDelete: () => void;
+  renameLayer: (id: LayerId, name: string) => void;
+  changeLayerHeight: (id: LayerId, delta: number) => void;
+  reorderByDisplayIndex: (fromDisplayIndex: number, toDisplayIndex: number) => void;
+}
+
+export function useLayerListController(options?: {
+  onReorderError?: (message: string) => void;
+}): LayerListController {
+  const t = useTranslation();
+  const onReorderError = options?.onReorderError;
+  const [deleteLayerId, setDeleteLayerId] = useState<LayerId | null>(null);
+
+  const layout = useLayoutStore((state) => state.layout);
+  const { addLayer, updateLayer, deleteLayer, reorderLayers } = useMutations();
+
+  const { activeLayerId, setActiveLayer } = useSelectionStore(
+    useShallow((state) => ({
+      activeLayerId: state.activeLayerId,
+      setActiveLayer: state.setActiveLayer,
+    }))
+  );
+
+  const addToast = useToastStore((state) => state.addToast);
+  const { showErrorToast } = useResultToast();
+
+  const layers = layout.layers;
+  const activeLayer = layers.find((l) => l.id === activeLayerId);
+  const totalLayerHeight = layers.reduce((sum, l) => sum + l.height, 0);
+  const drawerHeight = layout.drawer.height;
+  const canAddLayer = layers.length < CONSTRAINTS.LAYERS_MAX && totalLayerHeight < drawerHeight;
+  const heightFull = totalLayerHeight > drawerHeight;
+
+  const displayToArrayIndex = (displayIndex: number) => layers.length - 1 - displayIndex;
+  const displayLayers = getDisplayLayers(layers);
+
+  const addLayerWithAutoExpand = () => {
+    const topLayer = layers[layers.length - 1];
+
+    const expansion = calculateLayerAutoExpansion(
+      topLayer,
+      layout.bins,
+      totalLayerHeight,
+      drawerHeight
+    );
+
+    if (expansion.wouldExceedCapacity && expansion.smallestExceedingHeight !== undefined) {
+      addToast(
+        t('layers.cannotAddLayerTallBins', {
+          layerName: topLayer.name,
+          binHeight: expansion.smallestExceedingHeight,
+          layerHeight: topLayer.height,
+        }),
+        'error'
+      );
+      return;
+    }
+
+    if (expansion.needsExpansion && expansion.newHeight !== undefined) {
+      const newHeight = expansion.newHeight;
+      batch(() => {
+        const expandResult = updateLayer(topLayer.id, { height: newHeight as HeightUnits });
+        if (isErr(expandResult)) {
+          showErrorToast(expandResult.error);
+          return;
+        }
+        const addResult = addLayer();
+        if (isOk(addResult)) {
+          setActiveLayer(addResult.value);
+        } else {
+          showErrorToast(addResult.error);
+        }
+      });
+    } else {
+      batch(() => {
+        const result = addLayer();
+        if (isOk(result)) {
+          setActiveLayer(result.value);
+        }
+      });
+    }
+  };
+
+  const requestDelete = (id: LayerId) => {
+    if (layers.length <= CONSTRAINTS.LAYERS_MIN) return;
+    setDeleteLayerId(id);
+  };
+
+  const confirmDelete = () => {
+    if (!deleteLayerId) return;
+    batch(() => {
+      const result = deleteLayer(deleteLayerId);
+      if (isOk(result) && activeLayerId === deleteLayerId && layers.length > 0) {
+        const remaining = layers.filter((l) => l.id !== deleteLayerId);
+        if (remaining.length > 0) {
+          setActiveLayer(remaining[0].id);
+        }
+      }
+    });
+    setDeleteLayerId(null);
+  };
+
+  const cancelDelete = () => {
+    setDeleteLayerId(null);
+  };
+
+  const renameLayer = (id: LayerId, name: string) => {
+    batch(() => {
+      const result = updateLayer(id, {
+        name: name.slice(0, CONSTRAINTS.LABEL_MAX_LENGTH),
+      });
+      if (isErr(result)) {
+        showErrorToast(result.error);
+      }
+    });
+  };
+
+  const changeLayerHeight = (id: LayerId, delta: number) => {
+    const layer = layers.find((l) => l.id === id);
+    if (!layer) return;
+    const newHeight = Math.max(CONSTRAINTS.MIN_LAYER_HEIGHT, layer.height + delta);
+    batch(() => {
+      const result = updateLayer(id, { height: newHeight as HeightUnits });
+      if (isErr(result)) {
+        showErrorToast(result.error);
+      }
+    });
+  };
+
+  const reorderByDisplayIndex = (fromDisplayIndex: number, toDisplayIndex: number) => {
+    if (toDisplayIndex < 0 || toDisplayIndex >= layers.length) return;
+    const fromArrayIndex = displayToArrayIndex(fromDisplayIndex);
+    const toArrayIndex = displayToArrayIndex(toDisplayIndex);
+    batch(() => {
+      const result = reorderLayers(fromArrayIndex, toArrayIndex);
+      if (isErr(result)) {
+        if (onReorderError) {
+          onReorderError(getUserMessage(result.error));
+        } else {
+          showErrorToast(result.error);
+        }
+      }
+    });
+  };
+
+  const layerToDelete = deleteLayerId ? (layers.find((l) => l.id === deleteLayerId) ?? null) : null;
+  const deletedLayerBinCount = deleteLayerId ? getLayerBins(layout.bins, deleteLayerId).length : 0;
+
+  return {
+    layers,
+    displayLayers,
+    activeLayerId,
+    activeLayer,
+    setActiveLayer,
+    totalLayerHeight,
+    canAddLayer,
+    heightFull,
+    addLayerWithAutoExpand,
+    deleteLayerId,
+    layerToDelete,
+    deletedLayerBinCount,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+    renameLayer,
+    changeLayerHeight,
+    reorderByDisplayIndex,
+  };
+}

--- a/src/shell/Mobile/MobileLayersPanel/LayersTab/LayersTab.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/LayersTab/LayersTab.tsx
@@ -1,21 +1,14 @@
 import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
-import { useSelectionStore, useInteractionStore } from '@/core/store';
-import { useMutations } from '@/shared/contexts';
-import type { HeightUnits, LayerId } from '@/core/types';
+import { useInteractionStore } from '@/core/store';
+import type { LayerId } from '@/core/types';
 import { CONSTRAINTS } from '@/core/constants';
 import { getGridBins, getLayerBins } from '@/shared/utils';
-import { getDisplayLayers } from '@/shared/utils/collision';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
-import { isOk, isErr, getUserMessage } from '@/core/result';
-import { useToastStore } from '@/core/store/toast';
-import { useResultToast } from '@/shared/hooks';
 import { useTranslation } from '@/i18n';
 import { Button, IconButton, PlusIcon, MinusIcon } from '@/design-system';
-import { calculateLayerAutoExpansion } from '@/features/layers/utils/layerAutoExpansion';
-import { batch } from '@/core/cqrs';
+import { useLayerListController } from '@/features/layers/hooks/useLayerListController';
 
 /**
  * Layers tab content - layer list with selection, height controls, reordering, and deletion.
@@ -23,7 +16,6 @@ import { batch } from '@/core/cqrs';
  */
 export function LayersTab() {
   const t = useTranslation();
-  const [deleteLayerId, setDeleteLayerId] = useState<LayerId | null>(null);
   const [reorderError, setReorderError] = useState<string | null>(null);
   const [renameLayerId, setRenameLayerId] = useState<LayerId | null>(null);
   const [renameValue, setRenameValue] = useState('');
@@ -41,21 +33,34 @@ export function LayersTab() {
   }, [renameLayerId]);
 
   const layout = useLayoutStore((state) => state.layout);
-  const { addLayer, updateLayer, deleteLayer, reorderLayers } = useMutations();
-  const layers = layout.layers;
   const bins = layout.bins;
   const drawer = layout.drawer;
 
-  const { activeLayerId, setActiveLayer } = useSelectionStore(
-    useShallow((state) => ({
-      activeLayerId: state.activeLayerId,
-      setActiveLayer: state.setActiveLayer,
-    }))
-  );
   const announceToScreenReader = useInteractionStore((state) => state.announceToScreenReader);
 
-  const addToast = useToastStore((state) => state.addToast);
-  const { showErrorToast } = useResultToast();
+  const {
+    layers,
+    displayLayers,
+    activeLayerId,
+    setActiveLayer,
+    totalLayerHeight,
+    canAddLayer,
+    addLayerWithAutoExpand,
+    deleteLayerId,
+    layerToDelete,
+    deletedLayerBinCount,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+    renameLayer,
+    changeLayerHeight,
+    reorderByDisplayIndex,
+  } = useLayerListController({
+    onReorderError: (message) => {
+      setReorderError(message);
+      setTimeout(() => setReorderError(null), 3000);
+    },
+  });
 
   const handleRenameRequest = (id: LayerId) => {
     const layer = layers.find((l) => l.id === id);
@@ -67,17 +72,13 @@ export function LayersTab() {
     if (!renameLayerId) return;
     const trimmed = renameValue.trim();
     if (trimmed) {
-      batch(() => {
-        updateLayer(renameLayerId, { name: trimmed.slice(0, CONSTRAINTS.LABEL_MAX_LENGTH) });
-      });
+      renameLayer(renameLayerId, trimmed);
       announceToScreenReader(t('layers.announce.renamedTo', { name: trimmed }));
     }
     setRenameLayerId(null);
     setRenameValue('');
   };
 
-  const totalLayerHeight = layers.reduce((sum, l) => sum + l.height, 0);
-  const displayLayers = getDisplayLayers(layers);
   const hasMultipleLayers = layers.length > 1;
 
   // Coverage calculations
@@ -100,110 +101,9 @@ export function LayersTab() {
         )
       : 0;
 
-  // Display is reversed: index 0 in display = last in array (top layer)
-  const displayToArrayIndex = (displayIndex: number) => layers.length - 1 - displayIndex;
-
-  const handleAddLayer = () => {
-    const topLayer = layers[layers.length - 1];
-
-    // Calculate if layer expansion is needed before adding new layer
-    const expansion = calculateLayerAutoExpansion(topLayer, bins, totalLayerHeight, drawer.height);
-
-    if (expansion.wouldExceedCapacity && expansion.smallestExceedingHeight !== undefined) {
-      // Show friendly error explaining the issue and suggesting solutions
-      addToast(
-        t('layers.cannotAddLayerTallBins', {
-          layerName: topLayer.name,
-          binHeight: expansion.smallestExceedingHeight,
-          layerHeight: topLayer.height,
-        }),
-        'error'
-      );
-      return;
-    }
-
-    if (expansion.needsExpansion && expansion.newHeight !== undefined) {
-      // Auto-expand the top layer, then add the new layer (atomic via execute)
-      const newHeight = expansion.newHeight; // Capture for closure
-      batch(() => {
-        const expandResult = updateLayer(topLayer.id, { height: newHeight as HeightUnits });
-        if (isErr(expandResult)) {
-          showErrorToast(expandResult.error);
-          return;
-        }
-        const addResult = addLayer();
-        if (isOk(addResult)) {
-          setActiveLayer(addResult.value);
-        } else if (isErr(addResult)) {
-          showErrorToast(addResult.error);
-        }
-      });
-    } else {
-      // Normal case - no adjustment needed
-      batch(() => {
-        const result = addLayer();
-        if (isOk(result)) {
-          setActiveLayer(result.value);
-        }
-      });
-    }
-  };
-
-  // Selection behavior: select only, don't close panel
-  const handleSelectLayer = (id: LayerId) => {
-    setActiveLayer(id);
-  };
-
-  const handleDeleteLayer = (id: LayerId) => {
-    if (layers.length <= CONSTRAINTS.LAYERS_MIN) return;
-    setDeleteLayerId(id);
-  };
-
-  const confirmDeleteLayer = () => {
-    if (!deleteLayerId) return;
-    batch(() => {
-      const result = deleteLayer(deleteLayerId);
-      if (isOk(result) && activeLayerId === deleteLayerId && layers.length > 0) {
-        const remaining = layers.filter((l) => l.id !== deleteLayerId);
-        if (remaining.length > 0) {
-          setActiveLayer(remaining[0].id);
-        }
-      }
-    });
-    setDeleteLayerId(null);
-  };
-
-  const handleHeightChange = (id: LayerId, delta: number) => {
-    const layer = layers.find((l) => l.id === id);
-    if (!layer) return;
-    const newHeight = Math.max(CONSTRAINTS.MIN_LAYER_HEIGHT, layer.height + delta);
-    batch(() => {
-      updateLayer(id, { height: newHeight as HeightUnits });
-    });
-  };
-
   const handleMoveLayer = (displayIndex: number, direction: 'up' | 'down') => {
     const targetDisplayIndex = direction === 'up' ? displayIndex - 1 : displayIndex + 1;
-    if (targetDisplayIndex < 0 || targetDisplayIndex >= layers.length) return;
-
-    const fromArrayIndex = displayToArrayIndex(displayIndex);
-    const toArrayIndex = displayToArrayIndex(targetDisplayIndex);
-
-    batch(() => {
-      const result = reorderLayers(fromArrayIndex, toArrayIndex);
-      if (isErr(result)) {
-        setReorderError(getUserMessage(result.error));
-        setTimeout(() => setReorderError(null), 3000);
-      }
-    });
-  };
-
-  const layerToDelete = deleteLayerId ? layers.find((l) => l.id === deleteLayerId) : null;
-  const binsInLayer = deleteLayerId ? getLayerBins(bins, deleteLayerId).length : 0;
-  const canAddLayer = layers.length < CONSTRAINTS.LAYERS_MAX && totalLayerHeight < drawer.height;
-
-  const cancelDeleteLayer = () => {
-    setDeleteLayerId(null);
+    reorderByDisplayIndex(displayIndex, targetDisplayIndex);
   };
 
   return (
@@ -273,7 +173,7 @@ export function LayersTab() {
                 variant="ghost"
                 touchTarget={false}
                 className="flex-1 min-w-0 flex-col items-start text-left py-1 px-0 hover:bg-transparent"
-                onClick={() => handleSelectLayer(layer.id)}
+                onClick={() => setActiveLayer(layer.id)}
               >
                 <span
                   className={`truncate block text-sm ${isActive ? 'text-content font-semibold' : 'text-content font-medium'}`}
@@ -298,7 +198,7 @@ export function LayersTab() {
               <div className="flex items-center gap-1">
                 <IconButton
                   size="lg"
-                  onClick={() => handleHeightChange(layer.id, -1)}
+                  onClick={() => changeLayerHeight(layer.id, -1)}
                   disabled={layer.height <= CONSTRAINTS.MIN_LAYER_HEIGHT}
                   className="w-10 h-10 text-content-tertiary active:bg-surface-hover"
                   aria-label={t('layers.decreaseHeight', { name: layer.name })}
@@ -313,7 +213,7 @@ export function LayersTab() {
                 </span>
                 <IconButton
                   size="lg"
-                  onClick={() => handleHeightChange(layer.id, 1)}
+                  onClick={() => changeLayerHeight(layer.id, 1)}
                   className="w-10 h-10 text-content-tertiary active:bg-surface-hover"
                   aria-label={t('layers.increaseHeight', { name: layer.name })}
                 >
@@ -364,7 +264,7 @@ export function LayersTab() {
                 <IconButton
                   touchTarget={false}
                   variant="dangerGhost"
-                  onClick={() => handleDeleteLayer(layer.id)}
+                  onClick={() => requestDelete(layer.id)}
                   className="w-8 h-8 text-content-tertiary"
                   aria-label={t('mobile.deleteLayer')}
                 >
@@ -415,7 +315,7 @@ export function LayersTab() {
       <Button
         variant="primary"
         fullWidth
-        onClick={handleAddLayer}
+        onClick={addLayerWithAutoExpand}
         disabled={!canAddLayer}
         leftIcon={<PlusIcon />}
       >
@@ -427,12 +327,12 @@ export function LayersTab() {
         title={t('layers.confirmDelete.title')}
         message={t('layers.confirmDelete.message', {
           name: layerToDelete?.name || '',
-          count: binsInLayer,
+          count: deletedLayerBinCount,
         })}
         confirmText={t('common.delete')}
         destructive
-        onConfirm={confirmDeleteLayer}
-        onCancel={cancelDeleteLayer}
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
       />
 
       {/* Rename action sheet - portaled to escape BottomSheet's scrollable container */}


### PR DESCRIPTION
## Summary

Second desktop↔mobile dedup cluster (follows #2763). `LayerPanel` (desktop) and the mobile `LayersTab` duplicated the entire layer-list state machine: add-with-auto-expansion (including the tall-bin capacity error and the expand-then-add batch), delete with active-layer reassignment, rename, height stepping, and the reversed display-index reorder mapping.

Both now consume **`useLayerListController()`** from `features/layers/hooks`:

- **Reorder errors** ride an `onReorderError` option — mobile keeps its inline 3-second banner, desktop keeps the shared error toast default.
- The **`LAYERS_MIN` delete guard** (previously mobile-only) now protects both surfaces; desktop hid the control but had no guard behind it.
- Two mobile paths that previously **swallowed mutation errors** (height change, rename) now surface them via the shared error toast — deliberate small behavior improvements called out here rather than silently shipped.
- The display-reversal mapping (`layers[0]` = bottom, display index 0 = top — the classic coordinate gotcha) is owned by the hook once, with an in-range guard.

Components keep only their JSX and display-only stats (coverage bars, rename dialog, screen-reader announcements).

## Testing

- New `useLayerListController.test.ts`: display reversal, index mapping, out-of-range guard, error routing, delete flow with active-layer reassignment, min-count guard, height clamp, rename truncation
- All 122 tests across `features/layers` + `MobileLayersPanel` pass (existing panel tests exercise both surfaces through the hook)
- `pnpm run typecheck`, eslint, knip clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shared the layer-list controller between desktop `LayerPanel` and mobile `LayersTab` via `useLayerListController()` to remove duplicate logic and align behavior. This centralizes add-with-auto-expansion, rename, height changes, delete with reassignment, and reversed display-index reordering.

- **Refactors**
  - Introduced `useLayerListController()` in `features/layers/hooks` and wired both surfaces to it.
  - Hook owns add-with-auto-expansion, delete flow, rename, height stepping, and reversed display-index mapping.
  - Mobile passes `onReorderError` to keep its 3s inline banner; desktop uses the shared toast.
  - Added `useLayerListController.test.ts` covering mapping, guards, error routing, and flows.

- **Bug Fixes**
  - Enforced `LAYERS_MIN` delete guard on desktop (was mobile-only).
  - Surfaced mutation errors for mobile rename and height changes via the shared error toast.
  - Ignored out-of-range reorder targets and routed reorder errors consistently (banner on mobile, toast otherwise).

<sup>Written for commit 5a976e295314eff6e9daf52d671028dd0e768ca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

