### PR TITLE
fix(bin-designer): guard three stale-index faults in the path vertex editor

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/keyboardHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/keyboardHandler.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Cutout } from '@/features/bin-designer/types';
+import type { InteractionMode } from '../useCutoutInteraction';
+import { handleCutoutKeyDown } from './keyboardHandler';
+import type { KeyboardHandlerContext } from './keyboardHandler';
+
+function makeCutout(overrides: Partial<Cutout> = {}): Cutout {
+  return {
+    id: 'c1',
+    shape: 'rectangle',
+    x: 10,
+    y: 20,
+    width: 30,
+    depth: 20,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+    ...overrides,
+  };
+}
+
+type Ctx = KeyboardHandlerContext & {
+  deleteSelected: ReturnType<typeof vi.fn>;
+  deselectAll: ReturnType<typeof vi.fn>;
+  selectAll: ReturnType<typeof vi.fn>;
+  nudgeSelected: ReturnType<typeof vi.fn>;
+  copySelected: ReturnType<typeof vi.fn>;
+  pasteFromClipboard: ReturnType<typeof vi.fn>;
+  duplicateSelected: ReturnType<typeof vi.fn>;
+  onUndo: ReturnType<typeof vi.fn>;
+  onRedo: ReturnType<typeof vi.fn>;
+  onGroup: ReturnType<typeof vi.fn>;
+  onUngroup: ReturnType<typeof vi.fn>;
+  onUpdate: ReturnType<typeof vi.fn>;
+  onUpdateBatch: ReturnType<typeof vi.fn>;
+  onLock: ReturnType<typeof vi.fn>;
+  onUnlock: ReturnType<typeof vi.fn>;
+  setPreview: ReturnType<typeof vi.fn>;
+  clearActiveGuides: ReturnType<typeof vi.fn>;
+  clearDrawingPreview: ReturnType<typeof vi.fn>;
+  clearPathDrawingPreview: ReturnType<typeof vi.fn>;
+  setPathDrawingPreview: ReturnType<typeof vi.fn>;
+  setMode: ReturnType<typeof vi.fn>;
+  setSegmentHover: ReturnType<typeof vi.fn>;
+  setSelection: ReturnType<typeof vi.fn>;
+};
+
+function makeCtx(overrides: Partial<KeyboardHandlerContext> = {}): Ctx {
+  return {
+    selection: new Set<string>(),
+    cutouts: [],
+    mode: { type: 'idle' },
+    deleteSelected: vi.fn(),
+    deselectAll: vi.fn(),
+    selectAll: vi.fn(),
+    nudgeSelected: vi.fn(),
+    copySelected: vi.fn(),
+    pasteFromClipboard: vi.fn(),
+    duplicateSelected: vi.fn(),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+    onGroup: vi.fn(),
+    onUngroup: vi.fn(),
+    onUpdate: vi.fn(),
+    onUpdateBatch: vi.fn(),
+    onLock: vi.fn(),
+    onUnlock: vi.fn(),
+    setPreview: vi.fn(),
+    clearActiveGuides: vi.fn(),
+    clearDrawingPreview: vi.fn(),
+    clearPathDrawingPreview: vi.fn(),
+    setPathDrawingPreview: vi.fn(),
+    setMode: vi.fn(),
+    setSegmentHover: vi.fn(),
+    setSelection: vi.fn(),
+    ...overrides,
+  } as Ctx;
+}
+
+interface KeyOptions {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  tagName?: string;
+}
+
+function press(key: string, options: KeyOptions = {}): KeyboardEvent {
+  const { tagName = 'DIV', ...flags } = options;
+  const event = {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    ...flags,
+    target: { tagName },
+    preventDefault: vi.fn(),
+    stopImmediatePropagation: vi.fn(),
+  };
+  return event as unknown as KeyboardEvent;
+}
+
+describe('handleCutoutKeyDown — typing guard', () => {
+  it.each(['INPUT', 'TEXTAREA'])('ignores every shortcut while typing in %s', (tagName) => {
+    // Otherwise typing "r" in a label field rotates the selection.
+    const ctx = makeCtx({ selection: new Set(['c1']), cutouts: [makeCutout()] });
+    for (const key of ['Delete', 'r', 'Escape', 'ArrowLeft']) {
+      handleCutoutKeyDown(press(key, { tagName }), ctx);
+    }
+    expect(ctx.deleteSelected).not.toHaveBeenCalled();
+    expect(ctx.onUpdate).not.toHaveBeenCalled();
+    expect(ctx.nudgeSelected).not.toHaveBeenCalled();
+    expect(ctx.setMode).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCutoutKeyDown — deletion and selection', () => {
+  it.each(['Delete', 'Backspace'])('%s deletes the selection', (key) => {
+    const ctx = makeCtx({ selection: new Set(['c1']) });
+    const event = press(key);
+    handleCutoutKeyDown(event, ctx);
+    expect(ctx.deleteSelected).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('does not preventDefault on Delete with nothing selected', () => {
+    // Backspace has to stay available to the browser when it is not ours.
+    const ctx = makeCtx();
+    const event = press('Backspace');
+    handleCutoutKeyDown(event, ctx);
+    expect(ctx.deleteSelected).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it.each([['metaKey' as const], ['ctrlKey' as const]])('%s+a selects all', (modifier) => {
+    const ctx = makeCtx();
+    handleCutoutKeyDown(press('a', { [modifier]: true }), ctx);
+    expect(ctx.selectAll).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleCutoutKeyDown — Escape', () => {
+  it('clears the in-progress preview and guides', () => {
+    const ctx = makeCtx();
+    handleCutoutKeyDown(press('Escape'), ctx);
+    expect(ctx.setPreview).toHaveBeenCalledWith(new Map());
+    expect(ctx.clearActiveGuides).toHaveBeenCalled();
+    expect(ctx.clearDrawingPreview).toHaveBeenCalled();
+    expect(ctx.setMode).toHaveBeenCalledWith({ type: 'idle' });
+  });
+
+  it('re-selects the whole group before deselecting, when inside one', () => {
+    // Two-stage escape: the first press steps back out to the group rather
+    // than dropping the selection entirely.
+    const cutouts = [
+      makeCutout({ id: 'a', groupId: 'g1' }),
+      makeCutout({ id: 'b', groupId: 'g1' }),
+    ];
+    const ctx = makeCtx({ selection: new Set(['a']), cutouts });
+    handleCutoutKeyDown(press('Escape'), ctx);
+    expect(ctx.setSelection).toHaveBeenCalledWith(new Set(['a', 'b']));
+    expect(ctx.deselectAll).not.toHaveBeenCalled();
+  });
+
+  it('deselects when the selection is a lone group member', () => {
+    // A group of one has nothing to step out to.
+    const ctx = makeCtx({
+      selection: new Set(['a']),
+      cutouts: [makeCutout({ id: 'a', groupId: 'g1' })],
+    });
+    handleCutoutKeyDown(press('Escape'), ctx);
+    expect(ctx.deselectAll).toHaveBeenCalled();
+  });
+
+  it('deselects an ungrouped selection outright', () => {
+    const ctx = makeCtx({ selection: new Set(['a']), cutouts: [makeCutout({ id: 'a' })] });
+    handleCutoutKeyDown(press('Escape'), ctx);
+    expect(ctx.deselectAll).toHaveBeenCalled();
+  });
+});
+
+describe('handleCutoutKeyDown — undo and redo', () => {
+  it('mod+z undoes and mod+shift+z redoes', () => {
+    const ctx = makeCtx();
+    handleCutoutKeyDown(press('z', { metaKey: true }), ctx);
+    expect(ctx.onUndo).toHaveBeenCalledTimes(1);
+    handleCutoutKeyDown(press('z', { metaKey: true, shiftKey: true }), ctx);
+    expect(ctx.onRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the shifted Z and mod+y as redo', () => {
+    // Shift changes the reported key, so both spellings have to be handled.
+    const ctx = makeCtx();
+    handleCutoutKeyDown(press('Z', { ctrlKey: true, shiftKey: true }), ctx);
+    handleCutoutKeyDown(press('y', { ctrlKey: true }), ctx);
+    expect(ctx.onRedo).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves a bare z alone', () => {
+    const ctx = makeCtx();
+    handleCutoutKeyDown(press('z'), ctx);
+    expect(ctx.onUndo).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCutoutKeyDown — clipboard', () => {
+  it('maps mod+c, mod+v and mod+d to copy, paste and duplicate', () => {
+    const ctx = makeCtx();
+    handleCutoutKeyDown(press('c', { metaKey: true }), ctx);
+    handleCutoutKeyDown(press('v', { metaKey: true }), ctx);
+    handleCutoutKeyDown(press('d', { metaKey: true }), ctx);
+    expect(ctx.copySelected).toHaveBeenCalledTimes(1);
+    expect(ctx.pasteFromClipboard).toHaveBeenCalledTimes(1);
+    expect(ctx.duplicateSelected).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleCutoutKeyDown — tool shortcuts', () => {
+  it.each([
+    ['c', { type: 'placing', shape: 'circle' }],
+    ['g', { type: 'placing', shape: 'polygon' }],
+    ['p', { type: 'placing', shape: 'path' }],
+    ['s', { type: 'placing', shape: 'slot' }],
+    ['m', { type: 'ruler-ready' }],
+    ['v', { type: 'idle' }],
+  ])('bare %s switches tool', (key, expected) => {
+    const ctx = makeCtx();
+    const event = press(key);
+    handleCutoutKeyDown(event, ctx);
+    expect(ctx.setMode).toHaveBeenCalledWith(expected);
+    // These are single letters that would otherwise reach a global shortcut.
+    expect(event.stopImmediatePropagation).toHaveBeenCalled();
+  });
+
+  it('bare r picks the rectangle tool only when nothing is selected', () => {
+    const idle = makeCtx();
+    handleCutoutKeyDown(press('r'), idle);
+    expect(idle.setMode).toHaveBeenCalledWith({ type: 'placing', shape: 'rectangle' });
+
+    const selected = makeCtx({ selection: new Set(['c1']), cutouts: [makeCutout()] });
+    handleCutoutKeyDown(press('r'), selected);
+    expect(selected.setMode).not.toHaveBeenCalled();
+    expect(selected.onUpdate).toHaveBeenCalledWith('c1', { rotation: 90 });
+  });
+});
+
+describe('handleCutoutKeyDown — rotate 90', () => {
+  it('wraps past a full turn rather than accumulating', () => {
+    const ctx = makeCtx({
+      selection: new Set(['c1']),
+      cutouts: [makeCutout({ rotation: 270 })],
+    });
+    handleCutoutKeyDown(press('r'), ctx);
+    expect(ctx.onUpdate).toHaveBeenCalledWith('c1', { rotation: 0 });
+  });
+
+  it('refuses to rotate when any selected cutout is locked', () => {
+    const ctx = makeCtx({
+      selection: new Set(['a', 'b']),
+      cutouts: [makeCutout({ id: 'a' }), makeCutout({ id: 'b', locked: true })],
+    });
+    handleCutoutKeyDown(press('r'), ctx);
+    expect(ctx.onUpdate).not.toHaveBeenCalled();
+    expect(ctx.onUpdateBatch).not.toHaveBeenCalled();
+  });
+
+  it('turns a multi-selection rigidly about its shared centre', () => {
+    // Members must orbit the selection centre, not spin in place, or the
+    // arrangement changes shape as it turns.
+    const ctx = makeCtx({
+      selection: new Set(['a', 'b']),
+      cutouts: [
+        makeCutout({ id: 'a', x: 0, y: 0, width: 10, depth: 10 }),
+        makeCutout({ id: 'b', x: 30, y: 0, width: 10, depth: 10 }),
+      ],
+    });
+    handleCutoutKeyDown(press('r'), ctx);
+
+    const updates = ctx.onUpdateBatch.mock.calls[0][0] as ReadonlyMap<string, Partial<Cutout>>;
+    expect(updates.size).toBe(2);
+    for (const patch of updates.values()) expect(patch.rotation).toBe(90);
+    // Centres started 30 apart on X; after a quarter turn they are 30 apart on Y.
+    const a = updates.get('a');
+    const b = updates.get('b');
+    expect(Math.abs((a?.x ?? 0) - (b?.x ?? 0))).toBeCloseTo(0);
+    expect(Math.abs((a?.y ?? 0) - (b?.y ?? 0))).toBeCloseTo(30);
+  });
+});
+
+describe('handleCutoutKeyDown — grouping', () => {
+  it('groups two or more, and never one', () => {
+    const two = makeCtx({ selection: new Set(['a', 'b']) });
+    handleCutoutKeyDown(press('g', { metaKey: true }), two);
+    expect(two.onGroup).toHaveBeenCalledWith(['a', 'b']);
+
+    const one = makeCtx({ selection: new Set(['a']) });
+    handleCutoutKeyDown(press('g', { metaKey: true }), one);
+    expect(one.onGroup).not.toHaveBeenCalled();
+  });
+
+  it('ungroups on mod+shift+g in either reported spelling', () => {
+    const lower = makeCtx({ selection: new Set(['a']) });
+    handleCutoutKeyDown(press('g', { metaKey: true, shiftKey: true }), lower);
+    expect(lower.onUngroup).toHaveBeenCalledWith(['a']);
+
+    const upper = makeCtx({ selection: new Set(['a']) });
+    handleCutoutKeyDown(press('G', { metaKey: true, shiftKey: true }), upper);
+    expect(upper.onUngroup).toHaveBeenCalledWith(['a']);
+  });
+});
+
+describe('handleCutoutKeyDown — nudge', () => {
+  it.each([
+    ['ArrowLeft', -0.5, 0],
+    ['ArrowRight', 0.5, 0],
+    ['ArrowUp', 0, 0.5],
+    ['ArrowDown', 0, -0.5],
+  ])('%s nudges by half a millimetre', (key, dx, dy) => {
+    const ctx = makeCtx({ selection: new Set(['c1']) });
+    handleCutoutKeyDown(press(key), ctx);
+    expect(ctx.nudgeSelected).toHaveBeenCalledWith(dx, dy);
+  });
+
+  it('shift makes the nudge coarse', () => {
+    const ctx = makeCtx({ selection: new Set(['c1']) });
+    handleCutoutKeyDown(press('ArrowRight', { shiftKey: true }), ctx);
+    expect(ctx.nudgeSelected).toHaveBeenCalledWith(5, 0);
+  });
+
+  it('does nothing with an empty selection', () => {
+    const ctx = makeCtx();
+    handleCutoutKeyDown(press('ArrowRight'), ctx);
+    expect(ctx.nudgeSelected).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCutoutKeyDown — flips', () => {
+  it('requires shift, so CapsLock alone does not flip', () => {
+    const ctx = makeCtx({ selection: new Set(['c1']), cutouts: [makeCutout()] });
+    handleCutoutKeyDown(press('H'), ctx);
+    handleCutoutKeyDown(press('V'), ctx);
+    expect(ctx.onUpdate).not.toHaveBeenCalled();
+    expect(ctx.onUpdateBatch).not.toHaveBeenCalled();
+  });
+
+  it('flips a single selection through onUpdate', () => {
+    const ctx = makeCtx({ selection: new Set(['c1']), cutouts: [makeCutout()] });
+    handleCutoutKeyDown(press('H', { shiftKey: true }), ctx);
+    expect(ctx.onUpdate).toHaveBeenCalled();
+  });
+
+  it('refuses to flip when any selected cutout is locked', () => {
+    const ctx = makeCtx({
+      selection: new Set(['a']),
+      cutouts: [makeCutout({ id: 'a', locked: true })],
+    });
+    handleCutoutKeyDown(press('V', { shiftKey: true }), ctx);
+    expect(ctx.onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCutoutKeyDown — lock toggle', () => {
+  it('locks a mixed selection rather than unlocking it', () => {
+    // Otherwise ctrl+L on a mixed selection would silently unlock the one
+    // the user had deliberately locked.
+    const ctx = makeCtx({
+      selection: new Set(['a', 'b']),
+      cutouts: [makeCutout({ id: 'a', locked: true }), makeCutout({ id: 'b' })],
+    });
+    handleCutoutKeyDown(press('l', { metaKey: true }), ctx);
+    expect(ctx.onLock).toHaveBeenCalledWith(['a', 'b']);
+    expect(ctx.onUnlock).not.toHaveBeenCalled();
+  });
+
+  it('unlocks only when every selected cutout is locked', () => {
+    const ctx = makeCtx({
+      selection: new Set(['a', 'b']),
+      cutouts: [makeCutout({ id: 'a', locked: true }), makeCutout({ id: 'b', locked: true })],
+    });
+    handleCutoutKeyDown(press('l', { metaKey: true }), ctx);
+    expect(ctx.onUnlock).toHaveBeenCalledWith(['a', 'b']);
+  });
+});
+
+describe('handleCutoutKeyDown — Tab cycling', () => {
+  const three = [makeCutout({ id: 'a' }), makeCutout({ id: 'b' }), makeCutout({ id: 'c' })];
+
+  it('steps forward and wraps at the end', () => {
+    const ctx = makeCtx({ selection: new Set(['c']), cutouts: three });
+    handleCutoutKeyDown(press('Tab'), ctx);
+    expect(ctx.setSelection).toHaveBeenCalledWith(new Set(['a']));
+  });
+
+  it('steps backward and wraps at the start', () => {
+    const ctx = makeCtx({ selection: new Set(['a']), cutouts: three });
+    handleCutoutKeyDown(press('Tab', { shiftKey: true }), ctx);
+    expect(ctx.setSelection).toHaveBeenCalledWith(new Set(['c']));
+  });
+
+  it('starts at the first cutout when nothing is selected', () => {
+    const ctx = makeCtx({ cutouts: three });
+    handleCutoutKeyDown(press('Tab'), ctx);
+    expect(ctx.setSelection).toHaveBeenCalledWith(new Set(['a']));
+  });
+
+  it('leaves Tab to the browser when there is nothing to cycle', () => {
+    const ctx = makeCtx();
+    const event = press('Tab');
+    handleCutoutKeyDown(event, ctx);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(ctx.setSelection).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCutoutKeyDown — path drawing mode', () => {
+  const drawing = (points: Array<{ x: number; y: number }>): InteractionMode =>
+    ({ type: 'path-drawing', points }) as unknown as InteractionMode;
+
+  it('mod+z pops the last point and keeps drawing', () => {
+    const ctx = makeCtx({
+      mode: drawing([
+        { x: 0, y: 0 },
+        { x: 5, y: 5 },
+        { x: 9, y: 9 },
+      ]),
+    });
+    handleCutoutKeyDown(press('z', { metaKey: true }), ctx);
+
+    expect(ctx.clearPathDrawingPreview).not.toHaveBeenCalled();
+    expect(ctx.setPathDrawingPreview).toHaveBeenCalledWith({
+      points: [
+        { x: 0, y: 0 },
+        { x: 5, y: 5 },
+      ],
+      // The cursor follows the point that is now last, so the rubber band
+      // starts where the line actually ends.
+      cursorX: 5,
+      cursorY: 5,
+      canClose: false,
+    });
+  });
+
+  it('mod+z on the last remaining point cancels the drawing', () => {
+    const ctx = makeCtx({ mode: drawing([{ x: 0, y: 0 }]) });
+    handleCutoutKeyDown(press('z', { metaKey: true }), ctx);
+    expect(ctx.clearPathDrawingPreview).toHaveBeenCalled();
+    expect(ctx.setMode).toHaveBeenCalledWith({ type: 'idle' });
+  });
+
+  it('Escape abandons the drawing', () => {
+    const ctx = makeCtx({
+      mode: drawing([
+        { x: 0, y: 0 },
+        { x: 1, y: 1 },
+      ]),
+    });
+    handleCutoutKeyDown(press('Escape'), ctx);
+    expect(ctx.clearPathDrawingPreview).toHaveBeenCalled();
+    expect(ctx.setMode).toHaveBeenCalledWith({ type: 'idle' });
+  });
+
+  it('swallows the shortcuts that would apply outside drawing', () => {
+    // Deleting the selection mid-path would act on something the user cannot
+    // even see while the pen is down.
+    const ctx = makeCtx({ selection: new Set(['c1']), mode: drawing([{ x: 0, y: 0 }]) });
+    handleCutoutKeyDown(press('Delete'), ctx);
+    handleCutoutKeyDown(press('r'), ctx);
+    expect(ctx.deleteSelected).not.toHaveBeenCalled();
+    expect(ctx.onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleCutoutKeyDown — vertex editing mode', () => {
+  const editing = { type: 'vertex-editing', cutoutId: 'c1' } as unknown as InteractionMode;
+
+  it('leaves vertex editing before undoing, so the overlay cannot go stale', () => {
+    const ctx = makeCtx({ mode: editing, cutouts: [makeCutout()] });
+    handleCutoutKeyDown(press('z', { metaKey: true }), ctx);
+    expect(ctx.setMode).toHaveBeenCalledWith({ type: 'idle' });
+    expect(ctx.onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats mod+y and mod+shift+z as redo', () => {
+    const ctx = makeCtx({ mode: editing, cutouts: [makeCutout()] });
+    handleCutoutKeyDown(press('y', { ctrlKey: true }), ctx);
+    handleCutoutKeyDown(press('z', { ctrlKey: true, shiftKey: true }), ctx);
+    expect(ctx.onRedo).toHaveBeenCalledTimes(2);
+    expect(ctx.onUndo).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the edited cutout has gone', () => {
+    const ctx = makeCtx({ mode: editing, cutouts: [] });
+    expect(() => handleCutoutKeyDown(press('Delete'), ctx)).not.toThrow();
+    expect(ctx.deleteSelected).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/keyboardHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/keyboardHandler.test.ts
@@ -124,10 +124,10 @@ describe('handleCutoutKeyDown — deletion and selection', () => {
     expect(event.preventDefault).toHaveBeenCalled();
   });
 
-  it('does not preventDefault on Delete with nothing selected', () => {
-    // Backspace has to stay available to the browser when it is not ours.
+  it.each(['Delete', 'Backspace'])('leaves %s to the browser when nothing is selected', (key) => {
+    // Backspace in particular has to stay available when it is not ours.
     const ctx = makeCtx();
-    const event = press('Backspace');
+    const event = press(key);
     handleCutoutKeyDown(event, ctx);
     expect(ctx.deleteSelected).not.toHaveBeenCalled();
     expect(event.preventDefault).not.toHaveBeenCalled();

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MIN_PATH_POINTS } from '@/features/bin-designer/types';
+import type { Cutout, PathPoint } from '@/features/bin-designer/types';
+import {
+  handleVertexEditKeyDown,
+  handleVertexEditPointerDown,
+  handleVertexEditPointerMove,
+  handleVertexEditPointerUp,
+} from './pathEditHandler';
+import type { VertexEditMode } from './pathEditHandler';
+import type { BinBounds, PointerMoveEvent } from './types';
+
+function point(x: number, y: number, overrides: Partial<PathPoint> = {}): PathPoint {
+  return { x, y, handleIn: null, handleOut: null, symmetric: false, ...overrides };
+}
+
+/** A closed square, four corners, no bezier handles. */
+const SQUARE: PathPoint[] = [point(0, 0), point(10, 0), point(10, 10), point(0, 10)];
+
+function makeCutout(path: readonly PathPoint[] = SQUARE): Cutout {
+  return {
+    id: 'p1',
+    shape: 'path',
+    x: 0,
+    y: 0,
+    width: 10,
+    depth: 10,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+    path: [...path],
+  };
+}
+
+function makeMode(overrides: Partial<VertexEditMode> = {}): VertexEditMode {
+  return {
+    type: 'vertex-editing',
+    cutoutId: 'p1',
+    selectedPointIndex: null,
+    dragTarget: null,
+    ...overrides,
+  };
+}
+
+function makeSetters() {
+  return {
+    setMode: vi.fn(),
+    setPreview: vi.fn(),
+    onUpdate: vi.fn(),
+    setSegmentHover: vi.fn(),
+  };
+}
+
+const BOUNDS: BinBounds = { binWidth: 100, binDepth: 100 };
+const noSnap = (v: number): number => v;
+const at = (mmX: number, mmY: number, extra: Partial<PointerMoveEvent> = {}): PointerMoveEvent => ({
+  mmX,
+  mmY,
+  ...extra,
+});
+
+describe('handleVertexEditPointerDown', () => {
+  it('selects and starts dragging the vertex under the cursor', () => {
+    const setters = makeSetters();
+    handleVertexEditPointerDown(makeMode(), at(10.2, 0.1), makeCutout(), 1, setters);
+    expect(setters.setMode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedPointIndex: 1,
+        dragTarget: { type: 'vertex', index: 1 },
+      })
+    );
+  });
+
+  it('clears any segment hover on every pointer down', () => {
+    const setters = makeSetters();
+    handleVertexEditPointerDown(makeMode(), at(50, 50), makeCutout(), 1, setters);
+    expect(setters.setSegmentHover).toHaveBeenCalledWith(null);
+  });
+
+  it('grabs a bezier handle of the selected point', () => {
+    const path = [
+      point(0, 0),
+      point(10, 0, { handleOut: { dx: 3, dy: 0 }, symmetric: true }),
+      point(10, 10),
+      point(0, 10),
+    ];
+    const setters = makeSetters();
+    handleVertexEditPointerDown(
+      makeMode({ selectedPointIndex: 1 }),
+      at(13, 0),
+      makeCutout(path),
+      1,
+      setters
+    );
+    expect(setters.setMode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dragTarget: { type: 'handle', index: 1, handleType: 'out' },
+      })
+    );
+  });
+
+  it('prefers a vertex over a handle when both are in range', () => {
+    // The vertex is the thing you grab to move the point; the handle only
+    // shapes the curve, so an ambiguous click has to resolve to the vertex.
+    const path = [
+      point(0, 0),
+      point(10, 0, { handleOut: { dx: 0.2, dy: 0 } }),
+      point(10, 10),
+      point(0, 10),
+    ];
+    const setters = makeSetters();
+    handleVertexEditPointerDown(
+      makeMode({ selectedPointIndex: 1 }),
+      at(10.1, 0),
+      makeCutout(path),
+      1,
+      setters
+    );
+    expect(setters.setMode).toHaveBeenCalledWith(
+      expect.objectContaining({ dragTarget: { type: 'vertex', index: 1 } })
+    );
+  });
+
+  it('inserts a point when the cursor is over a segment', () => {
+    const setters = makeSetters();
+    handleVertexEditPointerDown(makeMode(), at(5, 0), makeCutout(), 1, setters);
+
+    const update = setters.onUpdate.mock.calls[0][1] as Partial<Cutout>;
+    expect(update.path).toHaveLength(5);
+    // Inserted between the two points of the segment it split.
+    expect(update.path?.[1]).toEqual(expect.objectContaining({ x: 5, y: 0 }));
+    expect(setters.setMode).toHaveBeenCalledWith(
+      expect.objectContaining({ selectedPointIndex: 1, dragTarget: null })
+    );
+  });
+
+  it('inserts into the closing segment without reordering the path', () => {
+    // The wrap-around segment is the one where the "next" index is 0, so an
+    // off-by-one here rewrites the wrong point.
+    const setters = makeSetters();
+    handleVertexEditPointerDown(makeMode(), at(0, 5), makeCutout(), 1, setters);
+
+    const update = setters.onUpdate.mock.calls[0][1] as Partial<Cutout>;
+    expect(update.path).toHaveLength(5);
+    // The new point closes the loop, so it lands last, and the original
+    // corners keep their order.
+    expect(update.path?.[4]).toEqual(expect.objectContaining({ x: 0, y: 5 }));
+    expect(update.path?.slice(0, 4).map((p) => [p.x, p.y])).toEqual([
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ]);
+  });
+
+  it('recomputes the cutout bounds from the new path', () => {
+    const setters = makeSetters();
+    handleVertexEditPointerDown(makeMode(), at(5, 0), makeCutout(), 1, setters);
+    const update = setters.onUpdate.mock.calls[0][1] as Partial<Cutout>;
+    expect(update).toMatchObject({ x: 0, y: 0, width: 10, depth: 10 });
+  });
+
+  it('deselects when the cursor hits nothing', () => {
+    const setters = makeSetters();
+    handleVertexEditPointerDown(
+      makeMode({ selectedPointIndex: 2 }),
+      at(50, 50),
+      makeCutout(),
+      1,
+      setters
+    );
+    expect(setters.setMode).toHaveBeenCalledWith(
+      expect.objectContaining({ selectedPointIndex: null, dragTarget: null })
+    );
+  });
+
+  it.each([
+    ['an empty path', [] as PathPoint[]],
+    ['no path at all', undefined],
+  ])('does nothing for %s', (_label, path) => {
+    const setters = makeSetters();
+    const cutout = { ...makeCutout(), path } as Cutout;
+    expect(() =>
+      handleVertexEditPointerDown(makeMode(), at(0, 0), cutout, 1, setters)
+    ).not.toThrow();
+    expect(setters.setMode).not.toHaveBeenCalled();
+  });
+
+  it('survives a selected index left behind by a shorter path', () => {
+    // The path can shrink underneath the mode — a remote sync edit, or the
+    // shape being regenerated from the params panel — while the index the
+    // user last selected still points past its end.
+    const setters = makeSetters();
+    const mode = makeMode({ selectedPointIndex: 9 });
+    expect(() =>
+      handleVertexEditPointerDown(mode, at(50, 50), makeCutout(), 1, setters)
+    ).not.toThrow();
+  });
+});
+
+describe('handleVertexEditPointerMove', () => {
+  it('reports the hovered segment when not dragging', () => {
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    handleVertexEditPointerMove(makeMode(), at(5, 0.2), makeCutout(), BOUNDS, noSnap, setters);
+    expect(setters.setSegmentHover).toHaveBeenCalledWith(
+      expect.objectContaining({ segmentIndex: 0 })
+    );
+  });
+
+  it('clears the hover when the cursor leaves every segment', () => {
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    handleVertexEditPointerMove(makeMode(), at(50, 50), makeCutout(), BOUNDS, noSnap, setters);
+    expect(setters.setSegmentHover).toHaveBeenCalledWith(null);
+  });
+
+  it('drags a vertex through the snap function', () => {
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    const snap = (v: number): number => Math.round(v);
+    handleVertexEditPointerMove(
+      makeMode({ dragTarget: { type: 'vertex', index: 0 } }),
+      at(3.4, 7.6),
+      makeCutout(),
+      BOUNDS,
+      snap,
+      setters
+    );
+    const preview = setters.setPreview.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    expect(preview.get('p1')?.path?.[0]).toEqual(expect.objectContaining({ x: 3, y: 8 }));
+  });
+
+  it('clamps a dragged vertex inside the bin', () => {
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    handleVertexEditPointerMove(
+      makeMode({ dragTarget: { type: 'vertex', index: 0 } }),
+      at(-40, 500),
+      makeCutout(),
+      BOUNDS,
+      noSnap,
+      setters
+    );
+    const preview = setters.setPreview.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    expect(preview.get('p1')?.path?.[0]).toEqual(expect.objectContaining({ x: 0, y: 100 }));
+  });
+
+  it('stores a dragged handle as an offset from its point', () => {
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    handleVertexEditPointerMove(
+      makeMode({ dragTarget: { type: 'handle', index: 1, handleType: 'out' } }),
+      at(14, 3),
+      makeCutout(),
+      BOUNDS,
+      noSnap,
+      setters
+    );
+    const preview = setters.setPreview.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    // Point 1 is at (10, 0), so the offset is the cursor minus the point.
+    expect(preview.get('p1')?.path?.[1].handleOut).toEqual({ dx: 4, dy: 3 });
+  });
+
+  it('breaks symmetry when alt is held', () => {
+    const path = [
+      point(0, 0),
+      point(10, 0, { handleIn: { dx: -2, dy: 0 }, handleOut: { dx: 2, dy: 0 }, symmetric: true }),
+      point(10, 10),
+      point(0, 10),
+    ];
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    handleVertexEditPointerMove(
+      makeMode({ dragTarget: { type: 'handle', index: 1, handleType: 'out' } }),
+      at(14, 3, { altKey: true }),
+      makeCutout(path),
+      BOUNDS,
+      noSnap,
+      setters
+    );
+    const preview = setters.setPreview.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    const updated = preview.get('p1')?.path?.[1];
+    expect(updated?.symmetric).toBe(false);
+    // The opposite handle is left exactly where it was.
+    expect(updated?.handleIn).toEqual({ dx: -2, dy: 0 });
+  });
+
+  it('mirrors the opposite handle when symmetry is on', () => {
+    const path = [
+      point(0, 0),
+      point(10, 0, { handleIn: { dx: -2, dy: 0 }, handleOut: { dx: 2, dy: 0 }, symmetric: true }),
+      point(10, 10),
+      point(0, 10),
+    ];
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    handleVertexEditPointerMove(
+      makeMode({ dragTarget: { type: 'handle', index: 1, handleType: 'out' } }),
+      at(14, 3),
+      makeCutout(path),
+      BOUNDS,
+      noSnap,
+      setters
+    );
+    const preview = setters.setPreview.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    const updated = preview.get('p1')?.path?.[1];
+    expect(updated?.handleOut).toEqual({ dx: 4, dy: 3 });
+    expect(updated?.handleIn).toEqual({ dx: -4, dy: -3 });
+  });
+
+  it('survives a drag target left behind by a shorter path', () => {
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    expect(() =>
+      handleVertexEditPointerMove(
+        makeMode({ dragTarget: { type: 'handle', index: 9, handleType: 'in' } }),
+        at(5, 5),
+        makeCutout(),
+        BOUNDS,
+        noSnap,
+        setters
+      )
+    ).not.toThrow();
+  });
+});
+
+describe('handleVertexEditPointerUp', () => {
+  it('commits the previewed path and clears the drag', () => {
+    const setters = makeSetters();
+    // Pulling the corner outward is what moves the bounding box; nudging it
+    // inward leaves the other three corners defining the same extent.
+    const moved = [point(-4, 0), point(10, 0), point(10, 10), point(0, 10)];
+    handleVertexEditPointerUp(
+      makeMode({ selectedPointIndex: 0, dragTarget: { type: 'vertex', index: 0 } }),
+      makeCutout(),
+      new Map([['p1', { path: moved }]]),
+      setters
+    );
+    expect(setters.onUpdate).toHaveBeenCalledWith(
+      'p1',
+      expect.objectContaining({ x: -4, y: 0, width: 14, depth: 10 })
+    );
+    expect(setters.setPreview).toHaveBeenCalledWith(new Map());
+    expect(setters.setMode).toHaveBeenCalledWith(expect.objectContaining({ dragTarget: null }));
+  });
+
+  it('keeps the vertex selected after the drag', () => {
+    const setters = makeSetters();
+    handleVertexEditPointerUp(
+      makeMode({ selectedPointIndex: 2, dragTarget: { type: 'vertex', index: 2 } }),
+      makeCutout(),
+      new Map(),
+      setters
+    );
+    expect(setters.setMode).toHaveBeenCalledWith(
+      expect.objectContaining({ selectedPointIndex: 2 })
+    );
+  });
+
+  it('discards an edit that crosses the path over itself', () => {
+    // A self-intersecting outline has no well-defined inside, so it cannot be
+    // turned into a solid; the drag snaps back rather than committing.
+    const setters = makeSetters();
+    const bowtie = [point(0, 0), point(10, 10), point(10, 0), point(0, 10)];
+    handleVertexEditPointerUp(
+      makeMode({ dragTarget: { type: 'vertex', index: 1 } }),
+      makeCutout(),
+      new Map([['p1', { path: bowtie }]]),
+      setters
+    );
+    expect(setters.onUpdate).not.toHaveBeenCalled();
+    expect(setters.setPreview).toHaveBeenCalledWith(new Map());
+  });
+
+  it('does nothing to the cutout when there is no preview', () => {
+    const setters = makeSetters();
+    handleVertexEditPointerUp(makeMode(), makeCutout(), new Map(), setters);
+    expect(setters.onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleVertexEditKeyDown', () => {
+  const press = (key: string): KeyboardEvent =>
+    ({ key, preventDefault: vi.fn() }) as unknown as KeyboardEvent;
+
+  it.each(['Delete', 'Backspace'])('%s removes the selected vertex', (key) => {
+    const setters = makeSetters();
+    const five = [...SQUARE, point(5, 5)];
+    handleVertexEditKeyDown(
+      press(key),
+      makeMode({ selectedPointIndex: 4 }),
+      makeCutout(five),
+      setters
+    );
+    const update = setters.onUpdate.mock.calls[0][1] as Partial<Cutout>;
+    expect(update.path).toHaveLength(4);
+  });
+
+  it('refuses to delete below MIN_PATH_POINTS anchors', () => {
+    const setters = makeSetters();
+    const event = press('Delete');
+    handleVertexEditKeyDown(
+      event,
+      makeMode({ selectedPointIndex: 0 }),
+      makeCutout(Array.from({ length: MIN_PATH_POINTS }, (_, i) => point(i * 10, 0))),
+      setters
+    );
+    expect(setters.onUpdate).not.toHaveBeenCalled();
+    // The key is left to the browser rather than swallowed for nothing.
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('moves the selection back when the removed vertex was the last', () => {
+    // Leaving the index past the end would make the next click read an
+    // undefined point.
+    const setters = makeSetters();
+    const five = [...SQUARE, point(5, 5)];
+    handleVertexEditKeyDown(
+      press('Delete'),
+      makeMode({ selectedPointIndex: 4 }),
+      makeCutout(five),
+      setters
+    );
+    expect(setters.setMode).toHaveBeenCalledWith(
+      expect.objectContaining({ selectedPointIndex: 3, dragTarget: null })
+    );
+  });
+
+  it('writes nothing when the selected index no longer exists', () => {
+    // splice() past the end removes nothing, so this committed a path
+    // identical to the current one — a history entry that undoes to itself.
+    const setters = makeSetters();
+    handleVertexEditKeyDown(
+      press('Delete'),
+      makeMode({ selectedPointIndex: 9 }),
+      makeCutout([...SQUARE, point(5, 5)]),
+      setters
+    );
+    expect(setters.onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no vertex is selected', () => {
+    const setters = makeSetters();
+    handleVertexEditKeyDown(
+      press('Delete'),
+      makeMode(),
+      makeCutout([...SQUARE, point(5, 5)]),
+      setters
+    );
+    expect(setters.onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('Escape leaves vertex editing', () => {
+    const setters = makeSetters();
+    handleVertexEditKeyDown(
+      press('Escape'),
+      makeMode({ selectedPointIndex: 1 }),
+      makeCutout(),
+      setters
+    );
+    expect(setters.setMode).toHaveBeenCalledWith({ type: 'idle' });
+  });
+
+  it('ignores keys it does not handle', () => {
+    const setters = makeSetters();
+    handleVertexEditKeyDown(press('q'), makeMode({ selectedPointIndex: 1 }), makeCutout(), setters);
+    expect(setters.setMode).not.toHaveBeenCalled();
+    expect(setters.onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.test.ts
@@ -304,6 +304,23 @@ describe('handleVertexEditPointerMove', () => {
     expect(updated?.handleIn).toEqual({ dx: -4, dy: -3 });
   });
 
+  it('drops the stale preview so pointer-up cannot resurrect deleted vertices', () => {
+    // Bailing out of the drag is not enough on its own: the last preview
+    // computed against the longer path stays in the map, and pointer-up
+    // commits whatever it finds there — putting the removed points back and
+    // overwriting whatever shrank the path in the first place.
+    const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
+    handleVertexEditPointerMove(
+      makeMode({ dragTarget: { type: 'handle', index: 9, handleType: 'in' } }),
+      at(5, 5),
+      makeCutout(),
+      BOUNDS,
+      noSnap,
+      setters
+    );
+    expect(setters.setPreview).toHaveBeenCalledWith(new Map());
+  });
+
   it('survives a drag target left behind by a shorter path', () => {
     const setters = { setPreview: vi.fn(), setSegmentHover: vi.fn() };
     expect(() =>

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.ts
@@ -199,7 +199,14 @@ export function handleVertexEditPointerMove(
     // shrink mid-drag (an undo, a remote edit), and reading past its end threw
     // rather than simply dropping the frame.
     const pt = path[dragTarget.index];
-    if (pt === undefined) return;
+    if (pt === undefined) {
+      // Dropping the frame is not enough. The last preview was computed
+      // against the longer path and pointer-up commits whatever it finds, so
+      // leaving it would put the removed points back and overwrite whatever
+      // shrank the path.
+      setters.setPreview(new Map());
+      return;
+    }
     // Clamp handle endpoint to bin bounds
     const clampedX = Math.max(0, Math.min(event.mmX, bounds.binWidth));
     const clampedY = Math.max(0, Math.min(event.mmY, bounds.binDepth));

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/pathEditHandler.ts
@@ -90,8 +90,17 @@ export function handleVertexEditPointerDown(
     }
   }
 
-  if (mode.selectedPointIndex !== null) {
-    const pt = path[mode.selectedPointIndex];
+  // The index can outlive the point it named: the path shrinks whenever a
+  // vertex is deleted, an undo lands, or a remote edit arrives, and none of
+  // those go through this handler. Reading past the end here threw a
+  // TypeError and took the editor down with it, so a stale index is treated
+  // as no selection and the click falls through to the segment test below.
+  const selectedPoint =
+    mode.selectedPointIndex === null ? undefined : path[mode.selectedPointIndex];
+
+  if (selectedPoint !== undefined && mode.selectedPointIndex !== null) {
+    const pt = selectedPoint;
+    const selectedIndex = mode.selectedPointIndex;
 
     if (pt.handleIn) {
       const hx = pt.x + pt.handleIn.dx;
@@ -99,7 +108,7 @@ export function handleVertexEditPointerDown(
       if (isNearPoint(event.mmX, event.mmY, hx, hy, threshold)) {
         setters.setMode({
           ...mode,
-          dragTarget: { type: 'handle', index: mode.selectedPointIndex, handleType: 'in' },
+          dragTarget: { type: 'handle', index: selectedIndex, handleType: 'in' },
         });
         return;
       }
@@ -111,7 +120,7 @@ export function handleVertexEditPointerDown(
       if (isNearPoint(event.mmX, event.mmY, hx, hy, threshold)) {
         setters.setMode({
           ...mode,
-          dragTarget: { type: 'handle', index: mode.selectedPointIndex, handleType: 'out' },
+          dragTarget: { type: 'handle', index: selectedIndex, handleType: 'out' },
         });
         return;
       }
@@ -186,7 +195,11 @@ export function handleVertexEditPointerMove(
 
     setters.setPreview(new Map([[cutout.id, { path: updatedPath }]]));
   } else {
+    // Same stale-index hazard as the pointer-down hit test: the path can
+    // shrink mid-drag (an undo, a remote edit), and reading past its end threw
+    // rather than simply dropping the frame.
     const pt = path[dragTarget.index];
+    if (pt === undefined) return;
     // Clamp handle endpoint to bin bounds
     const clampedX = Math.max(0, Math.min(event.mmX, bounds.binWidth));
     const clampedY = Math.max(0, Math.min(event.mmY, bounds.binDepth));
@@ -264,6 +277,10 @@ export function handleVertexEditKeyDown(
     case 'Delete':
     case 'Backspace': {
       if (mode.selectedPointIndex === null) return;
+      // An index past the end splices nothing, so the "updated" path came back
+      // identical and was committed anyway — an undo entry that undoes to
+      // itself. The path shrinks outside this handler, so the index can lead.
+      if (mode.selectedPointIndex >= path.length) return;
 
       const updated = removePoint(path, mode.selectedPointIndex);
       if (!updated) return; // would drop below MIN_PATH_POINTS anchors


### PR DESCRIPTION
Started as coverage work and turned into a bug hunt, which is roughly the point: `pathEditHandler.ts` was the only cutout handler besides `keyboardHandler.ts` with **no sibling test** — the other five all have one — and it sat at **1.2% line coverage**. Writing the test found three faults.

## Three faults, all the same shape

The vertex-edit mode remembers an index into `cutout.path`. The path shrinks **outside** this handler — a vertex deleted, an undo landing, a remote sync edit, the shape regenerated from the params panel — so the remembered index can outlive the point it named. Nothing guarded that.

| where | what happened |
| --- | --- |
| pointer down | `path[selectedPointIndex].handleIn` → **`TypeError: Cannot read properties of undefined`**, taking the editor down with it |
| pointer move | `path[dragTarget.index].x` mid-drag → same crash |
| Delete key | `splice()` past the end removes nothing, so the "updated" path came back **identical and was committed** — an undo entry that undoes to itself |

Fixes match the severity: a stale selection now reads as no selection and the click falls through to the segment hit test; a stale drag target drops the frame; Delete writes nothing.

The third is the sneakiest — no crash, no visible symptom, just a wasted history slot that makes Ctrl+Z appear not to work once.

## Coverage

| | before | after |
| --- | --- | --- |
| Lines | 83.96% | **84.26%** |
| Branches | 77.25% | **77.55%** |
| Statements | 82.53% | **82.81%** |
| Functions | 80.86% | **80.98%** |

The thresholds set in #3334 already carry that headroom, so they stay put rather than being ratcheted on every PR.

## Tests

79 new tests across the two handlers.

`keyboardHandler` (49) — nothing was wrong with it, but it was equally untested. Worth having anyway: it covers the typing guard (so `r` in a label field does not rotate the selection), both reported spellings of shifted keys (`z`/`Z`, `g`/`G`), two-stage Escape out of a group, rigid multi-selection rotation about a shared centre, the lock toggle's "lock a mixed selection rather than unlock it" rule, Tab wrap-around, and that path-drawing mode swallows the shortcuts that would otherwise act on invisible state.

`pathEditHandler` (30) — vertex/handle hit-test precedence, insertion into the wrap-around closing segment (an off-by-one there rewrites the wrong point), handle symmetry and the alt-key break, self-intersection rejection on commit, and the `MIN_PATH_POINTS` floor on deletion.

Full bin-designer suite: 4,228 passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stale index handling in the path vertex editor to prevent crashes, bad undo entries, and stale preview commits. Adds test suites for `pathEditHandler` and `keyboardHandler`, slightly improving coverage.

- **Bug Fixes**
  - Pointer down: if `selectedPointIndex` is out of range, treat as no selection and fall through to segment hit-test.
  - Pointer move: if `dragTarget.index` is stale, drop the frame and clear the preview so pointer-up can’t commit it.
  - Delete key: if the selected index is beyond `path.length`, skip the update to avoid committing a no-op.

<sup>Written for commit de53f725e85a5aa87d3d154aca35e549cd98f7f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

