### PR TITLE
fix(design-system): remove the duplicate focus outline on wrapper-based inputs

### DIFF
--- a/src/design-system/Combobox/Combobox.tsx
+++ b/src/design-system/Combobox/Combobox.tsx
@@ -195,6 +195,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(function Com
   return (
     <div
       ref={wrapperRef}
+      data-focus-ring
       className={cn(WRAPPER_STATIC, interactiveTransition, wrapperSize[size], className)}
     >
       {activeGhost && (

--- a/src/design-system/Input/Input.test.tsx
+++ b/src/design-system/Input/Input.test.tsx
@@ -54,6 +54,13 @@ describe('Input', () => {
     });
   });
 
+  describe('focus ring', () => {
+    it('marks the wrapper so the global focus outline is suppressed', () => {
+      const { container } = render(<Input aria-label="Search" />);
+      expect(container.firstChild).toHaveAttribute('data-focus-ring');
+    });
+  });
+
   describe('error state', () => {
     it('sets aria-invalid when error', () => {
       render(<Input error aria-label="Email" />);

--- a/src/design-system/Input/Input.tsx
+++ b/src/design-system/Input/Input.tsx
@@ -168,6 +168,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 
     return (
       <div
+        data-focus-ring
         className={cn(inputWrapperVariants({ size, error, disabled, fullWidth }), wrapperClassName)}
       >
         {leftIcon && (

--- a/src/index.css
+++ b/src/index.css
@@ -491,6 +491,16 @@ textarea:focus-visible {
   outline: none;
 }
 
+/* Opt-out for fields that draw their own focus ring, either on the control or
+   on a wrapper that also holds icons. The rules above are unlayered, so they
+   beat Tailwind's layered `outline-none`; without this the control's square
+   outline renders nested inside the wrapper's rounded ring. Mark whichever
+   element paints the ring with `data-focus-ring`. */
+[data-focus-ring] :is(input, textarea, select):focus-visible,
+:is(input, textarea, select)[data-focus-ring]:focus-visible {
+  outline: none;
+}
+
 /* Command palette input - custom focus handling */
 [cmdk-input]:focus {
   outline: none;

--- a/src/shared/components/ItemListShell/ItemSearch/ItemSearch.tsx
+++ b/src/shared/components/ItemListShell/ItemSearch/ItemSearch.tsx
@@ -41,6 +41,7 @@ export function ItemSearch({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        data-focus-ring
         className="w-full pl-9 pr-8 py-2 bg-surface border border-stroke rounded-lg text-sm text-content placeholder:text-content-tertiary focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent"
         aria-label={ariaLabel}
       />


### PR DESCRIPTION
Focused text fields painted two focus indicators: the wrapper's rounded accent border/ring, plus a square 2px outline on the inner `<input>`. The inner rectangle started after the left icon, so it read as an outline nested inside the field.

## Cause

`Input` is a wrapper pattern: the rounded border and `focus-within` ring live on a `<div>` (`Input.tsx:11-16`), while the `<input>` itself has `border-radius: 0`. The input already carried `outline-none` to opt out of the global focus rule, but that never applied.

Tailwind v4 emits every utility inside `@layer utilities`. The `FOCUS STATES` block in `src/index.css` is unlayered, and unlayered rules beat layered ones regardless of specificity, so `input:focus-visible { outline: 2px solid ... }` always won. No `!important` involved, which is why the component reads as though it opted out.

`:focus:not(:focus-visible)` does not rescue this either: browsers match `:focus-visible` on text inputs even for mouse clicks, so the outline showed on click as well as on tab.

## Change

An explicit opt-out in `index.css`, following the existing `[cmdk-input]` precedent:

```css
[data-focus-ring] :is(input, textarea, select):focus-visible,
:is(input, textarea, select)[data-focus-ring]:focus-visible {
  outline: none;
}
```

`data-focus-ring` goes on whichever element paints the ring:

- `design-system/Input` wrapper
- `design-system/Combobox` wrapper, same pattern
- `ItemListShell/ItemSearch` input, self-rounded, so it was getting border + ring + inset outline

`Textarea` and `Select` were already correct: they put `rounded-md` on the element itself, so their outline follows the border.

The global rules stay unlayered on purpose. Moving them into `@layer base` would have fixed this class of bug everywhere, but would also strip the outline from every other element using `outline-none` without a full replacement (`Menu.tsx:53` falls back to a background change), a silent accessibility regression.

## Verification

- Screenshotted the real app before and after via Playwright against the dev server. The `playwright-ct` harness does not generate Tailwind utilities, so it cannot reproduce this.
- Forced-colors mode drops `box-shadow`, leaving the input's outline as the only indicator. The `!important` block at `index.css:1248` outranks the new rule; confirmed a `2px solid` Highlight outline still renders under `forcedColors: 'active'`.
- `pnpm run typecheck` clean, eslint clean, 44 tests pass across Input/Combobox/ItemListShell.
- Added a test locking the `data-focus-ring` attribute on the `Input` wrapper. The CSS rule itself is not testable in jsdom.

The remaining indicator is a 1px accent border plus a 1px accent ring, a 2px accent perimeter, so the focus affordance is no weaker than before.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the duplicate focus outline on wrapper-based inputs and comboboxes so focused fields show a single rounded accent ring. Adds a `data-focus-ring` opt-out to suppress the inner control’s outline while keeping accessibility in forced-colors.

- **Bug Fixes**
  - Added a global CSS rule to remove `:focus-visible` outlines for `input/textarea/select` when inside or marked with `[data-focus-ring]`; existing forced-colors outline remains.
  - Applied `data-focus-ring` to the `Input` and `Combobox` wrappers, and to the self-rounded `ItemSearch` input.
  - Added a test to assert `Input` sets `data-focus-ring` on its wrapper.

<sup>Written for commit 8ee734895f78d74c3f91633885edbcfdd2c2960c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

