### PR TITLE
ci: shadow the generators suite on the self-hosted Mac mini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,60 @@ jobs:
           path: coverage/
           retention-days: 5
 
+  # Shadow run of the generators workload on the self-hosted Mac mini (M4 Pro,
+  # 10 performance cores), alongside the cloud shards above rather than replacing
+  # them. Deliberately absent from test-gate's `needs`, so a failure here cannot
+  # block a merge while we compare wall time and confirm snapshot parity.
+  #
+  # Two shards, not six. The 6-way split above is sized for six independent
+  # 4-core cloud runners; on one machine that split would pay checkout + install
+  # + WASM init six times over and leave each shard ~1.7 cores. Two shards at
+  # five workers each keeps the performance cores saturated while leaving the
+  # efficiency cores for interactive use and for halcyon's three runners, which
+  # share this host.
+  #
+  # `vars.SELF_HOSTED_CI` is the kill switch: unset it in repo settings and every
+  # shard here stops scheduling immediately, no code change needed. The head_repo
+  # comparison is the security boundary — a fork PR must never execute on
+  # self-hosted hardware, where it would run as a real user on a real machine
+  # with a persistent workspace.
+  test-selfhosted:
+    name: Unit Tests SH (${{ matrix.name }})
+    if: >-
+      ${{ vars.SELF_HOSTED_CI == 'true'
+      && !startsWith(github.head_ref, 'release-please--')
+      && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: [self-hosted, gflt-ci]
+    # Shadow mode: report, never block.
+    continue-on-error: true
+    # A wedged WASM kernel would otherwise hold a runner indefinitely, and there
+    # are only two of them.
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: generators 1/2
+            shard: 1/2
+          - name: generators 2/2
+            shard: 2/2
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pnpm + Node and install dependencies
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Generate artifacts
+        run: pnpm run build:en-locale
+
+      - name: Run generators tests
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: pnpm vitest run --project=generators --shard="$SHARD" --maxWorkers=5
+
   # Tests that need a real Redis. The rate limiter runs as a Lua script, and a
   # mocked ioredis can only assert the command was issued — it cannot execute
   # the body, so enforcement and atomicity are unverifiable without a server.


### PR DESCRIPTION
Moves the heaviest part of CI, the brepjs/OpenCascade generator tests, onto a self-hosted M4 Pro Mac mini. This lands it in shadow mode: the new job runs alongside the existing six cloud shards and cannot block a merge.

## What runs where

A new `test-selfhosted` job runs the `generators` project on `runs-on: [self-hosted, gflt-ci]`, split into two shards at five Vitest workers each. Everything else (build, core shards, integration, quality) stays on `ubuntu-latest`. The `integration` job in particular has to: its `services: redis` container is unsupported on macOS runners.

Two shards rather than six. The six-way split above it is sized for six independent 4-core cloud runners. On a single machine that split pays checkout, install and WASM init six times over while leaving each shard roughly 1.7 cores. Two shards keep the ten performance cores saturated and leave the efficiency cores for the three halcyon runners that share the host.

## Why it cannot block a merge

- Excluded from `test-gate`'s `needs`. `test-gate` is the single required branch-protection context, so shard topology can change without touching the ruleset.
- `continue-on-error: true`, so a failure reports as an annotation rather than a red check.

Either alone would be sufficient; both are present because branch protection is easy to misconfigure.

## Controls

- `vars.SELF_HOSTED_CI` is a kill switch. Unset it in repo settings and every self-hosted shard stops scheduling, with no code change and no PR.
- A head-repo comparison keeps fork PRs off the hardware. A self-hosted runner executes as a real user on a real machine with a persistent workspace, so untrusted code must never reach it.
- `timeout-minutes: 45`, so a wedged WASM kernel cannot hold one of only two runners indefinitely.

## Runners

`bl-mini-gflt-ci` and `bl-mini-gflt-ci-2`, repo-scoped, running under the existing unprivileged `ghrunner` account as LaunchDaemons so they start at boot without a GUI login.

## What this PR is for

Confirming two things before the cloud shards are removed in a follow-up:

1. **Snapshot parity.** The committed `triangleCount` baselines were generated on ubuntu-latest x64. Scenario snapshots are routed per kernel rather than per platform, and both platforms use the default `occt-wasm`, so they are expected to match, but that is worth demonstrating rather than assuming.
2. **Wall time**, measured against the six cloud shards on the same commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shadows the heavy `generators` test suite onto a self-hosted M4 Pro Mac mini to measure wall time and confirm snapshot parity without blocking merges.

- **New Features**
  - Adds `test-selfhosted` job for `generators` on `runs-on: [self-hosted, gflt-ci]`.
  - Uses 2 shards (`1/2`, `2/2`) with `--maxWorkers=5` to fit 10 performance cores.
  - Shadow mode: excluded from `test-gate` and `continue-on-error: true`.
  - Safety: gated by `vars.SELF_HOSTED_CI`, head-repo only, `timeout-minutes: 45`.
  - All other jobs stay on `ubuntu-latest` (e.g., `integration` needs Redis).

<sup>Written for commit 93cab7f8bb455996bd369ed7eb170343fbc688ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

