### PR TITLE
feat(baseplate): share a tower between opposite rounded-corner tiles

### DIFF
--- a/src/features/baseplate/utils/pieceFingerprint.test.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { computePieceFingerprint, groupPiecesByFingerprint } from './pieceFingerprint';
 import { computeBaseplateTiling } from './splitPlanner';
+import { rotateOutline180 } from '@/shared/utils/drawerOutline';
+import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+import type { DrawerOutline } from '@/core/types';
 
 function makeParams(overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams {
   return {
@@ -524,5 +527,88 @@ describe('groupPiecesByFingerprint', () => {
       const plain = makeParams({ width: 4, depth: 4, cornerRadius: 0, edges: interior });
       expect(computePieceFingerprint(padded)).not.toBe(computePieceFingerprint(plain));
     });
+  });
+});
+
+// ─── outline 180° dedup (point-symmetric plates, #3113) ──────────────────────
+// Mirrors the cornerRadii precedent above: a 180°-symmetric shape collapses its
+// opposite corner tiles into shared groups, an asymmetric one keeps them apart.
+describe('outline 180° dedup', () => {
+  const U = 42;
+  // 189mm bed tiles the 8×8 plate 2×2.
+  const BED = 4.5 * U;
+
+  const roundedAll = (r: number): DrawerOutline => ({
+    vertices: cornerCutVertices(8 * U, 8 * U, {
+      tl: { kind: 'radius', r },
+      tr: { kind: 'radius', r },
+      bl: { kind: 'radius', r },
+      br: { kind: 'radius', r },
+    }),
+  });
+
+  const roundedTrOnly = (r: number): DrawerOutline => ({
+    vertices: cornerCutVertices(8 * U, 8 * U, {
+      tl: { kind: 'none' },
+      tr: { kind: 'radius', r },
+      bl: { kind: 'none' },
+      br: { kind: 'none' },
+    }),
+  });
+
+  const shaped = (outline: DrawerOutline): ResolvedBaseplateParams =>
+    makeParams({
+      width: 8,
+      depth: 8,
+      connectorNubs: true,
+      preferIdenticalPieces: true,
+      outline,
+    });
+
+  it('collapses a point-symmetric radius-cut plate: 4 corners → 2 groups', () => {
+    const params = shaped(roundedAll(U));
+    const tiling = computeBaseplateTiling(params, BED);
+    expect(tiling.pieces).toHaveLength(4);
+    const groups = groupPiecesByFingerprint(tiling.pieces, params);
+    expect(groups.size).toBe(2);
+    for (const group of groups.values()) {
+      expect(group.indices).toHaveLength(2);
+    }
+  });
+
+  it('never merges a single rounded corner with its plain 180° opposite (no false dedupe)', () => {
+    const params = shaped(roundedTrOnly(U));
+    const tiling = computeBaseplateTiling(params, BED);
+    expect(tiling.pieces).toHaveLength(4);
+    const groups = groupPiecesByFingerprint(tiling.pieces, params);
+    // The two plain-rectangle corners (TL↔BR) still dedupe as before — that is
+    // the pre-existing preferIdenticalPieces behavior and is correct. The rounded
+    // TR corner must NOT collapse into its plain BL opposite, so it sits alone:
+    // three groups total, with the rounded corner in a singleton group.
+    expect(groups.size).toBe(3);
+    const b2Index = tiling.pieces.findIndex((p) => p.label === 'B2');
+    expect(b2Index).toBeGreaterThanOrEqual(0);
+    const b2Group = [...groups.values()].find((g) => g.indices.includes(b2Index));
+    expect(b2Group?.indices).toEqual([b2Index]);
+  });
+
+  it('hashes a point-symmetric outline equal to its 180° rotation', () => {
+    const P = roundedAll(U);
+    const base = shaped(P);
+    const rotated: ResolvedBaseplateParams = {
+      ...base,
+      outline: rotateOutline180(P, 8 * U, 8 * U),
+    };
+    expect(computePieceFingerprint(rotated)).toBe(computePieceFingerprint(base));
+  });
+
+  it('keeps an asymmetric outline distinct from its 180° rotation', () => {
+    const P = roundedTrOnly(U);
+    const base = shaped(P);
+    const rotated: ResolvedBaseplateParams = {
+      ...base,
+      outline: rotateOutline180(P, 8 * U, 8 * U),
+    };
+    expect(computePieceFingerprint(rotated)).not.toBe(computePieceFingerprint(base));
   });
 });

--- a/src/features/baseplate/utils/pieceFingerprint.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.ts
@@ -8,7 +8,7 @@
 
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { hasAllEdgeSlots } from '@/shared/types/bin';
-import { hashOutline } from '@/shared/utils/drawerOutline';
+import { canonicalStartOutline, hashOutline } from '@/shared/utils/drawerOutline';
 import { exteriorCorners, type CornerKey } from '@/shared/generation/baseplateCorners';
 import type { BaseplatePiece } from '../types/tiling';
 import { pieceToBaseplateParams } from './splitPlanner';
@@ -68,8 +68,14 @@ export function computePieceFingerprint(params: ResolvedBaseplateParams): string
   // unaffected (only generation time); a window-clipped canonical form would
   // need the 2D polygon clipping this design avoids. Fully-inside pieces
   // carry no outline and keep sharing entries with plain rectangles.
+  //
+  // Canonicalize the loop's starting vertex so a point-symmetric outline and its
+  // 180° rotation (the same polygon shifted by n/2) hash equal — the outline is
+  // the only piece field whose 180° rotation isn't already a plain field swap, so
+  // this is what lets opposite corner tiles (whose rotated partner carries the
+  // rotated outline, see pieceToBaseplateParams) collapse into one shared mesh.
   if (params.outline !== undefined) {
-    parts.push(`ol:${hashOutline(params.outline)}`);
+    parts.push(`ol:${hashOutline(canonicalStartOutline(params.outline))}`);
   }
 
   // Edge classification (exterior vs join) affects geometry through two

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -13,7 +13,8 @@ import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { BaseplatePiece } from '../types/tiling';
 import { computePieceFingerprint } from './pieceFingerprint';
 import { outlineFrameOffset } from '@/shared/utils/drawerOutlineGeometry';
-import { translateOutline } from '@/shared/utils/drawerOutline';
+import { rotateOutline180, translateOutline } from '@/shared/utils/drawerOutline';
+import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
 import type { DrawerOutline } from '@/core/types';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
@@ -1755,12 +1756,75 @@ describe('shaped plates (outline-aware splitting)', () => {
     expect(byLabel.get('A1')?.edges.back).toBe('join');
   });
 
-  it('forces placement rotation off for shaped tilings', () => {
+  // Point-symmetric radius cut on all four corners: a 1-unit arc trims each
+  // outer corner cell but leaves every interior seam fully inside, so all four
+  // corner tiles survive as partials and TL↔BR / TR↔BL are 180° rotations.
+  const roundedAll = (r: number): DrawerOutline => ({
+    vertices: cornerCutVertices(8 * U, 8 * U, {
+      tl: { kind: 'radius', r },
+      tr: { kind: 'radius', r },
+      bl: { kind: 'radius', r },
+      br: { kind: 'radius', r },
+    }),
+  });
+
+  // Only the top-right corner rounds — NOT point-symmetric, so opposite corner
+  // tiles are not congruent and must never share a tower.
+  const roundedTrOnly = (r: number): DrawerOutline => ({
+    vertices: cornerCutVertices(8 * U, 8 * U, {
+      tl: { kind: 'none' },
+      tr: { kind: 'radius', r },
+      bl: { kind: 'none' },
+      br: { kind: 'none' },
+    }),
+  });
+
+  it('shares one canonical tower between opposite rounded-corner tiles (point-symmetric)', () => {
     const tiling = computeBaseplateTiling(
-      shapedParams(L_OUTLINE, { preferIdenticalPieces: true }),
+      shapedParams(roundedAll(U), { preferIdenticalPieces: true }),
       BED
     );
-    expect(tiling.pieces.every((p) => p.placementRotationDeg === 0)).toBe(true);
+    expect(tiling.pieces).toHaveLength(4);
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+    const rotated = (l: string): boolean => byLabel.get(l)?.placementRotationDeg === 180;
+    // Each opposite pair gets a canonical 0 / rotated-180 split (A1↔B2, A2↔B1),
+    // so exactly one of each pair carries the rotation.
+    expect(rotated('A1')).not.toBe(rotated('B2'));
+    expect(rotated('A2')).not.toBe(rotated('B1'));
+    expect(tiling.pieces.filter((p) => p.placementRotationDeg === 180)).toHaveLength(2);
+  });
+
+  it('rotates (not merely translates) a 180° piece outline about its window (edit b)', () => {
+    const outline = roundedAll(U);
+    const parent = shapedParams(outline, { preferIdenticalPieces: true });
+    const tiling = computeBaseplateTiling(parent, BED);
+    const rotated = tiling.pieces.find(
+      (p) => p.placementRotationDeg === 180 && p.outlineWindowOriginMm !== undefined
+    );
+    if (rotated === undefined || rotated.outlineWindowOriginMm === undefined) {
+      expect.fail('expected a rotated partial rounded-corner piece');
+    }
+    const { x: ox, y: oy } = rotated.outlineWindowOriginMm;
+    const genParams = pieceToBaseplateParams(rotated, parent);
+    const localUnrotated = translateOutline(outline, -ox, -oy);
+    const windowW = rotated.widthUnits * U + rotated.paddingLeft + rotated.paddingRight;
+    const windowD = rotated.depthUnits * U + rotated.paddingFront + rotated.paddingBack;
+    expect(genParams.outline).toEqual(rotateOutline180(localUnrotated, windowW, windowD));
+  });
+
+  it('keeps opposite tiles of an asymmetric (single-corner) shape distinct', () => {
+    const parent = shapedParams(roundedTrOnly(U), { preferIdenticalPieces: true });
+    const tiling = computeBaseplateTiling(parent, BED);
+    expect(tiling.pieces).toHaveLength(4);
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+    const a1 = byLabel.get('A1'); // BL — plain rectangle
+    const b2 = byLabel.get('B2'); // TR — rounded, partial
+    if (a1 === undefined || b2 === undefined) {
+      expect.fail('expected all four corner tiles to survive');
+    }
+    const a1Fp = computePieceFingerprint(pieceToBaseplateParams(a1, parent));
+    const b2Fp = computePieceFingerprint(pieceToBaseplateParams(b2, parent));
+    expect(a1Fp).not.toBe(b2Fp);
   });
 
   it('measures seam bands with the per-axis pitch on a non-square grid (#2733)', () => {
@@ -1822,7 +1886,10 @@ describe('shaped plates (outline-aware splitting)', () => {
     const W = 9;
     const D = 4;
 
-    const driftedTiling = computeBaseplateTiling(shapedParams(drifted, { width: W, depth: D }), BED);
+    const driftedTiling = computeBaseplateTiling(
+      shapedParams(drifted, { width: W, depth: D }),
+      BED
+    );
     const driftedByLabel = new Map(driftedTiling.pieces.map((p) => [p.label, p]));
     // The extent-anchored left column [0,3U] falls entirely in the empty region
     // and is dropped; only the middle+right pieces survive with a single seam.

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -34,7 +34,7 @@ import type {
 } from '../types/tiling';
 import { estimateBedLoads, type Footprint } from './bedPacking';
 import type { DrawerOutline } from '@/core/types';
-import { translateOutline } from '@/shared/utils/drawerOutline';
+import { rotateOutline180, translateOutline } from '@/shared/utils/drawerOutline';
 import { classifyRect, type RegionClass } from '@/shared/utils/drawerOutlineGeometry';
 import { FRACTIONAL_THRESHOLD, isFractional, reorderForDisplay } from './splitReorder';
 
@@ -938,10 +938,14 @@ export function computeBaseplateTiling(
  * of the whole shared span must be fully inside. Partial seams (and seams to
  * dropped neighbors) become plain butt joints — both facing edges 'exterior'.
  *
- * `placementRotationDeg` is forced to 0: the preferIdenticalPieces 180° mesh
- * sharing pairs opposite corners of a SYMMETRIC tiling, which dropping and
- * reclassification break. Congruent pieces still dedupe via identical
- * fingerprints.
+ * `placementRotationDeg` follows the same palindromic rule the rectangular path
+ * uses, but computed from the RECLASSIFIED edges (partial/dropped seams demote
+ * some joins to exterior first). On a point-symmetric outline this lets opposite
+ * corner tiles (TL↔BR, TR↔BL) share one canonical mesh placed rotated 180° —
+ * their piece-local outlines are 180° rotations of each other, which the
+ * cyclic-start-canonical outline hash (see pieceFingerprint) collapses to one
+ * fingerprint. On a non-symmetric outline the rotated partner's outline differs,
+ * so the fingerprints diverge and the pieces stay single (rotation 0).
  *
  * The outline is plate-local mm over the padded extent (corner-cut shapes
  * compose with padding), so windows are the pieces' padded slab extents:
@@ -1007,6 +1011,10 @@ function applyOutlineToTiling(
     back: [0, 1],
   };
 
+  // Mirrors computeBaseplateTiling: preferIdenticalPieces only engages when
+  // connectors are on (the UI checkbox is hidden otherwise, but the flag persists).
+  const palindromic = !!params.preferIdenticalPieces && !!params.connectorNubs;
+
   const survivors: BaseplatePiece[] = [];
   for (const piece of tiling.pieces) {
     const cls = classAt(piece.col, piece.row);
@@ -1020,11 +1028,15 @@ function applyOutlineToTiling(
       if (neighborDropped || !fullSeam(piece, side)) edges[side] = 'exterior';
     }
 
+    // Canonicalize from the RECLASSIFIED edges: the 180° share only applies once
+    // partial/dropped seams have demoted their joins to exterior.
+    const needs180 = palindromic && edgeKey(edges) > edgeKey(rotateEdges180(edges));
+
     const w = windowOf(piece);
     survivors.push({
       ...piece,
       edges,
-      placementRotationDeg: 0,
+      placementRotationDeg: needs180 ? 180 : 0,
       ...(cls === 'partial' ? { outlineWindowOriginMm: { x: w.x0, y: w.y0 } } : {}),
     });
   }
@@ -1119,15 +1131,30 @@ export function pieceToBaseplateParams(
   // Partial pieces get the plate outline translated into their local frame;
   // the generator's 3D intersect performs the window clip (the piece slab IS
   // the window), so no 2D clipping is needed here. Fully-inside pieces carry
-  // no outline and stay byte-identical to unshaped rectangles.
-  const pieceOutline =
-    parentParams.outline !== undefined && piece.outlineWindowOriginMm !== undefined
-      ? translateOutline(
-          parentParams.outline,
-          -piece.outlineWindowOriginMm.x,
-          -piece.outlineWindowOriginMm.y
-        )
-      : undefined;
+  // no outline and stay byte-identical to unshaped rectangles. Under `rot` the
+  // outline is the ONLY positional field not yet rotated (padding/edges/
+  // fractionalEdge/cornerRadii already are), so rotate it 180° about the window
+  // center. Window extents are rotation-invariant per-axis sums, so they need no
+  // swap. On a point-symmetric outline this lands the rotated partner's local
+  // outline exactly on its canonical mate's (see the cyclic-start fingerprint).
+  const pieceOutline = ((): ResolvedBaseplateParams['outline'] => {
+    if (parentParams.outline === undefined || piece.outlineWindowOriginMm === undefined) {
+      return undefined;
+    }
+    const local = translateOutline(
+      parentParams.outline,
+      -piece.outlineWindowOriginMm.x,
+      -piece.outlineWindowOriginMm.y
+    );
+    if (!rot) return local;
+    const windowW =
+      piece.widthUnits * parentParams.gridUnitMm + piece.paddingLeft + piece.paddingRight;
+    const windowD =
+      piece.depthUnits * (parentParams.gridUnitMmY ?? parentParams.gridUnitMm) +
+      piece.paddingFront +
+      piece.paddingBack;
+    return rotateOutline180(local, windowW, windowD);
+  })();
 
   return {
     width: piece.widthUnits,

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -944,8 +944,10 @@ export function computeBaseplateTiling(
  * corner tiles (TL↔BR, TR↔BL) share one canonical mesh placed rotated 180° —
  * their piece-local outlines are 180° rotations of each other, which the
  * cyclic-start-canonical outline hash (see pieceFingerprint) collapses to one
- * fingerprint. On a non-symmetric outline the rotated partner's outline differs,
- * so the fingerprints diverge and the pieces stay single (rotation 0).
+ * fingerprint. `placementRotationDeg` follows the edge layout, not the outline,
+ * so a non-symmetric piece may still be placed at 180 — but its rotated outline
+ * differs from any partner's, so the fingerprints diverge and it never shares a
+ * tower (it stays in its own group; the rotation only affects placement).
  *
  * The outline is plate-local mm over the padded extent (corner-cut shapes
  * compose with padding), so windows are the pieces' padded slab extents:

--- a/src/features/baseplate/utils/stackPrint.test.ts
+++ b/src/features/baseplate/utils/stackPrint.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { mm } from '@/core/types';
-import type { StackPrintParams } from '@/core/types';
+import type { DrawerOutline, StackPrintParams } from '@/core/types';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
+import { computeBaseplateTiling } from './splitPlanner';
+import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
 import type { BaseplatePiece, BaseplateTiling } from '../types/tiling';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import {
@@ -402,6 +404,35 @@ describe('stackGroupsFromTiling', () => {
     expect(evaluateStackPrint(stackGroupsFromTiling(null, resolvedDefault, 3), 48, 5, 250)).toEqual(
       { kind: 'ok' }
     );
+  });
+
+  it('shares one tower per opposite-corner pair on a point-symmetric shaped plate (#3113)', () => {
+    // A 1-unit radius cut on all four corners of an 8×8 plate makes TL↔BR and
+    // TR↔BL 180° rotations, so the 2×2 split dedupes into two shared towers of
+    // quantity 2 — not four singletons.
+    const U = 42;
+    const outline: DrawerOutline = {
+      vertices: cornerCutVertices(8 * U, 8 * U, {
+        tl: { kind: 'radius', r: U },
+        tr: { kind: 'radius', r: U },
+        bl: { kind: 'radius', r: U },
+        br: { kind: 'radius', r: U },
+      }),
+    };
+    const params: ResolvedBaseplateParams = {
+      ...resolvedDefault,
+      width: 8,
+      depth: 8,
+      connectorNubs: true,
+      preferIdenticalPieces: true,
+      outline,
+    };
+    const tiling = computeBaseplateTiling(params, 4.5 * U);
+    expect(tiling.pieces).toHaveLength(4);
+
+    const groups = stackGroupsFromTiling(tiling, params);
+    expect(groups).toHaveLength(2);
+    expect(groups.every((g) => g.quantity === 2)).toBe(true);
   });
 });
 

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.rotShare.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.rotShare.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment node
+/**
+ * Load-bearing equivariance gate for the opposite-corner tower sharing (#3113).
+ *
+ * A SPLIT baseplate with a point-symmetric custom perimeter lets opposite corner
+ * tiles (TL↔BR, TR↔BL) print from ONE canonical mesh placed rotated 180°. That
+ * is only correct if the WASM generator is 180°-EQUIVARIANT for outline-clipped,
+ * re-based slabs: rotating the canonical tile's mesh 180° must reproduce the
+ * opposite tile's own (single-generation) mesh.
+ *
+ * This test proves it against real OCCT: it generates the canonical tile (A, the
+ * shared mesh source) and the opposite tile rendered singly (B, rotation forced
+ * off), rotates A's mesh 180° about the body center, and asserts the two are
+ * congruent — same triangle count, same enclosed volume, same bounding box, and
+ * the rounded cut lands on the SAME corner (orientation, not just size).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
+import {
+  assertStructurallyValid,
+  boundingBox,
+  meshVolume,
+} from './__kernel-tests__/meshAssertions';
+import {
+  computeBaseplateTiling,
+  pieceToBaseplateParams,
+} from '@/features/baseplate/utils/splitPlanner';
+import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
+import type { MeshData } from '@/features/generation/bridge/types';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+import type { BaseplatePiece } from '@/features/baseplate/types/tiling';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+const NO_OP = (): void => {};
+const U = 42;
+// 189mm bed tiles the 8×8 plate 2×2.
+const BED = 4.5 * U;
+
+const parentParams = (): ResolvedBaseplateParams => ({
+  width: 8,
+  depth: 8,
+  gridUnitMm: U,
+  magnetHoles: false,
+  magnetDiameter: 6.5,
+  magnetDepth: 2.4,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  lightweight: true,
+  connectorNubs: true,
+  preferIdenticalPieces: true,
+  // Point-symmetric: a 1-unit radius trims each outer corner cell, keeping every
+  // interior seam fully inside so all four corner tiles survive as partials.
+  outline: {
+    vertices: cornerCutVertices(8 * U, 8 * U, {
+      tl: { kind: 'radius', r: U },
+      tr: { kind: 'radius', r: U },
+      bl: { kind: 'radius', r: U },
+      br: { kind: 'radius', r: U },
+    }),
+  },
+});
+
+/** 180° rotation about the Z axis through the origin: (x, y, z) → (−x, −y, z). */
+function rotateVertices180Z(vertices: Float32Array): Float32Array {
+  const out = new Float32Array(vertices.length);
+  for (let i = 0; i < vertices.length; i += 3) {
+    out[i] = -vertices[i];
+    out[i + 1] = -vertices[i + 1];
+    out[i + 2] = vertices[i + 2];
+  }
+  return out;
+}
+
+/** Count mesh vertices inside a 2D mesh-frame window (any Z). */
+function countVerticesIn(
+  vertices: Float32Array,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+): number {
+  let count = 0;
+  for (let i = 0; i < vertices.length; i += 3) {
+    const x = vertices[i];
+    const y = vertices[i + 1];
+    if (x > x0 && x < x1 && y > y0 && y < y1) count++;
+  }
+  return count;
+}
+
+describe('baseplate 180° equivariance (opposite-corner tower sharing #3113)', () => {
+  it(
+    'reproduces the opposite rounded corner by rotating the canonical mesh 180°',
+    { timeout: 240_000 },
+    () => {
+      const parent = parentParams();
+      const tiling = computeBaseplateTiling(parent, BED);
+      expect(tiling.pieces).toHaveLength(4);
+
+      const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+      // A1 = bottom-left (canonical, rotation 0); B2 = top-right (its 180° mate).
+      const canonical = byLabel.get('A1');
+      const partner = byLabel.get('B2');
+      if (canonical === undefined || partner === undefined) {
+        expect.fail('expected A1 and B2 corner tiles');
+      }
+      // The shared mesh is generated from the canonical (rotation-0) tile; its
+      // partner is placed rotated 180°. Confirm that pairing before generating.
+      expect(canonical.placementRotationDeg).toBe(0);
+      expect(partner.placementRotationDeg).toBe(180);
+
+      const gen = getGenerateBaseplate();
+      // A: the shared canonical mesh (what the group actually generates).
+      const aParams = pieceToBaseplateParams(canonical, parent);
+      // B: the partner as if it printed singly — rotation forced off so its params
+      // carry its own unrotated outline/edges/padding (the ground-truth geometry).
+      const bTruePiece: BaseplatePiece = { ...partner, placementRotationDeg: 0 };
+      const bParams = pieceToBaseplateParams(bTruePiece, parent);
+
+      const aMesh = gen(aParams, NO_OP, true);
+      const bMesh: MeshData = gen(bParams, NO_OP, true);
+      assertStructurallyValid(aMesh, 'canonical A1');
+      assertStructurallyValid(bMesh, 'true B2');
+
+      // Congruent solids tessellate to the same triangle count and enclose the
+      // same volume regardless of orientation.
+      expect(aMesh.triangleCount).toBe(bMesh.triangleCount);
+      expect(meshVolume(aMesh)).toBeCloseTo(meshVolume(bMesh), 1);
+
+      const rotatedA = rotateVertices180Z(aMesh.vertices);
+
+      // Same footprint after the placement rotation the preview applies.
+      const rbb = boundingBox(rotatedA);
+      const bbb = boundingBox(bMesh.vertices);
+      expect(rbb.minX).toBeCloseTo(bbb.minX, 1);
+      expect(rbb.maxX).toBeCloseTo(bbb.maxX, 1);
+      expect(rbb.minY).toBeCloseTo(bbb.minY, 1);
+      expect(rbb.maxY).toBeCloseTo(bbb.maxY, 1);
+      expect(rbb.minZ).toBeCloseTo(bbb.minZ, 3);
+      expect(rbb.maxZ).toBeCloseTo(bbb.maxZ, 3);
+
+      // Orientation proof: B2's rounded cut sits at the +X/+Y corner (mesh 84,84)
+      // and its solid interior corner at −X/−Y. The window near (84,84) must be
+      // empty and the opposite corner solid — in BOTH the true B2 mesh and the
+      // rotated canonical A1 mesh — so the cut landed on the right corner, not a
+      // mirrored one.
+      const CUT: [number, number, number, number] = [78, 78, 83, 83];
+      const SOLID: [number, number, number, number] = [-83, -83, -78, -78];
+      expect(countVerticesIn(bMesh.vertices, ...CUT)).toBe(0);
+      expect(countVerticesIn(rotatedA, ...CUT)).toBe(0);
+      expect(countVerticesIn(bMesh.vertices, ...SOLID)).toBeGreaterThan(0);
+      expect(countVerticesIn(rotatedA, ...SOLID)).toBeGreaterThan(0);
+    }
+  );
+});

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -4,6 +4,7 @@ import type { DrawerOutline, Layout } from '@/core/types';
 import { gridUnits, mm } from '@/core/types';
 import { createTestLayout } from '@/test/testUtils';
 import {
+  canonicalStartOutline,
   hashOutline,
   normalizeDrawerOutline,
   OUTLINE_MAX_VERTICES,
@@ -256,6 +257,56 @@ describe('hashOutline', () => {
       vertices: L_SHAPE.vertices.map((v) => ({ x: v.x + U, y: v.y })),
     };
     expect(hashOutline(shifted)).not.toBe(hashOutline(L_SHAPE));
+  });
+});
+
+describe('canonicalStartOutline', () => {
+  /** A rectangle chamfered at BL and TR — point-symmetric about its center. */
+  const SYM_CHAMFER: DrawerOutline = {
+    vertices: [
+      { x: U, y: 0 },
+      { x: 4 * U, y: 0 },
+      { x: 4 * U, y: 3 * U },
+      { x: 3 * U, y: 4 * U },
+      { x: 0, y: 4 * U },
+      { x: 0, y: U },
+    ],
+  };
+
+  /** Rotate the vertex list by `k` — same polygon, different starting vertex. */
+  const rotateStart = (outline: DrawerOutline, k: number): DrawerOutline => ({
+    vertices: [...outline.vertices.slice(k), ...outline.vertices.slice(0, k)],
+  });
+
+  it('is invariant to the starting vertex (cyclic shift)', () => {
+    const base = canonicalStartOutline(SYM_CHAMFER);
+    for (let k = 1; k < SYM_CHAMFER.vertices.length; k++) {
+      expect(canonicalStartOutline(rotateStart(SYM_CHAMFER, k)).vertices).toEqual(base.vertices);
+      expect(hashOutline(canonicalStartOutline(rotateStart(SYM_CHAMFER, k)))).toBe(
+        hashOutline(base)
+      );
+    }
+  });
+
+  it('collapses a point-symmetric outline and its 180° rotation to one hash', () => {
+    const rotated = rotateOutline180(SYM_CHAMFER, 4 * U, 4 * U);
+    // The 180° rotation of a point-symmetric loop is the same polygon shifted by
+    // n/2, so canonical-start hashes match even though raw hashes need not.
+    expect(hashOutline(canonicalStartOutline(rotated))).toBe(
+      hashOutline(canonicalStartOutline(SYM_CHAMFER))
+    );
+  });
+
+  it('keeps an asymmetric outline distinct from its 180° rotation', () => {
+    const rotated = rotateOutline180(L_SHAPE, 4 * U, 4 * U);
+    expect(hashOutline(canonicalStartOutline(rotated))).not.toBe(
+      hashOutline(canonicalStartOutline(L_SHAPE))
+    );
+  });
+
+  it('preserves winding and bulge association', () => {
+    const canon = canonicalStartOutline(CURVED_BACK);
+    expect(outlineSignedArea(canon)).toBeCloseTo(outlineSignedArea(CURVED_BACK));
   });
 });
 

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -251,6 +251,44 @@ export function hashOutline(outline: DrawerOutline): string {
   return (h >>> 0).toString(36);
 }
 
+/**
+ * Rotate the vertex loop to a canonical starting index so a closed outline and
+ * any cyclic shift of it hash equal — in particular a point-symmetric loop and
+ * its 180° rotation, which trace the same polygon shifted by n/2. Winding,
+ * bulges, and the vertex→next-edge bulge association are all preserved; only the
+ * start moves. Picks the rotation whose quantized (x, y, bulge) vertex sequence
+ * is lexicographically smallest so a repeated smallest vertex still resolves
+ * deterministically. Drops the authoring annotation (pipeline-only op).
+ */
+export function canonicalStartOutline(outline: DrawerOutline): DrawerOutline {
+  const verts = outline.vertices;
+  const n = verts.length;
+  if (n < 2) return { vertices: verts.map((v) => v) };
+  const keys = verts.map((v): readonly [number, number, number] => [
+    Math.round(v.x / OUTLINE_QUANTUM_MM),
+    Math.round(v.y / OUTLINE_QUANTUM_MM),
+    Math.round((v.bulge ?? 0) * 1e6),
+  ]);
+  // True iff the rotation starting at index `a` is lexicographically smaller
+  // than the one starting at `b`, comparing the full vertex sequence.
+  const rotationLess = (a: number, b: number): boolean => {
+    for (let i = 0; i < n; i++) {
+      const ka = keys[(a + i) % n];
+      const kb = keys[(b + i) % n];
+      for (let c = 0; c < 3; c++) {
+        if (ka[c] !== kb[c]) return ka[c] < kb[c];
+      }
+    }
+    return false;
+  };
+  let best = 0;
+  for (let s = 1; s < n; s++) {
+    if (rotationLess(s, best)) best = s;
+  }
+  const rotated = best === 0 ? verts : [...verts.slice(best), ...verts.slice(0, best)];
+  return { vertices: rotated.map((v) => v) };
+}
+
 interface MutableVertex {
   x: number;
   y: number;


### PR DESCRIPTION
Follow-up to #3128/#3113 (shaped vertical stacking). Lets **opposite corner tiles** of a split, point-symmetric perimeter (rounded-rect / large-radius) share ONE canonical mesh and ONE stack tower via a 180° placement rotation — instead of each rounded corner printing singly.

## Change (3 edits + 1 pure helper)
1. `canonicalStartOutline` (new, in `drawerOutline.ts`) — rotates a loop's vertex list to its lexicographically-smallest quantized start, so a point-symmetric loop and its 180° rotation (same polygon, cyclically shifted by n/2) hash **equal**. `hashOutline` untouched.
2. `applyOutlineToTiling`: replace the forced `placementRotationDeg: 0` with the same `needs180 = palindromic && edgeKey(edges) > edgeKey(rotateEdges180(edges))` the rectangular path uses, from the **reclassified** edges.
3. `pieceToBaseplateParams`: under `rot`, the piece outline is now `rotateOutline180(local, windowW, windowD)` (previously only translated — the reason rotation was forced off).
4. `computePieceFingerprint`: outline term → `hashOutline(canonicalStartOutline(outline))`.

Preview/export/assembly-guide need no change (they already apply `rotZ` / export the canonical mesh / emit "rotate 180°" hints generically).

## Correctness gate (this is the load-bearing bit)
New real-WASM equivariance test asserts `rotate180(generate(A_canonical)) ≈ generate(B_true)` for a point-symmetric split rounded-rect pair — **equal triangleCount, equal enclosed volume, matching bbox, and the rounded cut on the correct corner**. This numerically proves the shared canonical mesh rotated 180° reproduces the opposite corner. Non-symmetric shapes provably do **not** false-dedupe (a single rounded corner stays a singleton group; only the two *plain* opposite corners dedupe, which is pre-existing congruent-rectangle behavior).

## Test plan
- [x] `pnpm run typecheck`; eslint/prettier clean
- [x] splitPlanner + pieceFingerprint + stackPrint + drawerOutline units — 244 passed (incl. asymmetric no-false-dedupe + `canonicalStartOutline` cyclic-invariance)
- [x] **Real-WASM equivariance** scenario (new) — 1 passed
- [x] outline scenario 16, dovetail (preferIdenticalPieces) scenario 9, full `src/features/baseplate` suite 904 — no snapshot churn (all edits gated on `outline` + `rot`; rectangular/non-preferIdentical plates byte-identical)

## Note
This is the geometry-sensitive one, so it's **not** on auto-merge. The equivariance test proves the property numerically; a physical STL overlay of the shared corner tile vs its 180°-rotated opposite is the final human sanity check — happy to capture a preview if wanted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares one canonical mesh and stack tower between opposite rounded-corner tiles on point‑symmetric shaped plates by placing one tile rotated 180°. Rotation follows the reclassified edge layout; non‑symmetric tiles may still be placed at 180° but won’t share because their outline fingerprints differ (Linear #3113).

- **New Features**
  - Compute 180° placement from reclassified edges; only active when `preferIdenticalPieces` and `connectorNubs` are enabled.
  - Rotate the piece-local outline 180° about its window for rotated pieces (was translate-only).
  - Add `canonicalStartOutline` and use it in `computePieceFingerprint` so a point‑symmetric outline and its 180° rotation hash the same.
  - Add a real‑WASM equivariance test: rotating the canonical mesh 180° reproduces its opposite corner (triangle count, volume, bbox, and corner correctness).
  - Clarify: `placementRotationDeg` follows edge layout; sharing is gated by the outline fingerprint, so non‑symmetric tiles never merge.

<sup>Written for commit 1ceb7ad865cabcc587927b8ffcf2d1f0ce92d0f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

