### PR TITLE
fix(drawer-shape): close the implicit-mutation gaps around the custom perimeter

### DIFF
--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { produce } from 'immer';
 import { isOk } from '@/core/result';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
+import type { DrawerOutline, Layout } from '@/core/types';
 import { binId, gridUnits, heightUnits } from '@/core/types';
 import { updateDrawer } from './updateDrawer';
 import { makeLayout, makeBin } from './_testHelpers';
@@ -81,9 +82,9 @@ describe('v2 drawer.update with an outline', () => {
       { x: 0, y: 4 * U },
     ],
   };
-  const withOutline = () => {
+  const withOutline = (outline: DrawerOutline = L_OUTLINE): Layout => {
     const base = makeLayout();
-    return { ...base, drawer: { ...base.drawer, outline: L_OUTLINE } };
+    return { ...base, drawer: { ...base.drawer, outline } };
   };
 
   it('clamps a shrink to the outline bounding grid and never touches the shape (#3149)', () => {
@@ -114,25 +115,61 @@ describe('v2 drawer.update with an outline', () => {
 
   it('clamps to the half-unit ceiling of a shape that overhangs whole units', () => {
     // Shape reaching to 4.2 units needs a 4.5-unit drawer.
-    const base = makeLayout();
-    const layout = {
-      ...base,
-      drawer: {
-        ...base.drawer,
-        outline: {
-          vertices: [
-            { x: 0, y: 0 },
-            { x: 4.2 * U, y: 0 },
-            { x: 4.2 * U, y: 4 * U },
-            { x: 0, y: 4 * U },
-          ],
-        },
-      },
-    };
+    const layout = withOutline({
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4.2 * U, y: 0 },
+        { x: 4.2 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    });
     const result = updateDrawer.handle({ width: 3 }, { aggregate: layout });
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) return;
     expect(result.value.event.payload.changes.width).toBe(gridUnits(4.5));
+  });
+
+  it('floors on the outline MAX, not its width — an offset shape counts from its far edge', () => {
+    // Shape spanning [2u, 5u]: only 3 units wide, but the drawer must keep
+    // reaching 5 units for it to stay inside.
+    const layout = withOutline({
+      vertices: [
+        { x: 2 * U, y: 0 },
+        { x: 5 * U, y: 0 },
+        { x: 5 * U, y: 3 * U },
+        { x: 2 * U, y: 3 * U },
+      ],
+    });
+    const result = updateDrawer.handle({ width: 3 }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.changes.width).toBe(gridUnits(5));
+  });
+
+  it('drops a rectangle-equivalent outline when the shrink lands on its bbox', () => {
+    // 4×4 rect outline inside the 6×4 drawer (a real shape at 6 wide).
+    // Shrinking to exactly 4 makes it trace the full rectangle — normalized
+    // to "no outline", same as setOutline and the read-side guard.
+    const layout = withOutline({
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    });
+    const result = updateDrawer.handle({ width: 4 }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const payload = result.value.event.payload;
+    expect(payload.changes.width).toBe(gridUnits(4));
+    expect('outline' in payload.changes).toBe(true);
+    expect(payload.changes.outline).toBeUndefined();
+
+    const next = produce(layout, (draft) => {
+      updateDrawer.apply({ payload } as never, draft);
+    });
+    expect('outline' in next.drawer).toBe(false);
   });
 
   it('displaces bins that fall outside the unchanged outline after a grow', () => {

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
@@ -19,7 +19,7 @@ import type { Result, LayoutError } from '@/core/result';
 import { ok } from '@/core/result';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
-import { minDrawerUnitsForOutline } from '@/shared/utils/drawerOutline';
+import { drawerSizeFloors, isOutlineFullRectangle } from '@/shared/utils/drawerOutline';
 import type { BinId, Drawer, GridUnits, MeasuredDrawerMm } from '@/core/types';
 import { effectiveGridUnitMmY, gridUnits, heightUnits } from '@/core/types';
 import { defineCommand } from '../../defineCommand';
@@ -95,30 +95,20 @@ export const updateDrawer = defineCommand({
   > => {
     const layout = ctx.aggregate;
     const drawer = layout.drawer;
+    const gridUnitMmY = effectiveGridUnitMmY(layout);
 
     // Resolve clamped/derived values up-front so the event records
     // exactly what apply() will install. With a custom outline active the
     // shrink floor rises to the outline's bounding half-unit grid: the shape
     // is user-authored and a resize must never crop or extend it (#3149) —
     // to go smaller, the user edits the shape first.
-    const outlineMin =
-      drawer.outline !== undefined
-        ? minDrawerUnitsForOutline(drawer.outline, layout.gridUnitMm, effectiveGridUnitMmY(layout))
-        : undefined;
+    const floors = drawerSizeFloors(drawer.outline, layout.gridUnitMm, gridUnitMmY);
     const changes: Partial<Drawer> = {};
     if (payload.width !== undefined) {
-      const floor = Math.min(
-        CONSTRAINTS.GRID_MAX,
-        Math.max(CONSTRAINTS.GRID_MIN, outlineMin?.width ?? 0)
-      );
-      changes.width = gridUnits(clamp(payload.width, floor, CONSTRAINTS.GRID_MAX));
+      changes.width = gridUnits(clamp(payload.width, floors.width, CONSTRAINTS.GRID_MAX));
     }
     if (payload.depth !== undefined) {
-      const floor = Math.min(
-        CONSTRAINTS.GRID_MAX,
-        Math.max(CONSTRAINTS.GRID_MIN, outlineMin?.depth ?? 0)
-      );
-      changes.depth = gridUnits(clamp(payload.depth, floor, CONSTRAINTS.GRID_MAX));
+      changes.depth = gridUnits(clamp(payload.depth, floors.depth, CONSTRAINTS.GRID_MAX));
     }
     if (payload.height !== undefined) {
       const totalLayerHeight = layout.layers.reduce((sum, l) => sum + (l.height as number), 0);
@@ -134,13 +124,26 @@ export const updateDrawer = defineCommand({
     const newWidth: GridUnits = changes.width ?? drawer.width;
     const newDepth: GridUnits = changes.depth ?? drawer.depth;
 
-    // The outline never changes on resize (see the clamp above); displacement
-    // runs against the new dims with the shape as-is.
+    // The shape never changes on resize (see the clamp above) — but a shrink
+    // can land exactly on the outline's bounding rectangle, and a
+    // rectangle-equivalent outline is stored as "no outline" everywhere else
+    // (setOutline, read-side normalize). Normalize here too, or the layout
+    // keeps a redundant "shaped" flag that flips behaviour on the next load.
+    const outlineBecameRectangle =
+      drawer.outline !== undefined &&
+      (newWidth !== drawer.width || newDepth !== drawer.depth) &&
+      isOutlineFullRectangle(drawer.outline, newWidth * layout.gridUnitMm, newDepth * gridUnitMmY);
+    if (outlineBecameRectangle) changes.outline = undefined;
+
     const displacedBinIds = computeDisplacedBins(
       layout.bins,
-      { width: newWidth, depth: newDepth, outline: drawer.outline },
+      {
+        width: newWidth,
+        depth: newDepth,
+        outline: outlineBecameRectangle ? undefined : drawer.outline,
+      },
       layout.gridUnitMm,
-      effectiveGridUnitMmY(layout)
+      gridUnitMmY
     );
 
     const previous = capturePrevious(drawer, changes);

--- a/src/core/cqrs/v2/domain/layout/_testHelpers.ts
+++ b/src/core/cqrs/v2/domain/layout/_testHelpers.ts
@@ -2,7 +2,7 @@
  * Shared fixtures for v2 layout-metadata command property tests.
  */
 
-import type { Layout } from '@/core/types';
+import type { Layout, OutlineVertex } from '@/core/types';
 import { layerId, categoryId, gridUnits, heightUnits } from '@/core/types';
 
 export function makeLayout(overrides: Partial<Layout> = {}): Layout {
@@ -22,4 +22,13 @@ export function makeLayout(overrides: Partial<Layout> = {}): Layout {
     bins: [],
     ...overrides,
   };
+}
+
+/** {@link makeLayout} carrying a custom drawer outline (6×4 at 42mm). */
+export function makeLayoutWithOutline(
+  vertices: OutlineVertex[],
+  overrides: Partial<Layout> = {}
+): Layout {
+  const base = makeLayout(overrides);
+  return { ...base, drawer: { ...base.drawer, outline: { vertices } } };
 }

--- a/src/core/cqrs/v2/domain/layout/setGridUnitMm.test.ts
+++ b/src/core/cqrs/v2/domain/layout/setGridUnitMm.test.ts
@@ -3,7 +3,7 @@ import { produce } from 'immer';
 import { isOk } from '@/core/result';
 import { mm } from '@/core/types';
 import { setGridUnitMm } from './setGridUnitMm';
-import { makeLayout } from './_testHelpers';
+import { makeLayout, makeLayoutWithOutline } from './_testHelpers';
 
 describe('v2 layout.setGridUnitMm', () => {
   it('clamps to [1, 200]', () => {
@@ -32,5 +32,36 @@ describe('v2 layout.setGridUnitMm', () => {
       );
     });
     expect(applied.gridUnitMm).toBe(mm(50));
+  });
+
+  it('floors the pitch so a custom outline stays inside the extent (#3149)', () => {
+    // 6×4 drawer with a shape reaching x=252, y=168: any pitch below 42
+    // shrinks the mm extent under the shape, which the read-side normalizer
+    // would then clip — so the pitch clamps at maxX/width = 42.
+    const layout = makeLayoutWithOutline([
+      { x: 0, y: 0 },
+      { x: 252, y: 0 },
+      { x: 252, y: 84 },
+      { x: 168, y: 84 },
+      { x: 168, y: 168 },
+      { x: 0, y: 168 },
+    ]);
+    const result = setGridUnitMm.handle({ mm: 30 }, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.mm).toBe(42);
+  });
+
+  it('honours the Y bound too when the pitch drives both axes (square grid)', () => {
+    // Same drawer, shape reaching y=168 over depth 4 → Y needs ≥42; a shape
+    // narrower in X (maxX=126 over width 6 → 21) must not lower the floor.
+    const layout = makeLayoutWithOutline([
+      { x: 0, y: 0 },
+      { x: 126, y: 0 },
+      { x: 126, y: 168 },
+      { x: 0, y: 168 },
+    ]);
+    const result = setGridUnitMm.handle({ mm: 30 }, { aggregate: layout });
+    if (!isOk(result)) throw new Error('handle failed');
+    expect(result.value.event.payload.mm).toBe(42);
   });
 });

--- a/src/core/cqrs/v2/domain/layout/setGridUnitMm.ts
+++ b/src/core/cqrs/v2/domain/layout/setGridUnitMm.ts
@@ -1,9 +1,16 @@
-/** Set the grid unit in mm. Clamps to [1, 200]; captures `previousMm` for undo. */
+/**
+ * Set the grid unit in mm. Clamps to the pitch range; with a custom drawer
+ * outline active the floor rises so the mm extent keeps containing the shape —
+ * the outline is stored in absolute mm, and a smaller pitch would leave it
+ * overhanging for the read-side normalizer to clip on the next load (#3149).
+ * Captures `previousMm` for undo.
+ */
 
 import { z } from 'zod';
 import { ok } from '@/core/result';
 import { clamp } from '@/shared/utils/validation';
 import { mm } from '@/core/types';
+import { GRID_PITCH_MM_MAX, gridPitchFloors } from '@/shared/utils/drawerOutline';
 import { defineCommand } from '../../defineCommand';
 
 const payloadSchema = z.object({ mm: z.number() });
@@ -18,8 +25,9 @@ export const setGridUnitMm = defineCommand({
   descriptionKey: 'undo.action.layoutSetGridUnitMm',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
-    const previousMm = ctx.aggregate.gridUnitMm as number;
-    const newMm = clamp(payload.mm, 1, 200);
+    const layout = ctx.aggregate;
+    const previousMm = layout.gridUnitMm as number;
+    const newMm = clamp(payload.mm, gridPitchFloors(layout).x, GRID_PITCH_MM_MAX);
     return ok({
       value: undefined,
       event: { payload: { mm: newMm, previousMm } },

--- a/src/core/cqrs/v2/domain/layout/setGridUnitMmY.test.ts
+++ b/src/core/cqrs/v2/domain/layout/setGridUnitMmY.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { produce } from 'immer';
-import { isOk } from '@/core/result';
+import { isErr, isOk } from '@/core/result';
 import { mm } from '@/core/types';
+import type { Layout } from '@/core/types';
 import { setGridUnitMmY } from './setGridUnitMmY';
-import { makeLayout } from './_testHelpers';
+import { makeLayout, makeLayoutWithOutline } from './_testHelpers';
 
 describe('v2 layout.setGridUnitMmY', () => {
   it('clamps a concrete value to [1, 200]', () => {
@@ -52,5 +53,41 @@ describe('v2 layout.setGridUnitMmY', () => {
       );
     });
     expect(applied.gridUnitMmY).toBeUndefined();
+  });
+
+  describe('with a custom outline (#3149)', () => {
+    /** 6×4 drawer, Y pitch 48, shape reaching the full y=192 back edge. */
+    const withOutline = (): Layout =>
+      makeLayoutWithOutline(
+        [
+          { x: 0, y: 0 },
+          { x: 252, y: 0 },
+          { x: 252, y: 96 },
+          { x: 126, y: 96 },
+          { x: 126, y: 192 },
+          { x: 0, y: 192 },
+        ],
+        { gridUnitMmY: mm(48) }
+      );
+
+    it('floors a concrete Y pitch at the shape bound', () => {
+      // maxY/depth = 192/4 = 48: anything lower would clip the shape.
+      const result = setGridUnitMmY.handle({ mm: 30 }, { aggregate: withOutline() });
+      if (!isOk(result)) throw new Error('handle failed');
+      expect(result.value.event.payload.mm).toBe(48);
+    });
+
+    it('refuses clearing to square when the square pitch would clip the shape', () => {
+      // Clearing makes Y follow gridUnitMm (42) < required 48.
+      const result = setGridUnitMmY.handle({ mm: null }, { aggregate: withOutline() });
+      expect(isErr(result)).toBe(true);
+    });
+
+    it('allows clearing when the square pitch still holds the shape', () => {
+      const layout = withOutline();
+      const roomy = { ...layout, gridUnitMm: mm(48) };
+      const result = setGridUnitMmY.handle({ mm: null }, { aggregate: roomy });
+      expect(isOk(result)).toBe(true);
+    });
   });
 });

--- a/src/core/cqrs/v2/domain/layout/setGridUnitMmY.ts
+++ b/src/core/cqrs/v2/domain/layout/setGridUnitMmY.ts
@@ -1,13 +1,17 @@
 /**
  * Set (or clear) the depth-axis (Y) grid pitch for a non-square grid.
- * A number clamps to [1, 200]; `null` clears back to a square grid
- * (`gridUnitMmY === undefined`). Captures `previousMmY` for undo.
+ * A number clamps to the pitch range; `null` clears back to a square grid
+ * (`gridUnitMmY === undefined`). With a custom drawer outline active the
+ * floor rises so the mm extent keeps containing the shape, and a clear is
+ * refused when the square pitch would not — the outline is absolute mm and
+ * nothing may mutate it implicitly (#3149). Captures `previousMmY` for undo.
  */
 
 import { z } from 'zod';
-import { ok } from '@/core/result';
+import { ok, err, layoutInvalidOperation } from '@/core/result';
 import { clamp } from '@/shared/utils/validation';
 import { mm } from '@/core/types';
+import { GRID_PITCH_MM_MAX, gridPitchFloors } from '@/shared/utils/drawerOutline';
 import { defineCommand } from '../../defineCommand';
 
 const payloadSchema = z.object({ mm: z.number().nullable() });
@@ -22,9 +26,20 @@ export const setGridUnitMmY = defineCommand({
   descriptionKey: 'undo.action.layoutSetGridUnitMmY',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
-    const prev = ctx.aggregate.gridUnitMmY as number | undefined;
+    const layout = ctx.aggregate;
+    const prev = layout.gridUnitMmY as number | undefined;
     const previousMmY = prev === undefined ? null : prev;
-    const newMm = payload.mm === null ? null : clamp(payload.mm, 1, 200);
+    const floorY = gridPitchFloors(layout).y;
+    if (payload.mm === null && (layout.gridUnitMm as number) < floorY) {
+      return err(
+        layoutInvalidOperation(
+          'setGridUnitMmY',
+          'clearing the Y pitch would leave the drawer shape outside the grid'
+        )
+      );
+    }
+    const newMm: number | null =
+      payload.mm === null ? null : clamp(payload.mm, floorY, GRID_PITCH_MM_MAX);
     return ok({
       value: undefined,
       event: { payload: { mm: newMm, previousMmY } },

--- a/src/core/store/layout/coreActions.ts
+++ b/src/core/store/layout/coreActions.ts
@@ -9,6 +9,7 @@ import type {
 } from '@/core/types';
 import { CONSTRAINTS, migrateBaseplateParams } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
+import { GRID_PITCH_MM_MAX, gridPitchFloors } from '@/shared/utils/drawerOutline';
 import type { EditSource, SetLocal, ImmerSet, GetState } from './types';
 
 export function createCoreActions(setLocal: SetLocal, set: ImmerSet, _get: GetState) {
@@ -81,15 +82,26 @@ export function createCoreActions(setLocal: SetLocal, set: ImmerSet, _get: GetSt
       });
     },
 
+    // With a custom outline active the pitch floors rise so the mm extent
+    // keeps containing the shape — same rule as the CQRS commands (#3149).
     setGridUnitMm: (mm: number): void => {
       setLocal((state) => {
-        state.layout.gridUnitMm = clamp(mm, 1, 200) as Mm;
+        const floorX = gridPitchFloors(state.layout).x;
+        state.layout.gridUnitMm = clamp(mm, floorX, GRID_PITCH_MM_MAX) as Mm;
       });
     },
 
     setGridUnitMmY: (mm: number | null): void => {
       setLocal((state) => {
-        state.layout.gridUnitMmY = mm === null ? undefined : (clamp(mm, 1, 200) as Mm);
+        const floorY = gridPitchFloors(state.layout).y;
+        if (mm === null) {
+          // Clearing to a square grid is refused when the square pitch would
+          // leave the shape overhanging (the normalizer would clip it).
+          if ((state.layout.gridUnitMm as number) < floorY) return;
+          state.layout.gridUnitMmY = undefined;
+          return;
+        }
+        state.layout.gridUnitMmY = clamp(mm, floorY, GRID_PITCH_MM_MAX) as Mm;
       });
     },
 

--- a/src/core/store/layout/drawerActions.ts
+++ b/src/core/store/layout/drawerActions.ts
@@ -2,7 +2,7 @@ import type { Drawer, GridUnits, HeightUnits } from '@/core/types';
 import { effectiveGridUnitMmY } from '@/core/types';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import { clamp } from '@/shared/utils/validation';
-import { minDrawerUnitsForOutline } from '@/shared/utils/drawerOutline';
+import { drawerSizeFloors, isOutlineFullRectangle } from '@/shared/utils/drawerOutline';
 import { computeDisplacedBins } from '@/core/cqrs/v2/domain/drawer/displacement';
 import type { SetLocal } from './types';
 
@@ -13,34 +13,18 @@ export function createDrawerActions(setLocal: SetLocal) {
         const drawer = state.layout.drawer;
         const oldWidth = drawer.width as number;
         const oldDepth = drawer.depth as number;
+        const gridUnitMmY = effectiveGridUnitMmY(state.layout);
 
         // With a custom outline active the shrink floor rises to the
         // outline's bounding half-unit grid — a resize must never mutate the
         // user's shape (#3149); same rule as the CQRS updateDrawer command.
-        const outlineMin =
-          drawer.outline !== undefined
-            ? minDrawerUnitsForOutline(
-                drawer.outline,
-                state.layout.gridUnitMm,
-                effectiveGridUnitMmY(state.layout)
-              )
-            : undefined;
-        const axisFloor = (min: number | undefined): number =>
-          Math.min(CONSTRAINTS.GRID_MAX, Math.max(CONSTRAINTS.GRID_MIN, min ?? 0));
+        const floors = drawerSizeFloors(drawer.outline, state.layout.gridUnitMm, gridUnitMmY);
 
         if (updates.width !== undefined) {
-          drawer.width = clamp(
-            updates.width,
-            axisFloor(outlineMin?.width),
-            CONSTRAINTS.GRID_MAX
-          ) as GridUnits;
+          drawer.width = clamp(updates.width, floors.width, CONSTRAINTS.GRID_MAX) as GridUnits;
         }
         if (updates.depth !== undefined) {
-          drawer.depth = clamp(
-            updates.depth,
-            axisFloor(outlineMin?.depth),
-            CONSTRAINTS.GRID_MAX
-          ) as GridUnits;
+          drawer.depth = clamp(updates.depth, floors.depth, CONSTRAINTS.GRID_MAX) as GridUnits;
         }
         if (updates.height !== undefined) {
           const totalLayerHeight = state.layout.layers.reduce((sum, l) => sum + l.height, 0);
@@ -59,13 +43,22 @@ export function createDrawerActions(setLocal: SetLocal) {
         const planarChanged =
           (drawer.width as number) !== oldWidth || (drawer.depth as number) !== oldDepth;
         if (!planarChanged) return;
-        const displaced = new Set(
-          computeDisplacedBins(
-            state.layout.bins,
-            drawer,
-            state.layout.gridUnitMm,
-            effectiveGridUnitMmY(state.layout)
+
+        // A shrink can land exactly on the outline's bounding rectangle;
+        // rectangle-equivalent outlines normalize to "no outline" everywhere
+        // else, so drop it here too (same rule as the CQRS command).
+        if (
+          drawer.outline !== undefined &&
+          isOutlineFullRectangle(
+            drawer.outline,
+            drawer.width * state.layout.gridUnitMm,
+            drawer.depth * gridUnitMmY
           )
+        ) {
+          delete drawer.outline;
+        }
+        const displaced = new Set(
+          computeDisplacedBins(state.layout.bins, drawer, state.layout.gridUnitMm, gridUnitMmY)
         );
         if (displaced.size > 0) {
           state.layout.bins = state.layout.bins.map((bin) =>

--- a/src/features/drawer-shape/README.md
+++ b/src/features/drawer-shape/README.md
@@ -70,9 +70,11 @@ hatching, baseplate generation/splitting) derives from it.
 5. **An import is never silently rescaled** — true scale is the point of
    importing a drawer measured in CAD, so an oversized perimeter raises
    `PenImportNotice` and the user picks between scaling it down and growing the
-   drawer. The grow path fits the loop against the drawer it is _about_ to
-   have, so the resize and the outline land in one commit instead of racing.
-   Loops dropped and points thinned are always toasted, never silent.
+   drawer. The grow target is the max of the file's size and the current
+   drawer per axis (growing never shrinks — the #3149 clamp would refuse it),
+   and the loop is fitted against that same target, so the prompt, the resize
+   and the outline all land consistently. Loops dropped and points thinned
+   are always toasted, never silent.
 6. **The outline never changes implicitly** (#3149) — `drawer.update` clamps a
    shrink to the shape's bounding half-unit grid (`minDrawerUnitsForOutline`)
    and keeps the outline byte-identical on grow; the old crop/weld adaptation

--- a/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.test.tsx
+++ b/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.test.tsx
@@ -2,7 +2,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { useLayoutStore } from '@/core/store';
 import { resetAllStores } from '@/test/testUtils';
-import type { DrawerOutline } from '@/core/types';
+import type { Drawer, DrawerOutline } from '@/core/types';
+import { gridUnits } from '@/core/types';
 import { CornerCutsDialog } from './CornerCutsDialog';
 
 vi.mock('@/i18n', () => ({
@@ -23,6 +24,32 @@ function kindSelect(cornerKey: string): HTMLSelectElement {
     name: `drawerShape.corners.${cornerKey}`,
   });
 }
+
+function setDrawer(patch: Partial<Drawer>): void {
+  useLayoutStore.setState((s) => ({
+    layout: { ...s.layout, drawer: { ...s.layout.drawer, ...patch } },
+  }));
+}
+
+/** A front-left 30mm chamfer on a 4×4 drawer, with its authoring echo. */
+const CHAMFER_OUTLINE: DrawerOutline = {
+  vertices: [
+    { x: 0, y: 30 },
+    { x: 30, y: 0 },
+    { x: 168, y: 0 },
+    { x: 168, y: 168 },
+    { x: 0, y: 168 },
+  ],
+  authoring: {
+    kind: 'corners',
+    corners: {
+      tl: { kind: 'none' },
+      tr: { kind: 'none' },
+      bl: { kind: 'chamfer', size: 30 },
+      br: { kind: 'none' },
+    },
+  },
+};
 
 describe('CornerCutsDialog', () => {
   beforeEach(() => {
@@ -53,56 +80,42 @@ describe('CornerCutsDialog', () => {
   });
 
   it('seeds from an existing corners outline for round-trip editing', () => {
-    useLayoutStore.setState((s) => ({
-      layout: {
-        ...s.layout,
-        drawer: {
-          ...s.layout.drawer,
-          outline: {
-            vertices: [
-              { x: 30, y: 0 },
-              { x: 168, y: 0 },
-              { x: 168, y: 168 },
-              { x: 0, y: 168 },
-              { x: 0, y: 30 },
-            ],
-            authoring: {
-              kind: 'corners',
-              corners: {
-                tl: { kind: 'none' },
-                tr: { kind: 'none' },
-                bl: { kind: 'chamfer', size: 30 },
-                br: { kind: 'none' },
-              },
-            },
-          } as DrawerOutline,
-        },
-      },
-    }));
+    // The echo is only trusted when it reproduces the vertices at the
+    // CURRENT drawer size, so the drawer must match the 4×4 fixture.
+    setDrawer({ width: gridUnits(4), depth: gridUnits(4), outline: CHAMFER_OUTLINE });
     render(<CornerCutsDialog open onClose={() => {}} />);
     expect(kindSelect('frontLeft').value).toBe('chamfer');
   });
 
+  it('confirms before replacing a corners shape whose echo went stale (#3149)', () => {
+    // Same cuts, but on the default 10×8 drawer: the annotation still says
+    // 'corners' while re-inscribing it on the NEW rectangle would replace the
+    // actual (now sub-rect) shape — the geometry check must treat it as
+    // foreign and ask first.
+    setDrawer({ outline: CHAMFER_OUTLINE });
+    render(<CornerCutsDialog open onClose={() => {}} />);
+    // Stale echo must not seed the pickers either.
+    expect(kindSelect('frontLeft').value).toBe('none');
+    fireEvent.change(kindSelect('backLeft'), { target: { value: 'radius' } });
+    fireEvent.click(screen.getByRole('button', { name: 'drawerShape.editor.apply' }));
+    expect(mockSetDrawerOutline).not.toHaveBeenCalled();
+    expect(screen.getByText('drawerShape.corners.replaceTitle')).toBeInTheDocument();
+  });
+
   it('confirms before replacing a shape drawn with another editor', () => {
-    useLayoutStore.setState((s) => ({
-      layout: {
-        ...s.layout,
-        drawer: {
-          ...s.layout.drawer,
-          outline: {
-            vertices: [
-              { x: 0, y: 0 },
-              { x: 168, y: 0 },
-              { x: 168, y: 84 },
-              { x: 84, y: 84 },
-              { x: 84, y: 168 },
-              { x: 0, y: 168 },
-            ],
-            authoring: { kind: 'cells' },
-          } as DrawerOutline,
-        },
+    setDrawer({
+      outline: {
+        vertices: [
+          { x: 0, y: 0 },
+          { x: 168, y: 0 },
+          { x: 168, y: 84 },
+          { x: 84, y: 84 },
+          { x: 84, y: 168 },
+          { x: 0, y: 168 },
+        ],
+        authoring: { kind: 'cells' },
       },
-    }));
+    });
     render(<CornerCutsDialog open onClose={() => {}} />);
     fireEvent.change(kindSelect('backLeft'), { target: { value: 'radius' } });
     fireEvent.click(screen.getByRole('button', { name: 'drawerShape.editor.apply' }));
@@ -130,25 +143,10 @@ describe('review regressions', () => {
   });
 
   it('treats a corners outline with a stripped annotation as foreign (confirms)', () => {
-    useLayoutStore.setState((s) => ({
-      layout: {
-        ...s.layout,
-        drawer: {
-          ...s.layout.drawer,
-          outline: {
-            vertices: [
-              { x: 30, y: 0 },
-              { x: 168, y: 0 },
-              { x: 168, y: 168 },
-              { x: 0, y: 168 },
-              { x: 0, y: 30 },
-            ],
-            // An older server stripped `corners` — only the kind survived.
-            authoring: { kind: 'corners' },
-          } as never,
-        },
-      },
-    }));
+    setDrawer({
+      // An older server stripped `corners` — only the kind survived.
+      outline: { vertices: CHAMFER_OUTLINE.vertices, authoring: { kind: 'corners' } },
+    });
     render(<CornerCutsDialog open onClose={() => {}} />);
     fireEvent.click(screen.getByRole('button', { name: 'drawerShape.editor.apply' }));
     expect(mockSetDrawerOutline).not.toHaveBeenCalled();

--- a/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.tsx
+++ b/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.tsx
@@ -8,8 +8,9 @@ import { useMutations } from '@/shared/contexts/MutationsContext';
 import { isOk } from '@/core/result';
 import { computeDisplacedBins } from '@/core/cqrs/v2/domain/drawer/displacement';
 import { trackDrawerShapeApplied } from '@/shared/analytics/posthog';
-import type { CornerCut, CornerCutParams } from '@/core/types';
+import type { CornerCut, CornerCutParams, DrawerOutline } from '@/core/types';
 import { effectiveGridUnitMmY } from '@/core/types';
+import { cornerCutsMatchVertices } from '@/shared/utils/cornerCutOutline';
 import { cornersToOutline, maxCutExtentMm, NO_CUTS } from '../../utils/cornersToOutline';
 
 interface CornerCutsDialogProps {
@@ -30,6 +31,27 @@ const CORNER_LAYOUT: ReadonlyArray<readonly [CornerKey, string]> = [
 
 function clampMm(value: number, maxMm: number): number {
   return Math.min(maxMm, Math.max(1, value));
+}
+
+/**
+ * The corner params this dialog may seed from, or undefined when the authoring
+ * echo cannot be trusted. The echo goes stale when the drawer resizes under it
+ * (#3149 keeps the outline byte-identical), so it counts only while it still
+ * reproduces the stored vertices at the CURRENT size — re-inscribing a stale
+ * echo on the new rectangle would silently replace the actual shape.
+ */
+function reproducibleCorners(
+  outline: DrawerOutline | undefined,
+  widthMm: number,
+  depthMm: number
+): CornerCutParams | undefined {
+  if (outline === undefined) return undefined;
+  const authoring = outline.authoring;
+  if (authoring?.kind !== 'corners' || authoring.corners === undefined) return undefined;
+  if (!cornerCutsMatchVertices(outline.vertices, widthMm, depthMm, authoring.corners)) {
+    return undefined;
+  }
+  return authoring.corners;
 }
 
 function defaultCut(kind: CutKind, maxMm: number): CornerCut {
@@ -64,21 +86,21 @@ export function CornerCutsDialog({ open, onClose }: CornerCutsDialogProps) {
   );
 
   const existing = layout.drawer.outline;
-  const seeded: CornerCutParams =
-    existing?.authoring?.kind === 'corners' && existing.authoring.corners !== undefined
-      ? existing.authoring.corners
-      : NO_CUTS;
+  const echoCorners = reproducibleCorners(
+    existing,
+    layout.drawer.width * layout.gridUnitMm,
+    layout.drawer.depth * gridUnitMmY
+  );
+  const seeded: CornerCutParams = echoCorners ?? NO_CUTS;
   const [cuts, setCuts] = useState<CornerCutParams | null>(null);
   const [confirmReplace, setConfirmReplace] = useState(false);
   const active = cuts ?? seeded;
 
   const maxMm = maxCutExtentMm(layout.drawer, layout.gridUnitMm, gridUnitMmY);
-  // A shape drawn with another editor — or a corners shape whose annotation
-  // was stripped by an older server (params lost) — must confirm before this
-  // dialog replaces it; the seeded pickers don't represent it.
-  const replacesForeignShape =
-    existing !== undefined &&
-    (existing.authoring?.kind !== 'corners' || existing.authoring.corners === undefined);
+  // A shape this dialog cannot reproduce — drawn with another editor, an
+  // annotation stripped by an older server, or a stale echo — must confirm
+  // before being replaced; the seeded pickers don't represent it.
+  const replacesForeignShape = existing !== undefined && echoCorners === undefined;
 
   const setCorner = useCallback(
     (key: CornerKey, cut: CornerCut) => {

--- a/src/features/drawer-shape/components/PenShapeDialog/useOutlineImport.test.ts
+++ b/src/features/drawer-shape/components/PenShapeDialog/useOutlineImport.test.ts
@@ -12,8 +12,8 @@ vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const U = 42;
 
-/** Closed square LWPOLYLINE of the given size, in millimetres. */
-function squareDxf(size: number): string {
+/** Closed rectangular LWPOLYLINE, in millimetres. */
+function rectDxf(width: number, depth: number): string {
   const pairs: [number, string | number][] = [
     [0, 'SECTION'],
     [2, 'ENTITIES'],
@@ -22,16 +22,20 @@ function squareDxf(size: number): string {
     [70, 1],
     [10, 0],
     [20, 0],
-    [10, size],
+    [10, width],
     [20, 0],
-    [10, size],
-    [20, size],
+    [10, width],
+    [20, depth],
     [10, 0],
-    [20, size],
+    [20, depth],
     [0, 'ENDSEC'],
     [0, 'EOF'],
   ];
   return pairs.map(([c, v]) => `${c}\n${v}`).join('\n') + '\n';
+}
+
+function squareDxf(size: number): string {
+  return rectDxf(size, size);
 }
 
 function setup(overrides: Partial<OutlineImportDeps> = {}) {
@@ -142,6 +146,29 @@ describe('useOutlineImport', () => {
     // True scale kept, and centred in the grown drawer (21.5u = 903mm).
     expect(Math.max(...xs) - Math.min(...xs)).toBeCloseTo(900, 6);
     expect(Math.min(...xs)).toBeCloseTo((21.5 * U - 900) / 2, 6);
+  });
+
+  // Growing must never shrink the other axis: the drawer-resize clamp (#3149)
+  // would refuse the shrink and land a different size than the loop was
+  // centred for, so the target maxes each axis against the current drawer.
+  it('grows only the overflowing axis, keeping the current size on the other', async () => {
+    const { result, onImported, onGrowDrawer } = setup();
+    // 500×100mm: width needs 12 units, depth (2.5) is under the current 8.
+    await pickFile('wide.dxf', rectDxf(500, 100));
+    await waitFor(() => expect(result.current.oversize).not.toBeNull());
+    expect(result.current.oversize?.requiredWidthUnits).toBe(12);
+    expect(result.current.oversize?.requiredDepthUnits).toBe(8);
+
+    await act(async () => {
+      result.current.resolveOversize('grow');
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
+    expect(onGrowDrawer).toHaveBeenCalledWith(12, 8);
+    const verts = onImported.mock.calls[0][0];
+    const ys = verts.map((v: { y: number }) => v.y);
+    // Centred in the drawer that actually lands (depth stays 8u = 336mm).
+    expect(Math.min(...ys)).toBeCloseTo((8 * U - 100) / 2, 6);
   });
 
   it('imports nothing when the prompt is cancelled', async () => {

--- a/src/features/drawer-shape/components/PenShapeDialog/useOutlineImport.ts
+++ b/src/features/drawer-shape/components/PenShapeDialog/useOutlineImport.ts
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { OutlineVertex } from '@/core/types';
-import { CONSTRAINTS } from '@/core/constants';
+import { CONSTRAINTS, snapToHalf } from '@/core/constants';
 import { isOk } from '@/core/result';
 import { useToastStore } from '@/core/store';
 import { useTranslation } from '@/i18n';
@@ -95,6 +95,16 @@ export function useOutlineImport(deps: OutlineImportDeps): UseOutlineImportRetur
       }
       const m = measured.value;
 
+      // Growing never shrinks the other axis: `updateDrawer` clamps a shrink
+      // while a custom outline is active (#3149), so promising the file's
+      // absolute dims would land a different drawer than the loop was fitted
+      // and centred for. Max against the current drawer so the prompt, the
+      // fit extent, and the landed size all agree.
+      const currentWidthUnits = snapToHalf(d.drawerWidthMm / d.gridUnitMm);
+      const currentDepthUnits = snapToHalf(d.drawerDepthMm / d.gridUnitMmY);
+      const growWidthUnits = Math.max(currentWidthUnits, m.requiredWidthUnits);
+      const growDepthUnits = Math.max(currentDepthUnits, m.requiredDepthUnits);
+
       if (mode.kind === 'trueScale' && !m.fitsAtTrueScale) {
         // A measured drawer must not be silently rescaled, so the choice
         // between shrinking the shape and growing the drawer is the user's.
@@ -102,11 +112,9 @@ export function useOutlineImport(deps: OutlineImportDeps): UseOutlineImportRetur
         setOversize({
           sourceWidthMm: m.sourceWidthMm,
           sourceDepthMm: m.sourceDepthMm,
-          requiredWidthUnits: m.requiredWidthUnits,
-          requiredDepthUnits: m.requiredDepthUnits,
-          canGrow:
-            m.requiredWidthUnits <= CONSTRAINTS.GRID_MAX &&
-            m.requiredDepthUnits <= CONSTRAINTS.GRID_MAX,
+          requiredWidthUnits: growWidthUnits,
+          requiredDepthUnits: growDepthUnits,
+          canGrow: growWidthUnits <= CONSTRAINTS.GRID_MAX && growDepthUnits <= CONSTRAINTS.GRID_MAX,
         });
         return;
       }
@@ -118,13 +126,13 @@ export function useOutlineImport(deps: OutlineImportDeps): UseOutlineImportRetur
       if (mode.kind === 'grow') {
         const grown = importOutline(text, {
           ...common,
-          drawerWidthMm: m.requiredWidthUnits * d.gridUnitMm,
-          drawerDepthMm: m.requiredDepthUnits * d.gridUnitMmY,
+          drawerWidthMm: growWidthUnits * d.gridUnitMm,
+          drawerDepthMm: growDepthUnits * d.gridUnitMmY,
           scaleToFit: false,
         });
         if (!isOk(grown)) return;
         final = grown.value;
-        d.onGrowDrawer(m.requiredWidthUnits, m.requiredDepthUnits);
+        d.onGrowDrawer(growWidthUnits, growDepthUnits);
       } else if (mode.kind === 'scaleToFit') {
         const scaled = importOutline(text, {
           ...common,

--- a/src/features/drawer-shape/utils/drawerMask.test.ts
+++ b/src/features/drawer-shape/utils/drawerMask.test.ts
@@ -138,6 +138,18 @@ describe('isOutlineCellRepresentable (#3149)', () => {
     expect(isOutlineCellRepresentable(offCell, drawer(4, 4), U)).toBe(false);
   });
 
+  it('round-trips a fractional-edge shape on a non-square grid', () => {
+    // 3.5×2 drawer at 48×42 with the half column dropped: the traced outline
+    // stops at 3 whole units and must survive the round-trip exactly.
+    const d = drawer(3.5, 2);
+    const grid = buildFullDrawerMask(d);
+    setCell(grid, 3, 0, 0);
+    setCell(grid, 3, 1, 0);
+    const result = drawerMaskToOutline(grid, 48, 42);
+    if (!('outline' in result)) throw new Error('expected outline');
+    expect(isOutlineCellRepresentable(result.outline, d, 48, 42)).toBe(true);
+  });
+
   it('rejects an outline whose rasterization collapses to nothing', () => {
     // Thinner than a cell everywhere: no cell is fully inside.
     const sliver = {

--- a/src/features/drawer-shape/utils/outlineImport/fitLoop.ts
+++ b/src/features/drawer-shape/utils/outlineImport/fitLoop.ts
@@ -9,6 +9,7 @@
  */
 
 import type { OutlineVertex } from '@/core/types';
+import { ceilHalfUnits } from '@/shared/utils/drawerOutline';
 import { flattenOutline, polylineSignedArea } from '@/shared/utils/drawerOutlineGeometry';
 import { isClockwise, reverseWinding } from '../penShape';
 import type { ImportedLoop } from './types';
@@ -82,9 +83,13 @@ export interface FittedLoop {
   readonly requiredDepthUnits: number;
 }
 
-/** Round up to the next half grid unit, the finest drawer dimension allowed. */
+/**
+ * Round up to the next half grid unit, the finest drawer dimension allowed.
+ * Shares `ceilHalfUnits` with the resize clamp (#3149) so a shape flush with
+ * the drawer edge never grows the drawer by float noise alone.
+ */
 export function unitsFor(mm: number, pitch: number): number {
-  return Math.max(1, Math.ceil((mm / pitch) * 2) / 2);
+  return Math.max(1, ceilHalfUnits(mm, pitch));
 }
 
 /**

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3003,6 +3003,7 @@
   "toast.binRotated": "Bin otočen",
   "toast.binsDeleted": "Smazáno {count} binů",
   "toast.binsDisplacedByShape": "{count} binů přesunuto do Stash (mimo nový tvar)",
+  "toast.drawerSizeLimitedByShape": "Zásuvka nemůže být menší než její vlastní tvar. Nejprve tvar upravte nebo obnovte.",
   "toast.outlineImport.parseFailed": "Tento soubor se nepodařilo přečíst jako výkres SVG ani DXF.",
   "toast.outlineImport.noClosedLoop": "Nenalezen uzavřený tvar. Obvod musí být spojený dokola.",
   "toast.outlineImport.tooComplex": "Tento tvar má i po zjednodušení příliš mnoho bodů.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3183,6 +3183,7 @@
   "toast.binRotated": "Bin gedreht",
   "toast.binsDeleted": "{count} Bin(s) gelöscht",
   "toast.binsDisplacedByShape": "{count} Bin(s) in die Ablage verschoben (außerhalb der neuen Form)",
+  "toast.drawerSizeLimitedByShape": "Die Schublade kann nicht kleiner als ihre eigene Form werden. Bearbeite oder setze die Form zuerst zurück.",
   "toast.outlineImport.parseFailed": "Diese Datei konnte nicht als SVG- oder DXF-Zeichnung gelesen werden.",
   "toast.outlineImport.noClosedLoop": "Keine geschlossene Form gefunden. Der Umriss muss rundherum verbunden sein.",
   "toast.outlineImport.tooComplex": "Diese Form hat auch nach dem Vereinfachen zu viele Punkte.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3727,6 +3727,8 @@ const en: Record<string, string> = {
   'drawerShape.editor.replacesDrawnShape':
     'The current perimeter was drawn freehand or imported. Applying a cell shape replaces it — curves and off-grid edges are lost.',
   'toast.binsDisplacedByShape': '{count} bin(s) moved to the stash (outside the new shape)',
+  'toast.drawerSizeLimitedByShape':
+    'The drawer cannot shrink below its custom shape. Edit or reset the shape first.',
   'toast.outlineImport.parseFailed': "That file couldn't be read as an SVG or DXF drawing.",
   'toast.outlineImport.noClosedLoop':
     'No closed shape found. The perimeter needs to join up all the way round.',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3183,6 +3183,7 @@
   "toast.binRotated": "Bin rotado",
   "toast.binsDeleted": "{count} bin(s) eliminado(s)",
   "toast.binsDisplacedByShape": "{count} bin(s) movidos al depósito (fuera de la nueva forma)",
+  "toast.drawerSizeLimitedByShape": "El cajón no puede reducirse por debajo de su forma personalizada. Edita o restablece la forma primero.",
   "toast.outlineImport.parseFailed": "No se pudo leer ese archivo como un dibujo SVG o DXF.",
   "toast.outlineImport.noClosedLoop": "No se encontró una forma cerrada. El perímetro debe unirse por completo.",
   "toast.outlineImport.tooComplex": "Esa forma tiene demasiados puntos, incluso tras simplificarla.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3003,6 +3003,7 @@
   "toast.binRotated": "Bin pivoté",
   "toast.binsDeleted": "{count} bin(s) supprimé(s)",
   "toast.binsDisplacedByShape": "{count} bac(s) déplacés en réserve (hors de la nouvelle forme)",
+  "toast.drawerSizeLimitedByShape": "Le tiroir ne peut pas devenir plus petit que sa forme personnalisée. Modifiez ou réinitialisez d'abord la forme.",
   "toast.outlineImport.parseFailed": "Ce fichier n’a pas pu être lu comme un dessin SVG ou DXF.",
   "toast.outlineImport.noClosedLoop": "Aucune forme fermée trouvée. Le périmètre doit se refermer entièrement.",
   "toast.outlineImport.tooComplex": "Cette forme a trop de points, même après simplification.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3183,6 +3183,7 @@
   "toast.binRotated": "Bin ruotato",
   "toast.binsDeleted": "Eliminati {count} bin",
   "toast.binsDisplacedByShape": "{count} bin spostati nell'area di sosta (fuori dalla nuova forma)",
+  "toast.drawerSizeLimitedByShape": "Il cassetto non può ridursi oltre la sua forma personalizzata. Modifica o reimposta prima la forma.",
   "toast.outlineImport.parseFailed": "Impossibile leggere quel file come disegno SVG o DXF.",
   "toast.outlineImport.noClosedLoop": "Nessuna forma chiusa trovata. Il perimetro deve chiudersi del tutto.",
   "toast.outlineImport.tooComplex": "Quella forma ha troppi punti, anche dopo la semplificazione.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3183,6 +3183,7 @@
   "toast.binRotated": "ビンを回転しました",
   "toast.binsDeleted": "{count}個のビンを削除しました",
   "toast.binsDisplacedByShape": "{count}個のビンをスタッシュへ移動しました（新しい形状の外）",
+  "toast.drawerSizeLimitedByShape": "引き出しはカスタム形状より小さくできません。先に形状を編集するかリセットしてください。",
   "toast.outlineImport.parseFailed": "そのファイルは SVG または DXF の図面として読み取れませんでした。",
   "toast.outlineImport.noClosedLoop": "閉じた形状が見つかりません。外周は一周つながっている必要があります。",
   "toast.outlineImport.tooComplex": "その形状は簡略化しても点が多すぎます。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2927,6 +2927,7 @@
   "toast.binRotated": "수납통을 회전했습니다",
   "toast.binsDeleted": "수납통 {count}개를 삭제했습니다",
   "toast.binsDisplacedByShape": "수납통 {count}개를 임시 보관함으로 이동했습니다(새 모양 바깥)",
+  "toast.drawerSizeLimitedByShape": "서랍은 사용자 지정 모양보다 작게 줄일 수 없습니다. 먼저 모양을 편집하거나 초기화하세요.",
   "toast.outlineImport.parseFailed": "해당 파일을 SVG 또는 DXF 도면으로 읽을 수 없습니다.",
   "toast.outlineImport.noClosedLoop": "닫힌 모양을 찾을 수 없습니다. 둘레가 한 바퀴 이어져야 합니다.",
   "toast.outlineImport.tooComplex": "해당 모양은 단순화한 뒤에도 점이 너무 많습니다.",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -3183,6 +3183,7 @@
   "toast.binRotated": "Bin rotert",
   "toast.binsDeleted": "Slettet {count} bin(s)",
   "toast.binsDisplacedByShape": "{count} bin(ner) flyttet til lageret (utenfor den nye formen)",
+  "toast.drawerSizeLimitedByShape": "Skuffen kan ikke bli mindre enn sin egendefinerte form. Rediger eller tilbakestill formen først.",
   "toast.outlineImport.parseFailed": "Denne filen kunne ikke leses som en SVG- eller DXF-tegning.",
   "toast.outlineImport.noClosedLoop": "Fant ingen lukket form. Omrisset må henge sammen hele veien rundt.",
   "toast.outlineImport.tooComplex": "Formen har for mange punkter, selv etter forenkling.",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -3183,6 +3183,7 @@
   "toast.binRotated": "Bin geroteerd",
   "toast.binsDeleted": "{count} bin(s) verwijderd",
   "toast.binsDisplacedByShape": "{count} bin(s) naar de stash verplaatst (buiten de nieuwe vorm)",
+  "toast.drawerSizeLimitedByShape": "De lade kan niet kleiner worden dan de aangepaste vorm. Bewerk of herstel eerst de vorm.",
   "toast.outlineImport.parseFailed": "Dat bestand kon niet als SVG- of DXF-tekening worden gelezen.",
   "toast.outlineImport.noClosedLoop": "Geen gesloten vorm gevonden. De omtrek moet helemaal rondlopen.",
   "toast.outlineImport.tooComplex": "Die vorm heeft te veel punten, zelfs na vereenvoudiging.",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3003,6 +3003,7 @@
   "toast.binRotated": "Bin obrócony",
   "toast.binsDeleted": "Usunięto {count} bin(ów)",
   "toast.binsDisplacedByShape": "{count} bin(ów) przeniesionych do Stash (poza nowym kształtem)",
+  "toast.drawerSizeLimitedByShape": "Szuflada nie może być mniejsza niż jej niestandardowy kształt. Najpierw edytuj lub zresetuj kształt.",
   "toast.outlineImport.parseFailed": "Nie udało się odczytać tego pliku jako rysunku SVG ani DXF.",
   "toast.outlineImport.noClosedLoop": "Nie znaleziono zamkniętego kształtu. Obrys musi łączyć się dookoła.",
   "toast.outlineImport.tooComplex": "Ten kształt ma zbyt wiele punktów, nawet po uproszczeniu.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3003,6 +3003,7 @@
   "toast.binRotated": "Bin rotacionado",
   "toast.binsDeleted": "{count} bin(s) excluído(s)",
   "toast.binsDisplacedByShape": "{count} bin(s) movidos para o depósito (fora do novo formato)",
+  "toast.drawerSizeLimitedByShape": "A gaveta não pode ficar menor que sua forma personalizada. Edite ou redefina a forma primeiro.",
   "toast.outlineImport.parseFailed": "Não foi possível ler esse arquivo como um desenho SVG ou DXF.",
   "toast.outlineImport.noClosedLoop": "Nenhuma forma fechada encontrada. O perímetro precisa se unir por completo.",
   "toast.outlineImport.tooComplex": "Essa forma tem pontos demais, mesmo após a simplificação.",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3003,6 +3003,7 @@
   "toast.binRotated": "Fack roterat",
   "toast.binsDeleted": "Raderade {count} fack",
   "toast.binsDisplacedByShape": "{count} bin(s) flyttade till förrådet (utanför den nya formen)",
+  "toast.drawerSizeLimitedByShape": "Lådan kan inte bli mindre än sin anpassade form. Redigera eller återställ formen först.",
   "toast.outlineImport.parseFailed": "Filen kunde inte läsas som en SVG- eller DXF-ritning.",
   "toast.outlineImport.noClosedLoop": "Ingen sluten form hittades. Omkretsen måste gå ihop hela vägen runt.",
   "toast.outlineImport.tooComplex": "Formen har för många punkter, även efter förenkling.",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -3183,6 +3183,7 @@
   "toast.binRotated": "Бін обернуто",
   "toast.binsDeleted": "Видалено {count} бінів",
   "toast.binsDisplacedByShape": "{count} бін(и) переміщено до сховку (поза новою формою)",
+  "toast.drawerSizeLimitedByShape": "Шухляда не може стати меншою за свою власну форму. Спочатку відредагуйте або скиньте форму.",
   "toast.outlineImport.parseFailed": "Не вдалося прочитати цей файл як креслення SVG або DXF.",
   "toast.outlineImport.noClosedLoop": "Замкнену форму не знайдено. Периметр має з’єднуватися по колу.",
   "toast.outlineImport.tooComplex": "Ця форма має забагато точок навіть після спрощення.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3003,6 +3003,7 @@
   "toast.binRotated": "收纳盒已旋转",
   "toast.binsDeleted": "已删除 {count} 个收纳盒",
   "toast.binsDisplacedByShape": "{count} 个收纳盒被移入暂存区（在新形状之外）",
+  "toast.drawerSizeLimitedByShape": "抽屉不能缩小到小于其自定义形状。请先编辑或重置形状。",
   "toast.outlineImport.parseFailed": "无法将该文件读取为 SVG 或 DXF 图纸。",
   "toast.outlineImport.noClosedLoop": "未找到闭合形状。轮廓需要首尾相连。",
   "toast.outlineImport.tooComplex": "该形状即使简化后点数仍然过多。",

--- a/src/shared/hooks/useDrawerSettings.ts
+++ b/src/shared/hooks/useDrawerSettings.ts
@@ -20,6 +20,7 @@ import {
 import { validateHalfGridModeToggle } from '@/shared/utils/halfGridConstraints';
 import type { HalfGridConstraintViolation } from '@/shared/utils/halfGridConstraints';
 import { fitAxisUnits, halfUnitUpgrade } from '@/shared/utils/drawerFit';
+import { drawerSizeFloors } from '@/shared/utils/drawerOutline';
 import {
   trackDrawerHalfFitSuggestion,
   trackDrawerMeasuredCommitted,
@@ -73,6 +74,9 @@ export interface UseDrawerSettingsReturn {
   // Computed values
   widthStep: number;
   depthStep: number;
+  /** Size floor set by the custom drawer shape, 0.5 without one (#3149). */
+  drawerMinWidth: number;
+  drawerMinDepth: number;
   hasFractionalWidth: boolean;
   hasFractionalDepth: boolean;
   realWorldDimensions: {
@@ -306,6 +310,15 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
   const depthStep = halfGridMode || hasFractionalDepth ? 0.5 : 1;
   const maxGridUnits = calcMaxGridUnits(printBedSize, gridUnitMm, printBedDepth, gridUnitMmY);
 
+  // A custom drawer shape floors the size (#3149: the command clamps rather
+  // than crop the shape); exposing the floor lets the steppers bound their
+  // range so the "−" button disables instead of silently doing nothing.
+  const drawerOutline = layout.drawer.outline;
+  const { width: drawerMinWidth, depth: drawerMinDepth } = useMemo(
+    () => drawerSizeFloors(drawerOutline, gridUnitMm, gridUnitMmY),
+    [drawerOutline, gridUnitMm, gridUnitMmY]
+  );
+
   const realWorldDimensions = useMemo(
     () => ({
       width: drawerWidth * gridUnitMm,
@@ -318,23 +331,23 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
   const handleDrawerWidthChange = useCallback(
     (delta: number) => {
       const newWidth = Math.max(
-        0.5,
+        drawerMinWidth,
         Math.min(CONSTRAINTS.GRID_MAX, drawerWidth + delta * widthStep)
       ) as GridUnits;
       batch(() => updateDrawer({ width: newWidth }));
     },
-    [widthStep, drawerWidth, updateDrawer]
+    [widthStep, drawerWidth, drawerMinWidth, updateDrawer]
   );
 
   const handleDrawerDepthChange = useCallback(
     (delta: number) => {
       const newDepth = Math.max(
-        0.5,
+        drawerMinDepth,
         Math.min(CONSTRAINTS.GRID_MAX, drawerDepth + delta * depthStep)
       ) as GridUnits;
       batch(() => updateDrawer({ depth: newDepth }));
     },
-    [depthStep, drawerDepth, updateDrawer]
+    [depthStep, drawerDepth, drawerMinDepth, updateDrawer]
   );
 
   const handleDrawerHeightChange = useCallback(
@@ -360,26 +373,30 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
 
   const handleDrawerWidthInput = useCallback(
     (width: number) => {
-      const snapped = gridUnits(snapToHalf(Math.max(0.5, Math.min(CONSTRAINTS.GRID_MAX, width))));
+      const snapped = gridUnits(
+        snapToHalf(Math.max(drawerMinWidth, Math.min(CONSTRAINTS.GRID_MAX, width)))
+      );
       batch(() => updateDrawer({ width: snapped }));
       if (isFractional(snapped) && !halfGridMode) {
         setHalfGridMode(true);
         addToast(t('toast.halfBinModeAutoEnabled'), 'info');
       }
     },
-    [updateDrawer, halfGridMode, setHalfGridMode, addToast, t]
+    [updateDrawer, drawerMinWidth, halfGridMode, setHalfGridMode, addToast, t]
   );
 
   const handleDrawerDepthInput = useCallback(
     (depth: number) => {
-      const snapped = gridUnits(snapToHalf(Math.max(0.5, Math.min(CONSTRAINTS.GRID_MAX, depth))));
+      const snapped = gridUnits(
+        snapToHalf(Math.max(drawerMinDepth, Math.min(CONSTRAINTS.GRID_MAX, depth)))
+      );
       batch(() => updateDrawer({ depth: snapped }));
       if (isFractional(snapped) && !halfGridMode) {
         setHalfGridMode(true);
         addToast(t('toast.halfBinModeAutoEnabled'), 'info');
       }
     },
-    [updateDrawer, halfGridMode, setHalfGridMode, addToast, t]
+    [updateDrawer, drawerMinDepth, halfGridMode, setHalfGridMode, addToast, t]
   );
 
   // Fractional edge position handler
@@ -501,9 +518,15 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
     batch(() =>
       updateDrawer({ width: drawerFitSuggestion.width, depth: drawerFitSuggestion.depth })
     );
+    // A custom shape floors the size (#3149), so the fit may land clamped —
+    // say so instead of dismissing the card as if the fit applied.
+    const landed = useLayoutStore.getState().layout.drawer;
+    if (landed.width !== drawerFitSuggestion.width || landed.depth !== drawerFitSuggestion.depth) {
+      addToast(t('toast.drawerSizeLimitedByShape'), 'info');
+    }
     setHalfFit(null);
     trackDrawerHalfFitSuggestion('accepted');
-  }, [drawerFitSuggestion, setHalfGridMode, updateDrawer]);
+  }, [drawerFitSuggestion, setHalfGridMode, updateDrawer, addToast, t]);
 
   const dismissDrawerFitSuggestion = useCallback(() => {
     setHalfFit(null);
@@ -651,6 +674,8 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
     // Computed values
     widthStep,
     depthStep,
+    drawerMinWidth,
+    drawerMinDepth,
     hasFractionalWidth,
     hasFractionalDepth,
     realWorldDimensions,

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -5,6 +5,7 @@ import { gridUnits, mm } from '@/core/types';
 import { createTestLayout } from '@/test/testUtils';
 import {
   canonicalStartOutline,
+  ceilHalfUnits,
   hashOutline,
   minDrawerUnitsForOutline,
   normalizeDrawerOutline,
@@ -310,6 +311,19 @@ describe('canonicalStartOutline', () => {
   });
 });
 
+describe('ceilHalfUnits', () => {
+  it('does not ceil float noise at an exact unit boundary', () => {
+    // 4 × 45.3 = 181.20000000000002: without the epsilon this reads as 4.5.
+    expect(ceilHalfUnits(4 * 45.3, 45.3)).toBe(4);
+    expect(ceilHalfUnits(8.5 * 48, 48)).toBe(8.5);
+  });
+
+  it('rounds a real overhang up to the next half unit', () => {
+    expect(ceilHalfUnits(181.5, 45.3)).toBe(4.5);
+    expect(ceilHalfUnits(396, 48)).toBe(8.5);
+  });
+});
+
 describe('minDrawerUnitsForOutline', () => {
   it('returns the exact unit dims for a whole-unit shape', () => {
     expect(minDrawerUnitsForOutline(L_SHAPE, U)).toEqual({ width: 4, depth: 4 });
@@ -352,6 +366,18 @@ describe('minDrawerUnitsForOutline', () => {
     };
     // The #3149 repro: 48 × 42 pitch needs an 8.5 × 7.5 drawer.
     expect(minDrawerUnitsForOutline(rect, 48, 42)).toEqual({ width: 8.5, depth: 7.5 });
+  });
+
+  it('floors on the outline max, not its width', () => {
+    const offset: DrawerOutline = {
+      vertices: [
+        { x: 2 * U, y: 0 },
+        { x: 5 * U, y: 0 },
+        { x: 5 * U, y: 3 * U },
+        { x: 2 * U, y: 3 * U },
+      ],
+    };
+    expect(minDrawerUnitsForOutline(offset, U)).toEqual({ width: 5, depth: 3 });
   });
 
   it('does not ceil an extent already on a half unit (float noise guarded)', () => {

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -10,6 +10,8 @@
 
 import type { DrawerOutline, Layout, OutlineVertex } from '@/core/types';
 import { effectiveGridUnitMmY } from '@/core/types';
+import { CONSTRAINTS } from '@/core/constants';
+import { clamp } from './math';
 import {
   arcGeometry,
   arcPointAt,
@@ -416,7 +418,11 @@ function clipHalfPlane(
  * two DIFFERENT lines, so even cuts far smaller than any area epsilon are
  * preserved as intentional geometry.
  */
-function isFullRectangle(outline: DrawerOutline, widthMm: number, depthMm: number): boolean {
+export function isOutlineFullRectangle(
+  outline: DrawerOutline,
+  widthMm: number,
+  depthMm: number
+): boolean {
   const n = outline.vertices.length;
   for (let i = 0; i < n; i++) {
     const a = outline.vertices[i];
@@ -453,11 +459,21 @@ function dropCoincident(verts: MutableVertex[]): MutableVertex[] {
 }
 
 /**
+ * Smallest half-unit count covering `mm` at `pitch`. The epsilon keeps an
+ * exact boundary (e.g. 8.5 units × 48mm, whose product carries float noise)
+ * from ceiling an extra half unit. Every "how many units does this length
+ * need" callsite must share this so clamps and grows agree on the boundary.
+ */
+export function ceilHalfUnits(mm: number, pitch: number): number {
+  return Math.ceil((mm / pitch) * 2 - 1e-9) / 2;
+}
+
+/**
  * Smallest half-unit drawer dims that contain the outline — the floor a
  * drawer resize may shrink to while a custom shape is active (#3149: a resize
  * must never crop or extend the user's shape, so the dims clamp instead).
- * Measured on the flattened path (an arc bows past its own endpoints), same
- * as the pen editor's auto-grow, so clamp and grow agree on the boundary.
+ * Measured on the flattened path (an arc bows past its own endpoints) and on
+ * {@link ceilHalfUnits}, shared with the pen editor's auto-grow.
  */
 export function minDrawerUnitsForOutline(
   outline: DrawerOutline,
@@ -466,12 +482,58 @@ export function minDrawerUnitsForOutline(
   gridUnitMmY: number = gridUnitMm
 ): { readonly width: number; readonly depth: number } {
   const b = outlineBounds(outline);
-  const ceilHalf = (mm: number, pitch: number): number =>
-    Math.max(0.5, Math.ceil((mm / pitch) * 2 - 1e-9) / 2);
   return {
-    width: ceilHalf(b.maxX, gridUnitMm),
-    depth: ceilHalf(b.maxY, gridUnitMmY),
+    width: Math.max(0.5, ceilHalfUnits(b.maxX, gridUnitMm)),
+    depth: Math.max(0.5, ceilHalfUnits(b.maxY, gridUnitMmY)),
   };
+}
+
+/**
+ * Drawer dims (grid units) a resize may clamp down to: the outline's bounding
+ * half-unit grid while a custom shape is active, the plain grid minimum
+ * without one. Shared by the CQRS command, the store mirror and the size
+ * steppers so all three refuse the same shrinks (#3149).
+ */
+export function drawerSizeFloors(
+  outline: DrawerOutline | undefined,
+  gridUnitMm: number,
+  gridUnitMmY: number = gridUnitMm
+): { readonly width: number; readonly depth: number } {
+  if (outline === undefined) {
+    return { width: CONSTRAINTS.GRID_MIN, depth: CONSTRAINTS.GRID_MIN };
+  }
+  const min = minDrawerUnitsForOutline(outline, gridUnitMm, gridUnitMmY);
+  return {
+    width: clamp(min.width, CONSTRAINTS.GRID_MIN, CONSTRAINTS.GRID_MAX),
+    depth: clamp(min.depth, CONSTRAINTS.GRID_MIN, CONSTRAINTS.GRID_MAX),
+  };
+}
+
+/** Range a grid pitch may be set to (mm), either axis. */
+const GRID_PITCH_MM_MIN = 1;
+export const GRID_PITCH_MM_MAX = 200;
+
+/**
+ * Grid pitch (mm) a pitch change may clamp down to, per axis. Lowering the
+ * pitch shrinks the mm extent without touching the stored outline, and the
+ * read-side normalizer would then clip the shape on the next load (#3149:
+ * nothing may mutate the shape implicitly, so the pitch clamps instead).
+ * Floors round up to 0.01mm so `units × pitch ≥ bounds` survives float noise.
+ * On a square grid the X pitch drives both axes, so its floor honours the Y
+ * bound too. Shared by the CQRS commands and their store mirrors.
+ */
+export function gridPitchFloors(layout: Pick<Layout, 'drawer' | 'gridUnitMm' | 'gridUnitMmY'>): {
+  readonly x: number;
+  readonly y: number;
+} {
+  const outline = layout.drawer.outline;
+  if (outline === undefined) return { x: GRID_PITCH_MM_MIN, y: GRID_PITCH_MM_MIN };
+  const b = outlineBounds(outline);
+  const floor = (extentMm: number, units: number): number =>
+    clamp(Math.ceil((extentMm / units) * 100 - 1e-6) / 100, GRID_PITCH_MM_MIN, GRID_PITCH_MM_MAX);
+  const x = floor(b.maxX, layout.drawer.width);
+  const y = floor(b.maxY, layout.drawer.depth);
+  return { x: layout.gridUnitMmY === undefined ? Math.max(x, y) : x, y };
 }
 
 /**
@@ -529,7 +591,7 @@ export function normalizeDrawerOutline(layout: Layout): Layout {
     widthMm,
     depthMm
   );
-  if (isFullRectangle(candidate, widthMm, depthMm)) return drop();
+  if (isOutlineFullRectangle(candidate, widthMm, depthMm)) return drop();
   if (validateOutline(candidate, widthMm, depthMm, layout.gridUnitMm, gridUnitMmY) !== null) {
     return drop();
   }

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -43,6 +43,8 @@ export function MobileSettingsPanel() {
     drawer,
     widthStep,
     depthStep,
+    drawerMinWidth,
+    drawerMinDepth,
     realWorldDimensions,
     measuredMm,
     drawerFitSuggestion,
@@ -105,7 +107,7 @@ export function MobileSettingsPanel() {
               value={drawer.width}
               onChange={handleDrawerWidthInput}
               onStep={handleDrawerWidthChange}
-              min={0.5}
+              min={drawerMinWidth}
               max={CONSTRAINTS.GRID_MAX}
               step={widthStep}
               size="lg"
@@ -122,7 +124,7 @@ export function MobileSettingsPanel() {
               value={drawer.depth}
               onChange={handleDrawerDepthInput}
               onStep={handleDrawerDepthChange}
-              min={0.5}
+              min={drawerMinDepth}
               max={CONSTRAINTS.GRID_MAX}
               step={depthStep}
               size="lg"

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -71,6 +71,8 @@ export function Sidebar() {
     fractionalEdges,
     widthStep,
     depthStep,
+    drawerMinWidth,
+    drawerMinDepth,
     hasFractionalWidth,
     hasFractionalDepth,
     realWorldDimensions,
@@ -335,7 +337,7 @@ export function Sidebar() {
                         value={drawer.width}
                         onChange={handleDrawerWidthInput}
                         onStep={handleDrawerWidthChange}
-                        min={0.5}
+                        min={drawerMinWidth}
                         max={CONSTRAINTS.GRID_MAX}
                         step={widthStep}
                         size="sm"
@@ -354,7 +356,7 @@ export function Sidebar() {
                         value={drawer.depth}
                         onChange={handleDrawerDepthInput}
                         onStep={handleDrawerDepthChange}
-                        min={0.5}
+                        min={drawerMinDepth}
                         max={CONSTRAINTS.GRID_MAX}
                         step={depthStep}
                         size="sm"


### PR DESCRIPTION
Part of #3149 — hardening pass from post-merge review of #3151 (adversarial review + gap analysis). Every finding is the same bug class the issue reports: something mutating or misrepresenting the user's drawn perimeter implicitly.

## Fixes

1. **Grid-pitch changes could clip the shape on the next load.** The outline is stored in absolute mm; lowering `gridUnitMm`/`gridUnitMmY` shrank the mm extent without touching the shape, and the read-side normalizer (`normalizeDrawerOutline`) then cropped or dropped it — a deferred, invisible mutation. Both pitch commands (and the store mirrors) now clamp to `minGridPitchForOutline`, and clearing the Y pitch back to square is refused when the square pitch wouldn't hold the shape. The ingress crop stays untouched — it is load-bearing against hostile payloads; the guard belongs on the write side.
2. **Import "Grow drawer to W × D u" under-delivered.** The grow target was the file's absolute size; the #3151 clamp refuses the shrink that implied on a non-overflowing axis, landing a different drawer than the loop was centred for. The target now maxes each axis against the current drawer, so the prompt, the fit extent, and the landed size agree.
3. **Shrink-to-bbox left a redundant "shaped" layout.** Landing exactly on the outline's bounding rectangle now drops the rectangle-equivalent outline (exported `isOutlineFullRectangle`), matching `setOutline` and the ingress normalizer — previously the layout stayed on the shaped codepath (slow BREP preview, "shaped" export naming) until a reload silently flipped it.
4. **CornerCutsDialog trusted a stale authoring echo.** After #3151 keeps the outline byte-identical across a drawer grow, a `corners` echo no longer matches the stored vertices — re-inscribing it on the new rectangle would destroy the actual shape with no prompt, and mis-seed the pickers. The dialog now applies the same `cornerCutsMatchVertices` geometry check every other echo consumer already uses.
5. **The #3151 size clamp was invisible.** The floor now reaches the UI: width/depth steppers bound their range (desktop sidebar + mobile panel, so the "−" button disables instead of silently no-oping), and the measured-fit card explains a clamped apply with a toast (`toast.drawerSizeLimitedByShape`, translated in all 14 locales) instead of dismissing as if the fit landed.
6. **Two half-unit ceilings could disagree.** `unitsFor` (pen auto-grow/import) and `minDrawerUnitsForOutline` (resize clamp) now share `ceilHalfUnits`, whose epsilon keeps float noise at an exact boundary (e.g. 4 × 45.3mm) from growing the drawer by half a unit.

## Test plan

- [x] New: pitch-floor tests (both commands, incl. refuse-clear + square-pitch-drives-both-axes), single-axis import grow, shrink-to-bbox outline drop (command + store), stale-echo confirm + no-seed, offset-shape floor (max, not width), `ceilHalfUnits` boundary cases, fractional-edge non-square cell-representability
- [x] Fixed a latent test bug: two CornerCutsDialog fixtures were hand-rotated off the canonical `cornerCutVertices` order (the index-wise echo check is order-sensitive by contract)
- [x] Full unit+dom suite: 1288 files / 17227 tests green; `pnpm run typecheck`; `check:i18n`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the custom drawer perimeter to prevent any implicit mutations. Clamps grid pitch and resize to the shape, fixes import grow targets, validates corner-cuts echoes, and surfaces size floors in the UI with a toast. Addresses #3149.

- **Bug Fixes**
  - Clamp grid pitch with `gridPitchFloors`; refuse clearing Y to square when the square pitch would clip; square pitch honors both axes and floors round to 0.01mm to resist float noise.
  - Clamp drawer shrink with `drawerSizeFloors`; floors count from the shape’s far edge (offset shapes), and a shrink landing on the bounding rectangle drops the outline via `isOutlineFullRectangle`.
  - Import grow now maxes each axis against the current drawer; `unitsFor` shares `ceilHalfUnits` with the clamp to avoid float-noise half-unit bumps.
  - CornerCutsDialog seeds only when the corners echo reproduces the current vertices (`cornerCutsMatchVertices`); otherwise confirm and don’t seed.
  - UI binds width/depth steppers to the shape floor (desktop + mobile) and shows `toast.drawerSizeLimitedByShape` when a measured fit is clamped (translated in 14 locales).

<sup>Written for commit 6ffaa390c7ac1302037d9d315d0492a742e86e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

