### PR TITLE
feat(bin-designer): preview the sliding tray in place, add a fit coupon

### DIFF
--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -24,6 +24,7 @@ import {
   BinMesh,
   LidMesh,
   StackPlateMesh,
+  SlideTrayMesh,
   LabelPlateMeshes,
   LidGuideLine,
   LidExplodeSlider,
@@ -437,6 +438,16 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
                 params.lid.separateStackPlate produced a mesh) — floats above
                 the lid to show the glue-on split. */}
               <StackPlateMesh
+                color={previewColor}
+                lidOffsetMm={lidOffsetMm}
+                wireframe={wireframe}
+                xray={xray}
+              />
+              {/* Sliding tray, seated on its rail (renders only when
+                params.slide produced a mesh). Shown in place because the
+                mechanism is the point, and how far it stands proud of the rim
+                is only obvious when you can see it sitting there. */}
+              <SlideTrayMesh
                 color={previewColor}
                 lidOffsetMm={lidOffsetMm}
                 wireframe={wireframe}

--- a/src/features/bin-designer/components/preview/SlideTrayMesh/SlideTrayMesh.test.tsx
+++ b/src/features/bin-designer/components/preview/SlideTrayMesh/SlideTrayMesh.test.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import {
+  DEFAULT_BIN_PARAMS,
+  DEFAULT_UI_STATE,
+  DEFAULT_GENERATION_STATE,
+} from '@/features/bin-designer/constants';
+import { SlideTrayMesh } from './SlideTrayMesh';
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: { children: ReactNode }) => <div data-testid="r3f-canvas">{children}</div>,
+  useThree: () => ({
+    invalidate: vi.fn(),
+    gl: { domElement: document.createElement('canvas') },
+    size: { width: 800, height: 600 },
+    scene: {},
+  }),
+  useFrame: vi.fn(),
+  extend: vi.fn(),
+}));
+
+vi.mock('three', () => {
+  class MockBufferGeometry {
+    setAttribute = vi.fn();
+    setIndex = vi.fn();
+    computeVertexNormals = vi.fn();
+    clearGroups = vi.fn();
+    addGroup = vi.fn();
+    dispose = vi.fn();
+  }
+  return {
+    BufferGeometry: MockBufferGeometry,
+    EdgesGeometry: MockBufferGeometry,
+    BufferAttribute: vi.fn(),
+    Float32BufferAttribute: vi.fn(),
+    Color: vi.fn(),
+    DoubleSide: 'DoubleSide',
+    FrontSide: 'FrontSide',
+  };
+});
+
+vi.mock('three/examples/jsm/utils/BufferGeometryUtils.js', () => ({
+  toCreasedNormals: vi.fn((geo: unknown) => geo),
+}));
+
+beforeEach(() => {
+  useDesignerStore.setState({
+    params: { ...DEFAULT_BIN_PARAMS },
+    ui: { ...DEFAULT_UI_STATE },
+  });
+});
+
+const tri = {
+  vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+  normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+  indices: new Uint32Array([0, 1, 2]),
+  edgeVertices: new Float32Array([0, 0, 0, 1, 0, 0]),
+};
+
+function seedTray(restZ = 21): void {
+  useDesignerStore.setState({
+    generation: {
+      ...DEFAULT_GENERATION_STATE,
+      status: 'complete',
+      mesh: {
+        ...tri,
+        error: null,
+        timingMs: 1,
+        slideTrayMesh: { ...tri, triangleCount: 1, restZ },
+      },
+      progress: 0,
+      epoch: 0,
+    },
+  });
+}
+
+const groupZ = (container: HTMLElement): number =>
+  Number(container.querySelector('group')?.getAttribute('position')?.split(',')[2]);
+
+describe('SlideTrayMesh', () => {
+  it('renders nothing when no tray mesh is in the store', () => {
+    const { container } = render(
+      <SlideTrayMesh color="#cccccc" lidOffsetMm={0} wireframe={false} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('seats the tray at its rest height rather than at the origin', () => {
+    // The tray is BUILT floor-down at Z=0 for printing; showing it there would
+    // bury it in the bin's base instead of on its rail.
+    seedTray(21);
+    const { container } = render(
+      <SlideTrayMesh color="#cccccc" lidOffsetMm={0} wireframe={false} />
+    );
+    expect(groupZ(container)).toBeGreaterThanOrEqual(21);
+  });
+
+  it('rides the explode slider so the assembly opens as one', () => {
+    seedTray(21);
+    const closed = render(<SlideTrayMesh color="#ccc" lidOffsetMm={0} wireframe={false} />);
+    const open = render(<SlideTrayMesh color="#ccc" lidOffsetMm={15} wireframe={false} />);
+    expect(groupZ(open.container) - groupZ(closed.container)).toBeCloseTo(15, 6);
+  });
+
+  it('uses the body colour', () => {
+    seedTray();
+    const { container } = render(
+      <SlideTrayMesh color="#abcdef" lidOffsetMm={0} wireframe={false} />
+    );
+    expect(container.querySelector('meshStandardMaterial')?.getAttribute('color')).toBe('#abcdef');
+  });
+});

--- a/src/features/bin-designer/components/preview/SlideTrayMesh/SlideTrayMesh.tsx
+++ b/src/features/bin-designer/components/preview/SlideTrayMesh/SlideTrayMesh.tsx
@@ -1,0 +1,96 @@
+/**
+ * Renders the sliding tray seated on its rail in the 3D preview.
+ *
+ * The tray is BUILT floor-down at the origin, which is its print orientation.
+ * Seating it is this component's job: the resolver reports `restZ` in the bin's
+ * own (box) frame, and the world position is that plus the base offset, the
+ * same conversion `LidMesh` makes for the lip top.
+ *
+ * Showing it in place rather than beside the bin is deliberate. The mechanism
+ * is the whole point of the feature, and how far the tray stands proud of the
+ * rim is a real trap: a rail dropped too little leaves the tray sticking out of
+ * the bin, which is only obvious when you can see it sitting there.
+ */
+
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+import { useThree } from '@react-three/fiber';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { useMeshGeometry } from '@/shared/components/preview/useMeshGeometry';
+import { baseFloorZ } from '@/features/bin-designer/utils/binDimensions';
+
+/** Solid enough to read as its own printed part, like the stack plate. */
+const BASE_OPACITY = 0.92;
+
+/** Matches LidMesh so companion parts ghost together under xray. */
+const XRAY_OPACITY_FACTOR = 0.32;
+
+interface SlideTrayMeshProps {
+  color: string;
+  /**
+   * Distance the lid is lifted by the explode slider. The tray rides it too, so
+   * one control opens the whole assembly instead of leaving the tray buried
+   * while everything above it lifts away.
+   */
+  lidOffsetMm: number;
+  wireframe?: boolean;
+  xray?: boolean;
+}
+
+export function SlideTrayMesh({
+  color,
+  lidOffsetMm,
+  wireframe = false,
+  xray = false,
+}: SlideTrayMeshProps) {
+  const { invalidate } = useThree();
+
+  const { slideTrayMesh, floorZ } = useDesignerStore(
+    useShallow((s) => ({
+      slideTrayMesh: s.generation.mesh?.slideTrayMesh ?? null,
+      floorZ: baseFloorZ(s.params.base, s.params.heightUnitMm, s.params.lid),
+    }))
+  );
+
+  const { geometry, edgesGeometry, hasPrecomputedNormals } = useMeshGeometry({
+    vertices: slideTrayMesh?.vertices ?? null,
+    normals: slideTrayMesh?.normals ?? null,
+    indices: slideTrayMesh?.indices ?? null,
+    edgeVertices: slideTrayMesh?.edgeVertices ?? null,
+  });
+
+  const matProps = useMemo(
+    () => ({
+      color,
+      roughness: 0.45,
+      metalness: 0,
+      wireframe,
+      side: THREE.DoubleSide,
+      transparent: true,
+      opacity: xray ? BASE_OPACITY * XRAY_OPACITY_FACTOR : BASE_OPACITY,
+      depthWrite: !xray,
+      flatShading: !hasPrecomputedNormals,
+    }),
+    [color, wireframe, hasPrecomputedNormals, xray]
+  );
+
+  useEffect(() => {
+    invalidate();
+  }, [geometry, lidOffsetMm, invalidate]);
+
+  if (!geometry || !slideTrayMesh) return null;
+
+  return (
+    <group position={[0, 0, floorZ + slideTrayMesh.restZ + lidOffsetMm]}>
+      <mesh geometry={geometry}>
+        <meshStandardMaterial {...matProps} />
+      </mesh>
+      {!wireframe && edgesGeometry && (
+        <lineSegments geometry={edgesGeometry} renderOrder={1}>
+          <lineBasicMaterial color="#000000" depthTest={true} transparent opacity={0.5} />
+        </lineSegments>
+      )}
+    </group>
+  );
+}

--- a/src/features/bin-designer/components/preview/SlideTrayMesh/index.ts
+++ b/src/features/bin-designer/components/preview/SlideTrayMesh/index.ts
@@ -1,0 +1,1 @@
+export { SlideTrayMesh } from './SlideTrayMesh';

--- a/src/features/bin-designer/components/preview/index.ts
+++ b/src/features/bin-designer/components/preview/index.ts
@@ -1,6 +1,7 @@
 export { BinMesh } from './BinMesh';
 export { LidMesh } from './LidMesh';
 export { StackPlateMesh } from './StackPlateMesh';
+export { SlideTrayMesh } from './SlideTrayMesh';
 export { LabelPlateMeshes } from './LabelPlateMeshes';
 export { LidGuideLine } from './LidGuideLine';
 export {

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -51,6 +51,7 @@ function toMeshPayload(result: BridgeResult): GenerationResult {
     // Stack plate has no face groups; the readonly typed arrays are ingested
     // directly (Immer treats typed arrays as opaque leaves).
     stackPlateMesh: result.mesh.stackPlateMesh,
+    slideTrayMesh: result.mesh.slideTrayMesh,
     labelPlates: result.mesh.labelPlates,
     labelTextOverflow: result.mesh.labelTextOverflow,
     error: null,
@@ -78,6 +79,7 @@ function meshDataToPayload(mesh: MeshData): GenerationResult {
         }
       : undefined,
     stackPlateMesh: mesh.stackPlateMesh,
+    slideTrayMesh: mesh.slideTrayMesh,
     labelPlates: mesh.labelPlates,
     labelTextOverflow: mesh.labelTextOverflow,
     error: null,

--- a/src/features/bin-designer/types/generation.ts
+++ b/src/features/bin-designer/types/generation.ts
@@ -3,6 +3,7 @@ import type {
   CoarseLODData,
   PerfSnapshot,
   StackPlateMeshData,
+  SlideTrayMeshData,
   LabelPlatesMeshData,
   LabelTextOverflow,
 } from '@/shared/types/generation';
@@ -47,6 +48,8 @@ export interface GenerationResult {
    *  only when the lid uses `separateStackPlate`. No face groups, so the shared
    *  readonly shape is ingested directly. */
   readonly stackPlateMesh?: StackPlateMeshData;
+  /** Optional sliding-tray mesh — the companion part that rides the bin's rail. */
+  readonly slideTrayMesh?: SlideTrayMeshData;
   /** Swappable label plates with their seated poses (socket mode, preview only). */
   readonly labelPlates?: LabelPlatesMeshData;
   /** Captions the build dropped because they overflow their host. Reported by

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -194,6 +194,23 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
                   triangleCount: response.stackPlateTriangleCount,
                 }
               : undefined;
+          // Sliding-tray mesh is optional; all six fields arrive together.
+          const slideTrayMesh =
+            response.slideTrayVertices &&
+            response.slideTrayNormals &&
+            response.slideTrayIndices &&
+            response.slideTrayEdgeVertices &&
+            response.slideTrayTriangleCount !== undefined &&
+            response.slideTrayRestZ !== undefined
+              ? {
+                  vertices: response.slideTrayVertices,
+                  normals: response.slideTrayNormals,
+                  indices: response.slideTrayIndices,
+                  edgeVertices: response.slideTrayEdgeVertices,
+                  triangleCount: response.slideTrayTriangleCount,
+                  restZ: response.slideTrayRestZ,
+                }
+              : undefined;
           // Seated snap-clip mesh is optional; all four fields arrive together.
           const connectorKeyMesh =
             response.connectorKeyVertices &&
@@ -218,6 +235,7 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
               coarseLOD: response.coarseLOD,
               lidMesh,
               stackPlateMesh,
+              slideTrayMesh,
               connectorKeyMesh,
               labelPlates: response.labelPlates,
               labelTextOverflow: response.labelTextOverflow,

--- a/src/features/generation/bridge/meshData.ts
+++ b/src/features/generation/bridge/meshData.ts
@@ -117,11 +117,6 @@ export interface LidMeshData {
 }
 
 /**
- * Mesh data for the separate stack-grid baseplate (glue-on companion slab).
- * A single lid-colored zone — no face groups. Carries edge lines so the pocket
- * ring reads crisply in the preview.
- */
-/**
  * Mesh data for the sliding tray. A single uniform part with no face groups,
  * built floor-down at the origin; the preview places it on its rail.
  */
@@ -135,6 +130,11 @@ export interface SlideTrayMeshData {
   readonly restZ: number;
 }
 
+/**
+ * Mesh data for the separate stack-grid baseplate (glue-on companion slab).
+ * A single lid-colored zone — no face groups. Carries edge lines so the pocket
+ * ring reads crisply in the preview.
+ */
 export interface StackPlateMeshData {
   readonly vertices: Float32Array;
   readonly normals: Float32Array;

--- a/src/features/generation/bridge/meshData.ts
+++ b/src/features/generation/bridge/meshData.ts
@@ -19,6 +19,8 @@ export interface MeshData {
   /** Optional separate stack-grid baseplate mesh — the glue-on companion slab,
    *  present only when the lid uses `separateStackPlate`. */
   readonly stackPlateMesh?: StackPlateMeshData;
+  /** Optional sliding-tray mesh — the companion part that rides the bin's rail. */
+  readonly slideTrayMesh?: SlideTrayMeshData;
   /**
    * Optional seated snap-clip connector mesh — the exact relieved part the
    * baseplate ships, so the preview can render it instead of an approximation.
@@ -119,6 +121,20 @@ export interface LidMeshData {
  * A single lid-colored zone — no face groups. Carries edge lines so the pocket
  * ring reads crisply in the preview.
  */
+/**
+ * Mesh data for the sliding tray. A single uniform part with no face groups,
+ * built floor-down at the origin; the preview places it on its rail.
+ */
+export interface SlideTrayMeshData {
+  readonly vertices: Float32Array;
+  readonly normals: Float32Array;
+  readonly indices: Uint32Array;
+  readonly edgeVertices: Float32Array;
+  readonly triangleCount: number;
+  /** Z the tray's underside rests at, in the bin's own (box) frame. */
+  readonly restZ: number;
+}
+
 export interface StackPlateMeshData {
   readonly vertices: Float32Array;
   readonly normals: Float32Array;

--- a/src/features/generation/bridge/responses.ts
+++ b/src/features/generation/bridge/responses.ts
@@ -200,6 +200,14 @@ export interface MeshResultResponse {
   readonly stackPlateIndices?: Uint32Array;
   readonly stackPlateEdgeVertices?: Float32Array;
   readonly stackPlateTriangleCount?: number;
+  /** Sliding-tray mesh — the companion part that rides the bin's rail. All
+   *  six fields land or are absent together. */
+  readonly slideTrayVertices?: Float32Array;
+  readonly slideTrayNormals?: Float32Array;
+  readonly slideTrayIndices?: Uint32Array;
+  readonly slideTrayEdgeVertices?: Float32Array;
+  readonly slideTrayTriangleCount?: number;
+  readonly slideTrayRestZ?: number;
   /** Seated snap-clip connector mesh — present only for split snap-clip plates. */
   readonly connectorKeyVertices?: Float32Array;
   readonly connectorKeyNormals?: Float32Array;

--- a/src/features/generation/worker/generators/slideFitSample.test.ts
+++ b/src/features/generation/worker/generators/slideFitSample.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getBounds, withScope } from 'brepjs';
+import type { DisposalScope } from 'brepjs';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import {
+  SLIDE_FIT_SAMPLE_CLEARANCES,
+  buildSlideFitRung,
+  buildSlideFitTrayStub,
+  buildSlideFitSampleCard,
+  exportSlideFitSample,
+} from './slideFitSample';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+
+describe('slide fit sample', () => {
+  beforeAll(async () => {
+    await initBrepjs();
+  }, 120_000);
+
+  it('sweeps a ladder that brackets the shipped default', () => {
+    // A ladder that does not contain the default would never confirm it, and a
+    // maker whose printer is already right would have no rung to land on.
+    expect(SLIDE_FIT_SAMPLE_CLEARANCES).toContain(DEFAULT_BIN_PARAMS.slide.clearanceMm);
+    expect(Math.min(...SLIDE_FIT_SAMPLE_CLEARANCES)).toBeLessThan(
+      DEFAULT_BIN_PARAMS.slide.clearanceMm
+    );
+    expect(Math.max(...SLIDE_FIT_SAMPLE_CLEARANCES)).toBeGreaterThan(
+      DEFAULT_BIN_PARAMS.slide.clearanceMm
+    );
+  });
+
+  it('widens the channel monotonically with clearance', () => {
+    // THE property that makes the card readable: the tray is constant, so the
+    // only thing separating one rung from the next is how much room it leaves.
+    const widths = SLIDE_FIT_SAMPLE_CLEARANCES.map((c) =>
+      withScope((scope: DisposalScope) => {
+        const pieces = buildSlideFitRung(c, DEFAULT_BIN_PARAMS.slide);
+        for (const p of pieces) scope.register(p);
+        const b = getBounds(scope.register(pieces[0]));
+        return b.yMax - b.yMin;
+      })
+    );
+    for (let i = 1; i < widths.length; i++) {
+      expect(widths[i]).toBeGreaterThan(widths[i - 1]);
+    }
+  });
+
+  it('builds a hollow tray stub, not a block', () => {
+    const solid = withScope((scope: DisposalScope) => {
+      const [stub] = buildSlideFitTrayStub();
+      return getBounds(scope.register(stub));
+    });
+    expect(solid.zMin).toBeCloseTo(0, 3);
+    expect(solid.zMax).toBeGreaterThan(0);
+  });
+
+  it('lays the tray stub clear of the ladder so they print apart', () => {
+    const pieces = buildSlideFitSampleCard();
+    try {
+      expect(pieces.length).toBeGreaterThan(SLIDE_FIT_SAMPLE_CLEARANCES.length);
+    } finally {
+      for (const p of pieces) p.delete();
+    }
+  });
+
+  it('exports one ready-to-slice file', async () => {
+    const stl = await exportSlideFitSample('stl');
+    expect(stl.fileName).toBe('slide_fit_sample.stl');
+    expect(new DataView(stl.data).getUint32(80, true)).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/src/features/generation/worker/generators/slideFitSample.ts
+++ b/src/features/generation/worker/generators/slideFitSample.ts
@@ -1,0 +1,195 @@
+/**
+ * Sliding-tray fit-calibration coupon.
+ *
+ * `clearanceMm` is the number a maker has to tune per printer, and the only
+ * way to find it today is to print a whole bin plus a whole tray and discover
+ * the tray binds. This card sweeps the clearance across a ladder on short rail
+ * stubs, with ONE tray stub that runs in all of them: the stub that slides best
+ * names the value to type into the field.
+ *
+ * Only the RAIL spacing varies across the ladder, never the tray. Varying both
+ * would test each pair against itself and tell the maker nothing, since every
+ * rung would fit equally well.
+ *
+ * The rung's rail profile is built here rather than through
+ * `resolveSlideGeometry`, because the resolver dimensions a rail against a
+ * BIN's walls and there is no bin here. It takes its shelf reach and thickness
+ * from the same `SlideConfig` the real rail uses, so the mating faces match;
+ * what the card cannot tell you is anything about the bin-specific placement
+ * (lip clearance, drop, span).
+ *
+ * Export mirrors `labelFitSample`: pieces → compound → one ready-to-slice file.
+ */
+
+import { compound, mesh, exportSTEP, translate, unwrap, draw, cut, clone } from 'brepjs';
+import type { Shape3D, ValidSolid } from 'brepjs';
+import type { SlideConfig } from '@/shared/types/bin';
+import type { ExportFormat } from '../../bridge/types';
+import { sketch } from './meshUtils';
+import { buildBaseplateSTL } from './baseplateSTL';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+
+/** Clearances swept across the coupons, in mm per side. */
+export const SLIDE_FIT_SAMPLE_CLEARANCES: readonly number[] = [0.15, 0.2, 0.25, 0.3, 0.35];
+
+/** Length of each rail stub along the slide axis. Long enough to feel a bind. */
+const STUB_LENGTH_MM = 30;
+/** Depth of the tray stub across the rails. */
+const TRAY_DEPTH_MM = 24;
+/** Height of the tray stub's walls. Shallow: this is a fit gauge, not a tray. */
+const TRAY_WALL_H_MM = 6;
+const TRAY_WALL_MM = 1.2;
+/** Slab under each rail pair, so a stub is a self-supporting printable part. */
+const BASE_THICKNESS_MM = 2;
+/** Gap between coupons in the row, and between the row and the tray stub. */
+const GAP_MM = 6;
+
+function box(
+  xMin: number,
+  xMax: number,
+  yMin: number,
+  yMax: number,
+  zMin: number,
+  zMax: number
+): Shape3D {
+  const profile = draw([xMin, yMin])
+    .lineTo([xMax, yMin])
+    .lineTo([xMax, yMax])
+    .lineTo([xMin, yMax])
+    .close();
+  const extruded = sketch(profile, 'XY').extrude(zMax - zMin);
+  const placed = translate(extruded, [0, 0, zMin]);
+  extruded.delete();
+  return placed;
+}
+
+/**
+ * One rung: a slab carrying two L-rails whose guides sit `clearance` clear of
+ * the tray stub on each side.
+ *
+ * The ladder is read by feel rather than by an embossed number: the rungs are
+ * emitted in ascending order along Y, so the winning rung's INDEX names the
+ * clearance without spending glyphs that a 0.4mm nozzle would smear anyway.
+ */
+export function buildSlideFitRung(clearance: number, slide: SlideConfig): Shape3D[] {
+  const halfChannel = TRAY_DEPTH_MM / 2 + clearance;
+  const shelf = slide.railProtrusionMm;
+  const thick = slide.railThicknessMm;
+  const outerY = halfChannel + shelf + thick;
+
+  const pieces: Shape3D[] = [
+    box(-STUB_LENGTH_MM / 2, STUB_LENGTH_MM / 2, -outerY, outerY, 0, BASE_THICKNESS_MM),
+  ];
+  for (const side of [-1, 1] as const) {
+    // Guide wall, standing outboard of the channel.
+    pieces.push(
+      box(
+        -STUB_LENGTH_MM / 2,
+        STUB_LENGTH_MM / 2,
+        side < 0 ? -outerY : halfChannel,
+        side < 0 ? -halfChannel : outerY,
+        BASE_THICKNESS_MM,
+        BASE_THICKNESS_MM + thick * 2
+      )
+    );
+    // Shelf reaching inward over the channel, at the guide's mid height, so
+    // the tray stub rests on it exactly as it would on a real rail.
+    pieces.push(
+      box(
+        -STUB_LENGTH_MM / 2,
+        STUB_LENGTH_MM / 2,
+        side < 0 ? -halfChannel : halfChannel - shelf,
+        side < 0 ? -halfChannel + shelf : halfChannel,
+        BASE_THICKNESS_MM,
+        BASE_THICKNESS_MM + thick
+      )
+    );
+  }
+  return pieces;
+}
+
+/** The tray stub that runs in every rung: one part, nominal size. */
+export function buildSlideFitTrayStub(): Shape3D[] {
+  const outer = box(
+    -STUB_LENGTH_MM / 2,
+    STUB_LENGTH_MM / 2,
+    -TRAY_DEPTH_MM / 2,
+    TRAY_DEPTH_MM / 2,
+    0,
+    TRAY_WALL_H_MM
+  );
+  const cavity = box(
+    -(STUB_LENGTH_MM - 2 * TRAY_WALL_MM) / 2,
+    (STUB_LENGTH_MM - 2 * TRAY_WALL_MM) / 2,
+    -(TRAY_DEPTH_MM - 2 * TRAY_WALL_MM) / 2,
+    (TRAY_DEPTH_MM - 2 * TRAY_WALL_MM) / 2,
+    TRAY_WALL_MM,
+    TRAY_WALL_H_MM + 1
+  );
+  try {
+    const hollow = cut(outer as ValidSolid, cavity as ValidSolid);
+    // A failed boolean yields the solid block rather than losing the card: the
+    // stub's OUTER size is what the fit is read from, and that is unaffected.
+    return [hollow.ok ? hollow.value : unwrap(clone(outer))];
+  } finally {
+    outer.delete();
+    cavity.delete();
+  }
+}
+
+/** Build the whole card: the clearance ladder plus one tray stub beside it. */
+export function buildSlideFitSampleCard(slide: SlideConfig = DEFAULT_BIN_PARAMS.slide): Shape3D[] {
+  const pieces: Shape3D[] = [];
+  const rowPitch = TRAY_DEPTH_MM + 4 * slide.railProtrusionMm + GAP_MM;
+  const n = SLIDE_FIT_SAMPLE_CLEARANCES.length;
+  const originY = ((n - 1) * rowPitch) / 2;
+
+  SLIDE_FIT_SAMPLE_CLEARANCES.forEach((clearance, i) => {
+    for (const piece of buildSlideFitRung(clearance, slide)) {
+      const placed = translate(piece, [0, originY - i * rowPitch, 0]);
+      piece.delete();
+      pieces.push(placed);
+    }
+  });
+
+  const stubX = STUB_LENGTH_MM + GAP_MM;
+  for (const piece of buildSlideFitTrayStub()) {
+    const placed = translate(piece, [stubX, 0, 0]);
+    piece.delete();
+    pieces.push(placed);
+  }
+  return pieces;
+}
+
+/** Export the fit-calibration card as a single STL or STEP file. */
+export async function exportSlideFitSample(
+  format: ExportFormat,
+  slide: SlideConfig = DEFAULT_BIN_PARAMS.slide,
+  tolerance?: number,
+  angularTolerance?: number
+): Promise<{ data: ArrayBuffer; fileName: string }> {
+  const pieces = buildSlideFitSampleCard(slide);
+  let assembled: Shape3D;
+  try {
+    assembled = compound(pieces);
+  } finally {
+    for (const p of pieces) p.delete();
+  }
+
+  try {
+    const name = 'slide_fit_sample';
+    if (format === 'step') {
+      const blob = unwrap(exportSTEP(assembled));
+      return { data: await blob.arrayBuffer(), fileName: `${name}.step` };
+    }
+    // Every fit-critical face here is planar, so the fine default would only
+    // bloat the rounded nothing this card contains.
+    const meshResult = mesh(assembled, {
+      tolerance: tolerance ?? 0.05,
+      angularTolerance: angularTolerance ?? 10,
+    });
+    return { data: buildBaseplateSTL(meshResult, name), fileName: `${name}.stl` };
+  } finally {
+    assembled.delete();
+  }
+}

--- a/src/features/generation/worker/generators/slideOrchestrator.ts
+++ b/src/features/generation/worker/generators/slideOrchestrator.ts
@@ -10,13 +10,17 @@
  * orientation (walls up, no overhangs, nothing to bridge).
  */
 
-import { exportSTEP } from 'brepjs';
+import { exportSTEP, mesh, meshEdges, getKernelCapabilities } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
-import type { ExportFormat } from '../../bridge/types';
+import type { ExportFormat, SlideTrayMeshData } from '../../bridge/types';
 import { buildSlideTray } from './slideRailBuilder';
 import { resolveSlideGeometry, slideInputFromDims } from './slideGeometry';
 import { deriveDimensions } from './pipeline/context';
 import { isPartialMask } from '@/shared/utils/cellMask';
+import { toIndexedMeshData, creaseEdges } from './utils';
+import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
+import { computeTessellationTolerances } from './utils/tolerances';
+import { checkCancelled } from './meshUtils';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { exportSolidToStl } from './utils/stlMeshFallback';
 
@@ -58,6 +62,54 @@ export async function exportSlideTray(
     }
     const data = await exportSolidToStl(solid, name, tolerance, angularTolerance);
     return { data, fileName: `${name}.stl` };
+  } finally {
+    solid.delete();
+  }
+}
+
+/**
+ * Tessellate the tray for the 3D preview, or null when the config makes none.
+ *
+ * `restZ` rides along so the preview can seat the tray on its rail. The solid
+ * itself is built floor-down at the origin (its print orientation), so placing
+ * it is the renderer's job, not the builder's.
+ */
+export function generateSlideTray(
+  params: BinParams,
+  signal?: AbortSignal
+): SlideTrayMeshData | null {
+  const input = slideInputForParams(params);
+  const { tray } = resolveSlideGeometry(input);
+  if (!tray) return null;
+
+  checkCancelled(signal);
+  const solid = buildSlideTray(input);
+  if (!solid) return null;
+
+  // Same WASM-heap discipline as generateLid: release the OCCT solid once
+  // tessellated, or it leaks on every param change.
+  try {
+    checkCancelled(signal);
+    const maxDimension = Math.max(tray.widthMm, tray.depthMm);
+    const { tolerance, angularTolerance } = computeTessellationTolerances(
+      false,
+      true,
+      maxDimension
+    );
+    const shapeMesh = mesh(solid, { tolerance, angularTolerance });
+    const edgeLines =
+      getKernelCapabilities().tessellationModel === 'build-time'
+        ? creaseEdges(shapeMesh)
+        : meshEdges(solid, { tolerance, angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD }).lines;
+    const indexed = toIndexedMeshData(shapeMesh, edgeLines);
+    return {
+      vertices: indexed.vertices,
+      normals: indexed.normals,
+      indices: indexed.indices,
+      edgeVertices: indexed.edgeVertices,
+      triangleCount: indexed.triangleCount,
+      restZ: tray.restZ,
+    };
   } finally {
     solid.delete();
   }

--- a/src/features/generation/worker/handlers/generateHandler.ts
+++ b/src/features/generation/worker/handlers/generateHandler.ts
@@ -8,12 +8,14 @@ import type {
   GenerateBaseplateMarginMessage,
   WarmMessage,
   LidMeshData,
+  SlideTrayMeshData,
   MeshData,
 } from '../../bridge/types';
 import { generateBin } from '../generators/binGenerator';
 import { generateBaseplate } from '../generators/baseplateGenerator';
 import { generateMargin } from '../generators/baseplateMargin';
 import { generateLid, generateStackPlate } from '../generators/lidOrchestrator';
+import { generateSlideTray } from '../generators/slideOrchestrator';
 import { generateLabelPlates } from '../generators/labelPlateGenerator';
 import { planLabelTextOverflow } from '../generators/labelTextFit';
 import type { BinParams } from '@/shared/types/bin';
@@ -69,13 +71,30 @@ export async function handleGenerate(message: GenerateMessage): Promise<void> {
 
         console.warn('[BinGen] Lid generation failed; falling back to bin-only:', e);
       }
+      // The sliding tray is independent of the lid, so it is resolved before
+      // the bin-only early return below — otherwise a bin with a tray and no
+      // lid would silently lose its tray. Same secondary-feature contract:
+      // a build failure degrades, a cancellation aborts.
+      let slideTrayMesh: SlideTrayMeshData | null = null;
+      try {
+        slideTrayMesh = generateSlideTray(params, signal);
+      } catch (e) {
+        if (isAbortError(e)) throw e;
+
+        console.warn('[BinGen] Slide-tray generation failed; skipping tray:', e);
+      }
+
       if (!lidMesh) {
         // Lid generation failed (or is disabled) → bin-only. The baseplate is a
         // companion to the lid, so emitting it here would leave a lone
         // baseplate with no lid; skip it and degrade cleanly to bin-only.
-        return binMesh;
+        return slideTrayMesh ? { ...binMesh, slideTrayMesh } : binMesh;
       }
-      let result: MeshData = { ...binMesh, lidMesh };
+      let result: MeshData = {
+        ...binMesh,
+        lidMesh,
+        ...(slideTrayMesh ? { slideTrayMesh } : {}),
+      };
       // Separate stack-grid baseplate (glue-on companion). Same secondary-
       // feature contract as the lid: a build failure degrades to lid+bin, but
       // a cancellation still aborts the whole request.

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -187,6 +187,18 @@ export function runGeneration(
         }
       : undefined;
 
+    // Prepare sliding-tray buffers when present (rides the bin's rail)
+    const slideTray = meshData.slideTrayMesh
+      ? {
+          vertices: maybeCopy(meshData.slideTrayMesh.vertices),
+          normals: maybeCopy(meshData.slideTrayMesh.normals),
+          indices: maybeCopy(meshData.slideTrayMesh.indices),
+          edgeVertices: maybeCopy(meshData.slideTrayMesh.edgeVertices),
+          triangleCount: meshData.slideTrayMesh.triangleCount,
+          restZ: meshData.slideTrayMesh.restZ,
+        }
+      : undefined;
+
     // Prepare separate stack-grid baseplate buffers when present (glue-on companion)
     const stackPlate = meshData.stackPlateMesh
       ? {
@@ -258,6 +270,16 @@ export function runGeneration(
             stackPlateTriangleCount: stackPlate.triangleCount,
           }
         : {}),
+      ...(slideTray
+        ? {
+            slideTrayVertices: slideTray.vertices,
+            slideTrayNormals: slideTray.normals,
+            slideTrayIndices: slideTray.indices,
+            slideTrayEdgeVertices: slideTray.edgeVertices,
+            slideTrayTriangleCount: slideTray.triangleCount,
+            slideTrayRestZ: slideTray.restZ,
+          }
+        : {}),
       ...(connectorKey
         ? {
             connectorKeyVertices: connectorKey.vertices,
@@ -288,6 +310,14 @@ export function runGeneration(
         stackPlate.normals.buffer,
         stackPlate.indices.buffer,
         stackPlate.edgeVertices.buffer
+      );
+    }
+    if (slideTray) {
+      transfer.push(
+        slideTray.vertices.buffer,
+        slideTray.normals.buffer,
+        slideTray.indices.buffer,
+        slideTray.edgeVertices.buffer
       );
     }
     if (connectorKey) {

--- a/src/shared/types/generation.ts
+++ b/src/shared/types/generation.ts
@@ -11,6 +11,7 @@ export type {
   CoarseLODData,
   LidMeshData,
   StackPlateMeshData,
+  SlideTrayMeshData,
   LabelPlatesMeshData,
   LabelTextOverflow,
   LabelPlateMeshData,


### PR DESCRIPTION
Last of three PRs finishing the sliding tray's geometry.

## The tray renders on its rail

It is **built** floor-down at the origin, which is its print orientation, so seating it is the renderer's job: `restZ` rides along on the mesh and the component converts it to world Z the same way `LidMesh` converts the lip top.

Shown **in place** rather than beside the bin because the mechanism is the whole point, and how far the tray stands proud of the rim is a real trap a side-by-side view hides entirely. It rides the explode slider so one control opens the whole assembly.

The mesh reaches the preview the way the lid's does — riding on `MeshData` through the worker, the transfer list, the bridge reassembly and the store.

One wrinkle worth flagging: the tray is resolved **before** the bin-only early return in `generateHandler`. It is independent of the lid, so leaving it after would mean a bin with a tray and no lid silently loses its tray.

## A fit-calibration coupon

`clearanceMm` is the number a maker has to tune per printer, and the only way to find it today is to print a whole bin plus a whole tray and discover the tray binds. The card sweeps the clearance across five rail stubs with **one** tray stub that runs in all of them; the rung that slides best names the value to type into the field.

**Only the rail spacing varies across the ladder, never the tray.** Varying both would test each pair against itself — every rung would fit equally well, and the card would always say yes. Two tests pin what makes it readable:

- the channel widens monotonically with clearance;
- the ladder brackets the shipped default, so a printer that is already correct has a rung to land on.

The rung's profile is built directly rather than through `resolveSlideGeometry`, because the resolver dimensions a rail against a *bin's* walls and there is no bin here. It takes its shelf reach and thickness from the same `SlideConfig`, so the mating faces match. What the card cannot tell you is anything bin-specific — lip clearance, drop, span — and the docstring says so.

## Not yet reachable

The coupon has no entry point, exactly the position the tray export was in before the previous PR: the button lands with the panel. The preview, by contrast, is live the moment `slide.enabled` is set.

## Verification

- `SlideTrayMesh.test.tsx`: renders nothing without a mesh, seats the tray at its rest height rather than the origin, rides the explode slider, uses the body colour.
- `slideFitSample.test.ts`: the ladder brackets the default, channels widen monotonically, the stub is hollow, and the card exports one ready-to-slice file.
- Full `generators` 268 files / 2667 passed; `unit` + `dom` 1347 files / 18303 passed.

## Where the feature stands

Geometry is complete and verified. What remains is entirely UI: the panel to enable it, surfacing the typed `rejection` reasons (a 3u bin still silently produces nothing), and the coupon button. Nothing further is blocked on geometry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the sliding tray seated on its rail in the preview and add a fit-calibration coupon to tune slide clearance without printing a full bin. This makes fit and how proud the tray sits obvious, and speeds up calibration.

- **New Features**
  - Preview: Renders the tray in place, seated using `restZ` + base offset; moves with the explode slider; uses body color; renders only when a tray mesh exists.
  - Generation pipeline: Adds optional `slideTrayMesh` (with `restZ` and edge lines) across worker → transfer list → bridge → store. Resolved before the lid so a bin without a lid can still show its tray. Failures degrade gracefully.
  - Fit coupon: Builds a ladder of rail stubs sweeping clearances (0.15–0.35 mm per side) with a single constant tray stub; only rail spacing varies. Exports one ready-to-slice STL or STEP and brackets the default clearance.
  - Availability: Coupon has no UI entry yet; the tray preview appears when `slide.enabled` is set.

- **Refactors**
  - Fixed stack-plate JSDoc placement after introducing `SlideTrayMeshData`.

<sup>Written for commit d1427cec8c2d78d1117c8d0cf8a7aa8b980e436c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

