### PR TITLE
perf(rate-limit): collapse the sliding window into one atomic Lua call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,10 @@ jobs:
           SHARD: ${{ matrix.shard }}
         run: |
           if [ "$GIT_REF" = "refs/heads/main" ]; then
+            # Projects are named explicitly rather than using the default "all":
+            # `integration` needs a Redis service and runs as its own job.
             echo "Running full suite with coverage (main branch)"
-            pnpm vitest run --coverage -u
+            pnpm vitest run --coverage -u --project=unit --project=dom --project=generators
           elif [ "$GROUP" = "generators" ]; then
             echo "Running generators project (shard $SHARD)"
             pnpm vitest run --project=generators --shard="$SHARD" -u
@@ -115,6 +117,40 @@ jobs:
           path: coverage/
           retention-days: 5
 
+  # Tests that need a real Redis. The rate limiter runs as a Lua script, and a
+  # mocked ioredis can only assert the command was issued — it cannot execute
+  # the body, so enforcement and atomicity are unverifiable without a server.
+  # One container here rather than a service on all nine Unit Tests shards.
+  integration:
+    name: Integration Tests
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pnpm + Node and install dependencies
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Generate artifacts
+        run: pnpm run build:en-locale
+
+      - name: Run integration tests
+        env:
+          REDIS_TEST_URL: redis://localhost:6379
+        run: pnpm vitest run --project=integration
+
   # Single stable gate that passes only if every Unit Tests shard passed.
   # Branch protection requires this one context instead of the individual
   # shard names, so shard/group counts can change without updating the ruleset.
@@ -122,19 +158,25 @@ jobs:
   # release-please PRs in lockstep with the test job above.
   test-gate:
     name: Unit Tests Complete
-    needs: [test]
+    needs: [test, integration]
     if: ${{ always() && !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify all unit-test shards passed
         env:
           TEST_RESULT: ${{ needs.test.result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
         run: |
           if [ "$TEST_RESULT" != "success" ]; then
             echo "Unit test shards did not all pass (result: $TEST_RESULT)"
             exit 1
           fi
-          echo "All unit-test shards passed."
+          # Folded in here so branch protection keeps requiring one context.
+          if [ "$INTEGRATION_RESULT" != "success" ]; then
+            echo "Integration tests did not pass (result: $INTEGRATION_RESULT)"
+            exit 1
+          fi
+          echo "All unit-test shards and integration tests passed."
 
   # PRs + main: Lint, i18n, module boundaries, union exhaustiveness
   # All checks run to completion so every failure is visible in one pass

--- a/api/README.md
+++ b/api/README.md
@@ -174,3 +174,7 @@ Share creation uses `put({ allowOverwrite: false })` as an atomic CAS lock — c
 7. **Liveblocks optional** — fails gracefully if `LIVEBLOCKS_SECRET_KEY` not set
 8. **Content filter minimal** — ~30 term blocklist; production should supplement with external service
 9. **IP hashing for privacy** — rate limiter hashes IP with SHA-256 before using as Redis key
+10. **Rate limiting is one atomic call** — check-and-consume runs as a Lua script, so concurrent
+    requests can't each read a below-limit count and all be admitted. Its behaviour is covered by
+    `api/lib/rateLimit.integration.test.ts` against a real Redis; a mocked ioredis cannot execute
+    the script, so changes to it are unverified by the unit suites.

--- a/api/lib/mlTelemetry/retention.test.ts
+++ b/api/lib/mlTelemetry/retention.test.ts
@@ -22,12 +22,16 @@ describe('ML telemetry retention policy', () => {
     expect(isExpiringAggregate(key)).toBe(false);
   });
 
-  // ml_ratelimit:* carries its own 120s TTL and is not an aggregate; the
-  // underscore keeps it out of an `ml:*` SCAN, and out of this predicate.
-  it.each(['ml_ratelimit:be667baa342372ce', 'session:abc', 'users:abc:profile'])(
-    'ignores the non-aggregate key %s',
-    (key) => {
-      expect(isExpiringAggregate(key)).toBe(false);
-    }
-  );
+  // Rate-limit keys carry their own short TTL and are not aggregates. The
+  // legacy `ml_ratelimit:*` namespace stays covered here because its underscore
+  // keeps it out of an `ml:*` SCAN — the property that matters for any such key
+  // outliving the move to the shared `ratelimit:telemetry:*` namespace.
+  it.each([
+    'ml_ratelimit:be667baa342372ce',
+    'ratelimit:telemetry:be667baa342372ce',
+    'session:abc',
+    'users:abc:profile',
+  ])('ignores the non-aggregate key %s', (key) => {
+    expect(isExpiringAggregate(key)).toBe(false);
+  });
 });

--- a/api/lib/rateLimit.integration.test.ts
+++ b/api/lib/rateLimit.integration.test.ts
@@ -8,8 +8,9 @@
  * Requires REDIS_TEST_URL (CI supplies a redis:7-alpine service container).
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { Redis } from 'ioredis';
+import type * as RateLimitModule from './rateLimit.js';
 
 const REDIS_TEST_URL = process.env.REDIS_TEST_URL;
 
@@ -20,6 +21,7 @@ if (!REDIS_TEST_URL && process.env.CI) {
 
 describe.skipIf(!REDIS_TEST_URL)('rate limiter (real Redis)', () => {
   let probe: Redis;
+  let loaded: typeof RateLimitModule | null = null;
 
   beforeAll(() => {
     process.env.REDIS_URL = REDIS_TEST_URL;
@@ -35,9 +37,17 @@ describe.skipIf(!REDIS_TEST_URL)('rate limiter (real Redis)', () => {
     vi.resetModules();
   });
 
+  // Each reset orphans the previous module's memoized client. Left open they
+  // accumulate one connection per test and can hang the run on open handles.
+  afterEach(async () => {
+    await loaded?.getRedis()?.quit();
+    loaded = null;
+  });
+
   // Fresh module per test: getRedis() memoizes its client and the script.
   async function limiter() {
-    return await import('./rateLimit.js');
+    loaded = await import('./rateLimit.js');
+    return loaded;
   }
 
   it('admits up to the limit and denies past it', async () => {
@@ -104,6 +114,34 @@ describe.skipIf(!REDIS_TEST_URL)('rate limiter (real Redis)', () => {
     expect((await checkRateLimit('ages-out', 'auth.start')).allowed).toBe(true);
     // The consume pass also prunes what it just aged past.
     expect(await probe.zcard(key)).toBe(1);
+  });
+
+  // The count floor is exclusive and the prune inclusive, so an entry sitting
+  // exactly on the boundary is not counted by the same call that deletes it.
+  // Date is frozen because at real time this passes either way once the clock
+  // ticks past the boundary, which would make it useless as a regression test.
+  it('excludes an entry sitting exactly on the window floor', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      const fixedMs = 1_800_000_000_000;
+      vi.setSystemTime(fixedMs);
+      const now = Math.floor(fixedMs / 1000);
+
+      const { checkRateLimit } = await limiter();
+      const { rateLimitKey } = await import('./redisKeys.js');
+      const { createHash } = await import('crypto');
+      const scope = createHash('sha256').update('boundary').digest('hex').slice(0, 16);
+      const key = rateLimitKey('auth.start', scope);
+
+      // A full budget parked exactly on the floor; an inclusive count denies.
+      for (let i = 0; i < 30; i++) await probe.zadd(key, now - 60, `boundary-${i}`);
+
+      expect((await checkRateLimit('boundary', 'auth.start')).allowed).toBe(true);
+      // The same call prunes them, so only the entry just written survives.
+      expect(await probe.zcard(key)).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('reports a retry-after that is never in the past', async () => {

--- a/api/lib/rateLimit.integration.test.ts
+++ b/api/lib/rateLimit.integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Rate limiter against a real Redis.
+ *
+ * The unit suites mock ioredis, which can only assert that a command was
+ * issued — it cannot execute the Lua body, so every claim about enforcement,
+ * window expiry and atomicity is unverifiable there. These run the script.
+ *
+ * Requires REDIS_TEST_URL (CI supplies a redis:7-alpine service container).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { Redis } from 'ioredis';
+
+const REDIS_TEST_URL = process.env.REDIS_TEST_URL;
+
+// A bare `describe` that never runs reads as a pass; fail loudly in CI instead.
+if (!REDIS_TEST_URL && process.env.CI) {
+  throw new Error('REDIS_TEST_URL must be set in CI — the integration project cannot be skipped');
+}
+
+describe.skipIf(!REDIS_TEST_URL)('rate limiter (real Redis)', () => {
+  let probe: Redis;
+
+  beforeAll(() => {
+    process.env.REDIS_URL = REDIS_TEST_URL;
+    probe = new Redis(REDIS_TEST_URL as string);
+  });
+
+  afterAll(async () => {
+    await probe.quit();
+  });
+
+  beforeEach(async () => {
+    await probe.flushdb();
+    vi.resetModules();
+  });
+
+  // Fresh module per test: getRedis() memoizes its client and the script.
+  async function limiter() {
+    return await import('./rateLimit.js');
+  }
+
+  it('admits up to the limit and denies past it', async () => {
+    const { checkRateLimit } = await limiter();
+    // 'auth.start' is 30/min — small enough to exhaust quickly.
+    const results = [];
+    for (let i = 0; i < 31; i++) results.push(await checkRateLimit('1.2.3.4', 'auth.start'));
+
+    expect(results.slice(0, 30).every((r) => r.allowed)).toBe(true);
+    expect(results[30].allowed).toBe(false);
+    expect(results[30].remaining).toBe(0);
+  });
+
+  it('counts down remaining accurately', async () => {
+    const { checkRateLimit } = await limiter();
+    expect((await checkRateLimit('ip-a', 'auth.start')).remaining).toBe(29);
+    expect((await checkRateLimit('ip-a', 'auth.start')).remaining).toBe(28);
+    expect((await checkRateLimit('ip-a', 'auth.start')).remaining).toBe(27);
+  });
+
+  it('scopes budgets independently', async () => {
+    const { checkRateLimit } = await limiter();
+    for (let i = 0; i < 30; i++) await checkRateLimit('noisy', 'auth.start');
+
+    expect((await checkRateLimit('noisy', 'auth.start')).allowed).toBe(false);
+    expect((await checkRateLimit('quiet', 'auth.start')).allowed).toBe(true);
+  });
+
+  it('separates budgets per action', async () => {
+    const { checkRateLimit } = await limiter();
+    for (let i = 0; i < 30; i++) await checkRateLimit('same-ip', 'auth.start');
+
+    expect((await checkRateLimit('same-ip', 'auth.start')).allowed).toBe(false);
+    expect((await checkRateLimit('same-ip', 'auth.callback')).allowed).toBe(true);
+  });
+
+  // The reason this rewrite exists: the old read-then-write pair let concurrent
+  // callers each observe a below-limit count and all be admitted.
+  it('admits exactly the limit under concurrent callers', async () => {
+    const { checkRateLimit } = await limiter();
+    const results = await Promise.all(
+      Array.from({ length: 60 }, () => checkRateLimit('thundering-herd', 'auth.start'))
+    );
+
+    expect(results.filter((r) => r.allowed)).toHaveLength(30);
+    expect(results.filter((r) => !r.allowed)).toHaveLength(30);
+  });
+
+  it('drops entries that age out of the window', async () => {
+    const { checkRateLimit } = await limiter();
+    const { rateLimitKey } = await import('./redisKeys.js');
+    const { createHash } = await import('crypto');
+
+    for (let i = 0; i < 30; i++) await checkRateLimit('ages-out', 'auth.start');
+    expect((await checkRateLimit('ages-out', 'auth.start')).allowed).toBe(false);
+
+    // Backdate every entry past the 60s window rather than waiting on wall time.
+    const scope = createHash('sha256').update('ages-out').digest('hex').slice(0, 16);
+    const key = rateLimitKey('auth.start', scope);
+    const entries = await probe.zrange(key, 0, -1);
+    const stale = Math.floor(Date.now() / 1000) - 120;
+    for (const entry of entries) await probe.zadd(key, stale, entry);
+
+    expect((await checkRateLimit('ages-out', 'auth.start')).allowed).toBe(true);
+    // The consume pass also prunes what it just aged past.
+    expect(await probe.zcard(key)).toBe(1);
+  });
+
+  it('reports a retry-after that is never in the past', async () => {
+    const { checkRateLimit } = await limiter();
+    for (let i = 0; i < 30; i++) await checkRateLimit('retry-after', 'auth.start');
+
+    const denied = await checkRateLimit('retry-after', 'auth.start');
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBeGreaterThan(0);
+    expect(denied.retryAfterSeconds).toBeLessThanOrEqual(60);
+    expect(denied.resetAt).toBeGreaterThanOrEqual(Math.floor(Date.now() / 1000));
+  });
+
+  it('expires the key so idle scopes cost nothing', async () => {
+    const { checkRateLimit } = await limiter();
+    const { rateLimitKey } = await import('./redisKeys.js');
+    const { createHash } = await import('crypto');
+
+    await checkRateLimit('ttl-check', 'auth.start');
+    const scope = createHash('sha256').update('ttl-check').digest('hex').slice(0, 16);
+    const ttl = await probe.ttl(rateLimitKey('auth.start', scope));
+
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(120); // windowSeconds + 60
+  });
+
+  // ioredis issues EVALSHA and re-sends the body on NOSCRIPT. Without that,
+  // every limiter call after a Redis restart or SCRIPT FLUSH would fail closed
+  // and lock users out of auth and share.
+  it('recovers from SCRIPT FLUSH without failing closed', async () => {
+    const { checkRateLimit } = await limiter();
+    expect((await checkRateLimit('flushed', 'auth.start')).allowed).toBe(true);
+
+    await probe.script('FLUSH');
+
+    expect((await checkRateLimit('flushed', 'auth.start')).allowed).toBe(true);
+  });
+
+  it('consumes exactly one slot per call', async () => {
+    const { checkRateLimit } = await limiter();
+    const { rateLimitKey } = await import('./redisKeys.js');
+    const { createHash } = await import('crypto');
+
+    for (let i = 0; i < 5; i++) await checkRateLimit('one-each', 'auth.start');
+
+    const scope = createHash('sha256').update('one-each').digest('hex').slice(0, 16);
+    expect(await probe.zcard(rateLimitKey('auth.start', scope))).toBe(5);
+  });
+});

--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -81,8 +81,48 @@ interface RateLimitResult {
   retryAfterSeconds?: number;
 }
 
+/**
+ * Sliding-window check-and-consume as a single command.
+ *
+ * This previously ran as four sequential awaits (ZCOUNT, ZADD,
+ * ZREMRANGEBYSCORE, EXPIRE). Beyond the four round trips, the gap between
+ * reading the count and writing the entry let concurrent callers each observe
+ * a below-limit count and all be admitted. A script closes that window.
+ *
+ * The denial branch reads the oldest entry *inside* the window rather than the
+ * oldest overall: cleanup only runs on the allow path, so a key under sustained
+ * denial retains entries older than `windowStart`, and using one of those would
+ * produce a resetAt in the past.
+ *
+ * Returns [allowed, remaining, oldestScoreInWindow].
+ */
+const SLIDING_WINDOW_LUA = `
+local count = redis.call('ZCOUNT', KEYS[1], ARGV[1], '+inf')
+local limit = tonumber(ARGV[2])
+if count >= limit then
+  local oldest = redis.call('ZRANGEBYSCORE', KEYS[1], ARGV[1], '+inf', 'WITHSCORES', 'LIMIT', 0, 1)
+  return {0, 0, oldest[2] or '0'}
+end
+redis.call('ZADD', KEYS[1], ARGV[3], ARGV[4])
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
+redis.call('EXPIRE', KEYS[1], ARGV[5])
+return {1, limit - count - 1, '0'}
+`;
+
+/** `defineCommand` attaches the script as a method; declare its shape for callers. */
+interface RateLimitRedis extends Redis {
+  slidingWindowRateLimit(
+    key: string,
+    windowStart: string,
+    limit: string,
+    now: string,
+    entryId: string,
+    ttlSeconds: string
+  ): Promise<[number, number, string]>;
+}
+
 // Lazy-initialize Redis connection
-let redis: Redis | null = null;
+let redis: RateLimitRedis | null = null;
 
 export function getRedis(): Redis | null {
   if (!process.env.REDIS_URL) {
@@ -90,12 +130,19 @@ export function getRedis(): Redis | null {
   }
   if (!redis) {
     const urlConfig = parseRedisUrl(process.env.REDIS_URL);
-    redis = new Redis({
+    const client = new Redis({
       ...urlConfig,
       maxRetriesPerRequest: 1,
       connectTimeout: 5000,
       commandTimeout: 5000,
     });
+    // ioredis sends EVALSHA and transparently re-loads the body on NOSCRIPT,
+    // so a Redis restart or SCRIPT FLUSH recovers without any handling here.
+    client.defineCommand('slidingWindowRateLimit', {
+      numberOfKeys: 1,
+      lua: SLIDING_WINDOW_LUA,
+    });
+    redis = client as RateLimitRedis;
   }
   return redis;
 }
@@ -132,16 +179,22 @@ export async function checkRateLimit(
   }
 
   try {
-    // Get current count within window
-    const count = await client.zcount(key, windowStart, '+inf');
+    const entryId = `${now}:${Math.random().toString(36).slice(2, 8)}`;
+    const [allowed, remaining, oldestScore] = await (
+      client as RateLimitRedis
+    ).slidingWindowRateLimit(
+      key,
+      String(windowStart),
+      String(config.limit),
+      String(now),
+      entryId,
+      String(config.windowSeconds + 60)
+    );
 
-    if (count >= config.limit) {
-      // Get oldest entry to calculate reset time
-      const oldest = await client.zrange(key, 0, 0, 'WITHSCORES');
+    if (allowed === 0) {
+      const oldest = Number(oldestScore);
       const resetAt =
-        oldest.length > 1
-          ? Math.ceil(Number(oldest[1]) + config.windowSeconds)
-          : now + config.windowSeconds;
+        oldest > 0 ? Math.ceil(oldest + config.windowSeconds) : now + config.windowSeconds;
 
       return {
         allowed: false,
@@ -151,17 +204,9 @@ export async function checkRateLimit(
       };
     }
 
-    // Add new entry with current timestamp as score
-    const entryId = `${now}:${Math.random().toString(36).slice(2, 8)}`;
-    await client.zadd(key, now, entryId);
-
-    // Clean up old entries and set TTL
-    await client.zremrangebyscore(key, 0, windowStart);
-    await client.expire(key, config.windowSeconds + 60);
-
     return {
       allowed: true,
-      remaining: config.limit - count - 1,
+      remaining,
       resetAt: now + config.windowSeconds,
     };
   } catch (error) {

--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -94,13 +94,18 @@ interface RateLimitResult {
  * denial retains entries older than `windowStart`, and using one of those would
  * produce a resetAt in the past.
  *
+ * The window floor is exclusive so it agrees with the inclusive prune below.
+ * Counting an entry at exactly `windowStart` while the same call deletes it
+ * would let a scope be denied on the strength of a slot it just gave up.
+ *
  * Returns [allowed, remaining, oldestScoreInWindow].
  */
 const SLIDING_WINDOW_LUA = `
-local count = redis.call('ZCOUNT', KEYS[1], ARGV[1], '+inf')
+local floor = '(' .. ARGV[1]
+local count = redis.call('ZCOUNT', KEYS[1], floor, '+inf')
 local limit = tonumber(ARGV[2])
 if count >= limit then
-  local oldest = redis.call('ZRANGEBYSCORE', KEYS[1], ARGV[1], '+inf', 'WITHSCORES', 'LIMIT', 0, 1)
+  local oldest = redis.call('ZRANGEBYSCORE', KEYS[1], floor, '+inf', 'WITHSCORES', 'LIMIT', 0, 1)
   return {0, 0, oldest[2] or '0'}
 end
 redis.call('ZADD', KEYS[1], ARGV[3], ARGV[4])

--- a/api/ml-telemetry.test.ts
+++ b/api/ml-telemetry.test.ts
@@ -28,8 +28,15 @@ vi.mock('ioredis', () => {
     }
     return pipeline;
   };
-  const client = { pipeline: makePipeline, zcount: async () => 0 };
-  // Must be `new`-able: the handler constructs its own client.
+  const client = {
+    pipeline: makePipeline,
+    // The shared limiter registers its Lua script via defineCommand. The script
+    // body is covered by the integration project against real Redis; here it
+    // only has to resolve as "allowed" so the handler proceeds.
+    defineCommand: () => undefined,
+    slidingWindowRateLimit: async (): Promise<[number, number, string]> => [1, 99, '0'],
+  };
+  // Must be `new`-able: the limiter constructs its own client.
   function Ctor(): typeof client {
     return client;
   }

--- a/api/ml-telemetry.ts
+++ b/api/ml-telemetry.ts
@@ -120,11 +120,8 @@
  * - ml:meta:client_versions   -> HASH of client version -> event count
  */
 
-import { createHash } from 'crypto';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { Redis } from 'ioredis';
-import type { RedisOptions } from 'ioredis';
-import { getClientIP } from './lib/rateLimit.js';
+import { checkRateLimit, getClientIP, getRedis } from './lib/rateLimit.js';
 import { logger } from './lib/logger.js';
 import type { Increments } from './lib/mlTelemetry/aggregators.js';
 import { ML_AGGREGATE_TTL_SECONDS } from './lib/mlTelemetry/retention.js';
@@ -150,82 +147,6 @@ import {
   aggregateUndo,
 } from './lib/mlTelemetry/aggregators.js';
 import { validateEvent } from './lib/mlTelemetry/validators.js';
-
-// ============================================
-// REDIS CONNECTION
-// ============================================
-
-/**
- * Parse Redis URL using WHATWG URL API to avoid deprecated url.parse().
- * ioredis accepts URL strings but uses the legacy url.parse() internally.
- */
-function parseRedisUrl(redisUrl: string): RedisOptions {
-  const url = new URL(redisUrl);
-  return {
-    host: url.hostname,
-    port: url.port ? parseInt(url.port, 10) : 6379,
-    password: url.password || undefined,
-    username: url.username || undefined,
-    tls: url.protocol === 'rediss:' ? {} : undefined,
-    db: url.pathname ? parseInt(url.pathname.slice(1), 10) || 0 : 0,
-  };
-}
-
-let redis: Redis | null = null;
-
-function getRedis(): Redis | null {
-  if (!process.env.REDIS_URL) {
-    return null;
-  }
-  if (!redis) {
-    const urlConfig = parseRedisUrl(process.env.REDIS_URL);
-    redis = new Redis({
-      ...urlConfig,
-      maxRetriesPerRequest: 1,
-      connectTimeout: 5000,
-      commandTimeout: 5000,
-    });
-  }
-  return redis;
-}
-
-// ============================================
-// RATE LIMITING
-// ============================================
-
-/**
- * Internal rate limiting for ML telemetry endpoint.
- * Uses the same Redis client as aggregation operations.
- * 100 requests per minute per IP.
- */
-async function checkRateLimitInternal(ip: string, client: Redis): Promise<boolean> {
-  const hashedIP = hashIP(ip);
-  const key = `ml_ratelimit:${hashedIP}`;
-  const now = Math.floor(Date.now() / 1000);
-  const windowStart = now - 60;
-
-  try {
-    const count = await client.zcount(key, windowStart, '+inf');
-    if (count >= 100) {
-      return false;
-    }
-
-    const pipe = client.pipeline();
-    pipe.zadd(key, now, `${now}-${Math.random()}`);
-    pipe.zremrangebyscore(key, '-inf', windowStart);
-    pipe.expire(key, 120);
-    await pipe.exec();
-
-    return true;
-  } catch {
-    // On error, deny the request (fail-closed, consistent with main rate limiter)
-    return false;
-  }
-}
-
-function hashIP(ip: string): string {
-  return createHash('sha256').update(ip).digest('hex').slice(0, 16);
-}
 
 // ============================================
 // HANDLER
@@ -265,10 +186,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     return;
   }
 
-  // Rate limiting
-  const ip = getClientIP(req);
-
-  const allowed = await checkRateLimitInternal(ip, client);
+  const { allowed } = await checkRateLimit(getClientIP(req), 'telemetry');
   if (!allowed) {
     res.status(429).json({ error: 'Rate limit exceeded' });
     return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,12 @@ const domIncludes = [
 // still executes all three projects.
 const generatorIncludes = ['src/features/generation/worker/generators/**/*.test.ts'];
 
+// Tests that need a real Redis rather than a hand-rolled ioredis mock — a Lua
+// script's behaviour cannot be asserted against a mock. Isolated into their own
+// project so the default `unit` run stays dependency-free; CI supplies
+// REDIS_TEST_URL from a service container.
+const integrationIncludes = ['api/**/*.integration.test.ts'];
+
 export default defineConfig({
   plugins: [react()],
   // Build-time version constants (provided by versionPlugin in the real build).
@@ -110,7 +116,7 @@ export default defineConfig({
             'scripts/**/*.test.ts',
             'packages/**/*.test.ts',
           ],
-          exclude: [...sharedExclude, ...domIncludes, ...generatorIncludes],
+          exclude: [...sharedExclude, ...domIncludes, ...generatorIncludes, ...integrationIncludes],
         },
       },
       {
@@ -130,6 +136,16 @@ export default defineConfig({
           environment: 'node',
           setupFiles: ['./src/test/setup.ts'],
           include: generatorIncludes,
+          exclude: sharedExclude,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'integration',
+          environment: 'node',
+          setupFiles: ['./src/test/setup.ts'],
+          include: integrationIncludes,
           exclude: sharedExclude,
         },
       },


### PR DESCRIPTION
## Why

Follow-up to #3008. Auditing Redis for the usage alert found rate limiting was **55.6% of all commands' worst offender**: `zcount` + `zadd` + `zremrangebyscore` at 4.9% each, with `zadd` alone consuming **16.3% of all Redis CPU time**.

`checkRateLimit` issued those four commands as **sequential awaits** — four round trips per guarded request, on every share, sync, auth, scan and Ko-fi webhook call.

## The race this also fixes

Reading the count and writing the entry were separate round trips, so concurrent callers could each observe a below-limit count and all be admitted. This is not theoretical. Against real Redis, with a limit of 30:

```
× admits exactly the limit under concurrent callers
    AssertionError: expected [ { allowed: true, …(2) }, …(59) ]
                    to have a length of 30 but got 60
```

**All 60 simultaneous requests were admitted — a clean 2x overshoot.** The script admits exactly 30.

## Also fixed: a resetAt in the past

The denial path read the oldest entry *overall* via `ZRANGE 0 0`. But pruning only happens when a request is admitted, so a key under sustained denial retains entries older than `windowStart` — and `oldest + window` could land before `now`, producing a negative `Retry-After`. It now reads the oldest entry *inside* the window, which makes `resetAt >= now` structural rather than incidental.

## Unification

`api/ml-telemetry.ts` carried a second, near-identical limiter plus its own Redis singleton, its own `parseRedisUrl` and its own IP hasher. It now calls the shared limiter under the `telemetry` action — **which was already declared in `RATE_LIMITS` and never referenced by anything.**

That deletes ~86 lines and removes one of the two connections each warm instance held (a contributor to the 22-of-30 connection count found during the audit). Keys move `ml_ratelimit:{h}` to `ratelimit:telemetry:{h}`; the old ones carry a 120s TTL, so there is no migration.

## Testing — this is the part that mattered

A mocked `ioredis` can assert that `evalsha` was called. It **cannot execute the Lua**, so every claim above would otherwise be unverified. This adds an `integration` vitest project and an `Integration Tests` CI job on `redis:7-alpine` covering:

- admits up to the limit, denies past it
- `remaining` counts down accurately
- budgets are independent per scope and per action
- **exactly the limit admitted under 60 concurrent callers** (the regression above)
- entries aging out of the window free capacity, and the consume pass prunes them
- `retryAfterSeconds` is never negative
- the key gets a TTL so idle scopes cost nothing
- **recovery from `SCRIPT FLUSH` without failing closed** — ioredis re-sends the body on `NOSCRIPT`; without that, every limiter call after a Redis restart would fail closed and lock users out of auth and share

Two deliberate choices:

- **One job, not a service on all nine shards.** `test-gate` now needs `[test, integration]`, so this blocks merges while branch protection keeps requiring only the `Unit Tests Complete` context — no ruleset change needed.
- **It fails loudly rather than skipping** if CI ever runs without `REDIS_TEST_URL`. A skipped suite reports green, which is exactly how this class of gap survives.

The main-branch full run now names its projects explicitly (`unit`, `dom`, `generators`) so it doesn't pull in the integration project without a Redis.

## Verification

`vitest run --project=unit --project=dom` — 15,341 passed. `--project=integration` against real Redis — 10 passed. Typecheck, eslint, and the full `api/` suite (1,129) clean. Skip-without-Redis and fail-without-Redis-in-CI both verified locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated the Redis rate limiter into a single atomic Lua call to cut round trips and remove a concurrency race. Also unified `ml-telemetry` to the shared limiter and added Redis-backed integration tests wired into CI.

- **Bug Fixes**
  - Prevented concurrent callers from overshooting the limit by making check-and-consume atomic.
  - Read the oldest entry inside the window so `resetAt`/`retryAfterSeconds` are never in the past.
  - Made the window floor exclusive to match the inclusive prune, so an entry on the boundary isn’t counted; added a boundary test and closed leaked Redis clients in integration tests.

- **Refactors**
  - Replaced `ZCOUNT`/`ZADD`/`ZREMRANGEBYSCORE`/`EXPIRE` with one Lua command via `ioredis.defineCommand`.
  - Removed the duplicate limiter and Redis client from `api/ml-telemetry.ts`; now calls the shared limiter (`telemetry` action). Keys move to `ratelimit:telemetry:{h}`; old `ml_ratelimit:{h}` keys expire in 120s (no migration).
  - Added an `integration` vitest project and a CI job using `redis:7-alpine`, folded into the `Unit Tests Complete` gate. Limited main-branch runs to `unit`, `dom`, `generators` and documented the atomic limiter in `api/README.md`.

<sup>Written for commit 3e444fdfbaad5ddee1989d1734215ec1629f1649. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

