### PR TITLE
fix(drawer-shape): show pen-editor corner radius to 2 decimals (#3090)

### DIFF
--- a/src/features/drawer-shape/components/PenShapeDialog/PenControls.test.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenControls.test.tsx
@@ -48,6 +48,13 @@ describe('PenControls', () => {
     expect(screen.getByLabelText('drawerShape.penFilletSelected')).toHaveValue(0);
   });
 
+  // Outline coords carry 0.01mm precision; the radius field must not re-round a
+  // typed decimal down to 1dp on display (#3090). At 1dp this reads 2.6.
+  it('displays a radius to two decimals so typed decimals survive', () => {
+    renderControls({ filletValue: 2.55 });
+    expect(screen.getByLabelText('drawerShape.penFillet')).toHaveValue(2.55);
+  });
+
   it('shows the coordinate fields only for a single selected corner', () => {
     const { unmount } = renderControls();
     expect(screen.queryByText(/^drawerShape\.penCorner/)).not.toBeInTheDocument();

--- a/src/features/drawer-shape/components/PenShapeDialog/PenControls.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenControls.tsx
@@ -113,6 +113,10 @@ export function PenControls({
           min={0}
           max={maxFillet}
           step={1}
+          // Outline coords are quantized to 0.01mm; without this the field's
+          // default 1dp formatter re-rounds a typed radius (e.g. 2.55 → 2.6),
+          // so decimals silently vanish on the display (#3090).
+          inputDecimals={2}
           size="sm"
           aria-label={filletLabel}
         />


### PR DESCRIPTION
## Summary

Addresses #3090 (enhancement). Lets the drawer-shape **pen editor** show decimal corner-radius values instead of truncating them to 1 dp on display.

## What was already working

Against current `main` (the pen editor landed recently in #3065/#3082/#3085), the per-corner **X / Y (mm)** inputs already accept and display decimals: `CompactNumberInput` uses `type="text" inputMode="decimal"`, commits via `parseFloat` with **clamp-only** (no snap-to-step), displays 2 dp, and the Snap toggle is applied only to drag/nudge — never to typed entry. Outline coords are quantized to 0.01 mm on commit. So typing `295.5` into X/Y already works; no change needed there. (The reporter was likely on an older deploy that predated these components.)

## The one real gap

The **"Round N corner(s) (mm)"** radius `Stepper` had no `inputDecimals`, so its default 1 dp formatter re-rounded a typed radius on display (`2.55 → 2.6`) — making decimals look unsupported even though the value committed full-precision. Set `inputDecimals={2}` so decimal radii survive on screen, matching the X/Y fields and the 0.01 mm data quantum.

## Test plan

- [x] `pnpm run typecheck`
- [x] `PenControls.test.tsx` (7 passed) — added a case asserting a `2.55` radius renders as `2.55` (would read `2.6` at 1 dp)
- [ ] Manual: select a corner, type a decimal radius, confirm it stays on screen

Note: this is an `enhancement`, not a `bug` — surfaced alongside the two split-baseplate bug fixes because it's from the same reporter/area.