### PR TITLE
refactor: extract a shared pointsBounds helper

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/pathGeometry.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/pathGeometry.ts
@@ -16,6 +16,7 @@
 
 import { MIN_PATH_POINTS } from '@/features/bin-designer/types';
 import type { PathPoint } from '@/features/bin-designer/types';
+import { pointsBounds } from '@/shared/utils/pointsBounds';
 import type { Bounds } from './geometry';
 import { flattenPath, type Point2D } from './pathGeometryBezier';
 
@@ -45,20 +46,7 @@ export function getPathBounds(points: readonly PathPoint[]): Bounds {
   }
 
   // For accuracy with bezier curves, flatten first
-  const flat = flattenPath(points);
-  let minX = Infinity,
-    minY = Infinity,
-    maxX = -Infinity,
-    maxY = -Infinity;
-
-  for (const p of flat) {
-    if (p.x < minX) minX = p.x;
-    if (p.y < minY) minY = p.y;
-    if (p.x > maxX) maxX = p.x;
-    if (p.y > maxY) maxY = p.y;
-  }
-
-  return { minX, minY, maxX, maxY };
+  return pointsBounds(flattenPath(points));
 }
 
 // Re-exported from utils/ so the cutout store can share the same transforms

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/outlineShapeGeometry.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/outlineShapeGeometry.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from 'three';
+import { pointsBounds } from '@/shared/utils/pointsBounds';
 
 /** Vertex shader passing local position for distance-field texture lookup. */
 export const outlineVertexShader = /* glsl */ `
@@ -50,18 +51,13 @@ export function bakeDistanceField(
   centerX: number,
   centerY: number
 ): { texture: THREE.DataTexture; boundsMin: [number, number]; boundsSize: [number, number] } {
-  let minX = Infinity,
-    minY = Infinity,
-    maxX = -Infinity,
-    maxY = -Infinity;
-  for (const p of polygon) {
-    const lx = p.x - centerX;
-    const ly = p.y - centerY;
-    if (lx < minX) minX = lx;
-    if (ly < minY) minY = ly;
-    if (lx > maxX) maxX = lx;
-    if (ly > maxY) maxY = ly;
-  }
+  // Bounds are in local (recentered) space; the recenter is a constant offset,
+  // so it factors out of the min/max and can be applied to the world-space box.
+  const b = pointsBounds(polygon);
+  let minX = b.minX - centerX;
+  let minY = b.minY - centerY;
+  let maxX = b.maxX - centerX;
+  let maxY = b.maxY - centerY;
   const pad = 0.5;
   minX -= pad;
   minY -= pad;

--- a/src/shared/utils/cutoutPolygon.ts
+++ b/src/shared/utils/cutoutPolygon.ts
@@ -13,6 +13,7 @@
 // Import via the shared barrel (not @/features/*) so this shared utility never
 // reaches into a feature — keeps the features → shared → core direction intact.
 import { MIN_POLYGON_SIDES, MAX_POLYGON_SIDES } from '@/shared/types/bin';
+import { pointsBounds } from './pointsBounds';
 
 export interface PolygonPoint {
   readonly x: number;
@@ -45,27 +46,6 @@ function unitPolygonVertices(sides: number): PolygonPoint[] {
   return verts;
 }
 
-interface Bbox {
-  readonly minX: number;
-  readonly minY: number;
-  readonly maxX: number;
-  readonly maxY: number;
-}
-
-function boundsOf(points: readonly PolygonPoint[]): Bbox {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const p of points) {
-    if (p.x < minX) minX = p.x;
-    if (p.y < minY) minY = p.y;
-    if (p.x > maxX) maxX = p.x;
-    if (p.y > maxY) maxY = p.y;
-  }
-  return { minX, minY, maxX, maxY };
-}
-
 /**
  * Vertices of a regular polygon centered at the origin, scaled to fill the
  * given `width × depth` bounding box exactly. CCW order. Degenerate sizes
@@ -74,7 +54,7 @@ function boundsOf(points: readonly PolygonPoint[]): Bbox {
 export function regularPolygonPoints(sides: number, width: number, depth: number): PolygonPoint[] {
   if (width <= 0 || depth <= 0) return [];
   const unit = unitPolygonVertices(sides);
-  const b = boundsOf(unit);
+  const b = pointsBounds(unit);
   const uw = b.maxX - b.minX;
   const uh = b.maxY - b.minY;
   if (uw <= 0 || uh <= 0) return [];
@@ -90,7 +70,7 @@ export function regularPolygonPoints(sides: number, width: number, depth: number
  * (≈1.1547 for a hexagon: point-to-point is wider than flat-to-flat).
  */
 function polygonAspect(sides: number): number {
-  const b = boundsOf(unitPolygonVertices(sides));
+  const b = pointsBounds(unitPolygonVertices(sides));
   const uw = b.maxX - b.minX;
   const uh = b.maxY - b.minY;
   return uh > 0 ? uw / uh : 1;

--- a/src/shared/utils/pointsBounds.test.ts
+++ b/src/shared/utils/pointsBounds.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { pointsBounds } from './pointsBounds';
+
+describe('pointsBounds', () => {
+  it('computes the bounding box of a point list', () => {
+    expect(
+      pointsBounds([
+        { x: 1, y: 2 },
+        { x: -3, y: 5 },
+        { x: 4, y: -1 },
+      ])
+    ).toEqual({ minX: -3, minY: -1, maxX: 4, maxY: 5 });
+  });
+
+  it('collapses to a point for a single vertex', () => {
+    expect(pointsBounds([{ x: 7, y: -2 }])).toEqual({ minX: 7, minY: -2, maxX: 7, maxY: -2 });
+  });
+
+  it('returns the inverted-infinite box for an empty list', () => {
+    expect(pointsBounds([])).toEqual({
+      minX: Infinity,
+      minY: Infinity,
+      maxX: -Infinity,
+      maxY: -Infinity,
+    });
+  });
+
+  it('handles all-negative coordinates', () => {
+    expect(
+      pointsBounds([
+        { x: -10, y: -4 },
+        { x: -2, y: -8 },
+      ])
+    ).toEqual({ minX: -10, minY: -8, maxX: -2, maxY: -4 });
+  });
+
+  it('accepts a readonly array', () => {
+    const pts: readonly { x: number; y: number }[] = [
+      { x: 0, y: 0 },
+      { x: 6, y: 3 },
+    ];
+    expect(pointsBounds(pts)).toEqual({ minX: 0, minY: 0, maxX: 6, maxY: 3 });
+  });
+
+  it('skips NaN coordinates rather than poisoning the bounds', () => {
+    expect(
+      pointsBounds([
+        { x: 1, y: 1 },
+        { x: NaN, y: NaN },
+        { x: 3, y: 5 },
+      ])
+    ).toEqual({ minX: 1, minY: 1, maxX: 3, maxY: 5 });
+  });
+});

--- a/src/shared/utils/pointsBounds.ts
+++ b/src/shared/utils/pointsBounds.ts
@@ -1,0 +1,27 @@
+/**
+ * Axis-aligned bounding box of a 2D point list.
+ *
+ * An empty input yields the inverted-infinite box
+ * (`minX`/`minY` = +Infinity, `maxX`/`maxY` = -Infinity) — the min/max
+ * identity every caller's hand-rolled loop already produced. Callers that need
+ * a concrete box guard the empty case themselves or test `Number.isFinite` on
+ * the result.
+ */
+export function pointsBounds(points: readonly { x: number; y: number }[]): {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+} {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { minX, minY, maxX, maxY };
+}


### PR DESCRIPTION
## Summary

The 2D min/max AABB loop over a point list was copy-pasted ~10×. Adds one shared `pointsBounds(points) => {minX,minY,maxX,maxY}` in `src/shared/utils/` (with a test) and adopts it where the loop is exactly that pattern. Behavior byte-identical.

## Adopted (3)
- `cutoutPolygon.ts` — replaced the private `boundsOf` + `Bbox`.
- `CutoutsSection/pathGeometry.ts` (`getPathBounds`) — exact pattern.
- `CutoutsSection/renderer/outlineShapeGeometry.ts` (`bakeDistanceField`) — recenters points by a **constant** offset, which factors out of min/max (`min(pₓ−c)=min(pₓ)−c`); adapted with a WHY comment.

## Skipped (5, with reason)
`geometryAlign`, `geometryCore`, `offBoardCutouts` (sub-bounds **merges**, not point lists); `maskFit` (per-point **non-constant** `rotatePoint` transform — would need an allocating `.map` in a drag hot-path); `scanIngest` (rectangle-footprint merge). Not forced.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pointsBounds` + `cutoutPolygon` (20) and full `CutoutsSection` suite (779) — green (`bakeDistanceField`'s test exercises the non-zero-center recenter path)
- [x] eslint + `check:boundaries` clean (`pointsBounds` in `shared/`, features→shared is allowed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `pointsBounds(points) => { minX, minY, maxX, maxY }` to remove duplicated AABB loops and keep behavior consistent across the codebase. Behavior is unchanged and covered by new tests.

- **Refactors**
  - Added `src/shared/utils/pointsBounds.ts` with `pointsBounds.test.ts`.
  - Replaced local loops in `src/shared/utils/cutoutPolygon.ts`, `CutoutsSection/pathGeometry.ts` (`getPathBounds`), and `CutoutsSection/renderer/outlineShapeGeometry.ts` (applies constant recenter offset).
  - Skipped `geometryAlign`, `geometryCore`, `offBoardCutouts` (sub-bounds merges), `maskFit` (non-constant per-point transform), and `scanIngest` (rectangle merge).

<sup>Written for commit 242baa2a9b3e957a994068e93aeada0db4096839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

