### PR TITLE
fix(cloud-share): carry linked bin designs through share links

### DIFF
--- a/api/lib/contentFilter.test.ts
+++ b/api/lib/contentFilter.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { filterDisplayName, filterLayoutContent } from '../../api/lib/contentFilter.js';
+import {
+  filterDisplayName,
+  filterLayoutContent,
+  filterSharedDesignsContent,
+} from '../../api/lib/contentFilter.js';
 
 describe('filterLayoutContent', () => {
   describe('clean content', () => {
@@ -312,5 +316,78 @@ describe('filterDisplayName', () => {
     const started = performance.now();
     filterDisplayName('on'.repeat(100_000));
     expect(performance.now() - started).toBeLessThan(150);
+  });
+});
+
+// Designs riding along with a shared layout carry user-authored names and
+// engraved text shown to whoever opens the link; without this they were a way
+// around layout moderation entirely.
+describe('filterSharedDesignsContent', () => {
+  const design = (over: Record<string, unknown> = {}) => ({
+    name: 'Socket Tray',
+    params: { width: 2, depth: 2 },
+    ...over,
+  });
+
+  it('passes clean designs', () => {
+    expect(filterSharedDesignsContent([design()]).passed).toBe(true);
+  });
+
+  it('passes an empty set', () => {
+    expect(filterSharedDesignsContent([]).passed).toBe(true);
+  });
+
+  it('blocks an offensive design name', () => {
+    const result = filterSharedDesignsContent([design({ name: 'retard box' })]);
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('Design name');
+  });
+
+  it('blocks offensive text engraved on a wall', () => {
+    const result = filterSharedDesignsContent([
+      design({ params: { surfaceText: { front: { text: 'kill yourself' } } } }),
+    ]);
+
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('text');
+  });
+
+  it('blocks an offensive cutout label nested in an array', () => {
+    const result = filterSharedDesignsContent([
+      design({ params: { cutouts: [{ id: 'c1', label: 'faggot' }] } }),
+    ]);
+
+    expect(result.passed).toBe(false);
+  });
+
+  it('blocks a harmful pattern in engraved text', () => {
+    const result = filterSharedDesignsContent([
+      design({ params: { surfaceText: { front: { text: 'https://evil.example' } } } }),
+    ]);
+
+    expect(result.passed).toBe(false);
+  });
+
+  // Enum values, hex colours and font names share the params tree; running
+  // them through the blocklist would be noise, so only text-bearing keys count.
+  it('ignores non-text string values', () => {
+    const result = filterSharedDesignsContent([
+      design({ params: { style: 'solid', featureColors: { body: '#aabbcc' }, fontFamily: 'kys' } }),
+    ]);
+
+    expect(result.passed).toBe(true);
+  });
+
+  it('tolerates params that are not an object', () => {
+    expect(filterSharedDesignsContent([design({ params: null })]).passed).toBe(true);
+    expect(filterSharedDesignsContent([design({ params: 'nonsense' })]).passed).toBe(true);
+  });
+
+  it('terminates on deeply nested params', () => {
+    let deep: Record<string, unknown> = { text: 'clean' };
+    for (let i = 0; i < 200; i++) deep = { nested: deep };
+
+    expect(filterSharedDesignsContent([design({ params: deep })]).passed).toBe(true);
   });
 });

--- a/api/lib/contentFilter.ts
+++ b/api/lib/contentFilter.ts
@@ -209,6 +209,67 @@ function checkText(text: string): ContentFilterResult {
 }
 
 /**
+ * Object keys whose *string* values are user-authored prose rendered to the
+ * recipient — engraved surface text, cutout labels. Keyed rather than scanning
+ * every string so enum values, hex colours, font names and ids don't get run
+ * through the blocklist.
+ */
+const TEXT_BEARING_KEYS = new Set(['text', 'label', 'name']);
+
+/** Bounds the walk over attacker-supplied params (depth and total strings). */
+const MAX_PARAM_DEPTH = 8;
+const MAX_TEXT_FIELDS = 500;
+
+/** Collect user-authored strings nested anywhere inside a design's params. */
+function collectDesignText(value: unknown, out: string[], depth = 0): void {
+  if (depth > MAX_PARAM_DEPTH || out.length >= MAX_TEXT_FIELDS) return;
+
+  if (Array.isArray(value)) {
+    for (const entry of value) collectDesignText(entry, out, depth + 1);
+    return;
+  }
+  if (typeof value !== 'object' || value === null) return;
+
+  for (const [key, nested] of Object.entries(value)) {
+    if (out.length >= MAX_TEXT_FIELDS) return;
+    if (typeof nested === 'string') {
+      if (TEXT_BEARING_KEYS.has(key)) out.push(nested);
+    } else {
+      collectDesignText(nested, out, depth + 1);
+    }
+  }
+}
+
+/**
+ * Check the bin designs travelling with a shared layout.
+ *
+ * Design names and the text engraved into their geometry are user-authored and
+ * shown to whoever opens the link, so they need the same moderation the layout
+ * itself gets — otherwise `linkedDesigns` is a way around it.
+ */
+export function filterSharedDesignsContent(
+  designs: ReadonlyArray<{ name: string; params: unknown }>
+): ContentFilterResult {
+  for (const design of designs) {
+    const nameResult = checkText(design.name);
+    if (!nameResult.passed) {
+      return { passed: false, reason: `Design name: ${nameResult.reason}` };
+    }
+
+    const texts: string[] = [];
+    collectDesignText(design.params, texts);
+    for (const text of texts) {
+      const result = checkText(text);
+      if (!result.passed) {
+        return { passed: false, reason: `Design "${design.name}" text: ${result.reason}` };
+      }
+    }
+  }
+
+  return { passed: true };
+}
+
+/**
  * Increment report count for a share.
  * If threshold exceeded, content should be reviewed/removed.
  */

--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -148,6 +148,12 @@ export const SHARE_LAST_ACCESSED_TTL_SECONDS = 365 * 24 * 60 * 60;
  */
 export interface ShareData {
   layout: unknown;
+  /**
+   * Bin designs referenced by the layout's `bin.linkedDesignId`s. Stored
+   * alongside rather than inside the layout so the client-side `Layout` type
+   * stays free of share-only fields. Absent on pre-#2894 shares.
+   */
+  linkedDesigns?: unknown;
   metadata: ShareMetadata;
 }
 

--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -4,7 +4,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { validateShareLayout, validateExpiration } from '../../api/lib/validation.js';
+import {
+  validateShareLayout,
+  validateExpiration,
+  validateSharedDesigns,
+} from '../../api/lib/validation.js';
 
 interface TestBin {
   id: string;
@@ -18,6 +22,7 @@ interface TestBin {
   label: string;
   notes: string;
   customProperties?: Record<string, string>;
+  linkedDesignId?: string;
 }
 
 // Helper to create a valid layout for testing
@@ -837,5 +842,128 @@ describe('drawer outline validation (issue #2528)', () => {
       ],
     };
     expect(validateShareLayout(layoutWithOutline(overlapping)).valid).toBe(false);
+  });
+});
+
+// A shared layout whose bins lose their design reference arrives as plain
+// boxes the recipient can neither preview nor print (#2894).
+describe('linked designs', () => {
+  it('preserves linkedDesignId through bin sanitization', () => {
+    const layout = createValidLayout();
+    layout.bins[0].linkedDesignId = 'design_1730000000000_ab12cd';
+
+    const result = validateShareLayout(layout, 1000);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.layout.bins[0].linkedDesignId).toBe('design_1730000000000_ab12cd');
+    }
+  });
+
+  it('leaves linkedDesignId undefined when the bin has no design', () => {
+    const result = validateShareLayout(createValidLayout(), 1000);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.layout.bins[0].linkedDesignId).toBeUndefined();
+    }
+  });
+
+  it('rejects a non-string linkedDesignId', () => {
+    const layout = createValidLayout();
+    (layout.bins[0] as unknown as Record<string, unknown>).linkedDesignId = 42;
+
+    expect(validateShareLayout(layout, 1000).valid).toBe(false);
+  });
+});
+
+describe('validateSharedDesigns', () => {
+  // Mirrors the fixture in designerValidation.test.ts — each design's params go
+  // through that same validator.
+  const validParams = () => ({
+    width: 2,
+    depth: 2,
+    height: 6,
+    style: 'standard',
+    scoop: true,
+    base: {
+      style: 'magnet',
+      magnetDiameter: 6.2,
+      magnetDepth: 2.4,
+      screwDiameter: 3,
+      stackingLip: true,
+    },
+    compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+    label: { enabled: false, support: 'bracket', depth: 12, width: 100, alignment: 'center' },
+    walls: { front: 0, back: 0, left: 0, right: 0 },
+    inserts: [] as Record<string, unknown>[],
+  });
+  const design = (over: Record<string, unknown> = {}) => ({
+    id: 'design_1',
+    name: 'Socket Tray',
+    params: validParams(),
+    ...over,
+  });
+
+  it('treats absent designs as an empty set', () => {
+    const result = validateSharedDesigns(undefined);
+    expect(result).toEqual({ valid: true, designs: [] });
+  });
+
+  it('accepts a well-formed design', () => {
+    const result = validateSharedDesigns([design()]);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.designs).toHaveLength(1);
+      expect(result.designs[0].id).toBe('design_1');
+      expect(result.designs[0].name).toBe('Socket Tray');
+    }
+  });
+
+  it('rejects a non-array payload', () => {
+    expect(validateSharedDesigns({ id: 'design_1' }).valid).toBe(false);
+  });
+
+  it('rejects entries with a missing or oversized id', () => {
+    expect(validateSharedDesigns([design({ id: '' })]).valid).toBe(false);
+    expect(validateSharedDesigns([design({ id: 'x'.repeat(65) })]).valid).toBe(false);
+    expect(validateSharedDesigns([design({ id: 7 })]).valid).toBe(false);
+  });
+
+  it('rejects a design whose params fail the designer validator', () => {
+    expect(validateSharedDesigns([design({ params: { width: -1 } })]).valid).toBe(false);
+  });
+
+  // Several bins routinely share one design, so the client can emit the same
+  // id more than once.
+  it('collapses duplicate ids', () => {
+    const result = validateSharedDesigns([design(), design()]);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.designs).toHaveLength(1);
+  });
+
+  it('rejects more designs than the count cap allows', () => {
+    const many = Array.from({ length: 251 }, (_, i) => design({ id: `design_${i}` }));
+    const result = validateSharedDesigns(many);
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects a design set over the byte budget', () => {
+    // Padded with inert names to push the set past 512KB without tripping the
+    // per-design param validator.
+    const bulky = Array.from({ length: 200 }, (_, i) =>
+      design({
+        id: `design_${i}`,
+        params: { ...validParams(), inserts: [], notes: 'x'.repeat(4000) },
+      })
+    );
+    const result = validateSharedDesigns(bulky);
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error.code).toBe('SIZE_LIMIT');
   });
 });

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -4,6 +4,7 @@
  */
 
 import { isNumber, isObject, inRange, validationError } from './validationUtils.js';
+import { validateDesignerShare } from './designerValidation.js';
 
 // Constraints for shared layouts
 const SHARE_CONSTRAINTS = {
@@ -28,6 +29,21 @@ const SHARE_CONSTRAINTS = {
   CUSTOM_PROPERTY_VALUE_MAX_LENGTH: 256,
   CUSTOM_PROPERTY_MAX_TOTAL_SIZE: 20480, // 20KB total per bin
 };
+
+/** Design ids are generated as `design_{timestamp}_{suffix}`; 64 leaves room to spare. */
+const DESIGN_ID_MAX_LENGTH = 64;
+
+/**
+ * Budget for the `linkedDesigns` payload that rides alongside a shared layout.
+ * Separate from the layout's own cap so a design-heavy share can't crowd out
+ * the layout itself. A plain design serializes to ~3KB and a cutout-heavy one
+ * to ~7KB, so this holds well over a hundred; imported-mesh designs (which
+ * carry base64 geometry in `params.meshAssets`) are the only realistic way to
+ * reach it, and those are skipped individually rather than failing the share.
+ */
+const MAX_LINKED_DESIGNS = 250;
+const MAX_LINKED_DESIGNS_BYTES = 512 * 1024;
+const DESIGN_NAME_MAX_LENGTH = 64;
 
 /** Reserved keys that cannot be used as custom property names */
 const RESERVED_PROPERTY_KEYS = [
@@ -100,6 +116,7 @@ interface BinShape {
   label: string;
   notes: string;
   customProperties?: Record<string, string>;
+  linkedDesignId?: string;
 }
 
 interface CategoryShape {
@@ -316,6 +333,11 @@ export function validateShareLayout(data: unknown, jsonSize: number): Validation
       label: bin.label ? sanitizeString(bin.label, SHARE_CONSTRAINTS.LABEL_MAX_LENGTH) : '',
       notes: bin.notes ? sanitizeString(bin.notes, SHARE_CONSTRAINTS.NOTES_MAX_LENGTH) : '',
       customProperties: validatedCustomProperties,
+      // Dropping this stripped the recipient's only handle on the bin's design
+      // (#2894); the payload it points at travels alongside as `linkedDesigns`.
+      linkedDesignId: bin.linkedDesignId
+        ? sanitizeString(bin.linkedDesignId, DESIGN_ID_MAX_LENGTH)
+        : undefined,
     });
   }
 
@@ -359,6 +381,90 @@ export function validateShareLayout(data: unknown, jsonSize: number): Validation
           : undefined,
     },
   };
+}
+
+/** A bin design travelling with a shared layout, keyed by the id its bins carry. */
+export interface SharedDesignShape {
+  id: string;
+  name: string;
+  params: Record<string, unknown>;
+}
+
+export type SharedDesignsResult =
+  { valid: true; designs: SharedDesignShape[] } | { valid: false; error: ValidationError };
+
+/**
+ * Validate the `linkedDesigns` payload accompanying a shared layout.
+ *
+ * Each design's params go through the same deep validator the single-design
+ * designer share uses, so a layout share can't become a side door around the
+ * stricter checks (mesh-asset cross-referencing in particular).
+ *
+ * Absent/empty is valid — layouts with no linked designs and pre-#2894 clients
+ * both land here.
+ */
+export function validateSharedDesigns(data: unknown): SharedDesignsResult {
+  if (data === undefined || data === null) return { valid: true, designs: [] };
+  if (!Array.isArray(data)) {
+    return validationError('VALIDATION_ERROR', 'linkedDesigns must be an array');
+  }
+  if (data.length > MAX_LINKED_DESIGNS) {
+    return validationError(
+      'VALIDATION_ERROR',
+      `Too many linked designs (max ${MAX_LINKED_DESIGNS})`
+    );
+  }
+
+  const designs: SharedDesignShape[] = [];
+  const seen = new Set<string>();
+  let totalBytes = 0;
+
+  for (const entry of data) {
+    if (!isObject(entry)) {
+      return validationError('VALIDATION_ERROR', 'Invalid linked design entry');
+    }
+    const { id, name, params } = entry;
+    if (typeof id !== 'string' || id.length === 0 || id.length > DESIGN_ID_MAX_LENGTH) {
+      return validationError('VALIDATION_ERROR', 'Invalid linked design id');
+    }
+    if (typeof name !== 'string') {
+      return validationError('VALIDATION_ERROR', 'Invalid linked design name');
+    }
+    // Bins share designs freely, so the client can emit the same id twice.
+    if (seen.has(id)) continue;
+
+    const paramsBytes = JSON.stringify(params ?? null).length;
+    const result = validateDesignerShare({ type: 'designer', version: 1, params }, paramsBytes);
+    if (!result.valid) {
+      return validationError('VALIDATION_ERROR', `Invalid linked design: ${result.error.message}`);
+    }
+
+    totalBytes += paramsBytes;
+    if (totalBytes > MAX_LINKED_DESIGNS_BYTES) {
+      return validationError(
+        'SIZE_LIMIT',
+        `Linked designs exceed maximum size of ${MAX_LINKED_DESIGNS_BYTES / 1024}KB`
+      );
+    }
+
+    seen.add(id);
+    designs.push({
+      id: sanitizeString(id, DESIGN_ID_MAX_LENGTH),
+      name: sanitizeString(name, DESIGN_NAME_MAX_LENGTH),
+      params: result.payload.params,
+    });
+  }
+
+  return { valid: true, designs };
+}
+
+/**
+ * Narrow a {@link SharedDesignsResult} to its failure case.
+ */
+export function isSharedDesignsError(
+  result: SharedDesignsResult
+): result is { valid: false; error: ValidationError } {
+  return !result.valid;
 }
 
 /**
@@ -601,7 +707,8 @@ function isValidBin(value: unknown): value is BinShape {
     inRange(value.height, SHARE_CONSTRAINTS.HEIGHT_MIN, SHARE_CONSTRAINTS.GRID_MAX) &&
     optString(value.category) &&
     optString(value.label) &&
-    optString(value.notes)
+    optString(value.notes) &&
+    optString(value.linkedDesignId)
   );
 }
 

--- a/api/share.test.ts
+++ b/api/share.test.ts
@@ -22,6 +22,8 @@ const mocks = vi.hoisted(() => ({
   redisSet: vi.fn(),
   validateShareLayout: vi.fn(),
   isValidationError: vi.fn(),
+  validateSharedDesigns: vi.fn(),
+  isSharedDesignsError: vi.fn(),
   validateDesignerShare: vi.fn(),
   filterLayoutContent: vi.fn(),
 }));
@@ -41,6 +43,8 @@ vi.mock('@vercel/blob', () => ({
 vi.mock('./lib/validation.js', () => ({
   validateShareLayout: mocks.validateShareLayout,
   isValidationError: mocks.isValidationError,
+  validateSharedDesigns: mocks.validateSharedDesigns,
+  isSharedDesignsError: mocks.isSharedDesignsError,
 }));
 
 vi.mock('./lib/designerValidation.js', () => ({
@@ -99,6 +103,8 @@ describe('share (create)', () => {
     mocks.isValidationError.mockReturnValue(false);
     mocks.filterLayoutContent.mockReturnValue({ passed: true });
     mocks.validateDesignerShare.mockReturnValue({ valid: true, payload: { params: {} } });
+    mocks.validateSharedDesigns.mockReturnValue({ valid: true, designs: [] });
+    mocks.isSharedDesignsError.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -202,6 +208,40 @@ describe('share (create)', () => {
     mocks.head.mockRejectedValue(new Error('also down'));
     const res = await handle(layoutBody());
     expect(res._status).toBe(500);
+  });
+
+  // A layout share whose designs stay behind arrives as bins pointing at
+  // designs that only exist in the sharer's browser (#2894).
+  it('stores the validated linked designs alongside the layout', async () => {
+    const designs = [{ id: 'design_1', name: 'Socket Tray', params: { width: 3 } }];
+    mocks.validateSharedDesigns.mockReturnValue({ valid: true, designs });
+
+    const res = await handle(layoutBody({ linkedDesigns: [{ id: 'design_1' }] }));
+
+    expect(res._status).toBe(201);
+    const written = JSON.parse(mocks.put.mock.calls[0][1] as string) as Record<string, unknown>;
+    expect(written.linkedDesigns).toEqual(designs);
+  });
+
+  it('omits the key entirely when the layout has no linked designs', async () => {
+    const res = await handle(layoutBody());
+
+    expect(res._status).toBe(201);
+    const written = JSON.parse(mocks.put.mock.calls[0][1] as string) as Record<string, unknown>;
+    expect(written).not.toHaveProperty('linkedDesigns');
+  });
+
+  it('400s when the linked designs fail validation, without writing a blob', async () => {
+    mocks.validateSharedDesigns.mockReturnValue({
+      valid: false,
+      error: { code: 'SIZE_LIMIT', message: 'Linked designs exceed maximum size of 512KB' },
+    });
+    mocks.isSharedDesignsError.mockReturnValue(true);
+
+    const res = await handle(layoutBody({ linkedDesigns: [{ id: 'design_1' }] }));
+
+    expect(res._status).toBe(400);
+    expect(mocks.put).not.toHaveBeenCalled();
   });
 
   it('rolls the blob back when the Redis hash write fails after put', async () => {

--- a/api/share.test.ts
+++ b/api/share.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   isSharedDesignsError: vi.fn(),
   validateDesignerShare: vi.fn(),
   filterLayoutContent: vi.fn(),
+  filterSharedDesignsContent: vi.fn(),
 }));
 
 vi.mock('./lib/rateLimit.js', () => ({
@@ -53,6 +54,7 @@ vi.mock('./lib/designerValidation.js', () => ({
 
 vi.mock('./lib/contentFilter.js', () => ({
   filterLayoutContent: mocks.filterLayoutContent,
+  filterSharedDesignsContent: mocks.filterSharedDesignsContent,
 }));
 
 function createResponse() {
@@ -102,6 +104,7 @@ describe('share (create)', () => {
     mocks.validateShareLayout.mockReturnValue({ layout: { name: 'My Drawer' } });
     mocks.isValidationError.mockReturnValue(false);
     mocks.filterLayoutContent.mockReturnValue({ passed: true });
+    mocks.filterSharedDesignsContent.mockReturnValue({ passed: true });
     mocks.validateDesignerShare.mockReturnValue({ valid: true, payload: { params: {} } });
     mocks.validateSharedDesigns.mockReturnValue({ valid: true, designs: [] });
     mocks.isSharedDesignsError.mockReturnValue(false);
@@ -229,6 +232,23 @@ describe('share (create)', () => {
     expect(res._status).toBe(201);
     const written = JSON.parse(mocks.put.mock.calls[0][1] as string) as Record<string, unknown>;
     expect(written).not.toHaveProperty('linkedDesigns');
+  });
+
+  it('400s with CONTENT_BLOCKED when a design name fails moderation', async () => {
+    mocks.validateSharedDesigns.mockReturnValue({
+      valid: true,
+      designs: [{ id: 'design_1', name: 'bad', params: {} }],
+    });
+    mocks.filterSharedDesignsContent.mockReturnValue({
+      passed: false,
+      reason: 'Design name: nope',
+    });
+
+    const res = await handle(layoutBody({ linkedDesigns: [{ id: 'design_1' }] }));
+
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe('CONTENT_BLOCKED');
+    expect(mocks.put).not.toHaveBeenCalled();
   });
 
   it('400s when the linked designs fail validation, without writing a blob', async () => {

--- a/api/share.ts
+++ b/api/share.ts
@@ -10,7 +10,7 @@ import {
   type SharedDesignShape,
 } from './lib/validation.js';
 import { validateDesignerShare } from './lib/designerValidation.js';
-import { filterLayoutContent } from './lib/contentFilter.js';
+import { filterLayoutContent, filterSharedDesignsContent } from './lib/contentFilter.js';
 import {
   isValidShareId,
   hashToken,
@@ -128,6 +128,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
       }
       sharedDesigns = designsResult.designs;
+
+      // Design names and engraved text are user-authored and shown to the
+      // recipient, so they get the same moderation the layout does.
+      const designContent = filterSharedDesignsContent(sharedDesigns);
+      if (!designContent.passed) {
+        return res.status(400).json({
+          error: `Content blocked: ${designContent.reason}`,
+          code: 'CONTENT_BLOCKED',
+        });
+      }
     }
 
     // Use client-provided layoutId as the share ID

--- a/api/share.ts
+++ b/api/share.ts
@@ -114,7 +114,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (!contentResult.passed) {
         return res.status(400).json({
           error: `Content blocked: ${contentResult.reason}`,
-          code: 'CONTENT_BLOCKED',
+          code: ErrorCode.CONTENT_BLOCKED,
         });
       }
 
@@ -135,7 +135,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (!designContent.passed) {
         return res.status(400).json({
           error: `Content blocked: ${designContent.reason}`,
-          code: 'CONTENT_BLOCKED',
+          code: ErrorCode.CONTENT_BLOCKED,
         });
       }
     }

--- a/api/share.ts
+++ b/api/share.ts
@@ -2,7 +2,13 @@ import { put, head, del } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP, getRedis } from './lib/rateLimit.js';
 import { logger } from './lib/logger.js';
-import { validateShareLayout, isValidationError } from './lib/validation.js';
+import {
+  validateShareLayout,
+  isValidationError,
+  validateSharedDesigns,
+  isSharedDesignsError,
+  type SharedDesignShape,
+} from './lib/validation.js';
 import { validateDesignerShare } from './lib/designerValidation.js';
 import { filterLayoutContent } from './lib/contentFilter.js';
 import {
@@ -48,7 +54,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // Parse and validate request body
     const body = (req.body ?? {}) as Record<string, unknown>;
-    const { layout, layoutId, permission = 'view', authorName, type, params } = body;
+    const { layout, layoutId, permission = 'view', authorName, type, params, linkedDesigns } = body;
 
     // Validate layoutId - must be provided by client
     if (!isValidShareId(layoutId)) {
@@ -67,6 +73,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     let sharePayload: unknown;
+    let sharedDesigns: SharedDesignShape[] = [];
 
     if (type === 'designer') {
       // Designer share: validate BinParams
@@ -112,6 +119,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       sharePayload = validationResult.layout;
+
+      const designsResult = validateSharedDesigns(linkedDesigns);
+      if (isSharedDesignsError(designsResult)) {
+        return res.status(400).json({
+          error: designsResult.error.message,
+          code: designsResult.error.code,
+        });
+      }
+      sharedDesigns = designsResult.designs;
     }
 
     // Use client-provided layoutId as the share ID
@@ -138,6 +154,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // tooling reading directly from the blob.
     const shareData: ShareData = {
       layout: sharePayload,
+      ...(sharedDesigns.length > 0 ? { linkedDesigns: sharedDesigns } : {}),
       metadata: {
         createdAt: nowIso,
         lastUpdatedAt: nowIso,

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -1,7 +1,12 @@
 import { put, del, head } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP, getRedis } from '../lib/rateLimit.js';
-import { validateShareLayout, isValidationError } from '../lib/validation.js';
+import {
+  validateShareLayout,
+  isValidationError,
+  validateSharedDesigns,
+  isSharedDesignsError,
+} from '../lib/validation.js';
 import { filterLayoutContent } from '../lib/contentFilter.js';
 import { logger } from '../lib/logger.js';
 import {
@@ -102,6 +107,7 @@ async function handleGet(req: VercelRequest, res: VercelResponse, _id: string, b
     // Return layout with public metadata (exclude sensitive fields)
     return res.status(200).json({
       layout: shareData.layout,
+      linkedDesigns: shareData.linkedDesigns,
       metadata: {
         createdAt: shareData.metadata.createdAt,
         lastUpdatedAt: shareData.metadata.lastUpdatedAt,
@@ -135,7 +141,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
     }
 
     const body = (req.body ?? {}) as Record<string, unknown>;
-    const { layout, permission, deleteToken } = body;
+    const { layout, permission, deleteToken, linkedDesigns } = body;
 
     if (!deleteToken || typeof deleteToken !== 'string') {
       return res.status(401).json({
@@ -248,10 +254,19 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
       });
     }
 
+    const designsResult = validateSharedDesigns(linkedDesigns);
+    if (isSharedDesignsError(designsResult)) {
+      return res.status(400).json({
+        error: designsResult.error.message,
+        code: designsResult.error.code,
+      });
+    }
+
     // Update share data (preserve original deleteTokenHash and createdAt;
     // drop legacy lastAccessedAt — see note above).
     const updatedData: ShareData = {
       layout: validationResult.layout,
+      ...(designsResult.designs.length > 0 ? { linkedDesigns: designsResult.designs } : {}),
       metadata: {
         ...metadataWithoutAccess,
         permission: newPermission,

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -7,7 +7,7 @@ import {
   validateSharedDesigns,
   isSharedDesignsError,
 } from '../lib/validation.js';
-import { filterLayoutContent } from '../lib/contentFilter.js';
+import { filterLayoutContent, filterSharedDesignsContent } from '../lib/contentFilter.js';
 import { logger } from '../lib/logger.js';
 import {
   isValidShareId,
@@ -259,6 +259,14 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
       return res.status(400).json({
         error: designsResult.error.message,
         code: designsResult.error.code,
+      });
+    }
+
+    const designContent = filterSharedDesignsContent(designsResult.designs);
+    if (!designContent.passed) {
+      return res.status(400).json({
+        error: `Content blocked: ${designContent.reason}`,
+        code: ErrorCode.CONTENT_BLOCKED,
       });
     }
 

--- a/src/core/api/share.ts
+++ b/src/core/api/share.ts
@@ -145,7 +145,8 @@ function validateFetchShareResponse(
           typeof (entry as Record<string, unknown>).id === 'string' &&
           typeof (entry as Record<string, unknown>).name === 'string' &&
           typeof (entry as Record<string, unknown>).params === 'object' &&
-          (entry as Record<string, unknown>).params !== null
+          (entry as Record<string, unknown>).params !== null &&
+          !Array.isArray((entry as Record<string, unknown>).params)
       )
     : undefined;
 

--- a/src/core/api/share.ts
+++ b/src/core/api/share.ts
@@ -26,9 +26,44 @@ export interface ShareMetadata {
   authorName?: string;
 }
 
+export interface SharedLinkedDesign {
+  id: string;
+  name: string;
+  params: unknown;
+}
+
 export interface FetchShareResponse {
   layout: Layout;
+  /** Bin designs the layout's bins reference. Absent on pre-#2894 shares. */
+  linkedDesigns?: SharedLinkedDesign[];
   metadata: ShareMetadata;
+}
+
+/**
+ * Mirrors MAX_LINKED_DESIGNS_BYTES in api/lib/validation.ts. Trimming here
+ * keeps an oversized design set (realistically: imported-mesh designs carrying
+ * base64 geometry) from turning the whole share into a 400.
+ */
+const LINKED_DESIGNS_BUDGET_BYTES = 512 * 1024;
+
+/**
+ * Resolve a layout's linked designs, dropping any that would push the payload
+ * past the server's budget. Order is preserved so the result is deterministic;
+ * a single oversized design is skipped rather than starving the rest.
+ */
+async function collectDesignsForShare(layout: Layout): Promise<SharedLinkedDesign[]> {
+  const { collectLinkedDesigns } = await import('@/core/storage/ShareService');
+  const designs = await collectLinkedDesigns(layout);
+
+  const withinBudget: SharedLinkedDesign[] = [];
+  let bytes = 0;
+  for (const design of designs) {
+    const size = JSON.stringify(design.params).length;
+    if (bytes + size > LINKED_DESIGNS_BUDGET_BYTES) continue;
+    bytes += size;
+    withinBudget.push({ id: design.id, name: design.name, params: design.params });
+  }
+  return withinBudget;
 }
 
 export interface UpdateShareResponse {
@@ -99,7 +134,22 @@ function validateFetchShareResponse(
     return { valid: false, errors: layoutValidation.errors };
   }
 
-  return { valid: true, data };
+  // Drop anything malformed rather than rejecting the whole share — a bad
+  // design entry should cost that one design, not the layout.
+  const raw: unknown = (data as unknown as Record<string, unknown>).linkedDesigns;
+  const linkedDesigns = Array.isArray(raw)
+    ? raw.filter(
+        (entry): entry is SharedLinkedDesign =>
+          typeof entry === 'object' &&
+          entry !== null &&
+          typeof (entry as Record<string, unknown>).id === 'string' &&
+          typeof (entry as Record<string, unknown>).name === 'string' &&
+          typeof (entry as Record<string, unknown>).params === 'object' &&
+          (entry as Record<string, unknown>).params !== null
+      )
+    : undefined;
+
+  return { valid: true, data: { ...data, linkedDesigns } };
 }
 
 /**
@@ -127,10 +177,11 @@ export async function createShare(
   authorName?: string
 ): Promise<Result<ShareResponse, ApiError>> {
   try {
+    const linkedDesigns = await collectDesignsForShare(layout);
     const response = await fetch('/api/share', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ layoutId, layout, permission, authorName }),
+      body: JSON.stringify({ layoutId, layout, permission, authorName, linkedDesigns }),
     });
 
     const data: unknown = await response.json();
@@ -161,10 +212,11 @@ export async function updateShare(
   permission?: SharePermission
 ): Promise<Result<UpdateShareResponse, ApiError>> {
   try {
+    const linkedDesigns = await collectDesignsForShare(layout);
     const response = await fetch(`/api/share/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ layout, permission, deleteToken }),
+      body: JSON.stringify({ layout, permission, deleteToken, linkedDesigns }),
     });
 
     const data: unknown = await response.json();

--- a/src/core/storage/ShareService.test.ts
+++ b/src/core/storage/ShareService.test.ts
@@ -13,6 +13,7 @@ import {
   exportLayoutJSON,
   exportLayoutJSONWithDesigns,
   restoreEmbeddedDesigns,
+  restoreSharedDesigns,
 } from '@/core/storage';
 import type { Layout } from '@/core/types';
 import { getUserMessage, ok, err, storageNotFound } from '@/core/result';
@@ -35,6 +36,12 @@ const mockSaveDesign = vi.fn();
 vi.mock('@/features/bin-designer/storage/DesignerStorage', () => ({
   loadDesign: (...args: unknown[]) => mockLoadDesign(...args),
   saveDesign: (...args: unknown[]) => mockSaveDesign(...args),
+}));
+
+const mockUpsertRegistryEntry = vi.fn();
+vi.mock('@/features/bin-designer/store/customBinRegistry', () => ({
+  upsertRegistryEntry: (...args: unknown[]) => mockUpsertRegistryEntry(...args),
+  registryEdgeFields: () => ({}),
 }));
 
 describe('storage-share', () => {
@@ -898,6 +905,116 @@ describe('storage-share', () => {
       expect(result.importedDesignCount).toBe(2);
       expect(result.layout.bins[0].linkedDesignId).toBe('new-id-1');
       expect(result.layout.bins[1].linkedDesignId).toBe('new-id-2');
+    });
+  });
+
+  // A cloud share used to carry bins whose linkedDesignId named a design that
+  // only existed in the sharer's browser (#2894).
+  describe('restoreSharedDesigns', () => {
+    const SHARE_ID = 'abc123DEF456';
+
+    const layoutLinkedTo = (designId: string): Layout => {
+      const layout = createTestLayout();
+      layout.bins = layout.bins.map((bin, i) => ({
+        ...bin,
+        linkedDesignId: i === 0 ? designId : undefined,
+      }));
+      return layout;
+    };
+
+    const savedAs = (id: string) =>
+      ok({
+        id,
+        name: 'Socket Tray',
+        params: { ...DEFAULT_BIN_PARAMS },
+        thumbnail: null,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        exportFileNameConfig: null,
+      });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('returns the layout untouched when no designs travelled with it', async () => {
+      const layout = createTestLayout();
+      const result = await restoreSharedDesigns(SHARE_ID, layout, []);
+
+      expect(result).toBe(layout);
+      expect(mockSaveDesign).not.toHaveBeenCalled();
+    });
+
+    it('persists each design and repoints the bins at the local copies', async () => {
+      mockSaveDesign.mockResolvedValue(savedAs('design_shared_deadbeef'));
+      const layout = layoutLinkedTo('remote-design-1');
+
+      const result = await restoreSharedDesigns(SHARE_ID, layout, [
+        { id: 'remote-design-1', name: 'Socket Tray', params: { ...DEFAULT_BIN_PARAMS } },
+      ]);
+
+      expect(result.bins[0].linkedDesignId).toBe('design_shared_deadbeef');
+      expect(result.bins[1]?.linkedDesignId).toBeUndefined();
+    });
+
+    it('registers each design so the planner and 3D preview can resolve it', async () => {
+      mockSaveDesign.mockResolvedValue(savedAs('design_shared_deadbeef'));
+
+      await restoreSharedDesigns(SHARE_ID, layoutLinkedTo('remote-design-1'), [
+        { id: 'remote-design-1', name: 'Socket Tray', params: { ...DEFAULT_BIN_PARAMS } },
+      ]);
+
+      expect(mockUpsertRegistryEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'design_shared_deadbeef', name: 'Socket Tray' })
+      );
+    });
+
+    // Unlike a one-shot file import, a share link is re-fetched on every visit.
+    it('derives a stable local id so re-opening a link does not duplicate designs', async () => {
+      mockSaveDesign.mockResolvedValue(savedAs('design_shared_deadbeef'));
+      const designs = [
+        { id: 'remote-design-1', name: 'Socket Tray', params: { ...DEFAULT_BIN_PARAMS } },
+      ];
+
+      await restoreSharedDesigns(SHARE_ID, layoutLinkedTo('remote-design-1'), designs);
+      const firstId = mockSaveDesign.mock.calls[0][0].id;
+      await restoreSharedDesigns(SHARE_ID, layoutLinkedTo('remote-design-1'), designs);
+      const secondId = mockSaveDesign.mock.calls[1][0].id;
+
+      expect(firstId).toBe(secondId);
+      expect(String(firstId).length).toBeLessThanOrEqual(64);
+    });
+
+    it('scopes the local id to the share so two shares cannot collide', async () => {
+      mockSaveDesign.mockResolvedValue(savedAs('design_shared_deadbeef'));
+      const designs = [
+        { id: 'remote-design-1', name: 'Socket Tray', params: { ...DEFAULT_BIN_PARAMS } },
+      ];
+
+      await restoreSharedDesigns(SHARE_ID, layoutLinkedTo('remote-design-1'), designs);
+      await restoreSharedDesigns('zzz999ZZZ999', layoutLinkedTo('remote-design-1'), designs);
+
+      expect(mockSaveDesign.mock.calls[0][0].id).not.toBe(mockSaveDesign.mock.calls[1][0].id);
+    });
+
+    it('keeps the bin unlinked when the design fails to persist', async () => {
+      mockSaveDesign.mockResolvedValue(err(storageNotFound('nope')));
+      const layout = layoutLinkedTo('remote-design-1');
+
+      const result = await restoreSharedDesigns(SHARE_ID, layout, [
+        { id: 'remote-design-1', name: 'Socket Tray', params: { ...DEFAULT_BIN_PARAMS } },
+      ]);
+
+      expect(result.bins[0].linkedDesignId).toBe('remote-design-1');
+    });
+
+    it('skips entries whose params are not an object', async () => {
+      const result = await restoreSharedDesigns(SHARE_ID, layoutLinkedTo('remote-design-1'), [
+        { id: 'remote-design-1', name: 'Socket Tray', params: 'nonsense' },
+      ]);
+
+      expect(mockSaveDesign).not.toHaveBeenCalled();
+      expect(result.bins[0].linkedDesignId).toBe('remote-design-1');
     });
   });
 });

--- a/src/core/storage/ShareService.ts
+++ b/src/core/storage/ShareService.ts
@@ -244,7 +244,7 @@ export async function restoreEmbeddedDesigns(
 function djb2(str: string): string {
   let hash = 5381;
   for (let i = 0; i < str.length; i++) {
-    hash = (hash * 33) ^ str.charCodeAt(i);
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
   }
   return (hash >>> 0).toString(16);
 }
@@ -287,7 +287,9 @@ export async function restoreSharedDesigns(
 
   const idMap = new Map<string, DesignId>();
   for (const design of designs) {
-    if (!design.params || typeof design.params !== 'object') continue;
+    if (!design.params || typeof design.params !== 'object' || Array.isArray(design.params)) {
+      continue;
+    }
     const params = design.params as BinParams;
 
     const result = await saveDesign({

--- a/src/core/storage/ShareService.ts
+++ b/src/core/storage/ShareService.ts
@@ -13,13 +13,52 @@ import { validateImport } from '@/shared/utils/validation';
 import { isValidLayoutId, isLegacyUUID } from '@/shared/utils/uuid';
 import { generateBinId, generateLayerId, generateCategoryId, STAGING_ID } from '@/core/constants';
 import type { Layout, LayerId, CategoryId, DesignId } from '@/core/types';
+import { designId as toDesignId } from '@/core/types';
 import type { Result, ValidationError } from '@/core/result';
 import { ok, err, validationImportFailed, isOk } from '@/core/result';
 import type { BinParams } from '@/shared/types/bin';
-interface LinkedDesignExport {
+export interface LinkedDesignExport {
   readonly id: string;
   readonly name: string;
   readonly params: BinParams;
+}
+
+/**
+ * Resolve the bin designs referenced by a layout's `linkedDesignId`s.
+ *
+ * Shared by file export and cloud share so both carry the same payload — a
+ * layout that travels without its designs arrives as bins with dangling
+ * references (#2894). Designs that fail to load (deleted) or have no `params`
+ * (tool racks, imported meshes) are omitted rather than failing the whole set.
+ */
+export async function collectLinkedDesigns(layout: Layout): Promise<LinkedDesignExport[]> {
+  const designIds = new Set<DesignId>();
+  for (const bin of layout.bins) {
+    if (bin.linkedDesignId) {
+      designIds.add(bin.linkedDesignId);
+    }
+  }
+  if (designIds.size === 0) return [];
+
+  // Dynamic import keeps the bin-designer chunk out of the core/storage
+  // entry; the layer rule's `disallow` covers static imports but flags
+  // dynamic ones too. Until the call site is inverted to pass the
+  // loader in (or this service moves to shared/), the exception is
+  // documented here.
+  // eslint-disable-next-line boundaries/dependencies -- TECH-DEBT: dynamic import is deliberate code-splitting; see the note above
+  const { loadDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
+  const linkedDesigns: LinkedDesignExport[] = [];
+  for (const id of designIds) {
+    const result = await loadDesign(id);
+    if (isOk(result) && result.value.params) {
+      linkedDesigns.push({
+        id: result.value.id,
+        name: result.value.name,
+        params: result.value.params,
+      });
+    }
+  }
+  return linkedDesigns;
 }
 
 /**
@@ -42,36 +81,7 @@ export function exportLayoutJSON(layout: Layout): string {
  * Async because it needs to look up designs from IndexedDB.
  */
 export async function exportLayoutJSONWithDesigns(layout: Layout): Promise<string> {
-  // Collect unique linkedDesignIds from bins
-  const designIds = new Set<DesignId>();
-  for (const bin of layout.bins) {
-    if (bin.linkedDesignId) {
-      designIds.add(bin.linkedDesignId);
-    }
-  }
-
-  // Look up each design from IndexedDB
-  const linkedDesigns: LinkedDesignExport[] = [];
-  if (designIds.size > 0) {
-    // Dynamic import keeps the bin-designer chunk out of the core/storage
-    // entry; the layer rule's `disallow` covers static imports but flags
-    // dynamic ones too. Until the call site is inverted to pass the
-    // loader in (or this service moves to shared/), the exception is
-    // documented here.
-    // eslint-disable-next-line boundaries/dependencies
-    const { loadDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
-    for (const id of designIds) {
-      const result = await loadDesign(id);
-      if (isOk(result) && result.value.params) {
-        linkedDesigns.push({
-          id: result.value.id,
-          name: result.value.name,
-          params: result.value.params,
-        });
-      }
-      // If design not found (deleted) or non-bin (no params), just omit it
-    }
-  }
+  const linkedDesigns = await collectLinkedDesigns(layout);
 
   const exportData = {
     ...layout,
@@ -230,6 +240,90 @@ export async function restoreEmbeddedDesigns(
 
   return { layout, importedDesignCount };
 }
+/** djb2 string hash → unsigned 32-bit hex (matches meshPersistence's pattern). */
+function djb2(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+/**
+ * Local id for a design that arrived with a share.
+ *
+ * Derived from (share, source design) rather than generated, because unlike a
+ * one-shot file import a share link is re-fetched on every visit — a fresh id
+ * each time would pile up duplicates in the recipient's design library. Hashed
+ * to stay well inside the 64-char id budget the share API enforces, so a
+ * recipient can re-share what they received.
+ */
+function sharedDesignLocalId(shareId: string, sourceDesignId: string): DesignId {
+  return toDesignId(`design_shared_${djb2(`${shareId}:${sourceDesignId}`)}`);
+}
+
+/**
+ * Persist the designs that travelled with a cloud share and repoint the
+ * layout's bins at the local copies.
+ *
+ * Without this the recipient gets bins whose `linkedDesignId` names a design
+ * that only ever existed in the sharer's browser (#2894) — no 3D geometry, no
+ * per-bin export, nothing to print.
+ */
+export async function restoreSharedDesigns(
+  shareId: string,
+  layout: Layout,
+  designs: ReadonlyArray<{ id: string; name: string; params: unknown }>
+): Promise<Layout> {
+  if (designs.length === 0) return layout;
+
+  // Dynamic imports for the same code-splitting reason as collectLinkedDesigns.
+  // eslint-disable-next-line boundaries/dependencies -- TECH-DEBT: dynamic import is deliberate code-splitting; see collectLinkedDesigns
+  const { saveDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
+  const { upsertRegistryEntry, registryEdgeFields } = await import(
+    // eslint-disable-next-line boundaries/dependencies -- TECH-DEBT: dynamic import is deliberate code-splitting; see collectLinkedDesigns
+    '@/features/bin-designer/store/customBinRegistry'
+  );
+
+  const idMap = new Map<string, DesignId>();
+  for (const design of designs) {
+    if (!design.params || typeof design.params !== 'object') continue;
+    const params = design.params as BinParams;
+
+    const result = await saveDesign({
+      id: sharedDesignLocalId(shareId, design.id),
+      name: design.name,
+      params,
+      thumbnail: null,
+      exportFileNameConfig: null,
+    });
+    if (!isOk(result)) continue;
+
+    idMap.set(design.id, result.value.id);
+    // The planner palette and the linked-bin mesh cache both key off the
+    // registry, so a design that skips it stays invisible to the layout.
+    upsertRegistryEntry({
+      id: result.value.id,
+      name: result.value.name,
+      width: params.width,
+      depth: params.depth,
+      height: params.height,
+      ...registryEdgeFields(params),
+      updatedAt: result.value.updatedAt,
+    });
+  }
+
+  if (idMap.size === 0) return layout;
+
+  return {
+    ...layout,
+    bins: layout.bins.map((bin) => {
+      const localId = bin.linkedDesignId ? idMap.get(bin.linkedDesignId) : undefined;
+      return localId ? { ...bin, linkedDesignId: localId } : bin;
+    }),
+  };
+}
+
 /**
  * Escape a value for TSV format.
  * Replaces tabs and newlines with spaces to prevent breaking the format.

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -64,6 +64,8 @@ export {
   importLayoutJSON,
   importLayoutResult,
   restoreEmbeddedDesigns,
+  restoreSharedDesigns,
+  collectLinkedDesigns,
   exportPrintListTSV,
   type PrintListTSVMeta,
 } from './ShareService';

--- a/src/features/cloud-share/README.md
+++ b/src/features/cloud-share/README.md
@@ -49,9 +49,19 @@ Delete token: random secret, hashed server-side, required for mutations.
 2. **Shares are permanent** - no expiration, only explicit delete
 3. **Staging bins never sync** - filtered from fingerprint
 4. **Owner can't see own share in "Shared with me"**
+5. **Bin designs travel with the layout** - `bin.linkedDesignId` names a design in the
+   _sharer's_ IndexedDB, so the payload carries a sibling `linkedDesigns` array and the
+   recipient materializes local copies (`restoreSharedDesigns`). Any new `Bin` field must be
+   added explicitly to the server sanitizer (`api/lib/validation.ts`) AND both client import
+   paths (`validationImport.ts`, `validationSalvage.ts`) — all three rebuild bins
+   field-by-field and silently drop anything unlisted.
+6. **Restored design ids are derived, not generated** - hashed from (share id, source design
+   id) so re-opening a link updates the same records instead of duplicating them on
+   every visit.
 
 ## Limits
 
-- Size: 500KB max
+- Size: 500KB max (layout), 512KB max (linked designs, budgeted separately)
 - Bins: 2500 max
+- Linked designs: 250 max
 - Rate: 100/min (create, update, view, delete)

--- a/src/features/cloud-share/components/SharedLayoutImporter/SharedLayoutImporter.tsx
+++ b/src/features/cloud-share/components/SharedLayoutImporter/SharedLayoutImporter.tsx
@@ -224,8 +224,26 @@ export function SharedLayoutImporter() {
         return;
       }
 
-      const { layout, metadata } = result.value;
+      const { metadata, linkedDesigns } = result.value;
       const permission = metadata.permission;
+
+      // Materialize the sharer's bin designs locally and repoint the bins at
+      // them, so the recipient sees real geometry and can export each bin
+      // (#2894). A storage failure degrades to the plain layout rather than
+      // dropping the share.
+      let layout = result.value.layout;
+      if (linkedDesigns && linkedDesigns.length > 0) {
+        try {
+          const { restoreSharedDesigns } = await import('@/core/storage');
+          layout = await restoreSharedDesigns(initialCloudShareId, layout, linkedDesigns);
+        } catch (e) {
+          console.error('Failed to restore shared bin designs:', e);
+        }
+      }
+
+      if (!isMountedRef.current) {
+        return;
+      }
 
       // Auto-track this share in "Shared with me" (unless it's the owner's own)
       // Wrap in try-catch to ensure robust error handling

--- a/src/shared/utils/validation.test.ts
+++ b/src/shared/utils/validation.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@/shared/utils/validation';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { isOk, isErr } from '@/core/result';
+import { designId } from '@/core/types';
 import { createTestLayout as baseCreateTestLayout, createTestBin } from '@/test/testUtils';
 
 const createTestLayout = () =>
@@ -872,5 +873,48 @@ describe('isValidBin type guard', () => {
       height: 3,
     };
     expect(isValidBin(bin)).toBe(false);
+  });
+});
+
+// Both import paths rebuild bins field-by-field, so a new Bin field has to be
+// added here explicitly or it is silently dropped. Losing linkedDesignId left
+// restoreEmbeddedDesigns remapping an id that was already gone (#2894).
+describe('linkedDesignId round-trip', () => {
+  const DESIGN_ID = 'design_1730000000000_ab12cd';
+  const layoutWithLinkedBin = () => {
+    const layout = createTestLayout();
+    layout.bins = [createTestBin({ linkedDesignId: designId(DESIGN_ID) })];
+    return layout;
+  };
+
+  it('validateImport preserves a bin linkedDesignId', () => {
+    const layout = layoutWithLinkedBin();
+
+    const result = validateImport(layout);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.layout.bins[0].linkedDesignId).toBe(DESIGN_ID);
+    }
+  });
+
+  it('validateImport leaves it undefined for an unlinked bin', () => {
+    const layout = createTestLayout();
+    layout.bins = [createTestBin()];
+    const result = validateImport(layout);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.layout.bins[0].linkedDesignId).toBeUndefined();
+  });
+
+  it('salvageImport preserves a bin linkedDesignId', () => {
+    const result = salvageImport(layoutWithLinkedBin());
+
+    expect(result.layout?.bins[0].linkedDesignId).toBe(DESIGN_ID);
+  });
+
+  it('isValidBin rejects a non-string linkedDesignId', () => {
+    expect(isValidBin({ ...createTestBin(), linkedDesignId: 42 })).toBe(false);
+    expect(isValidBin({ ...createTestBin(), linkedDesignId: 'design_1' })).toBe(true);
   });
 });

--- a/src/shared/utils/validationGuards.ts
+++ b/src/shared/utils/validationGuards.ts
@@ -32,6 +32,7 @@ export interface BinShape {
   label?: string;
   notes?: string;
   customProperties?: Record<string, string>;
+  linkedDesignId?: string;
 }
 
 export interface CategoryShape {
@@ -116,6 +117,7 @@ export function isValidBin(value: unknown): value is BinShape {
   if (obj.category !== undefined && typeof obj.category !== 'string') return false;
   if (obj.label !== undefined && typeof obj.label !== 'string') return false;
   if (obj.notes !== undefined && typeof obj.notes !== 'string') return false;
+  if (obj.linkedDesignId !== undefined && typeof obj.linkedDesignId !== 'string') return false;
   // customProperties (when present) must be a plain object of string values.
   if (obj.customProperties !== undefined) {
     if (

--- a/src/shared/utils/validationImport.ts
+++ b/src/shared/utils/validationImport.ts
@@ -16,6 +16,7 @@ import {
   binId as toBinId,
   layerId as toLayerId,
   categoryId as toCategoryId,
+  designId as toDesignId,
   mm,
   gridUnits,
   heightUnits,
@@ -181,6 +182,7 @@ export function validateImport(data: unknown): ImportValidationResult {
       label: bin.label || '',
       notes: bin.notes || '',
       customProperties: bin.customProperties,
+      linkedDesignId: bin.linkedDesignId ? toDesignId(bin.linkedDesignId) : undefined,
     });
 
     // Validate custom properties if present

--- a/src/shared/utils/validationSalvage.ts
+++ b/src/shared/utils/validationSalvage.ts
@@ -18,6 +18,7 @@ import {
   binId as toBinId,
   layerId as toLayerId,
   categoryId as toCategoryId,
+  designId as toDesignId,
   mm,
   gridUnits,
   heightUnits,
@@ -115,6 +116,7 @@ export function salvageImport(data: unknown): SalvageResult {
       label: bin.label || '',
       notes: bin.notes || '',
       customProperties: bin.customProperties,
+      linkedDesignId: bin.linkedDesignId ? toDesignId(bin.linkedDesignId) : undefined,
     };
 
     // Staging bins pass through


### PR DESCRIPTION
Fixes #2894.

## The bug

A recipient opening a share link saw the layout but no linked bins, and could not view or print any of the bin designs.

## Root cause

Two independent failures stacked.

**The reference was stripped.** `bin.linkedDesignId` never reached the recipient, because three separate places rebuild bins field-by-field and none of them listed it:

- `api/lib/validation.ts` — `validateShareLayout` builds the sanitized bin that actually gets stored in the blob
- `src/shared/utils/validationImport.ts` — `validateImport`
- `src/shared/utils/validationSalvage.ts` — `salvageImport`

This has a second victim: `restoreEmbeddedDesigns` (JSON file import) remaps `bin.linkedDesignId` *after* `validateImport` has already dropped it, so importing a `.json` with embedded designs put the designs in the library but left every bin unlinked.

**The payload never travelled.** Even with the id preserved, it names a record in the sharer's IndexedDB. `createShare` posted `{ layoutId, layout, permission, authorName }` and nothing else. `exportLayoutJSONWithDesigns` already embeds designs for *file* export; the cloud path never used it.

## The fix

Preserve `linkedDesignId` in all three sanitizers, and send the designs as a `linkedDesigns` sibling of the layout (kept out of the `Layout` type, which has no business carrying share-only fields).

**Validation.** Each design's params run through `validateDesignerShare` — the same deep validator the existing single-design designer share uses. A layout share is otherwise a side door around the stricter checks, mesh-asset cross-referencing in particular.

**Budget.** Designs get their own 512KB / 250-entry allowance rather than eating into the layout's 500KB. A plain design serializes to ~3.3KB and a 24-cutout one to ~6.6KB, so the realistic way to reach the cap is imported-mesh designs carrying base64 geometry in `params.meshAssets`. The client trims to fit before sending, so an oversized set costs the designs that don't fit rather than turning the whole share into a 400.

**Restore.** Recipients materialize local copies and the preview's bins are repointed at them. Ids are *derived* — `djb2(shareId + ':' + sourceDesignId)` — not generated. A share link is re-fetched on every visit, unlike a one-shot file import, so generated ids would duplicate the sharer's designs into the recipient's library on every open. Hashing also keeps ids inside the 64-char budget the API enforces, so a recipient can re-share what they received. Each restored design is registered in `CustomBinRegistry`, without which the planner palette and the linked-bin mesh cache can't resolve it.

## Compatibility

`linkedDesigns` is optional at every layer. Pre-existing shares fetch and render exactly as before; a new client reading an old share simply finds no designs.

## Tests

Server (`api/lib/validation.test.ts`, `api/share.test.ts`):
- `linkedDesignId` survives sanitization; stays `undefined` when absent; a non-string is rejected
- `validateSharedDesigns`: absent/empty, well-formed, non-array, bad ids, params failing the designer validator, duplicate-id collapsing, count cap, byte budget
- share creation stores the designs, omits the key when there are none, and 400s without writing a blob when they fail validation

Client (`src/shared/utils/validation.test.ts`, `src/core/storage/ShareService.test.ts`):
- `validateImport` and `salvageImport` both preserve `linkedDesignId`; `isValidBin` rejects a non-string
- `restoreSharedDesigns`: no-op on empty, persists and repoints bins, registers in the registry, derives a stable id across repeat opens, scopes the id per share, leaves the bin unlinked on a storage failure, skips malformed params

Full run over `api`, `src/core`, `src/shared/utils`, `src/features/cloud-share`, `src/features/layout-library`: 4633 passing. `pnpm run quality` clean.

## Note

The recipient's copies land in their design library, matching what JSON file import already does. That is what makes them printable, which is the reporter's actual ask — but it is a product call worth a second opinion. An alternative would be holding them in the shared-preview state and only persisting if the recipient keeps the layout; that needs every design-resolution path to consult an in-memory overlay, so I did not build it speculatively.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes share links that showed bins without designs by sending validated `linkedDesigns` and restoring them locally so recipients can preview and print. Adds moderation for design names and engraved text, and tightens validation and error handling.

- **Bug Fixes**
  - Preserve `bin.linkedDesignId` in `validateShareLayout`, `validateImport`, and `salvageImport`.
  - Send `linkedDesigns` with the layout; deep-validate via `validateDesignerShare`; separate 512KB/250-entry budget; client trims to fit.
  - Moderate shared designs: blocklist-check design names and text-bearing params (`text`, `label`, `name`); enforce on create/update.
  - On open, persist designs locally and repoint bins; derive stable ids via `djb2(shareId:sourceId)`; register in `CustomBinRegistry`.
  - Hardened guards and errors: reject array/non-object params; drop malformed entries on fetch; align `djb2` with mesh persistence; use `ErrorCode.CONTENT_BLOCKED` for moderated content.
  - Backward compatible: `linkedDesigns` is optional; older shares render unchanged.

<sup>Written for commit 1f4b061449399a2546f9e3fb4baebdadfb358bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

