### PR TITLE
feat(export): mobile continue-on-desktop handoff via account sync

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Anmelden",
+  "export.mobileHandoff.message": "Druckst du am Computer? Melde dich an – deine Arbeit wird mit deinem Konto synchronisiert. Öffne die Seite am Desktop, um fertigzustellen.",
   "auth.signInWithGithub": "Mit GitHub anmelden",
   "auth.signInWithGoogle": "Mit Google anmelden",
   "auth.signOut": "Abmelden",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -155,6 +155,8 @@ const en: Record<string, string> = {
 
   // Sign-in / user menu (multi-device sync)
   'auth.signIn': 'Sign in',
+  'export.mobileHandoff.message':
+    'Printing from your computer? Sign in and your work syncs to your account — open this site on desktop to finish.',
   'auth.signInWithGoogle': 'Sign in with Google',
   'auth.signInWithGithub': 'Sign in with GitHub',
   'auth.signOut': 'Sign out',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Iniciar sesión",
+  "export.mobileHandoff.message": "¿Imprimes desde tu ordenador? Inicia sesión y tu trabajo se sincroniza con tu cuenta: abre este sitio en el escritorio para terminar.",
   "auth.signInWithGithub": "Iniciar sesión con GitHub",
   "auth.signInWithGoogle": "Iniciar sesión con Google",
   "auth.signOut": "Cerrar sesión",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Se connecter",
+  "export.mobileHandoff.message": "Vous imprimez depuis votre ordinateur ? Connectez-vous et votre travail se synchronise avec votre compte — ouvrez ce site sur desktop pour terminer.",
   "auth.signInWithGithub": "Se connecter avec GitHub",
   "auth.signInWithGoogle": "Se connecter avec Google",
   "auth.signOut": "Se déconnecter",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Accedi",
+  "export.mobileHandoff.message": "Stampi dal computer? Accedi e il tuo lavoro si sincronizza con il tuo account: apri questo sito su desktop per completare.",
   "auth.signInWithGithub": "Accedi con GitHub",
   "auth.signInWithGoogle": "Accedi con Google",
   "auth.signOut": "Esci",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "サインイン",
+  "export.mobileHandoff.message": "パソコンから印刷しますか？サインインすると作業内容がアカウントに同期されます。デスクトップでこのサイトを開いて仕上げてください。",
   "auth.signInWithGithub": "GitHubでサインイン",
   "auth.signInWithGoogle": "Googleでサインイン",
   "auth.signOut": "サインアウト",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Logg inn",
+  "export.mobileHandoff.message": "Skriver du ut fra datamaskinen? Logg inn, så synkroniseres arbeidet ditt med kontoen din – åpne siden på desktop for å fullføre.",
   "auth.signInWithGithub": "Logg inn med GitHub",
   "auth.signInWithGoogle": "Logg inn med Google",
   "auth.signOut": "Logg ut",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Aanmelden",
+  "export.mobileHandoff.message": "Print je vanaf je computer? Log in en je werk synchroniseert met je account – open deze site op desktop om af te ronden.",
   "auth.signInWithGithub": "Aanmelden met GitHub",
   "auth.signInWithGoogle": "Aanmelden met Google",
   "auth.signOut": "Afmelden",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Entrar",
+  "export.mobileHandoff.message": "Vai imprimir do computador? Entre e seu trabalho sincroniza com sua conta — abra este site no desktop para concluir.",
   "auth.signInWithGithub": "Entrar com GitHub",
   "auth.signInWithGoogle": "Entrar com Google",
   "auth.signOut": "Sair",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Logga in",
+  "export.mobileHandoff.message": "Skriver du ut från datorn? Logga in så synkas ditt arbete med ditt konto – öppna sidan på datorn för att slutföra.",
   "auth.signInWithGithub": "Logga in med GitHub",
   "auth.signInWithGoogle": "Logga in med Google",
   "auth.signOut": "Logga ut",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -27,6 +27,7 @@
   "auth.providerGithub": "GitHub",
   "auth.providerGoogle": "Google",
   "auth.signIn": "Увійти",
+  "export.mobileHandoff.message": "Друкуєте з комп'ютера? Увійдіть — ваша робота синхронізується з обліковим записом. Відкрийте цей сайт на десктопі, щоб завершити.",
   "auth.signInWithGithub": "Увійти через GitHub",
   "auth.signInWithGoogle": "Увійти через Google",
   "auth.signOut": "Вийти",

--- a/src/shared/components/ExportDialog/ExportDialog.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.tsx
@@ -13,6 +13,7 @@ import { Dialog } from '@/design-system/Dialog';
 import { ProgressBar } from '@/design-system/ProgressBar';
 import { useTranslation } from '@/i18n';
 import type { ExportFileFormat, ExportFileNameConfig, FileNameStyle } from '@/shared/types/bin';
+import { MobileHandoffBanner } from './MobileHandoffBanner';
 
 /** Ordered format options for the selector */
 const FORMAT_OPTIONS: readonly ExportFileFormat[] = ['3mf', 'stl', 'step'] as const;
@@ -380,6 +381,8 @@ export function ExportDialog({
             {noMeshWarning && !canExport && (
               <p className="mt-2 text-center text-xs text-warning">{noMeshWarning}</p>
             )}
+
+            <MobileHandoffBanner />
           </div>
         )}
       </Dialog.Body>

--- a/src/shared/components/ExportDialog/MobileHandoffBanner.test.tsx
+++ b/src/shared/components/ExportDialog/MobileHandoffBanner.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@/shared/analytics/posthog', () => ({
+  trackEvent: vi.fn(),
+}));
+
+const responsive = { isMobile: true, isTablet: false, isDesktop: false, isLandscape: false };
+vi.mock('@/shared/hooks/useResponsive', () => ({
+  useResponsive: () => responsive,
+}));
+
+import { trackEvent } from '@/shared/analytics/posthog';
+import { useSessionStore } from '@/core/sync/session/useSession';
+import { MobileHandoffBanner } from './MobileHandoffBanner';
+
+beforeEach(() => {
+  responsive.isMobile = true;
+  useSessionStore.setState({ status: 'anonymous', user: null });
+  vi.mocked(trackEvent).mockClear();
+});
+
+describe('MobileHandoffBanner', () => {
+  it('offers sign-in on mobile for anonymous users and tracks the impression', () => {
+    render(<MobileHandoffBanner />);
+
+    expect(screen.getByRole('link', { name: /google/i })).toHaveAttribute(
+      'href',
+      '/api/auth/login/google'
+    );
+    expect(screen.getByRole('link', { name: /github/i })).toHaveAttribute(
+      'href',
+      '/api/auth/login/github'
+    );
+    expect(trackEvent).toHaveBeenCalledWith('mobile_handoff', { action: 'shown' });
+  });
+
+  it('renders nothing on desktop', () => {
+    responsive.isMobile = false;
+
+    const { container } = render(<MobileHandoffBanner />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing for signed-in users', () => {
+    useSessionStore.setState({
+      status: 'authenticated',
+      user: { userId: 'u1', email: 'a@b.c', provider: 'google' },
+    });
+
+    const { container } = render(<MobileHandoffBanner />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/shared/components/ExportDialog/MobileHandoffBanner.tsx
+++ b/src/shared/components/ExportDialog/MobileHandoffBanner.tsx
@@ -1,0 +1,57 @@
+/**
+ * "Continue on desktop" offer shown inside export dialogs on mobile for
+ * anonymous users. Mobile users create at a healthy rate but almost never
+ * download files — signing in syncs their work to their account so they can
+ * finish from a desktop browser. Direct mobile export stays available.
+ */
+
+import { useEffect } from 'react';
+import { useResponsive } from '@/shared/hooks/useResponsive';
+import { useSessionStore } from '@/core/sync/session/useSession';
+import { signInUrl } from '@/core/sync/session/sessionApi';
+import { trackEvent } from '@/shared/analytics/posthog';
+import { useTranslation } from '@/i18n';
+
+export function MobileHandoffBanner() {
+  const t = useTranslation();
+  const { isMobile } = useResponsive();
+  const status = useSessionStore((s) => s.status);
+
+  const visible = isMobile && status === 'anonymous';
+
+  useEffect(() => {
+    if (visible) {
+      trackEvent('mobile_handoff', { action: 'shown' });
+    }
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="mt-3 rounded-lg border border-stroke-subtle bg-surface p-3">
+      <p className="text-xs text-content-secondary leading-relaxed">
+        {t('export.mobileHandoff.message')}
+      </p>
+      <div className="mt-2 flex gap-2">
+        <a
+          href={signInUrl('google')}
+          onClick={() =>
+            trackEvent('mobile_handoff', { action: 'signin_clicked', provider: 'google' })
+          }
+          className="flex-1 rounded-md border border-stroke-subtle px-2 py-1.5 text-center text-xs font-medium text-content hover:bg-surface-hover focus-visible:bg-surface-hover focus-visible:outline-none"
+        >
+          {t('auth.signInWithGoogle')}
+        </a>
+        <a
+          href={signInUrl('github')}
+          onClick={() =>
+            trackEvent('mobile_handoff', { action: 'signin_clicked', provider: 'github' })
+          }
+          className="flex-1 rounded-md border border-stroke-subtle px-2 py-1.5 text-center text-xs font-medium text-content hover:bg-surface-hover focus-visible:bg-surface-hover focus-visible:outline-none"
+        >
+          {t('auth.signInWithGithub')}
+        </a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Final PR of the conversion program (#2792, #2794, #2796). The mobile funnel data: 32% of mobile users activate but only ~1.3% ever download a printable file (desktop: 23%). They reach the export moment and dead-end — printing needs a desktop anyway, and there was no path from a phone session to a desktop one.

## What

- **`MobileHandoffBanner`** inside the shared `ExportDialog` — one insertion point covers the export moment in all three tools (layout ZIP, designer bin, baseplate). Self-contained eligibility: renders only when `isMobile` and the session is anonymous.
- Copy: "Printing from your computer? Sign in and your work syncs to your account — open this site on desktop to finish." with Google/GitHub sign-in links (`signInUrl`, same flow as UserDock). Existing `auth.signInWith*` keys reused; 1 new key × 10 locales.
- Signed-in mobile users see nothing (sync already carries their work); direct mobile export stays untouched as the fallback.
- Analytics: `mobile_handoff` `{action: 'shown' | 'signin_clicked', provider}` — measurable against the `tool_converted` mobile split on the conversion dashboard.

## Testing

- `MobileHandoffBanner.test.tsx`: mobile+anonymous renders links with correct OAuth hrefs and tracks the impression; desktop renders nothing; authenticated renders nothing
- ExportDialog suite green (32 tests); typecheck, i18n checks, boundaries, eslint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a mobile “continue on desktop” handoff inside export dialogs so anonymous mobile users can sign in to sync work and finish exporting on a desktop. This should reduce drop-off at export on mobile.

- **New Features**
  - Added MobileHandoffBanner to the shared ExportDialog (all three tools). Renders only on mobile for anonymous sessions.
  - Copy invites sign-in to sync work; Google/GitHub buttons use existing auth and `signInUrl`. Direct mobile export stays available.
  - No banner for signed-in or desktop users. Added one new i18n key across 10 locales.
  - Tracks `mobile_handoff` events: `shown` and `signin_clicked` with `provider`. Tests cover visibility, OAuth hrefs, and impression tracking.

<sup>Written for commit 4bb8d6be7dba41ad9acf73cac25da41472e7e0c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

