### PR TITLE
chore(deps): sweep matured cooldown exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ minimumReleaseAge: 10080
 
 # Excluded: user-authored packages (no security benefit from cooldown) +
 # high-trust org scopes that release lockstep (would block install for a
-# week on every dep bump). The trailing entries are temporary — see TODO.
+# week on every dep bump). The trailing entry is temporary — see TODO.
 minimumReleaseAgeExclude:
   - brepjs
   - brepkit-wasm
@@ -24,22 +24,18 @@ minimumReleaseAgeExclude:
   - '@vercel/*'
   - '@protobufjs/*'
   - protobufjs
-  # js-yaml 5.2.2 (2026-07-23) is the first version patched against the
-  # exponential flow-collection parsing DoS (GHSA-pm4m-ph32-ghv5).
-  # TODO: remove after 2026-07-30 once 5.2.2 has aged past the window.
-  - js-yaml@5.2.2
-  # Both versions patch the unbounded-expansion OOM (CVE-2026-14257): 5.0.8
-  # (2026-07-23) on the 5.x line, and 1.1.17 (2026-07-29) backporting it to the
-  # 1.x line that minimatch@3 pins. 1.1.16 shipped an EXPANSION_MAX_LENGTH
-  # constant but the bound was ineffective — it still OOMs on the advisory's own
-  # PoC, so the marker cannot be trusted in place of running it.
+  # brace-expansion 1.1.17 (2026-07-29) backports the unbounded-expansion OOM
+  # fix (CVE-2026-14257) to the 1.x line that minimatch@3 pins. 1.1.16 shipped
+  # an EXPANSION_MAX_LENGTH constant but the bound was ineffective — it still
+  # OOMs on the advisory's own PoC, so the marker cannot be trusted in place of
+  # running it.
   #
-  # These MUST stay one `||` union entry, not two lines: pnpm returns the first
-  # rule whose package name matches and never unions across entries, so a second
+  # If another brace-expansion version ever needs exempting, add it to THIS
+  # entry as a `||` union, never as a second line: pnpm returns the first rule
+  # whose package name matches and never unions across entries, so a second
   # `brace-expansion@...` line is silently dead and its version stays blocked.
-  # TODO: drop 5.0.8 after 2026-07-30 and 1.1.17 after 2026-08-05, once each has
-  # aged past the window; remove the entry once both are gone.
-  - brace-expansion@1.1.17||5.0.8
+  # TODO: remove after 2026-08-05 once 1.1.17 has aged past the window.
+  - brace-expansion@1.1.17
 
 # Blocks Shai-Hulud-class worms that spread via npm lifecycle scripts.
 # Packages that need to build are listed in allowBuilds.


### PR DESCRIPTION
## Summary

**Type**: chore

Sweeps the two `minimumReleaseAgeExclude` entries in `pnpm-workspace.yaml` that have now aged past the repo's 7-day `minimumReleaseAge` window (10080 minutes).

## Context

Per [`SECURITY.md`](../blob/main/SECURITY.md), security fixes younger than the 7-day cooldown are admitted temporarily by pinning the exact version under `minimumReleaseAgeExclude` with a dated TODO. Once a version ages past the window the exclusion is dead weight and gets swept. This is that routine sweep — no behavior change, no dependency change.

Maturity was checked against wall-clock UTC at the time of the sweep (2026-07-30T23:15Z), not just the calendar date, since both deadlines land on today — `js-yaml@5.2.2` had cleared the window by only 20 minutes.

### Swept

| Entry | Published | Matured | Status |
| --- | --- | --- | --- |
| `js-yaml@5.2.2` | 2026-07-23T22:55:18Z | 2026-07-30T22:55Z | ✅ removed (entry + its 3-line comment) |
| `brace-expansion@5.0.8` | 2026-07-23T11:39:25Z | 2026-07-30T11:39Z | ✅ dropped from the `||` union |

### Deferred — intentionally kept

| Entry | Published | Matures | Status |
| --- | --- | --- | --- |
| `brace-expansion@1.1.17` | 2026-07-29T10:45:03Z | **2026-08-05** | ⏳ retained, not yet matured |

`brace-expansion@1.1.17` is 6 days old and stays until 2026-08-05. Its surrounding comment is rewritten to describe only the 1.x backport and to carry a single TODO for the 2026-08-05 deadline; the 5.0.8 narrative is trimmed.

The union-entry warning is **preserved and rephrased forward-looking**: if another `brace-expansion` version ever needs exempting it must join *this* entry as a `||` union, never a second list entry — pnpm's `evaluateVersionPolicy` returns the first rule whose package name matches and never unions across entries, so a second `brace-expansion@...` line would be silently dead and its version would stay blocked with no warning.

## Changes

- Remove `js-yaml@5.2.2` from `minimumReleaseAgeExclude` along with its explanatory comment.
- Narrow `brace-expansion@1.1.17||5.0.8` to `brace-expansion@1.1.17`.
- Rewrite the brace-expansion comment block for the remaining version; keep the `||` union warning.
- Adjust the section preamble from "trailing entries are" to "trailing entry is" now that one temporary entry remains.

Nothing under `overrides:` is touched — the `brace-expansion@&gt;=5.0.0 &lt;5.0.8` and `tar@&lt;7.5.21` pins are unrelated to cooldown and remain in force.

## Architecture

- **Stores**: none
- **Features**: none — build/dependency configuration only
- **New types**: none
- **i18n keys**: none
- **Storage/schema changes**: none

## Notes for reviewers

**On OSV:** I expected `OSV Scan (blocking)` to be red here on `brace-expansion@1.1.17`, since advisory GHSA-mh99-v99m-4gvg declares a single overbroad range (`introduced: 0` → `fixed: 5.0.8`) that sweeps in the genuinely-patched 1.x backport (being corrected upstream in github/advisory-database#8877). It is **not** red on this PR — `OSV Scan (blocking)` was `skipped` and `osv-scanner` passed green, consistent with `brace-expansion@1.1.17` not actually being in the resolved tree (see below). Either way, no `osv-scanner.toml` was added: `SECURITY.md` deliberately forbids suppressions, so an OSV finding stays visible rather than silenced.

**Observation, pre-existing and out of scope for this sweep:** `brace-expansion@1.1.17` does not currently appear in `pnpm-lock.yaml` at all — the tree resolves only `brace-expansion@5.0.8` via `minimatch@10.2.5`, consistent with #2974 having moved every `minimatch` consumer to the 10.x line and taken the 1.x line out of the tree. So the retained exclusion is currently inert rather than load-bearing, and the comment's "the 1.x line that minimatch@3 pins" is a description of why the backport exists, not of the current tree. This is identical on `main` (the lockfile diff here is empty), so it is not introduced by this PR. I left the entry in place rather than removing it early: dropping it is a separate judgement call about whether the 1.x line can re-enter the tree, and the 2026-08-05 TODO retires it either way.

## Test plan

Verified locally on this branch:

- [x] `pnpm install --lockfile-only` — succeeds, **no** `ERR_PNPM_NO_MATURE_MATCHING_VERSION`; supply-chain policy check passes (1173 entries)
- [x] `git diff pnpm-lock.yaml` is **empty** — removing the matured exclusions changed no resolved version
- [x] Lockfile still resolves `js-yaml@5.2.2` (and `js-yaml@4.3.0`, above the `js-yaml@&lt;4.2.0` override floor)
- [x] `pnpm run lint` — **0 errors**, 30 pre-existing `max-lines` warnings. `eslint-plugin-jsx-a11y` reaches `brace-expansion` through `minimatch`, so lint exercises that path functionally.

Covered by CI rather than locally: `pnpm run test:coverage` and `pnpm run build`. The lockfile is byte-identical to `main`, so every installed package version is unchanged and neither result can differ from `main`'s. Build, Quality, CodeQL and all 9 unit-test shards are green.

Remaining template items are N/A: no new code (so no sibling tests), no i18n keys, and no `console.log` / `any` / `var` / `==` / `!` introduced — the diff is comments and two YAML list entries.