### PR TITLE
chore(deps): bump brepkit-wasm to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.120.0",
-    "brepkit-wasm": "3.0.2",
+    "brepkit-wasm": "3.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.120.0
-        version: 18.120.0(patch_hash=3a74e63157337f68ceb081f4c9dca8dcff59279ae082a3e0ee1a598789b61a11)(brepkit-wasm@3.0.2)(occt-wasm@3.8.0)
+        version: 18.120.0(patch_hash=3a74e63157337f68ceb081f4c9dca8dcff59279ae082a3e0ee1a598789b61a11)(brepkit-wasm@3.2.1)(occt-wasm@3.8.0)
       brepkit-wasm:
-        specifier: 3.0.2
-        version: 3.0.2
+        specifier: 3.2.1
+        version: 3.2.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3188,8 +3188,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@3.0.2:
-    resolution: {integrity: sha512-gCBV3rtv6L5Hl3aJJdDyBEnLGSyccDOEh0Hz2xW9hQ2fa11pSfGOwhcA5srazIqH15BqdWqNsc2o3jMoEpGDDA==}
+  brepkit-wasm@3.2.1:
+    resolution: {integrity: sha512-KYxzfVtwSbYRWUd+lejltkC4VGrTT07zvCOmL8j+TURn/ORiT/PicUGIXKlHw3ZN7d102ZSIIl6fgscgYcAAzw==}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -8691,15 +8691,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.120.0(patch_hash=3a74e63157337f68ceb081f4c9dca8dcff59279ae082a3e0ee1a598789b61a11)(brepkit-wasm@3.0.2)(occt-wasm@3.8.0):
+  brepjs@18.120.0(patch_hash=3a74e63157337f68ceb081f4c9dca8dcff59279ae082a3e0ee1a598789b61a11)(brepkit-wasm@3.2.1)(occt-wasm@3.8.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 3.0.2
+      brepkit-wasm: 3.2.1
       occt-wasm: 3.8.0
 
-  brepkit-wasm@3.0.2: {}
+  brepkit-wasm@3.2.1: {}
 
   browserslist@4.28.7:
     dependencies:


### PR DESCRIPTION
Brings in the brepkit 3.2.x line:

- **Slots wall-pattern watertightness fix** (brepkit#1446): the 3x3x5 slots case measured here drops **53.7 s → 3.07 s** with fully analytic output (546 faces, 256 cylinders + 12 cones). Verified in this worktree: `wallPatterns` scenario 7/7 **and export 8/8** — the export arm carried the old slots signature.
- **`meshFallbackCount()`** (brepkit#1445's detectability ask): snapshot around an op chain and refuse the export when it grew — the mesh fallback does not guarantee watertight output.
- `fuse/cut/intersectWithOptions` (simplify) — wired in brepjs 18.121+ (brepjs#1966); inert until that bump.

Not fixed by this bump: the `groupedScoop` **export** failures (6) — the scoop's `filletVariable` emits open slivers before any boolean runs; that fillet-engine campaign is tracked in brepkit#1445 (kernel-side, in progress). Identical failures on 3.0.2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `brepkit-wasm` to 3.2.1 to fix wall-pattern watertightness and guard exports when mesh fallbacks appear. Slots run faster (53.7s → 3.07s) with fully analytic output.

- **Dependencies**
  - Bump `brepkit-wasm` 3.0.2 → 3.2.1; includes slots wall-pattern fix, `meshFallbackCount()` export guard, and boolean simplify entry points (inactive until `brepjs` ≥ 18.121). Known: `groupedScoop` export failures persist (upstream fillet engine).

<sup>Written for commit ca1596f3228076e5fb04783ead24daf15eaa5c87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

