### PR TITLE
feat(community): mark the shelf edges that hide cards

### DIFF
--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -128,6 +128,8 @@ Note the i18n key segments are camelCase (`...reason.wellMade`) while the union 
 - **Non-live and unknown ids are skipped**, and reported as `missingIds` so a curator can tell "not published yet" from "my ids are wrong".
 - **A collection with nothing left to show is dropped.** An empty shelf advertises a grouping and then fails to deliver it, so curation never has to be undone because a design went away.
 
+Each rail marks the edges that actually hide something: `useScrollEdges` measures the scroller and the fade plus its nudge button render only against an overflowing side. A permanent gradient is the easy version and the wrong one — on a shelf that fits it implies cards that are not there, and at the true end it veils the last card behind a hint that it is not the last card. The buttons are desktop-only and out of the tab order: touch swipes, and a keyboard already scrolls the rail by focusing the cards inside it, so they would be two extra stops to nothing new.
+
 A derived shelf needs `SHELF_MIN_CARDS` (3) to render at all. The rails are about ten cards wide on a desktop window, so one or two read as a layout fault rather than a short list, and nothing is lost: a suppressed card is still in the grid below and still reachable through the shelf's own "See all". Curated collections are exempt, because a human chose those and a collection of one is a deliberate pick rather than a thin derivation.
 
 Curated shelves render above the derived ones: a human vouched for these, which is a stronger claim than any derived shelf can make. They carry a blurb (the reason the grouping exists) and no "See all", because a collection is a pick rather than a filter.

--- a/src/features/community/components/CommunityGalleryTab/ShelfLanding.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/ShelfLanding.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { CommunityCard } from '@/shared/types/community';
 import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
@@ -197,6 +197,56 @@ describe('ShelfLanding', () => {
       render(<ShelfLanding items={items} onSelect={vi.fn()} onSelectAuthor={vi.fn()} />);
 
       expect(screen.queryByTestId('community-shelf-see-all-collection-starters')).toBeNull();
+    });
+  });
+
+  describe('scroll affordance', () => {
+    function stubRail({ scrollWidth, clientWidth }: { scrollWidth: number; clientWidth: number }) {
+      // jsdom lays nothing out, so the rail has to be told it overflows.
+      Object.defineProperty(HTMLUListElement.prototype, 'scrollWidth', {
+        value: scrollWidth,
+        configurable: true,
+      });
+      Object.defineProperty(HTMLUListElement.prototype, 'clientWidth', {
+        value: clientWidth,
+        configurable: true,
+      });
+    }
+
+    afterEach(() => {
+      Reflect.deleteProperty(HTMLUListElement.prototype, 'scrollWidth');
+      Reflect.deleteProperty(HTMLUListElement.prototype, 'clientWidth');
+    });
+
+    it('offers no affordance while the rail fits', () => {
+      stubRail({ scrollWidth: 400, clientWidth: 400 });
+      render(<ShelfLanding items={manyCards(12)} onSelect={vi.fn()} onSelectAuthor={vi.fn()} />);
+      expect(screen.queryByTestId('community-shelf-fade-end')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('community-shelf-fade-start')).not.toBeInTheDocument();
+    });
+
+    it('marks only the trailing edge before the rail is scrolled', () => {
+      stubRail({ scrollWidth: 1600, clientWidth: 400 });
+      render(<ShelfLanding items={manyCards(12)} onSelect={vi.fn()} onSelectAuthor={vi.fn()} />);
+      expect(screen.getAllByTestId('community-shelf-fade-end').length).toBeGreaterThan(0);
+      expect(screen.queryByTestId('community-shelf-fade-start')).not.toBeInTheDocument();
+    });
+
+    it('scrolls the rail from its forward button', () => {
+      stubRail({ scrollWidth: 1600, clientWidth: 400 });
+      const scrollBy = vi.fn();
+      Object.defineProperty(HTMLUListElement.prototype, 'scrollBy', {
+        value: scrollBy,
+        configurable: true,
+      });
+
+      render(<ShelfLanding items={manyCards(12)} onSelect={vi.fn()} onSelectAuthor={vi.fn()} />);
+      fireEvent.click(screen.getAllByRole('button', { name: /scrollForward/ })[0]);
+
+      expect(scrollBy).toHaveBeenCalledWith(
+        expect.objectContaining({ left: expect.any(Number), behavior: 'smooth' })
+      );
+      Reflect.deleteProperty(HTMLUListElement.prototype, 'scrollBy');
     });
   });
 });

--- a/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
+++ b/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo } from 'react';
-import { Button } from '@/design-system';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Button, IconButton, cn } from '@/design-system';
+import { ChevronDownIcon } from '@/design-system/Icon';
 import { useTranslation } from '@/i18n';
 import type { CommunityCard as CommunityCardData } from '@/shared/types/community';
 import { useBrowseStore } from '../../store/browseStore';
@@ -8,6 +9,7 @@ import type { ShelfId } from './shelfData';
 import { COMMUNITY_COLLECTIONS } from '../../data/collections';
 import { resolveCollections } from '../../utils/resolveCollections';
 import { buildShelves } from './shelfData';
+import { useScrollEdges } from './useScrollEdges';
 
 const SHELF_TITLE_KEYS: Record<ShelfId, string> = {
   'staff-picks': 'community.shelves.staffPicks',
@@ -110,8 +112,23 @@ interface RailProps {
   onSeeAll?: () => void;
 }
 
+/** One nudge moves most of a rail without overshooting what you were reading. */
+const RAIL_SCROLL_FRACTION = 0.8;
+
 function Rail({ id, title, blurb, cards, onSelect, onSelectAuthor, onSeeAll }: RailProps) {
   const t = useTranslation();
+  const railRef = useRef<HTMLUListElement>(null);
+  const { atStart, atEnd } = useScrollEdges(railRef, cards.length);
+
+  const nudge = useCallback((direction: -1 | 1) => {
+    const rail = railRef.current;
+    if (!rail) return;
+    rail.scrollBy({
+      left: direction * rail.clientWidth * RAIL_SCROLL_FRACTION,
+      behavior: 'smooth',
+    });
+  }, []);
+
   return (
     <section aria-labelledby={`community-shelf-${id}`}>
       <div className="flex items-center justify-between gap-2">
@@ -136,26 +153,95 @@ function Rail({ id, title, blurb, cards, onSelect, onSelectAuthor, onSeeAll }: R
 
       {blurb !== undefined && <p className="mb-1 text-xs text-content-secondary">{blurb}</p>}
 
-      {/* motion-reduce disables the snap yank outright, not just the timing:
-          scroll-snap can still animate into place without scroll-behavior. */}
-      {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
-      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-      <ul
-        role="list"
-        aria-label={title}
-        className="flex list-none snap-x snap-mandatory gap-3 overflow-x-auto pb-2 motion-reduce:snap-none motion-reduce:scroll-auto"
-      >
-        {cards.map((card, index) => (
-          <li key={card.id} className="w-40 shrink-0 snap-start sm:w-44">
-            <CommunityCard
-              card={card}
-              onSelect={onSelect}
-              onSelectAuthor={onSelectAuthor}
-              index={index}
-            />
-          </li>
-        ))}
-      </ul>
+      {/* The fades and the buttons render only against an edge that actually
+          hides something. A permanent gradient implies cards that are not
+          there, and at the true end it veils the last card behind a hint that
+          it is not the last card. */}
+      <div className="relative">
+        {/* motion-reduce disables the snap yank outright, not just the timing:
+            scroll-snap can still animate into place without scroll-behavior. */}
+        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- role="list" restores the list semantics Safari/iOS VoiceOver strips once list-style:none is applied. */}
+        <ul
+          ref={railRef}
+          role="list"
+          aria-label={title}
+          className="flex list-none snap-x snap-mandatory gap-3 overflow-x-auto pb-2 motion-reduce:snap-none motion-reduce:scroll-auto"
+        >
+          {cards.map((card, index) => (
+            <li key={card.id} className="w-40 shrink-0 snap-start sm:w-44">
+              <CommunityCard
+                card={card}
+                onSelect={onSelect}
+                onSelectAuthor={onSelectAuthor}
+                index={index}
+              />
+            </li>
+          ))}
+        </ul>
+
+        {atStart && <RailFade side="start" />}
+        {atEnd && <RailFade side="end" />}
+
+        {/* Touch scrolls by swiping and shows a scrollbar while it does; a
+            mouse gets neither, and many have no horizontal wheel at all. */}
+        {atStart && (
+          <RailButton
+            side="start"
+            label={t('community.shelves.scrollBack', { shelf: title })}
+            onClick={() => nudge(-1)}
+          />
+        )}
+        {atEnd && (
+          <RailButton
+            side="end"
+            label={t('community.shelves.scrollForward', { shelf: title })}
+            onClick={() => nudge(1)}
+          />
+        )}
+      </div>
     </section>
+  );
+}
+
+function RailFade({ side }: { side: 'start' | 'end' }) {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid={`community-shelf-fade-${side}`}
+      className={cn(
+        'pointer-events-none absolute inset-y-0 w-12',
+        side === 'start'
+          ? 'left-0 bg-gradient-to-r from-surface to-transparent'
+          : 'right-0 bg-gradient-to-l from-surface to-transparent'
+      )}
+    />
+  );
+}
+
+interface RailButtonProps {
+  side: 'start' | 'end';
+  label: string;
+  onClick: () => void;
+}
+
+function RailButton({ side, label, onClick }: RailButtonProps) {
+  return (
+    <IconButton
+      size="sm"
+      aria-label={label}
+      onClick={onClick}
+      // Hidden from touch, where the swipe is the affordance, and hidden from
+      // the tab order: keyboard users already scroll the rail by focusing the
+      // cards inside it, so these would be two extra stops to nothing new.
+      tabIndex={-1}
+      className={cn(
+        'absolute top-1/2 hidden -translate-y-1/2 border border-stroke-subtle bg-surface-elevated shadow-md md:flex',
+        side === 'start' ? 'left-1' : 'right-1'
+      )}
+    >
+      {/* Rotated rather than two more icons in the set; the chevron's own
+          docs sanction it for directional variants. */}
+      <ChevronDownIcon size="sm" className={side === 'start' ? 'rotate-90' : '-rotate-90'} />
+    </IconButton>
   );
 }

--- a/src/features/community/components/CommunityGalleryTab/useScrollEdges.test.ts
+++ b/src/features/community/components/CommunityGalleryTab/useScrollEdges.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useScrollEdges } from './useScrollEdges';
+
+function scroller({
+  scrollWidth,
+  clientWidth,
+  scrollLeft = 0,
+}: {
+  scrollWidth: number;
+  clientWidth: number;
+  scrollLeft?: number;
+}): HTMLDivElement {
+  const element = document.createElement('div');
+  // jsdom lays nothing out, so the three numbers the hook reads are stubbed.
+  Object.defineProperty(element, 'scrollWidth', { value: scrollWidth, configurable: true });
+  Object.defineProperty(element, 'clientWidth', { value: clientWidth, configurable: true });
+  Object.defineProperty(element, 'scrollLeft', {
+    value: scrollLeft,
+    writable: true,
+    configurable: true,
+  });
+  document.body.appendChild(element);
+  return element;
+}
+
+function edgesOf(element: HTMLDivElement) {
+  return renderHook(() => useScrollEdges({ current: element }));
+}
+
+describe('useScrollEdges', () => {
+  it('reports no edges when the content fits', () => {
+    const { result } = edgesOf(scroller({ scrollWidth: 400, clientWidth: 400 }));
+    expect(result.current).toEqual({ atStart: false, atEnd: false });
+  });
+
+  it('reports a trailing edge at the start of an overflowing scroller', () => {
+    const { result } = edgesOf(scroller({ scrollWidth: 1200, clientWidth: 400 }));
+    expect(result.current).toEqual({ atStart: false, atEnd: true });
+  });
+
+  it('reports both edges mid-scroll', () => {
+    const element = scroller({ scrollWidth: 1200, clientWidth: 400, scrollLeft: 400 });
+    const { result } = edgesOf(element);
+    expect(result.current).toEqual({ atStart: true, atEnd: true });
+  });
+
+  it('drops the trailing edge once scrolled to the end', () => {
+    const element = scroller({ scrollWidth: 1200, clientWidth: 400, scrollLeft: 800 });
+    const { result } = edgesOf(element);
+    expect(result.current).toEqual({ atStart: true, atEnd: false });
+  });
+
+  it('tolerates a fractional offset at the true end', () => {
+    // A hair short of the end must not strand a fade over nothing.
+    const element = scroller({ scrollWidth: 1200, clientWidth: 400, scrollLeft: 799.4 });
+    const { result } = edgesOf(element);
+    expect(result.current.atEnd).toBe(false);
+  });
+
+  it('re-measures on scroll', () => {
+    const element = scroller({ scrollWidth: 1200, clientWidth: 400 });
+    const { result } = edgesOf(element);
+    expect(result.current.atStart).toBe(false);
+
+    act(() => {
+      element.scrollLeft = 500;
+      element.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.atStart).toBe(true);
+  });
+
+  it('reads a negative RTL offset as distance travelled', () => {
+    const element = scroller({ scrollWidth: 1200, clientWidth: 400, scrollLeft: -400 });
+    const { result } = edgesOf(element);
+    expect(result.current.atStart).toBe(true);
+  });
+
+  it('stays inert without an element', () => {
+    const { result } = renderHook(() => useScrollEdges({ current: null }));
+    expect(result.current).toEqual({ atStart: false, atEnd: false });
+  });
+});

--- a/src/features/community/components/CommunityGalleryTab/useScrollEdges.ts
+++ b/src/features/community/components/CommunityGalleryTab/useScrollEdges.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { RefObject } from 'react';
+
+export interface ScrollEdges {
+  /** Content is hidden off the leading edge. */
+  readonly atStart: boolean;
+  /** Content is hidden off the trailing edge. */
+  readonly atEnd: boolean;
+}
+
+/**
+ * Sub-pixel slack. Fractional scroll offsets (zoom, trackpad momentum, RTL)
+ * leave `scrollLeft + clientWidth` a hair short of `scrollWidth` at the true
+ * end, which would strand a fade over nothing.
+ */
+const EPSILON = 2;
+
+function measure(element: HTMLElement): ScrollEdges {
+  // `Math.abs` so this reads the same under RTL, where scrollLeft is negative.
+  const offset = Math.abs(element.scrollLeft);
+  return {
+    atStart: offset > EPSILON,
+    atEnd: offset + element.clientWidth < element.scrollWidth - EPSILON,
+  };
+}
+
+/**
+ * Which edges of a horizontal scroller currently hide content.
+ *
+ * Drives the fades on the shelf rails. A permanent gradient is the easy
+ * version and the wrong one: on a shelf that fits, it implies cards that are
+ * not there, and at the true end it hides the last card behind a hint that it
+ * is not the last card.
+ *
+ * `revision` re-measures when the content changes without the box resizing —
+ * a rail swapping to a different shelf's cards keeps its dimensions.
+ */
+export function useScrollEdges(
+  ref: RefObject<HTMLElement | null>,
+  revision?: unknown
+): ScrollEdges {
+  const [edges, setEdges] = useState<ScrollEdges>({ atStart: false, atEnd: false });
+
+  const sync = useCallback(() => {
+    const element = ref.current;
+    if (!element) return;
+    const next = measure(element);
+    // Bail on an unchanged result: this runs on every scroll event.
+    setEdges((previous) =>
+      previous.atStart === next.atStart && previous.atEnd === next.atEnd ? previous : next
+    );
+  }, [ref]);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    sync();
+    element.addEventListener('scroll', sync, { passive: true });
+
+    const observer = new ResizeObserver(sync);
+    observer.observe(element);
+
+    return () => {
+      element.removeEventListener('scroll', sync);
+      observer.disconnect();
+    };
+  }, [ref, sync, revision]);
+
+  return edges;
+}

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "Š",
   "community.gallery.depthAbbrev": "H",
   "community.gallery.heightAbbrev": "V",
-  "community.shelves.seeAllAria": "Zobrazit vše: {shelf}"
+  "community.shelves.seeAllAria": "Zobrazit vše: {shelf}",
+  "community.shelves.scrollBack": "Posunout {shelf} zpět",
+  "community.shelves.scrollForward": "Posunout {shelf} vpřed"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "B",
   "community.gallery.depthAbbrev": "T",
   "community.gallery.heightAbbrev": "H",
-  "community.shelves.seeAllAria": "Alle anzeigen: {shelf}"
+  "community.shelves.seeAllAria": "Alle anzeigen: {shelf}",
+  "community.shelves.scrollBack": "{shelf} zurückscrollen",
+  "community.shelves.scrollForward": "{shelf} vorwärtsscrollen"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3498,6 +3498,8 @@ const en: Record<string, string> = {
   'community.shelves.mostRemixed': 'Most remixed',
   'community.shelves.seeAll': 'See all',
   'community.shelves.seeAllAria': 'See all: {shelf}',
+  'community.shelves.scrollBack': 'Scroll {shelf} back',
+  'community.shelves.scrollForward': 'Scroll {shelf} forward',
   'community.authorFilterAria': 'See all designs by {author}',
   'community.card.byAuthor': 'by {author}',
   'community.card.likesLabel': '{count} likes',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "An",
   "community.gallery.depthAbbrev": "P",
   "community.gallery.heightAbbrev": "Al",
-  "community.shelves.seeAllAria": "Ver todo: {shelf}"
+  "community.shelves.seeAllAria": "Ver todo: {shelf}",
+  "community.shelves.scrollBack": "Desplazar {shelf} hacia atrás",
+  "community.shelves.scrollForward": "Desplazar {shelf} hacia adelante"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "L",
   "community.gallery.depthAbbrev": "P",
   "community.gallery.heightAbbrev": "H",
-  "community.shelves.seeAllAria": "Tout voir : {shelf}"
+  "community.shelves.seeAllAria": "Tout voir : {shelf}",
+  "community.shelves.scrollBack": "Faire défiler {shelf} vers l’arrière",
+  "community.shelves.scrollForward": "Faire défiler {shelf} vers l’avant"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "L",
   "community.gallery.depthAbbrev": "P",
   "community.gallery.heightAbbrev": "A",
-  "community.shelves.seeAllAria": "Vedi tutto: {shelf}"
+  "community.shelves.seeAllAria": "Vedi tutto: {shelf}",
+  "community.shelves.scrollBack": "Scorri {shelf} indietro",
+  "community.shelves.scrollForward": "Scorri {shelf} avanti"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "幅",
   "community.gallery.depthAbbrev": "奥",
   "community.gallery.heightAbbrev": "高",
-  "community.shelves.seeAllAria": "すべて表示：{shelf}"
+  "community.shelves.seeAllAria": "すべて表示：{shelf}",
+  "community.shelves.scrollBack": "{shelf} を前にスクロール",
+  "community.shelves.scrollForward": "{shelf} を次にスクロール"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "너비",
   "community.gallery.depthAbbrev": "깊이",
   "community.gallery.heightAbbrev": "높이",
-  "community.shelves.seeAllAria": "모두 보기: {shelf}"
+  "community.shelves.seeAllAria": "모두 보기: {shelf}",
+  "community.shelves.scrollBack": "{shelf} 이전으로 스크롤",
+  "community.shelves.scrollForward": "{shelf} 다음으로 스크롤"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "B",
   "community.gallery.depthAbbrev": "D",
   "community.gallery.heightAbbrev": "H",
-  "community.shelves.seeAllAria": "Se alle: {shelf}"
+  "community.shelves.seeAllAria": "Se alle: {shelf}",
+  "community.shelves.scrollBack": "Bla {shelf} bakover",
+  "community.shelves.scrollForward": "Bla {shelf} forover"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "B",
   "community.gallery.depthAbbrev": "D",
   "community.gallery.heightAbbrev": "H",
-  "community.shelves.seeAllAria": "Alles bekijken: {shelf}"
+  "community.shelves.seeAllAria": "Alles bekijken: {shelf}",
+  "community.shelves.scrollBack": "{shelf} terugscrollen",
+  "community.shelves.scrollForward": "{shelf} vooruitscrollen"
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "S",
   "community.gallery.depthAbbrev": "G",
   "community.gallery.heightAbbrev": "W",
-  "community.shelves.seeAllAria": "Zobacz wszystko: {shelf}"
+  "community.shelves.seeAllAria": "Zobacz wszystko: {shelf}",
+  "community.shelves.scrollBack": "Przewiń {shelf} wstecz",
+  "community.shelves.scrollForward": "Przewiń {shelf} do przodu"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "L",
   "community.gallery.depthAbbrev": "P",
   "community.gallery.heightAbbrev": "A",
-  "community.shelves.seeAllAria": "Ver tudo: {shelf}"
+  "community.shelves.seeAllAria": "Ver tudo: {shelf}",
+  "community.shelves.scrollBack": "Rolar {shelf} para trás",
+  "community.shelves.scrollForward": "Rolar {shelf} para frente"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "B",
   "community.gallery.depthAbbrev": "D",
   "community.gallery.heightAbbrev": "H",
-  "community.shelves.seeAllAria": "Se alla: {shelf}"
+  "community.shelves.seeAllAria": "Se alla: {shelf}",
+  "community.shelves.scrollBack": "Bläddra {shelf} bakåt",
+  "community.shelves.scrollForward": "Bläddra {shelf} framåt"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "Ш",
   "community.gallery.depthAbbrev": "Г",
   "community.gallery.heightAbbrev": "В",
-  "community.shelves.seeAllAria": "Переглянути всі: {shelf}"
+  "community.shelves.seeAllAria": "Переглянути всі: {shelf}",
+  "community.shelves.scrollBack": "Прокрутити {shelf} назад",
+  "community.shelves.scrollForward": "Прокрутити {shelf} вперед"
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3578,5 +3578,7 @@
   "community.gallery.widthAbbrev": "宽",
   "community.gallery.depthAbbrev": "深",
   "community.gallery.heightAbbrev": "高",
-  "community.shelves.seeAllAria": "查看全部：{shelf}"
+  "community.shelves.seeAllAria": "查看全部：{shelf}",
+  "community.shelves.scrollBack": "向前滚动{shelf}",
+  "community.shelves.scrollForward": "向后滚动{shelf}"
 }


### PR DESCRIPTION
## Why

A rail wider than the window clipped its last card at the viewport edge with nothing to say it scrolled. Touch finds it by swiping; a mouse gets no scrollbar until it moves, and many have no horizontal wheel at all.

## What

Each rail marks the edges that **actually** hide something. `useScrollEdges` measures the scroller, and a fade plus a nudge button render only against an overflowing side.

```
fits (3 cards):   [card][card][card]                      no fade, no buttons
at the start:     [card][card][card][card][car▓  ›        trailing only
mid-scroll:    ‹  ▓rd][card][card][card][card][car▓  ›     both
at the end:    ‹  ▓rd][card][card][card][card]            leading only
```

A permanent gradient is the easy version and the wrong one: on a shelf that fits it implies cards that are not there, and at the true end it veils the last card behind a hint that it is not the last card.

It re-measures on scroll, on resize, and when the card count changes — a rail swapping to another shelf's cards keeps its own dimensions, so a size observer alone would miss it.

## Details worth the review

**The buttons are desktop-only and out of the tab order.** Touch has the swipe, and a keyboard already scrolls the rail by focusing the cards inside it, so these would be two extra stops to nothing new.

**A 2px epsilon on the end test.** Fractional offsets from zoom, trackpad momentum and RTL leave `scrollLeft + clientWidth` a hair short of `scrollWidth` at the true end, which would strand a fade over nothing. `Math.abs` on the offset so it reads the same under RTL, where `scrollLeft` is negative.

**The chevron is rotated, not two new icons.** `ChevronDownIcon`'s own docs sanction rotation for directional variants.

## Test plan

- New `useScrollEdges.test.ts` — fits / at start / mid-scroll / at end, the fractional-end tolerance, re-measuring on scroll, negative RTL offsets, and no element
- `ShelfLanding.test.tsx` — no affordance while the rail fits, trailing-only before scrolling, and the forward button scrolls the rail
- Full suite: 20627 passing, typecheck and lint clean
- Verified in a browser: forward button + trailing fade at rest, back button + leading fade after nudging, and a 3-card Staff picks shelf gets neither

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks shelf rails with fades and desktop nudge buttons only when cards overflow, making horizontal scroll obvious and easier for mouse users. Uses `useScrollEdges` to detect edges and handle RTL and fractional offsets.

- **New Features**
  - Added `useScrollEdges` to measure rails and re-measure on scroll, resize, and card count changes; includes a 2px epsilon and reads negative RTL offsets.
  - Render fades and chevron buttons only on overflowing sides; buttons are desktop-only and removed from the tab order.
  - Nudge scroll moves 80% of the rail width smoothly.
  - Added tests for the hook and rail affordance, plus i18n strings for scroll labels.

<sup>Written for commit 005fa46904ae65abb3bbb10985a239c9bdcc2135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

