### PR TITLE
fix(generation): restore falling kumiko diagonals at bin corners

### DIFF
--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -167,8 +167,11 @@ shipped), and `wrapped-lattice` (kumiko). Wrapped-lattice patterns are authored 
 perimeter coordinates (`patterns/kumiko/segmentLattice.ts` — pure math, u-periodic triangular
 jigumi + per-vertex fillings) and built by `kumikoWrapBuilder.ts` as one continuous lattice
 around all four walls: flat spans as slab-minus-strut-prism cuts, corner arcs as annular wedges
-minus revolve/helix-swept struts (exact kernels only — Manifold drafts render the phase-aligned
-flat panels with solid corners and the OCCT result replaces them). The lattice column count is
+minus strut solids — vertical/horizontal revolves, rising diagonals as helix sweeps, falling
+diagonals as chord-box chains, because occt-wasm's `makeHelixWire` has no handedness input and
+a left-handed helix is unreachable (see `__kernel-tests__/helixHandedness.test.ts`). Exact
+kernels only — Manifold drafts render the phase-aligned flat panels with solid corners and the
+OCCT result replaces them. The lattice column count is
 quantized to an EVEN number so the ±30° diagonals reconnect across the u = 0 seam, and all slab
 clipping is periodicity-aware (`clipSegmentToURangePeriodic`). Kumiko composes with
 cutouts/handles/text/divider junctions through the same clip machinery as stamp patterns

--- a/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
@@ -72,6 +72,6 @@ describe('helix handedness tripwire', () => {
     expect(
       mirrored.vol,
       'mirror now produces a real solid from a helical sweep — a mirrored right-handed sweep can replace the kumiko chord boxes'
-    ).toBe(0);
+    ).toBeLessThan(1e-6);
   }, 120_000);
 });

--- a/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+/**
+ * Diagnostic (not a CI gate): pin occt-wasm's helix handedness behavior.
+ * Sweeps a rectangle along right- and left-handed helixes (radius 3, one
+ * radian over height 5) and reports each swept solid's angular footprint.
+ *
+ * Current findings (occt-wasm pinned pair):
+ *   - makeHelixWire has no handedness input, so brepjs's sketchHelix
+ *     left-handed flag is a NO-OP — both flags produce the identical
+ *     right-handed sweep. This is why kumikoWrapBuilder approximates corner
+ *     diagonals with chord boxes instead of helix sweeps.
+ *   - brepjs `mirror` on a helical sweep yields an EMPTY solid (volume 0),
+ *     so mirroring a right-handed sweep is not a viable left-handed
+ *     substitute either.
+ * If this probe ever shows the two flags diverging and mirror producing a
+ * real solid, the upstream gaps are fixed and the chord-box approximation
+ * can be revisited.
+ */
+import { describe, it, beforeAll } from 'vitest';
+import { sketchHelix, drawRoundedRectangle, mesh, mirror, measureVolume, unwrap } from 'brepjs';
+import { initBrepjs } from './wasmInit';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+function sweepAndMeasure(lefthand: boolean, mirrored = false): string {
+  const dPhi = 1;
+  const height = 5;
+  const pitch = (height * 2 * Math.PI) / dPhi;
+  const spine = sketchHelix(pitch, height, 3, [0, 0, 0], [0, 0, 1], lefthand);
+  let swept = spine.sweepSketch((plane) => drawRoundedRectangle(2, 1, 0).sketchOnPlane(plane), {
+    frenet: true,
+  });
+  if (mirrored) {
+    const m2 = mirror(swept, [0, 1, 0], [0, 0, 0]);
+    swept.delete();
+    swept = m2;
+  }
+  const vol = unwrap(measureVolume(swept));
+  const m = mesh(swept, { tolerance: 0.1 });
+  let phiMin = Infinity;
+  let phiMax = -Infinity;
+  let zMin = Infinity;
+  let zMax = -Infinity;
+  for (let i = 0; i < m.vertices.length; i += 3) {
+    const x = m.vertices[i];
+    const y = m.vertices[i + 1];
+    const z = m.vertices[i + 2];
+    const phi = Math.atan2(y, x);
+    if (phi < phiMin) phiMin = phi;
+    if (phi > phiMax) phiMax = phi;
+    if (z < zMin) zMin = z;
+    if (z > zMax) zMax = z;
+  }
+  swept.delete();
+  return `lefthand=${lefthand} mirrored=${mirrored} vol=${vol.toFixed(2)}: phi [${phiMin.toFixed(3)}, ${phiMax.toFixed(3)}], z [${zMin.toFixed(2)}, ${zMax.toFixed(2)}]`;
+}
+
+describe('helix handedness probe', () => {
+  it('measures swept solid angular footprint per handedness', () => {
+    // eslint-disable-next-line no-console
+    console.log(sweepAndMeasure(false));
+    // eslint-disable-next-line no-console
+    console.log(sweepAndMeasure(true));
+    // eslint-disable-next-line no-console
+    console.log(sweepAndMeasure(false, true));
+  }, 120_000);
+});

--- a/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
@@ -1,22 +1,20 @@
 // @vitest-environment node
 /**
- * Diagnostic (not a CI gate): pin occt-wasm's helix handedness behavior.
- * Sweeps a rectangle along right- and left-handed helixes (radius 3, one
- * radian over height 5) and reports each swept solid's angular footprint.
+ * Tripwire for occt-wasm's helix handedness gaps (run with the other
+ * __kernel-tests__ diagnostics on every brepjs/occt-wasm bump).
  *
- * Current findings (occt-wasm pinned pair):
+ * Pinned CURRENT behavior (the assertions below fail when upstream fixes it):
  *   - makeHelixWire has no handedness input, so brepjs's sketchHelix
  *     left-handed flag is a NO-OP — both flags produce the identical
  *     right-handed sweep. This is why kumikoWrapBuilder approximates corner
- *     diagonals with chord boxes instead of helix sweeps.
+ *     FALLING diagonals with chord boxes instead of helix sweeps.
  *   - brepjs `mirror` on a helical sweep yields an EMPTY solid (volume 0),
  *     so mirroring a right-handed sweep is not a viable left-handed
  *     substitute either.
- * If this probe ever shows the two flags diverging and mirror producing a
- * real solid, the upstream gaps are fixed and the chord-box approximation
- * can be revisited.
+ * A failure here means the upstream gap is fixed: retire the chord-box
+ * approximation in kumikoWrapBuilder's falling-diagonal branch.
  */
-import { describe, it, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { sketchHelix, drawRoundedRectangle, mesh, mirror, measureVolume, unwrap } from 'brepjs';
 import { initBrepjs } from './wasmInit';
 
@@ -24,7 +22,13 @@ beforeAll(async () => {
   await initBrepjs();
 }, 120_000);
 
-function sweepAndMeasure(lefthand: boolean, mirrored = false): string {
+interface SweepFootprint {
+  readonly vol: number;
+  readonly phiMin: number;
+  readonly phiMax: number;
+}
+
+function sweepAndMeasure(lefthand: boolean, mirrored = false): SweepFootprint {
   const dPhi = 1;
   const height = 5;
   const pitch = (height * 2 * Math.PI) / dPhi;
@@ -41,29 +45,33 @@ function sweepAndMeasure(lefthand: boolean, mirrored = false): string {
   const m = mesh(swept, { tolerance: 0.1 });
   let phiMin = Infinity;
   let phiMax = -Infinity;
-  let zMin = Infinity;
-  let zMax = -Infinity;
   for (let i = 0; i < m.vertices.length; i += 3) {
-    const x = m.vertices[i];
-    const y = m.vertices[i + 1];
-    const z = m.vertices[i + 2];
-    const phi = Math.atan2(y, x);
+    const phi = Math.atan2(m.vertices[i + 1], m.vertices[i]);
     if (phi < phiMin) phiMin = phi;
     if (phi > phiMax) phiMax = phi;
-    if (z < zMin) zMin = z;
-    if (z > zMax) zMax = z;
   }
   swept.delete();
-  return `lefthand=${lefthand} mirrored=${mirrored} vol=${vol.toFixed(2)}: phi [${phiMin.toFixed(3)}, ${phiMax.toFixed(3)}], z [${zMin.toFixed(2)}, ${zMax.toFixed(2)}]`;
+  return { vol, phiMin, phiMax };
 }
 
-describe('helix handedness probe', () => {
-  it('measures swept solid angular footprint per handedness', () => {
-    // eslint-disable-next-line no-console
-    console.log(sweepAndMeasure(false));
-    // eslint-disable-next-line no-console
-    console.log(sweepAndMeasure(true));
-    // eslint-disable-next-line no-console
-    console.log(sweepAndMeasure(false, true));
+describe('helix handedness tripwire', () => {
+  it('left-handed flag is still a no-op (else retire the kumiko chord-box workaround)', () => {
+    const right = sweepAndMeasure(false);
+    const left = sweepAndMeasure(true);
+    expect(right.vol).toBeGreaterThan(0);
+    expect(
+      left.phiMin,
+      'left-handed sketchHelix now diverges from right-handed — occt-wasm gained handedness; retire the chord-box approximation in kumikoWrapBuilder'
+    ).toBeCloseTo(right.phiMin, 3);
+    expect(left.phiMax).toBeCloseTo(right.phiMax, 3);
+    expect(left.vol).toBeCloseTo(right.vol, 3);
+  }, 120_000);
+
+  it('mirror on a helical sweep is still empty (else it becomes a viable left-handed substitute)', () => {
+    const mirrored = sweepAndMeasure(false, true);
+    expect(
+      mirrored.vol,
+      'mirror now produces a real solid from a helical sweep — a mirrored right-handed sweep can replace the kumiko chord boxes'
+    ).toBe(0);
   }, 120_000);
 });

--- a/src/features/generation/worker/generators/kumikoWrapBuilder.ts
+++ b/src/features/generation/worker/generators/kumikoWrapBuilder.ts
@@ -10,8 +10,9 @@
  *     the wall, placed with the stamp-pattern transform chain.
  *   - Corner arcs (exact kernels only): annular wedge minus strut solids —
  *     vertical struts as small-angle revolves, near-horizontal struts as thin
- *     partial revolves, diagonal struts swept along a helix (a straight line
- *     in unrolled space IS a helix on the corner cylinder).
+ *     partial revolves, rising diagonals swept along a helix (a straight
+ *     line in unrolled space IS a helix on the corner cylinder), falling
+ *     diagonals as chord-box chains (see the falling-diagonal branch).
  *
  * Mesh kernels (Manifold drafts) can't sweep along a helix, so the corner
  * cutters are skipped there: drafts show the phase-aligned flat panels with
@@ -673,21 +674,53 @@ function buildCornerSlabCutter(
       const phiB = phiOf(Math.max(ua, ub));
       const slab3d = annularWedge(sr0, sr1, zMid - pw / 2, zMid + pw / 2, phiB - phiA);
       families[1].push(toCornerAngle(slab3d, phiA));
-    } else {
-      // Diagonal strut: rectangle swept along a helix. Base the helix at the
-      // lower endpoint; it winds left-handed when φ decreases as z rises.
+    } else if (zb - za > 0 === ub - ua > 0) {
+      // Rising diagonal (φ and z increase together): rectangle swept along a
+      // right-handed helix — the exact strut surface, and the construction
+      // whose contacts with rib fillings are proven to sew in exports.
       const lowFirst = za <= zb;
       const [uLow, zLow] = lowFirst ? [ua, za] : [ub, zb];
       const [uHigh, zHigh] = lowFirst ? [ub, zb] : [ua, za];
       const dPhi = phiOf(uHigh) - phiOf(uLow);
       const height = zHigh - zLow;
       const pitch = (height * 2 * Math.PI) / Math.abs(dPhi);
-      const spine = sketchHelix(pitch, height, rMid, [0, 0, zLow], [0, 0, 1], dPhi < 0);
+      const spine = sketchHelix(pitch, height, rMid, [0, 0, zLow], [0, 0, 1], false);
       const swept = spine.sweepSketch(
         (plane) => drawRoundedRectangle(radialSpan, pw, 0).sketchOnPlane(plane),
         { frenet: true }
       );
-      families[zb - za > 0 === ub - ua > 0 ? 2 : 3].push(toCornerAngle(swept, phiOf(uLow)));
+      families[2].push(toCornerAngle(swept, phiOf(uLow)));
+    } else {
+      // Falling diagonal (φ decreases as z rises): needs a LEFT-handed helix,
+      // but occt-wasm's makeHelixWire has no handedness input (the brepjs
+      // left-handed flag is silently dropped — both flags produce the same
+      // right-handed sweep), so the sweep landed in the mirrored angular span
+      // and the wedge cut swallowed the true strut location (clipped pattern
+      // + holes on every corner). brepjs `mirror` on a helical sweep yields
+      // an empty solid, so instead approximate with straight chord boxes
+      // split under CHORD_MAX_PHI (same construction as non-vertical
+      // fillings; sagitta below print resolution).
+      const phiA = phiOf(ua);
+      const phiB = phiOf(ub);
+      const steps = Math.max(1, Math.ceil(Math.abs(phiB - phiA) / CHORD_MAX_PHI));
+      // Sub-chords overlap by a parameter margin — exactly-shared end planes
+      // leave coplanar tool faces that crack the corner cylinder in exports.
+      const tPad = steps > 1 ? 0.02 : 0;
+      for (let i = 0; i < steps; i++) {
+        const t0 = Math.max(0, i / steps - tPad);
+        const t1 = Math.min(1, (i + 1) / steps + tPad);
+        families[3].push(
+          chordBoxStrut(
+            phiA + (phiB - phiA) * t0,
+            za + (zb - za) * t0,
+            phiA + (phiB - phiA) * t1,
+            za + (zb - za) * t1,
+            pw,
+            sr0,
+            sr1
+          )
+        );
+      }
     }
   }
 

--- a/src/features/generation/worker/generators/scenarios/kumiko.ts
+++ b/src/features/generation/worker/generators/scenarios/kumiko.ts
@@ -115,7 +115,11 @@ function pointTriangleDistance(
     const t = (d4 - d3) / (d4 - d3 + (d5 - d6));
     return dist([b[0] + (c[0] - b[0]) * t, b[1] + (c[1] - b[1]) * t, b[2] + (c[2] - b[2]) * t]);
   }
-  const denom = 1 / (va + vb + vc);
+  const sum = va + vb + vc;
+  // Degenerate (zero-area) triangle: barycentric weights are undefined, so
+  // fall back to the nearest vertex instead of dividing by ~0.
+  if (Math.abs(sum) < 1e-12) return Math.min(dist(a), dist(b), dist(c));
+  const denom = 1 / sum;
   const v = vb * denom;
   const w = vc * denom;
   return dist([

--- a/src/features/generation/worker/generators/scenarios/kumiko.ts
+++ b/src/features/generation/worker/generators/scenarios/kumiko.ts
@@ -13,10 +13,17 @@
  */
 import { expect } from 'vitest';
 import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
+import { DEFAULT_PATTERN_SCALE } from '@/shared/types/bin';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 import type { MeshData } from '@/features/generation/bridge/types';
-import type { WallPatternType } from '@/shared/types/bin';
+import type { BinParams, WallPatternType } from '@/shared/types/bin';
+import { deriveDimensions } from '../pipeline/context';
+import { TOP_KEEP_OUT, BOTTOM_SOLID_SKIRT } from '../wallPatterns';
+import { SOCKET_HEIGHT, BOX_CORNER_RADIUS } from '../generatorConstants';
+import { scaleFactor } from '../patterns/patternScale';
+import { generateKumikoLattice, KUMIKO_BASE_CELL_SIZE } from '../patterns/kumiko/segmentLattice';
+import { MITSUKUDE_DEF } from '../patterns/kumiko/mitsukude';
 import { assertRemovesMaterial } from './wallPatterns';
 
 const ALL_SIDES_OFF = {
@@ -64,6 +71,156 @@ function assertCornersWrapped(widthU: number, depthU: number) {
   };
 }
 
+/** Closest distance from a point to a triangle (Ericson, Real-Time Collision Detection). */
+function pointTriangleDistance(
+  p: readonly number[],
+  a: readonly number[],
+  b: readonly number[],
+  c: readonly number[]
+): number {
+  const sub = (u: readonly number[], v: readonly number[]): number[] => [
+    u[0] - v[0],
+    u[1] - v[1],
+    u[2] - v[2],
+  ];
+  const dot = (u: readonly number[], v: readonly number[]): number =>
+    u[0] * v[0] + u[1] * v[1] + u[2] * v[2];
+  const ab = sub(b, a);
+  const ac = sub(c, a);
+  const ap = sub(p, a);
+  const d1 = dot(ab, ap);
+  const d2 = dot(ac, ap);
+  const dist = (q: readonly number[]): number => Math.hypot(p[0] - q[0], p[1] - q[1], p[2] - q[2]);
+  if (d1 <= 0 && d2 <= 0) return dist(a);
+  const bp = sub(p, b);
+  const d3 = dot(ab, bp);
+  const d4 = dot(ac, bp);
+  if (d3 >= 0 && d4 <= d3) return dist(b);
+  const vc = d1 * d4 - d3 * d2;
+  if (vc <= 0 && d1 >= 0 && d3 <= 0) {
+    const t = d1 / (d1 - d3);
+    return dist([a[0] + ab[0] * t, a[1] + ab[1] * t, a[2] + ab[2] * t]);
+  }
+  const cp = sub(p, c);
+  const d5 = dot(ab, cp);
+  const d6 = dot(ac, cp);
+  if (d6 >= 0 && d5 <= d6) return dist(c);
+  const vb = d5 * d2 - d1 * d6;
+  if (vb <= 0 && d2 >= 0 && d6 <= 0) {
+    const t = d2 / (d2 - d6);
+    return dist([a[0] + ac[0] * t, a[1] + ac[1] * t, a[2] + ac[2] * t]);
+  }
+  const va = d3 * d6 - d5 * d4;
+  if (va <= 0 && d4 - d3 >= 0 && d5 - d6 >= 0) {
+    const t = (d4 - d3) / (d4 - d3 + (d5 - d6));
+    return dist([b[0] + (c[0] - b[0]) * t, b[1] + (c[1] - b[1]) * t, b[2] + (c[2] - b[2]) * t]);
+  }
+  const denom = 1 / (va + vb + vc);
+  const v = vb * denom;
+  const w = vc * denom;
+  return dist([
+    a[0] + ab[0] * v + ac[0] * w,
+    a[1] + ab[1] * v + ac[1] * w,
+    a[2] + ab[2] * v + ac[2] * w,
+  ]);
+}
+
+/** Min distance from a point to any triangle of an indexed mesh. */
+function distanceToMesh(mesh: MeshData, p: readonly number[]): number {
+  const { vertices, indices } = mesh;
+  let min = Infinity;
+  for (let t = 0; t < indices.length; t += 3) {
+    const ia = indices[t] * 3;
+    const ib = indices[t + 1] * 3;
+    const ic = indices[t + 2] * 3;
+    const d = pointTriangleDistance(
+      p,
+      [vertices[ia], vertices[ia + 1], vertices[ia + 2]],
+      [vertices[ib], vertices[ib + 1], vertices[ib + 2]],
+      [vertices[ic], vertices[ic + 1], vertices[ic + 2]]
+    );
+    if (d < min) min = d;
+  }
+  return min;
+}
+
+/**
+ * Both diagonal families must survive the corner wrap: for every point where
+ * a lattice diagonal crosses a corner arc, the outer wall surface must carry
+ * strut material. Guards the falling-diagonal family specifically — a
+ * mis-wound corner helix (the occt-wasm left-handed flag is a no-op) sweeps
+ * those struts to the mirrored angular span, so the wedge cut swallows the
+ * real strut location and the pattern reads as clipped with holes.
+ */
+function assertCornerDiagonalsPresent(mesh: MeshData, params: BinParams): void {
+  const dims = deriveDimensions(params, false);
+  const wallThickness = params.wallThickness;
+  const outerW = dims.innerW + 2 * wallThickness;
+  const outerD = dims.innerD + 2 * wallThickness;
+  const r = Math.min(BOX_CORNER_RADIUS, Math.min(outerW, outerD) / 2 - 0.1);
+  const flatW = outerW - 2 * r;
+  const flatD = outerD - 2 * r;
+  const arc = (Math.PI / 2) * r;
+  const perimeter = 2 * flatW + 2 * flatD + 4 * arc;
+  const bottomKeepOut = wallThickness + BOTTOM_SOLID_SKIRT;
+  const bandHeight = dims.interiorHeight - TOP_KEEP_OUT - bottomKeepOut;
+  const bandZ0 = SOCKET_HEIGHT + bottomKeepOut;
+  const scale = params.wallPattern.scale ?? DEFAULT_PATTERN_SCALE;
+  const lattice = generateKumikoLattice(
+    MITSUKUDE_DEF,
+    { perimeter, bandHeight },
+    KUMIKO_BASE_CELL_SIZE * scaleFactor(scale)
+  );
+
+  const corners = [
+    { name: 'FR', u0: flatW, cx: outerW / 2 - r, cy: -outerD / 2 + r, theta0: -Math.PI / 2 },
+    { name: 'BR', u0: flatW + arc + flatD, cx: outerW / 2 - r, cy: outerD / 2 - r, theta0: 0 },
+    {
+      name: 'BL',
+      u0: 2 * flatW + 2 * arc + flatD,
+      cx: -outerW / 2 + r,
+      cy: outerD / 2 - r,
+      theta0: Math.PI / 2,
+    },
+    {
+      name: 'FL',
+      u0: 2 * flatW + 3 * arc + 2 * flatD,
+      cx: -outerW / 2 + r,
+      cy: -outerD / 2 + r,
+      theta0: Math.PI,
+    },
+  ];
+
+  const missing: string[] = [];
+  for (const corner of corners) {
+    for (const frac of [0.3, 0.5, 0.7]) {
+      const u = corner.u0 + arc * frac;
+      for (const seg of lattice.segments) {
+        const du = seg.b[0] - seg.a[0];
+        const dz = seg.b[1] - seg.a[1];
+        if (Math.abs(du) < 0.15 || Math.abs(dz) < 0.15) continue;
+        for (const shift of [-perimeter, 0, perimeter]) {
+          const ua = seg.a[0] + shift;
+          const ub = seg.b[0] + shift;
+          if (u < Math.min(ua, ub) || u > Math.max(ua, ub)) continue;
+          const z = seg.a[1] + ((u - ua) / du) * dz;
+          if (z < 1.5 || z > bandHeight - 1.5) continue;
+          const theta = corner.theta0 + (u - corner.u0) / r;
+          const p = [corner.cx + r * Math.cos(theta), corner.cy + r * Math.sin(theta), bandZ0 + z];
+          const d = distanceToMesh(mesh, p);
+          if (d > 0.4) {
+            const family = dz / du > 0 ? 'rising' : 'falling';
+            missing.push(
+              `${corner.name} ${family} diagonal absent at u=${u.toFixed(1)} z=${z.toFixed(1)} (surface ${d.toFixed(2)}mm away)`
+            );
+          }
+        }
+      }
+    }
+  }
+  expect(missing, missing.join('\n')).toEqual([]);
+}
+
 /** Compact per-pattern case: valid geometry + material removed vs solid twin. */
 function kumikoPatternCase(pattern: WallPatternType): ScenarioCase {
   return defineScenario('kumiko', `${pattern} carves a 1×1×6 bin`, {
@@ -90,6 +247,19 @@ function kumikoPatternCase(pattern: WallPatternType): ScenarioCase {
 }
 
 export const kumiko: ScenarioCase[] = [
+  defineScenario('kumiko', 'mitsukude keeps both diagonal families on corners (1×1×4, bold)', {
+    assert: 'structural',
+    timeout: 180_000,
+    params: {
+      width: 1,
+      depth: 1,
+      height: 4,
+      wallThickness: 1.2,
+      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 1 },
+      walls: ALL_SIDES_OFF,
+    },
+    customAssert: assertCornerDiagonalsPresent,
+  }),
   kumikoPatternCase('goma'),
   defineScenario('kumiko', 'asanoha wraps a 1×1×6 bin including corners', {
     assert: 'structural',

--- a/src/features/generation/worker/generators/scenarios/kumiko.ts
+++ b/src/features/generation/worker/generators/scenarios/kumiko.ts
@@ -125,8 +125,12 @@ function pointTriangleDistance(
   ]);
 }
 
-/** Min distance from a point to any triangle of an indexed mesh. */
-function distanceToMesh(mesh: MeshData, p: readonly number[]): number {
+/**
+ * Min distance from a point to any triangle of an indexed mesh, with an
+ * early exit once a triangle within `closeEnough` is found — callers only
+ * need "is the surface within threshold", not the exact minimum.
+ */
+function distanceToMesh(mesh: MeshData, p: readonly number[], closeEnough: number): number {
   const { vertices, indices } = mesh;
   let min = Infinity;
   for (let t = 0; t < indices.length; t += 3) {
@@ -140,6 +144,7 @@ function distanceToMesh(mesh: MeshData, p: readonly number[]): number {
       [vertices[ic], vertices[ic + 1], vertices[ic + 2]]
     );
     if (d < min) min = d;
+    if (min <= closeEnough) return min;
   }
   return min;
 }
@@ -207,7 +212,7 @@ function assertCornerDiagonalsPresent(mesh: MeshData, params: BinParams): void {
           if (z < 1.5 || z > bandHeight - 1.5) continue;
           const theta = corner.theta0 + (u - corner.u0) / r;
           const p = [corner.cx + r * Math.cos(theta), corner.cy + r * Math.sin(theta), bandZ0 + z];
-          const d = distanceToMesh(mesh, p);
+          const d = distanceToMesh(mesh, p, 0.4);
           if (d > 0.4) {
             const family = dz / du > 0 ? 'rising' : 'falling';
             missing.push(


### PR DESCRIPTION
## Summary

Fixes the kumiko wall patterns rendering clipped, with holes, where the lattice wraps around bin corners (visible on every pattern in the set; screenshot repro was mitsukude on a 1×1×4 at 100% scale).

## Root cause

occt-wasm's `makeHelixWire` binding takes `(origin, axis, pitch, height, radius)` — there is **no handedness parameter** — so brepjs's `sketchHelix` left-handed flag is a silent no-op. Both flags produce the identical right-handed sweep (pinned by the new `__kernel-tests__/helixHandedness.test.ts` diagnostic).

At bin corners, falling diagonals (φ decreasing as z rises) need a left-handed helix. They got a right-handed one instead, sweeping the strut solid into the mirrored angular span; the corner wedge cut then swallowed the true strut location. Result: one entire diagonal family missing from every corner — the pattern reads as chopped flush at the wall tangent planes with holes through the corner arcs. The existing corner-wrap proof (corner vertex count > 2× solid twin) can't catch selective family loss, since verticals + rising diagonals alone clear the bar.

## Fix

- **Rising diagonals keep the exact helix sweep** — they were always wound correctly, and their contacts with filling ribs (goma) are proven to sew in exports.
- **Falling diagonals become chord-box chains** (`chordBoxStrut` split under `CHORD_MAX_PHI` with `tPad` overlap) — the same construction non-vertical fillings already use; sagitta stays below print resolution. A left-handed sweep is unreachable with the pinned kernel, and brepjs `mirror` on a helical sweep returns an empty solid, so mirroring is not a viable substitute.

Converting *both* families to chord boxes was tried and rejected: it introduced 6 boundary-edge cracks in goma exports (an unstitched micro-face at a rib/arm contact on the corner cylinder) that neither deeper overlaps, tool fusing, nor `simplify` reliably removed. Keeping rising arms helical avoids that contact class entirely.

## Testing

- New scenario `mitsukude keeps both diagonal families on corners (1×1×4, bold)`: samples every lattice-predicted diagonal crossing on all four corner arcs and requires wall material at each. Fails on main (14 missing falling diagonals); passes with the fix.
- Full kumiko scenario suite: 14/14.
- Full export-integrity matrix: **408/408** — goma exports watertight (0 boundary edges), byte-identical output verified across equivalent param spellings.
- Measured corner mesh density is now symmetric across all four corners (was 25% lighter on the two corners missing falling struts).
- `pnpm run typecheck`, ESLint: clean.

## Upstream follow-up

The real gap is occt-wasm's missing helix handedness parameter. `helixHandedness.test.ts` documents the current behavior and acts as a tripwire: when the flags diverge and `mirror` produces volume, the chord-box approximation can be revisited.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores missing falling diagonals on kumiko corner arcs by switching them to chord-box chains, so the lattice wraps cleanly with no holes. Rising diagonals stay as exact helix sweeps; vertical/horizontal struts are unchanged.

- Bug Fixes
  - Falling diagonals now use chord-box chains split by `CHORD_MAX_PHI` with small overlap; replaces the unreachable left-handed helix (`occt-wasm` `makeHelixWire` lacks handedness, and `brepjs` `mirror` of a helical sweep yields an empty solid).
  - Rising diagonals keep helical sweeps.
  - Added `__kernel-tests__/helixHandedness.test.ts` as an asserting tripwire with an epsilon-volume check; improved the corner scenario with an early-exit mesh distance probe that handles degenerate triangles and verifies both diagonal families on all four corners; README notes updated.

<sup>Written for commit b78c15e6170b3d69f09ab22c910f9354c1af02a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

