### PR TITLE
fix(cqrs): derive baseplate connectorStyle enum from one source (#2982)

### DIFF
--- a/src/core/cqrs/v2/domain/layout/setBaseplateParams.test.ts
+++ b/src/core/cqrs/v2/domain/layout/setBaseplateParams.test.ts
@@ -3,6 +3,7 @@ import { produce } from 'immer';
 import { isOk } from '@/core/result';
 import type { StoredBaseplateParams } from '@/core/types';
 import { mm } from '@/core/types';
+import { BASEPLATE_CONNECTOR_STYLES } from '@/shared/types/bin';
 import { setBaseplateParams } from './setBaseplateParams';
 import { makeLayout } from './_testHelpers';
 
@@ -55,6 +56,16 @@ describe('v2 layout.setBaseplateParams', () => {
     if (!isOk(result)) throw new Error('handle failed');
     expect(result.value.event.payload.params.paddingAnchor).toBe('tr');
   });
+
+  it.each(BASEPLATE_CONNECTOR_STYLES)(
+    'payload schema accepts the %s connector style',
+    (connectorStyle) => {
+      const parsed = setBaseplateParams.payload.safeParse({
+        params: { ...baseParams, connectorNubs: true, connectorStyle },
+      });
+      expect(parsed.success).toBe(true);
+    }
+  );
 
   it('apply() installs the new params', () => {
     const layout = makeLayout();

--- a/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
+++ b/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
@@ -10,6 +10,7 @@ import { ok } from '@/core/result';
 import { clamp } from '@/shared/utils/validation';
 import { SOLID_FLOOR_MIN_MM, SOLID_FLOOR_MAX_MM } from '@/core/constants';
 import type { StoredBaseplateParams, GridUnits, Mm } from '@/core/types';
+import { BASEPLATE_CONNECTOR_STYLES } from '@/shared/types/bin';
 import { defineCommand } from '../../defineCommand';
 
 // StoredBaseplateParams has many fields, most optional; the schema is permissive
@@ -28,7 +29,7 @@ const payloadSchema = z.object({
       .enum(['tl', 'tc', 'tr', 'ml', 'c', 'mr', 'bl', 'bc', 'br', 'custom'])
       .optional(),
     connectorNubs: z.boolean().optional(),
-    connectorStyle: z.enum(['dovetail', 'dovetailKey']).optional(),
+    connectorStyle: z.enum(BASEPLATE_CONNECTOR_STYLES).optional(),
     lightweight: z.boolean().optional(),
     solidFloor: z.boolean().optional(),
     solidFloorThickness: z.number().optional(),

--- a/src/core/cqrs/validation/schemas.ts
+++ b/src/core/cqrs/validation/schemas.ts
@@ -11,6 +11,7 @@
 import * as z from 'zod';
 import { CONSTRAINTS, SOLID_FLOOR_MIN_MM, SOLID_FLOOR_MAX_MM } from '@/core/constants';
 import { STACK_PRINT_MIN_GAP_MM, STACK_PRINT_MAX_GAP_MM } from '@/core/types';
+import { BASEPLATE_CONNECTOR_STYLES } from '@/shared/types/bin';
 import type { CommandType } from '../commands';
 import {
   libraryCreateEntrySchema,
@@ -265,7 +266,7 @@ const baseplateParamsSchema = z.object({
   paddingAnchor: z.enum(['tl', 'tc', 'tr', 'ml', 'c', 'mr', 'bl', 'bc', 'br', 'custom']).optional(),
   connectorNubs: z.boolean().optional(),
   invertDovetails: z.boolean().optional(),
-  connectorStyle: z.enum(['dovetail', 'puzzle', 'dovetailKey', 'snapClip']).optional(),
+  connectorStyle: z.enum(BASEPLATE_CONNECTOR_STYLES).optional(),
   lightweight: z.boolean().optional(),
   solidFloor: z.boolean().optional(),
   solidFloorThickness: z.number().min(SOLID_FLOOR_MIN_MM).max(SOLID_FLOOR_MAX_MM).optional(),

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -169,9 +169,20 @@ export function isExteriorEdge(kind: BaseplateEdgeKind): boolean {
   return kind === 'exterior' || kind === 'marginSeam';
 }
 
-/** Baseplate split-connector styles — derived from the param definition below
- *  so it can't drift when a style is added. */
-export type BaseplateConnectorStyle = NonNullable<ResolvedBaseplateParams['connectorStyle']>;
+/**
+ * Baseplate split-connector styles — the single source of truth for the union,
+ * as a runtime tuple so zod schemas can derive their enum from it instead of
+ * restating the strings (three copies had already drifted; see #2982). The
+ * `ResolvedBaseplateParams.connectorStyle` field and this type both point here.
+ */
+export const BASEPLATE_CONNECTOR_STYLES = [
+  'dovetail',
+  'puzzle',
+  'dovetailKey',
+  'snapClip',
+] as const;
+
+export type BaseplateConnectorStyle = (typeof BASEPLATE_CONNECTOR_STYLES)[number];
 
 /**
  * Whether the margin-seam connector (#2414) engages for a given connector
@@ -429,7 +440,7 @@ export interface ResolvedBaseplateParams {
    * edges blind ledged pockets and ships a separate top-insert snap clip
    * ("staple") whose barbs catch the ledges.
    */
-  readonly connectorStyle?: 'dovetail' | 'puzzle' | 'dovetailKey' | 'snapClip';
+  readonly connectorStyle?: BaseplateConnectorStyle;
   /**
    * Cut the seam slot on the plate's EXTERIOR edges too, not just on the join
    * seams between split pieces (issue #2866). Every piece then reads as a


### PR DESCRIPTION
## Summary

`src/core/cqrs/v2/domain/layout/setBaseplateParams.ts` declared its payload
schema's `connectorStyle` as `z.enum(['dovetail', 'dovetailKey'])` — dropping
`'puzzle'` and `'snapClip'`, two of the four `BaseplateConnectorStyle` values.

As #2982 notes, this is **latent, not live**: `wrapV2Handler` calls
`def.handle(...)` directly and never reads `def.payload`, and actual validation
goes through `COMMAND_SCHEMAS` (which was correct). But it was a third divergent
copy of the same union, and the moment the v2 migration wires `def.payload` into
the validation middleware, `puzzle`/`snapClip` baseplates would start being
rejected — a failure that would surface far from this line.

## Fix

Make the union derive from a single source instead of being restated three times:

- **New canonical tuple** `BASEPLATE_CONNECTOR_STYLES` in `src/shared/types/bin.ts`.
- `BaseplateConnectorStyle` and `ResolvedBaseplateParams.connectorStyle` now derive from it (identical union — no behavior change).
- Both zod schemas — the v2 payload schema **and** `validation/schemas.ts` `COMMAND_SCHEMAS` — now use `z.enum(BASEPLATE_CONNECTOR_STYLES)`.

The three copies can no longer drift, since they are now literally the same array.

## Test

Adds a schema test (`it.each(BASEPLATE_CONNECTOR_STYLES)`) asserting the v2
payload schema accepts all four styles — pinning behavior at the boundary the
issue flagged as declared-but-dead, ready for when `def.payload` is wired up.

## Verification

- `pnpm typecheck` clean (the type-derivation swap produces an identical union).
- Targeted vitest: 62 tests pass across `setBaseplateParams.test.ts` + `schemas.test.ts`.
- Lint + all pre-commit gates green.

Closes #2982

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the baseplate `connectorStyle` enum behind a single source so v2 payload validation accepts all four styles and can’t drift. Closes #2982 and prevents future rejects when v2 payload validation is wired in.

- **Bug Fixes**
  - Added `BASEPLATE_CONNECTOR_STYLES` tuple in `src/shared/types/bin.ts` as the single source of truth.
  - Updated `BaseplateConnectorStyle`, `ResolvedBaseplateParams.connectorStyle`, and both zod schemas (`setBaseplateParams.payload`, `COMMAND_SCHEMAS`) to use `z.enum(BASEPLATE_CONNECTOR_STYLES)`.
  - Added a schema test that iterates `BASEPLATE_CONNECTOR_STYLES` to confirm all four styles are accepted.

<sup>Written for commit cdf3a7c8daf3f35b960bd8c8338c9e38d664e587. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

