### PR TITLE
fix(bin-designer): align lid enable toggle with other feature toggles

### DIFF
--- a/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
@@ -181,19 +181,12 @@ export function LidSection() {
     <div className="space-y-4">
       {/* Master enable. Disabled (with a reason) when the bin has no stacking
           lip or a blocker-severity feature conflict is unresolved. */}
-      <div>
-        <Switch
-          label={t('binDesigner.lid.enable')}
-          checked={state.enabled}
-          onChange={handlers.toggleEnabled}
-          disabled={!!state.disabledReason}
-        />
-        {state.disabledReason && (
-          <p className="mt-1 text-[11px] leading-relaxed text-content-tertiary">
-            {state.disabledReason}
-          </p>
-        )}
-      </div>
+      <FeatureToggle
+        label={t('binDesigner.lid.enable')}
+        checked={state.enabled}
+        onChange={handlers.toggleEnabled}
+        disabledReason={state.disabledReason}
+      />
 
       {state.enabled && (
         <>


### PR DESCRIPTION
## Summary

The lid panel's master "Enable lid" toggle used the raw design-system `Switch` (toggle on the left, label after it), while every other top-level feature enable in the panel — Stacking lip, Magnet holes, Screw holes, Flat base, Half sockets, Lightweight floor, Multi-Color — uses the shared `FeatureToggle` row (label on the left, toggle pushed to the right edge). This made the LID section visibly inconsistent with the BASE section directly above it.

## Changes

- Swap the master enable from `Switch` to `FeatureToggle` in `LidSection.tsx`.
- Drop the hand-rolled disabled-reason paragraph — `FeatureToggle` renders `disabledReason` itself.
- Nested sub-toggles (magnet holes, separate stack plate) intentionally stay on `Switch`, matching the sub-option pattern used by ToolRack and divider-tilt controls.

## Testing

- `pnpm exec vitest run src/features/bin-designer/components/panel/LidSection` — 39/39 pass unchanged (tests query `role="switch"` by accessible name, which both components expose).
- `pnpm run typecheck`, ESLint on the changed file — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the Lid section’s master “Enable lid” control with other feature toggles by switching from `Switch` to `FeatureToggle`. This standardizes the label-left/toggle-right layout and shows `disabledReason` automatically; sub-toggles stay on `Switch` to match existing patterns.

<sup>Written for commit aa2f5aa22736b582bc29f38a145e2d83626dd252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

