### PR TITLE
fix(designer): raise the plate icon width cap to 11.5mm

### DIFF
--- a/src/features/generation/worker/generators/labelPlateBuilder.ts
+++ b/src/features/generation/worker/generators/labelPlateBuilder.ts
@@ -84,10 +84,15 @@ const TEXT_MARGIN = 1.6;
 export const TEXT_BAND_MM = LABEL_PLATE_HEIGHT_MM - 2 * TEXT_MARGIN;
 /**
  * Width ceiling for an icon (mm) and its gap to the text. Side-view fasteners
- * are ~1.5-1.9x wider than tall, so filling the band unchecked would spend a
+ * are ~1.5-1.9x wider than tall, so an uncapped fit to the band would spend a
  * third of a 1U plate's text run on the silhouette.
+ *
+ * 11.5 is where a bolt — the widest silhouette that still reaches band height
+ * — stops being width-bound, at a cost of ~9% of the text run. Raising it
+ * further only grows the wider outliers (nail, wood screw) while shrinking
+ * every label's text.
  */
-export const ICON_MAX_WIDTH_MM = 9.5;
+export const ICON_MAX_WIDTH_MM = 11.5;
 const ICON_TEXT_GAP = 1.2;
 
 /**


### PR DESCRIPTION
Follow-up to #2804. At the 9.5mm cap every side-view fastener was width-bound, so none of them reached the readable band that a nut or washer fills.

## Measured, not guessed

Rendered the embossed top faces at three caps:

| cap | bolt | screw | nail | woodScrew | text run on 1U |
| --- | --- | --- | --- | --- | --- |
| 9.5 (current) | 9.50 × 6.46 | 9.50 × 6.08 | 9.50 × 5.70 | 9.50 × 4.94 | 22.1mm |
| **11.5 (this PR)** | **11.47 × 7.80** | 11.50 × 7.36 | 11.50 × 6.90 | 11.50 × 5.98 | 20.1mm |
| 13.0 | 11.47 × 7.80 | 12.19 × 7.80 | 13.00 × 7.80 | 13.00 × 6.76 | 18.6mm |

`nut` (6.75 × 7.80) and `washer` (7.80 × 7.80) are height-bound and identical at every cap — the ceiling only ever affects the side-view silhouettes.

11.5 is the point where a bolt stops being width-bound and fills the band. Past it the extra width buys height only for the wider outliers, while every label's text keeps shrinking — 13.0 was visibly worse for text at no gain for the bolt.

## Scope

One constant. No behavioural or structural change: the `fitIcon` invariant test from #2804 (every icon is exactly at band height or exactly at the cap) holds unchanged at any cap value, which is why it needed no edit.

Typecheck, ESLint and the plate + icon suites (19 tests) pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the label plate icon width cap from 9.5mm to 11.5mm so side-view fasteners (e.g., bolts) reach the band height instead of being width-bound. Improves fastener clarity with a small text run tradeoff (~9% on 1U); no other behavior changes.

<sup>Written for commit 2e713078fba9cba0c63b7cfd8397662d746a99d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

