### PR TITLE
fix(baseplate): size preview overlays on the Y pitch for non-square grids

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -232,8 +232,10 @@ export function BaseplatePreview({
   // The footprint grid renders in every mode (including stacking) so the scene
   // always reads as "parts on a build plate". In stack mode it's sized to the
   // tower field so the grid reaches under every tower, not just one plate.
+  // Divide each axis by its own pitch so FootprintGrid multiplies it back to the
+  // true field mm — the depth axis must use gridUnitMmY on a non-square grid.
   const gridWidthUnits = stackEnabled && stackBounds ? stackBounds.widthMm / gridUnitMm : width;
-  const gridDepthUnits = stackEnabled && stackBounds ? stackBounds.depthMm / gridUnitMm : depth;
+  const gridDepthUnits = stackEnabled && stackBounds ? stackBounds.depthMm / gridUnitMmY : depth;
 
   // In stack mode the canvas renders StackedBaseplateMeshes instead of
   // BaseplateMesh/SplitBaseplateMeshes. Gate visibility on stackBounds so

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -149,6 +149,7 @@ export function BaseplatePreview({
     width,
     depth,
     gridUnitMm,
+    gridUnitMmY,
     paddingLeft,
     paddingRight,
     paddingFront,
@@ -333,6 +334,7 @@ export function BaseplatePreview({
                   width={width}
                   depth={depth}
                   gridUnitMm={gridUnitMm}
+                  gridUnitMmY={gridUnitMmY}
                   paddingLeft={paddingLeft}
                   paddingRight={paddingRight}
                   paddingFront={paddingFront}
@@ -382,6 +384,7 @@ export function BaseplatePreview({
                   width={gridWidthUnits}
                   depth={gridDepthUnits}
                   gridUnitMm={gridUnitMm}
+                  gridUnitMmY={gridUnitMmY}
                 />
 
                 {/* Remaining single-plate overlays (ghost, dimensions) don't apply
@@ -394,6 +397,7 @@ export function BaseplatePreview({
                         width={width}
                         depth={depth}
                         gridUnitMm={gridUnitMm}
+                        gridUnitMmY={gridUnitMmY}
                         paddingLeft={paddingLeft}
                         paddingRight={paddingRight}
                         paddingFront={paddingFront}
@@ -405,11 +409,17 @@ export function BaseplatePreview({
                     {/* Hide measurement labels in exploded mode -- pieces scatter beyond these positions */}
                     {splitViewMode !== 'exploded' && (
                       <>
-                        <BinAxisLabels width={width} depth={depth} gridUnitMm={gridUnitMm} />
+                        <BinAxisLabels
+                          width={width}
+                          depth={depth}
+                          gridUnitMm={gridUnitMm}
+                          gridUnitMmY={gridUnitMmY}
+                        />
                         <DimensionLabels
                           width={width}
                           depth={depth}
                           gridUnitMm={gridUnitMm}
+                          gridUnitMmY={gridUnitMmY}
                           paddingLeft={paddingLeft}
                           paddingRight={paddingRight}
                           paddingFront={paddingFront}

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.test.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.test.tsx
@@ -95,6 +95,7 @@ function renderController(
       width={overrides.width ?? 5}
       depth={overrides.depth ?? 5}
       gridUnitMm={42}
+      gridUnitMmY={42}
       paddingLeft={0}
       paddingRight={0}
       paddingFront={0}

--- a/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/CameraController.tsx
@@ -37,6 +37,7 @@ export function CameraController({
   width,
   depth,
   gridUnitMm,
+  gridUnitMmY,
   paddingLeft,
   paddingRight,
   paddingFront,
@@ -49,6 +50,7 @@ export function CameraController({
   width: number;
   depth: number;
   gridUnitMm: number;
+  gridUnitMmY: number;
   paddingLeft: number;
   paddingRight: number;
   paddingFront: number;
@@ -88,12 +90,14 @@ export function CameraController({
       paddingFront,
       paddingBack,
       fov,
-      aspect
+      aspect,
+      gridUnitMmY
     );
   }, [
     width,
     depth,
     gridUnitMm,
+    gridUnitMmY,
     paddingLeft,
     paddingRight,
     paddingFront,

--- a/src/features/baseplate/components/BaseplatePreview/DimensionLabels.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/DimensionLabels.tsx
@@ -23,6 +23,7 @@ export function DimensionLabels({
   width,
   depth,
   gridUnitMm,
+  gridUnitMmY,
   paddingLeft,
   paddingRight,
   paddingFront,
@@ -31,16 +32,16 @@ export function DimensionLabels({
   width: number;
   depth: number;
   gridUnitMm: number;
+  gridUnitMmY: number;
   paddingLeft: number;
   paddingRight: number;
   paddingFront: number;
   paddingBack: number;
 }) {
   const colors = useThreeColors();
-  const GS = gridUnitMm;
 
-  const gridW = width * GS;
-  const gridD = depth * GS;
+  const gridW = width * gridUnitMm;
+  const gridD = depth * gridUnitMmY;
   const totalW = gridW + paddingLeft + paddingRight;
   const totalD = gridD + paddingFront + paddingBack;
 

--- a/src/features/baseplate/components/BaseplatePreview/GhostPaddingOutline.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/GhostPaddingOutline.tsx
@@ -25,6 +25,7 @@ interface GhostPaddingOutlineProps {
   readonly width: number;
   readonly depth: number;
   readonly gridUnitMm: number;
+  readonly gridUnitMmY: number;
   readonly paddingLeft: number;
   readonly paddingRight: number;
   readonly paddingFront: number;
@@ -36,6 +37,7 @@ export function GhostPaddingOutline({
   width,
   depth,
   gridUnitMm,
+  gridUnitMmY,
   paddingLeft,
   paddingRight,
   paddingFront,
@@ -50,7 +52,7 @@ export function GhostPaddingOutline({
   const canvasHeight = size.height;
 
   const gridW = width * gridUnitMm;
-  const gridD = depth * gridUnitMm;
+  const gridD = depth * gridUnitMmY;
   const totalH = GRIDFINITY_SPEC.SOCKET_HEIGHT;
 
   // Slab edges: pockets centered at origin, slab offset by padding asymmetry

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.test.ts
@@ -42,6 +42,14 @@ describe('cameraUtils', () => {
       expect(large).toBeGreaterThan(small);
     });
 
+    it('frames the depth axis on the non-square Y pitch', () => {
+      // A tall plate where depth dominates the framing: a larger Y pitch must
+      // push the camera further out, not stay pinned to the square X pitch.
+      const square = calculateIdealDistance(1, 10, 42, 0, 0, 0, 0, 45, 1);
+      const nonSquare = calculateIdealDistance(1, 10, 42, 0, 0, 0, 0, 45, 1, 50);
+      expect(nonSquare).toBeGreaterThan(square);
+    });
+
     it('increases with padding', () => {
       const noPad = calculateIdealDistance(4, 4, 42, 0, 0, 0, 0, 45);
       const withPad = calculateIdealDistance(4, 4, 42, 10, 10, 10, 10, 45);

--- a/src/features/baseplate/components/BaseplatePreview/cameraUtils.ts
+++ b/src/features/baseplate/components/BaseplatePreview/cameraUtils.ts
@@ -44,10 +44,12 @@ export function calculateIdealDistance(
   paddingFront: number,
   paddingBack: number,
   fov: number,
-  aspect = 1
+  aspect = 1,
+  // Depth-axis pitch for a non-square grid; defaults to the square X pitch.
+  gridUnitMmY = gridUnitMm
 ): number {
   const outerW = width * gridUnitMm + paddingLeft + paddingRight;
-  const outerD = depth * gridUnitMm + paddingFront + paddingBack;
+  const outerD = depth * gridUnitMmY + paddingFront + paddingBack;
 
   const halfFovTan = Math.tan((fov / 2) * (Math.PI / 180));
   const dForWidth = outerW / 2 / (halfFovTan * aspect * FRAME_FILL);

--- a/src/features/baseplate/components/BaseplatePreview/useBaseplatePresetTransition.ts
+++ b/src/features/baseplate/components/BaseplatePreview/useBaseplatePresetTransition.ts
@@ -22,6 +22,7 @@ export function useBaseplatePresetTransition(
   width: number,
   depth: number,
   gridUnitMm: number,
+  gridUnitMmY: number,
   paddingLeft: number,
   paddingRight: number,
   paddingFront: number,
@@ -49,7 +50,8 @@ export function useBaseplatePresetTransition(
         paddingFront,
         paddingBack,
         fov,
-        aspect
+        aspect,
+        gridUnitMmY
       );
 
       const direction = new THREE.Vector3(...CAMERA_PRESETS[preset]).normalize();
@@ -106,6 +108,7 @@ export function useBaseplatePresetTransition(
       width,
       depth,
       gridUnitMm,
+      gridUnitMmY,
       paddingLeft,
       paddingRight,
       paddingFront,

--- a/src/shared/components/preview/BinAxisLabels.tsx
+++ b/src/shared/components/preview/BinAxisLabels.tsx
@@ -22,8 +22,10 @@ interface BinAxisLabelsProps {
   width: number;
   /** Bin depth in grid units (can be fractional for half-bin mode) */
   depth: number;
-  /** Grid unit size in mm (defaults to standard 42mm) */
+  /** Grid unit size in mm along X (defaults to standard 42mm) */
   gridUnitMm?: number;
+  /** Depth-axis pitch for a non-square grid; defaults to the X pitch */
+  gridUnitMmY?: number;
 }
 
 // Styling constants matched to planner's AxisLabels proportions
@@ -42,12 +44,13 @@ const FRACTIONAL_LABEL = '+.5'; // Display label for half-unit cells
  * Grid axis labels showing column/row numbers along bin edges.
  * Matches the architectural drawing style of the layout planner.
  */
-export function BinAxisLabels({ width, depth, gridUnitMm }: BinAxisLabelsProps) {
+export function BinAxisLabels({ width, depth, gridUnitMm, gridUnitMmY }: BinAxisLabelsProps) {
   const colors = useThreeColors();
   const GS = gridUnitMm ?? GRIDFINITY.GRID_SIZE;
+  const GSY = gridUnitMmY ?? GS;
 
   const halfW = (width * GS) / 2;
-  const halfD = (depth * GS) / 2;
+  const halfD = (depth * GSY) / 2;
 
   const integerWidth = Math.floor(width);
   const integerDepth = Math.floor(depth);
@@ -89,7 +92,7 @@ export function BinAxisLabels({ width, depth, gridUnitMm }: BinAxisLabelsProps) 
 
     // Y-axis ticks along the left edge — outward only (matching planner)
     for (let i = 0; i <= integerDepth; i++) {
-      const y = -halfD + i * GS;
+      const y = -halfD + i * GSY;
       positions.push(-halfW, y, TICK_OFFSET);
       positions.push(-halfW - TICK_SIZE, y, TICK_OFFSET);
     }
@@ -101,7 +104,7 @@ export function BinAxisLabels({ width, depth, gridUnitMm }: BinAxisLabelsProps) 
     const geo = new THREE.BufferGeometry();
     geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
     return geo;
-  }, [halfW, halfD, integerWidth, integerDepth, hasFractionalWidth, hasFractionalDepth, GS]);
+  }, [halfW, halfD, integerWidth, integerDepth, hasFractionalWidth, hasFractionalDepth, GS, GSY]);
 
   // Cleanup geometry on unmount or change
   useEffect(() => {
@@ -145,8 +148,8 @@ export function BinAxisLabels({ width, depth, gridUnitMm }: BinAxisLabelsProps) 
       {yLabels.map(({ value, isFractional }, idx) => {
         // Center label in its grid cell
         const yPos = isFractional
-          ? -halfD + (integerDepth + (depth - integerDepth) / 2) * GS
-          : -halfD + (value - 0.5) * GS;
+          ? -halfD + (integerDepth + (depth - integerDepth) / 2) * GSY
+          : -halfD + (value - 0.5) * GSY;
         const xPos = -halfW - LABEL_OFFSET;
         const label = isFractional ? FRACTIONAL_LABEL : value.toString();
 

--- a/src/shared/components/preview/FootprintGrid.tsx
+++ b/src/shared/components/preview/FootprintGrid.tsx
@@ -16,8 +16,10 @@ interface FootprintGridProps {
   width: number;
   /** Bin depth in grid units */
   depth: number;
-  /** Grid unit size in mm (defaults to standard 42mm) */
+  /** Grid unit size in mm along X (defaults to standard 42mm) */
   gridUnitMm?: number;
+  /** Depth-axis pitch for a non-square grid; defaults to the X pitch */
+  gridUnitMmY?: number;
 }
 
 /** How many grid units the floor extends beyond the bin footprint */
@@ -35,7 +37,7 @@ const gridVertexShader = /* glsl */ `
 `;
 
 const gridFragmentShader = /* glsl */ `
-  uniform float gridSize;
+  uniform vec2 gridSize;
   uniform vec2 gridOffset;
   uniform float fadeStart;
   uniform float fadeEnd;
@@ -70,28 +72,32 @@ const gridFragmentShader = /* glsl */ `
  * the bin's cell boundaries, so the bin appears correctly placed on
  * the grid cells it occupies.
  */
-export function FootprintGrid({ width, depth, gridUnitMm }: FootprintGridProps) {
+export function FootprintGrid({ width, depth, gridUnitMm, gridUnitMmY }: FootprintGridProps) {
   const colors = useThreeColors();
   const GS = gridUnitMm ?? GRIDFINITY.GRID_SIZE;
+  const GSY = gridUnitMmY ?? GS;
+  // Floor size + radial fade are isotropic; size them off the larger pitch so a
+  // non-square grid never fades before its own edge.
+  const maxGS = Math.max(GS, GSY);
   // Floor size: extends well beyond the bin for the "infinite" illusion
   const maxDim = Math.max(width, depth);
-  const floorSize = Math.max((maxDim + GRID_EXTENT * 2) * GS, GS * MIN_FLOOR_GRID_UNITS);
+  const floorSize = Math.max((maxDim + GRID_EXTENT * 2) * maxGS, maxGS * MIN_FLOOR_GRID_UNITS);
 
   // Grid offset: shift the grid pattern so lines align with the bin's cell boundaries
   // The bin is centered at origin, so offset by half the nominal width/depth
   const offsetX = (width * GS) / 2;
-  const offsetY = (depth * GS) / 2;
+  const offsetY = (depth * GSY) / 2;
 
   // Fade distances: grid stays crisp near the bin, fades out toward edges
-  const fadeStart = (maxDim / 2 + 4) * GS;
-  const fadeEnd = (maxDim / 2 + GRID_EXTENT) * GS;
+  const fadeStart = (maxDim / 2 + 4) * maxGS;
+  const fadeEnd = (maxDim / 2 + GRID_EXTENT) * maxGS;
 
   const material = useMemo(() => {
     return new THREE.ShaderMaterial({
       vertexShader: gridVertexShader,
       fragmentShader: gridFragmentShader,
       uniforms: {
-        gridSize: { value: GS },
+        gridSize: { value: new THREE.Vector2(GS, GSY) },
         gridOffset: { value: new THREE.Vector2(offsetX, offsetY) },
         fadeStart: { value: fadeStart },
         fadeEnd: { value: fadeEnd },
@@ -102,7 +108,7 @@ export function FootprintGrid({ width, depth, gridUnitMm }: FootprintGridProps) 
       transparent: true,
       depthWrite: false,
     });
-  }, [GS, offsetX, offsetY, fadeStart, fadeEnd, colors.footprintLine]);
+  }, [GS, GSY, offsetX, offsetY, fadeStart, fadeEnd, colors.footprintLine]);
 
   // Dispose shader material on unmount/change
   useEffect(() => {


### PR DESCRIPTION
## Summary

Follow-up to #3089. That PR fixed the split-piece *meshes* to collapse on the Y pitch (`gridUnitMmY`), but the baseplate preview **overlays** still sized the depth axis on the X pitch (`gridUnitMm`). On a non-square grid (`gridUnitMmY !== gridUnitMm`) that left them visibly off:

- **DimensionLabels** — depth label showed the wrong mm (and the leader line was mis-sized).
- **GhostPaddingOutline** — the regenerating ghost box was the wrong depth.
- **FootprintGrid** — drew square cells on a rectangular grid.
- **BinAxisLabels** — row ticks/labels were mis-spaced along the depth axis.
- **CameraController** / preset transitions — framing distance computed with the wrong depth extent.

## Change

Thread `gridUnitMmY` through `BaseplatePreview` to all five overlays (the prop was already in `BaseplatePreview` scope from #3089), plus `calculateIdealDistance` and the preset-transition hook. Each now uses `gridUnitMm` for width and `gridUnitMmY` for depth.

The two **shared** components (`FootprintGrid`, `BinAxisLabels`, used by the bin designer too) take an **optional** `gridUnitMmY` that defaults to the X pitch, so every other consumer renders byte-identically. `FootprintGrid`'s grid-pitch shader uniform becomes a `vec2` (component-wise division is identical for a square grid).

Square grids (the default) are unaffected everywhere.

## Test plan

- [x] `pnpm run typecheck` (covers all sibling test files)
- [x] `src/features/baseplate/components/BaseplatePreview` + `src/shared/components/preview` — 83 passed
- [x] New `calculateIdealDistance` non-square case: a taller Y pitch pushes the camera further out on a depth-dominated plate
- [ ] Manual: non-square grid (e.g. 42×50), confirm dimension label, ghost outline, footprint grid, and axis ticks all match the plate

## Not included (minor, separate)

Library **thumbnails** frame via a separate param chain that only carries `gridUnitMm`; since `calculateIdealDistance`'s new arg is optional they stay square-default (a slightly-off framing + square floor grid in the small static image). The bin designer's own preview has the same latent non-square gap in its local overlays — also out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-square baseplate preview overlays by sizing the depth axis on the Y pitch. Labels, outlines, grid (including stack mode), and camera framing now match the actual Y pitch; square grids are unchanged.

- **Bug Fixes**
  - Passed `gridUnitMmY` through `BaseplatePreview` to all overlays and camera utilities; width uses `gridUnitMm`, depth uses `gridUnitMmY` (including stack mode).
  - `FootprintGrid` and `BinAxisLabels` accept optional `gridUnitMmY` (default X); grid shader `gridSize` is a `vec2`.
  - Updated `calculateIdealDistance` and preset transitions to frame on the Y pitch; added a non-square test.

<sup>Written for commit 84dfd4ce89dab8d4b9284be5ce3cf5089dda6c87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

