### PR TITLE
feat(bin-inspector): concept + related-term semantic matching for labels

### DIFF
--- a/src/features/bin-inspector/README.md
+++ b/src/features/bin-inspector/README.md
@@ -30,7 +30,10 @@ a pure function of the current layout — fully on-device, no network. It blends
 signals: numeric **sequence** continuation (`M3`/`M4` → `M5`), reuse of an existing
 label, co-occurrence with **edge-adjacent or same-category** neighbors, vocabulary
 **domain** affinity, and text match (prefix / substring / cross-language alias /
-typo-tolerant fuzzy). The top prediction is offered as inline **ghost text**
+typo-tolerant fuzzy). Meaning-based matches come from `labelVocabulary/semantics.ts`:
+typing an umbrella word (`fasteners`, `werkzeug`) expands to that whole domain, and a
+term expands to related items (`screwdriver` → screw/bolt) — both surfaced with the
+`similar` reason even when no letters line up. The top prediction is offered as inline **ghost text**
 (Tab/→ to accept) on desktop; ghost is disabled on touch. Each row carries a muted
 reason tag. Accepts fire a hashed `label_suggestion_accepted` PostHog event (no raw
 text) for future model training. Ordering weights + the ghost confidence floor live

--- a/src/features/bin-inspector/labelSuggest/getLabelSuggestions.test.ts
+++ b/src/features/bin-inspector/labelSuggest/getLabelSuggestions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { getDisplayTerm } from '@/shared/analytics/labelVocabulary';
 import { computeGhost, getLabelSuggestions } from './getLabelSuggestions';
 import type { SuggestionBin, SuggestionContext } from './types';
 
@@ -96,6 +97,27 @@ describe('getLabelSuggestions', () => {
     const target = makeBin({ label: 's' });
     const results = getLabelSuggestions('s', ctx(target), { limit: 3 });
     expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  it('expands a typed concept word to its whole domain (similar)', () => {
+    const results = getLabelSuggestions('fasteners', ctx(makeBin({ label: 'fasteners' })));
+    const values = results.map((r) => r.value);
+    for (const term of ['screw', 'bolt', 'nut']) {
+      expect(values).toContain(getDisplayTerm(term));
+    }
+    const screw = results.find((r) => r.value === getDisplayTerm('screw'));
+    expect(screw?.reason).toBe('similar');
+  });
+
+  it('surfaces related items for a typed term (similar)', () => {
+    // "screwd" resolves to the "screw" canonical, whose related items include
+    // bolt/nut/washer — none of which share the typed letters.
+    const results = getLabelSuggestions('screwd', ctx(makeBin({ label: 'screwd' })));
+    const bolt = results.find((r) => r.value === getDisplayTerm('bolt'));
+    expect(bolt).toBeDefined();
+    expect(bolt?.reason).toBe('similar');
+    // The literal prefix match still wins the top slot.
+    expect(results[0]?.value).toBe(getDisplayTerm('screwdriver'));
   });
 
   it('never returns a suggestion longer than maxLength', () => {

--- a/src/features/bin-inspector/labelSuggest/getLabelSuggestions.ts
+++ b/src/features/bin-inspector/labelSuggest/getLabelSuggestions.ts
@@ -3,6 +3,8 @@ import {
   getCanonicalTerms,
   getDisplayTerm,
   getTermDomain,
+  conceptDomain,
+  relatedTermsForQuery,
   type LabelDomain,
 } from '@/shared/analytics/labelVocabulary';
 import { detectSequenceSuggestions } from './sequence';
@@ -32,11 +34,17 @@ const WEIGHTS = {
   text: 1.0,
 } as const;
 
+// Text-equivalent score for a candidate that matches only by meaning (concept
+// expansion or related-terms graph) rather than by letters. Below a prefix (1.0)
+// or substring (0.6) match so literal matches still rank first.
+const SEMANTIC_SCORE = 0.5;
+
 interface Candidate {
   value: string;
   isCatalog: boolean;
   isSequence: boolean;
   domain: LabelDomain | null;
+  canonical: string | null;
 }
 
 type TextKind = 'prefix' | 'substring' | 'alias' | 'fuzzy' | 'none';
@@ -110,12 +118,14 @@ export function getLabelSuggestions(
       if (meta.isCatalog) existing.isCatalog = true;
       if (meta.isSequence) existing.isSequence = true;
       if (meta.domain && !existing.domain) existing.domain = meta.domain;
+      if (meta.canonical && !existing.canonical) existing.canonical = meta.canonical;
     } else {
       candidates.set(key, {
         value,
         isCatalog: meta.isCatalog ?? false,
         isSequence: meta.isSequence ?? false,
         domain: meta.domain ?? null,
+        canonical: meta.canonical ?? null,
       });
     }
   };
@@ -124,7 +134,13 @@ export function getLabelSuggestions(
     add(pred.value, { isSequence: true, domain: processLabel(pred.value).domain });
   for (const { value } of counts.values()) add(value, {});
   for (const term of getCanonicalTerms())
-    add(getDisplayTerm(term), { isCatalog: true, domain: getTermDomain(term) });
+    add(getDisplayTerm(term), { isCatalog: true, domain: getTermDomain(term), canonical: term });
+
+  // Semantic expansion of a typed concept word ("fasteners" → the fasteners
+  // domain) or a term's related items ("screwdriver" → screw/bolt). Empty until
+  // the user types — pre-type prediction already leans on neighbor domains.
+  const conceptDom = query ? conceptDomain(query) : null;
+  const relatedSet = new Set(query ? relatedTermsForQuery(query) : []);
 
   const results: LabelSuggestion[] = [];
   for (const cand of candidates.values()) {
@@ -134,7 +150,16 @@ export function getLabelSuggestions(
     const isNeighbor = neighborKeys.has(key);
     const isSequence = cand.isSequence || sequenceKeys.has(key);
     const domainMatch = !!cand.domain && cand.domain === dominantDomain;
-    const text = query ? textScore(cand.value, query) : { score: 0, kind: 'none' as TextKind };
+    let text = query ? textScore(cand.value, query) : { score: 0, kind: 'none' as TextKind };
+
+    // Meaning-based match when letters don't line up: a concept word expands to
+    // its domain's terms; a term expands to its related items. Reason → similar.
+    if (query && text.score <= 0) {
+      const semantic =
+        (conceptDom !== null && cand.domain === conceptDom) ||
+        (cand.canonical !== null && relatedSet.has(cand.canonical));
+      if (semantic) text = { score: SEMANTIC_SCORE, kind: 'alias' };
+    }
 
     // While typing, only surface candidates that relate to the typed text.
     if (query && text.score <= 0) continue;

--- a/src/shared/analytics/labelVocabulary/index.ts
+++ b/src/shared/analytics/labelVocabulary/index.ts
@@ -10,3 +10,5 @@ export {
   getDisplayTerm,
 } from './normalize';
 export type { LabelData } from './normalize';
+
+export { conceptDomain, relatedTerms, relatedTermsForQuery, termsInDomain } from './semantics';

--- a/src/shared/analytics/labelVocabulary/semantics.test.ts
+++ b/src/shared/analytics/labelVocabulary/semantics.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { conceptDomain, relatedTerms, relatedTermsForQuery, termsInDomain } from './semantics';
+
+describe('conceptDomain', () => {
+  it('maps umbrella words to their domain', () => {
+    expect(conceptDomain('fasteners')).toBe('fasteners');
+    expect(conceptDomain('hardware')).toBe('fasteners');
+    expect(conceptDomain('electronics')).toBe('electronics');
+  });
+
+  it('is case- and whitespace-insensitive and multilingual', () => {
+    expect(conceptDomain('  Werkzeug ')).toBe('tools');
+    expect(conceptDomain('herramientas')).toBe('tools');
+  });
+
+  it('returns null for a specific item or unknown word', () => {
+    expect(conceptDomain('screw')).toBeNull();
+    expect(conceptDomain('banana')).toBeNull();
+  });
+});
+
+describe('relatedTerms / relatedTermsForQuery', () => {
+  it('lists related canonical terms', () => {
+    expect(relatedTerms('screwdriver')).toContain('screw');
+    expect(relatedTerms('wrench')).toContain('bolt');
+  });
+
+  it('resolves a free-text query to related terms via its canonical', () => {
+    expect(relatedTermsForQuery('screwdriver')).toContain('screw');
+    // A non-English alias still resolves (FR "tournevis" → screwdriver).
+    expect(relatedTermsForQuery('tournevis')).toContain('screw');
+  });
+
+  it('returns nothing for an unrelated query', () => {
+    expect(relatedTermsForQuery('banana')).toEqual([]);
+  });
+});
+
+describe('termsInDomain', () => {
+  it('returns catalog terms within a domain only', () => {
+    const fasteners = termsInDomain('fasteners');
+    expect(fasteners).toContain('screw');
+    expect(fasteners).toContain('bolt');
+    expect(fasteners).not.toContain('screwdriver');
+  });
+});

--- a/src/shared/analytics/labelVocabulary/semantics.ts
+++ b/src/shared/analytics/labelVocabulary/semantics.ts
@@ -1,0 +1,151 @@
+import type { LabelDomain } from './vocabulary';
+import { getCanonicalTerms, getTermDomain, processLabel } from './normalize';
+
+/**
+ * Concept / umbrella words (multilingual) that stand for a whole domain rather
+ * than a single item. Typing one expands to every catalog term in that domain,
+ * so "fasteners" → Screw / Bolt / Nut / Washer / Nail even though no term is
+ * literally called "fasteners". Keys are lowercase; accented and unaccented
+ * variants are listed separately since the query is lowercased but not folded.
+ */
+const DOMAIN_CONCEPTS: Record<string, LabelDomain> = {
+  // Tools
+  tool: 'tools',
+  tools: 'tools',
+  werkzeug: 'tools',
+  werkzeuge: 'tools',
+  outil: 'tools',
+  outils: 'tools',
+  herramienta: 'tools',
+  herramientas: 'tools',
+  gereedschap: 'tools',
+  attrezzi: 'tools',
+  utensili: 'tools',
+  ferramenta: 'tools',
+  ferramentas: 'tools',
+
+  // Fasteners
+  fastener: 'fasteners',
+  fasteners: 'fasteners',
+  hardware: 'fasteners',
+  befestigung: 'fasteners',
+  visserie: 'fasteners',
+  quincaillerie: 'fasteners',
+  tornilleria: 'fasteners',
+  tornillería: 'fasteners',
+  bevestiging: 'fasteners',
+  viteria: 'fasteners',
+
+  // Electronics
+  electronics: 'electronics',
+  electronic: 'electronics',
+  components: 'electronics',
+  elektronik: 'electronics',
+  electronique: 'electronics',
+  électronique: 'electronics',
+  composants: 'electronics',
+  electronica: 'electronics',
+  electrónica: 'electronics',
+  componentes: 'electronics',
+  elettronica: 'electronics',
+  componenti: 'electronics',
+
+  // Office
+  office: 'office',
+  stationery: 'office',
+  büro: 'office',
+  buro: 'office',
+  bureau: 'office',
+  oficina: 'office',
+  papeleria: 'office',
+  papelería: 'office',
+  kantoor: 'office',
+  ufficio: 'office',
+  cancelleria: 'office',
+
+  // Craft
+  craft: 'craft',
+  crafts: 'craft',
+  crafting: 'craft',
+  hobby: 'craft',
+  bastel: 'craft',
+  basteln: 'craft',
+  artisanat: 'craft',
+  manualidades: 'craft',
+  artesania: 'craft',
+  artesanía: 'craft',
+  knutselen: 'craft',
+  artigianato: 'craft',
+
+  // 3D printing
+  printing: 'printing_3d',
+  printer: 'printing_3d',
+  '3dprinting': 'printing_3d',
+  druck: 'printing_3d',
+  impression: 'printing_3d',
+  impresion: 'printing_3d',
+  impresión: 'printing_3d',
+  stampa: 'printing_3d',
+
+  // Cosmetics
+  cosmetics: 'cosmetics',
+  cosmetic: 'cosmetics',
+  makeup: 'cosmetics',
+  kosmetik: 'cosmetics',
+  maquillage: 'cosmetics',
+  maquillaje: 'cosmetics',
+  trucco: 'cosmetics',
+  cosmetici: 'cosmetics',
+};
+
+/**
+ * High-signal cross-domain relations that plain domain grouping misses — a
+ * screwdriver (tools) relates to a screw (fasteners), a wrench to a bolt, etc.
+ * Directed: `relatedTerms(a)` lists what `a` should also surface.
+ */
+const RELATED_TERMS: Record<string, string[]> = {
+  screwdriver: ['screw', 'bolt'],
+  screw: ['screwdriver', 'bolt', 'nut', 'washer'],
+  bolt: ['nut', 'washer', 'wrench', 'screw'],
+  nut: ['bolt', 'washer', 'wrench'],
+  washer: ['bolt', 'nut', 'screw'],
+  wrench: ['bolt', 'nut'],
+  drill_bit: ['screw'],
+  nail: ['hammer'],
+  hammer: ['nail'],
+  resistor: ['capacitor', 'led', 'wire'],
+  capacitor: ['resistor', 'led'],
+  led: ['resistor', 'wire'],
+  wire: ['led', 'resistor'],
+  battery_aa: ['battery_aaa'],
+  battery_aaa: ['battery_aa'],
+  paint: ['brush'],
+  brush: ['paint'],
+};
+
+/** The domain a concept/umbrella word stands for, or null. */
+export function conceptDomain(query: string): LabelDomain | null {
+  return DOMAIN_CONCEPTS[query.toLowerCase().trim()] ?? null;
+}
+
+/** Canonical terms directly related to a canonical term (see RELATED_TERMS). */
+export function relatedTerms(canonical: string): string[] {
+  return RELATED_TERMS[canonical] ?? [];
+}
+
+/** All catalog canonical terms in a domain. */
+export function termsInDomain(domain: LabelDomain): string[] {
+  return getCanonicalTerms().filter((term) => getTermDomain(term) === domain);
+}
+
+/**
+ * Canonical terms semantically related to a free-text query: the related terms
+ * of whatever canonical the query resolves to (exact or strong alias match).
+ * The domain-concept expansion is handled separately by `conceptDomain` since
+ * it keys off the catalog term's domain rather than a canonical list.
+ */
+export function relatedTermsForQuery(query: string): string[] {
+  const normalized = processLabel(query);
+  if (!normalized.normalized || normalized.confidence < 0.8) return [];
+  return relatedTerms(normalized.normalized);
+}


### PR DESCRIPTION
## What

Phase 2a of the smart label autocomplete (#2821): make the "understands meaning" part real — match by **concept and relation**, not just letters. Still fully on-device and deterministic; no baked embedding asset.

## Two additions

**`labelVocabulary/semantics.ts`**
- `DOMAIN_CONCEPTS` — a multilingual concept-word → domain table (`fasteners`/`hardware`/`werkzeug`/`électronique`/…). Membership is *derived* from the existing `TERM_DOMAINS`, so a concept expands to every catalog term in its domain for free.
- `RELATED_TERMS` — a small, high-signal cross-domain graph that plain domain grouping misses (`screwdriver`↔`screw`, `wrench`↔`bolt`, `resistor`↔`capacitor`, `paint`↔`brush`, …).

**Engine (`getLabelSuggestions`)**
- Candidates now carry their `canonical` term.
- A new semantic signal fires only while typing and only when letters don't line up: a typed umbrella word expands to its whole domain; a typed term expands to its related items. These surface with the existing **`similar`** reason, scored below literal prefix/substring matches so direct hits still win the top slots.

So typing `fasteners` → Screw / Bolt / Nut / Washer / Nail; typing `screwd` → Screwdriver (prefix) plus Bolt / Nut / Washer (related to *screw*).

## Testing

- New `semantics.test.ts` (concept mapping, related-terms, domain membership) + engine tests for concept expansion and related-term surfacing.
- Local: typecheck, lint, knip, all four i18n gates green; **661** analytics + bin-inspector tests pass. No new i18n keys (reason tags already exist).

## Not in this PR

Phase 2b — the telemetry-trained co-occurrence `model.json` (forking `scripts/train-bin-recommender/train.py` over `ml:cooccur:*` / `ml:size_seq:*`). That needs a run against production Redis, so it's a separate, ops-gated change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add meaning-based label suggestions to bin-inspector: concept words expand to their domain, and terms surface related items, ranked below direct text matches. Advances Phase 2a of the smart label autocomplete (#2821).

- New Features
  - Added concept-to-domain mapping and a small related-terms graph; both surface as “similar” only while typing and only when letters don’t align.
  - `getLabelSuggestions` now keeps a `canonical` term for candidates and uses new helpers (`conceptDomain`, `relatedTermsForQuery`, `termsInDomain`) to power semantic matches; docs and tests updated.

<sup>Written for commit a5241d3e058271b5a770b3393b10115f216207a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

