### PR TITLE
fix(seo): open reference pages with the promise, not the answer

### DIFF
--- a/content/gridfinity-sizes.md
+++ b/content/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: 'Gridfinity Sizes & Dimensions: Full Tables in mm and Inches'
-description: Every Gridfinity bin and baseplate dimension in one table, in millimeters and inches, plus a converter that turns drawer measurements into grid units.
+description: Every Gridfinity bin and baseplate dimension in millimeters and inches, plus height units, common bin sizes, and how to convert a drawer to grid units.
 keywords: gridfinity sizes, gridfinity dimensions, gridfinity bin sizes, gridfinity height units, gridfinity 42mm, gridfinity grid size, standard gridfinity size, why is gridfinity 42mm
 schema: Article
 breadcrumbs:
@@ -25,7 +25,7 @@ faqs:
 
 # Gridfinity Sizes & Dimensions
 
-Every Gridfinity bin and baseplate size, tabulated in millimeters and inches, with a converter that turns your own drawer measurements into grid units. Look up a size in the tables below, or measure the drawer and let the converter work out the grid that fits.
+Every Gridfinity bin and baseplate size, tabulated in millimeters and inches: grid units, height units, common bin sizes, and what fits on a print bed. Look up a size in the tables below, or measure your drawer and convert it to grid units in three steps.
 
 **One Gridfinity grid unit is 42mm × 42mm (width and depth), and one height unit (1U) is 7mm.** Every size on this page is a multiple of those two numbers: a 2×3 bin at 6U measures 84mm × 126mm × 42mm. Half-bin mode adds 0.5-unit (21mm) steps.
 
@@ -91,6 +91,8 @@ Gap at edges:  2mm width, 16mm depth
 ```
 
 Small gaps at the edges are normal. Baseplates don't need to fill every millimeter. Most people center the baseplates and ignore the gap.
+
+To skip the arithmetic, the [drawer calculator](/gridfinity-calculator) does the same conversion and reports the leftover space and the tallest bin that fits.
 
 ## Common Bin Sizes
 

--- a/content/gridfinity-sizes.md
+++ b/content/gridfinity-sizes.md
@@ -25,7 +25,9 @@ faqs:
 
 # Gridfinity Sizes & Dimensions
 
-**One Gridfinity grid unit is 42mm × 42mm (width and depth), and one height unit (1U) is 7mm.** Full size tables for every bin and baseplate, in millimeters and inches, are below. Every size is a multiple of those two numbers: a 2×3 bin at 6U measures 84mm × 126mm × 42mm. Half-bin mode adds 0.5-unit (21mm) steps, and the drawer converter turns your own measurements into grid units.
+Every Gridfinity bin and baseplate size, tabulated in millimeters and inches, with a converter that turns your own drawer measurements into grid units. Look up a size in the tables below, or measure the drawer and let the converter work out the grid that fits.
+
+**One Gridfinity grid unit is 42mm × 42mm (width and depth), and one height unit (1U) is 7mm.** Every size on this page is a multiple of those two numbers: a 2×3 bin at 6U measures 84mm × 126mm × 42mm. Half-bin mode adds 0.5-unit (21mm) steps.
 
 ## Grid Units (Width & Depth)
 

--- a/content/what-is-gridfinity.md
+++ b/content/what-is-gridfinity.md
@@ -41,7 +41,9 @@ faqs:
 
 # What is Gridfinity?
 
-Gridfinity is a free, open-source storage system you 3D print: bins rest on a 42mm baseplate grid, so every maker's design fits. Here's how to start. Standard bin sizes mean anything you print is interchangeable with anything anyone else prints. Zack Freedman, a maker and YouTuber, created it in 2022, and there are now over 10,000 free designs on Printables alone.
+A practical walkthrough of the 3D-printed storage system: what Gridfinity is, what you need to print your first drawer, and how to plan one that fits. Start here if you own a 3D printer and a drawer that has got away from you.
+
+Gridfinity is a free, open-source storage system you 3D print: bins rest on a 42mm baseplate grid, so every maker's design fits. Standard bin sizes mean anything you print is interchangeable with anything anyone else prints. Zack Freedman, a maker and YouTuber, created it in 2022, and there are now over 10,000 free designs on Printables alone.
 
 The idea is simple: everything uses a 42mm grid. Bins rest on baseplates. Baseplates tile to fill any drawer. When you need to reorganize, pick up the bins and move them.
 


### PR DESCRIPTION
## Why

`/gridfinity-sizes` ranks **4.29**, better than any other page on the site, and converts at **0.38x** the CTR expected at that position. `/what-is-gridfinity` runs at **0.32x**. Together that is roughly **940 clicks per three-month window**.

Google replaces the meta description most of the time on desktop and builds the snippet from the opening paragraph instead. Both pages opened by stating the answer outright, so the reader never needed to arrive. The August Search Console export shows it plainly:

| query | position | impressions | clicks |
| --- | --- | --- | --- |
| why is gridfinity 42mm | 3.84 | 50 | **0** |
| what is the standard gridfinity size | 3.94 | 48 | **0** |
| gridfinity unit height | 4.42 | 43 | **0** |
| gridfinity dimensions | 2.85 | 657 | 30 (par is ~77) |

## What changed

Both opening paragraphs now lead with what a snippet cannot deliver, and each closes a sentence inside the 155-character window Google reads:

- `/gridfinity-sizes` opens on the full mm-and-inch tables plus the drawer converter.
- `/what-is-gridfinity` opens on the print-your-first-drawer walkthrough.

The 42mm and 7mm answer keeps its bold sentence one paragraph down. The `faqs:` entries and the FAQPage schema are untouched, so featured-snippet and rich-result eligibility are unchanged.

## Verification

- `pnpm run build:content` is clean, zero SERP title-width warnings.
- Generated `public/gridfinity-sizes/index.html` carries the new paragraph as its first `<p>`.
- Snippet window checked programmatically: both openings close a sentence at char 150/151 of 155, and neither states a dimension inside it.
- 63 tests pass across `learnLinks`, `Sidebar`, `MobileAboutStrip` and `serpTitle`.

## Scope

English only. The 12 locale copies carry 5.2% of clicks and need translation, so they keep the current openings for now.

Titles and meta descriptions were already promise-shaped from the pass in #3358, so this changes only the body copy Google actually samples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the openings for `/gridfinity-sizes` and `/what-is-gridfinity` to lead with the promise (tables + print-bed check, and a first-drawer guide) instead of the answer, to lift CTR from Google snippets. Featured snippet and rich result eligibility remain unchanged.

- **Content Updates**
  - `/gridfinity-sizes`: Opens with mm/inch tables and a print-bed check; the 42mm/7mm definition moves one paragraph down. Drops the in-page “converter” claim and links to the `/gridfinity-calculator`.
  - `/what-is-gridfinity`: Opens with a practical first-drawer walkthrough.
  - Both openings close a sentence within ~155 characters to shape the snippet without giving dimensions.
  - Schema unchanged; meta description updated to remove the converter claim. English only; locales unchanged.

<sup>Written for commit d825346a0b35de7bc19641c21c0bf178f28328ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

