### PR TITLE
feat(content): add Polish (pl) SEO landing pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ public/nl/
 public/sv/
 public/nb/
 public/uk/
+public/pl/
 public/content.*.css
 public/sitemap.xml
 

--- a/content/pl/gridfinity-baseplate-generator.md
+++ b/content/pl/gridfinity-baseplate-generator.md
@@ -1,0 +1,103 @@
+---
+title: Generator płyt bazowych Gridfinity — STL online
+description: Generator płyt bazowych Gridfinity z podglądem 3D na żywo. Ustaw siatkę, dodaj otwory na magnesy, a duże płyty podzielą się na stół drukarki.
+keywords: generator płyt bazowych gridfinity, gridfinity baseplate, własna płyta bazowa gridfinity, gridfinity STL, płyta bazowa do szuflady, płyta z magnesami
+schema: HowTo
+breadcrumbs:
+  - name: Strona główna
+    url: https://gridfinitylayouttool.com/
+  - name: Generator płyt bazowych
+    url: https://gridfinitylayouttool.com/pl/gridfinity-baseplate-generator
+howTo:
+  name: Jak wygenerować własną płytę bazową Gridfinity
+  description: Ustaw rozmiar siatki, skonfiguruj funkcje, obejrzyj w 3D i pobierz swoją własną płytę bazową Gridfinity jako STL, STEP lub 3MF.
+  totalTime: PT3M
+  tools:
+    - Przeglądarka internetowa
+  steps:
+    - name: Ustaw wymiary płyty bazowej
+      text: Wybierz szerokość i głębokość w jednostkach siatki Gridfinity albo zsynchronizuj z istniejącym układem, by automatycznie dopasować rozmiar szuflady.
+    - name: Skonfiguruj funkcje
+      text: Włącz otwory na magnesy do magnetycznego mocowania Binów, dodaj wypustki łączące do wyrównania półkomórkowego i ustaw margines krawędziowy dla każdej strony pod dopasowanie do szuflady.
+    - name: Obejrzyj w 3D
+      text: Podgląd 3D na żywo aktualizuje się, gdy zmieniasz parametry. Obracaj i przybliżaj, by obejrzeć płytę bazową z każdej strony.
+    - name: Wyeksportuj i wydrukuj
+      text: Pobierz swoją płytę bazową jako STL, STEP lub 3MF. Duże płyty bazowe są automatycznie dzielone na części pasujące do stołu drukarki.
+softwareApplication:
+  name: Generator płyt bazowych Gridfinity
+  description: Parametryczny generator płyt bazowych Gridfinity z podglądem 3D na żywo. Ustaw rozmiar siatki, dodaj otwory na magnesy i wypustki łączące, skonfiguruj margines krawędziowy, a następnie wyeksportuj jako STL, STEP lub 3MF. Darmowe narzędzie w przeglądarce.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Parametryczne wymiary płyty bazowej zsynchronizowane z układem
+    - Eksport plików STL, STEP i 3MF
+    - Wgłębienia na otwory magnesów (6 mm × 2 mm)
+    - Półkomórkowe wypustki łączące
+    - Konfiguracja marginesu krawędziowego dla każdej strony
+    - Tryb dopasowania do szuflady z automatycznym doborem rozmiaru
+    - Automatyczny podział dużych płyt przekraczających stół drukarki
+    - Podgląd 3D na żywo
+    - Działa w przeglądarce, bez instalacji
+faqs:
+  - q: W jakich formatach mogę eksportować płyty bazowe?
+    a: Generator eksportuje STL (standardowy format druku 3D), STEP (do edycji w CAD) i 3MF (nowoczesny format z obsługą koloru i materiału). Większość slicerów przyjmuje wszystkie trzy.
+  - q: Czy płyta bazowa może mieć otwory na magnesy?
+    a: Tak. Włącz otwory na magnesy, by dodać wgłębienia 6 mm × 2 mm na każdym skrzyżowaniu siatki. Trzymają one standardowe magnesy neodymowe, dzięki czemu Biny pewnie wpinają się w płytę bazową.
+  - q: Co się stanie, jeśli płyta bazowa będzie za duża na mój stół drukarki?
+    a: Generator automatycznie wykrywa, kiedy płyta bazowa przekracza rozmiar stołu drukarki, i dzieli ją na drukowalne części. Otrzymujesz plik ZIP ze wszystkimi częściami gotowymi do druku i złożenia.
+  - q: Czy mogę dopasować płytę bazową do dokładnych wymiarów mojej szuflady?
+    a: Tak. Zsynchronizuj płytę bazową z układem, by automatycznie dopasować ją do rozmiaru szuflady. Użyj marginesu krawędziowego dla każdej strony, by dostroić dopasowanie i płyta usiadła równo w szufladzie.
+  - q: Czym różni się to od pobierania płyt bazowych z Printables lub Thangs?
+    a: Gotowe płyty bazowe mają stałe rozmiary. Ten generator tworzy płytę, która pasuje do dokładnych wymiarów twojej szuflady, z potrzebnymi ci funkcjami. Działa w przeglądarce, z wizualnym interfejsem i podglądem 3D na żywo.
+  - q: Czy te płyty bazowe będą działać ze standardowymi Binami Gridfinity?
+    a: Tak. Korzystają ze standardowej siatki 42 mm i profilu gniazda. Kompatybilne z każdym Binem Gridfinity z dowolnego źródła.
+navCta:
+  label: Otwórz generator
+  href: /baseplate?standalone=1
+---
+
+# Generator płyt bazowych Gridfinity
+
+Parametryczny generator płyt bazowych, który działa w przeglądarce. Ustaw rozmiar siatki, skonfiguruj otwory na magnesy i margines krawędziowy, sprawdź podgląd 3D i pobierz plik STL, STEP lub 3MF. Nic do instalowania. Część [pakietu Generator Gridfinity](/pl/gridfinity-generator), do którego należą też generator Binów i planer układu.
+
+[CTA: Zacznij generować](/baseplate?standalone=1)
+
+## Jak to działa
+
+1. **Ustaw rozmiar.** Wybierz szerokość i głębokość w jednostkach siatki albo zsynchronizuj z istniejącym układem, by automatycznie dopasować szufladę.
+2. **Skonfiguruj funkcje.** Włącz otwory na magnesy do mocowania magnetycznego, dodaj wypustki łączące do wyrównania półkomórkowego i ustaw margines krawędziowy dla każdej strony.
+3. **Sprawdź podgląd.** Widok 3D aktualizuje się natychmiast, gdy zmieniasz ustawienia. Obracaj i przybliżaj, by zobaczyć każdą stronę.
+4. **Pobierz i wydrukuj.** Wyeksportuj jako STL do slicera, STEP, jeśli chcesz edytować w CAD, albo 3MF dla obsługi koloru i materiału. Duże płyty bazowe dzielą się automatycznie.
+
+> Całe przetwarzanie odbywa się lokalnie. Twoje projekty zostają na twoim urządzeniu, chyba że je udostępnisz.
+
+## Funkcje
+
+**Rozmiar siatki.** Ustaw płytę bazową na dowolną szerokość i głębokość w standardowych jednostkach siatki Gridfinity (po 42 mm). Zsynchronizuj z układem, by automatycznie dopasować wymiary szuflady.
+
+**Otwory na magnesy.** Dodaj wgłębienia 6 mm × 2 mm na każdym skrzyżowaniu siatki na standardowe magnesy neodymowe. Biny pewnie wpinają się w płytę bazową i się nie ślizgają.
+
+**Wypustki łączące.** Półkomórkowe kołki na skrzyżowaniach siatki pomagają precyzyjnie wyrównać Biny — szczególnie przydatne w trybie pół-Bina dla precyzji 0,5 jednostki.
+
+**Margines krawędziowy.** Skonfiguruj margines niezależnie dla każdej strony — lewej, prawej, przedniej i tylnej. Dostrój dopasowanie tak, by płyta bazowa usiadła równo w szufladzie, bez luk i klinowania.
+
+**Automatyczny podział.** Płyty bazowe większe niż stół drukarki są automatycznie dzielone na drukowalne części. Pobierz plik ZIP ze wszystkimi częściami gotowymi do druku i złożenia.
+
+## Formaty eksportu
+
+| Format   | Kiedy użyć                                                                              |
+| -------- | --------------------------------------------------------------------------------------- |
+| **STL**  | Wyślij prosto do slicera. Działa z PrusaSlicer, Cura, OrcaSlicer i wszystkim innym.     |
+| **STEP** | Otwórz w Fusion 360, FreeCAD lub SolidWorks, by wprowadzić dalsze zmiany przed drukiem. |
+| **3MF**  | Zawiera metadane koloru i materiału. Dobry do drukarek wielomateriałowych.              |
+
+## Następne kroki
+
+Potrzebujesz własnych Binów do swojej płyty bazowej? Użyj [generatora Binów](/pl/gridfinity-bin-generator), by tworzyć Biny z przegródkami, wycięciami i zakładkami na etykiety. Rozplanuj całą szufladę w [planerze układu](/) albo sprawdź [zestawienie rozmiarów](/pl/gridfinity-sizes), by ustalić swoje wymiary.
+
+[CTA: Zacznij generować](/baseplate?standalone=1)

--- a/content/pl/gridfinity-bin-generator.md
+++ b/content/pl/gridfinity-bin-generator.md
@@ -1,0 +1,128 @@
+---
+title: Darmowy generator Binów Gridfinity — STL online
+description: Generator Binów Gridfinity z edytorem wizualnym i podglądem 3D na żywo. Ustaw wymiary, dodaj przegródki i wycięcia, eksportuj STL, STEP lub 3MF.
+keywords: gridfinity generator, gridfinity bin generator, gridfinity STL generator, własne biny gridfinity, gridfinity designer, generator gridfinity online
+schema: HowTo
+breadcrumbs:
+  - name: Strona główna
+    url: https://gridfinitylayouttool.com/
+  - name: Generator Binów
+    url: https://gridfinitylayouttool.com/pl/gridfinity-bin-generator
+howTo:
+  name: Jak wygenerować własny Bin Gridfinity
+  description: Ustaw wymiary, dodaj funkcje, obejrzyj w 3D i pobierz swój własny Bin Gridfinity jako STL, STEP lub 3MF.
+  totalTime: PT5M
+  tools:
+    - Przeglądarka internetowa
+  steps:
+    - name: Ustaw wymiary Bina
+      text: Wybierz szerokość, głębokość i wysokość w jednostkach siatki Gridfinity. Każda jednostka ma 42 mm szerokości i 7 mm wysokości.
+    - name: Wybierz podstawę i funkcje
+      text: Wybierz styl mocowania podstawy (standardowy, magnes, śruba lub płaski). W razie potrzeby dodaj przegródki, wycięcia w ściankach, zakładki na etykiety albo rampy zgarniające.
+    - name: Obejrzyj w 3D
+      text: Podgląd 3D na żywo aktualizuje się, gdy zmieniasz parametry. Obracaj i przybliżaj, by obejrzeć projekt z każdej strony.
+    - name: Wyeksportuj i wydrukuj
+      text: Pobierz swój Bin jako plik STL, STEP lub 3MF. Otwórz go w slicerze i drukuj.
+softwareApplication:
+  name: Generator Binów Gridfinity
+  description: Parametryczny generator Binów Gridfinity z podglądem 3D na żywo. Ustaw wymiary, dodaj przegródki, wycięcia i etykiety, a następnie wyeksportuj jako STL, STEP lub 3MF. Darmowe narzędzie w przeglądarce.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Parametryczne wymiary Bina (szerokość, głębokość, wysokość)
+    - Eksport plików STL, STEP i 3MF
+    - 6 stylów mocowania podstawy, w tym magnes i śruba
+    - Wzory ścian typu plaster miodu
+    - Konfigurowalne przegródki z wyjmowanymi ściankami działowymi
+    - Rampy zgarniające dla łatwiejszego dostępu
+    - Wycięcia w ściankach dla każdej strony osobno
+    - Zakładki na etykiety z podporą wspornikową lub pełną
+    - Wkłady denne (prostokąt, koło, sześciokąt, szczelina)
+    - Własny edytor wycięć z narzędziem pióra
+    - Podgląd 3D na żywo
+    - Tryb pół-Bina dla precyzji 0,5 jednostki
+    - Działa w przeglądarce, bez instalacji
+faqs:
+  - q: Jakie formaty plików mogę wyeksportować?
+    a: Generator eksportuje STL (standardowy format druku 3D), STEP (do edycji w CAD) i 3MF (nowoczesny format z obsługą koloru i materiału). Większość slicerów przyjmuje wszystkie trzy.
+  - q: Czy muszę instalować jakieś oprogramowanie?
+    a: Nie. Działa w przeglądarce. Otwórz stronę i zaczynaj — nie ma nic do pobrania ani zainstalowania.
+  - q: Czym różni się to od generatorów Gridfinity w OpenSCAD?
+    a: Generatory w OpenSCAD wymagają instalacji oprogramowania i edytowania kodu, by zmienić parametry. Ten generator działa w przeglądarce, z wizualnym interfejsem i podglądem 3D na żywo. Zmiany widzisz natychmiast, gdy dostrajasz ustawienia.
+  - q: Czy mogę tworzyć Biny z własnymi wycięciami?
+    a: Tak. Edytor wycięć pozwala dodawać do Binów wycięcia prostokątne, okrągłe lub o dowolnym kształcie. Użyj narzędzia pióra, by rysować złożone kształty krzywymi Béziera — na uchwyty narzędzi, zarządzanie kablami czy dowolny inny kształt.
+  - q: Czy te Biny będą pasować do moich płyt bazowych?
+    a: Tak. Korzystają ze standardowej siatki 42 mm i profilu gniazda. Kompatybilne z każdą płytą bazową Gridfinity z dowolnego źródła.
+  - q: Czy mogę zapisać projekt i wrócić do niego później?
+    a: Tak. Projekty zapisują się automatycznie w przeglądarce. Nadaj projektowi nazwę, a przetrwa między sesjami.
+  - q: Jak duże mogą być Biny?
+    a: Do 8×8 jednostek siatki (336 mm × 336 mm). W przypadku większych przestrzeni użyj planera układu, by zestawić kilka Binów razem.
+  - q: Skąd wziąć płyty bazowe?
+    a: Użyj generatora płyt bazowych, by stworzyć płytę dopasowaną do szuflady, z opcjonalnymi otworami na magnesy i marginesem krawędziowym. Wyeksportuj jako STL, STEP lub 3MF.
+navCta:
+  label: Otwórz generator
+  href: /designer
+---
+
+# Generator Binów Gridfinity
+
+Parametryczny generator Binów, który działa w przeglądarce. Ustaw wymiary, dodaj przegródki lub wycięcia, sprawdź podgląd 3D i pobierz plik STL, STEP lub 3MF. Nic do instalowania. Część [pakietu Generator Gridfinity](/pl/gridfinity-generator), do którego należą też generator płyt bazowych i planer układu.
+
+[CTA: Zacznij tworzyć Bin](/designer)
+
+## Jak to działa
+
+1. **Ustaw rozmiar.** Wybierz szerokość, głębokość i wysokość w jednostkach siatki. Potrzebujesz czegoś pomiędzy standardowymi rozmiarami? Tryb pół-Bina daje precyzję 0,5 jednostki.
+2. **Dodaj to, czego potrzebujesz.** Przegródki, wycięcia w ściankach, rampy zgarniające, zakładki na etykiety — włączaj je i dostrajaj suwakami.
+3. **Sprawdź podgląd.** Widok 3D aktualizuje się natychmiast, gdy zmieniasz ustawienia. Obracaj i przybliżaj, by zobaczyć każdą stronę.
+4. **Pobierz i wydrukuj.** Wyeksportuj jako STL do slicera, STEP, jeśli chcesz edytować w CAD, albo 3MF dla obsługi koloru i materiału.
+
+> Całe przetwarzanie odbywa się lokalnie. Twoje projekty zostają na twoim urządzeniu, chyba że je udostępnisz.
+
+## Funkcje
+
+**Przegródki.** Podziel Bin na siatkę sekcji, do 8×8. Ścianki działowe generują się automatycznie. Wyjmowane ścianki działowe możesz wyeksportować jako osobne pliki, jeśli chcesz zmieniać układ bez przedrukowywania.
+
+**Rampy zgarniające i wycięcia w ściankach.** Rampy zgarniające ułatwiają sięganie po drobne części na dnie. Wycięcia w ściankach — nacięcia w kształcie litery U na dowolnej stronie — pozwalają wysuwać rzeczy bokiem.
+
+**Zakładki na etykiety.** Półka na tylnej ściance przytrzymuje paski etykiet. Wybierz podporę wspornikową lub pełną i ustaw szerokość dla każdej kolumny.
+
+Do rzeczy, które muszą zostać na miejscu, **wkłady denne** wycinają w dnie ukształtowane wgłębienia — koła na baterie, sześciokąty na bity, prostokąty na elementy. Ustaw głębokość i obrót pod to, co przechowujesz.
+
+**Edytor wycięć** radzi sobie z nietypowymi kształtami. Przełącz się w tryb bryły pełnej, wyżłób od góry i użyj narzędzia pióra, by rysować dowolne ścieżki na klucze, szczypce czy cokolwiek o dziwnym profilu.
+
+## Opcje mocowania podstawy
+
+Wybierz, jak Bin łączy się z płytą bazową:
+
+- **Standardowy** — domyślne gniazdo Gridfinity
+- **Magnes** — wgłębienia na magnesy 6 mm × 2 mm
+- **Śruba** — otwory na wkładki gwintowane
+- **Magnes i śruba** — obie metody dla maksymalnego trzymania
+- **Obciążony** — cięższa podstawa bez magnesów
+- **Płaski** — bez gniazda, do użycia bez płyty bazowej
+
+## Formaty eksportu
+
+| Format   | Kiedy użyć                                                                              |
+| -------- | --------------------------------------------------------------------------------------- |
+| **STL**  | Wyślij prosto do slicera. Działa z PrusaSlicer, Cura, OrcaSlicer i wszystkim innym.     |
+| **STEP** | Otwórz w Fusion 360, FreeCAD lub SolidWorks, by wprowadzić dalsze zmiany przed drukiem. |
+| **3MF**  | Zawiera metadane koloru i materiału. Dobry do drukarek wielomateriałowych.              |
+
+## Dlaczego to zamiast OpenSCAD?
+
+Generatory Gridfinity w OpenSCAD działają, ale trzeba zainstalować oprogramowanie i edytować kod, żeby zmienić parametr. To działa w przeglądarce, z wizualnym interfejsem. Wynik widzisz od razu, zamiast czekać na renderowanie.
+
+Eksportuje też STEP i 3MF — nie tylko STL — i działa na telefonie, gdy musisz coś sprawdzić w drodze.
+
+## Następne kroki
+
+Nowy w Gridfinity? Przeczytaj [Czym jest Gridfinity?](/pl/what-is-gridfinity), by poznać podstawy. Wiesz już, czego potrzebujesz? Sprawdź [zestawienie rozmiarów](/pl/gridfinity-sizes), by ustalić swoje wymiary, albo przejdź do [przewodnika po planowaniu](/pl/guide), by rozplanować całą szufladę.
+
+[CTA: Zacznij tworzyć Bin](/designer)

--- a/content/pl/gridfinity-generator.md
+++ b/content/pl/gridfinity-generator.md
@@ -1,0 +1,289 @@
+---
+title: Generator Gridfinity — Biny i płyty bazowe online
+description: Darmowy generator Gridfinity. Twórz własne Biny i płyty bazowe w przeglądarce, podglądaj w 3D i eksportuj STL, STEP lub 3MF. Bez instalacji i konta.
+keywords: gridfinity generator, gridfinity bin generator, generator płyt bazowych gridfinity, gridfinity STL generator, generator gridfinity online, darmowy generator gridfinity, własne gridfinity, gridfinity 3MF, gridfinity STEP
+schema: HowTo
+breadcrumbs:
+  - name: Strona główna
+    url: https://gridfinitylayouttool.com/
+  - name: Generator Gridfinity
+    url: https://gridfinitylayouttool.com/pl/gridfinity-generator
+howTo:
+  name: Jak korzystać z generatora Gridfinity
+  description: Wybierz generator (Bin lub płyta bazowa), ustaw wymiary, skonfiguruj funkcje, obejrzyj efekt w 3D i pobierz plik STL, STEP lub 3MF gotowy do cięcia.
+  totalTime: PT3M
+  tools:
+    - Przeglądarka internetowa
+    - Drukarka 3D (do wydrukowania efektu)
+  supplies:
+    - Filament PLA, PETG lub ABS
+  steps:
+    - name: Otwórz generator
+      text: Wybierz generator Binów dla pojemników albo generator płyt bazowych dla siatki, w którą Biny się wpinają. Oba działają w przeglądarce.
+    - name: Ustaw wymiary
+      text: Biny i płyty bazowe używają standardowej jednostki siatki Gridfinity 42 mm. Wpisz szerokość i głębokość w jednostkach siatki. Dla Binów podaj wysokość w jednostkach 7 mm. Włącz tryb pół-Bina, jeśli potrzebujesz precyzji 0,5 jednostki.
+    - name: Skonfiguruj funkcje
+      text: Dla Binów wybierz styl mocowania podstawy i przełączaj przegródki, rampy zgarniające, zakładki na etykiety, wycięcia w ściankach lub wkłady denne. Dla płyt bazowych włączaj otwory na magnesy i ustawiaj margines krawędziowy dla każdej strony.
+    - name: Obejrzyj w 3D
+      text: Podgląd 3D aktualizuje się na żywo, gdy zmieniasz parametry. Obracaj, przybliżaj i sprawdzaj z każdej strony przed eksportem.
+    - name: Wyeksportuj plik
+      text: Pobierz jako STL do cięcia, STEP do dalszej edycji w CAD albo 3MF z metadanymi koloru i materiału. Duże płyty bazowe dzielą się automatycznie pod rozmiar stołu drukarki.
+    - name: Potnij i wydrukuj
+      text: Otwórz plik w PrusaSlicer, OrcaSlicer, Bambu Studio, Cura lub dowolnym innym slicerze. Większość Binów Gridfinity drukuje się dobrze przy warstwach 0,2 mm i wypełnieniu 15–20 procent.
+softwareApplication:
+  name: Generator Gridfinity
+  alternateName:
+    - Generator Binów Gridfinity
+    - Generator płyt bazowych Gridfinity
+    - Generator STL Gridfinity
+  description: Darmowy generator Gridfinity online do Binów i płyt bazowych. Ustaw wymiary, skonfiguruj funkcje, obejrzyj w 3D i wyeksportuj STL, STEP lub 3MF. Działa w przeglądarce, offline jako PWA.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  permissions: none
+  isAccessibleForFree: true
+  offers:
+    price: '0'
+    priceCurrency: USD
+    availability: https://schema.org/InStock
+  featureList:
+    - Parametryczny generator Binów z podglądem 3D na żywo
+    - Parametryczny generator płyt bazowych z siatką otworów na magnesy
+    - Eksport STL, STEP i 3MF
+    - Sześć stylów mocowania podstawy (standardowy, magnes, śruba, magnes+śruba, obciążony, płaski)
+    - Konfigurowalne przegródki do 8 na 8
+    - Wycięcia w ściankach dla każdej strony (kształt U, zgarniak, lejek)
+    - Zakładki na etykiety z podporą wspornikową lub pełną
+    - Wzory ścian typu plaster miodu
+    - Wkłady denne (prostokąt, koło, sześciokąt, szczelina)
+    - Własny kształt zarysu za pomocą maski komórek
+    - Tryb pół-Bina dla precyzji 0,5 jednostki
+    - Automatyczny podział płyty bazowej pod dowolny stół drukarki
+    - Konfigurowalny margines krawędziowy płyty bazowej dla każdej strony
+    - Otwory na magnesy (6 mm × 2 mm) na każdym skrzyżowaniu siatki
+    - Szacunek zużycia filamentu
+    - Działa offline jako Progressive Web App
+    - Bez konta, bez instalacji, bez reklam
+faqs:
+  - q: Czy generator Gridfinity jest darmowy?
+    a: Tak. Generator Gridfinity jest całkowicie darmowy, nie ma reklam, nie wymaga konta i działa offline po pierwszym załadowaniu. Nie ma płatnego pakietu ani limitu użycia.
+  - q: Co tworzy generator Gridfinity?
+    a: Tworzy dwie rzeczy — Biny do przechowywania i płyty bazowe, w które się one wpinają. Oba powstają jako pliki gotowe do druku w formacie STL, STEP lub 3MF. Możesz też zaplanować cały układ szuflady, rozmieścić na nim Biny i wyeksportować listę druku.
+  - q: Czy muszę instalować oprogramowanie, by korzystać z generatora Gridfinity?
+    a: Nie. Działa w całości w przeglądarce. Nie ma nic do pobrania ani zainstalowania. Możesz też zainstalować go jako Progressive Web App do użytku offline.
+  - q: Czy generator Gridfinity działa na telefonie?
+    a: Tak. Generator działa na iPhone, iPadzie oraz telefonach i tabletach z Androidem. Możesz skonfigurować Bina na telefonie, zapisać go na urządzeniu i wysłać STL mailem lub przez AirDrop do slicera na komputerze.
+  - q: Jakie formaty plików eksportuje generator Gridfinity?
+    a: STL do bezpośredniego cięcia, STEP do edycji w programach CAD jak Fusion 360 czy FreeCAD oraz 3MF dla slicerów, które korzystają z bogatszych metadanych, takich jak kolor czy przypisania materiału. Większość nowoczesnych slicerów przyjmuje wszystkie trzy formaty.
+  - q: Czy Biny z generatora będą pasować do moich istniejących płyt bazowych Gridfinity?
+    a: Tak. Generator trzyma się standardowej siatki Gridfinity 42 mm i standardowego profilu gniazda, więc Biny pasują do każdej oficjalnej lub stworzonej przez społeczność płyty bazowej Gridfinity. Działa to też w drugą stronę — płyty bazowe z generatora przyjmują każdy standardowy Bin Gridfinity.
+  - q: Czy generator Gridfinity potrafi tworzyć płyty bazowe z otworami na magnesy?
+    a: Tak. Generator płyt bazowych domyślnie umieszcza otwory na magnesy 6 mm × 2 mm na każdym skrzyżowaniu siatki. Możesz je wyłączyć, jeśli nie chcesz magnesów, albo zostawić i po prostu pominąć magnesy podczas druku.
+  - q: Czy w generatorze Gridfinity są ograniczenia rozmiaru?
+    a: Biny mogą mieć do 8 na 8 jednostek siatki (336 mm na 336 mm) i 20 jednostek wysokości (140 mm). Płyty bazowe mogą być większe i w razie potrzeby są automatycznie dzielone na części pasujące do stołu twojej drukarki.
+  - q: Czy generator Gridfinity obsługuje połówkowe rozmiary Binów?
+    a: Tak. Włącz tryb pół-Bina dla precyzji 0,5 jednostki — pozwala tworzyć Biny takie jak 1,5 na 2,5, by wypełnić niewygodne luki w szufladzie. Obsługa pół-Bina sięga aż do planera układu, więc połówkowe Biny układają się czysto obok pełnych.
+  - q: Czy mogę dostosować dno i ścianki Bina?
+    a: Tak. Możesz dodać przegródki z wyjmowanymi ściankami działowymi, rampy zgarniające dla łatwiejszego dostępu, zakładki na etykiety na tylnej ściance, wycięcia w kształcie U lub zgarniaka na dowolnej ściance, wzory ścian typu plaster miodu oraz ukształtowane wkłady denne (prostokąt, koło, sześciokąt, szczelina, zaokrąglony prostokąt) do porządkowania części.
+  - q: Jak generator Gridfinity wypada na tle skryptów OpenSCAD?
+    a: Skrypty OpenSCAD są potężne, ale wymagają instalacji oprogramowania, edytowania parametrów w kodzie i czekania na renderowanie. Generator Gridfinity działa w przeglądarce, daje wizualny interfejs z suwakami i przełącznikami oraz podgląda w 3D na żywo. Oba tworzą pliki zgodne ze standardem.
+  - q: Jak generator Gridfinity wypada na tle Fusion 360?
+    a: Fusion 360 to pełny pakiet parametrycznego CAD ze stromą krzywą uczenia. Generator Gridfinity jest stworzony specjalnie pod Gridfinity, więc typowe zadania (ustaw wymiary, dodaj podstawę magnetyczną, wyeksportuj STL) zajmują sekundy, a nie minuty. Jeśli chcesz połączyć Bin Gridfinity z własną geometrią, wyeksportuj STEP i pracuj dalej w Fusion.
+  - q: Użyć generatora Gridfinity czy pobrać Biny z MakerWorld i Printables?
+    a: Użyj generatora, gdy potrzebujesz dokładnego rozmiaru, konkretnej funkcji (zakładka na etykietę, otwory na magnesy, zgarniak) albo własnego kształtu zarysu. Użyj MakerWorld lub Printables, gdy ktoś już zaprojektował wyspecjalizowany uchwyt dokładnie na rzecz, którą chcesz przechowywać, jak multitool czy konkretny zestaw nasadek.
+  - q: Czy mogę zapisać moje projekty z generatora Gridfinity?
+    a: Tak. Projekty zapisują się automatycznie w przeglądarce. Możesz je nazwać, wrócić później i wyeksportować linki do udostępnienia, aby inni otworzyli tę samą konfigurację. Konto nie jest potrzebne.
+  - q: Czy generator Gridfinity szacuje zużycie filamentu?
+    a: Tak. Okno druku pokazuje szacowaną długość i wagę filamentu na jeden Bin. Przydatne do planowania budżetu filamentu przy całej szufladzie Binów.
+  - q: Czy moje dane są prywatne, gdy korzystam z generatora Gridfinity?
+    a: Całe generowanie Binów i płyt bazowych odbywa się lokalnie w twojej przeglądarce. Projekty pozostają w lokalnej pamięci przeglądarki i nigdy nie są wysyłane, chyba że sam wyraźnie utworzysz link do udostępnienia. Anonimowa analityka użycia pomaga nam ulepszać narzędzie, bez powiązanych danych osobowych.
+  - q: Czy generator Gridfinity obsługuje druk wielokolorowy lub wielomateriałowy?
+    a: Tak. Eksport 3MF niesie metadane koloru dla poszczególnych funkcji, więc slicery takie jak Bambu Studio i OrcaSlicer potrafią pomalować różne części Bina różnymi filamentami. Przydatne do zakładek na etykiety w kodzie kolorów albo dwukolorowych Binów na drukarkach wielomateriałowych.
+  - q: Które slicery działają z tym, co tworzy generator Gridfinity?
+    a: Wszystkie główne slicery — PrusaSlicer, OrcaSlicer, Bambu Studio, Cura, SuperSlicer, IdeaMaker i Simplify3D. Wyjście STL jest standardowe i niezależne od slicera. Wyjście 3MF działa najlepiej ze slicerami, które czytają metadane wielomateriałowe.
+  - q: Jaki jest najlepszy generator Gridfinity?
+    a: To zależy od tego, co tworzysz. Do pojedynczego, jednorazowego Bina wystarczy dowolny parametryczny generator z podglądem 3D na żywo, a skrypty oparte na OpenSCAD dają największą konfigurowalność, jeśli dobrze czujesz się w edytowaniu kodu. Do zorganizowania całej szuflady ten generator jest najmocniejszym wyborem — jest wbudowany w planer układu szuflady, więc Biny, płyty bazowe i plan szuflady dzielą jeden zestaw wymiarów i eksportują się razem jako lista druku, czego samodzielne generatory Binów nie oferują.
+navCta:
+  label: Otwórz generator
+  href: /designer?utm_source=gridfinity-generator&utm_medium=nav&utm_campaign=bin
+---
+
+# Generator Gridfinity
+
+Darmowy generator Gridfinity online do Binów i płyt bazowych. Ustaw wymiary, wybierz potrzebne funkcje i pobierz plik STL, STEP lub 3MF. Działa w przeglądarce — nic do instalowania — i działa offline po pierwszym załadowaniu. Dwa generatory, jedno narzędzie, bez konta. A w odróżnieniu od samodzielnych kreatorów Binów, oba są wbudowane w [planer układu szuflady](/) — zmierz szufladę raz, zaplanuj cały układ i wygeneruj każdy Bin tak, by pasował.
+
+[CTA: Otwórz generator Binów](/designer?utm_source=gridfinity-generator&utm_medium=hero&utm_campaign=bin) &nbsp; [CTA: Otwórz generator płyt bazowych](/baseplate?utm_source=gridfinity-generator&utm_medium=hero&utm_campaign=baseplate)
+
+## Co tworzy ten generator
+
+Gridfinity to modułowy system przechowywania zaprojektowany przez Zacka Freedmana. Definiuje siatkę 42 mm, w której Biny wpinają się w płyty bazowe. Żeby faktycznie używać Gridfinity, potrzebujesz obu elementów — Binów w rozmiarze twoich rzeczy i płyt bazowych w rozmiarze twojej szuflady. Ten generator ogarnia jedno i drugie.
+
+**Biny** to otwarte od góry pojemniki, które mieszczą twoje rzeczy. Generator Binów pozwala wybrać rozmiar, wybrać styl mocowania podstawy (zwykła, magnes, śruba, obciążona lub płaska), a potem nakładać funkcje — przegródki do podziału wnętrza, rampy zgarniające dla łatwego dostępu, zakładki na etykiety na tylnej ściance, wycięcia w ściankach do wysuwania rzeczy bokiem, wkłady denne ukształtowane pod konkretne przedmioty (koła na baterie, sześciokąty na bity) oraz dekoracyjne wzory ścian.
+
+**Płyty bazowe** to siatka, w którą wpinają się Biny. Generator płyt bazowych pozwala ustawić rozmiar siatki, skonfigurować otwory na magnesy 6 mm × 2 mm na każdym skrzyżowaniu, dodać margines krawędziowy dla każdej strony, by płyta dokładnie pasowała do szuflady, oraz automatycznie podzielić duże płyty na części mieszczące się na stole drukarki.
+
+Możesz też użyć [planera układu](/) generatora, by rozłożyć Biny na płycie bazowej, poprzesuwać je i wyeksportować listę druku wszystkich potrzebnych Binów. To trzecie narzędzie w pakiecie, ale parametrycznymi końmi roboczymi są generator Binów i generator płyt bazowych.
+
+## Jak to działa
+
+1. **Wybierz generator.** Otwórz generator Binów, jeśli tworzysz pojemniki, albo generator płyt bazowych, jeśli tworzysz siatkę, w którą się wpinają.
+2. **Ustaw wymiary.** Szerokość i głębokość w jednostkach siatki (1 jednostka = 42 mm). Wysokość w jednostkach 7 mm dla Binów. Tryb pół-Bina pozwala iść krokami co 0,5 jednostki.
+3. **Skonfiguruj funkcje.** Przełączaj i dostrajaj potrzebne elementy. Ustawienia domyślne są sensowne — podstawowy Bin wyślesz dwoma kliknięciami.
+4. **Obejrzyj w 3D.** Render aktualizuje się na żywo, gdy zmieniasz parametry. Przeciągnij, by obrócić, przewiń, by przybliżyć, kliknij ponownie, by odznaczyć.
+5. **Wyeksportuj.** Pobierz jako STL, STEP lub 3MF. Duże płyty bazowe dzielą się automatycznie na kilka plików.
+6. **Potnij i wydrukuj.** Otwórz plik w wybranym slicerze. Standardowe Gridfinity drukuje się dobrze przy warstwach 0,2 mm i wypełnieniu 15–20%.
+
+> Wszystko działa lokalnie. Nic nie jest wysyłane, chyba że sam wyraźnie utworzysz link do udostępnienia.
+
+## Generator Binów — co możesz konfigurować
+
+### Wymiary
+
+Szerokość, głębokość i wysokość. Szerokość i głębokość mieszczą się od 0,5 do 8 jednostek siatki (21 mm do 336 mm). Wysokość od 2 do 20 jednostek wysokości (14 mm do 140 mm). Jedna jednostka wysokości to 7 mm — standardowa jednostka Gridfinity z pierwotnej specyfikacji Zacka Freedmana.
+
+### Style mocowania podstawy
+
+Sześć opcji tego, jak Bin siedzi na płycie bazowej:
+
+- **Standardowy** — domyślne gniazdo Gridfinity. Pasuje do wszystkich płyt bazowych.
+- **Magnes** — wgłębienia na magnesy 6 mm × 2 mm. Wklej magnesy, by Biny się nie ślizgały.
+- **Śruba** — gwintowane otwory na wkładki M3. Dobre do ciężkich Binów lub w pojazdach.
+- **Magnes i śruba** — oba naraz. Maksymalne trzymanie dla rzeczy, które mają się nie ruszać.
+- **Obciążony** — grubsza podstawa jako balast, bez osprzętu.
+- **Płaski** — bez gniazda w ogóle. Gdy chcesz kształt Bina, ale bez mocowania Gridfinity.
+
+### Przegródki
+
+Podziel wnętrze na siatkę do 8 na 8 przegródek. Generator sam buduje ścianki działowe i dostosowuje ich grubość do wybranego rozmiaru. Ścianki działowe można też wyeksportować jako osobne, wyjmowane elementy — przydatne, gdy chcesz zmienić układ Bina bez przedrukowywania go.
+
+### Funkcje ścianek
+
+Trzy funkcje ścianek odpowiadają na różne potrzeby:
+
+- **Wycięcia w ściankach** — nacięcia w kształcie U, zgarniaka lub lejka na dowolnej z czterech stron plus na ściankach działowych. Pozwalają wysuwać rzeczy bokiem albo przeprowadzać kable.
+- **Rampy zgarniające** — pochylone dno z przodu, dzięki czemu drobne części zbierają się przy przedniej krawędzi i łatwo je podnieść.
+- **Wzory ścian** — plaster miodu lub inne dekoracyjne wzory dla wentylowanych Binów albo po prostu dla wyglądu.
+
+### Zakładki na etykiety
+
+Mała półka na tylnej ściance na paski etykiet. Wybierz podporę wspornikową (lżejsza, drukuje się szybciej) lub pełną (sztywniejsza). Skonfiguruj głębokość i szerokość zakładki oraz wyrównanie dla każdej kolumny. Zakładki na etykiety są świetne do szuflad narzędziowych, gdy chcesz oznaczyć zawartość każdego Bina, nie zaglądając do środka.
+
+### Wkłady denne
+
+Wgłębienia wycięte w dnie Bina w pięciu kształtach — prostokąt, koło, sześciokąt, zaokrąglony prostokąt, szczelina — z konfigurowalną głębokością i obrotem. Tego używasz, by zrobić uchwyt na baterie, uchwyt na bity, tackę na o-ringi albo sorter na śruby. Umieść do 20 wkładów na jeden Bin i skonfiguruj każdy niezależnie.
+
+### Własne kształty
+
+Większość Binów to prostokąty, ale generator obsługuje też własne zarysy za pomocą maski komórek. Przełącz się w tryb maski i maluj komórki na siatce pół-Bina — Bin przyjmuje ten kształt. Przydatne do dopasowania niewygodnych rogów szuflady albo budowania Binów w kształcie litery L czy T. Maska zostaje zachowana w linkach do udostępnienia.
+
+### Edytor wycięć
+
+Do kształtów, które nie pasują do żadnego gotowca, edytor wycięć pozwala rysować dowolne ścieżki narzędziem pióra. Uchwyty Béziera pozwalają tworzyć gładkie krzywe; tryb narożnika blokuje kąty dla prostych cięć. Wytnij zarys klucza, multitoola albo czegokolwiek innego — generator sam tworzy wgłębienie.
+
+## Generator płyt bazowych — co możesz konfigurować
+
+### Rozmiar siatki
+
+Szerokość i głębokość w jednostkach siatki. Generator skaluje się płynnie od 1 na 1 aż po płyty wielkości szuflady z dziesiątkami jednostek na stronę.
+
+### Otwory na magnesy
+
+Standardowe Gridfinity używa okrągłych magnesów 6 mm × 2 mm na każdym skrzyżowaniu siatki. Generator płyt bazowych umieszcza je domyślnie; możesz je całkowicie wyłączyć, jeśli nie chcesz magnesów. Magnesy zapobiegają ślizganiu się Binów przy otwieraniu i zamykaniu szuflady, co ma znaczenie, gdy nosisz szufladę albo prowadzisz wózek narzędziowy.
+
+### Margines krawędziowy
+
+Szuflady rzadko mają wymiar będący równą wielokrotnością 42 mm. Margines krawędziowy dodaje dodatkowy materiał z każdej strony płyty bazowej, by wypełniła szufladę od krawędzi do krawędzi bez marnowania miejsca. Margines może być inny z każdej strony, dzięki czemu możesz wyśrodkować siatkę albo dosunąć ją do jednej krawędzi.
+
+### Podział pod stół drukarki
+
+Ustaw rozmiar stołu swojej drukarki, a generator podzieli duże płyty bazowe na pasujące części. Każda część wychodzi wyrównana, więc idealnie składają się z powrotem jak kafelki. Opcjonalne łączniki na jaskółczy ogon lub pióro-wpust utrzymują części w pozycji podczas użytkowania.
+
+## Formaty wyjściowe
+
+Trzy formaty eksportu, dobrane pod różne narzędzia w dalszym etapie.
+
+| Format   | Kiedy użyć                                                                                                                                                                                                                                   |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **STL**  | Standardowy format druku 3D. Otwórz w dowolnym slicerze. Domyślny wybór, o ile nie masz konkretnego powodu na coś innego.                                                                                                                    |
+| **STEP** | Parametryczny format CAD. Otwórz w Fusion 360, FreeCAD, SolidWorks, Onshape lub dowolnym innym pakiecie CAD. Przydatny, gdy chcesz połączyć Bin Gridfinity z własną geometrią, albo dla czystych, edytowalnych powierzchni.                  |
+| **3MF**  | Nowoczesny format z metadanymi koloru i materiału. Najlepszy w parze z drukarkami wielomateriałowymi (Bambu A1 / X1, Prusa XL ze zmieniaczem narzędzi, MMU3). Slicery obsługujące 3MF zachowują wskazówki koloru dla poszczególnych funkcji. |
+
+Wszystkie trzy formaty powstają z tej samej geometrii źródłowej, więc wymiary i tolerancje są identyczne, niezależnie od tego, który wybierzesz. Wybieraj po tym, co woli twój slicer lub narzędzie w dalszym etapie.
+
+## Jak wypada na tle innych
+
+### vs. inne generatory online
+
+Istnieje kilka generatorów Gridfinity działających w przeglądarce, a te dobre dzielą ten sam rdzeń: parametryczne Biny, podgląd na żywo, pobieranie STL, brak instalacji. Gdy je porównujesz, faktycznie różnią je te szczegóły:
+
+- **Formaty eksportu.** Każdy generator eksportuje STL. Mniej z nich eksportuje STEP (do kontynuacji w CAD) i 3MF z metadanymi koloru (do drukarek wielomateriałowych). Ten eksportuje wszystkie trzy z tej samej geometrii.
+- **Płyty bazowe, nie tylko Biny.** Szuflady rzadko mają wymiar będący równą wielokrotnością 42 mm. Szukaj marginesu krawędziowego dla każdej strony i automatycznego podziału pod stół drukarki z łącznikami wyrównującymi — funkcji, które zmieniają płytę bazową z dema w coś, co faktycznie wypełnia twoją szufladę.
+- **Połówkowe rozmiary.** Kroki co 0,5 jednostki są ważniejsze, niż brzmią; to nimi wypełniasz niewygodne ostatnie 21 mm szuflady.
+- **Wymogi offline i konta.** Niektóre generatory renderują po stronie serwera, więc potrzebują połączenia i mogą kolejkować. Ten generuje lokalnie w przeglądarce i działa offline jako PWA, bez konta i bez wysyłania danych.
+
+Różnica strukturalna leży w tym, co otacza generator. Samodzielne generatory tworzą jeden Bin naraz, a plan szuflady żyje w twojej głowie albo w arkuszu. Tutaj generator Binów i generator płyt bazowych są wbudowane w planer układu szuflady: mierzysz szufladę raz, układasz każdy Bin wizualnie, a każdy generowany Bin ma już właściwy zarys. Gdy układ jest gotowy, eksportujesz listę druku obejmującą każdy plik w szufladzie — bez przepisywania wymiarów między narzędziami.
+
+### vs. skrypty OpenSCAD (kennethjiang, vector76 i inni)
+
+Skrypty OpenSCAD są koniem roboczym społeczności Gridfinity od początku projektu. Są potężne i darmowe. Są też kodem — by zmienić wysokość Bina, edytujesz parametr w pliku tekstowym i uruchamiasz render od nowa. Renderowanie zajmuje sekundy przy prostych Binach, minuty przy złożonych.
+
+Ten generator działa w przeglądarce z suwakami i przełącznikami. Podgląd 3D jest w czasie rzeczywistym, a nie kolejką renderów. Możesz dostroić głębokość magnesu i od razu zobaczyć efekt. Wyjścia STEP i 3MF są pełnoprawne, a nie doczepione na końcu. Jeśli dobrze czujesz się z kodem OpenSCAD, a GUI kastomizera ci wystarcza, te skrypty są świetne. Jeśli wolisz wizualny interfejs albo jesteś na telefonie, to tutaj jest szybciej.
+
+### vs. Fusion 360 (i inne parametryczne CAD)
+
+Fusion 360 to pełnoprawne CAD — parametry, szkice, historia, złożenia, symulacje, wszystko. Biny Gridfinity da się w Fusion zbudować bez problemu. Ceną jest krzywa uczenia i czas na każde zadanie — ustawianie szkiców i więzów pod Bin, który wydrukujesz raz, to przesada.
+
+Ten generator jest jednozadaniowy. Wie, czym jest Bin Gridfinity i jakie funkcje ludzie dodają. Typowe zadania zajmują sekundy. Kompromis — jeśli twój projekt potrzebuje własnej geometrii wykraczającej poza to, co generator udostępnia, natrafisz na ścianę. Rozwiązaniem jest wyeksportować STEP i pracować dalej w Fusion lub FreeCAD — parametryczne rusztowanie dostajesz za darmo, a potem przejmujesz stery przy tym, czego generator nie wyrazi.
+
+### vs. pobieranie z MakerWorld i Printables
+
+MakerWorld i Printables hostują tysiące Binów Gridfinity zaprojektowanych pod konkretne przedmioty — uchwyty na nasadki konkretnych marek, wkłady na multitoole, organizery na wkrętaki. Jeśli ktoś już zaprojektował dokładnie taki uchwyt, jakiego potrzebujesz, pobranie go jest szybsze niż projektowanie od nowa.
+
+Generator wygrywa przy Binach generycznych (potrzebujesz 2×3 ze zgarniakiem), dokładnych rozmiarach (twoja szuflada ma 296 mm, więc potrzebujesz 3,5×2,5 z marginesem krawędziowym) i kombinacjach, których nikt inny nie wgrał (chcesz 1×4 z magnesami, dwiema przegródkami, zakładką na etykietę i okrągłym wkładem dennym na baterię). Oba podejścia się uzupełniają — typowa szuflada miesza generowane Biny ogólnego przeznaczenia z jednym czy dwoma wyspecjalizowanymi uchwytami zaprojektowanymi przez społeczność.
+
+## Typowe zastosowania
+
+### Szuflady warsztatowe i narzędziowe
+
+Najczęstsze zastosowanie generatora Gridfinity to porządkowanie szuflad narzędziowych w warsztacie lub garażu. Klucze trafiają do długich, wąskich Binów z rampami zgarniającymi; nasadki do Binów z przegródkami i okrągłymi wkładami dennymi w rozmiarze średnicy nasadki; drobne części (śruby, podkładki, o-ringi) do Binów 1×1 lub 1×2 z podstawami magnetycznymi, żeby zamykająca się szuflada nimi nie rzucała. Zakładki na etykiety wzdłuż tyłu każdego Bina sprawiają, że inwentaryzacja narzędzi jest czytelna na pierwszy rzut oka, co ma znaczenie, gdy szuflada jest na wysokości kolan.
+
+### Stół warsztatowy do elektroniki
+
+Na stole do elektroniki generator ogarnia to, co nie pasuje nigdzie indziej — rolki komponentów SMD, płytki stykowe, wiązki przewodów połączeniowych i chaotyczną plątaninę kabli USB. Wzory typu plaster miodu są tu popularne, bo pozwalają zobaczyć zawartość Bina bez podnoszenia go. Edytor wycięć rysuje idealne kołyski na lutownice albo opalarki.
+
+### Szuflady kuchenne
+
+Gridfinity w szufladach kuchennych stało się w ostatnim roku pewnym trendem. Wycięcia w ściankach dla każdej strony przydają się w szufladach na sztućce (wycięcie w kształcie U pozwala długiej drewnianej łyżce wystawać jednym końcem), a tryb pół-Bina obejmuje niewygodne szerokości szuflad. PETG to zalecany materiał do zastosowań kuchennych ze względu na wyższą odporność na temperaturę.
+
+### Materiały hobbystyczne i do rękodzieła
+
+Twórcy rękodzieła używają wkładów dennych do wszystkiego — od miniaturowych farbek w słoiczkach, przez tacki na koraliki, po szpulki muliny. Własny edytor wycięć jest tu szczególnie cenny, bo przedmioty hobbystyczne rzadko mają standardowe rozmiary — narzędzie pióra pozwala narysować dokładny zarys tacki na kości, szpulki maszyny do szycia albo rzędu pędzli.
+
+### Akcesoria do druku 3D (rekurencyjnie)
+
+Sporo osób drukuje Biny Gridfinity, by uporządkować akcesoria, których używają do drukowania Binów Gridfinity — Biny na dysze, uchwyty na klucze imbusowe, próbki filamentu, osprzęt M3. Styl podstawy magnes-i-śruba to przesada dla szuflady w biurku, ale idealny do skrzyni narzędziowej, którą wozisz na kółkach.
+
+## Wskazówki do druku
+
+Większość Binów Gridfinity z generatora drukuje się z domyślnymi ustawieniami slicera, ale kilka szczegółów daje lepsze rezultaty.
+
+**Wysokość warstwy.** 0,2 mm to standard. Zejdź do 0,16 mm lub 0,12 mm dla wyrazistych zakładek na etykiety albo Binów drukowanych tak, że widać detal górnej warstwy. Grubsze warstwy 0,28 mm drukują się szybciej i są w porządku do Binów użytkowych, gdzie wykończenie nie ma znaczenia.
+
+**Wypełnienie.** 15–20% wypełnienia gyroid lub kratowego w zupełności wystarcza na ścianki Bina. Gniazdo podstawy i krawędź do sztaplowania korzystają na 100% wypełnieniu w dolnych 1,5 mm, co większość slicerów obsługuje automatycznie, gdy ustawisz 4 lub więcej warstw dna.
+
+**Podpory.** Większość Binów drukuje się bez podpór. Wycięcia w ściankach i zakładki na etykiety mogą skorzystać na podporach drzewkowych, jeśli geometria nawisa pod kątem większym niż 60 stopni. Wkłady denne (wgłębienia wycięte w dół w dnie) nigdy nie potrzebują podpór, bo są wycinane, a nie budowane.
+
+**Materiał.** PLA to domyślny wybór i sprawdza się w niemal każdym zastosowaniu wewnątrz. PETG to właściwy wybór do szuflad kuchennych, garaży czy miejsc, gdzie w grę wchodzą temperatura lub chemikalia. ABS albo ASA dodają trwałości do szuflad narzędziowych w pojazdach lub nieogrzewanych warsztatach. PLA-CF i PETG-CF drukują się przy ustawieniach podobnych do ich wariantów bez włókna węglowego i dają sztywniejsze Biny.
+
+**Orientacja druku.** Biny drukują się dnem w dół — to domyślna orientacja, gdy slicer wczyta plik. Płyty bazowe też drukują się dnem w dół. Nie obracaj przed cięciem — plik jest już zorientowany pod idealną przyczepność warstw.
+
+**Tolerancje.** Generator wbudowuje standardową tolerancję Gridfinity (~0,25 mm luzu w dopasowaniu gniazda). Jeśli twoja drukarka jest dokładna wymiarowo, Biny wpinają się w płyty bazowe z satysfakcjonującym kliknięciem. Jeśli siedzą luźno, drukarka przeekstrudowuje; jeśli nie pasują, drukarka niedoekstrudowuje. Rozwiązaniem jest kalibracja przepływu — a nie majstrowanie przy generatorze.
+
+## Otwórz generator
+
+Dwa punkty startowe. Wybierz ten, którego potrzebujesz najpierw — w każdej chwili możesz się przełączać między nimi.
+
+[CTA: Otwórz generator Binów](/designer?utm_source=gridfinity-generator&utm_medium=footer&utm_campaign=bin) &nbsp; [CTA: Otwórz generator płyt bazowych](/baseplate?utm_source=gridfinity-generator&utm_medium=footer&utm_campaign=baseplate)
+
+Nowy w Gridfinity? Zacznij od [Czym jest Gridfinity?](/pl/what-is-gridfinity), by poznać podstawy, albo przejdź do [przewodnika po planowaniu szuflady](/pl/guide), jeśli już wiesz, czego chcesz, i musisz to tylko rozplanować. [Zestawienie rozmiarów](/pl/gridfinity-sizes) omawia jednostki siatki i standardowe wymiary.

--- a/content/pl/gridfinity-sizes.md
+++ b/content/pl/gridfinity-sizes.md
@@ -1,0 +1,128 @@
+---
+title: Rozmiary Gridfinity — siatka 42 mm i wysokości 7 mm
+description: Jak duża jest jednostka Gridfinity? Siatka 42 mm, wysokości 7 mm. Szybka ściąga rozmiarów Binów, przeliczania szuflady i tego, co gdzie pasuje.
+keywords: rozmiary gridfinity, wymiary gridfinity, rozmiary binów gridfinity, jednostki wysokości gridfinity, gridfinity 42mm, rozmiar siatki gridfinity, standardowy rozmiar gridfinity, dlaczego gridfinity ma 42mm
+schema: Article
+breadcrumbs:
+  - name: Strona główna
+    url: https://gridfinitylayouttool.com/
+  - name: Zestawienie rozmiarów
+    url: https://gridfinitylayouttool.com/pl/gridfinity-sizes
+faqs:
+  - q: Jaki rozmiar ma jednostka siatki Gridfinity?
+    a: Jedna jednostka siatki Gridfinity to 42 mm × 42 mm. Bin 2×3 ma 84 mm szerokości i 126 mm głębokości. Wszystkie Biny i płyty bazowe Gridfinity używają tego standardu.
+  - q: Jak wysoka jest jednostka wysokości Gridfinity?
+    a: Jedna jednostka wysokości (1U) to 7 mm. Bin 3U ma około 21 mm wysokości wewnętrznej. Typowe wysokości mieszczą się w zakresie od 2U (14 mm) do 10U (70 mm).
+  - q: Jak obliczyć, ile jednostek Gridfinity zmieści się w mojej szufladzie?
+    a: Zmierz wewnętrzną szerokość i głębokość szuflady w milimetrach. Podziel każdą przez 42 i zaokrąglij w dół. Na przykład szuflada 380 mm × 260 mm mieści 9 × 6 jednostek Gridfinity.
+  - q: Czym jest tryb pół-Bina?
+    a: Tryb pół-Bina pozwala na przyrosty co 0,5 jednostki (21 mm) dla Binów, które muszą się zmieścić w przestrzeniach mniejszych niż pełna jednostka siatki. Bin 1,5×2 miałby 63 mm × 84 mm.
+  - q: Dlaczego Gridfinity ma 42 mm?
+    a: 42 mm to standard siatki, który Zack Freedman wybrał, tworząc Gridfinity w 2022 roku. Jest na tyle mały, że Bin 1×1 pomieści pojedyncze śruby lub karty SD bez marnowania miejsca, a zarazem na tyle duży, że Biny drukują się szybko i pozostają wytrzymałe. To właśnie ta stała liczba sprawia, że każdy Bin i każda płyta bazowa są wymienne, a przy tym zostawia miejsce na grubość ścianki, tolerancję i sczepiający profil podstawy.
+  - q: Jaki jest standardowy rozmiar Gridfinity?
+    a: Standardowy rozmiar Gridfinity to jedna jednostka siatki 42 mm × 42 mm, z wysokościami Binów mierzonymi co 7 mm (1U = 7 mm). Każdy Bin i każda płyta bazowa Gridfinity są wielokrotnością tych dwóch liczb — na przykład Bin 2×3 ma 84 mm × 126 mm.
+---
+
+# Rozmiary i wymiary Gridfinity
+
+**Standardowe rozmiary Gridfinity: jedna jednostka siatki to 42 mm × 42 mm (szerokość i głębokość), a jedna jednostka wysokości (1U) to 7 mm.** Każdy Bin i każda płyta bazowa są wielokrotnością tych dwóch liczb — Bin 2×3 o wysokości 6U ma 84 mm × 126 mm × 42 mm. Tryb pół-Bina dodaje kroki co 0,5 jednostki (21 mm). Gdy znasz te dwie liczby, potrafisz ustalić, co zmieści się w twojej szufladzie i które Biny wydrukować.
+
+## Jednostki siatki (szerokość i głębokość)
+
+**1 jednostka siatki = 42 mm.** Używa jej każdy Bin i każda płyta bazowa Gridfinity. Bin „2×3" jest 2 jednostki szeroki (84 mm) i 3 jednostki głęboki (126 mm).
+
+| Rozmiar siatki | Milimetry | Cale (w przybliżeniu) |
+| -------------- | --------- | --------------------- |
+| 1 jednostka    | 42 mm     | 1,65″                 |
+| 2 jednostki    | 84 mm     | 3,31″                 |
+| 3 jednostki    | 126 mm    | 4,96″                 |
+| 4 jednostki    | 168 mm    | 6,61″                 |
+| 5 jednostek    | 210 mm    | 8,27″                 |
+| 6 jednostek    | 252 mm    | 9,92″                 |
+| 7 jednostek    | 294 mm    | 11,57″                |
+| 8 jednostek    | 336 mm    | 13,23″                |
+
+### Tryb pół-Bina
+
+Dla ciaśniejszych dopasowań tryb pół-Bina używa **kroków co 0,5 jednostki (21 mm)**. Bin 1,5×2,5 miałby 63 mm × 105 mm. Włącz to w narzędziu do układów, naciskając `H`.
+
+## Dlaczego Gridfinity ma 42 mm?
+
+Siatka 42 mm to jeden standard, który sprawia, że każdy Bin i każda płyta bazowa Gridfinity są wymienne. Zack Freedman wybrał 42 mm, projektując Gridfinity w 2022 roku, bo trafia to w sam punkt: na tyle mało, że Bin 1×1 mieści pojedyncze śruby lub karty SD bez marnowania miejsca, ale na tyle dużo, że Biny drukują się szybko i pozostają wytrzymałe.
+
+42 mm dzieli się też równo na typowe rozmiary szuflad i stołów drukarek, a przy tym zostawia miejsce na grubość ścianki, luz tolerancji i sczepiający profil podstawy, dzięki któremu Biny łatwo się wyjmują, a zarazem nie ślizgają, gdy otwierasz szufladę. Ponieważ liczba jest stała, Bin wydrukowany dziś pasuje do płyty bazowej, którą ktoś zaprojektował lata temu — ta uniwersalna kompatybilność to cały sens tego standardu.
+
+**Standardowy rozmiar Gridfinity to jedna jednostka siatki 42 mm × 42 mm, z wysokościami mierzonymi co 7 mm.** Wszystko inne jest wielokrotnością tych dwóch liczb.
+
+## Jednostki wysokości
+
+**1 jednostka wysokości (1U) = 7 mm.** Tyle pionowej przestrzeni masz w środku Bina. Bin 3U pomieści rzeczy do około 21 mm wysokości.
+
+| Wysokość | Wnętrze (mm) | Typowe zastosowanie                          |
+| -------- | ------------ | -------------------------------------------- |
+| 2U       | 14 mm        | Karty SD, małe śruby, spinacze               |
+| 3U       | 21 mm        | Pendrive'y, baterie AA, sworznie             |
+| 4U       | 28 mm        | Długopisy, markery, wiertła                  |
+| 5U       | 35 mm        | Nożyczki, rolki taśmy, drobne narzędzia      |
+| 6U       | 42 mm        | Wkrętaki, szczypce (standardowa głębokość)   |
+| 7U       | 49 mm        | Puszki z aerozolem, większe narzędzia ręczne |
+| 8U       | 56 mm        | Butelki kleju, wysokie pojemniki             |
+| 10U      | 70 mm        | Głębokie przechowywanie, nieporęczne rzeczy  |
+
+> **Sprawdzenie prześwitu:** Twój najwyższy Bin plus płyta bazowa (~5 mm) musi się zmieścić przy zamkniętej szufladzie. Zmierz wewnętrzną wysokość zamkniętej szuflady, zanim zdecydujesz się na wysokie Biny.
+
+## Jak przeliczyć wymiary swojej szuflady
+
+Chwyć miarkę i zdobądź wewnętrzne wymiary szuflady w milimetrach. Następnie:
+
+1. Zmierz wewnętrzną szerokość i głębokość w milimetrach
+2. Podziel każdą przez 42
+3. Zaokrąglij w dół do najbliższej liczby całkowitej (lub połówki, jeśli używasz trybu pół-Bina)
+
+### Przykład
+
+```text
+Szerokość szuflady: 380 mm ÷ 42 = 9,04 → 9 jednostek
+Głębokość szuflady: 520 mm ÷ 42 = 12,38 → 12 jednostek
+Rozmiar układu:     9 × 12 (378 mm × 504 mm)
+Luka przy krawędzi: 2 mm szerokości, 16 mm głębokości
+```
+
+Niewielkie luki przy krawędziach to norma. Płyty bazowe nie muszą wypełniać każdego milimetra. Większość osób ustawia płyty bazowe centralnie i ignoruje lukę.
+
+## Popularne rozmiary Binów
+
+To właśnie te ludzie drukują najczęściej. Każdy z nich (lub dowolny własny rozmiar) utworzysz w [generatorze Binów](/pl/gridfinity-bin-generator).
+
+| Rozmiar Bina | Wymiary (mm) | Typowe zastosowania                            |
+| ------------ | ------------ | ---------------------------------------------- |
+| 1×1          | 42 × 42      | Pojedyncze śruby, nakrętki, drobne elementy    |
+| 1×2          | 42 × 84      | Długopisy, kable USB, baterie w rzędzie        |
+| 1×3          | 42 × 126     | Wkrętaki, linijki, długie narzędzia            |
+| 2×2          | 84 × 84      | Taśmy, kleje w sztyfcie, miarki                |
+| 2×3          | 84 × 126     | Szczypce, obcinaki do drutu, średnie narzędzia |
+| 3×3          | 126 × 126    | Zestawy wierteł, duże akcesoria                |
+| 4×2          | 168 × 84     | Klucze nasadowe, przechowywanie suwmiarek      |
+
+## Czy zmieści się na twoim stole drukarki?
+
+Większość drukarek FDM ma stół 220–256 mm, który obsługuje Biny do około 5×5 lub 6×6 jednostek. Cokolwiek większego trzeba podzielić lub wydrukować w sekcjach. Narzędzie do układów domyślnie przyjmuje stół 256 mm i oznaczy Biny, które się nie zmieszczą.
+
+## Szybka ściąga
+
+| Miara                            | Wartość           |
+| -------------------------------- | ----------------- |
+| Jednostka siatki                 | 42 mm × 42 mm     |
+| Pół jednostki siatki             | 21 mm             |
+| Jednostka wysokości (1U)         | 7 mm              |
+| Grubość płyty bazowej            | ~5 mm             |
+| Domyślny stół drukarki           | 256 mm            |
+| Maks. rozmiar siatki (narzędzie) | 50 × 50 jednostek |
+
+## Następne kroki
+
+Teraz, gdy znasz rozmiary, [wygeneruj własny Bin](/pl/gridfinity-bin-generator) albo otwórz [planer układu](/), by zobaczyć, jak Biny pasują w twojej szufladzie.
+
+Nowy w Gridfinity? [Oto krótki przegląd](/pl/what-is-gridfinity) tego, jak działa ten system.
+
+[CTA: Zaplanuj swój układ](/)

--- a/content/pl/guide.md
+++ b/content/pl/guide.md
@@ -1,0 +1,144 @@
+---
+title: Jak zaplanować układ szuflady Gridfinity
+description: Praktyczny przewodnik po planowaniu układów szuflad Gridfinity. Zmierz szufladę, dobierz potrzebne Biny i wyeksportuj listę druku.
+keywords: gridfinity planer, gridfinity układ, jak zaplanować gridfinity, planowanie organizera do szuflady, gridfinity przewodnik
+schema: HowTo
+breadcrumbs:
+  - name: Strona główna
+    url: https://gridfinitylayouttool.com/
+  - name: Przewodnik po planowaniu
+    url: https://gridfinitylayouttool.com/pl/guide
+faqs:
+  - q: Jak zmierzyć szufladę pod Gridfinity?
+    a: Zmierz wewnętrzne wymiary szuflady w milimetrach — szerokość (od lewej do prawej), głębokość (od przodu do tyłu) i prześwit na wysokość (od dna do góry przy zamkniętej szufladzie). Mierz w kilku miejscach, bo szuflady rzadko są idealnymi prostokątami, i dla każdego wymiaru przyjmij najmniejszą wartość, żeby mieć pewność.
+  - q: Jak przeliczyć wymiary szuflady na jednostki siatki Gridfinity?
+    a: Podziel każdy wymiar przez 42 mm i zaokrąglij w dół. Na przykład szuflada 380 mm × 260 mm mieści siatkę 9×6 (378 mm × 252 mm), zostawiając niewielkie luki przy krawędziach. Luki są w porządku — płyty bazowe nie muszą wypełniać każdego milimetra.
+  - q: Jakich rozmiarów Binów użyć w Gridfinity?
+    a: Na start — 1×1 z przegródkami na małe śruby i elementy; 1×2 lub 2×2 na długopisy, pendrive'y i baterie; 1×3 lub 1×4 na wkrętaki i szczypce; 2×2 lub 2×3 na taśmy i kleje; 3×3 lub większe na duże narzędzia. Zawsze możesz później wydrukować inne rozmiary, jeśli coś nie pasuje.
+  - q: Jak wysoki może być Bin Gridfinity?
+    a: Wysokość Bina ogranicza tylko prześwit szuflady i wysokość Z twojej drukarki. Wysokości mierzy się w jednostkach 7 mm (U). Bin 6U ma wewnątrz 42 mm, Bin 9U — 63 mm. Przed drukiem sprawdź swój najwyższy Bin plus 5 mm na płytę bazową względem prześwitu zamkniętej szuflady.
+  - q: Czy w głębokich szufladach warto używać kilku warstw?
+    a: Tak, jeśli masz zapas wysokości. Ustaw Biny w pionie, z warstwą 1 na dole. Ciężkie rzeczy trzymaj na dole, często używane na górze. Dobrze się to sprawdza przy oddzielaniu płaskich rzeczy (kable) od wysokich Binów albo przy trzymaniu osobno elektryki od mechaniki.
+  - q: Jak wyeksportować listę druku Gridfinity?
+    a: Gdy układ jest gotowy w narzędziu, lista druku pokazuje każdy rozmiar Bina, potrzebną liczbę, szacunki filamentu w gramach oraz linki wyszukiwania każdego rozmiaru na Printables, Thangs i MakerWorld. Możesz też wygenerować własne Biny wbudowanym generatorem i wyeksportować pliki STL, STEP lub 3MF.
+  - q: Ile pustej przestrzeni zostawić w szufladzie Gridfinity?
+    a: Zostaw 10–20% wolnego miejsca. Szuflada zaplanowana dziś w 100% jutro staje się problemem, gdy twoja kolekcja urośnie albo zmienią się potrzeby. Puste pola siatki nic nie kosztują i dają miejsce na dokładanie Binów później.
+  - q: Jaka jest najlepsza drukarka do Gridfinity?
+    a: Każda drukarka FDM z co najmniej stołem 256 mm × 256 mm bez problemu drukuje Biny Gridfinity. Bambu Lab X1, A1 i P1S są popularne ze względu na prędkość. Prusa MK4 i Ender 3 V3 KE też działają dobrze. Przy szufladach większych niż 6×6 jednostek albo poukładasz płyty bazowe jak kafelki, albo sięgniesz po drukarkę większego formatu, jak Bambu X1E czy Voron 2.4.
+---
+
+# Jak zaplanować układ szuflady Gridfinity
+
+Druk bez planu marnuje filament. Skończysz na przedrukowywaniu Binów, bo źle zgadłeś rozmiary, na niechcianych lukach albo na zapominaniu, czego potrzebowałeś. Ten przewodnik pokazuje, jak zmierzyć, zaplanować i uzyskać listę druku, zanim zaczniesz.
+
+## Zmierz szufladę
+
+Zdobądź wewnętrzne wymiary w milimetrach. Potrzebujesz:
+
+- **Szerokość** — od lewej do prawej
+- **Głębokość** — od przodu do tyłu
+- **Wysokość** — od dna do góry (prześwit przy zamkniętej szufladzie)
+
+Mierz w kilku miejscach. Szuflady rzadko są idealnymi prostokątami, zwłaszcza w starszych meblach. Dla pewności przyjmij najmniejszy wynik.
+
+### Przelicz na jednostki siatki
+
+Gridfinity używa jednostek 42 mm. Podziel i zaokrąglij w dół:
+
+```text
+Szerokość: 380 mm ÷ 42 = 9,04 → 9 jednostek
+Głębokość: 260 mm ÷ 42 = 6,19 → 6 jednostek
+```
+
+Siatka 9×6 to 378 mm × 252 mm. Będziesz mieć niewielkie luki przy krawędziach. To w porządku. Płyty bazowe nie muszą wypełniać każdego milimetra.
+
+## Ustal, co ma się w niej znaleźć
+
+Większość ludzi pomija ten krok i tego żałuje.
+
+Wyjmij wszystko z szuflady. Pogrupuj:
+
+- Rzeczy codzienne
+- Rzeczy cotygodniowe
+- Rzeczy, o których zapomniałeś, że je masz
+
+To, co codzienne, musi być pod ręką. Cotygodniowe może iść do tyłu. Zapomniane być może wcale nie potrzebuje Bina.
+
+### Dopasuj przedmioty do rozmiarów Binów
+
+Zgrubne wskazówki:
+
+| Zawartość                      | Rozmiar Bina       |
+| ------------------------------ | ------------------ |
+| Śruby M3, drobne elementy      | 1×1 z przegródkami |
+| Długopisy, pendrive'y, baterie | 1×2 lub 2×2        |
+| Wkrętaki, szczypce             | 1×3 lub 1×4        |
+| Taśmy, butelki kleju           | 2×2 lub 2×3        |
+| Duże narzędzia                 | 3×3 lub większe    |
+
+Nie przywiązuj się do tego zanadto. Zawsze możesz później wydrukować inne Biny.
+
+## Zaplanuj układ
+
+Otwórz narzędzie i ustaw rozmiar siatki. Przeciągaj, żeby tworzyć Biny. Narzędzie nie pozwoli ci nachodzić na siebie ani wyjść poza obszar.
+
+**Często używane rzeczy blisko przodu.** Po co sięgasz najpierw, gdy otwierasz szufladę? To idzie do przodu.
+
+**Grupuj powiązane rzeczy.** Wkrętaki w jednym miejscu, narzędzia pomiarowe w innym. Łatwiej zapamiętasz, gdzie co jest.
+
+**Zostaw trochę wolnego miejsca.** Twoja kolekcja urośnie. Szuflada zaplanowana dziś w 100% jutro jest problemem.
+
+### Warstwy w wysokich szufladach
+
+Jeśli szuflada ma zapas wysokości, możesz układać Biny w pionie. Warstwa 1 jest na dole.
+
+Dobrze sprawdza się to przy:
+
+- Płaskich rzeczach na dole (kable, drobne części), wyższych Binach na górze
+- Trzymaniu osobno elektryki od mechaniki
+
+Ciężkie rzeczy trzymaj na dole, często używane na górze.
+
+## Wyeksportuj listę druku
+
+Gdy układ ci odpowiada, wyeksportuj listę druku:
+
+- Każdy rozmiar Bina i liczbę sztuk
+- Szacunki filamentu w gramach
+- Linki wyszukiwania dla każdego rozmiaru
+
+### Znajdowanie plików STL
+
+Możesz [wygenerować własne Biny](/pl/gridfinity-bin-generator) wprost we wbudowanym generatorze — wybierz wymiary, styl podstawy, przegródki i wyeksportuj jako STL, STEP lub 3MF.
+
+Po wyspecjalizowane Biny (uchwyty pod konkretne narzędzia, złożone kształty) przeszukaj repozytoria społeczności:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — największy wybór
+- [Thangs](https://thangs.com/search/gridfinity) — dobre do znajdowania podobnych projektów
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — społeczność Bambu Lab
+
+Przykładowe wyszukiwanie: „gridfinity 2x2 3U" znajduje Biny 2×2 o wysokości 3 jednostek.
+
+## Zanim wydrukujesz
+
+### Najpierw przetestuj na kartonie
+
+> Wytnij karton na rozmiary swoich Binów (42 mm na jednostkę siatki) i ułóż go w szufladzie. Jeśli coś się nie zgadza, nie zmarnowałeś ani grama filamentu.
+
+### Najpierw wydrukuj jeden Bin
+
+Zanim wydrukujesz 20 Binów, wydrukuj jeden. Sprawdź dopasowanie, sprawdź wysokość i upewnij się, że projekt ci odpowiada. W razie potrzeby dostrój ustawienia drukarki.
+
+### Sprawdź prześwit
+
+Twój najwyższy Bin plus płyta bazowa (około 5 mm) musi się zmieścić przy zamykaniu szuflady. Zmierz to, zanim zdecydujesz się na wysokie Biny.
+
+## Częste błędy
+
+**Zbyt wiele malutkich Binów.** Siatka Binów 1×1 wygląda schludnie, ale w codziennym użyciu bywa irytująca. Większe Biny z przegródkami są zwykle lepsze.
+
+**Wypełnianie każdego pola.** To nie zostawia miejsca na nowe rzeczy. Zaplanuj 10–20% wolnej przestrzeni.
+
+**Ignorowanie tego, czego naprawdę używasz.** Nie organizuj wokół tego, co wydaje ci się, że powinieneś mieć. Organizuj wokół tego, po co realnie sięgasz.
+
+[CTA: Otwórz narzędzie do układów](/)

--- a/content/pl/what-is-gridfinity.md
+++ b/content/pl/what-is-gridfinity.md
@@ -1,0 +1,80 @@
+---
+title: Czym jest Gridfinity? System modułowy 42 mm
+description: Gridfinity to darmowy, otwartoźródłowy system modułowy drukowany 3D na siatce 42 mm. Poznaj Biny, płyty bazowe i wysokości 7 mm — zaprojektuj własny.
+keywords: gridfinity, czym jest gridfinity, organizer do szuflady, druk 3D, modułowy system przechowywania, Zack Freedman
+schema: Article
+breadcrumbs:
+  - name: Strona główna
+    url: https://gridfinitylayouttool.com/
+  - name: Czym jest Gridfinity?
+    url: https://gridfinitylayouttool.com/pl/what-is-gridfinity
+faqs:
+  - q: Czym jest Bin Gridfinity?
+    a: Bin Gridfinity to drukowany 3D pojemnik, który stoi na płycie bazowej Gridfinity. Biny występują w rozmiarach siatki (1×1, 2×2, 3×1 itd., gdzie 1 jednostka to 42 mm) i w wysokościach mierzonych co 7 mm. Profilowana podstawa wpasowuje się we wzór płyty bazowej, więc Biny pozostają na miejscu przy otwieraniu szuflady, ale łatwo się je wyjmuje.
+  - q: Jak duża jest jednostka Gridfinity?
+    a: Jedna jednostka siatki Gridfinity to 42 mm × 42 mm. Wysokość używa osobnego przyrostu 7 mm, często oznaczanego jako „U". Bin 2×2 o wysokości 3U ma więc mniej więcej 84 mm × 84 mm × 21 mm wewnątrz.
+  - q: Jaka jest różnica między Binem Gridfinity a płytą bazową?
+    a: Płyty bazowe to płaskie kafelki, które wkładasz do szuflady i które tworzą siatkę 42 mm. Biny to pojemniki na twoje rzeczy, spoczywające na wzorze płyty bazowej. Płyty bazowe drukujesz raz, żeby pokryć szufladę, a potem drukujesz na nich dowolne Biny.
+  - q: Jakiego filamentu użyć do Binów Gridfinity?
+    a: PLA to standardowy wybór, pod który zoptymalizowana jest większość projektów społeczności. PETG sprawdza się, gdy chcesz większej trwałości lub odporności na uderzenia. ASA albo ABS mają sens, jeśli Biny stoją w ciepłym miejscu (garaż, strych). Unikaj PLA w rozgrzanym aucie.
+  - q: Ile filamentu zużywa Bin Gridfinity?
+    a: Typowy Bin 2×2 zużywa około 20–40 gramów PLA, zależnie od wysokości i wypełnienia. Bin 1×1 to około 8–15 g. Płyty bazowe są cięższe w przeliczeniu na jednostkę — mniej więcej 25–30 g na jednostkę siatki.
+  - q: Ile trwa druk Bina Gridfinity?
+    a: Bin 2×2 drukuje się około 1–2 godzin przy standardowych prędkościach (50–80 mm/s). Bambu Lab i inne szybkie drukarki skracają to do 20–40 minut. Płyty bazowe zajmują więcej czasu na jednostkę ze względu na powierzchnię.
+  - q: Czy Biny Gridfinity wypadają przy otwieraniu szuflady?
+    a: Nie. Wypukły wzór płyty bazowej tworzy dość tarcia, by utrzymać Biny na miejscu przy normalnym korzystaniu z szuflady. Nie są zablokowane, więc możesz je wyjąć prosto do góry, ale nie ślizgają się, gdy otwierasz lub zamykasz szufladę.
+  - q: Czy mogę kupić Biny Gridfinity zamiast je drukować?
+    a: Tak — wielu sprzedawców oferuje gotowe, wydrukowane Biny na Etsy, Amazonie i w sklepach prosto od makerów. To opcja, jeśli nie masz drukarki 3D, choć druk samodzielny wychodzi zwykle taniej na Bin, gdy wliczysz wysyłkę.
+  - q: Czy Gridfinity jest darmowe?
+    a: Tak. Gridfinity ma otwarty kod. Projekty społeczności można pobrać za darmo z Printables, Thangs i MakerWorld. Twój jedyny koszt to filament.
+---
+
+# Czym jest Gridfinity?
+
+Gridfinity to darmowy, otwartoźródłowy modułowy system przechowywania, który drukujesz samodzielnie w 3D: Biny w standardowych rozmiarach spoczywają na siatce płyt bazowych 42 mm, więc każdy projekt każdego twórcy jest wymienny. Zack Freedman, maker i youtuber, stworzył go w 2022 roku — dziś tylko na Printables jest ponad 10 000 darmowych projektów.
+
+Idea jest prosta: wszystko opiera się na siatce 42 mm. Biny spoczywają na płytach bazowych. Płyty bazowe układa się jak kafelki, by wypełnić dowolną szufladę. Gdy chcesz coś przeorganizować, po prostu wyjmujesz Biny i przesuwasz je.
+
+## Jak to działa
+
+Zestaw Gridfinity składa się z dwóch części:
+
+**Płyty bazowe** trafiają do szuflady. To płaskie siatki z wypukłym wzorem, który utrzymuje Biny na miejscu. Układasz je jak kafelki, by pokryć dostępną powierzchnię.
+
+**Biny** mieszczą twoje rzeczy. Występują w rozmiarach siatki (1×1, 2×2, 3×1 itd.) i w wysokościach mierzonych w jednostkach 7 mm. Bin 3U daje około 21 mm wysokości wewnętrznej.
+
+Biny mają profilowaną podstawę, która wpasowuje się we wzór płyty bazowej. Zostają na miejscu przy otwieraniu szuflady, ale łatwo je wyjąć, gdy ich potrzebujesz.
+
+## Dlaczego ludzie tego używają
+
+**Drukujesz dokładnie to, czego potrzebujesz.** Żadnego kupowania 12-paku Binów, gdy potrzebujesz 2. Żadnego szukania właściwego rozmiaru. Jeśli istnieje Bin na twoje konkretne wiertła czy śruby, po prostu go drukujesz.
+
+**Wszystko jest kompatybilne.** Bin 2×2 od jednego projektanta pasuje do płyty bazowej innego. Każdy projekt trzyma się tej samej specyfikacji.
+
+**To za darmo.** Projekty mają otwarty kod. Jedyny koszt to filament. Typowy Bin zużywa 20–40 gramów PLA.
+
+## Znajdowanie projektów
+
+Społeczność stworzyła Biny na większość typowych potrzeb: uchwyty na wkrętaki, organizery na baterie, tacki na wiertła, zarządzanie kablami.
+
+Główne repozytoria:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — największa kolekcja, dobre filtrowanie
+- [Thangs](https://thangs.com/search/gridfinity) — wyszukiwanie po podobnym kształcie
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — popularne wśród posiadaczy Bambu
+
+Wyszukaj to, czego potrzebujesz (np. „gridfinity 2x2 battery holder"), a znajdziesz opcje.
+
+## Co jest potrzebne na start
+
+1. **Drukarka 3D.** Każda drukarka FDM się nada. PLA to standard.
+2. **Wymiary.** Wewnętrzne wymiary szuflady w milimetrach. Zajrzyj do [zestawienia rozmiarów](/pl/gridfinity-sizes) po przeliczenie.
+3. **Plan.** Ile jednostek siatki się mieści, jakich Binów potrzebujesz, gdzie mają trafić.
+
+To narzędzie pomaga w kroku 3. Rozrysuj układ, zobacz, jak wszystko pasuje, a potem wyeksportuj listę tego, co wydrukować. Możesz też [wygenerować własne Biny](/pl/gridfinity-bin-generator) z eksportem STL, STEP i 3MF bezpośrednio w przeglądarce.
+
+## Następny krok
+
+Gdy będziesz gotowy zaplanować szufladę, przewodnik przeprowadzi cię przez mierzenie, planowanie i eksport listy druku.
+
+[CTA: Przeczytaj przewodnik po planowaniu](/pl/guide)

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -37,7 +37,7 @@ const SITE_URL = 'https://gridfinitylayouttool.com';
 const MAX_TITLE_LEN = 55;
 const MAX_DESCRIPTION_LEN = 155;
 
-const SUPPORTED_LOCALES = ['en', 'de', 'fr', 'es', 'pt-BR', 'nl', 'sv', 'nb', 'uk'] as const;
+const SUPPORTED_LOCALES = ['en', 'de', 'fr', 'es', 'pt-BR', 'nl', 'sv', 'nb', 'uk', 'pl'] as const;
 type Locale = (typeof SUPPORTED_LOCALES)[number];
 const DEFAULT_LOCALE: Locale = 'en';
 
@@ -51,6 +51,7 @@ const LOCALE_LABELS: Record<Locale, { lang: string; openTool: string; siteName: 
   sv: { lang: 'sv', openTool: 'Öppna verktyget', siteName: 'Gridfinity Layout Tool' },
   nb: { lang: 'nb', openTool: 'Åpne verktøy', siteName: 'Gridfinity Layout Tool' },
   uk: { lang: 'uk', openTool: 'Відкрити інструмент', siteName: 'Gridfinity Layout Tool' },
+  pl: { lang: 'pl', openTool: 'Otwórz narzędzie', siteName: 'Gridfinity Layout Tool' },
 };
 
 const FAQ_HEADING: Record<Locale, string> = {
@@ -63,6 +64,7 @@ const FAQ_HEADING: Record<Locale, string> = {
   sv: 'Vanliga frågor',
   nb: 'Ofte stilte spørsmål',
   uk: 'Часті запитання',
+  pl: 'Najczęściej zadawane pytania',
 };
 
 const FOOTER_COPY: Record<Locale, string> = {
@@ -75,6 +77,7 @@ const FOOTER_COPY: Record<Locale, string> = {
   sv: 'Gratis att använda.',
   nb: 'Gratis å bruke.',
   uk: 'Безкоштовно у використанні.',
+  pl: 'Darmowe w użyciu.',
 };
 
 const OG_LOCALE: Record<Locale, string> = {
@@ -87,6 +90,7 @@ const OG_LOCALE: Record<Locale, string> = {
   sv: 'sv_SE',
   nb: 'nb_NO',
   uk: 'uk_UA',
+  pl: 'pl_PL',
 };
 
 const NATIVE_LANGUAGE: Record<Locale, string> = {
@@ -99,6 +103,7 @@ const NATIVE_LANGUAGE: Record<Locale, string> = {
   sv: 'Svenska',
   nb: 'Norsk',
   uk: 'Українська',
+  pl: 'Polski',
 };
 
 const LANGUAGE_LABEL: Record<Locale, string> = {
@@ -111,6 +116,7 @@ const LANGUAGE_LABEL: Record<Locale, string> = {
   sv: 'Språk',
   nb: 'Språk',
   uk: 'Мова',
+  pl: 'Język',
 };
 
 const FOOTER_LINKS: Record<
@@ -255,6 +261,20 @@ const FOOTER_LINKS: Record<
     software: 'Порівняння програм',
     privacy: 'Конфіденційність',
     terms: 'Умови',
+  },
+  pl: {
+    generator: 'Generator Gridfinity',
+    whatIs: 'Czym jest Gridfinity?',
+    bin: 'Generator Binów',
+    baseplate: 'Generator płyt bazowych',
+    sizes: 'Zestawienie rozmiarów',
+    guide: 'Przewodnik po planowaniu',
+    toolDrawer: 'Szuflady narzędziowe',
+    kitchen: 'Szuflady kuchenne',
+    calculator: 'Kalkulator',
+    software: 'Porównanie oprogramowania',
+    privacy: 'Prywatność',
+    terms: 'Regulamin',
   },
 };
 

--- a/src/shell/Sidebar/learnLinks.ts
+++ b/src/shell/Sidebar/learnLinks.ts
@@ -22,7 +22,7 @@ export const LEARN_LINKS: ReadonlyArray<{ slug: string; labelKey: string; locali
 
 // Locales with translated content pages (mirrors vercel.json's localized rewrite).
 // `ja` has UI translations but no content pages, so it stays on English content.
-const CONTENT_LOCALES = new Set<Locale>(['de', 'fr', 'es', 'pt-BR', 'nl', 'sv', 'nb', 'uk']);
+const CONTENT_LOCALES = new Set<Locale>(['de', 'fr', 'es', 'pt-BR', 'nl', 'sv', 'nb', 'uk', 'pl']);
 
 /**
  * Resolves the href for a Learn link, prefixing the active locale only when the

--- a/vercel.json
+++ b/vercel.json
@@ -167,6 +167,16 @@
       ]
     },
     {
+      "source": "/pl/:path((?!api/).*)",
+      "headers": [
+        { "key": "Content-Language", "value": "pl" },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
       "source": "/fr/:path((?!api/).*)",
       "headers": [
         { "key": "Content-Language", "value": "fr" },
@@ -314,7 +324,7 @@
       "destination": "/:slug/index.html"
     },
     {
-      "source": "/:locale(de|fr|es|pt-BR|nl|sv|nb|uk)/:slug(what-is-gridfinity|guide|gridfinity-generator|gridfinity-bin-generator|gridfinity-baseplate-generator|gridfinity-sizes)",
+      "source": "/:locale(de|fr|es|pt-BR|nl|sv|nb|uk|pl)/:slug(what-is-gridfinity|guide|gridfinity-generator|gridfinity-bin-generator|gridfinity-baseplate-generator|gridfinity-sizes)",
       "destination": "/:locale/:slug/index.html"
     },
     { "source": "/designer", "destination": "/" },


### PR DESCRIPTION
## Summary

Adds **Polish (`pl`) SEO landing pages** — the localized marketing/content pages (separate from the UI translation shipped in #2840). First of the content batch (pl → zh-CN → cs → ko).

Translates the same **6 core pages** every content locale carries (matching the de/fr/es/… convention): `what-is-gridfinity`, `guide`, `gridfinity-generator`, `gridfinity-bin-generator`, `gridfinity-baseplate-generator`, `gridfinity-sizes`.

## What changed

| File                              | Change                                                                                                                                                                                    |
| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `content/pl/*.md`                 | **New** — 6 translated long-form pages (~9.7k words) with full frontmatter (title, description, keywords, breadcrumbs, FAQs, schema)                                                      |
| `scripts/build-content.ts`        | `pl` in `SUPPORTED_LOCALES` + entries in all 7 `Record<Locale>` maps (LOCALE_LABELS, FAQ_HEADING, FOOTER_COPY, OG_LOCALE=`pl_PL`, NATIVE_LANGUAGE=`Polski`, LANGUAGE_LABEL, FOOTER_LINKS) |
| `vercel.json`                     | `/pl/` `Content-Language` header block + `pl` added to the localized-slug rewrite alternation                                                                                             |
| `src/shell/Sidebar/learnLinks.ts` | `pl` added to `CONTENT_LOCALES` (so in-app Learn links point to `/pl/…`)                                                                                                                  |
| `.gitignore`                      | ignore generated `public/pl/` (matches de/fr/… — HTML is regenerated by `build:content` in CI)                                                                                            |

## SEO correctness (verified locally via `build:content`)

- ✅ All 6 pages generate → `public/pl/<slug>/index.html`
- ✅ **No SERP length warnings** — every title ≤55 chars, every description ≤155 (kept tight; the existing nl/sv/nb/uk pages have pre-existing over-limit warnings, untouched here)
- ✅ `<html lang="pl">`, `hreflang="pl"` alternates + `x-default` → root
- ✅ Sitemap includes `/pl/` entries
- ✅ Breadcrumb URLs `/pl/`-prefixed (Home → root); internal links prefixed only for the 6 localized slugs
- ✅ `typecheck` passes (the `Record<Locale>` maps are now complete for `pl`)

## Translation notes

- **"Bin" kept as an English loanword** (declined: Biny/Binów) — consistent with the Polish UI (#2840) and how the de content page keeps "Bin". Other domain nouns localized (baseplate → płyta bazowa).
- Mirrored the existing-locale convention of **stripping inline images** from localized pages (de/fr do the same).
- `terms → Regulamin` (idiomatic PL for site terms); `Free to use. → Darmowe w użyciu.` — flag if you prefer alternatives.

## Out of scope

This is content/SEO only; the Polish **UI** translation already shipped in #2840. English-only pages (calculator, software, kitchen/tool-drawer, privacy, terms) remain English by the existing convention.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Polish (pl) SEO landing pages for our 6 core content pages and wire the locale into build, routing, and in-app Learn links. Ships /pl pages with correct metadata, sitemap entries, and hreflang.

- **New Features**
  - Added 6 Polish pages under content/pl/ (what-is-gridfinity, guide, gridfinity-generator, gridfinity-bin-generator, gridfinity-baseplate-generator, gridfinity-sizes).
  - Enabled locale: added `pl` to `SUPPORTED_LOCALES` and all locale maps in `scripts/build-content.ts`; added `pl` to `CONTENT_LOCALES` in `learnLinks.ts`; added `/pl/*` headers and localized rewrite in `vercel.json`; ignored `public/pl/` in `.gitignore`.
  - SEO verified: pages build to `/pl/<slug>/index.html`; titles ≤55 chars, descriptions ≤155; sitemap includes `/pl`; correct `lang="pl"` and `hreflang` alternates.

<sup>Written for commit 5506da031a43c512881cbb5d0f68eead9e59cc46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

