### PR TITLE
fix(deps): patch brepjs to dispose intersectCurves' bounding boxes (#2985)

### DIFF
--- a/patches/brepjs@18.119.2.patch
+++ b/patches/brepjs@18.119.2.patch
@@ -1,0 +1,40 @@
+diff --git a/dist/blueprintSketcher-C0EXFVb2.cjs b/dist/blueprintSketcher-C0EXFVb2.cjs
+index b5fcea84b0d91b52bc83681269dde9b3b0a493a1..38007e69b115851f123f1a9591ccb9bbeec803fb 100644
+--- a/dist/blueprintSketcher-C0EXFVb2.cjs
++++ b/dist/blueprintSketcher-C0EXFVb2.cjs
+@@ -540,7 +540,14 @@ function hilbert(x, y) {
+ * ```
+ */
+ var intersectCurves = (first, second, precision = 1e-9) => {
+-	if (first.boundingBox.isOut(second.boundingBox)) return require_errors.ok({
++	const __bb1 = first.boundingBox;
++	const __bb2 = second.boundingBox;
++	const __out = __bb1.isOut(__bb2);
++	if (first._boundingBox === __bb1) first._boundingBox = null;
++	if (second._boundingBox === __bb2) second._boundingBox = null;
++	if (typeof __bb1.delete === "function") __bb1.delete();
++	if (typeof __bb2.delete === "function") __bb2.delete();
++	if (__out) return require_errors.ok({
+ 		intersections: [],
+ 		commonSegments: [],
+ 		commonSegmentsPoints: []
+diff --git a/dist/blueprintSketcher-DDPyypmC.js b/dist/blueprintSketcher-DDPyypmC.js
+index 6ae0f387d3d6638cd268db3bfcad0e881ab381d7..3e64c67a920351bd4d30560ae5423d2a19a6db31 100644
+--- a/dist/blueprintSketcher-DDPyypmC.js
++++ b/dist/blueprintSketcher-DDPyypmC.js
+@@ -540,7 +540,14 @@ function hilbert(x, y) {
+ * ```
+ */
+ var intersectCurves = (first, second, precision = 1e-9) => {
+-	if (first.boundingBox.isOut(second.boundingBox)) return ok({
++	const __bb1 = first.boundingBox;
++	const __bb2 = second.boundingBox;
++	const __out = __bb1.isOut(__bb2);
++	if (first._boundingBox === __bb1) first._boundingBox = null;
++	if (second._boundingBox === __bb2) second._boundingBox = null;
++	if (typeof __bb1.delete === "function") __bb1.delete();
++	if (typeof __bb2.delete === "function") __bb2.delete();
++	if (__out) return ok({
+ 		intersections: [],
+ 		commonSegments: [],
+ 		commonSegmentsPoints: []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ overrides:
 
 patchedDependencies:
   '@ts-morph/common@0.11.1': af8386da3c617c0b08a3cd3b93405261181b9cd4661197cd64e6d244543796bf
+  brepjs@18.119.2: 66116d0f20d49765d73e6362a8bb906162421d6556371a85c48d2e76738cb646
   eslint-plugin-jsx-a11y@6.10.2: b8ef271a4b50b7ee48a5e92a3ee36f8e5ca942682264a445d0b76b82b084e993
 
 importers:
@@ -78,7 +79,7 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.119.2
-        version: 18.119.2(brepkit-wasm@2.128.7)(occt-wasm@3.8.0)
+        version: 18.119.2(patch_hash=66116d0f20d49765d73e6362a8bb906162421d6556371a85c48d2e76738cb646)(brepkit-wasm@2.128.7)(occt-wasm@3.8.0)
       brepkit-wasm:
         specifier: ^2.127.3
         version: 2.128.7
@@ -8504,7 +8505,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.119.2(brepkit-wasm@2.128.7)(occt-wasm@3.8.0):
+  brepjs@18.119.2(patch_hash=66116d0f20d49765d73e6362a8bb906162421d6556371a85c48d2e76738cb646)(brepkit-wasm@2.128.7)(occt-wasm@3.8.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -113,4 +113,5 @@ overrides:
 
 patchedDependencies:
   '@ts-morph/common@0.11.1': patches/@ts-morph__common@0.11.1.patch
+  brepjs@18.119.2: patches/brepjs@18.119.2.patch
   eslint-plugin-jsx-a11y@6.10.2: patches/eslint-plugin-jsx-a11y@6.10.2.patch


### PR DESCRIPTION
## Problem

brepjs's `DrawingPen.customCorner()` leaked **2 OCCT handles per call** — the reported `compartments 2x2 delta=280` in `disposalRegression` (4 rounded bin corners × churn), surfacing as gradual generation-worker memory growth and an eventually-wedged worker over a long editing session.

## Root cause

Traced with a fast `withScope` + `gcCollected` repro (reproduced the exact 2/call leak in ~1.4s) plus FinalizationRegistry creation-stack tagging, which gave a precise trace:

```
new BoundingBox2d  ←  Curve2D.get boundingBox  ←  intersectCurves  ←  removeCorner  ←  filletCurves  ←  customCorner
```

`intersectCurves()` does an AABB pre-check `first.boundingBox.isOut(second.boundingBox)`. `Curve2D.boundingBox` **lazily creates and caches** a `BoundingBox2d` (a `Bnd_Box2d` kernel handle), but `Curve2D` disposal never frees that cache — so both boxes leak to the FinalizationRegistry. `filletCurves → removeCorner` calls `intersectCurves` once per rounded corner → exactly **2 handles/corner**.

This is general to **every** `intersectCurves` caller (fillets, chamfers, dogbones, and drawing booleans), not just compartments.

## Fix

`pnpm patch` on both brepjs dist bundles — capture the two boxes, run `isOut`, clear the curves' cache, and delete them:

```js
const __bb1 = first.boundingBox, __bb2 = second.boundingBox;
const __out = __bb1.isOut(__bb2);
if (first._boundingBox === __bb1) first._boundingBox = null;
if (second._boundingBox === __bb2) second._boundingBox = null;
__bb1.delete?.(); __bb2.delete?.();
if (__out) return ok({ ... });
```

It's a **pure disposal change** — geometry is byte-identical. (This is why the earlier `closeWithCustomCorner` workaround, #3003, was wrong: it filleted the *first↔last* junction, a different corner, and regressed the #1968 thin-wall fix.)

## Verification

- **`disposalRegression`: `compartments 2x2` delta 280 → 0**, `wall cutouts + compartments` 280 → 0, every feature `delta=0`.
- **Geometry byte-identical:** `issue-1968` passes; compartment scenario snapshots pass **without `-u`** (no triangle-count change).
- **~1,070 tests** across every `intersectCurves`/`customCorner` user pass, no double-free: baseplate 867, general + cutout + labelPlate/Tab + compartment scenarios 193, issue-1968 4.
- No app-code changes — the diff is only the brepjs patch.

## Follow-ups

- Report upstream to brepjs: `Curve2D` disposal should also free its cached `_boundingBox`, so this patch can eventually be retired.
- `disposalRegression.test.ts` runs in no CI job (`__kernel-tests__`, `skipIf(!globalThis.gc)`, ~8min) — worth a scheduled `--expose-gc` job so this class of leak can't regress unnoticed.

Closes #2985

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patched `brepjs` to dispose bounding boxes in `intersectCurves`, fixing a 2-handle-per-call OCCT leak. This stops generation-worker memory growth and long-session stalls (issue #2985).

- **Bug Fixes**
  - Added `patches/brepjs@18.119.2.patch`: after the AABB check, clear each curve’s cached `_boundingBox` and `delete()` both `BoundingBox2d` instances.
  - Impact and verification: no geometry changes; leak across fillets/chamfers/dogbones/booleans eliminated; disposalRegression deltas now 0 and ~1,070 tests pass; `pnpm-workspace.yaml` and `pnpm-lock.yaml` updated to apply the patch.

<sup>Written for commit 00404dbe45a8ad90a0ca85f89e189f68394416d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

