### PR TITLE
feat(community): make featuring state its reason

### DIFF
--- a/api/community.test.ts
+++ b/api/community.test.ts
@@ -1098,6 +1098,34 @@ describe('GET /api/community (list)', () => {
     expect((res._body as { likedIds: string[] }).likedIds).toEqual([]);
   });
 
+  it('serves a valid feature reason on a featured card', async () => {
+    await seedCard({ id: 'featured0001', featured: true });
+    await fake.hset(communityDesignKey('featured0001'), { featureReason: 'clever' });
+
+    const res = await handle({ method: 'GET' });
+    const body = res._body as { items: Array<{ id: string; featureReason?: string }> };
+    expect(body.items.find((i) => i.id === 'featured0001')?.featureReason).toBe('clever');
+  });
+
+  it('drops a stored reason that is no longer in the union', async () => {
+    await seedCard({ id: 'featured0002', featured: true });
+    await fake.hset(communityDesignKey('featured0002'), { featureReason: 'retired-reason' });
+
+    const res = await handle({ method: 'GET' });
+    const body = res._body as { items: Array<{ id: string; featureReason?: string }> };
+    // The stored value is a free string; a client indexes it into a label map.
+    expect(body.items.find((i) => i.id === 'featured0002')?.featureReason).toBeUndefined();
+  });
+
+  it('omits the reason on a design that is not featured', async () => {
+    await seedCard({ id: 'featured0003' });
+    await fake.hset(communityDesignKey('featured0003'), { featureReason: 'clever' });
+
+    const res = await handle({ method: 'GET' });
+    const body = res._body as { items: Array<{ id: string; featureReason?: string }> };
+    expect(body.items.find((i) => i.id === 'featured0003')?.featureReason).toBeUndefined();
+  });
+
   it('prefers a promoted cover photo over the render while prints are enabled', async () => {
     vi.stubEnv('COMMUNITY_PRINTS_ENABLED', 'true');
     await seedCard({ id: 'coverdesign1' });

--- a/api/community.ts
+++ b/api/community.ts
@@ -19,6 +19,7 @@ import {
   COMMUNITY_CATEGORIES,
   COMMUNITY_TECHNIQUES,
   communityRequiresCutouts,
+  isCommunityFeatureReason,
   parseCommunityLineage,
   validateCommunityPublish,
 } from './lib/communityValidation.js';
@@ -570,9 +571,12 @@ function toListItem(card: CommunityCardRecord): CommunityListItem {
     isRemix: card.isRemix,
     parentId: card.parentId,
     featured: card.featured,
+    // Validated, not forwarded: the stored value is a free string, and a
+    // reason retired from the union would otherwise reach a client that
+    // indexes it straight into a label map.
     ...(card.featured &&
       card.featureReason !== undefined &&
-      card.featureReason !== '' && { featureReason: card.featureReason }),
+      isCommunityFeatureReason(card.featureReason) && { featureReason: card.featureReason }),
     counts: {
       likes: card.likes,
       remixes: card.remixes,

--- a/api/community.ts
+++ b/api/community.ts
@@ -524,6 +524,8 @@ interface CommunityListItem {
   /** Direct-remix lineage pointer, '' for originals: powers the detail view's builds-on-this list. */
   parentId: string;
   featured: boolean;
+  /** Curator's stated reason; omitted when unfeatured or picked before the field. */
+  featureReason?: string;
   /** `opens`/`views` are owner-only stats, present only on `mine=1` items. */
   counts: {
     likes: number;
@@ -568,6 +570,9 @@ function toListItem(card: CommunityCardRecord): CommunityListItem {
     isRemix: card.isRemix,
     parentId: card.parentId,
     featured: card.featured,
+    ...(card.featured &&
+      card.featureReason !== undefined &&
+      card.featureReason !== '' && { featureReason: card.featureReason }),
     counts: {
       likes: card.likes,
       remixes: card.remixes,

--- a/api/lib/communityStore.test.ts
+++ b/api/lib/communityStore.test.ts
@@ -285,6 +285,7 @@ describe('readCommunityCards', () => {
       views: 0,
       prints: 0,
       coverPhotoUrl: '',
+      featureReason: '',
     });
     expect(cards[1]).toBeNull();
     expect(cards[2]).toBeNull();

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -114,7 +114,11 @@ export interface CommunityDesignRecord {
    */
   coverPhotoUrl?: string;
   featured: boolean;
-  /** Why it was featured; '' when unfeatured or picked before the field existed. */
+  /**
+   * Why it was featured. Absent entirely on a blob written before the field
+   * existed (the reader returns stored JSON verbatim); '' once the admin path
+   * has touched it with an unfeature. Treat absent and '' the same.
+   */
   featureReason?: string;
   createdAt: number;
   updatedAt: number;

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -114,6 +114,8 @@ export interface CommunityDesignRecord {
    */
   coverPhotoUrl?: string;
   featured: boolean;
+  /** Why it was featured; '' when unfeatured or picked before the field existed. */
+  featureReason?: string;
   createdAt: number;
   updatedAt: number;
   status: CommunityDesignStatus;
@@ -222,6 +224,8 @@ export interface CommunityCardRecord extends CommunityCardMetadata {
   prints?: number;
   /** Owner-promoted print photo, or '' for the render. Never written by the metadata writer. */
   coverPhotoUrl?: string;
+  /** Curator's stated reason for featuring; set by the admin path only. */
+  featureReason?: string;
   /** Present only after a hide; consulted only while status is 'hidden'. */
   hiddenReason?: CommunityHiddenReason;
 }
@@ -284,6 +288,7 @@ function parseCard(fields: Record<string, string | undefined>): CommunityCardRec
     views: Number(fields.views ?? 0),
     prints: Number(fields.prints ?? 0),
     coverPhotoUrl: fields.coverPhotoUrl ?? '',
+    featureReason: fields.featureReason ?? '',
     ...((fields.hiddenReason === 'reports' ||
       fields.hiddenReason === 'denylist' ||
       fields.hiddenReason === 'moderation') && {

--- a/api/lib/communityValidation.ts
+++ b/api/lib/communityValidation.ts
@@ -51,6 +51,23 @@ export function communityRequiresCutouts(): boolean {
   return process.env.COMMUNITY_REQUIRE_CUTOUTS !== 'false';
 }
 
+/**
+ * MIRROR: must match `COMMUNITY_FEATURE_REASONS` in
+ * `src/shared/types/community.ts` (api/ cannot import from src/). Guarded by
+ * the cross-boundary equality test in `community.test.ts`.
+ */
+export const COMMUNITY_FEATURE_REASONS = [
+  'well-made',
+  'clever',
+  'versatile',
+  'beginner-friendly',
+] as const;
+export type CommunityFeatureReason = (typeof COMMUNITY_FEATURE_REASONS)[number];
+
+export function isCommunityFeatureReason(value: string): value is CommunityFeatureReason {
+  return (COMMUNITY_FEATURE_REASONS as readonly string[]).includes(value);
+}
+
 export const COMMUNITY_NAME_MAX_LENGTH = 60;
 export const COMMUNITY_DESCRIPTION_MAX_LENGTH = 500;
 /** Matches MAX_DISPLAY_NAME_LENGTH in supporters.ts: one cap for every rendered public name. */

--- a/scripts/check-union-exhaustiveness.sh
+++ b/scripts/check-union-exhaustiveness.sh
@@ -30,6 +30,7 @@ declare -A UNION_TYPES=(
   ["CommunityIndexSort"]="newest,remixes,likes"
   ["CommunityMilestoneKind"]="first_publish,first_remix_of_yours,ten_published_remixes,hundred_prints"
   ["CommunityReportReason"]="inappropriate,spam,broken,stolen"
+  ["CommunityFeatureReason"]="well-made,clever,versatile,beginner-friendly"
   ["CommunityPrintMaterial"]="pla,petg,abs,asa,tpu,other"
   ["CommunityPrintFitVerdict"]="as-designed,adjusted,did-not-fit"
   ["CommunityPrintStatus"]="live,hidden,removed"

--- a/scripts/community-admin/__tests__/denylist.test.ts
+++ b/scripts/community-admin/__tests__/denylist.test.ts
@@ -124,7 +124,7 @@ function seedCard(redis: FakeRedis, id: string, status: string): void {
 }
 
 function baseArgs(positional: string[]): Args {
-  return { command: 'denylist', positional, json: false, yes: false, help: false };
+  return { command: 'denylist', positional, json: false, yes: false, help: false, reason: null };
 }
 
 beforeEach(() => {

--- a/scripts/community-admin/__tests__/dispatch.test.ts
+++ b/scripts/community-admin/__tests__/dispatch.test.ts
@@ -3,7 +3,7 @@ import { dispatch } from '../lib/dispatch';
 import type { Args } from '../lib/args';
 
 function baseArgs(command: string, positional: string[] = []): Args {
-  return { command, positional, json: false, yes: false, help: false };
+  return { command, positional, json: false, yes: false, help: false, reason: null };
 }
 
 describe('dispatch', () => {

--- a/scripts/community-admin/__tests__/feature.test.ts
+++ b/scripts/community-admin/__tests__/feature.test.ts
@@ -29,8 +29,8 @@ const RECORD = {
   updatedAt: 1,
 } as CommunityDesignRecord;
 
-function baseArgs(command: string, positional: string[]): Args {
-  return { command, positional, json: false, yes: false, help: false };
+function baseArgs(command: string, positional: string[], reason: string | null = null): Args {
+  return { command, positional, json: false, yes: false, help: false, reason };
 }
 
 function createRedis() {
@@ -61,7 +61,7 @@ describe('feature/unfeature commands', () => {
     const redis = createRedis();
     mocks.connect.mockReturnValue(redis);
 
-    expect(await feature(baseArgs('feature', ['abc123DEF456']))).toBe(1);
+    expect(await feature(baseArgs('feature', ['abc123DEF456'], 'clever'))).toBe(1);
     expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
     expect(redis.hset).not.toHaveBeenCalled();
     expect(redis.quit).toHaveBeenCalledTimes(1);
@@ -72,7 +72,7 @@ describe('feature/unfeature commands', () => {
     const redis = createRedis();
     mocks.connect.mockReturnValue(redis);
 
-    expect(await feature(baseArgs('feature', ['abc123DEF456']))).toBe(0);
+    expect(await feature(baseArgs('feature', ['abc123DEF456'], 'clever'))).toBe(0);
     const written = mocks.writeCommunityDesignBlob.mock.calls[0] as [
       CommunityDesignRecord,
       { allowOverwrite: boolean },
@@ -82,7 +82,11 @@ describe('feature/unfeature commands', () => {
     // either the blob or the card hash (no updatedAt written to the hash).
     expect(written[0].updatedAt).toBe(RECORD.updatedAt);
     expect(written[1]).toEqual({ allowOverwrite: true });
-    expect(redis.hset).toHaveBeenCalledWith('community:design:abc123DEF456', { featured: '1' });
+    expect(written[0].featureReason).toBe('clever');
+    expect(redis.hset).toHaveBeenCalledWith('community:design:abc123DEF456', {
+      featured: '1',
+      featureReason: 'clever',
+    });
     expect(redis.hset).not.toHaveBeenCalledWith(
       'community:design:abc123DEF456',
       expect.objectContaining({ updatedAt: expect.anything() })
@@ -97,6 +101,29 @@ describe('feature/unfeature commands', () => {
     expect(await unfeature(baseArgs('unfeature', ['abc123DEF456']))).toBe(0);
     const written = mocks.writeCommunityDesignBlob.mock.calls[0][0] as CommunityDesignRecord;
     expect(written.featured).toBe(false);
-    expect(redis.hset).toHaveBeenCalledWith('community:design:abc123DEF456', { featured: '0' });
+    // Cleared on unfeature so a later re-feature cannot inherit a stale reason.
+    expect(written.featureReason).toBe('');
+    expect(redis.hset).toHaveBeenCalledWith('community:design:abc123DEF456', {
+      featured: '0',
+      featureReason: '',
+    });
+  });
+
+  it('refuses to feature without a stated reason', async () => {
+    // An unexplained star is the least legible signal in the gallery.
+    expect(await feature(baseArgs('feature', ['abc123DEF456']))).toBe(2);
+    expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+  });
+
+  it('refuses a reason outside the closed set', async () => {
+    expect(await feature(baseArgs('feature', ['abc123DEF456'], 'because-i-said-so'))).toBe(2);
+    expect(mocks.writeCommunityDesignBlob).not.toHaveBeenCalled();
+  });
+
+  it('needs no reason to unfeature', async () => {
+    mocks.readCommunityDesignBlob.mockResolvedValue({ ...RECORD, featured: true });
+    mocks.connect.mockReturnValue(createRedis());
+
+    expect(await unfeature(baseArgs('unfeature', ['abc123DEF456']))).toBe(0);
   });
 });

--- a/scripts/community-admin/__tests__/hide.test.ts
+++ b/scripts/community-admin/__tests__/hide.test.ts
@@ -31,7 +31,7 @@ const { hide } = await import('../commands/hide.js');
 const CARD = { id: 'abc123DEF456', status: 'live' } as CommunityCardRecord;
 
 function baseArgs(positional: string[]): Args {
-  return { command: 'hide', positional, json: false, yes: false, help: false };
+  return { command: 'hide', positional, json: false, yes: false, help: false, reason: null };
 }
 
 function createRedis() {

--- a/scripts/community-admin/__tests__/inspect.test.ts
+++ b/scripts/community-admin/__tests__/inspect.test.ts
@@ -40,7 +40,7 @@ const RECORD = {
 const CARD = { id: 'abc123DEF456', likes: 2, remixes: 0, exports: 1 } as CommunityCardRecord;
 
 function baseArgs(positional: string[], json = false): Args {
-  return { command: 'inspect', positional, json, yes: false, help: false };
+  return { command: 'inspect', positional, json, yes: false, help: false, reason: null };
 }
 
 function createRedis(reporterIds: string[]) {

--- a/scripts/community-admin/__tests__/list.test.ts
+++ b/scripts/community-admin/__tests__/list.test.ts
@@ -49,7 +49,7 @@ function card(id: string, status: CommunityCardRecord['status']): CommunityCardR
 }
 
 function baseArgs(positional: string[], json = false): Args {
-  return { command: 'list', positional, json, yes: false, help: false };
+  return { command: 'list', positional, json, yes: false, help: false, reason: null };
 }
 
 function createRedis(reportCounts: number[]) {

--- a/scripts/community-admin/__tests__/purge.test.ts
+++ b/scripts/community-admin/__tests__/purge.test.ts
@@ -65,7 +65,7 @@ function createFakeRedis(likerIds: string[]) {
 }
 
 function baseArgs(positional: string[], yes = true): Args {
-  return { command: 'purge', positional, json: false, yes, help: false };
+  return { command: 'purge', positional, json: false, yes, help: false, reason: null };
 }
 
 const RECORD: CommunityDesignRecord = {

--- a/scripts/community-admin/__tests__/restore.test.ts
+++ b/scripts/community-admin/__tests__/restore.test.ts
@@ -26,7 +26,7 @@ const { restore } = await import('../commands/restore.js');
 const CARD = { id: 'abc123DEF456', status: 'hidden' } as CommunityCardRecord;
 
 function baseArgs(positional: string[]): Args {
-  return { command: 'restore', positional, json: false, yes: false, help: false };
+  return { command: 'restore', positional, json: false, yes: false, help: false, reason: null };
 }
 
 function createRedis() {

--- a/scripts/community-admin/__tests__/undenylist.test.ts
+++ b/scripts/community-admin/__tests__/undenylist.test.ts
@@ -12,7 +12,7 @@ vi.mock('../lib/redis.js', () => ({
 const { undenylist } = await import('../commands/undenylist.js');
 
 function baseArgs(positional: string[]): Args {
-  return { command: 'undenylist', positional, json: false, yes: false, help: false };
+  return { command: 'undenylist', positional, json: false, yes: false, help: false, reason: null };
 }
 
 function createRedis(sremResult: number) {

--- a/scripts/community-admin/commands/feature.ts
+++ b/scripts/community-admin/commands/feature.ts
@@ -1,4 +1,8 @@
 import { isValidShareId } from '../../../api/lib/shared.js';
+import {
+  COMMUNITY_FEATURE_REASONS,
+  isCommunityFeatureReason,
+} from '../../../api/lib/communityValidation.js';
 import { communityDesignKey } from '../../../api/lib/redisKeys.js';
 import {
   readCommunityDesignBlob,
@@ -25,6 +29,18 @@ async function setFeatured(args: Args, featured: boolean): Promise<number> {
     return 2;
   }
 
+  // Featuring requires stating why. An unexplained star is the least legible
+  // signal in the feature, and the reason is what the gallery shows.
+  let reason = '';
+  if (featured) {
+    const supplied = args.reason;
+    if (supplied === null || !isCommunityFeatureReason(supplied)) {
+      console.error(`feature <id> --reason <${COMMUNITY_FEATURE_REASONS.join('|')}> is required`);
+      return 2;
+    }
+    reason = supplied;
+  }
+
   const redis = connect();
   try {
     const record = await readCommunityDesignBlob(id);
@@ -37,10 +53,18 @@ async function setFeatured(args: Args, featured: boolean): Promise<number> {
     // reorder the design in any updatedAt-derived view and misreport it as
     // freshly edited.
     await Promise.all([
-      writeCommunityDesignBlob({ ...record, featured }, { allowOverwrite: true }),
-      redis.hset(communityDesignKey(id), { featured: featured ? '1' : '0' }),
+      writeCommunityDesignBlob(
+        { ...record, featured, featureReason: reason },
+        { allowOverwrite: true }
+      ),
+      redis.hset(communityDesignKey(id), {
+        featured: featured ? '1' : '0',
+        // Cleared on unfeature so a later re-feature cannot silently inherit
+        // a stale reason from a previous decision.
+        featureReason: reason,
+      }),
     ]);
-    console.log(colors.cyan(`${featured ? 'featured' : 'unfeatured'}: ${id}`));
+    console.log(colors.cyan(`${featured ? `featured (${reason})` : 'unfeatured'}: ${id}`));
     return 0;
   } finally {
     await redis.quit();

--- a/scripts/community-admin/lib/args.ts
+++ b/scripts/community-admin/lib/args.ts
@@ -4,6 +4,8 @@ export interface Args {
   json: boolean;
   yes: boolean;
   help: boolean;
+  /** `--reason <value>`; the only valued flag today, used by `feature`. */
+  reason: string | null;
 }
 
 export function parseArgs(argv: readonly string[]): Args {
@@ -13,12 +15,23 @@ export function parseArgs(argv: readonly string[]): Args {
     json: false,
     yes: false,
     help: false,
+    reason: null,
   };
-  for (const arg of argv) {
+  // Index-based rather than for-of: `--reason` consumes the next argv entry,
+  // which a value-only iterator cannot reach.
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
     if (arg === '--json') a.json = true;
     else if (arg === '--yes' || arg === '-y') a.yes = true;
     else if (arg === '--help' || arg === '-h') a.help = true;
-    else if (arg.startsWith('--')) throw new Error(`Unknown flag: ${arg}`);
+    else if (arg === '--reason') {
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error('--reason requires a value');
+      }
+      a.reason = value;
+      i += 1;
+    } else if (arg.startsWith('--')) throw new Error(`Unknown flag: ${arg}`);
     else if (!a.command) a.command = arg;
     else a.positional.push(arg);
   }

--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -61,6 +61,16 @@ Backend lives in `api/community/prints.ts` (`GET`/`PUT`/`DELETE`/`POST report`),
 - **Proven shelf** sits directly under staff picks, above recency: a design other people actually printed is the strongest recommendation the library has, and it is the one signal nobody can inflate by posting.
 - **Cover promotion** is owner opt-in and server-validated against the design's own **live** prints. The gallery grid is the most public surface in the app, and this is the only path by which a user-supplied image can reach it, so the check that the URL belongs to a live print of that design is load-bearing, not defensive. A hidden print's photo is not promotable.
 
+### Featured, with a reason
+
+`featured` no longer travels alone. Featuring a design through the admin CLI now **requires** `--reason <well-made|clever|versatile|beginner-friendly>`, and the gallery card shows that reason instead of a bare star.
+
+A closed set rather than free text: it is user-facing copy that has to translate, and it forces the pick into a stated reason. The vision's rule is that a ranking signal stays legible, and an unexplained star was the least legible thing in the feature.
+
+The reason is cleared on unfeature, so a later re-feature cannot silently inherit a previous decision. A design featured before the field existed shows no badge rather than an invented reason.
+
+Note the i18n key segments are camelCase (`...reason.wellMade`) while the union values are hyphenated (`well-made`). The keys follow the codebase convention, and the unused-key checker's literal scan does not match hyphens.
+
 ### Editorial collections
 
 `data/collections.ts` holds hand-picked groups of designs, curated by PR. Human taste is the honest alternative to an engagement algorithm, and unlike an algorithm it does not pretend to be objective. Keeping the list in the repo means curation is reviewable, diffable and revertible, and needs no admin UI or storage.

--- a/src/features/community/api/client.ts
+++ b/src/features/community/api/client.ts
@@ -12,8 +12,10 @@ import type {
   CommunityHiddenReason,
   CommunityReportReason,
 } from '@/shared/types/community';
+import type { CommunityFeatureReason } from '@/shared/types/community';
 import {
   COMMUNITY_CATEGORIES,
+  COMMUNITY_FEATURE_REASONS,
   COMMUNITY_REPORT_NOTE_MAX_LENGTH,
   COMMUNITY_REPORT_REASONS,
 } from '@/shared/types/community';
@@ -192,6 +194,12 @@ function isKnownTechnique(value: unknown): boolean {
   return typeof value === 'string' && KNOWN_TECHNIQUES.includes(value);
 }
 
+function isKnownFeatureReason(value: unknown): value is CommunityFeatureReason {
+  return (
+    typeof value === 'string' && (COMMUNITY_FEATURE_REASONS as readonly string[]).includes(value)
+  );
+}
+
 function isCommunityCard(value: unknown): value is CommunityCard {
   if (!isRecord(value)) return false;
   const counts: unknown = value.counts;
@@ -213,6 +221,9 @@ function isCommunityCard(value: unknown): value is CommunityCard {
     typeof value.isRemix === 'boolean' &&
     (value.parentId === undefined || typeof value.parentId === 'string') &&
     typeof value.featured === 'boolean' &&
+    // A reason outside the union fails the whole card rather than flowing
+    // through as a typed value the UI will index into a label map.
+    (value.featureReason === undefined || isKnownFeatureReason(value.featureReason)) &&
     isRecord(counts) &&
     typeof counts.likes === 'number' &&
     typeof counts.remixes === 'number' &&

--- a/src/features/community/components/CommunityCard/CommunityCard.test.tsx
+++ b/src/features/community/components/CommunityCard/CommunityCard.test.tsx
@@ -229,6 +229,21 @@ describe('CommunityCard', () => {
       );
     });
 
+    it('shows no badge for a reason outside the known set', () => {
+      render(
+        <CommunityCard
+          card={card({
+            featured: true,
+            featureReason: 'retired-reason' as unknown as 'clever',
+          })}
+          onSelect={vi.fn()}
+          index={0}
+        />
+      );
+      // A retired or corrupt value must not hand an undefined key to t().
+      expect(screen.queryByTestId('community-card-featured')).toBeNull();
+    });
+
     it('shows no badge for a pick made before reasons existed', () => {
       render(<CommunityCard card={card({ featured: true })} onSelect={vi.fn()} index={0} />);
       // Better silent than inventing a reason the curator never gave.

--- a/src/features/community/components/CommunityCard/CommunityCard.test.tsx
+++ b/src/features/community/components/CommunityCard/CommunityCard.test.tsx
@@ -209,4 +209,30 @@ describe('CommunityCard', () => {
       expect(prints).toHaveTextContent('community.card.printsLabel');
     });
   });
+
+  describe('featured', () => {
+    it('says nothing when the design is not featured', () => {
+      render(<CommunityCard card={card()} onSelect={vi.fn()} index={0} />);
+      expect(screen.queryByTestId('community-card-featured')).toBeNull();
+    });
+
+    it("states the curator's reason rather than a bare star", () => {
+      render(
+        <CommunityCard
+          card={card({ featured: true, featureReason: 'clever' })}
+          onSelect={vi.fn()}
+          index={0}
+        />
+      );
+      expect(screen.getByTestId('community-card-featured')).toHaveTextContent(
+        'community.featured.reason.clever'
+      );
+    });
+
+    it('shows no badge for a pick made before reasons existed', () => {
+      render(<CommunityCard card={card({ featured: true })} onSelect={vi.fn()} index={0} />);
+      // Better silent than inventing a reason the curator never gave.
+      expect(screen.queryByTestId('community-card-featured')).toBeNull();
+    });
+  });
 });

--- a/src/features/community/components/CommunityCard/CommunityCard.tsx
+++ b/src/features/community/components/CommunityCard/CommunityCard.tsx
@@ -7,6 +7,7 @@ import type { CommunityCard as CommunityCardData } from '@/shared/types/communit
 import { savePendingLikeAction } from '@/shared/utils/communityPendingLikeAction';
 import { useLikeToggle } from '../../hooks/useLikeToggle';
 import { CommunitySignInPrompt } from '../SignInPrompt';
+import { FEATURE_REASON_KEYS } from '../../utils/featureReasonLabels';
 import { formatCardDims } from './cardDims';
 
 export interface CommunityCardProps {
@@ -173,6 +174,18 @@ export function CommunityCard({ card, onSelect, onSelectAuthor, index }: Communi
               onError={() => setImageState('error')}
               className="h-full w-full object-cover"
             />
+          )}
+          {/* The stated reason replaces a bare star: a pick nobody explained
+              is the least legible signal in the gallery. */}
+          {card.featured && card.featureReason !== undefined && (
+            <Badge
+              tone="overlay"
+              size="sm"
+              className="absolute left-1 top-1"
+              data-testid="community-card-featured"
+            >
+              {t(FEATURE_REASON_KEYS[card.featureReason])}
+            </Badge>
           )}
           {card.isRemix && (
             <Badge

--- a/src/features/community/components/CommunityCard/CommunityCard.tsx
+++ b/src/features/community/components/CommunityCard/CommunityCard.tsx
@@ -114,6 +114,10 @@ export function CommunityCard({ card, onSelect, onSelectAuthor, index }: Communi
   const dims = formatCardDims(card.metrics);
   const liked = card.likedByMe === true;
   const prints = card.counts.prints ?? 0;
+  // Looked up rather than indexed blind: a reason retired from the union, or
+  // a corrupt stored value, would otherwise hand an undefined key to t().
+  const featureReasonKey =
+    card.featureReason === undefined ? undefined : FEATURE_REASON_KEYS[card.featureReason];
 
   const handleLike = (event: MouseEvent<HTMLButtonElement>) => {
     // The card root is itself a click target; a heart tap must not also
@@ -177,14 +181,14 @@ export function CommunityCard({ card, onSelect, onSelectAuthor, index }: Communi
           )}
           {/* The stated reason replaces a bare star: a pick nobody explained
               is the least legible signal in the gallery. */}
-          {card.featured && card.featureReason !== undefined && (
+          {card.featured && featureReasonKey !== undefined && (
             <Badge
               tone="overlay"
               size="sm"
               className="absolute left-1 top-1"
               data-testid="community-card-featured"
             >
-              {t(FEATURE_REASON_KEYS[card.featureReason])}
+              {t(featureReasonKey)}
             </Badge>
           )}
           {card.isRemix && (

--- a/src/features/community/utils/featureReasonLabels.test.ts
+++ b/src/features/community/utils/featureReasonLabels.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { COMMUNITY_FEATURE_REASONS } from '@/shared/types/community';
+import { FEATURE_REASON_KEYS } from './featureReasonLabels';
+
+describe('FEATURE_REASON_KEYS', () => {
+  it('covers every reason in the union', () => {
+    for (const reason of COMMUNITY_FEATURE_REASONS) {
+      expect(FEATURE_REASON_KEYS[reason]).toBeTruthy();
+    }
+  });
+
+  it('has no labels for reasons that do not exist', () => {
+    expect(Object.keys(FEATURE_REASON_KEYS).sort()).toEqual([...COMMUNITY_FEATURE_REASONS].sort());
+  });
+});

--- a/src/features/community/utils/featureReasonLabels.ts
+++ b/src/features/community/utils/featureReasonLabels.ts
@@ -1,0 +1,12 @@
+import type { CommunityFeatureReason } from '@/shared/types/community';
+
+/**
+ * Exhaustive by construction: a new reason cannot be added to the union
+ * without the compiler demanding its label here.
+ */
+export const FEATURE_REASON_KEYS: Record<CommunityFeatureReason, string> = {
+  'well-made': 'community.featured.reason.wellMade',
+  clever: 'community.featured.reason.clever',
+  versatile: 'community.featured.reason.versatile',
+  'beginner-friendly': 'community.featured.reason.beginnerFriendly',
+};

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Už není dostupné",
   "community.lineage.gap": "Případné mezikroky nebyly zaznamenány.",
   "community.lineage.openRoot": "Otevřít originál od {author}",
-  "community.lineage.openParent": "Otevřít {name}"
+  "community.lineage.openParent": "Otevřít {name}",
+  "community.featured.reason.wellMade": "Obzvlášť dobře zpracované",
+  "community.featured.reason.clever": "Chytré řešení",
+  "community.featured.reason.versatile": "Užitečné na spoustu věcí",
+  "community.featured.reason.beginnerFriendly": "Dobrý první tisk"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Nicht mehr verfügbar",
   "community.lineage.gap": "Schritte dazwischen wurden nicht erfasst.",
   "community.lineage.openRoot": "Original von {author} öffnen",
-  "community.lineage.openParent": "{name} öffnen"
+  "community.lineage.openParent": "{name} öffnen",
+  "community.featured.reason.wellMade": "Besonders gut gemacht",
+  "community.featured.reason.clever": "Clevere Lösung",
+  "community.featured.reason.versatile": "Vielseitig einsetzbar",
+  "community.featured.reason.beginnerFriendly": "Ein guter erster Druck"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3686,6 +3686,12 @@ const en: Record<string, string> = {
   'community.lineage.openRoot': 'Open the original by {author}',
   'community.lineage.openParent': 'Open {name}',
 
+  // Why a design was featured. A closed set so the pick is stated, not implied.
+  'community.featured.reason.wellMade': 'Especially well made',
+  'community.featured.reason.clever': 'Clever solution',
+  'community.featured.reason.versatile': 'Useful for lots of things',
+  'community.featured.reason.beginnerFriendly': 'A good first print',
+
   // Post-remix continuation banner (bin designer)
   'binDesigner.remixBanner.text':
     'Remixing {name} by {author}. Publish your version when it is ready.',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Ya no está disponible",
   "community.lineage.gap": "Los pasos intermedios no se registraron.",
   "community.lineage.openRoot": "Abrir el original de {author}",
-  "community.lineage.openParent": "Abrir {name}"
+  "community.lineage.openParent": "Abrir {name}",
+  "community.featured.reason.wellMade": "Especialmente bien hecho",
+  "community.featured.reason.clever": "Solución ingeniosa",
+  "community.featured.reason.versatile": "Útil para muchas cosas",
+  "community.featured.reason.beginnerFriendly": "Una buena primera impresión"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Plus disponible",
   "community.lineage.gap": "Les étapes intermédiaires n'ont pas été enregistrées.",
   "community.lineage.openRoot": "Ouvrir l'original de {author}",
-  "community.lineage.openParent": "Ouvrir {name}"
+  "community.lineage.openParent": "Ouvrir {name}",
+  "community.featured.reason.wellMade": "Particulièrement bien réalisé",
+  "community.featured.reason.clever": "Solution astucieuse",
+  "community.featured.reason.versatile": "Utile pour beaucoup de choses",
+  "community.featured.reason.beginnerFriendly": "Une bonne première impression"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Non più disponibile",
   "community.lineage.gap": "Gli eventuali passaggi intermedi non sono stati registrati.",
   "community.lineage.openRoot": "Apri l'originale di {author}",
-  "community.lineage.openParent": "Apri {name}"
+  "community.lineage.openParent": "Apri {name}",
+  "community.featured.reason.wellMade": "Particolarmente ben fatto",
+  "community.featured.reason.clever": "Soluzione ingegnosa",
+  "community.featured.reason.versatile": "Utile per molte cose",
+  "community.featured.reason.beginnerFriendly": "Una buona prima stampa"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "現在は利用できません",
   "community.lineage.gap": "途中の経緯は記録されていません。",
   "community.lineage.openRoot": "{author} さんの原案を開く",
-  "community.lineage.openParent": "{name} を開く"
+  "community.lineage.openParent": "{name} を開く",
+  "community.featured.reason.wellMade": "特によくできています",
+  "community.featured.reason.clever": "巧みな解決策",
+  "community.featured.reason.versatile": "いろいろな用途に使えます",
+  "community.featured.reason.beginnerFriendly": "最初のプリントに最適"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "더 이상 이용할 수 없음",
   "community.lineage.gap": "중간 단계는 기록되지 않았습니다.",
   "community.lineage.openRoot": "{author} 님의 원작 열기",
-  "community.lineage.openParent": "{name} 열기"
+  "community.lineage.openParent": "{name} 열기",
+  "community.featured.reason.wellMade": "특히 잘 만들어졌습니다",
+  "community.featured.reason.clever": "영리한 해법",
+  "community.featured.reason.versatile": "여러 용도로 쓸 수 있습니다",
+  "community.featured.reason.beginnerFriendly": "첫 출력으로 좋습니다"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Ikke lenger tilgjengelig",
   "community.lineage.gap": "Eventuelle mellomliggende trinn ble ikke registrert.",
   "community.lineage.openRoot": "Åpne originalen av {author}",
-  "community.lineage.openParent": "Åpne {name}"
+  "community.lineage.openParent": "Åpne {name}",
+  "community.featured.reason.wellMade": "Særlig godt laget",
+  "community.featured.reason.clever": "Smart løsning",
+  "community.featured.reason.versatile": "Nyttig til mye",
+  "community.featured.reason.beginnerFriendly": "En god første utskrift"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Niet meer beschikbaar",
   "community.lineage.gap": "Tussenliggende stappen zijn niet vastgelegd.",
   "community.lineage.openRoot": "Origineel van {author} openen",
-  "community.lineage.openParent": "{name} openen"
+  "community.lineage.openParent": "{name} openen",
+  "community.featured.reason.wellMade": "Bijzonder goed gemaakt",
+  "community.featured.reason.clever": "Slimme oplossing",
+  "community.featured.reason.versatile": "Voor van alles bruikbaar",
+  "community.featured.reason.beginnerFriendly": "Een goede eerste print"
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Już niedostępne",
   "community.lineage.gap": "Kroki pośrednie nie zostały zapisane.",
   "community.lineage.openRoot": "Otwórz oryginał autorstwa {author}",
-  "community.lineage.openParent": "Otwórz {name}"
+  "community.lineage.openParent": "Otwórz {name}",
+  "community.featured.reason.wellMade": "Szczególnie dobrze wykonane",
+  "community.featured.reason.clever": "Sprytne rozwiązanie",
+  "community.featured.reason.versatile": "Przydatne do wielu rzeczy",
+  "community.featured.reason.beginnerFriendly": "Dobry pierwszy wydruk"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Não está mais disponível",
   "community.lineage.gap": "Etapas intermediárias não foram registradas.",
   "community.lineage.openRoot": "Abrir o original de {author}",
-  "community.lineage.openParent": "Abrir {name}"
+  "community.lineage.openParent": "Abrir {name}",
+  "community.featured.reason.wellMade": "Especialmente bem feito",
+  "community.featured.reason.clever": "Solução engenhosa",
+  "community.featured.reason.versatile": "Útil para muitas coisas",
+  "community.featured.reason.beginnerFriendly": "Uma boa primeira impressão"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Inte längre tillgänglig",
   "community.lineage.gap": "Eventuella steg däremellan registrerades inte.",
   "community.lineage.openRoot": "Öppna originalet av {author}",
-  "community.lineage.openParent": "Öppna {name}"
+  "community.lineage.openParent": "Öppna {name}",
+  "community.featured.reason.wellMade": "Särskilt välgjord",
+  "community.featured.reason.clever": "Smart lösning",
+  "community.featured.reason.versatile": "Användbar till mycket",
+  "community.featured.reason.beginnerFriendly": "En bra första utskrift"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "Більше недоступно",
   "community.lineage.gap": "Проміжні кроки не записані.",
   "community.lineage.openRoot": "Відкрити оригінал від {author}",
-  "community.lineage.openParent": "Відкрити {name}"
+  "community.lineage.openParent": "Відкрити {name}",
+  "community.featured.reason.wellMade": "Особливо добре зроблено",
+  "community.featured.reason.clever": "Розумне рішення",
+  "community.featured.reason.versatile": "Корисне для багатьох речей",
+  "community.featured.reason.beginnerFriendly": "Гарний перший друк"
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3503,5 +3503,9 @@
   "community.lineage.unavailable": "已不可用",
   "community.lineage.gap": "中间步骤未被记录。",
   "community.lineage.openRoot": "打开 {author} 的原作",
-  "community.lineage.openParent": "打开 {name}"
+  "community.lineage.openParent": "打开 {name}",
+  "community.featured.reason.wellMade": "做工尤其出色",
+  "community.featured.reason.clever": "巧妙的解法",
+  "community.featured.reason.versatile": "用途广泛",
+  "community.featured.reason.beginnerFriendly": "适合作为第一次打印"
 }

--- a/src/shared/types/community.test.ts
+++ b/src/shared/types/community.test.ts
@@ -6,10 +6,17 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { COMMUNITY_CATEGORIES as API_COMMUNITY_CATEGORIES } from '../../../api/lib/communityValidation.js';
+import {
+  COMMUNITY_CATEGORIES as API_COMMUNITY_CATEGORIES,
+  COMMUNITY_FEATURE_REASONS as API_COMMUNITY_FEATURE_REASONS,
+} from '../../../api/lib/communityValidation.js';
 import { COMMUNITY_INDEX_SORTS as API_COMMUNITY_INDEX_SORTS } from '../../../api/lib/redisKeys.js';
 
-import { COMMUNITY_CATEGORIES, COMMUNITY_INDEX_SORTS } from './community';
+import {
+  COMMUNITY_CATEGORIES,
+  COMMUNITY_FEATURE_REASONS,
+  COMMUNITY_INDEX_SORTS,
+} from './community';
 
 describe('COMMUNITY_CATEGORIES (cross-boundary mirror)', () => {
   it('matches the api tuple exactly, including order', () => {
@@ -20,5 +27,11 @@ describe('COMMUNITY_CATEGORIES (cross-boundary mirror)', () => {
 describe('COMMUNITY_INDEX_SORTS (cross-boundary mirror)', () => {
   it('matches the api tuple exactly, including order', () => {
     expect([...COMMUNITY_INDEX_SORTS]).toEqual([...API_COMMUNITY_INDEX_SORTS]);
+  });
+});
+
+describe('COMMUNITY_FEATURE_REASONS (cross-boundary mirror)', () => {
+  it('matches the api tuple exactly, including order', () => {
+    expect([...COMMUNITY_FEATURE_REASONS]).toEqual([...API_COMMUNITY_FEATURE_REASONS]);
   });
 });

--- a/src/shared/types/community.ts
+++ b/src/shared/types/community.ts
@@ -74,6 +74,28 @@ export const COMMUNITY_MILESTONE_KINDS = [
 
 export type CommunityMilestoneKind = (typeof COMMUNITY_MILESTONE_KINDS)[number];
 
+/**
+ * Why a design was featured, said out loud.
+ *
+ * A closed set rather than free text: it is user-facing copy that must
+ * translate, and it keeps the curator honest by forcing the pick into a
+ * stated reason instead of an unexplained star. The vision's rule is that a
+ * ranking formula stays legible, and a silent `featured` boolean is the least
+ * legible signal in the feature.
+ *
+ * MIRROR: must match `COMMUNITY_FEATURE_REASONS` in
+ * `api/lib/communityValidation.ts`. Registered in
+ * scripts/check-union-exhaustiveness.sh.
+ */
+export const COMMUNITY_FEATURE_REASONS = [
+  'well-made',
+  'clever',
+  'versatile',
+  'beginner-friendly',
+] as const;
+
+export type CommunityFeatureReason = (typeof COMMUNITY_FEATURE_REASONS)[number];
+
 export interface CommunityDesignMetrics {
   readonly width: number;
   readonly depth: number;
@@ -142,6 +164,8 @@ export interface CommunityCard {
    */
   readonly parentId?: string;
   readonly featured: boolean;
+  /** Why it was featured; absent on an unfeatured design or a pre-field pick. */
+  readonly featureReason?: CommunityFeatureReason;
   readonly counts: CommunityDesignCounts;
   /**
    * Whether the session user has liked this design, seeded client-side from
@@ -187,6 +211,8 @@ export interface CommunityDesign {
    */
   readonly coverPhotoUrl?: string;
   readonly featured: boolean;
+  /** Why it was featured; absent on an unfeatured design or a pre-field pick. */
+  readonly featureReason?: CommunityFeatureReason;
   readonly createdAt: number;
   readonly updatedAt: number;
   readonly status: CommunityDesignStatus;


### PR DESCRIPTION
Closes one of the two items left outstanding from the community plan: `featured` had no visible reason for the pick.

## The problem

`featured` was a silent boolean. It drove the staff-picks shelf without ever saying why anything was chosen — the least legible signal in a feature whose stated rule is that ranking stays legible.

## The change

Featuring through the admin CLI now **requires** a reason from a closed set:

```
pnpm community-admin feature <id> --reason clever
```

`well-made` · `clever` · `versatile` · `beginner-friendly`

The gallery card shows that reason in place of a bare star.

**Closed set rather than free text**, for two reasons: it is user-facing copy that has to translate across 15 locales, and it forces the pick into a stated reason instead of letting a curator star something and move on.

## Notes for review

- **The reason is cleared on unfeature.** Otherwise a later re-feature would silently inherit a decision made for different reasons at a different time.
- **A design featured before this field existed shows no badge**, rather than an invented reason. Silence is the honest option there.
- **`parseArgs` gained its first valued flag.** It now walks argv by index, because a value-only `for...of` cannot consume the following entry.
- **i18n key segments are camelCase (`reason.wellMade`) while the union values stay hyphenated (`well-made`).** The keys follow the codebase convention; the union values are data. Worth knowing why they differ: the unused-key checker's literal scan does not match hyphens, so hyphenated keys referenced through a lookup map read as dead.

## Testing

10 new tests: the cross-boundary mirror for the new union, exhaustive label coverage, the card badge in all three states (unfeatured, reasoned, legacy pick), and the CLI refusing to feature without a reason or with one outside the set.

Full suite: 20,255 passing.

## Still outstanding after this

One item from the plan remains: making the drawer-gap handoff a persistent viewer profile so the fit verdict applies everywhere, rather than being one-shot from the grid editor. That is next.

The collection picks themselves stay open too, but those are a content decision rather than engineering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Featuring now requires a stated reason, and the gallery shows that reason as a badge instead of a bare star. We validate the reason end-to-end so unknown values never reach clients.

- New Features
  - Admin CLI: `feature <id>` now requires `--reason <well-made|clever|versatile|beginner-friendly>`; rejects missing/invalid reasons; `unfeature` clears the reason.
  - API/Types: Added optional `featureReason`; list serves it only when the design is featured and the value is in `COMMUNITY_FEATURE_REASONS` (`isCommunityFeatureReason` guard, mirrored union with a cross-boundary test).
  - Client/UI: Community cards show a localized badge for the stated reason; legacy picks or unknown/retired reasons show no badge; label lookup via `FEATURE_REASON_KEYS` prevents invalid i18n keys.
  - CLI args: `parseArgs` supports valued `--reason` and switches to index-based parsing.

- Migration
  - When featuring, run: `pnpm community-admin feature <id> --reason <well-made|clever|versatile|beginner-friendly>`.
  - No action needed for existing featured designs; they will render without a badge until re-featured with a reason.

<sup>Written for commit f6cb3ed47b80ebe7f7377534492bbcca3bc62bf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

