### PR TITLE
ci: widen the self-hosted generators split to four shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,12 +131,25 @@ jobs:
   # them. Deliberately absent from test-gate's `needs`, so a failure here cannot
   # block a merge while we compare wall time and confirm snapshot parity.
   #
-  # Two shards, not six. The 6-way split above is sized for six independent
-  # 4-core cloud runners; on one machine that split would pay checkout + install
-  # + WASM init six times over and leave each shard ~1.7 cores. Two shards at
-  # five workers each keeps the performance cores saturated while leaving the
-  # efficiency cores for interactive use and for halcyon's three runners, which
-  # share this host.
+  # Four shards across four runners, three Vitest workers each. The sizing is
+  # bounded from two directions and has to sit between them.
+  #
+  # Measured on the first shadow run (#3221): two shards at five workers cost
+  # 1750 CPU-seconds of test time, which against ten performance cores puts the
+  # floor near 175s. That run took 224s instead, because `--shard` buckets by
+  # file-path HASH rather than duration — one shard drew 224s of work and the
+  # other 126s, a 1.8x imbalance. More buckets smooth that out, which is why
+  # this widens the split rather than narrowing it.
+  #
+  # The other bound is a single file: Vitest never parallelizes within one, so
+  # the longest file sets a floor no amount of sharding can cross (~330s on a
+  # cloud runner, closer to 130s here). Four shards approach the CPU floor while
+  # staying clear of the file floor, and 4x3 = 12 threads leaves headroom for
+  # interactive use and for halcyon's three runners, which share this host.
+  #
+  # Going past four would be wrong for a different reason than it is on the
+  # cloud side: here every shard pays checkout + install + WASM init on the SAME
+  # machine, so beyond the core count the fixed cost is pure loss.
   #
   # `vars.SELF_HOSTED_CI` is the kill switch: unset it in repo settings and every
   # shard here stops scheduling immediately, no code change needed. The head_repo
@@ -153,17 +166,21 @@ jobs:
     runs-on: [self-hosted, gflt-ci]
     # Shadow mode: report, never block.
     continue-on-error: true
-    # A wedged WASM kernel would otherwise hold a runner indefinitely, and there
-    # are only two of them.
+    # A wedged WASM kernel would otherwise hold a runner indefinitely, and the
+    # pool is small.
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: generators 1/2
-            shard: 1/2
-          - name: generators 2/2
-            shard: 2/2
+          - name: generators 1/4
+            shard: 1/4
+          - name: generators 2/4
+            shard: 2/4
+          - name: generators 3/4
+            shard: 3/4
+          - name: generators 4/4
+            shard: 4/4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -178,7 +195,7 @@ jobs:
       - name: Run generators tests
         env:
           SHARD: ${{ matrix.shard }}
-        run: pnpm vitest run --project=generators --shard="$SHARD" --maxWorkers=5
+        run: pnpm vitest run --project=generators --shard="$SHARD" --maxWorkers=3
 
   # Tests that need a real Redis. The rate limiter runs as a Lua script, and a
   # mocked ioredis can only assert the command was issued — it cannot execute


### PR DESCRIPTION
Follow-up to #3221, which put the generators suite on the Mac mini in shadow mode. This tunes the split using what that run actually measured.

## What the first run showed

| | Cloud (6 shards) | Self-hosted (2 shards) |
|---|---|---|
| Slowest job | 7m56s | 5m08s |
| Slowest test step | 450s | 224s |
| Aggregate test time | ~1160s | 350s |
| Snapshot parity | baseline | identical |

The mini does the same work in roughly a third of the compute time, and the committed x64 `triangleCount` baselines matched on arm64 macOS, so the WASM `occt-wasm` kernel tessellates deterministically across architectures.

## What is left on the table

1750 CPU-seconds of test time against ten performance cores puts the floor near 175s. The run took 224s because `--shard` buckets by file-path hash rather than duration: one shard drew 224s of work against the other's 126s, a 1.8x imbalance.

Four shards over four runners smooth that out. Workers drop from five to three so total threads stay at twelve rather than twenty, leaving headroom for interactive use and for the three halcyon runners that share the host. The gain comes from bucket balance, not from oversubscribing cores.

Four is also the ceiling worth paying for. Every shard pays checkout, install and WASM init on the same machine, so beyond the core count the fixed cost is pure loss, and a single file sets a floor that sharding cannot cross since Vitest never parallelizes within one.

## Runners

The pool is now `bl-mini-gflt-ci` through `-ci-4`, all repo-scoped, under the unprivileged `ghrunner` account as LaunchDaemons.

## Still shadow

Unchanged from #3221: absent from `test-gate`'s `needs`, `continue-on-error: true`, gated on `vars.SELF_HOSTED_CI` and a head-repo comparison. This cannot block a merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the self-hosted generators tests from 2 to 4 shards on the Mac mini pool to balance work and reduce wall time without oversubscribing cores. Still shadow-only and never blocks merges.

- **Refactors**
  - Split generators suite to 4 shards (1/4–4/4) on `[self-hosted, gflt-ci]`; run `vitest` with `--maxWorkers=3` (~12 total threads).
  - Target runner pool `bl-mini-gflt-ci` through `-ci-4`; keep 45-minute timeout.
  - Safeguards unchanged: gated by `vars.SELF_HOSTED_CI` and head-repo check, `continue-on-error: true`, and excluded from `test-gate` needs.

<sup>Written for commit 38d529f425dfd0f187de2f581ce99a51a9e924b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

