### PR TITLE
test: consolidate local createTest* fixtures onto testUtils

### DIFF
--- a/src/core/storage/ShareService.test.ts
+++ b/src/core/storage/ShareService.test.ts
@@ -16,11 +16,11 @@ import {
   restoreSharedDesigns,
 } from '@/core/storage';
 import type { Layout } from '@/core/types';
-import { binId, categoryId, designId, gridUnits, heightUnits, layerId, mm } from '@/core/types';
+import { binId, categoryId, designId, gridUnits, heightUnits, layerId } from '@/core/types';
 import { getUserMessage, ok, err, storageNotFound } from '@/core/result';
 import type { Result, ValidationError, ValidationImportError } from '@/core/result';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
-import { expectOk, expectErr } from '@/test/testUtils';
+import { expectOk, expectErr, createTestLayout as baseCreateTestLayout } from '@/test/testUtils';
 
 // Mock clipboard API
 const mockClipboard = {
@@ -57,30 +57,25 @@ function expectImportError(result: Result<unknown, ValidationError>): Validation
 
 describe('storage-share', () => {
   // Create a test layout
-  const createTestLayout = (): Layout => ({
-    version: '1.0',
-    name: 'Test Layout',
-    drawer: { width: gridUnits(10), depth: gridUnits(8), height: heightUnits(12) },
-    printBedSize: mm(256),
-    gridUnitMm: mm(42),
-    heightUnitMm: mm(7),
-    categories: [{ id: categoryId('cat-1'), name: 'Red', color: '#ff0000' }],
-    layers: [{ id: layerId('layer-1'), name: 'Layer 1', height: heightUnits(3) }],
-    bins: [
-      {
-        id: binId('bin-1'),
-        x: gridUnits(0),
-        y: gridUnits(0),
-        width: gridUnits(2),
-        depth: gridUnits(2),
-        height: heightUnits(3),
-        layerId: layerId('layer-1'),
-        category: categoryId('cat-1'),
-        label: '',
-        notes: '',
-      },
-    ],
-  });
+  const createTestLayout = (): Layout =>
+    baseCreateTestLayout({
+      categories: [{ id: categoryId('cat-1'), name: 'Red', color: '#ff0000' }],
+      layers: [{ id: layerId('layer-1'), name: 'Layer 1', height: heightUnits(3) }],
+      bins: [
+        {
+          id: binId('bin-1'),
+          x: gridUnits(0),
+          y: gridUnits(0),
+          width: gridUnits(2),
+          depth: gridUnits(2),
+          height: heightUnits(3),
+          layerId: layerId('layer-1'),
+          category: categoryId('cat-1'),
+          label: '',
+          notes: '',
+        },
+      ],
+    });
 
   describe('encodeLayoutForURL', () => {
     it('encodes a layout to a URL-safe string', () => {

--- a/src/core/storage/backends/indexedDB.test.ts
+++ b/src/core/storage/backends/indexedDB.test.ts
@@ -18,21 +18,15 @@ import {
 } from '@/core/storage/backends/indexedDB';
 import type { Bin, Layout, SharedWithMeEntry } from '@/core/types';
 import { binId, categoryId, gridUnits, heightUnits, layerId, mm } from '@/core/types';
+import { createTestLayout as baseCreateTestLayout } from '@/test/testUtils';
 
 // Test fixtures
 function createTestLayout(overrides: Partial<Layout> = {}): Layout {
-  return {
-    version: '1.0',
-    name: 'Test Layout',
-    drawer: { width: gridUnits(10), depth: gridUnits(8), height: heightUnits(12) },
+  return baseCreateTestLayout({
     layers: [{ id: layerId('layer-1'), name: 'Layer 1', height: heightUnits(3) }],
-    bins: [],
     categories: [{ id: categoryId('default'), name: 'Default', color: '#3b82f6' }],
-    gridUnitMm: mm(42),
-    heightUnitMm: mm(7),
-    printBedSize: mm(256),
     ...overrides,
-  };
+  });
 }
 
 describe('indexedDB backend', () => {

--- a/src/core/storage/migration.test.ts
+++ b/src/core/storage/migration.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { expectOk, expectErr } from '@/test/testUtils';
+import { expectOk, expectErr, createTestLayout } from '@/test/testUtils';
 import { ok } from '@/core/result';
 
 // Mock all dependencies before importing the module under test
@@ -38,25 +38,6 @@ import {
   migrateAllLayoutsToIndexedDBResult,
   getMigrationStatusResult,
 } from '@/core/storage/migration';
-
-import type { Layout } from '@/core/types';
-import { gridUnits, heightUnits, mm, layerId, categoryId } from '@/core/types';
-
-// Test fixtures
-function createTestLayout(overrides: Partial<Layout> = {}): Layout {
-  return {
-    version: '1.0',
-    name: 'Test Layout',
-    drawer: { width: gridUnits(10), depth: gridUnits(8), height: heightUnits(12) },
-    layers: [{ id: layerId('layer-1'), name: 'Layer 1', height: heightUnits(3) }],
-    bins: [],
-    categories: [{ id: categoryId('default'), name: 'Default', color: '#3b82f6' }],
-    gridUnitMm: mm(42),
-    heightUnitMm: mm(7),
-    printBedSize: mm(256),
-    ...overrides,
-  };
-}
 
 describe('migration.ts', () => {
   const MIGRATION_FLAG_KEY = 'gridfinity-indexeddb-migrated';

--- a/src/shared/analytics/posthog/posthog.test.ts
+++ b/src/shared/analytics/posthog/posthog.test.ts
@@ -28,6 +28,7 @@ import {
 import { useLayoutStore } from '@/core/store/layout';
 import { createDefaultLabsPreferences } from '@/core/labs';
 import { STAGING_ID } from '@/core/constants';
+import { createTestLayout as baseCreateTestLayout } from '@/test/testUtils';
 
 const coord = (x: number, y: number): Coord => ({ x: gridUnits(x), y: gridUnits(y) });
 
@@ -90,21 +91,15 @@ const setEnabledFeatures = (enabledFeatures: Record<string, boolean>): void => {
 };
 
 // Helper to create a test layout
-const createTestLayout = (overrides?: Partial<Layout>): Layout => ({
-  version: '1.0',
-  name: 'Test Layout',
-  drawer: makeDrawer(10, 8, 12),
-  printBedSize: mm(256),
-  gridUnitMm: mm(42),
-  heightUnitMm: mm(7),
-  categories: [
-    makeCategory('coral', 'Coral', '#FF6B6B'),
-    makeCategory('custom1', 'My Custom Category', '#00FF00'),
-  ],
-  layers: [makeLayer('layer1', 'Layer 1', 3)],
-  bins: [],
-  ...overrides,
-});
+const createTestLayout = (overrides?: Partial<Layout>): Layout =>
+  baseCreateTestLayout({
+    categories: [
+      makeCategory('coral', 'Coral', '#FF6B6B'),
+      makeCategory('custom1', 'My Custom Category', '#00FF00'),
+    ],
+    layers: [makeLayer('layer1', 'Layer 1', 3)],
+    ...overrides,
+  });
 
 describe('computeLayoutMetrics', () => {
   describe('drawer configuration', () => {

--- a/src/shared/utils/compression.test.ts
+++ b/src/shared/utils/compression.test.ts
@@ -13,20 +13,15 @@ import {
   getCompressionRatio,
 } from '@/shared/utils';
 import type { Bin, Layout } from '@/core/types';
-import { binId, categoryId, gridUnits, heightUnits, layerId, mm } from '@/core/types';
+import { binId, categoryId, gridUnits, heightUnits, layerId } from '@/core/types';
+import { createTestLayout as baseCreateTestLayout } from '@/test/testUtils';
 
 const LAYER = layerId('layer1');
 const CATEGORY = categoryId('cat1');
 
 // Helper to create a test layout
 function createTestLayout(overrides?: Partial<Layout>): Layout {
-  return {
-    version: '1.0',
-    name: 'Test Layout',
-    drawer: { width: gridUnits(10), depth: gridUnits(8), height: heightUnits(12) },
-    printBedSize: mm(256),
-    gridUnitMm: mm(42),
-    heightUnitMm: mm(7),
+  return baseCreateTestLayout({
     categories: [{ id: CATEGORY, name: 'Default', color: '#3b82f6' }],
     layers: [{ id: LAYER, name: 'Layer 1', height: heightUnits(3) }],
     bins: [
@@ -44,7 +39,7 @@ function createTestLayout(overrides?: Partial<Layout>): Layout {
       },
     ],
     ...overrides,
-  };
+  });
 }
 
 function expectLayout(decompressed: Layout | null): Layout {

--- a/src/shared/utils/entity.test.ts
+++ b/src/shared/utils/entity.test.ts
@@ -1,62 +1,59 @@
 import { describe, it, expect } from 'vitest';
 import { findBinById, findBinsByIds } from '@/shared/utils/entity';
 import type { Layout } from '@/core/types';
-import { binId, categoryId, gridUnits, heightUnits, layerId, mm } from '@/core/types';
+import { binId, categoryId, gridUnits, heightUnits, layerId } from '@/core/types';
+import { createTestLayout as baseCreateTestLayout } from '@/test/testUtils';
 
-const createTestLayout = (): Layout => ({
-  version: '1.0',
-  name: 'Test',
-  drawer: { width: gridUnits(10), depth: gridUnits(8), height: heightUnits(12) },
-  printBedSize: mm(256),
-  gridUnitMm: mm(42),
-  heightUnitMm: mm(7),
-  categories: [
-    { id: categoryId('cat1'), name: 'Category 1', color: '#ff0000' },
-    { id: categoryId('cat2'), name: 'Category 2', color: '#00ff00' },
-  ],
-  layers: [
-    { id: layerId('layer1'), name: 'Layer 1', height: heightUnits(3) },
-    { id: layerId('layer2'), name: 'Layer 2', height: heightUnits(3) },
-  ],
-  bins: [
-    {
-      id: binId('bin1'),
-      layerId: layerId('layer1'),
-      x: gridUnits(0),
-      y: gridUnits(0),
-      width: gridUnits(2),
-      depth: gridUnits(2),
-      height: heightUnits(3),
-      category: categoryId('cat1'),
-      label: 'Bin 1',
-      notes: '',
-    },
-    {
-      id: binId('bin2'),
-      layerId: layerId('layer1'),
-      x: gridUnits(2),
-      y: gridUnits(0),
-      width: gridUnits(2),
-      depth: gridUnits(2),
-      height: heightUnits(3),
-      category: categoryId('cat2'),
-      label: 'Bin 2',
-      notes: '',
-    },
-    {
-      id: binId('bin3'),
-      layerId: layerId('layer2'),
-      x: gridUnits(0),
-      y: gridUnits(0),
-      width: gridUnits(2),
-      depth: gridUnits(2),
-      height: heightUnits(3),
-      category: categoryId('cat1'),
-      label: 'Bin 3',
-      notes: '',
-    },
-  ],
-});
+const createTestLayout = (): Layout =>
+  baseCreateTestLayout({
+    name: 'Test',
+    categories: [
+      { id: categoryId('cat1'), name: 'Category 1', color: '#ff0000' },
+      { id: categoryId('cat2'), name: 'Category 2', color: '#00ff00' },
+    ],
+    layers: [
+      { id: layerId('layer1'), name: 'Layer 1', height: heightUnits(3) },
+      { id: layerId('layer2'), name: 'Layer 2', height: heightUnits(3) },
+    ],
+    bins: [
+      {
+        id: binId('bin1'),
+        layerId: layerId('layer1'),
+        x: gridUnits(0),
+        y: gridUnits(0),
+        width: gridUnits(2),
+        depth: gridUnits(2),
+        height: heightUnits(3),
+        category: categoryId('cat1'),
+        label: 'Bin 1',
+        notes: '',
+      },
+      {
+        id: binId('bin2'),
+        layerId: layerId('layer1'),
+        x: gridUnits(2),
+        y: gridUnits(0),
+        width: gridUnits(2),
+        depth: gridUnits(2),
+        height: heightUnits(3),
+        category: categoryId('cat2'),
+        label: 'Bin 2',
+        notes: '',
+      },
+      {
+        id: binId('bin3'),
+        layerId: layerId('layer2'),
+        x: gridUnits(0),
+        y: gridUnits(0),
+        width: gridUnits(2),
+        depth: gridUnits(2),
+        height: heightUnits(3),
+        category: categoryId('cat1'),
+        label: 'Bin 3',
+        notes: '',
+      },
+    ],
+  });
 
 describe('findBinById', () => {
   it('returns bin when found', () => {


### PR DESCRIPTION
## Summary

Tech-debt: several test files define their own local `createTestLayout` that duplicates the shared `@/test/testUtils` version. Consolidates the 6 that produce byte-identical fixtures (delegating to the shared helper with overrides for any intentional non-defaults). **Test-only, zero behavior change.** 6 files, +91/−134.

Consolidated: `migration.test`, `indexedDB.test`, `compression.test`, `ShareService.test`, `entity.test`, `posthog.test`.

**Left as-is (reason):** `createDefaultLayout`-based helpers (app-default base — random layer IDs / `DEFAULT_CATEGORIES` — differs from the deterministic shared helper), bespoke `BinSpec[]`/count-driven builders, and all `createTestLibrary` variants (fundamentally different signatures: `entries[]`/`entryCount`/`cloudShare`). Not forced.

## Test plan
- [x] `pnpm run typecheck`; eslint clean (no orphaned imports)
- [x] The 6 touched files — **214 tests passed**, and a stash-and-compare confirms **214 before == 214 after** (zero behavior change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated duplicate test layout fixtures to the shared `createTestLayout` in `@/test/testUtils` across six test files. Test-only change with no behavior differences and reduced duplication.

- **Refactors**
  - Replaced local helpers in: `migration.test`, `indexedDB.test`, `compression.test`, `ShareService.test`, `entity.test`, `posthog.test`.
  - Kept bespoke builders that rely on app defaults/random IDs or different signatures (e.g., `createDefaultLayout`-based, `BinSpec[]`/count-driven, `createTestLibrary` variants).

<sup>Written for commit 9dbba405fbb81813f5fc8e750b98c4ab58cccef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

