### PR TITLE
feat(labs): gate the sliding tray behind a labs flag

### DIFF
--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -200,6 +200,18 @@ export const FEATURE_FLAGS = [
     requiresRefresh: false,
   },
   {
+    id: 'sliding_tray',
+    name: 'Sliding Tray',
+    description:
+      'Add a rail to a bin and a companion tray that slides along it, so small parts ride above the bin floor and pull aside to reach what is underneath.',
+    status: 'experimental',
+    risk: 'medium',
+    warning:
+      'Unfinished. The rail and tray geometry is still changing, the printed fit is unverified, and a design saved with a tray may not reopen the same way once this ships.',
+    addedAt: '2026-08',
+    requiresRefresh: false,
+  },
+  {
     id: 'community_showcase',
     name: 'Community Showcase',
     description:

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.test.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { useLabsStore } from '@/core/store';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import { SlideTraySection } from './SlideTraySection';
 
@@ -10,9 +11,27 @@ function setParams(over: Partial<typeof DEFAULT_BIN_PARAMS>): void {
   });
 }
 
-beforeEach(() => setParams({}));
+function setSlideFlag(enabled: boolean): void {
+  useLabsStore.setState((s) => ({
+    preferences: {
+      ...s.preferences,
+      enabledFeatures: { ...s.preferences.enabledFeatures, sliding_tray: enabled },
+    },
+  }));
+}
+
+beforeEach(() => {
+  setParams({});
+  setSlideFlag(true);
+});
 
 describe('SlideTraySection', () => {
+  it('renders nothing while the labs flag is off', () => {
+    setSlideFlag(false);
+    const { container } = render(<SlideTraySection />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('renders the feature toggle', () => {
     render(<SlideTraySection />);
     expect(screen.getByText('Sliding tray')).toBeInTheDocument();

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.tsx
@@ -9,9 +9,15 @@
  * When the bin cannot carry a tray at all the toggle is disabled with the
  * reason, rather than letting a user switch the feature on and watch nothing
  * appear.
+ *
+ * The `sliding_tray` gate lives here rather than at the mount site: this
+ * section is the only thing in the app that can set `slide.enabled`, so gating
+ * the component itself keeps a future second mount point from reopening the
+ * feature while it is unfinished.
  */
 
 import { useTranslation } from '@/i18n';
+import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { FeatureToggle } from '../FeatureToggle';
 import { StepperField } from '../shared';
 import { SegmentedControl } from '@/design-system';
@@ -23,7 +29,10 @@ const MOUNTS: readonly SlideRailMount[] = ['interior', 'rim'];
 
 export function SlideTraySection() {
   const t = useTranslation();
+  const enabled = useFeatureFlag('sliding_tray');
   const { slide, meta, blockedReason, protrusionMm, constraints, handlers } = useSlideTraySection();
+
+  if (!enabled) return null;
 
   return (
     <FeatureToggle

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.tsx
@@ -13,7 +13,10 @@
  * The `sliding_tray` gate lives here rather than at the mount site: this
  * section is the only thing in the app that can set `slide.enabled`, so gating
  * the component itself keeps a future second mount point from reopening the
- * feature while it is unfinished.
+ * feature while it is unfinished. The gate is its own component so that
+ * `useSlideTraySection` — which subscribes to the whole `params` object and
+ * re-resolves the slide geometry on every edit — does not run for the users
+ * who cannot see the section.
  */
 
 import { useTranslation } from '@/i18n';
@@ -28,11 +31,12 @@ import type { SlideRailMount } from '@/features/bin-designer/types';
 const MOUNTS: readonly SlideRailMount[] = ['interior', 'rim'];
 
 export function SlideTraySection() {
-  const t = useTranslation();
-  const enabled = useFeatureFlag('sliding_tray');
-  const { slide, meta, blockedReason, protrusionMm, constraints, handlers } = useSlideTraySection();
+  return useFeatureFlag('sliding_tray') ? <SlideTrayControls /> : null;
+}
 
-  if (!enabled) return null;
+function SlideTrayControls() {
+  const t = useTranslation();
+  const { slide, meta, blockedReason, protrusionMm, constraints, handlers } = useSlideTraySection();
 
   return (
     <FeatureToggle

--- a/src/features/labs/README.md
+++ b/src/features/labs/README.md
@@ -36,6 +36,9 @@ Internal status enum values → UI badge labels: `experimental` → "Early acces
 | `brepkit_kernel`        | `experimental`  | Alternative 3D geometry engine (BrepKit) — driven by `EngineSelector`     |
 | `show_generation_perf`  | `experimental`  | Per-stage generation timing overlay in the bin designer                   |
 | `item_kinds`            | `experimental`  | Non-bin items (tool racks) that sit on a baseplate                        |
+| `community_fits_gap`    | `experimental`  | Select a layout gap and browse community designs that fit it              |
+| `sliding_tray`          | `experimental`  | Rail-and-tray sliding insert in the bin designer's Walls section          |
+| `community_showcase`    | `preview`       | Publish and remix bin designs in the community showcase                   |
 | `drawer_shapes`         | `graduated`     | Non-rectangular drawer shapes (L-shapes, notches, cut corners)            |
 | `bin_designer`          | `graduated`     | Custom bin designer                                                       |
 | `baseplate_generator`   | `graduated`     | Custom baseplate generator                                                |


### PR DESCRIPTION
The rail-and-tray geometry is unfinished, so the panel that reaches it should not be sitting in everyone's Walls section. New flag `sliding_tray`, `experimental`, no `defaultEnabled`, so it is off for everyone until it is ready.

The gate sits inside `SlideTraySection` rather than at its mount site in `WallsSection`, which is where the sibling `item_kinds` gate sits. That section is the only thing in the app that can set `slide.enabled`, so gating the component keeps a second mount point (mobile shell, a help deep-link) from reopening the feature by accident. The fit-test button is inside the section, so it goes with it.

Designs that already carry `slide.enabled` still generate their tray. Nothing sets it by default and the panel shipped in this release, so the alternative (stripping the config on the way to the worker) would risk silently dropping geometry from a saved design to cover no one.

Also fills in the three flags missing from the labs README table.

## Verification

- `pnpm run test:run src/features/bin-designer/components/panel src/features/labs` — 163 files, 1557 tests
- `pnpm run typecheck`, eslint, prettier, `check:boundaries`, `check:i18n:unused`
- New test asserts the section renders nothing with the flag off

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the sliding tray controls behind a new labs flag to keep the unfinished rail-and-tray out of the Walls section and avoid hidden work when disabled. Designs that already set `slide.enabled` still generate their tray.

- **New Features**
  - Added labs flag `sliding_tray` (`experimental`, off by default).
  - Gated `SlideTraySection` with `useFeatureFlag('sliding_tray')` to prevent accidental activation from other mounts.
  - Added test to ensure the section renders nothing when the flag is off.

- **Refactors**
  - Split the flag gate from the section body so `useSlideTraySection` doesn’t subscribe or resolve geometry when the flag is off.

<sup>Written for commit 1d9197e3f2dc011ab337471c02e6297323b730b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

