### PR TITLE
refactor: replace type-hiding double-casts with proper types/guards

### DIFF
--- a/src/core/api/share.ts
+++ b/src/core/api/share.ts
@@ -135,8 +135,9 @@ function validateFetchShareResponse(
   }
 
   // Drop anything malformed rather than rejecting the whole share — a bad
-  // design entry should cost that one design, not the layout.
-  const raw: unknown = (data as unknown as Record<string, unknown>).linkedDesigns;
+  // design entry should cost that one design, not the layout. The structure
+  // guard doesn't validate this field, so re-check it as untrusted input.
+  const raw: unknown = data.linkedDesigns;
   const linkedDesigns = Array.isArray(raw)
     ? raw.filter(
         (entry): entry is SharedLinkedDesign =>

--- a/src/core/cqrs/types.ts
+++ b/src/core/cqrs/types.ts
@@ -31,8 +31,11 @@ export interface EventMeta {
   readonly aggregateId: LayoutId;
   /** Monotonically increasing version per aggregate for ordering */
   readonly version: number;
-  /** Schema version for forward-compatible event migration */
-  readonly schemaVersion: number;
+  /**
+   * Schema version for forward-compatible event migration. Absent on events
+   * persisted before versioning existed; `migrateEvent` treats missing as v1.
+   */
+  readonly schemaVersion?: number;
 }
 export interface BaseCommand<TType extends string, TPayload> {
   readonly type: TType;

--- a/src/core/cqrs/v2/domain/library/setCloudShare.test.ts
+++ b/src/core/cqrs/v2/domain/library/setCloudShare.test.ts
@@ -16,7 +16,7 @@ describe('v2 library.setCloudShare', () => {
   it('emits library.cloudShareUpdated with the share info', () => {
     const library = makeLibrary();
     const result = setCloudShare.handle(
-      { layoutId: 'layout_1', shareInfo: { ...sampleShare, url: 'https://example.com' } },
+      { layoutId: 'layout_1', shareInfo: sampleShare },
       { aggregate: library }
     );
 
@@ -27,7 +27,7 @@ describe('v2 library.setCloudShare', () => {
   it('apply() sets cloudShare on the matching entry', () => {
     const library = makeLibrary({ entries: [makeEntry('layout_1')] });
     const result = setCloudShare.handle(
-      { layoutId: 'layout_1', shareInfo: { ...sampleShare, url: 'https://example.com' } },
+      { layoutId: 'layout_1', shareInfo: sampleShare },
       { aggregate: library }
     );
     if (!isOk(result)) throw new Error('handle failed');
@@ -44,7 +44,7 @@ describe('v2 library.setCloudShare', () => {
   it('apply() no-ops when the layoutId is unknown', () => {
     const library = makeLibrary();
     const result = setCloudShare.handle(
-      { layoutId: 'layout_gone', shareInfo: { ...sampleShare, url: 'https://example.com' } },
+      { layoutId: 'layout_gone', shareInfo: sampleShare },
       { aggregate: library }
     );
     if (!isOk(result)) throw new Error('handle failed');

--- a/src/core/cqrs/v2/domain/library/setCloudShare.ts
+++ b/src/core/cqrs/v2/domain/library/setCloudShare.ts
@@ -12,9 +12,17 @@ import { layoutId as toLayoutId } from '@/core/types';
 import type { CloudShareInfo } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
 
+const cloudShareInfoSchema = z.object({
+  id: z.string(),
+  deleteToken: z.string(),
+  sharedAt: z.number(),
+  permission: z.enum(['view', 'edit']),
+  lastUpdatedAt: z.number().optional(),
+});
+
 const payloadSchema = z.object({
   layoutId: z.string().min(1),
-  shareInfo: z.object({ id: z.string(), url: z.string() }).loose(),
+  shareInfo: cloudShareInfoSchema,
 });
 
 export const setCloudShare = defineCommand({
@@ -28,11 +36,7 @@ export const setCloudShare = defineCommand({
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload) => {
     const layoutId = toLayoutId(payload.layoutId);
-    // Central schema enforces {id, url} + .loose() — full CloudShareInfo
-    // shape (deleteToken, sharedAt, permission) is supplied by callers
-    // and trusted here. Cast through unknown because the validator only
-    // guarantees the two required fields.
-    const shareInfo = payload.shareInfo as unknown as CloudShareInfo;
+    const shareInfo: CloudShareInfo = payload.shareInfo;
     return ok({
       value: undefined,
       event: { payload: { layoutId, shareInfo } },

--- a/src/core/cqrs/versioning/migrations.ts
+++ b/src/core/cqrs/versioning/migrations.ts
@@ -58,10 +58,8 @@ export function migrateEvent(event: DomainEvent): DomainEvent {
   // Unknown event type (e.g., removed from the codebase) — return as-is
   if (currentVersion === undefined) return event;
 
-  const eventVersion =
-    (event.meta as unknown as Readonly<Record<string, unknown>>).schemaVersion ?? 1;
+  const eventVersion = event.meta.schemaVersion ?? 1;
 
-  if (typeof eventVersion !== 'number') return event;
   if (eventVersion >= currentVersion) return event;
 
   let migrated: unknown = event;

--- a/src/core/storage/wwwMigration.ts
+++ b/src/core/storage/wwwMigration.ts
@@ -74,6 +74,19 @@ interface MigrationError {
 
 type BridgeResponse = MigrationComplete | MigrationError;
 
+/** Narrow an untrusted postMessage payload to a well-formed bridge response. */
+function isBridgeResponse(value: unknown): value is BridgeResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (obj.type === 'www-migration-complete') {
+    return typeof obj.stats === 'object' && obj.stats !== null;
+  }
+  if (obj.type === 'www-migration-error') {
+    return typeof obj.error === 'string';
+  }
+  return false;
+}
+
 /** Collect all gridfinity-* keys from localStorage. */
 export function readAllLocalStorage(): Record<string, string> {
   const data: Record<string, string> = {};
@@ -179,12 +192,11 @@ function sendToBridge(data: MigrationData): Promise<BridgeResponse> {
 
     function onMessage(event: MessageEvent): void {
       if (event.origin !== CANONICAL_ORIGIN) return;
-      const msg = event.data as Record<string, unknown> | undefined;
-      if (!msg) return;
-      if (msg.type !== 'www-migration-complete' && msg.type !== 'www-migration-error') return;
+      const msg: unknown = event.data;
+      if (!isBridgeResponse(msg)) return;
 
       cleanup();
-      resolve(msg as unknown as BridgeResponse);
+      resolve(msg);
     }
 
     function cleanup(): void {

--- a/src/features/baseplate/sync/baseplateAdapter.test.ts
+++ b/src/features/baseplate/sync/baseplateAdapter.test.ts
@@ -27,7 +27,16 @@ vi.mock('@/features/baseplate/store/baseplateRegistry', () => ({
 import { baseplateAdapter } from './baseplateAdapter';
 import { __resetForTests, emit } from './baseplateEvents';
 
-const sampleParams = (): StoredBaseplateParams => ({}) as StoredBaseplateParams;
+const sampleParams = (): StoredBaseplateParams =>
+  ({
+    magnetHoles: false,
+    magnetDiameter: 6.5,
+    magnetDepth: 2.4,
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingFront: 0,
+    paddingBack: 0,
+  }) as StoredBaseplateParams;
 const samplePayload = (name = 'B'): { name: string; params: StoredBaseplateParams } => ({
   name,
   params: sampleParams(),
@@ -61,8 +70,8 @@ describe('baseplateAdapter.list', () => {
     expect(items.map((i) => i.id)).toEqual(['baseplate_1_a', 'baseplate_2_b']);
     expect(items[0].modifiedAt).toBe(Date.parse('2026-01-01T00:00:00.000Z'));
     expect(items[1].modifiedAt).toBe(Date.parse('2026-01-02T00:00:00.000Z'));
-    expect(items[0].payload).toEqual({ name: 'Alpha', params: {} });
-    expect(items[1].payload).toEqual({ name: 'Beta', params: {} });
+    expect(items[0].payload).toEqual({ name: 'Alpha', params: sampleParams() });
+    expect(items[1].payload).toEqual({ name: 'Beta', params: sampleParams() });
   });
 
   it('returns [] when listDesigns errors', async () => {
@@ -84,7 +93,7 @@ describe('baseplateAdapter.get', () => {
     const item = await baseplateAdapter.get('bp1');
     expect(item?.id).toBe('bp1');
     expect(item?.modifiedAt).toBe(Date.parse('2026-03-01T00:00:00.000Z'));
-    expect(item?.payload).toEqual({ name: 'My Plate', params: {} });
+    expect(item?.payload).toEqual({ name: 'My Plate', params: sampleParams() });
   });
 });
 

--- a/src/features/baseplate/sync/baseplateAdapter.ts
+++ b/src/features/baseplate/sync/baseplateAdapter.ts
@@ -41,27 +41,53 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Validate a remote params blob against the always-present v1 fields of
+ * StoredBaseplateParams before trusting it. Mirrors the required-field posture
+ * of `api/lib/baseplateValidation.ts` (server code can't be imported across the
+ * module boundary); numeric ranges stay a server concern. A malformed object —
+ * missing or mistyped required field, or an array — is rejected so a corrupt
+ * remote record is dropped rather than persisted.
+ */
+function isStoredBaseplateParams(value: unknown): value is StoredBaseplateParams {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.magnetHoles !== 'boolean') return false;
+  return (
+    isFiniteNumber(value.magnetDiameter) &&
+    isFiniteNumber(value.magnetDepth) &&
+    isFiniteNumber(value.paddingLeft) &&
+    isFiniteNumber(value.paddingRight) &&
+    isFiniteNumber(value.paddingFront) &&
+    isFiniteNumber(value.paddingBack)
+  );
+}
+
 /**
  * Accept either the `{ name, params }` wrapper or a bare params shape so a
  * legacy cloud blob still applies cleanly. Returns `null` for a malformed
- * payload (non-object or array params) so the caller can drop it rather than
- * persist a record that reads back corrupt and vanishes.
+ * payload (non-object, array, or params missing the required v1 fields) so the
+ * caller can drop it rather than persist a record that reads back corrupt and
+ * vanishes.
  */
 function unwrap(payload: unknown): { name?: string; params: StoredBaseplateParams } | null {
   if (payload !== null && typeof payload === 'object' && 'params' in payload) {
     const { name, params } = payload as { name?: unknown; params: unknown };
-    if (isPlainObject(params)) {
+    if (isStoredBaseplateParams(params)) {
       // Empty/whitespace-only remote names become `undefined` so the
       // fallback chain kicks in.
       const trimmed = typeof name === 'string' ? name.trim() : '';
       return {
         name: trimmed === '' ? undefined : trimmed,
-        params: params as unknown as StoredBaseplateParams,
+        params,
       };
     }
     return null;
   }
-  return isPlainObject(payload) ? { params: payload as unknown as StoredBaseplateParams } : null;
+  return isStoredBaseplateParams(payload) ? { params: payload } : null;
 }
 
 export const baseplateAdapter: BaseplateAdapter = {

--- a/src/features/bin-designer/components/DevThumbnailRoute/DevThumbnailRoute.tsx
+++ b/src/features/bin-designer/components/DevThumbnailRoute/DevThumbnailRoute.tsx
@@ -23,12 +23,6 @@ import {
 
 const THUMBNAIL_SIZE = 512;
 
-interface ThumbnailCaptureBridge {
-  __thumbnailReady?: boolean;
-  __captureThumbnail?: () => string | null;
-  __exportGlb?: () => Promise<string | null>;
-}
-
 export function DevThumbnailRoute() {
   const setParams = useDesignerStore((s) => s.setParams);
   const { status, mesh, params } = useDesignerStore(
@@ -96,8 +90,7 @@ export function DevThumbnailRoute() {
       // Require a short run of stable frames so the font has resettled and
       // R3F has drawn the completed mesh before we sample the canvas.
       if (stableFrames >= 8) {
-        const bridge = window as unknown as ThumbnailCaptureBridge;
-        bridge.__captureThumbnail = (): string | null =>
+        window.__captureThumbnail = (): string | null =>
           captureThumbnailAtPreset(
             {
               width: params.width,
@@ -109,10 +102,9 @@ export function DevThumbnailRoute() {
             },
             { size: THUMBNAIL_SIZE, mimeType: 'image/png' }
           );
-        bridge.__exportGlb = exportCommunityGlb;
-        (window as unknown as { __debugScene?: () => unknown }).__debugScene =
-          __debugSceneMaterials;
-        bridge.__thumbnailReady = true;
+        window.__exportGlb = exportCommunityGlb;
+        window.__debugScene = __debugSceneMaterials;
+        window.__thumbnailReady = true;
         return;
       }
       frame = window.requestAnimationFrame(publish);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,20 @@
+// Ambient globals attached to `window` at runtime by the boot, smoke, and
+// dev-thumbnail paths. Declared here so the read/write sites stay type-safe
+// without per-call casts. Kept a global script (no imports) so `interface
+// Window` merges with lib.dom.
+
+interface Window {
+  /** Set by the inline www→canonical migration detector in index.html. */
+  __wwwMigrationPending?: boolean;
+  /** Build info published by SmokeReporter for Playwright to read back. */
+  __SMOKE_BUILD_INFO__?: {
+    version: string;
+    gitSha: string;
+    buildTime: string;
+  };
+  /** DevThumbnailRoute capture bridge (dev-only, gated by ?devThumbnails). */
+  __thumbnailReady?: boolean;
+  __captureThumbnail?: () => string | null;
+  __exportGlb?: () => Promise<string | null>;
+  __debugScene?: () => unknown;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -41,7 +41,7 @@ if (isSmokeMode()) {
   void import('./shell/smokeBoot').then(({ runSmokeBoot }) => runSmokeBoot());
 } else if (recoverFromBadWwwMigration()) {
   // Reload triggered — stop all further initialization.
-} else if ((window as unknown as { __wwwMigrationPending?: boolean }).__wwwMigrationPending) {
+} else if (window.__wwwMigrationPending) {
   void import('./core/storage/wwwMigration')
     .then(({ runWwwMigration }) => runWwwMigration())
     .catch(() => {

--- a/src/shell/SmokeReporter.tsx
+++ b/src/shell/SmokeReporter.tsx
@@ -21,7 +21,7 @@ export function SmokeReporter(): null {
       gitSha: __GIT_SHA__,
       buildTime: __BUILD_TIME__,
     };
-    (window as unknown as { __SMOKE_BUILD_INFO__: SmokeBuildInfo }).__SMOKE_BUILD_INFO__ = info;
+    window.__SMOKE_BUILD_INFO__ = info;
 
     if (window.parent === window) return;
     const payload: SmokeResultMessage = {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,6 +8,7 @@
   },
   "include": [
     "src/vite-env.d.ts",
+    "src/global.d.ts",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/*.testUtils.ts",


### PR DESCRIPTION
## Summary

Replaces 6 source `as unknown as` double-casts that hid a real type-model gap with proper types/guards (one genuinely-blocked cast left in place). No new `as any`/`as unknown as` introduced.

1. **`EventMeta.schemaVersion?: number`** — the honest type (pre-versioning events lack it). Removes the cast **and** the now-dead `typeof` guard in `migrateEvent` (`schemaVersion ?? 1` is `number`).
2. **`baseplateAdapter`** — added `isStoredBaseplateParams` validating the 7 always-required v1 fields, replacing two `params as unknown as StoredBaseplateParams` on the **cloud-sync import path**. A malformed-but-object blob is now dropped instead of trusted. *(Behavior change, defensive: legit blobs always carry these fields; test fixture updated from `{}`.)*
3. **`setCloudShare`** — command `payloadSchema.shareInfo` tightened to the full `CloudShareInfo` shape; cast → typed assignment (inference-only; runtime validation path unchanged). *(Noted a pre-existing latent mismatch in `librarySchemas.ts` `shareInfo` for a follow-up.)*
4. **`core/api/share.ts`** — `data` was already narrowed to `FetchShareResponse` (declares `linkedDesigns?`), so `data.linkedDesigns` directly; no cast needed.
5. **SKIPPED — `shared/items/registry.ts`**: genuine variance blocker (`ItemTypeDescriptor<S>` invariant `schema` + contravariant `exportFileName` param); a safe fix needs an existential redesign of `getItemDescriptor` + consumers. Left as-is.
6. **`wwwMigration`** — added `isBridgeResponse` type guard before `resolve(...)`, replacing the postMessage cast.
7. **`global.d.ts` (new)** — `interface Window` augmentation for the dev/smoke globals, removing 4 `window as unknown as {...}` casts (`main.tsx`, `SmokeReporter`, `DevThumbnailRoute` ×2). Added to `tsconfig.test.json` include so the test project sees it.

## Test plan
- [x] `pnpm run typecheck`
- [x] 6 touched slices (baseplate/sync, cqrs library + versioning, core/api, shared/items, core/storage) — **720 tests passed**
- [x] eslint clean; `git diff` confirms no new `as unknown as`/`as any`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unsafe `as unknown as` double-casts with proper types and guards to improve type safety and runtime robustness. One variance-blocked cast remains by design.

- **Refactors**
  - Made `EventMeta.schemaVersion` optional; migration uses `schemaVersion ?? 1`.
  - Tightened `setCloudShare` payload to `CloudShareInfo`; removed casts in handler and `core/api/share.ts`.
  - Added `Window` globals in `src/global.d.ts` and included in `tsconfig.test.json`; removed per-call `window` casts.
  - Introduced `isBridgeResponse` to validate `postMessage` payloads in `wwwMigration`.

- **Bug Fixes**
  - Baseplate cloud-sync import now validates `StoredBaseplateParams` via `isStoredBaseplateParams`; malformed blobs are dropped.

<sup>Written for commit 3dc5bb18aec63f4dd2ae9a46b051b868962d9eeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

