### PR TITLE
fix(deps): patch js-yaml and brace-expansion DoS advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,12 @@ to fail closed on the patterns those attacks exploited:
 They cover user-authored packages (no security benefit from delaying our own
 releases) and high-trust org scopes that release frequently and lockstep.
 
+**OSV suppressions** live in [`osv-scanner.toml`](osv-scanner.toml) and are for
+advisories that are wrong about us, not advisories we've decided to accept. Each
+entry pins an exact package version, explains the evidence, and sets an
+`effectiveUntil` so it expires rather than lingering. Suppressing a finding you
+simply can't fix yet is not a valid use — leave the scan red instead.
+
 **Adding a build script allow-list entry** (`allowBuilds`) is a security
 decision. Audit the package's postinstall behavior before adding.
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,30 @@
+# Suppressions for the blocking OSV scan (.github/workflows/osv-scan.yml).
+# Keep this file empty by default — every entry must name the advisory, state
+# why the finding is wrong, and carry an effectiveUntil so it cannot linger.
+
+# GHSA-mh99-v99m-4gvg / CVE-2026-14257 declares a single affected range of
+# "<= 5.0.7", which sweeps in the 1.x and 2.x lines even though both were
+# already patched: 1.1.16 and 2.1.2 (published 2026-07-08, two weeks before the
+# advisory) define EXPANSION_MAX_LENGTH = 4_000_000 and name the CVE in source;
+# 1.1.15 and 2.1.1 contain neither. They are also the newest releases in their
+# lines, so there is no version to upgrade to. Both are pulled in by minimatch@3
+# (via eslint-plugin-jsx-a11y and vite-plugin-pwa), which cannot move to
+# brace-expansion@5 — it calls the module as a function, and 5.x exports an
+# object. Pinned to the exact patched versions so any other version still scans.
+# TODO: remove once the upstream advisory range is corrected.
+
+[[PackageOverrides]]
+name = "brace-expansion"
+version = "1.1.16"
+ecosystem = "npm"
+vulnerability.ignore = true
+effectiveUntil = 2026-10-31
+reason = "1.1.16 is the 1.x backport of the CVE-2026-14257 fix; the advisory's '<= 5.0.7' range is overbroad."
+
+[[PackageOverrides]]
+name = "brace-expansion"
+version = "2.1.2"
+ecosystem = "npm"
+vulnerability.ignore = true
+effectiveUntil = 2026-10-31
+reason = "2.1.2 is the 2.x backport of the CVE-2026-14257 fix; the advisory's '<= 5.0.7' range is overbroad."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,6 +1,12 @@
 # Suppressions for the blocking OSV scan (.github/workflows/osv-scan.yml).
 # Keep this file empty by default — every entry must name the advisory, state
 # why the finding is wrong, and carry an effectiveUntil so it cannot linger.
+#
+# effectiveUntil must stay an unquoted TOML date. Quoting it fails to decode
+# into time.Time, and osv-scanner then discards the WHOLE file with only an
+# "Ignored invalid config file" line on stdout — every suppression here silently
+# stops applying while the scan still exits non-zero. Re-verify after editing:
+#   osv-scanner scan source --lockfile=pnpm-lock.yaml
 
 # GHSA-mh99-v99m-4gvg / CVE-2026-14257 declares a single affected range of
 # "<= 5.0.7", which sweeps in the 1.x and 2.x lines even though both were

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "globals": "^17.7.0",
     "gltf-pipeline": "^4.3.1",
     "husky": "^9.1.7",
-    "js-yaml": "^5.2.1",
+    "js-yaml": "^5.2.2",
     "jsdom": "^29.1.1",
     "knip": "^6.27.0",
     "lint-staged": "^17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   vitest-axe>lodash-es: ^4.18.1
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
   brace-expansion@<1.1.16: ^1.1.16
+  brace-expansion@>=5.0.0 <5.0.8: ^5.0.8
   tar@<7.5.21: ^7.5.21
   '@vercel/python-analysis>smol-toml': ^1.6.1
   esbuild: 0.28.1
@@ -243,8 +244,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       js-yaml:
-        specifier: ^5.2.1
-        version: 5.2.1
+        specifier: ^5.2.2
+        version: 5.2.2
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -3108,9 +3109,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4187,8 +4188,8 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -8680,7 +8681,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9828,7 +9829,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -10144,7 +10145,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,17 +24,21 @@ minimumReleaseAgeExclude:
   - '@vercel/*'
   - '@protobufjs/*'
   - protobufjs
-  # fast-uri 3.1.4 (2026-07-19) is the first version patched against the
-  # host-confusion-via-backslash-authority flaw (CVE-2026-16221,
-  # GHSA-v2hh-gcrm-f6hx). Scoped to the exact reviewed release so no later
-  # fast-uri publish can bypass the cooldown via a lockfile regen.
-  # TODO: remove after 2026-07-26 once 3.1.4 has aged past the window.
-  - fast-uri@3.1.4
   # tar 7.5.21 (2026-07-21) is the first version patched against the
   # uncatchable stack-overflow DoS via crafted long-path archives
   # (GHSA-r292-9mhp-454m). Scoped to the exact reviewed release.
   # TODO: remove after 2026-07-28 once 7.5.21 has aged past the window.
   - tar@7.5.21
+  # js-yaml 5.2.2 (2026-07-23) is the first version patched against the
+  # exponential flow-collection parsing DoS (GHSA-pm4m-ph32-ghv5).
+  # TODO: remove after 2026-07-30 once 5.2.2 has aged past the window.
+  - js-yaml@5.2.2
+  # brace-expansion 5.0.8 (2026-07-23) is the first 5.x version patched
+  # against the unbounded-expansion OOM (CVE-2026-14257). The 1.x and 2.x
+  # lines were already patched in 1.1.16 / 2.1.2 despite the advisory's
+  # overbroad '<= 5.0.7' range, so only the 5.x line needs to move.
+  # TODO: remove after 2026-07-30 once 5.0.8 has aged past the window.
+  - brace-expansion@5.0.8
 
 # Blocks Shai-Hulud-class worms that spread via npm lifecycle scripts.
 # Packages that need to build are listed in allowBuilds.
@@ -83,6 +87,10 @@ overrides:
   'vitest-axe>lodash-es': '^4.18.1'
   'picomatch@>=4.0.0 <4.0.4': '^4.0.4'
   'brace-expansion@<1.1.16': '^1.1.16'
+  # Scoped to the 5.x line: minimatch@3 does `var expand = require(...)` and
+  # calls it directly, but brace-expansion@5's CJS build exports `{ expand }`,
+  # so a blanket range would drag 1.1.16 up to 5.x and break it at runtime.
+  'brace-expansion@>=5.0.0 <5.0.8': '^5.0.8'
   'tar@<7.5.21': '^7.5.21'
   '@vercel/python-analysis>smol-toml': '^1.6.1'
   esbuild: '0.28.1'


### PR DESCRIPTION
Clears all open security findings. Two were real, two were the advisory database being wrong about us.

## Real vulnerabilities

| Package | Advisory | Fix |
| --- | --- | --- |
| `js-yaml` 5.2.1 | GHSA-pm4m-ph32-ghv5 — exponential parsing time in flow collections | → 5.2.2 |
| `brace-expansion` 5.0.7 | CVE-2026-14257 — unbounded expansion length → OOM crash | → 5.0.8 |

Both fixes published 2026-07-23, which puts them inside the 7-day `minimumReleaseAge` cooldown. Each is excluded by **exact version** with a dated TODO, matching the pattern already used for `fast-uri` and `tar` — pinning to the exact release means no later, unreviewed publish can slip through the same hole.

The `brace-expansion` override is deliberately scoped to the 5.x line:

```
'brace-expansion@>=5.0.0 <5.0.8': '^5.0.8'
```

`minimatch@3.1.5` does `var expand = require('brace-expansion')` and calls it directly, but 5.x's CJS build exports `{ expand }` as an object. A blanket `<5.0.8` range would drag the 1.x copy up to 5.x and break every glob with `expand is not a function`. Smoke-tested after install: `minimatch@3.1.5` `braceExpand('a{b,c}d')` still returns `["abd","acd"]`.

## False positives

`brace-expansion` 1.1.16 and 2.1.2 were flagged for the same CVE, but **both already contain the fix**. Unpacking them:

- 1.1.16 / 2.1.2 (published 2026-07-08, over two weeks before the advisory) define `EXPANSION_MAX_LENGTH = 4_000_000` and name CVE-2026-14257 directly in source comments.
- 1.1.15 / 2.1.1 contain neither.

They're also the newest releases in their lines, so there is no version to upgrade to, and they're required by `minimatch@3` via `eslint-plugin-jsx-a11y` and `vite-plugin-pwa`. GHSA-mh99-v99m-4gvg declares a single affected range of `<= 5.0.7`, which sweeps up the already-patched 1.x and 2.x lines.

Adding a new `osv-scanner.toml` to suppress those two by exact version, with an `effectiveUntil`. The corresponding dashboard alerts (#62, #63) are dismissed as false positives with the same evidence.

## Verification

Run with `osv-scanner v2.3.8` — the version CI pins:

```
Before:  2 packages affected by 2 known vulnerabilities (2 High)
After:   No issues found
```

Because [a typo'd suppression key silently no-ops](https://github.com/google/osv-scanner/issues/1098), I negative-tested the scoping: retargeting the two entries at `1.1.15` / `2.1.1` brings both findings straight back, and restoring them clears the scan again. So the `version` match is doing real work — if `brace-expansion` ever resolves to some other version, it gets scanned normally.

Also verified: `pnpm run build:content` (js-yaml's only consumer, in `scripts/build-content.ts`) regenerates all 84 content pages byte-identically; typecheck clean; lint has 0 errors.

## Unrelated cleanup

Drops the `fast-uri@3.1.4` cooldown exclusion — its TODO said remove after 2026-07-26 and 3.1.4 aged past the window on schedule. `tar@7.5.21` is left in place; it doesn't age out until later today.

## Note

Neither vulnerability reached production — `pnpm why --prod` returns empty for both packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch DoS advisories by bumping `js-yaml` and `brace-expansion` 5.x, and add scoped OSV suppressions for false positives in 1.x/2.x. Clears the OSV scan without changing runtime behavior.

- **Dependencies**
  - Upgrade `js-yaml` 5.2.1 → 5.2.2 (GHSA-pm4m-ph32-ghv5); add cooldown entry.
  - Force `brace-expansion@>=5.0.0 <5.0.8` → `^5.0.8` (CVE-2026-14257); add cooldown; keep 1.x/2.x as-is to avoid breaking `minimatch@3`.
  - Add `osv-scanner.toml` suppressions for `brace-expansion` `1.1.16` and `2.1.2` (already patched) with `effectiveUntil`; document policy and the effectiveUntil quoting footgun in `SECURITY.md`.
  - Update `pnpm-lock.yaml` and `pnpm-workspace.yaml`; remove expired `fast-uri@3.1.4` cooldown.

<sup>Written for commit 37ac8cbc2cfc538afa124c427273609939fe59cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

