### PR TITLE
fix(generation): stop the compartments path leaking WASM handles (#2985)

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.brepkit.snap
@@ -2,8 +2,8 @@
 
 exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `4172`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `4344`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `4023`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `4030`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3875`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `4792`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `4216`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2796`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2908`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2852`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `2936`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `2880`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3196`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3140`;

--- a/src/features/generation/worker/generators/compartmentBuilder.ts
+++ b/src/features/generation/worker/generators/compartmentBuilder.ts
@@ -82,30 +82,50 @@ function cavityDrawing(corners: CavityCorners, cornerRadius: number): Drawing {
   // Cap the radius at half the smaller span so opposing fillets can't overrun.
   const { cavW, cavD } = cavitySpan(corners);
   const r = Math.max(0, Math.min(cornerRadius, cavW / 2 - 0.05, cavD / 2 - 0.05));
-  const rBL = exterior.bl ? r : 0;
-  const rBR = exterior.br ? r : 0;
-  const rTR = exterior.tr ? r : 0;
-  const rTL = exterior.tl ? r : 0;
-
   if (r <= 0.1 || !hasExteriorCorner(exterior)) {
     return draw(bl).lineTo(br).lineTo(tr).lineTo(tl).close();
   }
 
-  // Start at the midpoint of BL→BR so close() forms a real edge through BL,
-  // letting customCorner(rBL) apply to it (mirrors buildSlabProfile in
-  // baseplateSlab.ts). Starting at a corner would make close() degenerate.
-  // Use the true midpoint (not [mid_x, bl[1]]): an override can tilt the
-  // bottom edge (bl[1] !== br[1]), and the start point must stay on it.
-  let pen = draw([(bl[0] + br[0]) / 2, (bl[1] + br[1]) / 2]);
-  pen = pen.lineTo(br);
-  if (rBR > 0) pen = pen.customCorner(rBR);
-  pen = pen.lineTo(tr);
-  if (rTR > 0) pen = pen.customCorner(rTR);
-  pen = pen.lineTo(tl);
-  if (rTL > 0) pen = pen.customCorner(rTL);
-  pen = pen.lineTo(bl);
-  if (rBL > 0) pen = pen.customCorner(rBL);
-  return pen.close();
+  // CCW corner ring (bl→br→tr→tl); only perimeter corners get a nonzero radius.
+  const ring: Array<{ point: [number, number]; radius: number }> = [
+    { point: bl, radius: exterior.bl ? r : 0 },
+    { point: br, radius: exterior.br ? r : 0 },
+    { point: tr, radius: exterior.tr ? r : 0 },
+    { point: tl, radius: exterior.tl ? r : 0 },
+  ];
+
+  // brepjs's customCorner() leaks 2 WASM handles per call when a later lineTo()
+  // consumes its deferred fillet (#2985); closeWithCustomCorner() — which rounds
+  // the corner between the last-drawn segment and the closing edge — does not.
+  // Rotate the ring so the last rounded corner is drawn last and closed via the
+  // leak-free path. A cavity with a single perimeter corner (the common case —
+  // each interior compartment cell touches at most one bin corner) then makes
+  // zero customCorner() calls. An edge-spanning compartment with two perimeter
+  // corners still routes the earlier one through the leaky customCorner(): a
+  // residual that needs an upstream brepjs fix, but it now leaks one corner
+  // instead of both.
+  // hasExteriorCorner() guaranteed at least one rounded corner, so `lastRounded`
+  // is >= 0 and `ordered` is the full ring ending on that rounded corner.
+  const lastRounded = ring.map((c) => c.radius > 0).lastIndexOf(true);
+  const ordered = [...ring.slice(lastRounded + 1), ...ring.slice(0, lastRounded + 1)];
+  const target = ordered[ordered.length - 1];
+  const closeTo = ordered[0];
+
+  // Start on the closing edge's midpoint so close() forms a real edge through
+  // `target` (mirrors buildSlabProfile in baseplateSlab.ts). Starting at a
+  // corner would make the closing edge degenerate. Use the true midpoint: an
+  // override can tilt an edge, and the start point must stay on it.
+  let pen = draw([
+    (target.point[0] + closeTo.point[0]) / 2,
+    (target.point[1] + closeTo.point[1]) / 2,
+  ]);
+  for (let i = 0; i < ordered.length - 1; i++) {
+    const corner = ordered[i];
+    pen = pen.lineTo(corner.point);
+    if (corner.radius > 0) pen = pen.customCorner(corner.radius);
+  }
+  pen = pen.lineTo(target.point);
+  return pen.closeWithCustomCorner(target.radius);
 }
 
 interface CavityCorners {


### PR DESCRIPTION
## Problem

The compartments generation path leaks OCCT/WASM handles — the `disposalRegression` profiling test measured `delta 280` (budget 10), while every other feature was exactly `0`. Left unfixed it surfaces as unbounded generation-worker memory growth (and eventually a wedged worker) over a long editing session with repeated regeneration.

## Root cause

`cavityDrawing()` rounded each exterior compartment corner with brepjs's `customCorner()`, which **leaks 2 OCCT handles per call** when a later `lineTo()` consumes its deferred fillet. The compartments path is the only default generation path that calls it: 4 bin corners × 2 handles × churn iterations = the reported 280. (It is a general brepjs defect, not specific to compartments — label tabs would hit it too in a narrower-width config; compartments is just the path the test exercises.)

## Fix

brepjs's `closeWithCustomCorner()` — which rounds the corner between the last-drawn segment and the closing edge — routes through a **different, leak-free path**. Rotate the corner ring so the last rounded corner is drawn last and closed that way:

- A cavity with a **single** perimeter corner (the common case — each interior cell touches at most one bin corner) then makes **zero** `customCorner()` calls → leak goes to **0**.
- An **edge-spanning** compartment with two adjacent perimeter corners still routes the earlier one through `customCorner()` — a residual that halves rather than eliminates for that shape, and needs an upstream fix to brepjs's own `customCorner()` disposal.

The fillet geometry is unchanged (same underlying `filletCurves()`); only tessellation differs.

## Verification

- **Disposal regression:** `compartments 2x2` delta **280 → 0** (and `wall cutouts + compartments` 280 → 0).
- **Geometry integrity:** manifold/watertight (18), export-invariant + tilted-divider (8), and both-kernel scenario tests all pass.
- **Snapshots:** triangle counts shift by a constant −56/bin on the default kernel (a benign tessellation change); both `.snap` and `.brepkit.snap` updated. Typecheck + lint clean.

## Follow-ups (out of scope)

- `disposalRegression.test.ts` runs in **no** CI job today (it's under `__kernel-tests__`, `skipIf(!globalThis.gc)`), which is why this went unnoticed — worth wiring into a scheduled `--expose-gc` job.
- The residual edge-spanning-compartment leak wants an upstream brepjs fix to `customCorner()`'s disposal.

Closes #2985

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a WASM handle leak in the compartments generation path by reordering corner drawing and using `closeWithCustomCorner()`. Prevents unbounded generation-worker memory growth; disposal regression drops from 280 to 0.

- **Bug Fixes**
  - Cause: `brepjs` `customCorner()` leaked 2 handles per call when a later `lineTo()` consumed its deferred fillet.
  - Change: Rotate the corner ring so the last rounded corner closes via `closeWithCustomCorner()`, avoiding `customCorner()` in the common case. Geometry is unchanged; only tessellation shifts.
  - Verification: disposal regression 280 → 0 (also for wall cutouts + compartments), geometry/invariance tests pass, snapshots updated (triangle counts −56/bin on default kernel).

<sup>Written for commit cb78faa7c0d392c1e9925b1fa4217c9016c3abf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

