### PR TITLE
fix(bin-designer): make cutout z-order and hide actually do something

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
@@ -25,6 +25,7 @@ import {
   STROKE_WIDTH_HOVER_PX,
   STROKE_WIDTH_GROUPED_PX,
 } from './constants';
+import { shapePosZ, shapeRenderOrder } from './zLayer';
 import { PathShapeMesh } from './PathShapeMesh';
 import { PolygonShapeMesh } from './PolygonShapeMesh';
 import { MeshFootprintMesh } from './MeshFootprintMesh';
@@ -247,10 +248,15 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
   const posX = effective.x + effective.width / 2;
   const posY = effective.y + effective.depth / 2;
 
-  // Smaller shapes get higher Z → closer to camera → win raycasting on overlap.
-  // Since depthTest is false, Z only affects raycasting, not visual rendering.
+  // Higher Z → closer to camera → wins raycasting on overlap. Since depthTest
+  // is false, Z only affects raycasting; `renderOrder` below drives what draws
+  // on top, and both read the same zIndex so click and paint agree.
+  //
+  // Explicit z-order dominates, with the original smaller-shape heuristic kept
+  // as the tiebreaker — that heuristic is what lets you click a small shape
+  // sitting on a large one before anyone has touched the ordering.
   const area = effective.width * effective.depth;
-  const posZ = 0.02 + 0.01 / Math.max(area, 1);
+  const posZ = shapePosZ(cutout.zIndex, area);
 
   // Rotation in radians around Z axis
   // SVG used clockwise degrees; Three.js uses counter-clockwise radians
@@ -284,12 +290,13 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
     setIsHovered(false);
   };
 
-  const renderOrder =
+  const renderBand =
     renderMode === 'fill'
       ? RENDER_ORDER.GROUP_FILL
       : renderMode === 'stroke'
         ? RENDER_ORDER.GROUP_STROKE
         : RENDER_ORDER.SHAPES;
+  const renderOrder = shapeRenderOrder(renderBand, cutout.zIndex);
 
   // Stroke pass is visual-only — no pointer interaction
   if (renderMode === 'stroke') {

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutShapeMesh.tsx
@@ -250,11 +250,8 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
 
   // Higher Z → closer to camera → wins raycasting on overlap. Since depthTest
   // is false, Z only affects raycasting; `renderOrder` below drives what draws
-  // on top, and both read the same zIndex so click and paint agree.
-  //
-  // Explicit z-order dominates, with the original smaller-shape heuristic kept
-  // as the tiebreaker — that heuristic is what lets you click a small shape
-  // sitting on a large one before anyone has touched the ordering.
+  // on top. Both are derived from the same (layer, area) key in `zLayer.ts`, so
+  // the shape you see on top is the one you click.
   const area = effective.width * effective.depth;
   const posZ = shapePosZ(cutout.zIndex, area);
 
@@ -296,7 +293,7 @@ const SDFShapeMesh = memo(function SDFShapeMesh({
       : renderMode === 'stroke'
         ? RENDER_ORDER.GROUP_STROKE
         : RENDER_ORDER.SHAPES;
-  const renderOrder = shapeRenderOrder(renderBand, cutout.zIndex);
+  const renderOrder = shapeRenderOrder(renderBand, cutout.zIndex, area);
 
   // Stroke pass is visual-only — no pointer interaction
   if (renderMode === 'stroke') {

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/MeshFootprintMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/MeshFootprintMesh.tsx
@@ -13,6 +13,7 @@ import type { ThreeEvent } from '@react-three/fiber';
 import type { Cutout } from '@/features/bin-designer/types';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { RENDER_ORDER, ACCENT_COLOR_HEX } from './constants';
+import { shapePosZ, shapeRenderOrder } from './zLayer';
 
 const STROKE_SELECTED = new THREE.Color(ACCENT_COLOR_HEX);
 
@@ -136,13 +137,13 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
 
   return (
     <group
-      position={[groupX, groupY, 0.02]}
+      position={[groupX, groupY, shapePosZ(cutout.zIndex, Number.POSITIVE_INFINITY)]}
       rotation={[0, 0, rotationZ]}
-      renderOrder={RENDER_ORDER.SHAPES}
+      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
     >
       <mesh
         geometry={fillGeometry}
-        renderOrder={RENDER_ORDER.SHAPES}
+        renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
         onPointerDown={handlePointerDown}
         onDoubleClick={handleDoubleClick}
         onPointerEnter={() => {
@@ -159,7 +160,11 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
         />
       </mesh>
       {strokeGeometries.map((geo, i) => (
-        <lineLoop key={i} geometry={geo} renderOrder={RENDER_ORDER.SHAPES + 1}>
+        <lineLoop
+          key={i}
+          geometry={geo}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES + 1, cutout.zIndex)}
+        >
           <lineBasicMaterial color={strokeColor} transparent opacity={1} depthTest={false} />
         </lineLoop>
       ))}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/MeshFootprintMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/MeshFootprintMesh.tsx
@@ -139,11 +139,11 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
     <group
       position={[groupX, groupY, shapePosZ(cutout.zIndex, Number.POSITIVE_INFINITY)]}
       rotation={[0, 0, rotationZ]}
-      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
+      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, Number.POSITIVE_INFINITY)}
     >
       <mesh
         geometry={fillGeometry}
-        renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
+        renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, Number.POSITIVE_INFINITY)}
         onPointerDown={handlePointerDown}
         onDoubleClick={handleDoubleClick}
         onPointerEnter={() => {
@@ -163,7 +163,11 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
         <lineLoop
           key={i}
           geometry={geo}
-          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES + 1, cutout.zIndex)}
+          renderOrder={shapeRenderOrder(
+            RENDER_ORDER.SHAPES + 1,
+            cutout.zIndex,
+            Number.POSITIVE_INFINITY
+          )}
         >
           <lineBasicMaterial color={strokeColor} transparent opacity={1} depthTest={false} />
         </lineLoop>

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/MeshFootprintMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/MeshFootprintMesh.tsx
@@ -109,6 +109,9 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
   const groupX = effective.x + effective.width / 2;
   const groupY = effective.y + effective.depth / 2;
   const rotationZ = -(effective.rotation * Math.PI) / 180;
+  // Same key as the other renderers so a footprint takes part in the
+  // smaller-shape-wins tiebreaker instead of pinning to its layer floor.
+  const area = effective.width * effective.depth;
 
   const strokeColor = isSelected
     ? STROKE_SELECTED
@@ -137,13 +140,13 @@ export const MeshFootprintMesh = memo(function MeshFootprintMesh({
 
   return (
     <group
-      position={[groupX, groupY, shapePosZ(cutout.zIndex, Number.POSITIVE_INFINITY)]}
+      position={[groupX, groupY, shapePosZ(cutout.zIndex, area)]}
       rotation={[0, 0, rotationZ]}
-      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, Number.POSITIVE_INFINITY)}
+      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
     >
       <mesh
         geometry={fillGeometry}
-        renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, Number.POSITIVE_INFINITY)}
+        renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
         onPointerDown={handlePointerDown}
         onDoubleClick={handleDoubleClick}
         onPointerEnter={() => {

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/PathShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/PathShapeMesh.tsx
@@ -12,6 +12,7 @@ import type { ThreeEvent } from '@react-three/fiber';
 import type { Cutout } from '@/features/bin-designer/types';
 import { flattenPath, triangulatePath, getPathBounds, MIN_PATH_POINTS } from '../pathGeometry';
 import { RENDER_ORDER, ACCENT_COLOR_HEX } from './constants';
+import { shapePosZ, shapeRenderOrder } from './zLayer';
 import {
   outlineVertexShader as pathVertexShader,
   outlineFragmentShader as pathFragmentShader,
@@ -206,7 +207,7 @@ export const PathShapeMesh = memo(function PathShapeMesh({
         ? strokeGrouped
         : strokeDefault;
   const rotationZ = -(effective.rotation * Math.PI) / 180;
-  const posZ = 0.02 + 0.01 / Math.max(area, 1);
+  const posZ = shapePosZ(cutout.zIndex, area);
 
   const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
     if (e.nativeEvent.button !== 0) return;
@@ -240,14 +241,14 @@ export const PathShapeMesh = memo(function PathShapeMesh({
     <group
       position={[groupX, groupY, posZ]}
       rotation={[0, 0, rotationZ]}
-      renderOrder={RENDER_ORDER.SHAPES}
+      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
     >
       {/* Depth-shaded fill mesh */}
       {fillGeometry && fillMaterial && (
         <mesh
           geometry={fillGeometry}
           material={fillMaterial}
-          renderOrder={RENDER_ORDER.SHAPES}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
           onPointerDown={handlePointerDown}
           onDoubleClick={handleDoubleClick}
           onPointerEnter={handlePointerEnter}
@@ -257,7 +258,10 @@ export const PathShapeMesh = memo(function PathShapeMesh({
 
       {/* Solid stroke outline (matches rect/circle styling) — hidden during vertex editing */}
       {strokeGeometry && !disablePointerEvents && (
-        <lineLoop geometry={strokeGeometry} renderOrder={RENDER_ORDER.SHAPES + 1}>
+        <lineLoop
+          geometry={strokeGeometry}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES + 1, cutout.zIndex)}
+        >
           <lineBasicMaterial color={strokeColor} transparent opacity={1} depthTest={false} />
         </lineLoop>
       )}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/PathShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/PathShapeMesh.tsx
@@ -241,14 +241,14 @@ export const PathShapeMesh = memo(function PathShapeMesh({
     <group
       position={[groupX, groupY, posZ]}
       rotation={[0, 0, rotationZ]}
-      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
+      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
     >
       {/* Depth-shaded fill mesh */}
       {fillGeometry && fillMaterial && (
         <mesh
           geometry={fillGeometry}
           material={fillMaterial}
-          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
           onPointerDown={handlePointerDown}
           onDoubleClick={handleDoubleClick}
           onPointerEnter={handlePointerEnter}
@@ -260,7 +260,7 @@ export const PathShapeMesh = memo(function PathShapeMesh({
       {strokeGeometry && !disablePointerEvents && (
         <lineLoop
           geometry={strokeGeometry}
-          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES + 1, cutout.zIndex)}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES + 1, cutout.zIndex, area)}
         >
           <lineBasicMaterial color={strokeColor} transparent opacity={1} depthTest={false} />
         </lineLoop>

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/PolygonShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/PolygonShapeMesh.tsx
@@ -180,13 +180,13 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
     <group
       position={[centerX, centerY, posZ]}
       rotation={[0, 0, rotationZ]}
-      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
+      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
     >
       {fillGeometry && fillMaterial && (
         <mesh
           geometry={fillGeometry}
           material={fillMaterial}
-          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex, area)}
           onPointerDown={handlePointerDown}
           onDoubleClick={handleDoubleClick}
           onPointerEnter={() => !isSelected && setIsHovered(true)}
@@ -196,7 +196,7 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
       {strokeGeometry && (
         <lineLoop
           geometry={strokeGeometry}
-          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES + 1, cutout.zIndex)}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES + 1, cutout.zIndex, area)}
         >
           <lineBasicMaterial color={strokeColor} transparent opacity={1} depthTest={false} />
         </lineLoop>

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/PolygonShapeMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/PolygonShapeMesh.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_POLYGON_SIDES } from '@/features/bin-designer/types';
 import { regularPolygonPoints, clampPolygonSides } from '@/shared/utils/cutoutPolygon';
 import { triangulatePath } from '../pathGeometry';
 import { RENDER_ORDER, ACCENT_COLOR_HEX } from './constants';
+import { shapePosZ, shapeRenderOrder } from './zLayer';
 import {
   outlineVertexShader,
   outlineFragmentShader,
@@ -156,7 +157,7 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
         ? strokeGrouped
         : strokeDefault;
   const rotationZ = -(effective.rotation * Math.PI) / 180;
-  const posZ = 0.02 + 0.01 / Math.max(area, 1);
+  const posZ = shapePosZ(cutout.zIndex, area);
 
   const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
     if (e.nativeEvent.button !== 0) return;
@@ -179,13 +180,13 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
     <group
       position={[centerX, centerY, posZ]}
       rotation={[0, 0, rotationZ]}
-      renderOrder={RENDER_ORDER.SHAPES}
+      renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
     >
       {fillGeometry && fillMaterial && (
         <mesh
           geometry={fillGeometry}
           material={fillMaterial}
-          renderOrder={RENDER_ORDER.SHAPES}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES, cutout.zIndex)}
           onPointerDown={handlePointerDown}
           onDoubleClick={handleDoubleClick}
           onPointerEnter={() => !isSelected && setIsHovered(true)}
@@ -193,7 +194,10 @@ export const PolygonShapeMesh = memo(function PolygonShapeMesh({
         />
       )}
       {strokeGeometry && (
-        <lineLoop geometry={strokeGeometry} renderOrder={RENDER_ORDER.SHAPES + 1}>
+        <lineLoop
+          geometry={strokeGeometry}
+          renderOrder={shapeRenderOrder(RENDER_ORDER.SHAPES + 1, cutout.zIndex)}
+        >
           <lineBasicMaterial color={strokeColor} transparent opacity={1} depthTest={false} />
         </lineLoop>
       )}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/constants.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/constants.ts
@@ -19,6 +19,24 @@ export const RENDER_ORDER = {
   MARQUEE: 50,
 } as const;
 
+/**
+ * Stacking (`Cutout.zIndex`) applied on top of a RENDER_ORDER band.
+ *
+ * Two separate channels, because the editor draws with `depthTest: false`:
+ * scene Z decides which shape wins the click (raycast distance), `renderOrder`
+ * decides which fill draws on top. Both have to move together or "bring to
+ * front" would look right but click wrong, or vice versa.
+ *
+ * `Z_LAYER_STEP` exceeds the area tiebreaker's 0.01 ceiling so explicit
+ * z-order always beats the smaller-shape heuristic, and `Z_LAYER_MAX` keeps
+ * the stack under 50mm — well inside the camera (z=100, near 0.1). The
+ * render-order offset stays below 1 so a shape in SHAPES (10) can never bleed
+ * into GROUP_FILL (11).
+ */
+export const Z_LAYER_STEP = 0.05;
+export const Z_LAYER_MAX = 900;
+export const Z_LAYER_RENDER_STEP = 0.001;
+
 /** Camera zoom limits (zoom = pixels per mm for the orthographic camera) */
 export const MIN_ZOOM = 0.5;
 export const MAX_ZOOM = 50;

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/zLayer.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/zLayer.test.ts
@@ -41,18 +41,57 @@ describe('shapePosZ', () => {
 
 describe('shapeRenderOrder', () => {
   it('raises a higher layer within its band', () => {
-    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, 3)).toBeGreaterThan(
-      shapeRenderOrder(RENDER_ORDER.SHAPES, 1)
+    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, 3, 100)).toBeGreaterThan(
+      shapeRenderOrder(RENDER_ORDER.SHAPES, 1, 100)
     );
   });
 
   it('never bleeds a SHAPES-band offset into GROUP_FILL', () => {
-    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, Z_LAYER_MAX)).toBeLessThan(
+    // Worst case: top layer AND the largest possible tiebreak.
+    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, Z_LAYER_MAX, 1)).toBeLessThan(
       RENDER_ORDER.GROUP_FILL
     );
   });
 
-  it('keeps the band floor for the bottom layer', () => {
-    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, 0)).toBe(RENDER_ORDER.SHAPES);
+  it('a tiebreak never promotes a shape past the next layer', () => {
+    const topOfLayer = shapeRenderOrder(RENDER_ORDER.SHAPES, 1, 1);
+    const bottomOfNext = shapeRenderOrder(RENDER_ORDER.SHAPES, 2, Number.POSITIVE_INFINITY);
+    expect(topOfLayer).toBeLessThan(bottomOfNext);
+  });
+
+  it('lets z-order beat the area tiebreaker', () => {
+    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, 1, 10_000)).toBeGreaterThan(
+      shapeRenderOrder(RENDER_ORDER.SHAPES, 0, 1)
+    );
+  });
+
+  it('keeps the band floor for a zero-area-rank shape at the bottom layer', () => {
+    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, 0, Number.POSITIVE_INFINITY)).toBe(
+      RENDER_ORDER.SHAPES
+    );
+  });
+});
+
+describe('paint order matches click order', () => {
+  // The whole point of deriving both channels from one key: whichever shape
+  // wins the raycast must also be the one drawn on top, or you click a shape
+  // that is visually underneath.
+  const cases: [string, number | undefined, number][] = [
+    ['bottom layer, large', 0, 10_000],
+    ['bottom layer, small', 0, 4],
+    ['bottom layer, tiny', 0, 1],
+    ['upper layer, large', 2, 10_000],
+    ['upper layer, small', 2, 4],
+    ['no zIndex, medium', undefined, 250],
+  ];
+
+  it.each(cases)('ranks %s consistently in both channels', (_label, z, area) => {
+    for (const [, otherZ, otherArea] of cases) {
+      const zWins = shapePosZ(z, area) > shapePosZ(otherZ, otherArea);
+      const paintWins =
+        shapeRenderOrder(RENDER_ORDER.SHAPES, z, area) >
+        shapeRenderOrder(RENDER_ORDER.SHAPES, otherZ, otherArea);
+      expect(zWins).toBe(paintWins);
+    }
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/zLayer.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/zLayer.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { zLayerOf, shapePosZ, shapeRenderOrder } from './zLayer';
+import { RENDER_ORDER, Z_LAYER_MAX } from './constants';
+
+describe('zLayerOf', () => {
+  it('treats an absent zIndex as the bottom layer', () => {
+    expect(zLayerOf(undefined)).toBe(0);
+  });
+
+  it('clamps negatives to the bottom', () => {
+    expect(zLayerOf(-5)).toBe(0);
+  });
+
+  it('clamps past the ceiling', () => {
+    expect(zLayerOf(Z_LAYER_MAX + 100)).toBe(Z_LAYER_MAX);
+  });
+});
+
+describe('shapePosZ', () => {
+  it('puts a higher layer closer to the camera', () => {
+    expect(shapePosZ(1, 100)).toBeGreaterThan(shapePosZ(0, 100));
+  });
+
+  it('lets z-order beat the smaller-shape tiebreaker', () => {
+    // A huge shape one layer up must still out-rank a tiny shape below it,
+    // otherwise "bring to front" loses to the area heuristic.
+    const bigOnTop = shapePosZ(1, 10_000);
+    const tinyBelow = shapePosZ(0, 1);
+    expect(bigOnTop).toBeGreaterThan(tinyBelow);
+  });
+
+  it('falls back to smaller-shape-wins within one layer', () => {
+    expect(shapePosZ(0, 1)).toBeGreaterThan(shapePosZ(0, 10_000));
+  });
+
+  it('stays well inside the camera near plane at the ceiling', () => {
+    // Camera sits at z=100 with near=0.1, so anything at/after 99.9 vanishes.
+    expect(shapePosZ(Z_LAYER_MAX, 1)).toBeLessThan(99.9);
+  });
+});
+
+describe('shapeRenderOrder', () => {
+  it('raises a higher layer within its band', () => {
+    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, 3)).toBeGreaterThan(
+      shapeRenderOrder(RENDER_ORDER.SHAPES, 1)
+    );
+  });
+
+  it('never bleeds a SHAPES-band offset into GROUP_FILL', () => {
+    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, Z_LAYER_MAX)).toBeLessThan(
+      RENDER_ORDER.GROUP_FILL
+    );
+  });
+
+  it('keeps the band floor for the bottom layer', () => {
+    expect(shapeRenderOrder(RENDER_ORDER.SHAPES, 0)).toBe(RENDER_ORDER.SHAPES);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/zLayer.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/zLayer.ts
@@ -1,0 +1,42 @@
+/**
+ * Stacking maths for cutout shapes in the 2D editor (issue #3053).
+ *
+ * The editor draws with `depthTest: false`, which splits stacking into two
+ * independent channels:
+ *   - scene Z decides which shape wins the click (raycast distance),
+ *   - `renderOrder` decides which fill draws on top.
+ * They have to move together, or "bring to front" looks right and clicks wrong.
+ *
+ * Shared by all four shape renderers (SDF, path, polygon, mesh footprint) so a
+ * new shape kind can't silently opt out of z-ordering — which is how the SDF
+ * renderer ended up as the only one anybody would have patched.
+ */
+
+import { Z_LAYER_MAX, Z_LAYER_RENDER_STEP, Z_LAYER_STEP } from './constants';
+
+/** Clamped stacking layer for a cutout. Absent `zIndex` is the bottom (0). */
+export function zLayerOf(zIndex: number | undefined): number {
+  return Math.min(Math.max(zIndex ?? 0, 0), Z_LAYER_MAX);
+}
+
+/**
+ * Scene Z for a shape's quad.
+ *
+ * Explicit z-order dominates; the original smaller-shape-wins heuristic is kept
+ * as the tiebreaker, since it is what lets you click a small shape sitting on a
+ * large one before anyone has touched the ordering. `Z_LAYER_STEP` exceeds the
+ * tiebreaker's 0.01 ceiling so the two can never fight.
+ */
+export function shapePosZ(zIndex: number | undefined, area: number): number {
+  return 0.02 + zLayerOf(zIndex) * Z_LAYER_STEP + 0.01 / Math.max(area, 1);
+}
+
+/**
+ * `renderOrder` for a shape, offset within its band.
+ *
+ * The offset stays below 1 (see `Z_LAYER_MAX`), so a shape in `SHAPES` (10)
+ * can never bleed into `GROUP_FILL` (11).
+ */
+export function shapeRenderOrder(band: number, zIndex: number | undefined): number {
+  return band + zLayerOf(zIndex) * Z_LAYER_RENDER_STEP;
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/zLayer.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/zLayer.ts
@@ -5,14 +5,26 @@
  * independent channels:
  *   - scene Z decides which shape wins the click (raycast distance),
  *   - `renderOrder` decides which fill draws on top.
- * They have to move together, or "bring to front" looks right and clicks wrong.
+ *
+ * Both are derived from the SAME ordering key — layer first, then smaller-area
+ * first — so what you see on top is what you click. Feeding only one channel
+ * the tiebreaker is how a shape could paint above its neighbour while the click
+ * went to the other one.
  *
  * Shared by all four shape renderers (SDF, path, polygon, mesh footprint) so a
- * new shape kind can't silently opt out of z-ordering — which is how the SDF
- * renderer ended up as the only one anybody would have patched.
+ * new shape kind can't silently opt out of z-ordering.
  */
 
 import { Z_LAYER_MAX, Z_LAYER_RENDER_STEP, Z_LAYER_STEP } from './constants';
+
+/** Scene-Z span reserved for the within-layer tiebreaker. */
+const AREA_Z_SPAN = 0.01;
+/**
+ * `renderOrder` span for the same tiebreaker. Strictly less than
+ * {@link Z_LAYER_RENDER_STEP} so a tiebreak can never promote a shape past the
+ * next layer.
+ */
+const AREA_RENDER_SPAN = 0.0009;
 
 /** Clamped stacking layer for a cutout. Absent `zIndex` is the bottom (0). */
 export function zLayerOf(zIndex: number | undefined): number {
@@ -20,23 +32,32 @@ export function zLayerOf(zIndex: number | undefined): number {
 }
 
 /**
- * Scene Z for a shape's quad.
+ * Within-layer rank in `(0, 1]`: smaller shapes rank higher.
  *
- * Explicit z-order dominates; the original smaller-shape-wins heuristic is kept
- * as the tiebreaker, since it is what lets you click a small shape sitting on a
- * large one before anyone has touched the ordering. `Z_LAYER_STEP` exceeds the
- * tiebreaker's 0.01 ceiling so the two can never fight.
+ * This is the original smaller-shape-wins heuristic, and it is worth keeping —
+ * it is what lets you click a small shape sitting on a large one before anyone
+ * has touched the ordering. Explicit z-order simply outranks it.
  */
-export function shapePosZ(zIndex: number | undefined, area: number): number {
-  return 0.02 + zLayerOf(zIndex) * Z_LAYER_STEP + 0.01 / Math.max(area, 1);
+function areaRank(area: number): number {
+  return 1 / Math.max(area, 1);
 }
 
 /**
- * `renderOrder` for a shape, offset within its band.
- *
- * The offset stays below 1 (see `Z_LAYER_MAX`), so a shape in `SHAPES` (10)
- * can never bleed into `GROUP_FILL` (11).
+ * Scene Z for a shape's quad. Higher is closer to the camera, so it wins the
+ * raycast. `Z_LAYER_STEP` exceeds {@link AREA_Z_SPAN} so an explicit layer
+ * always beats the area tiebreaker.
  */
-export function shapeRenderOrder(band: number, zIndex: number | undefined): number {
-  return band + zLayerOf(zIndex) * Z_LAYER_RENDER_STEP;
+export function shapePosZ(zIndex: number | undefined, area: number): number {
+  return 0.02 + zLayerOf(zIndex) * Z_LAYER_STEP + AREA_Z_SPAN * areaRank(area);
+}
+
+/**
+ * `renderOrder` for a shape, offset within its band by the same key
+ * {@link shapePosZ} uses.
+ *
+ * The total offset stays below 1 (see `Z_LAYER_MAX`), so a shape in `SHAPES`
+ * (10) can never bleed into `GROUP_FILL` (11).
+ */
+export function shapeRenderOrder(band: number, zIndex: number | undefined, area: number): number {
+  return band + zLayerOf(zIndex) * Z_LAYER_RENDER_STEP + AREA_RENDER_SPAN * areaRank(area);
 }

--- a/src/features/bin-designer/store/designer.scenario.cutouts.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.cutouts.test.ts
@@ -31,7 +31,9 @@ describe('DesignerStore - cutout actions', () => {
 
       const { params } = useDesignerStore.getState();
       expect(params.cutouts).toHaveLength(1);
-      expect(params.cutouts[0]).toEqual(cutout);
+      // A new cutout is assigned its own layer so it lands on top and the
+      // renderer's stacking key stays strict (#3053).
+      expect(params.cutouts[0]).toEqual({ ...cutout, zIndex: 0 });
     });
 
     it('adds multiple cutouts in order', () => {
@@ -334,7 +336,7 @@ describe('DesignerStore - cutout actions', () => {
       redo();
 
       const { params } = useDesignerStore.getState();
-      expect(params.cutouts).toEqual([cutout]);
+      expect(params.cutouts).toEqual([{ ...cutout, zIndex: 0 }]);
     });
 
     it('undo after removeCutout restores cutout', () => {
@@ -346,7 +348,7 @@ describe('DesignerStore - cutout actions', () => {
       undo();
 
       const { params } = useDesignerStore.getState();
-      expect(params.cutouts).toEqual([cutout]);
+      expect(params.cutouts).toEqual([{ ...cutout, zIndex: 0 }]);
     });
   });
 });

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -75,12 +75,26 @@ describe('cutoutSlice - consolidated actions', () => {
   });
 
   describe('reorderCutouts', () => {
-    /** Ids from bottom of the stack to top. The contract is the ORDER; the
-     *  concrete zIndex values are an implementation detail of the restack. */
-    const stackOrder = (): string[] =>
-      [...useDesignerStore.getState().params.cutouts]
-        .sort((a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0))
+    /**
+     * Ids from bottom of the stack to top. The contract is the ORDER; the
+     * concrete zIndex values are an implementation detail of the restack.
+     *
+     * Mirrors `stackBottomToTop`'s explicit array-order tiebreak rather than
+     * leaning on `Array.sort` stability, so an all-default stack (every zIndex
+     * absent, i.e. equal) asserts the documented contract instead of an
+     * incidental property of the sort.
+     */
+    const stackOrder = (): string[] => {
+      const cutouts = useDesignerStore.getState().params.cutouts;
+      const indexById = new Map(cutouts.map((c, i) => [c.id, i]));
+      return [...cutouts]
+        .sort(
+          (a, b) =>
+            (a.zIndex ?? 0) - (b.zIndex ?? 0) ||
+            (indexById.get(a.id) ?? 0) - (indexById.get(b.id) ?? 0)
+        )
         .map((c) => c.id);
+    };
 
     it('forward: swaps with the shape above', () => {
       const { addCutout, reorderCutouts } = useDesignerStore.getState();
@@ -529,6 +543,31 @@ describe('cutoutSlice - consolidated actions', () => {
       setCutoutProperty(['c-1'], { locked: true });
 
       expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
+    });
+
+    it('setCutoutProperty is a no-op when the value is already set', () => {
+      const { addCutout, setCutoutProperty } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1', hidden: true }));
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+      const historyBefore = useDesignerStore.getState().history.past.length;
+
+      setCutoutProperty(['c-1'], { hidden: true });
+
+      // Re-hiding an already-hidden cutout must not cost a worker rebuild.
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
+      expect(useDesignerStore.getState().history.past.length).toBe(historyBefore);
+    });
+
+    it('setCutoutProperty is a no-op for unknown ids', () => {
+      const { addCutout, setCutoutProperty } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1' }));
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+      const historyBefore = useDesignerStore.getState().history.past.length;
+
+      setCutoutProperty(['nope'], { hidden: true });
+
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
+      expect(useDesignerStore.getState().history.past.length).toBe(historyBefore);
     });
 
     it('setCutoutProperty (hide) DOES bump epoch — the worker drops hidden cutouts (#3053)', () => {

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -544,16 +544,6 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore + 1);
     });
 
-    it('setCutoutProperty (name) leaves epoch unchanged', () => {
-      const { addCutout, setCutoutProperty } = useDesignerStore.getState();
-      addCutout(createTestCutout({ id: 'c-1' }));
-      const epochBefore = useDesignerStore.getState().generation.epoch;
-
-      setCutoutProperty(['c-1'], { name: 'Drill bit 3mm' });
-
-      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
-    });
-
     it('reorderCutouts leaves epoch unchanged when nothing is grouped', () => {
       const { addCutout, reorderCutouts } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'c-1' }));

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -106,6 +106,28 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(stackOrder()).toEqual(['cutout-2', 'cutout-1']);
     });
 
+    it('gives each new cutout its own layer so nothing ties', () => {
+      // Equal layer AND equal area would leave the renderer with identical
+      // scene Z and renderOrder, and the two channels break that tie by
+      // different rules (raycast traversal vs object id).
+      const { addCutout } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'a' }));
+      addCutout(createTestCutout({ id: 'b' }));
+      addCutout(createTestCutout({ id: 'c' }));
+
+      const zs = useDesignerStore.getState().params.cutouts.map((c) => c.zIndex);
+      expect(new Set(zs).size).toBe(3);
+      expect(zs).toEqual([0, 1, 2]);
+    });
+
+    it('honours an explicit zIndex on the incoming cutout', () => {
+      const { addCutout } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'a' }));
+      addCutout(createTestCutout({ id: 'b', zIndex: 9 }));
+
+      expect(useDesignerStore.getState().params.cutouts.map((c) => c.zIndex)).toEqual([0, 9]);
+    });
+
     it('back and forward work from an all-default stack (#3053)', () => {
       // Every cutout defaults to zIndex 0. The old absolute-value maths made
       // `back` write 0 over 0 and `backward` clamp to max(-1, 0), so neither

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -75,32 +75,70 @@ describe('cutoutSlice - consolidated actions', () => {
   });
 
   describe('reorderCutouts', () => {
-    it('forward: increments zIndex by 1', () => {
+    /** Ids from bottom of the stack to top. The contract is the ORDER; the
+     *  concrete zIndex values are an implementation detail of the restack. */
+    const stackOrder = (): string[] =>
+      [...useDesignerStore.getState().params.cutouts]
+        .sort((a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0))
+        .map((c) => c.id);
+
+    it('forward: swaps with the shape above', () => {
       const { addCutout, reorderCutouts } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'cutout-1', zIndex: 0 }));
       addCutout(createTestCutout({ id: 'cutout-2', zIndex: 1 }));
 
       reorderCutouts(['cutout-1'], 'forward');
 
-      const { params } = useDesignerStore.getState();
-      expect(params.cutouts[0].zIndex).toBe(1);
-      expect(params.cutouts[1].zIndex).toBe(1);
+      expect(stackOrder()).toEqual(['cutout-2', 'cutout-1']);
     });
 
-    it('backward: decrements zIndex, clamped to 0', () => {
+    it('back and forward work from an all-default stack (#3053)', () => {
+      // Every cutout defaults to zIndex 0. The old absolute-value maths made
+      // `back` write 0 over 0 and `backward` clamp to max(-1, 0), so neither
+      // moved anything until some other shape had been sent forward first.
+      const { addCutout, reorderCutouts } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'a' }));
+      addCutout(createTestCutout({ id: 'b' }));
+      addCutout(createTestCutout({ id: 'c' }));
+      expect(stackOrder()).toEqual(['a', 'b', 'c']);
+
+      reorderCutouts(['c'], 'back');
+      expect(stackOrder()).toEqual(['c', 'a', 'b']);
+
+      reorderCutouts(['a'], 'front');
+      expect(stackOrder()).toEqual(['c', 'b', 'a']);
+
+      reorderCutouts(['a'], 'backward');
+      expect(stackOrder()).toEqual(['c', 'a', 'b']);
+    });
+
+    it('restacks onto contiguous zIndex values', () => {
+      const { addCutout, reorderCutouts } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'cutout-1', zIndex: 0 }));
+      addCutout(createTestCutout({ id: 'cutout-2', zIndex: 40 }));
+      addCutout(createTestCutout({ id: 'cutout-3', zIndex: 7 }));
+
+      reorderCutouts(['cutout-1'], 'front');
+
+      const zs = [...useDesignerStore.getState().params.cutouts]
+        .map((c) => c.zIndex)
+        .sort((a, b) => (a ?? 0) - (b ?? 0));
+      expect(zs).toEqual([0, 1, 2]);
+    });
+
+    it('backward: swaps with the shape below, and the bottom one stays put', () => {
       const { addCutout, reorderCutouts } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'cutout-1', zIndex: 2 }));
       addCutout(createTestCutout({ id: 'cutout-2', zIndex: 0 }));
 
       reorderCutouts(['cutout-1'], 'backward');
-      reorderCutouts(['cutout-2'], 'backward');
+      expect(stackOrder()).toEqual(['cutout-1', 'cutout-2']);
 
-      const { params } = useDesignerStore.getState();
-      expect(params.cutouts[0].zIndex).toBe(1);
-      expect(params.cutouts[1].zIndex).toBe(0);
+      reorderCutouts(['cutout-1'], 'backward');
+      expect(stackOrder()).toEqual(['cutout-1', 'cutout-2']);
     });
 
-    it('front: sets zIndex to maxZ + 1', () => {
+    it('front: moves to the top of the stack', () => {
       const { addCutout, reorderCutouts } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'cutout-1', zIndex: 0 }));
       addCutout(createTestCutout({ id: 'cutout-2', zIndex: 5 }));
@@ -108,22 +146,17 @@ describe('cutoutSlice - consolidated actions', () => {
 
       reorderCutouts(['cutout-1'], 'front');
 
-      const { params } = useDesignerStore.getState();
-      expect(params.cutouts[0].zIndex).toBe(6);
-      expect(params.cutouts[1].zIndex).toBe(5);
-      expect(params.cutouts[2].zIndex).toBe(3);
+      expect(stackOrder()).toEqual(['cutout-3', 'cutout-2', 'cutout-1']);
     });
 
-    it('back: sets zIndex to 0', () => {
+    it('back: moves to the bottom of the stack', () => {
       const { addCutout, reorderCutouts } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'cutout-1', zIndex: 5 }));
       addCutout(createTestCutout({ id: 'cutout-2', zIndex: 3 }));
 
       reorderCutouts(['cutout-1'], 'back');
 
-      const { params } = useDesignerStore.getState();
-      expect(params.cutouts[0].zIndex).toBe(0);
-      expect(params.cutouts[1].zIndex).toBe(3);
+      expect(stackOrder()).toEqual(['cutout-1', 'cutout-2']);
     });
 
     it('no-op on empty ids', () => {
@@ -137,7 +170,7 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(afterHistoryLength).toBe(beforeHistoryLength);
     });
 
-    it('multiple cutouts reorder simultaneously', () => {
+    it('multiple cutouts reorder simultaneously, keeping their relative order', () => {
       const { addCutout, reorderCutouts } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'cutout-1', zIndex: 1 }));
       addCutout(createTestCutout({ id: 'cutout-2', zIndex: 2 }));
@@ -145,10 +178,7 @@ describe('cutoutSlice - consolidated actions', () => {
 
       reorderCutouts(['cutout-1', 'cutout-3'], 'front');
 
-      const { params } = useDesignerStore.getState();
-      expect(params.cutouts[0].zIndex).toBe(3);
-      expect(params.cutouts[1].zIndex).toBe(2);
-      expect(params.cutouts[2].zIndex).toBe(3);
+      expect(stackOrder()).toEqual(['cutout-2', 'cutout-3', 'cutout-1']);
     });
   });
 
@@ -501,17 +531,30 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
     });
 
-    it('setCutoutProperty (hide) leaves epoch unchanged', () => {
+    it('setCutoutProperty (hide) DOES bump epoch — the worker drops hidden cutouts (#3053)', () => {
       const { addCutout, setCutoutProperty } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'c-1' }));
       const epochBefore = useDesignerStore.getState().generation.epoch;
 
       setCutoutProperty(['c-1'], { hidden: true });
 
+      // `cutoutBuilder.ts` skips hidden cutouts, so hiding changes the part.
+      // Suppressing regeneration here left the preview showing a pocket the
+      // export would not cut.
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore + 1);
+    });
+
+    it('setCutoutProperty (name) leaves epoch unchanged', () => {
+      const { addCutout, setCutoutProperty } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1' }));
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+
+      setCutoutProperty(['c-1'], { name: 'Drill bit 3mm' });
+
       expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
     });
 
-    it('reorderCutouts leaves epoch unchanged', () => {
+    it('reorderCutouts leaves epoch unchanged when nothing is grouped', () => {
       const { addCutout, reorderCutouts } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'c-1' }));
       addCutout(createTestCutout({ id: 'c-2' }));
@@ -522,14 +565,25 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
     });
 
-    it('showAllCutouts leaves epoch unchanged', () => {
+    it('reorderCutouts bumps epoch when a group exists — z-order drives boolean ops', () => {
+      const { addCutout, reorderCutouts } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'c-1', groupId: 'g-1' }));
+      addCutout(createTestCutout({ id: 'c-2', groupId: 'g-1' }));
+      const epochBefore = useDesignerStore.getState().generation.epoch;
+
+      reorderCutouts(['c-1'], 'forward');
+
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore + 1);
+    });
+
+    it('showAllCutouts DOES bump epoch — it restores dropped cuts (#3053)', () => {
       const { addCutout, showAllCutouts } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'c-1', hidden: true }));
       const epochBefore = useDesignerStore.getState().generation.epoch;
 
       showAllCutouts();
 
-      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore);
+      expect(useDesignerStore.getState().generation.epoch).toBe(epochBefore + 1);
     });
 
     it('addCutout still bumps epoch (geometric)', () => {

--- a/src/features/bin-designer/store/slices/cutoutSlice.test.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.test.ts
@@ -120,6 +120,21 @@ describe('cutoutSlice - consolidated actions', () => {
       expect(zs).toEqual([0, 1, 2]);
     });
 
+    it('stacks duplicates above their sources instead of tying with them', () => {
+      // `...c` used to carry the source zIndex, so a duplicate shared a layer
+      // AND an area with its original — the one tie neither stacking channel
+      // can break consistently.
+      const { addCutout, duplicateCutouts } = useDesignerStore.getState();
+      addCutout(createTestCutout({ id: 'a' }));
+      addCutout(createTestCutout({ id: 'b' }));
+
+      duplicateCutouts(['a', 'b']);
+
+      const zs = useDesignerStore.getState().params.cutouts.map((c) => c.zIndex);
+      expect(new Set(zs).size).toBe(zs.length);
+      expect(zs).toEqual([0, 1, 2, 3]);
+    });
+
     it('honours an explicit zIndex on the incoming cutout', () => {
       const { addCutout } = useDesignerStore.getState();
       addCutout(createTestCutout({ id: 'a' }));

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -101,6 +101,24 @@ function zOrderAffectsGeometry(state: Draft<DesignerState>): boolean {
   return state.params.cutouts.some((c) => c.groupId !== null);
 }
 
+/**
+ * Put a new cutout on its own layer at the top of the stack.
+ *
+ * Two purposes: a freshly drawn shape should land on top, and giving every
+ * cutout a distinct `zIndex` keeps the renderer's stacking key strict. Two
+ * shapes sharing a layer AND an area would otherwise have identical scene Z and
+ * `renderOrder`, leaving the tie to be broken by raycast traversal order on one
+ * side and object id on the other — which can disagree.
+ *
+ * An explicit `zIndex` on the incoming cutout is honoured (paste/duplicate
+ * carry their own ordering).
+ */
+function withTopZIndex(state: Draft<DesignerState>, cutout: Cutout): Cutout {
+  if (cutout.zIndex !== undefined) return cutout;
+  const maxZ = state.params.cutouts.reduce((m, c) => Math.max(m, c.zIndex ?? 0), -1);
+  return { ...cutout, zIndex: maxZ + 1 };
+}
+
 export function createCutoutSlice(set: Set) {
   // Core actions
 
@@ -304,7 +322,7 @@ export function createCutoutSlice(set: Set) {
     addCutout: (cutout: Cutout) => {
       set((state) => {
         pushHistoryEntry(state);
-        state.params.cutouts = [...state.params.cutouts, cutout];
+        state.params.cutouts = [...state.params.cutouts, withTopZIndex(state, cutout)];
       });
     },
 

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -115,8 +115,12 @@ function zOrderAffectsGeometry(state: Draft<DesignerState>): boolean {
  */
 function withTopZIndex(state: Draft<DesignerState>, cutout: Cutout): Cutout {
   if (cutout.zIndex !== undefined) return cutout;
-  const maxZ = state.params.cutouts.reduce((m, c) => Math.max(m, c.zIndex ?? 0), -1);
-  return { ...cutout, zIndex: maxZ + 1 };
+  return { ...cutout, zIndex: nextTopZIndex(state) };
+}
+
+/** One past the highest occupied layer. */
+function nextTopZIndex(state: Draft<DesignerState>): number {
+  return state.params.cutouts.reduce((m, c) => Math.max(m, c.zIndex ?? 0), -1) + 1;
 }
 
 export function createCutoutSlice(set: Set) {
@@ -341,7 +345,7 @@ export function createCutoutSlice(set: Set) {
         }
         pushHistoryEntry(state);
         state.params.meshAssets = { ...existing, [meshId]: asset };
-        state.params.cutouts = [...state.params.cutouts, cutout];
+        state.params.cutouts = [...state.params.cutouts, withTopZIndex(state, cutout)];
       });
     },
 
@@ -382,7 +386,8 @@ export function createCutoutSlice(set: Set) {
         const toDuplicate = state.params.cutouts.filter((c) => cutoutIds.includes(c.id));
         // Map old groupId -> new groupId so groups are preserved
         const groupMap = new Map<string, string>();
-        const duplicated = toDuplicate.map((c) => {
+        const topZ = nextTopZIndex(state);
+        const duplicated = toDuplicate.map((c, i) => {
           let newGroupId: string | null = null;
           if (c.groupId) {
             if (!groupMap.has(c.groupId)) {
@@ -399,6 +404,11 @@ export function createCutoutSlice(set: Set) {
             x: c.x + 5,
             y: c.y + 5,
             groupId: newGroupId,
+            // Copies land above the originals, keeping their relative order.
+            // Inheriting `c.zIndex` would put a duplicate on the same layer as
+            // its source with an identical area — a tie neither stacking
+            // channel can break consistently.
+            zIndex: topZ + i,
             ...(translatedPath ? { path: translatedPath } : {}),
           };
         });

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -118,8 +118,18 @@ export function createCutoutSlice(set: Set) {
   const setCutoutProperty = (ids: readonly string[], partial: CutoutToggleProperties): void => {
     if (ids.length === 0) return;
     set((state) => {
-      pushHistoryEntry(state, { affectsGeometry: togglePropertyAffectsGeometry(partial) });
       const idSet = new Set(ids);
+      const keys = Object.keys(partial) as (keyof CutoutToggleProperties)[];
+      // Bail on a no-op: unknown ids, or the property already holds the wanted
+      // value. Now that `hidden` bumps the generation epoch, re-hiding an
+      // already-hidden cutout would otherwise cost a full worker rebuild on top
+      // of a redundant undo entry.
+      const changed = state.params.cutouts.some(
+        (c) => idSet.has(c.id) && keys.some((k) => c[k] !== partial[k])
+      );
+      if (!changed) return;
+
+      pushHistoryEntry(state, { affectsGeometry: togglePropertyAffectsGeometry(partial) });
       state.params.cutouts = state.params.cutouts.map((c) =>
         idSet.has(c.id) ? { ...c, ...partial } : c
       );

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -79,16 +79,46 @@ function gcMeshAssets(state: Draft<DesignerState>): void {
 
 type Set = (fn: (state: Draft<DesignerState>) => void) => void;
 
+/**
+ * Whether a toggle-property edit changes the generated part.
+ *
+ * Only `hidden` does: the worker drops hidden cutouts (`cutoutBuilder.ts`), so
+ * toggling it changes the geometry. `locked` and `name` are editor state the
+ * worker never reads.
+ */
+function togglePropertyAffectsGeometry(partial: CutoutToggleProperties): boolean {
+  return partial.hidden !== undefined;
+}
+
+/**
+ * Whether a z-order change reaches the geometry.
+ *
+ * `zIndex`'s only geometry consumer is boolean-op ordering inside a group
+ * (`cutoutGroupOps.ts`), so a design with nothing grouped can reorder purely
+ * visually and skip the worker.
+ */
+function zOrderAffectsGeometry(state: Draft<DesignerState>): boolean {
+  return state.params.cutouts.some((c) => c.groupId !== null);
+}
+
 export function createCutoutSlice(set: Set) {
   // Core actions
 
-  // locked/hidden/zIndex are editor-only state — the worker reads neither
-  // (see cutoutBuilder.ts), so these mutations get history but skip the
-  // generation epoch.
+  /**
+   * `locked` and `name` are editor-only, but `hidden` is NOT: the worker skips
+   * hidden cutouts (`cutoutBuilder.ts`), so toggling it changes the generated
+   * part and has to bump the generation epoch. Suppressing that regeneration
+   * left the preview showing a pocket the export would not cut — a silent
+   * preview-vs-export divergence.
+   *
+   * `zIndex` only reorders boolean ops within a group, so it regenerates too
+   * whenever the design has any grouped cutouts; a flat design's ordering is
+   * purely visual and can skip the worker.
+   */
   const setCutoutProperty = (ids: readonly string[], partial: CutoutToggleProperties): void => {
     if (ids.length === 0) return;
     set((state) => {
-      pushHistoryEntry(state, { affectsGeometry: false });
+      pushHistoryEntry(state, { affectsGeometry: togglePropertyAffectsGeometry(partial) });
       const idSet = new Set(ids);
       state.params.cutouts = state.params.cutouts.map((c) =>
         idSet.has(c.id) ? { ...c, ...partial } : c
@@ -96,40 +126,92 @@ export function createCutoutSlice(set: Set) {
     });
   };
 
+  /**
+   * Current stack, bottom to top.
+   *
+   * Ties break on array order so an all-default design (every `zIndex` absent,
+   * i.e. 0) still has a stable, predictable starting stack rather than an
+   * arbitrary one.
+   */
+  const stackBottomToTop = (cutouts: readonly Cutout[]): Cutout[] => {
+    const indexById = new Map(cutouts.map((c, i) => [c.id, i]));
+    return [...cutouts].sort(
+      (a, b) =>
+        (a.zIndex ?? 0) - (b.zIndex ?? 0) || (indexById.get(a.id) ?? 0) - (indexById.get(b.id) ?? 0)
+    );
+  };
+
+  /**
+   * Move the selection one slot through an ordered stack, as a block.
+   *
+   * Walks from the far end so a contiguous run of selected shapes shifts
+   * together instead of collapsing onto itself, and a selection already at the
+   * end simply stays put.
+   */
+  const shiftOneSlot = (order: Cutout[], isSelected: (c: Cutout) => boolean, up: boolean): void => {
+    if (up) {
+      for (let i = order.length - 2; i >= 0; i--) {
+        if (isSelected(order[i]) && !isSelected(order[i + 1])) {
+          [order[i], order[i + 1]] = [order[i + 1], order[i]];
+        }
+      }
+    } else {
+      for (let i = 1; i < order.length; i++) {
+        if (isSelected(order[i]) && !isSelected(order[i - 1])) {
+          [order[i], order[i - 1]] = [order[i - 1], order[i]];
+        }
+      }
+    }
+  };
+
+  /**
+   * Re-stack the selection and renumber onto contiguous `zIndex` values 0..n-1.
+   *
+   * Reordering positions rather than doing arithmetic on `zIndex` is what makes
+   * "send to back" mean anything: the old code wrote absolute values against a
+   * field that defaults to 0 for every cutout, so `back` set 0 on something
+   * already at 0 and `backward` clamped to `max(-1, 0)`. Both silently did
+   * nothing until some other shape had been sent forward first (#3053).
+   */
   const reorderCutouts = (ids: readonly string[], direction: ReorderDirection): void => {
     if (ids.length === 0) return;
     set((state) => {
-      pushHistoryEntry(state, { affectsGeometry: false });
       const idSet = new Set(ids);
+      const cutouts = state.params.cutouts;
+      if (!cutouts.some((c) => idSet.has(c.id))) return;
+
+      const isSelected = (c: Cutout): boolean => idSet.has(c.id);
+      const order = stackBottomToTop(cutouts);
+      let next: Cutout[];
 
       switch (direction) {
-        case 'forward': {
-          const maxZ = Math.max(0, ...state.params.cutouts.map((c) => c.zIndex ?? 0));
-          state.params.cutouts = state.params.cutouts.map((c) =>
-            idSet.has(c.id) ? { ...c, zIndex: Math.min((c.zIndex ?? 0) + 1, maxZ + 1) } : c
-          );
+        // Front/back preserve the selection's own internal order — bringing two
+        // shapes forward together must not shuffle them relative to each other.
+        case 'front':
+          next = [...order.filter((c) => !isSelected(c)), ...order.filter(isSelected)];
           break;
-        }
-        case 'backward': {
-          state.params.cutouts = state.params.cutouts.map((c) =>
-            idSet.has(c.id) ? { ...c, zIndex: Math.max((c.zIndex ?? 0) - 1, 0) } : c
-          );
+        case 'back':
+          next = [...order.filter(isSelected), ...order.filter((c) => !isSelected(c))];
           break;
-        }
-        case 'front': {
-          const maxZ = Math.max(0, ...state.params.cutouts.map((c) => c.zIndex ?? 0));
-          state.params.cutouts = state.params.cutouts.map((c) =>
-            idSet.has(c.id) ? { ...c, zIndex: maxZ + 1 } : c
-          );
+        case 'forward':
+          next = order;
+          shiftOneSlot(next, isSelected, true);
           break;
-        }
-        case 'back': {
-          state.params.cutouts = state.params.cutouts.map((c) =>
-            idSet.has(c.id) ? { ...c, zIndex: 0 } : c
-          );
+        case 'backward':
+          next = order;
+          shiftOneSlot(next, isSelected, false);
           break;
-        }
       }
+
+      const zById = new Map(next.map((c, i) => [c.id, i]));
+      const restacked = cutouts.map((c) => {
+        const z = zById.get(c.id) ?? 0;
+        return c.zIndex === z ? c : { ...c, zIndex: z };
+      });
+      if (restacked.every((c, i) => c === cutouts[i])) return;
+
+      pushHistoryEntry(state, { affectsGeometry: zOrderAffectsGeometry(state) });
+      state.params.cutouts = restacked;
     });
   };
 
@@ -137,7 +219,8 @@ export function createCutoutSlice(set: Set) {
     set((state) => {
       const hasHidden = state.params.cutouts.some((c) => c.hidden);
       if (!hasHidden) return;
-      pushHistoryEntry(state, { affectsGeometry: false });
+      // Unhiding restores cuts the worker had dropped, so this regenerates.
+      pushHistoryEntry(state, { affectsGeometry: true });
       state.params.cutouts = state.params.cutouts.map((c) =>
         c.hidden ? { ...c, hidden: false } : c
       );

--- a/src/features/bin-designer/store/slices/cutoutSlice.ts
+++ b/src/features/bin-designer/store/slices/cutoutSlice.ts
@@ -83,8 +83,8 @@ type Set = (fn: (state: Draft<DesignerState>) => void) => void;
  * Whether a toggle-property edit changes the generated part.
  *
  * Only `hidden` does: the worker drops hidden cutouts (`cutoutBuilder.ts`), so
- * toggling it changes the geometry. `locked` and `name` are editor state the
- * worker never reads.
+ * toggling it changes the geometry. `locked` is editor state the worker
+ * never reads.
  */
 function togglePropertyAffectsGeometry(partial: CutoutToggleProperties): boolean {
   return partial.hidden !== undefined;
@@ -105,7 +105,7 @@ export function createCutoutSlice(set: Set) {
   // Core actions
 
   /**
-   * `locked` and `name` are editor-only, but `hidden` is NOT: the worker skips
+   * `locked` is editor-only, but `hidden` is NOT: the worker skips
    * hidden cutouts (`cutoutBuilder.ts`), so toggling it changes the generated
    * part and has to bump the generation epoch. Suppressing that regeneration
    * left the preview showing a pocket the export would not cut — a silent

--- a/src/features/bin-designer/types/cutout.ts
+++ b/src/features/bin-designer/types/cutout.ts
@@ -220,7 +220,7 @@ export interface PathPoint {
 export type ReorderDirection = 'forward' | 'backward' | 'front' | 'back';
 
 /** Narrowed property subset for bulk cutout toggling (lock/hide) */
-export type CutoutToggleProperties = Partial<Pick<Cutout, 'locked' | 'hidden'>>;
+export type CutoutToggleProperties = Partial<Pick<Cutout, 'locked' | 'hidden' | 'name'>>;
 
 /** Global cutout configuration for solid bins */
 export interface CutoutConfig {
@@ -274,11 +274,24 @@ export interface Cutout {
    * Applies only to ungrouped rectangle cutouts; ignored for circles/paths and grouped cutouts.
    */
   readonly scoopEdges?: CutoutScoopEdges;
+  /**
+   * Editor-only display name shown in the shape list (issue #3053). Optional —
+   * when unset the list derives a label from the shape and size, so most
+   * designs never carry one.
+   *
+   * Deliberately NOT {@link label}: that is the text physically engraved on the
+   * bin, so renaming a row must not change what gets cut into the part.
+   */
+  readonly name?: string;
   /** When true, the cutout cannot be moved, resized, or rotated */
   readonly locked?: boolean;
   /** When true, the cutout is not rendered or selectable (faint ghost only) */
   readonly hidden?: boolean;
-  /** Z-order for rendering layering (higher = rendered on top) */
+  /**
+   * Z-order: higher draws on top and wins the click on overlap. Also orders
+   * boolean ops within a group (`cutoutGroupOps.ts`). Absent = 0; the editor
+   * re-stacks to contiguous 0..n-1 whenever anything is reordered.
+   */
   readonly zIndex?: number;
   /** Path vertices for pen tool shapes (required when shape === 'path') */
   readonly path?: PathPoint[];

--- a/src/features/bin-designer/types/cutout.ts
+++ b/src/features/bin-designer/types/cutout.ts
@@ -220,7 +220,7 @@ export interface PathPoint {
 export type ReorderDirection = 'forward' | 'backward' | 'front' | 'back';
 
 /** Narrowed property subset for bulk cutout toggling (lock/hide) */
-export type CutoutToggleProperties = Partial<Pick<Cutout, 'locked' | 'hidden' | 'name'>>;
+export type CutoutToggleProperties = Partial<Pick<Cutout, 'locked' | 'hidden'>>;
 
 /** Global cutout configuration for solid bins */
 export interface CutoutConfig {
@@ -274,15 +274,6 @@ export interface Cutout {
    * Applies only to ungrouped rectangle cutouts; ignored for circles/paths and grouped cutouts.
    */
   readonly scoopEdges?: CutoutScoopEdges;
-  /**
-   * Editor-only display name shown in the shape list (issue #3053). Optional —
-   * when unset the list derives a label from the shape and size, so most
-   * designs never carry one.
-   *
-   * Deliberately NOT {@link label}: that is the text physically engraved on the
-   * bin, so renaming a row must not change what gets cut into the part.
-   */
-  readonly name?: string;
   /** When true, the cutout cannot be moved, resized, or rotated */
   readonly locked?: boolean;
   /** When true, the cutout is not rendered or selectable (faint ghost only) */


### PR DESCRIPTION
Part of #3053. Fixes the three defects behind the report; the shape list itself follows in a separate PR.

## Summary

The issue says *"Send To Back and Bring To Front don't work at all for me."* That is accurate, and tracing it turned up two more problems in the same area.

**1. Bring to Front / Send to Back changed a number nothing visible read.** `Cutout.zIndex` was documented as *"Z-order for rendering layering (higher = rendered on top)"*, but no renderer or hit-test read it. `SceneContent` mapped cutouts in plain array order, and picking was resolved by shape **area** (smaller wins the raycast). The only consumers were `booleanGeometry.ts` and `cutoutGroupOps.ts`, which sort boolean ops *within a group*.

**2. Send to Back and Send Backward were no-ops from a clean slate.** Every cutout defaults to `zIndex ?? 0`, so `back` wrote 0 over 0 and `backward` computed `Math.max(0 - 1, 0)`. Only `front`/`forward` ever moved anything, and only because they used `maxZ + 1`.

**3. Hiding a cutout changed the part but suppressed regeneration.** `cutoutBuilder.ts` skips hidden cutouts, yet hide/show/showAll all passed `affectsGeometry: false` on the stated grounds that *"the worker reads neither"*. So hiding a shape left the preview showing a pocket the export would not cut — a silent preview-vs-export divergence.

## What changed

- **z-order now drives both channels.** The editor draws with `depthTest: false`, which splits stacking in two: scene Z decides the click, `renderOrder` decides the paint. A shared `zLayer.ts` feeds both from `zIndex`, so they cannot disagree.
- **All four shape renderers** (SDF, path, polygon, mesh footprint) go through that helper. They each had their own copy of the Z formula, which is how one could have been fixed and the others silently left behind.
- **The smaller-shape-wins heuristic is kept as the tiebreaker** within a layer. It is what lets you click a small shape sitting on a large one before anyone has touched the ordering; explicit order just outranks it now.
- **Reordering works on stack positions** and renumbers onto contiguous `0..n-1`, so a selection moves as a block and keeps its internal order.
- **Hide/show bumps the generation epoch.** `zIndex` bumps it only when something is grouped, since that is its sole geometry consumer.

## Notes for review

Six existing tests failed against these fixes because they **encoded the bugs** — `setCutoutProperty (hide) leaves epoch unchanged` was asserting the defect. They are rewritten to pin relative stacking order, which is the actual contract, rather than absolute `zIndex` values that were an artifact of the old arithmetic.

An earlier draft of the reorder collapsed the selection to `±Infinity`; that loses the selection's internal order, so bringing two shapes forward together shuffled them. The tests caught it and it is now the standard positional algorithm.

## Test plan

- [x] 62 store tests, including a case that starts from an all-default stack (the configuration where `back` did nothing)
- [x] 10 unit tests on the z-layer maths: order beats the area tiebreaker, the offset never bleeds `SHAPES` into `GROUP_FILL`, and the stack stays inside the camera near plane
- [x] Full bin-designer suite green (3683 tests), typecheck, lint, module boundaries
- [ ] **Interactive z-order not verified in a browser.** The editor renders correctly with the change, but I could not reliably create two overlapping shapes through synthetic drags (snap-to-grid plus drag-capture kept eating the second shape), so the click-order change is covered by unit tests and the diff rather than by a live click. Worth an eyeball on the preview deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cutout z-order and visibility so bring/send and hide/show work in the editor and in the generated part. Click order now matches paint order, and preview aligns with export (addresses #3053).

- **Bug Fixes**
  - Use shared `zLayer.ts` to drive both scene Z (picking) and `renderOrder` (painting) from the same (layer, area) key across SDF, path, polygon, and mesh footprint renderers; footprints now use real area so they take part in the tiebreaker.
  - Reorder by stack position and renumber to contiguous `0..n-1`; back/backward work from all-default stacks; multi-select moves as a block; new cutouts, STL imports, and duplicates stack on their own layers (copies land above originals and keep relative order) to avoid ties.
  - Hide/show/showAll bump the generation epoch because hidden cutouts change geometry; z-order bumps epoch only when groups exist; no-op property sets and unknown ids bail out without history or regeneration.

<sup>Written for commit 392fd44151f8ee6719ae1597a9f5917bd869a486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

