### PR TITLE
fix(community): reachable support links on mobile, and no one-card shelves

### DIFF
--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -128,6 +128,8 @@ Note the i18n key segments are camelCase (`...reason.wellMade`) while the union 
 - **Non-live and unknown ids are skipped**, and reported as `missingIds` so a curator can tell "not published yet" from "my ids are wrong".
 - **A collection with nothing left to show is dropped.** An empty shelf advertises a grouping and then fails to deliver it, so curation never has to be undone because a design went away.
 
+A derived shelf needs `SHELF_MIN_CARDS` (3) to render at all. The rails are about ten cards wide on a desktop window, so one or two read as a layout fault rather than a short list, and nothing is lost: a suppressed card is still in the grid below and still reachable through the shelf's own "See all". Curated collections are exempt, because a human chose those and a collection of one is a deliberate pick rather than a thin derivation.
+
 Curated shelves render above the derived ones: a human vouched for these, which is a stronger claim than any derived shelf can make. They carry a blurb (the reason the grouping exists) and no "See all", because a collection is a pick rather than a filter.
 
 The shipped list is deliberately empty. The mechanism is the engineering deliverable; the picks are a separate content decision, made by opening a PR against that file. Adding one means adding its two i18n keys across all locales, since editorial copy is user-facing like everything else.

--- a/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.test.tsx
@@ -579,7 +579,8 @@ describe('CommunityGalleryTab shelf landing', () => {
     return Array.from({ length: count }, (_, i) =>
       card(`design${String(i).padStart(3, '0')}`, {
         createdAt: 1000 + i,
-        featured: i === 0,
+        // SHELF_MIN_CARDS: a rail needs enough cards to fill a row.
+        featured: i < 3,
       })
     );
   }
@@ -643,7 +644,7 @@ describe('CommunityGalleryTab shelf landing', () => {
     // with the filtered grid.
     expect(screen.queryByTestId('community-shelves')).not.toBeInTheDocument();
     const grid = screen.getByRole('list', { name: 'community.gallery.gridLabel' });
-    expect(within(grid).getAllByRole('listitem')).toHaveLength(1);
+    expect(within(grid).getAllByRole('listitem')).toHaveLength(3);
     expect(within(grid).getByText('Bin design000')).toBeInTheDocument();
   });
 });

--- a/src/features/community/components/CommunityGalleryTab/ShelfLanding.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/ShelfLanding.test.tsx
@@ -65,7 +65,7 @@ describe('ShelfLanding', () => {
   it('renders shelf sections with accessible headings and cards', () => {
     render(
       <ShelfLanding
-        items={manyCards(20, (i) => ({ featured: i === 3 }))}
+        items={manyCards(20, (i) => ({ featured: i >= 3 && i < 6 }))}
         onSelect={vi.fn()}
         onSelectAuthor={vi.fn()}
       />
@@ -88,7 +88,7 @@ describe('ShelfLanding', () => {
   it('see all on staff picks applies the featured-only filter', () => {
     render(
       <ShelfLanding
-        items={manyCards(12, (i) => ({ featured: i === 0 }))}
+        items={manyCards(12, (i) => ({ featured: i < 3 }))}
         onSelect={vi.fn()}
         onSelectAuthor={vi.fn()}
       />
@@ -106,18 +106,22 @@ describe('ShelfLanding', () => {
   });
 
   it('see-all buttons use the per-shelf label key', () => {
+    // A real clock, so the 1000-era createdAt values fall outside the
+    // new-this-week window and the remixed cards reach most-remixed instead
+    // of being consumed by recency.
+    useBrowseStore.setState({ fetchedAt: 30 * 24 * 60 * 60 * 1000 });
     render(
       <ShelfLanding
         items={manyCards(12, (i) => ({
-          featured: i === 0,
-          counts: { likes: 0, remixes: i === 1 ? 2 : 0, exports: 0 },
+          featured: i < 3,
+          counts: { likes: 0, remixes: i >= 3 && i < 6 ? 2 : 0, exports: 0 },
         }))}
         onSelect={vi.fn()}
         onSelectAuthor={vi.fn()}
       />
     );
-    // The echo mock returns the key itself; the real label interpolates the
-    // shelf title ('See all: {shelf}'), giving each button a distinct name.
+    // The visible label is the same short string on every shelf; the shelf
+    // name lives in the accessible name, which is what distinguishes them.
     expect(screen.getByTestId('community-shelf-see-all-staff-picks').textContent).toBe(
       'community.shelves.seeAll'
     );

--- a/src/features/community/components/CommunityGalleryTab/shelfData.test.ts
+++ b/src/features/community/components/CommunityGalleryTab/shelfData.test.ts
@@ -78,13 +78,25 @@ describe('buildShelves', () => {
   });
 
   it('a card exactly 7 days old still counts as this week', () => {
+    // Three in-window cards, the oldest of them exactly on the boundary: the
+    // shelf is never padded with older designs, and SHELF_MIN_CARDS keeps a
+    // one-card rail from rendering at all.
     const items = manyCards(12, (i) => ({
-      createdAt: i === 0 ? NOW - 7 * DAY_MS : NOW - (20 + i) * DAY_MS,
+      createdAt: i === 0 ? NOW - 7 * DAY_MS : i < 3 ? NOW - i * DAY_MS : NOW - (20 + i) * DAY_MS,
     }));
-    // Only one in-window card: a short shelf, never padded with old designs.
     const shelves = buildShelves(items, NOW);
     const newThisWeek = shelves.find((shelf) => shelf.id === 'new-this-week');
-    expect(newThisWeek?.cards.map((c) => c.id)).toEqual(['design000']);
+    expect(newThisWeek?.cards.map((c) => c.id)).toContain('design000');
+    expect(newThisWeek?.cards).toHaveLength(3);
+  });
+
+  it('drops a rail that cannot fill a row', () => {
+    // Two in-window cards is not a shelf, it is two cards in an empty row.
+    // They still reach the grid below, which is the point of the rule.
+    const items = manyCards(12, (i) => ({
+      createdAt: i < 2 ? NOW - i * DAY_MS : NOW - (20 + i) * DAY_MS,
+    }));
+    expect(buildShelves(items, NOW).map((s) => s.id)).not.toContain('new-this-week');
   });
 
   it('a thin week shows only the genuinely-new designs', () => {
@@ -171,17 +183,32 @@ describe('buildShelves', () => {
       const items = [
         ...Array.from({ length: 12 }, (_, i) => card(`d${i}`)),
         card('printed-low', { counts: { likes: 0, remixes: 0, exports: 0, prints: 1 } }),
+        card('printed-mid', { counts: { likes: 0, remixes: 0, exports: 0, prints: 4 } }),
         card('printed-high', { counts: { likes: 0, remixes: 0, exports: 0, prints: 9 } }),
       ];
 
       const proven = buildShelves(items, NOW).find((s) => s.id === 'proven');
-      expect(proven?.cards.map((c) => c.id)).toEqual(['printed-high', 'printed-low']);
+      expect(proven?.cards.map((c) => c.id)).toEqual([
+        'printed-high',
+        'printed-mid',
+        'printed-low',
+      ]);
+    });
+
+    it('is absent when too few designs have been printed to fill a row', () => {
+      const items = [
+        ...Array.from({ length: 12 }, (_, i) => card(`d${i}`)),
+        card('printed', { counts: { likes: 0, remixes: 0, exports: 0, prints: 3 } }),
+      ];
+      expect(buildShelves(items, NOW).map((s) => s.id)).not.toContain('proven');
     });
 
     it('ranks above new-this-week, since proof outranks recency', () => {
       const items = [
         ...Array.from({ length: 12 }, (_, i) => card(`d${i}`, { createdAt: NOW })),
-        card('printed', { counts: { likes: 0, remixes: 0, exports: 0, prints: 3 } }),
+        ...Array.from({ length: 3 }, (_, i) =>
+          card(`printed${i}`, { counts: { likes: 0, remixes: 0, exports: 0, prints: 3 } })
+        ),
       ];
 
       const ids = buildShelves(items, NOW).map((s) => s.id);
@@ -191,10 +218,15 @@ describe('buildShelves', () => {
     it('does not repeat a design already shown in staff picks', () => {
       const items = [
         ...Array.from({ length: 12 }, (_, i) => card(`d${i}`)),
+        // Enough featured designs for a staff-picks rail to exist at all.
+        ...Array.from({ length: 2 }, (_, i) => card(`feat${i}`, { featured: true })),
         card('both', {
           featured: true,
           counts: { likes: 0, remixes: 0, exports: 0, prints: 5 },
         }),
+        ...Array.from({ length: 2 }, (_, i) =>
+          card(`printed${i}`, { counts: { likes: 0, remixes: 0, exports: 0, prints: 2 } })
+        ),
       ];
 
       const proven = buildShelves(items, NOW).find((s) => s.id === 'proven');

--- a/src/features/community/components/CommunityGalleryTab/shelfData.ts
+++ b/src/features/community/components/CommunityGalleryTab/shelfData.ts
@@ -4,6 +4,21 @@ export const SHELF_LANDING_MIN_DESIGNS = 12;
 
 export const SHELF_CARD_LIMIT = 8;
 
+/**
+ * A rail below this is not a shelf, it is a card sitting in a mostly empty
+ * row: the rails are ~10 cards wide on a desktop window, so one or two look
+ * like a layout fault rather than a short list.
+ *
+ * The same rule the curated collections already follow — a grouping that
+ * cannot deliver on itself is dropped — and nothing is lost by it: every card
+ * suppressed here is still in the grid below, and still reachable through the
+ * shelf's own "See all".
+ *
+ * Curated collections are exempt: a human chose those, and a collection of
+ * one is a deliberate pick rather than a thin derivation.
+ */
+export const SHELF_MIN_CARDS = 3;
+
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 export type ShelfId = 'staff-picks' | 'proven' | 'new-this-week' | 'most-remixed';
@@ -28,7 +43,7 @@ export function buildShelves(items: readonly CommunityCard[], now: number): Shel
     .filter((card) => card.featured)
     .sort(byNewest)
     .slice(0, SHELF_CARD_LIMIT);
-  if (staffPicks.length > 0) {
+  if (staffPicks.length >= SHELF_MIN_CARDS) {
     shelves.push({ id: 'staff-picks', cards: staffPicks });
     for (const card of staffPicks) shownIds.add(card.id);
   }
@@ -43,7 +58,7 @@ export function buildShelves(items: readonly CommunityCard[], now: number): Shel
       return delta !== 0 ? delta : byNewest(a, b);
     })
     .slice(0, SHELF_CARD_LIMIT);
-  if (proven.length > 0) {
+  if (proven.length >= SHELF_MIN_CARDS) {
     shelves.push({ id: 'proven', cards: proven });
     for (const card of proven) shownIds.add(card.id);
   }
@@ -55,7 +70,7 @@ export function buildShelves(items: readonly CommunityCard[], now: number): Shel
   // Only genuinely-new designs belong under the "New this week" heading: a
   // thin week shows a short shelf, a dead week shows none, never months-old
   // designs relabeled as new.
-  if (thisWeek.length > 0) {
+  if (thisWeek.length >= SHELF_MIN_CARDS) {
     const cards = thisWeek.slice(0, SHELF_CARD_LIMIT);
     shelves.push({ id: 'new-this-week', cards });
     for (const card of cards) shownIds.add(card.id);
@@ -68,7 +83,10 @@ export function buildShelves(items: readonly CommunityCard[], now: number): Shel
     )
     .slice(0, SHELF_CARD_LIMIT);
   // An all-zero "Most remixed" rail would just repeat "New this week".
-  if (mostRemixed.some((card) => card.counts.remixes > 0)) {
+  if (
+    mostRemixed.length >= SHELF_MIN_CARDS &&
+    mostRemixed.some((card) => card.counts.remixes > 0)
+  ) {
     shelves.push({ id: 'most-remixed', cards: mostRemixed });
   }
 

--- a/src/features/community/components/CommunityPage/CommunityPage.tsx
+++ b/src/features/community/components/CommunityPage/CommunityPage.tsx
@@ -150,11 +150,12 @@ export function CommunityPage({
     <div className="flex h-screen flex-col overflow-hidden bg-surface text-content">
       <header className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-stroke-subtle bg-surface-secondary px-3 md:px-4">
         <ToolSwitcher compact={isMobile} iconOnly={isMobile} />
-        {!isMobile && (
-          <div className="flex items-center gap-1">
-            <HeaderSupportLinks />
-          </div>
-        )}
+        <div className="flex items-center gap-1">
+          {/* Compact on mobile rather than absent: this route has no other
+              chrome, so hiding the cluster left Help, Feedback and the
+              language selector unreachable here. */}
+          <HeaderSupportLinks compact={isMobile} />
+        </div>
       </header>
 
       <div className="flex shrink-0 flex-wrap items-start justify-between gap-3 border-b border-stroke-subtle px-3 py-3 md:px-4">

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -30,16 +30,16 @@ graph TB
 
 ## Key Components (`components/`)
 
-| Component                  | Purpose                                                                  |
-| -------------------------- | ------------------------------------------------------------------------ |
-| `DeferredNumberInput`      | Number input that commits on blur/Enter (prevents mid-type validation)   |
-| `ItemListShell`            | Generic searchable, sortable, filterable list container (grid/list view) |
-| `ConfirmDialog`            | Modal with focus trap, Escape handling, portal rendering                 |
-| `Toast` / `ToastContainer` | Auto-dismiss notifications with pause-on-hover                           |
-| `ContextMenu*`             | Framework for consistent right-click menus                               |
-| `CollapsibleSection`       | Expandable container with arrow indicator                                |
-| `ToolSwitcher`             | Segmented nav across Layout / Bins / Baseplate / Community               |
-| `HeaderSupportLinks`       | Shared top-right cluster; outbound links live in its overflow menu       |
+| Component                  | Purpose                                                                                |
+| -------------------------- | -------------------------------------------------------------------------------------- |
+| `DeferredNumberInput`      | Number input that commits on blur/Enter (prevents mid-type validation)                 |
+| `ItemListShell`            | Generic searchable, sortable, filterable list container (grid/list view)               |
+| `ConfirmDialog`            | Modal with focus trap, Escape handling, portal rendering                               |
+| `Toast` / `ToastContainer` | Auto-dismiss notifications with pause-on-hover                                         |
+| `ContextMenu*`             | Framework for consistent right-click menus                                             |
+| `CollapsibleSection`       | Expandable container with arrow indicator                                              |
+| `ToolSwitcher`             | Segmented nav across Layout / Bins / Baseplate / Community                             |
+| `HeaderSupportLinks`       | Shared top-right cluster; outbound links in its overflow, `compact` folds all of it in |
 
 ## Key Hooks (`hooks/`)
 

--- a/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.test.tsx
+++ b/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.test.tsx
@@ -139,4 +139,37 @@ describe('HeaderSupportLinks', () => {
       'noopener,noreferrer'
     );
   });
+
+  describe('compact', () => {
+    it('leaves only the language selector and the overflow in the bar', () => {
+      render(<HeaderSupportLinks compact />);
+      expect(screen.getByTestId('language-selector')).toBeInTheDocument();
+      expect(screen.getByLabelText('header.moreLinks')).toBeInTheDocument();
+      expect(screen.queryByLabelText('header.sendFeedback')).toBeNull();
+      expect(screen.queryByLabelText('header.helpAndShortcuts')).toBeNull();
+      expect(screen.queryByLabelText('header.supportOnKofi')).toBeNull();
+    });
+
+    it('still reaches every action through the overflow', () => {
+      render(<HeaderSupportLinks compact />);
+      fireEvent.click(screen.getByLabelText('header.moreLinks'));
+
+      expect(screen.getByRole('menuitem', { name: 'header.sendFeedback' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'header.helpAndShortcuts' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'header.supportOnKofi' })).toBeInTheDocument();
+      expect(screen.getByText('header.starOnGithubLong')).toBeInTheDocument();
+    });
+
+    it('dispatches the help event from the overflow', () => {
+      const handler = vi.fn();
+      window.addEventListener('open-help-modal', handler);
+      render(<HeaderSupportLinks compact />);
+
+      fireEvent.click(screen.getByLabelText('header.moreLinks'));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'header.helpAndShortcuts' }));
+
+      expect(handler).toHaveBeenCalledOnce();
+      window.removeEventListener('open-help-modal', handler);
+    });
+  });
 });

--- a/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
+++ b/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
@@ -23,7 +23,18 @@ import {
  * has to hold the design name and the export controls at every width, and
  * those are the actions a user came here for.
  */
-export function HeaderSupportLinks() {
+export interface HeaderSupportLinksProps {
+  /**
+   * Fold every action except the language selector into the overflow menu.
+   *
+   * For narrow headers that still have to offer Help, Feedback and the rest:
+   * hiding the cluster entirely is what left the mobile /community route with
+   * no way to reach any of them.
+   */
+  compact?: boolean;
+}
+
+export function HeaderSupportLinks({ compact = false }: HeaderSupportLinksProps = {}) {
   const t = useTranslation();
   const feedbackToastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const overflowRef = useRef<HTMLButtonElement>(null);
@@ -87,6 +98,73 @@ export function HeaderSupportLinks() {
     );
   };
 
+  const overflowMenu = (
+    <Menu.Root
+      open={overflow.open}
+      onClose={() => setOverflow((previous) => ({ ...previous, open: false }))}
+      position={overflow.position}
+      align="end"
+    >
+      {compact && (
+        <>
+          <Menu.Item onClick={handleFeedbackClick}>{t('header.sendFeedback')}</Menu.Item>
+          <Menu.Item onClick={handleHelpClick}>{t('header.helpAndShortcuts')}</Menu.Item>
+        </>
+      )}
+      <Menu.Item
+        href={GITHUB_REPO_URL}
+        icon={
+          <svg fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+            <path d={GITHUB_ICON_PATH} />
+          </svg>
+        }
+      >
+        {t('header.starOnGithubLong')}
+      </Menu.Item>
+      <Menu.Item
+        href={REDDIT_GRIDFINITY_URL}
+        onClick={handleRedditClick}
+        aria-label={t('common.redditCommunityAria')}
+        icon={
+          <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d={REDDIT_ICON_PATH} />
+          </svg>
+        }
+      >
+        {t('common.redditCommunity')}
+      </Menu.Item>
+      {compact && <Menu.Item onClick={handleKofiClick}>{t('header.supportOnKofi')}</Menu.Item>}
+    </Menu.Root>
+  );
+
+  const overflowTrigger = (
+    <IconButton
+      ref={overflowRef}
+      size="sm"
+      aria-label={t('header.moreLinks')}
+      aria-haspopup="menu"
+      aria-expanded={overflow.open}
+      title={t('header.moreLinks')}
+      onClick={toggleOverflow}
+    >
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        {ICON_PATHS.dotsHorizontal.map((d) => (
+          <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
+        ))}
+      </svg>
+    </IconButton>
+  );
+
+  if (compact) {
+    return (
+      <>
+        <LanguageSelector />
+        {overflowTrigger}
+        {overflowMenu}
+      </>
+    );
+  }
+
   return (
     <>
       <LanguageSelector />
@@ -129,51 +207,8 @@ export function HeaderSupportLinks() {
         <span className="hidden lg:inline">{t('header.help')}</span>
       </Button>
 
-      {/* Overflow: outbound links (GitHub, r/gridfinity) */}
-      <IconButton
-        ref={overflowRef}
-        size="sm"
-        aria-label={t('header.moreLinks')}
-        aria-haspopup="menu"
-        aria-expanded={overflow.open}
-        title={t('header.moreLinks')}
-        onClick={toggleOverflow}
-      >
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          {ICON_PATHS.dotsHorizontal.map((d) => (
-            <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
-          ))}
-        </svg>
-      </IconButton>
-      <Menu.Root
-        open={overflow.open}
-        onClose={() => setOverflow((previous) => ({ ...previous, open: false }))}
-        position={overflow.position}
-        align="end"
-      >
-        <Menu.Item
-          href={GITHUB_REPO_URL}
-          icon={
-            <svg fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
-              <path d={GITHUB_ICON_PATH} />
-            </svg>
-          }
-        >
-          {t('header.starOnGithubLong')}
-        </Menu.Item>
-        <Menu.Item
-          href={REDDIT_GRIDFINITY_URL}
-          onClick={handleRedditClick}
-          aria-label={t('common.redditCommunityAria')}
-          icon={
-            <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path d={REDDIT_ICON_PATH} />
-            </svg>
-          }
-        >
-          {t('common.redditCommunity')}
-        </Menu.Item>
-      </Menu.Root>
+      {overflowTrigger}
+      {overflowMenu}
 
       {/* Ko-fi support — the official Widget_2 button reproduced natively (the site's
           CSP blocks the remote ko-fi script). Accent fill via btn-primary, official


### PR DESCRIPTION
Two things the browser pass turned up that the toolbar work left behind.

## The mobile `/community` header had nothing but a tool switcher

The support cluster was hidden outright at that width, so Help, Feedback, the language selector and the outbound links were **unreachable on the one route that has no other chrome of its own**.

`HeaderSupportLinks` takes a `compact` mode: the language selector stays inline, everything else folds into the overflow it already owned. That fits beside the icon-only switcher at 390px.

```
was:  [⊞][▣][⊞][◈]
now:  [⊞][▣][⊞][◈]                              EN ▾   …
                                                        │
                                                        ├─ Send feedback
                                                        ├─ Help & shortcuts
                                                        ├─ ☆ Star on GitHub
                                                        ├─ r/gridfinity
                                                        └─ ♥ Support on Ko-fi
```

## A shelf of one card is not a shelf

The rails are about ten cards wide on a desktop window, so a single featured design rendered as a heading over ~1700px of empty row — a layout fault rather than a short list. Derived shelves now need `SHELF_MIN_CARDS` (3).

Nothing is lost by the rule: a suppressed card is still in the grid below and still reachable through the shelf's own "See all". It is the same rule the curated collections already follow — a grouping that cannot deliver on itself is dropped.

**Curated collections stay exempt.** A human chose those, and a collection of one is a deliberate pick rather than a thin derivation.

## Test plan

- `HeaderSupportLinks.test.tsx` — compact leaves only the language selector and overflow in the bar; every action is still reachable through the menu; the help event still fires from it
- `shelfData.test.ts` — a rail that cannot fill a row is dropped; the boundary cases (exactly 7 days old, proven ordering, staff-picks dedupe) rebuilt on fixtures that clear the minimum
- Full suite: 20616 passing, typecheck and lint clean
- Checked in a browser at 390 / 900 / 1024 / 1280 / 1440 / 1600

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make support actions reachable on mobile and remove thin, one-card rails in Community. Adds a compact header mode and enforces a minimum shelf size to keep the layout clean.

- **Bug Fixes**
  - Mobile `/community` header: `HeaderSupportLinks` now supports `compact`, keeping the language selector inline and moving Help, Feedback, GitHub, Reddit, and Ko-fi into the overflow menu.

- **Refactors**
  - Enforce `SHELF_MIN_CARDS` = 3 for derived shelves (staff picks, proven, new-this-week, most-remixed). Shelves that can’t fill a row are dropped; curated collections stay exempt.

<sup>Written for commit 444aade827059101cf3ab7318b4bafc205e49988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

