### PR TITLE
test: consolidate i18n mocks onto the shared i18nEcho

### DIFF
--- a/src/core/sync/useSyncToasts.test.ts
+++ b/src/core/sync/useSyncToasts.test.ts
@@ -19,9 +19,7 @@ vi.mock('./engine', () => ({
   },
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function emitEngineEvent(event: EngineEvent): void {
   for (const cb of onEngineEventListeners) cb(event);

--- a/src/features/baseplate/components/ActiveBaseplatePanel/ActiveBaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/ActiveBaseplatePanel/ActiveBaseplatePanel.test.tsx
@@ -36,9 +36,7 @@ vi.mock('@/core/store/view', () => ({
     selector({ setShowBaseplateLibrary: mocks.setShowBaseplateLibrary }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('ActiveBaseplatePanel', () => {
   beforeEach(() => {

--- a/src/features/baseplate/components/BaseplatePage/BaseplatePage.test.tsx
+++ b/src/features/baseplate/components/BaseplatePage/BaseplatePage.test.tsx
@@ -4,9 +4,7 @@ import { BaseplatePage } from './BaseplatePage';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
 
 // Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Mock responsive hook
 const mocks = vi.hoisted(() => ({

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.test.tsx
@@ -2,9 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ConnectorPicker } from './ConnectorPicker';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('ConnectorPicker', () => {
   it('renders a radio for every connector style', () => {

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorSampleButton.test.tsx
@@ -3,12 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ConnectorSampleButton } from './ConnectorSampleButton';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation:
-    () =>
-    (key: string): string =>
-      key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const downloadSample = vi.fn().mockResolvedValue(true);
 let canExport = true;

--- a/src/features/baseplate/components/BaseplatePanel/CornerRadiusControl.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/CornerRadiusControl.test.tsx
@@ -2,12 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { CornerRadiusControl } from './CornerRadiusControl';
 
-vi.mock('@/i18n', () => ({
-  useTranslation:
-    () =>
-    (key: string): string =>
-      key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('CornerRadiusControl', () => {
   it('shows only the uniform control when not in per-corner mode', () => {

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.test.tsx
@@ -3,19 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { SplitViewStrip } from './SplitViewStrip';
 import type { BaseplateTiling } from '../../types/tiling';
 
-vi.mock('@/i18n', () => ({
-  useTranslation:
-    () =>
-    (key: string, params?: Record<string, unknown>): string => {
-      if (params) {
-        return Object.entries(params).reduce(
-          (str, [k, v]) => str.replace(`{${k}}`, String(v)),
-          key
-        );
-      }
-      return key;
-    },
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const basePieceFields = {
   paddingLeft: 0,

--- a/src/features/baseplate/components/BaseplatePanel/StackSampleButton.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/StackSampleButton.test.tsx
@@ -3,12 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { StackSampleButton } from './StackSampleButton';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation:
-    () =>
-    (key: string): string =>
-      key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const downloadSample = vi.fn().mockResolvedValue(true);
 let canExport = true;

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.test.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.test.tsx
@@ -81,9 +81,7 @@ vi.mock('@/core/store', () => ({
   useSettingsStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({ settings: { baseplateFilamentColor: '#d4d8dc' } }),
 }));
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Mock internal modules
 vi.mock('../../store/baseplatePageStore', () => ({

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.test.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.test.tsx
@@ -8,9 +8,7 @@ vi.mock('@/shared/hooks/useResponsive', () => ({
   useResponsive: () => ({ isDesktop: true, isTouchDevice: false }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('../../store/baseplatePageStore', () => ({}));
 

--- a/src/features/baseplate/components/BaseplateSelector/BaseplateSelector.test.tsx
+++ b/src/features/baseplate/components/BaseplateSelector/BaseplateSelector.test.tsx
@@ -49,9 +49,7 @@ vi.mock('@/core/store/toast', () => ({
   useToastStore: (selector: (s: unknown) => unknown) => selector({ addToast: mocks.addToast }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const nameButton = () => screen.getByText('Baseplate 1');
 const nameInput = () => screen.getByLabelText('baseplate.library.namePrompt');

--- a/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.test.tsx
+++ b/src/features/baseplate/components/PaddingAnchor/PaddingAnchor.test.tsx
@@ -2,9 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { PaddingAnchor } from './PaddingAnchor';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('PaddingAnchor', () => {
   it('renders nine radio buttons in a radiogroup', () => {

--- a/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
@@ -4,12 +4,7 @@ import { useConnectorSampleExport } from './useConnectorSampleExport';
 import { triggerDownload } from '@/shared/generation/exportUtils';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation:
-    () =>
-    (key: string): string =>
-      key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 let activeBridge: unknown = null;
 vi.mock('@/shared/generation/bridge', () => ({

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutBoardSettings.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutBoardSettings.test.tsx
@@ -2,9 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CutoutBoardSettings } from './CutoutBoardSettings';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const baseProps = {
   gridSize: 0.5,

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutColorControls.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutColorControls.test.tsx
@@ -2,9 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { CutoutColorControls } from './CutoutColorControls';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_CUTOUT_COLOR } from '@/features/bin-designer/constants/defaults';
 import type { Cutout } from '@/features/bin-designer/types';

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.test.tsx
@@ -49,9 +49,7 @@ vi.mock('@/design-system', async () => ({
   ),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function makeCutout(overrides: Partial<Cutout> = {}): Cutout {
   return {

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -4,9 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { InspectorContent } from './InspectorContent';
 import type { Cutout } from '@/features/bin-designer/types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Mirrors the real input's commit clamp (CompactNumberInput.tsx `clampTyped`).
 // A pass-through mock would report 156 whether or not `softMax` is wired, so the

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorDock.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorDock.test.tsx
@@ -4,9 +4,7 @@ import { InspectorDock } from './InspectorDock';
 import type { Cutout } from '@/features/bin-designer/types';
 import { loadInspectorCollapsed } from './inspectorDockStorage';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('./InspectorContent', () => ({
   InspectorContent: () => <div data-testid="inspector-content" />,

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.test.tsx
@@ -3,9 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { WorkspaceHeader } from './WorkspaceHeader';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/features/bin-designer/store', () => ({
   useDesignerStore: vi.fn(),

--- a/src/features/bin-designer/components/DesignerPage/FractionalEdgeMismatchBanner.test.tsx
+++ b/src/features/bin-designer/components/DesignerPage/FractionalEdgeMismatchBanner.test.tsx
@@ -4,9 +4,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FractionalEdgeMismatchBanner } from './FractionalEdgeMismatchBanner';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('FractionalEdgeMismatchBanner', () => {
   it('renders the warning and match-drawer action', () => {

--- a/src/features/bin-designer/components/ExampleGallery/Example3DViewer.test.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/Example3DViewer.test.tsx
@@ -5,9 +5,7 @@ import { render, screen } from '@testing-library/react';
 import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
 import { Example3DViewer } from './Example3DViewer';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/features/bin-designer/data/examples/meshes', () => ({
   meshUrl: (id: string) => (id === 'with-mesh' ? '/bundled/with-mesh.glb' : undefined),

--- a/src/features/bin-designer/components/ExampleGallery/ExampleCard.test.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/ExampleCard.test.tsx
@@ -5,9 +5,7 @@ import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
 import { ExampleCard } from './ExampleCard';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const example: ExampleDesign = {
   id: 'custom-l-shape',

--- a/src/features/bin-designer/components/ExampleGallery/ExamplePreviewOverlay.test.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/ExamplePreviewOverlay.test.tsx
@@ -4,9 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
 import { ExamplePreviewOverlay } from './ExamplePreviewOverlay';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('./Example3DViewer', () => ({
   Example3DViewer: () => <div data-testid="example-3d-viewer" />,

--- a/src/features/bin-designer/components/ExampleGallery/TechniqueFilterPills.test.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/TechniqueFilterPills.test.tsx
@@ -4,9 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import type { ExampleDesign } from '@/features/bin-designer/types/exampleGallery';
 import { TechniqueFilterPills } from './TechniqueFilterPills';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const examples = [
   { techniques: ['scoop'] },

--- a/src/features/bin-designer/components/controls/LabelSizeControl/LabelSizeControl.test.tsx
+++ b/src/features/bin-designer/components/controls/LabelSizeControl/LabelSizeControl.test.tsx
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 import { LabelSizeControl } from './LabelSizeControl';
 

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.test.tsx
@@ -6,9 +6,7 @@ import { DEFAULT_SETTINGS } from '@/core/store/settings.types';
 import { makeUniformLipCells } from '@/features/bin-designer/types/featureColors';
 import type { FeatureColorConfig } from '@/features/bin-designer/types/featureColors';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/design-system/Popover/Popover', () => ({
   Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsHintBanner.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsHintBanner.test.tsx
@@ -4,9 +4,7 @@ import { ColorsHintBanner } from './ColorsHintBanner';
 import { useSettingsStore } from '@/core/store';
 import { DEFAULT_SETTINGS } from '@/core/store/settings.types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('ColorsHintBanner', () => {
   beforeEach(() => {

--- a/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.test.tsx
@@ -4,7 +4,7 @@ import { LipColorEditor } from './LipColorEditor';
 import { makeUniformLipCells } from '@/features/bin-designer/types/featureColors';
 import type { LipColorConfig } from '@/features/bin-designer/types/featureColors';
 
-vi.mock('@/i18n', () => ({ useTranslation: () => (key: string) => key }));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function lip(corners: 1 | 2 | 4, bands: 1 | 2 | 4): LipColorConfig {
   return { corners, bands, cells: makeUniformLipCells('#d4d8dc') };

--- a/src/features/bin-designer/components/panel/ColorsSection/LipGridDiagram.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/LipGridDiagram.test.tsx
@@ -4,7 +4,7 @@ import { LipGridDiagram } from './LipGridDiagram';
 import { makeUniformLipCells } from '@/features/bin-designer/types/featureColors';
 import type { LipColorConfig } from '@/features/bin-designer/types/featureColors';
 
-vi.mock('@/i18n', () => ({ useTranslation: () => (key: string) => key }));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function lip(corners: 1 | 2 | 4, bands: 1 | 2 | 4): LipColorConfig {
   return { corners, bands, cells: makeUniformLipCells('#d4d8dc') };

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.test.tsx
@@ -5,9 +5,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import { CutoutEditor } from './CutoutEditor';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/design-system', async () => ({
   ...(await vi.importActual<typeof DesignSystem>('@/design-system')),

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutFitControls.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutFitControls.test.tsx
@@ -4,9 +4,7 @@ import { CutoutFitControls } from './CutoutFitControls';
 import { hasFitControls } from './cutoutSectionVisibility';
 import type { Cutout } from '@/features/bin-designer/types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function makeCutout(overrides: Partial<Cutout> = {}): Cutout {
   return {

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutPresetChips.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutPresetChips.test.tsx
@@ -3,9 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { CutoutPresetChips } from './CutoutPresetChips';
 import type { CutoutSizePreset } from './cutoutShapePresets';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const PRESETS: CutoutSizePreset[] = [
   { id: 'a', label: '1/4" hex bit (6.35mm)', mm: 6.35 },

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.test.tsx
@@ -4,9 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import type { Cutout } from '@/features/bin-designer/types';
 import { CutoutPropertyPanel } from './CutoutPropertyPanel';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/design-system', async () => ({
   ...(await vi.importActual<typeof DesignSystem>('@/design-system')),

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeBadge.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeBadge.test.tsx
@@ -3,9 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { CutoutShapeBadge } from './CutoutShapeBadge';
 import type { Cutout } from '@/features/bin-designer/types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function c(overrides: Partial<Cutout> = {}): Cutout {
   return {

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeControls.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeControls.test.tsx
@@ -4,9 +4,7 @@ import { CutoutShapeControls } from './CutoutShapeControls';
 import { hasShapeControls } from './cutoutSectionVisibility';
 import type { Cutout } from '@/features/bin-designer/types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function makeCutout(overrides: Partial<Cutout> = {}): Cutout {
   return {

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeToolbar.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeToolbar.test.tsx
@@ -3,9 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { CutoutShapeToolbar } from './CutoutShapeToolbar';
 import type { InteractionMode } from './useCutoutInteraction';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('CutoutShapeToolbar', () => {
   const idleMode: InteractionMode = { type: 'idle' };

--- a/src/features/bin-designer/components/panel/CutoutsSection/scanImport/ScanWithPhoneDialog.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/scanImport/ScanWithPhoneDialog.test.tsx
@@ -27,9 +27,7 @@ vi.mock('@/core/store/toast', () => ({
     selector({ addToast: mockAddToast }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/useSvgImport.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/useSvgImport.test.ts
@@ -23,9 +23,7 @@ vi.mock('@/core/store/toast', () => ({
     selector({ addToast: mockAddToast }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const mockTrackEvent = vi.fn();
 vi.mock('@/shared/analytics/posthog', () => ({

--- a/src/features/bin-designer/components/panel/FeatureToggle/FeatureToggle.test.tsx
+++ b/src/features/bin-designer/components/panel/FeatureToggle/FeatureToggle.test.tsx
@@ -2,9 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { FeatureToggle } from './FeatureToggle';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('FeatureToggle', () => {
   it('renders label text', () => {

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.test.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.test.tsx
@@ -18,9 +18,7 @@ vi.mock('../../SlotConfigurator/SlotConfigurator', () => ({
 }));
 
 // Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Mock store
 vi.mock('@/features/bin-designer/store', () => ({

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelFitSampleButton.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelFitSampleButton.test.tsx
@@ -3,12 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { LabelFitSampleButton } from './LabelFitSampleButton';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation:
-    () =>
-    (key: string): string =>
-      key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const downloadSample = vi.fn().mockResolvedValue(true);
 let canExport = true;

--- a/src/features/bin-designer/hooks/useLabelFitSampleExport.test.ts
+++ b/src/features/bin-designer/hooks/useLabelFitSampleExport.test.ts
@@ -4,12 +4,7 @@ import { useLabelFitSampleExport } from './useLabelFitSampleExport';
 import { triggerDownload } from '@/shared/generation/exportUtils';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation:
-    () =>
-    (key: string): string =>
-      key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 let activeBridge: unknown = null;
 vi.mock('@/shared/generation/bridge', () => ({

--- a/src/features/cloud-share/components/ShareButton/DeleteShareConfirm.test.tsx
+++ b/src/features/cloud-share/components/ShareButton/DeleteShareConfirm.test.tsx
@@ -2,9 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DeleteShareConfirm } from './DeleteShareConfirm';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('DeleteShareConfirm', () => {
   it('renders the trigger button by default', () => {

--- a/src/features/cloud-share/components/ShareButton/ShareButton.test.tsx
+++ b/src/features/cloud-share/components/ShareButton/ShareButton.test.tsx
@@ -28,9 +28,7 @@ vi.mock('@/shared/hooks/useCollabMode', () => ({
   useCollabMode: () => ({ isCollaborative: false }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/shared/utils/slug', () => ({
   slugify: (str: string) => str.toLowerCase().replace(/\s+/g, '-'),

--- a/src/features/cloud-share/components/ShareButton/ShareLinkSection.test.tsx
+++ b/src/features/cloud-share/components/ShareButton/ShareLinkSection.test.tsx
@@ -2,9 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ShareLinkSection } from './ShareLinkSection';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const baseProps = {
   shareUrl: 'https://example.test/l/abc/test',

--- a/src/features/cloud-share/components/ShareButton/SharePopover.test.tsx
+++ b/src/features/cloud-share/components/ShareButton/SharePopover.test.tsx
@@ -10,9 +10,7 @@ vi.mock('@/shared/hooks/useCollabMode', () => ({
   useCollabMode: () => ({ isCollaborative: false }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/shared/utils/slug', () => ({
   slugify: (str: string) => str.toLowerCase().replace(/\s+/g, '-'),

--- a/src/features/community/components/CommunityCard/CommunityCard.test.tsx
+++ b/src/features/community/components/CommunityCard/CommunityCard.test.tsx
@@ -8,9 +8,7 @@ import { loadPendingLikeAction } from '@/shared/utils/communityPendingLikeAction
 import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
 import { CommunityCard } from './CommunityCard';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('../../api/client', () => ({
   setDesignLiked: vi.fn(),

--- a/src/features/community/components/CommunityDetail/DirectRemixList.test.tsx
+++ b/src/features/community/components/CommunityDetail/DirectRemixList.test.tsx
@@ -11,9 +11,7 @@ import { fetchCommunityIndex } from '../../api/client';
 import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
 import { DirectRemixList } from './DirectRemixList';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('../../api/client', async (importOriginal) => {
   const actual = await importOriginal<object>();

--- a/src/features/community/components/CommunityDetail/SimilarRail.test.tsx
+++ b/src/features/community/components/CommunityDetail/SimilarRail.test.tsx
@@ -13,9 +13,7 @@ import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
 import { SIMILAR_DESIGNS_MAX } from '../../utils/similarDesigns';
 import { SimilarRail } from './SimilarRail';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('../../api/client', async (importOriginal) => {
   const actual = await importOriginal<object>();

--- a/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.test.tsx
@@ -13,9 +13,7 @@ import { fetchCommunityIndex } from '../../api/client';
 import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
 import { CommunityGalleryTab, GALLERY_PAGE_SIZE } from './CommunityGalleryTab';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),

--- a/src/features/community/components/CommunityGalleryTab/CommunityTechniquePills.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityTechniquePills.test.tsx
@@ -5,9 +5,7 @@ import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
 import { ALL_TECHNIQUES } from './galleryFilterOptions';
 import { CommunityTechniquePills } from './CommunityTechniquePills';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('CommunityTechniquePills', () => {
   it('renders the full static technique enum plus an All pill', () => {

--- a/src/features/community/components/CommunityGalleryTab/FilterSheet.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/FilterSheet.test.tsx
@@ -5,9 +5,7 @@ import { ALL_TECHNIQUES } from './galleryFilterOptions';
 import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
 import { FilterSheet } from './FilterSheet';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 beforeEach(() => {
   useBrowseStore.setState({ ...INITIAL_BROWSE_STATE });

--- a/src/features/community/components/CommunityGalleryTab/GalleryToolbar.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/GalleryToolbar.test.tsx
@@ -6,9 +6,7 @@ import { ALL_TECHNIQUES } from './galleryFilterOptions';
 import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
 import { GalleryToolbar } from './GalleryToolbar';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const responsiveMock = vi.hoisted(() => ({ isMobile: false }));
 vi.mock('@/shared/hooks/useResponsive', () => ({

--- a/src/features/community/components/CommunityPage/CommunityPage.test.tsx
+++ b/src/features/community/components/CommunityPage/CommunityPage.test.tsx
@@ -11,9 +11,7 @@ import type { CommunityCard } from '@/shared/types/community';
 import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
 import { CommunityPage } from './CommunityPage';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('../CommunityGalleryTab', () => ({
   CommunityGalleryTab: ({ surface }: { surface?: string }) => (

--- a/src/features/community/components/ReportDialog/ReportDialog.test.tsx
+++ b/src/features/community/components/ReportDialog/ReportDialog.test.tsx
@@ -5,9 +5,7 @@ import { ok, err } from '@/core/result';
 import { INITIAL_TOAST_STATE, useToastStore } from '@/core/store/toast';
 import { ReportDialog } from './ReportDialog';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('../../api/client', () => ({
   reportDesign: vi.fn(),

--- a/src/features/community/components/SignInPrompt/CommunitySignInPrompt.test.tsx
+++ b/src/features/community/components/SignInPrompt/CommunitySignInPrompt.test.tsx
@@ -11,9 +11,7 @@ import {
 } from '@/shared/utils/communityReturnPath';
 import { CommunitySignInPrompt } from './CommunitySignInPrompt';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Hash URLs keep jsdom quiet: assigning location.href to a hash change is
 // implemented, a full navigation is not.

--- a/src/features/community/hooks/useLikeToggle.test.ts
+++ b/src/features/community/hooks/useLikeToggle.test.ts
@@ -15,9 +15,7 @@ vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 import { setDesignLiked } from '../api/client';
 import { trackEvent } from '@/shared/analytics/posthog';

--- a/src/features/engagement/useEngagementNudges.test.ts
+++ b/src/features/engagement/useEngagementNudges.test.ts
@@ -19,9 +19,7 @@ vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 import { useToastStore } from '@/core/store/toast';
 import { shouldShowNudge } from './engagementTracker';

--- a/src/features/engagement/useLayoutPromotion.test.ts
+++ b/src/features/engagement/useLayoutPromotion.test.ts
@@ -37,9 +37,7 @@ vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/shared/utils', () => ({
   // Raw literal rather than STAGING_ID: vi.mock factories are hoisted above

--- a/src/features/grid-editor/components/Grid/Bin/BinOverhangExtension.test.tsx
+++ b/src/features/grid-editor/components/Grid/Bin/BinOverhangExtension.test.tsx
@@ -8,7 +8,7 @@ import { createTestBin } from '@/test/testUtils';
 import { gridUnits, heightUnits, mm } from '@/core/types';
 import type { Bin, Drawer, StoredBaseplateParams } from '@/core/types';
 
-vi.mock('@/i18n', () => ({ useTranslation: () => (key: string) => key }));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const DRAWER: Drawer = { width: gridUnits(5), depth: gridUnits(4), height: heightUnits(6) };
 

--- a/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerMargin/DrawerMargin.test.tsx
@@ -7,9 +7,7 @@ import { createDefaultLayout } from '@/core/constants';
 import { mm } from '@/core/types';
 import type { StoredBaseplateParams } from '@/core/types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function setPadding(padding: Partial<StoredBaseplateParams>): void {
   const layout = createDefaultLayout();

--- a/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerOutlineOverlay/DrawerOutlineOverlay.test.tsx
@@ -4,9 +4,7 @@ import { useLayoutStore } from '@/core/store';
 import { resetAllStores } from '@/test/testUtils';
 import { gridUnits } from '@/core/types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 import type { DrawerOutline } from '@/core/types';
 import { DrawerOutlineOverlay } from './DrawerOutlineOverlay';
 

--- a/src/features/grid-editor/components/Grid/DrawerResizeHandles/DrawerResizeHandles.test.tsx
+++ b/src/features/grid-editor/components/Grid/DrawerResizeHandles/DrawerResizeHandles.test.tsx
@@ -4,9 +4,7 @@ import { resetAllStores } from '@/test/testUtils';
 import { DrawerResizeHandles } from './DrawerResizeHandles';
 
 // Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('DrawerResizeHandles', () => {
   const mockOnResizeStart = vi.fn();

--- a/src/features/grid-editor/components/Grid/IsometricPreview/BananaScale/BananaScale.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/BananaScale/BananaScale.test.tsx
@@ -126,9 +126,7 @@ vi.mock('three', () => {
 });
 
 // Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('BananaScale', () => {
   beforeEach(() => {

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.test.tsx
@@ -202,9 +202,7 @@ vi.mock('@/shared/hooks/use3DPreviewKeyboard', () => ({
   use3DPreviewKeyboard: vi.fn(),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // useTranslation is mocked to echo keys, so the layer-mode buttons carry their
 // raw i18n key as the title attribute.

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreviewControls.test.tsx
@@ -3,9 +3,7 @@ import { render } from '@testing-library/react';
 import { IsometricPreviewControls } from './IsometricPreviewControls';
 import type { Layer } from '@/core/types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const defaultProps = {
   sceneRef: { current: null },

--- a/src/features/grid-editor/components/Grid/IsometricPreview/Scene/Scene.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/Scene/Scene.test.tsx
@@ -184,9 +184,7 @@ vi.mock('three', () => {
 });
 
 // Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('Scene', () => {
   beforeEach(() => {

--- a/src/features/grid-editor/components/Grid/Overlay/Overlay.test.tsx
+++ b/src/features/grid-editor/components/Grid/Overlay/Overlay.test.tsx
@@ -7,9 +7,7 @@ import { createDefaultLayout, STAGING_ID } from '@/core/constants';
 import { binId, gridUnits, heightUnits } from '@/core/types';
 
 // Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('Overlay', () => {
   beforeEach(() => {

--- a/src/features/grid-editor/components/Grid/QuickLabelPopover/QuickLabelPopover.test.tsx
+++ b/src/features/grid-editor/components/Grid/QuickLabelPopover/QuickLabelPopover.test.tsx
@@ -8,9 +8,7 @@ import { createDefaultLayout } from '@/core/constants';
 import { binId, gridUnits, heightUnits } from '@/core/types';
 
 // Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Mock mutations
 vi.mock('@/shared/contexts', () => ({

--- a/src/features/labs/components/EngineSelector/EngineSelector.test.tsx
+++ b/src/features/labs/components/EngineSelector/EngineSelector.test.tsx
@@ -5,9 +5,7 @@ import { useLabsStore, useToastStore } from '@/core/store';
 import { trackEvent } from '@/shared/analytics/posthog/trackEvent';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/shared/analytics/posthog/trackEvent', () => ({
   trackEvent: vi.fn(),

--- a/src/features/labs/components/LabsButton/LabsButton.test.tsx
+++ b/src/features/labs/components/LabsButton/LabsButton.test.tsx
@@ -27,9 +27,7 @@ vi.mock('../icons', () => ({
   ),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('LabsButton', () => {
   beforeEach(() => {

--- a/src/features/labs/components/LabsDrawer/LabsDrawer.test.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.test.tsx
@@ -70,9 +70,7 @@ vi.mock('../icons', () => ({
   CloseIcon: ({ className }: { className?: string }) => <div className={className}>Close</div>,
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function mockLabsStore(
   overrides: {

--- a/src/features/layout-library/components/LayoutManagerModal/NewLayoutCard/NewLayoutCard.test.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/NewLayoutCard/NewLayoutCard.test.tsx
@@ -2,9 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { NewLayoutCard } from './NewLayoutCard';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('NewLayoutCard', () => {
   const mockOnCreate = vi.fn();

--- a/src/features/layout-library/components/LayoutManagerModal/ViewModeToggle/ViewModeToggle.test.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/ViewModeToggle/ViewModeToggle.test.tsx
@@ -39,9 +39,7 @@ vi.mock('@/shared/components', () => ({
   ),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('ViewModeToggle', () => {
   const mockOnChange = vi.fn();

--- a/src/features/scan-capture/components/CardSizeEditor/CardSizeEditor.test.tsx
+++ b/src/features/scan-capture/components/CardSizeEditor/CardSizeEditor.test.tsx
@@ -3,9 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { CardSizeEditor } from './CardSizeEditor';
 import { DEFAULT_CARD_SIZE } from '@/features/scan-capture/cardSize';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 function setup(size = DEFAULT_CARD_SIZE) {
   const onChange = vi.fn();

--- a/src/features/scan-capture/components/ScanPage/ScanPage.test.tsx
+++ b/src/features/scan-capture/components/ScanPage/ScanPage.test.tsx
@@ -29,9 +29,7 @@ vi.mock('@/shared/scanTrace', () => ({
   CARD_HEIGHT_MM: 53.98,
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const TOKEN = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
 const IMAGE = { width: 24, height: 20, data: new Uint8ClampedArray(24 * 20 * 4) };

--- a/src/features/supporters/components/SupportersPage/SupportersPage.test.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.test.tsx
@@ -7,9 +7,7 @@ import { KOFI_URL } from '@/shared/constants/links';
 import supportersData from '../../data/supporters.json';
 import { FALLBACK_SUPPORTERS, type SupportersData } from '../../utils/supportersData';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),

--- a/src/shared/components/ExperimentalBadge/ExperimentalBadge.test.tsx
+++ b/src/shared/components/ExperimentalBadge/ExperimentalBadge.test.tsx
@@ -2,9 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ExperimentalBadge } from './ExperimentalBadge';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('ExperimentalBadge', () => {
   it('renders the experimental label', () => {

--- a/src/shared/components/FeatureToggle/FeatureToggle.test.tsx
+++ b/src/shared/components/FeatureToggle/FeatureToggle.test.tsx
@@ -2,9 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { FeatureToggle } from './FeatureToggle';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('FeatureToggle', () => {
   it('renders label text', () => {

--- a/src/shared/components/GlbViewer/GlbViewer.test.tsx
+++ b/src/shared/components/GlbViewer/GlbViewer.test.tsx
@@ -41,9 +41,7 @@ vi.mock('@react-three/drei', () => ({
   useProgress: () => ({ active: true, progress: 40, errors: [], item: '', loaded: 2, total: 5 }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const reducedMotion = vi.hoisted(() => ({ value: false }));
 vi.mock('@/shared/hooks/usePrefersReducedMotion', () => ({

--- a/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.test.tsx
+++ b/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.test.tsx
@@ -3,9 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { HeaderSupportLinks } from './HeaderSupportLinks';
 
 // Mock i18n
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Mock LanguageSelector
 vi.mock('@/shared/components/LanguageSelector', () => ({

--- a/src/shared/hooks/useCommunityLikeReturn.test.ts
+++ b/src/shared/hooks/useCommunityLikeReturn.test.ts
@@ -29,9 +29,7 @@ vi.mock('@/features/community/api/client', () => ({
   setDesignLiked: vi.fn(),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),

--- a/src/shared/hooks/useIndexedDBRecovery.test.ts
+++ b/src/shared/hooks/useIndexedDBRecovery.test.ts
@@ -33,9 +33,7 @@ vi.mock('@/core/store/toast', () => ({
   INITIAL_TOAST_STATE: {},
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- dynamic import bound late via vi.resetModules()
 let storage: typeof import('@/core/storage');

--- a/src/shell/Mobile/BinContextMenuDesignSection/BinContextMenuDesignSection.test.tsx
+++ b/src/shell/Mobile/BinContextMenuDesignSection/BinContextMenuDesignSection.test.tsx
@@ -18,9 +18,7 @@ vi.mock('@/features/design-linking', () => ({
   useLinkingStore: () => vi.fn(),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('BinContextMenuDesignSection', () => {
   beforeEach(() => {

--- a/src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.test.tsx
+++ b/src/shell/Mobile/MobileCategoriesPanel/MobileCategoriesPanel.test.tsx
@@ -7,9 +7,7 @@ vi.mock('@/shared/components/ConfirmDialog', () => ({
   ConfirmDialog: () => <div data-testid="confirm-dialog" />,
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('MobileCategoriesPanel', () => {
   beforeEach(() => {

--- a/src/shell/Mobile/MobileGridToolbar/MobileGridToolbar.test.tsx
+++ b/src/shell/Mobile/MobileGridToolbar/MobileGridToolbar.test.tsx
@@ -3,9 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { MobileGridToolbar } from './MobileGridToolbar';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('MobileGridToolbar', () => {
   beforeEach(() => {

--- a/src/shell/Mobile/MobileHeader/MobileHeader.test.tsx
+++ b/src/shell/Mobile/MobileHeader/MobileHeader.test.tsx
@@ -2,9 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MobileHeader } from './MobileHeader';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/core/store/layout', () => ({
   useLayoutStore: (selector: (state: Record<string, unknown>) => unknown) =>

--- a/src/shell/Mobile/MobileInspector/MobileInspector.test.tsx
+++ b/src/shell/Mobile/MobileInspector/MobileInspector.test.tsx
@@ -21,9 +21,7 @@ vi.mock('@/features/bin-inspector', () => ({
   EmptyState: () => <div data-testid="empty-state" />,
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('MobileInspector', () => {
   beforeEach(() => {

--- a/src/shell/Mobile/MobileLayersPanel/TabBar/TabBar.test.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/TabBar/TabBar.test.tsx
@@ -3,9 +3,7 @@ import { render } from '@testing-library/react';
 import { TabBar } from './TabBar';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('TabBar', () => {
   beforeEach(() => {

--- a/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.test.tsx
+++ b/src/shell/Mobile/MobileLayersPanel/ToolsTab/ToolsTab.test.tsx
@@ -3,9 +3,7 @@ import { render } from '@testing-library/react';
 import { ToolsTab } from './ToolsTab';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('ToolsTab', () => {
   beforeEach(() => {

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileCloudSharePanel.test.tsx
@@ -4,9 +4,7 @@ import { MobileCloudSharePanel } from './MobileCloudSharePanel';
 import { resetAllStores } from '@/test/testUtils';
 import * as cloudShareHook from '@/features/cloud-share/hooks/useCloudShare';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const baseHook = {
   status: 'idle' as const,

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsListItem.test.tsx
@@ -5,9 +5,7 @@ import { resetAllStores } from '@/test/testUtils';
 import type { LayoutEntry } from '@/core/types';
 import { gridUnits, heightUnits, layoutId } from '@/core/types';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 beforeEach(() => {
   resetAllStores();

--- a/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.test.tsx
+++ b/src/shell/Mobile/MobileLayoutsPanel/MobileLayoutsPanelParts.test.tsx
@@ -9,9 +9,7 @@ import {
 } from './MobileLayoutsPanelParts';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 beforeEach(() => {
   resetAllStores();

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.test.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.test.tsx
@@ -2,9 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MobileSettingsPanel } from './MobileSettingsPanel';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/core/store/settings', () => {
   const state = {

--- a/src/shell/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/src/shell/Modals/SettingsModal/SettingsModal.test.tsx
@@ -8,9 +8,7 @@ vi.mock('@/shared/hooks', () => ({
   useResponsive: () => ({ isMobile: false, isTablet: false, isDesktop: true }),
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('./TabNavigation/TabNavigation', () => ({
   TabNavigation: ({

--- a/src/shell/Modals/SettingsModal/TabNavigation/TabNavigation.test.tsx
+++ b/src/shell/Modals/SettingsModal/TabNavigation/TabNavigation.test.tsx
@@ -10,9 +10,7 @@ vi.mock('@/shared/hooks', () => ({
 }));
 
 // Mock useTranslation
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 // Derive from the source of truth so adding/removing a tab doesn't require a
 // manual bump here (tabDefinitions.test.ts asserts the exact expected set).

--- a/src/shell/Modals/SettingsModal/components/SettingSection/SettingSection.test.tsx
+++ b/src/shell/Modals/SettingsModal/components/SettingSection/SettingSection.test.tsx
@@ -8,9 +8,7 @@ const mockUpdateSettings = vi.hoisted(() => vi.fn());
 const mockAddToast = vi.hoisted(() => vi.fn());
 const mockSettings = vi.hoisted(() => ({ theme: 'dark', accentColor: 'amber' }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('@/core/store', () => ({
   useSettingsStore: Object.assign(() => undefined, {

--- a/src/shell/Modals/SettingsModal/tabs/AccessibilityTab/AccessibilityTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/AccessibilityTab/AccessibilityTab.test.tsx
@@ -9,9 +9,7 @@ const mockState = vi.hoisted(() => ({
   distinguishCategoriesByPattern: false,
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('zustand/react/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/src/shell/Modals/SettingsModal/tabs/AppearanceTab/AppearanceTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/AppearanceTab/AppearanceTab.test.tsx
@@ -10,9 +10,7 @@ const mockState = vi.hoisted(() => ({
   uiDensity: 'default',
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('zustand/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/src/shell/Modals/SettingsModal/tabs/CategoriesTab/CategoriesTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/CategoriesTab/CategoriesTab.test.tsx
@@ -10,9 +10,7 @@ const mockState = vi.hoisted(() => ({
   hasCustomBinDefault: false,
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('zustand/react/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.test.tsx
@@ -11,9 +11,7 @@ const mockDrawerState = vi.hoisted(() => ({
   hasCustomCategoryDefaults: false,
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('zustand/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/src/shell/Modals/SettingsModal/tabs/IntegrationsTab/IntegrationsTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/IntegrationsTab/IntegrationsTab.test.tsx
@@ -5,9 +5,7 @@ import { IntegrationsTab } from './IntegrationsTab';
 
 const mockUpdateSetting = vi.hoisted(() => vi.fn());
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('zustand/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.test.tsx
@@ -14,9 +14,7 @@ const mockFeatures = vi.hoisted(() => ({
   ] as Array<{ id: string; titleKey: string; descriptionKey: string }>,
 }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('zustand/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/src/shell/Modals/SettingsModal/tabs/PrintTab/PrintTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/PrintTab/PrintTab.test.tsx
@@ -5,9 +5,7 @@ import { PrintTab } from './PrintTab';
 
 const mockUpdateSetting = vi.hoisted(() => vi.fn());
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('zustand/react/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/src/shell/Modals/SettingsModal/tabs/PrivacyTab/PrivacyTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/PrivacyTab/PrivacyTab.test.tsx
@@ -10,9 +10,7 @@ const mockPruneAnalytics = vi.hoisted(() => vi.fn());
 const mockIsTrackingOptOut = vi.hoisted(() => vi.fn(() => false));
 const mockState = vi.hoisted(() => ({ analyticsEnabled: true }));
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 vi.mock('zustand/shallow', () => ({
   useShallow: (fn: unknown) => fn,

--- a/src/shell/Modals/SettingsModal/tabs/StorageTab/StorageTab.test.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/StorageTab/StorageTab.test.tsx
@@ -3,9 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StorageTab } from './StorageTab';
 import type { StorageInfo } from './useStorageInfo';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const mockUseStorageInfo = vi.hoisted(() => vi.fn());
 

--- a/src/shell/Tablet/TabletPanelTriggers/TabletPanelTriggers.test.tsx
+++ b/src/shell/Tablet/TabletPanelTriggers/TabletPanelTriggers.test.tsx
@@ -3,9 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { TabletPanelTriggers } from './TabletPanelTriggers';
 import { resetAllStores } from '@/test/testUtils';
 
-vi.mock('@/i18n', () => ({
-  useTranslation: () => (key: string) => key,
-}));
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 describe('TabletPanelTriggers', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Tech-debt cleanup: ~107 test files defined their own local `vi.mock('@/i18n', …)` key-echo mock. Consolidate the behaviorally-equivalent ones onto the shared `src/test/mocks/i18nEcho.ts`:

    vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));

**Test-only, zero runtime change.** 113 files, +146 / −432.

## Careful, not blanket

- **Swapped 107** files whose local mock was output-identical to `i18nEcho` (plain `(key) => key`, or the same interpolation `reduce` — translation *keys* never contain literal `{param}` placeholders, so the echo is identical).
- **Left ~51** where the local mock genuinely differs and a test relies on it: param interpolation into a distinct asserted string, key-specific/conditional translated copy, or extra i18n exports `i18nEcho` doesn't provide (`useLocale`, `getStaticTranslation`, `useFormatting`, `SUPPORTED_LOCALES`, …). Each documented in the commit.
- `i18nEcho` unchanged — no extension needed.

## Test plan

- [x] `pnpm run typecheck`
- [x] Full touched set: **709 tests passed**, identical before/after (verified by stash-and-compare). The 2 non-loading suites (`MobileCategoriesPanel`, `MobileSettingsPanel`) fail identically pre-change — a worktree `?url`-WASM `server.fs` artifact, not this change; they run fine in CI's clean checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated duplicate `@/i18n` test mocks to the shared echo mock `@/test/mocks/i18nEcho` to reduce noise and keep tests consistent. Test-only change with no runtime impact.

- **Refactors**
  - Replaced local `vi.mock('@/i18n', ...)` in 100+ tests with `vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'))`.
  - Kept custom mocks where tests need special behavior or extra i18n exports (e.g., `useLocale`, `getStaticTranslation`, `SUPPORTED_LOCALES`).
  - `i18nEcho` is unchanged; all affected tests pass with identical results.

<sup>Written for commit 175c91332bd3b0247f84fed7204c523ad129b931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

