### PR TITLE
fix(ml-telemetry): expire every aggregate with a sliding TTL

### DIFF
--- a/api/lib/mlTelemetry/retention.test.ts
+++ b/api/lib/mlTelemetry/retention.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { ML_AGGREGATE_TTL_SECONDS, ML_LIFETIME_KEYS, isExpiringAggregate } from './retention.js';
+
+describe('ML telemetry retention policy', () => {
+  it('expires 90 days out', () => {
+    expect(ML_AGGREGATE_TTL_SECONDS).toBe(7776000);
+  });
+
+  it.each([
+    'ml:label_hash:1ba025cd',
+    'ml:cat:mpwa8w43-50ce8db90a',
+    'ml:clusters:000078d9',
+    'ml:drawer_sizes:9x7x12.86',
+    'ml:sizes',
+    'ml:meta:vocab_versions',
+    'ml:meta:client_versions',
+  ])('expires the aggregate %s', (key) => {
+    expect(isExpiringAggregate(key)).toBe(true);
+  });
+
+  it.each([...ML_LIFETIME_KEYS])('never expires the running total %s', (key) => {
+    expect(isExpiringAggregate(key)).toBe(false);
+  });
+
+  // ml_ratelimit:* carries its own 120s TTL and is not an aggregate; the
+  // underscore keeps it out of an `ml:*` SCAN, and out of this predicate.
+  it.each(['ml_ratelimit:be667baa342372ce', 'session:abc', 'users:abc:profile'])(
+    'ignores the non-aggregate key %s',
+    (key) => {
+      expect(isExpiringAggregate(key)).toBe(false);
+    }
+  );
+});

--- a/api/lib/mlTelemetry/retention.ts
+++ b/api/lib/mlTelemetry/retention.ts
@@ -1,0 +1,28 @@
+/**
+ * Retention policy for ML telemetry aggregates.
+ *
+ * The TTL is *sliding* — refreshed on every write, not set once at creation.
+ * A create-once TTL drops a counter 90 days after it first appeared however
+ * much signal it has since accumulated; a sliding one reaps only keys that
+ * stopped receiving writes, which is precisely the unbounded tail (label,
+ * cluster and drawer-size hashes observed once and never again).
+ */
+export const ML_AGGREGATE_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+/**
+ * Keys the ingest handler deliberately never expires: running totals whose
+ * value is their whole history. Nothing refreshes their TTL, so granting one
+ * — from a backfill, say — would silently delete them 90 days later.
+ */
+export const ML_LIFETIME_KEYS: ReadonlySet<string> = new Set([
+  'ml:meta:total_events',
+  'ml:meta:last_updated',
+  'ml:meta:validation:passed',
+  'ml:meta:validation:failed',
+  'ml:meta:validation:failed_by_type',
+]);
+
+/** Whether `key` is an aggregate the ingest path keeps alive with a sliding TTL. */
+export function isExpiringAggregate(key: string): boolean {
+  return key.startsWith('ml:') && !ML_LIFETIME_KEYS.has(key);
+}

--- a/api/ml-telemetry.test.ts
+++ b/api/ml-telemetry.test.ts
@@ -3,11 +3,38 @@
  * telemetry must NEVER fail the client — without Redis it discards events
  * with a 200, and only genuine rate limiting produces a non-200. The
  * aggregation/validation internals are covered by the api/lib/mlTelemetry
- * tests; this file pins the handler's entry behavior.
+ * tests; this file pins the handler's entry behavior and its TTL policy.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { ML_AGGREGATE_TTL_SECONDS, ML_LIFETIME_KEYS } from './lib/mlTelemetry/retention.js';
+
+interface Recorded {
+  cmd: string;
+  args: unknown[];
+}
+
+const recorded: Recorded[] = [];
+
+vi.mock('ioredis', () => {
+  const makePipeline = (): Record<string, unknown> => {
+    const pipeline: Record<string, unknown> = { exec: async () => [] };
+    for (const cmd of ['hincrby', 'expire', 'incrby', 'set', 'zadd', 'zremrangebyscore']) {
+      pipeline[cmd] = (...args: unknown[]) => {
+        recorded.push({ cmd, args });
+        return pipeline;
+      };
+    }
+    return pipeline;
+  };
+  const client = { pipeline: makePipeline, zcount: async () => 0 };
+  // Must be `new`-able: the handler constructs its own client.
+  function Ctor(): typeof client {
+    return client;
+  }
+  return { Redis: Ctor, default: Ctor };
+});
 
 function createResponse() {
   const res = {
@@ -38,9 +65,39 @@ async function handle(method: string, body: unknown = []) {
   return res;
 }
 
+const BIN_PLACED = {
+  type: 'bin_placed',
+  bin_size: '2x3x4',
+  prev_bin_size: null,
+  drawer_size: '6x8x6',
+  position: '0,0',
+  layer_index: 0,
+  largest_gap: '4x5',
+  fill_pct: 50,
+  gap_fit: 'exact',
+  label_hash: 'a1b2c3d4',
+  label_normalized: null,
+  label_domain: null,
+  label_embedding_bucket: null,
+  category_id: 'cat-01',
+  adjacent_label_hashes: [],
+  adjacent_sizes: [],
+  adjacent_count: 0,
+  recent_sizes: [],
+  time_since_last_ms: null,
+  is_first_of_label: false,
+  method: 'draw',
+  session_index: 0,
+  vocab_version: 'v1',
+};
+
+const cmds = (name: string) => recorded.filter((r) => r.cmd === name);
+const keysOf = (name: string) => new Set(cmds(name).map((r) => r.args[0] as string));
+
 describe('ml-telemetry', () => {
   beforeEach(() => {
     vi.resetModules();
+    recorded.length = 0;
     delete process.env.REDIS_URL;
     delete process.env.VERCEL_ENV;
   });
@@ -65,5 +122,51 @@ describe('ml-telemetry', () => {
     const res = await handle('POST', [{ v: 1 }]);
     expect(res._status).toBe(200);
     expect(res._body).toEqual({ ok: true, processed: 0 });
+  });
+
+  describe('retention', () => {
+    beforeEach(() => {
+      process.env.REDIS_URL = 'redis://localhost:6379';
+    });
+
+    it('expires every aggregate it increments', async () => {
+      const res = await handle('POST', [BIN_PLACED]);
+      expect(res._body).toEqual({ ok: true, processed: 1, failed: 0 });
+
+      const incremented = [...keysOf('hincrby')].filter((k) => !ML_LIFETIME_KEYS.has(k));
+      const expired = keysOf('expire');
+
+      expect(incremented.length).toBeGreaterThan(5);
+      expect(incremented.filter((k) => !expired.has(k))).toEqual([]);
+    });
+
+    // The bug this replaces: an allowlist covered 4 of ~32 key shapes, so
+    // ml:label_hash:* and friends accumulated with no expiry at all.
+    it('expires the high-cardinality shapes that previously leaked', async () => {
+      await handle('POST', [BIN_PLACED]);
+      const expired = keysOf('expire');
+      expect(expired).toContain('ml:label_hash:a1b2c3d4');
+      expect(expired).toContain('ml:cat:cat-01');
+      expect(expired).toContain('ml:drawer:6x8x6');
+      expect(expired).toContain('ml:sizes');
+    });
+
+    // Sliding, not create-once: NX would delete a hot counter 90 days after
+    // it first appeared regardless of how much signal it had accumulated.
+    it('refreshes the TTL on every write rather than setting it once', async () => {
+      await handle('POST', [BIN_PLACED]);
+      const expires = cmds('expire').filter((r) => (r.args[0] as string).startsWith('ml:'));
+      expect(expires.length).toBeGreaterThan(0);
+      for (const { args } of expires) {
+        expect(args[1]).toBe(ML_AGGREGATE_TTL_SECONDS);
+        expect(args).toHaveLength(2);
+      }
+    });
+
+    it('never expires the running totals', async () => {
+      await handle('POST', [BIN_PLACED]);
+      const expired = keysOf('expire');
+      for (const key of ML_LIFETIME_KEYS) expect(expired).not.toContain(key);
+    });
   });
 });

--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -4,8 +4,10 @@
  * Receives batched telemetry events from clients and aggregates into Redis counters.
  * No raw events are stored - only aggregate counts for ML training.
  *
- * Every key below carries a sliding 90-day TTL (see ./lib/mlTelemetry/retention.ts),
- * so a hash that stops receiving writes ages out instead of accumulating forever.
+ * Aggregates carry a sliding 90-day TTL (see ./lib/mlTelemetry/retention.ts), so a
+ * hash that stops receiving writes ages out instead of accumulating forever. The
+ * running totals under Metadata are the exception — nothing refreshes them, so
+ * they are never given a TTL (ML_LIFETIME_KEYS).
  *
  * Redis Schema:
  *
@@ -106,13 +108,16 @@
  * - ml:cluster_archetypes:{hash} -> Archetype correlations per cluster
  * - ml:cluster_distribution   -> How common each structure hash is
  *
- * === Metadata ===
- * - ml:meta:*                 -> Metadata counters
+ * === Metadata (running totals — never expired) ===
+ * - ml:meta:total_events      -> Total events accepted
+ * - ml:meta:last_updated      -> ISO timestamp of the last accepted batch
  * - ml:meta:validation:passed -> Total events that passed validation
  * - ml:meta:validation:failed -> Total events that failed validation
- * - ml:meta:validation:failed:{type} -> Failed events by event type
- * - ml:meta:vocab_version:{version} -> Events by vocabulary version
- * - ml:meta:client_version:{version} -> Events by client version
+ * - ml:meta:validation:failed_by_type -> HASH of event type -> failed count
+ *
+ * === Metadata (expiring) ===
+ * - ml:meta:vocab_versions    -> HASH of vocabulary version -> event count
+ * - ml:meta:client_versions   -> HASH of client version -> event count
  */
 
 import { createHash } from 'crypto';

--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -4,6 +4,9 @@
  * Receives batched telemetry events from clients and aggregates into Redis counters.
  * No raw events are stored - only aggregate counts for ML training.
  *
+ * Every key below carries a sliding 90-day TTL (see ./lib/mlTelemetry/retention.ts),
+ * so a hash that stops receiving writes ages out instead of accumulating forever.
+ *
  * Redis Schema:
  *
  * === Bin Placement ===
@@ -12,7 +15,7 @@
  * - ml:drawer:{size}          -> Bin sizes per drawer size
  * - ml:label_hash:{hash}      -> Bin sizes per label hash (PRIMARY - any language, all events)
  * - ml:label_hash_high:{hash} -> Bin sizes per label hash, restricted to high-quality snapshots
- *                                (training source for the bin-size recommender; 90d TTL)
+ *                                (training source for the bin-size recommender)
  * - ml:label:{normalized}     -> Bin sizes per normalized label (ENRICHMENT)
  * - ml:label_domain:{domain}  -> Bin sizes per domain category (FALLBACK)
  * - ml:cat:{category}         -> Bin sizes per category
@@ -119,6 +122,7 @@ import type { RedisOptions } from 'ioredis';
 import { getClientIP } from './lib/rateLimit.js';
 import { logger } from './lib/logger.js';
 import type { Increments } from './lib/mlTelemetry/aggregators.js';
+import { ML_AGGREGATE_TTL_SECONDS } from './lib/mlTelemetry/retention.js';
 import {
   aggregateBinAbandonment,
   aggregateBinDeletion,
@@ -382,17 +386,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
         pipe.hincrby(hash, field, count);
       }
 
-      // Add TTLs for keys that can grow unbounded (90 days)
-      // These are lower-value or temporary data
-      // Use NX flag to only set TTL on first creation, not reset on every write
-      if (
-        hash === 'ml:unknown_hashes' ||
-        hash.startsWith('ml:size_seq:') ||
-        hash.startsWith('ml:cooccur:') ||
-        hash.startsWith('ml:label_hash_high:')
-      ) {
-        pipe.expire(hash, 90 * 24 * 60 * 60, 'NX'); // 90 days, only if no TTL exists
-      }
+      pipe.expire(hash, ML_AGGREGATE_TTL_SECONDS);
     }
 
     // Update metadata
@@ -414,21 +408,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       }
     }
 
-    // Track vocab versions (90 day TTL for version tracking)
     for (const [version, count] of Object.entries(vocabVersions)) {
       const safeVersion = version.replace(/[^a-z0-9_.]/gi, '_').slice(0, 16) || 'unknown';
       pipe.hincrby('ml:meta:vocab_versions', safeVersion, count);
     }
-    // Use NX flag to only set TTL on first creation, not reset on every write
-    pipe.expire('ml:meta:vocab_versions', 90 * 24 * 60 * 60, 'NX');
+    pipe.expire('ml:meta:vocab_versions', ML_AGGREGATE_TTL_SECONDS);
 
-    // Track client versions (90 day TTL for version tracking)
     for (const [version, count] of Object.entries(clientVersions)) {
       const safeVersion = version.replace(/[^a-z0-9_.]/gi, '_').slice(0, 16) || 'unknown';
       pipe.hincrby('ml:meta:client_versions', safeVersion, count);
     }
-    // Use NX flag to only set TTL on first creation, not reset on every write
-    pipe.expire('ml:meta:client_versions', 90 * 24 * 60 * 60, 'NX');
+    pipe.expire('ml:meta:client_versions', ML_AGGREGATE_TTL_SECONDS);
 
     await pipe.exec();
 

--- a/api/sync/README.md
+++ b/api/sync/README.md
@@ -95,7 +95,7 @@ The existing share endpoints (`/api/share`) run `filterLayoutContent` because sh
 
 1. `SMEMBERS users:{uid}:sessions` → `DEL session:{token}` for each
 2. `HKEYS users:{uid}:index:{layouts|designs}` → `del()` each blob
-3. `DEL users:{uid}:*` (indexes, profile, sessions set, indexUpdatedAt)
+3. `DEL users:{uid}:*` (indexes, profile, sessions set, indexUpdatedAt, tombstoneSweptAt)
 4. Clear session cookie on responding device
 
 Idempotent: each step uses unconditional `DEL`, so a partial-failure replay is safe. Per-blob errors are logged but don't block the cascade — leftover blobs are storage cost only. Worst-case time at 200 items × ~50 ms = ~10 s, well within Vercel's 60 s function limit.

--- a/api/sync/account.ts
+++ b/api/sync/account.ts
@@ -12,6 +12,7 @@ import {
   userIndexUpdatedAtKey,
   userProfileKey,
   userSessionsKey,
+  userTombstoneSweptAtKey,
 } from '../lib/redisKeys.js';
 
 /**
@@ -22,7 +23,8 @@ import {
  *   1. Sessions   — DEL session:{token} for every token in the user's set
  *                   (so other tabs/devices flip to anonymous on next sync)
  *   2. Blobs      — del() each layouts/{id}.json, designs/{id}.json, baseplates/{id}.json
- *   3. KV keys    — drop indexes, profile, sessions set, indexUpdatedAt
+ *   3. KV keys    — drop indexes, profile, sessions set, indexUpdatedAt,
+ *                   tombstoneSweptAt
  *   4. Cookie     — clear the session cookie on the responding device
  *
  * Idempotent on partial-failure replay: each step uses unconditional DEL,
@@ -80,7 +82,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       userIndexKey(userId, 'baseplates'),
       userIndexUpdatedAtKey(userId),
       userProfileKey(userId),
-      userSessionsKey(userId)
+      userSessionsKey(userId),
+      userTombstoneSweptAtKey(userId)
     );
 
     // 4. Clear the session cookie on the device making this request.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "check:component-structure": "./scripts/check-component-structure.sh",
     "seed-supporters": "tsx scripts/seed-supporters.ts",
     "sync-admin": "tsx scripts/sync-admin/index.ts",
+    "backfill-ml-ttls": "tsx scripts/backfill-ml-ttls.ts",
     "gen:example-thumbnails": "tsx --tsconfig tsconfig.app.json scripts/gen-example-thumbnails.ts",
     "bench": "vitest bench",
     "bench:json": "vitest bench --outputJson benchmarks/latest.json",

--- a/scripts/backfill-ml-ttls.ts
+++ b/scripts/backfill-ml-ttls.ts
@@ -1,0 +1,111 @@
+/**
+ * One-off backfill: grant a sliding TTL to `ml:*` aggregates written before
+ * the ingest path expired them.
+ *
+ * Run AFTER deploying the ingest change. Ordering is what makes this safe:
+ * once deployed, every write refreshes the TTL, so keys still receiving data
+ * keep sliding forward and only the dormant tail actually expires. Run it
+ * against a build that does not refresh and the whole corpus dies at T+90d.
+ *
+ *   pnpm backfill-ml-ttls            # dry run — report only
+ *   pnpm backfill-ml-ttls --apply    # set TTLs
+ */
+
+import { ML_AGGREGATE_TTL_SECONDS, isExpiringAggregate } from '../api/lib/mlTelemetry/retention.js';
+import { loadEnv } from './sync-admin/lib/env.js';
+import { connect, scanKeys } from './sync-admin/lib/redis.js';
+
+const CHUNK = 200;
+
+function namespaceOf(key: string): string {
+  const parts = key.split(':');
+  return parts.length > 2 ? `${parts[0]}:${parts[1]}:*` : key;
+}
+
+async function ttlMany(
+  redis: ReturnType<typeof connect>,
+  keys: readonly string[]
+): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  for (let i = 0; i < keys.length; i += CHUNK) {
+    const chunk = keys.slice(i, i + CHUNK);
+    const pipeline = redis.pipeline();
+    for (const key of chunk) pipeline.ttl(key);
+    const results = await pipeline.exec();
+    if (results === null) throw new Error('backfill-ml-ttls: redis pipeline failed');
+    results.forEach(([err, value], j) => {
+      if (err) throw err;
+      out.set(chunk[j], value as number);
+    });
+  }
+  return out;
+}
+
+async function main(): Promise<number> {
+  const apply = process.argv.includes('--apply');
+  loadEnv();
+  const redis = connect();
+
+  try {
+    const keys = await scanKeys(redis, 'ml:*');
+    const ttls = await ttlMany(redis, keys);
+
+    const needsTtl: string[] = [];
+    let alreadyExpiring = 0;
+    let lifetime = 0;
+
+    for (const key of keys) {
+      if (!isExpiringAggregate(key)) {
+        lifetime++;
+        continue;
+      }
+      // -1 is "exists, no TTL"; -2 is "already gone" (expired mid-scan).
+      if (ttls.get(key) === -1) needsTtl.push(key);
+      else alreadyExpiring++;
+    }
+
+    const byNamespace = new Map<string, number>();
+    for (const key of needsTtl) {
+      const ns = namespaceOf(key);
+      byNamespace.set(ns, (byNamespace.get(ns) ?? 0) + 1);
+    }
+
+    console.log(`scanned            ${keys.length} ml:* keys`);
+    console.log(`already expiring   ${alreadyExpiring}`);
+    console.log(`lifetime (skipped) ${lifetime}`);
+    console.log(`needs TTL          ${needsTtl.length}`);
+    console.log('');
+    for (const [ns, n] of [...byNamespace].sort((a, b) => b[1] - a[1]).slice(0, 20)) {
+      console.log(`  ${ns.padEnd(28)} ${n}`);
+    }
+
+    if (!apply) {
+      console.log(`\nDry run. Re-run with --apply to set a ${ML_AGGREGATE_TTL_SECONDS}s TTL.`);
+      return 0;
+    }
+
+    let set = 0;
+    for (let i = 0; i < needsTtl.length; i += CHUNK) {
+      const chunk = needsTtl.slice(i, i + CHUNK);
+      const pipeline = redis.pipeline();
+      for (const key of chunk) pipeline.expire(key, ML_AGGREGATE_TTL_SECONDS);
+      const results = await pipeline.exec();
+      if (results === null) throw new Error('backfill-ml-ttls: redis pipeline failed');
+      results.forEach(([err, value]) => {
+        if (err) throw err;
+        if (value === 1) set++;
+      });
+    }
+    console.log(`\nSet TTL on ${set} keys.`);
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });

--- a/scripts/backfill-ml-ttls.ts
+++ b/scripts/backfill-ml-ttls.ts
@@ -53,14 +53,18 @@ async function main(): Promise<number> {
     const needsTtl: string[] = [];
     let alreadyExpiring = 0;
     let lifetime = 0;
+    let vanished = 0;
 
     for (const key of keys) {
       if (!isExpiringAggregate(key)) {
         lifetime++;
         continue;
       }
-      // -1 is "exists, no TTL"; -2 is "already gone" (expired mid-scan).
-      if (ttls.get(key) === -1) needsTtl.push(key);
+      const ttl = ttls.get(key);
+      if (ttl === -1) needsTtl.push(key);
+      // -2 means the key expired between SCAN and TTL. Counting it as
+      // "already expiring" would mask drift between the two passes.
+      else if (ttl === -2) vanished++;
       else alreadyExpiring++;
     }
 
@@ -73,6 +77,7 @@ async function main(): Promise<number> {
     console.log(`scanned            ${keys.length} ml:* keys`);
     console.log(`already expiring   ${alreadyExpiring}`);
     console.log(`lifetime (skipped) ${lifetime}`);
+    console.log(`vanished mid-scan  ${vanished}`);
     console.log(`needs TTL          ${needsTtl.length}`);
     console.log('');
     for (const [ns, n] of [...byNamespace].sort((a, b) => b[1] - a[1]).slice(0, 20)) {

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -18,5 +18,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["scripts/sync-admin/**/*.ts"]
+  "include": ["scripts/sync-admin/**/*.ts", "scripts/backfill-ml-ttls.ts"]
 }


### PR DESCRIPTION
## Why

Vercel alerted at 80% of the Redis dataset cap. Auditing production found the cause: **ML telemetry is ~90% of the dataset and 55.6% of all Redis commands.**

`api/ml-telemetry.ts` set a TTL on 4 of ~32 key shapes. Everything else — `ml:label_hash:*`, `ml:cat:*`, `ml:clusters:*`, `ml:drawer_sizes:*` and ~24 more — was written with no expiry at all. Measured in production:

```
143,117 keys total, only 13,464 (9.4%) with any TTL
134,283 ml:* keys  (93.8% of the keyspace)
123,099 ml:* keys with no TTL
 61,346 ml:label_hash:* alone, median 1 field per key
```

Key count is the cost driver, not value size: measured payload is ~13 MB against 24 MB `used_memory`, the gap being per-key overhead.

## The subtler bug

The four shapes that *did* have a TTL used `EXPIRE ... NX`. `NX` starts the clock at creation and never resets, so a hot counter was **deleted 90 days after it first appeared regardless of how much signal it had since accumulated**. That is data loss, not retention.

This switches to a **sliding** TTL, refreshed on every write. Keys still receiving data slide forward indefinitely; only the dormant tail expires. That also makes applying it unconditionally safe — bounded global counters like `ml:sizes` are written on nearly every flush — so the allowlist that silently omitted 28 shapes is gone rather than extended.

`ml:meta` running totals stay TTL-less: nothing refreshes them, so granting one would delete them 90 days later. `ML_LIFETIME_KEYS` pins that asymmetry in one place, shared with the backfill script so the two cannot drift.

## Also

`DELETE /api/sync/account` DEL'd six per-user keys but missed `users:{uid}:tombstoneSweptAt` — 1,207 orphaned in production.

## Backfill

`scripts/backfill-ml-ttls.ts` grants the TTL to keys written before this change. Dry run by default; verified against production:

```
scanned            134305 ml:* keys
already expiring   11201
lifetime (skipped) 5
needs TTL          123099
```

**Ordering matters:** run it only after this deploys. Writes are what refresh expiry, so running it against a build that does not refresh would put the whole corpus on a 90-day fuse.

## Retention change

Cold single-observation keys now age out after 90 days of no writes. `scripts/train-bin-recommender/train.py` reads these keys; the long tail it loses is overwhelmingly labels seen exactly once (158 of 200 sampled `ml:label_hash:*` had a single field).

## Testing

`api/ml-telemetry.test.ts` gains a mocked-Redis suite asserting every incremented aggregate is expired, that the previously-leaking shapes are covered, that no `EXPIRE` carries `NX`, and that lifetime totals are never expired. Confirmed these fail against the pre-fix handler:

```
× expires every aggregate it increments
    expected [ 'ml:sizes', 'ml:drawer:6x8x6', …(5) ] to deeply equal []
× expires the high-cardinality shapes that previously leaked
    expected [ …(4) ] to include 'ml:label_hash:a1b2c3d4'
× refreshes the TTL on every write rather than setting it once
    expected [ 'ml:unknown_hashes', 7776000, 'NX' ] to have a length of 2 but got 3
```

`pnpm exec vitest run api/` — 1128 passed. `pnpm run typecheck`, `check:test-types`, and eslint on changed files all clean.

## Note

The store was separately moved off the Free 30 MB plan to 250 MB, which also lifted throughput 100 → 1,000 ops/sec and connections 30 → 256. Measured peak was **96.7 ops/sec against the old 100/sec cap** — the tighter of the two ceilings, though nothing had been rejected yet (`rejected_calls: 0`). This PR addresses the growth that caused it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply a sliding 90-day TTL to all ML telemetry aggregates to stop unbounded Redis growth; includes a backfill for existing keys. Also corrects metadata docs and deletes `users:{uid}:tombstoneSweptAt` during account deletion.

- **Bug Fixes**
  - Expire every `ml:*` aggregate with a sliding TTL; removed `EXPIRE ... NX` and the allowlist.
  - Centralized retention in `api/lib/mlTelemetry/retention.ts`; pinned lifetime totals via `ML_LIFETIME_KEYS`.
  - `ml:meta:vocab_versions` and `ml:meta:client_versions` now use the sliding TTL.
  - Updated handler schema header to split expiring vs never-expiring metadata and document `ml:meta:total_events`/`ml:meta:last_updated`.
  - Backfill now reports TTL `-2` keys as “vanished mid-scan” instead of “already expiring”.
  - Added tests to verify sliding TTLs and lifetime exceptions.

- **Migration**
  - After deploying, run the backfill to grant TTLs to existing keys: `pnpm backfill-ml-ttls --apply` (dry run by default).
  - Run only post-deploy so active keys keep sliding while dormant ones expire.

<sup>Written for commit dd0cfcfe9d8bc03c6c2fe0091416b1a0cf5b90d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

