### PR TITLE
fix(drawer-shape): never change the custom perimeter implicitly

### DIFF
--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
@@ -86,35 +86,58 @@ describe('v2 drawer.update with an outline', () => {
     return { ...base, drawer: { ...base.drawer, outline: L_OUTLINE } };
   };
 
-  it('crops the outline on shrink and records it in changes', () => {
+  it('clamps a shrink to the outline bounding grid and never touches the shape (#3149)', () => {
+    // The L-shape spans the full 6×4 extent — a shrink below that would cut
+    // into the drawn shape, so the width clamps back up to 6.
     const result = updateDrawer.handle({ width: 5 }, { aggregate: withOutline() });
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) return;
     const changes = result.value.event.payload.changes;
-    expect(changes.outline).toBeDefined();
-    expect(changes.outline?.vertices.every((v) => v.x <= 5 * U + 0.01)).toBe(true);
-    expect(result.value.event.payload.previous.outline).toBe(L_OUTLINE);
+    expect(changes.width).toBe(gridUnits(6));
+    expect('outline' in changes).toBe(false);
   });
 
-  it('resets to a plain rectangle when the shrink consumes the notch', () => {
-    // Shrinking to width 4 removes everything right of the notch — the
-    // remaining region is the full 4×4 rectangle.
-    const result = updateDrawer.handle({ width: 4 }, { aggregate: withOutline() });
+  it('keeps the outline byte-identical across a grow', () => {
+    const result = updateDrawer.handle({ width: 8, depth: 6 }, { aggregate: withOutline() });
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) return;
     const payload = result.value.event.payload;
-    expect('outline' in payload.changes).toBe(true);
-    expect(payload.changes.outline).toBeUndefined();
+    expect(payload.changes.width).toBe(gridUnits(8));
+    expect(payload.changes.depth).toBe(gridUnits(6));
+    expect('outline' in payload.changes).toBe(false);
 
     const next = produce(withOutline(), (draft) => {
       updateDrawer.apply({ payload } as never, draft);
     });
-    expect('outline' in next.drawer).toBe(false);
+    expect(next.drawer.outline).toBe(L_OUTLINE);
   });
 
-  it('displaces bins that fall outside the adapted outline', () => {
-    // Growing depth to 6 extends the shape upward except over the notch;
-    // a bin in the notch column stays displaced.
+  it('clamps to the half-unit ceiling of a shape that overhangs whole units', () => {
+    // Shape reaching to 4.2 units needs a 4.5-unit drawer.
+    const base = makeLayout();
+    const layout = {
+      ...base,
+      drawer: {
+        ...base.drawer,
+        outline: {
+          vertices: [
+            { x: 0, y: 0 },
+            { x: 4.2 * U, y: 0 },
+            { x: 4.2 * U, y: 4 * U },
+            { x: 0, y: 4 * U },
+          ],
+        },
+      },
+    };
+    const result = updateDrawer.handle({ width: 3 }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.changes.width).toBe(gridUnits(4.5));
+  });
+
+  it('displaces bins that fall outside the unchanged outline after a grow', () => {
+    // Growing depth leaves the shape as-is; a bin in the notch column stays
+    // displaced.
     const layout = { ...withOutline(), bins: [makeBin('bin_notch', 5, 3)] };
     const result = updateDrawer.handle({ depth: 6 }, { aggregate: layout });
     expect(isOk(result)).toBe(true);
@@ -122,12 +145,17 @@ describe('v2 drawer.update with an outline', () => {
     expect(result.value.event.payload.displacedBinIds).toEqual([binId('bin_notch')]);
   });
 
-  it('replay deletes the outline key on reset, matching apply()', () => {
-    const result = updateDrawer.handle({ width: 4 }, { aggregate: withOutline() });
-    if (!isOk(result)) throw new Error('handle failed');
+  it('replay of a legacy outline-reset event still deletes the key', () => {
+    // Events persisted before #3149 carried an adapted (or reset) outline in
+    // `changes`; apply()/replay must keep honouring them.
     const event = {
       type: 'drawer.updated',
-      payload: result.value.event.payload,
+      payload: {
+        changes: { width: gridUnits(4), outline: undefined },
+        previous: { width: gridUnits(6), outline: L_OUTLINE },
+        binsDisplacedToStaging: 0,
+        displacedBinIds: [],
+      },
     } as never;
     const replayed = applyEvent(withOutline(), event);
     expect('outline' in replayed.drawer).toBe(false);

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
@@ -1,11 +1,13 @@
 /**
  * Update drawer dims and cascade out-of-bounds bins to staging.
  *
- * Clamping (width/depth in [GRID_MIN, GRID_MAX], height >= sum of layer
- * heights) happens in handle() so the event's `changes` always reflects
- * the value that lands. The displaced bin set is also precomputed in
- * handle() and goes into the event as `displacedBinIds`, so apply()
- * applies the drawer change AND the displacement deterministically.
+ * Clamping (width/depth in [GRID_MIN, GRID_MAX] and, with a custom outline
+ * active, no smaller than the outline's bounding half-unit grid — a resize
+ * must never mutate the user's shape, #3149; height >= sum of layer heights)
+ * happens in handle() so the event's `changes` always reflects the value
+ * that lands. The displaced bin set is also precomputed in handle() and
+ * goes into the event as `displacedBinIds`, so apply() applies the drawer
+ * change AND the displacement deterministically.
  *
  * `displacedBinIds` is optional on the event type for back-compat with
  * persisted events that predate the field (those carried only the
@@ -17,7 +19,7 @@ import type { Result, LayoutError } from '@/core/result';
 import { ok } from '@/core/result';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
-import { resizeDrawerOutline } from '@/shared/utils/drawerOutline';
+import { minDrawerUnitsForOutline } from '@/shared/utils/drawerOutline';
 import type { BinId, Drawer, GridUnits, MeasuredDrawerMm } from '@/core/types';
 import { effectiveGridUnitMmY, gridUnits, heightUnits } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
@@ -95,13 +97,28 @@ export const updateDrawer = defineCommand({
     const drawer = layout.drawer;
 
     // Resolve clamped/derived values up-front so the event records
-    // exactly what apply() will install.
+    // exactly what apply() will install. With a custom outline active the
+    // shrink floor rises to the outline's bounding half-unit grid: the shape
+    // is user-authored and a resize must never crop or extend it (#3149) —
+    // to go smaller, the user edits the shape first.
+    const outlineMin =
+      drawer.outline !== undefined
+        ? minDrawerUnitsForOutline(drawer.outline, layout.gridUnitMm, effectiveGridUnitMmY(layout))
+        : undefined;
     const changes: Partial<Drawer> = {};
     if (payload.width !== undefined) {
-      changes.width = gridUnits(clamp(payload.width, CONSTRAINTS.GRID_MIN, CONSTRAINTS.GRID_MAX));
+      const floor = Math.min(
+        CONSTRAINTS.GRID_MAX,
+        Math.max(CONSTRAINTS.GRID_MIN, outlineMin?.width ?? 0)
+      );
+      changes.width = gridUnits(clamp(payload.width, floor, CONSTRAINTS.GRID_MAX));
     }
     if (payload.depth !== undefined) {
-      changes.depth = gridUnits(clamp(payload.depth, CONSTRAINTS.GRID_MIN, CONSTRAINTS.GRID_MAX));
+      const floor = Math.min(
+        CONSTRAINTS.GRID_MAX,
+        Math.max(CONSTRAINTS.GRID_MIN, outlineMin?.depth ?? 0)
+      );
+      changes.depth = gridUnits(clamp(payload.depth, floor, CONSTRAINTS.GRID_MAX));
     }
     if (payload.height !== undefined) {
       const totalLayerHeight = layout.layers.reduce((sum, l) => sum + (l.height as number), 0);
@@ -117,30 +134,11 @@ export const updateDrawer = defineCommand({
     const newWidth: GridUnits = changes.width ?? drawer.width;
     const newDepth: GridUnits = changes.depth ?? drawer.depth;
 
-    // A resize adapts the outline (cropped where the drawer shrank, extended
-    // where it grew); a degenerate result falls back to the full rectangle.
-    // The derived change rides in the event so replay stays deterministic.
-    const dimsChanged = newWidth !== drawer.width || newDepth !== drawer.depth;
-    let newOutline = drawer.outline;
-    if (drawer.outline !== undefined && dimsChanged) {
-      const u = layout.gridUnitMm as number;
-      const uy = effectiveGridUnitMmY(layout) as number;
-      newOutline = resizeDrawerOutline(
-        drawer.outline,
-        (drawer.width as number) * u,
-        (drawer.depth as number) * uy,
-        (newWidth as number) * u,
-        (newDepth as number) * uy,
-        u,
-        uy
-      );
-      changes.outline = newOutline;
-    }
-
-    // Displacement against the post-update drawer (dims AND adapted outline).
+    // The outline never changes on resize (see the clamp above); displacement
+    // runs against the new dims with the shape as-is.
     const displacedBinIds = computeDisplacedBins(
       layout.bins,
-      { width: newWidth, depth: newDepth, outline: newOutline },
+      { width: newWidth, depth: newDepth, outline: drawer.outline },
       layout.gridUnitMm,
       effectiveGridUnitMmY(layout)
     );

--- a/src/core/store/layout/drawerActions.test.ts
+++ b/src/core/store/layout/drawerActions.test.ts
@@ -110,6 +110,51 @@ describe('drawerActions', () => {
       expect(useLayoutStore.getState().layout.bins[0].layerId).toBe(lid);
     });
 
+    it('clamps a shrink to the custom outline bounding grid, shape untouched (#3149)', () => {
+      const u = useLayoutStore.getState().layout.gridUnitMm as number;
+      const outline = {
+        vertices: [
+          { x: 0, y: 0 },
+          { x: 4.2 * u, y: 0 },
+          { x: 4.2 * u, y: 4 * u },
+          { x: 2 * u, y: 4 * u },
+          { x: 2 * u, y: 6 * u },
+          { x: 0, y: 6 * u },
+        ],
+      };
+      useLayoutStore.setState((state) => ({
+        layout: { ...state.layout, drawer: { ...state.layout.drawer, outline } },
+      }));
+
+      const { updateDrawer } = useLayoutStore.getState();
+      updateDrawer({ width: gridUnits(3), depth: gridUnits(3) });
+      const drawer = useLayoutStore.getState().layout.drawer;
+      expect(drawer.width).toBe(4.5);
+      expect(drawer.depth).toBe(6);
+      expect(drawer.outline).toBe(outline);
+    });
+
+    it('keeps the outline byte-identical across a grow', () => {
+      const u = useLayoutStore.getState().layout.gridUnitMm as number;
+      const outline = {
+        vertices: [
+          { x: 0, y: 0 },
+          { x: 4 * u, y: 0 },
+          { x: 4 * u, y: 2 * u },
+          { x: 0, y: 2 * u },
+        ],
+      };
+      useLayoutStore.setState((state) => ({
+        layout: { ...state.layout, drawer: { ...state.layout.drawer, outline } },
+      }));
+
+      const { updateDrawer } = useLayoutStore.getState();
+      updateDrawer({ width: gridUnits(12), depth: gridUnits(9) });
+      const drawer = useLayoutStore.getState().layout.drawer;
+      expect(drawer.width).toBe(12);
+      expect(drawer.outline).toBe(outline);
+    });
+
     it('updates fractionalEdgeX', () => {
       const { updateDrawer } = useLayoutStore.getState();
       updateDrawer({ fractionalEdgeX: 'start' });

--- a/src/core/store/layout/drawerActions.ts
+++ b/src/core/store/layout/drawerActions.ts
@@ -2,7 +2,7 @@ import type { Drawer, GridUnits, HeightUnits } from '@/core/types';
 import { effectiveGridUnitMmY } from '@/core/types';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
-import { resizeDrawerOutline } from '@/shared/utils/drawerOutline';
+import { minDrawerUnitsForOutline } from '@/shared/utils/drawerOutline';
 import { computeDisplacedBins } from '@/core/cqrs/v2/domain/drawer/displacement';
 import type { SetLocal } from './types';
 
@@ -14,17 +14,31 @@ export function createDrawerActions(setLocal: SetLocal) {
         const oldWidth = drawer.width as number;
         const oldDepth = drawer.depth as number;
 
+        // With a custom outline active the shrink floor rises to the
+        // outline's bounding half-unit grid — a resize must never mutate the
+        // user's shape (#3149); same rule as the CQRS updateDrawer command.
+        const outlineMin =
+          drawer.outline !== undefined
+            ? minDrawerUnitsForOutline(
+                drawer.outline,
+                state.layout.gridUnitMm,
+                effectiveGridUnitMmY(state.layout)
+              )
+            : undefined;
+        const axisFloor = (min: number | undefined): number =>
+          Math.min(CONSTRAINTS.GRID_MAX, Math.max(CONSTRAINTS.GRID_MIN, min ?? 0));
+
         if (updates.width !== undefined) {
           drawer.width = clamp(
             updates.width,
-            CONSTRAINTS.GRID_MIN,
+            axisFloor(outlineMin?.width),
             CONSTRAINTS.GRID_MAX
           ) as GridUnits;
         }
         if (updates.depth !== undefined) {
           drawer.depth = clamp(
             updates.depth,
-            CONSTRAINTS.GRID_MIN,
+            axisFloor(outlineMin?.depth),
             CONSTRAINTS.GRID_MAX
           ) as GridUnits;
         }
@@ -37,31 +51,6 @@ export function createDrawerActions(setLocal: SetLocal) {
         }
         if (updates.fractionalEdgeY !== undefined) {
           drawer.fractionalEdgeY = updates.fractionalEdgeY;
-        }
-
-        // Adapt the outline to the new dims (crop/extend; degenerate result →
-        // back to the plain rectangle) — same rule as the CQRS updateDrawer
-        // command, shared via resizeDrawerOutline.
-        if (
-          drawer.outline !== undefined &&
-          ((drawer.width as number) !== oldWidth || (drawer.depth as number) !== oldDepth)
-        ) {
-          const u = state.layout.gridUnitMm as number;
-          const uy = effectiveGridUnitMmY(state.layout) as number;
-          const resized = resizeDrawerOutline(
-            drawer.outline,
-            oldWidth * u,
-            oldDepth * uy,
-            (drawer.width as number) * u,
-            (drawer.depth as number) * uy,
-            u,
-            uy
-          );
-          if (resized === undefined) {
-            delete drawer.outline;
-          } else {
-            drawer.outline = resized;
-          }
         }
 
         // Move bins that no longer fit (bounds or outline) to staging. Planar

--- a/src/features/drawer-shape/README.md
+++ b/src/features/drawer-shape/README.md
@@ -73,7 +73,13 @@ hatching, baseplate generation/splitting) derives from it.
    drawer. The grow path fits the loop against the drawer it is _about_ to
    have, so the resize and the outline land in one commit instead of racing.
    Loops dropped and points thinned are always toasted, never silent.
-6. The corner-cut vertex geometry lives in
+6. **The outline never changes implicitly** (#3149) — `drawer.update` clamps a
+   shrink to the shape's bounding half-unit grid (`minDrawerUnitsForOutline`)
+   and keeps the outline byte-identical on grow; the old crop/weld adaptation
+   is gone. The cell editor warns (`drawerShape.editor.replacesDrawnShape`)
+   when the stored perimeter would not survive rasterization
+   (`isOutlineCellRepresentable`), since applying a cell paint replaces it.
+7. The corner-cut vertex geometry lives in
    `@/shared/utils/cornerCutOutline` (not here) so the baseplate's
    `buildFullParams` can re-inscribe the same cuts on the padded plate
    rectangle (issue #2612). `cornersToOutline` is a thin wrapper that adds

--- a/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.test.tsx
+++ b/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.test.tsx
@@ -77,6 +77,55 @@ describe('ShapeEditorDialog', () => {
     expect(screen.getByRole('button', { name: 'drawerShape.editor.apply' })).toBeDisabled();
   });
 
+  it('warns when the stored perimeter is not cell-representable (#3149)', () => {
+    setDrawer(4, 4);
+    const u = useLayoutStore.getState().layout.gridUnitMm as number;
+    useLayoutStore.setState((s) => ({
+      layout: {
+        ...s.layout,
+        drawer: {
+          ...s.layout.drawer,
+          outline: {
+            vertices: [
+              { x: 0, y: 0 },
+              { x: 4 * u, y: 0 },
+              { x: 4 * u, y: 4 * u, bulge: -0.25 },
+              { x: 0, y: 4 * u },
+            ],
+          },
+        },
+      },
+    }));
+    render(<ShapeEditorDialog open onClose={() => {}} />);
+    expect(screen.getByText('drawerShape.editor.replacesDrawnShape')).toBeInTheDocument();
+  });
+
+  it('shows no warning for a cell-painted perimeter', () => {
+    setDrawer(2, 2);
+    const u = useLayoutStore.getState().layout.gridUnitMm as number;
+    useLayoutStore.setState((s) => ({
+      layout: {
+        ...s.layout,
+        drawer: {
+          ...s.layout.drawer,
+          outline: {
+            vertices: [
+              { x: 0, y: 0 },
+              { x: 2 * u, y: 0 },
+              { x: 2 * u, y: u },
+              { x: u, y: u },
+              { x: u, y: 2 * u },
+              { x: 0, y: 2 * u },
+            ],
+            authoring: { kind: 'cells' as const },
+          },
+        },
+      },
+    }));
+    render(<ShapeEditorDialog open onClose={() => {}} />);
+    expect(screen.queryByText('drawerShape.editor.replacesDrawnShape')).not.toBeInTheDocument();
+  });
+
   it('trace seeds the grid from bin footprints', () => {
     setDrawer(2, 1);
     useLayoutStore.setState((s) => ({

--- a/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
+++ b/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
@@ -12,6 +12,7 @@ import { trackDrawerShapeApplied } from '@/shared/analytics/posthog';
 import {
   buildFullDrawerMask,
   drawerMaskToOutline,
+  isOutlineCellRepresentable,
   outlineToDrawerMask,
   type DrawerMaskGrid,
 } from '../../utils/drawerMask';
@@ -54,6 +55,20 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- reseed only on open
   }, [open]);
   const active = grid ?? seeded;
+
+  // A pen-drawn or imported perimeter (arcs, diagonals, off-cell edges) does
+  // not survive rasterization — applying a cell paint would replace it, so
+  // the dialog says so up front (#3149).
+  const replacesDrawnShape = useMemo(() => {
+    if (!open || layout.drawer.outline === undefined) return false;
+    return !isOutlineCellRepresentable(
+      layout.drawer.outline,
+      layout.drawer,
+      layout.gridUnitMm,
+      gridUnitMmY
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- evaluate only on open
+  }, [open]);
 
   const cellFromEvent = useCallback((e: PointerEvent<HTMLDivElement>): number | null => {
     const el = (e.target as HTMLElement).closest('[data-cell-index]');
@@ -166,6 +181,11 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
       <Dialog.Body>
         <div className="space-y-3">
           <p className="text-xs text-content-secondary">{t('drawerShape.editor.hint')}</p>
+          {replacesDrawnShape && (
+            <p className="text-xs text-status-warning" role="alert">
+              {t('drawerShape.editor.replacesDrawnShape')}
+            </p>
+          )}
           <div
             role="grid"
             aria-label={t('drawerShape.editor.gridAria')}

--- a/src/features/drawer-shape/utils/drawerMask.test.ts
+++ b/src/features/drawer-shape/utils/drawerMask.test.ts
@@ -5,6 +5,7 @@ import {
   buildFullDrawerMask,
   drawerMaskToOutline,
   editorAxisCells,
+  isOutlineCellRepresentable,
   outlineToDrawerMask,
 } from './drawerMask';
 
@@ -97,6 +98,57 @@ describe('outlineToDrawerMask round-trip', () => {
     const d = drawer(4, 4);
     const back = outlineToDrawerMask(result.outline, d, U);
     expect(Array.from(back.cells)).toEqual(Array.from(grid.cells));
+  });
+});
+
+describe('isOutlineCellRepresentable (#3149)', () => {
+  it('accepts a cell-painted shape (exact round-trip)', () => {
+    const grid = buildFullDrawerMask(drawer(4, 4));
+    setCell(grid, 2, 2, 0);
+    setCell(grid, 3, 2, 0);
+    setCell(grid, 2, 3, 0);
+    setCell(grid, 3, 3, 0);
+    const result = drawerMaskToOutline(grid, U);
+    if (!('outline' in result)) throw new Error('expected outline');
+    expect(isOutlineCellRepresentable(result.outline, drawer(4, 4), U)).toBe(true);
+  });
+
+  it('rejects a pen shape with arcs', () => {
+    const curved = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 4 * U, bulge: -0.25 },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    expect(isOutlineCellRepresentable(curved, drawer(4, 4), U)).toBe(false);
+  });
+
+  it('rejects a pen shape with off-cell edges', () => {
+    // Straight-edged, but the right edge sits at 3.3 units — between cells.
+    const offCell = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 3.3 * U, y: 0 },
+        { x: 3.3 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    expect(isOutlineCellRepresentable(offCell, drawer(4, 4), U)).toBe(false);
+  });
+
+  it('rejects an outline whose rasterization collapses to nothing', () => {
+    // Thinner than a cell everywhere: no cell is fully inside.
+    const sliver = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 0.4 * U },
+        { x: 0, y: 0.4 * U },
+      ],
+    };
+    expect(isOutlineCellRepresentable(sliver, drawer(4, 4), U)).toBe(false);
   });
 });
 

--- a/src/features/drawer-shape/utils/drawerMask.ts
+++ b/src/features/drawer-shape/utils/drawerMask.ts
@@ -11,6 +11,7 @@
 
 import type { Drawer, DrawerOutline, FractionalEdge } from '@/core/types';
 import { MASK_CELLS_PER_UNIT, maskToPolygon, type CellMask } from '@/shared/utils/cellMask';
+import { canonicalStartOutline, hashOutline } from '@/shared/utils/drawerOutline';
 import { getOutsideCellSet } from '@/shared/utils/drawerOutlineCells';
 
 /** One paintable editor cell (whole drawer cell or the fractional edge cell). */
@@ -132,6 +133,32 @@ export function drawerMaskToOutline(
       authoring: { kind: 'cells' },
     },
   };
+}
+
+/**
+ * Whether the stored outline survives a rasterize → trace round-trip intact.
+ * False means the cell editor cannot express this shape (arcs, diagonals,
+ * off-cell edges from the pen editor or an import), so applying a cell paint
+ * would replace the drawn perimeter — the dialog warns before that happens
+ * (#3149). Hash-compares canonical geometry, so vertex order and the
+ * authoring echo don't produce false negatives.
+ */
+export function isOutlineCellRepresentable(
+  outline: DrawerOutline,
+  drawer: Drawer,
+  gridUnitMm: number,
+  // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
+  gridUnitMmY: number = gridUnitMm
+): boolean {
+  const conv = drawerMaskToOutline(
+    outlineToDrawerMask(outline, drawer, gridUnitMm, gridUnitMmY),
+    gridUnitMm,
+    gridUnitMmY
+  );
+  if (!('outline' in conv)) return false;
+  return (
+    hashOutline(canonicalStartOutline(conv.outline)) === hashOutline(canonicalStartOutline(outline))
+  );
 }
 
 function isFourConnected(grid: DrawerMaskGrid): boolean {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1773,6 +1773,7 @@
   "drawerShape.editor.gridAria": "Buňky tvaru zásuvky",
   "drawerShape.editor.hint": "Klikáním nebo tažením vyřezávej buňky ze zásuvky. Biny mimo tvar se při použití přesunou do Stash.",
   "drawerShape.editor.invalidDisconnected": "Tvar musí být jeden souvislý kus.",
+  "drawerShape.editor.replacesDrawnShape": "Aktuální obrys byl nakreslen od ruky nebo importován. Použitím tvaru z buněk se nahradí — křivky a hrany mimo mřížku budou ztraceny.",
   "drawerShape.editor.invalidEmpty": "Tvar potřebuje alespoň jednu buňku.",
   "drawerShape.editor.title": "Tvar zásuvky",
   "drawerShape.penOpen": "Nakreslit tvar…",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1926,6 +1926,7 @@
   "drawerShape.editor.gridAria": "Zellen der Schubladenform",
   "drawerShape.editor.hint": "Klicke oder ziehe, um Zellen aus der Schublade zu entfernen. Bins außerhalb der Form wandern beim Anwenden in die Ablage.",
   "drawerShape.editor.invalidDisconnected": "Die Form muss zusammenhängend sein.",
+  "drawerShape.editor.replacesDrawnShape": "Der aktuelle Umriss wurde freihändig gezeichnet oder importiert. Beim Anwenden einer Zellenform wird er ersetzt — Kurven und rasterfremde Kanten gehen verloren.",
   "drawerShape.editor.invalidEmpty": "Die Form braucht mindestens eine Zelle.",
   "drawerShape.editor.title": "Schubladenform",
   "drawerShape.penOpen": "Form zeichnen…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3695,6 +3695,8 @@ const en: Record<string, string> = {
   'drawerShape.editor.apply': 'Apply shape',
   'drawerShape.editor.invalidEmpty': 'The shape needs at least one cell.',
   'drawerShape.editor.invalidDisconnected': 'The shape must be one connected piece.',
+  'drawerShape.editor.replacesDrawnShape':
+    'The current perimeter was drawn freehand or imported. Applying a cell shape replaces it — curves and off-grid edges are lost.',
   'toast.binsDisplacedByShape': '{count} bin(s) moved to the stash (outside the new shape)',
   'toast.outlineImport.parseFailed': "That file couldn't be read as an SVG or DXF drawing.",
   'toast.outlineImport.noClosedLoop':

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1926,6 +1926,7 @@
   "drawerShape.editor.gridAria": "Celdas de la forma del cajón",
   "drawerShape.editor.hint": "Haz clic o arrastra para recortar celdas del cajón. Los bins fuera de la forma pasan al depósito al aplicar.",
   "drawerShape.editor.invalidDisconnected": "La forma debe ser una sola pieza conectada.",
+  "drawerShape.editor.replacesDrawnShape": "El perímetro actual se dibujó a mano alzada o se importó. Aplicar una forma de celdas lo reemplaza: se pierden las curvas y los bordes fuera de la cuadrícula.",
   "drawerShape.editor.invalidEmpty": "La forma necesita al menos una celda.",
   "drawerShape.editor.title": "Forma del cajón",
   "drawerShape.penOpen": "Dibujar forma…",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1773,6 +1773,7 @@
   "drawerShape.editor.gridAria": "Cellules de la forme du tiroir",
   "drawerShape.editor.hint": "Cliquez ou faites glisser pour retirer des cellules du tiroir. Les bacs hors de la forme partent en réserve à l’application.",
   "drawerShape.editor.invalidDisconnected": "La forme doit être d’un seul tenant.",
+  "drawerShape.editor.replacesDrawnShape": "Le périmètre actuel a été dessiné à main levée ou importé. Appliquer une forme par cellules le remplace — les courbes et les bords hors grille sont perdus.",
   "drawerShape.editor.invalidEmpty": "La forme doit contenir au moins une cellule.",
   "drawerShape.editor.title": "Forme du tiroir",
   "drawerShape.penOpen": "Dessiner la forme…",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1926,6 +1926,7 @@
   "drawerShape.editor.gridAria": "Celle della forma del cassetto",
   "drawerShape.editor.hint": "Clicca o trascina per ritagliare celle dal cassetto. I bin fuori dalla forma si spostano nell'area di sosta quando applichi.",
   "drawerShape.editor.invalidDisconnected": "La forma deve essere un unico pezzo connesso.",
+  "drawerShape.editor.replacesDrawnShape": "Il perimetro attuale è stato disegnato a mano libera o importato. Applicando una forma a celle verrà sostituito: curve e bordi fuori griglia andranno persi.",
   "drawerShape.editor.invalidEmpty": "La forma richiede almeno una cella.",
   "drawerShape.editor.title": "Forma del cassetto",
   "drawerShape.penOpen": "Disegna forma…",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1926,6 +1926,7 @@
   "drawerShape.editor.gridAria": "引き出し形状のセル",
   "drawerShape.editor.hint": "クリックまたはドラッグでセルを削り取ります。形状の外のビンは適用時にスタッシュへ移動します。",
   "drawerShape.editor.invalidDisconnected": "形状はひとつながりである必要があります。",
+  "drawerShape.editor.replacesDrawnShape": "現在の外形はフリーハンドで描かれたか、インポートされたものです。セル形状を適用すると置き換えられ、曲線やグリッド外のエッジは失われます。",
   "drawerShape.editor.invalidEmpty": "形状には少なくとも1つのセルが必要です。",
   "drawerShape.editor.title": "引き出しの形状",
   "drawerShape.penOpen": "形状を描く…",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1697,6 +1697,7 @@
   "drawerShape.editor.gridAria": "서랍 모양 셀",
   "drawerShape.editor.hint": "클릭하거나 드래그하여 서랍에서 셀을 파내세요. 적용하면 모양 바깥의 수납통은 임시 보관함으로 이동합니다.",
   "drawerShape.editor.invalidDisconnected": "모양은 하나로 연결된 조각이어야 합니다.",
+  "drawerShape.editor.replacesDrawnShape": "현재 윤곽은 자유 곡선으로 그렸거나 가져온 것입니다. 셀 모양을 적용하면 대체되며 곡선과 그리드를 벗어난 가장자리는 사라집니다.",
   "drawerShape.editor.invalidEmpty": "모양에는 셀이 최소 하나 필요합니다.",
   "drawerShape.editor.title": "서랍 모양",
   "drawerShape.penOpen": "형상 그리기…",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1926,6 +1926,7 @@
   "drawerShape.editor.gridAria": "Celler i skuffeformen",
   "drawerShape.editor.hint": "Klikk eller dra for å fjerne celler fra skuffen. Binner utenfor formen flyttes til lageret når du bruker den.",
   "drawerShape.editor.invalidDisconnected": "Formen må henge sammen.",
+  "drawerShape.editor.replacesDrawnShape": "Den gjeldende omkretsen ble tegnet på frihånd eller importert. Å bruke en celleform erstatter den — kurver og kanter utenfor rutenettet går tapt.",
   "drawerShape.editor.invalidEmpty": "Formen trenger minst én celle.",
   "drawerShape.editor.title": "Skuffeform",
   "drawerShape.penOpen": "Tegn form…",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1926,6 +1926,7 @@
   "drawerShape.editor.gridAria": "Cellen van de ladevorm",
   "drawerShape.editor.hint": "Klik of sleep om cellen uit de lade te verwijderen. Bins buiten de vorm gaan bij toepassen naar de stash.",
   "drawerShape.editor.invalidDisconnected": "De vorm moet één aaneengesloten geheel zijn.",
+  "drawerShape.editor.replacesDrawnShape": "De huidige omtrek is uit de vrije hand getekend of geïmporteerd. Een celvorm toepassen vervangt deze — bochten en randen buiten het raster gaan verloren.",
   "drawerShape.editor.invalidEmpty": "De vorm heeft minstens één cel nodig.",
   "drawerShape.editor.title": "Ladevorm",
   "drawerShape.penOpen": "Vorm tekenen…",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1773,6 +1773,7 @@
   "drawerShape.editor.gridAria": "Komórki kształtu szuflady",
   "drawerShape.editor.hint": "Kliknij lub przeciągnij, aby wyciąć komórki z szuflady. Biny poza kształtem przenoszą się do Stash po zastosowaniu.",
   "drawerShape.editor.invalidDisconnected": "Kształt musi być jednym połączonym elementem.",
+  "drawerShape.editor.replacesDrawnShape": "Obecny obrys narysowano odręcznie lub zaimportowano. Zastosowanie kształtu z komórek zastąpi go — krzywe i krawędzie poza siatką zostaną utracone.",
   "drawerShape.editor.invalidEmpty": "Kształt potrzebuje przynajmniej jednej komórki.",
   "drawerShape.editor.title": "Kształt szuflady",
   "drawerShape.penOpen": "Narysuj kształt…",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1773,6 +1773,7 @@
   "drawerShape.editor.gridAria": "Células do formato da gaveta",
   "drawerShape.editor.hint": "Clique ou arraste para recortar células da gaveta. Bins fora do formato vão para o depósito ao aplicar.",
   "drawerShape.editor.invalidDisconnected": "O formato precisa ser uma única peça conectada.",
+  "drawerShape.editor.replacesDrawnShape": "O perímetro atual foi desenhado à mão livre ou importado. Aplicar uma forma de células o substitui — curvas e bordas fora da grade são perdidas.",
   "drawerShape.editor.invalidEmpty": "O formato precisa de pelo menos uma célula.",
   "drawerShape.editor.title": "Formato da gaveta",
   "drawerShape.penOpen": "Desenhar forma…",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1773,6 +1773,7 @@
   "drawerShape.editor.gridAria": "Celler i lådans form",
   "drawerShape.editor.hint": "Klicka eller dra för att ta bort celler ur lådan. Bins utanför formen flyttas till förrådet när du tillämpar.",
   "drawerShape.editor.invalidDisconnected": "Formen måste hänga ihop.",
+  "drawerShape.editor.replacesDrawnShape": "Den nuvarande konturen ritades på fri hand eller importerades. Att tillämpa en cellform ersätter den — kurvor och kanter utanför rutnätet går förlorade.",
   "drawerShape.editor.invalidEmpty": "Formen behöver minst en cell.",
   "drawerShape.editor.title": "Lådans form",
   "drawerShape.penOpen": "Rita form…",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1926,6 +1926,7 @@
   "drawerShape.editor.gridAria": "Клітинки форми шухляди",
   "drawerShape.editor.hint": "Клацайте або тягніть, щоб вирізати клітинки з шухляди. Біни поза формою перемістяться до сховку після застосування.",
   "drawerShape.editor.invalidDisconnected": "Форма має бути суцільною.",
+  "drawerShape.editor.replacesDrawnShape": "Поточний контур намальовано від руки або імпортовано. Застосування форми з клітинок замінить його — криві та краї поза сіткою буде втрачено.",
   "drawerShape.editor.invalidEmpty": "Форма має містити принаймні одну клітинку.",
   "drawerShape.editor.title": "Форма шухляди",
   "drawerShape.penOpen": "Намалювати форму…",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1773,6 +1773,7 @@
   "drawerShape.editor.gridAria": "抽屉形状单元",
   "drawerShape.editor.hint": "点击或拖动以从抽屉中挖去单元。应用时，形状之外的收纳盒会被移入暂存区。",
   "drawerShape.editor.invalidDisconnected": "形状必须是一个连通的整体。",
+  "drawerShape.editor.replacesDrawnShape": "当前轮廓是手绘或导入的。应用单元格形状将替换它——曲线和网格外的边缘将丢失。",
   "drawerShape.editor.invalidEmpty": "形状至少需要一个单元。",
   "drawerShape.editor.title": "抽屉形状",
   "drawerShape.penOpen": "绘制形状…",

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -6,10 +6,10 @@ import { createTestLayout } from '@/test/testUtils';
 import {
   canonicalStartOutline,
   hashOutline,
+  minDrawerUnitsForOutline,
   normalizeDrawerOutline,
   OUTLINE_MAX_VERTICES,
   quantizeOutline,
-  resizeDrawerOutline,
   rotateOutline180,
   snapOutlineToBounds,
   translateOutline,
@@ -310,183 +310,60 @@ describe('canonicalStartOutline', () => {
   });
 });
 
-describe('resizeDrawerOutline', () => {
-  it('returns the same outline when dims are unchanged', () => {
-    expect(resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 4 * U, 4 * U, U)).toBe(L_SHAPE);
+describe('minDrawerUnitsForOutline', () => {
+  it('returns the exact unit dims for a whole-unit shape', () => {
+    expect(minDrawerUnitsForOutline(L_SHAPE, U)).toEqual({ width: 4, depth: 4 });
   });
 
-  it('crops on shrink, preserving the notch', () => {
-    const shrunk = resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 3 * U, 4 * U, U);
-    expect(shrunk).toBeDefined();
-    const o = shrunk as DrawerOutline;
-    expect(validateOutline(o, 3 * U, 4 * U, U)).toBeNull();
-    expect(outlineSignedArea(o)).toBeCloseTo(3 * 4 * U * U - 1 * 2 * U * U);
-  });
-
-  it('resets to rectangle when the shrink consumes the notch', () => {
-    expect(resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 2 * U, 4 * U, U)).toBeUndefined();
-  });
-
-  it('extends across a grown edge with the new area inside', () => {
-    const grown = resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 5 * U, 4 * U, U);
-    expect(grown).toBeDefined();
-    const o = grown as DrawerOutline;
-    expect(validateOutline(o, 5 * U, 4 * U, U)).toBeNull();
-    expect(outlineSignedArea(o)).toBeCloseTo(16 * U * U - 4 * U * U + 4 * U * U);
-  });
-
-  it('grows both axes sequentially', () => {
-    // Notch at the bottom-right, away from both grown edges.
-    const bottomNotch: DrawerOutline = {
+  it('ceils a fractional extent to the next half unit', () => {
+    const overhang: DrawerOutline = {
       vertices: [
         { x: 0, y: 0 },
-        { x: 2 * U, y: 0 },
-        { x: 2 * U, y: 2 * U },
-        { x: 4 * U, y: 2 * U },
-        { x: 4 * U, y: 4 * U },
-        { x: 0, y: 4 * U },
+        { x: 4.2 * U, y: 0 },
+        { x: 4.2 * U, y: 3.6 * U },
+        { x: 0, y: 3.6 * U },
       ],
     };
-    const grown = resizeDrawerOutline(bottomNotch, 4 * U, 4 * U, 5 * U, 5 * U, U);
-    expect(grown).toBeDefined();
-    const o = grown as DrawerOutline;
-    expect(validateOutline(o, 5 * U, 5 * U, U)).toBeNull();
-    // L area + right strip (1×4) + top strip (5×1).
-    expect(outlineSignedArea(o)).toBeCloseTo((12 + 4 + 5) * U * U);
+    expect(minDrawerUnitsForOutline(overhang, U)).toEqual({ width: 4.5, depth: 4 });
   });
 
-  it('grows depth past an edge-touching notch, keeping it open', () => {
-    const grown = resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 4 * U, 5 * U, U);
-    expect(grown).toBeDefined();
-    const o = grown as DrawerOutline;
-    expect(validateOutline(o, 4 * U, 5 * U, U)).toBeNull();
-    // L area + top strip over the body only (the notch mouth stays open at
-    // the right drawer edge — no hole).
-    expect(outlineSignedArea(o)).toBeCloseTo((12 + 4) * U * U);
-  });
-
-  it('keeps the shape when a second-axis growth cannot weld (welds the first, notch stays open)', () => {
-    // Width growth welds a strip along the notch's right side; the later depth
-    // growth would then span two separate top runs, so it welds nothing and the
-    // width-grown shape is kept rather than discarded (#3114).
-    const grown = resizeDrawerOutline(L_SHAPE, 4 * U, 4 * U, 5 * U, 5 * U, U);
-    expect(grown).toBeDefined();
-    const o = grown as DrawerOutline;
-    expect(validateOutline(o, 5 * U, 5 * U, U)).toBeNull();
-    // L area (12) + welded right strip (1×4); the top stays open (unwelded).
-    expect(outlineSignedArea(o)).toBeCloseTo((12 + 4) * U * U);
-  });
-
-  it('keeps an off-edge outline when growing (the grid enlarges around it)', () => {
-    // An L inset from the 4-wide drawer's right edge: growing to 5 wide welds
-    // nothing (no run flush with the old edge), so it is kept unchanged, now
-    // offset within the larger grid (#3114).
-    const inset: DrawerOutline = {
-      vertices: [
-        { x: 0, y: 0 },
-        { x: 3 * U, y: 0 },
-        { x: 3 * U, y: 2 * U },
-        { x: U, y: 2 * U },
-        { x: U, y: 4 * U },
-        { x: 0, y: 4 * U },
-      ],
-    };
-    const grown = resizeDrawerOutline(inset, 4 * U, 4 * U, 5 * U, 4 * U, U);
-    expect(grown).toBeDefined();
-    const o = grown as DrawerOutline;
-    expect(validateOutline(o, 5 * U, 4 * U, U)).toBeNull();
-    expect(o.vertices).toEqual(inset.vertices);
-  });
-
-  it('keeps a right-notched outline when growing past its two-run edge', () => {
-    // The notch cuts the old right edge into two runs; welding both would trap a
-    // hole. Growing instead keeps the shape, the notch now interior to the
-    // larger grid (#3114).
-    const sideNotch: DrawerOutline = {
+  it('measures the flattened arc, not the vertices', () => {
+    // Positive bulge on the back edge bows outward past y = 4u (sagitta
+    // 0.5u at bulge 0.25 over a 4u chord), so the depth floor is 4.5.
+    const bowedBack: DrawerOutline = {
       vertices: [
         { x: 0, y: 0 },
         { x: 4 * U, y: 0 },
-        { x: 4 * U, y: U },
-        { x: 2 * U, y: U },
-        { x: 2 * U, y: 3 * U },
-        { x: 4 * U, y: 3 * U },
-        { x: 4 * U, y: 4 * U },
+        { x: 4 * U, y: 4 * U, bulge: 0.25 },
         { x: 0, y: 4 * U },
       ],
     };
-    expect(validateOutline(sideNotch, 4 * U, 4 * U, U)).toBeNull();
-    const grown = resizeDrawerOutline(sideNotch, 4 * U, 4 * U, 5 * U, 4 * U, U);
-    expect(grown).toBeDefined();
-    const o = grown as DrawerOutline;
-    expect(validateOutline(o, 5 * U, 4 * U, U)).toBeNull();
-    // Full 4×4 minus the 2×2 notch.
-    expect(outlineSignedArea(o)).toBeCloseTo((16 - 4) * U * U);
+    expect(minDrawerUnitsForOutline(bowedBack, U).depth).toBe(4.5);
   });
 
-  it('keeps an oversize outline on grow, revalidated against the larger bounds', () => {
-    // The perimeter already reaches past the old 4-wide grid (x = 4.5u).
-    // Growing welds nothing and keeps it, now within the 5-wide bounds (#3114).
-    const oversize: DrawerOutline = {
+  it('uses the per-axis pitch on a non-square grid', () => {
+    const rect: DrawerOutline = {
       vertices: [
         { x: 0, y: 0 },
-        { x: 4.5 * U, y: 0 },
-        { x: 4.5 * U, y: 3.5 * U },
-        { x: 4 * U, y: 4 * U },
-        { x: 0, y: 4 * U },
+        { x: 396, y: 0 },
+        { x: 396, y: 295.5 },
+        { x: 0, y: 295.5 },
       ],
     };
-    const grown = resizeDrawerOutline(oversize, 4 * U, 4 * U, 5 * U, 4 * U, U);
-    expect(grown).toBeDefined();
-    const o = grown as DrawerOutline;
-    expect(validateOutline(o, 5 * U, 4 * U, U)).toBeNull();
-    expect(o.vertices).toEqual(oversize.vertices);
+    // The #3149 repro: 48 × 42 pitch needs an 8.5 × 7.5 drawer.
+    expect(minDrawerUnitsForOutline(rect, 48, 42)).toEqual({ width: 8.5, depth: 7.5 });
   });
 
-  it('resets when a shrink would split the shape into two components', () => {
-    const bridge: DrawerOutline = {
+  it('does not ceil an extent already on a half unit (float noise guarded)', () => {
+    const exact: DrawerOutline = {
       vertices: [
         { x: 0, y: 0 },
-        { x: U, y: 0 },
-        { x: U, y: 3 * U },
-        { x: 3 * U, y: 3 * U },
-        { x: 3 * U, y: 0 },
-        { x: 4 * U, y: 0 },
-        { x: 4 * U, y: 4 * U },
-        { x: 0, y: 4 * U },
+        { x: 8.5 * 48, y: 0 },
+        { x: 8.5 * 48, y: 7.5 * 42 },
+        { x: 0, y: 7.5 * 42 },
       ],
     };
-    expect(validateOutline(bridge, 4 * U, 4 * U, U)).toBeNull();
-    expect(resizeDrawerOutline(bridge, 4 * U, 4 * U, 4 * U, 2 * U, U)).toBeUndefined();
-  });
-
-  it('resets when the crop removes the whole curved region', () => {
-    // CURVED_BACK's arc only dips to y = 3.5u; cropping to 3u leaves a plain
-    // rectangle, which must normalize back to "no outline".
-    expect(resizeDrawerOutline(CURVED_BACK, 4 * U, 4 * U, 4 * U, 3 * U, U)).toBeUndefined();
-  });
-
-  it('crops through arcs without breaking validity', () => {
-    // Deeper bow (sagitta 1u): the clip line at 3.5u crosses the arc twice.
-    const deepCurve: DrawerOutline = {
-      vertices: [
-        { x: 0, y: 0 },
-        { x: 4 * U, y: 0 },
-        { x: 4 * U, y: 4 * U, bulge: -0.5 },
-        { x: 0, y: 4 * U },
-      ],
-    };
-    const shrunk = resizeDrawerOutline(deepCurve, 4 * U, 4 * U, 4 * U, 3.5 * U, U);
-    expect(shrunk).toBeDefined();
-    const o = shrunk as DrawerOutline;
-    expect(validateOutline(o, 4 * U, 3.5 * U, U)).toBeNull();
-    expect(o.vertices.some((v) => (v.bulge ?? 0) !== 0)).toBe(true);
-    expect(outlineSignedArea(o)).toBeLessThan(4 * 3.5 * U * U);
-  });
-
-  it('drops the authoring annotation when geometry changes', () => {
-    const annotated: DrawerOutline = { ...L_SHAPE, authoring: { kind: 'cells' } };
-    const shrunk = resizeDrawerOutline(annotated, 4 * U, 4 * U, 3 * U, 4 * U, U);
-    expect((shrunk as DrawerOutline).authoring).toBeUndefined();
+    expect(minDrawerUnitsForOutline(exact, 48, 42)).toEqual({ width: 8.5, depth: 7.5 });
   });
 });
 

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -1,6 +1,6 @@
 /**
  * Model operations for `DrawerOutline`: validation, transforms, hashing,
- * resize (crop/extend), and read-side normalization.
+ * and read-side normalization.
  *
  * Everything here is brepjs/WASM-free and pure. The geometry math (arcs,
  * flattening, classification) lives in `drawerOutlineGeometry.ts`; this module
@@ -16,6 +16,7 @@ import {
   BULGE_EPS,
   bulgeForSweep,
   flattenOutline,
+  outlineBounds,
   polylineSignedArea,
   type OutlinePoint,
 } from './drawerOutlineGeometry';
@@ -409,96 +410,6 @@ function clipHalfPlane(
 }
 
 /**
- * Extend the loop across a grown drawer edge. The grown strip
- * (`newRect \ oldRect` on this axis) defaults to inside, welded to the shape
- * along the segment run the outline shares with the moved edge. Exactly one
- * maximal run can weld: zero (the loop never lay flush with, or already runs
- * past, the moved edge) or two-plus (welding would enclose a hole) return
- * null. On a grow the caller then keeps the loop unchanged — a bigger grid
- * only enlarges the valid region around an already-valid shape.
- */
-function growAxis(
-  verts: readonly MutableVertex[],
-  axis: Axis,
-  oldK: number,
-  newK: number,
-  crossExtent: number
-): MutableVertex[] | null {
-  const n = verts.length;
-  const onEdge = (i: number): boolean => {
-    const a = verts[i];
-    const b = verts[(i + 1) % n];
-    return (
-      Math.abs(a.bulge) < BULGE_EPS &&
-      Math.abs(coord(a, axis) - oldK) <= LINE_EPS &&
-      Math.abs(coord(b, axis) - oldK) <= LINE_EPS
-    );
-  };
-
-  const runStarts: number[] = [];
-  for (let i = 0; i < n; i++) {
-    if (onEdge(i) && !onEdge((i - 1 + n) % n)) runStarts.push(i);
-  }
-  if (runStarts.length !== 1) return null;
-
-  let runEnd = runStarts[0];
-  while (onEdge(runEnd)) runEnd = (runEnd + 1) % n;
-
-  // Rotate so the run's interior vertices sit at the end of the array:
-  // rotated[0] follows the run, rotated[last] starts it.
-  const start = runStarts[0];
-  const rotated: MutableVertex[] = [];
-  for (let i = runEnd; i !== start; i = (i + 1) % n) rotated.push(verts[i]);
-  const runStartVertex = verts[start];
-  const runEndVertex = verts[runEnd];
-
-  // Walk the strip's boundary from weld start to weld end (CCW, interior
-  // left). X axis: down the old edge, around the strip; Y axis mirrored.
-  const detour: MutableVertex[] = [{ ...runStartVertex, bulge: 0 }];
-  const push = (x: number, y: number): void => {
-    const last = detour[detour.length - 1];
-    if (Math.hypot(last.x - x, last.y - y) >= COINCIDENT_EPS) {
-      detour.push({ x, y, bulge: 0 });
-    }
-  };
-  if (axis === 'x') {
-    push(oldK, 0);
-    push(newK, 0);
-    push(newK, crossExtent);
-    push(oldK, crossExtent);
-  } else {
-    push(crossExtent, oldK);
-    push(crossExtent, newK);
-    push(0, newK);
-    push(0, oldK);
-  }
-  const last = detour[detour.length - 1];
-  if (Math.hypot(last.x - runEndVertex.x, last.y - runEndVertex.y) < COINCIDENT_EPS) {
-    detour.pop();
-  }
-
-  return [...rotated, ...detour];
-}
-
-/**
- * Grow an axis, keeping the loop unchanged when {@link growAxis} can't weld a
- * strip (the loop is off the moved edge, or already runs past it). A grow only
- * enlarges the valid region, so an unweldable perimeter stays valid as-is;
- * discarding it would delete a custom shape the instant the grid grows (#3114).
- * Shrinks stay on {@link clipHalfPlane}, whose null result is a genuine
- * fall-back-to-rectangle (the clip severed or emptied the loop).
- */
-function growOrKeep(
-  verts: readonly MutableVertex[],
-  axis: Axis,
-  oldK: number,
-  newK: number,
-  crossExtent: number
-): MutableVertex[] {
-  return growAxis(verts, axis, oldK, newK, crossExtent) ?? [...verts];
-}
-
-/**
  * Topology test, not an area tolerance: the loop traces the full rectangle
  * exactly when every segment is straight and hugs one of the four boundary
  * lines. A corner-cutting edge (e.g. a small chamfer) has its endpoints on
@@ -542,61 +453,25 @@ function dropCoincident(verts: MutableVertex[]): MutableVertex[] {
 }
 
 /**
- * Adapt an outline to resized drawer dims (mm): cropped where the drawer
- * shrank, and where it grew either welded across the moved edge (loop flush
- * with it) or kept unchanged (loop off it — the grid just enlarges around a
- * still-valid shape). Returns:
- * - the same outline when dims are unchanged,
- * - a new outline when the crop/extend succeeded,
- * - `undefined` when the result is the full rectangle OR degenerate/invalid
- *   (a shrink severed the loop, or the kept shape no longer validates) — the
- *   caller must fall back to a plain rectangular drawer (drop the field).
- *
- * The authoring annotation is dropped whenever geometry changes; editors
- * re-derive their state from geometry.
+ * Smallest half-unit drawer dims that contain the outline — the floor a
+ * drawer resize may shrink to while a custom shape is active (#3149: a resize
+ * must never crop or extend the user's shape, so the dims clamp instead).
+ * Measured on the flattened path (an arc bows past its own endpoints), same
+ * as the pen editor's auto-grow, so clamp and grow agree on the boundary.
  */
-export function resizeDrawerOutline(
+export function minDrawerUnitsForOutline(
   outline: DrawerOutline,
-  oldWidthMm: number,
-  oldDepthMm: number,
-  newWidthMm: number,
-  newDepthMm: number,
   gridUnitMm: number,
   // Depth-axis pitch for a non-square grid; defaults to the X pitch (square).
   gridUnitMmY: number = gridUnitMm
-): DrawerOutline | undefined {
-  const sameW = Math.abs(newWidthMm - oldWidthMm) < OUTLINE_QUANTUM_MM;
-  const sameD = Math.abs(newDepthMm - oldDepthMm) < OUTLINE_QUANTUM_MM;
-  if (sameW && sameD) return outline;
-
-  let verts: MutableVertex[] | null = toMutable(outline.vertices);
-  if (!sameW) {
-    verts =
-      newWidthMm < oldWidthMm
-        ? clipHalfPlane(verts, 'x', newWidthMm)
-        : growOrKeep(verts, 'x', oldWidthMm, newWidthMm, oldDepthMm);
-  }
-  if (verts !== null && !sameD) {
-    verts =
-      newDepthMm < oldDepthMm
-        ? clipHalfPlane(verts, 'y', newDepthMm)
-        : growOrKeep(verts, 'y', oldDepthMm, newDepthMm, newWidthMm);
-  }
-  if (verts === null) return undefined;
-
-  verts = dropCoincident(verts);
-  if (verts.length < 3) return undefined;
-
-  const candidate = snapOutlineToBounds(
-    quantizeOutline({ vertices: toVertices(verts) }),
-    newWidthMm,
-    newDepthMm
-  );
-  if (isFullRectangle(candidate, newWidthMm, newDepthMm)) return undefined;
-  if (validateOutline(candidate, newWidthMm, newDepthMm, gridUnitMm, gridUnitMmY) !== null) {
-    return undefined;
-  }
-  return candidate;
+): { readonly width: number; readonly depth: number } {
+  const b = outlineBounds(outline);
+  const ceilHalf = (mm: number, pitch: number): number =>
+    Math.max(0.5, Math.ceil((mm / pitch) * 2 - 1e-9) / 2);
+  return {
+    width: ceilHalf(b.maxX, gridUnitMm),
+    depth: ceilHalf(b.maxY, gridUnitMmY),
+  };
 }
 
 /**


### PR DESCRIPTION
Part of #3149 (bugs 2 and 3 of the report: drag-resize mutating the drawn shape, and "Edit shape" destroying it).

## What was happening

`drawer.update` adapted the outline on every resize via `resizeDrawerOutline`: a shrink **clipped** the loop at the new edge (the reporter's right-side points at x=396 were pulled to x=360), and a later grow **welded** a full-depth strip onto the clipped edge (y suddenly spanning the whole drawer on the right — the distorted shape in the report's last two screenshots). Reproduced 1:1 at the command level with the reported point set.

## Fix

- **A resize never touches `drawer.outline`.** With a shape active, `drawer.update` (and the store-side live-drag mirror in `drawerActions`) clamp width/depth to the shape's bounding half-unit grid — new `minDrawerUnitsForOutline`, which uses the same flattened-arc bounds and half-unit ceiling as the pen editor's auto-grow, so clamp and grow agree at the boundary. Growing keeps the outline byte-identical. To shrink further, the user edits or resets the shape — nothing edits it on their behalf.
- The crop/weld machinery (`resizeDrawerOutline`, `growAxis`, `growOrKeep`) is deleted; `clipHalfPlane` stays for the read-side ingress normalizer. `apply()` still honours legacy persisted events that carry an adapted/reset outline, so replay is unchanged.
- **The cell editor now warns before replacing a drawn perimeter.** New `isOutlineCellRepresentable` does a rasterize → trace round-trip and hash-compares canonical geometry; when a pen-drawn or imported shape (arcs, off-cell edges) wouldn't survive, the dialog shows `drawerShape.editor.replacesDrawnShape` (translated in all 14 locales) instead of silently flattening it on apply.

## Test plan

- [x] `updateDrawer.test.ts` — clamp-to-bounding-grid, byte-identical grow, half-unit ceiling, legacy-event replay
- [x] `drawerActions.test.ts` — same invariants on the live-drag path
- [x] `drawerOutline.test.ts` — `minDrawerUnitsForOutline` incl. arc bows, non-square pitch (the #3149 repro: 396×295.5mm at 48×42 → 8.5×7.5)
- [x] `drawerMask.test.ts` + `ShapeEditorDialog.test.tsx` — representability detection + warning render
- [x] Full unit+dom suite: 1283 files / 17092 tests green; `pnpm run typecheck`; `check:i18n`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops drawer resize from implicitly changing a custom perimeter. Clamps width/depth to the outline’s bounding half‑unit grid and adds a cell editor warning when painting would replace a drawn/imported shape (addresses #3149).

- **Bug Fixes**
  - Resizing clamps to the outline’s bounding half‑unit grid (supports non‑square grids).
  - The outline never changes on grow/shrink; bin displacement runs against the unchanged shape.
  - Legacy events that carried outline changes still replay as before.

- **New Features**
  - Cell editor warns when the current perimeter isn’t cell‑representable, so applying a cell shape would replace it.

<sup>Written for commit c00ea17ec7267bad6821fcd7189c71d74bb4c8ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

