### PR TITLE
fix(ui): size the context menu to its widest item

### DIFF
--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -12,6 +12,11 @@ import {
 const MAX_REASONABLE_MENU_WIDTH = 320;
 
 test.describe('Bin context menu', () => {
+  // The container clamps itself to the viewport, so a narrow one hides an oversized
+  // menu behind the clamp: on a 393px-wide project the regression measured 323px,
+  // barely over the bound. Pin a wide viewport so the width is purely intrinsic.
+  test.use({ viewport: { width: 1280, height: 800 } });
+
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await waitForAppReady(page);

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -1,0 +1,40 @@
+import {
+  test,
+  expect,
+  waitForAppReady,
+  getGridBounds,
+  waitForBinCount,
+  clearAllStorage,
+  resetViewport,
+} from './fixtures';
+
+/** Widest label ("Link Existing Design") plus icon and padding sits near 220px. */
+const MAX_REASONABLE_MENU_WIDTH = 320;
+
+test.describe('Bin context menu', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+    await clearAllStorage(page);
+    await resetViewport(page);
+  });
+
+  test('sizes to its widest item, not the sum of its items', async ({ page }) => {
+    const bounds = await getGridBounds(page);
+    await page.mouse.click(bounds.x + 60, bounds.y + 60);
+    await waitForBinCount(page, 1);
+
+    await page.mouse.click(bounds.x + 60, bounds.y + 60, { button: 'right' });
+
+    const menu = page.getByRole('menu').first();
+    await expect(menu).toBeVisible();
+
+    const box = await menu.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box?.width).toBeLessThan(MAX_REASONABLE_MENU_WIDTH);
+  });
+});

--- a/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.test.tsx
+++ b/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.test.tsx
@@ -51,6 +51,16 @@ describe('ContextMenuItem', () => {
     expect(handleClick).not.toHaveBeenCalled();
   });
 
+  // Inline-level items share a line during the shrink-to-fit container's max-content
+  // pass, so their widths sum and the menu balloons to the total. jsdom has no layout,
+  // so pin the display class instead.
+  it('is block-level, not inline-flex', () => {
+    render(<ContextMenuItem icon={mockIcon} label="Edit" onClick={vi.fn()} />);
+    const button = screen.getByRole('menuitem');
+    expect(button).toHaveClass('flex');
+    expect(button).not.toHaveClass('inline-flex');
+  });
+
   it('has menuitem role', () => {
     render(<ContextMenuItem icon={mockIcon} label="Menu Item" onClick={vi.fn()} />);
     expect(screen.getByRole('menuitem')).toBeInTheDocument();

--- a/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.tsx
+++ b/src/shared/components/ContextMenu/ContextMenuItem/ContextMenuItem.tsx
@@ -40,7 +40,10 @@ export function ContextMenuItem({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        'justify-start gap-3 rounded-none px-4 py-3 font-normal',
+        // Block-level `flex`, not the Button default `inline-flex`: the menu container is
+        // shrink-to-fit, and `w-full` is a percentage that intrinsic sizing ignores — so
+        // inline items would share one line and their max-content widths would sum.
+        'flex justify-start gap-3 rounded-none px-4 py-3 font-normal',
         destructive ? 'text-error hover:text-error' : 'text-content'
       )}
     >

--- a/src/shell/STLSearchDropdown/STLSearchDropdown.tsx
+++ b/src/shell/STLSearchDropdown/STLSearchDropdown.tsx
@@ -194,7 +194,7 @@ export function STLSearchDropdown({
           fullWidth
           type="button"
           onClick={handleClick}
-          className={`justify-start px-4 py-3 gap-3 rounded-none text-content hover:bg-surface-hover ${className}`}
+          className={`flex justify-start px-4 py-3 gap-3 rounded-none text-content hover:bg-surface-hover ${className}`}
           aria-label={t('stlSearch.searchFor', {
             width: formatDimension(width),
             depth: formatDimension(depth),


### PR DESCRIPTION
The Layout right-click menu rendered 820px wide. It now renders 218px.

## Cause

`ContextMenuContainer` is `position: fixed` with `width: auto`, so the browser shrink-to-fits it to `min(available, max-content)`. Its rows are design-system `Button`s, which are `inline-flex`; `fullWidth` gives them `width: 100%`, and percentages are ignored during intrinsic sizing.

So in the `max-content` pass the rows had no width constraint and, being inline-level, all laid out on a single line. Their widths summed:

```
Duplicate 133 + Rotate 110 + Lock Size 133 + Expand to Fit 163
  + To Stash 125 + Find STL 156 = 820px
```

against a widest single row of 216px. The layer and category pickers each sit in their own `<div>`, which is why they never contributed.

## Fix

Make the two row types that appear consecutively without a block wrapper block-level: `ContextMenuItem` and the STL search `menu-item` variant. `cn`'s tailwind-merge resolves `flex` over the `inline-flex` base.

Every menu built on `ContextMenuContainer` picks this up: single-bin, multi-bin, and the STL search submenu.

## Verification

Measured in Chromium via Playwright before and after: 820px → 218px, with row layout unchanged. Covered by a new `e2e/context-menu.spec.ts` asserting the rendered width, plus a unit assertion pinning the display class (jsdom has no layout).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Context menus now size to their widest item (~218px) instead of summing row widths (~820px). This fixes oversized menus across single-bin, multi-bin, and the STL search submenu.

- **Bug Fixes**
  - Made `ContextMenuItem` and the STL search menu item block-level `flex` (not `inline-flex`) so the shrink-to-fit container sizes to the widest row.
  - Tests: e2e asserts width stays under 320px with a pinned wide viewport; unit test pins the `flex` display class.

<sup>Written for commit e2dc49b7eb4109e045de771043a158dc54ba0de3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

