### PR TITLE
fix(deps): bump transitive tar to 7.5.21 for GHSA-r292-9mhp-454m

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   vitest-axe>lodash-es: ^4.18.1
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
   brace-expansion@<1.1.16: ^1.1.16
+  tar@<7.5.21: ^7.5.21
   '@vercel/python-analysis>smol-toml': ^1.6.1
   esbuild: 0.28.1
 
@@ -5329,8 +5330,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   temp-dir@2.0.0:
@@ -7222,7 +7223,7 @@ snapshots:
       node-fetch: 2.6.9
       nopt: 8.1.0
       semver: 7.8.5
-      tar: 7.5.20
+      tar: 7.5.21
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11018,7 +11019,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.20:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,11 @@ minimumReleaseAgeExclude:
   # fast-uri publish can bypass the cooldown via a lockfile regen.
   # TODO: remove after 2026-07-26 once 3.1.4 has aged past the window.
   - fast-uri@3.1.4
+  # tar 7.5.21 (2026-07-21) is the first version patched against the
+  # uncatchable stack-overflow DoS via crafted long-path archives
+  # (GHSA-r292-9mhp-454m). Scoped to the exact reviewed release.
+  # TODO: remove after 2026-07-28 once 7.5.21 has aged past the window.
+  - tar@7.5.21
 
 # Blocks Shai-Hulud-class worms that spread via npm lifecycle scripts.
 # Packages that need to build are listed in allowBuilds.
@@ -78,5 +83,6 @@ overrides:
   'vitest-axe>lodash-es': '^4.18.1'
   'picomatch@>=4.0.0 <4.0.4': '^4.0.4'
   'brace-expansion@<1.1.16': '^1.1.16'
+  'tar@<7.5.21': '^7.5.21'
   '@vercel/python-analysis>smol-toml': '^1.6.1'
   esbuild: '0.28.1'


### PR DESCRIPTION
## Summary

The blocking OSV scan on main ([run 30110606221](https://github.com/andymai/gridfinity-layout-tool/actions/runs/30110606221)) flags `tar@7.5.20` for [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m) (medium): uncatchable stack-overflow DoS via a crafted long-path tar archive with member selection. Patched in 7.5.21.

`tar` is reached only transitively, via `@vercel/node > @vercel/nft > @mapbox/node-pre-gyp` (devDependencies) — never bundled into the browser.

## Changes

- **Override** `tar@<7.5.21 -> ^7.5.21` in `pnpm-workspace.yaml`. node-pre-gyp declares `tar: ^7.4.0`, so the patched release satisfies the range; the override just floors it past the stale lockfile resolution.
- **Cooldown exclude** scoped to the exact release `tar@7.5.21` (published 2026-07-21, inside the 7-day `minimumReleaseAge` window), with a dated TODO to remove it after 2026-07-28 — same pattern as the fast-uri fix (#2731).
- Lockfile: `tar 7.5.20 -> 7.5.21`, nothing else.

## Verification

- `pnpm install` regenerates only the tar entries (no unrelated drift)
- `pnpm install --frozen-lockfile` passes the supply-chain policy
- Advisory range is `<= 7.5.20`, so the resolved 7.5.21 clears the OSV finding

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped transitive `tar` to 7.5.21 to patch GHSA-r292-9mhp-454m and unblock the OSV scan on `main`. `tar` is only reached via dev tooling (`@vercel/node > @vercel/nft > @mapbox/node-pre-gyp`), not shipped to the browser.

- **Dependencies**
  - Added override `'tar@<7.5.21': '^7.5.21'` in `pnpm-workspace.yaml`.
  - Added `minimumReleaseAgeExclude` for `tar@7.5.21` with a TODO to remove after 2026-07-28.
  - Updated `pnpm-lock.yaml`: `tar 7.5.20 -> 7.5.21`.

<sup>Written for commit 054af5d6ea9acd43c3d33fb4dabe778db193c2ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

