### PR TITLE
refactor(api): extract the shared sync resource handler skeleton

### DIFF
--- a/api/ml-telemetry.test.ts
+++ b/api/ml-telemetry.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the ML telemetry ingest endpoint's degradation contract:
+ * telemetry must NEVER fail the client — without Redis it discards events
+ * with a 200, and only genuine rate limiting produces a non-200. The
+ * aggregation/validation internals are covered by the api/lib/mlTelemetry
+ * tests; this file pins the handler's entry behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+function createResponse() {
+  const res = {
+    _status: 0,
+    _body: null as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(body: unknown) {
+      res._body = body;
+      return res;
+    },
+    setHeader() {
+      return res;
+    },
+    end() {
+      return res;
+    },
+  };
+  return res as unknown as VercelResponse & { _status: number; _body: unknown };
+}
+
+async function handle(method: string, body: unknown = []) {
+  const res = createResponse();
+  const mod = await import('./ml-telemetry.js');
+  await mod.default({ method, headers: {}, body } as unknown as VercelRequest, res);
+  return res;
+}
+
+describe('ml-telemetry', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.REDIS_URL;
+    delete process.env.VERCEL_ENV;
+  });
+
+  afterEach(() => {
+    delete process.env.REDIS_URL;
+  });
+
+  it('405s non-POST methods', async () => {
+    const res = await handle('GET');
+    expect(res._status).toBe(405);
+  });
+
+  it('degrades to 200 processed:0 when Redis is unconfigured (never fails the client)', async () => {
+    const res = await handle('POST', [{ v: 1 }]);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ ok: true, processed: 0 });
+  });
+
+  it('degrades the same way in production (discard, not error)', async () => {
+    process.env.VERCEL_ENV = 'production';
+    const res = await handle('POST', [{ v: 1 }]);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ ok: true, processed: 0 });
+  });
+});

--- a/api/share/[id].test.ts
+++ b/api/share/[id].test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for share GET/PUT/DELETE. The load-bearing invariants:
+ *  - GET never leaks sensitive metadata (delete-token hash, report count,
+ *    legacy lastAccessedAt) and never blocks on the lastAccessed write
+ *  - PUT/DELETE require the delete token, verified against the REAL
+ *    hashToken/timingSafeCompare implementations (Redis hash first, blob
+ *    fallback for pre-migration shares)
+ *  - rewrites drop the legacy lastAccessedAt field and preserve createdAt
+ *  - DELETE accepts the token from header or body and cleans up all three
+ *    Redis keys alongside the blob
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { hashToken } from '../lib/shared.js';
+
+const mocks = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  getRedis: vi.fn(),
+  put: vi.fn(),
+  head: vi.fn(),
+  del: vi.fn(),
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+  redisDel: vi.fn(),
+  validateShareLayout: vi.fn(),
+  isValidationError: vi.fn(),
+  filterLayoutContent: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('../lib/rateLimit.js', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getRedis: mocks.getRedis,
+  getClientIP: () => '203.0.113.1',
+}));
+
+vi.mock('@vercel/blob', () => ({
+  put: mocks.put,
+  head: mocks.head,
+  del: mocks.del,
+}));
+
+vi.mock('../lib/validation.js', () => ({
+  validateShareLayout: mocks.validateShareLayout,
+  isValidationError: mocks.isValidationError,
+}));
+
+vi.mock('../lib/contentFilter.js', () => ({
+  filterLayoutContent: mocks.filterLayoutContent,
+}));
+
+function createResponse() {
+  const res = {
+    _status: 0,
+    _body: null as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(body: unknown) {
+      res._body = body;
+      return res;
+    },
+    setHeader() {
+      return res;
+    },
+    end() {
+      return res;
+    },
+  };
+  return res as unknown as VercelResponse & { _status: number; _body: unknown };
+}
+
+const VALID_ID = 'abc123DEF456';
+const TOKEN = 'correct-token';
+
+function shareBlob(metadata: Record<string, unknown> = {}) {
+  return {
+    layout: { name: 'Drawer' },
+    metadata: {
+      createdAt: '2026-01-01T00:00:00.000Z',
+      lastUpdatedAt: '2026-01-02T00:00:00.000Z',
+      permission: 'view',
+      authorName: 'Jo',
+      ...metadata,
+    },
+  };
+}
+
+function primeBlobFetch(data: unknown) {
+  mocks.head.mockResolvedValue({ url: 'https://blob.example/shares/x.json' });
+  mocks.fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(data) });
+}
+
+async function handle(
+  method: string,
+  over: { id?: unknown; body?: unknown; headers?: Record<string, string> } = {}
+) {
+  const res = createResponse();
+  const mod = await import('./[id].js');
+  await mod.default(
+    {
+      method,
+      query: { id: over.id ?? VALID_ID },
+      headers: over.headers ?? {},
+      body: over.body ?? {},
+    } as unknown as VercelRequest,
+    res
+  );
+  return res;
+}
+
+describe('share/[id]', () => {
+  let correctHash: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.TOKEN_SALT = 'test-salt';
+    correctHash = await hashToken(TOKEN);
+    vi.stubGlobal('fetch', mocks.fetch);
+    mocks.checkRateLimit.mockResolvedValue({ allowed: true });
+    mocks.getRedis.mockReturnValue({
+      get: mocks.redisGet,
+      set: mocks.redisSet,
+      del: mocks.redisDel,
+    });
+    mocks.redisGet.mockResolvedValue(null);
+    mocks.redisSet.mockResolvedValue('OK');
+    mocks.redisDel.mockResolvedValue(1);
+    mocks.put.mockResolvedValue({ url: 'blob://ok' });
+    mocks.del.mockResolvedValue(undefined);
+    mocks.validateShareLayout.mockReturnValue({ layout: { name: 'Updated' } });
+    mocks.isValidationError.mockReturnValue(false);
+    mocks.filterLayoutContent.mockReturnValue({ passed: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.TOKEN_SALT;
+  });
+
+  it('400s on a malformed id for every method', async () => {
+    const res = await handle('GET', { id: '../evil' });
+    expect(res._status).toBe(400);
+  });
+
+  it('405s unsupported methods', async () => {
+    const res = await handle('PATCH');
+    expect(res._status).toBe(405);
+  });
+
+  describe('GET', () => {
+    it('404s when the blob is missing', async () => {
+      mocks.head.mockRejectedValue(new Error('gone'));
+      const res = await handle('GET');
+      expect(res._status).toBe(404);
+    });
+
+    it('returns the layout but strips sensitive metadata fields', async () => {
+      primeBlobFetch(
+        shareBlob({
+          deleteTokenHash: 'secret-hash',
+          reportCount: 3,
+          lastAccessedAt: '2026-01-03T00:00:00.000Z',
+        })
+      );
+      const res = await handle('GET');
+      expect(res._status).toBe(200);
+      const body = res._body as { layout: unknown; metadata: Record<string, unknown> };
+      expect(body.layout).toEqual({ name: 'Drawer' });
+      expect(body.metadata.deleteTokenHash).toBeUndefined();
+      expect(body.metadata.reportCount).toBeUndefined();
+      expect(body.metadata.lastAccessedAt).toBeUndefined();
+      expect(body.metadata.permission).toBe('view');
+    });
+
+    it('records lastAccessedAt in Redis fire-and-forget (a failure never breaks the GET)', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisSet.mockRejectedValue(new Error('redis down'));
+      const res = await handle('GET');
+      expect(res._status).toBe(200);
+      expect(mocks.redisSet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('PUT', () => {
+    it('401s without a delete token', async () => {
+      const res = await handle('PUT', { body: {} });
+      expect(res._status).toBe(401);
+    });
+
+    it('401s on a wrong token via the real constant-time comparison', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('PUT', { body: { deleteToken: 'wrong-token' } });
+      expect(res._status).toBe(401);
+      expect(mocks.put).not.toHaveBeenCalled();
+    });
+
+    it('accepts the correct token from the Redis-stored hash', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('PUT', { body: { deleteToken: TOKEN, permission: 'edit' } });
+      expect(res._status).toBe(200);
+      expect((res._body as { permission: string }).permission).toBe('edit');
+    });
+
+    it('falls back to the blob hash for pre-migration shares', async () => {
+      primeBlobFetch(shareBlob({ deleteTokenHash: correctHash }));
+      mocks.redisGet.mockResolvedValue(null);
+      const res = await handle('PUT', { body: { deleteToken: TOKEN } });
+      expect(res._status).toBe(200);
+    });
+
+    it('404s when no hash exists anywhere', async () => {
+      primeBlobFetch(shareBlob());
+      const res = await handle('PUT', { body: { deleteToken: TOKEN } });
+      expect(res._status).toBe(404);
+    });
+
+    it('rejects an invalid permission value', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('PUT', { body: { deleteToken: TOKEN, permission: 'admin' } });
+      expect(res._status).toBe(400);
+    });
+
+    it('permission-only updates rewrite the blob without validating a layout', async () => {
+      primeBlobFetch(shareBlob({ lastAccessedAt: 'stale', deleteTokenHash: correctHash }));
+      const res = await handle('PUT', { body: { deleteToken: TOKEN, permission: 'edit' } });
+      expect(res._status).toBe(200);
+      expect(mocks.validateShareLayout).not.toHaveBeenCalled();
+      const written = JSON.parse(mocks.put.mock.calls[0][1] as string) as {
+        metadata: Record<string, unknown>;
+      };
+      // Legacy lastAccessedAt must be dropped on rewrite; createdAt preserved.
+      expect(written.metadata.lastAccessedAt).toBeUndefined();
+      expect(written.metadata.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(written.metadata.permission).toBe('edit');
+    });
+
+    it('full updates validate and content-filter the new layout', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      mocks.filterLayoutContent.mockReturnValue({ passed: false, reason: 'profanity' });
+      const res = await handle('PUT', {
+        body: { deleteToken: TOKEN, layout: { name: 'bad' } },
+      });
+      expect(res._status).toBe(400);
+      expect((res._body as { code: string }).code).toBe('CONTENT_BLOCKED');
+      expect(mocks.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE', () => {
+    it('accepts the token from the x-delete-token header', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('DELETE', { headers: { 'x-delete-token': TOKEN } });
+      expect(res._status).toBe(200);
+      expect(mocks.del).toHaveBeenCalledWith(`shares/${VALID_ID}.json`);
+      // All three Redis keys cleaned up alongside the blob.
+      expect(mocks.redisDel).toHaveBeenCalledTimes(1);
+      expect(mocks.redisDel.mock.calls[0]).toHaveLength(3);
+    });
+
+    it('accepts the token from the body', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('DELETE', { body: { deleteToken: TOKEN } });
+      expect(res._status).toBe(200);
+    });
+
+    it('401s on a wrong token and leaves the blob alone', async () => {
+      primeBlobFetch(shareBlob());
+      mocks.redisGet.mockResolvedValue(correctHash);
+      const res = await handle('DELETE', { headers: { 'x-delete-token': 'wrong' } });
+      expect(res._status).toBe(401);
+      expect(mocks.del).not.toHaveBeenCalled();
+    });
+
+    it('401s with no token at all', async () => {
+      const res = await handle('DELETE');
+      expect(res._status).toBe(401);
+    });
+  });
+});

--- a/api/sync/baseplates/[id].ts
+++ b/api/sync/baseplates/[id].ts
@@ -1,22 +1,7 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { requireMethod } from '../../lib/method.js';
-import {
-  rateLimited,
-  serviceUnavailable,
-  serverError,
-  singleParam,
-  isValidShareId,
-  ErrorCode,
-} from '../../lib/shared.js';
-import { logger } from '../../lib/logger.js';
-import { checkRateLimit, getRedis } from '../../lib/rateLimit.js';
-import { requireSession } from '../../lib/session.js';
+import { ErrorCode, isValidShareId } from '../../lib/shared.js';
 import { validateBaseplateShare } from '../../lib/baseplateValidation.js';
 import { sanitizeString } from '../../lib/validation.js';
-import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
-import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
-import { checkQuota } from '../../lib/quota.js';
-import { compareForTiebreaker } from '../../lib/lwwTiebreaker.js';
+import { createSyncResourceHandler } from '../lib/resourceHandler.js';
 
 export const SCHEMA_VERSION = 1 as const;
 
@@ -28,86 +13,6 @@ interface BaseplateEnvelope {
   baseplate: unknown;
   modifiedAt: number;
   schemaVersion: typeof SCHEMA_VERSION;
-}
-
-/**
- * GET    /api/sync/baseplates/{id}
- * PUT    /api/sync/baseplates/{id}  — body { baseplate, modifiedAt }. `baseplate`
- *                                     is `{ name, params }` (new shape) or bare
- *                                     params (legacy/tolerant, still accepted).
- * DELETE /api/sync/baseplates/{id}
- *
- * Mirrors the designs endpoint's LWW + tombstone semantics.
- */
-export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  if (!requireMethod(req, res, ['GET', 'PUT', 'DELETE'])) return;
-
-  const session = await requireSession(req, res);
-  if (!session) return;
-
-  const id = singleParam(req.query.id);
-  if (!id || !isValidBaseplateId(id)) {
-    res.status(400).json({ error: 'Invalid baseplate id', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-
-  const action = req.method === 'GET' ? 'sync.read' : 'sync.write';
-  const rate = await checkRateLimit(session.userId, action);
-  if (!rate.allowed) {
-    rateLimited(res, rate.retryAfterSeconds);
-    return;
-  }
-
-  const redis = getRedis();
-  if (!redis) {
-    serviceUnavailable(res);
-    return;
-  }
-
-  try {
-    if (req.method === 'GET') {
-      await handleGet(res, redis, session.userId, id);
-    } else if (req.method === 'PUT') {
-      await handlePut(req, res, redis, session.userId, id);
-    } else {
-      await handleDelete(res, redis, session.userId, id);
-    }
-  } catch (error) {
-    logger.error('sync/baseplates handler failed', {
-      userId: session.userId,
-      method: req.method,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    serverError(res);
-  }
-}
-
-async function handleGet(
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const entry = await getEntry(redis, userId, 'baseplates', id);
-  if (!entry) {
-    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
-    return;
-  }
-  if (entry.deletedAt !== undefined) {
-    res.status(410).json({ error: 'Deleted', code: ErrorCode.NOT_FOUND, indexEntry: entry });
-    return;
-  }
-  const envelope = await getJson<BaseplateEnvelope>(blobPath(userId, id));
-  if (!envelope) {
-    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
-    return;
-  }
-  res.status(200).json({ envelope, indexEntry: entry });
-}
-
-interface PutBody {
-  baseplate: unknown;
-  modifiedAt: unknown;
 }
 
 /**
@@ -128,167 +33,76 @@ function unwrapBaseplatePayload(
   return { name: null, params: baseplate };
 }
 
-async function handlePut(
-  req: VercelRequest,
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const body = req.body as PutBody | undefined;
-  if (!body || typeof body !== 'object') {
-    res.status(400).json({ error: 'Missing body', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-  const { baseplate, modifiedAt } = body;
-  if (typeof modifiedAt !== 'number' || !Number.isFinite(modifiedAt)) {
-    res
-      .status(400)
-      .json({ error: 'modifiedAt must be a number (ms epoch)', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-
-  const unwrapped = unwrapBaseplatePayload(baseplate);
-  if (!unwrapped) {
-    res.status(400).json({
-      error: 'baseplate must be an object with a string `name`',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
-    return;
-  }
-  const name = sanitizeString(unwrapped.name ?? '', MAX_NAME_LENGTH);
-
-  // Two byte counts: `preValidationBytes` is what the validator's size cap
-  // sees (a CPU guard); `sizeBytes` is what we store after sanitization and
-  // what the quota check + index entry track.
-  const validationPayload = {
-    type: 'baseplate' as const,
-    version: 1 as const,
-    params: unwrapped.params,
-  };
-  const preValidationBytes = Buffer.byteLength(
-    JSON.stringify({ name, ...validationPayload }),
-    'utf8'
-  );
-  const validation = validateBaseplateShare(validationPayload, preValidationBytes);
-  if (!validation.valid) {
-    res.status(400).json({ error: validation.error.message, code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-  const sizeBytes = Buffer.byteLength(
-    JSON.stringify({
-      name,
-      type: 'baseplate',
-      version: 1,
-      params: validation.payload.params,
-    }),
-    'utf8'
-  );
-
-  const existing = await getEntry(redis, userId, 'baseplates', id);
-  if (existing && existing.deletedAt === undefined) {
-    if (existing.modifiedAt > modifiedAt) {
-      const stored = await getJson<BaseplateEnvelope>(blobPath(userId, id));
-      res.status(409).json({
-        error: 'A newer version already exists.',
-        code: ErrorCode.VALIDATION_ERROR,
-        stored,
-        indexEntry: existing,
-      });
-      return;
-    }
-    if (existing.modifiedAt === modifiedAt) {
-      // Equal-ms tie: hash over `{ name, params }` so renames also participate.
-      const stored = await getJson<BaseplateEnvelope>(blobPath(userId, id));
-      if (stored !== null) {
-        const candidate = { name, params: validation.payload.params };
-        const order = compareForTiebreaker(candidate, stored.baseplate);
-        if (order <= 0) {
-          res.status(409).json({
-            error: 'A newer version already exists.',
-            code: ErrorCode.VALIDATION_ERROR,
-            stored,
-            indexEntry: existing,
-          });
-          return;
-        }
-      }
-    }
-  }
-
-  if (existing?.deletedAt !== undefined && existing.deletedAt >= modifiedAt) {
-    res.status(410).json({
-      error: 'Baseplate was deleted on another device. Save again to restore.',
-      code: ErrorCode.NOT_FOUND,
-      indexEntry: existing,
-    });
-    return;
-  }
-
-  const replacingId = existing && existing.deletedAt === undefined ? id : undefined;
-  const quota = await checkQuota(redis, userId, 'baseplates', {
-    op: 'put',
-    sizeBytes,
-    replacingId,
-  });
-  if (!quota.ok) {
-    res.status(413).json({
-      error: `Quota exceeded (${quota.error.reason}): ${quota.error.current} of ${quota.error.limit}.`,
-      code: ErrorCode.SIZE_LIMIT,
-    });
-    return;
-  }
-
-  // Always emit the new wrapper shape. Bare-params posts become `name = ''`;
-  // readers fall back from there.
-  const envelope: BaseplateEnvelope = {
-    baseplate: { name, params: validation.payload.params },
-    modifiedAt,
-    schemaVersion: SCHEMA_VERSION,
-  };
-  await putJson(blobPath(userId, id), envelope, { allowOverwrite: true });
-
-  const newEntry: IndexEntry = { modifiedAt, sizeBytes };
-  await upsertEntry(redis, userId, 'baseplates', id, newEntry);
-
-  res.status(200).json({ envelope, indexEntry: newEntry });
-}
-
-async function handleDelete(
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const existing = await getEntry(redis, userId, 'baseplates', id);
-  // Already tombstoned: don't try to delete the blob (it's already gone)
-  // and don't bump the tombstone timestamp.
-  if (existing?.deletedAt !== undefined) {
-    res.status(204).end();
-    return;
-  }
-  if (!existing) {
-    await tombstone(redis, userId, 'baseplates', id, Date.now());
-    res.status(204).end();
-    return;
-  }
-  await deleteBlob(blobPath(userId, id));
-  await tombstone(redis, userId, 'baseplates', id, Date.now());
-  res.status(204).end();
-}
-
-function blobPath(userId: string, id: string): string {
-  return `users/${userId}/baseplates/${id}.json`;
-}
-
 /**
- * Baseplate library ids use the `baseplate_<ms-epoch>_<base36>` shape generated
- * by `generateBaseplateDesignId` in `BaseplateStorage.ts`
- * (`baseplate_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`). The
- * base36 suffix is up to 6 chars but can be shorter, so accept 1–8. The three
- * legacy share shapes (UUID, base36 timestamp, 12-char alphanumeric) are also
- * accepted to match `designs`/`layouts`, so ids round-trip without renaming.
+ * GET    /api/sync/baseplates/{id}
+ * PUT    /api/sync/baseplates/{id}  — body { baseplate, modifiedAt }. `baseplate`
+ *                                     is `{ name, params }` (new shape) or bare
+ *                                     params (legacy/tolerant, still accepted).
+ * DELETE /api/sync/baseplates/{id}
+ *
+ * Mirrors the designs endpoint's LWW + tombstone semantics.
  */
-function isValidBaseplateId(id: string): boolean {
-  return /^baseplate_\d+_[a-z0-9]{1,8}$/.test(id) || isValidShareId(id);
-}
+export default createSyncResourceHandler<BaseplateEnvelope>({
+  kind: 'baseplates',
+  payloadKey: 'baseplate',
+  // Locally-minted baseplate ids (base36 suffix up to 6 chars but can be
+  // shorter, so accept 1-8) plus the share formats for round-tripping.
+  isValidId: (id) => /^baseplate_\d+_[a-z0-9]{1,8}$/.test(id) || isValidShareId(id),
+  invalidIdError: 'Invalid baseplate id',
+  deletedError: 'Baseplate was deleted on another device. Save again to restore.',
+  buildPut: (baseplate, modifiedAt) => {
+    const unwrapped = unwrapBaseplatePayload(baseplate);
+    if (!unwrapped) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'baseplate must be an object with a string `name`',
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+    const name = sanitizeString(unwrapped.name ?? '', MAX_NAME_LENGTH);
+
+    // Two byte counts: `preValidationBytes` is what the validator's size cap
+    // sees (a CPU guard); `sizeBytes` is what we store after sanitization and
+    // what the quota check + index entry track.
+    const validationPayload = {
+      type: 'baseplate' as const,
+      version: 1 as const,
+      params: unwrapped.params,
+    };
+    const preValidationBytes = Buffer.byteLength(
+      JSON.stringify({ name, ...validationPayload }),
+      'utf8'
+    );
+    const validation = validateBaseplateShare(validationPayload, preValidationBytes);
+    if (!validation.valid) {
+      return {
+        ok: false,
+        status: 400,
+        error: validation.error.message,
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+    const sizeBytes = Buffer.byteLength(
+      JSON.stringify({
+        name,
+        type: 'baseplate',
+        version: 1,
+        params: validation.payload.params,
+      }),
+      'utf8'
+    );
+
+    // Always emit the new wrapper shape. Bare-params posts become `name = ''`;
+    // readers fall back from there. Equal-ms ties hash over `{ name, params }`
+    // so renames also participate.
+    const stored = { name, params: validation.payload.params };
+    return {
+      ok: true,
+      envelope: { baseplate: stored, modifiedAt, schemaVersion: SCHEMA_VERSION },
+      sizeBytes,
+      tiebreakerCandidate: stored,
+    };
+  },
+  storedComparable: (stored) => stored.baseplate,
+});

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -1,22 +1,7 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { requireMethod } from '../../lib/method.js';
-import {
-  rateLimited,
-  serviceUnavailable,
-  serverError,
-  singleParam,
-  isValidShareId,
-  ErrorCode,
-} from '../../lib/shared.js';
-import { logger } from '../../lib/logger.js';
-import { checkRateLimit, getRedis } from '../../lib/rateLimit.js';
-import { requireSession } from '../../lib/session.js';
+import { ErrorCode, isValidShareId } from '../../lib/shared.js';
 import { validateDesignerShare, sanitizeTags } from '../../lib/designerValidation.js';
 import { sanitizeString } from '../../lib/validation.js';
-import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
-import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
-import { checkQuota } from '../../lib/quota.js';
-import { compareForTiebreaker } from '../../lib/lwwTiebreaker.js';
+import { createSyncResourceHandler } from '../lib/resourceHandler.js';
 
 export const SCHEMA_VERSION = 1 as const;
 
@@ -28,86 +13,6 @@ interface DesignEnvelope {
   design: unknown;
   modifiedAt: number;
   schemaVersion: typeof SCHEMA_VERSION;
-}
-
-/**
- * GET    /api/sync/designs/{id}
- * PUT    /api/sync/designs/{id}   — body { design, modifiedAt }. `design`
- *                                    is `{ name, params }` (new shape) or
- *                                    bare BinParams (legacy, still accepted).
- * DELETE /api/sync/designs/{id}
- *
- * Mirrors the layouts endpoint's LWW + tombstone semantics.
- */
-export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  if (!requireMethod(req, res, ['GET', 'PUT', 'DELETE'])) return;
-
-  const session = await requireSession(req, res);
-  if (!session) return;
-
-  const id = singleParam(req.query.id);
-  if (!id || !isValidDesignId(id)) {
-    res.status(400).json({ error: 'Invalid design id', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-
-  const action = req.method === 'GET' ? 'sync.read' : 'sync.write';
-  const rate = await checkRateLimit(session.userId, action);
-  if (!rate.allowed) {
-    rateLimited(res, rate.retryAfterSeconds);
-    return;
-  }
-
-  const redis = getRedis();
-  if (!redis) {
-    serviceUnavailable(res);
-    return;
-  }
-
-  try {
-    if (req.method === 'GET') {
-      await handleGet(res, redis, session.userId, id);
-    } else if (req.method === 'PUT') {
-      await handlePut(req, res, redis, session.userId, id);
-    } else {
-      await handleDelete(res, redis, session.userId, id);
-    }
-  } catch (error) {
-    logger.error('sync/designs handler failed', {
-      userId: session.userId,
-      method: req.method,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    serverError(res);
-  }
-}
-
-async function handleGet(
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const entry = await getEntry(redis, userId, 'designs', id);
-  if (!entry) {
-    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
-    return;
-  }
-  if (entry.deletedAt !== undefined) {
-    res.status(410).json({ error: 'Deleted', code: ErrorCode.NOT_FOUND, indexEntry: entry });
-    return;
-  }
-  const envelope = await getJson<DesignEnvelope>(blobPath(userId, id));
-  if (!envelope) {
-    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
-    return;
-  }
-  res.status(200).json({ envelope, indexEntry: entry });
-}
-
-interface PutBody {
-  design: unknown;
-  modifiedAt: unknown;
 }
 
 /**
@@ -132,178 +37,88 @@ function unwrapDesignPayload(
   return { name: null, params: design, tags: undefined };
 }
 
-async function handlePut(
-  req: VercelRequest,
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const body = req.body as PutBody | undefined;
-  if (!body || typeof body !== 'object') {
-    res.status(400).json({ error: 'Missing body', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-  const { design, modifiedAt } = body;
-  if (typeof modifiedAt !== 'number' || !Number.isFinite(modifiedAt)) {
-    res
-      .status(400)
-      .json({ error: 'modifiedAt must be a number (ms epoch)', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-
-  const unwrapped = unwrapDesignPayload(design);
-  if (!unwrapped) {
-    res.status(400).json({
-      error: 'design must be an object with a string `name`',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
-    return;
-  }
-  // Mirror the share validator's handling of user-visible strings: strip
-  // null bytes and control chars, trim, and truncate. Legacy bare-params
-  // posts have no name; they persist as '' and the adapter falls back.
-  const name = sanitizeString(unwrapped.name ?? '', MAX_NAME_LENGTH);
-  // Tags ride alongside `name` (not inside `params`), so they bypass the
-  // params validator and are sanitized/capped here instead.
-  const tags = sanitizeTags(unwrapped.tags);
-
-  // Two byte counts intentionally: `preValidationBytes` is what the
-  // validator's 100 KB size cap sees — purely a CPU guard against huge
-  // params. `sizeBytes` is what we actually store after sanitization, and
-  // it's what the quota check and index entry track. Without the split,
-  // users get charged for bytes the validator stripped and the index
-  // drifts from what the blob holds.
-  const validationPayload = {
-    type: 'designer' as const,
-    version: 1 as const,
-    params: unwrapped.params,
-  };
-  const preValidationBytes = Buffer.byteLength(
-    JSON.stringify({ name, tags, ...validationPayload }),
-    'utf8'
-  );
-  const validation = validateDesignerShare(validationPayload, preValidationBytes);
-  if (!validation.valid) {
-    res.status(400).json({ error: validation.error.message, code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-  const sizeBytes = Buffer.byteLength(
-    JSON.stringify({
-      name,
-      tags,
-      type: 'designer',
-      version: 1,
-      params: validation.payload.params,
-    }),
-    'utf8'
-  );
-
-  const existing = await getEntry(redis, userId, 'designs', id);
-  // `deletedAt === undefined` is the explicit live-entry check.
-  if (existing && existing.deletedAt === undefined) {
-    if (existing.modifiedAt > modifiedAt) {
-      const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
-      res.status(409).json({
-        error: 'A newer version already exists.',
-        code: ErrorCode.VALIDATION_ERROR,
-        stored,
-        indexEntry: existing,
-      });
-      return;
-    }
-    if (existing.modifiedAt === modifiedAt) {
-      // Equal-ms tie: hash over `{ name, params, tags }` so renames and
-      // tag-only edits also participate.
-      const stored = await getJson<DesignEnvelope>(blobPath(userId, id));
-      // See layouts/[id].ts for the missing-blob rationale.
-      if (stored !== null) {
-        const candidate = { name, params: validation.payload.params, tags };
-        const order = compareForTiebreaker(candidate, stored.design);
-        if (order <= 0) {
-          res.status(409).json({
-            error: 'A newer version already exists.',
-            code: ErrorCode.VALIDATION_ERROR,
-            stored,
-            indexEntry: existing,
-          });
-          return;
-        }
-      }
-    }
-  }
-
-  if (existing?.deletedAt !== undefined && existing.deletedAt >= modifiedAt) {
-    res.status(410).json({
-      error: 'Design was deleted on another device. Save again to restore.',
-      code: ErrorCode.NOT_FOUND,
-      indexEntry: existing,
-    });
-    return;
-  }
-
-  const replacingId = existing && existing.deletedAt === undefined ? id : undefined;
-  const quota = await checkQuota(redis, userId, 'designs', {
-    op: 'put',
-    sizeBytes,
-    replacingId,
-  });
-  if (!quota.ok) {
-    res.status(413).json({
-      error: `Quota exceeded (${quota.error.reason}): ${quota.error.current} of ${quota.error.limit}.`,
-      code: ErrorCode.SIZE_LIMIT,
-    });
-    return;
-  }
-
-  // Always emit the new wrapper shape. Legacy posts become `name = ''`;
-  // readers fall back from there. `tags` is always an array (possibly empty).
-  const envelope: DesignEnvelope = {
-    design: { name, params: validation.payload.params, tags },
-    modifiedAt,
-    schemaVersion: SCHEMA_VERSION,
-  };
-  await putJson(blobPath(userId, id), envelope, { allowOverwrite: true });
-
-  const newEntry: IndexEntry = { modifiedAt, sizeBytes };
-  await upsertEntry(redis, userId, 'designs', id, newEntry);
-
-  res.status(200).json({ envelope, indexEntry: newEntry });
-}
-
-async function handleDelete(
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const existing = await getEntry(redis, userId, 'designs', id);
-  // Already tombstoned: don't try to delete the blob (it's already gone)
-  // and don't bump the tombstone timestamp.
-  if (existing?.deletedAt !== undefined) {
-    res.status(204).end();
-    return;
-  }
-  if (!existing) {
-    await tombstone(redis, userId, 'designs', id, Date.now());
-    res.status(204).end();
-    return;
-  }
-  await deleteBlob(blobPath(userId, id));
-  await tombstone(redis, userId, 'designs', id, Date.now());
-  res.status(204).end();
-}
-
-function blobPath(userId: string, id: string): string {
-  return `users/${userId}/designs/${id}.json`;
-}
-
 /**
- * Bin Designer designs use the `design_<ms-epoch>_<6-char-base36>` shape
- * generated by `generateDesignId` in `DesignerStorage.ts`. Older shares may
- * also surface UUIDs, base36-timestamp ids, or 12-char alphanumeric ids, so
- * accept those too for round-trip with the share feature.
+ * GET    /api/sync/designs/{id}
+ * PUT    /api/sync/designs/{id}   — body { design, modifiedAt }. `design`
+ *                                    is `{ name, params }` (new shape) or
+ *                                    bare BinParams (legacy, still accepted).
+ * DELETE /api/sync/designs/{id}
+ *
+ * Mirrors the layouts endpoint's LWW + tombstone semantics.
  */
-function isValidDesignId(id: string): boolean {
-  return /^design_\d+_[a-z0-9]{6}$/.test(id) || isValidShareId(id);
-}
+export default createSyncResourceHandler<DesignEnvelope>({
+  kind: 'designs',
+  payloadKey: 'design',
+  // Locally-minted design ids plus the share formats (UUID, base36
+  // timestamp, 12-char alphanumeric) so ids round-trip with the share
+  // feature without renaming.
+  isValidId: (id) => /^design_\d+_[a-z0-9]{6}$/.test(id) || isValidShareId(id),
+  invalidIdError: 'Invalid design id',
+  deletedError: 'Design was deleted on another device. Save again to restore.',
+  buildPut: (design, modifiedAt) => {
+    const unwrapped = unwrapDesignPayload(design);
+    if (!unwrapped) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'design must be an object with a string `name`',
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+    // Mirror the share validator's handling of user-visible strings: strip
+    // null bytes and control chars, trim, and truncate. Legacy bare-params
+    // posts have no name; they persist as '' and the adapter falls back.
+    const name = sanitizeString(unwrapped.name ?? '', MAX_NAME_LENGTH);
+    // Tags ride alongside `name` (not inside `params`), so they bypass the
+    // params validator and are sanitized/capped here instead.
+    const tags = sanitizeTags(unwrapped.tags);
+
+    // Two byte counts intentionally: `preValidationBytes` is what the
+    // validator's 100 KB size cap sees — purely a CPU guard against huge
+    // params. `sizeBytes` is what we actually store after sanitization, and
+    // it's what the quota check and index entry track. Without the split,
+    // users get charged for bytes the validator stripped and the index
+    // drifts from what the blob holds.
+    const validationPayload = {
+      type: 'designer' as const,
+      version: 1 as const,
+      params: unwrapped.params,
+    };
+    const preValidationBytes = Buffer.byteLength(
+      JSON.stringify({ name, tags, ...validationPayload }),
+      'utf8'
+    );
+    const validation = validateDesignerShare(validationPayload, preValidationBytes);
+    if (!validation.valid) {
+      return {
+        ok: false,
+        status: 400,
+        error: validation.error.message,
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+    const sizeBytes = Buffer.byteLength(
+      JSON.stringify({
+        name,
+        tags,
+        type: 'designer',
+        version: 1,
+        params: validation.payload.params,
+      }),
+      'utf8'
+    );
+
+    // Always emit the new wrapper shape. Legacy posts become `name = ''`;
+    // readers fall back from there. `tags` is always an array (possibly
+    // empty). Equal-ms ties hash over `{ name, params, tags }` so renames
+    // and tag-only edits also participate.
+    const stored = { name, params: validation.payload.params, tags };
+    return {
+      ok: true,
+      envelope: { design: stored, modifiedAt, schemaVersion: SCHEMA_VERSION },
+      sizeBytes,
+      tiebreakerCandidate: stored,
+    };
+  },
+  storedComparable: (stored) => stored.design,
+});

--- a/api/sync/layouts/[id].ts
+++ b/api/sync/layouts/[id].ts
@@ -1,21 +1,6 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { requireMethod } from '../../lib/method.js';
-import {
-  rateLimited,
-  serviceUnavailable,
-  serverError,
-  singleParam,
-  isValidShareId,
-  ErrorCode,
-} from '../../lib/shared.js';
-import { logger } from '../../lib/logger.js';
-import { checkRateLimit, getRedis } from '../../lib/rateLimit.js';
-import { requireSession } from '../../lib/session.js';
+import { isValidShareId } from '../../lib/shared.js';
 import { isValidationError, validateShareLayout } from '../../lib/validation.js';
-import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
-import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
-import { checkQuota } from '../../lib/quota.js';
-import { compareForTiebreaker } from '../../lib/lwwTiebreaker.js';
+import { createSyncResourceHandler } from '../lib/resourceHandler.js';
 
 export const SCHEMA_VERSION = 1 as const;
 
@@ -33,226 +18,40 @@ interface LayoutEnvelope {
  *                                    tombstone newer than the edit.
  * DELETE /api/sync/layouts/{id}   — tombstone + blob delete (204)
  */
-export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  if (!requireMethod(req, res, ['GET', 'PUT', 'DELETE'])) return;
-
-  const session = await requireSession(req, res);
-  if (!session) return;
-
-  const id = singleParam(req.query.id);
-  if (!id || !isValidLayoutId(id)) {
-    res.status(400).json({ error: 'Invalid layout id', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-
-  const action = req.method === 'GET' ? 'sync.read' : 'sync.write';
-  const rate = await checkRateLimit(session.userId, action);
-  if (!rate.allowed) {
-    rateLimited(res, rate.retryAfterSeconds);
-    return;
-  }
-
-  const redis = getRedis();
-  if (!redis) {
-    serviceUnavailable(res);
-    return;
-  }
-
-  try {
-    if (req.method === 'GET') {
-      await handleGet(res, redis, session.userId, id);
-    } else if (req.method === 'PUT') {
-      await handlePut(req, res, redis, session.userId, id);
-    } else {
-      await handleDelete(res, redis, session.userId, id);
+export default createSyncResourceHandler<LayoutEnvelope>({
+  kind: 'layouts',
+  payloadKey: 'layout',
+  // Layouts the client may sync share three id formats with the existing
+  // share feature (UUID, base36 timestamp, 12-char alphanumeric); we accept
+  // the same shapes here so layouts can be round-tripped between local
+  // storage and the cloud without renaming.
+  isValidId: isValidShareId,
+  invalidIdError: 'Invalid layout id',
+  deletedError: 'Layout was deleted on another device. Save again to restore.',
+  buildPut: (layout, modifiedAt) => {
+    // Two byte counts intentionally: `preValidationBytes` is what the
+    // validator's 500 KB size cap sees — purely a CPU guard against huge
+    // inputs. `sizeBytes` is what we actually store after sanitization, and
+    // it's what the quota check and index entry track. Without the split,
+    // users get charged for bytes the validator stripped and the index
+    // drifts from what the blob holds.
+    const preValidationBytes = Buffer.byteLength(JSON.stringify({ layout }), 'utf8');
+    const validation = validateShareLayout(layout, preValidationBytes);
+    if (isValidationError(validation)) {
+      return {
+        ok: false,
+        status: 400,
+        error: validation.error.message,
+        code: validation.error.code,
+      };
     }
-  } catch (error) {
-    logger.error('sync/layouts handler failed', {
-      userId: session.userId,
-      method: req.method,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    serverError(res);
-  }
-}
-
-async function handleGet(
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const entry = await getEntry(redis, userId, 'layouts', id);
-  if (!entry) {
-    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
-    return;
-  }
-  if (entry.deletedAt !== undefined) {
-    res.status(410).json({ error: 'Deleted', code: ErrorCode.NOT_FOUND, indexEntry: entry });
-    return;
-  }
-  const envelope = await getJson<LayoutEnvelope>(blobPath(userId, id));
-  if (!envelope) {
-    // Blob missing but index says it should exist — treat as 404 so the
-    // client refreshes its view. Don't 500 since the user can't act on it.
-    res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
-    return;
-  }
-  res.status(200).json({ envelope, indexEntry: entry });
-}
-
-interface PutBody {
-  layout: unknown;
-  modifiedAt: unknown;
-}
-
-async function handlePut(
-  req: VercelRequest,
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const body = req.body as PutBody | undefined;
-  if (!body || typeof body !== 'object') {
-    res.status(400).json({ error: 'Missing body', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-  const { layout, modifiedAt } = body;
-  if (typeof modifiedAt !== 'number' || !Number.isFinite(modifiedAt)) {
-    res
-      .status(400)
-      .json({ error: 'modifiedAt must be a number (ms epoch)', code: ErrorCode.VALIDATION_ERROR });
-    return;
-  }
-
-  // Two byte counts intentionally: `preValidationBytes` is what the
-  // validator's 500 KB size cap sees — purely a CPU guard against huge
-  // inputs. `sizeBytes` is what we actually store after sanitization, and
-  // it's what the quota check and index entry track. Without the split,
-  // users get charged for bytes the validator stripped and the index
-  // drifts from what the blob holds.
-  const preValidationBytes = Buffer.byteLength(JSON.stringify({ layout }), 'utf8');
-  const validation = validateShareLayout(layout, preValidationBytes);
-  if (isValidationError(validation)) {
-    res.status(400).json({ error: validation.error.message, code: validation.error.code });
-    return;
-  }
-  const sizeBytes = Buffer.byteLength(JSON.stringify({ layout: validation.layout }), 'utf8');
-
-  const existing = await getEntry(redis, userId, 'layouts', id);
-
-  // LWW comparison. `deletedAt === undefined` is the explicit live-entry
-  // check — `!existing.deletedAt` would also accept 0/NaN, which would
-  // misclassify any future tombstone written with such a value.
-  if (existing && existing.deletedAt === undefined) {
-    if (existing.modifiedAt > modifiedAt) {
-      const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
-      res.status(409).json({
-        error: 'A newer version already exists.',
-        code: ErrorCode.VALIDATION_ERROR,
-        stored,
-        indexEntry: existing,
-      });
-      return;
-    }
-    if (existing.modifiedAt === modifiedAt) {
-      // Equal-ms tie: deterministic tiebreaker so concurrent devices converge.
-      const stored = await getJson<LayoutEnvelope>(blobPath(userId, id));
-      // Blob missing while index entry exists = divergence (deleted blob,
-      // failed prior write, etc.). Let the candidate repair it instead of
-      // running a tiebreaker against `undefined`, which would arbitrarily
-      // 409 a write that could have fixed the gap.
-      if (stored !== null) {
-        const order = compareForTiebreaker(validation.layout, stored.layout);
-        if (order <= 0) {
-          res.status(409).json({
-            error: 'A newer version already exists.',
-            code: ErrorCode.VALIDATION_ERROR,
-            stored,
-            indexEntry: existing,
-          });
-          return;
-        }
-      }
-    }
-  }
-
-  // Tombstone protection: a stale edit can't resurrect a deletion that
-  // happened *after* the local change.
-  if (existing?.deletedAt !== undefined && existing.deletedAt >= modifiedAt) {
-    res.status(410).json({
-      error: 'Layout was deleted on another device. Save again to restore.',
-      code: ErrorCode.NOT_FOUND,
-      indexEntry: existing,
-    });
-    return;
-  }
-
-  // Quota: replacing if the existing entry is live (tombstones don't count).
-  const replacingId = existing && existing.deletedAt === undefined ? id : undefined;
-  const quota = await checkQuota(redis, userId, 'layouts', {
-    op: 'put',
-    sizeBytes,
-    replacingId,
-  });
-  if (!quota.ok) {
-    res.status(413).json({
-      error: `Quota exceeded (${quota.error.reason}): ${quota.error.current} of ${quota.error.limit}.`,
-      code: ErrorCode.SIZE_LIMIT,
-    });
-    return;
-  }
-
-  const envelope: LayoutEnvelope = {
-    layout: validation.layout,
-    modifiedAt,
-    schemaVersion: SCHEMA_VERSION,
-  };
-  await putJson(blobPath(userId, id), envelope, { allowOverwrite: true });
-
-  const newEntry: IndexEntry = { modifiedAt, sizeBytes };
-  await upsertEntry(redis, userId, 'layouts', id, newEntry);
-
-  res.status(200).json({ envelope, indexEntry: newEntry });
-}
-
-async function handleDelete(
-  res: VercelResponse,
-  redis: ReturnType<typeof getRedis> & object,
-  userId: string,
-  id: string
-): Promise<void> {
-  const existing = await getEntry(redis, userId, 'layouts', id);
-  // Already tombstoned: don't try to delete the blob (it's already gone)
-  // and don't bump the tombstone timestamp — the original deletion is
-  // the source of truth for LWW.
-  if (existing?.deletedAt !== undefined) {
-    res.status(204).end();
-    return;
-  }
-  if (!existing) {
-    // Never existed — write a tombstone so peer devices learn about
-    // the deletion on next pull. Idempotent.
-    await tombstone(redis, userId, 'layouts', id, Date.now());
-    res.status(204).end();
-    return;
-  }
-  await deleteBlob(blobPath(userId, id));
-  await tombstone(redis, userId, 'layouts', id, Date.now());
-  res.status(204).end();
-}
-
-function blobPath(userId: string, id: string): string {
-  return `users/${userId}/layouts/${id}.json`;
-}
-
-/**
- * Layouts the client may sync share three id formats with the existing
- * share feature (UUID, base36 timestamp, 12-char alphanumeric); we accept
- * the same shapes here so layouts can be round-tripped between local
- * storage and the cloud without renaming.
- */
-function isValidLayoutId(id: string): boolean {
-  return isValidShareId(id);
-}
+    const sizeBytes = Buffer.byteLength(JSON.stringify({ layout: validation.layout }), 'utf8');
+    return {
+      ok: true,
+      envelope: { layout: validation.layout, modifiedAt, schemaVersion: SCHEMA_VERSION },
+      sizeBytes,
+      tiebreakerCandidate: validation.layout,
+    };
+  },
+  storedComparable: (stored) => stored.layout,
+});

--- a/api/sync/lib/resourceHandler.ts
+++ b/api/sync/lib/resourceHandler.ts
@@ -1,0 +1,264 @@
+/**
+ * Shared GET/PUT/DELETE skeleton for the per-item sync resources
+ * (layouts/designs/baseplates). The three handlers were ~80% identical; the
+ * genuinely per-resource part — parsing and validating the PUT payload and
+ * shaping the stored envelope — stays in each resource's `buildPut`.
+ *
+ * The skeleton owns the LWW semantics: 409 when the remote is newer, the
+ * deterministic equal-ms tiebreaker (skipped when the blob is missing so a
+ * candidate write can repair index/blob divergence), tombstone protection
+ * (410 when a stale edit would resurrect a newer deletion), quota, and the
+ * blob+index write pair.
+ */
+
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { requireMethod } from '../../lib/method.js';
+import {
+  rateLimited,
+  serviceUnavailable,
+  serverError,
+  singleParam,
+  ErrorCode,
+} from '../../lib/shared.js';
+import { logger } from '../../lib/logger.js';
+import { checkRateLimit, getRedis } from '../../lib/rateLimit.js';
+import { requireSession } from '../../lib/session.js';
+import { deleteBlob, getJson, putJson } from '../../lib/blobStore.js';
+import { getEntry, tombstone, upsertEntry, type IndexEntry } from '../../lib/userIndex.js';
+import { checkQuota } from '../../lib/quota.js';
+import { compareForTiebreaker } from '../../lib/lwwTiebreaker.js';
+
+type RedisClient = NonNullable<ReturnType<typeof getRedis>>;
+
+export type SyncResourceKind = 'layouts' | 'designs' | 'baseplates';
+
+export interface SyncEnvelope {
+  modifiedAt: number;
+  schemaVersion: number;
+}
+
+export type BuildPutResult<TEnvelope> =
+  | {
+      ok: true;
+      envelope: TEnvelope;
+      /** Stored byte size after sanitization — what quota and the index track. */
+      sizeBytes: number;
+      /** Candidate for the equal-ms tiebreaker; must mirror `storedComparable`. */
+      tiebreakerCandidate: unknown;
+    }
+  | { ok: false; status: number; error: string; code: string };
+
+export interface SyncResourceConfig<TEnvelope extends SyncEnvelope> {
+  kind: SyncResourceKind;
+  /** Key carrying the payload in the PUT body (`layout`/`design`/`baseplate`). */
+  payloadKey: string;
+  isValidId: (id: string) => boolean;
+  invalidIdError: string;
+  /** 410 message when a stale edit hits a newer tombstone. */
+  deletedError: string;
+  /** Validate the payload and shape the envelope; everything per-resource. */
+  buildPut: (payload: unknown, modifiedAt: number) => BuildPutResult<TEnvelope>;
+  /** Stored-side value handed to the equal-ms tiebreaker. */
+  storedComparable: (stored: TEnvelope) => unknown;
+}
+
+export function createSyncResourceHandler<TEnvelope extends SyncEnvelope>(
+  config: SyncResourceConfig<TEnvelope>
+): (req: VercelRequest, res: VercelResponse) => Promise<void> {
+  const blobPath = (userId: string, id: string): string =>
+    `users/${userId}/${config.kind}/${id}.json`;
+
+  async function handleGet(
+    res: VercelResponse,
+    redis: RedisClient,
+    userId: string,
+    id: string
+  ): Promise<void> {
+    const entry = await getEntry(redis, userId, config.kind, id);
+    if (!entry) {
+      res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
+      return;
+    }
+    if (entry.deletedAt !== undefined) {
+      res.status(410).json({ error: 'Deleted', code: ErrorCode.NOT_FOUND, indexEntry: entry });
+      return;
+    }
+    const envelope = await getJson<TEnvelope>(blobPath(userId, id));
+    if (!envelope) {
+      // Blob missing but index says it should exist — treat as 404 so the
+      // client refreshes its view. Don't 500 since the user can't act on it.
+      res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
+      return;
+    }
+    res.status(200).json({ envelope, indexEntry: entry });
+  }
+
+  async function handlePut(
+    req: VercelRequest,
+    res: VercelResponse,
+    redis: RedisClient,
+    userId: string,
+    id: string
+  ): Promise<void> {
+    const body = req.body as Record<string, unknown> | undefined;
+    if (!body || typeof body !== 'object') {
+      res.status(400).json({ error: 'Missing body', code: ErrorCode.VALIDATION_ERROR });
+      return;
+    }
+    const modifiedAt = body.modifiedAt;
+    if (typeof modifiedAt !== 'number' || !Number.isFinite(modifiedAt)) {
+      res.status(400).json({
+        error: 'modifiedAt must be a number (ms epoch)',
+        code: ErrorCode.VALIDATION_ERROR,
+      });
+      return;
+    }
+
+    const built = config.buildPut(body[config.payloadKey], modifiedAt);
+    if (!built.ok) {
+      res.status(built.status).json({ error: built.error, code: built.code });
+      return;
+    }
+    const { envelope, sizeBytes, tiebreakerCandidate } = built;
+
+    const existing = await getEntry(redis, userId, config.kind, id);
+
+    // LWW comparison. `deletedAt === undefined` is the explicit live-entry
+    // check — `!existing.deletedAt` would also accept 0/NaN, which would
+    // misclassify any future tombstone written with such a value.
+    if (existing && existing.deletedAt === undefined) {
+      if (existing.modifiedAt > modifiedAt) {
+        const stored = await getJson<TEnvelope>(blobPath(userId, id));
+        res.status(409).json({
+          error: 'A newer version already exists.',
+          code: ErrorCode.VALIDATION_ERROR,
+          stored,
+          indexEntry: existing,
+        });
+        return;
+      }
+      if (existing.modifiedAt === modifiedAt) {
+        // Equal-ms tie: deterministic tiebreaker so concurrent devices converge.
+        const stored = await getJson<TEnvelope>(blobPath(userId, id));
+        // Blob missing while index entry exists = divergence (deleted blob,
+        // failed prior write, etc.). Let the candidate repair it instead of
+        // running a tiebreaker against `undefined`, which would arbitrarily
+        // 409 a write that could have fixed the gap.
+        if (stored !== null) {
+          const order = compareForTiebreaker(tiebreakerCandidate, config.storedComparable(stored));
+          if (order <= 0) {
+            res.status(409).json({
+              error: 'A newer version already exists.',
+              code: ErrorCode.VALIDATION_ERROR,
+              stored,
+              indexEntry: existing,
+            });
+            return;
+          }
+        }
+      }
+    }
+
+    // Tombstone protection: a stale edit can't resurrect a deletion that
+    // happened *after* the local change.
+    if (existing?.deletedAt !== undefined && existing.deletedAt >= modifiedAt) {
+      res.status(410).json({
+        error: config.deletedError,
+        code: ErrorCode.NOT_FOUND,
+        indexEntry: existing,
+      });
+      return;
+    }
+
+    // Quota: replacing if the existing entry is live (tombstones don't count).
+    const replacingId = existing && existing.deletedAt === undefined ? id : undefined;
+    const quota = await checkQuota(redis, userId, config.kind, {
+      op: 'put',
+      sizeBytes,
+      replacingId,
+    });
+    if (!quota.ok) {
+      res.status(413).json({
+        error: `Quota exceeded (${quota.error.reason}): ${quota.error.current} of ${quota.error.limit}.`,
+        code: ErrorCode.SIZE_LIMIT,
+      });
+      return;
+    }
+
+    await putJson(blobPath(userId, id), envelope, { allowOverwrite: true });
+
+    const newEntry: IndexEntry = { modifiedAt, sizeBytes };
+    await upsertEntry(redis, userId, config.kind, id, newEntry);
+
+    res.status(200).json({ envelope, indexEntry: newEntry });
+  }
+
+  async function handleDelete(
+    res: VercelResponse,
+    redis: RedisClient,
+    userId: string,
+    id: string
+  ): Promise<void> {
+    const existing = await getEntry(redis, userId, config.kind, id);
+    // Already tombstoned: don't try to delete the blob (it's already gone)
+    // and don't bump the tombstone timestamp — the original deletion is
+    // the source of truth for LWW.
+    if (existing?.deletedAt !== undefined) {
+      res.status(204).end();
+      return;
+    }
+    if (!existing) {
+      // Never existed — write a tombstone so peer devices learn about
+      // the deletion on next pull. Idempotent.
+      await tombstone(redis, userId, config.kind, id, Date.now());
+      res.status(204).end();
+      return;
+    }
+    await deleteBlob(blobPath(userId, id));
+    await tombstone(redis, userId, config.kind, id, Date.now());
+    res.status(204).end();
+  }
+
+  return async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+    if (!requireMethod(req, res, ['GET', 'PUT', 'DELETE'])) return;
+
+    const session = await requireSession(req, res);
+    if (!session) return;
+
+    const id = singleParam(req.query.id);
+    if (!id || !config.isValidId(id)) {
+      res.status(400).json({ error: config.invalidIdError, code: ErrorCode.VALIDATION_ERROR });
+      return;
+    }
+
+    const action = req.method === 'GET' ? 'sync.read' : 'sync.write';
+    const rate = await checkRateLimit(session.userId, action);
+    if (!rate.allowed) {
+      rateLimited(res, rate.retryAfterSeconds);
+      return;
+    }
+
+    const redis = getRedis();
+    if (!redis) {
+      serviceUnavailable(res);
+      return;
+    }
+
+    try {
+      if (req.method === 'GET') {
+        await handleGet(res, redis, session.userId, id);
+      } else if (req.method === 'PUT') {
+        await handlePut(req, res, redis, session.userId, id);
+      } else {
+        await handleDelete(res, redis, session.userId, id);
+      }
+    } catch (error) {
+      logger.error(`sync/${config.kind} handler failed`, {
+        userId: session.userId,
+        method: req.method,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      serverError(res);
+    }
+  };
+}


### PR DESCRIPTION
## Summary

The `layouts`/`designs`/`baseplates` `[id].ts` handlers were ~80% identical (~880 lines total): the same method/session/rate-limit/Redis gate sequence, byte-identical GET and DELETE, and the same LWW machinery wrapped around a per-resource PUT validation middle.

**`createSyncResourceHandler`** (`api/sync/lib/resourceHandler.ts`) now owns the skeleton — and, more importantly, states the LWW semantics **once** instead of three drift-prone times:

- 409 when the remote is newer, with the stored envelope attached
- the equal-ms deterministic tiebreaker — including the subtle missing-blob case, where the tiebreaker is skipped so a candidate write can repair index/blob divergence instead of being arbitrarily 409'd
- tombstone protection (410 on stale resurrect) with the explicit `deletedAt === undefined` live-entry check the original comments warn about
- quota with live-replacement accounting (tombstones don't count)
- the blob+index write pair

Each resource keeps what genuinely differs, in its `buildPut`: payload unwrapping (wrapper vs. legacy bare params), name/tags sanitization, its validator, envelope shape, and tiebreaker candidate — plus its id format and 410 message. Per the original duplication audit: the skeleton merges, the PUT middle parametrizes.

Net: three ~300-line handlers become ~60/125/110-line configs + one 260-line skeleton (−390 lines), and a future LWW fix lands in one place.

## Testing

- **All 62 sync handler tests pass unchanged** — that's the load-bearing verification: the wire contract of all three resources is pinned by tests that did not move
- `pnpm run typecheck` and eslint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared sync resource handler for layouts, designs, and baseplates to remove duplicate LWW logic and make conflict handling consistent. API behavior stays the same; handlers are smaller and future fixes land in one place.

- **Refactors**
  - Introduced `createSyncResourceHandler` (`api/sync/lib/resourceHandler.ts`) centralizing session/rate-limit/Redis gates, identical GET/DELETE, and LWW semantics: 409 if remote is newer, equal-ms deterministic tiebreaker (skips when the blob is missing), tombstone protection (410 on stale resurrect), quota with live-replacement accounting, and the blob+index write pair.
  - Converted `api/sync/layouts/[id].ts`, `api/sync/designs/[id].ts`, and `api/sync/baseplates/[id].ts` into thin configs with per-resource `buildPut` (payload unwrap, name/tags sanitization, validation, envelope, tiebreaker candidate) plus id validation and 410 wording.
  - Cut ~390 LOC across handlers; all existing sync tests pass unchanged.

<sup>Written for commit f3e1f669e95a7902d4633369ea71659941d50297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

