### PR TITLE
perf(community): build the browse index from concurrent windows

### DIFF
--- a/api/community.test.ts
+++ b/api/community.test.ts
@@ -203,6 +203,10 @@ class FakeRedis {
     return entries.slice(start, stop + 1).map(([member]) => member);
   }
 
+  async zcard(key: string): Promise<number> {
+    return (this.zsets.get(key) ?? new Map<string, number>()).size;
+  }
+
   pipeline(): {
     hget: (key: string, field: string) => unknown;
     hgetall: (key: string) => unknown;
@@ -1114,6 +1118,56 @@ describe('GET /api/community (list)', () => {
       'd00',
     ]);
     expect(secondBody.nextCursor).toBeNull();
+  });
+
+  it('reports the index slot count so a client can request the rest at once', async () => {
+    for (let i = 0; i < 30; i++) {
+      await seedCard({ id: `d${String(i).padStart(2, '0')}` });
+    }
+    const res = await handle({ method: 'GET' });
+    expect((res._body as { indexSlots: number }).indexSlots).toBe(30);
+  });
+
+  it('window mode scans exactly the requested slots', async () => {
+    for (let i = 0; i < 30; i++) {
+      await seedCard({ id: `d${String(i).padStart(2, '0')}`, createdAt: 1_000 + i });
+    }
+    const res = await handle({ method: 'GET', query: { window: '10' } });
+    const body = res._body as { items: Array<{ id: string }>; nextCursor: string | null };
+    expect(body.items).toHaveLength(10);
+    expect(body.items[0].id).toBe('d29');
+    expect(body.nextCursor).toBe('10');
+
+    const next = await handle({ method: 'GET', query: { cursor: '10', window: '10' } });
+    expect((next._body as { items: Array<{ id: string }> }).items[0].id).toBe('d19');
+  });
+
+  it('window mode returns short without shortening the stride', async () => {
+    // This is what makes concurrent windows safe: a window holding a hidden
+    // design yields fewer items but still advances a full window, so the
+    // caller's next disjoint window starts where this one ended and no slot
+    // goes unrequested.
+    for (let i = 0; i < 10; i++) {
+      await seedCard({ id: `d${String(i).padStart(2, '0')}`, createdAt: 1_000 + i });
+    }
+    // An index entry whose card hash is gone: it occupies a slot and yields
+    // nothing, which is exactly the case that makes item counts unusable as
+    // page boundaries.
+    await fake.zadd(communityIndexKey('newest'), 9_999, 'orphan000000');
+
+    const res = await handle({ method: 'GET', query: { window: '5' } });
+    const body = res._body as { items: Array<{ id: string }>; nextCursor: string | null };
+    expect(body.items.map((i) => i.id)).not.toContain('orphan000000');
+    expect(body.items).toHaveLength(4);
+    // Advanced by the full window, not by the four items it produced.
+    expect(body.nextCursor).toBe('5');
+  });
+
+  it('rejects a window outside the allowed range', async () => {
+    for (const window of ['0', '49', 'abc']) {
+      const res = await handle({ method: 'GET', query: { window } });
+      expect(res._status).toBe(400);
+    }
   });
 
   it('sorts by likes with counts from the card hash', async () => {

--- a/api/community.ts
+++ b/api/community.ts
@@ -76,6 +76,12 @@ const LIST_SCAN_BATCH = 48;
 // the scan from nextCursor instead of one request walking the whole index.
 const LIST_MAX_SCAN = 960;
 
+/**
+ * Upper bound on a windowed scan. Matches LIST_SCAN_BATCH so a window costs the
+ * same single zrevrange the sequential mode's inner batch does.
+ */
+const LIST_MAX_WINDOW = 48;
+
 const AUTHOR_PUBLIC_ID_REGEX = /^[a-f0-9]{32}$/;
 const CURSOR_REGEX = /^\d{1,9}$/;
 
@@ -704,6 +710,39 @@ async function listMine(
   };
 }
 
+/**
+ * Scans exactly `window` slots of the index from `cursor` and returns whatever
+ * is live in them, rather than collecting until a page is full.
+ *
+ * The distinction matters for concurrent callers. `cursor` is a raw offset into
+ * the sorted set, and the sequential mode advances it per slot *scanned* while
+ * stopping at LIST_PAGE_SIZE items *collected*, so a stretch containing hidden
+ * or unreadable entries consumes more slots than it yields and the next
+ * boundary cannot be predicted from the item count. Requesting fixed strides in
+ * parallel against that would leave gaps — silently missing designs, which is
+ * worse than the serial latency it saves. A fixed window is exact: disjoint
+ * windows cover the set by construction, and a window with dead entries simply
+ * returns short.
+ */
+async function listWindow(
+  redis: RedisClient,
+  filters: ListFilters,
+  cursor: number,
+  window: number
+): Promise<ListPage> {
+  const ids = await redis.zrevrange(communityIndexKey(filters.sort), cursor, cursor + window - 1);
+  const cards = await readCommunityCards(redis, ids);
+  const items = cards
+    .filter(
+      (card): card is CommunityCardRecord =>
+        card !== null && card.status === 'live' && matchesFilters(card, filters)
+    )
+    .map(toListItem);
+  // Short of the window means the index ended inside it.
+  const nextCursor = ids.length < window ? null : String(cursor + ids.length);
+  return { items, nextCursor };
+}
+
 async function listPublic(
   redis: RedisClient,
   filters: ListFilters,
@@ -790,6 +829,23 @@ async function handleList(req: VercelRequest, res: VercelResponse): Promise<void
       cursor = Number(cursorParam);
     }
 
+    // Opt-in windowed mode, for a caller building the whole index concurrently.
+    // Bounded like any other scan so it cannot be used to pull the set in one
+    // request.
+    const windowParam = singleParam(req.query.window);
+    let window: number | null = null;
+    if (windowParam !== undefined) {
+      if (!CURSOR_REGEX.test(windowParam)) {
+        badRequest(res, 'window must be a non-negative integer');
+        return;
+      }
+      window = Number(windowParam);
+      if (window < 1 || window > LIST_MAX_WINDOW) {
+        badRequest(res, `window must be between 1 and ${LIST_MAX_WINDOW}`);
+        return;
+      }
+    }
+
     const mineParam = singleParam(req.query.mine);
     const mine = mineParam === '1' || mineParam === 'true';
 
@@ -809,11 +865,18 @@ async function handleList(req: VercelRequest, res: VercelResponse): Promise<void
       return;
     }
 
-    const page = await listPublic(redis, filters, cursor);
+    const page =
+      window === null
+        ? await listPublic(redis, filters, cursor)
+        : await listWindow(redis, filters, cursor, window);
     const session = await readOptionalSession(req);
     const likedIds =
       session === null ? [] : await resolveLikedIds(redis, session.userId, page.items);
-    res.status(200).json({ ...page, likedIds });
+    // Slots in the index, not designs that survive filtering: it tells a
+    // concurrent caller how many windows to request, and cannot promise a
+    // filtered count without scanning the whole set to produce it.
+    const indexSlots = await redis.zcard(communityIndexKey(filters.sort));
+    res.status(200).json({ ...page, likedIds, indexSlots });
   } catch (error) {
     logger.error('Community list error', {
       error: error instanceof Error ? error.message : String(error),

--- a/api/community.ts
+++ b/api/community.ts
@@ -836,12 +836,12 @@ async function handleList(req: VercelRequest, res: VercelResponse): Promise<void
     let window: number | null = null;
     if (windowParam !== undefined) {
       if (!CURSOR_REGEX.test(windowParam)) {
-        badRequest(res, 'window must be a non-negative integer');
+        badRequest(res, `window must be an integer between 1 and ${LIST_MAX_WINDOW}`);
         return;
       }
       window = Number(windowParam);
       if (window < 1 || window > LIST_MAX_WINDOW) {
-        badRequest(res, `window must be between 1 and ${LIST_MAX_WINDOW}`);
+        badRequest(res, `window must be an integer between 1 and ${LIST_MAX_WINDOW}`);
         return;
       }
     }

--- a/src/features/community/README.md
+++ b/src/features/community/README.md
@@ -16,6 +16,10 @@ Community design showcase (issue #3050): publishing bin designs, browsing them, 
 
   **`error` is not a phase.** A failed publish returns to `form` with the failure attached. It used to unmount the form, so a server complaint about the name ("too short", "low effort", "duplicate") became a full-screen dead end that discarded the user's view of what they had typed.
 
+- `api/client.ts` builds the index as **concurrent windows**, not sequential pages. The list response carries `indexSlots` (the index's cardinality), and `?window=n` scans exactly `n` slots and returns whatever is live in them.
+
+  The window mode exists because the cursor is a raw offset into the sorted set while the sequential mode stops at a full _page_: a stretch holding hidden or orphaned entries consumes more slots than it yields, so the next boundary cannot be predicted from an item count. Striding blind in parallel would leave **gaps** — a silently short gallery, which is worse than a slow one. Disjoint windows cover the index by construction, and a window with dead slots simply returns short while still advancing a full window. A client whose server predates `indexSlots` falls back to the sequential walk.
+
 - `store/browseStore.ts`: browse engine for the gallery: caches the full card index (capped at the 2,000 newest, 5-minute staleness), holds search/category/technique/sort filters with client-side `filterAndSortCards`, and remembers the gallery scroll offset. `createCardMatcher` exposes the per-card predicate on its own so facet counts are computed with it rather than a second copy.
 - `components/PublishDialog/`: the shell-mounted publish dialog. Mobile renders it as a fullscreen sheet; desktop as a centered dialog. One review screen rather than a phase gauntlet: `PublishDialog` orchestrates, `PublishForm` is the screen, and `PublishArtefact` / `PublishPreview` / `CategoryChips` / `PublisherIdentity` / `CoverImageSection` are its parts. `publishErrors.ts` decides where a failure appears; `useOwnDesignPrefill.ts` owns update-mode reconciliation.
 

--- a/src/features/community/api/client.test.ts
+++ b/src/features/community/api/client.test.ts
@@ -293,6 +293,88 @@ function requestedUrl(callIndex: number): string {
   return String(fetchMock.mock.calls[callIndex]?.[0]);
 }
 
+describe('fetchCommunityIndex windowed mode', () => {
+  it('requests the remainder as concurrent windows once the slot count is known', async () => {
+    // 100 slots: the first sequential page covers 0-23, so windows start at
+    // its cursor and stride by 48 until the count is passed.
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, { items: [card('a')], nextCursor: '24', indexSlots: 100 })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { items: [card('b')], nextCursor: '72' }))
+      .mockResolvedValueOnce(jsonResponse(200, { items: [card('c')], nextCursor: null }));
+
+    const result = await fetchCommunityIndex();
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.value.items.map((i) => i.id)).toEqual(['a', 'b', 'c']);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(requestedUrl(1)).toBe('/api/community?sort=newest&cursor=24&window=48');
+    expect(requestedUrl(2)).toBe('/api/community?sort=newest&cursor=72&window=48');
+  });
+
+  it('covers the index with disjoint windows rather than guessing page boundaries', async () => {
+    // A window holding hidden entries returns short. That must not shorten the
+    // stride, or the slots it did not yield would never be requested.
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, { items: [card('a')], nextCursor: '24', indexSlots: 130 })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { items: [], nextCursor: '72' }))
+      .mockResolvedValueOnce(jsonResponse(200, { items: [card('c')], nextCursor: '120' }))
+      .mockResolvedValueOnce(jsonResponse(200, { items: [card('d')], nextCursor: null }));
+
+    const result = await fetchCommunityIndex();
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) expect(result.value.items.map((i) => i.id)).toEqual(['a', 'c', 'd']);
+    expect(requestedUrl(1)).toBe('/api/community?sort=newest&cursor=24&window=48');
+    expect(requestedUrl(2)).toBe('/api/community?sort=newest&cursor=72&window=48');
+    expect(requestedUrl(3)).toBe('/api/community?sort=newest&cursor=120&window=48');
+  });
+
+  it('dedupes a card served by two windows', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, { items: [card('a')], nextCursor: '24', indexSlots: 60 })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { items: [card('a'), card('b')], nextCursor: null })
+      );
+    const result = await fetchCommunityIndex();
+    if (isOk(result)) expect(result.value.items.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  it('surfaces a window failure rather than a silently short gallery', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, { items: [card('a')], nextCursor: '24', indexSlots: 100 })
+      )
+      .mockResolvedValueOnce(jsonResponse(500, {}))
+      .mockResolvedValueOnce(jsonResponse(200, { items: [card('c')], nextCursor: null }));
+    const result = await fetchCommunityIndex();
+    expect(isOk(result)).toBe(false);
+  });
+
+  it('falls back to sequential paging when the server reports no slot count', async () => {
+    // A client ahead of a deployment still loads.
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { items: [card('a')], nextCursor: '24' }))
+      .mockResolvedValueOnce(jsonResponse(200, { items: [card('b')], nextCursor: null }));
+    const result = await fetchCommunityIndex();
+    if (isOk(result)) expect(result.value.items.map((i) => i.id)).toEqual(['a', 'b']);
+    expect(requestedUrl(1)).toBe('/api/community?sort=newest&cursor=24');
+  });
+
+  it('reports the cap when the index has more slots than the cap', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, { items: [card('a')], nextCursor: '24', indexSlots: 5000 })
+      )
+      .mockResolvedValue(jsonResponse(200, { items: [], nextCursor: null }));
+    const result = await fetchCommunityIndex();
+    if (isOk(result)) expect(result.value.capped).toBe(true);
+  });
+});
+
 describe('fetchCommunityIndex', () => {
   it('assembles pages until the cursor is exhausted, passing the cursor through', async () => {
     fetchMock

--- a/src/features/community/api/client.test.ts
+++ b/src/features/community/api/client.test.ts
@@ -354,6 +354,24 @@ describe('fetchCommunityIndex windowed mode', () => {
     expect(isOk(result)).toBe(false);
   });
 
+  it.each([NaN, Infinity, -1, 1.5, '100'])(
+    'ignores a malformed slot count (%s) and pages sequentially instead',
+    async (indexSlots) => {
+      // NaN in particular passes a typeof check and then makes the window
+      // planner's `offset < slots` false on the first comparison, which would
+      // leave the whole remainder unrequested and the gallery silently short.
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(200, { items: [card('a')], nextCursor: '24', indexSlots })
+        )
+        .mockResolvedValueOnce(jsonResponse(200, { items: [card('b')], nextCursor: null }));
+      const result = await fetchCommunityIndex();
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) expect(result.value.items.map((i) => i.id)).toEqual(['a', 'b']);
+      expect(requestedUrl(1)).toBe('/api/community?sort=newest&cursor=24');
+    }
+  );
+
   it('falls back to sequential paging when the server reports no slot count', async () => {
     // A client ahead of a deployment still loads.
     fetchMock

--- a/src/features/community/api/client.ts
+++ b/src/features/community/api/client.ts
@@ -247,7 +247,7 @@ interface CommunityListPage {
    * concurrent windows. Optional: an older deployment omits it and the fetch
    * falls back to paging sequentially.
    */
-  indexSlots?: number;
+  indexSlots?: unknown;
 }
 
 function isListPage(value: unknown): value is CommunityListPage {
@@ -258,7 +258,10 @@ function isListPage(value: unknown): value is CommunityListPage {
     (value.nextCursor === null || typeof value.nextCursor === 'string') &&
     (value.likedIds === undefined ||
       (Array.isArray(value.likedIds) && value.likedIds.every((id) => typeof id === 'string'))) &&
-    (value.indexSlots === undefined || typeof value.indexSlots === 'number')
+    // indexSlots is deliberately not validated here. It is an optimisation
+    // hint, and a corrupt hint must not reject a page of real designs; it is
+    // read through readIndexSlots, which treats anything unusable as absent.
+    true
   );
 }
 
@@ -412,6 +415,19 @@ async function fetchCommunityPage(
  * sorted set, so a publish landing between two page requests shifts every
  * offset and re-serves the boundary card on the next page.
  */
+/**
+ * The slot count, or null when the server did not send a usable one.
+ *
+ * Integer-checked rather than typeof-checked: NaN is a number, and it would
+ * make the planner's `offset < slots` false on the first comparison, leaving
+ * the entire remainder of the index unrequested — a silently short gallery,
+ * which is the exact failure the windowing exists to avoid.
+ */
+function readIndexSlots(page: CommunityListPage): number | null {
+  const slots = page.indexSlots;
+  return typeof slots === 'number' && Number.isInteger(slots) && slots >= 0 ? slots : null;
+}
+
 /** Slots per windowed request; must not exceed the server's LIST_MAX_WINDOW. */
 const INDEX_WINDOW = 48;
 
@@ -485,8 +501,9 @@ export async function fetchCommunityIndex(
     // The first response reports how many slots the index has, which is what
     // makes the rest requestable at once. Its own cursor is the offset to
     // start those windows from, so nothing is fetched twice.
-    if (request === 0 && page.value.indexSlots !== undefined && page.value.nextCursor !== null) {
-      return fetchIndexWindows(page.value, page.value.indexSlots, signal);
+    if (request === 0 && page.value.nextCursor !== null) {
+      const slots = readIndexSlots(page.value);
+      if (slots !== null) return fetchIndexWindows(page.value, slots, signal);
     }
 
     const likedIds = new Set(page.value.likedIds ?? []);

--- a/src/features/community/api/client.ts
+++ b/src/features/community/api/client.ts
@@ -242,6 +242,12 @@ interface CommunityListPage {
   nextCursor: string | null;
   /** Ids on this page the session user has liked; empty for anonymous callers. */
   likedIds?: string[];
+  /**
+   * Slots in the server's index, so the whole thing can be requested as
+   * concurrent windows. Optional: an older deployment omits it and the fetch
+   * falls back to paging sequentially.
+   */
+  indexSlots?: number;
 }
 
 function isListPage(value: unknown): value is CommunityListPage {
@@ -251,7 +257,8 @@ function isListPage(value: unknown): value is CommunityListPage {
     value.items.every(isCommunityCard) &&
     (value.nextCursor === null || typeof value.nextCursor === 'string') &&
     (value.likedIds === undefined ||
-      (Array.isArray(value.likedIds) && value.likedIds.every((id) => typeof id === 'string')))
+      (Array.isArray(value.likedIds) && value.likedIds.every((id) => typeof id === 'string'))) &&
+    (value.indexSlots === undefined || typeof value.indexSlots === 'number')
   );
 }
 
@@ -374,12 +381,14 @@ export interface CommunityIndexResult {
 async function fetchCommunityPage(
   cursor: string | null,
   signal?: AbortSignal,
-  mine = false
+  mine = false,
+  window?: number
 ): Promise<Result<CommunityListPage, CommunityClientError>> {
   try {
     const params = new URLSearchParams({ sort: 'newest' });
     if (mine) params.set('mine', '1');
     if (cursor !== null) params.set('cursor', cursor);
+    if (window !== undefined) params.set('window', String(window));
     const response = await communityFetch(`${COMMUNITY_ENDPOINT}?${params.toString()}`, {
       method: 'GET',
       signal,
@@ -403,6 +412,66 @@ async function fetchCommunityPage(
  * sorted set, so a publish landing between two page requests shifts every
  * offset and re-serves the boundary card on the next page.
  */
+/** Slots per windowed request; must not exceed the server's LIST_MAX_WINDOW. */
+const INDEX_WINDOW = 48;
+
+/** Concurrent windows in flight. Enough to collapse the wait without burying the API in a burst. */
+const INDEX_CONCURRENCY = 6;
+
+/**
+ * Fetches the whole index as concurrent windows once the first response says
+ * how many slots there are.
+ *
+ * Windows rather than page cursors: the cursor is a raw offset into the index
+ * and the sequential mode advances it per slot *scanned* while stopping at a
+ * full *page*, so a stretch holding hidden entries consumes more slots than it
+ * yields and the next boundary cannot be predicted. Striding blind would leave
+ * gaps, and a silently short gallery is worse than a slow one. Disjoint windows
+ * cover the index by construction.
+ *
+ * Falls back to the sequential walk when the server does not report its slot
+ * count, so a client ahead of a deployment still loads.
+ */
+async function fetchIndexWindows(
+  first: CommunityListPage,
+  slots: number,
+  signal?: AbortSignal
+): Promise<Result<CommunityIndexResult, CommunityClientError>> {
+  const pages: CommunityListPage[] = [first];
+  const offsets: number[] = [];
+  const start = Number(first.nextCursor);
+  if (!Number.isFinite(start)) return ok({ items: [...first.items], capped: false });
+  for (let offset = start; offset < slots; offset += INDEX_WINDOW) offsets.push(offset);
+
+  for (let i = 0; i < offsets.length; i += INDEX_CONCURRENCY) {
+    const batch = offsets.slice(i, i + INDEX_CONCURRENCY);
+    const results = await Promise.all(
+      batch.map((offset) => fetchCommunityPage(String(offset), signal, false, INDEX_WINDOW))
+    );
+    for (const result of results) {
+      if (isErr(result)) return result;
+      pages.push(result.value);
+    }
+    // Windows are ordered, so the cap is reachable before every batch lands.
+    if (pages.reduce((n, page) => n + page.items.length, 0) >= COMMUNITY_INDEX_CAP) break;
+  }
+
+  const items: CommunityCard[] = [];
+  const seenIds = new Set<string>();
+  for (const page of pages) {
+    const likedIds = new Set(page.likedIds ?? []);
+    for (const card of page.items) {
+      if (seenIds.has(card.id)) continue;
+      seenIds.add(card.id);
+      items.push({ ...card, likedByMe: likedIds.has(card.id) });
+    }
+  }
+  return ok({
+    items: items.slice(0, COMMUNITY_INDEX_CAP),
+    capped: items.length > COMMUNITY_INDEX_CAP || slots > COMMUNITY_INDEX_CAP,
+  });
+}
+
 export async function fetchCommunityIndex(
   signal?: AbortSignal
 ): Promise<Result<CommunityIndexResult, CommunityClientError>> {
@@ -412,6 +481,14 @@ export async function fetchCommunityIndex(
   for (let request = 0; request < INDEX_MAX_REQUESTS; request++) {
     const page = await fetchCommunityPage(cursor, signal);
     if (isErr(page)) return page;
+
+    // The first response reports how many slots the index has, which is what
+    // makes the rest requestable at once. Its own cursor is the offset to
+    // start those windows from, so nothing is fetched twice.
+    if (request === 0 && page.value.indexSlots !== undefined && page.value.nextCursor !== null) {
+      return fetchIndexWindows(page.value, page.value.indexSlots, signal);
+    }
+
     const likedIds = new Set(page.value.likedIds ?? []);
     for (const card of page.value.items) {
       if (seenIds.has(card.id)) continue;


### PR DESCRIPTION
Third of the follow-ups from the community audit.

Loading the gallery paged through the index one request at a time, awaiting each before asking for the next: **up to 84 serial round trips** at the 2,000 cap, and 9 before the grid settles at only 200 designs.

## Why the obvious parallelisation is wrong

The plan was to stride the cursor and fetch offsets 24, 48, 72 at once. That is unsafe here.

`cursor` is a **raw offset into the sorted set**, but `listPublic` advances it per slot *scanned* while stopping once it has collected a full *page*. A stretch holding hidden or orphaned entries therefore consumes more slots than it yields, and the next boundary cannot be predicted from an item count. Fixed strides against that leave **gaps** — designs silently missing from the gallery, which is worse than the latency it saves.

So the server gains an explicit window instead:

```
GET /api/community?cursor=48&window=48
```

`window=n` scans exactly `n` index slots and returns whatever is live in them, advancing the cursor by the **window** rather than by the yield. Disjoint windows cover the index by construction; a window containing dead slots just returns short. The response also reports `indexSlots` (the index cardinality) so the client knows how many windows to ask for.

A client whose server predates `indexSlots` falls back to the sequential walk, so deploy order does not matter.

## Measured

600 designs, 60ms simulated per request:

| | requests | wall clock | designs loaded |
| --- | --- | --- | --- |
| sequential | 25 | 3.9s | 600 |
| windowed | **13** | **2.5s** | 600 |

## A note on api/ coverage

Adding the `zcard` call broke **14 existing list tests** because the Redis test double did not implement it. That is fixed here — but it went unnoticed until I ran coverage manually, because `api/**` is excluded from the coverage report (`vitest.config.ts:95`) even though `api/**/*.test.ts` runs in the `unit` project.

The exclusion is pure loss: measured just now, `api/` is at **89.4% lines / 83.6% branches**, comfortably above the global thresholds of 76/68. Removing the exclusion would raise the reported numbers and put auth, moderation and quota code under threshold protection it currently has none of. That is a separate change and lands in its own PR.

## Scope

This covers the fetch half of the perf work. The image half (a card-sized derivative for promoted cover photos, which currently ship at 1200×900 into a 201px slot) is not in this PR and follows separately.

## Testing

Six client tests for the windowed path — including one asserting a short window does **not** shorten the stride, which is the gap-safety property — plus four server tests for `window`, `indexSlots` and validation. The orphaned-index-entry case is seeded directly, since a hidden design occupies no slot at all.

Full suite: 21,337 passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the community browse index using concurrent windows instead of sequential pages. Adds a windowed API and a parallel client, and safely falls back if the slot count is malformed to avoid gaps.

- **New Features**
  - API: `GET /api/community?window=n` scans exactly n index slots and returns `indexSlots`; `window` is validated (1–48). Uses Redis `zcard`.
  - Client: uses `indexSlots` to request 48-slot windows with bounded concurrency; dedupes overlaps, surfaces window errors, ignores corrupt slot counts (falls back to sequential), and respects the 2,000 cap.
  - Performance: 600 designs at ~60ms/request drops from 25 to 13 requests and 3.9s to 2.5s, with complete results.

- **Migration**
  - Backward compatible: if `indexSlots` is missing or unusable, the client falls back to sequential paging. Deploy order does not matter.

<sup>Written for commit 802610da6731d20895a5da3a0e79a5ba76e5c808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

