### PR TITLE
style(drawer-shape): demote the corner cuts entrypoint to a ghost link

### DIFF
--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.test.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.test.tsx
@@ -69,6 +69,21 @@ describe('DrawerShapeSection', () => {
     expect(screen.getByRole('button', { name: 'drawerShape.corners.open' })).toHaveClass('h-8');
   });
 
+  it('renders the actions as right-aligned links, not full-width buttons', () => {
+    useLayoutStore.setState((s) => ({
+      layout: { ...s.layout, drawer: { ...s.layout.drawer, outline: L_OUTLINE } },
+    }));
+    render(<DrawerShapeSection />);
+    const corners = screen.getByRole('button', { name: 'drawerShape.corners.open' });
+    const edit = screen.getByRole('button', { name: 'drawerShape.edit' });
+    for (const action of [corners, edit]) {
+      expect(action).not.toHaveClass('w-full');
+      expect(action).toHaveClass('bg-transparent');
+    }
+    expect(corners.parentElement).toHaveClass('justify-end');
+    expect(corners.compareDocumentPosition(edit)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
   it('confirms before resetting an existing shape', () => {
     useLayoutStore.setState((s) => ({
       layout: { ...s.layout, drawer: { ...s.layout.drawer, outline: L_OUTLINE } },

--- a/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
+++ b/src/features/drawer-shape/components/DrawerShapeSection/DrawerShapeSection.tsx
@@ -58,7 +58,7 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
   }, [mutations]);
 
   // 44px on mobile to match the touch target the rest of the settings sheet uses.
-  const actionClass = variant === 'mobile' ? 'text-sm h-11' : 'text-xs h-8';
+  const actionClass = variant === 'mobile' ? 'text-sm h-11 px-3' : 'text-xs h-8 px-2';
 
   return (
     <>
@@ -69,13 +69,10 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
         helpTarget="drawer-shape"
         variant={variant}
       />
-      {/* Full-width action buttons, matching the ActiveLayerPanel toolbar rather
-          than floating a lone ghost link. Corner cuts stay available with no
-          outline — they build one from the plain rectangle. */}
-      <div className="flex gap-1.5 pt-2">
+      <div className="flex justify-end gap-1 pt-1">
         <Button
-          variant="secondary"
-          fullWidth
+          variant="ghost"
+          size="sm"
           type="button"
           onClick={handleOpenCorners}
           className={actionClass}
@@ -84,8 +81,8 @@ export function DrawerShapeSection({ variant = 'desktop' }: DrawerShapeSectionPr
         </Button>
         {hasOutline && (
           <Button
-            variant="secondary"
-            fullWidth
+            variant="ghost"
+            size="sm"
             type="button"
             onClick={handleOpenEditor}
             className={actionClass}


### PR DESCRIPTION
## Problem

The drawer section of the layout planner sidebar led with a **full-width secondary button** for corner cuts. Because that button is visible whether or not a custom shape exists, the default state of the section was a lone filled bar sitting under the "Custom drawer shape" toggle — it read as the section's primary action, which the toggle is.

## Change

Both shape actions become right-aligned ghost links, aligned with the toggle's checkbox column.

```
BEFORE (no outline)                 AFTER (no outline)
[ ] Custom drawer shape    (?)      [ ] Custom drawer shape      (?)
┌───────────────────────────┐                        Corner cuts…
│       Corner cuts…        │
└───────────────────────────┘       AFTER (outline drawn)
                                    [x] Custom drawer shape      (?)
                                          Corner cuts…  Edit shape…
```

- `variant="secondary"` + `fullWidth` → `variant="ghost"` `size="sm"`, row is `justify-end`.
- Corner cuts stays first in the pair, and stays visible with no outline drawn — it is a shortcut that *creates* an outline from the plain rectangle, so gating it behind the toggle would remove the shortcut.
- Labels are unchanged, so no i18n key or locale churn.

## Touch targets

The mobile settings sheet keeps its 44px tap height (`h-11`); only the fill and full-width are dropped, not the hit area. Desktop stays `h-8`.

## Tests

Existing height assertions cover both platforms. Added one case asserting the pair is right-aligned, transparent, not `w-full`, and ordered corner-cuts-then-edit.

- `pnpm exec vitest run src/features/drawer-shape src/shell/Sidebar src/shell/Mobile/MobileSettingsPanel` — 93 passed
- `pnpm run typecheck`, `eslint` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demoted the drawer shape actions to right‑aligned ghost links so the toggle reads as the primary action and the sidebar looks cleaner. Corner cuts stays available without an outline; tap targets are unchanged.

- **Refactors**
  - Switched buttons from `variant="secondary" fullWidth` to `variant="ghost" size="sm"`; container now `justify-end`; added `px-3` (mobile) / `px-2` (desktop).
  - Preserved order: Corner cuts first, Edit shape second; corner cuts visible without an outline.
  - Added tests for right alignment, transparency, non-`w-full`, and action order.

<sup>Written for commit b4161a1abcaf733d9425b755cb038be8077025ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

