### PR TITLE
fix(build): separate ML model weights from the app JS budget

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,10 +100,17 @@
         "!dist/assets/nl-*.js",
         "!dist/assets/pt-BR-*.js",
         "!dist/assets/sv-*.js",
-        "!dist/assets/uk-*.js"
+        "!dist/assets/uk-*.js",
+        "!dist/assets/ml-model-*.js"
       ],
       "gzip": true,
-      "limit": "1900 kB"
+      "limit": "1850 kB"
+    },
+    {
+      "name": "ML model weights (gzip)",
+      "path": "dist/assets/ml-model-*.js",
+      "gzip": true,
+      "limit": "115 kB"
     }
   ],
   "dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -299,6 +299,21 @@ export default defineConfig({
             },
             // Liveblocks — only loaded when collaborative editing is active (Labs).
             { name: 'liveblocks', priority: 80, test: /[\\/]node_modules[\\/]@liveblocks[\\/]/ },
+            // Committed ML weights, pinned to stable `ml-model-*` names so the
+            // size-limit budget tracks them by an intentional rule rather than by
+            // whatever the source JSON happens to be called. Deliberately one
+            // group EACH: merging them would make loading either feature pull
+            // both models' weights.
+            {
+              name: 'ml-model-recommender',
+              priority: 85,
+              test: /[\\/]src[\\/]features[\\/]bin-recommender[\\/]model\.json$/,
+            },
+            {
+              name: 'ml-model-label-suggester',
+              priority: 85,
+              test: /[\\/]src[\\/]features[\\/]bin-inspector[\\/]labelSuggest[\\/]labelSuggester\.model\.json$/,
+            },
           ],
         },
         // Note: posthog-js is dynamically imported in src/shared/analytics/posthog.ts

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -297,8 +297,6 @@ export default defineConfig({
               priority: 90,
               test: /[\\/]node_modules[\\/](?:three[\\/]|@react-three[\\/]|three-stdlib[\\/]|troika-[^\\/]+[\\/]|bidi-js[\\/]|webgl-sdf-generator[\\/]|maath[\\/]|meshline[\\/]|camera-controls[\\/]|stats\.js[\\/]|stats-gl[\\/]|suspend-react[\\/]|its-fine[\\/]|react-use-measure[\\/]|tunnel-rat[\\/]|@use-gesture[\\/]|potpack[\\/])/,
             },
-            // Liveblocks — only loaded when collaborative editing is active (Labs).
-            { name: 'liveblocks', priority: 80, test: /[\\/]node_modules[\\/]@liveblocks[\\/]/ },
             // Committed ML weights, pinned to stable `ml-model-*` names so the
             // size-limit budget tracks them by an intentional rule rather than by
             // whatever the source JSON happens to be called. Deliberately one
@@ -314,6 +312,8 @@ export default defineConfig({
               priority: 85,
               test: /[\\/]src[\\/]features[\\/]bin-inspector[\\/]labelSuggest[\\/]labelSuggester\.model\.json$/,
             },
+            // Liveblocks — only loaded when collaborative editing is active (Labs).
+            { name: 'liveblocks', priority: 80, test: /[\\/]node_modules[\\/]@liveblocks[\\/]/ },
           ],
         },
         // Note: posthog-js is dynamically imported in src/shared/analytics/posthog.ts


### PR DESCRIPTION
## Problem

`pnpm run size:check` **fails on `main`**, blocking every PR:

```
Total JS (gzip, one locale)
  Size limit: 1.9 MB
  Size:       1.91 MB gzipped   ← over by 10.25 kB
```

The committed label-suggester model from #2828 tipped it over. Note the `dist/` in a stale working tree won't show this — it needs a fresh `pnpm run build`.

## Why not just raise the limit

The two committed models are **data, not app code**, and they grow for unrelated reasons. `retrain-label-suggester.yml` can move model weight on a schedule with no app change, so a single combined ceiling would keep getting re-breached — and in the meantime it masks app growth behind model weight.

| chunk | gzip | source |
| --- | --- | --- |
| `ml-model-recommender-*.js` | 53.7 kB | `bin-recommender/model.json` |
| `ml-model-label-suggester-*.js` | 48.0 kB | `bin-inspector/labelSuggest/labelSuggester.model.json` |

## Change

Split them into their own tracked budget so each is bounded and visible:

```
Main bundle (gzip)            29.67 kB / 190 kB
Eager initial JS (gzip)       97.31 kB / 260 kB
Total JS (gzip, one locale)    1.81 MB / 1.85 MB
ML model weights (gzip)      102.28 kB / 115 kB
```

Chunks are pinned to stable `ml-model-*` names via `advancedChunks` rather than globbing the incidental source filenames, so renaming a model file can't silently drop it out of the budget. They stay in **separate** groups on purpose — merging them would make loading either feature pull both models' weights.

## Tradeoff, stated plainly

This raises the combined ceiling from 1900 kB to **1965 kB** (1850 + 115). That's real. The follow-up moves the weights to fetched static assets, which takes them out of the JS budget entirely and lets the app ceiling drop back down.

## Verification

- Model chunks are still lazy — absent from the entry `modulepreload` list and from every static import graph; only the two feature chunks reference them, dynamically. Eager initial JS unchanged (97.30 → 97.31 kB).
- `pnpm exec vitest run src/features/bin-recommender src/features/bin-inspector` — 216 passed / 17 files.
- `pnpm run quality` — 0 errors, knip clean.

## Not included

`OSV Scan (blocking)` is also red on `main` (4 High, all devDependency-only). It is **not** fixable yet: `brace-expansion@5.0.8` and `js-yaml@5.2.2` were both published 2026-07-23, and `minimumReleaseAge: 10080` holds them until **2026-07-30**. A `pnpm.overrides` workaround is unsafe — `brace-expansion@5`'s CJS build exports `{ expand }`, but `minimatch@3.1.5` does `var expand = require('brace-expansion')` and calls it directly. Left alone deliberately; a plain bump resolves all four after the cooldown clears.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated ML model weights from the app JS size budget to fix the failing size check on main and keep model growth visible. Model weights now have their own `size-limit` entry and still load lazily.

- **Bug Fixes**
  - Split budgets: app bundle 1850 kB; `ml-model-*` weights 115 kB. Current build: Total JS 1.81 MB / 1.85 MB; ML weights 102.28 kB / 115 kB.
  - Pinned model chunks with Vite `advancedChunks` to stable names (`ml-model-recommender`, `ml-model-label-suggester`) so renames don’t bypass the budget.
  - Preserved loading behavior: no modulepreload; eager initial JS unchanged (~97.31 kB).

- **Refactors**
  - Restored descending priority order in `advancedChunks`; no build output changes (model chunk hashes and size budgets unchanged).

<sup>Written for commit a6131273bd023b4a2ddf4e649956091e4e1b3597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

