### PR TITLE
fix(bin-designer): keep a typed cutout size instead of truncating it to the bin

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
@@ -34,4 +34,56 @@ describe('BinSizeSection', () => {
     expect(screen.getByText('binDesigner.cutoutEditor.offBoardWarning')).toBeInTheDocument();
     expect(screen.queryByText('binDesigner.cutoutEditor.bringBackIn')).not.toBeInTheDocument();
   });
+
+  it('offers to grow the bin alongside clamping back in', () => {
+    const onGrow = vi.fn();
+    render(
+      <BinSizeSection
+        offBoardCount={1}
+        onClampOffBoard={vi.fn()}
+        growTarget={{ width: 4, depth: 3 }}
+        onGrowToFit={onGrow}
+      />
+    );
+    fireEvent.click(screen.getByText('binDesigner.cutoutEditor.growBinToFit'));
+    expect(onGrow).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('binDesigner.cutoutEditor.bringBackIn')).toBeInTheDocument();
+    expect(
+      screen.queryByText('binDesigner.cutoutEditor.growBinUnavailable')
+    ).not.toBeInTheDocument();
+  });
+
+  it('leads with the grow action', () => {
+    render(
+      <BinSizeSection
+        offBoardCount={1}
+        onClampOffBoard={vi.fn()}
+        growTarget={{ width: 4, depth: 3 }}
+        onGrowToFit={vi.fn()}
+      />
+    );
+    const labels = screen.getAllByRole('button').map((b) => b.textContent);
+    expect(labels.indexOf('binDesigner.cutoutEditor.growBinToFit')).toBeLessThan(
+      labels.indexOf('binDesigner.cutoutEditor.bringBackIn')
+    );
+  });
+
+  it('explains why instead of offering a grow that cannot clear the warning', () => {
+    render(
+      <BinSizeSection
+        offBoardCount={1}
+        onClampOffBoard={vi.fn()}
+        growTarget={null}
+        onGrowToFit={vi.fn()}
+      />
+    );
+    expect(screen.queryByText('binDesigner.cutoutEditor.growBinToFit')).not.toBeInTheDocument();
+    expect(screen.getByText('binDesigner.cutoutEditor.growBinUnavailable')).toBeInTheDocument();
+    expect(screen.getByText('binDesigner.cutoutEditor.bringBackIn')).toBeInTheDocument();
+  });
+
+  it('keeps the grow action out of the panel when nothing is stranded', () => {
+    render(<BinSizeSection offBoardCount={0} growTarget={{ width: 4, depth: 3 }} />);
+    expect(screen.queryByText('binDesigner.cutoutEditor.growBinToFit')).not.toBeInTheDocument();
+  });
 });

--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
@@ -2,9 +2,17 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BinSizeSection } from './BinSizeSection';
 
+// Interpolating mock: a key-only mock cannot tell "Grow bin to 5 × 3" from a
+// button with no size in it, which is the behaviour this panel exists for.
 vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
+  useTranslation: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key} ${JSON.stringify(params)}` : key,
 }));
+
+/** Mirrors the mock, so assertions read as the string the panel renders. */
+const tk = (key: string, params?: Record<string, unknown>) =>
+  params ? `${key} ${JSON.stringify(params)}` : key;
+const K = 'binDesigner.cutoutEditor';
 
 vi.mock('../panel/DimensionsSection/DimensionsSection', () => ({
   DimensionsSection: () => <div data-testid="dimensions-section" />,
@@ -18,21 +26,21 @@ describe('BinSizeSection', () => {
 
   it('hides the off-board warning when nothing is stranded', () => {
     render(<BinSizeSection offBoardCount={0} onClampOffBoard={vi.fn()} />);
-    expect(screen.queryByText('binDesigner.cutoutEditor.offBoardWarning')).not.toBeInTheDocument();
+    expect(screen.queryByText(tk(`${K}.offBoardWarning`, { count: 0 }))).not.toBeInTheDocument();
   });
 
   it('shows the warning and recover button when cutouts are off-board', () => {
     const onClamp = vi.fn();
     render(<BinSizeSection offBoardCount={2} onClampOffBoard={onClamp} />);
-    expect(screen.getByText('binDesigner.cutoutEditor.offBoardWarning')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('binDesigner.cutoutEditor.bringBackIn'));
+    expect(screen.getByText(tk(`${K}.offBoardWarning`, { count: 2 }))).toBeInTheDocument();
+    fireEvent.click(screen.getByText(`${K}.bringBackIn`));
     expect(onClamp).toHaveBeenCalledTimes(1);
   });
 
   it('omits the recover button when no handler is provided', () => {
     render(<BinSizeSection offBoardCount={2} />);
-    expect(screen.getByText('binDesigner.cutoutEditor.offBoardWarning')).toBeInTheDocument();
-    expect(screen.queryByText('binDesigner.cutoutEditor.bringBackIn')).not.toBeInTheDocument();
+    expect(screen.getByText(tk(`${K}.offBoardWarning`, { count: 2 }))).toBeInTheDocument();
+    expect(screen.queryByText(`${K}.bringBackIn`)).not.toBeInTheDocument();
   });
 
   it('offers to grow the bin alongside clamping back in', () => {
@@ -45,12 +53,10 @@ describe('BinSizeSection', () => {
         onGrowToFit={onGrow}
       />
     );
-    fireEvent.click(screen.getByText('binDesigner.cutoutEditor.growBinToFit'));
+    fireEvent.click(screen.getByText(tk(`${K}.growBinToFit`, { width: 4, depth: 3 })));
     expect(onGrow).toHaveBeenCalledTimes(1);
-    expect(screen.getByText('binDesigner.cutoutEditor.bringBackIn')).toBeInTheDocument();
-    expect(
-      screen.queryByText('binDesigner.cutoutEditor.growBinUnavailable')
-    ).not.toBeInTheDocument();
+    expect(screen.getByText(`${K}.bringBackIn`)).toBeInTheDocument();
+    expect(screen.queryByText(`${K}.growBinUnavailable`)).not.toBeInTheDocument();
   });
 
   it('leads with the grow action', () => {
@@ -63,11 +69,11 @@ describe('BinSizeSection', () => {
       />
     );
     const labels = screen.getAllByRole('button').map((b) => b.textContent);
-    const grow = labels.indexOf('binDesigner.cutoutEditor.growBinToFit');
+    const grow = labels.indexOf(tk(`${K}.growBinToFit`, { width: 4, depth: 3 }));
     // Assert presence first: a missing button indexes to -1, which would pass
     // the ordering comparison on its own.
     expect(grow).toBeGreaterThanOrEqual(0);
-    expect(grow).toBeLessThan(labels.indexOf('binDesigner.cutoutEditor.bringBackIn'));
+    expect(grow).toBeLessThan(labels.indexOf(`${K}.bringBackIn`));
   });
 
   it('explains why instead of offering a grow that cannot clear the warning', () => {
@@ -79,28 +85,50 @@ describe('BinSizeSection', () => {
         onGrowToFit={vi.fn()}
       />
     );
-    expect(screen.queryByText('binDesigner.cutoutEditor.growBinToFit')).not.toBeInTheDocument();
-    expect(screen.getByText('binDesigner.cutoutEditor.growBinUnavailable')).toBeInTheDocument();
-    expect(screen.getByText('binDesigner.cutoutEditor.bringBackIn')).toBeInTheDocument();
+    expect(
+      screen.queryByText(tk(`${K}.growBinToFit`, { width: 4, depth: 3 }))
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(`${K}.growBinUnavailable`)).toBeInTheDocument();
+    expect(screen.getByText(`${K}.bringBackIn`)).toBeInTheDocument();
   });
 
   it('keeps the grow action out of the panel when nothing is stranded', () => {
     render(<BinSizeSection offBoardCount={0} growTarget={{ width: 4, depth: 3 }} />);
-    expect(screen.queryByText('binDesigner.cutoutEditor.growBinToFit')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(tk(`${K}.growBinToFit`, { width: 4, depth: 3 }))
+    ).not.toBeInTheDocument();
+  });
+
+  // Naming the resulting size is the point of the action: it lets you see what
+  // the click will produce before committing to it. Half-grid targets are
+  // fractional, so the exact values have to survive into the label.
+  it.each([
+    { width: 4, depth: 3 },
+    { width: 3.5, depth: 2 },
+  ])('names the exact size it will produce ($width × $depth)', (target) => {
+    render(
+      <BinSizeSection
+        offBoardCount={1}
+        onClampOffBoard={vi.fn()}
+        growTarget={target}
+        onGrowToFit={vi.fn()}
+      />
+    );
+    expect(screen.getByText(tk(`${K}.growBinToFit`, target))).toBeInTheDocument();
   });
 
   // Screen readers got nothing when a cutout went off-board before this.
   it('announces the warning assertively', () => {
     render(<BinSizeSection offBoardCount={1} onClampOffBoard={vi.fn()} />);
-    expect(screen.getByRole('alert')).toHaveTextContent('binDesigner.cutoutEditor.offBoardWarning');
+    expect(screen.getByRole('alert')).toHaveTextContent(`${K}.offBoardWarning`);
   });
 
   it('puts the unavailable reason above the actions, not after them', () => {
     render(<BinSizeSection offBoardCount={1} onClampOffBoard={vi.fn()} growTarget={null} />);
     const alert = screen.getByRole('alert');
     const order = [...alert.querySelectorAll('p, button')].map((n) => n.textContent);
-    expect(order.indexOf('binDesigner.cutoutEditor.growBinUnavailable')).toBeLessThan(
-      order.indexOf('binDesigner.cutoutEditor.bringBackIn')
+    expect(order.indexOf(`${K}.growBinUnavailable`)).toBeLessThan(
+      order.indexOf(`${K}.bringBackIn`)
     );
   });
 
@@ -115,9 +143,8 @@ describe('BinSizeSection', () => {
         onGrowToFit={vi.fn()}
       />
     );
-    for (const name of ['growBinToFit', 'bringBackIn']) {
-      const btn = screen.getByText(`binDesigner.cutoutEditor.${name}`);
-      expect(btn).toHaveClass('h-auto', 'whitespace-normal');
+    for (const label of [tk(`${K}.growBinToFit`, { width: 4, depth: 3 }), `${K}.bringBackIn`]) {
+      expect(screen.getByText(label)).toHaveClass('h-auto', 'whitespace-normal');
     }
   });
 });

--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
@@ -63,9 +63,11 @@ describe('BinSizeSection', () => {
       />
     );
     const labels = screen.getAllByRole('button').map((b) => b.textContent);
-    expect(labels.indexOf('binDesigner.cutoutEditor.growBinToFit')).toBeLessThan(
-      labels.indexOf('binDesigner.cutoutEditor.bringBackIn')
-    );
+    const grow = labels.indexOf('binDesigner.cutoutEditor.growBinToFit');
+    // Assert presence first: a missing button indexes to -1, which would pass
+    // the ordering comparison on its own.
+    expect(grow).toBeGreaterThanOrEqual(0);
+    expect(grow).toBeLessThan(labels.indexOf('binDesigner.cutoutEditor.bringBackIn'));
   });
 
   it('explains why instead of offering a grow that cannot clear the warning', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
@@ -86,4 +86,36 @@ describe('BinSizeSection', () => {
     render(<BinSizeSection offBoardCount={0} growTarget={{ width: 4, depth: 3 }} />);
     expect(screen.queryByText('binDesigner.cutoutEditor.growBinToFit')).not.toBeInTheDocument();
   });
+
+  // Screen readers got nothing when a cutout went off-board before this.
+  it('announces the warning assertively', () => {
+    render(<BinSizeSection offBoardCount={1} onClampOffBoard={vi.fn()} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('binDesigner.cutoutEditor.offBoardWarning');
+  });
+
+  it('puts the unavailable reason above the actions, not after them', () => {
+    render(<BinSizeSection offBoardCount={1} onClampOffBoard={vi.fn()} growTarget={null} />);
+    const alert = screen.getByRole('alert');
+    const order = [...alert.querySelectorAll('p, button')].map((n) => n.textContent);
+    expect(order.indexOf('binDesigner.cutoutEditor.growBinUnavailable')).toBeLessThan(
+      order.indexOf('binDesigner.cutoutEditor.bringBackIn')
+    );
+  });
+
+  // The dock narrows to 220px and 7 of 15 locales overrun the label there, so a
+  // fixed-height button would clip the second line.
+  it('lets the action labels wrap instead of clipping', () => {
+    render(
+      <BinSizeSection
+        offBoardCount={1}
+        onClampOffBoard={vi.fn()}
+        growTarget={{ width: 4, depth: 3 }}
+        onGrowToFit={vi.fn()}
+      />
+    );
+    for (const name of ['growBinToFit', 'bringBackIn']) {
+      const btn = screen.getByText(`binDesigner.cutoutEditor.${name}`);
+      expect(btn).toHaveClass('h-auto', 'whitespace-normal');
+    }
+  });
 });

--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
@@ -7,10 +7,17 @@
  */
 
 import type { GrowTarget } from '../panel/CutoutsSection/growBinToFit';
-import { Button } from '@/design-system';
+import { Alert, Button } from '@/design-system';
 import { AlertTriangleIcon } from '@/design-system/Icon';
 import { useTranslation } from '@/i18n';
 import { DimensionsSection } from '../panel/DimensionsSection/DimensionsSection';
+
+/**
+ * The dock narrows to 220px and the action names a bin size, so verbose locales
+ * (it/uk/de and four others measure past the content box) need a second line.
+ * `h-6` would clip it, so the button sizes to its content instead.
+ */
+const WRAPPING_ACTION = 'h-auto min-h-6 whitespace-normal py-1 leading-tight';
 
 interface BinSizeSectionProps {
   /** Count of cutouts stranded past the board after a resize (0 = none). */
@@ -43,32 +50,49 @@ export function BinSizeSection({
       <DimensionsSection />
 
       {offBoardCount > 0 && (
-        <div className="space-y-2 rounded-md border border-error/40 bg-error-muted p-2">
-          <div className="flex items-start gap-1.5">
-            <AlertTriangleIcon size="xs" className="mt-0.5 shrink-0 text-error" />
-            <span className="text-[11px] leading-snug text-error">
-              {t('binDesigner.cutoutEditor.offBoardWarning', { count: offBoardCount })}
-            </span>
-          </div>
-          {growTarget && onGrowToFit && (
-            <Button type="button" variant="primary" size="sm" fullWidth onClick={onGrowToFit}>
-              {t('binDesigner.cutoutEditor.growBinToFit', {
-                width: growTarget.width,
-                depth: growTarget.depth,
-              })}
-            </Button>
-          )}
-          {onClampOffBoard && (
-            <Button type="button" variant="secondary" size="sm" fullWidth onClick={onClampOffBoard}>
-              {t('binDesigner.cutoutEditor.bringBackIn')}
-            </Button>
-          )}
+        // Alert carries role="alert", so the warning now announces when a cutout
+        // is stranded; the hand-rolled box it replaces was silent.
+        <Alert intent="error" icon={<AlertTriangleIcon size="xs" className="mt-0.5" />}>
+          <p className="leading-snug text-error">
+            {t('binDesigner.cutoutEditor.offBoardWarning', { count: offBoardCount })}
+          </p>
+          {/* Reads as the reason the grow action is absent, so it belongs with
+              the warning rather than below the buttons. */}
           {growTarget === null && (
-            <span className="block text-[10px] leading-snug text-content-tertiary">
+            <p className="mt-1 leading-snug text-error/80">
               {t('binDesigner.cutoutEditor.growBinUnavailable')}
-            </span>
+            </p>
           )}
-        </div>
+          <div className="mt-2 space-y-2">
+            {growTarget && onGrowToFit && (
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                fullWidth
+                className={WRAPPING_ACTION}
+                onClick={onGrowToFit}
+              >
+                {t('binDesigner.cutoutEditor.growBinToFit', {
+                  width: growTarget.width,
+                  depth: growTarget.depth,
+                })}
+              </Button>
+            )}
+            {onClampOffBoard && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                fullWidth
+                className={WRAPPING_ACTION}
+                onClick={onClampOffBoard}
+              >
+                {t('binDesigner.cutoutEditor.bringBackIn')}
+              </Button>
+            )}
+          </div>
+        </Alert>
       )}
     </div>
   );

--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
@@ -1,10 +1,12 @@
 /**
  * Always-visible bin-size block at the top of the cutout inspector, so the bin
  * can be resized without leaving the editor. Reuses the main DimensionsSection
- * (self-wired to the designer store) and, when a resize strands cutouts past
- * the new footprint, surfaces a warning with a one-click clamp-back action.
+ * (self-wired to the designer store) and, when cutouts sit past the footprint,
+ * surfaces a warning offering the two ways out: grow the board to them, or
+ * clamp them back in.
  */
 
+import type { GrowTarget } from '../panel/CutoutsSection/growBinToFit';
 import { Button } from '@/design-system';
 import { AlertTriangleIcon } from '@/design-system/Icon';
 import { useTranslation } from '@/i18n';
@@ -15,9 +17,22 @@ interface BinSizeSectionProps {
   readonly offBoardCount: number;
   /** Clamp every off-board cutout back inside the board. */
   readonly onClampOffBoard?: () => void;
+  /**
+   * Bin size that would fit every stray, or `null` when growing can't clear the
+   * warning (past `MAX_DIMENSION`, a custom footprint, or a stray hanging past
+   * the origin edge). `null` hides the action rather than growing partway.
+   */
+  readonly growTarget?: GrowTarget | null;
+  /** Resize the bin to {@link growTarget}. */
+  readonly onGrowToFit?: () => void;
 }
 
-export function BinSizeSection({ offBoardCount, onClampOffBoard }: BinSizeSectionProps) {
+export function BinSizeSection({
+  offBoardCount,
+  onClampOffBoard,
+  growTarget,
+  onGrowToFit,
+}: BinSizeSectionProps) {
   const t = useTranslation();
   return (
     <div className="space-y-3 border-b border-stroke-subtle pb-3 pt-3">
@@ -35,10 +50,23 @@ export function BinSizeSection({ offBoardCount, onClampOffBoard }: BinSizeSectio
               {t('binDesigner.cutoutEditor.offBoardWarning', { count: offBoardCount })}
             </span>
           </div>
+          {growTarget && onGrowToFit && (
+            <Button type="button" variant="primary" size="sm" fullWidth onClick={onGrowToFit}>
+              {t('binDesigner.cutoutEditor.growBinToFit', {
+                width: growTarget.width,
+                depth: growTarget.depth,
+              })}
+            </Button>
+          )}
           {onClampOffBoard && (
             <Button type="button" variant="secondary" size="sm" fullWidth onClick={onClampOffBoard}>
               {t('binDesigner.cutoutEditor.bringBackIn')}
             </Button>
+          )}
+          {growTarget === null && (
+            <span className="block text-[10px] leading-snug text-content-tertiary">
+              {t('binDesigner.cutoutEditor.growBinUnavailable')}
+            </span>
           )}
         </div>
       )}

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -26,6 +26,7 @@ import {
   getOffBoardCutoutIds,
   clampOffBoardCutouts,
 } from '../panel/CutoutsSection/offBoardCutouts';
+import { computeGrowToFit } from '../panel/CutoutsSection/growBinToFit';
 import { CutoutCanvas3D } from '../panel/CutoutsSection/renderer';
 import { WorkspaceHeader } from './WorkspaceHeader';
 import { CutoutShapeToolbar } from '../panel/CutoutsSection/CutoutShapeToolbar';
@@ -70,6 +71,8 @@ export function CutoutWorkspace() {
     canRedo,
     lockCutouts,
     unlockCutouts,
+    halfGridMode,
+    setParams,
   } = useDesignerStore(
     useShallow((s) => ({
       params: s.params,
@@ -93,6 +96,8 @@ export function CutoutWorkspace() {
       canRedo: s.history.future.length > 0,
       lockCutouts: s.lockCutouts,
       unlockCutouts: s.unlockCutouts,
+      halfGridMode: s.ui.halfGridMode,
+      setParams: s.setParams,
     }))
   );
 
@@ -179,6 +184,21 @@ export function CutoutWorkspace() {
     (id: string) => applyFlattenArray(id, cutouts, updateCutout, addCutout),
     [cutouts, updateCutout, addCutout]
   );
+
+  // Grow-to-fit companion to the clamp: a typed W/H past the board is kept
+  // rather than truncated (#3061), so the warning offers to move the board to
+  // the cutouts as well as the cutouts to the board. `null` = growing can't
+  // clear the warning, and the action is hidden rather than half-applied.
+  const growTarget = useMemo(
+    () => computeGrowToFit(params, cutouts, halfGridMode),
+    [params, cutouts, halfGridMode]
+  );
+
+  const handleGrowToFit = useCallback(() => {
+    if (!growTarget) return;
+    // One setParams, so growing both axes is a single undo step.
+    setParams({ width: growTarget.width, depth: growTarget.depth });
+  }, [growTarget, setParams]);
 
   const handleClampOffBoard = useCallback(() => {
     const updates = clampOffBoardCutouts(
@@ -516,6 +536,8 @@ export function CutoutWorkspace() {
           onFlattenArray={handleFlattenArray}
           offBoardCount={offBoardIds.size}
           onClampOffBoard={handleClampOffBoard}
+          growTarget={growTarget}
+          onGrowToFit={handleGrowToFit}
           onDuplicate={duplicateSelected}
           onDelete={deleteSelected}
           board={{

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -345,6 +345,41 @@ describe('InspectorContent multi-select editing', () => {
     expect(updates.get('pinned')?.cutDepth).toBe(8);
   });
 
+  it('keeps a batch W past the board instead of truncating the measurement (#3061)', () => {
+    const onUpdateBatch = renderMulti([
+      createCutout({ id: 'a' }),
+      createCutout({ id: 'b', width: 40 }),
+    ]);
+
+    // binWidth is 100 — the old behaviour silently rewrote this to 100.
+    fireEvent.change(screen.getByTestId('compact-input-W'), { target: { value: '156' } });
+
+    const updates = onUpdateBatch.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    expect(updates.get('a')?.width).toBe(156);
+    expect(updates.get('b')?.width).toBe(156);
+  });
+
+  it('still floors a batch W at the minimum cutout size', () => {
+    const onUpdateBatch = renderMulti([createCutout({ id: 'a' }), createCutout({ id: 'b' })]);
+
+    fireEvent.change(screen.getByTestId('compact-input-W'), { target: { value: '0.5' } });
+
+    const updates = onUpdateBatch.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    expect(updates.get('a')?.width).toBe(2);
+  });
+
+  it('pins a batch X to 0 for a cutout wider than the board', () => {
+    const onUpdateBatch = renderMulti([
+      createCutout({ id: 'oversize', width: 156 }),
+      createCutout({ id: 'normal' }),
+    ]);
+
+    fireEvent.change(screen.getByTestId('compact-input-X'), { target: { value: '20' } });
+
+    const updates = onUpdateBatch.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    expect(updates.get('oversize')?.x).toBe(0);
+  });
+
   it('skips meshes when batch-resizing, since their geometry is baked', () => {
     const onUpdateBatch = renderMulti([
       createCutout({ id: 'rect' }),

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -36,7 +36,9 @@ vi.mock('@/shared/components/CompactNumberInput', () => ({
       value={value}
       onChange={(e) => {
         const v = Number(e.target.value);
-        onChange?.(softMax ? Math.max(min, v) : Math.max(min, Math.min(max, v)));
+        // `Math.max(max, value)` mirrors the real ceiling: it never falls below
+        // the value already held, so focusing a field cannot destroy it.
+        onChange?.(Math.max(min, Math.min(softMax ? Infinity : Math.max(max, value), v)));
       }}
     />
   ),

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -8,24 +8,36 @@ vi.mock('@/i18n', () => ({
   useTranslation: () => (key: string) => key,
 }));
 
+// Mirrors the real input's commit clamp (CompactNumberInput.tsx `clampTyped`).
+// A pass-through mock would report 156 whether or not `softMax` is wired, so the
+// oversize-W test below would pass against the old truncating behaviour too.
 vi.mock('@/shared/components/CompactNumberInput', () => ({
   CompactNumberInput: ({
     label,
     value,
     indeterminate,
     onChange,
+    min = 0,
+    max = Infinity,
+    softMax = false,
   }: {
     label: string;
     value: number;
     indeterminate?: boolean;
     onChange?: (value: number) => void;
+    min?: number;
+    max?: number;
+    softMax?: boolean;
   }) => (
     <input
       data-testid={`compact-input-${label}`}
       data-label={label}
       data-indeterminate={indeterminate ? 'true' : 'false'}
       value={value}
-      onChange={(e) => onChange?.(Number(e.target.value))}
+      onChange={(e) => {
+        const v = Number(e.target.value);
+        onChange?.(softMax ? Math.max(min, v) : Math.max(min, Math.min(max, v)));
+      }}
     />
   ),
 }));

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from '@/i18n';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import { CHAMFER_SHAPES, MAX_CUTOUT_CHAMFER, maxEntryChamfer } from '@/features/bin-designer/types';
 import type { FitCue } from '../panel/CutoutsSection/cutoutSectionVisibility';
+import type { GrowTarget } from '../panel/CutoutsSection/growBinToFit';
 import { alignSelection, distributeSelection } from '../panel/CutoutsSection/geometryAlign';
 import type { AlignMode, DistributeAxis } from '../panel/CutoutsSection/geometryAlign';
 import { SingleCutoutInspector } from './SingleCutoutInspector';
@@ -47,6 +48,10 @@ interface InspectorContentProps {
   readonly offBoardCount?: number;
   /** Clamp every off-board cutout back inside the board. */
   readonly onClampOffBoard?: () => void;
+  /** Bin size that would fit every stray, or `null` when growing can't clear it. */
+  readonly growTarget?: GrowTarget | null;
+  /** Resize the bin to {@link growTarget}. */
+  readonly onGrowToFit?: () => void;
 }
 
 /** Effective field value, merging this cutout's live preview override. */
@@ -107,6 +112,8 @@ export function InspectorContent({
   board,
   offBoardCount = 0,
   onClampOffBoard,
+  growTarget,
+  onGrowToFit,
 }: InspectorContentProps) {
   const t = useTranslation();
 
@@ -118,7 +125,12 @@ export function InspectorContent({
   // Bin-size controls stay visible across every selection state so the user can
   // resize without leaving the editor.
   const binSize = (
-    <BinSizeSection offBoardCount={offBoardCount} onClampOffBoard={onClampOffBoard} />
+    <BinSizeSection
+      offBoardCount={offBoardCount}
+      onClampOffBoard={onClampOffBoard}
+      growTarget={growTarget}
+      onGrowToFit={onGrowToFit}
+    />
   );
 
   if (selectedCutouts.length === 0) {
@@ -176,26 +188,24 @@ export function InspectorContent({
     if (updates.size > 0) onUpdateBatch(updates);
   };
 
-  // Position and size are per-cutout clamped: an X that fits a 10mm hole runs a
-  // 40mm one past the wall, so each shape gets its own ceiling rather than the
-  // control refusing the whole edit.
+  // Position is per-cutout clamped: an X that fits a 10mm hole runs a 40mm one
+  // past the wall, so each shape gets its own ceiling rather than the control
+  // refusing the whole edit. Size is not — a typed W/H is a measurement, and it
+  // is kept past the board for the grow-to-fit action to resolve (#3061).
   const handleGeometryBatch = (key: 'x' | 'y' | 'width' | 'depth', value: number) => {
     if (!onUpdateBatch || selectedCutouts.length <= 1) return;
     const updates = new Map<string, Partial<Cutout>>();
     for (const c of selectedCutouts) {
       if (c.locked) continue;
-      // Meshes carry baked geometry — resizing them would desync the asset.
-      if ((key === 'width' || key === 'depth') && c.shape === 'mesh') continue;
-      const limit =
-        key === 'x'
-          ? binWidth - c.width
-          : key === 'y'
-            ? binDepth - c.depth
-            : key === 'width'
-              ? binWidth
-              : binDepth;
-      const floor = key === 'x' || key === 'y' ? 0 : MIN_CUTOUT_SIZE_MM;
-      updates.set(c.id, { [key]: Math.max(floor, Math.min(value, limit)) });
+      if (key === 'width' || key === 'depth') {
+        // Meshes carry baked geometry — resizing them would desync the asset.
+        if (c.shape === 'mesh') continue;
+        updates.set(c.id, { [key]: Math.max(MIN_CUTOUT_SIZE_MM, value) });
+        continue;
+      }
+      // An oversize cutout leaves no valid offset on this axis; pin it to 0.
+      const limit = Math.max(0, key === 'x' ? binWidth - c.width : binDepth - c.depth);
+      updates.set(c.id, { [key]: Math.max(0, Math.min(value, limit)) });
     }
     if (updates.size > 0) onUpdateBatch(updates);
   };
@@ -297,6 +307,7 @@ export function InspectorContent({
               onChange={(width) => handleGeometryBatch('width', width)}
               min={MIN_CUTOUT_SIZE_MM}
               max={binWidth}
+              softMax
               step={0.5}
               unit="mm"
               disabled={disabled}
@@ -308,6 +319,7 @@ export function InspectorContent({
               onChange={(depth) => handleGeometryBatch('depth', depth)}
               min={MIN_CUTOUT_SIZE_MM}
               max={binDepth}
+              softMax
               step={0.5}
               unit="mm"
               disabled={disabled}

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorDock.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorDock.tsx
@@ -16,6 +16,7 @@ import type { Cutout } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import type { FitCue } from '../panel/CutoutsSection/cutoutSectionVisibility';
+import type { GrowTarget } from '../panel/CutoutsSection/growBinToFit';
 import { InspectorContent, type BoardSettings } from './InspectorContent';
 import {
   INSPECTOR_MAX_WIDTH,
@@ -42,6 +43,10 @@ interface InspectorDockProps {
   readonly offBoardCount?: number;
   /** Clamp every off-board cutout back inside the board. */
   readonly onClampOffBoard?: () => void;
+  /** Bin size that would fit every stray, or `null` when growing can't clear it. */
+  readonly growTarget?: GrowTarget | null;
+  /** Resize the bin to {@link growTarget}. */
+  readonly onGrowToFit?: () => void;
   /** Editor-level settings shown when nothing is selected. */
   readonly board?: BoardSettings;
   /** Duplicate the current selection. */

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
@@ -47,15 +47,23 @@ describe('SingleCutoutInspector', () => {
     expect(screen.getByText('binDesigner.cutouts.section.label')).toBeInTheDocument();
   });
 
-  // #3061: W/H hold a measurement, so the field must not rewrite it to the board
-  // size. X/Y still clamp, but their ceiling can't go negative once W > board.
-  it('marks W/H as soft-capped and keeps the X/Y ceilings non-negative', () => {
-    renderit(makeCutout({ shape: 'rectangle', width: 156, depth: 156 }));
-    for (const label of ['W', 'H']) {
-      expect(screen.getByRole('slider', { name: label })).not.toHaveAttribute('aria-valuemax', '0');
-    }
-    for (const label of ['X', 'Y']) {
-      expect(screen.getByRole('slider', { name: label })).toHaveAttribute('aria-valuemax', '0');
+  // An oversize cutout (#3061) puts every transform field past its ceiling: W/H
+  // hold a measurement the board can't contain, and X/Y have no valid offset
+  // left at all, so their max collapses to 0 while the stored offset stands.
+  // Every slider must still announce a range that contains its own value.
+  // (That `softMax` is wired is covered by the commit test below, not here —
+  // these values come from the cutout, not from the field.)
+  it('announces a valid slider range for a cutout larger than the board', () => {
+    renderit(makeCutout({ shape: 'rectangle', x: 20, y: 20, width: 156, depth: 156 }));
+    for (const [label, now] of [
+      ['W', '156'],
+      ['H', '156'],
+      ['X', '20'],
+      ['Y', '20'],
+    ] as const) {
+      const slider = screen.getByRole('slider', { name: label });
+      expect(slider).toHaveAttribute('aria-valuenow', now);
+      expect(slider).toHaveAttribute('aria-valuemax', now);
     }
   });
 

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { SingleCutoutInspector } from './SingleCutoutInspector';
 import type { Cutout } from '@/features/bin-designer/types';
 
@@ -45,6 +45,40 @@ describe('SingleCutoutInspector', () => {
     expect(screen.getByText('binDesigner.cutouts.section.transform')).toBeInTheDocument();
     expect(screen.getByText('binDesigner.cutouts.section.shape')).toBeInTheDocument();
     expect(screen.getByText('binDesigner.cutouts.section.label')).toBeInTheDocument();
+  });
+
+  // #3061: W/H hold a measurement, so the field must not rewrite it to the board
+  // size. X/Y still clamp, but their ceiling can't go negative once W > board.
+  it('marks W/H as soft-capped and keeps the X/Y ceilings non-negative', () => {
+    renderit(makeCutout({ shape: 'rectangle', width: 156, depth: 156 }));
+    for (const label of ['W', 'H']) {
+      expect(screen.getByRole('slider', { name: label })).not.toHaveAttribute('aria-valuemax', '0');
+    }
+    for (const label of ['X', 'Y']) {
+      expect(screen.getByRole('slider', { name: label })).toHaveAttribute('aria-valuemax', '0');
+    }
+  });
+
+  it('commits a typed W past the board instead of truncating it', () => {
+    const onUpdate = vi.fn();
+    render(
+      <SingleCutoutInspector
+        cutout={makeCutout({ shape: 'rectangle' })}
+        preview={new Map()}
+        binWidth={123.1}
+        binDepth={123.1}
+        maxCutDepth={20}
+        onUpdate={onUpdate}
+        disabled={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'W: 10 mm' }));
+    const input = screen.getByRole('textbox', { name: 'W' });
+    fireEvent.change(input, { target: { value: '156' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onUpdate).toHaveBeenCalledWith('c1', { width: 156 });
   });
 
   it('shows the Array section for an arrayable shape but not for a path', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
@@ -105,12 +105,15 @@ export function SingleCutoutInspector({
       <div className="-mx-4 border-b border-stroke-subtle px-4 pt-2 pb-3">
         <Collapsible title={t('binDesigner.cutouts.section.transform')} size="sm">
           <div className="grid grid-cols-2 gap-1">
+            {/* A cutout wider than the board leaves no valid offset, and a
+                negative ceiling would report a nonsense aria-valuemax — pin the
+                axis to 0 until the board grows or the cutout shrinks. */}
             <CompactNumberInput
               label="X"
               value={getEffective(cutout, preview, 'x')}
               onChange={(x) => onUpdate(cutout.id, { x })}
               min={0}
-              max={binWidth - cutout.width}
+              max={Math.max(0, binWidth - cutout.width)}
               step={0.5}
               unit="mm"
               disabled={disabled}
@@ -120,17 +123,21 @@ export function SingleCutoutInspector({
               value={getEffective(cutout, preview, 'y')}
               onChange={(y) => onUpdate(cutout.id, { y })}
               min={0}
-              max={binDepth - cutout.depth}
+              max={Math.max(0, binDepth - cutout.depth)}
               step={0.5}
               unit="mm"
               disabled={disabled}
             />
+            {/* softMax: W/H hold a measured dimension, so a typed value past the
+                board is kept and the off-board banner offers to grow the bin
+                (#3061) — truncating it silently shipped wrong-sized pockets. */}
             <CompactNumberInput
               label="W"
               value={getEffective(cutout, preview, 'width')}
               onChange={(width) => onUpdate(cutout.id, { width })}
               min={2}
               max={binWidth}
+              softMax
               step={0.5}
               unit="mm"
               disabled={disabled || cutout.shape === 'mesh'}
@@ -141,6 +148,7 @@ export function SingleCutoutInspector({
               onChange={(depth) => onUpdate(cutout.id, { depth })}
               min={2}
               max={binDepth}
+              softMax
               step={0.5}
               unit="mm"
               disabled={disabled || cutout.shape === 'mesh'}

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -667,6 +667,14 @@ describe('geometry', () => {
       const result = clampRotationToBounds(cutout, 90, 100, 50);
       expect(result).toBeCloseTo(0, 0);
     });
+
+    // A typed W/H past the board is kept rather than truncated (#3061), so the
+    // cutout can already be out of bounds. Freezing its angle would make the
+    // rotation field a silent no-op — the exact failure this issue is about.
+    it('lets rotation through for a cutout already outside the board', () => {
+      const cutout = createCutout({ x: 0, y: 0, width: 156, depth: 20, rotation: 0 });
+      expect(clampRotationToBounds(cutout, 45, 100, 100)).toBe(45);
+    });
   });
 
   describe('flipCutoutHorizontal', () => {

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometryCore.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometryCore.ts
@@ -108,6 +108,14 @@ export function clampRotationToBounds(
     return normalize(proposedAngle);
   }
 
+  // Already off the board (a typed oversize W/H, #3061) — no angle fits, so the
+  // search below would converge back onto the current rotation and the control
+  // would silently do nothing. The guard exists to stop a rotation pushing a
+  // fitting cutout out, not to freeze one that is already out.
+  if (!fitsInBounds(cutout.rotation)) {
+    return normalize(proposedAngle);
+  }
+
   // Unwrap proposed angle relative to current rotation so the binary search
   // follows the shortest arc (handles 350° → 10° wrap-around correctly)
   let delta = proposedAngle - cutout.rotation;

--- a/src/features/bin-designer/components/panel/CutoutsSection/growBinToFit.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/growBinToFit.test.ts
@@ -88,6 +88,16 @@ describe('computeGrowToFit', () => {
     expect(computeGrowToFit(p, [cutout({ width: 130 })], false)).toEqual({ width: 3.5, depth: 3 });
   });
 
+  // Half-grid on is 0.5 granularity, not "stay fractional": landing on a whole
+  // unit is the smallest size that fits and is a size the user has opted into.
+  // Off, the same start can only step by 1 and so stays fractional.
+  it('may land on a whole unit from a fractional start when half-grid mode is on', () => {
+    // 2.5u interior is 102.1mm and 3u is 123.1mm, so 110mm needs exactly 3u.
+    const p = params({ width: 2.5 });
+    expect(computeGrowToFit(p, [cutout({ width: 110 })], true)).toEqual({ width: 3, depth: 3 });
+    expect(computeGrowToFit(p, [cutout({ width: 110 })], false)).toEqual({ width: 3.5, depth: 3 });
+  });
+
   it('grows each axis independently', () => {
     const p = params();
     expect(computeGrowToFit(p, [cutout({ width: 156, depth: 200 })], false)).toEqual({

--- a/src/features/bin-designer/components/panel/CutoutsSection/growBinToFit.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/growBinToFit.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import type { BinParams, Cutout, PathPoint } from '@/features/bin-designer/types';
+import { cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { computeGrowToFit } from './growBinToFit';
+
+/** Default wall thickness (1.2mm) + tolerance ⇒ interior = 42u − 2.9. */
+const params = (overrides: Partial<BinParams> = {}): BinParams => ({
+  ...DEFAULT_BIN_PARAMS,
+  width: 3,
+  depth: 3,
+  cutouts: [],
+  ...overrides,
+});
+
+const cutout = (overrides: Partial<Cutout> = {}): Cutout => ({
+  id: 'c1',
+  shape: 'rectangle',
+  x: 0,
+  y: 0,
+  width: 20,
+  depth: 20,
+  cutDepth: 5,
+  rotation: 0,
+  cornerRadius: 0,
+  label: '',
+  groupId: null,
+  locked: false,
+  hidden: false,
+  ...overrides,
+});
+
+const corner = (x: number, y: number): PathPoint => ({
+  x,
+  y,
+  handleIn: null,
+  handleOut: null,
+  symmetric: true,
+});
+
+const gridArray = (cols: number, rows: number, pitchX: number, pitchY: number) =>
+  ({
+    mode: 'grid',
+    cols,
+    rows,
+    pitchX,
+    pitchY,
+    count: 1,
+    radius: 0,
+    startAngle: 0,
+    rotateToCenter: false,
+  }) as const;
+
+const fullMask = (cols: number, rows: number): CellMask => ({
+  cols,
+  rows,
+  cells: Array.from({ length: cols * rows }, () => 1 as const),
+});
+
+describe('computeGrowToFit', () => {
+  it('returns null when every cutout already fits', () => {
+    const p = params();
+    expect(computeGrowToFit(p, [cutout()], false)).toBeNull();
+  });
+
+  it('returns null for a cutout flush with the board edge', () => {
+    const p = params();
+    const { innerW } = cutoutInterior(p);
+    expect(computeGrowToFit(p, [cutout({ x: 0, width: innerW })], false)).toBeNull();
+  });
+
+  it('grows to the next whole grid unit with half-grid mode off (#3061)', () => {
+    // 3u interior is 123.1mm; the reported repro types 156mm.
+    const p = params();
+    expect(computeGrowToFit(p, [cutout({ width: 156 })], false)).toEqual({ width: 4, depth: 3 });
+  });
+
+  it('uses half-unit steps when half-grid mode is on', () => {
+    // 130mm needs more than 3u (123.1) but fits 3.5u (144.1).
+    const p = params();
+    expect(computeGrowToFit(p, [cutout({ width: 130 })], true)).toEqual({ width: 3.5, depth: 3 });
+    expect(computeGrowToFit(p, [cutout({ width: 130 })], false)).toEqual({ width: 4, depth: 3 });
+  });
+
+  it('keeps an existing fractional dimension when half-grid mode is off', () => {
+    const p = params({ width: 2.5 });
+    expect(computeGrowToFit(p, [cutout({ width: 130 })], false)).toEqual({ width: 3.5, depth: 3 });
+  });
+
+  it('grows each axis independently', () => {
+    const p = params();
+    expect(computeGrowToFit(p, [cutout({ width: 156, depth: 200 })], false)).toEqual({
+      width: 4,
+      depth: 5,
+    });
+  });
+
+  it('sizes for the full cutout footprint, not just its width', () => {
+    const p = params();
+    // Offset 100 + width 60 = 140mm of board needed on X.
+    expect(computeGrowToFit(p, [cutout({ x: 100, width: 60 })], false)).toEqual({
+      width: 4,
+      depth: 3,
+    });
+  });
+
+  it('accounts for array instances, not only the master', () => {
+    const p = params();
+    const master = cutout({ width: 20, array: gridArray(4, 1, 45, 0) });
+    // Instances at x = 0, 45, 90, 135 ⇒ far edge 155mm.
+    expect(computeGrowToFit(p, [master], false)).toEqual({ width: 4, depth: 3 });
+  });
+
+  it('takes the union across every cutout so one click clears the warning', () => {
+    const p = params();
+    const result = computeGrowToFit(
+      p,
+      [cutout({ id: 'a', width: 156 }), cutout({ id: 'b', depth: 200 })],
+      false
+    );
+    expect(result).toEqual({ width: 4, depth: 5 });
+  });
+
+  it('returns null past MAX_DIMENSION rather than growing partway', () => {
+    const p = params();
+    expect(computeGrowToFit(p, [cutout({ width: 900 })], false)).toBeNull();
+  });
+
+  it('returns null for a custom (partial) footprint', () => {
+    const mask = fullMask(3, 3);
+    const partial: CellMask = { ...mask, cells: mask.cells.map((_, i) => (i === 0 ? 0 : 1)) };
+    const p = params({ cellMask: partial });
+    expect(computeGrowToFit(p, [cutout({ width: 156 })], false)).toBeNull();
+  });
+
+  it('still grows for a fully-filled mask, which is not a custom shape', () => {
+    const p = params({ cellMask: fullMask(6, 6) });
+    expect(computeGrowToFit(p, [cutout({ width: 156 })], false)).toEqual({ width: 4, depth: 3 });
+  });
+
+  it('returns null when a cutout hangs past the origin edge', () => {
+    // Growing only moves the far edges, so this can never clear the warning.
+    const p = params();
+    const path = [corner(-10, 10), corner(60, 10), corner(60, 60), corner(-10, 60)];
+    expect(
+      computeGrowToFit(p, [cutout({ shape: 'path', path, width: 70, depth: 50 })], false)
+    ).toBe(null);
+  });
+
+  it('folds per-side overhang into the interior it measures', () => {
+    // Overhang grows the interior floor, so less grid growth is needed.
+    const withOverhang = params({
+      overhang: { enabled: true, left: 20, right: 20, front: 0, back: 0 },
+    });
+    const { innerW } = cutoutInterior(withOverhang);
+    expect(innerW).toBeGreaterThan(cutoutInterior(params()).innerW);
+    expect(computeGrowToFit(withOverhang, [cutout({ width: 156 })], false)).toBeNull();
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/growBinToFit.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/growBinToFit.ts
@@ -18,9 +18,10 @@ import { cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
 import { getCutoutBounds } from './maskFit';
+import { OFF_BOARD_EPSILON } from './offBoardCutouts';
 
-/** Matches the off-board detector's tolerance so a flush edge doesn't grow the bin. */
-const EPSILON = 0.01;
+/** The detector's own tolerance, so a flush edge can't grow the bin. */
+const EPSILON = OFF_BOARD_EPSILON;
 
 /** Grid units (width × depth) a bin must be to hold every cutout. */
 export interface GrowTarget {

--- a/src/features/bin-designer/components/panel/CutoutsSection/growBinToFit.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/growBinToFit.ts
@@ -1,0 +1,92 @@
+/**
+ * "Grow the bin to fit" — the companion to `clampCutoutToBoard`.
+ *
+ * Cutout W/H are typed as real measurements, so a value past the current
+ * footprint is kept rather than truncated (#3061) and the board grows to meet
+ * it instead. Growing extends the interior toward +X/+Y, which leaves every
+ * cutout's stored `x`/`y` (relative to the interior's bottom-left) untouched —
+ * the same thing the width/depth steppers already do.
+ *
+ * Sizes are searched, not solved: each candidate is measured through the real
+ * `cutoutInterior`, so wall thickness, tolerance, per-side overhang and
+ * non-square grid pitch can't drift out of sync with a hand-inverted formula.
+ */
+
+import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import type { BinParams, Cutout } from '@/features/bin-designer/types';
+import { cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
+import { isPartialMask } from '@/shared/utils/cellMask';
+import { expandCutoutArray } from '@/shared/utils/cutoutArray';
+import { getCutoutBounds } from './maskFit';
+
+/** Matches the off-board detector's tolerance so a flush edge doesn't grow the bin. */
+const EPSILON = 0.01;
+
+/** Grid units (width × depth) a bin must be to hold every cutout. */
+export interface GrowTarget {
+  readonly width: number;
+  readonly depth: number;
+}
+
+/**
+ * Smallest step ≥ `from` whose interior reaches `requiredMm`, or `null` past
+ * `MAX_DIMENSION`. `measure` takes grid units and returns interior mm.
+ */
+function growAxis(
+  from: number,
+  requiredMm: number,
+  step: number,
+  measure: (units: number) => number
+): number | null {
+  for (let units = from; units <= DESIGNER_CONSTRAINTS.MAX_DIMENSION; units += step) {
+    if (measure(units) >= requiredMm - EPSILON) return units;
+  }
+  return null;
+}
+
+/**
+ * Bin size that would bring every cutout back inside the board, or `null` when
+ * growing alone can't do it — which the caller surfaces by hiding the action
+ * rather than growing partway and leaving the warning up.
+ *
+ * `null` cases:
+ * - A custom (masked) footprint. Reshaping the mask decides its own filled
+ *   cells, so a larger bin does not imply a larger usable region.
+ * - A cutout hanging past the origin side (negative bounds, reachable via
+ *   rotation or path vertices). Only the far edges move when the bin grows.
+ * - A footprint that needs more than `MAX_DIMENSION` grid units.
+ *
+ * `step` follows the user's half-grid mode: 1u when off, 0.5u when on. A width
+ * that is already fractional keeps its fraction either way — growing is not the
+ * place to quietly re-round a dimension the user chose.
+ */
+export function computeGrowToFit(
+  params: BinParams,
+  cutouts: readonly Cutout[],
+  halfGridMode: boolean
+): GrowTarget | null {
+  if (isPartialMask(params.cellMask)) return null;
+
+  const { innerW, innerD } = cutoutInterior(params);
+  let requiredW = innerW;
+  let requiredD = innerD;
+  for (const cutout of cutouts) {
+    for (const instance of expandCutoutArray(cutout)) {
+      const b = getCutoutBounds(instance);
+      if (b.minX < -EPSILON || b.minY < -EPSILON) return null;
+      if (b.maxX > requiredW) requiredW = b.maxX;
+      if (b.maxY > requiredD) requiredD = b.maxY;
+    }
+  }
+  if (requiredW <= innerW + EPSILON && requiredD <= innerD + EPSILON) return null;
+
+  const step = halfGridMode ? 0.5 : 1;
+  const width = growAxis(params.width, requiredW, step, (units) =>
+    units === params.width ? innerW : cutoutInterior({ ...params, width: units }).innerW
+  );
+  const depth = growAxis(params.depth, requiredD, step, (units) =>
+    units === params.depth ? innerD : cutoutInterior({ ...params, depth: units }).innerD
+  );
+  if (width === null || depth === null) return null;
+  return { width, depth };
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -23,8 +23,13 @@ import { translatePathPoints } from './pathGeometry';
 import { getCutoutBounds, cutoutFitsInMask, type MaskCellSize } from './maskFit';
 import type { Bounds } from './geometryCore';
 
-/** Tolerance (mm) — mirrors the interaction clamps so a flush edge isn't flagged. */
-const EPSILON = 0.01;
+/**
+ * Tolerance (mm) — mirrors the interaction clamps so a flush edge isn't flagged.
+ * Exported because `growBinToFit` must size against the same tolerance: if the
+ * two drift, a grow can return a bin that still leaves the warning up.
+ */
+export const OFF_BOARD_EPSILON = 0.01;
+const EPSILON = OFF_BOARD_EPSILON;
 
 function boundsOutsideRect(b: Bounds, binWidth: number, binDepth: number): boolean {
   return (

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Deska",
   "binDesigner.cutoutEditor.boardSize": "Velikost desky",
   "binDesigner.cutoutEditor.bringBackIn": "Vrátit dovnitř",
+  "binDesigner.cutoutEditor.growBinToFit": "Zvětšit box na {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "Box nelze zvětšit natolik, aby se sem vešly.",
   "binDesigner.cutoutEditor.delete": "Smazat výběr",
   "binDesigner.cutoutEditor.done": "Hotovo",
   "binDesigner.cutoutEditor.duplicate": "Duplikovat výběr",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Platte",
   "binDesigner.cutoutEditor.boardSize": "Plattengröße",
   "binDesigner.cutoutEditor.bringBackIn": "Wieder einpassen",
+  "binDesigner.cutoutEditor.growBinToFit": "Behälter auf {width} × {depth} vergrößern",
+  "binDesigner.cutoutEditor.growBinUnavailable": "Der Behälter kann nicht groß genug werden, um diese aufzunehmen.",
   "binDesigner.cutoutEditor.delete": "Auswahl löschen",
   "binDesigner.cutoutEditor.done": "Fertig",
   "binDesigner.cutoutEditor.duplicate": "Auswahl duplizieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2397,6 +2397,8 @@ const en: Record<string, string> = {
   'binDesigner.cutoutEditor.binSize': 'Bin size',
   'binDesigner.cutoutEditor.offBoardWarning': '{count} cutout(s) outside the board',
   'binDesigner.cutoutEditor.bringBackIn': 'Bring back in',
+  'binDesigner.cutoutEditor.growBinToFit': 'Grow bin to {width} × {depth}',
+  'binDesigner.cutoutEditor.growBinUnavailable': "The bin can't grow far enough to fit these.",
   'binDesigner.cutoutEditor.duplicate': 'Duplicate selection',
   'binDesigner.cutoutEditor.delete': 'Delete selection',
   'binDesigner.cutoutEditor.selectedCount': '{count} selected',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Tablero",
   "binDesigner.cutoutEditor.boardSize": "Tamaño del tablero",
   "binDesigner.cutoutEditor.bringBackIn": "Traer de vuelta",
+  "binDesigner.cutoutEditor.growBinToFit": "Ampliar contenedor a {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "El contenedor no puede crecer lo suficiente para que quepan.",
   "binDesigner.cutoutEditor.delete": "Eliminar selección",
   "binDesigner.cutoutEditor.done": "Listo",
   "binDesigner.cutoutEditor.duplicate": "Duplicar selección",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Plateau",
   "binDesigner.cutoutEditor.boardSize": "Taille du plateau",
   "binDesigner.cutoutEditor.bringBackIn": "Replacer à l’intérieur",
+  "binDesigner.cutoutEditor.growBinToFit": "Agrandir le bac à {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "Le bac ne peut pas s’agrandir assez pour les contenir.",
   "binDesigner.cutoutEditor.delete": "Supprimer la sélection",
   "binDesigner.cutoutEditor.done": "Terminé",
   "binDesigner.cutoutEditor.duplicate": "Dupliquer la sélection",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Pannello",
   "binDesigner.cutoutEditor.boardSize": "Dimensione pannello",
   "binDesigner.cutoutEditor.bringBackIn": "Riporta dentro",
+  "binDesigner.cutoutEditor.growBinToFit": "Ingrandisci il contenitore a {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "Il contenitore non può crescere abbastanza da contenerli.",
   "binDesigner.cutoutEditor.delete": "Elimina selezione",
   "binDesigner.cutoutEditor.done": "Fatto",
   "binDesigner.cutoutEditor.duplicate": "Duplica selezione",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "ボード",
   "binDesigner.cutoutEditor.boardSize": "ボードサイズ",
   "binDesigner.cutoutEditor.bringBackIn": "内側に戻す",
+  "binDesigner.cutoutEditor.growBinToFit": "ビンを {width} × {depth} に拡大",
+  "binDesigner.cutoutEditor.growBinUnavailable": "これらを収めるほどビンを大きくできません。",
   "binDesigner.cutoutEditor.delete": "選択を削除",
   "binDesigner.cutoutEditor.done": "完了",
   "binDesigner.cutoutEditor.duplicate": "選択を複製",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "보드",
   "binDesigner.cutoutEditor.boardSize": "보드 크기",
   "binDesigner.cutoutEditor.bringBackIn": "안으로 되돌리기",
+  "binDesigner.cutoutEditor.growBinToFit": "빈을 {width} × {depth}(으)로 확대",
+  "binDesigner.cutoutEditor.growBinUnavailable": "이들을 담을 만큼 빈을 키울 수 없습니다.",
   "binDesigner.cutoutEditor.delete": "선택 항목 삭제",
   "binDesigner.cutoutEditor.done": "완료",
   "binDesigner.cutoutEditor.duplicate": "선택 항목 복제",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Brett",
   "binDesigner.cutoutEditor.boardSize": "Brettstørrelse",
   "binDesigner.cutoutEditor.bringBackIn": "Hent inn igjen",
+  "binDesigner.cutoutEditor.growBinToFit": "Utvid kassen til {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "Kassen kan ikke bli stor nok til å romme disse.",
   "binDesigner.cutoutEditor.delete": "Slett utvalg",
   "binDesigner.cutoutEditor.done": "Ferdig",
   "binDesigner.cutoutEditor.duplicate": "Dupliser utvalg",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Bord",
   "binDesigner.cutoutEditor.boardSize": "Bordgrootte",
   "binDesigner.cutoutEditor.bringBackIn": "Terugzetten",
+  "binDesigner.cutoutEditor.growBinToFit": "Bak vergroten naar {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "De bak kan niet groot genoeg worden om deze te bevatten.",
   "binDesigner.cutoutEditor.delete": "Selectie verwijderen",
   "binDesigner.cutoutEditor.done": "Klaar",
   "binDesigner.cutoutEditor.duplicate": "Selectie dupliceren",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Płyta",
   "binDesigner.cutoutEditor.boardSize": "Rozmiar płyty",
   "binDesigner.cutoutEditor.bringBackIn": "Przywróć do środka",
+  "binDesigner.cutoutEditor.growBinToFit": "Powiększ pojemnik do {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "Pojemnik nie może urosnąć na tyle, aby je pomieścić.",
   "binDesigner.cutoutEditor.delete": "Usuń zaznaczenie",
   "binDesigner.cutoutEditor.done": "Gotowe",
   "binDesigner.cutoutEditor.duplicate": "Duplikuj zaznaczenie",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Placa",
   "binDesigner.cutoutEditor.boardSize": "Tamanho da placa",
   "binDesigner.cutoutEditor.bringBackIn": "Trazer de volta",
+  "binDesigner.cutoutEditor.growBinToFit": "Aumentar caixa para {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "A caixa não pode crescer o suficiente para caberem.",
   "binDesigner.cutoutEditor.delete": "Excluir seleção",
   "binDesigner.cutoutEditor.done": "Concluído",
   "binDesigner.cutoutEditor.duplicate": "Duplicar seleção",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Bräda",
   "binDesigner.cutoutEditor.boardSize": "Brädstorlek",
   "binDesigner.cutoutEditor.bringBackIn": "Flytta in igen",
+  "binDesigner.cutoutEditor.growBinToFit": "Förstora lådan till {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "Lådan kan inte bli tillräckligt stor för att rymma dessa.",
   "binDesigner.cutoutEditor.delete": "Ta bort markering",
   "binDesigner.cutoutEditor.done": "Klar",
   "binDesigner.cutoutEditor.duplicate": "Duplicera markering",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "Дошка",
   "binDesigner.cutoutEditor.boardSize": "Розмір дошки",
   "binDesigner.cutoutEditor.bringBackIn": "Повернути всередину",
+  "binDesigner.cutoutEditor.growBinToFit": "Збільшити контейнер до {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "Контейнер не може вирости настільки, щоб вмістити їх.",
   "binDesigner.cutoutEditor.delete": "Видалити вибране",
   "binDesigner.cutoutEditor.done": "Готово",
   "binDesigner.cutoutEditor.duplicate": "Дублювати вибране",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -452,6 +452,8 @@
   "binDesigner.cutoutEditor.boardSettings": "画板",
   "binDesigner.cutoutEditor.boardSize": "画板尺寸",
   "binDesigner.cutoutEditor.bringBackIn": "移回画板内",
+  "binDesigner.cutoutEditor.growBinToFit": "将收纳盒扩大到 {width} × {depth}",
+  "binDesigner.cutoutEditor.growBinUnavailable": "收纳盒无法扩大到足以容纳它们。",
   "binDesigner.cutoutEditor.delete": "删除选中项",
   "binDesigner.cutoutEditor.done": "完成",
   "binDesigner.cutoutEditor.duplicate": "复制选中项",

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -178,6 +178,74 @@ describe('CompactNumberInput', () => {
     expect(onChange).toHaveBeenCalledWith(15);
   });
 
+  describe('softMax', () => {
+    it('commits a typed value past max instead of truncating it', () => {
+      const onChange = vi.fn();
+      render(<CompactNumberInput label="W" value={10} onChange={onChange} max={123.1} softMax />);
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '156' } });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledWith(156);
+    });
+
+    it('still enforces min on a typed value', () => {
+      const onChange = vi.fn();
+      render(<CompactNumberInput label="W" value={10} onChange={onChange} min={2} softMax />);
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '-5' } });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledWith(2);
+    });
+
+    it('still caps arrow keys at max while the value is under it', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <CompactNumberInput label="W" value={15} onChange={onChange} max={15} step={1} softMax />
+      );
+
+      await user.click(screen.getByRole('button'));
+      await user.keyboard('{ArrowUp}');
+
+      expect(onChange).toHaveBeenCalledWith(15);
+    });
+
+    it('steps down from an over-max value rather than snapping back to max', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <CompactNumberInput
+          label="W"
+          value={156}
+          onChange={onChange}
+          max={123.1}
+          step={1}
+          softMax
+        />
+      );
+
+      await user.click(screen.getByRole('button'));
+      await user.keyboard('{ArrowDown}');
+
+      expect(onChange).toHaveBeenCalledWith(155);
+    });
+
+    it('leaves the default (hard max) behaviour untouched', () => {
+      const onChange = vi.fn();
+      render(<CompactNumberInput label="W" value={10} onChange={onChange} max={123.1} />);
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '156' } });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledWith(123.1);
+    });
+  });
+
   it('prevents decrement below min with arrow keys', async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -432,6 +432,39 @@ describe('CompactNumberInput', () => {
     });
   });
 
+  // Only `softMax` may let typed text raise the nudge ceiling. Without the
+  // distinction a hard-max field can be walked past its own limit: type 500
+  // into a max-359 field, then arrow, and the nudge clamps to 500 not 359.
+  it('does not let a typed over-max entry raise the nudge ceiling on a hard-max field', () => {
+    const onChange = vi.fn();
+    render(
+      <CompactNumberInput label="R" value={10} onChange={onChange} min={0} max={359} step={1} />
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '500' } });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(onChange).toHaveBeenLastCalledWith(359);
+  });
+
+  it('binds a max that drops while the field is open', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <CompactNumberInput label="R" value={200} onChange={onChange} min={0} max={359} step={1} />
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    // The ceiling is derived from live props, not captured on entry.
+    rerender(
+      <CompactNumberInput label="R" value={200} onChange={onChange} min={0} max={100} step={1} />
+    );
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowUp' });
+
+    expect(onChange).toHaveBeenLastCalledWith(200);
+  });
+
   it('prevents decrement below min with arrow keys', async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -267,6 +267,19 @@ describe('CompactNumberInput', () => {
       expect(onChange).toHaveBeenLastCalledWith(156);
     });
 
+    // A hard `max` used to absorb these; softMax has no ceiling to absorb them,
+    // and a non-finite dimension would poison bounds and geometry downstream.
+    it.each(['Infinity', '-Infinity', '1e309'])('rejects %s instead of committing it', (raw) => {
+      const onChange = vi.fn();
+      render(<CompactNumberInput label="W" value={10} onChange={onChange} min={2} softMax />);
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: raw } });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('reports a valid ARIA range while the value sits past max', () => {
       render(<CompactNumberInput label="W" value={156} onChange={vi.fn()} max={123.1} softMax />);
       const slider = screen.getByRole('slider', { name: 'W' });

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -330,6 +330,45 @@ describe('CompactNumberInput', () => {
       expect(onChange).toHaveBeenLastCalledWith(155);
     });
 
+    it('re-derives the nudge ceiling when a smaller value is typed over an over-max one', () => {
+      const onChange = vi.fn();
+      render(
+        <CompactNumberInput
+          label="W"
+          value={156}
+          onChange={onChange}
+          max={123.1}
+          step={1}
+          softMax
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '100' } });
+      for (let i = 0; i < 5; i++) fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+      // 100 + 5 would be 105; the point is it may not climb toward the old 156.
+      expect(onChange.mock.calls.every(([v]) => v <= 123.1)).toBe(true);
+    });
+
+    it('keeps a large finite entry legible instead of rendering it as Infinity', () => {
+      const onChange = vi.fn();
+      const { rerender } = render(
+        <CompactNumberInput label="W" value={10} onChange={onChange} softMax />
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '1e307' } });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+      expect(onChange).toHaveBeenLastCalledWith(1e307);
+
+      // `v * 100` overflows here, so an unguarded round would display "Infinity"
+      // — a string that no longer parses back to a committable value.
+      rerender(<CompactNumberInput label="W" value={1e307} onChange={onChange} softMax />);
+      expect(screen.queryByText('Infinity')).not.toBeInTheDocument();
+    });
+
     it('reports a valid ARIA range while the value sits past max', () => {
       render(<CompactNumberInput label="W" value={156} onChange={vi.fn()} max={123.1} softMax />);
       const slider = screen.getByRole('slider', { name: 'W' });
@@ -351,6 +390,45 @@ describe('CompactNumberInput', () => {
       fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
 
       expect(onChange).toHaveBeenCalledWith(123.1);
+    });
+  });
+
+  // A `max` can drop below the value it governs — an oversize cutout pins its
+  // X ceiling to 0 while X still holds its stored offset. Focusing such a field
+  // and leaving must not rewrite what the user is looking at.
+  describe('when max has fallen below the value', () => {
+    it('does not destroy the value on focus and blur', () => {
+      const onChange = vi.fn();
+      render(<CompactNumberInput label="X" value={20} onChange={onChange} min={0} max={0} />);
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.blur(screen.getByRole('textbox'));
+
+      expect(onChange).toHaveBeenLastCalledWith(20);
+    });
+
+    it('still refuses a typed value above it', () => {
+      const onChange = vi.fn();
+      render(<CompactNumberInput label="X" value={20} onChange={onChange} min={0} max={0} />);
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '50' } });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+      expect(onChange).toHaveBeenLastCalledWith(20);
+    });
+
+    it('lets an arrow key move the value back toward range', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <CompactNumberInput label="X" value={20} onChange={onChange} min={0} max={0} step={0.5} />
+      );
+
+      await user.click(screen.getByRole('button'));
+      await user.keyboard('{ArrowDown}');
+
+      expect(onChange).toHaveBeenLastCalledWith(19.5);
     });
   });
 

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -234,6 +234,51 @@ describe('CompactNumberInput', () => {
       expect(onChange).toHaveBeenCalledWith(155);
     });
 
+    it('can nudge an over-max value back up after stepping it down', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      // Re-render with the new value, as the real parent does — a ceiling
+      // pinned to `value` would ratchet down and strand ArrowUp at 155.
+      const { rerender } = render(
+        <CompactNumberInput
+          label="W"
+          value={156}
+          onChange={onChange}
+          max={123.1}
+          step={1}
+          softMax
+        />
+      );
+      await user.click(screen.getByRole('button'));
+      await user.keyboard('{ArrowDown}');
+      expect(onChange).toHaveBeenLastCalledWith(155);
+
+      rerender(
+        <CompactNumberInput
+          label="W"
+          value={155}
+          onChange={onChange}
+          max={123.1}
+          step={1}
+          softMax
+        />
+      );
+      await user.keyboard('{ArrowUp}');
+      expect(onChange).toHaveBeenLastCalledWith(156);
+    });
+
+    it('reports a valid ARIA range while the value sits past max', () => {
+      render(<CompactNumberInput label="W" value={156} onChange={vi.fn()} max={123.1} softMax />);
+      const slider = screen.getByRole('slider', { name: 'W' });
+      expect(slider).toHaveAttribute('aria-valuenow', '156');
+      expect(slider).toHaveAttribute('aria-valuemax', '156');
+    });
+
+    it('still reports the prop max while the value is inside the range', () => {
+      render(<CompactNumberInput label="W" value={40} onChange={vi.fn()} max={123.1} softMax />);
+      expect(screen.getByRole('slider', { name: 'W' })).toHaveAttribute('aria-valuemax', '123.1');
+    });
+
     it('leaves the default (hard max) behaviour untouched', () => {
       const onChange = vi.fn();
       render(<CompactNumberInput label="W" value={10} onChange={onChange} max={123.1} />);

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -280,6 +280,19 @@ describe('CompactNumberInput', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    // The guard is app-wide on purpose: a hard-max field used to commit the
+    // ceiling for "Infinity" while leaving "abc" alone. Both revert now.
+    it('rejects a non-finite entry on a hard-max field too', () => {
+      const onChange = vi.fn();
+      render(<CompactNumberInput label="R" value={10} onChange={onChange} max={359} />);
+
+      fireEvent.click(screen.getByRole('button'));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '1e309' } });
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('reports a valid ARIA range while the value sits past max', () => {
       render(<CompactNumberInput label="W" value={156} onChange={vi.fn()} max={123.1} softMax />);
       const slider = screen.getByRole('slider', { name: 'W' });

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -314,6 +314,22 @@ describe('CompactNumberInput', () => {
       expect(onChange).toHaveBeenLastCalledWith(156);
     });
 
+    // Arrows used to nudge from the last committed value, so a typed-then-nudged
+    // entry was discarded — the same truncation this PR exists to remove.
+    it('nudges from a typed but uncommitted value, not the committed one', () => {
+      const onChange = vi.fn();
+      render(
+        <CompactNumberInput label="W" value={10} onChange={onChange} max={123.1} step={1} softMax />
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '156' } });
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      expect(onChange).toHaveBeenLastCalledWith(155);
+    });
+
     it('reports a valid ARIA range while the value sits past max', () => {
       render(<CompactNumberInput label="W" value={156} onChange={vi.fn()} max={123.1} softMax />);
       const slider = screen.getByRole('slider', { name: 'W' });

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.test.tsx
@@ -293,6 +293,27 @@ describe('CompactNumberInput', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    // Overflow is typed-only: a nudge may not push a value further past the
+    // ceiling than the number the user actually entered.
+    it('will not nudge an over-max value any higher', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <CompactNumberInput
+          label="W"
+          value={156}
+          onChange={onChange}
+          max={123.1}
+          step={1}
+          softMax
+        />
+      );
+      await user.click(screen.getByRole('button'));
+      await user.keyboard('{ArrowUp}');
+
+      expect(onChange).toHaveBeenLastCalledWith(156);
+    });
+
     it('reports a valid ARIA range while the value sits past max', () => {
       render(<CompactNumberInput label="W" value={156} onChange={vi.fn()} max={123.1} softMax />);
       const slider = screen.getByRole('slider', { name: 'W' });

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -33,8 +33,8 @@ interface CompactNumberInputProps {
    * what happens next.
    *
    * Overflow stays typed-only: scrubbing and arrow keys still stop at `max`,
-   * and past it they stop at whatever was typed, so no gesture can raise a
-   * value beyond what the user entered.
+   * and past it they stop at whatever is currently in the field, so no gesture
+   * can raise a value beyond what the user entered.
    */
   readonly softMax?: boolean;
 }
@@ -73,34 +73,53 @@ export function CompactNumberInput({
   const [scrubbing, setScrubbing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  /**
+   * Ceiling applied to a typed entry. `softMax` lifts it entirely; otherwise it
+   * is `max`, but never below the value already held — a field must not destroy
+   * its own contents just by being focused and blurred, which is what a `max`
+   * that has dropped below `value` would otherwise do (an oversize cutout pins
+   * X's max to 0 while X still reads its stored offset).
+   */
   const clampTyped = useCallback(
-    (v: number) => (softMax ? Math.max(min, v) : clampRange(v, min, max)),
-    [softMax, min, max]
+    (v: number) => clampRange(v, min, softMax ? Infinity : Math.max(max, value)),
+    [softMax, min, max, value]
   );
 
   /**
-   * Step ceiling for a whole gesture — a drag, or one visit to the text field.
+   * Step ceiling for a gesture — a drag, or the current contents of the text
+   * field. `max`, or the starting value when that already sits above it.
    *
-   * Normally `max`, so scrubbing can never carry a value that fits past the
-   * limit. A `softMax` value already typed above it raises the ceiling to
-   * itself, which keeps the overflow typed-only without freezing the field:
-   * recomputing this per keystroke instead would let it follow the value down,
-   * so ArrowDown from 156 to 155 would drop the ceiling to 155 and ArrowUp
-   * could never get back. Fixing it for the gesture gives both.
+   * Independent of `softMax`, which governs typed commits only: a hard `max`
+   * can also fall below the value, and a nudge must be able to move such a
+   * value without being yanked to the ceiling first.
+   *
+   * Held for the gesture rather than recomputed per keystroke, because a
+   * per-keystroke ceiling follows the value down — ArrowDown from 156 to 155
+   * would drop the ceiling to 155 and ArrowUp could never get back.
    */
-  const ceilingFrom = useCallback(
-    (start: number) => (softMax ? Math.max(max, start) : max),
-    [softMax, max]
-  );
+  const ceilingFrom = useCallback((start: number) => Math.max(max, start), [max]);
   const [editCeiling, setEditCeiling] = useState(max);
 
-  const formatValue = useCallback((v: number) => {
-    const rounded = Math.round(v * 100) / 100;
-    return rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toString();
+  /**
+   * Round to 2dp, keeping accumulated scrub/nudge deltas free of float noise.
+   * Guarded: `v * 100` overflows to Infinity past ~9e306, which would render a
+   * committed finite entry as "Infinity" and wedge the field, since that string
+   * no longer parses back to anything committable.
+   */
+  const round2 = useCallback((v: number) => {
+    const scaled = v * 100;
+    return Number.isFinite(scaled) ? Math.round(scaled) / 100 : v;
   }, []);
 
-  /** Round to 2dp to keep accumulated scrub/nudge deltas free of float noise. */
-  const tidy = useCallback((v: number) => Math.round(v * 100) / 100, []);
+  const formatValue = useCallback(
+    (v: number) => {
+      const rounded = round2(v);
+      return rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toString();
+    },
+    [round2]
+  );
+
+  const tidy = round2;
 
   const startEditing = useCallback(() => {
     if (disabled) return;
@@ -239,7 +258,15 @@ export function CompactNumberInput({
           type="text"
           inputMode="decimal"
           value={editValue}
-          onChange={(e) => setEditValue(e.target.value)}
+          onChange={(e) => {
+            setEditValue(e.target.value);
+            // Re-derive the nudge ceiling from what is now in the field. Without
+            // this it only ever rises, so typing 100 over a committed 156 would
+            // leave arrows free to climb back to 156, past both `max` and the
+            // number actually entered.
+            const typed = parseFloat(e.target.value);
+            setEditCeiling(ceilingFrom(Number.isFinite(typed) ? typed : value));
+          }}
           onBlur={() => commit(editValue)}
           onKeyDown={handleKeyDown}
           className="min-w-0 flex-1 bg-transparent pr-1 text-right text-xs text-content outline-none"

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -143,12 +143,22 @@ export function CompactNumberInput({
       } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
         e.preventDefault();
         const delta = effectiveStep(step, e) * (e.key === 'ArrowUp' ? 1 : -1);
-        const next = clampRange(tidy(value + delta), min, editCeiling);
+        // Nudge from what the field shows, not the last committed value: typing
+        // 156 over a committed 10 and pressing ArrowDown must reach 155, not 9.5.
+        // (`editValue` is empty for an untouched mixed selection, hence the
+        // fallback.)
+        const typed = parseFloat(editValue);
+        const base = Number.isFinite(typed) ? typed : value;
+        // A typed value can sit above the ceiling captured on entry, so raise it
+        // — upward only, which is what keeps a nudge from ratcheting back down.
+        const ceiling = Math.max(editCeiling, ceilingFrom(base));
+        if (ceiling !== editCeiling) setEditCeiling(ceiling);
+        const next = clampRange(tidy(base + delta), min, ceiling);
         onChange(next);
         setEditValue(formatValue(next));
       }
     },
-    [editValue, commit, value, min, editCeiling, onChange, formatValue, tidy, step]
+    [editValue, commit, value, min, editCeiling, ceilingFrom, onChange, formatValue, tidy, step]
   );
 
   const handleScrubStart = useCallback(

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -27,6 +27,13 @@ interface CompactNumberInputProps {
   readonly highlight?: boolean;
   /** Selected items have differing values — show a "mixed" placeholder until edited. */
   readonly indeterminate?: boolean;
+  /**
+   * Treat `max` as a soft ceiling for typed entries only. Scrubbing and arrow
+   * keys still stop at it — dragging past a limit is meaningless — but a typed
+   * number commits as written, so a field holding a real-world measurement
+   * can't silently truncate it (#3061). The caller owns what happens next.
+   */
+  readonly softMax?: boolean;
 }
 
 /** Placeholder glyph shown when a multi-selection has mixed values (en dash). */
@@ -56,13 +63,24 @@ export function CompactNumberInput({
   info,
   highlight = false,
   indeterminate = false,
+  softMax = false,
 }: CompactNumberInputProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [scrubbing, setScrubbing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const clamp = useCallback((v: number) => clampRange(v, min, max), [min, max]);
+  const clampTyped = useCallback(
+    (v: number) => (softMax ? Math.max(min, v) : clampRange(v, min, max)),
+    [softMax, min, max]
+  );
+  // Scrub/arrow ceiling. Under `softMax` a value typed past `max` raises the
+  // ceiling to itself, so nudging an over-max measurement steps down from where
+  // it is instead of snapping back to `max` on the first keypress.
+  const clampStep = useCallback(
+    (v: number) => clampRange(v, min, softMax ? Math.max(max, value) : max),
+    [softMax, min, max, value]
+  );
 
   const formatValue = useCallback((v: number) => {
     const rounded = Math.round(v * 100) / 100;
@@ -89,10 +107,10 @@ export function CompactNumberInput({
   const commit = useCallback(
     (raw: string) => {
       const parsed = parseFloat(raw);
-      if (!isNaN(parsed)) onChange(clamp(parsed));
+      if (!isNaN(parsed)) onChange(clampTyped(parsed));
       setEditing(false);
     },
-    [onChange, clamp]
+    [onChange, clampTyped]
   );
 
   const handleKeyDown = useCallback(
@@ -104,12 +122,12 @@ export function CompactNumberInput({
       } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
         e.preventDefault();
         const delta = effectiveStep(step, e) * (e.key === 'ArrowUp' ? 1 : -1);
-        const next = clamp(tidy(value + delta));
+        const next = clampStep(tidy(value + delta));
         onChange(next);
         setEditValue(formatValue(next));
       }
     },
-    [editValue, commit, value, clamp, onChange, formatValue, tidy, step]
+    [editValue, commit, value, clampStep, onChange, formatValue, tidy, step]
   );
 
   const handleScrubStart = useCallback(
@@ -128,7 +146,7 @@ export function CompactNumberInput({
         }
         if (!moved) return;
         const steps = Math.round(dx / PIXELS_PER_STEP);
-        const next = clamp(tidy(startValue + steps * effectiveStep(step, moveEvent)));
+        const next = clampStep(tidy(startValue + steps * effectiveStep(step, moveEvent)));
         onChange(next);
       };
 
@@ -142,7 +160,7 @@ export function CompactNumberInput({
       document.addEventListener('pointermove', handleMove);
       document.addEventListener('pointerup', handleUp);
     },
-    [disabled, editing, value, clamp, onChange, tidy, startEditing, step]
+    [disabled, editing, value, clampStep, onChange, tidy, startEditing, step]
   );
 
   return (

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -28,10 +28,13 @@ interface CompactNumberInputProps {
   /** Selected items have differing values — show a "mixed" placeholder until edited. */
   readonly indeterminate?: boolean;
   /**
-   * Treat `max` as a soft ceiling for typed entries only. Scrubbing and arrow
-   * keys still stop at it — dragging past a limit is meaningless — but a typed
-   * number commits as written, so a field holding a real-world measurement
-   * can't silently truncate it (#3061). The caller owns what happens next.
+   * Treat `max` as a soft ceiling for typed entries only, so a field holding a
+   * real-world measurement can't silently truncate it (#3061). The caller owns
+   * what happens next.
+   *
+   * Overflow stays typed-only: scrubbing and arrow keys still stop at `max`,
+   * and past it they stop at whatever was typed, so no gesture can raise a
+   * value beyond what the user entered.
    */
   readonly softMax?: boolean;
 }
@@ -74,19 +77,22 @@ export function CompactNumberInput({
     (v: number) => (softMax ? Math.max(min, v) : clampRange(v, min, max)),
     [softMax, min, max]
   );
+
   /**
-   * True once a `softMax` field holds a typed value past its ceiling — `max`
-   * then describes the recommended range rather than the field's limit.
+   * Step ceiling for a whole gesture — a drag, or one visit to the text field.
+   *
+   * Normally `max`, so scrubbing can never carry a value that fits past the
+   * limit. A `softMax` value already typed above it raises the ceiling to
+   * itself, which keeps the overflow typed-only without freezing the field:
+   * recomputing this per keystroke instead would let it follow the value down,
+   * so ArrowDown from 156 to 155 would drop the ceiling to 155 and ArrowUp
+   * could never get back. Fixing it for the gesture gives both.
    */
-  const overSoftMax = softMax && value > max;
-  // Scrub/arrow ceiling. `max` still caps a value that is inside the range, so
-  // dragging can't take a legal value past it. Above the range the cap lifts
-  // entirely — pinning it to the current value instead would ratchet downward,
-  // letting ArrowDown leave 156 for 155 and then refusing to go back up.
-  const clampStep = useCallback(
-    (v: number) => (overSoftMax ? Math.max(min, v) : clampRange(v, min, max)),
-    [overSoftMax, min, max]
+  const ceilingFrom = useCallback(
+    (start: number) => (softMax ? Math.max(max, start) : max),
+    [softMax, max]
   );
+  const [editCeiling, setEditCeiling] = useState(max);
 
   const formatValue = useCallback((v: number) => {
     const rounded = Math.round(v * 100) / 100;
@@ -100,8 +106,9 @@ export function CompactNumberInput({
     if (disabled) return;
     // Mixed selection: start from an empty field so a typed value unifies all.
     setEditValue(indeterminate ? '' : formatValue(value));
+    setEditCeiling(ceilingFrom(value));
     setEditing(true);
-  }, [disabled, indeterminate, value, formatValue]);
+  }, [disabled, indeterminate, value, formatValue, ceilingFrom]);
 
   useEffect(() => {
     if (editing && inputRef.current) {
@@ -136,12 +143,12 @@ export function CompactNumberInput({
       } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
         e.preventDefault();
         const delta = effectiveStep(step, e) * (e.key === 'ArrowUp' ? 1 : -1);
-        const next = clampStep(tidy(value + delta));
+        const next = clampRange(tidy(value + delta), min, editCeiling);
         onChange(next);
         setEditValue(formatValue(next));
       }
     },
-    [editValue, commit, value, clampStep, onChange, formatValue, tidy, step]
+    [editValue, commit, value, min, editCeiling, onChange, formatValue, tidy, step]
   );
 
   const handleScrubStart = useCallback(
@@ -150,6 +157,8 @@ export function CompactNumberInput({
       e.preventDefault();
       const startX = e.clientX;
       const startValue = value;
+      // Fixed for the drag, so the ceiling can't drift as the value moves.
+      const ceiling = ceilingFrom(startValue);
       let moved = false;
 
       const handleMove = (moveEvent: PointerEvent) => {
@@ -160,7 +169,11 @@ export function CompactNumberInput({
         }
         if (!moved) return;
         const steps = Math.round(dx / PIXELS_PER_STEP);
-        const next = clampStep(tidy(startValue + steps * effectiveStep(step, moveEvent)));
+        const next = clampRange(
+          tidy(startValue + steps * effectiveStep(step, moveEvent)),
+          min,
+          ceiling
+        );
         onChange(next);
       };
 
@@ -174,7 +187,7 @@ export function CompactNumberInput({
       document.addEventListener('pointermove', handleMove);
       document.addEventListener('pointerup', handleUp);
     },
-    [disabled, editing, value, clampStep, onChange, tidy, startEditing, step]
+    [disabled, editing, value, min, ceilingFrom, onChange, tidy, startEditing, step]
   );
 
   return (

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -114,9 +114,13 @@ export function CompactNumberInput({
     (raw: string) => {
       const parsed = parseFloat(raw);
       // Finite, not merely non-NaN: `parseFloat` maps "Infinity" and any
-      // overflowing exponent to Infinity, which a hard `max` used to absorb.
-      // `softMax` has no ceiling to absorb it, and downstream geometry must
-      // never see a non-finite dimension.
+      // overflowing exponent to Infinity. `softMax` has no ceiling to absorb
+      // that, and downstream geometry must never see a non-finite dimension.
+      //
+      // Deliberately app-wide rather than gated on `softMax`. A hard `max` did
+      // absorb it, but by silently committing the ceiling — so "Infinity" set a
+      // rotation field to 359 while "abc" left it alone. Non-finite input is
+      // unparseable garbage, not a big number, and now reverts like any other.
       if (Number.isFinite(parsed)) onChange(clampTyped(parsed));
       setEditing(false);
     },

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -75,9 +75,8 @@ export function CompactNumberInput({
     [softMax, min, max]
   );
   /**
-   * True once a `softMax` field holds a typed value past its ceiling. `max` then
-   * describes the recommended range rather than the field's limit, so both the
-   * step clamp and the ARIA range have to follow the value instead.
+   * True once a `softMax` field holds a typed value past its ceiling — `max`
+   * then describes the recommended range rather than the field's limit.
    */
   const overSoftMax = softMax && value > max;
   // Scrub/arrow ceiling. `max` still caps a value that is inside the range, so
@@ -114,7 +113,11 @@ export function CompactNumberInput({
   const commit = useCallback(
     (raw: string) => {
       const parsed = parseFloat(raw);
-      if (!isNaN(parsed)) onChange(clampTyped(parsed));
+      // Finite, not merely non-NaN: `parseFloat` maps "Infinity" and any
+      // overflowing exponent to Infinity, which a hard `max` used to absorb.
+      // `softMax` has no ceiling to absorb it, and downstream geometry must
+      // never see a non-finite dimension.
+      if (Number.isFinite(parsed)) onChange(clampTyped(parsed));
       setEditing(false);
     },
     [onChange, clampTyped]
@@ -195,9 +198,11 @@ export function CompactNumberInput({
         aria-label={label}
         aria-valuenow={value}
         aria-valuemin={min}
-        // Reporting the prop's `max` here while `value` sits above it would
-        // publish valuenow > valuemax, which is an invalid slider state.
-        aria-valuemax={max === Infinity ? undefined : overSoftMax ? value : max}
+        // The announced range always contains the value: publishing valuenow >
+        // valuemax is an invalid slider state. Independent of `softMax` — a hard
+        // ceiling can also sit below the value (an oversize cutout leaves no
+        // valid X offset, so X's max is 0 while it still reads its old offset).
+        aria-valuemax={max === Infinity ? undefined : Math.max(max, value)}
       >
         {label}
       </span>

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -86,19 +86,28 @@ export function CompactNumberInput({
   );
 
   /**
-   * Step ceiling for a gesture — a drag, or the current contents of the text
-   * field. `max`, or the starting value when that already sits above it.
+   * Ceiling for a nudge or drag, given the highest content the field has held.
    *
-   * Independent of `softMax`, which governs typed commits only: a hard `max`
-   * can also fall below the value, and a nudge must be able to move such a
-   * value without being yanked to the ceiling first.
-   *
-   * Held for the gesture rather than recomputed per keystroke, because a
-   * per-keystroke ceiling follows the value down — ArrowDown from 156 to 155
-   * would drop the ceiling to 155 and ArrowUp could never get back.
+   * Two different things can sit above `max`, and only one of them may raise
+   * this. A committed `value` can, because `max` itself may have fallen beneath
+   * it (an oversize cutout pins X's ceiling to 0 while X keeps its offset), and
+   * such a value still has to be nudgeable. Text the user has *typed* may only
+   * raise it under `softMax` — otherwise a hard-max field could be walked past
+   * its own limit one arrow key at a time.
    */
-  const ceilingFrom = useCallback((start: number) => Math.max(max, start), [max]);
-  const [editCeiling, setEditCeiling] = useState(max);
+  const stepCeiling = useCallback(
+    (peak: number) => (softMax ? Math.max(max, peak) : Math.max(max, value)),
+    [softMax, max, value]
+  );
+
+  /**
+   * Highest content the field has held this visit. Held so a nudge can't ratchet
+   * its own ceiling down — ArrowDown from 156 to 155 must leave ArrowUp able to
+   * return — and reset on typing so a smaller entry lowers it again. The ceiling
+   * is derived from it against live props, so a `max` that drops mid-edit binds
+   * immediately rather than leaving a stale ceiling behind.
+   */
+  const [editPeak, setEditPeak] = useState(0);
 
   /**
    * Round to 2dp, keeping accumulated scrub/nudge deltas free of float noise.
@@ -125,9 +134,9 @@ export function CompactNumberInput({
     if (disabled) return;
     // Mixed selection: start from an empty field so a typed value unifies all.
     setEditValue(indeterminate ? '' : formatValue(value));
-    setEditCeiling(ceilingFrom(value));
+    setEditPeak(value);
     setEditing(true);
-  }, [disabled, indeterminate, value, formatValue, ceilingFrom]);
+  }, [disabled, indeterminate, value, formatValue]);
 
   useEffect(() => {
     if (editing && inputRef.current) {
@@ -168,16 +177,14 @@ export function CompactNumberInput({
         // fallback.)
         const typed = parseFloat(editValue);
         const base = Number.isFinite(typed) ? typed : value;
-        // A typed value can sit above the ceiling captured on entry, so raise it
-        // — upward only, which is what keeps a nudge from ratcheting back down.
-        const ceiling = Math.max(editCeiling, ceilingFrom(base));
-        if (ceiling !== editCeiling) setEditCeiling(ceiling);
-        const next = clampRange(tidy(base + delta), min, ceiling);
+        const peak = Math.max(editPeak, base);
+        if (peak !== editPeak) setEditPeak(peak);
+        const next = clampRange(tidy(base + delta), min, stepCeiling(peak));
         onChange(next);
         setEditValue(formatValue(next));
       }
     },
-    [editValue, commit, value, min, editCeiling, ceilingFrom, onChange, formatValue, tidy, step]
+    [editValue, commit, value, min, editPeak, stepCeiling, onChange, formatValue, tidy, step]
   );
 
   const handleScrubStart = useCallback(
@@ -187,7 +194,7 @@ export function CompactNumberInput({
       const startX = e.clientX;
       const startValue = value;
       // Fixed for the drag, so the ceiling can't drift as the value moves.
-      const ceiling = ceilingFrom(startValue);
+      const ceiling = stepCeiling(startValue);
       let moved = false;
 
       const handleMove = (moveEvent: PointerEvent) => {
@@ -216,7 +223,7 @@ export function CompactNumberInput({
       document.addEventListener('pointermove', handleMove);
       document.addEventListener('pointerup', handleUp);
     },
-    [disabled, editing, value, min, ceilingFrom, onChange, tidy, startEditing, step]
+    [disabled, editing, value, min, stepCeiling, onChange, tidy, startEditing, step]
   );
 
   return (
@@ -260,12 +267,10 @@ export function CompactNumberInput({
           value={editValue}
           onChange={(e) => {
             setEditValue(e.target.value);
-            // Re-derive the nudge ceiling from what is now in the field. Without
-            // this it only ever rises, so typing 100 over a committed 156 would
-            // leave arrows free to climb back to 156, past both `max` and the
-            // number actually entered.
+            // Reset rather than raise, so typing 100 over a committed 156 lowers
+            // the ceiling instead of leaving arrows free to climb back to 156.
             const typed = parseFloat(e.target.value);
-            setEditCeiling(ceilingFrom(Number.isFinite(typed) ? typed : value));
+            setEditPeak(Number.isFinite(typed) ? typed : value);
           }}
           onBlur={() => commit(editValue)}
           onKeyDown={handleKeyDown}

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -74,12 +74,19 @@ export function CompactNumberInput({
     (v: number) => (softMax ? Math.max(min, v) : clampRange(v, min, max)),
     [softMax, min, max]
   );
-  // Scrub/arrow ceiling. Under `softMax` a value typed past `max` raises the
-  // ceiling to itself, so nudging an over-max measurement steps down from where
-  // it is instead of snapping back to `max` on the first keypress.
+  /**
+   * True once a `softMax` field holds a typed value past its ceiling. `max` then
+   * describes the recommended range rather than the field's limit, so both the
+   * step clamp and the ARIA range have to follow the value instead.
+   */
+  const overSoftMax = softMax && value > max;
+  // Scrub/arrow ceiling. `max` still caps a value that is inside the range, so
+  // dragging can't take a legal value past it. Above the range the cap lifts
+  // entirely — pinning it to the current value instead would ratchet downward,
+  // letting ArrowDown leave 156 for 155 and then refusing to go back up.
   const clampStep = useCallback(
-    (v: number) => clampRange(v, min, softMax ? Math.max(max, value) : max),
-    [softMax, min, max, value]
+    (v: number) => (overSoftMax ? Math.max(min, v) : clampRange(v, min, max)),
+    [overSoftMax, min, max]
   );
 
   const formatValue = useCallback((v: number) => {
@@ -188,7 +195,9 @@ export function CompactNumberInput({
         aria-label={label}
         aria-valuenow={value}
         aria-valuemin={min}
-        aria-valuemax={max === Infinity ? undefined : max}
+        // Reporting the prop's `max` here while `value` sits above it would
+        // publish valuenow > valuemax, which is an invalid slider state.
+        aria-valuemax={max === Infinity ? undefined : overSoftMax ? value : max}
       >
         {label}
       </span>


### PR DESCRIPTION
Typing a measured width or height into a cutout larger than the current bin silently rewrote it to the bin's interior size, then showed an "outside the board" error about the value it had just changed. On a 3x3 bin, `156` became `123.1` with no indication. Cutouts got printed at the wrong size because the truncation was invisible.

Fixes #3061.

## What changed

**The W and H fields keep what you type.** They are measurements, so the input records them; whether they fit is the board's problem, not the field's.

**The off-board warning now offers both ways out.** It leads with `Grow bin to 5 x 3` (naming the size it will produce, so the consequence is visible before you click), with `Bring back in` underneath as the existing clamp.

Growing:

- respects half-grid mode: whole units when it's off, 0.5 steps when it's on. With it off, a fractional dimension necessarily stays fractional; with it on, a fractional start may land on a whole unit, since that is the smallest size that fits and 0.5 granularity is what the mode opts into
- extends the board toward +X/+Y, so no other cutout moves. Same as bumping the width stepper today
- sizes for every stranded cutout at once, so one click clears the warning
- applies as a single undo step

**The action is hidden, with a one-line explanation, when growing cannot clear the warning:** past `MAX_DIMENSION` (16u), on a custom-shaped (masked) bin where a larger footprint does not imply a larger usable region, or for a cutout hanging past the origin edge. A button that grows partway and leaves the warning up reads as broken.

## Interaction scope

Overflow is typed-only. The step ceiling is fixed for the duration of a gesture — captured when the text field is entered, and at pointer-down for a drag. Inside the range it is `max`, so a value that fits cannot be dragged off the board; above it, it is the number that was typed, so no gesture can raise a value beyond what the user entered while nudging it still works in both directions. Recomputing that ceiling per keystroke instead would let it follow the value down, stranding ArrowUp one step below where it started.

Two consequences of allowing an oversize cutout are handled: the X/Y ceilings pin to 0 rather than going negative, and `clampRotationToBounds` no longer freezes a cutout that is already out of bounds (the binary search would otherwise converge back onto the current angle, making the rotation field a silent no-op of exactly the kind this issue is about).

The clamp lives in the shared `CompactNumberInput`, so it is relaxed via an opt-in `softMax` prop rather than changed for the ~20 other call sites.

## Two app-wide changes to the shared input

Both surfaced while reviewing the above, and both are deliberate rather than scoped to `softMax`:

- **Non-finite entries no longer commit.** `parseFloat` maps `Infinity` and any overflowing exponent (`1e309`) to `Infinity`, and the old `!isNaN` guard let it through. A hard `max` absorbed it by silently committing the ceiling, so `Infinity` set a rotation field to 359 while `abc` left it alone. Both revert now; a `softMax` field has no ceiling to absorb it at all, and geometry must never see a non-finite dimension.
- **`aria-valuemax` always contains the value.** It was taken from the `max` prop, so any value above it published `valuenow > valuemax`, an invalid slider state. That is reachable two ways: a soft-max measurement, and X/Y on an oversize cutout, whose ceiling collapses to 0 while the stored offset stands.

## UI

The warning box was hand-rolled and carried no `role`, so it was silent to screen readers; it now uses the design-system `Alert`, which supplies `role="alert"` and the canonical intent tokens. The action names a bin size and the inspector dock narrows to 220px, where 7 of the 15 locale strings measure past the 157px content box, so both actions size to their content rather than clipping a second line against a fixed height. The "can't grow far enough" line moved up to sit with the warning it qualifies.

## Verification

- `computeGrowToFit` unit tests cover the reported repro, half-grid stepping, per-axis growth, array instances, overhang-expanded interiors, and all three `null` branches
- `pnpm run quality` clean; 2622 tests passing across the touched areas
- Driven end to end in a browser: typing `156` keeps `156` and shows `Grow bin to 5 x 3`; clicking it grows the bin to 210 x 126 mm and clears the warning with the cutout unmoved. `900` keeps `900`, hides the grow action and shows the explanation. Half-grid on produces `Grow bin to 3.5 x 2`
- Label overflow measured in-page at the dock minimum before and after the fix (`scrollHeight` 28 against a 24px box, now 38 against 38)

