### PR TITLE
docs(security): note committed pnpm patches reproduce on a clean install

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,6 +84,16 @@ target versions are frozen, so the patches won't rot), then routed to
 `minimatch@3` and `brace-expansion@1.x` from the tree entirely, so the scan goes
 green on the version the advisory itself names as fixed.
 
+**Committed `pnpm patch`es reproduce on a clean install.** The three patches in
+[`patches/`](patches/) (the two above, plus a `brepjs` OCCT-handle-disposal fix)
+are each pinned by a content `patch_hash` in [`pnpm-lock.yaml`](pnpm-lock.yaml),
+so `pnpm install --frozen-lockfile` re-hashes every committed patch against the
+lockfile and **fails closed on any drift** — a patched dependency can't silently
+revert to its unpatched (or a tampered) form, and a missing patch file breaks the
+install rather than shipping an unmodified package. Verified against a fresh
+GitHub clone installed into an empty pnpm store: each patched package is
+re-derived from its committed patch file, not copied from a cached variant.
+
 **Adding a build script allow-list entry** (`allowBuilds`) is a security
 decision. Audit the package's postinstall behavior before adding.
 


### PR DESCRIPTION
Adds a Supply Chain note to `SECURITY.md` documenting that the three committed `pnpm patch`es (`jsx-a11y`, `@ts-morph/common`, and the `brepjs` OCCT-handle-disposal fix) are pinned by a content `patch_hash` in `pnpm-lock.yaml`, so:

- `pnpm install --frozen-lockfile` re-hashes each committed patch against the lockfile and **fails closed on any drift** — a patched dependency can't silently revert to its unpatched (or tampered) form, and a missing patch file breaks the install rather than shipping an unmodified package.

**Verification performed:** a fresh GitHub clone of `main` installed into an *isolated empty* pnpm store (806M, not the shared cache). `--frozen-lockfile` exited 0 (all committed patch hashes matched the lockfile), and the resolved `brepjs` bundle contained the patch's `intersectCurves` bbox-disposal in both dist files — proving the patched package is **re-derived from the committed patch file**, not copied from a cached variant.

Docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update SECURITY.md to document that the three committed `pnpm patch`es (`jsx-a11y`, `@ts-morph/common`, `brepjs`) are pinned via `patch_hash` in `pnpm-lock.yaml` and verified by `pnpm install --frozen-lockfile`. This ensures clean installs reproduce the patches and fail closed on any drift or missing files.

<sup>Written for commit b85c95f48c4da675290fa185f8baeb26ab7d41b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

