### PR TITLE
ci: give each main commit its own concurrency group so its run can finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,28 @@ on:
 permissions:
   contents: read
 
+# A PR shares one group across its pushes and cancels the superseded run: once
+# the branch moves, the older result is worthless. Main gets a group PER COMMIT
+# instead, so a push there can never cancel the one before it. Every commit on
+# main is a release candidate and its run is the only full-suite signal that
+# commit will ever get, so cancelling threw away the answer rather than an
+# obsolete one.
+#
+# Cancelling on main was near-total, not occasional: release-please pushes its
+# release commit within a minute of the merge that triggered it, and the main
+# suite takes ~30 minutes, so almost every run was killed by the next push. The
+# tell is `Unit Tests Complete: failure` under an otherwise all-`cancelled` run
+# — the gate is `if: always()`, so it outlives its own cancelled dependencies and
+# then fails them for not being `success`. Main read as red because nothing had
+# finished, which looks identical to a real failure at a glance.
+#
+# Per-commit groups rather than one queue: main runs are independent, and
+# serialising them would put each behind ~30 minutes of backlog during a burst of
+# merges. Only `github.sha`/`ref`/`event_name` appear here, all trusted — gating
+# on the commit MESSAGE would be attacker-influenceable, since a PR title becomes
+# the squash commit subject.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'other' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,12 @@ permissions:
   contents: read
   security-events: write
 
+# Per-commit group on push so a main commit's analysis is never cancelled by the
+# next one; PRs keep sharing a group and cancelling superseded runs. See ci.yml
+# for the full rationale — release-please pushes land inside the run window, so a
+# ref-keyed group meant main's scans were routinely killed before finishing.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'other' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -13,8 +13,13 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+# Per-commit group on push, so the BLOCKING main scan is never cancelled by the
+# next push; PRs keep sharing a group and cancelling superseded runs. A cancelled
+# blocking scan is the worst case here: it reports neither pass nor fail, so a
+# lockfile regression on main could land with no scan ever completing on it. See
+# ci.yml for the full rationale.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'other' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Main's unit tests have not been completing. Not flaking — being **cancelled**, almost every time.

## What was happening

Every workflow keyed its concurrency group on `github.ref`, which is `refs/heads/main` for *every* push to main. With `cancel-in-progress: true`, each push cancelled the run of the one before it.

release-please pushes its release commit within ~1 minute of the merge that triggered it, and the main suite takes **29–36 minutes**. So the release commit reliably killed the feature merge's run, and the next merge killed that one.

**Of the last six runs on main, six were cancelled** — including commits unrelated to whatever landed next:

```
cancelled  1901e51b1    cancelled  0b8248da5
cancelled  87de8621a    cancelled  8b85d62ea
cancelled  2eb668145    cancelled  abe5373e5
```

## Why it looked like a failure instead of a gap

`Unit Tests Complete` is `if: always()`, so it outlives its own cancelled dependencies and then fails them for not being `success`. Main showed a **red gate over an all-cancelled run** — at a glance indistinguishable from a real break, while the suite it gates had not actually run in some time.

That's the worst shape for a CI gap: it isn't silent (it's red), but the red means "nothing finished," not "something broke," and nothing in the UI distinguishes the two.

## The fix

Push events add `github.sha` to the group, so main commits never share one and nothing cancels anything:

```
push   commit A  →  CI-refs/heads/main-aaaa111   ┐ distinct groups,
push   commit B  →  CI-refs/heads/main-bbbb222   ┘ neither cancels

PR #10 push 1    →  CI-refs/pull/10/merge-other  ┐ shared group,
PR #10 push 2    →  CI-refs/pull/10/merge-other  ┘ supersede preserved
```

Pull requests are **unchanged** — still one group per ref, still cancelling superseded runs, which is what that setting is for.

Per-commit groups rather than one un-cancelled queue: main runs don't depend on each other, and serialising them would put each behind ~30 minutes of backlog whenever merges cluster.

## Applied to three workflows

| Workflow | Had the bug | Now |
|---|---|---|
| `ci.yml` | ✅ | per-commit group on push |
| `codeql.yml` | ✅ | per-commit group on push |
| `osv-scan.yml` | ✅ | per-commit group on push |

The OSV one is the most damaging of the three: a cancelled **blocking** scan reports neither pass nor fail, so a lockfile regression could land on main with no scan ever completing against it. That is exactly the guarantee SECURITY.md's "main fails closed" claim rests on.

## Deliberately not included

- **`release.yml`** also cancels on `github.ref`. Cancelling a partially completed *release* is a different and more delicate problem than cancelling a test run, so it wants its own change rather than being folded in here.
- **Skipping the suite on release commits.** release-please commits only touch `.release-please-manifest.json`, `CHANGELOG.md`, and the `package.json` version — they cannot change a test outcome, so running the full 30-minute suite on them is pure waste. The obvious gate is the commit message, which is **attacker-influenceable**: a PR title becomes the squash commit subject, so anyone could title a PR `chore(main): release …` and skip main's suite. Left out rather than introducing that. Only `github.sha` / `ref` / `event_name` appear in this diff, all trusted.

## Verification

Expression semantics confirmed by simulation (GitHub's `&&`/`||` return the operand, not a boolean, so `event_name == 'push' && sha || 'other'` yields the sha on push and `'other'` elsewhere), and all three files verified to parse. The real proof is post-merge: main's next run should reach a conclusion instead of `cancelled`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops main CI runs from cancelling each other by giving each push its own concurrency group keyed by `github.sha`. Applied to `ci.yml`, `codeql.yml`, and `osv-scan.yml` so tests and scans can finish.

- **Bug Fixes**
  - Root cause: concurrency groups keyed only on `github.ref` with `cancel-in-progress: true` made each main push cancel the previous run.
  - Fix: on push events, add `github.sha` to the group (`${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'other' }}`); PRs keep shared groups to cancel superseded runs.
  - Impact: main runs now reach a conclusion; removes the false “red gate” from all-cancelled runs. Prevents the blocking OSV scan from being cancelled before it can report.
  - Not included: `release.yml` left unchanged; skipping tests on release commits is not added due to commit message spoofing risk.

<sup>Written for commit 451fc3a4d263bda08982023fa0f96e6090e5cee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

