### PR TITLE
feat(bin-inspector): trained popularity + co-occurrence prior for labels

### DIFF
--- a/scripts/train-label-suggester/README.md
+++ b/scripts/train-label-suggester/README.md
@@ -1,0 +1,50 @@
+# train-label-suggester
+
+Builds the label-autocomplete's learned prior — `labelSuggester.model.json` — from
+aggregate Redis telemetry. Runs offline, on demand (not in CI), like
+[`train-bin-recommender`](../train-bin-recommender/README.md).
+
+## What it produces
+
+A hash-keyed model with two maps:
+
+- **`popularity`**: `labelHash → 0..1` — how common each label is globally
+  (from `ml:label_hash:*`), scaled so the most common label is `1.0`.
+- **`cooccur`**: `labelHash → { neighborHash → P(label | neighbor) }` —
+  row-normalized from the symmetric co-occurrence matrix `ml:cooccur:*`.
+
+Only one-way `simpleHash` values are read; no raw label text exists to read. The
+client computes the same hashes from candidate text and the current bin's
+neighbor labels, so it only ever looks up hashes it already holds — it never
+reverses one.
+
+## Run
+
+```bash
+vercel env pull .env --environment=production
+uv run train.py --redis-url "$(grep ^REDIS_URL= .env | cut -d= -f2-)" \
+    --out ../../src/features/bin-inspector/labelSuggest/labelSuggester.model.json
+rm .env  # contains the prod Redis password
+```
+
+Then commit the regenerated `labelSuggester.model.json`. The client lazy-loads it
+and, once `sampleCount > 0`, blends the prior into ranking (popularity nudges
+common labels up; co-occurrence surfaces labels that tend to sit next to the
+current bin's neighbors). Until then the committed placeholder (`sampleCount: 0`)
+is inert and the autocomplete runs on heuristics alone.
+
+## Tuning
+
+- `--min-label-samples` (default 5): floor before a label enters `popularity`.
+- `--min-cooccur-samples` (default 5): floor before a co-occurrence row is kept.
+- Bounds (`POP_TOP_K`, `COOCCUR_TOP_KEYS`, `COOCCUR_TOP_NEIGHBORS`) cap the file
+  size; raise them in `train.py` if the model is too sparse.
+- Blend weights live client-side in `src/features/bin-inspector/labelSuggest/model.ts`
+  (`W_POPULARITY`, `W_COOCCUR`) — deliberately gentle so the prior never overrides
+  a literal text match.
+
+## Retrain when
+
+- The co-occurrence / label keyspaces have grown materially (≥ ~20%).
+- The vocabulary version bumps (hashes are text-based and unaffected, but it's a
+  good cadence signal).

--- a/scripts/train-label-suggester/pyproject.toml
+++ b/scripts/train-label-suggester/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "train-label-suggester"
+version = "0.1.0"
+description = "Build the label-suggester's popularity + co-occurrence prior from Redis telemetry."
+requires-python = ">=3.11"
+dependencies = [
+  "redis>=5.0.0",
+  "click>=8.1.0",
+]
+
+[tool.uv]
+package = false

--- a/scripts/train-label-suggester/train.py
+++ b/scripts/train-label-suggester/train.py
@@ -1,0 +1,193 @@
+"""Build the label-suggester's static prior from Redis telemetry.
+
+Emits a JSON model the client bundles. Like the bin-size recommender it does
+**no hashing of its own** — label hashes in the output are exactly what the
+server already wrote, so train/serve parity holds by construction. Only
+one-way hashes are read; no raw label text exists anywhere to read.
+
+Two signals:
+  * popularity  — how often each label hash appears (from ml:label_hash:*),
+                  normalized so the most common label is 1.0.
+  * cooccur     — P(label | neighbor label), row-normalized from the symmetric
+                  co-occurrence matrix (ml:cooccur:*). The client looks up
+                  cooccur[neighborHash][candidateHash] for the current bin's
+                  neighbors.
+
+Usage:
+    vercel env pull .env --environment=production
+    uv run train.py --redis-url "$REDIS_URL" \
+        --out ../../src/features/bin-inspector/labelSuggest/labelSuggester.model.json
+    rm .env  # contains the prod Redis password
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+
+import click
+import redis
+
+SCHEMA_VERSION = 1
+SCAN_PAGE_SIZE = 500
+
+# Bounds keep the committed JSON small and the client lookups cheap.
+POP_TOP_K = 2000
+MIN_LABEL_SAMPLES = 5
+COOCCUR_TOP_KEYS = 2000
+COOCCUR_TOP_NEIGHBORS = 12
+MIN_COOCCUR_SAMPLES = 5
+
+
+def fetch_hash_map(client: redis.Redis, prefix: str) -> dict[str, dict[str, int]]:
+    """Read every `{prefix}{key}` hash into `{key -> {field -> count}}`.
+
+    Pipelined by SCAN page to avoid an N+1 round-trip against production Redis.
+    """
+    out: dict[str, dict[str, int]] = {}
+    page: list[bytes | str] = []
+    for raw_key in client.scan_iter(match=f"{prefix}*", count=SCAN_PAGE_SIZE):
+        page.append(raw_key)
+        if len(page) >= SCAN_PAGE_SIZE:
+            _drain_page(client, prefix, page, out)
+    _drain_page(client, prefix, page, out)
+    return out
+
+
+def _drain_page(
+    client: redis.Redis,
+    prefix: str,
+    page: list[bytes | str],
+    out: dict[str, dict[str, int]],
+) -> None:
+    if not page:
+        return
+    pipe = client.pipeline(transaction=False)
+    for key in page:
+        pipe.hgetall(key)
+    results = pipe.execute()
+    for key, fields in zip(page, results):
+        decoded_key = key.decode() if isinstance(key, bytes) else key
+        suffix = decoded_key[len(prefix) :]
+        out[suffix] = {
+            (f.decode() if isinstance(f, bytes) else f): int(v)
+            for f, v in fields.items()
+        }
+    page.clear()
+
+
+def build_popularity(
+    raw: dict[str, dict[str, int]], min_samples: int, top_k: int
+) -> tuple[dict[str, float], int]:
+    """Normalized label popularity (0..1) and the total sample count.
+
+    Each ml:label_hash:{hash} maps size -> count; the label's frequency is the
+    sum over sizes. Kept to the top_k most frequent labels above the floor,
+    scaled so the most common label is 1.0.
+    """
+    totals = {h: sum(sizes.values()) for h, sizes in raw.items()}
+    totals = {h: n for h, n in totals.items() if n >= min_samples}
+    if not totals:
+        return {}, 0
+    ranked = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)[:top_k]
+    max_n = ranked[0][1]
+    popularity = {h: round(n / max_n, 4) for h, n in ranked}
+    return popularity, sum(totals.values())
+
+
+def build_cooccur(
+    raw: dict[str, dict[str, int]], min_samples: int, top_keys: int, top_neighbors: int
+) -> dict[str, dict[str, float]]:
+    """Row-normalized co-occurrence: cooccur[hash] = {neighbor -> P(hash | neighbor)}.
+
+    The matrix is symmetric, so a row keyed by the *neighbor* hash yields the
+    conditional distribution the client needs. Rows below the sample floor are
+    dropped; each kept row holds its top_neighbors entries.
+    """
+    row_totals = {h: sum(row.values()) for h, row in raw.items()}
+    eligible = sorted(
+        ((h, n) for h, n in row_totals.items() if n >= min_samples),
+        key=lambda kv: kv[1],
+        reverse=True,
+    )[:top_keys]
+
+    cooccur: dict[str, dict[str, float]] = {}
+    for h, total in eligible:
+        ranked = sorted(raw[h].items(), key=lambda kv: kv[1], reverse=True)[:top_neighbors]
+        cooccur[h] = {n: round(c / total, 4) for n, c in ranked}
+    return cooccur
+
+
+def dominant_vocab_version(client: redis.Redis) -> str:
+    versions = client.hgetall("ml:meta:vocab_versions")
+    if not versions:
+        return "unknown"
+    decoded = {
+        (k.decode() if isinstance(k, bytes) else k): int(v) for k, v in versions.items()
+    }
+    return max(decoded.items(), key=lambda kv: kv[1])[0]
+
+
+@click.command()
+@click.option("--redis-url", envvar="REDIS_URL", required=True, help="Redis connection URL.")
+@click.option(
+    "--min-label-samples",
+    type=int,
+    default=MIN_LABEL_SAMPLES,
+    show_default=True,
+    help="Minimum occurrences before a label enters the popularity prior.",
+)
+@click.option(
+    "--min-cooccur-samples",
+    type=int,
+    default=MIN_COOCCUR_SAMPLES,
+    show_default=True,
+    help="Minimum row total before a co-occurrence row is kept.",
+)
+@click.option("--out", type=click.Path(dir_okay=False), required=True, help="Output JSON path.")
+def main(
+    redis_url: str,
+    min_label_samples: int,
+    min_cooccur_samples: int,
+    out: str,
+) -> None:
+    client = redis.Redis.from_url(redis_url)
+    click.echo(f"Connecting to Redis at {redis_url.split('@')[-1]}…")
+    client.ping()
+
+    click.echo("Reading ml:label_hash:* …")
+    label_raw = fetch_hash_map(client, "ml:label_hash:")
+    click.echo(f"  {len(label_raw)} label keys")
+
+    click.echo("Reading ml:cooccur:* …")
+    cooccur_raw = fetch_hash_map(client, "ml:cooccur:")
+    click.echo(f"  {len(cooccur_raw)} co-occurrence keys")
+
+    popularity, sample_count = build_popularity(label_raw, min_label_samples, POP_TOP_K)
+    cooccur = build_cooccur(
+        cooccur_raw, min_cooccur_samples, COOCCUR_TOP_KEYS, COOCCUR_TOP_NEIGHBORS
+    )
+
+    model = {
+        "schemaVersion": SCHEMA_VERSION,
+        "vocabVersion": dominant_vocab_version(client),
+        "trainedAt": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "sampleCount": sample_count,
+        "popularity": popularity,
+        "cooccur": cooccur,
+    }
+
+    with open(out, "w") as f:
+        json.dump(model, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    click.echo(
+        f"\nWrote {out}: {len(popularity)} popular labels, "
+        f"{len(cooccur)} co-occurrence rows, {sample_count} total label samples."
+    )
+
+
+if __name__ == "__main__":
+    main(auto_envvar_prefix="LABEL_SUGGESTER")
+    sys.exit(0)

--- a/src/features/bin-inspector/README.md
+++ b/src/features/bin-inspector/README.md
@@ -39,6 +39,18 @@ reason tag. Accepts fire a hashed `label_suggestion_accepted` PostHog event (no 
 text) for future model training. Ordering weights + the ghost confidence floor live
 in `labelSuggest/getLabelSuggestions.ts`.
 
+### Trained prior (optional)
+
+`labelSuggest/model.ts` blends a learned, hash-keyed prior on top of the heuristics:
+global **popularity** and neighbor **co-occurrence** (`modelScore`). It's built from
+aggregate telemetry by `scripts/train-label-suggester/train.py` and committed as
+`labelSuggest/labelSuggester.model.json` (lazy-loaded via `loadModel.ts` /
+`useLabelSuggesterModel`). Because only one-way label hashes are stored, the client
+looks up hashes it computes itself (candidate text + the current bin's neighbors) — it
+never reverses one. The committed placeholder has `sampleCount: 0` and is **inert**;
+run the trainer against prod Redis to activate it. The prior is deliberately gentle —
+it nudges ranking but never outranks a literal text match.
+
 ## Size suggestion (Labs)
 
 `SingleBinInspector` renders the `bin-recommender` `BinSizeSuggestion` under the label field, gated on the `bin_recommender` Labs flag (the lazy chunk isn't fetched when off). It wires `onApply={applySuggestedSize}` and `canFit={canApplySuggestedSize}`.

--- a/src/features/bin-inspector/components/Inspector/BinLabelField/BinLabelField.tsx
+++ b/src/features/bin-inspector/components/Inspector/BinLabelField/BinLabelField.tsx
@@ -6,6 +6,7 @@ import { trackEvent } from '@/shared/analytics/posthog';
 import { useTranslation } from '@/i18n';
 import type { Bin } from '@/core/types';
 import { useLabelSuggestions } from '@/features/bin-inspector/hooks/useLabelSuggestions';
+import { useLabelSuggesterModel } from '@/features/bin-inspector/hooks/useLabelSuggesterModel';
 import type { SuggestionReason } from '@/features/bin-inspector/labelSuggest';
 
 interface BinLabelFieldProps {
@@ -32,7 +33,13 @@ const REASON_KEY: Record<SuggestionReason, string> = {
  */
 export function BinLabelField({ bin, bins, onChange, variant }: BinLabelFieldProps) {
   const t = useTranslation();
-  const { suggestions, ghost } = useLabelSuggestions(bin, bins, CONSTRAINTS.LABEL_MAX_LENGTH);
+  const model = useLabelSuggesterModel();
+  const { suggestions, ghost } = useLabelSuggestions(
+    bin,
+    bins,
+    CONSTRAINTS.LABEL_MAX_LENGTH,
+    model
+  );
   const enableInlineGhost = variant === 'desktop';
 
   const options = useMemo<ComboboxOption[]>(

--- a/src/features/bin-inspector/hooks/useLabelSuggesterModel.test.tsx
+++ b/src/features/bin-inspector/hooks/useLabelSuggesterModel.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useLabelSuggesterModel } from './useLabelSuggesterModel';
+
+describe('useLabelSuggesterModel', () => {
+  it('starts null and resolves to the loaded model', async () => {
+    const { result } = renderHook(() => useLabelSuggesterModel());
+    expect(result.current).toBeNull();
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current?.schemaVersion).toBe(1);
+  });
+});

--- a/src/features/bin-inspector/hooks/useLabelSuggesterModel.ts
+++ b/src/features/bin-inspector/hooks/useLabelSuggesterModel.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { loadLabelSuggesterModel } from '@/features/bin-inspector/labelSuggest/loadModel';
+import type { LabelSuggesterModel } from '@/features/bin-inspector/labelSuggest/model';
+
+/**
+ * Lazily loads the trained label-suggester model once and returns it, or null
+ * until it resolves. Ranking works from heuristics alone while null, then the
+ * learned prior kicks in on the next render.
+ */
+export function useLabelSuggesterModel(): LabelSuggesterModel | null {
+  const [model, setModel] = useState<LabelSuggesterModel | null>(null);
+  useEffect(() => {
+    let alive = true;
+    void loadLabelSuggesterModel().then((loaded) => {
+      if (alive) setModel(loaded);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return model;
+}

--- a/src/features/bin-inspector/hooks/useLabelSuggestions.ts
+++ b/src/features/bin-inspector/hooks/useLabelSuggestions.ts
@@ -1,7 +1,11 @@
 import { useMemo } from 'react';
 import type { Bin } from '@/core/types';
 import { computeGhost, getLabelSuggestions } from '@/features/bin-inspector/labelSuggest';
-import type { LabelGhost, LabelSuggestion } from '@/features/bin-inspector/labelSuggest';
+import type {
+  LabelGhost,
+  LabelSuggestion,
+  LabelSuggesterModel,
+} from '@/features/bin-inspector/labelSuggest';
 
 export interface LabelSuggestionsResult {
   suggestions: LabelSuggestion[];
@@ -11,15 +15,17 @@ export interface LabelSuggestionsResult {
 /**
  * Ranked label suggestions for a bin, derived from the current layout. The
  * live field text (`bin.label`) doubles as the query, so this recomputes as the
- * user types. Pure and on-device — no network, no model download.
+ * user types. On-device — no network. An optional trained model adds a learned
+ * cross-user prior; heuristics alone run while it's null.
  */
 export function useLabelSuggestions(
   bin: Bin,
   bins: readonly Bin[],
-  maxLength?: number
+  maxLength?: number,
+  model?: LabelSuggesterModel | null
 ): LabelSuggestionsResult {
   return useMemo(() => {
-    const suggestions = getLabelSuggestions(bin.label, { target: bin, bins }, { maxLength });
+    const suggestions = getLabelSuggestions(bin.label, { target: bin, bins }, { maxLength, model });
     return { suggestions, ghost: computeGhost(bin.label, suggestions) };
-  }, [bin, bins, maxLength]);
+  }, [bin, bins, maxLength, model]);
 }

--- a/src/features/bin-inspector/labelSuggest/getLabelSuggestions.test.ts
+++ b/src/features/bin-inspector/labelSuggest/getLabelSuggestions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { getDisplayTerm } from '@/shared/analytics/labelVocabulary';
+import { getDisplayTerm, processLabel } from '@/shared/analytics/labelVocabulary';
 import { computeGhost, getLabelSuggestions } from './getLabelSuggestions';
+import { EMPTY_MODEL, type LabelSuggesterModel } from './model';
 import type { SuggestionBin, SuggestionContext } from './types';
 
 let counter = 0;
@@ -129,6 +130,39 @@ describe('getLabelSuggestions', () => {
     expect(results[0]?.value).toBe(getDisplayTerm('screwdriver'));
     const boltIndex = results.findIndex((r) => r.value === 'Bolt');
     expect(boltIndex).toBeGreaterThan(0);
+  });
+
+  it('surfaces a model-popular catalog term before typing', () => {
+    const screw = getDisplayTerm('screw');
+    const model: LabelSuggesterModel = {
+      ...EMPTY_MODEL,
+      sampleCount: 100,
+      popularity: { [processLabel(screw).hash]: 1.0 },
+      cooccur: {},
+    };
+    // Empty field, no in-layout context: only the model can surface a catalog term.
+    const results = getLabelSuggestions('', ctx(makeBin({ label: '' })), { model });
+    expect(results.some((r) => r.value === screw)).toBe(true);
+  });
+
+  it('surfaces a label the model says co-occurs with a neighbor', () => {
+    const bolt = getDisplayTerm('bolt');
+    const neighborHash = processLabel('Widget').hash;
+    const model: LabelSuggesterModel = {
+      ...EMPTY_MODEL,
+      sampleCount: 100,
+      popularity: {},
+      cooccur: { [neighborHash]: { [processLabel(bolt).hash]: 1.0 } },
+    };
+    const target = makeBin({ x: 0, category: 'c1', label: '' });
+    const neighbor = makeBin({ x: 1, category: 'c1', label: 'Widget' });
+    const results = getLabelSuggestions('', ctx(target, neighbor), { model });
+    expect(results.some((r) => r.value === bolt)).toBe(true);
+  });
+
+  it('ignores a model with no training data (inert)', () => {
+    const results = getLabelSuggestions('', ctx(makeBin({ label: '' })), { model: EMPTY_MODEL });
+    expect(results).toEqual([]);
   });
 
   it('never returns a suggestion longer than maxLength', () => {

--- a/src/features/bin-inspector/labelSuggest/getLabelSuggestions.ts
+++ b/src/features/bin-inspector/labelSuggest/getLabelSuggestions.ts
@@ -8,6 +8,7 @@ import {
   type LabelDomain,
 } from '@/shared/analytics/labelVocabulary';
 import { detectSequenceSuggestions } from './sequence';
+import { isModelUsable, modelScore, type LabelSuggesterModel } from './model';
 import type {
   LabelGhost,
   LabelSuggestion,
@@ -73,7 +74,7 @@ interface ScoredSuggestion extends LabelSuggestion {
 export function getLabelSuggestions(
   rawQuery: string,
   ctx: SuggestionContext,
-  options: { limit?: number; maxLength?: number } = {}
+  options: { limit?: number; maxLength?: number; model?: LabelSuggesterModel | null } = {}
 ): LabelSuggestion[] {
   const limit = options.limit ?? DEFAULT_LIMIT;
   // Never surface a suggestion the field can't hold verbatim — otherwise the
@@ -95,7 +96,9 @@ export function getLabelSuggestions(
   }
 
   // Neighbor labels: edge-adjacent on the same layer, or in the same category.
+  const model = isModelUsable(options.model) ? options.model : null;
   const neighborKeys = new Set<string>();
+  const neighborHashes: string[] = [];
   const domainTally = new Map<LabelDomain, number>();
   for (const b of others) {
     const value = b.label.trim();
@@ -105,8 +108,9 @@ export function getLabelSuggestions(
       b.category === ctx.target.category;
     if (!isNeighbor) continue;
     neighborKeys.add(value.toLowerCase());
-    const domain = processLabel(value).domain;
-    if (domain) domainTally.set(domain, (domainTally.get(domain) ?? 0) + 1);
+    const label = processLabel(value);
+    if (model) neighborHashes.push(label.hash);
+    if (label.domain) domainTally.set(label.domain, (domainTally.get(label.domain) ?? 0) + 1);
   }
   const dominantDomain = pickDominant(domainTally);
 
@@ -169,12 +173,18 @@ export function getLabelSuggestions(
       if (semantic) text = { score: SEMANTIC_SCORE, kind: 'semantic' };
     }
 
-    // While typing, only surface candidates that relate to the typed text.
+    // While typing, only surface candidates that relate to the typed text —
+    // the learned prior refines ranking, it never bypasses text relevance.
     if (query && text.score <= 0) continue;
 
+    // Learned cross-user prior (popularity + neighbor co-occurrence), or 0 when
+    // no trained model is loaded.
+    const learned = model ? modelScore(model, processLabel(cand.value).hash, neighborHashes) : 0;
+
     // Pre-type: drop bare catalog terms with no contextual pull, else focusing
-    // the field floods the list with generic vocabulary entries.
-    const hasContext = isSequence || isNeighbor || reuse > 0 || domainMatch;
+    // the field floods the list with generic vocabulary entries. A strong
+    // learned prior counts as context.
+    const hasContext = isSequence || isNeighbor || reuse > 0 || domainMatch || learned > 0;
     if (!query && cand.isCatalog && !hasContext) continue;
 
     let score = 0;
@@ -184,6 +194,7 @@ export function getLabelSuggestions(
     if (domainMatch) score += WEIGHTS.domain;
     if (cand.isCatalog) score += WEIGHTS.catalog;
     score += text.score * WEIGHTS.text;
+    score += learned;
     if (score <= 0) continue;
 
     const reason = pickReason({

--- a/src/features/bin-inspector/labelSuggest/index.ts
+++ b/src/features/bin-inspector/labelSuggest/index.ts
@@ -1,6 +1,9 @@
 export { getLabelSuggestions, computeGhost, GHOST_MIN_SCORE } from './getLabelSuggestions';
 export { detectSequenceSuggestions } from './sequence';
 export type { SequencePrediction } from './sequence';
+export { EMPTY_MODEL, MODEL_SCHEMA_VERSION, isModelUsable, modelScore } from './model';
+export type { LabelSuggesterModel } from './model';
+export { loadLabelSuggesterModel } from './loadModel';
 export type {
   LabelSuggestion,
   LabelGhost,

--- a/src/features/bin-inspector/labelSuggest/labelSuggester.model.json
+++ b/src/features/bin-inspector/labelSuggest/labelSuggester.model.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "vocabVersion": "v1",
+  "trainedAt": "1970-01-01T00:00:00Z",
+  "sampleCount": 0,
+  "popularity": {},
+  "cooccur": {}
+}

--- a/src/features/bin-inspector/labelSuggest/loadModel.test.ts
+++ b/src/features/bin-inspector/labelSuggest/loadModel.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { loadLabelSuggesterModel } from './loadModel';
+
+describe('loadLabelSuggesterModel', () => {
+  it('loads the committed model and caches the promise', async () => {
+    const first = loadLabelSuggesterModel();
+    const second = loadLabelSuggesterModel();
+    expect(first).toBe(second); // cached
+
+    const model = await first;
+    expect(model.schemaVersion).toBe(1);
+    // The committed placeholder is inert until a trained model replaces it.
+    expect(model.sampleCount).toBe(0);
+  });
+});

--- a/src/features/bin-inspector/labelSuggest/loadModel.ts
+++ b/src/features/bin-inspector/labelSuggest/loadModel.ts
@@ -1,0 +1,20 @@
+import { EMPTY_MODEL, type LabelSuggesterModel } from './model';
+
+let modelPromise: Promise<LabelSuggesterModel> | null = null;
+
+/**
+ * Lazily load the committed model.json (code-split into its own chunk). Cached
+ * after the first call; a transient failure clears the cache so it can retry,
+ * and always resolves — falling back to the inert EMPTY_MODEL.
+ */
+export function loadLabelSuggesterModel(): Promise<LabelSuggesterModel> {
+  if (!modelPromise) {
+    modelPromise = import('./labelSuggester.model.json')
+      .then((m): LabelSuggesterModel => m.default)
+      .catch(() => {
+        modelPromise = null;
+        return EMPTY_MODEL;
+      });
+  }
+  return modelPromise;
+}

--- a/src/features/bin-inspector/labelSuggest/model.test.ts
+++ b/src/features/bin-inspector/labelSuggest/model.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { EMPTY_MODEL, isModelUsable, modelScore, type LabelSuggesterModel } from './model';
+
+describe('isModelUsable', () => {
+  it('rejects null, empty, and wrong-schema models', () => {
+    expect(isModelUsable(null)).toBe(false);
+    expect(isModelUsable(undefined)).toBe(false);
+    expect(isModelUsable(EMPTY_MODEL)).toBe(false); // sampleCount 0
+    expect(isModelUsable({ ...EMPTY_MODEL, sampleCount: 10, schemaVersion: 999 })).toBe(false);
+  });
+
+  it('accepts a populated model at the current schema', () => {
+    expect(isModelUsable({ ...EMPTY_MODEL, sampleCount: 10 })).toBe(true);
+  });
+});
+
+describe('modelScore', () => {
+  const model: LabelSuggesterModel = {
+    ...EMPTY_MODEL,
+    sampleCount: 100,
+    popularity: { cand: 1.0 },
+    cooccur: { nbr: { cand: 1.0 } },
+  };
+
+  it('adds a popularity prior for a known candidate', () => {
+    expect(modelScore(model, 'cand', [])).toBeGreaterThan(0);
+  });
+
+  it('adds neighbor co-occurrence on top of popularity', () => {
+    expect(modelScore(model, 'cand', ['nbr'])).toBeGreaterThan(modelScore(model, 'cand', []));
+  });
+
+  it('is zero for an unknown candidate with unrelated neighbors', () => {
+    expect(modelScore(model, 'unknown', ['nbr'])).toBe(0);
+  });
+
+  it('caps co-occurrence so it cannot dominate arbitrarily', () => {
+    const many: LabelSuggesterModel = {
+      ...EMPTY_MODEL,
+      sampleCount: 100,
+      popularity: {},
+      cooccur: { a: { cand: 1 }, b: { cand: 1 }, c: { cand: 1 } },
+    };
+    // Three neighbors each fully co-occurring — still capped at the single-hit weight.
+    expect(modelScore(many, 'cand', ['a', 'b', 'c'])).toBe(modelScore(many, 'cand', ['a']));
+  });
+});

--- a/src/features/bin-inspector/labelSuggest/model.ts
+++ b/src/features/bin-inspector/labelSuggest/model.ts
@@ -1,0 +1,69 @@
+/**
+ * Trained label-suggester model: a privacy-preserving, hash-keyed prior learned
+ * from aggregate telemetry (see scripts/train-label-suggester/). It never stores
+ * raw label text — only one-way `simpleHash` values — so the client can only look
+ * up hashes it can compute itself (candidate text + the current bin's neighbors).
+ *
+ * Regenerate with:
+ *   uv run scripts/train-label-suggester/train.py --redis-url "$REDIS_URL" \
+ *     --out src/features/bin-inspector/labelSuggest/labelSuggester.model.json
+ */
+export interface LabelSuggesterModel {
+  schemaVersion: number;
+  vocabVersion: string;
+  trainedAt: string;
+  sampleCount: number;
+  /** label hash → global popularity (0..1). */
+  popularity: Record<string, number>;
+  /** label hash → { co-occurring neighbor hash → P(this | neighbor), 0..1 }. */
+  cooccur: Record<string, Record<string, number>>;
+}
+
+export const MODEL_SCHEMA_VERSION = 1;
+
+/** Inert default: contributes nothing until a trained model is committed. */
+export const EMPTY_MODEL: LabelSuggesterModel = {
+  schemaVersion: MODEL_SCHEMA_VERSION,
+  vocabVersion: 'v1',
+  trainedAt: '1970-01-01T00:00:00Z',
+  sampleCount: 0,
+  popularity: {},
+  cooccur: {},
+};
+
+// Deliberately gentle: the model is a prior that nudges ranking, it must not
+// override strong literal text signals. Tune against real telemetry.
+const W_POPULARITY = 0.2;
+const W_COOCCUR = 0.5;
+
+/** Whether a model carries usable training data at the expected schema. */
+export function isModelUsable(
+  model: LabelSuggesterModel | null | undefined
+): model is LabelSuggesterModel {
+  return !!model && model.schemaVersion === MODEL_SCHEMA_VERSION && model.sampleCount > 0;
+}
+
+/**
+ * Learned score for a candidate given the current bin's neighbor labels: a
+ * global popularity prior plus co-occurrence with the neighbors. Hashes are the
+ * candidate's and neighbors' `processLabel().hash` values.
+ */
+export function modelScore(
+  model: LabelSuggesterModel,
+  candidateHash: string,
+  neighborHashes: readonly string[]
+): number {
+  // `Object.hasOwn` guards (not `??`/`?.`): the maps are typed with non-optional
+  // index signatures, so a missing key is undefined at runtime but `number` to
+  // the type system — the presence checks keep it safe without a dead condition.
+  const popularity = Object.hasOwn(model.popularity, candidateHash)
+    ? model.popularity[candidateHash]
+    : 0;
+  let cooccur = 0;
+  for (const hash of neighborHashes) {
+    if (!Object.hasOwn(model.cooccur, hash)) continue;
+    const row = model.cooccur[hash];
+    if (Object.hasOwn(row, candidateHash)) cooccur += row[candidateHash];
+  }
+  return popularity * W_POPULARITY + Math.min(cooccur, 1) * W_COOCCUR;
+}


### PR DESCRIPTION
## What

Phase 2b of the smart label autocomplete: a **learned, privacy-preserving prior** on top of the heuristics, plus the offline pipeline that builds it. Completes the phased plan from #2821.

## The model

`labelSuggest/model.ts` — a hash-keyed `LabelSuggesterModel` with two maps:
- **`popularity`**: `labelHash → 0..1` — global label frequency (from `ml:label_hash:*`).
- **`cooccur`**: `labelHash → { neighborHash → P(label | neighbor) }` — from the symmetric `ml:cooccur:*` matrix.

`modelScore` blends a gentle popularity prior with capped neighbor co-occurrence. Because only one-way `simpleHash` values are stored, **the client only ever looks up hashes it computes itself** — the candidate's text (catalog + your own labels) and the current bin's neighbor labels. It never reverses a hash, so the privacy-by-hash design holds while still getting a cross-user learned signal.

## Engine integration

`getLabelSuggestions` takes an optional `model`. The learned score:
- adds to ranking and counts as pre-type context (so a popular/co-occurring term can surface on an empty field),
- but **never bypasses literal text relevance** while typing and stays **weighted below a literal match** (the tier from #2825 still holds).

## The pipeline

`scripts/train-label-suggester/` (mirrors `train-bin-recommender`): pipelined SCAN/HGETALL over prod Redis → row-normalized `model.json`. Run it with:
```bash
uv run train.py --redis-url "$REDIS_URL" \
  --out ../../src/features/bin-inspector/labelSuggest/labelSuggester.model.json
```

## Inert until trained

The committed `labelSuggester.model.json` is a placeholder with `sampleCount: 0`. `isModelUsable` gates on that, so the autocomplete runs on heuristics alone (zero behavior change) until you run the trainer against prod Redis and commit a real model. **This PR ships no behavior change on its own** — it wires up the machinery.

## Testing

New: `model.test.ts` (scoring + cap + schema gating), `loadModel.test.ts` (lazy load + placeholder), `useLabelSuggesterModel.test.tsx` (async hook), and engine cases (model surfaces a popular term pre-type / a co-occurring term given a neighbor / inert empty model). `train.py` byte-compiles. Local: typecheck, lint, knip, i18n ×4 green; 194 bin-inspector + 56 shell-chain tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a learned, privacy-preserving prior (popularity + neighbor co-occurrence) to label autocomplete and adds an offline trainer that builds a hash-keyed model from Redis telemetry. The feature is wired but inert until a trained `labelSuggester.model.json` is committed.

- **New Features**
  - Blends an optional `LabelSuggesterModel` into ranking; never outranks literal text and can surface suggestions before typing.
  - Hash-only design: client looks up self-computed hashes from candidate text and neighbor labels; no reversal.
  - Lazy-loaded model via `loadLabelSuggesterModel` and `useLabelSuggesterModel`; `isModelUsable` gates on `sampleCount > 0`.
  - Offline trainer `scripts/train-label-suggester/train.py` reads `ml:label_hash:*` and `ml:cooccur:*`, normalizes, caps, and writes `labelSuggester.model.json` (uses `redis`, `click`, `uv`).
  - Tests added for model loading, scoring, gating, and engine integration.

- **Migration**
  - To enable, run the trainer against prod `REDIS_URL` and commit the generated `src/features/bin-inspector/labelSuggest/labelSuggester.model.json`.
  - No behavior change until a trained model is committed.

<sup>Written for commit 24506f3859be30feb0d0868e7d260704efe57574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

