### PR TITLE
fix(generation): carry kumiko per-segment widths through every clip path, retune sakura

### DIFF
--- a/src/features/generation/worker/generators/kumikoWrapBuilder.ts
+++ b/src/features/generation/worker/generators/kumikoWrapBuilder.ts
@@ -198,7 +198,13 @@ function clipSegmentToURangePeriodic(
   const pieces: KumikoSegment[] = [];
   for (const shift of [-period, 0, period]) {
     const shifted: KumikoSegment =
-      shift === 0 ? seg : { a: [seg.a[0] + shift, seg.a[1]], b: [seg.b[0] + shift, seg.b[1]] };
+      shift === 0
+        ? seg
+        : {
+            a: [seg.a[0] + shift, seg.a[1]],
+            b: [seg.b[0] + shift, seg.b[1]],
+            ...(seg.width === undefined ? {} : { width: seg.width }),
+          };
     const clipped = clipSegmentToURange(shifted, u0, u1);
     if (clipped) pieces.push(clipped);
   }
@@ -230,7 +236,11 @@ function extendSegment(seg: KumikoSegment, by: number): KumikoSegment {
   if (len < 1e-9) return seg;
   const dx = ((ub - ua) / len) * by;
   const dz = ((zb - za) / len) * by;
-  return { a: [ua - dx, za - dz], b: [ub + dx, zb + dz] };
+  return {
+    a: [ua - dx, za - dz],
+    b: [ub + dx, zb + dz],
+    ...(seg.width === undefined ? {} : { width: seg.width }),
+  };
 }
 
 /** Stroke a segment into a Drawing rectangle in slab-local (a, y) coords. */

--- a/src/features/generation/worker/generators/patterns/kumiko/fillings.test.ts
+++ b/src/features/generation/worker/generators/patterns/kumiko/fillings.test.ts
@@ -108,7 +108,7 @@ describe('kumiko vertex fillings', () => {
     const segs = filling(CELL, PITCH);
     expect(segs).toHaveLength(6);
     for (const seg of segs) {
-      expect(seg.width).toBeCloseTo(0.28 * CELL, 9);
+      expect(seg.width).toBeCloseTo(0.18 * CELL, 9);
     }
   });
 

--- a/src/features/generation/worker/generators/patterns/kumiko/sakura.ts
+++ b/src/features/generation/worker/generators/patterns/kumiko/sakura.ts
@@ -22,8 +22,11 @@ export const SAKURA_DEF: KumikoPatternDef = {
   maxColumns: 32,
   filling: (cellSize, columnPitch) => {
     const reach = (2 * columnPitch) / 3;
+    // Anchored near the vertex so each petal joins the star core with real
+    // material (a farther inner end leaves only a knife-edge contact with the
+    // arms), slim enough that lens-shaped openings remain outboard.
     return replicateRotations(
-      [{ a: [0.3 * reach, 0], b: [0.85 * reach, 0], width: 0.28 * cellSize }],
+      [{ a: [0.1 * reach, 0], b: [0.85 * reach, 0], width: 0.18 * cellSize }],
       SIX_FOLD
     );
   },

--- a/src/features/generation/worker/generators/patterns/kumiko/tsumiishiKikko.ts
+++ b/src/features/generation/worker/generators/patterns/kumiko/tsumiishiKikko.ts
@@ -3,8 +3,9 @@
  *
  * Radial ribs from each arm's midpoint toward the cell interior form
  * hexagonal chambers inside the triangular lattice. Base segments
- * (vertex-local, arm pointing +z): ledge (0, s/2) → (q/3, s/2) and brace
- * (q/2, s/4) → (q/3, s/2), replicated six-fold.
+ * (vertex-local, arm pointing +z): a symmetric ledge (−q/3, s/2) → (q/3, s/2)
+ * crossing each arm once (alternate-arm THREE_FOLD — arms are shared between
+ * vertices) and a brace (q/2, s/4) → (q/3, s/2) replicated six-fold.
  *
  * Pure-math module — NO brepjs imports.
  */


### PR DESCRIPTION
Review follow-ups from #2777 (Copilot's second pass landed after automerge fired):

- `clipSegmentToURangePeriodic` dropped `width` on ±period-shifted copies, and `extendSegment` dropped it on every capped piece — sakura's petals silently rendered at default strut width on flat walls. Both now spread the override through.
- With widths actually honored, sakura's original petal spec was wrong in both directions (too wide for the star gaps; anchored so far out that only the accidental thin render connected it to the star). Petals are now vertex-anchored at 0.18·s — solidly joined, lens openings restored. Render in PR discussion.
- Fixed tsumiishi-kikko's stale base-segment doc comment (symmetric three-fold ledge).

Sakura scenario + export-integrity slice re-verified; kumiko unit tests updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes kumiko segment widths not being preserved through clipping/extension so custom widths render correctly. Retunes the sakura petal to properly join the star core and restore the lens openings.

- **Bug Fixes**
  - Preserve per-segment width in periodic clipping and in extendSegment.
  - Sakura petals: anchor at 0.1·reach, width 0.18·s for solid joins and correct gaps.
  - Update unit test; fix tsumiishi-kikko doc comment.

<sup>Written for commit 137f1508137f1f2b727742038946d5085cdb3726. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

