### PR TITLE
fix(baseplate): offer split-into-pieces for STEP export (#3088)

### DIFF
--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -189,7 +189,9 @@ export function BaseplatePage() {
   const stackPlateCount = stackPlan.reduce((sum, s) => sum + s.copies, 0);
 
   // Split-into-pieces banner only when NOT stacking (stacking has its own).
-  const showSplitBanner = !stackEnabled && tiling?.isSplit === true && activeFormat !== 'step';
+  // Format-agnostic: buildBaseplateExportPieces splits STEP the same as STL/3MF
+  // (one solid per unique tile), so STEP gets the option too (#3088).
+  const showSplitBanner = !stackEnabled && tiling?.isSplit === true;
   // When stacking, a split drawer always takes the per-tower export path; the
   // user can't opt out, so there's no split checkbox to gate it.
   const useSplitExport = stackEnabled ? tiling?.isSplit === true : showSplitBanner && splitEnabled;

--- a/src/features/baseplate/utils/buildBaseplateExportPieces.test.ts
+++ b/src/features/baseplate/utils/buildBaseplateExportPieces.test.ts
@@ -112,6 +112,32 @@ describe('buildBaseplateExportPieces', () => {
     expect(result.guideText).toContain('Gridfinity Baseplate Print Guide');
   });
 
+  it('splits a large STEP plate into labelled pieces, same as STL/3MF (#3088)', async () => {
+    const { bridge, exportBaseplate } = makeBridge();
+    // 8×8u (336mm) plate on a 256mm bed forces a 2×2 split.
+    const result = await buildBaseplateExportPieces(
+      bridge,
+      null,
+      input({
+        format: 'step',
+        fileNameConfig: { style: 'descriptive', customName: '', format: 'step' },
+        drawerWidth: 8,
+        drawerDepth: 8,
+        printBedWidthMm: 256,
+        printBedDepthMm: 256,
+      })
+    );
+
+    expect(result.extension).toBe('.step');
+    expect(result.splitStats).toBeDefined();
+    expect(result.pieces.length).toBe(result.splitStats?.totalPieces);
+    expect(result.pieces.length).toBeGreaterThan(1);
+    expect(result.pieces.every((p) => p.label.length > 0)).toBe(true);
+    // Each unique tile is exported as a native STEP solid — never rerouted to STL.
+    expect(exportBaseplate).toHaveBeenCalledWith(expect.anything(), 'step');
+    expect(exportBaseplate).not.toHaveBeenCalledWith(expect.anything(), 'stl');
+  });
+
   it('ships rail pieces and a combined guide alongside a stacked tower (#2641)', async () => {
     const { bridge, exportMargin } = makeBridge();
     const result = await buildBaseplateExportPieces(


### PR DESCRIPTION
## Summary

Fixes #3088. Oversized STEP baseplates now offer the same **Split into pieces** option that STL and 3MF already have.

## Root cause

The export builder (`buildBaseplateExportPieces`) has always been **format-agnostic** about splitting — its split path exports one solid per unique tile and packages them as a ZIP, and it's already exercised for STEP by the whole-layout ZIP export. Only the standalone baseplate page gated the option behind `activeFormat !== 'step'`, so an oversized STEP plate fell through to the single-solid branch and the user got one file that doesn't fit the bed.

## Change

- `BaseplatePage.tsx`: drop the `activeFormat !== 'step'` clause from `showSplitBanner`. STEP now surfaces the split banner + checkbox; when checked, `useSplitExport` flows `splitEnabled: true` into the already-working builder split path (native per-tile STEP solids, never rerouted to STL). STEP still never stacks, so the `!stackEnabled` guard is unaffected.
- Added a builder-level regression test asserting a large STEP plate splits into labelled pieces and each tile is exported as a native `.step` solid.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test:run src/features/baseplate/utils/buildBaseplateExportPieces.test.ts` (7 passed)
- [ ] Manual: generate a baseplate larger than the bed, pick STEP, confirm the "Split into pieces" checkbox appears and export produces a ZIP of per-tile `.step` files