### PR TITLE
test(generation): per-stage baseplate generation breakdown

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/baseplatePerfBreakdown.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/baseplatePerfBreakdown.test.ts
@@ -113,7 +113,9 @@ function measureOnce(params: ResolvedBaseplateParams): Breakdown {
       prev = m.at;
     }
     // Whatever the last probe did not cover, so the parts always sum to the whole.
-    if (builtAt - prev > 0.5) stages.push({ label: '(post-final build)', ms: builtAt - prev });
+    // Pushed unconditionally: `report` medians stage i across samples, so a row
+    // that appears in only some of them shifts every later row in those samples.
+    stages.push({ label: '(post-final build)', ms: builtAt - prev });
     stages.push({ label: 'mesh', ms: meshedAt - meshStart });
     stages.push({ label: 'creaseEdges', ms: creasedAt - meshedAt });
 

--- a/src/features/generation/worker/generators/__kernel-tests__/baseplatePerfBreakdown.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/baseplatePerfBreakdown.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+/**
+ * Per-stage baseplate-generation breakdown (investigation harness, not a CI gate).
+ *
+ * Answers: when a plate takes 30s on brepkit and 1.5s on occt-wasm, which
+ * construction step owns the gap? `previewPerfBreakdown` covers bins only, and
+ * plates share none of that pipeline, so there was no way to tell whether the
+ * cost sits in the pocket fuse, a later boolean, or tessellation.
+ *
+ * Splits each generation by BREP milestone using the `BaseplateProbe` hook, then
+ * times the two post-build steps `generateBaseplate` runs (`mesh` + `creaseEdges`)
+ * with the same tolerances the preview path picks.
+ *
+ * Run (the table also lands in `PERF_OUT`, default /tmp/perfbench/baseplate.txt,
+ * because the console copy only survives under --reporter=verbose):
+ *   BREPJS_KERNEL=brepkit   pnpm exec vitest run --config vitest.profile.config.ts baseplatePerfBreakdown
+ *   BREPJS_KERNEL=occt-wasm pnpm exec vitest run --config vitest.profile.config.ts baseplatePerfBreakdown
+ *
+ * Milestone → meaning (labels come from `buildBaseplateSolid`):
+ *   slabExtruded         slab profile extruded
+ *   pocketsCut           the N-way pocket fuse            <- brepkit#1490 targets this
+ *   outlineIntersected   custom-perimeter clip
+ *   cornerIntersected    corner rounding clip
+ *   magnetHolesCut       magnet hole batch
+ *   lightweightFloorCut  underside floor cutters
+ *   final                last op before return
+ *   mesh                 tessellation
+ *   creaseEdges          preview edge overlay
+ */
+import { appendFileSync } from 'node:fs';
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import { mesh } from 'brepjs';
+import { writeReport } from './reportTable';
+import { initBrepjs, getKernelName } from './wasmInit';
+import {
+  buildBaseplateSolid,
+  clearBaseplateCaches,
+  type BaseplateProbe,
+} from '@/features/generation/worker/generators/baseplateGenerator';
+import { creaseEdges } from '@/features/generation/worker/generators/utils';
+import type { ResolvedBaseplateParams } from '@/shared/types/bin';
+
+const SAMPLES = 3; // first sample discarded (JIT warm-up); median of the rest
+
+interface Breakdown {
+  readonly stages: ReadonlyArray<{ label: string; ms: number }>;
+  readonly total: number;
+  readonly triangles: number;
+}
+
+const reports: string[] = [];
+const OUT = process.env['PERF_OUT'] ?? '/tmp/perfbench/baseplate.txt';
+
+beforeAll(async () => {
+  await initBrepjs();
+  writeReport(OUT, `Baseplate stage breakdown — kernel: ${getKernelName()}\n\n`);
+}, 60_000);
+
+afterAll(() => {
+  /* eslint-disable no-console -- diagnostic harness prints its table for inspection */
+  console.log(`\nBaseplate stage breakdown — kernel: ${getKernelName()}\n`);
+  for (const r of reports) console.log(r);
+  /* eslint-enable no-console */
+});
+
+function median(xs: readonly number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+/**
+ * Preview-path tessellation tolerances, mirroring `generateBaseplate`. Kept in
+ * sync by hand: importing them is not possible, they are computed inline there.
+ */
+function previewTolerances(p: ResolvedBaseplateParams): {
+  tolerance: number;
+  angularTolerance: number;
+} {
+  const totalW = p.width * p.gridUnitMm + p.paddingLeft + p.paddingRight;
+  const totalD = p.depth * (p.gridUnitMmY ?? p.gridUnitMm) + p.paddingFront + p.paddingBack;
+  const maxDimension = Math.max(totalW, totalD);
+  return p.magnetHoles
+    ? { tolerance: Math.min(0.1, Math.max(0.05, maxDimension / 2500)), angularTolerance: 10 }
+    : { tolerance: Math.min(0.4, Math.max(0.15, maxDimension / 600)), angularTolerance: 12 };
+}
+
+/** One cold generation, timed per milestone. */
+function measureOnce(params: ResolvedBaseplateParams): Breakdown {
+  clearBaseplateCaches();
+
+  const marks: Array<{ label: string; at: number }> = [];
+  // The probe's `shape` is borrowed for the call only, so nothing here retains
+  // it — reading the clock is safe, keeping the handle would be a use-after-free.
+  const probe: BaseplateProbe = (label) => marks.push({ label, at: performance.now() });
+
+  const start = performance.now();
+  const solid = buildBaseplateSolid(params, false, undefined, probe, false);
+  const builtAt = performance.now();
+
+  try {
+    const { tolerance, angularTolerance } = previewTolerances(params);
+    const meshStart = performance.now();
+    const meshResult = mesh(solid, { tolerance, angularTolerance });
+    const meshedAt = performance.now();
+    creaseEdges(meshResult);
+    const creasedAt = performance.now();
+
+    const stages: Array<{ label: string; ms: number }> = [];
+    let prev = start;
+    for (const m of marks) {
+      stages.push({ label: m.label, ms: m.at - prev });
+      prev = m.at;
+    }
+    // Whatever the last probe did not cover, so the parts always sum to the whole.
+    if (builtAt - prev > 0.5) stages.push({ label: '(post-final build)', ms: builtAt - prev });
+    stages.push({ label: 'mesh', ms: meshedAt - meshStart });
+    stages.push({ label: 'creaseEdges', ms: creasedAt - meshedAt });
+
+    return {
+      stages,
+      total: creasedAt - start,
+      triangles: meshResult.triangles.length / 3,
+    };
+  } finally {
+    solid.delete();
+  }
+}
+
+function report(name: string, runs: readonly Breakdown[]): void {
+  const measured = runs.slice(1);
+  const labels = measured[0].stages.map((s) => s.label);
+  const total = median(measured.map((r) => r.total));
+  const lines = [
+    `  ${name}`,
+    `    total      ${total.toFixed(0).padStart(7)}ms   (${median(
+      measured.map((r) => r.triangles)
+    ).toLocaleString()} tris)`,
+  ];
+  for (const [i, label] of labels.entries()) {
+    const ms = median(measured.map((r) => r.stages[i].ms));
+    const pct = ((ms / total) * 100).toFixed(0);
+    lines.push(`    ${label.padEnd(20)} ${ms.toFixed(0).padStart(7)}ms   ${pct.padStart(3)}%`);
+  }
+  const block = lines.join('\n') + '\n';
+  reports.push(block);
+  appendFileSync(OUT, block + '\n');
+}
+
+function run(name: string, params: ResolvedBaseplateParams): void {
+  const runs: Breakdown[] = [];
+  for (let i = 0; i < SAMPLES; i++) runs.push(measureOnce(params));
+  report(name, runs);
+}
+
+const BASE: ResolvedBaseplateParams = {
+  width: 2,
+  depth: 2,
+  gridUnitMm: 42,
+  magnetHoles: false,
+  magnetDiameter: 6.5,
+  magnetDepth: 2,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  connectorNubs: false,
+};
+
+describe(`baseplate stage breakdown (${getKernelName()})`, () => {
+  it('2×2 plain', () => {
+    run('2×2 plain', BASE);
+  }, 300_000);
+
+  it('4×4 plain', () => {
+    run('4×4 plain', { ...BASE, width: 4, depth: 4 });
+  }, 600_000);
+
+  it('4×4 magnets', () => {
+    run('4×4 magnets', { ...BASE, width: 4, depth: 4, magnetHoles: true });
+  }, 600_000);
+
+  it('6×4 magnets', () => {
+    run('6×4 magnets', { ...BASE, width: 6, depth: 4, magnetHoles: true });
+  }, 900_000);
+});


### PR DESCRIPTION
## Why

`previewPerfBreakdown` covers bins only, and baseplates share none of that pipeline. When a plate takes 32s on brepkit against 1.4s on occt-wasm ([brepkit#1488](https://github.com/andymai/brepkit/issues/1488)), there was no way to attribute the gap to a construction step, so the upstream fix was being validated against a native probe that turned out not to model the app path.

## What

Times each BREP milestone via the existing `BaseplateProbe` hook, plus the two post-build steps `generateBaseplate` runs (`mesh`, `creaseEdges`) at the tolerances the preview path picks. Diagnostic harness, not a CI gate, same posture as its bin-side sibling. Excluded from the default suite; runs under `vitest.profile.config.ts`.

No production code changes. The probe seam already existed for `diagnoseBaseplateWinding`.

## Validation

Totals track the `profileBin` baseplate rows to within noise, so the parts account for the whole:

| Plate | profileBin | this harness |
| --- | --- | --- |
| 2x2 plain | 267ms | 260ms |
| 4x4 plain | 876ms | 812ms |
| 6x4 magnets | 1493ms | 1375ms |

## What it found immediately

Under brepkit 3.2.12 at 6x4 magnets, tessellation is at parity (`mesh` 1.5x, `creaseEdges` 1.9x) and every BREP boolean is not: `pocketsCut` 31.7x, `cornerIntersected` 24.9x, `magnetHolesCut` 20.5x, `lightweightFloorCut` 19.7x. That rules out tessellation and the adapter boundary as the gap, which is what the upstream issue needed to know.

Test plan: `BREPJS_KERNEL=occt-wasm pnpm exec vitest run --config vitest.profile.config.ts baseplatePerfBreakdown`, typecheck clean, eslint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-stage performance harness for baseplate generation to pinpoint where time is spent across BREP milestones and post-build steps. Helps attribute `brepkit` vs `occt-wasm` gaps and rules out tessellation when appropriate.

- **New Features**
  - Adds a `vitest` node test that times `BaseplateProbe` milestones plus `mesh` (`brepjs`) and `creaseEdges` using preview tolerances.
  - Outputs a readable table to stdout and `PERF_OUT` (default `/tmp/perfbench/baseplate.txt`).
  - Runs only via `vitest.profile.config.ts` (e.g., `BREPJS_KERNEL=occt-wasm pnpm exec vitest run --config vitest.profile.config.ts baseplatePerfBreakdown`); not a CI gate.
  - No production code changes.
  - Validated: totals match existing `profileBin` baseplate rows within noise; early runs show boolean ops dominate on `brepkit`, not tessellation.

- **Bug Fixes**
  - Stabilizes the stage list across samples by always including the post-final build row, preventing misaligned medians and out-of-bounds reads under timing jitter.

<sup>Written for commit 5986a50012b72176b906863bd96ec261c299db72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

