### PR TITLE
feat(community): make remix ancestry a navigable strip

### DIFF
--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -61,6 +61,14 @@ Backend lives in `api/community/prints.ts` (`GET`/`PUT`/`DELETE`/`POST report`),
 - **Proven shelf** sits directly under staff picks, above recency: a design other people actually printed is the strongest recommendation the library has, and it is the one signal nobody can inflate by posting.
 - **Cover promotion** is owner opt-in and server-validated against the design's own **live** prints. The gallery grid is the most public surface in the app, and this is the only path by which a user-supplied image can reach it, so the check that the URL belongs to a live print of that design is load-bearing, not defensive. A hidden print's photo is not promotable.
 
+### Remix ancestry
+
+`components/CommunityDetail/RemixLineage.tsx` replaces the old one-line lineage sentence with a navigable strip: root (when it differs from the parent), parent, then this design.
+
+**Deliberately not called a tree.** The stored lineage is only `parentId` and `rootId`, so when those differ there may be steps in between that were never recorded. Drawing a continuous chain would imply completeness the data does not have, so the strip states the gap instead of smoothing over it.
+
+A parent that is gone is labelled and _not_ linked: its detail fetch would 404, and a dead link is worse than a plainly labelled dead end. A live parent's current name and author win over the publish-time snapshot.
+
 ### Author portrait
 
 `components/AuthorSummary/` renders a derived portrait while the gallery is filtered to one author: how many designs, since when, what they mostly make, and how often their work has been printed or built upon.

--- a/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
@@ -408,7 +408,11 @@ describe('CommunityDetail', () => {
     useCommunityDetailStore.getState().open('Child1234567', card({ id: 'Child1234567' }));
     renderDetail();
     // Both the parent name and the parent author upgrade to the live record.
-    expect(await screen.findByText(/Remixed from Renamed Parent by Samuel/)).toBeInTheDocument();
+    // Wait on the resolved content, not just the element: the strip renders
+    // with the publish-time snapshot first and upgrades once the live parent
+    // record arrives, so findByTestId alone would race that upgrade.
+    expect(await screen.findByText(/Renamed Parent/)).toBeInTheDocument();
+    expect(screen.getByTestId('remix-lineage-parent')).toHaveTextContent('Samuel');
   });
 
   it('marks the lineage parent as no longer published when it 404s', async () => {
@@ -428,8 +432,9 @@ describe('CommunityDetail', () => {
     });
     useCommunityDetailStore.getState().open('Child1234567', card({ id: 'Child1234567' }));
     renderDetail();
-    expect(await screen.findByText(/Remixed from Older Bin by Sam/)).toBeInTheDocument();
-    expect(await screen.findByText(/no longer published/)).toBeInTheDocument();
+    // Same race: the gone verdict only lands after the parent fetch 404s.
+    expect(await screen.findByText(/No longer available/)).toBeInTheDocument();
+    expect(screen.getByTestId('remix-lineage-parent')).toHaveTextContent('Older Bin');
   });
 
   it('renders the stats-row heart with aria-pressed and toggles the like optimistically', async () => {

--- a/src/features/community/components/CommunityDetail/CommunityDetail.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.tsx
@@ -437,6 +437,12 @@ function CommunityDetailDialog({
 
   const printDialogOpen = usePrintDialogStore((s) => s.phase !== 'closed');
 
+  // Opening by bare id rather than a card: an ancestor may sit outside the
+  // loaded index, and the detail view already handles a cold id fetch.
+  const handleOpenAncestor = useCallback((ancestorId: string) => {
+    useCommunityDetailStore.getState().open(ancestorId);
+  }, []);
+
   const handleAddPrint = useCallback(() => {
     if (design === null) return;
     usePrintDialogStore.getState().open({
@@ -548,6 +554,7 @@ function CommunityDetailDialog({
             }
             onFilterByAuthor={handleFilterByAuthor}
             ownerModeration={ownerModeration}
+            onOpenDesign={handleOpenAncestor}
             onAddPrint={printsAvailable ? handleAddPrint : undefined}
             costSlot={
               <PrintCostPanel

--- a/src/features/community/components/CommunityDetail/CommunityDetailContent.test.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetailContent.test.tsx
@@ -157,8 +157,11 @@ describe('CommunityDetailContent', () => {
         rootAuthorName: 'Root Author',
       },
     });
-    expect(screen.getByText(/Remixed from Older Bin by Sam/)).toBeInTheDocument();
-    expect(screen.getByText(/originally by Root Author/)).toBeInTheDocument();
+    expect(screen.getByTestId('remix-lineage-parent')).toHaveTextContent('Older Bin');
+    expect(screen.getByTestId('remix-lineage-root')).toHaveTextContent('Originally by Root Author');
+    // Only parentId and rootId are stored, so the strip says so rather than
+    // drawing a chain it cannot vouch for.
+    expect(screen.getByTestId('remix-lineage-gap')).toBeInTheDocument();
   });
 
   it('upgrades the lineage line to the live parent name', () => {
@@ -174,7 +177,9 @@ describe('CommunityDetailContent', () => {
       },
       { parentResolution: { kind: 'live', name: 'Renamed Parent', authorName: 'Samuel' } }
     );
-    expect(screen.getByText(/Remixed from Renamed Parent by Samuel/)).toBeInTheDocument();
+    const parent = screen.getByTestId('remix-lineage-parent');
+    expect(parent).toHaveTextContent('Renamed Parent');
+    expect(parent).toHaveTextContent('Samuel');
   });
 
   it('marks the parent as no longer published when it is gone', () => {
@@ -190,7 +195,7 @@ describe('CommunityDetailContent', () => {
       },
       { parentResolution: { kind: 'gone' } }
     );
-    expect(screen.getByText(/no longer published/)).toBeInTheDocument();
+    expect(screen.getByTestId('remix-lineage-parent')).toHaveTextContent('No longer available');
   });
 
   it('renders the updated date only when later than the published date', () => {

--- a/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
@@ -15,6 +15,7 @@ import { HeartGlyph } from '../CommunityCard/CommunityCard';
 import { CATEGORY_LABEL_KEYS } from '../../utils/categoryLabels';
 import { REPORT_REASON_LABEL_KEYS } from '../../utils/reportReasonLabels';
 import { DirectRemixList } from './DirectRemixList';
+import { RemixLineage } from './RemixLineage';
 import { SimilarRail } from './SimilarRail';
 
 /**
@@ -61,6 +62,8 @@ interface CommunityDetailContentProps {
   printsSlot?: ReactNode;
   /** Print cost and bed fit; sits with the dimensions, which is the same question. */
   costSlot?: ReactNode;
+  /** Navigates to an ancestor design; absent renders the lineage read-only. */
+  onOpenDesign?: (designId: string) => void;
 }
 
 function formatMm(value: number): string {
@@ -87,6 +90,7 @@ export function CommunityDetailContent({
   hasOwnPrint = false,
   printsSlot,
   costSlot,
+  onOpenDesign,
 }: CommunityDetailContentProps) {
   const t = useTranslation();
   const [angleIndex, setAngleIndex] = useState(0);
@@ -96,12 +100,6 @@ export function CommunityDetailContent({
 
   const poster = design.thumbnails.at(angleIndex) ?? design.thumbnails.at(0) ?? '';
   const { params, metrics, lineage } = design;
-  const parentName =
-    parentResolution.kind === 'live' ? parentResolution.name : (lineage?.parentName ?? '');
-  const parentAuthorName =
-    parentResolution.kind === 'live'
-      ? parentResolution.authorName
-      : (lineage?.parentAuthorName ?? '');
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto md:flex-row md:overflow-hidden">
@@ -333,16 +331,12 @@ export function CommunityDetailContent({
         )}
 
         {lineage !== null && (
-          <p className="text-xs text-content-tertiary">
-            {t('community.detail.lineageRemixOf', {
-              parent: parentName,
-              author: parentAuthorName,
-            })}
-            {lineage.rootId !== lineage.parentId && (
-              <> · {t('community.detail.lineageRoot', { author: lineage.rootAuthorName })}</>
-            )}
-            {parentResolution.kind === 'gone' && <> · {t('community.detail.lineageGoneSuffix')}</>}
-          </p>
+          <RemixLineage
+            lineage={lineage}
+            parentResolution={parentResolution}
+            designName={design.name}
+            onOpenDesign={onOpenDesign}
+          />
         )}
 
         {/* Sits above the similar rail: whether this printed for other people

--- a/src/features/community/components/CommunityDetail/RemixLineage.test.tsx
+++ b/src/features/community/components/CommunityDetail/RemixLineage.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { CommunityDesignLineage } from '@/shared/types/community';
+import { RemixLineage } from './RemixLineage';
+import type { ParentResolution } from './CommunityDetailContent';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+const PARENT_ID = 'ParentDes1gn';
+const ROOT_ID = 'RootDesign12';
+
+function lineage(overrides: Partial<CommunityDesignLineage> = {}): CommunityDesignLineage {
+  return {
+    parentId: PARENT_ID,
+    rootId: PARENT_ID,
+    parentName: 'Parent Bin',
+    parentAuthorName: 'Jo',
+    rootAuthorName: 'Jo',
+    ...overrides,
+  };
+}
+
+function setup(
+  overrides: Partial<CommunityDesignLineage> = {},
+  parentResolution: ParentResolution = { kind: 'snapshot' },
+  onOpenDesign: ((id: string) => void) | undefined = vi.fn()
+) {
+  render(
+    <RemixLineage
+      lineage={lineage(overrides)}
+      parentResolution={parentResolution}
+      designName="My Remix"
+      onOpenDesign={onOpenDesign}
+    />
+  );
+  return onOpenDesign;
+}
+
+describe('RemixLineage', () => {
+  it('shows the parent and the current design', () => {
+    setup();
+
+    expect(screen.getByTestId('remix-lineage-parent')).toHaveTextContent('Parent Bin');
+    expect(screen.getByTestId('remix-lineage-current')).toHaveTextContent('My Remix');
+  });
+
+  it('omits the root step when the parent is the root', () => {
+    setup();
+    expect(screen.queryByTestId('remix-lineage-root')).toBeNull();
+  });
+
+  it('shows a separate root step when the chain is longer', () => {
+    setup({ rootId: ROOT_ID, rootAuthorName: 'Sam' });
+    // The echo mock returns keys, so assert the key rather than the copy.
+    expect(screen.getByTestId('remix-lineage-root')).toHaveTextContent('community.lineage.root');
+  });
+
+  it('admits that intermediate steps are unrecorded', () => {
+    setup({ rootId: ROOT_ID, rootAuthorName: 'Sam' });
+    // Only parentId and rootId are stored, so a continuous chain would imply
+    // completeness the data does not have.
+    expect(screen.getByTestId('remix-lineage-gap')).toBeInTheDocument();
+  });
+
+  it('does not claim a gap when there is none to claim', () => {
+    setup();
+    expect(screen.queryByTestId('remix-lineage-gap')).toBeNull();
+  });
+
+  it('opens the parent when it is still available', () => {
+    const onOpen = setup();
+    fireEvent.click(screen.getByLabelText('community.lineage.openParent'));
+    expect(onOpen).toHaveBeenCalledWith(PARENT_ID);
+  });
+
+  it('opens the root when there is one', () => {
+    const onOpen = setup({ rootId: ROOT_ID, rootAuthorName: 'Sam' });
+    fireEvent.click(screen.getByLabelText('community.lineage.openRoot'));
+    expect(onOpen).toHaveBeenCalledWith(ROOT_ID);
+  });
+
+  it('labels a gone parent and refuses to link it', () => {
+    setup({}, { kind: 'gone' });
+
+    const parent = screen.getByTestId('remix-lineage-parent');
+    expect(parent).toHaveTextContent('community.lineage.unavailable');
+    // A dead link is worse than a plainly labelled dead end.
+    expect(screen.queryByLabelText('community.lineage.openParent')).toBeNull();
+  });
+
+  it('prefers the live parent name over the publish-time snapshot', () => {
+    setup({}, { kind: 'live', name: 'Renamed Bin', authorName: 'Jo' });
+    expect(screen.getByTestId('remix-lineage-parent')).toHaveTextContent('Renamed Bin');
+  });
+
+  it('renders read-only with no navigation handler', () => {
+    render(
+      <RemixLineage
+        lineage={lineage({ rootId: ROOT_ID })}
+        parentResolution={{ kind: 'snapshot' }}
+        designName="My Remix"
+      />
+    );
+    expect(screen.queryByLabelText('community.lineage.openParent')).toBeNull();
+    expect(screen.getByTestId('remix-lineage-parent')).toHaveTextContent('Parent Bin');
+  });
+});

--- a/src/features/community/components/CommunityDetail/RemixLineage.test.tsx
+++ b/src/features/community/components/CommunityDetail/RemixLineage.test.tsx
@@ -105,4 +105,20 @@ describe('RemixLineage', () => {
     expect(screen.queryByLabelText('community.lineage.openParent')).toBeNull();
     expect(screen.getByTestId('remix-lineage-parent')).toHaveTextContent('Parent Bin');
   });
+
+  it('draws a connector on every step but the last', () => {
+    setup({ rootId: ROOT_ID, rootAuthorName: 'Sam' });
+
+    const steps = [
+      screen.getByTestId('remix-lineage-root'),
+      screen.getByTestId('remix-lineage-parent'),
+      screen.getByTestId('remix-lineage-current'),
+    ];
+    // A `last:` variant resolves against the span's siblings inside the li,
+    // so it never matched and the rule hung below the final step.
+    const connectors = steps.map(
+      (step) => step.querySelectorAll('span[aria-hidden="true"]').length
+    );
+    expect(connectors).toEqual([2, 2, 1]);
+  });
 });

--- a/src/features/community/components/CommunityDetail/RemixLineage.tsx
+++ b/src/features/community/components/CommunityDetail/RemixLineage.tsx
@@ -26,6 +26,7 @@ function Step({
   label,
   sub,
   current = false,
+  isLast = false,
   onOpen,
   openAria,
   testId,
@@ -33,15 +34,15 @@ function Step({
   label: string;
   sub?: string;
   current?: boolean;
+  /** Suppresses the connector rule; there is nothing below to connect to. */
+  isLast?: boolean;
   onOpen?: () => void;
   openAria?: string;
   testId: string;
 }) {
   const body = (
     <>
-      <span className={cn('block truncate text-sm', current ? 'text-content' : 'text-content')}>
-        {label}
-      </span>
+      <span className="block truncate text-sm text-content">{label}</span>
       {sub !== undefined && (
         <span className="block truncate text-xs text-content-tertiary">{sub}</span>
       )}
@@ -58,10 +59,14 @@ function Step({
           current ? 'bg-accent' : 'bg-stroke-subtle'
         )}
       />
-      <span
-        aria-hidden="true"
-        className="absolute bottom-0 left-[3px] top-3.5 w-px bg-stroke-subtle last:hidden"
-      />
+      {/* Rendered conditionally rather than via `last:`, which resolves
+          against this span's siblings inside the li and so never matched. */}
+      {!isLast && (
+        <span
+          aria-hidden="true"
+          className="absolute bottom-0 left-[3px] top-3.5 w-px bg-stroke-subtle"
+        />
+      )}
       {onOpen === undefined ? (
         <div className={cn('min-w-0', current && 'font-medium')}>{body}</div>
       ) : (
@@ -97,6 +102,7 @@ export function RemixLineage({
     <div className="space-y-1" data-testid="remix-lineage">
       <h3 className="text-sm font-medium text-content">{t('community.lineage.title')}</h3>
 
+      {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ul role="list" className="space-y-2">
         {hasSeparateRoot && (
@@ -131,6 +137,7 @@ export function RemixLineage({
           label={designName}
           sub={t('community.lineage.thisDesign')}
           current
+          isLast
         />
       </ul>
 

--- a/src/features/community/components/CommunityDetail/RemixLineage.tsx
+++ b/src/features/community/components/CommunityDetail/RemixLineage.tsx
@@ -1,0 +1,144 @@
+/**
+ * Where a remix came from, as a navigable strip rather than a sentence.
+ *
+ * Deliberately not called a tree: the stored lineage is only `parentId` and
+ * `rootId`, so when those differ there may be steps in between that were never
+ * recorded. Drawing a continuous chain would imply completeness the data does
+ * not have, so the gap is stated instead of smoothed over.
+ */
+
+import { Button, cn } from '@/design-system';
+import { useTranslation } from '@/i18n';
+import type { CommunityDesignLineage } from '@/shared/types/community';
+import type { ParentResolution } from './CommunityDetailContent';
+
+export interface RemixLineageProps {
+  lineage: CommunityDesignLineage;
+  /** Whether the parent is still live, a name snapshot, or gone. */
+  parentResolution: ParentResolution;
+  /** Current design's own name, shown as the last step. */
+  designName: string;
+  /** Opens an ancestor in the detail view; absent renders the strip read-only. */
+  onOpenDesign?: (designId: string) => void;
+}
+
+function Step({
+  label,
+  sub,
+  current = false,
+  onOpen,
+  openAria,
+  testId,
+}: {
+  label: string;
+  sub?: string;
+  current?: boolean;
+  onOpen?: () => void;
+  openAria?: string;
+  testId: string;
+}) {
+  const body = (
+    <>
+      <span className={cn('block truncate text-sm', current ? 'text-content' : 'text-content')}>
+        {label}
+      </span>
+      {sub !== undefined && (
+        <span className="block truncate text-xs text-content-tertiary">{sub}</span>
+      )}
+    </>
+  );
+
+  return (
+    <li className="relative pl-4" data-testid={testId}>
+      {/* Connector: a dot on the step and a rule down to the next one. */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          'absolute left-0 top-1.5 h-2 w-2 rounded-full',
+          current ? 'bg-accent' : 'bg-stroke-subtle'
+        )}
+      />
+      <span
+        aria-hidden="true"
+        className="absolute bottom-0 left-[3px] top-3.5 w-px bg-stroke-subtle last:hidden"
+      />
+      {onOpen === undefined ? (
+        <div className={cn('min-w-0', current && 'font-medium')}>{body}</div>
+      ) : (
+        <Button
+          variant="ghost"
+          aria-label={openAria}
+          onClick={onOpen}
+          className="h-auto w-full min-w-0 justify-start p-0 text-left font-normal underline-offset-2 hover:underline"
+        >
+          <span className="min-w-0">{body}</span>
+        </Button>
+      )}
+    </li>
+  );
+}
+
+export function RemixLineage({
+  lineage,
+  parentResolution,
+  designName,
+  onOpenDesign,
+}: RemixLineageProps) {
+  const t = useTranslation();
+
+  const parentGone = parentResolution.kind === 'gone';
+  const parentName = parentResolution.kind === 'live' ? parentResolution.name : lineage.parentName;
+  const parentAuthor =
+    parentResolution.kind === 'live' ? parentResolution.authorName : lineage.parentAuthorName;
+
+  const hasSeparateRoot = lineage.rootId !== lineage.parentId;
+
+  return (
+    <div className="space-y-1" data-testid="remix-lineage">
+      <h3 className="text-sm font-medium text-content">{t('community.lineage.title')}</h3>
+
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+      <ul role="list" className="space-y-2">
+        {hasSeparateRoot && (
+          <Step
+            testId="remix-lineage-root"
+            label={t('community.lineage.root', { author: lineage.rootAuthorName })}
+            onOpen={onOpenDesign === undefined ? undefined : () => onOpenDesign(lineage.rootId)}
+            openAria={t('community.lineage.openRoot', { author: lineage.rootAuthorName })}
+          />
+        )}
+
+        <Step
+          testId="remix-lineage-parent"
+          label={parentName}
+          sub={
+            parentGone
+              ? t('community.lineage.unavailable')
+              : t('community.lineage.byAuthor', { author: parentAuthor })
+          }
+          // A gone parent is not openable: the detail fetch would 404, and a
+          // dead link is worse than a plainly labelled dead end.
+          onOpen={
+            onOpenDesign === undefined || parentGone
+              ? undefined
+              : () => onOpenDesign(lineage.parentId)
+          }
+          openAria={t('community.lineage.openParent', { name: parentName })}
+        />
+
+        <Step
+          testId="remix-lineage-current"
+          label={designName}
+          sub={t('community.lineage.thisDesign')}
+          current
+        />
+      </ul>
+
+      {hasSeparateRoot && (
+        <p className="text-xs text-content-tertiary" data-testid="remix-lineage-gap">
+          {t('community.lineage.gap')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3297,9 +3297,6 @@
   "community.detail.stats.likes": "Lajky",
   "community.detail.stats.remixes": "Remixy",
   "community.detail.stats.exports": "Tisky",
-  "community.detail.lineageRemixOf": "Remixováno z {parent} od {author}",
-  "community.detail.lineageRoot": "původně od {author}",
-  "community.detail.lineageGoneSuffix": "už není publikováno",
   "community.detail.license": "Publikováno pod licencí CC BY 4.0.",
   "community.detail.remix": "remix",
   "community.detail.remixHint": "Remix otevře upravitelnou kopii tohoto návrhu.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Navázáno {count}krát",
   "community.author.printedOne": "Vytištěno 1krát",
   "community.author.printedOther": "Vytištěno {count}krát",
-  "community.author.partial": "Podle návrhů načtených zde, starší mohou chybět."
+  "community.author.partial": "Podle návrhů načtených zde, starší mohou chybět.",
+  "community.lineage.title": "Odkud to pochází",
+  "community.lineage.root": "Původně od {author}",
+  "community.lineage.byAuthor": "od {author}",
+  "community.lineage.thisDesign": "Tento návrh",
+  "community.lineage.unavailable": "Už není dostupné",
+  "community.lineage.gap": "Případné mezikroky nebyly zaznamenány.",
+  "community.lineage.openRoot": "Otevřít originál od {author}",
+  "community.lineage.openParent": "Otevřít {name}"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1622,9 +1622,6 @@
   "community.detail.stats.likes": "Likes",
   "community.detail.stats.remixes": "Remixe",
   "community.detail.stats.exports": "Drucke",
-  "community.detail.lineageRemixOf": "Remix von {parent} von {author}",
-  "community.detail.lineageRoot": "ursprünglich von {author}",
-  "community.detail.lineageGoneSuffix": "nicht mehr veröffentlicht",
   "community.detail.license": "Veröffentlicht unter der CC-BY-4.0-Lizenz.",
   "community.detail.remix": "Remixen",
   "community.detail.remixHint": "Remixen öffnet eine bearbeitbare Kopie dieses Designs.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "{count}-mal darauf aufgebaut",
   "community.author.printedOne": "1-mal gedruckt",
   "community.author.printedOther": "{count}-mal gedruckt",
-  "community.author.partial": "Basiert auf den hier geladenen Designs, ältere können fehlen."
+  "community.author.partial": "Basiert auf den hier geladenen Designs, ältere können fehlen.",
+  "community.lineage.title": "Woher das stammt",
+  "community.lineage.root": "Ursprünglich von {author}",
+  "community.lineage.byAuthor": "von {author}",
+  "community.lineage.thisDesign": "Dieses Design",
+  "community.lineage.unavailable": "Nicht mehr verfügbar",
+  "community.lineage.gap": "Schritte dazwischen wurden nicht erfasst.",
+  "community.lineage.openRoot": "Original von {author} öffnen",
+  "community.lineage.openParent": "{name} öffnen"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3479,9 +3479,6 @@ const en: Record<string, string> = {
   'community.detail.stats.likes': 'Likes',
   'community.detail.stats.remixes': 'Remixes',
   'community.detail.stats.exports': 'Prints',
-  'community.detail.lineageRemixOf': 'Remixed from {parent} by {author}',
-  'community.detail.lineageRoot': 'originally by {author}',
-  'community.detail.lineageGoneSuffix': 'no longer published',
   'community.detail.license': 'Published under the CC BY 4.0 license.',
   'community.detail.remix': 'Remix',
   'community.detail.remixHint': 'Remix opens an editable copy of this design.',
@@ -3677,6 +3674,17 @@ const en: Record<string, string> = {
   'community.author.printedOne': 'Printed 1 time',
   'community.author.printedOther': 'Printed {count} times',
   'community.author.partial': 'Based on the designs loaded here, so older ones may be missing.',
+
+  // Remix ancestry strip on the detail view. Only parentId and rootId are
+  // stored, so the copy must not imply a complete chain.
+  'community.lineage.title': 'Where this came from',
+  'community.lineage.root': 'Originally by {author}',
+  'community.lineage.byAuthor': 'by {author}',
+  'community.lineage.thisDesign': 'This design',
+  'community.lineage.unavailable': 'No longer available',
+  'community.lineage.gap': 'Any steps between these were not recorded.',
+  'community.lineage.openRoot': 'Open the original by {author}',
+  'community.lineage.openParent': 'Open {name}',
 
   // Post-remix continuation banner (bin designer)
   'binDesigner.remixBanner.text':

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1760,9 +1760,6 @@
   "community.detail.stats.likes": "Me gusta",
   "community.detail.stats.remixes": "Remezclas",
   "community.detail.stats.exports": "Impresiones",
-  "community.detail.lineageRemixOf": "Remezclado de {parent} por {author}",
-  "community.detail.lineageRoot": "originalmente por {author}",
-  "community.detail.lineageGoneSuffix": "ya no está publicado",
   "community.detail.license": "Publicado bajo la licencia CC BY 4.0.",
   "community.detail.remix": "Remezclar",
   "community.detail.remixHint": "Remezclar abre una copia editable de este diseño.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Reutilizado {count} veces",
   "community.author.printedOne": "Impreso 1 vez",
   "community.author.printedOther": "Impreso {count} veces",
-  "community.author.partial": "Basado en los diseños cargados aquí, pueden faltar los más antiguos."
+  "community.author.partial": "Basado en los diseños cargados aquí, pueden faltar los más antiguos.",
+  "community.lineage.title": "De dónde viene",
+  "community.lineage.root": "Originalmente de {author}",
+  "community.lineage.byAuthor": "por {author}",
+  "community.lineage.thisDesign": "Este diseño",
+  "community.lineage.unavailable": "Ya no está disponible",
+  "community.lineage.gap": "Los pasos intermedios no se registraron.",
+  "community.lineage.openRoot": "Abrir el original de {author}",
+  "community.lineage.openParent": "Abrir {name}"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3267,9 +3267,6 @@
   "community.detail.stats.likes": "Mentions J'aime",
   "community.detail.stats.remixes": "Remix",
   "community.detail.stats.exports": "Impressions",
-  "community.detail.lineageRemixOf": "Remixé à partir de {parent} par {author}",
-  "community.detail.lineageRoot": "à l'origine par {author}",
-  "community.detail.lineageGoneSuffix": "n'est plus publié",
   "community.detail.license": "Publié sous licence CC BY 4.0.",
   "community.detail.remix": "Remixer",
   "community.detail.remixHint": "Remixer ouvre une copie modifiable de ce design.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Repris {count} fois",
   "community.author.printedOne": "Imprimé 1 fois",
   "community.author.printedOther": "Imprimé {count} fois",
-  "community.author.partial": "Basé sur les designs chargés ici, les plus anciens peuvent manquer."
+  "community.author.partial": "Basé sur les designs chargés ici, les plus anciens peuvent manquer.",
+  "community.lineage.title": "D'où cela vient",
+  "community.lineage.root": "À l'origine de {author}",
+  "community.lineage.byAuthor": "par {author}",
+  "community.lineage.thisDesign": "Ce design",
+  "community.lineage.unavailable": "Plus disponible",
+  "community.lineage.gap": "Les étapes intermédiaires n'ont pas été enregistrées.",
+  "community.lineage.openRoot": "Ouvrir l'original de {author}",
+  "community.lineage.openParent": "Ouvrir {name}"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1610,9 +1610,6 @@
   "community.detail.goneTitle": "Questo design non è più disponibile.",
   "community.detail.gridUnits": "{width}×{depth}×{height} unità di griglia",
   "community.detail.license": "Pubblicato con licenza CC BY 4.0.",
-  "community.detail.lineageGoneSuffix": "non più pubblicato",
-  "community.detail.lineageRemixOf": "Remixato da {parent} di {author}",
-  "community.detail.lineageRoot": "originariamente di {author}",
   "community.detail.loadFailed": "Impossibile caricare questo design.",
   "community.detail.loading": "Caricamento del design…",
   "community.detail.millimeters": "{width}×{depth}×{height} mm",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Ripreso {count} volte",
   "community.author.printedOne": "Stampato 1 volta",
   "community.author.printedOther": "Stampato {count} volte",
-  "community.author.partial": "Basato sui design caricati qui, i più vecchi potrebbero mancare."
+  "community.author.partial": "Basato sui design caricati qui, i più vecchi potrebbero mancare.",
+  "community.lineage.title": "Da dove arriva",
+  "community.lineage.root": "Originariamente di {author}",
+  "community.lineage.byAuthor": "di {author}",
+  "community.lineage.thisDesign": "Questo design",
+  "community.lineage.unavailable": "Non più disponibile",
+  "community.lineage.gap": "Gli eventuali passaggi intermedi non sono stati registrati.",
+  "community.lineage.openRoot": "Apri l'originale di {author}",
+  "community.lineage.openParent": "Apri {name}"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1563,9 +1563,6 @@
   "community.detail.goneTitle": "このデザインは利用できなくなりました。",
   "community.detail.gridUnits": "{width}×{depth}×{height} グリッド単位",
   "community.detail.license": "CC BY 4.0ライセンスのもとで公開されています。",
-  "community.detail.lineageGoneSuffix": "現在は非公開",
-  "community.detail.lineageRemixOf": "{author}による{parent}のリミックス",
-  "community.detail.lineageRoot": "オリジナル制作者：{author}",
   "community.detail.loadFailed": "このデザインを読み込めませんでした。",
   "community.detail.loading": "デザインを読み込み中…",
   "community.detail.millimeters": "{width}×{depth}×{height} mm",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "{count} 回リミックスされました",
   "community.author.printedOne": "1 回プリントされました",
   "community.author.printedOther": "{count} 回プリントされました",
-  "community.author.partial": "ここに読み込まれたデザインに基づくため、古いものは含まれない場合があります。"
+  "community.author.partial": "ここに読み込まれたデザインに基づくため、古いものは含まれない場合があります。",
+  "community.lineage.title": "この作品の由来",
+  "community.lineage.root": "原案: {author}",
+  "community.lineage.byAuthor": "作成: {author}",
+  "community.lineage.thisDesign": "この作品",
+  "community.lineage.unavailable": "現在は利用できません",
+  "community.lineage.gap": "途中の経緯は記録されていません。",
+  "community.lineage.openRoot": "{author} さんの原案を開く",
+  "community.lineage.openParent": "{name} を開く"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3297,9 +3297,6 @@
   "community.detail.stats.likes": "좋아요",
   "community.detail.stats.remixes": "리믹스",
   "community.detail.stats.exports": "인쇄",
-  "community.detail.lineageRemixOf": "{author}의 \"{parent}\" 리믹스",
-  "community.detail.lineageRoot": "원작자: {author}",
-  "community.detail.lineageGoneSuffix": "더 이상 게시되지 않음",
   "community.detail.license": "CC BY 4.0 라이선스로 게시되었습니다.",
   "community.detail.remix": "리믹스",
   "community.detail.remixHint": "리믹스하면 이 디자인의 편집 가능한 사본이 열립니다.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "{count}번 리믹스됨",
   "community.author.printedOne": "1번 출력됨",
   "community.author.printedOther": "{count}번 출력됨",
-  "community.author.partial": "여기에 불러온 디자인 기준이라 오래된 것은 빠질 수 있습니다."
+  "community.author.partial": "여기에 불러온 디자인 기준이라 오래된 것은 빠질 수 있습니다.",
+  "community.lineage.title": "이 디자인의 출처",
+  "community.lineage.root": "원작: {author}",
+  "community.lineage.byAuthor": "작성: {author}",
+  "community.lineage.thisDesign": "이 디자인",
+  "community.lineage.unavailable": "더 이상 이용할 수 없음",
+  "community.lineage.gap": "중간 단계는 기록되지 않았습니다.",
+  "community.lineage.openRoot": "{author} 님의 원작 열기",
+  "community.lineage.openParent": "{name} 열기"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1610,9 +1610,6 @@
   "community.detail.goneTitle": "Dette designet er ikke lenger tilgjengelig.",
   "community.detail.gridUnits": "{width}×{depth}×{height} rutenettenheter",
   "community.detail.license": "Publisert under CC BY 4.0-lisensen.",
-  "community.detail.lineageGoneSuffix": "ikke lenger publisert",
-  "community.detail.lineageRemixOf": "Remixet fra {parent} av {author}",
-  "community.detail.lineageRoot": "opprinnelig av {author}",
   "community.detail.loadFailed": "Kunne ikke laste dette designet.",
   "community.detail.loading": "Laster design…",
   "community.detail.millimeters": "{width}×{depth}×{height} mm",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Bygget videre på {count} ganger",
   "community.author.printedOne": "Skrevet ut 1 gang",
   "community.author.printedOther": "Skrevet ut {count} ganger",
-  "community.author.partial": "Basert på designene som er lastet her, eldre kan mangle."
+  "community.author.partial": "Basert på designene som er lastet her, eldre kan mangle.",
+  "community.lineage.title": "Hvor dette kommer fra",
+  "community.lineage.root": "Opprinnelig av {author}",
+  "community.lineage.byAuthor": "av {author}",
+  "community.lineage.thisDesign": "Dette designet",
+  "community.lineage.unavailable": "Ikke lenger tilgjengelig",
+  "community.lineage.gap": "Eventuelle mellomliggende trinn ble ikke registrert.",
+  "community.lineage.openRoot": "Åpne originalen av {author}",
+  "community.lineage.openParent": "Åpne {name}"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1622,9 +1622,6 @@
   "community.detail.stats.likes": "Vind-ik-leuks",
   "community.detail.stats.remixes": "Remixen",
   "community.detail.stats.exports": "Afdrukken",
-  "community.detail.lineageRemixOf": "Geremixt van {parent} door {author}",
-  "community.detail.lineageRoot": "oorspronkelijk door {author}",
-  "community.detail.lineageGoneSuffix": "niet meer gepubliceerd",
   "community.detail.license": "Gepubliceerd onder de CC BY 4.0-licentie.",
   "community.detail.remix": "Remixen",
   "community.detail.remixHint": "Remixen opent een bewerkbare kopie van dit ontwerp.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "{count} keer op voortgebouwd",
   "community.author.printedOne": "1 keer geprint",
   "community.author.printedOther": "{count} keer geprint",
-  "community.author.partial": "Gebaseerd op de hier geladen designs, oudere kunnen ontbreken."
+  "community.author.partial": "Gebaseerd op de hier geladen designs, oudere kunnen ontbreken.",
+  "community.lineage.title": "Waar dit vandaan komt",
+  "community.lineage.root": "Oorspronkelijk van {author}",
+  "community.lineage.byAuthor": "door {author}",
+  "community.lineage.thisDesign": "Dit design",
+  "community.lineage.unavailable": "Niet meer beschikbaar",
+  "community.lineage.gap": "Tussenliggende stappen zijn niet vastgelegd.",
+  "community.lineage.openRoot": "Origineel van {author} openen",
+  "community.lineage.openParent": "{name} openen"
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3297,9 +3297,6 @@
   "community.detail.stats.likes": "Polubienia",
   "community.detail.stats.remixes": "Remiksy",
   "community.detail.stats.exports": "Wydruki",
-  "community.detail.lineageRemixOf": "Remiks {parent} autorstwa {author}",
-  "community.detail.lineageRoot": "pierwotnie autorstwa {author}",
-  "community.detail.lineageGoneSuffix": "nie jest już publikowany",
   "community.detail.license": "Opublikowano na licencji CC BY 4.0.",
   "community.detail.remix": "Remiksuj",
   "community.detail.remixHint": "Remiksowanie otwiera edytowalną kopię tego projektu.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Rozwinięty {count} razy",
   "community.author.printedOne": "Wydrukowany 1 raz",
   "community.author.printedOther": "Wydrukowany {count} razy",
-  "community.author.partial": "Na podstawie projektów wczytanych tutaj, starsze mogą się nie pojawić."
+  "community.author.partial": "Na podstawie projektów wczytanych tutaj, starsze mogą się nie pojawić.",
+  "community.lineage.title": "Skąd to pochodzi",
+  "community.lineage.root": "Pierwotnie autorstwa {author}",
+  "community.lineage.byAuthor": "autor: {author}",
+  "community.lineage.thisDesign": "Ten projekt",
+  "community.lineage.unavailable": "Już niedostępne",
+  "community.lineage.gap": "Kroki pośrednie nie zostały zapisane.",
+  "community.lineage.openRoot": "Otwórz oryginał autorstwa {author}",
+  "community.lineage.openParent": "Otwórz {name}"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3297,9 +3297,6 @@
   "community.detail.stats.likes": "Curtidas",
   "community.detail.stats.remixes": "Remixes",
   "community.detail.stats.exports": "Impressões",
-  "community.detail.lineageRemixOf": "Remixado de {parent}, de {author}",
-  "community.detail.lineageRoot": "originalmente por {author}",
-  "community.detail.lineageGoneSuffix": "não está mais publicado",
   "community.detail.license": "Publicado sob a licença CC BY 4.0.",
   "community.detail.remix": "Remixar",
   "community.detail.remixHint": "Remixar abre uma cópia editável deste design.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Remixado {count} vezes",
   "community.author.printedOne": "Impresso 1 vez",
   "community.author.printedOther": "Impresso {count} vezes",
-  "community.author.partial": "Baseado nos designs carregados aqui, os mais antigos podem faltar."
+  "community.author.partial": "Baseado nos designs carregados aqui, os mais antigos podem faltar.",
+  "community.lineage.title": "De onde isto veio",
+  "community.lineage.root": "Originalmente de {author}",
+  "community.lineage.byAuthor": "por {author}",
+  "community.lineage.thisDesign": "Este design",
+  "community.lineage.unavailable": "Não está mais disponível",
+  "community.lineage.gap": "Etapas intermediárias não foram registradas.",
+  "community.lineage.openRoot": "Abrir o original de {author}",
+  "community.lineage.openParent": "Abrir {name}"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3297,9 +3297,6 @@
   "community.detail.stats.likes": "Gillningar",
   "community.detail.stats.remixes": "Remixar",
   "community.detail.stats.exports": "Utskrifter",
-  "community.detail.lineageRemixOf": "Remixad från {parent} av {author}",
-  "community.detail.lineageRoot": "ursprungligen av {author}",
-  "community.detail.lineageGoneSuffix": "inte längre publicerad",
   "community.detail.license": "Publicerad under licensen CC BY 4.0.",
   "community.detail.remix": "Remixa",
   "community.detail.remixHint": "Remixa öppnar en redigerbar kopia av den här designen.",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Byggd vidare på {count} gånger",
   "community.author.printedOne": "Utskriven 1 gång",
   "community.author.printedOther": "Utskriven {count} gånger",
-  "community.author.partial": "Baserat på de designer som laddats här, äldre kan saknas."
+  "community.author.partial": "Baserat på de designer som laddats här, äldre kan saknas.",
+  "community.lineage.title": "Var det kommer ifrån",
+  "community.lineage.root": "Ursprungligen av {author}",
+  "community.lineage.byAuthor": "av {author}",
+  "community.lineage.thisDesign": "Den här designen",
+  "community.lineage.unavailable": "Inte längre tillgänglig",
+  "community.lineage.gap": "Eventuella steg däremellan registrerades inte.",
+  "community.lineage.openRoot": "Öppna originalet av {author}",
+  "community.lineage.openParent": "Öppna {name}"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1563,9 +1563,6 @@
   "community.detail.goneTitle": "Цей дизайн більше не доступний.",
   "community.detail.gridUnits": "{width}×{depth}×{height} одиниць сітки",
   "community.detail.license": "Опубліковано за ліцензією CC BY 4.0.",
-  "community.detail.lineageGoneSuffix": "більше не опубліковано",
-  "community.detail.lineageRemixOf": "Ремікс дизайну «{parent}» від {author}",
-  "community.detail.lineageRoot": "автор оригіналу: {author}",
   "community.detail.loadFailed": "Не вдалося завантажити цей дизайн.",
   "community.detail.loading": "Завантаження дизайну…",
   "community.detail.millimeters": "{width}×{depth}×{height} мм",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "Розвинуто {count} разів",
   "community.author.printedOne": "Надруковано 1 раз",
   "community.author.printedOther": "Надруковано {count} разів",
-  "community.author.partial": "На основі завантажених тут дизайнів, старіші можуть бути відсутні."
+  "community.author.partial": "На основі завантажених тут дизайнів, старіші можуть бути відсутні.",
+  "community.lineage.title": "Звідки це походить",
+  "community.lineage.root": "Спочатку від {author}",
+  "community.lineage.byAuthor": "від {author}",
+  "community.lineage.thisDesign": "Цей дизайн",
+  "community.lineage.unavailable": "Більше недоступно",
+  "community.lineage.gap": "Проміжні кроки не записані.",
+  "community.lineage.openRoot": "Відкрити оригінал від {author}",
+  "community.lineage.openParent": "Відкрити {name}"
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3360,9 +3360,6 @@
   "community.detail.stats.likes": "赞",
   "community.detail.stats.remixes": "二次创作",
   "community.detail.stats.exports": "打印次数",
-  "community.detail.lineageRemixOf": "二次创作自「{parent}」，作者：{author}",
-  "community.detail.lineageRoot": "原作者：{author}",
-  "community.detail.lineageGoneSuffix": "已不再发布",
   "community.detail.license": "依据 CC BY 4.0 协议发布。",
   "community.detail.remix": "二次创作",
   "community.detail.remixHint": "二次创作会打开此设计的可编辑副本。",
@@ -3498,5 +3495,13 @@
   "community.author.remixedOther": "被再创作 {count} 次",
   "community.author.printedOne": "被打印 1 次",
   "community.author.printedOther": "被打印 {count} 次",
-  "community.author.partial": "基于此处已加载的设计，较早的可能未包含。"
+  "community.author.partial": "基于此处已加载的设计，较早的可能未包含。",
+  "community.lineage.title": "它的来源",
+  "community.lineage.root": "最初来自 {author}",
+  "community.lineage.byAuthor": "作者 {author}",
+  "community.lineage.thisDesign": "当前设计",
+  "community.lineage.unavailable": "已不可用",
+  "community.lineage.gap": "中间步骤未被记录。",
+  "community.lineage.openRoot": "打开 {author} 的原作",
+  "community.lineage.openParent": "打开 {name}"
 }


### PR DESCRIPTION
Phase 3b, completing Phase 3. Replaces the one-line lineage sentence on the design detail with a strip you can actually walk: root (when it differs from the parent), parent, then this design.

Before: `Remixed from Older Bin by Sam · originally by Root Author · no longer published`, none of it clickable.

## Deliberately not a tree

The stored lineage is only `parentId` and `rootId`. When those differ, there may be steps in between that were **never recorded** — the data model does not capture them.

Drawing a continuous chain would imply a completeness the data does not have, so the strip states the gap ("Any steps between these were not recorded") rather than smoothing over it. That is the same rule the rest of this feature runs on: a display must not claim more than it knows.

## Notes for review

- **A gone parent is labelled and not linked.** Its detail fetch would 404, so a dead link would be strictly worse than a plainly labelled dead end.
- **A live parent's current name and author win** over the publish-time snapshot, preserving the existing behaviour.
- **Ancestors open by bare id**, not by card: an ancestor may sit outside the loaded browse index, and the detail view already handles a cold id fetch.
- Removed the three now-dead lineage keys from `en.ts` and all 14 locales.

## A flake I introduced and then fixed

Two existing detail tests asserted the old sentence. My first rewrite used `findByTestId`, which resolves as soon as the strip renders — but the strip renders with the publish-time snapshot and *upgrades* once the live parent record arrives, so the assertion raced that upgrade and failed roughly one run in two.

They now wait on the resolved content, which is the property the original `findByText` had. Verified stable across four consecutive runs.

## Testing

10 new tests for the strip (root shown only when distinct, gap disclosure and its absence, navigation for root and parent, gone-parent labelling and non-linking, live-name preference, read-only mode) plus four existing tests updated to the new structure.

Full suite: 20,228 passing.

## Phase status

With this, Phase 3 is complete. Phase 4 (repo-authored editorial collections) is the last one in the plan.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the remix lineage sentence with a navigable ancestry strip on the design detail. It shows root, parent, and the current design, and lets users open ancestors when available.

- **New Features**
  - Added `RemixLineage` strip: root (if different), parent, then this design.
  - Shows a gap notice when only `parentId` and `rootId` are known.
  - Labels a removed parent as "No longer available" and does not link it.
  - Uses the live parent name/author over the publish-time snapshot.
  - Opens ancestors by bare id to work outside the loaded index.
  - Added new i18n strings and removed the old lineage sentence keys in all locales.

- **Bug Fixes**
  - Hid the vertical connector on the final step; now driven by an explicit `isLast` prop and covered by a test.
  - Fixed a flaky detail test by waiting for resolved content; added 11 new lineage tests and updated four existing ones.

<sup>Written for commit 804a73b299cc4225c87be2f36e4afe08e9807236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

