### PR TITLE
chore(deps): bump brepkit-wasm to 3.2.16 and brepjs to 18.124.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.2",
-    "brepkit-wasm": "3.2.15",
+    "brepkit-wasm": "3.2.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.124.2
-        version: 18.124.2(patch_hash=cdbc7cbdbdba1a63ffdaa6b22c2783aaa05ab361876c440a39eab47b57043732)(brepkit-wasm@3.2.15)(occt-wasm@4.2.0)
+        version: 18.124.2(patch_hash=cdbc7cbdbdba1a63ffdaa6b22c2783aaa05ab361876c440a39eab47b57043732)(brepkit-wasm@3.2.16)(occt-wasm@4.2.0)
       brepkit-wasm:
-        specifier: 3.2.15
-        version: 3.2.15
+        specifier: 3.2.16
+        version: 3.2.16
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3188,8 +3188,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@3.2.15:
-    resolution: {integrity: sha512-+SdwvkJkeThWY+YCS5zRKzJS2GX+AuLBFCwUtB08GWYUx4hBFmz/FjaobmmaPetFzBmHRrdbXOl8El1DKS+R0A==}
+  brepkit-wasm@3.2.16:
+    resolution: {integrity: sha512-mVqCLiuwxXL7We6Gqsuqv4ptFG+zsal5O3gretqINMQUQY+SdUViQGGfFIJvKFhSwo936Tx6febVVKaUczv7mQ==}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -8691,15 +8691,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.124.2(patch_hash=cdbc7cbdbdba1a63ffdaa6b22c2783aaa05ab361876c440a39eab47b57043732)(brepkit-wasm@3.2.15)(occt-wasm@4.2.0):
+  brepjs@18.124.2(patch_hash=cdbc7cbdbdba1a63ffdaa6b22c2783aaa05ab361876c440a39eab47b57043732)(brepkit-wasm@3.2.16)(occt-wasm@4.2.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 3.2.15
+      brepkit-wasm: 3.2.16
       occt-wasm: 4.2.0
 
-  brepkit-wasm@3.2.15: {}
+  brepkit-wasm@3.2.16: {}
 
   browserslist@4.28.7:
     dependencies:


### PR DESCRIPTION
## Summary

- brepkit-wasm 3.2.13 → 3.2.16: kumiko cutAll chain fixes (brepkit#1499 false trivial-containment EmptyResult + untrimmed-parent-curve volume misreads, brepkit#1508 wasm timer panic) and the export-tessellation spatial hash (brepkit#1500).
- brepjs 18.123.0 → 18.124.2: `cutAll` accepts compound bases (brepjs#1996), so carving loops that feed their own output back in compose.

## Verified on these exact pins (stock npm packages, no overlays)

- `BREPJS_KERNEL=brepkit vitest --config vitest.profile.config.ts kumikoProfile`: **passes** (failed on the old pins with `cutAll requires a solid, got compound`).
- `exportCache`: first=706-740ms, second=490-503ms across 3 runs (reference kernel on the same machine: 1691-1739 / 890-906), volumes matching. The warm re-export flips from a 1.37x deficit to a 1.8x lead.

Closes the tool side of brepkit#1499, brepkit#1500, brepkit#1508.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `brepkit-wasm` to 3.2.16 and `brepjs` to 18.124.2. Fixes `cutAll` chain errors, enables compound-base cuts, speeds up export tessellation, and resolves a wasm timer panic.

- **Bug Fixes**
  - Prevent false EmptyResult in trivial containment during `cutAll`.
  - Fix volume misreads from untrimmed parent curves.
  - Resolve wasm timer panic.

- **New Features**
  - `cutAll` accepts compound bases in `brepjs`, enabling fan-out loops in compose.
  - Faster export tessellation via a spatial hash.

<sup>Written for commit 196d846341e89c30e248f68c1be5b96341c9668c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

