### PR TITLE
docs(bin-inspector): clarify LabelSuggestion.score tier contract

### DIFF
--- a/src/features/bin-inspector/labelSuggest/types.ts
+++ b/src/features/bin-inspector/labelSuggest/types.ts
@@ -15,7 +15,11 @@ export interface LabelSuggestion {
   value: string;
   /** Dominant signal behind the suggestion. */
   reason: SuggestionReason;
-  /** Combined score; higher sorts first. */
+  /**
+   * Combined score. Orders suggestions only *within* a tier: literal (letter)
+   * matches always sort ahead of meaning-only ones regardless of score, so a
+   * higher score does not by itself mean an earlier position in the result.
+   */
   score: number;
   /** For `usedBefore`: how many other bins already carry this label. */
   count?: number;


### PR DESCRIPTION
Doc-only. Addresses Greptile's trailing P2 note on #2825: the `LabelSuggestion.score` comment said "higher sorts first," but since the literal-tier sort landed, score only orders suggestions *within* a tier. Comment updated to reflect that; no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `LabelSuggestion.score` contract: the score orders suggestions only within a tier. Literal (letter) matches always sort before meaning-only ones, so a higher score doesn't guarantee an earlier overall position; docs-only, no behavior change.

<sup>Written for commit f0abf8ec3fe5fc4c93c35b8c92081c2cf35fe85f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

