### PR TITLE
fix(ci): assert snapshots instead of rewriting them (#3181)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,18 +95,26 @@ jobs:
           GIT_REF: ${{ github.ref }}
           GROUP: ${{ matrix.group }}
           SHARD: ${{ matrix.shard }}
+        # No `-u` here, deliberately: it makes Vitest REWRITE a mismatched
+        # snapshot in the runner and pass, so committed baselines gate nothing
+        # (#3181). It was correct when added — 3d1fccb7 had just deleted the
+        # scenario snapshots from git, so every missing baseline failed a shard
+        # — but e8653992 restored them to version control in June. Baselines are
+        # now committed, so CI asserts them. Regenerate locally and commit the
+        # diff: `pnpm exec vitest run <path> -u` (filter FIRST — `-u <path>`
+        # swallows the path as the flag's value and runs the whole project).
         run: |
           if [ "$GIT_REF" = "refs/heads/main" ]; then
             # Projects are named explicitly rather than using the default "all":
             # `integration` needs a Redis service and runs as its own job.
             echo "Running full suite with coverage (main branch)"
-            pnpm vitest run --coverage -u --project=unit --project=dom --project=generators
+            pnpm vitest run --coverage --project=unit --project=dom --project=generators
           elif [ "$GROUP" = "generators" ]; then
             echo "Running generators project (shard $SHARD)"
-            pnpm vitest run --project=generators --shard="$SHARD" -u
+            pnpm vitest run --project=generators --shard="$SHARD"
           else
             echo "Running core projects unit+dom (shard $SHARD)"
-            pnpm vitest run --project=unit --project=dom --shard="$SHARD" -u
+            pnpm vitest run --project=unit --project=dom --shard="$SHARD"
           fi
 
       - name: Upload coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,9 @@ jobs:
         # scenario snapshots from git, so every missing baseline failed a shard
         # — but e8653992 restored them to version control in June. Baselines are
         # now committed, so CI asserts them. Regenerate locally and commit the
-        # diff: `pnpm exec vitest run <path> -u` (filter FIRST — `-u <path>`
-        # swallows the path as the flag's value and runs the whole project).
+        # diff: `pnpm exec vitest run <path> -u` — keep the filter BEFORE `-u`,
+        # since a bare `-u` consumes the next token as its value and would run
+        # the whole suite. See scenarioRunner.ts for the full CLI note.
         run: |
           if [ "$GIT_REF" = "refs/heads/main" ]; then
             # Projects are named explicitly rather than using the default "all":

--- a/src/features/generation/worker/generators/__kernel-tests__/scenarioRunner.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/scenarioRunner.ts
@@ -8,11 +8,18 @@
  * placement obvious: a scenario lives in `scenarios/<domain>.ts` and runs in
  * `binGenerator.scenario.<domain>.test.ts`.
  *
- * Update snapshots after verified geometry changes (whole domain or one file).
- * The filter MUST precede `-u`: after `--` vitest reads everything as positional
- * filters (#1329), and `--update <path>` eats the path as the flag's value —
- * both silently run the whole project instead of the file you named.
+ * Update snapshots after verified geometry changes (whole domain or one file):
  *   pnpm exec vitest run src/features/generation/worker/generators/binGenerator.scenario.handles -u
+ *
+ * Put the filter BEFORE `-u`. Two separate ways to lose it, both silent:
+ *   1. A bare `-u`/`--update` consumes the NEXT token as its value, so
+ *      `-u <path>` leaves no filter and runs all ~1550 files. Verified on
+ *      vitest 4.1.10: `vitest list -u <path>` enumerates the whole project,
+ *      while `vitest list --update=true <path>` lists just that file — so
+ *      `--update=true <path>` is the other safe form.
+ *   2. Routing through `pnpm run <script> -- ...` puts a literal `--` in the
+ *      vitest argv; everything after it is read as a positional filter and the
+ *      `-u` is ignored outright (b2ee64e5, #1329, same trap with --shard).
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './wasmInit';

--- a/src/features/generation/worker/generators/__kernel-tests__/scenarioRunner.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/scenarioRunner.ts
@@ -8,8 +8,11 @@
  * placement obvious: a scenario lives in `scenarios/<domain>.ts` and runs in
  * `binGenerator.scenario.<domain>.test.ts`.
  *
- * Update snapshots after verified geometry changes (whole domain or one file):
- *   pnpm run test:run -- -u src/features/generation/worker/generators/binGenerator.scenario.handles
+ * Update snapshots after verified geometry changes (whole domain or one file).
+ * The filter MUST precede `-u`: after `--` vitest reads everything as positional
+ * filters (#1329), and `--update <path>` eats the path as the flag's value —
+ * both silently run the whole project instead of the file you named.
+ *   pnpm exec vitest run src/features/generation/worker/generators/binGenerator.scenario.handles -u
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './wasmInit';

--- a/src/features/generation/worker/generators/binGenerator.scenarios.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenarios.ts
@@ -4,8 +4,9 @@
  * Split into category-based files under `./scenarios/`.
  * This barrel re-exports the aggregated array and helper functions.
  *
- * Update snapshots after verified geometry changes:
- *   pnpm run test:run -- -u src/features/generation/worker/generators/binGenerator.scenario.test
+ * Update snapshots after verified geometry changes (filter before `-u` — see
+ * the note in `__kernel-tests__/scenarioRunner.ts` for why):
+ *   pnpm exec vitest run binGenerator.scenario -u
  */
 export { ALL_SCENARIOS } from './scenarios/index';
 export type { ScenarioCase } from './scenarios/index';

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -8,8 +8,9 @@
  *   - half-bin L: half-cell resolution, validates mask granularity end-to-end
  *
  * All fixtures produce meshes; triangle counts are snapshotted. When
- * verified visually correct, update with:
- *   pnpm run test:run -- -u src/features/generation/worker/generators/binGenerator.scenario.test
+ * verified visually correct, update with (filter before `-u` — see the note in
+ * `__kernel-tests__/scenarioRunner.ts` for why):
+ *   pnpm exec vitest run binGenerator.scenario.customShape -u
  */
 import {
   DEFAULT_BIN_PARAMS,


### PR DESCRIPTION
## Summary

Fixes #3181. All three vitest invocations in `.github/workflows/ci.yml` passed `-u` (`--update`), which makes vitest **rewrite** a mismatched snapshot in the runner and pass. The 37 tracked `.snap` files gated nothing, on any branch — we maintained baselines, reviewed their diffs, and asserted none of them.

It was a reasonable call when added, and only stopped being one later:

| | |
|---|---|
| 2026-04-03 | `3d1fccb7` deletes the scenario snapshots from git for CI regeneration |
| 2026-04-04 | `156584f1` (#1321) adds `-u` — with no committed baselines, every missing snapshot failed a shard |
| 2026-06-05 | `e8653992` (#2017) splits scenarios per-domain and **restores snapshots to version control** |

The premise expired in June; the flag stayed.

Caught by PR #3179, where all 9 shards went green on a commit carrying 3 stale `honeycombJunction` baselines (4760→5230, 4436→4952, 4824→5584). A local run without `-u` failed on exactly those three.

## Also fixed: three doc comments teaching a broken command

`scenarioRunner.ts`, `binGenerator.scenarios.ts` and `scenarios/customShape.ts` all documented:

```
pnpm run test:run -- -u <path>
```

That form silently does not update anything — it expands to `vitest run -- …`, and vitest reads everything after `--` as positional test-name filters, so `-u` is discarded. This is the same trap `b2ee64e5` (#1329) fixed in CI back in April with `--shard`, but the docs were never updated. Two of them also pointed at `binGenerator.scenario.test`, deleted by #2017.

The working form is **filter first**: `pnpm exec vitest run <path> -u`. (`--update <path>` is also wrong — it eats the path as the flag's value and runs the whole project.)

## Verification

Both risks of removing the flag were checked **before** committing, so this cannot land a red CI:

**1. Are the committed baselines actually correct?** Full local suite on current main with no `-u`:

```
Test Files  1552 passed | 2 skipped (1554)
Tests       20015 passed | 20 skipped (20035)
```

**2. Does `--shard` report another shard's snapshots as obsolete and fail?** No — sharding splits by *file*, so an unloaded file's `.snap` is never read, and every test within a loaded file runs. Confirmed by running single shards without `-u`:

| shard | result |
|---|---|
| `--project=generators --shard=1/6` | 42 files, 506 tests, exit 0 |
| `--project=unit --project=dom --shard=2/3` | 434 files, 5,498 tests, exit 0 |

## Behaviour change to expect

A PR that adds a **new** snapshot must now commit the `.snap` file. That is the normal expectation and no longer the papercut #1321 was working around, since baselines are version-controlled again. Regenerate with `pnpm exec vitest run <path> -u` and commit the diff — which is exactly the reviewable signal a geometry PR wants.

I removed `-u` from the main-branch coverage run too, so main and PRs agree; otherwise drift could still land silently through the main path.

## Out of scope

The alternate-kernel `*.brepkit.snap` baselines have been touched by two commits ever and no CI job sets `BREPJS_KERNEL`, so they drift regardless of this flag. Worth deciding separately whether to gate or delete them.

Closes #3181

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now asserts `vitest` snapshots instead of rewriting them, so stale baselines fail fast. Docs now show the correct update command, explain argv pitfalls, and note `--update=true` as a safe alternative.

- **Bug Fixes**
  - Removed `-u/--update` from all CI `vitest run` commands in `.github/workflows/ci.yml` (including coverage) to ensure mismatches fail.
  - Clarified snapshot update docs: use `pnpm exec vitest run <path> -u`; explain that flag order is load‑bearing; avoid `pnpm run ... -- -u`; document `--update=true <path>` as another safe form.

- **Migration**
  - When adding/changing snapshots, regenerate locally with `pnpm exec vitest run <path> -u` (or `--update=true <path>`) and commit the updated `.snap` files.

<sup>Written for commit 80720d43bf4f321dfbf81dce2ea9527e3a64af2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

