### PR TITLE
fix(bin-designer): keep the wall-cutout corner radius independent of bin height (#3162)

### DIFF
--- a/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeInteriorDividerCutouts } from './wallCutoutBuilder';
+import { autoCornerRadius, computeInteriorDividerCutouts } from './wallCutoutBuilder';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams, DividerOverride } from '@/features/bin-designer/types';
 
@@ -220,5 +220,16 @@ describe('computeInteriorDividerCutouts', () => {
       WALL_HEIGHT
     );
     expect(cut.cutW).toBeCloseTo(10, 6);
+  });
+});
+
+describe('autoCornerRadius', () => {
+  it('derives from the cutout width alone — bin height must not move it (#3162)', () => {
+    // The regression: a height term (min(width, height) * 0.15) made raising
+    // the bin height balloon the corner radius of an untouched cutout
+    // (~2.8mm at 3u → the 5mm clamp at 6u). Width-only keeps it stable.
+    expect(autoCornerRadius(98)).toBe(5); // wide slot hits the 5mm cap
+    expect(autoCornerRadius(20)).toBeCloseTo(3, 9); // 15% slope in range
+    expect(autoCornerRadius(1)).toBe(0.5); // floor for tiny slots
   });
 });

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -29,9 +29,15 @@ import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
 // Re-export for consumers that were importing from this module
 export { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
 
-/** Auto-compute corner radius: 15% of the smaller dimension, clamped to [0.5, 5] mm. */
-function autoCornerRadius(cutWidth: number, cutHeight: number): number {
-  return Math.max(0.5, Math.min(5, Math.min(cutWidth * 0.15, cutHeight * 0.15)));
+/**
+ * Auto-compute corner radius: 15% of the cutout's span, clamped to [0.5, 5] mm.
+ * Deliberately independent of the cut height — at 100% height the cut tracks
+ * the wall, so a height term makes the bin's HEIGHT change the corner look of
+ * an otherwise untouched cutout (#3162). Degenerately short or narrow cutouts
+ * are still bounded by the callers' width/2 and height/2 guards.
+ */
+export function autoCornerRadius(cutWidth: number): number {
+  return Math.max(0.5, Math.min(5, cutWidth * 0.15));
 }
 
 /** Funnel taper ratio: bottom width is 60% of top width. */
@@ -74,7 +80,7 @@ export function buildCutoutProfile(
 
     case 'funnel': {
       // Tapered U: wider at top, narrower at bottom with rounded corners.
-      const cornerR = autoCornerRadius(cutWidth, userCutHeight);
+      const cornerR = autoCornerRadius(cutWidth);
       const safeR = Math.min(cornerR, cutWidth / 2 - 0.01, userCutHeight / 2 - 0.01);
 
       const topHW = cutWidth / 2;
@@ -92,7 +98,7 @@ export function buildCutoutProfile(
 
     default: {
       // U-shape: rounded rectangle (existing behavior)
-      const cornerR = autoCornerRadius(cutWidth, userCutHeight);
+      const cornerR = autoCornerRadius(cutWidth);
       const safeR = Math.min(cornerR, cutWidth / 2 - 0.01, userCutHeight / 2 - 0.01);
       if (safeR > 0.1) {
         return drawRoundedRectangle(cutWidth, totalHeight, safeR);
@@ -294,7 +300,9 @@ function buildWallCutoutCutsInScope(
   const cellMask = params.cellMask;
   const sides: PolygonSideGeometry[] = isPartialMask(cellMask)
     ? (['front', 'back', 'left', 'right'] as const)
-        .map((key) => resolvePolygonSideGeometry(cellMask, pitchFromParams(params), wallThickness, key))
+        .map((key) =>
+          resolvePolygonSideGeometry(cellMask, pitchFromParams(params), wallThickness, key)
+        )
         .filter((g): g is PolygonSideGeometry => g !== null)
     : [
         { key: 'front', wallSpan: innerW, x: 0, y: -innerD / 2, rotateZ: 0 },


### PR DESCRIPTION
## Summary

Fixes #3162 — the U-shape (and funnel) wall-cutout corner radius changed when only the bin's height changed.

`autoCornerRadius` derived the radius from `min(cutWidth, cutHeight) × 0.15` (clamped [0.5, 5]mm). At 100% cutout height the cut height tracks the wall, so raising the bin from 3u to 6u ballooned the radius of an untouched cutout (~2.8mm → the 5mm clamp in the reported setup). The radius now derives from the cutout's **span only** — the dimension the corner curve is visually read against — still clamped to [0.5, 5]mm, with the callers' existing `width/2 − 0.01` / `height/2 − 0.01` degeneracy guards unchanged, so short or narrow cutouts still shrink safely.

## Verification

- New unit test pins the width-only formula (slope, floor, cap) with the #3162 regression noted.
- Real-WASM `binGenerator.scenario.wallCutouts` and `binGenerator.export.wallCutouts` suites pass with zero snapshot churn (existing fixtures were already width-limited; only tall-wall configurations like the report change).
- Full unit project (9,358 tests) + typecheck green.

Closes #3162

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3162 by making wall-cutout corner radius independent of bin height. `autoCornerRadius` now uses the cutout width only, keeping U and funnel cutouts visually stable across bin sizes.

- **Bug Fixes**
  - Compute radius as 15% of cutout width, clamped to [0.5, 5] mm; removed height term.
  - Kept existing safety guards (`width/2 − 0.01`, `height/2 − 0.01`).
  - Added unit test for the width-only formula; WASM suites pass with no snapshot churn.

<sup>Written for commit ed8a8d4e63c7f3485821a5cb9fbf3e3b715151ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

