### PR TITLE
fix: print fit-sample coupon labels on a 0.4mm nozzle (connector + label-plate) (#3019)

### DIFF
--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -12,13 +12,20 @@
  * connector profile (reused verbatim from `baseplateConnectors` so the printed
  * fit matches the real plate — the tolerance lives in the female groove/pocket,
  * not the surrounding socket, which is why a plain block coupon fits identically
- * to a full 42 mm cell). Both halves of every pair are embossed with their
- * style + offset so detached pieces stay identifiable.
+ * to a full 42 mm cell). Both halves of every pair are embossed with the offset
+ * so detached coupons stay identifiable; the style is implicit (the whole tray
+ * is one style), so it is NOT repeated on every coupon — that kept the label
+ * short enough to render at a printable stem width (see below).
  *
  * The dovetail KEY and snap CLIP are nominal parts — the offset rides entirely
  * on the female pocket — so each of those rows ships ONE shared loose part the
  * maker inserts into each offset's pair to feel the fit, rather than five
  * redundant copies.
+ *
+ * The embossed offset label is sized so its thinnest glyph stem stays at least
+ * one nozzle bead wide (`minPrintableLabelFontMm`); the coupon is then sized to
+ * hold that label. Older, smaller labels sliced away to nothing on a 0.4mm
+ * nozzle, leaving the card useless (issue #3019).
  *
  * Pieces are separate, non-fused solids resting on the bed (Z≥0); the export
  * compounds them into one ready-to-slice file.
@@ -40,7 +47,13 @@ import type { Shape3D, ValidSolid, DisposalScope } from 'brepjs';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { ExportFormat } from '../../bridge/types';
 import { sketch } from './meshUtils';
-import { formatOffset, roundedRect } from './couponHelpers';
+import {
+  formatOffset,
+  roundedRect,
+  minPrintableLabelFontMm,
+  JBM_ADVANCE_PER_GLYPH,
+  JBM_DIGIT_INK_PER_FONT,
+} from './couponHelpers';
 import {
   SOCKET_HEIGHT,
   MAGNET_FLOOR,
@@ -72,36 +85,54 @@ const SAMPLE_OFFSETS: readonly number[] = [-0.1, -0.05, 0, 0.05, 0.1];
 
 interface SampleStyle {
   readonly key: 'dovetail' | 'puzzle' | 'dovetailKey' | 'snapClip';
-  readonly abbr: string;
   /** Shared loose part this row ships (inserted into each pair to feel the fit), if any. */
   readonly loose: 'key' | 'clip' | null;
 }
 
 const SAMPLE_STYLES: readonly SampleStyle[] = [
-  { key: 'dovetail', abbr: 'DT', loose: null },
+  { key: 'dovetail', loose: null },
   // Puzzle is an integral tongue/groove like the dovetail (no loose part); it just
   // carries the stronger jigsaw-lobe profile (issue #2241).
-  { key: 'puzzle', abbr: 'PZ', loose: null },
-  { key: 'dovetailKey', abbr: 'DK', loose: 'key' },
-  { key: 'snapClip', abbr: 'SC', loose: 'clip' },
+  { key: 'puzzle', loose: null },
+  { key: 'dovetailKey', loose: 'key' },
+  { key: 'snapClip', loose: 'clip' },
 ];
 
-// Tray layout (mm). A coupon's long axis is X so the embossed label reads
+// Tray layout (mm). A coupon's long axis is X so the embossed offset label reads
 // left-to-right; the seam runs along X, so a pair stacks front/back along Y.
-const COUPON_X = 15;
-const COUPON_Y = 9;
 const COUPON_FILLET = 1.4;
 const SEAM_GAP = 5;
 const COL_GAP = 7;
 const ROW_GAP = 10;
 const LABEL_DEPTH = 0.6;
 const LABEL_MARGIN = 1.4;
-const LABEL_MIN_FONT = 1.0;
-const LABEL_MAX_FONT = 2.4;
 
-const CELL_Y = 2 * COUPON_Y + SEAM_GAP;
-const COL_PITCH = COUPON_X + COL_GAP;
-const ROW_PITCH = CELL_Y + ROW_GAP;
+/** Widest offset label, e.g. "+0.05" / "-0.10" (5 glyphs); "0.00" is shorter. */
+const LABEL_MAX_GLYPHS = 5;
+/** Coupon headroom past the label so auto-fit lands exactly on the target font
+ *  instead of tripping the fit verifier's epsilon at the razor's edge (mm). */
+const LABEL_FIT_SLACK = 0.4;
+/** Floor for coupon depth — keeps the body generous for the seam feature (mm). */
+const COUPON_Y_MIN = 9;
+
+/** Coupon footprint sized to hold the widest offset label at `fontMm`. Grows
+ *  with the nozzle (via `fontMm`) so bigger-nozzle labels still fit. */
+function couponDims(fontMm: number): { readonly x: number; readonly y: number } {
+  const labelW = LABEL_MAX_GLYPHS * JBM_ADVANCE_PER_GLYPH * fontMm;
+  const labelInkH = JBM_DIGIT_INK_PER_FONT * fontMm;
+  return {
+    x: labelW + 2 * LABEL_MARGIN + LABEL_FIT_SLACK,
+    y: Math.max(COUPON_Y_MIN, labelInkH + 2 * LABEL_MARGIN + LABEL_FIT_SLACK),
+  };
+}
+
+/** Per-tray geometry shared by every coupon: footprint, label font, height. */
+interface CouponLayout {
+  readonly couponX: number;
+  readonly couponY: number;
+  readonly fontMm: number;
+  readonly totalHeight: number;
+}
 
 /** Map (wall, boundary) → XY point for a seam running along X (protrude on Y). */
 function ptY(wall: number, bp: number): [number, number] {
@@ -120,17 +151,18 @@ type CouponFeature =
  * the whole tray onto the bed.
  */
 function buildCoupon(
+  layout: CouponLayout,
   cx: number,
   cy: number,
-  totalHeight: number,
   label: string,
   wallY: number,
   d: -1 | 1,
   feature: CouponFeature
 ): Shape3D {
+  const { couponX, couponY, fontMm, totalHeight } = layout;
   return withScope((scope: DisposalScope): Shape3D => {
     let solid: Shape3D = scope.register(
-      sketch(roundedRect(cx, cy, COUPON_X, COUPON_Y, COUPON_FILLET), 'XY', 0).extrude(-totalHeight)
+      sketch(roundedRect(cx, cy, couponX, couponY, COUPON_FILLET), 'XY', 0).extrude(-totalHeight)
     );
 
     switch (feature.kind) {
@@ -181,23 +213,27 @@ function buildCoupon(
       }
     }
 
-    // Emboss the style+offset on the top face (raised letters). Degrades to an
-    // unlabeled coupon if the font isn't loaded or auto-fit can't satisfy the
-    // floor — a single label must never tank the whole tray.
+    // Emboss the offset on the top face (raised letters). Pinned to `fontMm` (min
+    // == max) so every coupon reads at the same nozzle-printable size, measured
+    // against the glyph ink (`inkBox`) — the digits have no descenders, so the
+    // full ascender→descender band would waste vertical room and shrink the font.
+    // Degrades to an unlabeled coupon if the font isn't loaded or auto-fit can't
+    // fit the pinned size — a single label must never tank the whole tray.
     const text = buildTextSolid(scope, {
       text: label,
       fontFamily: 'jetbrains-mono',
       mode: 'emboss',
-      availW: COUPON_X,
-      availD: COUPON_Y,
+      availW: couponX,
+      availD: couponY,
       centerX: cx,
       centerY: cy,
       topZ: 0,
       depth: LABEL_DEPTH,
       hostThickness: totalHeight,
       margin: LABEL_MARGIN,
-      minFontSize: LABEL_MIN_FONT,
-      maxFontSize: LABEL_MAX_FONT,
+      minFontSize: fontMm,
+      maxFontSize: fontMm,
+      verticalFit: 'inkBox',
     });
     if (text) {
       try {
@@ -228,6 +264,15 @@ export function buildConnectorSampleTray(rawParams: ResolvedBaseplateParams): Sh
   const totalHeight = couponHeight(params);
   const gridUnitMm = params.gridUnitMm;
 
+  // Size the offset label so its stems clear the nozzle bead, then size the
+  // coupon (and hence the tray pitch) to hold it — both grow with the nozzle.
+  const fontMm = minPrintableLabelFontMm(params.nozzleSizeMm);
+  const { x: couponX, y: couponY } = couponDims(fontMm);
+  const layout: CouponLayout = { couponX, couponY, fontMm, totalHeight };
+  const cellYSpan = 2 * couponY + SEAM_GAP;
+  const colPitch = couponX + COL_GAP;
+  const rowPitch = cellYSpan + ROW_GAP;
+
   // Only build the row for the connector style the user actually picked — a
   // calibration card for the other two styles is wasted geometry/print time.
   // `connectorStyle` is undefined for the default integral dovetail.
@@ -238,21 +283,23 @@ export function buildConnectorSampleTray(rawParams: ResolvedBaseplateParams): Sh
   const nRows = styles.length;
   const nCols = SAMPLE_OFFSETS.length;
   // Center the grid on the origin (columns 0..nCols include the loose column).
-  const originX = -(nCols * COL_PITCH) / 2;
-  const originY = ((nRows - 1) * ROW_PITCH) / 2;
+  const originX = -(nCols * colPitch) / 2;
+  const originY = ((nRows - 1) * rowPitch) / 2;
 
   const pieces: Shape3D[] = [];
 
   styles.forEach((style, r) => {
-    const cellY = originY - r * ROW_PITCH;
+    const cellY = originY - r * rowPitch;
     const frontWallY = cellY - SEAM_GAP / 2; // +Y face of the front coupon
     const backWallY = cellY + SEAM_GAP / 2; // -Y face of the back coupon
-    const frontCenterY = cellY - SEAM_GAP / 2 - COUPON_Y / 2;
-    const backCenterY = cellY + SEAM_GAP / 2 + COUPON_Y / 2;
+    const frontCenterY = cellY - SEAM_GAP / 2 - couponY / 2;
+    const backCenterY = cellY + SEAM_GAP / 2 + couponY / 2;
 
     SAMPLE_OFFSETS.forEach((offset, c) => {
-      const cx = originX + c * COL_PITCH;
-      const label = `${style.abbr} ${formatOffset(offset)}`;
+      const cx = originX + c * colPitch;
+      // Offset only — the style is implicit (one style per tray), and keeping the
+      // label short is what lets the font grow to a printable stem width (#3019).
+      const label = formatOffset(offset);
 
       let frontFeature: CouponFeature;
       let backFeature: CouponFeature;
@@ -277,15 +324,15 @@ export function buildConnectorSampleTray(rawParams: ResolvedBaseplateParams): Sh
         };
       }
 
-      pieces.push(buildCoupon(cx, frontCenterY, totalHeight, label, frontWallY, 1, frontFeature));
-      pieces.push(buildCoupon(cx, backCenterY, totalHeight, label, backWallY, -1, backFeature));
+      pieces.push(buildCoupon(layout, cx, frontCenterY, label, frontWallY, 1, frontFeature));
+      pieces.push(buildCoupon(layout, cx, backCenterY, label, backWallY, -1, backFeature));
     });
 
     // One shared loose part per key/clip row, placed in the column beyond the
     // ladder. Built at nominal size (the offset is in the pocket), shifted down
     // into the pre-lift frame so it rests on the bed after the global lift.
     if (style.loose) {
-      const looseX = originX + nCols * COL_PITCH;
+      const looseX = originX + nCols * colPitch;
       const part =
         style.loose === 'clip'
           ? buildSnapClipForPrint(totalHeight, gridUnitMm, params.nozzleSizeMm)

--- a/src/features/generation/worker/generators/couponHelpers.test.ts
+++ b/src/features/generation/worker/generators/couponHelpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { formatOffset, minPrintableLabelFontMm, JBM_DIGIT_STEM_PER_FONT } from './couponHelpers';
+import { NOZZLE_BASELINE } from '@/shared/printSettings/connectorScaling';
+
+/** Thinnest JetBrains Mono digit stem (mm) at the label size for `nozzle`. */
+const stemAt = (nozzle: number | undefined): number =>
+  minPrintableLabelFontMm(nozzle) * JBM_DIGIT_STEM_PER_FONT;
+
+describe('minPrintableLabelFontMm', () => {
+  // The bug (#3019): a raised stroke thinner than one nozzle bead is culled by
+  // the slicer, so the fit-sample labels sliced away to nothing. Every supported
+  // nozzle must produce a label whose thinnest stem is at least one bead wide.
+  it.each([0.4, 0.6, 0.8, 1.0])('keeps the digit stem ≥ one bead at nozzle %smm', (nozzle) => {
+    expect(stemAt(nozzle)).toBeGreaterThanOrEqual(nozzle);
+  });
+
+  it('grows the label with the nozzle', () => {
+    expect(minPrintableLabelFontMm(0.6)).toBeGreaterThan(minPrintableLabelFontMm(0.4));
+    expect(minPrintableLabelFontMm(0.8)).toBeGreaterThan(minPrintableLabelFontMm(0.6));
+  });
+
+  it('falls back to the 0.4mm baseline for a missing or invalid nozzle', () => {
+    const baseline = minPrintableLabelFontMm(NOZZLE_BASELINE);
+    const invalid: readonly (number | undefined)[] = [undefined, NaN, 0, -0.4, Infinity];
+    for (const bad of invalid) {
+      expect(minPrintableLabelFontMm(bad)).toBe(baseline);
+    }
+  });
+
+  it('honors a legibility floor for sub-baseline nozzles', () => {
+    // A tiny nozzle can print a thin stem, but the label must stay readable, so
+    // the font never drops below the legibility floor.
+    const font = minPrintableLabelFontMm(0.2);
+    expect(font).toBeGreaterThanOrEqual(3.5);
+    // At the floor the stem still clears the (small) 0.2mm bead comfortably.
+    expect(font * JBM_DIGIT_STEM_PER_FONT).toBeGreaterThan(0.2);
+  });
+});
+
+describe('formatOffset', () => {
+  it('signs positive offsets and leaves zero unsigned', () => {
+    expect(formatOffset(0.05)).toBe('+0.05');
+    expect(formatOffset(0.1)).toBe('+0.10');
+    expect(formatOffset(-0.1)).toBe('-0.10');
+    expect(formatOffset(0)).toBe('0.00');
+  });
+});

--- a/src/features/generation/worker/generators/couponHelpers.ts
+++ b/src/features/generation/worker/generators/couponHelpers.ts
@@ -5,6 +5,48 @@
 
 import type { Drawing } from 'brepjs';
 import { draw } from 'brepjs';
+import { NOZZLE_BASELINE } from '@/shared/printSettings/connectorScaling';
+
+/**
+ * JetBrains Mono metrics, measured from the shipped Regular TTF (unitsPerEm 1000)
+ * for the digit + sign glyphs the fit-offset labels are made of:
+ *  - a digit's thinnest vertical stem is ~0.086·fontSize,
+ *  - its ink is ~0.75·fontSize tall (digits carry no descenders), and
+ *  - every glyph advances 0.6·fontSize (monospace).
+ * The coupon generators size their labels from these so the raised strokes stay
+ * printable and the text still fits the coupon.
+ */
+export const JBM_DIGIT_STEM_PER_FONT = 0.086;
+export const JBM_DIGIT_INK_PER_FONT = 0.75;
+export const JBM_ADVANCE_PER_GLYPH = 0.6;
+
+/**
+ * A raised label stroke narrower than one nozzle bead is dropped by the slicer,
+ * which is why the fit-sample coupons sliced blank on a 0.4mm nozzle — their
+ * digit stems were ~0.21mm, about half a bead (issue #3019). Target the thinnest
+ * stem at ~1.1 beads: a hair above one line so the slicer keeps it after XY
+ * (contour) compensation.
+ */
+const LABEL_STROKE_BEAD_MARGIN = 1.1;
+/** Legibility floor so a sub-baseline nozzle still gets readable text (mm). */
+const LABEL_LEGIBLE_MIN_FONT = 3.5;
+
+/**
+ * Smallest JetBrains Mono font size (mm) whose digit stems still lay down as a
+ * full nozzle bead, so an embossed fit-offset label survives slicing (issue
+ * #3019). Scales with the nozzle exactly as the connector features do; a
+ * non-finite or non-positive nozzle falls back to the 0.4mm baseline.
+ */
+export function minPrintableLabelFontMm(nozzleSizeMm: number | undefined): number {
+  const nozzle =
+    Number.isFinite(nozzleSizeMm) && (nozzleSizeMm ?? 0) > 0
+      ? (nozzleSizeMm as number)
+      : NOZZLE_BASELINE;
+  return Math.max(
+    LABEL_LEGIBLE_MIN_FONT,
+    (LABEL_STROKE_BEAD_MARGIN * nozzle) / JBM_DIGIT_STEM_PER_FONT
+  );
+}
 
 /**
  * Signed fit-offset label, e.g. "+0.05", "-0.10", "0.00" (zero is unsigned).

--- a/src/features/generation/worker/generators/couponHelpers.ts
+++ b/src/features/generation/worker/generators/couponHelpers.ts
@@ -9,9 +9,11 @@ import { NOZZLE_BASELINE } from '@/shared/printSettings/connectorScaling';
 
 /**
  * JetBrains Mono metrics, measured from the shipped Regular TTF (unitsPerEm 1000)
- * for the digit + sign glyphs the fit-offset labels are made of:
- *  - a digit's thinnest vertical stem is ~0.086·fontSize,
- *  - its ink is ~0.75·fontSize tall (digits carry no descenders), and
+ * for the glyphs the fit-offset labels use (digits, sign, and the decimal point):
+ *  - the thinnest digit stem is ~0.086·fontSize (the printability-limiting
+ *    feature — the sign and "." are chunkier),
+ *  - the digits' ink is ~0.75·fontSize tall (they carry no descenders, so they
+ *    set the label's ink height), and
  *  - every glyph advances 0.6·fontSize (monospace).
  * The coupon generators size their labels from these so the raised strokes stay
  * printable and the text still fits the coupon.
@@ -34,13 +36,16 @@ const LABEL_LEGIBLE_MIN_FONT = 3.5;
 /**
  * Smallest JetBrains Mono font size (mm) whose digit stems still lay down as a
  * full nozzle bead, so an embossed fit-offset label survives slicing (issue
- * #3019). Scales with the nozzle exactly as the connector features do; a
- * non-finite or non-positive nozzle falls back to the 0.4mm baseline.
+ * #3019). Grows with the nozzle (a wider bead needs a bigger stem), floored at
+ * {@link LABEL_LEGIBLE_MIN_FONT} so a sub-baseline nozzle still gets readable
+ * text. Unlike the connector-feature scalers, it isn't clamped to the 0.4mm
+ * baseline — a finer nozzle can carry a smaller (but still legible) label. A
+ * non-finite or non-positive nozzle falls back to the baseline.
  */
 export function minPrintableLabelFontMm(nozzleSizeMm: number | undefined): number {
   const nozzle =
-    Number.isFinite(nozzleSizeMm) && (nozzleSizeMm ?? 0) > 0
-      ? (nozzleSizeMm as number)
+    typeof nozzleSizeMm === 'number' && Number.isFinite(nozzleSizeMm) && nozzleSizeMm > 0
+      ? nozzleSizeMm
       : NOZZLE_BASELINE;
   return Math.max(
     LABEL_LEGIBLE_MIN_FONT,

--- a/src/features/generation/worker/generators/labelFitSample.ts
+++ b/src/features/generation/worker/generators/labelFitSample.ts
@@ -8,6 +8,11 @@
  * its offset, plus one nominal blank 1U plate to click into each socket.
  * The winning coupon's label is the value to type into the fit-offset field.
  *
+ * The offset label is sized so its thinnest glyph stem stays at least one nozzle
+ * bead wide (`minPrintableLabelFontMm`), and the front strip holding it grows to
+ * match — otherwise the label slices away to nothing on a 0.4mm nozzle and the
+ * card can't be read (issue #3019).
+ *
  * Coupons are cut with `cutLabelSocket` — the exact geometry the label-tab
  * shelf gets — at the real shelf thickness, so the printed fit transfers
  * 1:1 to bins. The offsets are absolute (the ladder is NOT centered on the
@@ -34,7 +39,7 @@ import {
 import type { TextStyleDefaults } from '@/shared/types/bin';
 import type { ExportFormat } from '../../bridge/types';
 import { sketch } from './meshUtils';
-import { roundedRect } from './couponHelpers';
+import { roundedRect, minPrintableLabelFontMm, JBM_DIGIT_INK_PER_FONT } from './couponHelpers';
 import { buildTextSolid } from './textBuilder';
 import { buildBaseplateSTL } from './baseplateSTL';
 import { cutLabelSocket } from './labelTabBuilder';
@@ -53,10 +58,12 @@ const ROW_PITCH = COUPON_D + ROW_GAP;
 const PLATE_GAP = 8;
 
 const LABEL_DEPTH = 0.6;
-const LABEL_ZONE_D = 4.4;
+/** Minimum front-strip depth for the label band (mm); grows with the nozzle so a
+ *  bigger printable font still fits between the front wall and the socket. */
+const LABEL_ZONE_D_MIN = 4.4;
 const LABEL_MARGIN_X = 2;
-const LABEL_MIN_FONT = 1.2;
-const LABEL_MAX_FONT = 3.2;
+/** Band headroom past the glyph ink so the pinned font clears the fit epsilon (mm). */
+const LABEL_FIT_SLACK = 0.4;
 
 /** The reference plate carries no text; the defaults only satisfy the type. */
 const PLATE_TEXT_DEFAULTS: TextStyleDefaults = {
@@ -106,20 +113,27 @@ function buildCoupon(cy: number, offset: number, nozzleSizeMm: number | undefine
       clearanceMm,
     });
 
+    // Size the label so its stems clear the nozzle bead (issue #3019), pinned to
+    // that size (min == max) and measured against glyph ink (`inkBox`) — the
+    // digits have no descenders, so the full line box would waste the band and
+    // shrink the font. The front strip grows with the font to hold it.
+    const fontMm = minPrintableLabelFontMm(nozzleSizeMm);
+    const bandD = Math.max(LABEL_ZONE_D_MIN, JBM_DIGIT_INK_PER_FONT * fontMm + LABEL_FIT_SLACK);
     const text = buildTextSolid(scope, {
       text: formatOffset(offset),
       fontFamily: 'jetbrains-mono',
       mode: 'emboss',
       availW: COUPON_W - 2 * LABEL_MARGIN_X,
-      availD: LABEL_ZONE_D,
+      availD: bandD,
       centerX: 0,
-      centerY: cy - COUPON_D / 2 + 1 + LABEL_ZONE_D / 2,
+      centerY: cy - COUPON_D / 2 + 1 + bandD / 2,
       topZ: t,
       depth: LABEL_DEPTH,
       hostThickness: t,
       margin: 0,
-      minFontSize: LABEL_MIN_FONT,
-      maxFontSize: LABEL_MAX_FONT,
+      minFontSize: fontMm,
+      maxFontSize: fontMm,
+      verticalFit: 'inkBox',
     });
     if (text) {
       try {


### PR DESCRIPTION
Closes #3019.

Both printable **fit-sample calibration cards** — the connector fit sample and
the swappable-label socket fit sample — embossed offset labels that sliced away
to nothing on a 0.4 mm nozzle, leaving the cards blank and unusable. Same root
cause, same shared fix.

## Root cause (measured, not guessed)

JetBrains Mono digit stems are `~0.086 · fontSize`. The labels auto-fit under a
fixed font cap (**2.4 mm** connector, **3.2 mm** label-plate), so the thinnest
stems came out **~0.21–0.27 mm** — under one 0.4 mm nozzle bead. The slicer culls
any raised feature narrower than one line width, so the labels vanished (exactly
the reporter's before/after screenshots).

## Fix

Shared helper `minPrintableLabelFontMm(nozzle)` in `couponHelpers.ts` picks the
smallest font whose digit stems still lay down as a full bead (~1.1×), scaling
with the nozzle just like the connector features already do. Both coupons then:

- **Pin the label to that font** (`min == max`) so every coupon reads at the same
  printable size.
- **Fit against glyph ink (`inkBox`)**, not the full ascender→descender line box —
  digits have no descenders, so the line box wasted ~40% of the vertical budget.
- **Size the coupon / label band from the font**, so the label always fits and the
  whole thing scales with the nozzle.

Connector-specific: dropped the redundant style prefix (`PZ`) — the tray only
builds the selected style's row, so the style is implicit — which is what freed
the width for the larger font (label is now just the offset, e.g. `+0.05`).

At the 0.4 mm baseline the thinnest stem goes **~0.21 → ~0.44 mm** (above one
bead). Fit-critical connector/socket geometry is untouched — only the labels and
the slabs holding them.

## Verification

- Real-OCCT-WASM scenario tests green for both coupons: watertight, bed-resting,
  positive-volume, correct counts. The label-plate card's **strict
  coupon-volume-ordering** test still passes — the larger font's per-coupon
  label-volume spread (~1.5 mm³, max adjacent step ~1.05 mm³) stays well under the
  ~4.7 mm³ pocket step.
- New `couponHelpers.test.ts` locks the core invariant: the label's thinnest stem
  stays ≥ one nozzle bead across 0.4/0.6/0.8/1.0 mm, with baseline fallback and a
  legibility floor.
- Rasterized both exported STLs' raised glyph-tops at 0.1 mm/px (print resolution,
  font loaded): the offset labels render as solid, unbroken, bold strokes — the
  opposite of the sliced-away originals.