### PR TITLE
fix(baseplate): keep shaped-plate seam connectors at every junction inside the perimeter (#3163)

### DIFF
--- a/src/features/baseplate/types/tiling.ts
+++ b/src/features/baseplate/types/tiling.ts
@@ -9,7 +9,12 @@
 // MarginPiece lives in shared so the generation worker can build a rail without
 // a cross-feature import; imported here for `BaseplateTiling` and re-exported
 // for baseplate-local consumers.
-import type { BaseplateEdgeKind, MarginCorner, MarginPiece } from '@/shared/types/bin';
+import type {
+  BaseplateEdgeKind,
+  ConnectorBoundaryFilter,
+  MarginCorner,
+  MarginPiece,
+} from '@/shared/types/bin';
 
 export type { MarginCorner, MarginPiece };
 
@@ -47,6 +52,14 @@ export interface BaseplatePiece {
   readonly fractionalEdgeX: 'start' | 'end' | 'none';
   readonly fractionalEdgeY: 'start' | 'end' | 'none';
   readonly edges: PieceEdges;
+  /**
+   * Per-side allowed connector positions (piece-centered mm on the seam's
+   * boundary axis), in the piece's actual (world) orientation — present only
+   * when a shaped plate keeps a join edge but gates its connectors to the
+   * sub-span inside the perimeter (#3163). `pieceToBaseplateParams` rotates it
+   * into the canonical frame alongside the other positional fields.
+   */
+  readonly connectorFilter?: ConnectorBoundaryFilter;
   /**
    * Rotation in degrees (0 or 180) to apply to the generated mesh when placing
    * this piece. Non-zero only under `preferIdenticalPieces`: opposite-corner

--- a/src/features/baseplate/utils/connectorKeys.test.ts
+++ b/src/features/baseplate/utils/connectorKeys.test.ts
@@ -272,3 +272,37 @@ describe('keyed margin seams (issue #2866)', () => {
     expect(countConnectorKeys(tiling, params)).toBe(splitKeys + marginJunctions(params).length);
   });
 });
+
+describe('shaped-plate seam gating (#3163)', () => {
+  it('skips the junctions the planner gated off a crossed seam', () => {
+    const U = 42;
+    // Diagonal chamfer across the top-right quadrant (x + y = 12u): the seams
+    // into B2 stay joined but lose their junction nearest the diagonal.
+    const chamfer = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 8 * U, y: 0 },
+        { x: 8 * U, y: 4 * U },
+        { x: 4 * U, y: 8 * U },
+        { x: 0, y: 8 * U },
+      ],
+    };
+    const params = makeParams({
+      width: 8,
+      depth: 8,
+      connectorNubs: true,
+      connectorStyle: 'dovetailKey',
+      outline: chamfer,
+    });
+    const tiling = computeBaseplateTiling(params, 4.5 * U);
+    const junctions = computeSeamJunctions(tiling, params);
+    // 12 ungated junctions minus the two the diagonal crosses (y = 126 on the
+    // vertical seam, x = 126 on the horizontal one).
+    expect(junctions).toHaveLength(10);
+    const verticalSeam = junctions
+      .filter((j) => j.axis === 'x' && Math.abs(j.xMm) < 1e-6)
+      .map((j) => j.yMm)
+      .sort((a, b) => a - b);
+    expect(verticalSeam).toEqual([-126, -84, -42, 42, 84]);
+  });
+});

--- a/src/features/baseplate/utils/connectorKeys.ts
+++ b/src/features/baseplate/utils/connectorKeys.ts
@@ -39,7 +39,7 @@ export interface SeamJunction {
  * (rather than imported) to avoid a cross-feature dependency on the generation
  * worker; parity is guarded by unit tests.
  */
-function interiorBoundaryOffsetsMm(
+export function interiorBoundaryOffsetsMm(
   units: number,
   gridUnitMm: number,
   fractionalEdge: 'start' | 'end' | 'none'
@@ -107,15 +107,23 @@ export function computeSeamJunctions(
       const centerX = piece.gridOffsetX * gx + pieceWmm / 2 - totalWmm / 2;
       const centerY = piece.gridOffsetY * gy + pieceDmm / 2 - totalDmm / 2;
 
+      // A shaped plate can gate a seam's connectors to a sub-span (#3163) —
+      // a key only exists where the pieces actually cut grooves.
+      const allowed = (side: 'right' | 'back', off: number): boolean => {
+        const filter = piece.connectorFilter?.[side];
+        return filter === undefined || filter.some((a) => Math.abs(a - off) < 0.05);
+      };
       if (piece.edges.right === 'join') {
         const seamX = piece.gridOffsetX * gx + pieceWmm - totalWmm / 2;
         for (const off of interiorBoundaryOffsetsMm(piece.depthUnits, gy, piece.fractionalEdgeY)) {
+          if (!allowed('right', off)) continue;
           junctions.push({ xMm: seamX, yMm: centerY + off, axis: 'x' });
         }
       }
       if (piece.edges.back === 'join') {
         const seamY = piece.gridOffsetY * gy + pieceDmm - totalDmm / 2;
         for (const off of interiorBoundaryOffsetsMm(piece.widthUnits, gx, piece.fractionalEdgeX)) {
+          if (!allowed('back', off)) continue;
           junctions.push({ xMm: centerX + off, yMm: seamY, axis: 'y' });
         }
       }

--- a/src/features/baseplate/utils/pieceFingerprint.ts
+++ b/src/features/baseplate/utils/pieceFingerprint.ts
@@ -78,6 +78,16 @@ export function computePieceFingerprint(params: ResolvedBaseplateParams): string
     parts.push(`ol:${hashOutline(canonicalStartOutline(params.outline))}`);
   }
 
+  // Per-seam connector gating (#3163): pieces whose seams carry different
+  // allowed-connector subsets cut different grooves and must never dedupe.
+  // Already expressed in the piece's canonical (post-rotation) frame.
+  if (params.connectorFilter !== undefined) {
+    const cf = params.connectorFilter;
+    const fmt = (side: 'left' | 'right' | 'front' | 'back'): string =>
+      cf[side] === undefined ? '' : cf[side].map((v) => v.toFixed(2)).join(',');
+    parts.push(`cf:${(['left', 'right', 'front', 'back'] as const).map(fmt).join(';')}`);
+  }
+
   // Edge classification (exterior vs join) affects geometry through two
   // independent channels — and keying on the raw labels over-distinguishes
   // pieces that are actually identical:

--- a/src/features/baseplate/utils/splitPlanner.test.ts
+++ b/src/features/baseplate/utils/splitPlanner.test.ts
@@ -1743,17 +1743,86 @@ describe('shaped plates (outline-aware splitting)', () => {
     expect(b2Params.outline?.vertices).toContainEqual({ x: 0, y: 4 * U });
   });
 
-  it('butts a seam the outline crosses (partial seam)', () => {
+  it('keeps a crossed seam joined at the junctions inside the outline (#3163)', () => {
     const tiling = computeBaseplateTiling(shapedParams(CHAMFER_OUTLINE), BED);
     const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
-    // The diagonal crosses both of B2's join seams → butt joints on both sides.
+    // The diagonal (x + y = 12u) crosses both of B2's join seams, but the
+    // junctions whose one-cell bands sit fully inside keep their connectors —
+    // the old whole-span rule butted the entire seam. On B2's left seam
+    // (x = 4U, span y 4U..8U, center 6U) the junctions at y = 5U and 6U are
+    // inside (piece-centered offsets −U and 0); y = 7U is crossed.
+    const b2 = byLabel.get('B2');
+    expect(b2?.edges.left).toBe('join');
+    expect(b2?.connectorFilter?.left).toEqual([-U, 0]);
+    expect(b2?.edges.front).toBe('join');
+    expect(b2?.connectorFilter?.front).toEqual([-U, 0]);
+    // Both flanks of each seam gate identically, so grooves stay paired.
+    const a2 = byLabel.get('A2');
+    const b1 = byLabel.get('B1');
+    expect(a2?.edges.right).toBe('join');
+    expect(a2?.connectorFilter?.right).toEqual([-U, 0]);
+    expect(b1?.edges.back).toBe('join');
+    expect(b1?.connectorFilter?.back).toEqual([-U, 0]);
+    // The body seams away from the diagonal keep every connector — no filter,
+    // byte-stable with unshaped plates.
+    const a1 = byLabel.get('A1');
+    expect(a1?.edges.right).toBe('join');
+    expect(a1?.edges.back).toBe('join');
+    expect(a1?.connectorFilter).toBeUndefined();
+  });
+
+  it('still butts a seam with no inside junction at all', () => {
+    // A step notch leaves B2 only a half-cell sliver (x ∈ [4U, 4.5U]) along
+    // its left seam: every junction's right-hand band crosses the outline, so
+    // the seam demotes to exterior on BOTH flanks, exactly like before.
+    const step: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 8 * U, y: 0 },
+        { x: 8 * U, y: 4 * U },
+        { x: 4.5 * U, y: 4 * U },
+        { x: 4.5 * U, y: 8 * U },
+        { x: 0, y: 8 * U },
+      ],
+    };
+    const tiling = computeBaseplateTiling(shapedParams(step), BED);
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
     expect(byLabel.get('B2')?.edges.left).toBe('exterior');
-    expect(byLabel.get('B2')?.edges.front).toBe('exterior');
     expect(byLabel.get('A2')?.edges.right).toBe('exterior');
-    expect(byLabel.get('B1')?.edges.back).toBe('exterior');
-    // The body seams away from the diagonal keep connectors.
-    expect(byLabel.get('A1')?.edges.right).toBe('join');
-    expect(byLabel.get('A1')?.edges.back).toBe('join');
+  });
+
+  it('rotates the connector filter alongside the other positional fields', () => {
+    const parent = shapedParams(CHAMFER_OUTLINE, { preferIdenticalPieces: true });
+    const tiling = computeBaseplateTiling(parent, BED);
+    const rotated = tiling.pieces.find(
+      (p) => p.placementRotationDeg === 180 && p.connectorFilter !== undefined
+    );
+    if (rotated === undefined || rotated.connectorFilter === undefined) {
+      // The canonicalization may orient the filtered pieces at 0° — then the
+      // pass-through branch is covered by the assertions above; only assert
+      // the rotation math when a rotated filtered piece exists.
+      return;
+    }
+    const gen = pieceToBaseplateParams(rotated, parent);
+    const sides = ['left', 'right', 'front', 'back'] as const;
+    const opposite = { left: 'right', right: 'left', front: 'back', back: 'front' } as const;
+    for (const side of sides) {
+      const worldFilter = rotated.connectorFilter[side];
+      if (worldFilter === undefined) continue;
+      expect(gen.connectorFilter?.[opposite[side]]).toEqual(
+        [...worldFilter].map((v) => -v).sort((x, y) => x - y)
+      );
+    }
+  });
+
+  it('distinguishes fingerprints by connector gating (#3163)', () => {
+    const parent = shapedParams(CHAMFER_OUTLINE);
+    const tiling = computeBaseplateTiling(parent, BED);
+    const byLabel = new Map(tiling.pieces.map((p) => [p.label, p]));
+    const b1 = byLabel.get('B1') as BaseplatePiece;
+    const ungated = pieceToBaseplateParams({ ...b1, connectorFilter: undefined }, parent);
+    const gated = pieceToBaseplateParams(b1, parent);
+    expect(computePieceFingerprint(gated)).not.toBe(computePieceFingerprint(ungated));
   });
 
   // Point-symmetric radius cut on all four corners: a 1-unit arc trims each

--- a/src/features/baseplate/utils/splitPlanner.ts
+++ b/src/features/baseplate/utils/splitPlanner.ts
@@ -16,8 +16,13 @@
  * fit, otherwise become a separate piece.
  */
 
-import type { BaseplateEdgeKind, ResolvedBaseplateParams } from '@/shared/types/bin';
+import type {
+  BaseplateEdgeKind,
+  ConnectorBoundaryFilter,
+  ResolvedBaseplateParams,
+} from '@/shared/types/bin';
 import { isExteriorEdge, isMarginSeamStyle } from '@/shared/types/bin';
+import { interiorBoundaryOffsetsMm } from './connectorKeys';
 // The fit checker subtracts the tongue protrusion from the bed budget on male
 // join edges — otherwise pieces that compute to exactly the bed width on paper
 // exceed it as STLs (#1498).
@@ -984,26 +989,50 @@ function applyOutlineToTiling(
   const classAt = (col: number, row: number): RegionClass =>
     classByKey.get(`${col},${row}`) ?? 'outside';
 
-  // A seam keeps its connector only when the one-cell band on BOTH sides of
-  // the entire shared span is fully inside the outline. Bands are pure GRID
-  // extents (seams are interior, padding-free), offset into plate-local mm.
-  const fullSeam = (piece: BaseplatePiece, side: 'left' | 'right' | 'front' | 'back'): boolean => {
+  // Per-junction connector gating (#3163). A junction keeps its connector when
+  // the one-cell band on BOTH sides of its along-seam cell pair is fully
+  // inside the outline — the same insideness rule the old whole-span check
+  // used, but applied per cell boundary instead of all-or-nothing: a seam that
+  // merely grazes the shaped boundary used to lose every connector along it.
+  // Windows are pure GRID extents (seams are interior, padding-free), offset
+  // into plate-local mm.
+  //
+  // Returns 'all' (every junction inside → no filter, byte-stable with
+  // unshaped plates), 'none' (no junction survives → the seam demotes to
+  // exterior, as before), or the allowed subset in piece-centered mm along
+  // the seam's boundary axis — the exact coordinate `buildConnectors` and
+  // `computeSeamJunctions` place connectors at.
+  const seamGate = (
+    piece: BaseplatePiece,
+    side: 'left' | 'right' | 'front' | 'back'
+  ): 'all' | 'none' | number[] => {
     const gx0 = padL + piece.gridOffsetX * u;
     const gx1 = padL + (piece.gridOffsetX + piece.widthUnits) * u;
     const gy0 = padF + piece.gridOffsetY * uy;
     const gy1 = padF + (piece.gridOffsetY + piece.depthUnits) * uy;
-    if (side === 'left' || side === 'right') {
-      const xB = side === 'left' ? gx0 : gx1;
-      return (
-        classifyRect(outline, xB - u, gy0, xB, gy1) === 'inside' &&
-        classifyRect(outline, xB, gy0, xB + u, gy1) === 'inside'
-      );
-    }
-    const yB = side === 'front' ? gy0 : gy1;
-    return (
-      classifyRect(outline, gx0, yB - uy, gx1, yB) === 'inside' &&
-      classifyRect(outline, gx0, yB, gx1, yB + uy) === 'inside'
-    );
+    const vertical = side === 'left' || side === 'right';
+    const alongPitch = vertical ? uy : u;
+    const offsets = vertical
+      ? interiorBoundaryOffsetsMm(piece.depthUnits, uy, piece.fractionalEdgeY)
+      : interiorBoundaryOffsetsMm(piece.widthUnits, u, piece.fractionalEdgeX);
+    // A 1-cell span has no junctions, so there is nothing to gate — the seam
+    // stays a friction-fit butt joint exactly like its unshaped counterpart.
+    if (offsets.length === 0) return 'all';
+
+    const seam = vertical ? (side === 'left' ? gx0 : gx1) : side === 'front' ? gy0 : gy1;
+    const centerAlong = vertical ? (gy0 + gy1) / 2 : (gx0 + gx1) / 2;
+    const allowed = offsets.filter((off) => {
+      const lo = centerAlong + off - alongPitch / 2;
+      const hi = centerAlong + off + alongPitch / 2;
+      return vertical
+        ? classifyRect(outline, seam - u, lo, seam, hi) === 'inside' &&
+            classifyRect(outline, seam, lo, seam + u, hi) === 'inside'
+        : classifyRect(outline, lo, seam - uy, hi, seam) === 'inside' &&
+            classifyRect(outline, lo, seam, hi, seam + uy) === 'inside';
+    });
+    if (allowed.length === 0) return 'none';
+    if (allowed.length === offsets.length) return 'all';
+    return allowed;
   };
 
   const NEIGHBOR: Record<'left' | 'right' | 'front' | 'back', readonly [number, number]> = {
@@ -1023,11 +1052,22 @@ function applyOutlineToTiling(
     if (cls === 'outside') continue;
 
     const edges = { ...piece.edges };
+    const filter: Partial<Record<'left' | 'right' | 'front' | 'back', number[]>> = {};
+    let hasFilter = false;
     for (const side of ['left', 'right', 'front', 'back'] as const) {
       if (edges[side] !== 'join') continue;
       const [dc, dr] = NEIGHBOR[side];
-      const neighborDropped = classAt(piece.col + dc, piece.row + dr) === 'outside';
-      if (neighborDropped || !fullSeam(piece, side)) edges[side] = 'exterior';
+      if (classAt(piece.col + dc, piece.row + dr) === 'outside') {
+        edges[side] = 'exterior';
+        continue;
+      }
+      const gate = seamGate(piece, side);
+      if (gate === 'none') {
+        edges[side] = 'exterior';
+      } else if (gate !== 'all') {
+        filter[side] = gate;
+        hasFilter = true;
+      }
     }
 
     // Canonicalize from the RECLASSIFIED edges: the 180° share only applies once
@@ -1040,6 +1080,7 @@ function applyOutlineToTiling(
       edges,
       placementRotationDeg: needs180 ? 180 : 0,
       ...(cls === 'partial' ? { outlineWindowOriginMm: { x: w.x0, y: w.y0 } } : {}),
+      ...(hasFilter ? { connectorFilter: filter } : {}),
     });
   }
 
@@ -1158,6 +1199,22 @@ export function pieceToBaseplateParams(
     return rotateOutline180(local, windowW, windowD);
   })();
 
+  // Like the outline, the connector filter is positional: under `rot` the
+  // sides swap (L↔R, F↔B) and the piece-centered along-seam offsets negate
+  // (a 180° turn about the center). Sorted so equal gatings hash equal.
+  const connectorFilter = ((): ConnectorBoundaryFilter | undefined => {
+    const f = piece.connectorFilter;
+    if (f === undefined) return undefined;
+    if (!rot) return f;
+    const neg = (a: readonly number[]): number[] => a.map((v) => -v).sort((x, y) => x - y);
+    return {
+      ...(f.right !== undefined ? { left: neg(f.right) } : {}),
+      ...(f.left !== undefined ? { right: neg(f.left) } : {}),
+      ...(f.back !== undefined ? { front: neg(f.back) } : {}),
+      ...(f.front !== undefined ? { back: neg(f.front) } : {}),
+    };
+  })();
+
   return {
     width: piece.widthUnits,
     depth: piece.depthUnits,
@@ -1166,6 +1223,7 @@ export function pieceToBaseplateParams(
     // axis identity, so the parent's X/Y pitch carries straight through.
     gridUnitMmY: parentParams.gridUnitMmY,
     outline: pieceOutline,
+    connectorFilter,
     magnetHoles: parentParams.magnetHoles,
     magnetDiameter: parentParams.magnetDiameter,
     magnetDepth: parentParams.magnetDepth,

--- a/src/features/generation/worker/generators/baseplateCacheKeys.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.ts
@@ -115,6 +115,13 @@ export function meshCacheKey(
     params.edges?.right ?? '',
     params.edges?.front ?? '',
     params.edges?.back ?? '',
+    // Per-seam connector gating on shaped plates (#3163) — empty when absent,
+    // so every ungated plate keeps its cache identity.
+    params.connectorFilter !== undefined
+      ? `cf:${(['left', 'right', 'front', 'back'] as const)
+          .map((s) => params.connectorFilter?.[s]?.map((v) => v.toFixed(2)).join(',') ?? '')
+          .join(';')}`
+      : '',
     params.connectorNubs ?? false,
     params.invertDovetails ?? false,
     params.preferIdenticalPieces ?? false,

--- a/src/features/generation/worker/generators/baseplateConnectors.ts
+++ b/src/features/generation/worker/generators/baseplateConnectors.ts
@@ -392,8 +392,13 @@ export function buildConnectors(
       if (!edgeCarriesSlot(edges[def.side], allEdgeSlots, def.paddingMm)) continue;
       if (def.boundaries.length === 0) continue;
       const pt = ptFor(def);
+      // A shaped plate can gate this seam's connectors to the sub-span whose
+      // bands sit inside the perimeter (#3163) — positions come from the
+      // planner in the same piece-centered mm as `def.boundaries`.
+      const allowed = params.connectorFilter?.[def.side];
 
       for (const bp of def.boundaries) {
+        if (allowed !== undefined && !allowed.some((a) => Math.abs(a - bp) < 0.05)) continue;
         const w = def.wallPos;
         const d = def.protrudeDir;
 

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
@@ -307,6 +307,41 @@ describe('baseplate outline geometry', () => {
     expect(bb.minX).toBeLessThan(-2 * U - 0.5);
   });
 
+  it('gates seam connectors to the filtered junctions (#3163)', { timeout: 240_000 }, () => {
+    // Same partial piece, but the planner gated the left seam to the single
+    // junction at piece-centered −42: connectors must exist there and ONLY
+    // there, and the ungated piece must differ — the filter is a
+    // geometry-affecting control, not a label.
+    const gen = getGenerateBaseplate();
+    const outline: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U, y: 0 },
+        { x: 4 * U, y: 3 * U },
+        { x: 3 * U, y: 3 * U },
+        { x: 3 * U, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const base = defaults({
+      outline,
+      connectorNubs: true,
+      edges: { left: 'join', right: 'exterior', front: 'exterior', back: 'exterior' },
+    });
+    const gated = gen({ ...base, connectorFilter: { left: [-U] } }, NO_OP, true);
+    assertStructurallyValid(gated, 'gated partial piece');
+    const full = gen(base, NO_OP, true);
+
+    // Vertices past the left face (mesh x = −84) are connector geometry.
+    // Junctions sit at piece-centered y ∈ {−42, 0, +42}.
+    const allowedWindow = countVerticesIn(gated.vertices, -95, -52, -84.5, -32);
+    const gatedWindows = countVerticesIn(gated.vertices, -95, -10, -84.5, 52);
+    const fullWindows = countVerticesIn(full.vertices, -95, -10, -84.5, 52);
+    expect(allowedWindow).toBeGreaterThan(0);
+    expect(gatedWindows).toBe(0);
+    expect(fullWindows).toBeGreaterThan(0);
+  });
+
   it.skipIf(BREPKIT_CORNER_NOTCH_INTERSECT_BROKEN)(
     'scales with a non-standard grid unit',
     { timeout: 240_000 },

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -304,6 +304,14 @@ export interface BaseplateEdges {
   readonly back: BaseplateEdgeKind;
 }
 
+/**
+ * Per-side allowed connector positions along a join seam (piece-centered mm on
+ * the seam's boundary axis). See `ResolvedBaseplateParams.connectorFilter`.
+ */
+export type ConnectorBoundaryFilter = Partial<
+  Record<'left' | 'right' | 'front' | 'back', readonly number[]>
+>;
+
 /** A plate corner, named by the integral plate's exterior face pair. */
 export type MarginCorner = 'tl' | 'tr' | 'bl' | 'br';
 
@@ -421,6 +429,15 @@ export interface ResolvedBaseplateParams {
   readonly wholeCellsOnly?: boolean;
   /** Edge classification for split pieces — omit for single (unsplit) baseplates. */
   readonly edges?: BaseplateEdges;
+  /**
+   * Per-side allowed connector positions along a join seam, in piece-centered
+   * mm on the seam's boundary axis (the same coordinate `buildConnectors`
+   * places dovetails at). Present only when a shaped plate keeps a seam but
+   * gates its connectors to the sub-span whose one-cell bands sit fully inside
+   * the perimeter (#3163). Absent side (or absent map) = every interior cell
+   * boundary carries a connector, byte-identical to unshaped plates.
+   */
+  readonly connectorFilter?: ConnectorBoundaryFilter;
   /**
    * Non-rectangular plate boundary in plate-local mm (origin bottom-left of
    * the plate's outer extent). Cells fully inside get standard pockets; cells


### PR DESCRIPTION
## Summary

Fixes #3163 — sub-divisions of a custom-perimeter (shaped) plate were missing baseplate connectors on seams the boundary merely grazed.

### Root cause

`applyOutlineToTiling`'s seam rule was all-or-nothing: a join edge kept its connectors only when the one-cell band on **both sides of the entire shared span** was fully inside the outline. On a shaped plate (#3149 setup, #3109 lineage) almost every seam touches the boundary somewhere, so whole seams — including their deep-interior junctions — printed as plain butt joints (the red regions in the issue screenshot).

### Fix

- **Per-junction gating** (`splitPlanner.ts`): each interior cell boundary keeps its connector when the one-cell bands flanking its along-seam cell pair are fully inside — the same insideness rule, applied at connector granularity. A seam with ≥1 surviving junction stays `join` and carries the allowed positions (`connectorFilter`, piece-centered mm — the exact coordinate connectors are placed at); a seam with none demotes to exterior as before. Both flanks gate against identical plate-local windows, so tongues/grooves stay paired.
- **Rotation-aware bridge**: `pieceToBaseplateParams` rotates the filter with the other 180°-canonicalized positional fields (side swap + offset negation) under `preferIdenticalPieces`.
- **Worker** (`baseplateConnectors.ts`): skips gated boundaries for every style (dovetail/puzzle/paired/dovetailKey/snapClip).
- **Seated keys** (`connectorKeys.ts`): `computeSeamJunctions` (and the key count derived from it) skips gated junctions, so preview keys only appear where grooves exist.
- **Identity**: the filter joins the piece fingerprint and the mesh cache key, so differently-gated pieces never dedupe or serve stale meshes; ungated plates emit no filter and stay byte-identical (cache-stable).

### Verification

- Planner tests: crossed seams keep exactly the inside junctions (positions asserted), both flanks pair, zero-junction seams still butt, filter rotation math, fingerprint distinction.
- Seam-key test: a chamfered split plate emits 10 of 12 junctions, gated positions absent.
- New real-WASM **differential scenario**: a gated piece emits connector geometry at the allowed junction and none at gated ones, while the ungated twin differs — plus the outline/dovetail/rotShare/puzzle/snapClip scenario suites all green with zero snapshot churn.
- Full unit (9,379) + dom (7,969) suites, typecheck, lint green.

Closes #3163

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps seam connectors on shaped plates at every junction inside the outline. Seams the outline grazes no longer drop all connectors or turn into butt joints.

- **Bug Fixes**
  - Planner gates connectors per junction: keep positions where both flanking one-cell bands are inside; seams with no surviving junctions demote to exterior.
  - Worker and key/clip previews honor a per-side `connectorFilter` so connectors only generate at allowed positions.
  - Rotation-aware: the filter rotates with 180° canonicalization (side swap + offset negation) for identical-piece preference.
  - Identity and caching: piece fingerprint and mesh cache key include the filter; ungated plates omit it and remain cache-stable.
  - Tests cover crossed seams, pairing on both flanks, rotation math, and WASM geometry; all suites pass.

<sup>Written for commit b83fbb3b9e7580b8204af2c533c6dd712b4b6bf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

