### PR TITLE
fix(bin-designer): thread the Y pitch into axis labels and preset framing

### DIFF
--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -259,7 +259,8 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
     params.depth,
     params.height,
     params.gridUnitMm,
-    params.heightUnitMm
+    params.heightUnitMm,
+    params.gridUnitMmY
   );
 
   const setCameraPreset = useCallback(
@@ -491,7 +492,12 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
               {/* Dimension markers and labels — hidden for split pieces */}
               {!hideChrome && !showSplitPieces && (
                 <>
-                  <BinAxisLabels width={width} depth={depth} gridUnitMm={params.gridUnitMm} />
+                  <BinAxisLabels
+                    width={width}
+                    depth={depth}
+                    gridUnitMm={params.gridUnitMm}
+                    gridUnitMmY={params.gridUnitMmY}
+                  />
                   {isBinKind && (
                     <>
                       <AssembledBinDimensions

--- a/src/features/bin-designer/components/PreviewCanvas/previewCanvasCamera.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/previewCanvasCamera.tsx
@@ -280,7 +280,8 @@ export function usePresetTransition(
   depth: number,
   height: number,
   gridUnitMm: number,
-  heightUnitMm: number
+  heightUnitMm: number,
+  gridUnitMmY?: number
 ) {
   const animFrameRef = useRef<number | null>(null);
 
@@ -298,7 +299,8 @@ export function usePresetTransition(
         height,
         fov,
         gridUnitMm,
-        heightUnitMm
+        heightUnitMm,
+        gridUnitMmY
       );
 
       // Calculate target position from preset direction
@@ -351,7 +353,7 @@ export function usePresetTransition(
 
       animate();
     },
-    [controlsRef, invalidateRef, width, depth, height, gridUnitMm, heightUnitMm]
+    [controlsRef, invalidateRef, width, depth, height, gridUnitMm, heightUnitMm, gridUnitMmY]
   );
 
   // Cleanup on unmount

--- a/src/features/bin-designer/utils/cameraFraming.test.ts
+++ b/src/features/bin-designer/utils/cameraFraming.test.ts
@@ -68,6 +68,14 @@ describe('cameraFraming', () => {
       expect(tall).toBeGreaterThan(short);
     });
 
+    it('frames the depth axis on the non-square Y pitch', () => {
+      // Depth-dominated bin: a larger Y pitch must push the camera out, not stay
+      // pinned to the square X pitch.
+      const square = calculateIdealDistance(1, 8, 3, 50, 42, 7);
+      const nonSquare = calculateIdealDistance(1, 8, 3, 50, 42, 7, 60);
+      expect(nonSquare).toBeGreaterThan(square);
+    });
+
     it('produces larger distance for smaller FOV (zoom effect)', () => {
       const wideFov = calculateIdealDistance(1, 1, 3, 75);
       const narrowFov = calculateIdealDistance(1, 1, 3, 30);

--- a/src/features/bin-designer/utils/cameraFraming.test.ts
+++ b/src/features/bin-designer/utils/cameraFraming.test.ts
@@ -71,8 +71,23 @@ describe('cameraFraming', () => {
     it('frames the depth axis on the non-square Y pitch', () => {
       // Depth-dominated bin: a larger Y pitch must push the camera out, not stay
       // pinned to the square X pitch.
-      const square = calculateIdealDistance(1, 8, 3, 50, 42, 7);
-      const nonSquare = calculateIdealDistance(1, 8, 3, 50, 42, 7, 60);
+      const square = calculateIdealDistance(
+        1,
+        8,
+        3,
+        50,
+        GRIDFINITY.GRID_SIZE,
+        GRIDFINITY.HEIGHT_UNIT
+      );
+      const nonSquare = calculateIdealDistance(
+        1,
+        8,
+        3,
+        50,
+        GRIDFINITY.GRID_SIZE,
+        GRIDFINITY.HEIGHT_UNIT,
+        GRIDFINITY.GRID_SIZE + 18
+      );
       expect(nonSquare).toBeGreaterThan(square);
     });
 


### PR DESCRIPTION
## Summary

Companion to the baseplate non-square work. The bin designer preview is already non-square-aware almost everywhere (`params.ln` / `gridUnitMmY` is threaded through the ghost overlays, `BinDimensions`, `SplitBinMeshes`, `OverhangHighlight`, its own `FootprintGrid`, the auto-frame `CameraController`, and the thumbnail path). Two sites still sized the **depth** axis on the X pitch:

1. **`BinAxisLabels`** — rendered in `PreviewCanvas` without `gridUnitMmY`, so the row ticks/labels along the depth edge were mis-spaced on a non-square grid. (The rendered component is the shared `@/shared/components/preview/BinAxisLabels`, which already supports `gridUnitMmY`; only the render site omitted it.)
2. **`usePresetTransition`** — the front/side/top/isometric preset-button framing called `calculateIdealDistance` without the Y pitch, so presets framed with square depth. (The sibling auto-frame hook in the same file already threads it.)

## Change

- Pass `params.gridUnitMmY` to `<BinAxisLabels>` in `PreviewCanvas`.
- Add an optional `gridUnitMmY` param to `usePresetTransition`, forward it to `calculateIdealDistance` (which already applies it to the depth extent), and thread `params.gridUnitMmY` at the call site.

## Test plan

- [x] `pnpm run typecheck`
- [x] `PreviewCanvas` suites + `cameraFraming.test.ts` — 51 + 21 passed (added a non-square `calculateIdealDistance` case: a taller Y pitch pushes a depth-dominated bin's camera further out)

Square grids unchanged. Verified the bin designer thumbnail/regenerator already thread the Y pitch — no change needed there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-square grid support in the bin designer preview by threading the Y pitch into axis labels and preset camera framing. Depth ticks/labels and preset views now respect the non-square Y pitch.

- **Bug Fixes**
  - Pass `params.gridUnitMmY` to `BinAxisLabels` in `PreviewCanvas` to fix mis-spaced depth ticks/labels.
  - Thread `gridUnitMmY` through `usePresetTransition` to `calculateIdealDistance` so preset framing uses the Y pitch; test updated to use `GRIDFINITY.GRID_SIZE`/`GRIDFINITY.HEIGHT_UNIT` and verify larger Y pitch increases distance.

<sup>Written for commit 560396ededf7f2374eb8df03c5ba7f34f8f62a71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

