### PR TITLE
test(rate-limit): stub REDIS_URL instead of assigning it

### DIFF
--- a/api/lib/rateLimit.integration.test.ts
+++ b/api/lib/rateLimit.integration.test.ts
@@ -23,12 +23,15 @@ describe.skipIf(!REDIS_TEST_URL)('rate limiter (real Redis)', () => {
   let probe: Redis;
   let loaded: typeof RateLimitModule | null = null;
 
+  // Stubbed rather than assigned: process.env is process-wide, so a bare
+  // assignment leaks this URL into any suite sharing the run.
   beforeAll(() => {
-    process.env.REDIS_URL = REDIS_TEST_URL;
+    vi.stubEnv('REDIS_URL', REDIS_TEST_URL);
     probe = new Redis(REDIS_TEST_URL as string);
   });
 
   afterAll(async () => {
+    vi.unstubAllEnvs();
     await probe.quit();
   });
 


### PR DESCRIPTION
Follow-up to #3022, which merged before this review finding was addressed.

`beforeAll` assigned `process.env.REDIS_URL` and never restored it. `process.env` is process-wide, so running the integration project alongside another one leaks the test URL into suites that expect it unset or different. `vi.stubEnv` is undone via `vi.unstubAllEnvs()` in `afterAll`.

No behaviour change to the limiter itself — test hygiene only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stubs `REDIS_URL` in the rate limiter integration test to prevent process-wide env leakage and restores it after the suite. No changes to limiter behavior; improves test isolation.

- **Bug Fixes**
  - Use `vi.stubEnv('REDIS_URL', ...)` in `beforeAll` instead of assigning `process.env`.
  - Call `vi.unstubAllEnvs()` in `afterAll` to clean up.

<sup>Written for commit a51b26cd27ca6df5b35804505fc1bb357fa43e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

