### PR TITLE
fix(deps): scope every security override to the major line it floors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,14 +8,14 @@ overrides:
   '@vercel/node>undici': ^7.29.0
   undici@>=6.0.0 <6.28.0: ^6.28.0
   undici@>=7.0.0 <7.29.0: ^7.29.0
-  path-to-regexp: 6.3.0
+  path-to-regexp@>=6.0.0 <6.3.0: 6.3.0
   '@rollup/plugin-replace>magic-string': 0.30.21
   '@surma/rollup-plugin-off-main-thread>magic-string': 0.30.21
   workbox-build>@rollup/plugin-node-resolve: ^16.0.0
   '@apideck/better-ajv-errors>ajv': ^8.17.1
-  fast-uri: ^3.1.5
+  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
   sharp: ^0.35.0
-  serialize-javascript: ^7.0.3
+  serialize-javascript@>=7.0.0 <7.0.5: ^7.0.5
   eslint-plugin-react-hooks>eslint: ^10.0.3
   eslint-plugin-jsx-a11y>eslint: ^10.0.3
   eslint-plugin-jsx-a11y>minimatch: ^10.2.5
@@ -25,18 +25,19 @@ overrides:
   '@vercel/python-analysis>minimatch': ^10.2.3
   '@vercel/static-config>ajv': ^8.18.0
   glob>minimatch: ^10.2.3
-  flatted: ^3.4.2
-  dompurify: ^3.4.13
-  '@babel/core@<7.29.6': ^7.29.6
+  flatted@>=3.0.0 <3.4.2: ^3.4.2
+  dompurify@>=3.0.0 <3.4.13: ^3.4.13
+  '@babel/core@>=7.0.0 <7.29.6': ^7.29.6
   js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   js-yaml@>=3.0.0 <3.15.1: ^3.15.1
   nanoid@>=3.0.0 <3.3.17: ^3.3.17
-  protobufjs: ^7.6.4
+  protobufjs@>=7.0.0 <7.6.5: ^7.6.5
+  protobufjs@>=8.0.0 <8.6.6: ^8.6.6
   eslint-plugin-i18next>lodash: ^4.18.1
   vitest-axe>lodash-es: ^4.18.1
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
   brace-expansion@>=5.0.0 <5.0.9: ^5.0.9
-  tar@<7.5.21: ^7.5.21
+  tar@>=7.0.0 <7.5.21: ^7.5.21
   '@vercel/python-analysis>smol-toml': ^1.6.1
   esbuild: 0.28.1
 
@@ -1754,33 +1755,6 @@ packages:
 
   '@posthog/types@1.399.0':
     resolution: {integrity: sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw==}
-
-  '@protobufjs/aspromise@1.1.2':
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
-
-  '@protobufjs/base64@1.1.2':
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
-
-  '@protobufjs/codegen@2.0.5':
-    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
-
-  '@protobufjs/eventemitter@1.1.1':
-    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
-
-  '@protobufjs/fetch@1.1.1':
-    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
-
-  '@protobufjs/float@1.0.2':
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/path@1.1.2':
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
-
-  '@protobufjs/pool@1.1.0':
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-
-  '@protobufjs/utf8@1.1.2':
-    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/primitive@1.1.7':
     resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
@@ -4934,8 +4908,8 @@ packages:
   property-graph@4.1.0:
     resolution: {integrity: sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==}
 
-  protobufjs@7.6.5:
-    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+  protobufjs@8.7.1:
+    resolution: {integrity: sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
@@ -6801,7 +6775,7 @@ snapshots:
       mersenne-twister: 1.1.0
       meshoptimizer: 1.2.0
       pako: 3.0.1
-      protobufjs: 7.6.5
+      protobufjs: 8.7.1
       rbush: 4.0.1
       topojson-client: 3.1.0
       urijs: 1.19.11
@@ -7485,26 +7459,6 @@ snapshots:
       '@posthog/types': 1.399.0
 
   '@posthog/types@1.399.0': {}
-
-  '@protobufjs/aspromise@1.1.2': {}
-
-  '@protobufjs/base64@1.1.2': {}
-
-  '@protobufjs/codegen@2.0.5': {}
-
-  '@protobufjs/eventemitter@1.1.1': {}
-
-  '@protobufjs/fetch@1.1.1':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-
-  '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/path@1.1.2': {}
-
-  '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/primitive@1.1.7': {}
 
@@ -8797,7 +8751,7 @@ snapshots:
     dependencies:
       '@cesium/engine': 26.1.0
       '@cesium/widgets': 16.1.0
-      protobufjs: 7.6.5
+      protobufjs: 8.7.1
 
   chai@6.2.2: {}
 
@@ -10508,18 +10462,8 @@ snapshots:
 
   property-graph@4.1.0: {}
 
-  protobufjs@7.6.5:
+  protobufjs@8.7.1:
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.1
-      '@protobufjs/fetch': 1.1.1
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.2
-      '@types/node': 26.1.2
       long: 5.3.2
 
   punycode@2.3.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,23 +53,40 @@ peerDependencyRules:
   allowedVersions:
     vite-plugin-pwa>vite: '^8.0.0'
 
+# A security override is a FLOOR, and its selector has to say which major line
+# it floors. A bare `pkg: '^X'` matches every major, so a consumer that asks for
+# a newer major gets silently dragged DOWN to X; an unbounded `pkg@<X` matches
+# every older major, so an old consumer gets dragged UP across a breaking
+# boundary. Both read as ordinary pins and neither fails loudly. Range-scope per
+# major instead, one entry per affected line, and let OSV flag a major that has
+# no rule yet rather than guessing at one. `parent>child` entries are exempt --
+# naming the parent already bounds the blast radius.
 overrides:
   '@vercel/node>undici': '^7.29.0'
   'undici@>=6.0.0 <6.28.0': '^6.28.0'
   'undici@>=7.0.0 <7.29.0': '^7.29.0'
-  path-to-regexp: '6.3.0'
+  # GHSA-9wv6-86v2-598j — ReDoS, fixed at 6.3.0 for the 4.x-6.x range with no
+  # backport. Scoped to 6.x, the only line in the tree (@vercel/node pins 6.1.0).
+  # The 7.x and 8.x lines have their own advisories and their own fixes; a bare
+  # rule here would have pinned either of them back to 6.3.0.
+  'path-to-regexp@>=6.0.0 <6.3.0': '6.3.0'
   '@rollup/plugin-replace>magic-string': '0.30.21'
   '@surma/rollup-plugin-off-main-thread>magic-string': '0.30.21'
   'workbox-build>@rollup/plugin-node-resolve': '^16.0.0'
   '@apideck/better-ajv-errors>ajv': '^8.17.1'
-  fast-uri: '^3.1.5'
+  # ajv pins ^3.0.1; the 4.x line has separate advisories fixed at 4.1.2.
+  'fast-uri@>=3.0.0 <3.1.5': '^3.1.5'
   # sharp <0.35.0 inherits libvips CVE-2026-33327/33328/35590/35591
   # (GHSA-f88m-g3jw-g9cj). Only reachable transitively via
   # manifold-3d>@gltf-transform/functions>ndarray-pixels (build-time glTF
   # texture processing, never bundled into the browser). ndarray-pixels pins
   # sharp ^0.34.0; there is no patched 0.34.x, so force the 0.35 line.
   sharp: '^0.35.0'
-  serialize-javascript: '^7.0.3'
+  # Floor raised 7.0.3 -> 7.0.5: GHSA-qj8w-gfj5-8c6v affects [5.0.0, 7.0.5), so
+  # the old floor was itself a vulnerable version. It never resolved there --
+  # @rollup/plugin-terser asks for ^7.0.3 and gets 7.0.7 -- so OSV stayed green
+  # and the stale floor never surfaced.
+  'serialize-javascript@>=7.0.0 <7.0.5': '^7.0.5'
   'eslint-plugin-react-hooks>eslint': '^10.0.3'
   'eslint-plugin-jsx-a11y>eslint': '^10.0.3'
   # All minimatch consumers are pinned to the 10.x line, the only line pulling a
@@ -92,9 +109,10 @@ overrides:
   '@vercel/python-analysis>minimatch': '^10.2.3'
   '@vercel/static-config>ajv': '^8.18.0'
   'glob>minimatch': '^10.2.3'
-  flatted: '^3.4.2'
-  dompurify: '^3.4.13'
-  '@babel/core@<7.29.6': '^7.29.6'
+  'flatted@>=3.0.0 <3.4.2': '^3.4.2'
+  # posthog-js (^3.3.2) and @cesium/engine (^3.3.0) both sit on 3.x.
+  'dompurify@>=3.0.0 <3.4.13': '^3.4.13'
+  '@babel/core@>=7.0.0 <7.29.6': '^7.29.6'
   # GHSA-5p4m-2wfm-xmqj (quadratic CPU in !!omap resolution) is fixed in 4.3.1
   # on the 4.x line and 3.15.1 on 3.x, with no single version covering both.
   # Range-scoped per line so a 3.x consumer is bumped within its own major —
@@ -110,7 +128,17 @@ overrides:
   # major cannot be patched in place anyway — OSV would flag it and it gets its
   # own rule then. The 4.x–5.x affected range is not in the tree.
   'nanoid@>=3.0.0 <3.3.17': '^3.3.17'
-  protobufjs: '^7.6.4'
+  # The bare `protobufjs: ^7.6.4` this replaces was not latent -- it was firing.
+  # @cesium/engine asks for ^8.6.5 and was being pinned back to the 7.x line,
+  # two majors of API behind what it declares, for no security gain: 8.x resolves
+  # above its own last advisory (8.6.6) and is clean. Splitting per line lets
+  # cesium have the major it asked for and keeps a floor on each.
+  #
+  # The 7.x floor also moves 7.6.4 -> 7.6.5: GHSA-j3f2-48v5-ccww affects
+  # [7.5.0, 7.6.5), so the old floor was a vulnerable version that only stayed
+  # green because `^` resolved past it.
+  'protobufjs@>=7.0.0 <7.6.5': '^7.6.5'
+  'protobufjs@>=8.0.0 <8.6.6': '^8.6.6'
   'eslint-plugin-i18next>lodash': '^4.18.1'
   'vitest-axe>lodash-es': '^4.18.1'
   'picomatch@>=4.0.0 <4.0.4': '^4.0.4'
@@ -119,7 +147,10 @@ overrides:
   # release patched against GHSA-rgw5-rvv9-x895. The 1.x line is gone, so its old
   # `brace-expansion@<1.1.17` pin is no longer needed (#2974).
   'brace-expansion@>=5.0.0 <5.0.9': '^5.0.9'
-  'tar@<7.5.21': '^7.5.21'
+  # @mapbox/node-pre-gyp asks for ^7.4.0. Lower-bounded because tar 6.x is very
+  # common transitively and an unbounded `<7.5.21` would have forced any that
+  # appeared onto 7.x, which is an ESM/API break.
+  'tar@>=7.0.0 <7.5.21': '^7.5.21'
   '@vercel/python-analysis>smol-toml': '^1.6.1'
   esbuild: '0.28.1'
 


### PR DESCRIPTION
Follow-up to #3325. Two reviewers there caught the same bug in one override selector; this is the sweep of the rest of the block.

> Targets `main` rather than #3325's branch, so the first two commits here are #3325's and the diff shrinks to just the sweep once that merges. `ci.yml` and `osv-scan.yml` both filter `pull_request: branches: [main]`, so a PR stacked onto another branch draws no Build, test, quality, or OSV run at all — retargeted so this is actually gated. Merge #3325 first.

## The bug class

A security override is a **floor**, and its selector has to say which major line it floors. Two shapes don't:

| Shape | Matches | Failure |
|---|---|---|
| `pkg: '^X'` | every major | a consumer asking for a **newer** major is silently dragged **down** to X |
| `pkg@<X` | every older major | an old consumer is dragged **up** across a breaking boundary |

Both read as ordinary pins, and neither fails loudly — the resolution just quietly isn't what anyone declared.

## One was not latent

`protobufjs: '^7.6.4'` was **firing**. `@cesium/engine` declares `protobufjs: ^8.6.5` and was being held on the 7.x line — two majors of API behind what it asks for — with no security justification, since 8.x resolves past its own last advisory (8.6.6) and is clean.

It now gets the major it declared, and the ten `@protobufjs/*` helper packages that only 7.x needs leave the tree (1201 → 1192 entries).

## Two floors were themselves vulnerable

Masked because `^` resolved past them, not because the floor was correct:

| Override | Was | Now | Advisory |
|---|---|---|---|
| `protobufjs` | `^7.6.4` | `^7.6.5` | GHSA-j3f2-48v5-ccww — affects `[7.5.0, 7.6.5)` |
| `serialize-javascript` | `^7.0.3` | `^7.0.5` | GHSA-qj8w-gfj5-8c6v — affects `[5.0.0, 7.0.5)` |

## Changed (9 selectors)

```
path-to-regexp         6.3.0         → @>=6.0.0 <6.3.0
fast-uri               ^3.1.5        → @>=3.0.0 <3.1.5
serialize-javascript   ^7.0.3        → @>=7.0.0 <7.0.5  : ^7.0.5
flatted                ^3.4.2        → @>=3.0.0 <3.4.2
dompurify              ^3.4.13       → @>=3.0.0 <3.4.13
protobufjs             ^7.6.4        → @>=7.0.0 <7.6.5  : ^7.6.5
                                     + @>=8.0.0 <8.6.6  : ^8.6.6
@babel/core            @<7.29.6      → @>=7.0.0 <7.29.6
tar                    @<7.5.21      → @>=7.0.0 <7.5.21
```

## Deliberately left alone

- **`sharp`** (`^0.35.0`) and **`esbuild`** (`0.28.1`) — 0.x-only upstream, where a caret already scopes to a single line and the exact pin is intentional lockstep.
- The **seven already-bounded ranges** (`undici` ×2, `js-yaml` ×2, `nanoid`, `picomatch`, `brace-expansion`).
- Every **`parent>child`** entry — naming the parent bounds the blast radius on its own.

## Verification

The risk in narrowing a floor is un-flooring something load-bearing, so each overridden package's **requesters were checked for their declared ranges** before changing it — all are within-major (`ajv → fast-uri ^3.0.1`, `posthog-js → dompurify ^3.3.2`, `@mapbox/node-pre-gyp → tar ^7.4.0`, etc.), so no narrowing drops a floor that was doing cross-major work. The one exception is protobufjs, which is the finding above.

- **OSV clean** over all 1192 lockfile entries
- **Draco path exercised directly** — `processGlb` round-trip with `dracoOptions`, the exact call `gen-supporters-meshes.ts` and `gen-example-thumbnails.ts` make, since that's what reaches protobufjs through cesium. Output verified to carry `KHR_draco_mesh_compression`.
- `pnpm run build` ✅ · `size:check` ✅ (all 4 budgets) · `pnpm run quality` ✅ (0 errors)
- **18,601 unit + dom tests passing** across 1,361 files
- Only package-set change in the lockfile is `protobufjs@7.6.5 → 8.7.1` plus the ten dropped helpers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes all security overrides to the specific major lines they floor to prevent cross‑major downgrades/upgrades. Fixes an active mis‑pin in `protobufjs`, raises vulnerable floors, and keeps OSV clean while slightly reducing dependencies.

- **Bug Fixes**
  - Scoped override selectors by major to avoid `pkg: '^X'` and `pkg@<X` matching across majors.
  - `protobufjs`: split floors for 7.x and 8.x; raised 7.x floor to `^7.6.5`. `@cesium/engine` now resolves `protobufjs` 8.x as declared, and ten `@protobufjs/*` helpers drop from the tree.

- **Dependencies**
  - Raised `serialize-javascript` floor to `^7.0.5` (GHSA-qj8w-gfj5-8c6v).
  - Scoped by major: `path-to-regexp` 6.x `<6.3.0`, `fast-uri` 3.x `<3.1.5`, `flatted` 3.x `<3.4.2`, `dompurify` 3.x `<3.4.13`, `@babel/core` 7.x `<7.29.6`, `tar` 7.x `<7.5.21`.
  - Result: OSV clean; build and tests pass; lockfile now resolves `protobufjs` `8.7.1` and total entries drop from 1201 to 1192.

<sup>Written for commit e918ac5da6de897517f8ea4a573b26e1adfe4410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

