### PR TITLE
fix(baseplate): center the socket/seam grid on the custom-perimeter bbox (#3108, #3109)

### DIFF
--- a/src/features/baseplate/utils/buildFullParams.test.ts
+++ b/src/features/baseplate/utils/buildFullParams.test.ts
@@ -637,6 +637,71 @@ describe('drawer outline handling', () => {
     expect(result.outline).toBeUndefined();
     expect(result.paddingLeft).toBe(1.0);
   });
+
+  // #3108/#3109: the pen editor auto-grows the drawer to the MAX extent only
+  // (#3092), so a custom perimeter usually lands in a corner-offset sub-rect of
+  // the declared extent. The resolver re-bases the one derived outline onto that
+  // bbox so the generator's socket grid and the split planner's seam bands share
+  // one centred frame.
+  describe('outline re-centring on the perimeter bbox', () => {
+    const zeroPad = {
+      ...storedBase,
+      paddingLeft: mm(0),
+      paddingRight: mm(0),
+      paddingFront: mm(0),
+      paddingBack: mm(0),
+    };
+    // 3×3-unit square pinned to the bottom-left of a 4×4 drawer — half a unit of
+    // grown, unused extent on the top and right.
+    const drifted: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 126, y: 0 },
+        { x: 126, y: 126 },
+        { x: 0, y: 126 },
+      ],
+    };
+
+    const bboxOf = (o: DrawerOutline): { cx: number; cy: number; w: number; h: number } => {
+      const xs = o.vertices.map((v) => v.x);
+      const ys = o.vertices.map((v) => v.y);
+      const minX = Math.min(...xs);
+      const maxX = Math.max(...xs);
+      const minY = Math.min(...ys);
+      const maxY = Math.max(...ys);
+      return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2, w: maxX - minX, h: maxY - minY };
+    };
+
+    it('shifts a corner-offset outline to the extent centre (grid stays put)', () => {
+      const result = buildFullParams(zeroPad, 4, 4, 42, 'end', 'end', undefined, drifted);
+      // Drift = 63 − 84 = −21 per axis; re-centre translates by +21.
+      expect(result.outline?.vertices).toEqual([
+        { x: 21, y: 21 },
+        { x: 147, y: 21 },
+        { x: 147, y: 147 },
+        { x: 21, y: 147 },
+      ]);
+      // Same shape, now centred on the 168×168 extent.
+      const b = bboxOf(result.outline as DrawerOutline);
+      expect(b.cx).toBeCloseTo(84, 6);
+      expect(b.cy).toBeCloseTo(84, 6);
+      expect(b.w).toBeCloseTo(126, 6);
+    });
+
+    it('leaves a full-extent outline byte-identical (no drift, cache-stable)', () => {
+      // `outline` fills the 10×8 extent (bbox [0,420]×[0,336]) → offset 0.
+      const result = buildFullParams(zeroPad, 10, 8, 42, 'end', 'end', undefined, outline);
+      expect(result.outline?.vertices).toEqual(outline.vertices);
+    });
+
+    it('centres against the PADDED extent, composing with asymmetric padding', () => {
+      // storedBase padding L1/R2/F3/B4 → padded extent 171×175.
+      const result = buildFullParams(storedBase, 4, 4, 42, 'end', 'end', undefined, drifted);
+      const b = bboxOf(result.outline as DrawerOutline);
+      expect(b.cx).toBeCloseTo(171 / 2, 6);
+      expect(b.cy).toBeCloseTo(175 / 2, 6);
+    });
+  });
 });
 
 describe('corner-cut shape + padding composition', () => {

--- a/src/features/baseplate/utils/buildFullParams.ts
+++ b/src/features/baseplate/utils/buildFullParams.ts
@@ -19,10 +19,17 @@ import {
   cornerCutsMatchVertices,
 } from '@/shared/utils/cornerCutOutline';
 import { padOutline } from '@/shared/utils/padOutline';
+import { translateOutline } from '@/shared/utils/drawerOutline';
+import { outlineFrameOffset } from '@/shared/utils/drawerOutlineGeometry';
 
 /** Keeps regenerated cuts off degenerate geometry (mirrors the generator's
  * own geometric radius clamp). */
 const CUT_GEOMETRY_MARGIN_MM = 0.1;
+
+/** Below this the outline is treated as already centred on the extent (no
+ * re-base) — well under the 0.01mm outline-hash quantum, so it only absorbs
+ * float noise, never a real pen auto-grow drift. */
+const RECENTER_EPS_MM = 1e-6;
 
 /**
  * Largest corner radius the plain rounding path may cut: the arc can enter
@@ -120,8 +127,46 @@ export function hasEffectivePerimeter(
  * paddings it permits. Corner-cut drawer shapes re-inscribe their cuts on the
  * padded rectangle; every other shape offsets its edges outward (`padOutline`).
  * Either way padding composes, unless it would fold the loop (then it's zeroed).
+ *
+ * A final step re-bases the outline onto its own bbox centre (see below) so the
+ * plate's socket/seam grid ends up centred on the perimeter rather than the
+ * extent (#3108/#3109).
  */
 function resolveOutline(
+  drawerOutline: DrawerOutline | undefined,
+  outlineOn: boolean,
+  stored: StoredBaseplateParams,
+  widthMm: number,
+  depthMm: number,
+  gridUnitMm: number
+): { outline: DrawerOutline | undefined; paddingOn: boolean } {
+  const resolved = resolveOutlineRaw(drawerOutline, outlineOn, stored, widthMm, depthMm, gridUnitMm);
+  if (resolved.outline === undefined) return resolved;
+
+  // Re-base the plate's grid onto the perimeter. Since the pen editor auto-grows
+  // the drawer to the max extent only (#3092), a custom outline usually sits in a
+  // corner-offset sub-rectangle of `[0,totalW]×[0,totalD]`; anchoring the socket/
+  // seam grid to that extent leaves it off-centre (#3108) and misclassifies
+  // boundary seams (#3109). Centring the outline on the extent here — once, on the
+  // one derived outline the generator, the split planner, and every piece all
+  // consume — makes those two frames identical by construction. Zero-drift
+  // outlines (corner-cut / radius / already-centred) translate by 0 and keep their
+  // exact vertices, so square and full-extent plates stay cache-stable.
+  const padL = resolved.paddingOn ? stored.paddingLeft : 0;
+  const padR = resolved.paddingOn ? stored.paddingRight : 0;
+  const padF = resolved.paddingOn ? stored.paddingFront : 0;
+  const padB = resolved.paddingOn ? stored.paddingBack : 0;
+  const offset = outlineFrameOffset(resolved.outline, widthMm + padL + padR, depthMm + padF + padB);
+  // Corner-cut / radius outlines fill the extent and give an exact 0; the eps
+  // only guards float noise on an already-centred freeform shape.
+  if (Math.abs(offset.x) < RECENTER_EPS_MM && Math.abs(offset.y) < RECENTER_EPS_MM) return resolved;
+  return {
+    outline: translateOutline(resolved.outline, -offset.x, -offset.y),
+    paddingOn: resolved.paddingOn,
+  };
+}
+
+function resolveOutlineRaw(
   drawerOutline: DrawerOutline | undefined,
   outlineOn: boolean,
   stored: StoredBaseplateParams,

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -12,6 +12,9 @@ import { CONSTRAINTS } from '@/core/constants';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { BaseplatePiece } from '../types/tiling';
 import { computePieceFingerprint } from './pieceFingerprint';
+import { outlineFrameOffset } from '@/shared/utils/drawerOutlineGeometry';
+import { translateOutline } from '@/shared/utils/drawerOutline';
+import type { DrawerOutline } from '@/core/types';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -1797,6 +1800,50 @@ describe('shaped plates (outline-aware splitting)', () => {
     const b2 = pieceToBaseplateParams(byLabel.get('B2') as BaseplatePiece, parent);
     expect(computePieceFingerprint(b2)).not.toBe(computePieceFingerprint(a1));
     expect(computePieceFingerprint(b2)).toBe(computePieceFingerprint(b2));
+  });
+
+  // #3109: an outline sitting in an offset sub-region of the plate extent (the
+  // pen editor auto-grows to the max only and never re-bases the min, #3092) is
+  // classified against extent-anchored seam bands, so seams near the boundary
+  // misclassify and lose their connectors — and pieces over the empty grown
+  // region drop entirely. Re-basing the outline onto its bbox (what
+  // buildFullParams now does via `outlineFrameOffset`) restores them.
+  it('re-basing an offset outline restores dropped pieces and seam connectors', () => {
+    // A 6-unit-wide full-height rectangle drawn in the right two thirds of a
+    // 9-unit plate: the drawer grew to hold maxX = 9U but the min stayed at 3U.
+    const drifted: DrawerOutline = {
+      vertices: [
+        { x: 3 * U, y: 0 },
+        { x: 9 * U, y: 0 },
+        { x: 9 * U, y: 4 * U },
+        { x: 3 * U, y: 4 * U },
+      ],
+    };
+    const W = 9;
+    const D = 4;
+
+    const driftedTiling = computeBaseplateTiling(shapedParams(drifted, { width: W, depth: D }), BED);
+    const driftedByLabel = new Map(driftedTiling.pieces.map((p) => [p.label, p]));
+    // The extent-anchored left column [0,3U] falls entirely in the empty region
+    // and is dropped; only the middle+right pieces survive with a single seam.
+    expect(driftedByLabel.has('A1')).toBe(false);
+    expect(driftedByLabel.get('B1')?.edges.left).toBe('exterior');
+
+    // Re-base onto the bbox centre — exactly the transform buildFullParams applies.
+    const off = outlineFrameOffset(drifted, W * U, D * U);
+    expect(off.x).toBeCloseTo(1.5 * U, 6);
+    const centered = translateOutline(drifted, -off.x, -off.y);
+
+    const centeredTiling = computeBaseplateTiling(
+      shapedParams(centered, { width: W, depth: D }),
+      BED
+    );
+    const centeredByLabel = new Map(centeredTiling.pieces.map((p) => [p.label, p]));
+    // The left piece survives and its seam to the middle piece keeps a connector.
+    expect(centeredByLabel.has('A1')).toBe(true);
+    expect(centeredByLabel.get('A1')?.edges.right).toBe('join');
+    expect(centeredByLabel.get('B1')?.edges.left).toBe('join');
+    expect(centeredTiling.pieces.length).toBeGreaterThan(driftedTiling.pieces.length);
   });
 });
 

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
@@ -15,6 +15,8 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBaseplate, getKernelName } from './__kernel-tests__/wasmInit';
 import { assertStructurallyValid, boundingBox } from './__kernel-tests__/meshAssertions';
 import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
+import { outlineFrameOffset } from '@/shared/utils/drawerOutlineGeometry';
+import { translateOutline } from '@/shared/utils/drawerOutline';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { DrawerOutline } from '@/core/types';
 
@@ -389,6 +391,42 @@ describe('baseplate outline geometry', () => {
     // 10mm margins clear the 8mm printable-tile floor → the ring gains
     // outline-clipped pockets.
     expect(tiledRing.triangleCount).toBeGreaterThan(solidRing.triangleCount);
+  });
+
+  // #3108: a custom perimeter that occupies a corner-offset sub-rectangle of the
+  // grown extent (pen auto-grow, #3092) must generate its grid CENTRED on the
+  // perimeter, not anchored to the extent corner. buildFullParams re-bases the
+  // outline via `outlineFrameOffset`; here we feed the generator the same re-based
+  // outline and confirm the resulting solid is valid and symmetric.
+  it('centres the socket grid on an offset perimeter (whole-cell fit)', { timeout: 240_000 }, () => {
+    const gen = getGenerateBaseplate();
+    // 3×3-unit square pinned bottom-left of a 4×4 plate: bbox [0,3u], extent 4u.
+    const drifted: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 3 * U, y: 0 },
+        { x: 3 * U, y: 3 * U },
+        { x: 0, y: 3 * U },
+      ],
+    };
+    const off = outlineFrameOffset(drifted, 4 * U, 4 * U);
+    expect(off.x).toBeCloseTo(-0.5 * U, 6);
+    const centered = translateOutline(drifted, -off.x, -off.y);
+
+    const raw = gen(defaults({ outline: drifted, wholeCellsOnly: true }), NO_OP, true);
+    const fixed = gen(defaults({ outline: centered, wholeCellsOnly: true }), NO_OP, true);
+    assertStructurallyValid(fixed, 'offset perimeter (centred)');
+
+    // Zero padding → mesh frame is the extent centred on origin. The re-based plate
+    // spans plate-local [0.5u,3.5u] → mesh [-1.5u,1.5u], symmetric about 0; the raw
+    // drifted plate spans [0,3u] → mesh [-2u,1u], skewed toward −X.
+    const rawBB = boundingBox(raw.vertices);
+    const fixedBB = boundingBox(fixed.vertices);
+    expect(fixedBB.minX + fixedBB.maxX).toBeCloseTo(0, 0);
+    expect(fixedBB.minY + fixedBB.maxY).toBeCloseTo(0, 0);
+    expect(rawBB.minX + rawBB.maxX).toBeLessThan(-1);
+    // A whole socket sits at the centred plate's middle cell (mesh origin).
+    expect(countVerticesIn(fixed.vertices, -20, -20, 20, 20)).toBeGreaterThan(0);
   });
 
   it('cuts a geometric-max corner radius, trimming corner sockets', { timeout: 240_000 }, () => {

--- a/src/shared/utils/drawerOutlineGeometry.test.ts
+++ b/src/shared/utils/drawerOutlineGeometry.test.ts
@@ -8,6 +8,8 @@ import {
   flattenOutline,
   insideAreaFraction,
   isFootprintInsideOutline,
+  outlineBounds,
+  outlineFrameOffset,
   outlineSignedArea,
   pointInOutline,
 } from './drawerOutlineGeometry';
@@ -210,5 +212,74 @@ describe('isFootprintInsideOutline', () => {
     expect(isFootprintInsideOutline({ x: 0, y: 2, width: 2, depth: 2 }, lNs, UX, UY)).toBe(true);
     expect(isFootprintInsideOutline({ x: 2, y: 0, width: 2, depth: 2 }, lNs, UX, UY)).toBe(true);
     expect(isFootprintInsideOutline({ x: 2, y: 2, width: 1, depth: 1 }, lNs, UX, UY)).toBe(false);
+  });
+});
+
+describe('outlineBounds', () => {
+  it('measures the flattened extent, including an arc that bows past its endpoints', () => {
+    // The back edge (segment leaving [4U,4U] toward [0,4U]) bows outward: positive
+    // bulge sweeps right of −x travel, i.e. up, pushing maxY past the vertex row.
+    const bowed: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 4 * U, bulge: 0.4 },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const b = outlineBounds(bowed);
+    expect(b.minX).toBeCloseTo(0, 6);
+    expect(b.maxX).toBeCloseTo(4 * U, 6);
+    expect(b.minY).toBeCloseTo(0, 6);
+    // The arc pushes maxY past the vertex row at 4U.
+    expect(b.maxY).toBeGreaterThan(4 * U);
+  });
+});
+
+describe('outlineFrameOffset', () => {
+  it('is zero when the outline fills the extent', () => {
+    const full: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const offset = outlineFrameOffset(full, 4 * U, 4 * U);
+    expect(offset.x).toBe(0);
+    expect(offset.y).toBe(0);
+  });
+
+  it('is zero when a smaller outline is already centred on the extent', () => {
+    // 2×2 outline centred in a 4×4 extent — no drift.
+    const centred: DrawerOutline = {
+      vertices: [
+        { x: U, y: U },
+        { x: 3 * U, y: U },
+        { x: 3 * U, y: 3 * U },
+        { x: U, y: 3 * U },
+      ],
+    };
+    const offset = outlineFrameOffset(centred, 4 * U, 4 * U);
+    expect(offset.x).toBeCloseTo(0, 6);
+    expect(offset.y).toBeCloseTo(0, 6);
+  });
+
+  it('returns the bbox-centre drift for a corner-offset sub-rectangle (#3092 auto-grow)', () => {
+    // Outline pinned to the bottom-left, leaving a half-unit of grown extent on
+    // the top/right — exactly what auto-grow's ceil-the-max-only produces.
+    const drifted: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 3 * U, y: 0 },
+        { x: 3 * U, y: 3 * U },
+        { x: 0, y: 3 * U },
+      ],
+    };
+    const offset = outlineFrameOffset(drifted, 3.5 * U, 3.5 * U);
+    // bbox centre = 1.5U; extent centre = 1.75U → drift = -0.25U on each axis.
+    expect(offset.x).toBeCloseTo(-0.25 * U, 6);
+    expect(offset.y).toBeCloseTo(-0.25 * U, 6);
   });
 });

--- a/src/shared/utils/drawerOutlineGeometry.ts
+++ b/src/shared/utils/drawerOutlineGeometry.ts
@@ -116,6 +116,65 @@ export function outlineSignedArea(outline: DrawerOutline): number {
   return polylineSignedArea(flattenOutline(outline));
 }
 
+export interface OutlineBounds {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+}
+
+/**
+ * Axis-aligned bounds of the outline's flattened polyline. Measured on the
+ * flattened path, not the vertices, so an arc that bows past its own endpoints
+ * is included (the `loopBounds` precedent in the drawer-shape importer).
+ */
+export function outlineBounds(outline: DrawerOutline): OutlineBounds {
+  const pts = flattenOutline(outline);
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of pts) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+/**
+ * Millimetre offset that re-bases a plate's socket/seam grid onto the outline
+ * bbox instead of the plate extent — the drift of the flattened bbox centre
+ * from the extent centre of `[0,widthMm]×[0,depthMm]`.
+ *
+ * Since the pen editor's auto-grow (#3092) grows only the max extent (ceiled to
+ * a half unit) and never re-bases the min to 0, a custom perimeter commonly
+ * occupies a corner-offset SUB-rectangle of its declared extent. Anchoring the
+ * grid to the extent then straddles the perimeter asymmetrically — the socket
+ * grid is off-centre and "fit whole cells" drops cells (#3108), and split-seam
+ * bands near the boundary misclassify and lose their connectors (#3109).
+ *
+ * Translating the outline by `-x,-y` centres it on the extent (equivalently,
+ * centres the grid on the outline), which is what the generator and the split
+ * planner both consume. Zero when the outline already fills or is centred, so
+ * square and full-extent plates are untouched. Measured against the extent
+ * centre (not the padding-shifted grid centre) so asymmetric padding is
+ * preserved: the grid stays the same distance off the outline centre that the
+ * user's padding asked for.
+ */
+export function outlineFrameOffset(
+  outline: DrawerOutline,
+  widthMm: number,
+  depthMm: number
+): { readonly x: number; readonly y: number } {
+  const b = outlineBounds(outline);
+  return {
+    x: (b.minX + b.maxX) / 2 - widthMm / 2,
+    y: (b.minY + b.maxY) / 2 - depthMm / 2,
+  };
+}
+
 export function polylineSignedArea(pts: readonly OutlinePoint[]): number {
   let area = 0;
   for (let i = 0; i < pts.length; i++) {


### PR DESCRIPTION
Fixes #3108. Fixes #3109.

## Summary

Both bugs share one root cause: since the pen editor's auto-grow (#3092) grows only the *max* extent (ceiled to a half unit) and never re-bases the min to 0, a custom perimeter usually occupies a **corner-offset sub-rectangle** of its declared `[0,width·u]×[0,depth·u]` extent. The baseplate anchors its socket/seam grid to that **extent**, not the **outline bbox**, so the grid straddles the perimeter asymmetrically:
- **#3108** — "Fit whole cells only" drops cells because the off-center grid crosses the perimeter on more cells than necessary.
- **#3109** — split-seam bands near the boundary misclassify and lose their connectors.

## Fix — one re-base, inherited by everyone

Rather than offset the grid in two places (the worker generator *and* the split planner) — which is provably wrong for split pieces, whose `params.outline` is the whole parent outline in piece-local frame — re-base the **single resolved outline** onto its own bbox center **once**, in `buildFullParams.resolveOutline`. The generator (whole-plate), the split planner (`computeBaseplateTiling`), and every split piece (`pieceToBaseplateParams`) all consume that same centered outline, so the two frames are **identical by construction** (the anti-drift goal, maximized). `hashOutline` carries the re-base into the mesh cache key + piece fingerprints automatically — no cache-key code change.

- New `outlineFrameOffset` / `outlineBounds` in `drawerOutlineGeometry.ts` (brepjs-free, boundary-clean) — the drift of the flattened bbox center from the extent center; **0** for full-extent/centered/corner-cut/radius outlines, guarded by a 1e-6 eps so those stay byte-identical (no churn).
- Measured against the (padded) **extent center**, so asymmetric padding is preserved.

## Test plan

- [x] `pnpm run typecheck`
- [x] `splitPlanner.test.ts` (104) incl. new #3109 repro: a drifted `[3u..9u]` outline drops the left piece + its seam connector; re-basing restores both
- [x] `buildFullParams.test.ts` + `drawerOutlineGeometry.test.ts` (83): re-base drifted→centered, full-extent byte-identical, padded composition
- [x] `baseplateGenerator.scenario.outline` (real WASM, 16): manifold-valid + symmetric bbox for the centered offset perimeter (vs raw skew)
- [x] split-stress + baseplateGenerator (WASM, 37); cache-key + pieceFingerprint green; **no snapshot/triangleCount churn**

Square / full-extent / centered plates are untouched. (The "allow manual shifting within the perimeter" half of #3108 is a separate enhancement; this fixes the auto-centering bug.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the baseplate socket/seam grid on the custom perimeter by re-basing the resolved outline to its bbox center. Fixes off-center whole-cell fitting and misclassified boundary seams in splits (#3108, #3109).

- **Bug Fixes**
  - Re-based the outline once in `buildFullParams.resolveOutline`, so the generator and split planner share one centered frame.
  - Added `outlineFrameOffset` and `outlineBounds` to compute drift; uses a small eps to avoid byte churn and preserves asymmetric padding.
  - Cache keys remain stable (`hashOutline` includes the re-base); no snapshot/triangle count churn.
  - Updated tests for re-centering and WASM generation; restores dropped pieces and seam connectors.

<sup>Written for commit e478a278c366a08fbb9d26f75a3afa3870fedaa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

