### PR TITLE
perf(test): split the export-integrity matrix per domain to unblock CI

### DIFF
--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -87,7 +87,7 @@ graph TB
 - `worker/generators/shapeCache.ts` — LRU caches for BREP solids. Includes a per-cell-size **cell-socket template** cache: a uniform socket grid lofts one cell once and clones it per position (intrinsic-keyed, placement-invariant), turning a cold build from N lofts into 1 loft + (N−1) clones — the bin-side mirror of the baseplate `pocketTemplateCache`
 - `worker/generators/socketMeshCache.ts` — LRU cache for the deferred socket's tessellated mesh (triangles + edge lines), keyed by socket geometry identity + tolerance; reused across edits that don't change the base
 - `worker/generators/patterns/` — pattern system (honeycomb, registry)
-- `worker/generators/scenarios/` — test scenario data by category
+- `worker/generators/scenarios/` — test scenario data by category. Each module is run TWICE, by one `binGenerator.scenario.<domain>.test.ts` (generation) and one `binGenerator.export.<domain>.test.ts` (export integrity, via `__kernel-tests__/exportIntegrityRunner.ts`). **The one-file-per-domain split is a CI requirement, not tidiness**: Vitest parallelizes across files but never within one, and `--shard` divides by file path, so a whole-catalog file pins a single worker and its duration becomes the floor for the entire CI run — the export matrix in that form cost 14 minutes and set the critical path on its own. `binGenerator.scenarioCoverage.test.ts` enforces that both files exist for every module
 - `export/stlExporter.ts` — STL file export
 - `export/threemfExporter.ts` — 3MF file export (see [3MF multi-color compatibility](#3mf-multi-color-compatibility) for the slicer interop notes)
 - `export/validation.ts` — shared mesh data validation

--- a/src/features/generation/worker/generators/__kernel-tests__/exportIntegrityRunner.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/exportIntegrityRunner.ts
@@ -1,7 +1,8 @@
-// @vitest-environment node
 /**
- * Export-integrity matrix — runs the FULL scenario catalog through binary STL
- * export and asserts the invariants the occt-wasm kernel regressions violated:
+ * Shared export-integrity runner.
+ *
+ * Runs a set of catalog scenarios through binary STL export and asserts the
+ * invariants the occt-wasm kernel regressions violated:
  *
  *  1. The exported binary STL is well-formed and parseable. occt-wasm's native
  *     `exportStl` returned the binary payload as a lossy JS string, so the
@@ -15,17 +16,26 @@
  *     MEASURE_ZERO_SELF_CONTACT_SCENARIOS).
  *  3. No NaN/Infinity coordinates.
  *
- * Generation validity (vertex counts, structure) is already covered by
- * `binGenerator.scenario.test.ts`; this file is purely about EXPORT geometry,
+ * Generation validity (vertex counts, structure) is covered by the matching
+ * `binGenerator.scenario.<domain>.test.ts`; this is purely about EXPORT geometry,
  * the layer where the kernel swap introduced corruption.
+ *
+ * One file per scenario domain (`binGenerator.export.<domain>.test.ts`) calls
+ * this, mirroring the generation matrix. That split is a CI wall-time
+ * requirement, not tidiness: Vitest parallelizes across FILES but never within
+ * one, and `--shard` divides by file path — so the whole catalog in a single file
+ * pinned one worker for ~14 minutes and single-handedly set the CI critical path.
+ * `binGenerator.scenarioCoverage.test.ts` enforces that every domain has a file
+ * here, since per-file wiring can drift in a way a `for (ALL_SCENARIOS)` loop
+ * could not.
  */
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
-import { buildParams } from './__kernel-tests__/scenarioTypes';
-import { ALL_SCENARIOS } from './scenarios';
-import { setLastSolid, clearAllCaches } from './shapeCache';
-import type * as BinExporterModule from './binExporter';
+import { buildParams } from './scenarioTypes';
+import type { ScenarioCase } from './scenarioTypes';
+import { setLastSolid, clearAllCaches } from '../shapeCache';
+import type * as BinExporterModule from '../binExporter';
 
 let exportBin: typeof BinExporterModule.exportBin;
 
@@ -45,6 +55,10 @@ let exportBin: typeof BinExporterModule.exportBin;
 // inert on wasm (panic=abort) and Rust cannot reset the flag; the only recovery
 // is a NEW BrepKernel. This harness detects the poison signature and recreates
 // the kernel so each later scenario runs healthy, revealing the true pass/fail.
+//
+// Splitting the matrix per domain shrinks each worker's arena, so the stranding
+// is rarer than it was in the single-file form — but it is per-worker state, so
+// the recovery has to live here rather than being dropped.
 const KERNEL_IS_BREPKIT = ['brepkit', 'wasm'].includes(process.env['BREPJS_KERNEL'] ?? '');
 const POISON_RE = /recursive use of an object|unsafe aliasing/i;
 let lastPanicMessage: (() => string | undefined) | null = null;
@@ -70,25 +84,11 @@ async function recoverBrepkitKernel(): Promise<void> {
   const { registerKernel, BrepkitAdapter } = await import('brepjs');
   const brepkitWasm = await import('brepkit-wasm');
   const kernel = new brepkitWasm.BrepKernel();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- KernelInstance is typed as any in brepjs
   registerKernel('brepkit', new BrepkitAdapter(kernel as any));
   clearLastPanicMessage?.();
   poisoned = false;
 }
-
-beforeAll(async () => {
-  const { initBrepjs } = await import('./__kernel-tests__/wasmInit');
-  await initBrepjs();
-  exportBin = (await import('./binExporter')).exportBin;
-  if (KERNEL_IS_BREPKIT) {
-    const bkw = (await import('brepkit-wasm')) as unknown as {
-      lastPanicMessage?: () => string | undefined;
-      clearLastPanicMessage?: () => void;
-    };
-    lastPanicMessage = bkw.lastPanicMessage ?? null;
-    clearLastPanicMessage = bkw.clearLastPanicMessage ?? null;
-    clearLastPanicMessage?.();
-  }
-}, 120_000);
 
 interface ManifoldStats {
   triangleCount: number;
@@ -173,80 +173,101 @@ const MEASURE_ZERO_SELF_CONTACT_SCENARIOS = new Set<string>([
  */
 const MAX_MEASURE_ZERO_CONTACT_EDGES = 8;
 
-describe('export integrity: full scenario matrix → binary STL', () => {
-  // Reset the last-solid pointer so each scenario actually builds and exports
-  // its OWN solid. `exportBin` skips regeneration whenever the cached solid is
-  // export-quality (isLastSolidExportQuality), and that flag is param-blind —
-  // without this reset the first scenario's export-quality solid would be
-  // re-exported for all 354 scenarios, making every assertion vacuous. In
-  // production a preview pass (forExport=false) clears the flag on every param
-  // change; this loop never previews, so we clear it explicitly. The
-  // param-keyed intermediate LRU caches (socket/lip/box) stay warm for speed.
-  beforeEach(async () => {
-    setLastSolid(null);
-    // Recover if the prior scenario stranded the kernel — detected by the
-    // borrow-flag poison signature in its error (`poisoned`, covers both the
-    // panic-abort and non-panic stranding) OR by a recorded Rust panic that
-    // left no catchable JS error on this scenario yet (lastPanicMessage).
-    if (KERNEL_IS_BREPKIT && (poisoned || lastPanicMessage?.())) {
-      await recoverBrepkitKernel();
+/**
+ * Register the export-integrity suite for one domain's scenarios. Call once at
+ * the top level of a `binGenerator.export.<domain>.test.ts` file.
+ */
+export function runExportIntegrity(scenarios: readonly ScenarioCase[]): void {
+  beforeAll(async () => {
+    const { initBrepjs } = await import('./wasmInit');
+    await initBrepjs();
+    exportBin = (await import('../binExporter')).exportBin;
+    if (KERNEL_IS_BREPKIT) {
+      const bkw = (await import('brepkit-wasm')) as unknown as {
+        lastPanicMessage?: () => string | undefined;
+        clearLastPanicMessage?: () => void;
+      };
+      lastPanicMessage = bkw.lastPanicMessage ?? null;
+      clearLastPanicMessage = bkw.clearLastPanicMessage ?? null;
+      clearLastPanicMessage?.();
+    }
+  }, 120_000);
+
+  describe('export integrity: scenario matrix → binary STL', () => {
+    // Reset the last-solid pointer so each scenario actually builds and exports
+    // its OWN solid. `exportBin` skips regeneration whenever the cached solid is
+    // export-quality (isLastSolidExportQuality), and that flag is param-blind —
+    // without this reset the first scenario's export-quality solid would be
+    // re-exported for every later one, making every assertion vacuous. In
+    // production a preview pass (forExport=false) clears the flag on every param
+    // change; this loop never previews, so we clear it explicitly. The
+    // param-keyed intermediate LRU caches (socket/lip/box) stay warm for speed.
+    beforeEach(async () => {
+      setLastSolid(null);
+      // Recover if the prior scenario stranded the kernel — detected by the
+      // borrow-flag poison signature in its error (`poisoned`, covers both the
+      // panic-abort and non-panic stranding) OR by a recorded Rust panic that
+      // left no catchable JS error on this scenario yet (lastPanicMessage).
+      if (KERNEL_IS_BREPKIT && (poisoned || lastPanicMessage?.())) {
+        await recoverBrepkitKernel();
+      }
+    });
+
+    for (const scenario of scenarios) {
+      const label = `${scenario.category} › ${scenario.name}`;
+      const measureZeroSelfContact = MEASURE_ZERO_SELF_CONTACT_SCENARIOS.has(label);
+      it(
+        label,
+        async () => {
+          try {
+            const params = buildParams(scenario.params);
+            const result = await exportBin(params, 'stl');
+
+            // 1. Buffer is well-formed and parseable (the occt-wasm STL bug).
+            const stats = analyze(result.data, scenario.name);
+
+            // 2. Non-empty printable solid (the compound-cut empty-result bug).
+            expect(stats.triangleCount, `${scenario.name}: triangle count`).toBeGreaterThan(0);
+
+            // 3. No NaN/Infinity coordinates.
+            expect(stats.minFinite, `${scenario.name}: finite coordinates`).toBe(true);
+
+            // 4. Hole-free: no boundary edges. This is the real printable-watertight
+            //    guarantee and holds for EVERY scenario, including the measure-zero
+            //    self-contact cases.
+            expect(stats.boundaryEdges, `${scenario.name}: boundary edges`).toBe(0);
+
+            // 5. Fully 2-manifold (no edge shared by >2 triangles) — required of
+            //    every scenario except the documented measure-zero self-contact
+            //    cases (see MEASURE_ZERO_SELF_CONTACT_SCENARIOS). Those are bounded
+            //    on BOTH sides rather than left unchecked: a lower bound of >0 makes
+            //    the carve-out self-expiring — if a kernel upgrade ever resolves the
+            //    pinch, this fails and signals the scenario can rejoin the strict
+            //    tier — and the upper cap catches a hole-free-but-manifold-broken
+            //    regression that the boundary-edge check (4) alone would miss.
+            if (measureZeroSelfContact) {
+              expect(
+                stats.nonManifoldEdges,
+                `${scenario.name}: non-manifold edges (self-contact must persist)`
+              ).toBeGreaterThan(0);
+              expect(
+                stats.nonManifoldEdges,
+                `${scenario.name}: non-manifold edges (must stay bounded)`
+              ).toBeLessThanOrEqual(MAX_MEASURE_ZERO_CONTACT_EDGES);
+            } else {
+              expect(stats.nonManifoldEdges, `${scenario.name}: non-manifold edges`).toBe(0);
+            }
+          } catch (e) {
+            // Flag borrow-flag poison so beforeEach recreates the kernel before
+            // the next scenario — stops one stranding from cascading into ~0ms
+            // "recursive use" failures across every later scenario.
+            const msg = e instanceof Error ? e.message : String(e);
+            if (KERNEL_IS_BREPKIT && POISON_RE.test(msg)) poisoned = true;
+            throw e;
+          }
+        },
+        scenario.timeout
+      );
     }
   });
-
-  for (const scenario of ALL_SCENARIOS) {
-    const label = `${scenario.category} › ${scenario.name}`;
-    const measureZeroSelfContact = MEASURE_ZERO_SELF_CONTACT_SCENARIOS.has(label);
-    it(
-      label,
-      async () => {
-        try {
-          const params = buildParams(scenario.params);
-          const result = await exportBin(params, 'stl');
-
-          // 1. Buffer is well-formed and parseable (the occt-wasm STL bug).
-          const stats = analyze(result.data, scenario.name);
-
-          // 2. Non-empty printable solid (the compound-cut empty-result bug).
-          expect(stats.triangleCount, `${scenario.name}: triangle count`).toBeGreaterThan(0);
-
-          // 3. No NaN/Infinity coordinates.
-          expect(stats.minFinite, `${scenario.name}: finite coordinates`).toBe(true);
-
-          // 4. Hole-free: no boundary edges. This is the real printable-watertight
-          //    guarantee and holds for EVERY scenario, including the measure-zero
-          //    self-contact cases.
-          expect(stats.boundaryEdges, `${scenario.name}: boundary edges`).toBe(0);
-
-          // 5. Fully 2-manifold (no edge shared by >2 triangles) — required of
-          //    every scenario except the documented measure-zero self-contact
-          //    cases (see MEASURE_ZERO_SELF_CONTACT_SCENARIOS). Those are bounded
-          //    on BOTH sides rather than left unchecked: a lower bound of >0 makes
-          //    the carve-out self-expiring — if a kernel upgrade ever resolves the
-          //    pinch, this fails and signals the scenario can rejoin the strict
-          //    tier — and the upper cap catches a hole-free-but-manifold-broken
-          //    regression that the boundary-edge check (4) alone would miss.
-          if (measureZeroSelfContact) {
-            expect(
-              stats.nonManifoldEdges,
-              `${scenario.name}: non-manifold edges (self-contact must persist)`
-            ).toBeGreaterThan(0);
-            expect(
-              stats.nonManifoldEdges,
-              `${scenario.name}: non-manifold edges (must stay bounded)`
-            ).toBeLessThanOrEqual(MAX_MEASURE_ZERO_CONTACT_EDGES);
-          } else {
-            expect(stats.nonManifoldEdges, `${scenario.name}: non-manifold edges`).toBe(0);
-          }
-        } catch (e) {
-          // Flag borrow-flag poison so beforeEach recreates the kernel before
-          // the next scenario — stops one stranding from cascading into ~0ms
-          // "recursive use" failures across every later scenario.
-          const msg = e instanceof Error ? e.message : String(e);
-          if (KERNEL_IS_BREPKIT && POISON_RE.test(msg)) poisoned = true;
-          throw e;
-        }
-      },
-      scenario.timeout
-    );
-  }
-});
+}

--- a/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
@@ -97,7 +97,7 @@ export interface MeshTopologyStats {
  * independently, so a closed solid still has coincident-but-distinct vertices
  * along every shared edge. Quantizing to 1e-4 mm collapses those so a genuinely
  * closed surface reports zero boundary edges. Mirrors the `analyze()` topology
- * pass in binGenerator.scenario.export-integrity.test.ts, which asserts the same
+ * pass in the binGenerator.export.<domain>.test.ts matrix, which asserts the same
  * invariant over every exported scenario.
  */
 export function meshTopologyStats({ vertices, indices }: MeshData): MeshTopologyStats {

--- a/src/features/generation/worker/generators/binGenerator.export.baseStyles.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.baseStyles.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { baseStyles } from './scenarios/baseStyles';
+
+runExportIntegrity(baseStyles);

--- a/src/features/generation/worker/generators/binGenerator.export.binStyles.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.binStyles.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { binStyles } from './scenarios/binStyles';
+
+runExportIntegrity(binStyles);

--- a/src/features/generation/worker/generators/binGenerator.export.combinedFeatures.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.combinedFeatures.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { combinedFeatures } from './scenarios/combinedFeatures';
+
+runExportIntegrity(combinedFeatures);

--- a/src/features/generation/worker/generators/binGenerator.export.compartments.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.compartments.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { compartments } from './scenarios/compartments';
+
+runExportIntegrity(compartments);

--- a/src/features/generation/worker/generators/binGenerator.export.customShape.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.customShape.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { customShapes } from './scenarios/customShape';
+
+runExportIntegrity(customShapes);

--- a/src/features/generation/worker/generators/binGenerator.export.cutoutOffset.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.cutoutOffset.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { cutoutOffset } from './scenarios/cutoutOffset';
+
+runExportIntegrity(cutoutOffset);

--- a/src/features/generation/worker/generators/binGenerator.export.dimensions.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.dimensions.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { dimensions } from './scenarios/dimensions';
+
+runExportIntegrity(dimensions);

--- a/src/features/generation/worker/generators/binGenerator.export.dividerPatterns.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.dividerPatterns.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { dividerPatterns } from './scenarios/dividerPatterns';
+
+runExportIntegrity(dividerPatterns);

--- a/src/features/generation/worker/generators/binGenerator.export.edgeCases.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.edgeCases.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { edgeCases } from './scenarios/edgeCases';
+
+runExportIntegrity(edgeCases);

--- a/src/features/generation/worker/generators/binGenerator.export.exportAndLarge.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.exportAndLarge.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { exportMode, largeBin, asymmetric } from './scenarios/exportAndLarge';
+
+runExportIntegrity([...exportMode, ...largeBin, ...asymmetric]);

--- a/src/features/generation/worker/generators/binGenerator.export.floorPatterns.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.floorPatterns.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { floorPatterns } from './scenarios/floorPatterns';
+
+runExportIntegrity(floorPatterns);

--- a/src/features/generation/worker/generators/binGenerator.export.groupedScoop.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.groupedScoop.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { groupedScoop } from './scenarios/groupedScoop';
+
+runExportIntegrity(groupedScoop);

--- a/src/features/generation/worker/generators/binGenerator.export.halfSockets.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.halfSockets.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { halfSockets } from './scenarios/halfSockets';
+
+runExportIntegrity(halfSockets);

--- a/src/features/generation/worker/generators/binGenerator.export.handles.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.handles.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { handles } from './scenarios/handles';
+
+runExportIntegrity(handles);

--- a/src/features/generation/worker/generators/binGenerator.export.heights.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.heights.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { heightVariations } from './scenarios/heights';
+
+runExportIntegrity(heightVariations);

--- a/src/features/generation/worker/generators/binGenerator.export.honeycombJunction.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.honeycombJunction.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { honeycombJunction } from './scenarios/honeycombJunction';
+
+runExportIntegrity(honeycombJunction);

--- a/src/features/generation/worker/generators/binGenerator.export.inserts.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.inserts.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { inserts, multipleInserts } from './scenarios/inserts';
+
+runExportIntegrity([...inserts, ...multipleInserts]);

--- a/src/features/generation/worker/generators/binGenerator.export.integration.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.integration.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { integration } from './scenarios/integration';
+
+runExportIntegrity(integration);

--- a/src/features/generation/worker/generators/binGenerator.export.kumiko.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.kumiko.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { kumiko } from './scenarios/kumiko';
+
+runExportIntegrity(kumiko);

--- a/src/features/generation/worker/generators/binGenerator.export.labelSockets.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.labelSockets.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { labelSockets } from './scenarios/labelSockets';
+
+runExportIntegrity(labelSockets);

--- a/src/features/generation/worker/generators/binGenerator.export.labelTabs.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.labelTabs.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { labelTabs } from './scenarios/labelTabs';
+
+runExportIntegrity(labelTabs);

--- a/src/features/generation/worker/generators/binGenerator.export.lightweight.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.lightweight.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { lightweight } from './scenarios/lightweight';
+
+runExportIntegrity(lightweight);

--- a/src/features/generation/worker/generators/binGenerator.export.lipWall.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.lipWall.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { lipWall } from './scenarios/lipWall';
+
+runExportIntegrity(lipWall);

--- a/src/features/generation/worker/generators/binGenerator.export.pathfinderOps.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.pathfinderOps.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { pathfinderOps } from './scenarios/pathfinderOps';
+
+runExportIntegrity(pathfinderOps);

--- a/src/features/generation/worker/generators/binGenerator.export.permutationMatrix.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.permutationMatrix.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { permutationMatrix } from './scenarios/permutationMatrix';
+
+runExportIntegrity(permutationMatrix);

--- a/src/features/generation/worker/generators/binGenerator.export.regressions.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.regressions.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { regressions } from './scenarios/regressions';
+
+runExportIntegrity(regressions);

--- a/src/features/generation/worker/generators/binGenerator.export.scoops.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.scoops.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { scoop, scoopTwoVariable, scoopLipInteraction } from './scenarios/scoops';
+
+runExportIntegrity([...scoop, ...scoopTwoVariable, ...scoopLipInteraction]);

--- a/src/features/generation/worker/generators/binGenerator.export.slotted.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.slotted.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { slottedVariations } from './scenarios/slotted';
+
+runExportIntegrity(slottedVariations);

--- a/src/features/generation/worker/generators/binGenerator.export.solidCutoutMatrix.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.solidCutoutMatrix.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { solidCutoutMatrix } from './scenarios/solidCutoutMatrix';
+
+runExportIntegrity(solidCutoutMatrix);

--- a/src/features/generation/worker/generators/binGenerator.export.solidCutouts.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.solidCutouts.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { solidCutouts } from './scenarios/solidCutouts';
+
+runExportIntegrity(solidCutouts);

--- a/src/features/generation/worker/generators/binGenerator.export.solidMode.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.solidMode.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { solidMode } from './scenarios/solidMode';
+
+runExportIntegrity(solidMode);

--- a/src/features/generation/worker/generators/binGenerator.export.spacer.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.spacer.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { spacer } from './scenarios/spacer';
+
+runExportIntegrity(spacer);

--- a/src/features/generation/worker/generators/binGenerator.export.wallCutouts.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.wallCutouts.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { wallCutouts } from './scenarios/wallCutouts';
+
+runExportIntegrity(wallCutouts);

--- a/src/features/generation/worker/generators/binGenerator.export.wallPatterns.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.wallPatterns.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { wallPatterns } from './scenarios/wallPatterns';
+
+runExportIntegrity(wallPatterns);

--- a/src/features/generation/worker/generators/binGenerator.export.wallThickness.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.wallThickness.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { wallThickness } from './scenarios/wallThickness';
+
+runExportIntegrity(wallThickness);

--- a/src/features/generation/worker/generators/binGenerator.scenarioCoverage.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenarioCoverage.test.ts
@@ -2,19 +2,28 @@
 /**
  * Guards the one-file-per-scenario-domain convention:
  *   1. every scenario module under `./scenarios/` is aggregated into
- *      `ALL_SCENARIOS` (i.e. wired into `scenarios/index.ts`), and
+ *      `ALL_SCENARIOS` (i.e. wired into `scenarios/index.ts`),
  *   2. every scenario module has a matching
- *      `binGenerator.scenario.<module>.test.ts` that runs it.
+ *      `binGenerator.scenario.<module>.test.ts` that generates it, and
+ *   3. every scenario module has a matching
+ *      `binGenerator.export.<module>.test.ts` that exports it.
  *
  * Without this, adding a `scenarios/<domain>.ts` module but forgetting to wire
- * it into `index.ts` or to add its test file would silently skip those
- * scenarios. Pure data / filesystem checks — no WASM kernel, so it stays fast.
+ * it into `index.ts` or to add its test files would silently skip those
+ * scenarios. Check 3 matters most: the export matrix used to be a single file
+ * looping `ALL_SCENARIOS`, which was complete by construction but pinned one
+ * Vitest worker for ~14 minutes and set the whole CI critical path. Splitting it
+ * per domain bought the parallelism back and traded that automatic completeness
+ * for per-file wiring — this is what keeps the trade honest.
+ *
+ * Pure data / filesystem checks — no WASM kernel, so it stays fast.
  */
 import { describe, it, expect } from 'vitest';
 import { ALL_SCENARIOS } from './binGenerator.scenarios';
 
 const moduleGlob = import.meta.glob('./scenarios/*.ts', { eager: true });
 const testFileGlob = import.meta.glob('./binGenerator.scenario.*.test.ts');
+const exportFileGlob = import.meta.glob('./binGenerator.export.*.test.ts');
 
 function moduleName(path: string): string {
   return path.split('/').pop()?.replace(/\.ts$/, '') ?? '';
@@ -42,5 +51,21 @@ describe('binGenerator scenario domain coverage', () => {
       (name) => !testFiles.has(`binGenerator.scenario.${name}.test.ts`)
     );
     expect(missing).toEqual([]);
+  });
+
+  it('has an export-integrity file for every scenario module', () => {
+    const exportFiles = new Set(Object.keys(exportFileGlob).map((path) => path.split('/').pop()));
+    const missing = moduleNames.filter(
+      (name) => !exportFiles.has(`binGenerator.export.${name}.test.ts`)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('runs every catalog scenario through export exactly once', () => {
+    // The per-domain export files partition the catalog; a module wired into two
+    // of them (or into one under the wrong name) would double-run or drop
+    // scenarios without the file-presence check above noticing.
+    const exported = moduleNames.length;
+    expect(Object.keys(exportFileGlob)).toHaveLength(exported);
   });
 });


### PR DESCRIPTION
## The problem

CI wall time was set by **one test file**.

Job durations from a representative run:

| Job | Time |
|---|---|
| **Unit Tests (generators 2/3)** | **872s** |
| Unit Tests (generators 1/3) | 271s |
| Unit Tests (generators 3/3) | 260s |
| Unit Tests (core 1–3/3) | 171–197s |
| Quality | 192s |
| Build | 40s |

Not a fluke — six consecutive runs put `generators 2/3` at **872, 1117, 1183, 1084, 1096, 1091s** while its siblings stayed at 210–351s.

Inside that shard it was one file:

- `binGenerator.scenario.export-integrity.test.ts` — **831s (13m51s)**, 445 tests
- `binGenerator.scenario.kumiko.test.ts` — 301s
- every other file on the shard — ≤ 46s

**Sharding could not fix this.** Vitest parallelizes across files but never within one, and `--shard` divides by file-path hash — so one file is one worker, strictly serial, and a shard's wall time is bounded below by its longest file. The `ci.yml` comment targets "~150–170s each"; it was missing by 6–8× because that file looped all 407 catalog scenarios in a single `describe`.

## The fix

This repo already solved the identical problem for the other half of the same catalog. `scenarioRunner.ts` records that the generation matrix "used to share one ~370s file" and was split into one file per scenario domain "so Vitest runs them on separate workers in parallel". The export matrix never got that treatment.

This applies the same shape:

- the harness — kernel-poison recovery, STL topology analysis, the measure-zero self-contact carve-out — moves to a shared `__kernel-tests__/exportIntegrityRunner.ts`;
- 35 `binGenerator.export.<domain>.test.ts` files call it with their domain's scenarios, mirroring the generation files one-for-one.

**No assertion changed.** The runner is the old file's body with the scenario list as a parameter.

## Measured

- Same **445 tests**, before and after.
- **978s of test CPU now completes in 377s wall** locally, purely because it can run in parallel at all. In the old form 831s of CPU took 831s of wall by construction.
- No remaining export file exceeds ~330s (kumiko — which is already the long pole in the generation matrix), so the generators shard is no longer pinned by a 14-minute serial file.
- Full generation project: 252 files, 2588 passed, 0 failures.

## Keeping it honest

A `for (const scenario of ALL_SCENARIOS)` loop cannot miss a scenario; 35 hand-wired files can. So `binGenerator.scenarioCoverage.test.ts` now also requires an export file per scenario module, next to the generation file it already required — a new `scenarios/<domain>.ts` fails the guard until both are wired.

## Next lever

Kumiko is now the longest file in both matrices (~300s generation, ~330s export) and will set the floor once this lands. Splitting `scenarios/kumiko.ts` into two modules would halve it; worth doing as a follow-up if CI is still slower than you want.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the export-integrity tests into one file per scenario domain to let Vitest run them in parallel and remove the 14-minute CI bottleneck. Shared the harness in a runner and added a guard to keep coverage complete; test count and assertions stay the same.

- **Refactors**
  - Moved the export-integrity harness to `__kernel-tests__/exportIntegrityRunner.ts`.
  - Added 35 `binGenerator.export.<domain>.test.ts` files that call the runner.
  - Extended `binGenerator.scenarioCoverage.test.ts` to require a matching export file for each scenario module and ensure a 1:1 partition.
  - Documented the one-file-per-domain requirement in `README.md`.
  - Performance: same 445 tests now run in parallel (local: ~978s CPU in ~377s wall); no single file exceeds ~330s, so the shard is no longer pinned.

<sup>Written for commit 975b44d030cb586a967ae55a10584597cea94205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

