### PR TITLE
perf(generation): cut kumiko wall pattern generation by up to 55%

### DIFF
--- a/src/features/generation/worker/generators/kumikoWrapBuilder.partition.test.ts
+++ b/src/features/generation/worker/generators/kumikoWrapBuilder.partition.test.ts
@@ -2,21 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { partitionDisjoint, strokeFootprint, type FootprintBox } from './kumikoWrapBuilder';
 import type { KumikoSegment } from './patterns';
 
-/** partitionDisjoint only reads `boxes`; the tool handles are opaque to it. */
-function toolsFor(boxes: readonly FootprintBox[]): number[] {
-  return boxes.map((_, i) => i);
-}
-
 function box(u0: number, u1: number, z0: number, z1: number): FootprintBox {
   return { u0, u1, z0, z1 };
 }
 
 function partitionIndices(boxes: readonly FootprintBox[]): number[][] {
-  // The production signature takes Shape3D[]; the algorithm never touches a
-  // shape, so stand in plain indices to keep this test off the WASM kernel.
+  // `partitionDisjoint` reads only `box` and never touches the solid, so stand
+  // in plain indices to keep this test off the WASM kernel.
+  const tools = boxes.map((b, i) => ({ solid: i, box: b }));
   return partitionDisjoint(
-    toolsFor(boxes) as unknown as Parameters<typeof partitionDisjoint>[0],
-    boxes
+    tools as unknown as Parameters<typeof partitionDisjoint>[0]
   ) as unknown as number[][];
 }
 
@@ -31,13 +26,22 @@ describe('strokeFootprint', () => {
     expect(f.z1).toBeCloseTo(1, 6);
   });
 
-  it('grows the box for a rotated segment', () => {
+  it('encloses a rotated segment on every side', () => {
+    // A 45° thin rect: the box must contain the whole rotated rectangle, and
+    // pinning all four bounds catches an asymmetric under-estimate that a
+    // width-only check would let through. `partitionDisjoint` relies on the
+    // enclosure being conservative, never tight.
     const diagonal: KumikoSegment = { a: [0, 0], b: [10, 10] };
     const f = strokeFootprint(diagonal, 2);
-    // A 45° thin rect needs a box wider than its own width on both axes —
-    // this conservatism is why struts are not partitioned this way.
+    // len = 10√2; stroke rect is (len + 2) x 2 at 45°, so each half-extent is
+    // ((len + 2) + 2) / √2 / 2, about the midpoint (5, 5).
+    const half = (10 * Math.SQRT2 + 4) / Math.SQRT2 / 2;
+    expect(f.u0).toBeCloseTo(5 - half, 6);
+    expect(f.u1).toBeCloseTo(5 + half, 6);
+    expect(f.z0).toBeCloseTo(5 - half, 6);
+    expect(f.z1).toBeCloseTo(5 + half, 6);
+    // Conservative: strictly larger than the segment's own 10mm span.
     expect(f.u1 - f.u0).toBeGreaterThan(10);
-    expect(f.z1 - f.z0).toBeGreaterThan(10);
   });
 
   it('honours a per-segment width override', () => {

--- a/src/features/generation/worker/generators/kumikoWrapBuilder.partition.test.ts
+++ b/src/features/generation/worker/generators/kumikoWrapBuilder.partition.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { partitionDisjoint, strokeFootprint, type FootprintBox } from './kumikoWrapBuilder';
+import type { KumikoSegment } from './patterns';
+
+/** partitionDisjoint only reads `boxes`; the tool handles are opaque to it. */
+function toolsFor(boxes: readonly FootprintBox[]): number[] {
+  return boxes.map((_, i) => i);
+}
+
+function box(u0: number, u1: number, z0: number, z1: number): FootprintBox {
+  return { u0, u1, z0, z1 };
+}
+
+function partitionIndices(boxes: readonly FootprintBox[]): number[][] {
+  // The production signature takes Shape3D[]; the algorithm never touches a
+  // shape, so stand in plain indices to keep this test off the WASM kernel.
+  return partitionDisjoint(
+    toolsFor(boxes) as unknown as Parameters<typeof partitionDisjoint>[0],
+    boxes
+  ) as unknown as number[][];
+}
+
+describe('strokeFootprint', () => {
+  it('boxes a horizontal segment as length+width by width', () => {
+    const seg: KumikoSegment = { a: [0, 0], b: [10, 0] };
+    const f = strokeFootprint(seg, 2);
+    // Stroke rect is (10 + 2) long and 2 tall, centred on (5, 0).
+    expect(f.u0).toBeCloseTo(-1, 6);
+    expect(f.u1).toBeCloseTo(11, 6);
+    expect(f.z0).toBeCloseTo(-1, 6);
+    expect(f.z1).toBeCloseTo(1, 6);
+  });
+
+  it('grows the box for a rotated segment', () => {
+    const diagonal: KumikoSegment = { a: [0, 0], b: [10, 10] };
+    const f = strokeFootprint(diagonal, 2);
+    // A 45° thin rect needs a box wider than its own width on both axes —
+    // this conservatism is why struts are not partitioned this way.
+    expect(f.u1 - f.u0).toBeGreaterThan(10);
+    expect(f.z1 - f.z0).toBeGreaterThan(10);
+  });
+
+  it('honours a per-segment width override', () => {
+    const seg: KumikoSegment = { a: [0, 0], b: [10, 0], width: 4 };
+    expect(strokeFootprint(seg, 2).z1).toBeCloseTo(2, 6);
+  });
+});
+
+describe('partitionDisjoint', () => {
+  it('keeps mutually disjoint tools in a single bucket', () => {
+    const boxes = [box(0, 1, 0, 1), box(2, 3, 0, 1), box(4, 5, 0, 1)];
+    expect(partitionIndices(boxes)).toEqual([[0, 1, 2]]);
+  });
+
+  it('separates overlapping tools into different buckets', () => {
+    const boxes = [box(0, 2, 0, 1), box(1, 3, 0, 1)];
+    expect(partitionIndices(boxes)).toEqual([[0], [1]]);
+  });
+
+  it('every bucket it returns is pairwise disjoint', () => {
+    // A chain where each piece overlaps only its neighbour — the shape a
+    // lattice's filling pieces actually make.
+    const boxes = Array.from({ length: 20 }, (_, i) => box(i, i + 1.5, 0, 1));
+    const buckets = partitionIndices(boxes);
+    for (const bucket of buckets) {
+      for (const a of bucket) {
+        for (const b of bucket) {
+          if (a === b) continue;
+          const overlap =
+            boxes[a].u0 < boxes[b].u1 &&
+            boxes[b].u0 < boxes[a].u1 &&
+            boxes[a].z0 < boxes[b].z1 &&
+            boxes[b].z0 < boxes[a].z1;
+          expect(overlap).toBe(false);
+        }
+      }
+    }
+    // A chain of neighbour-overlaps needs exactly two colours, and greedy
+    // first-fit finds them — over-splitting would cost more cutAll calls than
+    // it saves in intersection work.
+    expect(buckets).toHaveLength(2);
+  });
+
+  it('treats edge-touching boxes as disjoint', () => {
+    expect(partitionIndices([box(0, 1, 0, 1), box(1, 2, 0, 1)])).toEqual([[0, 1]]);
+  });
+
+  it('returns no buckets for no tools', () => {
+    expect(partitionIndices([])).toEqual([]);
+  });
+});

--- a/src/features/generation/worker/generators/kumikoWrapBuilder.ts
+++ b/src/features/generation/worker/generators/kumikoWrapBuilder.ts
@@ -356,6 +356,80 @@ function fillingPiecesForRange(
  * Returns null when the slab has no struts at all — an empty lattice must
  * degrade to solid walls, not cut the whole wall away.
  */
+/** Axis-aligned footprint of a stroked segment in the slab's (u, z) plane. */
+export interface FootprintBox {
+  readonly u0: number;
+  readonly u1: number;
+  readonly z0: number;
+  readonly z1: number;
+}
+
+/**
+ * AABB of the rectangle `strokeSegment` draws for `seg` — length |ab| + width,
+ * height width, rotated to the segment's direction.
+ *
+ * Deliberately conservative for a rotated segment: the box around a diagonal
+ * thin rectangle is much larger than the rectangle. That over-reports overlap,
+ * which is safe here (a bucket stays disjoint) but is why this is only used to
+ * partition filling pieces — the struts are already split by direction, and
+ * boxing a diagonal family would split it far past the point where the
+ * per-`cutAll` overhead outweighs the saved intersection work.
+ */
+export function strokeFootprint(seg: KumikoSegment, defaultWidth: number): FootprintBox {
+  const width = seg.width ?? defaultWidth;
+  const [ua, za] = seg.a;
+  const [ub, zb] = seg.b;
+  const du = ub - ua;
+  const dz = zb - za;
+  const len = Math.hypot(du, dz);
+  const cos = len === 0 ? 1 : Math.abs(du) / len;
+  const sin = len === 0 ? 0 : Math.abs(dz) / len;
+  const halfU = ((len + width) * cos + width * sin) / 2;
+  const halfZ = ((len + width) * sin + width * cos) / 2;
+  return {
+    u0: (ua + ub) / 2 - halfU,
+    u1: (ua + ub) / 2 + halfU,
+    z0: (za + zb) / 2 - halfZ,
+    z1: (za + zb) / 2 + halfZ,
+  };
+}
+
+function boxesOverlap(a: FootprintBox, b: FootprintBox): boolean {
+  return a.u0 < b.u1 && b.u0 < a.u1 && a.z0 < b.z1 && b.z0 < a.z1;
+}
+
+/**
+ * Split tools into buckets whose footprints are pairwise disjoint.
+ *
+ * `cutAll` pays for tool-TOOL intersections on top of tool-vs-region, and that
+ * pairwise cost grows super-linearly in the bucket — which is exactly why the
+ * struts are partitioned by direction above. Filling pieces radiate from a
+ * lattice vertex and are extended to weld into their neighbours, so they have
+ * no direction to group by and every piece overlaps the next; cutting all of
+ * them in one op was ~93% of a kumiko bin's generation time.
+ *
+ * Greedy first-fit. A piece only reaches its immediate neighbours, so this
+ * settles at a handful of buckets (6 of 14 for asanoha) — and bigger disjoint
+ * buckets beat smaller overlapping ones, since each `cutAll` also carries a
+ * fixed cost that punishes over-splitting.
+ */
+export function partitionDisjoint(tools: Shape3D[], boxes: readonly FootprintBox[]): Shape3D[][] {
+  const buckets: Shape3D[][] = [];
+  const bucketBoxes: FootprintBox[][] = [];
+  for (let i = 0; i < tools.length; i++) {
+    const box = boxes[i];
+    const free = bucketBoxes.findIndex((taken) => !taken.some((o) => boxesOverlap(o, box)));
+    if (free === -1) {
+      buckets.push([tools[i]]);
+      bucketBoxes.push([box]);
+    } else {
+      buckets[free].push(tools[i]);
+      bucketBoxes[free].push(box);
+    }
+  }
+  return buckets;
+}
+
 export function buildFlatSlabCutter(
   slab: FlatSlab,
   lattice: KumikoLattice,
@@ -400,11 +474,12 @@ export function buildFlatSlabCutter(
       strutCount++;
     }
   }
-  // Filling pieces ride as individual prisms in their own bucket. Prebuilt
-  // per-vertex stamp solids were tried and measured WORSE: neighboring stamps
-  // overlap, and overlapping multi-prism tools cost more in the cutAll than
-  // the extra prism count saves.
+  // Filling pieces ride as individual prisms, bucketed by `partitionDisjoint`
+  // below. Prebuilt per-vertex stamp solids were tried and measured WORSE:
+  // neighboring stamps overlap, and overlapping multi-prism tools cost more in
+  // the cutAll than the extra prism count saves.
   const fillings: Shape3D[] = [];
+  const fillingBoxes: FootprintBox[] = [];
   const maxW = maxStrutWidth(lattice);
   for (const piece of fillingPiecesForRange(lattice, uA - maxW, uB + maxW, perimeter)) {
     const pw = piece.width ?? w;
@@ -413,7 +488,9 @@ export function buildFlatSlabCutter(
       b: [piece.b[0], piece.b[1] + bandZ0],
       ...(piece.width === undefined ? {} : { width: piece.width }),
     };
-    const drawing = strokeSegment(extendSegment(absolute, pw / 2), w, uCenter, zCenter);
+    const extended = extendSegment(absolute, pw / 2);
+    fillingBoxes.push(strokeFootprint(extended, w));
+    const drawing = strokeSegment(extended, w, uCenter, zCenter);
     const prism = sketch(drawing, 'XY').extrude(strutDepth);
     fillings.push(translate(prism, [0, 0, -strutDepth / 2]));
     prism.delete();
@@ -429,7 +506,7 @@ export function buildFlatSlabCutter(
   let region = translate(slabPrism, [0, 0, -halfDepth]);
   slabPrism.delete();
 
-  for (const family of [...families, fillings]) {
+  for (const family of [...families, ...partitionDisjoint(fillings, fillingBoxes)]) {
     if (family.length === 0) continue;
     const carved = unwrap(cutAll(region, family, { trackEvolution: false }));
     region.delete();

--- a/src/features/generation/worker/generators/kumikoWrapBuilder.ts
+++ b/src/features/generation/worker/generators/kumikoWrapBuilder.ts
@@ -398,6 +398,13 @@ function boxesOverlap(a: FootprintBox, b: FootprintBox): boolean {
   return a.u0 < b.u1 && b.u0 < a.u1 && a.z0 < b.z1 && b.z0 < a.z1;
 }
 
+/** A cut tool paired with its footprint. One array, not two, so a tool can
+ *  never drift out of step with the box that describes it. */
+export interface BoxedTool {
+  readonly solid: Shape3D;
+  readonly box: FootprintBox;
+}
+
 /**
  * Split tools into buckets whose footprints are pairwise disjoint.
  *
@@ -413,17 +420,16 @@ function boxesOverlap(a: FootprintBox, b: FootprintBox): boolean {
  * buckets beat smaller overlapping ones, since each `cutAll` also carries a
  * fixed cost that punishes over-splitting.
  */
-export function partitionDisjoint(tools: Shape3D[], boxes: readonly FootprintBox[]): Shape3D[][] {
+export function partitionDisjoint(tools: readonly BoxedTool[]): Shape3D[][] {
   const buckets: Shape3D[][] = [];
   const bucketBoxes: FootprintBox[][] = [];
-  for (let i = 0; i < tools.length; i++) {
-    const box = boxes[i];
+  for (const { solid, box } of tools) {
     const free = bucketBoxes.findIndex((taken) => !taken.some((o) => boxesOverlap(o, box)));
     if (free === -1) {
-      buckets.push([tools[i]]);
+      buckets.push([solid]);
       bucketBoxes.push([box]);
     } else {
-      buckets[free].push(tools[i]);
+      buckets[free].push(solid);
       bucketBoxes[free].push(box);
     }
   }
@@ -478,8 +484,7 @@ export function buildFlatSlabCutter(
   // below. Prebuilt per-vertex stamp solids were tried and measured WORSE:
   // neighboring stamps overlap, and overlapping multi-prism tools cost more in
   // the cutAll than the extra prism count saves.
-  const fillings: Shape3D[] = [];
-  const fillingBoxes: FootprintBox[] = [];
+  const fillings: BoxedTool[] = [];
   const maxW = maxStrutWidth(lattice);
   for (const piece of fillingPiecesForRange(lattice, uA - maxW, uB + maxW, perimeter)) {
     const pw = piece.width ?? w;
@@ -489,10 +494,12 @@ export function buildFlatSlabCutter(
       ...(piece.width === undefined ? {} : { width: piece.width }),
     };
     const extended = extendSegment(absolute, pw / 2);
-    fillingBoxes.push(strokeFootprint(extended, w));
     const drawing = strokeSegment(extended, w, uCenter, zCenter);
     const prism = sketch(drawing, 'XY').extrude(strutDepth);
-    fillings.push(translate(prism, [0, 0, -strutDepth / 2]));
+    fillings.push({
+      solid: translate(prism, [0, 0, -strutDepth / 2]),
+      box: strokeFootprint(extended, w),
+    });
     prism.delete();
   }
 
@@ -506,7 +513,7 @@ export function buildFlatSlabCutter(
   let region = translate(slabPrism, [0, 0, -halfDepth]);
   slabPrism.delete();
 
-  for (const family of [...families, ...partitionDisjoint(fillings, fillingBoxes)]) {
+  for (const family of [...families, ...partitionDisjoint(fillings)]) {
     if (family.length === 0) continue;
     const carved = unwrap(cutAll(region, family, { trackEvolution: false }));
     region.delete();


### PR DESCRIPTION
Kumiko wall patterns were the slowest thing the designer builds — sakura took **36 seconds** on a 4×4×6 bin. Nearly all of it was one boolean.

## Where it went

Profiled with the existing `kumikoProfile` harness (`KUMIKO_PROFILE_PATTERN=asanoha KUMIKO_PROFILE_CASE=4x4x6`), plus temporary sub-timers inside `buildFlatSlabCutter`:

```
features 16.2s of 22.5s total   ·   kumiko_build = 16.206s of that
per flat slab (~965ms, x12):
  strut prisms (7-11)   3-7ms
  filling prisms (84)   32-45ms
  cutAll                ~920ms   <-- 95%
    n=3 : 11ms      n=4 : 25ms     n=4 : 25ms     n=84 : 917ms
```

So ~93% of a kumiko bin's generation is a single `cutAll` over 84 mutually-overlapping filling prisms, repeated for 3 u-windows × 4 walls.

## Why the struts are fast and the fillings are not

`cutAll` pays for tool-**tool** intersections on top of tool-vs-region, and that pairwise cost grows super-linearly. `familyOf()` already exploits this, partitioning struts into parallel families — the existing comment says "tools within a family are parallel and disjoint, so each family cut has zero tool-tool intersection work."

Filling pieces radiate from a lattice vertex and are deliberately extended to weld into their neighbours, so they have no direction to group by. They were the one bucket that never got partitioned.

## The change

Colour the fillings by actual footprint overlap (greedy first-fit). The AABB is derived in closed form from the rectangle `strokeSegment` will draw — length `|ab| + width`, height `width`, rotated to the segment angle — so it is computed before any solid exists and costs microseconds of JS.

Asanoha's 84 fillings settle into **6 disjoint buckets of 14**:

```
before:  [n=84: 917ms]
after:   [n=14:23ms n=14:29ms n=14:30ms n=14:34ms n=14:31ms n=14:38ms]  = 248ms
```

Note it beats a stride heuristic (12 buckets of 7) **with larger buckets**. That's the mechanism confirmed: bucket size is not what costs, mutual intersection is.

## Results — 4×4×6, triangle counts identical in every case

| pattern | before | after | |
|---|---:|---:|---:|
| sakura | 35.7s | 16.2s | **−55%** |
| tsumiishi-kikko | 27.3s | 15.2s | **−45%** |
| mikado | 36.4s | 21.4s | **−41%** |
| asanoha | 22.9s | 14.3s | **−38%** |
| rindo | 18.8s | 13.6s | **−27%** |
| goma | 26.0s | 21.9s | **−16%** |
| mitsukude | 15.7s | 15.7s | — (no filling pieces) |

## Rejected on measurement

Three other approaches were tried and lost. Recording them so they aren't retried:

- **One `cutAll` with all tools** — 1.8× worse (asanoha 16.2→29.8s, mitsukude 7.1→12.7s). The family split earns its keep.
- **Fusing the fillings into a single tool** — worse (16.2→18.0s). It *does* drop the cut to 265ms, but the fuse itself costs 790ms; the fuse just relocates the same pairwise work.
- **Extending the colouring to the strut families** — 688ms→896ms. Each `cutAll` carries a ~40–70ms floor (even `n=1` costs 40ms), and an axis-aligned box around a *rotated thin* rectangle over-reports overlap, splitting a diagonal family into 5 buckets that gain nothing. Fillings-only is the evidenced scope, and `strokeFootprint`'s doc comment explains why so nobody generalises it later.

## Tests

- New `kumikoWrapBuilder.partition.test.ts` — 8 pure unit tests, no WASM: footprint arithmetic (including that a rotated segment's box is conservative), and the disjointness invariant on a neighbour-overlap chain, asserting greedy first-fit finds the minimal 2 colours rather than over-splitting.
- Existing kumiko suites green: `binGenerator.scenario.kumiko`, `binGenerator.export.kumiko`, `kumikoWrapBuilder.cache` (31 tests).
- Equivalence was verified by generating each of the 7 patterns both ways in one process and comparing `triangleCount` — identical throughout.

`pnpm run quality` clean (0 errors; pre-existing `max-lines` warning on this file).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up kumiko wall pattern generation by partitioning filling prisms into disjoint buckets using conservative stroke AABBs. Cuts `cutAll` time and reduces total build time by 16–55% across patterns with identical triangle counts.

- **Performance**
  - Buckets fillings by AABB overlap via `strokeFootprint` and `partitionDisjoint`; runs `cutAll` per bucket.
  - Replaces one large `cutAll` with a few disjoint ones (e.g., asanoha: 84 tools → 6 buckets of 14). Strut families unchanged.
  - Refactor: `partitionDisjoint` now takes `{solid, box}` pairs to prevent drift; rotated-footprint test pins all four bounds to ensure the box stays conservative.

<sup>Written for commit 073e16820fc1b1c9575505a4b0ef0275c0d67877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

