### PR TITLE
ci(release): queue release runs instead of cancelling them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,27 @@ permissions:
   contents: write
   pull-requests: write
 
+# Deliberately the OPPOSITE of ci.yml's per-commit groups. Two release-please
+# runs against the same branch would race on the same release PR and the same
+# tag, so these must stay mutually exclusive: one shared group, and they QUEUE.
+#
+# `cancel-in-progress: false` because the job below is a stateful sequence, not
+# an idempotent check. release-please creates or updates the release PR, and only
+# then does a separate step approve it and a third enable auto-merge — the last
+# one looping up to six times with 10s sleeps while the PR's required checks
+# register. A cancel anywhere after the first step leaves the release PR created
+# but never approved and never set to auto-merge, which is exactly the "release
+# PR sits open, no versions ship" stall in the release-and-ci skill. Pushes to
+# main land seconds apart during a merge burst, and that ~50s retry window is
+# wide open to them.
+#
+# Queueing is affordable here in a way it would not be in ci.yml: this run takes
+# about a minute, so the queue drains as fast as merges arrive. Sequential runs
+# are also the intended usage — each one reconciles the release PR against
+# current main, so the last to run produces the correct result.
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release-please:


### PR DESCRIPTION
Completes the concurrency sweep from #3335 — but with the **opposite** resolution, because the constraint here is the reverse.

## Why not the #3335 fix

| | `ci.yml` | `release.yml` |
|---|---|---|
| Runs are | independent checks | a stateful, order-dependent sequence |
| Two at once is | fine — faster | **a race** on the same release PR and tag |
| Fix | per-commit group → parallel | shared group, `cancel-in-progress: false` → **queue** |

Giving release runs per-commit groups would let two release-please invocations run against the same branch simultaneously, racing on the same release PR and the same tag. They have to stay mutually exclusive. The bug isn't that they share a group — it's that they *cancel*.

## What cancelling breaks

`release-please` is a four-step sequence, not an idempotent check:

1. Generate App Token
2. `release-please-action` — creates or updates the release PR
3. **Auto-approve** the release PR
4. **Auto-merge** — loops up to 6× with 10s sleeps while required checks register

A cancel anywhere after step 2 leaves the release PR **created but never approved and never set to auto-merge**. That is precisely the symptom the `release-and-ci` skill has a recipe for:

> Symptom: a `chore(main): release gridfinity-layout-tool x.y.z` PR sits open; no versions ship.

That recipe lists two usual causes — expired App credentials, and a newly-added required check missing the `release-please--` skip guard. **Cancellation was a third and isn't in the list.** Step 4's retry window alone is ~50 seconds, and pushes to main land seconds apart during a merge burst.

## How often

Rarely — the run takes about a minute, so the window is narrow. **1 cancelled in the last 30 runs**, when a push landed 31s into the previous one:

```
success    a9e05ab2f   04:38:06   ← this push
cancelled  6f709dcbc   04:37:35   ← killed this run, 31s in
```

Rare but expensive: the failure mode needs manual intervention (merge the release PR by hand) and presents as "releases mysteriously stopped."

## Why queueing is fine here

It would not be in `ci.yml` — serialising a ~30-minute suite would build a backlog, which is why that one went parallel. This run is ~1 minute, so the queue drains as fast as merges arrive. Sequential execution is also release-please's intended usage: each run reconciles the release PR against current `main`, so the last to run produces the correct result.

## Not included

The **Auto-approve** step interpolates `${{ fromJSON(steps.release.outputs.pr).number }}` straight into its `run:` block, while the Auto-merge step directly below it uses the safer `env:` + `"$PR_NUMBER"` pattern. It isn't a live vulnerability — the value is a PR number from a trusted action, and `run:` (unlike `env:`) is only evaluated when the step actually executes, so it also dodges the `fromJSON('')` trap that forced the guard on the merge step. Left out to keep a release-path change single-purpose and easy to revert; worth a follow-up so the two adjacent steps stop disagreeing about the pattern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queue release runs instead of cancelling in-progress ones to prevent orphaned release PRs and ensure deterministic releases. This keeps `release-please` runs mutually exclusive without races on the same PR or tag.

- **Bug Fixes**
  - Set a shared concurrency group in release.yml with `cancel-in-progress: false` to queue pushes.
  - Prevents cancelling a stateful sequence that could leave the PR created but not approved/auto-merged.
  - No change to ci.yml; only the release workflow is affected.

<sup>Written for commit 1ea14d4d6b6859798f05156b07717f9edbab6735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

