### PR TITLE
ci: cut generators over to the self-hosted Mac mini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Three cases, in order:
+        #   1. Not a PR (i.e. main): full suite with coverage, one runner.
+        #   2. PR with self-hosted generators eligible: core shards only, because
+        #      `test-selfhosted` is covering generators on the Mac mini.
+        #   3. PR otherwise: all nine, the pre-cut-over layout.
+        #
+        # Case 3 is the fallback and its condition MUST stay the exact negation of
+        # `test-selfhosted`'s `if`. If the two ever disagree, a PR matching neither
+        # runs no generator tests at all and still reports green — the failure mode
+        # is silence, not a red check. That is why the head-repo comparison is
+        # duplicated here rather than simplified away: a fork PR is barred from the
+        # hardware, so it has to keep the cloud shards.
         include: >-
-          ${{ github.event_name == 'pull_request'
-          && fromJSON('[{"name":"generators 1/6","group":"generators","shard":"1/6"},{"name":"generators 2/6","group":"generators","shard":"2/6"},{"name":"generators 3/6","group":"generators","shard":"3/6"},{"name":"generators 4/6","group":"generators","shard":"4/6"},{"name":"generators 5/6","group":"generators","shard":"5/6"},{"name":"generators 6/6","group":"generators","shard":"6/6"},{"name":"core 1/3","group":"core","shard":"1/3"},{"name":"core 2/3","group":"core","shard":"2/3"},{"name":"core 3/3","group":"core","shard":"3/3"}]')
-          || fromJSON('[{"name":"full","group":"full","shard":"1/1"}]') }}
+          ${{ github.event_name != 'pull_request'
+          && fromJSON('[{"name":"full","group":"full","shard":"1/1"}]')
+          || (vars.SELF_HOSTED_CI == 'true'
+          && github.event.pull_request.head.repo.full_name == github.repository)
+          && fromJSON('[{"name":"core 1/3","group":"core","shard":"1/3"},{"name":"core 2/3","group":"core","shard":"2/3"},{"name":"core 3/3","group":"core","shard":"3/3"}]')
+          || fromJSON('[{"name":"generators 1/6","group":"generators","shard":"1/6"},{"name":"generators 2/6","group":"generators","shard":"2/6"},{"name":"generators 3/6","group":"generators","shard":"3/6"},{"name":"generators 4/6","group":"generators","shard":"4/6"},{"name":"generators 5/6","group":"generators","shard":"5/6"},{"name":"generators 6/6","group":"generators","shard":"6/6"},{"name":"core 1/3","group":"core","shard":"1/3"},{"name":"core 2/3","group":"core","shard":"2/3"},{"name":"core 3/3","group":"core","shard":"3/3"}]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -126,10 +141,17 @@ jobs:
           path: coverage/
           retention-days: 5
 
-  # Shadow run of the generators workload on the self-hosted Mac mini (M4 Pro,
-  # 10 performance cores), alongside the cloud shards above rather than replacing
-  # them. Deliberately absent from test-gate's `needs`, so a failure here cannot
-  # block a merge while we compare wall time and confirm snapshot parity.
+  # The generators workload, on the self-hosted Mac mini (M4 Pro, 10 performance
+  # cores). This REPLACES the cloud generators shards on same-repo PRs; the matrix
+  # above drops to core-only when this job is eligible.
+  #
+  # Measured against the cloud shards on the same commits: 450s -> 224s before the
+  # kumiko files were split (#3223), 331s -> 196s after. Snapshot parity with the
+  # x64 baselines was confirmed across two runs before cutting over — the WASM
+  # occt-wasm kernel tessellates identically on arm64.
+  #
+  # PRs only. Pushes to main keep the full cloud suite with coverage, so releases
+  # never depend on the mini being up.
   #
   # Two shards, not six. The 6-way split above is sized for six independent
   # 4-core cloud runners; on one machine that split would pay checkout + install
@@ -148,11 +170,9 @@ jobs:
     if: >-
       ${{ vars.SELF_HOSTED_CI == 'true'
       && !startsWith(github.head_ref, 'release-please--')
-      && (github.event_name != 'pull_request'
-      || github.event.pull_request.head.repo.full_name == github.repository) }}
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, gflt-ci]
-    # Shadow mode: report, never block.
-    continue-on-error: true
     # A wedged WASM kernel would otherwise hold a runner indefinitely, and there
     # are only two of them.
     timeout-minutes: 45
@@ -221,7 +241,7 @@ jobs:
   # release-please PRs in lockstep with the test job above.
   test-gate:
     name: Unit Tests Complete
-    needs: [test, integration]
+    needs: [test, integration, test-selfhosted]
     if: ${{ always() && !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
@@ -229,6 +249,7 @@ jobs:
         env:
           TEST_RESULT: ${{ needs.test.result }}
           INTEGRATION_RESULT: ${{ needs.integration.result }}
+          SELFHOSTED_RESULT: ${{ needs.test-selfhosted.result }}
         run: |
           if [ "$TEST_RESULT" != "success" ]; then
             echo "Unit test shards did not all pass (result: $TEST_RESULT)"
@@ -239,6 +260,20 @@ jobs:
             echo "Integration tests did not pass (result: $INTEGRATION_RESULT)"
             exit 1
           fi
+          # `skipped` is legitimate and means the cloud matrix above ran the
+          # generators shards instead: kill switch off, a fork PR, or a push to
+          # main. It is NOT a silent pass — the two conditions are written as
+          # exact negations of each other, so whichever path is skipped, the other
+          # one ran. Any other non-success state is a real failure.
+          case "$SELFHOSTED_RESULT" in
+            success|skipped) ;;
+            *)
+              echo "Self-hosted generator shards did not pass (result: $SELFHOSTED_RESULT)"
+              echo "If the Mac mini is down, unset the SELF_HOSTED_CI repo variable"
+              echo "to fall back to cloud generator shards."
+              exit 1
+              ;;
+          esac
           echo "All unit-test shards and integration tests passed."
 
   # PRs + main: Lint, i18n, module boundaries, union exhaustiveness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,17 @@ jobs:
         #      `test-selfhosted` is covering generators on the Mac mini.
         #   3. PR otherwise: all nine, the pre-cut-over layout.
         #
-        # Case 3 is the fallback and its condition MUST stay the exact negation of
-        # `test-selfhosted`'s `if`. If the two ever disagree, a PR matching neither
-        # runs no generator tests at all and still reports green — the failure mode
-        # is silence, not a red check. That is why the head-repo comparison is
-        # duplicated here rather than simplified away: a fork PR is barred from the
-        # hardware, so it has to keep the cloud shards.
+        # Case 3 is the fallback, and its condition must stay the negation of
+        # `test-selfhosted`'s `if` for every PR that reaches this job. If the two
+        # ever disagree, a PR matching neither runs no generator tests at all and
+        # still reports green — the failure mode is silence, not a red check. That
+        # is why the head-repo comparison is duplicated here rather than simplified
+        # away: a fork PR is barred from the hardware, so it has to keep the cloud
+        # shards.
+        #
+        # `test-selfhosted` also carries a release-please guard that is deliberately
+        # absent here: this job's own `if` already skips those PRs outright, so
+        # repeating it inside the matrix would be unreachable.
         include: >-
           ${{ github.event_name != 'pull_request'
           && fromJSON('[{"name":"full","group":"full","shard":"1/1"}]')
@@ -269,8 +274,8 @@ jobs:
             success|skipped) ;;
             *)
               echo "Self-hosted generator shards did not pass (result: $SELFHOSTED_RESULT)"
-              echo "If the Mac mini is down, unset the SELF_HOSTED_CI repo variable"
-              echo "to fall back to cloud generator shards."
+              echo "If the Mac mini is down, set the SELF_HOSTED_CI repo variable to"
+              echo "false (or unset it) to fall back to cloud generator shards."
               exit 1
               ;;
           esac


### PR DESCRIPTION
Same-repo PRs now run the generators suite on the Mac mini instead of six cloud shards, and the result is required rather than advisory. Completes the migration started in #3221.

## Evidence

Two shadow runs on identical commits, self-hosted alongside cloud:

| | Cloud | Self-hosted |
|---|---|---|
| Before the kumiko split | 450s | 224s |
| After the kumiko split (#3223) | 331s | **196s** |

Snapshot parity held on both runs: the committed `triangleCount` baselines were generated on ubuntu-latest x64 and matched on arm64 macOS, so the WASM `occt-wasm` kernel tessellates identically across architectures.

## What changed

- The cloud matrix drops to core-only when the self-hosted job is eligible.
- `test-selfhosted` loses `continue-on-error` and joins `test-gate`'s `needs`.
- It is now PR-only. Pushes to main keep the full cloud suite with coverage, so releases never depend on the mini being reachable.

No ruleset change: `Unit Tests Complete` is still the single required context, exactly as its comment intends.

## The condition that matters

The cloud fallback is written as the exact negation of `test-selfhosted`'s `if`. If the two ever disagree, a PR matching neither would run no generator tests and still report green, and the failure mode is silence rather than a red check. Every path was checked:

| Case | Cloud matrix | Self-hosted | Generators covered |
|---|---|---|---|
| push to main | full + coverage | skipped | yes |
| PR same-repo, SH on | core only | runs | yes |
| PR same-repo, SH off | all 9 | skipped | yes |
| PR fork, SH on | all 9 | skipped | yes |
| PR fork, SH off | all 9 | skipped | yes |

No path runs them twice either. `test-gate` accepts `skipped` for that reason and fails on anything else.

## Operational notes

- Fork PRs are barred from the hardware and keep the cloud shards. A self-hosted runner executes as a real user on a real machine with a persistent workspace, so untrusted code must never reach it.
- If the mini goes down, `gh variable set SELF_HOSTED_CI --body false` restores all nine cloud shards with no code change and no PR. The gate's failure message says so.
- Runners are `bl-mini-gflt-ci` through `-ci-4`, repo-scoped, under the unprivileged `ghrunner` account as LaunchDaemons.

This PR is itself a same-repo PR with `SELF_HOSTED_CI=true`, so its own CI exercises the cut-over path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Same-repo PRs now run the generators suite on our self-hosted Mac mini instead of six cloud shards, and that result is required. Pushes to main keep the full cloud suite with coverage; forks and kill-switch fallback use the cloud shards.

- **Migration**
  - Cloud matrix drops to core-only when the self-hosted job is eligible; fork PRs cannot use the hardware.
  - `test-selfhosted` is added to the `Unit Tests Complete` gate; it accepts `skipped` and fails on anything else. The failure message explains setting `SELF_HOSTED_CI=false` (or unsetting it) to restore all nine cloud shards.
  - Conditions are written as exact negations for PRs; the matrix omits the release-please guard because the job’s `if` already skips those PRs.
  - Performance: 450s → 224s pre-split; 331s → 196s post-split. Snapshots match x64 baselines (`occt-wasm` tessellates identically on arm64).

<sup>Written for commit e40d330822d2c14e61a0ceaa731af82017414ee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

