### PR TITLE
perf(sync-admin): cut index-read cost from ~54s to ~2s

### DIFF
--- a/scripts/sync-admin/README.md
+++ b/scripts/sync-admin/README.md
@@ -35,8 +35,9 @@ pnpm sync-admin audit --strict              # exit non-zero on error/warn (CI)
 pnpm --silent sync-admin audit --json       # structured output for piping
 ```
 
-Expect roughly 1–2 minutes at ~1k users and ~8.5k blobs; progress goes to
-stderr so `--json` stdout stays pipeable.
+Expect roughly 30s at ~1.2k users and ~8.5k blobs, most of it the per-blob
+payload fetch (`--no-payload-fetch` cuts it to ~10s). Progress goes to stderr
+so `--json` stdout stays pipeable.
 
 ## Re-verification (why findings can be suppressed)
 
@@ -164,7 +165,11 @@ CI runs it. Run it by hand, or on a schedule with the credentials available.
 - Index reads are pipelined in chunks of 200 (`lib/redis.ts`). One `HGETALL`
   per user serially cost `users × RTT`, which dominated the run against a
   remote Redis and widened the blob↔index gap that manufactures findings.
-- `SCAN` stays serial — the cursor is inherently sequential.
+- `SCAN` stays serial — the cursor is inherently sequential — but runs with
+  `COUNT 10000`. `MATCH` filters server-side while the scan still walks the
+  whole keyspace (~142k keys for ~1.2k matches), and measured per-call latency
+  is round-trip-bound rather than growing with `COUNT`, so a small `COUNT` only
+  bought extra round trips. See `lib/redis.ts` for the measurements.
 - The envelope-overhead delta math lives in `lib/delta.ts`; see comments
   there for the precise byte accounting that distinguishes "expected" from
   "drift".

--- a/scripts/sync-admin/__tests__/inventory.test.ts
+++ b/scripts/sync-admin/__tests__/inventory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isMalformedRow, parseRow } from '../lib/inventory';
+import { isMalformedRow, parseIndexKey, parseRow } from '../lib/inventory';
 
 describe('parseRow', () => {
   it('parses a well-formed live entry', () => {
@@ -42,5 +42,31 @@ describe('parseRow', () => {
   it('flags unparseable JSON as malformed', () => {
     const r = parseRow('u', 'layouts', 'id', 'not-json');
     expect(isMalformedRow(r)).toBe(true);
+  });
+});
+
+describe('parseIndexKey', () => {
+  it.each(['layouts', 'designs', 'baseplates'] as const)('parses a %s index key', (kind) => {
+    expect(parseIndexKey(`users:abc123:index:${kind}`)).toEqual({ uid: 'abc123', kind });
+  });
+
+  it.each([
+    'users:abc123:indexUpdatedAt',
+    'users:abc123:tombstoneSweptAt',
+    'users:abc123:profile',
+    'users:abc123:sessions',
+  ])('rejects the sibling key %s', (key) => {
+    expect(parseIndexKey(key)).toBeNull();
+  });
+
+  it('rejects an unknown kind so a future index namespace is not read as rows', () => {
+    expect(parseIndexKey('users:abc123:index:widgets')).toBeNull();
+  });
+
+  it('rejects malformed shapes', () => {
+    expect(parseIndexKey('users:abc123:index')).toBeNull();
+    expect(parseIndexKey('users::index:layouts')).toBeNull();
+    expect(parseIndexKey('share:hash:abc')).toBeNull();
+    expect(parseIndexKey('users:a:b:index:layouts')).toBeNull();
   });
 });

--- a/scripts/sync-admin/__tests__/redis.test.ts
+++ b/scripts/sync-admin/__tests__/redis.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type Redis from 'ioredis';
-import { hgetallMany } from '../lib/redis';
+import { hgetallMany, scanKeys } from '../lib/redis';
 
 /**
  * Pipeline stub recording how many batches were flushed, so the test can assert
@@ -100,5 +100,48 @@ describe('hgetallMany', () => {
     } as unknown as Redis;
 
     await expect(hgetallMany(redis, ['k'])).rejects.toThrow('pipeline failed');
+  });
+});
+
+describe('scanKeys', () => {
+  function scanStub(pages: [string, string[]][]) {
+    const counts: number[] = [];
+    let i = 0;
+    const redis = {
+      scan: vi.fn(async (_cursor: string, _m: string, _p: string, _c: string, count: number) => {
+        counts.push(count);
+        return pages[i++];
+      }),
+    } as unknown as Redis;
+    return { redis, counts };
+  }
+
+  it('follows the cursor to completion and de-duplicates repeated keys', async () => {
+    // SCAN may return the same key in more than one page.
+    const { redis } = scanStub([
+      ['12', ['a', 'b']],
+      ['7', ['b', 'c']],
+      ['0', ['c']],
+    ]);
+
+    const keys = await scanKeys(redis, 'users:*:index:layouts');
+
+    expect(keys.sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('uses a COUNT large enough to keep round trips down', async () => {
+    const { redis, counts } = scanStub([['0', []]]);
+
+    await scanKeys(redis, 'users:*:index:layouts');
+
+    expect(counts[0]).toBeGreaterThanOrEqual(10_000);
+  });
+
+  it('honours an explicit count override', async () => {
+    const { redis, counts } = scanStub([['0', []]]);
+
+    await scanKeys(redis, 'p', 250);
+
+    expect(counts).toEqual([250]);
   });
 });

--- a/scripts/sync-admin/lib/inventory.ts
+++ b/scripts/sync-admin/lib/inventory.ts
@@ -77,25 +77,57 @@ async function listBlobs(opts: BuildOpts, progress: Progress): Promise<BlobRow[]
   return out;
 }
 
+const ALL_KINDS: readonly Kind[] = ['layouts', 'designs', 'baseplates'];
+
+/**
+ * `users:{uid}:index:{kind}` → its parts, or null for anything else the glob
+ * happens to reach. Sibling keys (`indexUpdatedAt`, `tombstoneSweptAt`) can't
+ * match `users:*:index:*` today, but a future one shouldn't become an index row.
+ */
+export function parseIndexKey(key: string): { uid: string; kind: Kind } | null {
+  const parts = key.split(':');
+  if (parts.length !== 4 || parts[0] !== 'users' || parts[2] !== 'index') return null;
+  const kind = parts[3] as Kind;
+  if (!ALL_KINDS.includes(kind) || !parts[1]) return null;
+  return { uid: parts[1], kind };
+}
+
 async function readIndexes(redis: Redis, opts: BuildOpts, progress: Progress): Promise<IndexRow[]> {
-  const kinds: Kind[] = opts.kind ? [opts.kind] : ['layouts', 'designs', 'baseplates'];
-  const out: IndexRow[] = [];
-  for (const kind of kinds) {
-    progress.phase(`reading ${kind} index`);
-    const keys = opts.user
-      ? [userIndexKey(opts.user, kind)]
-      : await scanKeys(redis, `users:*:index:${kind}`);
-    const hashes = await hgetallMany(redis, keys, 200, (done) =>
-      progress.update(`${done}/${keys.length} users`)
-    );
-    for (const [key, raw] of hashes) {
-      const uid = key.split(':')[1];
-      for (const [id, encoded] of Object.entries(raw)) {
-        out.push(parseRow(uid, kind, id, encoded));
-      }
+  const kinds = opts.kind ? [opts.kind] : ALL_KINDS;
+  const user = opts.user;
+  progress.phase('reading index');
+
+  const targets: { key: string; uid: string; kind: Kind }[] = [];
+  if (user) {
+    // uid and kind are already known here; no need to parse them back out.
+    for (const kind of kinds) targets.push({ key: userIndexKey(user, kind), uid: user, kind });
+  } else {
+    // One cursor pass covers every kind. MATCH filters server-side but SCAN
+    // still walks the whole keyspace, so a scan per kind paid that walk thrice.
+    const keys = await scanKeys(redis, `users:*:index:${opts.kind ?? '*'}`);
+    const wanted = new Set<Kind>(kinds);
+    for (const key of keys) {
+      const parsed = parseIndexKey(key);
+      if (parsed && wanted.has(parsed.kind)) targets.push({ key, ...parsed });
     }
-    progress.done(`${keys.length} users`);
   }
+
+  const hashes = await hgetallMany(
+    redis,
+    targets.map((t) => t.key),
+    200,
+    (done) => progress.update(`${done}/${targets.length} indexes`)
+  );
+
+  const out: IndexRow[] = [];
+  for (const { key, uid, kind } of targets) {
+    for (const [id, encoded] of Object.entries(hashes.get(key) ?? {})) {
+      out.push(parseRow(uid, kind, id, encoded));
+    }
+  }
+  progress.done(
+    `${targets.length} indexes across ${new Set(targets.map((t) => t.uid)).size} users`
+  );
   return out;
 }
 

--- a/scripts/sync-admin/lib/redis.ts
+++ b/scripts/sync-admin/lib/redis.ts
@@ -40,13 +40,35 @@ export async function hgetallMany(
   return out;
 }
 
-export async function scanKeys(redis: Redis, pattern: string): Promise<string[]> {
+/**
+ * MATCH filters server-side but SCAN still walks the whole keyspace, so the
+ * cursor cost tracks DBSIZE (~142k) rather than the ~1.2k keys that match.
+ * Measured against production, per-call latency is round-trip-bound and flat
+ * across this range — it does not degrade as COUNT grows — so the round trips
+ * are pure overhead:
+ *
+ *   COUNT    calls   total    slowest call
+ *     500      284   17.8s      117ms
+ *    5000       29    1.8s       64ms
+ *   10000       15    1.0s       84ms
+ *   20000        8    0.5s       67ms
+ *
+ * 10000 takes nearly all of the win while keeping per-call server work modest,
+ * which matters because this runs against the shared production instance.
+ */
+const SCAN_COUNT = 10_000;
+
+export async function scanKeys(
+  redis: Redis,
+  pattern: string,
+  count = SCAN_COUNT
+): Promise<string[]> {
   // SCAN can yield the same key more than once during a single iteration;
   // a Set keeps the audit from double-counting.
   const out = new Set<string>();
   let cursor = '0';
   do {
-    const [next, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 500);
+    const [next, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', count);
     for (const k of batch) out.add(k);
     cursor = next;
   } while (cursor !== '0');


### PR DESCRIPTION
Two changes to the same underlying cost. `MATCH` filters server-side but `SCAN` still walks the **whole** keyspace, so cursor cost tracks `DBSIZE` (~142k keys) rather than the ~2.8k that match — and the audit paid that walk once per item kind.

## 1. Raise `SCAN COUNT` (500 → 10000)

Measured against production on `users:*:index:layouts`:

| COUNT | calls | total | slowest call |
| ----: | ----: | ----: | -----------: |
| 500 | 284 | 17.8s | 117ms |
| 1000 | 142 | 8.9s | 89ms |
| 2500 | 57 | 3.6s | 92ms |
| 5000 | 29 | 1.8s | 64ms |
| 10000 | 15 | 1.0s | 84ms |
| 20000 | 8 | 0.5s | 67ms |

The key column is the last one: **per-call latency does not grow with COUNT**. It's round-trip-bound, not server-work-bound, so the extra calls bought nothing. That also settles the obvious worry — that a large `COUNT` blocks a single-threaded shared Redis — since at 20000 the slowest call is still ~67ms, of which ~60ms is RTT.

`10000` takes nearly all the win while keeping per-call server work modest. `scanKeys` accepts an override.

## 2. One cursor pass for all kinds

Scanning `users:*:index:{kind}` three times walked 142k keys three times. Now a single `users:*:index:*` pass collects everything and buckets by the kind parsed off each key.

Keys are validated before use, so a future `users:*:index:*` namespace can't be misread as index rows — the existing siblings (`indexUpdatedAt`, `tombstoneSweptAt`) already can't match that glob, but the guard makes it explicit. The `--user` path builds its keys directly instead of parsing them back out.

## Effect

| | before | after |
| --- | ---: | ---: |
| Index read (all kinds) | ~54s | **~2s** |
| Full audit | 78s | **25s** |
| `--no-payload-fetch` | 34s | **8s** |

Payload validation (~17s of the 25s) is now the dominant cost and is inherent — ~8.5k HTTP fetches at concurrency 16.

## Verification

Equivalence against production — the single scan finds `2839` index keys, exactly `1177 layouts + 1081 designs + 581 baseplates`, with `indexEntries` / `liveEntries` / `tombstones` identical to the three-scan version:

```
blobs=8546  indexEntries=9396  live=8546  tombstones=850  users=1177/1177
findings:   0
suppressed: 2  (in-flight writes)
```

All three code paths exercised: full scan, `--kind=designs` (1081 users, matching its per-kind count), and `--user` (no scan at all).

9 new tests (96 total) covering cursor-following, dedup of repeated keys, the COUNT override, and `parseIndexKey` rejecting every sibling key and unknown kind.