### PR TITLE
fix(generation): repair rotted __kernel-tests__ diagnostics

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/deferCorrectness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/deferCorrectness.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { writeFileSync } from 'node:fs';
+import { writeReport } from './reportTable';
 import { describe, it, beforeAll, expect } from 'vitest';
 import { initBrepjs, getGenerateBin } from './wasmInit';
 import { buildParams, makeCutout } from './scenarioTypes';
@@ -88,7 +88,7 @@ describe('defer-socket correctness vs features that reach the socket', () => {
       )
     );
 
-    writeFileSync(
+    writeReport(
       '/tmp/perfbench/defer-correctness.txt',
       rows
         .map(

--- a/src/features/generation/worker/generators/__kernel-tests__/exportCache.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/exportCache.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { writeFileSync } from 'node:fs';
+import { writeReport } from './reportTable';
 import { describe, it, beforeAll, expect } from 'vitest';
 import { measureVolume, unwrap } from 'brepjs';
 import { initBrepjs, getGenerateBin } from './wasmInit';
@@ -33,7 +33,7 @@ describe('export shell cache', () => {
     gen(p, undefined, true);
     const second = performance.now() - t;
     const v2 = vol(getLastSolid());
-    writeFileSync(
+    writeReport(
       '/tmp/perfbench/export-cache.txt',
       `first=${first.toFixed(0)}ms second=${second.toFixed(0)}ms vol1=${v1.toFixed(0)} vol2=${v2.toFixed(0)}\n`
     );

--- a/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
@@ -1,18 +1,24 @@
 // @vitest-environment node
 /**
- * Tripwire for occt-wasm's helix handedness gaps (run with the other
- * __kernel-tests__ diagnostics on every brepjs/occt-wasm bump).
+ * occt-wasm helix handedness, for kumikoWrapBuilder's corner FALLING diagonals
+ * (run with the other __kernel-tests__ diagnostics on every brepjs bump).
  *
- * Pinned CURRENT behavior (the assertions below fail when upstream fixes it):
- *   - makeHelixWire has no handedness input, so brepjs's sketchHelix
- *     left-handed flag is a NO-OP — both flags produce the identical
- *     right-handed sweep. This is why kumikoWrapBuilder approximates corner
- *     FALLING diagonals with chord boxes instead of helix sweeps.
- *   - brepjs `mirror` on a helical sweep USED to yield an empty solid. As of
- *     brepjs 18.119.2 it yields a real one, so mirroring a right-handed sweep
- *     IS now a viable left-handed substitute — see the second case.
- * A failure here means the remaining upstream gap is fixed: retire the
- * chord-box approximation in kumikoWrapBuilder's falling-diagonal branch.
+ * The two cases here fail for OPPOSITE reasons — read the one that broke:
+ *
+ *   1. Tripwire. `makeHelixWire` takes no handedness input, so sketchHelix's
+ *      left-handed flag is a NO-OP: both flags give the same right-handed
+ *      sweep. A FAILURE means upstream gained handedness.
+ *
+ *   2. Regression guard. `mirror` on a helical sweep used to yield an empty
+ *      solid; as of brepjs 18.119.2 it yields a true reflection, so a mirrored
+ *      right-handed sweep is a viable left-handed substitute. This one should
+ *      keep PASSING — a failure means that capability regressed.
+ *
+ * Either outcome bears on the same decision: the chord-box approximation in
+ * kumikoWrapBuilder's falling-diagonal branch exists because BOTH routes to a
+ * left-handed sweep were unavailable. Route 2 has since opened, so the
+ * approximation is already retirable (see the TODO on that case); case 1
+ * turning green would make it doubly so.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { sketchHelix, drawRoundedRectangle, mesh, mirror, measureVolume, unwrap } from 'brepjs';

--- a/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
@@ -8,11 +8,11 @@
  *     left-handed flag is a NO-OP — both flags produce the identical
  *     right-handed sweep. This is why kumikoWrapBuilder approximates corner
  *     FALLING diagonals with chord boxes instead of helix sweeps.
- *   - brepjs `mirror` on a helical sweep yields an EMPTY solid (volume 0),
- *     so mirroring a right-handed sweep is not a viable left-handed
- *     substitute either.
- * A failure here means the upstream gap is fixed: retire the chord-box
- * approximation in kumikoWrapBuilder's falling-diagonal branch.
+ *   - brepjs `mirror` on a helical sweep USED to yield an empty solid. As of
+ *     brepjs 18.119.2 it yields a real one, so mirroring a right-handed sweep
+ *     IS now a viable left-handed substitute — see the second case.
+ * A failure here means the remaining upstream gap is fixed: retire the
+ * chord-box approximation in kumikoWrapBuilder's falling-diagonal branch.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { sketchHelix, drawRoundedRectangle, mesh, mirror, measureVolume, unwrap } from 'brepjs';
@@ -37,7 +37,7 @@ function sweepAndMeasure(lefthand: boolean, mirrored = false): SweepFootprint {
     frenet: true,
   });
   if (mirrored) {
-    const m2 = mirror(swept, [0, 1, 0], [0, 0, 0]);
+    const m2 = mirror(swept, { normal: [0, 1, 0], at: [0, 0, 0] });
     swept.delete();
     swept = m2;
   }
@@ -67,11 +67,19 @@ describe('helix handedness tripwire', () => {
     expect(left.vol).toBeCloseTo(right.vol, 3);
   }, 120_000);
 
-  it('mirror on a helical sweep is still empty (else it becomes a viable left-handed substitute)', () => {
+  // This tripwire FIRED. It asserted mirror yields an empty solid; on
+  // brepjs 18.119.2 it yields a real one (~11.66mm³ for this fixture), so a
+  // mirrored right-handed sweep is now a viable left-handed substitute. The
+  // assertion is inverted to record that, and still catches a regression if
+  // mirror goes back to producing nothing.
+  // TODO: retire the chord-box approximation in kumikoWrapBuilder's
+  // falling-diagonal branch, now that this substitute exists. Needs visual
+  // verification of the corner diagonals before/after.
+  it('mirror on a helical sweep produces a real solid (left-handed substitute is viable)', () => {
     const mirrored = sweepAndMeasure(false, true);
     expect(
       mirrored.vol,
-      'mirror now produces a real solid from a helical sweep — a mirrored right-handed sweep can replace the kumiko chord boxes'
-    ).toBeLessThan(1e-6);
+      'mirror stopped producing a solid from a helical sweep — the left-handed substitute regressed'
+    ).toBeGreaterThan(1e-6);
   }, 120_000);
 });

--- a/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/helixHandedness.test.ts
@@ -75,11 +75,27 @@ describe('helix handedness tripwire', () => {
   // TODO: retire the chord-box approximation in kumikoWrapBuilder's
   // falling-diagonal branch, now that this substitute exists. Needs visual
   // verification of the corner diagonals before/after.
-  it('mirror on a helical sweep produces a real solid (left-handed substitute is viable)', () => {
+  it('mirror on a helical sweep produces a true reflection (left-handed substitute is viable)', () => {
+    const right = sweepAndMeasure(false);
     const mirrored = sweepAndMeasure(false, true);
+
+    // A non-empty result is not enough to justify retiring the workaround — a
+    // degenerate sliver would clear that bar. Reflection through the y=0 plane
+    // preserves volume and negates phi = atan2(y, x), so the angular footprint
+    // must come back inverted end-for-end. The ~1 rad sweep never approaches
+    // the ±pi branch cut, so phiMin/phiMax stay comparable.
+    //
+    // The footprint is asymmetric ([-0.211, +1.211] rad right-handed), which is
+    // what makes this discriminating: an unmirrored or wrongly-oriented solid
+    // misses by ~1 rad against a 5e-4 tolerance.
     expect(
       mirrored.vol,
-      'mirror stopped producing a solid from a helical sweep — the left-handed substitute regressed'
-    ).toBeGreaterThan(1e-6);
+      'mirror stopped reproducing the sweep volume — the left-handed substitute regressed'
+    ).toBeCloseTo(right.vol, 3);
+    expect(
+      mirrored.phiMin,
+      'mirrored footprint is not the reflection of the right-handed one'
+    ).toBeCloseTo(-right.phiMax, 3);
+    expect(mirrored.phiMax).toBeCloseTo(-right.phiMin, 3);
   }, 120_000);
 });

--- a/src/features/generation/worker/generators/__kernel-tests__/previewPerfBreakdown.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/previewPerfBreakdown.test.ts
@@ -16,7 +16,8 @@
  *   boolean  booleanStage   apply the cuts/fuses  ← Manifold mesh-CSG targets this
  *   merge    translate + tessellate + meshEdges    ← Manifold also re-meshes here
  */
-import { appendFileSync, writeFileSync } from 'node:fs';
+import { appendFileSync } from 'node:fs';
+import { writeReport } from './reportTable';
 import { describe, it, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './wasmInit';
 import { buildParams } from './scenarioTypes';
@@ -28,7 +29,7 @@ import type { CutoutArrayConfig } from '@/features/bin-designer/types';
 
 beforeAll(async () => {
   await initBrepjs();
-  writeFileSync(process.env['PERF_OUT'] ?? '/tmp/perfbench/results.txt', '');
+  writeReport(process.env['PERF_OUT'] ?? '/tmp/perfbench/results.txt', '');
 }, 60_000);
 
 const SAMPLES = 5; // first sample discarded (hot-CPU/JIT warm-up); median of rest

--- a/src/features/generation/worker/generators/__kernel-tests__/reportTable.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/reportTable.ts
@@ -2,6 +2,19 @@
  * Console timing table for scenario test performance reporting.
  * Called from afterAll — output is suppressed in --reporter=json mode.
  */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Write a probe report, creating the directory first.
+ *
+ * These default to /tmp/perfbench, which does not exist on a clean machine —
+ * probes were failing on ENOENT before reaching their assertions.
+ */
+export function writeReport(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
 
 export interface TimingEntry {
   name: string;

--- a/src/features/generation/worker/generators/__kernel-tests__/reportTable.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/reportTable.ts
@@ -1,6 +1,7 @@
 /**
- * Console timing table for scenario test performance reporting.
- * Called from afterAll — output is suppressed in --reporter=json mode.
+ * Reporting helpers for the __kernel-tests__ diagnostics: `printTimingTable`
+ * for the console summary (called from afterAll — suppressed under
+ * --reporter=json) and `writeReport` for probes that dump results to a file.
  */
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';


### PR DESCRIPTION
## Context

`__kernel-tests__` is in `sharedExclude`, so it runs in no vitest project and never in CI. It has its own runner, `vitest.profile.config.ts`. That arrangement is deliberate — these are slow, WASM-heavy diagnostics — but it means a broken probe stays broken silently. Three of the tracked correctness probes had rotted.

## Repairs

**`deferCorrectness`, `exportCache`** — both died on `ENOENT: /tmp/perfbench/...` *before reaching a single assertion*. They write reports into a directory that does not exist on a clean machine. All four report writers now route through a `writeReport()` helper in `reportTable.ts` that creates the directory first.

**`helixHandedness`** — called `mirror(swept, [0,1,0], [0,0,0])`, but brepjs moved to `mirror(shape, { normal, at })`. The test threw on the signature rather than reporting its result.

## The interesting part: a tripwire had fired

`helixHandedness` is a deliberate tripwire. Its docstring:

> A failure here means the upstream gap is fixed: retire the chord-box approximation in `kumikoWrapBuilder`'s falling-diagonal branch.

Once the signature was repaired, it failed — correctly:

```
AssertionError: mirror now produces a real solid from a helical sweep —
a mirrored right-handed sweep can replace the kumiko chord boxes:
expected 11.6618595462753 to be less than 0.000001
```

`mirror` on a helical sweep used to yield an empty solid. On brepjs 18.119.2 it yields a real one. So a mirrored right-handed sweep **is** now a viable left-handed substitute, and `kumikoWrapBuilder` is working around a limitation that no longer exists.

I inverted the assertion to record the new reality — it still catches a regression if `mirror` stops producing a solid — and left a `TODO` with a concrete trigger. **I did not touch `kumikoWrapBuilder`**: that is a geometry change and wants visual verification of the corner diagonals first.

Worth noting only *half* the tripwire lapsed. `sketchHelix`'s left-handed flag is still a no-op, so one of the two gaps that justified the chord boxes remains.

## Triage

All 10 correctness-oriented probes under `vitest.profile.config.ts`:

```
deferCorrectness      1 passed      authoredDividers        2 passed
exportCache           1 passed      deferStress             2 passed
helixHandedness       2 passed      disposalRegression      5 passed | 3 skipped
dividerCrossLap       5 passed      occtWasmIsolation       1 passed
sagittaArcConvention  4 passed      honeycombManifoldCheck  1 passed
```

24 passed, 3 skipped, 0 failing. Perf profilers (`profileBin`, `previewPerfBreakdown`, `compartments.perf`, `splitPerfBreakdown`, `kumikoProfile`) were not run — they emit measurements rather than pass/fail.

`pnpm run quality` clean. No CI behavior change: these files still do not run in CI.

## Follow-ups found, not done here

- **Retire the chord-box approximation** in `kumikoWrapBuilder`'s falling-diagonal branch (the fired tripwire above).
- **Watertightness gap**: `assertStructurallyValid` checks vertices/normals/indices/NaN but not watertightness, so suites using `assert: 'structural'` cannot tell a correct mesh from a leaky one. A working `analyzeManifold`/`expectWatertight` pair already exists — duplicated twice inside `compartmentBuilder.scenario.manifold.test.ts` — and is the obvious thing to promote into `meshAssertions.ts`.
- **An O-ring bin** (`O lip=OFF base=flat`, minimal repro) exports closed-but-non-manifold.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repair broken `__kernel-tests__` diagnostics by adding a safe report writer and fixing the `brepjs` `mirror` call. Clarified test headers to match current behavior.

- **Bug Fixes**
  - Prevent ENOENT by routing report writes through `writeReport()` which creates directories (`deferCorrectness`, `exportCache`, `previewPerfBreakdown`).
  - Update `helixHandedness` to `mirror(shape, { normal, at })`; tighten the tripwire to assert a true reflection: volume matches the unmirrored sweep and the angular footprint is inverted end‑for‑end (records upstream fix in `brepjs`).
  - Left a TODO to retire the chord-box approximation in `kumikoWrapBuilder` once visually verified.
  - Result: 24 passed, 3 skipped across probes under `vitest.profile.config.ts`; no CI behavior change (tests remain excluded).

<sup>Written for commit e4cac88869e9fe66c1f3befa5a1c8947a9169f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

