### PR TITLE
fix(a11y): give every role="menu" the keyboard contract it advertises

### DIFF
--- a/src/features/baseplate/components/BaseplateLibraryModal/BaseplateLibraryModal.test.tsx
+++ b/src/features/baseplate/components/BaseplateLibraryModal/BaseplateLibraryModal.test.tsx
@@ -124,6 +124,19 @@ describe('BaseplateLibraryModal', () => {
     expect(screen.getByLabelText('baseplate.library.designName')).toBeInTheDocument();
   });
 
+  // Wiring guard: the menu role advertises arrow traversal, so the shared
+  // keyboard hook must stay attached (#3277).
+  it('focuses the first item on open and traverses with the arrow keys', async () => {
+    render(<BaseplateLibraryModal isOpen onClose={vi.fn()} />);
+    await screen.findByText('One');
+    fireEvent.click(screen.getAllByRole('button', { name: /moreActions/ })[0]);
+
+    const items = screen.getAllByRole('menuitem');
+    await waitFor(() => expect(items[0]).toHaveFocus());
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+    expect(items[1]).toHaveFocus();
+  });
+
   it('delete opens the warning dialog and confirming orphans the current layout', async () => {
     render(<BaseplateLibraryModal isOpen onClose={vi.fn()} />);
     await screen.findByText('One');

--- a/src/features/baseplate/components/BaseplateLibraryModal/BaseplateLibraryModal.tsx
+++ b/src/features/baseplate/components/BaseplateLibraryModal/BaseplateLibraryModal.tsx
@@ -16,6 +16,7 @@ import { useToastStore } from '@/core/store/toast';
 import { useMutations } from '@/shared/contexts';
 import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
+import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 import { useInlineEdit, useResponsive } from '@/shared/hooks';
 import { Button, IconButton, XIcon } from '@/design-system';
 import type { BaseplateDesignId } from '@/core/types';
@@ -354,6 +355,8 @@ function BaseplateCardActions({
   const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const closeMenu = useCallback(() => setIsMenuOpen(false), []);
+  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: isMenuOpen, menuRef, onClose: closeMenu });
 
   useEffect(() => {
     if (!isMenuOpen) return;
@@ -419,6 +422,8 @@ function BaseplateCardActions({
           <div
             ref={menuRef}
             role="menu"
+            tabIndex={-1}
+            onKeyDown={onMenuKeyDown}
             style={menuStyle}
             className="w-40 bg-surface-elevated border border-stroke rounded-lg shadow-lg py-1 z-50"
           >

--- a/src/features/bin-designer/components/DesignActions/DesignActions.test.tsx
+++ b/src/features/bin-designer/components/DesignActions/DesignActions.test.tsx
@@ -47,6 +47,18 @@ describe('DesignActions', () => {
     });
   });
 
+  // Wiring guard: the menu role advertises arrow traversal, so the shared
+  // keyboard hook must stay attached (#3277).
+  it('focuses the first item on open and traverses with the arrow keys', async () => {
+    render(<DesignActions {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+
+    const items = await screen.findAllByRole('menuitem');
+    await waitFor(() => expect(items[0]).toHaveFocus());
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+    expect(items[1]).toHaveFocus();
+  });
+
   it('shows Load option when not active', async () => {
     render(<DesignActions {...defaultProps} isActive={false} />);
 

--- a/src/features/bin-designer/components/DesignActions/DesignActions.tsx
+++ b/src/features/bin-designer/components/DesignActions/DesignActions.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from '@/i18n';
+import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 import { Button, IconButton } from '@/design-system';
 import { useTwoClickDelete } from '@/shared/components';
 import type { SavedDesign } from '../../types';
@@ -35,6 +36,8 @@ export function DesignActions({
   const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const closeMenu = useCallback(() => setIsMenuOpen(false), []);
+  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: isMenuOpen, menuRef, onClose: closeMenu });
 
   // Two-click delete state
   const {
@@ -130,6 +133,8 @@ export function DesignActions({
           <div
             ref={menuRef}
             role="menu"
+            tabIndex={-1}
+            onKeyDown={onMenuKeyDown}
             style={menuStyle}
             className="w-40 bg-surface-elevated border border-stroke rounded-lg shadow-lg py-1 z-50"
           >

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ColorsActionsMenu } from './ColorsActionsMenu';
 import { useSettingsStore } from '@/core/store';
 import { DEFAULT_SETTINGS } from '@/core/store/settings.types';
@@ -36,6 +36,20 @@ describe('ColorsActionsMenu', () => {
     );
     fireEvent.click(screen.getByLabelText('binDesigner.colors.actions'));
     expect(screen.getByText('binDesigner.colors.matchAllToBody')).toBeInTheDocument();
+  });
+
+  // Wiring guard: the menu role advertises arrow traversal, so the shared
+  // keyboard hook must stay attached (#3277).
+  it('focuses the first item on open and traverses with the arrow keys', async () => {
+    render(
+      <ColorsActionsMenu featureColors={fc} onMatchAllToBody={vi.fn()} onApplyPalette={vi.fn()} />
+    );
+    fireEvent.click(screen.getByLabelText('binDesigner.colors.actions'));
+
+    const items = screen.getAllByRole('menuitem');
+    await waitFor(() => expect(items[0]).toHaveFocus());
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+    expect(items[1]).toHaveFocus();
   });
 
   it('invokes onMatchAllToBody when the menu item is clicked', () => {

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.tsx
@@ -24,6 +24,7 @@ import { COLOR_PALETTE_CONSTRAINTS } from '@/core/store/settings.types';
 import type { SavedColorPalette } from '@/core/store/settings.types';
 import { normalizePaletteLip, lipCellZone } from '@/features/bin-designer/types/featureColors';
 import { useTranslation } from '@/i18n';
+import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 import type { FeatureColorConfig } from '@/features/bin-designer/types/featureColors';
 
 interface ColorsActionsMenuProps {
@@ -47,6 +48,7 @@ export function ColorsActionsMenu({
   const [draftName, setDraftName] = useState('');
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const { palettes, updateSettings } = useSettingsStore(
     useShallow((s) => ({
@@ -69,6 +71,8 @@ export function ColorsActionsMenu({
     setSaveMode(false);
     setDraftName('');
   }, []);
+
+  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: open, menuRef, onClose: closeMenu });
 
   const commitSave = useCallback(() => {
     const name = draftName.trim().slice(0, COLOR_PALETTE_CONSTRAINTS.NAME_MAX_LENGTH);
@@ -129,7 +133,13 @@ export function ColorsActionsMenu({
 
       {open && (
         <Popover anchorRef={triggerRef} isOpen onClose={closeMenu} placement="bottom-end">
-          <div role="menu" className="w-56 p-1 text-xs">
+          <div
+            ref={menuRef}
+            role="menu"
+            tabIndex={-1}
+            className="w-56 p-1 text-xs"
+            onKeyDown={onMenuKeyDown}
+          >
             <MenuButton
               icon={<RotateCcwIcon size="sm" />}
               onClick={() => {

--- a/src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.test.tsx
+++ b/src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { LinkedDesignSection } from './LinkedDesignSection';
 import { resetAllStores, createTestBin } from '@/test/testUtils';
 import type { Bin } from '@/core/types';
@@ -207,5 +207,30 @@ describe('LinkedDesignSection', () => {
     fireEvent.click(moreButton);
 
     expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  // Wiring guard: the menu role advertises arrow traversal, so the shared
+  // keyboard hook must stay attached (#3277).
+  it('focuses the first item on open and traverses with the arrow keys', async () => {
+    vi.mocked(useLinkedDesign).mockReturnValue({
+      linkedDesign: {
+        id: designId('design-1'),
+        name: 'My Design',
+        width: 2,
+        depth: 3,
+        height: 5,
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+      isStale: false,
+      hasLink: true,
+    });
+
+    render(<LinkedDesignSection bin={testBin} variant="desktop" />);
+    fireEvent.click(screen.getByTitle('common.moreOptions'));
+
+    const items = screen.getAllByRole('menuitem');
+    await waitFor(() => expect(items[0]).toHaveFocus());
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+    expect(items[1]).toHaveFocus();
   });
 });

--- a/src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.tsx
+++ b/src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.tsx
@@ -14,6 +14,7 @@ import { ConfirmDialog } from '@/shared/components';
 import { useDesignThumbnail } from '@/features/bin-designer';
 import { Button, IconButton, PlusIcon, AlertTriangleIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
+import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { hasFractionalEdgeMismatch } from '@/shared/utils/fractionalEdge';
@@ -41,11 +42,13 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
   const bins = useLayoutStore(useShallow((s) => s.layout.bins));
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
   const [confirmUnlink, setConfirmUnlink] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [matchingEdges, setMatchingEdges] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: menuOpen, menuRef, onClose: closeMenu });
 
   const isMobile = variant === 'mobile';
   const buttonHeight = isMobile ? 'h-11' : 'h-8';
@@ -382,6 +385,8 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
               ref={menuRef}
               className="absolute right-0 mt-1 w-40 py-1 bg-surface-secondary border border-stroke rounded-lg shadow-lg z-10"
               role="menu"
+              tabIndex={-1}
+              onKeyDown={onMenuKeyDown}
             >
               <Button
                 variant="ghost"

--- a/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.test.tsx
+++ b/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.test.tsx
@@ -1,6 +1,6 @@
 import type * as DesignSystem from '@/design-system';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { GridToolbar } from './GridToolbar';
 import { useViewStore, useInteractionStore, useLabsStore } from '@/core/store';
 import { resetAllStores } from '@/test/testUtils';
@@ -364,6 +364,23 @@ describe('GridToolbar', () => {
         fireEvent.mouseDown(document.body);
         expect(screen.queryByRole('menu')).not.toBeInTheDocument();
       }
+    });
+
+    // Wiring guard: the menu role advertises arrow traversal, so the shared
+    // keyboard hook must stay attached (#3277).
+    // This menu holds a single toggle, so there is nothing to traverse — the
+    // guard is that focus enters the menu rather than stranding on the trigger.
+    // Its item carries menuitemcheckbox, which the hook must match alongside
+    // menuitem.
+    it('moves focus onto the item when the menu opens', async () => {
+      const { container } = render(<GridToolbar {...defaultProps} isNarrowToolbar={true} />);
+
+      const overflowButton = container.querySelector('[aria-haspopup="menu"]');
+      expect(overflowButton).toBeInTheDocument();
+      fireEvent.click(overflowButton as Element);
+
+      const item = screen.getByRole('menuitemcheckbox');
+      await waitFor(() => expect(item).toHaveFocus());
     });
 
     it('closes overflow menu on Escape key', () => {

--- a/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.tsx
+++ b/src/features/grid-editor/components/Grid/GridToolbar/GridToolbar.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useEffect, useRef, type RefObject } from 'react';
+import { memo, useState, useEffect, useRef, type RefObject, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useViewStore } from '@/core/store/view';
 import { useInteractionStore } from '@/core/store/interaction';
@@ -14,6 +14,7 @@ import {
 import { trackEvent } from '@/shared/analytics/posthog';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { useTranslation } from '@/i18n';
+import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 import type { Layer } from '@/core/types';
 import type { GridZoomState } from '@/features/grid-editor/hooks/useGridZoom';
 
@@ -83,6 +84,13 @@ export const GridToolbar = memo(function GridToolbar({
   // Overflow menu state
   const overflowMenuRef = useRef<HTMLDivElement>(null);
   const [overflowMenuOpen, setOverflowMenuOpen] = useState(false);
+  const overflowMenuListRef = useRef<HTMLDivElement>(null);
+  const closeOverflowMenu = useCallback(() => setOverflowMenuOpen(false), []);
+  const onOverflowMenuKeyDown = useMenuKeyboardNav({
+    isOpen: overflowMenuOpen,
+    menuRef: overflowMenuListRef,
+    onClose: closeOverflowMenu,
+  });
 
   // Close overflow menu when clicking outside or pressing Escape
   useEffect(() => {
@@ -351,8 +359,11 @@ export const GridToolbar = memo(function GridToolbar({
             {/* Overflow dropdown */}
             {overflowMenuOpen && (
               <div
+                ref={overflowMenuListRef}
                 className="absolute right-0 top-full mt-1 py-2 px-1 bg-surface-elevated border border-stroke-subtle rounded-lg shadow-lg z-50 min-w-[160px]"
                 role="menu"
+                tabIndex={-1}
+                onKeyDown={onOverflowMenuKeyDown}
               >
                 {layers.length > 1 && (
                   <div

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.test.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { LayoutActions } from '@/features/layout-library/components/LayoutManagerModal/LayoutActions';
 import type { LayoutEntry } from '@/core/types';
 import { gridUnits, heightUnits, layoutId } from '@/core/types';
@@ -73,6 +73,18 @@ describe('LayoutActions', () => {
       fireEvent.click(screen.getByLabelText('More actions for Test Layout'));
 
       expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    // Wiring guard: the menu role advertises arrow traversal, so the shared
+    // keyboard hook must stay attached (#3277).
+    it('focuses the first item on open and traverses with the arrow keys', async () => {
+      render(<LayoutActions {...defaultProps} />);
+      fireEvent.click(screen.getByLabelText('More actions for Test Layout'));
+
+      const items = screen.getAllByRole('menuitem');
+      await waitFor(() => expect(items[0]).toHaveFocus());
+      fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+      expect(items[1]).toHaveFocus();
     });
 
     it('shows copy link option', () => {

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutActions/LayoutActions.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { LayoutEntry } from '@/core/types';
 import { useTranslation } from '@/i18n';
+import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 import { useTwoClickDelete } from '@/shared/components';
 import { Button, IconButton } from '@/design-system';
 
@@ -33,6 +34,8 @@ export function LayoutActions({
   const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const closeMenu = useCallback(() => setIsMenuOpen(false), []);
+  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: isMenuOpen, menuRef, onClose: closeMenu });
 
   // Two-click delete state
   const {
@@ -154,6 +157,8 @@ export function LayoutActions({
             <div
               ref={menuRef}
               role="menu"
+              tabIndex={-1}
+              onKeyDown={onMenuKeyDown}
               style={menuStyle}
               className="w-40 bg-surface-elevated border border-stroke rounded-lg shadow-lg py-1 z-50"
             >

--- a/src/features/layout-library/components/LayoutQuickSwitch/LayoutQuickSwitch.test.tsx
+++ b/src/features/layout-library/components/LayoutQuickSwitch/LayoutQuickSwitch.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type * as SharedHooks from '@/shared/hooks';
 
 const switchLayout = vi.fn().mockResolvedValue({ ok: true, value: undefined });
@@ -55,6 +55,18 @@ describe('LayoutQuickSwitch', () => {
     fireEvent.click(screen.getByRole('button', { name: /switch layout/i }));
     expect(screen.getByRole('menuitem', { name: /Kitchen Drawer/i })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: /Garage Bench/i })).toBeInTheDocument();
+  });
+
+  // Wiring guard: the menu role advertises arrow traversal, so the shared
+  // keyboard hook must stay attached (#3277).
+  it('focuses the first item on open and traverses with the arrow keys', async () => {
+    render(<LayoutQuickSwitch onManage={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /switch layout/i }));
+
+    const items = screen.getAllByRole('menuitem');
+    await waitFor(() => expect(items[0]).toHaveFocus());
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+    expect(items[1]).toHaveFocus();
   });
 
   it('switches to a different layout on click', () => {

--- a/src/features/layout-library/components/LayoutQuickSwitch/LayoutQuickSwitch.tsx
+++ b/src/features/layout-library/components/LayoutQuickSwitch/LayoutQuickSwitch.tsx
@@ -7,6 +7,7 @@ import { LayoutThumbnail } from '@/shell/LayoutThumbnail';
 import type { LayoutPreview } from '@/core/types';
 import { layoutId } from '@/core/types';
 import { useTranslation } from '@/i18n';
+import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 import { Button } from '@/design-system';
 
 interface LayoutQuickSwitchProps {
@@ -84,6 +85,9 @@ export function LayoutQuickSwitch({ onManage }: LayoutQuickSwitchProps) {
   const currentLayout = useLayoutStore((s) => s.layout);
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const closeMenu = useCallback(() => setOpen(false), []);
+  const onMenuKeyDown = useMenuKeyboardNav({ isOpen: open, menuRef, onClose: closeMenu });
 
   // In shared-preview / embed mode the active layout isn't a library entry, so
   // the trigger reflects the live layout store instead of mislabeling itself
@@ -141,7 +145,10 @@ export function LayoutQuickSwitch({ onManage }: LayoutQuickSwitchProps) {
 
       {open && (
         <div
+          ref={menuRef}
           role="menu"
+          tabIndex={-1}
+          onKeyDown={onMenuKeyDown}
           className="absolute left-0 top-full z-50 mt-1 max-h-[70vh] w-64 overflow-auto rounded-lg border border-stroke bg-surface-elevated py-1 shadow-lg"
         >
           {library.entries.map((entry) => {

--- a/src/shared/components/ContextMenu/ContextMenuContainer/ContextMenuContainer.tsx
+++ b/src/shared/components/ContextMenu/ContextMenuContainer/ContextMenuContainer.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useLayoutEffect, useCallback } from 'react';
+import { useLayoutEffect } from 'react';
 import type { RefObject } from 'react';
 import { useTranslation } from '@/i18n';
+import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 
 /** Margin from viewport edges (px) */
 const VIEWPORT_MARGIN = 8;
@@ -74,59 +75,7 @@ export function ContextMenuContainer({
     menu.style.top = `${y}px`;
   }, [isOpen, position, menuRef]);
 
-  // Focus first menu item when menu opens
-  useEffect(() => {
-    if (!isOpen || !menuRef.current) return;
-    const firstItem = menuRef.current.querySelector<HTMLElement>(
-      '[role="menuitem"]:not([disabled])'
-    );
-    firstItem?.focus();
-  }, [isOpen, menuRef]);
-
-  // Keyboard navigation handler
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (!menuRef.current) return;
-
-      const items = Array.from(
-        menuRef.current.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])')
-      );
-      if (items.length === 0) return;
-
-      const currentIndex = items.indexOf(document.activeElement as HTMLElement);
-
-      switch (e.key) {
-        case 'ArrowDown': {
-          e.preventDefault();
-          const nextIndex = currentIndex < items.length - 1 ? currentIndex + 1 : 0;
-          items[nextIndex].focus();
-          break;
-        }
-        case 'ArrowUp': {
-          e.preventDefault();
-          const prevIndex = currentIndex > 0 ? currentIndex - 1 : items.length - 1;
-          items[prevIndex].focus();
-          break;
-        }
-        case 'Home': {
-          e.preventDefault();
-          items[0].focus();
-          break;
-        }
-        case 'End': {
-          e.preventDefault();
-          items[items.length - 1].focus();
-          break;
-        }
-        case 'Escape': {
-          e.preventDefault();
-          onClose();
-          break;
-        }
-      }
-    },
-    [menuRef, onClose]
-  );
+  const handleKeyDown = useMenuKeyboardNav({ isOpen, menuRef, onClose });
 
   if (!isOpen) return null;
 

--- a/src/shared/hooks/README.hooks.md
+++ b/src/shared/hooks/README.hooks.md
@@ -32,6 +32,7 @@ graph TB
 | `useLayoutSwitcher.ts`  | Atomic layout CRUD: switch, create, delete, duplicate, import            |
 | `useBinGeometry.ts`     | Three.js geometry generation for 3D bin preview                          |
 | `useContextMenu.ts`     | Right-click menu lifecycle (position, outside-click, escape)             |
+| `useMenuKeyboardNav.ts` | The keyboard contract `role="menu"` promises: focus-in, arrows, Home/End |
 | `useDesignerRouting.ts` | Bin Designer URL navigation with history integration                     |
 
 ## Collaborative Hooks
@@ -71,3 +72,9 @@ See [`interactions/README.md`](./interactions/README.md) for the FSM architectur
    `isNonLayoutRoute`; without it a Bin Designer `Delete`/`r`/`w` also reaches the layout (#2896)
 7. **Half-bin remediation** — `handleRemediate()` moves fractional bins to staging before disabling mode
 8. **Layout switch side effects** — clears undo history, resets selection, updates URL slug, resets ML session
+9. **`role="menu"` obliges keyboard nav** — any container with `role="menu"` MUST attach
+   `useMenuKeyboardNav`, or use the `Menu` design-system primitive which has it built in.
+   Declaring the role without arrow traversal is worse than declaring nothing: AT announces
+   navigation that does not exist and the user follows it into a dead end (#3277). The hook
+   matches `menuitem`, `menuitemcheckbox` and `menuitemradio` — a menu of toggles uses the
+   latter two, and matching only `menuitem` leaves it with nothing to traverse.

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -7,6 +7,7 @@ export { useCrossTabSync } from './useCrossTabSync';
 export { usePWAUpdate } from './usePWAUpdate';
 export { usePrefetchChunks } from './usePrefetchChunks';
 export { useFocusTrap } from './useFocusTrap';
+export { useMenuKeyboardNav } from './useMenuKeyboardNav';
 export { useInlineEdit } from './useInlineEdit';
 export { useKeyboard } from './useKeyboard';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/src/shared/hooks/useMenuKeyboardNav.test.tsx
+++ b/src/shared/hooks/useMenuKeyboardNav.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useRef } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useMenuKeyboardNav } from './useMenuKeyboardNav';
+
+function Harness({
+  isOpen = true,
+  onClose = vi.fn(),
+  withInput = false,
+  disabledSecond = false,
+}: {
+  isOpen?: boolean;
+  onClose?: () => void;
+  withInput?: boolean;
+  disabledSecond?: boolean;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const onKeyDown = useMenuKeyboardNav({ isOpen, menuRef, onClose });
+
+  if (!isOpen) return null;
+
+  return (
+    <div ref={menuRef} role="menu" tabIndex={-1} onKeyDown={onKeyDown}>
+      {withInput && <input aria-label="filter" />}
+      <button type="button" role="menuitem">
+        One
+      </button>
+      <button type="button" role="menuitem" disabled={disabledSecond}>
+        Two
+      </button>
+      <button type="button" role="menuitem">
+        Three
+      </button>
+    </div>
+  );
+}
+
+const menu = () => screen.getByRole('menu');
+const items = () => screen.getAllByRole('menuitem');
+
+describe('useMenuKeyboardNav', () => {
+  it('moves focus to the first item when the menu opens', async () => {
+    render(<Harness />);
+    await waitFor(() => expect(items()[0]).toHaveFocus());
+  });
+
+  it('traverses down and wraps at the end', async () => {
+    render(<Harness />);
+    await waitFor(() => expect(items()[0]).toHaveFocus());
+    fireEvent.keyDown(menu(), { key: 'ArrowDown' });
+    expect(items()[1]).toHaveFocus();
+    fireEvent.keyDown(menu(), { key: 'ArrowDown' });
+    expect(items()[2]).toHaveFocus();
+    fireEvent.keyDown(menu(), { key: 'ArrowDown' });
+    expect(items()[0]).toHaveFocus();
+  });
+
+  it('traverses up and wraps at the start', async () => {
+    render(<Harness />);
+    await waitFor(() => expect(items()[0]).toHaveFocus());
+    fireEvent.keyDown(menu(), { key: 'ArrowUp' });
+    expect(items()[2]).toHaveFocus();
+  });
+
+  it('jumps to the ends with Home and End', async () => {
+    render(<Harness />);
+    await waitFor(() => expect(items()[0]).toHaveFocus());
+    fireEvent.keyDown(menu(), { key: 'End' });
+    expect(items()[2]).toHaveFocus();
+    fireEvent.keyDown(menu(), { key: 'Home' });
+    expect(items()[0]).toHaveFocus();
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.keyDown(menu(), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips disabled items', async () => {
+    render(<Harness disabledSecond />);
+    await waitFor(() => expect(items()[0]).toHaveFocus());
+    fireEvent.keyDown(menu(), { key: 'ArrowDown' });
+    expect(items()[2]).toHaveFocus();
+  });
+
+  // A menu can hold a filter or rename field; arrow keys there belong to the caret.
+  it('leaves caret keys to a text field inside the menu', () => {
+    render(<Harness withInput />);
+    const input = screen.getByLabelText('filter');
+    input.focus();
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input).toHaveFocus();
+  });
+
+  it('still closes on Escape from a text field inside the menu', () => {
+    const onClose = vi.fn();
+    render(<Harness withInput onClose={onClose} />);
+    const input = screen.getByLabelText('filter');
+    input.focus();
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // A menu carrying toggles uses menuitemcheckbox/menuitemradio; matching only
+  // "menuitem" would leave those menus with nothing to traverse.
+  it('traverses checkbox and radio item roles too', async () => {
+    function Toggles() {
+      const menuRef = useRef<HTMLDivElement>(null);
+      const onKeyDown = useMenuKeyboardNav({ isOpen: true, menuRef, onClose: vi.fn() });
+      return (
+        <div ref={menuRef} role="menu" tabIndex={-1} onKeyDown={onKeyDown}>
+          <div role="menuitemcheckbox" aria-checked tabIndex={0}>
+            Show layers below
+          </div>
+          <div role="menuitemradio" aria-checked={false} tabIndex={0}>
+            Sort by size
+          </div>
+        </div>
+      );
+    }
+    render(<Toggles />);
+    const check = screen.getByRole('menuitemcheckbox');
+    await waitFor(() => expect(check).toHaveFocus());
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+    expect(screen.getByRole('menuitemradio')).toHaveFocus();
+  });
+
+  it('skips aria-disabled items', async () => {
+    function WithAriaDisabled() {
+      const menuRef = useRef<HTMLDivElement>(null);
+      const onKeyDown = useMenuKeyboardNav({ isOpen: true, menuRef, onClose: vi.fn() });
+      return (
+        <div ref={menuRef} role="menu" tabIndex={-1} onKeyDown={onKeyDown}>
+          <div role="menuitem" tabIndex={0}>
+            One
+          </div>
+          <div role="menuitem" aria-disabled="true" tabIndex={-1}>
+            Two
+          </div>
+          <div role="menuitem" tabIndex={0}>
+            Three
+          </div>
+        </div>
+      );
+    }
+    render(<WithAriaDisabled />);
+    const all = screen.getAllByRole('menuitem');
+    await waitFor(() => expect(all[0]).toHaveFocus());
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+    expect(all[2]).toHaveFocus();
+  });
+
+  it('does not steal focus while the menu is closed', () => {
+    render(<Harness isOpen={false} />);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/src/shared/hooks/useMenuKeyboardNav.ts
+++ b/src/shared/hooks/useMenuKeyboardNav.ts
@@ -1,0 +1,90 @@
+import {
+  useCallback,
+  useEffect,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+} from 'react';
+
+interface UseMenuKeyboardNavOptions {
+  /** Whether the menu is currently rendered. Focus moves in on the false→true edge. */
+  isOpen: boolean;
+  /** The element carrying `role="menu"`. */
+  menuRef: RefObject<HTMLElement | null>;
+  /** Called on Escape. */
+  onClose: () => void;
+}
+
+// menuitemcheckbox/menuitemradio are equally valid children of role="menu" —
+// a menu carrying toggles (layer visibility, sort order) uses them, and
+// matching only "menuitem" would leave those menus with nothing to traverse.
+const ITEM_SELECTOR = ['[role="menuitem"]', '[role="menuitemcheckbox"]', '[role="menuitemradio"]']
+  .map((role) => `${role}:not([disabled]):not([aria-disabled="true"])`)
+  .join(',');
+
+/**
+ * The keyboard contract that `role="menu"` promises: focus lands on the first
+ * item when the menu opens, Arrow keys traverse with wraparound, Home/End jump
+ * to the ends, Escape closes.
+ *
+ * Declaring the role without this is worse than declaring nothing — assistive
+ * tech announces navigation the menu does not implement, so the user follows
+ * the announcement into a dead end (#3277).
+ *
+ * Items are discovered by DOM query rather than by registration, so a menu can
+ * hold arbitrary content (inputs, swatches, headers) and still traverse only
+ * its items.
+ */
+export function useMenuKeyboardNav({ isOpen, menuRef, onClose }: UseMenuKeyboardNavOptions) {
+  useEffect(() => {
+    if (!isOpen) return;
+    // Menus that mount their content in the same commit need a frame before the
+    // items exist to query.
+    const frame = requestAnimationFrame(() => {
+      menuRef.current?.querySelector<HTMLElement>(ITEM_SELECTOR)?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, menuRef]);
+
+  return useCallback(
+    (e: ReactKeyboardEvent) => {
+      const menu = menuRef.current;
+      if (!menu) return;
+
+      // A text field inside the menu owns its own caret keys.
+      const target = e.target as HTMLElement | null;
+      const editable =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target?.isContentEditable === true;
+      if (editable && e.key !== 'Escape') return;
+
+      const items = Array.from(menu.querySelectorAll<HTMLElement>(ITEM_SELECTOR));
+
+      const move = (next: (current: number) => number) => {
+        if (items.length === 0) return;
+        e.preventDefault();
+        items[next(items.indexOf(document.activeElement as HTMLElement))]?.focus();
+      };
+
+      switch (e.key) {
+        case 'ArrowDown':
+          move((i) => (i < items.length - 1 ? i + 1 : 0));
+          break;
+        case 'ArrowUp':
+          move((i) => (i > 0 ? i - 1 : items.length - 1));
+          break;
+        case 'Home':
+          move(() => 0);
+          break;
+        case 'End':
+          move(() => items.length - 1);
+          break;
+        case 'Escape':
+          e.preventDefault();
+          onClose();
+          break;
+      }
+    },
+    [menuRef, onClose]
+  );
+}

--- a/src/shared/hooks/useMenuKeyboardNav.ts
+++ b/src/shared/hooks/useMenuKeyboardNav.ts
@@ -21,6 +21,13 @@ const ITEM_SELECTOR = ['[role="menuitem"]', '[role="menuitemcheckbox"]', '[role=
   .map((role) => `${role}:not([disabled]):not([aria-disabled="true"])`)
   .join(',');
 
+const STEPS: Record<string, ((current: number, count: number) => number) | undefined> = {
+  ArrowDown: (current, count) => (current < count - 1 ? current + 1 : 0),
+  ArrowUp: (current, count) => (current > 0 ? current - 1 : count - 1),
+  Home: () => 0,
+  End: (_current, count) => count - 1,
+};
+
 /**
  * The keyboard contract that `role="menu"` promises: focus lands on the first
  * item when the menu opens, Arrow keys traverse with wraparound, Home/End jump
@@ -50,40 +57,31 @@ export function useMenuKeyboardNav({ isOpen, menuRef, onClose }: UseMenuKeyboard
       const menu = menuRef.current;
       if (!menu) return;
 
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      const step = STEPS[e.key];
+      // Every other key — Tab, Shift, letters — leaves before the DOM query.
+      if (!step) return;
+
       // A text field inside the menu owns its own caret keys.
       const target = e.target as HTMLElement | null;
-      const editable =
+      if (
         target instanceof HTMLInputElement ||
         target instanceof HTMLTextAreaElement ||
-        target?.isContentEditable === true;
-      if (editable && e.key !== 'Escape') return;
+        target?.isContentEditable === true
+      ) {
+        return;
+      }
 
       const items = Array.from(menu.querySelectorAll<HTMLElement>(ITEM_SELECTOR));
+      if (items.length === 0) return;
 
-      const move = (next: (current: number) => number) => {
-        if (items.length === 0) return;
-        e.preventDefault();
-        items[next(items.indexOf(document.activeElement as HTMLElement))]?.focus();
-      };
-
-      switch (e.key) {
-        case 'ArrowDown':
-          move((i) => (i < items.length - 1 ? i + 1 : 0));
-          break;
-        case 'ArrowUp':
-          move((i) => (i > 0 ? i - 1 : items.length - 1));
-          break;
-        case 'Home':
-          move(() => 0);
-          break;
-        case 'End':
-          move(() => items.length - 1);
-          break;
-        case 'Escape':
-          e.preventDefault();
-          onClose();
-          break;
-      }
+      e.preventDefault();
+      items[step(items.indexOf(document.activeElement as HTMLElement), items.length)]?.focus();
     },
     [menuRef, onClose]
   );


### PR DESCRIPTION
Seven menus declared `role="menu"` and `role="menuitem"` without implementing what those roles promise. Focus stayed on the trigger and arrow keys did nothing.

This is worse than omitting the roles. Without them a menu is a list of plainly tabbable buttons — degraded but honest. With them, a screen reader announces "menu, N items" and tells the user to navigate with arrows, so the user follows the announcement into a dead end.

Found in review on #3277, which fixed one instance. This closes the other seven.

## What was broken

| Component | Arrows | Escape |
| --- | --- | --- |
| `LinkedDesignSection` | ✗ | document-level |
| `LayoutQuickSwitch` | ✗ | document-level |
| `LayoutActions` | ✗ | ✗ |
| `BaseplateLibraryModal` | ✗ | document-level |
| `GridToolbar` | ✗ | document-level |
| `DesignActions` | ✗ | ✗ |
| `ColorsActionsMenu` | ✗ | document-level |
| `ContextMenuContainer` | ✓ | ✓ |

## Approach

`ContextMenuContainer` was the only correct implementation, so its logic is extracted to `useMenuKeyboardNav` and the other seven attach it. Refactoring `ContextMenuContainer` onto the extracted hook passes its 26 existing tests unchanged, which is the equivalence check.

Migrating all seven to the `Menu.Root` primitive was the alternative and was rejected: several hold content `Menu.Item` cannot carry (a rename input, colour swatches, section headers), and `Menu.Root`'s full-screen scrim would have visually changed seven surfaces. The hook is DOM-query based rather than registration based, so those menus keep working without restructuring.

## Three details the sites needed

- **`menuitemcheckbox` and `menuitemradio` count as items.** `GridToolbar`'s overflow menu is a toggle, so a `menuitem`-only selector would have left it with nothing to traverse — the same defect one level down. Caught by the wiring test, not by review.
- **A text field inside a menu keeps its caret keys**; only Escape is taken. `ColorsActionsMenu`'s palette-name input needs this.
- **Menu containers take `tabIndex={-1}`.** A keydown handler on an interactive role requires the element to be focusable; `jsx-a11y/interactive-supports-focus` enforces it.

## Verification

880 test files / 10560 tests. 9 hook tests (traversal, wraparound, Home/End, Escape, disabled and `aria-disabled` skipping, the text-field carve-out, the checkbox/radio roles) plus a wiring guard per site so the gap cannot reopen silently. `GridToolbar`'s guard asserts focus-on-open only — its menu holds one item, so there is nothing to traverse.

Typecheck, ESLint (0 errors), all four i18n checks, design-system usage, module boundaries and Prettier clean. The rule is recorded as gotcha 9 in `src/shared/hooks/README.hooks.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures every `role="menu"` implements expected keyboard navigation via a shared `useMenuKeyboardNav` hook. Fixes focus and arrow-key traversal across seven menus to align with screen reader expectations, and avoids DOM work for non-navigation keys.

- **Bug Fixes**
  - Applied `useMenuKeyboardNav` to `LinkedDesignSection`, `LayoutQuickSwitch`, `LayoutActions`, `BaseplateLibraryModal`, `GridToolbar`, `DesignActions`, and `ColorsActionsMenu`.
  - Focuses the first item on open; supports ArrowUp/Down with wraparound, Home/End, and Escape to close.
  - Preserves caret keys inside text inputs; only Escape is handled there.
  - Matches `menuitem`, `menuitemcheckbox`, and `menuitemradio`; skips disabled and `aria-disabled` items.
  - Adds `tabIndex={-1}` to menu containers so key handlers can receive focus.

- **Refactors**
  - Extracted keyboard logic from `ContextMenuContainer` into `useMenuKeyboardNav` and refactored the container to use it; optimized the handler to handle Escape first and skip DOM queries for non-navigation keys.
  - Added unit tests for the hook and wiring guards in each menu; updated hooks README with the a11y requirement.

<sup>Written for commit 0cf5c6e7b70bb143bb9ce4f7c42b4aa2e11f3bf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

