### PR TITLE
feat(layout-export): export a slicer project file with parts on build plates

### DIFF
--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -176,6 +176,33 @@ export function buildSinglePiece3MF(
   threeMFPrintSettings: ThreeMFPrintSettings,
   applyMultiColor: boolean
 ): Blob {
+  const object = buildSinglePiece3MFObject(
+    pieceData,
+    faceGroups,
+    params,
+    modelName,
+    applyMultiColor
+  );
+  return export3MF(object.vertices, object.normals, {
+    name: modelName,
+    colorConfig: object.colorConfig,
+    printSettings: threeMFPrintSettings,
+  });
+}
+
+/**
+ * The coloured mesh behind {@link buildSinglePiece3MF}, before it is sealed
+ * into a file. Exposed so a whole-layout PROJECT export can carry the same
+ * `colorConfig` into a shared multi-plate file instead of re-deriving it (or,
+ * worse, shipping the part uncoloured).
+ */
+export function buildSinglePiece3MFObject(
+  pieceData: ArrayBuffer,
+  faceGroups: CombinedExportResult['faceGroups'],
+  params: BinParams,
+  modelName: string,
+  applyMultiColor: boolean
+): ThreeMFObject {
   const parseResult = parseSTLBinary(pieceData);
   if (isErr(parseResult)) {
     throw new Error(getUserMessage(parseResult.error));
@@ -210,11 +237,7 @@ export function buildSinglePiece3MF(
     }
   }
 
-  return export3MF(vertices, normals, {
-    name: modelName,
-    colorConfig,
-    printSettings: threeMFPrintSettings,
-  });
+  return { vertices, normals, name: modelName, colorConfig };
 }
 
 /** Map ancillary piece label → the ColorZone whose color paints the piece. */
@@ -382,6 +405,25 @@ export function buildMultiObject3MF(
   threeMFPrintSettings: ThreeMFPrintSettings,
   lidFaceGroups?: CombinedExportResult['lidFaceGroups']
 ): Blob {
+  return export3MFMultiObject(
+    buildMultiObject3MFObjects(pieces, faceGroups, params, lidFaceGroups),
+    { name: modelName, printSettings: threeMFPrintSettings }
+  );
+}
+
+/**
+ * The coloured objects behind {@link buildMultiObject3MF}, before they are
+ * sealed into a file. Exposed for the same reason as
+ * {@link buildSinglePiece3MFObject}: a whole-layout PROJECT export packs these
+ * onto build plates itself, and re-deriving the colour mapping there would
+ * duplicate the zone/cutout logic that lives here.
+ */
+export function buildMultiObject3MFObjects(
+  pieces: CombinedExportResult['pieces'],
+  faceGroups: CombinedExportResult['faceGroups'],
+  params: BinParams,
+  lidFaceGroups?: CombinedExportResult['lidFaceGroups']
+): ThreeMFObject[] {
   const objects: ThreeMFObject[] = [];
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors typed required but legacy persisted configs may omit it; runtime guard preserved
   const featureColorsEnabled: boolean = params.featureColors?.enabled ?? false;
@@ -459,10 +501,7 @@ export function buildMultiObject3MF(
     });
   }
 
-  return export3MFMultiObject(objects, {
-    name: modelName,
-    printSettings: threeMFPrintSettings,
-  });
+  return objects;
 }
 
 /**

--- a/src/features/generation/export/threemfColor.ts
+++ b/src/features/generation/export/threemfColor.ts
@@ -146,11 +146,23 @@ function dominantSlot(triangleMaterialIndices: readonly number[]): number {
  * sidecar fall back to today's paint_color-only behavior, so it can't regress
  * the already-working multi-zone bin.
  *
- * Returns undefined when no object carries colors (single-color assemblies
- * need no extruder overrides).
+ * The same file also declares BUILD PLATES. A `<plate>` carries its 1-based
+ * `plater_id` and one `<model_instance>` per part assigned to it, referencing
+ * the object by the same id the model XML used. That reference is the whole
+ * mechanism: the part's world transform decides where it is drawn, this decides
+ * which plate owns it, and a slicer renders a part floating off its plate if
+ * the two disagree. Note the key is `plater_name`, not `plate_name` (an
+ * upstream spelling that stuck).
+ *
+ * Returns undefined when no object carries colors AND no plates are declared
+ * (single-color single-plate assemblies need no sidecar at all).
  */
 export function buildModelSettingsConfig(
-  meshes: readonly { name: string; colorConfig?: ThreeMFColorConfig }[]
+  meshes: readonly {
+    name: string;
+    colorConfig?: ThreeMFColorConfig;
+    placement?: { plate: number };
+  }[]
 ): string | undefined {
   const entries: string[] = [];
   meshes.forEach((m, i) => {
@@ -165,8 +177,49 @@ export function buildModelSettingsConfig(
         `  </object>\n`
     );
   });
-  if (entries.length === 0) return undefined;
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<config>\n${entries.join('')}</config>\n`;
+
+  const plates = buildPlateEntries(meshes);
+  if (entries.length === 0 && plates.length === 0) return undefined;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<config>\n${entries.join('')}${plates.join('')}</config>\n`;
+}
+
+function buildPlateEntries(
+  meshes: readonly { placement?: { plate: number } }[]
+): readonly string[] {
+  const byPlate = new Map<number, number[]>();
+  meshes.forEach((m, i) => {
+    if (!m.placement) return;
+    const ids = byPlate.get(m.placement.plate);
+    if (ids) ids.push(i + 1);
+    else byPlate.set(m.placement.plate, [i + 1]);
+  });
+  if (byPlate.size === 0) return [];
+
+  // Emit every plate from 0 to the highest occupied index, in order. A gap
+  // would renumber the plates that follow it, silently moving parts to a
+  // different plate than the one they were packed onto.
+  const maxPlate = Math.max(...byPlate.keys());
+  const out: string[] = [];
+  for (let plate = 0; plate <= maxPlate; plate++) {
+    const ids = byPlate.get(plate) ?? [];
+    const instances = ids
+      .map(
+        (id) =>
+          `    <model_instance>\n` +
+          `      <metadata key="object_id" value="${id}"/>\n` +
+          `      <metadata key="instance_id" value="0"/>\n` +
+          `    </model_instance>\n`
+      )
+      .join('');
+    out.push(
+      `  <plate>\n` +
+        `    <metadata key="plater_id" value="${plate + 1}"/>\n` +
+        `    <metadata key="plater_name" value=""/>\n` +
+        instances +
+        `  </plate>\n`
+    );
+  }
+  return out;
 }
 
 /**

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -1315,4 +1315,126 @@ describe('threemfExporter', () => {
       }
     });
   });
+
+  describe('build plates', () => {
+    /** Unit square at a known spot, so its footprint centre is predictable. */
+    function square(x0: number, y0: number) {
+      const vertices = new Float32Array([
+        x0,
+        y0,
+        0,
+        x0 + 10,
+        y0,
+        0,
+        x0 + 10,
+        y0 + 10,
+        0,
+        x0,
+        y0,
+        0,
+        x0 + 10,
+        y0 + 10,
+        0,
+        x0,
+        y0 + 10,
+        0,
+      ]);
+      const normals = new Float32Array(Array.from({ length: 18 }, (_, i) => (i % 3 === 2 ? 1 : 0)));
+      return { vertices, normals };
+    }
+
+    const settingsOf = (buffer: Uint8Array): string =>
+      strFromU8(unzipSync(buffer)['Metadata/model_settings.config'] ?? new Uint8Array());
+
+    it('omits the sidecar entirely when nothing is placed or coloured', () => {
+      const buffer = build3MFMultiObjectBuffer([{ ...square(0, 0), name: 'a' }], { name: 'plain' });
+      expect(unzipSync(buffer)['Metadata/model_settings.config']).toBeUndefined();
+    });
+
+    it('declares one plate per occupied index with 1-based plater_id', () => {
+      const buffer = build3MFMultiObjectBuffer(
+        [
+          { ...square(0, 0), name: 'a', placement: { plate: 0, x: 50, y: 50 } },
+          { ...square(0, 0), name: 'b', placement: { plate: 1, x: 60, y: 60 } },
+        ],
+        { name: 'plates' }
+      );
+      const settings = settingsOf(buffer);
+      expect(settings).toContain('<metadata key="plater_id" value="1"/>');
+      expect(settings).toContain('<metadata key="plater_id" value="2"/>');
+      expect(settings.match(/<plate>/g) ?? []).toHaveLength(2);
+    });
+
+    it('assigns each object to its own plate by object_id', () => {
+      const buffer = build3MFMultiObjectBuffer(
+        [
+          { ...square(0, 0), name: 'a', placement: { plate: 0, x: 50, y: 50 } },
+          { ...square(0, 0), name: 'b', placement: { plate: 1, x: 60, y: 60 } },
+          { ...square(0, 0), name: 'c', placement: { plate: 0, x: 90, y: 50 } },
+        ],
+        { name: 'plates' }
+      );
+      const plates = settingsOf(buffer).split('<plate>').slice(1);
+      // Objects are numbered in emission order, so a and c (ids 1 and 3) share
+      // plate 1 and b (id 2) is alone on plate 2.
+      expect(plates[0]).toContain('value="1"');
+      expect(plates[0]).toContain('value="3"');
+      expect(plates[1]).toContain('value="2"');
+    });
+
+    it('emits an empty plate rather than renumbering around a gap', () => {
+      // A skipped plate index must still produce a <plate>: dropping it would
+      // shift every later plate down one and move parts off the plate they were
+      // packed onto.
+      const buffer = build3MFMultiObjectBuffer(
+        [{ ...square(0, 0), name: 'a', placement: { plate: 2, x: 50, y: 50 } }],
+        { name: 'gap' }
+      );
+      const settings = settingsOf(buffer);
+      expect(settings.match(/<plate>/g) ?? []).toHaveLength(3);
+      expect(settings).toContain('<metadata key="plater_id" value="3"/>');
+    });
+
+    it('carries each placed part to its own spot instead of a shared centre', () => {
+      const buffer = build3MFMultiObjectBuffer(
+        [
+          { ...square(0, 0), name: 'a', placement: { plate: 0, x: 50, y: 50 } },
+          { ...square(0, 0), name: 'b', placement: { plate: 0, x: 150, y: 90 } },
+        ],
+        { name: 'placed' }
+      );
+      const xml = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
+      const items = [
+        ...xml.matchAll(/<item objectid="\d+" transform="[^"]*?([-\d.]+) ([-\d.]+) ([-\d.]+)"/g),
+      ];
+      expect(items).toHaveLength(2);
+      // Footprint centre of the square is (5, 5), so the translation is the
+      // placement minus that centre.
+      expect(Number(items[0][1])).toBeCloseTo(45, 6);
+      expect(Number(items[0][2])).toBeCloseTo(45, 6);
+      expect(Number(items[1][1])).toBeCloseTo(145, 6);
+      expect(Number(items[1][2])).toBeCloseTo(85, 6);
+    });
+
+    it('sits every placed part on the bed', () => {
+      const raised = square(0, 0);
+      const lifted = new Float32Array(raised.vertices);
+      for (let i = 2; i < lifted.length; i += 3) lifted[i] += 12;
+      const buffer = build3MFMultiObjectBuffer(
+        [
+          {
+            vertices: lifted,
+            normals: raised.normals,
+            name: 'a',
+            placement: { plate: 0, x: 50, y: 50 },
+          },
+        ],
+        { name: 'bed' }
+      );
+      const xml = strFromU8(unzipSync(buffer)['3D/3dmodel.model']);
+      const m = xml.match(/<item objectid="\d+" transform="[^"]*?([-\d.]+) ([-\d.]+) ([-\d.]+)"/);
+      expect(m).not.toBeNull();
+      expect(Number(m?.[3])).toBeCloseTo(-12, 6);
+    });
+  });
 });

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -47,6 +47,7 @@ export function build3MFMultiObjectBuffer(
     mesh: deduplicateVertices(obj.vertices),
     name: obj.name,
     colorConfig: obj.colorConfig,
+    placement: obj.placement,
   }));
 
   const palette = unifiedPalette(meshes.map((m) => m.colorConfig));

--- a/src/features/generation/export/threemfTypes.ts
+++ b/src/features/generation/export/threemfTypes.ts
@@ -3,11 +3,31 @@ export interface ThreeMFColorConfig {
   readonly triangleMaterialIndices: readonly number[];
 }
 
+/**
+ * Where a part sits when the file carries build plates.
+ *
+ * `x`/`y` are WORLD coordinates with the plate's own origin already applied,
+ * because BambuStudio/OrcaSlicer lay plates out as a grid in one world space
+ * (`PartPlateList`, stride = bed size * 1.2). Resolving the origin in the
+ * caller keeps the grid math in one tested place: the transform written here
+ * and the `plater_id` written into `model_settings.config` come from the same
+ * computation, and a slicer shows parts floating off their plate if they
+ * disagree.
+ */
+export interface ThreeMFPlacement {
+  /** Zero-based plate index. Serialised as a 1-based `plater_id`. */
+  readonly plate: number;
+  /** World centre of the part's footprint, in mm. */
+  readonly x: number;
+  readonly y: number;
+}
+
 export interface ThreeMFObject {
   readonly vertices: Float32Array;
   readonly normals: Float32Array;
   readonly name: string;
   readonly colorConfig?: ThreeMFColorConfig;
+  readonly placement?: ThreeMFPlacement;
 }
 
 export interface ThreeMFOptions {

--- a/src/features/generation/export/threemfXml.ts
+++ b/src/features/generation/export/threemfXml.ts
@@ -1,4 +1,9 @@
-import type { IndexedMesh, ThreeMFColorConfig, ThreeMFOptions } from './threemfTypes';
+import type {
+  IndexedMesh,
+  ThreeMFColorConfig,
+  ThreeMFOptions,
+  ThreeMFPlacement,
+} from './threemfTypes';
 import { centeringTranslation, computeBBox, mergeBBoxes } from './threemfGeometry';
 import {
   activeColorConfig,
@@ -64,6 +69,7 @@ export function buildMultiObjectModelXML(
     mesh: IndexedMesh;
     name: string;
     colorConfig?: ThreeMFColorConfig;
+    placement?: ThreeMFPlacement;
   }[],
   options: ThreeMFOptions
 ): string {
@@ -78,9 +84,12 @@ export function buildMultiObjectModelXML(
   });
 
   const anyHasColors = resolved.some((obj) => obj.colorConfig !== undefined);
+  const placed = resolved.some((obj) => obj.placement !== undefined);
 
   // Single shared offset across all objects so the bin + dividers + lid keep
-  // their relative positions and the assembly lands centered together.
+  // their relative positions and the assembly lands centered together. Only
+  // used when the file has no plate layout: a placed export positions each part
+  // independently, so a shared offset would stack them all on one spot.
   const combinedBBox = mergeBBoxes(resolved.map((obj) => computeBBox(obj.mesh.vertices)));
   const offset = centeringTranslation(combinedBBox);
 
@@ -98,15 +107,38 @@ export function buildMultiObjectModelXML(
 
   xml += '  </resources>\n';
   xml += '  <build>\n';
-  const tx = formatFloat(offset.x);
-  const ty = formatFloat(offset.y);
-  const tz = formatFloat(offset.z);
-  for (const id of objectIds) {
-    xml += `    <item objectid="${id}" transform="1 0 0 0 1 0 0 0 1 ${tx} ${ty} ${tz}" />\n`;
+  if (placed) {
+    resolved.forEach((obj, i) => {
+      xml += `    <item objectid="${objectIds[i]}" transform="1 0 0 0 1 0 0 0 1 ${placedTranslation(obj)}" />\n`;
+    });
+  } else {
+    const tx = formatFloat(offset.x);
+    const ty = formatFloat(offset.y);
+    const tz = formatFloat(offset.z);
+    for (const id of objectIds) {
+      xml += `    <item objectid="${id}" transform="1 0 0 0 1 0 0 0 1 ${tx} ${ty} ${tz}" />\n`;
+    }
   }
   xml += '  </build>\n';
   xml += '</model>';
   return xml;
+}
+
+/**
+ * Translation that carries one part's mesh to its packed spot: footprint centre
+ * onto the placement, underside onto the bed. An object without a placement in
+ * an otherwise-placed export falls back to its own centre so it lands on plate
+ * 1 rather than wherever its authored coordinates happen to sit.
+ */
+function placedTranslation(obj: { mesh: IndexedMesh; placement?: ThreeMFPlacement }): string {
+  const bbox = computeBBox(obj.mesh.vertices);
+  if (!bbox) return '0 0 0';
+  const centreX = (bbox.min.x + bbox.max.x) / 2;
+  const centreY = (bbox.min.y + bbox.max.y) / 2;
+  const target = obj.placement ?? centeringTranslation(bbox);
+  const x = obj.placement ? target.x - centreX : target.x;
+  const y = obj.placement ? target.y - centreY : target.y;
+  return `${formatFloat(x)} ${formatFloat(y)} ${formatFloat(-bbox.min.z)}`;
 }
 
 function buildMetadataXml(options: ThreeMFOptions, flags: { bambuCompat: boolean }): string {

--- a/src/shell/layoutExport/buildLayoutManifest.ts
+++ b/src/shell/layoutExport/buildLayoutManifest.ts
@@ -88,6 +88,18 @@ export interface LayoutManifestInput {
   } | null;
   /** Present when socket-mode designs shipped swappable label plates. */
   readonly labels?: readonly ManifestLabelGroup[] | null;
+  /**
+   * Present when the parts were folded into one slicer project file. The
+   * archive then holds a single model file, so the per-bin paths listed below
+   * name objects inside it rather than files on disk.
+   */
+  readonly project?: {
+    readonly fileName: string;
+    readonly plateCount: number;
+    readonly partCount: number;
+    /** Parts that exceed the print bed and landed on a plate of their own. */
+    readonly oversizeNames: readonly string[];
+  } | null;
   readonly skipped: ManifestSkipped;
   readonly totals: { readonly filamentGrams: number; readonly printTimeMinutes: number };
 }
@@ -130,7 +142,7 @@ function formatTime(minutes: number): string {
 }
 
 export function buildLayoutManifest(input: LayoutManifestInput): string {
-  const { layoutName, format, bins, baseplate, skipped, totals } = input;
+  const { layoutName, format, bins, baseplate, skipped, totals, project } = input;
   const totalBinFiles = bins.length;
   const totalBinUnits = bins.reduce((sum, b) => sum + b.quantity, 0);
 
@@ -147,6 +159,24 @@ export function buildLayoutManifest(input: LayoutManifestInput): string {
     lines.push(`  Baseplate: ${baseplate.pieceCount} ${plural(baseplate.pieceCount, 'file')}`);
   }
   lines.push('');
+
+  if (project) {
+    lines.push(
+      '─── Project file ────────────────────────────────',
+      '',
+      `  ${project.fileName}`,
+      `    ${project.partCount} ${plural(project.partCount, 'part')} arranged on ` +
+        `${project.plateCount} build ${plural(project.plateCount, 'plate')}.`,
+      '    Open it in Bambu Studio or OrcaSlicer and every plate is ready to slice.',
+      '    PrusaSlicer has no multi-plate concept and will load the parts onto one plate.'
+    );
+    if (project.oversizeNames.length > 0) {
+      lines.push(
+        `    Too large for the bed, each on its own plate: ${project.oversizeNames.join(', ')}`
+      );
+    }
+    lines.push('');
+  }
 
   lines.push('─── Bins ────────────────────────────────────────', '');
   if (bins.length === 0) {

--- a/src/shell/layoutExport/buildProjectFile.test.ts
+++ b/src/shell/layoutExport/buildProjectFile.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { unzipSync, strFromU8 } from 'fflate';
+import {
+  buildLayoutProjectFile,
+  createProjectPartCollector,
+  footprintOf,
+} from './buildProjectFile';
+import { plateOrigin, LOGICAL_PLATE_GAP } from './platePacking';
+import type { ThreeMFObject, ThreeMFPrintSettings } from '@/shared/generation/export';
+
+const BED = 256;
+
+const PRINT: ThreeMFPrintSettings = {
+  layerHeight: 0.2,
+  infillPercent: 15,
+  material: 'PLA',
+  supportRequired: false,
+  estimatedMinutes: 0,
+  estimatedGrams: 0,
+};
+
+/** Flat square part of `size` mm, sitting at the origin. */
+function part(name: string, size: number, extra?: Partial<ThreeMFObject>): ThreeMFObject {
+  const v = new Float32Array([
+    0,
+    0,
+    0,
+    size,
+    0,
+    0,
+    size,
+    size,
+    0,
+    0,
+    0,
+    0,
+    size,
+    size,
+    0,
+    0,
+    size,
+    0,
+  ]);
+  const n = new Float32Array(Array.from({ length: 18 }, (_, i) => (i % 3 === 2 ? 1 : 0)));
+  return { vertices: v, normals: n, name, ...extra };
+}
+
+/** Minimal binary STL with one triangle, for the collector. */
+function binaryStl(): ArrayBuffer {
+  const buf = new ArrayBuffer(84 + 50);
+  const view = new DataView(buf);
+  view.setUint32(80, 1, true);
+  const coords = [0, 0, 1, 0, 0, 0, 10, 0, 0, 10, 10, 0];
+  coords.forEach((c, i) => view.setFloat32(84 + i * 4, c, true));
+  return buf;
+}
+
+const opts = { name: 'layout', bedWidthMm: BED, bedDepthMm: BED, printSettings: PRINT };
+
+async function filesOf(parts: readonly ThreeMFObject[]) {
+  const result = await buildLayoutProjectFile(parts, opts);
+  if (!result) throw new Error('expected a project file');
+  const files = unzipSync(new Uint8Array(result.data));
+  return {
+    result,
+    model: strFromU8(files['3D/3dmodel.model']),
+    settings: strFromU8(files['Metadata/model_settings.config'] ?? new Uint8Array()),
+  };
+}
+
+describe('footprintOf', () => {
+  it('measures the XY bounding box and ignores Z', () => {
+    expect(footprintOf(new Float32Array([0, 0, 0, 30, 10, 99, 5, 4, -7]))).toEqual({
+      widthMm: 30,
+      depthMm: 10,
+    });
+  });
+
+  it('returns a zero footprint for an empty mesh', () => {
+    expect(footprintOf(new Float32Array([]))).toEqual({ widthMm: 0, depthMm: 0 });
+  });
+});
+
+describe('createProjectPartCollector', () => {
+  it('parses STL parts and keeps their name', () => {
+    const c = createProjectPartCollector();
+    c.addStl('bin-a', binaryStl());
+    expect(c.parts).toHaveLength(1);
+    expect(c.parts[0].name).toBe('bin-a');
+    expect(c.parts[0].vertices.length).toBe(9);
+  });
+
+  it('skips an unparseable payload instead of throwing', () => {
+    const c = createProjectPartCollector();
+    c.addStl('broken', new ArrayBuffer(4));
+    expect(c.parts).toHaveLength(0);
+  });
+
+  it('takes pre-coloured objects as they are', () => {
+    const c = createProjectPartCollector();
+    const coloured = part('lid', 20, {
+      colorConfig: { materials: [{ color: '#ff0000' }], triangleMaterialIndices: [0, 0] },
+    });
+    c.addObjects([coloured]);
+    expect(c.parts[0].colorConfig).toBe(coloured.colorConfig);
+  });
+});
+
+describe('buildLayoutProjectFile', () => {
+  it('returns null when there is nothing to place', async () => {
+    expect(await buildLayoutProjectFile([], opts)).toBeNull();
+  });
+
+  it('returns null when every part is empty geometry', async () => {
+    const empty: ThreeMFObject = {
+      vertices: new Float32Array([]),
+      normals: new Float32Array([]),
+      name: 'empty',
+    };
+    expect(await buildLayoutProjectFile([empty], opts)).toBeNull();
+  });
+
+  it('puts a small set on one plate', async () => {
+    const { result, settings } = await filesOf([part('a', 40), part('b', 40)]);
+    expect(result.plateCount).toBe(1);
+    expect(result.partCount).toBe(2);
+    expect(settings.match(/<plate>/g) ?? []).toHaveLength(1);
+  });
+
+  it('preserves a part colour config through packing', async () => {
+    // Packing must not flatten multi-colour designs: the config survives into
+    // the per-object extruder assignment in the sidecar.
+    const { settings } = await filesOf([
+      part('a', 40),
+      part('lid', 40, {
+        colorConfig: {
+          materials: [{ color: '#101010' }, { color: '#ff0000' }],
+          triangleMaterialIndices: [1, 1],
+        },
+      }),
+    ]);
+    expect(settings).toContain('<metadata key="name" value="lid"/>');
+    expect(settings).toContain('<metadata key="extruder" value="2"/>');
+  });
+
+  it('agrees between plate assignment and world transform', async () => {
+    // THE invariant: a part drawn outside the plate it is assigned to shows up
+    // in the slicer floating off its bed. Both come from the same packing, so
+    // this pins them together.
+    const parts = Array.from({ length: 30 }, (_, i) => part(`p${i}`, 60));
+    const { result, model, settings } = await filesOf(parts);
+    expect(result.plateCount).toBeGreaterThan(1);
+
+    // object id -> plate index, read back from the sidecar.
+    const assigned = new Map<number, number>();
+    settings
+      .split('<plate>')
+      .slice(1)
+      .forEach((block) => {
+        const plateId = Number(block.match(/plater_id" value="(\d+)"/)?.[1]);
+        for (const m of block.matchAll(/object_id" value="(\d+)"/g)) {
+          assigned.set(Number(m[1]), plateId - 1);
+        }
+      });
+    expect(assigned.size).toBe(parts.length);
+
+    const items = [
+      ...model.matchAll(/<item objectid="(\d+)" transform="[^"]*?([-\d.]+) ([-\d.]+) [-\d.]+"/g),
+    ];
+    expect(items).toHaveLength(parts.length);
+
+    for (const item of items) {
+      const id = Number(item[1]);
+      const plate = assigned.get(id);
+      expect(plate, `object ${id} has no plate`).toBeDefined();
+      const origin = plateOrigin(plate ?? 0, result.plateCount, BED, BED);
+      // The transform carries the part's min corner, so its centre is +30mm.
+      const cx = Number(item[2]) + 30;
+      const cy = Number(item[3]) + 30;
+      expect(cx).toBeGreaterThanOrEqual(origin.x);
+      expect(cx).toBeLessThanOrEqual(origin.x + BED);
+      expect(cy).toBeGreaterThanOrEqual(origin.y);
+      expect(cy).toBeLessThanOrEqual(origin.y + BED);
+    }
+  });
+
+  it('strides plates by the slicer gap so they do not overlap', async () => {
+    const parts = Array.from({ length: 30 }, (_, i) => part(`p${i}`, 60));
+    const { result, model } = await filesOf(parts);
+    const xs = [
+      ...model.matchAll(/<item objectid="\d+" transform="[^"]*?([-\d.]+) [-\d.]+ [-\d.]+"/g),
+    ].map((m) => Number(m[1]));
+    // Something must land beyond the first bed, on the second column.
+    expect(Math.max(...xs)).toBeGreaterThan(BED * (1 + LOGICAL_PLATE_GAP) - 1);
+    expect(result.plateCount).toBeGreaterThan(1);
+  });
+
+  it('reports parts too large for the bed by name', async () => {
+    const { result } = await filesOf([part('normal', 40), part('enormous', 400)]);
+    expect(result.oversizeNames).toEqual(['enormous']);
+  });
+});

--- a/src/shell/layoutExport/buildProjectFile.ts
+++ b/src/shell/layoutExport/buildProjectFile.ts
@@ -1,0 +1,151 @@
+/**
+ * Packs a layout's parts into ONE slicer project file with every part already
+ * placed on a build plate.
+ *
+ * Takes `ThreeMFObject`s rather than model files so a part keeps the
+ * `colorConfig` its own builder derived (`buildMultiObject3MFObjects`,
+ * `buildLabelPlateColorConfig`). Re-deriving colour here would duplicate the
+ * zone/cutout logic; dropping it would silently flatten multi-colour designs.
+ *
+ * Bambu Studio and OrcaSlicer read the plate assignment from
+ * `model_settings.config` while drawing each part at its world transform in
+ * `3dmodel.model`. Both come from the same `packOntoPlates` result here, so
+ * they cannot disagree.
+ */
+
+import { isOk } from '@/core/result';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { export3MFMultiObject } from '@/shared/generation/export';
+import type {
+  ThreeMFObject,
+  ThreeMFPrintSettings,
+  ThreeMFColorConfig,
+} from '@/shared/generation/export';
+import {
+  packOntoPlates,
+  plateOrigin,
+  DEFAULT_PART_SPACING_MM,
+  DEFAULT_PLATE_MARGIN_MM,
+} from './platePacking';
+import type { PlatePackingItem } from './platePacking';
+
+export interface BuildProjectFileOptions {
+  readonly name: string;
+  readonly bedWidthMm: number;
+  readonly bedDepthMm: number;
+  readonly printSettings: ThreeMFPrintSettings;
+}
+
+export interface ProjectFileResult {
+  readonly data: ArrayBuffer;
+  readonly plateCount: number;
+  readonly partCount: number;
+  /** Names of parts that exceed the usable bed area. */
+  readonly oversizeNames: readonly string[];
+}
+
+export interface ProjectPartCollector {
+  /** Add a part from raw binary STL. Unparseable payloads are skipped. */
+  readonly addStl: (name: string, stl: ArrayBuffer, colorConfig?: ThreeMFColorConfig) => void;
+  /** Add parts that already carry their own colour mapping. */
+  readonly addObjects: (objects: readonly ThreeMFObject[]) => void;
+  readonly parts: readonly ThreeMFObject[];
+}
+
+/**
+ * Gathers parts across the export's phases, which produce geometry in three
+ * shapes: raw STL from the worker, coloured `ThreeMFObject`s from the bin
+ * builders, and STL plus a separately-derived colour config for label sheets.
+ */
+export function createProjectPartCollector(): ProjectPartCollector {
+  const parts: ThreeMFObject[] = [];
+  return {
+    addStl(name, stl, colorConfig) {
+      const parsed = parseSTLBinary(stl);
+      if (!isOk(parsed)) return;
+      parts.push({
+        vertices: parsed.value.vertices,
+        normals: parsed.value.normals,
+        name,
+        colorConfig,
+      });
+    },
+    addObjects(objects) {
+      parts.push(...objects);
+    },
+    parts,
+  };
+}
+
+/** Footprint bounding box, which is what the packer arranges. */
+export function footprintOf(vertices: Float32Array): PlatePackingItem {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (let i = 0; i < vertices.length; i += 3) {
+    const x = vertices[i];
+    const y = vertices[i + 1];
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(minY)) {
+    return { widthMm: 0, depthMm: 0 };
+  }
+  return { widthMm: maxX - minX, depthMm: maxY - minY };
+}
+
+/**
+ * Build the project file. Returns null when no part carries geometry, so the
+ * caller ships the individual parts rather than replacing them with an empty
+ * file.
+ */
+export async function buildLayoutProjectFile(
+  parts: readonly ThreeMFObject[],
+  options: BuildProjectFileOptions
+): Promise<ProjectFileResult | null> {
+  const usable = parts.filter((p) => p.vertices.length > 0);
+  if (usable.length === 0) return null;
+
+  const packing = packOntoPlates(
+    usable.map((p) => footprintOf(p.vertices)),
+    {
+      bedWidthMm: options.bedWidthMm,
+      bedDepthMm: options.bedDepthMm,
+      spacingMm: DEFAULT_PART_SPACING_MM,
+      marginMm: DEFAULT_PLATE_MARGIN_MM,
+    }
+  );
+
+  const placed: ThreeMFObject[] = usable.map((part, i) => {
+    const placement = packing.placements[i];
+    const origin = plateOrigin(
+      placement.plate,
+      packing.plateCount,
+      options.bedWidthMm,
+      options.bedDepthMm
+    );
+    return {
+      ...part,
+      placement: {
+        plate: placement.plate,
+        x: origin.x + placement.x,
+        y: origin.y + placement.y,
+      },
+    };
+  });
+
+  const blob = export3MFMultiObject(placed, {
+    name: options.name,
+    printSettings: options.printSettings,
+  });
+
+  return {
+    data: await blob.arrayBuffer(),
+    plateCount: packing.plateCount,
+    partCount: placed.length,
+    oversizeNames: packing.oversizeIndices.map((i) => usable[i].name),
+  };
+}

--- a/src/shell/layoutExport/platePacking.test.ts
+++ b/src/shell/layoutExport/platePacking.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import {
+  packOntoPlates,
+  plateColumnCount,
+  plateOrigin,
+  LOGICAL_PLATE_GAP,
+  DEFAULT_PART_SPACING_MM,
+  DEFAULT_PLATE_MARGIN_MM,
+} from './platePacking';
+import type { PlatePackingItem, PlatePackingOptions, PlatePlacement } from './platePacking';
+
+const BED: PlatePackingOptions = {
+  bedWidthMm: 256,
+  bedDepthMm: 256,
+  spacingMm: DEFAULT_PART_SPACING_MM,
+  marginMm: DEFAULT_PLATE_MARGIN_MM,
+};
+
+/** 1x1 gridfinity bin footprint. */
+const unit = (w: number, d: number): PlatePackingItem => ({ widthMm: w * 42, depthMm: d * 42 });
+
+/** Axis-aligned overlap test on the same plate. */
+function overlaps(
+  a: PlatePlacement,
+  ai: PlatePackingItem,
+  b: PlatePlacement,
+  bi: PlatePackingItem
+): boolean {
+  if (a.plate !== b.plate) return false;
+  const dx = Math.abs(a.x - b.x);
+  const dy = Math.abs(a.y - b.y);
+  return dx < (ai.widthMm + bi.widthMm) / 2 && dy < (ai.depthMm + bi.depthMm) / 2;
+}
+
+describe('plateColumnCount', () => {
+  it('mirrors the slicer grid: a square-ish column count', () => {
+    // compute_colum_count in PartPlate.hpp: round(sqrt(n)), +1 when sqrt
+    // overshoots the round. 5 plates -> sqrt 2.24, round 2, so 3 columns.
+    expect(plateColumnCount(1)).toBe(1);
+    expect(plateColumnCount(2)).toBe(2);
+    expect(plateColumnCount(4)).toBe(2);
+    expect(plateColumnCount(5)).toBe(3);
+    expect(plateColumnCount(9)).toBe(3);
+    expect(plateColumnCount(10)).toBe(4);
+  });
+
+  it('never returns zero columns for an empty or single plate', () => {
+    expect(plateColumnCount(0)).toBe(1);
+  });
+});
+
+describe('plateOrigin', () => {
+  it('places the first plate at the world origin', () => {
+    expect(plateOrigin(0, 1, 256, 256)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('strides by the bed size plus the fixed logical gap', () => {
+    // LOGICAL_PART_PLATE_GAP is 1/5 in PartPlate.hpp, so the stride is 1.2x bed.
+    expect(plateOrigin(1, 2, 256, 256)).toEqual({ x: 256 * (1 + LOGICAL_PLATE_GAP), y: 0 });
+  });
+
+  it('advances rows in NEGATIVE Y', () => {
+    // origin(1) = -row * depth * 1.2 — getting this sign wrong puts row 2
+    // behind the printer instead of in front of it.
+    const third = plateOrigin(2, 4, 256, 200);
+    expect(third.x).toBe(0);
+    expect(third.y).toBe(-200 * (1 + LOGICAL_PLATE_GAP));
+  });
+});
+
+describe('packOntoPlates', () => {
+  it('returns nothing for no items', () => {
+    const result = packOntoPlates([], BED);
+    expect(result.placements).toEqual([]);
+    expect(result.plateCount).toBe(0);
+  });
+
+  it('keeps a small set on one plate', () => {
+    const items = [unit(1, 1), unit(2, 1), unit(1, 2)];
+    const result = packOntoPlates(items, BED);
+    expect(result.plateCount).toBe(1);
+    expect(result.placements.every((p) => p.plate === 0)).toBe(true);
+  });
+
+  it('returns one placement per item in input order', () => {
+    // Placement is computed in sorted order, so an off-by-one in the index
+    // carry would silently transpose two parts.
+    const items = [unit(1, 1), unit(4, 4), unit(2, 2)];
+    const result = packOntoPlates(items, BED);
+    expect(result.placements).toHaveLength(3);
+    expect(result.placements.every((p) => p !== undefined)).toBe(true);
+  });
+
+  it('never overlaps two parts on the same plate', () => {
+    const items = Array.from({ length: 40 }, (_, i) => unit((i % 3) + 1, (i % 2) + 1));
+    const { placements } = packOntoPlates(items, BED);
+    for (let i = 0; i < items.length; i++) {
+      for (let j = i + 1; j < items.length; j++) {
+        expect(
+          overlaps(placements[i], items[i], placements[j], items[j]),
+          `item ${i} overlaps item ${j}`
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('keeps every part inside the usable bed area', () => {
+    const items = Array.from({ length: 25 }, () => unit(2, 2));
+    const { placements } = packOntoPlates(items, BED);
+    placements.forEach((p, i) => {
+      expect(p.x - items[i].widthMm / 2).toBeGreaterThanOrEqual(BED.marginMm - 1e-9);
+      expect(p.y - items[i].depthMm / 2).toBeGreaterThanOrEqual(BED.marginMm - 1e-9);
+      expect(p.x + items[i].widthMm / 2).toBeLessThanOrEqual(BED.bedWidthMm - BED.marginMm + 1e-9);
+      expect(p.y + items[i].depthMm / 2).toBeLessThanOrEqual(BED.bedDepthMm - BED.marginMm + 1e-9);
+    });
+  });
+
+  it('opens a second plate once the bed is full', () => {
+    // 30 x 2x2 bins (84mm each) cannot fit a 246mm usable square.
+    const items = Array.from({ length: 30 }, () => unit(2, 2));
+    const result = packOntoPlates(items, BED);
+    expect(result.plateCount).toBeGreaterThan(1);
+  });
+
+  it('gives an oversize part its own plate instead of dropping it', () => {
+    const items = [unit(1, 1), { widthMm: 400, depthMm: 400 }, unit(1, 1)];
+    const result = packOntoPlates(items, BED);
+    expect(result.oversizeIndices).toEqual([1]);
+    expect(result.placements).toHaveLength(3);
+    const oversizePlate = result.placements[1].plate;
+    expect(result.placements.filter((p) => p.plate === oversizePlate)).toHaveLength(1);
+  });
+
+  it('does not report a trailing empty plate when the last part is oversize', () => {
+    // The oversize branch opens a fresh plate for whatever comes next; if that
+    // plate counted as used, the slicer would show an empty plate at the end.
+    const result = packOntoPlates([unit(1, 1), { widthMm: 400, depthMm: 400 }], BED);
+    expect(result.plateCount).toBe(2);
+  });
+
+  it('counts exactly the plates it used', () => {
+    const items = Array.from({ length: 12 }, () => unit(2, 2));
+    const { placements, plateCount } = packOntoPlates(items, BED);
+    const used = new Set(placements.map((p) => p.plate));
+    expect(used.size).toBe(plateCount);
+    expect(Math.max(...used)).toBe(plateCount - 1);
+  });
+});

--- a/src/shell/layoutExport/platePacking.ts
+++ b/src/shell/layoutExport/platePacking.ts
@@ -1,0 +1,174 @@
+/**
+ * Packs export parts onto build plates.
+ *
+ * Shelf-based first-fit-decreasing: parts are sorted deepest-first and laid
+ * into rows across the bed, opening a new plate when the current one runs out
+ * of depth. Good enough for gridfinity footprints, which are near-uniform
+ * multiples of 42mm, and it keeps the result stable and inspectable rather
+ * than chasing optimal packing.
+ *
+ * Pure and self-contained so the placement can be asserted without a kernel or
+ * a slicer: the world transform written into `3dmodel.model` and the plate
+ * assignment written into `model_settings.config` are both derived from this
+ * output, and they must agree or parts float off their plate.
+ */
+
+/** A part to place, measured by its footprint bounding box. */
+export interface PlatePackingItem {
+  readonly widthMm: number;
+  readonly depthMm: number;
+}
+
+/** Where a part ended up: plate index plus its centre on that plate. */
+export interface PlatePlacement {
+  /** Zero-based plate index. */
+  readonly plate: number;
+  /** Centre offset from the plate's front-left usable corner, in mm. */
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface PlatePackingOptions {
+  readonly bedWidthMm: number;
+  readonly bedDepthMm: number;
+  /** Gap between neighbouring parts, in mm. */
+  readonly spacingMm: number;
+  /** Keep-out inset from each bed edge, in mm. */
+  readonly marginMm: number;
+}
+
+export interface PlatePackingResult {
+  /** One placement per input item, in input order. */
+  readonly placements: readonly PlatePlacement[];
+  readonly plateCount: number;
+  /**
+   * Indices of items too large for the usable bed area at any rotation. They
+   * are still placed (on their own plate, centred) rather than dropped, so an
+   * oversize part reaches the slicer visibly instead of vanishing from the
+   * export.
+   */
+  readonly oversizeIndices: readonly number[];
+}
+
+export const DEFAULT_PART_SPACING_MM = 4;
+export const DEFAULT_PLATE_MARGIN_MM = 5;
+
+/**
+ * Plate grid geometry, mirroring OrcaSlicer/BambuStudio `PartPlateList`.
+ *
+ * Plates are not a list but a square-ish grid in world space, and every plate
+ * origin is a multiple of the bed size plus a fixed 1/5 gap
+ * (`LOGICAL_PART_PLATE_GAP` in `PartPlate.hpp`). Y advances NEGATIVE per row.
+ */
+export const LOGICAL_PLATE_GAP = 1 / 5;
+
+/** Columns the slicer lays plates out in for a given plate count. */
+export function plateColumnCount(plateCount: number): number {
+  if (plateCount <= 1) return 1;
+  const value = Math.sqrt(plateCount);
+  const rounded = Math.round(value);
+  return value > rounded ? rounded + 1 : rounded;
+}
+
+/** World-space origin of plate `index` within a `plateCount` grid. */
+export function plateOrigin(
+  index: number,
+  plateCount: number,
+  bedWidthMm: number,
+  bedDepthMm: number
+): { x: number; y: number } {
+  const cols = plateColumnCount(plateCount);
+  const col = index % cols;
+  const row = Math.floor(index / cols);
+  return {
+    x: col * bedWidthMm * (1 + LOGICAL_PLATE_GAP),
+    // Row 0 is written explicitly rather than as `-0 * depth`: negative zero
+    // survives into the transform matrix and serialises as "-0".
+    y: row === 0 ? 0 : -row * bedDepthMm * (1 + LOGICAL_PLATE_GAP),
+  };
+}
+
+interface Shelf {
+  /** Front edge of the shelf, measured from the usable area's front edge. */
+  readonly y: number;
+  /** Depth of the tallest part on the shelf. */
+  depth: number;
+  /** Next free X on the shelf. */
+  cursorX: number;
+}
+
+export function packOntoPlates(
+  items: readonly PlatePackingItem[],
+  options: PlatePackingOptions
+): PlatePackingResult {
+  const { bedWidthMm, bedDepthMm, spacingMm, marginMm } = options;
+  const usableW = Math.max(0, bedWidthMm - 2 * marginMm);
+  const usableD = Math.max(0, bedDepthMm - 2 * marginMm);
+
+  const placements: PlatePlacement[] = new Array<PlatePlacement>(items.length);
+  const oversizeIndices: number[] = [];
+
+  // Deepest-first, tie-broken by width, so shelves start with their tallest
+  // member and later parts fill the gap beside it. Index carried through so the
+  // result can be returned in input order.
+  const order = items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => b.item.depthMm - a.item.depthMm || b.item.widthMm - a.item.widthMm);
+
+  let plate = 0;
+  let shelves: Shelf[] = [];
+  let plateUsedDepth = 0;
+  // Highest plate index actually occupied. Tracked separately from `plate`
+  // because opening a plate for the NEXT part must not count as a used one:
+  // an oversize part at the end would otherwise report a trailing empty plate.
+  let maxPlateUsed = -1;
+
+  const openPlate = (): void => {
+    plate += 1;
+    shelves = [];
+    plateUsedDepth = 0;
+  };
+
+  for (const { item, index } of order) {
+    if (item.widthMm > usableW || item.depthMm > usableD) {
+      // Oversize: give it an exclusive plate so it cannot collide with a part
+      // that does fit, and report it rather than silently dropping it.
+      if (shelves.length > 0) openPlate();
+      oversizeIndices.push(index);
+      placements[index] = { plate, x: marginMm + usableW / 2, y: marginMm + usableD / 2 };
+      maxPlateUsed = Math.max(maxPlateUsed, plate);
+      openPlate();
+      continue;
+    }
+
+    let shelf = shelves.find((s) => s.cursorX + item.widthMm <= usableW && item.depthMm <= s.depth);
+
+    if (!shelf) {
+      const shelfY = plateUsedDepth === 0 ? 0 : plateUsedDepth + spacingMm;
+      if (shelfY + item.depthMm > usableD) {
+        openPlate();
+        shelf = { y: 0, depth: item.depthMm, cursorX: 0 };
+        shelves.push(shelf);
+        plateUsedDepth = item.depthMm;
+      } else {
+        shelf = { y: shelfY, depth: item.depthMm, cursorX: 0 };
+        shelves.push(shelf);
+        plateUsedDepth = shelfY + item.depthMm;
+      }
+    }
+
+    placements[index] = {
+      plate,
+      x: marginMm + shelf.cursorX + item.widthMm / 2,
+      y: marginMm + shelf.y + item.depthMm / 2,
+    };
+    shelf.cursorX += item.widthMm + spacingMm;
+    maxPlateUsed = Math.max(maxPlateUsed, plate);
+  }
+
+  return {
+    placements,
+    plateCount: maxPlateUsed + 1,
+    oversizeIndices: oversizeIndices.sort((a, b) => a - b),
+  };
+}

--- a/src/shell/layoutExport/useLayoutExport.ts
+++ b/src/shell/layoutExport/useLayoutExport.ts
@@ -15,7 +15,7 @@ import { effectiveGridUnitMmY } from '@/core/types';
 import { useSettingsStore } from '@/core/store/settings';
 import { useToastStore } from '@/core/store/toast';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
-import { isOk, getUserMessage } from '@/core/result';
+import { isOk } from '@/core/result';
 import { useTranslation } from '@/i18n';
 import { trackEvent, trackToolConverted } from '@/shared/analytics/posthog';
 import { getErrorMessage } from '@/shared/utils/errors';
@@ -23,9 +23,6 @@ import { bridgeManager, workerPoolManager } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
 import type { ExportFormat, CombinedExportResult } from '@/shared/generation/bridge';
 import { withSocketNozzle } from '@/shared/generation/socketNozzle';
-import { export3MF } from '@/shared/generation/export';
-import type { FaceGroupData } from '@/shared/types/generation';
-import type { FeatureColorConfig } from '@/shared/types/bin';
 // Deep import (not the barrel): this code only runs inside the lazy
 // layout-export chunk (same rationale as planLabelPlateExport's deep imports).
 import { buildLabelPlateColorConfig } from '@/features/bin-designer/utils/labelPlateColors';
@@ -46,6 +43,7 @@ import type { BinParams } from '@/features/bin-designer';
 import {
   buildBinDownloadPayload,
   buildThreeMFPrintSettings,
+  buildMultiObject3MFObjects,
 } from '@/features/bin-designer/utils/binDownloadHelpers';
 import { getLinkedDesignIds } from '@/features/design-linking';
 import { planLayoutBinExport } from './planLayoutBinExport';
@@ -58,6 +56,7 @@ import { snapTextDepthToLayers } from '@/shared/constants/labelPlates';
 import type { LabelPlateExportSpec } from '@/shared/generation/bridge';
 import { buildLayoutManifest } from './buildLayoutManifest';
 import type { ManifestLabelGroup } from './buildLayoutManifest';
+import { buildLayoutProjectFile, createProjectPartCollector } from './buildProjectFile';
 
 type Progress = { current: number; total: number; label?: string } | null;
 
@@ -72,42 +71,6 @@ interface UseLayoutExportReturn {
   ) => Promise<boolean>;
 }
 
-/** Convert STL bytes to 3MF bytes (the bridge emits STL only). `plateColors`
- *  adds label-plate paint_color zones (#2666) derived from the worker's face
- *  provenance against the parsed triangle count. */
-async function stlTo3mf(
-  stl: ArrayBuffer,
-  name: string,
-  printSettings: { layerHeightMm: number; infillPercent: number },
-  plateColors?: {
-    faceGroups: readonly FaceGroupData[] | undefined;
-    featureColors: FeatureColorConfig | undefined;
-  }
-): Promise<ArrayBuffer> {
-  const parsed = parseSTLBinary(stl);
-  if (!isOk(parsed)) throw new Error(getUserMessage(parsed.error));
-  const colorConfig = plateColors
-    ? buildLabelPlateColorConfig(
-        plateColors.faceGroups,
-        parsed.value.vertices.length / 9,
-        plateColors.featureColors
-      )
-    : undefined;
-  const blob = export3MF(parsed.value.vertices, parsed.value.normals, {
-    name,
-    colorConfig,
-    printSettings: {
-      layerHeight: printSettings.layerHeightMm,
-      infillPercent: printSettings.infillPercent,
-      material: 'PLA',
-      supportRequired: false,
-      estimatedMinutes: 0,
-      estimatedGrams: 0,
-    },
-  });
-  return blob.arrayBuffer();
-}
-
 function baseNameOf(path: string): string {
   return (path.split('/').pop() ?? path).replace(/\.[^.]+$/, '');
 }
@@ -118,12 +81,18 @@ function baseNameOf(path: string): string {
  * 3MF packs everything into one multi-object file and STEP into one compound —
  * reusing the bin designer's packaging so colours/orientation match.
  */
+/**
+ * Format a part file can take. A whole-layout 3MF export is a PROJECT file, so
+ * 3MF never reaches the per-part writers; naming that in the type keeps a dead
+ * per-part 3MF branch from creeping back in.
+ */
+type PartFileFormat = Exclude<ExportFileFormat, '3mf'>;
+
 async function combinedFiles(
   result: CombinedExportResult,
-  format: ExportFileFormat,
+  format: PartFileFormat,
   basePath: string,
-  params: BinParams,
-  printSettings: { layerHeightMm: number; infillPercent: number }
+  params: BinParams
 ): Promise<ZipBinaryFile[]> {
   if (format === 'stl') {
     const baseNoExt = basePath.replace(/\.[^.]+$/, '');
@@ -133,18 +102,7 @@ async function combinedFiles(
     }));
   }
 
-  const name = baseNameOf(basePath);
-  const threeMFContext =
-    format === '3mf'
-      ? {
-          modelName: name,
-          threeMFPrintSettings: buildThreeMFPrintSettings(printSettings, {
-            printTimeMinutes: 0,
-            gramsFilament: 0,
-          }),
-        }
-      : null;
-  const { blob } = buildBinDownloadPayload(format, result, params, name, threeMFContext);
+  const { blob } = buildBinDownloadPayload(format, result, params, baseNameOf(basePath), null);
   return [{ path: basePath, data: await blob.arrayBuffer() }];
 }
 
@@ -197,18 +155,10 @@ async function splitFiles(
     }
   }
 
-  const files: ZipBinaryFile[] = [];
-  for (const piece of pieces) {
-    const path = `${baseNoExt}/${piece.label}.${format}`;
-    // Name the 3MF model after the design plus the piece, not the bare label —
-    // "A1" alone in a slicer's object list says nothing about which bin it is.
-    const data =
-      format === '3mf'
-        ? await stlTo3mf(piece.data, `${baseNameOf(baseNoExt)}_${piece.label}`, printSettings)
-        : piece.data;
-    files.push({ path, data });
-  }
-  return files;
+  return pieces.map((piece) => ({
+    path: `${baseNoExt}/${piece.label}.${format}`,
+    data: piece.data,
+  }));
 }
 
 export function useLayoutExport(): UseLayoutExportReturn {
@@ -259,17 +209,30 @@ export function useLayoutExport(): UseLayoutExportReturn {
           loaded.push({ id, design: isOk(res) ? res.value : null });
         }
 
+        // A whole-layout 3MF export is a slicer PROJECT: one file holding every
+        // part, already packed onto build plates, instead of a pile of models
+        // the user arranges by hand. Every phase below still produces plain
+        // STL parts (`partFormat`); they are folded into the project file once
+        // the file list is complete, so a new part type joins it for free.
+        const projectMode = format === '3mf';
+        const partFormat: ExportFileFormat = projectMode ? 'stl' : format;
+
+        // Parts destined for the project file. A part joins this collector
+        // INSTEAD of the archive, carrying whatever colorConfig its own builder
+        // derived.
+        const projectParts = createProjectPartCollector();
+
         // The dialog's custom name applies to the ZIP archive only; inner files
         // fall back to a descriptive style (a single custom name across many
         // files would just collide). Descriptive/compact pass straight through.
         const innerConfig: ExportFileNameConfig =
           fileNameConfig.style === 'custom'
-            ? { style: 'descriptive', customName: '', format }
+            ? { style: 'descriptive', customName: '', format: partFormat }
             : fileNameConfig;
         const plan = planLayoutBinExport({
           bins,
           loaded,
-          format,
+          format: partFormat,
           fileNameConfig: innerConfig,
           printSettings,
           drawer: layout.drawer,
@@ -284,7 +247,7 @@ export function useLayoutExport(): UseLayoutExportReturn {
         // Phase 1 — bins. The bridge emits STL/STEP only; 3MF + companion parts
         // are packaged here. Worker format: STEP stays STEP, STL and 3MF both
         // export STL geometry.
-        const workerFormat: ExportFormat = format === 'step' ? 'step' : 'stl';
+        const workerFormat: ExportFormat = partFormat === 'step' ? 'step' : 'stl';
         const binTotal = plan.exportable.length + plan.meshExportable.length;
         const binLabel = (current: number): string =>
           t('layoutExport.progress.bins', { current, total: binTotal });
@@ -322,11 +285,8 @@ export function useLayoutExport(): UseLayoutExportReturn {
             }
           }
           for (let i = 0; i < simple.length; i++) {
-            const data =
-              format === '3mf'
-                ? await stlTo3mf(bytes[i], baseNameOf(simple[i].path), printSettings)
-                : bytes[i];
-            binFiles.push({ path: simple[i].path, data });
+            if (projectMode) projectParts.addStl(baseNameOf(simple[i].path), bytes[i]);
+            else binFiles.push({ path: simple[i].path, data: bytes[i] });
           }
           done = simple.length;
           setExportProgress({ current: done, total: binTotal, label: binLabel(done) });
@@ -337,7 +297,20 @@ export function useLayoutExport(): UseLayoutExportReturn {
             withSocketNozzle(e.params, printSettings.nozzleSizeMm),
             workerFormat
           );
-          binFiles.push(...(await combinedFiles(result, format, e.path, e.params, printSettings)));
+          if (projectMode) {
+            // Each companion is its own print, so they enter the packer as
+            // independent parts rather than as one pre-arranged assembly.
+            projectParts.addObjects(
+              buildMultiObject3MFObjects(
+                result.pieces,
+                result.faceGroups,
+                e.params,
+                result.lidFaceGroups
+              )
+            );
+          } else {
+            binFiles.push(...(await combinedFiles(result, partFormat, e.path, e.params)));
+          }
           done++;
           setExportProgress({ current: done, total: binTotal, label: binLabel(done) });
         }
@@ -347,9 +320,19 @@ export function useLayoutExport(): UseLayoutExportReturn {
         // instead of one part that doesn't fit the machine (#3074).
         for (const e of splits) {
           if (!e.split) continue;
-          binFiles.push(
-            ...(await splitFiles(bridge, e, e.split, format, printSettings, workerFormat))
+          const pieces = await splitFiles(
+            bridge,
+            e,
+            e.split,
+            partFormat,
+            printSettings,
+            workerFormat
           );
+          if (projectMode) {
+            for (const piece of pieces) projectParts.addStl(baseNameOf(piece.path), piece.data);
+          } else {
+            binFiles.push(...pieces);
+          }
           done++;
           setExportProgress({ current: done, total: binTotal, label: binLabel(done) });
         }
@@ -367,9 +350,8 @@ export function useLayoutExport(): UseLayoutExportReturn {
               decoded.value.indices,
               baseNameOf(m.path)
             );
-            const data =
-              format === '3mf' ? await stlTo3mf(stl, baseNameOf(m.path), printSettings) : stl;
-            binFiles.push({ path: m.path, data });
+            if (projectMode) projectParts.addStl(baseNameOf(m.path), stl);
+            else binFiles.push({ path: m.path, data: stl });
           }
           done++;
           setExportProgress({ current: done, total: binTotal, label: binLabel(done) });
@@ -398,7 +380,7 @@ export function useLayoutExport(): UseLayoutExportReturn {
                         .toLowerCase()
                         .replace(/[^a-z0-9]+/g, '-')
                         .replace(/^-+|-+$/g, '') || 'design'
-                    }_plates_${si + 1}.${format}`
+                    }_plates_${si + 1}.${partFormat}`
                 )
               )
             );
@@ -431,14 +413,22 @@ export function useLayoutExport(): UseLayoutExportReturn {
                   position: p.position,
                 }));
                 const result = await bridge.exportLabelPlates(specs, options, workerFormat);
-                const data =
-                  format === '3mf'
-                    ? await stlTo3mf(result.data, baseNameOf(path), printSettings, {
-                        faceGroups: result.faceGroups,
-                        featureColors: group.featureColors,
-                      })
-                    : result.data;
-                labelFiles.push({ path, data });
+                if (projectMode) {
+                  const parsed = parseSTLBinary(result.data);
+                  projectParts.addStl(
+                    baseNameOf(path),
+                    result.data,
+                    isOk(parsed)
+                      ? buildLabelPlateColorConfig(
+                          result.faceGroups,
+                          parsed.value.vertices.length / 9,
+                          group.featureColors
+                        )
+                      : undefined
+                  );
+                } else {
+                  labelFiles.push({ path, data: result.data });
+                }
                 sheetPaths.push(path);
                 sheetsDone++;
                 setExportProgress({
@@ -477,7 +467,7 @@ export function useLayoutExport(): UseLayoutExportReturn {
           gridShiftY: layout.drawer.gridShiftY ?? 0,
           printBedWidthMm: layout.printBedSize,
           printBedDepthMm: layout.printBedDepth ?? layout.printBedSize,
-          format,
+          format: partFormat,
           splitEnabled: true,
           fileNameConfig: innerConfig,
           printSettings: {
@@ -527,6 +517,53 @@ export function useLayoutExport(): UseLayoutExportReturn {
             : []),
         ];
 
+        // Pack every collected part onto build plates and seal them into one
+        // project file. The baseplate's pieces are gathered here rather than at
+        // their phase because they are produced after it. Non-model artefacts
+        // (the assembly map) ride along untouched, and a failure keeps whatever
+        // individual parts exist rather than shipping an archive with no
+        // geometry.
+        let projectPlateCount = 0;
+        let projectPartCount = 0;
+        let projectOversize: readonly string[] = [];
+        if (projectMode) {
+          if (bp) {
+            for (const piece of bp.pieces) {
+              projectParts.addStl(
+                piece.label ? `${bp.baseNameNoExt}_${piece.label}` : bp.baseNameNoExt,
+                piece.data
+              );
+            }
+          }
+          try {
+            const project = await buildLayoutProjectFile(projectParts.parts, {
+              name: zipBaseName,
+              bedWidthMm: layout.printBedSize,
+              bedDepthMm: layout.printBedDepth ?? layout.printBedSize,
+              printSettings: buildThreeMFPrintSettings(printSettings, {
+                printTimeMinutes: plan.totals.printTimeMinutes,
+                gramsFilament: plan.totals.filamentGrams,
+              }),
+            });
+            if (project) {
+              binaryFiles.length = 0;
+              binaryFiles.push(
+                { path: `${zipBaseName}.3mf`, data: project.data },
+                ...(bp?.assemblyImage
+                  ? [{ path: 'baseplate/assembly-map.png', data: bp.assemblyImage }]
+                  : [])
+              );
+              projectPlateCount = project.plateCount;
+              projectPartCount = project.partCount;
+              projectOversize = project.oversizeNames;
+            }
+          } catch {
+            // Keep the individual parts. A project file that failed to build is
+            // a worse outcome than a ZIP of models the user arranges by hand,
+            // but an archive with no geometry at all is worse than both.
+          }
+        }
+
         const manifest = buildLayoutManifest({
           layoutName: layout.name,
           format,
@@ -539,6 +576,15 @@ export function useLayoutExport(): UseLayoutExportReturn {
               }
             : null,
           labels: manifestLabels.length > 0 ? manifestLabels : null,
+          project:
+            projectPlateCount > 0
+              ? {
+                  fileName: `${zipBaseName}.3mf`,
+                  plateCount: projectPlateCount,
+                  partCount: projectPartCount,
+                  oversizeNames: projectOversize,
+                }
+              : null,
           skipped: plan.skipped,
           totals: plan.totals,
         });


### PR DESCRIPTION
Reported via Ko-fi: "would love to see an option that lets me download the 'project file' for Bambu Studio or Prusa Slicer with all the build plates created and parts laid out".

## Before

A whole-layout 3MF export produced a ZIP of separate model files, one per bin, split piece, label sheet and baseplate piece. The user imported each one and arranged it by hand.

## After

Choosing 3MF for a whole-layout export produces a single project file with every part already packed onto build plates. STL and STEP are unchanged.

## The plate grid

Plates are not a list, they are a square-ish grid in world space. The constants come from OrcaSlicer/BambuStudio `PartPlate`:

```cpp
static const double LOGICAL_PART_PLATE_GAP = 1. / 5.;
cols     = round(sqrt(n)), +1 when sqrt overshoots the round   // compute_colum_count
origin(0) =  col * plate_width * (1 + LOGICAL_PART_PLATE_GAP)
origin(1) = -row * plate_depth * (1 + LOGICAL_PART_PLATE_GAP)   // note the sign
```

Bambu and Orca read the plate assignment from `model_settings.config` while drawing each part at its world transform in `3dmodel.model`. Those are two independent statements about where a part lives, and a slicer renders a part floating off its plate if they disagree. Both are derived from one `packOntoPlates` result, and a test reads them back out of the built file and asserts every part's transform lands inside the plate it was assigned to.

## Colour

Parts reach the packer as `ThreeMFObject`s rather than model files, so each keeps the `colorConfig` its own builder derived.

`buildMultiObject3MF` and `buildSinglePiece3MF` computed their colour mapping internally and returned a finished Blob, so there was no way to pack their output without losing it. Each is now split into an object builder plus an export step, and the blob builders are thin wrappers over them. Without this, every multi-colour design and every coloured label plate would have come out single-colour, which `tsgo` surfaced by proving the colour-carrying branches unreachable rather than letting them rot silently.

## Packing

Shelf-based first-fit-decreasing over footprint bounding boxes, with a 4mm part gap and a 5mm bed margin. Gridfinity footprints are near-uniform multiples of 42mm, so the result is stable and inspectable rather than optimal. A part too large for the bed gets an exclusive plate and is named in the manifest instead of being dropped.

## PrusaSlicer

PrusaSlicer has no multi-plate concept and loads the parts onto a single plate. The manifest says so rather than implying the file behaves the same everywhere.

## Dead code

3MF now always means a project file in this path, so the per-part 3MF writers became unreachable. `combinedFiles` and `splitFiles` take `PartFileFormat = Exclude<ExportFileFormat, '3mf'>`, which deletes the branches and stops them creeping back. `stlTo3mf` is removed.

## Verification

- `platePacking.test.ts` (14): the grid formulas against the upstream ones, no overlap on a plate, everything inside the usable bed, plate count matches plates used, no trailing empty plate, oversize parts isolated.
- `buildProjectFile.test.ts` (12): the plate/transform agreement invariant, colour survival, plate striding, oversize reporting, collector behaviour on unparseable payloads.
- `threemfExporter.test.ts` (+6): plate declarations, 1-based `plater_id`, object-to-plate mapping, no renumbering around a gap, per-part transforms, parts sitting on the bed.
- Full `unit` + `dom` projects: 1347 files, 18288 passed, 0 failed.

Per the format decision on this work: automated tests only, no slicer round-trip. A structurally valid 3MF can still be rejected or mis-rendered by a slicer, so the first real signal for the Bambu-specific metadata may be a user report.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Whole-layout 3MF export now creates a single slicer project file with all parts pre-arranged on build plates for Bambu Studio and OrcaSlicer. STL and STEP exports are unchanged.

- **New Features**
  - Export one .3mf project with every part placed on build plates; placement uses the slicer’s grid (square-ish columns, 1/5 bed gap, rows in negative Y).
  - World transforms and plate assignments come from the same packing, so parts land on the correct plate.
  - Preserves per-part colors (including label plate zones) by exporting `ThreeMFObject`s and carrying their color config.
  - Packing: shelf-based first-fit-decreasing over footprints with 4mm part gap and 5mm bed margin; oversize parts get their own plate and are listed in the manifest.
  - Manifest notes the project file, plate count, and that PrusaSlicer loads all parts onto a single plate.

- **Refactors**
  - Split 3MF builders into object builders plus export to retain colors; added placement to 3MF types and emit plate data in model_settings.config.
  - Layout 3MF now always builds a project file; per-part 3MF branches removed and types narrowed to prevent regressions.
  - Added pure plate-packing module and tests; extended exporter and project-file tests to cover plate IDs, object-to-plate mapping, transforms, and bed contact.

<sup>Written for commit e3b2799891dec4f7495814635b4073bd45643d7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

