### PR TITLE
fix(sync-admin): keep findings when a re-verify fetch fails

### DIFF
--- a/scripts/sync-admin/__tests__/redis.test.ts
+++ b/scripts/sync-admin/__tests__/redis.test.ts
@@ -83,6 +83,12 @@ describe('hgetallMany', () => {
     await expect(hgetallMany(redis, ['k'])).rejects.toThrow('WRONGTYPE');
   });
 
+  it.each([0, -1, 1.5, NaN])('rejects a chunkSize of %s instead of looping forever', async (n) => {
+    const { redis } = redisStub({});
+
+    await expect(hgetallMany(redis, ['k'], n)).rejects.toThrow('positive integer');
+  });
+
   it('throws when the pipeline itself fails', async () => {
     const redis = {
       pipeline: () => ({

--- a/scripts/sync-admin/__tests__/reverify.test.ts
+++ b/scripts/sync-admin/__tests__/reverify.test.ts
@@ -280,6 +280,53 @@ describe('reverify — payload-dependent kinds', () => {
     expect(suppressed).toHaveLength(1);
   });
 
+  it.each([
+    'modifiedAt_mismatch',
+    'listing_size_mismatch',
+    'fetch_timeout',
+    'envelope_invalid',
+  ] as const)('keeps %s when the re-fetch returns a non-2xx', async (kind) => {
+    stableRead();
+    fetchMock.mockResolvedValue({ ok: false, status: 500, text: async () => '' });
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const finding: Finding = {
+      kind,
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'x',
+    };
+    const { confirmed, suppressed } = await reverify(redis, stableInv(), [finding], 1000);
+
+    expect(suppressed).toHaveLength(0);
+    expect(confirmed).toHaveLength(1);
+  });
+
+  it.each([
+    'modifiedAt_mismatch',
+    'listing_size_mismatch',
+    'fetch_timeout',
+    'envelope_invalid',
+  ] as const)('keeps %s when the re-fetch throws', async (kind) => {
+    stableRead();
+    fetchMock.mockRejectedValue(new Error('network down'));
+    const redis = redisStub(JSON.stringify({ modifiedAt: T, sizeBytes: 100 }));
+
+    const finding: Finding = {
+      kind,
+      uid: UID,
+      itemKind: 'layouts',
+      id: 'a1',
+      severity: 'error',
+      detail: 'x',
+    };
+    const { confirmed } = await reverify(redis, stableInv(), [finding], 1000);
+
+    expect(confirmed).toHaveLength(1);
+  });
+
   it('confirms envelope_invalid when the envelope is still wrong', async () => {
     stableRead();
     fetchMock.mockResolvedValue({

--- a/scripts/sync-admin/lib/redis.ts
+++ b/scripts/sync-admin/lib/redis.ts
@@ -21,6 +21,9 @@ export async function hgetallMany(
   chunkSize = 200,
   onChunk?: (done: number) => void
 ): Promise<Map<string, Record<string, string>>> {
+  if (!Number.isInteger(chunkSize) || chunkSize < 1) {
+    throw new Error(`hgetallMany: chunkSize must be a positive integer, got ${chunkSize}`);
+  }
   const out = new Map<string, Record<string, string>>();
   for (let i = 0; i < keys.length; i += chunkSize) {
     const chunk = keys.slice(i, i + chunkSize);

--- a/scripts/sync-admin/lib/reverify.ts
+++ b/scripts/sync-admin/lib/reverify.ts
@@ -180,11 +180,14 @@ async function payloadStillInconsistent(
   let text: string;
   try {
     const r = await fetch(s.blobUrl, { signal: AbortSignal.timeout(fetchTimeoutMs) });
-    if (!r.ok) return f.kind === 'envelope_invalid';
+    // Suppression requires positive evidence that the item is fine. A failed
+    // re-fetch is the absence of evidence, so the finding has to stand — the
+    // listing still shows this blob (stateKey matched), so a non-2xx here is
+    // itself worth surfacing.
+    if (!r.ok) return true;
     text = await r.text();
   } catch {
-    // A second failure on the same blob is a real problem, not a race.
-    return f.kind === 'envelope_invalid' || f.kind === 'fetch_timeout';
+    return true;
   }
 
   if (f.kind === 'fetch_timeout' || f.kind === 'envelope_invalid') {


### PR DESCRIPTION
Follow-up to #2958, which merged before Copilot's review landed. Two of its three comments were valid; the third (blob lookup on `skipBlobs` inventories) was already fixed in that PR's second commit.

## Failed re-fetch no longer suppresses a finding

Suppression is supposed to require **positive evidence** that an item is fine. A non-2xx response or a network error during re-verification is the *absence* of evidence, but it was being read as proof:

```ts
if (!r.ok) return f.kind === 'envelope_invalid';   // false for 3 other kinds → suppressed
} catch {
  return f.kind === 'envelope_invalid' || f.kind === 'fetch_timeout';
}
```

So a 500 or a dropped connection silently dropped `modifiedAt_mismatch`, `listing_size_mismatch`, and (for non-2xx) `fetch_timeout` — the exact hiding-real-problems behavior the re-verify pass exists to prevent.

Any fetch failure now keeps the finding. Note the listing still shows the blob at that point (`stateKey` matched), so a non-2xx is itself worth surfacing rather than swallowing.

## `hgetallMany` chunkSize guard

`chunkSize` advances the loop counter, so `0` or a negative value would spin forever. Now validated as a positive integer.

## Tests

12 new (84 total, up from 72): every payload-dependent kind is asserted to survive both a non-2xx and a thrown fetch, plus `chunkSize` rejection cases.

Verified against production: 0 findings, 0 suppressed, ~77s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix re-verify logic so fetch failures no longer suppress findings, and validate `hgetallMany` input to prevent infinite loops. This prevents hiding real issues during sync.

- **Bug Fixes**
  - Re-verify now keeps findings on non-2xx responses and fetch errors; no suppression of `modifiedAt_mismatch`, `listing_size_mismatch`, `fetch_timeout`, or `envelope_invalid`.
  - `hgetallMany` rejects non-integer or non-positive `chunkSize` values.

<sup>Written for commit 37f35863672221977e0f5fdbbc8f91a28656b258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

