### PR TITLE
chore(ci): make Vercel PR previews opt-in

### DIFF
--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -1,13 +1,17 @@
 name: Smoke (Preview)
 
-# Runs the PWA smoke spec against the Vercel preview deployment for every PR.
+# Runs the PWA smoke spec against a PR's Vercel preview deployment.
 # Catches deploy-time bugs (broken precache, missing assets, wwwMigration-class
-# hash mismatches) before merge. Mark this as a required status check in branch
-# protection to block merges on smoke failure.
+# hash mismatches) before merge.
 #
-# When the Vercel deploy is "ignored" by `scripts/vercel-ignore.sh` (e.g. a
-# PR that touches only CI / docs), there is no preview to smoke against.
-# The workflow exits success with a clear warning in that case.
+# Previews are OPT-IN (see scripts/vercel-ignore.sh) — branch as `preview/<name>`
+# or put `[preview]` in the head commit message. Without a preview there is
+# nothing to smoke against and this workflow exits success with a warning, so
+# it only provides real coverage on PRs that requested one. Opt in for anything
+# touching the service worker, build output, or public/ assets.
+#
+# Because it passes vacuously without a preview, this is NOT a useful required
+# status check on its own — a green run may mean "nothing was tested".
 
 on:
   pull_request:

--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -51,10 +51,30 @@ if [ "$VERCEL_GIT_COMMIT_REF" = "main" ]; then
   fi
 fi
 
-# Always build preview deployments for PRs
+# PR previews are opt-in. Most PRs never need one, and every preview build
+# costs a full deploy. Request one either way:
+#   - branch the work as `preview/<name>`, or
+#   - put `[preview]` anywhere in the head commit message.
+#
+# Note: the PWA smoke spec (.github/workflows/smoke-preview.yml) can only run
+# against a real preview URL. Without one it exits success with a warning, so
+# opting out also opts out of deploy-time smoke coverage — precache breakage,
+# missing assets, asset-hash mismatches. Use `[preview]` on anything touching
+# the service worker, build output, or public/ assets.
 if [ -n "$VERCEL_GIT_PULL_REQUEST_ID" ]; then
-  echo "PR preview deployment. Proceeding with build."
-  exit 1
+  if [[ "$VERCEL_GIT_COMMIT_REF" == preview/* ]]; then
+    echo "PR on a preview/* branch. Proceeding with build."
+    exit 1
+  fi
+
+  if [[ "$VERCEL_GIT_COMMIT_MESSAGE" == *"[preview]"* ]]; then
+    echo "PR head commit requests [preview]. Proceeding with build."
+    exit 1
+  fi
+
+  echo "PR preview not requested. Skipping build."
+  echo "To get one: branch as preview/<name>, or add [preview] to the commit message."
+  exit 0
 fi
 
 # Skip other branch deploys (feature branches without PRs)


### PR DESCRIPTION
## Summary

Every PR triggered a full Vercel preview deploy. Most never need one, so previews are now requested explicitly:

- branch as `preview/<name>`, **or**
- put `[preview]` anywhere in the head commit message

Production deploys from `main`, the release-please skip, and the no-PR-branch skip are all unchanged.

## The tradeoff, stated plainly

The PWA smoke spec (`.github/workflows/smoke-preview.yml`) can only run against a live preview URL. When there is no preview it exits success with a warning — so **opting out of a preview also opts out of deploy-time smoke coverage**: broken precache, missing assets, `wwwMigration`-class asset-hash mismatches. Those are exactly the failures that unit tests cannot see, because they only exist in built output.

Two consequences worth being deliberate about:

1. Anything touching the service worker, build output, or `public/` assets should opt in.
2. `smoke-preview` is no longer meaningful as a *required* status check on its own — a green run may now mean "nothing was tested". Noted in the workflow header so nobody reads a vacuous pass as a real one.

If that coverage loss matters more than the deploy cost, the alternative is to invert the default: keep previews on and add a `[no-preview]` opt-out instead. Happy to switch — it's a one-line change to the same conditional.

## Verification

Invoked the script directly with the relevant `VERCEL_GIT_*` variables to check every path:

| Scenario | Exit | Result |
|---|---|---|
| PR, plain branch | 0 | skip |
| PR, `preview/*` branch | 1 | build |
| PR, `[preview]` in message | 1 | build |
| Branch with no PR | 0 | skip |
| release-please branch | 0 | skip |

`main` handling is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Vercel PR previews opt-in to reduce unnecessary deploys. Smoke tests now run only when a preview exists; otherwise the workflow exits success with a warning.

- **Migration**
  - To request a preview: use a `preview/<name>` branch or add `[preview]` to the head commit message.
  - Opt in for changes to the service worker, build output, or `public/` assets.
  - Do not require “Smoke (Preview)” as a standalone required check, since it can pass without testing.
  - Production deploys from `main` and existing release-please/no-PR skips are unchanged.

<sup>Written for commit fd1e0eb4059f6e22e0cf2bb01f9e6dcde2a2be22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

