### PR TITLE
fix(community): hide the filter rail when there is nothing to narrow

### DIFF
--- a/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.test.tsx
@@ -162,6 +162,24 @@ describe('CommunityGalleryTab', () => {
     window.removeEventListener('switch-to-designer', dispatched);
   });
 
+  it('leaves the empty state to stand alone, with no rail of dead filters beside it', async () => {
+    indexMock.mockResolvedValue(ok({ items: [], capped: false }));
+    render(<CommunityGalleryTab onRequestClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('community.gallery.empty.title')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('community-filter-rail')).toBeNull();
+    expect(screen.queryByTestId('community-filter-button')).toBeNull();
+  });
+
+  it('brings the rail back as soon as there is something to narrow', async () => {
+    indexMock.mockResolvedValue(ok({ items: [card('a')], capped: false }));
+    render(<CommunityGalleryTab onRequestClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('community-filter-rail')).toBeInTheDocument();
+    });
+  });
+
   it('adapts the empty-state CTA when local designs exist and opens the publish flow', async () => {
     localStorage.setItem('gridfinity-designer-active-v1', 'design-id');
     indexMock.mockResolvedValue(ok({ items: [], capped: false }));
@@ -464,6 +482,26 @@ describe('CommunityGalleryTab Mine view', () => {
     fireEvent.click(screen.getByTestId('community-mine-empty-cta'));
     expect(onRequestClose).toHaveBeenCalled();
     expect(onRequestPublish).toHaveBeenCalled();
+  });
+
+  // The Mine toggle lives inside the rail, so hiding the rail over an empty
+  // Mine view would strand the visitor in it. The chip row is what the rail
+  // hands the exit back to.
+  it('keeps a way out of an empty Mine view once the rail is gone', async () => {
+    indexMock.mockResolvedValue(ok({ items: [card('public000001')], capped: false }));
+    mineIndexMock.mockResolvedValue(ok({ items: [], capped: false }));
+    activateMine();
+    render(<CommunityGalleryTab onRequestClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('community.gallery.mineEmpty.title')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('community-filter-rail')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'community.gallery.clearNamedFilter' }));
+    expect(useBrowseStore.getState().filters.mineOnly).toBe(false);
+    await waitFor(() => {
+      expect(screen.getByTestId('community-filter-rail')).toBeInTheDocument();
+    });
   });
 
   it('falls back to the public grid when the session signs out mid-visit', async () => {

--- a/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
@@ -200,7 +200,13 @@ export function CommunityGalleryTab({
   // The mobile filter view unmounts the grid, so returning from it lands on a
   // fresh scroll container. The offset was banked by handleTogglePanel while
   // the old one was still on screen.
-  const mobileFiltersOpen = isMobile && filterPanel.open;
+  // Nothing loaded means nothing to narrow, and every control in the panel
+  // would be a dead one: all counts zero, every category and technique
+  // disabled, every size axis with an empty window. The empty state stands on
+  // its own instead.
+  const filtersAvailable = activeItems.length > 0;
+  const panelOpen = filterPanel.open && filtersAvailable;
+  const mobileFiltersOpen = isMobile && panelOpen;
   useEffect(() => {
     if (mobileFiltersOpen) return;
     const el = scrollRef.current;
@@ -356,13 +362,14 @@ export function CommunityGalleryTab({
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="community-gallery-tab">
       <GalleryToolbar
-        panelOpen={filterPanel.open}
+        panelOpen={panelOpen}
+        filtersAvailable={filtersAvailable}
         onTogglePanel={handleTogglePanel}
         activeFilterCount={countPanelFilters(filters)}
       />
 
       <div className="flex min-h-0 flex-1">
-        {filterPanel.open && (
+        {panelOpen && (
           <FilterRail
             items={activeItems}
             counts={facetCounts}

--- a/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
@@ -69,7 +69,6 @@ export function CommunityGalleryTab({
 }: CommunityGalleryTabProps) {
   const t = useTranslation();
   const { isMobile } = useResponsive();
-  const filterPanel = useFilterPanel(isMobile);
 
   const { status, items, capped, error, filters, fitsGapContext, visibleCount } = useBrowseStore(
     useShallow((s) => ({
@@ -197,16 +196,18 @@ export function CommunityGalleryTab({
     };
   }, []);
 
-  // The mobile filter view unmounts the grid, so returning from it lands on a
-  // fresh scroll container. The offset was banked by handleTogglePanel while
-  // the old one was still on screen.
   // Nothing loaded means nothing to narrow, and every control in the panel
   // would be a dead one: all counts zero, every category and technique
   // disabled, every size axis with an empty window. The empty state stands on
   // its own instead.
   const filtersAvailable = activeItems.length > 0;
-  const panelOpen = filterPanel.open && filtersAvailable;
+  const filterPanel = useFilterPanel(isMobile, filtersAvailable);
+  const panelOpen = filterPanel.open;
   const mobileFiltersOpen = isMobile && panelOpen;
+
+  // The mobile filter view unmounts the grid, so returning from it lands on a
+  // fresh scroll container. The offset was banked by handleTogglePanel while
+  // the old one was still on screen.
   useEffect(() => {
     if (mobileFiltersOpen) return;
     const el = scrollRef.current;

--- a/src/features/community/components/CommunityGalleryTab/GalleryToolbar.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/GalleryToolbar.test.tsx
@@ -75,6 +75,11 @@ describe('GalleryToolbar', () => {
     expect(screen.getByTestId('community-filter-button')).toBeInTheDocument();
   });
 
+  it('drops the toggle when there is nothing to narrow', () => {
+    renderToolbar({ filtersAvailable: false });
+    expect(screen.queryByTestId('community-filter-button')).toBeNull();
+  });
+
   it('badges the toggle with the active filter count', () => {
     renderToolbar({ activeFilterCount: 3 });
     expect(screen.getByTestId('community-filter-button')).toHaveTextContent('3');

--- a/src/features/community/components/CommunityGalleryTab/GalleryToolbar.tsx
+++ b/src/features/community/components/CommunityGalleryTab/GalleryToolbar.tsx
@@ -20,12 +20,18 @@ import { browseSortOptions, isBrowseSort } from './galleryFilterOptions';
 export interface GalleryToolbarProps {
   /** Whether the filter surface (desktop rail or mobile view) is showing. */
   panelOpen: boolean;
+  /**
+   * Whether there is anything to narrow. False over an empty index, where the
+   * panel would be nothing but disabled controls.
+   */
+  filtersAvailable?: boolean;
   onTogglePanel: () => void;
   activeFilterCount: number;
 }
 
 export function GalleryToolbar({
   panelOpen,
+  filtersAvailable = true,
   onTogglePanel,
   activeFilterCount,
 }: GalleryToolbarProps) {
@@ -183,7 +189,7 @@ export function GalleryToolbar({
       <div className="flex items-center gap-2">
         {/* An open rail carries its own collapse control in its header, so a
             second one here would sit two inches away doing the same thing. */}
-        {(isMobile || !panelOpen) && (
+        {filtersAvailable && (isMobile || !panelOpen) && (
           <Button
             variant="secondary"
             onClick={onTogglePanel}

--- a/src/features/community/components/CommunityGalleryTab/useFilterPanel.test.ts
+++ b/src/features/community/components/CommunityGalleryTab/useFilterPanel.test.ts
@@ -52,6 +52,35 @@ describe('useFilterPanel on desktop', () => {
   });
 });
 
+describe('useFilterPanel when there is nothing to narrow', () => {
+  it('reports closed without disturbing the rail preference', () => {
+    const { result, rerender } = renderHook(({ available }) => useFilterPanel(false, available), {
+      initialProps: { available: true },
+    });
+    expect(result.current.open).toBe(true);
+    rerender({ available: false });
+    expect(result.current.open).toBe(false);
+    // The rail is a layout preference, so it comes back on its own once there
+    // are cards again.
+    rerender({ available: true });
+    expect(result.current.open).toBe(true);
+  });
+
+  it('does not let the mobile view reopen on its own when filters return', () => {
+    const { result, rerender } = renderHook(({ available }) => useFilterPanel(true, available), {
+      initialProps: { available: true },
+    });
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(true);
+    // Narrowing to an empty set (an owner with nothing published) drops the
+    // view; clearing that filter must not throw the visitor back into it.
+    rerender({ available: false });
+    expect(result.current.open).toBe(false);
+    rerender({ available: true });
+    expect(result.current.open).toBe(false);
+  });
+});
+
 describe('useFilterPanel on mobile', () => {
   it('starts closed regardless of the stored rail preference', () => {
     localStorage.setItem('gridfinity-community-filter-rail-v1', 'open');

--- a/src/features/community/components/CommunityGalleryTab/useFilterPanel.ts
+++ b/src/features/community/components/CommunityGalleryTab/useFilterPanel.ts
@@ -34,16 +34,22 @@ export interface FilterPanelState {
  *
  * They are tracked separately so resizing across the breakpoint mid-session
  * cannot leak one into the other.
+ *
+ * `filtersAvailable` is false when there is nothing to narrow. It gates the
+ * surface without touching the rail preference, so the rail returns on its own
+ * once cards load — while the mobile view, being a full takeover, does not.
  */
-export function useFilterPanel(isMobile: boolean): FilterPanelState {
+export function useFilterPanel(isMobile: boolean, filtersAvailable = true): FilterPanelState {
   const [railOpen, setRailOpen] = useState(loadRailOpen);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [lastIsMobile, setLastIsMobile] = useState(isMobile);
+  const [lastAvailable, setLastAvailable] = useState(filtersAvailable);
 
-  // Leaving mobile ends the mobile view for good. Left standing, it would
-  // reopen on the way back to mobile width and take the whole grid over
-  // unprompted — a rail quietly reappearing is recoverable, a full-screen
-  // takeover nobody asked for is not.
+  // Both resets kill the mobile view for the same reason: it would otherwise
+  // reappear on its own — on the way back to mobile width, or the moment
+  // filters become available again — and seize the whole grid unprompted. A
+  // rail quietly reappearing is recoverable; a full-screen takeover nobody
+  // asked for is not.
   //
   // Adjusted during render rather than in an effect: React re-runs this
   // component before committing, so the stale value never reaches the DOM and
@@ -51,6 +57,10 @@ export function useFilterPanel(isMobile: boolean): FilterPanelState {
   if (lastIsMobile !== isMobile) {
     setLastIsMobile(isMobile);
     if (!isMobile) setMobileOpen(false);
+  }
+  if (lastAvailable !== filtersAvailable) {
+    setLastAvailable(filtersAvailable);
+    if (!filtersAvailable) setMobileOpen(false);
   }
 
   const toggle = useCallback(() => {
@@ -73,5 +83,5 @@ export function useFilterPanel(isMobile: boolean): FilterPanelState {
     saveRailOpen(false);
   }, [isMobile]);
 
-  return { open: isMobile ? mobileOpen : railOpen, toggle, close };
+  return { open: filtersAvailable && (isMobile ? mobileOpen : railOpen), toggle, close };
 }


### PR DESCRIPTION
Follow-up to #3264.

`FilterRail` rendered on its open state alone, with no check that there was anything to filter. Against an empty index that means every control in it is dead — all eight categories disabled at 0, all ten technique pills disabled, all three size sliders disabled on null windows, every show-toggle at 0 — sitting in a 240px column next to "No community designs yet".

The public index is empty today (`/api/community` returns `{"items":[],"nextCursor":null,"likedIds":[]}` with a 200), so this is exactly what the live gallery shows. The old filter sheet hid all of it behind a button, so an empty gallery just showed the empty state.

## Change

The rail and the toolbar's filter toggle now require at least one loaded card. Neither the empty state nor the initial-load skeletons get a column of disabled controls beside them.

The chip row is deliberately left alone, and that matters for one case: the Mine toggle lives *inside* the rail, so an owner with nothing published would be stranded in an empty Mine view with no control to leave it. Because chips render whenever the panel is not showing, the Mine chip appears and clears it. There is a test for that exact round trip.

## Why the original tests missed it

Every unit test was fixture-backed and every browser check ran against 60 stubbed cards, so nothing exercised the one state production is actually in.

## Verification

- 20,719 unit tests pass; typecheck clean; 0 lint errors
- New coverage: rail and toggle absent over an empty index, rail returns once cards load, and the empty-Mine escape hatch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the filter rail and toolbar toggle when there’s nothing to narrow. Also prevent the mobile filter view from reopening by itself when filters return.

- **Bug Fixes**
  - Gate panel visibility inside `useFilterPanel`; clear the mobile state when nothing is available while leaving the desktop rail preference intact.
  - Hide the filter toggle in the toolbar unless at least one card is loaded.
  - Keep chips visible so users can clear the “Mine” filter when the rail is hidden.
  - Add tests for empty index, rail returning after items load, the empty-Mine escape, and the mobile view not auto-reopening.

<sup>Written for commit fe0bdee74bd7c0c7abcbdd138884e318076928d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

