### PR TITLE
fix(layout-editor): render and preserve oversize custom perimeters (#3107, #3114)

### DIFF
--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
@@ -106,6 +106,51 @@ describe('DrawerOutlineOverlay', () => {
     expect(paths[2].getAttribute('stroke-dasharray')).toBe('4 3');
   });
 
+  it('frames the padding rim of an oversize outline so it is not clipped (#3107)', () => {
+    // Right/back-heavy padding pushes the rim past the raw outline's bbox; the
+    // viewport must include the rim, not just the shape.
+    const OVERSIZE: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 7 * U, y: 0 },
+        { x: 7 * U, y: 2 * U },
+        { x: 4 * U, y: 2 * U },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    useLayoutStore.setState((s) => ({
+      layout: {
+        ...s.layout,
+        drawer: { ...s.layout.drawer, width: gridUnits(6), depth: gridUnits(4), outline: OVERSIZE },
+        baseplateParams: {
+          ...s.layout.baseplateParams,
+          paddingLeft: 4,
+          paddingRight: 24,
+          paddingFront: 4,
+          paddingBack: 24,
+        },
+      },
+    }));
+    const { container } = renderOverlay();
+    const svg = screen.getByRole('img');
+    const svgW = Number(svg.getAttribute('width'));
+    const svgH = Number(svg.getAttribute('height'));
+    // Every drawn vertex (rim, plate boundary, shape) must sit inside the SVG —
+    // the outside hatch (path 0) uses H/V commands, so skip it.
+    const drawn = [...container.querySelectorAll('path')].slice(1);
+    expect(drawn.length).toBeGreaterThan(0);
+    for (const path of drawn) {
+      const nums = (path.getAttribute('d') ?? '').match(/-?\d+(?:\.\d+)?/g) ?? [];
+      for (let i = 0; i + 1 < nums.length; i += 2) {
+        expect(Number(nums[i])).toBeGreaterThanOrEqual(-0.05);
+        expect(Number(nums[i])).toBeLessThanOrEqual(svgW + 0.05);
+        expect(Number(nums[i + 1])).toBeGreaterThanOrEqual(-0.05);
+        expect(Number(nums[i + 1])).toBeLessThanOrEqual(svgH + 0.05);
+      }
+    }
+  });
+
   it('omits the rim when padding would fold the shape (dropped by the resolver)', () => {
     // A one-unit-wide top slot; 30+30mm L/R padding crosses its walls.
     const SLOT: DrawerOutline = {

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
@@ -37,6 +37,31 @@ describe('DrawerOutlineOverlay', () => {
     expect(screen.queryByRole('img')).toBeNull();
   });
 
+  it('grows the SVG viewport to hold an outline reaching past the grid (#3107)', () => {
+    // The perimeter's right edge sits at 7u in a 6-wide drawer. The viewport
+    // must widen to it (default 42mm pitch → 42px/unit) rather than clip it.
+    const OVERSIZE: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 7 * U, y: 0 },
+        { x: 7 * U, y: 2 * U },
+        { x: 4 * U, y: 2 * U },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    useLayoutStore.setState((s) => ({
+      layout: {
+        ...s.layout,
+        drawer: { ...s.layout.drawer, width: gridUnits(6), depth: gridUnits(4), outline: OVERSIZE },
+      },
+    }));
+    renderOverlay();
+    const svg = screen.getByRole('img');
+    // gap 2, cell 40 → 42px/unit; the 6-unit grid is ~250px but the shape needs 7u.
+    expect(Number(svg.getAttribute('width'))).toBeCloseTo(7 * (40 + 2), 0);
+  });
+
   it('renders the hatch and boundary for a shaped drawer', () => {
     useLayoutStore.setState((s) => ({
       layout: {

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.tsx
@@ -6,6 +6,7 @@ import { effectiveGridUnitMmY } from '@/core/types';
 import { useTranslation } from '@/i18n';
 import { flattenOutline } from '@/shared/utils/drawerOutlineGeometry';
 import { padOutline } from '@/shared/utils/padOutline';
+import { computeOverlayViewport } from './overlayViewport';
 
 interface DrawerOutlineOverlayProps {
   cellSize: number;
@@ -17,8 +18,9 @@ interface DrawerOutlineOverlayProps {
  * region outside the outline, strokes the boundary, and — when the baseplate
  * carries per-side padding — draws the drawer-fit rim the plate gains around
  * the shape (#2705), the shaped counterpart of the rectangular {@link
- * DrawerMargin} band. One SVG, sized to the padded extent so the rim can
- * overhang the grid; even-odd paths keep a 50×50 grid as cheap as a 2×2.
+ * DrawerMargin} band. One SVG, sized to the union of the padded extent and the
+ * outline's own bbox so a rim overhang OR an oversize/off-grid perimeter (#3107)
+ * stays un-clipped; even-odd paths keep a 50×50 grid as cheap as a 2×2.
  *
  * Purely visual and `pointer-events: none`: placement truth lives in
  * `canPlaceBin` (same geometry predicate), so a hatched cell is exactly a
@@ -87,15 +89,49 @@ export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProp
     const padT = showRim ? backPx : 0;
     const padB = showRim ? frontPx : 0;
 
-    const svgW = gridW + padL + padR;
-    const svgH = gridD + padT + padB;
+    // The shape sits at the grid's inset only when the rim is drawn; otherwise
+    // it maps straight onto the grid extent (no canvas extension).
+    const shapeTx = showRim ? paddingLeft : 0;
+    const shapeTy = showRim ? paddingFront : 0;
 
-    // Everything is mapped in PLATE-local mm (origin at the padded plate's
-    // bottom-left), so the padded outline maps directly and the drawer-local
-    // shape is shifted in by (left, front) to sit at the grid's inset position.
-    // With no padding this collapses to the plain drawer-local mapping.
-    const gx = (mm: number): number => (mm / gridUnitMm) * unitPx;
-    const gy = (mm: number): number => svgH - (mm / gridUnitMmY) * unitPxY;
+    // Plate-local mm → px, kept separate from gx/gy so the frame and the drawn
+    // loops share one factor per axis. Origin at the padded plate's bottom-left.
+    const toPxX = (mm: number): number => (mm / gridUnitMm) * unitPx;
+    const toPxY = (mm: number): number => (mm / gridUnitMmY) * unitPxY;
+
+    // Frame the SVG to the union of the padded plate and the shape's flattened
+    // bbox (arcs expanded), so an oversize/off-edge perimeter is not clipped by
+    // the SVG's overflow (#3107). With an in-bounds shape the union is the plate.
+    const flat = flattenOutline(outline);
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (const p of flat) {
+      minX = Math.min(minX, p.x);
+      maxX = Math.max(maxX, p.x);
+      minY = Math.min(minY, p.y);
+      maxY = Math.max(maxY, p.y);
+    }
+    const { svgW, svgH, offsetX, offsetY, originX, originY } = computeOverlayViewport(
+      gridW + padL + padR,
+      gridD + padT + padB,
+      padL,
+      padT,
+      {
+        minX: toPxX(minX + shapeTx),
+        maxX: toPxX(maxX + shapeTx),
+        minY: toPxY(minY + shapeTy),
+        maxY: toPxY(maxY + shapeTy),
+      }
+    );
+
+    // Padded outline maps directly; the drawer-local shape is shifted in by
+    // (left, front) to sit at the grid's inset. originX/originY (≤ 0) shift the
+    // mapping so a shape reaching past the plate origin stays on-canvas — both
+    // are 0 for an in-bounds shape, collapsing to the plain plate-local map.
+    const gx = (mm: number): number => toPxX(mm) - originX;
+    const gy = (mm: number): number => svgH - (toPxY(mm) - originY);
     const loopFrom = (pts: readonly { x: number; y: number }[], tx = 0, ty = 0): string =>
       pts
         .map(
@@ -103,11 +139,7 @@ export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProp
         )
         .join(' ') + ' Z';
 
-    // The shape sits at the grid's inset only when the rim is drawn; otherwise
-    // it maps straight onto the grid extent (no canvas extension).
-    const shapeTx = showRim ? paddingLeft : 0;
-    const shapeTy = showRim ? paddingFront : 0;
-    const shapeLoop = loopFrom(flattenOutline(outline), shapeTx, shapeTy);
+    const shapeLoop = loopFrom(flat, shapeTx, shapeTy);
     const plateLoop = paddedOutline !== null ? loopFrom(flattenOutline(paddedOutline)) : null;
 
     // Hatch outside the plate (or the shape when there's no rim) — never the rim
@@ -117,7 +149,7 @@ export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProp
     const rim = plateLoop !== null ? `${plateLoop} ${shapeLoop}` : null;
     const plateBoundary = plateLoop;
 
-    return { svgW, svgH, offsetX: -padL, offsetY: -padT, outside, shapeLoop, rim, plateBoundary };
+    return { svgW, svgH, offsetX, offsetY, outside, shapeLoop, rim, plateBoundary };
   }, [
     outline,
     paddingLeft,

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.tsx
@@ -99,15 +99,29 @@ export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProp
     const toPxX = (mm: number): number => (mm / gridUnitMm) * unitPx;
     const toPxY = (mm: number): number => (mm / gridUnitMmY) * unitPxY;
 
-    // Frame the SVG to the union of the padded plate and the shape's flattened
-    // bbox (arcs expanded), so an oversize/off-edge perimeter is not clipped by
-    // the SVG's overflow (#3107). With an in-bounds shape the union is the plate.
+    // Frame the SVG to the union of the padded plate and everything drawn (arcs
+    // expanded), so an oversize/off-edge perimeter — or a rim overhang beyond it
+    // — is not clipped by the SVG's overflow (#3107). The rim (`plateLoop`) is
+    // drawn from `paddedOutline`, which reaches past the raw outline's bbox by
+    // the padding, so it must be part of the frame too. With an in-bounds shape
+    // and no rim the union is just the plate.
     const flat = flattenOutline(outline);
+    // Same (x, y) → px each loop is drawn with below: the shape is inset by
+    // (shapeTx, shapeTy); the padded rim maps directly.
+    const framePts: { x: number; y: number }[] = flat.map((p) => ({
+      x: toPxX(p.x + shapeTx),
+      y: toPxY(p.y + shapeTy),
+    }));
+    if (paddedOutline !== null) {
+      for (const p of flattenOutline(paddedOutline)) {
+        framePts.push({ x: toPxX(p.x), y: toPxY(p.y) });
+      }
+    }
     let minX = Infinity;
     let maxX = -Infinity;
     let minY = Infinity;
     let maxY = -Infinity;
-    for (const p of flat) {
+    for (const p of framePts) {
       minX = Math.min(minX, p.x);
       maxX = Math.max(maxX, p.x);
       minY = Math.min(minY, p.y);
@@ -118,12 +132,7 @@ export function DrawerOutlineOverlay({ cellSize, gap }: DrawerOutlineOverlayProp
       gridD + padT + padB,
       padL,
       padT,
-      {
-        minX: toPxX(minX + shapeTx),
-        maxX: toPxX(maxX + shapeTx),
-        minY: toPxY(minY + shapeTy),
-        maxY: toPxY(maxY + shapeTy),
-      }
+      { minX, maxX, minY, maxY }
     );
 
     // Padded outline maps directly; the drawer-local shape is shifted in by

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/overlayViewport.test.ts
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/overlayViewport.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeOverlayViewport } from './overlayViewport';
+
+describe('computeOverlayViewport', () => {
+  it('frames to the plate when the shape sits inside it', () => {
+    const vp = computeOverlayViewport(100, 80, 0, 0, {
+      minX: 10,
+      maxX: 90,
+      minY: 5,
+      maxY: 70,
+    });
+    expect(vp).toEqual({
+      svgW: 100,
+      svgH: 80,
+      offsetX: 0,
+      offsetY: 0,
+      originX: 0,
+      originY: 0,
+    });
+  });
+
+  it('keeps the padding offset (and no origin shift) for an in-bounds shape with padding', () => {
+    const vp = computeOverlayViewport(120, 100, 10, 8, {
+      minX: 10,
+      maxX: 110,
+      minY: 5,
+      maxY: 95,
+    });
+    expect(vp).toMatchObject({ svgW: 120, svgH: 100, offsetX: -10, offsetY: -8 });
+    expect(vp.originX).toBe(0);
+    expect(vp.originY).toBe(0);
+  });
+
+  it('grows right and up when the shape overflows the plate (#3107)', () => {
+    const vp = computeOverlayViewport(100, 80, 0, 0, {
+      minX: 10,
+      maxX: 120,
+      minY: 5,
+      maxY: 95,
+    });
+    // Right overflow widens the canvas; top overflow lifts the SVG so it stays
+    // visible (offsetY drops by the 15px overrun).
+    expect(vp.svgW).toBe(120);
+    expect(vp.svgH).toBe(95);
+    expect(vp.offsetX).toBe(0);
+    expect(vp.offsetY).toBe(-15);
+    expect(vp.originX).toBe(0);
+    expect(vp.originY).toBe(0);
+  });
+
+  it('shifts the origin left/down when the shape reaches past the plate origin', () => {
+    const vp = computeOverlayViewport(100, 80, 0, 0, {
+      minX: -20,
+      maxX: 90,
+      minY: -10,
+      maxY: 70,
+    });
+    // Left overflow moves the SVG out (offsetX) and negatives the origin so the
+    // mm→px mapping shifts to keep the far side on-canvas.
+    expect(vp.svgW).toBe(120);
+    expect(vp.svgH).toBe(90);
+    expect(vp.offsetX).toBe(-20);
+    expect(vp.offsetY).toBe(0);
+    expect(vp.originX).toBe(-20);
+    expect(vp.originY).toBe(-10);
+  });
+});

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/overlayViewport.ts
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/overlayViewport.ts
@@ -1,0 +1,58 @@
+/**
+ * Frame the drawer-outline overlay's SVG to the UNION of the padded plate and
+ * the shape's flattened bbox (#3107). A custom perimeter may now reach past the
+ * grid extent (or sit offset within it); framing to the plate alone clips
+ * whatever the shape draws beyond it, since the SVG's own `overflow: hidden`
+ * hard-crops the canvas. Mirrors the pen editor's grid∪sketch frame.
+ *
+ * All values are px in the plate-local frame (origin at the padded plate's
+ * bottom-left, y-up). A shape reaching left of / below that origin yields a
+ * negative `originX`/`originY`; the caller shifts its mm→px mapping by them so
+ * the far side stays on-canvas without moving the grid.
+ */
+
+export interface OverlayShapeBoundsPx {
+  readonly minX: number;
+  readonly maxX: number;
+  /** y-up: `minY` is the bottom edge, `maxY` the top. */
+  readonly minY: number;
+  readonly maxY: number;
+}
+
+export interface OverlayViewport {
+  readonly svgW: number;
+  readonly svgH: number;
+  /** Container offsets: the SVG sits at `left = gap + offsetX`, `top = gap + offsetY`. */
+  readonly offsetX: number;
+  readonly offsetY: number;
+  /** Subtract from the raw mm→px x so an off-origin shape stays on-canvas (≤ 0). */
+  readonly originX: number;
+  /** Undo inside the flipped mm→px y for the same reason (≤ 0). */
+  readonly originY: number;
+}
+
+/**
+ * `plateW`/`plateH` are the padded plate's px extent; `padL`/`padT` are the
+ * left/top padding (px) already folded into that extent. `shape` is the
+ * flattened outline bbox in the same plate-local px frame.
+ */
+export function computeOverlayViewport(
+  plateW: number,
+  plateH: number,
+  padL: number,
+  padT: number,
+  shape: OverlayShapeBoundsPx
+): OverlayViewport {
+  const xMin = Math.min(0, shape.minX);
+  const xMax = Math.max(plateW, shape.maxX);
+  const yMin = Math.min(0, shape.minY);
+  const yMax = Math.max(plateH, shape.maxY);
+  return {
+    svgW: xMax - xMin,
+    svgH: yMax - yMin,
+    offsetX: -padL + xMin,
+    offsetY: -padT + (plateH - yMax),
+    originX: xMin,
+    originY: yMin,
+  };
+}

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -314,25 +314,43 @@ describe('resizeDrawerOutline', () => {
     expect(outlineSignedArea(o)).toBeCloseTo((12 + 4) * U * U);
   });
 
-  it('resets when sequential growth would trap the notch as a hole', () => {
-    // Width growth welds a strip along the notch's right side; the later
-    // depth growth would then need to weld across two separate runs.
-    expect(resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 5 * U, 5 * U, U)).toBeUndefined();
+  it('keeps the shape when a second-axis growth cannot weld (welds the first, notch stays open)', () => {
+    // Width growth welds a strip along the notch's right side; the later depth
+    // growth would then span two separate top runs, so it welds nothing and the
+    // width-grown shape is kept rather than discarded (#3114).
+    const grown = resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 5 * U, 5 * U, U);
+    expect(grown).toBeDefined();
+    const o = grown as DrawerOutline;
+    expect(validateOutline(o, 5 * U, 5 * U, U)).toBeNull();
+    // L area (12) + welded right strip (1×4); the top stays open (unwelded).
+    expect(outlineSignedArea(o)).toBeCloseTo((12 + 4) * U * U);
   });
 
-  it('resets when the outline never touches the grown edge', () => {
+  it('keeps an off-edge outline when growing (the grid enlarges around it)', () => {
+    // An L inset from the 4-wide drawer's right edge: growing to 5 wide welds
+    // nothing (no run flush with the old edge), so it is kept unchanged, now
+    // offset within the larger grid (#3114).
     const inset: DrawerOutline = {
       vertices: [
         { x: 0, y: 0 },
         { x: 3 * U, y: 0 },
-        { x: 3 * U, y: 4 * U },
+        { x: 3 * U, y: 2 * U },
+        { x: U, y: 2 * U },
+        { x: U, y: 4 * U },
         { x: 0, y: 4 * U },
       ],
     };
-    expect(resizeDrawerOutline(inset, 4 * U, 4 * U, 5 * U, 4 * U, U)).toBeUndefined();
+    const grown = resizeDrawerOutline(inset, 4 * U, 4 * U, 5 * U, 4 * U, U);
+    expect(grown).toBeDefined();
+    const o = grown as DrawerOutline;
+    expect(validateOutline(o, 5 * U, 4 * U, U)).toBeNull();
+    expect(o.vertices).toEqual(inset.vertices);
   });
 
-  it('resets when growth would enclose a hole (two edge runs)', () => {
+  it('keeps a right-notched outline when growing past its two-run edge', () => {
+    // The notch cuts the old right edge into two runs; welding both would trap a
+    // hole. Growing instead keeps the shape, the notch now interior to the
+    // larger grid (#3114).
     const sideNotch: DrawerOutline = {
       vertices: [
         { x: 0, y: 0 },
@@ -346,7 +364,31 @@ describe('resizeDrawerOutline', () => {
       ],
     };
     expect(validateOutline(sideNotch, 4 * U, 4 * U, U)).toBeNull();
-    expect(resizeDrawerOutline(sideNotch, 4 * U, 4 * U, 5 * U, 4 * U, U)).toBeUndefined();
+    const grown = resizeDrawerOutline(sideNotch, 4 * U, 4 * U, 5 * U, 4 * U, U);
+    expect(grown).toBeDefined();
+    const o = grown as DrawerOutline;
+    expect(validateOutline(o, 5 * U, 4 * U, U)).toBeNull();
+    // Full 4×4 minus the 2×2 notch.
+    expect(outlineSignedArea(o)).toBeCloseTo((16 - 4) * U * U);
+  });
+
+  it('keeps an oversize outline on grow, revalidated against the larger bounds', () => {
+    // The perimeter already reaches past the old 4-wide grid (x = 4.5u).
+    // Growing welds nothing and keeps it, now within the 5-wide bounds (#3114).
+    const oversize: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4.5 * U, y: 0 },
+        { x: 4.5 * U, y: 3.5 * U },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const grown = resizeDrawerOutline(oversize, 4 * U, 4 * U, 5 * U, 4 * U, U);
+    expect(grown).toBeDefined();
+    const o = grown as DrawerOutline;
+    expect(validateOutline(o, 5 * U, 4 * U, U)).toBeNull();
+    expect(o.vertices).toEqual(oversize.vertices);
   });
 
   it('resets when a shrink would split the shape into two components', () => {

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -374,9 +374,10 @@ function clipHalfPlane(
  * Extend the loop across a grown drawer edge. The grown strip
  * (`newRect \ oldRect` on this axis) defaults to inside, welded to the shape
  * along the segment run the outline shares with the moved edge. Exactly one
- * maximal run must exist: zero means the strip would be disconnected, two or
- * more would enclose a hole — both unrepresentable, so the caller resets to a
- * full rectangle (returns null).
+ * maximal run can weld: zero (the loop never lay flush with, or already runs
+ * past, the moved edge) or two-plus (welding would enclose a hole) return
+ * null. On a grow the caller then keeps the loop unchanged — a bigger grid
+ * only enlarges the valid region around an already-valid shape.
  */
 function growAxis(
   verts: readonly MutableVertex[],
@@ -442,6 +443,24 @@ function growAxis(
 }
 
 /**
+ * Grow an axis, keeping the loop unchanged when {@link growAxis} can't weld a
+ * strip (the loop is off the moved edge, or already runs past it). A grow only
+ * enlarges the valid region, so an unweldable perimeter stays valid as-is;
+ * discarding it would delete a custom shape the instant the grid grows (#3114).
+ * Shrinks stay on {@link clipHalfPlane}, whose null result is a genuine
+ * fall-back-to-rectangle (the clip severed or emptied the loop).
+ */
+function growOrKeep(
+  verts: readonly MutableVertex[],
+  axis: Axis,
+  oldK: number,
+  newK: number,
+  crossExtent: number
+): MutableVertex[] {
+  return growAxis(verts, axis, oldK, newK, crossExtent) ?? [...verts];
+}
+
+/**
  * Topology test, not an area tolerance: the loop traces the full rectangle
  * exactly when every segment is straight and hugs one of the four boundary
  * lines. A corner-cutting edge (e.g. a small chamfer) has its endpoints on
@@ -486,11 +505,14 @@ function dropCoincident(verts: MutableVertex[]): MutableVertex[] {
 
 /**
  * Adapt an outline to resized drawer dims (mm): cropped where the drawer
- * shrank, extended (new area inside) where it grew. Returns:
+ * shrank, and where it grew either welded across the moved edge (loop flush
+ * with it) or kept unchanged (loop off it — the grid just enlarges around a
+ * still-valid shape). Returns:
  * - the same outline when dims are unchanged,
  * - a new outline when the crop/extend succeeded,
- * - `undefined` when the result is the full rectangle OR degenerate/invalid —
- *   the caller must fall back to a plain rectangular drawer (drop the field).
+ * - `undefined` when the result is the full rectangle OR degenerate/invalid
+ *   (a shrink severed the loop, or the kept shape no longer validates) — the
+ *   caller must fall back to a plain rectangular drawer (drop the field).
  *
  * The authoring annotation is dropped whenever geometry changes; editors
  * re-derive their state from geometry.
@@ -514,13 +536,13 @@ export function resizeDrawerOutline(
     verts =
       newWidthMm < oldWidthMm
         ? clipHalfPlane(verts, 'x', newWidthMm)
-        : growAxis(verts, 'x', oldWidthMm, newWidthMm, oldDepthMm);
+        : growOrKeep(verts, 'x', oldWidthMm, newWidthMm, oldDepthMm);
   }
   if (verts !== null && !sameD) {
     verts =
       newDepthMm < oldDepthMm
         ? clipHalfPlane(verts, 'y', newDepthMm)
-        : growAxis(verts, 'y', oldDepthMm, newDepthMm, newWidthMm);
+        : growOrKeep(verts, 'y', oldDepthMm, newDepthMm, newWidthMm);
   }
   if (verts === null) return undefined;
 


### PR DESCRIPTION
## Summary

Two layout-editor bugs, one feature gap: the recently-shipped "custom drawer perimeter may extend **beyond** the grid" (oversize) support was added in the pen editor but never propagated to the layout editor.

## #3114 — drag-to-expand the grid deleted the custom shape
The resize handle dispatches `updateDrawer` per pointer-move; the store action and CQRS `updateDrawer` both `delete drawer.outline` when `resizeDrawerOutline` returns `undefined`. On a **grow**, `growAxis` only welds a strip when the loop has exactly one straight run flush with the *old* grid edge — a custom/off-edge/oversize perimeter has zero, so it returned `null` → the shape vanished on the first drag step.

**Fix:** new `growOrKeep` — when `growAxis` can't weld, keep the loop unchanged (a grow only *enlarges* the valid region around an already-valid shape). Shrinks still use `clipHalfPlane`, whose `null` remains a genuine fall-back-to-rectangle. Both the live-drag store action and the CQRS command inherit the fix through the shared `resizeDrawerOutline`. The grid-flush grow-weld path is untouched.

## #3107 — the outline rendered truncated when it extended past the grid
`DrawerOutlineOverlay` sized its `<svg>` to the padded grid extent only, so `overflow:hidden` clipped anything the outline drew beyond it.

**Fix:** extracted a pure `computeOverlayViewport` helper that frames the viewport to the **union** of the padded plate and the flattened outline bbox, shifting the mm→px origin so an outline reaching left-of/below the plate origin also stays on-canvas. For an in-bounds shape both origins are 0 and the mapping is unchanged.

## Test plan
- [x] `pnpm run typecheck`
- [x] `drawerOutline.test.ts` (38) — grow keeps an off-edge/oversize outline; grid-flush weld still works; shrink-that-clips still resets
- [x] `DrawerOutlineOverlay` + new `overlayViewport` tests (9) — viewport grows to include an out-of-grid vertex
- [x] `src/core/store/layout` + `src/core/cqrs/v2/domain/drawer` (290) — no resize/updateDrawer regressions

Square/in-bounds drawers are unchanged. (Some `grid-editor/Grid` suites fail only under the worktree's symlinked-node_modules WASM fs-deny — a CI-clean-checkout artifact, verified pre-existing.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves custom and oversize drawer perimeters during grid resize and renders outlines and padding rims that extend beyond the grid without clipping. Fixes shapes disappearing on grow and makes off‑grid geometry fully visible.

- **Bug Fixes**
  - Keep the outline on grid grow when welding isn’t possible (#3114); shrinks still clip and may reset to rectangle.
  - Frame the overlay SVG to the union of the padded plate and both the inset outline bbox and padded rim points, shifting the origin so left/bottom overflow stays on canvas (#3107).
  - Added tests for growth behavior, rim framing, and viewport sizing.

<sup>Written for commit b37475b8f6931136fe214974196b29e0509cad81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

