### PR TITLE
fix(community): stop the detail filmstrip collapsing, and align modal chrome

### DIFF
--- a/src/features/community/components/CommunityDetail/CommunityDetail.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetail.tsx
@@ -589,7 +589,7 @@ function CommunityDetailDialog({
       <Dialog.Header title={title} bordered closeAriaLabel={t('common.close')} />
       <Dialog.Body padding="none" scroll={false}>
         {phase === 'loading' && (
-          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8">
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6">
             {card !== null && card.thumbnailUrl !== '' && (
               <img
                 src={card.thumbnailUrl}

--- a/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
@@ -185,7 +185,7 @@ export function CommunityDetailContent({
   const { params, metrics, lineage } = design;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto md:flex-row md:overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto scrollbar-thin md:flex-row md:overflow-hidden">
       <DesignMediaPanel
         design={design}
         images={images}
@@ -194,7 +194,10 @@ export function CommunityDetailContent({
       />
 
       {/* Details rail */}
-      <div className="space-y-4 p-4 md:w-80 md:shrink-0 md:overflow-y-auto md:border-l md:border-stroke-subtle">
+      {/* `scrollbar-thin` is a plain CSS class, not a Tailwind utility, so it
+          takes no `md:` prefix. Harmless unprefixed: it only styles a scrollbar
+          that exists, and this rail only scrolls at md and up. */}
+      <div className="space-y-4 p-6 scrollbar-thin md:w-80 md:shrink-0 md:overflow-y-auto md:border-l md:border-stroke-subtle">
         {ownerModeration !== null && <HiddenNotice moderation={ownerModeration} />}
 
         <div>

--- a/src/features/community/components/CommunityDetail/DesignMediaPanel.test.tsx
+++ b/src/features/community/components/CommunityDetail/DesignMediaPanel.test.tsx
@@ -160,6 +160,20 @@ describe('DesignMediaPanel', () => {
     expect(onOpenLightbox).toHaveBeenCalledWith(visible);
   });
 
+  // No layout engine in jsdom, so this guards the class contract the way the
+  // other community rails do. `overflow-x-auto` computes overflow-y to `auto`,
+  // which drops the strip's min-content floor as a flex item: without
+  // `shrink-0` the height-capped media column crushed it to 40px and showed a
+  // vertical scrollbar on any viewport under ~850px.
+  it('keeps the strip from being crushed by the column it sits in', () => {
+    renderPanel();
+    const strip = screen.getByTestId('design-media-filmstrip');
+    expect(strip.className).toContain('shrink-0');
+    expect(strip.className).toContain('overflow-x-auto');
+    // Reserves room for the horizontal scrollbar instead of it sitting on the tiles.
+    expect(strip.className).toContain('pb-2');
+  });
+
   it('drops the strip entirely for a design with no imagery', () => {
     renderPanel([]);
     expect(screen.queryByTestId('design-media-filmstrip')).not.toBeInTheDocument();

--- a/src/features/community/components/CommunityDetail/DesignMediaPanel.tsx
+++ b/src/features/community/components/CommunityDetail/DesignMediaPanel.tsx
@@ -74,7 +74,10 @@ export function DesignMediaPanel({
   const hiddenCount = images.length - visibleCount;
 
   return (
-    <div className="flex flex-col items-center gap-3 bg-surface p-4 md:flex-1 md:justify-center md:overflow-y-auto">
+    // `safe center`, not `center`: once the column overflows, centred content
+    // sits partly above the scrollport, and scrollTop cannot go negative to
+    // reach it. `safe` drops back to start-alignment exactly then.
+    <div className="flex flex-col items-center gap-3 bg-surface p-6 scrollbar-thin md:flex-1 md:justify-center-safe md:overflow-y-auto">
       <div
         className="relative w-full max-w-xl"
         style={{ aspectRatio: '1 / 1', maxHeight: isMobile ? '45vh' : '55vh' }}
@@ -129,7 +132,14 @@ export function DesignMediaPanel({
         <div
           role="group"
           aria-label={t('community.media.filmstripLabel')}
-          className="flex w-full max-w-xl items-center gap-2 overflow-x-auto scrollbar-thin"
+          // `shrink-0` is load-bearing, not defensive. `overflow-x-auto`
+          // computes overflow-y to `auto` too, and a flex item whose block-axis
+          // overflow is not `visible` loses its min-content floor. That left
+          // the strip the only thing in this column that could be crushed (the
+          // hero's aspect-ratio floors it), so it absorbed the whole shortfall
+          // on any viewport under ~850px: 40px-tall tiles and a vertical
+          // scrollbar. `pb-2` keeps the horizontal scrollbar off the tiles.
+          className="flex w-full max-w-xl shrink-0 items-center gap-2 overflow-x-auto pb-2 scrollbar-thin"
           data-testid="design-media-filmstrip"
         >
           <Button

--- a/src/features/community/components/CommunityDetail/DirectRemixList.tsx
+++ b/src/features/community/components/CommunityDetail/DirectRemixList.tsx
@@ -50,7 +50,7 @@ export function DirectRemixList({ designId, remixCount }: DirectRemixListProps) 
         <ul
           role="list"
           aria-label={t('community.detail.buildsOnThis', { count: remixCount })}
-          className="flex list-none gap-2 overflow-x-auto pb-1"
+          className="flex list-none gap-2 overflow-x-auto pb-2 scrollbar-thin"
         >
           {remixes.map((card) => (
             <li key={card.id} className="shrink-0">

--- a/src/features/community/components/CommunityDetail/SimilarRail.tsx
+++ b/src/features/community/components/CommunityDetail/SimilarRail.tsx
@@ -84,7 +84,7 @@ export function SimilarRail({ design }: SimilarRailProps) {
       <ul
         role="list"
         aria-label={t('community.detail.similarTitle')}
-        className="flex list-none gap-2 overflow-x-auto pb-1"
+        className="flex list-none gap-2 overflow-x-auto pb-2 scrollbar-thin"
       >
         {similar.map((card) => (
           <li key={card.id} className="shrink-0">

--- a/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
@@ -70,6 +70,11 @@ export function CommunityGalleryTab({
   const t = useTranslation();
   const { isMobile } = useResponsive();
 
+  // The /community route heads the page with an h1, so its sections are h2.
+  // Every other surface is the gallery dialog, whose own title is already an
+  // h2, so the same sections drop to h3 there.
+  const sectionHeadingLevel = surface === 'route' ? 2 : 3;
+
   const { status, items, capped, error, filters, fitsGapContext, visibleCount } = useBrowseStore(
     useShallow((s) => ({
       status: s.status,
@@ -355,6 +360,7 @@ export function CommunityGalleryTab({
           items={activeItems}
           counts={facetCounts}
           onBack={() => filterPanel.close()}
+          headingLevel={sectionHeadingLevel}
         />
       </div>
     );
@@ -375,6 +381,7 @@ export function CommunityGalleryTab({
             items={activeItems}
             counts={facetCounts}
             onCollapse={() => filterPanel.close()}
+            headingLevel={sectionHeadingLevel}
           />
         )}
 

--- a/src/features/community/components/CommunityGalleryTab/FilterRail.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/FilterRail.test.tsx
@@ -22,7 +22,7 @@ beforeEach(() => {
 
 describe('FilterRail', () => {
   it('is a labelled landmark, not a dialog stacked on the gallery', () => {
-    render(<FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={vi.fn()} />);
+    render(<FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={vi.fn()} headingLevel={3} />);
     const rail = screen.getByTestId('community-filter-rail');
     expect(rail.tagName).toBe('ASIDE');
     expect(rail).toHaveAttribute('aria-label', 'community.gallery.filterPanelLabel');
@@ -30,22 +30,27 @@ describe('FilterRail', () => {
   });
 
   it('holds the filter panel', () => {
-    render(<FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={vi.fn()} />);
+    render(<FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={vi.fn()} headingLevel={3} />);
     expect(screen.getByTestId('community-filter-panel')).toBeInTheDocument();
   });
 
-  // The gallery mounts inside DesignGalleryModal, whose Dialog title is an h2,
-  // and under CommunityPage's h1. An h2 here was a peer of the dialog title.
-  it('titles itself below the surface heading, level with the other sections', () => {
-    render(<FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={vi.fn()} />);
+  // The gallery mounts under two different headings: the gallery dialog's own
+  // h2 title, and the /community route's h1. A hardcoded level is a peer of
+  // the dialog title in one host or skips a level in the other.
+  it.each([2, 3] as const)('titles itself at the depth its host dictates (h%i)', (level) => {
+    render(
+      <FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={vi.fn()} headingLevel={level} />
+    );
     expect(
-      screen.getByRole('heading', { level: 3, name: 'community.gallery.filterPanelLabel' })
+      screen.getByRole('heading', { level, name: 'community.gallery.filterPanelLabel' })
     ).toBeInTheDocument();
   });
 
   it('collapses from its own header control', () => {
     const onCollapse = vi.fn();
-    render(<FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={onCollapse} />);
+    render(
+      <FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={onCollapse} headingLevel={3} />
+    );
     fireEvent.click(screen.getByTestId('community-filter-rail-collapse'));
     expect(onCollapse).toHaveBeenCalledOnce();
   });

--- a/src/features/community/components/CommunityGalleryTab/FilterRail.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/FilterRail.test.tsx
@@ -34,6 +34,15 @@ describe('FilterRail', () => {
     expect(screen.getByTestId('community-filter-panel')).toBeInTheDocument();
   });
 
+  // The gallery mounts inside DesignGalleryModal, whose Dialog title is an h2,
+  // and under CommunityPage's h1. An h2 here was a peer of the dialog title.
+  it('titles itself below the surface heading, level with the other sections', () => {
+    render(<FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={vi.fn()} />);
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'community.gallery.filterPanelLabel' })
+    ).toBeInTheDocument();
+  });
+
   it('collapses from its own header control', () => {
     const onCollapse = vi.fn();
     render(<FilterRail items={[]} counts={EMPTY_COUNTS} onCollapse={onCollapse} />);

--- a/src/features/community/components/CommunityGalleryTab/FilterRail.tsx
+++ b/src/features/community/components/CommunityGalleryTab/FilterRail.tsx
@@ -26,9 +26,13 @@ export function FilterRail({ items, counts, onCollapse }: FilterRailProps) {
       data-testid="community-filter-rail"
     >
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-stroke-subtle px-3 py-2">
-        <h2 className="text-sm font-semibold text-content">
+        {/* h3, matching the shelf and filter-group headings: the gallery renders
+            both inside DesignGalleryModal, whose Dialog title is already an h2,
+            and under CommunityPage's h1. h2 here made it a peer of the dialog
+            title in the modal. */}
+        <h3 className="text-sm font-semibold text-content">
           {t('community.gallery.filterPanelLabel')}
-        </h2>
+        </h3>
         <IconButton
           variant="ghost"
           size="sm"

--- a/src/features/community/components/CommunityGalleryTab/FilterRail.tsx
+++ b/src/features/community/components/CommunityGalleryTab/FilterRail.tsx
@@ -9,6 +9,13 @@ export interface FilterRailProps {
   items: readonly CommunityCard[];
   counts: FacetCounts;
   onCollapse: () => void;
+  /**
+   * Depth of this section's title, which depends on the host: under the
+   * gallery dialog's own h2 title it is an h3, under the /community route's
+   * h1 it is an h2. Hardcoding either one flattens or skips a level in the
+   * other surface.
+   */
+  headingLevel: 2 | 3;
 }
 
 /**
@@ -16,8 +23,9 @@ export interface FilterRailProps {
  * results stay visible and there is no second focus trap, overlay or scroll
  * lock on top of the gallery dialog.
  */
-export function FilterRail({ items, counts, onCollapse }: FilterRailProps) {
+export function FilterRail({ items, counts, onCollapse, headingLevel }: FilterRailProps) {
   const t = useTranslation();
+  const Heading = `h${headingLevel}` as const;
 
   return (
     <aside
@@ -26,13 +34,9 @@ export function FilterRail({ items, counts, onCollapse }: FilterRailProps) {
       data-testid="community-filter-rail"
     >
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-stroke-subtle px-3 py-2">
-        {/* h3, matching the shelf and filter-group headings: the gallery renders
-            both inside DesignGalleryModal, whose Dialog title is already an h2,
-            and under CommunityPage's h1. h2 here made it a peer of the dialog
-            title in the modal. */}
-        <h3 className="text-sm font-semibold text-content">
+        <Heading className="text-sm font-semibold text-content">
           {t('community.gallery.filterPanelLabel')}
-        </h3>
+        </Heading>
         <IconButton
           variant="ghost"
           size="sm"

--- a/src/features/community/components/CommunityGalleryTab/MobileFilterView.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/MobileFilterView.test.tsx
@@ -22,31 +22,40 @@ beforeEach(() => {
 
 describe('MobileFilterView', () => {
   it('takes over in place rather than stacking a dialog on the gallery', () => {
-    render(<MobileFilterView items={[]} counts={EMPTY_COUNTS} onBack={vi.fn()} />);
+    render(<MobileFilterView items={[]} counts={EMPTY_COUNTS} onBack={vi.fn()} headingLevel={3} />);
     expect(screen.getByTestId('community-mobile-filters')).toBeInTheDocument();
     expect(screen.getByTestId('community-filter-panel')).toBeInTheDocument();
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 
-  // Same surface as FilterRail: an h2 here was a peer of the gallery dialog's
-  // own h2 title rather than a section under it.
-  it('titles itself below the surface heading, level with the other sections', () => {
-    render(<MobileFilterView items={[]} counts={EMPTY_COUNTS} onBack={vi.fn()} />);
+  // Same two hosts as FilterRail: the gallery dialog's h2 title, or the
+  // /community route's h1.
+  it.each([2, 3] as const)('titles itself at the depth its host dictates (h%i)', (level) => {
+    render(
+      <MobileFilterView items={[]} counts={EMPTY_COUNTS} onBack={vi.fn()} headingLevel={level} />
+    );
     expect(
-      screen.getByRole('heading', { level: 3, name: 'community.gallery.filterSheetTitle' })
+      screen.getByRole('heading', { level, name: 'community.gallery.filterSheetTitle' })
     ).toBeInTheDocument();
   });
 
   it('returns to the results from the back control', () => {
     const onBack = vi.fn();
-    render(<MobileFilterView items={[]} counts={EMPTY_COUNTS} onBack={onBack} />);
+    render(<MobileFilterView items={[]} counts={EMPTY_COUNTS} onBack={onBack} headingLevel={3} />);
     fireEvent.click(screen.getByTestId('community-mobile-filters-back'));
     expect(onBack).toHaveBeenCalledOnce();
   });
 
   it('doubles the live result count as the way back', () => {
     const onBack = vi.fn();
-    render(<MobileFilterView items={[]} counts={{ ...EMPTY_COUNTS, total: 47 }} onBack={onBack} />);
+    render(
+      <MobileFilterView
+        items={[]}
+        counts={{ ...EMPTY_COUNTS, total: 47 }}
+        onBack={onBack}
+        headingLevel={3}
+      />
+    );
     const apply = screen.getByTestId('community-mobile-filters-apply');
     expect(apply).toHaveTextContent('community.gallery.showResults');
     fireEvent.click(apply);

--- a/src/features/community/components/CommunityGalleryTab/MobileFilterView.test.tsx
+++ b/src/features/community/components/CommunityGalleryTab/MobileFilterView.test.tsx
@@ -28,6 +28,15 @@ describe('MobileFilterView', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 
+  // Same surface as FilterRail: an h2 here was a peer of the gallery dialog's
+  // own h2 title rather than a section under it.
+  it('titles itself below the surface heading, level with the other sections', () => {
+    render(<MobileFilterView items={[]} counts={EMPTY_COUNTS} onBack={vi.fn()} />);
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'community.gallery.filterSheetTitle' })
+    ).toBeInTheDocument();
+  });
+
   it('returns to the results from the back control', () => {
     const onBack = vi.fn();
     render(<MobileFilterView items={[]} counts={EMPTY_COUNTS} onBack={onBack} />);

--- a/src/features/community/components/CommunityGalleryTab/MobileFilterView.tsx
+++ b/src/features/community/components/CommunityGalleryTab/MobileFilterView.tsx
@@ -9,6 +9,8 @@ export interface MobileFilterViewProps {
   items: readonly CommunityCard[];
   counts: FacetCounts;
   onBack: () => void;
+  /** Host-dependent title depth. See {@link FilterRailProps.headingLevel}. */
+  headingLevel: 2 | 3;
 }
 
 /**
@@ -16,8 +18,9 @@ export interface MobileFilterViewProps {
  * opening a sheet: the gallery is already a fullscreen dialog, and a second
  * one stacks a focus trap and a scroll lock on top of the first.
  */
-export function MobileFilterView({ items, counts, onBack }: MobileFilterViewProps) {
+export function MobileFilterView({ items, counts, onBack, headingLevel }: MobileFilterViewProps) {
   const t = useTranslation();
+  const Heading = `h${headingLevel}` as const;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="community-mobile-filters">
@@ -31,9 +34,9 @@ export function MobileFilterView({ items, counts, onBack }: MobileFilterViewProp
         >
           <ArrowLeftIcon className="h-5 w-5" />
         </IconButton>
-        <h3 className="min-w-0 flex-1 truncate text-base font-semibold text-content">
+        <Heading className="min-w-0 flex-1 truncate text-base font-semibold text-content">
           {t('community.gallery.filterSheetTitle')}
-        </h3>
+        </Heading>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin px-3 py-3">

--- a/src/features/community/components/CommunityGalleryTab/MobileFilterView.tsx
+++ b/src/features/community/components/CommunityGalleryTab/MobileFilterView.tsx
@@ -31,9 +31,9 @@ export function MobileFilterView({ items, counts, onBack }: MobileFilterViewProp
         >
           <ArrowLeftIcon className="h-5 w-5" />
         </IconButton>
-        <h2 className="min-w-0 flex-1 truncate text-base font-semibold text-content">
+        <h3 className="min-w-0 flex-1 truncate text-base font-semibold text-content">
           {t('community.gallery.filterSheetTitle')}
-        </h2>
+        </h3>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto scrollbar-thin px-3 py-3">

--- a/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
+++ b/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
@@ -165,7 +165,7 @@ function Rail({ id, title, blurb, cards, onSelect, onSelectAuthor, onSeeAll }: R
           ref={railRef}
           role="list"
           aria-label={title}
-          className="flex list-none snap-x snap-mandatory gap-3 overflow-x-auto pb-2 motion-reduce:snap-none motion-reduce:scroll-auto"
+          className="flex list-none snap-x snap-mandatory gap-3 overflow-x-auto pb-2 scrollbar-thin motion-reduce:snap-none motion-reduce:scroll-auto"
         >
           {cards.map((card, index) => (
             <li key={card.id} className="w-40 shrink-0 snap-start sm:w-44">

--- a/src/features/community/components/PrintDialog/PrintDialog.test.tsx
+++ b/src/features/community/components/PrintDialog/PrintDialog.test.tsx
@@ -91,6 +91,19 @@ describe('PrintDialog', () => {
     expect(screen.queryByTestId('print-form')).toBeNull();
   });
 
+  // `fullScreen` and `mobilePresentation` are mutually exclusive mobile
+  // layouts. Passing both emitted `rounded-none` and `rounded-t-2xl` together
+  // (tailwind-merge keeps both, since rounded-t does not supersede rounded),
+  // leaving stylesheet order to decide the corners of a full-height box that
+  // was simultaneously pinned to the bottom.
+  it('picks one mobile layout rather than stacking two contradictory ones', () => {
+    renderOpen();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toContain('max-md:h-dvh');
+    expect(dialog.className).not.toContain('max-md:rounded-t-2xl');
+    expect(dialog.className).not.toContain('max-md:bottom-0');
+  });
+
   it('shows the sign-in step for an anonymous caller', () => {
     renderOpen({}, null, false);
     expect(screen.getByText('community.print.signinMessage')).toBeInTheDocument();

--- a/src/features/community/components/PrintDialog/PrintDialog.tsx
+++ b/src/features/community/components/PrintDialog/PrintDialog.tsx
@@ -202,11 +202,15 @@ function PrintDialogOpen({ onSaved, onDeleted }: PrintDialogProps) {
         open
         onClose={reset}
         size="lg"
+        // `fullScreen` and `mobilePresentation` are mutually exclusive mobile
+        // layouts: together they emit both `rounded-none` and `rounded-t-2xl`,
+        // which tailwind-merge keeps, leaving stylesheet order to pick the
+        // corners of a full-height box pinned to the bottom. A long form wants
+        // the whole screen, so this keeps `fullScreen` and drops the sheet.
         fullScreen="mobile"
-        mobilePresentation="sheet"
         dismissable={!busy}
       >
-        <Dialog.Header title={title} closeAriaLabel={t('common.closeDialog')} />
+        <Dialog.Header title={title} bordered closeAriaLabel={t('common.closeDialog')} />
 
         {phase === 'signin' && (
           <Dialog.Body>
@@ -267,7 +271,7 @@ function PrintDialogOpen({ onSaved, onDeleted }: PrintDialogProps) {
               />
             </Dialog.Body>
 
-            <Dialog.Footer>
+            <Dialog.Footer bordered>
               <div className="flex w-full items-center justify-between gap-2">
                 {mode === 'edit' ? (
                   <Button

--- a/src/features/community/components/PublishDialog/PublishDialog.tsx
+++ b/src/features/community/components/PublishDialog/PublishDialog.tsx
@@ -373,8 +373,11 @@ export function PublishDialog() {
         open
         onClose={handleClose}
         size="3xl"
+        // Mutually exclusive with `mobilePresentation`: together they emit both
+        // `rounded-none` and `rounded-t-2xl`, which tailwind-merge keeps, so
+        // stylesheet order picked the corners of a full-height box pinned to
+        // the bottom. The publish form wants the whole screen on mobile.
         fullScreen="mobile"
-        mobilePresentation="sheet"
         dismissable={phase !== 'publishing' && !unpublishBusy}
       >
         <Dialog.Header
@@ -385,6 +388,7 @@ export function PublishDialog() {
             </span>
           }
           closeAriaLabel={t('common.closeDialog')}
+          bordered
         >
           {canUnpublish && phase === 'form' && (
             <IconButton
@@ -449,7 +453,7 @@ export function PublishDialog() {
                 {t('community.publish.unavailable.body')}
               </Alert>
             </Dialog.Body>
-            <Dialog.Footer>
+            <Dialog.Footer bordered>
               <Button variant="primary" className="min-h-11 md:min-h-0" onClick={handleClose}>
                 {t('common.close')}
               </Button>
@@ -465,7 +469,7 @@ export function PublishDialog() {
                   {t('community.publish.error.loadFailed')}
                 </Alert>
               </Dialog.Body>
-              <Dialog.Footer>
+              <Dialog.Footer bordered>
                 <Button variant="primary" className="min-h-11 md:min-h-0" onClick={ownDesign.retry}>
                   {t('community.publish.error.tryAgain')}
                 </Button>
@@ -536,7 +540,7 @@ export function PublishDialog() {
                 </Field>
               </div>
             </Dialog.Body>
-            <Dialog.Footer>
+            <Dialog.Footer bordered>
               <Button variant="ghost" className="min-h-11 md:min-h-0" onClick={handleClose}>
                 {t('community.publish.success.done')}
               </Button>

--- a/src/features/community/components/ReportDialog/ReportDialog.tsx
+++ b/src/features/community/components/ReportDialog/ReportDialog.tsx
@@ -124,6 +124,7 @@ export function ReportDialog({ designId, onClose, onNeedsAuth, submit, title }: 
       <Dialog.Header
         title={title ?? t('community.report.title')}
         closeAriaLabel={t('common.closeDialog')}
+        bordered
       />
       <Dialog.Body>
         <div className="space-y-4">


### PR DESCRIPTION
## The reported bug

The filmstrip added in #3311 showed a vertical scrollbar and clipped its thumbnails. Root cause is a two-rule CSS chain rather than a sizing oversight:

1. `overflow-x-auto` made `overflow-y` compute to `auto` as well (CSS Overflow spec: a `visible` axis paired with a non-`visible` one becomes `auto`). That is the only reason a vertical scrollbar could exist.
2. A flex item whose block-axis overflow is not `visible` loses its automatic minimum size, so the strip's min-content floor of 80px became 0.

The media column is height-capped (`md:flex-1` inside an `h-[85vh]` dialog). Its sibling, the hero, has `aspect-ratio: 1/1`, which gives it a min-content floor it cannot shrink past. The strip was therefore the only compressible thing in the column and absorbed the entire shortfall.

Measured against the real dialog geometry (`size="4xl"`, `h-[85vh]`, 320px rail):

| Viewport height | Strip height | Vertical scrollbar |
| --- | --- | --- |
| 700px | 40px | yes |
| 768px | 60px | yes |
| 800px | 70px | yes |
| 900px+ | 80px | no |

That 900px cutoff is why it shipped. `shrink-0` restores the floor; `pb-2` keeps the horizontal scrollbar off the tiles. The column also moves to `justify-center-safe`: with the strip back at full height the column overflows sooner, and centred content in a scroll container puts its top above the scrollport where `scrollTop` cannot reach it (8px unreachable at 700px).

Verified in Chromium at 667/700/768/800/900/1080px: 80px tiles, no vertical scrollbar, nothing unreachable.

The same trap does not recur elsewhere. It only bites when the overflow element **is** the flex item; `ShelfLanding`, `SimilarRail` and `DirectRemixList` each wrap their rail in a block element, which preserves the floor (measured 80px vs 0px).

## Audit fixes

**Scrollbars.** Every scroll container on the gallery side carried `scrollbar-thin`; none on the detail side did, so opening a design swapped 6px custom scrollbars for platform defaults. The detail scrollers and the three card rails now match. Note `scrollbar-thin` is a plain CSS class in `index.css`, not a Tailwind utility, so it takes no responsive prefix (a `md:` prefix would silently generate nothing).

**Padding.** The Dialog chrome insets at 24px (`--space-2xl`), but the detail modal hand-rolled 16px and its loading state 32px, leaving the header title misaligned with the content below it. Both move to 24px. The lightbox stage keeps its tighter inset, which exists to give the image room, as does the gallery card grid.

**Mobile presentation.** `PrintDialog` and `PublishDialog` passed both `fullScreen="mobile"` and `mobilePresentation="sheet"`, which are mutually exclusive layouts. Together they emit `rounded-none` and `rounded-t-2xl`, both of which survive tailwind-merge (`rounded-t` does not supersede `rounded`), so stylesheet order decided the corners of a full-height box that was simultaneously pinned to the bottom. Both keep `fullScreen`, which matches the geometry they already had.

**Headings.** `FilterRail` and `MobileFilterView` hardcoded `h2`, but the gallery renders under two different headings: `DesignGalleryModal`, whose Dialog title is already an `h2`, and `CommunityPage`'s `h1`. A fixed level is a peer of the dialog title in one host or skips a level in the other, so the depth is derived from the `surface` prop the gallery already receives: `"route"` renders `h2`, the dialog surfaces render `h3`. `bordered` is now applied consistently to every header and footer in the family.

## Testing

- 988 tests pass across `src/features/community` and `src/shell/Modals/DesignGalleryModal`.
- New regression tests cover the strip's shrink contract, both heading levels in both components, and the mobile-layout conflict. The conflict test was confirmed to fail when the fix is reverted.
- Lint clean. The `max-lines` warnings on `CommunityDetail`, `PublishDialog` and `CommunityGalleryTab` are pre-existing.