### PR TITLE
test(generation): split the kumiko scenarios into three files

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.export.kumikoComposition.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.kumikoComposition.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
-import { kumikoComposition } from './scenarios/kumiko';
+import { kumikoComposition } from './scenarios/kumikoComposition';
 
 runExportIntegrity(kumikoComposition);

--- a/src/features/generation/worker/generators/binGenerator.export.kumikoComposition.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.kumikoComposition.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { kumikoComposition } from './scenarios/kumiko';
+
+runExportIntegrity(kumikoComposition);

--- a/src/features/generation/worker/generators/binGenerator.export.kumikoPatterns.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.kumikoPatterns.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { kumikoPatterns } from './scenarios/kumiko';
+
+runExportIntegrity(kumikoPatterns);

--- a/src/features/generation/worker/generators/binGenerator.export.kumikoPatterns.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.kumikoPatterns.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
-import { kumikoPatterns } from './scenarios/kumiko';
+import { kumikoPatterns } from './scenarios/kumikoPatterns';
 
 runExportIntegrity(kumikoPatterns);

--- a/src/features/generation/worker/generators/binGenerator.export.kumikoWrapping.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.kumikoWrapping.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
-import { kumiko } from './scenarios/kumiko';
+import { kumikoWrapping } from './scenarios/kumiko';
 
-runExportIntegrity(kumiko);
+runExportIntegrity(kumikoWrapping);

--- a/src/features/generation/worker/generators/binGenerator.export.kumikoWrapping.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.kumikoWrapping.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
-import { kumikoWrapping } from './scenarios/kumiko';
+import { kumikoWrapping } from './scenarios/kumikoWrapping';
 
 runExportIntegrity(kumikoWrapping);

--- a/src/features/generation/worker/generators/binGenerator.scenario.kumikoComposition.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.kumikoComposition.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runScenarios } from './__kernel-tests__/scenarioRunner';
-import { kumikoComposition } from './scenarios/kumiko';
+import { kumikoComposition } from './scenarios/kumikoComposition';
 
 runScenarios(kumikoComposition);

--- a/src/features/generation/worker/generators/binGenerator.scenario.kumikoComposition.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.kumikoComposition.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runScenarios } from './__kernel-tests__/scenarioRunner';
+import { kumikoComposition } from './scenarios/kumiko';
+
+runScenarios(kumikoComposition);

--- a/src/features/generation/worker/generators/binGenerator.scenario.kumikoPatterns.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.kumikoPatterns.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runScenarios } from './__kernel-tests__/scenarioRunner';
-import { kumikoPatterns } from './scenarios/kumiko';
+import { kumikoPatterns } from './scenarios/kumikoPatterns';
 
 runScenarios(kumikoPatterns);

--- a/src/features/generation/worker/generators/binGenerator.scenario.kumikoPatterns.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.kumikoPatterns.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runScenarios } from './__kernel-tests__/scenarioRunner';
-import { kumiko } from './scenarios/kumiko';
+import { kumikoPatterns } from './scenarios/kumiko';
 
-runScenarios(kumiko);
+runScenarios(kumikoPatterns);

--- a/src/features/generation/worker/generators/binGenerator.scenario.kumikoWrapping.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.kumikoWrapping.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runScenarios } from './__kernel-tests__/scenarioRunner';
+import { kumikoWrapping } from './scenarios/kumiko';
+
+runScenarios(kumikoWrapping);

--- a/src/features/generation/worker/generators/binGenerator.scenario.kumikoWrapping.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.kumikoWrapping.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runScenarios } from './__kernel-tests__/scenarioRunner';
-import { kumikoWrapping } from './scenarios/kumiko';
+import { kumikoWrapping } from './scenarios/kumikoWrapping';
 
 runScenarios(kumikoWrapping);

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -39,7 +39,9 @@ import { lightweight } from './lightweight';
 import { spacer } from './spacer';
 import { labelSockets } from './labelSockets';
 import { wallPatterns } from './wallPatterns';
-import { kumiko } from './kumiko';
+import { kumikoComposition } from './kumikoComposition';
+import { kumikoPatterns } from './kumikoPatterns';
+import { kumikoWrapping } from './kumikoWrapping';
 import { dividerPatterns } from './dividerPatterns';
 import { floorPatterns } from './floorPatterns';
 
@@ -83,7 +85,9 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...lightweight,
   ...labelSockets,
   ...wallPatterns,
-  ...kumiko,
+  ...kumikoPatterns,
+  ...kumikoWrapping,
+  ...kumikoComposition,
   ...dividerPatterns,
   ...floorPatterns,
   ...spacer,

--- a/src/features/generation/worker/generators/scenarios/kumiko.ts
+++ b/src/features/generation/worker/generators/scenarios/kumiko.ts
@@ -272,7 +272,17 @@ function kumikoPatternCase(pattern: WallPatternType): ScenarioCase {
   });
 }
 
-export const kumiko: ScenarioCase[] = [
+// One case per kumiko pattern: each must remove material from a 1×1×6 bin.
+export const kumikoPatterns: ScenarioCase[] = [
+  kumikoPatternCase('goma'),
+  kumikoPatternCase('sakura'),
+  kumikoPatternCase('rindo'),
+  kumikoPatternCase('mikado'),
+  kumikoPatternCase('tsumiishi-kikko'),
+];
+
+// How a pattern reaches corners, and which walls it covers.
+export const kumikoWrapping: ScenarioCase[] = [
   defineScenario('kumiko', 'mitsukude keeps both diagonal families on corners (1×1×4, bold)', {
     assert: 'structural',
     timeout: 180_000,
@@ -286,7 +296,6 @@ export const kumiko: ScenarioCase[] = [
     },
     customAssert: assertCornerDiagonalsPresent,
   }),
-  kumikoPatternCase('goma'),
   defineScenario('kumiko', 'asanoha wraps a 1×1×6 bin including corners', {
     assert: 'structural',
     timeout: 180_000,
@@ -308,10 +317,6 @@ export const kumiko: ScenarioCase[] = [
       assert: assertCornersWrapped(1, 1),
     },
   }),
-  kumikoPatternCase('sakura'),
-  kumikoPatternCase('rindo'),
-  kumikoPatternCase('mikado'),
-  kumikoPatternCase('tsumiishi-kikko'),
   defineScenario('kumiko', 'mitsukude wraps a 1×1×6 bin including corners', {
     assert: 'structural',
     timeout: 180_000,
@@ -380,6 +385,10 @@ export const kumiko: ScenarioCase[] = [
       assert: assertRemovesMaterial,
     },
   }),
+];
+
+// Kumiko composed with other bin features.
+export const kumikoComposition: ScenarioCase[] = [
   defineScenario('kumiko', 'mitsukude composes with a front wall cutout', {
     assert: 'structural',
     timeout: 180_000,
@@ -448,3 +457,9 @@ export const kumiko: ScenarioCase[] = [
     },
   }),
 ];
+
+// Aggregate for scenarios/index.ts. The three groups above each get their own
+// test file: at ~13s per case these fifteen were a single 200s file, and Vitest
+// never parallelizes within a file, so it floored the whole generators shard no
+// matter how the suite was sharded. Same fix as #2882.
+export const kumiko: ScenarioCase[] = [...kumikoPatterns, ...kumikoWrapping, ...kumikoComposition];

--- a/src/features/generation/worker/generators/scenarios/kumikoComposition.ts
+++ b/src/features/generation/worker/generators/scenarios/kumikoComposition.ts
@@ -1,0 +1,84 @@
+/**
+ * Kumiko composed with other bin features: wall cutouts, handles, compartment
+ * dividers, magnet bases and asymmetric overhang.
+ *
+ * Split out of the kumiko wrapping cases so the catalogue's slowest domain is
+ * three test files rather than one. Vitest never parallelizes within a file, so
+ * a single 200s file floored the whole generators shard regardless of sharding
+ * (same reasoning as #2882). Per-pattern coverage lives in `kumikoPatterns.ts`
+ * and corner-wrap proofs in `kumikoWrapping.ts`.
+ */
+import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
+import { defineScenario } from '../__kernel-tests__/scenarioTypes';
+import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+import { ALL_SIDES_OFF } from './kumikoWrapping';
+
+export const kumikoComposition: ScenarioCase[] = [
+  defineScenario('kumiko', 'mitsukude composes with a front wall cutout', {
+    assert: 'structural',
+    timeout: 180_000,
+    params: {
+      width: 2,
+      depth: 1,
+      height: 6,
+      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
+      walls: {
+        ...ALL_SIDES_OFF,
+        enabled: true,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 60, depth: 50 },
+      },
+    },
+  }),
+  defineScenario('kumiko', 'mitsukude composes with handles', {
+    assert: 'structural',
+    timeout: 180_000,
+    params: {
+      width: 2,
+      depth: 1,
+      height: 6,
+      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
+      walls: ALL_SIDES_OFF,
+      handles: {
+        ...DEFAULT_BIN_PARAMS.handles,
+        enabled: true,
+        front: { ...DEFAULT_BIN_PARAMS.handles.front, enabled: true },
+      },
+    },
+  }),
+  defineScenario('kumiko', 'mitsukude composes with 2×2 compartment dividers', {
+    assert: 'structural',
+    timeout: 180_000,
+    params: {
+      width: 2,
+      depth: 2,
+      height: 6,
+      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
+      walls: ALL_SIDES_OFF,
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
+    },
+  }),
+  defineScenario('kumiko', 'mitsukude on a half-grid 1.5×1×6 bin with magnets', {
+    assert: 'structural',
+    timeout: 180_000,
+    params: {
+      width: 1.5,
+      depth: 1,
+      height: 6,
+      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
+      walls: ALL_SIDES_OFF,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
+    },
+  }),
+  defineScenario('kumiko', 'mitsukude with asymmetric overhang', {
+    assert: 'structural',
+    timeout: 180_000,
+    params: {
+      width: 2,
+      depth: 2,
+      height: 6,
+      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
+      walls: ALL_SIDES_OFF,
+      overhang: { ...DEFAULT_BIN_PARAMS.overhang, left: 4, right: 0, front: 2, back: 0 },
+    },
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/kumikoPatterns.ts
+++ b/src/features/generation/worker/generators/scenarios/kumikoPatterns.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-pattern kumiko coverage: one case per pattern, each asserting the lattice
+ * removes material from a 1×1×6 bin against its solid-walled twin.
+ *
+ * Split out of the kumiko wrapping cases so the catalogue's slowest domain is
+ * three test files rather than one. Vitest never parallelizes within a file, so
+ * a single 200s file floored the whole generators shard regardless of sharding
+ * (same reasoning as #2882). Corner-wrap proofs live in `kumikoWrapping.ts` and
+ * feature interactions in `kumikoComposition.ts`.
+ */
+import { defineScenario } from '../__kernel-tests__/scenarioTypes';
+import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+import type { WallPatternType } from '@/shared/types/bin';
+import { ALL_SIDES_OFF } from './kumikoWrapping';
+import { assertRemovesMaterial } from './wallPatterns';
+
+/** Compact per-pattern case: valid geometry + material removed vs solid twin. */
+function kumikoPatternCase(pattern: WallPatternType): ScenarioCase {
+  return defineScenario('kumiko', `${pattern} carves a 1×1×6 bin`, {
+    assert: 'structural',
+    timeout: 180_000,
+    params: {
+      width: 1,
+      depth: 1,
+      height: 6,
+      wallPattern: { enabled: true, pattern, scale: 0.5 },
+      walls: ALL_SIDES_OFF,
+    },
+    compareWith: {
+      params: {
+        width: 1,
+        depth: 1,
+        height: 6,
+        wallPattern: { enabled: false, pattern, scale: 0.5 },
+        walls: ALL_SIDES_OFF,
+      },
+      assert: assertRemovesMaterial,
+    },
+  });
+}
+
+export const kumikoPatterns: ScenarioCase[] = [
+  kumikoPatternCase('goma'),
+  kumikoPatternCase('sakura'),
+  kumikoPatternCase('rindo'),
+  kumikoPatternCase('mikado'),
+  kumikoPatternCase('tsumiishi-kikko'),
+];

--- a/src/features/generation/worker/generators/scenarios/kumikoWrapping.ts
+++ b/src/features/generation/worker/generators/scenarios/kumikoWrapping.ts
@@ -17,7 +17,7 @@ import { DEFAULT_PATTERN_SCALE } from '@/shared/types/bin';
 import { defineScenario } from '../__kernel-tests__/scenarioTypes';
 import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 import type { MeshData } from '@/features/generation/bridge/types';
-import type { BinParams, WallPatternType } from '@/shared/types/bin';
+import type { BinParams } from '@/shared/types/bin';
 import { deriveDimensions } from '../pipeline/context';
 import { TOP_KEEP_OUT, BOTTOM_SOLID_SKIRT } from '../wallPatterns';
 import { SOCKET_HEIGHT, BOX_CORNER_RADIUS } from '../generatorConstants';
@@ -26,7 +26,7 @@ import { generateKumikoLattice, KUMIKO_BASE_CELL_SIZE } from '../patterns/kumiko
 import { MITSUKUDE_DEF } from '../patterns/kumiko/mitsukude';
 import { assertRemovesMaterial } from './wallPatterns';
 
-const ALL_SIDES_OFF = {
+export const ALL_SIDES_OFF = {
   ...DEFAULT_BIN_PARAMS.walls,
   enabled: false,
   front: DISABLED_WALL_CUTOUT,
@@ -247,40 +247,6 @@ function assertCornerDiagonalsPresent(mesh: MeshData, params: BinParams): void {
   expect(missing, missing.join('\n')).toEqual([]);
 }
 
-/** Compact per-pattern case: valid geometry + material removed vs solid twin. */
-function kumikoPatternCase(pattern: WallPatternType): ScenarioCase {
-  return defineScenario('kumiko', `${pattern} carves a 1×1×6 bin`, {
-    assert: 'structural',
-    timeout: 180_000,
-    params: {
-      width: 1,
-      depth: 1,
-      height: 6,
-      wallPattern: { enabled: true, pattern, scale: 0.5 },
-      walls: ALL_SIDES_OFF,
-    },
-    compareWith: {
-      params: {
-        width: 1,
-        depth: 1,
-        height: 6,
-        wallPattern: { enabled: false, pattern, scale: 0.5 },
-        walls: ALL_SIDES_OFF,
-      },
-      assert: assertRemovesMaterial,
-    },
-  });
-}
-
-// One case per kumiko pattern: each must remove material from a 1×1×6 bin.
-export const kumikoPatterns: ScenarioCase[] = [
-  kumikoPatternCase('goma'),
-  kumikoPatternCase('sakura'),
-  kumikoPatternCase('rindo'),
-  kumikoPatternCase('mikado'),
-  kumikoPatternCase('tsumiishi-kikko'),
-];
-
 // How a pattern reaches corners, and which walls it covers.
 export const kumikoWrapping: ScenarioCase[] = [
   defineScenario('kumiko', 'mitsukude keeps both diagonal families on corners (1×1×4, bold)', {
@@ -386,80 +352,3 @@ export const kumikoWrapping: ScenarioCase[] = [
     },
   }),
 ];
-
-// Kumiko composed with other bin features.
-export const kumikoComposition: ScenarioCase[] = [
-  defineScenario('kumiko', 'mitsukude composes with a front wall cutout', {
-    assert: 'structural',
-    timeout: 180_000,
-    params: {
-      width: 2,
-      depth: 1,
-      height: 6,
-      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
-      walls: {
-        ...ALL_SIDES_OFF,
-        enabled: true,
-        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 60, depth: 50 },
-      },
-    },
-  }),
-  defineScenario('kumiko', 'mitsukude composes with handles', {
-    assert: 'structural',
-    timeout: 180_000,
-    params: {
-      width: 2,
-      depth: 1,
-      height: 6,
-      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
-      walls: ALL_SIDES_OFF,
-      handles: {
-        ...DEFAULT_BIN_PARAMS.handles,
-        enabled: true,
-        front: { ...DEFAULT_BIN_PARAMS.handles.front, enabled: true },
-      },
-    },
-  }),
-  defineScenario('kumiko', 'mitsukude composes with 2×2 compartment dividers', {
-    assert: 'structural',
-    timeout: 180_000,
-    params: {
-      width: 2,
-      depth: 2,
-      height: 6,
-      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
-      walls: ALL_SIDES_OFF,
-      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
-    },
-  }),
-  defineScenario('kumiko', 'mitsukude on a half-grid 1.5×1×6 bin with magnets', {
-    assert: 'structural',
-    timeout: 180_000,
-    params: {
-      width: 1.5,
-      depth: 1,
-      height: 6,
-      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
-      walls: ALL_SIDES_OFF,
-      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
-    },
-  }),
-  defineScenario('kumiko', 'mitsukude with asymmetric overhang', {
-    assert: 'structural',
-    timeout: 180_000,
-    params: {
-      width: 2,
-      depth: 2,
-      height: 6,
-      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
-      walls: ALL_SIDES_OFF,
-      overhang: { ...DEFAULT_BIN_PARAMS.overhang, left: 4, right: 0, front: 2, back: 0 },
-    },
-  }),
-];
-
-// Aggregate for scenarios/index.ts. The three groups above each get their own
-// test file: at ~13s per case these fifteen were a single 200s file, and Vitest
-// never parallelizes within a file, so it floored the whole generators shard no
-// matter how the suite was sharded. Same fix as #2882.
-export const kumiko: ScenarioCase[] = [...kumikoPatterns, ...kumikoWrapping, ...kumikoComposition];


### PR DESCRIPTION
`binGenerator.export.kumiko.test.ts` ran 200s and its scenario counterpart 180s, the two slowest files in the `generators` project. Vitest never parallelizes within a file, so 200s was a hard floor on the generators critical path that no sharding could cross.

That floor was measurable. Running the suite on the self-hosted Mac mini added in #3221:

| Split | Critical path |
|---|---|
| 2 shards x 5 workers | 224s |
| 4 shards x 3 workers | 244s |

Both are noise around the same 200s file. Shard 3/4 held it and took 244s while the other three finished in 66s, 147s and 147s and then sat idle. `--shard` buckets by file-path hash, so all sharding does is decide which shard inherits the floor.

## What changed

`scenarios/kumiko.ts` becomes three modules, five cases each:

- `kumikoPatterns` — one case per pattern (goma, sakura, rindo, mikado, tsumiishi-kikko)
- `kumikoWrapping` — corner reach and which walls a pattern covers
- `kumikoComposition` — kumiko combined with cutouts, handles, dividers, magnets, overhang

Each module gets its own `scenario` and `export` test file, so two test files become six. `ALL_SIDES_OFF` is exported from `kumikoWrapping` and shared by the other two, mirroring how `wallPatterns` already exports `assertRemovesMaterial`.

Splitting the module rather than pointing three test-file pairs at one module is what `binGenerator.scenarioCoverage.test.ts` requires: it enforces one module to exactly one scenario file and one export file, and asserts the export file count equals the module count. That guard exists so a module wired under the wrong name cannot silently double-run or drop scenarios, and it caught the first attempt here.

## Measured result

| Path | Before | After |
|---|---|---|
| Cloud, slowest generators shard | 450s | 331s |
| Self-hosted, slowest shard | 224s | 196s |

The self-hosted shards also went from 126s/224s to 196s/195s. That balance is the more useful outcome: the generators group is now CPU-bound rather than pinned by one file, which per `ci.yml:64-67` is the regime where adding shards actually buys wall time.

## Safety

- `scenarios/index.ts` spreads the three modules, so `ALL_SCENARIOS` is unchanged.
- These scenarios assert structurally (`assert: 'structural'` with `customAssert`/`compareWith`) rather than against `triangleCount` baselines, and have no `__snapshots__` entry, so there are no snapshots to migrate.
- All 30 tests still run and pass: 15 scenario, 15 export, the same as before.

Follows the fix #2882 applied to the export file it describes at `ci.yml:61-64`.