### PR TITLE
fix(staging): flip rotate button on the visually top row, not the bottom (#2979)

### DIFF
--- a/src/features/staging/components/Staging/Staging.tsx
+++ b/src/features/staging/components/Staging/Staging.tsx
@@ -575,7 +575,6 @@ export function Staging() {
                     isDragging={bin.id === draggingBinId}
                     isHovered={hoveredBinId === bin.id}
                     isTouchDevice={isTouchDevice}
-                    isTopRow={bin.y === 0}
                     cellSize={cellSize}
                     gap={gap}
                     gridHeight={gridHeight}

--- a/src/features/staging/components/Staging/StagingBin.test.tsx
+++ b/src/features/staging/components/Staging/StagingBin.test.tsx
@@ -61,7 +61,6 @@ describe('StagingBin', () => {
       isDragging: false,
       isHovered: false,
       isTouchDevice: false,
-      isTopRow: false,
       cellSize: 40,
       gap: 4,
       gridHeight: 10,
@@ -224,6 +223,54 @@ describe('StagingBin', () => {
     renderInGrid(<StagingBin {...props} />);
 
     expect(screen.getByTitle('Rotate bin (R)')).toBeInTheDocument();
+  });
+
+  it('flips the rotate button below the bin for the visually top row (#2979)', () => {
+    // gridHeight 10, a depth-2 bin at y=8 lands on the top row (gridRowStart === 1);
+    // the button must escape downward (bottom: -22) so it doesn't overflow above the stash.
+    const props = defaultProps({
+      isHovered: true,
+      gridHeight: 10,
+      bin: {
+        id: binId('bin-1'),
+        x: 0,
+        y: 8,
+        width: 3,
+        depth: 2,
+        height: 4,
+        category: categoryId('cat-1'),
+        label: 'Tools',
+      },
+    });
+    renderInGrid(<StagingBin {...props} />);
+
+    const rotateButton = screen.getByTitle('Rotate bin (R)');
+    expect(rotateButton.style.bottom).toBe('-22px');
+    expect(rotateButton.style.top).toBe('');
+  });
+
+  it('keeps the rotate button above the bin for lower rows (#2979)', () => {
+    // Same 10-row stash, but a bin at y=0 is the bottom row (gridRowStart === 9),
+    // so the button stays at its normal position above the bin (top: -22).
+    const props = defaultProps({
+      isHovered: true,
+      gridHeight: 10,
+      bin: {
+        id: binId('bin-1'),
+        x: 0,
+        y: 0,
+        width: 3,
+        depth: 2,
+        height: 4,
+        category: categoryId('cat-1'),
+        label: 'Tools',
+      },
+    });
+    renderInGrid(<StagingBin {...props} />);
+
+    const rotateButton = screen.getByTitle('Rotate bin (R)');
+    expect(rotateButton.style.top).toBe('-22px');
+    expect(rotateButton.style.bottom).toBe('');
   });
 
   it('fires onBinClick with bin ID', () => {

--- a/src/features/staging/components/Staging/StagingBin.tsx
+++ b/src/features/staging/components/Staging/StagingBin.tsx
@@ -13,7 +13,6 @@ interface StagingBinProps {
   isDragging: boolean;
   isHovered: boolean;
   isTouchDevice: boolean;
-  isTopRow: boolean;
   cellSize: number;
   gap: number;
   gridHeight: number;
@@ -92,7 +91,6 @@ export const StagingBin = memo(function StagingBin({
   isDragging,
   isHovered,
   isTouchDevice,
-  isTopRow,
   cellSize,
   gap,
   gridHeight,
@@ -142,6 +140,12 @@ export const StagingBin = memo(function StagingBin({
 
   // Calculate grid row start (must be integer for valid CSS Grid)
   const gridRowStart = gridHeight - Math.ceil(bin.y + bin.depth) + 1;
+
+  // Staging renders bottom-origin (higher bin.y draws higher, i.e. a smaller
+  // gridRowStart), so the visually top row is gridRowStart === 1 — not bin.y === 0
+  // (which is the bottom row). Derived from gridRowStart here, rather than passed
+  // in, so the two can't disagree about which row is on top (#2979).
+  const isTopRow = gridRowStart === 1;
 
   const dimensionsText = `${formatDim(bin.width)}×${formatDim(bin.depth)}`;
   const hasLabel = !!bin.label;
@@ -285,6 +289,8 @@ export const StagingBin = memo(function StagingBin({
           className="absolute transition-opacity duration-150"
           style={{
             right: -22,
+            // Button normally sits above the bin (top: -22); for the visually top
+            // row that would overflow above the stash, so flip it below instead.
             ...(isTopRow ? { bottom: -22 } : { top: -22 }),
             width: 44,
             height: 44,


### PR DESCRIPTION
## Problem

The staging stash renders **bottom-origin**. `StagingBin.tsx` positions each bin with:

```ts
const gridRowStart = gridHeight - Math.ceil(bin.y + bin.depth) + 1;
```

so higher `bin.y` draws *higher* on screen (a smaller `gridRowStart`). The visually top row is therefore `gridRowStart === 1`.

`Staging.tsx` passed `isTopRow={bin.y === 0}` — which is the **bottom** row. That prop drives the rotate button's overflow escape (`isTopRow ? { bottom: -22 } : { top: -22 }`), so with the predicate inverted:

- bins in the **visually top row** got a rotate button that **overflows above the stash**, and
- bottom-row bins got one pushed below for no reason.

Only visible when the stash has more than one row (a single-row stash is both top and bottom), which is why it went unnoticed. (Found via the test type-check burn-down #2978.)

## Fix

Rather than correct the predicate in `Staging.tsx` and leave two files independently computing row position, **delete the `isTopRow` prop and derive it inside `StagingBin` from the `gridRowStart` it already computes**:

```ts
const isTopRow = gridRowStart === 1;
```

Now the flip predicate and the row the bin actually renders on come from a single computation and can't drift.

## Tests

Adds two tests covering **both** branches of the flip in a genuine multi-row (`gridHeight: 10`) stash:
- a top-row bin (`y: 8`, `gridRowStart === 1`) → button escapes to `bottom: -22`,
- a lower-row bin (`y: 0`, `gridRowStart === 9`) → button stays at `top: -22`.

The prior test never passed `isTopRow`, so only the falsy branch was ever exercised.

## Verification

`pnpm typecheck` clean · 26/26 StagingBin tests pass · lint + pre-commit gates green.

Closes #2979

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the rotate button in staging so it flips below only on the visually top row, preventing overflow in multi-row stashes. Implements #2979 by deriving top-row detection from `gridRowStart` inside `StagingBin`.

- **Bug Fixes**
  - Top row flips down (`bottom: -22`); other rows stay up (`top: -22`). Adds two tests in a 10-row grid.

- **Refactors**
  - Removed `isTopRow` prop and compute `gridRowStart === 1` inside `StagingBin` to keep row logic in one place.

<sup>Written for commit f6b8dd3e5775101d97e0187adc1af06468a16c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

