### PR TITLE
docs(legal): add published designs license and privacy terms

### DIFF
--- a/content/privacy.md
+++ b/content/privacy.md
@@ -7,7 +7,7 @@ schema: Article
 
 # Privacy Policy
 
-**Last updated:** May 2026
+**Last updated:** August 2026
 
 Gridfinity Layout Tool is a free, open-source web application maintained by Andy Aragon. This policy explains what data we collect and how we use it.
 
@@ -17,6 +17,7 @@ Gridfinity Layout Tool is a free, open-source web application maintained by Andy
 - Layouts you create are stored **locally in your browser** unless you choose to share them or sign in
 - When you share a layout, it's stored on our servers with a shareable link
 - **Sign-in is optional.** If you sign in to sync across devices, we collect your name and email from Google or GitHub
+- **Publishing is optional.** If you publish a bin design to the community showcase, the design and the public display name you choose become public under a CC BY 4.0 license
 - We don't sell your data or use it for advertising
 
 ## Data We Collect
@@ -54,7 +55,7 @@ When you use the collaboration feature, your presence data (cursor position and 
 
 ### Sign-in and Multi-Device Sync (Optional)
 
-The app is fully usable without an account. If you choose to sign in — currently behind the **Cloud Sync** opt-in in Labs settings — we use Google or GitHub as the identity provider and collect:
+The app is fully usable without an account. If you choose to sign in (for cloud sync or to publish to the community showcase), we use Google or GitHub as the identity provider and collect:
 
 - A **stable account identifier** issued by the provider (so we can recognize you on return visits without storing a password)
 - Your **email address** (must be verified by the provider)
@@ -69,12 +70,13 @@ We use this information solely to:
 
 - Identify your account so we can return your synced layouts and bin designs to you on any device
 - Display your name in the in-app account UI
+- Associate designs you publish, likes you give, and reports you submit with your account
 
 We do not use your email for marketing and do not share your account information with third parties.
 
 #### Synced layouts and designs
 
-When you're signed in, layouts and bin designs you create are uploaded to our [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) storage under per-account paths that aren't listed publicly. Reads and writes go through our authenticated server endpoints, which check your session cookie before returning data — clients don't access blob URLs directly. Per-account limits currently apply: up to 100 layouts and 100 bin designs, with each layout up to 500 KB, each design up to 100 KB, and 10 MB total per kind.
+When you're signed in, layouts and bin designs you create are uploaded to our [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) storage under per-account paths that aren't listed publicly. Reads and writes go through our authenticated server endpoints, which check your session cookie before returning data. Clients don't access blob URLs directly. Per-account limits currently apply: up to 100 layouts and 100 bin designs, with each layout up to 500 KB, each design up to 100 KB, and 10 MB total per kind.
 
 #### Authentication cookies
 
@@ -91,9 +93,29 @@ You can delete your account at any time from **Settings > Account > Delete accou
 
 1. Signs you out on every device
 2. Deletes every synced layout and bin design from our servers
-3. Deletes your account profile from our servers
+3. Removes your published designs from the community showcase
+4. Removes your likes from published designs
+5. Deletes reports you've submitted
+6. Deletes your account profile from our servers
 
-Local data in your browser is unaffected — your locally-stored layouts remain on your device.
+Local data in your browser is unaffected: your locally-stored layouts remain on your device.
+
+### Published Designs (Optional)
+
+If you sign in and publish a bin design to the community showcase, the following becomes public:
+
+- The design itself (its editable configuration)
+- The name you give it and any description you add
+- Preview images and a 3D preview model
+- The public display name you choose when publishing
+
+Published designs are visible to anyone, can be indexed by search engines, and can be downloaded and remixed by others under the CC BY 4.0 license described in our [Terms of Service](/terms).
+
+You can unpublish a design at any time from the app, which removes it from the showcase. Copies and remixes others already made are not recalled.
+
+#### Reporting a design
+
+Signed-in users can report a published design, whether or not they have published anything themselves. If you report a design, we record the report (its reason and any note you add) with your account so we can review the design and prevent duplicate reports.
 
 ## Data We Don't Collect
 
@@ -101,17 +123,17 @@ Local data in your browser is unaffected — your locally-stored layouts remain 
 - Precise location
 - Contacts, calendar, files, or anything outside the OAuth scopes listed above
 - Cookies for advertising or tracking across sites
-- Personal information (name, email) **unless you sign in for cloud sync**
+- Personal information (name, email) **unless you sign in for cloud sync or publish to the community showcase**
 
 ## Third-Party Services
 
-| Service    | Purpose                                | Privacy Policy                                                                                                                                                         |
-| ---------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PostHog    | Analytics                              | [posthog.com/privacy](https://posthog.com/privacy)                                                                                                                     |
-| Vercel     | Hosting & storage                      | [vercel.com/legal/privacy-policy](https://vercel.com/legal/privacy-policy)                                                                                             |
-| Liveblocks | Real-time collaboration                | [liveblocks.io/privacy](https://liveblocks.io/privacy)                                                                                                                 |
-| Google     | Sign-in for sync (only if you sign in) | [policies.google.com/privacy](https://policies.google.com/privacy)                                                                                                     |
-| GitHub     | Sign-in for sync (only if you sign in) | [docs.github.com/site-policy/privacy-policies/github-general-privacy-statement](https://docs.github.com/site-policy/privacy-policies/github-general-privacy-statement) |
+| Service    | Purpose                                               | Privacy Policy                                                                                                                                                         |
+| ---------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PostHog    | Analytics                                             | [posthog.com/privacy](https://posthog.com/privacy)                                                                                                                     |
+| Vercel     | Hosting & storage                                     | [vercel.com/legal/privacy-policy](https://vercel.com/legal/privacy-policy)                                                                                             |
+| Liveblocks | Real-time collaboration                               | [liveblocks.io/privacy](https://liveblocks.io/privacy)                                                                                                                 |
+| Google     | Sign-in for sync and publishing (only if you sign in) | [policies.google.com/privacy](https://policies.google.com/privacy)                                                                                                     |
+| GitHub     | Sign-in for sync and publishing (only if you sign in) | [docs.github.com/site-policy/privacy-policies/github-general-privacy-statement](https://docs.github.com/site-policy/privacy-policies/github-general-privacy-statement) |
 
 ## Your Rights
 
@@ -120,8 +142,10 @@ You can:
 - **Opt out of analytics** in Settings > Privacy
 - **Use your browser's privacy setting** (Global Privacy Control or Do Not Track) to disable analytics automatically
 - **Delete your shared layouts** using the share modal
+- **Unpublish your published designs** from the community showcase at any time
+- **Export your synced data**, including your published designs, as a downloadable archive while signed in
 - **Sign out** from Settings > Account at any time
-- **Delete your account** (and all synced data) from Settings > Account > Delete account
+- **Delete your account** (including all synced data and your published designs) from Settings > Account > Delete account
 - **Clear all local data** by clearing your browser's site data for this domain
 
 ## Data Retention
@@ -132,6 +156,8 @@ You can:
 - **Account session cookies:** 30 days from sign-in
 - **Account profile (name, email, provider account ID):** 1 year, refreshed on every sign-in. Profiles for accounts that don't sign in for a year are automatically deleted
 - **Synced layouts and designs:** Retained until you delete them, or until you delete your account
+- **Published designs:** Retained in the showcase until you unpublish them, delete your account, or we remove them under our [Terms of Service](/terms)
+- **Design reports:** Retained until you delete your account
 
 ## Children's Privacy
 

--- a/content/terms.md
+++ b/content/terms.md
@@ -7,7 +7,7 @@ schema: Article
 
 # Terms of Service
 
-**Last updated:** May 2026
+**Last updated:** August 2026
 
 By using Gridfinity Layout Tool, you agree to these terms.
 
@@ -15,13 +15,13 @@ By using Gridfinity Layout Tool, you agree to these terms.
 
 Gridfinity Layout Tool is a free, open-source web application for planning storage layouts for 3D-printed Gridfinity drawer organizers. The source code is available under the [AGPL-3.0 license](https://github.com/andymai/gridfinity-layout-tool/blob/main/LICENSE).
 
-The app is fully usable anonymously. Optional sign-in unlocks multi-device sync of your layouts and bin designs.
+The app is fully usable anonymously. Optional sign-in unlocks multi-device sync of your layouts and bin designs, and publishing to the community showcase.
 
 ## Your Layouts
 
-**You own your content.** Layouts you create belong to you. We don't claim ownership of your drawer designs, bin configurations, labels, or notes.
+**You own your content.** Layouts you create belong to you. We don't claim ownership of your drawer designs, bin configurations, labels, or notes. Designs you publish to the community showcase are covered by Published Designs below.
 
-**Local storage.** Your layouts are stored in your browser by default. We don't have access to them unless you share or sign in for sync.
+**Local storage.** Your layouts are stored in your browser by default. We don't have access to them unless you share, publish, or sign in for sync.
 
 **Shared layouts.** When you share a layout, it becomes accessible via a public link. Anyone with the link can view it. You're responsible for not sharing content that:
 
@@ -31,7 +31,23 @@ The app is fully usable anonymously. Optional sign-in unlocks multi-device sync 
 
 We reserve the right to remove shared content that violates these terms.
 
-**Synced layouts and designs.** When you're signed in, your layouts and bin designs are uploaded to per-account storage tied to your account. Sync paths aren't listed publicly, and reads and writes go through our authenticated server endpoints — your session cookie is required to access your synced data. The public sharing flow above is separate and still requires you to explicitly create a share link.
+**Synced layouts and designs.** When you're signed in, your layouts and bin designs are uploaded to per-account storage tied to your account. Sync paths aren't listed publicly, and reads and writes go through our authenticated server endpoints: your session cookie is required to access your synced data. The public sharing flow above is separate and still requires you to explicitly create a share link.
+
+## Published Designs
+
+You can publish a bin design to the public community showcase. Publishing is optional and requires signing in.
+
+**License.** When you publish a design, you grant us and the public a [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) (CC BY 4.0) license to the published design, including its name, description, preview images, and 3D preview model. Anyone may view, download, modify, and republish derivative designs, in this app or elsewhere, as long as they credit you (remixes published in the app include this credit).
+
+**You keep ownership.** Publishing grants the license above. It does not transfer ownership of your design to us or to anyone else.
+
+**Your responsibility.** By publishing, you confirm you have the rights to share everything in the design (including its name, description, and images) under this license.
+
+**Unpublishing.** You can unpublish a design at any time. This removes it from the showcase, but copies and remixes others already made are not recalled, and the CC BY 4.0 license on those copies stays in effect.
+
+**Account deletion.** Deleting your account removes your published designs from the showcase, with the same effect as unpublishing.
+
+**Reports and takedowns.** Signed-in users can report a published design, and we may hide or remove designs that violate these terms. If you believe a published design infringes your intellectual property (including copyright complaints under the DMCA), open an issue on our [GitHub repository](https://github.com/andymai/gridfinity-layout-tool/issues). We review IP complaints and may remove content we determine to be infringing.
 
 ## Accounts
 
@@ -40,7 +56,7 @@ Sign-in is optional. If you choose to sign in via Google or GitHub:
 - You're responsible for keeping your linked Google or GitHub account secure. We rely on the upstream provider for authentication.
 - One person, one account. Don't create accounts under another person's identity.
 - You can sign out from any device at **Settings > Account**.
-- You can permanently delete your account and all synced data at **Settings > Account > Delete account**. This signs you out on every device, removes your account profile, and deletes every synced layout and bin design.
+- You can permanently delete your account and all synced data at **Settings > Account > Delete account**. This signs you out on every device, removes your account profile, deletes every synced layout and bin design, and removes your published designs from the community showcase.
 - We may suspend or terminate accounts that violate these terms or are used to abuse the service.
 
 We may impose per-account limits. Currently: up to 100 layouts and 100 bin designs, with each layout up to 500 KB, each design up to 100 KB, and 10 MB total per kind. Limits exist to keep the service free and may change.
@@ -85,6 +101,9 @@ Don't use this app to:
 - Overload our servers with automated requests
 - Scrape or harvest data from shared layouts
 - Use credentials or accounts that aren't yours
+- Publish designs or content you don't have the rights to
+- Put offensive or abusive content in design names, descriptions, or your public display name
+- Spam the community showcase or artificially manipulate its statistics
 - Violate any applicable laws
 
 ## Changes to Terms


### PR DESCRIPTION
## What

Adds the legal groundwork for community design publishing (#3050): users will be able to publish bin designs to a public community showcase and remix each other's designs, so the terms and privacy policy now define what publishing means before any publishing feature ships.

**Terms of Service**
- New "Published Designs" section: publishing grants a CC BY 4.0 license (view, download, modify, republish derivatives with attribution); the publisher keeps ownership; publisher confirms they have rights to what they publish; unpublishing removes the design from the showcase but does not recall existing copies; account deletion has the same effect; IP complaints and takedowns go through the existing GitHub issues channel.
- "You own your content" now cross-references the license so the two never contradict.
- Acceptable Use extended: no publishing content you lack rights to, no offensive names/descriptions/display names, no spam or stat manipulation.

**Privacy Policy**
- New "Published Designs" block: exactly what becomes public (design, name, description, previews, chosen display name), that it is search-indexable, and how to remove it.
- Sign-in section now covers publishing as a second reason to sign in; account data association covers published designs, likes, and reports.
- Account deletion list, retention table, and Your Rights updated: export and deletion explicitly cover published designs.

## Why now

The remix workflow hands one user's design to another for modification and republication. Without a license grant that would conflict with the existing "You own your content" clause, so this lands ahead of the publishing feature itself.

Built pages are regenerated at deploy by the content build; only the markdown sources change here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds legal terms for the upcoming community showcase: published bin designs are licensed under CC BY 4.0 with attribution, publishers keep ownership, must have rights to publish, can unpublish, and IP reports/takedowns are supported.

Updates the Privacy Policy to clarify what becomes public when publishing, sign-in for publishing, data association (published designs, likes, reports), retention, and user rights to export, unpublish, and delete.

<sup>Written for commit 8dd0e9cb99b7f2bae93f4610ea8581b36efb2780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

