### PR TITLE
docs(test): update createTestBin's example to compile

### DIFF
--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -137,8 +137,8 @@ export function getBinId(result: Result<BinId, unknown>): BinId {
  * @returns A new Bin object
  *
  * @example
- * const bin = createTestBin({ id: 'bin-1', x: 3, y: 5 });
- * const stagingBin = createTestBin({ layerId: '__staging__' });
+ * const bin = createTestBin({ id: binId('bin-1'), x: gridUnits(3), y: gridUnits(5) });
+ * const stagingBin = createTestBin({ layerId: STAGING_ID });
  */
 export function createTestBin(overrides: Partial<Bin> = {}): Bin {
   return {


### PR DESCRIPTION
Follow-up to a review comment on #2989.

The JSDoc example above `createTestBin` still showed raw values:

```ts
const bin = createTestBin({ id: 'bin-1', x: 3, y: 5 });
const stagingBin = createTestBin({ layerId: '__staging__' });
```

None of that compiles now that `Bin`'s fields are branded — and this is the example test authors copy when they need a fixture, so a stale one propagates the exact pattern the burn-down is removing.

Now uses `binId()`/`gridUnits()`, and `STAGING_ID` instead of the raw `'__staging__'` literal the repo bans elsewhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the JSDoc example for createTestBin so it compiles with branded Bin fields. Replaced raw values with `binId()`, `gridUnits()`, and `STAGING_ID` to match the current API and prevent invalid test fixtures.

<sup>Written for commit 347abd0df66adca2a78df10d34d4be34ca49e4cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

