### PR TITLE
feat(community): make a narrowed gallery shareable and reload-safe

### DIFF
--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -64,7 +64,15 @@ Identity is a line on the form (`Publishing as X · Change`), not a step. As a s
 
   **The footer wraps; it does not clip.** `touchTarget` grows the heart to 44px on touch, which is what makes the row too wide. The stat groups are `shrink-0` so a narrow column takes a second line rather than slicing a count in half, and the dimensions truncate first.
 
-- `components/CommunityPage/`: full-page host for the `/community` route. URL-driven detail: `/community/d/<id>` is pushed on open and restored on back/forward and cold deep links. Routing lives in `@/shared/hooks/useCommunityRouting` so the SPA-route CI guard covers the rewrite.
+- `utils/browseUrlState.ts`: query-string codec for the browse filters, making a narrowed gallery shareable, bookmarkable and reload-safe. `q`, `cat`, `tech`, `sort`, `w`, `d`, `h`, `liked`, `recent`, `featured`, `author`.
+
+  **Defaults are omitted**, so an unfiltered gallery is a bare `/community` and a link carries only what the sender chose. **Ranges are `min-max`** with either side droppable (`w=2-` is "at least 2"); a crossed or unparseable range is dropped whole, because half of one renders a slider with its thumbs swapped. **A bad value costs its own parameter, never the view** — these strings are user-editable and outlive deploys, so a retired category or a hand-typed `w=banana` drops that key and leaves the rest. Re-encoding after decode means the URL visibly self-heals.
+
+  **Three things deliberately do not travel.** `fitsGapContext` describes a gap in the sender's drawer and means nothing in a recipient's browser. `mineOnly` is resolved per account, so a shared link would show the recipient their own designs instead of the sender's view. `best-fit` depends on the gap it cannot carry and falls back to `newest` the moment no dimension constraint remains. That is why decoding returns a **patch** rather than a whole `BrowseFilters`, applied through `applyUrlFilters`: a key absent from the patch is left alone, so a shared link cannot clear the viewer's own state. Everything the URL _does_ own resets to its default when absent, or navigating back to an unfiltered view would keep whatever the store was holding.
+
+  Writes go through `replaceState`: narrowing a gallery is not navigation, and pushing would mean a Back press per filter tweak just to leave the page. `replaceState` fires no popstate, which is also what keeps the two directions from feeding each other — the reader only re-runs on a real popstate or mount.
+
+- `components/CommunityPage/`: full-page host for the `/community` route. URL-driven detail: `/community/d/<id>` is pushed on open and restored on back/forward and cold deep links. Routing lives in `@/shared/hooks/useCommunityRouting` so the SPA-route CI guard covers the rewrite. That module owns _where_ the query lives (`getCommunityGalleryQuery` / `syncCommunityGalleryQuery`); what the parameters _mean_ stays in this feature, since `shared/` cannot import from it.
 
   **The page wears the app's chrome.** It renders `ToolSwitcher` + `HeaderSupportLinks` like every other surface, so a visitor who followed a shared link has the whole app in the header. Below it, a title row carries the page name, the `Experimental` badge and one CTA.
 

--- a/src/features/community/components/CommunityPage/CommunityPage.test.tsx
+++ b/src/features/community/components/CommunityPage/CommunityPage.test.tsx
@@ -276,7 +276,85 @@ describe('CommunityPage', () => {
     });
   });
 
-  describe('shareable author view (?author=)', () => {
+  describe('shareable filter state', () => {
+    it('cold visit applies every filter the query carries', () => {
+      window.history.replaceState(null, '', '/community?q=hex&cat=tools&sort=prints&w=2-4&liked=1');
+      renderPage();
+      const { filters } = useBrowseStore.getState();
+      expect(filters.searchText).toBe('hex');
+      expect(filters.category).toBe('tools');
+      expect(filters.sort).toBe('prints');
+      expect(filters.widthMin).toBe(2);
+      expect(filters.widthMax).toBe(4);
+      expect(filters.likedOnly).toBe(true);
+    });
+
+    it('narrowing the gallery writes the query in place', () => {
+      renderPage();
+      act(() => {
+        useBrowseStore.getState().setCategory('kitchen');
+        useBrowseStore.getState().setSearchText('bit');
+      });
+      expect(window.location.pathname).toBe('/community');
+      expect(window.location.search).toBe('?q=bit&cat=kitchen');
+    });
+
+    it('clearing every filter leaves a bare /community', () => {
+      window.history.replaceState(null, '', '/community?cat=tools&liked=1');
+      renderPage();
+      act(() => {
+        useBrowseStore.getState().clearFilters();
+      });
+      expect(window.location.search).toBe('');
+    });
+
+    it('never pushes a history entry for a filter change', () => {
+      // Narrowing is not navigation: pushing would mean a Back press per
+      // filter tweak just to leave the page.
+      renderPage();
+      const pushSpy = vi.spyOn(window.history, 'pushState');
+      act(() => {
+        useBrowseStore.getState().setCategory('tools');
+        useBrowseStore.getState().setCategory('kitchen');
+        useBrowseStore.getState().setLikedOnly(true);
+      });
+      expect(pushSpy).not.toHaveBeenCalled();
+      expect(window.location.search).toBe('?cat=kitchen&liked=1');
+    });
+
+    it('leaves the layout editor gap context out of the URL', () => {
+      // It describes a gap in the sender's drawer and means nothing in a
+      // recipient's browser.
+      renderPage();
+      act(() => {
+        useBrowseStore.getState().setFitsGapContext({
+          widthMax: 3,
+          depthMax: 2,
+          maxHeight: 6,
+          gridUnitMm: 42,
+          gridUnitMmY: 42,
+          heightUnitMm: 7,
+        });
+      });
+      expect(window.location.search).toBe('');
+    });
+
+    it('a shared link does not clear the viewer’s own Mine view', () => {
+      // mineOnly is resolved per account, so the URL neither carries nor
+      // clears it.
+      renderPage();
+      act(() => {
+        useBrowseStore.getState().setMineOnly(true);
+      });
+      expect(window.location.search).toBe('');
+      act(() => {
+        window.history.replaceState(null, '', '/community?cat=tools');
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+      expect(useBrowseStore.getState().filters.mineOnly).toBe(true);
+      expect(useBrowseStore.getState().filters.category).toBe('tools');
+    });
+
     const AUTHOR_ID = 'a'.repeat(32);
 
     function authorCard(id: string): CommunityCard {

--- a/src/features/community/components/CommunityPage/CommunityPage.test.tsx
+++ b/src/features/community/components/CommunityPage/CommunityPage.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/core/store/communityDetail';
 import { useSessionStore } from '@/core/sync/session/useSession';
 import type { CommunityCard } from '@/shared/types/community';
-import { INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
+import { GALLERY_PAGE_SIZE, INITIAL_BROWSE_STATE, useBrowseStore } from '../../store/browseStore';
 import { CommunityPage } from './CommunityPage';
 
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
@@ -320,6 +320,58 @@ describe('CommunityPage', () => {
       });
       expect(pushSpy).not.toHaveBeenCalled();
       expect(window.location.search).toBe('?cat=kitchen&liked=1');
+    });
+
+    it('opening a detail does not clear the gallery underneath it', () => {
+      // A detail URL carries no query, so the reader has to stand down while
+      // one owns the path: applying its empty query would wipe the filters
+      // behind the overlay and reset the paging Back is meant to return to.
+      window.history.replaceState(null, '', '/community?q=hex&cat=tools');
+      renderPage();
+      act(() => {
+        useBrowseStore.getState().showMore();
+      });
+      const pagedTo = useBrowseStore.getState().visibleCount;
+
+      act(() => {
+        useCommunityDetailStore.getState().open('DesignAAAAAA');
+      });
+      const during = useBrowseStore.getState();
+      expect(during.filters.searchText).toBe('hex');
+      expect(during.filters.category).toBe('tools');
+      expect(during.visibleCount).toBe(pagedTo);
+    });
+
+    it('returning from a detail replays the same query without resetting paging', () => {
+      window.history.replaceState(null, '', '/community?q=hex');
+      renderPage();
+      act(() => {
+        useBrowseStore.getState().showMore();
+      });
+      const pagedTo = useBrowseStore.getState().visibleCount;
+
+      act(() => {
+        window.history.replaceState(null, '', '/community?q=hex');
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+      // The replay is a no-op, so it must not count as a filter change: those
+      // legitimately reset scroll and page count, and Back is not one.
+      expect(useBrowseStore.getState().visibleCount).toBe(pagedTo);
+      expect(useBrowseStore.getState().filters.searchText).toBe('hex');
+    });
+
+    it('a query that really changes still resets paging', () => {
+      window.history.replaceState(null, '', '/community?q=hex');
+      renderPage();
+      act(() => {
+        useBrowseStore.getState().showMore();
+      });
+      expect(useBrowseStore.getState().visibleCount).toBeGreaterThan(GALLERY_PAGE_SIZE);
+      act(() => {
+        window.history.replaceState(null, '', '/community?q=bit');
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      });
+      expect(useBrowseStore.getState().visibleCount).toBe(GALLERY_PAGE_SIZE);
     });
 
     it('leaves the layout editor gap context out of the URL', () => {

--- a/src/features/community/components/CommunityPage/CommunityPage.tsx
+++ b/src/features/community/components/CommunityPage/CommunityPage.tsx
@@ -115,9 +115,16 @@ export function CommunityPage({
   // whatever the query carries. Only runs when the query actually changed,
   // and the write below uses replaceState (which fires no popstate), so the
   // two directions cannot feed each other.
+  //
+  // Skipped while a detail deep link owns the path, mirroring the guard on the
+  // write below. A detail URL carries no query, so without this the open would
+  // apply an empty one: clearing the gallery's filters underneath the overlay
+  // and resetting the scroll offset and page count that Back is supposed to
+  // return to.
   useEffect(() => {
+    if (communityDesignIdFromUrl !== null) return;
     applyUrlFilters(decodeBrowseParams(new URLSearchParams(communityGalleryQuery)));
-  }, [communityGalleryQuery, applyUrlFilters]);
+  }, [communityGalleryQuery, communityDesignIdFromUrl, applyUrlFilters]);
 
   // The URL carries the author's id but not their name, which is not in it to
   // carry: it resolves once the index holds one of their cards.

--- a/src/features/community/components/CommunityPage/CommunityPage.tsx
+++ b/src/features/community/components/CommunityPage/CommunityPage.tsx
@@ -25,11 +25,12 @@ import { ToolSwitcher } from '@/shared/components/ToolSwitcher';
 import { useResponsive } from '@/shared/hooks';
 import {
   getCommunityDesignIdFromUrl,
-  syncCommunityAuthorParam,
+  syncCommunityGalleryQuery,
   useCommunityRouting,
 } from '@/shared/hooks/useCommunityRouting';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
 import { useBrowseStore } from '../../store/browseStore';
+import { decodeBrowseParams, encodeBrowseParams } from '../../utils/browseUrlState';
 import { CommunityGalleryTab, GALLERY_RESULTS_ID } from '../CommunityGalleryTab';
 import { hasLocalDesigns } from '../CommunityGalleryTab/hasLocalDesigns';
 
@@ -58,13 +59,15 @@ export function CommunityPage({
   const { isMobile } = useResponsive();
   const {
     communityDesignIdFromUrl,
-    communityAuthorIdFromUrl,
+    communityGalleryQuery,
     openCommunityDesignUrl,
     closeCommunityDesignUrl,
   } = useCommunityRouting();
   const request = useCommunityDetailStore((s) => s.request);
   const hasUnseenDigest = useCommunityDigestStore((s) => s.hasUnseenDeltas);
   const setAuthor = useBrowseStore((s) => s.setAuthor);
+  const applyUrlFilters = useBrowseStore((s) => s.applyUrlFilters);
+  const filters = useBrowseStore((s) => s.filters);
   const authorFilterId = useBrowseStore((s) => s.filters.author?.id ?? null);
   const authorFilterName = useBrowseStore((s) => s.filters.author?.name ?? null);
   const items = useBrowseStore((s) => s.items);
@@ -108,31 +111,29 @@ export function CommunityPage({
     }
   }, [request, openCommunityDesignUrl, closeCommunityDesignUrl]);
 
-  // URL -> store: a shared /community?author= link applies the filter. The
-  // display name is unknown on a cold visit ('' placeholder); the effect
-  // below resolves it once the index holds one of the author's cards.
+  // URL -> store: a shared link, a reload, or Back out of a detail applies
+  // whatever the query carries. Only runs when the query actually changed,
+  // and the write below uses replaceState (which fires no popstate), so the
+  // two directions cannot feed each other.
   useEffect(() => {
-    if (communityAuthorIdFromUrl === null) return;
-    const current = useBrowseStore.getState().filters.author;
-    if (current?.id === communityAuthorIdFromUrl) return;
-    const match = useBrowseStore
-      .getState()
-      .items.find((c) => c.authorPublicId === communityAuthorIdFromUrl);
-    setAuthor({ id: communityAuthorIdFromUrl, name: match?.authorName ?? '' });
-  }, [communityAuthorIdFromUrl, setAuthor]);
+    applyUrlFilters(decodeBrowseParams(new URLSearchParams(communityGalleryQuery)));
+  }, [communityGalleryQuery, applyUrlFilters]);
 
+  // The URL carries the author's id but not their name, which is not in it to
+  // carry: it resolves once the index holds one of their cards.
   useEffect(() => {
     if (authorFilterId === null || authorFilterName !== '') return;
     const match = items.find((c) => c.authorPublicId === authorFilterId);
     if (match !== undefined) setAuthor({ id: authorFilterId, name: match.authorName });
   }, [items, authorFilterId, authorFilterName, setAuthor]);
 
-  // Store -> URL: keeps the author view shareable. Skipped while a detail
-  // deep link owns the path; re-runs when it closes back to /community.
+  // Store -> URL: keeps the narrowed view shareable and reload-safe. Skipped
+  // while a detail deep link owns the path; the gallery's query is restored
+  // from history when the detail closes.
   useEffect(() => {
     if (communityDesignIdFromUrl !== null) return;
-    syncCommunityAuthorParam(authorFilterId);
-  }, [authorFilterId, communityDesignIdFromUrl]);
+    syncCommunityGalleryQuery(encodeBrowseParams(filters).toString());
+  }, [filters, communityDesignIdFromUrl]);
 
   // Publishing needs the designer mounted: the dialog captures thumbnails and
   // a GLB from the live mesh, which only exists there. So the CTA leaves for

--- a/src/features/community/store/browseStore.ts
+++ b/src/features/community/store/browseStore.ts
@@ -370,6 +370,31 @@ function withBestFitFallback(
   return { ...filters, sort: 'newest' };
 }
 
+/**
+ * Value equality over the filters. `author` is the only non-primitive, and it
+ * is compared by id and name rather than by reference: the URL rebuilds it on
+ * every decode, so a reference check would report a change on every replay.
+ */
+export function sameBrowseFilters(a: BrowseFilters, b: BrowseFilters): boolean {
+  return (
+    a.searchText === b.searchText &&
+    a.category === b.category &&
+    a.technique === b.technique &&
+    a.sort === b.sort &&
+    a.likedOnly === b.likedOnly &&
+    a.recentOnly === b.recentOnly &&
+    a.featuredOnly === b.featuredOnly &&
+    a.mineOnly === b.mineOnly &&
+    a.widthMin === b.widthMin &&
+    a.widthMax === b.widthMax &&
+    a.depthMin === b.depthMin &&
+    a.depthMax === b.depthMax &&
+    a.maxHeight === b.maxHeight &&
+    a.author?.id === b.author?.id &&
+    a.author?.name === b.author?.name
+  );
+}
+
 function withDimensionPatch(
   state: Pick<BrowseState, 'filters' | 'fitsGapContext'>,
   patch: Partial<BrowseFilters>
@@ -567,7 +592,14 @@ export const useBrowseStore = create<BrowseStore>((set, get) => {
       }));
     },
     applyUrlFilters: (patch) => {
-      set((state) => withDimensionPatch(state, patch));
+      set((state) => {
+        const next = withDimensionPatch(state, patch);
+        // A no-op re-apply must stay a no-op. Returning from a detail replays
+        // the same query, and withDimensionPatch zeroes scrollTop and
+        // visibleCount, so without this Back lands at the top of a gallery
+        // that has forgotten every Load more.
+        return sameBrowseFilters(state.filters, next.filters) ? {} : next;
+      });
     },
     clearFilters: () => {
       set({ filters: INITIAL_BROWSE_FILTERS, scrollTop: 0, visibleCount: GALLERY_PAGE_SIZE });

--- a/src/features/community/store/browseStore.ts
+++ b/src/features/community/store/browseStore.ts
@@ -174,6 +174,13 @@ interface BrowseActions {
   clearDimensionFilters: () => void;
   setFitsGapContext: (fitsGapContext: FitsGapContext | null) => void;
   setMineOnly: (mineOnly: boolean) => void;
+  /**
+   * Applies the filters carried by the URL in one write. A patch rather than a
+   * whole `BrowseFilters` because the URL deliberately does not carry
+   * `mineOnly` or the gap context, and a shared link must not clear the
+   * viewer's own account state or a gap handed over by the layout editor.
+   */
+  applyUrlFilters: (patch: Partial<BrowseFilters>) => void;
   clearFilters: () => void;
   setScrollTop: (scrollTop: number) => void;
   showMore: () => void;
@@ -558,6 +565,9 @@ export const useBrowseStore = create<BrowseStore>((set, get) => {
         scrollTop: 0,
         visibleCount: GALLERY_PAGE_SIZE,
       }));
+    },
+    applyUrlFilters: (patch) => {
+      set((state) => withDimensionPatch(state, patch));
     },
     clearFilters: () => {
       set({ filters: INITIAL_BROWSE_FILTERS, scrollTop: 0, visibleCount: GALLERY_PAGE_SIZE });

--- a/src/features/community/utils/browseUrlState.test.ts
+++ b/src/features/community/utils/browseUrlState.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { INITIAL_BROWSE_FILTERS } from '../store/browseStore';
+import type { BrowseFilters } from '../store/browseStore';
+import { decodeBrowseParams, encodeBrowseParams } from './browseUrlState';
+
+const AUTHOR_ID = 'a'.repeat(32);
+
+function filters(overrides: Partial<BrowseFilters> = {}): BrowseFilters {
+  return { ...INITIAL_BROWSE_FILTERS, ...overrides };
+}
+
+function encode(overrides: Partial<BrowseFilters> = {}): string {
+  return encodeBrowseParams(filters(overrides)).toString();
+}
+
+function decode(query: string) {
+  return decodeBrowseParams(new URLSearchParams(query));
+}
+
+describe('encodeBrowseParams', () => {
+  it('emits nothing for an unfiltered gallery', () => {
+    // The common URL is /community with no query at all.
+    expect(encode()).toBe('');
+  });
+
+  it('omits each filter that is at its default', () => {
+    expect(encode({ category: 'tools' })).toBe('cat=tools');
+    expect(encode({ sort: 'newest' })).toBe('');
+    expect(encode({ likedOnly: false })).toBe('');
+  });
+
+  it('writes flags as presence rather than a value pair', () => {
+    expect(encode({ likedOnly: true, featuredOnly: true })).toBe('liked=1&featured=1');
+  });
+
+  it('writes one-sided and two-sided ranges', () => {
+    expect(encode({ widthMin: 2, widthMax: 4 })).toBe('w=2-4');
+    expect(encode({ widthMin: 2 })).toBe('w=2-');
+    expect(encode({ widthMax: 4 })).toBe('w=-4');
+    expect(encode({ depthMin: 1.5, depthMax: 3 })).toBe('d=1.5-3');
+    expect(encode({ maxHeight: 6 })).toBe('h=6');
+  });
+
+  it('carries the author id', () => {
+    expect(encode({ author: { id: AUTHOR_ID, name: 'ada' } })).toBe(`author=${AUTHOR_ID}`);
+  });
+
+  it('trims search text and never carries the whitespace-only case', () => {
+    expect(encode({ searchText: '  hex  ' })).toBe('q=hex');
+    expect(encode({ searchText: '   ' })).toBe('');
+  });
+
+  it('caps search text rather than emitting an unusable URL', () => {
+    const long = 'x'.repeat(400);
+    const value = new URLSearchParams(encode({ searchText: long })).get('q');
+    expect(value).toHaveLength(100);
+  });
+
+  it('never carries best-fit', () => {
+    // It falls back to newest the moment no dimension constraint remains, and
+    // the constraint it depends on is the sender's gap, which does not travel.
+    expect(encode({ sort: 'best-fit' })).toBe('');
+  });
+
+  it('never carries mineOnly', () => {
+    // Resolved per account: a shared link would show the recipient their own
+    // designs instead of the sender's view.
+    expect(encode({ mineOnly: true })).toBe('');
+  });
+});
+
+describe('decodeBrowseParams', () => {
+  it('round-trips a fully narrowed view', () => {
+    const original = filters({
+      searchText: 'hex',
+      category: 'tools',
+      technique: 'labelTab',
+      sort: 'prints',
+      widthMin: 2,
+      widthMax: 4,
+      depthMin: 1.5,
+      maxHeight: 6,
+      likedOnly: true,
+      recentOnly: true,
+      featuredOnly: true,
+      author: { id: AUTHOR_ID, name: 'ada' },
+    });
+    const decoded = decodeBrowseParams(encodeBrowseParams(original));
+    expect({ ...original, ...decoded }).toEqual({
+      ...original,
+      // The name is not in the URL to carry; it resolves from the index.
+      author: { id: AUTHOR_ID, name: '' },
+    });
+  });
+
+  it('resets an absent parameter to its default rather than leaving it', () => {
+    // Otherwise navigating back to an unfiltered view would keep the filters
+    // the store happened to be holding.
+    const decoded = decode('');
+    expect(decoded.category).toBeNull();
+    expect(decoded.searchText).toBe('');
+    expect(decoded.sort).toBe('newest');
+    expect(decoded.likedOnly).toBe(false);
+    expect(decoded.widthMin).toBeNull();
+    expect(decoded.author).toBeNull();
+  });
+
+  it('leaves mineOnly and the gap context untouched', () => {
+    // Absent from the patch entirely, so applying it cannot clear the
+    // viewer's own account state.
+    const decoded = decode('cat=tools&liked=1');
+    expect(decoded).not.toHaveProperty('mineOnly');
+    expect(decoded).not.toHaveProperty('fitsGapContext');
+  });
+
+  it.each([
+    ['cat=nonsense', 'category'],
+    ['tech=nonsense', 'technique'],
+    ['sort=nonsense', 'sort'],
+    [`author=${'z'.repeat(32)}`, 'author'],
+    ['author=tooshort', 'author'],
+  ])('drops the unrecognised value in %s', (query, key) => {
+    // These strings are user-editable and outlive deploys: a retired category
+    // must cost that one parameter, not the view.
+    const decoded = decode(query) as Record<string, unknown>;
+    expect(decoded[key]).toEqual(INITIAL_BROWSE_FILTERS[key as keyof BrowseFilters] ?? null);
+  });
+
+  it('never accepts best-fit from a URL', () => {
+    expect(decode('sort=best-fit').sort).toBe('newest');
+  });
+
+  it.each(['w=banana', 'w=4-2', 'w=abc-2', 'w=2-abc', 'w=1-2-3', 'w=-', 'w=0-4', 'w=1.3-4'])(
+    'drops the malformed range %s whole',
+    (query) => {
+      // Half of a crossed or unparseable range is worse than none: it renders
+      // a slider whose thumbs have swapped.
+      const decoded = decode(query);
+      expect(decoded.widthMin).toBeNull();
+      expect(decoded.widthMax).toBeNull();
+    }
+  );
+
+  it('accepts half-grid steps but not finer', () => {
+    expect(decode('w=1.5-2.5').widthMin).toBe(1.5);
+    expect(decode('h=2.5').maxHeight).toBe(2.5);
+    expect(decode('h=2.25').maxHeight).toBeNull();
+  });
+
+  it('treats any flag value as present', () => {
+    expect(decode('liked=1').likedOnly).toBe(true);
+    expect(decode('liked=0').likedOnly).toBe(true);
+    expect(decode('liked=').likedOnly).toBe(true);
+    expect(decode('').likedOnly).toBe(false);
+  });
+
+  it('keeps the rest of the view when one parameter is junk', () => {
+    const decoded = decode('cat=nonsense&tech=scoop&q=hex&liked=1');
+    expect(decoded.category).toBeNull();
+    expect(decoded.technique).toBe('scoop');
+    expect(decoded.searchText).toBe('hex');
+    expect(decoded.likedOnly).toBe(true);
+  });
+});

--- a/src/features/community/utils/browseUrlState.ts
+++ b/src/features/community/utils/browseUrlState.ts
@@ -1,0 +1,222 @@
+/**
+ * Query-string codec for the browse filters, making a narrowed gallery
+ * shareable, bookmarkable and reload-safe.
+ *
+ * Three rules shape it:
+ *
+ * - **Defaults are omitted.** An unfiltered gallery is `/community` with no
+ *   query at all, so the common URL stays clean and a shared link carries only
+ *   what the sender actually chose.
+ * - **Only state the user stated travels.** `fitsGapContext` arrives from the
+ *   layout editor and describes a gap in the sender's drawer, which means
+ *   nothing in the recipient's browser; `mineOnly` is resolved per account, so
+ *   a shared link would show the recipient their own designs rather than the
+ *   sender's view. Both are deliberately excluded, which is why decoding
+ *   returns a patch rather than a whole `BrowseFilters`.
+ * - **A bad value is dropped, never fatal.** These strings are user-editable
+ *   and outlive deploys: a category that has since been retired, or a hand-typed
+ *   `w=banana`, drops that one parameter and leaves the rest of the view intact.
+ */
+
+import { COMMUNITY_CATEGORIES } from '@/shared/types/community';
+import type { CommunityCategory } from '@/shared/types/community';
+import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
+import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
+import type { BrowseFilters, BrowseSort } from '../store/browseStore';
+import { INITIAL_BROWSE_FILTERS } from '../store/browseStore';
+import { isBrowseSort } from '../components/CommunityGalleryTab/galleryFilterOptions';
+
+/** Mirrors AUTHOR_PUBLIC_ID_RE in api/community.ts. */
+const AUTHOR_ID_RE = /^[a-f0-9]{32}$/;
+
+/**
+ * Search text is a filter, not a document: a URL carrying kilobytes of it is a
+ * broken link in most clients, and nothing in the index is matched by more.
+ */
+const MAX_SEARCH_LENGTH = 100;
+
+export const BROWSE_PARAM = {
+  search: 'q',
+  category: 'cat',
+  technique: 'tech',
+  sort: 'sort',
+  width: 'w',
+  depth: 'd',
+  height: 'h',
+  liked: 'liked',
+  recent: 'recent',
+  featured: 'featured',
+  author: 'author',
+} as const;
+
+/**
+ * The subset of filters the URL owns. Everything absent from a decoded patch
+ * is left as the store has it, so the excluded filters above survive a decode.
+ */
+type UrlOwnedKey =
+  | 'searchText'
+  | 'category'
+  | 'technique'
+  | 'sort'
+  | 'likedOnly'
+  | 'recentOnly'
+  | 'featuredOnly'
+  | 'widthMin'
+  | 'widthMax'
+  | 'depthMin'
+  | 'depthMax'
+  | 'maxHeight'
+  | 'author';
+
+// `BrowseFilters` is readonly throughout, so the patch drops the modifier to
+// be assembled field by field. It is still consumed as a plain partial.
+export type BrowseUrlPatch = {
+  -readonly [K in UrlOwnedKey]?: BrowseFilters[K];
+};
+
+function isCategory(value: string): value is CommunityCategory {
+  return (COMMUNITY_CATEGORIES as readonly string[]).includes(value);
+}
+
+function isTechnique(value: string): value is ExampleTechnique {
+  return Object.prototype.hasOwnProperty.call(TECHNIQUE_CONFIG, value);
+}
+
+/**
+ * Grid units at half steps. Rejects anything else outright rather than
+ * rounding: a bound the user did not choose is worse than no bound, because
+ * the grid would silently disagree with the URL that produced it.
+ */
+function parseUnits(raw: string): number | null {
+  if (raw === '') return null;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value * 2 === Math.round(value * 2) ? value : null;
+}
+
+function formatUnits(value: number): string {
+  return String(value);
+}
+
+/**
+ * A range is `min-max`, with either side omitted for a one-sided bound
+ * (`2-` is "at least 2", `-4` is "at most 4"). Crossed bounds are dropped
+ * whole: honouring them would render a slider whose thumbs have swapped.
+ */
+function parseRange(raw: string): { min: number | null; max: number | null } | null {
+  const parts = raw.split('-');
+  if (parts.length !== 2) return null;
+  const [lower, upper] = parts;
+  const min = parseUnits(lower);
+  const max = parseUnits(upper);
+  if (min === null && max === null) return null;
+  if (lower !== '' && min === null) return null;
+  if (upper !== '' && max === null) return null;
+  if (min !== null && max !== null && min > max) return null;
+  return { min, max };
+}
+
+function formatRange(min: number | null, max: number | null): string | null {
+  if (min === null && max === null) return null;
+  return `${min === null ? '' : formatUnits(min)}-${max === null ? '' : formatUnits(max)}`;
+}
+
+/** Present-means-true, so an inactive toggle costs no characters. */
+function readFlag(params: URLSearchParams, key: string): boolean | undefined {
+  return params.has(key) ? true : undefined;
+}
+
+export function encodeBrowseParams(filters: BrowseFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  const search = filters.searchText.trim();
+  if (search !== '') params.set(BROWSE_PARAM.search, search.slice(0, MAX_SEARCH_LENGTH));
+  if (filters.category !== null) params.set(BROWSE_PARAM.category, filters.category);
+  if (filters.technique !== null) params.set(BROWSE_PARAM.technique, filters.technique);
+  // 'best-fit' is excluded with the gap context it depends on: it falls back to
+  // 'newest' the moment no dimension constraint remains, so a recipient would
+  // land on a sort that immediately rewrites itself.
+  if (filters.sort !== INITIAL_BROWSE_FILTERS.sort && filters.sort !== 'best-fit') {
+    params.set(BROWSE_PARAM.sort, filters.sort);
+  }
+  const width = formatRange(filters.widthMin, filters.widthMax);
+  if (width !== null) params.set(BROWSE_PARAM.width, width);
+  const depth = formatRange(filters.depthMin, filters.depthMax);
+  if (depth !== null) params.set(BROWSE_PARAM.depth, depth);
+  if (filters.maxHeight !== null) params.set(BROWSE_PARAM.height, formatUnits(filters.maxHeight));
+  if (filters.likedOnly) params.set(BROWSE_PARAM.liked, '1');
+  if (filters.recentOnly) params.set(BROWSE_PARAM.recent, '1');
+  if (filters.featuredOnly) params.set(BROWSE_PARAM.featured, '1');
+  if (filters.author !== null) params.set(BROWSE_PARAM.author, filters.author.id);
+  return params;
+}
+
+export function decodeBrowseParams(params: URLSearchParams): BrowseUrlPatch {
+  const patch: BrowseUrlPatch = {
+    // Absent means default, not "leave as is": arriving on a link without a
+    // parameter has to clear whatever the store was holding, or navigating
+    // back from a narrowed view would keep its filters.
+    searchText: INITIAL_BROWSE_FILTERS.searchText,
+    category: null,
+    technique: null,
+    sort: INITIAL_BROWSE_FILTERS.sort,
+    likedOnly: false,
+    recentOnly: false,
+    featuredOnly: false,
+    widthMin: null,
+    widthMax: null,
+    depthMin: null,
+    depthMax: null,
+    maxHeight: null,
+    author: null,
+  };
+
+  const search = params.get(BROWSE_PARAM.search);
+  if (search !== null && search.trim() !== '') {
+    patch.searchText = search.trim().slice(0, MAX_SEARCH_LENGTH);
+  }
+
+  const category = params.get(BROWSE_PARAM.category);
+  if (category !== null && isCategory(category)) patch.category = category;
+
+  const technique = params.get(BROWSE_PARAM.technique);
+  if (technique !== null && isTechnique(technique)) patch.technique = technique;
+
+  const sort = params.get(BROWSE_PARAM.sort);
+  if (sort !== null && isBrowseSort(sort) && sort !== 'best-fit') {
+    patch.sort = sort satisfies BrowseSort;
+  }
+
+  const width = params.get(BROWSE_PARAM.width);
+  if (width !== null) {
+    const range = parseRange(width);
+    if (range !== null) {
+      patch.widthMin = range.min;
+      patch.widthMax = range.max;
+    }
+  }
+
+  const depth = params.get(BROWSE_PARAM.depth);
+  if (depth !== null) {
+    const range = parseRange(depth);
+    if (range !== null) {
+      patch.depthMin = range.min;
+      patch.depthMax = range.max;
+    }
+  }
+
+  const height = params.get(BROWSE_PARAM.height);
+  if (height !== null) patch.maxHeight = parseUnits(height);
+
+  patch.likedOnly = readFlag(params, BROWSE_PARAM.liked) ?? false;
+  patch.recentOnly = readFlag(params, BROWSE_PARAM.recent) ?? false;
+  patch.featuredOnly = readFlag(params, BROWSE_PARAM.featured) ?? false;
+
+  const author = params.get(BROWSE_PARAM.author);
+  if (author !== null && AUTHOR_ID_RE.test(author)) {
+    // The display name is not in the URL; a cold visit resolves it from the
+    // index once one of the author's cards has loaded.
+    patch.author = { id: author, name: '' };
+  }
+
+  return patch;
+}

--- a/src/shared/hooks/useCommunityRouting.test.ts
+++ b/src/shared/hooks/useCommunityRouting.test.ts
@@ -3,9 +3,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useLabsStore } from '@/core/store';
 import {
-  getCommunityAuthorIdFromUrl,
+  getCommunityGalleryQuery,
   getCommunityDesignIdFromUrl,
-  syncCommunityAuthorParam,
+  syncCommunityGalleryQuery,
   useCommunityRouting,
 } from '@/shared/hooks/useCommunityRouting';
 
@@ -181,66 +181,66 @@ describe('useCommunityRouting', () => {
     });
   });
 
-  describe('author view query param', () => {
-    it('reads a valid ?author= on the gallery path', () => {
-      window.history.replaceState(null, '', `/community?author=${AUTHOR_ID}`);
-      expect(getCommunityAuthorIdFromUrl()).toBe(AUTHOR_ID);
+  describe('gallery query string', () => {
+    it('reads the query on the gallery path, without the leading ?', () => {
+      window.history.replaceState(null, '', `/community?author=${AUTHOR_ID}&cat=tools`);
+      expect(getCommunityGalleryQuery()).toBe(`author=${AUTHOR_ID}&cat=tools`);
     });
 
-    it('exposes the author id through the hook and re-derives it on popstate', () => {
-      window.history.replaceState(null, '', `/community?author=${AUTHOR_ID}`);
+    it('is empty off the gallery path even with a query present', () => {
+      window.history.replaceState(null, '', `/community/d/${DESIGN_ID}?author=${AUTHOR_ID}`);
+      expect(getCommunityGalleryQuery()).toBe('');
+    });
+
+    it('exposes the query through the hook and re-derives it on popstate', () => {
+      window.history.replaceState(null, '', '/community?cat=tools');
       const { result } = renderHook(() => useCommunityRouting());
-      expect(result.current.communityAuthorIdFromUrl).toBe(AUTHOR_ID);
+      expect(result.current.communityGalleryQuery).toBe('cat=tools');
       act(() => {
         window.history.replaceState(null, '', '/community');
         window.dispatchEvent(new PopStateEvent('popstate'));
       });
-      expect(result.current.communityAuthorIdFromUrl).toBeNull();
+      expect(result.current.communityGalleryQuery).toBe('');
     });
 
-    it.each(['not-an-id', 'ABCDEF', 'a'.repeat(31), 'a'.repeat(33), 'G'.repeat(32)])(
-      'rejects invalid author value %s',
-      (value) => {
-        window.history.replaceState(null, '', `/community?author=${value}`);
-        expect(getCommunityAuthorIdFromUrl()).toBeNull();
-      }
-    );
-
-    it('returns null off the gallery path even with the param present', () => {
-      window.history.replaceState(null, '', `/community/d/${DESIGN_ID}?author=${AUTHOR_ID}`);
-      expect(getCommunityAuthorIdFromUrl()).toBeNull();
-    });
-
-    it('syncCommunityAuthorParam writes, rewrites, and removes the param in place', () => {
+    it('writes, rewrites, and clears the query in place', () => {
       window.history.replaceState(null, '', '/community');
-      syncCommunityAuthorParam(AUTHOR_ID);
-      expect(window.location.search).toBe(`?author=${AUTHOR_ID}`);
-      const other = 'f'.repeat(32);
-      syncCommunityAuthorParam(other);
-      expect(window.location.search).toBe(`?author=${other}`);
-      syncCommunityAuthorParam(null);
+      syncCommunityGalleryQuery('cat=tools');
+      expect(window.location.search).toBe('?cat=tools');
+      syncCommunityGalleryQuery('cat=kitchen&liked=1');
+      expect(window.location.search).toBe('?cat=kitchen&liked=1');
+      syncCommunityGalleryQuery('');
       expect(window.location.search).toBe('');
       expect(window.location.pathname).toBe('/community');
     });
 
-    it('syncCommunityAuthorParam replaces instead of pushing history entries', () => {
+    it('replaces instead of pushing history entries', () => {
+      // Narrowing a gallery is not navigation: pushing would mean a dozen
+      // Back presses to leave a page filtered a dozen times.
       window.history.replaceState(null, '', '/community');
       const pushSpy = vi.spyOn(window.history, 'pushState');
       const replaceSpy = vi.spyOn(window.history, 'replaceState');
-      syncCommunityAuthorParam(AUTHOR_ID);
+      syncCommunityGalleryQuery('cat=tools');
       expect(pushSpy).not.toHaveBeenCalled();
       expect(replaceSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('syncCommunityAuthorParam is a no-op off the gallery path', () => {
+    it('does not touch history when the query is unchanged', () => {
+      window.history.replaceState(null, '', '/community?cat=tools');
+      const replaceSpy = vi.spyOn(window.history, 'replaceState');
+      syncCommunityGalleryQuery('cat=tools');
+      expect(replaceSpy).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op off the gallery path', () => {
       window.history.replaceState(null, '', `/community/d/${DESIGN_ID}`);
-      syncCommunityAuthorParam(AUTHOR_ID);
+      syncCommunityGalleryQuery('cat=tools');
       expect(window.location.search).toBe('');
     });
 
-    it('syncCommunityAuthorParam preserves the detail marker state', () => {
+    it('preserves the detail marker state', () => {
       window.history.replaceState({ communityRouteDetail: true }, '', '/community');
-      syncCommunityAuthorParam(AUTHOR_ID);
+      syncCommunityGalleryQuery('cat=tools');
       expect(window.history.state).toEqual({ communityRouteDetail: true });
     });
   });

--- a/src/shared/hooks/useCommunityRouting.ts
+++ b/src/shared/hooks/useCommunityRouting.ts
@@ -31,12 +31,6 @@ interface CommunityDetailHistoryState {
   communityRouteDetail?: boolean;
 }
 
-// Kept in lockstep with AUTHOR_PUBLIC_ID_REGEX in api/community.ts (the
-// 32-char hex authorPublicId derived by the publish handler).
-const AUTHOR_PUBLIC_ID_RE = /^[a-f0-9]{32}$/;
-
-const AUTHOR_PARAM = 'author';
-
 function isCommunityGalleryPath(): boolean {
   return window.location.pathname === '/community' || window.location.pathname === '/community/';
 }
@@ -57,26 +51,30 @@ export function communityDesignPath(designId: string): string {
   return `/community/d/${designId}`;
 }
 
-/** The `?author=` filter on /community, making the author view shareable. */
-export function getCommunityAuthorIdFromUrl(): string | null {
-  if (!isCommunityGalleryPath()) return null;
-  const value = new URLSearchParams(window.location.search).get(AUTHOR_PARAM);
-  return value !== null && AUTHOR_PUBLIC_ID_RE.test(value) ? value : null;
+/**
+ * The gallery's query string, making a narrowed view shareable and reload-safe.
+ * Empty off the gallery path: a detail deep link carries no query of its own,
+ * and the gallery's is restored from history when the detail closes.
+ *
+ * The meaning of these parameters belongs to the browse feature; this module
+ * only owns where they live. Returned as a string so it compares by value in a
+ * dependency array.
+ */
+export function getCommunityGalleryQuery(): string {
+  return isCommunityGalleryPath() ? window.location.search.replace(/^\?/, '') : '';
 }
 
 /**
- * Mirrors the browse store's author filter into the /community URL. Replaces
- * rather than pushes: filters keep no history entries of their own, matching
- * the other gallery filters. No-ops off the gallery path (a detail deep link
- * carries no query; the filter is restored when the gallery path returns).
+ * Mirrors the browse filters into the /community URL. Replaces rather than
+ * pushes: narrowing a gallery is not navigation, and pushing would mean a
+ * dozen Back presses to leave a page the user filtered a dozen times.
+ *
+ * replaceState fires no popstate, so this cannot feed back into the reader
+ * above and the two directions never loop.
  */
-export function syncCommunityAuthorParam(authorId: string | null): void {
+export function syncCommunityGalleryQuery(query: string): void {
   if (!isCommunityGalleryPath()) return;
-  const params = new URLSearchParams(window.location.search);
-  if (params.get(AUTHOR_PARAM) === authorId) return;
-  if (authorId === null) params.delete(AUTHOR_PARAM);
-  else params.set(AUTHOR_PARAM, authorId);
-  const query = params.toString();
+  if (getCommunityGalleryQuery() === query) return;
   window.history.replaceState(
     window.history.state,
     '',
@@ -94,15 +92,13 @@ export function useCommunityRouting() {
   const [communityDesignIdFromUrl, setCommunityDesignIdFromUrl] = useState<string | null>(
     getCommunityDesignIdFromUrl
   );
-  const [communityAuthorIdFromUrl, setCommunityAuthorIdFromUrl] = useState<string | null>(
-    getCommunityAuthorIdFromUrl
-  );
+  const [communityGalleryQuery, setCommunityGalleryQuery] = useState(getCommunityGalleryQuery);
 
   useEffect(() => {
     const handlePopState = () => {
       setIsCommunityPathActive(isCommunityPath());
       setCommunityDesignIdFromUrl(getCommunityDesignIdFromUrl());
-      setCommunityAuthorIdFromUrl(getCommunityAuthorIdFromUrl());
+      setCommunityGalleryQuery(getCommunityGalleryQuery());
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
@@ -144,8 +140,8 @@ export function useCommunityRouting() {
     /** True on /community and /community/d/<id> while community_showcase is on. */
     isCommunityRoute: communityEnabled && isCommunityPathActive,
     communityDesignIdFromUrl,
-    /** The shareable `?author=` filter, null off the gallery path or when invalid. */
-    communityAuthorIdFromUrl,
+    /** The gallery's raw query string; '' off the gallery path. */
+    communityGalleryQuery,
     openCommunityDesignUrl,
     closeCommunityDesignUrl,
   };


### PR DESCRIPTION
First of four follow-ups from the community browse audit.

Only `?author=` was ever synced to the URL. Search, category, technique, sort, size bounds and the liked/recent/featured toggles lived in memory alone, so a narrowed gallery could not be shared or bookmarked and did not survive a reload.

## What travels

`q`, `cat`, `tech`, `sort`, `w`, `d`, `h`, `liked`, `recent`, `featured`, `author`.

```
/community?q=hex&cat=tools&sort=prints&w=2-4&liked=1
```

Defaults are omitted, so an unfiltered gallery stays a bare `/community`. Ranges are `min-max` with either side droppable (`w=2-` is "at least 2"). A crossed or unparseable range is dropped whole rather than half-applied, because half of one renders a slider with its thumbs swapped.

A bad value costs its own parameter, never the view. These strings are user-editable and outlive deploys, so a retired category or a hand-typed `w=banana` drops that key and leaves the rest intact. Because the URL is re-encoded from the decoded state, it visibly self-heals: `?cat=nonsense&w=9-1&tech=scoop&q=Bit` rewrites itself to `?q=Bit&tech=scoop`.

## What deliberately does not travel

- **`fitsGapContext`** describes a gap in the sender's drawer and means nothing in a recipient's browser.
- **`mineOnly`** is resolved per account, so a shared link would show the recipient their own designs instead of the sender's view.
- **`best-fit`** depends on the gap it cannot carry, and falls back to `newest` the moment no dimension constraint remains, so a recipient would land on a sort that immediately rewrites itself.

This is why decoding returns a **patch** rather than a whole `BrowseFilters`, applied through a new `applyUrlFilters` action: a key absent from the patch is left alone, so a shared link cannot clear the viewer's own state. Everything the URL does own resets to its default when absent, or navigating back to an unfiltered view would keep whatever the store was holding.

## History behaviour

Writes use `replaceState`. Narrowing a gallery is not navigation, and pushing would mean a Back press per filter tweak just to leave the page. It also fires no popstate, which is what keeps the two directions from feeding each other: the reader only re-runs on a real popstate or on mount.

## Structure

The author-specific `getCommunityAuthorIdFromUrl` / `syncCommunityAuthorParam` pair is replaced by a generic query reader and writer. `useCommunityRouting` owns *where* the query lives; what the parameters *mean* stays in the community feature, since `shared/` cannot import from it.

## Testing

29 codec tests (round-trip, hostile input, exclusions) plus page-level integration tests. Verified in a real browser across six scenarios:

| scenario | result |
| --- | --- |
| narrow via UI | `?q=Hex&cat=tools`, 10 cards |
| reload | state and card count preserved, search box repopulated |
| cold shared link | search, category, sort and toggle all applied |
| open detail, press Back | `?q=Hex&cat=tools` restored, same 10 cards |
| three filter changes | **0** history entries added |
| junk params | dropped, valid ones kept, URL self-healed |

Full suite: 21,320 passing. The browse-layout e2e guards from #3322 still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Community gallery’s filters shareable and reload-safe by syncing the current filter state to the `/community` query. Also keeps the gallery intact when opening a detail and when pressing Back.

- **New Features**
  - Added a URL codec for gallery filters with params: `q`, `cat`, `tech`, `sort`, `w`, `d`, `h`, `liked`, `recent`, `featured`, `author`. Omits defaults, supports `min-max` ranges with either side optional, drops invalid values, and re-encodes to self-heal the URL.
  - Excludes `fitsGapContext`, `mineOnly`, and `best-fit`. Decoding returns a patch and is applied via a new `applyUrlFilters` action so personal or gap-dependent state isn’t cleared by a link. Writes use `replaceState` (no extra history or popstate loops). Detail deep links carry no query; the gallery query is restored on close. Replaced author-only handling with generic query sync in `useCommunityRouting` (`getCommunityGalleryQuery` / `syncCommunityGalleryQuery`); `CommunityPage` uses `encodeBrowseParams` / `decodeBrowseParams`. Tests and docs added.

- **Bug Fixes**
  - The reader stands down while a detail deep link owns the path, preventing filter and paging resets under the overlay.
  - `applyUrlFilters` is a no-op when a replayed query doesn’t change filters, so Back doesn’t reset paging; real filter changes still reset as before.

<sup>Written for commit 71f04a045827e8a98e0b507c40c471f2dab74932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

