### PR TITLE
ci: run PR workflows regardless of base branch so stacked PRs are gated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,16 @@ on:
   push:
     branches:
       - main
+  # No `branches:` filter on pull_request. That filter matches the BASE branch,
+  # so a PR stacked on another PR's branch drew no Build, test, quality or OSV
+  # run at all -- and reported green, because a rollup over zero jobs is green.
+  # The checks that did appear on such a PR were exactly the ones without this
+  # filter (pr-title, Vercel, the review bots), which is what made it look like
+  # CI had run.
+  #
+  # Push stays pinned to main: branches are gated as pull requests, and a bare
+  # branch push should not spend a full suite.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,9 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  # Unfiltered by base branch so a PR stacked on another PR is analysed too --
+  # see ci.yml for why the `branches:` filter silently exempted those.
   pull_request:
-    branches: [main]
   schedule:
     - cron: '0 6 * * 1' # Weekly Monday 6am UTC
 

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -6,8 +6,9 @@ name: OSV Scan
 # a feature PR); main + weekly schedule fail closed so the dashboard stays loud.
 
 on:
+  # Unfiltered by base branch so a PR stacked on another PR is scanned too --
+  # see ci.yml for why the `branches:` filter silently exempted those.
   pull_request:
-    branches: [main]
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -14,8 +14,9 @@ name: Smoke (Preview)
 # status check on its own — a green run may mean "nothing was tested".
 
 on:
+  # Unfiltered by base branch so a stacked PR that opted into a preview is
+  # smoked too -- see ci.yml. paths-ignore stays; only the base filter goes.
   pull_request:
-    branches: [main]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'


### PR DESCRIPTION
`branches:` on a `pull_request` trigger matches the **base** branch. Every gate keyed to `[main]` therefore exempted any PR stacked on another PR's branch — no Build, no unit tests, no Quality, no OSV scan. And it displayed **green**, because a rollup over zero jobs is green.

## Seen directly on #3327

It opened against #3325's branch and drew **5 checks instead of 19**:

| Fired | Why |
|---|---|
| Conventional Commit, Vercel ×2, Greptile, cubic | no `branches:` filter |
| ~~Build, Unit Tests ×6, Quality, Integration, CodeQL, OSV~~ | filtered to `[main]` |

Five green checks reads as a quieter run, not an absent one. Retargeting to `main` didn't fix it either — `on: pull_request` defaults to `[opened, synchronize, reopened]`, and a base change fires `edited`. It took a close/reopen to get a real run.

## Change

Removed the base filter from the four gates — `ci`, `codeql`, `osv-scan`, `smoke-preview`. The substantive diff is four deleted lines.

`push` stays pinned to `main`: branches are gated as pull requests, and a bare branch push shouldn't spend a full suite.

## Severity — bounded, not zero

Worth stating precisely rather than overselling. The `protection` ruleset targets `~DEFAULT_BRANCH` and requires `Conventional Commit` / `Build` / `Unit Tests Complete`, so a stack's **final** merge to main was always gated — that's why #3327 sat `BLOCKED` instead of merging unchecked.

What was actually missing:

1. **No feedback while the stack was being built** — you'd discover breakage only at the last hop.
2. **Dishonest reporting** — green meant "nothing ran."
3. **Intermediate merges ungated** — merging C→B→A ran nothing at any step.

A bonus effect: checks now attach to the head SHA *before* a retarget, so a stacked PR won't need the close/reopen dance to become mergeable.

## Deliberately unchanged

- **`labeler.yml`** keeps its `[main]` filter. It's `pull_request_target`, so it runs privileged, and auto-labeling is cosmetic — not worth widening where a privileged workflow fires for no gate value.
- **`pr-title.yml`** already had no filter, which is why its check was among the five that fired.
- **The self-hosted fork boundary.** `test-selfhosted` still gates on `head.repo.full_name == github.repository`, so a fork PR still cannot reach the Mac mini regardless of what it targets. Verified absent from the diff.
- **`types:`.** Adding `edited` would make base changes trigger CI, but it also fires on every title/body edit — a full suite per description tweak. Unnecessary now that checks exist before the retarget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run PR workflows regardless of base branch so stacked PRs get full CI coverage and accurate status checks. Fixes missing Build, test, CodeQL, and OSV runs that previously showed green due to zero jobs.

- **Bug Fixes**
  - Removed base-branch filter from `pull_request` in `ci`, `codeql`, `osv-scan`, and `smoke-preview`.
  - Kept `push` pinned to `main`; preserved existing `paths-ignore` and privileged `pull_request_target` labeler.
  - Stacked PRs now run full checks and attach to the head SHA; no close/reopen after retargeting.

<sup>Written for commit cb2e57d2b75488a8281d0d5cdd8838015f158522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

