### PR TITLE
fix(generation): clip dividers under a spanning label shelf

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -223,6 +223,14 @@ intersection`, not XOR** — they coincide for 2 members but diverge for
   compartment depth, both-edges collision) and has the same three callers. #2910 is what
   happens without it: the plate planner keyed off the compartment grid alone, so an
   `edges: 'both'` design — two sockets per compartment — shipped half the plates it needed.
+  A spanning shelf runs wall to wall, so the column dividers it crosses must stop at its
+  underside — `planSpanningDividerClips` (labelTabBuilder) derives those footprints from the
+  same layout plan the shelves are built from. The clip has to be applied at BOTH divider
+  sources: the shell itself when `compartmentsBakedIntoShell` (2D cavity drawings can't
+  express a partial height, so `shellStage` cuts it before `featuresStage` fuses the shelf —
+  the boolean stage runs every cut AFTER every fuse, so a cut target would eat the shelf) and
+  `buildCompartmentWalls` on the additive path. Both spanning shapes need it: `label.span`,
+  and the socket plan's bin-spanning fallback for columns too narrow to host a plate.
 - **Cutout align/distribute**: `geometryAlign.ts` moves shapes by _delta_, never by
   assignment — `x`/`y` is the UNROTATED top-left while alignment is judged on the rotated
   silhouette (`getRotatedBounds`), and path cutouts store ABSOLUTE points that must travel

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelSockets.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelSockets.test.ts.snap
@@ -6,7 +6,7 @@ exports[`label sockets > 1×1 socket hosts a 1U plate 1`] = `836`;
 
 exports[`label sockets > 1×1 text mode unchanged 1`] = `708`;
 
-exports[`label sockets > 2×1 four columns → bin-spanning 2U socket 1`] = `2820`;
+exports[`label sockets > 2×1 four columns → bin-spanning 2U socket 1`] = `2064`;
 
 exports[`label sockets > 2×1 two compartments, two 1U sockets 1`] = `2176`;
 

--- a/src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.scenario.manifold.test.ts
@@ -93,6 +93,31 @@ describe('compartmentBuilder — partition export manifold-ness (issue #1753)', 
     expect(stats.boundaryEdges, `${label}: boundary edges`).toBe(0);
   }
 
+  // #2897: a wall-to-wall label shelf clips the dividers it passes over. That
+  // clip lands on the shell itself (compartments baked in) or on the additive
+  // walls, so it must not reintroduce the seam this suite exists to guard.
+  it(
+    'spanning label shelf over four columns exports watertight STL',
+    async () => {
+      clearAllCaches();
+      const params = withCompartments(4, 1, [0, 1, 2, 3], {
+        width: 3,
+        depth: 3,
+        label: {
+          ...DEFAULT_BIN_PARAMS.label,
+          enabled: true,
+          span: true,
+          mode: 'socket',
+          socketStyle: 'clickIn',
+          depth: 14,
+        },
+        base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      });
+      expectWatertight(analyzeManifold((await exportBin(params, 'stl')).data), 'spanning label');
+    },
+    TEST_TIMEOUT_MS
+  );
+
   it(
     '2×2 bin with a single full-span divider exports watertight STL',
     async () => {

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -5,13 +5,19 @@
  * Walls appear at boundaries between cells with different compartment IDs.
  */
 
-import { box, withScope, clone, unwrap, fuseAll, draw, intersect } from 'brepjs';
+import { box, withScope, clone, unwrap, fuseAll, draw, intersect, cut } from 'brepjs';
 import type { Shape3D, ValidSolid, DisposalScope, Drawing } from 'brepjs';
 import type { BinParams, DividerOverride } from '@/shared/types/bin';
 import { buildCacheKey, compactKey, quantize, stableSerialize } from './cacheKeyUtils';
 import { sketch } from './meshUtils';
 import { BOX_CORNER_RADIUS } from './generatorConstants';
 import { resolveCompartmentDividerHeight } from '@/shared/utils/slotMath';
+import {
+  buildSpanningDividerClipTools,
+  planSpanningDividerClips,
+  spanningDividerClipsKey,
+} from './labelTabBuilder';
+import type { SpanningDividerClip } from './labelTabBuilder';
 
 // Re-export for backwards compatibility with existing imports
 export { fuseAllOrNull } from './utils/shapeOps';
@@ -663,7 +669,8 @@ export function buildCompartmentWalls(
   params: BinParams,
   innerW: number,
   innerD: number,
-  wallHeight: number
+  wallHeight: number,
+  spanningClips: readonly SpanningDividerClip[] = []
 ): Shape3D | null {
   const { cols, rows, cells } = params.compartments;
 
@@ -673,8 +680,38 @@ export function buildCompartmentWalls(
 
   return withScope((scope: DisposalScope): Shape3D | null => {
     const fused = buildCompartmentWallsInScope(scope, params, innerW, innerD, wallHeight);
-    return fused ? unwrap(clone(fused)) : null;
+    if (!fused) return null;
+    const clipped = clipUnderSpanningTabs(scope, fused, spanningClips, wallHeight);
+    return clipped ? unwrap(clone(clipped)) : null;
   });
+}
+
+/**
+ * Drop the divider tops that a wall-to-wall label shelf passes over (#2897),
+ * so the span reads as one unbroken surface instead of being sliced by
+ * dividers standing proud of it.
+ *
+ * A failed cut returns the unclipped walls: a divider poking through the shelf
+ * is cosmetically wrong, a missing divider set is a broken bin.
+ */
+function clipUnderSpanningTabs(
+  scope: DisposalScope,
+  walls: Shape3D,
+  clips: readonly SpanningDividerClip[],
+  wallHeight: number
+): Shape3D | null {
+  if (clips.length === 0) return walls;
+  const tools = buildSpanningDividerClipTools(clips, wallHeight + 1).map((t) => scope.register(t));
+  if (tools.length === 0) return walls;
+  let result = walls;
+  for (const tool of tools) {
+    try {
+      result = scope.register(unwrap(cut(result as ValidSolid, tool as ValidSolid)));
+    } catch {
+      return walls;
+    }
+  }
+  return result;
 }
 
 function buildCompartmentWallsInScope(
@@ -801,7 +838,9 @@ export const compartmentWallsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        'v2',
+        // `v3`: dividers crossed by a spanning label shelf are clipped to its
+        // underside (#2897), so the same grid now yields shorter dividers.
+        'v3',
         dim.shellKey,
         quantize(dim.innerW),
         quantize(dim.innerD),
@@ -813,18 +852,32 @@ export const compartmentWallsFeature: FeatureBuilder = {
         stableSerialize(params.compartments.dividerOverrides ?? []),
         quantize(
           resolveCompartmentDividerHeight(params.compartments.dividerHeight, dim.interiorHeight)
+        ),
+        spanningDividerClipsKey(
+          planSpanningDividerClips(
+            params,
+            dim.innerW,
+            dim.innerD,
+            dim.interiorHeight,
+            params.wallThickness
+          )
         )
       )
     );
   },
   build: (ctx) => {
+    const { params, dimensions: dim } = ctx;
     const result = buildCompartmentWalls(
-      ctx.params,
-      ctx.dimensions.innerW,
-      ctx.dimensions.innerD,
-      resolveCompartmentDividerHeight(
-        ctx.params.compartments.dividerHeight,
-        ctx.dimensions.interiorHeight
+      params,
+      dim.innerW,
+      dim.innerD,
+      resolveCompartmentDividerHeight(params.compartments.dividerHeight, dim.interiorHeight),
+      planSpanningDividerClips(
+        params,
+        dim.innerW,
+        dim.innerD,
+        dim.interiorHeight,
+        params.wallThickness
       )
     );
     return result ? [result] : null;

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -12,6 +12,7 @@ import { buildCacheKey, compactKey, quantize, stableSerialize } from './cacheKey
 import { sketch } from './meshUtils';
 import { BOX_CORNER_RADIUS } from './generatorConstants';
 import { resolveCompartmentDividerHeight } from '@/shared/utils/slotMath';
+import { isAbortError } from './utils/abort';
 import {
   buildSpanningDividerClipTools,
   planSpanningDividerClips,
@@ -707,7 +708,8 @@ function clipUnderSpanningTabs(
   for (const tool of tools) {
     try {
       result = scope.register(unwrap(cut(result as ValidSolid, tool as ValidSolid)));
-    } catch {
+    } catch (e: unknown) {
+      if (isAbortError(e)) throw e;
       return walls;
     }
   }
@@ -828,6 +830,32 @@ function buildCompartmentWallsInScope(
 import type { FeatureBuilder } from './pipeline/featureBuilder';
 import { FeatureTag } from './featureTags';
 
+/**
+ * Spanning-shelf clips that actually reach this bin's dividers.
+ *
+ * A divider shortened below the shelf underside (an explicit
+ * `compartments.dividerHeight`) already ends under the span, so its clip cuts
+ * nothing. Filtering here rather than at the cut keeps the cache key honest —
+ * otherwise identical geometry would key differently and miss the cache.
+ */
+function spanClipsThatBite(ctx: {
+  params: BinParams;
+  dimensions: { innerW: number; innerD: number; interiorHeight: number };
+}): SpanningDividerClip[] {
+  const { params, dimensions: dim } = ctx;
+  const dividerHeight = resolveCompartmentDividerHeight(
+    params.compartments.dividerHeight,
+    dim.interiorHeight
+  );
+  return planSpanningDividerClips(
+    params,
+    dim.innerW,
+    dim.innerD,
+    dim.interiorHeight,
+    params.wallThickness
+  ).filter((clip) => clip.zMin < dividerHeight);
+}
+
 export const compartmentWallsFeature: FeatureBuilder = {
   name: 'compartmentWalls',
   tag: FeatureTag.DIVIDER,
@@ -853,15 +881,7 @@ export const compartmentWallsFeature: FeatureBuilder = {
         quantize(
           resolveCompartmentDividerHeight(params.compartments.dividerHeight, dim.interiorHeight)
         ),
-        spanningDividerClipsKey(
-          planSpanningDividerClips(
-            params,
-            dim.innerW,
-            dim.innerD,
-            dim.interiorHeight,
-            params.wallThickness
-          )
-        )
+        spanningDividerClipsKey(spanClipsThatBite(ctx))
       )
     );
   },
@@ -872,13 +892,7 @@ export const compartmentWallsFeature: FeatureBuilder = {
       dim.innerW,
       dim.innerD,
       resolveCompartmentDividerHeight(params.compartments.dividerHeight, dim.interiorHeight),
-      planSpanningDividerClips(
-        params,
-        dim.innerW,
-        dim.innerD,
-        dim.interiorHeight,
-        params.wallThickness
-      )
+      spanClipsThatBite(ctx)
     );
     return result ? [result] : null;
   },

--- a/src/features/generation/worker/generators/labelTabBuilder.test.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.test.ts
@@ -793,3 +793,82 @@ describe('planLabelPlateSeats', () => {
     expect(seats.length).toBeLessThanOrEqual(1);
   });
 });
+
+describe('planSpanningDividerClips', () => {
+  const fourColumns = { cols: 4, rows: 1, thickness: 1.2, cells: [0, 1, 2, 3] };
+  const INNER_W = 123.1;
+  const INNER_D = 123.1;
+  const INTERIOR_H = 15.3;
+
+  const spanParams = (over: Record<string, unknown> = {}) => ({
+    ...DEFAULT_BIN_PARAMS,
+    compartments: { ...DEFAULT_BIN_PARAMS.compartments, ...fourColumns },
+    label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, span: true, ...over },
+  });
+
+  it('produces no clips for per-compartment tabs', async () => {
+    const { planSpanningDividerClips } = await import('./labelTabBuilder');
+    const params = spanParams({ span: false });
+    expect(planSpanningDividerClips(params, INNER_W, INNER_D, INTERIOR_H, 1.2)).toHaveLength(0);
+  });
+
+  it('produces no clips when labels are disabled', async () => {
+    const { planSpanningDividerClips } = await import('./labelTabBuilder');
+    const params = spanParams({ enabled: false });
+    expect(planSpanningDividerClips(params, INNER_W, INNER_D, INTERIOR_H, 1.2)).toHaveLength(0);
+  });
+
+  it('clips at the shelf underside for a full-width span', async () => {
+    const { planSpanningDividerClips } = await import('./labelTabBuilder');
+    const clips = planSpanningDividerClips(spanParams(), INNER_W, INNER_D, INTERIOR_H, 1.2);
+
+    expect(clips).toHaveLength(1);
+    // Text mode: shelf is one wallThickness thick and tops out at the ceiling.
+    expect(clips[0].zMin).toBeCloseTo(INTERIOR_H - 1.2, 5);
+    // The footprint reaches the dividers it has to clear.
+    expect(clips[0].xMax - clips[0].xMin).toBeCloseTo(INNER_W, 5);
+    expect(clips[0].yMax - clips[0].yMin).toBeCloseTo(DEFAULT_BIN_PARAMS.label.depth, 5);
+  });
+
+  // The reporter's case (#2897): a click-in socket on a lipped bin sinks the
+  // shelf below the ceiling, so full-height dividers stood proud of it.
+  it('clips below the interior ceiling for a click-in socket on a lipped bin', async () => {
+    const { planSpanningDividerClips } = await import('./labelTabBuilder');
+    const params = {
+      ...spanParams({ mode: 'socket' as const, socketStyle: 'clickIn' as const, depth: 14 }),
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+    };
+
+    const clips = planSpanningDividerClips(params, INNER_W, INNER_D, INTERIOR_H, 1.2);
+
+    expect(clips).toHaveLength(1);
+    expect(clips[0].zMin).toBeLessThan(INTERIOR_H);
+  });
+
+  // The socket plan degrades to one bin-wide tab when no column can host a
+  // plate — that shelf spans the dividers too, without `label.span`.
+  it('clips for the socket bin-spanning fallback even with span off', async () => {
+    const { planSpanningDividerClips } = await import('./labelTabBuilder');
+    const params = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: {
+        ...DEFAULT_BIN_PARAMS.compartments,
+        cols: 12,
+        rows: 1,
+        thickness: 1.2,
+        cells: Array.from({ length: 12 }, (_, i) => i),
+      },
+      label: {
+        ...DEFAULT_BIN_PARAMS.label,
+        enabled: true,
+        span: false,
+        mode: 'socket' as const,
+        depth: 14,
+      },
+    };
+
+    const clips = planSpanningDividerClips(params, INNER_W, INNER_D, INTERIOR_H, 1.2);
+
+    expect(clips.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/generation/worker/generators/labelTabBuilder.test.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.test.ts
@@ -847,6 +847,19 @@ describe('planSpanningDividerClips', () => {
 
   // The socket plan degrades to one bin-wide tab when no column can host a
   // plate — that shelf spans the dividers too, without `label.span`.
+  // A divider already ending below the shelf has nothing to clip; the feature
+  // builder filters those out so the cache key can't churn on identical geometry.
+  it('reports clips above a shortened divider so callers can filter them', async () => {
+    const { planSpanningDividerClips } = await import('./labelTabBuilder');
+    const clips = planSpanningDividerClips(spanParams(), INNER_W, INNER_D, INTERIOR_H, 1.2);
+
+    expect(clips).toHaveLength(1);
+    // A 5mm divider ends well under the shelf underside, so nothing bites.
+    expect(clips.filter((c) => c.zMin < 5)).toHaveLength(0);
+    // A full-height divider does.
+    expect(clips.filter((c) => c.zMin < INTERIOR_H)).toHaveLength(1);
+  });
+
   it('clips for the socket bin-spanning fallback even with span off', async () => {
     const { planSpanningDividerClips } = await import('./labelTabBuilder');
     const params = {

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  box,
   draw,
   drawRoundedRectangle,
   unwrap,
@@ -180,6 +181,102 @@ export function buildLabelTabs(
     const fused = buildLabelTabsInScope(scope, params, innerW, innerD, wallHeight, wallThickness);
     return fused ? unwrap(clone(fused)) : null;
   });
+}
+
+/**
+ * A footprint a wall-to-wall shelf passes over, in the bin-interior frame.
+ * `zMin` is the shelf underside: divider material from there up is what the
+ * shelf would otherwise collide with.
+ */
+export interface SpanningDividerClip {
+  readonly xMin: number;
+  readonly xMax: number;
+  readonly yMin: number;
+  readonly yMax: number;
+  readonly zMin: number;
+}
+
+/**
+ * Where a full-width shelf crosses the column dividers (#2897).
+ *
+ * `planSpanningTabAtRow` already assumes those dividers "pass beneath" the
+ * span — but nothing ever shortened them, so they ran to the interior ceiling
+ * and stood proud of any shelf sunk below it (a click-in socket's stacking
+ * relief, or an explicit `label.height`), splitting the one continuous label
+ * surface the feature exists to provide.
+ *
+ * Derived from the same layout plan the shelves themselves are built from, so
+ * the clip and the shelf cannot drift apart. Both spanning shapes qualify: the
+ * `label.span` feature and the socket plan's bin-spanning fallback.
+ */
+export function planSpanningDividerClips(
+  params: BinParams,
+  innerW: number,
+  innerD: number,
+  wallHeight: number,
+  wallThickness: number
+): SpanningDividerClip[] {
+  if (!params.label.enabled) return [];
+  const layout = planLabelTabLayout(params, innerW, innerD, wallHeight, wallThickness);
+  if (!layout) return [];
+  // Per-compartment tabs are bounded by the dividers rather than crossing
+  // them, so there is nothing to clip.
+  if (!layout.spanningFallback && params.label.span !== true) return [];
+
+  const { dims } = layout;
+  const zMin = dims.shelfTopZ - dims.shelfT;
+  const clips: SpanningDividerClip[] = [];
+  for (const row of layout.plannedRows) {
+    const depthSign = row.anchor === 'back' ? -1 : 1;
+    for (const slot of row.slots) {
+      const yEnd = slot.positionY + depthSign * dims.tabDepth;
+      clips.push({
+        xMin: slot.tabXStart,
+        xMax: slot.tabXStart + slot.tabWidth,
+        yMin: Math.min(slot.positionY, yEnd),
+        yMax: Math.max(slot.positionY, yEnd),
+        zMin,
+      });
+    }
+  }
+  return clips;
+}
+
+/**
+ * Cut tools for a clip set, each running from the shelf underside to `topZ`.
+ *
+ * `topZ` must clear whatever the caller is cutting (the interior ceiling, or a
+ * collared rim) — the box only has to swallow the divider top, and overshooting
+ * upward hits empty space.
+ */
+export function buildSpanningDividerClipTools(
+  clips: readonly SpanningDividerClip[],
+  topZ: number,
+  offsetX = 0,
+  offsetY = 0
+): Shape3D[] {
+  const tools: Shape3D[] = [];
+  for (const c of clips) {
+    const height = topZ - c.zMin;
+    if (height <= 0) continue;
+    const w = c.xMax - c.xMin;
+    const d = c.yMax - c.yMin;
+    if (w <= 0 || d <= 0) continue;
+    tools.push(
+      box(w, d, height, {
+        at: [(c.xMin + c.xMax) / 2 + offsetX, (c.yMin + c.yMax) / 2 + offsetY, c.zMin + height / 2],
+      })
+    );
+  }
+  return tools;
+}
+
+/** Cache-key segment for a clip set. Empty string when nothing is clipped. */
+export function spanningDividerClipsKey(clips: readonly SpanningDividerClip[]): string {
+  if (clips.length === 0) return '';
+  return clips
+    .map((c) => [c.xMin, c.xMax, c.yMin, c.yMax, c.zMin].map((n) => n.toFixed(3)).join(','))
+    .join(';');
 }
 
 /** Everything the tab build needs, resolved without touching BREP. */

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -18,6 +18,7 @@ import {
   hasDividerOverrides,
   hasMultipleCompartments,
 } from '../compartmentBuilder';
+import { planSpanningDividerClips, spanningDividerClipsKey } from '../labelTabBuilder';
 // HEIGHT_UNIT is kept as a fallback default for backwards compatibility with
 // callers (or serialized designs) that predate heightUnitMm. The grid-unit
 // fallback now lives in `pitchFromParams` (gridPitch.ts).
@@ -158,6 +159,14 @@ export function deriveDimensions(params: BinParams, _forExport: boolean): BinDim
   const compartmentsKey =
     compartmentsBakedIntoShell || lightweight ? buildCompartmentsCacheKey(params) : 'none';
 
+  // Only the shell-baked path carries dividers in the shell; elsewhere the
+  // clip lands on the additive walls and is keyed by that feature instead.
+  const spanningClipKey = compartmentsBakedIntoShell
+    ? spanningDividerClipsKey(
+        planSpanningDividerClips(params, innerW, innerD, interiorHeight, params.wallThickness)
+      )
+    : '';
+
   const shellKey = compactKey(
     buildCacheKey(
       'v7',
@@ -190,7 +199,11 @@ export function deriveDimensions(params: BinParams, _forExport: boolean): BinDim
       ...(collarHeight > 0 ? [`collar${quantize(collarHeight)}`] : []),
       // Spacer punches the floor through, so it must never share a cached body
       // with the lite bin it otherwise looks like. Appended for the same reason.
-      ...(isSpacer ? ['spacer'] : [])
+      ...(isSpacer ? ['spacer'] : []),
+      // Shell-baked dividers get clipped where a spanning label shelf crosses
+      // them (#2897), so that clip is part of the shell. Appended only when it
+      // applies, keeping every other bin's v7 key byte-identical.
+      ...(spanningClipKey ? [`spanclip${spanningClipKey}`] : [])
     )
   );
 

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -22,6 +22,7 @@ import type { LightweightBase, LightweightOpenDirection } from '../../lightweigh
 import { buildBinBox, buildTopShape } from '../../boxBuilder';
 import { buildBinBoxWithLip } from '../../integratedLipBuilder';
 import { maskHasHoles } from '../../maskPolygon';
+import { buildSpanningDividerClipTools, planSpanningDividerClips } from '../../labelTabBuilder';
 import { hasOverhang, overhangKey } from '../../overhang';
 import {
   buildCompartmentCavityDrawings,
@@ -218,6 +219,38 @@ export const shellStage: PipelineStage = {
         built = opened;
         floorOpenings.delete();
         floorOpenings = null;
+      }
+
+      // Dividers baked into the shell by the multi-cavity cut still run to the
+      // rim, so a wall-to-wall label shelf would be sliced by the ones it
+      // passes over (#2897). The cavity drawings are 2D and can't express a
+      // partial height, so drop those divider tops here — before featuresStage
+      // fuses the shelf, which a later cut pass would otherwise eat into.
+      if (dim.compartmentsBakedIntoShell) {
+        const clips = planSpanningDividerClips(
+          params,
+          dim.innerW,
+          dim.innerD,
+          dim.interiorHeight,
+          params.wallThickness
+        );
+        const tools = buildSpanningDividerClipTools(
+          clips,
+          boxWallHeight + 1,
+          dim.innerOffsetX,
+          dim.innerOffsetY
+        );
+        for (const tool of tools) {
+          try {
+            const clipped = unwrap(cut(built as ValidSolid, tool as ValidSolid));
+            if (clipped !== built) built.delete();
+            built = clipped;
+          } catch {
+            // Keep the unclipped shell: a divider through the shelf is
+            // cosmetically wrong, a failed shell is an unusable bin.
+          }
+          tool.delete();
+        }
       }
 
       setShellCache(dim.shellKey, built);

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -240,16 +240,21 @@ export const shellStage: PipelineStage = {
           dim.innerOffsetX,
           dim.innerOffsetY
         );
-        for (const tool of tools) {
-          try {
-            const clipped = unwrap(cut(built as ValidSolid, tool as ValidSolid));
-            if (clipped !== built) built.delete();
-            built = clipped;
-          } catch {
-            // Keep the unclipped shell: a divider through the shelf is
-            // cosmetically wrong, a failed shell is an unusable bin.
+        // Best effort per tool: a divider left standing through the shelf is
+        // cosmetically wrong, a failed shell is an unusable bin. Clips that
+        // already succeeded stay applied.
+        try {
+          for (const tool of tools) {
+            try {
+              const clipped = unwrap(cut(built as ValidSolid, tool as ValidSolid));
+              if (clipped !== built) built.delete();
+              built = clipped;
+            } catch (e: unknown) {
+              if (isAbortError(e)) throw e;
+            }
           }
-          tool.delete();
+        } finally {
+          for (const tool of tools) tool.delete();
         }
       }
 


### PR DESCRIPTION
Reported by @Robert-B-H on #2897, after the spanning-label feature (#2909) shipped.

## The bug

`planSpanningTabAtRow` already carries the assumption in a comment:

> Spanning tabs run outer wall to outer wall. **Column dividers pass beneath** rather than bounding the span, so they take no thickness deduction.

Nothing ever shortened them. They ran to `interiorHeight` and passed straight *through* the shelf.

Where the shelf top happens to sit at the ceiling that reads as flush — which is what the reporter saw in printed-text mode, and it still slices the one continuous label surface the feature exists to provide into one segment per column. Sink the shelf below the ceiling and the divider tops stand proud of it, so a swappable plate has ridges through its seat. Measured against a 16mm wall with a lip (`interiorHeight` 15.3mm):

| Label style | Shelf top | Divider top | Proud by |
| --- | --- | --- | --- |
| Printed text | 15.3 | 15.3 | 0 (flush, but the label is still quartered) |
| Swappable, click-in | 14.5 | 15.3 | **0.8mm** (`LABEL_SOCKET_STACK_RELIEF_MM`) |
| Swappable, slide-in | 15.3 | 15.3 | 0 |
| Any style, explicit `label.height` | `height` | 15.3 | `15.3 − height` |

That last row is the general case behind "when you recede this surface for the swappable label" — the height control positions the shelf, and the dividers never followed it.

## The fix

Dividers are clipped to the shelf underside **inside the tab footprint only**, so they keep full height through the rest of the bin — the shelf is 12mm of a ~123mm depth by default. `planSpanningDividerClips` derives those footprints from the same layout plan the shelves are built from, so the clip and the shelf cannot drift.

The clip has to land at **both** divider sources:

- **Baked-into-shell path** — dividers are cut residue in the shell and the cavity drawings are 2D, so they cannot express a partial height. `shellStage` cuts the clip there, next to the existing `floorOpenings` cut. It has to happen at that point specifically: the boolean stage runs every cut *after* every fuse, so registering a cut target would eat the shelf itself.
- **Additive path** — clipped inside `buildCompartmentWalls`.

Keeping the shell path intact is deliberate. That path is what #1753 introduced to avoid the fuse T-junction slicers read as non-manifold; forcing spanning designs onto the additive path would have been one clip site instead of two, at the cost of re-exposing them to that bug.

Both spanning shapes are covered: `label.span`, and the socket plan's bin-spanning fallback for columns too narrow to host their own plate (which spans the dividers without `label.span` ever being set).

## Verification

Top view of a 3x3x3, four columns, spanning label, click-in socket, stacking lip:

- **Before** — divider lines run up through the label band to the back wall, splitting it into four.
- **After** — the label band is a single unbroken rectangle; dividers stop cleanly at its edge.

- `binGenerator.scenario.labelSockets` "four columns → bin-spanning 2U socket" snapshot moves 2820 → 2064 triangles — the divider tops that used to pass through the shelf. That scenario reaching for the clip also confirms the socket fallback path is covered.
- New watertight/manifold export case in `compartmentBuilder.scenario.manifold` (the #1753 suite) for a spanning shelf over four columns — 0 non-manifold edges, 0 boundary edges.
- Five unit tests on `planSpanningDividerClips`: no clips for per-compartment tabs or disabled labels, correct underside Z and footprint for a span, below-ceiling clip for the reporter's click-in-on-lipped case, and the span-off socket fallback.
- Full generator suite: 243 files, 2396 passed. Typecheck and lint clean.

Cache keys bumped so existing entries can't serve pre-clip geometry: `compartmentWallsFeature` v2 → v3, and a `spanclip` segment appended to `shellKey` only when it applies, so every other bin's v7 key stays byte-identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clips column dividers beneath spanning label shelves so the label surface is unbroken and no divider tops protrude. Applies to both shell-baked and additive divider paths, with cache keys updated to avoid stale or churned geometry.

- Bug Fixes
  - Compute shelf-footprint clips from the same layout used to build shelves and apply them inside the tab area only; dividers keep full height elsewhere.
  - Apply clips at both sources: in shell builds during `shellStage` (before fusing the shelf) and in additive builds during compartment wall construction.
  - Filters no-op clips (e.g., dividers already shorter than the shelf underside) to keep cache keys stable; honors abort signals during clip cuts and falls back to unclipped walls on non-abort failures to avoid breaking bins.
  - Works for explicit `label.span` and the socket plan’s bin-spanning fallback when columns are too narrow.
  - Adds tests and updates snapshots; preserves manifoldness; reduces triangles in the bin-spanning socket case (2820 → 2064).
  - Bumps compartment walls cache to v3 and appends a `spanclip` segment to the shell key only when applicable.

<sup>Written for commit 2406e25c2dbc76a0d75c05bd40b55b3441ee0b35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

