### PR TITLE
feat: sliding-tray model and rail geometry

### DIFF
--- a/api/lib/communityExampleParamHashes.ts
+++ b/api/lib/communityExampleParamHashes.ts
@@ -12,15 +12,15 @@
  * the values it reports.
  */
 export const COMMUNITY_EXAMPLE_PARAM_HASHES: ReadonlySet<string> = new Set<string>([
-  '1586c532e67d27e15457027903459522',
-  '1873bc918d6d0c3b6aa00003771bddcd',
-  '1d2106d9f0b74fccf1597fcaa772acad',
-  '20d09d9dba28f257f8c87a24c7db1957',
-  '2e0b0b83f571663233ad2635507dc405',
-  '8166e40ab1a21e74c799d5829619abf0',
-  '8aa27b0d2f5a3bcab5a24ccd0e1b3425',
-  'b54a495e491c412a540e39c95870b92c',
-  'b75f8919a120bdcce50c213938b0fd23',
-  'c99174bdf28694d8635d45f4de8b5363',
-  'd0b7a3cb6c92e8ae4e81b23c11b466be',
+  '076a75bf64aa7169da60eb39fe025def',
+  '1c2959aa16ddb948755fa0ada156fb38',
+  '25a17b48879500000ffbb2b831f155f2',
+  '32b81fd81272d45f03bdae7ab493bdb7',
+  '377fd35c7f129ba99970534b3545a18b',
+  '3ccc8ef3bbe8c7a079ae53505a7be94e',
+  '3f25d10525c5cb7f12bd8534d6b82b97',
+  '4bd0d00a6de5f30a5e4d7efba09e34c4',
+  '8c202c7af46d89b9edbad5982ed7adc6',
+  'b45ab088f8cba120601b20349a2dc55d',
+  'c3d63ec153761b588629af18db8930b9',
 ]);

--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -1653,3 +1653,61 @@ describe('validateDesignerShare — spacer height floor tracks the height unit',
     expect(validateDesignerShare(tray, 500).valid).toBe(true);
   });
 });
+
+describe('slide (sliding tray)', () => {
+  const withSlide = (slide: unknown) => {
+    const p = validPayload();
+    return { ...p, params: { ...p.params, slide } };
+  };
+
+  it('accepts a well-formed config', () => {
+    expect(
+      validateDesignerShare(
+        withSlide({
+          enabled: true,
+          railMount: 'rim',
+          trayWidthUnits: 2,
+          trayDepthMm: 20,
+          trayWallMm: 1.2,
+          railDropMm: 0,
+          railProtrusionMm: 2,
+          railThicknessMm: 2,
+          clearanceMm: 0.45,
+        }),
+        500
+      ).valid
+    ).toBe(true);
+  });
+
+  it('accepts a partial config from an older client', () => {
+    expect(validateDesignerShare(withSlide({ enabled: true }), 500).valid).toBe(true);
+  });
+
+  it('rejects an unknown rail mount', () => {
+    expect(validateDesignerShare(withSlide({ railMount: 'sideways' }), 500).valid).toBe(false);
+  });
+
+  it('rejects a runaway rail protrusion', () => {
+    // Every numeric field feeds BREP directly, so out-of-range values are the
+    // thing a crafted share would use to drive runaway geometry.
+    expect(validateDesignerShare(withSlide({ railProtrusionMm: 5000 }), 500).valid).toBe(false);
+  });
+
+  it('rejects a clearance below the floor', () => {
+    expect(validateDesignerShare(withSlide({ clearanceMm: 0 }), 500).valid).toBe(false);
+  });
+
+  it('rejects a non-object slide', () => {
+    expect(validateDesignerShare(withSlide('rim'), 500).valid).toBe(false);
+  });
+
+  it('keeps the key through param sanitization', () => {
+    // pickAllowedParams strips unknown top-level keys, so a missing entry in
+    // ALLOWED_PARAM_KEYS would silently drop the whole feature from shares.
+    const result = validateDesignerShare(withSlide({ enabled: true }), 500);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.payload.params.slide).toEqual({ enabled: true });
+    }
+  });
+});

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -14,7 +14,11 @@ import {
   validationError,
 } from './validationUtils.js';
 import { sanitizeString } from './validation.js';
-import { CONSTRAINTS } from './designerValidationConstants.js';
+import {
+  CONSTRAINTS,
+  SLIDE_CONSTRAINTS,
+  VALID_SLIDE_RAIL_MOUNTS,
+} from './designerValidationConstants.js';
 import {
   validateDividers,
   validateCellMask,
@@ -129,6 +133,7 @@ const ALLOWED_PARAM_KEYS = new Set<string>([
   'splitConnectors',
   'featureColors',
   'lid',
+  'slide',
   'textDefaults',
   'surfaceText',
   'meshAssets',
@@ -287,6 +292,55 @@ function validateWalls(walls: unknown): string | null {
       if (isNumber(sideConfig.depth) && !inRange(sideConfig.depth, 0, 100)) {
         return `walls.${side}.depth must be 0-100`;
       }
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate the sliding-tray sub-object. Every field here feeds the generator
+ * directly, so a crafted share could otherwise drive a runaway rail or tray.
+ * Bounds mirror `SLIDE_CONSTRAINTS` in
+ * `src/features/bin-designer/types/slide.ts`. Fields are individually optional
+ * so a payload written by an older client still validates.
+ */
+function validateSlide(slide: unknown): string | null {
+  if (!isObject(slide)) return 'slide must be an object';
+  if (slide.enabled !== undefined && !isBoolean(slide.enabled)) {
+    return 'slide.enabled must be boolean';
+  }
+  if (
+    slide.railMount !== undefined &&
+    !VALID_SLIDE_RAIL_MOUNTS.includes(slide.railMount as string)
+  ) {
+    return `slide.railMount must be one of: ${VALID_SLIDE_RAIL_MOUNTS.join(', ')}`;
+  }
+  const ranges: readonly [string, number, number][] = [
+    [
+      'trayWidthUnits',
+      SLIDE_CONSTRAINTS.MIN_TRAY_WIDTH_UNITS,
+      SLIDE_CONSTRAINTS.MAX_TRAY_WIDTH_UNITS,
+    ],
+    ['trayDepthMm', SLIDE_CONSTRAINTS.MIN_TRAY_DEPTH_MM, SLIDE_CONSTRAINTS.MAX_TRAY_DEPTH_MM],
+    ['trayWallMm', SLIDE_CONSTRAINTS.MIN_TRAY_WALL_MM, SLIDE_CONSTRAINTS.MAX_TRAY_WALL_MM],
+    ['railDropMm', SLIDE_CONSTRAINTS.MIN_RAIL_DROP_MM, SLIDE_CONSTRAINTS.MAX_RAIL_DROP_MM],
+    [
+      'railProtrusionMm',
+      SLIDE_CONSTRAINTS.MIN_RAIL_PROTRUSION_MM,
+      SLIDE_CONSTRAINTS.MAX_RAIL_PROTRUSION_MM,
+    ],
+    [
+      'railThicknessMm',
+      SLIDE_CONSTRAINTS.MIN_RAIL_THICKNESS_MM,
+      SLIDE_CONSTRAINTS.MAX_RAIL_THICKNESS_MM,
+    ],
+    ['clearanceMm', SLIDE_CONSTRAINTS.MIN_CLEARANCE_MM, SLIDE_CONSTRAINTS.MAX_CLEARANCE_MM],
+  ];
+  for (const [field, min, max] of ranges) {
+    const value = slide[field];
+    if (value === undefined) continue;
+    if (!isNumber(value) || !inRange(value, min, max)) {
+      return `slide.${field} must be a number between ${min} and ${max}`;
     }
   }
   return null;
@@ -1074,6 +1128,11 @@ export function validateDesignerShare(body: unknown, sizeBytes: number): Designe
   if (params.lid !== undefined) {
     const lidErr = validateLid(params.lid);
     if (lidErr) return validationError('INVALID_PARAMS', lidErr);
+  }
+
+  if (params.slide !== undefined) {
+    const slideErr = validateSlide(params.slide);
+    if (slideErr) return validationError('INVALID_PARAMS', slideErr);
   }
 
   // Custom-shape footprint: structurally-valid masks are enforced here so

--- a/api/lib/designerValidationConstants.ts
+++ b/api/lib/designerValidationConstants.ts
@@ -97,3 +97,31 @@ export const VALID_LABEL_PLATE_ICONS: readonly string[] = [
   'washer',
   'nail',
 ];
+
+/**
+ * Sliding-tray bounds. Mirrors `SLIDE_CONSTRAINTS` in
+ * `src/features/bin-designer/types/slide.ts` — keep in sync, or valid client
+ * payloads 400 on sync.
+ *
+ * These are the numbers a crafted share could otherwise use to drive runaway
+ * BREP: the rail and tray dimensions feed the generator directly.
+ */
+export const SLIDE_CONSTRAINTS = {
+  MIN_TRAY_WIDTH_UNITS: 0.5,
+  MAX_TRAY_WIDTH_UNITS: 16,
+  MIN_TRAY_DEPTH_MM: 3,
+  MAX_TRAY_DEPTH_MM: 140,
+  MIN_TRAY_WALL_MM: 0.4,
+  MAX_TRAY_WALL_MM: 2.4,
+  MIN_RAIL_DROP_MM: 0,
+  MAX_RAIL_DROP_MM: 140,
+  MIN_RAIL_PROTRUSION_MM: 0.8,
+  MAX_RAIL_PROTRUSION_MM: 6,
+  MIN_RAIL_THICKNESS_MM: 0.8,
+  MAX_RAIL_THICKNESS_MM: 6,
+  MIN_CLEARANCE_MM: 0.1,
+  MAX_CLEARANCE_MM: 2,
+} as const;
+
+/** Mirrors `SLIDE_RAIL_MOUNTS` in `src/features/bin-designer/types/slide.ts`. */
+export const VALID_SLIDE_RAIL_MOUNTS: readonly string[] = ['interior', 'rim'];

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -29,6 +29,7 @@ import {
 import type { FeatureColorConfig } from '../types/featureColors';
 import { makeUniformLipCells, TOP_ACCENT_DEFAULT_MM } from '../types/featureColors';
 import { DEFAULT_LID_CONFIG } from '../types/lid';
+import { DEFAULT_SLIDE_CONFIG } from '../types/slide';
 import { DEFAULT_TEXT_STYLE_DEFAULTS } from '../types/text';
 import { DESIGNER_CONSTRAINTS } from './gridfinity';
 
@@ -240,6 +241,7 @@ export const DEFAULT_BIN_PARAMS: BinParams = {
   floorPattern: DEFAULT_FLOOR_PATTERN_CONFIG,
   featureColors: DEFAULT_FEATURE_COLOR_CONFIG,
   lid: DEFAULT_LID_CONFIG,
+  slide: DEFAULT_SLIDE_CONFIG,
   textDefaults: DEFAULT_TEXT_STYLE_DEFAULTS,
   overhang: { left: 0, right: 0, front: 0, back: 0, feet: false },
   extraWallHeightMm: 0,

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -10,6 +10,7 @@ import { FLOOR_PATTERN_TYPES, WALL_PATTERN_TYPES } from '../types';
 import { DESIGNER_CONSTRAINTS } from './gridfinity';
 import { validateBinParams } from '../utils/validation';
 import { makeUniformLipCells } from '../types/featureColors';
+import { DEFAULT_SLIDE_CONFIG } from '../types/slide';
 import { expectOk } from '@/test/testUtils';
 import type { BinParams } from '../types';
 
@@ -1224,6 +1225,37 @@ describe('migrateParams', () => {
       });
       expect(result.cutouts[0].scoopRadiusW).toBeUndefined();
       expect(result.cutouts[0].scoopRadiusD).toBeUndefined();
+    });
+  });
+
+  describe('sliding tray migration', () => {
+    it('backfills the whole config for designs predating the feature', () => {
+      const result = migrateParams({});
+      expect(result.slide).toEqual(DEFAULT_SLIDE_CONFIG);
+    });
+
+    it('completes a partially-stored config from the default', () => {
+      // A design saved mid-feature carries some fields and not others; the
+      // generator must never see a half-formed config.
+      const result = migrateParams({
+        slide: { enabled: true, trayWidthUnits: 2 } as BinParams['slide'],
+      });
+      expect(result.slide.enabled).toBe(true);
+      expect(result.slide.trayWidthUnits).toBe(2);
+      expect(result.slide.clearanceMm).toBe(DEFAULT_SLIDE_CONFIG.clearanceMm);
+      expect(result.slide.railMount).toBe(DEFAULT_SLIDE_CONFIG.railMount);
+    });
+
+    it('coerces an unknown railMount back to the default', () => {
+      const result = migrateParams({
+        slide: { railMount: 'sideways' } as unknown as BinParams['slide'],
+      });
+      expect(result.slide.railMount).toBe(DEFAULT_SLIDE_CONFIG.railMount);
+    });
+
+    it('is idempotent', () => {
+      const once = migrateParams({ slide: { enabled: true } as BinParams['slide'] });
+      expect(migrateParams({ slide: once.slide }).slide).toEqual(once.slide);
     });
   });
 });

--- a/src/features/bin-designer/constants/paramMigration.ts
+++ b/src/features/bin-designer/constants/paramMigration.ts
@@ -26,6 +26,8 @@ import type {
 import { DEFAULT_PATTERN_SCALE } from '../types';
 import type { FeatureColorConfig, LipAxisCount, TopAccentConfig } from '../types/featureColors';
 import { makeUniformLipCells, LIP_CELL_ZONES } from '../types/featureColors';
+import type { SlideConfig, SlideRailMount } from '../types/slide';
+import { DEFAULT_SLIDE_CONFIG, SLIDE_RAIL_MOUNTS } from '../types/slide';
 import type { BaseConfig, TrayBottomConfig } from '../types/base';
 import { DEFAULT_TRAY_BOTTOM } from '../types/base';
 import {
@@ -888,8 +890,22 @@ export function migrateParams(params: MigrateParamsInput): BinParams {
     dividers: _legacyDividers,
     eco: _legacyEco,
     handles: _handlesHandled,
+    slide: _slideHandled,
     ...rest
   } = params as Record<string, unknown>;
+
+  // Designs predating the sliding tray have no `slide` at all, and one saved
+  // mid-feature may be missing individual fields; both re-complete from the
+  // default rather than reaching the generator half-formed.
+  const slideConfig: SlideConfig = {
+    ...DEFAULT_SLIDE_CONFIG,
+    ...((params.slide as Partial<SlideConfig> | undefined) ?? {}),
+    railMount: SLIDE_RAIL_MOUNTS.includes(
+      (params.slide as Partial<SlideConfig> | undefined)?.railMount as SlideRailMount
+    )
+      ? ((params.slide as Partial<SlideConfig>).railMount as SlideRailMount)
+      : DEFAULT_SLIDE_CONFIG.railMount,
+  };
 
   // Wall top (height units × mm/unit, plus any exterior-wall collar), matching
   // the top-accent slider cap in the Colors panel. Used to clamp a persisted
@@ -936,6 +952,7 @@ export function migrateParams(params: MigrateParamsInput): BinParams {
     scoop: scoopConfig,
     label: { ...DEFAULT_BIN_PARAMS.label, ...(params.label ?? {}) },
     walls: wallsConfig,
+    slide: slideConfig,
     handles: handlesConfig,
     slotConfig,
     dividerPieces,

--- a/src/features/bin-designer/store/slices/paramSlice/scopedUpdaters.ts
+++ b/src/features/bin-designer/store/slices/paramSlice/scopedUpdaters.ts
@@ -10,6 +10,7 @@ import type {
   LabelTabConfig,
   ScoopConfig,
   WallConfig,
+  SlideConfig,
   OverhangConfig,
   WallCutout,
   WallSide,
@@ -81,6 +82,13 @@ export function createScopedUpdaters(set: Set) {
       set((state) => {
         pushHistoryEntry(state);
         state.params.walls = { ...state.params.walls, ...partial };
+      });
+    },
+
+    updateSlide: (partial: Partial<SlideConfig>) => {
+      set((state) => {
+        pushHistoryEntry(state);
+        state.params.slide = { ...state.params.slide, ...partial };
       });
     },
 

--- a/src/features/bin-designer/types/binParams.ts
+++ b/src/features/bin-designer/types/binParams.ts
@@ -7,6 +7,7 @@ import type { CompartmentConfig, ScoopConfig } from './compartments';
 import type { LabelTabConfig } from './labelTabs';
 import type { HandleConfig } from './handles';
 import type { WallConfig, WallPatternConfig, OverhangConfig } from './walls';
+import type { SlideConfig } from './slide';
 import type { FloorPatternConfig } from './floor';
 import type { SplitConnectorConfig } from './splitConnector';
 import type { FeatureColorConfig } from './featureColors';
@@ -62,6 +63,8 @@ export interface BinParams {
   readonly scoop: ScoopConfig;
   readonly label: LabelTabConfig;
   readonly walls: WallConfig;
+  /** Sliding tray: a rail on this bin plus the companion tray that rides it. */
+  readonly slide: SlideConfig;
   readonly handles: HandleConfig;
   readonly slotConfig: SlotConfig;
   readonly dividerPieces: DividerPieceConfig;

--- a/src/features/bin-designer/types/designerState.ts
+++ b/src/features/bin-designer/types/designerState.ts
@@ -31,6 +31,7 @@ import type {
   OverhangHighlightSide,
   WallPatternConfig,
 } from './walls';
+import type { SlideConfig } from './slide';
 import type { FloorPatternConfig } from './floor';
 import type { BinParams, Insert } from './binParams';
 import type {
@@ -95,6 +96,7 @@ export interface DesignerState {
   updateLabel: (partial: Partial<LabelTabConfig>) => void;
   updateScoop: (partial: Partial<ScoopConfig>) => void;
   updateWalls: (partial: Partial<WallConfig>) => void;
+  updateSlide: (partial: Partial<SlideConfig>) => void;
   updateOverhang: (partial: Partial<OverhangConfig>) => void;
   updateWallSide: (side: WallSide, partial: Partial<WallCutout>) => void;
   updateHandles: (partial: Partial<HandleConfig>) => void;

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -143,6 +143,7 @@ export * from './compartments';
 export * from './labelTabs';
 export * from './handles';
 export * from './walls';
+export * from './slide';
 export * from './floor';
 export * from './splitConnector';
 export * from './binParams';

--- a/src/features/bin-designer/types/slide.ts
+++ b/src/features/bin-designer/types/slide.ts
@@ -1,0 +1,104 @@
+/**
+ * Sliding tray: a rail carried by the bin plus a companion tray that rides on
+ * it, so a shallow tray can be pushed aside to reach what sits underneath.
+ *
+ * The rail runs along the FRONT and BACK walls, so the tray travels in X. That
+ * is what makes the multi-bin case work without the layout knowing anything: a
+ * rail spanning a bin's full length meets its neighbour's rail when two railed
+ * bins are placed side by side, so a wide tray simply rides across both. The
+ * ~8mm interruption at each junction (two corner radii plus the standard
+ * bin-to-bin clearance) is bridged by any tray wider than a single unit.
+ *
+ * Not to be confused with `LidConfig.tray`, which turns a LID into a shallow
+ * tray and does not slide.
+ */
+
+/**
+ * Where the rail sits, which decides whether a tray can leave its own bin.
+ *
+ *  - `interior` — a ledge protruding inward from the front/back walls, below
+ *    the rim. The tray drops into the bin. Travel is bounded by this bin's own
+ *    side walls, so it never crosses to a neighbour.
+ *  - `rim` — a rebate on top of the front/back walls. The tray rides above the
+ *    rim and crosses freely between adjacent railed bins, which is the
+ *    "two tall bins with a tray sliding over both" arrangement.
+ */
+export type SlideRailMount = 'interior' | 'rim';
+
+export const SLIDE_RAIL_MOUNTS: readonly SlideRailMount[] = ['interior', 'rim'];
+
+export interface SlideConfig {
+  /** Master toggle. When false no rail is cut and no tray is generated. */
+  readonly enabled: boolean;
+  readonly railMount: SlideRailMount;
+  /**
+   * Tray width in GRID UNITS, not mm, and deliberately independent of the
+   * host's width: a tray narrower than its bin can slide within it, and a tray
+   * wider than its bin is the multi-bin case. Fractional halves are allowed to
+   * match the rest of the app's half-grid support.
+   */
+  readonly trayWidthUnits: number;
+  /** Tray interior depth (how deep the tray's own cavity is), mm. */
+  readonly trayDepthMm: number;
+  /** Tray wall thickness, mm. */
+  readonly trayWallMm: number;
+  /**
+   * Rail top measured DOWN from the bin rim, mm. Zero puts the rail's top
+   * flush with the rim. The generator additionally pushes an `interior` rail
+   * clear of the stacking lip, which reaches further down the wall than its
+   * own height suggests.
+   */
+  readonly railDropMm: number;
+  /** How far the rail protrudes from the wall it is carried by, mm. */
+  readonly railProtrusionMm: number;
+  /** Rail thickness in Z, mm. */
+  readonly railThicknessMm: number;
+  /**
+   * Gap held on EVERY face between rail and groove, mm.
+   *
+   * Deliberately its own number rather than the shared `CLEARANCE` (0.5mm):
+   * that constant describes the bin-to-baseplate seating fit and is free to
+   * move with the Gridfinity spec, while this one is the number a user tunes
+   * against their own printer until the tray slides without rattling.
+   */
+  readonly clearanceMm: number;
+}
+
+export const SLIDE_CONSTRAINTS = {
+  MIN_TRAY_WIDTH_UNITS: 0.5,
+  MAX_TRAY_WIDTH_UNITS: 16,
+  MIN_TRAY_DEPTH_MM: 3,
+  MAX_TRAY_DEPTH_MM: 140,
+  MIN_TRAY_WALL_MM: 0.4,
+  MAX_TRAY_WALL_MM: 2.4,
+  MIN_RAIL_DROP_MM: 0,
+  MAX_RAIL_DROP_MM: 140,
+  MIN_RAIL_PROTRUSION_MM: 0.8,
+  MAX_RAIL_PROTRUSION_MM: 6,
+  MIN_RAIL_THICKNESS_MM: 0.8,
+  MAX_RAIL_THICKNESS_MM: 6,
+  MIN_CLEARANCE_MM: 0.1,
+  MAX_CLEARANCE_MM: 2,
+} as const;
+
+/**
+ * Defaults chosen so enabling the feature on a stock bin produces something
+ * printable without further tuning:
+ *
+ * - `rim` mount, because crossing between bins is what was actually asked for.
+ * - `clearanceMm: 0.45` — a running fit at typical FDM tolerances. Below ~0.3
+ *   most printers bind; above ~0.6 the tray rattles.
+ * - `railProtrusion` 2mm on a 1.2mm wall gives a shelf that supports the tray
+ *   without eating the cavity.
+ */
+export const DEFAULT_SLIDE_CONFIG: SlideConfig = {
+  enabled: false,
+  railMount: 'rim',
+  trayWidthUnits: 1,
+  trayDepthMm: 20,
+  trayWallMm: 1.2,
+  railDropMm: 0,
+  railProtrusionMm: 2,
+  railThicknessMm: 2,
+  clearanceMm: 0.45,
+} as const;

--- a/src/features/generation/worker/generators/binDirectMesh.ts
+++ b/src/features/generation/worker/generators/binDirectMesh.ts
@@ -395,6 +395,10 @@ export function canBinUseDirectMesh(params: BinParams): boolean {
   // the open top — and the feet the draft draws solid.
   if (params.floorPattern?.enabled === true) return false;
   if (params.lid.enabled) return false;
+  // Slide rails are fused onto the front/back walls by the BREP pipeline;
+  // the procedural emitters draw plain walls, so a draft would show a bare
+  // bin and then visibly grow a track when exact generation lands.
+  if (params.slide.enabled) return false;
   // Wall surface text (#2695) engraves/embosses the camera-visible outer
   // walls; the procedural emitters don't render glyphs.
   const wallTexts = params.surfaceText?.walls;

--- a/src/features/generation/worker/generators/binGenerator.export.slideTray.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.slideTray.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { slideTray } from './scenarios/slideTray';
+
+runExportIntegrity(slideTray);

--- a/src/features/generation/worker/generators/binGenerator.scenario.slideTray.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.slideTray.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runScenarios } from './__kernel-tests__/scenarioRunner';
+import { slideTray } from './scenarios/slideTray';
+
+runScenarios(slideTray);

--- a/src/features/generation/worker/generators/featureTags.ts
+++ b/src/features/generation/worker/generators/featureTags.ts
@@ -27,6 +27,8 @@ export const FeatureTag = {
    * {@link LIP}, which is the BIN's top-rim lip on a different object.
    */
   LID_LIP: 15,
+  /** The sliding tray's track, fused onto the bin's front and back walls. */
+  SLIDE_RAIL: 16,
   UNKNOWN: 255,
 } as const;
 

--- a/src/features/generation/worker/generators/pipeline/featureComposition.ts
+++ b/src/features/generation/worker/generators/pipeline/featureComposition.ts
@@ -18,6 +18,7 @@ import { labelTabsFeature } from '../labelTabBuilder';
 import { handlesFeature } from '../handleBuilder';
 import { scoopRampsFeature } from '../scoopRampBuilder';
 import { wallCutoutsFeature } from '../wallCutoutBuilder';
+import { slideRailsFeature } from '../slideRailBuilder';
 import { dividerBlendFeature } from '../dividerBlendBuilder';
 import { wallTextCutFeature, wallTextEmbossFeature } from '../wallTextBuilder';
 
@@ -29,6 +30,7 @@ export const BIN_FEATURE_BUILDERS: readonly FeatureBuilder[] = [
   handlesFeature,
   scoopRampsFeature,
   wallCutoutsFeature,
+  slideRailsFeature,
   dividerBlendFeature,
   wallTextCutFeature,
   wallTextEmbossFeature,

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -39,6 +39,7 @@ import { lightweight } from './lightweight';
 import { spacer } from './spacer';
 import { tile } from './tile';
 import { trayBottom } from './trayBottom';
+import { slideTray } from './slideTray';
 import { labelSockets } from './labelSockets';
 import { wallPatterns } from './wallPatterns';
 import { kumikoComposition } from './kumikoComposition';
@@ -95,4 +96,5 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...spacer,
   ...tile,
   ...trayBottom,
+  ...slideTray,
 ];

--- a/src/features/generation/worker/generators/scenarios/slideTray.ts
+++ b/src/features/generation/worker/generators/scenarios/slideTray.ts
@@ -1,0 +1,54 @@
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { defineScenario } from '../__kernel-tests__/scenarioTypes';
+import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+
+const slide = (over: Partial<(typeof DEFAULT_BIN_PARAMS)['slide']>) => ({
+  ...DEFAULT_BIN_PARAMS.slide,
+  enabled: true,
+  ...over,
+});
+
+export const slideTray: ScenarioCase[] = [
+  defineScenario('slide tray', 'interior ledges on a tall bin', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 2,
+      height: 6,
+      slide: slide({ railMount: 'interior', trayWidthUnits: 1 }),
+    },
+    timeout: 60_000,
+  }),
+  defineScenario('slide tray', 'rim track on a lipped bin', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 2,
+      height: 6,
+      slide: slide({ railMount: 'rim', trayWidthUnits: 2 }),
+    },
+    timeout: 60_000,
+  }),
+  defineScenario('slide tray', 'rim track without a stacking lip', {
+    assert: 'structural',
+    params: {
+      width: 2,
+      depth: 2,
+      height: 5,
+      base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
+      slide: slide({ railMount: 'rim' }),
+    },
+    timeout: 60_000,
+  }),
+  defineScenario('slide tray', 'interior ledges with compartments and a lid', {
+    assert: 'structural',
+    params: {
+      width: 3,
+      depth: 2,
+      height: 6,
+      compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
+      slide: slide({ railMount: 'interior', railDropMm: 6 }),
+    },
+    timeout: 90_000,
+  }),
+];

--- a/src/features/generation/worker/generators/slideGeometry.test.ts
+++ b/src/features/generation/worker/generators/slideGeometry.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSlideGeometry, interiorRailCeiling, rimTrackBaseZ } from './slideGeometry';
+import type { SlideGeometryInput } from './slideGeometry';
+import { DEFAULT_SLIDE_CONFIG } from '@/features/bin-designer/types/slide';
+import { LIP_HEIGHT, LIP_TAPER_WIDTH } from './generatorConstants';
+import type { SlideConfig } from '@/shared/types/bin';
+
+/** A 3x2x6 bin at stock wall thickness. */
+function input(slide: Partial<SlideConfig> = {}, over: Partial<SlideGeometryInput> = {}) {
+  const wallThickness = 1.2;
+  const outerW = 3 * 42 - 0.5;
+  const outerD = 2 * 42 - 0.5;
+  return {
+    slide: { ...DEFAULT_SLIDE_CONFIG, enabled: true, ...slide },
+    innerW: outerW - 2 * wallThickness,
+    innerD: outerD - 2 * wallThickness,
+    outerW,
+    outerD,
+    wallThickness,
+    wallHeight: 42,
+    collarHeight: 0,
+    hasLip: true,
+    gridUnitMmX: 42,
+    ...over,
+  } satisfies SlideGeometryInput;
+}
+
+describe('interiorRailCeiling', () => {
+  it('keeps a rail clear of the lip taper on a lipped bin', () => {
+    // The lip reaches LIP_TAPER_WIDTH below its own base plane; a rail above
+    // this either back-fills the taper or is silently thinned by it.
+    expect(interiorRailCeiling(42, true)).toBe(42 - LIP_TAPER_WIDTH);
+  });
+
+  it('allows the full wall height when there is no lip', () => {
+    expect(interiorRailCeiling(42, false)).toBe(42);
+  });
+});
+
+describe('rimTrackBaseZ', () => {
+  it('stands on the wall top when there is no lip', () => {
+    expect(rimTrackBaseZ(42, 0, false)).toBe(42);
+  });
+
+  it('stands on the lip when there is one', () => {
+    expect(rimTrackBaseZ(42, 0, true)).toBe(42 + LIP_HEIGHT);
+  });
+
+  it('rides the collar up', () => {
+    expect(rimTrackBaseZ(42, 5, false)).toBe(47);
+  });
+});
+
+describe('resolveSlideGeometry', () => {
+  it('produces nothing when disabled', () => {
+    const g = resolveSlideGeometry(input({ enabled: false }));
+    expect(g.rails).toEqual([]);
+    expect(g.tray).toBeNull();
+    expect(g.rejection).toBe('disabled');
+  });
+
+  describe('interior mount', () => {
+    const interior = (slide: Partial<SlideConfig> = {}) =>
+      resolveSlideGeometry(input({ railMount: 'interior', ...slide }));
+
+    it('builds one ledge on each of the front and back walls', () => {
+      const g = interior();
+      expect(g.rejection).toBeNull();
+      expect(g.rails).toHaveLength(2);
+      const [front, back] = g.rails;
+      expect(front.yMin).toBeLessThan(0);
+      expect(back.yMax).toBeGreaterThan(0);
+      // Mirrored about Y=0, so the tray sits level.
+      expect(front.yMax - front.yMin).toBeCloseTo(back.yMax - back.yMin, 9);
+      expect(front.zMin).toBeCloseTo(back.zMin, 9);
+    });
+
+    it('clamps the rail top under the lip taper even at zero drop', () => {
+      const g = interior({ railDropMm: 0 });
+      expect(g.rails[0].zMax).toBe(interiorRailCeiling(42, true));
+    });
+
+    it('honours a drop below that ceiling', () => {
+      const g = interior({ railDropMm: 10 });
+      expect(g.rails[0].zMax).toBe(32);
+    });
+
+    it('leaves the tray narrower than its track by the clearance', () => {
+      // THE fit invariant. Getting this backwards binds the tray solid, and
+      // no bounding-box or watertight assertion would notice.
+      const slide = { railMount: 'interior' as const, clearanceMm: 0.45 };
+      const g = resolveSlideGeometry(input(slide));
+      const inp = input(slide);
+      expect(g.tray?.depthMm).toBeCloseTo(inp.innerD - 2 * 0.45, 9);
+      expect(inp.innerD - (g.tray?.depthMm ?? 0)).toBeCloseTo(2 * 0.45, 9);
+    });
+
+    it('rests the tray above the ledge by the clearance', () => {
+      const g = interior({ clearanceMm: 0.3 });
+      expect(g.tray?.restZ).toBeCloseTo(g.rails[0].zMax + 0.3, 9);
+    });
+
+    it('rejects a rail that would sit in the floor slab', () => {
+      // A 2u-high bin with a big drop puts the ledge below the floor, which is
+      // a solid block filling the cavity rather than a track.
+      const g = resolveSlideGeometry(
+        input({ railMount: 'interior', railDropMm: 20 }, { wallHeight: 14 })
+      );
+      expect(g.rejection).toBe('rail-below-floor');
+      expect(g.tray).toBeNull();
+    });
+
+    it('rejects a bin too shallow for the ledges to leave a floor', () => {
+      const g = resolveSlideGeometry(
+        input({ railMount: 'interior', railProtrusionMm: 6 }, { innerD: 10, outerD: 12.4 })
+      );
+      expect(g.rejection).toBe('bin-too-shallow');
+    });
+  });
+
+  describe('rim mount', () => {
+    const rim = (slide: Partial<SlideConfig> = {}, over: Partial<SlideGeometryInput> = {}) =>
+      resolveSlideGeometry(input({ railMount: 'rim', ...slide }, over));
+
+    it('tops the strips out one thickness above the lip', () => {
+      const g = rim();
+      expect(g.rejection).toBeNull();
+      expect(g.rails).toHaveLength(2);
+      expect(g.rails[0].zMax).toBe(
+        rimTrackBaseZ(42, 0, true) + DEFAULT_SLIDE_CONFIG.railThicknessMm
+      );
+    });
+
+    it('sinks the strips below the nominal lip top so they weld', () => {
+      // The lip's peak is filleted a little below `wallHeight + LIP_HEIGHT`, so
+      // a strip starting exactly at the nominal height floats clear of it and
+      // fuses as a disconnected island — watertight, right bounding box, and it
+      // falls off the print.
+      const g = rim();
+      expect(g.rails[0].zMin).toBeLessThan(rimTrackBaseZ(42, 0, true));
+    });
+
+    it('stops the strips short of the corner arcs', () => {
+      // A bar run into the rounded corner hangs off the silhouette, and the
+      // gap is what lets a neighbour's strip pick the track up.
+      const g = rim();
+      const inp = input({ railMount: 'rim' });
+      expect(g.rails[0].xMax).toBeLessThan(inp.outerW / 2);
+      expect(g.rails[0].xMax).toBeCloseTo(inp.outerW / 2 - 3.75, 9);
+    });
+
+    it('puts the tray above every wall so it can cross to a neighbour', () => {
+      const g = rim();
+      const inp = input({ railMount: 'rim' });
+      const rimTop = inp.wallHeight + inp.collarHeight + LIP_HEIGHT;
+      expect(g.tray?.restZ).toBeGreaterThanOrEqual(rimTop);
+    });
+
+    it('fits the tray into the channel between the strips', () => {
+      const g = rim({ clearanceMm: 0.5 });
+      const inp = input({ railMount: 'rim' });
+      const channel = 2 * (inp.outerD / 2 - inp.wallThickness);
+      expect(g.tray?.depthMm).toBeCloseTo(channel - 1, 9);
+      expect(g.tray?.depthMm).toBeLessThan(channel);
+    });
+
+    it('sizes the tray from grid units, not from the host bin', () => {
+      // This is what makes the multi-bin case work: a tray wider than its host
+      // is the whole point, so nothing may clamp it to the bin.
+      const wide = rim({ trayWidthUnits: 6 });
+      const inp = input({ railMount: 'rim' });
+      expect(wide.tray?.widthMm).toBeGreaterThan(inp.outerW);
+      expect(wide.tray?.widthMm).toBeCloseTo(6 * 42 - DEFAULT_SLIDE_CONFIG.clearanceMm, 9);
+    });
+
+    it('rejects a tray width that collapses to nothing', () => {
+      const g = rim({ trayWidthUnits: 0.5 }, { gridUnitMmX: 2 });
+      expect(g.rejection).toBe('bin-too-narrow');
+    });
+  });
+});

--- a/src/features/generation/worker/generators/slideGeometry.test.ts
+++ b/src/features/generation/worker/generators/slideGeometry.test.ts
@@ -59,6 +59,17 @@ describe('resolveSlideGeometry', () => {
     expect(g.rejection).toBe('disabled');
   });
 
+  it('rejects a wall thick enough to collapse the tray in X', () => {
+    // Depth alone was checked at first, so a fat wall on a narrow tray closed
+    // the cavity in X and the builder returned the un-hollowed outer solid: a
+    // printable block the resolver still called a tray.
+    const g = resolveSlideGeometry(
+      input({ trayWidthUnits: 0.5, trayWallMm: 2.4 }, { gridUnitMmX: 12 })
+    );
+    expect(g.rejection).toBe('tray-too-thin');
+    expect(g.tray).toBeNull();
+  });
+
   describe('interior mount', () => {
     const interior = (slide: Partial<SlideConfig> = {}) =>
       resolveSlideGeometry(input({ railMount: 'interior', ...slide }));

--- a/src/features/generation/worker/generators/slideGeometry.ts
+++ b/src/features/generation/worker/generators/slideGeometry.ts
@@ -116,6 +116,11 @@ export function resolveSlideGeometry(input: SlideGeometryInput): SlideGeometry {
 
   const trayWidth = slide.trayWidthUnits * input.gridUnitMmX - clearance;
   if (trayWidth <= MIN_TRAY_INTERIOR_MM) return none('bin-too-narrow');
+  // Walls are checked against BOTH axes. Only checking depth let a thick wall
+  // on a narrow tray collapse the cavity in X, and the builder then returned
+  // the un-hollowed outer solid: a printable block that the resolver still
+  // reported as a tray.
+  if (trayWidth - 2 * slide.trayWallMm <= MIN_TRAY_INTERIOR_MM) return none('tray-too-thin');
 
   if (slide.railMount === 'interior') {
     const ceiling = interiorRailCeiling(wallHeight, input.hasLip);

--- a/src/features/generation/worker/generators/slideGeometry.ts
+++ b/src/features/generation/worker/generators/slideGeometry.ts
@@ -1,0 +1,212 @@
+/**
+ * Sliding-tray geometry resolver.
+ *
+ * Pure and separate from the BREP builders so the relationship that actually
+ * matters — that the tray is narrower than the track it runs in, by the
+ * clearance, on every face — can be asserted without a kernel. Both the rail
+ * fused onto the bin and the companion tray are derived from ONE call here, so
+ * they cannot disagree about where the bearing surfaces are.
+ *
+ * Neither mount uses a tongue-and-groove. The tray's own floor is the runner:
+ *
+ *  - `interior` — two ledges protrude inward from the front/back walls. The
+ *    tray's floor rests on them and the walls above the ledges guide it in Y.
+ *  - `rim` — two strips stand on the front/back wall tops. The tray's floor
+ *    bridges the opening, resting on the wall tops, guided in Y by the strips.
+ *    Because it sits above every wall, it crosses to an adjacent railed bin.
+ *
+ * Fewer mating faces means fewer places for a fit to go wrong, and nothing
+ * here needs support material.
+ */
+
+import { LIP_HEIGHT, LIP_TAPER_WIDTH, BOX_CORNER_RADIUS } from './generatorConstants';
+import type { SlideConfig } from '@/shared/types/bin';
+
+/** One rail bar, as an axis-aligned box in bin-centred mm. */
+export interface SlideRailBar {
+  readonly xMin: number;
+  readonly xMax: number;
+  readonly yMin: number;
+  readonly yMax: number;
+  readonly zMin: number;
+  readonly zMax: number;
+}
+
+export interface SlideGeometry {
+  /** Front and back rail bars. Empty when the config cannot produce a rail. */
+  readonly rails: readonly SlideRailBar[];
+  /** Companion tray outer footprint and height, in mm. */
+  readonly tray: {
+    readonly widthMm: number;
+    readonly depthMm: number;
+    readonly heightMm: number;
+    readonly wallMm: number;
+    /** Z the tray's underside sits at when placed on its track. */
+    readonly restZ: number;
+  } | null;
+  /**
+   * Why no geometry was produced, for the caller to surface. `null` when the
+   * resolve succeeded.
+   */
+  readonly rejection: SlideRejection | null;
+}
+
+export type SlideRejection =
+  'disabled' | 'bin-too-shallow' | 'bin-too-narrow' | 'tray-too-thin' | 'rail-below-floor';
+
+export interface SlideGeometryInput {
+  readonly slide: SlideConfig;
+  readonly innerW: number;
+  readonly innerD: number;
+  readonly outerW: number;
+  readonly outerD: number;
+  readonly wallThickness: number;
+  readonly wallHeight: number;
+  readonly collarHeight: number;
+  readonly hasLip: boolean;
+  readonly gridUnitMmX: number;
+}
+
+/** Smallest tray wall-to-wall interior that is worth generating, mm. */
+const MIN_TRAY_INTERIOR_MM = 2;
+
+/**
+ * How far a `rim` strip is sunk below the nominal lip top so it always welds.
+ *
+ * The lip's peak is filleted (`TOP_FILLET`), so the surface actually sits ~0.1mm
+ * below `wallHeight + LIP_HEIGHT`. A strip placed at the nominal height floats
+ * clear of it and fuses as a DISCONNECTED island: still watertight, still the
+ * right bounding box, still passes every structural assertion, and the tray
+ * would ride on a part that falls off the print. The margin is buried inside
+ * the lip, so the track's height above the rim is unchanged.
+ */
+const RAIL_FUSION_MARGIN_MM = 0.5;
+
+/**
+ * Highest an `interior` rail's top may sit.
+ *
+ * The stacking lip reaches `LIP_TAPER_WIDTH` BELOW its own base plane for the
+ * angled support that blends it into the wall, so a rail placed against the
+ * rim lands inside that taper: it either fuses into the lip and back-fills it
+ * (the foot stops seating in a baseplate) or comes out silently thinner than
+ * asked for. Neither is visible to a bounding-box or watertight check.
+ */
+export function interiorRailCeiling(wallHeight: number, hasLip: boolean): number {
+  return hasLip ? wallHeight - LIP_TAPER_WIDTH : wallHeight;
+}
+
+/** Z the `rim` track stands on: the wall top, or the lip's top when there is one. */
+export function rimTrackBaseZ(wallHeight: number, collarHeight: number, hasLip: boolean): number {
+  return wallHeight + collarHeight + (hasLip ? LIP_HEIGHT : 0);
+}
+
+export function resolveSlideGeometry(input: SlideGeometryInput): SlideGeometry {
+  const { slide, innerW, innerD, outerD, wallThickness, wallHeight } = input;
+  const none = (rejection: SlideRejection): SlideGeometry => ({
+    rails: [],
+    tray: null,
+    rejection,
+  });
+
+  if (!slide.enabled) return none('disabled');
+
+  const protrusion = slide.railProtrusionMm;
+  const thickness = slide.railThicknessMm;
+  const clearance = slide.clearanceMm;
+
+  const trayWidth = slide.trayWidthUnits * input.gridUnitMmX - clearance;
+  if (trayWidth <= MIN_TRAY_INTERIOR_MM) return none('bin-too-narrow');
+
+  if (slide.railMount === 'interior') {
+    const ceiling = interiorRailCeiling(wallHeight, input.hasLip);
+    const railTop = Math.min(ceiling, wallHeight - slide.railDropMm);
+    const railBottom = railTop - thickness;
+    // The rail must stand clear of the floor slab, or it is a solid block
+    // filling the cavity rather than a ledge.
+    if (railBottom <= wallThickness) return none('rail-below-floor');
+
+    // Tray runs BETWEEN the front and back walls, riding on the ledges.
+    const trayDepth = innerD - 2 * clearance;
+    if (trayDepth - 2 * slide.trayWallMm <= MIN_TRAY_INTERIOR_MM) return none('bin-too-shallow');
+    // Overlap onto each ledge must leave the tray with a floor between them.
+    if (protrusion * 2 >= trayDepth) return none('bin-too-shallow');
+
+    const rails: SlideRailBar[] = [
+      {
+        xMin: -innerW / 2,
+        xMax: innerW / 2,
+        yMin: -innerD / 2,
+        yMax: -innerD / 2 + protrusion,
+        zMin: railBottom,
+        zMax: railTop,
+      },
+      {
+        xMin: -innerW / 2,
+        xMax: innerW / 2,
+        yMin: innerD / 2 - protrusion,
+        yMax: innerD / 2,
+        zMin: railBottom,
+        zMax: railTop,
+      },
+    ];
+
+    return {
+      rails,
+      tray: {
+        widthMm: trayWidth,
+        depthMm: trayDepth,
+        heightMm: slide.trayDepthMm,
+        wallMm: slide.trayWallMm,
+        restZ: railTop + clearance,
+      },
+      rejection: null,
+    };
+  }
+
+  // `rim`: strips stand on the wall tops at the OUTER edge, so the channel
+  // between them is the full opening plus both wall thicknesses. The tray
+  // bridges it, resting on the wall tops.
+  const baseZ = rimTrackBaseZ(wallHeight, input.collarHeight, input.hasLip);
+  // Keep the strips on the straight part of the wall: the footprint's corners
+  // are arcs of BOX_CORNER_RADIUS, and a bar run into them would hang off the
+  // silhouette. Stopping short also leaves the corner clear for the neighbour's
+  // strip to pick up the track.
+  const xEnd = input.outerW / 2 - BOX_CORNER_RADIUS;
+  if (xEnd <= 0) return none('bin-too-narrow');
+
+  const stripInnerY = outerD / 2 - wallThickness;
+  const channel = 2 * stripInnerY;
+  const trayDepth = channel - 2 * clearance;
+  if (trayDepth - 2 * slide.trayWallMm <= MIN_TRAY_INTERIOR_MM) return none('bin-too-shallow');
+
+  const rails: SlideRailBar[] = [
+    {
+      xMin: -xEnd,
+      xMax: xEnd,
+      yMin: -outerD / 2,
+      yMax: -stripInnerY,
+      zMin: baseZ - RAIL_FUSION_MARGIN_MM,
+      zMax: baseZ + thickness,
+    },
+    {
+      xMin: -xEnd,
+      xMax: xEnd,
+      yMin: stripInnerY,
+      yMax: outerD / 2,
+      zMin: baseZ - RAIL_FUSION_MARGIN_MM,
+      zMax: baseZ + thickness,
+    },
+  ];
+
+  return {
+    rails,
+    tray: {
+      widthMm: trayWidth,
+      depthMm: trayDepth,
+      heightMm: slide.trayDepthMm,
+      wallMm: slide.trayWallMm,
+      restZ: baseZ,
+    },
+    rejection: null,
+  };
+}

--- a/src/features/generation/worker/generators/slideRailBuilder.test.ts
+++ b/src/features/generation/worker/generators/slideRailBuilder.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from 'vitest';
-import { getBounds, withScope } from 'brepjs';
-import type { DisposalScope } from 'brepjs';
+import { getBounds, withScope, intersect, draw } from 'brepjs';
+import type { DisposalScope, ValidSolid } from 'brepjs';
 import { buildSlideRails, buildSlideTray } from './slideRailBuilder';
 import { resolveSlideGeometry, rimTrackBaseZ } from './slideGeometry';
 import type { SlideGeometryInput } from './slideGeometry';
@@ -62,7 +62,7 @@ describe('slide rail solids', () => {
     expect(b.zMax).toBeCloseTo(Math.max(...zs), 3);
   });
 
-  it('builds a hollow tray, not a solid block', () => {
+  it('sits at the planned outer size, floor down', () => {
     const inp = input();
     const planned = resolveSlideGeometry(inp);
     const b = withScope((scope: DisposalScope) => {
@@ -76,6 +76,39 @@ describe('slide rail solids', () => {
     // still have the right bounding box height.
     expect(b.zMin).toBeCloseTo(0, 3);
     expect(b.zMax).toBeCloseTo(planned.tray?.heightMm ?? 0, 3);
+  });
+
+  it('is actually hollow', () => {
+    // Bounding box says nothing here: a failed cavity boolean returns the outer
+    // solid at exactly these bounds. Probe the middle of where the cavity
+    // should be — a hollow tray has no material there.
+    const inp = input();
+    const planned = resolveSlideGeometry(inp);
+    const height = planned.tray?.heightMm ?? 0;
+    const empty = withScope((scope: DisposalScope) => {
+      const tray = scope.register(buildSlideTray(inp) as ValidSolid);
+      const probe = scope.register(
+        draw([-1, -1])
+          .lineTo([1, -1])
+          .lineTo([1, 1])
+          .lineTo([-1, 1])
+          .close()
+          .sketchOnPlane('XY', height / 2)
+          .extrude(1)
+      );
+      const hit = intersect(tray, probe as ValidSolid);
+      if (!hit.ok) return true;
+      // An empty intersection has no geometry to bound, and the kernel throws
+      // rather than returning a degenerate box — that throw IS the "nothing
+      // there" answer.
+      try {
+        const hb = getBounds(scope.register(hit.value));
+        return hb.xMax - hb.xMin < 1e-6;
+      } catch {
+        return true;
+      }
+    });
+    expect(empty).toBe(true);
   });
 });
 

--- a/src/features/generation/worker/generators/slideRailBuilder.test.ts
+++ b/src/features/generation/worker/generators/slideRailBuilder.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getBounds, withScope } from 'brepjs';
+import type { DisposalScope } from 'brepjs';
+import { buildSlideRails, buildSlideTray } from './slideRailBuilder';
+import { resolveSlideGeometry, rimTrackBaseZ } from './slideGeometry';
+import type { SlideGeometryInput } from './slideGeometry';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { buildParams } from './__kernel-tests__/scenarioTypes';
+import { clearAllCaches } from './shapeCache';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { SlideConfig } from '@/shared/types/bin';
+
+const WT = 1.2;
+
+function input(slide: Partial<SlideConfig> = {}): SlideGeometryInput {
+  const outerW = 3 * 42 - 0.5;
+  const outerD = 2 * 42 - 0.5;
+  return {
+    slide: { ...DEFAULT_BIN_PARAMS.slide, enabled: true, ...slide },
+    innerW: outerW - 2 * WT,
+    innerD: outerD - 2 * WT,
+    outerW,
+    outerD,
+    wallThickness: WT,
+    wallHeight: 42,
+    collarHeight: 0,
+    hasLip: true,
+    gridUnitMmX: 42,
+  };
+}
+
+describe('slide rail solids', () => {
+  beforeAll(async () => {
+    await initBrepjs();
+  }, 120_000);
+
+  it('returns nothing when the feature is off', () => {
+    expect(buildSlideRails(input({ enabled: false }))).toBeNull();
+    expect(buildSlideTray(input({ enabled: false }))).toBeNull();
+  });
+
+  it('occupies exactly the bounds the resolver planned', () => {
+    // The resolver is the single source both the bin rail and the tray read,
+    // so a builder that drifts from it would put the tray on a track that is
+    // not where the rail actually is.
+    const inp = input({ railMount: 'interior' });
+    const planned = resolveSlideGeometry(inp);
+    const b = withScope((scope: DisposalScope) => {
+      const rails = buildSlideRails(inp);
+      if (!rails) throw new Error('expected rails');
+      return getBounds(scope.register(rails));
+    });
+    const xs = planned.rails.flatMap((r) => [r.xMin, r.xMax]);
+    const ys = planned.rails.flatMap((r) => [r.yMin, r.yMax]);
+    const zs = planned.rails.flatMap((r) => [r.zMin, r.zMax]);
+    expect(b.xMin).toBeCloseTo(Math.min(...xs), 3);
+    expect(b.xMax).toBeCloseTo(Math.max(...xs), 3);
+    expect(b.yMin).toBeCloseTo(Math.min(...ys), 3);
+    expect(b.yMax).toBeCloseTo(Math.max(...ys), 3);
+    expect(b.zMin).toBeCloseTo(Math.min(...zs), 3);
+    expect(b.zMax).toBeCloseTo(Math.max(...zs), 3);
+  });
+
+  it('builds a hollow tray, not a solid block', () => {
+    const inp = input();
+    const planned = resolveSlideGeometry(inp);
+    const b = withScope((scope: DisposalScope) => {
+      const tray = buildSlideTray(inp);
+      if (!tray) throw new Error('expected a tray');
+      return getBounds(scope.register(tray));
+    });
+    expect(b.xMax - b.xMin).toBeCloseTo(planned.tray?.widthMm ?? 0, 3);
+    expect(b.yMax - b.yMin).toBeCloseTo(planned.tray?.depthMm ?? 0, 3);
+    // Floor on Z=0 is the print orientation; a tray built upside down would
+    // still have the right bounding box height.
+    expect(b.zMin).toBeCloseTo(0, 3);
+    expect(b.zMax).toBeCloseTo(planned.tray?.heightMm ?? 0, 3);
+  });
+});
+
+describe('slide rails on a generated bin', () => {
+  beforeAll(async () => {
+    await initBrepjs();
+  }, 120_000);
+
+  const generate = (slide?: Partial<SlideConfig>) => {
+    clearAllCaches();
+    const mesh = getGenerateBin()(
+      buildParams({
+        width: 3,
+        depth: 2,
+        height: 6,
+        ...(slide ? { slide: { ...DEFAULT_BIN_PARAMS.slide, enabled: true, ...slide } } : {}),
+      })
+    );
+    const v = mesh.vertices;
+    if (!v) throw new Error('no vertices');
+    let zMax = -Infinity;
+    for (let i = 2; i < v.length; i += 3) if (v[i] > zMax) zMax = v[i];
+    return { zMax, triangles: v.length / 9 };
+  };
+
+  it('tops the rim track out at the planned height', () => {
+    // The load-bearing assertion that the feature actually ran: a builder
+    // returning null would leave a bin that still passes every structural
+    // check, and the tray would then ride on nothing.
+    //
+    // Asserted against the PLANNED top rather than a delta from the plain bin:
+    // the lip's peak is filleted a little below its nominal height, so a delta
+    // silently absorbs a strip that floats clear of the lip instead of welding
+    // to it.
+    const plain = generate();
+    const railed = generate({ railMount: 'rim', railThicknessMm: 2 });
+    expect(railed.zMax).toBeGreaterThan(plain.zMax);
+    expect(railed.zMax).toBeCloseTo(rimTrackBaseZ(6 * 7, 0, true) + 2, 2);
+  });
+
+  it('leaves the rim untouched on an interior mount but adds material', () => {
+    const plain = generate();
+    const railed = generate({ railMount: 'interior' });
+    expect(railed.zMax).toBeCloseTo(plain.zMax, 2);
+    expect(railed.triangles).toBeGreaterThan(plain.triangles);
+  });
+});

--- a/src/features/generation/worker/generators/slideRailBuilder.ts
+++ b/src/features/generation/worker/generators/slideRailBuilder.ts
@@ -1,0 +1,142 @@
+/**
+ * Sliding-tray rail: the track fused onto the bin, and the companion tray.
+ *
+ * All placement comes from `resolveSlideGeometry`, which is pure and tested
+ * without a kernel. This file only turns those boxes into solids, so the rail
+ * on the bin and the tray that rides it can never disagree about where the
+ * bearing surfaces are.
+ */
+
+import { draw, translate, withScope, clone, unwrap, fuseAll, cut } from 'brepjs';
+import type { Shape3D, DisposalScope, ValidSolid } from 'brepjs';
+import type { BinParams } from '@/shared/types/bin';
+import { sketch } from './meshUtils';
+import { resolveSlideGeometry } from './slideGeometry';
+import type { SlideRailBar, SlideGeometryInput } from './slideGeometry';
+
+/** Axis-aligned box as a solid, from bin-centred mm bounds. */
+function boxSolid(scope: DisposalScope, b: SlideRailBar): Shape3D {
+  const profile = draw([b.xMin, b.yMin])
+    .lineTo([b.xMax, b.yMin])
+    .lineTo([b.xMax, b.yMax])
+    .lineTo([b.xMin, b.yMax])
+    .close();
+  const extruded = scope.register(sketch(profile, 'XY').extrude(b.zMax - b.zMin));
+  return scope.register(translate(extruded, [0, 0, b.zMin]));
+}
+
+/** Build the rail bars for a bin, or null when the config produces none. */
+export function buildSlideRails(input: SlideGeometryInput): Shape3D | null {
+  const geometry = resolveSlideGeometry(input);
+  if (geometry.rails.length === 0) return null;
+
+  return withScope((scope: DisposalScope): Shape3D | null => {
+    const bars = geometry.rails.map((bar) => boxSolid(scope, bar));
+    if (bars.length === 0) return null;
+    const fused =
+      bars.length === 1 ? bars[0] : scope.register(unwrap(fuseAll(bars as ValidSolid[])));
+    return unwrap(clone(fused));
+  });
+}
+
+/**
+ * Build the companion tray: an open-topped box sized to run in this bin's
+ * track. Returned at the origin with its floor on Z=0, which is the print
+ * orientation; the caller places it.
+ */
+export function buildSlideTray(input: SlideGeometryInput): Shape3D | null {
+  const { tray } = resolveSlideGeometry(input);
+  if (!tray) return null;
+
+  return withScope((scope: DisposalScope): Shape3D | null => {
+    const outer = boxSolid(scope, {
+      xMin: -tray.widthMm / 2,
+      xMax: tray.widthMm / 2,
+      yMin: -tray.depthMm / 2,
+      yMax: tray.depthMm / 2,
+      zMin: 0,
+      zMax: tray.heightMm,
+    });
+    const innerW = tray.widthMm - 2 * tray.wallMm;
+    const innerD = tray.depthMm - 2 * tray.wallMm;
+    if (innerW <= 0 || innerD <= 0) return unwrap(clone(outer));
+
+    // Cavity runs past the top so the boolean leaves no skin over the opening.
+    const cavity = boxSolid(scope, {
+      xMin: -innerW / 2,
+      xMax: innerW / 2,
+      yMin: -innerD / 2,
+      yMax: innerD / 2,
+      zMin: tray.wallMm,
+      zMax: tray.heightMm + 1,
+    });
+    const hollow = cut(outer as ValidSolid, cavity as ValidSolid);
+    if (!hollow.ok) return unwrap(clone(outer));
+    return unwrap(clone(scope.register(hollow.value)));
+  });
+}
+
+// --- FeatureBuilder protocol ---
+
+import type { FeatureBuilder } from './pipeline/featureBuilder';
+import { FeatureTag } from './featureTags';
+import { buildCacheKey, quantize, stableSerialize, compactKey } from './cacheKeyUtils';
+import type { PipelineContext } from './pipeline/types';
+
+/** Resolver input from a pipeline context, so the feature and the export agree. */
+export function slideInputFromContext(ctx: PipelineContext): SlideGeometryInput {
+  const { params, dimensions: dim } = ctx;
+  return {
+    slide: params.slide,
+    innerW: dim.innerW,
+    innerD: dim.innerD,
+    outerW: dim.outerW,
+    outerD: dim.outerD,
+    wallThickness: params.wallThickness,
+    wallHeight: dim.wallHeight,
+    collarHeight: dim.collarHeight,
+    hasLip: dim.hasLip,
+    gridUnitMmX: dim.gridUnitMmX,
+  };
+}
+
+export const slideRailsFeature: FeatureBuilder = {
+  name: 'slideRails',
+  tag: FeatureTag.SLIDE_RAIL,
+  target: 'fuse',
+  shouldBuild: (ctx: PipelineContext) => ctx.params.slide.enabled,
+  cacheKey: (ctx: PipelineContext) => {
+    const { dimensions: dim, params } = ctx;
+    return compactKey(
+      buildCacheKey(
+        'slideRails-v1',
+        stableSerialize(params.slide),
+        quantize(dim.innerW),
+        quantize(dim.innerD),
+        quantize(dim.outerW),
+        quantize(dim.outerD),
+        quantize(dim.wallHeight),
+        quantize(dim.collarHeight),
+        quantize(params.wallThickness),
+        quantize(dim.gridUnitMmX),
+        dim.hasLip ? 'lip' : 'nolip'
+      )
+    );
+  },
+  build: (ctx: PipelineContext) => {
+    const rails = buildSlideRails(slideInputFromContext(ctx));
+    return rails ? [rails] : null;
+  },
+};
+
+/** Re-exported so callers outside the pipeline can resolve the same geometry. */
+export type { SlideGeometryInput } from './slideGeometry';
+export { resolveSlideGeometry } from './slideGeometry';
+
+/** Convenience for callers holding raw params rather than a pipeline context. */
+export function slideInputFromParams(
+  params: BinParams,
+  dims: Omit<SlideGeometryInput, 'slide' | 'wallThickness'>
+): SlideGeometryInput {
+  return { ...dims, slide: params.slide, wallThickness: params.wallThickness };
+}

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -60,6 +60,8 @@ export type {
   HandleSide,
   HandleWallSide,
   LidConfig,
+  SlideConfig,
+  SlideRailMount,
   LidAttachment,
   LidMagnetConfig,
   LidTrayConfig,


### PR DESCRIPTION
First half of the Ko-fi sliding-tray request (#3286 is the design). A rail carried by the bin plus a companion tray that rides on it, so a shallow tray can be pushed aside to reach what sits underneath.

**Not yet usable from the app.** The tray solid builds but is not emitted as an export piece, and there is no UI, so nothing generates for a user. That is the next PR; this one is the model and the geometry, with the traps pinned.

## The arrangement

The rail runs along the FRONT and BACK walls, so the tray travels in X. `railMount` picks where it sits, which is what decides whether a tray can leave its own bin at all:

```
railMount: 'interior'        railMount: 'rim'

  ┌─┐         ┌─┐          ┌─┐        ┌─┐
  │ │ ▄▄▄▄▄▄▄ │ │          │ ├────────┤ │
  │ ├─┘     └─┤ │          │ │ ▄▄▄▄▄▄ │ │
  │ │  tray   │ │          │ │        │ │
  │ │         │ │          │ │  bin   │ │
  └─┘         └─┘          └─┘        └─┘

  drops inside one bin     rides over the rim,
                           crosses to the next bin
```

Neither mount uses a tongue and groove. The tray's own floor is the runner: `interior` ledges carry it with the walls above guiding it in Y, `rim` strips guide it while it bridges the opening resting on the wall tops. Fewer mating faces to get wrong, and nothing needs support material.

## Why the multi-bin case needs no layout awareness

A rail spanning a bin's full length meets its neighbour's when two railed bins sit side by side, so the track is continuous on its own. Adjacent bins are a known `CLEARANCE` apart plus two corner radii, an ~8mm interruption that any tray wider than a unit bridges without noticing.

That collapses the expensive "derive the tray width from layout placement" problem the design doc worried about into one ordinary parameter, `trayWidthUnits`. Spanning is an emergent property of placing railed bins next to each other, not a feature that has to be built.

## Two traps, neither visible to a structural assertion

**An interior rail is clamped under the lip taper.** The stacking lip reaches `LIP_TAPER_WIDTH` below its own base plane for the angled support that blends it into the wall, so a rail placed against the rim lands inside it: it either back-fills the taper (the foot stops seating in a baseplate) or comes out silently thinner than asked for.

**A rim strip is sunk 0.5mm below the NOMINAL lip top.** The lip's peak is filleted ~0.1mm below `wallHeight + LIP_HEIGHT`. A strip placed at the nominal height floats clear of it and fuses as a **disconnected island** — still watertight, still the right bounding box, still passes every structural check, and it falls off the print.

The second one was a real defect in my first version. The test caught it because it asserts the planned top rather than a delta from a plain bin; a delta silently absorbs a floating strip.

## Fit

All placement comes from one pure resolver (`slideGeometry.ts`), so the rail on the bin and the tray that rides it cannot disagree about where the bearing surfaces are. That also makes the fit assertable without a kernel: the tray is narrower than its track by the clearance on every face.

Sliding clearance is its own parameter rather than the shared `CLEARANCE` (0.5mm). That constant is the bin-to-baseplate seating fit and is free to move with the Gridfinity spec; this one is what a user tunes against their own printer. Default 0.45mm, a running fit at typical FDM tolerances.

## Verification

- `slideGeometry.test.ts` (19): both mounts, the lip clamps, the fit invariant, tray sizing from grid units rather than the host bin, and every rejection path.
- `slideRailBuilder.test.ts` (6, real kernel): solids match the resolver's planned bounds, the tray is hollow and floor-down, the rim track tops out where planned, an interior mount leaves the rim untouched while adding material.
- Four scenarios through both the structural matrix and export integrity.
- Full `generators` project: 266 files, 2631 passed, 0 failed. No snapshot churn, since the feature is off by default.
- Server validation mirror with tests, including one asserting `slide` survives `pickAllowedParams` — it did not at first, and that test is what caught it.

## Follow-ups

- Emit the tray as a combined-export piece (`exportHandler` already does this for the lid).
- Panel UI, ghost overlay, i18n.
- Wall-pattern interaction: the rails are additive rather than cuts, so the border-clipping rule does not apply directly, but a perforated front/back wall is a poor bonding surface for a rail. Worth a keep-out like the divider one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the sliding-tray model and rail geometry: bins carry front/back rails and a companion tray that slides in X; the feature is off and hidden, and the tray solid is generated but not exported. Direct-mesh drafts skip slide-enabled bins. Also regenerates community example param fingerprints so the duplicate-upload guard keeps working.

- **New Features**
  - Two mounts: `interior` ledges (tray stays in-bin) and `rim` strips (tray crosses bins).
  - One resolver (`slideGeometry.ts`) defines rails/tray; builders create solids and integrate as `SLIDE_RAIL` in the pipeline.
  - Tray width set by `trayWidthUnits`; print-tuned `clearanceMm` is separate from `CLEARANCE`.
  - Server validation adds `slide` with `SLIDE_CONSTRAINTS` and allowed mounts; accepts partial configs and keeps `slide` through sanitization.
  - Tests pin fit, lip-taper clearance, rim fusion height; added scenarios and export integrity checks.
  - Generation guards: slide bins are excluded from direct-mesh; resolver rejects too-thin trays on both axes; hollow-tray test probes the cavity instead of bounds.

- **Migration**
  - `migrateParams` backfills and completes `slide`; unknown `railMount` is coerced; defaults added to `DEFAULT_BIN_PARAMS`; store adds `updateSlide`.
  - No user-visible change until UI and export are added in a follow-up.

<sup>Written for commit d97f207f737b084cff48fe353ac57c47a3b1b850. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

