### PR TITLE
feat(bin-designer): add the sliding-tray fit test button

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "!dist/assets/zh-CN-*.js"
       ],
       "gzip": true,
-      "limit": "1905 kB"
+      "limit": "1910 kB"
     },
     {
       "name": "Fetched JSON assets (gzip)",

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideFitSampleButton.test.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideFitSampleButton.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SlideFitSampleButton } from './SlideFitSampleButton';
+
+vi.mock('../../../hooks/useSlideFitSampleExport', () => ({
+  SLIDE_FIT_SAMPLE_BASE_NAME: 'slide-fit-sample',
+  useSlideFitSampleExport: () => ({
+    isExporting: false,
+    canExport: true,
+    downloadSample: vi.fn().mockResolvedValue(true),
+  }),
+}));
+
+describe('SlideFitSampleButton', () => {
+  it('offers the fit test', () => {
+    render(<SlideFitSampleButton />);
+    expect(screen.getByRole('button', { name: /fit test/i })).toBeEnabled();
+  });
+});

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideFitSampleButton.test.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideFitSampleButton.test.tsx
@@ -1,19 +1,48 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { SlideFitSampleButton } from './SlideFitSampleButton';
+import { resetAllStores } from '@/test/testUtils';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+const downloadSample = vi.fn().mockResolvedValue(true);
+let canExport = true;
 
 vi.mock('../../../hooks/useSlideFitSampleExport', () => ({
   SLIDE_FIT_SAMPLE_BASE_NAME: 'slide-fit-sample',
-  useSlideFitSampleExport: () => ({
-    isExporting: false,
-    canExport: true,
-    downloadSample: vi.fn().mockResolvedValue(true),
-  }),
+  useSlideFitSampleExport: () => ({ isExporting: false, canExport, downloadSample }),
 }));
 
 describe('SlideFitSampleButton', () => {
+  beforeEach(() => {
+    resetAllStores();
+    downloadSample.mockClear();
+    canExport = true;
+  });
+
   it('offers the fit test', () => {
     render(<SlideFitSampleButton />);
-    expect(screen.getByRole('button', { name: /fit test/i })).toBeEnabled();
+    expect(
+      screen.getByRole('button', { name: 'binDesigner.slideTray.fitSample.button' })
+    ).toBeEnabled();
+  });
+
+  it('disables the button when no bridge is ready', () => {
+    canExport = false;
+    render(<SlideFitSampleButton />);
+    expect(
+      screen.getByRole('button', { name: 'binDesigner.slideTray.fitSample.button' })
+    ).toBeDisabled();
+  });
+
+  it('opens the export dialog and downloads', async () => {
+    render(<SlideFitSampleButton />);
+    fireEvent.click(screen.getByRole('button', { name: 'binDesigner.slideTray.fitSample.button' }));
+    await waitFor(() =>
+      expect(screen.getByText('binDesigner.slideTray.fitSample.dialogTitle')).toBeInTheDocument()
+    );
+    // The rungs are ordered rather than labelled, so these tips are the only
+    // thing telling a user how to read the card.
+    expect(screen.getByText('binDesigner.slideTray.fitSample.tip1')).toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideFitSampleButton.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideFitSampleButton.tsx
@@ -1,0 +1,107 @@
+/**
+ * "Print fit test" control for the sliding tray.
+ *
+ * Opens the shared ExportDialog to download a one-file calibration card: five
+ * rail stubs across a clearance ladder plus one tray stub that runs in all of
+ * them. The rung the stub slides best in names the clearance to enter above.
+ *
+ * The rungs are ordered rather than labelled, so the tips explain how to read
+ * the card. Embossing five numbers would smear on a 0.4mm nozzle, which is the
+ * nozzle most of these will be printed on.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { Button } from '@/design-system/Button';
+import { ExportDialog } from '@/shared/components/ExportDialog';
+import { useToastStore } from '@/core/store/toast';
+import { useTranslation } from '@/i18n';
+import {
+  useSlideFitSampleExport,
+  SLIDE_FIT_SAMPLE_BASE_NAME,
+} from '../../../hooks/useSlideFitSampleExport';
+import { FORMAT_EXTENSIONS } from '@/shared/generation/exportUtils';
+import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
+
+export function SlideFitSampleButton() {
+  const t = useTranslation();
+  const { isExporting, canExport, downloadSample } = useSlideFitSampleExport();
+
+  const [open, setOpen] = useState(false);
+  const [fileNameConfig, setFileNameConfig] = useState<ExportFileNameConfig>({
+    style: 'descriptive',
+    customName: '',
+    format: 'stl',
+  });
+
+  const activeFormat: ExportFileFormat = fileNameConfig.format ?? 'stl';
+  const displayExtension = FORMAT_EXTENSIONS[activeFormat];
+  const baseName =
+    fileNameConfig.style === 'custom' && fileNameConfig.customName.trim() !== ''
+      ? fileNameConfig.customName.trim()
+      : SLIDE_FIT_SAMPLE_BASE_NAME;
+
+  const handleDownload = useCallback(() => {
+    void downloadSample(activeFormat, baseName).then((succeeded) => {
+      if (!succeeded) return;
+      useToastStore
+        .getState()
+        .addToast(t('binDesigner.slideTray.fitSample.exportComplete'), 'success', 3000);
+      setOpen(false);
+    });
+  }, [downloadSample, activeFormat, baseName, t]);
+
+  const tips = useMemo(
+    () => [
+      t('binDesigner.slideTray.fitSample.tip1'),
+      t('binDesigner.slideTray.fitSample.tip2'),
+      t('binDesigner.slideTray.fitSample.tip3'),
+    ],
+    [t]
+  );
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="sm"
+        fullWidth
+        onClick={() => setOpen(true)}
+        disabled={!canExport}
+      >
+        {t('binDesigner.slideTray.fitSample.button')}
+      </Button>
+
+      <ExportDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        activeFormat={activeFormat}
+        fileNameConfig={fileNameConfig}
+        onFileNameConfigChange={setFileNameConfig}
+        fileName={`${baseName}${displayExtension}`}
+        displayExtension={displayExtension}
+        canExport={canExport}
+        isExporting={isExporting}
+        onDownload={handleDownload}
+        sectionTitle={t('binDesigner.slideTray.fitSample.dialogTitle')}
+        sectionDescription={t('binDesigner.slideTray.fitSample.dialogDescription')}
+        extras={
+          <div className="mb-4 rounded-lg border border-stroke-subtle bg-surface p-3">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-tertiary">
+              {t('binDesigner.slideTray.fitSample.tipsTitle')}
+            </h3>
+            <ul className="space-y-1 text-xs text-content-secondary">
+              {tips.map((tip) => (
+                <li key={tip} className="flex gap-2">
+                  <span aria-hidden="true" className="text-content-tertiary">
+                    •
+                  </span>
+                  <span>{tip}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        }
+      />
+    </>
+  );
+}

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.tsx
@@ -16,6 +16,7 @@ import { FeatureToggle } from '../FeatureToggle';
 import { StepperField } from '../shared';
 import { SegmentedControl } from '@/design-system';
 import { useSlideTraySection } from './useSlideTraySection';
+import { SlideFitSampleButton } from './SlideFitSampleButton';
 import type { SlideRailMount } from '@/features/bin-designer/types';
 
 const MOUNTS: readonly SlideRailMount[] = ['interior', 'rim'];
@@ -108,6 +109,7 @@ export function SlideTraySection() {
       <p className="text-[11px] leading-relaxed text-content-tertiary">
         {t('binDesigner.slideTray.clearanceHint')}
       </p>
+      <SlideFitSampleButton />
     </FeatureToggle>
   );
 }

--- a/src/features/bin-designer/hooks/useSlideFitSampleExport.test.ts
+++ b/src/features/bin-designer/hooks/useSlideFitSampleExport.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSlideFitSampleExport } from './useSlideFitSampleExport';
+import { triggerDownload } from '@/shared/generation/exportUtils';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import { resetAllStores } from '@/test/testUtils';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+let activeBridge: unknown = null;
+vi.mock('@/shared/generation/bridge', () => ({
+  getActiveBridge: () => activeBridge,
+}));
+
+vi.mock('@/shared/generation/exportUtils', () => ({
+  triggerDownload: vi.fn(),
+  FORMAT_MIME_TYPES: { stl: 'model/stl', step: 'model/step', '3mf': 'model/3mf' },
+  FORMAT_EXTENSIONS: { stl: '.stl', step: '.step', '3mf': '.3mf' },
+}));
+
+vi.mock('@/shared/generation/stlParser', async () => {
+  const { ok } = await import('@/core/result');
+  return {
+    parseSTLBinary: () =>
+      ok({
+        vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      }),
+  };
+});
+vi.mock('@/shared/generation/export', () => ({ export3MF: () => new Blob(['3mf']) }));
+
+describe('useSlideFitSampleExport', () => {
+  beforeEach(() => {
+    resetAllStores();
+    activeBridge = null;
+    vi.mocked(triggerDownload).mockClear();
+  });
+
+  it('reports canExport from the active bridge presence', () => {
+    const { result, rerender } = renderHook(() => useSlideFitSampleExport());
+    expect(result.current.canExport).toBe(false);
+    activeBridge = {};
+    rerender();
+    expect(result.current.canExport).toBe(true);
+  });
+
+  it('refuses to export without a bridge', async () => {
+    const { result } = renderHook(() => useSlideFitSampleExport());
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.downloadSample('stl');
+    });
+    expect(ok).toBe(false);
+    expect(triggerDownload).not.toHaveBeenCalled();
+  });
+
+  it("sends the design's own slide config, not a generic one", async () => {
+    // The coupon's rail profile follows the config's shelf reach and thickness,
+    // so a card built from defaults would test a shelf this design never has.
+    const spy = vi.fn().mockResolvedValue({ data: new ArrayBuffer(8) });
+    activeBridge = { exportSlideFitSample: spy };
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        slide: { ...DEFAULT_BIN_PARAMS.slide, railProtrusionMm: 3 },
+      },
+    });
+    const { result } = renderHook(() => useSlideFitSampleExport());
+    await act(async () => {
+      await result.current.downloadSample('stl');
+    });
+    expect(spy).toHaveBeenCalledWith('stl', expect.objectContaining({ railProtrusionMm: 3 }));
+    expect(triggerDownload).toHaveBeenCalled();
+  });
+
+  it('names the download after the card', async () => {
+    activeBridge = {
+      exportSlideFitSample: vi.fn().mockResolvedValue({ data: new ArrayBuffer(8) }),
+    };
+    const { result } = renderHook(() => useSlideFitSampleExport());
+    await act(async () => {
+      await result.current.downloadSample('stl');
+    });
+    expect(vi.mocked(triggerDownload).mock.calls[0][1]).toBe('slide-fit-sample.stl');
+  });
+});

--- a/src/features/bin-designer/hooks/useSlideFitSampleExport.test.ts
+++ b/src/features/bin-designer/hooks/useSlideFitSampleExport.test.ts
@@ -75,6 +75,32 @@ describe('useSlideFitSampleExport', () => {
     expect(triggerDownload).toHaveBeenCalled();
   });
 
+  it('converts to 3MF through the STL parser rather than shipping raw STL', async () => {
+    // The 3MF branch is a different path: it exports STL from the worker, then
+    // re-wraps it on the main thread. A regression there would download a file
+    // named .3mf containing STL bytes.
+    const spy = vi.fn().mockResolvedValue({ data: new ArrayBuffer(8) });
+    activeBridge = { exportSlideFitSample: spy };
+    const { result } = renderHook(() => useSlideFitSampleExport());
+    await act(async () => {
+      await result.current.downloadSample('3mf');
+    });
+    expect(spy).toHaveBeenCalledWith('stl', expect.anything());
+    expect(vi.mocked(triggerDownload).mock.calls[0][1]).toBe('slide-fit-sample.3mf');
+  });
+
+  it('reports failure and stops exporting when the bridge throws', async () => {
+    activeBridge = { exportSlideFitSample: vi.fn().mockRejectedValue(new Error('kernel died')) };
+    const { result } = renderHook(() => useSlideFitSampleExport());
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.downloadSample('stl');
+    });
+    expect(ok).toBe(false);
+    expect(result.current.isExporting).toBe(false);
+    expect(triggerDownload).not.toHaveBeenCalled();
+  });
+
   it('names the download after the card', async () => {
     activeBridge = {
       exportSlideFitSample: vi.fn().mockResolvedValue({ data: new ArrayBuffer(8) }),

--- a/src/features/bin-designer/hooks/useSlideFitSampleExport.ts
+++ b/src/features/bin-designer/hooks/useSlideFitSampleExport.ts
@@ -1,0 +1,88 @@
+/**
+ * Export the sliding-tray fit-calibration card: a clearance ladder of rail
+ * stubs plus one tray stub that runs in all of them, so a maker can find the
+ * clearance their printer needs without printing a whole bin and tray.
+ *
+ * The design's own `slide` config rides along, because the coupon's rail
+ * profile follows its shelf reach and thickness — the card should test the
+ * shelf this design would actually carry, not a generic one.
+ */
+
+import { useCallback, useState } from 'react';
+import { useSettingsStore } from '@/core/store/settings';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { useToastStore } from '@/core/store/toast';
+import { useTranslation } from '@/i18n';
+import { getActiveBridge } from '@/shared/generation/bridge';
+import { export3MF } from '@/shared/generation/export';
+import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { isErr, getUserMessage } from '@/core/result';
+import { getErrorMessage } from '@/shared/utils/errors';
+import {
+  FORMAT_MIME_TYPES,
+  FORMAT_EXTENSIONS,
+  triggerDownload,
+} from '@/shared/generation/exportUtils';
+import type { ExportFileFormat } from '@/shared/types/bin';
+
+export const SLIDE_FIT_SAMPLE_BASE_NAME = 'slide-fit-sample';
+
+interface UseSlideFitSampleExportReturn {
+  readonly isExporting: boolean;
+  readonly canExport: boolean;
+  readonly downloadSample: (format: ExportFileFormat, baseName?: string) => Promise<boolean>;
+}
+
+export function useSlideFitSampleExport(): UseSlideFitSampleExportReturn {
+  const t = useTranslation();
+  const [isExporting, setIsExporting] = useState(false);
+  const canExport = getActiveBridge() !== null;
+
+  const downloadSample = useCallback(
+    async (format: ExportFileFormat, baseName: string = SLIDE_FIT_SAMPLE_BASE_NAME) => {
+      const bridge = getActiveBridge();
+      if (!bridge) return false;
+
+      setIsExporting(true);
+      try {
+        const slide = useDesignerStore.getState().params.slide;
+        if (format === '3mf') {
+          const stlResult = await bridge.exportSlideFitSample('stl', slide);
+          const parseResult = parseSTLBinary(stlResult.data);
+          if (isErr(parseResult)) throw new Error(getUserMessage(parseResult.error));
+          const printSettings = useSettingsStore.getState().settings.printSettings;
+          const blob = export3MF(parseResult.value.vertices, parseResult.value.normals, {
+            name: baseName,
+            printSettings: {
+              layerHeight: printSettings.layerHeightMm,
+              infillPercent: printSettings.infillPercent,
+              material: 'PLA',
+              supportRequired: false,
+              estimatedMinutes: 0,
+              estimatedGrams: 0,
+            },
+          });
+          triggerDownload(blob, `${baseName}${FORMAT_EXTENSIONS['3mf']}`);
+        } else {
+          const result = await bridge.exportSlideFitSample(format, slide);
+          const blob = new Blob([result.data], { type: FORMAT_MIME_TYPES[format] });
+          triggerDownload(blob, `${baseName}${FORMAT_EXTENSIONS[format]}`);
+        }
+        return true;
+      } catch (error: unknown) {
+        useToastStore
+          .getState()
+          .addToast(
+            getErrorMessage(error, t('binDesigner.slideTray.fitSample.exportFailed')),
+            'error'
+          );
+        return false;
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [t]
+  );
+
+  return { isExporting, canExport, downloadSample };
+}

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -22,6 +22,7 @@ import type {
   ResolvedBaseplateParams,
   SplitConnectorConfig,
   MarginPiece,
+  SlideConfig,
 } from '@/shared/types/bin';
 import type { GridfinityItem } from '@/shared/types/item';
 import type {
@@ -77,6 +78,7 @@ import {
   exportConnectorSample as exportConnectorSampleImpl,
   exportLabelPlates as exportLabelPlatesImpl,
   exportLabelFitSample as exportLabelFitSampleImpl,
+  exportSlideFitSample as exportSlideFitSampleImpl,
 } from './bridgeExports';
 import type { KernelName } from './types';
 
@@ -591,6 +593,10 @@ export class GenerationBridge {
     nozzleSizeMm?: number
   ): Promise<BaseplateExportResult> {
     return exportLabelFitSampleImpl(this, format, nozzleSizeMm);
+  }
+
+  exportSlideFitSample(format: ExportFormat, slide: SlideConfig): Promise<BaseplateExportResult> {
+    return exportSlideFitSampleImpl(this, format, slide);
   }
 
   /** Whether the bridge has been destroyed */

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -13,6 +13,7 @@ import type {
   ResolvedBaseplateParams,
   SplitConnectorConfig,
   MarginPiece,
+  SlideConfig,
 } from '@/shared/types/bin';
 import type { GridfinityItem } from '@/shared/types/item';
 import type {
@@ -409,6 +410,26 @@ export function exportLabelPlates(
     (requestId) => ({
       type: 'EXPORT_LABEL_PLATES',
       payload: { plates, options, requestId, format },
+    })
+  );
+}
+
+/**
+ * Export the sliding-tray fit-calibration card. Fixed small workload (five
+ * rail stubs plus one tray stub), so it shares the fixed export ceiling.
+ */
+export function exportSlideFitSample(
+  ctx: BridgeExportContext,
+  format: ExportFormat,
+  slide: SlideConfig
+): Promise<BaseplateExportResult> {
+  return runExport<BaseplateExportResult>(
+    ctx,
+    'export',
+    CONNECTOR_SAMPLE_TIMEOUT_MS,
+    (requestId) => ({
+      type: 'EXPORT_SLIDE_FIT_SAMPLE',
+      payload: { requestId, format, slide },
     })
   );
 }

--- a/src/features/generation/bridge/messages.ts
+++ b/src/features/generation/bridge/messages.ts
@@ -11,6 +11,7 @@ import type {
   SplitConnectorConfig,
   MarginPiece,
   TextStyleDefaults,
+  SlideConfig,
 } from '@/shared/types/bin';
 import type { GridfinityItem } from '@/shared/types/item';
 import type { LabelPlateIconId } from '@/shared/constants/labelPlates';
@@ -38,6 +39,7 @@ export type WorkerMessage =
   | ExportConnectorSampleMessage
   | ExportLabelPlatesMessage
   | ExportLabelFitSampleMessage
+  | ExportSlideFitSampleMessage
   | ExportDividersMessage
   | ExportCombinedMessage
   | ExportSplitMessage
@@ -262,6 +264,24 @@ export interface ExportLabelPlatesPayload {
  * fully standard-defined, so the payload carries nothing beyond the format.
  * Reuses the BASEPLATE_EXPORT_RESULT response shape.
  */
+/**
+ * Export the sliding-tray fit-calibration card: a clearance ladder of rail
+ * stubs plus one tray stub that runs in all of them. The card's own sizes are
+ * standard-defined, but the rail PROFILE follows the design's slide config, so
+ * the coupon tests the same shelf the bin would carry.
+ * Reuses the BASEPLATE_EXPORT_RESULT response shape.
+ */
+export interface ExportSlideFitSampleMessage {
+  readonly type: 'EXPORT_SLIDE_FIT_SAMPLE';
+  readonly payload: ExportSlideFitSamplePayload;
+}
+
+export interface ExportSlideFitSamplePayload {
+  readonly requestId: string;
+  readonly format: ExportFormat;
+  readonly slide: SlideConfig;
+}
+
 export interface ExportLabelFitSampleMessage {
   readonly type: 'EXPORT_LABEL_FIT_SAMPLE';
   readonly payload: ExportLabelFitSamplePayload;

--- a/src/features/generation/worker/generation.worker.ts
+++ b/src/features/generation/worker/generation.worker.ts
@@ -45,6 +45,7 @@ import {
   handleExportConnectorSample,
   handleExportLabelPlates,
   handleExportLabelFitSample,
+  handleExportSlideFitSample,
   handleExportDividers,
   handleExportCombined,
 } from './handlers/exportHandler';
@@ -165,6 +166,10 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
 
       case 'EXPORT_LABEL_FIT_SAMPLE':
         await handleExportLabelFitSample(message);
+        break;
+
+      case 'EXPORT_SLIDE_FIT_SAMPLE':
+        await handleExportSlideFitSample(message);
         break;
 
       case 'EXPORT_DIVIDERS':

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -11,6 +11,7 @@ import type {
   ExportConnectorSampleMessage,
   ExportLabelPlatesMessage,
   ExportLabelFitSampleMessage,
+  ExportSlideFitSampleMessage,
   ExportDividersMessage,
   ExportCombinedMessage,
   CombinedExportPiece,
@@ -29,6 +30,7 @@ import { buildUniqueDividerPieces } from '../generators/dividerBuilder';
 import { pitchFromParams } from '../generators/gridPitch';
 import { exportLid, exportStackPlate } from '../generators/lidOrchestrator';
 import { exportSlideTray } from '../generators/slideOrchestrator';
+import { exportSlideFitSample } from '../generators/slideFitSample';
 import type { FaceGroupData } from '@/shared/types/generation';
 import { buildLid, buildStackPlate } from '../generators/lidBuilder';
 import { lidAnchorZ } from '../generators/lidConstants';
@@ -176,6 +178,23 @@ export async function handleExportLabelFitSample(
       return { data: result.data, format: payload.format, fileName: result.fileName };
     },
     'Label fit sample export failed',
+    (p) => [p.data],
+    classifyExportError
+  );
+}
+
+export async function handleExportSlideFitSample(
+  message: ExportSlideFitSampleMessage
+): Promise<void> {
+  const payload = message.payload;
+  await runExport(
+    payload.requestId,
+    'BASEPLATE_EXPORT_RESULT',
+    async () => {
+      const result = await exportSlideFitSample(payload.format, payload.slide);
+      return { data: result.data, format: payload.format, fileName: result.fileName };
+    },
+    'Slide fit sample export failed',
     (p) => [p.data],
     classifyExportError
   );

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "Kolejnice zasahuje méně než vůle, takže by zásobník neunesla.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Tato přihrádka je příliš nízká pro pokles kolejnice. Snižte pokles nebo přihrádku zvyšte.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Tato přihrádka je příliš mělká, aby se zásobník vešel mezi kolejnice.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "Zásobník by v této velikosti neměl použitelný vnitřek."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "Zásobník by v této velikosti neměl použitelný vnitřek.",
+  "binDesigner.slideTray.fitSample.button": "Vytisknout zkoušku uložení",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Zkouška uložení posuvného zásobníku",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Pět úseků kolejnic s různými vůlemi a jeden zkušební zásobník, který jimi všemi projede.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Jak ji číst",
+  "binDesigner.slideTray.fitSample.tip1": "Kolejnice jsou seřazeny od nejtěsnější po nejvolnější. První, ve které zásobník volně klouže, je vaše vůle.",
+  "binDesigner.slideTray.fitSample.tip2": "Žebřík jde od 0,15 mm do 0,35 mm po 0,05 mm; třetí kolejnice je výchozích 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Tiskněte se stejným filamentem a tryskou, jaké použijete pro přihrádku.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Zkouška uložení stažena",
+  "binDesigner.slideTray.fitSample.exportFailed": "Zkoušku uložení se nepodařilo exportovat"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "Die Schiene greift weniger weit als das Spiel und würde das Fach nicht tragen.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Diese Box ist zu niedrig für die Schienenabsenkung. Verringere die Absenkung oder mache die Box höher.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Diese Box ist zu flach, damit ein Fach zwischen die Schienen passt.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "Das Fach hätte bei dieser Größe keinen nutzbaren Innenraum."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "Das Fach hätte bei dieser Größe keinen nutzbaren Innenraum.",
+  "binDesigner.slideTray.fitSample.button": "Passungstest drucken",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Passungstest für Schiebefach",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Fünf Schienenstücke mit unterschiedlichem Spiel und ein Fachstück, das in allen läuft.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "So liest du ihn",
+  "binDesigner.slideTray.fitSample.tip1": "Die Schienen sind von eng nach weit sortiert. Die erste, in der das Stück frei gleitet, ist dein Spiel.",
+  "binDesigner.slideTray.fitSample.tip2": "Die Leiter läuft von 0,15 mm bis 0,35 mm in 0,05-mm-Schritten; die dritte Schiene ist der Standard 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Drucke ihn mit demselben Filament und derselben Düse wie die Box.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Passungstest heruntergeladen",
+  "binDesigner.slideTray.fitSample.exportFailed": "Passungstest konnte nicht exportiert werden"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2579,6 +2579,19 @@ const en: Record<string, string> = {
   'binDesigner.walls.text.disabledSolid': 'Not available for solid bins.',
   'binDesigner.walls.text.hint':
     'Text auto-fits into the clear area of each wall, avoiding cutouts and handles. Wall patterns are cleared behind it.',
+  'binDesigner.slideTray.fitSample.button': 'Print a fit test',
+  'binDesigner.slideTray.fitSample.dialogTitle': 'Sliding tray fit test',
+  'binDesigner.slideTray.fitSample.dialogDescription':
+    'Five rail stubs at different clearances, plus one tray stub that runs in all of them.',
+  'binDesigner.slideTray.fitSample.tipsTitle': 'How to read it',
+  'binDesigner.slideTray.fitSample.tip1':
+    'Rails are ordered tightest to loosest. The first one the stub slides in freely is your clearance.',
+  'binDesigner.slideTray.fitSample.tip2':
+    'The ladder runs 0.15mm to 0.35mm in 0.05mm steps; the third rail is the default 0.25mm.',
+  'binDesigner.slideTray.fitSample.tip3':
+    'Print it with the same filament and nozzle you will use for the bin.',
+  'binDesigner.slideTray.fitSample.exportComplete': 'Fit test downloaded',
+  'binDesigner.slideTray.fitSample.exportFailed': 'Could not export the fit test',
   'binDesigner.slideTray.title': 'Sliding tray',
   'binDesigner.slideTray.summary': '{{width}}u, {{mount}}',
   'binDesigner.slideTray.mount.interior': 'Inside bin',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "El riel entra menos que la holgura, así que no sostendría la bandeja.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Este cajón es demasiado bajo para ese descenso del riel. Redúcelo o haz el cajón más alto.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Este cajón es demasiado poco profundo para que quepa una bandeja entre los rieles.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "La bandeja no tendría interior aprovechable a este tamaño."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "La bandeja no tendría interior aprovechable a este tamaño.",
+  "binDesigner.slideTray.fitSample.button": "Imprimir prueba de ajuste",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Prueba de ajuste de la bandeja deslizante",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Cinco tramos de riel con holguras distintas y una bandeja de prueba que recorre todos.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Cómo interpretarla",
+  "binDesigner.slideTray.fitSample.tip1": "Los rieles van de más ajustado a más holgado. El primero por el que la bandeja se desliza con soltura es tu holgura.",
+  "binDesigner.slideTray.fitSample.tip2": "La escala va de 0,15 mm a 0,35 mm en pasos de 0,05 mm; el tercer riel es el valor por defecto de 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Imprímela con el mismo filamento y la misma boquilla que usarás para el cajón.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Prueba de ajuste descargada",
+  "binDesigner.slideTray.fitSample.exportFailed": "No se pudo exportar la prueba de ajuste"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "Le rail avance moins que le jeu et ne porterait donc pas le plateau.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Ce bac est trop court pour cet abaissement du rail. Réduisez-le ou augmentez la hauteur du bac.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Ce bac est trop peu profond pour qu'un plateau tienne entre les rails.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "Le plateau n'aurait aucun intérieur utilisable à cette taille."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "Le plateau n'aurait aucun intérieur utilisable à cette taille.",
+  "binDesigner.slideTray.fitSample.button": "Imprimer un test d'ajustement",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Test d'ajustement du plateau coulissant",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Cinq tronçons de rail à jeux différents, plus un plateau d'essai qui passe dans tous.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Comment le lire",
+  "binDesigner.slideTray.fitSample.tip1": "Les rails vont du plus serré au plus lâche. Le premier dans lequel le plateau glisse librement donne votre jeu.",
+  "binDesigner.slideTray.fitSample.tip2": "L'échelle va de 0,15 mm à 0,35 mm par pas de 0,05 mm ; le troisième rail correspond au défaut de 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Imprimez-le avec le filament et la buse que vous utiliserez pour le bac.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Test d'ajustement téléchargé",
+  "binDesigner.slideTray.fitSample.exportFailed": "Impossible d'exporter le test d'ajustement"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "La guida rientra meno del gioco, quindi non reggerebbe il vassoio.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Questo contenitore è troppo basso per tale abbassamento. Riducilo o alza il contenitore.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Questo contenitore è troppo poco profondo perché un vassoio stia tra le guide.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "Il vassoio non avrebbe interno utilizzabile a questa misura."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "Il vassoio non avrebbe interno utilizzabile a questa misura.",
+  "binDesigner.slideTray.fitSample.button": "Stampa prova di accoppiamento",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Prova di accoppiamento del vassoio scorrevole",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Cinque tratti di guida con giochi diversi più un vassoio di prova che scorre in tutti.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Come leggerla",
+  "binDesigner.slideTray.fitSample.tip1": "Le guide vanno dalla più stretta alla più larga. La prima in cui il vassoio scorre liberamente è il tuo gioco.",
+  "binDesigner.slideTray.fitSample.tip2": "La scala va da 0,15 mm a 0,35 mm a passi di 0,05 mm; la terza guida è il valore predefinito di 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Stampala con lo stesso filamento e ugello che userai per il contenitore.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Prova di accoppiamento scaricata",
+  "binDesigner.slideTray.fitSample.exportFailed": "Impossibile esportare la prova di accoppiamento"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "レールの張り出しがクリアランスより小さいため、トレーを支えられません。",
   "binDesigner.slideTray.unavailable.railBelowFloor": "このビンはレール下げ量に対して低すぎます。下げ量を減らすかビンを高くしてください。",
   "binDesigner.slideTray.unavailable.binTooShallow": "このビンは浅すぎて、レールの間にトレーが収まりません。",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "このサイズではトレーの内側が使えません。"
+  "binDesigner.slideTray.unavailable.trayTooSmall": "このサイズではトレーの内側が使えません。",
+  "binDesigner.slideTray.fitSample.button": "フィットテストを印刷",
+  "binDesigner.slideTray.fitSample.dialogTitle": "スライドトレーのフィットテスト",
+  "binDesigner.slideTray.fitSample.dialogDescription": "クリアランスの異なる5本のレール片と、そのすべてで走らせる1つのトレー片。",
+  "binDesigner.slideTray.fitSample.tipsTitle": "読み方",
+  "binDesigner.slideTray.fitSample.tip1": "レールはきつい順に並んでいます。トレー片がスムーズに滑る最初のレールがあなたのクリアランスです。",
+  "binDesigner.slideTray.fitSample.tip2": "0.15mm から 0.35mm まで 0.05mm 刻み。3本目が既定の 0.25mm です。",
+  "binDesigner.slideTray.fitSample.tip3": "ビンに使うのと同じフィラメントとノズルで印刷してください。",
+  "binDesigner.slideTray.fitSample.exportComplete": "フィットテストをダウンロードしました",
+  "binDesigner.slideTray.fitSample.exportFailed": "フィットテストを書き出せませんでした"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "레일이 여유보다 적게 뻗어 있어 트레이를 지지하지 못합니다.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "이 빈은 레일 낮춤에 비해 너무 낮습니다. 낮춤을 줄이거나 빈을 높이세요.",
   "binDesigner.slideTray.unavailable.binTooShallow": "이 빈은 너무 얕아 레일 사이에 트레이가 들어가지 않습니다.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "이 크기에서는 트레이 내부를 쓸 수 없습니다."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "이 크기에서는 트레이 내부를 쓸 수 없습니다.",
+  "binDesigner.slideTray.fitSample.button": "맞춤 테스트 출력",
+  "binDesigner.slideTray.fitSample.dialogTitle": "슬라이딩 트레이 맞춤 테스트",
+  "binDesigner.slideTray.fitSample.dialogDescription": "여유가 각기 다른 레일 조각 다섯 개와 모두에서 움직이는 트레이 조각 하나.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "읽는 방법",
+  "binDesigner.slideTray.fitSample.tip1": "레일은 빡빡한 순서로 정렬되어 있습니다. 트레이 조각이 부드럽게 미끄러지는 첫 레일이 여러분의 여유입니다.",
+  "binDesigner.slideTray.fitSample.tip2": "0.15mm에서 0.35mm까지 0.05mm 간격이며, 세 번째 레일이 기본값 0.25mm입니다.",
+  "binDesigner.slideTray.fitSample.tip3": "빈에 사용할 필라멘트와 노즐로 출력하세요.",
+  "binDesigner.slideTray.fitSample.exportComplete": "맞춤 테스트를 내려받았습니다",
+  "binDesigner.slideTray.fitSample.exportFailed": "맞춤 테스트를 내보내지 못했습니다"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "Skinnen stikker kortere inn enn klaringen, så den ville ikke bære brettet.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Denne boksen er for lav for skinnesenkingen. Reduser senkingen eller gjør boksen høyere.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Denne boksen er for grunn til at et brett får plass mellom skinnene.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "Brettet ville ikke hatt brukbart innvendig rom i denne størrelsen."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "Brettet ville ikke hatt brukbart innvendig rom i denne størrelsen.",
+  "binDesigner.slideTray.fitSample.button": "Skriv ut en passtest",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Passtest for skyvebrett",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Fem skinnestubber med ulik klaring, pluss én brettstubb som går i alle.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Slik leser du den",
+  "binDesigner.slideTray.fitSample.tip1": "Skinnene går fra trangest til løsest. Den første brettstubben glir fritt i, er din klaring.",
+  "binDesigner.slideTray.fitSample.tip2": "Stigen går fra 0,15 mm til 0,35 mm i trinn på 0,05 mm; tredje skinne er standard 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Skriv den ut med samme filament og dyse som du skal bruke til boksen.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Passtest lastet ned",
+  "binDesigner.slideTray.fitSample.exportFailed": "Kunne ikke eksportere passtesten"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "De rail steekt minder ver in dan de speling en zou de lade dus niet dragen.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Deze bak is te laag voor die railverlaging. Verklein de verlaging of maak de bak hoger.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Deze bak is te ondiep om een lade tussen de rails te laten passen.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "De lade zou bij deze maat geen bruikbare binnenruimte hebben."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "De lade zou bij deze maat geen bruikbare binnenruimte hebben.",
+  "binDesigner.slideTray.fitSample.button": "Pasvormtest printen",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Pasvormtest schuiflade",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Vijf railstukken met verschillende speling, plus één ladestuk dat er in alle loopt.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Hoe lees je hem",
+  "binDesigner.slideTray.fitSample.tip1": "De rails lopen van strak naar ruim. De eerste waarin het ladestuk soepel glijdt, is jouw speling.",
+  "binDesigner.slideTray.fitSample.tip2": "De reeks loopt van 0,15 mm tot 0,35 mm in stappen van 0,05 mm; de derde rail is de standaard 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Print hem met hetzelfde filament en dezelfde nozzle als de bak.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Pasvormtest gedownload",
+  "binDesigner.slideTray.fitSample.exportFailed": "Kon de pasvormtest niet exporteren"
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "Szyna sięga mniej niż luz, więc nie utrzymałaby tacy.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Ten pojemnik jest za niski dla takiego obniżenia szyny. Zmniejsz obniżenie lub podwyższ pojemnik.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Ten pojemnik jest za płytki, by taca zmieściła się między szynami.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "Taca nie miałaby użytecznego wnętrza przy tym rozmiarze."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "Taca nie miałaby użytecznego wnętrza przy tym rozmiarze.",
+  "binDesigner.slideTray.fitSample.button": "Wydrukuj test dopasowania",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Test dopasowania przesuwnej tacy",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Pięć odcinków szyny o różnych luzach oraz jedna próbka tacy, która przesuwa się w każdym.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Jak go czytać",
+  "binDesigner.slideTray.fitSample.tip1": "Szyny są ułożone od najciaśniejszej do najluźniejszej. Pierwsza, w której taca przesuwa się swobodnie, to twój luz.",
+  "binDesigner.slideTray.fitSample.tip2": "Skala biegnie od 0,15 mm do 0,35 mm co 0,05 mm; trzecia szyna to domyślne 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Wydrukuj go tym samym filamentem i dyszą, których użyjesz do pojemnika.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Pobrano test dopasowania",
+  "binDesigner.slideTray.fitSample.exportFailed": "Nie udało się wyeksportować testu dopasowania"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "O trilho avança menos que a folga, então não sustentaria a bandeja.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Este compartimento é baixo demais para esse rebaixo. Reduza-o ou aumente a altura.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Este compartimento é raso demais para uma bandeja caber entre os trilhos.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "A bandeja não teria interior aproveitável neste tamanho."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "A bandeja não teria interior aproveitável neste tamanho.",
+  "binDesigner.slideTray.fitSample.button": "Imprimir teste de ajuste",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Teste de ajuste da bandeja deslizante",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Cinco trechos de trilho com folgas diferentes e uma bandeja de teste que percorre todos.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Como interpretar",
+  "binDesigner.slideTray.fitSample.tip1": "Os trilhos vão do mais apertado ao mais folgado. O primeiro em que a bandeja desliza livremente é a sua folga.",
+  "binDesigner.slideTray.fitSample.tip2": "A escala vai de 0,15 mm a 0,35 mm em passos de 0,05 mm; o terceiro trilho é o padrão de 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Imprima com o mesmo filamento e bico que usará no compartimento.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Teste de ajuste baixado",
+  "binDesigner.slideTray.fitSample.exportFailed": "Não foi possível exportar o teste de ajuste"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "Skenan når kortare in än spelet och skulle därför inte bära brickan.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Den här lådan är för låg för skensänkningen. Minska sänkningen eller gör lådan högre.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Den här lådan är för grund för att en bricka ska rymmas mellan skenorna.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "Brickan skulle inte få något användbart innerutrymme i den här storleken."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "Brickan skulle inte få något användbart innerutrymme i den här storleken.",
+  "binDesigner.slideTray.fitSample.button": "Skriv ut ett passningstest",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Passningstest för skjutbricka",
+  "binDesigner.slideTray.fitSample.dialogDescription": "Fem skenstumpar med olika spel, plus en brickstump som går i alla.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Så läser du det",
+  "binDesigner.slideTray.fitSample.tip1": "Skenorna går från trängst till lösast. Den första brickstumpen glider fritt i är ditt spel.",
+  "binDesigner.slideTray.fitSample.tip2": "Stegen går från 0,15 mm till 0,35 mm i steg om 0,05 mm; tredje skenan är standardvärdet 0,25 mm.",
+  "binDesigner.slideTray.fitSample.tip3": "Skriv ut det med samma filament och munstycke som du ska använda till lådan.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Passningstest nedladdat",
+  "binDesigner.slideTray.fitSample.exportFailed": "Kunde inte exportera passningstestet"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "Напрямна виступає менше, ніж зазор, тож не втримала б лоток.",
   "binDesigner.slideTray.unavailable.railBelowFloor": "Цей контейнер занадто низький для такого опускання. Зменште опускання або зробіть контейнер вищим.",
   "binDesigner.slideTray.unavailable.binTooShallow": "Цей контейнер занадто мілкий, щоб лоток помістився між напрямними.",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "За такого розміру лоток не мав би корисного внутрішнього простору."
+  "binDesigner.slideTray.unavailable.trayTooSmall": "За такого розміру лоток не мав би корисного внутрішнього простору.",
+  "binDesigner.slideTray.fitSample.button": "Надрукувати тест припасування",
+  "binDesigner.slideTray.fitSample.dialogTitle": "Тест припасування висувного лотка",
+  "binDesigner.slideTray.fitSample.dialogDescription": "П'ять відрізків напрямної з різними зазорами та один пробний лоток, який іде в усіх.",
+  "binDesigner.slideTray.fitSample.tipsTitle": "Як його читати",
+  "binDesigner.slideTray.fitSample.tip1": "Напрямні впорядковані від найтіснішої до найвільнішої. Перша, у якій лоток ковзає вільно, — ваш зазор.",
+  "binDesigner.slideTray.fitSample.tip2": "Шкала йде від 0,15 мм до 0,35 мм із кроком 0,05 мм; третя напрямна — типові 0,25 мм.",
+  "binDesigner.slideTray.fitSample.tip3": "Друкуйте його тим самим філаментом і соплом, які використаєте для контейнера.",
+  "binDesigner.slideTray.fitSample.exportComplete": "Тест припасування завантажено",
+  "binDesigner.slideTray.fitSample.exportFailed": "Не вдалося експортувати тест припасування"
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3662,5 +3662,14 @@
   "binDesigner.slideTray.unavailable.noBearing": "导轨伸入量小于间隙，无法承托托盘。",
   "binDesigner.slideTray.unavailable.railBelowFloor": "此箱高度不足以容纳该导轨下沉量。请减小下沉量或增加箱体高度。",
   "binDesigner.slideTray.unavailable.binTooShallow": "此箱过浅，托盘无法装入导轨之间。",
-  "binDesigner.slideTray.unavailable.trayTooSmall": "在此尺寸下托盘将没有可用的内部空间。"
+  "binDesigner.slideTray.unavailable.trayTooSmall": "在此尺寸下托盘将没有可用的内部空间。",
+  "binDesigner.slideTray.fitSample.button": "打印配合测试件",
+  "binDesigner.slideTray.fitSample.dialogTitle": "滑动托盘配合测试",
+  "binDesigner.slideTray.fitSample.dialogDescription": "五段间隙不同的导轨，以及一个可在全部导轨中滑动的托盘试件。",
+  "binDesigner.slideTray.fitSample.tipsTitle": "如何判读",
+  "binDesigner.slideTray.fitSample.tip1": "导轨按由紧到松排列。试件能顺畅滑动的第一段即为你的间隙。",
+  "binDesigner.slideTray.fitSample.tip2": "梯度从 0.15mm 到 0.35mm，步进 0.05mm；第三段为默认的 0.25mm。",
+  "binDesigner.slideTray.fitSample.tip3": "请使用与箱体相同的耗材和喷嘴打印。",
+  "binDesigner.slideTray.fitSample.exportComplete": "已下载配合测试件",
+  "binDesigner.slideTray.fitSample.exportFailed": "无法导出配合测试件"
 }


### PR DESCRIPTION
Last piece. `exportSlideFitSample` has existed with no caller since the coupon landed; this is the plumbing that reaches it.

## The chain

Mirrors the label-socket fit card at every link: bridge message → worker case → handler → bridge method → export hook → button in the panel's Customize area.

## The design's config rides along

The card is not fully standard-defined the way the label one is. Its rail profile follows the `slide` config's shelf reach and thickness, so a card built from defaults would test a shelf this design never carries. A test pins that the config actually reaches the bridge rather than being dropped somewhere in the chain.

## Reading the card

The rungs are **ordered rather than labelled**, so the dialog's tips carry the instructions: tightest to loosest, 0.15mm to 0.35mm in 0.05mm steps, third rung is the 0.25mm default, print with the filament and nozzle you'll use for the bin. Embossing five numbers would smear on the 0.4mm nozzle most of these will be printed on.

## Verification

- `useSlideFitSampleExport.test.ts` (4): `canExport` tracks the bridge, refuses without one, sends the design's own config, names the download.
- `SlideFitSampleButton.test.tsx`: the button renders enabled.
- Full `unit` + `dom` 1355 files / 18399 passed; `generators` 268 files / 2686 passed. All four i18n checks green.

9 keys across 15 locales.

## The feature is complete

Model, geometry, export, preview, panel, rejections and now the fit test. The one thing left is outside the code: **nobody has printed one**. The 0.25mm clearance default is reasoned from Gridfinity's own spec and FDM practice, and this card is how a user finds out whether it's right for their printer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Print a fit test” button for the sliding tray that exports a clearance calibration card. Wires `exportSlideFitSample` through the bridge and worker so users can download the card from the panel.

- **New Features**
  - `SlideFitSampleButton` in the Slide Tray panel opens `ExportDialog` to download a five‑rung clearance card (STL/STEP/3MF).
  - Full export path added: bridge message, worker handler, bridge method, and `useSlideFitSampleExport` hook; 3MF is built by parsing STL and packaging on the main thread.
  - Uses the current design’s `slide` config so the rail profile matches the bin. Dialog tips explain tight→loose rungs (0.15–0.35 mm, 0.05 mm steps; third is 0.25 mm). Success/error toasts added. i18n: 9 new keys across 15 locales. Tests cover export eligibility, disabled state, dialog open, config passthrough, naming, 3MF path, and failure resets exporting.

- **Bug Fixes**
  - Raised the Total JS budget from 1905 kB to 1910 kB to accommodate this feature.
  - Updated button test to mock `@/i18n` and assert keys to match test conventions.

<sup>Written for commit 2442697ec3697706c90895eb497200b4df41075a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

