### PR TITLE
feat(bin-designer): let the cutout editor clear the stacking lip

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -36,7 +36,10 @@ graph TB
   a docked, resizable/collapsible `InspectorDock` (width + collapsed state persisted via
   `inspectorDockStorage`), not a floating overlay. `InspectorContent` switches between
   single-select sections, multi-select shared fields (mixed values show a "—" placeholder),
-  and an empty board-settings state; number-first `CompactNumberInput` (drag-scrub + type)
+  and an empty board-settings state, above a bin-level block (`BinSizeSection`,
+  `BinFeaturesSection`) that stays put across every selection state so the board can be
+  resized and the stacking lip cleared without leaving the editor; those two are self-wired
+  to the designer store rather than prop-drilled. Number-first `CompactNumberInput` (drag-scrub + type)
   replaces sliders, and hardware-size presets surface as quick-pick chips. The multi-select
   section leads with `AlignControls` (align/distribute, backed by the pure
   `panel/CutoutsSection/geometryAlign.ts`) and batch-edits position, size, rotation, cut depth,
@@ -334,6 +337,10 @@ estimates), and the source file name.
    `params.base.stackingLip` at every layer (orchestrator, export handler,
    `useLidSection`). The mating cavity wraps the lip; without a lip there is
    nothing for the lid to clip onto, so the lid is silently skipped.
+   `lid.enabled` stays persisted through all of it, so the skip is invisible
+   in the params — any surface that lets the lip be cleared owes the user that
+   warning. The Lid section carries it in the main panel; the cutout editor's
+   `BinFeaturesSection` repeats it, because that panel is off screen there.
 10. **Two-piece export** — when `hasLid`, the `EXPORT_COMBINED` flow emits the
     lid as its own labeled piece for STL/3MF (main thread ZIPs them) and
     folds it into the STEP compound. The STEP path must `translate()` the

--- a/src/features/bin-designer/components/CutoutWorkspace/BinFeaturesSection.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinFeaturesSection.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BinFeaturesSection } from './BinFeaturesSection';
+import { useDesignerStore } from '../../store';
+import { DEFAULT_BIN_PARAMS } from '../../constants';
+
+const LIP = 'Stacking lip';
+
+function setParams(overrides: Partial<typeof DEFAULT_BIN_PARAMS> = {}) {
+  useDesignerStore.setState({
+    params: { ...DEFAULT_BIN_PARAMS, ...overrides },
+    history: { past: [], future: [] },
+  });
+}
+
+const lipSwitch = () => screen.getByRole('switch', { name: LIP });
+
+describe('BinFeaturesSection', () => {
+  beforeEach(() => {
+    setParams();
+  });
+
+  it('reflects the stacking lip currently on the bin', () => {
+    setParams({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true } });
+    render(<BinFeaturesSection />);
+
+    expect(lipSwitch()).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('clears the stacking lip without leaving the cutout editor', () => {
+    setParams({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true } });
+    render(<BinFeaturesSection />);
+
+    fireEvent.click(lipSwitch());
+
+    expect(useDesignerStore.getState().params.base.stackingLip).toBe(false);
+    expect(lipSwitch()).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('puts the stacking lip back', () => {
+    setParams({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } });
+    render(<BinFeaturesSection />);
+
+    fireEvent.click(lipSwitch());
+
+    expect(useDesignerStore.getState().params.base.stackingLip).toBe(true);
+  });
+
+  // The workspace's Ctrl+Z and undo button read the designer history stack, so a
+  // toggle that skipped it would be the one edit in the editor you can't take
+  // back.
+  it('records the toggle on the undo stack', () => {
+    setParams({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true } });
+    render(<BinFeaturesSection />);
+
+    fireEvent.click(lipSwitch());
+    useDesignerStore.getState().undo();
+
+    expect(useDesignerStore.getState().params.base.stackingLip).toBe(true);
+  });
+
+  // Clearing the lip stops the lid generating while `lid.enabled` stays true.
+  // The Lid section carries that warning in the main panel, which is off screen
+  // here, so without this the lid would vanish unexplained.
+  it('warns that an enabled lid is paused once the lip is off', () => {
+    setParams({
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
+    });
+    render(<BinFeaturesSection />);
+
+    expect(screen.getByText(/lid needs the stacking lip/i)).toBeInTheDocument();
+  });
+
+  it('stays quiet about the lid while the lip is on', () => {
+    setParams({
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+      lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
+    });
+    render(<BinFeaturesSection />);
+
+    expect(screen.queryByText(/lid needs the stacking lip/i)).not.toBeInTheDocument();
+  });
+
+  it('stays quiet when there is no lid to pause', () => {
+    setParams({
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: false },
+    });
+    render(<BinFeaturesSection />);
+
+    expect(screen.queryByText(/lid needs the stacking lip/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/CutoutWorkspace/BinFeaturesSection.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinFeaturesSection.test.tsx
@@ -1,10 +1,13 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BinFeaturesSection } from './BinFeaturesSection';
 import { useDesignerStore } from '../../store';
 import { DEFAULT_BIN_PARAMS } from '../../constants';
 
-const LIP = 'Stacking lip';
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+const LIP = 'assembledHeight.stackingLip';
+const LID_PAUSED = 'binDesigner.cutoutEditor.lipOffPausesLid';
 
 function setParams(overrides: Partial<typeof DEFAULT_BIN_PARAMS> = {}) {
   useDesignerStore.setState({
@@ -69,7 +72,7 @@ describe('BinFeaturesSection', () => {
     });
     render(<BinFeaturesSection />);
 
-    expect(screen.getByText(/lid needs the stacking lip/i)).toBeInTheDocument();
+    expect(screen.getByText(LID_PAUSED)).toBeInTheDocument();
   });
 
   it('stays quiet about the lid while the lip is on', () => {
@@ -79,7 +82,7 @@ describe('BinFeaturesSection', () => {
     });
     render(<BinFeaturesSection />);
 
-    expect(screen.queryByText(/lid needs the stacking lip/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(LID_PAUSED)).not.toBeInTheDocument();
   });
 
   it('stays quiet when there is no lid to pause', () => {
@@ -89,6 +92,6 @@ describe('BinFeaturesSection', () => {
     });
     render(<BinFeaturesSection />);
 
-    expect(screen.queryByText(/lid needs the stacking lip/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(LID_PAUSED)).not.toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/components/CutoutWorkspace/BinFeaturesSection.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinFeaturesSection.tsx
@@ -1,0 +1,57 @@
+/**
+ * Bin-level feature toggles inside the cutout editor, so a shadow board or tool
+ * tray can drop the stacking lip without leaving the workspace for the main
+ * parameter panel. Self-wired to the designer store like the DimensionsSection
+ * the BinSizeSection above it reuses.
+ *
+ * The toggle deliberately mirrors `useBaseSection.toggleStackingLip` — a bare
+ * `updateBase`, no constraint-engine round trip — because the lip has no
+ * feature id in the engine and a second surface inventing gating would make the
+ * two controls disagree.
+ */
+
+import { useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { useTranslation } from '@/i18n';
+import { FeatureToggle } from '../panel/FeatureToggle';
+
+export function BinFeaturesSection() {
+  const t = useTranslation();
+  const { stackingLip, lidEnabled, updateBase } = useDesignerStore(
+    useShallow((s) => ({
+      stackingLip: s.params.base.stackingLip,
+      lidEnabled: s.params.lid.enabled,
+      updateBase: s.updateBase,
+    }))
+  );
+
+  const toggleStackingLip = useCallback(() => {
+    updateBase({ stackingLip: !stackingLip });
+  }, [stackingLip, updateBase]);
+
+  return (
+    <div className="space-y-2 border-b border-stroke-subtle pb-3 pt-3">
+      <span className="block text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+        {t('binDesigner.cutoutEditor.binFeatures')}
+      </span>
+
+      {/* Same key as the Base section's toggle — one noun for one lip. */}
+      <FeatureToggle
+        label={t('assembledHeight.stackingLip')}
+        checked={stackingLip}
+        onChange={toggleStackingLip}
+      />
+
+      {/* The lid seats on the lip, so clearing it stops the lid generating while
+          `lid.enabled` stays persisted (useLidSection's `effectiveEnabled`).
+          The Lid section carries that warning in the main panel; it is off
+          screen here, so the lid would otherwise vanish unexplained. */}
+      {lidEnabled && !stackingLip && (
+        <p className="text-[11px] leading-relaxed text-content-tertiary">
+          {t('binDesigner.cutoutEditor.lipOffPausesLid')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -77,6 +77,13 @@ vi.mock('./BinSizeSection', () => ({
   ),
 }));
 
+// Stubbed for the same reason as BinSizeSection: it is self-wired to the
+// designer store, and this suite is about what InspectorContent renders in each
+// selection state, not what the store holds.
+vi.mock('./BinFeaturesSection', () => ({
+  BinFeaturesSection: () => <div data-testid="bin-features-section" />,
+}));
+
 const createCutout = (overrides: Partial<Cutout> = {}): Cutout => ({
   id: 'cutout1',
   shape: 'rectangle',
@@ -124,6 +131,22 @@ describe('InspectorContent', () => {
       />
     );
     expect(screen.getByTestId('bin-size-section')).toBeInTheDocument();
+  });
+
+  // Bin-level controls are the ones you must not have to change selection to
+  // reach — the stacking lip included, which is why it lives here rather than
+  // in the no-selection board settings.
+  it.each([
+    ['nothing selected', [] as Cutout[], new Set<string>()],
+    ['a single selection', [createCutout()], new Set(['cutout1'])],
+    [
+      'a multi-selection',
+      [createCutout({ id: 'a' }), createCutout({ id: 'b' })],
+      new Set(['a', 'b']),
+    ],
+  ])('keeps the bin-features controls on screen with %s', (_label, cutouts, selection) => {
+    render(<InspectorContent {...defaultProps} cutouts={cutouts} selection={selection} />);
+    expect(screen.getByTestId('bin-features-section')).toBeInTheDocument();
   });
 
   it('renders X/Y/W/H inputs and rotation/depth sliders for a single selection', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
@@ -18,6 +18,7 @@ import { SingleCutoutInspector } from './SingleCutoutInspector';
 import { CutoutColorControls } from './CutoutColorControls';
 import { CutoutBoardSettings } from './CutoutBoardSettings';
 import { BinSizeSection } from './BinSizeSection';
+import { BinFeaturesSection } from './BinFeaturesSection';
 import { AlignControls } from './AlignControls';
 
 /** Matches the per-cutout minimum the single-cutout inspector enforces. */
@@ -122,21 +123,24 @@ export function InspectorContent({
     [cutouts, selection]
   );
 
-  // Bin-size controls stay visible across every selection state so the user can
-  // resize without leaving the editor.
-  const binSize = (
-    <BinSizeSection
-      offBoardCount={offBoardCount}
-      onClampOffBoard={onClampOffBoard}
-      growTarget={growTarget}
-      onGrowToFit={onGrowToFit}
-    />
+  // Bin-level controls stay visible across every selection state so the user can
+  // resize the board and clear the stacking lip without leaving the editor.
+  const binControls = (
+    <>
+      <BinSizeSection
+        offBoardCount={offBoardCount}
+        onClampOffBoard={onClampOffBoard}
+        growTarget={growTarget}
+        onGrowToFit={onGrowToFit}
+      />
+      <BinFeaturesSection />
+    </>
   );
 
   if (selectedCutouts.length === 0) {
     return (
       <div className="space-y-1.5">
-        {binSize}
+        {binControls}
         {board ? (
           <CutoutBoardSettings
             gridSize={board.gridSize}
@@ -251,7 +255,7 @@ export function InspectorContent({
 
   return (
     <div className="space-y-1.5">
-      {binSize}
+      {binControls}
       {singleCutout && (
         <SingleCutoutInspector
           cutout={singleCutout}

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -28,8 +28,10 @@ export function BaseSection() {
 
   return (
     <div className="space-y-3">
+      {/* Shares the assembled-height breakdown's noun — the same lip, named
+          once — rather than duplicating the string across every locale. */}
       <FeatureToggle
-        label="Stacking lip"
+        label={t('assembledHeight.stackingLip')}
         checked={state.base.stackingLip}
         onChange={handlers.toggleStackingLip}
       />

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Rozdělit",
   "binDesigner.cutoutDesktopOnly": "Editor výřezů je dostupný na počítači. Pro použití této funkce přejdi prosím na širší obrazovku.",
   "binDesigner.cutoutEditor.binSize": "Velikost binu",
+  "binDesigner.cutoutEditor.binFeatures": "Funkce binu",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Víko potřebuje stohovací lem, takže se nevygeneruje, dokud lem znovu nezapnete.",
   "binDesigner.cutoutEditor.boardCutouts": "Výřezy",
   "binDesigner.cutoutEditor.boardSettings": "Deska",
   "binDesigner.cutoutEditor.boardSize": "Velikost desky",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Teilen",
   "binDesigner.cutoutDesktopOnly": "Der Ausschnitt-Editor ist auf dem Desktop verfügbar. Bitte wechseln Sie zu einem breiteren Bildschirm, um diese Funktion zu nutzen.",
   "binDesigner.cutoutEditor.binSize": "Bin-Größe",
+  "binDesigner.cutoutEditor.binFeatures": "Bin-Funktionen",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Der Deckel braucht den Stapelrand und wird erst erzeugt, wenn du den Rand wieder aktivierst.",
   "binDesigner.cutoutEditor.boardCutouts": "Aussparungen",
   "binDesigner.cutoutEditor.boardSettings": "Platte",
   "binDesigner.cutoutEditor.boardSize": "Plattengröße",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2466,6 +2466,9 @@ const en: Record<string, string> = {
   'binDesigner.cutoutEditor.boardSize': 'Board size',
   'binDesigner.cutoutEditor.boardCutouts': 'Cutouts',
   'binDesigner.cutoutEditor.binSize': 'Bin size',
+  'binDesigner.cutoutEditor.binFeatures': 'Bin features',
+  'binDesigner.cutoutEditor.lipOffPausesLid':
+    "The lid needs the stacking lip, so it won't be generated until you turn the lip back on.",
   'binDesigner.cutoutEditor.offBoardWarning': '{count} cutout(s) outside the board',
   'binDesigner.cutoutEditor.bringBackIn': 'Bring back in',
   'binDesigner.cutoutEditor.growBinToFit': 'Grow bin to {width} × {depth}',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Dividir",
   "binDesigner.cutoutDesktopOnly": "El editor de recortes está disponible en escritorio. Cambie a una pantalla más ancha para usar esta función.",
   "binDesigner.cutoutEditor.binSize": "Tamaño de bin",
+  "binDesigner.cutoutEditor.binFeatures": "Funciones del bin",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "La tapa necesita el borde de apilado, así que no se generará hasta que vuelvas a activarlo.",
   "binDesigner.cutoutEditor.boardCutouts": "Recortes",
   "binDesigner.cutoutEditor.boardSettings": "Tablero",
   "binDesigner.cutoutEditor.boardSize": "Tamaño del tablero",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Diviser",
   "binDesigner.cutoutDesktopOnly": "L'éditeur de découpes est disponible sur ordinateur. Veuillez passer à un écran plus large pour utiliser cette fonctionnalité.",
   "binDesigner.cutoutEditor.binSize": "Taille de bin",
+  "binDesigner.cutoutEditor.binFeatures": "Fonctions du bin",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Le couvercle a besoin de la lèvre d'empilage : il ne sera pas généré tant que vous ne l'aurez pas réactivée.",
   "binDesigner.cutoutEditor.boardCutouts": "Découpes",
   "binDesigner.cutoutEditor.boardSettings": "Plateau",
   "binDesigner.cutoutEditor.boardSize": "Taille du plateau",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Dividi",
   "binDesigner.cutoutDesktopOnly": "L'editor dei ritagli è disponibile su desktop. Passa a uno schermo più ampio per usare questa funzione.",
   "binDesigner.cutoutEditor.binSize": "Dimensione bin",
+  "binDesigner.cutoutEditor.binFeatures": "Funzioni del bin",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Il coperchio richiede il bordo di impilamento, quindi non verrà generato finché non lo riattivi.",
   "binDesigner.cutoutEditor.boardCutouts": "Ritagli",
   "binDesigner.cutoutEditor.boardSettings": "Pannello",
   "binDesigner.cutoutEditor.boardSize": "Dimensione pannello",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "分割",
   "binDesigner.cutoutDesktopOnly": "切り抜きエディターはデスクトップ専用です。より大きい画面に切り替えてご利用ください。",
   "binDesigner.cutoutEditor.binSize": "ビンサイズ",
+  "binDesigner.cutoutEditor.binFeatures": "ビンの機能",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "フタにはスタッキングリップが必要です。リップをオンに戻すまでフタは生成されません。",
   "binDesigner.cutoutEditor.boardCutouts": "切り抜き",
   "binDesigner.cutoutEditor.boardSettings": "ボード",
   "binDesigner.cutoutEditor.boardSize": "ボードサイズ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "분할",
   "binDesigner.cutoutDesktopOnly": "컷아웃 편집기는 데스크톱에서 사용할 수 있습니다. 이 기능을 사용하려면 더 넓은 화면으로 전환하세요.",
   "binDesigner.cutoutEditor.binSize": "수납통 크기",
+  "binDesigner.cutoutEditor.binFeatures": "빈 기능",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "뚜껑에는 스태킹 립이 필요하므로 립을 다시 켤 때까지 뚜껑은 생성되지 않습니다.",
   "binDesigner.cutoutEditor.boardCutouts": "컷아웃",
   "binDesigner.cutoutEditor.boardSettings": "보드",
   "binDesigner.cutoutEditor.boardSize": "보드 크기",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Del",
   "binDesigner.cutoutDesktopOnly": "Utskjæringsredigereren er tilgjengelig på datamaskinen. Bytt til en bredere skjerm for å bruke denne funksjonen.",
   "binDesigner.cutoutEditor.binSize": "Bin-størrelse",
+  "binDesigner.cutoutEditor.binFeatures": "Bin-funksjoner",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Lokket trenger stablekanten, så det blir ikke generert før du slår kanten på igjen.",
   "binDesigner.cutoutEditor.boardCutouts": "Utskjæringer",
   "binDesigner.cutoutEditor.boardSettings": "Brett",
   "binDesigner.cutoutEditor.boardSize": "Brettstørrelse",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Splitsen",
   "binDesigner.cutoutDesktopOnly": "De uitsnijdingseditor is beschikbaar op desktop. Schakel over naar een breder scherm om deze functie te gebruiken.",
   "binDesigner.cutoutEditor.binSize": "Bin-grootte",
+  "binDesigner.cutoutEditor.binFeatures": "Bin-functies",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Het deksel heeft de stapelrand nodig en wordt pas gegenereerd als je de rand weer inschakelt.",
   "binDesigner.cutoutEditor.boardCutouts": "Uitsparingen",
   "binDesigner.cutoutEditor.boardSettings": "Bord",
   "binDesigner.cutoutEditor.boardSize": "Bordgrootte",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Podziel",
   "binDesigner.cutoutDesktopOnly": "Edytor wycięć jest dostępny na komputerze. Przełącz się na szerszy ekran, aby użyć tej funkcji.",
   "binDesigner.cutoutEditor.binSize": "Rozmiar bina",
+  "binDesigner.cutoutEditor.binFeatures": "Funkcje bina",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Pokrywa wymaga rantu sztaplującego, więc nie zostanie wygenerowana, dopóki go nie włączysz z powrotem.",
   "binDesigner.cutoutEditor.boardCutouts": "Wycięcia",
   "binDesigner.cutoutEditor.boardSettings": "Płyta",
   "binDesigner.cutoutEditor.boardSize": "Rozmiar płyty",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Dividir",
   "binDesigner.cutoutDesktopOnly": "O editor de recortes está disponível no desktop. Mude para uma tela mais larga para usar este recurso.",
   "binDesigner.cutoutEditor.binSize": "Tamanho de bin",
+  "binDesigner.cutoutEditor.binFeatures": "Recursos do bin",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "A tampa precisa da borda de empilhamento, então ela não será gerada até você ligar a borda de novo.",
   "binDesigner.cutoutEditor.boardCutouts": "Recortes",
   "binDesigner.cutoutEditor.boardSettings": "Placa",
   "binDesigner.cutoutEditor.boardSize": "Tamanho da placa",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Dela",
   "binDesigner.cutoutDesktopOnly": "Urtagsredigeraren är tillgänglig på dator. Byt till en bredare skärm för att använda denna funktion.",
   "binDesigner.cutoutEditor.binSize": "Fackstorlek",
+  "binDesigner.cutoutEditor.binFeatures": "Bin-funktioner",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Locket behöver staplingskanten, så det genereras inte förrän du slår på kanten igen.",
   "binDesigner.cutoutEditor.boardCutouts": "Urtag",
   "binDesigner.cutoutEditor.boardSettings": "Bräda",
   "binDesigner.cutoutEditor.boardSize": "Brädstorlek",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "Розділити",
   "binDesigner.cutoutDesktopOnly": "Редактор вирізів доступний на десктопі. Перейдіть на ширший екран, щоб скористатися цією функцією.",
   "binDesigner.cutoutEditor.binSize": "Розмір біна",
+  "binDesigner.cutoutEditor.binFeatures": "Функції біна",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "Кришці потрібен штабелювальний бортик, тож вона не згенерується, доки ви не ввімкнете бортик знову.",
   "binDesigner.cutoutEditor.boardCutouts": "Вирізи",
   "binDesigner.cutoutEditor.boardSettings": "Дошка",
   "binDesigner.cutoutEditor.boardSize": "Розмір дошки",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -473,6 +473,8 @@
   "binDesigner.customSplit": "拆分",
   "binDesigner.cutoutDesktopOnly": "挖槽编辑器仅在桌面端可用。请切换到更宽的屏幕以使用此功能。",
   "binDesigner.cutoutEditor.binSize": "收纳盒尺寸",
+  "binDesigner.cutoutEditor.binFeatures": "收纳盒功能",
+  "binDesigner.cutoutEditor.lipOffPausesLid": "盖子需要堆叠唇边，重新开启唇边之前不会生成盖子。",
   "binDesigner.cutoutEditor.boardCutouts": "挖槽",
   "binDesigner.cutoutEditor.boardSettings": "画板",
   "binDesigner.cutoutEditor.boardSize": "画板尺寸",


### PR DESCRIPTION
## What

Adds a stacking-lip toggle to the cutout editor's inspector dock.

A shadow board or tool tray usually wants no lip, but the only control for it lived in the main parameter panel, which the cutout editor replaces. Reaching it meant leaving the editor and coming back.

It sits in the always-visible bin-level block alongside `BinSizeSection`, so it is reachable in every selection state (nothing selected, one shape, many).

## How

- `BinFeaturesSection` is self-wired to the designer store, like the `DimensionsSection` that `BinSizeSection` reuses, so `InspectorContent` gained no new props.
- The toggle mirrors `useBaseSection.toggleStackingLip` exactly: a bare `updateBase`, no constraint-engine round trip. The lip is the one base flag with no feature id in the engine, and a second surface inventing gating would make the two controls disagree.
- `updateBase` pushes a history entry, so the workspace's existing Ctrl+Z and undo button cover the toggle for free. There's a test pinning that.

## The lid coupling

`useLidSection` computes `effectiveEnabled = lid.enabled && base.stackingLip && !blocked` — clearing the lip stops the lid generating while `lid.enabled` stays persisted `true`. The main panel's Lid section explains that with "Requires stacking lip"; that section is off screen in the cutout editor, so the lid would just disappear with no reason given.

The new section repeats the warning when both conditions hold. README gotcha 9 now records the obligation rather than just the gate.

## Also

Both lip toggles now read their label from `assembledHeight.stackingLip` instead of the Base section's hardcoded English string, so the new control isn't a fresh untranslated literal and the two surfaces can't drift apart. Two genuinely-new keys (`binFeatures`, `lipOffPausesLid`) are translated across all 14 locales.

## Verification

- 7 new tests on `BinFeaturesSection` (store round-trip, undo capture, all three lid-warning states)
- Full bin-designer component suite: 264 files / 2280 tests green
- typecheck, eslint, and all four i18n checks clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a stacking‑lip toggle to the cutout editor’s inspector so you can turn the lip on/off without leaving the workspace. Shows a lid warning when the lip is off and supports undo.

- **New Features**
  - Added `BinFeaturesSection` to the inspector’s always-visible bin block; toggles the stacking lip via `updateBase` (no engine round-trip) and records undo.
  - `InspectorContent` now renders bin size and features across all selection states; tests pin the always-visible controls.
  - Displays a warning when `lid.enabled` is true but the lip is off, explaining why the lid isn’t generated.
  - Unified the lip label to `assembledHeight.stackingLip`; added `binDesigner.cutoutEditor.binFeatures` and `binDesigner.cutoutEditor.lipOffPausesLid` across all locales with key assertions.

<sup>Written for commit f8e607039dcbee528184fe5bf16423a1d59580d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

