### PR TITLE
fix(baseplate): frame library thumbnails on the Y pitch for non-square grids

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateAutoSave.ts
+++ b/src/features/baseplate/hooks/useBaseplateAutoSave.ts
@@ -63,6 +63,7 @@ function resolveThumbnailFraming(stored: StoredBaseplateParams): BaseplateThumbn
     width: full.width,
     depth: full.depth,
     gridUnitMm: full.gridUnitMm,
+    gridUnitMmY: full.gridUnitMmY ?? full.gridUnitMm,
     paddingLeft: full.paddingLeft,
     paddingRight: full.paddingRight,
     paddingFront: full.paddingFront,

--- a/src/features/baseplate/utils/thumbnail.test.ts
+++ b/src/features/baseplate/utils/thumbnail.test.ts
@@ -9,6 +9,15 @@ import {
   clearPreviewCanvas,
   type BaseplateThumbnailFraming,
 } from './thumbnail';
+import { calculateIdealDistance } from '../components/BaseplatePreview/cameraUtils';
+import type * as CameraUtils from '../components/BaseplatePreview/cameraUtils';
+
+// Spy on the framing math so a test can assert the Y pitch actually reaches it
+// (an omitted/reordered gridUnitMmY would otherwise silently re-square the depth).
+vi.mock('../components/BaseplatePreview/cameraUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof CameraUtils>();
+  return { ...actual, calculateIdealDistance: vi.fn(actual.calculateIdealDistance) };
+});
 
 const FRAMING: BaseplateThumbnailFraming = {
   width: 4,
@@ -106,6 +115,22 @@ describe('captureBaseplateThumbnailAtPreset', () => {
 
   it('returns null when nothing is registered at all', () => {
     expect(captureBaseplateThumbnailAtPreset(FRAMING)).toBeNull();
+  });
+
+  it('frames the capture on the non-square Y pitch', () => {
+    const renderer = { render: vi.fn() } as unknown as WebGLRenderer;
+    const scene = new Scene();
+    const camera = new PerspectiveCamera(45, 1, 0.1, 20_000);
+    setPreviewCanvas(mockCanvas);
+    setPreviewContext(renderer, scene, camera);
+
+    const calc = vi.mocked(calculateIdealDistance);
+    calc.mockClear();
+    captureBaseplateThumbnailAtPreset({ ...FRAMING, gridUnitMmY: 60 });
+
+    expect(calc).toHaveBeenCalledTimes(1);
+    // Signature: (…paddings, fov, aspect, gridUnitMmY) — the Y pitch is arg 10.
+    expect(calc.mock.calls[0][9]).toBe(60);
   });
 
   it('renders one preset frame, captures, then restores the original camera pose', () => {

--- a/src/features/baseplate/utils/thumbnail.test.ts
+++ b/src/features/baseplate/utils/thumbnail.test.ts
@@ -14,6 +14,7 @@ const FRAMING: BaseplateThumbnailFraming = {
   width: 4,
   depth: 4,
   gridUnitMm: 42,
+  gridUnitMmY: 42,
   paddingLeft: 0,
   paddingRight: 0,
   paddingFront: 0,

--- a/src/features/baseplate/utils/thumbnail.ts
+++ b/src/features/baseplate/utils/thumbnail.ts
@@ -113,6 +113,8 @@ export interface BaseplateThumbnailFraming {
   readonly width: number;
   readonly depth: number;
   readonly gridUnitMm: number;
+  /** Depth-axis pitch for a non-square grid; defaults to the X pitch. */
+  readonly gridUnitMmY: number;
   readonly paddingLeft: number;
   readonly paddingRight: number;
   readonly paddingFront: number;
@@ -148,8 +150,16 @@ export function captureBaseplateThumbnailAtPreset(
   const hidden: { visible: boolean }[] = [];
 
   try {
-    const { width, depth, gridUnitMm, paddingLeft, paddingRight, paddingFront, paddingBack } =
-      framing;
+    const {
+      width,
+      depth,
+      gridUnitMm,
+      gridUnitMmY,
+      paddingLeft,
+      paddingRight,
+      paddingFront,
+      paddingBack,
+    } = framing;
     // The plate is thin and centered on the origin (pockets align to the
     // FootprintGrid), so framing on (0,0,0) is exact enough for a thumbnail.
     const center = new Vector3(0, 0, 0);
@@ -163,7 +173,9 @@ export function captureBaseplateThumbnailAtPreset(
       paddingRight,
       paddingFront,
       paddingBack,
-      camera.fov
+      camera.fov,
+      1,
+      gridUnitMmY
     );
 
     camera.position.copy(


### PR DESCRIPTION
## Summary

Small follow-up to the non-square overlay fix (#3102). The **library thumbnail** framing chain carried only `gridUnitMm`, so `calculateIdealDistance` sized the plate's depth extent on the X pitch — a non-square baseplate (e.g. 42×50) was framed slightly wrong in its saved thumbnail.

The thumbnail captures the *live* `BaseplatePreview` scene (whose overlays already thread `gridUnitMmY` from #3102), so the only depth-sizing left in the thumbnail module was that framing distance.

## Change

- Add `gridUnitMmY` to `BaseplateThumbnailFraming`.
- Pass it into `calculateIdealDistance` (with an explicit `aspect = 1`, since the pitch is the 10th positional arg). The function already applies `gridUnitMmY` to the depth extent.
- Populate it at the sole caller (`resolveThumbnailFraming` in `useBaseplateAutoSave`), which already resolves the layout's Y pitch via `effectiveGridUnitMmY`.

## Test plan

- [x] `pnpm run typecheck`
- [x] `thumbnail.test.ts` (9 passed; fixture updated with `gridUnitMmY`)

Square grids unchanged. The bin designer's own thumbnail already threads its Y pitch (`ln`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix thumbnail framing for non-square baseplates. Thumbnails now use the Y pitch to size depth correctly, so plates like 42×50 are framed accurately.

- **Bug Fixes**
  - Added `gridUnitMmY` to `BaseplateThumbnailFraming` and passed it to `calculateIdealDistance` with `aspect = 1`.
  - Populated `gridUnitMmY` in `resolveThumbnailFraming` using `effectiveGridUnitMmY`.
  - Added a test that spies on `calculateIdealDistance` and asserts `gridUnitMmY` is passed (arg 10) to prevent regressions.

<sup>Written for commit 49cb9bc621fefb0b493bec8a09871e9794176c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

