### PR TITLE
feat(generation): ship the sliding tray as an export piece, with end stops

### DIFF
--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -76,6 +76,8 @@ export function formatPieceDisplayName(
       return `Lid ${dims}`;
     case 'lid-baseplate':
       return `Lid Baseplate ${dims}`;
+    case 'slide-tray':
+      return `Sliding Tray ${dims}`;
     case 'divider-horizontal':
       return 'Divider Horizontal';
     case 'divider-vertical':
@@ -250,7 +252,9 @@ function pieceZone(label: string): ColorZone | null {
 
 /** Labels laid out in a row to the right of the bin in multi-object 3MF. */
 function isSideLaidOutPiece(label: string): boolean {
-  return label === 'lid' || label === 'lid-baseplate';
+  // The sliding tray is a separate print, so it is laid out beside the bin
+  // rather than left overlapping the cavity it rides in.
+  return label === 'lid' || label === 'lid-baseplate' || label === 'slide-tray';
 }
 
 /** Bounding box of a flat [x,y,z,x,y,z,...] STL vertex array. */

--- a/src/features/generation/worker/generators/slideGeometry.test.ts
+++ b/src/features/generation/worker/generators/slideGeometry.test.ts
@@ -139,10 +139,11 @@ describe('resolveSlideGeometry', () => {
     const rim = (slide: Partial<SlideConfig> = {}, over: Partial<SlideGeometryInput> = {}) =>
       resolveSlideGeometry(input({ railMount: 'rim', ...slide }, over));
 
-    it('builds a shelf and a guide on each side', () => {
+    it('builds a shelf and a guide on each side, plus end stops', () => {
+      // Two shelves, two guides, and one stop at each end of each shelf.
       const g = rim();
       expect(g.rejection).toBeNull();
-      expect(g.rails).toHaveLength(4);
+      expect(g.rails).toHaveLength(8);
     });
 
     it('rests the tray on the shelf, above the lip', () => {
@@ -168,7 +169,10 @@ describe('resolveSlideGeometry', () => {
       const g = rim();
       const inp = input({ railMount: 'rim' });
       const shelfTop = rimTrackBaseZ(42, 0, true) + DEFAULT_SLIDE_CONFIG.railThicknessMm;
-      const guides = g.rails.map(sectionBounds).filter((b) => b.zMin >= shelfTop - 1e-9);
+      // Guides run a full thickness tall; the end stops also start at the
+      // shelf top but are much shorter, so filter on the top, not the base.
+      const guideTop = shelfTop + DEFAULT_SLIDE_CONFIG.railThicknessMm;
+      const guides = g.rails.map(sectionBounds).filter((b) => Math.abs(b.zMax - guideTop) < 1e-9);
       expect(guides).toHaveLength(2);
       for (const guide of guides) {
         expect(Math.min(Math.abs(guide.yMin), Math.abs(guide.yMax))).toBeGreaterThanOrEqual(
@@ -235,6 +239,39 @@ describe('resolveSlideGeometry', () => {
       // exists so the panel can SAY why nothing appeared.
       const g = resolveSlideGeometry({ ...input(), isPolygon: true });
       expect(g.rejection).toBe('unsupported-shape');
+    });
+  });
+
+  describe('end stops', () => {
+    it('caps a rim track at both ends', () => {
+      // Rim rails deliberately run the bin's full length so a neighbour's track
+      // continues them, which is also what lets a tray keep going past the last
+      // bin. Interior needs none: the bin's own side walls bound the travel.
+      const g = resolveSlideGeometry(input({ railMount: 'rim' }));
+      const shelfTop = rimTrackBaseZ(42, 0, true) + DEFAULT_SLIDE_CONFIG.railThicknessMm;
+      const guideTop = shelfTop + DEFAULT_SLIDE_CONFIG.railThicknessMm;
+      // Stops rise above the shelf but stop short of the guides, and they bite
+      // down into the shelf so the fuse has a volume to merge rather than a
+      // coplanar face.
+      const stops = g.rails
+        .map(sectionBounds)
+        .filter((b) => b.zMax > shelfTop + 1e-9 && b.zMax < guideTop - 1e-9);
+      expect(stops).toHaveLength(4);
+      for (const stop of stops) expect(stop.zMin).toBeLessThan(shelfTop);
+    });
+
+    it('leaves an interior track uncapped', () => {
+      const g = resolveSlideGeometry(input({ railMount: 'interior' }));
+      expect(g.rails).toHaveLength(2);
+    });
+
+    it('never lets a stop outgrow the track it sits on', () => {
+      // A tiny bin would otherwise get stops longer than the rail.
+      const g = resolveSlideGeometry(input({ railMount: 'rim' }, { outerW: 42, innerW: 39.6 }));
+      for (const rail of g.rails) {
+        expect(rail.xMax - rail.xMin).toBeGreaterThan(0);
+        expect(rail.xMax).toBeLessThanOrEqual(42 / 2 - 3.75 + 1e-9);
+      }
     });
   });
 

--- a/src/features/generation/worker/generators/slideGeometry.ts
+++ b/src/features/generation/worker/generators/slideGeometry.ts
@@ -184,6 +184,30 @@ const MIN_TRAY_INTERIOR_MM = 2;
 const RAIL_FUSION_MARGIN_MM = 0.5;
 
 /**
+ * End stops on a `rim` track, so the tray cannot run off the end.
+ *
+ * `interior` needs none: its travel is already bounded by the bin's own side
+ * walls. Rim rails run the full length of the bin precisely so a neighbour's
+ * track continues them, which is exactly what lets a tray keep going past the
+ * last bin. Every mature sliding design surveyed has a stop of some kind.
+ *
+ * Sized to be clicked past by hand rather than to lock: the tray still lifts
+ * straight out, so a stop that could not be overridden would only make the
+ * thing harder to load.
+ */
+const END_STOP_HEIGHT_MM = 0.6;
+const END_STOP_LENGTH_MM = 3;
+/**
+ * How far a stop bites into the shelf below it and the guide beside it.
+ *
+ * Sitting exactly ON those faces makes coplanar contact, which fuses into
+ * non-manifold edges: the export stayed watertight and the bounding box was
+ * unchanged, and only the manifold check caught it. Interpenetrating instead
+ * gives the boolean a real volume to merge.
+ */
+const END_STOP_BITE_MM = 0.3;
+
+/**
  * Highest an `interior` rail's top may sit.
  *
  * The stacking lip reaches `LIP_TAPER_WIDTH` BELOW its own base plane for the
@@ -366,6 +390,30 @@ export function resolveSlideGeometry(input: SlideGeometryInput): SlideGeometry {
     boxSection(-xEnd, xEnd, -outerD / 2, -innerHalf, shelfTop, shelfTop + thickness),
     boxSection(-xEnd, xEnd, innerHalf, outerD / 2, shelfTop, shelfTop + thickness),
   ];
+
+  // End stops sit ON the shelf at both extremities, inside the guides, so they
+  // meet the tray's floor edge rather than its wall.
+  const stopLen = Math.min(END_STOP_LENGTH_MM, xEnd);
+  for (const sign of [-1, 1] as const) {
+    for (const side of [-1, 1] as const) {
+      // Inset from the very end: three solids terminating on one plane makes a
+      // T-junction the fuse resolves as a non-manifold edge, and a stop flush
+      // with the end has nothing for the tray to seat against anyway.
+      rails.push(
+        boxSection(
+          sign < 0 ? -xEnd + END_STOP_BITE_MM : xEnd - END_STOP_BITE_MM - stopLen,
+          sign < 0 ? -xEnd + END_STOP_BITE_MM + stopLen : xEnd - END_STOP_BITE_MM,
+          // Kept strictly on the shelf's EXPOSED top (inboard of the guide) so
+          // each stop interpenetrates exactly one solid. Reaching the guide as
+          // well makes a three-way junction the fuse leaves non-manifold.
+          side < 0 ? -innerHalf + END_STOP_BITE_MM : shelfInnerY,
+          side < 0 ? -shelfInnerY : innerHalf - END_STOP_BITE_MM,
+          shelfTop - END_STOP_BITE_MM,
+          shelfTop + END_STOP_HEIGHT_MM
+        )
+      );
+    }
+  }
 
   return {
     rails,

--- a/src/features/generation/worker/generators/slideOrchestrator.test.ts
+++ b/src/features/generation/worker/generators/slideOrchestrator.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { buildParams } from './__kernel-tests__/scenarioTypes';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { exportSlideTray, shouldGenerateSlideTray, slideInputForParams } from './slideOrchestrator';
+import { resolveSlideGeometry } from './slideGeometry';
+
+const enabled = { ...DEFAULT_BIN_PARAMS.slide, enabled: true };
+
+describe('slide tray export', () => {
+  beforeAll(async () => {
+    await initBrepjs();
+  }, 120_000);
+
+  it('produces nothing when the feature is off', async () => {
+    const params = buildParams({ width: 3, depth: 2, height: 6 });
+    expect(shouldGenerateSlideTray(params)).toBe(false);
+    expect(await exportSlideTray(params, 'stl')).toBeNull();
+  });
+
+  it('exports a named STL for a standard bin', async () => {
+    const params = buildParams({ width: 3, depth: 2, height: 6, slide: enabled });
+    const result = await exportSlideTray(params, 'stl');
+    expect(result).not.toBeNull();
+    expect(result?.fileName).toBe('gridfinity-3x2-slide-tray.stl');
+    expect(new DataView(result?.data ?? new ArrayBuffer(84)).getUint32(80, true)).toBeGreaterThan(
+      0
+    );
+  }, 60_000);
+
+  it('exports STEP under the step format', async () => {
+    const params = buildParams({ width: 3, depth: 2, height: 6, slide: enabled });
+    expect((await exportSlideTray(params, 'step'))?.fileName).toBe(
+      'gridfinity-3x2-slide-tray.step'
+    );
+  }, 60_000);
+
+  for (const [name, extra] of [
+    ['a solid bin', { base: { ...DEFAULT_BIN_PARAMS.base, solid: true } }],
+    ['a slotted bin', { style: 'slotted' as const }],
+  ] as const) {
+    it(`produces nothing for ${name}`, async () => {
+      // The resolver's rejections are the single gate: the export path repeats
+      // none of them, so a new rejection cannot be forgotten here.
+      const params = buildParams({ width: 3, depth: 2, height: 6, ...extra, slide: enabled });
+      expect(await exportSlideTray(params, 'stl')).toBeNull();
+    }, 60_000);
+  }
+
+  it('resolves the same track the pipeline fuses onto the bin', () => {
+    // The exported tray is dimensioned against this; if the two inputs drifted,
+    // the tray would be built for a rail the bin does not have.
+    const params = buildParams({ width: 3, depth: 2, height: 6, slide: enabled });
+    const g = resolveSlideGeometry(slideInputForParams(params));
+    expect(g.rejection).toBeNull();
+    expect(g.tray).not.toBeNull();
+    expect(g.rails.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/generation/worker/generators/slideOrchestrator.ts
+++ b/src/features/generation/worker/generators/slideOrchestrator.ts
@@ -1,0 +1,64 @@
+/**
+ * Export path for the sliding tray's companion part.
+ *
+ * The tray is the piece that RIDES the rail; the rail itself is fused onto the
+ * bin by `slideRailsFeature`. Both are resolved from `resolveSlideGeometry`, so
+ * the exported tray is dimensioned against the same track the bin carries.
+ *
+ * Unlike `exportLid`, the solid is not reoriented: `buildSlideTray` already
+ * returns it floor-down with its underside on Z=0, which is the print
+ * orientation (walls up, no overhangs, nothing to bridge).
+ */
+
+import { exportSTEP } from 'brepjs';
+import type { BinParams } from '@/shared/types/bin';
+import type { ExportFormat } from '../../bridge/types';
+import { buildSlideTray } from './slideRailBuilder';
+import { resolveSlideGeometry, slideInputFromDims } from './slideGeometry';
+import { deriveDimensions } from './pipeline/context';
+import { isPartialMask } from '@/shared/utils/cellMask';
+import { unwrapExportBlob } from './utils/exportUnwrap';
+import { exportSolidToStl } from './utils/stlMeshFallback';
+
+export interface SlideTrayExportResult {
+  readonly data: ArrayBuffer;
+  readonly fileName: string;
+}
+
+/** Resolver input for a bare `BinParams`, outside the generation pipeline. */
+export function slideInputForParams(params: BinParams): ReturnType<typeof slideInputFromDims> {
+  return slideInputFromDims(params, deriveDimensions(params, true), isPartialMask(params.cellMask));
+}
+
+/** True when this design produces a tray worth exporting. */
+export function shouldGenerateSlideTray(params: BinParams): boolean {
+  return resolveSlideGeometry(slideInputForParams(params)).tray !== null;
+}
+
+/**
+ * Export the companion tray, or null when the config produces none — which
+ * covers every rejection the resolver can return (a solid bin, a slotted bin,
+ * a custom shape, a rail with no bearing), so the caller never has to repeat
+ * those checks.
+ */
+export async function exportSlideTray(
+  params: BinParams,
+  format: ExportFormat,
+  tolerance = 0.01,
+  angularTolerance = 5
+): Promise<SlideTrayExportResult | null> {
+  const solid = buildSlideTray(slideInputForParams(params));
+  if (!solid) return null;
+
+  const name = `gridfinity-${params.width}x${params.depth}-slide-tray`;
+  try {
+    if (format === 'step') {
+      const blob = unwrapExportBlob(exportSTEP(solid), 'STEP');
+      return { data: await blob.arrayBuffer(), fileName: `${name}.step` };
+    }
+    const data = await exportSolidToStl(solid, name, tolerance, angularTolerance);
+    return { data, fileName: `${name}.stl` };
+  } finally {
+    solid.delete();
+  }
+}

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -28,6 +28,7 @@ import { exportDividers, exportDividerPiecesSeparately } from '../generators/div
 import { buildUniqueDividerPieces } from '../generators/dividerBuilder';
 import { pitchFromParams } from '../generators/gridPitch';
 import { exportLid, exportStackPlate } from '../generators/lidOrchestrator';
+import { exportSlideTray } from '../generators/slideOrchestrator';
 import type { FaceGroupData } from '@/shared/types/generation';
 import { buildLid, buildStackPlate } from '../generators/lidBuilder';
 import { lidAnchorZ } from '../generators/lidConstants';
@@ -329,6 +330,13 @@ export async function handleExportCombined(message: ExportCombinedMessage): Prom
         if (plateExport) {
           pieces.push({ data: plateExport.data, label: 'lid-baseplate' });
         }
+      }
+
+      // The sliding tray is the part that RIDES the rail the bin carries. It
+      // returns null for every config the resolver rejects, so no gate here.
+      const trayExport = await exportSlideTray(params, format, tolerance, angularTolerance);
+      if (trayExport) {
+        pieces.push({ data: trayExport.data, label: 'slide-tray' });
       }
 
       reportProgress(requestId, 'merge', 1);


### PR DESCRIPTION
Second of three PRs finishing the sliding tray's geometry. This is the one that makes the feature coherent.

## The tray is finally emitted

`buildSlideTray` had **no callers** — the feature produced a bin with rails and nothing to ride them. It now comes out of the combined export as a `slide-tray` piece alongside the bin, lid and dividers, laid beside the bin (`isSideLaidOutPiece`) because it is a separate print. The layout-export packer then places it on a plate like any other part.

`exportSlideTray` returns `null` for every config the resolver rejects — solid bin, slotted bin, custom shape, a rail with no bearing — so the export path repeats none of those checks and a future rejection cannot be forgotten there.

## End stops on rim tracks

Interior needs none: its travel is already bounded by the bin's own side walls. Rim rails deliberately run the bin's full length so a neighbour's track continues them, which is exactly what also lets a tray keep going past the last bin.

Sized to be clicked past by hand rather than to lock — the tray still lifts straight out, so a stop that couldn't be overridden would only make loading harder.

### Placing them took three attempts

| attempt | non-manifold edges |
|---|---|
| stops sitting **on** the shelf (coplanar contact) | 2 |
| inset from the ends, but still touching the guide | **6** |
| kept on the shelf's **exposed** top, biting down into it | **0** |

Every attempt stayed watertight with an unchanged bounding box. Only the manifold check saw any of it, and the middle attempt made things *worse* while looking like progress.

The rule that fell out: **a stop must interpenetrate exactly one solid.** Reaching two makes a three-way junction the fuse resolves as a non-manifold edge. That is also why it bites down rather than resting — coplanar contact is not a fuse.

## Verification

- `slideOrchestrator.test.ts`: export returns null when off and for each gated style, produces a named STL and STEP otherwise, and resolves the same track the pipeline fuses onto the bin (if those two inputs drifted, the tray would be built for a rail the bin does not have).
- End-stop resolver tests: four stops on rim, none on interior, and stops never outgrow the track on a small bin.
- Full `generators` 267 files / 2661 passed; `unit` + `dom` 1347 files / 18299 passed.

Next and last: the tray rendered in place at its rest position, plus the rail-and-tray fit coupon.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports the sliding tray as its own `slide-tray` piece and adds end stops on rim rails so the tray can’t run off the end. The tray is laid beside the bin in combined export and matches the same rail geometry used on the bin.

- **New Features**
  - Combined export now includes `slide-tray` (side layout like the lid).
  - `exportSlideTray` outputs STL/STEP and returns null for unsupported configs (solid, slotted, custom shape, no bearing).
  - Added small end stops on rim rails; none on interior. Placed to remain manifold by biting into the shelf.
  - Tray dimensions come from the same `resolveSlideGeometry` input as the bin rails. Tests cover export gating, file naming, STEP/STL, and end-stop placement.

<sup>Written for commit ca06efff7e0ffa0e96ac2fcdb5476418d2d16535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

