### PR TITLE
feat(community): repo-authored editorial collections

### DIFF
--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -61,6 +61,20 @@ Backend lives in `api/community/prints.ts` (`GET`/`PUT`/`DELETE`/`POST report`),
 - **Proven shelf** sits directly under staff picks, above recency: a design other people actually printed is the strongest recommendation the library has, and it is the one signal nobody can inflate by posting.
 - **Cover promotion** is owner opt-in and server-validated against the design's own **live** prints. The gallery grid is the most public surface in the app, and this is the only path by which a user-supplied image can reach it, so the check that the URL belongs to a live print of that design is load-bearing, not defensive. A hidden print's photo is not promotable.
 
+### Editorial collections
+
+`data/collections.ts` holds hand-picked groups of designs, curated by PR. Human taste is the honest alternative to an engagement algorithm, and unlike an algorithm it does not pretend to be objective. Keeping the list in the repo means curation is reviewable, diffable and revertible, and needs no admin UI or storage.
+
+`utils/resolveCollections.ts` is where those intentions meet reality:
+
+- **Curated order is preserved exactly.** The sequence is part of the editorial judgement, so the index order never overrides it.
+- **Non-live and unknown ids are skipped**, and reported as `missingIds` so a curator can tell "not published yet" from "my ids are wrong".
+- **A collection with nothing left to show is dropped.** An empty shelf advertises a grouping and then fails to deliver it, so curation never has to be undone because a design went away.
+
+Curated shelves render above the derived ones: a human vouched for these, which is a stronger claim than any derived shelf can make. They carry a blurb (the reason the grouping exists) and no "See all", because a collection is a pick rather than a filter.
+
+The shipped list is deliberately empty. The mechanism is the engineering deliverable; the picks are a separate content decision, made by opening a PR against that file. Adding one means adding its two i18n keys across all locales, since editorial copy is user-facing like everything else.
+
 ### Remix ancestry
 
 `components/CommunityDetail/RemixLineage.tsx` replaces the old one-line lineage sentence with a navigable strip: root (when it differs from the parent), parent, then this design.

--- a/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
@@ -220,7 +220,11 @@ describe('CommunityDetail', () => {
     fetchMock.mockResolvedValueOnce(ok(detail()));
     Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true });
     fireEvent(window, new Event('online'));
-    expect(await screen.findByText('by Jo', undefined, { timeout: 5000 })).toBeInTheDocument();
+    // Two full fetch-and-render cycles of the whole detail tree (viewer,
+    // prints, cost panel, lineage), so the wait is sized to that rather than
+    // to a single request. It has twice tripped the old 5s cap on loaded CI
+    // runners while passing consistently in isolation.
+    expect(await screen.findByText('by Jo', undefined, { timeout: 15000 })).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/features/community/components/CommunityGalleryTab/ShelfLanding.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/ShelfLanding.test.tsx
@@ -8,6 +8,11 @@ import { SHELF_LANDING_MIN_DESIGNS } from './shelfData';
 
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
+// The shipped list is empty on purpose; these drive it directly so the
+// mechanism is covered without committing editorial picks.
+const collections = vi.hoisted(() => ({ COMMUNITY_COLLECTIONS: [] as unknown[] }));
+vi.mock('../../data/collections', () => collections);
+
 vi.mock('@/shared/hooks/useResponsive', () => ({
   useResponsive: () => ({ isMobile: false }),
 }));
@@ -138,5 +143,56 @@ describe('ShelfLanding', () => {
     render(<ShelfLanding items={manyCards(12)} onSelect={onSelect} onSelectAuthor={vi.fn()} />);
     fireEvent.click(screen.getAllByRole('button', { name: /Bin design011/ })[0]);
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'design011' }));
+  });
+
+  describe('curated collections', () => {
+    it('renders a curated shelf above the derived ones', () => {
+      collections.COMMUNITY_COLLECTIONS = [
+        {
+          id: 'starters',
+          titleKey: 'collections.starters.title',
+          blurbKey: 'collections.starters.blurb',
+          designIds: ['design000'],
+        },
+      ];
+      const items = manyCards(SHELF_LANDING_MIN_DESIGNS);
+      render(<ShelfLanding items={items} onSelect={vi.fn()} onSelectAuthor={vi.fn()} />);
+
+      const headings = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent);
+      // A human vouched for these, which outranks any derived shelf.
+      expect(headings[0]).toBe('collections.starters.title');
+      expect(screen.getByText('collections.starters.blurb')).toBeInTheDocument();
+    });
+
+    it('drops a curated shelf whose designs are all gone', () => {
+      collections.COMMUNITY_COLLECTIONS = [
+        {
+          id: 'ghosts',
+          titleKey: 'collections.ghosts.title',
+          blurbKey: 'collections.ghosts.blurb',
+          designIds: ['not-published'],
+        },
+      ];
+      const items = manyCards(SHELF_LANDING_MIN_DESIGNS);
+      render(<ShelfLanding items={items} onSelect={vi.fn()} onSelectAuthor={vi.fn()} />);
+
+      // An empty shelf advertises a grouping then fails to deliver it.
+      expect(screen.queryByText('collections.ghosts.title')).toBeNull();
+    });
+
+    it('gives a curated shelf no see-all, since it is not a filter', () => {
+      collections.COMMUNITY_COLLECTIONS = [
+        {
+          id: 'starters',
+          titleKey: 'collections.starters.title',
+          blurbKey: 'collections.starters.blurb',
+          designIds: ['design000'],
+        },
+      ];
+      const items = manyCards(SHELF_LANDING_MIN_DESIGNS);
+      render(<ShelfLanding items={items} onSelect={vi.fn()} onSelectAuthor={vi.fn()} />);
+
+      expect(screen.queryByTestId('community-shelf-see-all-collection-starters')).toBeNull();
+    });
   });
 });

--- a/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
+++ b/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import type { CommunityCard as CommunityCardData } from '@/shared/types/community';
@@ -32,6 +32,21 @@ export function ShelfLanding({ items, onSelect, onSelectAuthor }: ShelfLandingPr
 
   const shelves = useMemo(() => buildShelves(items, fetchedAt ?? 0), [items, fetchedAt]);
   const collections = useMemo(() => resolveCollections(COMMUNITY_COLLECTIONS, items), [items]);
+
+  // Curation happens by PR against a static file, so a typo has no other way
+  // of announcing itself: without this the shelf just quietly shrinks. Dev
+  // only, since in production an unresolved id is usually a design that was
+  // moderated or has aged out of the capped index, not a mistake.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    for (const collection of collections) {
+      if (collection.missingIds.length > 0) {
+        console.warn(
+          `[collections] "${collection.id}" has ids with no live design: ${collection.missingIds.join(', ')}`
+        );
+      }
+    }
+  }, [collections]);
   if (shelves.length === 0 && collections.length === 0) return null;
 
   // Deliberately not clearFilters(): if a filter raced in from another tab,

--- a/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
+++ b/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
@@ -5,6 +5,8 @@ import type { CommunityCard as CommunityCardData } from '@/shared/types/communit
 import { useBrowseStore } from '../../store/browseStore';
 import { CommunityCard } from '../CommunityCard';
 import type { ShelfId } from './shelfData';
+import { COMMUNITY_COLLECTIONS } from '../../data/collections';
+import { resolveCollections } from '../../utils/resolveCollections';
 import { buildShelves } from './shelfData';
 
 const SHELF_TITLE_KEYS: Record<ShelfId, string> = {
@@ -29,7 +31,8 @@ export function ShelfLanding({ items, onSelect, onSelectAuthor }: ShelfLandingPr
   const fetchedAt = useBrowseStore((s) => s.fetchedAt);
 
   const shelves = useMemo(() => buildShelves(items, fetchedAt ?? 0), [items, fetchedAt]);
-  if (shelves.length === 0) return null;
+  const collections = useMemo(() => resolveCollections(COMMUNITY_COLLECTIONS, items), [items]);
+  if (shelves.length === 0 && collections.length === 0) return null;
 
   // Deliberately not clearFilters(): if a filter raced in from another tab,
   // "See all" should apply this one change, not silently wipe the rest.
@@ -50,45 +53,90 @@ export function ShelfLanding({ items, onSelect, onSelectAuthor }: ShelfLandingPr
       className="shrink-0 space-y-2 border-b border-stroke-subtle px-3 pt-2 md:px-4"
       data-testid="community-shelves"
     >
+      {/* Curated collections lead: a human vouched for these, which is a
+          stronger claim than any of the derived shelves can make. */}
+      {collections.map((collection) => (
+        <Rail
+          key={collection.id}
+          id={`collection-${collection.id}`}
+          title={t(collection.titleKey)}
+          blurb={t(collection.blurbKey)}
+          cards={collection.cards}
+          onSelect={onSelect}
+          onSelectAuthor={onSelectAuthor}
+        />
+      ))}
+
       {shelves.map((shelf) => (
-        <section key={shelf.id} aria-labelledby={`community-shelf-${shelf.id}`}>
-          <div className="flex items-center justify-between gap-2">
-            <h3 id={`community-shelf-${shelf.id}`} className="text-sm font-semibold text-content">
-              {t(SHELF_TITLE_KEYS[shelf.id])}
-            </h3>
-            {shelf.id !== 'new-this-week' && (
-              <Button
-                variant="ghost"
-                onClick={() => handleSeeAll(shelf.id)}
-                className="shrink-0 text-sm"
-                data-testid={`community-shelf-see-all-${shelf.id}`}
-              >
-                {t('community.shelves.seeAll', { shelf: t(SHELF_TITLE_KEYS[shelf.id]) })}
-              </Button>
-            )}
-          </div>
-          {/* motion-reduce disables the snap yank outright, not just the timing:
-              scroll-snap can still animate into place without scroll-behavior. */}
-          {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
-          {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-          <ul
-            role="list"
-            aria-label={t(SHELF_TITLE_KEYS[shelf.id])}
-            className="flex list-none snap-x snap-mandatory gap-3 overflow-x-auto pb-2 motion-reduce:snap-none motion-reduce:scroll-auto"
-          >
-            {shelf.cards.map((card, index) => (
-              <li key={card.id} className="w-40 shrink-0 snap-start sm:w-44">
-                <CommunityCard
-                  card={card}
-                  onSelect={onSelect}
-                  onSelectAuthor={onSelectAuthor}
-                  index={index}
-                />
-              </li>
-            ))}
-          </ul>
-        </section>
+        <Rail
+          key={shelf.id}
+          id={shelf.id}
+          title={t(SHELF_TITLE_KEYS[shelf.id])}
+          cards={shelf.cards}
+          onSelect={onSelect}
+          onSelectAuthor={onSelectAuthor}
+          // New-this-week has no action: the grid below is already
+          // newest-first, so its "See all" would be a visible no-op.
+          onSeeAll={shelf.id === 'new-this-week' ? undefined : () => handleSeeAll(shelf.id)}
+        />
       ))}
     </div>
+  );
+}
+
+interface RailProps {
+  id: string;
+  title: string;
+  /** Editorial one-liner; derived shelves have none, their titles say enough. */
+  blurb?: string;
+  cards: readonly CommunityCardData[];
+  onSelect: (card: CommunityCardData) => void;
+  onSelectAuthor: (card: CommunityCardData) => void;
+  onSeeAll?: () => void;
+}
+
+function Rail({ id, title, blurb, cards, onSelect, onSelectAuthor, onSeeAll }: RailProps) {
+  const t = useTranslation();
+  return (
+    <section aria-labelledby={`community-shelf-${id}`}>
+      <div className="flex items-center justify-between gap-2">
+        <h3 id={`community-shelf-${id}`} className="text-sm font-semibold text-content">
+          {title}
+        </h3>
+        {onSeeAll !== undefined && (
+          <Button
+            variant="ghost"
+            onClick={onSeeAll}
+            className="shrink-0 text-sm"
+            data-testid={`community-shelf-see-all-${id}`}
+          >
+            {t('community.shelves.seeAll', { shelf: title })}
+          </Button>
+        )}
+      </div>
+
+      {blurb !== undefined && <p className="mb-1 text-xs text-content-secondary">{blurb}</p>}
+
+      {/* motion-reduce disables the snap yank outright, not just the timing:
+          scroll-snap can still animate into place without scroll-behavior. */}
+      {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+      <ul
+        role="list"
+        aria-label={title}
+        className="flex list-none snap-x snap-mandatory gap-3 overflow-x-auto pb-2 motion-reduce:snap-none motion-reduce:scroll-auto"
+      >
+        {cards.map((card, index) => (
+          <li key={card.id} className="w-40 shrink-0 snap-start sm:w-44">
+            <CommunityCard
+              card={card}
+              onSelect={onSelect}
+              onSelectAuthor={onSelectAuthor}
+              index={index}
+            />
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/src/features/community/data/collections.test.ts
+++ b/src/features/community/data/collections.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { COMMUNITY_COLLECTIONS } from './collections';
+
+/**
+ * Curation happens by hand-editing this file, so these guard the shape a
+ * reviewer would otherwise have to eyeball. They pass vacuously while the
+ * list is empty and start doing real work the moment someone curates.
+ */
+describe('COMMUNITY_COLLECTIONS', () => {
+  it('has unique ids', () => {
+    const ids = COMMUNITY_COLLECTIONS.map((collection) => collection.id);
+    // Each id becomes a React key and part of a heading DOM id, so a duplicate
+    // means reconciliation warnings and an ambiguous aria-labelledby.
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('uses lowercase hyphenated slugs for ids', () => {
+    for (const collection of COMMUNITY_COLLECTIONS) {
+      expect(collection.id).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    }
+  });
+
+  it('gives every collection a title and blurb key', () => {
+    for (const collection of COMMUNITY_COLLECTIONS) {
+      expect(collection.titleKey).not.toBe('');
+      expect(collection.blurbKey).not.toBe('');
+    }
+  });
+
+  it('never ships a collection with no designs', () => {
+    for (const collection of COMMUNITY_COLLECTIONS) {
+      // It would resolve to nothing and be dropped, so it is dead curation.
+      expect(collection.designIds.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no duplicate design ids within a collection', () => {
+    for (const collection of COMMUNITY_COLLECTIONS) {
+      expect(new Set(collection.designIds).size).toBe(collection.designIds.length);
+    }
+  });
+});

--- a/src/features/community/data/collections.ts
+++ b/src/features/community/data/collections.ts
@@ -24,7 +24,11 @@
  */
 
 export interface CommunityCollection {
-  /** Stable slug; used as a React key and in analytics. */
+  /**
+   * Stable slug, lowercase with hyphens. Becomes a React key and part of the
+   * shelf's DOM id, so it must be unique across the list; `collections.test.ts`
+   * enforces both.
+   */
   readonly id: string;
   /** i18n key for the shelf heading. */
   readonly titleKey: string;

--- a/src/features/community/data/collections.ts
+++ b/src/features/community/data/collections.ts
@@ -1,0 +1,37 @@
+/**
+ * Editorial collections: hand-picked groups of designs, curated by PR.
+ *
+ * Human taste is the honest alternative to an engagement algorithm, and unlike
+ * an algorithm it does not pretend to be objective. Keeping the list in the
+ * repo means curation is reviewable, diffable and revertible, and needs no
+ * admin UI or storage.
+ *
+ * ## Adding a collection
+ *
+ * 1. Add an entry below with a stable `id`, the i18n keys for its title and
+ *    blurb, and the design ids in the order you want them shown.
+ * 2. Add those two keys to `src/i18n/locales/en.ts` and every locale JSON
+ *    (see the i18n-changes skill). Editorial copy is user-facing, so it is
+ *    translated like everything else.
+ * 3. Open a PR. That PR *is* the curation record.
+ *
+ * A collection whose designs have since been removed or hidden simply shrinks;
+ * one with nothing left to show disappears. Curating never has to be undone
+ * because a design went away.
+ *
+ * The list is deliberately empty: the mechanism ships here, the picks are a
+ * separate content decision.
+ */
+
+export interface CommunityCollection {
+  /** Stable slug; used as a React key and in analytics. */
+  readonly id: string;
+  /** i18n key for the shelf heading. */
+  readonly titleKey: string;
+  /** i18n key for the one-line reason this grouping exists. */
+  readonly blurbKey: string;
+  /** Design ids, in the order they should appear. */
+  readonly designIds: readonly string[];
+}
+
+export const COMMUNITY_COLLECTIONS: readonly CommunityCollection[] = [];

--- a/src/features/community/utils/resolveCollections.test.ts
+++ b/src/features/community/utils/resolveCollections.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { CommunityCard } from '@/shared/types/community';
+import type { CommunityCollection } from '../data/collections';
+import { resolveCollection, resolveCollections } from './resolveCollections';
+
+function card(id: string, overrides: Partial<CommunityCard> = {}): CommunityCard {
+  return {
+    id,
+    name: `Bin ${id}`,
+    authorName: 'Casey',
+    authorPublicId: 'a'.repeat(32),
+    category: 'tools',
+    techniques: [],
+    metrics: { width: 83.5, depth: 125.5, height: 42, gridUnitMm: 42 },
+    thumbnailUrl: '',
+    isRemix: false,
+    featured: false,
+    counts: { likes: 0, remixes: 0, exports: 0 },
+    createdAt: 1000,
+    updatedAt: 1000,
+    status: 'live',
+    ...overrides,
+  };
+}
+
+function collection(designIds: string[]): CommunityCollection {
+  return {
+    id: 'starters',
+    titleKey: 'community.collections.starters.title',
+    blurbKey: 'community.collections.starters.blurb',
+    designIds,
+  };
+}
+
+describe('resolveCollection', () => {
+  it('preserves the curated order rather than the index order', () => {
+    const items = [card('c'), card('a'), card('b')];
+
+    const resolved = resolveCollection(collection(['b', 'a', 'c']), items);
+
+    // Sequence is part of the editorial judgement.
+    expect(resolved.cards.map((c) => c.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('skips designs that are not live', () => {
+    const items = [card('a'), card('b', { status: 'hidden' }), card('c', { status: 'removed' })];
+
+    const resolved = resolveCollection(collection(['a', 'b', 'c']), items);
+
+    expect(resolved.cards.map((c) => c.id)).toEqual(['a']);
+    expect(resolved.missingIds).toEqual(['b', 'c']);
+  });
+
+  it('reports ids with no card at all', () => {
+    const resolved = resolveCollection(collection(['a', 'ghost']), [card('a')]);
+
+    // Lets a curator tell "not published yet" from "my ids are wrong".
+    expect(resolved.missingIds).toEqual(['ghost']);
+  });
+
+  it('renders a duplicated id once', () => {
+    const resolved = resolveCollection(collection(['a', 'a']), [card('a')]);
+    expect(resolved.cards.map((c) => c.id)).toEqual(['a']);
+  });
+
+  it('carries the i18n keys through untouched', () => {
+    const resolved = resolveCollection(collection(['a']), [card('a')]);
+    expect(resolved).toMatchObject({
+      id: 'starters',
+      titleKey: 'community.collections.starters.title',
+      blurbKey: 'community.collections.starters.blurb',
+    });
+  });
+
+  it('resolves to nothing when the index is empty', () => {
+    const resolved = resolveCollection(collection(['a']), []);
+    expect(resolved.cards).toEqual([]);
+    expect(resolved.missingIds).toEqual(['a']);
+  });
+});
+
+describe('resolveCollections', () => {
+  it('drops a collection with nothing left to show', () => {
+    const items = [card('a')];
+    const collections: CommunityCollection[] = [
+      { ...collection(['a']), id: 'keeps' },
+      { ...collection(['gone']), id: 'drops' },
+    ];
+
+    // An empty shelf advertises a grouping and then fails to deliver it.
+    expect(resolveCollections(collections, items).map((c) => c.id)).toEqual(['keeps']);
+  });
+
+  it('keeps a collection that only partly resolved', () => {
+    const collections = [collection(['a', 'gone'])];
+
+    const resolved = resolveCollections(collections, [card('a')]);
+
+    // Curation never has to be undone because one design went away.
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].cards.map((c) => c.id)).toEqual(['a']);
+  });
+
+  it('returns nothing when nothing is curated', () => {
+    expect(resolveCollections([], [card('a')])).toEqual([]);
+  });
+});

--- a/src/features/community/utils/resolveCollections.ts
+++ b/src/features/community/utils/resolveCollections.ts
@@ -1,0 +1,75 @@
+/**
+ * Turn curated id lists into renderable shelves against the loaded index.
+ *
+ * The curated file is a list of intentions; this is where those meet reality.
+ * A design can be removed, hidden, or simply sit outside the capped index, and
+ * none of those should require editing the curation.
+ */
+
+import type { CommunityCard } from '@/shared/types/community';
+import type { CommunityCollection } from '../data/collections';
+
+export interface ResolvedCollection {
+  readonly id: string;
+  readonly titleKey: string;
+  readonly blurbKey: string;
+  readonly cards: readonly CommunityCard[];
+  /**
+   * Curated ids with no live card in the loaded index. Surfaced so a curator
+   * can tell "nobody has published this yet" from "my ids are wrong", rather
+   * than watching a shelf silently shrink.
+   */
+  readonly missingIds: readonly string[];
+}
+
+/**
+ * Resolve one collection. Order follows the curation, not the index: the
+ * sequence is part of the editorial judgement, so it is preserved exactly.
+ */
+export function resolveCollection(
+  collection: CommunityCollection,
+  items: readonly CommunityCard[]
+): ResolvedCollection {
+  const live = new Map(
+    items.filter((card) => card.status === 'live').map((card) => [card.id, card])
+  );
+
+  const cards: CommunityCard[] = [];
+  const missingIds: string[] = [];
+  // Guard against a duplicated id in the curated list rendering twice.
+  const seen = new Set<string>();
+
+  for (const id of collection.designIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const card = live.get(id);
+    if (card === undefined) {
+      missingIds.push(id);
+      continue;
+    }
+    cards.push(card);
+  }
+
+  return {
+    id: collection.id,
+    titleKey: collection.titleKey,
+    blurbKey: collection.blurbKey,
+    cards,
+    missingIds,
+  };
+}
+
+/**
+ * Resolve every collection, dropping those with nothing left to show.
+ *
+ * An empty shelf is worse than no shelf: it advertises a grouping and then
+ * fails to deliver it. Curation never needs undoing because a design went away.
+ */
+export function resolveCollections(
+  collections: readonly CommunityCollection[],
+  items: readonly CommunityCard[]
+): ResolvedCollection[] {
+  return collections
+    .map((collection) => resolveCollection(collection, items))
+    .filter((resolved) => resolved.cards.length > 0);
+}


### PR DESCRIPTION
Phase 4, the last of the plan. Hand-picked groups of designs, curated by opening a PR against a file rather than through an admin UI.

## Why a repo file

Human taste is the honest alternative to an engagement algorithm, and unlike an algorithm it does not pretend to be objective. Keeping the list in the repo means curation is reviewable, diffable and revertible, and needs no storage, no endpoint and no moderation surface. The PR *is* the curation record.

## Where intentions meet reality

`resolveCollections` handles the gap between a curated id list and what actually exists:

- **Curated order is preserved exactly.** The sequence is part of the editorial judgement, so index order never overrides it.
- **Non-live and unknown ids are skipped**, and reported as `missingIds` so a curator can tell "not published yet" from "my ids are wrong" rather than watching a shelf silently shrink.
- **A collection with nothing left to show is dropped.** An empty shelf advertises a grouping then fails to deliver it. This is what makes curation durable: it never has to be undone because a design was removed or hidden.

Curated shelves render **above** the derived ones — a human vouched for these, which is a stronger claim than "most remixed" can make. They carry a blurb saying why the grouping exists, and deliberately no "See all": a collection is a pick, not a filter.

## The shipped list is empty, on purpose

This PR lands the mechanism, fully tested. The picks are a separate content decision, made by opening a PR against `data/collections.ts` with the ids and two i18n keys.

I want to be straight about the tradeoff rather than dress it up: **this PR produces no user-visible change on its own.** Nothing renders until something is curated. I judged that better than inventing placeholder picks against a library whose designs I have not seen, which would be editorial judgement I am not in a position to exercise. The file documents the three-step workflow.

The tests drive the mechanism through a mocked collection list, so coverage does not depend on shipping picks.

## Notes for review

- The shelf rail markup is extracted into a shared `Rail`, so curated and derived shelves cannot drift apart. That is most of the diff in `ShelfLanding.tsx`.
- A duplicated id in a curated list renders once.
- Adding a collection costs two i18n keys across all 15 locales. Editorial copy is user-facing, so it is translated like everything else, and I did not carve out an exception for it.

## Testing

12 new tests: resolution (order preservation, non-live skipping, unknown-id reporting, dedupe, empty index, dropping empty collections, keeping partial ones) and rendering (curated shelf leads, blurb shown, all-gone collection dropped, no see-all).

Full suite: 20,241 passing.

## Plan complete

All four phases from the vision have now shipped: proof of print (#3178, #3183, #3191, #3195), fit and print cost (#3199), provenance and identity (#3201, #3203), and editorial curation (this one).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repo-authored editorial collections to the Community gallery. Curated shelves render above derived shelves; dev-only warns on missing IDs and nothing changes for users until collections are added.

- **New Features**
  - Adds `src/features/community/data/collections.ts` for hand-picked design groups curated by PR.
  - Introduces `resolveCollections` to map curated ids to live cards with exact order, skip non-live/unknown ids (exposed via `missingIds`), de-duplicate, drop empty collections, and warn in dev when ids don’t resolve.
  - Updates `ShelfLanding` to render curated shelves first, include a blurb, and omit "See all" for collections.

- **Refactors**
  - Extracts a shared `Rail` component so curated and derived shelves use the same markup.
  - Hardening/tests: adds `collections.test.ts` to guard curated file shape (unique slug ids, non-empty keys, no empty/duplicate id lists); increases reconnect wait in `CommunityDetail` test to 15s to deflake CI.

<sup>Written for commit ddc7da37aefecb2275e841c3189ecdf5207c5bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

