### PR TITLE
feat(drawer-shape): round each corner to its own radius

### DIFF
--- a/src/features/drawer-shape/README.md
+++ b/src/features/drawer-shape/README.md
@@ -24,6 +24,12 @@ hatching, baseplate generation/splitting) derives from it.
   boundary; the outer loop scales by the per-axis grid pitch (`gridUnitMm` /
   `gridUnitMmY`, issue #2733) into outline mm. Enclosed holes are filled
   (single-loop model); empty/disconnected grids error.
+- `components/PenShapeDialog` — freeform perimeter editor. Drag corners and bow
+  segments into arcs; per-corner rounding comes from `@/shared/utils/filletOutline`
+  and is baked into the stored vertices, so every consumer sees the same shape.
+  Sketch state lives in `usePenSketch`, which owns the `radii` parallel array —
+  inserting and deleting are hook methods precisely so no call site can shift
+  vertex indices without moving the radii with them.
 - `utils/traceBinFootprint.ts` — bins → editor grid (all layers, staging
   excluded).
 
@@ -36,7 +42,13 @@ hatching, baseplate generation/splitting) derives from it.
 3. Reopening the editor rasterizes the stored outline back to cells with the
    same `classifyRect` predicate placement uses — a cell is filled iff bins
    may occupy it.
-4. The corner-cut vertex geometry lives in
+4. **Rounding is stored as geometry, not as a parameter** — so the pen editor
+   reopens a saved shape through `unfilletOutline`, which collapses each tangent
+   arc back to the corner it was built from plus its radius. That inverse is
+   what keeps a radius adjustable without persisting a second copy of the shape
+   alongside the outline. A hand-drawn arc is not tangent to its neighbours, so
+   it survives as drawn.
+5. The corner-cut vertex geometry lives in
    `@/shared/utils/cornerCutOutline` (not here) so the baseplate's
    `buildFullParams` can re-inscribe the same cuts on the padded plate
    rectangle (issue #2612). `cornersToOutline` is a thin wrapper that adds

--- a/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.test.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.test.tsx
@@ -14,6 +14,7 @@ function renderCanvas(overrides: Partial<Parameters<typeof PenCanvas>[0]> = {}) 
   const props = {
     svgRef: createRef<SVGSVGElement>(),
     verts: VERTS,
+    radii: [0, 0, 0, 0],
     selected: new Set<number>(),
     pathD: 'M 0 0 L 100 0 L 100 80 L 0 80 Z',
     widthMm: 100,
@@ -60,6 +61,16 @@ describe('PenCanvas', () => {
     expect(filled).toHaveLength(2);
   });
 
+  // Which corners carry a radius has to be readable without clicking each one,
+  // now that rounding is per corner rather than one value for the shape.
+  it('draws a rounded corner differently from a sharp one', () => {
+    const { container } = renderCanvas({ radii: [12, 0, 0, 0] });
+    const rings = [...container.querySelectorAll('circle')].filter((c) =>
+      (c.getAttribute('class') ?? '').includes('stroke-content-secondary')
+    );
+    expect(rings).toHaveLength(1);
+  });
+
   it('colours the outline by validity', () => {
     const { container, rerender } = renderCanvas();
     expect(container.querySelector('path')?.getAttribute('class')).toContain('stroke-accent');
@@ -69,6 +80,7 @@ describe('PenCanvas', () => {
         {...{
           svgRef: createRef<SVGSVGElement>(),
           verts: VERTS,
+          radii: [0, 0, 0, 0],
           selected: new Set<number>(),
           pathD: 'M 0 0 Z',
           widthMm: 100,

--- a/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenCanvas.tsx
@@ -19,6 +19,8 @@ import { segmentHandle } from '../../utils/penShape';
 export interface PenCanvasProps {
   readonly svgRef: RefObject<SVGSVGElement | null>;
   readonly verts: readonly OutlineVertex[];
+  /** Fillet radius per corner; a rounded one is drawn differently. */
+  readonly radii: readonly number[];
   readonly selected: ReadonlySet<number>;
   readonly pathD: string;
   readonly widthMm: number;
@@ -43,6 +45,7 @@ export interface PenCanvasProps {
 export function PenCanvas({
   svgRef,
   verts,
+  radii,
   selected,
   pathD,
   widthMm,
@@ -145,20 +148,27 @@ export function PenCanvas({
             />
           );
         })}
-        {verts.map((v, i) => (
-          <circle
-            key={`vert-${i}`}
-            cx={v.x}
-            cy={v.y}
-            r={handleR}
-            className={
-              selected.has(i)
-                ? 'cursor-move fill-accent stroke-accent'
-                : 'cursor-move fill-surface stroke-accent'
-            }
-            strokeWidth={handleR / 3}
-          />
-        ))}
+        {verts.map((v, i) => {
+          // A rounded corner reads as a ring rather than a dot, so which
+          // corners carry a radius is visible without selecting them one by one.
+          const rounded = (radii[i] ?? 0) > 0;
+          return (
+            <circle
+              key={`vert-${i}`}
+              cx={v.x}
+              cy={v.y}
+              r={handleR}
+              className={
+                selected.has(i)
+                  ? 'cursor-move fill-accent stroke-accent'
+                  : rounded
+                    ? 'cursor-move fill-surface stroke-content-secondary'
+                    : 'cursor-move fill-surface stroke-accent'
+              }
+              strokeWidth={rounded ? handleR / 1.6 : handleR / 3}
+            />
+          );
+        })}
       </g>
     </svg>
   );

--- a/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.test.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.test.tsx
@@ -4,6 +4,7 @@ import type { DrawerOutline } from '@/core/types';
 import { ok } from '@/core/result';
 import { useLayoutStore } from '@/core/store';
 import { resetAllStores } from '@/test/testUtils';
+import { filletOutline } from '@/shared/utils/filletOutline';
 import { PenShapeDialog } from './PenShapeDialog';
 
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
@@ -174,6 +175,104 @@ describe('PenShapeDialog', () => {
     // A rounded rectangle is eight points, four of them carrying an arc.
     expect(applied?.vertices).toHaveLength(8);
     expect(applied?.vertices.filter((v) => (v.bulge ?? 0) !== 0)).toHaveLength(4);
+  });
+
+  // A drawer moulding is rarely uniform, so the radius control follows the
+  // selection rather than always rounding the whole shape (#3054).
+  describe('per-corner rounding', () => {
+    const rect = () => ({ left: 0, top: 0, width: 448, height: 364 }) as DOMRect;
+    /** Screen point for a drawer-local mm coordinate, in the default view. */
+    const at = (x: number, y: number) => ({ clientX: x + 14, clientY: 364 - 14 - y });
+
+    function selectCorner(x: number, y: number, shiftKey = false): void {
+      const svg = screen.getByRole('application');
+      svg.getBoundingClientRect = rect;
+      fireEvent.pointerDown(svg, { ...at(x, y), shiftKey });
+      fireEvent.pointerUp(svg);
+    }
+
+    function setRadius(label: string, value: string): void {
+      const stepper = screen.getByLabelText(label);
+      fireEvent.change(stepper, { target: { value } });
+      fireEvent.blur(stepper);
+    }
+
+    it('rounds only the selected corner', () => {
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      selectCorner(0, 0);
+
+      setRadius('drawerShape.penFilletSelected', '20');
+      fireEvent.click(screen.getByText('drawerShape.editor.apply'));
+
+      const applied = setDrawerOutline.mock.calls[0][0];
+      // One corner became two points joined by a single arc; the rest stay sharp.
+      expect(applied?.vertices).toHaveLength(5);
+      expect(applied?.vertices.filter((v) => (v.bulge ?? 0) !== 0)).toHaveLength(1);
+    });
+
+    it('gives each corner its own radius', () => {
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      selectCorner(0, 0);
+      setRadius('drawerShape.penFilletSelected', '20');
+      selectCorner(420, 0);
+      setRadius('drawerShape.penFilletSelected', '40');
+      fireEvent.click(screen.getByText('drawerShape.editor.apply'));
+
+      const applied = setDrawerOutline.mock.calls[0][0];
+      expect(applied?.vertices).toHaveLength(6);
+      expect(applied?.vertices.filter((v) => (v.bulge ?? 0) !== 0)).toHaveLength(2);
+    });
+
+    // Without an inverse, a saved radius is unreachable: reopening shows arcs,
+    // and filletOutline skips arc-adjacent corners, so the stepper does nothing.
+    it('recovers the radius of a saved shape so it stays adjustable', () => {
+      const { w, d } = extent();
+      setOutline(
+        filletOutline(
+          {
+            vertices: [
+              { x: 0, y: 0 },
+              { x: w, y: 0 },
+              { x: w, y: d },
+              { x: 0, y: d },
+            ],
+          },
+          25
+        ).vertices
+      );
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+
+      // Four corners again, not the eight points the stored outline has.
+      expect(screen.getByLabelText('drawerShape.penFillet')).toHaveValue(25);
+      selectCorner(0, 0);
+      setRadius('drawerShape.penFilletSelected', '5');
+      fireEvent.click(screen.getByText('drawerShape.editor.apply'));
+
+      const applied = setDrawerOutline.mock.calls[0][0];
+      expect(applied?.vertices.filter((v) => (v.bulge ?? 0) !== 0)).toHaveLength(4);
+    });
+
+    it('reports a mixed radius rather than a wrong one', () => {
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      selectCorner(0, 0);
+      setRadius('drawerShape.penFilletSelected', '20');
+      selectCorner(420, 0, true);
+
+      expect(screen.getByText('drawerShape.penFilletMixed')).toBeInTheDocument();
+      expect(screen.getByLabelText('drawerShape.penFilletSelected')).toHaveValue(0);
+    });
+
+    it('drops every radius when the sketch is reset', () => {
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      setRadius('drawerShape.penFillet', '20');
+
+      fireEvent.click(screen.getByText('drawerShape.penReset'));
+      fireEvent.click(screen.getByText('drawerShape.editor.apply'));
+
+      const applied = setDrawerOutline.mock.calls[0][0];
+      expect(applied?.vertices).toHaveLength(4);
+      expect(applied?.vertices.filter((v) => (v.bulge ?? 0) !== 0)).toHaveLength(0);
+    });
   });
 
   // role="application" tells assistive technology the canvas handles its own

--- a/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.tsx
@@ -29,14 +29,13 @@ import { useMutations } from '@/shared/contexts/MutationsContext';
 import { computeDisplacedBins } from '@/core/cqrs/v2/domain/drawer/displacement';
 import { trackDrawerShapeApplied } from '@/shared/analytics/posthog';
 import { validateOutline } from '@/shared/utils/drawerOutline';
-import { filletOutline } from '@/shared/utils/filletOutline';
+import { filletOutline, unfilletOutline } from '@/shared/utils/filletOutline';
 import {
   bulgeThroughPoint,
   clampToDrawer,
   alignmentGuides,
   hitSegmentMidpoint,
   hitVertex,
-  insertVertex,
   moveVertex,
   clampGroupDelta,
   moveVertices,
@@ -87,16 +86,22 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
 
   // Reseed only when the dialog opens: an existing outline becomes the starting
   // sketch (any authoring surface, so a painted shape can be refined freehand),
-  // otherwise start from the drawer rectangle.
+  // otherwise start from the drawer rectangle. `unfilletOutline` collapses a
+  // rounded corner back to a sharp one plus its radius, so a saved shape reopens
+  // with its rounding still adjustable rather than as arcs made of extra points.
   const seeded = useMemo(() => {
     if (!open) return null;
     const existing = layout.drawer.outline;
-    return existing !== undefined ? [...existing.vertices] : rectangleSketch(widthMm, depthMm);
+    if (existing !== undefined) {
+      const { vertices, radii } = unfilletOutline(existing);
+      return { verts: vertices, radii };
+    }
+    const verts = rectangleSketch(widthMm, depthMm);
+    return { verts, radii: verts.map(() => 0) };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- reseed only on open
   }, [open]);
 
   const [snap, setSnap] = useState<SnapFraction>(0.5);
-  const [fillet, setFillet] = useState(0);
   const dragRef = useRef<Drag | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const sketch = usePenSketch(seeded);
@@ -104,7 +109,7 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
   const view = usePenView(widthMm, depthMm, seeded);
   // Divided by the zoom so the grab area matches the drawn handle at any zoom.
   const hitR = hitRadiusMm(widthMm, depthMm) / view.zoom;
-  const { verts, selected, setSelected } = sketch;
+  const { verts, radii, selected, setSelected } = sketch;
   const [marquee, setMarquee] = useState<{ x0: number; y0: number; x1: number; y1: number } | null>(
     null
   );
@@ -122,8 +127,13 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
     if (verts.length < 3) return null;
     // Baked into the stored geometry rather than kept as a parameter, so every
     // consumer — plate, hatching, placement — sees the same rounded shape.
-    return filletOutline(sketchToOutline(verts), fillet);
-  }, [verts, fillet]);
+    //
+    // Fillet BEFORE normalizing the winding: `sketchToOutline` reverses a
+    // clockwise loop, which reorders vertices and would leave every radius
+    // describing a different corner than the one it was set on. `cornerAt`'s
+    // turn is signed, so an unnormalized loop still rounds on the correct side.
+    return sketchToOutline(filletOutline({ vertices: [...verts] }, radii).vertices);
+  }, [verts, radii]);
   const error = useMemo(
     () =>
       outline === null
@@ -245,17 +255,22 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
           widthMm,
           depthMm
         );
-        sketch.preview(moveVertices(verts, moving, dx, dy));
+        sketch.preview({ verts: moveVertices(verts, moving, dx, dy), radii });
         return;
       }
 
       // Bulge is a curvature, not a position, so it is never snapped.
       const clamped = clampToDrawer(p.x, p.y, widthMm, depthMm);
-      sketch.preview(
-        setBulge(verts, drag.index, bulgeThroughPoint(verts, drag.index, clamped.x, clamped.y))
-      );
+      sketch.preview({
+        verts: setBulge(
+          verts,
+          drag.index,
+          bulgeThroughPoint(verts, drag.index, clamped.x, clamped.y)
+        ),
+        radii,
+      });
     },
-    [toMm, snapPoint, verts, widthMm, depthMm, sketch, view, selected, hitR]
+    [toMm, snapPoint, verts, radii, widthMm, depthMm, sketch, view, selected, hitR]
   );
 
   const endDrag = useCallback(() => {
@@ -289,17 +304,36 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
       if (p === null) return;
       const seg = hitSegmentMidpoint(verts, p.x, p.y, hitR * 2);
       if (seg >= 0) {
-        sketch.commit(insertVertex(verts, seg));
-        setSelected([seg + 1]);
+        setSelected([sketch.insertAt(seg)]);
       }
     },
     [verts, toMm, hitR, setSelected, sketch]
   );
 
   const maxFillet = Math.round(Math.min(widthMm, depthMm) / 4);
+  /** Corners the radius control edits: the selection, or the whole shape. */
+  const filletTargets = useMemo(
+    () => (selected.size > 0 ? [...selected] : radii.map((_, i) => i)),
+    [selected, radii]
+  );
+  /**
+   * Their shared radius, or null when they disagree. Compared with a tolerance
+   * rather than exactly: radii recovered from a stored shape come off
+   * coordinates already quantized to 0.01mm, so corners rounded together can
+   * land a few hundredths apart and would otherwise report as mixed.
+   */
+  const filletValue = useMemo(() => {
+    if (filletTargets.length === 0) return 0;
+    const first = radii[filletTargets[0]] ?? 0;
+    return filletTargets.every((i) => Math.abs((radii[i] ?? 0) - first) <= 0.05) ? first : null;
+  }, [filletTargets, radii]);
+  const applyFillet = useCallback(
+    (r: number) => sketch.setRadii(filletTargets, Math.min(maxFillet, Math.max(0, r))),
+    [sketch, filletTargets, maxFillet]
+  );
   const stepFillet = useCallback(
-    (delta: number) => setFillet((r) => Math.min(maxFillet, Math.max(0, r + delta))),
-    [maxFillet]
+    (delta: number) => applyFillet((filletValue ?? 0) + delta),
+    [applyFillet, filletValue]
   );
 
   /**
@@ -371,14 +405,13 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
         widthMm,
         depthMm
       );
-      sketch.commit(moveVertex(verts, lone, p.x, p.y));
+      sketch.commit({ verts: moveVertex(verts, lone, p.x, p.y), radii });
     },
-    [lone, verts, widthMm, depthMm, sketch]
+    [lone, verts, radii, widthMm, depthMm, sketch]
   );
 
   const handleReset = useCallback(() => {
     sketch.reset(widthMm, depthMm);
-    setFillet(0);
   }, [widthMm, depthMm, sketch]);
 
   const handleApply = useCallback(() => {
@@ -402,14 +435,8 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
     if (displaced > 0) {
       addToast(t('toast.binsDisplacedByShape', { count: displaced }), 'info');
     }
-    setFillet(0);
     onClose();
   }, [outline, error, layout, gridUnitMmY, mutations, addToast, t, onClose]);
-
-  const handleClose = useCallback(() => {
-    setFillet(0);
-    onClose();
-  }, [onClose]);
 
   if (!open) return null;
 
@@ -418,7 +445,7 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
   const handleR = baseHandleR / view.zoom;
 
   return (
-    <Dialog.Root open={open} onClose={handleClose} size="lg">
+    <Dialog.Root open={open} onClose={onClose} size="lg">
       <Dialog.Header title={t('drawerShape.penTitle')} />
       <Dialog.Body>
         <div className="space-y-3">
@@ -428,6 +455,7 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
             <PenCanvas
               svgRef={svgRef}
               verts={verts}
+              radii={radii}
               selected={selected}
               pathD={outline !== null ? sketchPathD(outline.vertices) : sketchPathD(verts)}
               widthMm={widthMm}
@@ -497,17 +525,30 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
               </div>
             )}
             <div className="flex items-center gap-2">
-              <span className="text-xs text-content-secondary">{t('drawerShape.penFillet')}</span>
+              <span className="text-xs text-content-secondary">
+                {selected.size > 0
+                  ? t('drawerShape.penFilletSelected', { count: selected.size })
+                  : t('drawerShape.penFillet')}
+              </span>
               <Stepper
-                value={fillet}
-                onChange={setFillet}
+                value={filletValue ?? 0}
+                onChange={applyFillet}
                 onStep={stepFillet}
                 min={0}
                 max={maxFillet}
                 step={1}
                 size="sm"
-                aria-label={t('drawerShape.penFillet')}
+                aria-label={
+                  selected.size > 0
+                    ? t('drawerShape.penFilletSelected', { count: selected.size })
+                    : t('drawerShape.penFillet')
+                }
               />
+              {filletValue === null && (
+                <span className="text-xs text-content-tertiary">
+                  {t('drawerShape.penFilletMixed')}
+                </span>
+              )}
             </div>
             <div className="flex items-center gap-2">
               <Button
@@ -547,7 +588,7 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
         </div>
       </Dialog.Body>
       <Dialog.Footer>
-        <Button type="button" variant="secondary" onClick={handleClose}>
+        <Button type="button" variant="secondary" onClick={onClose}>
           {t('common.cancel')}
         </Button>
         <Button type="button" variant="primary" onClick={handleApply} disabled={error !== null}>

--- a/src/features/drawer-shape/components/PenShapeDialog/usePenSketch.test.ts
+++ b/src/features/drawer-shape/components/PenShapeDialog/usePenSketch.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { usePenSketch, type Sketch } from './usePenSketch';
+
+const SQUARE: Sketch = {
+  verts: [
+    { x: 0, y: 0 },
+    { x: 100, y: 0 },
+    { x: 100, y: 100 },
+    { x: 0, y: 100 },
+  ],
+  radii: [1, 2, 3, 4],
+};
+
+const BOUNDS = { widthMm: 100, depthMm: 100, pitchX: 42, pitchY: 42, snap: 0.5 } as const;
+
+function setup(seed: Sketch = SQUARE) {
+  return renderHook(() => usePenSketch(seed));
+}
+
+// `radii` is a per-index parallel array. Any operation that shifts vertex
+// indices without moving it leaves every radius describing a different corner
+// than the one it was set on, which is silent — the shape just rounds in the
+// wrong places.
+describe('usePenSketch radius alignment', () => {
+  it('seeds the radii that came with the sketch', () => {
+    const { result } = setup();
+    expect(result.current.radii).toEqual([1, 2, 3, 4]);
+  });
+
+  it('keeps radii with their corners when a corner is inserted', () => {
+    const { result } = setup();
+    let inserted = -1;
+    act(() => {
+      inserted = result.current.insertAt(0);
+    });
+    expect(inserted).toBe(1);
+    // The new corner lands between 0 and 1, sharp, and pushes the rest along.
+    expect(result.current.radii).toEqual([1, 0, 2, 3, 4]);
+    expect(result.current.verts).toHaveLength(5);
+  });
+
+  it('keeps radii with their corners when corners are deleted', () => {
+    const { result } = setup();
+    act(() => result.current.setSelected([1]));
+    act(() => result.current.deleteSelected());
+    expect(result.current.radii).toEqual([1, 3, 4]);
+    expect(result.current.verts).toHaveLength(3);
+  });
+
+  it('refuses a delete that would leave less than a triangle', () => {
+    const { result } = setup();
+    act(() => result.current.setSelected([0, 1]));
+    act(() => result.current.deleteSelected());
+    expect(result.current.radii).toEqual([1, 2, 3, 4]);
+    expect(result.current.verts).toHaveLength(4);
+  });
+
+  it('restores both arrays together on undo', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.insertAt(2);
+    });
+    act(() => result.current.undo());
+    expect(result.current.verts).toHaveLength(4);
+    expect(result.current.radii).toEqual([1, 2, 3, 4]);
+  });
+
+  it('sets the radius of only the given corners', () => {
+    const { result } = setup();
+    act(() => result.current.setRadii([0, 2], 9));
+    expect(result.current.radii).toEqual([9, 2, 9, 4]);
+  });
+
+  it('leaves the radii alone when a corner only moves', () => {
+    const { result } = setup();
+    act(() => result.current.setSelected([0]));
+    act(() => result.current.nudge(1, 0, BOUNDS));
+    expect(result.current.verts[0].x).toBeGreaterThan(0);
+    expect(result.current.radii).toEqual([1, 2, 3, 4]);
+  });
+
+  it('clears every radius when reset to a rectangle', () => {
+    const { result } = setup();
+    act(() => result.current.reset(100, 100));
+    expect(result.current.radii).toEqual([0, 0, 0, 0]);
+  });
+
+  // insertVertex refuses to split a zero-length segment, so nothing was added
+  // and the radii must not shift either.
+  it('does not shift radii when a degenerate split is refused', () => {
+    const { result } = setup({
+      verts: [
+        { x: 0, y: 0 },
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 0, y: 100 },
+      ],
+      radii: [1, 2, 3, 4],
+    });
+    act(() => {
+      expect(result.current.insertAt(0)).toBe(0);
+    });
+    expect(result.current.radii).toEqual([1, 2, 3, 4]);
+    expect(result.current.verts).toHaveLength(4);
+  });
+});

--- a/src/features/drawer-shape/components/PenShapeDialog/usePenSketch.ts
+++ b/src/features/drawer-shape/components/PenShapeDialog/usePenSketch.ts
@@ -1,22 +1,40 @@
 /**
- * Sketch state for the pen editor: the vertex list, the selection, and a
- * bounded undo stack.
+ * Sketch state for the pen editor: the vertex list, the per-corner radii, the
+ * selection, and a bounded undo stack.
  *
  * Split from the component because the editor is judged against a real vector
  * tool, where undo and keyboard editing are not extras — a drag that overshoots
  * is otherwise only recoverable by cancelling and starting the shape again.
+ *
+ * `radii` is a per-index parallel array, so every operation that shifts vertex
+ * indices has to move it in lockstep. That is why inserting and deleting live
+ * here rather than in the component: `commit` only accepts a whole sketch, and
+ * the two index-shifting edits are the hook's own methods, so there is no call
+ * site that can update one array and forget the other.
  */
 
 import { useCallback, useMemo, useRef, useState } from 'react';
 import type { OutlineVertex } from '@/core/types';
-import { clampToDrawer, moveVertices, rectangleSketch, removeVertices } from '../../utils/penShape';
+import {
+  clampToDrawer,
+  insertVertex,
+  moveVertices,
+  rectangleSketch,
+  removeVertices,
+} from '../../utils/penShape';
 import type { SnapFraction } from '../../utils/penShape';
 
 /** Undo depth. Deep enough for a long editing session, bounded so a drag can't grow it without limit. */
 const MAX_HISTORY = 50;
 
-export interface PenSketch {
+/** A sketch and the corner radii that go with it, index for index. */
+export interface Sketch {
   readonly verts: readonly OutlineVertex[];
+  /** Fillet radius (mm) per corner; 0 leaves it sharp. */
+  readonly radii: readonly number[];
+}
+
+export interface PenSketch extends Sketch {
   /** Selected corner indices. Empty when nothing is selected. */
   readonly selected: ReadonlySet<number>;
   readonly canUndo: boolean;
@@ -25,12 +43,12 @@ export interface PenSketch {
   /** Add or remove one corner, for Shift-click. */
   toggleSelected: (index: number) => void;
   /** Replace the sketch and push the previous state onto the undo stack. */
-  commit: (next: readonly OutlineVertex[]) => void;
+  commit: (next: Sketch) => void;
   /**
    * Replace the sketch without a history entry. For the continuous part of a
    * drag: one pointer gesture should undo as one step, not fifty.
    */
-  preview: (next: readonly OutlineVertex[]) => void;
+  preview: (next: Sketch) => void;
   /** Open a history entry for a drag about to start. */
   beginGesture: () => void;
   undo: () => void;
@@ -40,6 +58,10 @@ export interface PenSketch {
   /** Move every selected corner by a snapped step, for arrow-key nudging. */
   nudge: (dx: number, dy: number, bounds: NudgeBounds) => void;
   deleteSelected: () => void;
+  /** Split segment `index` at its midpoint, returning the new corner's index. */
+  insertAt: (index: number) => number;
+  /** Set the radius of the given corners, leaving the rest alone. */
+  setRadii: (indices: Iterable<number>, radiusMm: number) => void;
 }
 
 export interface NudgeBounds {
@@ -50,8 +72,10 @@ export interface NudgeBounds {
   readonly snap: SnapFraction;
 }
 
-export function usePenSketch(seeded: readonly OutlineVertex[] | null): PenSketch {
-  const [verts, setVerts] = useState<readonly OutlineVertex[] | null>(null);
+const EMPTY: Sketch = { verts: [], radii: [] };
+
+export function usePenSketch(seeded: Sketch | null): PenSketch {
+  const [sketch, setSketch] = useState<Sketch | null>(null);
   const [selected, setSelectedState] = useState<ReadonlySet<number>>(() => new Set());
   const setSelected = useCallback(
     (indices: Iterable<number>) => setSelectedState(new Set(indices)),
@@ -64,7 +88,7 @@ export function usePenSketch(seeded: readonly OutlineVertex[] | null): PenSketch
       return next;
     });
   }, []);
-  const [history, setHistory] = useState<readonly (readonly OutlineVertex[])[]>([]);
+  const [history, setHistory] = useState<readonly Sketch[]>([]);
   // Set at pointer-down so the whole drag collapses into one undo entry.
   const gestureRef = useRef(false);
 
@@ -74,36 +98,36 @@ export function usePenSketch(seeded: readonly OutlineVertex[] | null): PenSketch
   const [seedIdentity, setSeedIdentity] = useState(seeded);
   if (seedIdentity !== seeded) {
     setSeedIdentity(seeded);
-    setVerts(null);
+    setSketch(null);
     setHistory([]);
     setSelectedState(new Set());
   }
 
-  const active = useMemo(() => verts ?? seeded ?? [], [verts, seeded]);
+  const active = useMemo(() => sketch ?? seeded ?? EMPTY, [sketch, seeded]);
 
-  const push = useCallback((prev: readonly OutlineVertex[]) => {
+  const push = useCallback((prev: Sketch) => {
     setHistory((h) => [...h.slice(-(MAX_HISTORY - 1)), prev]);
   }, []);
 
   const commit = useCallback(
-    (next: readonly OutlineVertex[]) => {
+    (next: Sketch) => {
       // A commit is a completed edit, so it also disarms: a press that armed a
       // gesture and then committed without moving would otherwise leave the
       // flag set, and the next drag would spend a second entry on it.
       gestureRef.current = false;
       push(active);
-      setVerts(next);
+      setSketch(next);
     },
     [active, push]
   );
 
   const preview = useCallback(
-    (next: readonly OutlineVertex[]) => {
+    (next: Sketch) => {
       if (gestureRef.current) {
         gestureRef.current = false;
         push(active);
       }
-      setVerts(next);
+      setSketch(next);
     },
     [active, push]
   );
@@ -132,17 +156,18 @@ export function usePenSketch(seeded: readonly OutlineVertex[] | null): PenSketch
     if (history.length === 0) return;
     const restored = history[history.length - 1];
     setHistory(history.slice(0, -1));
-    setVerts(restored);
+    setSketch(restored);
     // Keep the selection across an undo where the corners still exist, so the
     // coordinate fields do not blink out from under an edit. Undoing an insert
     // or delete can shorten the list, hence the bound filter.
-    setSelectedState((sel) => new Set([...sel].filter((i) => i < restored.length)));
+    setSelectedState((sel) => new Set([...sel].filter((i) => i < restored.verts.length)));
   }, [history]);
 
   const reset = useCallback(
     (widthMm: number, depthMm: number) => {
       push(active);
-      setVerts(rectangleSketch(widthMm, depthMm));
+      const verts = rectangleSketch(widthMm, depthMm);
+      setSketch({ verts, radii: verts.map(() => 0) });
       setSelectedState(new Set());
     },
     [active, push]
@@ -161,26 +186,59 @@ export function usePenSketch(seeded: readonly OutlineVertex[] | null): PenSketch
       let my = dy * stepY;
       for (const i of selected) {
         // A stale index can outlive its vertex (a delete, or a reseed).
-        if (i >= active.length) continue;
-        const v = active[i];
+        if (i >= active.verts.length) continue;
+        const v = active.verts[i];
         const c = clampToDrawer(v.x + mx, v.y + my, bounds.widthMm, bounds.depthMm);
         mx = c.x - v.x;
         my = c.y - v.y;
       }
       if (mx === 0 && my === 0) return;
-      commit(moveVertices(active, selected, mx, my));
+      commit({ verts: moveVertices(active.verts, selected, mx, my), radii: active.radii });
     },
     [selected, active, commit]
   );
 
   const deleteSelected = useCallback(() => {
-    if (selected.size === 0 || active.length - selected.size < 3) return;
-    commit(removeVertices(active, selected));
+    if (selected.size === 0 || active.verts.length - selected.size < 3) return;
+    commit({
+      verts: removeVertices(active.verts, selected),
+      radii: active.radii.filter((_, i) => !selected.has(i)),
+    });
     setSelectedState(new Set());
   }, [selected, active, commit]);
 
+  const insertAt = useCallback(
+    (index: number) => {
+      const verts = insertVertex(active.verts, index);
+      // insertVertex refuses a degenerate split, in which case nothing moved and
+      // the radii must not shift either.
+      if (verts.length === active.verts.length) return index;
+      const radii = [...active.radii];
+      // The new corner lands at index + 1 and starts sharp. The split corner
+      // keeps its radius: the midpoint sits on the segment it already had, so
+      // the angle the fillet was built from has not moved.
+      radii.splice(index + 1, 0, 0);
+      commit({ verts, radii });
+      return index + 1;
+    },
+    [active, commit]
+  );
+
+  const setRadii = useCallback(
+    (indices: Iterable<number>, radiusMm: number) => {
+      const targets = new Set(indices);
+      if (targets.size === 0) return;
+      commit({
+        verts: active.verts,
+        radii: active.radii.map((r, i) => (targets.has(i) ? radiusMm : r)),
+      });
+    },
+    [active, commit]
+  );
+
   return {
-    verts: active,
+    verts: active.verts,
+    radii: active.radii,
     selected,
     canUndo: history.length > 0,
     setSelected,
@@ -193,5 +251,7 @@ export function usePenSketch(seeded: readonly OutlineVertex[] | null): PenSketch
     reset,
     nudge,
     deleteSelected,
+    insertAt,
+    setRadii,
   };
 }

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Obnovit zobrazení",
   "drawerShape.penCorner": "Roh {n}",
   "drawerShape.penFillet": "Zaoblit rohy (mm)",
+  "drawerShape.penFilletSelected": "Zaoblit {count} roh(ů) (mm)",
+  "drawerShape.penFilletMixed": "Různé",
   "drawerShape.penSnapOff": "Vypnuto",
   "drawerShape.penDeletePoint": "Odstranit roh",
   "drawerShape.penReset": "Zpět na obdélník",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Ansicht zurücksetzen",
   "drawerShape.penCorner": "Ecke {n}",
   "drawerShape.penFillet": "Ecken abrunden (mm)",
+  "drawerShape.penFilletSelected": "{count} Ecke(n) abrunden (mm)",
+  "drawerShape.penFilletMixed": "Gemischt",
   "drawerShape.penSnapOff": "Aus",
   "drawerShape.penDeletePoint": "Ecke löschen",
   "drawerShape.penReset": "Auf Rechteck zurücksetzen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3402,6 +3402,8 @@ const en: Record<string, string> = {
   'drawerShape.penResetView': 'Reset view',
   'drawerShape.penCorner': 'Corner {n}',
   'drawerShape.penFillet': 'Round corners (mm)',
+  'drawerShape.penFilletSelected': 'Round {count} corner(s) (mm)',
+  'drawerShape.penFilletMixed': 'Mixed',
   'drawerShape.penSnapOff': 'Off',
   'drawerShape.penDeletePoint': 'Delete corner',
   'drawerShape.penReset': 'Reset to rectangle',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Restablecer vista",
   "drawerShape.penCorner": "Esquina {n}",
   "drawerShape.penFillet": "Redondear esquinas (mm)",
+  "drawerShape.penFilletSelected": "Redondear {count} esquina(s) (mm)",
+  "drawerShape.penFilletMixed": "Variado",
   "drawerShape.penSnapOff": "Desactivado",
   "drawerShape.penDeletePoint": "Eliminar esquina",
   "drawerShape.penReset": "Restablecer a rectángulo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Réinitialiser la vue",
   "drawerShape.penCorner": "Coin {n}",
   "drawerShape.penFillet": "Arrondir les coins (mm)",
+  "drawerShape.penFilletSelected": "Arrondir {count} coin(s) (mm)",
+  "drawerShape.penFilletMixed": "Variable",
   "drawerShape.penSnapOff": "Désactivé",
   "drawerShape.penDeletePoint": "Supprimer le coin",
   "drawerShape.penReset": "Revenir au rectangle",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Reimposta vista",
   "drawerShape.penCorner": "Angolo {n}",
   "drawerShape.penFillet": "Arrotonda angoli (mm)",
+  "drawerShape.penFilletSelected": "Arrotonda {count} angolo/i (mm)",
+  "drawerShape.penFilletMixed": "Vari",
   "drawerShape.penSnapOff": "Disattivato",
   "drawerShape.penDeletePoint": "Elimina angolo",
   "drawerShape.penReset": "Ripristina rettangolo",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "表示をリセット",
   "drawerShape.penCorner": "角 {n}",
   "drawerShape.penFillet": "角を丸める (mm)",
+  "drawerShape.penFilletSelected": "{count} 個の角を丸める (mm)",
+  "drawerShape.penFilletMixed": "混在",
   "drawerShape.penSnapOff": "オフ",
   "drawerShape.penDeletePoint": "角を削除",
   "drawerShape.penReset": "長方形に戻す",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "보기 초기화",
   "drawerShape.penCorner": "모서리 {n}",
   "drawerShape.penFillet": "모서리 둥글리기 (mm)",
+  "drawerShape.penFilletSelected": "모서리 {count}개 둥글리기 (mm)",
+  "drawerShape.penFilletMixed": "혼합",
   "drawerShape.penSnapOff": "끄기",
   "drawerShape.penDeletePoint": "모서리 삭제",
   "drawerShape.penReset": "직사각형으로 되돌리기",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Tilbakestill visning",
   "drawerShape.penCorner": "Hjørne {n}",
   "drawerShape.penFillet": "Avrund hjørner (mm)",
+  "drawerShape.penFilletSelected": "Avrund {count} hjørne(r) (mm)",
+  "drawerShape.penFilletMixed": "Blandet",
   "drawerShape.penSnapOff": "Av",
   "drawerShape.penDeletePoint": "Slett hjørne",
   "drawerShape.penReset": "Tilbakestill til rektangel",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Weergave herstellen",
   "drawerShape.penCorner": "Hoek {n}",
   "drawerShape.penFillet": "Hoeken afronden (mm)",
+  "drawerShape.penFilletSelected": "{count} hoek(en) afronden (mm)",
+  "drawerShape.penFilletMixed": "Gemengd",
   "drawerShape.penSnapOff": "Uit",
   "drawerShape.penDeletePoint": "Hoek verwijderen",
   "drawerShape.penReset": "Terug naar rechthoek",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Zresetuj widok",
   "drawerShape.penCorner": "Narożnik {n}",
   "drawerShape.penFillet": "Zaokrąglij narożniki (mm)",
+  "drawerShape.penFilletSelected": "Zaokrąglij {count} narożnik(ów) (mm)",
+  "drawerShape.penFilletMixed": "Różne",
   "drawerShape.penSnapOff": "Wyłączone",
   "drawerShape.penDeletePoint": "Usuń narożnik",
   "drawerShape.penReset": "Przywróć prostokąt",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Redefinir visualização",
   "drawerShape.penCorner": "Canto {n}",
   "drawerShape.penFillet": "Arredondar cantos (mm)",
+  "drawerShape.penFilletSelected": "Arredondar {count} canto(s) (mm)",
+  "drawerShape.penFilletMixed": "Variado",
   "drawerShape.penSnapOff": "Desligado",
   "drawerShape.penDeletePoint": "Excluir canto",
   "drawerShape.penReset": "Voltar ao retângulo",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Återställ vyn",
   "drawerShape.penCorner": "Hörn {n}",
   "drawerShape.penFillet": "Runda hörn (mm)",
+  "drawerShape.penFilletSelected": "Runda {count} hörn (mm)",
+  "drawerShape.penFilletMixed": "Blandat",
   "drawerShape.penSnapOff": "Av",
   "drawerShape.penDeletePoint": "Ta bort hörn",
   "drawerShape.penReset": "Återställ till rektangel",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "Скинути вигляд",
   "drawerShape.penCorner": "Кут {n}",
   "drawerShape.penFillet": "Заокруглити кути (мм)",
+  "drawerShape.penFilletSelected": "Заокруглити {count} кут(и) (мм)",
+  "drawerShape.penFilletMixed": "Різні",
   "drawerShape.penSnapOff": "Вимкнено",
   "drawerShape.penDeletePoint": "Видалити кут",
   "drawerShape.penReset": "Повернути прямокутник",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1716,6 +1716,8 @@
   "drawerShape.penResetView": "重置视图",
   "drawerShape.penCorner": "角点 {n}",
   "drawerShape.penFillet": "圆角 (mm)",
+  "drawerShape.penFilletSelected": "{count} 个角点圆角 (mm)",
+  "drawerShape.penFilletMixed": "不一致",
   "drawerShape.penSnapOff": "关闭",
   "drawerShape.penDeletePoint": "删除角点",
   "drawerShape.penReset": "恢复为矩形",

--- a/src/shared/utils/filletOutline.test.ts
+++ b/src/shared/utils/filletOutline.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { DrawerOutline } from '@/core/types';
-import { filletOutline } from './filletOutline';
-import { validateOutline } from './drawerOutline';
+import { filletOutline, unfilletOutline } from './filletOutline';
+import { quantizeOutline, validateOutline } from './drawerOutline';
 import { arcGeometry, flattenOutline, outlineSignedArea } from './drawerOutlineGeometry';
 
 const U = 42;
@@ -159,5 +159,133 @@ describe('filletOutline', () => {
     };
     // All four corners round, as they would with the bulge absent entirely.
     expect(filletOutline(almost, 20).vertices.filter((v) => (v.bulge ?? 0) !== 0)).toHaveLength(4);
+  });
+
+  describe('per-corner radii', () => {
+    it('rounds only the corners the array gives a radius', () => {
+      const filleted = filletOutline(rect(), [20, 0, 20, 0]);
+      expect(filleted.vertices).toHaveLength(6);
+      expect(filleted.vertices.filter((v) => (v.bulge ?? 0) !== 0)).toHaveLength(2);
+    });
+
+    it('gives each corner its own radius', () => {
+      const filleted = filletOutline(rect(), [10, 30, 0, 0]);
+      const radii = filleted.vertices
+        .map((v, i) =>
+          arcGeometry(v, filleted.vertices[(i + 1) % filleted.vertices.length], v.bulge ?? 0)
+        )
+        .filter((a) => a !== null)
+        .map((a) => a.r);
+      expect(radii).toHaveLength(2);
+      expect(radii[0]).toBeCloseTo(10, 6);
+      expect(radii[1]).toBeCloseTo(30, 6);
+    });
+
+    it('leaves the outline untouched when every radius is zero', () => {
+      const o = rect();
+      expect(filletOutline(o, [0, 0, 0, 0])).toBe(o);
+    });
+
+    it('treats a short array as zero for the corners it does not reach', () => {
+      const filleted = filletOutline(rect(), [20]);
+      expect(filleted.vertices.filter((v) => (v.bulge ?? 0) !== 0)).toHaveLength(1);
+    });
+  });
+});
+
+/** Assert two vertex lists describe the same corners, ignoring where the loop starts. */
+function expectSameCorners(actual: DrawerOutline['vertices'], expected: DrawerOutline['vertices']) {
+  expect(actual).toHaveLength(expected.length);
+  const offset = actual.findIndex(
+    (v) => Math.abs(v.x - expected[0].x) < 1e-6 && Math.abs(v.y - expected[0].y) < 1e-6
+  );
+  expect(offset).toBeGreaterThanOrEqual(0);
+  for (let i = 0; i < expected.length; i++) {
+    const v = actual[(offset + i) % actual.length];
+    expect(v.x).toBeCloseTo(expected[i].x, 6);
+    expect(v.y).toBeCloseTo(expected[i].y, 6);
+  }
+}
+
+describe('unfilletOutline', () => {
+  it('returns an unrounded outline as drawn, with no radii', () => {
+    const o = rect();
+    const { vertices, radii } = unfilletOutline(o);
+    expect(vertices).toEqual(o.vertices);
+    expect(radii).toEqual([0, 0, 0, 0]);
+  });
+
+  it('recovers the corners and the radius a uniform fillet was built from', () => {
+    const original = rect();
+    const { vertices, radii } = unfilletOutline(filletOutline(original, 20));
+    expectSameCorners(vertices, original.vertices);
+    expect(radii.every((r) => Math.abs(r - 20) < 1e-6)).toBe(true);
+  });
+
+  it('recovers per-corner radii, including a concave one', () => {
+    const original = lShape();
+    const asked = [10, 25, 0, 15, 0, 20];
+    const { vertices, radii } = unfilletOutline(filletOutline(original, asked));
+    expectSameCorners(vertices, original.vertices);
+    const offset = vertices.findIndex(
+      (v) => Math.abs(v.x - original.vertices[0].x) < 1e-6 && Math.abs(v.y) < 1e-6
+    );
+    for (let i = 0; i < asked.length; i++) {
+      expect(radii[(offset + i) % radii.length]).toBeCloseTo(asked[i], 6);
+    }
+  });
+
+  // The pen editor seeds from a stored outline, which has been quantized to
+  // 0.01mm — an exact tangency test would find no fillets at all after a save.
+  it('still recognises a fillet after the outline is quantized', () => {
+    const original = rect();
+    const stored = quantizeOutline(filletOutline(original, 17.5));
+    const { vertices, radii } = unfilletOutline(stored);
+    expect(vertices).toHaveLength(4);
+    for (const r of radii) expect(r).toBeCloseTo(17.5, 1);
+  });
+
+  // The setback cap can clip a radius well below the one asked for. Reporting
+  // the request would show a number the shape does not have.
+  it('reports the radius that was applied, not the one requested', () => {
+    const { radii } = unfilletOutline(filletOutline(rect(), 10_000));
+    // 0.49 of the shorter (D = 252mm) edge, which a 90 degree turn sets back 1:1.
+    const capped = D * 0.49;
+    expect(radii).toHaveLength(4);
+    for (const r of radii) expect(r).toBeCloseTo(capped, 6);
+  });
+
+  it('leaves a hand-drawn arc alone rather than reading it as a fillet', () => {
+    // The bowed segment is not tangent to its neighbours, so collapsing it
+    // would move geometry the user drew on purpose.
+    const drawn: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: W, y: 0, bulge: 0.4 },
+        { x: W, y: D },
+        { x: 0, y: D },
+      ],
+    };
+    const { vertices, radii } = unfilletOutline(drawn);
+    expect(vertices).toEqual(drawn.vertices);
+    expect(radii).toEqual([0, 0, 0, 0]);
+  });
+
+  it('round-trips back to the same geometry', () => {
+    const filleted = filletOutline(lShape(), [12, 12, 0, 12, 0, 12]);
+    const { vertices, radii } = unfilletOutline(filleted);
+    const again = filletOutline({ vertices }, radii);
+    expect(again.vertices).toHaveLength(filleted.vertices.length);
+    expectSameCorners(again.vertices, filleted.vertices);
+  });
+
+  it('keeps a fillet that wraps the end of the vertex array', () => {
+    // Rotating the loop puts one fillet's two vertices across index 0, which a
+    // non-cyclic scan would miss.
+    const filleted = filletOutline(rect(), 20);
+    const rotated: DrawerOutline = {
+      vertices: [...filleted.vertices.slice(-1), ...filleted.vertices.slice(0, -1)],
+    };
+    expect(unfilletOutline(rotated).vertices).toHaveLength(4);
   });
 });

--- a/src/shared/utils/filletOutline.ts
+++ b/src/shared/utils/filletOutline.ts
@@ -12,8 +12,8 @@
  */
 
 import type { DrawerOutline, OutlineVertex } from '@/core/types';
-import { BULGE_EPS } from './drawerOutlineGeometry';
-import { OUTLINE_MAX_VERTICES } from './drawerOutline';
+import { arcGeometry, BULGE_EPS, type OutlinePoint } from './drawerOutlineGeometry';
+import { OUTLINE_MAX_VERTICES, OUTLINE_QUANTUM_MM } from './drawerOutline';
 
 /** Below this a corner is treated as straight and left alone. */
 const MIN_TURN_RAD = 1e-4;
@@ -69,7 +69,11 @@ function cornerAt(
 }
 
 /**
- * Round every eligible corner of `outline` to `radiusMm`.
+ * Round the eligible corners of `outline`.
+ *
+ * `radii` is either one radius for every corner or a per-vertex array indexed
+ * by the corner it rounds — a drawer moulding is rarely uniform, so a single
+ * radius cannot express the shape people actually measure (issue #3054).
  *
  * A corner is skipped, staying sharp, when either adjacent segment is already
  * an arc (the tangent construction assumes straight edges), when the corner is
@@ -82,8 +86,13 @@ function cornerAt(
  * is budgeted against `OUTLINE_MAX_VERTICES` so rounding a detailed perimeter
  * cannot push it past the model ceiling and block Apply.
  */
-export function filletOutline(outline: DrawerOutline, radiusMm: number): DrawerOutline {
-  if (radiusMm < MIN_RADIUS_MM) return outline;
+export function filletOutline(
+  outline: DrawerOutline,
+  radii: number | readonly number[]
+): DrawerOutline {
+  const uniform = typeof radii === 'number';
+  if (uniform && radii < MIN_RADIUS_MM) return outline;
+  const radiusAt = (i: number): number => (uniform ? radii : (radii[i] ?? 0));
   const verts = outline.vertices;
   const n = verts.length;
   if (n < 3) return outline;
@@ -107,8 +116,10 @@ export function filletOutline(outline: DrawerOutline, radiusMm: number): DrawerO
     // straight must be filletable here too.
     const straightIn = Math.abs(prev.bulge ?? 0) < BULGE_EPS;
     const straightOut = Math.abs(v.bulge ?? 0) < BULGE_EPS;
+    // A zero radius falls out naturally: cornerAt's setback collapses below
+    // MIN_RADIUS_MM and it returns null, so an unrounded corner needs no branch.
     const corner =
-      straightIn && straightOut && budget > 0 ? cornerAt(prev, v, next, radiusMm) : null;
+      straightIn && straightOut && budget > 0 ? cornerAt(prev, v, next, radiusAt(i)) : null;
 
     if (corner === null) {
       out.push(v);
@@ -138,4 +149,143 @@ export function filletOutline(outline: DrawerOutline, radiusMm: number): DrawerO
   return outline.authoring !== undefined
     ? { vertices: out, authoring: outline.authoring }
     : { vertices: out };
+}
+
+/**
+ * Setback mismatch (mm) still read as tangent. A stored outline has been
+ * quantized to `OUTLINE_QUANTUM_MM`, so an exactly-filleted corner comes back
+ * off by a few hundredths and an exact test would find no fillets at all.
+ */
+const UNFILLET_SETBACK_TOL_MM = 0.05;
+/** Same allowance on the arc's sweep, which the quantization also perturbs. */
+const UNFILLET_BULGE_TOL = 5e-3;
+
+export interface UnfilletedOutline {
+  readonly vertices: OutlineVertex[];
+  /** Radius (mm) recovered per returned vertex; 0 where the corner is sharp. */
+  readonly radii: number[];
+}
+
+/** Intersection of two lines given a point and a unit direction on each. */
+function lineIntersection(
+  p0: OutlinePoint,
+  d0: OutlinePoint,
+  p1: OutlinePoint,
+  d1: OutlinePoint
+): OutlinePoint | null {
+  const cross = d0.x * d1.y - d0.y * d1.x;
+  if (Math.abs(cross) < 1e-9) return null;
+  const t = ((p1.x - p0.x) * d1.y - (p1.y - p0.y) * d1.x) / cross;
+  return { x: p0.x + d0.x * t, y: p0.y + d0.y * t };
+}
+
+/**
+ * The corner and radius a `start`/`end` vertex pair was rounded from, or null
+ * when the arc is drawn geometry rather than a fillet.
+ *
+ * Both adjacent segments must be straight, the recovered corner must lie ahead
+ * of the arc's start and behind its end, and the arc must be tangent to both
+ * edges — which shows up as equal setbacks and a sweep equal to the corner's
+ * turn. A hand-drawn arc failing any of these is left exactly as drawn.
+ */
+function recoverFillet(
+  prev: OutlineVertex,
+  start: OutlineVertex,
+  end: OutlineVertex,
+  next: OutlineVertex
+): { corner: OutlinePoint; radius: number } | null {
+  const bulge = start.bulge ?? 0;
+  if (Math.abs(bulge) < BULGE_EPS) return null;
+  if (Math.abs(prev.bulge ?? 0) >= BULGE_EPS) return null;
+  if (Math.abs(end.bulge ?? 0) >= BULGE_EPS) return null;
+
+  const inLen = Math.hypot(start.x - prev.x, start.y - prev.y);
+  const outLen = Math.hypot(next.x - end.x, next.y - end.y);
+  if (inLen < MIN_RADIUS_MM || outLen < MIN_RADIUS_MM) return null;
+  const din = { x: (start.x - prev.x) / inLen, y: (start.y - prev.y) / inLen };
+  const dout = { x: (next.x - end.x) / outLen, y: (next.y - end.y) / outLen };
+
+  const corner = lineIntersection(start, din, end, dout);
+  if (corner === null) return null;
+
+  const setIn = (corner.x - start.x) * din.x + (corner.y - start.y) * din.y;
+  const setOut = (end.x - corner.x) * dout.x + (end.y - corner.y) * dout.y;
+  if (setIn < MIN_RADIUS_MM || setOut < MIN_RADIUS_MM) return null;
+  const setback = Math.max(setIn, setOut);
+  if (Math.abs(setIn - setOut) > Math.max(UNFILLET_SETBACK_TOL_MM, 0.01 * setback)) return null;
+
+  const turn = Math.atan2(din.x * dout.y - din.y * dout.x, din.x * dout.x + din.y * dout.y);
+  if (Math.abs(Math.tan(turn / 4) - bulge) > Math.max(UNFILLET_BULGE_TOL, 0.02 * Math.abs(bulge))) {
+    return null;
+  }
+
+  const arc = arcGeometry(start, end, bulge);
+  if (arc === null) return null;
+  // Quantized like the coordinates it is derived from, or four corners rounded
+  // to the same radius come back differing in the last float digit and read as
+  // four different radii.
+  return { corner, radius: Math.round(arc.r / OUTLINE_QUANTUM_MM) * OUTLINE_QUANTUM_MM };
+}
+
+/**
+ * Inverse of {@link filletOutline}: collapse every rounded corner back to a
+ * sharp one plus its radius.
+ *
+ * This is what lets the pen editor reopen a saved shape with its radii still
+ * adjustable. Storing the pre-fillet sketch alongside the geometry would do the
+ * same, but the tangent construction is exactly invertible — the corner is
+ * where the two adjacent edges meet — so no second copy of the shape has to be
+ * persisted, versioned or sanitized.
+ *
+ * Where `filletOutline` clipped a radius to the setback cap, this recovers the
+ * radius that was actually applied rather than the one that was asked for.
+ */
+export function unfilletOutline(outline: DrawerOutline): UnfilletedOutline {
+  const verts = outline.vertices;
+  const n = verts.length;
+  const asDrawn = (): UnfilletedOutline => ({
+    vertices: [...verts],
+    radii: new Array<number>(n).fill(0),
+  });
+  // A fillet costs one vertex, so the smallest shape that can carry one is a
+  // rounded triangle.
+  if (n < 4) return asDrawn();
+
+  const corners = new Map<number, { x: number; y: number; radius: number }>();
+  const consumed = new Set<number>();
+  for (let i = 0; i < n; i++) {
+    if (consumed.has(i)) continue;
+    const endIdx = (i + 1) % n;
+    if (consumed.has(endIdx) || corners.has(endIdx)) continue;
+    const found = recoverFillet(
+      verts[(i - 1 + n) % n],
+      verts[i],
+      verts[endIdx],
+      verts[(i + 2) % n]
+    );
+    if (found === null) continue;
+    corners.set(i, { x: found.corner.x, y: found.corner.y, radius: found.radius });
+    consumed.add(endIdx);
+  }
+  if (corners.size === 0) return asDrawn();
+
+  const vertices: OutlineVertex[] = [];
+  const radii: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (consumed.has(i)) continue;
+    const corner = corners.get(i);
+    if (corner === undefined) {
+      vertices.push(verts[i]);
+      radii.push(0);
+      continue;
+    }
+    // No bulge on the recovered corner: filletOutline only rounds a corner
+    // whose outgoing edge is straight, so the consumed `end` never carried one.
+    vertices.push({ x: corner.x, y: corner.y });
+    radii.push(corner.radius);
+  }
+  // Unreachable for filletOutline output (three corners round to six vertices),
+  // but a hand-edited or synced outline is not bound by that.
+  if (vertices.length < 3) return asDrawn();
+  return { vertices, radii };
 }


### PR DESCRIPTION
Rounding a drawn perimeter used to apply one radius to every corner, and once applied it could not be changed. Both are fixed: each corner takes its own radius, and a saved shape reopens with those radii still adjustable.

Closes half of #3054. gismofx asked for a radius per corner and for internal corners to round too — the latter already worked, since `filletOutline` derives the arc from a signed turn.

## What changed

**The radius control follows the selection.** Select corners and the stepper rounds those; select none and it rounds the whole shape, as before. Corners that disagree report `Mixed` rather than a number none of them has. A rounded corner draws as a ring on the canvas, so which corners carry a radius is visible without clicking each one.

**A saved radius is reachable again.** Rounding is baked into the stored vertices as arcs, so the plate, the layout hatching and bin placement all see the same shape rather than the plate rounding while the layout still believes the corner is sharp. The cost was that reopening the editor showed arcs, and `filletOutline` skips arc-adjacent corners — so the stepper silently did nothing on a shape you had already rounded.

Rather than persist the pre-fillet sketch alongside the geometry, `unfilletOutline` inverts the transform. The tangent construction sets each arc back along the two adjacent edges, so intersecting those edges recovers the corner exactly and the radius comes off the arc. Consequences worth naming:

- No new persisted data, so no change to `DrawerOutline`, the zod schema, the wire format or the server sanitizer.
- A hand-drawn arc is not tangent to its neighbours and survives exactly as drawn.
- Where the setback cap clipped a radius, the recovered value is the one that was **applied**, not the one that was asked for.
- Recognition is tolerant of the 0.01mm coordinate quantization a stored outline goes through; an exact test would find no fillets at all after a save.

**Radii are a per-index parallel array**, the hazard CLAUDE.md gotcha 6 describes. Inserting and deleting corners are therefore methods on `usePenSketch` rather than something the dialog assembles: no call site can shift vertex indices without moving the radii with them.

## Verification

Driven through the real app, not only jsdom:

- One corner set to 40mm rounds alone; a second at 12mm rounds independently; selecting both shows `Mixed`.
- Apply, reopen: the rendered path is byte-identical, four corner handles instead of eight, and selecting each corner reads back 40 and 12.
- Both radii appear in the layout grid hatching, which is what the bake-into-geometry choice is for.

Plus `filletOutline` round-trip tests (uniform, per-corner, concave, wrap-around, post-quantization, setback-capped, hand-drawn arc), `usePenSketch` alignment tests across insert/delete/undo/refused-split, and dialog tests for the contextual stepper. Full coverage run green; typecheck, all four i18n checks, and the module-boundary and design-system gates pass.

## Still open on #3054

SVG/DXF perimeter import. DXF group code 42 is already `OutlineVertex.bulge` — same `tan(sweep/4)` convention — so a CAD-drawn arc will import as a real arc rather than a flattened polyline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-corner fillet radii to the drawer shape editor and makes saved rounded corners reopen with their radii still adjustable. This addresses #3054 and improves accuracy for non‑uniform mouldings while keeping plate, hatching, and placement in sync.

- New Features
  - Radius control follows selection: round only selected corners, or all when none are selected; mixed selections show “Mixed”.
  - Saved fillets persist as arcs, and `unfilletOutline` reconstructs sharp corners plus per-corner radii on reopen; tolerant to 0.01mm quantization and leaves hand‑drawn arcs unchanged.
  - Per-corner radii are a parallel array; `usePenSketch` keeps indices aligned across insert/delete/undo and exposes `insertAt` and `setRadii`.
  - Canvas marks rounded corners as rings; `filletOutline(outline, radii)` supports per‑corner arrays.

<sup>Written for commit 471da7c86ca96cb9896e24785fae261a2165195f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

