### PR TITLE
test(api): cover share/[id] and ml-telemetry handlers

### DIFF
--- a/api/ml-telemetry.test.ts
+++ b/api/ml-telemetry.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the ML telemetry ingest endpoint's degradation contract:
+ * telemetry must NEVER fail the client — without Redis it discards events
+ * with a 200, and only genuine rate limiting produces a non-200. The
+ * aggregation/validation internals are covered by the api/lib/mlTelemetry
+ * tests; this file pins the handler's entry behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+function createResponse() {
+  const res = {
+    _status: 0,
+    _body: null as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(body: unknown) {
+      res._body = body;
+      return res;
+    },
+    setHeader() {
+      return res;
+    },
+    end() {
+      return res;
+    },
+  };
+  return res as unknown as VercelResponse & { _status: number; _body: unknown };
+}
+
+async function handle(method: string, body: unknown = []) {
+  const res = createResponse();
+  const mod = await import('./ml-telemetry.js');
+  await mod.default({ method, headers: {}, body } as unknown as VercelRequest, res);
+  return res;
+}
+
+describe('ml-telemetry', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.REDIS_URL;
+    delete process.env.VERCEL_ENV;
+  });
+
+  afterEach(() => {
+    delete process.env.REDIS_URL;
+  });
+
+  it('405s non-POST methods', async () => {
+    const res = await handle('GET');
+    expect(res._status).toBe(405);
+  });
+
+  it('degrades to 200 processed:0 when Redis is unconfigured (never fails the client)', async () => {
+    const res = await handle('POST', [{ v: 1 }]);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ ok: true, processed: 0 });
+  });
+
+  it('degrades the same way in production (discard, not error)', async () => {
+    process.env.VERCEL_ENV = 'production';
+    const res = await handle('POST', [{ v: 1 }]);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ ok: true, processed: 0 });
+  });
+});

--- a/api/share/[id].test.ts
+++ b/api/share/[id].test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for share GET/PUT/DELETE. The load-bearing invariants:
+ *  - GET never leaks sensitive metadata (delete-token hash, report count,
+ *    legacy lastAccessedAt) and never blocks on the lastAccessed write
+ *  - PUT/DELETE require the delete token, verified against the REAL
+ *    hashToken/timingSafeCompare implementations (Redis hash first, blob
+ *    fallback for pre-migration shares)
+ *  - rewrites drop the legacy lastAccessedAt field and preserve createdAt
+ *  - DELETE accepts the token from header or body and cleans up all three
+ *    Redis keys alongside the blob
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { hashToken } from '../lib/shared.js';
+
+const mocks = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  getRedis: vi.fn(),
+  put: vi.fn(),
+  head: vi.fn(),
+  del: vi.fn(),
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+  redisDel: vi.fn(),
+  validateShareLayout: vi.fn(),
+  isValidationError: vi.fn(),
+  filterLayoutContent: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('../lib/rateLimit.js', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getRedis: mocks.getRedis,
+  getClientIP: () => '203.0.113.1',
+}));
+
+vi.mock('@vercel/blob', () => ({
+  put: mocks.put,
+  head: mocks.head,
+  del: mocks.del,
+}));
+
+vi.mock('../lib/validation.js', () => ({
+  validateShareLayout: mocks.validateShareLayout,
+  isValidationError: mocks.isValidationError,
+}));
+
+vi.mock('../lib/contentFilter.js', () => ({
+  filterLayoutContent: mocks.filterLayoutContent,
+}));
+
+function createResponse() {
+  const res = {
+    _status: 0,
+    _body: null as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(body: unknown) {
+      res._body = body;
+      return res;
+    },
+    setHeader() {
+      return res;
+    },
+    end() {
+      return res;
+    },
+  };
+  return res as unknown as VercelResponse & { _status: number; _body: unknown };
+}
+
+const VALID_ID = 'abc123DEF456';
+const TOKEN = 'correct-token';
+
+function shareBlob(metadata: Record<string, unknown> = {}) {
+  return {
+    layout: { name: 'Drawer' },
+    metadata: {
+      createdAt: '2026-01-01T00:00:00.000Z',
+      lastUpdatedAt: '2026-01-02T00:00:00.000Z',
+      permission: 'view',
+      authorName: 'Jo',
+      ...metadata,
+    },
+  };
+}
+
+function primeBlobFetch(data: unknown) {
+  mocks.head.mockResolvedValue({ url: 'https://blob.example/shares/x.json' });
+  mocks.fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(data) });
+}
+
+async function handle(
+  method: string,
+  over: { id?: unknown; body?: unknown; headers?: Record<string, string> } = {}
+) {
+  const res = createResponse();
+  const mod = await import('./[id].js');
+  await mod.default(
+    {
+      method,
+      query: { id: over.id ?? VALID_ID },
+      headers: over.headers ?? {},
+      body: over.body ?? {},
+    } as unknown as VercelRequest,
+    res
+  );
+  return res;
+}
+
+describe('share/[id]', () => {
+  let correctHash: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.TOKEN_SALT = 'test-salt';
+    correctHash = await hashToken(TOKEN);
+    vi.stubGlobal('fetch', mocks.fetch);
+    mocks.checkRateLimit.mockResolvedValue({ allowed: true });
+    mocks.getRedis.mockReturnValue({
+      get: mocks.redisGet,
+      set: mocks.redisSet,
+      del: mocks.redisDel,
+    });
+    mocks.redisGet.mockResolvedValue(null);
+    mocks.redisSet.mockResolvedValue('OK');
+    mocks.redisDel.mockResolvedValue(1);
+    mocks.put.mockResolvedValue({ url: 'blob://ok' });
+    mocks.del.mockResolvedValue(undefined);
+    mocks.validateShareLayout.mockReturnValue({ layout: { name: 'Updated' } });
+    mocks.isValidationError.mockReturnValue(false);
+    mocks.filterLayoutContent.mockReturnValue({ passed: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.TOKEN_SALT;
+  });
+
+  it('400s on a malformed id for every method', async () => {
+    const res = await handle('GET', { id: '../evil' });
+    expect(res._status).toBe(400);
+  });
+
+  it('405s unsupported methods', async () => {
+    const res = await handle('PATCH');
+    expect(res._status).toBe(405);
+  });
+
+  describe('GET', () => {
+    it('404s when the blob is missing', async () => {
+      mocks.head.mockRejectedValue(new Error('gone'));
+      const res = await handle('GET');
+      expect(res._status).toBe(404);
+    });
+
+    it('returns the layout but strips sensitive metadata fields', async () => {
+      primeBlobFetch(
+        shareBlob({
+          deleteTokenHash: 'secret-hash',
+          reportCount: 3,
+          lastAccessedAt: '2026-01-03T00:00:00.000Z',
+        })
+      );
+      const res = await handle('GET');
+      expect(res._status).toBe(200);
+      const body = res._body as { layout: unknown; metadata: Record<string, unknown> };
+      expect(body.layout).toEqual({ name: 'Drawer' });
+      expect(body.metadata.deleteTokenHash).toBeUndefined();
+      expect(body.metadata.reportCount).toBeUndefined();
+      expect(body.metadata.lastAccessedAt).toBeUndefined();
+      expect(body.metadata.permission).toBe('view');
+    });
+
+    it('records lastAccessedAt in Redis fire-and-forget (a failure never breaks the GET)', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisSet.mockRejectedValue(new Error('redis down'));
+      const res = await handle('GET');
+      expect(res._status).toBe(200);
+      expect(mocks.redisSet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('PUT', () => {
+    it('401s without a delete token', async () => {
+      const res = await handle('PUT', { body: {} });
+      expect(res._status).toBe(401);
+    });
+
+    it('401s on a wrong token via the real constant-time comparison', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('PUT', { body: { deleteToken: 'wrong-token' } });
+      expect(res._status).toBe(401);
+      expect(mocks.put).not.toHaveBeenCalled();
+    });
+
+    it('accepts the correct token from the Redis-stored hash', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('PUT', { body: { deleteToken: TOKEN, permission: 'edit' } });
+      expect(res._status).toBe(200);
+      expect((res._body as { permission: string }).permission).toBe('edit');
+    });
+
+    it('falls back to the blob hash for pre-migration shares', async () => {
+      primeBlobFetch(shareBlob({ deleteTokenHash: correctHash }));
+      mocks.redisGet.mockResolvedValue(null);
+      const res = await handle('PUT', { body: { deleteToken: TOKEN } });
+      expect(res._status).toBe(200);
+    });
+
+    it('404s when no hash exists anywhere', async () => {
+      primeBlobFetch(shareBlob());
+      const res = await handle('PUT', { body: { deleteToken: TOKEN } });
+      expect(res._status).toBe(404);
+    });
+
+    it('rejects an invalid permission value', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('PUT', { body: { deleteToken: TOKEN, permission: 'admin' } });
+      expect(res._status).toBe(400);
+    });
+
+    it('permission-only updates rewrite the blob without validating a layout', async () => {
+      primeBlobFetch(shareBlob({ lastAccessedAt: 'stale', deleteTokenHash: correctHash }));
+      const res = await handle('PUT', { body: { deleteToken: TOKEN, permission: 'edit' } });
+      expect(res._status).toBe(200);
+      expect(mocks.validateShareLayout).not.toHaveBeenCalled();
+      const written = JSON.parse(mocks.put.mock.calls[0][1] as string) as {
+        metadata: Record<string, unknown>;
+      };
+      // Legacy lastAccessedAt must be dropped on rewrite; createdAt preserved.
+      expect(written.metadata.lastAccessedAt).toBeUndefined();
+      expect(written.metadata.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(written.metadata.permission).toBe('edit');
+    });
+
+    it('full updates validate and content-filter the new layout', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      mocks.filterLayoutContent.mockReturnValue({ passed: false, reason: 'profanity' });
+      const res = await handle('PUT', {
+        body: { deleteToken: TOKEN, layout: { name: 'bad' } },
+      });
+      expect(res._status).toBe(400);
+      expect((res._body as { code: string }).code).toBe('CONTENT_BLOCKED');
+      expect(mocks.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE', () => {
+    it('accepts the token from the x-delete-token header', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('DELETE', { headers: { 'x-delete-token': TOKEN } });
+      expect(res._status).toBe(200);
+      expect(mocks.del).toHaveBeenCalledWith(`shares/${VALID_ID}.json`);
+      // All three Redis keys cleaned up alongside the blob.
+      expect(mocks.redisDel).toHaveBeenCalledTimes(1);
+      expect(mocks.redisDel.mock.calls[0]).toHaveLength(3);
+    });
+
+    it('accepts the token from the body', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('DELETE', { body: { deleteToken: TOKEN } });
+      expect(res._status).toBe(200);
+    });
+
+    it('401s on a wrong token and leaves the blob alone', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('DELETE', { headers: { 'x-delete-token': 'wrong' } });
+      expect(res._status).toBe(401);
+      expect(mocks.del).not.toHaveBeenCalled();
+    });
+
+    it('401s with no token at all', async () => {
+      const res = await handle('DELETE');
+      expect(res._status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Completes the API route-handler coverage started in #2762 — these were the last two handlers with zero direct tests.

**`share/[id].ts`** (GET/PUT/DELETE — the most security-sensitive uncovered surface), 17 tests:
- GET strips sensitive metadata from responses (`deleteTokenHash`, `reportCount`, legacy `lastAccessedAt`) and treats the lastAccessed Redis write as fire-and-forget — a Redis failure never breaks the read
- PUT/DELETE token verification runs the **real** `hashToken` + `timingSafeCompare` (with `TOKEN_SALT` set in the test) rather than mocking the crypto: wrong tokens 401 through the actual constant-time path, and the Redis-first / blob-fallback hash lookup is exercised both ways, plus the no-hash-anywhere 404
- Rewrites drop the legacy `lastAccessedAt` field and preserve `createdAt`; permission-only updates skip layout validation entirely
- DELETE accepts the token from the `x-delete-token` header or the body, and cleans up the blob plus all three Redis keys

**`ml-telemetry.ts`**, 3 tests pinning its degradation contract: telemetry must never fail the client — without Redis it discards events with `200 processed:0`, including in production. The aggregation/validation internals stay covered by the existing `api/lib/mlTelemetry` tests.

## Testing

- 20 new tests; full api suite now 1042 tests, all green
- `pnpm run typecheck` and eslint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add direct tests for `api/share/[id]` (GET/PUT/DELETE) and `api/ml-telemetry` to lock down security and resilience, closing the last untested API handlers.
Tests cover redacting sensitive metadata, non-blocking last-access writes, real delete-token verification with Redis-first and blob fallback, permission-only updates without layout validation, full cleanup on delete (blob + Redis keys), and telemetry always returning 200 with processed:0 when Redis is absent (including production).

<sup>Written for commit 287acf528228e473d761128e06695e19ef15ab0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

