### PR TITLE
refactor(bin-designer): dedup compartment merge/split onto the canonical impls

### DIFF
--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -31,6 +31,8 @@ import {
   getEligibleDividers,
   isRectangularSelection,
   cellIndex,
+  previewMergeCells,
+  previewSplitCells,
 } from '@/features/bin-designer/utils/compartments';
 import {
   minUniformCavity,
@@ -227,7 +229,6 @@ export function CompartmentEditor() {
     if (!isDragging || selection.size < 2 || selectionAction === 'none') return null;
 
     const indices = [...selection];
-    const newCells = [...cells];
 
     // Compute selection bounds
     let minCol = cols,
@@ -243,19 +244,10 @@ export function CompartmentEditor() {
       maxRow = Math.max(maxRow, row);
     }
 
-    if (selectionAction === 'merge') {
-      // Merge: assign all selected cells to a new ID (use first selected ID)
-      const targetId = cells[indices[0]];
-      for (const idx of indices) {
-        newCells[idx] = targetId;
-      }
-    } else {
-      // Split: assign each cell a unique ID
-      let nextId = Math.max(...cells) + 1;
-      for (const idx of indices) {
-        newCells[idx] = nextId++;
-      }
-    }
+    const newCells =
+      selectionAction === 'merge'
+        ? previewMergeCells(cells, indices)
+        : previewSplitCells(cells, indices);
 
     return {
       compartments: { cols, rows, thickness, cells: newCells },

--- a/src/features/bin-designer/components/SlotConfigurator/CustomGridEditor.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/CustomGridEditor.tsx
@@ -16,7 +16,12 @@ import { useCallback, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { Button, Stepper } from '@/design-system';
-import { mergeCells, normalizeIds, isRectangularSelection } from '@/features/bin-designer/utils';
+import {
+  mergeCells,
+  normalizeIds,
+  isRectangularSelection,
+  previewSplitCells,
+} from '@/features/bin-designer/utils';
 import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
 import { deriveWallSegments } from '@/shared/utils/compartmentGeometry';
 import { computeAuthoredDividers } from '@/shared/utils/authoredDividerMath';
@@ -130,9 +135,11 @@ export function CustomGridEditor() {
     // normalize once. Splitting compartment-by-compartment would be unstable —
     // each split renumbers ids, invalidating the remaining targets.
     const targets = new Set(selectionIndices.map((i) => cells[i]));
-    let nextId = Math.max(...cells) + 1;
-    const split = cells.map((id) => (targets.has(id) ? nextId++ : id));
-    commitGrid({ cols, rows, cells: normalizeIds(split) });
+    const targetIndices: number[] = [];
+    for (let i = 0; i < cells.length; i++) {
+      if (targets.has(cells[i])) targetIndices.push(i);
+    }
+    commitGrid({ cols, rows, cells: normalizeIds(previewSplitCells(cells, targetIndices)) });
   }, [cells, cols, rows, selectionIndices, commitGrid]);
 
   // Grid preview sizing: keep the interior aspect ratio, cap the long edge.

--- a/src/features/bin-designer/store/slices/paramSlice.ts
+++ b/src/features/bin-designer/store/slices/paramSlice.ts
@@ -38,12 +38,9 @@ import { DEFAULT_BIN_PARAMS, DEFAULT_FLOOR_PATTERN_CONFIG } from '../../constant
 import { isErr } from '@/core/result';
 import {
   carryCompartmentTextsByPosition,
-  remapLabelPlateWidths,
-  remapLabelIcons,
   isRectangularSelection,
-  normalizeIdsWithRemap,
-  remapCompartmentTexts,
-  remapDividerOverrides,
+  mergeCells,
+  splitCompartment,
 } from '../../utils/compartments';
 import { validateCompartmentSizes } from '../../utils/validation';
 import { defaultsForNewDesign, paramsNeedHalfGridMode, pushHistoryEntry } from '../helpers';
@@ -386,34 +383,14 @@ export function createParamSlice(set: Set, get: Get) {
       const { params } = get();
       const { cols } = params.compartments;
 
+      // Guard before the history entry so a non-rectangular selection (which the
+      // canonical mergeCells rejects with null) stays a true no-op.
       if (!isRectangularSelection(cols, cellIndices)) return;
-
-      const existingIds = cellIndices.map((i) => params.compartments.cells[i]);
-      const targetId = Math.min(...existingIds);
 
       set((state) => {
         pushHistoryEntry(state);
-        const newCells = [...state.params.compartments.cells];
-        for (const idx of cellIndices) {
-          newCells[idx] = targetId;
-        }
-        const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
-        const prevTexts = state.params.compartments.compartmentTexts;
-        const prevPlateWidths = state.params.compartments.labelPlateWidths;
-        const prevIcons = state.params.compartments.labelIcons;
-        const prevOverrides = state.params.compartments.dividerOverrides;
-        state.params.compartments = {
-          ...state.params.compartments,
-          cells: normalized,
-          ...(prevTexts ? { compartmentTexts: remapCompartmentTexts(prevTexts, remap) } : {}),
-          ...(prevPlateWidths
-            ? { labelPlateWidths: remapLabelPlateWidths(prevPlateWidths, remap) }
-            : {}),
-          ...(prevIcons ? { labelIcons: remapLabelIcons(prevIcons, remap) } : {}),
-          ...(prevOverrides
-            ? { dividerOverrides: remapDividerOverrides(prevOverrides, remap) }
-            : {}),
-        };
+        state.params.compartments =
+          mergeCells(state.params.compartments, cellIndices) ?? state.params.compartments;
       });
     },
 
@@ -434,35 +411,7 @@ export function createParamSlice(set: Set, get: Get) {
 
       set((state) => {
         pushHistoryEntry(state);
-        const newCells = [...state.params.compartments.cells];
-        let nextId = Math.max(...newCells) + 1;
-        let first = true;
-        for (let i = 0; i < newCells.length; i++) {
-          if (newCells[i] === compartmentId) {
-            if (first) {
-              first = false;
-            } else {
-              newCells[i] = nextId++;
-            }
-          }
-        }
-        const { cells: normalized, remap } = normalizeIdsWithRemap(newCells);
-        const prevTexts = state.params.compartments.compartmentTexts;
-        const prevPlateWidths = state.params.compartments.labelPlateWidths;
-        const prevIcons = state.params.compartments.labelIcons;
-        const prevOverrides = state.params.compartments.dividerOverrides;
-        state.params.compartments = {
-          ...state.params.compartments,
-          cells: normalized,
-          ...(prevTexts ? { compartmentTexts: remapCompartmentTexts(prevTexts, remap) } : {}),
-          ...(prevPlateWidths
-            ? { labelPlateWidths: remapLabelPlateWidths(prevPlateWidths, remap) }
-            : {}),
-          ...(prevIcons ? { labelIcons: remapLabelIcons(prevIcons, remap) } : {}),
-          ...(prevOverrides
-            ? { dividerOverrides: remapDividerOverrides(prevOverrides, remap) }
-            : {}),
-        };
+        state.params.compartments = splitCompartment(state.params.compartments, compartmentId);
       });
     },
 

--- a/src/features/bin-designer/utils/compartments.test.ts
+++ b/src/features/bin-designer/utils/compartments.test.ts
@@ -18,6 +18,8 @@ import {
   validateCompartmentGrid,
   mergeCells,
   splitCompartment,
+  previewMergeCells,
+  previewSplitCells,
   normalizeIds,
   normalizeIdsWithRemap,
   remapCompartmentTexts,
@@ -645,6 +647,72 @@ describe('compartments', () => {
 
       // Should create 6 separate compartments
       expect(getCompartmentCount(result)).toBe(6);
+    });
+  });
+
+  describe('previewMergeCells', () => {
+    it('assigns every selected cell to the first selection ID', () => {
+      const cells = [0, 1, 2, 3];
+      const result = previewMergeCells(cells, [1, 2]);
+      expect(result).toEqual([0, 1, 1, 3]);
+    });
+
+    it('uses the first supplied index for the target ID (not the minimum)', () => {
+      // Unlike committed mergeCells (Math.min), the preview shows the first
+      // selected cell's ID so the ghost matches the drag anchor.
+      const cells = [5, 2, 7, 9];
+      const result = previewMergeCells(cells, [2, 0]);
+      expect(result).toEqual([5, 2, 7, 9].map((id, i) => (i === 2 || i === 0 ? 7 : id)));
+      expect(result[0]).toBe(7);
+      expect(result[2]).toBe(7);
+    });
+
+    it('does not normalize or mutate the input', () => {
+      const cells = [3, 3, 5, 8];
+      const result = previewMergeCells(cells, [2, 3]);
+      // ID 5 is carried onto index 3; nothing is renumbered to be contiguous.
+      expect(result).toEqual([3, 3, 5, 5]);
+      expect(cells).toEqual([3, 3, 5, 8]);
+      expect(result).not.toBe(cells);
+    });
+
+    it('returns a copy unchanged for an empty selection', () => {
+      const cells = [0, 1, 2, 3];
+      const result = previewMergeCells(cells, []);
+      expect(result).toEqual(cells);
+      expect(result).not.toBe(cells);
+    });
+  });
+
+  describe('previewSplitCells', () => {
+    it('gives each selected cell a fresh ID counting up from the max', () => {
+      const cells = [0, 0, 0, 1];
+      const result = previewSplitCells(cells, [1, 2]);
+      // max is 1, so fresh IDs start at 2 in index order.
+      expect(result).toEqual([0, 2, 3, 1]);
+    });
+
+    it('leaves unselected cells untouched and does not normalize', () => {
+      const cells = [0, 0, 5];
+      const result = previewSplitCells(cells, [0]);
+      expect(result).toEqual([6, 0, 5]);
+      expect(cells).toEqual([0, 0, 5]);
+      expect(result).not.toBe(cells);
+    });
+
+    it('normalizes cleanly to per-cell compartments when wrapped in normalizeIds', () => {
+      // The commit path (CustomGridEditor) composes previewSplitCells with
+      // normalizeIds; every fully-split cell becomes its own compartment.
+      const cells = [0, 0, 0, 0];
+      const split = previewSplitCells(cells, [0, 1, 2, 3]);
+      expect(normalizeIds(split)).toEqual([0, 1, 2, 3]);
+    });
+
+    it('returns a copy unchanged for an empty selection', () => {
+      const cells = [0, 1, 2, 3];
+      const result = previewSplitCells(cells, []);
+      expect(result).toEqual(cells);
+      expect(result).not.toBe(cells);
     });
   });
 

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -795,6 +795,49 @@ export function splitCompartment(
 }
 
 /**
+ * Cells-only preview of a merge: assign every selected cell to the first
+ * selection's compartment ID. Returns a fresh array.
+ *
+ * Deliberately skips ID normalization and the parallel-array remap that the
+ * committed {@link mergeCells} performs — a drag ghost only needs the cell
+ * partition to derive divider walls, and normalizing the preview would renumber
+ * IDs the committed result hasn't yet applied.
+ */
+export function previewMergeCells(
+  cells: readonly number[],
+  cellIndices: readonly number[]
+): number[] {
+  const next = [...cells];
+  if (cellIndices.length === 0) return next;
+  const targetId = cells[cellIndices[0]];
+  for (const idx of cellIndices) {
+    next[idx] = targetId;
+  }
+  return next;
+}
+
+/**
+ * Cells-only preview of a split: give each selected cell a fresh unique ID,
+ * counting up from the current maximum in the order the indices are supplied.
+ * Leaves unselected cells untouched. Returns a fresh array.
+ *
+ * Like {@link previewMergeCells}, this skips normalization and parallel-array
+ * remap — those belong to the commit path. Callers that need a canonical grid
+ * (e.g. a committed split) wrap the result in {@link normalizeIds}.
+ */
+export function previewSplitCells(
+  cells: readonly number[],
+  cellIndices: readonly number[]
+): number[] {
+  const next = [...cells];
+  let nextId = Math.max(...cells) + 1;
+  for (const idx of cellIndices) {
+    next[idx] = nextId++;
+  }
+  return next;
+}
+
+/**
  * Normalize compartment IDs to be contiguous starting from 0.
  * Preserves spatial ordering (top-left to bottom-right first occurrence).
  */

--- a/src/features/bin-designer/utils/index.ts
+++ b/src/features/bin-designer/utils/index.ts
@@ -12,6 +12,8 @@ export {
   validateCompartmentGrid,
   mergeCells,
   splitCompartment,
+  previewMergeCells,
+  previewSplitCells,
   normalizeIds,
   deriveWallSegments,
   fromDividerConfig,


### PR DESCRIPTION
## Summary

The compartment merge/split "parallel-array lockstep" logic — the exact thing **CLAUDE.md gotcha #6** warns about (normalizeIds renumbers cell IDs, so `compartmentTexts`/`labelPlateWidths`/`labelIcons`/`dividerOverrides` must be remapped in lockstep) — was reimplemented **4×**, which can silently drift. This unifies them onto the canonical `compartments.ts` implementations. **Behavior-preserving.**

## Change

- **`paramSlice.mergeCells`/`splitCompartment`** now delegate to the canonical `mergeCells`/`splitCompartment` (verified functionally identical: same `Math.min` merge target, same split loop, same `normalizeIdsWithRemap` + all four remaps). All surrounding behavior preserved exactly — the `length < 2` / `isRectangularSelection` / `validateCompartmentSizes` no-op guards and `pushHistoryEntry`. Removed 5 now-unused imports; `paramSlice.ts` shrank ~65 lines.
- **Preview sites** (`CompartmentEditor` drag-ghost, `CustomGridEditor` split) now use new cells-only `previewMergeCells`/`previewSplitCells` helpers (no ID normalization / no parallel-array remap — previews only need the partition), with sibling tests.
- **Deliberately NOT unified:** the merge-preview's first-selected-ID (vs committed `Math.min`) — a genuine, documented divergence, left intact.

## Test plan
- [x] `pnpm run typecheck`; eslint clean (paramSlice shrank, warning reduced)
- [x] `compartments.test.ts` 170 (incl. 8 new preview tests)
- [x] **`designer.scenario.compartments.test.ts` 73** — load-bearing (real store: history capture, no-op guards, undo)
- [x] `CompartmentEditor` + `CustomGridEditor` + `compartmentDimensions` — 34

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies compartment merge/split onto the canonical utils to prevent drift and keep behavior consistent. Adds cells-only preview helpers used by the editors; no changes to committed behavior.

- **Refactors**
  - Store actions delegate to canonical mergeCells/splitCompartment; existing guards and history kept.
  - Removed duplicate lockstep remap logic and unused imports; `paramSlice.ts` shrank ~65 lines.
  - Committed merge still targets `Math.min`; non-rectangular selections remain no-ops.

- **New Features**
  - Added previewMergeCells/previewSplitCells (cells-only, no normalization) for drag ghosts.
  - Wired into CompartmentEditor and CustomGridEditor; preview keeps first-selected-ID behavior.

<sup>Written for commit 68efcf7f80326a14086912c8e7ab889fa6c64f2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

