### PR TITLE
fix(generation): time out a worker init that never reports ready (#3035)

### DIFF
--- a/src/features/generation/bridge/GenerationBridge.test.ts
+++ b/src/features/generation/bridge/GenerationBridge.test.ts
@@ -36,6 +36,9 @@ class MockWorker {
     const msgType = (data as { type: string }).type;
     // Auto-respond to INIT
     if (msgType === 'INIT') {
+      // Simulates a worker that loads but hangs inside WASM init: no INIT_READY,
+      // no error event, nothing (#3035).
+      if (stallInit) return;
       const kernel = (data as { kernel?: string }).kernel ?? 'occt-wasm';
       setTimeout(() => {
         this.simulateResponse({
@@ -71,6 +74,8 @@ class MockWorker {
 }
 
 let mockWorkerInstance: MockWorker | null = null;
+/** When true, MockWorker swallows INIT instead of replying — see #3035. */
+let stallInit = false;
 
 // Mock the Worker constructor globally
 function createMockWorkerClass() {
@@ -94,6 +99,7 @@ describe('GenerationBridge', () => {
 
   beforeEach(() => {
     mockWorkerInstance = null;
+    stallInit = false;
     bridge = new GenerationBridge();
     vi.useFakeTimers();
   });
@@ -121,6 +127,29 @@ describe('GenerationBridge', () => {
 
       expect(getWorker().messages[0]).toEqual({ type: 'INIT', kernel: 'brepkit' });
       brepkitBridge.destroy();
+    });
+
+    it('rejects instead of hanging when the worker never reports ready', async () => {
+      stallInit = true;
+      const initPromise = bridge.init();
+      const assertion = expect(initPromise).rejects.toThrow(/did not report ready within 60s/);
+
+      // Two attempts: init() retries once, and the retry stalls the same way.
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      await assertion;
+    });
+
+    it('does not fire the init timeout once the worker reports ready', async () => {
+      const initPromise = bridge.init();
+      await vi.advanceTimersByTimeAsync(10);
+      await expect(initPromise).resolves.toBeUndefined();
+
+      // Past the timeout the resolved promise must stay resolved, and the timer
+      // must not leave a dangling rejection behind.
+      await vi.advanceTimersByTimeAsync(120_000);
+      await expect(bridge.init()).resolves.toBeUndefined();
     });
 
     it('returns cached promise on multiple init calls', async () => {

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -100,6 +100,14 @@ export type {
 } from './bridgeTypes';
 export { ExportTimeoutError } from './bridgeTypes';
 
+/**
+ * Ceiling on a single worker init attempt. Generous on purpose: this is a
+ * last-resort "the worker is hung" guard, not a performance budget, and a cold
+ * occt-wasm start on a slow connection is legitimately slow. `init()` retries
+ * once, so a genuine hang surfaces as an error after at most twice this.
+ */
+const INIT_TIMEOUT_MS = 60_000;
+
 export class GenerationBridge {
   private readonly kernel: KernelName;
   worker: Worker | null = null;
@@ -188,41 +196,67 @@ export class GenerationBridge {
   /** Single init attempt: create worker, send INIT, wait for INIT_READY. */
   private tryInit(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      const teardown = (): void => {
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        this.worker?.removeEventListener('message', onInitMessage);
+        this.worker?.removeEventListener('error', onInitError);
+      };
+
+      const onInitError = (e: ErrorEvent): void => {
+        // When a worker script fails to load (network error, CSP block, missing module),
+        // the ErrorEvent.message is often empty. Build a diagnostic message from whatever
+        // fields are available so the error is actionable in telemetry.
+        const detail =
+          e.message ||
+          (e.filename ? `loading ${e.filename}${e.lineno ? `:${e.lineno}` : ''}` : '') ||
+          'script failed to load (possible network error, CSP restriction, or unsupported browser)';
+        teardown();
+        reject(new Error(`Worker failed to initialize: ${detail}`));
+      };
+
+      const onInitMessage = (event: MessageEvent<WorkerResponse>): void => {
+        if (event.data.type === 'INIT_READY') {
+          teardown();
+          this.threadingInfo = extractThreadingInfo(event.data);
+          this.setupMessageHandler();
+          resolve();
+        } else if (event.data.type === 'ERROR') {
+          teardown();
+          reject(new Error(event.data.error));
+        }
+      };
+
       try {
         this.worker = new Worker(new URL('../worker/generation.worker.ts', import.meta.url), {
           type: 'module',
         });
 
-        const onInitError = (e: ErrorEvent): void => {
-          // When a worker script fails to load (network error, CSP block, missing module),
-          // the ErrorEvent.message is often empty. Build a diagnostic message from whatever
-          // fields are available so the error is actionable in telemetry.
-          const detail =
-            e.message ||
-            (e.filename ? `loading ${e.filename}${e.lineno ? `:${e.lineno}` : ''}` : '') ||
-            'script failed to load (possible network error, CSP restriction, or unsupported browser)';
-          reject(new Error(`Worker failed to initialize: ${detail}`));
-        };
-
-        const onInitMessage = (event: MessageEvent<WorkerResponse>) => {
-          if (event.data.type === 'INIT_READY') {
-            this.worker?.removeEventListener('message', onInitMessage);
-            this.worker?.removeEventListener('error', onInitError);
-            this.threadingInfo = extractThreadingInfo(event.data);
-            this.setupMessageHandler();
-            resolve();
-          } else if (event.data.type === 'ERROR') {
-            this.worker?.removeEventListener('message', onInitMessage);
-            this.worker?.removeEventListener('error', onInitError);
-            reject(new Error(event.data.error));
-          }
-        };
+        // A worker that loads but then stalls inside WASM init emits neither a
+        // message nor an error event, so without this the promise never settles:
+        // wasmStatus stays 'loading' and the preview sits on a bare spinner with
+        // no error text and no retry affordance (#3035).
+        timer = setTimeout(() => {
+          teardown();
+          reject(
+            new Error(
+              `Worker failed to initialize: kernel '${this.kernel}' did not report ready within ${
+                INIT_TIMEOUT_MS / 1000
+              }s`
+            )
+          );
+        }, INIT_TIMEOUT_MS);
 
         this.worker.addEventListener('message', onInitMessage);
         this.worker.addEventListener('error', onInitError);
 
         this.postMessage({ type: 'INIT', kernel: this.kernel });
       } catch (e) {
+        teardown();
         reject(e instanceof Error ? e : new Error(String(e)));
       }
     });

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -208,6 +208,9 @@ export class GenerationBridge {
       };
 
       const onInitError = (e: ErrorEvent): void => {
+        // Rejecting below handles this, so stop it also surfacing as an uncaught
+        // window-level error (same reason bridgeMessageHandler does).
+        e.preventDefault();
         // When a worker script fails to load (network error, CSP block, missing module),
         // the ErrorEvent.message is often empty. Build a diagnostic message from whatever
         // fields are available so the error is actionable in telemetry.


### PR DESCRIPTION
Fixes #3035.

## Symptom

Both the bin designer and the baseplate designer hang forever on the loading spinner. No error text, no Retry button. The layout editor is unaffected.

## Root cause

`GenerationBridge.tryInit()` settles on exactly three events: an `INIT_READY` message, an `ERROR` message, or the worker's `error` event. A worker that *loads* but then stalls inside WASM init fires none of them, so the promise stayed pending forever.

That propagates all the way up:

- `BridgeManager.acquire()` awaits `initPromise` and never settles
- `useGeneration`'s `acquire().then(...)` never runs, and neither does its `.catch(...)`
- `wasmStatus` stays `'loading'`
- `PreviewCanvas` keeps `showSkeleton` true, and `PreviewSkeleton`'s `isError` stays false, which is why there is no error message and no Retry affordance

The layout editor is unaffected because it does not go through the geometry worker. The baseplate page is affected for the same reason the designer is, which matches the report's "bin/plate designer".

The generation path was already hardened against this exact failure. `sendWhenReady` arms its timeout *before* awaiting `init()`, with a comment saying why. But that guard is unreachable here, because `runGeneration` is only ever called *inside* the `acquire().then()` callback that never fires.

The existing retry-once wrapper did not help either: it only re-attempts when the first attempt *rejects*, and a hang never rejects.

## Fix

Bound each init attempt with a 60s ceiling and tear down the timer on every settle path. The value is deliberately generous. This is a last-resort "the worker is hung" guard, not a performance budget, and a cold occt-wasm start on a slow connection is legitimately slow. `init()` retries once, so a genuine hang surfaces after at most two attempts through the error + Retry UI that already exists.

The rejection names the kernel and the elapsed budget, so the next report of this arrives diagnosable rather than as a silent spinner.

## Tests

Added a `stallInit` mode to the mock worker that swallows `INIT` without replying, reproducing a worker that loads and then hangs.

- `rejects instead of hanging when the worker never reports ready` - hangs until vitest's 30s timeout on the unfixed source, passes with the fix
- `does not fire the init timeout once the worker reports ready` - guards against the timer leaving a dangling rejection on the happy path

`pnpm exec vitest run src/features/generation/bridge/ src/features/bin-designer/hooks/useGeneration.test.ts` - 162 passed. `pnpm run typecheck` clean.

## What this does not do

This converts a silent hang into a diagnosable, retryable error. It does not identify why the worker stalls on Brave/Windows specifically, which I could not reproduce. The reporter's GPU report is healthy (RTX 4070, hardware accelerated) and the `ANGLE_instanced_arrays` errors in their log come from troika's SDF text path, which recovers on its own and is present in the working layout editor too.

Separately, their console log shows the report-only CSP is violated on every load: 56 blob-script loads (the WASM pthread workers, checked against `script-src`, which lacks `blob:`) and 403 `unsafe-eval` violations from the `schemas` chunk. Nothing is enforced today since the header is `Content-Security-Policy-Report-Only`, so this is not the cause. But the policy as written would break the designer if it were ever promoted to enforcing. Worth a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop indefinite loading in the bin and baseplate designers by bounding worker init in `GenerationBridge` with a 60s timeout. Hung inits now surface a clear, retryable error instead of spinning forever.

- **Bug Fixes**
  - Bound each init attempt with a 60s timeout; clear the timer and listeners on any settle.
  - Prevented init worker errors from bubbling as uncaught; build actionable messages when scripts fail to load.
  - Since `init()` retries once, a hang now fails after at most two attempts and shows the existing Retry UI.
  - Tests cover stalled init rejection and no dangling timeout after success.

<sup>Written for commit 05f2e72e39b464cb0feb1d3795385ee9ae09f224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

