### PR TITLE
fix(deps): advance the undici, brace-expansion and fast-uri pins

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,15 +5,15 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@vercel/node>undici': ^7.28.0
-  undici@>=6.0.0 <6.27.0: ^6.27.0
-  undici@>=7.0.0 <7.28.0: ^7.28.0
+  '@vercel/node>undici': ^7.29.0
+  undici@>=6.0.0 <6.28.0: ^6.28.0
+  undici@>=7.0.0 <7.29.0: ^7.29.0
   path-to-regexp: 6.3.0
   '@rollup/plugin-replace>magic-string': 0.30.21
   '@surma/rollup-plugin-off-main-thread>magic-string': 0.30.21
   workbox-build>@rollup/plugin-node-resolve: ^16.0.0
   '@apideck/better-ajv-errors>ajv': ^8.17.1
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   sharp: ^0.35.0
   serialize-javascript: ^7.0.3
   eslint-plugin-react-hooks>eslint: ^10.0.3
@@ -33,7 +33,7 @@ overrides:
   eslint-plugin-i18next>lodash: ^4.18.1
   vitest-axe>lodash-es: ^4.18.1
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
-  brace-expansion@>=5.0.0 <5.0.8: ^5.0.8
+  brace-expansion@>=5.0.0 <5.0.9: ^5.0.9
   tar@<7.5.21: ^7.5.21
   '@vercel/python-analysis>smol-toml': ^1.6.1
   esbuild: 0.28.1
@@ -3186,8 +3186,8 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3733,8 +3733,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -5571,12 +5571,12 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -8373,7 +8373,7 @@ snapshots:
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@vercel/build-utils@13.36.2':
     dependencies:
@@ -8434,7 +8434,7 @@ snapshots:
       ts-morph: 12.0.0
       tsx: 4.21.0
       typescript: 5.9.3
-      undici: 7.28.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -8571,7 +8571,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8727,7 +8727,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9361,7 +9361,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-xml-builder@1.3.0:
     dependencies:
@@ -9895,7 +9895,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -10186,11 +10186,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -11256,9 +11256,9 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@6.27.0: {}
+  undici@6.28.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,8 +34,14 @@ minimumReleaseAgeExclude:
   # entry as a `||` union, never as a second line: pnpm returns the first rule
   # whose package name matches and never unions across entries, so a second
   # `brace-expansion@...` line is silently dead and its version stays blocked.
-  # TODO: remove after 2026-08-05 once 1.1.17 has aged past the window.
-  - brace-expansion@1.1.17
+  # 5.0.9 (2026-07-30) patches GHSA-rgw5-rvv9-x895 and is younger than the
+  # window, so it is unioned into THIS entry rather than added as a second
+  # `brace-expansion@...` line, which would be silently dead per the rule above.
+  # TODO: drop 5.0.9 from this union after 2026-08-06, and 1.1.17 after 2026-08-05.
+  - brace-expansion@1.1.17 || 5.0.9
+  # fast-uri 3.1.5 (2026-07-31) patches GHSA-7p8r-x3mc-p8w7 and is inside the
+  # window. TODO: remove after 2026-08-07.
+  - fast-uri@3.1.5
 
 # Blocks Shai-Hulud-class worms that spread via npm lifecycle scripts.
 # Packages that need to build are listed in allowBuilds.
@@ -52,15 +58,15 @@ peerDependencyRules:
     vite-plugin-pwa>vite: '^8.0.0'
 
 overrides:
-  '@vercel/node>undici': '^7.28.0'
-  'undici@>=6.0.0 <6.27.0': '^6.27.0'
-  'undici@>=7.0.0 <7.28.0': '^7.28.0'
+  '@vercel/node>undici': '^7.29.0'
+  'undici@>=6.0.0 <6.28.0': '^6.28.0'
+  'undici@>=7.0.0 <7.29.0': '^7.29.0'
   path-to-regexp: '6.3.0'
   '@rollup/plugin-replace>magic-string': '0.30.21'
   '@surma/rollup-plugin-off-main-thread>magic-string': '0.30.21'
   'workbox-build>@rollup/plugin-node-resolve': '^16.0.0'
   '@apideck/better-ajv-errors>ajv': '^8.17.1'
-  fast-uri: '^3.1.4'
+  fast-uri: '^3.1.5'
   # sharp <0.35.0 inherits libvips CVE-2026-33327/33328/35590/35591
   # (GHSA-f88m-g3jw-g9cj). Only reachable transitively via
   # manifold-3d>@gltf-transform/functions>ndarray-pixels (build-time glTF
@@ -99,10 +105,10 @@ overrides:
   'vitest-axe>lodash-es': '^4.18.1'
   'picomatch@>=4.0.0 <4.0.4': '^4.0.4'
   # brace-expansion arrives only via minimatch@10 now (all consumers pinned to
-  # 10.x above), which uses the 5.x line. Force any 5.0.x below 5.0.8 up to the
-  # release patched against GHSA-mh99-v99m-4gvg. The 1.x line is gone, so its old
+  # 10.x above), which uses the 5.x line. Force any 5.0.x below 5.0.9 up to the
+  # release patched against GHSA-rgw5-rvv9-x895. The 1.x line is gone, so its old
   # `brace-expansion@<1.1.17` pin is no longer needed (#2974).
-  'brace-expansion@>=5.0.0 <5.0.8': '^5.0.8'
+  'brace-expansion@>=5.0.0 <5.0.9': '^5.0.9'
   'tar@<7.5.21': '^7.5.21'
   '@vercel/python-analysis>smol-toml': '^1.6.1'
   esbuild: '0.28.1'


### PR DESCRIPTION
## Why

The blocking OSV scan on `main` is red: 10 advisories across four packages (3 High, 7 Medium). All four are already pinned in `pnpm-workspace.yaml` and all four are now exactly one patch behind.

| Package | Pinned | Patched | Advisories |
| --- | --- | --- | --- |
| `undici` (6.x) | 6.27.0 | 6.28.0 | GHSA-8xcm-r25x-g524, GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm |
| `undici` (7.x) | 7.28.0 | 7.29.0 | GHSA-4cwx-7wf7-3272, GHSA-jr45-8vmc-qm54, plus the three above |
| `brace-expansion` | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 |
| `fast-uri` | 3.1.4 | 3.1.5 | GHSA-7p8r-x3mc-p8w7 |

## Release cooldown

`brace-expansion@5.0.9` (2026-07-30) and `fast-uri@3.1.5` (2026-07-31) are inside the seven-day `minimumReleaseAge` window, so both are excluded **by exact version** with a TODO to remove once they age out. undici's releases are from 2026-07-24 and need no exemption.

`5.0.9` is unioned into the existing `brace-expansion@1.1.17` exclude entry rather than added as a second line — the rule already documented in that file is that pnpm returns the first entry whose package name matches and never unions across them, so a second `brace-expansion@...` line would be silently dead and the version would stay blocked.

## Test plan

- `pnpm why` confirms undici 6.28.0 / 7.29.0, brace-expansion 5.0.9, fast-uri 3.1.5 in the tree
- Typecheck clean, 20567 tests passing
- The blocking OSV scan is the real check; it only runs on `main`, so this lands and then main goes green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates dependency pins to patch security advisories and unblock the OSV scan on `main`. Advances `undici` (6.28.0/7.29.0), `brace-expansion` (5.0.9), and `fast-uri` (3.1.5), with temporary excludes for releases inside the seven-day cooldown.

- **Dependencies**
  - Updated overrides in `pnpm-workspace.yaml` and `pnpm-lock.yaml` for `undici` and `fast-uri`.
  - Cooldown excludes: `brace-expansion@1.1.17 || 5.0.9` (unioned in one line; drop 5.0.9 after 2026-08-06) and `fast-uri@3.1.5` (drop after 2026-08-07).

<sup>Written for commit 5e0e40cff932debbf3b5b387b0417f3ffce9adf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

