### PR TITLE
test(ml-telemetry): escape identifiers before building the scan regex

### DIFF
--- a/api/lib/mlTelemetry/aggregatorRetention.test.ts
+++ b/api/lib/mlTelemetry/aggregatorRetention.test.ts
@@ -368,8 +368,12 @@ describe('aggregator retention coverage', () => {
     const unresolved: string[] = [];
     const resolved: string[] = [];
     for (const name of names) {
+      // `$` is the only regex metacharacter that is also a valid identifier
+      // character, so unescaped it would anchor the pattern and a name like
+      // `$key` would never resolve against its own declaration.
+      const escaped = name.replace(/\$/g, '\\$&');
       const decl = source.match(
-        new RegExp(`\\bconst ${name}\\s*(?::[^=]+)?=\\s*(['"\`])([^'"\`]*)`)
+        new RegExp(`\\bconst ${escaped}\\s*(?::[^=]+)?=\\s*(['"\`])([^'"\`]*)`)
       );
       if (decl) resolved.push(decl[2]);
       else unresolved.push(name);

--- a/api/lib/mlTelemetry/aggregatorRetention.test.ts
+++ b/api/lib/mlTelemetry/aggregatorRetention.test.ts
@@ -368,10 +368,10 @@ describe('aggregator retention coverage', () => {
     const unresolved: string[] = [];
     const resolved: string[] = [];
     for (const name of names) {
-      // `$` is the only regex metacharacter that is also a valid identifier
-      // character, so unescaped it would anchor the pattern and a name like
-      // `$key` would never resolve against its own declaration.
-      const escaped = name.replace(/\$/g, '\\$&');
+      // `$` is a valid identifier character, so unescaped it would anchor the
+      // pattern and a name like `$key` would never resolve against its own
+      // declaration.
+      const escaped = name.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
       const decl = source.match(
         new RegExp(`\\bconst ${escaped}\\s*(?::[^=]+)?=\\s*(['"\`])([^'"\`]*)`)
       );


### PR DESCRIPTION
Follow-up to #3023, closing the last review finding from that PR.

The computed-key scan in `aggregatorRetention.test.ts` interpolated the identifier straight into a `RegExp`. The capture class is `[A-Za-z_$][\w$]*`, and `$` is a regex anchor — so a key variable named `$key` would never match its own `const` declaration and would land in `unresolved` instead.

The consequence was a confusing red test rather than a missed retention leak, which is why it wasn't a merge blocker. Escaping the name makes the scan correct for every valid JS identifier. `$` is the only regex metacharacter that is also a valid identifier character, so the targeted escape is complete.

## Verification

Renaming `confByDrawerKey` to `conf$Key` in `aggregators.ts`:

- before this change: `AssertionError: expected [ 'key', 'conf$Key' ] to deeply equal [ 'key' ]`
- after: 23/23 pass

`aggregators.ts` is unchanged on this branch — the rename was a throwaway check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes all regex metacharacters in identifier names before building the scan regex in `aggregatorRetention.test.ts`. This ensures variables like `$key` match their `const` declarations and prevents false unresolved entries.

<sup>Written for commit 46fda64f18e70c45c2369e9112ac518a5d893885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

