### PR TITLE
perf(build): make chunk hashes reproducible across builds

### DIFF
--- a/scripts/vite-plugin-version.test.ts
+++ b/scripts/vite-plugin-version.test.ts
@@ -1,0 +1,48 @@
+import { execFileSync } from 'node:child_process';
+import { describe, it, expect } from 'vitest';
+import type { Plugin } from 'vite';
+import { versionPlugin } from './vite-plugin-version';
+
+type Defines = Record<string, string>;
+
+/** Invoke the plugin's `config` hook, which may be a bare function or an object hook. */
+function defines(plugin: Plugin): Defines {
+  const hook = plugin.config;
+  const handler = typeof hook === 'function' ? hook : hook?.handler;
+  if (!handler) throw new Error('versionPlugin lost its config hook');
+  const result = handler.call(
+    // The hook reads nothing off `this`, and neither arg is used.
+    null as never,
+    {} as never,
+    { command: 'build', mode: 'production' } as never
+  );
+  const config = result as { define: Defines } | undefined;
+  if (!config?.define) throw new Error('config hook returned no defines');
+  return config.define;
+}
+
+describe('versionPlugin', () => {
+  it('derives __BUILD_TIME__ from the commit, not the wall clock', () => {
+    const commitIso = new Date(
+      execFileSync('git', ['log', '-1', '--format=%cI'], { encoding: 'utf-8' }).trim()
+    ).toISOString();
+
+    expect(defines(versionPlugin()).__BUILD_TIME__).toBe(JSON.stringify(commitIso));
+  });
+
+  // The regression this guards: a wall-clock build time gave smokeBoot a fresh
+  // hash on every build, and Rolldown propagated that to every chunk
+  // referencing it — ~24% of the bundle re-downloaded per deploy for unchanged
+  // code. Two builds of one commit must produce identical defines.
+  it('is stable across repeated builds of the same commit', () => {
+    expect(defines(versionPlugin()).__BUILD_TIME__).toBe(defines(versionPlugin()).__BUILD_TIME__);
+  });
+
+  it('exposes the commit sha and package version alongside it', () => {
+    const d = defines(versionPlugin());
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
+
+    expect(d.__GIT_SHA__).toBe(JSON.stringify(sha));
+    expect(d.__APP_VERSION__).toMatch(/^"\d+\.\d+\.\d+"$/);
+  });
+});

--- a/scripts/vite-plugin-version.test.ts
+++ b/scripts/vite-plugin-version.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { Plugin } from 'vite';
 import { versionPlugin } from './vite-plugin-version';
 
@@ -21,7 +21,18 @@ function defines(plugin: Plugin): Defines {
   return config.define;
 }
 
-describe('versionPlugin', () => {
+// The plugin deliberately tolerates a missing git (tarball builds, minimal
+// images), so the suite that depends on a real checkout has to tolerate it too.
+const HAS_GIT = ((): boolean => {
+  try {
+    execFileSync('git', ['rev-parse', '--git-dir'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.skipIf(!HAS_GIT)('versionPlugin in a git checkout', () => {
   it('derives __BUILD_TIME__ from the commit, not the wall clock', () => {
     const commitIso = new Date(
       execFileSync('git', ['log', '-1', '--format=%cI'], { encoding: 'utf-8' }).trim()
@@ -44,5 +55,29 @@ describe('versionPlugin', () => {
 
     expect(d.__GIT_SHA__).toBe(JSON.stringify(sha));
     expect(d.__APP_VERSION__).toMatch(/^"\d+\.\d+\.\d+"$/);
+  });
+});
+
+describe('versionPlugin without git', () => {
+  afterEach(() => {
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+  });
+
+  it('still builds, falling back to the wall clock and an unknown sha', async () => {
+    vi.resetModules();
+    vi.doMock('node:child_process', () => ({
+      execFileSync: () => {
+        throw new Error('git: command not found');
+      },
+    }));
+
+    const { versionPlugin: plugin } = await import('./vite-plugin-version');
+    const d = defines(plugin());
+
+    expect(d.__GIT_SHA__).toBe(JSON.stringify('unknown'));
+    expect(d.__APP_VERSION__).toMatch(/^"\d+\.\d+\.\d+"$/);
+    // A real ISO instant, just not a reproducible one — the documented tradeoff.
+    expect(Number.isNaN(Date.parse(JSON.parse(d.__BUILD_TIME__) as string))).toBe(false);
   });
 });

--- a/scripts/vite-plugin-version.ts
+++ b/scripts/vite-plugin-version.ts
@@ -22,10 +22,25 @@ function readVersionInfo(): VersionInfo {
     // ignore
   }
 
+  // The commit's timestamp, NOT the wall clock. `__BUILD_TIME__` is inlined into
+  // smokeBoot, so a per-build value gave that chunk a fresh hash every time —
+  // and Rolldown propagates a changed hash to every chunk that references it,
+  // which churned ~24% of the bundle between byte-identical builds. Users then
+  // re-download unchanged code on every deploy. Same commit now means the same
+  // output. The value still identifies the deployed build for the smoke gate.
+  let buildTime: string | null = null;
+  try {
+    buildTime = new Date(
+      execFileSync('git', ['log', '-1', '--format=%cI'], { encoding: 'utf-8' }).trim()
+    ).toISOString();
+  } catch {
+    // ignore
+  }
+
   return {
     version: pkg.version,
     gitSha,
-    buildTime: new Date().toISOString(),
+    buildTime: buildTime ?? new Date().toISOString(),
   };
 }
 


### PR DESCRIPTION
## Problem

Two builds of **byte-identical source** produced 33 of 139 chunks (24%) with fresh content hashes:

```
$ cp -r dist/assets /tmp/bA && pnpm run build && cp -r dist/assets /tmp/bB
$ comm -3 <(ls /tmp/bA/*.js|xargs -n1 basename|sort) \
          <(ls /tmp/bB/*.js|xargs -n1 basename|sort) | wc -l
33
```

Costs, all continuous:

- Returning users re-download ~24% of the app on **every deploy** for code that did not change
- The service worker re-precaches those chunks each release
- Chunk-hash diffs are useless for review — real changes are indistinguishable from noise

## Root cause

One value. Normalizing every `name-HASH.js` reference out of the chunk bodies and comparing showed **exactly one** chunk whose own content differed — `smokeBoot`:

```
< 2026-07-26T03:16:13.050Z`};if(window.__SMOKE_BUILD_INFO__=e,...
> 2026-07-26T03:16:19.630Z`};if(window.__SMOKE_BUILD_INFO__=e,...
```

`__BUILD_TIME__` was `new Date().toISOString()`, so it moved every build. `smokeBoot` inlines it, and Rolldown propagates a changed chunk hash to every chunk that references it — one timestamp rippled across a quarter of the bundle. The other 32 chunks differed *only* in import specifiers.

## Fix

Derive it from the commit (`git log -1 --format=%cI`), keeping the wall-clock fallback for tarball builds where git is unavailable — the same fallback `gitSha` already uses. Same commit now means byte-identical output.

## Verification

```
before:  33 of 139 chunks changed
after:    0 of 138 chunks changed
```

## Safety

`buildTime` is only carried as an opaque build identifier — `SmokeReporter` and `smokeBoot` report it, `smokeGate.ts:222` checks it for truthiness and passes it through in a payload. Nothing compares it or does arithmetic on it; `bootVersionCheck.ts:42` decides freshness from `gitSha`. A rebuild of the same commit now reports the same value, which is arguably more useful — it identifies the code, not the CI run.

## Test

`scripts/vite-plugin-version.test.ts` asserts `__BUILD_TIME__` equals the commit timestamp rather than the wall clock. That's the invariant a future refactor could silently undo, reintroducing the churn — and it fails against the old implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chunk hashes reproducible across builds by deriving `__BUILD_TIME__` from the latest commit instead of the wall clock. This stops hash churn and prevents users from re-downloading unchanged code.

- **Bug Fixes**
  - Set `__BUILD_TIME__` from `git log -1 --format=%cI`, with a wall-clock fallback when git isn’t available (mirrors `__GIT_SHA__` fallback).
  - Added `scripts/vite-plugin-version.test.ts` to assert commit-derived build time, stability across runs, and exposure of `__GIT_SHA__` and `__APP_VERSION__`; gated git-dependent cases and mocked `node:child_process` to cover the fallback path (unknown sha, wall-clock time).

<sup>Written for commit 47d8f0cf6a49a4374a3a8eba9af0fed353749747. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

