### PR TITLE
fix(baseplate): keep a cheap preview for shaped plates (#3111)

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -820,6 +820,11 @@ export function useBaseplateGeneration(): void {
         setTiling(tiling);
         setSplitProgress(null);
         setDedupStats(null);
+        // No draft ran this epoch, so reset the preview-timing refs — otherwise
+        // runBrepGeneration's telemetry would report a stale draft (kind/ms)
+        // left over from a previous, differently-shaped generation.
+        directMeshDurationRef.current = 0;
+        previewKindRef.current = 'direct';
       } else if (preview && !preview.isDestroyed) {
         // manifold_preview on: draft with the Manifold kernel (real generator,
         // draft quality) instead of the procedural direct-mesh.

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -26,6 +26,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { effectiveGridUnitMmY } from '@/core/types';
+import type { StoredBaseplateParams, DrawerOutline } from '@/core/types';
 import { useTranslation } from '@/i18n';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
 import { hasEffectivePerimeter } from '../utils/buildFullParams';
@@ -47,7 +48,7 @@ import { generateBaseplateDirect } from '@/shared/generation/directMesh';
 import { useBaseplatePageStore } from '../store/baseplatePageStore';
 import { buildFullParams } from '../utils/buildFullParams';
 import { computeBaseplateTiling, bodyParamsForDetach } from '../utils/splitPlanner';
-import { shouldDeferBrepPreview } from '../utils/previewComplexity';
+import { shouldDeferBrepPreview, shouldSkipManifoldDraft } from '../utils/previewComplexity';
 import { groupPiecesByFingerprint } from '../utils/pieceFingerprint';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isSeatedConnectorStyle } from '@/shared/types/bin';
@@ -167,6 +168,68 @@ const NO_OP_PROGRESS = (_stage: string, _progress: number): void => {};
 type LayoutStoreState = ReturnType<typeof useLayoutStore.getState>;
 
 /**
+ * Single-slot memo for {@link hasEffectivePerimeter}, which resolves and pads
+ * the outline — a per-vertex pass that is wasted on unrelated store ticks.
+ *
+ * `selectGenerationTriggers` runs on EVERY layout-store update (bin edits,
+ * camera, any slider), so without this the outline resolve+pad ran per frame of
+ * every drag whenever whole-cell fitting was on. Baseplate params, drawer dims,
+ * and the outline are replaced-never-mutated, so the key is a straight
+ * identity/value compare of the six resolver inputs — unrelated ticks (which
+ * touch none of them) hit the cache. The cache is correctness-neutral: the key
+ * fully determines the result, so a stale slot at worst forces a recompute.
+ */
+let perimeterMemo: {
+  bp: StoredBaseplateParams;
+  drawerWidth: number;
+  drawerDepth: number;
+  gridUnitMm: number;
+  drawerOutline: DrawerOutline | undefined;
+  gridUnitMmY: number;
+  result: boolean;
+} | null = null;
+
+function hasEffectivePerimeterMemoized(
+  bp: StoredBaseplateParams,
+  drawerWidth: number,
+  drawerDepth: number,
+  gridUnitMm: number,
+  drawerOutline: DrawerOutline | undefined,
+  gridUnitMmY: number
+): boolean {
+  const cached = perimeterMemo;
+  if (
+    cached !== null &&
+    cached.bp === bp &&
+    cached.drawerWidth === drawerWidth &&
+    cached.drawerDepth === drawerDepth &&
+    cached.gridUnitMm === gridUnitMm &&
+    cached.drawerOutline === drawerOutline &&
+    cached.gridUnitMmY === gridUnitMmY
+  ) {
+    return cached.result;
+  }
+  const result = hasEffectivePerimeter(
+    bp,
+    drawerWidth,
+    drawerDepth,
+    gridUnitMm,
+    drawerOutline,
+    gridUnitMmY
+  );
+  perimeterMemo = {
+    bp,
+    drawerWidth,
+    drawerDepth,
+    gridUnitMm,
+    drawerOutline,
+    gridUnitMmY,
+    result,
+  };
+  return result;
+}
+
+/**
  * The layout fields whose change must trigger a baseplate regeneration. Used as
  * the single source of truth for BOTH the `useShallow` selection and the regen
  * effect's dependency — they previously duplicated this list, and a geometry
@@ -202,15 +265,14 @@ export function selectGenerationTriggers(state: LayoutStoreState) {
         : false,
     // Folded out without a perimeter, matching buildFullParams and the mesh
     // cache key: a stored flag on a rectangular plate cannot alter geometry, so
-    // toggling it must not trigger a regeneration.
-    // Folded out without a perimeter, matching buildFullParams and the mesh
-    // cache key: a stored flag on a rectangular plate cannot alter geometry, so
     // toggling it must not trigger a regeneration. Uses the resolver's own
     // predicate, since a large corner radius also yields a perimeter — keying
-    // on the raw drawer outline would leave those plates stale on a toggle.
+    // on the raw drawer outline would leave those plates stale on a toggle. The
+    // `&&` short-circuits the (memoized) resolve+pad away entirely unless the
+    // flag is set, and the memo spares the rest of the drags.
     wholeCellsOnly:
       bp.wholeCellsOnly === true &&
-      hasEffectivePerimeter(
+      hasEffectivePerimeterMemoized(
         bp,
         state.layout.drawer.width,
         state.layout.drawer.depth,
@@ -746,7 +808,19 @@ export function useBaseplateGeneration(): void {
       }
 
       const preview = previewBridgeRef.current;
-      if (preview && !preview.isDestroyed) {
+      if (shouldSkipManifoldDraft(fullParams)) {
+        // Shaped plates clip the slab against the outline with the same
+        // expensive coplanar boolean the exact BREP runs, so a Manifold draft
+        // would do that heavy work twice per edit for an identical-looking
+        // result — and the procedural direct-mesh only draws rectangles, so it
+        // can't stand in either. Skip both drafts: keep the last good mesh on
+        // screen (never blank to EMPTY_MESH mid-edit) and let the single exact
+        // BREP replace it when it lands. Still publish the tiling/progress so
+        // the split overlay tracks the new piece layout while the exact runs.
+        setTiling(tiling);
+        setSplitProgress(null);
+        setDedupStats(null);
+      } else if (preview && !preview.isDestroyed) {
         // manifold_preview on: draft with the Manifold kernel (real generator,
         // draft quality) instead of the procedural direct-mesh.
         setTiling(tiling);

--- a/src/features/baseplate/utils/previewComplexity.test.ts
+++ b/src/features/baseplate/utils/previewComplexity.test.ts
@@ -2,12 +2,26 @@ import { describe, it, expect } from 'vitest';
 import {
   estimatePreviewComplexity,
   shouldDeferBrepPreview,
+  shouldSkipManifoldDraft,
   DEFER_MAX_PIECE_CELLS,
   DEFER_TOTAL_CELLS,
   DEFER_LAST_BREP_MS,
 } from './previewComplexity';
 import { computeBaseplateTiling } from './splitPlanner';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+import type { DrawerOutline } from '@/core/types';
+
+/** A closed CCW rectangle outline spanning the plate's grid extent. */
+function rectOutline(widthMm: number, depthMm: number): DrawerOutline {
+  return {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: widthMm, y: 0 },
+      { x: widthMm, y: depthMm },
+      { x: 0, y: depthMm },
+    ],
+  };
+}
 
 function makeParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
@@ -101,5 +115,30 @@ describe('shouldDeferBrepPreview', () => {
     const p = makeParams({ width: 6, depth: 6 }); // small, would not defer statically
     expect(defer(p, 256, null)).toBe(false);
     expect(defer(p, 256, DEFER_LAST_BREP_MS + 1)).toBe(true);
+  });
+
+  it('never defers a shaped (outlined) plate — it must run the exact BREP', () => {
+    // The same 10×10 magnet plate that defers when rectangular, now shaped. The
+    // direct-mesh is rectangles-only, so deferring would freeze a wrong preview;
+    // shaped plates always run BREP even when otherwise over the cost threshold.
+    expect(defer(makeParams({ width: 10, depth: 10 }), 460)).toBe(true);
+    expect(defer(makeParams({ width: 10, depth: 10, outline: rectOutline(420, 420) }), 460)).toBe(
+      false
+    );
+  });
+
+  it('defers past the adaptive threshold only for rectangular plates, never shaped', () => {
+    const shaped = makeParams({ width: 6, depth: 6, outline: rectOutline(252, 252) });
+    expect(defer(shaped, 256, DEFER_LAST_BREP_MS + 1)).toBe(false);
+  });
+});
+
+describe('shouldSkipManifoldDraft', () => {
+  it('skips the draft for a shaped (outlined) plate — the draft duplicates the exact intersect', () => {
+    expect(shouldSkipManifoldDraft(makeParams({ outline: rectOutline(252, 252) }))).toBe(true);
+  });
+
+  it('keeps the draft for a rectangular plate (no outline)', () => {
+    expect(shouldSkipManifoldDraft(makeParams())).toBe(false);
   });
 });

--- a/src/features/baseplate/utils/previewComplexity.ts
+++ b/src/features/baseplate/utils/previewComplexity.ts
@@ -98,3 +98,18 @@ export function shouldDeferBrepPreview(
   const { maxPieceCells, totalCells } = estimatePreviewComplexity(tiling, parentParams);
   return maxPieceCells >= DEFER_MAX_PIECE_CELLS || totalCells >= DEFER_TOTAL_CELLS;
 }
+
+/**
+ * True when the fast Manifold DRAFT preview should be skipped in favor of going
+ * straight to the exact BREP.
+ *
+ * A shaped (outlined) plate clips the slab against its outline with the same
+ * expensive coplanar boolean the exact BREP runs, so drafting one does that
+ * heavy work twice per edit for a result indistinguishable from the exact. The
+ * caller keeps the last good mesh on screen until the single exact build lands
+ * instead. Rectangular plates keep the draft — there it is a cheap early fill,
+ * not a duplicate of the exact.
+ */
+export function shouldSkipManifoldDraft(params: ResolvedBaseplateParams): boolean {
+  return params.outline !== undefined;
+}


### PR DESCRIPTION
Fixes #3111.

## Summary

A baseplate with a custom perimeter was 15-30s unresponsive on every edit because outlined plates bypass **both** fast-preview paths, so the expensive coplanar outline-clip boolean ran with no cheap intermediate — and, with `manifold_preview` on, it ran **twice** per edit (draft + exact).

## Fixes

**A — stop the double intersect.** New pure `shouldSkipManifoldDraft(params) = outline !== undefined`. Shaped plates skip the Manifold draft (it runs the *same* heavy intersect as the exact) and go straight to the single exact BREP. Non-outlined plates keep the existing draft/skip logic.

**B — no blank mid-edit.** The shaped branch publishes tiling/progress/dedup but leaves the mesh untouched, so the **last good mesh stays on screen** while the exact catches up (instead of clearing to `EMPTY_MESH`). `shouldDeferBrepPreview` still returns `false` for outlined plates, so the exact BREP always runs and finalizes the correct mesh — the skip removes only the redundant draft.

**C — memoize the per-tick perimeter check.** `selectGenerationTriggers` runs on every store update; `hasEffectivePerimeter` (which resolves + pads the outline) is now behind a single-slot memo keyed on its six replaced-never-mutated inputs, so unrelated ticks (bin edits, camera, sliders) no longer re-run the resolve+pad. Correctness-neutral (the key fully determines the result); `useShallow` identity is preserved.

## Before → after (shaped-plate edit)
- manifold on: **2 heavy intersects → 1**.
- manifold off: **canvas blanks + 15-30s wait → last good mesh held**, 1 intersect.

## Test plan
- [x] `pnpm run typecheck`
- [x] `previewComplexity.test.ts` (13) — draft skipped for outlined plates; deferral still `false` for outlined (exact still runs) at both thresholds
- [x] `src/features/baseplate/hooks` (47)
- [x] module boundaries + i18n parity + eslint clean

Non-outlined plates are unchanged. (Not done: a trailing debounce-then-defer for outlined plates — that needs a new regeneration mechanism; flagged as a separate, larger change.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long edit stalls for shaped baseplates by skipping the redundant Manifold draft and keeping the last good mesh visible. This removes one heavy intersect per edit and avoids blank previews.

- **Bug Fixes**
  - Skip the Manifold draft for outlined plates and go straight to the exact BREP, halving heavy intersects when `manifold_preview` is on.
  - Keep the last good mesh on screen for shaped plates while the exact BREP runs; still publish tiling/progress/dedup.
  - Memoize perimeter detection in `selectGenerationTriggers` to avoid re-running outline resolve/pad on unrelated store ticks.
  - Reset preview-timing refs on the held-mesh path to prevent stale draft telemetry.

<sup>Written for commit 498c85edad23341c93f07beeacf2d5cf399386d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

