### PR TITLE
refactor(bin-designer): split DesignListDialog into cohesive modules

### DIFF
--- a/src/features/bin-designer/components/DesignListDialog/DesignItemsView.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignItemsView.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { designId } from '@/core/types';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import type { SavedDesign } from '@/features/bin-designer/types';
+import { DesignItemsView } from './DesignItemsView';
+
+const designs: SavedDesign[] = [
+  {
+    id: designId('design-1'),
+    name: 'Tool Holder',
+    params: { ...DEFAULT_BIN_PARAMS, width: 3, depth: 2 },
+    thumbnail: null,
+    exportFileNameConfig: null,
+    createdAt: '2026-01-20T10:00:00.000Z',
+    updatedAt: '2026-01-22T12:00:00.000Z',
+  },
+  {
+    id: designId('design-2'),
+    name: 'Screw Bin',
+    params: { ...DEFAULT_BIN_PARAMS, width: 1, depth: 1, height: 6 },
+    thumbnail: null,
+    exportFileNameConfig: null,
+    createdAt: '2026-01-19T08:00:00.000Z',
+    updatedAt: '2026-01-21T15:00:00.000Z',
+  },
+];
+
+function baseProps() {
+  return {
+    items: designs,
+    currentDesignId: 'design-1' as string | null,
+    focusedIndex: 0,
+    selectionActive: false,
+    isSelected: () => false,
+    onLoad: vi.fn(),
+    onDownloadJSON: vi.fn(),
+    onRename: vi.fn(),
+    onEditTags: vi.fn(),
+    onDuplicate: vi.fn(),
+    onDelete: vi.fn(),
+    onFocus: vi.fn(),
+    onToggleSelect: vi.fn(),
+    registerItemRef: vi.fn(),
+  };
+}
+
+describe('DesignItemsView', () => {
+  it('renders every design in grid variant', () => {
+    render(
+      <div>
+        <DesignItemsView variant="grid" {...baseProps()} />
+      </div>
+    );
+    expect(screen.getByText('Tool Holder')).toBeInTheDocument();
+    expect(screen.getByText('Screw Bin')).toBeInTheDocument();
+  });
+
+  it('renders list items inside a list wrapper', () => {
+    const { container } = render(
+      <ul>
+        <DesignItemsView variant="list" {...baseProps()} />
+      </ul>
+    );
+    expect(container.querySelectorAll('li').length).toBe(designs.length);
+  });
+
+  it('calls onLoad with the clicked design', () => {
+    const props = baseProps();
+    render(
+      <div>
+        <DesignItemsView variant="grid" {...props} />
+      </div>
+    );
+    fireEvent.click(screen.getByText('Screw Bin'));
+    expect(props.onLoad).toHaveBeenCalledWith(designs[1]);
+  });
+
+  it('registers a DOM ref for each rendered item', () => {
+    const props = baseProps();
+    render(
+      <div>
+        <DesignItemsView variant="grid" {...props} />
+      </div>
+    );
+    const registeredIds = props.registerItemRef.mock.calls
+      .filter(([, el]) => el !== null)
+      .map(([id]) => id);
+    expect(registeredIds).toEqual(expect.arrayContaining(['design-1', 'design-2']));
+  });
+});

--- a/src/features/bin-designer/components/DesignListDialog/DesignItemsView.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignItemsView.tsx
@@ -1,0 +1,86 @@
+import { DesignGridItem } from '../DesignGridItem';
+import { DesignListItem } from '../DesignListItem';
+import type { SavedDesign } from '../../types';
+
+interface DesignItemsViewProps {
+  variant: 'grid' | 'list';
+  items: readonly SavedDesign[];
+  currentDesignId: string | null;
+  focusedIndex: number;
+  selectionActive: boolean;
+  isSelected: (id: string) => boolean;
+  onLoad: (design: SavedDesign) => void;
+  onDownloadJSON: (design: SavedDesign) => void;
+  onRename: (design: SavedDesign, newName: string) => void;
+  onEditTags: (design: SavedDesign) => void;
+  onDuplicate: (design: SavedDesign) => void;
+  onDelete: (design: SavedDesign) => void;
+  onFocus: (index: number) => void;
+  onToggleSelect: (id: string) => void;
+  registerItemRef: (id: string, el: HTMLDivElement | HTMLLIElement | null) => void;
+}
+
+/**
+ * Renders the saved-design items for either the grid or list view. Both
+ * variants share identical per-item wiring; only the item component and its
+ * `itemRef` element type differ.
+ */
+export function DesignItemsView({
+  variant,
+  items,
+  currentDesignId,
+  focusedIndex,
+  selectionActive,
+  isSelected,
+  onLoad,
+  onDownloadJSON,
+  onRename,
+  onEditTags,
+  onDuplicate,
+  onDelete,
+  onFocus,
+  onToggleSelect,
+  registerItemRef,
+}: DesignItemsViewProps) {
+  const commonProps = (design: SavedDesign, index: number) => ({
+    design,
+    isActive: design.id === currentDesignId,
+    isFocused: index === focusedIndex,
+    onSelect: () => onLoad(design),
+    onDownloadJSON: () => onDownloadJSON(design),
+    onRename: (newName: string) => onRename(design, newName),
+    onEditTags: () => onEditTags(design),
+    onDuplicate: () => onDuplicate(design),
+    onDelete: () => onDelete(design),
+    onFocus: () => onFocus(index),
+    selectionActive,
+    isSelected: isSelected(design.id),
+    onToggleSelect: () => onToggleSelect(design.id),
+  });
+
+  if (variant === 'grid') {
+    return (
+      <>
+        {items.map((design, index) => (
+          <DesignGridItem
+            key={design.id}
+            {...commonProps(design, index)}
+            itemRef={(el) => registerItemRef(design.id, el)}
+          />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {items.map((design, index) => (
+        <DesignListItem
+          key={design.id}
+          {...commonProps(design, index)}
+          itemRef={(el) => registerItemRef(design.id, el)}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
@@ -16,15 +16,22 @@ import {
   saveDesign,
   updateDesignTags,
 } from '@/features/bin-designer/storage/DesignerStorage';
-import { Menu, Button, IconButton, XIcon, PlusIcon } from '@/design-system';
 import { useBinDefaults } from '../../hooks';
-import { collectTags, filterByTags, toggleTag } from '@/features/bin-designer/utils/tagFilter';
+import { collectTags, toggleTag } from '@/features/bin-designer/utils/tagFilter';
 import { normalizeTags, tagsEqual } from '@/features/bin-designer/utils/tags';
 import { TagFilterBar } from './TagFilterBar';
 import { BulkActionBar } from './BulkActionBar';
 import { TagEditDialog } from './TagEditDialog';
 import { TagManagerDialog } from '../TagManagerDialog';
 import { useDesignSelection } from './useDesignSelection';
+import { DesignListHeader } from './DesignListHeader';
+import { DesignListSkeleton } from './DesignListSkeleton';
+import { DesignListEmptyState } from './DesignListEmptyState';
+import { DesignListNoResults } from './DesignListNoResults';
+import { DesignListOptionsMenu } from './DesignListOptionsMenu';
+import { DesignItemsView } from './DesignItemsView';
+import { filterAndSortDesigns, SORT_OPTIONS, SORT_OPTION_KEYS } from './designListSort';
+import type { SortOption } from './designListSort';
 import { removeRegistryEntry } from '../../store/customBinRegistry';
 import { useDesignerStore } from '../../store';
 import { useDesignerRouting } from '@/shared/hooks/useDesignerRouting';
@@ -33,13 +40,10 @@ import { useToastStore } from '@/core/store/toast';
 import { useSettingsStore } from '@/core/store/settings';
 import { useResponsive } from '@/shared/hooks';
 import { ItemListShell } from '@/shared/components';
-import { DesignGridItem } from '../DesignGridItem';
-import { DesignListItem } from '../DesignListItem';
 import { DesignImportView } from '../DesignImportView';
 import { ImportBinDialog, useImportBinDesign } from '../ImportBinDialog';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import type { SavedDesign, BinParams } from '../../types';
-import { designFootprint } from '../../utils/designKind';
 import { useThumbnailRegeneration } from '../../hooks/useThumbnailRegeneration';
 import { useTranslation } from '@/i18n';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog/ConfirmDialog';
@@ -50,18 +54,6 @@ interface DesignListDialogProps {
   open: boolean;
   onClose: () => void;
 }
-
-type SortOption = 'recent' | 'name' | 'size';
-
-/** Sort option values - labels are generated dynamically via i18n */
-const SORT_OPTIONS: readonly SortOption[] = ['recent', 'name', 'size'] as const;
-
-/** i18n key mapping for sort options */
-const SORT_OPTION_KEYS: Record<SortOption, string> = {
-  recent: 'binDesigner.sortRecent',
-  name: 'binDesigner.sortName',
-  size: 'binDesigner.sortSize',
-};
 
 /**
  * Renders a modal dialog listing saved designs and providing load, rename, duplicate, delete, and create actions.
@@ -200,34 +192,10 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
   }
 
   // Filter and sort designs
-  const sortedDesigns = useMemo(() => {
-    let filtered = filterByTags(designs, activeTags);
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter((d) => d.name.toLowerCase().includes(query));
-    }
-
-    return [...filtered].sort((a, b) => {
-      // Active design always first
-      if (a.id === currentDesignId) return -1;
-      if (b.id === currentDesignId) return 1;
-
-      switch (sortBy) {
-        case 'name':
-          return a.name.localeCompare(b.name);
-        case 'size': {
-          const af = designFootprint(a);
-          const bf = designFootprint(b);
-          const aSize = af.width * af.depth * Math.max(af.height, 1);
-          const bSize = bf.width * bf.depth * Math.max(bf.height, 1);
-          return bSize - aSize;
-        }
-        case 'recent':
-        default:
-          return b.updatedAt.localeCompare(a.updatedAt);
-      }
-    });
-  }, [designs, activeTags, searchQuery, sortBy, currentDesignId]);
+  const sortedDesigns = useMemo(
+    () => filterAndSortDesigns(designs, { activeTags, searchQuery, sortBy, currentDesignId }),
+    [designs, activeTags, searchQuery, sortBy, currentDesignId]
+  );
 
   // Get localized sort options
   const localizedSortOptions = useMemo(
@@ -528,6 +496,27 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
     [loadDesign, navigateToDesign, addToast, onClose, t]
   );
 
+  const registerItemRef = useCallback((id: string, el: HTMLDivElement | HTMLLIElement | null) => {
+    if (el) itemRefs.current.set(id, el);
+    else itemRefs.current.delete(id);
+  }, []);
+
+  const itemViewProps = {
+    currentDesignId,
+    focusedIndex,
+    selectionActive: selection.active,
+    isSelected: selection.isSelected,
+    onLoad: handleLoad,
+    onDownloadJSON: handleDownloadJSON,
+    onRename: (design: SavedDesign, newName: string) => void handleRename(design, newName),
+    onEditTags: (design: SavedDesign) => setTagEdit({ mode: 'single', design }),
+    onDuplicate: (design: SavedDesign) => void handleDuplicate(design),
+    onDelete: (design: SavedDesign) => void handleDelete(design),
+    onFocus: setFocusedIndex,
+    onToggleSelect: selection.toggle,
+    registerItemRef,
+  };
+
   if (!open) return null;
 
   return (
@@ -548,80 +537,16 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
         aria-modal="true"
         aria-label={t('binDesigner.savedDesigns')}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-stroke-subtle px-5 py-4">
-          <h2 className="text-lg font-semibold text-content">{t('binDesigner.savedDesigns')}</h2>
-          <div className="flex flex-wrap items-center gap-2">
-            {!showImport && designs.length > 0 && !selection.active && (
-              <Button
-                variant="secondary"
-                onClick={() => selection.enter()}
-                className="rounded-md bg-surface-secondary px-3 py-1.5 text-sm font-medium text-content border border-stroke transition-colors hover:bg-surface-hover"
-              >
-                {t('binDesigner.select')}
-              </Button>
-            )}
-            <Button
-              variant="secondary"
-              onClick={() => setShowImport(true)}
-              className="rounded-md bg-surface-secondary px-3 py-1.5 text-sm font-medium text-content border border-stroke transition-colors hover:bg-surface-hover"
-            >
-              {t('common.import')}
-            </Button>
-            <Button
-              variant="primary"
-              onClick={handleNewDesign}
-              className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
-            >
-              {t('binDesigner.newDesign')}
-            </Button>
-            <IconButton
-              type="button"
-              size="md"
-              touchTarget={false}
-              onClick={handleOpenOptionsMenu}
-              className="relative h-auto w-auto rounded-md p-1.5 text-content-secondary border border-stroke transition-colors hover:bg-surface-hover hover:text-content"
-              aria-label={
-                customDefaultActive
-                  ? `${t('binDesigner.moreOptions')} — ${t('binDesigner.customDefaultActive')}`
-                  : t('binDesigner.moreOptions')
-              }
-              aria-haspopup="menu"
-              aria-expanded={optionsMenu.open}
-              title={t('binDesigner.moreOptions')}
-            >
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 5v.01M12 12v.01M12 19v.01"
-                />
-              </svg>
-              {customDefaultActive && (
-                <span
-                  className="absolute right-0.5 top-0.5 h-2 w-2 rounded-full bg-accent ring-2 ring-surface-secondary"
-                  aria-hidden="true"
-                />
-              )}
-            </IconButton>
-            <IconButton
-              size="sm"
-              touchTarget={false}
-              onClick={onClose}
-              className="h-auto w-auto rounded-md p-1 text-content-secondary hover:bg-surface-hover hover:text-content"
-              aria-label={t('common.close')}
-            >
-              <XIcon className="h-5 w-5" />
-            </IconButton>
-          </div>
-        </div>
+        <DesignListHeader
+          showSelectButton={!showImport && designs.length > 0 && !selection.active}
+          optionsMenuOpen={optionsMenu.open}
+          customDefaultActive={customDefaultActive}
+          onEnterSelect={() => selection.enter()}
+          onShowImport={() => setShowImport(true)}
+          onNewDesign={handleNewDesign}
+          onOpenOptionsMenu={handleOpenOptionsMenu}
+          onClose={onClose}
+        />
 
         {/* Design list or import view */}
         <div className="flex-1 min-h-0 flex flex-col px-5 py-3" aria-busy={loading}>
@@ -643,53 +568,9 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
               />
             </>
           ) : loading ? (
-            <div className="space-y-2 py-2">
-              {[1, 2, 3].map((i) => (
-                <div
-                  key={i}
-                  className="flex animate-pulse motion-reduce:animate-none items-center gap-3 rounded-lg border border-stroke-subtle px-3 py-2.5"
-                >
-                  <div className="h-10 w-10 flex-shrink-0 rounded-md bg-surface-elevated" />
-                  <div className="flex-1 space-y-1.5">
-                    <div className="h-3.5 w-24 rounded bg-surface-elevated" />
-                    <div className="h-3 w-16 rounded bg-surface-elevated" />
-                  </div>
-                </div>
-              ))}
-            </div>
+            <DesignListSkeleton />
           ) : designs.length === 0 ? (
-            <div className="py-8 text-center">
-              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-surface-elevated">
-                <svg
-                  className="h-6 w-6 text-content-tertiary"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
-                  />
-                </svg>
-              </div>
-              <p className="text-sm font-medium text-content-secondary">
-                {t('binDesigner.noSavedDesignsYet')}
-              </p>
-              <p className="mt-1 text-xs text-content-disabled">
-                {t('binDesigner.changesAreSavedAutomaticallyAsYouDe')}
-              </p>
-              <Button
-                variant="primary"
-                onClick={handleNewDesign}
-                className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
-                leftIcon={<PlusIcon className="h-4 w-4" />}
-              >
-                {t('binDesigner.startANewDesign')}
-              </Button>
-            </div>
+            <DesignListEmptyState onNewDesign={handleNewDesign} />
           ) : (
             <ItemListShell
               items={sortedDesigns}
@@ -739,74 +620,15 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
                   aria-label={t('binDesigner.savedDesigns')}
                   className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 content-start"
                 >
-                  {items.map((design, index) => (
-                    <DesignGridItem
-                      key={design.id}
-                      design={design}
-                      isActive={design.id === currentDesignId}
-                      isFocused={index === focusedIndex}
-                      onSelect={() => handleLoad(design)}
-                      onDownloadJSON={() => handleDownloadJSON(design)}
-                      onRename={(newName) => void handleRename(design, newName)}
-                      onEditTags={() => setTagEdit({ mode: 'single', design })}
-                      onDuplicate={() => void handleDuplicate(design)}
-                      onDelete={() => void handleDelete(design)}
-                      onFocus={() => setFocusedIndex(index)}
-                      selectionActive={selection.active}
-                      isSelected={selection.isSelected(design.id)}
-                      onToggleSelect={() => selection.toggle(design.id)}
-                      itemRef={(el) => {
-                        if (el) itemRefs.current.set(design.id, el);
-                        else itemRefs.current.delete(design.id);
-                      }}
-                    />
-                  ))}
+                  <DesignItemsView variant="grid" items={items} {...itemViewProps} />
                 </div>
               )}
               renderList={(items) => (
                 <ul role="listbox" aria-label={t('binDesigner.savedDesigns')} className="space-y-2">
-                  {items.map((design, index) => (
-                    <DesignListItem
-                      key={design.id}
-                      design={design}
-                      isActive={design.id === currentDesignId}
-                      isFocused={index === focusedIndex}
-                      onSelect={() => handleLoad(design)}
-                      onDownloadJSON={() => handleDownloadJSON(design)}
-                      onRename={(newName) => void handleRename(design, newName)}
-                      onEditTags={() => setTagEdit({ mode: 'single', design })}
-                      onDuplicate={() => void handleDuplicate(design)}
-                      onDelete={() => void handleDelete(design)}
-                      onFocus={() => setFocusedIndex(index)}
-                      selectionActive={selection.active}
-                      isSelected={selection.isSelected(design.id)}
-                      onToggleSelect={() => selection.toggle(design.id)}
-                      itemRef={(el) => {
-                        if (el) itemRefs.current.set(design.id, el);
-                        else itemRefs.current.delete(design.id);
-                      }}
-                    />
-                  ))}
+                  <DesignItemsView variant="list" items={items} {...itemViewProps} />
                 </ul>
               )}
-              noResultsState={
-                <div className="text-center py-8 text-content-tertiary">
-                  <svg
-                    className="w-10 h-10 mx-auto mb-3 opacity-50"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                    />
-                  </svg>
-                  <p>{t('binDesigner.noDesignsMatch', { query: searchQuery })}</p>
-                </div>
-              }
+              noResultsState={<DesignListNoResults searchQuery={searchQuery} />}
               footer={t('binDesigner.designCount', { count: designs.length })}
             />
           )}
@@ -850,72 +672,18 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
         onConfirm={() => void handleBulkDelete()}
         onCancel={() => setShowBulkDeleteConfirm(false)}
       />
-      <Menu.Root
+      <DesignListOptionsMenu
         open={optionsMenu.open}
-        onClose={closeOptionsMenu}
         position={optionsMenu.position}
-        className="min-w-[18rem]"
-      >
-        {customDefaultActive && (
-          <div
-            className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-content-tertiary"
-            aria-hidden="true"
-          >
-            <span className="h-2 w-2 rounded-full bg-accent" />
-            {t('binDesigner.customDefaultActive')}
-          </div>
-        )}
-        <Menu.Item
-          icon={
-            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          }
-          onClick={setCurrentAsDefault}
-        >
-          {t('binDesigner.setAsDefault')}
-        </Menu.Item>
-        <Menu.Item
-          icon={
-            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
-              />
-            </svg>
-          }
-          onClick={() => {
-            closeOptionsMenu();
-            setShowTagManager(true);
-          }}
-        >
-          {t('binDesigner.tagManager.menuItem')}
-        </Menu.Item>
-        <Menu.Divider />
-        <Menu.Item
-          icon={
-            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>
-          }
-          disabled={!customDefaultActive}
-          onClick={resetToFactory}
-        >
-          {t('binDesigner.resetFactoryDefaults')}
-        </Menu.Item>
-      </Menu.Root>
+        customDefaultActive={customDefaultActive}
+        onClose={closeOptionsMenu}
+        onSetDefault={setCurrentAsDefault}
+        onOpenTagManager={() => {
+          closeOptionsMenu();
+          setShowTagManager(true);
+        }}
+        onResetFactory={resetToFactory}
+      />
     </div>
   );
 }

--- a/src/features/bin-designer/components/DesignListDialog/DesignListEmptyState.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListEmptyState.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DesignListEmptyState } from './DesignListEmptyState';
+
+describe('DesignListEmptyState', () => {
+  it('shows the empty-state copy', () => {
+    render(<DesignListEmptyState onNewDesign={vi.fn()} />);
+    expect(screen.getByText('No saved designs yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Start a new design/ })).toBeInTheDocument();
+  });
+
+  it('fires onNewDesign when the start button is clicked', () => {
+    const onNewDesign = vi.fn();
+    render(<DesignListEmptyState onNewDesign={onNewDesign} />);
+    fireEvent.click(screen.getByRole('button', { name: /Start a new design/ }));
+    expect(onNewDesign).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/bin-designer/components/DesignListDialog/DesignListEmptyState.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListEmptyState.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from '@/i18n';
+import { Button, PlusIcon } from '@/design-system';
+
+interface DesignListEmptyStateProps {
+  onNewDesign: () => void;
+}
+
+/** Shown when no designs are saved yet, inviting the user to start a new design. */
+export function DesignListEmptyState({ onNewDesign }: DesignListEmptyStateProps) {
+  const t = useTranslation();
+
+  return (
+    <div className="py-8 text-center">
+      <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-surface-elevated">
+        <svg
+          className="h-6 w-6 text-content-tertiary"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+          />
+        </svg>
+      </div>
+      <p className="text-sm font-medium text-content-secondary">
+        {t('binDesigner.noSavedDesignsYet')}
+      </p>
+      <p className="mt-1 text-xs text-content-disabled">
+        {t('binDesigner.changesAreSavedAutomaticallyAsYouDe')}
+      </p>
+      <Button
+        variant="primary"
+        onClick={onNewDesign}
+        className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
+        leftIcon={<PlusIcon className="h-4 w-4" />}
+      >
+        {t('binDesigner.startANewDesign')}
+      </Button>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/DesignListDialog/DesignListHeader.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListHeader.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DesignListHeader } from './DesignListHeader';
+
+function setup(overrides?: {
+  showSelectButton?: boolean;
+  optionsMenuOpen?: boolean;
+  customDefaultActive?: boolean;
+}) {
+  const handlers = {
+    onEnterSelect: vi.fn(),
+    onShowImport: vi.fn(),
+    onNewDesign: vi.fn(),
+    onOpenOptionsMenu: vi.fn(),
+    onClose: vi.fn(),
+  };
+  render(
+    <DesignListHeader
+      showSelectButton={overrides?.showSelectButton ?? true}
+      optionsMenuOpen={overrides?.optionsMenuOpen ?? false}
+      customDefaultActive={overrides?.customDefaultActive ?? false}
+      {...handlers}
+    />
+  );
+  return handlers;
+}
+
+describe('DesignListHeader', () => {
+  it('renders the title and primary actions', () => {
+    setup();
+    expect(screen.getByText('Saved Designs')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Import' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New Design' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select' })).toBeInTheDocument();
+  });
+
+  it('hides the Select button when showSelectButton is false', () => {
+    setup({ showSelectButton: false });
+    expect(screen.queryByRole('button', { name: 'Select' })).not.toBeInTheDocument();
+  });
+
+  it('fires the corresponding handler for each action', () => {
+    const h = setup();
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    fireEvent.click(screen.getByRole('button', { name: 'New Design' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(h.onEnterSelect).toHaveBeenCalled();
+    expect(h.onShowImport).toHaveBeenCalled();
+    expect(h.onNewDesign).toHaveBeenCalled();
+    expect(h.onClose).toHaveBeenCalled();
+  });
+
+  it('reflects the options-menu open state via aria-expanded', () => {
+    setup({ optionsMenuOpen: true });
+    const optionsButton = screen.getByRole('button', { name: 'More options' });
+    fireEvent.click(optionsButton);
+    expect(optionsButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('annotates the options button when a custom default is active', () => {
+    setup({ customDefaultActive: true });
+    expect(
+      screen.getByRole('button', { name: /More options — Custom default active/ })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/DesignListDialog/DesignListHeader.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListHeader.tsx
@@ -1,0 +1,104 @@
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { useTranslation } from '@/i18n';
+import { Button, IconButton, XIcon } from '@/design-system';
+
+interface DesignListHeaderProps {
+  showSelectButton: boolean;
+  optionsMenuOpen: boolean;
+  customDefaultActive: boolean;
+  onEnterSelect: () => void;
+  onShowImport: () => void;
+  onNewDesign: () => void;
+  onOpenOptionsMenu: (e: ReactMouseEvent<HTMLButtonElement>) => void;
+  onClose: () => void;
+}
+
+/** Header bar for the design list dialog: title plus select/import/new/options/close controls. */
+export function DesignListHeader({
+  showSelectButton,
+  optionsMenuOpen,
+  customDefaultActive,
+  onEnterSelect,
+  onShowImport,
+  onNewDesign,
+  onOpenOptionsMenu,
+  onClose,
+}: DesignListHeaderProps) {
+  const t = useTranslation();
+
+  return (
+    <div className="flex items-center justify-between border-b border-stroke-subtle px-5 py-4">
+      <h2 className="text-lg font-semibold text-content">{t('binDesigner.savedDesigns')}</h2>
+      <div className="flex flex-wrap items-center gap-2">
+        {showSelectButton && (
+          <Button
+            variant="secondary"
+            onClick={onEnterSelect}
+            className="rounded-md bg-surface-secondary px-3 py-1.5 text-sm font-medium text-content border border-stroke transition-colors hover:bg-surface-hover"
+          >
+            {t('binDesigner.select')}
+          </Button>
+        )}
+        <Button
+          variant="secondary"
+          onClick={onShowImport}
+          className="rounded-md bg-surface-secondary px-3 py-1.5 text-sm font-medium text-content border border-stroke transition-colors hover:bg-surface-hover"
+        >
+          {t('common.import')}
+        </Button>
+        <Button
+          variant="primary"
+          onClick={onNewDesign}
+          className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
+        >
+          {t('binDesigner.newDesign')}
+        </Button>
+        <IconButton
+          type="button"
+          size="md"
+          touchTarget={false}
+          onClick={onOpenOptionsMenu}
+          className="relative h-auto w-auto rounded-md p-1.5 text-content-secondary border border-stroke transition-colors hover:bg-surface-hover hover:text-content"
+          aria-label={
+            customDefaultActive
+              ? `${t('binDesigner.moreOptions')} — ${t('binDesigner.customDefaultActive')}`
+              : t('binDesigner.moreOptions')
+          }
+          aria-haspopup="menu"
+          aria-expanded={optionsMenuOpen}
+          title={t('binDesigner.moreOptions')}
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 5v.01M12 12v.01M12 19v.01"
+            />
+          </svg>
+          {customDefaultActive && (
+            <span
+              className="absolute right-0.5 top-0.5 h-2 w-2 rounded-full bg-accent ring-2 ring-surface-secondary"
+              aria-hidden="true"
+            />
+          )}
+        </IconButton>
+        <IconButton
+          size="sm"
+          touchTarget={false}
+          onClick={onClose}
+          className="h-auto w-auto rounded-md p-1 text-content-secondary hover:bg-surface-hover hover:text-content"
+          aria-label={t('common.close')}
+        >
+          <XIcon className="h-5 w-5" />
+        </IconButton>
+      </div>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/DesignListDialog/DesignListNoResults.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListNoResults.test.tsx
@@ -1,0 +1,11 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DesignListNoResults } from './DesignListNoResults';
+
+describe('DesignListNoResults', () => {
+  it('interpolates the search query into the empty-results message', () => {
+    render(<DesignListNoResults searchQuery="widget" />);
+    expect(screen.getByText('No designs match "widget"')).toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/DesignListDialog/DesignListNoResults.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListNoResults.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from '@/i18n';
+
+interface DesignListNoResultsProps {
+  searchQuery: string;
+}
+
+/** Shown inside the list shell when a search matches no saved designs. */
+export function DesignListNoResults({ searchQuery }: DesignListNoResultsProps) {
+  const t = useTranslation();
+
+  return (
+    <div className="text-center py-8 text-content-tertiary">
+      <svg
+        className="w-10 h-10 mx-auto mb-3 opacity-50"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+      <p>{t('binDesigner.noDesignsMatch', { query: searchQuery })}</p>
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/DesignListDialog/DesignListOptionsMenu.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListOptionsMenu.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DesignListOptionsMenu } from './DesignListOptionsMenu';
+
+function setup(overrides?: { open?: boolean; customDefaultActive?: boolean }) {
+  const handlers = {
+    onClose: vi.fn(),
+    onSetDefault: vi.fn(),
+    onOpenTagManager: vi.fn(),
+    onResetFactory: vi.fn(),
+  };
+  render(
+    <DesignListOptionsMenu
+      open={overrides?.open ?? true}
+      position={{ x: 0, y: 0 }}
+      customDefaultActive={overrides?.customDefaultActive ?? false}
+      {...handlers}
+    />
+  );
+  return handlers;
+}
+
+describe('DesignListOptionsMenu', () => {
+  it('renders nothing when closed', () => {
+    setup({ open: false });
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('shows the default-management actions when open', () => {
+    setup();
+    expect(
+      screen.getByRole('menuitem', { name: 'Set as default for new bins' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Manage tags…' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Reset to factory defaults' })).toBeInTheDocument();
+  });
+
+  it('disables reset and hides the badge without a custom default', () => {
+    setup({ customDefaultActive: false });
+    expect(screen.getByRole('menuitem', { name: 'Reset to factory defaults' })).toBeDisabled();
+    expect(screen.queryByText('Custom default active')).not.toBeInTheDocument();
+  });
+
+  it('enables reset and shows the badge when a custom default is active', () => {
+    setup({ customDefaultActive: true });
+    expect(screen.getByRole('menuitem', { name: 'Reset to factory defaults' })).not.toBeDisabled();
+    expect(screen.getByText('Custom default active')).toBeInTheDocument();
+  });
+
+  it('fires the matching handler for each menu item', () => {
+    const h = setup({ customDefaultActive: true });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Set as default for new bins' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Manage tags…' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Reset to factory defaults' }));
+    expect(h.onSetDefault).toHaveBeenCalled();
+    expect(h.onOpenTagManager).toHaveBeenCalled();
+    expect(h.onResetFactory).toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/components/DesignListDialog/DesignListOptionsMenu.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListOptionsMenu.tsx
@@ -1,0 +1,81 @@
+import { useTranslation } from '@/i18n';
+import { Menu } from '@/design-system';
+
+interface DesignListOptionsMenuProps {
+  open: boolean;
+  position: { x: number; y: number };
+  customDefaultActive: boolean;
+  onClose: () => void;
+  onSetDefault: () => void;
+  onOpenTagManager: () => void;
+  onResetFactory: () => void;
+}
+
+/** Overflow ("...") menu for new-bin default management and tag administration. */
+export function DesignListOptionsMenu({
+  open,
+  position,
+  customDefaultActive,
+  onClose,
+  onSetDefault,
+  onOpenTagManager,
+  onResetFactory,
+}: DesignListOptionsMenuProps) {
+  const t = useTranslation();
+
+  return (
+    <Menu.Root open={open} onClose={onClose} position={position} className="min-w-[18rem]">
+      {customDefaultActive && (
+        <div
+          className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-content-tertiary"
+          aria-hidden="true"
+        >
+          <span className="h-2 w-2 rounded-full bg-accent" />
+          {t('binDesigner.customDefaultActive')}
+        </div>
+      )}
+      <Menu.Item
+        icon={
+          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        }
+        onClick={onSetDefault}
+      >
+        {t('binDesigner.setAsDefault')}
+      </Menu.Item>
+      <Menu.Item
+        icon={
+          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
+            />
+          </svg>
+        }
+        onClick={onOpenTagManager}
+      >
+        {t('binDesigner.tagManager.menuItem')}
+      </Menu.Item>
+      <Menu.Divider />
+      <Menu.Item
+        icon={
+          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+        }
+        disabled={!customDefaultActive}
+        onClick={onResetFactory}
+      >
+        {t('binDesigner.resetFactoryDefaults')}
+      </Menu.Item>
+    </Menu.Root>
+  );
+}

--- a/src/features/bin-designer/components/DesignListDialog/DesignListSkeleton.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListSkeleton.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { DesignListSkeleton } from './DesignListSkeleton';
+
+describe('DesignListSkeleton', () => {
+  it('renders three placeholder rows', () => {
+    const { container } = render(<DesignListSkeleton />);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
+  });
+
+  it('opts placeholder rows out of animation under reduced motion', () => {
+    const { container } = render(<DesignListSkeleton />);
+    expect(container.querySelectorAll('.motion-reduce\\:animate-none')).toHaveLength(3);
+  });
+});

--- a/src/features/bin-designer/components/DesignListDialog/DesignListSkeleton.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListSkeleton.tsx
@@ -1,0 +1,19 @@
+/** Loading placeholder rows shown while the saved-design list is being fetched. */
+export function DesignListSkeleton() {
+  return (
+    <div className="space-y-2 py-2">
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="flex animate-pulse motion-reduce:animate-none items-center gap-3 rounded-lg border border-stroke-subtle px-3 py-2.5"
+        >
+          <div className="h-10 w-10 flex-shrink-0 rounded-md bg-surface-elevated" />
+          <div className="flex-1 space-y-1.5">
+            <div className="h-3.5 w-24 rounded bg-surface-elevated" />
+            <div className="h-3 w-16 rounded bg-surface-elevated" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/DesignListDialog/designListSort.test.ts
+++ b/src/features/bin-designer/components/DesignListDialog/designListSort.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { designId } from '@/core/types';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import type { SavedDesign } from '@/features/bin-designer/types';
+import { filterAndSortDesigns, SORT_OPTIONS, SORT_OPTION_KEYS } from './designListSort';
+
+function makeDesign(overrides: {
+  id: string;
+  name?: string;
+  params?: SavedDesign['params'];
+  updatedAt?: string;
+  tags?: readonly string[];
+}): SavedDesign {
+  return {
+    id: designId(overrides.id),
+    name: overrides.name ?? 'Design',
+    params: overrides.params ?? { ...DEFAULT_BIN_PARAMS },
+    thumbnail: null,
+    exportFileNameConfig: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00.000Z',
+    tags: overrides.tags,
+  };
+}
+
+const noFilter = { activeTags: [] as string[], searchQuery: '', currentDesignId: null };
+
+describe('designListSort constants', () => {
+  it('exposes the three sort options with i18n keys', () => {
+    expect(SORT_OPTIONS).toEqual(['recent', 'name', 'size']);
+    for (const option of SORT_OPTIONS) {
+      expect(SORT_OPTION_KEYS[option]).toMatch(/^binDesigner\.sort/);
+    }
+  });
+});
+
+describe('filterAndSortDesigns', () => {
+  const alpha = makeDesign({ id: 'a', name: 'Alpha', updatedAt: '2026-01-01T00:00:00.000Z' });
+  const bravo = makeDesign({ id: 'b', name: 'Bravo', updatedAt: '2026-03-01T00:00:00.000Z' });
+  const charlie = makeDesign({ id: 'c', name: 'Charlie', updatedAt: '2026-02-01T00:00:00.000Z' });
+
+  it('sorts by most-recently updated by default', () => {
+    const result = filterAndSortDesigns([alpha, bravo, charlie], { ...noFilter, sortBy: 'recent' });
+    expect(result.map((d) => d.id)).toEqual([bravo.id, charlie.id, alpha.id]);
+  });
+
+  it('sorts by name A-Z', () => {
+    const result = filterAndSortDesigns([charlie, alpha, bravo], { ...noFilter, sortBy: 'name' });
+    expect(result.map((d) => d.name)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+  });
+
+  it('sorts by size largest-first', () => {
+    const small = makeDesign({
+      id: 's',
+      name: 'Small',
+      params: { ...DEFAULT_BIN_PARAMS, width: 1, depth: 1, height: 1 },
+    });
+    const large = makeDesign({
+      id: 'l',
+      name: 'Large',
+      params: { ...DEFAULT_BIN_PARAMS, width: 5, depth: 4, height: 3 },
+    });
+    const result = filterAndSortDesigns([small, large], { ...noFilter, sortBy: 'size' });
+    expect(result.map((d) => d.id)).toEqual([large.id, small.id]);
+  });
+
+  it('pins the active design first regardless of sort', () => {
+    const result = filterAndSortDesigns([bravo, charlie, alpha], {
+      ...noFilter,
+      sortBy: 'name',
+      currentDesignId: charlie.id,
+    });
+    expect(result[0].id).toBe(charlie.id);
+  });
+
+  it('filters by search query (case-insensitive substring on name)', () => {
+    const result = filterAndSortDesigns([alpha, bravo, charlie], {
+      activeTags: [],
+      searchQuery: 'RaV',
+      sortBy: 'name',
+      currentDesignId: null,
+    });
+    expect(result.map((d) => d.name)).toEqual(['Bravo']);
+  });
+
+  it('filters by active tags', () => {
+    const tagged = makeDesign({ id: 't', name: 'Tagged', tags: ['kitchen'] });
+    const untagged = makeDesign({ id: 'u', name: 'Untagged' });
+    const result = filterAndSortDesigns([tagged, untagged], {
+      activeTags: ['kitchen'],
+      searchQuery: '',
+      sortBy: 'name',
+      currentDesignId: null,
+    });
+    expect(result.map((d) => d.id)).toEqual([tagged.id]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [bravo, alpha, charlie];
+    const snapshot = [...input];
+    filterAndSortDesigns(input, { ...noFilter, sortBy: 'name' });
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/src/features/bin-designer/components/DesignListDialog/designListSort.ts
+++ b/src/features/bin-designer/components/DesignListDialog/designListSort.ts
@@ -1,0 +1,58 @@
+import { filterByTags } from '@/features/bin-designer/utils/tagFilter';
+import { designFootprint } from '../../utils/designKind';
+import type { SavedDesign } from '../../types';
+
+export type SortOption = 'recent' | 'name' | 'size';
+
+/** Sort option values - labels are generated dynamically via i18n */
+export const SORT_OPTIONS: readonly SortOption[] = ['recent', 'name', 'size'] as const;
+
+/** i18n key mapping for sort options */
+export const SORT_OPTION_KEYS: Record<SortOption, string> = {
+  recent: 'binDesigner.sortRecent',
+  name: 'binDesigner.sortName',
+  size: 'binDesigner.sortSize',
+};
+
+interface FilterAndSortOptions {
+  activeTags: readonly string[];
+  searchQuery: string;
+  sortBy: SortOption;
+  currentDesignId: string | null;
+}
+
+/**
+ * Filter designs by active tags and search query, then sort by the chosen
+ * option. The active design is always pinned first.
+ */
+export function filterAndSortDesigns(
+  designs: readonly SavedDesign[],
+  { activeTags, searchQuery, sortBy, currentDesignId }: FilterAndSortOptions
+): SavedDesign[] {
+  let filtered = filterByTags(designs, activeTags);
+  if (searchQuery.trim()) {
+    const query = searchQuery.toLowerCase();
+    filtered = filtered.filter((d) => d.name.toLowerCase().includes(query));
+  }
+
+  return [...filtered].sort((a, b) => {
+    // Active design always first
+    if (a.id === currentDesignId) return -1;
+    if (b.id === currentDesignId) return 1;
+
+    switch (sortBy) {
+      case 'name':
+        return a.name.localeCompare(b.name);
+      case 'size': {
+        const af = designFootprint(a);
+        const bf = designFootprint(b);
+        const aSize = af.width * af.depth * Math.max(af.height, 1);
+        const bSize = bf.width * bf.depth * Math.max(bf.height, 1);
+        return bSize - aSize;
+      }
+      case 'recent':
+      default:
+        return b.updatedAt.localeCompare(a.updatedAt);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Behavior-preserving decomposition of the 921-line `DesignListDialog.tsx`. Public API unchanged (same barrel export; only consumer `DesignerPage.tsx` unaffected).

| Module | Lines | Role |
|--------|------:|------|
| `DesignListDialog.tsx` | 921 → **689** | Thin orchestrator (state + handlers) |
| `designListSort.ts` | 58 | Pure `filterAndSortDesigns` + sort options |
| `DesignListHeader.tsx` | 104 | Title / select / import / new / options bar |
| `DesignListOptionsMenu.tsx` | 81 | Overflow menu |
| `DesignItemsView.tsx` | 86 | Grid/list item renderer |
| `DesignListEmptyState` / `NoResults` / `Skeleton` | 46/29/19 | States |

Each new module has a colocated test.

**Deliberately left in the orchestrator:** the entangled stateful core (load effect, thumbnail regen, render-phase selection pruning, focus-trap, CRUD/bulk/import handlers) — order-sensitive, so extracting it risked behavior change for little gain. Only the low-risk presentational + pure-sort slices were lifted.

## Test plan
- [x] `pnpm run typecheck`
- [x] `DesignListDialog` dir (75) + broader `bin-designer/components` (2200) — green (the pre-existing 17-test `DesignListDialog.test.tsx` passing against the refactored orchestrator is the behavior-preservation proof)
- [x] eslint + i18n + boundaries + design-system + component-structure + missing-tests gates — all pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `DesignListDialog` into small, focused modules with behavior preserved and the public API unchanged. This improves readability and adds targeted tests without affecting `DesignerPage`.

- **Refactors**
  - Moved sort/filter logic to `designListSort.ts` (`filterAndSortDesigns`, `SORT_OPTIONS`, `SORT_OPTION_KEYS`).
  - Extracted UI pieces: `DesignListHeader`, `DesignListOptionsMenu`, `DesignItemsView`, `DesignListSkeleton`, `DesignListEmptyState`, `DesignListNoResults`.
  - Kept the stateful orchestration in `DesignListDialog.tsx`; replaced inline rendering with the new components.
  - Added colocated tests for each new module.

<sup>Written for commit b7c87b64402b51e1e3fa053402a788039ec6ee91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

