### PR TITLE
fix(generation): interlock the triangle wall pattern and keep stamps off corner arcs

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
@@ -12,9 +12,9 @@ exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`
 
 exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5730`;
 
-exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `8790`;
+exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `8550`;
 
-exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `8234`;
+exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `7994`;
 
 exports[`custom-shape > 3×3 L with lip 1`] = `5250`;
 
@@ -26,6 +26,6 @@ exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`
 
 exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5690`;
 
-exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `9328`;
+exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `8968`;
 
 exports[`custom-shape > 3×3 U with lip 1`] = `5328`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
@@ -1,23 +1,23 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`divider patterns > 2×2 honeycomb dividers 1`] = `11444`;
+exports[`divider patterns > 2×2 honeycomb dividers 1`] = `9940`;
 
-exports[`divider patterns > dividers + interior cutouts 1`] = `10504`;
+exports[`divider patterns > dividers + interior cutouts 1`] = `9000`;
 
-exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `11884`;
+exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `10380`;
 
-exports[`divider patterns > dividers + outer cutouts + handles 1`] = `14956`;
+exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13452`;
 
-exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `14170`;
+exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `12114`;
 
-exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `11260`;
+exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10324`;
 
 exports[`divider patterns > mitsukude lattice on dividers 1`] = `15896`;
 
-exports[`divider patterns > overhang shifts the interior with the dividers 1`] = `11292`;
+exports[`divider patterns > overhang shifts the interior with the dividers 1`] = `10844`;
 
-exports[`divider patterns > round pattern on a single column divider 1`] = `22044`;
+exports[`divider patterns > round pattern on a single column divider 1`] = `20212`;
 
-exports[`divider patterns > shortened dividers re-fit the band 1`] = `9984`;
+exports[`divider patterns > shortened dividers re-fit the band 1`] = `8480`;
 
-exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `11568`;
+exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `10060`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
@@ -6,7 +6,7 @@ exports[`floor patterns > custom-shape bin patterns only its filled feet 1`] = `
 
 exports[`floor patterns > flat base takes one interior-wide window 1`] = `5176`;
 
-exports[`floor patterns > floor and wall patterns compose 1`] = `10332`;
+exports[`floor patterns > floor and wall patterns compose 1`] = `9852`;
 
 exports[`floor patterns > fractional edge foot carries a narrower window 1`] = `5924`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5584`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5104`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `5230`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `4750`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4632`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4152`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4632`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4152`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4952`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4472`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `4292`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `3812`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `4284`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `3804`;

--- a/src/features/generation/worker/generators/patterns/trianglePattern.test.ts
+++ b/src/features/generation/worker/generators/patterns/trianglePattern.test.ts
@@ -22,6 +22,83 @@ describe('TrianglePatternCalculator', () => {
     expect(rotations.has(180)).toBe(true);
   });
 
+  it('tiles interlocked with a uniform web and no overlaps', () => {
+    const R = 4;
+    const web = 0.8;
+    const calc = new TrianglePatternCalculator(R, web);
+    const centers = calc.calculateCenters({ fillW: 80, fillH: 28 });
+    expect(centers.length).toBeGreaterThan(10);
+
+    const verts = (c: { x: number; y: number; rotation?: number }) => {
+      const rot = ((c.rotation ?? 0) * Math.PI) / 180;
+      return [0, 1, 2].map((i) => {
+        const a = Math.PI / 2 + rot + (i * 2 * Math.PI) / 3;
+        return [c.x + R * Math.cos(a), c.y + R * Math.sin(a)] as const;
+      });
+    };
+    const side = (
+      a: readonly [number, number],
+      b: readonly [number, number],
+      p: readonly [number, number]
+    ) => (b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0]);
+    const inside = (p: readonly [number, number], v: (readonly [number, number])[]) => {
+      const d = [side(v[0], v[1], p), side(v[1], v[2], p), side(v[2], v[0], p)];
+      return !(d.some((x) => x < 0) && d.some((x) => x > 0));
+    };
+    const segDist = (
+      a: readonly [number, number],
+      b: readonly [number, number],
+      c: readonly [number, number],
+      d: readonly [number, number]
+    ) => {
+      const clamp = (t: number) => Math.max(0, Math.min(1, t));
+      const d1 = [b[0] - a[0], b[1] - a[1]];
+      const d2 = [d[0] - c[0], d[1] - c[1]];
+      const r = [c[0] - a[0], c[1] - a[1]];
+      const A = d1[0] * d1[0] + d1[1] * d1[1];
+      const B = d1[0] * d2[0] + d1[1] * d2[1];
+      const C = d2[0] * d2[0] + d2[1] * d2[1];
+      const D = d1[0] * r[0] + d1[1] * r[1];
+      const E = d2[0] * r[0] + d2[1] * r[1];
+      let best = Infinity;
+      const cands: (readonly [number, number])[] = [
+        [0, 0],
+        [0, 1],
+        [1, 0],
+        [1, 1],
+        [clamp(D / A), 0],
+        [clamp((D + B) / A), 1],
+        [0, clamp(-E / C)],
+        [1, clamp((B - E) / C)],
+      ];
+      for (const [sT, tT] of cands) {
+        const px = a[0] + sT * d1[0] - c[0] - tT * d2[0];
+        const py = a[1] + sT * d1[1] - c[1] - tT * d2[1];
+        best = Math.min(best, Math.hypot(px, py));
+      }
+      return best;
+    };
+
+    let minGap = Infinity;
+    for (let i = 0; i < centers.length; i++) {
+      for (let j = i + 1; j < centers.length; j++) {
+        if (Math.hypot(centers[i].x - centers[j].x, centers[i].y - centers[j].y) > 3 * R) continue;
+        const vi = verts(centers[i]);
+        const vj = verts(centers[j]);
+        expect(vj.some((pt) => inside(pt, vi)) || vi.some((pt) => inside(pt, vj))).toBe(false);
+        let g = Infinity;
+        for (let a = 0; a < 3; a++) {
+          for (let b = 0; b < 3; b++) {
+            g = Math.min(g, segDist(vi[a], vi[(a + 1) % 3], vj[b], vj[(b + 1) % 3]));
+          }
+        }
+        minGap = Math.min(minGap, g);
+      }
+    }
+    // Nearest neighbours are separated by exactly the design web.
+    expect(minGap).toBeCloseTo(web, 6);
+  });
+
   it('returns no centers when the fill area is too small', () => {
     expect(new TrianglePatternCalculator(4).calculateCenters({ fillW: 3, fillH: 3 })).toEqual([]);
   });

--- a/src/features/generation/worker/generators/patterns/trianglePattern.ts
+++ b/src/features/generation/worker/generators/patterns/trianglePattern.ts
@@ -1,11 +1,12 @@
 /**
  * Triangular-grid pattern calculator.
  *
- * A staggered field of equilateral-triangle holes whose orientation alternates
- * up / down in a checkerboard, reading as a classic triangular pattern. This is
- * a PERFORATION (solid web between every triangle), not a zero-web tessellation
- * — the web keeps the wall printable and rigid rather than leaving knife-edge
- * struts. Per-element flip is carried on each center's `rotation`.
+ * An interlocked field of equilateral-triangle holes: apex-down triangles nest
+ * between the apex-up ones (centroid R/2 above, half a period over), reading
+ * as the classic triangular tessellation. This is a PERFORATION (uniform solid
+ * web between every triangle), not a zero-web tessellation — the web keeps the
+ * wall printable and rigid rather than leaving knife-edge struts. Per-element
+ * flip is carried on each center's `rotation`.
  *
  * Equilateral triangle, circumradius R:
  *   side       = √3 R
@@ -41,29 +42,45 @@ export class TrianglePatternCalculator implements StampPatternCalculator {
   calculateCenters(config: PatternGridConfig): PatternCenter[] {
     const { fillW, fillH } = config;
     const R = this.radius;
+    const w = this.webThickness;
     const halfWidth = (Math.sqrt(3) / 2) * R;
-    const colSpacing = Math.sqrt(3) * R + this.webThickness;
-    const rowSpacing = 1.5 * R + this.webThickness;
+    // Interlocked classic tiling: each apex-down triangle nests between two
+    // apex-up neighbours, its centroid R/2 ABOVE the up row and half a period
+    // over. The slant web is exact: the gap between an up's right edge and
+    // the next down's left edge is (sqrt3*dx + dy)/2 - R for a (dx, dy)
+    // centroid offset, so dy = R/2 gives dx = sqrt3*R/2 + 2w/sqrt3.
+    const dx = halfWidth + (2 / Math.sqrt(3)) * w;
+    const period = 2 * dx;
+    const rowSpacing = 1.5 * R + w;
     const maxX = fillW / 2 - halfWidth;
     const maxY = fillH / 2 - R;
 
     if (maxX < 0 || maxY < 0) return [];
 
     const centers: PatternCenter[] = [];
-    const startRow = Math.floor(-maxY / rowSpacing);
+    // A down row rides R/2 above its up row, so up rows just below the
+    // window can still contribute their downs.
+    const startRow = Math.floor((-maxY - R / 2) / rowSpacing);
     const endRow = Math.ceil(maxY / rowSpacing);
 
     for (let row = startRow; row <= endRow; row++) {
-      const y = row * rowSpacing;
-      if (Math.abs(y) > maxY) continue;
-      const xOffset = (row & 1) === 1 ? colSpacing / 2 : 0;
-      const startCol = Math.ceil((-maxX - xOffset) / colSpacing);
-      const endCol = Math.floor((maxX - xOffset) / colSpacing);
-      for (let col = startCol; col <= endCol; col++) {
-        const x = col * colSpacing + xOffset;
-        // Checkerboard flip: alternate apex up / down across rows and columns.
-        const rotation = ((row + col) & 1) === 0 ? APEX_UP_DEG : APEX_DOWN_DEG;
-        centers.push({ x, y, rotation });
+      const yUp = row * rowSpacing;
+      const xOffset = (row & 1) === 1 ? period / 2 : 0;
+      if (Math.abs(yUp) <= maxY) {
+        const startCol = Math.ceil((-maxX - xOffset) / period);
+        const endCol = Math.floor((maxX - xOffset) / period);
+        for (let col = startCol; col <= endCol; col++) {
+          centers.push({ x: col * period + xOffset, y: yUp, rotation: APEX_UP_DEG });
+        }
+      }
+      const yDown = yUp + R / 2;
+      if (Math.abs(yDown) <= maxY) {
+        const off = xOffset + dx;
+        const startCol = Math.ceil((-maxX - off) / period);
+        const endCol = Math.floor((maxX - off) / period);
+        for (let col = startCol; col <= endCol; col++) {
+          centers.push({ x: col * period + off, y: yDown, rotation: APEX_DOWN_DEG });
+        }
       }
     }
     return centers;

--- a/src/features/generation/worker/generators/wallPatterns.test.ts
+++ b/src/features/generation/worker/generators/wallPatterns.test.ts
@@ -7,6 +7,7 @@ import {
   BOTTOM_SOLID_SKIRT,
   getExpandedCutoutDimensions,
 } from './wallPatterns';
+import { BOX_CORNER_RADIUS } from './generatorConstants';
 import { computeCutoutCenter } from '@/shared/utils/wallCutoutPosition';
 import type { BinParams, WallPatternSides } from '@/shared/types/bin';
 import type { CellMask } from '@/shared/utils/cellMask';
@@ -491,7 +492,7 @@ describe('getPatternDescriptors — corner keep-out (#2865)', () => {
     // The inner wall curves away over the last innerCornerRadius of the span;
     // a stamp reaching into that zone scallops the curved corner obliquely.
     // Lipped and lip-less bins both stay clear of it.
-    const innerCornerRadius = 3.75 - params.wallThickness;
+    const innerCornerRadius = Math.max(BOX_CORNER_RADIUS - params.wallThickness, 0);
     const withLip = frontCornerGap(params, innerW, innerD, true);
     expect(withLip.gap).toBeGreaterThanOrEqual(innerCornerRadius);
     // No lip additionally keeps the #2865 printability margin.
@@ -504,7 +505,7 @@ describe('getPatternDescriptors — corner keep-out (#2865)', () => {
     // corner (gap > corner keep-out), so the clamp drops nothing — identical
     // output with and without a lip.
     const params = boldRound(0.5);
-    const innerCornerRadius = 3.75 - params.wallThickness;
+    const innerCornerRadius = Math.max(BOX_CORNER_RADIUS - params.wallThickness, 0);
     const withLip = frontCornerGap(params, innerW, innerD, true);
     expect(withLip.gap).toBeGreaterThan(innerCornerRadius);
     const noLip = frontCornerGap(params, innerW, innerD, false);

--- a/src/features/generation/worker/generators/wallPatterns.test.ts
+++ b/src/features/generation/worker/generators/wallPatterns.test.ts
@@ -486,24 +486,27 @@ describe('getPatternDescriptors — corner keep-out (#2865)', () => {
   const innerW = 2 * 42 - 2 * 0.8;
   const innerD = 3 * 42 - 2 * 0.8;
 
-  it('a lip-less bin whose pattern reaches the corner gets a solid keep-out band', () => {
+  it('every bin keeps its stamps on the flat wall span, clear of the corner arc', () => {
     const params = boldRound(0.7);
-    // Pre-fix behaviour (a lip re-joins the walls, so no keep-out is applied):
-    // the hole reaches to within a sliver of the corner.
+    // The inner wall curves away over the last innerCornerRadius of the span;
+    // a stamp reaching into that zone scallops the curved corner obliquely.
+    // Lipped and lip-less bins both stay clear of it.
+    const innerCornerRadius = 3.75 - params.wallThickness;
     const withLip = frontCornerGap(params, innerW, innerD, true);
-    expect(withLip.gap).toBeLessThan(WALL_CORNER_KEEP_OUT);
-    // No lip → keep-out clears the outermost column(s), restoring a solid band.
+    expect(withLip.gap).toBeGreaterThanOrEqual(innerCornerRadius);
+    // No lip additionally keeps the #2865 printability margin.
     const noLip = frontCornerGap(params, innerW, innerD, false);
-    expect(noLip.gap).toBeGreaterThanOrEqual(WALL_CORNER_KEEP_OUT);
-    expect(noLip.cols).toBeLessThan(withLip.cols);
+    expect(noLip.gap).toBeGreaterThanOrEqual(Math.max(innerCornerRadius, WALL_CORNER_KEEP_OUT));
   });
 
   it('leaves a pattern that already clears the corner untouched (targeted, no churn)', () => {
     // At the neutral scale this bin's pattern already stops well clear of the
-    // corner (gap > keep-out), so the keep-out drops nothing — identical output.
+    // corner (gap > corner keep-out), so the clamp drops nothing — identical
+    // output with and without a lip.
     const params = boldRound(0.5);
+    const innerCornerRadius = 3.75 - params.wallThickness;
     const withLip = frontCornerGap(params, innerW, innerD, true);
-    expect(withLip.gap).toBeGreaterThan(WALL_CORNER_KEEP_OUT);
+    expect(withLip.gap).toBeGreaterThan(innerCornerRadius);
     const noLip = frontCornerGap(params, innerW, innerD, false);
     expect(noLip.cols).toBe(withLip.cols);
     expect(noLip.gap).toBeCloseTo(withLip.gap, 5);

--- a/src/features/generation/worker/generators/wallPatterns.ts
+++ b/src/features/generation/worker/generators/wallPatterns.ts
@@ -12,7 +12,7 @@ import type { CellMask } from '@/shared/utils/cellMask';
 import { MASK_CELL_SIZE, isPartialMask, maskToPolygon } from '@/shared/utils/cellMask';
 import { slottedWalls } from '@/shared/utils/slotMath';
 import { resolveWallPatternSides } from '@/shared/utils/wallPatternSides';
-import { CLEARANCE } from './generatorConstants';
+import { BOX_CORNER_RADIUS, CLEARANCE } from './generatorConstants';
 import { findPolygonEdgeForSide } from './maskPolygonEdges';
 import type { PatternCenter, StampPatternCalculator } from './patterns';
 import { getPatternCalculator, isStampCalculator, PATTERN_REGISTRY } from './patterns';
@@ -160,11 +160,17 @@ function getWallPatternDescriptors(
     zRotation?: number,
     allowClip = true
   ): void => {
-    // Corner keep-out (#2865): on a lip-less bin, trim the outermost pattern
-    // column clear of both wall ends so a bold pattern can't leave a razor-thin
-    // corner post. `wallSpan` stays the full inner span so cutout/handle clip
-    // anchoring is unaffected; only the stamped centers shrink.
-    const centerFillW = hasLip ? fillW : Math.max(0, fillW - 2 * WALL_CORNER_KEEP_OUT);
+    // Corner keep-out: keep every stamp on the FLAT wall span. The inner wall
+    // curves into the corner arc over the last innerCornerRadius of the span,
+    // and a stamp reaching into that zone cuts an oblique scallop through the
+    // curved corner (visible as a mangled hole at every wall end). Lip-less
+    // bins additionally keep the #2865 printability margin so a bold pattern
+    // can't leave a razor-thin corner post. `wallSpan` stays the full inner
+    // span so cutout/handle clip anchoring is unaffected; only the stamped
+    // centers shrink.
+    const innerCornerRadius = Math.max(BOX_CORNER_RADIUS - params.wallThickness, 0);
+    const cornerKeepOut = Math.max(innerCornerRadius, hasLip ? 0 : WALL_CORNER_KEEP_OUT);
+    const centerFillW = Math.max(0, fillW - 2 * cornerKeepOut);
     const centers = calculator.calculateCenters({ fillW: centerFillW, fillH: patternHeight });
     if (centers.length === 0) return;
     const [first, ...rest] = centers;


### PR DESCRIPTION
## Summary

Two user-reported wall-pattern defects, both reproduced from the pure pattern math and verified visually against the wall elevation (flat span + corner-arc zones):

**Triangle pattern was not the classic tessellation.** The calculator stamped apex-up and apex-down triangles at the same centroid height on a double pitch with a checkerboard flip, which reads as scattered triangles with wide uneven lanes. Classic interlocking requires the apex-down triangles to nest between the ups: centroid R/2 above the up row, half a period over. The rewritten `calculateCenters` derives the pitch from the exact slant-web equation (`gap = (√3·dx + dy)/2 − R`, so `dy = R/2`, `dx = √3R/2 + 2w/√3`), giving a uniform web equal to the design thickness everywhere. A new geometric test pins zero overlaps and the exact 0.8 mm minimum web.

**Honeycomb (and every stamp pattern) scalloped the bin corners.** Stamps stayed on the full inner span on lipped bins, so the outermost element (the unstaggered row reaches a half-period farther) crossed into the corner-arc zone — the inner wall curves away over the last `innerCornerRadius` of the span, and a wall-normal prism there cuts an oblique scallop through the curved corner. The corner keep-out now clamps every bin's stamps to the flat wall span (`BOX_CORNER_RADIUS − wallThickness`); lip-less bins additionally keep the #2865 printability margin. Divider-band patterns are untouched (they stamp via their own span).

## Verification

- Pattern unit tests 83/83 including the new interlock/web pin
- `wallPatterns` corner keep-out tests updated to the new invariant (stamps clear the corner arc on lipped and lip-less bins; no-churn case unchanged)
- Honeycomb junction scenarios: junction-blocking and manifold assertions unchanged and green; triangle-count snapshots drop by exactly the removed corner intruders
- **Full generator suite: 20,882 passed / 0 failed** with the updated snapshots

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the triangle wall pattern to a classic interlocked tessellation with a uniform web and keeps wall stamps off the corner arcs for clean, solid corners on all bins.

- **Bug Fixes**
  - Triangle pattern: apex-down triangles now nest between apex-up ones (R/2 up, half-period over) with pitch from the slant‑web equation, ensuring a uniform 0.8 mm web and no overlaps.
  - Corner keep-out: stamp centers are clamped to the flat wall span (`BOX_CORNER_RADIUS - wallThickness`); lip-less bins also keep the `WALL_CORNER_KEEP_OUT` margin. Divider-band patterns are unchanged.
  - Tests: added a geometric interlock/web pin; corner keep-out tests derive the bound from `BOX_CORNER_RADIUS`; snapshots updated; full generator suite passes.

<sup>Written for commit 88f6567694795eac6db11ece7d5120b681315f1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

