### PR TITLE
fix(deps): upgrade brace-expansion to 1.1.17 (CVE-2026-14257)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,18 +48,36 @@ to fail closed on the patterns those attacks exploited:
 [`pnpm-workspace.yaml`](pnpm-workspace.yaml) under `minimumReleaseAgeExclude`.
 They cover user-authored packages (no security benefit from delaying our own
 releases) and high-trust org scopes that release frequently and lockstep.
+Security fixes younger than the cutoff are admitted by pinning the exact
+reviewed version with a dated TODO, never a bare package name.
+
+Exempting two versions of the **same** package requires a single `||` union
+entry (`pkg@1.1.17||5.0.8`). pnpm returns the first rule whose name matches and
+never unions across list entries, so a second line for that package is silently
+dead and its version stays blocked — with no warning that the entry did nothing.
 
 **OSV findings are not suppressed.** There is deliberately no `osv-scanner.toml`.
 A finding we can't fix yet stays red rather than being silenced, and "the
 advisory looks wrong" is not grounds for an exception — verify it by running the
 advisory's proof-of-concept against the installed version before believing it.
 
-**Currently open:** `brace-expansion@1.1.16` (CVE-2026-14257, High, build-time
-devDependency only). It arrives via `minimatch@3`, which `eslint-plugin-jsx-a11y`
-and `@ts-morph/common` both require and call as a function — an API minimatch@10
-dropped. No version of either package uses a minimatch line that resolves a
-patched `brace-expansion`, and 1.1.16 is the `maintenance-v1` head, so there is
-nothing to upgrade to. It clears when jsx-a11y and ts-morph move to minimatch@10.
+**Currently open:** `brace-expansion@1.1.17` (CVE-2026-14257) — **reported but not
+exploitable; the installed version carries the fix.**
+
+Upstream backported the fix to the 1.x line as 1.1.17 on 2026-07-29. `minimatch@3`
+— still pinned by `eslint-plugin-jsx-a11y`, which calls minimatch as a function, an
+API minimatch@10 dropped — declares `^1.1.7`, so it takes 1.1.17 without the
+minimatch@10 migration that previously looked like the only exit. Verified with the
+advisory's own PoC (`'{a,b}'.repeat(1500)` under `--max-old-space-size=512`): 1.1.17
+returns a bounded 2666 items, 1.1.16 dies with a heap OOM. 1.1.16 did define an
+`EXPANSION_MAX_LENGTH` constant, but the bound was ineffective — which is why that
+marker is not evidence of a fix.
+
+GHSA-mh99-v99m-4gvg declares a single range, `introduced: 0` → `fixed: 5.0.8`, with
+no per-line fixed events, so it sweeps in every backport below 5.0.8 (1.1.17, 2.1.3,
+3.0.5). The scan therefore stays red on a version that is genuinely patched. Per the
+no-suppression rule above this is left red rather than silenced; the fix is an
+upstream correction to the advisory's ranges, not an `osv-scanner.toml`.
 
 **Adding a build script allow-list entry** (`allowBuilds`) is a security
 decision. Audit the package's postinstall behavior before adding.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,8 +61,10 @@ A finding we can't fix yet stays red rather than being silenced, and "the
 advisory looks wrong" is not grounds for an exception — verify it by running the
 advisory's proof-of-concept against the installed version before believing it.
 
-**Currently open:** `brace-expansion@1.1.17` (CVE-2026-14257) — **reported but not
-exploitable; the installed version carries the fix.**
+**Currently open:** `brace-expansion@1.1.17` (CVE-2026-14257, High, build-time
+devDependency only — `pnpm why brace-expansion --prod` is empty, so it is never
+shipped to users) — **reported but not exploitable; the installed version carries
+the fix.**
 
 Upstream backported the fix to the 1.x line as 1.1.17 on 2026-07-29. `minimatch@3`
 — still pinned by `eslint-plugin-jsx-a11y`, which calls minimatch as a function, an
@@ -75,7 +77,8 @@ marker is not evidence of a fix.
 
 GHSA-mh99-v99m-4gvg declares a single range, `introduced: 0` → `fixed: 5.0.8`, with
 no per-line fixed events, so it sweeps in every backport below 5.0.8 (1.1.17, 2.1.3,
-3.0.5). The scan therefore stays red on a version that is genuinely patched. Per the
+3.0.3). The scan therefore stays red on a version that is genuinely patched. A range
+correction is filed upstream as github/advisory-database#8877. Per the
 no-suppression rule above this is left red rather than silenced; the fix is an
 upstream correction to the advisory's ranges, not an `osv-scanner.toml`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,8 +63,8 @@ advisory's proof-of-concept against the installed version before believing it.
 
 **Currently open:** `brace-expansion@1.1.17` (CVE-2026-14257, High, build-time
 devDependency only — `pnpm why brace-expansion --prod` is empty, so it is never
-shipped to users) — **reported but not exploitable; the installed version carries
-the fix.**
+shipped to users) — **reported against a version that carries the fix.** The
+advisory's range is stale, not the dependency.
 
 Upstream backported the fix to the 1.x line as 1.1.17 on 2026-07-29. `minimatch@3`
 — still pinned by `eslint-plugin-jsx-a11y`, which calls minimatch as a function, an

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ overrides:
   eslint-plugin-i18next>lodash: ^4.18.1
   vitest-axe>lodash-es: ^4.18.1
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
-  brace-expansion@<1.1.16: ^1.1.16
+  brace-expansion@<1.1.17: ^1.1.17
   brace-expansion@>=5.0.0 <5.0.8: ^5.0.8
   tar@<7.5.21: ^7.5.21
   '@vercel/python-analysis>smol-toml': ^1.6.1
@@ -1497,12 +1497,15 @@ packages:
 
   '@oslojs/asn1@1.0.0':
     resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/binary@1.0.0':
     resolution: {integrity: sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/crypto@1.0.1':
     resolution: {integrity: sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oslojs/encoding@0.4.1':
     resolution: {integrity: sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==}
@@ -1512,6 +1515,7 @@ packages:
 
   '@oslojs/jwt@0.2.0':
     resolution: {integrity: sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oxc-parser/binding-android-arm-eabi@0.137.0':
     resolution: {integrity: sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==}
@@ -2971,6 +2975,7 @@ packages:
 
   arctic@3.7.0:
     resolution: {integrity: sha512-ZMQ+f6VazDgUJOd+qNV+H7GohNSYal1mVjm5kEaZfE2Ifb7Ss70w+Q7xpJC87qZDkMZIXYf0pTIYZA0OPasSbw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -3104,8 +3109,8 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.17:
+    resolution: {integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -8666,7 +8671,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.17:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -10139,7 +10144,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.17
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,21 +24,22 @@ minimumReleaseAgeExclude:
   - '@vercel/*'
   - '@protobufjs/*'
   - protobufjs
-  # tar 7.5.21 (2026-07-21) is the first version patched against the
-  # uncatchable stack-overflow DoS via crafted long-path archives
-  # (GHSA-r292-9mhp-454m). Scoped to the exact reviewed release.
-  # TODO: remove after 2026-07-28 once 7.5.21 has aged past the window.
-  - tar@7.5.21
   # js-yaml 5.2.2 (2026-07-23) is the first version patched against the
   # exponential flow-collection parsing DoS (GHSA-pm4m-ph32-ghv5).
   # TODO: remove after 2026-07-30 once 5.2.2 has aged past the window.
   - js-yaml@5.2.2
-  # brace-expansion 5.0.8 (2026-07-23) is the first 5.x version patched
-  # against the unbounded-expansion OOM (CVE-2026-14257). The 1.x and 2.x
-  # lines were already patched in 1.1.16 / 2.1.2 despite the advisory's
-  # overbroad '<= 5.0.7' range, so only the 5.x line needs to move.
-  # TODO: remove after 2026-07-30 once 5.0.8 has aged past the window.
-  - brace-expansion@5.0.8
+  # Both versions patch the unbounded-expansion OOM (CVE-2026-14257): 5.0.8
+  # (2026-07-23) on the 5.x line, and 1.1.17 (2026-07-29) backporting it to the
+  # 1.x line that minimatch@3 pins. 1.1.16 shipped an EXPANSION_MAX_LENGTH
+  # constant but the bound was ineffective — it still OOMs on the advisory's own
+  # PoC, so the marker cannot be trusted in place of running it.
+  #
+  # These MUST stay one `||` union entry, not two lines: pnpm returns the first
+  # rule whose package name matches and never unions across entries, so a second
+  # `brace-expansion@...` line is silently dead and its version stays blocked.
+  # TODO: drop 5.0.8 after 2026-07-30 and 1.1.17 after 2026-08-05, once each has
+  # aged past the window; remove the entry once both are gone.
+  - brace-expansion@1.1.17||5.0.8
 
 # Blocks Shai-Hulud-class worms that spread via npm lifecycle scripts.
 # Packages that need to build are listed in allowBuilds.
@@ -83,7 +84,7 @@ overrides:
   # jsx-a11y and @ts-morph/common cannot follow: both call minimatch's *default*
   # export, which minimatch@10's CJS build does not define (it sets __esModule
   # with no `default`), so both throw `is not a function` at runtime. That keeps
-  # minimatch@3 — and brace-expansion@1.1.16 — in the tree. See SECURITY.md.
+  # minimatch@3 in the tree, which is why the 1.x line has to stay patched.
   'filelist>minimatch': '^10.2.5'
   '@vercel/build-utils>minimatch': '^10.2.3'
   '@vercel/python-analysis>minimatch': '^10.2.3'
@@ -97,10 +98,11 @@ overrides:
   'eslint-plugin-i18next>lodash': '^4.18.1'
   'vitest-axe>lodash-es': '^4.18.1'
   'picomatch@>=4.0.0 <4.0.4': '^4.0.4'
-  'brace-expansion@<1.1.16': '^1.1.16'
+  'brace-expansion@<1.1.17': '^1.1.17'
   # Scoped to the 5.x line: minimatch@3 does `var expand = require(...)` and
   # calls it directly, but brace-expansion@5's CJS build exports `{ expand }`,
-  # so a blanket range would drag 1.1.16 up to 5.x and break it at runtime.
+  # so a blanket range would drag the 1.x line up to 5.x and break it at
+  # runtime. 1.1.17 keeps the callable export, so it is safe where 5.x is not.
   'brace-expansion@>=5.0.0 <5.0.8': '^5.0.8'
   'tar@<7.5.21': '^7.5.21'
   '@vercel/python-analysis>smol-toml': '^1.6.1'


### PR DESCRIPTION
Resolves the dependency half of #2926. Upstream backported the unbounded-expansion OOM fix to the 1.x line as `1.1.17` (published 2026-07-29), which `minimatch@3` accepts directly.

## Why this works without the minimatch@10 migration

#2926 tracked this as blocked on `eslint-plugin-jsx-a11y` and `@ts-morph/common` adopting `minimatch@10`. That path is no longer needed:

- `minimatch@3.1.5` declares `brace-expansion: ^1.1.7`, and **1.1.17 satisfies that caret range**.
- `1.1.17` keeps `module.exports` as a **callable function**, so minimatch@3's `var expand = require('brace-expansion')` still works. This is the exact failure mode that made the 5.x line unusable there — `brace-expansion@5`'s CJS build exports `{ expand }` instead.

So jsx-a11y can stay on `minimatch@3` and still get a patched transitive dependency.

## Verification

Checked behaviourally, per the rule in `SECURITY.md` — not by grepping for the `EXPANSION_MAX_LENGTH` marker, which `1.1.16` defines but does **not** enforce:

```
'{a,b}'.repeat(1500) under --max-old-space-size=512
  1.1.17  -> bounded: 2666 items / 3,999,000 chars
  1.1.16  -> FATAL ERROR: JavaScript heap out of memory
```

Also confirmed end-to-end that `minimatch@3.1.5` + `1.1.17` glob and `braceExpand` correctly, and that the lockfile links `minimatch@3.1.5 -> brace-expansion: 1.1.17` with no vulnerable versions left. `pnpm run lint` passes (0 errors) — that exercises `label-has-associated-control` / `control-has-associated-label`, the rules that reach minimatch. `pnpm run typecheck` passes.

## The `||` union entry

The two `brace-expansion` cooldown exclusions are collapsed into one entry:

```yaml
- brace-expansion@1.1.17||5.0.8
```

They cannot be two lines. pnpm's `evaluateVersionPolicy` returns the **first** rule whose package name matches and never unions across list entries, so a second `brace-expansion@...` line is silently dead and its version stays blocked — with no warning that the entry did nothing. This was not theoretical: the two-line form failed with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` because the `@5.0.8` rule matched first and returned `['5.0.8']`. Documented in `SECURITY.md` alongside the existing silent-no-op traps.

## OSV will still be red

`GHSA-mh99-v99m-4gvg` declares a single range, `introduced: 0` -> `fixed: 5.0.8`, with **no per-line fixed events**, so it sweeps in every backport below 5.0.8 (1.1.17, 2.1.3, 3.0.5). The installed version is genuinely patched but still reported.

Per `SECURITY.md` this stays red rather than being silenced — no `osv-scanner.toml`. The correct fix is an upstream correction to the advisory's ranges, which is being filed separately. This PR is still a real improvement: the actual vulnerability is gone, and main was already red.

## Also in this change

- Sweeps the `tar@7.5.21` cooldown exclusion, expired 2026-07-28. Verified `tar` still resolves to 7.5.21 without it.
- Corrects the comment claiming 1.1.16 / 2.1.2 were already patched and the advisory range was overbroad. #2921 disproved that, and the PoC above confirms 1.1.16 genuinely OOMs.

Refs #2926

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `brace-expansion` to `1.1.17` to patch CVE-2026-14257 via `minimatch@3`, removing the OOM risk without migrating to `minimatch@10`. Clarifies that the installed version is fixed and OSV remains red due to a stale advisory range; devDependency-only and not shipped.

- **Dependencies**
  - Override `brace-expansion@<1.1.17` to `^1.1.17`; keep `brace-expansion@>=5.0.0 <5.0.8` to `^5.0.8`.
  - Collapse cooldowns into `brace-expansion@1.1.17||5.0.8`; document the single-entry `||` rule.
  - Update `SECURITY.md`: devDependency-only scope, correct `3.x` boundary to `3.0.3`, link upstream range fix, and state precisely that the advisory’s range is stale.
  - Remove expired `tar@7.5.21` cooldown.
  - Lockfile now resolves `minimatch@3.1.5` → `brace-expansion@1.1.17`.

<sup>Written for commit 232b52213efe0215265ffebc37c92dad7e6da71d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

