### PR TITLE
docs(design): rewrite the sliding tray doc as built

### DIFF
--- a/docs/design/sliding-tray.md
+++ b/docs/design/sliding-tray.md
@@ -1,173 +1,90 @@
-# Design: sliding tray
+# Sliding tray
 
-Status: proposal, no code written.
-
-Requested via Ko-fi:
+A shallow tray that rides a rail on the bin and slides aside to reach what is underneath. Requested via Ko-fi:
 
 > One thing I'd love to do is have a cut out to be able to slide gridfinity inserts across different inserts (so you have 2 base, say, 5u height bins, and another on top that slides between them.
 
-A second storey for a drawer. Tall bins hold the bulk; a shallow tray rides above them on rails and slides aside to reach what is underneath. Two variants are in scope:
-
-- **Spanning** — the tray bridges the gap between two separate tall bins, riding on a rail carried by each.
-- **Internal** — the tray rides on ledges inside a single wide bin.
-
-They share a rail profile and a tolerance model. They differ in who owns the rail and, critically, in what determines the tray's width.
+The geometry is built and verified. What remains is the panel: nothing exposes `slide.enabled`, so today the feature is only reachable through a design payload that sets it directly.
 
 ---
 
-## Why this is the expensive one
+## How it works
 
-A sliding fit is a **paired-tolerance** feature. Nothing in the current model expresses "this part's groove must match that part's rail, forever". Every existing multi-part feature is either self-contained (a bin's own cutouts) or generated as a matched set in one pass from one `BinParams` (a lid and its bin, dividers and their bin).
+`SlideConfig` on `BinParams` (`src/features/bin-designer/types/slide.ts`). The rail runs along the FRONT and BACK walls, so the tray travels in X.
 
-The spanning variant breaks a boundary the designer does not currently cross: the tray's width is a property of **the layout** (how far apart the two host bins sit), not of any one design. The bin designer edits one `BinParams` with no knowledge of where the bin is placed. This is the single most important design decision below.
-
----
-
-## Precedent worth copying
-
-| Existing thing                       | Where                                                             | What to take from it                                                                                                                                                                                                  |
-| ------------------------------------ | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LidClickRails`                      | `src/features/bin-designer/types/lid.ts`                          | Per-side independent boolean flags, so a user can rail left+right only. Exactly the shape a rail config needs.                                                                                                        |
-| `LidAttachment`                      | same file                                                         | The "exactly one of friction / clickRails / magnetic" mode union, with migration deriving the mode from legacy per-side flags. A tray's retention (free-sliding vs detented vs end-stopped) wants the same treatment. |
-| `lidClickRail.ts`                    | `src/features/generation/worker/generators/`                      | An existing rail solid swept along a chosen wall. The closest geometry to a slide rail.                                                                                                                               |
-| `CLEARANCE` (`GRIDFINITY.TOLERANCE`) | `src/features/generation/worker/generators/generatorConstants.ts` | 0.5mm, the bin-to-baseplate seating clearance. Read it for the order of magnitude, but a sliding fit needs its OWN parameter rather than borrowing a spec value with a different job.                                 |
-| `design-linking`                     | `src/features/design-linking/`                                    | Machinery for keeping related designs in sync, including `useBinResizedListener` and the blocked-resize dialog. The natural home for "these two designs are a sliding pair".                                          |
-| Size lock (`locked: true`)           | gotcha 11 in CLAUDE.md                                            | `bin.update` is the only enforcement point for refusing a resize. A sliding pair needs the same discipline.                                                                                                           |
-
----
-
-## The decision that gates everything
-
-**Where does the tray's width come from?**
-
-### Option A — the tray is a layout-level part
-
-The tray spans a gap the layout defines. Its width is derived from the two host bins' positions.
-
-- Correct for what was asked.
-- Requires a part whose dimensions are computed from layout state, which the bin designer has no concept of. Either the designer gains a "sized by layout" mode, or the tray becomes a new kind of object owned by the layout rather than by a design.
-- Moving either host bin silently invalidates the tray, and **a move is not a resize**. `design-linking` today reacts to dimension changes; dragging a bin across the grid changes the span without changing any design at all. Tracking placement, not just size, is a requirement of this option rather than a detail of it.
-
-### Option B — the tray is a normal design, the user sets its width
-
-The tray is an ordinary bin with a `slideProfile` on its left and right walls. The user is responsible for making it match the gap.
-
-- Fits the existing model with no new concepts.
-- Puts a tolerance-critical measurement on the user, which is exactly the kind of thing this tool exists to avoid.
-
-### Option C (recommended) — pair the designs, derive the width
-
-The tray is a normal design, but it is **linked** to its host design(s) through `design-linking`. The link stores the rail geometry and the span; the tray's width is derived and re-derived when a host changes, and a host resize that would break the pair is blocked the way a locked bin's resize is blocked today.
-
-- Keeps the tray inside the bin designer.
-- Reuses machinery that already exists for exactly this class of problem.
-- The internal variant is then the degenerate case where host and tray are the same design.
-
-**Open question for the requester:** in their drawer, are the two tall bins the same design placed twice, or two different designs? If they are the same design, the span is `2 * binWidth + gap` and the derivation is trivial. Worth asking before building.
-
----
-
-## Geometry
-
-### Rail profile
-
-A rail is a shelf plus a lip, swept along the host wall's top region, with the mating groove cut into the tray's wall.
+`railMount` decides where the rail sits, which is what decides whether a tray can leave its own bin at all:
 
 ```
-   host wall            tray wall
-   ┌──────┐             ┌─────────┐
-   │      │  ◄─ slideClearance ─►  │
-   │   ┌──┴──┐       ┌──┴──┐       │
-   │   │ rail│       │groove       │   the groove is the rail
-   │   └──┬──┘       └──┬──┘       │   grown by slideClearance
-   │      │             │          │   on every face
+railMount: 'interior'        railMount: 'rim'
+
+  ┌─┐         ┌─┐          ┌─┐        ┌─┐
+  │ │ ▄▄▄▄▄▄▄ │ │          │ ├────────┤ │
+  │ ├─┘     └─┤ │          │ │ ▄▄▄▄▄▄ │ │
+  │ │  tray   │ │          │ │        │ │
+  │ │         │ │          │ │  bin   │ │
+  └─┘         └─┘          └─┘        └─┘
+
+  drops inside one bin     rides over the rim,
+  (the default)            crosses to the next bin
 ```
 
-Parameters:
+Both mounts are the **same L-section rail** at two heights: a shelf to carry the tray, a guide outboard of it to locate the tray in Y. Both hold the same bearing overlap, `railProtrusionMm - clearanceMm`. Neither uses a tongue-and-groove — the tray's own floor is the runner, which means fewer mating faces to get wrong and nothing that needs support material.
 
-| Name             | Meaning                                | Notes                                                                                                                                                                                                                                                                                                                              |
-| ---------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `railHeightMm`   | shelf thickness                        | Must clear the host's stacking lip. See below.                                                                                                                                                                                                                                                                                     |
-| `railDepthMm`    | how far the shelf protrudes inward     | Bounded by the host's wall thickness and its cavity.                                                                                                                                                                                                                                                                               |
-| `slideClearance` | per-face gap                           | New parameter. Do NOT reuse `CLEARANCE`: it is 0.5mm and it describes the bin-to-baseplate seating fit, not a general tolerance, so borrowing it couples a sliding surface to an unrelated spec value that may change. Start around 0.4-0.5mm per face and expose it, since it is the number users will actually tune per printer. |
-| `railZ`          | height of the rail above the bin floor | For the spanning variant this must be identical on both hosts.                                                                                                                                                                                                                                                                     |
+`interior` needs no end stop (the bin's own side walls bound the travel). `rim` gets one at each end of the track.
 
-### The stacking-lip collision
+### The multi-bin case needs no layout awareness
 
-This is the trap most likely to produce a broken part.
+A rail spanning a bin's full length meets its neighbour's when two railed bins sit side by side, so the track is continuous on its own. Adjacent bins are a known `CLEARANCE` apart plus two corner radii — an ~8mm interruption any tray wider than a unit bridges.
 
-Per gotcha 10 in `CLAUDE.md`, `buildTopShapeLoft` extends the lip `LIP_TAPER_WIDTH` **below** its own base plane for the angled support blending it into the wall. A rail placed near the top of a host wall lands inside that taper region. Two failure modes:
-
-1. The rail fuses into the lip taper and back-fills it, so the host no longer stacks or seats.
-2. The rail is cut away by the lip geometry and silently comes out thinner than specified, which a bounding-box or watertight check cannot see.
-
-A rail must therefore either sit clear of `LIP_HEIGHT + LIP_TAPER_WIDTH` from the rim, or the lip must be locally suppressed along that wall the way the cutout editor now clears it (#3281 did exactly this for cutouts and is the pattern to follow).
-
-### Wall pattern clipping
-
-Gotcha 5: any feature cutting through a wall needs matching border clipping in `src/features/generation/worker/generators/wallPatternBuilder.ts`. A rail and its groove both qualify. Without it, hex prisms will bleed into the rail and produce a jagged sliding surface, which is worse here than cosmetically, because it is the bearing face.
-
-### Print orientation
-
-A rail's underside and a groove's roof are both horizontal overhangs. At typical rail depths this bridges fine, but it should be checked with the existing overhang audit rather than assumed. A chamfered rail underside (45°) avoids supports entirely and is probably the right default.
+That is why `trayWidthUnits` is an ordinary number rather than something derived from placement. **Spanning is an emergent property of placing railed bins next to each other, not a feature.** An earlier draft of this document proposed design pairing and placement tracking to derive the tray's width; none of it was needed.
 
 ---
 
-## Data model sketch
+## Where it does not apply
 
-```ts
-export type SlideRole = 'host' | 'tray';
-export type SlideSide = 'left' | 'right';
+Each returns a typed `SlideRejection` so the panel can explain a bin that produces nothing:
 
-export interface SlideProfile {
-  readonly enabled: boolean;
-  readonly role: SlideRole;
-  /** Independent per side, mirroring LidClickRails. */
-  readonly sides: Record<SlideSide, boolean>;
-  readonly railHeightMm: number;
-  readonly railDepthMm: number;
-  /** Rail top measured from the bin floor. Must match across a pair. */
-  readonly railZMm: number;
-  readonly clearanceMm: number;
-  /** Stops the tray sliding out. */
-  readonly endStop: 'none' | 'front' | 'back' | 'both';
-}
-```
-
-Hangs off `BinParams` as `slide`. Migration: absent means disabled, so old designs are untouched.
+| rejection           | why                                                                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `no-cavity`         | A solid bin has nowhere for a tray to sit.                                                                                                             |
+| `slot-conflict`     | `slotBuilder` cuts divider slots into the front/back walls — the rail's walls — and cuts apply after fuses, so the slots would notch the bearing face. |
+| `unsupported-shape` | Custom-shape (cellMask) bins have no polygon-edge mapping yet.                                                                                         |
+| `no-bearing`        | A shelf reaching in less than the clearance carries nothing; the tray passes it.                                                                       |
+| `rail-below-floor`  | The drop puts the ledge in the floor slab. A 3u bin cannot give the default 21mm drop.                                                                 |
 
 ---
 
-## Work breakdown
+## Clearance
 
-Each row is a reviewable PR.
+`clearanceMm` defaults to **0.25mm per side**, the same per-side gap Gridfinity itself uses (a 41.5mm foot in a 42mm cell is 0.5mm total), so a printer already calibrated to seat bins in a baseplate needs no retuning. It is deliberately looser than the usual FDM sliding fit (0.1–0.2mm per side) because the tray can be 250mm long, where binding is a worse failure than a little play.
 
-| #   | Scope                                                                                                                   | Notes                                                                                                                                                                           |
-| --- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | `SlideProfile` type, defaults, migration, `api/lib/designerValidation.ts` mirror                                        | Server rejects unknown params, so the mirror is not optional.                                                                                                                   |
-| 2   | Rail + groove geometry in the worker, with lip suppression                                                              | The real work. Needs `__kernel-tests__` probes for the lip interaction, since it is invisible to standard assertions.                                                           |
-| 3   | Wall pattern border clipping for rail and groove                                                                        | Gotcha 5.                                                                                                                                                                       |
-| 4   | Panel UI, ghost overlay, i18n across 15 locales                                                                         | Ghost overlay matters: users need to see where the rail sits before printing.                                                                                                   |
-| 5   | Design pairing via `src/features/design-linking/`, derived tray width, blocked-resize guard, and **placement tracking** | Option C. The part that makes it trustworthy. Placement is the easy thing to forget: a host dragged one cell sideways changes the span while every design stays byte-identical. |
-| 6   | Fit-test coupon                                                                                                         | A short rail + groove pair users print to tune `clearanceMm` before committing to a full set. Precedent: the existing calibration coupons.                                      |
+It is NOT the shared `CLEARANCE` constant: that is measured across a whole cell rather than per face, so borrowing it would apply double the intended gap.
 
-Items 1–4 deliver the internal variant. 5 adds the spanning variant.
+`slideFitSample.ts` builds a coupon that sweeps the clearance across five rail stubs with one tray stub that runs in all of them, so a maker can find their number without printing a whole bin.
 
 ---
 
-## What to verify, and how
+## Traps, all found by measuring the generated mesh
 
-Standard assertions will not catch the failure modes here.
+Every one of these passed watertight, 2-manifold and bounding-box checks while being wrong.
 
-- **Rail thinned by the lip taper** — invisible to bounding box, triangle count and watertightness. Probe the volume with `isSolidThrough` / `sectionHalfWidth` from `src/features/generation/worker/generators/__kernel-tests__/meshAssertions.ts`, the same approach that caught the foot and lip defects in gotcha 10.
-- **The pair actually slides** — assert `groove − rail ≥ 2 × clearanceMm` on every face analytically, from the same parameters that drive both solids. This is the equivalent of the plate/transform agreement test in the project-file work: two independently generated things that must agree, pinned by one shared derivation.
-- **Rail heights match across a pair** — a scenario building both host and tray from a linked pair and comparing `railZMm`.
-- **Overhang** — run the existing stack-print overhang audit over a railed bin.
+**A wall pattern deleted the rail entirely.** The pipeline runs fuse → cut → patternCut, so hex prisms carved through the already-fused rail: 0 of 23 sample points survived. Fixed with a keep-out band (gotcha 5), inflated by `max(CUTOUT_BORDER_WIDTH, shapeRadius)`. Kumiko has its own clipping call site and needed the same, including in its `hasClips` guard — a bin whose only clip is the rail keep-out was skipping the clipping pass entirely.
+
+**A rim strip floated above the lip.** The lip's peak is filleted ~0.1mm below `wallHeight + LIP_HEIGHT`, so a strip at the nominal height fused as a **disconnected island** — watertight, right bounding box, falls off the print. Strips now sink 0.5mm into the lip.
+
+**An interior rail against the rim lands inside the lip taper**, which reaches `LIP_TAPER_WIDTH` below its own base plane. It either back-fills the taper (the foot stops seating in a baseplate) or comes out silently thinner than asked for. `interiorRailCeiling` clamps it.
+
+**A square shelf is a 90° cantilever** running the bin's whole length: 486.8mm² of support-needing area on a 3-wide bin. Chamfering the underside 45° back to its wall drops that to 3.1mm², and the rail now costs 0–4mm² across every wall thickness, half-grid and non-square grid.
+
+**End stops must interpenetrate exactly one solid.** Resting them on the shelf gave 2 non-manifold edges; letting them also touch the guide gave 6. They now sit on the shelf's exposed top and bite down into it.
+
+**The tray must rest on real material.** A first `rim` design put the strips outboard of the tray, so the tray was narrower than the opening it was meant to bridge: it rested on nothing and dropped onto the lip's taper. The bearing check now runs against both mounts from one assertion.
 
 ---
 
-## Recommendation
+## What is left
 
-Build items 1–4 for the internal variant first. It is self-contained, needs no new layout concepts, and produces the rail geometry, the lip interaction and the tolerance model that the spanning variant also needs. Ship it, get real print feedback on `clearanceMm`, then do 5.
-
-Before any of it, ask the requester whether their two tall bins are one design placed twice. It changes how much of item 5 is needed.
+- Panel UI, i18n, and surfacing `rejection` — a 3u bin silently produces nothing today.
+- A button for the fit coupon (`exportSlideFitSample` exists; nothing calls it).
+- Polygon bins, if wanted: `resolvePolygonSideGeometry` already maps wall cutouts onto polygon edges.
+- Nobody has printed one. The clearance default is reasoned, not measured.


### PR DESCRIPTION
The design doc still opened with *"Status: proposal, no code written"* after three merged PRs (#3293, #3298, #3300), and described a design that differs materially from what shipped.

The biggest divergence: it proposed **design pairing and placement tracking** to derive the tray's width for the multi-bin case, treating that as the expensive part of the feature. None of it was needed. A rail spanning a bin's full length meets its neighbour's when two railed bins sit side by side, so spanning is an emergent property of placing railed bins next to each other rather than a feature to build. `trayWidthUnits` is an ordinary number.

Rewritten to state what is true now: the L-section rail shared by both mounts, the typed rejections, where the clearance number comes from, and the traps.

The traps section is the part worth keeping. Every one of them passed watertight, 2-manifold and bounding-box checks while being wrong:

- a wall pattern deleting the rail outright (0 of 23 sample points survived);
- a rim strip fusing as a disconnected island because the lip's peak is filleted below nominal;
- an interior rail landing inside the lip taper and back-filling it;
- a square shelf costing 486.8mm² of support-needing area;
- end stops making non-manifold edges unless they interpenetrate exactly one solid;
- a tray resting on nothing because the strips sat outboard of it.

Also lists honestly what is left, including that nobody has printed one and the clearance default is reasoned rather than measured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite the sliding tray design doc to match the shipped feature and remove the outdated proposal. It now describes the L‑section rail on front/back walls with `interior` and `rim` mounts, explains that spanning needs no placement pairing (`trayWidthUnits` is explicit), lists typed `SlideRejection`s, sets a 0.25mm‑per‑side `clearanceMm`, records key geometry traps, and notes remaining panel/fit‑coupon work.

<sup>Written for commit 73ff138eb27c487732f7cda9c21d689b4b09652f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

