### PR TITLE
fix(generation): pack diamond wall pattern as a tight staggered lattice

### DIFF
--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -483,7 +483,7 @@ function computeScoopVolume(
 const PATTERN_VOID_FRACTION: Record<WallPatternType, number> = {
   honeycomb: 0.907,
   round: 0.62,
-  diamond: 0.5,
+  diamond: 0.72,
   triangle: 0.42,
   slots: 0.48,
   mitsukude: 0.58,

--- a/src/features/generation/worker/generators/patterns/diamondPattern.test.ts
+++ b/src/features/generation/worker/generators/patterns/diamondPattern.test.ts
@@ -12,20 +12,30 @@ describe('DiamondPatternCalculator', () => {
     expect(calc.getPatternType()).toBe('diamond');
   });
 
-  it('uses an aligned (non-staggered) grid — rows share the same x positions', () => {
-    const calc = new DiamondPatternCalculator(2);
+  it('packs a staggered checkerboard lattice with uniform edge webs', () => {
+    const web = 0.8;
+    const calc = new DiamondPatternCalculator(2, web);
     const centers = calc.calculateCenters({ fillW: 40, fillH: 40 });
     expect(centers.length).toBeGreaterThan(0);
-    const xsAtY0 = centers.filter((c) => Math.abs(c.y) < 1e-6).map((c) => c.x);
-    const ys = [...new Set(centers.map((c) => Math.round(c.y * 1000)))];
-    // Every row reuses the same column x-set (no half-column stagger).
-    for (const yKey of ys) {
-      const xsAtRow = centers
+
+    const colSpacing = 2 * 2 + web * Math.SQRT2;
+    const rows = [...new Set(centers.map((c) => Math.round(c.y * 1000)))].sort((a, b) => a - b);
+    expect(rows.length).toBeGreaterThan(2);
+    for (let i = 1; i < rows.length; i++) {
+      expect((rows[i] - rows[i - 1]) / 1000).toBeCloseTo(colSpacing / 2, 2);
+    }
+
+    // Adjacent rows are offset half a column; diagonal neighbors' parallel
+    // 45° edges then sit exactly one web thickness apart.
+    const xs = (yKey: number): number[] =>
+      centers
         .filter((c) => Math.round(c.y * 1000) === yKey)
         .map((c) => c.x)
         .sort((a, b) => a - b);
-      expect(xsAtRow).toEqual([...xsAtY0].sort((a, b) => a - b));
-    }
+    const [row0, row1] = [xs(rows[0]), xs(rows[1])];
+    expect(Math.abs(row1[0] - row0[0]) % colSpacing).toBeCloseTo(colSpacing / 2, 6);
+    const edgeGap = (colSpacing - 2 * 2) / Math.SQRT2;
+    expect(edgeGap).toBeCloseTo(web, 6);
   });
 });
 

--- a/src/features/generation/worker/generators/patterns/diamondPattern.ts
+++ b/src/features/generation/worker/generators/patterns/diamondPattern.ts
@@ -1,8 +1,9 @@
 /**
- * Diamond-lattice (argyle) pattern calculator.
+ * Diamond-lattice pattern calculator.
  *
- * Axis-aligned grid of squares rotated 45°, reading as a diamond lattice. The
- * aligned (non-staggered) grid gives the clean argyle look. Pure math module —
+ * Squares rotated 45° packed on a checkerboard lattice (odd rows offset half a
+ * column), so the openings tile the wall and the remaining material forms
+ * uniform diagonal webs — the classic diamond-mesh grille. Pure math module —
  * no brepjs imports.
  */
 
@@ -12,7 +13,7 @@ import type {
   ShapeDescriptor,
   StampPatternCalculator,
 } from './types';
-import { calculateAlignedGrid } from './gridUtils';
+import { calculateStaggeredGrid } from './gridUtils';
 import { PATTERN_WEB_THICKNESS, resolveElementRadius } from './patternScale';
 
 export class DiamondPatternCalculator implements StampPatternCalculator {
@@ -30,11 +31,13 @@ export class DiamondPatternCalculator implements StampPatternCalculator {
   calculateCenters(config: PatternGridConfig): PatternCenter[] {
     const { fillW, fillH } = config;
     const R = this.radius;
-    // Diamond (square rotated 45°) spans 2R vertex-to-vertex on both axes.
-    const spacing = 2 * R + this.webThickness;
+    // Checkerboard packing: diagonal neighbors sit at (c/2, c/2), so their
+    // parallel 45° edges are (c − 2R)/√2 apart. c = 2R + web·√2 makes that
+    // gap exactly the web thickness.
+    const colSpacing = 2 * R + this.webThickness * Math.SQRT2;
     const maxX = fillW / 2 - R;
     const maxY = fillH / 2 - R;
-    return calculateAlignedGrid({ maxX, maxY, colSpacing: spacing, rowSpacing: spacing });
+    return calculateStaggeredGrid({ maxX, maxY, colSpacing, rowSpacing: colSpacing / 2 });
   }
 
   getShapeDescriptor(): ShapeDescriptor {

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -38,7 +38,7 @@ const META_STORE = 'binMeshMeta';
  * Preview always uses the occt-wasm exact kernel at `forExport=false`, so the
  * kernel and quality are folded into this constant rather than the per-entry key.
  */
-const MESH_CACHE_VERSION = 'v3-brepjs18.116.1';
+const MESH_CACHE_VERSION = 'v4-diamond-lattice';
 
 /** Evict oldest entries once the total stored mesh bytes exceed this budget. */
 let maxCacheBytes = 64 * 1024 * 1024;

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -38,7 +38,7 @@ const META_STORE = 'binMeshMeta';
  * Preview always uses the occt-wasm exact kernel at `forExport=false`, so the
  * kernel and quality are folded into this constant rather than the per-entry key.
  */
-const MESH_CACHE_VERSION = 'v4-diamond-lattice';
+const MESH_CACHE_VERSION = 'v4-brepjs18.119.2';
 
 /** Evict oldest entries once the total stored mesh bytes exceed this budget. */
 let maxCacheBytes = 64 * 1024 * 1024;


### PR DESCRIPTION
## Problem

The diamond wall pattern read as sparse floating squares rather than a lattice. The calculator placed diamonds on an **aligned** grid spaced `2R + web`, but a 45°-rotated square tiles the plane on a *checkerboard* lattice — so the aligned grid left solid diamond-shaped slabs exactly as large as the holes (~50% open). On a 2×2×6 bin that rendered as three thin rows of small diamonds in mostly solid wall, while honeycomb and triangle fill their walls edge-to-edge with uniform webs.

## Fix

`DiamondPatternCalculator.calculateCenters` now packs a staggered checkerboard lattice:

- `colSpacing = 2R + web·√2`, `rowSpacing = colSpacing / 2`, odd rows offset half a column (`calculateStaggeredGrid`)
- Diagonal neighbors' facing edges are parallel 45° lines; the √2 term puts them exactly one web thickness (0.8mm) apart, giving uniform diagonal struts — the classic diamond-mesh grille, matching the visual language of honeycomb/triangle
- All hole edges stay at 45°, so the pattern remains supportless-printable

## Supporting changes

- `printEstimates.ts`: `PATTERN_VOID_FRACTION.diamond` 0.5 → 0.72 (`4R²/c²` for the new packing)
- `meshPersistence.ts`: bumped `MESH_CACHE_VERSION` — geometry changed for identical params, so the cross-session IndexedDB mesh cache must not serve stale meshes
- `diamondPattern.test.ts`: aligned-grid assertion replaced with staggered-lattice + edge-web assertions

## Verification

- `patterns/` unit tests, `wallPatterns.test.ts`, `meshPersistence.test.ts`, `printEstimates.test.ts` — 110 tests pass
- `binGenerator.scenario.wallPatterns` on real OCCT WASM — structural validity + volume-reduction assertions pass (this domain deliberately uses volume comparison, not triangleCount snapshots, so no snapshot churn)
- Verified visually in the designer (front + iso views, short and tall bins): dense uniform mesh, no jagged edges at wall borders
- Draft parity: `canBinUseDirectMesh` rejects all wall-pattern bins — no direct-mesh emitter to update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the diamond wall pattern by using a staggered checkerboard lattice so openings tile and webs are uniform. Updates print estimates and bumps the mesh cache version (with kernel provenance) to reflect the new geometry.

- **Bug Fixes**
  - Packs a checkerboard lattice: `colSpacing = 2R + web·√2`, `rowSpacing = colSpacing / 2`, odd rows offset by half a column; keeps 45° edges for supportless printing.
  - Updates void fraction for `diamond` from 0.5 to 0.72 in `printEstimates.ts`.
  - Sets `MESH_CACHE_VERSION` to `v4-brepjs18.119.2` to invalidate old meshes and retain the brepjs kernel provenance; adjusts tests for staggered layout and uniform edge-web gap.

<sup>Written for commit 536ce560b860cf6e04a4117bd1768ef83b42c826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

