### PR TITLE
feat(community): show what a design costs to print, and say where that came from

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -148,6 +148,7 @@
     "common.redditCommunity",
     "common.standard",
     "community.card.remixBadge",
+    "community.cost.filamentLabel",
     "community.detail.millimeters",
     "community.detail.remix",
     "community.detail.stats.likes",

--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -69,7 +69,7 @@ The rule that shapes it: **observed beats estimated, and the difference is never
 
 Observed data only displaces the model at `OBSERVED_MIN_SAMPLE` (2) reports: one person's print is a data point, not a distribution.
 
-The estimator itself is bin-designer internal, so the wrapper lives in `shared/` (the sanctioned bridge, as in `shared/items/bin/descriptor.ts`) rather than being imported across slices. It is wrapped in a try/catch: a design published by an older client can carry params this build cannot read, and no estimate is honest where a wrong one is not.
+The estimator itself is bin-designer internal, so the wrapper lives in `shared/` (the sanctioned bridge, as in `shared/items/bin/descriptor.ts`) rather than being imported across slices. `estimateCommunityPrint` propagates whatever the estimator throws; `PrintCostPanel` is what catches it, because a design published by an older client can carry params this build cannot read, and that must not take the detail view down. Other callers need their own handling.
 
 Bed fit compares the footprint against the viewer's configured bed and allows rotation, since every slicer will rotate it for you.
 

--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -61,6 +61,18 @@ Backend lives in `api/community/prints.ts` (`GET`/`PUT`/`DELETE`/`POST report`),
 - **Proven shelf** sits directly under staff picks, above recency: a design other people actually printed is the strongest recommendation the library has, and it is the one signal nobody can inflate by posting.
 - **Cover promotion** is owner opt-in and server-validated against the design's own **live** prints. The gallery grid is the most public surface in the app, and this is the only path by which a user-supplied image can reach it, so the check that the URL belongs to a live print of that design is load-bearing, not defensive. A hidden print's photo is not promotable.
 
+### Print cost
+
+`components/PrintCostPanel/` answers "what will this cost me" before you commit, from `@/shared/utils/communityPrintCost`.
+
+The rule that shapes it: **observed beats estimated, and the difference is never hidden.** A model estimate and the median of twelve real prints are different kinds of claim, so each figure carries a `source` the panel renders as a distinct badge. Time and filament resolve independently, because reporting filament is optional and an observed time beside an estimated weight is the normal case.
+
+Observed data only displaces the model at `OBSERVED_MIN_SAMPLE` (2) reports: one person's print is a data point, not a distribution.
+
+The estimator itself is bin-designer internal, so the wrapper lives in `shared/` (the sanctioned bridge, as in `shared/items/bin/descriptor.ts`) rather than being imported across slices. It is wrapped in a try/catch: a design published by an older client can carry params this build cannot read, and no estimate is honest where a wrong one is not.
+
+Bed fit compares the footprint against the viewer's configured bed and allows rotation, since every slicer will rotate it for you.
+
 Note that `counts.exports` means file downloads, not prints. The two are different signals and the UI must not conflate them.
 
 ## Deferred to later PRs

--- a/src/features/community/components/CommunityDetail/CommunityDetail.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.tsx
@@ -18,7 +18,7 @@ import { useToastStore } from '@/core/store/toast';
 import { useSessionStore } from '@/core/sync/session/useSession';
 import { trackEvent } from '@/shared/analytics/posthog';
 import type { CommunityDesign, CommunityDesignCounts } from '@/shared/types/community';
-import type { CommunityPrint } from '@/shared/types/communityPrint';
+import type { CommunityPrint, CommunityPrintSummary } from '@/shared/types/communityPrint';
 import type { CommunityDetailProps } from '@/shared/types/communityDetail';
 import { savePendingLikeAction } from '@/shared/utils/communityPendingLikeAction';
 import { fetchCommunityDesign } from '../../api/client';
@@ -32,6 +32,7 @@ import { CommunitySignInPrompt } from '../SignInPrompt';
 import { fetchPrints, reportPrint } from '../../api/printsClient';
 import { usePrintDialogStore } from '../../store/printDialogStore';
 import { PrintDialog } from '../PrintDialog';
+import { PrintCostPanel } from '../PrintCostPanel';
 import { PrintsSection } from '../PrintsSection';
 import { CommunityDetailContent } from './CommunityDetailContent';
 import type { OwnerModeration, ParentResolution } from './CommunityDetailContent';
@@ -121,6 +122,7 @@ function CommunityDetailDialog({
   const [ownPrint, setOwnPrint] = useState<{
     designId: string;
     print: CommunityPrint | null;
+    summary: CommunityPrintSummary | null;
   } | null>(null);
   const [printsAvailable, setPrintsAvailable] = useState(true);
   // Bumped after a write so the list refetches; the parent owns it because the
@@ -408,21 +410,27 @@ function CommunityDetailDialog({
     void fetchPrints(printsDesignId).then((result) => {
       if (cancelled) return;
       if (isOk(result)) {
-        setOwnPrint({ designId: printsDesignId, print: result.value.mine });
+        setOwnPrint({
+          designId: printsDesignId,
+          print: result.value.mine,
+          summary: result.value.summary,
+        });
         return;
       }
       // The kill switch is the one failure worth acting on: a CTA that opens a
       // dialog which can only fail is worse than no CTA. Any other error just
       // leaves the button in its "post" state.
       setPrintsAvailable(result.error.kind !== 'disabled');
-      setOwnPrint({ designId: printsDesignId, print: null });
+      setOwnPrint({ designId: printsDesignId, print: null, summary: null });
     });
     return () => {
       cancelled = true;
     };
   }, [phase, printsDesignId]);
 
-  const myPrint = design !== null && ownPrint?.designId === design.id ? ownPrint.print : null;
+  const stampedPrints = design !== null && ownPrint?.designId === design.id ? ownPrint : null;
+  const myPrint = stampedPrints?.print ?? null;
+  const printSummary = stampedPrints?.summary ?? null;
 
   const printDialogOpen = usePrintDialogStore((s) => s.phase !== 'closed');
 
@@ -538,6 +546,13 @@ function CommunityDetailDialog({
             onFilterByAuthor={handleFilterByAuthor}
             ownerModeration={ownerModeration}
             onAddPrint={printsAvailable ? handleAddPrint : undefined}
+            costSlot={
+              <PrintCostPanel
+                params={design.params}
+                metrics={design.metrics}
+                summary={printSummary}
+              />
+            }
             printsSlot={
               printsAvailable && design !== null ? (
                 <PrintsSection
@@ -740,11 +755,17 @@ function CommunityDetailDialog({
       {printDialogOpen && (
         <PrintDialog
           onSaved={(print) => {
-            setOwnPrint({ designId: print.designId, print });
+            setOwnPrint((current) => ({
+              designId: print.designId,
+              print,
+              summary: current?.designId === print.designId ? current.summary : null,
+            }));
             setPrintsRefresh((n) => n + 1);
           }}
           onDeleted={() => {
-            setOwnPrint(design === null ? null : { designId: design.id, print: null });
+            setOwnPrint(
+              design === null ? null : { designId: design.id, print: null, summary: null }
+            );
             setPrintsRefresh((n) => n + 1);
           }}
         />

--- a/src/features/community/components/CommunityDetail/CommunityDetail.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.tsx
@@ -426,7 +426,10 @@ function CommunityDetailDialog({
     return () => {
       cancelled = true;
     };
-  }, [phase, printsDesignId]);
+    // printsRefresh is a dependency, not just PrintsSection's: the cost panel
+    // reads its summary from here, so without it a save could leave the panel
+    // showing "estimated" after the report that should have flipped it.
+  }, [phase, printsDesignId, printsRefresh]);
 
   const stampedPrints = design !== null && ownPrint?.designId === design.id ? ownPrint : null;
   const myPrint = stampedPrints?.print ?? null;

--- a/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
@@ -59,6 +59,8 @@ interface CommunityDetailContentProps {
   hasOwnPrint?: boolean;
   /** Rendered below the CTA; absent while prints are unavailable. */
   printsSlot?: ReactNode;
+  /** Print cost and bed fit; sits with the dimensions, which is the same question. */
+  costSlot?: ReactNode;
 }
 
 function formatMm(value: number): string {
@@ -84,6 +86,7 @@ export function CommunityDetailContent({
   onAddPrint,
   hasOwnPrint = false,
   printsSlot,
+  costSlot,
 }: CommunityDetailContentProps) {
   const t = useTranslation();
   const [angleIndex, setAngleIndex] = useState(0);
@@ -276,6 +279,8 @@ export function CommunityDetailContent({
             })}
           </p>
         </div>
+
+        {costSlot}
 
         {counts !== null && (
           <>

--- a/src/features/community/components/PrintCostPanel/PrintCostPanel.test.tsx
+++ b/src/features/community/components/PrintCostPanel/PrintCostPanel.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { BinParams } from '@/shared/types/bin';
+import type { CommunityPrintSummary } from '@/shared/types/communityPrint';
+import { PrintCostPanel } from './PrintCostPanel';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+const estimate = vi.hoisted(() => vi.fn());
+vi.mock('@/shared/utils/communityPrintCost', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, estimateCommunityPrint: estimate };
+});
+
+const bed = vi.hoisted(() => ({ width: 256, depth: 256 }));
+vi.mock('@/core/store/settings', () => ({
+  useSettingsStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      settings: { defaultPrintBedSize: bed.width, defaultPrintBedDepth: bed.depth },
+    }),
+}));
+
+const PARAMS = { width: 2, depth: 3, height: 6 } as unknown as BinParams;
+const METRICS = { width: 83.5, depth: 125.5, height: 42, gridUnitMm: 42 };
+
+function summary(overrides: Partial<CommunityPrintSummary> = {}): CommunityPrintSummary {
+  return {
+    count: 5,
+    asDesigned: 5,
+    adjusted: 0,
+    didNotFit: 0,
+    commonMaterial: 'pla',
+    commonLayerHeightMm: 0.2,
+    medianPrintMinutes: 130,
+    medianFilamentGrams: 24,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bed.width = 256;
+  bed.depth = 256;
+  estimate.mockReturnValue({ grams: 20, meters: 6.7, minutes: 100 });
+});
+
+describe('PrintCostPanel', () => {
+  it('labels model-derived figures as estimated', () => {
+    render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
+
+    expect(screen.getAllByTestId('cost-source-estimated').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('cost-source-observed')).toBeNull();
+    expect(screen.getByTestId('cost-estimate-note')).toBeInTheDocument();
+  });
+
+  it('labels real reports as observed and drops the estimate caveat', () => {
+    render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={summary()} />);
+
+    // An estimate must never be presented as a measurement, and vice versa.
+    expect(screen.getAllByTestId('cost-source-observed').length).toBe(2);
+    expect(screen.queryByTestId('cost-source-estimated')).toBeNull();
+    expect(screen.queryByTestId('cost-estimate-note')).toBeNull();
+  });
+
+  it('mixes an observed time with an estimated weight', () => {
+    render(
+      <PrintCostPanel
+        params={PARAMS}
+        metrics={METRICS}
+        summary={summary({ medianFilamentGrams: null })}
+      />
+    );
+
+    // Reporting filament is optional, so this is the normal case.
+    expect(screen.getByTestId('cost-source-observed')).toBeInTheDocument();
+    expect(screen.getByTestId('cost-source-estimated')).toBeInTheDocument();
+    expect(screen.getByTestId('cost-estimate-note')).toBeInTheDocument();
+  });
+
+  it('confirms a design that fits the configured bed', () => {
+    render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
+    expect(screen.getByTestId('cost-bed-fits')).toBeInTheDocument();
+  });
+
+  it('warns when the design is larger than the bed, noting rotation was tried', () => {
+    bed.width = 100;
+    bed.depth = 100;
+    render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
+
+    expect(screen.getByTestId('cost-bed-too-large')).toBeInTheDocument();
+    // Answers the obvious "but what if I turn it?" before it is asked.
+    expect(screen.getByText('community.cost.bedHint')).toBeInTheDocument();
+  });
+
+  it('omits the rotation note when the design already fits', () => {
+    render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
+    expect(screen.queryByText('community.cost.bedHint')).toBeNull();
+  });
+
+  it('survives params the estimator cannot read', () => {
+    estimate.mockImplementation(() => {
+      throw new Error('unknown param shape');
+    });
+
+    render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
+
+    // A design published by an older client must not take the detail down.
+    expect(screen.queryByTestId('cost-time')).toBeNull();
+    expect(screen.getByTestId('cost-bed-fits')).toBeInTheDocument();
+  });
+
+  it('renders nothing when it has neither a figure nor a usable bed', () => {
+    estimate.mockImplementation(() => {
+      throw new Error('nope');
+    });
+    bed.width = 0;
+    bed.depth = 0;
+
+    render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
+
+    expect(screen.queryByTestId('print-cost-panel')).toBeNull();
+  });
+});

--- a/src/features/community/components/PrintCostPanel/PrintCostPanel.test.tsx
+++ b/src/features/community/components/PrintCostPanel/PrintCostPanel.test.tsx
@@ -98,6 +98,19 @@ describe('PrintCostPanel', () => {
     expect(screen.queryByText('community.cost.bedHint')).toBeNull();
   });
 
+  it('omits the estimate caveat when no estimated figure is on screen', () => {
+    estimate.mockImplementation(() => {
+      throw new Error('unknown param shape');
+    });
+
+    render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
+
+    // Only bed-fit text renders here, so a note claiming a model figure
+    // would be describing something that is not there.
+    expect(screen.queryByTestId('cost-time')).toBeNull();
+    expect(screen.queryByTestId('cost-estimate-note')).toBeNull();
+  });
+
   it('survives params the estimator cannot read', () => {
     estimate.mockImplementation(() => {
       throw new Error('unknown param shape');

--- a/src/features/community/components/PrintCostPanel/PrintCostPanel.tsx
+++ b/src/features/community/components/PrintCostPanel/PrintCostPanel.tsx
@@ -1,0 +1,142 @@
+/**
+ * "What it takes to print" on the design detail.
+ *
+ * Every figure is labelled with where it came from. A model estimate and the
+ * median of twelve real prints are different kinds of claim, and collapsing
+ * them into one confident-looking number is the failure this whole feature
+ * exists to avoid.
+ */
+
+import { useMemo } from 'react';
+import { Badge } from '@/design-system';
+import { useTranslation } from '@/i18n';
+import { useSettingsStore } from '@/core/store/settings';
+import type { BinParams } from '@/shared/types/bin';
+import type { CommunityDesignMetrics } from '@/shared/types/community';
+import type { CommunityPrintSummary } from '@/shared/types/communityPrint';
+import {
+  estimateCommunityPrint,
+  fitsPrintBed,
+  resolvePrintCost,
+} from '@/shared/utils/communityPrintCost';
+import type { PrintCostFigure } from '@/shared/utils/communityPrintCost';
+import { formatGrams, formatPrintDuration, roundSummaryMinutes } from '../../utils/printFormat';
+
+export interface PrintCostPanelProps {
+  params: BinParams;
+  metrics: CommunityDesignMetrics;
+  /** Null until the print list resolves; the panel shows estimates meanwhile. */
+  summary: CommunityPrintSummary | null;
+}
+
+function SourceBadge({ source }: { source: PrintCostFigure['source'] }) {
+  const t = useTranslation();
+  if (source.kind === 'estimated') {
+    return (
+      <Badge size="sm" tone="neutral" data-testid="cost-source-estimated">
+        {t('community.cost.estimated')}
+      </Badge>
+    );
+  }
+  return (
+    <Badge size="sm" tone="success" data-testid="cost-source-observed">
+      {source.sampleSize === 1
+        ? t('community.cost.observedOne')
+        : t('community.cost.observedOther', { count: source.sampleSize })}
+    </Badge>
+  );
+}
+
+export function PrintCostPanel({ params, metrics, summary }: PrintCostPanelProps) {
+  const t = useTranslation();
+  const bedWidth = useSettingsStore((s) => s.settings.defaultPrintBedSize);
+  const bedDepth = useSettingsStore(
+    (s) => s.settings.defaultPrintBedDepth ?? s.settings.defaultPrintBedSize
+  );
+
+  // The estimator walks the whole param tree, so it is memoised against the
+  // params rather than recomputed on every summary refresh.
+  const estimate = useMemo(() => {
+    try {
+      return estimateCommunityPrint(params);
+    } catch {
+      // A design published by an older client can carry params this build's
+      // estimator does not understand. No estimate is honest; a wrong one is
+      // not, and it must not take the detail view down with it.
+      return null;
+    }
+  }, [params]);
+
+  const { time, filament } = resolvePrintCost(estimate, summary);
+  const bedFit = fitsPrintBed(metrics, bedWidth, bedDepth);
+
+  if (time.minutes === null && filament.grams === null && bedFit === 'unknown') return null;
+
+  const duration =
+    time.minutes === null ? null : formatPrintDuration(roundSummaryMinutes(time.minutes));
+
+  return (
+    <div className="space-y-2" data-testid="print-cost-panel">
+      <h3 className="text-sm font-medium text-content">{t('community.cost.title')}</h3>
+
+      {duration !== null && (
+        <div className="flex items-center justify-between gap-2 text-sm">
+          <span className="text-content-secondary">{t('community.cost.timeLabel')}</span>
+          <span className="flex items-center gap-2">
+            <span className="font-medium text-content" data-testid="cost-time">
+              {duration.hours === 0
+                ? t('community.prints.durationMinutes', { minutes: duration.minutes })
+                : duration.minutes === 0
+                  ? t('community.prints.durationHoursExact', { hours: duration.hours })
+                  : t('community.prints.durationHours', {
+                      hours: duration.hours,
+                      minutes: duration.minutes,
+                    })}
+            </span>
+            <SourceBadge source={time.source} />
+          </span>
+        </div>
+      )}
+
+      {filament.grams !== null && (
+        <div className="flex items-center justify-between gap-2 text-sm">
+          <span className="text-content-secondary">{t('community.cost.filamentLabel')}</span>
+          <span className="flex items-center gap-2">
+            <span className="font-medium text-content" data-testid="cost-filament">
+              {t('community.prints.filament', { grams: formatGrams(filament.grams) })}
+            </span>
+            <SourceBadge source={filament.source} />
+          </span>
+        </div>
+      )}
+
+      {bedFit !== 'unknown' && (
+        <p
+          className={bedFit === 'fits' ? 'text-xs text-content-secondary' : 'text-xs text-warning'}
+          data-testid={`cost-bed-${bedFit}`}
+        >
+          {bedFit === 'fits'
+            ? t('community.cost.bedFits')
+            : t('community.cost.bedTooLarge', {
+                width: Math.round(bedWidth),
+                depth: Math.round(bedDepth),
+              })}
+        </p>
+      )}
+
+      {/* Only alongside a negative verdict: there it answers the obvious
+          "but what if I turn it?", which the check already did. */}
+      {bedFit === 'too-large' && (
+        <p className="text-xs text-content-tertiary">{t('community.cost.bedHint')}</p>
+      )}
+
+      {/* Shown only while a figure is still model-derived, so the caveat
+          disappears once real reports have taken over. */}
+      {(time.source.kind === 'estimated' || filament.source.kind === 'estimated') && (
+        <p className="text-xs text-content-tertiary" data-testid="cost-estimate-note">
+          {t('community.cost.estimateNote')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/community/components/PrintCostPanel/PrintCostPanel.tsx
+++ b/src/features/community/components/PrintCostPanel/PrintCostPanel.tsx
@@ -75,6 +75,10 @@ export function PrintCostPanel({ params, metrics, summary }: PrintCostPanelProps
   const duration =
     time.minutes === null ? null : formatPrintDuration(roundSummaryMinutes(time.minutes));
 
+  const showsEstimate =
+    (duration !== null && time.source.kind === 'estimated') ||
+    (filament.grams !== null && filament.source.kind === 'estimated');
+
   return (
     <div className="space-y-2" data-testid="print-cost-panel">
       <h3 className="text-sm font-medium text-content">{t('community.cost.title')}</h3>
@@ -130,9 +134,10 @@ export function PrintCostPanel({ params, metrics, summary }: PrintCostPanelProps
         <p className="text-xs text-content-tertiary">{t('community.cost.bedHint')}</p>
       )}
 
-      {/* Shown only while a figure is still model-derived, so the caveat
-          disappears once real reports have taken over. */}
-      {(time.source.kind === 'estimated' || filament.source.kind === 'estimated') && (
+      {/* Gated on a figure that is actually rendered, not merely on a source
+          kind: with no estimate to show, the note would claim a model figure
+          that is not there. Disappears once real reports have taken over. */}
+      {showsEstimate && (
         <p className="text-xs text-content-tertiary" data-testid="cost-estimate-note">
           {t('community.cost.estimateNote')}
         </p>

--- a/src/features/community/components/PrintCostPanel/index.ts
+++ b/src/features/community/components/PrintCostPanel/index.ts
@@ -1,0 +1,2 @@
+export { PrintCostPanel } from './PrintCostPanel';
+export type { PrintCostPanelProps } from './PrintCostPanel';

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Použít jako titulní obrázek",
   "community.prints.coverCurrent": "Titulní obrázek",
   "community.prints.clearCover": "Použít místo toho render",
-  "community.prints.coverFailed": "Titulní obrázek se nepodařilo změnit."
+  "community.prints.coverFailed": "Titulní obrázek se nepodařilo změnit.",
+  "community.cost.title": "Co tisk vyžaduje",
+  "community.cost.timeLabel": "Doba tisku",
+  "community.cost.filamentLabel": "Filament",
+  "community.cost.estimated": "Odhad",
+  "community.cost.observedOne": "Z 1 tisku",
+  "community.cost.observedOther": "Z {count} tisků",
+  "community.cost.estimateNote": "Odhadnuto z modelu při 0,2mm a 15% výplni. Skutečné tisky to nahradí, jakmile jich pár bude.",
+  "community.cost.bedFits": "Vejde se na tvou podložku",
+  "community.cost.bedTooLarge": "Větší než tvá podložka ({width} x {depth}mm)",
+  "community.cost.bedHint": "Otočení je zohledněno."
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Als Titelbild verwenden",
   "community.prints.coverCurrent": "Titelbild",
   "community.prints.clearCover": "Stattdessen Render verwenden",
-  "community.prints.coverFailed": "Titelbild konnte nicht geändert werden."
+  "community.prints.coverFailed": "Titelbild konnte nicht geändert werden.",
+  "community.cost.title": "Was der Druck erfordert",
+  "community.cost.timeLabel": "Druckzeit",
+  "community.cost.filamentLabel": "Filament",
+  "community.cost.estimated": "Geschätzt",
+  "community.cost.observedOne": "Aus 1 Druck",
+  "community.cost.observedOther": "Aus {count} Drucken",
+  "community.cost.estimateNote": "Geschätzt aus dem Modell bei 0,2mm und 15% Infill. Echte Drucke ersetzen dies, sobald einige berichten.",
+  "community.cost.bedFits": "Passt auf dein Druckbett",
+  "community.cost.bedTooLarge": "Größer als dein Druckbett ({width} x {depth}mm)",
+  "community.cost.bedHint": "Drehung wird berücksichtigt."
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3653,6 +3653,20 @@ const en: Record<string, string> = {
   'community.prints.verdictDidNotFit': '{count} did not fit',
   'community.prints.verdictHint': 'What other people found when they printed it.',
 
+  // Print cost panel: what this design costs to print, and whether that
+  // figure is a model estimate or what people actually reported.
+  'community.cost.title': 'What it takes to print',
+  'community.cost.timeLabel': 'Print time',
+  'community.cost.filamentLabel': 'Filament',
+  'community.cost.estimated': 'Estimated',
+  'community.cost.observedOne': 'From 1 print',
+  'community.cost.observedOther': 'From {count} prints',
+  'community.cost.estimateNote':
+    'Estimated from the model at 0.2mm, 15% infill. Real prints will replace this once a few people report theirs.',
+  'community.cost.bedFits': 'Fits your print bed',
+  'community.cost.bedTooLarge': 'Larger than your print bed ({width} x {depth}mm)',
+  'community.cost.bedHint': 'Rotation is taken into account.',
+
   // Post-remix continuation banner (bin designer)
   'binDesigner.remixBanner.text':
     'Remixing {name} by {author}. Publish your version when it is ready.',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Usar como portada",
   "community.prints.coverCurrent": "Imagen de portada",
   "community.prints.clearCover": "Usar el render en su lugar",
-  "community.prints.coverFailed": "No se pudo actualizar la portada."
+  "community.prints.coverFailed": "No se pudo actualizar la portada.",
+  "community.cost.title": "Lo que cuesta imprimirlo",
+  "community.cost.timeLabel": "Tiempo de impresión",
+  "community.cost.filamentLabel": "Filamento",
+  "community.cost.estimated": "Estimado",
+  "community.cost.observedOne": "Según 1 impresión",
+  "community.cost.observedOther": "Según {count} impresiones",
+  "community.cost.estimateNote": "Estimado con el modelo a 0,2mm y 15% de relleno. Las impresiones reales lo sustituirán cuando haya varias.",
+  "community.cost.bedFits": "Cabe en tu cama de impresión",
+  "community.cost.bedTooLarge": "Más grande que tu cama de impresión ({width} x {depth}mm)",
+  "community.cost.bedHint": "Se tiene en cuenta la rotación."
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Utiliser comme couverture",
   "community.prints.coverCurrent": "Image de couverture",
   "community.prints.clearCover": "Utiliser le rendu à la place",
-  "community.prints.coverFailed": "Impossible de mettre à jour la couverture."
+  "community.prints.coverFailed": "Impossible de mettre à jour la couverture.",
+  "community.cost.title": "Ce que l'impression demande",
+  "community.cost.timeLabel": "Temps d'impression",
+  "community.cost.filamentLabel": "Filament",
+  "community.cost.estimated": "Estimé",
+  "community.cost.observedOne": "D'après 1 impression",
+  "community.cost.observedOther": "D'après {count} impressions",
+  "community.cost.estimateNote": "Estimé à partir du modèle à 0,2mm et 15% de remplissage. Les impressions réelles remplaceront cette valeur.",
+  "community.cost.bedFits": "Tient sur votre plateau",
+  "community.cost.bedTooLarge": "Plus grand que votre plateau ({width} x {depth}mm)",
+  "community.cost.bedHint": "La rotation est prise en compte."
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Usa come copertina",
   "community.prints.coverCurrent": "Immagine di copertina",
   "community.prints.clearCover": "Usa invece il render",
-  "community.prints.coverFailed": "Impossibile aggiornare la copertina."
+  "community.prints.coverFailed": "Impossibile aggiornare la copertina.",
+  "community.cost.title": "Cosa serve per stamparlo",
+  "community.cost.timeLabel": "Tempo di stampa",
+  "community.cost.filamentLabel": "Filamento",
+  "community.cost.estimated": "Stimato",
+  "community.cost.observedOne": "Da 1 stampa",
+  "community.cost.observedOther": "Da {count} stampe",
+  "community.cost.estimateNote": "Stimato dal modello a 0,2mm e 15% di riempimento. Le stampe reali lo sostituiranno quando saranno alcune.",
+  "community.cost.bedFits": "Sta sul tuo piano di stampa",
+  "community.cost.bedTooLarge": "Più grande del tuo piano di stampa ({width} x {depth}mm)",
+  "community.cost.bedHint": "La rotazione è considerata."
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "カバー画像にする",
   "community.prints.coverCurrent": "カバー画像",
   "community.prints.clearCover": "代わりにレンダー画像を使う",
-  "community.prints.coverFailed": "カバー画像を更新できませんでした。"
+  "community.prints.coverFailed": "カバー画像を更新できませんでした。",
+  "community.cost.title": "プリントに必要なもの",
+  "community.cost.timeLabel": "プリント時間",
+  "community.cost.filamentLabel": "フィラメント",
+  "community.cost.estimated": "推定値",
+  "community.cost.observedOne": "1 件のプリントより",
+  "community.cost.observedOther": "{count} 件のプリントより",
+  "community.cost.estimateNote": "0.2mm・インフィル15%のモデルによる推定です。実際のプリント報告が集まると置き換わります。",
+  "community.cost.bedFits": "お使いのプリントベッドに収まります",
+  "community.cost.bedTooLarge": "プリントベッドより大きいです（{width} x {depth}mm）",
+  "community.cost.bedHint": "回転も考慮しています。"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "대표 이미지로 사용",
   "community.prints.coverCurrent": "대표 이미지",
   "community.prints.clearCover": "대신 렌더 이미지 사용",
-  "community.prints.coverFailed": "대표 이미지를 변경하지 못했습니다."
+  "community.prints.coverFailed": "대표 이미지를 변경하지 못했습니다.",
+  "community.cost.title": "출력에 필요한 것",
+  "community.cost.timeLabel": "출력 시간",
+  "community.cost.filamentLabel": "필라멘트",
+  "community.cost.estimated": "예상치",
+  "community.cost.observedOne": "출력 기록 1건 기준",
+  "community.cost.observedOther": "출력 기록 {count}건 기준",
+  "community.cost.estimateNote": "0.2mm, 인필 15% 기준 모델 예상치입니다. 실제 출력 기록이 쌓이면 대체됩니다.",
+  "community.cost.bedFits": "사용 중인 베드에 맞습니다",
+  "community.cost.bedTooLarge": "베드보다 큽니다 ({width} x {depth}mm)",
+  "community.cost.bedHint": "회전도 고려했습니다."
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Bruk som omslag",
   "community.prints.coverCurrent": "Omslagsbilde",
   "community.prints.clearCover": "Bruk gjengivelsen i stedet",
-  "community.prints.coverFailed": "Kunne ikke oppdatere omslaget."
+  "community.prints.coverFailed": "Kunne ikke oppdatere omslaget.",
+  "community.cost.title": "Hva utskriften krever",
+  "community.cost.timeLabel": "Utskriftstid",
+  "community.cost.filamentLabel": "Filament",
+  "community.cost.estimated": "Anslått",
+  "community.cost.observedOne": "Fra 1 utskrift",
+  "community.cost.observedOther": "Fra {count} utskrifter",
+  "community.cost.estimateNote": "Anslått fra modellen ved 0,2mm og 15% fyll. Ekte utskrifter erstatter dette når noen har rapportert.",
+  "community.cost.bedFits": "Får plass på byggeplaten din",
+  "community.cost.bedTooLarge": "Større enn byggeplaten din ({width} x {depth}mm)",
+  "community.cost.bedHint": "Rotasjon er tatt med."
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Als omslag gebruiken",
   "community.prints.coverCurrent": "Omslagafbeelding",
   "community.prints.clearCover": "Gebruik in plaats daarvan de render",
-  "community.prints.coverFailed": "Kon de omslag niet bijwerken."
+  "community.prints.coverFailed": "Kon de omslag niet bijwerken.",
+  "community.cost.title": "Wat printen kost",
+  "community.cost.timeLabel": "Printtijd",
+  "community.cost.filamentLabel": "Filament",
+  "community.cost.estimated": "Geschat",
+  "community.cost.observedOne": "Uit 1 print",
+  "community.cost.observedOther": "Uit {count} prints",
+  "community.cost.estimateNote": "Geschat op basis van het model bij 0,2mm en 15% vulling. Echte prints vervangen dit zodra er enkele zijn.",
+  "community.cost.bedFits": "Past op je printbed",
+  "community.cost.bedTooLarge": "Groter dan je printbed ({width} x {depth}mm)",
+  "community.cost.bedHint": "Rotatie wordt meegerekend."
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Użyj jako okładki",
   "community.prints.coverCurrent": "Obraz okładki",
   "community.prints.clearCover": "Użyj zamiast tego renderu",
-  "community.prints.coverFailed": "Nie udało się zaktualizować okładki."
+  "community.prints.coverFailed": "Nie udało się zaktualizować okładki.",
+  "community.cost.title": "Czego wymaga wydruk",
+  "community.cost.timeLabel": "Czas druku",
+  "community.cost.filamentLabel": "Filament",
+  "community.cost.estimated": "Szacowane",
+  "community.cost.observedOne": "Z 1 wydruku",
+  "community.cost.observedOther": "Z {count} wydruków",
+  "community.cost.estimateNote": "Oszacowane z modelu przy 0,2mm i 15% wypełnienia. Prawdziwe wydruki zastąpią tę wartość.",
+  "community.cost.bedFits": "Mieści się na twoim stole",
+  "community.cost.bedTooLarge": "Większe niż twój stół roboczy ({width} x {depth}mm)",
+  "community.cost.bedHint": "Obrót jest uwzględniony."
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Usar como capa",
   "community.prints.coverCurrent": "Imagem de capa",
   "community.prints.clearCover": "Usar a renderização",
-  "community.prints.coverFailed": "Não foi possível atualizar a capa."
+  "community.prints.coverFailed": "Não foi possível atualizar a capa.",
+  "community.cost.title": "O que a impressão exige",
+  "community.cost.timeLabel": "Tempo de impressão",
+  "community.cost.filamentLabel": "Filamento",
+  "community.cost.estimated": "Estimado",
+  "community.cost.observedOne": "De 1 impressão",
+  "community.cost.observedOther": "De {count} impressões",
+  "community.cost.estimateNote": "Estimado pelo modelo a 0,2mm e 15% de preenchimento. Impressões reais substituirão este valor.",
+  "community.cost.bedFits": "Cabe na sua mesa de impressão",
+  "community.cost.bedTooLarge": "Maior que sua mesa de impressão ({width} x {depth}mm)",
+  "community.cost.bedHint": "A rotação é considerada."
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Använd som omslag",
   "community.prints.coverCurrent": "Omslagsbild",
   "community.prints.clearCover": "Använd renderingen i stället",
-  "community.prints.coverFailed": "Kunde inte uppdatera omslaget."
+  "community.prints.coverFailed": "Kunde inte uppdatera omslaget.",
+  "community.cost.title": "Vad utskriften kräver",
+  "community.cost.timeLabel": "Utskriftstid",
+  "community.cost.filamentLabel": "Filament",
+  "community.cost.estimated": "Uppskattat",
+  "community.cost.observedOne": "Från 1 utskrift",
+  "community.cost.observedOther": "Från {count} utskrifter",
+  "community.cost.estimateNote": "Uppskattat från modellen vid 0,2mm och 15% fyllnad. Riktiga utskrifter ersätter detta när några rapporterats.",
+  "community.cost.bedFits": "Får plats på din byggplatta",
+  "community.cost.bedTooLarge": "Större än din byggplatta ({width} x {depth}mm)",
+  "community.cost.bedHint": "Rotation räknas in."
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "Використати як обкладинку",
   "community.prints.coverCurrent": "Зображення обкладинки",
   "community.prints.clearCover": "Використати рендер натомість",
-  "community.prints.coverFailed": "Не вдалося оновити обкладинку."
+  "community.prints.coverFailed": "Не вдалося оновити обкладинку.",
+  "community.cost.title": "Що потрібно для друку",
+  "community.cost.timeLabel": "Час друку",
+  "community.cost.filamentLabel": "Філамент",
+  "community.cost.estimated": "Оцінка",
+  "community.cost.observedOne": "З 1 друку",
+  "community.cost.observedOther": "З {count} друків",
+  "community.cost.estimateNote": "Оцінено за моделлю при 0,2мм і 15% заповнення. Реальні друки замінять це значення.",
+  "community.cost.bedFits": "Вміщується на твій стіл",
+  "community.cost.bedTooLarge": "Більше за твій стіл ({width} x {depth}мм)",
+  "community.cost.bedHint": "Обертання враховано."
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3479,5 +3479,15 @@
   "community.prints.useAsCover": "设为封面",
   "community.prints.coverCurrent": "封面图片",
   "community.prints.clearCover": "改用渲染图",
-  "community.prints.coverFailed": "无法更新封面图片。"
+  "community.prints.coverFailed": "无法更新封面图片。",
+  "community.cost.title": "打印所需",
+  "community.cost.timeLabel": "打印时间",
+  "community.cost.filamentLabel": "耗材",
+  "community.cost.estimated": "预估",
+  "community.cost.observedOne": "来自 1 次打印",
+  "community.cost.observedOther": "来自 {count} 次打印",
+  "community.cost.estimateNote": "基于 0.2mm、15% 填充的模型预估。有几次真实打印记录后将替换此数值。",
+  "community.cost.bedFits": "可放入你的热床",
+  "community.cost.bedTooLarge": "大于你的热床（{width} x {depth}mm）",
+  "community.cost.bedHint": "已考虑旋转摆放。"
 }

--- a/src/shared/utils/communityPrintCost.test.ts
+++ b/src/shared/utils/communityPrintCost.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { CommunityDesignMetrics } from '@/shared/types/community';
+import type { CommunityPrintSummary } from '@/shared/types/communityPrint';
+import { OBSERVED_MIN_SAMPLE, fitsPrintBed, resolvePrintCost } from './communityPrintCost';
+import type { CommunityPrintEstimate } from './communityPrintCost';
+
+const ESTIMATE: CommunityPrintEstimate = { grams: 20, meters: 6.7, minutes: 100 };
+
+function summary(overrides: Partial<CommunityPrintSummary> = {}): CommunityPrintSummary {
+  return {
+    count: 5,
+    asDesigned: 5,
+    adjusted: 0,
+    didNotFit: 0,
+    commonMaterial: 'pla',
+    commonLayerHeightMm: 0.2,
+    medianPrintMinutes: 130,
+    medianFilamentGrams: 24,
+    ...overrides,
+  };
+}
+
+describe('resolvePrintCost', () => {
+  it('falls back to the estimate when nobody has printed it', () => {
+    const { time, filament } = resolvePrintCost(ESTIMATE, null);
+
+    expect(time).toMatchObject({ minutes: 100, source: { kind: 'estimated' } });
+    expect(filament).toMatchObject({ grams: 20, source: { kind: 'estimated' } });
+  });
+
+  it('prefers observed medians once the sample is large enough', () => {
+    const { time, filament } = resolvePrintCost(ESTIMATE, summary());
+
+    expect(time).toMatchObject({ minutes: 130, source: { kind: 'observed', sampleSize: 5 } });
+    expect(filament).toMatchObject({ grams: 24, source: { kind: 'observed', sampleSize: 5 } });
+  });
+
+  it('keeps the estimate while only one person has reported', () => {
+    const { time } = resolvePrintCost(ESTIMATE, summary({ count: 1 }));
+
+    // One print is a data point, not a distribution: they may have printed at
+    // 0.3mm on a machine nothing like yours.
+    expect(time).toMatchObject({ minutes: 100, source: { kind: 'estimated' } });
+  });
+
+  it('switches over exactly at the sample threshold', () => {
+    const below = resolvePrintCost(ESTIMATE, summary({ count: OBSERVED_MIN_SAMPLE - 1 }));
+    const at = resolvePrintCost(ESTIMATE, summary({ count: OBSERVED_MIN_SAMPLE }));
+
+    expect(below.time.source.kind).toBe('estimated');
+    expect(at.time.source.kind).toBe('observed');
+  });
+
+  it('resolves time and filament independently', () => {
+    // Reporting filament is optional, so an observed time alongside an
+    // estimated weight is the normal case, not an edge case.
+    const { time, filament } = resolvePrintCost(ESTIMATE, summary({ medianFilamentGrams: null }));
+
+    expect(time.source.kind).toBe('observed');
+    expect(filament).toMatchObject({ grams: 20, source: { kind: 'estimated' } });
+  });
+
+  it('reports nulls rather than zeros when there is neither estimate nor report', () => {
+    const { time, filament } = resolvePrintCost(null, null);
+
+    // A missing figure must not render as a measured zero.
+    expect(time.minutes).toBeNull();
+    expect(filament.grams).toBeNull();
+  });
+
+  it('still surfaces observed data when the design has no estimate', () => {
+    const { time } = resolvePrintCost(null, summary());
+    expect(time).toMatchObject({ minutes: 130, source: { kind: 'observed', sampleSize: 5 } });
+  });
+});
+
+describe('fitsPrintBed', () => {
+  function metrics(width: number, depth: number): CommunityDesignMetrics {
+    return { width, depth, height: 42, gridUnitMm: 42 };
+  }
+
+  it('fits a design well inside the bed', () => {
+    expect(fitsPrintBed(metrics(83.5, 125.5), 256, 256)).toBe('fits');
+  });
+
+  it('fits a design that only works rotated', () => {
+    // Every slicer will rotate it for you, so refusing this would be wrong.
+    expect(fitsPrintBed(metrics(200, 100), 120, 250)).toBe('fits');
+  });
+
+  it('rejects a design larger than the bed in both orientations', () => {
+    expect(fitsPrintBed(metrics(300, 300), 256, 256)).toBe('too-large');
+  });
+
+  it('accepts a design exactly the size of the bed', () => {
+    expect(fitsPrintBed(metrics(256, 256), 256, 256)).toBe('fits');
+  });
+
+  it.each([
+    [0, 256],
+    [256, 0],
+    [Number.NaN, 256],
+    [Number.POSITIVE_INFINITY, 256],
+  ])('reports unknown for an unusable bed (%s x %s)', (w, d) => {
+    expect(fitsPrintBed(metrics(83.5, 125.5), w, d)).toBe('unknown');
+  });
+
+  it('reports unknown for unusable metrics rather than guessing', () => {
+    expect(fitsPrintBed(metrics(0, 125.5), 256, 256)).toBe('unknown');
+  });
+});

--- a/src/shared/utils/communityPrintCost.ts
+++ b/src/shared/utils/communityPrintCost.ts
@@ -1,0 +1,124 @@
+/**
+ * "What will this cost me to print" for a community design.
+ *
+ * Lives in shared rather than in the community slice because the estimator it
+ * wraps is bin-designer internal, and features cannot import across slices.
+ * shared/ is the sanctioned bridge (see `shared/items/bin/descriptor.ts` for
+ * the same pattern).
+ *
+ * The central rule here: **observed beats estimated, and the difference is
+ * never hidden.** A model estimate and twelve people's actual print times are
+ * different kinds of claim, so they carry a `source` the UI must render
+ * differently. Presenting an estimate as though it were measured is the exact
+ * failure this feature exists to avoid.
+ */
+
+import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
+import type { BinParams } from '@/shared/types/bin';
+import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
+import type { PrintSettings } from '@/shared/printSettings';
+import type { CommunityDesignMetrics } from '@/shared/types/community';
+import type { CommunityPrintSummary } from '@/shared/types/communityPrint';
+
+export interface CommunityPrintEstimate {
+  readonly grams: number;
+  readonly meters: number;
+  readonly minutes: number;
+}
+
+export function estimateCommunityPrint(
+  params: BinParams,
+  settings: PrintSettings = DEFAULT_PRINT_SETTINGS
+): CommunityPrintEstimate {
+  const estimate = estimatePrint(params, settings);
+  return {
+    grams: estimate.gramsFilament,
+    meters: estimate.metersFilament,
+    minutes: estimate.printTimeMinutes,
+  };
+}
+
+/**
+ * How a displayed figure was arrived at. `observed` carries the sample size,
+ * because "about 2h, from 12 prints" and "about 2h, from 1 print" are not
+ * equally trustworthy and the reader should be able to tell.
+ */
+export type PrintCostSource =
+  { readonly kind: 'observed'; readonly sampleSize: number } | { readonly kind: 'estimated' };
+
+export interface PrintCostFigure {
+  readonly minutes: number | null;
+  readonly grams: number | null;
+  readonly source: PrintCostSource;
+}
+
+/**
+ * Minimum reports before observed data displaces the model.
+ *
+ * One person's print is a data point, not a distribution: they may have
+ * printed at 0.3mm on a machine nothing like yours. Two agreeing medians are
+ * weak evidence but they are evidence, and by then the model has been checked
+ * against reality at least twice.
+ */
+export const OBSERVED_MIN_SAMPLE = 2;
+
+/**
+ * Resolve what to show, preferring real reports over the model.
+ *
+ * Time and filament resolve independently: reporting filament is optional, so
+ * a design can easily have an observed time and an estimated weight. Mixing
+ * them is correct, and the UI labels each.
+ */
+export function resolvePrintCost(
+  estimate: CommunityPrintEstimate | null,
+  summary: CommunityPrintSummary | null
+): { time: PrintCostFigure; filament: PrintCostFigure } {
+  const observedCount = summary?.count ?? 0;
+  const enough = observedCount >= OBSERVED_MIN_SAMPLE;
+
+  const observedMinutes = enough ? (summary?.medianPrintMinutes ?? null) : null;
+  const observedGrams = enough ? (summary?.medianFilamentGrams ?? null) : null;
+
+  return {
+    time:
+      observedMinutes !== null
+        ? {
+            minutes: observedMinutes,
+            grams: null,
+            source: { kind: 'observed', sampleSize: observedCount },
+          }
+        : { minutes: estimate?.minutes ?? null, grams: null, source: { kind: 'estimated' } },
+    filament:
+      observedGrams !== null
+        ? {
+            minutes: null,
+            grams: observedGrams,
+            source: { kind: 'observed', sampleSize: observedCount },
+          }
+        : { minutes: null, grams: estimate?.grams ?? null, source: { kind: 'estimated' } },
+  };
+}
+
+export type BedFit = 'fits' | 'too-large' | 'unknown';
+
+/**
+ * Whether the design's footprint fits the viewer's bed.
+ *
+ * Footprint only: height is a separate constraint with its own setting, and a
+ * bin taller than the machine is a far rarer problem than one that is too wide.
+ * Rotation is allowed, because every slicer will do it for you.
+ */
+export function fitsPrintBed(
+  metrics: CommunityDesignMetrics,
+  bedWidthMm: number,
+  bedDepthMm: number
+): BedFit {
+  if (!Number.isFinite(bedWidthMm) || !Number.isFinite(bedDepthMm)) return 'unknown';
+  if (bedWidthMm <= 0 || bedDepthMm <= 0) return 'unknown';
+  if (!Number.isFinite(metrics.width) || !Number.isFinite(metrics.depth)) return 'unknown';
+  if (metrics.width <= 0 || metrics.depth <= 0) return 'unknown';
+
+  const upright = metrics.width <= bedWidthMm && metrics.depth <= bedDepthMm;
+  const rotated = metrics.depth <= bedWidthMm && metrics.width <= bedDepthMm;
+  return upright || rotated ? 'fits' : 'too-large';
+}


### PR DESCRIPTION
Phase 2 of the community direction: answer **"what will this cost me"** before someone commits to a print. Phase 1 (proof of print) shipped in #3178, #3183, #3191, #3195.

## The rule this is built around

**Observed beats estimated, and the difference is never hidden.**

A model estimate and the median of twelve real prints are different kinds of claim. Collapsing them into one confident-looking number is precisely the failure this whole direction exists to avoid, so every figure carries a `source` and the panel renders them as distinct badges: *Estimated* vs *From 12 prints*.

Three consequences worth reviewing:

- **Time and filament resolve independently.** Reporting filament is optional, so an observed print time beside an estimated weight is the normal case, not an edge case. The panel labels each separately.
- **Observed data only displaces the model at 2 reports** (`OBSERVED_MIN_SAMPLE`). One person's print is a data point, not a distribution: they may have printed at 0.3mm on a machine nothing like yours. Two agreeing medians are weak evidence, but by then the model has been checked against reality twice.
- **The estimate caveat disappears once real reports take over.** It would be noise on a design with a dozen prints behind it.

Now that Phase 1 is collecting real `printMinutes` and `filamentGrams`, this is the calibration loop the plan described: the model fills the gap until reality arrives, then gets out of the way.

## Bed fit

Compares the design's footprint against the viewer's configured print bed, and **allows rotation**, because every slicer will rotate it for you. Refusing a design that fits sideways would be wrong.

The "rotation is taken into account" note renders only next to a *negative* verdict, where it answers the obvious "but what if I turn it?" before it is asked. Next to a positive verdict it would be noise.

Footprint only: height is a separate constraint with its own setting, and a bin taller than the machine is a far rarer problem than one too wide.

## Notes for review

**Where the estimator lives.** `estimatePrint` is bin-designer internal, and features cannot import across slices, so the wrapper sits in `shared/utils/communityPrintCost.ts` — the sanctioned bridge, matching `shared/items/bin/descriptor.ts`. It deliberately does not go in `shared/printSettings/`, which the estimator itself imports, as that would make a real runtime cycle.

**The estimate is wrapped in a try/catch.** A design published by an older client can carry params this build's estimator does not understand. No estimate is honest; a wrong one is not; and neither should take the detail view down. Covered by a test.

**No new network request.** The overlay already fetches prints once for the CTA, and that response carries the summary, so the panel reads it from the same stamped record rather than fetching again.

## Testing

24 new tests: the resolution rules (threshold behaviour, independent resolution, nulls rather than zeros when there is neither estimate nor report), bed fit (rotation, exact-size, unusable bed and unusable metrics), and the panel (source labelling in all three combinations, bed verdicts, estimator failure, and the render-nothing case).

Full suite green.

## Next

3. Author pages and the remix tree
4. Editorial collections

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show print cost upfront on community designs. The panel shows print time, filament, and bed fit with clear “Estimated” vs “From N prints” badges, integrated into the design detail with no extra requests.

- **New Features**
  - Added `components/PrintCostPanel/` to show time and filament with independent sources; the caveat disappears once observed data is used.
  - Bed fit check allows rotation; the rotation hint only appears when the design is too large.
  - Introduced `@/shared/utils/communityPrintCost` (`estimateCommunityPrint`, `resolvePrintCost`, `fitsPrintBed`); `estimateCommunityPrint` now propagates estimator errors, and the panel catches them to avoid breaking the page.
  - Wired into `CommunityDetail` via `costSlot`, reusing `CommunityPrintSummary` from `fetchPrints` (no extra network calls). Added i18n strings and allowlist entry; tests cover resolution rules, bed fit, panel states, and estimator failure.

- **Bug Fixes**
  - Show the “estimated from model” note only when an estimated value is actually rendered.
  - Refresh the panel with `printsRefresh` so saving a print flips to “observed”; updated README to note error handling lives in the panel.

<sup>Written for commit 96130c0080a2af28faf042d4ee9eab9a11db963c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

