### PR TITLE
feat(settings): raise the print bed size cap to 3000mm

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -53,9 +53,10 @@ export const CONSTRAINTS = {
   // detector in storage migration: a stored printBedSize below it is grid
   // units, not mm. Kept distinct from GRID_UNIT_MM_DEFAULT even though both
   // are 42 — they're unrelated concepts that happen to share a value.
-  // The max equals GRID_MAX × GRID_UNIT_MM_MAX (3000), the largest drawer
-  // dimension: a bed at the cap never forces a split, so a higher value would
-  // have no effect on any layout, bin or baseplate.
+  // The max equals GRID_MAX × GRID_UNIT_MM_MAX (3000), the largest grid extent
+  // the tool can express, so a bed at the cap never splits an unpadded plate.
+  // Baseplate padding and connector tongues are charged against the bed budget
+  // on top of that, so a heavily padded plate can still split at the cap.
   PRINT_BED_MM_MIN: 42,
   PRINT_BED_MM_MAX: 3000,
   PRINT_BED_MM_DEFAULT: 256,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -53,8 +53,11 @@ export const CONSTRAINTS = {
   // detector in storage migration: a stored printBedSize below it is grid
   // units, not mm. Kept distinct from GRID_UNIT_MM_DEFAULT even though both
   // are 42 — they're unrelated concepts that happen to share a value.
+  // The max equals GRID_MAX × GRID_UNIT_MM_MAX (3000), the largest drawer
+  // dimension: a bed at the cap never forces a split, so a higher value would
+  // have no effect on any layout, bin or baseplate.
   PRINT_BED_MM_MIN: 42,
-  PRINT_BED_MM_MAX: 500,
+  PRINT_BED_MM_MAX: 3000,
   PRINT_BED_MM_DEFAULT: 256,
   // Layout library constraints
   LAYOUTS_MAX: 500, // Max layouts in library (IndexedDB storage)

--- a/src/core/cqrs/v2/domain/layout/setPrintBedSize.test.ts
+++ b/src/core/cqrs/v2/domain/layout/setPrintBedSize.test.ts
@@ -1,16 +1,29 @@
 import { describe, it, expect } from 'vitest';
 import { produce } from 'immer';
 import { isOk } from '@/core/result';
+import { CONSTRAINTS } from '@/core/constants';
 import { mm } from '@/core/types';
 import { setPrintBedSize } from './setPrintBedSize';
 import { makeLayout } from './_testHelpers';
 
 describe('v2 layout.setPrintBedSize', () => {
-  it('clamps size to [42, 500]', () => {
+  it('clamps size to the configured print-bed bounds', () => {
     const layout = makeLayout();
-    const result = setPrintBedSize.handle({ size: 9999 }, { aggregate: layout });
+    const tooLarge = setPrintBedSize.handle({ size: 99999 }, { aggregate: layout });
+    if (!isOk(tooLarge)) throw new Error('handle failed');
+    expect(tooLarge.value.event.payload.size).toBe(CONSTRAINTS.PRINT_BED_MM_MAX);
+
+    const tooSmall = setPrintBedSize.handle({ size: 1 }, { aggregate: layout });
+    if (!isOk(tooSmall)) throw new Error('handle failed');
+    expect(tooSmall.value.event.payload.size).toBe(CONSTRAINTS.PRINT_BED_MM_MIN);
+  });
+
+  it('accepts large-format beds', () => {
+    const layout = makeLayout();
+    const result = setPrintBedSize.handle({ size: 1000, depth: 1000 }, { aggregate: layout });
     if (!isOk(result)) throw new Error('handle failed');
-    expect(result.value.event.payload.size).toBe(500);
+    expect(result.value.event.payload.size).toBe(1000);
+    expect(result.value.event.payload.depth).toBe(1000);
   });
 
   it('captures previousSize and previousDepth', () => {

--- a/src/core/store/layout.test.ts
+++ b/src/core/store/layout.test.ts
@@ -815,7 +815,10 @@ describe('layout store', () => {
       expect(useLayoutStore.getState().layout.printBedSize).toBe(300);
 
       setPrintBedSize(1000);
-      expect(useLayoutStore.getState().layout.printBedSize).toBe(500); // Max
+      expect(useLayoutStore.getState().layout.printBedSize).toBe(1000);
+
+      setPrintBedSize(99999);
+      expect(useLayoutStore.getState().layout.printBedSize).toBe(CONSTRAINTS.PRINT_BED_MM_MAX);
     });
 
     it('setGridUnitMm updates and clamps value', () => {

--- a/src/core/store/layout/coreActions.test.ts
+++ b/src/core/store/layout/coreActions.test.ts
@@ -82,9 +82,14 @@ describe('coreActions', () => {
       expect(useLayoutStore.getState().layout.printBedSize).toBe(42);
     });
 
-    it('clamps to maximum 500', () => {
-      useLayoutStore.getState().setPrintBedSize(9999);
-      expect(useLayoutStore.getState().layout.printBedSize).toBe(500);
+    it('accepts large-format beds', () => {
+      useLayoutStore.getState().setPrintBedSize(1000);
+      expect(useLayoutStore.getState().layout.printBedSize).toBe(1000);
+    });
+
+    it('clamps to the maximum', () => {
+      useLayoutStore.getState().setPrintBedSize(99999);
+      expect(useLayoutStore.getState().layout.printBedSize).toBe(CONSTRAINTS.PRINT_BED_MM_MAX);
     });
   });
 

--- a/src/core/store/layout/coreActions.test.ts
+++ b/src/core/store/layout/coreActions.test.ts
@@ -77,9 +77,9 @@ describe('coreActions', () => {
       expect(useLayoutStore.getState().layout.printBedSize).toBe(300);
     });
 
-    it('clamps to minimum 42', () => {
+    it('clamps to the minimum', () => {
       useLayoutStore.getState().setPrintBedSize(1);
-      expect(useLayoutStore.getState().layout.printBedSize).toBe(42);
+      expect(useLayoutStore.getState().layout.printBedSize).toBe(CONSTRAINTS.PRINT_BED_MM_MIN);
     });
 
     it('accepts large-format beds', () => {

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -87,13 +87,36 @@ describe('computeBaseplateTiling', () => {
   });
 
   it('leaves the largest expressible plate unsplit on a bed at PRINT_BED_MM_MAX', () => {
-    const params = makeParams({ width: CONSTRAINTS.GRID_MAX, depth: CONSTRAINTS.GRID_MAX });
+    // GRID_MAX × GRID_UNIT_MM_MAX is exactly PRINT_BED_MM_MAX, so this is the
+    // boundary case the cap is derived from, not merely a large plate.
+    const params = makeParams({
+      width: CONSTRAINTS.GRID_MAX,
+      depth: CONSTRAINTS.GRID_MAX,
+      gridUnitMm: CONSTRAINTS.GRID_UNIT_MM_MAX,
+    });
     const tiling = computeBaseplateTiling(params, CONSTRAINTS.PRINT_BED_MM_MAX);
 
     expect(tiling.isSplit).toBe(false);
     expect(tiling.pieces).toHaveLength(1);
     expect(tiling.pieces[0].widthUnits).toBe(CONSTRAINTS.GRID_MAX);
     expect(tiling.pieces[0].depthUnits).toBe(CONSTRAINTS.GRID_MAX);
+  });
+
+  it('still splits a padded max plate at PRINT_BED_MM_MAX', () => {
+    // Padding is charged against the bed budget on top of the grid extent, so
+    // the cap does not make every plate single-piece.
+    const params = makeParams({
+      width: CONSTRAINTS.GRID_MAX,
+      depth: CONSTRAINTS.GRID_MAX,
+      gridUnitMm: CONSTRAINTS.GRID_UNIT_MM_MAX,
+      paddingLeft: 100,
+      paddingRight: 100,
+      paddingFront: 100,
+      paddingBack: 100,
+    });
+    const tiling = computeBaseplateTiling(params, CONSTRAINTS.PRINT_BED_MM_MAX);
+
+    expect(tiling.isSplit).toBe(true);
   });
 
   it('preserves all padding on single piece', () => {

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -8,6 +8,7 @@ import {
 import { bodyCenterYMm } from './stackPrint';
 import { TONGUE_PROTRUSION } from '@/features/generation/worker/generators/generatorConstants';
 import { computeConnectorPositions } from '@/features/generation/worker/generators/connectorUtils';
+import { CONSTRAINTS } from '@/core/constants';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { BaseplatePiece } from '../types/tiling';
 import { computePieceFingerprint } from './pieceFingerprint';
@@ -83,6 +84,16 @@ describe('computeBaseplateTiling', () => {
     expect(piece.edges.right).toBe('exterior');
     expect(piece.edges.front).toBe('exterior');
     expect(piece.edges.back).toBe('exterior');
+  });
+
+  it('leaves the largest expressible plate unsplit on a bed at PRINT_BED_MM_MAX', () => {
+    const params = makeParams({ width: CONSTRAINTS.GRID_MAX, depth: CONSTRAINTS.GRID_MAX });
+    const tiling = computeBaseplateTiling(params, CONSTRAINTS.PRINT_BED_MM_MAX);
+
+    expect(tiling.isSplit).toBe(false);
+    expect(tiling.pieces).toHaveLength(1);
+    expect(tiling.pieces[0].widthUnits).toBe(CONSTRAINTS.GRID_MAX);
+    expect(tiling.pieces[0].depthUnits).toBe(CONSTRAINTS.GRID_MAX);
   });
 
   it('preserves all padding on single piece', () => {

--- a/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.test.ts
+++ b/src/features/bin-designer/components/panel/PhysicalUnitsSection/usePhysicalUnitsSection.test.ts
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { usePhysicalUnitsSection } from './usePhysicalUnitsSection';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSettingsStore } from '@/core/store';
+import { CONSTRAINTS } from '@/core/constants';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import { resetAllStores } from '@/test/testUtils';
@@ -133,15 +134,19 @@ describe('usePhysicalUnitsSection', () => {
     const { result } = renderHook(() => usePhysicalUnitsSection());
 
     act(() => {
-      result.current.handlers.handlePrintBedChange(10, 999);
+      result.current.handlers.handlePrintBedChange(10, 99999);
     });
-    expect(useSettingsStore.getState().settings.defaultPrintBedSize).toBe(42);
-    expect(useSettingsStore.getState().settings.defaultPrintBedDepth).toBe(500);
+    expect(useSettingsStore.getState().settings.defaultPrintBedSize).toBe(
+      CONSTRAINTS.PRINT_BED_MM_MIN
+    );
+    expect(useSettingsStore.getState().settings.defaultPrintBedDepth).toBe(
+      CONSTRAINTS.PRINT_BED_MM_MAX
+    );
 
     act(() => {
-      result.current.handlers.handlePrintBedChange(999);
+      result.current.handlers.handlePrintBedChange(1000);
     });
-    expect(useSettingsStore.getState().settings.defaultPrintBedSize).toBe(500);
+    expect(useSettingsStore.getState().settings.defaultPrintBedSize).toBe(1000);
     expect(useSettingsStore.getState().settings.defaultPrintBedDepth).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #2951.

## Problem

The print bed size was capped at 500mm. Owners of large-format printers (BigRep ONE, Modix BIG-Meter, etc.) could not enter their real bed size, so the tool split baseplates and bins that would have fit on their bed in one piece.

## Change

`CONSTRAINTS.PRINT_BED_MM_MAX`: 500 → 3000.

3000mm is `GRID_MAX (50) × GRID_UNIT_MM_MAX (60)` — the largest grid extent the tool can express. A bed at the cap therefore never splits an *unpadded* plate. Baseplate padding (0–100mm per side) and connector tongues are charged against the bed budget on top of the grid extent, so a heavily padded plate can still split at the cap; both cases are covered by tests.

`PRINT_BED_MM_MIN` is deliberately untouched: it doubles as the legacy grid-units-vs-mm detector in `LayoutService` storage migration.

## Scope

Every consumer already reads the constant rather than hardcoding, so this is a one-value change:

- `layout.setPrintBedSize` command handler (clamp)
- `coreActions.setPrintBedSize` (clamp)
- `DefaultsTab`, bin-designer `usePhysicalUnitsSection` (clamp)
- `PrintBedInput` (input `min`/`max`; no caller overrides them)

`api/lib/validation.ts` has no upper bound on `printBedSize`, so shared/synced layouts needed no server change. No UI copy or help text quotes the old figure.

## Verification

- Tests that hardcoded 500 now assert against the constant, plus new cases at 1000mm (command handler, store action, designer hook).
- Two new `splitPlanner` regression tests at `GRID_UNIT_MM_MAX`, so the plate is exactly 3000mm at the cap: an unpadded max plate stays single-piece, and a fully padded one still splits (6 pieces).
- The unsplit case is the genuinely new code path — a max-size baseplate previously always split into 6+ pieces and can now be requested as one solid.
- `pnpm run typecheck`, eslint, and the baseplate / print-export / shell / core-store / CQRS suites pass.