### PR TITLE
perf(ci): give the generators group 6 shards now that it is CPU-bound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,22 @@ jobs:
           project-id: ${{ secrets.POSTHOG_PROJECT_ID }}
           api-key: ${{ secrets.POSTHOG_API_KEY }}
 
-  # PRs: Split into two test groups for fast, balanced feedback (6 runners).
+  # PRs: Split into two test groups for fast, balanced feedback (9 runners).
   #   Vitest shards by hashing the file path, not by duration, so the heavy
   #   brepjs/OpenCascade WASM generator tests (their own `generators` project)
   #   would otherwise cluster onto one shard and dominate wall time. Running
-  #   them on dedicated shards decouples that bottleneck from hash luck. After
-  #   the scenario monolith was split (#2017) the generator floor is ~166s
-  #   (split-robustness), so both groups get 3 shards to land ~150-170s each.
+  #   them on dedicated shards decouples that bottleneck from hash luck.
+  #
+  #   Generators get 6 shards, core 3. The asymmetry is the point: generators
+  #   carry ~3700s of WASM test CPU against core's few hundred, and a shard is
+  #   bounded below by BOTH its longest single file and its own CPU ÷ workers
+  #   (4 on a standard runner). Until #2882 the first bound dominated — one
+  #   14-minute export file that no amount of sharding could divide, since
+  #   `--shard` splits by file path and Vitest never parallelizes within a file.
+  #   With that file split per domain the generators group became CPU-bound
+  #   instead (767s wall against a ~330s longest file), which is the regime where
+  #   adding shards actually buys wall time. Past ~6 the per-shard fixed cost
+  #   (checkout + install + WASM init) starts eating the gain.
   # Main: Full test suite (all projects) with coverage thresholds, single runner.
   test:
     name: Unit Tests (${{ matrix.name }})
@@ -66,7 +75,7 @@ jobs:
       matrix:
         include: >-
           ${{ github.event_name == 'pull_request'
-          && fromJSON('[{"name":"generators 1/3","group":"generators","shard":"1/3"},{"name":"generators 2/3","group":"generators","shard":"2/3"},{"name":"generators 3/3","group":"generators","shard":"3/3"},{"name":"core 1/3","group":"core","shard":"1/3"},{"name":"core 2/3","group":"core","shard":"2/3"},{"name":"core 3/3","group":"core","shard":"3/3"}]')
+          && fromJSON('[{"name":"generators 1/6","group":"generators","shard":"1/6"},{"name":"generators 2/6","group":"generators","shard":"2/6"},{"name":"generators 3/6","group":"generators","shard":"3/6"},{"name":"generators 4/6","group":"generators","shard":"4/6"},{"name":"generators 5/6","group":"generators","shard":"5/6"},{"name":"generators 6/6","group":"generators","shard":"6/6"},{"name":"core 1/3","group":"core","shard":"1/3"},{"name":"core 2/3","group":"core","shard":"2/3"},{"name":"core 3/3","group":"core","shard":"3/3"}]')
           || fromJSON('[{"name":"full","group":"full","shard":"1/1"}]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Follow-up to #2882, which is what makes this worth doing.

## Why now and not before

A shard's wall time is bounded below by **both**:
1. its longest single test file, and
2. its own CPU ÷ the runner's workers (4 on a standard runner).

Before #2882 bound (1) dominated: a single 14-minute export file. `--shard` divides by file path and Vitest never parallelizes within a file, so adding shards would have bought nothing — that file would just have landed on one of them.

#2882 split it per domain, and the measured result showed the regime change:

| | worst generators shard | longest file |
|---|---|---|
| before #2882 | 872–1183s | 831s (export-integrity) |
| after #2882 | **767s** | ~330s (kumiko) |

767s against a 330s longest file means bound (2) is now binding — the group is CPU-bound. That's the regime where more shards convert directly into wall time.

## Change

Generators 3 → 6 shards; core stays at 3. The asymmetry is deliberate: generators carry ~3700s of WASM test CPU against core's few hundred (core shards already finish in 138–190s, so splitting them further would just pay fixed setup cost for nothing).

Runners go 6 → 9 for PR runs.

## Expected

~3700s of generator CPU across 6 shards × 4 workers, plus per-shard fixed cost (checkout + install + WASM init), should land the group around 250–350s — versus 767s today. The PR's own CI run measures it.

Past ~6 shards the fixed cost starts eating the gain, which is why this stops there rather than going to 8 or 12.

The completion gate reads `needs.test.result` rather than shard names, so the branch ruleset needs no update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase generator test shards from 3 to 6 and bump PR runners to 9 to cut CI wall time now that generators are CPU-bound. Core stays at 3 shards.

- **Performance**
  - Generators run across 6 shards; core remains 3. PR matrix now has 9 runners.
  - Expected generators wall time: ~250–350s (down from ~767s). After #2882 the group is CPU-bound, so more shards help. `needs.test.result` gating means no branch rules change.

<sup>Written for commit 84d4dc07aa6bfd5f1aac34f093750f3b8c00ae0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

