### PR TITLE
test(community): stop losing the reconnect event instead of widening the wait

### DIFF
--- a/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
@@ -217,15 +217,27 @@ describe('CommunityDetail', () => {
     openDetail();
     renderDetail();
     expect(await screen.findByText('You appear to be offline')).toBeInTheDocument();
-    fetchMock.mockResolvedValueOnce(ok(detail()));
+    fetchMock.mockResolvedValue(ok(detail()));
     Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true });
-    fireEvent(window, new Event('online'));
-    // Two full fetch-and-render cycles of the whole detail tree (viewer,
-    // prints, cost panel, lineage), so the wait is sized to that rather than
-    // to a single request. It has twice tripped the old 5s cap on loaded CI
-    // runners while passing consistently in isolation.
-    expect(await screen.findByText('by Jo', undefined, { timeout: 15000 })).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // `useRetryOnReconnect` attaches its 'online' listener from a passive
+    // effect, which React flushes after the commit that put the offline copy on
+    // screen. A dispatch that lands before that flush is simply dropped, and
+    // nothing re-arms it: the load never retries and the wait burns its entire
+    // budget with the error copy still up. That is why raising the cap (5s, then
+    // 15s) never helped — the test wasn't slow, it was waiting for an event that
+    // had already been thrown away. Dispatch until the reload is observed
+    // instead of betting on the interleaving; a browser is free to fire 'online'
+    // repeatedly, so this is also the more faithful simulation.
+    await waitFor(
+      () => {
+        fireEvent(window, new Event('online'));
+        expect(screen.getByText('by Jo')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+    // At least two, not exactly two: a retry dispatched while the reload was
+    // already in flight legitimately adds a call.
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('shows an error state with a retry that refetches', async () => {

--- a/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.test.tsx
@@ -230,7 +230,12 @@ describe('CommunityDetail', () => {
     // repeatedly, so this is also the more faithful simulation.
     await waitFor(
       () => {
-        fireEvent(window, new Event('online'));
+        // Only while the reload hasn't landed: dispatching on the winning pass
+        // too could bump `attempt` once more in the window before the listener
+        // is torn down, stranding a fetch that resolves after the test ends.
+        if (screen.queryByText('by Jo') === null) {
+          fireEvent(window, new Event('online'));
+        }
         expect(screen.getByText('by Jo')).toBeInTheDocument();
       },
       { timeout: 5000 }


### PR DESCRIPTION
`CommunityDetail > shows offline copy … auto-retries on reconnect` has been failing intermittently on CI. It blocked #3270 (a docs-only PR), and its own comment records the timeout already being raised from 5s to 15s after two earlier trips.

## It was never slow

`useRetryOnReconnect` attaches its `online` listener from a passive effect, which React flushes **after** the commit that puts the offline copy on screen. The test awaited that copy and then dispatched `online` once. A dispatch landing before the flush is dropped, and nothing re-arms it — so the load never retries, the component sits in `phase === 'error'`, and the wait burns its entire budget with the offline copy still up. That is precisely the DOM the failing CI job dumped.

That also explains why raising the cap never helped: the test wasn't running out of time, it was waiting on an event that had already been thrown away.

## Evidence

Measured before changing anything, since "loaded CI runner" was the standing theory:

| Check | Result |
| --- | --- |
| Full file, locally | 40/40, 2s |
| Single test, isolated, ×12 | 12/12 pass |
| Full file with all 32 cores saturated, ×6 | 6/6 pass |
| Pinned to 2 cores, ×5 / 1 contended core, ×4 | all pass |
| 60 iterations of the scenario in one run | 60/60 pass |
| **Single test on one pinned core** | **79ms, against a 15000ms budget** |

190x headroom rules out slowness — no runner is 190x slower than one core here. The only way to consume the full budget is a lost trigger.

I also instrumented `addEventListener` to count how often the listener was still unregistered when `findByText` resolved: 0/30 on this hardware, which is consistent with a race that only opens on a slower box, and is why this reproduces on CI and not locally.

**Direct proof of the mechanism.** Deferring the real `online` registration by 300ms:

- old single-dispatch pattern → times out, exactly as on CI
- new pattern → recovers in ~330ms

The fixed test then passes that same adversarial interleaving (386ms), plus 8/8 on a single pinned core.

## The fix

Dispatch `online` until the reload is observed, rather than betting on the interleaving. This is also the more faithful simulation: a browser may fire `online` repeatedly, and the component has to tolerate that.

**Trade-off, stated plainly:** the call-count assertion relaxes from `toHaveBeenCalledTimes(2)` to `>= 2`, because a retry dispatched while the reload is already in flight legitimately adds a call. Pinning the exact count is what forced the fragile single dispatch. The 15s cap is gone; the wait is now 5s and normally settles in well under 100ms.

Full suite: 20764 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky CommunityDetail reconnect test by firing `online` until the reload is observed, instead of relying on a single event that could be dropped. The timeout is reduced to 5s and the fetch call assertion is relaxed to keep the test stable on CI.

- **Bug Fixes**
  - Addressed a race where `useRetryOnReconnect` attaches `online` in a passive effect, causing early events to be lost.
  - Replaced single-dispatch with a `waitFor` loop that re-fires `online` only while the reload hasn’t landed, then asserts "by Jo" is visible.
  - Relaxed fetch assertion from exactly 2 to at least 2; typical runs settle well under 100ms.

<sup>Written for commit c2f278af8b9855d905eaf8e50f29ce5b9539011c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

