### PR TITLE
test: measure api/ in coverage and refresh the thresholds

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -92,15 +92,21 @@ export default defineConfig({
         '**/*.config.*',
         '**/types.ts',
         '**/index.ts',
-        'api/**',
+        // api/ is NOT excluded. Its tests already run in the unit project, so
+        // excluding it only suppressed the report: a well-covered, security-
+        // sensitive surface (auth, moderation, quotas, rate limits) sat under
+        // no threshold at all, and a regression there registered as nothing.
         'src/shell/Collab/**',
         'src/shared/hooks/usePresence.ts',
       ],
+      // Set just under what the suite actually achieves (84.0 / 77.3 / 80.9 /
+      // 82.5), leaving room for ordinary churn. They had drifted 6-9 points
+      // below reality, so a real regression could land without tripping one.
       thresholds: {
-        lines: 76,
-        branches: 68,
-        functions: 74,
-        statements: 75,
+        lines: 82,
+        branches: 75,
+        functions: 79,
+        statements: 81,
       },
     },
     projects: [


### PR DESCRIPTION
`api/**` was excluded from the coverage report (`vitest.config.ts`) while `api/**/*.test.ts` has been running in the `unit` project the whole time. The exclusion suppressed the *measurement*, not the work.

That left the most security-sensitive surface in the repo — auth, moderation, quotas, rate limits, the community and share endpoints — under no coverage threshold at all. A regression there registered as nothing.

## It was never a coverage liability

Measured in isolation, `api/` is *better* covered than the bar it was being kept out of:

| | api/ | old global threshold |
| --- | --- | --- |
| Lines | **89.4%** | 76 |
| Statements | **87.3%** | 75 |
| Branches | **83.6%** | 68 |
| Functions | **90.7%** | 74 |

## The thresholds had also drifted

Including `api/` barely moves the global numbers, because the two are similarly covered. What the measurement did surface is that the thresholds were 6-9 points below what the suite already achieves:

| | threshold (before) | actual | threshold (now) |
| --- | --- | --- | --- |
| Lines | 76 | 84.0 | **82** |
| Statements | 75 | 82.5 | **81** |
| Branches | 68 | 77.3 | **75** |
| Functions | 74 | 80.9 | **79** |

An 8-point gap is room for a real regression to land without tripping anything. The new values sit just under the measured figures, leaving headroom for ordinary churn.

## Why now

Adding a `zcard` call in #3330 broke **14 existing api list tests** — the Redis test double did not implement it. Nothing in the coverage report would have shown that, and I only caught it by running coverage over `api/` by hand.

Verified locally: full suite with coverage passes the new thresholds (exit 0, 21,342 tests).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `api/**` in coverage reporting and raise the global thresholds to align with what the suite already achieves. This holds auth/moderation/rate-limit endpoints to coverage budgets and reduces the chance of silent regressions.

- **Refactors**
  - Stop excluding `api/**` from coverage in `vitest.config.ts`; tests already ran, now they count.
  - Update thresholds: lines 82, statements 81, branches 75, functions 79 (just under current 84.0 / 82.5 / 77.3 / 80.9).

<sup>Written for commit 32a4fd907575432bc5a18824ae51acdc0aac63b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

