### PR TITLE
fix(generation): keep wall pattern clear of corners on lip-less bins (#2865)

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/honeycombManifoldCheck.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/honeycombManifoldCheck.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin, getKernelName } from './wasmInit';
 import { buildParams } from './scenarioTypes';
+import { assertWatertight } from './meshAssertions';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import { clearAllCaches } from '../shapeCache';
 
@@ -50,5 +51,7 @@ describe(`honeycomb wall pattern on ${getKernelName()}`, () => {
 
     expect(honeycomb.triangleCount).toBeGreaterThan(plain.triangleCount);
     expect(minZ(honeycomb.vertices)).toBeGreaterThanOrEqual(-0.001);
+    // The carved shell must stay closed, not just gain triangles.
+    assertWatertight(honeycomb, `honeycomb wall pattern on ${getKernelName()}`);
   });
 });

--- a/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
@@ -81,6 +81,65 @@ export function meshVolume({ vertices, indices }: MeshData): number {
   return Math.abs(volume) / 6;
 }
 
+// ─── Watertightness (hole-free) ──────────────────────────────────────────────
+
+export interface MeshTopologyStats {
+  /** Edges used by exactly one triangle — a mesh is hole-free iff this is 0. */
+  boundaryEdges: number;
+  /** Edges shared by more than two triangles (non-manifold junctions). */
+  nonManifoldEdges: number;
+}
+
+/**
+ * Weld vertices by quantized position and count boundary / non-manifold edges.
+ *
+ * Welding by position (not index) is required: the kernel tessellates each face
+ * independently, so a closed solid still has coincident-but-distinct vertices
+ * along every shared edge. Quantizing to 1e-4 mm collapses those so a genuinely
+ * closed surface reports zero boundary edges. Mirrors the `analyze()` topology
+ * pass in binGenerator.scenario.export-integrity.test.ts, which asserts the same
+ * invariant over every exported scenario.
+ */
+export function meshTopologyStats({ vertices, indices }: MeshData): MeshTopologyStats {
+  const QUANTIZE = 1e4;
+  const vKey = (i: number): string => {
+    const b = i * 3;
+    return `${Math.round(vertices[b] * QUANTIZE)},${Math.round(vertices[b + 1] * QUANTIZE)},${Math.round(vertices[b + 2] * QUANTIZE)}`;
+  };
+  const eKey = (a: string, b: string): string => (a < b ? `${a}|${b}` : `${b}|${a}`);
+
+  const edgeCount = new Map<string, number>();
+  for (let i = 0; i < indices.length; i += 3) {
+    const k = [vKey(indices[i]), vKey(indices[i + 1]), vKey(indices[i + 2])];
+    for (let e = 0; e < 3; e++) {
+      const key = eKey(k[e], k[(e + 1) % 3]);
+      edgeCount.set(key, (edgeCount.get(key) ?? 0) + 1);
+    }
+  }
+
+  let boundaryEdges = 0;
+  let nonManifoldEdges = 0;
+  for (const count of edgeCount.values()) {
+    if (count === 1) boundaryEdges++;
+    else if (count > 2) nonManifoldEdges++;
+  }
+  return { boundaryEdges, nonManifoldEdges };
+}
+
+/**
+ * Assert a mesh is hole-free (watertight): every edge is shared by ≥2 triangles.
+ *
+ * The definitive "the shell didn't split apart" check. A severed wall/corner
+ * pillar opens the shell, producing boundary edges (#2865).
+ */
+export function assertWatertight(result: MeshData, label?: string): void {
+  const prefix = label ? `${label}: ` : '';
+  const { boundaryEdges } = meshTopologyStats(result);
+  expect(boundaryEdges, `${prefix}mesh has ${boundaryEdges} boundary edges (not watertight)`).toBe(
+    0
+  );
+}
+
 // ─── Bounding box ────────────────────────────────────────────────────────────
 
 export interface BoundingBox {

--- a/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
+++ b/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
@@ -11,6 +11,7 @@ import { expect } from 'vitest';
 import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+import { assertWatertight } from '../__kernel-tests__/meshAssertions';
 import type { MeshData } from '@/features/generation/bridge/types';
 
 /** Enclosed (solid) volume of a triangle mesh via the signed-tetrahedron sum. */
@@ -302,6 +303,40 @@ export const honeycombJunction: ScenarioCase[] = [
             'triangle count must match regardless of walls.enabled when no sides are active'
           ).toBe(cutoutsOnSidesOff.triangleCount);
         },
+      },
+      timeout: 60_000,
+    }
+  ),
+
+  // ── #2865: a BOLD wall pattern on thin, lip-less walls with pattern dividers.
+  //    At 0.8mm walls the round holes (70% scale) reach to within ~0.4mm of each
+  //    corner, leaving a razor-thin corner post — it renders as a seam and prints
+  //    as a break ("empty space between wall faces"). Without a lip there is no
+  //    top rim to re-join the walls. The corner keep-out clears the pattern from
+  //    each corner so a solid post survives. Structural + (via the export-
+  //    integrity matrix) hole-free STL guard for the exact reported config.
+
+  defineScenario(
+    'honeycomb junction',
+    'bold round pattern + dividers, thin walls, no lip — solid corners (#2865)',
+    {
+      assert: 'structural',
+      params: {
+        width: 2,
+        depth: 3,
+        height: 6,
+        wallThickness: 0.8,
+        base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+        wallPattern: { enabled: true, pattern: 'round', scale: 0.7, dividers: true },
+        compartments: { cols: 1, rows: 2, cells: [0, 1], thickness: 1.2 },
+        walls: ALL_SIDES_OFF,
+      },
+      customAssert: (mesh) => {
+        expect(
+          meshVolume(mesh),
+          'bold-pattern thin-wall bin should enclose positive volume'
+        ).toBeGreaterThan(0);
+        assertWatertight(mesh, 'bold round pattern + dividers, thin walls, no lip (#2865)');
       },
       timeout: 60_000,
     }

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -427,7 +427,7 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
   const { innerW, innerD, interiorHeight, innerOffsetX, innerOffsetY } = dim;
   const patternCutTargets: Shape3D[] = [];
 
-  const patternResult = getPatternDescriptors(params, innerW, innerD, interiorHeight);
+  const patternResult = getPatternDescriptors(params, innerW, innerD, interiorHeight, dim.hasLip);
   if (!patternResult) return patternCutTargets;
 
   // patternResult.calculator is a StampPatternCalculator: getPatternDescriptors

--- a/src/features/generation/worker/generators/wallPatterns.test.ts
+++ b/src/features/generation/worker/generators/wallPatterns.test.ts
@@ -393,10 +393,10 @@ describe('getPatternDescriptors — corner keep-out (#2865)', () => {
     // Pre-fix behaviour (a lip re-joins the walls, so no keep-out is applied):
     // the hole reaches to within a sliver of the corner.
     const withLip = frontCornerGap(params, innerW, innerD, true);
-    expect(withLip.gap).toBeLessThan(1);
+    expect(withLip.gap).toBeLessThan(WALL_CORNER_KEEP_OUT);
     // No lip → keep-out clears the outermost column(s), restoring a solid band.
     const noLip = frontCornerGap(params, innerW, innerD, false);
-    expect(noLip.gap).toBeGreaterThanOrEqual(WALL_CORNER_KEEP_OUT - 0.5);
+    expect(noLip.gap).toBeGreaterThanOrEqual(WALL_CORNER_KEEP_OUT);
     expect(noLip.cols).toBeLessThan(withLip.cols);
   });
 

--- a/src/features/generation/worker/generators/wallPatterns.test.ts
+++ b/src/features/generation/worker/generators/wallPatterns.test.ts
@@ -3,6 +3,7 @@ import {
   getSlotFreeWalls,
   getPatternDescriptors,
   CUTOUT_BORDER_WIDTH,
+  WALL_CORNER_KEEP_OUT,
   BOTTOM_SOLID_SKIRT,
   getExpandedCutoutDimensions,
 } from './wallPatterns';
@@ -345,5 +346,68 @@ describe('getPatternDescriptors — polygon (cellMask) bins', () => {
     for (const d of result!.descriptors) {
       expect(d.allowClip).toBe(true);
     }
+  });
+});
+
+describe('getPatternDescriptors — corner keep-out (#2865)', () => {
+  // Solid gap between the outermost front-wall pattern element's outer edge and
+  // the wall end (the shared corner). A bold pattern on a thin, lip-less wall
+  // used to leave a sub-millimetre gap — a razor-thin corner post that renders
+  // as a seam and prints as a break. The keep-out pushes the pattern back so a
+  // solid corner survives.
+  function frontCornerGap(
+    params: BinParams,
+    innerW: number,
+    innerD: number,
+    hasLip: boolean
+  ): { gap: number; cols: number } {
+    const res = getPatternDescriptors(
+      params,
+      innerW,
+      innerD,
+      params.height * params.heightUnitMm,
+      hasLip
+    );
+    if (!res) throw new Error('expected descriptors');
+    const radius = res.calculator.getShapeRadius();
+    const front = res.descriptors.find((d) => d.side === 'front');
+    if (!front) throw new Error('expected a front descriptor');
+    let maxX = 0;
+    for (const c of front.centers) maxX = Math.max(maxX, Math.abs(c.x));
+    return { gap: front.wallSpan / 2 - (maxX + radius), cols: front.centers.length };
+  }
+
+  const boldRound = (scale: number): BinParams =>
+    makeParams({
+      width: 2,
+      depth: 3,
+      height: 6,
+      wallThickness: 0.8,
+      wallPattern: { enabled: true, pattern: 'round' as const, scale },
+    });
+  const innerW = 2 * 42 - 2 * 0.8;
+  const innerD = 3 * 42 - 2 * 0.8;
+
+  it('a lip-less bin whose pattern reaches the corner gets a solid keep-out band', () => {
+    const params = boldRound(0.7);
+    // Pre-fix behaviour (a lip re-joins the walls, so no keep-out is applied):
+    // the hole reaches to within a sliver of the corner.
+    const withLip = frontCornerGap(params, innerW, innerD, true);
+    expect(withLip.gap).toBeLessThan(1);
+    // No lip → keep-out clears the outermost column(s), restoring a solid band.
+    const noLip = frontCornerGap(params, innerW, innerD, false);
+    expect(noLip.gap).toBeGreaterThanOrEqual(WALL_CORNER_KEEP_OUT - 0.5);
+    expect(noLip.cols).toBeLessThan(withLip.cols);
+  });
+
+  it('leaves a pattern that already clears the corner untouched (targeted, no churn)', () => {
+    // At the neutral scale this bin's pattern already stops well clear of the
+    // corner (gap > keep-out), so the keep-out drops nothing — identical output.
+    const params = boldRound(0.5);
+    const withLip = frontCornerGap(params, innerW, innerD, true);
+    expect(withLip.gap).toBeGreaterThan(WALL_CORNER_KEEP_OUT);
+    const noLip = frontCornerGap(params, innerW, innerD, false);
+    expect(noLip.cols).toBe(withLip.cols);
+    expect(noLip.gap).toBeCloseTo(withLip.gap, 5);
   });
 });

--- a/src/features/generation/worker/generators/wallPatterns.ts
+++ b/src/features/generation/worker/generators/wallPatterns.ts
@@ -73,6 +73,24 @@ export const TOP_KEEP_OUT = 1.5;
 export const CUTOUT_BORDER_WIDTH = 1.5;
 
 /**
+ * Solid keep-out at each wall END (the shared corner), applied only when the bin
+ * has NO stacking lip (#2865).
+ *
+ * With a lip, the continuous top rim re-joins all four walls, so the corner is
+ * not the sole join and no keep-out is needed — lipped bins regenerate
+ * identically. With NO lip, a bold pattern on a thin wall places its outermost
+ * element hard against the corner: at 0.8mm walls a 70%-scale round hole lands
+ * ~0.4mm from the corner, leaving a razor-thin corner post. The mesh stays
+ * closed but that post reads as a seam and prints as a break ("empty space
+ * between wall faces"). Keeping the outermost element this far clear of each
+ * corner restores a solid post. Sized to `CUTOUT_BORDER_WIDTH` — the same solid
+ * border the wall-pattern border rule uses everywhere else. For a circular
+ * element this is exact: the keep-out changes a bin only when its corner gap
+ * would otherwise fall below this width.
+ */
+export const WALL_CORNER_KEEP_OUT = CUTOUT_BORDER_WIDTH;
+
+/**
  * Solid skirt left ABOVE the interior floor before the pattern starts (mm).
  * The bottom keep-out is `wallThickness + this`: one `wallThickness` clears the
  * floor slab, and the skirt is the actual solid band the lowest hex row anchors
@@ -102,7 +120,8 @@ function getWallPatternDescriptors(
   innerW: number,
   innerD: number,
   wallHeight: number,
-  calculator: StampPatternCalculator
+  calculator: StampPatternCalculator,
+  hasLip: boolean
 ): { descriptors: WallPatternDescriptor[]; patternHeight: number } | null {
   if (!params.wallPattern.enabled) {
     return null;
@@ -136,7 +155,12 @@ function getWallPatternDescriptors(
     zRotation?: number,
     allowClip = true
   ): void => {
-    const centers = calculator.calculateCenters({ fillW, fillH: patternHeight });
+    // Corner keep-out (#2865): on a lip-less bin, trim the outermost pattern
+    // column clear of both wall ends so a bold pattern can't leave a razor-thin
+    // corner post. `wallSpan` stays the full inner span so cutout/handle clip
+    // anchoring is unaffected; only the stamped centers shrink.
+    const centerFillW = hasLip ? fillW : Math.max(0, fillW - 2 * WALL_CORNER_KEEP_OUT);
+    const centers = calculator.calculateCenters({ fillW: centerFillW, fillH: patternHeight });
     if (centers.length === 0) return;
     const [first, ...rest] = centers;
     descriptors.push({
@@ -344,7 +368,10 @@ export function getPatternDescriptors(
   params: BinParams,
   innerW: number,
   innerD: number,
-  wallHeight: number
+  wallHeight: number,
+  // Defaults to true so omitting it reproduces the pre-#2865 behavior (no corner
+  // keep-out); the sole production caller passes the real `dim.hasLip`.
+  hasLip = true
 ): {
   descriptors: WallPatternDescriptor[];
   calculator: StampPatternCalculator;
@@ -375,7 +402,7 @@ export function getPatternDescriptors(
     return null;
   }
 
-  const result = getWallPatternDescriptors(params, innerW, innerD, wallHeight, calculator);
+  const result = getWallPatternDescriptors(params, innerW, innerD, wallHeight, calculator, hasLip);
 
   if (!result) {
     return null;


### PR DESCRIPTION
## Summary

**Type**: fix

Closes #2865. A bold wall pattern on thin, lip-less walls left a razor-thin corner post that reads as a seam in the preview and prints as a break ("empty space between wall faces").

## Root cause

The reported config is **Round pattern @ 70% scale + pattern-divider walls + 0.8mm walls + no stacking lip**. Wall patterns are stamped per wall, and the outermost element is placed right up to the inner corner. On a thin, lip-less wall that leaves almost nothing at the corner:

| scale              | outermost hole → corner gap (pre-fix) |
| ------------------ | ------------------------------------- |
| 0.5 (neutral)      | 2.35mm — fine                         |
| **0.7 (reported)** | **0.36mm — razor-thin post**          |
| 1.0                | 0.95mm                                |

The generated mesh stays **watertight** (which is why it isn't a topological hole), but a ~0.4mm corner on a 0.8mm wall renders as a gap and prints as a break. With a stacking lip the continuous top rim re-joins the four walls, so the corner isn't load-bearing — which is exactly why the repro requires the lip **off**.

## Fix

`getPatternDescriptors` now takes `hasLip`, and on a lip-less bin the per-wall stamp span is trimmed by `WALL_CORNER_KEEP_OUT` (1.5mm, the existing wall-pattern border width) at each end, clearing the outermost element off the corner. `wallSpan` is unchanged, so cutout/handle clip anchoring is untouched — only the stamped centers shrink.

**Targeted, no churn:** for a circular element this is exact — a bin changes only when its corner gap would otherwise fall below 1.5mm. Lipped bins skip the keep-out entirely (byte-identical), and patterns that already clear the corner (e.g. the neutral 0.5 scale) drop zero columns. After the fix the reported config leaves a **3.77mm** solid corner band.

## Tests

- **`wallPatterns.test.ts`** — deterministic corner-gap unit tests (the real regression guard, no WASM): asserts the keep-out restores a solid band on a lip-less bold-pattern bin, and leaves an already-clear pattern byte-identical.
- **`scenarios/honeycombJunction.ts`** — new real-WASM scenario at the exact reported config (round @ 70% + pattern dividers + 0.8mm + no lip) asserting positive volume + watertightness; it also flows through the export-integrity matrix (hole-free STL over the full catalog).
- **`honeycombManifoldCheck`** — promoted from "triangles changed" to asserting the carved shell stays watertight (new shared `assertWatertight` / `meshTopologyStats` helper).

## Validation

- typecheck + lint clean
- corner-gap unit tests pass (~1ms each)
- honeycomb-junction scenarios (incl. new #2865 case) pass on real WASM
- wallPatterns / dividerPatterns / wallThickness / floorPatterns scenarios pass — **no snapshot churn**
- full unit + dom suite: 14,867 passing

## Notes

Scoped to the corner geometry per discussion. Two related findings surfaced while reproducing and are **not** addressed here (candidates for follow-ups): kumiko/round patterns + dividers on thin walls are slow (20–48s at 4×4×6), and the `asanoha` pattern yields a small number of non-manifold edges — either could be the "export gets stuck" the reporter also mentions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents razor-thin corner seams on lip-less bins by keeping bold wall patterns off the corners. Addresses #2865 and leaves lipped bins byte-identical.

- **Bug Fixes**
  - On bins without a stacking lip, apply a 1.5 mm corner keep-out so the outermost pattern column avoids corners (`WALL_CORNER_KEEP_OUT`).
  - Threaded via `getPatternDescriptors(..., hasLip)` and used in `buildWallPatterns`; `wallSpan` is unchanged, only stamped centers shrink.
  - Strengthened tests: added `assertWatertight` with topology stats, promoted the honeycomb manifold check to assert watertightness, added a real-WASM scenario for the reported config, and updated corner-gap unit tests to assert thresholds against `WALL_CORNER_KEEP_OUT` (no magic numbers).

<sup>Written for commit e8caae2b50ba756f95ef6a4e9b47ae4148684c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

