### PR TITLE
feat(baseplate): support vertical stacking with a custom perimeter (#3113)

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -1142,6 +1142,19 @@ describe('shaped drawer (outline present)', () => {
     render(<BaseplatePanel />);
     expect(screen.getByText('baseplate.shapedPaddingNotice')).toBeInTheDocument();
   });
+
+  it('shows the compose notice for a stacked shaped drawer on STL too (#3113)', () => {
+    // Stacking keeps the custom perimeter now, so the shaped tiles print as the
+    // shape — the panel must show it for every format, not only the STEP export
+    // that clears stackPrint.
+    mockLayoutState.layout.drawer = { width: 4, depth: 6, outline: ARC_OUTLINE } as never;
+    mockLayoutState.layout.baseplateParams = {
+      ...DEFAULT_BASEPLATE_PARAMS,
+      stackPrint: { enabled: true, gapMm: 0.2 },
+    } as never;
+    render(<BaseplatePanel />);
+    expect(screen.getByText('baseplate.shapedPaddingNotice')).toBeInTheDocument();
+  });
 });
 
 describe('corner-cut shaped drawer (padding composes, issue #2612)', () => {

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
@@ -135,6 +135,20 @@ describe('DimensionsSection', () => {
       expect(row()).not.toBeInTheDocument();
     });
 
+    // A large radius shapes the plate under stacking too (#3113): the rounded
+    // perimeter survives and its tiles stack, so the whole-cell control must reach
+    // them (the removed stacking override used to hide it).
+    it('appears for a large radius even while stacking (#3113)', () => {
+      const current = useLayoutStore.getState().layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
+      useLayoutStore.getState().setBaseplateParams({
+        ...current,
+        cornerRadius: mm(40),
+        stackPrint: { enabled: true, gapMm: mm(0.2) },
+      });
+      render(<DimensionsSection />);
+      expect(row()).toBeInTheDocument();
+    });
+
     it('appears once the drawer has a perimeter', () => {
       shapedDrawer();
       render(<DimensionsSection />);

--- a/src/features/baseplate/components/BaseplatePanel/panelState.ts
+++ b/src/features/baseplate/components/BaseplatePanel/panelState.ts
@@ -107,12 +107,10 @@ export function useBaseplatePanelDerived(): BaseplatePanelDerived {
   // padding (the cuts are re-inscribed on the padded rectangle), so padding
   // stays live and only corner rounding + detached margins hide. Painted/pen/
   // trace shapes have no parametric resize: they subsume padding too, so all
-  // those controls hide behind the notice. Stacking wins over the shape
-  // (uniform rectangular tiles), so the stack section stays functional — but
-  // via the export-format-aware `stackEnabled`: STEP clears stackPrint before
-  // buildFullParams, so a STEP export of a stacked shaped drawer IS shaped and
-  // the panel must say so.
-  const outlineActive = drawerOutline !== undefined && synced && !stackEnabled;
+  // those controls hide behind the notice. Stacking keeps the shape now (#3113):
+  // the shaped tiles dedupe and stack, so a stacked shaped drawer IS shaped and
+  // the panel must say so — for every export format, not just STEP.
+  const outlineActive = drawerOutline !== undefined && synced;
   const cornerShaped =
     outlineActive &&
     drawerOutline.authoring?.kind === 'corners' &&

--- a/src/features/baseplate/components/BaseplatePanel/panelState.ts
+++ b/src/features/baseplate/components/BaseplatePanel/panelState.ts
@@ -130,6 +130,9 @@ export function useBaseplatePanelDerived(): BaseplatePanelDerived {
   // outline in buildFullParams, so the plate really does get a curved perimeter
   // slicing sockets. Asking the resolver's own predicate rather than repeating
   // its threshold keeps the panel, the trigger and the resolver from drifting.
+  // Stacking-independent since #3113: a large radius shapes the plate whether or
+  // not stacking is on (the rounded tiles stack), so the whole-cell control this
+  // gates surfaces for a stacked large-radius plate too — no format override.
   /** The plate has a curved or angled perimeter that can slice sockets. */
   const perimeterShaped = hasEffectivePerimeter(
     baseplateParams,
@@ -137,11 +140,7 @@ export function useBaseplatePanelDerived(): BaseplatePanelDerived {
     drawerDepth,
     gridUnitMm,
     drawerOutline,
-    gridUnitMmY,
-    // Format-aware override: a STEP export clears stackPrint before the
-    // resolver runs, so its controls stay live the way every other
-    // stacking-stripped control already does.
-    stackEnabled
+    gridUnitMmY
   );
 
   return {

--- a/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackedBaseplateMeshes.tsx
@@ -70,6 +70,7 @@ export function StackedBaseplateMeshes({
   const {
     drawerWidth,
     drawerDepth,
+    drawerOutline,
     gridUnitMm,
     gridUnitMmY,
     fractionalEdgeX,
@@ -79,6 +80,9 @@ export function StackedBaseplateMeshes({
     useShallow((s) => ({
       drawerWidth: s.layout.drawer.width,
       drawerDepth: s.layout.drawer.depth,
+      // A custom perimeter now stacks (#3113); pass it so the preview's
+      // fingerprint grouping matches the shaped tiles generation produced.
+      drawerOutline: s.layout.drawer.outline,
       gridUnitMm: s.layout.gridUnitMm,
       gridUnitMmY: effectiveGridUnitMmY(s.layout),
       fractionalEdgeX: s.layout.drawer.fractionalEdgeX ?? 'end',
@@ -102,7 +106,7 @@ export function StackedBaseplateMeshes({
       fractionalEdgeX,
       fractionalEdgeY,
       nozzleSizeMm,
-      undefined,
+      drawerOutline,
       undefined,
       gridUnitMmY
     );
@@ -171,6 +175,7 @@ export function StackedBaseplateMeshes({
     baseplateParams,
     drawerWidth,
     drawerDepth,
+    drawerOutline,
     gridUnitMm,
     gridUnitMmY,
     fractionalEdgeX,

--- a/src/features/baseplate/hooks/useStackPrintStatus.test.ts
+++ b/src/features/baseplate/hooks/useStackPrintStatus.test.ts
@@ -103,6 +103,46 @@ describe('useStackPrintStatus', () => {
     expect(result.current.railCount).toBe(1);
   });
 
+  it('does not stack differently-shaped partial tiles (threads the outline, #3113)', () => {
+    // Two partial tiles whose only difference is where the plate outline crosses
+    // them. With the outline threaded into buildFullParams they fingerprint
+    // distinctly, so the status reports "nothing to stack" instead of the
+    // outline-blind "ok" that used to merge them into one deceptive tower.
+    const U = 42;
+    useLayoutStore.setState((state) => ({
+      layout: {
+        ...state.layout,
+        drawer: {
+          ...state.layout.drawer,
+          outline: {
+            vertices: [
+              { x: 0, y: 0 },
+              { x: 8 * U, y: 0 },
+              { x: 8 * U, y: 4 * U },
+              { x: 4 * U, y: 4 * U },
+              { x: 4 * U, y: 8 * U },
+              { x: 0, y: 8 * U },
+            ],
+          },
+        },
+      },
+    }));
+    useLayoutStore.getState().setBaseplateParams({
+      ...DEFAULT_BASEPLATE_PARAMS,
+      stackPrint: { enabled: true, gapMm: mm(0.2), copies: 1 },
+    });
+    useBaseplatePageStore
+      .getState()
+      .setTiling(
+        tiling([
+          piece('A1', { outlineWindowOriginMm: { x: 0, y: 0 } }),
+          piece('B1', { outlineWindowOriginMm: { x: 4 * U, y: 0 } }),
+        ])
+      );
+    const { result } = renderHook(() => useStackPrintStatus(0.2));
+    expect(result.current.status).toEqual({ kind: 'singlePlate' });
+  });
+
   it('clears singlePlate and reports the plan when copies ≥ 2 on an unsplit drawer', () => {
     // resetAllStores() doesn't touch the baseplate page store, so clear any
     // tiling a previous test left behind to assert the true unsplit path.

--- a/src/features/baseplate/hooks/useStackPrintStatus.ts
+++ b/src/features/baseplate/hooks/useStackPrintStatus.ts
@@ -37,6 +37,7 @@ export function useStackPrintStatus(gapMm: number): StackPrintStatusInfo {
   const {
     drawerWidth,
     drawerDepth,
+    drawerOutline,
     gridUnitMm,
     gridUnitMmY,
     fractionalEdgeX,
@@ -46,6 +47,10 @@ export function useStackPrintStatus(gapMm: number): StackPrintStatusInfo {
     useShallow((s) => ({
       drawerWidth: s.layout.drawer.width,
       drawerDepth: s.layout.drawer.depth,
+      // A custom perimeter now stacks (#3113); pass it so the shaped tiles
+      // fingerprint the same way generation grouped them, keeping the status
+      // (ok vs nothing-to-stack) honest.
+      drawerOutline: s.layout.drawer.outline,
       gridUnitMm: s.layout.gridUnitMm,
       gridUnitMmY: effectiveGridUnitMmY(s.layout),
       fractionalEdgeX: s.layout.drawer.fractionalEdgeX ?? 'end',
@@ -68,7 +73,7 @@ export function useStackPrintStatus(gapMm: number): StackPrintStatusInfo {
       fractionalEdgeX,
       fractionalEdgeY,
       nozzleSizeMm,
-      undefined,
+      drawerOutline,
       undefined,
       gridUnitMmY
     );
@@ -82,6 +87,7 @@ export function useStackPrintStatus(gapMm: number): StackPrintStatusInfo {
     baseplateParams,
     drawerWidth,
     drawerDepth,
+    drawerOutline,
     gridUnitMm,
     gridUnitMmY,
     fractionalEdgeX,

--- a/src/features/baseplate/utils/buildBaseplateExportPieces.test.ts
+++ b/src/features/baseplate/utils/buildBaseplateExportPieces.test.ts
@@ -186,6 +186,46 @@ describe('buildBaseplateExportPieces', () => {
     expect(result.guideText).toBe('');
   });
 
+  it('stacks a shaped split plate: identical tiles tower, the notched tile prints singly (#3113)', async () => {
+    const { bridge } = makeBridge();
+    const U = 42;
+    // 8×8 plate with the top-right 2×2 corner notched out, on a 4u bed → a 2×2
+    // grid of 4u tiles. Three tiles stay full squares (one dedup group, stacked
+    // into a tower); the notched tile is unique (its own single-plate tower).
+    // Before #3113 the outline was dropped under stacking, collapsing this into
+    // one rectangular tower (uniqueCount 1) — the confusing "nothing to shape".
+    const notched = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 8 * U, y: 0 },
+        { x: 8 * U, y: 6 * U },
+        { x: 6 * U, y: 6 * U },
+        { x: 6 * U, y: 8 * U },
+        { x: 0, y: 8 * U },
+      ],
+    };
+    const result = await buildBaseplateExportPieces(
+      bridge,
+      null,
+      input({
+        drawerWidth: 8,
+        drawerDepth: 8,
+        drawerOutline: notched,
+        printBedWidthMm: 4 * U,
+        printBedDepthMm: 4 * U,
+        baseplateParams: {
+          ...DEFAULT_BASEPLATE_PARAMS,
+          stackPrint: { enabled: true, gapMm: mm(0.2), copies: 1 },
+        },
+      })
+    );
+
+    // The shape kept all four tiles, deduped to two unique tiles (3 full + 1 notched).
+    expect(result.splitStats).toEqual({ uniqueCount: 2, totalPieces: 4, stackEnabled: true });
+    // One tower per unique tile: the three full tiles collapse into a single tower.
+    expect(result.pieces).toHaveLength(2);
+  });
+
   it('reports progress during a split export', async () => {
     const { bridge } = makeBridge();
     const onProgress = vi.fn();

--- a/src/features/baseplate/utils/buildBaseplateExportPieces.test.ts
+++ b/src/features/baseplate/utils/buildBaseplateExportPieces.test.ts
@@ -193,7 +193,7 @@ describe('buildBaseplateExportPieces', () => {
     // grid of 4u tiles. Three tiles stay full squares (one dedup group, stacked
     // into a tower); the notched tile is unique (its own single-plate tower).
     // Before #3113 the outline was dropped under stacking, collapsing this into
-    // one rectangular tower (uniqueCount 1) — the confusing "nothing to shape".
+    // one rectangular tower (uniqueCount 1) — the confusing "nothing to stack".
     const notched = {
       vertices: [
         { x: 0, y: 0 },

--- a/src/features/baseplate/utils/buildFullParams.test.ts
+++ b/src/features/baseplate/utils/buildFullParams.test.ts
@@ -112,9 +112,8 @@ describe('buildFullParams', () => {
     /** Same arguments buildFullParams is called with throughout this file. */
     const perimeter = (
       stored: Parameters<typeof hasEffectivePerimeter>[0],
-      drawerOutline?: DrawerOutline,
-      stackingOverride?: boolean
-    ): boolean => hasEffectivePerimeter(stored, 10, 8, 42, drawerOutline, 42, stackingOverride);
+      drawerOutline?: DrawerOutline
+    ): boolean => hasEffectivePerimeter(stored, 10, 8, 42, drawerOutline, 42);
 
     it('is false for a plain rectangle', () => {
       expect(perimeter(storedBase)).toBe(false);
@@ -130,21 +129,16 @@ describe('buildFullParams', () => {
       expect(perimeter({ ...storedBase, cornerRadius: mm(10) })).toBe(false);
     });
 
-    // A custom drawer perimeter now stacks (#3113): its tiles dedupe by
-    // fingerprint like any others, so the resolver keeps the shape. Only the
-    // radius→outline conversion stays stacking-gated (rounding is stripped, not
-    // converted), so a stored radius alone claims no perimeter under stacking.
-    it('keeps a drawer shape under stacking but not a radius conversion (#3113)', () => {
+    // A custom perimeter now stacks (#3113): both a drawer shape and a
+    // large-radius conversion keep their perimeter under stacking (the shaped
+    // tiles dedupe by fingerprint like any others), so the answer is
+    // stacking-independent — matching what generation actually produces.
+    it('keeps a drawer shape AND a radius conversion under stacking (#3113)', () => {
       const stacked = { ...storedBase, stackPrint: { enabled: true, gapMm: mm(0.2) } };
       expect(perimeter(stacked, outline)).toBe(true);
-      expect(perimeter({ ...stacked, cornerRadius: mm(40) })).toBe(false);
-    });
-
-    it('honours the format-aware override for a STEP export', () => {
-      const stacked = { ...storedBase, stackPrint: { enabled: true, gapMm: mm(0.2) } };
-      // STEP clears stackPrint before the resolver runs, so a stored radius the
-      // resolver would convert to an outline counts as a perimeter again.
-      expect(perimeter({ ...stacked, cornerRadius: mm(40) }, undefined, false)).toBe(true);
+      expect(perimeter({ ...stacked, cornerRadius: mm(40) })).toBe(true);
+      // A small radius still leaves no perimeter (plain rounding, no outline).
+      expect(perimeter({ ...stacked, cornerRadius: mm(10) })).toBe(false);
     });
 
     // It runs the resolver rather than restating its rules, so this walks a
@@ -765,6 +759,37 @@ describe('shaped stacking splits into stackable tiles (#3113)', () => {
     const stackGroups = stackGroupsFromTiling(tiling, params, 1);
     expect(evaluateStackPrint(stackGroups, 8, 5, 250)).toEqual({ kind: 'ok' });
   });
+
+  it('shapes a large radius under stacking: interior tiles stack, rounded corners print singly (#3113)', () => {
+    // 12×12 plate, uniform R60 corners → a radius-cut outline (not plain
+    // rounding). On a 4u bed it tiles 3×3: the four corner tiles each carry a
+    // distinct rounded corner (unique, print singly — placementRotationDeg is
+    // forced to 0 on shaped tilings, so opposite corners do NOT share a mesh),
+    // while the five interior/edge tiles are full squares that share a
+    // fingerprint and stack.
+    const stored = { ...zeroPadStacked, cornerRadius: mm(60) };
+    const params = buildFullParams(stored, 12, 12, U, 'end', 'end');
+    expect(params.outline).toBeDefined();
+    // The radius lives in the outline arcs, so plain rounding is zeroed.
+    expect(params.cornerRadius).toBe(0);
+
+    const tiling = computeBaseplateTiling(params, 4 * U, 4 * U);
+    expect(tiling.isSplit).toBe(true);
+    // Four rounded-corner tiles are partial (each a distinct arc).
+    const partial = tiling.pieces.filter((p) => p.outlineWindowOriginMm !== undefined);
+    expect(partial).toHaveLength(4);
+
+    const groups = groupPiecesByFingerprint(tiling.pieces, params);
+    // The five full square tiles dedupe into one stackable group.
+    const maxGroup = Math.max(...[...groups.values()].map((g) => g.indices.length));
+    expect(maxGroup).toBe(5);
+    // Each rounded corner tile is its own group — no false dedup via the flip.
+    const singletons = [...groups.values()].filter((g) => g.indices.length === 1);
+    expect(singletons).toHaveLength(4);
+
+    const stackGroups = stackGroupsFromTiling(tiling, params, 1);
+    expect(evaluateStackPrint(stackGroups, 8, 5, 250)).toEqual({ kind: 'ok' });
+  });
 });
 
 describe('corner-cut shape + padding composition', () => {
@@ -953,14 +978,20 @@ describe('large corner radius → outline conversion', () => {
     expect(result.paddingLeft).toBe(11);
   });
 
-  it('never converts while stacking (rounding is stripped instead)', () => {
+  it('converts while stacking too, so the rounded tiles stack (#3113)', () => {
     const stored = {
       ...storedBase,
       cornerRadius: mm(60),
       stackPrint: { enabled: true, gapMm: mm(0.2) },
     };
     const result = buildFullParams(stored, 10, 8, 42, 'end', 'end');
-    expect(result.outline).toBeUndefined();
+    // The radius becomes a radius-cut outline (same as the non-stacking path), so
+    // the rounded perimeter survives instead of being flattened under stacking.
+    const r: CornerCutParams['tl'] = { kind: 'radius', r: 60 };
+    expect(result.outline?.vertices).toEqual(
+      cornerCutVertices(420, 336, { tl: r, tr: r, bl: r, br: r })
+    );
+    // The radius lives in the outline arcs now, so plain rounding is zeroed.
     expect(result.cornerRadius).toBe(0);
   });
 

--- a/src/features/baseplate/utils/buildFullParams.test.ts
+++ b/src/features/baseplate/utils/buildFullParams.test.ts
@@ -6,6 +6,9 @@ import {
   maxCornerRadiusMm,
   plainRoundingLimit,
 } from './buildFullParams';
+import { computeBaseplateTiling } from './splitPlanner';
+import { groupPiecesByFingerprint } from './pieceFingerprint';
+import { stackGroupsFromTiling, evaluateStackPrint } from './stackPrint';
 import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
 import type { CornerCutParams, DrawerOutline } from '@/core/types';
 
@@ -127,19 +130,21 @@ describe('buildFullParams', () => {
       expect(perimeter({ ...storedBase, cornerRadius: mm(10) })).toBe(false);
     });
 
-    // Stacking needs uniform rectangular tiles, so the resolver drops every
-    // perimeter. Checking only the drawer-shape half would leave a stored
-    // radius claiming a perimeter generation never produces.
-    it('is false under stacking, whatever is stored', () => {
+    // A custom drawer perimeter now stacks (#3113): its tiles dedupe by
+    // fingerprint like any others, so the resolver keeps the shape. Only the
+    // radius→outline conversion stays stacking-gated (rounding is stripped, not
+    // converted), so a stored radius alone claims no perimeter under stacking.
+    it('keeps a drawer shape under stacking but not a radius conversion (#3113)', () => {
       const stacked = { ...storedBase, stackPrint: { enabled: true, gapMm: mm(0.2) } };
-      expect(perimeter(stacked, outline)).toBe(false);
+      expect(perimeter(stacked, outline)).toBe(true);
       expect(perimeter({ ...stacked, cornerRadius: mm(40) })).toBe(false);
     });
 
     it('honours the format-aware override for a STEP export', () => {
       const stacked = { ...storedBase, stackPrint: { enabled: true, gapMm: mm(0.2) } };
-      // STEP clears stackPrint before the resolver runs, so the caller says so.
-      expect(perimeter(stacked, outline, false)).toBe(true);
+      // STEP clears stackPrint before the resolver runs, so a stored radius the
+      // resolver would convert to an outline counts as a perimeter again.
+      expect(perimeter({ ...stacked, cornerRadius: mm(40) }, undefined, false)).toBe(true);
     });
 
     // It runs the resolver rather than restating its rules, so this walks a
@@ -626,10 +631,15 @@ describe('drawer outline handling', () => {
     expect(result.paddingLeft).toBe(5);
   });
 
-  it('strips the outline under stack printing (uniform rectangular tiles)', () => {
+  it('keeps the outline under stack printing so shaped tiles stack (#3113)', () => {
     const stored = { ...storedBase, stackPrint: { enabled: true, gapMm: mm(0.2) } };
     const result = buildFullParams(stored, 10, 8, 42, 'end', 'end', undefined, outline);
-    expect(result.outline).toBeUndefined();
+    // The shape survives (composed with padding), same as the non-stack path —
+    // the tiles dedupe by fingerprint downstream so identical ones still stack.
+    expect(result.outline).toBeDefined();
+    // Magnets and solid floor still strip under stacking (the flip bridges them).
+    expect(result.magnetHoles).toBe(false);
+    expect(result.solidFloor).toBe(false);
   });
 
   it('emits no outline when the drawer has none', () => {
@@ -701,6 +711,59 @@ describe('drawer outline handling', () => {
       expect(b.cx).toBeCloseTo(171 / 2, 6);
       expect(b.cy).toBeCloseTo(175 / 2, 6);
     });
+  });
+});
+
+// #3113: a shaped, larger-than-bed plate under stacking used to have its outline
+// dropped, so it tiled as a rectangle and reported the confusing "single plate /
+// nothing to stack" warning. With the outline kept, the shape tiles and its
+// identical tiles stack while the unique perimeter tiles print singly.
+describe('shaped stacking splits into stackable tiles (#3113)', () => {
+  const U = 42;
+  const zeroPadStacked = {
+    magnetHoles: true,
+    magnetDiameter: mm(6.5),
+    magnetDepth: mm(2.4),
+    paddingLeft: mm(0),
+    paddingRight: mm(0),
+    paddingFront: mm(0),
+    paddingBack: mm(0),
+    stackPrint: { enabled: true, gapMm: mm(0.2), copies: 1 },
+  };
+  // 8×8 plate with the top-right 2×2-cell corner notched out — the notch lands
+  // wholly inside the top-right 4×4 tile, so the other three tiles stay full
+  // squares that share a fingerprint (they stack), while the notched tile is
+  // unique (prints singly).
+  const notched: DrawerOutline = {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: 8 * U, y: 0 },
+      { x: 8 * U, y: 6 * U },
+      { x: 6 * U, y: 6 * U },
+      { x: 6 * U, y: 8 * U },
+      { x: 0, y: 8 * U },
+    ],
+  };
+
+  it('keeps the shape, so interior tiles stack and the notched tile prints singly', () => {
+    const params = buildFullParams(zeroPadStacked, 8, 8, U, 'end', 'end', undefined, notched);
+    expect(params.outline).toBeDefined();
+
+    // 8u plate on a 4u bed → a 2×2 grid of 4u tiles; the notch clips the top-right one.
+    const tiling = computeBaseplateTiling(params, 4 * U, 4 * U);
+    expect(tiling.isSplit).toBe(true);
+    // Exactly one tile is partial (carries a window origin); the rest are full squares.
+    const partial = tiling.pieces.filter((p) => p.outlineWindowOriginMm !== undefined);
+    expect(partial).toHaveLength(1);
+
+    // The three full tiles share a fingerprint → a stackable group of ≥2.
+    const groups = groupPiecesByFingerprint(tiling.pieces, params);
+    const maxGroup = Math.max(...[...groups.values()].map((g) => g.indices.length));
+    expect(maxGroup).toBeGreaterThanOrEqual(2);
+
+    // Status agrees: a real tower forms, not the spurious "nothing to stack".
+    const stackGroups = stackGroupsFromTiling(tiling, params, 1);
+    expect(evaluateStackPrint(stackGroups, 8, 5, 250)).toEqual({ kind: 'ok' });
   });
 });
 

--- a/src/features/baseplate/utils/buildFullParams.ts
+++ b/src/features/baseplate/utils/buildFullParams.ts
@@ -50,10 +50,13 @@ export function maxCornerRadiusMm(totalW: number, totalD: number): number {
  * The inputs the outline resolution depends on, derived once.
  *
  * Both `buildFullParams` and {@link hasEffectivePerimeter} read these, so the
- * rules for which dimensions apply, whether the drawer shape is in play, and
- * whether stacking suppresses everything exist in one place. Restating them
- * per caller is what let the panel and the regeneration trigger disagree about
- * radius-cut plates once already.
+ * rules for which dimensions apply and whether the drawer shape is in play exist
+ * in one place. Restating them per caller is what let the panel and the
+ * regeneration trigger disagree about radius-cut plates once already.
+ *
+ * A custom drawer shape now applies under stacking too (#3113): the shaped tiles
+ * split and dedupe by fingerprint like any others, so identical tiles stack.
+ * Only the radius→outline conversion stays stacking-gated (see `resolveOutlineRaw`).
  */
 function outlineInputs(
   stored: StoredBaseplateParams,
@@ -70,7 +73,7 @@ function outlineInputs(
   return {
     synced,
     stackingOn,
-    outlineOn: drawerOutline !== undefined && synced && !stackingOn,
+    outlineOn: drawerOutline !== undefined && synced,
     widthMm: width * gridUnitMm,
     depthMm: depth * gridUnitMmY,
   };
@@ -87,9 +90,11 @@ function outlineInputs(
  * made outlines from large radii, which showed the whole-cell control on plates
  * the trigger considered rectangular.
  *
- * `stackingOverride` exists for the one caller that needs a different answer:
- * the panel keeps controls live for a STEP export, which clears `stackPrint`
- * before this resolver ever runs.
+ * A drawer shape is a perimeter under stacking too (#3113); only the
+ * radius→outline conversion stays stacking-gated. `stackingOverride` still
+ * flips that gate for the one caller that needs it: the panel keeps rounding
+ * controls live for a STEP export, which clears `stackPrint` before this
+ * resolver ever runs, so its plate really is radius-shaped.
  */
 export function hasEffectivePerimeter(
   stored: StoredBaseplateParams,
@@ -109,15 +114,15 @@ export function hasEffectivePerimeter(
     drawerOutline
   );
   const stacking = stackingOverride ?? inputs.stackingOn;
-  if (stacking) return false;
   return (
     resolveOutline(
       drawerOutline,
-      drawerOutline !== undefined && inputs.synced,
+      inputs.outlineOn,
       stored,
       inputs.widthMm,
       inputs.depthMm,
-      gridUnitMm
+      gridUnitMm,
+      stacking
     ).outline !== undefined
   );
 }
@@ -138,9 +143,18 @@ function resolveOutline(
   stored: StoredBaseplateParams,
   widthMm: number,
   depthMm: number,
-  gridUnitMm: number
+  gridUnitMm: number,
+  stacking: boolean
 ): { outline: DrawerOutline | undefined; paddingOn: boolean } {
-  const resolved = resolveOutlineRaw(drawerOutline, outlineOn, stored, widthMm, depthMm, gridUnitMm);
+  const resolved = resolveOutlineRaw(
+    drawerOutline,
+    outlineOn,
+    stored,
+    widthMm,
+    depthMm,
+    gridUnitMm,
+    stacking
+  );
   if (resolved.outline === undefined) return resolved;
 
   // Re-base the plate's grid onto the perimeter. Since the pen editor auto-grows
@@ -172,7 +186,8 @@ function resolveOutlineRaw(
   stored: StoredBaseplateParams,
   widthMm: number,
   depthMm: number,
-  gridUnitMm: number
+  gridUnitMm: number,
+  stacking: boolean
 ): { outline: DrawerOutline | undefined; paddingOn: boolean } {
   if (outlineOn && drawerOutline !== undefined) {
     // The authoring echo is a round-trip hint, never trusted blindly: only
@@ -219,10 +234,16 @@ function resolveOutlineRaw(
     };
   }
 
-  // No active drawer shape: corner radii beyond the plain rounding limit
-  // become a radius-cut outline, so the generator's cell classification
-  // handles the sockets the arc consumes (the plain path must never orphan a
-  // pocket, which is why it clamps at the limit).
+  // No active drawer shape. Under stacking, corner rounding is stripped rather
+  // than converted to a radius-cut outline — a flipped rounded corner tile would
+  // differ from the interior tiles it should stack with — so no perimeter is
+  // derived from a large radius here. A user-authored drawer shape above is still
+  // honoured while stacking (#3113); only this rounding conversion stays gated.
+  if (stacking) return { outline: undefined, paddingOn: true };
+
+  // Corner radii beyond the plain rounding limit become a radius-cut outline, so
+  // the generator's cell classification handles the sockets the arc consumes (the
+  // plain path must never orphan a pocket, which is why it clamps at the limit).
   const radii = stored.cornerRadii ?? {
     tl: stored.cornerRadius ?? 0,
     tr: stored.cornerRadius ?? 0,
@@ -263,13 +284,15 @@ function resolveOutlineRaw(
  *
  * @param drawerOutline - The drawer's non-rectangular boundary, if any.
  * Applied only when the baseplate syncs with the layout (a custom-size plate
- * has no defined relationship to the drawer shape) and stack printing is off
- * (stacking needs uniform rectangular tiles). Padding composes with every
- * shape — corner-cut shapes re-inscribe their cuts on the padded rectangle,
- * all others offset their edges outward (`padOutline`) — so the resolved
- * outline is plate-local over the padded extent. Corner rounding and detached
- * margins are outline-unaware, so while a shape is active they are functionally
- * zeroed, stored values untouched (the stack-print stripping precedent).
+ * has no defined relationship to the drawer shape). Under stacking the shape is
+ * kept too (#3113): the shaped tiles split, dedupe by fingerprint, and stack —
+ * identical tiles into towers, unique perimeter tiles printed singly. Padding
+ * composes with every shape — corner-cut shapes re-inscribe their cuts on the
+ * padded rectangle, all others offset their edges outward (`padOutline`) — so
+ * the resolved outline is plate-local over the padded extent. Corner rounding
+ * and detached margins are outline-unaware, so while a shape is active they are
+ * functionally zeroed, stored values untouched (the stack-print stripping
+ * precedent).
  */
 export function buildFullParams(
   stored: StoredBaseplateParams,
@@ -297,17 +320,26 @@ export function buildFullParams(
   // Stack printing flips every plate above the bottom upside down. Magnet
   // pockets become downward bridges when flipped (audited ~10% bridge area, vs
   // 0% for a magnet-free plate), and corner rounding makes corner tiles differ
-  // from the rest, so both are stripped. Dovetail connectors survive: tongues,
-  // grooves, and the dovetail key are full-height vertical prisms that flip
-  // cleanly. Only snap clip is incompatible — its blind top pocket (sealed
-  // floor + undercut ledge) inverts into a downward bridge/overhang — so it
-  // alone is stripped. Done here rather than by mutating stored params, so the
-  // user's settings return intact when stacking is turned off.
+  // from the rest, so both are stripped. A custom drawer perimeter is NOT
+  // stripped (#3113): its tiles split and dedupe by fingerprint, so identical
+  // ones still stack into towers while the unique perimeter tiles print singly.
+  // Dovetail connectors survive: tongues, grooves, and the dovetail key are
+  // full-height vertical prisms that flip cleanly. Only snap clip is
+  // incompatible — its blind top pocket (sealed floor + undercut ledge) inverts
+  // into a downward bridge/overhang — so it alone is stripped. Done here rather
+  // than by mutating stored params, so the user's settings return intact when
+  // stacking is turned off.
   const stripConnectors = stackingOn && stored.connectorStyle === 'snapClip';
 
-  const { outline, paddingOn } = stackingOn
-    ? { outline: undefined, paddingOn: true }
-    : resolveOutline(drawerOutline, outlineOn, stored, outlineWidthMm, outlineDepthMm, gridUnitMm);
+  const { outline, paddingOn } = resolveOutline(
+    drawerOutline,
+    outlineOn,
+    stored,
+    outlineWidthMm,
+    outlineDepthMm,
+    gridUnitMm,
+    stackingOn
+  );
   // An outline carries its own corner geometry as arcs and shares the same
   // post-cache intersect slot, so rounding is zeroed whenever one is active —
   // whether it came from the drawer shape or from the radius conversion above.

--- a/src/features/baseplate/utils/buildFullParams.ts
+++ b/src/features/baseplate/utils/buildFullParams.ts
@@ -54,9 +54,11 @@ export function maxCornerRadiusMm(totalW: number, totalD: number): number {
  * in one place. Restating them per caller is what let the panel and the
  * regeneration trigger disagree about radius-cut plates once already.
  *
- * A custom drawer shape now applies under stacking too (#3113): the shaped tiles
- * split and dedupe by fingerprint like any others, so identical tiles stack.
- * Only the radius→outline conversion stays stacking-gated (see `resolveOutlineRaw`).
+ * A custom drawer shape (and a large corner radius, which the resolver converts
+ * to a radius-cut outline) applies under stacking too (#3113): the shaped tiles
+ * split and dedupe by fingerprint like any others. An unsplit rounded/shaped
+ * plate stacks whole; a split one stacks its identical (square interior) tiles
+ * while unique perimeter tiles print singly.
  */
 function outlineInputs(
   stored: StoredBaseplateParams,
@@ -90,11 +92,9 @@ function outlineInputs(
  * made outlines from large radii, which showed the whole-cell control on plates
  * the trigger considered rectangular.
  *
- * A drawer shape is a perimeter under stacking too (#3113); only the
- * radius→outline conversion stays stacking-gated. `stackingOverride` still
- * flips that gate for the one caller that needs it: the panel keeps rounding
- * controls live for a STEP export, which clears `stackPrint` before this
- * resolver ever runs, so its plate really is radius-shaped.
+ * Stacking-independent since #3113: both a drawer shape and a large-radius
+ * conversion now yield a perimeter whether or not stacking is on, so the panel,
+ * trigger and STEP export all read the same answer without an override.
  */
 export function hasEffectivePerimeter(
   stored: StoredBaseplateParams,
@@ -102,8 +102,7 @@ export function hasEffectivePerimeter(
   drawerDepth: number,
   gridUnitMm: number,
   drawerOutline: DrawerOutline | undefined,
-  gridUnitMmY: number = gridUnitMm,
-  stackingOverride?: boolean
+  gridUnitMmY: number = gridUnitMm
 ): boolean {
   const inputs = outlineInputs(
     stored,
@@ -113,7 +112,6 @@ export function hasEffectivePerimeter(
     gridUnitMmY,
     drawerOutline
   );
-  const stacking = stackingOverride ?? inputs.stackingOn;
   return (
     resolveOutline(
       drawerOutline,
@@ -121,8 +119,7 @@ export function hasEffectivePerimeter(
       stored,
       inputs.widthMm,
       inputs.depthMm,
-      gridUnitMm,
-      stacking
+      gridUnitMm
     ).outline !== undefined
   );
 }
@@ -143,18 +140,9 @@ function resolveOutline(
   stored: StoredBaseplateParams,
   widthMm: number,
   depthMm: number,
-  gridUnitMm: number,
-  stacking: boolean
+  gridUnitMm: number
 ): { outline: DrawerOutline | undefined; paddingOn: boolean } {
-  const resolved = resolveOutlineRaw(
-    drawerOutline,
-    outlineOn,
-    stored,
-    widthMm,
-    depthMm,
-    gridUnitMm,
-    stacking
-  );
+  const resolved = resolveOutlineRaw(drawerOutline, outlineOn, stored, widthMm, depthMm, gridUnitMm);
   if (resolved.outline === undefined) return resolved;
 
   // Re-base the plate's grid onto the perimeter. Since the pen editor auto-grows
@@ -186,8 +174,7 @@ function resolveOutlineRaw(
   stored: StoredBaseplateParams,
   widthMm: number,
   depthMm: number,
-  gridUnitMm: number,
-  stacking: boolean
+  gridUnitMm: number
 ): { outline: DrawerOutline | undefined; paddingOn: boolean } {
   if (outlineOn && drawerOutline !== undefined) {
     // The authoring echo is a round-trip hint, never trusted blindly: only
@@ -234,16 +221,13 @@ function resolveOutlineRaw(
     };
   }
 
-  // No active drawer shape. Under stacking, corner rounding is stripped rather
-  // than converted to a radius-cut outline — a flipped rounded corner tile would
-  // differ from the interior tiles it should stack with — so no perimeter is
-  // derived from a large radius here. A user-authored drawer shape above is still
-  // honoured while stacking (#3113); only this rounding conversion stays gated.
-  if (stacking) return { outline: undefined, paddingOn: true };
-
-  // Corner radii beyond the plain rounding limit become a radius-cut outline, so
-  // the generator's cell classification handles the sockets the arc consumes (the
-  // plain path must never orphan a pocket, which is why it clamps at the limit).
+  // No active drawer shape: corner radii beyond the plain rounding limit become
+  // a radius-cut outline, so the generator's cell classification handles the
+  // sockets the arc consumes (the plain path must never orphan a pocket, which is
+  // why it clamps at the limit). This runs under stacking too (#3113): the rounded
+  // perimeter survives instead of being flattened, so an unsplit rounded plate
+  // stacks whole and a split one stacks its square interior tiles (the four rounded
+  // corner tiles are each unique and print singly, like any perimeter tile).
   const radii = stored.cornerRadii ?? {
     tl: stored.cornerRadius ?? 0,
     tr: stored.cornerRadius ?? 0,
@@ -319,10 +303,13 @@ export function buildFullParams(
 
   // Stack printing flips every plate above the bottom upside down. Magnet
   // pockets become downward bridges when flipped (audited ~10% bridge area, vs
-  // 0% for a magnet-free plate), and corner rounding makes corner tiles differ
-  // from the rest, so both are stripped. A custom drawer perimeter is NOT
-  // stripped (#3113): its tiles split and dedupe by fingerprint, so identical
-  // ones still stack into towers while the unique perimeter tiles print singly.
+  // 0% for a magnet-free plate), so magnets are stripped. A custom perimeter is
+  // NOT stripped (#3113) — nor is a large corner radius, which the resolver turns
+  // into a radius-cut outline: the shaped tiles split and dedupe by fingerprint,
+  // so identical ones stack into towers (an unsplit rounded plate stacks whole)
+  // while the unique perimeter tiles print singly. Only plain rounding within the
+  // corner cell — a small radius the resolver leaves as `cornerRadius` rather than
+  // an outline — is stripped, via `roundingOn` below.
   // Dovetail connectors survive: tongues, grooves, and the dovetail key are
   // full-height vertical prisms that flip cleanly. Only snap clip is
   // incompatible — its blind top pocket (sealed floor + undercut ledge) inverts
@@ -337,8 +324,7 @@ export function buildFullParams(
     stored,
     outlineWidthMm,
     outlineDepthMm,
-    gridUnitMm,
-    stackingOn
+    gridUnitMm
   );
   // An outline carries its own corner geometry as arcs and shares the same
   // post-cache intersect slot, so rounding is zeroed whenever one is active —


### PR DESCRIPTION
Fixes #3113.

## Summary

Vertical stack printing now keeps the **custom drawer perimeter** — and **rounded corners** — instead of silently dropping them and stacking a plain rectangle (which produced a confusing "nothing to stack" warning).

## How

The tower-baking / preview / export machinery is already **`meshBounds`-driven and shape-agnostic**, and the keystone PR (#3123) made the split/fingerprint pipeline outline-aware — so a Z-translated tower of a shaped tile "just works." The breakage was that `buildFullParams` force-dropped the outline (and converted-radius outline) under stacking, and two hooks didn't pass the outline. So:

- `buildFullParams`: stop dropping the outline under stacking (`outlineOn` no longer gated on `!stackingOn`), and remove the `resolveOutlineRaw` gate that stripped the **large-radius → radius-cut outline** conversion under stacking. `hasEffectivePerimeter` is now **stacking-independent** (a drawer shape or large radius yields a perimeter whether or not stacking is on) — its vestigial `stackingOverride` param is gone, and `panelState` no longer passes `stackEnabled` into it. A **small** radius (plain rounding, no outline) is still stripped under stacking via `roundingOn`.
- `panelState`: `outlineActive` / `perimeterShaped` no longer suppressed by `stackEnabled`, so the panel shows the shape and surfaces the whole-cell control for a large-radius stacking plate too.
- `StackedBaseplateMeshes` + `useStackPrintStatus`: pass `drawer.outline` into `buildFullParams` so their fingerprint grouping matches the shaped tiles generation produces.

## Behavior (accurate)

- An **unsplit** rounded/shaped plate stacks whole (rounded corners preserved).
- A **split** (larger-than-bed) plate stacks its **identical square interior** tiles into towers, while the **shaped perimeter tiles** (incl. the four rounded-corner tiles) print **singly** — each is a distinct shape, and shaped tilings force `placementRotationDeg: 0`, so opposite corners are not mesh-shared. The rounded shape is preserved throughout; the corners simply don't stack *with each other*. (Making opposite corners share a tower would be a separate rotation-aware-fingerprint feature.)

## Scope notes (flagged, not newly broken)
- The corner-**radius control** in `BaseSection` is still hidden while stacking, so a radius is set with stacking off, then stacking enabled — same pattern as other stacking-hidden controls. Surfacing it under stacking is a small follow-up if wanted.

## Test plan

- [x] `pnpm run typecheck` (rebased on merged perf PR — composes cleanly)
- [x] `buildFullParams.test.ts`: large radius (R40/R60) now **keeps** its radius-cut outline under stacking; small radius (R10) still stripped; new `interior tiles stack, rounded corners print singly` integration (12×12 R60 on a 4u bed → 4 singleton corner tiles + one group of 5 interior squares); resolver self-consistency matrix green
- [x] `panelState` / `DimensionsSection` (whole-cell control appears for a large radius while stacking); `useStackPrintStatus` (distinct partial tiles → `singlePlate`); `buildBaseplateExportPieces` (shaped split → 2 towers)
- [x] Real-WASM `baseplateGenerator.scenario.outline` (16): manifold-valid radius-cut mesh (the rounded tiles the towers stack)
- [x] Reproduce proven: re-inserting the gate fails the flipped assertions

No new i18n strings.