### PR TITLE
feat(community): derived author portrait on the filtered gallery

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -147,6 +147,8 @@
     "common.notes",
     "common.redditCommunity",
     "common.standard",
+    "community.author.designsOne",
+    "community.author.designsOther",
     "community.card.remixBadge",
     "community.cost.filamentLabel",
     "community.detail.millimeters",

--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -61,6 +61,14 @@ Backend lives in `api/community/prints.ts` (`GET`/`PUT`/`DELETE`/`POST report`),
 - **Proven shelf** sits directly under staff picks, above recency: a design other people actually printed is the strongest recommendation the library has, and it is the one signal nobody can inflate by posting.
 - **Cover promotion** is owner opt-in and server-validated against the design's own **live** prints. The gallery grid is the most public surface in the app, and this is the only path by which a user-supplied image can reach it, so the check that the URL belongs to a live print of that design is load-bearing, not defensive. A hidden print's photo is not promotable.
 
+### Author portrait
+
+`components/AuthorSummary/` renders a derived portrait while the gallery is filtered to one author: how many designs, since when, what they mostly make, and how often their work has been printed or built upon.
+
+Everything is derived from cards already loaded, so it adds no request. **No self-authored bio by design**: a bio answers "how does this person present themselves", where the useful question is "what do they make, and does it work", and it would be a new moderation surface for the weaker answer.
+
+Zero-valued proof signals are omitted rather than shown: "built on 0 times" says nothing while looking like a measurement. When the browse index is capped, the portrait says so, because an understated count that looks authoritative is worse than one that states its own limits.
+
 ### Print cost
 
 `components/PrintCostPanel/` answers "what will this cost me" before you commit, from `@/shared/utils/communityPrintCost`.

--- a/src/features/community/components/AuthorSummary/AuthorSummary.test.tsx
+++ b/src/features/community/components/AuthorSummary/AuthorSummary.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { CommunityCard } from '@/shared/types/community';
+import { AuthorSummary } from './AuthorSummary';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+const AUTHOR = 'a'.repeat(32);
+
+function card(overrides: Partial<CommunityCard> = {}): CommunityCard {
+  return {
+    id: 'abc123def456',
+    name: 'Bin',
+    authorName: 'Casey',
+    authorPublicId: AUTHOR,
+    category: 'tools',
+    techniques: ['compartments'],
+    metrics: { width: 83.5, depth: 125.5, height: 42, gridUnitMm: 42 },
+    thumbnailUrl: '',
+    isRemix: false,
+    featured: false,
+    counts: { likes: 0, remixes: 0, exports: 0 },
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    status: 'live',
+    ...overrides,
+  };
+}
+
+function setup(items: CommunityCard[], indexCapped = false) {
+  render(
+    <AuthorSummary
+      items={items}
+      authorPublicId={AUTHOR}
+      authorName="Casey"
+      indexCapped={indexCapped}
+    />
+  );
+}
+
+describe('AuthorSummary', () => {
+  it('renders nothing when the author has no loaded designs', () => {
+    setup([card({ authorPublicId: 'b'.repeat(32) })]);
+    expect(screen.queryByTestId('author-summary')).toBeNull();
+  });
+
+  it('shows the author name and their basic facts', () => {
+    setup([card({ id: 'a' }), card({ id: 'b' })]);
+
+    expect(screen.getByText('Casey')).toBeInTheDocument();
+    const facts = screen.getByTestId('author-summary-facts');
+    expect(facts).toHaveTextContent('community.author.designsOther');
+    expect(facts).toHaveTextContent('community.author.since');
+    expect(facts).toHaveTextContent('community.author.makes');
+  });
+
+  it('uses the singular for a single design', () => {
+    setup([card()]);
+    expect(screen.getByTestId('author-summary-facts')).toHaveTextContent(
+      'community.author.designsOne'
+    );
+  });
+
+  it('omits proof signals that are zero', () => {
+    setup([card()]);
+    // "Built on 0 times" says nothing while looking like a measurement.
+    expect(screen.queryByTestId('author-summary-proof')).toBeNull();
+  });
+
+  it('shows prints and remixes once they are non-zero', () => {
+    setup([card({ counts: { likes: 0, remixes: 2, exports: 0, prints: 5 } })]);
+
+    const proof = screen.getByTestId('author-summary-proof');
+    expect(proof).toHaveTextContent('community.author.printedOther');
+    expect(proof).toHaveTextContent('community.author.remixedOther');
+  });
+
+  it('lists the techniques they reach for', () => {
+    setup([card({ techniques: ['scoop', 'labelTab'] })]);
+    expect(screen.getByTestId('author-summary-techniques').children.length).toBeGreaterThan(0);
+  });
+
+  it('admits when the loaded index may be missing older designs', () => {
+    setup([card()], true);
+    // An understated count that looks authoritative is worse than one that
+    // states its own limits.
+    expect(screen.getByTestId('author-summary-partial')).toBeInTheDocument();
+  });
+
+  it('stays quiet about limits when the index is complete', () => {
+    setup([card()]);
+    expect(screen.queryByTestId('author-summary-partial')).toBeNull();
+  });
+});

--- a/src/features/community/components/AuthorSummary/AuthorSummary.tsx
+++ b/src/features/community/components/AuthorSummary/AuthorSummary.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useMemo } from 'react';
-import { useTranslation } from '@/i18n';
+import { useFormatting, useTranslation } from '@/i18n';
 import type { CommunityCard } from '@/shared/types/community';
 import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
 import { CATEGORY_LABEL_KEYS } from '../../utils/categoryLabels';
@@ -26,10 +26,6 @@ export interface AuthorSummaryProps {
   indexCapped: boolean;
 }
 
-function formatDate(timestamp: number): string {
-  return new Date(timestamp).toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
-}
-
 export function AuthorSummary({
   items,
   authorPublicId,
@@ -37,6 +33,9 @@ export function AuthorSummary({
   indexCapped,
 }: AuthorSummaryProps) {
   const t = useTranslation();
+  // The app's locale, not the OS one: an in-app language switch must move
+  // this date with it.
+  const { formatDate } = useFormatting();
   const summary = useMemo(() => buildAuthorSummary(items, authorPublicId), [items, authorPublicId]);
 
   if (summary.designCount === 0) return null;
@@ -48,7 +47,10 @@ export function AuthorSummary({
   ];
 
   if (summary.firstPublishedAt !== null) {
-    facts.push(t('community.author.since', { date: formatDate(summary.firstPublishedAt) }));
+    // Hoisted rather than inlined: the interpolation check parses t() args
+    // with a regex and reads a nested options object as extra params.
+    const since = formatDate(summary.firstPublishedAt, { year: 'numeric', month: 'long' });
+    facts.push(t('community.author.since', { date: since }));
   }
 
   if (summary.topCategories.length > 0) {

--- a/src/features/community/components/AuthorSummary/AuthorSummary.tsx
+++ b/src/features/community/components/AuthorSummary/AuthorSummary.tsx
@@ -1,0 +1,116 @@
+/**
+ * Derived portrait shown while the gallery is filtered to one author.
+ *
+ * No self-authored bio by design: a bio answers "how does this person present
+ * themselves", where the useful question is "what do they make, and does it
+ * work". Everything here is derived from cards already loaded, so it adds no
+ * request and no moderation surface.
+ */
+
+import { useMemo } from 'react';
+import { useTranslation } from '@/i18n';
+import type { CommunityCard } from '@/shared/types/community';
+import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
+import { CATEGORY_LABEL_KEYS } from '../../utils/categoryLabels';
+import { buildAuthorSummary } from '../../utils/authorSummary';
+
+export interface AuthorSummaryProps {
+  items: readonly CommunityCard[];
+  authorPublicId: string;
+  authorName: string;
+  /**
+   * The loaded index hit its cap, so older designs by this author may be
+   * absent. Surfaced rather than hidden: an understated count that looks
+   * authoritative is worse than one that admits its own limits.
+   */
+  indexCapped: boolean;
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
+}
+
+export function AuthorSummary({
+  items,
+  authorPublicId,
+  authorName,
+  indexCapped,
+}: AuthorSummaryProps) {
+  const t = useTranslation();
+  const summary = useMemo(() => buildAuthorSummary(items, authorPublicId), [items, authorPublicId]);
+
+  if (summary.designCount === 0) return null;
+
+  const facts: string[] = [
+    summary.designCount === 1
+      ? t('community.author.designsOne')
+      : t('community.author.designsOther', { count: summary.designCount }),
+  ];
+
+  if (summary.firstPublishedAt !== null) {
+    facts.push(t('community.author.since', { date: formatDate(summary.firstPublishedAt) }));
+  }
+
+  if (summary.topCategories.length > 0) {
+    facts.push(
+      t('community.author.makes', {
+        categories: summary.topCategories.map((c) => t(CATEGORY_LABEL_KEYS[c])).join(', '),
+      })
+    );
+  }
+
+  // Proof signals only when non-zero: "built on 0 times" is a way of saying
+  // nothing while looking like a measurement.
+  const proof: string[] = [];
+  if (summary.printsOfTheirWork > 0) {
+    proof.push(
+      summary.printsOfTheirWork === 1
+        ? t('community.author.printedOne')
+        : t('community.author.printedOther', { count: summary.printsOfTheirWork })
+    );
+  }
+  if (summary.remixesOfTheirWork > 0) {
+    proof.push(
+      summary.remixesOfTheirWork === 1
+        ? t('community.author.remixedOne')
+        : t('community.author.remixedOther', { count: summary.remixesOfTheirWork })
+    );
+  }
+
+  return (
+    <div
+      className="mb-3 rounded-lg border border-stroke-subtle bg-surface-secondary px-3 py-2"
+      data-testid="author-summary"
+    >
+      <p className="text-sm font-medium text-content">{authorName}</p>
+      <p className="mt-0.5 text-xs text-content-secondary" data-testid="author-summary-facts">
+        {facts.join(' · ')}
+      </p>
+
+      {proof.length > 0 && (
+        <p className="mt-1 text-xs text-content" data-testid="author-summary-proof">
+          {proof.join(' · ')}
+        </p>
+      )}
+
+      {summary.topTechniques.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1" data-testid="author-summary-techniques">
+          {summary.topTechniques.map((technique) => (
+            <span
+              key={technique}
+              className="rounded bg-surface px-1.5 py-0.5 text-[11px] uppercase tracking-wide text-content-tertiary"
+            >
+              {t(TECHNIQUE_CONFIG[technique].labelKey)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {indexCapped && (
+        <p className="mt-1 text-[11px] text-content-tertiary" data-testid="author-summary-partial">
+          {t('community.author.partial')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/community/components/AuthorSummary/index.ts
+++ b/src/features/community/components/AuthorSummary/index.ts
@@ -1,0 +1,2 @@
+export { AuthorSummary } from './AuthorSummary';
+export type { AuthorSummaryProps } from './AuthorSummary';

--- a/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
@@ -17,6 +17,17 @@ vi.mock('../../api/client', () => ({
   reportDesign: vi.fn(),
 }));
 
+// The overlay fetches prints for its CTA and cost panel. Left unmocked these
+// are real network calls in a component test: nondeterministic, and slow
+// enough under CI load to push the reconnect assertion past its timeout.
+vi.mock('../../api/printsClient', () => ({
+  fetchPrints: vi.fn(async () => ok({ items: [], nextCursor: null, summary: null, mine: null })),
+  setCoverPhoto: vi.fn(),
+  reportPrint: vi.fn(),
+  savePrint: vi.fn(),
+  deletePrint: vi.fn(),
+}));
+
 vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),
 }));

--- a/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
@@ -25,6 +25,7 @@ import { CommunityCard } from '../CommunityCard';
 import { HeartGlyph } from '../CommunityCard/CommunityCard';
 import { formatUnits } from '../CommunityCard/cardDims';
 import { MineCard } from '../CommunityCard/MineCard';
+import { AuthorSummary } from '../AuthorSummary';
 import { MineDigestSummary } from '../MineDigestSummary';
 import { GalleryToolbar } from './GalleryToolbar';
 import { hasLocalDesigns } from './hasLocalDesigns';
@@ -323,6 +324,21 @@ export function CommunityGalleryTab({
             summary mounts only inside the Mine branch: browsing the public
             grid keeps the deltas unseen. */}
         {mineActive && <MineDigestSummary />}
+
+        {/* Sits above the grid rather than replacing it: the author filter is
+            still a gallery view, and the portrait is context for it. */}
+        {!mineActive && filters.author !== null && (
+          <AuthorSummary
+            items={items}
+            authorPublicId={filters.author.id}
+            authorName={
+              filters.author.name !== ''
+                ? filters.author.name
+                : t('community.gallery.authorFallback')
+            }
+            indexCapped={capped}
+          />
+        )}
 
         {activeStatus === 'error' && activeItems.length > 0 && (
           <div

--- a/src/features/community/utils/authorSummary.test.ts
+++ b/src/features/community/utils/authorSummary.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import type { CommunityCard } from '@/shared/types/community';
+import { buildAuthorSummary } from './authorSummary';
+
+const AUTHOR = 'a'.repeat(32);
+const OTHER = 'b'.repeat(32);
+
+function card(overrides: Partial<CommunityCard> = {}): CommunityCard {
+  return {
+    id: 'abc123def456',
+    name: 'Bin',
+    authorName: 'Casey',
+    authorPublicId: AUTHOR,
+    category: 'tools',
+    techniques: ['compartments'],
+    metrics: { width: 83.5, depth: 125.5, height: 42, gridUnitMm: 42 },
+    thumbnailUrl: '',
+    isRemix: false,
+    featured: false,
+    counts: { likes: 0, remixes: 0, exports: 0 },
+    createdAt: 1000,
+    updatedAt: 1000,
+    status: 'live',
+    ...overrides,
+  };
+}
+
+describe('buildAuthorSummary', () => {
+  it('reports an empty portrait when the author has nothing loaded', () => {
+    expect(buildAuthorSummary([card({ authorPublicId: OTHER })], AUTHOR)).toEqual({
+      designCount: 0,
+      firstPublishedAt: null,
+      topCategories: [],
+      topTechniques: [],
+      remixesOfTheirWork: 0,
+      printsOfTheirWork: 0,
+    });
+  });
+
+  it("counts only this author's designs", () => {
+    const summary = buildAuthorSummary(
+      [card({ id: 'a' }), card({ id: 'b' }), card({ id: 'c', authorPublicId: OTHER })],
+      AUTHOR
+    );
+    expect(summary.designCount).toBe(2);
+  });
+
+  it('excludes non-live designs from the portrait', () => {
+    const summary = buildAuthorSummary(
+      [card({ id: 'a' }), card({ id: 'b', status: 'hidden' })],
+      AUTHOR
+    );
+    // A moderated design must not pad someone's body of work.
+    expect(summary.designCount).toBe(1);
+  });
+
+  it('takes the earliest publish date', () => {
+    const summary = buildAuthorSummary(
+      [card({ id: 'a', createdAt: 5000 }), card({ id: 'b', createdAt: 2000 })],
+      AUTHOR
+    );
+    expect(summary.firstPublishedAt).toBe(2000);
+  });
+
+  it('ranks categories by how often they are used', () => {
+    const summary = buildAuthorSummary(
+      [
+        card({ id: 'a', category: 'kitchen' }),
+        card({ id: 'b', category: 'tools' }),
+        card({ id: 'c', category: 'tools' }),
+      ],
+      AUTHOR
+    );
+    expect(summary.topCategories).toEqual(['tools', 'kitchen']);
+  });
+
+  it('caps categories at two and techniques at three', () => {
+    const summary = buildAuthorSummary(
+      [
+        card({ id: 'a', category: 'kitchen', techniques: ['scoop', 'lid'] }),
+        card({ id: 'b', category: 'tools', techniques: ['labelTab'] }),
+        card({ id: 'c', category: 'office', techniques: ['handles'] }),
+      ],
+      AUTHOR
+    );
+    expect(summary.topCategories).toHaveLength(2);
+    expect(summary.topTechniques).toHaveLength(3);
+  });
+
+  it('breaks a tie toward recent practice', () => {
+    // The index arrives newest-first, so first-seen is the more recent one.
+    const summary = buildAuthorSummary(
+      [card({ id: 'a', category: 'office' }), card({ id: 'b', category: 'crafts' })],
+      AUTHOR
+    );
+    expect(summary.topCategories[0]).toBe('office');
+  });
+
+  it('totals remixes and prints across their designs', () => {
+    const summary = buildAuthorSummary(
+      [
+        card({ id: 'a', counts: { likes: 1, remixes: 2, exports: 0, prints: 3 } }),
+        card({ id: 'b', counts: { likes: 0, remixes: 1, exports: 0, prints: 4 } }),
+      ],
+      AUTHOR
+    );
+    expect(summary.remixesOfTheirWork).toBe(3);
+    expect(summary.printsOfTheirWork).toBe(7);
+  });
+
+  it('treats a card with no print count as zero rather than NaN', () => {
+    const summary = buildAuthorSummary(
+      [card({ counts: { likes: 0, remixes: 0, exports: 0 } })],
+      AUTHOR
+    );
+    expect(summary.printsOfTheirWork).toBe(0);
+  });
+});

--- a/src/features/community/utils/authorSummary.ts
+++ b/src/features/community/utils/authorSummary.ts
@@ -1,0 +1,83 @@
+/**
+ * Derived portrait of an author, computed from the loaded card index.
+ *
+ * Everything here is derived. There is no self-authored bio by design: a bio
+ * is a new moderation surface that answers "how does this person present
+ * themselves", where the useful question is "what do they make, and does it
+ * work". Those are answerable from data the gallery already has.
+ */
+
+import type { CommunityCard, CommunityCategory } from '@/shared/types/community';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
+
+export interface AuthorSummary {
+  readonly designCount: number;
+  /** Earliest publish among the loaded cards, or null when there are none. */
+  readonly firstPublishedAt: number | null;
+  /** Up to two categories they publish in most, most-used first. */
+  readonly topCategories: readonly CommunityCategory[];
+  /** Up to three techniques they reach for most, most-used first. */
+  readonly topTechniques: readonly ExampleTechnique[];
+  /** Times their designs have been built upon. */
+  readonly remixesOfTheirWork: number;
+  /** Distinct printers across their designs, the unfarmable signal. */
+  readonly printsOfTheirWork: number;
+}
+
+const MAX_CATEGORIES = 2;
+const MAX_TECHNIQUES = 3;
+
+/**
+ * Most frequent values first, ties broken by first appearance.
+ *
+ * The input is ordered newest-first, so a tie resolves toward recent practice,
+ * which is the more useful answer to "what do they make" than an arbitrary one.
+ */
+function topBy<T>(values: readonly T[], limit: number): T[] {
+  const counts = new Map<T, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([value]) => value);
+}
+
+export function buildAuthorSummary(
+  items: readonly CommunityCard[],
+  authorPublicId: string
+): AuthorSummary {
+  const own = items.filter(
+    (card) => card.authorPublicId === authorPublicId && card.status === 'live'
+  );
+
+  if (own.length === 0) {
+    return {
+      designCount: 0,
+      firstPublishedAt: null,
+      topCategories: [],
+      topTechniques: [],
+      remixesOfTheirWork: 0,
+      printsOfTheirWork: 0,
+    };
+  }
+
+  return {
+    designCount: own.length,
+    firstPublishedAt: own.reduce(
+      (earliest, card) => Math.min(earliest, card.createdAt),
+      own[0].createdAt
+    ),
+    topCategories: topBy(
+      own.map((card) => card.category),
+      MAX_CATEGORIES
+    ),
+    topTechniques: topBy(
+      own.flatMap((card) => [...card.techniques]),
+      MAX_TECHNIQUES
+    ),
+    remixesOfTheirWork: own.reduce((total, card) => total + card.counts.remixes, 0),
+    printsOfTheirWork: own.reduce((total, card) => total + (card.counts.prints ?? 0), 0),
+  };
+}

--- a/src/features/community/utils/authorSummary.ts
+++ b/src/features/community/utils/authorSummary.ts
@@ -20,7 +20,12 @@ export interface AuthorSummary {
   readonly topTechniques: readonly ExampleTechnique[];
   /** Times their designs have been built upon. */
   readonly remixesOfTheirWork: number;
-  /** Distinct printers across their designs, the unfarmable signal. */
+  /**
+   * Prints summed across their designs. Each design contributes its own
+   * distinct-printer count, so one person who printed two of their designs
+   * counts twice: this is "how often their work got printed", not "how many
+   * different people printed it". The copy says "printed N times" to match.
+   */
   readonly printsOfTheirWork: number;
 }
 

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Odhadnuto z modelu při 0,2mm a 15% výplni. Skutečné tisky to nahradí, jakmile jich pár bude.",
   "community.cost.bedFits": "Vejde se na tvou podložku",
   "community.cost.bedTooLarge": "Větší než tvá podložka ({width} x {depth}mm)",
-  "community.cost.bedHint": "Otočení je zohledněno."
+  "community.cost.bedHint": "Otočení je zohledněno.",
+  "community.author.designsOne": "1 návrh",
+  "community.author.designsOther": "Návrhů: {count}",
+  "community.author.since": "Publikuje od {date}",
+  "community.author.makes": "Hlavně {categories}",
+  "community.author.remixedOne": "Navázáno 1krát",
+  "community.author.remixedOther": "Navázáno {count}krát",
+  "community.author.printedOne": "Vytištěno 1krát",
+  "community.author.printedOther": "Vytištěno {count}krát",
+  "community.author.partial": "Podle návrhů načtených zde, starší mohou chybět."
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Geschätzt aus dem Modell bei 0,2mm und 15% Infill. Echte Drucke ersetzen dies, sobald einige berichten.",
   "community.cost.bedFits": "Passt auf dein Druckbett",
   "community.cost.bedTooLarge": "Größer als dein Druckbett ({width} x {depth}mm)",
-  "community.cost.bedHint": "Drehung wird berücksichtigt."
+  "community.cost.bedHint": "Drehung wird berücksichtigt.",
+  "community.author.designsOne": "1 Design",
+  "community.author.designsOther": "{count} Designs",
+  "community.author.since": "Veröffentlicht seit {date}",
+  "community.author.makes": "Meist {categories}",
+  "community.author.remixedOne": "1-mal darauf aufgebaut",
+  "community.author.remixedOther": "{count}-mal darauf aufgebaut",
+  "community.author.printedOne": "1-mal gedruckt",
+  "community.author.printedOther": "{count}-mal gedruckt",
+  "community.author.partial": "Basiert auf den hier geladenen Designs, ältere können fehlen."
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3667,6 +3667,17 @@ const en: Record<string, string> = {
   'community.cost.bedTooLarge': 'Larger than your print bed ({width} x {depth}mm)',
   'community.cost.bedHint': 'Rotation is taken into account.',
 
+  // Derived author portrait, shown while the gallery is filtered to one author.
+  'community.author.designsOne': '1 design',
+  'community.author.designsOther': '{count} designs',
+  'community.author.since': 'Publishing since {date}',
+  'community.author.makes': 'Mostly {categories}',
+  'community.author.remixedOne': 'Built on 1 time',
+  'community.author.remixedOther': 'Built on {count} times',
+  'community.author.printedOne': 'Printed 1 time',
+  'community.author.printedOther': 'Printed {count} times',
+  'community.author.partial': 'Based on the designs loaded here, so older ones may be missing.',
+
   // Post-remix continuation banner (bin designer)
   'binDesigner.remixBanner.text':
     'Remixing {name} by {author}. Publish your version when it is ready.',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Estimado con el modelo a 0,2mm y 15% de relleno. Las impresiones reales lo sustituirán cuando haya varias.",
   "community.cost.bedFits": "Cabe en tu cama de impresión",
   "community.cost.bedTooLarge": "Más grande que tu cama de impresión ({width} x {depth}mm)",
-  "community.cost.bedHint": "Se tiene en cuenta la rotación."
+  "community.cost.bedHint": "Se tiene en cuenta la rotación.",
+  "community.author.designsOne": "1 diseño",
+  "community.author.designsOther": "{count} diseños",
+  "community.author.since": "Publicando desde {date}",
+  "community.author.makes": "Sobre todo {categories}",
+  "community.author.remixedOne": "Reutilizado 1 vez",
+  "community.author.remixedOther": "Reutilizado {count} veces",
+  "community.author.printedOne": "Impreso 1 vez",
+  "community.author.printedOther": "Impreso {count} veces",
+  "community.author.partial": "Basado en los diseños cargados aquí, pueden faltar los más antiguos."
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Estimé à partir du modèle à 0,2mm et 15% de remplissage. Les impressions réelles remplaceront cette valeur.",
   "community.cost.bedFits": "Tient sur votre plateau",
   "community.cost.bedTooLarge": "Plus grand que votre plateau ({width} x {depth}mm)",
-  "community.cost.bedHint": "La rotation est prise en compte."
+  "community.cost.bedHint": "La rotation est prise en compte.",
+  "community.author.designsOne": "1 design",
+  "community.author.designsOther": "{count} designs",
+  "community.author.since": "Publie depuis {date}",
+  "community.author.makes": "Surtout {categories}",
+  "community.author.remixedOne": "Repris 1 fois",
+  "community.author.remixedOther": "Repris {count} fois",
+  "community.author.printedOne": "Imprimé 1 fois",
+  "community.author.printedOther": "Imprimé {count} fois",
+  "community.author.partial": "Basé sur les designs chargés ici, les plus anciens peuvent manquer."
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Stimato dal modello a 0,2mm e 15% di riempimento. Le stampe reali lo sostituiranno quando saranno alcune.",
   "community.cost.bedFits": "Sta sul tuo piano di stampa",
   "community.cost.bedTooLarge": "Più grande del tuo piano di stampa ({width} x {depth}mm)",
-  "community.cost.bedHint": "La rotazione è considerata."
+  "community.cost.bedHint": "La rotazione è considerata.",
+  "community.author.designsOne": "1 design",
+  "community.author.designsOther": "{count} design",
+  "community.author.since": "Pubblica da {date}",
+  "community.author.makes": "Soprattutto {categories}",
+  "community.author.remixedOne": "Ripreso 1 volta",
+  "community.author.remixedOther": "Ripreso {count} volte",
+  "community.author.printedOne": "Stampato 1 volta",
+  "community.author.printedOther": "Stampato {count} volte",
+  "community.author.partial": "Basato sui design caricati qui, i più vecchi potrebbero mancare."
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "0.2mm・インフィル15%のモデルによる推定です。実際のプリント報告が集まると置き換わります。",
   "community.cost.bedFits": "お使いのプリントベッドに収まります",
   "community.cost.bedTooLarge": "プリントベッドより大きいです（{width} x {depth}mm）",
-  "community.cost.bedHint": "回転も考慮しています。"
+  "community.cost.bedHint": "回転も考慮しています。",
+  "community.author.designsOne": "デザイン 1 件",
+  "community.author.designsOther": "デザイン {count} 件",
+  "community.author.since": "{date} から公開",
+  "community.author.makes": "主に {categories}",
+  "community.author.remixedOne": "1 回リミックスされました",
+  "community.author.remixedOther": "{count} 回リミックスされました",
+  "community.author.printedOne": "1 回プリントされました",
+  "community.author.printedOther": "{count} 回プリントされました",
+  "community.author.partial": "ここに読み込まれたデザインに基づくため、古いものは含まれない場合があります。"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "0.2mm, 인필 15% 기준 모델 예상치입니다. 실제 출력 기록이 쌓이면 대체됩니다.",
   "community.cost.bedFits": "사용 중인 베드에 맞습니다",
   "community.cost.bedTooLarge": "베드보다 큽니다 ({width} x {depth}mm)",
-  "community.cost.bedHint": "회전도 고려했습니다."
+  "community.cost.bedHint": "회전도 고려했습니다.",
+  "community.author.designsOne": "디자인 1개",
+  "community.author.designsOther": "디자인 {count}개",
+  "community.author.since": "{date}부터 공개",
+  "community.author.makes": "주로 {categories}",
+  "community.author.remixedOne": "1번 리믹스됨",
+  "community.author.remixedOther": "{count}번 리믹스됨",
+  "community.author.printedOne": "1번 출력됨",
+  "community.author.printedOther": "{count}번 출력됨",
+  "community.author.partial": "여기에 불러온 디자인 기준이라 오래된 것은 빠질 수 있습니다."
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Anslått fra modellen ved 0,2mm og 15% fyll. Ekte utskrifter erstatter dette når noen har rapportert.",
   "community.cost.bedFits": "Får plass på byggeplaten din",
   "community.cost.bedTooLarge": "Større enn byggeplaten din ({width} x {depth}mm)",
-  "community.cost.bedHint": "Rotasjon er tatt med."
+  "community.cost.bedHint": "Rotasjon er tatt med.",
+  "community.author.designsOne": "1 design",
+  "community.author.designsOther": "{count} design",
+  "community.author.since": "Publiserer siden {date}",
+  "community.author.makes": "Mest {categories}",
+  "community.author.remixedOne": "Bygget videre på 1 gang",
+  "community.author.remixedOther": "Bygget videre på {count} ganger",
+  "community.author.printedOne": "Skrevet ut 1 gang",
+  "community.author.printedOther": "Skrevet ut {count} ganger",
+  "community.author.partial": "Basert på designene som er lastet her, eldre kan mangle."
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Geschat op basis van het model bij 0,2mm en 15% vulling. Echte prints vervangen dit zodra er enkele zijn.",
   "community.cost.bedFits": "Past op je printbed",
   "community.cost.bedTooLarge": "Groter dan je printbed ({width} x {depth}mm)",
-  "community.cost.bedHint": "Rotatie wordt meegerekend."
+  "community.cost.bedHint": "Rotatie wordt meegerekend.",
+  "community.author.designsOne": "1 design",
+  "community.author.designsOther": "{count} designs",
+  "community.author.since": "Publiceert sinds {date}",
+  "community.author.makes": "Vooral {categories}",
+  "community.author.remixedOne": "1 keer op voortgebouwd",
+  "community.author.remixedOther": "{count} keer op voortgebouwd",
+  "community.author.printedOne": "1 keer geprint",
+  "community.author.printedOther": "{count} keer geprint",
+  "community.author.partial": "Gebaseerd op de hier geladen designs, oudere kunnen ontbreken."
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Oszacowane z modelu przy 0,2mm i 15% wypełnienia. Prawdziwe wydruki zastąpią tę wartość.",
   "community.cost.bedFits": "Mieści się na twoim stole",
   "community.cost.bedTooLarge": "Większe niż twój stół roboczy ({width} x {depth}mm)",
-  "community.cost.bedHint": "Obrót jest uwzględniony."
+  "community.cost.bedHint": "Obrót jest uwzględniony.",
+  "community.author.designsOne": "1 projekt",
+  "community.author.designsOther": "Projekty: {count}",
+  "community.author.since": "Publikuje od {date}",
+  "community.author.makes": "Głównie {categories}",
+  "community.author.remixedOne": "Rozwinięty 1 raz",
+  "community.author.remixedOther": "Rozwinięty {count} razy",
+  "community.author.printedOne": "Wydrukowany 1 raz",
+  "community.author.printedOther": "Wydrukowany {count} razy",
+  "community.author.partial": "Na podstawie projektów wczytanych tutaj, starsze mogą się nie pojawić."
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Estimado pelo modelo a 0,2mm e 15% de preenchimento. Impressões reais substituirão este valor.",
   "community.cost.bedFits": "Cabe na sua mesa de impressão",
   "community.cost.bedTooLarge": "Maior que sua mesa de impressão ({width} x {depth}mm)",
-  "community.cost.bedHint": "A rotação é considerada."
+  "community.cost.bedHint": "A rotação é considerada.",
+  "community.author.designsOne": "1 design",
+  "community.author.designsOther": "{count} designs",
+  "community.author.since": "Publicando desde {date}",
+  "community.author.makes": "Principalmente {categories}",
+  "community.author.remixedOne": "Remixado 1 vez",
+  "community.author.remixedOther": "Remixado {count} vezes",
+  "community.author.printedOne": "Impresso 1 vez",
+  "community.author.printedOther": "Impresso {count} vezes",
+  "community.author.partial": "Baseado nos designs carregados aqui, os mais antigos podem faltar."
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Uppskattat från modellen vid 0,2mm och 15% fyllnad. Riktiga utskrifter ersätter detta när några rapporterats.",
   "community.cost.bedFits": "Får plats på din byggplatta",
   "community.cost.bedTooLarge": "Större än din byggplatta ({width} x {depth}mm)",
-  "community.cost.bedHint": "Rotation räknas in."
+  "community.cost.bedHint": "Rotation räknas in.",
+  "community.author.designsOne": "1 design",
+  "community.author.designsOther": "{count} designer",
+  "community.author.since": "Publicerar sedan {date}",
+  "community.author.makes": "Mest {categories}",
+  "community.author.remixedOne": "Byggd vidare på 1 gång",
+  "community.author.remixedOther": "Byggd vidare på {count} gånger",
+  "community.author.printedOne": "Utskriven 1 gång",
+  "community.author.printedOther": "Utskriven {count} gånger",
+  "community.author.partial": "Baserat på de designer som laddats här, äldre kan saknas."
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "Оцінено за моделлю при 0,2мм і 15% заповнення. Реальні друки замінять це значення.",
   "community.cost.bedFits": "Вміщується на твій стіл",
   "community.cost.bedTooLarge": "Більше за твій стіл ({width} x {depth}мм)",
-  "community.cost.bedHint": "Обертання враховано."
+  "community.cost.bedHint": "Обертання враховано.",
+  "community.author.designsOne": "1 дизайн",
+  "community.author.designsOther": "Дизайнів: {count}",
+  "community.author.since": "Публікує з {date}",
+  "community.author.makes": "Здебільшого {categories}",
+  "community.author.remixedOne": "Розвинуто 1 раз",
+  "community.author.remixedOther": "Розвинуто {count} разів",
+  "community.author.printedOne": "Надруковано 1 раз",
+  "community.author.printedOther": "Надруковано {count} разів",
+  "community.author.partial": "На основі завантажених тут дизайнів, старіші можуть бути відсутні."
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3489,5 +3489,14 @@
   "community.cost.estimateNote": "基于 0.2mm、15% 填充的模型预估。有几次真实打印记录后将替换此数值。",
   "community.cost.bedFits": "可放入你的热床",
   "community.cost.bedTooLarge": "大于你的热床（{width} x {depth}mm）",
-  "community.cost.bedHint": "已考虑旋转摆放。"
+  "community.cost.bedHint": "已考虑旋转摆放。",
+  "community.author.designsOne": "1 个设计",
+  "community.author.designsOther": "{count} 个设计",
+  "community.author.since": "自 {date} 起发布",
+  "community.author.makes": "主要是 {categories}",
+  "community.author.remixedOne": "被再创作 1 次",
+  "community.author.remixedOther": "被再创作 {count} 次",
+  "community.author.printedOne": "被打印 1 次",
+  "community.author.printedOther": "被打印 {count} 次",
+  "community.author.partial": "基于此处已加载的设计，较早的可能未包含。"
 }

--- a/src/test/mocks/i18nEcho.ts
+++ b/src/test/mocks/i18nEcho.ts
@@ -14,3 +14,18 @@ export function useTranslation() {
     return key;
   };
 }
+
+/**
+ * Deterministic `useFormatting`, so a component that formats a date is
+ * testable without a LocaleProvider and without the runner's own locale
+ * leaking into assertions. Fixed values, not `toLocaleDateString`: the real
+ * output varies by machine.
+ */
+export function useFormatting() {
+  return {
+    formatDate: (date: Date | string | number): string => new Date(date).toISOString().slice(0, 10),
+    formatRelativeDate: (date: Date | string | number): string =>
+      new Date(date).toISOString().slice(0, 10),
+    formatNumber: (value: number): string => String(value),
+  };
+}


### PR DESCRIPTION
Phase 3a of the community direction: give the existing author filter a sense of the person behind it.

The gallery could already filter to one author via `?author=`, but the result was an anonymous grid. This adds a derived portrait above it: how many designs, since when, what they mostly make, and how often their work has been printed or built upon.

## No bio, deliberately

The plan called for author pages with "no self-authored bio", and this holds that line.

A bio answers *"how does this person present themselves"*. The useful question is *"what do they make, and does it work"* — and that is answerable from data the gallery already has. A bio would add a moderation surface (spam links, abuse) in exchange for the weaker answer.

Everything here is derived from cards already loaded, so it costs **no additional request**.

## Two honesty rules, carried over

Both come from the same principle the rest of this feature is built on: a number must not imply more than it knows.

- **Zero-valued proof signals are omitted.** "Built on 0 times" says nothing while looking like a measurement, so prints and remixes appear only once non-zero.
- **When the browse index is capped, the portrait says so.** The index holds the 2,000 newest designs globally, so an author's older work can genuinely be absent. An understated count that looks authoritative is worse than one that states its own limits.

Hidden and removed designs are excluded, so a moderated design cannot pad someone's body of work.

## Notes for review

- Category and technique rankings break ties toward **recent** practice: the index arrives newest-first and first-seen wins a tie, which is the more useful answer to "what do they make" than an arbitrary one.
- Capped at two categories and three techniques. Past that it stops being a portrait and becomes a list.
- A card with no `prints` field reads as zero rather than `NaN` (pre-field snapshots).

## Testing

17 new tests: the derivation (ownership filtering, moderated-design exclusion, earliest date, ranking and caps, tie-breaking, totals, missing-field handling) and the component (singular/plural, zero omission, capped-index disclosure).

Full suite: 20,218 passing.

## Scope note

This is Phase 3**a**. The plan's Phase 3 also includes making the remix tree structural on the detail page (currently a one-line lineage sentence plus a "builds on this" list). That is a separate, self-contained change and is not in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a derived author portrait above the community gallery when filtered to a single author. It shows design count, first publish date, what they mostly make, and non-zero prints/remixes, all derived from already loaded cards.

- **New Features**
  - Renders `AuthorSummary` above the grid when the `?author` filter is active.
  - Uses loaded cards only; no extra requests; excludes hidden/removed designs.
  - Omits zero-valued proof signals; shows a partial notice when the index is capped.
  - Caps at 2 categories and 3 techniques; ties favor recent practice.
  - Adds i18n strings across locales and tests for derivation and UI.

- **Bug Fixes**
  - Formats the author “since” date using the app locale via `useFormatting`.
  - Stabilizes tests: mocks the prints client in `CommunityDetail` and adds deterministic date formatting in `i18nEcho`.

<sup>Written for commit 3bf96c639ca892ff827ab321fcf3822693df3382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

