### PR TITLE
fix(deps): drop vulnerable brace-expansion@2.1.2 via minimatch@10

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,13 @@ A finding we can't fix yet stays red rather than being silenced, and "the
 advisory looks wrong" is not grounds for an exception — verify it by running the
 advisory's proof-of-concept against the installed version before believing it.
 
+**Currently open:** `brace-expansion@1.1.16` (CVE-2026-14257, High, build-time
+devDependency only). It arrives via `minimatch@3`, which `eslint-plugin-jsx-a11y`
+and `@ts-morph/common` both require and call as a function — an API minimatch@10
+dropped. No version of either package uses a minimatch line that resolves a
+patched `brace-expansion`, and 1.1.16 is the `maintenance-v1` head, so there is
+nothing to upgrade to. It clears when jsx-a11y and ts-morph move to minimatch@10.
+
 **Adding a build script allow-list entry** (`allowBuilds`) is a security
 decision. Audit the package's postinstall behavior before adding.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,9 @@ overrides:
   serialize-javascript: ^7.0.3
   eslint-plugin-react-hooks>eslint: ^10.0.3
   eslint-plugin-jsx-a11y>eslint: ^10.0.3
-  eslint-plugin-jsx-a11y>minimatch: ^3.1.3
+  eslint-plugin-jsx-a11y>minimatch: ^10.2.5
+  '@ts-morph/common>minimatch': ^10.2.5
+  filelist>minimatch: ^10.2.5
   '@vercel/build-utils>minimatch': ^10.2.3
   '@vercel/python-analysis>minimatch': ^10.2.3
   '@vercel/static-config>ajv': ^8.18.0
@@ -3071,9 +3073,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.29.6
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3102,12 +3101,6 @@ packages:
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
-
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -3264,9 +3257,6 @@ packages:
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -4559,13 +4549,6 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
-
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -8003,7 +7986,7 @@ snapshots:
   '@ts-morph/common@0.11.1':
     dependencies:
       fast-glob: 3.3.3
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       mkdirp: 1.0.4
       path-browserify: 1.0.1
 
@@ -8650,8 +8633,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -8671,15 +8652,6 @@ snapshots:
   bitmap-sdf@1.0.4: {}
 
   bluebird@3.7.2: {}
-
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.8:
     dependencies:
@@ -8826,8 +8798,6 @@ snapshots:
   commander@2.20.3: {}
 
   common-tags@1.8.2: {}
-
-  concat-map@0.0.1: {}
 
   consola@3.4.2: {}
 
@@ -9194,7 +9164,7 @@ snapshots:
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -9363,7 +9333,7 @@ snapshots:
 
   filelist@1.0.6:
     dependencies:
-      minimatch: 5.1.9
+      minimatch: 10.2.5
 
   fill-range@7.1.1:
     dependencies:
@@ -10146,14 +10116,6 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.8
-
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.16
-
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,7 @@ overrides:
   serialize-javascript: ^7.0.3
   eslint-plugin-react-hooks>eslint: ^10.0.3
   eslint-plugin-jsx-a11y>eslint: ^10.0.3
-  eslint-plugin-jsx-a11y>minimatch: ^10.2.5
-  '@ts-morph/common>minimatch': ^10.2.5
+  eslint-plugin-jsx-a11y>minimatch: ^3.1.3
   filelist>minimatch: ^10.2.5
   '@vercel/build-utils>minimatch': ^10.2.3
   '@vercel/python-analysis>minimatch': ^10.2.3
@@ -3073,6 +3072,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.29.6
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3101,6 +3103,9 @@ packages:
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -3257,6 +3262,9 @@ packages:
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -4549,6 +4557,9 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -7986,7 +7997,7 @@ snapshots:
   '@ts-morph/common@0.11.1':
     dependencies:
       fast-glob: 3.3.3
-      minimatch: 10.2.5
+      minimatch: 3.1.5
       mkdirp: 1.0.4
       path-browserify: 1.0.1
 
@@ -8633,6 +8644,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -8652,6 +8665,11 @@ snapshots:
   bitmap-sdf@1.0.4: {}
 
   bluebird@3.7.2: {}
+
+  brace-expansion@1.1.16:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.8:
     dependencies:
@@ -8798,6 +8816,8 @@ snapshots:
   commander@2.20.3: {}
 
   common-tags@1.8.2: {}
+
+  concat-map@0.0.1: {}
 
   consola@3.4.2: {}
 
@@ -9164,7 +9184,7 @@ snapshots:
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 10.2.5
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -10116,6 +10136,10 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.8
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,20 +73,17 @@ overrides:
   serialize-javascript: '^7.0.3'
   'eslint-plugin-react-hooks>eslint': '^10.0.3'
   'eslint-plugin-jsx-a11y>eslint': '^10.0.3'
-  # minimatch <10.2 pins brace-expansion ^1/^2/^4, and every one of those lines
-  # is unpatched for CVE-2026-14257 with no release to upgrade to. 10.2.x is the
-  # only line that pulls a fixed brace-expansion (5.0.8), so these three consumers
-  # are forced onto it to keep the vulnerable copies out of the tree entirely.
+  'eslint-plugin-jsx-a11y>minimatch': '^3.1.3'
+  # filelist reaches minimatch only through `minimatch.match(...)`, a named
+  # export 10.x still provides, so it can move off the minimatch@5 line — whose
+  # brace-expansion ^2.0.1 resolves to 2.1.2, unpatched for CVE-2026-14257 with
+  # no 2.x release to upgrade to. 10.2.x is the only line pulling a fixed
+  # brace-expansion (5.0.8).
   #
-  # jsx-a11y is the one with a caveat: it does `_interopRequireDefault(require(
-  # 'minimatch'))` and calls `.default(...)`, but minimatch@10's CJS build sets
-  # __esModule with no default export, so that call throws. Only
-  # mayHaveAccessibleLabel / mayContainChildComponent use it, reached solely from
-  # `label-has-associated-control` and `control-has-associated-label` — both
-  # disabled here. Enabling either requires dropping this override and accepting
-  # the CVE back, until jsx-a11y ships a minimatch@10-compatible release.
-  'eslint-plugin-jsx-a11y>minimatch': '^10.2.5'
-  '@ts-morph/common>minimatch': '^10.2.5'
+  # jsx-a11y and @ts-morph/common cannot follow: both call minimatch's *default*
+  # export, which minimatch@10's CJS build does not define (it sets __esModule
+  # with no `default`), so both throw `is not a function` at runtime. That keeps
+  # minimatch@3 — and brace-expansion@1.1.16 — in the tree. See SECURITY.md.
   'filelist>minimatch': '^10.2.5'
   '@vercel/build-utils>minimatch': '^10.2.3'
   '@vercel/python-analysis>minimatch': '^10.2.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,7 +73,21 @@ overrides:
   serialize-javascript: '^7.0.3'
   'eslint-plugin-react-hooks>eslint': '^10.0.3'
   'eslint-plugin-jsx-a11y>eslint': '^10.0.3'
-  'eslint-plugin-jsx-a11y>minimatch': '^3.1.3'
+  # minimatch <10.2 pins brace-expansion ^1/^2/^4, and every one of those lines
+  # is unpatched for CVE-2026-14257 with no release to upgrade to. 10.2.x is the
+  # only line that pulls a fixed brace-expansion (5.0.8), so these three consumers
+  # are forced onto it to keep the vulnerable copies out of the tree entirely.
+  #
+  # jsx-a11y is the one with a caveat: it does `_interopRequireDefault(require(
+  # 'minimatch'))` and calls `.default(...)`, but minimatch@10's CJS build sets
+  # __esModule with no default export, so that call throws. Only
+  # mayHaveAccessibleLabel / mayContainChildComponent use it, reached solely from
+  # `label-has-associated-control` and `control-has-associated-label` — both
+  # disabled here. Enabling either requires dropping this override and accepting
+  # the CVE back, until jsx-a11y ships a minimatch@10-compatible release.
+  'eslint-plugin-jsx-a11y>minimatch': '^10.2.5'
+  '@ts-morph/common>minimatch': '^10.2.5'
+  'filelist>minimatch': '^10.2.5'
   '@vercel/build-utils>minimatch': '^10.2.3'
   '@vercel/python-analysis>minimatch': '^10.2.3'
   '@vercel/static-config>ajv': '^8.18.0'


### PR DESCRIPTION
Removes one of the two open CVE-2026-14257 findings by getting `brace-expansion@2.1.2` out of the tree. The other is not fixable today; details below.

## Where the vulnerable copies come from

Neither is a direct dependency — both arrive through old `minimatch`:

| Vulnerable package | Via | Pulled by |
| --- | --- | --- |
| `brace-expansion@2.1.2` | `minimatch@5.1.9` | `filelist` (jake → ejs → workbox → vite-plugin-pwa) |
| `brace-expansion@1.1.16` | `minimatch@3.1.5` | `eslint-plugin-jsx-a11y`, `@ts-morph/common` |

Neither has an upgrade path in its own line — 1.1.16 and 2.1.2 are the `maintenance-v1` / `maintenance-v2` heads and remain unpatched. And only one `minimatch` line resolves a fixed `brace-expansion`:

```
minimatch@5.1.9 … 9.0.5   brace-expansion ^2.0.1  -> 2.1.2   vulnerable
minimatch@10.0.0          brace-expansion ^4.0.0  -> 4.0.1   vulnerable (4.x has no fix)
minimatch@10.2.5          brace-expansion ^5.0.5  -> 5.0.8   patched
```

So the only fix is moving consumers to `minimatch@10.2.x`.

## What can move, and what can't

`filelist` reaches minimatch only through `minimatch.match(...)` — a **named** export 10.x still provides. It moves cleanly, taking `minimatch@5` and `brace-expansion@2.1.2` with it.

`eslint-plugin-jsx-a11y` and `@ts-morph/common` cannot. Both call minimatch's **default** export, which minimatch@10's CJS build does not define — it sets `__esModule: true` with no `default`:

```
__esModule: true | has default: false
TypeError: d.default is not a function
```

- jsx-a11y: `_interopRequireDefault(require('minimatch'))` → `.default(name, control)`, in `mayHaveAccessibleLabel` / `mayContainChildComponent`, reached from `label-has-associated-control` and `control-has-associated-label` — both enabled here via `jsxA11y.flatConfigs.recommended`.
- `@ts-morph/common`: `_interopDefaultLegacy(require('minimatch'))` → `["default"](path, pattern)` in `getPathMatchesPattern`, on the Vercel TypeScript analysis path.

An earlier revision of this PR overrode all three. That was wrong on both counts and is corrected here.

## Result

`brace-expansion@2.1.2` and `minimatch@5.1.9` are gone. `brace-expansion@1.1.16` remains via `minimatch@3`, and stays until jsx-a11y and ts-morph adopt minimatch@10 upstream — no released version of either uses a minimatch line with a patched `brace-expansion`. Recorded in `SECURITY.md` as a known-open, build-time devDependency finding.

`osv-scanner v2.3.8`: **2 findings → 1**, with no `osv-scanner.toml` present — nothing is filtered.

## Verification

Run with the ESLint cache cleared, since `pnpm run lint` passes `--cache` and that is what hid the jsx-a11y crash locally on the first attempt:

- `eslint .` (no cache): 0 errors, 58 pre-existing `max-lines` warnings, exit 0
- `pnpm run typecheck`: clean
- `pnpm run build`: succeeds, PWA service worker emitted — the path that exercises `filelist`
- `vitest run src/core`: 146 files, 2215 tests passed