### PR TITLE
fix(seo): bring every page title under the SERP pixel budget

### DIFF
--- a/content/de/gridfinity-baseplate-generator.md
+++ b/content/de/gridfinity-baseplate-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Gridfinity-Grundplatten-Generator — Kostenloser Online-STL-Creator
+title: 'Gridfinity-Grundplatten-Generator: kostenlos als STL'
 description: Gridfinity-Grundplatten-Generator mit Echtzeit-3D-Vorschau. Rastergröße, Magnetlöcher und Randabstand konfigurieren. Export als STL, STEP oder 3MF.
 keywords: gridfinity grundplatte generator, gridfinity baseplate, individuelle gridfinity grundplatte, gridfinity STL, schubladen grundplatte, magnet grundplatte
 schema: HowTo

--- a/content/de/gridfinity-generator.md
+++ b/content/de/gridfinity-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Gridfinity-Generator — Kostenloser Online-Bin- und Grundplatten-Generator
+title: 'Gridfinity-Generator: Bins und Grundplatten kostenlos erstellen'
 description: Kostenloser Gridfinity-Generator. Erstelle Bins und Grundplatten im Browser, sieh sie in 3D vorab und exportiere als STL, STEP oder 3MF. Ohne Konto.
 keywords: gridfinity generator, gridfinity bin generator, gridfinity grundplatte generator, gridfinity STL generator, online gridfinity generator, kostenloser gridfinity generator
 schema: HowTo

--- a/content/es/gridfinity-baseplate-generator.md
+++ b/content/es/gridfinity-baseplate-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Generador de placas base Gridfinity — Creador STL en línea gratis
+title: 'Generador de placas base Gridfinity: STL gratis en línea'
 description: Generador de placas base Gridfinity con vista previa 3D. Configura la cuadrícula, orificios para imanes y márgenes. Exporta a STL, STEP o 3MF. Gratis.
 keywords: generador placa gridfinity, gridfinity baseplate, placa gridfinity personalizada, gridfinity STL, placa para cajón, placa con imanes
 schema: HowTo

--- a/content/fr/gridfinity-baseplate-generator.md
+++ b/content/fr/gridfinity-baseplate-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Générateur de plaques de base Gridfinity — Créateur STL en ligne gratuit
+title: 'Générateur de plaques de base Gridfinity : STL gratuit'
 description: Générateur de plaques de base Gridfinity avec aperçu 3D. Configurez la grille, les trous d’aimants et les marges. Export en STL, STEP ou 3MF. Gratuit.
 keywords: gridfinity générateur plaque, gridfinity baseplate, plaque gridfinity personnalisée, gridfinity STL, plaque pour tiroir, plaque magnétique
 schema: HowTo

--- a/content/gridfinity-kitchen-drawer.md
+++ b/content/gridfinity-kitchen-drawer.md
@@ -1,5 +1,5 @@
 ---
-title: Gridfinity Kitchen Drawer Organizer — Utensils, Cutlery & Junk Drawers
+title: 'Gridfinity Kitchen Drawer Organizer: Utensils & Cutlery'
 description: Organize kitchen drawers with 3D-printed Gridfinity bins. Plan utensil, cutlery, and junk drawer layouts, then print bins that fit exactly. Free.
 keywords: gridfinity kitchen drawer, gridfinity kitchen drawer organizer, gridfinity utensil drawer, gridfinity silverware organizer, gridfinity cutlery organizer, gridfinity junk drawer, 3d printed kitchen drawer organizer
 schema: HowTo

--- a/content/gridfinity-software.md
+++ b/content/gridfinity-software.md
@@ -1,5 +1,5 @@
 ---
-title: Gridfinity Software Compared — Online Generators vs CAD Plugins
+title: 'Gridfinity Software Compared: Generators vs CAD Plugins'
 description: Online generators, OpenSCAD, Fusion 360 and Blender plugins, and STL libraries compared. Which way to make Gridfinity bins fits your workflow, and when.
 keywords: gridfinity software, gridfinity generator online, gridfinity fusion 360, gridfinity plugin, blender gridfinity, gridfinity openscad, gridfinity configurator, gridfinity customizer, online gridfinity generator
 schema: Article

--- a/content/nb/gridfinity-generator.md
+++ b/content/nb/gridfinity-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Gridfinity-generator — Gratis bin- og grunnplate-generator på nett
+title: 'Gridfinity-generator: gratis bins og grunnplater på nett'
 description: Gratis Gridfinity-generator. Lag egne bins og grunnplater i nettleseren, forhåndsvis i 3D og eksporter som STL, STEP eller 3MF. Uten konto.
 keywords: gridfinity generator, gridfinity bin-generator, gridfinity grunnplate-generator, gridfinity STL, gridfinity online, gridfinity gratis
 schema: HowTo

--- a/content/nl/gridfinity-generator.md
+++ b/content/nl/gridfinity-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Gridfinity-generator — Gratis online bin- en bodemplaat-generator
+title: 'Gridfinity-generator: gratis bins en bodemplaten online'
 description: Gratis Gridfinity-generator. Maak eigen bins en bodemplaten in je browser, bekijk in 3D en exporteer als STL, STEP of 3MF. Zonder account.
 keywords: gridfinity generator, gridfinity bin generator, gridfinity bodemplaat generator, gridfinity STL, gridfinity online, gridfinity gratis
 schema: HowTo

--- a/content/pt-BR/gridfinity-generator.md
+++ b/content/pt-BR/gridfinity-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Gerador Gridfinity — Gerador online gratuito de bins e placas-base
+title: 'Gerador Gridfinity: bins e placas-base grátis online'
 description: Gerador Gridfinity gratuito. Crie bins e placas-base no navegador, visualize em 3D e exporte para STL, STEP ou 3MF. Sem instalar e sem conta.
 keywords: gerador gridfinity, gridfinity bin generator, gerador placa gridfinity, gridfinity STL, gridfinity online, gridfinity grátis
 schema: HowTo

--- a/content/sv/gridfinity-generator.md
+++ b/content/sv/gridfinity-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Gridfinity-generator — Gratis bin- och bottenplatta-generator online
+title: 'Gridfinity-generator: gratis bins och bottenplattor online'
 description: Gratis Gridfinity-generator. Skapa bins och bottenplattor i din webbläsare, förhandsgranska i 3D och exportera som STL, STEP eller 3MF. Utan konto.
 keywords: gridfinity generator, gridfinity bin-generator, gridfinity bottenplatta-generator, gridfinity STL, gridfinity online, gridfinity gratis
 schema: HowTo

--- a/content/uk/gridfinity-baseplate-generator.md
+++ b/content/uk/gridfinity-baseplate-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Генератор основ Gridfinity — Безкоштовний онлайн-конструктор STL
+title: 'Генератор основ Gridfinity: безкоштовний конструктор STL'
 description: Генератор основ Gridfinity з 3D-переглядом. Налаштуйте розмір сітки, магнітні отвори та відступ по краях. Експорт у STL, STEP або 3MF. Безкоштовно.
 keywords: генератор основ gridfinity, gridfinity baseplate, власна основа gridfinity, gridfinity STL, основа для шухляди, магнітна основа
 schema: HowTo

--- a/content/uk/gridfinity-bin-generator.md
+++ b/content/uk/gridfinity-bin-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Генератор Gridfinity bin — Безкоштовний онлайн-конструктор STL
+title: 'Генератор Gridfinity bin: безкоштовний конструктор STL'
 description: Генератор Gridfinity bin із візуальним редактором і 3D-переглядом. Задайте розміри, додайте відсіки та вирізи, експортуйте у STL, STEP або 3MF.
 keywords: gridfinity генератор, генератор bin gridfinity, gridfinity STL, власні gridfinity bins, gridfinity дизайнер, gridfinity онлайн
 schema: HowTo

--- a/content/uk/gridfinity-generator.md
+++ b/content/uk/gridfinity-generator.md
@@ -1,5 +1,5 @@
 ---
-title: Генератор Gridfinity — Безкоштовний онлайн-генератор bin і основ
+title: 'Генератор Gridfinity: bin і основи безкоштовно онлайн'
 description: Безкоштовний генератор Gridfinity. Створюйте bin і основи у браузері, переглядайте у 3D і експортуйте у STL, STEP або 3MF. Без облікового запису.
 keywords: генератор gridfinity, gridfinity bin generator, gridfinity baseplate generator, gridfinity STL, gridfinity онлайн, gridfinity безкоштовно
 schema: HowTo


### PR DESCRIPTION
The last 13 build warnings. **`pnpm run build:content` now emits zero warnings.**

## What they had in common

All 13 were the same shape, `X — Y` where Y restated X:

| Before | px |
|---|---:|
| `Gridfinity-Generator — Kostenloser Online-Bin- und Grundplatten-Generator` | 675 |
| `Генератор основ Gridfinity — Безкоштовний онлайн-конструктор STL` | 653 |
| `Gridfinity Software Compared — Online Generators vs CAD Plugins` | 598 |

Six locale titles said "generator" on both sides of the dash. The em dash is also the widest glyph in the width table at 20px, so the construction cost ~20px before any words. Cutting the restatement brings every title to **449-559px** against the 580px column, with the keyword still at the front.

It also removes the em dashes, which the house style does not use in user-facing copy.

Titles are YAML-quoted now that they carry a colon.

## Verified

Rendered output checked across Latin, accented and Cyrillic locales:

```
de/gridfinity-generator     Gridfinity-Generator: Bins und Grundplatten kostenlos erstellen
uk/...baseplate-generator   Генератор основ Gridfinity: безкоштовний конструктор STL
fr/...baseplate-generator   Générateur de plaques de base Gridfinity : STL gratuit
nb/gridfinity-generator     Gridfinity-generator: gratis bins og grunnplater på nett
```

With this and #3355, every SERP-facing title and description across all 84 generated pages is inside Google's display budget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened all remaining page titles to fit Google’s SERP pixel limit and match house style. The content build now has zero warnings.

- **Bug Fixes**
  - Rewrote 13 localized titles to remove the “X — Y” restatement and replace the em dash with a colon.
  - Kept the keyword first; titles now measure 449–559px within the 580px budget.
  - Quoted titles in YAML where colons were added.
  - Verified across Latin, accented, and Cyrillic locales; `pnpm run build:content` is clean.

<sup>Written for commit 105efcdad762d0e38ac298ee2fe5abd69660ec31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

