### PR TITLE
test(rate-limit): stub REDIS_URL instead of assigning it

### DIFF
--- a/api/lib/rateLimit.integration.test.ts
+++ b/api/lib/rateLimit.integration.test.ts
@@ -23,12 +23,15 @@ describe.skipIf(!REDIS_TEST_URL)('rate limiter (real Redis)', () => {
   let probe: Redis;
   let loaded: typeof RateLimitModule | null = null;
 
+  // Stubbed rather than assigned: process.env is process-wide, so a bare
+  // assignment leaks this URL into any suite sharing the run.
   beforeAll(() => {
-    process.env.REDIS_URL = REDIS_TEST_URL;
+    vi.stubEnv('REDIS_URL', REDIS_TEST_URL);
     probe = new Redis(REDIS_TEST_URL as string);
   });
 
   afterAll(async () => {
+    vi.unstubAllEnvs();
     await probe.quit();
   });
 


### PR DESCRIPTION
Follow-up to #3022.

The integration suite set `process.env.REDIS_URL` directly in `beforeAll`. `process.env` is process-wide, so once that suite ran, any other suite sharing the same Vitest process would see the test Redis URL — and `getRedis()` returns a client rather than `null` whenever it is set. A unit suite that expects the unconfigured path could silently talk to the test server instead.

`vi.stubEnv` scopes the value and `vi.unstubAllEnvs` restores it in `afterAll`.

The integration project runs in its own job today, so nothing is currently mis-testing because of this — it is a trap for whoever next adds a file to that project.

## Testing

`--project=integration` against real Redis — 11 passed. Typecheck and eslint clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped `REDIS_URL` in rate limit integration tests using `vitest` stubs to prevent env leakage across suites. This avoids unit tests unintentionally connecting to the test Redis.

- **Bug Fixes**
  - Use `vi.stubEnv('REDIS_URL', ...)` in `beforeAll` and `vi.unstubAllEnvs()` in `afterAll`.
  - Remove direct `process.env.REDIS_URL` assignment.

<sup>Written for commit 12e804557ffbf648e0c8bf9b239fc1a988191292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

