### PR TITLE
fix(drawer-shape): re-frame the pen canvas on resize, release space-pan on blur

### DIFF
--- a/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.test.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.test.tsx
@@ -31,6 +31,7 @@ function renderCanvas(overrides: Partial<Parameters<typeof PenCanvas>[0]> = {}) 
     onDoubleClick: vi.fn(),
     onKeyDown: vi.fn(),
     onKeyUp: vi.fn(),
+    onBlur: vi.fn(),
     onWheel: vi.fn(),
     ...overrides,
   };
@@ -85,6 +86,7 @@ describe('PenCanvas', () => {
           onDoubleClick: vi.fn(),
           onKeyDown: vi.fn(),
           onKeyUp: vi.fn(),
+          onBlur: vi.fn(),
           onWheel: vi.fn(),
         }}
       />

--- a/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.tsx
@@ -7,7 +7,11 @@
  * now that it carries history, keyboard editing, a view and a selection model.
  */
 
-import type { PointerEvent as ReactPointerEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type {
+  PointerEvent as ReactPointerEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+  FocusEvent as ReactFocusEvent,
+} from 'react';
 import type { RefObject } from 'react';
 import type { OutlineVertex } from '@/core/types';
 import { segmentHandle } from '../../utils/penShape';
@@ -32,7 +36,7 @@ export interface PenCanvasProps {
   readonly onDoubleClick: (e: ReactPointerEvent<SVGSVGElement>) => void;
   readonly onKeyDown: (e: ReactKeyboardEvent<SVGSVGElement>) => void;
   readonly onKeyUp: (e: ReactKeyboardEvent<SVGSVGElement>) => void;
-  readonly onBlur: () => void;
+  readonly onBlur: (e: ReactFocusEvent<SVGSVGElement>) => void;
   readonly onWheel: (e: React.WheelEvent<SVGSVGElement>) => void;
 }
 

--- a/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.tsx
@@ -32,6 +32,7 @@ export interface PenCanvasProps {
   readonly onDoubleClick: (e: ReactPointerEvent<SVGSVGElement>) => void;
   readonly onKeyDown: (e: ReactKeyboardEvent<SVGSVGElement>) => void;
   readonly onKeyUp: (e: ReactKeyboardEvent<SVGSVGElement>) => void;
+  readonly onBlur: () => void;
   readonly onWheel: (e: React.WheelEvent<SVGSVGElement>) => void;
 }
 
@@ -55,6 +56,7 @@ export function PenCanvas({
   onDoubleClick,
   onKeyDown,
   onKeyUp,
+  onBlur,
   onWheel,
 }: PenCanvasProps) {
   return (
@@ -70,6 +72,7 @@ export function PenCanvas({
       onDoubleClick={onDoubleClick}
       onKeyDown={onKeyDown}
       onKeyUp={onKeyUp}
+      onBlur={onBlur}
       // Role before tabIndex: it declares what the element is before how it is
       // reached, which is also the order the a11y check reads the pair in.
       role="application"

--- a/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.test.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import type { DrawerOutline } from '@/core/types';
 import { ok } from '@/core/result';
 import { useLayoutStore } from '@/core/store';
@@ -289,6 +289,41 @@ describe('PenShapeDialog', () => {
       expect(vb[2]).toBeLessThan(448);
       expect(vb[0]).toBeGreaterThan(0);
       expect(screen.getByText('drawerShape.penResetView')).toBeInTheDocument();
+    });
+
+    // A resize changes the frame itself, so a pan chosen for the old one can
+    // sit outside it or hide the area that just appeared.
+    it('re-frames when the drawer is resized while open', () => {
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      const svg = canvas();
+      svg.getBoundingClientRect = rect;
+      fireEvent.wheel(svg, { deltaY: -100, clientX: 224, clientY: 182 });
+      expect(svg.getAttribute('viewBox')).not.toBe('0 0 448 364');
+
+      act(() => {
+        useLayoutStore.setState((state) => ({
+          layout: { ...state.layout, drawer: { ...state.layout.drawer, width: 12 } },
+        }));
+      });
+
+      expect(canvas().getAttribute('viewBox')).toBe('0 0 532 364');
+    });
+
+    // Focus can leave while Space is held, and the keyup then never arrives —
+    // leaving every later drag stuck in pan mode.
+    it('releases space-pan when the canvas loses focus', () => {
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      const svg = canvas();
+      svg.getBoundingClientRect = rect;
+      fireEvent.keyDown(svg, { key: ' ' });
+      fireEvent.blur(svg);
+
+      // A background drag should now marquee, not pan: the view must not move.
+      const before = svg.getAttribute('viewBox');
+      fireEvent.pointerDown(svg, { clientX: 200, clientY: 200 });
+      fireEvent.pointerMove(svg, { clientX: 150, clientY: 150 });
+      fireEvent.pointerUp(svg);
+      expect(svg.getAttribute('viewBox')).toBe(before);
     });
 
     it('restores the default framing from the reset control', () => {

--- a/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.test.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.test.tsx
@@ -315,6 +315,9 @@ describe('PenShapeDialog', () => {
       render(<PenShapeDialog open onClose={vi.fn()} />);
       const svg = canvas();
       svg.getBoundingClientRect = rect;
+      // Zoom in first: at 1x the window fills the frame and panning has no room,
+      // so the view would hold still whether or not blur cleared the flag.
+      fireEvent.wheel(svg, { deltaY: -100, clientX: 224, clientY: 182 });
       fireEvent.keyDown(svg, { key: ' ' });
       fireEvent.blur(svg);
 

--- a/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.tsx
@@ -447,6 +447,12 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
               onKeyUp={(e) => {
                 if (e.key === ' ') spaceRef.current = false;
               }}
+              // Focus can leave while Space is held, and the keyup then never
+              // reaches this element — leaving the canvas stuck in pan mode for
+              // every later drag, including in a new session.
+              onBlur={() => {
+                spaceRef.current = false;
+              }}
               onWheel={handleWheel}
             />
           </div>

--- a/src/features/drawer-shape/components/PenShapeDialog/usePenView.ts
+++ b/src/features/drawer-shape/components/PenShapeDialog/usePenView.ts
@@ -38,11 +38,17 @@ export function usePenView(widthMm: number, depthMm: number, session: unknown): 
   // both together, and splitting them would let a render observe half a step.
   const [view, setView] = useState({ zoom: 1, x: 0, y: 0 });
   // A new session, or a resized drawer, must start in the default framing: the
-  // dialog stays mounted, so the previous session's zoom and pan would
-  // otherwise be inherited by a shape they were never framed for.
-  const [viewSession, setViewSession] = useState<unknown>(session);
-  if (viewSession !== session) {
-    setViewSession(session);
+  // dialog stays mounted, so the previous zoom and pan would otherwise be
+  // inherited by a shape they were never framed for. The frame dimensions are
+  // part of the identity because a resize changes the frame itself, leaving a
+  // pan that can sit outside it or hide the area that just appeared.
+  const identity = `${String(frameW)}x${String(frameH)}`;
+  const [viewIdentity, setViewIdentity] = useState<{ session: unknown; frame: string }>({
+    session,
+    frame: identity,
+  });
+  if (viewIdentity.session !== session || viewIdentity.frame !== identity) {
+    setViewIdentity({ session, frame: identity });
     setView({ zoom: 1, x: 0, y: 0 });
   }
   const { zoom } = view;


### PR DESCRIPTION
Two review findings that arrived on #3065 roughly nine seconds before it merged, so they were not in the sweep that gated it.

## Resize keeps a stale view

The view reset keyed only on the editing session, so resizing the drawer while the dialog is open kept a pan chosen for the old frame. That pan can sit outside the new frame, or hide exactly the area the resize just added. The frame dimensions are part of the reset identity now.

## Space-pan survives losing focus

Space-pan was cleared on keyup, which never arrives if focus leaves while the key is held. The canvas then stayed in pan mode for every later drag, including in a new session, so a background drag panned instead of sweeping a marquee. It clears on blur as well.

## The third finding, not fixed

The same batch reported a P1 that bowed edges render mirrored relative to the persisted outline, on the grounds that a positive bulge uses SVG sweep flag `1` while the canvas is Y-flipped.

I could not reproduce it and believe the mapping is correct. The flip is what makes `sweep > 0 ? 1 : 0` right rather than wrong: `arcGeometry` returns a DXF-convention sweep, positive meaning counter-clockwise in a Y-up frame, and inside `scale(1 -1)` the user space is Y-up, where SVG's positive-angle direction is counter-clockwise. Without the flip the flag would need inverting.

Measured in the browser, bowing the front edge and sampling the rendered path at mid-chord against the segment handle, which is placed from the same sagitta relation `arcGeometry` gives validation and generation:

```
path d       : M 0 0 A 501.75 501.75 0 0 0 420 0 L 420 336 L 0 336 Z
curve at x=210, y = 46.06
handle       : x = 210.00 y = 46.06
```

Same side, agreeing to 0.01mm. Reasoning and evidence are on the thread; happy to reopen against a case that diverges.

## Verification

- Two tests: a resize while open restores the default framing, and a background drag after Space-then-blur marquees rather than pans
- 117 drawer-shape tests pass; typecheck and lint clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframes the Pen editor canvas when the drawer is resized and releases space-to-pan on blur. Fixes stale views after resize and prevents the canvas from getting stuck in pan mode.

- **Bug Fixes**
  - Reset view now keys off session + frame dimensions. Resizing restores the default framing instead of keeping a stale pan.
  - Space-pan clears on blur (not just keyup). `onBlur` is typed and wired through `PenCanvas`, and the regression test now zooms in to reliably catch the bug.

<sup>Written for commit 51bbbd6c829067f6636c479cd2578636f3b74b61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

