### PR TITLE
fix(baseplate): collapse split pieces on the Y pitch for non-square grids (#3089)

### DIFF
--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.tsx
@@ -236,6 +236,7 @@ export function BaseplatePage() {
       width={effectiveWidth}
       depth={effectiveDepth}
       gridUnitMm={gridUnitMm}
+      gridUnitMmY={gridUnitMmY}
       paddingLeft={paddingLeft}
       paddingRight={paddingRight}
       paddingFront={paddingFront}

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -70,6 +70,7 @@ interface BaseplatePreviewProps {
   width: number;
   depth: number;
   gridUnitMm: number;
+  gridUnitMmY: number;
   paddingLeft: number;
   paddingRight: number;
   paddingFront: number;
@@ -80,6 +81,7 @@ export function BaseplatePreview({
   width,
   depth,
   gridUnitMm,
+  gridUnitMmY,
   paddingLeft,
   paddingRight,
   paddingFront,
@@ -352,6 +354,7 @@ export function BaseplatePreview({
                       totalWidthUnits={width}
                       totalDepthUnits={depth}
                       gridUnitMm={gridUnitMm}
+                      gridUnitMmY={gridUnitMmY}
                       isPreview={hasDirectPreview}
                       xray={xray}
                     />

--- a/src/features/baseplate/components/BaseplatePreview/SplitBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/SplitBaseplateMeshes.tsx
@@ -14,7 +14,6 @@ import * as THREE from 'three';
 import { useShallow } from 'zustand/react/shallow';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { useBaseplatePageStore } from '../../store/baseplatePageStore';
-import { EXPLODE_GAP_MM } from '../../constants';
 import {
   MESH_MATERIAL_PROPS,
   EDGE_MATERIAL_PROPS,
@@ -22,6 +21,7 @@ import {
   desaturateColor,
 } from './materialProps';
 import { useMeshGeometry } from './useMeshGeometry';
+import { computePiecePlacement } from './pieceLayout';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';
 import { useSettingsStore } from '@/core/store';
 import { getAccentHex } from '@/shared/utils/color';
@@ -35,8 +35,7 @@ interface PieceMeshProps {
   readonly totalWidthMm: number;
   readonly totalDepthMm: number;
   readonly gridUnitMm: number;
-  readonly explodeX: number;
-  readonly explodeY: number;
+  readonly gridUnitMmY: number;
   readonly splitViewMode: SplitViewMode;
   readonly hoveredPieceLabel: string | null;
   readonly selectedPieceLabel: string | null;
@@ -50,8 +49,7 @@ function PieceMesh({
   totalWidthMm,
   totalDepthMm,
   gridUnitMm,
-  explodeX,
-  explodeY,
+  gridUnitMmY,
   splitViewMode,
   hoveredPieceLabel,
   selectedPieceLabel,
@@ -114,10 +112,19 @@ function PieceMesh({
     setSelectedPieceLabel(selectedPieceLabel === entry.label ? null : entry.label);
   }, [entry.label, selectedPieceLabel, setSelectedPieceLabel]);
 
+  // Single source of truth for placement + footprint. Depth uses the Y pitch so
+  // pieces collapse without a residual per-row gap on non-square grids (#3089).
+  const placement = computePiecePlacement(entry, {
+    totalWidthMm,
+    totalDepthMm,
+    gridUnitMm,
+    gridUnitMmY,
+    splitViewMode,
+  });
+
   // Invisible hit-test plane covering the full piece footprint.
   // Catches pointer events over socket holes and empty areas within the piece.
-  const pieceWidthMm = entry.widthUnits * gridUnitMm;
-  const pieceDepthMm = entry.depthUnits * gridUnitMm;
+  const { widthMm: pieceWidthMm, depthMm: pieceDepthMm } = placement;
 
   const hitPlaneGeometry = useMemo(
     () => new THREE.PlaneGeometry(pieceWidthMm, pieceDepthMm),
@@ -132,12 +139,7 @@ function PieceMesh({
 
   if (!geometry) return null;
 
-  // Position: piece's grid center relative to the total baseplate center
-  const pieceCenterX = entry.offsetX * gridUnitMm + pieceWidthMm / 2 - totalWidthMm / 2;
-  const pieceCenterY = entry.offsetY * gridUnitMm + pieceDepthMm / 2 - totalDepthMm / 2;
-
-  const x = pieceCenterX + explodeX;
-  const y = pieceCenterY + explodeY;
+  const { x, y } = placement;
 
   // 180°-rotated placement keeps a single canonical mesh shared between
   // opposite-corner pieces (preferIdenticalPieces). Rotation is around the
@@ -199,6 +201,7 @@ interface SplitBaseplateMeshesProps {
   readonly totalWidthUnits: number;
   readonly totalDepthUnits: number;
   readonly gridUnitMm: number;
+  readonly gridUnitMmY: number;
   readonly isPreview?: boolean;
   readonly xray?: boolean;
 }
@@ -210,6 +213,7 @@ export function SplitBaseplateMeshes({
   totalWidthUnits,
   totalDepthUnits,
   gridUnitMm,
+  gridUnitMmY,
   isPreview = false,
   xray = false,
 }: SplitBaseplateMeshesProps) {
@@ -224,31 +228,25 @@ export function SplitBaseplateMeshes({
     );
 
   const totalWidthMm = totalWidthUnits * gridUnitMm;
-  const totalDepthMm = totalDepthUnits * gridUnitMm;
+  const totalDepthMm = totalDepthUnits * gridUnitMmY;
 
   return (
     <>
-      {pieceMeshes.map((entry) => {
-        const explodeX = splitViewMode === 'exploded' ? entry.col * EXPLODE_GAP_MM : 0;
-        const explodeY = splitViewMode === 'exploded' ? entry.row * EXPLODE_GAP_MM : 0;
-
-        return (
-          <PieceMesh
-            key={entry.label}
-            entry={entry}
-            totalWidthMm={totalWidthMm}
-            totalDepthMm={totalDepthMm}
-            gridUnitMm={gridUnitMm}
-            explodeX={explodeX}
-            explodeY={explodeY}
-            splitViewMode={splitViewMode}
-            hoveredPieceLabel={hoveredPieceLabel}
-            selectedPieceLabel={selectedPieceLabel}
-            isPreview={isPreview}
-            xray={xray}
-          />
-        );
-      })}
+      {pieceMeshes.map((entry) => (
+        <PieceMesh
+          key={entry.label}
+          entry={entry}
+          totalWidthMm={totalWidthMm}
+          totalDepthMm={totalDepthMm}
+          gridUnitMm={gridUnitMm}
+          gridUnitMmY={gridUnitMmY}
+          splitViewMode={splitViewMode}
+          hoveredPieceLabel={hoveredPieceLabel}
+          selectedPieceLabel={selectedPieceLabel}
+          isPreview={isPreview}
+          xray={xray}
+        />
+      ))}
     </>
   );
 }

--- a/src/features/baseplate/components/BaseplatePreview/pieceLayout.test.ts
+++ b/src/features/baseplate/components/BaseplatePreview/pieceLayout.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computePiecePlacement, type PiecePlacement } from './pieceLayout';
+import { EXPLODE_GAP_MM } from '../../constants';
 import type { PieceMeshEntry } from '../../store/baseplatePageStore';
 
 type PieceFixture = Pick<
@@ -166,14 +167,14 @@ describe('computePiecePlacement', () => {
     const assembled = placeAll(pieces, GU, GUY, 'assembled');
     const exploded = placeAll(pieces, GU, GUY, 'exploded');
 
-    it('offsets each piece by exactly col*10 and row*10 relative to assembled', () => {
+    it('offsets each piece by exactly col and row × EXPLODE_GAP_MM relative to assembled', () => {
       for (const piece of pieces) {
         const key = `${piece.col},${piece.row}`;
         const asm = assembled.get(key);
         const exp = exploded.get(key);
         if (!asm || !exp) throw new Error('missing piece');
-        expect(exp.x - asm.x).toBeCloseTo(piece.col * 10, 10);
-        expect(exp.y - asm.y).toBeCloseTo(piece.row * 10, 10);
+        expect(exp.x - asm.x).toBeCloseTo(piece.col * EXPLODE_GAP_MM, 10);
+        expect(exp.y - asm.y).toBeCloseTo(piece.row * EXPLODE_GAP_MM, 10);
       }
     });
 

--- a/src/features/baseplate/components/BaseplatePreview/pieceLayout.test.ts
+++ b/src/features/baseplate/components/BaseplatePreview/pieceLayout.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { computePiecePlacement, type PiecePlacement } from './pieceLayout';
+import type { PieceMeshEntry } from '../../store/baseplatePageStore';
+
+type PieceFixture = Pick<
+  PieceMeshEntry,
+  'offsetX' | 'offsetY' | 'widthUnits' | 'depthUnits' | 'col' | 'row'
+>;
+
+/**
+ * 2-column × 3-row tiling with per-column/row unit sizes:
+ *   columns: [3u, 4u]  → totalWidthUnits 7
+ *   rows:    [2u, 3u, 2u] → totalDepthUnits 7
+ * offsetX/offsetY are the cumulative unit offsets from the left/front edge.
+ */
+const COLUMN_WIDTHS = [3, 4] as const;
+const ROW_DEPTHS = [2, 3, 2] as const;
+const TOTAL_WIDTH_UNITS = 7;
+const TOTAL_DEPTH_UNITS = 7;
+
+function buildTiling(): PieceFixture[] {
+  const pieces: PieceFixture[] = [];
+  let offsetY = 0;
+  for (let row = 0; row < ROW_DEPTHS.length; row++) {
+    let offsetX = 0;
+    for (let col = 0; col < COLUMN_WIDTHS.length; col++) {
+      pieces.push({
+        offsetX,
+        offsetY,
+        widthUnits: COLUMN_WIDTHS[col],
+        depthUnits: ROW_DEPTHS[row],
+        col,
+        row,
+      });
+      offsetX += COLUMN_WIDTHS[col];
+    }
+    offsetY += ROW_DEPTHS[row];
+  }
+  return pieces;
+}
+
+const leftEdge = (p: PiecePlacement): number => p.x - p.widthMm / 2;
+const rightEdge = (p: PiecePlacement): number => p.x + p.widthMm / 2;
+const bottomEdge = (p: PiecePlacement): number => p.y - p.depthMm / 2;
+const topEdge = (p: PiecePlacement): number => p.y + p.depthMm / 2;
+
+function placeAll(
+  pieces: PieceFixture[],
+  gridUnitMm: number,
+  gridUnitMmY: number,
+  splitViewMode: 'assembled' | 'exploded'
+): Map<string, PiecePlacement> {
+  const totalWidthMm = TOTAL_WIDTH_UNITS * gridUnitMm;
+  const totalDepthMm = TOTAL_DEPTH_UNITS * gridUnitMmY;
+  const placed = new Map<string, PiecePlacement>();
+  for (const piece of pieces) {
+    placed.set(
+      `${piece.col},${piece.row}`,
+      computePiecePlacement(piece, {
+        totalWidthMm,
+        totalDepthMm,
+        gridUnitMm,
+        gridUnitMmY,
+        splitViewMode,
+      })
+    );
+  }
+  return placed;
+}
+
+describe('computePiecePlacement', () => {
+  describe('square grid (assembled)', () => {
+    const GU = 42;
+    const pieces = buildTiling();
+    const placed = placeAll(pieces, GU, GU, 'assembled');
+
+    it('tiles horizontally with no gap: each piece right edge meets its neighbor left edge', () => {
+      for (let row = 0; row < ROW_DEPTHS.length; row++) {
+        const left = placed.get(`0,${row}`);
+        const right = placed.get(`1,${row}`);
+        if (!left || !right) throw new Error('missing piece');
+        expect(rightEdge(left)).toBeCloseTo(leftEdge(right), 10);
+      }
+    });
+
+    it('tiles vertically with no gap: each piece top edge meets the piece above bottom edge', () => {
+      for (let col = 0; col < COLUMN_WIDTHS.length; col++) {
+        for (let row = 0; row < ROW_DEPTHS.length - 1; row++) {
+          const lower = placed.get(`${col},${row}`);
+          const upper = placed.get(`${col},${row + 1}`);
+          if (!lower || !upper) throw new Error('missing piece');
+          expect(topEdge(lower)).toBeCloseTo(bottomEdge(upper), 10);
+        }
+      }
+    });
+
+    it('spans the full plate with no accumulated slack', () => {
+      const totalWidthMm = TOTAL_WIDTH_UNITS * GU;
+      const totalDepthMm = TOTAL_DEPTH_UNITS * GU;
+      const bottomLeft = placed.get('0,0');
+      const topRight = placed.get('1,2');
+      if (!bottomLeft || !topRight) throw new Error('missing piece');
+      expect(leftEdge(bottomLeft)).toBeCloseTo(-totalWidthMm / 2, 10);
+      expect(bottomEdge(bottomLeft)).toBeCloseTo(-totalDepthMm / 2, 10);
+      expect(rightEdge(topRight)).toBeCloseTo(totalWidthMm / 2, 10);
+      expect(topEdge(topRight)).toBeCloseTo(totalDepthMm / 2, 10);
+    });
+  });
+
+  describe('non-square grid (assembled) — #3089 regression', () => {
+    const GU = 42;
+    const GUY = 50;
+    const pieces = buildTiling();
+    const placed = placeAll(pieces, GU, GUY, 'assembled');
+
+    it('vertical seams meet exactly (depth sized on the Y pitch)', () => {
+      for (let col = 0; col < COLUMN_WIDTHS.length; col++) {
+        for (let row = 0; row < ROW_DEPTHS.length - 1; row++) {
+          const lower = placed.get(`${col},${row}`);
+          const upper = placed.get(`${col},${row + 1}`);
+          if (!lower || !upper) throw new Error('missing piece');
+          expect(topEdge(lower)).toBeCloseTo(bottomEdge(upper), 10);
+        }
+      }
+    });
+
+    it('horizontal seams still meet exactly on the X pitch', () => {
+      for (let row = 0; row < ROW_DEPTHS.length; row++) {
+        const left = placed.get(`0,${row}`);
+        const right = placed.get(`1,${row}`);
+        if (!left || !right) throw new Error('missing piece');
+        expect(rightEdge(left)).toBeCloseTo(leftEdge(right), 10);
+      }
+    });
+
+    it('spans the full non-square plate with no accumulated vertical gap', () => {
+      const totalDepthMm = TOTAL_DEPTH_UNITS * GUY;
+      const bottom = placed.get('0,0');
+      const top = placed.get('0,2');
+      if (!bottom || !top) throw new Error('missing piece');
+      expect(bottomEdge(bottom)).toBeCloseTo(-totalDepthMm / 2, 10);
+      expect(topEdge(top)).toBeCloseTo(totalDepthMm / 2, 10);
+    });
+
+    it('the old X-pitch slot math leaves the seams unaligned (guards the fix)', () => {
+      // Reproduce the pre-fix positioning: the Y slot sized with the X pitch,
+      // while the mesh footprint was always the true Y-pitch depth.
+      const buggyTotalDepthMm = TOTAL_DEPTH_UNITS * GU;
+      const buggyCenterY = (p: PieceFixture): number =>
+        p.offsetY * GU + (p.depthUnits * GU) / 2 - buggyTotalDepthMm / 2;
+      const meshHalfDepth = (p: PieceFixture): number => (p.depthUnits * GUY) / 2;
+
+      const lower = pieces.find((p) => p.col === 0 && p.row === 0);
+      const upper = pieces.find((p) => p.col === 0 && p.row === 1);
+      if (!lower || !upper) throw new Error('missing piece');
+      const lowerTop = buggyCenterY(lower) + meshHalfDepth(lower);
+      const upperBottom = buggyCenterY(upper) - meshHalfDepth(upper);
+      expect(Math.abs(upperBottom - lowerTop)).toBeGreaterThan(0.5);
+    });
+  });
+
+  describe('exploded mode', () => {
+    const GU = 42;
+    const GUY = 50;
+    const pieces = buildTiling();
+    const assembled = placeAll(pieces, GU, GUY, 'assembled');
+    const exploded = placeAll(pieces, GU, GUY, 'exploded');
+
+    it('offsets each piece by exactly col*10 and row*10 relative to assembled', () => {
+      for (const piece of pieces) {
+        const key = `${piece.col},${piece.row}`;
+        const asm = assembled.get(key);
+        const exp = exploded.get(key);
+        if (!asm || !exp) throw new Error('missing piece');
+        expect(exp.x - asm.x).toBeCloseTo(piece.col * 10, 10);
+        expect(exp.y - asm.y).toBeCloseTo(piece.row * 10, 10);
+      }
+    });
+
+    it('leaves piece footprint dimensions unchanged by explode', () => {
+      for (const piece of pieces) {
+        const key = `${piece.col},${piece.row}`;
+        const asm = assembled.get(key);
+        const exp = exploded.get(key);
+        if (!asm || !exp) throw new Error('missing piece');
+        expect(exp.widthMm).toBeCloseTo(asm.widthMm, 10);
+        expect(exp.depthMm).toBeCloseTo(asm.depthMm, 10);
+      }
+    });
+  });
+});

--- a/src/features/baseplate/components/BaseplatePreview/pieceLayout.ts
+++ b/src/features/baseplate/components/BaseplatePreview/pieceLayout.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure placement math for split-baseplate pieces.
+ *
+ * The piece meshes are generated grid-centered with a Y-extent of
+ * `depthUnits * gridUnitMmY` (see baseplateDirectMesh `totalD`), so the depth
+ * (Y) slot MUST be sized with the Y pitch. Sizing it with the X pitch leaves a
+ * residual per-row gap on non-square grids that accumulates across rows (#3089).
+ */
+
+import { EXPLODE_GAP_MM } from '../../constants';
+import type { PieceMeshEntry, SplitViewMode } from '../../store/baseplatePageStore';
+
+export interface PiecePlacement {
+  readonly x: number;
+  readonly y: number;
+  readonly widthMm: number;
+  readonly depthMm: number;
+}
+
+export interface PiecePlacementOptions {
+  readonly totalWidthMm: number;
+  readonly totalDepthMm: number;
+  readonly gridUnitMm: number;
+  readonly gridUnitMmY: number;
+  readonly splitViewMode: SplitViewMode;
+}
+
+export function computePiecePlacement(
+  entry: Pick<
+    PieceMeshEntry,
+    'offsetX' | 'offsetY' | 'widthUnits' | 'depthUnits' | 'col' | 'row'
+  >,
+  opts: PiecePlacementOptions
+): PiecePlacement {
+  const { totalWidthMm, totalDepthMm, gridUnitMm, gridUnitMmY, splitViewMode } = opts;
+
+  const widthMm = entry.widthUnits * gridUnitMm;
+  const depthMm = entry.depthUnits * gridUnitMmY;
+
+  const explodeX = splitViewMode === 'exploded' ? entry.col * EXPLODE_GAP_MM : 0;
+  const explodeY = splitViewMode === 'exploded' ? entry.row * EXPLODE_GAP_MM : 0;
+
+  const x = entry.offsetX * gridUnitMm + widthMm / 2 - totalWidthMm / 2 + explodeX;
+  const y = entry.offsetY * gridUnitMmY + depthMm / 2 - totalDepthMm / 2 + explodeY;
+
+  return { x, y, widthMm, depthMm };
+}


### PR DESCRIPTION
## Summary

Fixes #3089. On a **non-square grid** (`gridUnitMmY !== gridUnitMm`), the "Assembled" view of a split baseplate didn't fully collapse — a residual **vertical** gap grew with each row, while columns collapsed correctly.

## Root cause

`SplitBaseplateMeshes` sized the vertical (depth) slot with the **X pitch** `gridUnitMm`, but each piece mesh is generated grid-centered with Y-extent `depthUnits * gridUnitMmY` (`baseplateDirectMesh.ts`). On a square grid the two pitches coincide so seams meet exactly; on a non-square grid the per-row error `(Σ depthUnits)/2 · (gridUnitMm − gridUnitMmY)` accumulates — hence the vertical-only, grows-with-rows symptom. The sibling `StackedBaseplateMeshes` already threads `gridUnitMmY` correctly; the split path was the outlier.

## Change

- Extracted the placement math into a pure `computePiecePlacement()` helper (`pieceLayout.ts`) — single source of truth — using `gridUnitMmY` for the depth axis (slot size, center, and hover hit-plane). X-axis math and the explode gaps are unchanged.
- Threaded `gridUnitMmY` as a prop `BaseplatePage → BaseplatePreview → SplitBaseplateMeshes` (it was already in `BaseplatePage` scope via `effectiveGridUnitMmY`), mirroring how `gridUnitMm` already flows.
- Added `pieceLayout.test.ts`: square-grid seams meet, **non-square #3089 regression** (Y seams meet on the Y pitch; a witness asserts the old X-pitch math misaligns by >0.5mm), and exploded-mode offsets.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pieceLayout.test.ts` (9 passed)
- [x] `BaseplatePreview` dir (71 passed) + `BaseplatePage` dir (9 passed)
- [ ] Manual: non-square grid (e.g. 42×50), plate >2 rows, toggle Assembled — pieces collapse flush

## Known follow-up (out of scope)

The preview *overlays* (GhostPaddingOutline, DimensionLabels, FootprintGrid, BinAxisLabels, camera framing) also size depth on `gridUnitMm` and will read slightly off on non-square grids — a separate cosmetic PR; this one fixes the reported piece-collapse bug.