### PR TITLE
fix(bin-designer): validate cutout placement by outline, not bounding box

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -421,6 +421,20 @@ estimates), and the source file name.
     cell-aligned placement where every instance fits the polygon, and leaves the
     cutout flagged when none exists (translation can't fit an arbitrary concave
     region — honest rather than a silent false-fix).
+21. **A masked board is concave, so a bounding box can't decide containment** —
+    an axis-aligned box proves a fit but never a miss once the board has a
+    notch: an L-shaped cutout nested in an L-shaped bin has a box spanning the
+    notch. `cutoutFitsInMask` therefore uses `rectFitsInMask` as a **fast
+    accept** only, falling back to clipping the real silhouette
+    (`cutoutOutline.getCutoutOutline`) against the filled region with
+    `polygon-clipping`. Rings are deliberately **conservative supersets** —
+    curved spans sample a _circumscribing_ polygon — so an accepted placement
+    never clips in the generated mesh. `mesh` cutouts need their stored
+    silhouette, which is why `meshAssets` is threaded to every mask check;
+    without it a mesh imprint falls back to its footprint rectangle. Any new
+    caller building a _candidate_ cutout from a drag patch must move path
+    vertices with x/y (`translateCutoutPreview`), or the outline is validated
+    where the cutout used to be.
 
 ## Thumbnail Pipeline
 

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -107,8 +107,16 @@ export function CutoutWorkspace() {
   // are stored in absolute mm and never auto-rescaled. Flag them so the canvas
   // can frame them and the inspector can offer a one-click clamp back in.
   const offBoardIds = useMemo(
-    () => getOffBoardCutoutIds(cutouts, binWidth, binDepth, params.cellMask, maskCellSize),
-    [cutouts, binWidth, binDepth, params.cellMask, maskCellSize]
+    () =>
+      getOffBoardCutoutIds(
+        cutouts,
+        binWidth,
+        binDepth,
+        params.cellMask,
+        maskCellSize,
+        params.meshAssets
+      ),
+    [cutouts, binWidth, binDepth, params.cellMask, maskCellSize, params.meshAssets]
   );
 
   const t = useTranslation();
@@ -166,10 +174,19 @@ export function CutoutWorkspace() {
       binWidth,
       binDepth,
       params.cellMask,
-      maskCellSize
+      maskCellSize,
+      params.meshAssets
     );
     if (updates.size > 0) updateCutoutsBatch(updates);
-  }, [cutouts, binWidth, binDepth, params.cellMask, maskCellSize, updateCutoutsBatch]);
+  }, [
+    cutouts,
+    binWidth,
+    binDepth,
+    params.cellMask,
+    maskCellSize,
+    params.meshAssets,
+    updateCutoutsBatch,
+  ]);
 
   const {
     mode,

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
@@ -161,6 +161,7 @@ export function CutoutEditor() {
     gridSize,
     cellMask: params.cellMask,
     maskCellSize,
+    meshAssets: params.meshAssets,
   });
 
   const t = useTranslation();

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   defaultPlaceSize,
   resizeKeepingCenter,
   flattenCutoutArray,
+  translateCutoutPreview,
 } from './cutoutHelpers';
 import type { Cutout } from '@/features/bin-designer/types';
 
@@ -107,5 +108,46 @@ describe('flattenCutoutArray', () => {
     expect(added.every((a) => a.array === undefined)).toBe(true);
     expect(new Set(added.map((a) => a.id)).size).toBe(2); // unique ids
     expect(added.every((a) => a.id !== 'm')).toBe(true);
+  });
+});
+
+describe('translateCutoutPreview', () => {
+  const pathCutout: Cutout = {
+    id: 'p',
+    shape: 'path',
+    x: 10,
+    y: 10,
+    width: 20,
+    depth: 20,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+    path: [
+      { x: 10, y: 10, handleIn: null, handleOut: null, symmetric: false },
+      { x: 30, y: 10, handleIn: null, handleOut: null, symmetric: false },
+      { x: 30, y: 30, handleIn: null, handleOut: null, symmetric: false },
+    ],
+  };
+
+  it('carries absolute path vertices along with an x/y patch', () => {
+    const moved = translateCutoutPreview(pathCutout, { x: 15, y: 40 });
+    expect(moved.path?.map((pt) => [pt.x, pt.y])).toEqual([
+      [15, 40],
+      [35, 40],
+      [35, 60],
+    ]);
+  });
+
+  it('leaves the path alone when the patch does not move the cutout', () => {
+    const moved = translateCutoutPreview(pathCutout, { rotation: 45 });
+    expect(moved.path).toBe(pathCutout.path);
+    expect(moved.rotation).toBe(45);
+  });
+
+  it('passes non-path shapes straight through', () => {
+    const rect = { ...pathCutout, shape: 'rectangle' as const, path: undefined };
+    expect(translateCutoutPreview(rect, { x: 99 })).toEqual({ ...rect, x: 99 });
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
@@ -12,6 +12,7 @@ import {
 } from '@/features/bin-designer/types';
 import { polygonBoxFromAcrossFlats } from '@/shared/utils/cutoutPolygon';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
+import { translatePathPoints } from './pathGeometry';
 import {
   DEFAULT_RECT_SIZE,
   DEFAULT_CIRCLE_SIZE,
@@ -53,6 +54,25 @@ export function cloneCutoutsWithGroups(
       originalId: original.id,
     };
   });
+}
+
+/** Move a cutout by (dx, dy), carrying a path's absolute vertices along. */
+export function translateCutout(cutout: Cutout, dx: number, dy: number): Cutout {
+  const moved = { ...cutout, x: cutout.x + dx, y: cutout.y + dy };
+  if (cutout.shape !== 'path' || !cutout.path || (dx === 0 && dy === 0)) return moved;
+  return { ...moved, path: translatePathPoints(cutout.path, dx, dy) };
+}
+
+/**
+ * Apply a transform preview patch, moving a path cutout's vertices in lockstep
+ * with its x/y. Mirrors what the drag commit writes to the store, so validators
+ * run against the geometry the commit will actually produce rather than against
+ * the position the cutout is leaving.
+ */
+export function translateCutoutPreview(cutout: Cutout, patch: Partial<Cutout>): Cutout {
+  const dx = (patch.x ?? cutout.x) - cutout.x;
+  const dy = (patch.y ?? cutout.y) - cutout.y;
+  return { ...translateCutout(cutout, dx, dy), ...patch };
 }
 
 /** Clamp a position so the cutout stays within bin bounds (both lower and upper). */

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutInteractionTypes.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutInteractionTypes.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Cutout, CutoutShape } from '@/features/bin-designer/types';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
 import type { CellMask } from '@/shared/utils/cellMask';
 import type { MaskCellSize } from './maskFit';
 import type { PathDrawingMode, VertexEditMode } from './handlers';
@@ -129,4 +130,7 @@ export interface UseCutoutInteractionOptions {
   readonly cellMask?: CellMask;
   /** Mm per mask cell. Required alongside cellMask; X/Y differ on non-square bins. */
   readonly maskCellSize?: MaskCellSize;
+  /** Mesh imprint silhouettes, so `mesh` cutouts validate against their outline
+   *  rather than their footprint box on a custom footprint. */
+  readonly meshAssets?: Readonly<Record<string, MeshAsset>>;
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutOutline.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutOutline.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import type { Cutout, PathPoint } from '@/features/bin-designer/types';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
+import { getCutoutOutline } from './cutoutOutline';
+
+const base: Cutout = {
+  id: 'c1',
+  shape: 'rectangle',
+  x: 10,
+  y: 20,
+  width: 30,
+  depth: 40,
+  cutDepth: 5,
+  rotation: 0,
+  cornerRadius: 0,
+  label: '',
+  groupId: null,
+};
+
+const makeCutout = (overrides: Partial<Cutout>): Cutout => ({ ...base, ...overrides });
+
+const corner = (x: number, y: number): PathPoint => ({
+  x,
+  y,
+  handleIn: null,
+  handleOut: null,
+  symmetric: false,
+});
+
+function boundsOf(rings: readonly (readonly { x: number; y: number }[])[]) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const ring of rings) {
+    for (const p of ring) {
+      minX = Math.min(minX, p.x);
+      minY = Math.min(minY, p.y);
+      maxX = Math.max(maxX, p.x);
+      maxY = Math.max(maxY, p.y);
+    }
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+/** Signed area (shoelace) of a ring; positive when wound CCW. */
+function ringArea(ring: readonly { x: number; y: number }[]): number {
+  let a = 0;
+  for (let i = 0, n = ring.length; i < n; i++) {
+    const p = ring[i];
+    const q = ring[(i + 1) % n];
+    a += (p.x * q.y - q.x * p.y) / 2;
+  }
+  return Math.abs(a);
+}
+
+describe('getCutoutOutline', () => {
+  it('returns the four corners of a square-cornered rectangle', () => {
+    const rings = getCutoutOutline(makeCutout({}));
+    expect(rings).toHaveLength(1);
+    expect(rings?.[0]).toEqual([
+      { x: 10, y: 20 },
+      { x: 40, y: 20 },
+      { x: 40, y: 60 },
+      { x: 10, y: 60 },
+    ]);
+  });
+
+  it('rotates about the box center', () => {
+    const rings = getCutoutOutline(makeCutout({ x: 0, y: 0, width: 10, depth: 10, rotation: 90 }));
+    const b = boundsOf(rings ?? []);
+    expect(b.minX).toBeCloseTo(0);
+    expect(b.minY).toBeCloseTo(0);
+    expect(b.maxX).toBeCloseTo(10);
+    expect(b.maxY).toBeCloseTo(10);
+  });
+
+  it('circumscribes an ellipse rather than inscribing it', () => {
+    // A sampled ring that merely touched the ellipse would read smaller than
+    // the real curve and let a placement through that clips in the mesh.
+    const cutout = makeCutout({ shape: 'circle', x: 0, y: 0, width: 20, depth: 10 });
+    const ring = getCutoutOutline(cutout)?.[0] ?? [];
+    for (const p of ring) {
+      const nx = (p.x - 10) / 10;
+      const ny = (p.y - 5) / 5;
+      expect(Math.hypot(nx, ny)).toBeGreaterThanOrEqual(1);
+    }
+    // ...but only just: the ring must not be a wildly loose over-approximation.
+    expect(ringArea(ring)).toBeLessThan(Math.PI * 10 * 5 * 1.01);
+  });
+
+  it('traces a polygon cutout as an N-gon, not its bounding box', () => {
+    const hex = makeCutout({ shape: 'polygon', sides: 6, x: 0, y: 0, width: 20, depth: 20 });
+    const ring = getCutoutOutline(hex)?.[0] ?? [];
+    expect(ring).toHaveLength(6);
+    expect(ringArea(ring)).toBeLessThan(20 * 20);
+  });
+
+  it('rounds the ends of a slot', () => {
+    const slot = makeCutout({ shape: 'slot', x: 0, y: 0, width: 40, depth: 10 });
+    const ring = getCutoutOutline(slot)?.[0] ?? [];
+    // Stadium = 30×10 rectangle + a d=10 circle, well under the 40×10 box.
+    expect(ringArea(ring)).toBeGreaterThan(300);
+    expect(ringArea(ring)).toBeLessThan(400);
+  });
+
+  it('uses the flattened path vertices for a path cutout', () => {
+    const path = [corner(5, 5), corner(35, 5), corner(35, 35), corner(5, 35)];
+    const rings = getCutoutOutline(makeCutout({ shape: 'path', path }));
+    expect(rings).toHaveLength(1);
+    expect(ringArea(rings?.[0] ?? [])).toBeCloseTo(900);
+  });
+
+  it('rotates a path about its own vertex bounds, not the width/depth box', () => {
+    // x/y/width/depth deliberately disagree with the path — the renderer pivots
+    // on the vertex bounds, so the outline must too.
+    const path = [corner(0, 0), corner(10, 0), corner(10, 10), corner(0, 10)];
+    const rings = getCutoutOutline(
+      makeCutout({ shape: 'path', path, x: 100, y: 100, width: 999, depth: 999, rotation: 90 })
+    );
+    const b = boundsOf(rings ?? []);
+    expect(b.minX).toBeCloseTo(0);
+    expect(b.minY).toBeCloseTo(0);
+    expect(b.maxX).toBeCloseTo(10);
+    expect(b.maxY).toBeCloseTo(10);
+  });
+
+  it('returns null for shapes too degenerate to outline', () => {
+    expect(getCutoutOutline(makeCutout({ width: 0 }))).toBeNull();
+    expect(getCutoutOutline(makeCutout({ shape: 'path', path: undefined }))).toBeNull();
+    expect(getCutoutOutline(makeCutout({ shape: 'path', path: [corner(1, 1)] }))).toBeNull();
+  });
+
+  describe('mesh imprints', () => {
+    const asset: MeshAsset = {
+      name: 'wrench',
+      data: '',
+      triangleCount: 0,
+      sizeMm: { x: 20, y: 20, z: 5 },
+      // L-shaped silhouette filling the bottom-left and bottom-right of the box.
+      outlines: [
+        [
+          { x: 0, y: 0 },
+          { x: 20, y: 0 },
+          { x: 20, y: 10 },
+          { x: 10, y: 10 },
+          { x: 10, y: 20 },
+          { x: 0, y: 20 },
+        ],
+      ],
+    };
+    const meshCutout = makeCutout({
+      shape: 'mesh',
+      meshId: 'm1',
+      x: 0,
+      y: 0,
+      width: 20,
+      depth: 20,
+    });
+
+    it('maps the stored silhouette onto the footprint box', () => {
+      const ring = getCutoutOutline(meshCutout, { m1: asset })?.[0] ?? [];
+      expect(ring).toHaveLength(6);
+      // L covers 3 of the 4 quadrants — decisively less than the 400mm² box.
+      expect(ringArea(ring)).toBeCloseTo(300);
+    });
+
+    it('rescales the silhouette when the footprint box differs from the asset', () => {
+      const ring =
+        getCutoutOutline({ ...meshCutout, width: 40, depth: 20 }, { m1: asset })?.[0] ?? [];
+      expect(ringArea(ring)).toBeCloseTo(600);
+    });
+
+    it('falls back to the footprint rectangle without the asset', () => {
+      const ring = getCutoutOutline(meshCutout)?.[0] ?? [];
+      expect(ring).toHaveLength(4);
+      expect(ringArea(ring)).toBeCloseTo(400);
+    });
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutOutline.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutOutline.ts
@@ -1,0 +1,192 @@
+/**
+ * Silhouette rings for cutout containment checks, in absolute interior mm and
+ * already rotated.
+ *
+ * Placement against a non-rectangular (masked) board can't be decided from an
+ * axis-aligned box: an L-shaped path inside an L-shaped bin has a bbox that
+ * covers the notch even though every point of the outline sits on the board.
+ * These rings are what `maskFit` tests when the box check is inconclusive.
+ *
+ * Every ring is a **superset** of the shape it stands for, so a placement built
+ * on it never overhangs in the generated geometry: curved spans are sampled on
+ * a *circumscribing* polygon, and a mesh imprint with no stored silhouette
+ * falls back to its footprint rectangle.
+ *
+ * Rings are returned in the same frame `getCutoutBounds` measures, so the box
+ * check stays a sound fast-accept for the outline check.
+ */
+
+import type { Cutout } from '@/features/bin-designer/types';
+import { DEFAULT_POLYGON_SIDES, MIN_PATH_POINTS } from '@/features/bin-designer/types';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
+import {
+  clampPolygonSides,
+  regularPolygonPoints,
+  slotCornerRadius,
+} from '@/shared/utils/cutoutPolygon';
+import { rotatePoint } from './geometryCore';
+import { getPathBounds, flattenPath } from './pathGeometry';
+import type { Point2D } from './pathGeometryBezier';
+
+/** Samples per full turn for curved spans. Corner arcs use a quarter of these,
+ *  so both share one angular step — and therefore one inflation factor. */
+const ARC_SEGMENTS_PER_TURN = 64;
+const CORNER_SEGMENTS = ARC_SEGMENTS_PER_TURN / 4;
+
+/**
+ * Radial scale turning an inscribed sampled arc into a circumscribing one.
+ * Without it a sampled curve reads ~0.1% smaller than the curve itself and the
+ * validator would accept placements that clip in the generated mesh.
+ */
+const ARC_INFLATION = 1 / Math.cos(Math.PI / ARC_SEGMENTS_PER_TURN);
+
+/** Minimum vertices for a ring to bound any area. */
+const MIN_RING_POINTS = 3;
+
+function rotateRing(
+  points: readonly Point2D[],
+  cx: number,
+  cy: number,
+  degrees: number
+): Point2D[] {
+  if (!degrees) return [...points];
+  return points.map((p) => rotatePoint(p.x, p.y, cx, cy, degrees));
+}
+
+function ellipseRing(cx: number, cy: number, rx: number, ry: number): Point2D[] {
+  const points: Point2D[] = [];
+  for (let i = 0; i < ARC_SEGMENTS_PER_TURN; i++) {
+    const a = (i / ARC_SEGMENTS_PER_TURN) * Math.PI * 2;
+    points.push({
+      x: cx + rx * ARC_INFLATION * Math.cos(a),
+      y: cy + ry * ARC_INFLATION * Math.sin(a),
+    });
+  }
+  return points;
+}
+
+/**
+ * Rounded-rectangle ring, CCW from the bottom-left corner arc. The inflated
+ * corner radius also pushes each arc's endpoints outward along the straight
+ * edges' normals, so the straight spans stay outside the true profile too.
+ */
+function roundedRectRing(
+  x: number,
+  y: number,
+  width: number,
+  depth: number,
+  radius: number
+): Point2D[] {
+  const r = Math.max(0, Math.min(radius, width / 2, depth / 2));
+  if (r === 0) {
+    return [
+      { x, y },
+      { x: x + width, y },
+      { x: x + width, y: y + depth },
+      { x, y: y + depth },
+    ];
+  }
+  const ri = r * ARC_INFLATION;
+  const points: Point2D[] = [];
+  const arc = (acx: number, acy: number, startAngle: number): void => {
+    for (let i = 0; i <= CORNER_SEGMENTS; i++) {
+      const a = startAngle + (Math.PI / 2) * (i / CORNER_SEGMENTS);
+      points.push({ x: acx + ri * Math.cos(a), y: acy + ri * Math.sin(a) });
+    }
+  };
+  arc(x + r, y + r, Math.PI);
+  arc(x + width - r, y + r, -Math.PI / 2);
+  arc(x + width - r, y + depth - r, 0);
+  arc(x + r, y + depth - r, Math.PI / 2);
+  return points;
+}
+
+/**
+ * Stored top-down silhouette of a mesh imprint, mapped from the asset's
+ * `[0..sizeMm]` frame onto the cutout's footprint box. Returns `null` when the
+ * asset is unavailable so the caller can fall back to the footprint rectangle.
+ * Holes were already dropped at import, so each ring is an independent island.
+ */
+function meshRings(
+  cutout: Cutout,
+  meshAssets: Readonly<Record<string, MeshAsset>> | undefined
+): Point2D[][] | null {
+  const asset = cutout.meshId !== undefined ? meshAssets?.[cutout.meshId] : undefined;
+  if (!asset || asset.sizeMm.x <= 0 || asset.sizeMm.y <= 0) return null;
+  const scaleX = cutout.width / asset.sizeMm.x;
+  const scaleY = cutout.depth / asset.sizeMm.y;
+  const rings = asset.outlines
+    .filter((ring) => ring.length >= MIN_RING_POINTS)
+    .map((ring) => ring.map((p) => ({ x: cutout.x + p.x * scaleX, y: cutout.y + p.y * scaleY })));
+  return rings.length > 0 ? rings : null;
+}
+
+/**
+ * Silhouette of a cutout as one or more closed rings. Returns `null` for
+ * cutouts too degenerate to outline (empty path, zero-sized box), leaving the
+ * caller to keep whatever verdict the bounding box gave.
+ *
+ * `clearance` is deliberately not applied: the editor validates the nominal
+ * size the user entered, matching `cutoutToPolygon` and the on-screen outline.
+ */
+export function getCutoutOutline(
+  cutout: Cutout,
+  meshAssets?: Readonly<Record<string, MeshAsset>>
+): Point2D[][] | null {
+  if (cutout.shape === 'path') {
+    if (!cutout.path || cutout.path.length < MIN_PATH_POINTS) return null;
+    const flat = flattenPath(cutout.path);
+    if (flat.length < MIN_RING_POINTS) return null;
+    // Paths rotate about their own vertex-bounds center (see `PathShapeMesh`),
+    // not the width/depth box, whose metadata can lag the actual points.
+    const b = getPathBounds(cutout.path);
+    return [rotateRing(flat, (b.minX + b.maxX) / 2, (b.minY + b.maxY) / 2, cutout.rotation)];
+  }
+
+  if (cutout.width <= 0 || cutout.depth <= 0) return null;
+
+  const cx = cutout.x + cutout.width / 2;
+  const cy = cutout.y + cutout.depth / 2;
+
+  let rings: Point2D[][] | null;
+  switch (cutout.shape) {
+    case 'circle':
+      rings = [ellipseRing(cx, cy, cutout.width / 2, cutout.depth / 2)];
+      break;
+    case 'polygon': {
+      const pts = regularPolygonPoints(
+        clampPolygonSides(cutout.sides ?? DEFAULT_POLYGON_SIDES),
+        cutout.width,
+        cutout.depth
+      );
+      rings =
+        pts.length >= MIN_RING_POINTS ? [pts.map((p) => ({ x: cx + p.x, y: cy + p.y }))] : null;
+      break;
+    }
+    case 'slot':
+      rings = [
+        roundedRectRing(
+          cutout.x,
+          cutout.y,
+          cutout.width,
+          cutout.depth,
+          slotCornerRadius(cutout.width, cutout.depth)
+        ),
+      ];
+      break;
+    case 'mesh':
+      rings = meshRings(cutout, meshAssets) ??
+        // No stored silhouette reachable — the footprint box is the only
+        // outline we can vouch for, which is the pre-outline behaviour.
+        [roundedRectRing(cutout.x, cutout.y, cutout.width, cutout.depth, 0)];
+      break;
+    case 'rectangle':
+      rings = [
+        roundedRectRing(cutout.x, cutout.y, cutout.width, cutout.depth, cutout.cornerRadius),
+      ];
+      break;
+  }
+
+  if (!rings) return null;
+  return rings.map((ring) => rotateRing(ring, cx, cy, cutout.rotation));
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -1123,5 +1123,114 @@ describe('geometry', () => {
       });
       expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(false);
     });
+
+    // Issue #2922: the bounding box of a concave cutout spans the board's notch
+    // even when every point of the outline sits on filled cells.
+    describe('concave outlines on a concave board', () => {
+      const pathPoint = (x: number, y: number): PathPoint => ({
+        x,
+        y,
+        handleIn: null,
+        handleOut: null,
+        symmetric: false,
+      });
+
+      /** L-shaped path filling the same three quadrants the L-mask fills. */
+      const lPath: PathPoint[] = [
+        pathPoint(2, 2),
+        pathPoint(82, 2),
+        pathPoint(82, 40),
+        pathPoint(40, 40),
+        pathPoint(40, 82),
+        pathPoint(2, 82),
+      ];
+
+      it('accepts an L-shaped path nested in the L-shaped board', () => {
+        const cutout = createCutout({
+          shape: 'path',
+          x: 2,
+          y: 2,
+          width: 80,
+          depth: 80,
+          path: lPath,
+        });
+        // Its box spans x 2–82, y 2–82 — straight across the notch.
+        expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(true);
+      });
+
+      it('still rejects the same path once an arm reaches into the notch', () => {
+        const intoNotch = lPath.map((p) => pathPoint(p.x + 4, p.y + 4));
+        const cutout = createCutout({
+          shape: 'path',
+          x: 6,
+          y: 6,
+          width: 80,
+          depth: 80,
+          path: intoNotch,
+        });
+        expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(false);
+      });
+
+      it('accepts a circle whose corner-straddling box overhangs the notch', () => {
+        // Centered at (34, 34) with r=10: the box reaches (44, 44) past the
+        // notch corner at (42, 42), but that corner is 11.3mm out — clear of
+        // the rim, so no part of the disc is actually off the board.
+        const cutout = createCutout({ shape: 'circle', x: 24, y: 24, width: 20, depth: 20 });
+        expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(true);
+      });
+
+      it('rejects a circle that genuinely reaches into the notch', () => {
+        // Centered at (36, 36) with r=20 — the notch corner is 8.5mm out, well
+        // inside the disc.
+        const cutout = createCutout({ shape: 'circle', x: 16, y: 16, width: 40, depth: 40 });
+        expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(false);
+      });
+
+      it('validates a mesh imprint by its silhouette when the asset is supplied', () => {
+        const assets = {
+          m1: {
+            name: 'tool',
+            data: '',
+            triangleCount: 0,
+            sizeMm: { x: 80, y: 80, z: 5 },
+            outlines: [
+              [
+                { x: 0, y: 0 },
+                { x: 80, y: 0 },
+                { x: 80, y: 38 },
+                { x: 38, y: 38 },
+                { x: 38, y: 80 },
+                { x: 0, y: 80 },
+              ],
+            ],
+          },
+        };
+        const cutout = createCutout({
+          shape: 'mesh',
+          meshId: 'm1',
+          x: 2,
+          y: 2,
+          width: 80,
+          depth: 80,
+        });
+        expect(cutoutFitsInMask(cutout, lMask, CELL, assets)).toBe(true);
+        // Without the asset there is no silhouette to vouch for, so the
+        // footprint box decides — and it straddles the notch.
+        expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(false);
+      });
+
+      it('rejects an outline that escapes the board entirely', () => {
+        const outside = lPath.map((p) => pathPoint(p.x + 200, p.y));
+        const cutout = createCutout({
+          shape: 'path',
+          x: 202,
+          y: 2,
+          width: 80,
+          depth: 80,
+          path: outside,
+        });
+        expect(cutoutFitsInMask(cutout, lMask, CELL)).toBe(false);
+      });
+    });
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.test.ts
@@ -118,3 +118,71 @@ describe('handleDragMove rotation-aware clamping', () => {
     expect(patch?.x).toBe(bounds.binWidth - cutout.width);
   });
 });
+
+describe('handleDragMove polygon-mask rejection', () => {
+  // 2×2 mask, top-right cell empty — the notch is x ≥ 50, y ≥ 50.
+  const L_MASK: BinBounds = {
+    binWidth: 100,
+    binDepth: 100,
+    cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 0] },
+    maskCellSize: { cellMmX: 50, cellMmY: 50 },
+  };
+
+  const squarePath = (x: number, y: number, size: number) =>
+    [
+      { x, y },
+      { x: x + size, y },
+      { x: x + size, y: y + size },
+      { x, y: y + size },
+    ].map((p) => ({ ...p, handleIn: null, handleOut: null, symmetric: false }));
+
+  it('sticks a path cutout at the polygon edge instead of letting it slide into the notch', () => {
+    // Path vertices are absolute; the drag commit translates them along with
+    // x/y, so the candidate has to be tested at the dragged-to position.
+    const cutout = makeCutout({
+      shape: 'path',
+      x: 5,
+      y: 60,
+      width: 20,
+      depth: 20,
+      path: squarePath(5, 60, 20),
+    });
+    const setters = makeSetters();
+
+    handleDragMove(
+      makeMode(5, 60, [['c-1', 0, 0]]),
+      { mmX: 70, mmY: 60 },
+      [cutout],
+      L_MASK,
+      noopSnap,
+      NO_DEAD_ZONE,
+      setters as unknown as PreviewSetters
+    );
+
+    expect(setters.setPreview).not.toHaveBeenCalled();
+  });
+
+  it('allows a path drag that stays on filled cells', () => {
+    const cutout = makeCutout({
+      shape: 'path',
+      x: 5,
+      y: 60,
+      width: 20,
+      depth: 20,
+      path: squarePath(5, 60, 20),
+    });
+    const setters = makeSetters();
+
+    handleDragMove(
+      makeMode(5, 60, [['c-1', 0, 0]]),
+      { mmX: 25, mmY: 60 },
+      [cutout],
+      L_MASK,
+      noopSnap,
+      NO_DEAD_ZONE,
+      setters as unknown as PreviewSetters
+    );
+
+    expect(setters.preview?.get('c-1')?.x).toBe(25);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/dragHandler.ts
@@ -12,6 +12,7 @@ import {
   findAlignmentGuides,
   getRotatedBounds,
 } from '../geometry';
+import { translateCutoutPreview } from '../cutoutHelpers';
 import { cutoutFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
 import type { PointerMoveEvent, BinBounds, SnapFn, PreviewSetters, DeadZoneRef } from './types';
@@ -90,8 +91,11 @@ export function handleDragMove(
     for (const [id, updates] of nextPreview) {
       const orig = cutouts.find((c) => c.id === id);
       if (!orig) continue;
-      const candidate = { ...orig, ...updates };
-      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) {
+      // Path vertices are absolute and get translated on commit
+      // (`commitTransformPreview`), so the candidate has to move them too —
+      // otherwise the outline is validated at the position the drag left.
+      const candidate = translateCutoutPreview(orig, updates);
+      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize, bounds.meshAssets)) {
         return;
       }
     }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/drawHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/drawHandler.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleDrawMove } from './drawHandler';
+import type { InteractionMode } from '../useCutoutInteraction';
+import type { BinBounds, PreviewSetters } from './types';
+
+type DrawingMode = Extract<InteractionMode, { type: 'drawing' }>;
+
+const noopSnap = (n: number): number => n;
+
+const makeMode = (shape: DrawingMode['shape'], x: number, y: number): DrawingMode => ({
+  type: 'drawing',
+  shape,
+  startMmX: x,
+  startMmY: y,
+});
+
+function makeSetters() {
+  const setDrawingPreview = vi.fn();
+  return { setDrawingPreview } as unknown as Pick<PreviewSetters, 'setDrawingPreview'> & {
+    setDrawingPreview: ReturnType<typeof vi.fn>;
+  };
+}
+
+const PLAIN: BinBounds = { binWidth: 100, binDepth: 100 };
+
+// 2×2 mask with the top-right cell empty — the notch is x ≥ 50, y ≥ 50.
+const L_MASK: BinBounds = {
+  binWidth: 100,
+  binDepth: 100,
+  cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 0] },
+  maskCellSize: { cellMmX: 50, cellMmY: 50 },
+};
+
+describe('handleDrawMove', () => {
+  it('emits a corner-to-corner preview on an unmasked bin', () => {
+    const setters = makeSetters();
+    handleDrawMove(makeMode('rectangle', 10, 10), { mmX: 40, mmY: 30 }, PLAIN, noopSnap, setters);
+    expect(setters.setDrawingPreview).toHaveBeenCalledWith({
+      x: 10,
+      y: 10,
+      width: 30,
+      depth: 20,
+      shape: 'rectangle',
+    });
+  });
+
+  it('rejects a rectangle preview that straddles the notch', () => {
+    const setters = makeSetters();
+    handleDrawMove(makeMode('rectangle', 40, 40), { mmX: 70, mmY: 70 }, L_MASK, noopSnap, setters);
+    expect(setters.setDrawingPreview).not.toHaveBeenCalled();
+  });
+
+  it('accepts a circle whose bounding box overhangs the notch but whose disc does not', () => {
+    // Drawn 24→44 on both axes: the box crosses the (50, 50) notch corner…
+    const setters = makeSetters();
+    handleDrawMove(makeMode('circle', 24, 24), { mmX: 44, mmY: 44 }, L_MASK, noopSnap, setters);
+    expect(setters.setDrawingPreview).toHaveBeenCalledTimes(1);
+  });
+
+  it('still rejects a circle that genuinely reaches into the notch', () => {
+    const setters = makeSetters();
+    handleDrawMove(makeMode('circle', 20, 20), { mmX: 60, mmY: 60 }, L_MASK, noopSnap, setters);
+    expect(setters.setDrawingPreview).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/drawHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/drawHandler.ts
@@ -5,8 +5,9 @@
  * support: Shift constrains to square, Alt draws from center.
  */
 
+import { createDefaultCutout } from '../cutoutHelpers';
 import { MIN_CUTOUT_SIZE } from '../geometry';
-import { rectFitsInMask } from '../maskFit';
+import { cutoutFitsInMask } from '../maskFit';
 import type { InteractionMode } from '../useCutoutInteraction';
 import type { PointerMoveEvent, BinBounds, SnapFn, PreviewSetters } from './types';
 
@@ -56,20 +57,21 @@ export function handleDrawMove(
     shape: mode.shape,
   };
 
-  // Polygon mask: hard-reject draw preview that overhangs the polygon.
-  if (
-    bounds.cellMask &&
-    bounds.maskCellSize &&
-    !rectFitsInMask(
-      bounds.cellMask,
+  // Polygon mask: hard-reject draw preview that overhangs the polygon. Tested
+  // as the shape being drawn, not its box, so a circle can nest into a notch
+  // corner its bounding rect would straddle.
+  if (bounds.cellMask && bounds.maskCellSize) {
+    const candidate = createDefaultCutout(
+      'draw-preview',
+      preview.shape,
       preview.x,
       preview.y,
       preview.width,
-      preview.depth,
-      bounds.maskCellSize
-    )
-  ) {
-    return;
+      preview.depth
+    );
+    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize, bounds.meshAssets)) {
+      return;
+    }
   }
 
   setters.setDrawingPreview(preview);

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/groupRotateHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/groupRotateHandler.ts
@@ -60,7 +60,8 @@ export function handleGroupRotateMove(
       const orig = cutouts.find((c) => c.id === id);
       if (!orig) continue;
       const candidate = { ...orig, ...patch };
-      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) return;
+      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize, bounds.meshAssets))
+        return;
     }
   }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/groupScaleHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/groupScaleHandler.ts
@@ -61,7 +61,8 @@ export function handleGroupScaleMove(
       const orig = cutouts.find((c) => c.id === id);
       if (!orig) continue;
       const candidate = { ...orig, ...patch };
-      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) return;
+      if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize, bounds.meshAssets))
+        return;
     }
   }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/resizeHandler.ts
@@ -76,7 +76,7 @@ export function handleResizeMove(
   // Polygon mask: hard-reject resizes that would overhang the polygon.
   if (bounds.cellMask && bounds.maskCellSize) {
     const candidate = { ...cutout, ...nextPatch } as Cutout;
-    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) {
+    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize, bounds.meshAssets)) {
       return;
     }
   }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/rotateHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/rotateHandler.ts
@@ -57,7 +57,7 @@ export function handleRotateMove(
   // Polygon mask: hard-reject rotations whose rotated AABB overhangs the polygon.
   if (bounds.cellMask && bounds.maskCellSize) {
     const candidate = { ...cutout, rotation: newRotation } as Cutout;
-    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize)) {
+    if (!cutoutFitsInMask(candidate, bounds.cellMask, bounds.maskCellSize, bounds.meshAssets)) {
       return;
     }
   }

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/types.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Cutout, CutoutShape } from '@/features/bin-designer/types';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
 import type { CellMask } from '@/shared/utils/cellMask';
 import type { AlignmentGuide } from '../geometry';
 import type { MaskCellSize } from '../maskFit';
@@ -32,6 +33,9 @@ export interface BinBounds {
   readonly cellMask?: CellMask;
   /** Mm per mask cell. Required alongside cellMask; separate X/Y for non-square bins. */
   readonly maskCellSize?: MaskCellSize;
+  /** Mesh imprint silhouettes, so `mesh` cutouts validate against their outline
+   *  rather than their footprint box on a custom footprint. */
+  readonly meshAssets?: Readonly<Record<string, MeshAsset>>;
 }
 
 /** Snap function that respects the current snap-enabled state. */

--- a/src/features/bin-designer/components/panel/CutoutsSection/maskFit.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/maskFit.ts
@@ -5,10 +5,20 @@
  * covers is filled. Wall-thickness offset between interior and outer grid
  * coords is ignored — it's <5% of a mask cell and this check is purely UX
  * (the generator silently clips out-of-polygon geometry regardless).
+ *
+ * A bounding box decides this only for a *rectangular* board, where the box of
+ * a shape that fits is itself always inside. A masked board is concave, so the
+ * box test is a fast **accept** and nothing more — an L-shaped cutout sitting
+ * happily inside an L-shaped bin has a box that spans the notch. When the box
+ * test fails the real silhouette (`getCutoutOutline`) is clipped against the
+ * filled region instead.
  */
 
+import polygonClipping, { type MultiPolygon, type Polygon } from 'polygon-clipping';
 import type { Cutout } from '@/features/bin-designer/types';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
 import type { CellMask } from '@/shared/utils/cellMask';
+import { getCutoutOutline } from './cutoutOutline';
 import { getRotatedBounds, rotatePoint, type Bounds } from './geometry';
 import { getPathBounds, flattenPath } from './pathGeometry';
 
@@ -89,13 +99,123 @@ export function rectFitsInMask(
 }
 
 /**
- * Check whether a cutout's effective AABB fits within the mask polygon.
+ * Filled region of a mask as a clipping polygon, in bin-interior mm.
  *
- * Uses `getRotatedBounds()` for rectangles/ellipses and `getPathBounds()` for
- * path cutouts — all shapes are validated via their axis-aligned bounding box
- * for consistency with the existing bin-bound clamping.
+ * Each cell is grown by {@link MASK_FIT_EPSILON} before the union so a flush
+ * outline isn't rejected on float noise — the same slack `rectFitsInMask`
+ * grants by shrinking its query rect.
  */
-export function cutoutFitsInMask(cutout: Cutout, mask: CellMask, cellSize: MaskCellSize): boolean {
+function buildFilledRegion(mask: CellMask, cellSize: MaskCellSize): MultiPolygon {
+  const { cellMmX, cellMmY } = cellSize;
+  const rects: Polygon[] = [];
+  for (let r = 0; r < mask.rows; r++) {
+    for (let c = 0; c < mask.cols; c++) {
+      if (mask.cells[r * mask.cols + c] !== 1) continue;
+      const x0 = c * cellMmX - MASK_FIT_EPSILON;
+      const y0 = r * cellMmY - MASK_FIT_EPSILON;
+      const x1 = (c + 1) * cellMmX + MASK_FIT_EPSILON;
+      const y1 = (r + 1) * cellMmY + MASK_FIT_EPSILON;
+      rects.push([
+        [
+          [x0, y0],
+          [x1, y0],
+          [x1, y1],
+          [x0, y1],
+        ],
+      ]);
+    }
+  }
+  if (rects.length === 0) return [];
+  return polygonClipping.union(rects[0], ...rects.slice(1));
+}
+
+/**
+ * Memoized per mask instance: a drag re-checks the same board on every pointer
+ * move. `CellMask.cells` is contractually never mutated in place, so the object
+ * identity is a sound cache key (see `cellMask.ts`).
+ */
+const filledRegionCache = new WeakMap<CellMask, Map<string, MultiPolygon>>();
+
+function filledRegion(mask: CellMask, cellSize: MaskCellSize): MultiPolygon {
+  let byCellSize = filledRegionCache.get(mask);
+  if (!byCellSize) {
+    byCellSize = new Map<string, MultiPolygon>();
+    filledRegionCache.set(mask, byCellSize);
+  }
+  const key = `${cellSize.cellMmX}:${cellSize.cellMmY}`;
+  const cached = byCellSize.get(key);
+  if (cached) return cached;
+  const region = buildFilledRegion(mask, cellSize);
+  byCellSize.set(key, region);
+  return region;
+}
+
+/**
+ * Leftover area (mm²) below which a clip result is float noise rather than a
+ * real overhang. Genuine sub-epsilon overhangs are already absorbed by the
+ * region's epsilon growth, so anything surviving that is either noise or real.
+ */
+const RESIDUAL_AREA_EPSILON = 1e-6;
+
+function totalArea(polygons: MultiPolygon): number {
+  let area = 0;
+  for (const polygon of polygons) {
+    for (const ring of polygon) {
+      // Shoelace. Outer rings come back CCW (positive), holes CW (negative),
+      // so the running sum is the net covered area.
+      for (let i = 0, n = ring.length; i < n; i++) {
+        const [x1, y1] = ring[i];
+        const [x2, y2] = ring[(i + 1) % n];
+        area += (x1 * y2 - x2 * y1) / 2;
+      }
+    }
+  }
+  return area;
+}
+
+/** True when none of a cutout's silhouette rings escape the filled region. */
+function outlineFitsInMask(
+  cutout: Cutout,
+  mask: CellMask,
+  cellSize: MaskCellSize,
+  meshAssets: Readonly<Record<string, MeshAsset>> | undefined
+): boolean {
+  const rings = getCutoutOutline(cutout, meshAssets);
+  if (!rings || rings.length === 0) return false;
+  const region = filledRegion(mask, cellSize);
+  if (region.length === 0) return false;
+  const subject: MultiPolygon = rings.map((ring) => [
+    ring.map((p): [number, number] => [p.x, p.y]),
+  ]);
+  try {
+    return totalArea(polygonClipping.difference(subject, region)) <= RESIDUAL_AREA_EPSILON;
+  } catch {
+    // polygon-clipping rejects degenerate/self-intersecting rings, which a
+    // freeform pen path can be. Falling back to the bounding-box verdict keeps
+    // the drag loop alive and only ever errs toward rejecting the placement.
+    return false;
+  }
+}
+
+/**
+ * Check whether a cutout fits within the mask polygon.
+ *
+ * The bounding box (`getRotatedBounds()` for parametric shapes, true vertex
+ * bounds for paths) is tried first: a box inside the filled region proves the
+ * shape inside it is too, give or take the sub-epsilon slack both checks grant.
+ * Only when that fails does the real silhouette get clipped against the region,
+ * so concave boards accept the concave shapes that genuinely nest into them.
+ *
+ * `meshAssets` supplies the stored silhouette for `mesh` cutouts; without it a
+ * mesh imprint is validated by its footprint rectangle.
+ */
+export function cutoutFitsInMask(
+  cutout: Cutout,
+  mask: CellMask,
+  cellSize: MaskCellSize,
+  meshAssets?: Readonly<Record<string, MeshAsset>>
+): boolean {
   const { minX, minY, maxX, maxY } = getCutoutBounds(cutout);
-  return rectFitsInMask(mask, minX, minY, maxX - minX, maxY - minY, cellSize);
+  if (rectFitsInMask(mask, minX, minY, maxX - minX, maxY - minY, cellSize)) return true;
+  return outlineFitsInMask(cutout, mask, cellSize, meshAssets);
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
@@ -114,6 +114,53 @@ describe('isCutoutOffBoard', () => {
     expect(isCutoutOffBoard(overNotch, 100, 100, mask, cellSize)).toBe(true);
   });
 
+  // Issue #2922: "1 cutout(s) outside the board" on a concave cutout that is
+  // entirely on the board — its bounding box, not the cutout, spanned the notch.
+  it('does not flag a concave path nested inside the notch of an L-shaped board', () => {
+    const mask: CellMask = { cols: 2, rows: 2, cells: [1, 1, 1, 0] };
+    const cellSize = { cellMmX: 50, cellMmY: 50 };
+    // L-shaped path hugging the three filled cells; its box is the full 100×100.
+    const lShape = createCutout({
+      shape: 'path',
+      x: 2,
+      y: 2,
+      width: 96,
+      depth: 96,
+      path: [
+        corner(2, 2),
+        corner(98, 2),
+        corner(98, 48),
+        corner(48, 48),
+        corner(48, 98),
+        corner(2, 98),
+      ],
+    });
+    expect(isCutoutOffBoard(lShape, 100, 100, mask, cellSize)).toBe(false);
+    expect(getOffBoardCutoutIds([lShape], 100, 100, mask, cellSize).size).toBe(0);
+    expect(clampOffBoardCutouts([lShape], 100, 100, mask, cellSize).size).toBe(0);
+  });
+
+  it('still flags a concave path whose arm crosses into the notch', () => {
+    const mask: CellMask = { cols: 2, rows: 2, cells: [1, 1, 1, 0] };
+    const cellSize = { cellMmX: 50, cellMmY: 50 };
+    const reachesIn = createCutout({
+      shape: 'path',
+      x: 2,
+      y: 2,
+      width: 96,
+      depth: 96,
+      path: [
+        corner(2, 2),
+        corner(98, 2),
+        corner(98, 70),
+        corner(70, 70),
+        corner(70, 98),
+        corner(2, 98),
+      ],
+    });
+    expect(isCutoutOffBoard(reachesIn, 100, 100, mask, cellSize)).toBe(true);
+  });
+
   it('flags an array whose outer instance spills past the edge', () => {
     // Master fits at 70..90, but a 2-wide grid puts a second instance at 110..130.
     const arr = createCutout({

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -10,14 +10,17 @@
  * there is no array), so an array whose outer instances spill past the edge is
  * flagged even when the master fits. Footprints use the same `getCutoutBounds`
  * placement validation uses (true vertex bounds for paths), and a custom
- * (masked) footprint defers to polygon containment.
+ * (masked) footprint defers to the outline containment in `cutoutFitsInMask` —
+ * a bounding box would flag an L-shaped cutout nested in an L-shaped bin.
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
 import type { CellMask } from '@/shared/utils/cellMask';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
+import { translateCutout } from './cutoutHelpers';
 import { translatePathPoints } from './pathGeometry';
-import { getCutoutBounds, cutoutFitsInMask, rectFitsInMask, type MaskCellSize } from './maskFit';
+import { getCutoutBounds, cutoutFitsInMask, type MaskCellSize } from './maskFit';
 import type { Bounds } from './geometryCore';
 
 /** Tolerance (mm) — mirrors the interaction clamps so a flush edge isn't flagged. */
@@ -52,12 +55,15 @@ export function isCutoutOffBoard(
   binWidth: number,
   binDepth: number,
   mask?: CellMask,
-  cellSize?: MaskCellSize
+  cellSize?: MaskCellSize,
+  meshAssets?: Readonly<Record<string, MeshAsset>>
 ): boolean {
   const instances = expandCutoutArray(cutout);
   // Custom (masked) footprint: an instance inside the bounding rectangle can
   // still overhang the polygon, so defer to the containment check placements use.
-  if (mask && cellSize) return instances.some((inst) => !cutoutFitsInMask(inst, mask, cellSize));
+  if (mask && cellSize) {
+    return instances.some((inst) => !cutoutFitsInMask(inst, mask, cellSize, meshAssets));
+  }
   return instances.some((inst) => boundsOutsideRect(getCutoutBounds(inst), binWidth, binDepth));
 }
 
@@ -67,11 +73,12 @@ export function getOffBoardCutoutIds(
   binWidth: number,
   binDepth: number,
   mask?: CellMask,
-  cellSize?: MaskCellSize
+  cellSize?: MaskCellSize,
+  meshAssets?: Readonly<Record<string, MeshAsset>>
 ): Set<string> {
   const ids = new Set<string>();
   for (const c of cutouts) {
-    if (isCutoutOffBoard(c, binWidth, binDepth, mask, cellSize)) ids.add(c.id);
+    if (isCutoutOffBoard(c, binWidth, binDepth, mask, cellSize, meshAssets)) ids.add(c.id);
   }
   return ids;
 }
@@ -103,28 +110,30 @@ function rectOffset(
  * corner to each mask cell, so a valid run is found whenever one exists.
  */
 function maskOffset(
-  instanceBounds: readonly Bounds[],
+  instances: readonly Cutout[],
   mask: CellMask,
-  cellSize: MaskCellSize
+  cellSize: MaskCellSize,
+  meshAssets: Readonly<Record<string, MeshAsset>> | undefined
 ): { dx: number; dy: number } | null {
-  const u = unionBounds(instanceBounds);
+  const u = unionBounds(instances.map(getCutoutBounds));
   let best: { dx: number; dy: number } | null = null;
   let bestDist = Infinity;
   // Min-corner candidates only need cells [0, cols)×[0, rows): aligning the
-  // corner to the far boundary always overhangs (rectFitsInMask rejects it).
+  // corner to the far boundary always overhangs (cutoutFitsInMask rejects it).
   for (let r = 0; r < mask.rows; r++) {
     for (let c = 0; c < mask.cols; c++) {
       const dx = c * cellSize.cellMmX - u.minX;
       const dy = r * cellSize.cellMmY - u.minY;
-      const fits = instanceBounds.every((b) =>
-        rectFitsInMask(mask, b.minX + dx, b.minY + dy, b.maxX - b.minX, b.maxY - b.minY, cellSize)
+      const dist = dx * dx + dy * dy;
+      // Containment is the expensive half of this scan, so skip candidates that
+      // can't beat the incumbent before testing them.
+      if (dist >= bestDist) continue;
+      const fits = instances.every((inst) =>
+        cutoutFitsInMask(translateCutout(inst, dx, dy), mask, cellSize, meshAssets)
       );
       if (!fits) continue;
-      const dist = dx * dx + dy * dy;
-      if (dist < bestDist) {
-        best = { dx, dy };
-        bestDist = dist;
-      }
+      best = { dx, dy };
+      bestDist = dist;
     }
   }
   return best;
@@ -141,13 +150,14 @@ export function clampCutoutToBoard(
   binWidth: number,
   binDepth: number,
   mask?: CellMask,
-  cellSize?: MaskCellSize
+  cellSize?: MaskCellSize,
+  meshAssets?: Readonly<Record<string, MeshAsset>>
 ): Partial<Cutout> | null {
-  const instanceBounds = expandCutoutArray(cutout).map(getCutoutBounds);
+  const instances = expandCutoutArray(cutout);
   const offset =
     mask && cellSize
-      ? maskOffset(instanceBounds, mask, cellSize)
-      : rectOffset(instanceBounds, binWidth, binDepth);
+      ? maskOffset(instances, mask, cellSize, meshAssets)
+      : rectOffset(instances.map(getCutoutBounds), binWidth, binDepth);
   if (!offset) return null;
   const { dx, dy } = offset;
   if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) return null;
@@ -164,12 +174,13 @@ export function clampOffBoardCutouts(
   binWidth: number,
   binDepth: number,
   mask?: CellMask,
-  cellSize?: MaskCellSize
+  cellSize?: MaskCellSize,
+  meshAssets?: Readonly<Record<string, MeshAsset>>
 ): Map<string, Partial<Cutout>> {
   const updates = new Map<string, Partial<Cutout>>();
   for (const c of cutouts) {
-    if (!isCutoutOffBoard(c, binWidth, binDepth, mask, cellSize)) continue;
-    const moved = clampCutoutToBoard(c, binWidth, binDepth, mask, cellSize);
+    if (!isCutoutOffBoard(c, binWidth, binDepth, mask, cellSize, meshAssets)) continue;
+    const moved = clampCutoutToBoard(c, binWidth, binDepth, mask, cellSize, meshAssets);
     if (moved) updates.set(c.id, moved);
   }
   return updates;

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
+import { useDesignerStore } from '@/features/bin-designer/store';
 import type { CellMask } from '@/shared/utils/cellMask';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
 import type { PreviewMap } from '../useCutoutInteraction';
@@ -30,6 +31,10 @@ export function OffBoardFrames3D({
   binDepth,
   cellMask,
 }: OffBoardFrames3DProps) {
+  // Read straight from the store (like MeshFootprintMesh) so a mesh imprint is
+  // re-tested by the same silhouette `offBoardIds` used — otherwise the frames
+  // drift out of lockstep with the warning that summons them.
+  const meshAssets = useDesignerStore((s) => s.params.meshAssets);
   if (offBoardIds.size === 0) return null;
   const maskCellSize = cellMask
     ? { cellMmX: binWidth / cellMask.cols, cellMmY: binDepth / cellMask.rows }
@@ -40,7 +45,9 @@ export function OffBoardFrames3D({
         .filter((c) => offBoardIds.has(c.id) && !c.hidden)
         .flatMap((c) =>
           expandCutoutArray({ ...c, ...preview.get(c.id) })
-            .filter((inst) => isCutoutOffBoard(inst, binWidth, binDepth, cellMask, maskCellSize))
+            .filter((inst) =>
+              isCutoutOffBoard(inst, binWidth, binDepth, cellMask, maskCellSize, meshAssets)
+            )
             .map((inst) => (
               <OffBoardBounds3D key={`offboard-${inst.id}`} bounds={getCutoutBounds(inst)} />
             ))

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutClipboard.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutClipboard.ts
@@ -9,6 +9,7 @@
 import { useCallback, useRef, useState } from 'react';
 import type { Cutout } from '@/features/bin-designer/types';
 import type { CellMask } from '@/shared/utils/cellMask';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
 import type { MaskCellSize } from './maskFit';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
@@ -25,6 +26,7 @@ interface UseCutoutClipboardOptions {
   readonly binDepth: number;
   readonly cellMask?: CellMask;
   readonly maskCellSize?: MaskCellSize;
+  readonly meshAssets?: Readonly<Record<string, MeshAsset>>;
 }
 
 export interface CutoutClipboard {
@@ -43,6 +45,7 @@ export function useCutoutClipboard({
   binDepth,
   cellMask,
   maskCellSize,
+  meshAssets,
 }: UseCutoutClipboardOptions): CutoutClipboard {
   const addToast = useToastStore((s) => s.addToast);
   const t = useTranslation();
@@ -73,7 +76,7 @@ export function useCutoutClipboard({
       cellMask && maskCellSize
         ? clipboard.filter((orig) => {
             const pos = clampedOffset(orig, offset, binWidth, binDepth);
-            return cutoutFitsInMask({ ...orig, ...pos }, cellMask, maskCellSize);
+            return cutoutFitsInMask({ ...orig, ...pos }, cellMask, maskCellSize, meshAssets);
           })
         : clipboard;
     if (placeable.length === 0) return;
@@ -81,7 +84,7 @@ export function useCutoutClipboard({
     addClonedCutouts(placeable, onAdd, setSelection, (original) =>
       clampedOffset(original, offset, binWidth, binDepth)
     );
-  }, [clipboard, onAdd, setSelection, binWidth, binDepth, cellMask, maskCellSize]);
+  }, [clipboard, onAdd, setSelection, binWidth, binDepth, cellMask, maskCellSize, meshAssets]);
 
   const duplicateSelected = useCallback(() => {
     const selected = cutouts.filter((c) => selection.has(c.id));
@@ -91,7 +94,7 @@ export function useCutoutClipboard({
       cellMask && maskCellSize
         ? selected.filter((orig) => {
             const pos = clampedOffset(orig, PASTE_OFFSET, binWidth, binDepth);
-            return cutoutFitsInMask({ ...orig, ...pos }, cellMask, maskCellSize);
+            return cutoutFitsInMask({ ...orig, ...pos }, cellMask, maskCellSize, meshAssets);
           })
         : selected;
     if (placeable.length === 0) return;
@@ -99,7 +102,17 @@ export function useCutoutClipboard({
     addClonedCutouts(placeable, onAdd, setSelection, (original) =>
       clampedOffset(original, PASTE_OFFSET, binWidth, binDepth)
     );
-  }, [cutouts, selection, onAdd, setSelection, binWidth, binDepth, cellMask, maskCellSize]);
+  }, [
+    cutouts,
+    selection,
+    onAdd,
+    setSelection,
+    binWidth,
+    binDepth,
+    cellMask,
+    maskCellSize,
+    meshAssets,
+  ]);
 
   return { clipboard, copySelected, pasteFromClipboard, duplicateSelected };
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutInteraction.ts
@@ -56,6 +56,7 @@ export function useCutoutInteraction({
   gridSize = 0.5,
   cellMask,
   maskCellSize,
+  meshAssets,
 }: UseCutoutInteractionOptions) {
   const [mode, setMode] = useState<InteractionMode>({ type: 'placing', shape: 'rectangle' });
   const [selection, setSelection] = useState<ReadonlySet<string>>(new Set());
@@ -197,7 +198,7 @@ export function useCutoutInteraction({
           const orig = cutouts.find((c) => c.id === id);
           if (!orig) continue;
           const candidate = { ...orig, ...patch };
-          if (!cutoutFitsInMask(candidate, cellMask, maskCellSize)) return;
+          if (!cutoutFitsInMask(candidate, cellMask, maskCellSize, meshAssets)) return;
         }
       }
 
@@ -209,7 +210,17 @@ export function useCutoutInteraction({
         }
       }
     },
-    [selection, cutouts, onUpdate, onUpdateBatch, binWidth, binDepth, cellMask, maskCellSize]
+    [
+      selection,
+      cutouts,
+      onUpdate,
+      onUpdateBatch,
+      binWidth,
+      binDepth,
+      cellMask,
+      maskCellSize,
+      meshAssets,
+    ]
   );
 
   // ── Sub-hooks: clipboard, context menu, undo toasts ───────────────
@@ -223,6 +234,7 @@ export function useCutoutInteraction({
     binDepth,
     cellMask,
     maskCellSize,
+    meshAssets,
   });
 
   const { contextMenu, openContextMenu, closeContextMenu } = useCutoutContextMenu();
@@ -298,6 +310,7 @@ export function useCutoutInteraction({
     binDepth,
     cellMask,
     maskCellSize,
+    meshAssets,
     rulerSnapTargets,
     rulerZoomRef,
     pastDeadZoneRef,

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPathTool.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPathTool.ts
@@ -26,7 +26,7 @@ import {
   isSelfIntersecting,
 } from './pathGeometry';
 import { dropCoincidentPoints } from '@/shared/utils/polyline';
-import { rectFitsInMask, type MaskCellSize } from './maskFit';
+import { cutoutFitsInMask, type MaskCellSize } from './maskFit';
 import { createDefaultCutout } from './cutoutHelpers';
 import type { InteractionMode, PreviewMap } from './cutoutInteractionTypes';
 
@@ -104,23 +104,22 @@ export function useCutoutPathTool({
       }
 
       const { minX, minY, maxX, maxY } = getPathBounds(clamped);
+      const newId = crypto.randomUUID();
+      const created: Cutout = {
+        ...createDefaultCutout(newId, 'path', minX, minY, maxX - minX, maxY - minY),
+        path: clamped,
+      };
 
-      // Polygon bins: reject paths whose bounds overhang the mask.
-      if (
-        cellMask &&
-        maskCellSize &&
-        !rectFitsInMask(cellMask, minX, minY, maxX - minX, maxY - minY, maskCellSize)
-      ) {
+      // Polygon bins: reject paths that overhang the mask. Tested against the
+      // drawn outline, not its bounding box — a concave path can sit entirely
+      // inside a concave board whose notch its box would straddle.
+      if (cellMask && maskCellSize && !cutoutFitsInMask(created, cellMask, maskCellSize)) {
         setPathDrawingPreview(null);
         setMode({ type: 'idle' });
         return;
       }
 
-      const newId = crypto.randomUUID();
-      onAdd({
-        ...createDefaultCutout(newId, 'path', minX, minY, maxX - minX, maxY - minY),
-        path: clamped,
-      });
+      onAdd(created);
       setSelection(new Set([newId]));
       setMode({ type: 'idle' });
       setPathDrawingPreview(null);

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPointerHandlers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPointerHandlers.ts
@@ -10,6 +10,7 @@
 
 import { useCallback } from 'react';
 import type { Cutout, CutoutShape, PathPoint } from '@/features/bin-designer/types';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
 import type { CellMask } from '@/shared/utils/cellMask';
 import {
   handlePendingPlaceMove,
@@ -28,7 +29,7 @@ import type { PathDrawingPreviewState, SegmentHoverInfo } from './handlers';
 import { snapToNearestTarget, computeMeasurement } from './handlers/rulerHandler';
 import type { RulerMeasurement, SnapTarget } from './handlers/rulerHandler';
 import { MIN_CUTOUT_SIZE, type AlignmentGuide } from './geometry';
-import { rectFitsInMask, type MaskCellSize } from './maskFit';
+import { cutoutFitsInMask, type MaskCellSize } from './maskFit';
 import { createDefaultCutout, defaultPlaceSize } from './cutoutHelpers';
 import { type InteractionMode, type PreviewMap } from './cutoutInteractionTypes';
 
@@ -58,6 +59,7 @@ interface UseCutoutPointerHandlersOptions {
   readonly binDepth: number;
   readonly cellMask?: CellMask;
   readonly maskCellSize?: MaskCellSize;
+  readonly meshAssets?: Readonly<Record<string, MeshAsset>>;
   readonly rulerSnapTargets: readonly SnapTarget[];
   readonly rulerZoomRef: React.RefObject<number>;
   readonly pastDeadZoneRef: React.RefObject<boolean>;
@@ -99,6 +101,7 @@ export function useCutoutPointerHandlers(
     binDepth,
     cellMask,
     maskCellSize,
+    meshAssets,
     rulerSnapTargets,
     rulerZoomRef,
     pastDeadZoneRef,
@@ -112,7 +115,7 @@ export function useCutoutPointerHandlers(
   const handlePointerMove = useCallback(
     (mmX: number, mmY: number, shiftKey?: boolean, altKey?: boolean) => {
       const event = { mmX, mmY, shiftKey, altKey };
-      const bounds = { binWidth, binDepth, cellMask, maskCellSize };
+      const bounds = { binWidth, binDepth, cellMask, maskCellSize, meshAssets };
 
       switch (mode.type) {
         case 'pending-place':
@@ -206,6 +209,7 @@ export function useCutoutPointerHandlers(
       binDepth,
       cellMask,
       maskCellSize,
+      meshAssets,
       snap,
       commitPath,
       rulerSnapTargets,
@@ -228,22 +232,25 @@ export function useCutoutPointerHandlers(
       const x = Math.max(0, Math.min(snap(placeMode.startMmX - defaultW / 2), binWidth - defaultW));
       const y = Math.max(0, Math.min(snap(placeMode.startMmY - defaultD / 2), binDepth - defaultD));
 
-      // Polygon mask: reject click-to-place inside an unfilled notch.
+      const newId = crypto.randomUUID();
+      const created = createDefaultCutout(newId, placeMode.shape, x, y, defaultW, defaultD);
+
+      // Polygon mask: reject click-to-place inside an unfilled notch, testing
+      // the shape's outline rather than its bounding box.
       if (
         cellMask &&
         maskCellSize &&
-        !rectFitsInMask(cellMask, x, y, defaultW, defaultD, maskCellSize)
+        !cutoutFitsInMask(created, cellMask, maskCellSize, meshAssets)
       ) {
         setMode({ type: 'idle' });
         return;
       }
 
-      const newId = crypto.randomUUID();
-      onAdd(createDefaultCutout(newId, placeMode.shape, x, y, defaultW, defaultD));
+      onAdd(created);
       setSelection(new Set([newId]));
       setMode({ type: 'idle' });
     },
-    [snap, binWidth, binDepth, cellMask, maskCellSize, onAdd, setSelection, setMode]
+    [snap, binWidth, binDepth, cellMask, maskCellSize, meshAssets, onAdd, setSelection, setMode]
   );
 
   /**


### PR DESCRIPTION
Fixes #2922

## Problem

On a custom (masked) bin footprint, cutout placement and off-board detection tested a cutout's **axis-aligned bounding box** against the cell mask.

That is exact for a *rectangular* board — the bounding box of a shape that fits is itself inside the rectangle. But a masked board is **concave**, and there the box test only ever proves a fit, never a miss. An L-shaped cutout nested inside an L-shaped bin has a box that spans the notch, so the editor reported `1 cutout(s) outside the board` for a cutout entirely on the board:

<img width="500" alt="reported symptom" src="https://github.com/user-attachments/assets/b1ad7edf-5f43-4e9b-8ede-69696bf4869d" />

## Fix

`cutoutFitsInMask` now treats `rectFitsInMask` as a **fast accept** only. When the box test fails it clips the cutout's real silhouette against the mask's filled region using `polygon-clipping` (already a dependency, used by the Pathfinder preview).

Silhouettes come from a new `cutoutOutline` module and are deliberately **conservative supersets** of the shape — curved spans (ellipses, rounded-rect and slot corners) sample a *circumscribing* polygon rather than an inscribed one — so a placement this check accepts never clips in the generated mesh.

Since the box test short-circuits on accept, the hot drag loop pays nothing in the common case, and the filled region is memoized per `CellMask` instance.

Surfaces switched from box to outline:

- off-board detection + the red frames and "Bring back in" clamp (the reported symptom)
- drag / resize / rotate / group-rotate / group-scale, keyboard nudge, paste & duplicate
- pen-tool commit, draw-to-place preview, click-to-place

`mesh` cutouts need their stored silhouette rings, so `meshAssets` is threaded through the mask checks; without it a mesh imprint still falls back to its footprint rectangle (unchanged behaviour).

## Second bug found along the way

A path cutout's absolute vertices are translated when a drag **commits**, but the preview candidate handed to the mask validator only had `x`/`y` patched. `getCutoutBounds` reads the path vertices, so dragging a path cutout around a masked bin validated the position it was *leaving* — the check never fired, and a path could be dragged into a notch. `translateCutoutPreview` now moves the vertices in lockstep, mirroring what the commit writes.

## Testing

- `cutoutOutline.test.ts` (new, 11 tests) — per-shape rings, the circumscribing property for ellipses, path rotation about vertex bounds, mesh silhouette mapping and its no-asset fallback
- `geometry.test.ts` — the reported repro plus concave/circle accept-and-reject pairs and the mesh path
- `offBoardCutouts.test.ts` — the L-in-L board no longer flags, an arm reaching into the notch still does
- `dragHandler.test.ts` / `drawHandler.test.ts` (new) — path drag sticks at the polygon edge; draw preview accepts a circle whose box straddles a notch corner
- Full `bin-designer` suite: 3541 tests pass. `pnpm run quality` clean.

The path-drag regression test was verified to fail against the pre-fix candidate construction.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false “outside the board” flags on masked boards by validating cutout placement against the actual outline instead of the axis-aligned bounding box. Resolves the L-in-L case in #2922 and updates all interactions to respect concave footprints without hurting drag performance.

- **Bug Fixes**
  - `cutoutFitsInMask` now treats the AABB as a fast accept; on failure it clips the real outline against the filled region using `polygon-clipping`.
  - New `cutoutOutline` builds conservative silhouette rings (curves are circumscribed). `mesh` cutouts use stored outline rings; fallback to the footprint rectangle if the asset is missing. Threaded `meshAssets` through validators and callers.
  - Fixed path drag validation: preview candidates now translate absolute path vertices with x/y (`translateCutoutPreview`), matching commit behavior.
  - Switched to outline checks for off-board detection, “Bring back in” clamping, drag/resize/rotate/group ops, keyboard nudge, paste/duplicate, draw preview, and click-to-place.
  - Memoized the mask’s filled region per `CellMask`. The common case still short-circuits on the AABB, so drag stays fast.

<sup>Written for commit 30f79954e561352218f22c65f3ed5859200d4a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

