### PR TITLE
fix(baseplate): show the corner-radius control while stacking

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseSection.test.tsx
@@ -43,6 +43,18 @@ describe('BaseSection', () => {
     render(<BaseSection />);
     expect(screen.getByText('baseplate.magnetHoles')).toBeInTheDocument();
     expect(screen.getByText('baseplate.solidFloor')).toBeInTheDocument();
+    expect(screen.getByText('baseplate.cornerRadius')).toBeInTheDocument();
+  });
+
+  it('shows the corner-radius control while stacking, since a radius shapes the tiles (#3113)', () => {
+    useLayoutStore.getState().setBaseplateParams({
+      ...DEFAULT_BASEPLATE_PARAMS,
+      stackPrint: { enabled: true, copies: 2, gapMm: mm(0.2) },
+    });
+    render(<BaseSection />);
+    expect(screen.getByText('baseplate.cornerRadius')).toBeInTheDocument();
+    // Magnets are still stripped (and hidden) while stacking.
+    expect(screen.queryByText('baseplate.magnetHoles')).not.toBeInTheDocument();
   });
 
   it('toggling magnet holes writes through to the layout store', () => {
@@ -119,11 +131,29 @@ describe('BaseSection', () => {
     });
   });
 
-  it('renders nothing when stacking hides every control and the plate is unsplit', () => {
+  it('renders nothing when stacking + unsplit + a drawn shape hides even the radius control', () => {
     useLayoutStore.getState().setBaseplateParams({
       ...DEFAULT_BASEPLATE_PARAMS,
       stackPrint: { enabled: true, copies: 2, gapMm: mm(0.2) },
     });
+    // A drawn outline makes the plate shaped, so the corner-radius control hides
+    // too (the shape carries its own corners) — leaving the section empty.
+    useLayoutStore.setState((s) => ({
+      layout: {
+        ...s.layout,
+        drawer: {
+          ...s.layout.drawer,
+          outline: {
+            vertices: [
+              { x: 0, y: 0 },
+              { x: 100, y: 0 },
+              { x: 100, y: 80 },
+              { x: 0, y: 80 },
+            ],
+          },
+        },
+      },
+    }));
     const { container } = render(<BaseSection />);
     expect(container).toBeEmptyDOMElement();
   });

--- a/src/features/baseplate/components/BaseplatePanel/BaseSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseSection.tsx
@@ -1,8 +1,9 @@
 /**
  * Section 3 of the baseplate panel: connectors (when split), magnet holes,
- * solid floor, and corner radius. While stacking, magnets and corner rounding
+ * solid floor, and corner radius. While stacking, magnets and the solid floor
  * are stripped so they hide, but connectors stay reachable (dovetail styles
- * stack fine); the group only renders when it still has content, so it never
+ * stack fine) and corner rounding stays too — a radius now shapes the stacked
+ * tiles (#3113). The group only renders when it still has content, so it never
  * shows as an empty collapsible group.
  */
 
@@ -58,7 +59,10 @@ export function BaseSection() {
   const tiling = useBaseplatePageStore((s) => s.tiling);
   const nozzleSizeMm = useSettingsStore((s) => s.settings.printSettings.nozzleSizeMm);
 
-  if (!(tiling?.isSplit || !stackEnabled)) return null;
+  // Render when the section has any content: connectors (split), magnets/floor
+  // (not stacking), or the corner-radius control (no drawn shape) — which now
+  // shows under stacking too, since a radius shapes the stacked tiles (#3113).
+  if (!(tiling?.isSplit || !stackEnabled || !outlineActive)) return null;
 
   return (
     <StickyGroupHeader
@@ -219,38 +223,39 @@ export function BaseSection() {
                 }
               />
             </div>
-            {/* Corner rounding is zeroed whenever an outline is active
-                (the shape carries its own corners), so show the control
-                only for an unshaped rectangular plate. */}
-            {!outlineActive && (
-              <div className="border-t border-stroke-subtle pt-3">
-                <CornerRadiusControl
-                  cornerRadius={baseplateParams.cornerRadius}
-                  cornerRadii={baseplateParams.cornerRadii}
-                  // Geometric max (up to a pill shape), floored to the
-                  // slider's 0.5 step. Radii beyond the plain rounding
-                  // limit become a radius-cut outline downstream, which
-                  // trims or drops the sockets the arc consumes.
-                  maxRadius={Math.max(
-                    0,
-                    Math.floor(maxCornerRadiusMm(totalWidthMm, totalDepthMm) * 2) / 2
-                  )}
-                  onUniformChange={(r) => {
-                    updateParam('cornerRadius', mm(r));
-                    updateParam('cornerRadii', undefined);
-                  }}
-                  onPerCornerChange={(radii) => {
-                    updateParam('cornerRadii', {
-                      tl: mm(radii.tl),
-                      tr: mm(radii.tr),
-                      bl: mm(radii.bl),
-                      br: mm(radii.br),
-                    });
-                  }}
-                />
-              </div>
-            )}
           </>
+        )}
+        {/* Corner rounding is zeroed whenever an outline is active (the shape
+            carries its own corners), so show the control only for an unshaped
+            plate — including while stacking, where a radius now shapes the
+            stacked tiles (#3113) rather than being stripped. */}
+        {!outlineActive && (
+          <div className="border-t border-stroke-subtle pt-3">
+            <CornerRadiusControl
+              cornerRadius={baseplateParams.cornerRadius}
+              cornerRadii={baseplateParams.cornerRadii}
+              // Geometric max (up to a pill shape), floored to the slider's 0.5
+              // step. Radii beyond the plain rounding limit become a radius-cut
+              // outline downstream, which trims or drops the sockets the arc
+              // consumes.
+              maxRadius={Math.max(
+                0,
+                Math.floor(maxCornerRadiusMm(totalWidthMm, totalDepthMm) * 2) / 2
+              )}
+              onUniformChange={(r) => {
+                updateParam('cornerRadius', mm(r));
+                updateParam('cornerRadii', undefined);
+              }}
+              onPerCornerChange={(radii) => {
+                updateParam('cornerRadii', {
+                  tl: mm(radii.tl),
+                  tr: mm(radii.tr),
+                  bl: mm(radii.bl),
+                  br: mm(radii.br),
+                });
+              }}
+            />
+          </div>
         )}
       </div>
     </StickyGroupHeader>

--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -415,7 +415,7 @@ describe('BaseplatePanel', () => {
     describe('while vertical stacking', () => {
       const stacking = { enabled: true, gapMm: mm(0.2) };
 
-      it('keeps the connector picker reachable but hides magnets and corner radius', () => {
+      it('keeps the connector picker and corner radius reachable but hides magnets', () => {
         mockLayoutState.layout.baseplateParams = {
           ...DEFAULT_BASEPLATE_PARAMS,
           connectorNubs: true,
@@ -426,7 +426,8 @@ describe('BaseplatePanel', () => {
           screen.getByRole('radio', { name: 'baseplate.connectorStyle.dovetail' })
         ).toBeChecked();
         expect(screen.queryByText('baseplate.magnetHoles')).toBeNull();
-        expect(screen.queryByText('baseplate.cornerRadius')).toBeNull();
+        // A radius now shapes the stacked tiles (#3113), so the control stays.
+        expect(screen.getByText('baseplate.cornerRadius')).toBeInTheDocument();
       });
 
       it('disables the snap clip option with a reason', () => {


### PR DESCRIPTION
Follow-up to #3128 (shaped/rounded vertical stacking).

## Why

Now that a corner radius **shapes the stacked tiles** (#3113) instead of being stripped, the corner-radius control shouldn't be hidden while stacking — otherwise you'd have to toggle stacking off, set the radius, and toggle it back on.

## Change

- Move `CornerRadiusControl` out of the `!stackEnabled` block in `BaseSection` (still gated on no drawn shape, `!outlineActive`, which keys on the user-drawn outline — not the radius-cut outline — so it stays visible while you adjust a radius).
- Relax the section's empty-group early-return (`return null`) so it renders when the radius control has content (stacking + unsplit + no drawn shape). Magnets and solid floor remain stacking-hidden.

## Test plan

- [x] `pnpm run typecheck`
- [x] `BaseSection.test.tsx`: new "shows the corner-radius control while stacking (magnets still hidden)"; the "renders nothing" case updated to require a drawn shape (which hides even the radius control)
- [x] `BaseplatePanel.test.tsx`: flipped the "hides magnets and corner radius while stacking" assertion — radius now reachable
- [x] full `BaseplatePanel` suite (166) green

No new i18n strings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the corner-radius control visible while stacking, since the radius now shapes stacked tiles. BaseSection also renders when the radius control is the only content; magnets and solid floor stay hidden while stacking.

- **Bug Fixes**
  - Moved `CornerRadiusControl` outside the `!stackEnabled` block; still gated by `!outlineActive`.
  - Relaxed the section’s early return to render when the radius control has content.
  - Updated tests in `BaseSection.test.tsx` and `BaseplatePanel.test.tsx`; full panel suite passes.

<sup>Written for commit d2a0b0d701ace7216950961140ff8c10e0f7a606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

