### PR TITLE
fix(baseplate): register the perimeter re-base to the socket lattice

### DIFF
--- a/src/features/baseplate/utils/buildFullParams.test.ts
+++ b/src/features/baseplate/utils/buildFullParams.test.ts
@@ -644,10 +644,11 @@ describe('drawer outline handling', () => {
 
   // #3108/#3109: the pen editor auto-grows the drawer to the MAX extent only
   // (#3092), so a custom perimeter usually lands in a corner-offset sub-rect of
-  // the declared extent. The resolver re-bases the one derived outline onto that
-  // bbox so the generator's socket grid and the split planner's seam bands share
-  // one centred frame.
-  describe('outline re-centring on the perimeter bbox', () => {
+  // the declared extent. The resolver re-bases the one derived outline so the
+  // generator's socket grid and the split planner's seam bands share one frame —
+  // but only by lattice-registered shifts: a sub-cell move breaks whole-cell
+  // registration and drops sockets (#3149).
+  describe('outline re-basing onto the socket lattice', () => {
     const zeroPad = {
       ...storedBase,
       paddingLeft: mm(0),
@@ -676,34 +677,68 @@ describe('drawer outline handling', () => {
       return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2, w: maxX - minX, h: maxY - minY };
     };
 
-    it('shifts a corner-offset outline to the extent centre (grid stays put)', () => {
+    it('keeps a corner-anchored whole-unit shape in place — no sub-cell shift (#3149)', () => {
+      // 3u square in a 4u extent: corner-anchor already holds all 3×3 whole
+      // cells; the old bbox centring (+21 per axis) left only 2×2. Both
+      // registered positions (0 and 42) centre equally, so the smaller move
+      // wins and the outline stays byte-identical.
       const result = buildFullParams(zeroPad, 4, 4, 42, 'end', 'end', undefined, drifted);
-      // Drift = 63 − 84 = −21 per axis; re-centre translates by +21.
-      expect(result.outline?.vertices).toEqual([
-        { x: 21, y: 21 },
-        { x: 147, y: 21 },
-        { x: 147, y: 147 },
-        { x: 21, y: 147 },
-      ]);
-      // Same shape, now centred on the 168×168 extent.
+      expect(result.outline?.vertices).toEqual(drifted.vertices);
+    });
+
+    it('re-bases a whole-unit drift by whole cells, restoring the split frame (#3109)', () => {
+      // 3u square stuck at the right of a 5u extent. A whole-unit −42 shift
+      // relabels the same three cells while landing the shape centred; the
+      // pure-centring −21 would have cost a cell.
+      const rightStuck: DrawerOutline = {
+        vertices: [
+          { x: 84, y: 0 },
+          { x: 210, y: 0 },
+          { x: 210, y: 126 },
+          { x: 84, y: 126 },
+        ],
+      };
+      const result = buildFullParams(zeroPad, 5, 4, 42, 'end', 'end', undefined, rightStuck);
       const b = bboxOf(result.outline as DrawerOutline);
-      expect(b.cx).toBeCloseTo(84, 6);
-      expect(b.cy).toBeCloseTo(84, 6);
+      // [84,210] → [42,168]: registered AND centred on the 210 extent.
+      expect(b.cx).toBeCloseTo(105, 6);
       expect(b.w).toBeCloseTo(126, 6);
     });
 
+    it("registers to the shifted lattice of a 'start' fractional edge", () => {
+      // 4.5-unit drawer, half cell FIRST: whole cells run [21,189] in 42mm
+      // steps. A 4u-wide corner shape must shift +21 onto that lattice to
+      // hold all four cells; with the edge at 'end' it is already registered.
+      const fourWide: DrawerOutline = {
+        vertices: [
+          { x: 0, y: 0 },
+          { x: 168, y: 0 },
+          { x: 168, y: 168 },
+          { x: 0, y: 168 },
+        ],
+      };
+      const startEdge = buildFullParams(zeroPad, 4.5, 4, 42, 'start', 'end', undefined, fourWide);
+      expect(bboxOf(startEdge.outline as DrawerOutline).cx - 84).toBeCloseTo(21, 6);
+      const endEdge = buildFullParams(zeroPad, 4.5, 4, 42, 'end', 'end', undefined, fourWide);
+      expect(endEdge.outline?.vertices).toEqual(fourWide.vertices);
+    });
+
     it('leaves a full-extent outline byte-identical (no drift, cache-stable)', () => {
-      // `outline` fills the 10×8 extent (bbox [0,420]×[0,336]) → offset 0.
+      // `outline` fills the 10×8 extent (bbox [0,420]×[0,336]) → shift 0.
       const result = buildFullParams(zeroPad, 10, 8, 42, 'end', 'end', undefined, outline);
       expect(result.outline?.vertices).toEqual(outline.vertices);
     });
 
-    it('centres against the PADDED extent, composing with asymmetric padding', () => {
-      // storedBase padding L1/R2/F3/B4 → padded extent 171×175.
+    it('registers against the PADDED lattice, composing with asymmetric padding', () => {
+      // storedBase padding L1/R2/F3/B4 → padded extent 171×175, lattice
+      // origin (1,3), and the outline itself padded first (x span 129,
+      // y span 133). The only shift that holds a full 3-cell block lands the
+      // block on padded lattice lines — [43,169]×[45,171] — putting the
+      // padded bbox at 41.5 on each axis.
       const result = buildFullParams(storedBase, 4, 4, 42, 'end', 'end', undefined, drifted);
       const b = bboxOf(result.outline as DrawerOutline);
-      expect(b.cx).toBeCloseTo(171 / 2, 6);
-      expect(b.cy).toBeCloseTo(175 / 2, 6);
+      expect(b.cx - b.w / 2).toBeCloseTo(41.5, 6);
+      expect(b.cy - b.h / 2).toBeCloseTo(41.5, 6);
     });
   });
 });

--- a/src/features/baseplate/utils/buildFullParams.ts
+++ b/src/features/baseplate/utils/buildFullParams.ts
@@ -20,16 +20,41 @@ import {
 } from '@/shared/utils/cornerCutOutline';
 import { padOutline } from '@/shared/utils/padOutline';
 import { translateOutline } from '@/shared/utils/drawerOutline';
-import { outlineFrameOffset } from '@/shared/utils/drawerOutlineGeometry';
+import { outlineLatticeShift, type OutlineLatticeAxis } from '@/shared/utils/drawerOutlineGeometry';
 
 /** Keeps regenerated cuts off degenerate geometry (mirrors the generator's
  * own geometric radius clamp). */
 const CUT_GEOMETRY_MARGIN_MM = 0.1;
 
-/** Below this the outline is treated as already centred on the extent (no
+/** Below this the outline is treated as already lattice-registered (no
  * re-base) — well under the 0.01mm outline-hash quantum, so it only absorbs
  * float noise, never a real pen auto-grow drift. */
 const RECENTER_EPS_MM = 1e-6;
+
+/** Keeps a whole cell from being lost to float noise in `spanMm / pitchMm`. */
+const CELL_COUNT_EPS = 1e-9;
+
+/**
+ * The whole-cell socket lattice of one plate axis. A 'start' fractional edge
+ * puts the half cell FIRST (cellDecomposition reverses the cell array), so the
+ * whole-cell lattice begins after it.
+ */
+function latticeAxis(
+  spanMm: number,
+  pitchMm: number,
+  padLeadMm: number,
+  padTrailMm: number,
+  fractionalEdge: 'start' | 'end'
+): OutlineLatticeAxis {
+  const wholeCells = Math.floor(spanMm / pitchMm + CELL_COUNT_EPS);
+  const fractionalMm = spanMm - wholeCells * pitchMm;
+  return {
+    extentMm: spanMm + padLeadMm + padTrailMm,
+    originMm: padLeadMm + (fractionalEdge === 'start' ? fractionalMm : 0),
+    pitchMm,
+    wholeCells,
+  };
+}
 
 /**
  * Largest corner radius the plain rounding path may cut: the arc can enter
@@ -112,8 +137,10 @@ export function hasEffectivePerimeter(
     gridUnitMmY,
     drawerOutline
   );
+  // Presence only: the lattice re-base translates an outline but never adds
+  // or removes one, so the raw resolution answers without the frame inputs.
   return (
-    resolveOutline(
+    resolveOutlineRaw(
       drawerOutline,
       inputs.outlineOn,
       stored,
@@ -130,9 +157,9 @@ export function hasEffectivePerimeter(
  * padded rectangle; every other shape offsets its edges outward (`padOutline`).
  * Either way padding composes, unless it would fold the loop (then it's zeroed).
  *
- * A final step re-bases the outline onto its own bbox centre (see below) so the
- * plate's socket/seam grid ends up centred on the perimeter rather than the
- * extent (#3108/#3109).
+ * A final step re-bases the outline onto the socket lattice (see below) so the
+ * plate's socket/seam grid sits registered and centred on the perimeter rather
+ * than corner-anchored to the extent (#3108/#3109/#3149).
  */
 function resolveOutline(
   drawerOutline: DrawerOutline | undefined,
@@ -140,30 +167,43 @@ function resolveOutline(
   stored: StoredBaseplateParams,
   widthMm: number,
   depthMm: number,
-  gridUnitMm: number
+  gridUnitMm: number,
+  gridUnitMmY: number,
+  fractionalEdgeX: 'start' | 'end',
+  fractionalEdgeY: 'start' | 'end'
 ): { outline: DrawerOutline | undefined; paddingOn: boolean } {
-  const resolved = resolveOutlineRaw(drawerOutline, outlineOn, stored, widthMm, depthMm, gridUnitMm);
+  const resolved = resolveOutlineRaw(
+    drawerOutline,
+    outlineOn,
+    stored,
+    widthMm,
+    depthMm,
+    gridUnitMm
+  );
   if (resolved.outline === undefined) return resolved;
 
   // Re-base the plate's grid onto the perimeter. Since the pen editor auto-grows
   // the drawer to the max extent only (#3092), a custom outline usually sits in a
   // corner-offset sub-rectangle of `[0,totalW]×[0,totalD]`; anchoring the socket/
-  // seam grid to that extent leaves it off-centre (#3108) and misclassifies
-  // boundary seams (#3109). Centring the outline on the extent here — once, on the
-  // one derived outline the generator, the split planner, and every piece all
-  // consume — makes those two frames identical by construction. Zero-drift
-  // outlines (corner-cut / radius / already-centred) translate by 0 and keep their
-  // exact vertices, so square and full-extent plates stay cache-stable.
+  // seam grid to that extent misclassifies boundary seams (#3109) and leaves it
+  // off-centre (#3108). The shift happens here — once, on the one derived outline
+  // the generator, the split planner, and every piece all consume — so the two
+  // frames are identical by construction. It is lattice-registered, never raw
+  // bbox centring: a sub-cell shift breaks whole-cell registration and cost the
+  // #3149 reporter an entire row and column of sockets. Zero-shift outlines
+  // (corner-cut / radius / registered freeform) keep their exact vertices, so
+  // square and full-extent plates stay cache-stable.
   const padL = resolved.paddingOn ? stored.paddingLeft : 0;
   const padR = resolved.paddingOn ? stored.paddingRight : 0;
   const padF = resolved.paddingOn ? stored.paddingFront : 0;
   const padB = resolved.paddingOn ? stored.paddingBack : 0;
-  const offset = outlineFrameOffset(resolved.outline, widthMm + padL + padR, depthMm + padF + padB);
-  // Corner-cut / radius outlines fill the extent and give an exact 0; the eps
-  // only guards float noise on an already-centred freeform shape.
-  if (Math.abs(offset.x) < RECENTER_EPS_MM && Math.abs(offset.y) < RECENTER_EPS_MM) return resolved;
+  const shift = outlineLatticeShift(resolved.outline, {
+    x: latticeAxis(widthMm, gridUnitMm, padL, padR, fractionalEdgeX),
+    y: latticeAxis(depthMm, gridUnitMmY, padF, padB, fractionalEdgeY),
+  });
+  if (Math.abs(shift.x) < RECENTER_EPS_MM && Math.abs(shift.y) < RECENTER_EPS_MM) return resolved;
   return {
-    outline: translateOutline(resolved.outline, -offset.x, -offset.y),
+    outline: translateOutline(resolved.outline, shift.x, shift.y),
     paddingOn: resolved.paddingOn,
   };
 }
@@ -318,13 +358,18 @@ export function buildFullParams(
   // stacking is turned off.
   const stripConnectors = stackingOn && stored.connectorStyle === 'snapClip';
 
+  const effFractionalEdgeX = synced ? fractionalEdgeX : (stored.fractionalEdgeX ?? 'end');
+  const effFractionalEdgeY = synced ? fractionalEdgeY : (stored.fractionalEdgeY ?? 'end');
   const { outline, paddingOn } = resolveOutline(
     drawerOutline,
     outlineOn,
     stored,
     outlineWidthMm,
     outlineDepthMm,
-    gridUnitMm
+    gridUnitMm,
+    gridUnitMmY,
+    effFractionalEdgeX,
+    effFractionalEdgeY
   );
   // An outline carries its own corner geometry as arcs and shares the same
   // post-cache intersect slot, so rounding is zeroed whenever one is active —
@@ -371,8 +416,8 @@ export function buildFullParams(
     paddingRight: paddingOn ? stored.paddingRight : 0,
     paddingFront: paddingOn ? stored.paddingFront : 0,
     paddingBack: paddingOn ? stored.paddingBack : 0,
-    fractionalEdgeX: synced ? fractionalEdgeX : (stored.fractionalEdgeX ?? 'end'),
-    fractionalEdgeY: synced ? fractionalEdgeY : (stored.fractionalEdgeY ?? 'end'),
+    fractionalEdgeX: effFractionalEdgeX,
+    fractionalEdgeY: effFractionalEdgeY,
     overTile: stored.overTile,
     // Half-grid is meaningless without over-tile; normalize so an orphaned flag
     // can't fragment caches or trigger needless regeneration.

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -12,7 +12,7 @@ import { CONSTRAINTS } from '@/core/constants';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { BaseplatePiece } from '../types/tiling';
 import { computePieceFingerprint } from './pieceFingerprint';
-import { outlineFrameOffset } from '@/shared/utils/drawerOutlineGeometry';
+import { outlineLatticeShift } from '@/shared/utils/drawerOutlineGeometry';
 import { rotateOutline180, translateOutline } from '@/shared/utils/drawerOutline';
 import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
 import type { DrawerOutline } from '@/core/types';
@@ -1870,8 +1870,9 @@ describe('shaped plates (outline-aware splitting)', () => {
   // pen editor auto-grows to the max only and never re-bases the min, #3092) is
   // classified against extent-anchored seam bands, so seams near the boundary
   // misclassify and lose their connectors — and pieces over the empty grown
-  // region drop entirely. Re-basing the outline onto its bbox (what
-  // buildFullParams now does via `outlineFrameOffset`) restores them.
+  // region drop entirely. Re-basing the outline onto the socket lattice (what
+  // buildFullParams does via `outlineLatticeShift`) restores them — by whole
+  // cells only, so registration is preserved (#3149).
   it('re-basing an offset outline restores dropped pieces and seam connectors', () => {
     // A 6-unit-wide full-height rectangle drawn in the right two thirds of a
     // 9-unit plate: the drawer grew to hold maxX = 9U but the min stayed at 3U.
@@ -1896,21 +1897,25 @@ describe('shaped plates (outline-aware splitting)', () => {
     expect(driftedByLabel.has('A1')).toBe(false);
     expect(driftedByLabel.get('B1')?.edges.left).toBe('exterior');
 
-    // Re-base onto the bbox centre — exactly the transform buildFullParams applies.
-    const off = outlineFrameOffset(drifted, W * U, D * U);
-    expect(off.x).toBeCloseTo(1.5 * U, 6);
-    const centered = translateOutline(drifted, -off.x, -off.y);
+    // Re-base onto the lattice — exactly the transform buildFullParams applies.
+    // The 6 whole cells register at any whole-unit shift; nearest-centre wins.
+    const shift = outlineLatticeShift(drifted, {
+      x: { extentMm: W * U, originMm: 0, pitchMm: U, wholeCells: W },
+      y: { extentMm: D * U, originMm: 0, pitchMm: U, wholeCells: D },
+    });
+    expect(shift.x).toBeCloseTo(-U, 6);
+    const rebased = translateOutline(drifted, shift.x, shift.y);
 
-    const centeredTiling = computeBaseplateTiling(
-      shapedParams(centered, { width: W, depth: D }),
+    const rebasedTiling = computeBaseplateTiling(
+      shapedParams(rebased, { width: W, depth: D }),
       BED
     );
-    const centeredByLabel = new Map(centeredTiling.pieces.map((p) => [p.label, p]));
+    const rebasedByLabel = new Map(rebasedTiling.pieces.map((p) => [p.label, p]));
     // The left piece survives and its seam to the middle piece keeps a connector.
-    expect(centeredByLabel.has('A1')).toBe(true);
-    expect(centeredByLabel.get('A1')?.edges.right).toBe('join');
-    expect(centeredByLabel.get('B1')?.edges.left).toBe('join');
-    expect(centeredTiling.pieces.length).toBeGreaterThan(driftedTiling.pieces.length);
+    expect(rebasedByLabel.has('A1')).toBe(true);
+    expect(rebasedByLabel.get('A1')?.edges.right).toBe('join');
+    expect(rebasedByLabel.get('B1')?.edges.left).toBe('join');
+    expect(rebasedTiling.pieces.length).toBeGreaterThan(driftedTiling.pieces.length);
   });
 });
 

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBaseplate, getKernelName } from './__kernel-tests__/wasmInit';
 import { assertStructurallyValid, boundingBox } from './__kernel-tests__/meshAssertions';
 import { cornerCutVertices } from '@/shared/utils/cornerCutOutline';
-import { outlineFrameOffset } from '@/shared/utils/drawerOutlineGeometry';
+import { outlineLatticeShift } from '@/shared/utils/drawerOutlineGeometry';
 import { translateOutline } from '@/shared/utils/drawerOutline';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { DrawerOutline } from '@/core/types';
@@ -393,41 +393,55 @@ describe('baseplate outline geometry', () => {
     expect(tiledRing.triangleCount).toBeGreaterThan(solidRing.triangleCount);
   });
 
-  // #3108: a custom perimeter that occupies a corner-offset sub-rectangle of the
-  // grown extent (pen auto-grow, #3092) must generate its grid CENTRED on the
-  // perimeter, not anchored to the extent corner. buildFullParams re-bases the
-  // outline via `outlineFrameOffset`; here we feed the generator the same re-based
-  // outline and confirm the resulting solid is valid and symmetric.
-  it('centres the socket grid on an offset perimeter (whole-cell fit)', { timeout: 240_000 }, () => {
-    const gen = getGenerateBaseplate();
-    // 3×3-unit square pinned bottom-left of a 4×4 plate: bbox [0,3u], extent 4u.
-    const drifted: DrawerOutline = {
-      vertices: [
-        { x: 0, y: 0 },
-        { x: 3 * U, y: 0 },
-        { x: 3 * U, y: 3 * U },
-        { x: 0, y: 3 * U },
-      ],
-    };
-    const off = outlineFrameOffset(drifted, 4 * U, 4 * U);
-    expect(off.x).toBeCloseTo(-0.5 * U, 6);
-    const centered = translateOutline(drifted, -off.x, -off.y);
+  // #3108/#3149: a custom perimeter in a corner-offset sub-rectangle of the
+  // grown extent (pen auto-grow, #3092) must generate its grid centred on the
+  // perimeter — but only by whole-cell shifts, so no socket is lost to
+  // misregistration. buildFullParams re-bases the outline via
+  // `outlineLatticeShift`; here we feed the generator the same re-based outline
+  // and confirm the solid is valid, symmetric, and a pure translate of the raw
+  // drifted plate (identical socket pattern relative to the perimeter).
+  it(
+    'centres the socket grid on an offset perimeter (whole-cell fit)',
+    { timeout: 240_000 },
+    () => {
+      const gen = getGenerateBaseplate();
+      // 3×3-unit square stuck at the right of a 5×4 plate: bbox [2u,5u], extent 5u.
+      const drifted: DrawerOutline = {
+        vertices: [
+          { x: 2 * U, y: 0 },
+          { x: 5 * U, y: 0 },
+          { x: 5 * U, y: 3 * U },
+          { x: 2 * U, y: 3 * U },
+        ],
+      };
+      const shift = outlineLatticeShift(drifted, {
+        x: { extentMm: 5 * U, originMm: 0, pitchMm: U, wholeCells: 5 },
+        y: { extentMm: 4 * U, originMm: 0, pitchMm: U, wholeCells: 4 },
+      });
+      expect(shift.x).toBeCloseTo(-U, 6);
+      const rebased = translateOutline(drifted, shift.x, shift.y);
 
-    const raw = gen(defaults({ outline: drifted, wholeCellsOnly: true }), NO_OP, true);
-    const fixed = gen(defaults({ outline: centered, wholeCellsOnly: true }), NO_OP, true);
-    assertStructurallyValid(fixed, 'offset perimeter (centred)');
+      const raw = gen(defaults({ width: 5, outline: drifted, wholeCellsOnly: true }), NO_OP, true);
+      const fixed = gen(
+        defaults({ width: 5, outline: rebased, wholeCellsOnly: true }),
+        NO_OP,
+        true
+      );
+      assertStructurallyValid(fixed, 'offset perimeter (re-based)');
 
-    // Zero padding → mesh frame is the extent centred on origin. The re-based plate
-    // spans plate-local [0.5u,3.5u] → mesh [-1.5u,1.5u], symmetric about 0; the raw
-    // drifted plate spans [0,3u] → mesh [-2u,1u], skewed toward −X.
-    const rawBB = boundingBox(raw.vertices);
-    const fixedBB = boundingBox(fixed.vertices);
-    expect(fixedBB.minX + fixedBB.maxX).toBeCloseTo(0, 0);
-    expect(fixedBB.minY + fixedBB.maxY).toBeCloseTo(0, 0);
-    expect(rawBB.minX + rawBB.maxX).toBeLessThan(-1);
-    // A whole socket sits at the centred plate's middle cell (mesh origin).
-    expect(countVerticesIn(fixed.vertices, -20, -20, 20, 20)).toBeGreaterThan(0);
-  });
+      // Zero padding → mesh frame is the extent centred on origin. The re-based
+      // plate spans plate-local [1u,4u] in X → mesh [-1.5u,1.5u], symmetric about
+      // 0; the raw drifted plate spans [2u,5u] → mesh [-0.5u,2.5u], skewed +X.
+      const rawBB = boundingBox(raw.vertices);
+      const fixedBB = boundingBox(fixed.vertices);
+      expect(fixedBB.minX + fixedBB.maxX).toBeCloseTo(0, 0);
+      expect(rawBB.minX + rawBB.maxX).toBeGreaterThan(1);
+      // A whole-unit shift is a pure relabelling: same solid, translated.
+      expect(fixed.vertices.length).toBe(raw.vertices.length);
+      // A whole socket sits at the re-based plate's middle cell (mesh origin).
+      expect(countVerticesIn(fixed.vertices, -20, -20, 20, 20)).toBeGreaterThan(0);
+    }
+  );
 
   it('cuts a geometric-max corner radius, trimming corner sockets', { timeout: 240_000 }, () => {
     // What buildFullParams emits for cornerRadius 60 on a 4×4 plate: a

--- a/src/shared/utils/drawerOutlineGeometry.test.ts
+++ b/src/shared/utils/drawerOutlineGeometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { DrawerOutline } from '@/core/types';
+import type { OutlineLatticeFrame } from './drawerOutlineGeometry';
 import {
   arcGeometry,
   arcPointAt,
@@ -9,7 +10,7 @@ import {
   insideAreaFraction,
   isFootprintInsideOutline,
   outlineBounds,
-  outlineFrameOffset,
+  outlineLatticeShift,
   outlineSignedArea,
   pointInOutline,
 } from './drawerOutlineGeometry';
@@ -236,7 +237,13 @@ describe('outlineBounds', () => {
   });
 });
 
-describe('outlineFrameOffset', () => {
+describe('outlineLatticeShift', () => {
+  /** Zero-padding frame over a widthU×depthU drawer. */
+  const frame = (widthU: number, depthU: number, pitchX = U, pitchY = U): OutlineLatticeFrame => ({
+    x: { extentMm: widthU * pitchX, originMm: 0, pitchMm: pitchX, wholeCells: Math.floor(widthU) },
+    y: { extentMm: depthU * pitchY, originMm: 0, pitchMm: pitchY, wholeCells: Math.floor(depthU) },
+  });
+
   it('is zero when the outline fills the extent', () => {
     const full: DrawerOutline = {
       vertices: [
@@ -246,30 +253,49 @@ describe('outlineFrameOffset', () => {
         { x: 0, y: 4 * U },
       ],
     };
-    const offset = outlineFrameOffset(full, 4 * U, 4 * U);
-    expect(offset.x).toBe(0);
-    expect(offset.y).toBe(0);
+    const shift = outlineLatticeShift(full, frame(4, 4));
+    expect(shift.x).toBe(0);
+    expect(shift.y).toBe(0);
   });
 
-  it('is zero when a smaller outline is already centred on the extent', () => {
-    // 2×2 outline centred in a 4×4 extent — no drift.
-    const centred: DrawerOutline = {
+  it('keeps a half-unit-slack corner outline in place — registration beats centring (#3149)', () => {
+    // The #3149 auto-grow shape: 8.25×7.04 units on a 48×42 pitch, grown to an
+    // 8.5×7.5 drawer. The only position holding 8×7 whole cells is the corner
+    // anchor; a bbox-centring shift (+6, +9.75) would lose a column and a row.
+    const grown: DrawerOutline = {
       vertices: [
-        { x: U, y: U },
-        { x: 3 * U, y: U },
-        { x: 3 * U, y: 3 * U },
-        { x: U, y: 3 * U },
+        { x: 0, y: 0 },
+        { x: 396, y: 0 },
+        { x: 396, y: 295.5 },
+        { x: 0, y: 295.5 },
       ],
     };
-    const offset = outlineFrameOffset(centred, 4 * U, 4 * U);
-    expect(offset.x).toBeCloseTo(0, 6);
-    expect(offset.y).toBeCloseTo(0, 6);
+    const shift = outlineLatticeShift(grown, frame(8.5, 7.5, 48, 42));
+    expect(shift.x).toBe(0);
+    expect(shift.y).toBe(0);
   });
 
-  it('returns the bbox-centre drift for a corner-offset sub-rectangle (#3092 auto-grow)', () => {
-    // Outline pinned to the bottom-left, leaving a half-unit of grown extent on
-    // the top/right — exactly what auto-grow's ceil-the-max-only produces.
+  it('centres a whole-unit-drifted outline by whole cells only', () => {
+    // 6u-wide rectangle stuck in the right two thirds of a 9u extent: any
+    // whole-unit shift keeps all 6 cells, so centring picks the least move
+    // that lands nearest the extent centre.
     const drifted: DrawerOutline = {
+      vertices: [
+        { x: 3 * U, y: 0 },
+        { x: 9 * U, y: 0 },
+        { x: 9 * U, y: 4 * U },
+        { x: 3 * U, y: 4 * U },
+      ],
+    };
+    const shift = outlineLatticeShift(drifted, frame(9, 4));
+    expect(shift.x).toBe(-U);
+    expect(shift.y).toBe(0);
+  });
+
+  it('registers the cell block to the padded lattice origin', () => {
+    // 3u square at the corner of a 4u drawer with 10mm padding all round:
+    // whole cells start at x=10, so the registered shifts land on 10+k·U.
+    const square: DrawerOutline = {
       vertices: [
         { x: 0, y: 0 },
         { x: 3 * U, y: 0 },
@@ -277,9 +303,28 @@ describe('outlineFrameOffset', () => {
         { x: 0, y: 3 * U },
       ],
     };
-    const offset = outlineFrameOffset(drifted, 3.5 * U, 3.5 * U);
-    // bbox centre = 1.5U; extent centre = 1.75U → drift = -0.25U on each axis.
-    expect(offset.x).toBeCloseTo(-0.25 * U, 6);
-    expect(offset.y).toBeCloseTo(-0.25 * U, 6);
+    const shift = outlineLatticeShift(square, {
+      x: { extentMm: 4 * U + 20, originMm: 10, pitchMm: U, wholeCells: 4 },
+      y: { extentMm: 4 * U + 20, originMm: 10, pitchMm: U, wholeCells: 4 },
+    });
+    // Candidate registrations are 10 (k=0) and 52 (k=1), equally centred;
+    // the smaller move wins.
+    expect(shift.x).toBe(10);
+    expect(shift.y).toBe(10);
+  });
+
+  it('falls back to clamped bbox centring when no whole cell fits', () => {
+    // A sliver thinner than a cell has no registration to preserve.
+    const sliver: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 0.8 * U, y: 0 },
+        { x: 0.8 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const shift = outlineLatticeShift(sliver, frame(4, 4));
+    expect(shift.x).toBeCloseTo(1.6 * U, 6);
+    expect(shift.y).toBe(0);
   });
 });

--- a/src/shared/utils/drawerOutlineGeometry.ts
+++ b/src/shared/utils/drawerOutlineGeometry.ts
@@ -144,35 +144,123 @@ export function outlineBounds(outline: DrawerOutline): OutlineBounds {
 }
 
 /**
- * Millimetre offset that re-bases a plate's socket/seam grid onto the outline
- * bbox instead of the plate extent — the drift of the flattened bbox centre
- * from the extent centre of `[0,widthMm]×[0,depthMm]`.
- *
- * Since the pen editor's auto-grow (#3092) grows only the max extent (ceiled to
- * a half unit) and never re-bases the min to 0, a custom perimeter commonly
- * occupies a corner-offset SUB-rectangle of its declared extent. Anchoring the
- * grid to the extent then straddles the perimeter asymmetrically — the socket
- * grid is off-centre and "fit whole cells" drops cells (#3108), and split-seam
- * bands near the boundary misclassify and lose their connectors (#3109).
- *
- * Translating the outline by `-x,-y` centres it on the extent (equivalently,
- * centres the grid on the outline), which is what the generator and the split
- * planner both consume. Zero when the outline already fills or is centred, so
- * square and full-extent plates are untouched. Measured against the extent
- * centre (not the padding-shifted grid centre) so asymmetric padding is
- * preserved: the grid stays the same distance off the outline centre that the
- * user's padding asked for.
+ * One axis of the lattice frame for {@link outlineLatticeShift}: the padded
+ * plate extent, where the nominal socket lattice starts inside it (the leading
+ * padding, plus a leading fractional cell), the cell pitch, and how many whole
+ * nominal cells exist.
  */
-export function outlineFrameOffset(
+export interface OutlineLatticeAxis {
+  readonly extentMm: number;
+  readonly originMm: number;
+  readonly pitchMm: number;
+  readonly wholeCells: number;
+}
+
+export interface OutlineLatticeFrame {
+  readonly x: OutlineLatticeAxis;
+  readonly y: OutlineLatticeAxis;
+}
+
+/**
+ * Millimetre translation that re-bases a plate's custom perimeter onto the
+ * socket lattice: among all positions that keep the maximum number of whole
+ * lattice cells inside the perimeter bbox, the one that centres the cell
+ * block in the bbox (then the bbox on the extent, then moves least).
+ *
+ * Since the pen editor's auto-grow (#3092) grows only the max extent (ceiled
+ * to a half unit) and never re-bases the min to 0, a custom perimeter commonly
+ * occupies a corner-offset SUB-rectangle of its declared extent, which
+ * misclassifies split-seam bands near the boundary (#3109) and leaves the
+ * socket grid straddling the perimeter asymmetrically (#3108). Pure bbox
+ * centring (the first fix) moved the perimeter by sub-cell amounts, breaking
+ * lattice registration: "fit whole cells" then dropped an entire row and column
+ * of sockets the corner-anchored frame kept (#3149). Registration is therefore
+ * the primary objective and centring only breaks ties — a whole-cell
+ * translation is a pure relabelling (sockets sit at the same places relative to
+ * the perimeter), so it fixes the extent interaction without costing a socket.
+ *
+ * Zero when the outline already fills or is registered to the extent, so
+ * square and full-extent plates stay byte-identical (cache-stable).
+ */
+export function outlineLatticeShift(
   outline: DrawerOutline,
-  widthMm: number,
-  depthMm: number
+  frame: OutlineLatticeFrame
 ): { readonly x: number; readonly y: number } {
   const b = outlineBounds(outline);
   return {
-    x: (b.minX + b.maxX) / 2 - widthMm / 2,
-    y: (b.minY + b.maxY) / 2 - depthMm / 2,
+    x: axisLatticeShift(b.minX, b.maxX, frame.x),
+    y: axisLatticeShift(b.minY, b.maxY, frame.y),
   };
+}
+
+const LATTICE_EPS = 1e-9;
+
+interface ShiftCandidate {
+  readonly shift: number;
+  /** How far the shift lands from centring the cell block in the bbox. */
+  readonly blockMiss: number;
+  /** How far the shift lands from centring the bbox on the extent. */
+  readonly centerMiss: number;
+}
+
+/**
+ * Tie-break order, in full: tightest registration, then closest to centred,
+ * then the smallest move. Deterministic by construction — the trailing
+ * `|shift|` comparison decides candidates that tie on both misses.
+ */
+function beatsBest(candidate: ShiftCandidate, best: ShiftCandidate): boolean {
+  if (candidate.blockMiss < best.blockMiss - LATTICE_EPS) return true;
+  if (candidate.blockMiss >= best.blockMiss + LATTICE_EPS) return false;
+  if (candidate.centerMiss < best.centerMiss - LATTICE_EPS) return true;
+  if (candidate.centerMiss >= best.centerMiss + LATTICE_EPS) return false;
+  return Math.abs(candidate.shift) < Math.abs(best.shift);
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, value));
+}
+
+function axisLatticeShift(bboxMin: number, bboxMax: number, axis: OutlineLatticeAxis): number {
+  const { extentMm, originMm, pitchMm, wholeCells } = axis;
+  // Every shift must keep the bbox inside the plate extent; a bbox wider than
+  // the extent has none, so it stays where the author put it.
+  const shiftMin = -bboxMin;
+  const shiftMax = extentMm - bboxMax;
+  if (shiftMax < shiftMin) return 0;
+
+  const bboxCenter = (bboxMin + bboxMax) / 2;
+  const centeringShift = extentMm / 2 - bboxCenter;
+  const blockCells = Math.min(Math.floor((bboxMax - bboxMin) / pitchMm + LATTICE_EPS), wholeCells);
+
+  // Where that block of cells can sit on the lattice; none when the bbox is
+  // narrower than a single cell.
+  const blockPositions = blockCells >= 1 ? wholeCells - blockCells + 1 : 0;
+
+  let best: ShiftCandidate | null = null;
+  for (let k = 0; k < blockPositions; k++) {
+    const blockStart = originMm + k * pitchMm;
+    const blockEnd = blockStart + blockCells * pitchMm;
+    // Shifts that keep this cell block inside the bbox AND the bbox inside the
+    // extent. k=0 is always feasible (blockCells·pitch ≤ span ≤ extent), so the
+    // loop never comes up empty.
+    const lo = Math.max(blockEnd - bboxMax, shiftMin);
+    const hi = Math.min(blockStart - bboxMin, shiftMax);
+    if (lo > hi + LATTICE_EPS) continue;
+    const blockCenteringShift = (blockStart + blockEnd) / 2 - bboxCenter;
+    const shift = clamp(blockCenteringShift, lo, hi);
+    const candidate: ShiftCandidate = {
+      shift,
+      blockMiss: Math.abs(shift - blockCenteringShift),
+      centerMiss: Math.abs(shift - centeringShift),
+    };
+    if (best === null || beatsBest(candidate, best)) best = candidate;
+  }
+
+  // No whole cell fits inside the bbox: there is no registration to preserve,
+  // so fall back to plain bbox centring within the feasible range.
+  const shift = best === null ? clamp(centeringShift, shiftMin, shiftMax) : best.shift;
+  // The `-bboxMin` bound can clamp to -0; normalize so callers and tests see 0.
+  return shift === 0 ? 0 : shift;
 }
 
 export function polylineSignedArea(pts: readonly OutlinePoint[]): number {


### PR DESCRIPTION
Part of #3149 (bug 1 of the report: sockets missing / grid misregistered against the custom perimeter).

## What was happening

#3123 re-based the resolved outline by raw bbox centring — a **sub-cell** shift. The socket lattice is fixed to the plate extent, so shifting the perimeter by a fraction of a cell breaks whole-cell registration: on the reporter's 8.5×7.5 drawer (48×42mm pitch, perimeter 396×295.5mm) the +6/+9.75mm shift made "Fit whole cells only" drop an entire socket column **and** row that the corner-anchored frame kept — the empty margins visible in the report's baseplate screenshot. The old fix's own test fixture shows it too: a 3-unit square centred into a 4-unit extent retains only 2×2 of its 3×3 whole cells.

## Fix

`outlineFrameOffset` → `outlineLatticeShift`: among all outline positions that keep the **maximum number of whole lattice cells** inside the perimeter bbox, pick the one that centres the cell block in the bbox, then the bbox on the extent, then moves least. Key property: a whole-cell shift is a pure relabelling — sockets sit at identical positions relative to the perimeter — so the #3109 seam/piece fixes are preserved without ever costing a socket. The frame accounts for the padded lattice origin, the per-axis pitch (#2733), and a `'start'` fractional edge (the generator puts the half cell first, so the whole-cell lattice starts after it — without this, every half-unit drawer with a leading fractional edge would reproduce the reported symptom).

- `resolveOutline` gains `gridUnitMmY` + effective fractional edges; `hasEffectivePerimeter` now answers from `resolveOutlineRaw` (the re-base translates but never adds/removes an outline, so presence needs no frame inputs).
- For the reporter's exact shape the shift is 0 on both axes: the outline stays byte-identical, all 8×7 sockets return, and the baseplate frame agrees with the layout view's placement frame again.

## Test plan

- [x] `drawerOutlineGeometry.test.ts` — the #3149 shape stays put; whole-unit drift centres by whole cells; padded lattice origin; no-whole-cell fallback
- [x] `buildFullParams.test.ts` — corner-anchored stays byte-identical; whole-unit re-base restores the #3109 frame; `'start'` fractional edge registration; padded composition; full-extent cache stability
- [x] `splitPlanner.test.ts` (106) — #3109 repro updated to the lattice re-base (whole-unit −1u shift), pieces + seam connectors restored
- [x] `baseplateGenerator.scenario.outline.test.ts` (real WASM, 16) — re-based plate valid, symmetric, and **vertex-count-identical** to the raw drifted plate (pure relabelling verified on real geometry)
- [x] Full unit+dom suite (17095 green), `pnpm run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-base custom baseplate outlines to the socket lattice using whole-cell shifts so the grid stays registered and centred. Fixes dropped sockets and misclassified seams caused by bbox-based centring on auto-grown drawers.

- **Bug Fixes**
  - Use lattice-registered translation via `outlineLatticeShift` instead of raw bbox centring to preserve whole-cell fit (fixes #3149; restores edge seam connectors, #3109).
  - Respect padded lattice origin, per-axis pitch (X/Y), and `'start'` fractional edges; pick the shift that keeps the max whole cells, then centres the block/bbox, then moves least.
  - Fall back to clamped bbox centring only when no whole cell fits.
  - Zero-shift when already registered or full-extent to keep outline bytes and caches stable.

- **Refactors**
  - Replace `outlineFrameOffset` with `outlineLatticeShift`; update `buildFullParams` to pass `gridUnitMmY`, padding, and effective `fractionalEdgeX/Y`.
  - `hasEffectivePerimeter` now checks presence via `resolveOutlineRaw` (re-base never adds/removes outlines).
  - Update generator, planner, and geometry tests to validate whole-cell re-base, padded origins, and pure-translation/vertex-count identity.

<sup>Written for commit 7b417e645725715a61338a343bf5330c0358d833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

