### PR TITLE
refactor(categories): share the category manager between desktop and mobile

### DIFF
--- a/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
+++ b/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
@@ -1,19 +1,14 @@
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore, useSettingsStore } from '@/core/store';
 import { useSelectionStore } from '@/core/store/selection';
 import { useViewStore } from '@/core/store/view';
-import { useMutations } from '@/shared/contexts';
-import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR, CATEGORY_COLOR_PALETTE } from '@/core/constants';
+import { CONSTRAINTS, CATEGORY_COLOR_PALETTE } from '@/core/constants';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
 import { useToastStore } from '@/core/store/toast';
-import { isOk, isErr } from '@/core/result';
-import { useResultToast } from '@/shared/hooks';
 import { mlTracking } from '@/shared/analytics/useMLTracking';
 import { useTranslation } from '@/i18n';
-import { categoryId as toCategoryId } from '@/core/types';
-import type { CategoryId } from '@/core/types';
-import { batch } from '@/core/cqrs';
+import { useCategoryManager } from '../../hooks/useCategoryManager';
 import { Button, Collapsible, IconButton, PlusIcon, XIcon } from '@/design-system';
 
 interface ColorPaletteGridProps {
@@ -56,44 +51,40 @@ function ColorPaletteGrid({ selectedColor, onColorSelect, t }: ColorPaletteGridP
 
 export function CategoriesPanel() {
   const t = useTranslation();
-  const [editingId, setEditingId] = useState<string | null>(null);
   const [colorPickerId, setColorPickerId] = useState<string | null>(null);
-  const [deleteConfirm, setDeleteConfirm] = useState<{ id: string; name: string } | null>(null);
   const [hoveredCategoryId, setHoveredCategoryId] = useState<string | null>(null);
   const [showSaveCategoriesConfirm, setShowSaveCategoriesConfirm] = useState(false);
   const colorPickerRef = useRef<HTMLDivElement>(null);
   const editingRef = useRef<HTMLDivElement>(null);
 
-  const { categories, bins } = useLayoutStore(
+  const { categories } = useLayoutStore(
     useShallow((state) => ({
       categories: state.layout.categories,
-      bins: state.layout.bins,
     }))
   );
-  const { addCategory, updateCategory, deleteCategory, updateBin } = useMutations();
-
-  const { activeCategoryId, setActiveCategory, selectedBinIds } = useSelectionStore(
-    useShallow((state) => ({
-      activeCategoryId: state.activeCategoryId,
-      setActiveCategory: state.setActiveCategory,
-      selectedBinIds: state.selectedBinIds,
-    }))
-  );
-
+  const selectedBinIds = useSelectionStore((state) => state.selectedBinIds);
   const setHighlightedCategoryId = useViewStore((state) => state.setHighlightedCategoryId);
-
   const saveCategoriesAsDefaults = useSettingsStore((state) => state.saveCategoriesAsDefaults);
   const addToast = useToastStore((state) => state.addToast);
-  const { showErrorToast } = useResultToast();
 
-  // Calculate bin counts per category
-  const binCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const bin of bins) {
-      counts.set(bin.category, (counts.get(bin.category) || 0) + 1);
-    }
-    return counts;
-  }, [bins]);
+  const {
+    binCounts,
+    activeCategoryId,
+    canAddCategory,
+    editingId,
+    setEditingId,
+    selectCategory,
+    addCategory,
+    updateCategoryField,
+    deleteConfirm,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useCategoryManager({
+    onSelectionApplied: (firstBin, categoryName, count) => {
+      mlTracking.trackCategory(firstBin, categoryName, count);
+    },
+  });
 
   // Cleanup: Clear highlighted category when panel unmounts (e.g., sidebar collapses)
   useEffect(() => {
@@ -140,98 +131,7 @@ export function CategoriesPanel() {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [editingId, colorPickerId]);
-
-  // Handle category selection: applies to selected bins if any, always sets active category
-  const handleCategorySelect = (rawCategoryId: string, categoryName: string) => {
-    const catId: CategoryId = toCategoryId(rawCategoryId);
-    // Always set active category for new bins
-    setActiveCategory(catId);
-
-    // If bins are selected, update their categories
-    if (selectedBinIds.length > 0) {
-      const binsToUpdate = selectedBinIds
-        .map((id) => bins.find((b) => b.id === id))
-        .filter((bin): bin is (typeof bins)[number] => !!bin && bin.category !== catId);
-      if (binsToUpdate.length === 0) return;
-
-      const binCount = binsToUpdate.length;
-      batch(() => {
-        for (const bin of binsToUpdate) {
-          if (isErr(updateBin(bin.id, { category: catId }))) break;
-        }
-      });
-
-      mlTracking.trackCategory(binsToUpdate[0], categoryName, binCount);
-      addToast(t('toast.categoryChanged', { count: binCount, name: categoryName }), 'success');
-    }
-  };
-
-  const handleAddCategory = () => {
-    batch(() => {
-      const result = addCategory({ name: 'New Category', color: DEFAULT_CATEGORY_COLOR });
-      if (isOk(result)) {
-        setActiveCategory(result.value);
-        setEditingId(result.value);
-      }
-    });
-  };
-
-  const handleUpdateCategory = (id: string, field: 'name' | 'color', value: string) => {
-    const updates = {
-      [field]: field === 'name' ? value.slice(0, CONSTRAINTS.LABEL_MAX_LENGTH) : value,
-    };
-    const result = batch(() => updateCategory(toCategoryId(id), updates));
-    if (isErr(result)) {
-      showErrorToast(result.error);
-    }
-  };
-
-  const handleDeleteCategory = (id: string, name: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    const binCount = binCounts.get(id) || 0;
-
-    // Show helpful message if category is in use
-    if (binCount > 0) {
-      addToast(
-        `${binCount} bin${binCount > 1 ? 's' : ''} use "${name}". Reassign them first.`,
-        'error'
-      );
-      return;
-    }
-
-    // Show message if it's the last category
-    if (categories.length <= CONSTRAINTS.CATEGORIES_MIN) {
-      addToast(t('categories.cannotDeleteLast'), 'error');
-      return;
-    }
-
-    setDeleteConfirm({ id, name });
-  };
-
-  const confirmDeleteCategory = () => {
-    if (!deleteConfirm) return;
-    const { id } = deleteConfirm;
-    const result = batch(() => {
-      const deleteResult = deleteCategory(toCategoryId(id));
-      if (isOk(deleteResult)) {
-        // Access fresh state to avoid stale closure issues
-        const currentCategories = useLayoutStore.getState().layout.categories;
-        const currentActiveCategoryId = useSelectionStore.getState().activeCategoryId;
-        if (currentActiveCategoryId === id && currentCategories.length > 0) {
-          setActiveCategory(currentCategories[0].id);
-        }
-      }
-      return deleteResult;
-    });
-    if (isErr(result)) {
-      showErrorToast(result.error);
-    }
-    setEditingId(null);
-    setDeleteConfirm(null);
-  };
-
-  const canAddCategory = categories.length < CONSTRAINTS.CATEGORIES_MAX;
+  }, [editingId, colorPickerId, setEditingId]);
 
   const handleSaveCategoriesAsDefaults = () => {
     saveCategoriesAsDefaults(categories);
@@ -262,7 +162,7 @@ export function CategoriesPanel() {
       <IconButton
         size="sm"
         touchTarget={false}
-        onClick={handleAddCategory}
+        onClick={addCategory}
         disabled={!canAddCategory}
         className="w-7 h-7"
         title={t('categories.addCategory')}
@@ -289,7 +189,7 @@ export function CategoriesPanel() {
               <div
                 key={category.id}
                 className={`group relative flex items-center gap-2 p-2 rounded-md cursor-pointer min-w-0 transition-colors duration-150 ${isActive ? 'bg-[var(--bg-active)]' : 'hover:bg-surface-hover'}`}
-                onClick={() => handleCategorySelect(category.id, category.name)}
+                onClick={() => selectCategory(category.id, category.name)}
                 onMouseEnter={() => {
                   setHoveredCategoryId(category.id);
                   setHighlightedCategoryId(category.id);
@@ -310,7 +210,7 @@ export function CategoriesPanel() {
                     <input
                       type="text"
                       value={category.name}
-                      onChange={(e) => handleUpdateCategory(category.id, 'name', e.target.value)}
+                      onChange={(e) => updateCategoryField(category.id, 'name', e.target.value)}
                       onKeyDown={(e) => e.key === 'Enter' && setEditingId(null)}
                       className="input w-full py-1 px-2 text-sm"
                       // eslint-disable-next-line jsx-a11y/no-autofocus -- Intentional autofocus for modal/dialog UX
@@ -319,7 +219,7 @@ export function CategoriesPanel() {
                     />
                     <ColorPaletteGrid
                       selectedColor={category.color}
-                      onColorSelect={(color) => handleUpdateCategory(category.id, 'color', color)}
+                      onColorSelect={(color) => updateCategoryField(category.id, 'color', color)}
                       t={t}
                     />
                     {/* Footer row: hint + delete link */}
@@ -328,7 +228,10 @@ export function CategoriesPanel() {
                       {canDelete && (
                         <Button
                           variant="ghost"
-                          onClick={(e) => handleDeleteCategory(category.id, category.name, e)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            requestDelete(category.id, category.name);
+                          }}
                           className="text-content-tertiary hover:text-error px-0 py-0 hover:bg-transparent"
                           aria-label={t('categories.deleteCategory')}
                         >
@@ -383,7 +286,7 @@ export function CategoriesPanel() {
                         <ColorPaletteGrid
                           selectedColor={category.color}
                           onColorSelect={(color) => {
-                            handleUpdateCategory(category.id, 'color', color);
+                            updateCategoryField(category.id, 'color', color);
                             setColorPickerId(null);
                           }}
                           t={t}
@@ -396,7 +299,7 @@ export function CategoriesPanel() {
                       className="flex-1 min-w-0 text-left justify-start px-0 py-0 hover:bg-transparent"
                       onClick={(e) => {
                         e.stopPropagation();
-                        handleCategorySelect(category.id, category.name);
+                        selectCategory(category.id, category.name);
                       }}
                       onDoubleClick={(e) => {
                         e.stopPropagation();
@@ -455,7 +358,10 @@ export function CategoriesPanel() {
                         variant="dangerGhost"
                         size="sm"
                         touchTarget={false}
-                        onClick={(e) => handleDeleteCategory(category.id, category.name, e)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          requestDelete(category.id, category.name);
+                        }}
                         className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 -my-1 text-content-tertiary flex-shrink-0"
                         title={t('categories.deleteCategory')}
                         aria-label={t('categories.deleteCategoryAria', { name: category.name })}
@@ -488,8 +394,8 @@ export function CategoriesPanel() {
         message={t('categories.confirmDelete.message', { name: deleteConfirm?.name || '' })}
         confirmText={t('categories.confirmDelete.confirm')}
         destructive
-        onConfirm={confirmDeleteCategory}
-        onCancel={() => setDeleteConfirm(null)}
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
       />
 
       <ConfirmDialog

--- a/src/features/categories/hooks/useCategoryManager.test.ts
+++ b/src/features/categories/hooks/useCategoryManager.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCategoryManager } from './useCategoryManager';
+import { useLayoutStore } from '@/core/store/layout';
+import { useSelectionStore } from '@/core/store/selection';
+import { useToastStore } from '@/core/store/toast';
+import { resetAllStores, createTestBin } from '@/test/testUtils';
+import { ok } from '@/core/result';
+import { categoryId } from '@/core/types';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+const mutations = vi.hoisted(() => ({
+  addCategory: vi.fn(),
+  updateCategory: vi.fn(),
+  deleteCategory: vi.fn(),
+  updateBin: vi.fn(),
+}));
+
+vi.mock('@/shared/contexts', () => ({
+  useMutations: () => mutations,
+}));
+
+describe('useCategoryManager', () => {
+  beforeEach(() => {
+    resetAllStores();
+    vi.clearAllMocks();
+    mutations.addCategory.mockReturnValue(ok(categoryId('new-cat')));
+    mutations.updateCategory.mockReturnValue(ok(undefined));
+    mutations.deleteCategory.mockReturnValue(ok(undefined));
+    mutations.updateBin.mockReturnValue(ok(undefined));
+  });
+
+  function firstCategoryId(): string {
+    return useLayoutStore.getState().layout.categories[0].id;
+  }
+
+  it('selecting with no bins selected only activates the category', () => {
+    const onAfterSelect = vi.fn();
+    const { result } = renderHook(() => useCategoryManager({ onAfterSelect }));
+    const catId = firstCategoryId();
+    act(() => {
+      result.current.selectCategory(catId, 'Tools');
+    });
+    expect(useSelectionStore.getState().activeCategoryId).toBe(catId);
+    expect(mutations.updateBin).not.toHaveBeenCalled();
+    expect(onAfterSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('reassigns only bins not already in the category and reports the changed count', () => {
+    const catId = firstCategoryId();
+    const inCategory = createTestBin({ id: 'bin-1', category: catId });
+    const other = createTestBin({ id: 'bin-2' });
+    const state = useLayoutStore.getState();
+    useLayoutStore.setState({ layout: { ...state.layout, bins: [inCategory, other] } });
+    useSelectionStore.getState().setSelectedBins(['bin-1', 'bin-2']);
+
+    const onSelectionApplied = vi.fn();
+    const { result } = renderHook(() => useCategoryManager({ onSelectionApplied }));
+    act(() => {
+      result.current.selectCategory(catId, 'Tools');
+    });
+
+    expect(mutations.updateBin).toHaveBeenCalledTimes(1);
+    expect(mutations.updateBin).toHaveBeenCalledWith('bin-2', { category: catId });
+    expect(onSelectionApplied).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'bin-2' }),
+      'Tools',
+      1
+    );
+  });
+
+  it('does not fire onSelectionApplied when every selected bin already matches', () => {
+    const catId = firstCategoryId();
+    const bin = createTestBin({ id: 'bin-1', category: catId });
+    const state = useLayoutStore.getState();
+    useLayoutStore.setState({ layout: { ...state.layout, bins: [bin] } });
+    useSelectionStore.getState().setSelectedBins(['bin-1']);
+
+    const onSelectionApplied = vi.fn();
+    const { result } = renderHook(() => useCategoryManager({ onSelectionApplied }));
+    act(() => {
+      result.current.selectCategory(catId, 'Tools');
+    });
+    expect(mutations.updateBin).not.toHaveBeenCalled();
+    expect(onSelectionApplied).not.toHaveBeenCalled();
+  });
+
+  it('addCategory activates the new category and opens it for editing', () => {
+    const { result } = renderHook(() => useCategoryManager());
+    act(() => {
+      result.current.addCategory();
+    });
+    expect(useSelectionStore.getState().activeCategoryId).toBe(categoryId('new-cat'));
+    expect(result.current.editingId).toBe(categoryId('new-cat'));
+  });
+
+  it('requestDelete toasts instead of opening the dialog when the category is in use', () => {
+    const catId = firstCategoryId();
+    const state = useLayoutStore.getState();
+    useLayoutStore.setState({
+      layout: { ...state.layout, bins: [createTestBin({ category: catId })] },
+    });
+    const { result } = renderHook(() => useCategoryManager());
+    act(() => {
+      result.current.requestDelete(catId, 'Tools');
+    });
+    expect(result.current.deleteConfirm).toBeNull();
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts.some((toast) => toast.message.startsWith('categories.deleteInUse'))).toBe(true);
+  });
+
+  it('confirmDelete deletes and reassigns the active category', () => {
+    const categories = useLayoutStore.getState().layout.categories;
+    if (categories.length < 2) {
+      const state = useLayoutStore.getState();
+      useLayoutStore.setState({
+        layout: {
+          ...state.layout,
+          categories: [
+            ...state.layout.categories,
+            { id: categoryId('cat-b'), name: 'B', color: '#fff' },
+          ],
+        },
+      });
+    }
+    const target = useLayoutStore.getState().layout.categories[1].id;
+    useSelectionStore.getState().setActiveCategory(target);
+
+    const { result } = renderHook(() => useCategoryManager());
+    act(() => {
+      result.current.requestDelete(target, 'B');
+    });
+    expect(result.current.deleteConfirm?.id).toBe(target);
+    act(() => {
+      result.current.confirmDelete();
+    });
+    expect(mutations.deleteCategory).toHaveBeenCalledWith(target);
+    expect(result.current.deleteConfirm).toBeNull();
+  });
+});

--- a/src/features/categories/hooks/useCategoryManager.ts
+++ b/src/features/categories/hooks/useCategoryManager.ts
@@ -1,0 +1,196 @@
+/**
+ * Category CRUD + selection state shared by the desktop CategoriesPanel and
+ * the mobile MobileCategoriesPanel.
+ *
+ * Selecting a category always sets it active for new bins; when bins are
+ * selected it also reassigns them — skipping bins already in the category and
+ * aborting the batch on the first mutation error. `onSelectionApplied` fires
+ * only when bins actually changed (desktop hangs ML tracking off it);
+ * `onAfterSelect` always fires after a selection (mobile closes its panel).
+ */
+
+import { useMemo, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useLayoutStore } from '@/core/store/layout';
+import { useSelectionStore } from '@/core/store/selection';
+import { useMutations } from '@/shared/contexts';
+import { useToastStore } from '@/core/store/toast';
+import { useResultToast } from '@/shared/hooks';
+import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR } from '@/core/constants';
+import { isOk, isErr } from '@/core/result';
+import { categoryId as toCategoryId } from '@/core/types';
+import type { Bin, Category, CategoryId } from '@/core/types';
+import { useTranslation } from '@/i18n';
+import { batch } from '@/core/cqrs';
+
+export interface CategoryManager {
+  categories: Category[];
+  binCounts: Map<string, number>;
+  activeCategoryId: CategoryId;
+  selectedBinIds: string[];
+  canAddCategory: boolean;
+  editingId: CategoryId | null;
+  setEditingId: (id: CategoryId | null) => void;
+  /** Sets the category active and reassigns any selected bins to it. */
+  selectCategory: (id: string, name: string) => void;
+  /** Adds a category, activates it, and opens it for editing. */
+  addCategory: () => void;
+  updateCategoryField: (id: string, field: 'name' | 'color', value: string) => void;
+  deleteConfirm: { id: CategoryId; name: string } | null;
+  /** Opens the delete confirm; toasts instead when in use or last category. */
+  requestDelete: (id: string, name: string) => void;
+  confirmDelete: () => void;
+  cancelDelete: () => void;
+}
+
+export function useCategoryManager(options?: {
+  onSelectionApplied?: (firstBin: Bin, categoryName: string, count: number) => void;
+  onAfterSelect?: () => void;
+}): CategoryManager {
+  const t = useTranslation();
+  const onSelectionApplied = options?.onSelectionApplied;
+  const onAfterSelect = options?.onAfterSelect;
+  const [editingId, setEditingId] = useState<CategoryId | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<{ id: CategoryId; name: string } | null>(null);
+
+  const { categories, bins } = useLayoutStore(
+    useShallow((state) => ({
+      categories: state.layout.categories,
+      bins: state.layout.bins,
+    }))
+  );
+  const {
+    addCategory: addCategoryMutation,
+    updateCategory,
+    deleteCategory,
+    updateBin,
+  } = useMutations();
+
+  const { activeCategoryId, setActiveCategory, selectedBinIds } = useSelectionStore(
+    useShallow((state) => ({
+      activeCategoryId: state.activeCategoryId,
+      setActiveCategory: state.setActiveCategory,
+      selectedBinIds: state.selectedBinIds,
+    }))
+  );
+
+  const addToast = useToastStore((state) => state.addToast);
+  const { showErrorToast } = useResultToast();
+
+  const binCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const bin of bins) {
+      counts.set(bin.category, (counts.get(bin.category) || 0) + 1);
+    }
+    return counts;
+  }, [bins]);
+
+  const selectCategory = (rawCategoryId: string, categoryName: string) => {
+    const catId: CategoryId = toCategoryId(rawCategoryId);
+    // Always set active category for new bins
+    setActiveCategory(catId);
+
+    // If bins are selected, update their categories
+    if (selectedBinIds.length > 0) {
+      const binsToUpdate = selectedBinIds
+        .map((id) => bins.find((b) => b.id === id))
+        .filter((bin): bin is (typeof bins)[number] => !!bin && bin.category !== catId);
+      if (binsToUpdate.length > 0) {
+        const binCount = binsToUpdate.length;
+        batch(() => {
+          for (const bin of binsToUpdate) {
+            if (isErr(updateBin(bin.id, { category: catId }))) break;
+          }
+        });
+
+        onSelectionApplied?.(binsToUpdate[0], categoryName, binCount);
+        addToast(t('toast.categoryChanged', { count: binCount, name: categoryName }), 'success');
+      }
+    }
+
+    onAfterSelect?.();
+  };
+
+  const addCategory = () => {
+    batch(() => {
+      const result = addCategoryMutation({ name: 'New Category', color: DEFAULT_CATEGORY_COLOR });
+      if (isOk(result)) {
+        setActiveCategory(result.value);
+        setEditingId(result.value);
+      }
+    });
+  };
+
+  const updateCategoryField = (id: string, field: 'name' | 'color', value: string) => {
+    const updates = {
+      [field]: field === 'name' ? value.slice(0, CONSTRAINTS.LABEL_MAX_LENGTH) : value,
+    };
+    const result = batch(() => updateCategory(toCategoryId(id), updates));
+    if (isErr(result)) {
+      showErrorToast(result.error);
+    }
+  };
+
+  const requestDelete = (id: string, name: string) => {
+    const binCount = binCounts.get(id) || 0;
+
+    // Show helpful message if category is in use
+    if (binCount > 0) {
+      addToast(t('categories.deleteInUse', { count: binCount, name }), 'error');
+      return;
+    }
+
+    // Show message if it's the last category
+    if (categories.length <= CONSTRAINTS.CATEGORIES_MIN) {
+      addToast(t('categories.cannotDeleteLast'), 'error');
+      return;
+    }
+
+    setDeleteConfirm({ id: toCategoryId(id), name });
+  };
+
+  const confirmDelete = () => {
+    if (!deleteConfirm) return;
+    const { id } = deleteConfirm;
+    const result = batch(() => {
+      const deleteResult = deleteCategory(toCategoryId(id));
+      if (isOk(deleteResult)) {
+        // Access fresh state to avoid stale closure issues
+        const currentCategories = useLayoutStore.getState().layout.categories;
+        const currentActiveCategoryId = useSelectionStore.getState().activeCategoryId;
+        if (currentActiveCategoryId === id && currentCategories.length > 0) {
+          setActiveCategory(currentCategories[0].id);
+        }
+      }
+      return deleteResult;
+    });
+    if (isErr(result)) {
+      showErrorToast(result.error);
+    }
+    setEditingId(null);
+    setDeleteConfirm(null);
+  };
+
+  const cancelDelete = () => {
+    setDeleteConfirm(null);
+  };
+
+  const canAddCategory = categories.length < CONSTRAINTS.CATEGORIES_MAX;
+
+  return {
+    categories,
+    binCounts,
+    activeCategoryId,
+    selectedBinIds,
+    canAddCategory,
+    editingId,
+    setEditingId,
+    selectCategory,
+    addCategory,
+    updateCategoryField,
+    deleteConfirm,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  };
+}

--- a/src/features/categories/index.ts
+++ b/src/features/categories/index.ts
@@ -1,3 +1,5 @@
 // Barrel export for categories feature
 export * from './components';
 export { helpEntries } from './helpEntries';
+export { useCategoryManager } from './hooks/useCategoryManager';
+export type { CategoryManager } from './hooks/useCategoryManager';

--- a/src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.tsx
+++ b/src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.tsx
@@ -1,128 +1,43 @@
-import { useState, useMemo } from 'react';
-import { useShallow } from 'zustand/react/shallow';
-import { useLayoutStore } from '@/core/store/layout';
-import { useSelectionStore, useMobileStore } from '@/core/store';
-import { useMutations } from '@/shared/contexts';
-import { useToastStore } from '@/core/store/toast';
+import { useSelectionStore } from '@/core/store/selection';
+import { useMobileStore } from '@/core/store';
 import type { CategoryId } from '@/core/types';
-import { CONSTRAINTS, DEFAULT_CATEGORY_COLOR, CATEGORY_COLOR_PALETTE } from '@/core/constants';
+import { CONSTRAINTS, CATEGORY_COLOR_PALETTE } from '@/core/constants';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog';
-import { isOk } from '@/core/result';
 import { Button, IconButton, PlusIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
-import { batch } from '@/core/cqrs';
+import { useCategoryManager } from '@/features/categories/hooks/useCategoryManager';
 
 /**
  * Mobile-optimized categories panel with large touch targets.
  */
 export function MobileCategoriesPanel() {
   const t = useTranslation();
-  const [editingId, setEditingId] = useState<CategoryId | null>(null);
-  const [deleteConfirm, setDeleteConfirm] = useState<{ id: CategoryId; name: string } | null>(null);
-
-  const { categories, bins } = useLayoutStore(
-    useShallow((state) => ({
-      categories: state.layout.categories,
-      bins: state.layout.bins,
-    }))
-  );
-  const { addCategory, updateCategory, deleteCategory, updateBin } = useMutations();
-
-  const { activeCategoryId, setActiveCategory, selectedBinIds } = useSelectionStore(
-    useShallow((state) => ({
-      activeCategoryId: state.activeCategoryId,
-      setActiveCategory: state.setActiveCategory,
-      selectedBinIds: state.selectedBinIds,
-    }))
-  );
   const closeMobilePanel = useMobileStore((state) => state.closeMobilePanel);
+  const selectedBinIds = useSelectionStore((state) => state.selectedBinIds);
 
-  const addToast = useToastStore((state) => state.addToast);
-
-  // Calculate bin counts per category
-  const binCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const bin of bins) {
-      counts.set(bin.category, (counts.get(bin.category) || 0) + 1);
-    }
-    return counts;
-  }, [bins]);
-
-  const handleSelectCategory = (id: CategoryId, name: string) => {
-    // Always set active category for new bins
-    setActiveCategory(id);
-
-    // If bins are selected, update their categories
-    if (selectedBinIds.length > 0) {
-      batch(() => {
-        for (const binId of selectedBinIds) {
-          updateBin(binId, { category: id });
-        }
-      });
-      const binCount = selectedBinIds.length;
-      addToast(t('toast.categoryChanged', { count: binCount, name }), 'success');
-    }
-
-    closeMobilePanel();
-  };
-
-  const handleAddCategory = () => {
-    batch(() => {
-      const result = addCategory({ name: 'New Category', color: DEFAULT_CATEGORY_COLOR });
-      if (isOk(result)) {
-        setActiveCategory(result.value);
-        setEditingId(result.value);
-      }
-    });
-  };
+  const {
+    categories,
+    binCounts,
+    activeCategoryId,
+    canAddCategory,
+    editingId,
+    setEditingId,
+    selectCategory,
+    addCategory,
+    updateCategoryField,
+    deleteConfirm,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useCategoryManager({ onAfterSelect: closeMobilePanel });
 
   const handleUpdateColor = (id: CategoryId, color: string) => {
-    batch(() => {
-      updateCategory(id, { color });
-    });
+    updateCategoryField(id, 'color', color);
   };
 
   const handleUpdateName = (id: CategoryId, name: string) => {
-    batch(() => {
-      updateCategory(id, { name: name.slice(0, CONSTRAINTS.LABEL_MAX_LENGTH) });
-    });
+    updateCategoryField(id, 'name', name);
   };
-
-  const handleDelete = (id: CategoryId, name: string) => {
-    const binCount = binCounts.get(id) || 0;
-
-    // Show helpful message if category is in use
-    if (binCount > 0) {
-      addToast(t('categories.deleteInUse', { count: binCount, name }), 'error');
-      return;
-    }
-
-    // Show message if it's the last category
-    if (categories.length <= CONSTRAINTS.CATEGORIES_MIN) {
-      addToast(t('categories.cannotDeleteLast'), 'error');
-      return;
-    }
-
-    setDeleteConfirm({ id, name });
-  };
-
-  const confirmDelete = () => {
-    if (!deleteConfirm) return;
-    const { id } = deleteConfirm;
-    batch(() => {
-      deleteCategory(id);
-      // Access fresh state to avoid stale closure issues
-      const currentCategories = useLayoutStore.getState().layout.categories;
-      const currentActiveCategoryId = useSelectionStore.getState().activeCategoryId;
-      if (currentActiveCategoryId === id && currentCategories.length > 0) {
-        setActiveCategory(currentCategories[0].id);
-      }
-    });
-    setEditingId(null);
-    setDeleteConfirm(null);
-  };
-
-  const canAddCategory = categories.length < CONSTRAINTS.CATEGORIES_MAX;
 
   return (
     <div className="pb-4">
@@ -186,7 +101,7 @@ export function MobileCategoriesPanel() {
                     <Button
                       variant={canDelete ? 'danger' : 'secondary'}
                       fullWidth
-                      onClick={() => handleDelete(category.id, category.name)}
+                      onClick={() => requestDelete(category.id, category.name)}
                       className={`flex-1 ${canDelete ? '' : 'opacity-50'}`}
                     >
                       {t('common.delete')}
@@ -207,7 +122,7 @@ export function MobileCategoriesPanel() {
                   variant="ghost"
                   fullWidth
                   className="p-4 flex items-center gap-3 justify-start rounded-none hover:bg-transparent"
-                  onClick={() => handleSelectCategory(category.id, category.name)}
+                  onClick={() => selectCategory(category.id, category.name)}
                   aria-label={
                     selectedBinIds.length > 0
                       ? t('mobile.categories.applyToSelected', {
@@ -263,7 +178,7 @@ export function MobileCategoriesPanel() {
       <Button
         variant="primary"
         fullWidth
-        onClick={handleAddCategory}
+        onClick={addCategory}
         disabled={!canAddCategory}
         className="mt-4"
         leftIcon={<PlusIcon />}
@@ -278,7 +193,7 @@ export function MobileCategoriesPanel() {
         confirmText={t('categories.confirmDelete.confirm')}
         destructive
         onConfirm={confirmDelete}
-        onCancel={() => setDeleteConfirm(null)}
+        onCancel={cancelDelete}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Third and final desktop↔mobile dedup cluster (follows #2763, #2764). `CategoriesPanel` and `MobileCategoriesPanel` duplicated the category CRUD + selection logic: select-and-reassign-selected-bins, add-and-open-for-editing, field updates, and the guarded delete with fresh-state active-category reassignment.

Both now consume **`useCategoryManager()`** from `features/categories/hooks`:

- ML tracking rides `onSelectionApplied` (fires only when bins actually changed — desktop-only); mobile's close-panel rides `onAfterSelect` (always fires).
- Mobile previously reassigned **all** selected bins unconditionally and counted them all in the toast; it now gets desktop's filtered logic (skip bins already in the category, abort the batch on the first mutation error, toast the real changed count).
- Desktop's category-in-use delete message was a **hardcoded English string** (`"N bins use X. Reassign them first."`) — an i18n gap the `i18next` lint rule can't see inside template literals. Both surfaces now use the existing `categories.deleteInUse` key.
- Mobile's field updates previously swallowed mutation errors; both now surface them via the shared error toast.

Deliberate behavior changes are exactly the four bullets above; everything else moved verbatim. Desktop keeps its hover highlight, click-outside/Escape handling, color picker, and save-as-defaults; mobile keeps its touch-target JSX.

## Testing

- New `useCategoryManager.test.ts`: activate-only selection, filtered reassignment with changed-count reporting, no-op when all bins already match, add-and-edit flow, in-use delete guard toast, delete + active reassignment
- All 27 tests across `features/categories` + `MobileCategoriesPanel` pass
- `pnpm run typecheck`, eslint, knip clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shared category management logic between desktop and mobile by introducing a single hook for category selection, CRUD, and guarded deletes. This removes duplication, unifies behavior, and adds targeted tests.

- **Refactors**
  - Added `useCategoryManager()` and wired it into `CategoriesPanel` and `MobileCategoriesPanel`.
  - Centralized selection, add-and-edit, field updates, and delete-with-active reassignment; exported the hook and added unit tests.

- **Bug Fixes**
  - Mobile now reassigns only bins that change and toasts the actual changed count; aborts the batch on first mutation error.
  - Desktop’s “category in use” delete message now uses the `categories.deleteInUse` i18n key.
  - Both surfaces show mutation errors via the shared error toast.
  - ML tracking hooks into `onSelectionApplied`; mobile always closes via `onAfterSelect`.

<sup>Written for commit 59238a3906bd4583f56664bc5f8f1b8b63275207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

