### PR TITLE
fix(lint): ignore git worktree directories

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,10 @@ import noInitTimeImportedCall from './eslint-rules/no-init-time-imported-call.js
 const literal = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage', 'e2e', 'scripts', 'benchmarks', 'reports', 'brep-parts', 'playwright.config.ts', 'playwright.smoke.config.ts', 'playwright-ct.config.ts', 'playwright', '**/*.visual.tsx', 'src/test/setup.ts']),
+  // `.worktrees` / `.claude/worktrees` hold git worktrees — each is a full copy
+  // of the repo. Both are gitignored, but flat config does not read .gitignore,
+  // so without these `eslint .` type-checks every checkout at once and OOMs.
+  globalIgnores(['dist', 'coverage', 'e2e', 'scripts', 'benchmarks', 'reports', 'brep-parts', 'playwright.config.ts', 'playwright.smoke.config.ts', 'playwright-ct.config.ts', 'playwright', '**/*.visual.tsx', 'src/test/setup.ts', '.worktrees', '.claude/worktrees']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [


### PR DESCRIPTION
## Problem

`eslint .` from a checkout that has git worktrees under `.worktrees/` or `.claude/worktrees/` walks every one of them. Each worktree is a **full copy of the repo**, so type-aware linting builds a program per checkout and the run dies:

```
FatalProcessOutOfMemory
[ELIFECYCLE] Command failed.
timeout: the monitored command dumped core
```

`NODE_OPTIONS=--max-old-space-size=8192` is already set on the `lint` script and does not help — it's linting several entire codebases at once.

Both paths are gitignored, but ESLint flat config does not read `.gitignore`, so they have to be named in `globalIgnores` explicitly.

CI never saw this: it lints a fresh clone with no worktrees. It only bites locally, and it bites hardest during parallel-agent work, where several worktrees are the normal state.

## Verification

Confirmed causal rather than incidental, on the same tree with one worktree present:

| Config | Result |
|---|---|
| entries removed | dumps core (OOM) |
| entries restored | exits 0 |

And the fix doesn't change what actually gets linted — identical output with and without a worktree present:

```
✖ 29 problems (0 errors, 29 warnings)
```

Same 29 pre-existing warnings in both cases, so nothing that should be linted has been ignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore Git worktree directories in ESLint to prevent out-of-memory crashes when running `eslint .` on repos with worktrees. Lint results are unchanged; this only stops scanning duplicate checkouts.

- **Bug Fixes**
  - Added `.worktrees` and `.claude/worktrees` to `globalIgnores` in `eslint.config.js` (flat config doesn’t read `.gitignore`).
  - Prevents type-aware linting from walking full duplicate repos in worktrees and OOMing locally.

<sup>Written for commit b034dcb943d50950b9a8a5ed0dadcf5edde7a88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

