### PR TITLE
fix(drawer-shape): centre a perimeter drawn larger than its grid

### DIFF
--- a/src/features/baseplate/utils/buildFullParams.test.ts
+++ b/src/features/baseplate/utils/buildFullParams.test.ts
@@ -1232,8 +1232,9 @@ describe('outline overhang (#3169)', () => {
  */
 describe('split-piece outline frame vs. its overhang-widened slab (#3212)', () => {
   // The reporter's plate: a 393 × 295.5mm perimeter on an 8 × 7 drawer at
-  // 48 × 42 pitch (extent 384 × 294), centred by a (4.5, 0.75) grid shift — so
-  // BOTH sides of BOTH axes overhang, and a 256mm bed tiles it 2 × 2.
+  // 48 × 42 pitch (extent 384 × 294). The oversize shape auto-centres now
+  // (#3212), so no manual grid shift is needed to reach the case where BOTH
+  // sides of BOTH axes overhang. A 256mm bed tiles it 2 × 2.
   const REPORTED: DrawerOutline = {
     vertices: [
       { x: 0, y: 0 },
@@ -1266,12 +1267,22 @@ describe('split-piece outline frame vs. its overhang-widened slab (#3212)', () =
     REPORTED,
     undefined,
     42,
-    4.5,
-    0.75
+    0,
+    0
   );
 
   it('overhangs all four sides — the case a single-sided shift never reached', () => {
     expect(plate.outlineOverhang).toEqual({ left: 4.5, right: 4.5, front: 0.75, back: 0.75 });
+  });
+
+  it('auto-centres the oversize shape the reporter hand-shifted', () => {
+    // (4.5, 0.75) is exactly what they typed into the grid-shift steppers; the
+    // registration now supplies it, so the manual shift starts (and stays) 0.
+    const b = outlineBounds(plate.outline as DrawerOutline);
+    expect(b.minX).toBeCloseTo(-4.5, 9);
+    expect(b.maxX).toBeCloseTo(388.5, 9);
+    expect(b.minY).toBeCloseTo(-0.75, 9);
+    expect(b.maxY).toBeCloseTo(294.75, 9);
   });
 
   it('starts every piece outline at minus its own overhang, not at zero', () => {

--- a/src/shared/utils/drawerOutlineGeometry.test.ts
+++ b/src/shared/utils/drawerOutlineGeometry.test.ts
@@ -238,6 +238,47 @@ describe('outlineBounds', () => {
 });
 
 describe('outlineLatticeShift', () => {
+  /**
+   * #3212: a shape drawn larger than its grid used to get no registration at
+   * all — "keep the bbox inside the extent" is unsatisfiable for an oversize
+   * bbox, so it stayed corner-anchored at the author's origin and the user
+   * hand-entered the centring grid shift. The containment simply runs the
+   * other way round there: the socket lattice must stay inside the material.
+   */
+  describe('oversize bbox (#3212)', () => {
+    const rect = (w: number, d: number): DrawerOutline => ({
+      vertices: [
+        { x: 0, y: 0 },
+        { x: w, y: 0 },
+        { x: w, y: d },
+        { x: 0, y: d },
+      ],
+    });
+
+    it('centres a shape wider than its extent instead of leaving it anchored', () => {
+      // The reporter's plate: 393 x 295.5mm on an 8 x 7 grid at 48 x 42.
+      const shift = outlineLatticeShift(rect(393, 295.5), frame(8, 7, 48, 42));
+      expect(shift.x).toBeCloseTo(-4.5, 9);
+      expect(shift.y).toBeCloseTo(-0.75, 9);
+    });
+
+    it('keeps the whole lattice inside the material while centring', () => {
+      // The invariant that replaces "bbox inside extent" when the shape is the
+      // larger of the two: every socket the plate has still sits on material,
+      // so centring costs no cell (what pure bbox centring cost in #3149).
+      const shift = outlineLatticeShift(rect(393, 295.5), frame(8, 7, 48, 42));
+      expect(0 + shift.x).toBeLessThanOrEqual(0);
+      expect(393 + shift.x).toBeGreaterThanOrEqual(8 * 48);
+      expect(0 + shift.y).toBeLessThanOrEqual(0);
+      expect(295.5 + shift.y).toBeGreaterThanOrEqual(7 * 42);
+    });
+
+    it('leaves an in-extent shape exactly where registration put it', () => {
+      // The ordering change must not touch the normal case.
+      expect(outlineLatticeShift(rect(8 * U, 7 * U), frame(8, 7))).toEqual({ x: 0, y: 0 });
+    });
+  });
+
   /** Zero-padding frame over a widthU×depthU drawer. */
   const frame = (widthU: number, depthU: number, pitchX = U, pitchY = U): OutlineLatticeFrame => ({
     x: { extentMm: widthU * pitchX, originMm: 0, pitchMm: pitchX, wholeCells: Math.floor(widthU) },

--- a/src/shared/utils/drawerOutlineGeometry.ts
+++ b/src/shared/utils/drawerOutlineGeometry.ts
@@ -179,6 +179,12 @@ export interface OutlineLatticeFrame {
  * translation is a pure relabelling (sockets sit at the same places relative to
  * the perimeter), so it fixes the extent interaction without costing a socket.
  *
+ * An OVERSIZE perimeter — bbox wider than the extent, what a shape drawn
+ * larger than its grid produces — centres too (#3212). Containment there runs
+ * the other way round (the lattice stays inside the material rather than the
+ * material inside the extent), which is the only sense the constraint can
+ * have when the shape is the larger of the two.
+ *
  * Zero when the outline already fills or is registered to the extent, so
  * square and full-extent plates stay byte-identical (cache-stable).
  */
@@ -222,11 +228,18 @@ function clamp(value: number, lo: number, hi: number): number {
 
 function axisLatticeShift(bboxMin: number, bboxMax: number, axis: OutlineLatticeAxis): number {
   const { extentMm, originMm, pitchMm, wholeCells } = axis;
-  // Every shift must keep the bbox inside the plate extent; a bbox wider than
-  // the extent has none, so it stays where the author put it.
-  const shiftMin = -bboxMin;
-  const shiftMax = extentMm - bboxMax;
-  if (shiftMax < shiftMin) return 0;
+  // Containment runs whichever way round the two spans sit (#3212). Normally
+  // the bbox must stay inside the extent. An OVERSIZE bbox — one wider than the
+  // extent, which is what a shape drawn larger than its grid produces — can
+  // never satisfy that, so the requirement inverts: the extent (the socket
+  // lattice) must stay inside the bbox (the material). Both are the same
+  // interval with its ends ordered, so ordering them covers both. Treating the
+  // oversize case as "no feasible shift" left the perimeter corner-anchored,
+  // and the user had to hand-enter the centring grid shift.
+  const boundA = -bboxMin;
+  const boundB = extentMm - bboxMax;
+  const shiftMin = Math.min(boundA, boundB);
+  const shiftMax = Math.max(boundA, boundB);
 
   const bboxCenter = (bboxMin + bboxMax) / 2;
   const centeringShift = extentMm / 2 - bboxCenter;


### PR DESCRIPTION
Follow-up to #3213/#3215, closing the last gap in the custom-perimeter cluster (#3107, #3108, #3109, #3113, #3149, #3163, #3169, #3212).

## The bug

The lattice registration required the perimeter's bbox to stay inside the grid extent:

```js
const shiftMin = -bboxMin;
const shiftMax = extentMm - bboxMax;
if (shiftMax < shiftMin) return 0;   // oversize -> no registration at all
```

An **oversize** perimeter (bbox wider than the extent — what setting a smaller grid after drawing produces) can never satisfy that, so it got no registration and stayed anchored at the corner the author drew it from. The two issues titled "grid not centered" were both this.

## The fix

The constraint simply runs the other way round there: when the shape is the larger of the two, the socket lattice must stay inside the **material**, rather than the material inside the extent. Both are the same interval with its ends ordered, so ordering them covers both cases — and the in-extent path is byte-identical, since `shiftMin <= shiftMax` already held there.

The reporter of #3149/#3212 hit this twice and hand-computed the centring shift both times: `4.5` and `0.75`mm, for a 393 × 295.5mm perimeter on an 8 × 7 grid at 48 × 42 pitch. The registration now supplies exactly that, with the manual grid shift left at 0.

## This does not repeat #3149

Registration stays the primary objective and centring only breaks the tie. On the reporter's plate the cell block still lands on the lattice (`blockMiss` 0), so every socket survives. Pure bbox centring — the first attempt at #3108 — moved the perimeter by sub-cell amounts and cost an entire row and column of sockets under "fit whole cells".

## Migration note

A manual grid shift on an oversize shape now **composes** with the centring instead of supplying it, so it wants resetting to 0. Called out to the reporter in #3212. In-extent shapes are unaffected.

## Verification

- Lattice-shift regressions: the reporter's plate centres to `(-4.5, -0.75)`; every whole cell stays on material; an in-extent shape is untouched (the ordering change must not touch the normal path).
- The #3212 suite now reaches four-sided overhang with **no** manual shift — the reproduction as users actually meet it.
- Full run **20,285 passed, 0 failed**. WASM outline scenarios 21/21; shared + baseplate + core 4,429/4,429.
- typecheck, lint, i18n, module-boundary and design-system gates clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-center perimeters drawn larger than their grid by keeping the socket lattice inside the material instead of leaving the shape corner‑anchored. In-extent behavior is unchanged and socket coverage is preserved.

- **Bug Fixes**
  - Handle oversize outlines by ordering containment bounds and centering the lattice inside the material; normal in-extent path remains byte-identical.
  - Keeps all whole cells on material; adds tests covering the oversize case and four-sided overhang without manual shifts.

- **Migration**
  - If you applied a manual grid shift to an oversize shape, reset it to 0. In-extent shapes require no changes.

<sup>Written for commit 0e7835ab6bc9b0eadd738567d3af4330498869d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

