### PR TITLE
fix(generation): diagnose an empty kernel mesh instead of reporting a number

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
@@ -23,12 +23,22 @@ import type { SplitPreviewResult } from './wasmInit';
  */
 export function assertKernelReturnedGeometry(result: MeshData, label?: string): void {
   const where = label ? ` (${label})` : '';
-  const diagnosis =
-    `kernel returned an EMPTY mesh${where} — 0 triangles is a generation failure, ` +
-    `not a geometry change. Usually WASM init/allocation failing under memory ` +
-    `pressure; re-run this file alone before treating it as a regression.`;
-  expect(result.triangleCount, diagnosis).toBeGreaterThan(0);
-  expect(result.vertices.length, diagnosis).toBeGreaterThan(0);
+  const why =
+    `An empty result is a generation failure, not a geometry change. Usually ` +
+    `WASM init/allocation failing under memory pressure; re-run this file alone ` +
+    `before treating it as a regression.`;
+  // Each half states what was actually observed. A shared message would report
+  // "0 triangles" for the count-without-buffers case below, which is the same
+  // misdiagnosis this helper exists to prevent.
+  expect(
+    result.triangleCount,
+    `kernel returned an EMPTY mesh${where} — no triangles. ${why}`
+  ).toBeGreaterThan(0);
+  expect(
+    result.vertices.length,
+    `kernel returned an EMPTY mesh${where} — ${result.triangleCount} triangles but ` +
+      `no vertex data. ${why}`
+  ).toBeGreaterThan(0);
 }
 
 /** Assert a MeshData result has valid structure: vertices > 0, normals match, indices consistent, no NaN. */

--- a/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts
@@ -9,17 +9,40 @@ import type { SplitPreviewResult } from './wasmInit';
 
 // ─── Structural validity ─────────────────────────────────────────────────────
 
+/**
+ * Assert the kernel returned geometry at all.
+ *
+ * An empty mesh is categorically different from wrong geometry: no generator
+ * path produces zero triangles as an *answer*, so a zero means the kernel
+ * yielded nothing — a WASM init or allocation failure, characteristically under
+ * memory pressure from concurrent builds. Bare `toBeGreaterThan(0)` reports
+ * that as "expected +0 to be greater than +0", which reads as a geometry defect
+ * and sent #3184 to a bisect for a regression that was never there. The message
+ * names the failure class instead, so the next zero is diagnosed rather than
+ * investigated.
+ */
+export function assertKernelReturnedGeometry(result: MeshData, label?: string): void {
+  const where = label ? ` (${label})` : '';
+  const diagnosis =
+    `kernel returned an EMPTY mesh${where} — 0 triangles is a generation failure, ` +
+    `not a geometry change. Usually WASM init/allocation failing under memory ` +
+    `pressure; re-run this file alone before treating it as a regression.`;
+  expect(result.triangleCount, diagnosis).toBeGreaterThan(0);
+  expect(result.vertices.length, diagnosis).toBeGreaterThan(0);
+}
+
 /** Assert a MeshData result has valid structure: vertices > 0, normals match, indices consistent, no NaN. */
 export function assertStructurallyValid(result: MeshData, label?: string): void {
   const prefix = label ? `${label}: ` : '';
-  expect(result.vertices.length, `${prefix}vertices should exist`).toBeGreaterThan(0);
+  // Emptiness first: it has its own diagnosis, and every check below reads as
+  // geometry drift when the real cause is that nothing was generated.
+  assertKernelReturnedGeometry(result, label);
   expect(result.normals.length, `${prefix}normals should match vertices`).toBe(
     result.vertices.length
   );
   expect(result.indices.length, `${prefix}indices should match triangleCount`).toBe(
     result.triangleCount * 3
   );
-  expect(result.triangleCount, `${prefix}should have triangles`).toBeGreaterThan(0);
   expect(hasNoNaNOrInfinity(result.vertices), `${prefix}vertices have NaN/Infinity`).toBe(true);
   expect(hasNoNaNOrInfinity(result.normals), `${prefix}normals have NaN/Infinity`).toBe(true);
 }

--- a/src/features/generation/worker/generators/__kernel-tests__/scenarioRunner.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/scenarioRunner.ts
@@ -23,7 +23,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './wasmInit';
-import { assertStructurallyValid } from './meshAssertions';
+import { assertKernelReturnedGeometry, assertStructurallyValid } from './meshAssertions';
 import { printTimingTable } from './reportTable';
 import type { TimingEntry } from './reportTable';
 import { buildParams } from './scenarioTypes';
@@ -37,8 +37,11 @@ function runScenario(scenario: ScenarioCase, timings: TimingEntry[]): void {
     const result = generateBin(fullParams, undefined, scenario.forExport);
 
     if (scenario.assert === 'snapshot') {
-      expect(result.vertices.length).toBeGreaterThan(0);
-      expect(result.triangleCount).toBeGreaterThan(0);
+      // Before the snapshot, never after: a kernel that returned nothing must
+      // report itself as a kernel failure, not as a triangle-count diff against
+      // the baseline (#3184). This also keeps a zero out of the baseline under
+      // `-u`, which would bake the failure in.
+      assertKernelReturnedGeometry(result, scenario.name);
       // Triangle counts are kernel-specific (each kernel tessellates to its
       // own density). The vitest config's `resolveSnapshotPath` routes each
       // non-default kernel to its own `.<kernel>.snap` file, so occt-wasm and
@@ -52,6 +55,9 @@ function runScenario(scenario: ScenarioCase, timings: TimingEntry[]): void {
     if (scenario.compareWith) {
       const compareParams = buildParams(scenario.compareWith.params);
       const compareResult = generateBin(compareParams, undefined, scenario.compareWith.forExport);
+      // The comparison arm is a generated mesh too, and an empty one makes any
+      // "removed material" / "differs from" assertion trivially true.
+      assertKernelReturnedGeometry(compareResult, `${scenario.name} (comparison)`);
       scenario.compareWith.assert(result, compareResult);
     }
 

--- a/src/features/generation/worker/generators/meshAssertions.test.ts
+++ b/src/features/generation/worker/generators/meshAssertions.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The empty-mesh diagnosis is the whole point of `assertKernelReturnedGeometry`
+ * (#3184): a zero-triangle result is a kernel failure, and reporting it as a
+ * bare numeric assertion is what sent a memory-pressure flake to a bisect for a
+ * regression that did not exist. Pinned here so the wording cannot decay back
+ * into an anonymous `expected +0 to be greater than +0`.
+ *
+ * Pure assertion logic over hand-built MeshData — no kernel needed.
+ *
+ * Deliberately NOT colocated beside `__kernel-tests__/meshAssertions.ts`: every
+ * Vitest project excludes the `__kernel-tests__` directory, so a test written
+ * there never runs. One directory up it lands in the `generators` project.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  assertKernelReturnedGeometry,
+  assertStructurallyValid,
+} from './__kernel-tests__/meshAssertions';
+import type { MeshData } from '@/features/generation/bridge/types';
+
+/** One degenerate-but-nonempty triangle: enough to pass every structural check. */
+function mesh(overrides: Partial<MeshData> = {}): MeshData {
+  return {
+    vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    triangleCount: 1,
+    ...overrides,
+  } as MeshData;
+}
+
+const empty = (): MeshData =>
+  mesh({
+    vertices: new Float32Array([]),
+    normals: new Float32Array([]),
+    indices: new Uint32Array([]),
+    triangleCount: 0,
+  });
+
+describe('assertKernelReturnedGeometry (#3184)', () => {
+  it('passes a mesh that has geometry', () => {
+    expect(() => assertKernelReturnedGeometry(mesh(), 'ok')).not.toThrow();
+  });
+
+  it('names the failure class rather than the number', () => {
+    let message = '';
+    try {
+      assertKernelReturnedGeometry(empty(), 'L-shape with front cutout');
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    // The three things a reader needs: what happened, that it is not geometry
+    // drift, and what to do next.
+    expect(message).toContain('EMPTY mesh');
+    expect(message).toContain('not a geometry change');
+    expect(message).toContain('re-run this file alone');
+    // ...and which scenario, since a whole domain file shares one runner.
+    expect(message).toContain('L-shape with front cutout');
+  });
+
+  it('catches an empty mesh that still claims triangles', () => {
+    // A kernel can hand back a count with no buffer; both halves are checked so
+    // neither shape of emptiness slips into a snapshot comparison.
+    expect(() => assertKernelReturnedGeometry(mesh({ vertices: new Float32Array([]) }))).toThrow(
+      /EMPTY mesh/
+    );
+  });
+});
+
+describe('assertStructurallyValid diagnoses emptiness first', () => {
+  it('reports an empty mesh as a kernel failure, not as a mismatch', () => {
+    // Every downstream check (normals match, indices match) is also violated by
+    // an empty mesh, and each of those reads as geometry drift. Emptiness has to
+    // win the race or the diagnosis is lost.
+    expect(() => assertStructurallyValid(empty(), 'scenario')).toThrow(/EMPTY mesh/);
+  });
+
+  it('still reports real structural damage on a non-empty mesh', () => {
+    expect(() =>
+      assertStructurallyValid(mesh({ normals: new Float32Array([0, 0, 1]) }), 'scenario')
+    ).toThrow(/normals should match vertices/);
+  });
+
+  it('still catches NaN', () => {
+    expect(() =>
+      assertStructurallyValid(mesh({ vertices: new Float32Array([0, 0, 0, NaN, 0, 0, 0, 1, 0]) }))
+    ).toThrow(/NaN\/Infinity/);
+  });
+});

--- a/src/features/generation/worker/generators/meshAssertions.test.ts
+++ b/src/features/generation/worker/generators/meshAssertions.test.ts
@@ -18,15 +18,17 @@ import {
 } from './__kernel-tests__/meshAssertions';
 import type { MeshData } from '@/features/generation/bridge/types';
 
-/** One degenerate-but-nonempty triangle: enough to pass every structural check. */
+/** One degenerate-but-nonempty triangle: enough to pass every structural check.
+ * Fully typed (no cast) so a change to the MeshData contract surfaces here. */
 function mesh(overrides: Partial<MeshData> = {}): MeshData {
   return {
     vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
     normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
     indices: new Uint32Array([0, 1, 2]),
+    edgeVertices: new Float32Array(0),
     triangleCount: 1,
     ...overrides,
-  } as MeshData;
+  };
 }
 
 const empty = (): MeshData =>
@@ -56,6 +58,20 @@ describe('assertKernelReturnedGeometry (#3184)', () => {
     expect(message).toContain('re-run this file alone');
     // ...and which scenario, since a whole domain file shares one runner.
     expect(message).toContain('L-shape with front cutout');
+  });
+
+  it('describes the count-without-buffers case as itself, not as "no triangles"', () => {
+    // A kernel can hand back a count with no buffer. Reporting that as
+    // "0 triangles" would be the same misdiagnosis this helper exists to
+    // prevent, so each half states what it actually observed.
+    let message = '';
+    try {
+      assertKernelReturnedGeometry(mesh({ triangleCount: 7, vertices: new Float32Array([]) }));
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('7 triangles but no vertex data');
+    expect(message).not.toContain('no triangles');
   });
 
   it('catches an empty mesh that still claims triangles', () => {


### PR DESCRIPTION
Fixes #3184, taking the hardening from the issue's own correction rather than the originally-filed correctness bug.

## What was actually wrong

The `> 0` guards already ran **before** `toMatchSnapshot()`, so a zero could never structurally become a snapshot diff — nor be written into a baseline under `-u`. Nothing was broken in the check.

What was missing is **diagnosis**. A bare `toBeGreaterThan(0)` reports:

```
expected +0 to be greater than +0
```

which reads as a geometry defect. That is what had this filed as a correctness regression across eight scenarios, and pointed toward bisecting for a commit that never existed. The eight scenarios pass on `main` (50/50 across the three files), consistent with the correction.

## The change

A zero-triangle result is categorically different from wrong geometry: no generator path produces an empty mesh as an *answer*, so a zero means the kernel yielded nothing — WASM init or allocation failing, characteristically under memory pressure from concurrent builds.

`assertKernelReturnedGeometry` names the failure class, the scenario, and what to do next:

```
kernel returned an EMPTY mesh (3x3 L with front cutout) — 0 triangles is a
generation failure, not a geometry change. Usually WASM init/allocation
failing under memory pressure; re-run this file alone before treating it as
a regression.
```

Three call sites:

- **`assertStructurallyValid`** calls it *first* — an empty mesh violates its normals and indices checks too, and each of those also reads as geometry drift, so emptiness has to win the race or the diagnosis is lost.
- **The scenario runner's snapshot branch**, replacing the two bare `> 0` expects.
- **The runner's comparison arm**, which was unguarded: an empty compare mesh makes any "removed material" / "differs from" assertion trivially true.

## Root cause is upstream of anything fixable here

`initBrepjs` does not swallow errors (a real init failure fails `beforeAll` loudly), and `toIndexedMeshData` passes the tessellation straight through with no empty fallback. The zero originates inside the kernel with no error raised. The harness is the right boundary — making the generator throw on an empty tessellation would be a production behaviour change with real risk.

## Two notes for reviewers

**The test is not colocated, deliberately.** Every Vitest project excludes the `__kernel-tests__` directory, so a test written beside the helper is collected by nothing and never runs. It sits one directory up, in the `generators` project, with the reason recorded in the file. The pre-commit `check-missing-tests` warning about `meshAssertions.ts` / `scenarioRunner.ts` lacking siblings is this tradeoff — moving the test back to satisfy it would silently disable it.

**Six tests, all failing without the change.** They pin the wording, the scenario name, both shapes of emptiness (no triangles, and a count with no buffer), and that emptiness beats the structural checks. Controls confirm real structural damage and NaN still report as themselves on a non-empty mesh.

## Verification

- Full run **20,291 passed, 0 failed**.
- The three scenario files from the report: 50/50. Baseplate outline scenarios 21/21.
- typecheck, lint, i18n, module-boundary and design-system gates clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Diagnose empty kernel meshes so zero triangles or missing buffers are reported as kernel failures, not geometry regressions. Fixes #3184 by asserting before snapshots/comparisons and refining messages to state exactly what was observed.

- **Bug Fixes**
  - Added `assertKernelReturnedGeometry` to flag empties with the scenario name and guidance; messages distinguish "no triangles" from "N triangles but no vertex data."
  - Called this assertion in the snapshot path and comparison arm to keep zeros out of baselines and avoid trivially true diffs.
  - Updated `assertStructurallyValid` to check emptiness first to prevent misleading normals/indices errors.
  - Added unit tests for wording and both emptiness shapes; placed outside `__kernel-tests__` so `vitest` collects them.

<sup>Written for commit 8f612dee9c79bceb36c54292169cd891f404a01b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

