### PR TITLE
feat(community): carry the gap-fit verdict into the detail view

### DIFF
--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -61,6 +61,18 @@ Backend lives in `api/community/prints.ts` (`GET`/`PUT`/`DELETE`/`POST report`),
 - **Proven shelf** sits directly under staff picks, above recency: a design other people actually printed is the strongest recommendation the library has, and it is the one signal nobody can inflate by posting.
 - **Cover promotion** is owner opt-in and server-validated against the design's own **live** prints. The gallery grid is the most public surface in the app, and this is the only path by which a user-supplied image can reach it, so the check that the URL belongs to a live print of that design is load-bearing, not defensive. A hidden print's photo is not promotable.
 
+### Gap fit
+
+`utils/gapFit.ts` answers whether a design fits the gap the viewer picked in the layout editor. It is the **single** implementation: the browse filter and the detail view both call it, because filtering a card out of the grid and telling someone "this will not fit" are the same question and must never disagree.
+
+It encodes three things that are easy to get wrong:
+
+- **Rotation counts.** Placement probes both orientations, so a 2x3 design does fit a 3x2 gap. The verdict distinguishes `fits` from `fits-rotated` so the detail can say which.
+- **Scale is checked first.** Comparing footprints across different `gridUnitMm` compares numbers that do not mean the same thing, and placement hard-rejects the mismatch anyway.
+- **Height is checked before footprint**, so a design that fails both reports the ceiling as the reason.
+
+An explicit toolbar bound overrides the corresponding gap dimension while keeping the rest of the context (notably the grid scale), so precedence stays one comparison rather than two competing ones.
+
 ### Featured, with a reason
 
 `featured` no longer travels alone. Featuring a design through the admin CLI now **requires** `--reason <well-made|clever|versatile|beginner-friendly>`, and the gallery card shows that reason instead of a bare star.

--- a/src/features/community/components/CommunityDetail/CommunityDetail.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.tsx
@@ -125,6 +125,10 @@ function CommunityDetailDialog({
     summary: CommunityPrintSummary | null;
   } | null>(null);
   const [printsAvailable, setPrintsAvailable] = useState(true);
+  // The gap the viewer picked in the layout editor, if any. Read here rather
+  // than passed down so the detail answers the same question the gallery
+  // filtered on.
+  const gapContext = useBrowseStore((s) => s.fitsGapContext);
   // Bumped after a write so the list refetches; the parent owns it because the
   // CTA and the list must agree on whether the viewer has a print.
   const [printsRefresh, setPrintsRefresh] = useState(0);
@@ -561,6 +565,7 @@ function CommunityDetailDialog({
                 params={design.params}
                 metrics={design.metrics}
                 summary={printSummary}
+                gapContext={gapContext}
               />
             }
             printsSlot={

--- a/src/features/community/components/PrintCostPanel/PrintCostPanel.test.tsx
+++ b/src/features/community/components/PrintCostPanel/PrintCostPanel.test.tsx
@@ -134,4 +134,59 @@ describe('PrintCostPanel', () => {
 
     expect(screen.queryByTestId('print-cost-panel')).toBeNull();
   });
+
+  describe('gap fit', () => {
+    const gap = {
+      widthMax: 3,
+      depthMax: 2,
+      maxHeight: 6,
+      gridUnitMm: 42,
+      gridUnitMmY: 42,
+      heightUnitMm: 7,
+    };
+
+    it('says nothing when the viewer is not filling a gap', () => {
+      render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
+      expect(screen.queryByTestId('cost-gap-fits')).toBeNull();
+    });
+
+    it('confirms a design that fits the picked gap upright', () => {
+      const upright = { width: 2 * 42 - 0.5, depth: 1 * 42 - 0.5, height: 21, gridUnitMm: 42 };
+      render(<PrintCostPanel params={PARAMS} metrics={upright} summary={null} gapContext={gap} />);
+      expect(screen.getByTestId('cost-gap-fits')).toBeInTheDocument();
+    });
+
+    it('says so when it only fits turned sideways', () => {
+      // 2 wide x 3 deep against a 3 x 2 gap. Placement probes both
+      // orientations, so this is a fit, not a failure.
+      const rotated = { width: 2 * 42 - 0.5, depth: 3 * 42 - 0.5, height: 21, gridUnitMm: 42 };
+      render(<PrintCostPanel params={PARAMS} metrics={rotated} summary={null} gapContext={gap} />);
+      expect(screen.getByTestId('cost-gap-fits-rotated')).toBeInTheDocument();
+    });
+
+    it('warns when it is too big for the gap', () => {
+      const big = { width: 9 * 42, depth: 9 * 42, height: 21, gridUnitMm: 42 };
+      render(<PrintCostPanel params={PARAMS} metrics={big} summary={null} gapContext={gap} />);
+      expect(screen.getByTestId('cost-gap-too-large')).toBeInTheDocument();
+    });
+
+    it('flags a grid-scale mismatch rather than comparing sizes', () => {
+      const other = { ...METRICS, gridUnitMm: 30 };
+      render(<PrintCostPanel params={PARAMS} metrics={other} summary={null} gapContext={gap} />);
+      expect(screen.getByTestId('cost-gap-scale-mismatch')).toBeInTheDocument();
+    });
+
+    it('renders the panel for the gap verdict alone', () => {
+      estimate.mockImplementation(() => {
+        throw new Error('nope');
+      });
+      bed.width = 0;
+      bed.depth = 0;
+
+      const upright = { width: 2 * 42 - 0.5, depth: 1 * 42 - 0.5, height: 21, gridUnitMm: 42 };
+      render(<PrintCostPanel params={PARAMS} metrics={upright} summary={null} gapContext={gap} />);
+
+      expect(screen.getByTestId('print-cost-panel')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/features/community/components/PrintCostPanel/PrintCostPanel.tsx
+++ b/src/features/community/components/PrintCostPanel/PrintCostPanel.tsx
@@ -20,6 +20,9 @@ import {
   resolvePrintCost,
 } from '@/shared/utils/communityPrintCost';
 import type { PrintCostFigure } from '@/shared/utils/communityPrintCost';
+import type { FitsGapContext } from '../../store/browseStore';
+import { gapFitVerdict } from '../../utils/gapFit';
+import type { GapFitVerdict } from '../../utils/gapFit';
 import { formatGrams, formatPrintDuration, roundSummaryMinutes } from '../../utils/printFormat';
 
 export interface PrintCostPanelProps {
@@ -27,7 +30,25 @@ export interface PrintCostPanelProps {
   metrics: CommunityDesignMetrics;
   /** Null until the print list resolves; the panel shows estimates meanwhile. */
   summary: CommunityPrintSummary | null;
+  /** The gap the viewer picked in their layout; absent outside that flow. */
+  gapContext?: FitsGapContext | null;
 }
+
+const GAP_VERDICT_KEYS: Record<GapFitVerdict, string> = {
+  fits: 'community.gapFit.fits',
+  'fits-rotated': 'community.gapFit.fitsRotated',
+  'too-large': 'community.gapFit.tooLarge',
+  'too-tall': 'community.gapFit.tooTall',
+  'scale-mismatch': 'community.gapFit.scaleMismatch',
+};
+
+const GAP_VERDICT_FITS: Record<GapFitVerdict, boolean> = {
+  fits: true,
+  'fits-rotated': true,
+  'too-large': false,
+  'too-tall': false,
+  'scale-mismatch': false,
+};
 
 function SourceBadge({ source }: { source: PrintCostFigure['source'] }) {
   const t = useTranslation();
@@ -47,7 +68,12 @@ function SourceBadge({ source }: { source: PrintCostFigure['source'] }) {
   );
 }
 
-export function PrintCostPanel({ params, metrics, summary }: PrintCostPanelProps) {
+export function PrintCostPanel({
+  params,
+  metrics,
+  summary,
+  gapContext = null,
+}: PrintCostPanelProps) {
   const t = useTranslation();
   const bedWidth = useSettingsStore((s) => s.settings.defaultPrintBedSize);
   const bedDepth = useSettingsStore(
@@ -69,8 +95,14 @@ export function PrintCostPanel({ params, metrics, summary }: PrintCostPanelProps
 
   const { time, filament } = resolvePrintCost(estimate, summary);
   const bedFit = fitsPrintBed(metrics, bedWidth, bedDepth);
+  // The same verdict the gallery filtered on, carried through to the design
+  // the viewer actually opened. Filtering a card out and saying "this will
+  // not fit" are the same question and must not disagree.
+  const gapFit = gapContext === null ? null : gapFitVerdict(metrics, gapContext);
 
-  if (time.minutes === null && filament.grams === null && bedFit === 'unknown') return null;
+  if (time.minutes === null && filament.grams === null && bedFit === 'unknown' && gapFit === null) {
+    return null;
+  }
 
   const duration =
     time.minutes === null ? null : formatPrintDuration(roundSummaryMinutes(time.minutes));
@@ -112,6 +144,17 @@ export function PrintCostPanel({ params, metrics, summary }: PrintCostPanelProps
             <SourceBadge source={filament.source} />
           </span>
         </div>
+      )}
+
+      {gapFit !== null && (
+        <p
+          className={
+            GAP_VERDICT_FITS[gapFit] ? 'text-xs text-content-secondary' : 'text-xs text-warning'
+          }
+          data-testid={`cost-gap-${gapFit}`}
+        >
+          {t(GAP_VERDICT_KEYS[gapFit])}
+        </p>
       )}
 
       {bedFit !== 'unknown' && (

--- a/src/features/community/store/browseStore.ts
+++ b/src/features/community/store/browseStore.ts
@@ -9,6 +9,7 @@ import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
 import type { CommunityClientError } from '../api/client';
 import { fetchCommunityIndex } from '../api/client';
 import { cardDimensionUnits } from '../components/CommunityCard/cardDims';
+import { gapFitVerdict } from '../utils/gapFit';
 
 export const BROWSE_INDEX_STALE_MS = 5 * 60 * 1000;
 
@@ -247,23 +248,34 @@ export function filterAndSortCards(
   const effectiveWidthMax = filters.widthMax ?? fitsGapContext?.widthMax ?? null;
   const effectiveDepthMax = filters.depthMax ?? fitsGapContext?.depthMax ?? null;
   const effectiveMaxHeight = filters.maxHeight ?? fitsGapContext?.maxHeight ?? null;
+  // An explicit toolbar bound overrides the corresponding gap dimension but
+  // keeps the rest of the context (notably the grid scale), so the verdict
+  // stays a single comparison rather than two competing ones.
+  const effectiveGap =
+    fitsGapContext === null
+      ? null
+      : {
+          ...fitsGapContext,
+          widthMax: filters.widthMax ?? fitsGapContext.widthMax,
+          depthMax: filters.depthMax ?? fitsGapContext.depthMax,
+          maxHeight: filters.maxHeight ?? fitsGapContext.maxHeight,
+        };
   const fitsFootprintMax = (width: number, depth: number): boolean =>
     (effectiveWidthMax === null || width <= effectiveWidthMax) &&
     (effectiveDepthMax === null || depth <= effectiveDepthMax);
   const matched = items.filter((card) => {
     const dims = cardDimensionUnits(card.metrics);
-    // With a gap context, placement probes both orientations
-    // (placeCommunityDesignInLayout), so the filter must too: a 1x3 design
-    // does fit a 3x1 gap. Toolbar-only bounds stay literal.
+    // With a gap context the verdict comes from gapFitVerdict, the same
+    // function the detail view renders, so filtering a card out of the grid
+    // and telling someone "this will not fit" can never disagree. It covers
+    // rotation (placement probes both orientations) and the scale match that
+    // placement hard-rejects on.
+    const gapVerdict = effectiveGap === null ? null : gapFitVerdict(card.metrics, effectiveGap);
     const footprintOk =
-      fitsGapContext !== null
-        ? fitsFootprintMax(dims.width, dims.depth) || fitsFootprintMax(dims.depth, dims.width)
+      gapVerdict !== null
+        ? gapVerdict === 'fits' || gapVerdict === 'fits-rotated'
         : fitsFootprintMax(dims.width, dims.depth);
-    // Placement hard-rejects scale mismatches. The card index only carries the
-    // X grid scale, so this screens what it can; a rare Y/height-unit
-    // mismatch still surfaces through the placement failure toast.
-    const scaleOk =
-      fitsGapContext === null || card.metrics.gridUnitMm === fitsGapContext.gridUnitMm;
+    const scaleOk = gapVerdict === null || gapVerdict !== 'scale-mismatch';
     return (
       scaleOk &&
       (filters.category === null || card.category === filters.category) &&

--- a/src/features/community/utils/gapFit.test.ts
+++ b/src/features/community/utils/gapFit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { CommunityDesignMetrics } from '@/shared/types/community';
+import type { FitsGapContext } from '../store/browseStore';
+import { gapFitVerdict } from './gapFit';
+
+const UNIT = 42;
+
+/** Metrics for a design of `w` x `d` grid units and `h` height units. */
+function metrics(w: number, d: number, h = 3, gridUnitMm = UNIT): CommunityDesignMetrics {
+  return { width: w * UNIT - 0.5, depth: d * UNIT - 0.5, height: h * 7, gridUnitMm };
+}
+
+function gap(overrides: Partial<FitsGapContext> = {}): FitsGapContext {
+  return {
+    widthMax: 3,
+    depthMax: 2,
+    maxHeight: 6,
+    gridUnitMm: UNIT,
+    gridUnitMmY: UNIT,
+    heightUnitMm: 7,
+    ...overrides,
+  };
+}
+
+describe('gapFitVerdict', () => {
+  it('fits when it is smaller in both axes', () => {
+    expect(gapFitVerdict(metrics(2, 1), gap())).toBe('fits');
+  });
+
+  it('fits at exactly the gap size', () => {
+    expect(gapFitVerdict(metrics(3, 2), gap())).toBe('fits');
+  });
+
+  it('reports a rotated fit rather than rejecting it', () => {
+    // Placement probes both orientations, so a 2x3 does fit a 3x2 gap.
+    expect(gapFitVerdict(metrics(2, 3), gap())).toBe('fits-rotated');
+  });
+
+  it('rejects a design too large in both orientations', () => {
+    expect(gapFitVerdict(metrics(4, 4), gap())).toBe('too-large');
+  });
+
+  it('rejects a design taller than the remaining stack budget', () => {
+    expect(gapFitVerdict(metrics(2, 1, 9), gap())).toBe('too-tall');
+  });
+
+  it('accepts any height when the gap has no ceiling', () => {
+    expect(gapFitVerdict(metrics(2, 1, 99), gap({ maxHeight: null }))).toBe('fits');
+  });
+
+  it('rejects a mismatched grid scale before comparing sizes', () => {
+    // Comparing footprints across different grid units compares numbers that
+    // do not mean the same thing, and placement hard-rejects them anyway.
+    expect(gapFitVerdict(metrics(1, 1, 1, 30), gap())).toBe('scale-mismatch');
+  });
+
+  it('checks height before footprint, so the ceiling is the stated reason', () => {
+    expect(gapFitVerdict(metrics(9, 9, 9), gap())).toBe('too-tall');
+  });
+});

--- a/src/features/community/utils/gapFit.test.ts
+++ b/src/features/community/utils/gapFit.test.ts
@@ -5,9 +5,18 @@ import { gapFitVerdict } from './gapFit';
 
 const UNIT = 42;
 
-/** Metrics for a design of `w` x `d` grid units and `h` height units. */
+/**
+ * Metrics for a design of `w` x `d` grid units and `h` height units, sized
+ * against its own `gridUnitMm` so a non-default scale produces coherent
+ * millimetres rather than 42mm dimensions wearing another unit's label.
+ */
 function metrics(w: number, d: number, h = 3, gridUnitMm = UNIT): CommunityDesignMetrics {
-  return { width: w * UNIT - 0.5, depth: d * UNIT - 0.5, height: h * 7, gridUnitMm };
+  return {
+    width: w * gridUnitMm - 0.5,
+    depth: d * gridUnitMm - 0.5,
+    height: h * 7,
+    gridUnitMm,
+  };
 }
 
 function gap(overrides: Partial<FitsGapContext> = {}): FitsGapContext {

--- a/src/features/community/utils/gapFit.ts
+++ b/src/features/community/utils/gapFit.ts
@@ -1,0 +1,45 @@
+/**
+ * Does a design fit the gap the viewer picked in their layout?
+ *
+ * Extracted from the browse filter so the gallery and the detail view answer
+ * with one implementation. Filtering a card out of the grid and telling
+ * someone "this will not fit" are the same question, and they must never
+ * disagree.
+ */
+
+import type { CommunityDesignMetrics } from '@/shared/types/community';
+import type { FitsGapContext } from '../store/browseStore';
+import { cardDimensionUnits } from '../components/CommunityCard/cardDims';
+
+export type GapFitVerdict =
+  | 'fits'
+  /** Fits only turned 90 degrees, which placement does probe. */
+  | 'fits-rotated'
+  | 'too-large'
+  | 'too-tall'
+  /**
+   * Built against a different mm-per-unit scale than the layout. Placement
+   * hard-rejects these, so a size comparison would be meaningless.
+   */
+  | 'scale-mismatch';
+
+export function gapFitVerdict(
+  metrics: CommunityDesignMetrics,
+  context: FitsGapContext
+): GapFitVerdict {
+  // Scale first: comparing footprints across different grid units compares
+  // numbers that do not mean the same thing.
+  if (metrics.gridUnitMm !== context.gridUnitMm) return 'scale-mismatch';
+
+  const dims = cardDimensionUnits(metrics);
+
+  if (context.maxHeight !== null && dims.height > context.maxHeight) return 'too-tall';
+
+  const upright = dims.width <= context.widthMax && dims.depth <= context.depthMax;
+  if (upright) return 'fits';
+
+  // Placement probes both orientations (placeCommunityDesignInLayout), so a
+  // 1x3 design does fit a 3x1 gap and saying otherwise would be wrong.
+  const rotated = dims.depth <= context.widthMax && dims.width <= context.depthMax;
+  return rotated ? 'fits-rotated' : 'too-large';
+}

--- a/src/features/community/utils/gapFit.ts
+++ b/src/features/community/utils/gapFit.ts
@@ -20,6 +20,14 @@ export type GapFitVerdict =
   /**
    * Built against a different mm-per-unit scale than the layout. Placement
    * hard-rejects these, so a size comparison would be meaningless.
+   *
+   * Only the X grid scale is screened: `CommunityDesignMetrics` is what the
+   * card index carries, and it has no `gridUnitMmY` or `heightUnitMm`. A
+   * design matching on X but differing on either still reaches placement and
+   * surfaces through its failure toast. Screening it here would mean either
+   * widening the list index or giving the detail view a second, better
+   * implementation, and two implementations is exactly what this module
+   * exists to prevent.
    */
   | 'scale-mismatch';
 
@@ -28,7 +36,8 @@ export function gapFitVerdict(
   context: FitsGapContext
 ): GapFitVerdict {
   // Scale first: comparing footprints across different grid units compares
-  // numbers that do not mean the same thing.
+  // numbers that do not mean the same thing. Partial by necessity, see the
+  // note on the verdict type.
   if (metrics.gridUnitMm !== context.gridUnitMm) return 'scale-mismatch';
 
   const dims = cardDimensionUnits(metrics);

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Obzvlášť dobře zpracované",
   "community.featured.reason.clever": "Chytré řešení",
   "community.featured.reason.versatile": "Užitečné na spoustu věcí",
-  "community.featured.reason.beginnerFriendly": "Dobrý první tisk"
+  "community.featured.reason.beginnerFriendly": "Dobrý první tisk",
+  "community.gapFit.fits": "Vejde se do vybrané mezery",
+  "community.gapFit.fitsRotated": "Vejde se do vybrané mezery, otočený",
+  "community.gapFit.tooLarge": "Příliš velký na vybranou mezeru",
+  "community.gapFit.tooTall": "Příliš vysoký na místo nad touto vrstvou",
+  "community.gapFit.scaleMismatch": "Vytvořeno pro jinou velikost mřížky než tvůj layout"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Besonders gut gemacht",
   "community.featured.reason.clever": "Clevere Lösung",
   "community.featured.reason.versatile": "Vielseitig einsetzbar",
-  "community.featured.reason.beginnerFriendly": "Ein guter erster Druck"
+  "community.featured.reason.beginnerFriendly": "Ein guter erster Druck",
+  "community.gapFit.fits": "Passt in die gewählte Lücke",
+  "community.gapFit.fitsRotated": "Passt in die gewählte Lücke, quer gedreht",
+  "community.gapFit.tooLarge": "Zu groß für die gewählte Lücke",
+  "community.gapFit.tooTall": "Zu hoch für den Platz über dieser Ebene",
+  "community.gapFit.scaleMismatch": "Für eine andere Rastergröße als dein Layout gebaut"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3692,6 +3692,13 @@ const en: Record<string, string> = {
   'community.featured.reason.versatile': 'Useful for lots of things',
   'community.featured.reason.beginnerFriendly': 'A good first print',
 
+  // Gap-fit verdict on the detail view, for the "find bins that fit" flow.
+  'community.gapFit.fits': 'Fits the gap you picked',
+  'community.gapFit.fitsRotated': 'Fits the gap you picked, turned sideways',
+  'community.gapFit.tooLarge': 'Too big for the gap you picked',
+  'community.gapFit.tooTall': 'Too tall for the space above that layer',
+  'community.gapFit.scaleMismatch': 'Built for a different grid size than your layout',
+
   // Post-remix continuation banner (bin designer)
   'binDesigner.remixBanner.text':
     'Remixing {name} by {author}. Publish your version when it is ready.',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Especialmente bien hecho",
   "community.featured.reason.clever": "Solución ingeniosa",
   "community.featured.reason.versatile": "Útil para muchas cosas",
-  "community.featured.reason.beginnerFriendly": "Una buena primera impresión"
+  "community.featured.reason.beginnerFriendly": "Una buena primera impresión",
+  "community.gapFit.fits": "Cabe en el hueco elegido",
+  "community.gapFit.fitsRotated": "Cabe en el hueco elegido, girado",
+  "community.gapFit.tooLarge": "Demasiado grande para el hueco elegido",
+  "community.gapFit.tooTall": "Demasiado alto para el espacio sobre esa capa",
+  "community.gapFit.scaleMismatch": "Hecho para un tamaño de rejilla distinto al de tu diseño"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Particulièrement bien réalisé",
   "community.featured.reason.clever": "Solution astucieuse",
   "community.featured.reason.versatile": "Utile pour beaucoup de choses",
-  "community.featured.reason.beginnerFriendly": "Une bonne première impression"
+  "community.featured.reason.beginnerFriendly": "Une bonne première impression",
+  "community.gapFit.fits": "Tient dans l'espace choisi",
+  "community.gapFit.fitsRotated": "Tient dans l'espace choisi, tourné",
+  "community.gapFit.tooLarge": "Trop grand pour l'espace choisi",
+  "community.gapFit.tooTall": "Trop haut pour la place au-dessus de ce calque",
+  "community.gapFit.scaleMismatch": "Conçu pour une taille de grille différente de votre agencement"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Particolarmente ben fatto",
   "community.featured.reason.clever": "Soluzione ingegnosa",
   "community.featured.reason.versatile": "Utile per molte cose",
-  "community.featured.reason.beginnerFriendly": "Una buona prima stampa"
+  "community.featured.reason.beginnerFriendly": "Una buona prima stampa",
+  "community.gapFit.fits": "Entra nello spazio scelto",
+  "community.gapFit.fitsRotated": "Entra nello spazio scelto, ruotato",
+  "community.gapFit.tooLarge": "Troppo grande per lo spazio scelto",
+  "community.gapFit.tooTall": "Troppo alto per lo spazio sopra quel livello",
+  "community.gapFit.scaleMismatch": "Creato per una griglia diversa da quella del tuo layout"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "特によくできています",
   "community.featured.reason.clever": "巧みな解決策",
   "community.featured.reason.versatile": "いろいろな用途に使えます",
-  "community.featured.reason.beginnerFriendly": "最初のプリントに最適"
+  "community.featured.reason.beginnerFriendly": "最初のプリントに最適",
+  "community.gapFit.fits": "選んだ隙間に収まります",
+  "community.gapFit.fitsRotated": "選んだ隙間に、横向きなら収まります",
+  "community.gapFit.tooLarge": "選んだ隙間には大きすぎます",
+  "community.gapFit.tooTall": "そのレイヤーの上の高さに収まりません",
+  "community.gapFit.scaleMismatch": "レイアウトとは異なるグリッドサイズ向けです"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "특히 잘 만들어졌습니다",
   "community.featured.reason.clever": "영리한 해법",
   "community.featured.reason.versatile": "여러 용도로 쓸 수 있습니다",
-  "community.featured.reason.beginnerFriendly": "첫 출력으로 좋습니다"
+  "community.featured.reason.beginnerFriendly": "첫 출력으로 좋습니다",
+  "community.gapFit.fits": "선택한 공간에 들어갑니다",
+  "community.gapFit.fitsRotated": "선택한 공간에 돌려서 들어갑니다",
+  "community.gapFit.tooLarge": "선택한 공간에는 너무 큽니다",
+  "community.gapFit.tooTall": "해당 레이어 위 공간에 비해 너무 높습니다",
+  "community.gapFit.scaleMismatch": "레이아웃과 다른 그리드 크기로 만들어졌습니다"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Særlig godt laget",
   "community.featured.reason.clever": "Smart løsning",
   "community.featured.reason.versatile": "Nyttig til mye",
-  "community.featured.reason.beginnerFriendly": "En god første utskrift"
+  "community.featured.reason.beginnerFriendly": "En god første utskrift",
+  "community.gapFit.fits": "Passer i åpningen du valgte",
+  "community.gapFit.fitsRotated": "Passer i åpningen du valgte, snudd",
+  "community.gapFit.tooLarge": "For stor for åpningen du valgte",
+  "community.gapFit.tooTall": "For høy for plassen over det laget",
+  "community.gapFit.scaleMismatch": "Laget for en annen rutestørrelse enn oppsettet ditt"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Bijzonder goed gemaakt",
   "community.featured.reason.clever": "Slimme oplossing",
   "community.featured.reason.versatile": "Voor van alles bruikbaar",
-  "community.featured.reason.beginnerFriendly": "Een goede eerste print"
+  "community.featured.reason.beginnerFriendly": "Een goede eerste print",
+  "community.gapFit.fits": "Past in de gekozen ruimte",
+  "community.gapFit.fitsRotated": "Past in de gekozen ruimte, gedraaid",
+  "community.gapFit.tooLarge": "Te groot voor de gekozen ruimte",
+  "community.gapFit.tooTall": "Te hoog voor de ruimte boven die laag",
+  "community.gapFit.scaleMismatch": "Gemaakt voor een andere rastermaat dan jouw layout"
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Szczególnie dobrze wykonane",
   "community.featured.reason.clever": "Sprytne rozwiązanie",
   "community.featured.reason.versatile": "Przydatne do wielu rzeczy",
-  "community.featured.reason.beginnerFriendly": "Dobry pierwszy wydruk"
+  "community.featured.reason.beginnerFriendly": "Dobry pierwszy wydruk",
+  "community.gapFit.fits": "Mieści się w wybranej luce",
+  "community.gapFit.fitsRotated": "Mieści się w wybranej luce, obrócony",
+  "community.gapFit.tooLarge": "Za duży na wybraną lukę",
+  "community.gapFit.tooTall": "Za wysoki na miejsce nad tą warstwą",
+  "community.gapFit.scaleMismatch": "Zbudowany dla innego rozmiaru siatki niż twój układ"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Especialmente bem feito",
   "community.featured.reason.clever": "Solução engenhosa",
   "community.featured.reason.versatile": "Útil para muitas coisas",
-  "community.featured.reason.beginnerFriendly": "Uma boa primeira impressão"
+  "community.featured.reason.beginnerFriendly": "Uma boa primeira impressão",
+  "community.gapFit.fits": "Cabe no espaço que você escolheu",
+  "community.gapFit.fitsRotated": "Cabe no espaço que você escolheu, virado",
+  "community.gapFit.tooLarge": "Grande demais para o espaço escolhido",
+  "community.gapFit.tooTall": "Alto demais para o espaço acima daquela camada",
+  "community.gapFit.scaleMismatch": "Feito para um tamanho de grade diferente do seu layout"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Särskilt välgjord",
   "community.featured.reason.clever": "Smart lösning",
   "community.featured.reason.versatile": "Användbar till mycket",
-  "community.featured.reason.beginnerFriendly": "En bra första utskrift"
+  "community.featured.reason.beginnerFriendly": "En bra första utskrift",
+  "community.gapFit.fits": "Passar i luckan du valde",
+  "community.gapFit.fitsRotated": "Passar i luckan du valde, vänd",
+  "community.gapFit.tooLarge": "För stor för luckan du valde",
+  "community.gapFit.tooTall": "För hög för utrymmet ovanför det lagret",
+  "community.gapFit.scaleMismatch": "Byggd för en annan rutstorlek än din layout"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "Особливо добре зроблено",
   "community.featured.reason.clever": "Розумне рішення",
   "community.featured.reason.versatile": "Корисне для багатьох речей",
-  "community.featured.reason.beginnerFriendly": "Гарний перший друк"
+  "community.featured.reason.beginnerFriendly": "Гарний перший друк",
+  "community.gapFit.fits": "Вміщується в обраний проміжок",
+  "community.gapFit.fitsRotated": "Вміщується в обраний проміжок, якщо повернути",
+  "community.gapFit.tooLarge": "Завеликий для обраного проміжку",
+  "community.gapFit.tooTall": "Зависокий для місця над цим шаром",
+  "community.gapFit.scaleMismatch": "Створено для іншого розміру сітки, ніж твій макет"
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3507,5 +3507,10 @@
   "community.featured.reason.wellMade": "做工尤其出色",
   "community.featured.reason.clever": "巧妙的解法",
   "community.featured.reason.versatile": "用途广泛",
-  "community.featured.reason.beginnerFriendly": "适合作为第一次打印"
+  "community.featured.reason.beginnerFriendly": "适合作为第一次打印",
+  "community.gapFit.fits": "能放进你选的空位",
+  "community.gapFit.fitsRotated": "转个方向就能放进你选的空位",
+  "community.gapFit.tooLarge": "对你选的空位来说太大了",
+  "community.gapFit.tooTall": "高度超过该层上方的空间",
+  "community.gapFit.scaleMismatch": "按与你的布局不同的网格尺寸制作"
 }


### PR DESCRIPTION
Closes the last engineering item from the community plan: "the gap handoff is one-shot from the grid editor; the fit verdict should apply everywhere."

## The problem

You pick a gap in your layout, the gallery filters to designs that fit, you open one — and the detail view says nothing about the gap. The answer to the question that brought you there disappears at the moment you need it.

## The change

Extracted the gap logic out of the browse filter into `utils/gapFit.ts` and pointed **both** surfaces at it.

That single-implementation point is the reason for the refactor rather than a nicety: filtering a card out of the grid and telling someone "this will not fit" are the same question, and two implementations is precisely how they come to disagree.

The verdict distinguishes cases the filter could only collapse into a boolean:

- **`fits` vs `fits-rotated`** — placement probes both orientations, so a 2x3 design does fit a 3x2 gap. The grid only needed to know it fits; the detail can say *how*.
- **`too-tall` vs `too-large`** — a design failing both now reports the ceiling, which is the more actionable reason.
- **`scale-mismatch`** — checked first, because comparing footprints across different `gridUnitMm` compares numbers that do not mean the same thing, and placement hard-rejects the mismatch anyway.

## Notes for review

**I broke and then restored a precedence rule.** The original filter let an explicit toolbar bound override the corresponding gap dimension (`filters.widthMax ?? fitsGapContext.widthMax`). My first pass delegated wholly to the verdict and lost it — caught by the existing `an explicit toolbar bound wins over the gap context` test, which did its job.

The fix builds an effective context by overlaying the toolbar bounds onto the gap while keeping the rest (notably the grid scale), so precedence stays one comparison rather than two competing ones.

**The verdict renders in `PrintCostPanel`**, alongside bed fit. Both answer "will this work for me", and splitting them across two panels would separate questions a reader asks together.

## Testing

14 new tests: the verdict (upright, exact-size, rotated, too-large, too-tall, no ceiling, scale mismatch, height-before-footprint precedence) and its rendering (absent without a gap, each verdict class, and the panel rendering for the gap verdict alone).

Full suite: 20,273 passing.

## Plan status

With this, everything in the community vision that is engineering work has shipped. The one remaining item is the collection picks themselves, which is a content decision rather than a change to the code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carry the gap-fit verdict from the gallery into the detail view and unify the logic so both surfaces agree. Users now see if a design fits the selected gap, including rotation, height ceiling, and grid-scale mismatches.

- **New Features**
  - Show gap-fit verdict in `PrintCostPanel`: `fits`, `fits-rotated`, `too-large`, `too-tall`, `scale-mismatch`.
  - Only shown when a gap is picked; the panel can render with the verdict alone.

- **Refactors**
  - Moved gap-fit logic to `utils/gapFit.ts` and use it in both the browse filter and the detail view.
  - Browse filter now calls `gapFitVerdict` to handle rotation and grid-scale checks; toolbar bounds override matching gap dimensions while keeping the gap’s scale.
  - Documented why the grid-scale check is partial (X-only given available metrics) and fixed a test helper to honor `gridUnitMm`; updated tests and i18n strings.

<sup>Written for commit 2544686377ec0ceb12d36c7e8d0a7966cd1529e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

