### PR TITLE
test(kofi-webhook): pin timestamp to de-flake the amount-leak assertion

### DIFF
--- a/api/kofi-webhook.test.ts
+++ b/api/kofi-webhook.test.ts
@@ -197,7 +197,10 @@ describe('kofi-webhook', () => {
   });
 
   it('never writes the email or amount into the donor record', async () => {
-    await handle(payload({ amount: '5.00' }));
+    // Pin the timestamp: without it the record's joinedAt defaults to now, and an
+    // ISO string like "…:X5.001Z" can coincidentally contain "5.00" (seconds
+    // ending in 5, ms starting 00), flaking the substring assertion below.
+    await handle(payload({ amount: '5.00', timestamp: '2026-07-01T13:04:30Z' }));
     const written = JSON.stringify(mocks.hset.mock.calls[0]);
     expect(written).not.toContain('jo@example.com');
     expect(written).not.toContain('5.00');


### PR DESCRIPTION
Fixes the intermittent `api/kofi-webhook.test.ts` failure seen on #2832 (and lurking for any PR on the core 2/3 shard).

**Root cause:** the test asserts the serialized donor-record write doesn't contain `5.00`, but the record's `joinedAt` defaults to `Date.now()` when the payload omits a `timestamp`. An ISO string like `…:X5.001Z` (seconds ending in 5, ms starting 00) coincidentally contains the substring `5.00`, so the assertion fails by wall-clock luck. The amount never leaks into the record — it's folded into a per-currency total via `hincrby` (a different mock).

**Fix:** pin the payload timestamp so the record is deterministic. One line + a comment. Verified 20/20 across repeated runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the payload timestamp in `api/kofi-webhook.test.ts` to stop a flaky "amount not in donor record" assertion. This avoids accidental "5.00" matches from the ISO `joinedAt` value when it defaulted to `Date.now()` (e.g., ...5.001Z), making the test deterministic.

<sup>Written for commit 233265836d70bef2b8590aa03b9962faade1bca7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

