### PR TITLE
refactor(core): invert the DesignerStorage dependency behind a core-owned port

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import { BinContextMenuWrapper } from '@/shell/Mobile/BinContextMenuWrapper';
 import { TabletPanelOverlay, TabletPanelTriggers } from '@/shell/Tablet';
 import { LiveRegion } from '@/shell/LiveRegion';
 import { LocalMutationsProvider } from '@/shared/contexts';
+import { DesignStoreRegistration } from '@/shared/storage/DesignStoreRegistration';
 import { useTranslation } from '@/i18n';
 import { useCommandPalette } from '@/features/command-palette';
 import { useEngagementNudges, useLayoutPromotion } from '@/features/engagement';
@@ -604,6 +605,7 @@ export default function App() {
                 ? t('seo.community.title')
                 : t('seo.h1')}
       </h1>
+      <DesignStoreRegistration />
       {cloudSyncEnabled && (
         <Suspense fallback={null}>
           <LazySyncSessionMount />

--- a/src/core/storage/BulkArchiveService.test.ts
+++ b/src/core/storage/BulkArchiveService.test.ts
@@ -6,8 +6,22 @@ import {
   importArchive,
 } from '@/core/storage/BulkArchiveService';
 import type { Layout, LayoutLibrary, LayoutEntry } from '@/core/types';
-import { layoutId, layerId, gridUnits, heightUnits, mm } from '@/core/types';
+import {
+  layoutId,
+  layerId,
+  binId,
+  categoryId,
+  designId,
+  gridUnits,
+  heightUnits,
+  mm,
+} from '@/core/types';
 import { ok, err } from '@/core/result';
+import {
+  registerDesignStorePort,
+  resetDesignStorePort,
+  type DesignStorePort,
+} from '@/core/storage/designStorePort';
 
 // === Mocks ===
 
@@ -25,6 +39,16 @@ const mockImportLayoutJSON = vi.fn();
 vi.mock('@/core/storage/ShareService', () => ({
   importLayoutJSON: (...args: unknown[]) => mockImportLayoutJSON(...args),
 }));
+
+// Fake DesignStorePort — exportAllLayouts reads linked designs through it.
+// Only loadDesign is exercised here; the rest are inert stubs.
+const mockLoadDesign = vi.fn();
+const fakePort: DesignStorePort = {
+  loadDesign: (...args: unknown[]) => mockLoadDesign(...args),
+  saveDesign: () => Promise.reject(new Error('saveDesign not used in BulkArchive tests')),
+  upsertRegistryEntry: () => Promise.reject(new Error('upsertRegistryEntry not used')),
+  registryEdgeFields: () => Promise.resolve({}),
+};
 
 // === Fixtures ===
 
@@ -61,6 +85,26 @@ function makeEntry(id: string, name: string): LayoutEntry {
 
 function makeLibrary(entries: LayoutEntry[]): LayoutLibrary {
   return { version: '1.0', activeLayoutId: entries[0]?.id ?? '', settings: {}, entries };
+}
+
+function makeLayoutWithLinkedDesign(remoteId: string, name = 'Linked'): Layout {
+  const layout = makeLayout(name);
+  layout.bins = [
+    {
+      id: binId('bin-1'),
+      x: gridUnits(0),
+      y: gridUnits(0),
+      width: gridUnits(2),
+      depth: gridUnits(2),
+      height: heightUnits(3),
+      layerId: layerId('layer-1'),
+      category: categoryId('cat-1'),
+      label: '',
+      notes: '',
+      linkedDesignId: designId(remoteId),
+    },
+  ];
+  return layout;
 }
 
 // === isArchiveFormat ===
@@ -136,6 +180,7 @@ describe('parseArchive', () => {
 describe('exportAllLayouts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetDesignStorePort();
   });
 
   it('builds archive JSON containing each layout entry', async () => {
@@ -193,6 +238,31 @@ describe('exportAllLayouts', () => {
     expect(result.skipped).toBe(1);
     expect(parsed._archive.layoutCount).toBe(1);
     expect(parsed.layouts[0].name).toBe('Beta');
+  });
+
+  it('embeds linked designs resolved through the registered port', async () => {
+    registerDesignStorePort(fakePort);
+    mockLoadLayoutAsync.mockResolvedValueOnce(makeLayoutWithLinkedDesign('d1'));
+    mockLoadDesign.mockResolvedValue(ok({ id: 'd1', name: 'Widget', params: { width: 2 } }));
+
+    const result = await exportAllLayouts(makeLibrary([makeEntry('id-1', 'L1')]));
+    const parsed = JSON.parse(result.json);
+
+    expect(mockLoadDesign).toHaveBeenCalledWith('d1');
+    expect(parsed.layouts[0].linkedDesigns).toHaveLength(1);
+    expect(parsed.layouts[0].linkedDesigns[0].id).toBe('d1');
+  });
+
+  it('omits linked designs when no port is registered (null fallback)', async () => {
+    resetDesignStorePort();
+    mockLoadLayoutAsync.mockResolvedValueOnce(makeLayoutWithLinkedDesign('d1'));
+
+    const result = await exportAllLayouts(makeLibrary([makeEntry('id-1', 'L1')]));
+    const parsed = JSON.parse(result.json);
+
+    expect(result.exported).toBe(1);
+    expect(mockLoadDesign).not.toHaveBeenCalled();
+    expect(parsed.layouts[0].linkedDesigns).toBeUndefined();
   });
 });
 

--- a/src/core/storage/BulkArchiveService.ts
+++ b/src/core/storage/BulkArchiveService.ts
@@ -15,6 +15,7 @@ import { CONSTRAINTS } from '@/core/constants';
 import { loadLayoutAsync } from './LayoutService';
 import { createLayoutEntry } from './LayoutManager';
 import { importLayoutJSON } from './ShareService';
+import { getDesignStorePort } from './designStorePort';
 interface LinkedDesignExport {
   readonly id: string;
   readonly name: string;
@@ -107,19 +108,20 @@ export async function exportAllLayouts(
       if (designIds.size > 0) {
         linkedDesigns = [];
         try {
-          // Dynamic import — same rationale as ShareService.ts: keeps the
-          // bin-designer chunk out of core/storage's entry. Future cleanup
-          // could move this service to shared/ or invert the loader.
-          // eslint-disable-next-line boundaries/dependencies
-          const { loadDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
-          for (const id of designIds) {
-            const result = await loadDesign(id);
-            if (isOk(result)) {
-              linkedDesigns.push({
-                id: result.value.id,
-                name: result.value.name,
-                params: result.value.params,
-              });
+          // The port loads designs through the bin-designer adapter without a
+          // core → feature import. A null port (feature not registered) leaves
+          // the array empty, so the layout exports without linked designs.
+          const port = getDesignStorePort();
+          if (port !== null) {
+            for (const id of designIds) {
+              const result = await port.loadDesign(id);
+              if (isOk(result)) {
+                linkedDesigns.push({
+                  id: result.value.id,
+                  name: result.value.name,
+                  params: result.value.params,
+                });
+              }
             }
           }
         } catch {

--- a/src/core/storage/ShareService.test.ts
+++ b/src/core/storage/ShareService.test.ts
@@ -19,6 +19,11 @@ import type { Layout } from '@/core/types';
 import { binId, categoryId, designId, gridUnits, heightUnits, layerId } from '@/core/types';
 import { getUserMessage, ok, err, storageNotFound } from '@/core/result';
 import type { Result, ValidationError, ValidationImportError } from '@/core/result';
+import {
+  registerDesignStorePort,
+  resetDesignStorePort,
+  type DesignStorePort,
+} from '@/core/storage/designStorePort';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import { expectOk, expectErr, createTestLayout as baseCreateTestLayout } from '@/test/testUtils';
 
@@ -32,19 +37,18 @@ const originalWindow = global.window;
 const originalNavigator = global.navigator;
 const originalDocument = global.document;
 
-// Mock DesignerStorage
+// Fake DesignStorePort — the core-owned seam the share flows now talk to,
+// replacing the old direct DesignerStorage / customBinRegistry mocks.
 const mockLoadDesign = vi.fn();
 const mockSaveDesign = vi.fn();
-vi.mock('@/features/bin-designer/storage/DesignerStorage', () => ({
+const mockUpsertRegistryEntry = vi.fn();
+
+const fakePort: DesignStorePort = {
   loadDesign: (...args: unknown[]) => mockLoadDesign(...args),
   saveDesign: (...args: unknown[]) => mockSaveDesign(...args),
-}));
-
-const mockUpsertRegistryEntry = vi.fn();
-vi.mock('@/features/bin-designer/store/customBinRegistry', () => ({
   upsertRegistryEntry: (...args: unknown[]) => mockUpsertRegistryEntry(...args),
-  registryEdgeFields: () => ({}),
-}));
+  registryEdgeFields: async () => ({}),
+};
 
 function expectImportError(result: Result<unknown, ValidationError>): ValidationImportError {
   const error = expectErr(result);
@@ -634,6 +638,7 @@ describe('storage-share', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
+      registerDesignStorePort(fakePort);
     });
 
     it('exports layout without linked designs (no linkedDesigns key in output)', async () => {
@@ -729,6 +734,7 @@ describe('storage-share', () => {
   describe('restoreEmbeddedDesigns', () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      registerDesignStorePort(fakePort);
     });
 
     it('returns unchanged layout when no linkedDesigns in JSON', async () => {
@@ -954,6 +960,7 @@ describe('storage-share', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
+      registerDesignStorePort(fakePort);
     });
 
     it('returns the layout untouched when no designs travelled with it', async () => {
@@ -1034,6 +1041,63 @@ describe('storage-share', () => {
 
       expect(mockSaveDesign).not.toHaveBeenCalled();
       expect(result.bins[0].linkedDesignId).toBe('remote-design-1');
+    });
+  });
+
+  // Before boot registers the adapter (or if the design feature is otherwise
+  // unavailable) the port is null, and every design flow must degrade to the
+  // same output as the "no designs resolved" path.
+  describe('when no DesignStorePort is registered', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetDesignStorePort();
+    });
+
+    it('exports the layout with no linkedDesigns key', async () => {
+      const layout = createTestLayout();
+      layout.bins = layout.bins.map((bin, i) => ({
+        ...bin,
+        linkedDesignId: i === 0 ? designId('design-1') : undefined,
+      }));
+
+      const json = await exportLayoutJSONWithDesigns(layout);
+      const parsed = JSON.parse(json);
+
+      expect(parsed.linkedDesigns).toBeUndefined();
+      expect(mockLoadDesign).not.toHaveBeenCalled();
+    });
+
+    it('restores embedded designs as a no-op, leaving bins unchanged', async () => {
+      const layout = createTestLayout();
+      layout.bins[0].linkedDesignId = designId('old-design-id');
+      const json = JSON.stringify({
+        ...layout,
+        linkedDesigns: [
+          { id: 'old-design-id', name: 'Test Design', params: { ...DEFAULT_BIN_PARAMS } },
+        ],
+      });
+
+      const result = await restoreEmbeddedDesigns(json, layout);
+
+      expect(result.importedDesignCount).toBe(0);
+      expect(result.layout.bins[0].linkedDesignId).toBe('old-design-id');
+      expect(mockSaveDesign).not.toHaveBeenCalled();
+    });
+
+    it('restores shared designs as a no-op, returning the layout untouched', async () => {
+      const layout = createTestLayout();
+      layout.bins = layout.bins.map((bin, i) => ({
+        ...bin,
+        linkedDesignId: i === 0 ? designId('remote-design-1') : undefined,
+      }));
+
+      const result = await restoreSharedDesigns('abc123DEF456', layout, [
+        { id: 'remote-design-1', name: 'Socket Tray', params: { ...DEFAULT_BIN_PARAMS } },
+      ]);
+
+      expect(result).toBe(layout);
+      expect(mockSaveDesign).not.toHaveBeenCalled();
+      expect(mockUpsertRegistryEntry).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/core/storage/ShareService.ts
+++ b/src/core/storage/ShareService.ts
@@ -16,6 +16,7 @@ import type { Layout, LayerId, CategoryId, DesignId } from '@/core/types';
 import { designId as toDesignId } from '@/core/types';
 import type { Result, ValidationError } from '@/core/result';
 import { ok, err, validationImportFailed, isOk } from '@/core/result';
+import { getDesignStorePort } from './designStorePort';
 import type { BinParams } from '@/shared/types/bin';
 export interface LinkedDesignExport {
   readonly id: string;
@@ -40,21 +41,19 @@ export async function collectLinkedDesigns(layout: Layout): Promise<LinkedDesign
   }
   if (designIds.size === 0) return [];
 
-  // Dynamic import keeps the bin-designer chunk out of the core/storage
-  // entry; the layer rule's `disallow` covers static imports but flags
-  // dynamic ones too. Until the call site is inverted to pass the
-  // loader in (or this service moves to shared/), the exception is
-  // documented here.
-  // eslint-disable-next-line boundaries/dependencies -- TECH-DEBT: dynamic import is deliberate code-splitting; see the note above
-  const { loadDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
+  // A missing port means the design feature has not registered its adapter
+  // yet; treat it exactly like "no designs resolved" (empty result).
+  const port = getDesignStorePort();
+  if (port === null) return [];
+
   const linkedDesigns: LinkedDesignExport[] = [];
   for (const id of designIds) {
-    const result = await loadDesign(id);
+    const result = await port.loadDesign(id);
     if (isOk(result) && result.value.params) {
       linkedDesigns.push({
         id: result.value.id,
         name: result.value.name,
-        params: result.value.params,
+        params: result.value.params as BinParams,
       });
     }
   }
@@ -194,10 +193,11 @@ export async function restoreEmbeddedDesigns(
     return { layout, importedDesignCount: 0 };
   }
 
-  // Dynamic import — same code-splitting rationale as the loadDesign call
-  // above; see comment there for the cleanup follow-up.
-  // eslint-disable-next-line boundaries/dependencies
-  const { saveDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
+  const port = getDesignStorePort();
+  if (port === null) {
+    return { layout, importedDesignCount: 0 };
+  }
+
   const designIdMap = new Map<string, DesignId>();
   let importedDesignCount = 0;
 
@@ -212,9 +212,9 @@ export async function restoreEmbeddedDesigns(
       typeof linkedDesign.id === 'string' &&
       typeof linkedDesign.name === 'string'
     ) {
-      const result = await saveDesign({
+      const result = await port.saveDesign({
         name: linkedDesign.name,
-        params: linkedDesign.params as BinParams,
+        params: linkedDesign.params,
         thumbnail: null,
         exportFileNameConfig: null,
       });
@@ -277,13 +277,10 @@ export async function restoreSharedDesigns(
 ): Promise<Layout> {
   if (designs.length === 0) return layout;
 
-  // Dynamic imports for the same code-splitting reason as collectLinkedDesigns.
-  // eslint-disable-next-line boundaries/dependencies -- TECH-DEBT: dynamic import is deliberate code-splitting; see collectLinkedDesigns
-  const { saveDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
-  const { upsertRegistryEntry, registryEdgeFields } = await import(
-    // eslint-disable-next-line boundaries/dependencies -- TECH-DEBT: dynamic import is deliberate code-splitting; see collectLinkedDesigns
-    '@/features/bin-designer/store/customBinRegistry'
-  );
+  // No registered port means the design feature is unavailable; leave the
+  // layout untouched, exactly as when none of the designs resolve.
+  const port = getDesignStorePort();
+  if (port === null) return layout;
 
   const idMap = new Map<string, DesignId>();
   for (const design of designs) {
@@ -292,7 +289,7 @@ export async function restoreSharedDesigns(
     }
     const params = design.params as BinParams;
 
-    const result = await saveDesign({
+    const result = await port.saveDesign({
       id: sharedDesignLocalId(shareId, design.id),
       name: design.name,
       params,
@@ -304,13 +301,14 @@ export async function restoreSharedDesigns(
     idMap.set(design.id, result.value.id);
     // The planner palette and the linked-bin mesh cache both key off the
     // registry, so a design that skips it stays invisible to the layout.
-    upsertRegistryEntry({
+    const edgeFields = await port.registryEdgeFields(params);
+    await port.upsertRegistryEntry({
       id: result.value.id,
       name: result.value.name,
       width: params.width,
       depth: params.depth,
       height: params.height,
-      ...registryEdgeFields(params),
+      ...edgeFields,
       updatedAt: result.value.updatedAt,
     });
   }

--- a/src/core/storage/designStorePort.ts
+++ b/src/core/storage/designStorePort.ts
@@ -1,0 +1,103 @@
+/**
+ * Design-store port — the seam that lets `core/storage` persist and read bin
+ * designs without importing `features/bin-designer`.
+ *
+ * `core/` is infrastructure and must not depend on a feature (the
+ * `boundaries/dependencies` rule makes `core → feature` a `disallow` edge).
+ * Share/archive flows nonetheless need to load and save designs, so they talk
+ * to this interface instead of `DesignerStorage`/`customBinRegistry` directly.
+ * The concrete adapter lives in `features/bin-designer/storage/designStoreAdapter`
+ * and is registered at the `shared/` composition root at app boot — mirroring
+ * how the sync engine consumes `SyncAdapter`/`DesignAdapter`.
+ *
+ * Bin params are typed `unknown` here because `BinParams` lives in the feature
+ * and core cannot import it; the concrete adapter re-narrows them (same pattern
+ * as `DesignSyncPayload.params` in `@/core/sync/adapters/types`).
+ */
+
+import type { Result, StorageError } from '@/core/result';
+import type { DesignId } from '@/core/types';
+
+/** The slice of a stored design the share/archive flows read back on load. */
+export interface LoadedDesignData {
+  readonly id: DesignId;
+  readonly name: string;
+  /** Bin params (opaque; absent for non-bin design kinds). */
+  readonly params?: unknown;
+}
+
+/** What core hands the port to persist a design. */
+export interface SaveDesignInput {
+  /** Omit to mint a fresh id; provide to upsert a specific design. */
+  readonly id?: DesignId;
+  readonly name: string;
+  readonly params: unknown;
+  readonly thumbnail: string | null;
+  readonly exportFileNameConfig: null;
+}
+
+/** The slice of a saved design core reads back after a successful save. */
+export interface SavedDesignData {
+  readonly id: DesignId;
+  readonly name: string;
+  readonly updatedAt: string;
+}
+
+/**
+ * Fractional-edge projection carried on a registry entry — mirrors the shape
+ * the feature's `registryEdgeFields` returns so the two can't drift.
+ */
+export interface DesignRegistryEdgeFields {
+  readonly fractionalEdgeX?: 'start' | 'end';
+  readonly fractionalEdgeY?: 'start' | 'end';
+  readonly fractionalEdgeManualX?: boolean;
+  readonly fractionalEdgeManualY?: boolean;
+  readonly halfSockets?: boolean;
+}
+
+/**
+ * Lightweight registry entry core upserts after restoring a shared design —
+ * mirrors the feature's `CustomBinRef` public shape (minus feature-only fields
+ * core never sets).
+ */
+export interface DesignRegistryEntry extends DesignRegistryEdgeFields {
+  readonly id: DesignId;
+  readonly name: string;
+  readonly width: number;
+  readonly depth: number;
+  readonly height: number;
+  readonly updatedAt: string;
+}
+
+/**
+ * The four operations `core/storage` needs from the bin-designer feature.
+ * Every method is async so the adapter can lazily `import()` the feature
+ * chunk on first use, preserving the code-splitting the old dynamic imports
+ * gave us.
+ */
+export interface DesignStorePort {
+  loadDesign(id: DesignId): Promise<Result<LoadedDesignData, StorageError>>;
+  saveDesign(input: SaveDesignInput): Promise<Result<SavedDesignData, StorageError>>;
+  upsertRegistryEntry(entry: DesignRegistryEntry): Promise<Result<void, StorageError>>;
+  registryEdgeFields(params: unknown): Promise<DesignRegistryEdgeFields>;
+}
+
+let port: DesignStorePort | null = null;
+
+/** Install the concrete port. Called once from the shared composition root. */
+export function registerDesignStorePort(next: DesignStorePort): void {
+  port = next;
+}
+
+/**
+ * The installed port, or `null` before boot has registered it. Callers must
+ * treat `null` as "no designs available" and fall back gracefully.
+ */
+export function getDesignStorePort(): DesignStorePort | null {
+  return port;
+}
+
+/** Clear the installed port. For test teardown; not used in production. */
+export function resetDesignStorePort(): void {
+  port = null;
+}

--- a/src/features/bin-designer/index.ts
+++ b/src/features/bin-designer/index.ts
@@ -24,6 +24,11 @@ export {
 // --- Storage ---
 export { loadDesign, deleteDesign, listDesigns, updateDesignParams } from './storage';
 
+// Concrete DesignStorePort. Exposed for `shared/storage/` to register with the
+// core-owned port so core/storage can persist/read designs without a
+// cross-boundary import (parallels `designAdapter` for sync below).
+export { designStoreAdapter } from './storage/designStoreAdapter';
+
 // --- Hooks ---
 // Deep paths on purpose: the ./hooks barrel also re-exports useAutoSave /
 // useThumbnailCapture, which import ./utils/thumbnail (full three.js namespace).

--- a/src/features/bin-designer/storage/designStoreAdapter.ts
+++ b/src/features/bin-designer/storage/designStoreAdapter.ts
@@ -1,0 +1,53 @@
+/**
+ * Concrete `DesignStorePort` for the bin-designer feature.
+ *
+ * Lives here (not in `core/`) because it touches `DesignerStorage` and
+ * `customBinRegistry`, which own `BinParams`/`SavedDesign`/`CustomBinRef` —
+ * types core cannot import. Registered with the port at the `shared/`
+ * composition root at app boot.
+ *
+ * Each method `import()`s the underlying module on first use so the
+ * IndexedDB/registry code stays out of any eager chunk that only needs the
+ * adapter reference — the same code-splitting the old dynamic imports in
+ * `core/storage` provided, now on an allowed feature-internal edge.
+ */
+
+import type {
+  DesignRegistryEdgeFields,
+  DesignRegistryEntry,
+  DesignStorePort,
+  LoadedDesignData,
+  SaveDesignInput,
+  SavedDesignData,
+} from '@/core/storage/designStorePort';
+import type { Result, StorageError } from '@/core/result';
+import type { DesignId } from '@/core/types';
+import type { BinParams } from '@/features/bin-designer/types';
+
+export const designStoreAdapter: DesignStorePort = {
+  async loadDesign(id: DesignId): Promise<Result<LoadedDesignData, StorageError>> {
+    const { loadDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
+    return loadDesign(id);
+  },
+
+  async saveDesign(input: SaveDesignInput): Promise<Result<SavedDesignData, StorageError>> {
+    const { saveDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
+    return saveDesign({
+      id: input.id,
+      name: input.name,
+      params: input.params as BinParams,
+      thumbnail: input.thumbnail,
+      exportFileNameConfig: input.exportFileNameConfig,
+    });
+  },
+
+  async upsertRegistryEntry(entry: DesignRegistryEntry): Promise<Result<void, StorageError>> {
+    const { upsertRegistryEntry } = await import('@/features/bin-designer/store/customBinRegistry');
+    return upsertRegistryEntry(entry);
+  },
+
+  async registryEdgeFields(params: unknown): Promise<DesignRegistryEdgeFields> {
+    const { registryEdgeFields } = await import('@/features/bin-designer/store/customBinRegistry');
+    return registryEdgeFields(params as BinParams);
+  },
+};

--- a/src/shared/storage/DesignStoreRegistration.test.tsx
+++ b/src/shared/storage/DesignStoreRegistration.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getDesignStorePort, resetDesignStorePort } from '@/core/storage/designStorePort';
+
+// Stand in for the real feature adapter so this test never pulls the
+// bin-designer barrel's runtime graph.
+const { fakeAdapter } = vi.hoisted(() => ({
+  fakeAdapter: {
+    loadDesign: vi.fn(),
+    saveDesign: vi.fn(),
+    upsertRegistryEntry: vi.fn(),
+    registryEdgeFields: vi.fn(),
+  },
+}));
+
+vi.mock('@/features/bin-designer', () => ({ designStoreAdapter: fakeAdapter }));
+
+afterEach(() => {
+  resetDesignStorePort();
+});
+
+describe('DesignStoreRegistration', () => {
+  it('registers the bin-designer adapter with the core port on import', async () => {
+    await import('@/shared/storage/DesignStoreRegistration');
+    expect(getDesignStorePort()).toBe(fakeAdapter);
+  });
+
+  it('renders nothing', async () => {
+    const { DesignStoreRegistration } = await import('@/shared/storage/DesignStoreRegistration');
+    expect(DesignStoreRegistration()).toBeNull();
+  });
+});

--- a/src/shared/storage/DesignStoreRegistration.tsx
+++ b/src/shared/storage/DesignStoreRegistration.tsx
@@ -1,0 +1,23 @@
+import { registerDesignStorePort } from '@/core/storage/designStorePort';
+import { designStoreAdapter } from '@/features/bin-designer';
+
+/**
+ * Composition root wiring the bin-designer's concrete `DesignStorePort` into
+ * the core-owned holder, so `core/storage` share/archive flows can persist and
+ * read designs without a `core → feature` import.
+ *
+ * Registration runs at module load (not in an effect) so the port is in place
+ * before first paint and before any user-triggered export/share — those paths
+ * read the port synchronously and would otherwise see `null` during the gap
+ * between mount and the first effect flush.
+ */
+registerDesignStorePort(designStoreAdapter);
+
+/**
+ * Eager mount anchor. Renders nothing; its only job is to keep this module in
+ * the shell's import graph (alongside the sync mount) so the registration
+ * above always runs. Not gated behind any Labs flag.
+ */
+export function DesignStoreRegistration(): null {
+  return null;
+}


### PR DESCRIPTION
## Summary

`core` reached **down** into `features/bin-designer` via 5 dynamic imports, each with a sanctioned `// eslint-disable boundaries/dependencies` (`core→feature` is a `disallow` edge). This inverts the dependency behind a **core-owned port**, mirroring the existing sync-engine precedent (`core/sync/adapters` port + `shared/sync` composition root). **Zero behavior change, zero external-caller change.**

- **`core/storage/designStorePort.ts` (new)** — `DesignStorePort` (loadDesign/saveDesign/upsertRegistryEntry/registryEdgeFields), core-owned structural payload types (bin params typed `unknown`, re-narrowed in the adapter — same as the sync precedent). Holder: `registerDesignStorePort`/`getDesignStorePort`/`resetDesignStorePort`.
- **`features/bin-designer/storage/designStoreAdapter.ts` (new)** — thin adapter; each method `await import(...)`s DesignerStorage/registry on first call, so **code-splitting is preserved** (the dynamic import now lives on an allowed feature-internal edge; static imports are type-only).
- **`shared/storage/DesignStoreRegistration.tsx` (new)** — registers the adapter at **module load** (before paint), mounted eagerly in `App.tsx`. `shared→feature` is the allowed edge.
- **`ShareService.ts` / `BulkArchiveService.ts`** — all 5 disables + dynamic feature imports removed; each replaced with `getDesignStorePort()` + a null guard taking the **exact existing "no designs" path**.

## Verification
- [x] `pnpm run typecheck`
- [x] **Boundaries gate:** 0 `eslint-disable boundaries` remain, 0 `core→feature` imports in non-test core, eslint clean (the rule is `error`-level). **Proved the rule is live for this edge** by probe (adding a feature import to the port file → eslint errors "Denied by policy … boundaries/dependencies"; restored → clean) — guarding against the known eslint-boundaries fail-open trap.
- [x] `ShareService.test` + `BulkArchiveService.test` → **77 passed** (converted `vi.mock` → `registerDesignStorePort(fakePort)`; added null-fallback tests). Full `core/storage` → 560; the 3 other callers → 123.

## Notes
- **Ordering is safe:** all 5 entry points are user-triggered (export/share/import), which only fire after the shell mounts; registration runs at module load before render; idempotent (StrictMode-safe).
- `registryEdgeFields`/`upsertRegistryEntry` are now `await`ed (adapter makes them async via lazy import) — outcome identical (their `Result` was and is ignored).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inverted `core`’s bin-designer dependency by introducing a core-owned `DesignStorePort` and a feature adapter, removing all `core → feature` imports while keeping code-splitting. No behavior changes; share/archive flows now use the port with safe null fallbacks.

- **Refactors**
  - Added `core/storage/designStorePort.ts` with the `DesignStorePort` interface and `register/get/reset` helpers.
  - Added `features/bin-designer/storage/designStoreAdapter.ts` that lazily imports `DesignerStorage` and `customBinRegistry`.
  - Registered the adapter at boot via `shared/storage/DesignStoreRegistration.tsx` and mounted it in `App.tsx`.
  - Updated `ShareService` and `BulkArchiveService` to use `getDesignStorePort()`; removed dynamic imports and boundaries disables; null port follows the existing “no designs” path.
  - Updated tests to register a fake port and added null-fallback coverage.

<sup>Written for commit 6521ba16df54aa45aeeedd01d0a86f72c816140f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

