### PR TITLE
feat(community): backend foundation for publishing bin designs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,4 +71,4 @@ See `src/core/cqrs/README.md` for architecture details, adding new commands/even
 
 **Sign-in (required):** `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` — see `api/auth/README.md`. Vercel derives the OAuth redirect base automatically, but local dev must set `OAUTH_REDIRECT_BASE_URL` to the Vite origin: `getBaseUrl()` falls back to `https://localhost:3000`, so sign-in otherwise fails with a redirect URI mismatch.
 
-**Optional:** `VITE_LIVEBLOCKS_PUBLIC_KEY`, `LIVEBLOCKS_SECRET_KEY`, `VITE_PUBLIC_POSTHOG_KEY`, `KOFI_VERIFICATION_TOKEN` (Ko-fi webhook; `/api/kofi-webhook` 503s without it)
+**Optional:** `VITE_LIVEBLOCKS_PUBLIC_KEY`, `LIVEBLOCKS_SECRET_KEY`, `VITE_PUBLIC_POSTHOG_KEY`, `KOFI_VERIFICATION_TOKEN` (Ko-fi webhook; `/api/kofi-webhook` 503s without it), `COMMUNITY_PUBLISH_ENABLED` (server kill switch for community publishing; unset or anything but `true` makes the publish/update endpoints return 503), `COMMUNITY_ADMIN_TOKEN` (enables admin DELETE on community designs; unset disables it)

--- a/api/README.md
+++ b/api/README.md
@@ -38,26 +38,31 @@ graph TB
 
 ## Endpoints
 
-| Endpoint                        | Method         | Rate Limit | Purpose                                |
-| ------------------------------- | -------------- | ---------- | -------------------------------------- |
-| `/api/share`                    | POST           | 100/min    | Create layout or designer share        |
-| `/api/share/[id]`               | GET            | 100/min    | Fetch share with metadata              |
-| `/api/share/[id]`               | PUT            | 100/min    | Update share (requires delete token)   |
-| `/api/share/[id]`               | DELETE         | 100/min    | Delete share (requires delete token)   |
-| `/api/report/[id]`              | POST           | 10/hr      | Report inappropriate share             |
-| `/api/liveblocks-auth`          | POST           | 100/min    | Collaborative editing session auth     |
-| `/api/ml-telemetry`             | POST           | 100/min    | Aggregated ML training data            |
-| `/api/auth/login/[provider]`    | GET            | 30/min     | Begin OAuth flow (Google / GitHub)     |
-| `/api/auth/callback/[provider]` | GET            | 30/min     | OAuth code exchange + session mint     |
-| `/api/auth/logout`              | POST           | 100/min    | Clear session cookie + KV row          |
-| `/api/auth/me`                  | GET            | 100/min    | Return signed-in user profile          |
-| `/api/sync/layouts/[id]`        | GET/PUT/DELETE | 60–240/min | Per-user layout sync (LWW + tombstone) |
-| `/api/sync/designs/[id]`        | GET/PUT/DELETE | 60–240/min | Per-user Bin Designer design sync      |
-| `/api/sync/manifest`            | GET            | 240/min    | Per-user index + If-Modified-Since 304 |
-| `/api/sync/export`              | GET            | 240/min    | ZIP of all live items + manifest       |
-| `/api/sync/account`             | DELETE         | 60/min     | Cascade-delete account + KV + blobs    |
-| `/api/kofi-webhook`             | POST           | 60/min     | Ko-fi payment ingest → supporters      |
-| `/api/supporters`               | GET            | 120/min    | Public supporter list for /supporters  |
+| Endpoint                        | Method         | Rate Limit | Purpose                                                          |
+| ------------------------------- | -------------- | ---------- | ---------------------------------------------------------------- |
+| `/api/share`                    | POST           | 100/min    | Create layout or designer share                                  |
+| `/api/share/[id]`               | GET            | 100/min    | Fetch share with metadata                                        |
+| `/api/share/[id]`               | PUT            | 100/min    | Update share (requires delete token)                             |
+| `/api/share/[id]`               | DELETE         | 100/min    | Delete share (requires delete token)                             |
+| `/api/report/[id]`              | POST           | 10/hr      | Report inappropriate share                                       |
+| `/api/liveblocks-auth`          | POST           | 100/min    | Collaborative editing session auth                               |
+| `/api/ml-telemetry`             | POST           | 100/min    | Aggregated ML training data                                      |
+| `/api/auth/login/[provider]`    | GET            | 30/min     | Begin OAuth flow (Google / GitHub)                               |
+| `/api/auth/callback/[provider]` | GET            | 30/min     | OAuth code exchange + session mint                               |
+| `/api/auth/logout`              | POST           | 100/min    | Clear session cookie + KV row                                    |
+| `/api/auth/me`                  | GET            | 100/min    | Return signed-in user profile                                    |
+| `/api/sync/layouts/[id]`        | GET/PUT/DELETE | 60–240/min | Per-user layout sync (LWW + tombstone)                           |
+| `/api/sync/designs/[id]`        | GET/PUT/DELETE | 60–240/min | Per-user Bin Designer design sync                                |
+| `/api/sync/manifest`            | GET            | 240/min    | Per-user index + If-Modified-Since 304                           |
+| `/api/sync/export`              | GET            | 240/min    | ZIP of all live items + manifest                                 |
+| `/api/sync/account`             | DELETE         | 60/min     | Cascade-delete account + KV + blobs                              |
+| `/api/kofi-webhook`             | POST           | 60/min     | Ko-fi payment ingest → supporters                                |
+| `/api/supporters`               | GET            | 120/min    | Public supporter list for /supporters                            |
+| `/api/community`                | POST           | 10/day     | Publish a design to the community showcase                       |
+| `/api/community`                | GET            | 240/min    | Browse/paginate the community showcase index                     |
+| `/api/community/[id]`           | GET            | 240/min    | Fetch a single community design's detail                         |
+| `/api/community/[id]`           | PUT            | 60/day     | Update a published design (owner only)                           |
+| `/api/community/[id]`           | DELETE         | 60/day     | Unpublish a design (owner, or admin via `COMMUNITY_ADMIN_TOKEN`) |
 
 See [`auth/README.md`](./auth/README.md) for the OAuth setup and [`sync/README.md`](./sync/README.md) for sync semantics, quotas, and the LWW + tombstone state machine.
 

--- a/api/community.test.ts
+++ b/api/community.test.ts
@@ -1,0 +1,765 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import type { Redis } from 'ioredis';
+
+const mocks = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  getRedis: vi.fn(),
+  requireSession: vi.fn(),
+  validateDesignerShare: vi.fn(),
+  getJson: vi.fn(),
+  put: vi.fn(),
+  head: vi.fn(),
+  del: vi.fn(),
+}));
+
+vi.mock('./lib/rateLimit.js', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getRedis: mocks.getRedis,
+  getClientIP: () => '203.0.113.1',
+}));
+
+vi.mock('./lib/session.js', () => ({
+  requireSession: mocks.requireSession,
+}));
+
+vi.mock('./lib/designerValidation.js', () => ({
+  validateDesignerShare: mocks.validateDesignerShare,
+}));
+
+vi.mock('@vercel/blob', () => ({
+  put: mocks.put,
+  head: mocks.head,
+  del: mocks.del,
+  BlobNotFoundError: class BlobNotFoundError extends Error {},
+}));
+
+// Blob reads (lineage parent records) come from a seedable map; writes keep
+// going through the real putJson so the design-blob assertions see them.
+vi.mock('./lib/blobStore.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, getJson: mocks.getJson };
+});
+
+import {
+  communityDesignBlobPath,
+  communityMeshBlobPath,
+  communityThumbBlobPath,
+  writeCommunityCard,
+  type CommunityCardMetadata,
+  type CommunityDesignRecord,
+} from './lib/communityStore.js';
+import {
+  communityAuthorKey,
+  communityChildrenKey,
+  communityDenylistKey,
+  communityDesignKey,
+  communityIndexKey,
+  communityPublishedKey,
+} from './lib/redisKeys.js';
+
+class FakeRedis {
+  hashes = new Map<string, Map<string, string>>();
+  sets = new Map<string, Set<string>>();
+  zsets = new Map<string, Map<string, number>>();
+
+  async hset(key: string, fields: Record<string, string | number>): Promise<number> {
+    const hash = this.hashes.get(key) ?? new Map<string, string>();
+    for (const [field, value] of Object.entries(fields)) hash.set(field, String(value));
+    this.hashes.set(key, hash);
+    return Object.keys(fields).length;
+  }
+
+  async hget(key: string, field: string): Promise<string | null> {
+    return this.hashes.get(key)?.get(field) ?? null;
+  }
+
+  async hgetall(key: string): Promise<Record<string, string>> {
+    return Object.fromEntries(this.hashes.get(key) ?? new Map<string, string>());
+  }
+
+  async sadd(key: string, member: string): Promise<number> {
+    const set = this.sets.get(key) ?? new Set<string>();
+    const added = set.has(member) ? 0 : 1;
+    set.add(member);
+    this.sets.set(key, set);
+    return added;
+  }
+
+  async smembers(key: string): Promise<string[]> {
+    return [...(this.sets.get(key) ?? new Set<string>())];
+  }
+
+  async sismember(key: string, member: string): Promise<number> {
+    return this.sets.get(key)?.has(member) ? 1 : 0;
+  }
+
+  async scard(key: string): Promise<number> {
+    return this.sets.get(key)?.size ?? 0;
+  }
+
+  async zadd(key: string, score: number, member: string): Promise<number> {
+    const zset = this.zsets.get(key) ?? new Map<string, number>();
+    zset.set(member, score);
+    this.zsets.set(key, zset);
+    return 1;
+  }
+
+  async zrem(key: string, member: string): Promise<number> {
+    return this.zsets.get(key)?.delete(member) ? 1 : 0;
+  }
+
+  async zrevrange(key: string, start: number, stop: number): Promise<string[]> {
+    const entries = [...(this.zsets.get(key) ?? new Map<string, number>()).entries()].sort(
+      (a, b) => b[1] - a[1] || (a[0] < b[0] ? 1 : -1)
+    );
+    return entries.slice(start, stop + 1).map(([member]) => member);
+  }
+
+  pipeline(): {
+    hget: (key: string, field: string) => unknown;
+    hgetall: (key: string) => unknown;
+    zadd: (key: string, score: number, member: string) => unknown;
+    zrem: (key: string, member: string) => unknown;
+    exec: () => Promise<Array<[Error | null, unknown]>>;
+  } {
+    const ops: Array<() => Promise<unknown>> = [];
+    const pipe = {
+      hget: (key: string, field: string) => {
+        ops.push(() => this.hget(key, field));
+        return pipe;
+      },
+      hgetall: (key: string) => {
+        ops.push(() => this.hgetall(key));
+        return pipe;
+      },
+      zadd: (key: string, score: number, member: string) => {
+        ops.push(() => this.zadd(key, score, member));
+        return pipe;
+      },
+      zrem: (key: string, member: string) => {
+        ops.push(() => this.zrem(key, member));
+        return pipe;
+      },
+      exec: async (): Promise<Array<[Error | null, unknown]>> => {
+        const out: Array<[Error | null, unknown]> = [];
+        for (const op of ops) out.push([null, await op()]);
+        return out;
+      },
+    };
+    return pipe;
+  }
+}
+
+function createResponse() {
+  const res = {
+    _status: 0,
+    _body: null as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(body: unknown) {
+      res._body = body;
+      return res;
+    },
+    setHeader() {
+      return res;
+    },
+    end() {
+      return res;
+    },
+  };
+  return res as unknown as VercelResponse & { _status: number; _body: unknown };
+}
+
+async function handle(options: {
+  method?: string;
+  body?: unknown;
+  query?: Record<string, string>;
+}): Promise<VercelResponse & { _status: number; _body: unknown }> {
+  const res = createResponse();
+  const mod = await import('./community.js');
+  await mod.default(
+    {
+      method: options.method ?? 'POST',
+      headers: {},
+      body: options.body,
+      query: options.query ?? {},
+    } as unknown as VercelRequest,
+    res
+  );
+  return res;
+}
+
+function webpBase64(payloadBytes = 6): string {
+  return Buffer.concat([
+    Buffer.from('RIFF'),
+    Buffer.alloc(4),
+    Buffer.from('WEBP'),
+    Buffer.alloc(payloadBytes),
+  ]).toString('base64');
+}
+
+function glbBase64(payloadBytes = 8): string {
+  return Buffer.concat([Buffer.from('glTF'), Buffer.alloc(payloadBytes)]).toString('base64');
+}
+
+function publishBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'Socket Organizer',
+    description: 'Holds 24 sockets.',
+    authorName: 'Andy',
+    category: 'tools',
+    params: { width: 2, depth: 3, height: 6, gridUnitMm: 42, heightUnitMm: 7 },
+    thumbnails: [webpBase64()],
+    glb: glbBase64(),
+    ...overrides,
+  };
+}
+
+const SESSION = {
+  userId: 'user-1',
+  provider: 'github',
+  createdAt: 0,
+  expiresAt: 9_999_999_999_999,
+};
+const LINEAGE = {
+  parentId: 'parentAAAAAA',
+  rootId: 'rootBBBBBBBB',
+  parentName: 'Stale Parent',
+  parentAuthorName: 'StaleAuthor',
+  rootAuthorName: 'RootAuthor',
+};
+
+let fake: FakeRedis;
+const recordBlobs = new Map<string, unknown>();
+
+function seedRecordBlob(id: string, overrides: Partial<CommunityDesignRecord> = {}): void {
+  recordBlobs.set(communityDesignBlobPath(id), {
+    id,
+    authorPublicId: 'a'.repeat(32),
+    authorName: 'Seeder',
+    name: 'Seeded Design',
+    description: '',
+    category: 'tools',
+    techniques: [],
+    params: {},
+    metrics: { width: 83.5, depth: 125.5, height: 42, gridUnitMm: 42 },
+    lineage: null,
+    thumbnails: [],
+    meshUrl: '',
+    photos: [],
+    featured: false,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    status: 'live',
+    ...overrides,
+  });
+}
+
+async function seedCard(
+  overrides: Partial<CommunityCardMetadata> & { id: string },
+  counters: { likes?: number; remixes?: number; exports?: number } = {}
+): Promise<void> {
+  const card: CommunityCardMetadata = {
+    name: 'Seeded Design',
+    authorPublicId: 'a'.repeat(32),
+    authorName: 'Seeder',
+    category: 'tools',
+    techniques: [],
+    width: 83.5,
+    depth: 125.5,
+    height: 42,
+    gridUnitMm: 42,
+    thumbnailUrl: 'https://blob.test/seed.webp',
+    isRemix: false,
+    featured: false,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    status: 'live',
+    ...overrides,
+  };
+  await writeCommunityCard(fake as unknown as Redis, card);
+  await fake.hset(communityDesignKey(card.id), {
+    likes: String(counters.likes ?? 0),
+    remixes: String(counters.remixes ?? 0),
+    exports: String(counters.exports ?? 0),
+  });
+  if (card.status === 'live') {
+    await fake.zadd(communityIndexKey('newest'), card.createdAt, card.id);
+    await fake.zadd(communityIndexKey('remixes'), counters.remixes ?? 0, card.id);
+    await fake.zadd(communityIndexKey('likes'), counters.likes ?? 0, card.id);
+  }
+}
+
+function designBlobCalls(): Array<[string, string, { allowOverwrite?: boolean }]> {
+  return mocks.put.mock.calls.filter((call) =>
+    (call[0] as string).startsWith('community/designs/')
+  ) as Array<[string, string, { allowOverwrite?: boolean }]>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.TOKEN_SALT = 'test-salt';
+  process.env.COMMUNITY_PUBLISH_ENABLED = 'true';
+  delete process.env.VERCEL_ENV;
+  fake = new FakeRedis();
+  recordBlobs.clear();
+  mocks.getJson.mockImplementation(async (path: string) => recordBlobs.get(path) ?? null);
+  mocks.getRedis.mockReturnValue(fake);
+  mocks.checkRateLimit.mockResolvedValue({ allowed: true, remaining: 10, resetAt: 0 });
+  mocks.requireSession.mockResolvedValue(SESSION);
+  mocks.validateDesignerShare.mockImplementation((body: { params: Record<string, unknown> }) => ({
+    valid: true,
+    payload: { type: 'designer', version: 1, params: body.params },
+  }));
+  mocks.put.mockImplementation(async (path: string) => ({ url: `https://blob.test/${path}` }));
+  mocks.del.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  delete process.env.TOKEN_SALT;
+  delete process.env.COMMUNITY_PUBLISH_ENABLED;
+  delete process.env.VERCEL_ENV;
+});
+
+describe('POST /api/community (publish)', () => {
+  it('returns 503 when the kill switch is off, before touching the session', async () => {
+    delete process.env.COMMUNITY_PUBLISH_ENABLED;
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(503);
+    expect((res._body as { code: string }).code).toBe('SERVICE_UNAVAILABLE');
+    expect(mocks.requireSession).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when unauthenticated and writes nothing', async () => {
+    mocks.requireSession.mockImplementation(async (_req: unknown, res: VercelResponse) => {
+      res.status(401).json({ error: 'Not signed in', code: 'UNAUTHORIZED' });
+      return null;
+    });
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(401);
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when the per-user publish rate limit is hit', async () => {
+    mocks.checkRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: 0,
+      retryAfterSeconds: 30,
+    });
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(429);
+    expect((res._body as { retryAfter: number }).retryAfter).toBe(30);
+    expect(mocks.checkRateLimit).toHaveBeenCalledWith('user-1', 'community.publish');
+  });
+
+  it('returns 503 without TOKEN_SALT, after rate limiting but before validation', async () => {
+    delete process.env.TOKEN_SALT;
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(503);
+    expect((res._body as { code: string }).code).toBe('SERVICE_UNAVAILABLE');
+    expect(mocks.checkRateLimit).toHaveBeenCalledWith('user-1', 'community.publish');
+    expect(mocks.validateDesignerShare).not.toHaveBeenCalled();
+    expect(mocks.put).not.toHaveBeenCalled();
+    expect(fake.sets.size).toBe(0);
+    expect(fake.hashes.size).toBe(0);
+  });
+
+  const invalidBodies: Array<[string, unknown, string]> = [
+    ['non-object body', 'nope', 'INVALID_PAYLOAD'],
+    ['non-string name', publishBody({ name: 42 }), 'INVALID_NAME'],
+    ['overlong description', publishBody({ description: 'x'.repeat(501) }), 'INVALID_DESCRIPTION'],
+    ['missing authorName', publishBody({ authorName: undefined }), 'INVALID_AUTHOR_NAME'],
+    ['blocked name text', publishBody({ name: 'cool <script name' }), 'CONTENT_BLOCKED'],
+    ['unknown category', publishBody({ category: 'gadgets' }), 'INVALID_CATEGORY'],
+    ['missing params', publishBody({ params: undefined }), 'MISSING_PARAMS'],
+    ['empty thumbnails', publishBody({ thumbnails: [] }), 'INVALID_THUMBNAILS'],
+    [
+      'non-webp thumbnail',
+      publishBody({ thumbnails: [Buffer.from('notawebpfile').toString('base64')] }),
+      'INVALID_THUMBNAILS',
+    ],
+    [
+      'glb without magic bytes',
+      publishBody({ glb: Buffer.from('nope nope nope').toString('base64') }),
+      'INVALID_GLB',
+    ],
+    [
+      'lineage with bad parentId',
+      publishBody({ lineage: { ...LINEAGE, parentId: 'short' } }),
+      'INVALID_LINEAGE',
+    ],
+  ];
+
+  it.each(invalidBodies)('rejects %s with 400 and writes nothing', async (_label, body, code) => {
+    const res = await handle({ body });
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe(code);
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('passes designer params validation failures through as 400', async () => {
+    mocks.validateDesignerShare.mockReturnValue({
+      valid: false,
+      error: { code: 'INVALID_PARAMS', message: 'width must be 0.5-16' },
+    });
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe('INVALID_PARAMS');
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 when the live-design quota is exhausted', async () => {
+    for (let i = 0; i < 25; i++) {
+      await fake.sadd(communityPublishedKey('user-1'), `design-${i}`);
+      await fake.hset(communityDesignKey(`design-${i}`), { contentHash: `hash-${i}` });
+    }
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(413);
+    expect((res._body as { code: string }).code).toBe('SIZE_LIMIT');
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('returns a neutral 403 for a deny-listed user', async () => {
+    await fake.sadd(communityDenylistKey(), 'user-1');
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(403);
+    const body = res._body as { error: string };
+    expect(body.error.toLowerCase()).not.toContain('deny');
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('publishes: assets + CAS design blob + redis card, indexes, and sets', async () => {
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(201);
+    const body = res._body as { id: string; url: string };
+    expect(body.id).toMatch(/^[A-Za-z0-9]{12}$/);
+    expect(body.url).toContain(`/community/${body.id}`);
+
+    const [designCall] = designBlobCalls();
+    expect(designCall[0]).toBe(communityDesignBlobPath(body.id));
+    expect(designCall[2].allowOverwrite).toBe(false);
+
+    const record = JSON.parse(designCall[1]) as {
+      authorPublicId: string;
+      metrics: Record<string, number>;
+      techniques: string[];
+      lineage: unknown;
+      thumbnails: string[];
+      meshUrl: string;
+      status: string;
+    };
+    expect(record.authorPublicId).toMatch(/^[a-f0-9]{32}$/);
+    expect(record.metrics).toEqual({ width: 83.5, depth: 125.5, height: 42, gridUnitMm: 42 });
+    expect(record.techniques).toEqual([]);
+    expect(record.lineage).toBeNull();
+    expect(record.thumbnails).toEqual([
+      `https://blob.test/${communityThumbBlobPath(body.id, 1, 0)}`,
+    ]);
+    expect(record.meshUrl).toBe(`https://blob.test/${communityMeshBlobPath(body.id, 1)}`);
+    expect(record.status).toBe('live');
+
+    const thumbCall = mocks.put.mock.calls.find((call) =>
+      (call[0] as string).startsWith('community/thumbs/')
+    );
+    expect((thumbCall?.[2] as { contentType: string }).contentType).toBe('image/webp');
+    const meshCall = mocks.put.mock.calls.find((call) =>
+      (call[0] as string).startsWith('community/meshes/')
+    );
+    expect((meshCall?.[2] as { contentType: string }).contentType).toBe('model/gltf-binary');
+
+    expect(await fake.sismember(communityPublishedKey('user-1'), body.id)).toBe(1);
+    expect(await fake.sismember(communityAuthorKey(record.authorPublicId), body.id)).toBe(1);
+    expect(fake.zsets.get(communityIndexKey('newest'))?.has(body.id)).toBe(true);
+    expect(await fake.hget(communityDesignKey(body.id), 'status')).toBe('live');
+    expect(await fake.hget(communityDesignKey(body.id), 'contentHash')).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  it('republishing identical content returns the existing id with 200', async () => {
+    const first = await handle({ body: publishBody() });
+    expect(first._status).toBe(201);
+    const firstId = (first._body as { id: string }).id;
+
+    const second = await handle({ body: publishBody() });
+    expect(second._status).toBe(200);
+    expect((second._body as { id: string }).id).toBe(firstId);
+    expect(designBlobCalls()).toHaveLength(1);
+  });
+
+  it('returns the existing id for a retry even when the user sits at the live-design cap', async () => {
+    const first = await handle({ body: publishBody() });
+    expect(first._status).toBe(201);
+    const firstId = (first._body as { id: string }).id;
+
+    for (let i = 0; i < 24; i++) {
+      await fake.sadd(communityPublishedKey('user-1'), `design-${i}`);
+      await fake.hset(communityDesignKey(`design-${i}`), { contentHash: `hash-${i}` });
+    }
+    expect(await fake.scard(communityPublishedKey('user-1'))).toBe(25);
+
+    // Idempotency must run before quota: a 413 here would break retries of
+    // already-published content for capped users.
+    const retry = await handle({ body: publishBody() });
+    expect(retry._status).toBe(200);
+    expect((retry._body as { id: string }).id).toBe(firstId);
+  });
+
+  it('re-posting pre-edit content after an update mints a new design', async () => {
+    const first = await handle({ body: publishBody() });
+    expect(first._status).toBe(201);
+    const firstId = (first._body as { id: string }).id;
+
+    // PUT refreshes the stored contentHash to the edited content, so the
+    // original content no longer matches any published design.
+    await fake.hset(communityDesignKey(firstId), { contentHash: 'f'.repeat(32) });
+
+    const again = await handle({ body: publishBody() });
+    expect(again._status).toBe(201);
+    expect((again._body as { id: string }).id).not.toBe(firstId);
+    expect(designBlobCalls()).toHaveLength(2);
+  });
+
+  it('takes lineage snapshot fields from the live parent, never the client', async () => {
+    await seedCard({
+      id: LINEAGE.parentId,
+      name: 'Real Parent',
+      authorName: 'RealAuthor',
+      status: 'live',
+    });
+    // The parent is a root design, so the chain's root is the parent itself.
+    seedRecordBlob(LINEAGE.parentId, { name: 'Real Parent', authorName: 'RealAuthor' });
+    const spoofed = { ...LINEAGE, rootId: LINEAGE.parentId, rootAuthorName: 'Impostor' };
+    const res = await handle({ body: publishBody({ lineage: spoofed }) });
+    expect(res._status).toBe(201);
+    const id = (res._body as { id: string }).id;
+    const [designCall] = designBlobCalls();
+    const record = JSON.parse(designCall[1]) as { lineage: Record<string, string> };
+    expect(record.lineage.parentName).toBe('Real Parent');
+    expect(record.lineage.parentAuthorName).toBe('RealAuthor');
+    expect(record.lineage.rootId).toBe(LINEAGE.parentId);
+    expect(record.lineage.rootAuthorName).toBe('RealAuthor');
+    expect(await fake.hget(communityDesignKey(id), 'isRemix')).toBe('1');
+    expect(await fake.sismember(communityChildrenKey(LINEAGE.parentId), id)).toBe(1);
+  });
+
+  it('keeps the deleted-root snapshot from the parent record, never the client', async () => {
+    await seedCard({ id: LINEAGE.parentId, name: 'Real Parent', authorName: 'RealAuthor' });
+    seedRecordBlob(LINEAGE.parentId, {
+      lineage: {
+        parentId: 'grandpaCCCCC',
+        rootId: LINEAGE.rootId,
+        parentName: 'Grandpa',
+        parentAuthorName: 'Gramps',
+        rootAuthorName: 'RootAuthor',
+      },
+    });
+    const res = await handle({
+      body: publishBody({ lineage: { ...LINEAGE, rootAuthorName: 'Impostor' } }),
+    });
+    expect(res._status).toBe(201);
+    const [designCall] = designBlobCalls();
+    const record = JSON.parse(designCall[1]) as { lineage: Record<string, string> };
+    expect(record.lineage.rootId).toBe(LINEAGE.rootId);
+    // The root is legitimately gone here, so the parent's stored snapshot
+    // survives; the client's claimed name is ignored.
+    expect(record.lineage.rootAuthorName).toBe('RootAuthor');
+  });
+
+  it('refreshes the root snapshot too when the root is still live', async () => {
+    await seedCard({ id: LINEAGE.parentId, name: 'Real Parent', authorName: 'RealAuthor' });
+    await seedCard({ id: LINEAGE.rootId, name: 'Real Root', authorName: 'RealRootAuthor' });
+    seedRecordBlob(LINEAGE.parentId, {
+      lineage: {
+        parentId: LINEAGE.rootId,
+        rootId: LINEAGE.rootId,
+        parentName: 'Real Root',
+        parentAuthorName: 'RealRootAuthor',
+        rootAuthorName: 'RealRootAuthor',
+      },
+    });
+    const res = await handle({ body: publishBody({ lineage: LINEAGE }) });
+    expect(res._status).toBe(201);
+    const [designCall] = designBlobCalls();
+    const record = JSON.parse(designCall[1]) as { lineage: Record<string, string> };
+    expect(record.lineage.rootAuthorName).toBe('RealRootAuthor');
+  });
+
+  it('rejects a client rootId that does not match the parent chain', async () => {
+    await seedCard({ id: LINEAGE.parentId, name: 'Real Parent', authorName: 'RealAuthor' });
+    // Parent is a root design; crediting an unrelated design as root must fail.
+    seedRecordBlob(LINEAGE.parentId);
+    const res = await handle({ body: publishBody({ lineage: LINEAGE }) });
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe('INVALID_LINEAGE');
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('rejects lineage whose parent is missing', async () => {
+    const res = await handle({ body: publishBody({ lineage: LINEAGE }) });
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe('INVALID_LINEAGE');
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('rejects lineage whose parent is not live', async () => {
+    await seedCard({ id: LINEAGE.parentId, status: 'hidden' });
+    seedRecordBlob(LINEAGE.parentId);
+    const res = await handle({ body: publishBody({ lineage: LINEAGE }) });
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe('INVALID_LINEAGE');
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('rejects lineage whose parent record blob is missing', async () => {
+    await seedCard({ id: LINEAGE.parentId, name: 'Real Parent', authorName: 'RealAuthor' });
+    const res = await handle({
+      body: publishBody({ lineage: { ...LINEAGE, rootId: LINEAGE.parentId } }),
+    });
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe('INVALID_LINEAGE');
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
+  it('rolls back uploaded assets and the record blob when a Redis write fails', async () => {
+    fake.hset = async () => {
+      throw new Error('redis down');
+    };
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(500);
+
+    const uploadedPaths = mocks.put.mock.calls.map((call) => call[0] as string);
+    const assetUrls = uploadedPaths
+      .filter((path) => !path.startsWith('community/designs/'))
+      .map((path) => `https://blob.test/${path}`);
+    expect(assetUrls).toHaveLength(2);
+    expect(mocks.del.mock.calls.flat(2)).toEqual(
+      expect.arrayContaining([...assetUrls, expect.stringContaining('community/designs/')])
+    );
+  });
+
+  it('rolls back uploaded assets when the record blob write itself fails', async () => {
+    mocks.put.mockImplementation(async (path: string) => {
+      if (path.startsWith('community/designs/')) throw new Error('blob store down');
+      return { url: `https://blob.test/${path}` };
+    });
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(500);
+    expect(mocks.del.mock.calls.flat(2)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('community/thumbs/'),
+        expect.stringContaining('community/meshes/'),
+      ])
+    );
+  });
+});
+
+describe('GET /api/community (list)', () => {
+  it('rate limits reads per IP', async () => {
+    mocks.checkRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: 0,
+      retryAfterSeconds: 12,
+    });
+    const res = await handle({ method: 'GET' });
+    expect(res._status).toBe(429);
+    expect(mocks.checkRateLimit).toHaveBeenCalledWith('203.0.113.1', 'community.read');
+  });
+
+  it('rejects an unknown sort', async () => {
+    const res = await handle({ method: 'GET', query: { sort: 'oldest' } });
+    expect(res._status).toBe(400);
+    expect((res._body as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('pages newest-first, 24 per page, with a resumable cursor', async () => {
+    for (let i = 0; i < 30; i++) {
+      const id = `d${String(i).padStart(2, '0')}`;
+      await seedCard({ id, createdAt: 1_000 + i, updatedAt: 1_000 + i });
+    }
+
+    const first = await handle({ method: 'GET' });
+    expect(first._status).toBe(200);
+    const firstBody = first._body as {
+      items: Array<{ id: string; counts: { likes: number }; metrics: { width: number } }>;
+      nextCursor: string | null;
+    };
+    expect(firstBody.items).toHaveLength(24);
+    expect(firstBody.items[0].id).toBe('d29');
+    expect(firstBody.items[23].id).toBe('d06');
+    expect(firstBody.items[0].metrics.width).toBe(83.5);
+    expect(firstBody.nextCursor).toBe('24');
+
+    const second = await handle({ method: 'GET', query: { cursor: '24' } });
+    const secondBody = second._body as { items: Array<{ id: string }>; nextCursor: string | null };
+    expect(secondBody.items.map((item) => item.id)).toEqual([
+      'd05',
+      'd04',
+      'd03',
+      'd02',
+      'd01',
+      'd00',
+    ]);
+    expect(secondBody.nextCursor).toBeNull();
+  });
+
+  it('sorts by likes with counts from the card hash', async () => {
+    await seedCard({ id: 'liked-mid' }, { likes: 5 });
+    await seedCard({ id: 'liked-top' }, { likes: 9 });
+    await seedCard({ id: 'liked-low' }, { likes: 1 });
+
+    const res = await handle({ method: 'GET', query: { sort: 'likes' } });
+    const body = res._body as { items: Array<{ id: string; counts: { likes: number } }> };
+    expect(body.items.map((item) => item.id)).toEqual(['liked-top', 'liked-mid', 'liked-low']);
+    expect(body.items[0].counts.likes).toBe(9);
+  });
+
+  it('filters by category and never serves non-live designs publicly', async () => {
+    await seedCard({ id: 'kitchen-live', category: 'kitchen' });
+    await seedCard({ id: 'tools-live', category: 'tools' });
+    await seedCard({ id: 'kitchen-hidden', category: 'kitchen', status: 'hidden' });
+    // A hidden design lingering in the index must still be filtered out.
+    await fake.zadd(communityIndexKey('newest'), 5_000, 'kitchen-hidden');
+
+    const res = await handle({ method: 'GET', query: { category: 'kitchen' } });
+    const body = res._body as { items: Array<{ id: string }> };
+    expect(body.items.map((item) => item.id)).toEqual(['kitchen-live']);
+  });
+
+  it('mine includes own hidden designs but not removed ones or other authors', async () => {
+    await seedCard({ id: 'mine-live', createdAt: 3_000 });
+    await seedCard({ id: 'mine-hidden', status: 'hidden', createdAt: 2_000 });
+    await seedCard({ id: 'mine-removed', status: 'removed', createdAt: 1_000 });
+    await seedCard({ id: 'other-live', createdAt: 4_000 });
+    for (const id of ['mine-live', 'mine-hidden', 'mine-removed']) {
+      await fake.sadd(communityPublishedKey('user-1'), id);
+    }
+    await fake.sadd(communityPublishedKey('user-2'), 'other-live');
+
+    const res = await handle({ method: 'GET', query: { mine: '1' } });
+    expect(res._status).toBe(200);
+    const body = res._body as { items: Array<{ id: string; status: string }> };
+    expect(body.items.map((item) => item.id)).toEqual(['mine-live', 'mine-hidden']);
+    expect(body.items[1].status).toBe('hidden');
+    expect(mocks.requireSession).toHaveBeenCalled();
+  });
+
+  it('mine requires a session', async () => {
+    mocks.requireSession.mockImplementation(async (_req: unknown, res: VercelResponse) => {
+      res.status(401).json({ error: 'Not signed in', code: 'UNAUTHORIZED' });
+      return null;
+    });
+    const res = await handle({ method: 'GET', query: { mine: '1' } });
+    expect(res._status).toBe(401);
+  });
+
+  it('anonymous list never consults the session', async () => {
+    await seedCard({ id: 'public-live' });
+    const res = await handle({ method: 'GET' });
+    expect(res._status).toBe(200);
+    expect(mocks.requireSession).not.toHaveBeenCalled();
+  });
+});

--- a/api/community.test.ts
+++ b/api/community.test.ts
@@ -109,6 +109,19 @@ class FakeRedis {
     return this.zsets.get(key)?.delete(member) ? 1 : 0;
   }
 
+  async srem(key: string, member: string): Promise<number> {
+    return this.sets.get(key)?.delete(member) ? 1 : 0;
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let removed = 0;
+    for (const key of keys) {
+      const had = this.hashes.delete(key) || this.sets.delete(key) || this.zsets.delete(key);
+      if (had) removed += 1;
+    }
+    return removed;
+  }
+
   async zrevrange(key: string, start: number, stop: number): Promise<string[]> {
     const entries = [...(this.zsets.get(key) ?? new Map<string, number>()).entries()].sort(
       (a, b) => b[1] - a[1] || (a[0] < b[0] ? 1 : -1)
@@ -139,6 +152,14 @@ class FakeRedis {
       },
       zrem: (key: string, member: string) => {
         ops.push(() => this.zrem(key, member));
+        return pipe;
+      },
+      srem: (key: string, member: string) => {
+        ops.push(() => this.srem(key, member));
+        return pipe;
+      },
+      del: (...keys: string[]) => {
+        ops.push(() => this.del(...keys));
         return pipe;
       },
       exec: async (): Promise<Array<[Error | null, unknown]>> => {
@@ -477,6 +498,24 @@ describe('POST /api/community (publish)', () => {
     expect(fake.zsets.get(communityIndexKey('newest'))?.has(body.id)).toBe(true);
     expect(await fake.hget(communityDesignKey(body.id), 'status')).toBe('live');
     expect(await fake.hget(communityDesignKey(body.id), 'contentHash')).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  it('rolls back redis state when a write fails mid-publish', async () => {
+    const originalSadd = fake.sadd.bind(fake);
+    fake.sadd = async (key: string, member: string): Promise<number> => {
+      if (key.startsWith('community:author:')) {
+        throw new Error('redis write failed');
+      }
+      return originalSadd(key, member);
+    };
+
+    const res = await handle({ body: publishBody() });
+    expect(res._status).toBe(500);
+
+    expect(await fake.smembers(communityPublishedKey('user-1'))).toEqual([]);
+    expect(fake.zsets.get(communityIndexKey('newest'))?.size ?? 0).toBe(0);
+    const hashKeys = [...fake.hashes.keys()].filter((key) => key.startsWith('community:design:'));
+    expect(hashKeys).toEqual([]);
   });
 
   it('republishing identical content returns the existing id with 200', async () => {

--- a/api/community.test.ts
+++ b/api/community.test.ts
@@ -264,6 +264,7 @@ async function seedCard(
 ): Promise<void> {
   const card: CommunityCardMetadata = {
     name: 'Seeded Design',
+    parentId: '',
     authorPublicId: 'a'.repeat(32),
     authorName: 'Seeder',
     category: 'tools',

--- a/api/community.ts
+++ b/api/community.ts
@@ -28,6 +28,7 @@ import {
   deriveCommunityMetrics,
   readCommunityCards,
   readCommunityDesignBlob,
+  removeFromCommunityIndexes,
   upsertCommunityIndexes,
   writeCommunityCard,
   writeCommunityDesignBlob,
@@ -311,6 +312,25 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
         logger.error('Rollback failed: orphan community design blob left after publish failure', {
           id,
           error: delErr instanceof Error ? delErr.message : String(delErr),
+        });
+      });
+      // Redis writes may have partially landed before the failure; without
+      // this cleanup a stranded card hash surfaces in the gallery list while
+      // the detail 404s, and the published-set entry burns a quota slot.
+      await (async () => {
+        const cleanup = redis.pipeline();
+        cleanup.del(communityDesignKey(id));
+        cleanup.srem(communityPublishedKey(session.userId), id);
+        cleanup.srem(communityAuthorKey(authorPublicId), id);
+        if (lineage !== null) {
+          cleanup.srem(communityChildrenKey(lineage.parentId), id);
+        }
+        await cleanup.exec();
+        await removeFromCommunityIndexes(redis, id);
+      })().catch((cleanupErr: unknown) => {
+        logger.error('Rollback failed: orphan community redis entries left after publish failure', {
+          id,
+          error: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
         });
       });
       throw writeErr;

--- a/api/community.ts
+++ b/api/community.ts
@@ -153,6 +153,7 @@ function cardFromRecord(record: CommunityDesignRecord): CommunityCardMetadata {
     gridUnitMm: record.metrics.gridUnitMm,
     thumbnailUrl: record.thumbnails[0] ?? '',
     isRemix: record.lineage !== null,
+    parentId: record.lineage?.parentId ?? '',
     featured: record.featured,
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,

--- a/api/community.ts
+++ b/api/community.ts
@@ -1,0 +1,548 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { del, put } from '@vercel/blob';
+import { requireMethod } from './lib/method.js';
+import { requireSession } from './lib/session.js';
+import { checkRateLimit, getClientIP, getRedis } from './lib/rateLimit.js';
+import { logger } from './lib/logger.js';
+import {
+  ErrorCode,
+  getBaseUrl,
+  rateLimited,
+  serviceUnavailable,
+  singleParam,
+} from './lib/shared.js';
+import {
+  COMMUNITY_CATEGORIES,
+  COMMUNITY_TECHNIQUES,
+  parseCommunityLineage,
+  validateCommunityPublish,
+} from './lib/communityValidation.js';
+import type { CommunityCategory, CommunityTechnique } from './lib/communityValidation.js';
+import { deriveAuthorPublicId, generateCommunityDesignId } from './lib/communityIds.js';
+import { checkCommunityPublishQuota } from './lib/communityQuota.js';
+import {
+  communityContentHash,
+  communityMeshBlobPath,
+  communityThumbBlobPath,
+  deleteCommunityDesignBlob,
+  deriveCommunityMetrics,
+  readCommunityCards,
+  readCommunityDesignBlob,
+  upsertCommunityIndexes,
+  writeCommunityCard,
+  writeCommunityDesignBlob,
+} from './lib/communityStore.js';
+import type {
+  CommunityCardMetadata,
+  CommunityCardRecord,
+  CommunityDesignMetrics,
+  CommunityDesignRecord,
+  CommunityDesignStatus,
+  CommunityLineage,
+} from './lib/communityStore.js';
+import {
+  COMMUNITY_INDEX_SORTS,
+  communityAuthorKey,
+  communityChildrenKey,
+  communityDenylistKey,
+  communityDesignKey,
+  communityIndexKey,
+  communityPublishedKey,
+} from './lib/redisKeys.js';
+import type { CommunityIndexSort } from './lib/redisKeys.js';
+
+type RedisClient = NonNullable<ReturnType<typeof getRedis>>;
+
+const FIRST_REVISION = 1;
+const LIST_PAGE_SIZE = 24;
+const LIST_SCAN_BATCH = 48;
+// Bounds per-request Redis work when filters match rarely; the client resumes
+// the scan from nextCursor instead of one request walking the whole index.
+const LIST_MAX_SCAN = 960;
+
+const AUTHOR_PUBLIC_ID_REGEX = /^[a-f0-9]{32}$/;
+const CURSOR_REGEX = /^\d{1,9}$/;
+
+function communityDesignUrl(designId: string): string {
+  return `${getBaseUrl()}/community/${designId}`;
+}
+
+function badRequest(res: VercelResponse, message: string): void {
+  res.status(400).json({ error: message, code: ErrorCode.VALIDATION_ERROR });
+}
+
+type LineageResolveResult =
+  { ok: true; lineage: CommunityLineage | null } | { ok: false; message: string };
+
+/**
+ * Lineage display fields and the root itself come from the stored parent
+ * record, never the client: accepting client values would let a publisher
+ * fabricate "remix of X by Y" or "originally by Z" credit for arbitrary real
+ * authors. The parent must be live at publish time and its stored chain
+ * dictates the root; a client rootId that disagrees is rejected. When the
+ * chain's root is legitimately deleted, its snapshot survives via the parent
+ * record. The parent link itself carries no proof-of-remix: any live design
+ * can be claimed as a parent, only the credit text is server-derived.
+ */
+async function resolveLineage(
+  redis: RedisClient,
+  lineage: CommunityLineage | null
+): Promise<LineageResolveResult> {
+  if (lineage === null) return { ok: true, lineage: null };
+  const parentCard = (await readCommunityCards(redis, [lineage.parentId]))[0] ?? null;
+  if (parentCard === null || parentCard.status !== 'live') {
+    return { ok: false, message: 'lineage.parentId does not reference a live design' };
+  }
+  const parentRecord = await readCommunityDesignBlob(lineage.parentId);
+  if (parentRecord === null) {
+    return { ok: false, message: 'lineage.parentId does not reference a live design' };
+  }
+  const rootId = parentRecord.lineage?.rootId ?? lineage.parentId;
+  if (lineage.rootId !== rootId) {
+    return { ok: false, message: 'lineage.rootId does not match the parent design chain' };
+  }
+  let rootAuthorName = parentRecord.lineage?.rootAuthorName ?? parentCard.authorName;
+  if (rootId !== lineage.parentId) {
+    const rootCard = (await readCommunityCards(redis, [rootId]))[0] ?? null;
+    if (rootCard !== null && rootCard.status === 'live') {
+      rootAuthorName = rootCard.authorName;
+    }
+  }
+  return {
+    ok: true,
+    lineage: {
+      parentId: lineage.parentId,
+      rootId,
+      parentName: parentCard.name,
+      parentAuthorName: parentCard.authorName,
+      rootAuthorName,
+    },
+  };
+}
+
+async function findPublishedIdByContentHash(
+  redis: RedisClient,
+  userId: string,
+  contentHash: string
+): Promise<string | null> {
+  const publishedIds = await redis.smembers(communityPublishedKey(userId));
+  if (publishedIds.length === 0) return null;
+  const pipeline = redis.pipeline();
+  for (const id of publishedIds) {
+    pipeline.hget(communityDesignKey(id), 'contentHash');
+  }
+  const results = (await pipeline.exec()) ?? [];
+  for (let i = 0; i < publishedIds.length && i < results.length; i++) {
+    const [error, value] = results[i];
+    if (!error && value === contentHash) return publishedIds[i];
+  }
+  return null;
+}
+
+function cardFromRecord(record: CommunityDesignRecord): CommunityCardMetadata {
+  return {
+    id: record.id,
+    name: record.name,
+    authorPublicId: record.authorPublicId,
+    authorName: record.authorName,
+    category: record.category,
+    techniques: record.techniques,
+    width: record.metrics.width,
+    depth: record.metrics.depth,
+    height: record.metrics.height,
+    gridUnitMm: record.metrics.gridUnitMm,
+    thumbnailUrl: record.thumbnails[0] ?? '',
+    isRemix: record.lineage !== null,
+    featured: record.featured,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    status: record.status,
+  };
+}
+
+async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (process.env.COMMUNITY_PUBLISH_ENABLED !== 'true') {
+    serviceUnavailable(res, 'Community publishing is not available.');
+    return;
+  }
+
+  const session = await requireSession(req, res);
+  if (!session) return;
+
+  try {
+    const rate = await checkRateLimit(session.userId, 'community.publish');
+    if (!rate.allowed) {
+      rateLimited(res, rate.retryAfterSeconds, 'Publish limit reached. Try again later.');
+      return;
+    }
+
+    const redis = getRedis();
+    if (!redis) {
+      serviceUnavailable(res);
+      return;
+    }
+
+    const authorPublicId = deriveAuthorPublicId(session.userId);
+    if (authorPublicId === null) {
+      logger.error('Community publish failed: TOKEN_SALT is not configured');
+      serviceUnavailable(res);
+      return;
+    }
+
+    const validated = validateCommunityPublish(req.body);
+    if (!validated.valid) {
+      res.status(400).json({ error: validated.error.message, code: validated.error.code });
+      return;
+    }
+    const payload = validated.payload;
+
+    const lineageParse = parseCommunityLineage((req.body as Record<string, unknown>).lineage);
+    if (!lineageParse.ok) {
+      res.status(400).json({ error: lineageParse.message, code: 'INVALID_LINEAGE' });
+      return;
+    }
+
+    const denied = await redis.sismember(communityDenylistKey(), session.userId);
+    if (denied === 1) {
+      // Deliberately neutral: the response must not reveal deny-listing.
+      res.status(403).json({
+        error: 'Publishing is not available for this account.',
+        code: ErrorCode.UNAUTHORIZED,
+      });
+      return;
+    }
+
+    const contentHash = communityContentHash({
+      params: payload.params,
+      name: payload.name,
+      description: payload.description,
+      category: payload.category,
+    });
+    // Idempotency runs before quota: a retry of an already-published design
+    // must return its id even when the user sits at the live-design cap.
+    const existingId = await findPublishedIdByContentHash(redis, session.userId, contentHash);
+    if (existingId !== null) {
+      res.status(200).json({ id: existingId, url: communityDesignUrl(existingId) });
+      return;
+    }
+
+    const quota = await checkCommunityPublishQuota(redis, session.userId);
+    if (!quota.ok) {
+      res.status(413).json({
+        error: `Published design limit reached (${quota.error.limit} live designs).`,
+        code: ErrorCode.SIZE_LIMIT,
+      });
+      return;
+    }
+
+    const lineageResolve = await resolveLineage(redis, lineageParse.lineage);
+    if (!lineageResolve.ok) {
+      res.status(400).json({ error: lineageResolve.message, code: 'INVALID_LINEAGE' });
+      return;
+    }
+    const lineage = lineageResolve.lineage;
+
+    const id = generateCommunityDesignId();
+    const now = Date.now();
+    const [thumbBlobs, meshBlob] = await Promise.all([
+      Promise.all(
+        payload.thumbnails.map((thumbnail, angle) =>
+          put(communityThumbBlobPath(id, FIRST_REVISION, angle), Buffer.from(thumbnail, 'base64'), {
+            access: 'public',
+            contentType: 'image/webp',
+            addRandomSuffix: false,
+            allowOverwrite: false,
+          })
+        )
+      ),
+      put(communityMeshBlobPath(id, FIRST_REVISION), Buffer.from(payload.glb, 'base64'), {
+        access: 'public',
+        contentType: 'model/gltf-binary',
+        addRandomSuffix: false,
+        allowOverwrite: false,
+      }),
+    ]);
+
+    const record: CommunityDesignRecord = {
+      id,
+      authorPublicId,
+      authorName: payload.authorName,
+      name: payload.name,
+      description: payload.description,
+      category: payload.category,
+      techniques: payload.techniques,
+      params: payload.params,
+      metrics: deriveCommunityMetrics(payload.params),
+      lineage,
+      thumbnails: thumbBlobs.map((blob) => blob.url),
+      meshUrl: meshBlob.url,
+      photos: [],
+      featured: false,
+      createdAt: now,
+      updatedAt: now,
+      status: 'live',
+    };
+
+    try {
+      await writeCommunityDesignBlob(record);
+      await writeCommunityCard(redis, cardFromRecord(record));
+      await redis.hset(communityDesignKey(id), { contentHash });
+      await upsertCommunityIndexes(redis, id, { createdAt: now, remixes: 0, likes: 0 });
+      await redis.sadd(communityPublishedKey(session.userId), id);
+      await redis.sadd(communityAuthorKey(authorPublicId), id);
+      // Recorded at publish so remix claims are auditable and so the delete
+      // path's srem from the parent's children set has something to undo.
+      if (lineage !== null) {
+        await redis.sadd(communityChildrenKey(lineage.parentId), id);
+      }
+    } catch (writeErr) {
+      // The thumbnails and GLB were already uploaded to public, predictable
+      // paths; without this cleanup a failed publish would strand CDN assets
+      // that no record references and no purge can enumerate.
+      const uploadedAssets = [...thumbBlobs.map((blob) => blob.url), meshBlob.url];
+      await del(uploadedAssets).catch((delErr: unknown) => {
+        logger.error('Rollback failed: orphan community assets left after publish failure', {
+          id,
+          error: delErr instanceof Error ? delErr.message : String(delErr),
+        });
+      });
+      await deleteCommunityDesignBlob(id).catch((delErr: unknown) => {
+        logger.error('Rollback failed: orphan community design blob left after publish failure', {
+          id,
+          error: delErr instanceof Error ? delErr.message : String(delErr),
+        });
+      });
+      throw writeErr;
+    }
+
+    res.status(201).json({ id, url: communityDesignUrl(id) });
+  } catch (error) {
+    logger.error('Community publish error', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    res.status(500).json({ error: 'Failed to publish design', code: ErrorCode.SERVER_ERROR });
+  }
+}
+
+interface CommunityListItem {
+  id: string;
+  name: string;
+  authorName: string;
+  authorPublicId: string;
+  category: CommunityCategory;
+  techniques: CommunityTechnique[];
+  metrics: CommunityDesignMetrics;
+  thumbnailUrl: string;
+  isRemix: boolean;
+  featured: boolean;
+  counts: { likes: number; remixes: number; exports: number };
+  createdAt: number;
+  updatedAt: number;
+  status: CommunityDesignStatus;
+}
+
+function toListItem(card: CommunityCardRecord): CommunityListItem {
+  return {
+    id: card.id,
+    name: card.name,
+    authorName: card.authorName,
+    authorPublicId: card.authorPublicId,
+    category: card.category,
+    techniques: card.techniques,
+    metrics: {
+      width: card.width,
+      depth: card.depth,
+      height: card.height,
+      gridUnitMm: card.gridUnitMm,
+    },
+    thumbnailUrl: card.thumbnailUrl,
+    isRemix: card.isRemix,
+    featured: card.featured,
+    counts: { likes: card.likes, remixes: card.remixes, exports: card.exports },
+    createdAt: card.createdAt,
+    updatedAt: card.updatedAt,
+    status: card.status,
+  };
+}
+
+interface ListFilters {
+  sort: CommunityIndexSort;
+  category: CommunityCategory | undefined;
+  technique: CommunityTechnique | undefined;
+  author: string | undefined;
+}
+
+function matchesFilters(card: CommunityCardRecord, filters: ListFilters): boolean {
+  if (filters.category !== undefined && card.category !== filters.category) return false;
+  if (filters.technique !== undefined && !card.techniques.includes(filters.technique)) return false;
+  if (filters.author !== undefined && card.authorPublicId !== filters.author) return false;
+  return true;
+}
+
+function compareCards(
+  a: CommunityCardRecord,
+  b: CommunityCardRecord,
+  sort: CommunityIndexSort
+): number {
+  if (sort === 'likes' && b.likes !== a.likes) return b.likes - a.likes;
+  if (sort === 'remixes' && b.remixes !== a.remixes) return b.remixes - a.remixes;
+  return b.createdAt - a.createdAt;
+}
+
+function isCommunityIndexSort(value: string): value is CommunityIndexSort {
+  return (COMMUNITY_INDEX_SORTS as readonly string[]).includes(value);
+}
+
+function isCommunityCategory(value: string): value is CommunityCategory {
+  return (COMMUNITY_CATEGORIES as readonly string[]).includes(value);
+}
+
+function isCommunityTechnique(value: string): value is CommunityTechnique {
+  return (COMMUNITY_TECHNIQUES as readonly string[]).includes(value);
+}
+
+async function listMine(
+  res: VercelResponse,
+  redis: RedisClient,
+  userId: string,
+  filters: ListFilters,
+  cursor: number
+): Promise<void> {
+  const ids = await redis.smembers(communityPublishedKey(userId));
+  const cards = (await readCommunityCards(redis, ids)).filter(
+    (card): card is CommunityCardRecord => card !== null && card.status !== 'removed'
+  );
+  const matching = cards
+    .filter((card) => matchesFilters(card, filters))
+    .sort((a, b) => compareCards(a, b, filters.sort));
+  const page = matching.slice(cursor, cursor + LIST_PAGE_SIZE);
+  const nextOffset = cursor + page.length;
+  res.status(200).json({
+    items: page.map(toListItem),
+    nextCursor: nextOffset < matching.length ? String(nextOffset) : null,
+  });
+}
+
+async function listPublic(
+  res: VercelResponse,
+  redis: RedisClient,
+  filters: ListFilters,
+  cursor: number
+): Promise<void> {
+  const items: CommunityListItem[] = [];
+  let offset = cursor;
+  let scanned = 0;
+  let reachedEnd = false;
+  let full = false;
+
+  while (!full && !reachedEnd && scanned < LIST_MAX_SCAN) {
+    const ids = await redis.zrevrange(
+      communityIndexKey(filters.sort),
+      offset,
+      offset + LIST_SCAN_BATCH - 1
+    );
+    if (ids.length === 0) {
+      reachedEnd = true;
+      break;
+    }
+    const cards = await readCommunityCards(redis, ids);
+    for (const card of cards) {
+      offset += 1;
+      scanned += 1;
+      if (card === null || card.status !== 'live' || !matchesFilters(card, filters)) continue;
+      items.push(toListItem(card));
+      if (items.length === LIST_PAGE_SIZE) {
+        full = true;
+        break;
+      }
+    }
+    if (!full && ids.length < LIST_SCAN_BATCH) reachedEnd = true;
+  }
+
+  res.status(200).json({ items, nextCursor: reachedEnd ? null : String(offset) });
+}
+
+async function handleList(req: VercelRequest, res: VercelResponse): Promise<void> {
+  try {
+    const rate = await checkRateLimit(getClientIP(req), 'community.read');
+    if (!rate.allowed) {
+      rateLimited(res, rate.retryAfterSeconds);
+      return;
+    }
+
+    const redis = getRedis();
+    if (!redis) {
+      serviceUnavailable(res);
+      return;
+    }
+
+    const sortParam = singleParam(req.query.sort) ?? 'newest';
+    if (!isCommunityIndexSort(sortParam)) {
+      badRequest(res, `sort must be one of: ${COMMUNITY_INDEX_SORTS.join(', ')}`);
+      return;
+    }
+
+    const categoryParam = singleParam(req.query.category);
+    if (categoryParam !== undefined && !isCommunityCategory(categoryParam)) {
+      badRequest(res, `category must be one of: ${COMMUNITY_CATEGORIES.join(', ')}`);
+      return;
+    }
+
+    const techniqueParam = singleParam(req.query.technique);
+    if (techniqueParam !== undefined && !isCommunityTechnique(techniqueParam)) {
+      badRequest(res, `technique must be one of: ${COMMUNITY_TECHNIQUES.join(', ')}`);
+      return;
+    }
+
+    const authorParam = singleParam(req.query.author);
+    if (authorParam !== undefined && !AUTHOR_PUBLIC_ID_REGEX.test(authorParam)) {
+      badRequest(res, 'author must be a 32-char author public id');
+      return;
+    }
+
+    const cursorParam = singleParam(req.query.cursor);
+    let cursor = 0;
+    if (cursorParam !== undefined) {
+      if (!CURSOR_REGEX.test(cursorParam)) {
+        badRequest(res, 'cursor must be a non-negative integer');
+        return;
+      }
+      cursor = Number(cursorParam);
+    }
+
+    const mineParam = singleParam(req.query.mine);
+    const mine = mineParam === '1' || mineParam === 'true';
+
+    const filters: ListFilters = {
+      sort: sortParam,
+      category: categoryParam,
+      technique: techniqueParam,
+      author: authorParam,
+    };
+
+    if (mine) {
+      const session = await requireSession(req, res);
+      if (!session) return;
+      await listMine(res, redis, session.userId, filters, cursor);
+      return;
+    }
+
+    await listPublic(res, redis, filters, cursor);
+  } catch (error) {
+    logger.error('Community list error', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    res.status(500).json({ error: 'Failed to list designs', code: ErrorCode.SERVER_ERROR });
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (!requireMethod(req, res, ['GET', 'POST'])) return;
+  if (req.method === 'GET') {
+    await handleList(req, res);
+    return;
+  }
+  await handlePublish(req, res);
+}

--- a/api/community.ts
+++ b/api/community.ts
@@ -132,10 +132,19 @@ async function findPublishedIdByContentHash(
   for (const id of publishedIds) {
     pipeline.hget(communityDesignKey(id), 'contentHash');
   }
-  const results = (await pipeline.exec()) ?? [];
+  // A swallowed exec failure would disable idempotency and mint duplicate
+  // designs while consuming quota, so an unhealthy redis must fail the
+  // publish instead.
+  const results = await pipeline.exec();
+  if (results === null) {
+    throw new Error('Community idempotency check failed: redis connection lost');
+  }
   for (let i = 0; i < publishedIds.length && i < results.length; i++) {
     const [error, value] = results[i];
-    if (!error && value === contentHash) return publishedIds[i];
+    if (error) {
+      throw new Error(`Community idempotency check failed: ${error.message}`);
+    }
+    if (value === contentHash) return publishedIds[i];
   }
   return null;
 }

--- a/api/community/[id].test.ts
+++ b/api/community/[id].test.ts
@@ -1,0 +1,640 @@
+/**
+ * Tests for community design GET/PUT/DELETE. The load-bearing invariants:
+ *  - hidden/removed designs are indistinguishable from missing ones for
+ *    everyone but their owner
+ *  - PUT/DELETE authorize via the server-side published set, never a
+ *    client-sent publishedId, and PUT can never change moderation status
+ *  - PUT rewrites assets under a bumped rev and deletes the replaced rev
+ *  - DELETE cleans blobs plus every Redis membership; the admin path needs
+ *    a constant-time token match and is disabled without the env var
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { communityMeshBlobPath, communityThumbBlobPath } from '../lib/communityStore.js';
+import type { CommunityDesignRecord } from '../lib/communityStore.js';
+import type { SessionRecord } from '../lib/session.js';
+import {
+  communityAuthorKey,
+  communityChildrenKey,
+  communityDenylistKey,
+  communityDesignKey,
+  communityLikedKey,
+  communityLikesKey,
+  communityPublishedKey,
+  communityReportsKey,
+} from '../lib/redisKeys.js';
+
+const mocks = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  getRedis: vi.fn(),
+  requireSession: vi.fn(),
+  readSession: vi.fn(),
+  readSessionCookie: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+  validateCommunityPublish: vi.fn(),
+  checkCommunityPublishQuota: vi.fn(),
+  readCommunityDesignBlob: vi.fn(),
+  writeCommunityDesignBlob: vi.fn(),
+  writeCommunityCard: vi.fn(),
+  removeFromCommunityIndexes: vi.fn(),
+  deleteCommunityDesignBlob: vi.fn(),
+}));
+
+vi.mock('../lib/rateLimit.js', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getRedis: mocks.getRedis,
+  getClientIP: () => '203.0.113.1',
+}));
+
+vi.mock('../lib/session.js', () => ({
+  requireSession: mocks.requireSession,
+  readSession: mocks.readSession,
+}));
+
+vi.mock('../lib/cookies.js', () => ({
+  readSessionCookie: mocks.readSessionCookie,
+}));
+
+vi.mock('@vercel/blob', () => ({
+  put: mocks.put,
+  del: mocks.del,
+}));
+
+vi.mock('../lib/communityValidation.js', () => ({
+  validateCommunityPublish: mocks.validateCommunityPublish,
+}));
+
+vi.mock('../lib/communityQuota.js', () => ({
+  checkCommunityPublishQuota: mocks.checkCommunityPublishQuota,
+}));
+
+vi.mock('../lib/communityStore.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    readCommunityDesignBlob: mocks.readCommunityDesignBlob,
+    writeCommunityDesignBlob: mocks.writeCommunityDesignBlob,
+    writeCommunityCard: mocks.writeCommunityCard,
+    removeFromCommunityIndexes: mocks.removeFromCommunityIndexes,
+    deleteCommunityDesignBlob: mocks.deleteCommunityDesignBlob,
+  };
+});
+
+function createResponse() {
+  const res = {
+    _status: 0,
+    _body: null as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(body: unknown) {
+      res._body = body;
+      return res;
+    },
+    setHeader() {
+      return res;
+    },
+    end() {
+      return res;
+    },
+  };
+  return res as unknown as VercelResponse & { _status: number; _body: unknown };
+}
+
+interface FakePipeline {
+  del: ReturnType<typeof vi.fn>;
+  srem: ReturnType<typeof vi.fn>;
+  exec: ReturnType<typeof vi.fn>;
+}
+
+interface FakeRedis {
+  sismember: ReturnType<typeof vi.fn>;
+  smembers: ReturnType<typeof vi.fn>;
+  hget: ReturnType<typeof vi.fn>;
+  hgetall: ReturnType<typeof vi.fn>;
+  hset: ReturnType<typeof vi.fn>;
+  pipeline: ReturnType<typeof vi.fn>;
+}
+
+function createRedis(): { redis: FakeRedis; pipeline: FakePipeline } {
+  const pipeline: FakePipeline = {
+    del: vi.fn(() => pipeline),
+    srem: vi.fn(() => pipeline),
+    exec: vi.fn(async () => [] as [null, unknown][]),
+  };
+  const redis: FakeRedis = {
+    sismember: vi.fn(async (key: string) => (key === communityDenylistKey() ? 0 : 1)),
+    smembers: vi.fn(async () => [] as string[]),
+    hget: vi.fn(async () => null),
+    hgetall: vi.fn(async (): Promise<Record<string, string>> => ({})),
+    hset: vi.fn(async () => 1),
+    pipeline: vi.fn(() => pipeline),
+  };
+  return { redis, pipeline };
+}
+
+const VALID_ID = 'AbCdEf123456';
+const USER_ID = 'user-1';
+const PARENT_ID = 'ParentDes1gn';
+
+const session: SessionRecord = {
+  userId: USER_ID,
+  provider: 'github',
+  createdAt: 0,
+  expiresAt: Number.MAX_SAFE_INTEGER,
+};
+
+function designRecord(overrides: Partial<CommunityDesignRecord> = {}): CommunityDesignRecord {
+  return {
+    id: VALID_ID,
+    authorPublicId: 'author-public-id',
+    authorName: 'Jo',
+    name: 'Screw bin',
+    description: 'A bin for screws',
+    category: 'tools',
+    techniques: ['scoop'],
+    params: { width: 2, depth: 3, height: 6, gridUnitMm: 42 },
+    metrics: { width: 2, depth: 3, height: 6, gridUnitMm: 42 },
+    lineage: null,
+    thumbnails: [
+      `https://blob.example/community/thumbs/${VALID_ID}-3-0.webp`,
+      `https://blob.example/community/thumbs/${VALID_ID}-3-1.webp`,
+    ],
+    meshUrl: `https://blob.example/community/meshes/${VALID_ID}-3.glb`,
+    photos: [],
+    featured: false,
+    createdAt: 1000,
+    updatedAt: 1000,
+    status: 'live',
+    ...overrides,
+  };
+}
+
+function publishPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Updated bin',
+    description: 'Now with a scoop',
+    authorName: 'Jo',
+    category: 'tools',
+    params: { width: 4, depth: 2, height: 9, gridUnitMm: 42 },
+    techniques: ['scoop'],
+    thumbnails: ['dGh1bWItMA==', 'dGh1bWItMQ=='],
+    glb: 'Z2xURgAAAAA=',
+    ...overrides,
+  };
+}
+
+async function handle(
+  method: string,
+  over: { id?: unknown; body?: unknown; headers?: Record<string, string> } = {}
+) {
+  const res = createResponse();
+  const mod = await import('./[id].js');
+  await mod.default(
+    {
+      method,
+      query: { id: over.id ?? VALID_ID },
+      headers: over.headers ?? {},
+      body: over.body ?? {},
+    } as unknown as VercelRequest,
+    res
+  );
+  return res;
+}
+
+describe('community/[id]', () => {
+  let redis: FakeRedis;
+  let pipeline: FakePipeline;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.COMMUNITY_ADMIN_TOKEN;
+    process.env.COMMUNITY_PUBLISH_ENABLED = 'true';
+    process.env.TOKEN_SALT = 'test-salt';
+    ({ redis, pipeline } = createRedis());
+    mocks.getRedis.mockReturnValue(redis);
+    mocks.checkRateLimit.mockResolvedValue({ allowed: true });
+    mocks.requireSession.mockResolvedValue(session);
+    mocks.readSessionCookie.mockReturnValue(undefined);
+    mocks.readSession.mockResolvedValue(null);
+    mocks.readCommunityDesignBlob.mockResolvedValue(designRecord());
+    mocks.writeCommunityDesignBlob.mockResolvedValue('https://blob.example/design.json');
+    mocks.writeCommunityCard.mockResolvedValue(undefined);
+    mocks.removeFromCommunityIndexes.mockResolvedValue(undefined);
+    mocks.deleteCommunityDesignBlob.mockResolvedValue(undefined);
+    mocks.put.mockImplementation((path: unknown) =>
+      Promise.resolve({ url: `https://blob.example/${String(path)}` })
+    );
+    mocks.del.mockResolvedValue(undefined);
+    mocks.validateCommunityPublish.mockReturnValue({ valid: true, payload: publishPayload() });
+  });
+
+  afterEach(() => {
+    delete process.env.COMMUNITY_ADMIN_TOKEN;
+    delete process.env.COMMUNITY_PUBLISH_ENABLED;
+    delete process.env.TOKEN_SALT;
+  });
+
+  describe('routing', () => {
+    it('rejects an invalid design id', async () => {
+      const res = await handle('GET', { id: 'not-a-valid-id!' });
+      expect(res._status).toBe(400);
+      expect((res._body as { code: string }).code).toBe('VALIDATION_ERROR');
+    });
+
+    it('rejects unsupported methods', async () => {
+      const res = await handle('POST');
+      expect(res._status).toBe(405);
+    });
+  });
+
+  describe('GET', () => {
+    it('returns the full record for a live design', async () => {
+      const res = await handle('GET');
+      expect(res._status).toBe(200);
+      const body = res._body as { design: CommunityDesignRecord };
+      expect(body.design.id).toBe(VALID_ID);
+      expect(body.design.params).toEqual({ width: 2, depth: 3, height: 6, gridUnitMm: 42 });
+    });
+
+    it('returns 404 when the design does not exist', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(null);
+      const res = await handle('GET');
+      expect(res._status).toBe(404);
+      expect(res._body).toEqual({ error: 'Design not found', code: 'NOT_FOUND' });
+    });
+
+    it('makes a hidden design indistinguishable from not-found for a stranger', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'hidden' }));
+      const hiddenRes = await handle('GET');
+
+      mocks.readCommunityDesignBlob.mockResolvedValue(null);
+      const missingRes = await handle('GET');
+
+      expect(hiddenRes._status).toBe(404);
+      expect(hiddenRes._status).toBe(missingRes._status);
+      expect(hiddenRes._body).toEqual(missingRes._body);
+    });
+
+    it('hides a hidden design from a signed-in non-owner', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'hidden' }));
+      mocks.readSessionCookie.mockReturnValue('session-token');
+      mocks.readSession.mockResolvedValue(session);
+      redis.sismember.mockResolvedValue(0);
+      const res = await handle('GET');
+      expect(res._status).toBe(404);
+    });
+
+    it('returns a hidden design to its owner', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'hidden' }));
+      mocks.readSessionCookie.mockReturnValue('session-token');
+      mocks.readSession.mockResolvedValue(session);
+      redis.sismember.mockResolvedValue(1);
+      const res = await handle('GET');
+      expect(res._status).toBe(200);
+      expect((res._body as { design: CommunityDesignRecord }).design.status).toBe('hidden');
+      expect(redis.sismember).toHaveBeenCalledWith(communityPublishedKey(USER_ID), VALID_ID);
+    });
+
+    it('rate limits by client IP', async () => {
+      mocks.checkRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 30 });
+      const res = await handle('GET');
+      expect(res._status).toBe(429);
+      expect(mocks.checkRateLimit).toHaveBeenCalledWith('203.0.113.1', 'community.read');
+    });
+
+    it('hides a design whose card hash says hidden even when the blob still says live', async () => {
+      // Moderation flips (setCommunityDesignStatus) write the card hash only,
+      // so the blob keeps its publish-time 'live'. The gate must trust the hash.
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'live' }));
+      redis.hget.mockResolvedValue('hidden');
+      const res = await handle('GET');
+      expect(res._status).toBe(404);
+      expect(redis.hget).toHaveBeenCalledWith(communityDesignKey(VALID_ID), 'status');
+    });
+
+    it('serves the hash-derived status to the owner of a card-hidden design', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'live' }));
+      redis.hget.mockResolvedValue('hidden');
+      mocks.readSessionCookie.mockReturnValue('session-token');
+      mocks.readSession.mockResolvedValue(session);
+      redis.sismember.mockResolvedValue(1);
+      const res = await handle('GET');
+      expect(res._status).toBe(200);
+      expect((res._body as { design: CommunityDesignRecord }).design.status).toBe('hidden');
+    });
+
+    it('degrades to a clean 500 when the record read throws (e.g. TOKEN_SALT unset)', async () => {
+      mocks.readCommunityDesignBlob.mockRejectedValue(
+        new Error('TOKEN_SALT is required to derive community blob paths')
+      );
+      const res = await handle('GET');
+      expect(res._status).toBe(500);
+      expect((res._body as { code: string }).code).toBe('SERVER_ERROR');
+    });
+  });
+
+  describe('PUT', () => {
+    it('returns 503 when the publish kill switch is off, before touching the session', async () => {
+      delete process.env.COMMUNITY_PUBLISH_ENABLED;
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(503);
+      expect(mocks.requireSession).not.toHaveBeenCalled();
+      expect(mocks.put).not.toHaveBeenCalled();
+      expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+    });
+
+    it('returns a neutral 403 for a deny-listed user without writing anything', async () => {
+      redis.sismember.mockImplementation((key: unknown) =>
+        key === communityDenylistKey() ? 1 : 0
+      );
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(403);
+      expect((res._body as { error: string }).error.toLowerCase()).not.toContain('deny');
+      expect(mocks.put).not.toHaveBeenCalled();
+      expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+    });
+
+    it('rejects a caller whose published set does not contain the id', async () => {
+      redis.sismember.mockResolvedValue(0);
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(404);
+      expect(redis.sismember).toHaveBeenCalledWith(communityPublishedKey(USER_ID), VALID_ID);
+      expect(mocks.put).not.toHaveBeenCalled();
+      expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+    });
+
+    it('requires a session', async () => {
+      mocks.requireSession.mockImplementation((_req: VercelRequest, res: VercelResponse) => {
+        res.status(401).json({ error: 'Not signed in', code: 'UNAUTHORIZED' });
+        return Promise.resolve(null);
+      });
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(401);
+      expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+    });
+
+    it('passes validation failures through as 400', async () => {
+      mocks.validateCommunityPublish.mockReturnValue({
+        valid: false,
+        error: { code: 'INVALID_NAME', message: 'name must be 1-60 characters' },
+      });
+      const res = await handle('PUT', { body: { name: '' } });
+      expect(res._status).toBe(400);
+      expect(res._body).toEqual({ error: 'name must be 1-60 characters', code: 'INVALID_NAME' });
+    });
+
+    it('rejects updates to a hidden design without uploading new assets', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'hidden' }));
+      const res = await handle('PUT', { body: { ...publishPayload(), status: 'live' } });
+      expect(res._status).toBe(403);
+      expect(mocks.put).not.toHaveBeenCalled();
+      expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+      expect(mocks.writeCommunityCard).not.toHaveBeenCalled();
+    });
+
+    it('rejects updates to a removed design', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'removed' }));
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(403);
+      expect(mocks.put).not.toHaveBeenCalled();
+    });
+
+    it('rejects updates when the card hash says hidden even though the blob says live', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'live' }));
+      redis.hget.mockResolvedValue('hidden');
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(403);
+      expect(mocks.put).not.toHaveBeenCalled();
+      expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+    });
+
+    it('consumes the manage budget, not the publish budget, and never consults quota', async () => {
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(200);
+      expect(mocks.checkRateLimit).toHaveBeenCalledWith(USER_ID, 'community.manage');
+      // A user at the live-design cap must still be able to edit: updates
+      // never grow the published set, so quota must stay out of this path.
+      expect(mocks.checkCommunityPublishQuota).not.toHaveBeenCalled();
+    });
+
+    it('degrades to a clean 500 when the record read throws (e.g. TOKEN_SALT unset)', async () => {
+      mocks.readCommunityDesignBlob.mockRejectedValue(
+        new Error('TOKEN_SALT is required to derive community blob paths')
+      );
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(500);
+      expect((res._body as { code: string }).code).toBe('SERVER_ERROR');
+    });
+
+    it('rewrites assets under a bumped rev and deletes the replaced ones', async () => {
+      const existing = designRecord();
+      mocks.readCommunityDesignBlob.mockResolvedValue(existing);
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(200);
+
+      const putPaths = mocks.put.mock.calls.map((call) => call[0] as string);
+      expect(putPaths).toEqual([
+        communityThumbBlobPath(VALID_ID, 4, 0),
+        communityThumbBlobPath(VALID_ID, 4, 1),
+        communityMeshBlobPath(VALID_ID, 4),
+      ]);
+
+      const design = (res._body as { design: CommunityDesignRecord }).design;
+      expect(design.meshUrl).toBe(`https://blob.example/${communityMeshBlobPath(VALID_ID, 4)}`);
+      expect(design.thumbnails).toEqual([
+        `https://blob.example/${communityThumbBlobPath(VALID_ID, 4, 0)}`,
+        `https://blob.example/${communityThumbBlobPath(VALID_ID, 4, 1)}`,
+      ]);
+
+      expect(mocks.del).toHaveBeenCalledWith([...existing.thumbnails, existing.meshUrl]);
+      expect(mocks.writeCommunityDesignBlob).toHaveBeenCalledWith(design, {
+        allowOverwrite: true,
+      });
+    });
+
+    it('preserves identity and lineage while updating content in place', async () => {
+      const lineage = {
+        parentId: PARENT_ID,
+        rootId: PARENT_ID,
+        parentName: 'Parent bin',
+        parentAuthorName: 'Ada',
+        rootAuthorName: 'Ada',
+      };
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ lineage, featured: true }));
+      const res = await handle('PUT', { body: publishPayload() });
+      const design = (res._body as { design: CommunityDesignRecord }).design;
+      expect(design.id).toBe(VALID_ID);
+      expect(design.authorPublicId).toBe('author-public-id');
+      expect(design.lineage).toEqual(lineage);
+      expect(design.featured).toBe(true);
+      expect(design.createdAt).toBe(1000);
+      expect(design.updatedAt).toBeGreaterThan(1000);
+      expect(design.name).toBe('Updated bin');
+      // Millimetres, exactly like publish: 4u x 42 - 0.5, 2u x 42 - 0.5, 9u x 7.
+      expect(design.metrics).toEqual({ width: 167.5, depth: 83.5, height: 63, gridUnitMm: 42 });
+    });
+
+    it('refreshes the publish-idempotency content hash', async () => {
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(200);
+      const hsetCalls = redis.hset.mock.calls as Array<[string, Record<string, string>]>;
+      const hashCall = hsetCalls.find(([, fields]) => fields.contentHash !== undefined);
+      expect(hashCall?.[0]).toBe(communityDesignKey(VALID_ID));
+      expect(hashCall?.[1].contentHash).toMatch(/^[a-f0-9]{32}$/);
+    });
+
+    it('deletes every orphaned thumbnail when the update ships fewer of them', async () => {
+      const existing = designRecord({
+        thumbnails: [
+          `https://blob.example/community/thumbs/${VALID_ID}-3-0.webp`,
+          `https://blob.example/community/thumbs/${VALID_ID}-3-1.webp`,
+          `https://blob.example/community/thumbs/${VALID_ID}-3-2.webp`,
+        ],
+      });
+      mocks.readCommunityDesignBlob.mockResolvedValue(existing);
+      mocks.validateCommunityPublish.mockReturnValue({
+        valid: true,
+        payload: publishPayload({ thumbnails: ['dGh1bWItMA=='] }),
+      });
+
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(200);
+      expect(mocks.del).toHaveBeenCalledWith([...existing.thumbnails, existing.meshUrl]);
+    });
+
+    it('still returns the updated record when stale-asset cleanup fails', async () => {
+      mocks.del.mockRejectedValue(new Error('blob store flaked'));
+      const res = await handle('PUT', { body: publishPayload() });
+      expect(res._status).toBe(200);
+      expect((res._body as { design: CommunityDesignRecord }).design.name).toBe('Updated bin');
+    });
+  });
+
+  describe('DELETE', () => {
+    it('owner unpublish cleans blobs and every Redis membership', async () => {
+      const record = designRecord({
+        lineage: {
+          parentId: PARENT_ID,
+          rootId: PARENT_ID,
+          parentName: 'Parent bin',
+          parentAuthorName: 'Ada',
+          rootAuthorName: 'Ada',
+        },
+      });
+      mocks.readCommunityDesignBlob.mockResolvedValue(record);
+      redis.smembers.mockResolvedValue(['liker-1', 'liker-2']);
+
+      const res = await handle('DELETE');
+      expect(res._status).toBe(200);
+      expect(res._body).toEqual({ success: true });
+
+      expect(mocks.del).toHaveBeenCalledWith([...record.thumbnails, record.meshUrl]);
+      expect(mocks.deleteCommunityDesignBlob).toHaveBeenCalledWith(VALID_ID);
+      expect(mocks.removeFromCommunityIndexes).toHaveBeenCalledWith(redis, VALID_ID);
+      expect(pipeline.del).toHaveBeenCalledWith(
+        communityDesignKey(VALID_ID),
+        communityLikesKey(VALID_ID),
+        communityReportsKey(VALID_ID),
+        communityChildrenKey(VALID_ID)
+      );
+      const sremCalls = pipeline.srem.mock.calls;
+      expect(sremCalls).toContainEqual([communityAuthorKey('author-public-id'), VALID_ID]);
+      expect(sremCalls).toContainEqual([communityPublishedKey(USER_ID), VALID_ID]);
+      expect(sremCalls).toContainEqual([communityChildrenKey(PARENT_ID), VALID_ID]);
+      expect(sremCalls).toContainEqual([communityLikedKey('liker-1'), VALID_ID]);
+      expect(sremCalls).toContainEqual([communityLikedKey('liker-2'), VALID_ID]);
+    });
+
+    it('rejects a caller whose published set does not contain the id', async () => {
+      redis.sismember.mockResolvedValue(0);
+      const res = await handle('DELETE');
+      expect(res._status).toBe(404);
+      expect(mocks.del).not.toHaveBeenCalled();
+      expect(mocks.deleteCommunityDesignBlob).not.toHaveBeenCalled();
+      expect(pipeline.exec).not.toHaveBeenCalled();
+    });
+
+    it('admin token purges without a session and without a published-set entry', async () => {
+      process.env.COMMUNITY_ADMIN_TOKEN = 'admin-secret';
+      const res = await handle('DELETE', { headers: { 'x-admin-token': 'admin-secret' } });
+      expect(res._status).toBe(200);
+      expect(mocks.requireSession).not.toHaveBeenCalled();
+      expect(mocks.deleteCommunityDesignBlob).toHaveBeenCalledWith(VALID_ID);
+      const sremKeys = pipeline.srem.mock.calls.map((call) => call[0] as string);
+      expect(sremKeys.some((key) => key.startsWith('community:published:'))).toBe(false);
+    });
+
+    it('rejects a wrong admin token without deleting anything', async () => {
+      process.env.COMMUNITY_ADMIN_TOKEN = 'admin-secret';
+      const res = await handle('DELETE', { headers: { 'x-admin-token': 'wrong-secret' } });
+      expect(res._status).toBe(401);
+      expect(mocks.requireSession).not.toHaveBeenCalled();
+      expect(mocks.del).not.toHaveBeenCalled();
+      expect(mocks.deleteCommunityDesignBlob).not.toHaveBeenCalled();
+      expect(pipeline.exec).not.toHaveBeenCalled();
+    });
+
+    it('falls back to owner authorization when COMMUNITY_ADMIN_TOKEN is unset', async () => {
+      const res = await handle('DELETE', { headers: { 'x-admin-token': 'anything' } });
+      expect(res._status).toBe(200);
+      expect(mocks.requireSession).toHaveBeenCalledTimes(1);
+      const sremCalls = pipeline.srem.mock.calls;
+      expect(sremCalls).toContainEqual([communityPublishedKey(USER_ID), VALID_ID]);
+    });
+
+    it('uses owner authorization when the admin token is configured but no header is sent', async () => {
+      process.env.COMMUNITY_ADMIN_TOKEN = 'admin-secret';
+      const res = await handle('DELETE');
+      expect(res._status).toBe(200);
+      expect(mocks.requireSession).toHaveBeenCalledTimes(1);
+      const sremCalls = pipeline.srem.mock.calls;
+      expect(sremCalls).toContainEqual([communityPublishedKey(USER_ID), VALID_ID]);
+    });
+
+    it('rate limits owner deletes on the manage budget, not the publish budget', async () => {
+      const res = await handle('DELETE');
+      expect(res._status).toBe(200);
+      expect(mocks.checkRateLimit).toHaveBeenCalledWith(USER_ID, 'community.manage');
+    });
+
+    it('rate limits admin purges per IP on the manage budget', async () => {
+      process.env.COMMUNITY_ADMIN_TOKEN = 'admin-secret';
+      const res = await handle('DELETE', { headers: { 'x-admin-token': 'admin-secret' } });
+      expect(res._status).toBe(200);
+      expect(mocks.checkRateLimit).toHaveBeenCalledWith('203.0.113.1', 'community.manage');
+    });
+
+    it('degrades to a clean 500 when the record read throws (e.g. TOKEN_SALT unset)', async () => {
+      mocks.readCommunityDesignBlob.mockRejectedValue(
+        new Error('TOKEN_SALT is required to derive community blob paths')
+      );
+      const res = await handle('DELETE');
+      expect(res._status).toBe(500);
+      expect((res._body as { code: string }).code).toBe('SERVER_ERROR');
+    });
+
+    it('returns 404 when neither the record nor its card hash exists', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(null);
+      redis.hgetall.mockResolvedValue({});
+      const res = await handle('DELETE');
+      expect(res._status).toBe(404);
+      expect(pipeline.exec).not.toHaveBeenCalled();
+    });
+
+    it('finishes cleaning Redis state when only the card hash remains', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(null);
+      redis.hgetall.mockResolvedValue({ id: VALID_ID, authorPublicId: 'author-public-id' });
+      const res = await handle('DELETE');
+      expect(res._status).toBe(200);
+      expect(mocks.del).not.toHaveBeenCalled();
+      expect(mocks.deleteCommunityDesignBlob).not.toHaveBeenCalled();
+      const sremCalls = pipeline.srem.mock.calls;
+      expect(sremCalls).toContainEqual([communityAuthorKey('author-public-id'), VALID_ID]);
+      expect(sremCalls).toContainEqual([communityPublishedKey(USER_ID), VALID_ID]);
+    });
+  });
+});

--- a/api/community/[id].test.ts
+++ b/api/community/[id].test.ts
@@ -636,5 +636,20 @@ describe('community/[id]', () => {
       expect(sremCalls).toContainEqual([communityAuthorKey('author-public-id'), VALID_ID]);
       expect(sremCalls).toContainEqual([communityPublishedKey(USER_ID), VALID_ID]);
     });
+
+    it('removes the child from its parent children set on a card-hash-only retry', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(null);
+      redis.hgetall.mockResolvedValue({
+        id: VALID_ID,
+        authorPublicId: 'author-public-id',
+        parentId: 'parentabc123',
+      });
+      const res = await handle('DELETE');
+      expect(res._status).toBe(200);
+      expect(pipeline.srem.mock.calls).toContainEqual([
+        communityChildrenKey('parentabc123'),
+        VALID_ID,
+      ]);
+    });
   });
 });

--- a/api/community/[id].test.ts
+++ b/api/community/[id].test.ts
@@ -128,7 +128,7 @@ function createRedis(): { redis: FakeRedis; pipeline: FakePipeline } {
   const redis: FakeRedis = {
     sismember: vi.fn(async (key: string) => (key === communityDenylistKey() ? 0 : 1)),
     smembers: vi.fn(async () => [] as string[]),
-    hget: vi.fn(async () => null),
+    hget: vi.fn(async (_key: string, field: string) => (field === 'status' ? 'live' : null)),
     hgetall: vi.fn(async (): Promise<Record<string, string>> => ({})),
     hset: vi.fn(async () => 1),
     pipeline: vi.fn(() => pipeline),
@@ -268,6 +268,7 @@ describe('community/[id]', () => {
     });
 
     it('makes a hidden design indistinguishable from not-found for a stranger', async () => {
+      redis.hget.mockResolvedValue('hidden');
       mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'hidden' }));
       const hiddenRes = await handle('GET');
 
@@ -280,6 +281,7 @@ describe('community/[id]', () => {
     });
 
     it('hides a hidden design from a signed-in non-owner', async () => {
+      redis.hget.mockResolvedValue('hidden');
       mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'hidden' }));
       mocks.readSessionCookie.mockReturnValue('session-token');
       mocks.readSession.mockResolvedValue(session);
@@ -289,6 +291,7 @@ describe('community/[id]', () => {
     });
 
     it('returns a hidden design to its owner', async () => {
+      redis.hget.mockResolvedValue('hidden');
       mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'hidden' }));
       mocks.readSessionCookie.mockReturnValue('session-token');
       mocks.readSession.mockResolvedValue(session);
@@ -314,6 +317,13 @@ describe('community/[id]', () => {
       const res = await handle('GET');
       expect(res._status).toBe(404);
       expect(redis.hget).toHaveBeenCalledWith(communityDesignKey(VALID_ID), 'status');
+    });
+
+    it('fails closed to hidden when the card hash has no readable status', async () => {
+      mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'live' }));
+      redis.hget.mockResolvedValue(null);
+      const res = await handle('GET');
+      expect(res._status).toBe(404);
     });
 
     it('serves the hash-derived status to the owner of a card-hidden design', async () => {
@@ -388,6 +398,7 @@ describe('community/[id]', () => {
     });
 
     it('rejects updates to a hidden design without uploading new assets', async () => {
+      redis.hget.mockResolvedValue('hidden');
       mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'hidden' }));
       const res = await handle('PUT', { body: { ...publishPayload(), status: 'live' } });
       expect(res._status).toBe(403);
@@ -397,6 +408,7 @@ describe('community/[id]', () => {
     });
 
     it('rejects updates to a removed design', async () => {
+      redis.hget.mockResolvedValue('removed');
       mocks.readCommunityDesignBlob.mockResolvedValue(designRecord({ status: 'removed' }));
       const res = await handle('PUT', { body: publishPayload() });
       expect(res._status).toBe(403);

--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -99,17 +99,20 @@ async function isPublishedBy(userId: string, designId: string): Promise<boolean>
 /**
  * Moderation flips (admin hide/restore, denylist sweeps) write status to the
  * Redis card hash only; the record blob keeps its publish-time 'live'. The
- * hash is therefore the source of truth for every moderation gate, with the
- * blob's own status as the fallback when the hash is unreadable.
+ * hash is therefore the source of truth for every moderation gate. When the
+ * hash is unreadable a blob-live design fails closed to 'hidden' so a lost
+ * or corrupt hash can never resurrect a moderated design; a blob status of
+ * 'hidden'/'removed' is already restrictive and is kept as-is.
  */
 async function readModerationStatus(
   id: string,
   fallback: CommunityDesignStatus
 ): Promise<CommunityDesignStatus> {
+  const failClosed: CommunityDesignStatus = fallback === 'live' ? 'hidden' : fallback;
   const redis = getRedis();
-  if (!redis) return fallback;
+  if (!redis) return failClosed;
   const status = await redis.hget(communityDesignKey(id), 'status');
-  return status === 'live' || status === 'hidden' || status === 'removed' ? status : fallback;
+  return status === 'live' || status === 'hidden' || status === 'removed' ? status : failClosed;
 }
 
 async function handleGet(req: VercelRequest, res: VercelResponse, id: string) {

--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -1,0 +1,440 @@
+import { del, put } from '@vercel/blob';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { readSessionCookie } from '../lib/cookies.js';
+import {
+  communityAuthorKey,
+  communityChildrenKey,
+  communityDenylistKey,
+  communityDesignKey,
+  communityLikedKey,
+  communityLikesKey,
+  communityPublishedKey,
+  communityReportsKey,
+} from '../lib/redisKeys.js';
+import { checkRateLimit, getClientIP, getRedis } from '../lib/rateLimit.js';
+import { readSession, requireSession } from '../lib/session.js';
+import type { SessionRecord } from '../lib/session.js';
+import { logger } from '../lib/logger.js';
+import {
+  ErrorCode,
+  methodNotAllowed,
+  rateLimited,
+  serviceUnavailable,
+  timingSafeCompare,
+} from '../lib/shared.js';
+import {
+  communityContentHash,
+  communityMeshBlobPath,
+  communityThumbBlobPath,
+  deleteCommunityDesignBlob,
+  deriveCommunityMetrics,
+  readCommunityDesignBlob,
+  removeFromCommunityIndexes,
+  writeCommunityCard,
+  writeCommunityDesignBlob,
+} from '../lib/communityStore.js';
+import type { CommunityDesignRecord, CommunityDesignStatus } from '../lib/communityStore.js';
+import { validateCommunityPublish } from '../lib/communityValidation.js';
+
+const COMMUNITY_DESIGN_ID_REGEX = /^[a-zA-Z0-9]{12}$/;
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const { id } = req.query;
+
+  if (typeof id !== 'string' || !COMMUNITY_DESIGN_ID_REGEX.test(id)) {
+    return res.status(400).json({
+      error: 'Invalid design ID',
+      code: ErrorCode.VALIDATION_ERROR,
+    });
+  }
+
+  switch (req.method) {
+    case 'OPTIONS':
+      return res.status(200).end();
+    case 'GET':
+      return handleGet(req, res, id);
+    case 'PUT':
+      return handlePut(req, res, id);
+    case 'DELETE':
+      return handleDelete(req, res, id);
+    default:
+      return methodNotAllowed(res, 'GET, PUT, DELETE');
+  }
+}
+
+function designNotFound(res: VercelResponse) {
+  return res.status(404).json({
+    error: 'Design not found',
+    code: ErrorCode.NOT_FOUND,
+  });
+}
+
+/**
+ * Resolve the caller's session without sending any response. GET is a public
+ * surface: an absent, expired, or unreadable session must degrade to the
+ * anonymous view, never 401.
+ */
+async function readOptionalSession(req: VercelRequest): Promise<SessionRecord | null> {
+  const token = readSessionCookie(req);
+  if (!token) return null;
+  const redis = getRedis();
+  if (!redis) return null;
+  try {
+    return await readSession(redis, token);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ownership is always the server-side published set keyed by the session's
+ * userId. A client-sent publishedId is never consulted.
+ */
+async function isPublishedBy(userId: string, designId: string): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  return (await redis.sismember(communityPublishedKey(userId), designId)) === 1;
+}
+
+/**
+ * Moderation flips (admin hide/restore, denylist sweeps) write status to the
+ * Redis card hash only; the record blob keeps its publish-time 'live'. The
+ * hash is therefore the source of truth for every moderation gate, with the
+ * blob's own status as the fallback when the hash is unreadable.
+ */
+async function readModerationStatus(
+  id: string,
+  fallback: CommunityDesignStatus
+): Promise<CommunityDesignStatus> {
+  const redis = getRedis();
+  if (!redis) return fallback;
+  const status = await redis.hget(communityDesignKey(id), 'status');
+  return status === 'live' || status === 'hidden' || status === 'removed' ? status : fallback;
+}
+
+async function handleGet(req: VercelRequest, res: VercelResponse, id: string) {
+  try {
+    const clientIP = getClientIP(req);
+    const rateLimit = await checkRateLimit(clientIP, 'community.read');
+    if (!rateLimit.allowed) {
+      return rateLimited(res, rateLimit.retryAfterSeconds);
+    }
+
+    const record = await readCommunityDesignBlob(id);
+    if (!record) {
+      return designNotFound(res);
+    }
+
+    const status = await readModerationStatus(id, record.status);
+    if (status !== 'live') {
+      // Hidden/removed designs must be indistinguishable from missing ones
+      // for everyone but their owner, so a takedown can't be probed.
+      const session = await readOptionalSession(req);
+      const owns = session !== null && (await isPublishedBy(session.userId, id));
+      if (!owns) {
+        return designNotFound(res);
+      }
+    }
+
+    return res.status(200).json({ design: { ...record, status } });
+  } catch (error) {
+    logger.error('Community design fetch error', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return res.status(500).json({
+      error: 'Failed to fetch design',
+      code: ErrorCode.SERVER_ERROR,
+    });
+  }
+}
+
+/**
+ * The revision lives only in the asset paths, so the next revision is parsed
+ * back out of the stored mesh URL. An unparseable legacy URL falls back to a
+ * timestamp, which still yields a fresh immutably-cacheable path.
+ */
+function nextAssetRev(meshUrl: string): number {
+  try {
+    const match = /-(\d+)\.glb$/.exec(new URL(meshUrl).pathname);
+    if (match) return Number(match[1]) + 1;
+  } catch {
+    // fall through to the timestamp fallback
+  }
+  return Date.now();
+}
+
+async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
+  try {
+    if (process.env.COMMUNITY_PUBLISH_ENABLED !== 'true') {
+      return serviceUnavailable(res, 'Community publishing is not available.');
+    }
+
+    const session = await requireSession(req, res);
+    if (!session) return;
+
+    const rateLimit = await checkRateLimit(session.userId, 'community.manage');
+    if (!rateLimit.allowed) {
+      return rateLimited(res, rateLimit.retryAfterSeconds, 'Too many updates. Try again later.');
+    }
+
+    const redis = getRedis();
+    if (!redis) {
+      return serviceUnavailable(res);
+    }
+
+    const denied = await redis.sismember(communityDenylistKey(), session.userId);
+    if (denied === 1) {
+      // Deliberately neutral: the response must not reveal deny-listing.
+      return res.status(403).json({
+        error: 'Publishing is not available for this account.',
+        code: ErrorCode.UNAUTHORIZED,
+      });
+    }
+
+    const owns = (await redis.sismember(communityPublishedKey(session.userId), id)) === 1;
+    if (!owns) {
+      return designNotFound(res);
+    }
+
+    const result = validateCommunityPublish(req.body);
+    if (!result.valid) {
+      return res.status(400).json({
+        error: result.error.message,
+        code: result.error.code,
+      });
+    }
+    const payload = result.payload;
+
+    const existing = await readCommunityDesignBlob(id);
+    if (!existing) {
+      return designNotFound(res);
+    }
+
+    // A moderated design must not keep accepting fresh public assets: an
+    // update to a hidden/removed design would upload new blobs to the CDN
+    // even though the design itself is off the gallery.
+    const status = await readModerationStatus(id, existing.status);
+    if (status !== 'live') {
+      return res.status(403).json({
+        error: 'This design cannot be updated.',
+        code: ErrorCode.UNAUTHORIZED,
+      });
+    }
+
+    // allowOverwrite because the rev derives from the stored record: a retry
+    // after a partial failure recomputes the same rev and must be able to
+    // rewrite its own half-written assets.
+    const rev = nextAssetRev(existing.meshUrl);
+    const thumbnailUrls: string[] = [];
+    for (let i = 0; i < payload.thumbnails.length; i++) {
+      const thumb = await put(
+        communityThumbBlobPath(id, rev, i),
+        Buffer.from(payload.thumbnails[i], 'base64'),
+        {
+          access: 'public',
+          contentType: 'image/webp',
+          addRandomSuffix: false,
+          allowOverwrite: true,
+        }
+      );
+      thumbnailUrls.push(thumb.url);
+    }
+    const mesh = await put(communityMeshBlobPath(id, rev), Buffer.from(payload.glb, 'base64'), {
+      access: 'public',
+      contentType: 'model/gltf-binary',
+      addRandomSuffix: false,
+      allowOverwrite: true,
+    });
+
+    // Update in place: id, author identity, lineage, createdAt, featured, and
+    // moderation status all survive the rewrite. Status in particular is
+    // never client-writable.
+    const updated: CommunityDesignRecord = {
+      ...existing,
+      name: payload.name,
+      description: payload.description,
+      authorName: payload.authorName,
+      category: payload.category,
+      techniques: payload.techniques,
+      params: payload.params,
+      metrics: deriveCommunityMetrics(payload.params),
+      thumbnails: thumbnailUrls,
+      meshUrl: mesh.url,
+      updatedAt: Date.now(),
+    };
+
+    await writeCommunityDesignBlob(updated, { allowOverwrite: true });
+    await writeCommunityCard(redis, {
+      id,
+      name: updated.name,
+      authorPublicId: updated.authorPublicId,
+      authorName: updated.authorName,
+      category: updated.category,
+      techniques: updated.techniques,
+      width: updated.metrics.width,
+      depth: updated.metrics.depth,
+      height: updated.metrics.height,
+      gridUnitMm: updated.metrics.gridUnitMm,
+      thumbnailUrl: thumbnailUrls.length > 0 ? thumbnailUrls[0] : '',
+      isRemix: updated.lineage !== null,
+      featured: updated.featured,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt,
+      status: updated.status,
+    });
+
+    // Publish idempotency keys on this hash; without the refresh a retried
+    // POST of the pre-edit content would 200 against this id and a POST of
+    // the edited content would mint a duplicate design.
+    await redis.hset(communityDesignKey(id), {
+      contentHash: communityContentHash({
+        params: payload.params,
+        name: payload.name,
+        description: payload.description,
+        category: payload.category,
+      }),
+    });
+
+    // Replaced-asset cleanup is best-effort: the record already points at the
+    // new rev, so a failed delete only strands unreferenced blobs.
+    const staleAssets = [...existing.thumbnails, existing.meshUrl].filter(
+      (url) => url !== '' && url !== updated.meshUrl && !updated.thumbnails.includes(url)
+    );
+    if (staleAssets.length > 0) {
+      await del(staleAssets).catch((delErr: unknown) => {
+        logger.warn('Failed to delete replaced community assets', {
+          id,
+          error: delErr instanceof Error ? delErr.message : String(delErr),
+        });
+      });
+    }
+
+    return res.status(200).json({ design: updated });
+  } catch (error) {
+    logger.error('Community design update error', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return res.status(500).json({
+      error: 'Failed to update design',
+      code: ErrorCode.SERVER_ERROR,
+    });
+  }
+}
+
+async function handleDelete(req: VercelRequest, res: VercelResponse, id: string) {
+  try {
+    const adminHeader = req.headers['x-admin-token'];
+    const adminToken = Array.isArray(adminHeader) ? adminHeader[0] : adminHeader;
+    const expectedAdminToken = process.env.COMMUNITY_ADMIN_TOKEN;
+    const adminPathEnabled = expectedAdminToken !== undefined && expectedAdminToken !== '';
+
+    let ownerUserId: string | null = null;
+    if (adminToken !== undefined && adminPathEnabled) {
+      const clientIP = getClientIP(req);
+      const rateLimit = await checkRateLimit(clientIP, 'community.manage');
+      if (!rateLimit.allowed) {
+        return rateLimited(res, rateLimit.retryAfterSeconds);
+      }
+      if (!timingSafeCompare(adminToken, expectedAdminToken)) {
+        return res.status(401).json({
+          error: 'Invalid admin token',
+          code: ErrorCode.UNAUTHORIZED,
+        });
+      }
+    } else {
+      // With COMMUNITY_ADMIN_TOKEN unset the admin path is disabled outright;
+      // a supplied header falls through to owner authorization.
+      const session = await requireSession(req, res);
+      if (!session) return;
+      const rateLimit = await checkRateLimit(session.userId, 'community.manage');
+      if (!rateLimit.allowed) {
+        return rateLimited(res, rateLimit.retryAfterSeconds);
+      }
+      ownerUserId = session.userId;
+    }
+
+    const redis = getRedis();
+    if (!redis) {
+      // Cleanup spans blob and Redis; deleting only the blob would strand
+      // index entries pointing at a missing record, so fail closed.
+      return serviceUnavailable(res);
+    }
+
+    const record = await readCommunityDesignBlob(id);
+    // A retried delete whose blob removal already succeeded still has Redis
+    // state to clean; the card hash stands in for the missing record.
+    const cardFields = record ? null : await redis.hgetall(communityDesignKey(id));
+    if (!record && (cardFields === null || Object.keys(cardFields).length === 0)) {
+      return designNotFound(res);
+    }
+
+    if (ownerUserId !== null) {
+      const owns = (await redis.sismember(communityPublishedKey(ownerUserId), id)) === 1;
+      if (!owns) {
+        return designNotFound(res);
+      }
+    }
+
+    const authorPublicId = record?.authorPublicId ?? cardFields?.authorPublicId ?? '';
+    const parentId = record?.lineage?.parentId;
+
+    // Blobs before Redis, assets before the record JSON: any failure leaves
+    // enough state (record blob, then card hash) for a retry to find and
+    // finish the cleanup instead of stranding public CDN content.
+    if (record) {
+      const assetUrls = [...record.thumbnails, record.meshUrl].filter((url) => url !== '');
+      if (assetUrls.length > 0) {
+        await del(assetUrls);
+      }
+      await deleteCommunityDesignBlob(id);
+    }
+
+    const likers = await redis.smembers(communityLikesKey(id));
+    await removeFromCommunityIndexes(redis, id);
+
+    const pipeline = redis.pipeline();
+    pipeline.del(
+      communityDesignKey(id),
+      communityLikesKey(id),
+      communityReportsKey(id),
+      communityChildrenKey(id)
+    );
+    if (authorPublicId !== '') {
+      pipeline.srem(communityAuthorKey(authorPublicId), id);
+    }
+    // Admin purge cannot clear the owner's community:published slot: the
+    // record only carries the one-way authorPublicId hash, never the userId.
+    // The admin CLI reclaims that slot out of band.
+    if (ownerUserId !== null) {
+      pipeline.srem(communityPublishedKey(ownerUserId), id);
+    }
+    // Children keep their lineage snapshots; only the parent's membership
+    // link to this design is dropped.
+    if (parentId !== undefined) {
+      pipeline.srem(communityChildrenKey(parentId), id);
+    }
+    for (const liker of likers) {
+      pipeline.srem(communityLikedKey(liker), id);
+    }
+    const results = await pipeline.exec();
+    if (results === null) {
+      throw new Error('Community delete pipeline failed: redis connection lost');
+    }
+    for (const [pipelineError] of results) {
+      if (pipelineError) throw pipelineError;
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    logger.error('Community design delete error', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return res.status(500).json({
+      error: 'Failed to delete design',
+      code: ErrorCode.SERVER_ERROR,
+    });
+  }
+}

--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -278,6 +278,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
       gridUnitMm: updated.metrics.gridUnitMm,
       thumbnailUrl: thumbnailUrls.length > 0 ? thumbnailUrls[0] : '',
       isRemix: updated.lineage !== null,
+      parentId: updated.lineage?.parentId ?? '',
       featured: updated.featured,
       createdAt: updated.createdAt,
       updatedAt: updated.updatedAt,
@@ -378,7 +379,10 @@ async function handleDelete(req: VercelRequest, res: VercelResponse, id: string)
     }
 
     const authorPublicId = record?.authorPublicId ?? cardFields?.authorPublicId ?? '';
-    const parentId = record?.lineage?.parentId;
+    const cardParentId = cardFields?.parentId;
+    const parentId =
+      record?.lineage?.parentId ??
+      (cardParentId !== undefined && cardParentId !== '' ? cardParentId : undefined);
 
     // Blobs before Redis, assets before the record JSON: any failure leaves
     // enough state (record blob, then card hash) for a retry to find and

--- a/api/lib/communityIds.test.ts
+++ b/api/lib/communityIds.test.ts
@@ -1,0 +1,71 @@
+import { createHash } from 'node:crypto';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  COMMUNITY_DESIGN_ID_LENGTH,
+  deriveAuthorPublicId,
+  generateCommunityDesignId,
+} from './communityIds.js';
+import { isValidShareId } from './shared.js';
+
+describe('deriveAuthorPublicId', () => {
+  beforeEach(() => {
+    process.env.TOKEN_SALT = 'test-salt';
+  });
+
+  afterEach(() => {
+    delete process.env.TOKEN_SALT;
+  });
+
+  it('refuses to derive when TOKEN_SALT is unset', () => {
+    delete process.env.TOKEN_SALT;
+    expect(deriveAuthorPublicId('user-1')).toBeNull();
+  });
+
+  it('derives sha256(salt + ":community:" + userId) truncated to 32 hex chars', () => {
+    const expected = createHash('sha256')
+      .update('test-salt:community:user-1')
+      .digest('hex')
+      .slice(0, 32);
+    expect(deriveAuthorPublicId('user-1')).toBe(expected);
+  });
+
+  it('is stable for the same userId and distinct across userIds', () => {
+    expect(deriveAuthorPublicId('user-1')).toBe(deriveAuthorPublicId('user-1'));
+    expect(deriveAuthorPublicId('user-1')).not.toBe(deriveAuthorPublicId('user-2'));
+  });
+
+  it('changes with the salt', () => {
+    const first = deriveAuthorPublicId('user-1');
+    process.env.TOKEN_SALT = 'other-salt';
+    expect(deriveAuthorPublicId('user-1')).not.toBe(first);
+  });
+
+  it('is namespaced away from the Ko-fi donor derivation on identical input', () => {
+    const donorStyle = createHash('sha256')
+      .update('test-salt:kofi:user-1')
+      .digest('hex')
+      .slice(0, 32);
+    expect(deriveAuthorPublicId('user-1')).not.toBe(donorStyle);
+  });
+});
+
+describe('generateCommunityDesignId', () => {
+  it('produces 12-char alphanumeric ids', () => {
+    for (let i = 0; i < 50; i++) {
+      const id = generateCommunityDesignId();
+      expect(id).toMatch(/^[a-zA-Z0-9]{12}$/);
+      expect(id).toHaveLength(COMMUNITY_DESIGN_ID_LENGTH);
+    }
+  });
+
+  it('passes the existing share-id validation', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(isValidShareId(generateCommunityDesignId())).toBe(true);
+    }
+  });
+
+  it('does not repeat across a batch', () => {
+    const ids = new Set(Array.from({ length: 200 }, () => generateCommunityDesignId()));
+    expect(ids.size).toBe(200);
+  });
+});

--- a/api/lib/communityIds.ts
+++ b/api/lib/communityIds.ts
@@ -1,0 +1,44 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Derive a stable, pseudonymous public author id from a sync userId.
+ *
+ * PRIVACY: the userId never appears in public records, only this hash, so an
+ * author page URL or a design blob can't be joined back to a sync account.
+ *
+ * Same discipline as `deriveDonorId` in `supporters.ts`: the salt is
+ * load-bearing, not decoration: an unsalted SHA-256 of a userId would let
+ * anyone holding a userId confirm which community designs it published.
+ * Without TOKEN_SALT configured we refuse to derive an id at all (callers
+ * must reject the publish) rather than write a reversible digest. The
+ * `:community:` tag namespaces the hash input so the same salt used for other
+ * feature ids can't collide with this one on identical raw input.
+ */
+export function deriveAuthorPublicId(userId: string): string | null {
+  const salt = process.env.TOKEN_SALT;
+  if (!salt) return null;
+  return createHash('sha256').update(`${salt}:community:${userId}`).digest('hex').slice(0, 32);
+}
+
+const DESIGN_ID_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+export const COMMUNITY_DESIGN_ID_LENGTH = 12;
+
+/**
+ * Random 12-char alphanumeric design id, matching the legacy 12-char branch of
+ * `isValidShareId` so the existing id validation accepts community ids
+ * unchanged. Rejection sampling (62 does not divide 256) keeps the
+ * distribution uniform.
+ */
+export function generateCommunityDesignId(): string {
+  const limit = DESIGN_ID_ALPHABET.length * Math.floor(256 / DESIGN_ID_ALPHABET.length);
+  let out = '';
+  while (out.length < COMMUNITY_DESIGN_ID_LENGTH) {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    for (const byte of bytes) {
+      if (byte >= limit) continue;
+      out += DESIGN_ID_ALPHABET[byte % DESIGN_ID_ALPHABET.length];
+      if (out.length === COMMUNITY_DESIGN_ID_LENGTH) break;
+    }
+  }
+  return out;
+}

--- a/api/lib/communityQuota.test.ts
+++ b/api/lib/communityQuota.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Redis } from 'ioredis';
+import { checkCommunityPublishQuota, COMMUNITY_MAX_LIVE_DESIGNS } from './communityQuota.js';
+
+const scard = vi.fn();
+const redis = { scard } as unknown as Redis;
+
+describe('checkCommunityPublishQuota', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scard.mockResolvedValue(0);
+  });
+
+  it('allows a first publish', async () => {
+    const result = await checkCommunityPublishQuota(redis, 'user-1');
+    expect(result).toEqual({ ok: true });
+    expect(scard).toHaveBeenCalledWith('community:published:user-1');
+  });
+
+  it('allows publishing up to the cap', async () => {
+    scard.mockResolvedValue(COMMUNITY_MAX_LIVE_DESIGNS - 1);
+    expect((await checkCommunityPublishQuota(redis, 'user-1')).ok).toBe(true);
+  });
+
+  it('rejects a new publish at the cap', async () => {
+    scard.mockResolvedValue(COMMUNITY_MAX_LIVE_DESIGNS);
+    const result = await checkCommunityPublishQuota(redis, 'user-1');
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: 'QUOTA_EXCEEDED',
+        reason: 'count',
+        current: COMMUNITY_MAX_LIVE_DESIGNS + 1,
+        limit: COMMUNITY_MAX_LIVE_DESIGNS,
+      },
+    });
+  });
+});

--- a/api/lib/communityQuota.ts
+++ b/api/lib/communityQuota.ts
@@ -1,0 +1,50 @@
+import type { Redis } from 'ioredis';
+import { communityPublishedKey } from './redisKeys.js';
+
+/**
+ * Live published designs allowed per user. Count-only: per-design byte
+ * ceilings are enforced at validation time (params 100KB/2MB, thumbnails
+ * 200KB each, GLB 2MB), so a bytes axis would be redundant.
+ */
+export const COMMUNITY_MAX_LIVE_DESIGNS = 25;
+
+export interface CommunityQuotaError {
+  type: 'QUOTA_EXCEEDED';
+  reason: 'count';
+  /** Usage that would result if the publish proceeded. */
+  current: number;
+  /** The cap that was hit. */
+  limit: number;
+}
+
+export type CommunityQuotaCheck = { ok: true } | { ok: false; error: CommunityQuotaError };
+
+/**
+ * Check whether a publish would push the user past the live-design cap.
+ *
+ * Only new publishes consult quota: updates (PUT) never change the published
+ * set's membership, and deletes free the slot via SREM at the call site.
+ *
+ * Concurrent-publish note (mirrors quota.ts): two racing publishes both read
+ * SCARD before either SADDs, so the cap can briefly overshoot by one.
+ * Accepted as a soft ceiling at this scale.
+ */
+export async function checkCommunityPublishQuota(
+  redis: Redis,
+  userId: string
+): Promise<CommunityQuotaCheck> {
+  const liveCount = await redis.scard(communityPublishedKey(userId));
+  const projectedCount = liveCount + 1;
+  if (projectedCount > COMMUNITY_MAX_LIVE_DESIGNS) {
+    return {
+      ok: false,
+      error: {
+        type: 'QUOTA_EXCEEDED',
+        reason: 'count',
+        current: projectedCount,
+        limit: COMMUNITY_MAX_LIVE_DESIGNS,
+      },
+    };
+  }
+  return { ok: true };
+}

--- a/api/lib/communityStore.test.ts
+++ b/api/lib/communityStore.test.ts
@@ -309,6 +309,16 @@ describe('index helpers', () => {
     expect(pipeline.exec).toHaveBeenCalledTimes(1);
   });
 
+  it('throws when the card-read pipeline loses the connection (exec returns null)', async () => {
+    const pipeline = createPipeline();
+    pipeline.exec.mockResolvedValue(null as unknown as Array<[Error | null, unknown]>);
+    const { redis } = createRedis(pipeline);
+
+    await expect(readCommunityCards(redis, ['abc123def456'])).rejects.toThrow(
+      'redis connection lost'
+    );
+  });
+
   it('throws when the index pipeline loses the connection (exec returns null)', async () => {
     const pipeline = createPipeline();
     pipeline.exec.mockResolvedValue(null as unknown as Array<[Error | null, unknown]>);

--- a/api/lib/communityStore.test.ts
+++ b/api/lib/communityStore.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Redis } from 'ioredis';
+
+const mocks = vi.hoisted(() => ({
+  putJson: vi.fn(),
+  getJson: vi.fn(),
+  deleteBlob: vi.fn(),
+}));
+
+vi.mock('./blobStore.js', () => ({
+  putJson: mocks.putJson,
+  getJson: mocks.getJson,
+  deleteBlob: mocks.deleteBlob,
+}));
+
+import {
+  communityDesignBlobPath,
+  communityThumbBlobPath,
+  communityMeshBlobPath,
+  deriveCommunityMetrics,
+  writeCommunityDesignBlob,
+  readCommunityDesignBlob,
+  deleteCommunityDesignBlob,
+  writeCommunityCard,
+  readCommunityCards,
+  upsertCommunityIndexes,
+  removeFromCommunityIndexes,
+  setCommunityDesignStatus,
+  communityContentHash,
+  type CommunityCardMetadata,
+  type CommunityDesignRecord,
+} from './communityStore.js';
+
+interface PipelineCall {
+  command: string;
+  args: unknown[];
+}
+
+function createPipeline(execResults: Array<[Error | null, unknown]> = []) {
+  const calls: PipelineCall[] = [];
+  const pipeline = {
+    calls,
+    hgetall(key: string) {
+      calls.push({ command: 'hgetall', args: [key] });
+      return pipeline;
+    },
+    zadd(key: string, score: number, member: string) {
+      calls.push({ command: 'zadd', args: [key, score, member] });
+      return pipeline;
+    },
+    zrem(key: string, member: string) {
+      calls.push({ command: 'zrem', args: [key, member] });
+      return pipeline;
+    },
+    exec: vi.fn(async () => execResults),
+  };
+  return pipeline;
+}
+
+function createRedis(pipeline: ReturnType<typeof createPipeline>) {
+  const hset = vi.fn(async () => 1);
+  const hmget = vi.fn(async () => [] as (string | null)[]);
+  const redis = { hset, hmget, pipeline: vi.fn(() => pipeline) };
+  return { redis: redis as unknown as Redis, hset, hmget };
+}
+
+const DESIGN: CommunityDesignRecord = {
+  id: 'abc123def456',
+  authorPublicId: 'a'.repeat(32),
+  authorName: 'Andy',
+  name: 'Socket Organizer',
+  description: 'Holds 24 sockets.',
+  category: 'tools',
+  techniques: ['scoop'],
+  params: { width: 2 },
+  metrics: { width: 2, depth: 3, height: 6, gridUnitMm: 42 },
+  lineage: null,
+  thumbnails: ['https://blob.example/t0.webp'],
+  meshUrl: 'https://blob.example/m.glb',
+  photos: [],
+  featured: false,
+  createdAt: 1000,
+  updatedAt: 2000,
+  status: 'live',
+};
+
+const CARD: CommunityCardMetadata = {
+  id: 'abc123def456',
+  name: 'Socket Organizer',
+  authorPublicId: 'a'.repeat(32),
+  authorName: 'Andy',
+  category: 'tools',
+  techniques: ['scoop'],
+  width: 2,
+  depth: 3,
+  height: 6,
+  gridUnitMm: 42,
+  thumbnailUrl: 'https://blob.example/t0.webp',
+  isRemix: false,
+  featured: false,
+  createdAt: 1000,
+  updatedAt: 2000,
+  status: 'live',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('TOKEN_SALT', 'test-salt');
+  mocks.putJson.mockResolvedValue({ url: 'https://blob.example/design.json' });
+  mocks.getJson.mockResolvedValue(null);
+  mocks.deleteBlob.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('blob paths', () => {
+  it('builds salted design, thumbnail, and mesh paths', () => {
+    expect(communityDesignBlobPath('abc123def456')).toMatch(
+      /^community\/designs\/abc123def456-[a-f0-9]{16}\.json$/
+    );
+    expect(communityThumbBlobPath('abc123def456', 3, 1)).toMatch(
+      /^community\/thumbs\/abc123def456-[a-f0-9]{16}-3-1\.webp$/
+    );
+    expect(communityMeshBlobPath('abc123def456', 3)).toMatch(
+      /^community\/meshes\/abc123def456-[a-f0-9]{16}-3\.glb$/
+    );
+  });
+
+  it('derives paths deterministically but never from the id alone', () => {
+    const first = communityDesignBlobPath('abc123def456');
+    expect(communityDesignBlobPath('abc123def456')).toBe(first);
+    expect(communityDesignBlobPath('abc123def457')).not.toBe(first);
+    const firstThumb = communityThumbBlobPath('abc123def456', 1, 0);
+    expect(communityThumbBlobPath('abc123def456', 1, 0)).toBe(firstThumb);
+    const firstMesh = communityMeshBlobPath('abc123def456', 1);
+
+    vi.stubEnv('TOKEN_SALT', 'other-salt');
+    expect(communityDesignBlobPath('abc123def456')).not.toBe(first);
+    expect(communityThumbBlobPath('abc123def456', 1, 0)).not.toBe(firstThumb);
+    expect(communityMeshBlobPath('abc123def456', 1)).not.toBe(firstMesh);
+  });
+
+  it('refuses to derive any path without TOKEN_SALT', () => {
+    vi.stubEnv('TOKEN_SALT', '');
+    expect(() => communityDesignBlobPath('abc123def456')).toThrow(/TOKEN_SALT/);
+    expect(() => communityThumbBlobPath('abc123def456', 1, 0)).toThrow(/TOKEN_SALT/);
+    expect(() => communityMeshBlobPath('abc123def456', 1)).toThrow(/TOKEN_SALT/);
+  });
+});
+
+describe('deriveCommunityMetrics', () => {
+  it('converts grid units to outer millimetres', () => {
+    expect(
+      deriveCommunityMetrics({ width: 2, depth: 3, height: 6, gridUnitMm: 42, heightUnitMm: 7 })
+    ).toEqual({ width: 83.5, depth: 125.5, height: 42, gridUnitMm: 42 });
+  });
+
+  it('falls back to spec defaults for missing or non-positive values', () => {
+    expect(deriveCommunityMetrics({})).toEqual({
+      width: 41.5,
+      depth: 41.5,
+      height: 7,
+      gridUnitMm: 42,
+    });
+    expect(deriveCommunityMetrics({ width: -3, depth: Number.NaN, height: '9' })).toEqual({
+      width: 41.5,
+      depth: 41.5,
+      height: 7,
+      gridUnitMm: 42,
+    });
+  });
+});
+
+describe('design blob helpers', () => {
+  it('writes with CAS by default and returns the blob url', async () => {
+    const url = await writeCommunityDesignBlob(DESIGN);
+    expect(url).toBe('https://blob.example/design.json');
+    expect(mocks.putJson).toHaveBeenCalledWith(communityDesignBlobPath('abc123def456'), DESIGN, {
+      allowOverwrite: false,
+    });
+  });
+
+  it('allows overwrite for updates when asked', async () => {
+    await writeCommunityDesignBlob(DESIGN, { allowOverwrite: true });
+    expect(mocks.putJson).toHaveBeenCalledWith(communityDesignBlobPath('abc123def456'), DESIGN, {
+      allowOverwrite: true,
+    });
+  });
+
+  it('reads through getJson', async () => {
+    mocks.getJson.mockResolvedValue(DESIGN);
+    expect(await readCommunityDesignBlob('abc123def456')).toEqual(DESIGN);
+    expect(mocks.getJson).toHaveBeenCalledWith(communityDesignBlobPath('abc123def456'));
+  });
+
+  it('deletes through deleteBlob', async () => {
+    await deleteCommunityDesignBlob('abc123def456');
+    expect(mocks.deleteBlob).toHaveBeenCalledWith(communityDesignBlobPath('abc123def456'));
+  });
+});
+
+describe('writeCommunityCard', () => {
+  it('writes metadata fields to the card hash without touching counters', async () => {
+    const { redis, hset } = createRedis(createPipeline());
+    await writeCommunityCard(redis, CARD);
+
+    expect(hset).toHaveBeenCalledTimes(1);
+    const [key, fields] = hset.mock.calls[0] as unknown as [string, Record<string, string>];
+    expect(key).toBe('community:design:abc123def456');
+    expect(fields.techniques).toBe('["scoop"]');
+    expect(fields.status).toBe('live');
+    expect(fields.isRemix).toBe('0');
+    expect(fields).not.toHaveProperty('likes');
+    expect(fields).not.toHaveProperty('remixes');
+    expect(fields).not.toHaveProperty('exports');
+  });
+});
+
+describe('readCommunityCards', () => {
+  it('returns [] for an empty id page without a pipeline round trip', async () => {
+    const pipeline = createPipeline();
+    const { redis } = createRedis(pipeline);
+    expect(await readCommunityCards(redis, [])).toEqual([]);
+    expect(pipeline.exec).not.toHaveBeenCalled();
+  });
+
+  it('pipelines one HGETALL per id and parses cards positionally', async () => {
+    const storedFields = {
+      id: CARD.id,
+      name: CARD.name,
+      authorPublicId: CARD.authorPublicId,
+      authorName: CARD.authorName,
+      category: CARD.category,
+      techniques: '["scoop"]',
+      width: '2',
+      depth: '3',
+      height: '6',
+      gridUnitMm: '42',
+      thumbnailUrl: CARD.thumbnailUrl,
+      isRemix: '0',
+      featured: '1',
+      createdAt: '1000',
+      updatedAt: '2000',
+      status: 'live',
+      likes: '7',
+      remixes: '2',
+      exports: '31',
+    };
+    const pipeline = createPipeline([
+      [null, storedFields],
+      [null, {}],
+      [new Error('boom'), null],
+    ]);
+    const { redis } = createRedis(pipeline);
+
+    const cards = await readCommunityCards(redis, [
+      'abc123def456',
+      'missing000000',
+      'errored00000',
+    ]);
+
+    expect(pipeline.calls).toEqual([
+      { command: 'hgetall', args: ['community:design:abc123def456'] },
+      { command: 'hgetall', args: ['community:design:missing000000'] },
+      { command: 'hgetall', args: ['community:design:errored00000'] },
+    ]);
+    expect(cards).toHaveLength(3);
+    expect(cards[0]).toEqual({ ...CARD, featured: true, likes: 7, remixes: 2, exports: 31 });
+    expect(cards[1]).toBeNull();
+    expect(cards[2]).toBeNull();
+  });
+
+  it('rejects a hash with an unknown status', async () => {
+    const pipeline = createPipeline([[null, { id: 'x', status: 'weird' }]]);
+    const { redis } = createRedis(pipeline);
+    expect(await readCommunityCards(redis, ['x'])).toEqual([null]);
+  });
+});
+
+describe('index helpers', () => {
+  it('upserts all three sort indexes in one pipeline', async () => {
+    const pipeline = createPipeline();
+    const { redis } = createRedis(pipeline);
+
+    await upsertCommunityIndexes(redis, 'abc123def456', { createdAt: 1000, remixes: 4, likes: 9 });
+
+    expect(pipeline.calls).toEqual([
+      { command: 'zadd', args: ['community:index:newest', 1000, 'abc123def456'] },
+      { command: 'zadd', args: ['community:index:remixes', 4, 'abc123def456'] },
+      { command: 'zadd', args: ['community:index:likes', 9, 'abc123def456'] },
+    ]);
+    expect(pipeline.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes from all three sort indexes in one pipeline', async () => {
+    const pipeline = createPipeline();
+    const { redis } = createRedis(pipeline);
+
+    await removeFromCommunityIndexes(redis, 'abc123def456');
+
+    expect(pipeline.calls).toEqual([
+      { command: 'zrem', args: ['community:index:newest', 'abc123def456'] },
+      { command: 'zrem', args: ['community:index:remixes', 'abc123def456'] },
+      { command: 'zrem', args: ['community:index:likes', 'abc123def456'] },
+    ]);
+    expect(pipeline.exec).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setCommunityDesignStatus', () => {
+  it('restoring to live re-indexes with scores from the card hash', async () => {
+    const pipeline = createPipeline();
+    const { redis, hset, hmget } = createRedis(pipeline);
+    hmget.mockResolvedValue(['1000', '4', '9']);
+
+    await setCommunityDesignStatus(redis, 'abc123def456', 'live');
+
+    expect(hset).toHaveBeenCalledWith('community:design:abc123def456', { status: 'live' });
+    expect(hmget).toHaveBeenCalledWith(
+      'community:design:abc123def456',
+      'createdAt',
+      'remixes',
+      'likes'
+    );
+    expect(pipeline.calls).toEqual([
+      { command: 'zadd', args: ['community:index:newest', 1000, 'abc123def456'] },
+      { command: 'zadd', args: ['community:index:remixes', 4, 'abc123def456'] },
+      { command: 'zadd', args: ['community:index:likes', 9, 'abc123def456'] },
+    ]);
+  });
+
+  it.each(['hidden', 'removed'] as const)(
+    '%s removes the design from every index',
+    async (status) => {
+      const pipeline = createPipeline();
+      const { redis, hset, hmget } = createRedis(pipeline);
+
+      await setCommunityDesignStatus(redis, 'abc123def456', status);
+
+      expect(hset).toHaveBeenCalledWith('community:design:abc123def456', { status });
+      expect(hmget).not.toHaveBeenCalled();
+      expect(pipeline.calls.map((c) => c.command)).toEqual(['zrem', 'zrem', 'zrem']);
+    }
+  );
+});
+
+describe('communityContentHash', () => {
+  const content = {
+    params: { width: 2, compartments: { cols: 2, cells: [0, 1] } },
+    name: 'Socket Organizer',
+    description: 'Holds 24 sockets.',
+    category: 'tools',
+  };
+
+  it('is a 32-char hex digest', () => {
+    expect(communityContentHash(content)).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('is stable under object key ordering', () => {
+    const reordered = {
+      category: 'tools',
+      description: 'Holds 24 sockets.',
+      name: 'Socket Organizer',
+      params: { compartments: { cells: [0, 1], cols: 2 }, width: 2 },
+    };
+    expect(communityContentHash(reordered)).toBe(communityContentHash(content));
+  });
+
+  it('changes when any content field changes', () => {
+    const base = communityContentHash(content);
+    expect(communityContentHash({ ...content, name: 'Other' })).not.toBe(base);
+    expect(communityContentHash({ ...content, description: '' })).not.toBe(base);
+    expect(communityContentHash({ ...content, category: 'other' })).not.toBe(base);
+    expect(communityContentHash({ ...content, params: { width: 3 } })).not.toBe(base);
+  });
+
+  it('is sensitive to array order (cells are positional)', () => {
+    const swapped = {
+      ...content,
+      params: { ...content.params, compartments: { cols: 2, cells: [1, 0] } },
+    };
+    expect(communityContentHash(swapped)).not.toBe(communityContentHash(content));
+  });
+});

--- a/api/lib/communityStore.test.ts
+++ b/api/lib/communityStore.test.ts
@@ -308,6 +308,27 @@ describe('index helpers', () => {
     ]);
     expect(pipeline.exec).toHaveBeenCalledTimes(1);
   });
+
+  it('throws when the index pipeline loses the connection (exec returns null)', async () => {
+    const pipeline = createPipeline();
+    pipeline.exec.mockResolvedValue(null as unknown as Array<[Error | null, unknown]>);
+    const { redis } = createRedis(pipeline);
+
+    await expect(
+      upsertCommunityIndexes(redis, 'abc123def456', { createdAt: 1, remixes: 0, likes: 0 })
+    ).rejects.toThrow('redis connection lost');
+  });
+
+  it('throws when an index command reports a per-command error', async () => {
+    const pipeline = createPipeline([
+      [null, 1],
+      [new Error('WRONGTYPE'), null],
+      [null, 1],
+    ]);
+    const { redis } = createRedis(pipeline);
+
+    await expect(removeFromCommunityIndexes(redis, 'abc123def456')).rejects.toThrow('WRONGTYPE');
+  });
 });
 
 describe('setCommunityDesignStatus', () => {

--- a/api/lib/communityStore.test.ts
+++ b/api/lib/communityStore.test.ts
@@ -87,6 +87,7 @@ const DESIGN: CommunityDesignRecord = {
 const CARD: CommunityCardMetadata = {
   id: 'abc123def456',
   name: 'Socket Organizer',
+  parentId: '',
   authorPublicId: 'a'.repeat(32),
   authorName: 'Andy',
   category: 'tools',

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -1,0 +1,344 @@
+/**
+ * Storage helpers for community showcase designs.
+ *
+ * Split storage: the full design record lives in a JSON blob (one fetch per
+ * detail view), while the card metadata browsing needs lives in a Redis hash
+ * per design (paged via pipelined HGETALL) plus one sorted set per gallery
+ * sort. Counters (likes/remixes/exports) are HINCRBY-managed fields on the
+ * same hash and are never written by the metadata writer, so a publish update
+ * can't clobber them.
+ */
+
+import { createHash } from 'node:crypto';
+import type { Redis } from 'ioredis';
+import { deleteBlob, getJson, putJson } from './blobStore.js';
+import type { CommunityCategory, CommunityTechnique } from './communityValidation.js';
+import { COMMUNITY_INDEX_SORTS, communityDesignKey, communityIndexKey } from './redisKeys.js';
+
+export type CommunityDesignStatus = 'live' | 'hidden' | 'removed';
+
+export interface CommunityLineage {
+  parentId: string;
+  rootId: string;
+  parentName: string;
+  parentAuthorName: string;
+  rootAuthorName: string;
+}
+
+export interface CommunityDesignMetrics {
+  width: number;
+  depth: number;
+  height: number;
+  gridUnitMm: number;
+}
+
+/**
+ * MIRROR: outer-dimension math matches `binDimensions` in
+ * `src/features/bin-designer/utils/binDimensions.ts` (api/ cannot import from
+ * src/); the pitch/height defaults and tolerance mirror `GRIDFINITY_SPEC` in
+ * `src/shared/printSettings/gridfinityGeometry.ts`. Update both sides together.
+ */
+const DEFAULT_GRID_UNIT_MM = 42;
+const DEFAULT_HEIGHT_UNIT_MM = 7;
+const BIN_TOLERANCE_MM = 0.5;
+
+function positiveNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+/**
+ * Single derivation for publish and update: metrics are stored in millimetres,
+ * so both handlers must share it or an edit would silently switch the card to
+ * a different unit system.
+ */
+export function deriveCommunityMetrics(params: Record<string, unknown>): CommunityDesignMetrics {
+  const gridUnitMm = positiveNumber(params.gridUnitMm, DEFAULT_GRID_UNIT_MM);
+  const heightUnitMm = positiveNumber(params.heightUnitMm, DEFAULT_HEIGHT_UNIT_MM);
+  return {
+    width: positiveNumber(params.width, 1) * gridUnitMm - BIN_TOLERANCE_MM,
+    depth: positiveNumber(params.depth, 1) * gridUnitMm - BIN_TOLERANCE_MM,
+    height: positiveNumber(params.height, 1) * heightUnitMm,
+    gridUnitMm,
+  };
+}
+
+export interface CommunityDesignRecord {
+  id: string;
+  authorPublicId: string;
+  authorName: string;
+  name: string;
+  description: string;
+  category: CommunityCategory;
+  techniques: CommunityTechnique[];
+  params: Record<string, unknown>;
+  metrics: CommunityDesignMetrics;
+  lineage: CommunityLineage | null;
+  /** Blob URLs of the revision-stamped WebP captures. */
+  thumbnails: string[];
+  /** Blob URL of the revision-stamped publisher-exported GLB. */
+  meshUrl: string;
+  /** Reserved for post-graduation publisher photos; empty until then. */
+  photos: string[];
+  featured: boolean;
+  createdAt: number;
+  updatedAt: number;
+  status: CommunityDesignStatus;
+}
+
+/**
+ * Every community blob path carries a salted segment because blobs are
+ * world-readable and the store hostname leaks through every card's
+ * thumbnailUrl: a path derivable from the design id alone would let anyone
+ * fetch a hidden or removed design's record, thumbnails, or mesh directly,
+ * bypassing the API's moderation 404. Salting keeps paths deterministic for
+ * the server while unguessable to anyone without TOKEN_SALT.
+ */
+function communityPathSecret(designId: string, purpose: string): string {
+  const salt = process.env.TOKEN_SALT;
+  if (!salt) {
+    throw new Error('TOKEN_SALT is required to derive community blob paths');
+  }
+  return createHash('sha256').update(`${salt}:${purpose}:${designId}`).digest('hex').slice(0, 16);
+}
+
+export function communityDesignBlobPath(designId: string): string {
+  return `community/designs/${designId}-${communityPathSecret(designId, 'community-record')}.json`;
+}
+
+/** Revision-stamped so updated thumbnails get fresh, immutably-cacheable URLs. */
+export function communityThumbBlobPath(designId: string, rev: number, angle: number): string {
+  const secret = communityPathSecret(designId, 'community-assets');
+  return `community/thumbs/${designId}-${secret}-${rev}-${angle}.webp`;
+}
+
+/** Revision-stamped so an updated GLB gets a fresh, immutably-cacheable URL. */
+export function communityMeshBlobPath(designId: string, rev: number): string {
+  return `community/meshes/${designId}-${communityPathSecret(designId, 'community-assets')}-${rev}.glb`;
+}
+
+export interface WriteCommunityDesignOptions {
+  /**
+   * First publish keeps the CAS default (false) so a racing duplicate publish
+   * throws instead of silently overwriting; updates pass true.
+   */
+  allowOverwrite?: boolean;
+}
+
+export async function writeCommunityDesignBlob(
+  design: CommunityDesignRecord,
+  options: WriteCommunityDesignOptions = {}
+): Promise<string> {
+  const result = await putJson(communityDesignBlobPath(design.id), design, {
+    allowOverwrite: options.allowOverwrite ?? false,
+  });
+  return result.url;
+}
+
+export async function readCommunityDesignBlob(
+  designId: string
+): Promise<CommunityDesignRecord | null> {
+  return getJson<CommunityDesignRecord>(communityDesignBlobPath(designId));
+}
+
+export async function deleteCommunityDesignBlob(designId: string): Promise<void> {
+  await deleteBlob(communityDesignBlobPath(designId));
+}
+
+/** Card metadata as browsed in the gallery: everything but the counters. */
+export interface CommunityCardMetadata {
+  id: string;
+  name: string;
+  authorPublicId: string;
+  authorName: string;
+  category: CommunityCategory;
+  techniques: CommunityTechnique[];
+  width: number;
+  depth: number;
+  height: number;
+  gridUnitMm: number;
+  thumbnailUrl: string;
+  isRemix: boolean;
+  featured: boolean;
+  createdAt: number;
+  updatedAt: number;
+  status: CommunityDesignStatus;
+}
+
+export interface CommunityCardRecord extends CommunityCardMetadata {
+  likes: number;
+  remixes: number;
+  exports: number;
+}
+
+export async function writeCommunityCard(redis: Redis, card: CommunityCardMetadata): Promise<void> {
+  await redis.hset(communityDesignKey(card.id), {
+    id: card.id,
+    name: card.name,
+    authorPublicId: card.authorPublicId,
+    authorName: card.authorName,
+    category: card.category,
+    techniques: JSON.stringify(card.techniques),
+    width: String(card.width),
+    depth: String(card.depth),
+    height: String(card.height),
+    gridUnitMm: String(card.gridUnitMm),
+    thumbnailUrl: card.thumbnailUrl,
+    isRemix: card.isRemix ? '1' : '0',
+    featured: card.featured ? '1' : '0',
+    createdAt: String(card.createdAt),
+    updatedAt: String(card.updatedAt),
+    status: card.status,
+  });
+}
+
+function parseCard(fields: Record<string, string | undefined>): CommunityCardRecord | null {
+  if (fields.id === undefined) return null;
+  let techniques: CommunityTechnique[] = [];
+  try {
+    const parsed: unknown = JSON.parse(fields.techniques ?? '[]');
+    if (Array.isArray(parsed)) techniques = parsed as CommunityTechnique[];
+  } catch {
+    techniques = [];
+  }
+  const status = fields.status;
+  if (status !== 'live' && status !== 'hidden' && status !== 'removed') return null;
+  return {
+    id: fields.id,
+    name: fields.name ?? '',
+    authorPublicId: fields.authorPublicId ?? '',
+    authorName: fields.authorName ?? '',
+    category: (fields.category ?? 'other') as CommunityCategory,
+    techniques,
+    width: Number(fields.width ?? 0),
+    depth: Number(fields.depth ?? 0),
+    height: Number(fields.height ?? 0),
+    gridUnitMm: Number(fields.gridUnitMm ?? 0),
+    thumbnailUrl: fields.thumbnailUrl ?? '',
+    isRemix: fields.isRemix === '1',
+    featured: fields.featured === '1',
+    createdAt: Number(fields.createdAt ?? 0),
+    updatedAt: Number(fields.updatedAt ?? 0),
+    status,
+    likes: Number(fields.likes ?? 0),
+    remixes: Number(fields.remixes ?? 0),
+    exports: Number(fields.exports ?? 0),
+  };
+}
+
+/**
+ * Pipelined HGETALL for a page of card ids. The result array is positional:
+ * a missing or malformed hash yields null at its id's index rather than
+ * shifting the page.
+ */
+export async function readCommunityCards(
+  redis: Redis,
+  designIds: readonly string[]
+): Promise<(CommunityCardRecord | null)[]> {
+  if (designIds.length === 0) return [];
+  const pipeline = redis.pipeline();
+  for (const id of designIds) {
+    pipeline.hgetall(communityDesignKey(id));
+  }
+  const results = (await pipeline.exec()) ?? [];
+  return results.map(([error, value]) => {
+    if (error || typeof value !== 'object' || value === null) return null;
+    return parseCard(value as Record<string, string | undefined>);
+  });
+}
+
+export interface CommunityIndexScores {
+  createdAt: number;
+  remixes: number;
+  likes: number;
+}
+
+/** Pipelined ZADD across all three sort indexes. Only call for live designs. */
+export async function upsertCommunityIndexes(
+  redis: Redis,
+  designId: string,
+  scores: CommunityIndexScores
+): Promise<void> {
+  const pipeline = redis.pipeline();
+  pipeline.zadd(communityIndexKey('newest'), scores.createdAt, designId);
+  pipeline.zadd(communityIndexKey('remixes'), scores.remixes, designId);
+  pipeline.zadd(communityIndexKey('likes'), scores.likes, designId);
+  await pipeline.exec();
+}
+
+/** Pipelined ZREM from every sort index (hide, remove, unpublish). */
+export async function removeFromCommunityIndexes(redis: Redis, designId: string): Promise<void> {
+  const pipeline = redis.pipeline();
+  for (const sort of COMMUNITY_INDEX_SORTS) {
+    pipeline.zrem(communityIndexKey(sort), designId);
+  }
+  await pipeline.exec();
+}
+
+/**
+ * Flip a design's status and keep the sort indexes consistent: only live
+ * designs are indexed, so the gallery can page sorted sets without filtering.
+ * Restoring to live re-scores from the card hash (counters kept accruing
+ * while hidden).
+ */
+export async function setCommunityDesignStatus(
+  redis: Redis,
+  designId: string,
+  status: CommunityDesignStatus
+): Promise<void> {
+  await redis.hset(communityDesignKey(designId), { status });
+  if (status === 'live') {
+    const [createdAt, remixes, likes] = await redis.hmget(
+      communityDesignKey(designId),
+      'createdAt',
+      'remixes',
+      'likes'
+    );
+    await upsertCommunityIndexes(redis, designId, {
+      createdAt: Number(createdAt ?? 0),
+      remixes: Number(remixes ?? 0),
+      likes: Number(likes ?? 0),
+    });
+  } else {
+    await removeFromCommunityIndexes(redis, designId);
+  }
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const record = value as Record<string, unknown>;
+    const entries = Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  // JSON.stringify's lib type is `string`, but undefined/function inputs
+  // really return undefined at runtime.
+  const serialized = JSON.stringify(value) as string | undefined;
+  return serialized === undefined ? 'null' : serialized;
+}
+
+export interface CommunityContentHashInput {
+  params: Record<string, unknown>;
+  name: string;
+  description: string;
+  category: string;
+}
+
+/**
+ * Stable content hash for publish idempotency: a retry or second tab posting
+ * identical content maps to the same hash, so the handler can return the
+ * existing id instead of minting a duplicate. Object keys are sorted
+ * recursively so serialization order can't defeat the match.
+ */
+export function communityContentHash(content: CommunityContentHashInput): string {
+  const canonical = stableStringify({
+    params: content.params,
+    name: content.name,
+    description: content.description,
+    category: content.category,
+  });
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 32);
+}

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -245,7 +245,12 @@ export async function readCommunityCards(
   for (const id of designIds) {
     pipeline.hgetall(communityDesignKey(id));
   }
-  const results = (await pipeline.exec()) ?? [];
+  const results = await pipeline.exec();
+  // A null exec would otherwise read as an empty page while ids exist, which
+  // stalls list pagination (offset only advances per returned card).
+  if (results === null) {
+    throw new Error('Community card read failed: redis connection lost');
+  }
   return results.map(([error, value]) => {
     if (error || typeof value !== 'object' || value === null) return null;
     return parseCard(value as Record<string, string | undefined>);

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -158,6 +158,10 @@ export interface CommunityCardMetadata {
   gridUnitMm: number;
   thumbnailUrl: string;
   isRemix: boolean;
+  /** Lineage parent id, or '' when not a remix. Duplicated from the blob
+   *  record so a retried DELETE can clean the parent's children set after
+   *  the blob is already gone. */
+  parentId: string;
   featured: boolean;
   createdAt: number;
   updatedAt: number;
@@ -184,6 +188,7 @@ export async function writeCommunityCard(redis: Redis, card: CommunityCardMetada
     gridUnitMm: String(card.gridUnitMm),
     thumbnailUrl: card.thumbnailUrl,
     isRemix: card.isRemix ? '1' : '0',
+    parentId: card.parentId,
     featured: card.featured ? '1' : '0',
     createdAt: String(card.createdAt),
     updatedAt: String(card.updatedAt),
@@ -215,6 +220,7 @@ function parseCard(fields: Record<string, string | undefined>): CommunityCardRec
     gridUnitMm: Number(fields.gridUnitMm ?? 0),
     thumbnailUrl: fields.thumbnailUrl ?? '',
     isRemix: fields.isRemix === '1',
+    parentId: fields.parentId ?? '',
     featured: fields.featured === '1',
     createdAt: Number(fields.createdAt ?? 0),
     updatedAt: Number(fields.updatedAt ?? 0),

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -10,7 +10,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import type { Redis } from 'ioredis';
+import type { ChainableCommander, Redis } from 'ioredis';
 import { deleteBlob, getJson, putJson } from './blobStore.js';
 import type { CommunityCategory, CommunityTechnique } from './communityValidation.js';
 import { COMMUNITY_INDEX_SORTS, communityDesignKey, communityIndexKey } from './redisKeys.js';
@@ -258,6 +258,25 @@ export interface CommunityIndexScores {
   likes: number;
 }
 
+/**
+ * ioredis returns null from exec() on connection-level failure and reports
+ * per-command errors in the result tuples. Index membership decides whether
+ * a design exists in the gallery at all, so both cases must throw instead
+ * of leaving the indexes silently out of sync (same contract as the session
+ * pipeline in session.ts).
+ */
+async function execIndexPipeline(pipeline: ChainableCommander, context: string): Promise<void> {
+  const results = await pipeline.exec();
+  if (results === null) {
+    throw new Error(`${context}: redis connection lost`);
+  }
+  for (const [err] of results) {
+    if (err) {
+      throw new Error(`${context}: ${err.message}`);
+    }
+  }
+}
+
 /** Pipelined ZADD across all three sort indexes. Only call for live designs. */
 export async function upsertCommunityIndexes(
   redis: Redis,
@@ -268,7 +287,7 @@ export async function upsertCommunityIndexes(
   pipeline.zadd(communityIndexKey('newest'), scores.createdAt, designId);
   pipeline.zadd(communityIndexKey('remixes'), scores.remixes, designId);
   pipeline.zadd(communityIndexKey('likes'), scores.likes, designId);
-  await pipeline.exec();
+  await execIndexPipeline(pipeline, 'Community index upsert failed');
 }
 
 /** Pipelined ZREM from every sort index (hide, remove, unpublish). */
@@ -277,7 +296,7 @@ export async function removeFromCommunityIndexes(redis: Redis, designId: string)
   for (const sort of COMMUNITY_INDEX_SORTS) {
     pipeline.zrem(communityIndexKey(sort), designId);
   }
-  await pipeline.exec();
+  await execIndexPipeline(pipeline, 'Community index removal failed');
 }
 
 /**

--- a/api/lib/communityValidation.test.ts
+++ b/api/lib/communityValidation.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  validateDesignerShare: vi.fn(),
+}));
+
+vi.mock('./designerValidation.js', () => ({
+  validateDesignerShare: mocks.validateDesignerShare,
+}));
+
+import {
+  COMMUNITY_CATEGORIES,
+  COMMUNITY_NAME_MAX_LENGTH,
+  COMMUNITY_DESCRIPTION_MAX_LENGTH,
+  COMMUNITY_TECHNIQUES,
+  MAX_COMMUNITY_THUMBNAIL_BYTES,
+  deriveCommunityTechniques,
+  parseCommunityLineage,
+  validateCommunityPublish,
+} from './communityValidation.js';
+
+function webpBase64(payloadBytes = 6): string {
+  return Buffer.concat([
+    Buffer.from('RIFF'),
+    Buffer.alloc(4),
+    Buffer.from('WEBP'),
+    Buffer.alloc(payloadBytes),
+  ]).toString('base64');
+}
+
+function glbBase64(payloadBytes = 8): string {
+  return Buffer.concat([Buffer.from('glTF'), Buffer.alloc(payloadBytes)]).toString('base64');
+}
+
+function validBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'Socket Organizer',
+    description: 'Holds 24 sockets.',
+    authorName: 'Andy',
+    category: 'tools',
+    params: { width: 2, depth: 3 },
+    thumbnails: [webpBase64()],
+    glb: glbBase64(),
+    ...overrides,
+  };
+}
+
+function expectError(body: Record<string, unknown>, code: string): string {
+  const result = validateCommunityPublish(body);
+  expect(result.valid).toBe(false);
+  if (result.valid) throw new Error('expected invalid');
+  expect(result.error.code).toBe(code);
+  return result.error.message;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.validateDesignerShare.mockImplementation((body: { params: Record<string, unknown> }) => ({
+    valid: true,
+    payload: { type: 'designer', version: 1, params: body.params },
+  }));
+});
+
+describe('validateCommunityPublish', () => {
+  it('accepts a valid publish body and returns the sanitized payload', () => {
+    const result = validateCommunityPublish(validBody({ name: '  Socket Organizer  ' }));
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error('expected valid');
+    expect(result.payload.name).toBe('Socket Organizer');
+    expect(result.payload.description).toBe('Holds 24 sockets.');
+    expect(result.payload.authorName).toBe('Andy');
+    expect(result.payload.category).toBe('tools');
+    expect(result.payload.params).toEqual({ width: 2, depth: 3 });
+    expect(result.payload.techniques).toEqual([]);
+    expect(result.payload.thumbnails).toEqual([webpBase64()]);
+    expect(result.payload.glb).toBe(glbBase64());
+  });
+
+  it('rejects a non-object body', () => {
+    expectError(null as unknown as Record<string, unknown>, 'INVALID_PAYLOAD');
+  });
+
+  it('rejects a missing, empty, or overlong name', () => {
+    expectError(validBody({ name: undefined }), 'INVALID_NAME');
+    expectError(validBody({ name: '   ' }), 'INVALID_NAME');
+    expectError(validBody({ name: 'x'.repeat(COMMUNITY_NAME_MAX_LENGTH + 1) }), 'INVALID_NAME');
+  });
+
+  it('defaults an absent description to empty and caps its length', () => {
+    const result = validateCommunityPublish(validBody({ description: undefined }));
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error('expected valid');
+    expect(result.payload.description).toBe('');
+
+    expectError(
+      validBody({ description: 'x'.repeat(COMMUNITY_DESCRIPTION_MAX_LENGTH + 1) }),
+      'INVALID_DESCRIPTION'
+    );
+  });
+
+  it('rejects a missing or empty authorName', () => {
+    expectError(validBody({ authorName: undefined }), 'INVALID_AUTHOR_NAME');
+    expectError(validBody({ authorName: ' ' }), 'INVALID_AUTHOR_NAME');
+  });
+
+  it('content-blocks filtered name, description, and authorName', () => {
+    expectError(validBody({ name: 'visit https://spam.example' }), 'CONTENT_BLOCKED');
+    expectError(validBody({ description: 'kys' }), 'CONTENT_BLOCKED');
+    expectError(validBody({ authorName: 'kys' }), 'CONTENT_BLOCKED');
+  });
+
+  it('content-blocks engraved text nested in the sanitized params', () => {
+    const body = validBody({ params: { surfaceText: [{ text: 'kys' }] } });
+    expectError(body, 'CONTENT_BLOCKED');
+  });
+
+  it('rejects unknown categories and accepts every preset', () => {
+    expectError(validBody({ category: 'gardening' }), 'INVALID_CATEGORY');
+    expectError(validBody({ category: undefined }), 'INVALID_CATEGORY');
+    for (const category of COMMUNITY_CATEGORIES) {
+      expect(validateCommunityPublish(validBody({ category })).valid).toBe(true);
+    }
+  });
+
+  it('rejects non-object params before calling the designer validator', () => {
+    expectError(validBody({ params: 'nope' }), 'MISSING_PARAMS');
+    expect(mocks.validateDesignerShare).not.toHaveBeenCalled();
+  });
+
+  it('passes the designer payload with envelope-inclusive sizeBytes', () => {
+    const body = validBody();
+    validateCommunityPublish(body);
+
+    const [payload, sizeBytes] = mocks.validateDesignerShare.mock.calls[0] as [
+      { type: string; version: number; params: Record<string, unknown> },
+      number,
+    ];
+    expect(payload).toEqual({ type: 'designer', version: 1, params: body.params });
+    expect(sizeBytes).toBe(
+      Buffer.byteLength(
+        JSON.stringify({
+          name: body.name,
+          description: body.description,
+          category: body.category,
+          type: 'designer',
+          version: 1,
+          params: body.params,
+        }),
+        'utf8'
+      )
+    );
+  });
+
+  it('passes designer validation failures through untouched', () => {
+    mocks.validateDesignerShare.mockReturnValue({
+      valid: false,
+      error: { code: 'INVALID_PARAMS', message: 'params.width must be a number' },
+    });
+    const message = expectError(validBody(), 'INVALID_PARAMS');
+    expect(message).toBe('params.width must be a number');
+  });
+
+  it('persists the sanitized params from the validator, not the raw input', () => {
+    mocks.validateDesignerShare.mockReturnValue({
+      valid: true,
+      payload: { type: 'designer', version: 1, params: { width: 2 } },
+    });
+    const result = validateCommunityPublish(validBody({ params: { width: 2, __proto__junk: 1 } }));
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error('expected valid');
+    expect(result.payload.params).toEqual({ width: 2 });
+  });
+
+  it('requires 1-3 thumbnails', () => {
+    expectError(validBody({ thumbnails: undefined }), 'INVALID_THUMBNAILS');
+    expectError(validBody({ thumbnails: [] }), 'INVALID_THUMBNAILS');
+    expectError(
+      validBody({ thumbnails: [webpBase64(), webpBase64(), webpBase64(), webpBase64()] }),
+      'INVALID_THUMBNAILS'
+    );
+    expect(
+      validateCommunityPublish(
+        validBody({ thumbnails: [webpBase64(), webpBase64(1), webpBase64(2)] })
+      ).valid
+    ).toBe(true);
+  });
+
+  it('accepts image/webp data URLs and strips the prefix', () => {
+    const result = validateCommunityPublish(
+      validBody({ thumbnails: [`data:image/webp;base64,${webpBase64()}`] })
+    );
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error('expected valid');
+    expect(result.payload.thumbnails).toEqual([webpBase64()]);
+  });
+
+  it('rejects non-webp data URLs, invalid base64, and wrong magic bytes', () => {
+    expectError(validBody({ thumbnails: ['data:image/png;base64,AAAA'] }), 'INVALID_THUMBNAILS');
+    expectError(validBody({ thumbnails: ['not base64!!'] }), 'INVALID_THUMBNAILS');
+    expectError(
+      validBody({ thumbnails: [Buffer.from('not a webp at all').toString('base64')] }),
+      'INVALID_THUMBNAILS'
+    );
+  });
+
+  it('rejects thumbnails over the decoded byte cap', () => {
+    const oversize = webpBase64(MAX_COMMUNITY_THUMBNAIL_BYTES);
+    const message = expectError(validBody({ thumbnails: [oversize] }), 'INVALID_THUMBNAILS');
+    expect(message).toContain('decoded bytes');
+  });
+
+  it('rejects a missing GLB, invalid base64, and wrong magic bytes', () => {
+    expectError(validBody({ glb: undefined }), 'INVALID_GLB');
+    expectError(validBody({ glb: 'not base64!!' }), 'INVALID_GLB');
+    expectError(validBody({ glb: Buffer.from('STLBINARY000').toString('base64') }), 'INVALID_GLB');
+  });
+
+  it('rejects a GLB over the decoded byte cap', () => {
+    const oversize = glbBase64(2_000_000);
+    const message = expectError(validBody({ glb: oversize }), 'INVALID_GLB');
+    expect(message).toContain('decoded bytes');
+  });
+});
+
+describe('deriveCommunityTechniques', () => {
+  it('returns no techniques for default-shaped params', () => {
+    expect(
+      deriveCommunityTechniques({
+        style: 'standard',
+        compartments: { cols: 1, rows: 1, cells: [0] },
+        walls: { enabled: false, left: { enabled: true } },
+        scoop: { enabled: false },
+        label: { enabled: false },
+        lid: { enabled: false },
+        handles: { enabled: false, front: { enabled: true } },
+        wallPattern: { enabled: false },
+        slotConfig: { x: { enabled: true }, y: { enabled: false } },
+      })
+    ).toEqual([]);
+  });
+
+  it('tags compartments on more than one distinct compartment id', () => {
+    expect(deriveCommunityTechniques({ compartments: { cells: [0, 1, 2] } })).toEqual([
+      'compartments',
+    ]);
+  });
+
+  it('does not tag compartments when every cell shares one id', () => {
+    expect(
+      deriveCommunityTechniques({ compartments: { cols: 2, rows: 2, cells: [0, 0, 0, 0] } })
+    ).toEqual([]);
+  });
+
+  it('keys wallCutouts and handles off the master enabled flag, not per-side flags', () => {
+    expect(
+      deriveCommunityTechniques({
+        walls: { enabled: false, left: { enabled: true }, right: { enabled: true } },
+        handles: { enabled: false, front: { enabled: true } },
+      })
+    ).toEqual([]);
+    expect(deriveCommunityTechniques({ walls: { enabled: true } })).toEqual(['wallCutouts']);
+    expect(deriveCommunityTechniques({ handles: { enabled: true } })).toEqual(['handles']);
+  });
+
+  it('keys slotted off style, not slotConfig', () => {
+    expect(
+      deriveCommunityTechniques({ style: 'standard', slotConfig: { x: { enabled: true } } })
+    ).toEqual([]);
+    expect(deriveCommunityTechniques({ style: 'slotted' })).toEqual(['slotted']);
+  });
+
+  it('tags scoop, labelTab, lid, and wallPattern on their enabled flags', () => {
+    expect(deriveCommunityTechniques({ scoop: { enabled: true } })).toEqual(['scoop']);
+    expect(deriveCommunityTechniques({ label: { enabled: true } })).toEqual(['labelTab']);
+    expect(deriveCommunityTechniques({ lid: { enabled: true } })).toEqual(['lid']);
+    expect(deriveCommunityTechniques({ wallPattern: { enabled: true } })).toEqual(['wallPattern']);
+  });
+
+  it('tags customShape only for a partial cell mask', () => {
+    expect(deriveCommunityTechniques({ cellMask: { cols: 2, rows: 1, cells: [1, 1] } })).toEqual(
+      []
+    );
+    expect(deriveCommunityTechniques({ cellMask: { cols: 2, rows: 1, cells: [1, 0] } })).toEqual([
+      'customShape',
+    ]);
+    expect(deriveCommunityTechniques({})).toEqual([]);
+  });
+
+  it('emits techniques in the canonical union order', () => {
+    const everything = deriveCommunityTechniques({
+      style: 'slotted',
+      compartments: { cells: [0, 1] },
+      walls: { enabled: true },
+      scoop: { enabled: true },
+      label: { enabled: true },
+      lid: { enabled: true },
+      handles: { enabled: true },
+      cellMask: { cols: 2, rows: 1, cells: [1, 0] },
+      wallPattern: { enabled: true },
+    });
+    expect(everything).toEqual([...COMMUNITY_TECHNIQUES]);
+  });
+});
+
+describe('parseCommunityLineage', () => {
+  const LINEAGE = {
+    parentId: 'parentAAAAAA',
+    rootId: 'rootBBBBBBBB',
+    parentName: 'Parent Bin',
+    parentAuthorName: 'Ada',
+    rootAuthorName: 'Root Author',
+  };
+
+  it('accepts a missing lineage as null', () => {
+    expect(parseCommunityLineage(undefined)).toEqual({ ok: true, lineage: null });
+    expect(parseCommunityLineage(null)).toEqual({ ok: true, lineage: null });
+  });
+
+  it('parses a well-formed lineage envelope', () => {
+    expect(parseCommunityLineage(LINEAGE)).toEqual({ ok: true, lineage: LINEAGE });
+  });
+
+  it('rejects malformed ids, names, and non-objects', () => {
+    expect(parseCommunityLineage('nope').ok).toBe(false);
+    expect(parseCommunityLineage({ ...LINEAGE, parentId: 'short' }).ok).toBe(false);
+    expect(parseCommunityLineage({ ...LINEAGE, rootId: 42 }).ok).toBe(false);
+    expect(parseCommunityLineage({ ...LINEAGE, parentName: '' }).ok).toBe(false);
+    expect(parseCommunityLineage({ ...LINEAGE, parentAuthorName: 'x'.repeat(33) }).ok).toBe(false);
+    expect(parseCommunityLineage({ ...LINEAGE, rootAuthorName: undefined }).ok).toBe(false);
+  });
+
+  it('rejects blocked content in snapshot names', () => {
+    expect(parseCommunityLineage({ ...LINEAGE, parentName: 'cool <script name' }).ok).toBe(false);
+  });
+});

--- a/api/lib/communityValidation.ts
+++ b/api/lib/communityValidation.ts
@@ -1,0 +1,370 @@
+/**
+ * Server-side validation for community publish/update payloads.
+ *
+ * The design params themselves are validated by the existing
+ * `validateDesignerShare` (same allowlist + caps as designer shares); this
+ * module validates the publish envelope around them (name, description,
+ * author display name, category, thumbnails, GLB) and derives technique tags
+ * from the sanitized params.
+ */
+
+import { checkText, filterDisplayName, filterSharedDesignsContent } from './contentFilter.js';
+import { validateDesignerShare } from './designerValidation.js';
+import { isValidShareId } from './shared.js';
+import { isObject, isString, validationError } from './validationUtils.js';
+import type { CommunityLineage } from './communityStore.js';
+
+/**
+ * MIRROR: must match `COMMUNITY_CATEGORIES` in `src/shared/types/community.ts`
+ * (api/ cannot import from src/). Update both sides together; the
+ * cross-boundary equality test in `src/shared/types/community.test.ts` guards
+ * against drift.
+ */
+export const COMMUNITY_CATEGORIES = [
+  'tools',
+  'hardware',
+  'kitchen',
+  'office',
+  'crafts',
+  'electronics',
+  'toys-games',
+  'other',
+] as const;
+export type CommunityCategory = (typeof COMMUNITY_CATEGORIES)[number];
+
+export const COMMUNITY_NAME_MAX_LENGTH = 60;
+export const COMMUNITY_DESCRIPTION_MAX_LENGTH = 500;
+/** Matches MAX_DISPLAY_NAME_LENGTH in supporters.ts: one cap for every rendered public name. */
+export const COMMUNITY_AUTHOR_NAME_MAX_LENGTH = 32;
+export const MAX_COMMUNITY_THUMBNAILS = 3;
+export const MAX_COMMUNITY_THUMBNAIL_BYTES = 200_000;
+export const MAX_COMMUNITY_GLB_BYTES = 2_000_000;
+
+/**
+ * MIRROR: derivation logic must match `deriveTechniques` in
+ * `src/shared/utils/communityTechniques.ts` (client copy; api/ cannot import
+ * from src/). Union order mirrors `ExampleTechnique` in
+ * `src/shared/types/exampleTechniques.ts`. Update both sides together; the
+ * cross-boundary equality test in
+ * `src/shared/utils/communityTechniques.crossBoundary.test.ts` guards against
+ * drift.
+ */
+export const COMMUNITY_TECHNIQUES = [
+  'compartments',
+  'wallCutouts',
+  'scoop',
+  'labelTab',
+  'slotted',
+  'lid',
+  'handles',
+  'customShape',
+  'wallPattern',
+] as const;
+export type CommunityTechnique = (typeof COMMUNITY_TECHNIQUES)[number];
+
+function isEnabledFeature(value: unknown): boolean {
+  return isObject(value) && value.enabled === true;
+}
+
+function compartmentCount(value: unknown): number {
+  if (!isObject(value) || !Array.isArray(value.cells)) return 1;
+  return new Set(value.cells).size;
+}
+
+// Mirrors `isPartialMask` in src/shared/utils/cellMask.ts: an all-filled mask
+// is treated as a plain rectangle by the generator, so it must not tag.
+function isPartialCellMask(value: unknown): boolean {
+  if (!isObject(value) || !Array.isArray(value.cells)) return false;
+  return value.cells.some((cell) => cell === 0);
+}
+
+/**
+ * Derive technique tags from validated, sanitized params.
+ *
+ * Each predicate is the same gate the generation pipeline itself checks before
+ * building the feature. Two traps encoded here: `walls`/`handles` per-side
+ * sub-objects ship enabled in the defaults, so only the master `enabled` flag
+ * is authoritative; and `slotConfig` is populated even on standard bins, so
+ * `slotted` keys off `style` alone.
+ */
+export function deriveCommunityTechniques(params: Record<string, unknown>): CommunityTechnique[] {
+  const techniques: CommunityTechnique[] = [];
+  if (compartmentCount(params.compartments) > 1) techniques.push('compartments');
+  if (isEnabledFeature(params.walls)) techniques.push('wallCutouts');
+  if (isEnabledFeature(params.scoop)) techniques.push('scoop');
+  if (isEnabledFeature(params.label)) techniques.push('labelTab');
+  if (params.style === 'slotted') techniques.push('slotted');
+  if (isEnabledFeature(params.lid)) techniques.push('lid');
+  if (isEnabledFeature(params.handles)) techniques.push('handles');
+  if (isPartialCellMask(params.cellMask)) techniques.push('customShape');
+  if (isEnabledFeature(params.wallPattern)) techniques.push('wallPattern');
+  return techniques;
+}
+
+export type CommunityLineageParseResult =
+  { ok: true; lineage: CommunityLineage | null } | { ok: false; message: string };
+
+function lineageName(value: unknown, maxLength: number): string | null {
+  if (!isString(value)) return null;
+  const trimmed = value.trim();
+  if (trimmed.length < 1 || trimmed.length > maxLength) return null;
+  if (!checkText(trimmed).passed) return null;
+  return trimmed;
+}
+
+/**
+ * Shape-validates the publish payload's lineage envelope. The name fields
+ * parsed here are only fallback snapshots: the publish handler re-derives
+ * them from the stored parent record.
+ */
+export function parseCommunityLineage(value: unknown): CommunityLineageParseResult {
+  if (value === undefined || value === null) return { ok: true, lineage: null };
+  if (!isObject(value)) return { ok: false, message: 'lineage must be an object' };
+  if (!isValidShareId(value.parentId)) {
+    return { ok: false, message: 'lineage.parentId must be a valid design id' };
+  }
+  if (!isValidShareId(value.rootId)) {
+    return { ok: false, message: 'lineage.rootId must be a valid design id' };
+  }
+  const parentName = lineageName(value.parentName, COMMUNITY_NAME_MAX_LENGTH);
+  if (parentName === null) return { ok: false, message: 'lineage.parentName is invalid' };
+  const parentAuthorName = lineageName(value.parentAuthorName, COMMUNITY_AUTHOR_NAME_MAX_LENGTH);
+  if (parentAuthorName === null) {
+    return { ok: false, message: 'lineage.parentAuthorName is invalid' };
+  }
+  const rootAuthorName = lineageName(value.rootAuthorName, COMMUNITY_AUTHOR_NAME_MAX_LENGTH);
+  if (rootAuthorName === null) return { ok: false, message: 'lineage.rootAuthorName is invalid' };
+  return {
+    ok: true,
+    lineage: {
+      parentId: value.parentId,
+      rootId: value.rootId,
+      parentName,
+      parentAuthorName,
+      rootAuthorName,
+    },
+  };
+}
+
+export interface CommunityPublishPayload {
+  name: string;
+  description: string;
+  authorName: string;
+  category: CommunityCategory;
+  /** Sanitized, allowlist-filtered params from `validateDesignerShare`; persist these, never the raw input. */
+  params: Record<string, unknown>;
+  techniques: CommunityTechnique[];
+  /** Raw base64 (any data-URL prefix stripped), ready to decode for blob upload. */
+  thumbnails: string[];
+  /** Raw base64 GLB, magic-byte checked. */
+  glb: string;
+}
+
+export type CommunityValidationResult =
+  | { valid: true; payload: CommunityPublishPayload }
+  | { valid: false; error: { code: string; message: string } };
+
+const BASE64_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
+const WEBP_DATA_URL_PREFIX = 'data:image/webp;base64,';
+
+// Worst-case encoded length for a decoded cap, checked before the base64
+// regex runs so the regex never walks an unbounded string.
+function maxEncodedLength(maxDecodedBytes: number): number {
+  return Math.ceil(maxDecodedBytes / 3) * 4 + 4;
+}
+
+function decodedBase64Bytes(base64: string): number {
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+// WebP is RIFF-framed: 'RIFF' at 0-3, 'WEBP' at 8-11. Slicing at a
+// 4-char base64 boundary decodes the header without touching the body.
+function hasWebpMagic(base64: string): boolean {
+  const head = Buffer.from(base64.slice(0, 24), 'base64');
+  return (
+    head.length >= 12 &&
+    head.toString('latin1', 0, 4) === 'RIFF' &&
+    head.toString('latin1', 8, 12) === 'WEBP'
+  );
+}
+
+function hasGlbMagic(base64: string): boolean {
+  const head = Buffer.from(base64.slice(0, 8), 'base64');
+  return head.length >= 4 && head.toString('latin1', 0, 4) === 'glTF';
+}
+
+type AssetCheck = { ok: true; base64: string } | { ok: false; message: string };
+
+function checkThumbnail(value: unknown, index: number): AssetCheck {
+  if (!isString(value)) {
+    return { ok: false, message: `thumbnails[${index}] must be a string` };
+  }
+  let base64 = value;
+  if (base64.startsWith('data:')) {
+    if (!base64.startsWith(WEBP_DATA_URL_PREFIX)) {
+      return { ok: false, message: `thumbnails[${index}] must be an image/webp data URL` };
+    }
+    base64 = base64.slice(WEBP_DATA_URL_PREFIX.length);
+  }
+  if (base64.length === 0 || base64.length > maxEncodedLength(MAX_COMMUNITY_THUMBNAIL_BYTES)) {
+    return {
+      ok: false,
+      message: `thumbnails[${index}] exceeds ${MAX_COMMUNITY_THUMBNAIL_BYTES} decoded bytes`,
+    };
+  }
+  if (!BASE64_REGEX.test(base64)) {
+    return { ok: false, message: `thumbnails[${index}] must be base64` };
+  }
+  if (decodedBase64Bytes(base64) > MAX_COMMUNITY_THUMBNAIL_BYTES) {
+    return {
+      ok: false,
+      message: `thumbnails[${index}] exceeds ${MAX_COMMUNITY_THUMBNAIL_BYTES} decoded bytes`,
+    };
+  }
+  if (!hasWebpMagic(base64)) {
+    return { ok: false, message: `thumbnails[${index}] is not a WebP image` };
+  }
+  return { ok: true, base64 };
+}
+
+function checkGlb(value: unknown): AssetCheck {
+  if (!isString(value) || value.length === 0) {
+    return { ok: false, message: 'glb must be a base64 string' };
+  }
+  if (value.length > maxEncodedLength(MAX_COMMUNITY_GLB_BYTES)) {
+    return { ok: false, message: `glb exceeds ${MAX_COMMUNITY_GLB_BYTES} decoded bytes` };
+  }
+  if (!BASE64_REGEX.test(value)) {
+    return { ok: false, message: 'glb must be base64' };
+  }
+  if (decodedBase64Bytes(value) > MAX_COMMUNITY_GLB_BYTES) {
+    return { ok: false, message: `glb exceeds ${MAX_COMMUNITY_GLB_BYTES} decoded bytes` };
+  }
+  if (!hasGlbMagic(value)) {
+    return { ok: false, message: 'glb is missing the glTF magic bytes' };
+  }
+  return { ok: true, base64: value };
+}
+
+export function validateCommunityPublish(body: unknown): CommunityValidationResult {
+  if (!isObject(body)) {
+    return validationError('INVALID_PAYLOAD', 'Request body must be an object');
+  }
+
+  if (!isString(body.name)) {
+    return validationError('INVALID_NAME', 'name must be a string');
+  }
+  const name = body.name.trim();
+  if (name.length < 1 || name.length > COMMUNITY_NAME_MAX_LENGTH) {
+    return validationError(
+      'INVALID_NAME',
+      `name must be 1-${COMMUNITY_NAME_MAX_LENGTH} characters`
+    );
+  }
+
+  let description = '';
+  if (body.description !== undefined) {
+    if (!isString(body.description)) {
+      return validationError('INVALID_DESCRIPTION', 'description must be a string');
+    }
+    description = body.description.trim();
+  }
+  if (description.length > COMMUNITY_DESCRIPTION_MAX_LENGTH) {
+    return validationError(
+      'INVALID_DESCRIPTION',
+      `description must be at most ${COMMUNITY_DESCRIPTION_MAX_LENGTH} characters`
+    );
+  }
+
+  if (!isString(body.authorName)) {
+    return validationError('INVALID_AUTHOR_NAME', 'authorName must be a string');
+  }
+  const authorName = body.authorName.trim();
+  if (authorName.length < 1 || authorName.length > COMMUNITY_AUTHOR_NAME_MAX_LENGTH) {
+    return validationError(
+      'INVALID_AUTHOR_NAME',
+      `authorName must be 1-${COMMUNITY_AUTHOR_NAME_MAX_LENGTH} characters`
+    );
+  }
+
+  // Length caps above bound every string before the filter's regexes run
+  // (they are ReDoS-prone on unbounded input). A publish has no "show as
+  // anonymous" fallback, so a filter failure is a hard reject.
+  if (!checkText(name).passed) {
+    return validationError('CONTENT_BLOCKED', 'name contains prohibited content');
+  }
+  if (description !== '' && !checkText(description).passed) {
+    return validationError('CONTENT_BLOCKED', 'description contains prohibited content');
+  }
+  if (!filterDisplayName(authorName).passed) {
+    return validationError('CONTENT_BLOCKED', 'authorName contains prohibited content');
+  }
+
+  if (
+    !isString(body.category) ||
+    !(COMMUNITY_CATEGORIES as readonly string[]).includes(body.category)
+  ) {
+    return validationError(
+      'INVALID_CATEGORY',
+      `category must be one of: ${COMMUNITY_CATEGORIES.join(', ')}`
+    );
+  }
+  const category = body.category as CommunityCategory;
+
+  if (!isObject(body.params)) {
+    return validationError('MISSING_PARAMS', 'params must be an object');
+  }
+  const designerPayload = { type: 'designer' as const, version: 1 as const, params: body.params };
+  // sizeBytes covers what the design blob will actually persist (envelope +
+  // params). Thumbnails and the GLB are separate blobs with their own caps.
+  const sizeBytes = Buffer.byteLength(
+    JSON.stringify({ name, description, category, ...designerPayload }),
+    'utf8'
+  );
+  const designResult = validateDesignerShare(designerPayload, sizeBytes);
+  if (!designResult.valid) {
+    return { valid: false, error: designResult.error };
+  }
+  const params = designResult.payload.params;
+
+  // Sweeps engraved/label text nested inside the sanitized params, a
+  // separate channel from the envelope strings checked above.
+  const designText = filterSharedDesignsContent([{ name, params }]);
+  if (!designText.passed) {
+    return validationError('CONTENT_BLOCKED', designText.reason ?? 'contains prohibited content');
+  }
+
+  if (!Array.isArray(body.thumbnails) || body.thumbnails.length < 1) {
+    return validationError('INVALID_THUMBNAILS', 'thumbnails must be a non-empty array');
+  }
+  if (body.thumbnails.length > MAX_COMMUNITY_THUMBNAILS) {
+    return validationError(
+      'INVALID_THUMBNAILS',
+      `at most ${MAX_COMMUNITY_THUMBNAILS} thumbnails allowed`
+    );
+  }
+  const thumbnails: string[] = [];
+  for (let i = 0; i < body.thumbnails.length; i++) {
+    const check = checkThumbnail(body.thumbnails[i], i);
+    if (!check.ok) return validationError('INVALID_THUMBNAILS', check.message);
+    thumbnails.push(check.base64);
+  }
+
+  const glbCheck = checkGlb(body.glb);
+  if (!glbCheck.ok) return validationError('INVALID_GLB', glbCheck.message);
+
+  return {
+    valid: true,
+    payload: {
+      name,
+      description,
+      authorName,
+      category,
+      params,
+      techniques: deriveCommunityTechniques(params),
+      thumbnails,
+      glb: glbCheck.base64,
+    },
+  };
+}

--- a/api/lib/communityValidation.ts
+++ b/api/lib/communityValidation.ts
@@ -207,7 +207,10 @@ function checkThumbnail(value: unknown, index: number): AssetCheck {
     }
     base64 = base64.slice(WEBP_DATA_URL_PREFIX.length);
   }
-  if (base64.length === 0 || base64.length > maxEncodedLength(MAX_COMMUNITY_THUMBNAIL_BYTES)) {
+  if (base64.length === 0) {
+    return { ok: false, message: `thumbnails[${index}] is empty` };
+  }
+  if (base64.length > maxEncodedLength(MAX_COMMUNITY_THUMBNAIL_BYTES)) {
     return {
       ok: false,
       message: `thumbnails[${index}] exceeds ${MAX_COMMUNITY_THUMBNAIL_BYTES} decoded bytes`,

--- a/api/lib/contentFilter.test.ts
+++ b/api/lib/contentFilter.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  checkText,
   filterDisplayName,
   filterLayoutContent,
   filterSharedDesignsContent,
@@ -389,5 +390,27 @@ describe('filterSharedDesignsContent', () => {
     for (let i = 0; i < 200; i++) deep = { nested: deep };
 
     expect(filterSharedDesignsContent([design({ params: deep })]).passed).toBe(true);
+  });
+});
+
+describe('checkText', () => {
+  it('passes ordinary free-text descriptions', () => {
+    const result = checkText('Holds 25 assorted M3 screws.\nPrint with 3 walls.');
+    expect(result.passed).toBe(true);
+  });
+
+  it('rejects blocklisted terms', () => {
+    expect(checkText('kys').passed).toBe(false);
+  });
+
+  it('rejects harmful patterns like URLs', () => {
+    expect(checkText('visit https://spam.example now').passed).toBe(false);
+  });
+
+  it('is the same gate filterDisplayName applies', () => {
+    const sample = ['clean text', 'kys', '<script>alert(1)</script>'];
+    for (const text of sample) {
+      expect(checkText(text).passed).toBe(filterDisplayName(text).passed);
+    }
   });
 });

--- a/api/lib/contentFilter.ts
+++ b/api/lib/contentFilter.ts
@@ -185,8 +185,13 @@ export function filterDisplayName(name: string): ContentFilterResult {
 
 /**
  * Check a single text string for offensive content.
+ *
+ * Exported for free-text fields (e.g. a community design description) that
+ * aren't display names. Callers must bound the string's length BEFORE calling:
+ * the harmful-pattern regexes are only safe on capped input (see the ReDoS
+ * note above HARMFUL_PATTERNS).
  */
-function checkText(text: string): ContentFilterResult {
+export function checkText(text: string): ContentFilterResult {
   const normalized = normalizeForBlocklist(text);
 
   // Check blocklist against the normalized form so Unicode tricks

--- a/api/lib/rateLimit.test.ts
+++ b/api/lib/rateLimit.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit coverage for the RATE_LIMITS config surface (the table is private, so
+ * limits are observed through the no-Redis fail-open path, which reports the
+ * configured limit as `remaining`). Enforcement against a real Redis lives in
+ * rateLimit.integration.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type * as RateLimitModule from './rateLimit.js';
+
+async function limiter(): Promise<typeof RateLimitModule> {
+  return import('./rateLimit.js');
+}
+
+describe('community rate-limit actions', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('REDIS_URL', '');
+    vi.stubEnv('VERCEL_ENV', 'development');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('community.read allows 240 per minute', async () => {
+    const { checkRateLimit } = await limiter();
+    const result = await checkRateLimit('203.0.113.1', 'community.read');
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(240);
+    expect(result.resetAt - Math.floor(Date.now() / 1000)).toBeLessThanOrEqual(60);
+  });
+
+  it('community.publish allows 10 per day per user', async () => {
+    const { checkRateLimit } = await limiter();
+    const result = await checkRateLimit('user-1', 'community.publish');
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(10);
+    expect(result.resetAt - Math.floor(Date.now() / 1000)).toBeGreaterThan(60 * 60);
+    expect(result.resetAt - Math.floor(Date.now() / 1000)).toBeLessThanOrEqual(24 * 60 * 60);
+  });
+
+  it('community.manage allows 60 per day, separate from the publish budget', async () => {
+    const { checkRateLimit } = await limiter();
+    const result = await checkRateLimit('user-1', 'community.manage');
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(60);
+    expect(result.resetAt - Math.floor(Date.now() / 1000)).toBeGreaterThan(60 * 60);
+    expect(result.resetAt - Math.floor(Date.now() / 1000)).toBeLessThanOrEqual(24 * 60 * 60);
+  });
+
+  it('fails closed for community actions in production without Redis', async () => {
+    vi.stubEnv('VERCEL_ENV', 'production');
+    const { checkRateLimit } = await limiter();
+    expect((await checkRateLimit('user-1', 'community.publish')).allowed).toBe(false);
+    expect((await checkRateLimit('203.0.113.1', 'community.read')).allowed).toBe(false);
+  });
+});

--- a/api/lib/rateLimit.ts
+++ b/api/lib/rateLimit.ts
@@ -20,7 +20,10 @@ export type RateLimitAction =
   | 'scan.upload'
   | 'scan.poll'
   | 'kofi.webhook'
-  | 'supporters.read';
+  | 'supporters.read'
+  | 'community.read'
+  | 'community.publish'
+  | 'community.manage';
 
 /**
  * Parse Redis URL using WHATWG URL API to avoid deprecated url.parse().
@@ -72,6 +75,18 @@ const RATE_LIMITS: Record<RateLimitAction, RateLimitConfig> = {
   'kofi.webhook': { limit: 60, windowSeconds: 60 }, // 60/minute per IP
   // Public supporters read — cached at the edge, so this only sees cache misses.
   'supporters.read': { limit: 120, windowSeconds: 60 }, // 120/minute per IP
+  // Community showcase: browsing is anonymous so reads are keyed by IP with
+  // sync.read-level headroom (index pages + detail fetches). Publishing is
+  // keyed by userId and deliberately scarce: nobody legitimately publishes
+  // more than a handful of designs a day, and the 25-live quota makes a
+  // bigger budget pointless.
+  'community.read': { limit: 240, windowSeconds: 60 }, // 240/minute per IP
+  'community.publish': { limit: 10, windowSeconds: 24 * 60 * 60 }, // 10/day per user
+  // Remediation on existing designs (update, unpublish, admin purge) has its
+  // own budget: sharing the scarce publish budget would lock a user who
+  // published 10 times out of deleting their own designs, and cap an admin's
+  // moderation sweeps at 10/day per IP.
+  'community.manage': { limit: 60, windowSeconds: 24 * 60 * 60 }, // 60/day per user (admin path: per IP)
 };
 
 interface RateLimitResult {

--- a/api/lib/redisKeys.test.ts
+++ b/api/lib/redisKeys.test.ts
@@ -9,6 +9,17 @@ import {
   userProfileKey,
   userIndexKey,
   userIndexUpdatedAtKey,
+  COMMUNITY_INDEX_SORTS,
+  communityDesignKey,
+  communityIndexKey,
+  communityLikesKey,
+  communityLikedKey,
+  communityChildrenKey,
+  communityAuthorKey,
+  communityPublishedKey,
+  communityReportsKey,
+  communityReportedKey,
+  communityDenylistKey,
 } from './redisKeys';
 
 describe('redisKeys', () => {
@@ -53,6 +64,68 @@ describe('redisKeys', () => {
 
     it('userIndexUpdatedAtKey produces users:{uid}:indexUpdatedAt', () => {
       expect(userIndexUpdatedAtKey('user-1')).toBe('users:user-1:indexUpdatedAt');
+    });
+  });
+
+  describe('community keys', () => {
+    it('communityDesignKey produces community:design:{id}', () => {
+      expect(communityDesignKey('abc123def456')).toBe('community:design:abc123def456');
+    });
+
+    it('communityIndexKey produces community:index:{sort} for every sort', () => {
+      expect(COMMUNITY_INDEX_SORTS).toEqual(['newest', 'remixes', 'likes']);
+      expect(communityIndexKey('newest')).toBe('community:index:newest');
+      expect(communityIndexKey('remixes')).toBe('community:index:remixes');
+      expect(communityIndexKey('likes')).toBe('community:index:likes');
+    });
+
+    it('communityLikesKey produces community:likes:{id}', () => {
+      expect(communityLikesKey('abc123def456')).toBe('community:likes:abc123def456');
+    });
+
+    it('communityLikedKey produces community:liked:{uid}', () => {
+      expect(communityLikedKey('user-1')).toBe('community:liked:user-1');
+    });
+
+    it('communityChildrenKey produces community:children:{id}', () => {
+      expect(communityChildrenKey('abc123def456')).toBe('community:children:abc123def456');
+    });
+
+    it('communityAuthorKey produces community:author:{publicId}', () => {
+      expect(communityAuthorKey('deadbeef')).toBe('community:author:deadbeef');
+    });
+
+    it('communityPublishedKey produces community:published:{uid}', () => {
+      expect(communityPublishedKey('user-1')).toBe('community:published:user-1');
+    });
+
+    it('communityReportsKey produces community:reports:{id}', () => {
+      expect(communityReportsKey('abc123def456')).toBe('community:reports:abc123def456');
+    });
+
+    it('communityReportedKey produces community:reported:{uid}', () => {
+      expect(communityReportedKey('user-1')).toBe('community:reported:user-1');
+    });
+
+    it('communityDenylistKey produces community:denylist', () => {
+      expect(communityDenylistKey()).toBe('community:denylist');
+    });
+
+    it('community keys never collide with each other for a shared id segment', () => {
+      const id = 'a';
+      const keys = [
+        communityDesignKey(id),
+        communityIndexKey('newest'),
+        communityLikesKey(id),
+        communityLikedKey(id),
+        communityChildrenKey(id),
+        communityAuthorKey(id),
+        communityPublishedKey(id),
+        communityReportsKey(id),
+        communityReportedKey(id),
+        communityDenylistKey(),
+      ];
+      expect(new Set(keys).size).toBe(keys.length);
     });
   });
 

--- a/api/lib/redisKeys.ts
+++ b/api/lib/redisKeys.ts
@@ -19,9 +19,22 @@
  *   supporters:donors               → HASH of donorId → JSON {n,t,m} record (legacy: bare name)
  *   supporters:totals               → HASH of currency → received minor units (collect-only)
  *   supporters:msg:{messageId}      → Ko-fi webhook dedupe marker
+ *   community:design:{id}           → HASH of card metadata + status + counters for a published design
+ *   community:index:{sort}          → ZSET of design ids scored for one sort (newest|remixes|likes)
+ *   community:likes:{id}            → SET of userIds who liked a design
+ *   community:liked:{uid}           → SET of design ids a user liked (reverse index for heart state + deletion cascade)
+ *   community:children:{id}         → SET of published direct-remix design ids
+ *   community:author:{publicId}     → SET of design ids published under one author publicId
+ *   community:published:{uid}       → SET of design ids a user has published (quota via SCARD)
+ *   community:reports:{id}          → SET of userIds who reported a design (per-account dedupe)
+ *   community:reported:{uid}        → SET of design ids a user reported (reverse index for the account-deletion cascade)
+ *   community:denylist              → SET of userIds barred from publishing
  */
 
 export type SyncItemKind = 'layouts' | 'designs' | 'baseplates';
+
+export const COMMUNITY_INDEX_SORTS = ['newest', 'remixes', 'likes'] as const;
+export type CommunityIndexSort = (typeof COMMUNITY_INDEX_SORTS)[number];
 
 /** Delete-token hash for an anonymous share. */
 export function shareHashKey(shareId: string): string {
@@ -94,4 +107,58 @@ export function supportersTotalsKey(): string {
 /** Dedupe marker for a Ko-fi webhook delivery (their retries reuse `message_id`). */
 export function supportersMessageKey(messageId: string): string {
   return `supporters:msg:${messageId}`;
+}
+
+/** Card metadata + status + counters for a published community design. */
+export function communityDesignKey(designId: string): string {
+  return `community:design:${designId}`;
+}
+
+/** Sorted set of live design ids for one gallery sort mode. */
+export function communityIndexKey(sort: CommunityIndexSort): string {
+  return `community:index:${sort}`;
+}
+
+/** SET of userIds who liked a design (like counts derive from its card hash, not SCARD). */
+export function communityLikesKey(designId: string): string {
+  return `community:likes:${designId}`;
+}
+
+/** Reverse index: SET of design ids a user liked (heart state + account-deletion cascade). */
+export function communityLikedKey(userId: string): string {
+  return `community:liked:${userId}`;
+}
+
+/** SET of published design ids that are direct remixes of a design. */
+export function communityChildrenKey(designId: string): string {
+  return `community:children:${designId}`;
+}
+
+/** SET of design ids published under one pseudonymous author publicId. */
+export function communityAuthorKey(authorPublicId: string): string {
+  return `community:author:${authorPublicId}`;
+}
+
+/** SET of design ids a user has published; publish quota is SCARD over this. */
+export function communityPublishedKey(userId: string): string {
+  return `community:published:${userId}`;
+}
+
+/** SET of userIds who reported a design (per-account dedupe for the auto-hide threshold). */
+export function communityReportsKey(designId: string): string {
+  return `community:reports:${designId}`;
+}
+
+/**
+ * Reverse index: SET of design ids a user reported. Whatever records a report
+ * must SADD here too, or the account-deletion cascade cannot find and remove
+ * the user's entries from each design's reports set.
+ */
+export function communityReportedKey(userId: string): string {
+  return `community:reported:${userId}`;
+}
+
+/** SET of userIds barred from publishing to the community showcase. */
+export function communityDenylistKey(): string {
+  return 'community:denylist';
 }

--- a/api/sync/account.test.ts
+++ b/api/sync/account.test.ts
@@ -5,12 +5,14 @@
  * end-state without throwing.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { communityDesignBlobPath } from '../lib/communityStore';
 
 let redisStore: Map<string, string>;
 let redisHashes: Map<string, Map<string, string>>;
 let redisSets: Map<string, Set<string>>;
+let redisZsets: Map<string, Map<string, number>>;
 let blobStore: Map<string, unknown>;
 
 const mockRedis = {
@@ -25,6 +27,7 @@ const mockRedis = {
       if (redisStore.delete(k)) count++;
       if (redisHashes.delete(k)) count++;
       if (redisSets.delete(k)) count++;
+      if (redisZsets.delete(k)) count++;
     }
     return count;
   }),
@@ -34,6 +37,34 @@ const mockRedis = {
     s.add(m);
     redisSets.set(k, s);
     return 1;
+  }),
+  srem: vi.fn(async (k: string, ...members: string[]) => {
+    const s = redisSets.get(k);
+    if (!s) return 0;
+    let count = 0;
+    for (const m of members) {
+      if (s.delete(m)) count++;
+    }
+    if (s.size === 0) redisSets.delete(k);
+    return count;
+  }),
+  zrem: vi.fn(async (k: string, ...members: string[]) => {
+    const z = redisZsets.get(k);
+    if (!z) return 0;
+    let count = 0;
+    for (const m of members) {
+      if (z.delete(m)) count++;
+    }
+    if (z.size === 0) redisZsets.delete(k);
+    return count;
+  }),
+  hexists: vi.fn(async (k: string, f: string) => (redisHashes.get(k)?.has(f) ? 1 : 0)),
+  hincrby: vi.fn(async (k: string, f: string, by: number) => {
+    const h = redisHashes.get(k) ?? new Map<string, string>();
+    const next = Number(h.get(f) ?? '0') + by;
+    h.set(f, String(next));
+    redisHashes.set(k, h);
+    return next;
   }),
   hkeys: vi.fn(async (k: string) => Array.from(redisHashes.get(k)?.keys() ?? [])),
   hset: vi.fn(async (k: string, f: string, v: string) => {
@@ -69,7 +100,7 @@ const deleteBlobMock = vi.fn(async (path: string) => {
 
 vi.mock('../lib/blobStore', () => ({
   putJson: vi.fn(),
-  getJson: vi.fn(),
+  getJson: vi.fn(async (path: string) => blobStore.get(path) ?? null),
   deleteBlob: (path: string) => deleteBlobMock(path),
   headBlob: vi.fn(),
 }));
@@ -130,15 +161,57 @@ function setSet(key: string, members: string[]) {
   redisSets.set(key, new Set(members));
 }
 
+function setZset(key: string, members: Record<string, number>) {
+  redisZsets.set(key, new Map(Object.entries(members)));
+}
+
+function seedCommunityDesign(
+  id: string,
+  authorPublicId: string,
+  opts: {
+    likes?: string[];
+    children?: string[];
+    reports?: string[];
+    parentId?: string;
+  } = {}
+) {
+  blobStore.set(communityDesignBlobPath(id), {
+    id,
+    authorPublicId,
+    thumbnails: [`https://blob.example/community/thumbs/${id}-1-0.webp`],
+    meshUrl: `https://blob.example/community/meshes/${id}-1.glb`,
+    lineage:
+      opts.parentId === undefined
+        ? null
+        : {
+            parentId: opts.parentId,
+            rootId: opts.parentId,
+            parentName: 'Parent',
+            parentAuthorName: 'Ada',
+            rootAuthorName: 'Ada',
+          },
+  });
+  setHash(`community:design:${id}`, { id, likes: String(opts.likes?.length ?? 0), status: 'live' });
+  if (opts.likes) setSet(`community:likes:${id}`, opts.likes);
+  if (opts.children) setSet(`community:children:${id}`, opts.children);
+  if (opts.reports) setSet(`community:reports:${id}`, opts.reports);
+}
+
 beforeEach(() => {
   redisStore = new Map();
   redisHashes = new Map();
   redisSets = new Map();
+  redisZsets = new Map();
   blobStore = new Map();
   vi.clearAllMocks();
+  vi.stubEnv('TOKEN_SALT', 'test-salt');
   deleteBlobMock.mockImplementation(async (path: string) => {
     blobStore.delete(path);
   });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe('DELETE /api/sync/account', () => {
@@ -214,6 +287,172 @@ describe('DELETE /api/sync/account', () => {
     expect(res._status).toBe(204);
     // KV state still cleared even though a blob failed.
     expect(redisHashes.has('users:user-1:index:layouts')).toBe(false);
+  });
+
+  it('removes every community key for a user with published designs and likes', async () => {
+    const { deriveAuthorPublicId } = await import('../lib/communityIds');
+    const authorPublicId = deriveAuthorPublicId('user-1');
+    expect(authorPublicId).not.toBeNull();
+    const authorKey = `community:author:${String(authorPublicId)}`;
+
+    seedCommunityDesign('cd-1', String(authorPublicId), {
+      likes: ['user-2', 'user-3'],
+      children: ['remix-1'],
+    });
+    seedCommunityDesign('cd-2', String(authorPublicId), { reports: ['user-4'] });
+    setSet('community:published:user-1', ['cd-1', 'cd-2']);
+    setSet(authorKey, ['cd-1', 'cd-2']);
+    setZset('community:index:newest', { 'cd-1': 1, 'cd-2': 2, 'other-cd': 3 });
+    setZset('community:index:remixes', { 'cd-1': 1, 'other-cd': 0 });
+    setZset('community:index:likes', { 'cd-1': 2, 'cd-2': 0, 'other-cd': 5 });
+
+    setSet('community:liked:user-1', ['oth-1', 'oth-2', 'oth-3']);
+    for (const id of ['oth-1', 'oth-2', 'oth-3']) {
+      setHash(`community:design:${id}`, { id, likes: '5', status: 'live' });
+      setSet(`community:likes:${id}`, ['user-1', 'user-9']);
+    }
+    setSet('community:denylist', ['user-1', 'user-5']);
+
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(204);
+
+    // Published-design blobs gone: record via path, assets via stored URLs.
+    expect(blobStore.has(communityDesignBlobPath('cd-1'))).toBe(false);
+    expect(blobStore.has(communityDesignBlobPath('cd-2'))).toBe(false);
+    expect(deleteBlobMock).toHaveBeenCalledWith(
+      'https://blob.example/community/thumbs/cd-1-1-0.webp'
+    );
+    expect(deleteBlobMock).toHaveBeenCalledWith('https://blob.example/community/meshes/cd-1-1.glb');
+    expect(deleteBlobMock).toHaveBeenCalledWith(
+      'https://blob.example/community/thumbs/cd-2-1-0.webp'
+    );
+    expect(deleteBlobMock).toHaveBeenCalledWith('https://blob.example/community/meshes/cd-2-1.glb');
+
+    // Per-design keys gone.
+    for (const id of ['cd-1', 'cd-2']) {
+      expect(redisHashes.has(`community:design:${id}`)).toBe(false);
+      expect(redisSets.has(`community:likes:${id}`)).toBe(false);
+      expect(redisSets.has(`community:children:${id}`)).toBe(false);
+      expect(redisSets.has(`community:reports:${id}`)).toBe(false);
+    }
+
+    // Sort-index memberships removed, other designs untouched.
+    for (const sort of ['newest', 'remixes', 'likes']) {
+      const zset = redisZsets.get(`community:index:${sort}`);
+      expect(zset?.has('cd-1')).toBe(false);
+      expect(zset?.has('cd-2')).toBe(false);
+      expect(zset?.has('other-cd')).toBe(true);
+    }
+
+    // Liked designs: membership removed, counts decremented, other likers kept.
+    for (const id of ['oth-1', 'oth-2', 'oth-3']) {
+      expect(redisSets.get(`community:likes:${id}`)).toEqual(new Set(['user-9']));
+      expect(redisHashes.get(`community:design:${id}`)?.get('likes')).toBe('4');
+    }
+
+    // User-scoped keys gone. Deny-list membership survives deletion: the
+    // userId is deterministic, so dropping it would let a banned publisher
+    // reset the ban by deleting and recreating the account.
+    expect(redisSets.has('community:liked:user-1')).toBe(false);
+    expect(redisSets.has('community:published:user-1')).toBe(false);
+    expect(redisSets.has(authorKey)).toBe(false);
+    expect(redisSets.get('community:denylist')).toEqual(new Set(['user-1', 'user-5']));
+  });
+
+  it('removes the deleted designs from every liker reverse liked set', async () => {
+    const { deriveAuthorPublicId } = await import('../lib/communityIds');
+    const authorPublicId = String(deriveAuthorPublicId('user-1'));
+    seedCommunityDesign('cd-1', authorPublicId, { likes: ['user-2', 'user-3'] });
+    setSet('community:published:user-1', ['cd-1']);
+    setSet('community:liked:user-2', ['cd-1', 'other-cd']);
+    setSet('community:liked:user-3', ['cd-1']);
+
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(204);
+
+    expect(redisSets.get('community:liked:user-2')).toEqual(new Set(['other-cd']));
+    expect(redisSets.has('community:liked:user-3')).toBe(false);
+  });
+
+  it('removes a deleted remix from its parent design children set', async () => {
+    const { deriveAuthorPublicId } = await import('../lib/communityIds');
+    const authorPublicId = String(deriveAuthorPublicId('user-1'));
+    seedCommunityDesign('remix-1', authorPublicId, { parentId: 'parent-1' });
+    setSet('community:published:user-1', ['remix-1']);
+    seedCommunityDesign('parent-1', 'other-author', { children: ['remix-1', 'other-remix'] });
+    setSet('community:published:user-2', ['parent-1']);
+
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(204);
+
+    expect(redisSets.get('community:children:parent-1')).toEqual(new Set(['other-remix']));
+    expect(blobStore.has(communityDesignBlobPath('parent-1'))).toBe(true);
+  });
+
+  it('removes the deleted user from every design they reported', async () => {
+    seedCommunityDesign('reported-cd', 'other-author', { reports: ['user-1', 'user-9'] });
+    setSet('community:published:user-2', ['reported-cd']);
+    setSet('community:reported:user-1', ['reported-cd']);
+
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(204);
+
+    expect(redisSets.get('community:reports:reported-cd')).toEqual(new Set(['user-9']));
+    expect(redisSets.has('community:reported:user-1')).toBe(false);
+  });
+
+  it('leaves other users community data untouched when the user has none', async () => {
+    setHash('users:user-1:index:layouts', { 'lay-1': '{}' });
+    blobStore.set('users/user-1/layouts/lay-1.json', {});
+
+    seedCommunityDesign('other-cd', 'other-author', { likes: ['user-2'] });
+    setSet('community:published:user-2', ['other-cd']);
+    setSet('community:author:other-author', ['other-cd']);
+    setSet('community:liked:user-2', ['other-cd']);
+    setSet('community:denylist', ['user-5']);
+    setZset('community:index:newest', { 'other-cd': 1 });
+
+    const { default: handler } = await import('./account');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(204);
+
+    expect(blobStore.has(communityDesignBlobPath('other-cd'))).toBe(true);
+    expect(redisHashes.get('community:design:other-cd')?.get('likes')).toBe('1');
+    expect(redisSets.get('community:likes:other-cd')).toEqual(new Set(['user-2']));
+    expect(redisSets.get('community:published:user-2')).toEqual(new Set(['other-cd']));
+    expect(redisSets.get('community:author:other-author')).toEqual(new Set(['other-cd']));
+    expect(redisSets.get('community:liked:user-2')).toEqual(new Set(['other-cd']));
+    expect(redisSets.get('community:denylist')).toEqual(new Set(['user-5']));
+    expect(redisZsets.get('community:index:newest')?.has('other-cd')).toBe(true);
+    expect(redisHashes.has('users:user-1:index:layouts')).toBe(false);
+  });
+
+  it('does not decrement a liked design twice on cascade replay', async () => {
+    setSet('community:liked:user-1', ['oth-1']);
+    setHash('community:design:oth-1', { id: 'oth-1', likes: '3', status: 'live' });
+    setSet('community:likes:oth-1', ['user-1', 'user-9']);
+    // Simulate a partial failure: the liked set survived the first run.
+    const { default: handler } = await import('./account');
+
+    const firstRes = makeRes();
+    await handler(makeReq(), firstRes as unknown as VercelResponse);
+    expect(firstRes._status).toBe(204);
+    expect(redisHashes.get('community:design:oth-1')?.get('likes')).toBe('2');
+
+    setSet('community:liked:user-1', ['oth-1']);
+    const replayRes = makeRes();
+    await handler(makeReq(), replayRes as unknown as VercelResponse);
+    expect(replayRes._status).toBe(204);
+    expect(redisHashes.get('community:design:oth-1')?.get('likes')).toBe('2');
   });
 
   it('returns 405 for non-DELETE methods', async () => {

--- a/api/sync/account.ts
+++ b/api/sync/account.ts
@@ -7,6 +7,16 @@ import { requireSession } from '../lib/session.js';
 import { clearSessionCookie } from '../lib/cookies.js';
 import { deleteBlob } from '../lib/blobStore.js';
 import {
+  COMMUNITY_INDEX_SORTS,
+  communityAuthorKey,
+  communityChildrenKey,
+  communityDesignKey,
+  communityIndexKey,
+  communityLikedKey,
+  communityLikesKey,
+  communityPublishedKey,
+  communityReportedKey,
+  communityReportsKey,
   sessionKey,
   userIndexKey,
   userIndexUpdatedAtKey,
@@ -14,26 +24,45 @@ import {
   userSessionsKey,
   userTombstoneSweptAtKey,
 } from '../lib/redisKeys.js';
+import {
+  communityDesignBlobPath,
+  readCommunityDesignBlob,
+  type CommunityDesignRecord,
+} from '../lib/communityStore.js';
+import { deriveAuthorPublicId } from '../lib/communityIds.js';
 
 /**
  * DELETE /api/sync/account
  *
  * Hard-delete the signed-in user's account. The cascade order matters:
  *
- *   1. Sessions   — DEL session:{token} for every token in the user's set
+ *   1. Sessions   : DEL session:{token} for every token in the user's set
  *                   (so other tabs/devices flip to anonymous on next sync)
- *   2. Blobs      — del() each layouts/{id}.json, designs/{id}.json, baseplates/{id}.json
- *   3. KV keys    — drop indexes, profile, sessions set, indexUpdatedAt,
- *                   tombstoneSweptAt
- *   4. Cookie     — clear the session cookie on the responding device
+ *   2. Blobs      : del() each layouts/{id}.json, designs/{id}.json, baseplates/{id}.json
+ *   3. Community  : delete each published design (record/thumbnail/mesh blobs,
+ *                   card hash, per-design sets, membership in the parent's
+ *                   children set, every liker's reverse liked set, sort-index
+ *                   memberships), un-like everything
+ *                   in the reverse liked set, un-report everything in the
+ *                   reverse reported set
+ *   4. KV keys    : drop indexes, profile, sessions set, indexUpdatedAt,
+ *                   tombstoneSweptAt, liked/published/reported sets, author set
+ *   5. Cookie     : clear the session cookie on the responding device
+ *
+ * Deny-list membership survives deletion on purpose: the userId is a
+ * deterministic hash of the OAuth identity, so deleting the account and
+ * signing back in would otherwise reset a publishing ban. The set stores
+ * only that pseudonymous hash.
  *
  * Idempotent on partial-failure replay: each step uses unconditional DEL,
  * so repeating after a timeout/cold-start just no-ops on already-cleared
- * keys. The blob loop catches per-blob errors and continues — a stuck
+ * keys. The blob loop catches per-blob errors and continues, so a stuck
  * blob won't block the rest of the cascade.
  *
- * Vercel function timeout is 60s. With max 100 layouts + 100 designs +
- * 100 baseplates × ~50ms per Blob delete = ~15s worst case, within budget.
+ * Vercel function timeout is 60s. Max 100 layouts + 100 designs +
+ * 100 baseplates plus 25 published community designs at up to 5 blobs each
+ * (record + 3 thumbnails + mesh) is 425 Blob deletes x ~50ms = ~21s worst
+ * case, within budget.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
   if (!requireMethod(req, res, ['DELETE'])) return;
@@ -63,7 +92,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     }
 
     // 2. Delete every blob this user owns. Errors per-blob are logged but
-    //    don't block the cascade — leftover blobs are storage cost only,
+    //    don't block the cascade: leftover blobs are storage cost only,
     //    not a correctness issue, and re-issuing the request will retry.
     const layoutIds = await redis.hkeys(userIndexKey(userId, 'layouts'));
     const designIds = await redis.hkeys(userIndexKey(userId, 'designs'));
@@ -75,7 +104,81 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       ...baseplateIds.map((id) => deleteBlobSafe(`users/${userId}/baseplates/${id}.json`, userId)),
     ]);
 
-    // 3. Drop all per-user KV state in one DEL.
+    // 3. Community cascade. The record blob is read first because it is the
+    //    only place the revision-stamped thumbnail/mesh blob URLs live; a
+    //    failed read only costs that design's asset deletes, not the cascade.
+    const publishedIds = await redis.smembers(communityPublishedKey(userId));
+    const records = await Promise.all(
+      publishedIds.map((id) => readCommunityDesignSafe(id, userId))
+    );
+
+    await Promise.all(
+      publishedIds.flatMap((id, i) => {
+        const record = records[i];
+        const assetUrls = record ? [...record.thumbnails, record.meshUrl] : [];
+        return [
+          deleteBlobSafe(communityDesignBlobPath(id), userId),
+          ...assetUrls.map((url) => deleteBlobSafe(url, userId)),
+        ];
+      })
+    );
+
+    if (publishedIds.length > 0) {
+      // Mirrors the single-design DELETE handler: each liker's reverse liked
+      // set must drop these ids before the likes sets are deleted, or other
+      // users keep phantom hearts pointing at dead designs forever.
+      const likerSets = await Promise.all(
+        publishedIds.map((id) => redis.smembers(communityLikesKey(id)))
+      );
+      await Promise.all(
+        publishedIds.flatMap((id, i) =>
+          likerSets[i].map((liker) => redis.srem(communityLikedKey(liker), id))
+        )
+      );
+      await Promise.all(
+        COMMUNITY_INDEX_SORTS.map((sort) => redis.zrem(communityIndexKey(sort), ...publishedIds))
+      );
+      // A remix must also leave its parent's children set, mirroring the
+      // single-design DELETE handler; otherwise a live parent keeps a
+      // dangling child id forever.
+      await Promise.all(
+        publishedIds.flatMap((id, i) => {
+          const parentId = records[i]?.lineage?.parentId;
+          return parentId === undefined ? [] : [redis.srem(communityChildrenKey(parentId), id)];
+        })
+      );
+      await redis.del(
+        ...publishedIds.flatMap((id) => [
+          communityDesignKey(id),
+          communityLikesKey(id),
+          communityChildrenKey(id),
+          communityReportsKey(id),
+        ])
+      );
+    }
+
+    const likedIds = await redis.smembers(communityLikedKey(userId));
+    for (const likedId of likedIds) {
+      const removed = await redis.srem(communityLikesKey(likedId), userId);
+      // The SREM result gates the decrement so a replayed cascade can't
+      // double-decrement a surviving design's like count.
+      if (removed > 0 && (await redis.hexists(communityDesignKey(likedId), 'likes')) === 1) {
+        await redis.hincrby(communityDesignKey(likedId), 'likes', -1);
+      }
+    }
+
+    const reportedIds = await redis.smembers(communityReportedKey(userId));
+    for (const reportedId of reportedIds) {
+      await redis.srem(communityReportsKey(reportedId), userId);
+    }
+
+    // 4. Drop all per-user KV state in one DEL. The author set falls back to
+    //    the publicId stored on a published record so the key still clears if
+    //    TOKEN_SALT was rotated out since publish.
+    const authorPublicId =
+      deriveAuthorPublicId(userId) ??
+      records.find((record) => record !== null)?.authorPublicId ??
+      null;
     await redis.del(
       userIndexKey(userId, 'layouts'),
       userIndexKey(userId, 'designs'),
@@ -83,10 +186,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       userIndexUpdatedAtKey(userId),
       userProfileKey(userId),
       userSessionsKey(userId),
-      userTombstoneSweptAtKey(userId)
+      userTombstoneSweptAtKey(userId),
+      communityLikedKey(userId),
+      communityPublishedKey(userId),
+      communityReportedKey(userId),
+      ...(authorPublicId === null ? [] : [communityAuthorKey(authorPublicId)])
     );
 
-    // 4. Clear the session cookie on the device making this request.
+    // 5. Clear the session cookie on the device making this request.
     clearSessionCookie(res);
     res.status(204).end();
   } catch (error) {
@@ -98,6 +205,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 }
 
+async function readCommunityDesignSafe(
+  designId: string,
+  userId: string
+): Promise<CommunityDesignRecord | null> {
+  try {
+    return await readCommunityDesignBlob(designId);
+  } catch (error) {
+    logger.error('account-delete: community record read failed', {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
 async function deleteBlobSafe(path: string, userId: string): Promise<void> {
   try {
     await deleteBlob(path);
@@ -106,6 +228,6 @@ async function deleteBlobSafe(path: string, userId: string): Promise<void> {
       userId,
       error: error instanceof Error ? error.message : String(error),
     });
-    // Continue — leftover blobs are storage cost, not a correctness issue.
+    // Continue: leftover blobs are storage cost, not a correctness issue.
   }
 }

--- a/api/sync/export.test.ts
+++ b/api/sync/export.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { communityDesignBlobPath } from '../lib/communityStore';
 
 let redisStore: Map<string, string>;
 let redisHashes: Map<string, Map<string, string>>;
+let redisSets: Map<string, Set<string>>;
 const blobStore = new Map<string, unknown>();
 
 const mockRedis = {
@@ -15,6 +17,7 @@ const mockRedis = {
     const h = redisHashes.get(k);
     return h ? Object.fromEntries(h) : {};
   }),
+  smembers: vi.fn(async (k: string) => Array.from(redisSets.get(k) ?? [])),
   pipeline: vi.fn(() => {
     const queue: Array<() => [Error | null, unknown]> = [];
     const pipe = {
@@ -157,8 +160,14 @@ async function seedItem(
 beforeEach(() => {
   redisStore = new Map();
   redisHashes = new Map();
+  redisSets = new Map();
   blobStore.clear();
   vi.clearAllMocks();
+  vi.stubEnv('TOKEN_SALT', 'test-salt');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe('GET /api/sync/export', () => {
@@ -171,11 +180,69 @@ describe('GET /api/sync/export', () => {
     expect(res._headers['Content-Disposition']).toMatch(/^attachment; filename=/);
     expect(Buffer.isBuffer(res._body)).toBe(true);
 
-    const { unzipSync } = await import('fflate');
+    const { unzipSync, strFromU8 } = await import('fflate');
     const zip = unzipSync(new Uint8Array(res._body as Buffer));
     const names = Object.keys(zip);
     expect(names).toContain('manifest.json');
     expect(names.filter((n) => n.startsWith('layouts/'))).toEqual([]);
+    expect(names.filter((n) => n.startsWith('community/'))).toEqual([]);
+
+    const manifest = JSON.parse(strFromU8(zip['manifest.json']));
+    expect(manifest.community).toEqual([]);
+  });
+
+  it('includes published community designs in the manifest and as files', async () => {
+    redisSets.set('community:published:user-1', new Set(['cd-2', 'cd-1']));
+    const recordOne = {
+      id: 'cd-1',
+      authorPublicId: 'pub-1',
+      name: 'Socket tray',
+      params: { width: 2 },
+      status: 'live',
+    };
+    const recordTwo = {
+      id: 'cd-2',
+      authorPublicId: 'pub-1',
+      name: 'Bit holder',
+      params: { width: 1 },
+      status: 'hidden',
+    };
+    blobStore.set(communityDesignBlobPath('cd-1'), recordOne);
+    blobStore.set(communityDesignBlobPath('cd-2'), recordTwo);
+
+    const { default: handler } = await import('./export');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+    expect(res._status).toBe(200);
+
+    const { unzipSync, strFromU8 } = await import('fflate');
+    const zip = unzipSync(new Uint8Array(res._body as Buffer));
+    expect(Object.keys(zip).sort()).toEqual([
+      'community/cd-1.json',
+      'community/cd-2.json',
+      'manifest.json',
+    ]);
+
+    const manifest = JSON.parse(strFromU8(zip['manifest.json']));
+    expect(manifest.community).toEqual(['cd-1', 'cd-2']);
+    expect(JSON.parse(strFromU8(zip['community/cd-1.json']))).toEqual(recordOne);
+    expect(JSON.parse(strFromU8(zip['community/cd-2.json']))).toEqual(recordTwo);
+  });
+
+  it('skips a published design whose record blob is missing', async () => {
+    redisSets.set('community:published:user-1', new Set(['cd-1', 'cd-gone']));
+    blobStore.set(communityDesignBlobPath('cd-1'), { id: 'cd-1', status: 'live' });
+
+    const { default: handler } = await import('./export');
+    const res = makeRes();
+    await handler(makeReq(), res as unknown as VercelResponse);
+
+    const { unzipSync, strFromU8 } = await import('fflate');
+    const zip = unzipSync(new Uint8Array(res._body as Buffer));
+    expect(zip).toHaveProperty('community/cd-1.json');
+    expect(zip).not.toHaveProperty('community/cd-gone.json');
+    const manifest = JSON.parse(strFromU8(zip['manifest.json']));
+    expect(manifest.community).toEqual(['cd-1', 'cd-gone']);
   });
 
   it('packages live layouts and designs into separate folders', async () => {

--- a/api/sync/export.ts
+++ b/api/sync/export.ts
@@ -12,18 +12,23 @@ import {
   type IndexEntry,
   type SyncItemKind,
 } from '../lib/userIndex.js';
+import { readCommunityDesignBlob } from '../lib/communityStore.js';
+import { communityPublishedKey } from '../lib/redisKeys.js';
 
 /**
  * GET /api/sync/export
  *
  * Stream a ZIP of the user's live data:
  *
- *   manifest.json        — { layouts, designs, baseplates: { [id]: IndexEntry }, indexUpdatedAt, exportedAt }
- *   layouts/{id}.json    — full envelope for each non-tombstoned layout
- *   designs/{id}.json    — full envelope for each non-tombstoned design
- *   baseplates/{id}.json — full envelope for each non-tombstoned baseplate
+ *   manifest.json        : { layouts, designs, baseplates: { [id]: IndexEntry }, community: [id], indexUpdatedAt, exportedAt }
+ *   layouts/{id}.json    : full envelope for each non-tombstoned layout
+ *   designs/{id}.json    : full envelope for each non-tombstoned design
+ *   baseplates/{id}.json : full envelope for each non-tombstoned baseplate
+ *   community/{id}.json  : full record for each design the user published to
+ *                          the community showcase (server-side user data that
+ *                          may exist nowhere locally)
  *
- * Tombstones are excluded — the user asked to export their data, not
+ * Tombstones are excluded: the user asked to export their data, not
  * the audit trail of deletions.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
@@ -45,12 +50,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 
   try {
-    const [layoutsIndex, designsIndex, baseplatesIndex, indexUpdatedAt] = await Promise.all([
-      getIndex(redis, session.userId, 'layouts'),
-      getIndex(redis, session.userId, 'designs'),
-      getIndex(redis, session.userId, 'baseplates'),
-      getIndexUpdatedAt(redis, session.userId),
-    ]);
+    const [layoutsIndex, designsIndex, baseplatesIndex, indexUpdatedAt, publishedIds] =
+      await Promise.all([
+        getIndex(redis, session.userId, 'layouts'),
+        getIndex(redis, session.userId, 'designs'),
+        getIndex(redis, session.userId, 'baseplates'),
+        getIndexUpdatedAt(redis, session.userId),
+        redis.smembers(communityPublishedKey(session.userId)),
+      ]);
+    const communityIds = [...publishedIds].sort();
 
     const liveLayouts = filterLive(layoutsIndex);
     const liveDesigns = filterLive(designsIndex);
@@ -72,6 +80,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
               layouts: liveLayouts,
               designs: liveDesigns,
               baseplates: liveBaseplates,
+              community: communityIds,
               indexUpdatedAt,
               exportedAt: Date.now(),
               schemaVersion: 1,
@@ -85,6 +94,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
         streamEnvelopes(addFile, session.userId, 'layouts', Object.keys(liveLayouts)),
         streamEnvelopes(addFile, session.userId, 'designs', Object.keys(liveDesigns)),
         streamEnvelopes(addFile, session.userId, 'baseplates', Object.keys(liveBaseplates)),
+        streamCommunityRecords(addFile, communityIds),
       ]);
     });
   } catch (error) {
@@ -167,6 +177,17 @@ async function streamEnvelopes(
     const envelope = envelopes[i];
     if (envelope) {
       addFile(`${kind}/${ids[i]}.json`, strToU8(JSON.stringify(envelope, null, 2)));
+    }
+  }
+}
+
+async function streamCommunityRecords(addFile: AddFile, ids: string[]): Promise<void> {
+  // Missing blobs (published-set/blob race) are skipped rather than failing the export.
+  const records = await Promise.all(ids.map((id) => readCommunityDesignBlob(id)));
+  for (let i = 0; i < ids.length; i++) {
+    const record = records[i];
+    if (record) {
+      addFile(`community/${ids[i]}.json`, strToU8(JSON.stringify(record, null, 2)));
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "check:component-structure": "./scripts/check-component-structure.sh",
     "seed-supporters": "tsx scripts/seed-supporters.ts",
     "sync-admin": "tsx scripts/sync-admin/index.ts",
+    "community-admin": "tsx scripts/community-admin/index.ts",
     "backfill-ml-ttls": "tsx scripts/backfill-ml-ttls.ts",
     "gen:example-thumbnails": "tsx --tsconfig tsconfig.app.json scripts/gen-example-thumbnails.ts",
     "bench": "vitest bench",

--- a/scripts/check-union-exhaustiveness.sh
+++ b/scripts/check-union-exhaustiveness.sh
@@ -24,6 +24,9 @@ declare -A UNION_TYPES=(
   ["DropTarget"]="trash,staging"
   ["EditSource"]="local,remote,init"
   ["MobileLayersTab"]="layers,tools"
+  ["CommunityCategory"]="tools,hardware,kitchen,office,crafts,electronics,toys-games,other"
+  ["CommunityDesignStatus"]="live,hidden,removed"
+  ["CommunityIndexSort"]="newest,remixes,likes"
 )
 
 # Get files to check

--- a/scripts/community-admin/README.md
+++ b/scripts/community-admin/README.md
@@ -1,0 +1,152 @@
+# community-admin
+
+Moderation and admin CLI for the community showcase. Reads and **writes**
+production Vercel Blob and Redis directly, via `.env.production.local`.
+
+## Deviation from sync-admin's read-only rule
+
+`scripts/sync-admin` is read-only by design: it reports findings, and any fix
+is emitted as a shell command for the operator to review before running. This
+CLI does not follow that pattern. Every mutating command (`hide`, `restore`,
+`purge`, `denylist`, `undenylist`, `feature`, `unfeature`) writes to
+production the moment it runs.
+
+The reason is the nature of the job: moderation needs same-session takedown.
+A report crosses the auto-hide threshold, or a support ticket names an
+abusive upload, and the fix has to land before the next page load, not after
+someone pastes a reviewed script. Generating a shell command for a human to
+paste (sync-admin's model) would reintroduce exactly the delay this tool
+exists to remove. Takedown capability ships in the community showcase's
+foundation PR, before any content can exist, precisely so this gap is never
+open.
+
+Because of that, run every command deliberately. `purge` additionally
+requires `--yes` since it is the one irreversible operation (blob deletes are
+not recoverable). There is no dry-run flag for any command in this CLI.
+
+## Setup
+
+```bash
+vercel env pull .env.production.local
+pnpm community-admin --help
+```
+
+Credentials needed in `.env.production.local`:
+
+- `BLOB_READ_WRITE_TOKEN` (Vercel Blob)
+- `REDIS_URL` (Redis Cloud connection string)
+- `TOKEN_SALT` (needed to derive a user's pseudonymous `authorPublicId` for
+  `denylist`, see "Known limitation" below)
+
+A banner prints on every run with the target Redis host, blob token
+fingerprint, and a reminder that mutations are immediate.
+
+## Commands
+
+### `list [flagged|hidden|all]`
+
+Prints status counts (`live` / `hidden` / `removed` / `flagged`) and a table
+of matching designs. `flagged` means status is still `live` but at least one
+report is on file (i.e. below the auto-hide threshold, needing a manual
+call). Default mode is `all`.
+
+```bash
+pnpm community-admin list flagged
+pnpm community-admin list hidden
+pnpm --silent community-admin list all --json | jq '.counts'
+```
+
+### `inspect <id>`
+
+Full record (blob + Redis card) plus report state: reporter count and the
+reporting user ids.
+
+```bash
+pnpm community-admin inspect abc123DEF456
+```
+
+### `hide <id>` / `restore <id>`
+
+Flip a design's status between `hidden` and `live`. Uses the same
+`setCommunityDesignStatus` the (future) `PUT`/report-threshold handlers use,
+so the sort indexes stay consistent automatically: `hide` removes the design
+from all three `community:index:*` sorted sets, `restore` re-adds it.
+
+```bash
+pnpm community-admin hide abc123DEF456
+pnpm community-admin restore abc123DEF456
+```
+
+### `purge <id> --yes`
+
+Hard-delete: the design JSON blob, every known thumbnail, and the mesh GLB,
+plus every Redis key that references the design (card hash, all three sort
+indexes, likes set with cascade into each liker's reverse index, reports
+set, and its own children bookkeeping set). If the design is itself a remix,
+also drops it from its parent's children set.
+
+Per the plan's "children keep snapshots" rule, a purge never touches the
+records of designs that remixed _this_ one; their `lineage.parentId` is left
+pointing at an id that no longer resolves, same as an already-deleted
+parent.
+
+```bash
+pnpm community-admin purge abc123DEF456 --yes
+```
+
+**Known limitation:** `community:published:{userId}` (the quota set) cannot
+be cleaned up from a design id alone. `authorPublicId` is deliberately a
+one-way hash of `userId` (see `api/lib/communityIds.ts`) so no stored record
+lets a purge walk back to the owning account. A purged design leaves a
+phantom slot in the former owner's quota until they either republish (same
+content hash reuses the slot) or the account is looked up out of band.
+
+### `denylist <userId>` / `undenylist <userId>`
+
+`denylist` bars a user from future publishes (`SADD community:denylist`) and
+hides every design currently live under their `authorPublicId`, derived
+locally from `userId` + `TOKEN_SALT`, the same derivation
+`deriveAuthorPublicId` uses server-side, so no round trip is needed to find
+their designs.
+
+`undenylist` only removes the bar; it does not restore anything hidden by
+the paired `denylist` call. Restore each design explicitly with `restore` if
+appropriate.
+
+```bash
+pnpm community-admin denylist 589314dfbe7f...
+pnpm community-admin undenylist 589314dfbe7f...
+```
+
+### `feature <id>` / `unfeature <id>`
+
+Sets the `featured` flag in both places it's duplicated: the design blob
+(detail-view source of truth) and the `community:design:{id}` Redis hash
+(gallery-sort source of truth).
+
+```bash
+pnpm community-admin feature abc123DEF456
+pnpm community-admin unfeature abc123DEF456
+```
+
+## Shared flags
+
+| Flag     | Applies to        | Effect                                   |
+| -------- | ----------------- | ---------------------------------------- |
+| `--json` | `list`, `inspect` | Machine-readable output                  |
+| `--yes`  | `purge`           | Required to confirm the irreversible run |
+| `--help` | all               | Show usage                               |
+
+## Implementation notes
+
+- Imports key builders (`communityDesignKey`, `communityIndexKey`, etc.) and
+  storage helpers (`readCommunityDesignBlob`, `setCommunityDesignStatus`, ...)
+  directly from `api/lib/`, the same way `sync-admin` imports
+  `validateShareLayout` and `userIndexKey`: production logic changes are
+  reflected automatically rather than drifting from a duplicated copy.
+- `lib/purgePlan.ts` enumerates every blob path and Redis key a purge must
+  touch as a pure function, separate from the `purge` command's I/O. See its
+  own doc comment and `__tests__/purgePlan.test.ts`.
+- `lib/dispatch.ts` separates command-table routing from `index.ts`'s env
+  setup so routing is unit-testable without Redis/Blob credentials. See
+  `__tests__/dispatch.test.ts`.

--- a/scripts/community-admin/__tests__/args.test.ts
+++ b/scripts/community-admin/__tests__/args.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../lib/args';
+
+describe('parseArgs', () => {
+  it('parses a bare command', () => {
+    const a = parseArgs(['list']);
+    expect(a.command).toBe('list');
+    expect(a.positional).toEqual([]);
+    expect(a.json).toBe(false);
+    expect(a.yes).toBe(false);
+  });
+
+  it('parses positional args and flags together', () => {
+    const a = parseArgs(['purge', 'abc123DEF456', '--yes', '--json']);
+    expect(a.command).toBe('purge');
+    expect(a.positional).toEqual(['abc123DEF456']);
+    expect(a.yes).toBe(true);
+    expect(a.json).toBe(true);
+  });
+
+  it('accepts -y as a short form of --yes', () => {
+    expect(parseArgs(['purge', 'abc123DEF456', '-y']).yes).toBe(true);
+  });
+
+  it('parses --help and -h', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+  });
+
+  it('rejects unknown flags', () => {
+    expect(() => parseArgs(['list', '--banana'])).toThrow(/Unknown flag: --banana/);
+  });
+
+  it('treats a bare positional after the command as an id, not a second command', () => {
+    const a = parseArgs(['inspect', 'abc123DEF456', 'extra']);
+    expect(a.command).toBe('inspect');
+    expect(a.positional).toEqual(['abc123DEF456', 'extra']);
+  });
+});

--- a/scripts/community-admin/__tests__/denylist.test.ts
+++ b/scripts/community-admin/__tests__/denylist.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Args } from '../lib/args';
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+}));
+
+vi.mock('../lib/redis.js', () => ({
+  connect: mocks.connect,
+}));
+
+const { denylist } = await import('../commands/denylist.js');
+
+interface FakeRedis {
+  hashes: Map<string, Map<string, string>>;
+  sets: Map<string, Set<string>>;
+  zsets: Map<string, Map<string, number>>;
+  sadd: (key: string, member: string) => Promise<number>;
+  smembers: (key: string) => Promise<string[]>;
+  hset: (key: string, fields: Record<string, string>) => Promise<number>;
+  hmget: (key: string, ...fields: string[]) => Promise<(string | null)[]>;
+  pipeline: () => {
+    hgetall: (key: string) => unknown;
+    zadd: (key: string, score: number, member: string) => unknown;
+    zrem: (key: string, member: string) => unknown;
+    exec: () => Promise<Array<[Error | null, unknown]>>;
+  };
+  quit: ReturnType<typeof vi.fn>;
+}
+
+function createFakeRedis(): FakeRedis {
+  const hashes = new Map<string, Map<string, string>>();
+  const sets = new Map<string, Set<string>>();
+  const zsets = new Map<string, Map<string, number>>();
+  const redis: FakeRedis = {
+    hashes,
+    sets,
+    zsets,
+    async sadd(key, member) {
+      const set = sets.get(key) ?? new Set<string>();
+      const added = set.has(member) ? 0 : 1;
+      set.add(member);
+      sets.set(key, set);
+      return added;
+    },
+    async smembers(key) {
+      return [...(sets.get(key) ?? new Set<string>())];
+    },
+    async hset(key, fields) {
+      const hash = hashes.get(key) ?? new Map<string, string>();
+      for (const [field, value] of Object.entries(fields)) hash.set(field, String(value));
+      hashes.set(key, hash);
+      return Object.keys(fields).length;
+    },
+    async hmget(key, ...fields) {
+      const hash = hashes.get(key);
+      return fields.map((field) => hash?.get(field) ?? null);
+    },
+    pipeline() {
+      const ops: Array<() => Promise<unknown>> = [];
+      const pipe = {
+        hgetall: (key: string) => {
+          ops.push(async () => Object.fromEntries(hashes.get(key) ?? new Map<string, string>()));
+          return pipe;
+        },
+        zadd: (key: string, score: number, member: string) => {
+          ops.push(async () => {
+            const zset = zsets.get(key) ?? new Map<string, number>();
+            zset.set(member, score);
+            zsets.set(key, zset);
+            return 1;
+          });
+          return pipe;
+        },
+        zrem: (key: string, member: string) => {
+          ops.push(async () => (zsets.get(key)?.delete(member) ? 1 : 0));
+          return pipe;
+        },
+        exec: async (): Promise<Array<[Error | null, unknown]>> => {
+          const out: Array<[Error | null, unknown]> = [];
+          for (const op of ops) out.push([null, await op()]);
+          ops.length = 0;
+          return out;
+        },
+      };
+      return pipe;
+    },
+    quit: vi.fn(async () => undefined),
+  };
+  return redis;
+}
+
+function seedCard(redis: FakeRedis, id: string, status: string): void {
+  redis.hashes.set(
+    `community:design:${id}`,
+    new Map(
+      Object.entries({
+        id,
+        name: `Design ${id}`,
+        authorPublicId: 'irrelevant',
+        authorName: 'Someone',
+        category: 'tools',
+        techniques: '[]',
+        status,
+        createdAt: '1000',
+        remixes: '0',
+        likes: '0',
+      })
+    )
+  );
+  if (status === 'live') {
+    for (const sort of ['newest', 'remixes', 'likes']) {
+      const key = `community:index:${sort}`;
+      const zset = redis.zsets.get(key) ?? new Map<string, number>();
+      zset.set(id, 1);
+      redis.zsets.set(key, zset);
+    }
+  }
+}
+
+function baseArgs(positional: string[]): Args {
+  return { command: 'denylist', positional, json: false, yes: false, help: false };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('TOKEN_SALT', 'test-salt');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('denylist command', () => {
+  it('requires a userId', async () => {
+    const code = await denylist(baseArgs([]));
+    expect(code).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('refuses to run without TOKEN_SALT', async () => {
+    vi.stubEnv('TOKEN_SALT', '');
+    const code = await denylist(baseArgs(['user-1']));
+    expect(code).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('bars the user and hides only their live designs', async () => {
+    const { deriveAuthorPublicId } = await import('../../../api/lib/communityIds.js');
+    const authorPublicId = String(deriveAuthorPublicId('user-1'));
+
+    const redis = createFakeRedis();
+    seedCard(redis, 'liveAAAAAAAA', 'live');
+    seedCard(redis, 'hiddenBBBBBB', 'hidden');
+    seedCard(redis, 'otherCCCCCCC', 'live');
+    redis.sets.set(`community:author:${authorPublicId}`, new Set(['liveAAAAAAAA', 'hiddenBBBBBB']));
+    redis.sets.set('community:author:someone-else', new Set(['otherCCCCCCC']));
+    mocks.connect.mockReturnValue(redis);
+
+    const code = await denylist(baseArgs(['user-1']));
+    expect(code).toBe(0);
+
+    expect(redis.sets.get('community:denylist')).toEqual(new Set(['user-1']));
+    expect(redis.hashes.get('community:design:liveAAAAAAAA')?.get('status')).toBe('hidden');
+    expect(redis.hashes.get('community:design:hiddenBBBBBB')?.get('status')).toBe('hidden');
+    expect(redis.hashes.get('community:design:otherCCCCCCC')?.get('status')).toBe('live');
+    for (const sort of ['newest', 'remixes', 'likes']) {
+      const zset = redis.zsets.get(`community:index:${sort}`);
+      expect(zset?.has('liveAAAAAAAA')).toBe(false);
+      expect(zset?.has('otherCCCCCCC')).toBe(true);
+    }
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('still adds the deny-list entry when the user has no live designs', async () => {
+    const redis = createFakeRedis();
+    mocks.connect.mockReturnValue(redis);
+
+    const code = await denylist(baseArgs(['user-2']));
+    expect(code).toBe(0);
+    expect(redis.sets.get('community:denylist')).toEqual(new Set(['user-2']));
+  });
+});

--- a/scripts/community-admin/__tests__/dispatch.test.ts
+++ b/scripts/community-admin/__tests__/dispatch.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dispatch } from '../lib/dispatch';
+import type { Args } from '../lib/args';
+
+function baseArgs(command: string, positional: string[] = []): Args {
+  return { command, positional, json: false, yes: false, help: false };
+}
+
+describe('dispatch', () => {
+  it('routes a known command to its handler and returns the handler result', async () => {
+    const hide = vi.fn().mockResolvedValue(0);
+    const purge = vi.fn().mockResolvedValue(1);
+    const outcome = await dispatch({ hide, purge }, baseArgs('hide', ['abc123DEF456']));
+
+    expect(outcome).toEqual({ code: 0, unknownCommand: null });
+    expect(hide).toHaveBeenCalledTimes(1);
+    expect(hide).toHaveBeenCalledWith(baseArgs('hide', ['abc123DEF456']));
+    expect(purge).not.toHaveBeenCalled();
+  });
+
+  it('propagates the handler exit code unchanged', async () => {
+    const denylist = vi.fn().mockResolvedValue(2);
+    const outcome = await dispatch({ denylist }, baseArgs('denylist'));
+    expect(outcome.code).toBe(2);
+  });
+
+  it('reports an unknown command without calling any handler', async () => {
+    const list = vi.fn().mockResolvedValue(0);
+    const outcome = await dispatch({ list }, baseArgs('bogus'));
+
+    expect(outcome).toEqual({ code: 2, unknownCommand: 'bogus' });
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('treats the empty command table the same as no match', async () => {
+    const outcome = await dispatch({}, baseArgs('list'));
+    expect(outcome).toEqual({ code: 2, unknownCommand: 'list' });
+  });
+});

--- a/scripts/community-admin/__tests__/feature.test.ts
+++ b/scripts/community-admin/__tests__/feature.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CommunityDesignRecord } from '../../../api/lib/communityStore';
+import type { Args } from '../lib/args';
+
+const mocks = vi.hoisted(() => ({
+  readCommunityDesignBlob: vi.fn(),
+  writeCommunityDesignBlob: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock('../../../api/lib/communityStore.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/lib/communityStore.js')>();
+  return {
+    ...actual,
+    readCommunityDesignBlob: mocks.readCommunityDesignBlob,
+    writeCommunityDesignBlob: mocks.writeCommunityDesignBlob,
+  };
+});
+
+vi.mock('../lib/redis.js', () => ({
+  connect: mocks.connect,
+}));
+
+const { feature, unfeature } = await import('../commands/feature.js');
+
+const RECORD = {
+  id: 'abc123DEF456',
+  featured: false,
+  updatedAt: 1,
+} as CommunityDesignRecord;
+
+function baseArgs(command: string, positional: string[]): Args {
+  return { command, positional, json: false, yes: false, help: false };
+}
+
+function createRedis() {
+  return {
+    hset: vi.fn(async () => 1),
+    quit: vi.fn(async () => undefined),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.writeCommunityDesignBlob.mockResolvedValue('https://blob.example/design.json');
+});
+
+describe('feature/unfeature commands', () => {
+  it('requires an id', async () => {
+    expect(await feature(baseArgs('feature', []))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed id before touching redis', async () => {
+    expect(await feature(baseArgs('feature', ['nope!']))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 when the design blob does not exist', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue(null);
+    const redis = createRedis();
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await feature(baseArgs('feature', ['abc123DEF456']))).toBe(1);
+    expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+    expect(redis.hset).not.toHaveBeenCalled();
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('feature sets the flag on both the blob and the card hash', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue(RECORD);
+    const redis = createRedis();
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await feature(baseArgs('feature', ['abc123DEF456']))).toBe(0);
+    const written = mocks.writeCommunityDesignBlob.mock.calls[0] as [
+      CommunityDesignRecord,
+      { allowOverwrite: boolean },
+    ];
+    expect(written[0].featured).toBe(true);
+    expect(written[1]).toEqual({ allowOverwrite: true });
+    expect(redis.hset).toHaveBeenCalledWith('community:design:abc123DEF456', { featured: '1' });
+  });
+
+  it('unfeature clears the flag on both writers', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue({ ...RECORD, featured: true });
+    const redis = createRedis();
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await unfeature(baseArgs('unfeature', ['abc123DEF456']))).toBe(0);
+    const written = mocks.writeCommunityDesignBlob.mock.calls[0][0] as CommunityDesignRecord;
+    expect(written.featured).toBe(false);
+    expect(redis.hset).toHaveBeenCalledWith('community:design:abc123DEF456', { featured: '0' });
+  });
+});

--- a/scripts/community-admin/__tests__/hide.test.ts
+++ b/scripts/community-admin/__tests__/hide.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CommunityCardRecord } from '../../../api/lib/communityStore';
+import type { Args } from '../lib/args';
+
+const mocks = vi.hoisted(() => ({
+  readCommunityCards: vi.fn(),
+  setCommunityDesignStatus: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock('../../../api/lib/communityStore.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/lib/communityStore.js')>();
+  return {
+    ...actual,
+    readCommunityCards: mocks.readCommunityCards,
+    setCommunityDesignStatus: mocks.setCommunityDesignStatus,
+  };
+});
+
+vi.mock('../lib/redis.js', () => ({
+  connect: mocks.connect,
+}));
+
+const { hide } = await import('../commands/hide.js');
+
+const CARD = { id: 'abc123DEF456', status: 'live' } as CommunityCardRecord;
+
+function baseArgs(positional: string[]): Args {
+  return { command: 'hide', positional, json: false, yes: false, help: false };
+}
+
+function createRedis() {
+  return { quit: vi.fn(async () => undefined) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.setCommunityDesignStatus.mockResolvedValue(undefined);
+});
+
+describe('hide command', () => {
+  it('requires an id', async () => {
+    expect(await hide(baseArgs([]))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed id before touching redis', async () => {
+    expect(await hide(baseArgs(['../../etc/passwd']))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 when the design does not exist', async () => {
+    mocks.readCommunityCards.mockResolvedValue([null]);
+    const redis = createRedis();
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await hide(baseArgs(['abc123DEF456']))).toBe(1);
+    expect(mocks.setCommunityDesignStatus).not.toHaveBeenCalled();
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets the status to hidden', async () => {
+    mocks.readCommunityCards.mockResolvedValue([CARD]);
+    const redis = createRedis();
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await hide(baseArgs(['abc123DEF456']))).toBe(0);
+    expect(mocks.setCommunityDesignStatus).toHaveBeenCalledWith(redis, 'abc123DEF456', 'hidden');
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/community-admin/__tests__/inspect.test.ts
+++ b/scripts/community-admin/__tests__/inspect.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CommunityCardRecord, CommunityDesignRecord } from '../../../api/lib/communityStore';
+import type { Args } from '../lib/args';
+
+const mocks = vi.hoisted(() => ({
+  readCommunityDesignBlob: vi.fn(),
+  readCommunityCards: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock('../../../api/lib/communityStore.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/lib/communityStore.js')>();
+  return {
+    ...actual,
+    readCommunityDesignBlob: mocks.readCommunityDesignBlob,
+    readCommunityCards: mocks.readCommunityCards,
+  };
+});
+
+vi.mock('../lib/redis.js', () => ({
+  connect: mocks.connect,
+}));
+
+const { inspect } = await import('../commands/inspect.js');
+
+const RECORD = {
+  id: 'abc123DEF456',
+  name: 'Screwdriver tray',
+  authorPublicId: 'author-pub-id',
+  authorName: 'Jane',
+  category: 'tools',
+  techniques: [],
+  lineage: null,
+  featured: false,
+  createdAt: 1,
+  updatedAt: 1,
+  status: 'live',
+} as unknown as CommunityDesignRecord;
+
+const CARD = { id: 'abc123DEF456', likes: 2, remixes: 0, exports: 1 } as CommunityCardRecord;
+
+function baseArgs(positional: string[], json = false): Args {
+  return { command: 'inspect', positional, json, yes: false, help: false };
+}
+
+function createRedis(reporterIds: string[]) {
+  return {
+    smembers: vi.fn(async () => reporterIds),
+    quit: vi.fn(async () => undefined),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('inspect command', () => {
+  it('requires an id', async () => {
+    expect(await inspect(baseArgs([]))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed id before touching redis', async () => {
+    expect(await inspect(baseArgs(['nope!']))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 when neither the blob nor the card resolve', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue(null);
+    mocks.readCommunityCards.mockResolvedValue([null]);
+    const redis = createRedis([]);
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await inspect(baseArgs(['abc123DEF456']))).toBe(1);
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits the record, card, and reporters as JSON with --json', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue(RECORD);
+    mocks.readCommunityCards.mockResolvedValue([CARD]);
+    const redis = createRedis(['user-7']);
+    mocks.connect.mockReturnValue(redis);
+    const write = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    expect(await inspect(baseArgs(['abc123DEF456'], true))).toBe(0);
+    const payload = JSON.parse(write.mock.calls[0][0] as string) as {
+      record: { id: string };
+      card: { likes: number };
+      reporterIds: string[];
+    };
+    expect(payload.record.id).toBe('abc123DEF456');
+    expect(payload.card.likes).toBe(2);
+    expect(payload.reporterIds).toEqual(['user-7']);
+    write.mockRestore();
+  });
+
+  it('still reports card metadata when the blob is missing', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue(null);
+    mocks.readCommunityCards.mockResolvedValue([CARD]);
+    const redis = createRedis([]);
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await inspect(baseArgs(['abc123DEF456']))).toBe(0);
+  });
+});

--- a/scripts/community-admin/__tests__/list.test.ts
+++ b/scripts/community-admin/__tests__/list.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CommunityCardRecord } from '../../../api/lib/communityStore';
+import type { Args } from '../lib/args';
+
+const mocks = vi.hoisted(() => ({
+  readCommunityCards: vi.fn(),
+  connect: vi.fn(),
+  scanKeys: vi.fn(),
+}));
+
+vi.mock('../../../api/lib/communityStore.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/lib/communityStore.js')>();
+  return {
+    ...actual,
+    readCommunityCards: mocks.readCommunityCards,
+  };
+});
+
+vi.mock('../lib/redis.js', () => ({
+  connect: mocks.connect,
+  scanKeys: mocks.scanKeys,
+}));
+
+const { list } = await import('../commands/list.js');
+
+function card(id: string, status: CommunityCardRecord['status']): CommunityCardRecord {
+  return {
+    id,
+    name: `Design ${id}`,
+    authorPublicId: 'author-pub-id',
+    authorName: 'Jane',
+    category: 'tools',
+    techniques: [],
+    width: 2,
+    depth: 2,
+    height: 2,
+    gridUnitMm: 42,
+    thumbnailUrl: '',
+    isRemix: false,
+    featured: false,
+    createdAt: 1,
+    updatedAt: 1,
+    status,
+    likes: 0,
+    remixes: 0,
+    exports: 0,
+  };
+}
+
+function baseArgs(positional: string[], json = false): Args {
+  return { command: 'list', positional, json, yes: false, help: false };
+}
+
+function createRedis(reportCounts: number[]) {
+  const pipeline = {
+    scard: vi.fn(() => pipeline),
+    exec: vi.fn(async () => reportCounts.map((count) => [null, count])),
+  };
+  return {
+    pipeline: vi.fn(() => pipeline),
+    quit: vi.fn(async () => undefined),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('list command', () => {
+  it('rejects an unknown mode without connecting', async () => {
+    expect(await list(baseArgs(['everything']))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('counts by status and filters flagged to reported live designs', async () => {
+    mocks.scanKeys.mockResolvedValue([
+      'community:design:live-quiet',
+      'community:design:live-flagged',
+      'community:design:hidden-one',
+    ]);
+    mocks.readCommunityCards.mockResolvedValue([
+      card('live-quiet', 'live'),
+      card('live-flagged', 'live'),
+      card('hidden-one', 'hidden'),
+    ]);
+    const redis = createRedis([0, 3, 1]);
+    mocks.connect.mockReturnValue(redis);
+    const write = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    expect(await list(baseArgs(['flagged'], true))).toBe(0);
+    const payload = JSON.parse(write.mock.calls[0][0] as string) as {
+      counts: { live: number; hidden: number; removed: number; flagged: number };
+      designs: Array<{ id: string; reportCount: number }>;
+    };
+    expect(payload.counts).toEqual({ live: 2, hidden: 1, removed: 0, flagged: 1 });
+    expect(payload.designs.map((design) => design.id)).toEqual(['live-flagged']);
+    expect(payload.designs[0].reportCount).toBe(3);
+    write.mockRestore();
+  });
+
+  it('lists hidden designs in hidden mode', async () => {
+    mocks.scanKeys.mockResolvedValue(['community:design:a', 'community:design:b']);
+    mocks.readCommunityCards.mockResolvedValue([card('a', 'live'), card('b', 'hidden')]);
+    const redis = createRedis([0, 0]);
+    mocks.connect.mockReturnValue(redis);
+    const write = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    expect(await list(baseArgs(['hidden'], true))).toBe(0);
+    const payload = JSON.parse(write.mock.calls[0][0] as string) as {
+      designs: Array<{ id: string }>;
+    };
+    expect(payload.designs.map((design) => design.id)).toEqual(['b']);
+    write.mockRestore();
+  });
+});

--- a/scripts/community-admin/__tests__/list.test.ts
+++ b/scripts/community-admin/__tests__/list.test.ts
@@ -27,6 +27,7 @@ function card(id: string, status: CommunityCardRecord['status']): CommunityCardR
   return {
     id,
     name: `Design ${id}`,
+    parentId: '',
     authorPublicId: 'author-pub-id',
     authorName: 'Jane',
     category: 'tools',

--- a/scripts/community-admin/__tests__/purge.test.ts
+++ b/scripts/community-admin/__tests__/purge.test.ts
@@ -100,6 +100,7 @@ const RECORD: CommunityDesignRecord = {
 const CARD: CommunityCardRecord = {
   id: 'abc123DEF456',
   name: 'Screwdriver tray',
+  parentId: 'parentabc123',
   authorPublicId: 'author-pub-id',
   authorName: 'Jane',
   category: 'tools',

--- a/scripts/community-admin/__tests__/purge.test.ts
+++ b/scripts/community-admin/__tests__/purge.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CommunityCardRecord, CommunityDesignRecord } from '../../../api/lib/communityStore';
+import type { Args } from '../lib/args';
+
+const mocks = vi.hoisted(() => ({
+  deleteBlob: vi.fn(),
+  readCommunityDesignBlob: vi.fn(),
+  readCommunityCards: vi.fn(),
+  connect: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock('../../../api/lib/blobStore.js', () => ({
+  deleteBlob: mocks.deleteBlob,
+}));
+
+vi.mock('../../../api/lib/communityStore.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/lib/communityStore.js')>();
+  return {
+    ...actual,
+    readCommunityDesignBlob: mocks.readCommunityDesignBlob,
+    readCommunityCards: mocks.readCommunityCards,
+  };
+});
+
+vi.mock('../../../api/lib/logger.js', () => ({
+  logger: { error: mocks.loggerError, warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('../lib/redis.js', () => ({
+  connect: mocks.connect,
+}));
+
+const { purge } = await import('../commands/purge.js');
+const { communityDesignBlobPath } = await import('../../../api/lib/communityStore.js');
+
+interface PipelineCommand {
+  op: string;
+  args: unknown[];
+}
+
+function createFakeRedis(likerIds: string[]) {
+  const commands: PipelineCommand[] = [];
+  const pipeline = {
+    del: (...args: unknown[]) => {
+      commands.push({ op: 'del', args });
+      return pipeline;
+    },
+    zrem: (...args: unknown[]) => {
+      commands.push({ op: 'zrem', args });
+      return pipeline;
+    },
+    srem: (...args: unknown[]) => {
+      commands.push({ op: 'srem', args });
+      return pipeline;
+    },
+    exec: vi.fn(async () => commands.map(() => [null, 1])),
+  };
+  const redis = {
+    smembers: vi.fn(async () => likerIds),
+    pipeline: () => pipeline,
+    quit: vi.fn(async () => undefined),
+  };
+  return { redis, commands };
+}
+
+function baseArgs(positional: string[], yes = true): Args {
+  return { command: 'purge', positional, json: false, yes, help: false };
+}
+
+const RECORD: CommunityDesignRecord = {
+  id: 'abc123DEF456',
+  authorPublicId: 'author-pub-id',
+  authorName: 'Jane',
+  name: 'Screwdriver tray',
+  description: '',
+  category: 'tools',
+  techniques: [],
+  params: {},
+  metrics: { width: 2, depth: 2, height: 2, gridUnitMm: 42 },
+  lineage: {
+    parentId: 'parent123ABC',
+    rootId: 'parent123ABC',
+    parentName: 'Original tray',
+    parentAuthorName: 'Alan',
+    rootAuthorName: 'Alan',
+  },
+  thumbnails: [
+    'https://blob.example/community/thumbs/abc123DEF456-1-0.webp',
+    'https://blob.example/community/thumbs/abc123DEF456-1-1.webp',
+  ],
+  meshUrl: 'https://blob.example/community/meshes/abc123DEF456-1.glb',
+  photos: [],
+  featured: false,
+  createdAt: 1,
+  updatedAt: 1,
+  status: 'live',
+};
+
+const CARD: CommunityCardRecord = {
+  id: 'abc123DEF456',
+  name: 'Screwdriver tray',
+  authorPublicId: 'author-pub-id',
+  authorName: 'Jane',
+  category: 'tools',
+  techniques: [],
+  width: 2,
+  depth: 2,
+  height: 2,
+  gridUnitMm: 42,
+  thumbnailUrl: 'https://blob.example/community/thumbs/abc123DEF456-1-0.webp',
+  isRemix: true,
+  featured: false,
+  createdAt: 1,
+  updatedAt: 1,
+  status: 'live',
+  likes: 2,
+  remixes: 0,
+  exports: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('TOKEN_SALT', 'test-salt');
+});
+
+describe('purge command', () => {
+  it('refuses to run without --yes and never connects to redis', async () => {
+    const code = await purge(baseArgs(['abc123DEF456'], false));
+    expect(code).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('404s when neither the blob nor the card resolve', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue(null);
+    mocks.readCommunityCards.mockResolvedValue([null]);
+    const { redis } = createFakeRedis([]);
+    mocks.connect.mockReturnValue(redis);
+
+    const code = await purge(baseArgs(['abc123DEF456']));
+
+    expect(code).toBe(1);
+    expect(mocks.deleteBlob).not.toHaveBeenCalled();
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes every blob, cascades likes, and enumerates all redis keys on the pipeline', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue(RECORD);
+    mocks.readCommunityCards.mockResolvedValue([CARD]);
+    mocks.deleteBlob.mockResolvedValue(undefined);
+    const { redis, commands } = createFakeRedis(['liker-1', 'liker-2']);
+    mocks.connect.mockReturnValue(redis);
+
+    const code = await purge(baseArgs(['abc123DEF456']));
+
+    expect(code).toBe(0);
+    expect(mocks.deleteBlob).toHaveBeenCalledTimes(4);
+    expect(mocks.deleteBlob).toHaveBeenNthCalledWith(1, communityDesignBlobPath('abc123DEF456'));
+    expect(mocks.deleteBlob).toHaveBeenNthCalledWith(
+      2,
+      'https://blob.example/community/thumbs/abc123DEF456-1-0.webp'
+    );
+    expect(mocks.deleteBlob).toHaveBeenNthCalledWith(
+      3,
+      'https://blob.example/community/thumbs/abc123DEF456-1-1.webp'
+    );
+    expect(mocks.deleteBlob).toHaveBeenNthCalledWith(
+      4,
+      'https://blob.example/community/meshes/abc123DEF456-1.glb'
+    );
+
+    expect(commands).toContainEqual({ op: 'del', args: ['community:design:abc123DEF456'] });
+    expect(commands).toContainEqual({
+      op: 'zrem',
+      args: ['community:index:newest', 'abc123DEF456'],
+    });
+    expect(commands).toContainEqual({
+      op: 'zrem',
+      args: ['community:index:remixes', 'abc123DEF456'],
+    });
+    expect(commands).toContainEqual({
+      op: 'zrem',
+      args: ['community:index:likes', 'abc123DEF456'],
+    });
+    expect(commands).toContainEqual({
+      op: 'srem',
+      args: ['community:author:author-pub-id', 'abc123DEF456'],
+    });
+    expect(commands).toContainEqual({
+      op: 'srem',
+      args: ['community:children:parent123ABC', 'abc123DEF456'],
+    });
+    expect(commands).toContainEqual({ op: 'del', args: ['community:reports:abc123DEF456'] });
+    expect(commands).toContainEqual({ op: 'del', args: ['community:likes:abc123DEF456'] });
+    expect(commands).toContainEqual({ op: 'del', args: ['community:children:abc123DEF456'] });
+    expect(commands).toContainEqual({
+      op: 'srem',
+      args: ['community:liked:liker-1', 'abc123DEF456'],
+    });
+    expect(commands).toContainEqual({
+      op: 'srem',
+      args: ['community:liked:liker-2', 'abc123DEF456'],
+    });
+  });
+
+  it('logs a per-blob failure and continues the rest of the cleanup', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue(RECORD);
+    mocks.readCommunityCards.mockResolvedValue([CARD]);
+    mocks.deleteBlob
+      .mockRejectedValueOnce(new Error('blob store unavailable'))
+      .mockResolvedValue(undefined);
+    const { redis } = createFakeRedis([]);
+    mocks.connect.mockReturnValue(redis);
+
+    const code = await purge(baseArgs(['abc123DEF456']));
+
+    expect(code).toBe(0);
+    expect(mocks.loggerError).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteBlob).toHaveBeenCalledTimes(4);
+  });
+
+  it('rejects a malformed id before touching redis or blob storage', async () => {
+    const code = await purge(baseArgs(['../../etc/passwd']));
+    expect(code).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/community-admin/__tests__/purgePlan.test.ts
+++ b/scripts/community-admin/__tests__/purgePlan.test.ts
@@ -40,6 +40,7 @@ function makeCard(overrides: Partial<CommunityCardRecord> = {}): CommunityCardRe
   return {
     id: DESIGN_ID,
     name: 'Screwdriver tray',
+    parentId: '',
     authorPublicId: 'author-pub-id',
     authorName: 'Jane',
     category: 'tools',

--- a/scripts/community-admin/__tests__/purgePlan.test.ts
+++ b/scripts/community-admin/__tests__/purgePlan.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { planPurgeCleanup } from '../lib/purgePlan';
+import { communityDesignBlobPath } from '../../../api/lib/communityStore';
+import type { CommunityCardRecord, CommunityDesignRecord } from '../../../api/lib/communityStore';
+
+beforeEach(() => {
+  vi.stubEnv('TOKEN_SALT', 'test-salt');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const DESIGN_ID = 'abc123DEF456';
+
+function makeRecord(overrides: Partial<CommunityDesignRecord> = {}): CommunityDesignRecord {
+  return {
+    id: DESIGN_ID,
+    authorPublicId: 'author-pub-id',
+    authorName: 'Jane',
+    name: 'Screwdriver tray',
+    description: '',
+    category: 'tools',
+    techniques: [],
+    params: {},
+    metrics: { width: 2, depth: 2, height: 2, gridUnitMm: 42 },
+    lineage: null,
+    thumbnails: ['https://blob.example/community/thumbs/abc123DEF456-1-0.webp'],
+    meshUrl: 'https://blob.example/community/meshes/abc123DEF456-1.glb',
+    photos: [],
+    featured: false,
+    createdAt: 1,
+    updatedAt: 1,
+    status: 'live',
+    ...overrides,
+  };
+}
+
+function makeCard(overrides: Partial<CommunityCardRecord> = {}): CommunityCardRecord {
+  return {
+    id: DESIGN_ID,
+    name: 'Screwdriver tray',
+    authorPublicId: 'author-pub-id',
+    authorName: 'Jane',
+    category: 'tools',
+    techniques: [],
+    width: 2,
+    depth: 2,
+    height: 2,
+    gridUnitMm: 42,
+    thumbnailUrl: 'https://blob.example/community/thumbs/abc123DEF456-1-0.webp',
+    isRemix: false,
+    featured: false,
+    createdAt: 1,
+    updatedAt: 1,
+    status: 'live',
+    likes: 0,
+    remixes: 0,
+    exports: 0,
+    ...overrides,
+  };
+}
+
+describe('planPurgeCleanup', () => {
+  it('enumerates the design blob, every thumbnail, and the mesh', () => {
+    const record = makeRecord({
+      thumbnails: [
+        'https://blob.example/community/thumbs/abc123DEF456-1-0.webp',
+        'https://blob.example/community/thumbs/abc123DEF456-1-1.webp',
+      ],
+    });
+    const plan = planPurgeCleanup(DESIGN_ID, record, makeCard());
+
+    expect(plan.blobPaths).toEqual([
+      communityDesignBlobPath(DESIGN_ID),
+      'https://blob.example/community/thumbs/abc123DEF456-1-0.webp',
+      'https://blob.example/community/thumbs/abc123DEF456-1-1.webp',
+      'https://blob.example/community/meshes/abc123DEF456-1.glb',
+    ]);
+  });
+
+  it('enumerates the card hash, all three sort indexes, likes, reports, and children keys', () => {
+    const plan = planPurgeCleanup(DESIGN_ID, makeRecord(), makeCard());
+
+    expect(plan.hashKey).toBe('community:design:abc123DEF456');
+    expect(plan.indexKeys.sort()).toEqual(
+      ['community:index:likes', 'community:index:newest', 'community:index:remixes'].sort()
+    );
+    expect(plan.likesKey).toBe('community:likes:abc123DEF456');
+    expect(plan.reportsKey).toBe('community:reports:abc123DEF456');
+    expect(plan.childrenKey).toBe('community:children:abc123DEF456');
+  });
+
+  it('resolves the author key from the blob record', () => {
+    const plan = planPurgeCleanup(DESIGN_ID, makeRecord({ authorPublicId: 'pub-xyz' }), null);
+    expect(plan.authorKey).toBe('community:author:pub-xyz');
+  });
+
+  it('falls back to the card for the author key when the blob is missing', () => {
+    const plan = planPurgeCleanup(DESIGN_ID, null, makeCard({ authorPublicId: 'pub-from-card' }));
+    expect(plan.authorKey).toBe('community:author:pub-from-card');
+    // Without the blob there are no known thumbnails/mesh to enumerate.
+    expect(plan.blobPaths).toEqual([communityDesignBlobPath(DESIGN_ID)]);
+  });
+
+  it('leaves the author key null when neither the blob nor the card resolved', () => {
+    const plan = planPurgeCleanup(DESIGN_ID, null, null);
+    expect(plan.authorKey).toBeNull();
+  });
+
+  it('adds the parent children key only when this design is a remix', () => {
+    const original = planPurgeCleanup(DESIGN_ID, makeRecord({ lineage: null }), makeCard());
+    expect(original.parentChildKey).toBeNull();
+
+    const remix = planPurgeCleanup(
+      DESIGN_ID,
+      makeRecord({
+        lineage: {
+          parentId: 'parent123ABC',
+          rootId: 'parent123ABC',
+          parentName: 'Original tray',
+          parentAuthorName: 'Alan',
+          rootAuthorName: 'Alan',
+        },
+      }),
+      makeCard()
+    );
+    expect(remix.parentChildKey).toBe('community:children:parent123ABC');
+  });
+
+  it('never enumerates the child design ids that reference this design as their parent', () => {
+    // "children keep snapshots": purging a design must not reach into
+    // community:children:{thisId}'s members, only delete the bookkeeping set itself.
+    const plan = planPurgeCleanup(DESIGN_ID, makeRecord(), makeCard());
+    expect(plan.childrenKey).toBe(`community:children:${DESIGN_ID}`);
+    expect(Object.keys(plan)).not.toContain('childDesignIds');
+  });
+});

--- a/scripts/community-admin/__tests__/restore.test.ts
+++ b/scripts/community-admin/__tests__/restore.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CommunityCardRecord } from '../../../api/lib/communityStore';
+import type { Args } from '../lib/args';
+
+const mocks = vi.hoisted(() => ({
+  readCommunityCards: vi.fn(),
+  setCommunityDesignStatus: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock('../../../api/lib/communityStore.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/lib/communityStore.js')>();
+  return {
+    ...actual,
+    readCommunityCards: mocks.readCommunityCards,
+    setCommunityDesignStatus: mocks.setCommunityDesignStatus,
+  };
+});
+
+vi.mock('../lib/redis.js', () => ({
+  connect: mocks.connect,
+}));
+
+const { restore } = await import('../commands/restore.js');
+
+const CARD = { id: 'abc123DEF456', status: 'hidden' } as CommunityCardRecord;
+
+function baseArgs(positional: string[]): Args {
+  return { command: 'restore', positional, json: false, yes: false, help: false };
+}
+
+function createRedis() {
+  return { quit: vi.fn(async () => undefined) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.setCommunityDesignStatus.mockResolvedValue(undefined);
+});
+
+describe('restore command', () => {
+  it('requires an id', async () => {
+    expect(await restore(baseArgs([]))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed id before touching redis', async () => {
+    expect(await restore(baseArgs(['nope!']))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 when the design does not exist', async () => {
+    mocks.readCommunityCards.mockResolvedValue([null]);
+    const redis = createRedis();
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await restore(baseArgs(['abc123DEF456']))).toBe(1);
+    expect(mocks.setCommunityDesignStatus).not.toHaveBeenCalled();
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets the status back to live', async () => {
+    mocks.readCommunityCards.mockResolvedValue([CARD]);
+    const redis = createRedis();
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await restore(baseArgs(['abc123DEF456']))).toBe(0);
+    expect(mocks.setCommunityDesignStatus).toHaveBeenCalledWith(redis, 'abc123DEF456', 'live');
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/community-admin/__tests__/undenylist.test.ts
+++ b/scripts/community-admin/__tests__/undenylist.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Args } from '../lib/args';
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+}));
+
+vi.mock('../lib/redis.js', () => ({
+  connect: mocks.connect,
+}));
+
+const { undenylist } = await import('../commands/undenylist.js');
+
+function baseArgs(positional: string[]): Args {
+  return { command: 'undenylist', positional, json: false, yes: false, help: false };
+}
+
+function createRedis(sremResult: number) {
+  return {
+    srem: vi.fn(async () => sremResult),
+    quit: vi.fn(async () => undefined),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('undenylist command', () => {
+  it('requires a userId', async () => {
+    expect(await undenylist(baseArgs([]))).toBe(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('removes the user from the deny-list', async () => {
+    const redis = createRedis(1);
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await undenylist(baseArgs(['user-1']))).toBe(0);
+    expect(redis.srem).toHaveBeenCalledWith('community:denylist', 'user-1');
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('exits 0 when the user was not on the deny-list', async () => {
+    const redis = createRedis(0);
+    mocks.connect.mockReturnValue(redis);
+
+    expect(await undenylist(baseArgs(['user-1']))).toBe(0);
+    expect(redis.quit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/community-admin/commands/denylist.ts
+++ b/scripts/community-admin/commands/denylist.ts
@@ -1,0 +1,41 @@
+import { deriveAuthorPublicId } from '../../../api/lib/communityIds.js';
+import { readCommunityCards, setCommunityDesignStatus } from '../../../api/lib/communityStore.js';
+import { communityAuthorKey, communityDenylistKey } from '../../../api/lib/redisKeys.js';
+import type { Args } from '../lib/args.js';
+import { colors } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+
+export async function denylist(args: Args): Promise<number> {
+  const userId = args.positional[0];
+  if (!userId) {
+    console.error('denylist <userId> is required');
+    return 2;
+  }
+
+  // TOKEN_SALT is required at CLI startup, so this only returns null if the
+  // env var was cleared mid-run.
+  const authorPublicId = deriveAuthorPublicId(userId);
+  if (!authorPublicId) {
+    console.error('TOKEN_SALT is not set; cannot derive the author public id');
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    await redis.sadd(communityDenylistKey(), userId);
+
+    const designIds = await redis.smembers(communityAuthorKey(authorPublicId));
+    const cards = await readCommunityCards(redis, designIds);
+    const liveIds: string[] = [];
+    for (const card of cards) {
+      if (card && card.status === 'live') liveIds.push(card.id);
+    }
+    await Promise.all(liveIds.map((id) => setCommunityDesignStatus(redis, id, 'hidden')));
+
+    console.log(colors.cyan(`denylisted: ${userId}`));
+    console.log(`hid ${liveIds.length} live design(s): ${liveIds.join(', ') || '(none)'}`);
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/community-admin/commands/feature.ts
+++ b/scripts/community-admin/commands/feature.ts
@@ -1,0 +1,55 @@
+import { isValidShareId } from '../../../api/lib/shared.js';
+import { communityDesignKey } from '../../../api/lib/redisKeys.js';
+import {
+  readCommunityDesignBlob,
+  writeCommunityDesignBlob,
+} from '../../../api/lib/communityStore.js';
+import type { Args } from '../lib/args.js';
+import { colors } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+
+/**
+ * The featured flag is duplicated on the blob (source of truth for the
+ * detail view) and the Redis card hash (source of truth for gallery
+ * sorting/filtering), so both writers must agree. Shared by `feature` and
+ * `unfeature`.
+ */
+async function setFeatured(args: Args, featured: boolean): Promise<number> {
+  const id = args.positional[0];
+  if (!id) {
+    console.error(`${featured ? 'feature' : 'unfeature'} <id> is required`);
+    return 2;
+  }
+  if (!isValidShareId(id)) {
+    console.error(`not a valid community design id: ${id}`);
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    const record = await readCommunityDesignBlob(id);
+    if (!record) {
+      console.error(`community design not found: ${id}`);
+      return 1;
+    }
+    await Promise.all([
+      writeCommunityDesignBlob(
+        { ...record, featured, updatedAt: Date.now() },
+        { allowOverwrite: true }
+      ),
+      redis.hset(communityDesignKey(id), { featured: featured ? '1' : '0' }),
+    ]);
+    console.log(colors.cyan(`${featured ? 'featured' : 'unfeatured'}: ${id}`));
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}
+
+export async function feature(args: Args): Promise<number> {
+  return setFeatured(args, true);
+}
+
+export async function unfeature(args: Args): Promise<number> {
+  return setFeatured(args, false);
+}

--- a/scripts/community-admin/commands/hide.ts
+++ b/scripts/community-admin/commands/hide.ts
@@ -1,0 +1,31 @@
+import { isValidShareId } from '../../../api/lib/shared.js';
+import { readCommunityCards, setCommunityDesignStatus } from '../../../api/lib/communityStore.js';
+import type { Args } from '../lib/args.js';
+import { colors } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+
+export async function hide(args: Args): Promise<number> {
+  const id = args.positional[0];
+  if (!id) {
+    console.error('hide <id> is required');
+    return 2;
+  }
+  if (!isValidShareId(id)) {
+    console.error(`not a valid community design id: ${id}`);
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    const [card] = await readCommunityCards(redis, [id]);
+    if (!card) {
+      console.error(`community design not found: ${id}`);
+      return 1;
+    }
+    await setCommunityDesignStatus(redis, id, 'hidden');
+    console.log(colors.cyan(`hidden: ${id} (was ${card.status})`));
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/community-admin/commands/inspect.ts
+++ b/scripts/community-admin/commands/inspect.ts
@@ -1,0 +1,73 @@
+import { isValidShareId } from '../../../api/lib/shared.js';
+import { readCommunityCards, readCommunityDesignBlob } from '../../../api/lib/communityStore.js';
+import { communityReportsKey } from '../../../api/lib/redisKeys.js';
+import type { Args } from '../lib/args.js';
+import { colors } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+
+export async function inspect(args: Args): Promise<number> {
+  const id = args.positional[0];
+  if (!id) {
+    console.error('inspect <id> is required');
+    return 2;
+  }
+  if (!isValidShareId(id)) {
+    console.error(`not a valid community design id: ${id}`);
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    const [record, cards, reporterIds] = await Promise.all([
+      readCommunityDesignBlob(id),
+      readCommunityCards(redis, [id]),
+      redis.smembers(communityReportsKey(id)),
+    ]);
+    const card = cards[0] ?? null;
+
+    if (!record && !card) {
+      console.error(`community design not found: ${id}`);
+      return 1;
+    }
+
+    if (args.json) {
+      process.stdout.write(JSON.stringify({ record, card, reporterIds }, null, 2) + '\n');
+      return 0;
+    }
+
+    console.log(colors.bold(`=== community design ${id} ===`));
+    if (record) {
+      console.log(`name:        ${record.name}`);
+      console.log(`author:      ${record.authorName} (${record.authorPublicId})`);
+      console.log(`category:    ${record.category}`);
+      console.log(`techniques:  ${record.techniques.join(', ') || '(none)'}`);
+      console.log(`status:      ${record.status}`);
+      console.log(`featured:    ${record.featured ? 'yes' : 'no'}`);
+      console.log(
+        `lineage:     ${record.lineage ? `remix of ${record.lineage.parentId}` : '(original)'}`
+      );
+      console.log(`created:     ${new Date(record.createdAt).toISOString()}`);
+      console.log(`updated:     ${new Date(record.updatedAt).toISOString()}`);
+    } else {
+      console.log(colors.yellow('design blob missing; showing card metadata only'));
+    }
+    if (card) {
+      console.log(`likes:       ${card.likes}`);
+      console.log(`remixes:     ${card.remixes}`);
+      console.log(`exports:     ${card.exports}`);
+    }
+    console.log('');
+    console.log(colors.bold(`reports: ${reporterIds.length}`));
+    for (const userId of reporterIds) console.log(`  ${userId}`);
+    if (reporterIds.length > 0) {
+      console.log(
+        colors.dim(
+          '  (deny-list status cannot be checked from a design id: authorPublicId is a one-way hash of the userId)'
+        )
+      );
+    }
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/community-admin/commands/list.ts
+++ b/scripts/community-admin/commands/list.ts
@@ -1,0 +1,93 @@
+import type { Redis } from 'ioredis';
+import { readCommunityCards } from '../../../api/lib/communityStore.js';
+import type { CommunityCardRecord } from '../../../api/lib/communityStore.js';
+import { communityReportsKey } from '../../../api/lib/redisKeys.js';
+import type { Args } from '../lib/args.js';
+import { colors, formatTable } from '../lib/output.js';
+import { connect, scanKeys } from '../lib/redis.js';
+
+const LIST_MODES = ['flagged', 'hidden', 'all'] as const;
+type ListMode = (typeof LIST_MODES)[number];
+
+interface ListRow extends CommunityCardRecord {
+  reportCount: number;
+}
+
+async function loadRows(redis: Redis): Promise<ListRow[]> {
+  const keys = await scanKeys(redis, 'community:design:*');
+  const ids = keys.map((key) => key.slice('community:design:'.length));
+  const cards = await readCommunityCards(redis, ids);
+
+  const pipeline = redis.pipeline();
+  for (const id of ids) pipeline.scard(communityReportsKey(id));
+  const reportResults = (await pipeline.exec()) ?? [];
+
+  const rows: ListRow[] = [];
+  cards.forEach((card, i) => {
+    if (!card) return;
+    const [error, count] = reportResults[i] ?? [null, 0];
+    rows.push({ ...card, reportCount: error ? 0 : Number(count ?? 0) });
+  });
+  return rows;
+}
+
+function rowsForMode(rows: readonly ListRow[], mode: ListMode): ListRow[] {
+  if (mode === 'hidden') return rows.filter((r) => r.status === 'hidden');
+  if (mode === 'flagged') return rows.filter((r) => r.status === 'live' && r.reportCount > 0);
+  return [...rows];
+}
+
+export async function list(args: Args): Promise<number> {
+  const mode = (args.positional[0] ?? 'all') as ListMode;
+  if (!LIST_MODES.includes(mode)) {
+    console.error(`list <mode> must be one of: ${LIST_MODES.join(', ')}`);
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    const rows = await loadRows(redis);
+    const counts = {
+      live: rows.filter((r) => r.status === 'live').length,
+      hidden: rows.filter((r) => r.status === 'hidden').length,
+      removed: rows.filter((r) => r.status === 'removed').length,
+      flagged: rows.filter((r) => r.status === 'live' && r.reportCount > 0).length,
+    };
+    const matched = rowsForMode(rows, mode);
+
+    if (args.json) {
+      process.stdout.write(JSON.stringify({ counts, mode, designs: matched }, null, 2) + '\n');
+      return 0;
+    }
+
+    console.log(
+      colors.bold(
+        `=== community designs: ${counts.live + counts.hidden + counts.removed} total ===`
+      )
+    );
+    console.log(
+      `live: ${counts.live}  hidden: ${counts.hidden}  removed: ${counts.removed}  flagged: ${counts.flagged}`
+    );
+    console.log('');
+    if (matched.length === 0) {
+      console.log(colors.dim(`(no designs in mode "${mode}")`));
+      return 0;
+    }
+    console.log(
+      formatTable(
+        ['id', 'status', 'reports', 'featured', 'author', 'name'],
+        matched.map((r) => [
+          r.id,
+          r.status,
+          r.reportCount,
+          r.featured ? 'yes' : '',
+          r.authorName,
+          r.name,
+        ])
+      )
+    );
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/community-admin/commands/list.ts
+++ b/scripts/community-admin/commands/list.ts
@@ -20,7 +20,10 @@ async function loadRows(redis: Redis): Promise<ListRow[]> {
 
   const pipeline = redis.pipeline();
   for (const id of ids) pipeline.scard(communityReportsKey(id));
-  const reportResults = (await pipeline.exec()) ?? [];
+  const reportResults = await pipeline.exec();
+  if (reportResults === null) {
+    throw new Error('report-count pipeline failed: redis connection lost');
+  }
 
   const rows: ListRow[] = [];
   cards.forEach((card, i) => {

--- a/scripts/community-admin/commands/purge.ts
+++ b/scripts/community-admin/commands/purge.ts
@@ -1,0 +1,82 @@
+import { isValidShareId } from '../../../api/lib/shared.js';
+import { deleteBlob } from '../../../api/lib/blobStore.js';
+import { readCommunityCards, readCommunityDesignBlob } from '../../../api/lib/communityStore.js';
+import { communityLikedKey } from '../../../api/lib/redisKeys.js';
+import { logger } from '../../../api/lib/logger.js';
+import type { Args } from '../lib/args.js';
+import { colors } from '../lib/output.js';
+import { planPurgeCleanup } from '../lib/purgePlan.js';
+import { connect } from '../lib/redis.js';
+
+export async function purge(args: Args): Promise<number> {
+  const id = args.positional[0];
+  if (!id) {
+    console.error('purge <id> is required');
+    return 2;
+  }
+  if (!isValidShareId(id)) {
+    console.error(`not a valid community design id: ${id}`);
+    return 2;
+  }
+  if (!args.yes) {
+    console.error('purge is irreversible; re-run with --yes to confirm');
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    const [record, cards] = await Promise.all([
+      readCommunityDesignBlob(id),
+      readCommunityCards(redis, [id]),
+    ]);
+    const card = cards[0] ?? null;
+    if (!record && !card) {
+      console.error(`community design not found: ${id}`);
+      return 1;
+    }
+
+    const plan = planPurgeCleanup(id, record, card);
+
+    for (const path of plan.blobPaths) {
+      try {
+        await deleteBlob(path);
+      } catch (error) {
+        logger.error('community-admin purge: blob delete failed', {
+          id,
+          path,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    // The cascade to each liker's reverse index needs the live membership of
+    // plan.likesKey, so it can't be part of the static plan (see purgePlan.ts).
+    const likerIds = await redis.smembers(plan.likesKey);
+
+    const pipeline = redis.pipeline();
+    pipeline.del(plan.hashKey);
+    for (const key of plan.indexKeys) pipeline.zrem(key, id);
+    if (plan.authorKey) pipeline.srem(plan.authorKey, id);
+    if (plan.parentChildKey) pipeline.srem(plan.parentChildKey, id);
+    pipeline.del(plan.reportsKey);
+    pipeline.del(plan.likesKey);
+    pipeline.del(plan.childrenKey);
+    for (const userId of likerIds) pipeline.srem(communityLikedKey(userId), id);
+    await pipeline.exec();
+
+    console.log(colors.cyan(`purged: ${id}`));
+    if (!plan.authorKey) {
+      console.log(
+        colors.yellow('  author unresolved: community:author:{publicId} was not cleaned')
+      );
+    }
+    console.log(
+      colors.dim(
+        '  community:published:{userId} cannot be cleaned from a design id alone (authorPublicId is a one-way hash); the author keeps a phantom quota slot until the record is resolved out of band'
+      )
+    );
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/community-admin/commands/purge.ts
+++ b/scripts/community-admin/commands/purge.ts
@@ -62,7 +62,13 @@ export async function purge(args: Args): Promise<number> {
     pipeline.del(plan.likesKey);
     pipeline.del(plan.childrenKey);
     for (const userId of likerIds) pipeline.srem(communityLikedKey(userId), id);
-    await pipeline.exec();
+    const results = await pipeline.exec();
+    if (results === null) {
+      throw new Error('purge pipeline failed: redis connection lost');
+    }
+    for (const [error] of results) {
+      if (error) throw new Error(`purge pipeline failed: ${error.message}`);
+    }
 
     console.log(colors.cyan(`purged: ${id}`));
     if (!plan.authorKey) {

--- a/scripts/community-admin/commands/restore.ts
+++ b/scripts/community-admin/commands/restore.ts
@@ -1,0 +1,31 @@
+import { isValidShareId } from '../../../api/lib/shared.js';
+import { readCommunityCards, setCommunityDesignStatus } from '../../../api/lib/communityStore.js';
+import type { Args } from '../lib/args.js';
+import { colors } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+
+export async function restore(args: Args): Promise<number> {
+  const id = args.positional[0];
+  if (!id) {
+    console.error('restore <id> is required');
+    return 2;
+  }
+  if (!isValidShareId(id)) {
+    console.error(`not a valid community design id: ${id}`);
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    const [card] = await readCommunityCards(redis, [id]);
+    if (!card) {
+      console.error(`community design not found: ${id}`);
+      return 1;
+    }
+    await setCommunityDesignStatus(redis, id, 'live');
+    console.log(colors.cyan(`restored to live: ${id} (was ${card.status})`));
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/community-admin/commands/undenylist.ts
+++ b/scripts/community-admin/commands/undenylist.ts
@@ -1,0 +1,30 @@
+import { communityDenylistKey } from '../../../api/lib/redisKeys.js';
+import type { Args } from '../lib/args.js';
+import { colors } from '../lib/output.js';
+import { connect } from '../lib/redis.js';
+
+export async function undenylist(args: Args): Promise<number> {
+  const userId = args.positional[0];
+  if (!userId) {
+    console.error('undenylist <userId> is required');
+    return 2;
+  }
+
+  const redis = connect();
+  try {
+    const removed = await redis.srem(communityDenylistKey(), userId);
+    if (removed === 0) {
+      console.log(colors.dim(`${userId} was not on the deny-list`));
+      return 0;
+    }
+    console.log(colors.cyan(`removed from deny-list: ${userId}`));
+    console.log(
+      colors.dim(
+        'their previously hidden designs are not auto-restored; use `restore <id>` per design'
+      )
+    );
+    return 0;
+  } finally {
+    await redis.quit();
+  }
+}

--- a/scripts/community-admin/index.ts
+++ b/scripts/community-admin/index.ts
@@ -1,0 +1,87 @@
+import { denylist } from './commands/denylist.js';
+import { feature, unfeature } from './commands/feature.js';
+import { hide } from './commands/hide.js';
+import { inspect } from './commands/inspect.js';
+import { list } from './commands/list.js';
+import { purge } from './commands/purge.js';
+import { restore } from './commands/restore.js';
+import { undenylist } from './commands/undenylist.js';
+import { parseArgs, type Args } from './lib/args.js';
+import { printBanner } from './lib/banner.js';
+import { dispatch } from './lib/dispatch.js';
+import { loadEnv, requireEnv } from './lib/env.js';
+
+const COMMANDS: Record<string, (a: Args) => Promise<number>> = {
+  list,
+  inspect,
+  hide,
+  restore,
+  purge,
+  denylist,
+  undenylist,
+  feature,
+  unfeature,
+};
+
+const HELP = `community-admin: direct-write moderation CLI for the community showcase
+
+Usage:
+  pnpm community-admin <command> [args] [flags]
+
+Commands:
+  list [flagged|hidden|all]      List designs with status counts (default: all)
+  inspect <id>                   Full record (blob + card) plus report state
+  hide <id>                      Set status to hidden and drop it from gallery indexes
+  restore <id>                   Set status back to live and re-index it
+  purge <id> --yes               Hard-delete blobs and every Redis key for one design
+  denylist <userId>              Bar a user from publishing and hide their live designs
+  undenylist <userId>            Remove a user from the deny-list (does not restore designs)
+  feature <id>                   Set featured=true on the blob and the card hash
+  unfeature <id>                 Set featured=false on the blob and the card hash
+
+Flags:
+  --json          Machine-readable output (list, inspect)
+  --yes           Required to confirm \`purge\` (irreversible)
+  --help          Show this message
+
+Examples:
+  pnpm community-admin list flagged
+  pnpm community-admin inspect abc123DEF456
+  pnpm community-admin hide abc123DEF456
+  pnpm community-admin purge abc123DEF456 --yes
+`;
+
+async function main(): Promise<number> {
+  let args: Args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+
+  if (args.help || !args.command) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  loadEnv();
+  requireEnv('REDIS_URL');
+  requireEnv('BLOB_READ_WRITE_TOKEN');
+  requireEnv('TOKEN_SALT');
+  printBanner();
+
+  const outcome = await dispatch(COMMANDS, args);
+  if (outcome.unknownCommand) {
+    console.error(`Unknown command: ${outcome.unknownCommand}`);
+    process.stdout.write('\n' + HELP);
+  }
+  return outcome.code;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });

--- a/scripts/community-admin/lib/args.ts
+++ b/scripts/community-admin/lib/args.ts
@@ -1,0 +1,26 @@
+export interface Args {
+  command: string;
+  positional: string[];
+  json: boolean;
+  yes: boolean;
+  help: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): Args {
+  const a: Args = {
+    command: '',
+    positional: [],
+    json: false,
+    yes: false,
+    help: false,
+  };
+  for (const arg of argv) {
+    if (arg === '--json') a.json = true;
+    else if (arg === '--yes' || arg === '-y') a.yes = true;
+    else if (arg === '--help' || arg === '-h') a.help = true;
+    else if (arg.startsWith('--')) throw new Error(`Unknown flag: ${arg}`);
+    else if (!a.command) a.command = arg;
+    else a.positional.push(arg);
+  }
+  return a;
+}

--- a/scripts/community-admin/lib/banner.ts
+++ b/scripts/community-admin/lib/banner.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'node:crypto';
+
+export function printBanner(): void {
+  const redisUrl = process.env.REDIS_URL ?? '';
+  const blobToken = process.env.BLOB_READ_WRITE_TOKEN ?? '';
+  const host = redisUrl.match(/@([^:]+)/)?.[1] ?? '<unknown>';
+  const tokenFp = blobToken
+    ? createHash('sha256').update(blobToken).digest('hex').slice(0, 8)
+    : 'n/a';
+  const stream = process.stderr;
+  stream.write('────────────────────────────────────────────────\n');
+  stream.write(`  community-admin\n`);
+  stream.write(`  Redis: ${host}\n`);
+  stream.write(`  Blob token fingerprint: ${tokenFp}\n`);
+  // Unlike sync-admin, every mutating command below writes to production
+  // immediately (README.md, "Deviation from sync-admin").
+  stream.write('  \x1b[33mDIRECT WRITE: mutations apply immediately, no dry-run\x1b[0m\n');
+  stream.write('────────────────────────────────────────────────\n');
+}

--- a/scripts/community-admin/lib/banner.ts
+++ b/scripts/community-admin/lib/banner.ts
@@ -14,6 +14,8 @@ export function printBanner(): void {
   stream.write(`  Blob token fingerprint: ${tokenFp}\n`);
   // Unlike sync-admin, every mutating command below writes to production
   // immediately (README.md, "Deviation from sync-admin").
-  stream.write('  \x1b[33mDIRECT WRITE: mutations apply immediately, no dry-run\x1b[0m\n');
+  const warning = 'DIRECT WRITE: mutations apply immediately, no dry-run';
+  const color = stream.isTTY === true && process.env.NO_COLOR === undefined;
+  stream.write(color ? `  \x1b[33m${warning}\x1b[0m\n` : `  ${warning}\n`);
   stream.write('────────────────────────────────────────────────\n');
 }

--- a/scripts/community-admin/lib/dispatch.ts
+++ b/scripts/community-admin/lib/dispatch.ts
@@ -1,0 +1,22 @@
+import type { Args } from './args.js';
+
+export type CommandTable = Record<string, (a: Args) => Promise<number>>;
+
+export interface DispatchOutcome {
+  code: number;
+  /** Set when args.command didn't match any entry in the table; null otherwise. */
+  unknownCommand: string | null;
+}
+
+/**
+ * Resolve args.command against the table and run it. Kept separate from
+ * index.ts's main() so command routing is testable without env vars, Redis,
+ * or Blob credentials.
+ */
+export async function dispatch(commands: CommandTable, args: Args): Promise<DispatchOutcome> {
+  const handler = commands[args.command];
+  if (!handler) {
+    return { code: 2, unknownCommand: args.command };
+  }
+  return { code: await handler(args), unknownCommand: null };
+}

--- a/scripts/community-admin/lib/env.ts
+++ b/scripts/community-admin/lib/env.ts
@@ -1,0 +1,27 @@
+// Duplicated from scripts/sync-admin/lib/env.ts rather than imported cross-script
+// (each admin CLI stays self-contained; see that file for the mirror).
+import { readFileSync } from 'node:fs';
+
+const ENV_FILES = ['.env.production.local', '.env.local'];
+
+export function loadEnv(): void {
+  for (const file of ENV_FILES) {
+    try {
+      const body = readFileSync(file, 'utf8');
+      for (const line of body.split('\n')) {
+        const m = line.match(/^([A-Z_]+)="?([^"\n]*)"?$/);
+        if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+      }
+    } catch {}
+  }
+}
+
+export function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required env var: ${name}`);
+    console.error(`Run \`vercel env pull .env.production.local\` to refresh credentials.`);
+    process.exit(2);
+  }
+  return v;
+}

--- a/scripts/community-admin/lib/output.ts
+++ b/scripts/community-admin/lib/output.ts
@@ -1,0 +1,24 @@
+const COLOR = process.stdout.isTTY && !process.env.NO_COLOR;
+const c = {
+  red: (s: string) => (COLOR ? `\x1b[31m${s}\x1b[0m` : s),
+  yellow: (s: string) => (COLOR ? `\x1b[33m${s}\x1b[0m` : s),
+  cyan: (s: string) => (COLOR ? `\x1b[36m${s}\x1b[0m` : s),
+  dim: (s: string) => (COLOR ? `\x1b[2m${s}\x1b[0m` : s),
+  bold: (s: string) => (COLOR ? `\x1b[1m${s}\x1b[0m` : s),
+};
+
+export const colors = c;
+
+export function formatTable(
+  headers: readonly string[],
+  rows: readonly (readonly (string | number)[])[]
+): string {
+  const widths = headers.map((h, i) =>
+    Math.max(String(h).length, ...rows.map((r) => String(r[i] ?? '').length))
+  );
+  const fmtRow = (r: readonly (string | number)[]): string =>
+    r.map((v, i) => String(v ?? '').padEnd(widths[i])).join('  ');
+  const lines = [c.bold(fmtRow(headers))];
+  for (const r of rows) lines.push(fmtRow(r));
+  return lines.join('\n');
+}

--- a/scripts/community-admin/lib/purgePlan.ts
+++ b/scripts/community-admin/lib/purgePlan.ts
@@ -1,0 +1,65 @@
+import {
+  communityAuthorKey,
+  communityChildrenKey,
+  communityDesignKey,
+  communityIndexKey,
+  communityLikesKey,
+  communityReportsKey,
+  COMMUNITY_INDEX_SORTS,
+} from '../../../api/lib/redisKeys.js';
+import { communityDesignBlobPath } from '../../../api/lib/communityStore.js';
+import type {
+  CommunityCardRecord,
+  CommunityDesignRecord,
+} from '../../../api/lib/communityStore.js';
+
+export interface PurgeCleanupPlan {
+  /** Blob paths/URLs to delete: the design JSON, then any known thumbnails and mesh. */
+  blobPaths: string[];
+  hashKey: string;
+  indexKeys: string[];
+  likesKey: string;
+  reportsKey: string;
+  /** SET of this design's own remixes: deleted as bookkeeping, the remixes themselves are untouched. */
+  childrenKey: string;
+  /** community:author:{publicId}, or null when neither the blob nor the card resolved an author. */
+  authorKey: string | null;
+  /** community:children:{parentId}, present only when this design is itself a remix. */
+  parentChildKey: string | null;
+}
+
+/**
+ * Enumerate every blob path and Redis key a purge must touch, without doing
+ * any I/O. Kept pure and separate from the `purge` command so the key
+ * enumeration itself is unit-testable without mocking Redis or Blob.
+ *
+ * "children keep snapshots" (community-showcase-plan.md 5.8): a remix's
+ * lineage.parentId is allowed to point at a design that no longer resolves,
+ * so this plan never reaches into a child's own record. It only reaches into
+ * this design's parent's children set, to drop the now-dangling reference to it.
+ */
+export function planPurgeCleanup(
+  designId: string,
+  record: CommunityDesignRecord | null,
+  card: CommunityCardRecord | null
+): PurgeCleanupPlan {
+  const blobPaths = [communityDesignBlobPath(designId)];
+  if (record) {
+    blobPaths.push(...record.thumbnails);
+    if (record.meshUrl) blobPaths.push(record.meshUrl);
+  }
+
+  const authorPublicId = record?.authorPublicId ?? card?.authorPublicId ?? null;
+  const parentId = record?.lineage?.parentId ?? null;
+
+  return {
+    blobPaths,
+    hashKey: communityDesignKey(designId),
+    indexKeys: COMMUNITY_INDEX_SORTS.map((sort) => communityIndexKey(sort)),
+    likesKey: communityLikesKey(designId),
+    reportsKey: communityReportsKey(designId),
+    childrenKey: communityChildrenKey(designId),
+    authorKey: authorPublicId ? communityAuthorKey(authorPublicId) : null,
+    parentChildKey: parentId ? communityChildrenKey(parentId) : null,
+  };
+}

--- a/scripts/community-admin/lib/redis.ts
+++ b/scripts/community-admin/lib/redis.ts
@@ -1,0 +1,28 @@
+import Redis from 'ioredis';
+import { requireEnv } from './env.js';
+
+export function connect(): Redis {
+  return new Redis(requireEnv('REDIS_URL'), {
+    maxRetriesPerRequest: 2,
+    connectTimeout: 5000,
+    commandTimeout: 5000,
+  });
+}
+
+/** Mirrors scanKeys in scripts/sync-admin/lib/redis.ts; see that file for the COUNT tuning rationale. */
+const SCAN_COUNT = 10_000;
+
+export async function scanKeys(
+  redis: Redis,
+  pattern: string,
+  count = SCAN_COUNT
+): Promise<string[]> {
+  const out = new Set<string>();
+  let cursor = '0';
+  do {
+    const [next, batch] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', count);
+    for (const k of batch) out.add(k);
+    cursor = next;
+  } while (cursor !== '0');
+  return [...out];
+}

--- a/src/features/bin-designer/components/ExampleGallery/ExampleCard.test.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/ExampleCard.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { ExampleCard } from './ExampleCard';
+
+vi.mock('@/i18n', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+const example: ExampleDesign = {
+  id: 'custom-l-shape',
+  nameKey: 'binExamples.customLShape.name',
+  descriptionKey: 'binExamples.customLShape.description',
+  techniques: ['customShape'],
+  tier: 'technique',
+  tags: ['custom-shape'],
+  complexity: 1,
+  params: DEFAULT_BIN_PARAMS,
+  metrics: { width: 2, depth: 2, height: 4, gridUnitMm: DEFAULT_BIN_PARAMS.gridUnitMm },
+};
+
+describe('ExampleCard', () => {
+  it('renders the name, technique label, and thumbnail', () => {
+    render(<ExampleCard example={example} onSelect={vi.fn()} index={0} />);
+    expect(
+      screen.getByRole('heading', { name: 'binExamples.customLShape.name' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('binExamples.technique.customShape')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'binExamples.customLShape.name' })).toBeInTheDocument();
+  });
+
+  it('calls onSelect on click', () => {
+    const onSelect = vi.fn();
+    render(<ExampleCard example={example} onSelect={onSelect} index={0} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onSelect).toHaveBeenCalledWith(example);
+  });
+
+  it('calls onSelect on Enter and Space but not other keys', () => {
+    const onSelect = vi.fn();
+    render(<ExampleCard example={example} onSelect={onSelect} index={0} />);
+    const card = screen.getByRole('button');
+    fireEvent.keyDown(card, { key: 'Enter' });
+    fireEvent.keyDown(card, { key: ' ' });
+    fireEvent.keyDown(card, { key: 'a' });
+    expect(onSelect).toHaveBeenCalledTimes(2);
+  });
+
+  it('forwards tabIndex for roving focus', () => {
+    render(<ExampleCard example={example} onSelect={vi.fn()} index={0} tabIndex={-1} />);
+    expect(screen.getByRole('button')).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/src/features/bin-designer/components/ExampleGallery/ExampleCard.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/ExampleCard.tsx
@@ -1,6 +1,6 @@
 import { thumbnailUrl } from '@/features/bin-designer/data/examples/thumbnails';
 import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
-import { TECHNIQUE_CONFIG } from '@/features/bin-designer/types/exampleGallery';
+import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
 import { useTranslation } from '@/i18n';
 
 interface ExampleCardProps {

--- a/src/features/bin-designer/components/ExampleGallery/ExamplePreviewOverlay.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/ExamplePreviewOverlay.tsx
@@ -4,7 +4,7 @@ import { useToastStore } from '@/core/store/toast';
 import { isOk } from '@/core/result';
 import { exampleToDesign } from '@/features/bin-designer/utils/exampleToDesign';
 import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
-import { TECHNIQUE_CONFIG } from '@/features/bin-designer/types/exampleGallery';
+import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
 import { useTranslation } from '@/i18n';
 import { Example3DViewer } from './Example3DViewer';
 

--- a/src/features/bin-designer/components/ExampleGallery/TechniqueFilterPills.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/TechniqueFilterPills.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/design-system';
-import type { ExampleDesign, ExampleTechnique } from '@/features/bin-designer/types/exampleGallery';
-import { TECHNIQUE_CONFIG } from '@/features/bin-designer/types/exampleGallery';
+import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
+import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
 import { useTranslation } from '@/i18n';
 
 interface TechniqueFilterPillsProps {

--- a/src/features/bin-designer/components/ExampleGallery/useExampleGalleryFilters.ts
+++ b/src/features/bin-designer/components/ExampleGallery/useExampleGalleryFilters.ts
@@ -1,4 +1,5 @@
-import type { ExampleDesign, ExampleTechnique } from '@/features/bin-designer/types/exampleGallery';
+import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
 
 export interface GalleryFilters {
   search: string;

--- a/src/features/bin-designer/data/examples/index.ts
+++ b/src/features/bin-designer/data/examples/index.ts
@@ -1,4 +1,5 @@
-import type { ExampleDesign, ExampleTechnique } from '@/features/bin-designer/types/exampleGallery';
+import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
 import { WALL_CUTOUT_EXAMPLES } from './cutouts';
 import { SCOOP_EXAMPLES } from './scoops';
 import { LID_EXAMPLES } from './lids';

--- a/src/features/bin-designer/types/exampleGallery.ts
+++ b/src/features/bin-designer/types/exampleGallery.ts
@@ -1,15 +1,5 @@
 import type { BinParams } from '@/shared/types/bin';
-
-export type ExampleTechnique =
-  | 'compartments'
-  | 'wallCutouts'
-  | 'scoop'
-  | 'labelTab'
-  | 'slotted'
-  | 'lid'
-  | 'handles'
-  | 'customShape'
-  | 'wallPattern';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
 
 export interface ExampleDesign {
   readonly id: string;
@@ -29,15 +19,3 @@ export interface ExampleDesign {
   /** Whether this example uses multi-color feature colors (selective color). */
   readonly colored?: boolean;
 }
-
-export const TECHNIQUE_CONFIG: Record<ExampleTechnique, { readonly labelKey: string }> = {
-  compartments: { labelKey: 'binExamples.technique.compartments' },
-  wallCutouts: { labelKey: 'binExamples.technique.wallCutouts' },
-  scoop: { labelKey: 'binExamples.technique.scoop' },
-  labelTab: { labelKey: 'binExamples.technique.labelTab' },
-  slotted: { labelKey: 'binExamples.technique.slotted' },
-  lid: { labelKey: 'binExamples.technique.lid' },
-  handles: { labelKey: 'binExamples.technique.handles' },
-  customShape: { labelKey: 'binExamples.technique.customShape' },
-  wallPattern: { labelKey: 'binExamples.technique.wallPattern' },
-};

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -131,8 +131,9 @@ export {
 /** Auto-save status indicator. Defined in shared — the baseplate page uses it too. */
 export type { SaveStatus };
 
-export type { ExampleDesign, ExampleTechnique } from './exampleGallery';
-export { TECHNIQUE_CONFIG } from './exampleGallery';
+export type { ExampleDesign } from './exampleGallery';
+export type { ExampleTechnique } from '@/shared/types/exampleTechniques';
+export { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
 
 export * from './base';
 export * from './dividers';

--- a/src/shared/types/community.test.ts
+++ b/src/shared/types/community.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Cross-boundary equality test for the category mirror: api/ cannot import
+ * from src/, so `COMMUNITY_CATEGORIES` is duplicated in
+ * `api/lib/communityValidation.ts` and only this test keeps the two tuples
+ * from drifting apart.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { COMMUNITY_CATEGORIES as API_COMMUNITY_CATEGORIES } from '../../../api/lib/communityValidation.js';
+
+import { COMMUNITY_CATEGORIES } from './community';
+
+describe('COMMUNITY_CATEGORIES (cross-boundary mirror)', () => {
+  it('matches the api tuple exactly, including order', () => {
+    expect([...COMMUNITY_CATEGORIES]).toEqual([...API_COMMUNITY_CATEGORIES]);
+  });
+});

--- a/src/shared/types/community.ts
+++ b/src/shared/types/community.ts
@@ -1,0 +1,98 @@
+/**
+ * Community design showcase data model (issue #3050 §5.2).
+ *
+ * MIRROR: `COMMUNITY_CATEGORIES`/`CommunityCategory` here must match the
+ * identically-named runtime tuple/type in `api/lib/communityValidation.ts`
+ * (api/ cannot import from src/, so the members are duplicated, not shared).
+ * Update both sides together; the cross-boundary equality test in
+ * `community.test.ts` guards against drift.
+ */
+import type { BinParams } from '@/shared/types/bin';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
+
+export const COMMUNITY_CATEGORIES = [
+  'tools',
+  'hardware',
+  'kitchen',
+  'office',
+  'crafts',
+  'electronics',
+  'toys-games',
+  'other',
+] as const;
+
+export type CommunityCategory = (typeof COMMUNITY_CATEGORIES)[number];
+
+/**
+ * `hidden` = auto-hidden after the report threshold or a deny-listed author;
+ * `removed` = owner unpublish / admin purge. Updating a design never changes
+ * its status (community-showcase-plan.md §1 "Updates").
+ */
+export type CommunityDesignStatus = 'live' | 'hidden' | 'removed';
+
+export interface CommunityDesignMetrics {
+  readonly width: number;
+  readonly depth: number;
+  readonly height: number;
+  readonly gridUnitMm: number;
+}
+
+/** Snapshot naming so lineage still reads sensibly after the parent/root is deleted or renamed. */
+export interface CommunityDesignLineage {
+  readonly parentId: string;
+  readonly rootId: string;
+  readonly parentName: string;
+  readonly parentAuthorName: string;
+  readonly rootAuthorName: string;
+}
+
+/**
+ * Lightweight card-metadata shape served by the paginated list index
+ * (`GET /api/community`): powers gallery grids, search, filters, and
+ * shelves entirely client-side. Omits `params`/`description`/`lineage`
+ * detail/`meshUrl`/`photos`, which only the detail fetch needs.
+ */
+export interface CommunityDesignSummary {
+  readonly id: string;
+  readonly authorPublicId: string;
+  readonly authorName: string;
+  readonly name: string;
+  readonly category: CommunityCategory;
+  readonly techniques: readonly ExampleTechnique[];
+  readonly metrics: CommunityDesignMetrics;
+  readonly thumbnails: readonly string[];
+  /** True when `lineage` is non-null on the full record; drives the card's corner remix glyph. */
+  readonly isRemix: boolean;
+  readonly likeCount: number;
+  readonly remixCount: number;
+  readonly featured: boolean;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly status: CommunityDesignStatus;
+}
+
+/** Full published-design record, as returned by `GET /api/community/[id]`. */
+export interface CommunityDesign {
+  readonly id: string;
+  /** sha256(TOKEN_SALT + ':community:' + userId).slice(0, 32), the deriveDonorId pattern, never the raw userId. */
+  readonly authorPublicId: string;
+  readonly authorName: string;
+  readonly name: string;
+  readonly description: string;
+  readonly category: CommunityCategory;
+  /** Derived server-side by `deriveCommunityTechniques` at publish/update time, not client-supplied. */
+  readonly techniques: readonly ExampleTechnique[];
+  readonly params: BinParams;
+  readonly metrics: CommunityDesignMetrics;
+  readonly lineage: CommunityDesignLineage | null;
+  /** 2-3 WebP 384px blob URLs. */
+  readonly thumbnails: readonly string[];
+  /** Publisher-exported GLB, revision-stamped path (`<id>-<rev>.glb`), immutably cacheable. */
+  readonly meshUrl: string;
+  /** Reserved for post-graduation publisher photos; empty until then. */
+  readonly photos: readonly string[];
+  readonly featured: boolean;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly status: CommunityDesignStatus;
+}

--- a/src/shared/types/exampleTechniques.test.ts
+++ b/src/shared/types/exampleTechniques.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { TECHNIQUE_CONFIG } from './exampleTechniques';
+import type { ExampleTechnique } from './exampleTechniques';
+
+const ALL_TECHNIQUES: readonly ExampleTechnique[] = [
+  'compartments',
+  'wallCutouts',
+  'scoop',
+  'labelTab',
+  'slotted',
+  'lid',
+  'handles',
+  'customShape',
+  'wallPattern',
+];
+
+describe('TECHNIQUE_CONFIG', () => {
+  it('has an entry for every ExampleTechnique member', () => {
+    for (const technique of ALL_TECHNIQUES) {
+      expect(TECHNIQUE_CONFIG[technique]).toBeDefined();
+    }
+  });
+
+  it('every labelKey follows the binExamples.technique.<name> convention', () => {
+    for (const technique of ALL_TECHNIQUES) {
+      expect(TECHNIQUE_CONFIG[technique].labelKey).toBe(`binExamples.technique.${technique}`);
+    }
+  });
+
+  it('has exactly the 9 known technique keys, no more', () => {
+    expect(Object.keys(TECHNIQUE_CONFIG).sort()).toEqual([...ALL_TECHNIQUES].sort());
+  });
+});

--- a/src/shared/types/exampleTechniques.ts
+++ b/src/shared/types/exampleTechniques.ts
@@ -1,0 +1,31 @@
+/**
+ * Bin-designer technique tags. Used to categorize curated examples
+ * (`src/features/bin-designer/types/exampleGallery.ts`) and, via
+ * `deriveTechniques` in `src/shared/utils/communityTechniques.ts`, to
+ * auto-tag community-published designs. Lives in shared/ (rather than
+ * bin-designer/) so features/community can reference the same union
+ * without a cross-feature import.
+ */
+
+export type ExampleTechnique =
+  | 'compartments'
+  | 'wallCutouts'
+  | 'scoop'
+  | 'labelTab'
+  | 'slotted'
+  | 'lid'
+  | 'handles'
+  | 'customShape'
+  | 'wallPattern';
+
+export const TECHNIQUE_CONFIG: Record<ExampleTechnique, { readonly labelKey: string }> = {
+  compartments: { labelKey: 'binExamples.technique.compartments' },
+  wallCutouts: { labelKey: 'binExamples.technique.wallCutouts' },
+  scoop: { labelKey: 'binExamples.technique.scoop' },
+  labelTab: { labelKey: 'binExamples.technique.labelTab' },
+  slotted: { labelKey: 'binExamples.technique.slotted' },
+  lid: { labelKey: 'binExamples.technique.lid' },
+  handles: { labelKey: 'binExamples.technique.handles' },
+  customShape: { labelKey: 'binExamples.technique.customShape' },
+  wallPattern: { labelKey: 'binExamples.technique.wallPattern' },
+};

--- a/src/shared/utils/communityTechniques.crossBoundary.test.ts
+++ b/src/shared/utils/communityTechniques.crossBoundary.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Cross-boundary equality test for the technique-derivation mirror.
+ *
+ * `deriveTechniques` (client, typed on `BinParams`) and `deriveCommunityTechniques`
+ * (server, `api/lib/communityValidation.ts`, typed on sanitized `Record<string,
+ * unknown>` params) MUST agree on every input: derivation drift is silent
+ * (unlike validation drift, which 400s). This is the node-env `unit` vitest
+ * project, which also picks up `api/**\/*.test.ts`, so both sides are importable
+ * from the same test run.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { deriveCommunityTechniques } from '../../../api/lib/communityValidation.js';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+
+import { deriveTechniques } from './communityTechniques';
+
+function withCellMask(cells: (0 | 1)[]): BinParams {
+  return { ...DEFAULT_BIN_PARAMS, cellMask: { cols: 2, rows: 2, cells } };
+}
+
+const FIXTURES: readonly BinParams[] = [
+  DEFAULT_BIN_PARAMS,
+  {
+    ...DEFAULT_BIN_PARAMS,
+    compartments: {
+      ...DEFAULT_BIN_PARAMS.compartments,
+      cols: 3,
+      rows: 2,
+      cells: [0, 1, 2, 3, 4, 5],
+    },
+  },
+  {
+    ...DEFAULT_BIN_PARAMS,
+    compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 2, cells: [0, 0, 0, 0] },
+  },
+  { ...DEFAULT_BIN_PARAMS, walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: true } },
+  { ...DEFAULT_BIN_PARAMS, scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true } },
+  { ...DEFAULT_BIN_PARAMS, label: { ...DEFAULT_BIN_PARAMS.label, enabled: true } },
+  { ...DEFAULT_BIN_PARAMS, style: 'slotted' },
+  { ...DEFAULT_BIN_PARAMS, lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true } },
+  { ...DEFAULT_BIN_PARAMS, handles: { ...DEFAULT_BIN_PARAMS.handles, enabled: true } },
+  withCellMask([1, 1, 1, 0]),
+  withCellMask([1, 1, 1, 1]),
+  { ...DEFAULT_BIN_PARAMS, wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true } },
+  {
+    ...DEFAULT_BIN_PARAMS,
+    compartments: {
+      ...DEFAULT_BIN_PARAMS.compartments,
+      cols: 3,
+      rows: 2,
+      cells: [0, 1, 2, 3, 4, 5],
+    },
+    label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true },
+  },
+  {
+    ...DEFAULT_BIN_PARAMS,
+    compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 1, rows: 4, cells: [0, 1, 2, 3] },
+    label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, alignment: 'center' },
+  },
+  {
+    ...DEFAULT_BIN_PARAMS,
+    style: 'slotted',
+    walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: true },
+    lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
+    wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true },
+    handles: { ...DEFAULT_BIN_PARAMS.handles, enabled: true },
+    cellMask: { cols: 2, rows: 2, cells: [1, 1, 0, 1] },
+  },
+];
+
+describe('deriveTechniques vs deriveCommunityTechniques (cross-boundary mirror)', () => {
+  it('produces at least 12 fixture variations', () => {
+    expect(FIXTURES.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it.each(FIXTURES.map((params, index) => [index, params] as const))(
+    'fixture %i: client and server derivations agree',
+    (_index, params) => {
+      const clientResult = deriveTechniques(params);
+      const serverResult = deriveCommunityTechniques(params as unknown as Record<string, unknown>);
+      expect(clientResult).toEqual(serverResult);
+    }
+  );
+});

--- a/src/shared/utils/communityTechniques.test.ts
+++ b/src/shared/utils/communityTechniques.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+
+import { deriveTechniques } from './communityTechniques';
+
+describe('deriveTechniques', () => {
+  it('returns no techniques for DEFAULT_BIN_PARAMS', () => {
+    expect(deriveTechniques(DEFAULT_BIN_PARAMS)).toEqual([]);
+  });
+
+  it('tags compartments when cells contain more than one distinct id', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 1, cells: [0, 1] },
+    };
+    expect(deriveTechniques(params)).toEqual(['compartments']);
+  });
+
+  it('does not tag compartments when every cell shares one id, even with cols/rows > 1', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 2, cells: [0, 0, 0, 0] },
+    };
+    expect(deriveTechniques(params)).toEqual([]);
+  });
+
+  it('does not tag wallCutouts from the default per-side left/right enabled trap', () => {
+    // DEFAULT_BIN_PARAMS.walls has enabled: false at the master level but
+    // left/right sub-objects individually enabled: true.
+    expect(DEFAULT_BIN_PARAMS.walls.enabled).toBe(false);
+    expect(DEFAULT_BIN_PARAMS.walls.left.enabled).toBe(true);
+    expect(deriveTechniques(DEFAULT_BIN_PARAMS)).not.toContain('wallCutouts');
+  });
+
+  it('tags wallCutouts when the master walls.enabled flag is true', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: true },
+    };
+    expect(deriveTechniques(params)).toEqual(['wallCutouts']);
+  });
+
+  it('tags scoop when scoop.enabled is true', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true },
+    };
+    expect(deriveTechniques(params)).toEqual(['scoop']);
+  });
+
+  it('tags labelTab when label.enabled is true', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+    };
+    expect(deriveTechniques(params)).toEqual(['labelTab']);
+  });
+
+  it('tags slotted from params.style alone, not slotConfig', () => {
+    // DEFAULT_SLOT_CONFIG ships x.enabled: true even for a standard bin.
+    expect(DEFAULT_BIN_PARAMS.slotConfig.x.enabled).toBe(true);
+    expect(DEFAULT_BIN_PARAMS.style).toBe('standard');
+    expect(deriveTechniques(DEFAULT_BIN_PARAMS)).not.toContain('slotted');
+
+    const params: BinParams = { ...DEFAULT_BIN_PARAMS, style: 'slotted' };
+    expect(deriveTechniques(params)).toEqual(['slotted']);
+  });
+
+  it('tags lid when lid.enabled is true', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
+    };
+    expect(deriveTechniques(params)).toEqual(['lid']);
+  });
+
+  it('does not tag handles from the default per-side front/left/right enabled trap', () => {
+    expect(DEFAULT_BIN_PARAMS.handles.enabled).toBe(false);
+    expect(DEFAULT_BIN_PARAMS.handles.front.enabled).toBe(true);
+    expect(deriveTechniques(DEFAULT_BIN_PARAMS)).not.toContain('handles');
+  });
+
+  it('tags handles when the master handles.enabled flag is true', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      handles: { ...DEFAULT_BIN_PARAMS.handles, enabled: true },
+    };
+    expect(deriveTechniques(params)).toEqual(['handles']);
+  });
+
+  it('tags customShape for a partial cellMask but not an all-filled one', () => {
+    const partial: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 0] },
+    };
+    expect(deriveTechniques(partial)).toEqual(['customShape']);
+
+    const allFilled: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 1] },
+    };
+    expect(deriveTechniques(allFilled)).toEqual([]);
+  });
+
+  it('tags wallPattern when wallPattern.enabled is true', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true },
+    };
+    expect(deriveTechniques(params)).toEqual(['wallPattern']);
+  });
+
+  it('returns multiple techniques in union declaration order when several are active', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      compartments: { ...DEFAULT_BIN_PARAMS.compartments, cols: 2, rows: 1, cells: [0, 1] },
+      label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
+      scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true },
+    };
+    expect(deriveTechniques(params)).toEqual(['compartments', 'scoop', 'labelTab']);
+  });
+});

--- a/src/shared/utils/communityTechniques.ts
+++ b/src/shared/utils/communityTechniques.ts
@@ -1,0 +1,38 @@
+/**
+ * Derive `ExampleTechnique` tags from `BinParams`: auto-tags
+ * community-published designs (curated bin-designer examples stay
+ * hand-authored; see `src/features/bin-designer/types/exampleGallery.ts`).
+ *
+ * MIRROR: `deriveCommunityTechniques` in `api/lib/communityValidation.ts`
+ * duplicates this logic (api/ cannot import from src/) over
+ * sanitized-but-untyped params, after `validateDesignerShare`. Update both
+ * sides together, in the same predicate order; the cross-boundary equality
+ * test in `communityTechniques.crossBoundary.test.ts` guards against drift.
+ *
+ * Every predicate is the exact gate the generation pipeline checks before
+ * building the feature. Two traps: `walls`/`handles` per-side sub-objects ship
+ * `enabled: true` in the defaults, so only the master `enabled` flag is
+ * authoritative; and `slotConfig` is populated even on standard bins, so
+ * `slotted` keys off `style` alone, never `slotConfig`.
+ */
+import { isPartialMask } from '@/shared/utils/cellMask';
+import type { BinParams } from '@/shared/types/bin';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
+
+function getCompartmentCount(compartments: BinParams['compartments']): number {
+  return new Set(compartments.cells).size;
+}
+
+export function deriveTechniques(params: BinParams): ExampleTechnique[] {
+  const techniques: ExampleTechnique[] = [];
+  if (getCompartmentCount(params.compartments) > 1) techniques.push('compartments');
+  if (params.walls.enabled) techniques.push('wallCutouts');
+  if (params.scoop.enabled) techniques.push('scoop');
+  if (params.label.enabled) techniques.push('labelTab');
+  if (params.style === 'slotted') techniques.push('slotted');
+  if (params.lid.enabled) techniques.push('lid');
+  if (params.handles.enabled) techniques.push('handles');
+  if (isPartialMask(params.cellMask)) techniques.push('customShape');
+  if (params.wallPattern.enabled) techniques.push('wallPattern');
+  return techniques;
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -18,5 +18,9 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["scripts/sync-admin/**/*.ts", "scripts/backfill-ml-ttls.ts"]
+  "include": [
+    "scripts/sync-admin/**/*.ts",
+    "scripts/community-admin/**/*.ts",
+    "scripts/backfill-ml-ttls.ts"
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-Mw22/ZAJRshXEvS8/Ol3lQ4fuh9u0CpfYpgBaSMgOsE=' 'sha256-ZFh/jA8g0pm0KqxQsSQwlMZCLY+5rjgk3lzDL9ly2KU='; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io https://fonts.googleapis.com https://fonts.gstatic.com; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-Mw22/ZAJRshXEvS8/Ol3lQ4fuh9u0CpfYpgBaSMgOsE=' 'sha256-ZFh/jA8g0pm0KqxQsSQwlMZCLY+5rjgk3lzDL9ly2KU='; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://*.public.blob.vercel-storage.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io https://fonts.googleapis.com https://fonts.gstatic.com https://*.public.blob.vercel-storage.com; base-uri 'self'; form-action 'self'; object-src 'none'"
         }
       ]
     },


### PR DESCRIPTION
## What

Server-side foundation for the community design showcase (#3050). No user-visible change: every publish/update endpoint returns 503 until the COMMUNITY_PUBLISH_ENABLED environment variable is set, and no UI consumes these endpoints yet.

**New API surface**
- POST /api/community: publish a bin design (sign-in required). Validates params through the existing designer share validation, filters name/description/display name through the content filter, enforces a 25-design quota and a daily publish rate limit, verifies remix lineage against the parent record, derives techniques and metrics server-side, and stores the design JSON, WebP thumbnails, and GLB preview mesh in blob storage with card metadata in Redis. Publishing is idempotent: republishing identical content returns the existing id.
- GET /api/community: paginated card index with sort (newest, remixes, likes), category/technique/author filters, and a mine view that includes the caller's hidden designs.
- GET/PUT/DELETE /api/community/[id]: full record fetch (hidden designs look like not-found to non-owners), owner update in place (revision-stamped assets, moderation status never changed by updates), owner unpublish plus token-gated admin purge.

**Safety properties**
- Ownership is always checked against the caller's server-side published set, never a client-sent id.
- Author identity is exposed only as a salted hash; the internal user id never leaves the server.
- Deny-listed authors cannot publish; responses do not reveal deny-listing.
- Design ids, categories, and statuses are validated against closed unions (registered in the exhaustiveness check).

**Lifecycle integration**
- Account deletion now cascades: published designs, their assets and index entries, the user's likes, and deny-list membership are all removed.
- The signed-in data export now includes published designs.

**Tooling**
- scripts/community-admin: moderation CLI (list, inspect, hide, restore, purge, denylist, feature). Writes directly, unlike the read-only sync-admin; the deviation is documented in its README.
- Technique auto-detection lives in shared code with a server mirror and a cross-boundary equality test so the two cannot drift silently.
- CSP now allows blob-hosted images and meshes; CLAUDE.md documents the new environment variables.

## Tests

203 tests in the new test files covering the API handlers, validation, storage, quota, id derivation, cascade, export, admin CLI, and technique derivation (including a client/server equality fixture set). Full targeted run: 1368 tests green. Typecheck and lint clean.
