### PR TITLE
fix(inspector): stop height hints stretching the clearance cell

### DIFF
--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.test.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.test.tsx
@@ -126,10 +126,24 @@ describe('SingleBinInspector', () => {
       const inspector = createMockInspector();
       render(<SingleBinInspector inspector={inspector} variant="desktop" />);
 
-      // 4u * 7mm = 28mm in the editable field; the meta line shows the unit
-      // equivalent and mm limits (max 12u * 7mm = 84mm).
+      // 4u * 7mm = 28mm in the editable field, "= 4u" directly beneath it.
       expect(screen.getByDisplayValue('28')).toBeInTheDocument();
-      expect(screen.getByText(/= 4u.*Max 84mm/)).toBeInTheDocument();
+      expect(screen.getByText('= 4u')).toBeInTheDocument();
+    });
+
+    it('renders the height limit hints outside the Height/Clearance grid', () => {
+      const inspector = createMockInspector();
+      const { container } = render(<SingleBinInspector inspector={inspector} variant="desktop" />);
+
+      // min 3u * 7mm = 21mm, max 12u * 7mm = 84mm on one full-width line.
+      const limits = screen.getByText(/Min 21mm: layer height · Max 84mm: remaining space/);
+      expect(limits).toBeInTheDocument();
+
+      // Keeping these out of the grid is what stops the Clearance cell from
+      // being stretched by Height's wrapped hint text.
+      const grid = container.querySelector('.grid-cols-2');
+      expect(grid).toBeInTheDocument();
+      expect(grid).not.toContainElement(limits);
     });
 
     it('renders clearance control in mm when maxClearance > 0', () => {

--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -191,75 +191,84 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
         </div>
 
         {/* Height and Clearance - compact inline controls */}
-        <div
-          className={`grid gap-3 ${constraints.maxClearance > 0 ? 'grid-cols-2' : 'grid-cols-1'}`}
-        >
-          {/* Height control — entered in mm, stored as free fractional units */}
-          <div>
-            <label className={`block ${labelSize} text-content-tertiary`}>
-              {t('common.heightMm')}
-            </label>
-            <Stepper
-              value={bin.height * layout.heightUnitMm}
-              onChange={(mmValue) =>
-                updateField('height', mmToHeightUnits(mm(mmValue), layout.heightUnitMm))
-              }
-              onStep={(delta) => updateField('height', roundHeightUnits(bin.height + delta))}
-              min={constraints.minHeight * layout.heightUnitMm}
-              max={constraints.maxHeight * layout.heightUnitMm}
-              step={layout.heightUnitMm}
-              inputDecimals={2}
-              size={isMobile ? 'lg' : 'md'}
-              aria-label={t('inspector.single.heightAria')}
-            />
-            <div className="mt-1 space-y-0.5 text-[10px] text-content-disabled">
-              <div>{`${heightEquiv} · ${minHeightHint} · ${maxHeightHint}`}</div>
-              <div>
-                {t('inspector.printedAndStackHint', {
-                  printed: heightMmAt(bin.height, STACK_LIP_MM),
-                  pitch: heightMmAt(bin.height),
-                })}
-              </div>
-              {!isStandardStackHeight(bin.height, layout.heightUnitMm) && (
-                <div className="text-warning">{t('inspector.nonStandardStackWarning')}</div>
-              )}
-            </div>
-          </div>
-
-          {/* Clearance control */}
-          {constraints.maxClearance > 0 && (
+        <div className="space-y-1.5">
+          <div
+            className={`grid gap-3 ${constraints.maxClearance > 0 ? 'grid-cols-2' : 'grid-cols-1'}`}
+          >
+            {/* Height control — entered in mm, stored as free fractional units */}
             <div>
-              <label
-                className={`block ${labelSize} text-content-tertiary`}
-                title={t('inspector.clearanceTooltip')}
-              >
-                {t('inspector.clearanceMmLabel')}
+              <label className={`block ${labelSize} text-content-tertiary`}>
+                {t('common.heightMm')}
               </label>
               <Stepper
-                value={(bin.clearanceHeight || 0) * layout.heightUnitMm}
+                value={bin.height * layout.heightUnitMm}
                 onChange={(mmValue) =>
-                  updateField('clearanceHeight', mmToHeightUnits(mm(mmValue), layout.heightUnitMm))
+                  updateField('height', mmToHeightUnits(mm(mmValue), layout.heightUnitMm))
                 }
-                onStep={(delta) =>
-                  updateField(
-                    'clearanceHeight',
-                    roundHeightUnits((bin.clearanceHeight || 0) + delta)
-                  )
-                }
-                min={0}
-                max={constraints.maxClearance * layout.heightUnitMm}
+                onStep={(delta) => updateField('height', roundHeightUnits(bin.height + delta))}
+                min={constraints.minHeight * layout.heightUnitMm}
+                max={constraints.maxHeight * layout.heightUnitMm}
                 step={layout.heightUnitMm}
                 inputDecimals={2}
                 size={isMobile ? 'lg' : 'md'}
-                aria-label={t('inspector.single.clearanceAria')}
+                aria-label={t('inspector.single.heightAria')}
               />
-              <div className="text-center mt-1 text-[10px] text-content-disabled">
-                {t('inspector.heightUnitsEquiv', {
-                  units: formatHeightUnits(bin.clearanceHeight || 0),
-                })}
-              </div>
+              <div className="mt-1 text-[10px] text-content-disabled">{heightEquiv}</div>
             </div>
-          )}
+
+            {/* Clearance control */}
+            {constraints.maxClearance > 0 && (
+              <div>
+                <label
+                  className={`block ${labelSize} text-content-tertiary`}
+                  title={t('inspector.clearanceTooltip')}
+                >
+                  {t('inspector.clearanceMmLabel')}
+                </label>
+                <Stepper
+                  value={(bin.clearanceHeight || 0) * layout.heightUnitMm}
+                  onChange={(mmValue) =>
+                    updateField(
+                      'clearanceHeight',
+                      mmToHeightUnits(mm(mmValue), layout.heightUnitMm)
+                    )
+                  }
+                  onStep={(delta) =>
+                    updateField(
+                      'clearanceHeight',
+                      roundHeightUnits((bin.clearanceHeight || 0) + delta)
+                    )
+                  }
+                  min={0}
+                  max={constraints.maxClearance * layout.heightUnitMm}
+                  step={layout.heightUnitMm}
+                  inputDecimals={2}
+                  size={isMobile ? 'lg' : 'md'}
+                  aria-label={t('inspector.single.clearanceAria')}
+                />
+                <div className="mt-1 text-[10px] text-content-disabled">
+                  {t('inspector.heightUnitsEquiv', {
+                    units: formatHeightUnits(bin.clearanceHeight || 0),
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Outside the grid: inside the narrow Height column these lines wrap far
+              enough to stretch the row and strand the Clearance cell. */}
+          <div className="space-y-0.5 text-[10px] text-content-disabled">
+            <div>{`${minHeightHint} · ${maxHeightHint}`}</div>
+            <div>
+              {t('inspector.printedAndStackHint', {
+                printed: heightMmAt(bin.height, STACK_LIP_MM),
+                pitch: heightMmAt(bin.height),
+              })}
+            </div>
+            {!isStandardStackHeight(bin.height, layout.heightUnitMm) && (
+              <div className="text-warning">{t('inspector.nonStandardStackWarning')}</div>
+            )}
+          </div>
         </div>
 
         {/* Split warning with print bed visualization */}


### PR DESCRIPTION
## Problem

In the bin properties sidebar, Height and Clearance share a two-column grid. Height carried five wrapped lines of hint text (unit equivalent, min/max limits, print/stack info) while Clearance carried one (`= 0u`). A CSS grid row grows to fit its tallest cell, so the row stretched to Height's height and padded the Clearance cell out with dead space.

The narrow column made it worse: constrained to ~120px, `= 3u · Min 35mm: layer height · Max 42mm: remaining space` wraps to three lines. The same string at full sidebar width wraps to two.

```
Before                                  After
┌─ Height ───────┬─ Clearance ─┐        ┌─ Height ───┬─ Clearance ─┐
│ [ − 21 + ]     │ [ − 0 + ]   │        │ [ − 21 + ] │ [ − 0 + ]   │
│ = 3u · Min     │ = 0u        │        │ = 3u       │ = 0u        │
│ 35mm: layer    │             │ ← gap  └────────────┴─────────────┘
│ height · Max   │             │ ← gap  Min 35mm: layer height · Max
│ 42mm:          │             │ ← gap  42mm: remaining space
│ remaining      │             │ ← gap  Prints 25.3mm · stacks
│ space          │             │ ← gap  +21mm each
│ Prints 25.3mm  │             │ ← gap
│ · stacks +21mm │             │ ← gap
└────────────────┴─────────────┘
```

## Change

- Each column keeps only its own one-line unit equivalent (`= 3u` / `= 0u`), so the two cells are equal height and the row collapses with no padding.
- The shared height limit and print/stack hints move to a full-width row below the grid, where they wrap to fewer lines.
- Clearance's equivalent switches from `text-center` to left-aligned so it lines up with its label and stepper, matching Height.

No copy changes, no i18n changes. The `grid-cols-1` fallback (when `maxClearance === 0`) is unaffected — the metadata row sits below the grid either way, so there's no second layout path.

## Testing

- Updated the existing height-control test, which asserted `= 4u` and `Max 84mm` shared one text node — they're now separate elements.
- Added a test pinning the limit hints *outside* the grid, so a future refactor can't silently reintroduce the stretched row.
- `SingleBinInspector` suite passes (36 tests); `pnpm run typecheck` and ESLint clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bin inspector layout so Height hints no longer stretch the Clearance cell. Hints now sit below the grid and both cells stay equal height, especially on narrow columns.

- **Bug Fixes**
  - In the two-column grid, keep only each field’s unit equivalent (`= 3u` / `= 0u`) to prevent row stretch.
  - Move Min/Max and print/stack hints to a full-width row beneath the grid for better wrapping.
  - Left-align Clearance’s equivalent to match its label and stepper.
  - Updated tests to reflect the new DOM and to assert the limit hints render outside the grid.

<sup>Written for commit c62b36e7071797cdf8e5461578e9b9d2dc759909. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

