### PR TITLE
fix(shortcuts): scope layout keyboard shortcuts to the layout route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,7 @@ export default function App() {
   const isNonLayoutRoute =
     isDesignerRoute || isBaseplateRoute || isSupportersRoute || isDevThumbnailRoute;
   const { open: commandPaletteOpen, setOpen: setCommandPaletteOpen } = useCommandPalette({
-    disabled: isDesignerRoute || isBaseplateRoute || isSupportersRoute,
+    disabled: isNonLayoutRoute,
   });
   const binExampleGalleryOpen = useBinExampleGalleryStore((s) => s.isOpen);
   const closeBinExampleGallery = useBinExampleGalleryStore((s) => s.close);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -256,7 +256,9 @@ export default function App() {
     }
   }, [activeLayerId, activeCategoryId, layers, categories, setActiveLayer, setActiveCategory]);
 
-  useKeyboard();
+  useKeyboard({
+    disabled: isDesignerRoute || isBaseplateRoute || isSupportersRoute || isDevThumbnailRoute,
+  });
   const saveStatus = useAutoSave();
   useCrossTabSync();
   useLayoutRouting({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,6 +131,11 @@ export default function App() {
   // those hooks don't rewrite the URL and strip the query params we depend on.
   const isDevThumbnailRoute =
     import.meta.env.DEV && new URLSearchParams(window.location.search).get('devThumbnails') === '1';
+  // Every route tree except the layout editor. Hooks that act on the layout
+  // (its shortcuts, its URL slug) stand down here; add new routes to this one
+  // expression rather than to each call site.
+  const isNonLayoutRoute =
+    isDesignerRoute || isBaseplateRoute || isSupportersRoute || isDevThumbnailRoute;
   const { open: commandPaletteOpen, setOpen: setCommandPaletteOpen } = useCommandPalette({
     disabled: isDesignerRoute || isBaseplateRoute || isSupportersRoute,
   });
@@ -256,14 +261,10 @@ export default function App() {
     }
   }, [activeLayerId, activeCategoryId, layers, categories, setActiveLayer, setActiveCategory]);
 
-  useKeyboard({
-    disabled: isDesignerRoute || isBaseplateRoute || isSupportersRoute || isDevThumbnailRoute,
-  });
+  useKeyboard({ disabled: isNonLayoutRoute });
   const saveStatus = useAutoSave();
   useCrossTabSync();
-  useLayoutRouting({
-    skip: isDesignerRoute || isBaseplateRoute || isSupportersRoute || isDevThumbnailRoute,
-  });
+  useLayoutRouting({ skip: isNonLayoutRoute });
   usePWAUpdate();
   useAnalytics();
   useEngagementNudges();

--- a/src/shared/hooks/README.hooks.md
+++ b/src/shared/hooks/README.hooks.md
@@ -67,5 +67,7 @@ See [`interactions/README.md`](./interactions/README.md) for the FSM architectur
 4. **Collab sync loop prevention** — `lastEditSource === 'local'` skips re-sync of own edits
 5. **View-only shares stay local** — `permission === 'view'` never connects to Liveblocks
 6. **Keyboard skips inputs** — `useKeyboard` ignores events when focus is in `<input>` or `<textarea>`
+   — but a `<canvas>` passes that check, so routes with their own shortcuts (Bin Designer, Baseplate)
+   must pass `useKeyboard({ disabled: true })` or their `Delete`/`r`/`w` reach the layout (#2896)
 7. **Half-bin remediation** — `handleRemediate()` moves fractional bins to staging before disabling mode
 8. **Layout switch side effects** — clears undo history, resets selection, updates URL slug, resets ML session

--- a/src/shared/hooks/README.hooks.md
+++ b/src/shared/hooks/README.hooks.md
@@ -67,7 +67,7 @@ See [`interactions/README.md`](./interactions/README.md) for the FSM architectur
 4. **Collab sync loop prevention** — `lastEditSource === 'local'` skips re-sync of own edits
 5. **View-only shares stay local** — `permission === 'view'` never connects to Liveblocks
 6. **Keyboard skips inputs** — `useKeyboard` ignores events when focus is in `<input>` or `<textarea>`
-   — but a `<canvas>` passes that check, so routes with their own shortcuts (Bin Designer, Baseplate)
-   must pass `useKeyboard({ disabled: true })` or their `Delete`/`r`/`w` reach the layout (#2896)
+   — but a `<canvas>` passes that check, so `App.tsx` gates the whole listener behind
+   `isNonLayoutRoute`; without it a Bin Designer `Delete`/`r`/`w` also reaches the layout (#2896)
 7. **Half-bin remediation** — `handleRemediate()` moves fractional bins to staging before disabling mode
 8. **Layout switch side effects** — clears undo history, resets selection, updates URL slug, resets ML session

--- a/src/shared/hooks/useKeyboard.test.ts
+++ b/src/shared/hooks/useKeyboard.test.ts
@@ -1462,4 +1462,67 @@ describe('useKeyboard', () => {
       expect(useSelectionStore.getState().focusedBinId).toBe(binId2);
     });
   });
+
+  describe('disabled option', () => {
+    function addSelectedBin(width = 2, depth = 2): ReturnType<typeof getBinId> {
+      const { addBin, layout } = useLayoutStore.getState();
+      const binId = getBinId(
+        addBin({
+          layerId: layout.layers[0].id,
+          x: 0,
+          y: 0,
+          width,
+          depth,
+          height: 3,
+          category: layout.categories[0].id,
+          label: '',
+          notes: '',
+        })
+      );
+      useSelectionStore.getState().setSelectedBins([binId]);
+      return binId;
+    }
+
+    it('does not delete the selected bin when disabled', () => {
+      addSelectedBin();
+
+      renderHook(() => useKeyboard({ disabled: true }));
+
+      act(() => {
+        pressKey('Delete');
+      });
+
+      expect(useLayoutStore.getState().layout.bins).toHaveLength(1);
+      expect(useSelectionStore.getState().selectedBinIds).toHaveLength(1);
+    });
+
+    it('does not rotate the selected bin when disabled', () => {
+      addSelectedBin(2, 4);
+
+      renderHook(() => useKeyboard({ disabled: true }));
+
+      act(() => {
+        pressKey('r');
+      });
+
+      const bin = useLayoutStore.getState().layout.bins[0];
+      expect([bin.width, bin.depth]).toEqual([2, 4]);
+    });
+
+    it('binds again once re-enabled', () => {
+      addSelectedBin();
+
+      const { rerender } = renderHook(({ disabled }) => useKeyboard({ disabled }), {
+        initialProps: { disabled: true },
+      });
+
+      rerender({ disabled: false });
+
+      act(() => {
+        pressKey('Delete');
+      });
+
+      expect(useLayoutStore.getState().layout.bins).toHaveLength(0);
+    });
+  });
 });

--- a/src/shared/hooks/useKeyboard.ts
+++ b/src/shared/hooks/useKeyboard.ts
@@ -24,6 +24,12 @@
  * - [/]: Cycle category of selected bins, or cycle active drawing category if no bin selected
  * - L: Open quick label popover for selected bin
  *
+ * These bind on `window`, so they stay armed on every route the host
+ * component renders. Pass `disabled` on routes that own their own shortcuts
+ * (Bin Designer, Baseplate) — otherwise a `Delete` aimed at a cutout shape
+ * also deletes the selected layout bin, and `r`/`w`/`s` rotate bins and swap
+ * layers behind the user's back (issue #2896).
+ *
  * @example
  * ```tsx
  * function GridEditor() {
@@ -91,7 +97,12 @@ const handlers: KeyboardHandler[] = [
   handleNudge,
 ];
 
-export function useKeyboard() {
+interface UseKeyboardOptions {
+  /** Skip binding the listener entirely (non-layout routes). */
+  readonly disabled?: boolean;
+}
+
+export function useKeyboard({ disabled = false }: UseKeyboardOptions = {}) {
   const t = useTranslation();
 
   const {
@@ -228,7 +239,8 @@ export function useKeyboard() {
   );
 
   useEffect(() => {
+    if (disabled) return;
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleKeyDown]);
+  }, [handleKeyDown, disabled]);
 }


### PR DESCRIPTION
Fixes #2896.

## The bug

`useKeyboard()` binds a `window` keydown listener from `App.tsx` — the one component that renders the layout, designer, baseplate and supporters route trees. Sibling hooks take an explicit route guard (`useLayoutRouting({ skip: ... })`, `useCommandPalette({ disabled: ... })`); `useKeyboard` never got one, so all 15 layout shortcuts stayed armed on every route.

Its only guard is "is focus in an `<input>` / `<textarea>` / contenteditable / `<select>`". The cutout editor's drawing surface is a `<canvas>`, which passes that check.

So pressing `Delete` to remove a cutout shape also ran `handleDelete` against the selected **layout bin** — the very bin the user opened "Edit Design" from. Autosave then persisted the deletion, which is why the bin was gone from the 2D grid, the 3D preview, the bin list and the stash, and stayed gone through a hard refresh while the design itself survived in IndexedDB.

That matches the reporter's narrowed repro exactly: only cutout bins, and only once they started *deleting* shapes. Every other interior mode is steppers and toggles — the cutout editor is the only designer surface where `Delete` is how you remove something.

`Delete` was the destructive one, but the whole set collided:

| Key | Designer / cutout editor | Also fired on the layout |
| --- | --- | --- |
| `Delete` / `Backspace` | delete selected cutout shapes | **delete selected bin** |
| `Escape` | cancel current tool | clear layout selection |
| `r` | reset view | rotate bin (swap width/depth) |
| `w` | toggle wireframe | move up a layer |
| `s` | draw slot | move down a layer |
| Arrows | nudge cutouts | nudge the selected bin |
| `Ctrl+Z` / `Ctrl+D` | designer undo | layout undo / duplicate bin |

## The fix

`useKeyboard({ disabled })`, passed the same route guard `useLayoutRouting` already uses. The designer and baseplate own complete keyboard layers of their own (`useDesignerKeyboard`, `useCutoutKeyboardShortcuts`, `useBaseplateKeyboard`) — including `Shift+D` to get back to the planner — so nothing is lost by standing the layout listener down there.

## Verification

Reproduced and confirmed fixed in the running app: draw a bin → select it → Edit Design → press `Delete` → return to Layout.

- **Before:** grid shows "Click and drag to draw a bin", bin list empty, stash empty.
- **After:** bin is still there and still selected.

Three regression tests added to `useKeyboard.test.ts` (delete, rotate, and re-enable after `disabled` flips). The two behavioural ones fail against the unpatched hook.

`pnpm exec vitest run src/shared/hooks/` — 743 passed. Typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped layout keyboard shortcuts to the layout route by adding a `disabled` option to `useKeyboard`. Prevents designer/baseplate collisions that caused accidental bin deletes and other actions (Fixes #2896).

- **Bug Fixes**
  - Added `useKeyboard({ disabled })`; skips binding when disabled and rebinds when re-enabled.
  - Disabled on designer, baseplate, supporters, and dev thumbnail routes; added tests and docs.

- **Refactors**
  - Hoisted the route guard into `isNonLayoutRoute` and used it for `useKeyboard`, `useLayoutRouting`, and `useCommandPalette`.

<sup>Written for commit 737996cfb843ec0a0cedc31935294e3f8ace7988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

