### PR TITLE
chore: drop stale sync-UI gate references and document OAuth env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,3 @@ GITHUB_CLIENT_SECRET=
 # On Vercel, leave blank — VERCEL_PROJECT_PRODUCTION_URL / VERCEL_URL are used.
 # For local dev, set this to your Vite origin (e.g. http://localhost:5173).
 OAUTH_REDIRECT_BASE_URL=
-
-# Sync UI gate. Default off so the in-progress sync feature is invisible
-# to end users. Set to '1' (in .env.local) to expose the SignInButton and
-# session lifecycle while developing PRs 3-5. PR 6 will flip the default.
-VITE_ENABLE_SYNC_UI=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,4 +68,6 @@ See `src/core/cqrs/README.md` for architecture details, adding new commands/even
 
 **Vercel (required):** `BLOB_READ_WRITE_TOKEN`, `REDIS_URL`, `TOKEN_SALT`
 
-**Optional:** `VITE_LIVEBLOCKS_PUBLIC_KEY`, `LIVEBLOCKS_SECRET_KEY`, `VITE_PUBLIC_POSTHOG_KEY`, `KOFI_VERIFICATION_TOKEN` (Ko-fi webhook; `/api/kofi-webhook` 503s without it)
+**Sign-in (required):** `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` — see `api/auth/README.md`
+
+**Optional:** `VITE_LIVEBLOCKS_PUBLIC_KEY`, `LIVEBLOCKS_SECRET_KEY`, `VITE_PUBLIC_POSTHOG_KEY`, `KOFI_VERIFICATION_TOKEN` (Ko-fi webhook; `/api/kofi-webhook` 503s without it), `OAUTH_REDIRECT_BASE_URL` (redirect base override; falls back to the Vercel-derived URL)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,6 @@ See `src/core/cqrs/README.md` for architecture details, adding new commands/even
 
 **Vercel (required):** `BLOB_READ_WRITE_TOKEN`, `REDIS_URL`, `TOKEN_SALT`
 
-**Sign-in (required):** `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` — see `api/auth/README.md`
+**Sign-in (required):** `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` — see `api/auth/README.md`. Vercel derives the OAuth redirect base automatically, but local dev must set `OAUTH_REDIRECT_BASE_URL` to the Vite origin: `getBaseUrl()` falls back to `https://localhost:3000`, so sign-in otherwise fails with a redirect URI mismatch.
 
-**Optional:** `VITE_LIVEBLOCKS_PUBLIC_KEY`, `LIVEBLOCKS_SECRET_KEY`, `VITE_PUBLIC_POSTHOG_KEY`, `KOFI_VERIFICATION_TOKEN` (Ko-fi webhook; `/api/kofi-webhook` 503s without it), `OAUTH_REDIRECT_BASE_URL` (redirect base override; falls back to the Vercel-derived URL)
+**Optional:** `VITE_LIVEBLOCKS_PUBLIC_KEY`, `LIVEBLOCKS_SECRET_KEY`, `VITE_PUBLIC_POSTHOG_KEY`, `KOFI_VERIFICATION_TOKEN` (Ko-fi webhook; `/api/kofi-webhook` 503s without it)

--- a/api/auth/README.md
+++ b/api/auth/README.md
@@ -2,9 +2,7 @@
 
 OAuth-gated sign-in for the multi-device sync feature. Self-hosted via [Arctic](https://arcticjs.dev/) — no SaaS auth dependency. Cookie sessions stored in Redis. The app stays fully usable anonymously; sign-in only unlocks cross-device sync.
 
-> **Status: not yet user-facing.** The auth surface (endpoints + client session store + SignInButton component) is built and tested, but the UI is gated behind `SYNC_UI_ENABLED` (sourced from `VITE_ENABLE_SYNC_UI`). The gate is **off** in production until the full sync feature lands (target: PR 6). Vite tree-shakes the SignInButton chunk when the gate is false, so the production bundle has zero footprint for this feature today.
->
-> To exercise the flow locally: `echo 'VITE_ENABLE_SYNC_UI=1' >> .env.local`.
+> **Local setup.** Sign-in is surfaced through `UserDock`; there is no build-time or Labs gate. To exercise the flow locally, set the provider credentials plus `OAUTH_REDIRECT_BASE_URL` in `.env.local` — see [Provider setup](#provider-setup) below.
 
 ## Endpoints
 

--- a/api/auth/README.md
+++ b/api/auth/README.md
@@ -33,14 +33,14 @@ OAuth-gated sign-in for the multi-device sync feature. Self-hosted via [Arctic](
 
 ## Environment variables
 
-| Var                       | Required   | Purpose                                                                                            |
-| ------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
-| `GOOGLE_CLIENT_ID`        | yes        | Google OAuth app client id                                                                         |
-| `GOOGLE_CLIENT_SECRET`    | yes        | Google OAuth app client secret                                                                     |
-| `GITHUB_CLIENT_ID`        | yes        | GitHub OAuth app client id                                                                         |
-| `GITHUB_CLIENT_SECRET`    | yes        | GitHub OAuth app client secret                                                                     |
-| `OAUTH_REDIRECT_BASE_URL` | optional   | Override for the redirect base (e.g. custom domain). Falls back to `getBaseUrl()` (Vercel-derived) |
-| `REDIS_URL`               | yes (prod) | Same Redis used by share / rate-limit. Sessions and profiles stored here                           |
+| Var                       | Required   | Purpose                                                                                                                                                                                                          |
+| ------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GOOGLE_CLIENT_ID`        | yes        | Google OAuth app client id                                                                                                                                                                                       |
+| `GOOGLE_CLIENT_SECRET`    | yes        | Google OAuth app client secret                                                                                                                                                                                   |
+| `GITHUB_CLIENT_ID`        | yes        | GitHub OAuth app client id                                                                                                                                                                                       |
+| `GITHUB_CLIENT_SECRET`    | yes        | GitHub OAuth app client secret                                                                                                                                                                                   |
+| `OAUTH_REDIRECT_BASE_URL` | local dev  | Override for the redirect base (e.g. custom domain). Falls back to `getBaseUrl()`, which is Vercel-derived in deployments but `https://localhost:3000` elsewhere — so local dev must set this to the Vite origin |
+| `REDIS_URL`               | yes (prod) | Same Redis used by share / rate-limit. Sessions and profiles stored here                                                                                                                                         |
 
 ## Cookie shape
 


### PR DESCRIPTION
## Summary

Fallout from an audit of the project's Vercel environment variables. `VITE_ENABLE_SYNC_UI` has zero code references — #1605 replaced the `SYNC_UI_ENABLED` build gate with a Labs flag, which has since graduated — but three docs still described it as live.

## Changes

- **`.env.example`** — remove the `VITE_ENABLE_SYNC_UI` entry. Nothing reads it.
- **`api/auth/README.md`** — the status banner claimed auth was "not yet user-facing… gated behind `SYNC_UI_ENABLED`… target: PR 6" and pointed at a `SignInButton` component that no longer exists in `src/`. Sign-in ships through `UserDock`. Replaced with a local-setup note.
- **`CLAUDE.md`** — the env var section omitted all four OAuth credentials, which are required for sign-in, and `OAUTH_REDIRECT_BASE_URL`. Added, pointing at `api/auth/README.md` rather than duplicating its table.

## Companion Vercel changes (already applied, no code impact)

- Deleted `CRON_SECRET` — orphaned when #1143 removed the slicer-temp cleanup cron added in #848. No `crons` entry in `vercel.json`.
- Deleted `VITE_PUBLIC_POSTHOG_HOST` — superseded by the reverse proxy; `posthog/init.ts` hardcodes `api_host: '/ph'` and `vercel.json` rewrites it.
- Deleted the Development-scoped `LIVEBLOCKS_SECRET_KEY` — its stored value ended in a newline, making it an invalid HTTP header value, so it could never have authenticated.
- `TOKEN_SALT` (preview + production) and `KOFI_VERIFICATION_TOKEN` (production) converted to Vercel's `sensitive` type. Values unchanged.

## Test plan

- [x] Pre-commit gates pass (lint-staged, module boundaries, i18n ×4, exhaustiveness, component structure, missing tests)
- [x] `rg VITE_ENABLE_SYNC_UI` and `rg SYNC_UI_ENABLED` return no hits outside `CHANGELOG.md`
- [x] Docs-only diff — no runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the stale sync UI env gate and align auth docs with the current sign-in flow. Deletes `VITE_ENABLE_SYNC_UI`, updates `api/auth/README.md` to reflect sign-in via `UserDock` with no build-time gate, clarifies `OAUTH_REDIRECT_BASE_URL` is required for local dev (Vercel derives it automatically), and documents required OAuth vars in `CLAUDE.md`; docs-only, no runtime changes.

<sup>Written for commit a226bc46122c6ced767e0fd7c24b17c918e2fa5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

