### PR TITLE
fix(bin-designer): persist pending design edits when leaving the designer

### DIFF
--- a/src/features/bin-designer/hooks/useAutoSave.test.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.test.ts
@@ -349,6 +349,71 @@ describe('useAutoSave', () => {
       unsubscribe();
     });
 
+    it('does not duplicate a write for the save already in flight', async () => {
+      let resolveWrite: ((value: unknown) => void) | null = null;
+      vi.mocked(DesignerStorage.updateDesignParams).mockReturnValue(
+        new Promise((resolve) => {
+          resolveWrite = resolve;
+        })
+      );
+      useDesignerStore.setState({ currentDesignId: 'existing-id' });
+
+      const { unmount } = renderHook(() => useAutoSave());
+
+      act(() => {
+        useDesignerStore.getState().setParam('width', 4);
+      });
+
+      // Let the save reach updateDesignParams, where it now blocks.
+      await advanceThroughSave();
+      expect(DesignerStorage.updateDesignParams).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        unmount();
+      });
+
+      expect(DesignerStorage.updateDesignParams).toHaveBeenCalledOnce();
+      expect(resolveWrite).not.toBeNull();
+    });
+
+    // The in-flight save carries older params, so the newer edit still needs
+    // flushing rather than being swallowed by the dedupe above.
+    it('still flushes when the in-flight save is for older params', async () => {
+      let resolveWrite: ((value: unknown) => void) | null = null;
+      vi.mocked(DesignerStorage.updateDesignParams).mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveWrite = resolve;
+        })
+      );
+      useDesignerStore.setState({ currentDesignId: 'existing-id' });
+
+      const { unmount } = renderHook(() => useAutoSave());
+
+      act(() => {
+        useDesignerStore.getState().setParam('width', 4);
+      });
+      await advanceThroughSave();
+      expect(DesignerStorage.updateDesignParams).toHaveBeenCalledOnce();
+
+      mockUpdateDesignParams();
+      act(() => {
+        useDesignerStore.getState().setParam('width', 9);
+      });
+
+      await act(async () => {
+        unmount();
+      });
+
+      expect(DesignerStorage.updateDesignParams).toHaveBeenCalledTimes(2);
+      expect(DesignerStorage.updateDesignParams).toHaveBeenLastCalledWith(
+        'existing-id',
+        expect.objectContaining({ width: 9 }),
+        undefined,
+        expect.anything()
+      );
+      expect(resolveWrite).not.toBeNull();
+    });
+
     it('does not write when nothing changed since the last save', async () => {
       mockUpdateDesignParams();
       useDesignerStore.setState({ currentDesignId: 'existing-id' });

--- a/src/features/bin-designer/hooks/useAutoSave.test.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.test.ts
@@ -4,7 +4,9 @@ import { useAutoSave } from './useAutoSave';
 import { useDesignerStore } from '../store/designer';
 import * as DesignerStorage from '@/features/bin-designer/storage/DesignerStorage';
 import { ok, err, storageUnavailable } from '@/core/result';
+import { onSyncEvent } from '@/shared/events/syncEventBus';
 import { DEFAULT_BIN_PARAMS } from '../constants/defaults';
+import { loadRegistry } from '../store/customBinRegistry';
 import type { SavedDesign } from '../types';
 
 vi.mock('@/features/bin-designer/storage/DesignerStorage');
@@ -264,5 +266,121 @@ describe('useAutoSave', () => {
     await advanceThroughSave();
 
     expect(DesignerStorage.updateDesignParams).toHaveBeenCalledOnce();
+  });
+
+  // Leaving the designer unmounts the hook. Both the debounce and the
+  // generation wait used to be aborted, so the last edits never reached
+  // IndexedDB while the in-memory store kept showing them (#2895).
+  describe('flush on unmount', () => {
+    it('persists a pending edit when unmounted inside the debounce window', async () => {
+      mockUpdateDesignParams();
+      useDesignerStore.setState({ currentDesignId: 'existing-id' });
+
+      const { unmount } = renderHook(() => useAutoSave());
+
+      act(() => {
+        useDesignerStore.getState().setParam('width', 4);
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+        unmount();
+      });
+
+      expect(DesignerStorage.updateDesignParams).toHaveBeenCalledWith(
+        'existing-id',
+        expect.objectContaining({ width: 4 }),
+        undefined, // thumbnail untouched — the canvas is already gone
+        expect.objectContaining({ style: 'descriptive', customName: '' })
+      );
+    });
+
+    it('persists an edit whose save was still waiting on generation', async () => {
+      mockUpdateDesignParams();
+      useDesignerStore.setState({
+        currentDesignId: 'existing-id',
+        generation: { status: 'generating', mesh: null, progress: 0, epoch: 0 },
+      });
+
+      const { unmount } = renderHook(() => useAutoSave());
+
+      act(() => {
+        useDesignerStore.getState().setParam('width', 6);
+      });
+
+      // Debounce elapses; the save is parked in waitForGenerationComplete.
+      await act(async () => {
+        vi.advanceTimersByTime(1100);
+      });
+      expect(DesignerStorage.updateDesignParams).not.toHaveBeenCalled();
+
+      await act(async () => {
+        unmount();
+      });
+
+      expect(DesignerStorage.updateDesignParams).toHaveBeenCalledWith(
+        'existing-id',
+        expect.objectContaining({ width: 6 }),
+        undefined,
+        expect.anything()
+      );
+    });
+
+    it('updates the registry and notifies linked bins when flushing', async () => {
+      mockUpdateDesignParams();
+      useDesignerStore.setState({ currentDesignId: 'existing-id' });
+      const onDesignSaved = vi.fn();
+      const unsubscribe = onSyncEvent('design-saved', onDesignSaved);
+
+      const { unmount } = renderHook(() => useAutoSave());
+
+      act(() => {
+        useDesignerStore.getState().setParam('width', 4);
+      });
+
+      await act(async () => {
+        unmount();
+      });
+
+      expect(loadRegistry()).toContainEqual(expect.objectContaining({ id: 'existing-id' }));
+      expect(onDesignSaved).toHaveBeenCalledWith(
+        expect.objectContaining({ designId: 'existing-id' })
+      );
+      unsubscribe();
+    });
+
+    it('does not write when nothing changed since the last save', async () => {
+      mockUpdateDesignParams();
+      useDesignerStore.setState({ currentDesignId: 'existing-id' });
+
+      const { unmount } = renderHook(() => useAutoSave());
+
+      act(() => {
+        useDesignerStore.getState().setParam('width', 4);
+      });
+      await advanceThroughSave();
+      expect(DesignerStorage.updateDesignParams).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        unmount();
+      });
+
+      expect(DesignerStorage.updateDesignParams).toHaveBeenCalledOnce();
+    });
+
+    it('does not write for an unsaved design', async () => {
+      mockUpdateDesignParams();
+      const { unmount } = renderHook(() => useAutoSave());
+
+      act(() => {
+        useDesignerStore.getState().setParam('width', 4);
+      });
+
+      await act(async () => {
+        unmount();
+      });
+
+      expect(DesignerStorage.updateDesignParams).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -90,6 +90,10 @@ export function useAutoSave(): void {
   const lastDesignId = useRef<string | null>(null);
   // Abort token for the current pending save (new object per effect run)
   const abortTokenRef = useRef<{ current: boolean }>({ current: false });
+  // What a save currently past its abort checks is writing. `lastSaved*` only
+  // updates once the write resolves, so without this the unmount flush would
+  // re-issue an identical write for a save already in flight.
+  const inFlight = useRef<{ params: BinParams; config: ExportFileNameConfig } | null>(null);
 
   // The write itself plus the bookkeeping every consumer downstream depends on
   // (registry entry for the planner palette, `design-saved` for linked bins).
@@ -102,12 +106,24 @@ export function useAutoSave(): void {
       designId: string,
       thumbnail: string | null | undefined
     ): Promise<boolean> => {
-      const result = await updateDesignParams(
-        toDesignId(designId),
-        paramsToSave,
-        thumbnail,
-        configToSave
-      );
+      inFlight.current = { params: paramsToSave, config: configToSave };
+      let result;
+      try {
+        result = await updateDesignParams(
+          toDesignId(designId),
+          paramsToSave,
+          thumbnail,
+          configToSave
+        );
+      } finally {
+        // Only clear if a newer persist hasn't already claimed the slot.
+        if (
+          inFlight.current?.params === paramsToSave &&
+          inFlight.current?.config === configToSave
+        ) {
+          inFlight.current = null;
+        }
+      }
       if (!isOk(result)) return false;
 
       lastSavedParams.current = paramsToSave;
@@ -240,6 +256,14 @@ export function useAutoSave(): void {
       if (
         lastSavedParams.current === state.params &&
         lastSavedConfig.current === state.exportFileNameConfig
+      ) {
+        return;
+      }
+      // A save already writing exactly this will land on its own; an in-flight
+      // save for older params still needs the flush.
+      if (
+        inFlight.current?.params === state.params &&
+        inFlight.current?.config === state.exportFileNameConfig
       ) {
         return;
       }

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -91,6 +91,54 @@ export function useAutoSave(): void {
   // Abort token for the current pending save (new object per effect run)
   const abortTokenRef = useRef<{ current: boolean }>({ current: false });
 
+  // The write itself plus the bookkeeping every consumer downstream depends on
+  // (registry entry for the planner palette, `design-saved` for linked bins).
+  // Deliberately un-abortable: once we've decided to persist, dropping the
+  // registry/event half would leave the layout pointing at a stale design.
+  const persist = useCallback(
+    async (
+      paramsToSave: BinParams,
+      configToSave: ExportFileNameConfig,
+      designId: string,
+      thumbnail: string | null | undefined
+    ): Promise<boolean> => {
+      const result = await updateDesignParams(
+        toDesignId(designId),
+        paramsToSave,
+        thumbnail,
+        configToSave
+      );
+      if (!isOk(result)) return false;
+
+      lastSavedParams.current = paramsToSave;
+      lastSavedConfig.current = configToSave;
+      // Track active design for session restoration
+      setActiveDesignId(result.value.id);
+      // Sync lightweight ref to registry for Layout Planner
+      upsertRegistryEntry({
+        id: result.value.id,
+        name: result.value.name,
+        width: paramsToSave.width,
+        depth: paramsToSave.depth,
+        height: paramsToSave.height,
+        ...registryEdgeFields(paramsToSave),
+        updatedAt: result.value.updatedAt,
+      });
+      // Notify design-linking to auto-sync linked bins
+      emitSyncEvent({
+        type: 'design-saved',
+        designId: result.value.id,
+        dimensions: {
+          width: paramsToSave.width,
+          depth: paramsToSave.depth,
+          height: paramsToSave.height,
+        },
+      });
+      return true;
+    },
+    []
+  );
+
   const performSave = useCallback(
     async (
       paramsToSave: BinParams,
@@ -119,44 +167,10 @@ export function useAutoSave(): void {
         heightUnitMm: paramsToSave.heightUnitMm,
       });
 
-      const result = await updateDesignParams(
-        toDesignId(designId),
-        paramsToSave,
-        thumbnail,
-        configToSave
-      );
-      if (abortToken.current) return; // Superseded by newer save
-      if (isOk(result)) {
-        lastSavedParams.current = paramsToSave;
-        lastSavedConfig.current = configToSave;
-        setSaveStatus('saved');
-        // Track active design for session restoration
-        setActiveDesignId(result.value.id);
-        // Sync lightweight ref to registry for Layout Planner
-        upsertRegistryEntry({
-          id: result.value.id,
-          name: result.value.name,
-          width: paramsToSave.width,
-          depth: paramsToSave.depth,
-          height: paramsToSave.height,
-          ...registryEdgeFields(paramsToSave),
-          updatedAt: result.value.updatedAt,
-        });
-        // Notify design-linking to auto-sync linked bins
-        emitSyncEvent({
-          type: 'design-saved',
-          designId: result.value.id,
-          dimensions: {
-            width: paramsToSave.width,
-            depth: paramsToSave.depth,
-            height: paramsToSave.height,
-          },
-        });
-      } else {
-        setSaveStatus('error');
-      }
+      const saved = await persist(paramsToSave, configToSave, designId, thumbnail);
+      setSaveStatus(saved ? 'saved' : 'error');
     },
-    [setSaveStatus]
+    [setSaveStatus, persist]
   );
 
   useEffect(() => {
@@ -211,4 +225,25 @@ export function useAutoSave(): void {
       }
     };
   }, [params, exportFileNameConfig, currentDesignId, performSave]);
+
+  // Leaving the designer (route change) unmounts this hook, which aborts both
+  // the debounce and any save still waiting on generation — a window of up to
+  // ~6s in which the user's last edits were silently dropped while the
+  // in-memory store kept showing them (#2895). Flush straight to storage
+  // instead. No thumbnail: the canvas is already gone, and passing `undefined`
+  // keeps the stored one until useBackgroundThumbnailRegen refreshes it.
+  useEffect(() => {
+    return () => {
+      const state = useDesignerStore.getState();
+      const id = state.currentDesignId;
+      if (!id) return;
+      if (
+        lastSavedParams.current === state.params &&
+        lastSavedConfig.current === state.exportFileNameConfig
+      ) {
+        return;
+      }
+      void persist(state.params, state.exportFileNameConfig, id, undefined);
+    };
+  }, [persist]);
 }


### PR DESCRIPTION
Fixes #2895.

## The bug

Exporting bins from the layout — either the bulk export from the bin list or the single-bin export in the inspector — produced stale geometry, typically the design's creation-time defaults. Filenames were right, the meshes were not. Exporting the same design from inside the bin designer worked.

## Root cause

Layout export resolves designs from IndexedDB via `loadDesign`; the designer exports from its live store. That asymmetry only matters if the two disagree — and they did.

`useAutoSave` is mounted inside `DesignerPage`, so leaving the designer unmounts it. Its effect cleanup aborted the pending save:

```js
return () => { abortToken.current = true; clearTimeout(timerRef.current); };
```

Between the 1s debounce and `waitForGenerationComplete` (up to 5s, plus a 150ms render settle), there was a window of roughly six seconds in which navigating back to the layout silently discarded the write. Cutout-heavy designs sat at the wide end of that window because generation is slow.

The designer store is module-level, so it survives the route change and kept rendering the user's edits. Nothing surfaced the loss until an export read the actual stored record.

A second, quieter half: even when the write landed, `if (abortToken.current) return;` sat *after* `updateDesignParams`, so a superseded save could persist params while skipping the registry upsert and the `design-saved` event. The planner palette and the linked-bin mesh cache key off `registry.updatedAt`, so the layout could keep a stale mesh for a design that had in fact been rewritten.

## The fix

Split `persist` (the write plus the bookkeeping every downstream consumer depends on) out of the abortable thumbnail phase, and flush unsaved params on unmount.

The flush passes `undefined` for the thumbnail rather than capturing one — the canvas is already gone, and `updateDesignParams` treats `undefined` as "leave the stored thumbnail alone", so `useBackgroundThumbnailRegen` refreshes it later.

## Tests

Five regression tests in `useAutoSave.test.ts`, all of which fail on `main`:

- persists a pending edit when unmounted inside the debounce window
- persists an edit whose save was still waiting on generation
- updates the registry and notifies linked bins when flushing
- does not write when nothing changed since the last save
- does not write for an unsaved design

The 8 pre-existing tests still pass, as do `src/features/bin-designer/hooks` and `src/features/design-linking` (429 tests). Typecheck and lint clean.

## Not covered

Closing the tab mid-window still loses the edit — `beforeunload` cannot await an IndexedDB write. That is a separate, narrower gap than route navigation, which is what #2895 describes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist pending design edits when leaving the designer to fix stale geometry in layout exports, and dedupe unmount saves to prevent duplicate writes and events.

- **Bug Fixes**
  - Split persistence from the abortable thumbnail step so registry updates and `design-saved` events are never dropped.
  - Flush unsaved params on unmount; pass `undefined` thumbnail and let background regen refresh it later.
  - Dedupe saves: track last-saved and in-flight params/config to skip identical writes and events; still flush if the in-flight save has older params.

- **Tests**
  - Added regression tests covering flush during debounce/generation, registry updates and event emission, in-flight save dedupe, and no-op cases.

<sup>Written for commit 344c4fee28783791289a3a9763a7d545732f908e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

