### PR TITLE
fix(sync-admin): stop reporting mid-scan writes as integrity errors

### DIFF
--- a/scripts/sync-admin/README.md
+++ b/scripts/sync-admin/README.md
@@ -30,10 +30,40 @@ PUT endpoints use), and sanitization-drift detection.
 ```bash
 pnpm sync-admin audit                       # human-readable report
 pnpm sync-admin audit --suggest             # inline fix commands per finding
-pnpm sync-admin audit --no-payload-fetch    # fast path, skips HTTP fetch
-pnpm sync-admin audit --strict              # exit non-zero on any finding (CI)
+pnpm sync-admin audit --no-payload-fetch    # skips HTTP fetch
+pnpm sync-admin audit --strict              # exit non-zero on error/warn (CI)
 pnpm --silent sync-admin audit --json       # structured output for piping
 ```
+
+Expect roughly 1–2 minutes at ~1k users and ~8.5k blobs; progress goes to
+stderr so `--json` stdout stays pipeable.
+
+## Re-verification (why findings can be suppressed)
+
+The scan lists every blob before reading the Redis index, so on a live database
+any save landing in that gap is observed inconsistently — the old blob listing
+paired with the new index entry. That fabricates findings:
+
+| In-flight event       | Fabricated finding                              |
+| --------------------- | ----------------------------------------------- |
+| Create                | `missing_blob`                                  |
+| Edit shrinking bytes  | `index_size_undercount`                         |
+| Edit growing bytes    | `sanitization_drift`                            |
+| Any rewrite           | `modifiedAt_mismatch` + `listing_size_mismatch` |
+| Blob replaced mid-run | `envelope_invalid` (HTTP 404)                   |
+
+Every flagged item is therefore re-read once and compared against the first
+observation:
+
+- **Moved again** → being actively written → suppressed as in-flight.
+- **Byte-identical and still inconsistent** → real → reported.
+
+Suppressed counts are always printed (and listed under `suppressed` in `--json`)
+so nothing disappears silently. `--no-reverify` returns the raw findings, which
+is useful when debugging the detector itself.
+
+`suggest` runs the same pass, so a mid-write item can never produce a
+remediation command.
 
 ### `user <uid>`
 
@@ -86,15 +116,17 @@ bash drift-fixes.sh
 
 ## Shared flags
 
-| Flag                      | Applies to                 | Effect                                                                               |
-| ------------------------- | -------------------------- | ------------------------------------------------------------------------------------ |
-| `--json`                  | all                        | Machine-readable output (use with `pnpm --silent`)                                   |
-| `--strict`                | audit, user, tombstones    | Exit 1 if any finding present (errors, warnings, _and_ info — e.g. stale tombstones) |
-| `--kind=layouts\|designs` | most                       | Restrict to one item kind                                                            |
-| `--user=<uid>`            | audit, suggest, tombstones | Restrict to one user                                                                 |
-| `--no-payload-fetch`      | audit, user, suggest       | Skip per-blob HTTP fetch (skips envelope checks)                                     |
-| `--suggest`               | audit                      | Inline fix commands beneath each finding                                             |
-| `--older-than=Nd`         | tombstones, suggest        | Stale-tombstone age threshold (default 90d)                                          |
+| Flag                                  | Applies to                 | Effect                                                        |
+| ------------------------------------- | -------------------------- | ------------------------------------------------------------- |
+| `--json`                              | all                        | Machine-readable output (use with `pnpm --silent`)            |
+| `--strict`                            | audit, user                | Exit 1 on any error or warning finding; info does not fail    |
+| `--strict`                            | tombstones                 | Exit 1 if any tombstone is stale (that command's whole point) |
+| `--kind=layouts\|designs\|baseplates` | most                       | Restrict to one item kind                                     |
+| `--user=<uid>`                        | audit, suggest, tombstones | Restrict to one user                                          |
+| `--no-payload-fetch`                  | audit, user, suggest       | Skip per-blob HTTP fetch (skips envelope checks)              |
+| `--no-reverify`                       | audit, user, suggest       | Report raw findings without re-reading flagged items          |
+| `--suggest`                           | audit                      | Inline fix commands beneath each finding                      |
+| `--older-than=Nd`                     | tombstones, suggest        | Stale-tombstone age threshold (default 90d)                   |
 
 ## Finding kinds
 
@@ -107,18 +139,21 @@ bash drift-fixes.sh
 | `modifiedAt_mismatch`   | error    | Envelope's `modifiedAt` differs from index entry's           |
 | `envelope_invalid`      | error    | Envelope shape wrong: bad `schemaVersion` / `modifiedAt`     |
 | `payload_invalid`       | error    | `validateShareLayout` / `validateDesignerShare` rejected     |
+| `index_size_undercount` | error    | Index `sizeBytes` under-counts the blob; hides quota usage   |
+| `fetch_timeout`         | error    | Blob fetch exceeded the per-fetch deadline (default 15s)     |
 | `sanitization_drift`    | warn     | Index `sizeBytes` over-counts (quota leak in system's favor) |
 | `listing_size_mismatch` | warn     | Vercel Blob listing's `size` differs from fetched byte count |
 | `stale_tombstone`       | info     | Tombstone older than retention; safe to sweep                |
 
-## CI usage
+## Scripted / scheduled usage
 
 ```bash
 pnpm sync-admin audit --strict --no-payload-fetch
 ```
 
-Exits 1 on any error/warning. `--no-payload-fetch` keeps the run sub-second
-without sacrificing membership + drift detection.
+Exits 1 on any error or warning. This is an operator tool, not a per-PR gate:
+it needs production Redis + Blob credentials and takes minutes, so nothing in
+CI runs it. Run it by hand, or on a schedule with the credentials available.
 
 ## Implementation notes
 
@@ -126,6 +161,10 @@ without sacrificing membership + drift detection.
   `TOMBSTONE_RETENTION_MS` directly from `api/lib/` so production validation
   changes are reflected automatically.
 - Bounded concurrency of 16 in-flight blob fetches via `lib/concurrency.ts`.
+- Index reads are pipelined in chunks of 200 (`lib/redis.ts`). One `HGETALL`
+  per user serially cost `users × RTT`, which dominated the run against a
+  remote Redis and widened the blob↔index gap that manufactures findings.
+- `SCAN` stays serial — the cursor is inherently sequential.
 - The envelope-overhead delta math lives in `lib/delta.ts`; see comments
   there for the precise byte accounting that distinguishes "expected" from
   "drift".

--- a/scripts/sync-admin/__tests__/findings.test.ts
+++ b/scripts/sync-admin/__tests__/findings.test.ts
@@ -22,7 +22,7 @@ function makeInventory(blobs: BlobRow[], indexRows: IndexRow[]): Inventory {
     indexMap.set(itemKey(r.uid, r.kind, r.id), r);
     redisUsers.add(r.uid);
   }
-  return { blobs, blobMap, indexRows, indexMap, blobUsers, redisUsers };
+  return { blobs, blobMap, indexRows, indexMap, blobUsers, redisUsers, blobsListed: true };
 }
 
 const T = 1_780_000_000_000;

--- a/scripts/sync-admin/__tests__/redis.test.ts
+++ b/scripts/sync-admin/__tests__/redis.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import type Redis from 'ioredis';
+import { hgetallMany } from '../lib/redis';
+
+/**
+ * Pipeline stub recording how many batches were flushed, so the test can assert
+ * the reads were actually batched rather than issued one per key.
+ */
+function redisStub(data: Record<string, Record<string, string>>) {
+  const batches: string[][] = [];
+  const redis = {
+    pipeline() {
+      const keys: string[] = [];
+      return {
+        hgetall(key: string) {
+          keys.push(key);
+        },
+        async exec() {
+          batches.push([...keys]);
+          return keys.map((k) => [null, data[k] ?? {}] as [null, Record<string, string>]);
+        },
+      };
+    },
+  } as unknown as Redis;
+  return { redis, batches };
+}
+
+describe('hgetallMany', () => {
+  it('returns the same mapping a per-key serial read would', async () => {
+    const data = {
+      'users:a:index:layouts': { l1: '{"modifiedAt":1,"sizeBytes":2}' },
+      'users:b:index:layouts': { l2: '{"modifiedAt":3,"sizeBytes":4}' },
+      'users:c:index:layouts': {},
+    };
+    const { redis } = redisStub(data);
+
+    const out = await hgetallMany(redis, Object.keys(data));
+
+    expect(out.size).toBe(3);
+    expect(out.get('users:a:index:layouts')).toEqual(data['users:a:index:layouts']);
+    expect(out.get('users:b:index:layouts')).toEqual(data['users:b:index:layouts']);
+    expect(out.get('users:c:index:layouts')).toEqual({});
+  });
+
+  it('batches keys into chunks instead of one round trip per key', async () => {
+    const keys = Array.from({ length: 250 }, (_, i) => `users:u${i}:index:layouts`);
+    const { redis, batches } = redisStub({});
+
+    await hgetallMany(redis, keys, 100);
+
+    expect(batches.map((b) => b.length)).toEqual([100, 100, 50]);
+  });
+
+  it('reports progress per flushed chunk', async () => {
+    const keys = Array.from({ length: 5 }, (_, i) => `k${i}`);
+    const { redis } = redisStub({});
+    const seen: number[] = [];
+
+    await hgetallMany(redis, keys, 2, (done) => seen.push(done));
+
+    expect(seen).toEqual([2, 4, 5]);
+  });
+
+  it('handles an empty key list without a round trip', async () => {
+    const { redis, batches } = redisStub({});
+
+    const out = await hgetallMany(redis, []);
+
+    expect(out.size).toBe(0);
+    expect(batches).toHaveLength(0);
+  });
+
+  it('surfaces a per-command error rather than returning a partial map', async () => {
+    const redis = {
+      pipeline: () => ({
+        hgetall() {},
+        async exec() {
+          return [[new Error('WRONGTYPE'), null]];
+        },
+      }),
+    } as unknown as Redis;
+
+    await expect(hgetallMany(redis, ['k'])).rejects.toThrow('WRONGTYPE');
+  });
+
+  it('throws when the pipeline itself fails', async () => {
+    const redis = {
+      pipeline: () => ({
+        hgetall() {},
+        async exec() {
+          return null;
+        },
+      }),
+    } as unknown as Redis;
+
+    await expect(hgetallMany(redis, ['k'])).rejects.toThrow('pipeline failed');
+  });
+});

--- a/scripts/sync-admin/__tests__/reverify.test.ts
+++ b/scripts/sync-admin/__tests__/reverify.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type Redis from 'ioredis';
+import { reverify, stateFromInventory, stateKey } from '../lib/reverify';
+import { itemKey } from '../lib/inventory';
+import type { BlobRow, Finding, Inventory, IndexRow } from '../lib/types';
+
+const listMock = vi.fn();
+vi.mock('@vercel/blob', () => ({ list: (...a: unknown[]) => listMock(...a) }));
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+beforeEach(() => {
+  listMock.mockReset();
+  fetchMock.mockReset();
+});
+
+const UID = 'u1';
+const T = 1_780_000_000_000;
+
+function blobRow(id: string, size: number, kind: BlobRow['kind'] = 'layouts'): BlobRow {
+  return {
+    uid: UID,
+    kind,
+    id,
+    size,
+    url: `https://blob.test/users/${UID}/${kind}/${id}.json`,
+    uploadedAt: new Date(T),
+  };
+}
+
+function indexRow(
+  id: string,
+  sizeBytes: number,
+  modifiedAt = T,
+  deletedAt?: number,
+  kind: IndexRow['kind'] = 'layouts'
+): IndexRow {
+  return {
+    uid: UID,
+    kind,
+    id,
+    entry: { modifiedAt, sizeBytes, ...(deletedAt === undefined ? {} : { deletedAt }) },
+    tombstone: deletedAt !== undefined,
+  };
+}
+
+function inventory(blobs: BlobRow[], rows: IndexRow[], blobsListed = true): Inventory {
+  const blobMap = new Map<string, BlobRow>();
+  const blobUsers = new Set<string>();
+  for (const b of blobs) {
+    blobMap.set(itemKey(b.uid, b.kind, b.id), b);
+    blobUsers.add(b.uid);
+  }
+  const indexMap = new Map<string, IndexRow>();
+  const redisUsers = new Set<string>();
+  for (const r of rows) {
+    indexMap.set(itemKey(r.uid, r.kind, r.id), r);
+    redisUsers.add(r.uid);
+  }
+  return {
+    blobs,
+    blobMap,
+    indexRows: rows,
+    indexMap,
+    blobUsers,
+    redisUsers,
+    blobsListed,
+  };
+}
+
+/** Redis stub returning one canned HGET value. */
+function redisStub(hget: string | null): Redis {
+  return { hget: vi.fn().mockResolvedValue(hget) } as unknown as Redis;
+}
+
+function blobPage(rows: { pathname: string; size: number; url?: string }[]): {
+  blobs: { pathname: string; size: number; url: string }[];
+} {
+  return {
+    blobs: rows.map((r) => ({
+      pathname: r.pathname,
+      size: r.size,
+      url: r.url ?? `https://blob.test/${r.pathname}`,
+    })),
+  };
+}
+
+const missingBlobFinding: Finding = {
+  kind: 'missing_blob',
+  uid: UID,
+  itemKind: 'layouts',
+  id: 'a1',
+  severity: 'error',
+  detail: 'live index entry has no blob',
+  data: { sizeBytes: 100, modifiedAt: T },
+};
+
+describe('reverify — in-flight writes', () => {
+  it('suppresses a finding whose item changed between the two reads', async () => {
+    // Scan saw the index entry at modifiedAt=T with no blob. By re-read time the
+    // user has saved again, so modifiedAt moved: the item is being written.
+    const inv = inventory([], [indexRow('a1', 100, T)]);
+    listMock.mockResolvedValue(blobPage([]));
+    const redis = redisStub(JSON.stringify({ modifiedAt: T + 5000, sizeBytes: 140 }));
+
+    const { confirmed, suppressed } = await reverify(redis, inv, [missingBlobFinding], 1000);
+
+    expect(confirmed).toHaveLength(0);
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it('confirms a finding whose item is byte-identical on re-read', async () => {
+    const inv = inventory([], [indexRow('a1', 100, T)]);
+    listMock.mockResolvedValue(blobPage([]));
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const { confirmed, suppressed } = await reverify(redis, inv, [missingBlobFinding], 1000);
+
+    expect(suppressed).toHaveLength(0);
+    expect(confirmed).toEqual([missingBlobFinding]);
+  });
+
+  it('suppresses missing_blob once the blob has appeared', async () => {
+    // Stable index, but the blob landed after the listing — a create that raced.
+    const inv = inventory([], [indexRow('a1', 100, T)]);
+    listMock.mockResolvedValue(blobPage([{ pathname: `users/${UID}/layouts/a1.json`, size: 132 }]));
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const { confirmed, suppressed } = await reverify(redis, inv, [missingBlobFinding], 1000);
+
+    expect(confirmed).toHaveLength(0);
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it('suppresses orphan_blob once the index entry has appeared', async () => {
+    const inv = inventory([blobRow('a1', 132)], []);
+    listMock.mockResolvedValue(blobPage([{ pathname: `users/${UID}/layouts/a1.json`, size: 132 }]));
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const finding: Finding = {
+      kind: 'orphan_blob',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'blob has no index entry',
+    };
+    const { confirmed, suppressed } = await reverify(redis, inv, [finding], 1000);
+
+    expect(confirmed).toHaveLength(0);
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it('confirms a genuine orphan_blob that stays orphaned', async () => {
+    const inv = inventory([blobRow('a1', 132)], []);
+    listMock.mockResolvedValue(blobPage([{ pathname: `users/${UID}/layouts/a1.json`, size: 132 }]));
+    const redis = redisStub(null);
+
+    const finding: Finding = {
+      kind: 'orphan_blob',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'blob has no index entry',
+    };
+    const { confirmed } = await reverify(redis, inv, [finding], 1000);
+
+    expect(confirmed).toEqual([finding]);
+  });
+});
+
+describe('reverify — kinds that a re-read cannot settle', () => {
+  it('keeps malformed_index_entry without re-reading', async () => {
+    const inv = inventory([], []);
+    const redis = redisStub(null);
+    const finding: Finding = {
+      kind: 'malformed_index_entry',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'unparseable',
+    };
+
+    const { confirmed } = await reverify(redis, inv, [finding], 1000);
+
+    expect(confirmed).toEqual([finding]);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps payload_invalid without re-reading', async () => {
+    const inv = inventory([], []);
+    const redis = redisStub(null);
+    const finding: Finding = {
+      kind: 'payload_invalid',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'INVALID: bad',
+    };
+
+    const { confirmed } = await reverify(redis, inv, [finding], 1000);
+
+    expect(confirmed).toEqual([finding]);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('reverify — payload-dependent kinds', () => {
+  const stableInv = (): Inventory => inventory([blobRow('a1', 132)], [indexRow('a1', 100, T)]);
+
+  function stableRead(): void {
+    listMock.mockResolvedValue(blobPage([{ pathname: `users/${UID}/layouts/a1.json`, size: 132 }]));
+  }
+
+  it('suppresses modifiedAt_mismatch once the envelope agrees with the index', async () => {
+    stableRead();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ modifiedAt: T, schemaVersion: 1 }),
+    });
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const finding: Finding = {
+      kind: 'modifiedAt_mismatch',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'envelope=x index=y',
+    };
+    const { suppressed } = await reverify(redis, stableInv(), [finding], 1000);
+
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it('confirms modifiedAt_mismatch that persists', async () => {
+    stableRead();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ modifiedAt: T + 999, schemaVersion: 1 }),
+    });
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const finding: Finding = {
+      kind: 'modifiedAt_mismatch',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'envelope=x index=y',
+    };
+    const { confirmed } = await reverify(redis, stableInv(), [finding], 1000);
+
+    expect(confirmed).toHaveLength(1);
+  });
+
+  it('suppresses envelope_invalid when the blob fetches cleanly on retry', async () => {
+    // First pass recorded HTTP 404 mid-rewrite; the blob is fine now.
+    stableRead();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ modifiedAt: T, schemaVersion: 1 }),
+    });
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const finding: Finding = {
+      kind: 'envelope_invalid',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'HTTP 404 fetching blob',
+    };
+    const { suppressed } = await reverify(redis, stableInv(), [finding], 1000);
+
+    expect(suppressed).toHaveLength(1);
+  });
+
+  it('confirms envelope_invalid when the envelope is still wrong', async () => {
+    stableRead();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ modifiedAt: T, schemaVersion: 99 }),
+    });
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const finding: Finding = {
+      kind: 'envelope_invalid',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'schemaVersion=99 (expected 1)',
+    };
+    const { confirmed } = await reverify(redis, stableInv(), [finding], 1000);
+
+    expect(confirmed).toHaveLength(1);
+  });
+});
+
+describe('stateKey', () => {
+  it('ignores blob fields when the inventory skipped the blob listing', () => {
+    const inv = inventory([], [indexRow('a1', 100, T)], false);
+    const before = stateFromInventory(inv, UID, 'layouts', 'a1');
+    const after = { ...before, blobPresent: true, blobSize: 132, blobUrl: 'https://b' };
+
+    expect(stateKey(before, false)).toBe(stateKey(after, false));
+    expect(stateKey(before, true)).not.toBe(stateKey(after, true));
+  });
+
+  it('does not suppress a stale_tombstone just because blobs were not listed', async () => {
+    const inv = inventory([], [indexRow('a1', 0, T, T, 'layouts')], false);
+    listMock.mockResolvedValue(blobPage([{ pathname: `users/${UID}/layouts/a1.json`, size: 132 }]));
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 0, deletedAt: T }));
+
+    const finding: Finding = {
+      kind: 'stale_tombstone',
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'info',
+      detail: 'old',
+    };
+    const { confirmed } = await reverify(redis, inv, [finding], 1000);
+
+    expect(confirmed).toHaveLength(1);
+  });
+});

--- a/scripts/sync-admin/__tests__/reverify.test.ts
+++ b/scripts/sync-admin/__tests__/reverify.test.ts
@@ -328,5 +328,7 @@ describe('stateKey', () => {
     const { confirmed } = await reverify(redis, inv, [finding], 1000);
 
     expect(confirmed).toHaveLength(1);
+    // skipBlobs inventories ignore blob fields, so don't pay for the listing.
+    expect(listMock).not.toHaveBeenCalled();
   });
 });

--- a/scripts/sync-admin/commands/audit.ts
+++ b/scripts/sync-admin/commands/audit.ts
@@ -1,32 +1,44 @@
-import { analyze } from '../lib/findings.js';
+import { analyzeWithReverify } from '../lib/findings.js';
 import { buildInventory } from '../lib/inventory.js';
 import { colors, formatFinding } from '../lib/output.js';
+import { createProgress } from '../lib/progress.js';
 import { connect } from '../lib/redis.js';
 import { categoryOf, suggestFor } from '../lib/suggest.js';
 import type { Args } from '../lib/args.js';
 import type { Finding } from '../lib/types.js';
 
+/** Findings that should fail `--strict`. Info is housekeeping, not a defect. */
+export function failsStrict(findings: readonly Finding[]): boolean {
+  return findings.some((f) => f.severity === 'error' || f.severity === 'warn');
+}
+
 export async function audit(args: Args): Promise<number> {
   const redis = connect();
+  const progress = createProgress(true);
   try {
-    const inv = await buildInventory(redis, { user: args.user, kind: args.kind });
-    const findings = await analyze(inv, { fetchPayloads: !args.noPayloadFetch });
+    const inv = await buildInventory(redis, { user: args.user, kind: args.kind, progress });
+    const { findings, suppressed } = await analyzeWithReverify(inv, {
+      fetchPayloads: !args.noPayloadFetch,
+      reverifyWith: args.noReverify ? undefined : redis,
+      progress,
+    });
 
     if (args.json) {
       const payload = {
-        summary: summarize(inv, findings),
+        summary: summarize(inv, findings, suppressed),
         findings: findings.map((f) => ({
           ...f,
           suggestions: args.suggest ? suggestFor(f) : undefined,
           category: categoryOf(f),
         })),
+        suppressed: suppressed.map((f) => ({ ...f, category: categoryOf(f) })),
       };
       process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
     } else {
-      printHuman(inv, findings, args.suggest);
+      printHuman(inv, findings, suppressed, args.suggest);
     }
 
-    return args.strict && findings.length > 0 ? 1 : 0;
+    return args.strict && failsStrict(findings) ? 1 : 0;
   } finally {
     await redis.quit();
   }
@@ -34,7 +46,8 @@ export async function audit(args: Args): Promise<number> {
 
 function summarize(
   inv: ReturnType<typeof buildInventory> extends Promise<infer T> ? T : never,
-  findings: Finding[]
+  findings: Finding[],
+  suppressed: Finding[]
 ) {
   return {
     blobs: inv.blobs.length,
@@ -49,6 +62,10 @@ function summarize(
       warnings: findings.filter((f) => f.severity === 'warn').length,
       info: findings.filter((f) => f.severity === 'info').length,
       byKind: groupCount(findings, (f) => f.kind),
+    },
+    suppressed: {
+      total: suppressed.length,
+      byKind: groupCount(suppressed, (f) => f.kind),
     },
   };
 }
@@ -70,6 +87,7 @@ function printHuman(
     redisUsers: Set<string>;
   },
   findings: Finding[],
+  suppressed: Finding[],
   withSuggestions: boolean
 ): void {
   const live = inv.indexRows.filter((r) => !r.tombstone).length;
@@ -81,6 +99,11 @@ function printHuman(
   console.log(
     `Findings:        ${findings.length}  (errors: ${findings.filter((f) => f.severity === 'error').length}, warnings: ${findings.filter((f) => f.severity === 'warn').length}, info: ${findings.filter((f) => f.severity === 'info').length})`
   );
+  if (suppressed.length > 0) {
+    console.log(
+      colors.dim(`Suppressed:      ${suppressed.length}  (re-verified as in-flight writes)`)
+    );
+  }
 
   if (findings.length === 0) {
     console.log(`\n${colors.cyan('✓ no findings')}`);

--- a/scripts/sync-admin/commands/suggest.ts
+++ b/scripts/sync-admin/commands/suggest.ts
@@ -1,6 +1,7 @@
-import { analyze } from '../lib/findings.js';
+import { analyzeWithReverify } from '../lib/findings.js';
 import { buildInventory } from '../lib/inventory.js';
 import { colors } from '../lib/output.js';
+import { createProgress } from '../lib/progress.js';
 import { connect } from '../lib/redis.js';
 import {
   categoryOf,
@@ -28,18 +29,26 @@ export async function suggest(args: Args): Promise<number> {
 
   const redis = connect();
   try {
+    const progress = createProgress(true);
     const inv = await buildInventory(redis, {
       user: args.user,
       kind: args.kind,
       skipBlobs: !NEEDS_BLOBS[cat],
+      progress,
     });
-    const findings = await analyze(inv, {
+    // Re-verify before emitting anything: these commands delete blobs and index
+    // entries, and a finding produced by a write landing mid-scan is not a
+    // defect to remediate.
+    const { findings, suppressed } = await analyzeWithReverify(inv, {
       // Payload fetching only contributes envelope/payload findings, none of
       // which feed into `suggest`'s categories. Skip the fetch pass entirely.
       fetchPayloads: false,
       staleTombstoneMs: args.olderThanMs,
+      reverifyWith: args.noReverify ? undefined : redis,
+      progress,
     });
     const matched = findings.filter((f) => categoryOf(f) === cat);
+    const skipped = suppressed.filter((f) => categoryOf(f) === cat);
 
     if (args.json) {
       process.stdout.write(
@@ -54,11 +63,17 @@ export async function suggest(args: Args): Promise<number> {
 
     if (matched.length === 0) {
       console.log(colors.cyan(`✓ no findings in category "${cat}"`));
+      if (skipped.length > 0) {
+        console.log(colors.dim(`  (${skipped.length} suppressed as in-flight writes)`));
+      }
       return 0;
     }
     for (const line of SCRIPT_PREAMBLE) console.log(line);
     console.log(`# sync-admin suggest ${cat} — ${matched.length} finding(s)`);
     console.log(`# Review each command before running.`);
+    if (skipped.length > 0) {
+      console.log(`# ${skipped.length} candidate(s) omitted: in-flight writes, not defects.`);
+    }
     console.log('');
     for (const f of matched) {
       for (const line of suggestFor(f)) console.log(line);

--- a/scripts/sync-admin/commands/tombstones.ts
+++ b/scripts/sync-admin/commands/tombstones.ts
@@ -1,6 +1,7 @@
 import { TOMBSTONE_RETENTION_MS } from '../../../api/lib/userIndex.js';
 import { buildInventory } from '../lib/inventory.js';
 import { colors, formatTable } from '../lib/output.js';
+import { createProgress } from '../lib/progress.js';
 import { connect } from '../lib/redis.js';
 import type { Args } from '../lib/args.js';
 import type { Kind } from '../lib/types.js';
@@ -22,6 +23,7 @@ export async function tombstones(args: Args): Promise<number> {
       user: args.user,
       kind: args.kind,
       skipBlobs: true,
+      progress: createProgress(true),
     });
     const staleAge = args.olderThanMs ?? TOMBSTONE_RETENTION_MS;
     const now = Date.now();

--- a/scripts/sync-admin/commands/user.ts
+++ b/scripts/sync-admin/commands/user.ts
@@ -1,6 +1,7 @@
-import { analyze } from '../lib/findings.js';
+import { analyzeWithReverify } from '../lib/findings.js';
 import { buildInventory } from '../lib/inventory.js';
 import { colors, formatFinding, formatTable } from '../lib/output.js';
+import { createProgress } from '../lib/progress.js';
 import { connect } from '../lib/redis.js';
 import { suggestFor } from '../lib/suggest.js';
 import type { Args } from '../lib/args.js';
@@ -13,8 +14,13 @@ export async function user(args: Args): Promise<number> {
   }
   const redis = connect();
   try {
-    const inv = await buildInventory(redis, { user: uid, kind: args.kind });
-    const findings = await analyze(inv, { fetchPayloads: !args.noPayloadFetch });
+    const progress = createProgress(true);
+    const inv = await buildInventory(redis, { user: uid, kind: args.kind, progress });
+    const { findings, suppressed } = await analyzeWithReverify(inv, {
+      fetchPayloads: !args.noPayloadFetch,
+      reverifyWith: args.noReverify ? undefined : redis,
+      progress,
+    });
 
     if (args.json) {
       process.stdout.write(
@@ -27,13 +33,14 @@ export async function user(args: Args): Promise<number> {
               ...f,
               suggestions: args.suggest ? suggestFor(f) : undefined,
             })),
+            suppressed,
           },
           null,
           2
         ) + '\n'
       );
     } else {
-      printHuman(uid, inv, findings);
+      printHuman(uid, inv, findings, suppressed);
     }
 
     const hasErrors = findings.some((f) => f.severity === 'error' || f.severity === 'warn');
@@ -54,7 +61,8 @@ function printHuman(
       entry: { modifiedAt: number; sizeBytes: number; deletedAt?: number };
     }[];
   },
-  findings: readonly { severity: string }[]
+  findings: readonly { severity: string }[],
+  suppressed: readonly unknown[]
 ): void {
   console.log(colors.bold(`=== user ${uid} ===`));
   const live = inv.indexRows.filter((r) => !r.tombstone);
@@ -62,6 +70,9 @@ function printHuman(
   console.log(`Blobs:         ${inv.blobs.length}`);
   console.log(`Live entries:  ${live.length}`);
   console.log(`Tombstones:    ${tombs.length}`);
+  if (suppressed.length > 0) {
+    console.log(colors.dim(`Suppressed:    ${suppressed.length} (in-flight writes)`));
+  }
   console.log('');
 
   if (inv.blobs.length) {

--- a/scripts/sync-admin/index.ts
+++ b/scripts/sync-admin/index.ts
@@ -28,14 +28,16 @@ Commands:
   suggest <category>     Emit shell commands for: drift | orphans | stale-tombstones | malformed
 
 Flags:
-  --json                 Machine-readable output
-  --strict               Exit non-zero if any error/warning finding present
-  --kind=layouts|designs Restrict to one item kind
-  --user=<uid>           Restrict to one user (audit/tombstones/suggest)
-  --no-payload-fetch     Skip per-blob HTTP fetch (faster; envelope checks skipped)
-  --suggest              For \`audit\`: inline fix commands beneath each finding
-  --older-than=Nd        For \`tombstones\` / \`suggest stale-tombstones\`: age threshold (default 90d)
-  --help                 Show this message
+  --json                          Machine-readable output
+  --strict                        Exit non-zero if any error/warning finding present
+  --kind=layouts|designs|baseplates
+                                  Restrict to one item kind
+  --user=<uid>                    Restrict to one user (audit/tombstones/suggest)
+  --no-payload-fetch              Skip per-blob HTTP fetch (faster; envelope checks skipped)
+  --no-reverify                   Report raw findings without re-reading flagged items
+  --suggest                       For \`audit\`: inline fix commands beneath each finding
+  --older-than=Nd                 For \`tombstones\` / \`suggest stale-tombstones\`: age threshold (default 90d)
+  --help                          Show this message
 
 Examples:
   pnpm sync-admin audit

--- a/scripts/sync-admin/lib/args.ts
+++ b/scripts/sync-admin/lib/args.ts
@@ -7,6 +7,7 @@ export interface Args {
   strict: boolean;
   suggest: boolean;
   noPayloadFetch: boolean;
+  noReverify: boolean;
   kind?: Kind;
   user?: string;
   olderThanMs?: number;
@@ -29,6 +30,7 @@ export function parseArgs(argv: readonly string[]): Args {
     strict: false,
     suggest: false,
     noPayloadFetch: false,
+    noReverify: false,
     help: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -37,6 +39,7 @@ export function parseArgs(argv: readonly string[]): Args {
     else if (arg === '--strict') a.strict = true;
     else if (arg === '--suggest') a.suggest = true;
     else if (arg === '--no-payload-fetch') a.noPayloadFetch = true;
+    else if (arg === '--no-reverify') a.noReverify = true;
     else if (arg === '--help' || arg === '-h') a.help = true;
     else if (arg.startsWith('--kind=')) {
       const v = arg.slice('--kind='.length);

--- a/scripts/sync-admin/lib/findings.ts
+++ b/scripts/sync-admin/lib/findings.ts
@@ -5,6 +5,9 @@ import { TOMBSTONE_RETENTION_MS } from '../../../api/lib/userIndex.js';
 import { pMap } from './concurrency.js';
 import { expectedEnvelopeDelta } from './delta.js';
 import { isMalformedRow, itemKey } from './inventory.js';
+import { createProgress, type Progress } from './progress.js';
+import { reverify } from './reverify.js';
+import type Redis from 'ioredis';
 import type { Finding, Inventory, Kind } from './types.js';
 
 interface AnalyzeOpts {
@@ -12,9 +15,41 @@ interface AnalyzeOpts {
   staleTombstoneMs?: number;
   /** Per-fetch deadline in ms. Default 15s. */
   fetchTimeoutMs?: number;
+  /**
+   * Re-read each flagged item to separate real corruption from writes that
+   * landed mid-scan. Requires a redis handle; skipped when absent.
+   */
+  reverifyWith?: Redis;
+  progress?: Progress;
+}
+
+export interface AnalyzeResult {
+  findings: Finding[];
+  suppressed: Finding[];
 }
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+
+export async function analyzeWithReverify(
+  inv: Inventory,
+  opts: AnalyzeOpts
+): Promise<AnalyzeResult> {
+  const progress = opts.progress ?? createProgress(false);
+  const candidates = await analyze(inv, opts);
+  if (!opts.reverifyWith || candidates.length === 0) {
+    return { findings: candidates, suppressed: [] };
+  }
+  progress.phase('re-verifying candidates');
+  const { confirmed, suppressed } = await reverify(
+    opts.reverifyWith,
+    inv,
+    candidates,
+    opts.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS,
+    (done, total) => progress.update(`${done}/${total}`)
+  );
+  progress.done(`${confirmed.length} confirmed, ${suppressed.length} in-flight`);
+  return { findings: confirmed, suppressed };
+}
 
 export async function analyze(
   inv: Inventory,
@@ -140,9 +175,15 @@ export async function analyze(
       // findings would be misleading or use NaN values in the detail line.
       return r && !r.tombstone && !isMalformedRow(r);
     });
+    const progress = opts.progress ?? createProgress(false);
+    progress.phase('validating payloads');
+    let done = 0;
     const payloadFindings = await pMap(liveBlobs, async (blob) => {
-      return validateBlob(blob, inv, timeoutMs);
+      const out = await validateBlob(blob, inv, timeoutMs);
+      progress.update(`${++done}/${liveBlobs.length}`);
+      return out;
     });
+    progress.done(`${liveBlobs.length} blobs`);
     for (const list of payloadFindings) findings.push(...list);
   }
 

--- a/scripts/sync-admin/lib/inventory.ts
+++ b/scripts/sync-admin/lib/inventory.ts
@@ -2,7 +2,8 @@ import { list } from '@vercel/blob';
 import type Redis from 'ioredis';
 import { userIndexKey } from '../../../api/lib/redisKeys.js';
 import type { IndexEntry } from '../../../api/lib/userIndex.js';
-import { scanKeys } from './redis.js';
+import { createProgress, type Progress } from './progress.js';
+import { hgetallMany, scanKeys } from './redis.js';
 import type { BlobRow, Inventory, IndexRow, Kind } from './types.js';
 
 interface BuildOpts {
@@ -10,10 +11,12 @@ interface BuildOpts {
   kind?: Kind;
   /** Skip the Vercel Blob listing — only Redis index data is needed. */
   skipBlobs?: boolean;
+  progress?: Progress;
 }
 
 export async function buildInventory(redis: Redis, opts: BuildOpts = {}): Promise<Inventory> {
-  const blobs = opts.skipBlobs ? [] : await listBlobs(opts);
+  const progress = opts.progress ?? createProgress(false);
+  const blobs = opts.skipBlobs ? [] : await listBlobs(opts, progress);
   const blobMap = new Map<string, BlobRow>();
   const blobUsers = new Set<string>();
   for (const b of blobs) {
@@ -21,7 +24,7 @@ export async function buildInventory(redis: Redis, opts: BuildOpts = {}): Promis
     blobUsers.add(b.uid);
   }
 
-  const indexRows = await readIndexes(redis, opts);
+  const indexRows = await readIndexes(redis, opts, progress);
   const indexMap = new Map<string, IndexRow>();
   const redisUsers = new Set<string>();
   for (const r of indexRows) {
@@ -29,17 +32,26 @@ export async function buildInventory(redis: Redis, opts: BuildOpts = {}): Promis
     redisUsers.add(r.uid);
   }
 
-  return { blobs, blobMap, indexRows, indexMap, blobUsers, redisUsers };
+  return {
+    blobs,
+    blobMap,
+    indexRows,
+    indexMap,
+    blobUsers,
+    redisUsers,
+    blobsListed: !opts.skipBlobs,
+  };
 }
 
 export function itemKey(uid: string, kind: Kind, id: string): string {
   return `${uid}/${kind}/${id}`;
 }
 
-async function listBlobs(opts: BuildOpts): Promise<BlobRow[]> {
+async function listBlobs(opts: BuildOpts, progress: Progress): Promise<BlobRow[]> {
   const prefix = opts.user ? `users/${opts.user}/` : 'users/';
   const out: BlobRow[] = [];
   let cursor: string | undefined;
+  progress.phase('listing blobs');
   do {
     const page = await list({ prefix, cursor, limit: 1000 });
     for (const b of page.blobs) {
@@ -59,24 +71,30 @@ async function listBlobs(opts: BuildOpts): Promise<BlobRow[]> {
       });
     }
     cursor = page.cursor;
+    progress.update(`${out.length} found`);
   } while (cursor);
+  progress.done(`${out.length} found`);
   return out;
 }
 
-async function readIndexes(redis: Redis, opts: BuildOpts): Promise<IndexRow[]> {
+async function readIndexes(redis: Redis, opts: BuildOpts, progress: Progress): Promise<IndexRow[]> {
   const kinds: Kind[] = opts.kind ? [opts.kind] : ['layouts', 'designs', 'baseplates'];
   const out: IndexRow[] = [];
   for (const kind of kinds) {
+    progress.phase(`reading ${kind} index`);
     const keys = opts.user
       ? [userIndexKey(opts.user, kind)]
       : await scanKeys(redis, `users:*:index:${kind}`);
-    for (const key of keys) {
+    const hashes = await hgetallMany(redis, keys, 200, (done) =>
+      progress.update(`${done}/${keys.length} users`)
+    );
+    for (const [key, raw] of hashes) {
       const uid = key.split(':')[1];
-      const raw = await redis.hgetall(key);
       for (const [id, encoded] of Object.entries(raw)) {
         out.push(parseRow(uid, kind, id, encoded));
       }
     }
+    progress.done(`${keys.length} users`);
   }
   return out;
 }

--- a/scripts/sync-admin/lib/progress.ts
+++ b/scripts/sync-admin/lib/progress.ts
@@ -1,0 +1,39 @@
+export interface Progress {
+  phase(label: string): void;
+  update(detail: string): void;
+  done(detail?: string): void;
+}
+
+const NOOP: Progress = {
+  phase: () => {},
+  update: () => {},
+  done: () => {},
+};
+
+/**
+ * Phase lines on stderr so `--json` stdout stays pipeable. Interactive runs get
+ * a rewriting counter; redirected ones only get the phase and its summary, or a
+ * log file fills with thousands of carriage-returned partials.
+ */
+export function createProgress(enabled: boolean, tty = process.stderr.isTTY): Progress {
+  if (!enabled) return NOOP;
+  let label = '';
+  let started = 0;
+  const write = (s: string): void => {
+    process.stderr.write(s);
+  };
+  return {
+    phase(next: string): void {
+      label = next;
+      started = Date.now();
+      if (tty) write(`  ${label}…`);
+    },
+    update(detail: string): void {
+      if (tty) write(`\r  ${label}… ${detail}`);
+    },
+    done(detail?: string): void {
+      const secs = ((Date.now() - started) / 1000).toFixed(1);
+      write(`${tty ? '\r' : ''}  ${label}… ${detail ?? 'done'} (${secs}s)\n`);
+    },
+  };
+}

--- a/scripts/sync-admin/lib/redis.ts
+++ b/scripts/sync-admin/lib/redis.ts
@@ -9,6 +9,34 @@ export function connect(): Redis {
   });
 }
 
+/**
+ * HGETALL many keys with a handful of round trips instead of one per key.
+ * Against a remote Redis the serial version costs `keys × RTT`, which at
+ * ~1k users dominated the whole audit and widened the blob↔index read gap
+ * that produces in-flight false positives.
+ */
+export async function hgetallMany(
+  redis: Redis,
+  keys: readonly string[],
+  chunkSize = 200,
+  onChunk?: (done: number) => void
+): Promise<Map<string, Record<string, string>>> {
+  const out = new Map<string, Record<string, string>>();
+  for (let i = 0; i < keys.length; i += chunkSize) {
+    const chunk = keys.slice(i, i + chunkSize);
+    const pipeline = redis.pipeline();
+    for (const key of chunk) pipeline.hgetall(key);
+    const results = await pipeline.exec();
+    if (results === null) throw new Error('sync-admin: redis pipeline failed (connection lost)');
+    results.forEach(([err, value], j) => {
+      if (err) throw err;
+      out.set(chunk[j], (value as Record<string, string>) ?? {});
+    });
+    onChunk?.(Math.min(i + chunkSize, keys.length));
+  }
+  return out;
+}
+
 export async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
   // SCAN can yield the same key more than once during a single iteration;
   // a Set keeps the audit from double-counting.

--- a/scripts/sync-admin/lib/reverify.ts
+++ b/scripts/sync-admin/lib/reverify.ts
@@ -1,0 +1,208 @@
+import { list } from '@vercel/blob';
+import type Redis from 'ioredis';
+import { userIndexKey } from '../../../api/lib/redisKeys.js';
+import { pMap } from './concurrency.js';
+import { parseRow } from './inventory.js';
+import type { Finding, Inventory, IndexRow, Kind } from './types.js';
+
+export interface ReverifyResult {
+  confirmed: Finding[];
+  suppressed: Finding[];
+}
+
+/**
+ * How both stores see one item. Two reads that disagree mean the item was
+ * written between them, which is the whole point of the comparison.
+ */
+export interface ItemState {
+  indexPresent: boolean;
+  indexModifiedAt: number | null;
+  indexSizeBytes: number | null;
+  indexDeletedAt: number | null;
+  blobPresent: boolean;
+  blobSize: number | null;
+  blobUrl: string | null;
+}
+
+export function itemStateKey(uid: string, kind: Kind, id: string): string {
+  return `${uid}/${kind}/${id}`;
+}
+
+/**
+ * Identity of an observation. `withBlob` is false for inventories built with
+ * `skipBlobs`, where the first pass never looked at blob storage and comparing
+ * it against a fresh read would flag every item as having changed.
+ */
+export function stateKey(s: ItemState, withBlob = true): string {
+  const parts = [s.indexPresent ? '1' : '0', s.indexModifiedAt, s.indexSizeBytes, s.indexDeletedAt];
+  if (withBlob) parts.push(s.blobPresent ? '1' : '0', String(s.blobSize));
+  return parts.join('|');
+}
+
+/** The first-pass observation, reconstructed from the scan's own inventory. */
+export function stateFromInventory(inv: Inventory, uid: string, kind: Kind, id: string): ItemState {
+  const key = itemStateKey(uid, kind, id);
+  const row = inv.indexMap.get(key);
+  const blob = inv.blobMap.get(key);
+  return {
+    indexPresent: row !== undefined,
+    indexModifiedAt: row && Number.isFinite(row.entry.modifiedAt) ? row.entry.modifiedAt : null,
+    indexSizeBytes: row && Number.isFinite(row.entry.sizeBytes) ? row.entry.sizeBytes : null,
+    indexDeletedAt: row?.entry.deletedAt ?? null,
+    blobPresent: blob !== undefined,
+    blobSize: blob?.size ?? null,
+    blobUrl: blob?.url ?? null,
+  };
+}
+
+export async function readItemState(
+  redis: Redis,
+  uid: string,
+  kind: Kind,
+  id: string
+): Promise<ItemState> {
+  const pathname = `users/${uid}/${kind}/${id}.json`;
+  const [encoded, page] = await Promise.all([
+    redis.hget(userIndexKey(uid, kind), id),
+    list({ prefix: pathname, limit: 1 }),
+  ]);
+  const blob = page.blobs.find((b) => b.pathname === pathname);
+  let row: IndexRow | null = null;
+  if (encoded !== null) row = parseRow(uid, kind, id, encoded);
+  return {
+    indexPresent: encoded !== null,
+    indexModifiedAt: row && Number.isFinite(row.entry.modifiedAt) ? row.entry.modifiedAt : null,
+    indexSizeBytes: row && Number.isFinite(row.entry.sizeBytes) ? row.entry.sizeBytes : null,
+    indexDeletedAt: row?.entry.deletedAt ?? null,
+    blobPresent: blob !== undefined,
+    blobSize: blob?.size ?? null,
+    blobUrl: blob?.url ?? null,
+  };
+}
+
+/**
+ * Kinds decided entirely by data captured at scan time. Redis hash writes and
+ * Vercel Blob puts are both atomic, so a malformed entry or a payload that
+ * fails validation is a complete document that is genuinely wrong — re-reading
+ * it proves nothing.
+ */
+const RACE_IMMUNE: ReadonlySet<Finding['kind']> = new Set([
+  'malformed_index_entry',
+  'payload_invalid',
+]);
+
+/** Kinds whose inconsistency can only be re-checked by refetching the blob. */
+const NEEDS_PAYLOAD: ReadonlySet<Finding['kind']> = new Set([
+  'modifiedAt_mismatch',
+  'listing_size_mismatch',
+  'envelope_invalid',
+  'fetch_timeout',
+]);
+
+/**
+ * Re-read every flagged item and drop the ones that were merely mid-write.
+ *
+ * `buildInventory` lists all blobs before reading the Redis index, so on a live
+ * database any save landing in that gap is observed inconsistently — a create
+ * looks like `missing_blob`, a shrinking edit like `index_size_undercount`, a
+ * rewrite like `modifiedAt_mismatch` + `listing_size_mismatch`. A second read
+ * separates those from real corruption: if the item moved again it is being
+ * actively written, and if it is byte-identical yet still inconsistent the
+ * finding is real.
+ */
+export async function reverify(
+  redis: Redis,
+  inv: Inventory,
+  findings: readonly Finding[],
+  fetchTimeoutMs: number,
+  onProgress?: (done: number, total: number) => void
+): Promise<ReverifyResult> {
+  let done = 0;
+  const settled = await pMap(findings, async (f) => {
+    const keep = await isReal(redis, inv, f, fetchTimeoutMs);
+    onProgress?.(++done, findings.length);
+    return keep;
+  });
+
+  const confirmed: Finding[] = [];
+  const suppressed: Finding[] = [];
+  findings.forEach((f, i) => (settled[i] ? confirmed : suppressed).push(f));
+  return { confirmed, suppressed };
+}
+
+async function isReal(
+  redis: Redis,
+  inv: Inventory,
+  f: Finding,
+  fetchTimeoutMs: number
+): Promise<boolean> {
+  if (!f.id || !f.itemKind) return true;
+  if (RACE_IMMUNE.has(f.kind)) return true;
+
+  const before = stateFromInventory(inv, f.uid, f.itemKind, f.id);
+  const after = await readItemState(redis, f.uid, f.itemKind, f.id);
+
+  // Moved between the two reads — the item is being written right now.
+  if (stateKey(before, inv.blobsListed) !== stateKey(after, inv.blobsListed)) return false;
+
+  if (NEEDS_PAYLOAD.has(f.kind)) return await payloadStillInconsistent(f, after, fetchTimeoutMs);
+  return membershipStillInconsistent(f, after, inv.blobsListed);
+}
+
+function membershipStillInconsistent(f: Finding, s: ItemState, blobsListed: boolean): boolean {
+  switch (f.kind) {
+    case 'missing_blob':
+      return s.indexPresent && s.indexDeletedAt === null && !s.blobPresent;
+    case 'orphan_blob':
+      return s.blobPresent && !s.indexPresent;
+    case 'tombstone_with_blob':
+      return s.indexDeletedAt !== null && s.blobPresent;
+    case 'stale_tombstone':
+      // Age only grows; the tombstone still existing is the whole claim.
+      return s.indexDeletedAt !== null;
+    case 'sanitization_drift':
+    case 'index_size_undercount':
+      // Sizes are unchanged (stateKey matched), so the delta still holds.
+      return s.indexPresent && (!blobsListed || s.blobPresent);
+    default:
+      return true;
+  }
+}
+
+async function payloadStillInconsistent(
+  f: Finding,
+  s: ItemState,
+  fetchTimeoutMs: number
+): Promise<boolean> {
+  if (!s.blobPresent || !s.blobUrl) return false;
+  let text: string;
+  try {
+    const r = await fetch(s.blobUrl, { signal: AbortSignal.timeout(fetchTimeoutMs) });
+    if (!r.ok) return f.kind === 'envelope_invalid';
+    text = await r.text();
+  } catch {
+    // A second failure on the same blob is a real problem, not a race.
+    return f.kind === 'envelope_invalid' || f.kind === 'fetch_timeout';
+  }
+
+  if (f.kind === 'fetch_timeout' || f.kind === 'envelope_invalid') {
+    // It fetched cleanly this time; only a still-broken envelope is real.
+    try {
+      const body = JSON.parse(text) as Record<string, unknown>;
+      return body.schemaVersion !== 1 || !Number.isFinite(body.modifiedAt as number);
+    } catch {
+      return true;
+    }
+  }
+
+  if (f.kind === 'listing_size_mismatch') {
+    return Buffer.byteLength(text, 'utf8') !== s.blobSize;
+  }
+
+  try {
+    const body = JSON.parse(text) as { modifiedAt?: unknown };
+    return typeof body.modifiedAt === 'number' && body.modifiedAt !== s.indexModifiedAt;
+  } catch {
+    return true;
+  }
+}

--- a/scripts/sync-admin/lib/reverify.ts
+++ b/scripts/sync-admin/lib/reverify.ts
@@ -59,12 +59,14 @@ export async function readItemState(
   redis: Redis,
   uid: string,
   kind: Kind,
-  id: string
+  id: string,
+  withBlob = true
 ): Promise<ItemState> {
   const pathname = `users/${uid}/${kind}/${id}.json`;
   const [encoded, page] = await Promise.all([
     redis.hget(userIndexKey(uid, kind), id),
-    list({ prefix: pathname, limit: 1 }),
+    // A skipBlobs inventory ignores these fields anyway; don't pay for them.
+    withBlob ? list({ prefix: pathname, limit: 1 }) : Promise.resolve({ blobs: [] }),
   ]);
   const blob = page.blobs.find((b) => b.pathname === pathname);
   let row: IndexRow | null = null;
@@ -140,7 +142,7 @@ async function isReal(
   if (RACE_IMMUNE.has(f.kind)) return true;
 
   const before = stateFromInventory(inv, f.uid, f.itemKind, f.id);
-  const after = await readItemState(redis, f.uid, f.itemKind, f.id);
+  const after = await readItemState(redis, f.uid, f.itemKind, f.id, inv.blobsListed);
 
   // Moved between the two reads — the item is being written right now.
   if (stateKey(before, inv.blobsListed) !== stateKey(after, inv.blobsListed)) return false;

--- a/scripts/sync-admin/lib/types.ts
+++ b/scripts/sync-admin/lib/types.ts
@@ -26,6 +26,11 @@ export interface Inventory {
   indexMap: Map<string, IndexRow>;
   blobUsers: Set<string>;
   redisUsers: Set<string>;
+  /**
+   * False when built with `skipBlobs`. An empty blobMap then means "not looked
+   * at", not "absent" — re-verification must not read it as the latter.
+   */
+  blobsListed: boolean;
 }
 
 export type FindingKind =


### PR DESCRIPTION
## Problem

`buildInventory` lists **every blob** before reading the Redis index. Against production that gap is minutes wide, so any save landing inside it is observed inconsistently — the old blob listing paired with the new index entry.

That fabricates findings:

| In-flight event | Fabricated finding |
| --- | --- |
| Create | `missing_blob` |
| Edit shrinking bytes | `index_size_undercount` |
| Edit growing bytes | `sanitization_drift` |
| Any rewrite | `modifiedAt_mismatch` + `listing_size_mismatch` |
| Blob replaced mid-run | `envelope_invalid` (HTTP 404) |

A full audit against production reported **18 findings (9 errors, 9 warnings) on a healthy database**. Every one had a timestamp inside the run's own window; re-auditing the affected users individually cleared all of them. `--strict` would have failed CI on all 18.

## Fix

**Re-verify pass.** Each flagged item is re-read once and compared against the first observation:

- **Moved again** → being actively written → suppressed as in-flight
- **Byte-identical and still inconsistent** → real → reported

No sleeps or retries, so it can't flake under sustained editing — during verification one user was *still* mid-save on re-check and the comparison handled it correctly. Kinds that a re-read can't settle (`malformed_index_entry`, `payload_invalid`) skip it, since Redis `HSET` and Blob `put` are both atomic — a reader never sees a half-written document.

`suggest` runs the same pass, so a mid-write item can never produce a remediation command. Suppressed counts are always printed (and in `--json`), never silent. `--no-reverify` returns raw findings for debugging the detector.

**Pipelined index reads.** One `HGETALL` per user serially cost `users × RTT`, which dominated the run and widened the very gap that manufactures these findings. Production already pipelines in `api/lib/userIndex.ts:72`; this path didn't.

## Also

- `audit --strict` no longer fails on info-level findings (stale tombstones are housekeeping). `tombstones --strict` keeps its stale check — that's the command's purpose.
- Progress phases on **stderr**, so `--json` stdout stays pipeable.
- Docs: `baseplates` was a valid `--kind` but undocumented; the finding-kinds table was missing `index_size_undercount` and `fetch_timeout`; the "sub-second" claim and the CI recommendation were both wrong (nothing in CI runs this).

## Verification

Against production, before → after:

```
before:  18 findings (9 errors, 9 warnings)   ~265s
after:    0 findings, 3 suppressed as in-flight  ~78s
```

`blobs` now equals `liveEntries` exactly (8532). `--no-reverify` still surfaces the raw race finding, confirming suppression is doing the work and not hiding data.

19 new tests (`reverify.test.ts`, `redis.test.ts`); 72 pass across the sync-admin suite.

## Note

`SCAN` is now the dominant cost (~54s of 78s — 284 serial cursor iterations). Raising `COUNT` would cut it further; left out of this PR to keep the change focused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes race conditions in `sync-admin` by re-reading flagged items to filter out in-flight writes, eliminating false positives. Also pipelines Redis index reads and skips `@vercel/blob` lookups during re-verification for `skipBlobs` scans to cut runtime.

- **Bug Fixes**
  - Add re-verification: if an item moved, suppress as in-flight; if byte-identical and still inconsistent, report.
  - Apply re-verification to `audit`, `suggest`, and `user`; add `--no-reverify` to return raw findings.
  - `audit --strict` now fails on errors/warnings only; suppressed counts are shown and included in `--json`.

- **Refactors**
  - Pipeline Redis index reads via `hgetallMany` instead of one `HGETALL` per user; add progress on stderr and track whether blobs were listed.
  - Skip blob listing/fetch during re-verification when the inventory used `skipBlobs` (keeps `suggest stale-tombstones` and `suggest malformed` fast).
  - Docs updated; flags now include `--no-reverify`; kind list documents `baseplates`.
  - Results in production: findings dropped from 18 (all false) to 0; runtime ~265s → ~78s.

<sup>Written for commit 6b2e1c3b3559f9922ec401bd1b7302452c546bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

