### PR TITLE
refactor(api): dedup error responses via sendError/sendJson

### DIFF
--- a/api/auth/callback/[provider].ts
+++ b/api/auth/callback/[provider].ts
@@ -1,6 +1,12 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { requireMethod } from '../../lib/method.js';
-import { rateLimited, serviceUnavailable, singleParam, ErrorCode } from '../../lib/shared.js';
+import {
+  rateLimited,
+  serviceUnavailable,
+  singleParam,
+  ErrorCode,
+  sendError,
+} from '../../lib/shared.js';
 import { logger } from '../../lib/logger.js';
 import { checkRateLimit, getClientIP, getRedis } from '../../lib/rateLimit.js';
 import {
@@ -44,7 +50,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
 
   const provider = req.query.provider;
   if (typeof provider !== 'string' || !isSupportedProvider(provider)) {
-    res.status(400).json({ error: 'Unsupported provider', code: ErrorCode.VALIDATION_ERROR });
+    sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Unsupported provider');
     return;
   }
 
@@ -59,7 +65,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   const cookieState = readOAuthStateCookie(req);
   if (!code || !state || !cookieState || state !== cookieState) {
     clearOAuthCookies(res);
-    res.status(400).json({ error: 'Invalid OAuth state', code: ErrorCode.VALIDATION_ERROR });
+    sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid OAuth state');
     return;
   }
 
@@ -75,7 +81,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       error: error instanceof Error ? error.message : String(error),
     });
     clearOAuthCookies(res);
-    res.status(400).json({ error: 'OAuth exchange failed', code: ErrorCode.VALIDATION_ERROR });
+    sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'OAuth exchange failed');
     return;
   }
 

--- a/api/auth/login/[provider].ts
+++ b/api/auth/login/[provider].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { requireMethod } from '../../lib/method.js';
-import { rateLimited, ErrorCode } from '../../lib/shared.js';
+import { rateLimited, ErrorCode, sendError } from '../../lib/shared.js';
 import { logger } from '../../lib/logger.js';
 import { checkRateLimit, getClientIP } from '../../lib/rateLimit.js';
 import { setOAuthStateCookie, setOAuthVerifierCookie } from '../../lib/cookies.js';
@@ -21,7 +21,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
 
   const provider = req.query.provider;
   if (typeof provider !== 'string' || !isSupportedProvider(provider)) {
-    res.status(400).json({ error: 'Unsupported provider', code: ErrorCode.VALIDATION_ERROR });
+    sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Unsupported provider');
     return;
   }
 
@@ -44,6 +44,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       provider,
       error: error instanceof Error ? error.message : String(error),
     });
-    res.status(500).json({ error: 'Sign-in unavailable', code: ErrorCode.CONFIGURATION_ERROR });
+    sendError(res, 500, ErrorCode.CONFIGURATION_ERROR, 'Sign-in unavailable');
   }
 }

--- a/api/auth/me.ts
+++ b/api/auth/me.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { requireMethod } from '../lib/method.js';
 import { logger } from '../lib/logger.js';
-import { rateLimited, serviceUnavailable, ErrorCode } from '../lib/shared.js';
+import { rateLimited, serviceUnavailable, ErrorCode, sendError } from '../lib/shared.js';
 import { checkRateLimit, getClientIP, getRedis } from '../lib/rateLimit.js';
 import { checkCsrfDefense, readSession } from '../lib/session.js';
 import { readSessionCookie } from '../lib/cookies.js';
@@ -96,6 +96,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     logger.error('Failed to read user profile', {
       error: error instanceof Error ? error.message : String(error),
     });
-    res.status(500).json({ error: 'Profile read failed', code: ErrorCode.SERVER_ERROR });
+    sendError(res, 500, ErrorCode.SERVER_ERROR, 'Profile read failed');
   }
 }

--- a/api/community.ts
+++ b/api/community.ts
@@ -10,6 +10,7 @@ import {
   ErrorCode,
   getBaseUrl,
   rateLimited,
+  sendError,
   serviceUnavailable,
   singleParam,
 } from './lib/shared.js';
@@ -74,7 +75,7 @@ function communityDesignUrl(designId: string): string {
 }
 
 function badRequest(res: VercelResponse, message: string): void {
-  res.status(400).json({ error: message, code: ErrorCode.VALIDATION_ERROR });
+  sendError(res, 400, ErrorCode.VALIDATION_ERROR, message);
 }
 
 type LineageResolveResult =
@@ -221,10 +222,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
     const denied = await redis.sismember(communityDenylistKey(), session.userId);
     if (denied === 1) {
       // Deliberately neutral: the response must not reveal deny-listing.
-      res.status(403).json({
-        error: 'Publishing is not available for this account.',
-        code: ErrorCode.UNAUTHORIZED,
-      });
+      sendError(res, 403, ErrorCode.UNAUTHORIZED, 'Publishing is not available for this account.');
       return;
     }
 
@@ -244,10 +242,12 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
 
     const quota = await checkCommunityPublishQuota(redis, session.userId);
     if (!quota.ok) {
-      res.status(413).json({
-        error: `Published design limit reached (${quota.error.limit} live designs).`,
-        code: ErrorCode.SIZE_LIMIT,
-      });
+      sendError(
+        res,
+        413,
+        ErrorCode.SIZE_LIMIT,
+        `Published design limit reached (${quota.error.limit} live designs).`
+      );
       return;
     }
 
@@ -356,7 +356,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    res.status(500).json({ error: 'Failed to publish design', code: ErrorCode.SERVER_ERROR });
+    sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to publish design');
   }
 }
 
@@ -628,7 +628,7 @@ async function handleList(req: VercelRequest, res: VercelResponse): Promise<void
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    res.status(500).json({ error: 'Failed to list designs', code: ErrorCode.SERVER_ERROR });
+    sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to list designs');
   }
 }
 

--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -27,6 +27,7 @@ import {
   ErrorCode,
   methodNotAllowed,
   rateLimited,
+  sendError,
   serviceUnavailable,
   timingSafeCompare,
 } from '../lib/shared.js';
@@ -64,10 +65,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { id } = req.query;
 
   if (typeof id !== 'string' || !COMMUNITY_DESIGN_ID_REGEX.test(id)) {
-    return res.status(400).json({
-      error: 'Invalid design ID',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
+    return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid design ID');
   }
 
   switch (req.method) {
@@ -87,10 +85,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 }
 
 function designNotFound(res: VercelResponse) {
-  return res.status(404).json({
-    error: 'Design not found',
-    code: ErrorCode.NOT_FOUND,
-  });
+  return sendError(res, 404, ErrorCode.NOT_FOUND, 'Design not found');
 }
 
 /**
@@ -280,10 +275,7 @@ async function handleGet(req: VercelRequest, res: VercelResponse, id: string) {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Failed to fetch design',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to fetch design');
   }
 }
 
@@ -324,10 +316,12 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
     const denied = await redis.sismember(communityDenylistKey(), session.userId);
     if (denied === 1) {
       // Deliberately neutral: the response must not reveal deny-listing.
-      return res.status(403).json({
-        error: 'Publishing is not available for this account.',
-        code: ErrorCode.UNAUTHORIZED,
-      });
+      return sendError(
+        res,
+        403,
+        ErrorCode.UNAUTHORIZED,
+        'Publishing is not available for this account.'
+      );
     }
 
     const owns = (await redis.sismember(communityPublishedKey(session.userId), id)) === 1;
@@ -354,10 +348,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
     // even though the design itself is off the gallery.
     const status = await readModerationStatus(id, existing.status);
     if (status !== 'live') {
-      return res.status(403).json({
-        error: 'This design cannot be updated.',
-        code: ErrorCode.UNAUTHORIZED,
-      });
+      return sendError(res, 403, ErrorCode.UNAUTHORIZED, 'This design cannot be updated.');
     }
 
     // allowOverwrite because the rev derives from the stored record: a retry
@@ -455,10 +446,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Failed to update design',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to update design');
   }
 }
 
@@ -477,10 +465,7 @@ async function handleDelete(req: VercelRequest, res: VercelResponse, id: string)
         return rateLimited(res, rateLimit.retryAfterSeconds);
       }
       if (!timingSafeCompare(adminToken, expectedAdminToken)) {
-        return res.status(401).json({
-          error: 'Invalid admin token',
-          code: ErrorCode.UNAUTHORIZED,
-        });
+        return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Invalid admin token');
       }
     } else {
       // With COMMUNITY_ADMIN_TOKEN unset the admin path is disabled outright;
@@ -575,10 +560,7 @@ async function handleDelete(req: VercelRequest, res: VercelResponse, id: string)
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Failed to delete design',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to delete design');
   }
 }
 
@@ -604,10 +586,7 @@ async function handlePost(req: VercelRequest, res: VercelResponse, id: string) {
   try {
     const body: unknown = req.body;
     if (!isObject(body) || !isString(body.action)) {
-      return res.status(400).json({
-        error: 'action is required',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'action is required');
     }
     switch (body.action) {
       case 'like':
@@ -621,20 +600,14 @@ async function handlePost(req: VercelRequest, res: VercelResponse, id: string) {
       case 'export':
         return await handleCounterAction(req, res, id, 'export', body);
       default:
-        return res.status(400).json({
-          error: 'Unknown action',
-          code: ErrorCode.VALIDATION_ERROR,
-        });
+        return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Unknown action');
     }
   } catch (error) {
     logger.error('Community design action error', {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Failed to perform action',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to perform action');
   }
 }
 
@@ -720,27 +693,18 @@ async function handleReportAction(
 
   const { reason, note } = body;
   if (!isString(reason) || !(COMMUNITY_REPORT_REASONS as readonly string[]).includes(reason)) {
-    return res.status(400).json({
-      error: 'Invalid report reason',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
+    return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid report reason');
   }
   const reportReason = reason as CommunityReportReason;
   let reportNote = '';
   if (note !== undefined) {
     if (!isString(note)) {
-      return res.status(400).json({
-        error: 'note must be a string',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'note must be a string');
     }
     // The slice bounds the string before the filter's ReDoS-prone regexes run.
     reportNote = note.slice(0, COMMUNITY_REPORT_NOTE_MAX_LENGTH);
     if (reportNote !== '' && !checkText(reportNote).passed) {
-      return res.status(400).json({
-        error: 'note contains prohibited content',
-        code: ErrorCode.CONTENT_BLOCKED,
-      });
+      return sendError(res, 400, ErrorCode.CONTENT_BLOCKED, 'note contains prohibited content');
     }
   }
 
@@ -800,10 +764,7 @@ async function handleCounterAction(
 
   const { clientId } = body;
   if (!isString(clientId) || !COMMUNITY_CLIENT_ID_REGEX.test(clientId)) {
-    return res.status(400).json({
-      error: 'Invalid clientId',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
+    return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid clientId');
   }
 
   const redis = getRedis();

--- a/api/kofi-webhook.ts
+++ b/api/kofi-webhook.ts
@@ -3,7 +3,13 @@ import type { Redis } from 'ioredis';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP, getRedis } from './lib/rateLimit.js';
 import { logger } from './lib/logger.js';
-import { rateLimited, serviceUnavailable, ErrorCode, methodNotAllowed } from './lib/shared.js';
+import {
+  rateLimited,
+  serviceUnavailable,
+  ErrorCode,
+  methodNotAllowed,
+  sendError,
+} from './lib/shared.js';
 import { supportersDonorsKey, supportersMessageKey, supportersTotalsKey } from './lib/redisKeys.js';
 import {
   MESSAGE_DEDUPE_TTL_SECONDS,
@@ -74,10 +80,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const contentType = req.headers['content-type'] ?? '';
   if (!/application\/(x-www-form-urlencoded|json)/i.test(contentType)) {
     logger.warn('Ko-fi webhook rejected: unexpected content-type', { contentType });
-    return res.status(415).json({
-      error: 'Unsupported content type.',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
+    return sendError(res, 415, ErrorCode.VALIDATION_ERROR, 'Unsupported content type.');
   }
 
   const expectedToken = process.env.KOFI_VERIFICATION_TOKEN;
@@ -85,23 +88,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Fail closed: without the token we cannot tell Ko-fi from anyone else, and
     // this endpoint writes to a public page.
     logger.error('Ko-fi webhook rejected: KOFI_VERIFICATION_TOKEN is not configured');
-    return res.status(503).json({
-      error: 'Supporter sync is not configured.',
-      code: ErrorCode.CONFIGURATION_ERROR,
-    });
+    return sendError(res, 503, ErrorCode.CONFIGURATION_ERROR, 'Supporter sync is not configured.');
   }
 
   const payload = parseKofiPayload(req.body);
   if (!payload) {
-    return res.status(400).json({
-      error: 'Malformed Ko-fi payload.',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
+    return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Malformed Ko-fi payload.');
   }
 
   if (!tokensMatch(payload.verification_token, expectedToken)) {
     logger.warn('Ko-fi webhook rejected: verification token mismatch');
-    return res.status(401).json({ error: 'Invalid token.', code: ErrorCode.UNAUTHORIZED });
+    return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Invalid token.');
   }
 
   try {
@@ -177,9 +174,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     logger.error('Ko-fi webhook error', {
       error: error instanceof Error ? error.message : String(error),
     });
-    return res.status(500).json({
-      error: 'Failed to record supporter.',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to record supporter.');
   }
 }

--- a/api/lib/session.ts
+++ b/api/lib/session.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { Redis } from 'ioredis';
 import { getRedis } from './rateLimit.js';
-import { ErrorCode, serviceUnavailable } from './shared.js';
+import { ErrorCode, sendError, serviceUnavailable } from './shared.js';
 import { logger } from './logger.js';
 import { sessionKey, userSessionsKey } from './redisKeys.js';
 import { readSessionCookie } from './cookies.js';
@@ -149,13 +149,13 @@ function parseSessionRecord(raw: string): SessionRecord | null {
  */
 export function checkCsrfDefense(req: VercelRequest, res: VercelResponse): boolean {
   if (!isOriginAllowed(req)) {
-    res.status(403).json({ error: 'Forbidden origin', code: ErrorCode.UNAUTHORIZED });
+    sendError(res, 403, ErrorCode.UNAUTHORIZED, 'Forbidden origin');
     return false;
   }
   if (req.method && !SAFE_METHODS.has(req.method)) {
     const xrw = headerValue(req, 'x-requested-with');
     if (xrw !== 'gflt') {
-      res.status(403).json({ error: 'Missing CSRF header', code: ErrorCode.UNAUTHORIZED });
+      sendError(res, 403, ErrorCode.UNAUTHORIZED, 'Missing CSRF header');
       return false;
     }
   }
@@ -174,7 +174,7 @@ export async function requireSession(
 
   const token = readSessionCookie(req);
   if (!token) {
-    res.status(401).json({ error: 'Not signed in', code: ErrorCode.UNAUTHORIZED });
+    sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Not signed in');
     return null;
   }
 
@@ -185,13 +185,13 @@ export async function requireSession(
       serviceUnavailable(res);
       return null;
     }
-    res.status(401).json({ error: 'Not signed in', code: ErrorCode.UNAUTHORIZED });
+    sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Not signed in');
     return null;
   }
 
   const session = await readSession(redis, token);
   if (!session) {
-    res.status(401).json({ error: 'Session expired', code: ErrorCode.UNAUTHORIZED });
+    sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Session expired');
     return null;
   }
   return session;

--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -185,6 +185,19 @@ export function serverError(res: VercelResponse): VercelResponse {
   return res.status(500).json({ error: 'Server error', code: ErrorCode.SERVER_ERROR });
 }
 
+export function sendError(
+  res: VercelResponse,
+  status: number,
+  code: ErrorCodeType,
+  message?: string
+): VercelResponse {
+  return res.status(status).json({ error: message ?? code, code });
+}
+
+export function sendJson(res: VercelResponse, status: number, body: unknown): VercelResponse {
+  return res.status(status).json(body);
+}
+
 /** Collapse Vercel's `string | string[]` query param to its first value. */
 export function singleParam(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) return value[0];

--- a/api/liveblocks-auth.ts
+++ b/api/liveblocks-auth.ts
@@ -2,7 +2,13 @@ import { Liveblocks } from '@liveblocks/node';
 import { head } from '@vercel/blob';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP } from './lib/rateLimit.js';
-import { rateLimited, ErrorCode, isValidShareId, methodNotAllowed } from './lib/shared.js';
+import {
+  rateLimited,
+  ErrorCode,
+  isValidShareId,
+  methodNotAllowed,
+  sendError,
+} from './lib/shared.js';
 import { logger } from './lib/logger.js';
 import type { ShareData } from './lib/shared.js';
 
@@ -83,10 +89,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Check if Liveblocks is configured
     if (!process.env.LIVEBLOCKS_SECRET_KEY) {
       logger.error('LIVEBLOCKS_SECRET_KEY not configured');
-      return res.status(500).json({
-        error: 'Collaboration not configured',
-        code: ErrorCode.CONFIGURATION_ERROR,
-      });
+      return sendError(res, 500, ErrorCode.CONFIGURATION_ERROR, 'Collaboration not configured');
     }
 
     // Rate limiting - use 'view' limits (100/min) since auth is lightweight
@@ -102,34 +105,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // Validate room ID format (must be gridfinity-{shareId})
     if (!room || typeof room !== 'string') {
-      return res.status(400).json({
-        error: 'Missing room ID',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Missing room ID');
     }
 
     if (!room.startsWith('gridfinity-')) {
-      return res.status(400).json({
-        error: 'Invalid room ID format',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid room ID format');
     }
 
     // Extract share ID and validate format
     const shareId = room.replace('gridfinity-', '');
     if (!isValidShareId(shareId)) {
-      return res.status(400).json({
-        error: 'Invalid share ID',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid share ID');
     }
 
     // Validate user ID
     if (!userId || typeof userId !== 'string') {
-      return res.status(400).json({
-        error: 'Missing user ID',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Missing user ID');
     }
 
     // Fetch share metadata from Vercel Blob to check permission
@@ -137,18 +128,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const blobInfo = await head(blobPath).catch(() => null);
 
     if (!blobInfo) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     const blobResponse = await fetch(blobInfo.url);
     if (!blobResponse.ok) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     const shareData = (await blobResponse.json()) as ShareData;
@@ -175,9 +160,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Authentication failed',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Authentication failed');
   }
 }

--- a/api/report/[id].ts
+++ b/api/report/[id].ts
@@ -8,6 +8,7 @@ import {
   ErrorCode,
   methodNotAllowed,
   shareReportKey,
+  sendError,
 } from '../lib/shared.js';
 import { logger } from '../lib/logger.js';
 
@@ -38,10 +39,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { id } = req.query;
 
   if (typeof id !== 'string' || !isValidShareId(id)) {
-    return res.status(400).json({
-      error: 'Invalid share ID',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
+    return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid share ID');
   }
 
   try {
@@ -63,10 +61,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Verify the share exists before accepting the report
     const blobInfo = await head(blobPath).catch(() => null);
     if (!blobInfo) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     // Increment report count atomically in Redis (fixes TOCTOU race condition).
@@ -105,9 +100,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
   } catch (error) {
     logger.error('Report error', { error: error instanceof Error ? error.message : String(error) });
-    return res.status(500).json({
-      error: 'Failed to submit report',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to submit report');
   }
 }

--- a/api/scan-session.ts
+++ b/api/scan-session.ts
@@ -8,6 +8,7 @@ import {
   ErrorCode,
   getBaseUrl,
   methodNotAllowed,
+  sendError,
 } from './lib/shared.js';
 import { scanSessionKey } from './lib/redisKeys.js';
 import { SCAN_SESSION_TTL_SECONDS, type ScanSessionRecord } from './lib/scanSession.js';
@@ -54,9 +55,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     logger.error('Scan session create error', {
       error: error instanceof Error ? error.message : String(error),
     });
-    return res.status(500).json({
-      error: 'Failed to create scan session',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to create scan session');
   }
 }

--- a/api/scan-session/[token].ts
+++ b/api/scan-session/[token].ts
@@ -1,7 +1,13 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP, getRedis } from '../lib/rateLimit.js';
 import { logger } from '../lib/logger.js';
-import { rateLimited, serviceUnavailable, ErrorCode, methodNotAllowed } from '../lib/shared.js';
+import {
+  rateLimited,
+  serviceUnavailable,
+  ErrorCode,
+  methodNotAllowed,
+  sendError,
+} from '../lib/shared.js';
 import { scanSessionKey } from '../lib/redisKeys.js';
 import { isValidScanToken, validateScanSvg, type ScanSessionRecord } from '../lib/scanSession.js';
 
@@ -18,7 +24,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const raw = req.query.token;
   const token = Array.isArray(raw) ? raw[0] : raw;
   if (!isValidScanToken(token)) {
-    return res.status(400).json({ error: 'Invalid scan token.', code: ErrorCode.VALIDATION_ERROR });
+    return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid scan token.');
   }
 
   const redis = getRedis();
@@ -37,7 +43,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       // The session must still exist (not expired / already consumed).
       if (!(await redis.exists(key))) {
-        return res.status(404).json({ error: 'Scan session expired.', code: ErrorCode.EXPIRED });
+        return sendError(res, 404, ErrorCode.EXPIRED, 'Scan session expired.');
       }
 
       const body = (req.body ?? {}) as Record<string, unknown>;
@@ -66,9 +72,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       const stored = await redis.get(key);
       if (!stored) {
-        return res
-          .status(404)
-          .json({ error: 'Scan session not found or expired.', code: ErrorCode.EXPIRED });
+        return sendError(res, 404, ErrorCode.EXPIRED, 'Scan session not found or expired.');
       }
 
       let record: ScanSessionRecord;
@@ -76,9 +80,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         record = JSON.parse(stored) as ScanSessionRecord;
       } catch {
         // Corrupt record — treat as gone rather than 500.
-        return res
-          .status(404)
-          .json({ error: 'Scan session not found or expired.', code: ErrorCode.EXPIRED });
+        return sendError(res, 404, ErrorCode.EXPIRED, 'Scan session not found or expired.');
       }
       if (record.status === 'ready' && record.svg) {
         // Idempotent delivery: the outline stays available until the session's
@@ -98,6 +100,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     logger.error('Scan session handoff error', {
       error: error instanceof Error ? error.message : String(error),
     });
-    return res.status(500).json({ error: 'Scan handoff failed.', code: ErrorCode.SERVER_ERROR });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Scan handoff failed.');
   }
 }

--- a/api/share.ts
+++ b/api/share.ts
@@ -22,6 +22,7 @@ import {
   type ShareData,
   rateLimited,
   serviceUnavailable,
+  sendError,
 } from './lib/shared.js';
 
 /**
@@ -58,18 +59,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // Validate layoutId - must be provided by client
     if (!isValidShareId(layoutId)) {
-      return res.status(400).json({
-        error: 'Invalid or missing layoutId.',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid or missing layoutId.');
     }
 
     // Validate permission
     if (permission !== 'view' && permission !== 'edit') {
-      return res.status(400).json({
-        error: 'Invalid permission. Must be "view" or "edit".',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(
+        res,
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        'Invalid permission. Must be "view" or "edit".'
+      );
     }
 
     let sharePayload: unknown;
@@ -93,10 +93,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     } else {
       // Layout share: validate layout structure
       if (!layout) {
-        return res.status(400).json({
-          error: 'Missing layout data',
-          code: ErrorCode.VALIDATION_ERROR,
-        });
+        return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Missing layout data');
       }
 
       const layoutJson = JSON.stringify(layout);
@@ -112,10 +109,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       // Content filtering (layout shares only)
       const contentResult = filterLayoutContent(validationResult.layout);
       if (!contentResult.passed) {
-        return res.status(400).json({
-          error: `Content blocked: ${contentResult.reason}`,
-          code: ErrorCode.CONTENT_BLOCKED,
-        });
+        return sendError(
+          res,
+          400,
+          ErrorCode.CONTENT_BLOCKED,
+          `Content blocked: ${contentResult.reason}`
+        );
       }
 
       sharePayload = validationResult.layout;
@@ -133,10 +132,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       // recipient, so they get the same moderation the layout does.
       const designContent = filterSharedDesignsContent(sharedDesigns);
       if (!designContent.passed) {
-        return res.status(400).json({
-          error: `Content blocked: ${designContent.reason}`,
-          code: ErrorCode.CONTENT_BLOCKED,
-        });
+        return sendError(
+          res,
+          400,
+          ErrorCode.CONTENT_BLOCKED,
+          `Content blocked: ${designContent.reason}`
+        );
       }
     }
 
@@ -194,10 +195,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       // to distinguish "lost the race" from genuine errors.
       const collided = await head(blobPath).catch(() => null);
       if (collided) {
-        return res.status(409).json({
-          error: 'A share with this ID already exists.',
-          code: ErrorCode.VALIDATION_ERROR,
-        });
+        return sendError(
+          res,
+          409,
+          ErrorCode.VALIDATION_ERROR,
+          'A share with this ID already exists.'
+        );
       }
       throw putErr;
     }
@@ -233,9 +236,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Failed to create share',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to create share');
   }
 }

--- a/api/share/[id].ts
+++ b/api/share/[id].ts
@@ -22,16 +22,14 @@ import {
   SHARE_LAST_ACCESSED_TTL_SECONDS,
   type ShareData,
   rateLimited,
+  sendError,
 } from '../lib/shared.js';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { id } = req.query;
 
   if (typeof id !== 'string' || !isValidShareId(id)) {
-    return res.status(400).json({
-      error: 'Invalid share ID',
-      code: ErrorCode.VALIDATION_ERROR,
-    });
+    return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid share ID');
   }
 
   const blobPath = `shares/${id}.json`;
@@ -66,19 +64,13 @@ async function handleGet(req: VercelRequest, res: VercelResponse, _id: string, b
     // Check if blob exists
     const blobInfo = await head(blobPath).catch(() => null);
     if (!blobInfo) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     // Fetch the blob content
     const response = await fetch(blobInfo.url);
     if (!response.ok) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     const shareData = (await response.json()) as ShareData;
@@ -120,10 +112,7 @@ async function handleGet(req: VercelRequest, res: VercelResponse, _id: string, b
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Failed to fetch share',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to fetch share');
   }
 }
 
@@ -144,27 +133,18 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
     const { layout, permission, deleteToken, linkedDesigns } = body;
 
     if (!deleteToken || typeof deleteToken !== 'string') {
-      return res.status(401).json({
-        error: 'Delete token required for updates',
-        code: ErrorCode.UNAUTHORIZED,
-      });
+      return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Delete token required for updates');
     }
 
     // Fetch existing share
     const blobInfo = await head(blobPath).catch(() => null);
     if (!blobInfo) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     const response = await fetch(blobInfo.url);
     if (!response.ok) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     const existingData = (await response.json()) as ShareData;
@@ -175,28 +155,24 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
       (redis ? await redis.get(shareHashKey(id)) : null) ?? existingData.metadata.deleteTokenHash;
 
     if (!storedHash) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     // Verify delete token (constant-time comparison prevents timing attacks)
     const tokenHash = await hashToken(deleteToken);
     if (!timingSafeCompare(tokenHash, storedHash)) {
-      return res.status(401).json({
-        error: 'Invalid delete token',
-        code: ErrorCode.UNAUTHORIZED,
-      });
+      return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Invalid delete token');
     }
 
     // Validate permission if provided
     const newPermission = permission ?? existingData.metadata.permission;
     if (newPermission !== 'view' && newPermission !== 'edit') {
-      return res.status(400).json({
-        error: 'Invalid permission. Must be "view" or "edit".',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      return sendError(
+        res,
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        'Invalid permission. Must be "view" or "edit".'
+      );
     }
 
     const now = new Date().toISOString();
@@ -248,10 +224,12 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
     // Content filtering
     const contentResult = filterLayoutContent(validationResult.layout);
     if (!contentResult.passed) {
-      return res.status(400).json({
-        error: `Content blocked: ${contentResult.reason}`,
-        code: ErrorCode.CONTENT_BLOCKED,
-      });
+      return sendError(
+        res,
+        400,
+        ErrorCode.CONTENT_BLOCKED,
+        `Content blocked: ${contentResult.reason}`
+      );
     }
 
     const designsResult = validateSharedDesigns(linkedDesigns);
@@ -264,10 +242,12 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
 
     const designContent = filterSharedDesignsContent(designsResult.designs);
     if (!designContent.passed) {
-      return res.status(400).json({
-        error: `Content blocked: ${designContent.reason}`,
-        code: ErrorCode.CONTENT_BLOCKED,
-      });
+      return sendError(
+        res,
+        400,
+        ErrorCode.CONTENT_BLOCKED,
+        `Content blocked: ${designContent.reason}`
+      );
     }
 
     // Update share data (preserve original deleteTokenHash and createdAt;
@@ -301,10 +281,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string, bl
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Failed to update share',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to update share');
   }
 }
 
@@ -337,27 +314,18 @@ async function handleDelete(
       (typeof deleteBody.deleteToken === 'string' ? deleteBody.deleteToken : undefined);
 
     if (!deleteToken) {
-      return res.status(401).json({
-        error: 'Delete token required',
-        code: ErrorCode.UNAUTHORIZED,
-      });
+      return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Delete token required');
     }
 
     // Fetch existing share
     const blobInfo = await head(blobPath).catch(() => null);
     if (!blobInfo) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     const response = await fetch(blobInfo.url);
     if (!response.ok) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     const existingData = (await response.json()) as ShareData;
@@ -368,19 +336,13 @@ async function handleDelete(
       (redis ? await redis.get(shareHashKey(_id)) : null) ?? existingData.metadata.deleteTokenHash;
 
     if (!storedHash) {
-      return res.status(404).json({
-        error: 'Share not found',
-        code: ErrorCode.NOT_FOUND,
-      });
+      return sendError(res, 404, ErrorCode.NOT_FOUND, 'Share not found');
     }
 
     // Verify delete token (constant-time comparison prevents timing attacks)
     const tokenHash = await hashToken(deleteToken);
     if (!timingSafeCompare(tokenHash, storedHash)) {
-      return res.status(401).json({
-        error: 'Invalid delete token',
-        code: ErrorCode.UNAUTHORIZED,
-      });
+      return sendError(res, 401, ErrorCode.UNAUTHORIZED, 'Invalid delete token');
     }
 
     // Delete the blob and clean up Redis keys
@@ -398,9 +360,6 @@ async function handleDelete(
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
-    return res.status(500).json({
-      error: 'Failed to delete share',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to delete share');
   }
 }

--- a/api/supporters.ts
+++ b/api/supporters.ts
@@ -1,7 +1,13 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { checkRateLimit, getClientIP, getRedis } from './lib/rateLimit.js';
 import { logger } from './lib/logger.js';
-import { rateLimited, serviceUnavailable, ErrorCode, methodNotAllowed } from './lib/shared.js';
+import {
+  rateLimited,
+  serviceUnavailable,
+  ErrorCode,
+  methodNotAllowed,
+  sendError,
+} from './lib/shared.js';
 import { readSupporters } from './lib/supporters.js';
 
 /**
@@ -36,9 +42,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     logger.error('Supporters read error', {
       error: error instanceof Error ? error.message : String(error),
     });
-    return res.status(500).json({
-      error: 'Failed to read supporters.',
-      code: ErrorCode.SERVER_ERROR,
-    });
+    return sendError(res, 500, ErrorCode.SERVER_ERROR, 'Failed to read supporters.');
   }
 }

--- a/api/sync/lib/resourceHandler.ts
+++ b/api/sync/lib/resourceHandler.ts
@@ -18,6 +18,8 @@ import {
   serviceUnavailable,
   serverError,
   singleParam,
+  sendError,
+  sendJson,
   ErrorCode,
 } from '../../lib/shared.js';
 import { logger } from '../../lib/logger.js';
@@ -76,18 +78,18 @@ export function createSyncResourceHandler<TEnvelope extends SyncEnvelope>(
   ): Promise<void> {
     const entry = await getEntry(redis, userId, config.kind, id);
     if (!entry) {
-      res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
+      sendError(res, 404, ErrorCode.NOT_FOUND, 'Not found');
       return;
     }
     if (entry.deletedAt !== undefined) {
-      res.status(410).json({ error: 'Deleted', code: ErrorCode.NOT_FOUND, indexEntry: entry });
+      sendJson(res, 410, { error: 'Deleted', code: ErrorCode.NOT_FOUND, indexEntry: entry });
       return;
     }
     const envelope = await getJson<TEnvelope>(blobPath(userId, id));
     if (!envelope) {
       // Blob missing but index says it should exist — treat as 404 so the
       // client refreshes its view. Don't 500 since the user can't act on it.
-      res.status(404).json({ error: 'Not found', code: ErrorCode.NOT_FOUND });
+      sendError(res, 404, ErrorCode.NOT_FOUND, 'Not found');
       return;
     }
     res.status(200).json({ envelope, indexEntry: entry });
@@ -102,15 +104,12 @@ export function createSyncResourceHandler<TEnvelope extends SyncEnvelope>(
   ): Promise<void> {
     const body = req.body as Record<string, unknown> | undefined;
     if (!body || typeof body !== 'object') {
-      res.status(400).json({ error: 'Missing body', code: ErrorCode.VALIDATION_ERROR });
+      sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Missing body');
       return;
     }
     const modifiedAt = body.modifiedAt;
     if (typeof modifiedAt !== 'number' || !Number.isFinite(modifiedAt)) {
-      res.status(400).json({
-        error: 'modifiedAt must be a number (ms epoch)',
-        code: ErrorCode.VALIDATION_ERROR,
-      });
+      sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'modifiedAt must be a number (ms epoch)');
       return;
     }
 
@@ -129,7 +128,7 @@ export function createSyncResourceHandler<TEnvelope extends SyncEnvelope>(
     if (existing && existing.deletedAt === undefined) {
       if (existing.modifiedAt > modifiedAt) {
         const stored = await getJson<TEnvelope>(blobPath(userId, id));
-        res.status(409).json({
+        sendJson(res, 409, {
           error: 'A newer version already exists.',
           code: ErrorCode.VALIDATION_ERROR,
           stored,
@@ -147,7 +146,7 @@ export function createSyncResourceHandler<TEnvelope extends SyncEnvelope>(
         if (stored !== null) {
           const order = compareForTiebreaker(tiebreakerCandidate, config.storedComparable(stored));
           if (order <= 0) {
-            res.status(409).json({
+            sendJson(res, 409, {
               error: 'A newer version already exists.',
               code: ErrorCode.VALIDATION_ERROR,
               stored,
@@ -162,7 +161,7 @@ export function createSyncResourceHandler<TEnvelope extends SyncEnvelope>(
     // Tombstone protection: a stale edit can't resurrect a deletion that
     // happened *after* the local change.
     if (existing?.deletedAt !== undefined && existing.deletedAt >= modifiedAt) {
-      res.status(410).json({
+      sendJson(res, 410, {
         error: config.deletedError,
         code: ErrorCode.NOT_FOUND,
         indexEntry: existing,
@@ -178,10 +177,12 @@ export function createSyncResourceHandler<TEnvelope extends SyncEnvelope>(
       replacingId,
     });
     if (!quota.ok) {
-      res.status(413).json({
-        error: `Quota exceeded (${quota.error.reason}): ${quota.error.current} of ${quota.error.limit}.`,
-        code: ErrorCode.SIZE_LIMIT,
-      });
+      sendError(
+        res,
+        413,
+        ErrorCode.SIZE_LIMIT,
+        `Quota exceeded (${quota.error.reason}): ${quota.error.current} of ${quota.error.limit}.`
+      );
       return;
     }
 
@@ -227,7 +228,7 @@ export function createSyncResourceHandler<TEnvelope extends SyncEnvelope>(
 
     const id = singleParam(req.query.id);
     if (!id || !config.isValidId(id)) {
-      res.status(400).json({ error: config.invalidIdError, code: ErrorCode.VALIDATION_ERROR });
+      sendError(res, 400, ErrorCode.VALIDATION_ERROR, config.invalidIdError);
       return;
     }
 


### PR DESCRIPTION
## Summary

~161 raw `res.status(n).json({ error, code })` calls across `api/` are deduped through two new senders in `api/lib/shared.ts`. **HTTP contract invariant** — statuses, error codes, message text, and field names/order all byte-for-byte unchanged. 16 files, +199/−288.

- `sendError(res, status, code, message?)` → `res.status(status).json({ error: message ?? code, code })` (`code` typed to the `ErrorCode` enum).
- `sendJson(res, status, body)` → thin passthrough (used for the 4 error-with-extra-context 409/410 bodies in `resourceHandler`).

**Adopted:** 86 `sendError` + 4 `sendJson` across `share/[id]`, `community/[id]`, sync `resourceHandler`, `share`, `community`, `liveblocks-auth`, `session`, `kofi-webhook`, `scan-session`, `report`, auth handlers, etc.

**Left as-is (reason):** dynamic/validation error codes (`x.error.code` — `string`/union outside the enum), non-enum codes (`INVALID_LINEAGE`), `ml-telemetry`'s `{ error }`-without-`code` shape (genuinely different contract), and all success bodies. Only the consistent `{error, code}` majority was consolidated.

## Test plan
- [x] `pnpm run typecheck`
- [x] **`api` tests — 1486 passed** (unchanged): they assert status + body, so this is the wire-contract proof
- [x] eslint clean (`community.ts` max-lines warning actually *dropped*)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored API error handling to use `sendError` and `sendJson` helpers, replacing raw `res.status().json({ error, code })` calls. No behavior changes: HTTP statuses, error codes, and response body shape remain identical.

- **Refactors**
  - Added `sendError(res, status, code, message?)` and `sendJson(res, status, body)` in `api/lib/shared.ts`.
  - Updated handlers across auth, community, share, liveblocks-auth, session, kofi-webhook, scan-session, report, and sync resources.
  - Left dynamic/non-enum error shapes and success responses unchanged.
  - All `api` tests pass, confirming wire contract stays the same.

<sup>Written for commit e59c9b3492a68605d0bd73e506371426af0cdc33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

