### PR TITLE
fix(baseplate): bias split planner toward fewer pieces (#2988)

### DIFF
--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -210,15 +210,42 @@ describe('computeBaseplateTiling', () => {
     expect(tiling.bedLoads).toBe(1);
   });
 
-  it('chooses a finer split to save a build-plate load when the trade is cheap', () => {
-    // 10×8: the coarse 2×2 (4 pieces) prints 1-per-bed = 4 loads, but a 2×3
-    // (6 pieces) packs its shallower pieces two-per-bed → 3 loads. Saving a
-    // load for 2 extra pieces is within the per-load piece budget, so the
-    // packing-aware planner picks the 2×3.
+  it('prefers fewer pieces over saving a load when the trade costs 2+ pieces (#2988)', () => {
+    // 10×8: the coarse 2×2 (4 pieces) prints 1-per-bed = 4 loads; a 2×3
+    // (6 pieces) packs two-per-bed → 3 loads. Saving that one load costs 2 extra
+    // pieces, which exceeds the tightened per-load budget (2), so the planner
+    // keeps the coarser 2×2 — fewer seams to print/align/glue, and the finer
+    // split's load saving is only realized via a non-obvious cross-row bed pack.
     const tiling = computeBaseplateTiling(makeParams({ width: 10, depth: 8 }), 256);
     expect(tiling.cols).toBe(2);
-    expect(tiling.rows).toBe(3);
-    expect(tiling.bedLoads).toBe(3);
+    expect(tiling.rows).toBe(2);
+    expect(tiling.pieces).toHaveLength(4);
+  });
+
+  it('splits an 11×8 plate into 4 pieces, not 6, on a 270mm bed (#2988)', () => {
+    // The reported case: 11×8 with 15mm L/R and 19.5mm F/B padding on a 270mm
+    // bed. A 2×2 (4 pieces: 267/225mm wide × 187.5mm deep) fits the bed and is
+    // what the user expects; the old planner instead emitted a 2×3 (6 pieces) to
+    // shave one bed load. With the tightened budget it stays 2×2.
+    const tiling = computeBaseplateTiling(
+      makeParams({
+        width: 11,
+        depth: 8,
+        paddingLeft: 15,
+        paddingRight: 15,
+        paddingFront: 19.5,
+        paddingBack: 19.5,
+      }),
+      270
+    );
+    expect(tiling.cols).toBe(2);
+    expect(tiling.rows).toBe(2);
+    expect(tiling.pieces).toHaveLength(4);
+    // Every piece must still physically fit the bed.
+    for (const p of tiling.pieces) {
+      expect(p.widthUnits * 42 + p.paddingLeft + p.paddingRight).toBeLessThanOrEqual(270);
+      expect(p.depthUnits * 42 + p.paddingFront + p.paddingBack).toBeLessThanOrEqual(270);
+    }
   });
 
   it('does not over-fragment when finer pieces would not pack better', () => {

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -43,8 +43,15 @@ import { FRACTIONAL_THRESHOLD, isFractional, reorderForDisplay } from './splitRe
  * weight in the tiling cost (`LOAD_WEIGHT * bedLoads + pieceCount`): a finer
  * split that removes a load wins only if it adds fewer than this many pieces,
  * so the planner pursues fewer bed swaps without fragmenting into tiny tiles.
+ *
+ * Set to 2 (#2988): one saved load is worth at most one extra piece. Each extra
+ * piece is another dovetailed seam to print, align, and glue, and the finer
+ * split's load saving is only realized if the user re-derives the non-obvious
+ * cross-row bed packing (the print guide groups pieces by grid position, not by
+ * bed). So adding 2+ pieces to save a single load is a bad trade for most users
+ * — they'd rather print the coarser split's few large pieces one-per-bed.
  */
-const MAX_EXTRA_PIECES_PER_BED_LOAD = 4;
+const MAX_EXTRA_PIECES_PER_BED_LOAD = 2;
 
 /**
  * Only run the packing-aware refinement when the coarsest split has at most this


### PR DESCRIPTION
## Problem

Generating an **11×8** baseplate (15mm L/R, 19.5mm F/B padding) on a **270mm** bed produced **6 pieces in 3 build-plate loads** (2×3), when **4 pieces in 4 loads** (2×2) fit the bed fine and is what the user expected.

The planner minimizes *bed loads*, not *piece count*: `MAX_EXTRA_PIECES_PER_BED_LOAD` (=4) made it treat one saved load as worth up to 4 extra pieces, so trading +2 pieces for −1 load won.

The "3 loads" figure is **mathematically correct** — the shelf packer (`bedPacking.ts`) is a sound upper bound, and 6 pieces genuinely pack into 3 beds (`A1+A3`, `A2+B2`, `B1+B3`). But:

- The print guide groups pieces by **grid position** (A1,B1 / A2,B2 / …), never by bed, so the user reads "A1 must plate with B1" — which doesn't fit — and can't see the cross-row packing that makes 3 loads work.
- Every extra piece is another dovetail seam to print, align, and glue.

So +2 pieces to save one hard-to-realize load is a poor trade.

## Fix

Lower `MAX_EXTRA_PIECES_PER_BED_LOAD` from **4 → 2**: one saved load is now worth at most **one** extra piece. Trading +2 pieces for −1 load no longer wins, so the 11×8/270 plate (and the 10×8/256 case a test pinned) stay at the coarser 2×2.

The planner still refines when the trade is efficient (Δpieces < 2·Δloads) and when a finer split is required to fit — large plates are unaffected.

## Tests

- Rewrote the test that encoded the old tradeoff (`10×8` now asserts 2×2 / 4 pieces).
- Added the reported **11×8 on 270mm** scenario asserting 4 pieces, each verified to fit the bed.
- Full baseplate suite (865 tests) + `splitPlanner`/`bedPacking` green; only the one behavior-encoding test changed.

## Verification

`pnpm typecheck` clean · 865/865 baseplate tests pass · lint green.

Closes #2988

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bias the baseplate split planner toward fewer pieces by lowering the per-load piece budget from 4 to 2. Fixes #2988 where an 11×8 plate on a 270mm bed was split into 6 pieces; it now stays at 4 when they fit.

- **Bug Fixes**
  - Prefers 2×2 over 2×3 when saving one load would cost 2 extra pieces, aligning with how users plate pieces.
  - Updated tests: revised 10×8/256 to expect 2×2; added 11×8/270 case asserting 4 pieces and bed-fit checks.

<sup>Written for commit 5a668116daea11f1a69fd21d3773c64124319e24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/2996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

