### PR TITLE
feat(content): add Czech (cs) SEO landing pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ public/nb/
 public/uk/
 public/pl/
 public/zh-CN/
+public/cs/
 public/content.*.css
 public/sitemap.xml
 

--- a/content/cs/gridfinity-baseplate-generator.md
+++ b/content/cs/gridfinity-baseplate-generator.md
@@ -1,0 +1,103 @@
+---
+title: Generátor základních desek Gridfinity — STL online
+description: Generátor základních desek Gridfinity s živým náhledem 3D. Nastav mřížku, přidej otvory na magnety a velké desky se rozdělí podle podložky tiskárny.
+keywords: generátor základních desek gridfinity, gridfinity baseplate, vlastní základní deska gridfinity, gridfinity STL, základní deska do zásuvky, magnetická základní deska
+schema: HowTo
+breadcrumbs:
+  - name: Domů
+    url: https://gridfinitylayouttool.com/
+  - name: Generátor základních desek
+    url: https://gridfinitylayouttool.com/cs/gridfinity-baseplate-generator
+howTo:
+  name: Jak vygenerovat vlastní základní desku Gridfinity
+  description: Nastav rozměr mřížky, nakonfiguruj funkce, prohlédni ve 3D a stáhni svou vlastní základní desku Gridfinity jako STL, STEP nebo 3MF.
+  totalTime: PT3M
+  tools:
+    - Webový prohlížeč
+  steps:
+    - name: Nastav rozměry základní desky
+      text: Vyber šířku a hloubku v jednotkách mřížky Gridfinity nebo synchronizuj se svým rozvržením, ať se rozměr zásuvky doplní automaticky.
+    - name: Nakonfiguruj funkce
+      text: Zapni otvory na magnety pro magnetické uchycení Binů, přidej spojovací výstupky pro půlbuňkové zarovnání a nastav okrajovou výplň pro každou stranu podle zásuvky.
+    - name: Prohlédni ve 3D
+      text: Náhled 3D v reálném čase se aktualizuje, jak měníš parametry. Otáčej a přibližuj, ať si základní desku prohlédneš ze všech stran.
+    - name: Exportuj a vytiskni
+      text: Stáhni svou základní desku jako STL, STEP nebo 3MF. Velké základní desky se automaticky rozdělí na části, které se vejdou na podložku tiskárny.
+softwareApplication:
+  name: Generátor základních desek Gridfinity
+  description: Parametrický generátor základních desek Gridfinity s náhledem 3D v reálném čase. Nastav rozměr mřížky, přidej otvory na magnety a spojovací výstupky, nastav okrajovou výplň a pak exportuj jako STL, STEP nebo 3MF. Bezplatný nástroj v prohlížeči.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Parametrické rozměry základní desky synchronizované s rozvržením
+    - Export souborů STL, STEP a 3MF
+    - Dutiny na otvory magnetů (6 mm × 2 mm)
+    - Půlbuňkové spojovací výstupky
+    - Konfigurace okrajové výplně pro každou stranu
+    - Režim dopasování k zásuvce s automatickým rozměrem
+    - Automatické dělení velkých desek přesahujících podložku tiskárny
+    - Náhled 3D v reálném čase
+    - Běží v prohlížeči, bez instalace
+faqs:
+  - q: V jakých formátech můžu základní desky exportovat?
+    a: Generátor exportuje STL (standardní formát 3D tisku), STEP (pro úpravy v CAD) a 3MF (moderní formát s podporou barvy a materiálu). Většina slicerů přijímá všechny tři.
+  - q: Může mít základní deska otvory na magnety?
+    a: Ano. Zapni otvory na magnety a přidej dutiny 6 mm × 2 mm na každý průsečík mřížky. Drží standardní neodymové magnety, díky nimž Biny pevně přiléhají k základní desce.
+  - q: Co se stane, když je základní deska příliš velká na moji podložku tiskárny?
+    a: Generátor automaticky pozná, kdy základní deska přesahuje rozměr podložky tiskárny, a rozdělí ji na tisknutelné díly. Dostaneš soubor ZIP se všemi díly připravenými k tisku a sestavení.
+  - q: Můžu dopasovat základní desku na přesné rozměry své zásuvky?
+    a: Ano. Synchronizuj základní desku se svým rozvržením, ať se rozměr zásuvky doplní automaticky. Okrajovou výplní pro každou stranu dolaď dopasování tak, aby deska seděla v zásuvce zarovno.
+  - q: Čím se to liší od stahování základních desek z Printables nebo Thangs?
+    a: Hotové základní desky mají pevné rozměry. Tento generátor tvoří desku, která pasuje na přesné rozměry tvé zásuvky, s funkcemi, jaké potřebuješ. Běží v prohlížeči, s vizuálním rozhraním a náhledem 3D v reálném čase.
+  - q: Budou tyto základní desky fungovat se standardními Biny Gridfinity?
+    a: Ano. Používají standardní mřížku 42 mm a profil patice. Kompatibilní s jakýmkoli Binem Gridfinity z libovolného zdroje.
+navCta:
+  label: Otevřít generátor
+  href: /baseplate?standalone=1
+---
+
+# Generátor základních desek Gridfinity
+
+Parametrický generátor základních desek, který běží v prohlížeči. Nastav rozměr mřížky, nakonfiguruj otvory na magnety a okrajovou výplň, zkontroluj náhled 3D a stáhni soubor STL, STEP nebo 3MF. Nic se neinstaluje. Součást [sady Generátor Gridfinity](/cs/gridfinity-generator), do níž patří i generátor Binů a plánovač rozvržení.
+
+[CTA: Začni generovat](/baseplate?standalone=1)
+
+## Jak to funguje
+
+1. **Nastav velikost.** Vyber šířku a hloubku v jednotkách mřížky nebo synchronizuj se svým rozvržením, ať se zásuvka doplní automaticky.
+2. **Nakonfiguruj funkce.** Zapni otvory na magnety pro magnetické uchycení, přidej spojovací výstupky pro půlbuňkové zarovnání a nastav okrajovou výplň pro každou stranu.
+3. **Zkontroluj náhled.** Pohled 3D se aktualizuje okamžitě, jak měníš nastavení. Otáčej a přibližuj, ať vidíš každou stranu.
+4. **Stáhni a vytiskni.** Vyexportuj jako STL pro slicer, STEP, pokud chceš upravovat v CAD, nebo 3MF pro podporu barvy a materiálu. Velké základní desky se dělí automaticky.
+
+> Veškeré zpracování probíhá lokálně. Tvoje návrhy zůstávají na tvém zařízení, dokud je nesdílíš.
+
+## Funkce
+
+**Rozměr mřížky.** Nastav základní desku na libovolnou šířku a hloubku ve standardních jednotkách mřížky Gridfinity (po 42 mm). Synchronizuj s rozvržením, ať se rozměry zásuvky doplní automaticky.
+
+**Otvory na magnety.** Přidej dutiny 6 mm × 2 mm na každý průsečík mřížky na standardní neodymové magnety. Biny pevně přiléhají k základní desce a neposouvají se.
+
+**Spojovací výstupky.** Půlbuňkové kolíky na průsečících mřížky pomáhají přesně zarovnat Biny — obzvlášť užitečné v režimu půl-Binu pro přesnost 0,5 jednotky.
+
+**Okrajová výplň.** Nastav výplň nezávisle pro každou stranu — levou, pravou, přední a zadní. Dolaď dopasování tak, aby základní deska seděla v zásuvce zarovno, bez mezer a bez příčení.
+
+**Automatické dělení.** Základní desky větší než podložka tiskárny se automaticky dělí na tisknutelné díly. Stáhni soubor ZIP se všemi díly připravenými k tisku a sestavení.
+
+## Formáty exportu
+
+| Formát   | Kdy jej použít                                                                    |
+| -------- | --------------------------------------------------------------------------------- |
+| **STL**  | Pošli rovnou do sliceru. Funguje s PrusaSlicer, Cura, OrcaSlicer i vším ostatním. |
+| **STEP** | Otevři ve Fusion 360, FreeCAD nebo SolidWorks a proveď další úpravy před tiskem.  |
+| **3MF**  | Obsahuje metadata barvy a materiálu. Vhodný pro vícemateriálové tiskárny.         |
+
+## Další kroky
+
+Potřebuješ vlastní Biny ke své základní desce? Použij [generátor Binů](/cs/gridfinity-bin-generator) a vytvoř Biny s přihrádkami, výřezy a držáky štítků. Rozvrhni celou zásuvku v [plánovači rozvržení](/) nebo zkontroluj [přehled velikostí](/cs/gridfinity-sizes), ať zjistíš své rozměry.
+
+[CTA: Začni generovat](/baseplate?standalone=1)

--- a/content/cs/gridfinity-bin-generator.md
+++ b/content/cs/gridfinity-bin-generator.md
@@ -1,0 +1,128 @@
+---
+title: Bezplatný generátor Binů Gridfinity — STL online
+description: Generátor Binů Gridfinity s vizuálním editorem a náhledem 3D v reálném čase. Nastav rozměry, přidej přihrádky a výřezy, exportuj STL, STEP nebo 3MF.
+keywords: gridfinity generátor, gridfinity bin generator, gridfinity STL generátor, vlastní biny gridfinity, gridfinity designer, online generátor gridfinity
+schema: HowTo
+breadcrumbs:
+  - name: Domů
+    url: https://gridfinitylayouttool.com/
+  - name: Generátor Binů
+    url: https://gridfinitylayouttool.com/cs/gridfinity-bin-generator
+howTo:
+  name: Jak vygenerovat vlastní Bin Gridfinity
+  description: Nastav rozměry, přidej funkce, prohlédni ve 3D a stáhni svůj vlastní Bin Gridfinity jako STL, STEP nebo 3MF.
+  totalTime: PT5M
+  tools:
+    - Webový prohlížeč
+  steps:
+    - name: Nastav rozměry Binu
+      text: Vyber šířku, hloubku a výšku v jednotkách mřížky Gridfinity. Každá jednotka má 42 mm šířky a 7 mm výšky.
+    - name: Vyber podstavu a funkce
+      text: Vyber styl uchycení podstavy (standardní, magnet, šroub nebo plochý). Podle potřeby přidej přihrádky, výřezy ve stěnách, držáky štítků nebo shrnovací rampy.
+    - name: Prohlédni ve 3D
+      text: Náhled 3D v reálném čase se aktualizuje, jak měníš parametry. Otáčej a přibližuj, ať si návrh prohlédneš ze všech stran.
+    - name: Exportuj a vytiskni
+      text: Stáhni svůj Bin jako soubor STL, STEP nebo 3MF. Otevři ho ve sliceru a vytiskni.
+softwareApplication:
+  name: Generátor Binů Gridfinity
+  description: Parametrický generátor Binů Gridfinity s náhledem 3D v reálném čase. Nastav rozměry, přidej přihrádky, výřezy a štítky a pak exportuj jako STL, STEP nebo 3MF. Bezplatný nástroj v prohlížeči.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  offers:
+    price: '0'
+    priceCurrency: USD
+  featureList:
+    - Parametrické rozměry Binu (šířka, hloubka, výška)
+    - Export souborů STL, STEP a 3MF
+    - 6 stylů uchycení podstavy včetně magnetu a šroubu
+    - Voštinové vzory stěn
+    - Konfigurovatelné přihrádky s vyjímatelnými příčkami
+    - Shrnovací rampy pro snadnější přístup
+    - Výřezy ve stěnách pro každou stranu zvlášť
+    - Držáky štítků s konzolovou nebo plnou podporou
+    - Vložky do dna (obdélník, kruh, šestiúhelník, štěrbina)
+    - Vlastní editor výřezů s nástrojem pero
+    - Náhled 3D v reálném čase
+    - Režim půl-Binu pro přesnost 0,5 jednotky
+    - Běží v prohlížeči, bez instalace
+faqs:
+  - q: Jaké formáty souborů můžu exportovat?
+    a: Generátor exportuje STL (standardní formát 3D tisku), STEP (pro úpravy v CAD) a 3MF (moderní formát s podporou barvy a materiálu). Většina slicerů přijímá všechny tři.
+  - q: Musím instalovat nějaký software?
+    a: Ne. Běží v prohlížeči. Otevři stránku a začni — není co stahovat ani instalovat.
+  - q: Čím se to liší od generátorů gridfinity v OpenSCAD?
+    a: Generátory v OpenSCAD vyžadují instalaci softwaru a úpravu kódu, abys změnil parametry. Tento generátor běží v prohlížeči s vizuálním rozhraním a náhledem 3D v reálném čase. Změny vidíš okamžitě, jak dolaďuješ nastavení.
+  - q: Můžu vytvářet Biny s vlastními výřezy?
+    a: Ano. Editor výřezů umožňuje přidávat k Binům výřezy obdélníkové, kruhové nebo libovolného tvaru. Použij nástroj pero ke kreslení složitých tvarů Bézierovými křivkami — na držáky nářadí, správu kabelů nebo jakýkoli vlastní tvar.
+  - q: Budou tyto Biny pasovat na moje základní desky?
+    a: Ano. Používají standardní mřížku 42 mm a profil patice. Kompatibilní s jakoukoli základní deskou Gridfinity z libovolného zdroje.
+  - q: Můžu si uložit projekt a vrátit se k němu později?
+    a: Ano. Návrhy se automaticky ukládají v prohlížeči. Pojmenuj návrh a přetrvá mezi sezeními.
+  - q: Jak velké mohou Biny být?
+    a: Až 8×8 jednotek mřížky (336 mm × 336 mm). Pro větší prostory použij plánovač rozvržení a poskládej několik Binů dohromady.
+  - q: Kde vezmu základní desky?
+    a: Použij generátor základních desek a vytvoř desku v rozměru své zásuvky, s volitelnými otvory na magnety a okrajovou výplní. Vyexportuj jako STL, STEP nebo 3MF.
+navCta:
+  label: Otevřít generátor
+  href: /designer
+---
+
+# Generátor Binů Gridfinity
+
+Parametrický generátor Binů, který běží v prohlížeči. Nastav rozměry, přidej přihrádky nebo výřezy, zkontroluj náhled 3D a stáhni soubor STL, STEP nebo 3MF. Nic se neinstaluje. Součást [sady Generátor Gridfinity](/cs/gridfinity-generator), do níž patří i generátor základních desek a plánovač rozvržení.
+
+[CTA: Začni tvořit Bin](/designer)
+
+## Jak to funguje
+
+1. **Nastav velikost.** Vyber šířku, hloubku a výšku v jednotkách mřížky. Potřebuješ něco mezi standardními velikostmi? Režim půl-Binu dává přesnost 0,5 jednotky.
+2. **Přidej, co potřebuješ.** Přihrádky, výřezy ve stěnách, shrnovací rampy, držáky štítků — zapínej je a dolaď posuvníky.
+3. **Zkontroluj náhled.** Pohled 3D se aktualizuje okamžitě, jak měníš nastavení. Otáčej a přibližuj, ať vidíš každou stranu.
+4. **Stáhni a vytiskni.** Vyexportuj jako STL pro slicer, STEP, pokud chceš upravovat v CAD, nebo 3MF pro podporu barvy a materiálu.
+
+> Veškeré zpracování probíhá lokálně. Tvoje návrhy zůstávají na tvém zařízení, dokud je nesdílíš.
+
+## Funkce
+
+**Přihrádky.** Rozděl Bin na mřížku sekcí, až 8×8. Příčky se generují automaticky. Vyjímatelné příčky můžeš vyexportovat jako samostatné soubory, pokud chceš měnit uspořádání bez přetiskování.
+
+**Shrnovací rampy a výřezy ve stěnách.** Shrnovací rampy usnadňují sáhnutí po drobných dílech na dně. Výřezy ve stěnách — zářezy ve tvaru U na libovolné straně — umožňují vysouvat věci bokem.
+
+**Držáky štítků.** Polička na zadní stěně přidržuje proužky štítků. Vyber konzolovou nebo plnou podporu a nastav šířku pro každý sloupec.
+
+Pro věci, které musí zůstat na místě, **vložky do dna** vyřezávají do dna tvarované dutiny — kruhy na baterie, šestiúhelníky na bity, obdélníky na součástky. Nastav hloubku a otočení podle toho, co ukládáš.
+
+**Editor výřezů** si poradí s netypickými tvary. Přepni se do režimu plného tělesa, vyhloub od shora a použij nástroj pero ke kreslení libovolných cest na klíče, kleště nebo cokoli s podivným profilem.
+
+## Možnosti uchycení podstavy
+
+Vyber, jak se Bin spojí se základní deskou:
+
+- **Standardní** — výchozí patice Gridfinity
+- **Magnet** — zapuštěné dutiny na magnety 6 mm × 2 mm
+- **Šroub** — otvory na závitové vložky
+- **Magnet a šroub** — obě metody pro maximální držení
+- **Zatížený** — těžší podstava bez magnetů
+- **Plochý** — bez patice, pro použití bez základní desky
+
+## Formáty exportu
+
+| Formát   | Kdy jej použít                                                                    |
+| -------- | --------------------------------------------------------------------------------- |
+| **STL**  | Pošli rovnou do sliceru. Funguje s PrusaSlicer, Cura, OrcaSlicer i vším ostatním. |
+| **STEP** | Otevři ve Fusion 360, FreeCAD nebo SolidWorks a proveď další úpravy před tiskem.  |
+| **3MF**  | Obsahuje metadata barvy a materiálu. Vhodný pro vícemateriálové tiskárny.         |
+
+## Proč tohle místo OpenSCAD?
+
+Generátory gridfinity v OpenSCAD fungují, ale musíš nainstalovat software a upravovat kód, abys změnil parametr. Tohle běží v prohlížeči, s vizuálním rozhraním. Výsledek vidíš hned, místo čekání na vykreslení.
+
+Exportuje také STEP a 3MF — nejen STL — a funguje na telefonu, když si potřebuješ něco zkontrolovat na cestách.
+
+## Další kroky
+
+Nový v Gridfinity? Přečti si [Co je Gridfinity?](/cs/what-is-gridfinity) pro základy. Už víš, co potřebuješ? Zkontroluj [přehled velikostí](/cs/gridfinity-sizes), ať zjistíš své rozměry, nebo přejdi na [průvodce plánováním](/cs/guide) a rozvrhni celou zásuvku.
+
+[CTA: Začni tvořit Bin](/designer)

--- a/content/cs/gridfinity-generator.md
+++ b/content/cs/gridfinity-generator.md
@@ -1,0 +1,289 @@
+---
+title: Generátor Gridfinity — Biny a základní desky
+description: Bezplatný generátor Gridfinity. Vytvářej vlastní Biny a základní desky v prohlížeči, prohlížej ve 3D a exportuj STL, STEP nebo 3MF. Bez instalace a účtu.
+keywords: gridfinity generátor, gridfinity bin generator, generátor základních desek gridfinity, gridfinity STL generátor, online generátor gridfinity, bezplatný generátor gridfinity, vlastní gridfinity, gridfinity 3MF, gridfinity STEP
+schema: HowTo
+breadcrumbs:
+  - name: Domů
+    url: https://gridfinitylayouttool.com/
+  - name: Generátor Gridfinity
+    url: https://gridfinitylayouttool.com/cs/gridfinity-generator
+howTo:
+  name: Jak používat generátor Gridfinity
+  description: Vyber generátor (Bin nebo základní deska), nastav rozměry, nakonfiguruj funkce, prohlédni si výsledek ve 3D a stáhni soubor STL, STEP nebo 3MF připravený pro slicer.
+  totalTime: PT3M
+  tools:
+    - Webový prohlížeč
+    - 3D tiskárna (na tisk výsledku)
+  supplies:
+    - Filament PLA, PETG nebo ABS
+  steps:
+    - name: Otevři generátor
+      text: Vyber generátor Binů pro úložné Biny nebo generátor základních desek pro mřížku, do které Biny zapadají. Oba běží v prohlížeči.
+    - name: Nastav rozměry
+      text: Biny a základní desky používají standardní jednotku mřížky Gridfinity 42 mm. Zadej šířku a hloubku v jednotkách mřížky. U Binů zadej výšku v jednotkách po 7 mm. Zapni režim půl-Binu, pokud potřebuješ přesnost 0,5 jednotky.
+    - name: Nakonfiguruj funkce
+      text: U Binů vyber styl uchycení podstavy a zapínej přihrádky, shrnovací rampy, držáky štítků, výřezy ve stěnách nebo vložky do dna. U základních desek zapínej otvory na magnety a nastav okrajovou výplň pro každou stranu.
+    - name: Prohlédni ve 3D
+      text: Náhled 3D se aktualizuje v reálném čase, jak měníš parametry. Otáčej, přibližuj a zkoumej ze všech stran ještě před exportem.
+    - name: Exportuj soubor
+      text: Stáhni jako STL pro slicer, STEP pro další úpravy v CAD nebo 3MF s metadaty barvy a materiálu. Velké základní desky se automaticky rozdělí podle podložky tvé tiskárny.
+    - name: Nařež a vytiskni
+      text: Otevři soubor v PrusaSlicer, OrcaSlicer, Bambu Studio, Cura nebo jakémkoli jiném sliceru. Většina Binů Gridfinity se dobře tiskne s vrstvami 0,2 mm a výplní 15 až 20 procent.
+softwareApplication:
+  name: Generátor Gridfinity
+  alternateName:
+    - Generátor Binů Gridfinity
+    - Generátor základních desek Gridfinity
+    - Generátor STL Gridfinity
+  description: Bezplatný online generátor Gridfinity na Biny a základní desky. Nastav rozměry, nakonfiguruj funkce, prohlédni ve 3D a exportuj STL, STEP nebo 3MF. Běží v prohlížeči, offline jako PWA.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  permissions: none
+  isAccessibleForFree: true
+  offers:
+    price: '0'
+    priceCurrency: USD
+    availability: https://schema.org/InStock
+  featureList:
+    - Parametrický generátor Binů s náhledem 3D v reálném čase
+    - Parametrický generátor základních desek s mřížkou otvorů na magnety
+    - Export STL, STEP a 3MF
+    - Šest stylů uchycení podstavy (standardní, magnet, šroub, magnet+šroub, zatížený, plochý)
+    - Konfigurovatelné přihrádky až 8 na 8
+    - Výřezy ve stěnách pro každou stranu (tvar U, shrnovací, trychtýř)
+    - Držáky štítků s konzolovou nebo plnou podporou
+    - Voštinové vzory stěn
+    - Vložky do dna (obdélník, kruh, šestiúhelník, štěrbina)
+    - Vlastní tvar půdorysu pomocí masky buněk
+    - Režim půl-Binu pro přesnost 0,5 jednotky
+    - Automatické dělení základní desky podle libovolné podložky tiskárny
+    - Konfigurovatelná okrajová výplň základní desky pro každou stranu
+    - Otvory na magnety (6 mm × 2 mm) na každém průsečíku mřížky
+    - Odhad spotřeby filamentu
+    - Funguje offline jako Progressive Web App
+    - Bez účtu, bez instalace, bez reklam
+faqs:
+  - q: Je generátor Gridfinity zdarma?
+    a: Ano. Generátor Gridfinity je zcela zdarma, nemá reklamy, nevyžaduje účet a po prvním načtení funguje offline. Není zde žádná placená úroveň ani limit používání.
+  - q: Co generátor Gridfinity vytváří?
+    a: Vytváří dvě věci — úložné Biny a základní desky, do kterých zapadají. Obojí vzniká jako soubory připravené k tisku ve formátu STL, STEP nebo 3MF. Můžeš také naplánovat celé rozvržení zásuvky, rozmístit na něm Biny a vyexportovat seznam pro tisk.
+  - q: Musím kvůli generátoru Gridfinity instalovat software?
+    a: Ne. Běží celý v prohlížeči. Není co stahovat ani instalovat. Můžeš ho také nainstalovat jako Progressive Web App pro použití offline.
+  - q: Funguje generátor Gridfinity na mobilu?
+    a: Ano. Generátor funguje na iPhonu, iPadu i na telefonech a tabletech s Androidem. Bin nakonfiguruješ na telefonu, uložíš do zařízení a STL pošleš e-mailem nebo přes AirDrop do sliceru v počítači.
+  - q: Jaké formáty souborů generátor Gridfinity exportuje?
+    a: STL pro přímé slicování, STEP pro úpravy v CAD aplikacích jako Fusion 360 nebo FreeCAD a 3MF pro slicery, které využijí bohatší metadata, například barvu nebo přiřazení materiálu. Většina moderních slicerů přijímá všechny tři formáty.
+  - q: Budou Biny z generátoru pasovat na moje stávající základní desky Gridfinity?
+    a: Ano. Generátor dodržuje standardní mřížku Gridfinity 42 mm a standardní profil patice, takže Biny pasují na jakoukoli oficiální nebo komunitní základní desku Gridfinity. Platí to i naopak — základní desky z generátoru přijmou libovolný standardní Bin Gridfinity.
+  - q: Umí generátor Gridfinity vytvořit základní desky s otvory na magnety?
+    a: Ano. Generátor základních desek ve výchozím nastavení umisťuje otvory na magnety 6 mm × 2 mm na každý průsečík mřížky. Můžeš je vypnout, pokud magnety nechceš, nebo je nechat a magnety při tisku prostě vynechat.
+  - q: Má generátor Gridfinity limity velikosti?
+    a: Biny mohou mít až 8 na 8 jednotek mřížky (336 mm na 336 mm) a 20 jednotek výšky (140 mm). Základní desky mohou být větší a v případě potřeby se automaticky dělí na části, které se vejdou na podložku tvé tiskárny.
+  - q: Podporuje generátor Gridfinity poloviční velikosti Binů?
+    a: Ano. Zapni režim půl-Binu pro přesnost 0,5 jednotky — umožní vytvořit Biny jako 1,5 na 2,5, aby vyplnily nepohodlné mezery v zásuvce. Podpora půl-Binu sahá až do plánovače rozvržení, takže poloviční Biny se čistě skládají vedle celých.
+  - q: Můžu si přizpůsobit dno a stěny Binu?
+    a: Ano. Můžeš přidat přihrádky s vyjímatelnými příčkami, shrnovací rampy pro snadnější přístup, držáky štítků na zadní stěně, výřezy ve tvaru U nebo shrnovací na libovolné stěně, voštinové vzory stěn a tvarované vložky do dna (obdélník, kruh, šestiúhelník, štěrbina, zaoblený obdélník) pro uspořádání dílů.
+  - q: Jak si generátor Gridfinity stojí vedle skriptů OpenSCAD?
+    a: Skripty OpenSCAD jsou mocné, ale vyžadují instalaci softwaru, úpravu parametrů v kódu a čekání na vykreslení. Generátor Gridfinity běží v prohlížeči, dává vizuální rozhraní s posuvníky a přepínači a nabízí náhled ve 3D v reálném čase. Obojí produkuje soubory odpovídající standardu.
+  - q: Jak si generátor Gridfinity stojí vedle Fusion 360?
+    a: Fusion 360 je plnohodnotný parametrický CAD balík se strmou křivkou učení. Generátor Gridfinity je stavěný přímo pro Gridfinity, takže běžné úkoly (nastav rozměry, přidej magnetickou podstavu, vyexportuj STL) zaberou sekundy, ne minuty. Pokud chceš zkombinovat Bin Gridfinity s vlastní geometrií, vyexportuj STEP a pokračuj ve Fusion.
+  - q: Použít generátor Gridfinity, nebo stáhnout Biny z MakerWorld a Printables?
+    a: Použij generátor, když potřebuješ přesnou velikost, konkrétní funkci (držák štítku, otvory na magnety, shrnovací rampu) nebo vlastní tvar půdorysu. Použij MakerWorld nebo Printables, když už někdo navrhl specializovaný držák přesně na věc, kterou chceš uložit, jako multitool nebo konkrétní sadu nástrčných hlavic.
+  - q: Můžu si své návrhy z generátoru Gridfinity uložit?
+    a: Ano. Návrhy se automaticky ukládají v prohlížeči. Můžeš je pojmenovat, vrátit se k nim později a vyexportovat odkazy ke sdílení, aby ostatní otevřeli stejnou konfiguraci. Účet není potřeba.
+  - q: Odhaduje generátor Gridfinity spotřebu filamentu?
+    a: Ano. Okno tisku ukazuje odhadovanou délku a hmotnost filamentu na jeden Bin. Užitečné pro plánování rozpočtu filamentu při celé zásuvce Binů.
+  - q: Jsou moje data soukromá, když používám generátor Gridfinity?
+    a: Veškeré generování Binů a základních desek probíhá lokálně v tvém prohlížeči. Návrhy zůstávají v místním úložišti prohlížeče a nikdy se neodesílají, dokud sám výslovně nevytvoříš odkaz ke sdílení. Anonymní analytika používání nám pomáhá nástroj vylepšovat, bez připojených osobních údajů.
+  - q: Podporuje generátor Gridfinity vícebarevný nebo vícemateriálový tisk?
+    a: Ano. Export 3MF nese metadata barvy pro jednotlivé funkce, takže slicery jako Bambu Studio a OrcaSlicer umí obarvit různé části Binu různými filamenty. Užitečné pro barevně kódované držáky štítků nebo dvoubarevné Biny na vícemateriálových tiskárnách.
+  - q: Které slicery fungují s tím, co generátor Gridfinity vytváří?
+    a: Všechny hlavní slicery — PrusaSlicer, OrcaSlicer, Bambu Studio, Cura, SuperSlicer, IdeaMaker a Simplify3D. Výstup STL je standardní a nezávislý na sliceru. Výstup 3MF funguje nejlépe se slicery, které čtou vícemateriálová metadata.
+  - q: Jaký je nejlepší generátor Gridfinity?
+    a: Záleží na tom, co tvoříš. Na jeden jednorázový Bin stačí libovolný parametrický generátor s náhledem 3D v reálném čase a skripty postavené na OpenSCAD nabízejí největší konfigurovatelnost, pokud se v úpravě kódu cítíš dobře. Na uspořádání celé zásuvky je tento generátor nejsilnější volbou — je vestavěný do plánovače rozvržení zásuvky, takže Biny, základní desky a plán zásuvky sdílejí jednu sadu rozměrů a exportují se společně jako seznam pro tisk, což samostatné generátory Binů nenabízejí.
+navCta:
+  label: Otevřít generátor
+  href: /designer?utm_source=gridfinity-generator&utm_medium=nav&utm_campaign=bin
+---
+
+# Generátor Gridfinity
+
+Bezplatný online generátor Gridfinity na Biny a základní desky. Nastav rozměry, vyber potřebné funkce a stáhni soubor STL, STEP nebo 3MF. Běží v prohlížeči — nic se neinstaluje — a po prvním načtení funguje offline. Dva generátory, jeden nástroj, bez účtu. A na rozdíl od samostatných tvůrců Binů jsou oba vestavěné do [plánovače rozvržení zásuvky](/) — změř zásuvku jednou, naplánuj celé rozvržení a vygeneruj každý Bin tak, aby pasoval.
+
+[CTA: Otevři generátor Binů](/designer?utm_source=gridfinity-generator&utm_medium=hero&utm_campaign=bin) &nbsp; [CTA: Otevři generátor základních desek](/baseplate?utm_source=gridfinity-generator&utm_medium=hero&utm_campaign=baseplate)
+
+## Co tento generátor tvoří
+
+Gridfinity je modulární úložný systém navržený Zackem Freedmanem. Definuje mřížku 42 mm, do níž Biny zapadají do základních desek. Abys mohl Gridfinity opravdu používat, potřebuješ obě části — Biny v rozměru tvých věcí a základní desky v rozměru tvé zásuvky. Tento generátor zvládá obojí.
+
+**Biny** jsou nádoby otevřené shora, které pojmou tvoje věci. Generátor Binů umožňuje zvolit velikost, vybrat styl uchycení podstavy (obyčejná, magnet, šroub, zatížená nebo plochá) a pak nabalovat funkce — přihrádky pro rozdělení vnitřku, shrnovací rampy pro snadný přístup, držáky štítků na zadní stěnu, výřezy ve stěnách pro vysouvání věcí bokem, vložky do dna tvarované na konkrétní předměty (kruhy na baterie, šestiúhelníky na bity) a dekorativní vzory stěn.
+
+**Základní desky** jsou mřížka, do které Biny zapadají. Generátor základních desek umožňuje nastavit rozměr mřížky, nakonfigurovat otvory na magnety 6 mm × 2 mm na každém průsečíku, přidat okrajovou výplň pro každou stranu, aby deska přesně padla do zásuvky, a automaticky rozdělit velké desky na části, které se vejdou na podložku tiskárny.
+
+Můžeš také použít [plánovač rozvržení](/) generátoru, rozložit Biny na základní desku, přesouvat je a vyexportovat seznam pro tisk všech potřebných Binů. To je třetí nástroj v sadě, ale parametrickými tahouny jsou generátor Binů a generátor základních desek.
+
+## Jak to funguje
+
+1. **Vyber generátor.** Otevři generátor Binů, pokud tvoříš úložné Biny, nebo generátor základních desek, pokud tvoříš mřížku, do které zapadají.
+2. **Nastav rozměry.** Šířka a hloubka v jednotkách mřížky (1 jednotka = 42 mm). Výška v jednotkách po 7 mm u Binů. Režim půl-Binu umožňuje jít po krocích 0,5 jednotky.
+3. **Nakonfiguruj funkce.** Přepínej a dolaď potřebné prvky. Výchozí nastavení jsou rozumná — základní Bin odešleš dvěma kliknutími.
+4. **Prohlédni ve 3D.** Vykreslení se aktualizuje živě, jak měníš parametry. Táhni pro otočení, posouvej pro přiblížení, klikni znovu pro zrušení výběru.
+5. **Exportuj.** Stáhni jako STL, STEP nebo 3MF. Velké základní desky se automaticky rozdělí na několik souborů.
+6. **Nařež a vytiskni.** Otevři soubor ve vybraném sliceru. Standardní Gridfinity se dobře tiskne s vrstvami 0,2 mm a výplní 15–20 %.
+
+> Všechno běží lokálně. Nic se neodesílá, dokud sám výslovně nevytvoříš odkaz ke sdílení.
+
+## Generátor Binů — co můžeš nastavit
+
+### Rozměry
+
+Šířka, hloubka a výška. Šířka a hloubka jsou od 0,5 do 8 jednotek mřížky (21 mm až 336 mm). Výška od 2 do 20 jednotek výšky (14 mm až 140 mm). Jedna jednotka výšky je 7 mm — standardní jednotka Gridfinity z původní specifikace Zacka Freedmana.
+
+### Styly uchycení podstavy
+
+Šest možností, jak Bin sedí na základní desce:
+
+- **Standardní** — výchozí patice Gridfinity. Pasuje na všechny základní desky.
+- **Magnet** — dutiny na magnety 6 mm × 2 mm. Vlep magnety, aby se Biny neposouvaly.
+- **Šroub** — závitové otvory na vložky M3. Dobré pro těžké Biny nebo do vozidel.
+- **Magnet a šroub** — obojí naráz. Maximální držení pro věci, které se nemají hýbat.
+- **Zatížený** — tlustší podstava jako balast, bez kování.
+- **Plochý** — bez patice vůbec. Když chceš tvar Binu, ale bez uchycení Gridfinity.
+
+### Přihrádky
+
+Rozděl vnitřek na mřížku až 8 na 8 přihrádek. Generátor sám staví příčky a přizpůsobuje jejich tloušťku zvolené velikosti. Příčky lze také vyexportovat jako samostatné vyjímatelné díly — užitečné, když chceš změnit uspořádání Binu bez jeho přetiskování.
+
+### Funkce stěn
+
+Tři funkce stěn řeší různé potřeby:
+
+- **Výřezy ve stěnách** — zářezy ve tvaru U, shrnovací nebo trychtýřové na libovolné ze čtyř stran plus na vnitřních příčkách. Umožňují vysouvat věci bokem nebo protahovat kabely.
+- **Shrnovací rampy** — skloněné dno vpředu, díky němuž se drobné díly shromáždí u přední hrany a snadno se zvednou.
+- **Vzory stěn** — voština nebo jiné dekorativní vzory pro větrané Biny nebo prostě pro vzhled.
+
+### Držáky štítků
+
+Malá polička na zadní stěně na proužky štítků. Vyber konzolovou podporu (lehčí, tiskne se rychleji) nebo plnou (tužší). Nastav hloubku a šířku držáku a zarovnání pro každý sloupec. Držáky štítků jsou skvělé pro nářaďové zásuvky, kde chceš označit obsah každého Binu, aniž bys do něj nahlížel.
+
+### Vložky do dna
+
+Dutiny vyříznuté do dna Binu v pěti tvarech — obdélník, kruh, šestiúhelník, zaoblený obdélník, štěrbina — s nastavitelnou hloubkou a otočením. Tímto vytvoříš držák na baterie, držák na bity, tácek na o-kroužky nebo třídič na šrouby. Umísti až 20 vložek na jeden Bin a každou nastav nezávisle.
+
+### Vlastní tvary
+
+Většina Binů jsou obdélníky, ale generátor podporuje i vlastní půdorysy pomocí masky buněk. Přepni se do režimu masky a vybarvi buňky na mřížce půl-Binu — Bin přijme ten tvar. Užitečné pro dopasování nepohodlných rohů zásuvky nebo stavbu Binů ve tvaru písmene L či T. Maska zůstává zachovaná v odkazech ke sdílení.
+
+### Editor výřezů
+
+Pro tvary, které nesedí na žádnou předvolbu, umožňuje editor výřezů kreslit libovolné cesty nástrojem pero. Bézierova táhla dovolí tvořit hladké křivky; režim rohů zamkne úhly pro rovné řezy. Vyřízni obrys klíče, multitoolu nebo čehokoli jiného — generátor dutinu vytvoří sám.
+
+## Generátor základních desek — co můžeš nastavit
+
+### Rozměr mřížky
+
+Šířka a hloubka v jednotkách mřížky. Generátor se plynule škáluje od 1 na 1 až po desky velikosti zásuvky s desítkami jednotek na stranu.
+
+### Otvory na magnety
+
+Standardní Gridfinity používá kulaté magnety 6 mm × 2 mm na každém průsečíku mřížky. Generátor základních desek je umisťuje ve výchozím nastavení; můžeš je zcela vypnout, pokud magnety nechceš. Magnety brání posouvání Binů při otevírání a zavírání zásuvky, což má význam, když zásuvku nosíš nebo vozíš vozík s nářadím.
+
+### Okrajová výplň
+
+Zásuvky mají zřídka rozměr, který je čistým násobkem 42 mm. Okrajová výplň přidává materiál navíc na každou stranu základní desky, aby vyplnila zásuvku od kraje ke kraji bez plýtvání místem. Výplň může být na každé straně jiná, což umožňuje mřížku vycentrovat nebo přisunout k jedné hraně.
+
+### Dělení podle podložky tiskárny
+
+Nastav rozměr podložky své tiskárny a generátor rozdělí velké základní desky na pasující díly. Každý díl vyjde zarovnaný, takže do sebe znovu dokonale zapadnou jako dlaždice. Volitelné spoje na rybinu nebo na pero a drážku udrží díly zarovnané během používání.
+
+## Formáty výstupu
+
+Tři formáty exportu, zvolené pro různé navazující nástroje.
+
+| Formát   | Kdy jej použít                                                                                                                                                                                                             |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **STL**  | Standardní formát 3D tisku. Otevři v jakémkoli sliceru. Výchozí volba, pokud nemáš konkrétní důvod zvolit něco jiného.                                                                                                     |
+| **STEP** | Parametrický formát CAD. Otevři ve Fusion 360, FreeCAD, SolidWorks, Onshape nebo jakémkoli jiném CAD balíku. Užitečný, když chceš zkombinovat Bin Gridfinity s vlastní geometrií nebo pro čisté editovatelné plochy.       |
+| **3MF**  | Moderní formát s metadaty barvy a materiálu. Nejlepší ve dvojici s vícemateriálovými tiskárnami (Bambu A1 / X1, Prusa XL s měničem nástrojů, MMU3). Slicery s podporou 3MF zachovají nápovědy barvy pro jednotlivé funkce. |
+
+Všechny tři formáty vznikají ze stejné zdrojové geometrie, takže rozměry a tolerance jsou totožné, ať zvolíš cokoli. Vybírej podle toho, co preferuje tvůj slicer nebo navazující nástroj.
+
+## Jak si stojí ve srovnání
+
+### vs. jiné online generátory
+
+Existuje několik generátorů Gridfinity běžících v prohlížeči a ty dobré sdílejí stejné jádro: parametrické Biny, živý náhled, stažení STL, žádná instalace. Když je porovnáváš, skutečně je odlišují tyto detaily:
+
+- **Formáty exportu.** Každý generátor exportuje STL. Méně jich exportuje STEP (pro pokračování v CAD) a 3MF s metadaty barvy (pro vícemateriálové tiskárny). Tento exportuje všechny tři ze stejné geometrie.
+- **Základní desky, nejen Biny.** Zásuvky mají zřídka rozměr, který je čistým násobkem 42 mm. Hledej okrajovou výplň pro každou stranu a automatické dělení podle podložky tiskárny se zarovnávacími spoji — funkce, které mění základní desku z ukázky v něco, co skutečně vyplní tvoji zásuvku.
+- **Poloviční velikosti.** Kroky po 0,5 jednotky jsou důležitější, než zní; právě jimi vyplníš nepohodlných posledních 21 mm zásuvky.
+- **Požadavky na offline a účet.** Některé generátory renderují na straně serveru, takže potřebují připojení a mohou frontovat. Tento generuje lokálně v prohlížeči a funguje offline jako PWA, bez účtu a bez odesílání dat.
+
+Strukturální rozdíl je v tom, co generátor obklopuje. Samostatné generátory tvoří jeden Bin naráz a plán zásuvky žije v tvé hlavě nebo v tabulce. Tady jsou generátor Binů a generátor základních desek vestavěné do plánovače rozvržení zásuvky: změříš zásuvku jednou, rozvrhneš každý Bin vizuálně a každý generovaný Bin už má správný půdorys. Až je rozvržení hotové, vyexportuješ seznam pro tisk pokrývající každý soubor v zásuvce — bez přepisování rozměrů mezi nástroji.
+
+### vs. skripty OpenSCAD (kennethjiang, vector76 a další)
+
+Skripty OpenSCAD jsou tahounem komunity Gridfinity od začátku projektu. Jsou mocné a zdarma. Jsou také kód — abys změnil výšku Binu, upravíš parametr v textovém souboru a znovu spustíš renderer. Vykreslení zabere sekundy u jednoduchých Binů, minuty u složitých.
+
+Tento generátor běží v prohlížeči s posuvníky a přepínači. Náhled 3D je v reálném čase, ne fronta renderů. Doladíš hloubku magnetu a efekt uvidíš okamžitě. Výstupy STEP a 3MF jsou plnohodnotné, ne doplněné dodatečně. Pokud se cítíš dobře s kódem OpenSCAD a GUI customizeru ti stačí, jsou ty skripty skvělé. Pokud dáváš přednost vizuálnímu rozhraní nebo jsi na telefonu, tady to jde rychleji.
+
+### vs. Fusion 360 (a jiné parametrické CAD)
+
+Fusion 360 je plnohodnotný CAD — parametry, skici, historie, sestavy, simulace, všechno. Biny Gridfinity ve Fusion bez problému postavíš. Cenou je křivka učení a čas na každý úkol — nastavovat skici a vazby pro Bin, který vytiskneš jednou, je zbytečně mnoho.
+
+Tento generátor je jednoúčelový. Ví, co je Bin Gridfinity a jaké funkce lidé přidávají. Běžné úkoly zaberou sekundy. Kompromis — pokud tvůj návrh potřebuje vlastní geometrii nad rámec toho, co generátor nabízí, narazíš na zeď. Řešením je vyexportovat STEP a pokračovat v úpravách ve Fusion nebo FreeCAD — parametrické lešení dostaneš zdarma a pak převezmeš otěže u toho, co generátor nedokáže vyjádřit.
+
+### vs. stahování z MakerWorld a Printables
+
+MakerWorld a Printables hostují tisíce Binů Gridfinity navržených na konkrétní předměty — držáky nástrčných hlavic konkrétních značek, vložky na multitooly, organizéry na šroubováky. Pokud už někdo navrhl přesně ten držák, který potřebuješ, stažení je rychlejší než návrh od nuly.
+
+Generátor vítězí u obecných Binů (potřebuješ 2×3 se shrnovací rampou), přesných velikostí (tvoje zásuvka má 296 mm, takže potřebuješ 3,5×2,5 s okrajovou výplní) a kombinací, které nikdo jiný nenahrál (chceš 1×4 s magnety, dvěma přihrádkami, držákem štítku a kulatou vložkou do dna na baterii). Oba přístupy se doplňují — typická zásuvka míchá generované obecné Biny s jedním či dvěma specializovanými držáky navrženými komunitou.
+
+## Časté případy použití
+
+### Dílenské a nářaďové zásuvky
+
+Nejčastější použití generátoru Gridfinity je uspořádání nářaďových zásuvek v dílně nebo garáži. Klíče přijdou do dlouhých úzkých Binů se shrnovacími rampami; nástrčné hlavice do Binů s přihrádkami a kulatými vložkami do dna v rozměru průměru hlavice; drobné díly (šrouby, podložky, o-kroužky) do Binů 1×1 nebo 1×2 s magnetickými podstavami, aby jimi zavírající se zásuvka neházela. Držáky štítků podél zadní strany každého Binu dělají inventuru nářadí čitelnou na první pohled, což má význam, když je zásuvka ve výšce kolen.
+
+### Elektronický pracovní stůl
+
+Na elektronickém stole zvládá generátor to, co se nevejde jinam — cívky se součástkami SMD, nepájivá pole, svazky propojovacích vodičů a nepořádnou spleť USB kabelů. Voštinové vzory jsou tu populární, protože umožňují vidět obsah Binu, aniž bys ho zvedal. Editor výřezů nakreslí dokonalé kolébky na páječky nebo horkovzdušné pistole.
+
+### Kuchyňské zásuvky
+
+Gridfinity v kuchyňských zásuvkách se v posledním roce stalo trendem. Výřezy ve stěnách pro každou stranu se hodí do zásuvek na příbory (výřez ve tvaru U nechá dlouhou dřevěnou vařečku vyčnívat jedním koncem) a režim půl-Binu pokryje nepohodlné šířky zásuvek. PETG je doporučený materiál pro kuchyňské použití kvůli vyšší odolnosti proti teplu.
+
+### Hobby a rukodělné potřeby
+
+Tvůrci rukodělných věcí používají vložky do dna na všechno — od kalíšků s barvami na modely přes tácky na korálky po cívky s vyšívací přízí. Vlastní editor výřezů je tu obzvlášť cenný, protože hobby předměty mají zřídka standardní rozměry — nástroj pero umožní nakreslit přesný obrys tácku na kostky, cívky do šicího stroje nebo řady štětců.
+
+### Potřeby pro 3D tisk (rekurzivně)
+
+Spousta lidí tiskne Biny Gridfinity, aby uspořádali potřeby, které používají k tisku Binů Gridfinity — Biny na trysky, držáky imbusů, vzorky filamentu, spojovací materiál M3. Styl podstavy magnet-a-šroub je pro zásuvku ve stole zbytečně mnoho, ale přesně to pravé pro skříň s nářadím, kterou vozíš na kolečkách.
+
+## Tipy pro tisk
+
+Většina Binů Gridfinity z generátoru se tiskne s výchozím nastavením sliceru, ale pár detailů dá lepší výsledky.
+
+**Výška vrstvy.** 0,2 mm je standard. Sjeď na 0,16 mm nebo 0,12 mm u výrazných držáků štítků nebo Binů tištěných tak, že je vidět detail horní vrstvy. Hrubší vrstvy 0,28 mm se tisknou rychleji a jsou v pořádku pro užitkové Biny, kde na povrchu nezáleží.
+
+**Výplň.** 15–20 % výplně gyroid nebo mřížkové bohatě stačí na stěny Binu. Patice podstavy a stohovací lem těží ze 100% výplně ve spodních 1,5 mm, což většina slicerů zvládne automaticky, když nastavíš 4 nebo více spodních vrstev.
+
+**Podpory.** Většina Binů se tiskne bez podpor. Výřezy ve stěnách a držáky štítků mohou těžit ze stromových podpor, pokud geometrie přesahuje pod úhlem větším než 60 stupňů. Vložky do dna (dutiny vyříznuté dolů do dna) nikdy nepotřebují podpory, protože se vyřezávají, ne stavějí.
+
+**Materiál.** PLA je výchozí volba a hodí se na téměř každé použití uvnitř. PETG je správná volba do kuchyňských zásuvek, garáží nebo míst, kde hrají roli teplota nebo chemikálie. ABS nebo ASA přidají trvanlivost do nářaďových zásuvek ve vozidlech nebo nevytápěných dílnách. PLA-CF a PETG-CF se tisknou s nastavením podobným jejich variantám bez uhlíkových vláken a dávají tužší Biny.
+
+**Orientace tisku.** Biny se tisknou dnem dolů — výchozí orientace, když slicer načte soubor. Základní desky se také tisknou dnem dolů. Neotáčej před řezáním — soubor je už orientovaný pro ideální přilnavost vrstev.
+
+**Tolerance.** Generátor zabudovává standardní toleranci Gridfinity (~0,25 mm vůle v uložení patice). Pokud je tvá tiskárna rozměrově přesná, Biny zapadají do základních desek s uspokojivým cvaknutím. Pokud sedí volně, tiskárna přeextrudovává; pokud nepasují, tiskárna podextrudovává. Řešením je kalibrace průtoku — ne úpravy v generátoru.
+
+## Otevři generátor
+
+Dva výchozí body. Vyber ten, který potřebuješ nejdřív — mezi nimi se můžeš kdykoli přepínat.
+
+[CTA: Otevři generátor Binů](/designer?utm_source=gridfinity-generator&utm_medium=footer&utm_campaign=bin) &nbsp; [CTA: Otevři generátor základních desek](/baseplate?utm_source=gridfinity-generator&utm_medium=footer&utm_campaign=baseplate)
+
+Nový v Gridfinity? Začni s [Co je Gridfinity?](/cs/what-is-gridfinity) pro základy, nebo přejdi na [průvodce plánováním zásuvky](/cs/guide), pokud už víš, co chceš, a potřebuješ to jen rozvrhnout. [Přehled velikostí](/cs/gridfinity-sizes) pokrývá jednotky mřížky a standardní rozměry.

--- a/content/cs/gridfinity-sizes.md
+++ b/content/cs/gridfinity-sizes.md
@@ -1,0 +1,128 @@
+---
+title: Rozměry Gridfinity — mřížka 42 mm a výšky 7 mm
+description: Jak velká je jednotka Gridfinity? Mřížka 42 mm, výšky 7 mm. Rychlý přehled rozměrů Binů, převodu zásuvky a toho, co kam pasuje.
+keywords: rozměry gridfinity, velikosti gridfinity, velikosti binů gridfinity, výškové jednotky gridfinity, gridfinity 42mm, velikost mřížky gridfinity, standardní velikost gridfinity, proč má gridfinity 42mm
+schema: Article
+breadcrumbs:
+  - name: Domů
+    url: https://gridfinitylayouttool.com/
+  - name: Přehled velikostí
+    url: https://gridfinitylayouttool.com/cs/gridfinity-sizes
+faqs:
+  - q: Jaký rozměr má jednotka mřížky Gridfinity?
+    a: Jedna jednotka mřížky Gridfinity je 42 mm × 42 mm. Bin 2×3 má 84 mm šířky a 126 mm hloubky. Všechny Biny a základní desky Gridfinity používají tento standard.
+  - q: Jak vysoká je výšková jednotka Gridfinity?
+    a: Jedna výšková jednotka (1U) je 7 mm. Bin 3U má uvnitř asi 21 mm výšky. Běžné výšky se pohybují od 2U (14 mm) do 10U (70 mm).
+  - q: Jak spočítám, kolik jednotek Gridfinity se vejde do mé zásuvky?
+    a: Změř vnitřní šířku a hloubku zásuvky v milimetrech. Každou vyděl 42 a zaokrouhli dolů. Například zásuvka 380 mm × 260 mm pojme 9 × 6 jednotek Gridfinity.
+  - q: Co je režim půl-Binu?
+    a: Režim půl-Binu umožňuje kroky po 0,5 jednotky (21 mm) pro Biny, které se musí vejít do prostorů menších než celá jednotka mřížky. Bin 1,5×2 by měl 63 mm × 84 mm.
+  - q: Proč má Gridfinity 42 mm?
+    a: 42 mm je standard mřížky, který Zack Freedman zvolil, když v roce 2022 vytvořil Gridfinity. Je dost malý, aby Bin 1×1 pojal jednotlivé šrouby nebo karty SD bez plýtvání místem, a zároveň dost velký, aby se Biny tiskly rychle a zůstaly pevné. Právě toto pevné číslo dělá každý Bin a každou základní desku zaměnitelnou a nechává místo na tloušťku stěny, toleranci a zapadající profil podstavy.
+  - q: Jaká je standardní velikost Gridfinity?
+    a: Standardní velikost Gridfinity je jedna jednotka mřížky 42 mm × 42 mm, s výškami Binů měřenými po 7 mm (1U = 7 mm). Každý Bin a každá základní deska Gridfinity je násobkem těchto dvou čísel — například Bin 2×3 má 84 mm × 126 mm.
+---
+
+# Rozměry a velikosti Gridfinity
+
+**Standardní rozměry Gridfinity: jedna jednotka mřížky je 42 mm × 42 mm (šířka a hloubka) a jedna výšková jednotka (1U) je 7 mm.** Každý Bin a každá základní deska je násobkem těchto dvou čísel — Bin 2×3 o výšce 6U měří 84 mm × 126 mm × 42 mm. Režim půl-Binu přidává kroky po 0,5 jednotky (21 mm). Jakmile znáš tato dvě čísla, dokážeš zjistit, co se vejde do tvé zásuvky a které Biny vytisknout.
+
+## Jednotky mřížky (šířka a hloubka)
+
+**1 jednotka mřížky = 42 mm.** Používá ji každý Bin a každá základní deska Gridfinity. Bin „2×3“ je 2 jednotky široký (84 mm) a 3 jednotky hluboký (126 mm).
+
+| Rozměr mřížky | Milimetry | Palce (přibližně) |
+| ------------- | --------- | ----------------- |
+| 1 jednotka    | 42 mm     | 1,65″             |
+| 2 jednotky    | 84 mm     | 3,31″             |
+| 3 jednotky    | 126 mm    | 4,96″             |
+| 4 jednotky    | 168 mm    | 6,61″             |
+| 5 jednotek    | 210 mm    | 8,27″             |
+| 6 jednotek    | 252 mm    | 9,92″             |
+| 7 jednotek    | 294 mm    | 11,57″            |
+| 8 jednotek    | 336 mm    | 13,23″            |
+
+### Režim půl-Binu
+
+Pro těsnější dopasování používá režim půl-Binu **kroky po 0,5 jednotky (21 mm)**. Bin 1,5×2,5 by měl 63 mm × 105 mm. Zapni to v nástroji pro rozvržení stiskem klávesy `H`.
+
+## Proč má Gridfinity 42 mm?
+
+Mřížka 42 mm je jediný standard, který dělá každý Bin a každou základní desku Gridfinity zaměnitelnou. Zack Freedman zvolil 42 mm, když v roce 2022 navrhoval Gridfinity, protože to trefuje sladký bod: dost malý, aby Bin 1×1 pojal jednotlivé šrouby nebo karty SD bez plýtvání místem, ale dost velký, aby se Biny tiskly rychle a zůstaly pevné.
+
+42 mm se také čistě dělí na běžné rozměry zásuvek a podložek tiskáren a nechává místo na tloušťku stěny, mezeru pro toleranci a zapadající profil podstavy, díky němuž se Biny snadno vyjmou, a přitom neklouzají, když otevřeš zásuvku. Protože je číslo pevné, Bin vytištěný dnes pasuje na základní desku, kterou někdo navrhl před lety — tahle univerzální kompatibilita je celý smysl standardu.
+
+**Standardní velikost Gridfinity je jedna jednotka mřížky 42 mm × 42 mm, s výškami měřenými po 7 mm.** Všechno ostatní je násobkem těchto dvou čísel.
+
+## Výškové jednotky
+
+**1 výšková jednotka (1U) = 7 mm.** Tolik svislého prostoru máš uvnitř Binu. Bin 3U pojme věci do zhruba 21 mm výšky.
+
+| Výška | Vnitřní (mm) | Typické využití                           |
+| ----- | ------------ | ----------------------------------------- |
+| 2U    | 14 mm        | Karty SD, malé šrouby, kancelářské sponky |
+| 3U    | 21 mm        | USB disky, baterie AA, šrouby             |
+| 4U    | 28 mm        | Pera, fixy, vrtáky                        |
+| 5U    | 35 mm        | Nůžky, role pásky, drobné nářadí          |
+| 6U    | 42 mm        | Šroubováky, kleště (standardní hloubka)   |
+| 7U    | 49 mm        | Spreje, větší ruční nářadí                |
+| 8U    | 56 mm        | Lahve s lepidlem, vysoké nádoby           |
+| 10U   | 70 mm        | Hluboké úložiště, rozměrné věci           |
+
+> **Kontrola světlé výšky:** Tvůj nejvyšší Bin plus základní deska (~5 mm) se musí vejít při zavřené zásuvce. Změř vnitřní výšku zavřené zásuvky, než se rozhodneš pro vysoké Biny.
+
+## Jak převést rozměry své zásuvky
+
+Vezmi metr a získej vnitřní rozměry zásuvky v milimetrech. Pak:
+
+1. Změř vnitřní šířku a hloubku v milimetrech
+2. Každou vyděl 42
+3. Zaokrouhli dolů na nejbližší celé číslo (nebo na polovinu, pokud používáš režim půl-Binu)
+
+### Příklad
+
+```text
+Šířka zásuvky:  380 mm ÷ 42 = 9,04 → 9 jednotek
+Hloubka zásuvky: 520 mm ÷ 42 = 12,38 → 12 jednotek
+Rozměr rozvržení: 9 × 12 (378 mm × 504 mm)
+Mezera u okrajů:  2 mm šířka, 16 mm hloubka
+```
+
+Malé mezery u okrajů jsou normální. Základní desky nemusí vyplnit každý milimetr. Většina lidí základní desky vycentruje a mezeru ignoruje.
+
+## Běžné rozměry Binů
+
+Tohle lidé tisknou nejčastěji. Kterýkoli z nich (nebo libovolný vlastní rozměr) vytvoříš v [generátoru Binů](/cs/gridfinity-bin-generator).
+
+| Rozměr Binu | Rozměry (mm) | Časté využití                               |
+| ----------- | ------------ | ------------------------------------------- |
+| 1×1         | 42 × 42      | Jednotlivé šrouby, matice, drobné součástky |
+| 1×2         | 42 × 84      | Pera, USB kabely, baterie v řadě            |
+| 1×3         | 42 × 126     | Šroubováky, pravítka, dlouhé nářadí         |
+| 2×2         | 84 × 84      | Pásky, lepicí tyčinky, svinovací metry      |
+| 2×3         | 84 × 126     | Kleště, štípačky, střední nářadí            |
+| 3×3         | 126 × 126    | Sady vrtáků, velké příslušenství            |
+| 4×2         | 168 × 84     | Nástrčné klíče, uložení posuvných měřítek   |
+
+## Vejde se to na tvoji podložku tiskárny?
+
+Většina FDM tiskáren má podložku 220–256 mm, která zvládne Biny do zhruba 5×5 nebo 6×6 jednotek. Cokoli většího je potřeba rozdělit nebo vytisknout po sekcích. Nástroj pro rozvržení výchozí přijímá podložku 256 mm a označí Biny, které se nevejdou.
+
+## Rychlý přehled
+
+| Míra                         | Hodnota          |
+| ---------------------------- | ---------------- |
+| Jednotka mřížky              | 42 mm × 42 mm    |
+| Půl jednotky mřížky          | 21 mm            |
+| Výšková jednotka (1U)        | 7 mm             |
+| Tloušťka základní desky      | ~5 mm            |
+| Výchozí podložka tiskárny    | 256 mm           |
+| Max. rozměr mřížky (nástroj) | 50 × 50 jednotek |
+
+## Další kroky
+
+Teď, když znáš rozměry, [vygeneruj vlastní Bin](/cs/gridfinity-bin-generator) nebo otevři [plánovač rozvržení](/) a podívej se, jak Biny pasují ve tvé zásuvce.
+
+Nový v Gridfinity? [Tady je krátký přehled](/cs/what-is-gridfinity) toho, jak systém funguje.
+
+[CTA: Naplánuj své rozvržení](/)

--- a/content/cs/guide.md
+++ b/content/cs/guide.md
@@ -1,0 +1,144 @@
+---
+title: Jak naplánovat rozvržení zásuvky Gridfinity
+description: Praktický průvodce plánováním rozvržení zásuvek Gridfinity. Změř zásuvku, urči, jaké Biny potřebuješ, a vyexportuj seznam pro tisk.
+keywords: gridfinity plánovač, gridfinity rozvržení, jak naplánovat gridfinity, plánování organizéru do zásuvky, gridfinity průvodce
+schema: HowTo
+breadcrumbs:
+  - name: Domů
+    url: https://gridfinitylayouttool.com/
+  - name: Průvodce plánováním
+    url: https://gridfinitylayouttool.com/cs/guide
+faqs:
+  - q: Jak změřit zásuvku pro Gridfinity?
+    a: Změř vnitřní rozměry zásuvky v milimetrech — šířku (zleva doprava), hloubku (zepředu dozadu) a světlou výšku (odspodu nahoru při zavřené zásuvce). Měř na několika místech, protože zásuvky bývají málokdy dokonalé obdélníky, a pro jistotu u každého rozměru použij nejmenší hodnotu.
+  - q: Jak převést rozměry zásuvky na jednotky mřížky Gridfinity?
+    a: Vyděl každý rozměr 42 mm a zaokrouhli dolů. Například zásuvka 380 mm × 260 mm pojme mřížku 9×6 (378 mm × 252 mm) a u okrajů zůstanou malé mezery. Mezery nevadí — základní desky nemusí vyplnit každý milimetr.
+  - q: Jaké velikosti Binů použít pro Gridfinity?
+    a: Pro začátek — 1×1 s příčkami na malé šrouby a součástky; 1×2 nebo 2×2 na pera, USB disky a baterie; 1×3 nebo 1×4 na šroubováky a kleště; 2×2 nebo 2×3 na lepicí pásky a lepidla; 3×3 nebo větší na velké nářadí. Jiné velikosti můžeš vždy vytisknout později, pokud něco úplně nesedí.
+  - q: Jak vysoký může být Bin Gridfinity?
+    a: Výšku Binu omezuje jen světlá výška zásuvky a výška osy Z tvé tiskárny. Výšky se měří v jednotkách po 7 mm (U). Bin 6U má uvnitř 42 mm, Bin 9U 63 mm. Před tiskem porovnej svůj nejvyšší Bin plus 5 mm na základní desku se světlou výškou zavřené zásuvky.
+  - q: Vyplatí se v hlubokých zásuvkách používat více vrstev?
+    a: Ano, pokud máš výškovou rezervu. Skládej Biny na sebe svisle, s vrstvou 1 dole. Těžké věci drž dole, často používané nahoře. Dobře to funguje pro oddělení plochých věcí (kabely) od vysokých Binů nebo pro oddělení elektro od mechaniky.
+  - q: Jak vyexportovat seznam pro tisk Gridfinity?
+    a: Jakmile máš rozvržení v nástroji hotové, seznam pro tisk ukáže každou velikost Binu, potřebné množství, odhady filamentu v gramech a vyhledávací odkazy pro každou velikost na Printables, Thangs a MakerWorld. Vlastní Biny můžeš také vygenerovat přímo vestavěným generátorem Binů a vyexportovat soubory STL, STEP nebo 3MF.
+  - q: Kolik volného místa nechat v zásuvce Gridfinity?
+    a: Nech 10–20 % volného místa. Zásuvka dnes naplánovaná na 100 % se zítra stane problémem, až tvoje sbírka poroste nebo se změní tvoje potřeby. Prázdná pole mřížky nic nestojí a dávají prostor přidat Biny později.
+  - q: Jaká je nejlepší tiskárna na Gridfinity?
+    a: Jakákoli FDM tiskárna s podložkou aspoň 256 mm × 256 mm pohodlně vytiskne Biny Gridfinity. Bambu Lab X1, A1 a P1S jsou oblíbené díky rychlosti. Prusa MK4 a Ender 3 V3 KE fungují také dobře. U zásuvek větších než 6×6 jednotek mřížky budeš chtít buď skládat základní desky jako dlaždice, nebo použít tiskárnu většího formátu, jako Bambu X1E či Voron 2.4.
+---
+
+# Jak naplánovat rozvržení zásuvky Gridfinity
+
+Tisk bez plánu plýtvá filamentem. Skončíš u přetiskování Binů, protože jsi špatně odhadl velikosti, u nechtěných mezer nebo u zapomínání, co jsi vlastně potřeboval. Tento průvodce ukazuje, jak změřit, naplánovat a získat seznam pro tisk, ještě než začneš.
+
+## Změř zásuvku
+
+Získej vnitřní rozměry v milimetrech. Potřebuješ:
+
+- **Šířka** — zleva doprava
+- **Hloubka** — zepředu dozadu
+- **Výška** — odspodu nahoru (světlá výška při zavřené zásuvce)
+
+Měř na několika místech. Zásuvky bývají málokdy dokonalé obdélníky, zvlášť u staršího nábytku. Pro jistotu použij nejmenší naměřenou hodnotu.
+
+### Převeď na jednotky mřížky
+
+Gridfinity používá jednotky 42 mm. Vyděl a zaokrouhli dolů:
+
+```text
+Šířka:  380 mm ÷ 42 = 9,04 → 9 jednotek
+Hloubka: 260 mm ÷ 42 = 6,19 → 6 jednotek
+```
+
+Mřížka 9×6 je 378 mm × 252 mm. U okrajů budeš mít malé mezery. To nevadí. Základní desky nemusí vyplnit každý milimetr.
+
+## Urči, co do ní přijde
+
+Většina lidí tento krok přeskočí a pak toho lituje.
+
+Vyndej všechno ze zásuvky. Rozděl to do skupin:
+
+- Věci na denní použití
+- Věci na týdenní použití
+- Věci, o kterých jsi zapomněl, že je máš
+
+To, co používáš denně, musí být po ruce. Týdenní může přijít dozadu. Zapomenuté možná vůbec Bin nepotřebuje.
+
+### Přiřaď věci k velikostem Binů
+
+Hrubé vodítko:
+
+| Obsah                       | Rozměr Binu    |
+| --------------------------- | -------------- |
+| Šrouby M3, drobné součástky | 1×1 s příčkami |
+| Pera, USB disky, baterie    | 1×2 nebo 2×2   |
+| Šroubováky, kleště          | 1×3 nebo 1×4   |
+| Lepicí pásky, lepidla       | 2×2 nebo 2×3   |
+| Velké nářadí                | 3×3 nebo větší |
+
+Nepřikládej tomu přehnanou váhu. Jiné Biny můžeš vždy vytisknout později.
+
+## Naplánuj rozvržení
+
+Otevři nástroj a nastav rozměr mřížky. Přetahováním vytváříš Biny. Nástroj ti nedovolí, aby se překrývaly nebo vyjely mimo obrys.
+
+**Často používané věci blízko předku.** Po čem sáhneš první, když otevřeš zásuvku? To patří dopředu.
+
+**Seskupuj související věci.** Šroubováky na jednom místě, měřicí nástroje na druhém. Snáz si zapamatuješ, kde co je.
+
+**Nech trochu volného místa.** Tvoje sbírka poroste. Zásuvka dnes naplánovaná na 100 % je zítra problém.
+
+### Vrstvy do vysokých zásuvek
+
+Pokud má zásuvka výškovou rezervu, můžeš skládat Biny na sebe svisle. Vrstva 1 je dole.
+
+Dobře se to hodí pro:
+
+- Ploché věci dole (kabely, drobné díly), vyšší Biny nahoře
+- Oddělení elektro od mechaniky
+
+Těžké věci drž dole, často používané nahoře.
+
+## Vyexportuj seznam pro tisk
+
+Až ti rozvržení sedne, vyexportuj seznam pro tisk:
+
+- Každou velikost Binu a počet kusů
+- Odhady filamentu v gramech
+- Vyhledávací odkazy pro každou velikost
+
+### Hledání souborů STL
+
+Vlastní Biny můžeš [vygenerovat](/cs/gridfinity-bin-generator) přímo ve vestavěném generátoru — vyber rozměry, styl podstavy, přihrádky a vyexportuj jako STL, STEP nebo 3MF.
+
+Pro specializované Biny (držáky na konkrétní nářadí, složité tvary) prohledej komunitní repozitáře:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — největší výběr
+- [Thangs](https://thangs.com/search/gridfinity) — dobré na hledání podobných návrhů
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — komunita Bambu Lab
+
+Příklad vyhledávání: „gridfinity 2x2 3U“ najde Biny 2×2 o výšce 3 jednotky.
+
+## Než začneš tisknout
+
+### Nejdřív to vyzkoušej na kartonu
+
+> Nastříhej karton na velikosti svých Binů (42 mm na jednotku mřížky) a rozlož ho v zásuvce. Pokud něco nesedí, nepřišel jsi o jediný gram filamentu.
+
+### Nejdřív vytiskni jeden Bin
+
+Než vytiskneš 20 Binů, vytiskni jeden. Zkontroluj uložení, zkontroluj výšku a ujisti se, že se ti návrh líbí. V případě potřeby dolaď nastavení tiskárny.
+
+### Zkontroluj světlou výšku
+
+Tvůj nejvyšší Bin plus základní deska (asi 5 mm) se musí vejít při zavírání zásuvky. Změř to, než se rozhodneš pro vysoké Biny.
+
+## Časté chyby
+
+**Příliš mnoho maličkých Binů.** Mřížka Binů 1×1 vypadá uspořádaně, ale v každodenním používání bývá otravná. Větší Biny s příčkami jsou obvykle lepší.
+
+**Vyplnění každého pole.** To nenechá místo na nové věci. Naplánuj 10–20 % volného místa.
+
+**Ignorování toho, co reálně používáš.** Neorganizuj podle toho, co si myslíš, že bys měl mít. Organizuj podle toho, po čem reálně saháš.
+
+[CTA: Otevři nástroj pro rozvržení](/)

--- a/content/cs/what-is-gridfinity.md
+++ b/content/cs/what-is-gridfinity.md
@@ -1,0 +1,80 @@
+---
+title: Co je Gridfinity? Modulární systém 42 mm
+description: Gridfinity je bezplatný, otevřený modulární systém tištěný 3D na mřížce 42 mm. Poznej Biny, základní desky a výšky po 7 mm — a navrhni si vlastní zdarma.
+keywords: gridfinity, co je gridfinity, organizér do zásuvky, 3D tisk, modulární úložný systém, Zack Freedman
+schema: Article
+breadcrumbs:
+  - name: Domů
+    url: https://gridfinitylayouttool.com/
+  - name: Co je Gridfinity?
+    url: https://gridfinitylayouttool.com/cs/what-is-gridfinity
+faqs:
+  - q: Co je Bin Gridfinity?
+    a: Bin Gridfinity je 3D tištěná úložná nádoba, která stojí na základní desce Gridfinity. Biny se vyrábějí v rozměrech mřížky (1×1, 2×2, 3×1 atd., kde 1 jednotka odpovídá 42 mm) a ve výškách odstupňovaných po 7 mm. Profilovaná podstava zapadá do vzoru základní desky, takže Biny při otevření zásuvky zůstávají na místě, ale snadno se vyjmou.
+  - q: Jak velká je jednotka Gridfinity?
+    a: Jedna jednotka mřížky Gridfinity je 42 mm × 42 mm. Výšky používají samostatný krok 7 mm, často označovaný jako „U“. Bin 2×2 o výšce 3U má tedy uvnitř zhruba 84 mm × 84 mm × 21 mm.
+  - q: Jaký je rozdíl mezi Binem Gridfinity a základní deskou?
+    a: Základní desky jsou ploché dlaždice, které vložíš do zásuvky a které tvoří mřížku 42 mm. Biny jsou nádoby na tvoje věci, spočívající na vzoru základní desky. Základní desky vytiskneš jednou, abys pokryl zásuvku, a pak na ně tiskneš libovolné Biny.
+  - q: Jaký filament použít pro Biny Gridfinity?
+    a: PLA je standardní volba a většina komunitních návrhů je optimalizovaná právě pro něj. PETG se hodí, když chceš vyšší odolnost nebo odolnost proti nárazu. ASA nebo ABS dávají smysl, pokud Biny stojí na teplém místě (garáž, půda). PLA se vyhni v rozpáleném autě.
+  - q: Kolik filamentu spotřebuje Bin Gridfinity?
+    a: Typický Bin 2×2 spotřebuje asi 20–40 gramů PLA podle výšky a výplně. Bin 1×1 je kolem 8–15 g. Základní desky jsou v přepočtu na jednotku těžší — zhruba 25–30 g na jednotku mřížky.
+  - q: Jak dlouho trvá tisk Binu Gridfinity?
+    a: Bin 2×2 se tiskne asi 1–2 hodiny při standardních rychlostech (50–80 mm/s). Bambu Lab a další rychlé tiskárny to zkrátí na 20–40 minut. Základní desky trvají na jednotku déle kvůli velké ploše.
+  - q: Vypadávají Biny Gridfinity při otevření zásuvky?
+    a: Ne. Vyvýšený vzor základní desky vytváří dost tření, aby Biny při běžném používání zásuvky držely na místě. Nejsou zajištěné, takže je vyjmeš tak, že je zvedneš rovnou nahoru, ale při otevírání a zavírání zásuvky se neposouvají.
+  - q: Můžu Biny Gridfinity koupit místo tisku?
+    a: Ano — mnoho prodejců nabízí předtištěné Biny na Etsy, Amazonu a v obchodech přímo od makerů. Je to možnost, pokud nemáš 3D tiskárnu, i když vlastní tisk vychází obvykle levněji na jeden Bin, když započítáš poštovné.
+  - q: Je Gridfinity zdarma?
+    a: Ano. Gridfinity má otevřený zdrojový kód. Komunitní návrhy si zdarma stáhneš z Printables, Thangs a MakerWorld. Tvůj jediný náklad je filament.
+---
+
+# Co je Gridfinity?
+
+Gridfinity je bezplatný, otevřený modulární úložný systém, který si vytiskneš sám ve 3D: Biny ve standardních velikostech spočívají na mřížce základních desek 42 mm, takže každý návrh od každého makera je vzájemně zaměnitelný. Zack Freedman, maker a youtuber, ho vytvořil v roce 2022 — dnes je jen na Printables přes 10 000 bezplatných návrhů.
+
+Myšlenka je prostá: všechno stojí na mřížce 42 mm. Biny spočívají na základních deskách. Základní desky se skládají jako dlaždice, aby vyplnily libovolnou zásuvku. Když chceš něco přeorganizovat, prostě Biny zvedneš a přesuneš.
+
+## Jak to funguje
+
+Sestava Gridfinity se skládá ze dvou částí:
+
+**Základní desky** patří do zásuvky. Jsou to ploché mřížky s vyvýšeným vzorem, který drží Biny na místě. Skládáš je jako dlaždice, abys pokryl dostupnou plochu.
+
+**Biny** pojmou tvoje věci. Vyrábějí se v rozměrech mřížky (1×1, 2×2, 3×1 atd.) a ve výškách měřených v jednotkách po 7 mm. Bin 3U dává asi 21 mm vnitřní výšky.
+
+Biny mají profilovanou podstavu, která zapadá do vzoru základní desky. Při otevření zásuvky zůstávají na místě, ale snadno se vyjmou, když je potřebuješ.
+
+## Proč to lidé používají
+
+**Vytiskneš přesně to, co potřebuješ.** Žádné kupování balení 12 Binů, když potřebuješ 2. Žádné hledání správné velikosti. Pokud existuje Bin na tvoje konkrétní vrtáky nebo šrouby, prostě si ho vytiskneš.
+
+**Všechno je kompatibilní.** Bin 2×2 od jednoho návrháře pasuje k základní desce jiného. Každý návrh dodržuje stejnou specifikaci.
+
+**Je to zdarma.** Návrhy jsou open source. Jediný náklad je filament. Typický Bin spotřebuje 20–40 gramů PLA.
+
+## Hledání návrhů
+
+Komunita vytvořila Biny na většinu běžných potřeb: držáky šroubováků, organizéry na baterie, tácky na vrtáky, správu kabelů.
+
+Hlavní repozitáře:
+
+- [Printables](https://www.printables.com/search/models?q=gridfinity) — největší kolekce, dobré filtrování
+- [Thangs](https://thangs.com/search/gridfinity) — vyhledávání podle podobného tvaru
+- [MakerWorld](https://makerworld.com/en/search/models?keyword=gridfinity) — oblíbené u majitelů Bambu
+
+Vyhledej, co potřebuješ (např. „gridfinity 2x2 battery holder“), a najdeš možnosti.
+
+## Co potřebuješ na začátek
+
+1. **3D tiskárnu.** Poslouží jakákoli FDM tiskárna. PLA je standard.
+2. **Rozměry.** Vnitřní rozměry zásuvky v milimetrech. Přepočet najdeš v [přehledu velikostí](/cs/gridfinity-sizes).
+3. **Plán.** Kolik jednotek mřížky se vejde, jaké Biny potřebuješ, kam přijdou.
+
+Tento nástroj pomáhá s krokem 3. Rozvrhni si rozvržení, podívej se, jak všechno pasuje, a pak vyexportuj seznam toho, co vytisknout. Můžeš také [vygenerovat vlastní Biny](/cs/gridfinity-bin-generator) s exportem STL, STEP a 3MF přímo v prohlížeči.
+
+## Další krok
+
+Až budeš připravený naplánovat zásuvku, průvodce tě provede měřením, plánováním a exportem seznamu pro tisk.
+
+[CTA: Přečti si průvodce plánováním](/cs/guide)

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -49,6 +49,7 @@ const SUPPORTED_LOCALES = [
   'uk',
   'pl',
   'zh-CN',
+  'cs',
 ] as const;
 type Locale = (typeof SUPPORTED_LOCALES)[number];
 const DEFAULT_LOCALE: Locale = 'en';
@@ -65,6 +66,7 @@ const LOCALE_LABELS: Record<Locale, { lang: string; openTool: string; siteName: 
   uk: { lang: 'uk', openTool: 'Відкрити інструмент', siteName: 'Gridfinity Layout Tool' },
   pl: { lang: 'pl', openTool: 'Otwórz narzędzie', siteName: 'Gridfinity Layout Tool' },
   'zh-CN': { lang: 'zh-CN', openTool: '打开工具', siteName: 'Gridfinity Layout Tool' },
+  cs: { lang: 'cs', openTool: 'Otevřít nástroj', siteName: 'Gridfinity Layout Tool' },
 };
 
 const FAQ_HEADING: Record<Locale, string> = {
@@ -79,6 +81,7 @@ const FAQ_HEADING: Record<Locale, string> = {
   uk: 'Часті запитання',
   pl: 'Najczęściej zadawane pytania',
   'zh-CN': '常见问题',
+  cs: 'Často kladené otázky',
 };
 
 const FOOTER_COPY: Record<Locale, string> = {
@@ -93,6 +96,7 @@ const FOOTER_COPY: Record<Locale, string> = {
   uk: 'Безкоштовно у використанні.',
   pl: 'Darmowe w użyciu.',
   'zh-CN': '免费使用。',
+  cs: 'Zdarma k použití.',
 };
 
 const OG_LOCALE: Record<Locale, string> = {
@@ -107,6 +111,7 @@ const OG_LOCALE: Record<Locale, string> = {
   uk: 'uk_UA',
   pl: 'pl_PL',
   'zh-CN': 'zh_CN',
+  cs: 'cs_CZ',
 };
 
 const NATIVE_LANGUAGE: Record<Locale, string> = {
@@ -121,6 +126,7 @@ const NATIVE_LANGUAGE: Record<Locale, string> = {
   uk: 'Українська',
   pl: 'Polski',
   'zh-CN': '简体中文',
+  cs: 'Čeština',
 };
 
 const LANGUAGE_LABEL: Record<Locale, string> = {
@@ -135,6 +141,7 @@ const LANGUAGE_LABEL: Record<Locale, string> = {
   uk: 'Мова',
   pl: 'Język',
   'zh-CN': '语言',
+  cs: 'Jazyk',
 };
 
 const FOOTER_LINKS: Record<
@@ -307,6 +314,20 @@ const FOOTER_LINKS: Record<
     software: '软件对比',
     privacy: '隐私',
     terms: '条款',
+  },
+  cs: {
+    generator: 'Generátor Gridfinity',
+    whatIs: 'Co je Gridfinity?',
+    bin: 'Generátor Binů',
+    baseplate: 'Generátor základních desek',
+    sizes: 'Přehled velikostí',
+    guide: 'Průvodce plánováním',
+    toolDrawer: 'Nářaďové zásuvky',
+    kitchen: 'Kuchyňské zásuvky',
+    calculator: 'Kalkulačka',
+    software: 'Porovnání softwaru',
+    privacy: 'Soukromí',
+    terms: 'Podmínky',
   },
 };
 

--- a/src/shell/Sidebar/learnLinks.ts
+++ b/src/shell/Sidebar/learnLinks.ts
@@ -33,6 +33,7 @@ const CONTENT_LOCALES = new Set<Locale>([
   'uk',
   'pl',
   'zh-CN',
+  'cs',
 ]);
 
 /**

--- a/vercel.json
+++ b/vercel.json
@@ -187,6 +187,16 @@
       ]
     },
     {
+      "source": "/cs/:path((?!api/).*)",
+      "headers": [
+        { "key": "Content-Language", "value": "cs" },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
       "source": "/fr/:path((?!api/).*)",
       "headers": [
         { "key": "Content-Language", "value": "fr" },
@@ -334,7 +344,7 @@
       "destination": "/:slug/index.html"
     },
     {
-      "source": "/:locale(de|fr|es|pt-BR|nl|sv|nb|uk|pl|zh-CN)/:slug(what-is-gridfinity|guide|gridfinity-generator|gridfinity-bin-generator|gridfinity-baseplate-generator|gridfinity-sizes)",
+      "source": "/:locale(de|fr|es|pt-BR|nl|sv|nb|uk|pl|zh-CN|cs)/:slug(what-is-gridfinity|guide|gridfinity-generator|gridfinity-bin-generator|gridfinity-baseplate-generator|gridfinity-sizes)",
       "destination": "/:locale/:slug/index.html"
     },
     { "source": "/designer", "destination": "/" },


### PR DESCRIPTION
## Summary
Adds **Czech (`cs`) SEO landing pages** — third in the content batch (pl #2855 → zh-CN #2857 → **cs** → ko). Translates the 6 core content pages.

## What changed
- `content/cs/*.md` — 6 translated long-form pages (frontmatter: title/description/keywords/breadcrumbs/FAQs/schema)
- `scripts/build-content.ts` — `cs` in `SUPPORTED_LOCALES` + all 7 `Record<Locale>` maps (OG_LOCALE=`cs_CZ`, NATIVE_LANGUAGE=`Čeština`, …)
- `vercel.json` — `/cs/` `Content-Language` header + rewrite alternation
- `learnLinks.ts` — `cs` in `CONTENT_LOCALES`
- `.gitignore` — ignore generated `public/cs/`

## Verified (`build:content`)
- ✅ All 6 pages generate; **no SERP length warnings** (titles ≤55, descriptions ≤155)
- ✅ `<html lang="cs">`, `hreflang="cs"` + `x-default`, sitemap `/cs/` entries
- ✅ `typecheck` passes; `vercel.json` valid

## Translation notes
- **"Bin" kept as an English loanword** (declined Bin/Binu/Biny/Binů) — Latin-script convention, matching de/pl content + the cs UI (#2848). Other nouns localized (baseplate → základní deska).
- Inline images stripped per the existing-locale convention.

## Out of scope
Content/SEO only; the cs **UI** shipped in #2848. (Note: the pre-existing "8×8 max"/"magnet default" content inaccuracies Greptile flagged on #2857 are tracked for a separate en-source + all-locales accuracy PR.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Czech (`cs`) SEO landing pages and wire the locale across the site. Localized `/cs/` content now serves with correct headers, hreflang, and sitemap entries.

- **New Features**
  - Added 6 Czech pages under `content/cs` (generator, bin generator, baseplate generator, sizes, guide, what-is) with localized SEO frontmatter and FAQs/schema.
  - Enabled `cs` in `scripts/build-content.ts` (SUPPORTED_LOCALES, labels, `OG_LOCALE`=`cs_CZ`, native language, FAQ heading, footer copy/links).
  - Configured `/cs/` in `vercel.json` with `Content-Language: cs`, caching headers, and added `cs` to localized-slug rewrites.
  - Surfaced `cs` in UI links (`learnLinks.ts`), and ignored generated `public/cs/` in `.gitignore`.
  - Verified: pages build cleanly, titles/descriptions within SERP limits, `<html lang="cs">`/hreflang/x-default set, sitemap entries added, typecheck and config validate.

<sup>Written for commit a873752596a86a3267f9131d3563e7dc4e45ec15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

