### PR TITLE
fix(bin-designer): meet the wall rim square on u-shape cutouts (#3173)

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
@@ -8,11 +8,11 @@ exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4336`;
 
 exports[`custom-shape > 3×3 L flat base no lip 1`] = `260`;
 
-exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5330`;
+exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5612`;
 
 exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5730`;
 
-exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `8198`;
+exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `8790`;
 
 exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `8234`;
 
@@ -24,7 +24,7 @@ exports[`custom-shape > 3×3 T with lip 1`] = `4368`;
 
 exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5808`;
 
-exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5408`;
+exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5690`;
 
 exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `9328`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`divider patterns > 2×2 honeycomb dividers 1`] = `11444`;
 
-exports[`divider patterns > dividers + interior cutouts 1`] = `10020`;
+exports[`divider patterns > dividers + interior cutouts 1`] = `10504`;
 
 exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `11884`;
 
-exports[`divider patterns > dividers + outer cutouts + handles 1`] = `14588`;
+exports[`divider patterns > dividers + outer cutouts + handles 1`] = `14956`;
 
 exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `14170`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
@@ -1,14 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `4824`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5584`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `4760`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `5230`;
 
 exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4632`;
 
 exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4632`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4436`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4952`;
 
 exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `4292`;
 

--- a/src/features/generation/worker/generators/scenarios/wallCutouts.ts
+++ b/src/features/generation/worker/generators/scenarios/wallCutouts.ts
@@ -126,6 +126,58 @@ export const wallCutouts: ScenarioCase[] = [
     },
     timeout: 60_000,
   }),
+  defineScenario('wall cutouts', 'full-height u-shape meets the rim square (#3173)', {
+    // The reporter's config: a 14mm grid with 2.6mm walls and a 100%-height
+    // cutout, so the cut's top edge lands exactly on the rim. The u-shape's top
+    // corners are square there now, which makes the boolean coplanar with the
+    // wall top — assert the result is still a clean solid.
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 10,
+      height: 5,
+      gridUnitMm: 14,
+      wallThickness: 2.6,
+      walls: {
+        enabled: true,
+        shape: 'u-shape',
+        width: 0,
+        depth: 0,
+        front: DISABLED_WALL_CUTOUT,
+        back: DISABLED_WALL_CUTOUT,
+        left: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 100 },
+        right: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 100 },
+        interior: DISABLED_WALL_CUTOUT,
+      },
+    },
+    timeout: 60_000,
+  }),
+  defineScenario('wall cutouts', 'full-height u-shape through a stacking lip (#3173)', {
+    // Same cut against a lipped wall: the true rim is the lip peak at
+    // wallHeight + LIP_HEIGHT - LIP_OVERLAP, which the overshoot clears by only
+    // ~2.1mm — the case where a 5mm corner radius left the most arc behind.
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 4,
+      height: 5,
+      gridUnitMm: 14,
+      wallThickness: 2.6,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      walls: {
+        enabled: true,
+        shape: 'u-shape',
+        width: 0,
+        depth: 0,
+        front: DISABLED_WALL_CUTOUT,
+        back: DISABLED_WALL_CUTOUT,
+        left: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 100 },
+        right: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 100 },
+        interior: DISABLED_WALL_CUTOUT,
+      },
+    },
+    timeout: 60_000,
+  }),
   defineScenario('wall cutouts', 'left-aligned cutout with offset and absolute mm width', {
     assert: 'structural',
     params: {

--- a/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
@@ -1,7 +1,24 @@
-import { describe, it, expect } from 'vitest';
-import { autoCornerRadius, computeInteriorDividerCutouts } from './wallCutoutBuilder';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { draw, getBounds, intersect } from 'brepjs';
+import type { Shape3D } from 'brepjs';
+import { isOk } from '@/core/result';
+import {
+  autoCornerRadius,
+  buildSingleCutout,
+  computeInteriorDividerCutouts,
+} from './wallCutoutBuilder';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
-import type { BinParams, DividerOverride } from '@/features/bin-designer/types';
+import type { BinParams, DividerOverride, WallCutoutShape } from '@/features/bin-designer/types';
+
+const box = (x0: number, x1: number, y0: number, y1: number, z0: number, z1: number): Shape3D =>
+  draw([x0, y0])
+    .lineTo([x1, y0])
+    .lineTo([x1, y1])
+    .lineTo([x0, y1])
+    .close()
+    .sketchOnPlane('XY', z0)
+    .extrude(z1 - z0);
 
 const INNER_W = 80;
 const INNER_D = 40;
@@ -231,5 +248,114 @@ describe('autoCornerRadius', () => {
     expect(autoCornerRadius(98)).toBe(5); // wide slot hits the 5mm cap
     expect(autoCornerRadius(20)).toBeCloseTo(3, 9); // 15% slope in range
     expect(autoCornerRadius(1)).toBe(0.5); // floor for tiny slots
+  });
+});
+
+describe('buildSingleCutout corner placement', () => {
+  beforeAll(async () => {
+    await initBrepjs();
+  }, 120_000);
+
+  // 40mm span → autoCornerRadius saturates at its 5mm cap, the worst case for
+  // #3173. OVERSHOOT is the production no-lip value ((hasLip ? LIP_HEIGHT : 0) + 2),
+  // so the cut runs from z = WALL_HEIGHT - CUT_HEIGHT up to z = WALL_HEIGHT + 2
+  // and the wall's visible rim sits at z = WALL_HEIGHT.
+  const CUT_WIDTH = 40;
+  const CUT_HEIGHT = 30;
+  const OVERSHOOT = 2;
+  const EXTRUDE_DEPTH = 8;
+  const WALL_HEIGHT = 40;
+  const CENTERED = { x: 0, y: 0, rotateZ: 0 };
+  const FLOOR_Z = WALL_HEIGHT - CUT_HEIGHT;
+
+  /**
+   * Horizontal span of the cut across the thin Z slab starting at `z`.
+   *
+   * Measured on the positioned solid rather than the 2D profile on purpose:
+   * `isInside2D` is winding-sensitive (`drawRoundedRectangle` emits a
+   * counterClockwise blueprint and calls its own centre outside), and 2D
+   * drawing booleans throw on these profiles. A 3D bounding box is immune to
+   * both, and this exercises the real overshoot/`cutZ` placement — the half of
+   * #3173 that decides whether an arc reaches the rim at all.
+   */
+  const spanAtZ = (shape: WallCutoutShape, z: number, cutHeight: number = CUT_HEIGHT): number => {
+    const cut = buildSingleCutout(
+      shape,
+      CUT_WIDTH,
+      cutHeight,
+      OVERSHOOT,
+      EXTRUDE_DEPTH,
+      WALL_HEIGHT,
+      CENTERED
+    );
+    const slab = box(-CUT_WIDTH, CUT_WIDTH, -EXTRUDE_DEPTH, EXTRUDE_DEPTH, z, z + 0.001);
+    const clipped = intersect(cut, slab);
+    expect(isOk(clipped), `slab intersection at z=${z}`).toBe(true);
+    if (!isOk(clipped)) return NaN;
+    const b = getBounds(clipped.value);
+    return b.xMax - b.xMin;
+  };
+
+  it('straddles the wall and overshoots the rim', () => {
+    // The u-shape profile switched from drawRoundedRectangle to a pen for
+    // #3173, which flips the blueprint winding (counterClockwise → clockwise).
+    // Winding can flip an extrusion's direction, so pin the placement: the cut
+    // must stay centred on the wall face in Y and still clear the rim in Z.
+    const cut = buildSingleCutout(
+      'u-shape',
+      CUT_WIDTH,
+      CUT_HEIGHT,
+      OVERSHOOT,
+      EXTRUDE_DEPTH,
+      WALL_HEIGHT,
+      CENTERED
+    );
+    const b = getBounds(cut);
+    expect(b.yMin).toBeCloseTo(-EXTRUDE_DEPTH / 2, 3);
+    expect(b.yMax).toBeCloseTo(EXTRUDE_DEPTH / 2, 3);
+    expect(b.zMin).toBeCloseTo(FLOOR_Z, 3);
+    expect(b.zMax).toBeCloseTo(WALL_HEIGHT + OVERSHOOT, 3);
+  });
+
+  it('opens the u-shape to full width at the rim (#3173)', () => {
+    // The regression: a 5mm radius only clears a 2mm overshoot over the top 2mm
+    // of its arc, so at rim level the arc had already pulled the opening in by
+    // 5 - sqrt(5² - 2²) = 1mm per side — 2mm of visible flare on the wall's rim.
+    expect(spanAtZ('u-shape', WALL_HEIGHT)).toBeCloseTo(CUT_WIDTH, 2);
+  });
+
+  it('keeps the u-shape full width through the trimmed overshoot', () => {
+    // Nothing narrows anywhere in the strip the boolean consumes, so no arc can
+    // survive down to the rim no matter how the overshoot is retuned.
+    expect(spanAtZ('u-shape', WALL_HEIGHT + OVERSHOOT - 0.001)).toBeCloseTo(CUT_WIDTH, 2);
+  });
+
+  it('still rounds the u-shape bottom corners', () => {
+    const r = autoCornerRadius(CUT_WIDTH);
+    // At the floor the arcs have run their full radius in from each side. The
+    // probe slab has thickness, over which the arc widens back out ~0.2mm, so
+    // the tolerance is loose rather than an exact CUT_WIDTH - 2r.
+    expect(spanAtZ('u-shape', FLOOR_Z)).toBeCloseTo(CUT_WIDTH - 2 * r, 0);
+  });
+
+  it('falls back to a plain rectangle when the radius degenerates', () => {
+    // userCutHeight/2 - 0.01 drives safeR below the 0.1 threshold, so all four
+    // corners stay square and the floor spans the full width.
+    const tinyHeight = 0.2;
+    expect(spanAtZ('u-shape', WALL_HEIGHT - tinyHeight, tinyHeight)).toBeCloseTo(CUT_WIDTH, 2);
+  });
+
+  it('leaves the funnel and scoop top corners square', () => {
+    // Both are already square at the top; these guard against the u-shape fix
+    // being generalised into the branches that never had the defect.
+    expect(spanAtZ('funnel', WALL_HEIGHT + OVERSHOOT - 0.001)).toBeCloseTo(CUT_WIDTH, 2);
+    expect(spanAtZ('scoop', WALL_HEIGHT + OVERSHOOT - 0.001)).toBeCloseTo(CUT_WIDTH, 2);
+  });
+
+  it('still rounds the funnel bottom corners', () => {
+    // The funnel's sides are slanted, so its floor arcs do not inset by a flat
+    // `r` per side — assert only that the floor is clearly pulled in from the
+    // nominal 60% bottom width.
+    expect(spanAtZ('funnel', FLOOR_Z)).toBeLessThan(CUT_WIDTH * 0.6 - 1);
   });
 });

--- a/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { draw, getBounds, intersect } from 'brepjs';
-import type { Shape3D } from 'brepjs';
+import { draw, getBounds, intersect, withScope } from 'brepjs';
+import type { DisposalScope, Shape3D } from 'brepjs';
 import { isOk } from '@/core/result';
 import {
   autoCornerRadius,
@@ -278,39 +278,49 @@ describe('buildSingleCutout corner placement', () => {
    * both, and this exercises the real overshoot/`cutZ` placement — the half of
    * #3173 that decides whether an arc reaches the rim at all.
    */
-  const spanAtZ = (shape: WallCutoutShape, z: number, cutHeight: number = CUT_HEIGHT): number => {
-    const cut = buildSingleCutout(
-      shape,
-      CUT_WIDTH,
-      cutHeight,
-      OVERSHOOT,
-      EXTRUDE_DEPTH,
-      WALL_HEIGHT,
-      CENTERED
-    );
-    const slab = box(-CUT_WIDTH, CUT_WIDTH, -EXTRUDE_DEPTH, EXTRUDE_DEPTH, z, z + 0.001);
-    const clipped = intersect(cut, slab);
-    expect(isOk(clipped), `slab intersection at z=${z}`).toBe(true);
-    if (!isOk(clipped)) return NaN;
-    const b = getBounds(clipped.value);
-    return b.xMax - b.xMin;
-  };
+  const spanAtZ = (shape: WallCutoutShape, z: number, cutHeight: number = CUT_HEIGHT): number =>
+    withScope((scope: DisposalScope) => {
+      const cut = scope.register(
+        buildSingleCutout(
+          shape,
+          CUT_WIDTH,
+          cutHeight,
+          OVERSHOOT,
+          EXTRUDE_DEPTH,
+          WALL_HEIGHT,
+          CENTERED
+        )
+      );
+      const slab = scope.register(
+        box(-CUT_WIDTH, CUT_WIDTH, -EXTRUDE_DEPTH, EXTRUDE_DEPTH, z, z + 0.001)
+      );
+      const clipped = intersect(cut, slab);
+      expect(isOk(clipped), `slab intersection at z=${z}`).toBe(true);
+      if (!isOk(clipped)) return NaN;
+      const b = getBounds(scope.register(clipped.value));
+      return b.xMax - b.xMin;
+    });
 
   it('straddles the wall and overshoots the rim', () => {
     // The u-shape profile switched from drawRoundedRectangle to a pen for
     // #3173, which flips the blueprint winding (counterClockwise → clockwise).
     // Winding can flip an extrusion's direction, so pin the placement: the cut
     // must stay centred on the wall face in Y and still clear the rim in Z.
-    const cut = buildSingleCutout(
-      'u-shape',
-      CUT_WIDTH,
-      CUT_HEIGHT,
-      OVERSHOOT,
-      EXTRUDE_DEPTH,
-      WALL_HEIGHT,
-      CENTERED
+    const b = withScope((scope: DisposalScope) =>
+      getBounds(
+        scope.register(
+          buildSingleCutout(
+            'u-shape',
+            CUT_WIDTH,
+            CUT_HEIGHT,
+            OVERSHOOT,
+            EXTRUDE_DEPTH,
+            WALL_HEIGHT,
+            CENTERED
+          )
+        )
+      )
     );
-    const b = getBounds(cut);
     expect(b.yMin).toBeCloseTo(-EXTRUDE_DEPTH / 2, 3);
     expect(b.yMax).toBeCloseTo(EXTRUDE_DEPTH / 2, 3);
     expect(b.zMin).toBeCloseTo(FLOOR_Z, 3);

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -68,8 +68,8 @@ export function buildCutoutProfile(
         .close();
     }
 
-    case 'funnel':
-    default: {
+    case 'u-shape':
+    case 'funnel': {
       // U-shape and funnel are the same pen — a straight-sided u-shape is the
       // degenerate funnel with no taper.
       //

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -5,17 +5,7 @@
  * for u-shape, scoop (semicircle), and funnel (tapered U) profiles.
  */
 
-import {
-  draw,
-  drawRoundedRectangle,
-  drawRectangle,
-  translate,
-  rotate,
-  clone,
-  unwrap,
-  withScope,
-  fuseAll,
-} from 'brepjs';
+import { draw, translate, rotate, clone, unwrap, withScope, fuseAll } from 'brepjs';
 import type { Shape3D, Drawing, DisposalScope, ValidSolid } from 'brepjs';
 import type { BinParams, WallCutoutShape } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
@@ -78,32 +68,30 @@ export function buildCutoutProfile(
         .close();
     }
 
-    case 'funnel': {
-      // Tapered U: wider at top, narrower at bottom with rounded corners.
+    case 'funnel':
+    default: {
+      // U-shape and funnel are the same pen — a straight-sided u-shape is the
+      // degenerate funnel with no taper.
+      //
+      // Only the two BOTTOM corners are rounded. The top corners must stay
+      // square: the profile clears the wall by `overshoot`, but `safeR` can
+      // reach 5mm while the overshoot is only ~2mm above the true rim, so a
+      // four-corner rounding leaves arc on the visible rim instead of having
+      // it trimmed away by the boolean (#3173).
       const cornerR = autoCornerRadius(cutWidth);
       const safeR = Math.min(cornerR, cutWidth / 2 - 0.01, userCutHeight / 2 - 0.01);
 
       const topHW = cutWidth / 2;
-      const bottomHW = (cutWidth * FUNNEL_TAPER_RATIO) / 2;
+      const bottomHW = cutoutShape === 'funnel' ? (cutWidth * FUNNEL_TAPER_RATIO) / 2 : topHW;
       const topY = totalHeight / 2;
       const bottomY = -totalHeight / 2;
 
-      // Draw trapezoid: top-left -> top-right -> bottom-right -> bottom-left -> close
+      // top-left -> top-right -> bottom-right -> bottom-left -> close
       let pen = draw([-topHW, topY]).lineTo([topHW, topY]).lineTo([bottomHW, bottomY]);
       if (safeR > 0.1) pen = pen.customCorner(safeR);
       pen = pen.lineTo([-bottomHW, bottomY]);
       if (safeR > 0.1) pen = pen.customCorner(safeR);
       return pen.close();
-    }
-
-    default: {
-      // U-shape: rounded rectangle (existing behavior)
-      const cornerR = autoCornerRadius(cutWidth);
-      const safeR = Math.min(cornerR, cutWidth / 2 - 0.01, userCutHeight / 2 - 0.01);
-      if (safeR > 0.1) {
-        return drawRoundedRectangle(cutWidth, totalHeight, safeR);
-      }
-      return drawRectangle(cutWidth, totalHeight);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #3173 — the u-shape wall cutout's upper corners were rounded where the cut meets the top of the wall, so the opening flared outward instead of meeting the rim square.

`buildCutoutProfile`'s u-shape branch used `drawRoundedRectangle`, which rounds **all four** corners. The top pair was meant to be trimmed away by the boolean overshoot, but the overshoot clears the true rim by only ~2mm in both configurations:

| | true rim | profile top | clearance |
|---|---|---|---|
| no lip | `wallHeight` | `wallHeight + 2` | 2.0mm |
| stacking lip | `wallHeight + LIP_HEIGHT − LIP_OVERLAP` | `wallHeight + LIP_HEIGHT + 2` | 2.1mm |

Since #3164 the radius is `safeR = clamp(0.15 × cutWidth, 0.5, 5)`, so any cutout wider than ~13mm leaves arc below the rim — up to 3mm at the clamp.

Only the two **bottom** corners are rounded now, as the funnel branch already did. Rather than duplicate the funnel's pen into the u-shape branch, the two share one pen — a u-shape is the degenerate funnel with no taper — so the "round only the bottom" rule cannot drift between them again. The explicit `drawRectangle` fallback goes away because a pen with `safeR <= 0.1` already emits sharp corners.

## Verification

Reproduced first, measuring the positioned cut solid at rim level: **38mm span instead of 40** — exactly `5 − sqrt(5² − 2²) = 1mm` of inset per side — and 30.2mm at the top of the overshoot. Both are 40mm after the fix.

- New sibling unit tests (20 total in the file) pin the span at the rim, across the trimmed overshoot, and at the floor, for all three cutout shapes.
- Two new end-to-end structural scenarios use the reporter's exact config (3×10, 14mm grid, 2.6mm walls, 100%-height left+right cutouts), with and without a stacking lip — the lipped case is where the boolean is most nearly coplanar with the rim.
- An explicit assertion pins the cut solid's Y straddle and Z extent. The profile switched from `drawRoundedRectangle` (counterClockwise) to a pen (clockwise), and winding can flip an extrusion's direction, so the placement is now asserted rather than assumed.
- `typecheck` and `eslint` clean.

### A note on the test oracle

My first attempt used `isInside2D`, which turns out to be **winding-sensitive** — `drawRoundedRectangle` emits a counterClockwise blueprint and reports its own centre as *outside*, while pen-drawn profiles are clockwise. Every assertion would have flipped to passing after the fix while actually measuring winding rather than corner shape. The tests measure a 3D bounding box on the real positioned solid instead, which is orientation-free and also exercises the real `overshoot`/`cutZ` placement. (2D drawing booleans throw outright on these profiles, so they were not an option either.)

## Snapshot churn

Five triangle-count snapshots move, and every one is a scenario with a u-shape cutout enabled:

| scenario | before | after |
|---|---|---|
| custom-shape > 3×3 L with front cutout | 5330 | 5612 |
| custom-shape > 3×3 U with front cutout | 5408 | 5690 |
| custom-shape > 3×3 L with honeycomb + front cutout | 8198 | 8790 |
| divider patterns > dividers + interior cutouts | 10020 | 10504 |
| divider patterns > dividers + outer cutouts + handles | 14588 | 14956 |

Both single-outer-cutout cases move by an identical **+282**, the signature of one deterministic geometric change. The sibling `divider patterns` scenario with `walls: ALL_SIDES_OFF` is unchanged, as are the handle, scoop and pattern-only scenarios — a clean control.

## Not changed

The designer's transient ghost outline (`GhostWallCutouts.addUNotch`) already drew square top corners, open at the top. It disagreed with the generated mesh before this fix and now agrees with it.

Closes #3173

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes u‑shape wall cutouts so the opening meets the wall rim square instead of flaring. Top corners are square; only the bottom corners are rounded. `u-shape` now shares a pen with `funnel`; tests and snapshots updated.

- **Bug Fixes**
  - Replaced `drawRoundedRectangle` with a shared pen for `u-shape`/`funnel`; top corners square, bottom corners rounded; removed the `drawRectangle` fallback.
  - Removes the leftover arc at the rim from ~2mm overshoot vs `safeR` up to 5mm; fixes #3173.
  - Added two structural scenarios (with/without stacking lip) and unit tests that assert rim/overshoot/floor spans and extrusion placement.
  - Snapshots update only where a `u-shape` cutout is enabled, including honeycomb-junction scenarios; single outer cutouts are +282 triangles.

- **Refactors**
  - Made the cutout switch exhaustive by adding `case 'u-shape'`; new shapes won’t silently render as `u-shape`.
  - Wrapped new WASM tests in `withScope` to dispose shapes; documented ownership for `buildSingleCutout`.

<sup>Written for commit 65d2a718dfc48146b7405d60072a8f6ef65810c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

