### PR TITLE
feat(seo): give community design pages their own crawlable content

### DIFF
--- a/api/community/page.test.ts
+++ b/api/community/page.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { escapeAttr, injectDesignMeta, truncate } from './page.js';
+import {
+  designJsonLd,
+  escapeAttr,
+  injectDesignMeta,
+  isIndexable,
+  renderDesignFallback,
+  truncate,
+} from './page.js';
 import type { DesignMeta } from './page.js';
 
 const SITE = 'https://gridfinitylayouttool.com';
@@ -8,6 +15,7 @@ const SHELL = [
   '<!doctype html><html><head>',
   '<title>Gridfinity Layout Tool</title>',
   '<meta name="description" content="Plan drawer organizers.">',
+  '<meta name="robots" content="index, follow">',
   '<link rel="canonical" href="https://gridfinitylayouttool.com/">',
   '<meta property="og:url" content="https://gridfinitylayouttool.com/">',
   '<meta property="og:title" content="Gridfinity Layout Tool">',
@@ -17,7 +25,13 @@ const SHELL = [
   '<meta property="og:image:width" content="1200">',
   '<meta property="og:image:height" content="630">',
   '<meta property="og:image:alt" content="Gridfinity Layout Tool">',
-  '</head><body><script>boot()</script></body></html>',
+  '</head><body>',
+  '<div id="root"><div id="seo-fallback" style="display:none; padding: 20px;">',
+  '<noscript><style>#seo-fallback{display:block!important}</style></noscript>',
+  '<h1>Gridfinity Planner &amp; Layout Tool</h1>',
+  '<p>A free Gridfinity planner for making bins.</p>',
+  '</div></div>',
+  '<script>boot()</script></body></html>',
 ].join('');
 
 function design(overrides: Partial<DesignMeta> = {}): DesignMeta {
@@ -27,6 +41,10 @@ function design(overrides: Partial<DesignMeta> = {}): DesignMeta {
     authorName: 'ada',
     description: 'Holds twelve hex drivers upright so you can read the sizes.',
     thumbnailUrl: 'https://blob.test/thumb.webp',
+    category: 'tools',
+    metrics: { width: 83.5, depth: 41.5, height: 21, gridUnitMm: 42 },
+    counts: { likes: 3, remixes: 0, prints: 1 },
+    featured: false,
     ...overrides,
   };
 }
@@ -46,11 +64,70 @@ describe('injectDesignMeta', () => {
     expect(html).toContain('Holds twelve hex drivers upright');
   });
 
-  it('leaves the body and boot scripts byte-identical', () => {
+  it('leaves the boot scripts byte-identical', () => {
     // The shell's inline scripts are covered by CSP hashes; changing a byte of
-    // them would block the app from booting.
+    // them would block the app from booting. The SEO fallback is not a script
+    // and is deliberately replaced — everything else in the body is not.
     const html = injectDesignMeta(SHELL, design(), SITE);
-    expect(html).toContain('<body><script>boot()</script></body>');
+    expect(html).toContain('<script>boot()</script></body>');
+  });
+
+  it('replaces the homepage fallback copy with the design’s own', () => {
+    // Without this every design page served the same planner text under the same
+    // h1, which is why the route was disallowed instead of indexed.
+    const html = injectDesignMeta(SHELL, design(), SITE);
+    expect(html).toContain('<h1>Hex Driver Nest</h1>');
+    expect(html).not.toContain('<h1>Gridfinity Planner &amp; Layout Tool</h1>');
+    expect(html).not.toContain('A free Gridfinity planner for making bins.');
+    expect(html).toContain('Holds twelve hex drivers upright');
+  });
+
+  it('keeps the fallback’s opening tag and its noscript reveal', () => {
+    // The inline display:none lives on the opening tag, and the noscript inside
+    // is the only thing that shows the block to a visitor without JS.
+    const html = injectDesignMeta(SHELL, design(), SITE);
+    expect(html).toContain('<div id="seo-fallback" style="display:none; padding: 20px;">');
+    expect(html).toContain(
+      '<noscript><style>#seo-fallback{display:block!important}</style></noscript>'
+    );
+  });
+
+  it('states the size in grid units and millimetres', () => {
+    const html = injectDesignMeta(SHELL, design(), SITE);
+    expect(html).toContain('2×1 at 3U');
+    expect(html).toContain('83.5mm × 41.5mm × 21mm');
+  });
+
+  it('marks a design below the quality bar noindex and gives it no schema', () => {
+    const html = injectDesignMeta(
+      SHELL,
+      design({ counts: { likes: 0, remixes: 0, prints: 0 } }),
+      SITE
+    );
+    expect(html).toContain('<meta name="robots" content="noindex, follow">');
+    expect(html).not.toContain('application/ld+json');
+    // It still gets its own title and copy: scrapers and humans want those.
+    expect(html).toContain('<title>Hex Driver Nest by ada — Gridfinity Community</title>');
+    expect(html).toContain('<h1>Hex Driver Nest</h1>');
+  });
+
+  it('leaves an indexable design indexable and adds its schema', () => {
+    const html = injectDesignMeta(SHELL, design(), SITE);
+    expect(html).toContain('<meta name="robots" content="index, follow">');
+    expect(html).toContain('"@type":"CreativeWork"');
+    expect(html).toContain('</script></head>');
+  });
+
+  it('escapes a design name in the body, not just the meta', () => {
+    const html = injectDesignMeta(SHELL, design({ name: '<script>alert(1)</script>' }), SITE);
+    expect(html).not.toContain('<script>alert(1)</script>');
+  });
+
+  it('keeps a dollar sign in a design name literal', () => {
+    // replaceOne replaces via a function precisely so `$&` in user text is not
+    // treated as a replacement pattern.
+    const html = injectDesignMeta(SHELL, design({ name: 'Cost $& Value' }), SITE);
+    expect(html).toContain('Cost $&amp; Value');
   });
 
   it('escapes markup in a design name rather than emitting it', () => {
@@ -102,6 +179,125 @@ describe('injectDesignMeta', () => {
     expect(html.match(/property="og:title"/g)).toHaveLength(2);
     // The tags that are still unique are still swapped.
     expect(html).toContain('<meta property="og:type" content="article">');
+  });
+});
+
+describe('isIndexable', () => {
+  it('accepts a complete design someone has engaged with', () => {
+    expect(isIndexable(design())).toBe(true);
+  });
+
+  it('rejects a design nobody has touched', () => {
+    // Complete metadata is not enough: an unused page is crawl budget spent on
+    // nothing, and with a young gallery most designs are in this state.
+    expect(isIndexable(design({ counts: { likes: 0, remixes: 0, prints: 0 } }))).toBe(false);
+  });
+
+  it('accepts a featured design regardless of counts', () => {
+    expect(
+      isIndexable(design({ featured: true, counts: { likes: 0, remixes: 0, prints: 0 } }))
+    ).toBe(true);
+  });
+
+  it('rejects the default untitled name', () => {
+    expect(isIndexable(design({ name: 'Untitled layout' }))).toBe(false);
+    expect(isIndexable(design({ name: 'untitled' }))).toBe(false);
+  });
+
+  it('does not reject a real name that merely starts with the same letters', () => {
+    expect(isIndexable(design({ name: 'Untitledish Bracket' }))).toBe(true);
+  });
+
+  it('rejects a design with no render to show', () => {
+    expect(isIndexable(design({ thumbnailUrl: '' }))).toBe(false);
+  });
+
+  it('rejects a design with no real dimensions', () => {
+    expect(
+      isIndexable(design({ metrics: { width: 0, depth: 0, height: 0, gridUnitMm: 42 } }))
+    ).toBe(false);
+  });
+});
+
+describe('renderDesignFallback', () => {
+  it('omits the details list when there is nothing to put in it', () => {
+    const html = renderDesignFallback(
+      design({
+        category: '',
+        description: '',
+        thumbnailUrl: '',
+        metrics: { width: 0, depth: 0, height: 0, gridUnitMm: 0 },
+        counts: { likes: 0, remixes: 0, prints: 0 },
+      }),
+      `${SITE}/community/d/Abc123456789`
+    );
+    expect(html).not.toContain('<h2>Design details</h2>');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('<h1>Hex Driver Nest</h1>');
+  });
+
+  it('names an empty design rather than emitting an empty heading', () => {
+    const html = renderDesignFallback(design({ name: '  ' }), SITE);
+    expect(html).toContain('<h1>Untitled design</h1>');
+  });
+
+  it('links back to the gallery and the tool', () => {
+    const html = renderDesignFallback(design(), SITE);
+    expect(html).toContain('href="/community"');
+    expect(html).toContain('href="/"');
+  });
+});
+
+describe('designJsonLd', () => {
+  const url = `${SITE}/community/d/Abc123456789`;
+
+  it('declares a CC BY licensed CreativeWork, not a product', () => {
+    const graph: unknown = JSON.parse(
+      designJsonLd(design(), url)
+        .replace('<script type="application/ld+json">', '')
+        .replace('</script>', '')
+    );
+    expect(graph).toMatchObject({
+      '@type': 'CreativeWork',
+      url,
+      name: 'Hex Driver Nest',
+      author: { '@type': 'Person', name: 'ada' },
+      license: 'https://creativecommons.org/licenses/by/4.0/',
+      isAccessibleForFree: true,
+    });
+  });
+
+  it('omits fields the design does not have rather than emitting empties', () => {
+    const json = designJsonLd(
+      design({
+        description: '',
+        thumbnailUrl: '',
+        category: '',
+        counts: { likes: 0, remixes: 0, prints: 0 },
+      }),
+      url
+    );
+    expect(json).not.toContain('"description"');
+    expect(json).not.toContain('"image"');
+    expect(json).not.toContain('"genre"');
+    expect(json).not.toContain('interactionStatistic');
+  });
+
+  it('cannot be broken out of with a closing script tag in a design name', () => {
+    // HTML escaping does not apply inside a <script> block, so `</script>` in
+    // user text would close the element and turn the rest into live markup.
+    const json = designJsonLd(
+      design({ name: '</script><img src=x onerror=alert(1)>', description: '</SCRIPT>' }),
+      url
+    );
+    expect(json).not.toContain('</script><img');
+    expect(json.match(/<\/script>/gi)).toHaveLength(1);
+    expect(json).toContain('\\u003c/script>');
+    // Still valid JSON, and the name survives intact once parsed.
+    const parsed = JSON.parse(
+      json.replace('<script type="application/ld+json">', '').replace(/<\/script>$/, '')
+    ) as { name: string };
+    expect(parsed.name).toBe('</script><img src=x onerror=alert(1)>');
   });
 });
 

--- a/api/community/page.test.ts
+++ b/api/community/page.test.ts
@@ -111,6 +111,61 @@ describe('injectDesignMeta', () => {
     expect(html).toContain('<h1>Hex Driver Nest</h1>');
   });
 
+  it('also gates the bot-specific robots directives', () => {
+    // googlebot/bingbot meta OVERRIDE the generic robots meta for those
+    // crawlers, so gating only the generic one would let exactly the two
+    // crawlers that matter index a design the gate rejected.
+    const shell = SHELL.replace(
+      '<meta name="robots" content="index, follow">',
+      [
+        '<meta name="robots" content="index, follow">',
+        '<meta name="googlebot" content="index, follow, max-image-preview:large">',
+        '<meta name="bingbot" content="index, follow, max-snippet:-1">',
+      ].join('')
+    );
+    const html = injectDesignMeta(
+      shell,
+      design({ counts: { likes: 0, remixes: 0, prints: 0 } }),
+      SITE
+    );
+    expect(html).toContain('<meta name="googlebot" content="noindex, follow">');
+    expect(html).toContain('<meta name="bingbot" content="noindex, follow">');
+    expect(html).not.toContain('content="index, follow, max-image-preview:large"');
+  });
+
+  it('leaves the bot directives alone for an indexable design', () => {
+    const shell = SHELL.replace(
+      '<meta name="robots" content="index, follow">',
+      '<meta name="robots" content="index, follow"><meta name="googlebot" content="index, follow, max-snippet:-1">'
+    );
+    const html = injectDesignMeta(shell, design(), SITE);
+    expect(html).toContain('<meta name="googlebot" content="index, follow, max-snippet:-1">');
+  });
+
+  it('finds the fallback’s real close when the block has a nested div', () => {
+    // Matching to the first </div> would truncate the element and leave broken
+    // markup on every design page.
+    const shell = SHELL.replace(
+      '<p>A free Gridfinity planner for making bins.</p>',
+      '<div class="wrap"><p>A free Gridfinity planner for making bins.</p></div>'
+    );
+    const html = injectDesignMeta(shell, design(), SITE);
+    expect(html).toContain('<h1>Hex Driver Nest</h1>');
+    expect(html).not.toContain('A free Gridfinity planner for making bins.');
+    expect(html).not.toContain('<div class="wrap">');
+    // The shell after the block is intact: root close, boot script, document end.
+    expect(html).toContain('</div></div><script>boot()</script></body></html>');
+  });
+
+  it('leaves the document alone when the fallback has no balanced close', () => {
+    const shell = SHELL.replace('</div></div>', '');
+    const html = injectDesignMeta(shell, design(), SITE);
+    expect(html).toContain('<h1>Gridfinity Planner &amp; Layout Tool</h1>');
+    expect(html).not.toContain('<h1>Hex Driver Nest</h1>');
+    // Meta injection still happened; only the body swap backed out.
+    expect(html).toContain('<title>Hex Driver Nest by ada — Gridfinity Community</title>');
+  });
+
   it('leaves an indexable design indexable and adds its schema', () => {
     const html = injectDesignMeta(SHELL, design(), SITE);
     expect(html).toContain('<meta name="robots" content="index, follow">');

--- a/api/community/page.ts
+++ b/api/community/page.ts
@@ -6,10 +6,17 @@
  * unfurls as the generic site card and opens with the generic tab title — on a
  * surface whose whole purpose is being shared.
  *
- * This is deliberately NOT about search indexing. `robots.txt` disallows
- * `/community/d/` until the showcase graduates from its Labs flag, and that
- * decision stands; social scrapers unfurl regardless of it, and the tab title
- * is for the person who followed the link.
+ * The shell's `#seo-fallback` block is swapped for the design's own content too.
+ * Injecting meta alone left every design page serving the homepage's planner
+ * copy under an `<h1>Gridfinity Planner & Layout Tool</h1>`, so N designs were N
+ * pages of identical text — which is why `/community/d/` was disallowed rather
+ * than indexed. The body has to differ before crawling it is worth allowing.
+ *
+ * Indexing is gated per design by `isIndexable`, not by the route: a design
+ * below the bar still gets its own title, preview and fallback copy (social
+ * scrapers and the person who followed the link want those regardless) but
+ * carries `noindex, follow`, so the crawl budget goes to designs someone has
+ * actually used.
  *
  * The shell is fetched from the deployment's own root rather than bundled: `/`
  * is not rewritten here, so there is no loop, and it keeps the injected page
@@ -81,6 +88,159 @@ export interface DesignMeta {
   readonly authorName: string;
   readonly description: string;
   readonly thumbnailUrl: string;
+  readonly category: string;
+  readonly metrics: {
+    readonly width: number;
+    readonly depth: number;
+    readonly height: number;
+    readonly gridUnitMm: number;
+  };
+  readonly counts: {
+    readonly likes: number;
+    readonly remixes: number;
+    readonly prints: number;
+  };
+  readonly featured: boolean;
+}
+
+/** Height units are a 7mm increment, independent of the 42mm grid unit. */
+const HEIGHT_UNIT_MM = 7;
+
+/**
+ * The default name a layout carries before anyone renames it. These arrive in
+ * bulk and describe nothing, so they never earn an indexable page — the export
+ * that prompted this work already had `/l/AAd0hpIhpNak/untitled-layout` in it.
+ */
+const PLACEHOLDER_NAME = /^untitled\b/i;
+
+/**
+ * Whether a design earns `index, follow`.
+ *
+ * Two independent bars, both required. Complete metadata means the page has
+ * something to say: a real name, a render to show, and real dimensions.
+ * A signal of real use means someone other than the author engaged with it —
+ * exports and views are excluded deliberately, since an author generates those
+ * on their own design just by working on it.
+ */
+export function isIndexable(design: DesignMeta): boolean {
+  const name = design.name.trim();
+  const complete =
+    name !== '' &&
+    !PLACEHOLDER_NAME.test(name) &&
+    design.thumbnailUrl !== '' &&
+    design.metrics.width > 0 &&
+    design.metrics.depth > 0 &&
+    design.metrics.height > 0;
+  const used =
+    design.featured ||
+    design.counts.likes > 0 ||
+    design.counts.prints > 0 ||
+    design.counts.remixes > 0;
+  return complete && used;
+}
+
+/** Grid footprint in whole units, from the millimetre size and the grid pitch. */
+function gridFootprint(metrics: DesignMeta['metrics']): string | null {
+  const { width, depth, height, gridUnitMm } = metrics;
+  if (gridUnitMm <= 0 || width <= 0 || depth <= 0) return null;
+  const w = Math.round(width / gridUnitMm);
+  const d = Math.round(depth / gridUnitMm);
+  if (w < 1 || d < 1) return null;
+  const u = Math.round(height / HEIGHT_UNIT_MM);
+  return u >= 1 ? `${w}×${d} at ${u}U` : `${w}×${d}`;
+}
+
+/**
+ * The design's own crawlable copy, replacing the homepage planner text.
+ *
+ * Written for someone who arrived on this page cold: what the design is, how
+ * big it is in both unit systems, and where to go next. The dimensions are the
+ * part a snippet cannot summarise away.
+ */
+export function renderDesignFallback(design: DesignMeta, url: string): string {
+  const name = escapeAttr(design.name.trim() === '' ? 'Untitled design' : design.name);
+  const author = escapeAttr(design.authorName);
+  const { width, depth, height } = design.metrics;
+  const footprint = gridFootprint(design.metrics);
+  const mm = width > 0 && depth > 0 ? `${width}mm × ${depth}mm × ${height}mm` : null;
+
+  const facts: string[] = [];
+  if (footprint !== null) facts.push(`<li>Grid footprint: ${footprint}</li>`);
+  if (mm !== null) facts.push(`<li>Size: ${mm}</li>`);
+  if (design.category !== '') facts.push(`<li>Category: ${escapeAttr(design.category)}</li>`);
+  if (design.counts.prints > 0) facts.push(`<li>Print reports: ${design.counts.prints}</li>`);
+  if (design.counts.remixes > 0) facts.push(`<li>Remixes: ${design.counts.remixes}</li>`);
+
+  // Mirrors the shell: the block is display:none, and this is what reveals it
+  // when JS is off. Dropping it would hide the fallback from the only visitors
+  // who actually read it.
+  const parts = [
+    '    <noscript><style>#seo-fallback{display:block!important}</style></noscript>',
+    `        <h1>${name}</h1>`,
+  ];
+  parts.push(
+    `        <p>A Gridfinity bin design shared by ${author}, free to remix and print under CC BY 4.0.</p>`
+  );
+  if (design.description.trim() !== '') {
+    parts.push(`        <p>${escapeAttr(truncate(design.description, 600))}</p>`);
+  }
+  if (design.thumbnailUrl !== '') {
+    parts.push(
+      `        <img src="${escapeAttr(design.thumbnailUrl)}" alt="${name}, a Gridfinity bin design by ${author}" width="384" height="384">`
+    );
+  }
+  if (facts.length > 0) {
+    parts.push(
+      '        <h2>Design details</h2>',
+      `        <ul>\n${facts.map((f) => `          ${f}`).join('\n')}\n        </ul>`
+    );
+  }
+  parts.push(
+    '        <p>',
+    `          <a href="${escapeAttr(url)}">Open this design</a> ·`,
+    '          <a href="/community">All community designs</a> ·',
+    '          <a href="/designer">Bin Designer</a> ·',
+    '          <a href="/gridfinity-sizes">Sizes Reference</a> ·',
+    '          <a href="/">Layout Planner</a>',
+    '        </p>'
+  );
+  return `\n${parts.join('\n')}\n      `;
+}
+
+/**
+ * Schema for an indexable design. `CreativeWork` rather than `Product`: there
+ * is no price, no offer and nothing for sale, and claiming otherwise invites a
+ * structured-data penalty rather than a rich result.
+ */
+export function designJsonLd(design: DesignMeta, url: string): string {
+  const graph: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'CreativeWork',
+    '@id': url,
+    url,
+    name: design.name,
+    author: { '@type': 'Person', name: design.authorName },
+    license: 'https://creativecommons.org/licenses/by/4.0/',
+    isAccessibleForFree: true,
+    inLanguage: 'en',
+  };
+  if (design.description.trim() !== '') {
+    graph.description = truncate(design.description, MAX_DESCRIPTION);
+  }
+  if (design.thumbnailUrl !== '') graph.image = design.thumbnailUrl;
+  if (design.category !== '') graph.genre = design.category;
+  if (design.counts.likes > 0) {
+    graph.interactionStatistic = {
+      '@type': 'InteractionCounter',
+      interactionType: 'https://schema.org/LikeAction',
+      userInteractionCount: design.counts.likes,
+    };
+  }
+  // A design name is user text, and inside a <script> block HTML escaping does
+  // not apply — only the literal `</script>` matters, so a name containing one
+  // would close the element and everything after it becomes markup. Escaping
+  // `<` as \u003c is still valid JSON and leaves no way out of the block.
+  return `<script type="application/ld+json">${JSON.stringify(graph).replace(/</g, '\\u003c')}</script>`;
 }
 
 /**
@@ -142,6 +302,36 @@ export function injectDesignMeta(shell: string, design: DesignMeta, siteUrl: str
       `<meta property="${property}" content="${escapeAttr(value)}">`
     );
   }
+
+  const indexable = isIndexable(design);
+  if (!indexable) {
+    html = replaceOne(
+      html,
+      /<meta name="robots" content="[^"]*">/,
+      '<meta name="robots" content="noindex, follow">'
+    );
+  }
+
+  // The fallback carries no nested <div>, so the first close is its own. Guarded
+  // by replaceOne: a shell that grew one should lose the swap, not truncate.
+  // The opening tag is carried over rather than rebuilt so its inline style (the
+  // display:none the shell relies on) survives verbatim. replaceOne replaces via
+  // a function, so `$` in a design name stays literal and capture syntax would
+  // not expand — hence the explicit concatenation.
+  const fallbackOpen = /<div id="seo-fallback"[^>]*>/.exec(html)?.[0];
+  if (fallbackOpen !== undefined) {
+    html = replaceOne(
+      html,
+      /<div id="seo-fallback"[^>]*>[\s\S]*?<\/div>/,
+      `${fallbackOpen}${renderDesignFallback(design, url)}</div>`
+    );
+  }
+
+  // Schema only for pages Google is allowed to keep. Advertising structured
+  // data on a noindex page spends nothing and claims something.
+  if (indexable) {
+    html = replaceOne(html, /<\/head>/, `${designJsonLd(design, url)}</head>`);
+  }
   return html;
 }
 
@@ -159,6 +349,22 @@ async function readDesignMeta(designId: string): Promise<DesignMeta | null> {
     authorName: card.authorName,
     description: record?.description ?? '',
     thumbnailUrl: card.thumbnailUrl,
+    category: card.category,
+    // The stored record is flat; the API's nested `metrics`/`counts` shape is
+    // assembled elsewhere. `prints` is optional in the record for fixture
+    // ergonomics, so it needs the default here.
+    metrics: {
+      width: card.width,
+      depth: card.depth,
+      height: card.height,
+      gridUnitMm: card.gridUnitMm,
+    },
+    counts: {
+      likes: card.likes,
+      remixes: card.remixes,
+      prints: card.prints ?? 0,
+    },
+    featured: card.featured,
   };
 }
 

--- a/api/community/page.ts
+++ b/api/community/page.ts
@@ -254,6 +254,37 @@ function replaceOne(html: string, pattern: RegExp, replacement: string): string 
   return html.replace(pattern, () => replacement);
 }
 
+/**
+ * Swaps the SEO fallback's contents, finding the block's end by balancing
+ * nested `<div>`s rather than assuming the first `</div>` closes it.
+ *
+ * Matching to the first close silently truncates the element the moment the
+ * shell grows a wrapper inside the block, and every design page would then
+ * serve malformed markup — a single-match guard does not catch it, because the
+ * truncated form still matches exactly once. The opening tag is left in place
+ * rather than rebuilt, so the inline `display:none` the shell depends on
+ * survives verbatim.
+ *
+ * Returns the html untouched when the block, or a balanced close for it, is
+ * missing: a shell that changed shape should lose the injection, never be
+ * corrupted by it.
+ */
+function replaceFallbackContent(html: string, inner: string): string {
+  const open = /<div id="seo-fallback"[^>]*>/.exec(html);
+  if (open === null) return html;
+  const contentStart = open.index + open[0].length;
+  const divTag = /<div\b[^>]*>|<\/div\s*>/gi;
+  divTag.lastIndex = contentStart;
+  let depth = 1;
+  for (let match = divTag.exec(html); match !== null; match = divTag.exec(html)) {
+    depth += match[0].startsWith('</') ? -1 : 1;
+    if (depth === 0) {
+      return `${html.slice(0, contentStart)}${inner}${html.slice(match.index)}`;
+    }
+  }
+  return html;
+}
+
 export function injectDesignMeta(shell: string, design: DesignMeta, siteUrl: string): string {
   const url = `${siteUrl}/community/d/${design.id}`;
   const title = `${design.name} by ${design.authorName} — Gridfinity Community`;
@@ -305,27 +336,21 @@ export function injectDesignMeta(shell: string, design: DesignMeta, siteUrl: str
 
   const indexable = isIndexable(design);
   if (!indexable) {
-    html = replaceOne(
-      html,
-      /<meta name="robots" content="[^"]*">/,
-      '<meta name="robots" content="noindex, follow">'
-    );
+    // Every robots directive in the shell, not just the generic one: a
+    // bot-specific `googlebot`/`bingbot` meta OVERRIDES `robots` for that
+    // crawler, so leaving those at index would let exactly the two crawlers
+    // that matter index a page the gate rejected. No-ops if the shell drops
+    // them, since replaceOne leaves a pattern it cannot find alone.
+    for (const bot of ['robots', 'googlebot', 'bingbot']) {
+      html = replaceOne(
+        html,
+        new RegExp(`<meta name="${bot}" content="[^"]*">`),
+        `<meta name="${bot}" content="noindex, follow">`
+      );
+    }
   }
 
-  // The fallback carries no nested <div>, so the first close is its own. Guarded
-  // by replaceOne: a shell that grew one should lose the swap, not truncate.
-  // The opening tag is carried over rather than rebuilt so its inline style (the
-  // display:none the shell relies on) survives verbatim. replaceOne replaces via
-  // a function, so `$` in a design name stays literal and capture syntax would
-  // not expand — hence the explicit concatenation.
-  const fallbackOpen = /<div id="seo-fallback"[^>]*>/.exec(html)?.[0];
-  if (fallbackOpen !== undefined) {
-    html = replaceOne(
-      html,
-      /<div id="seo-fallback"[^>]*>[\s\S]*?<\/div>/,
-      `${fallbackOpen}${renderDesignFallback(design, url)}</div>`
-    );
-  }
+  html = replaceFallbackContent(html, renderDesignFallback(design, url));
 
   // Schema only for pages Google is allowed to keep. Advertising structured
   // data on a noindex page spends nothing and claims something.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,9 +10,10 @@ Disallow: /api/
 # Disallow shared layout URLs (user-generated content, dynamic)
 Disallow: /s/
 
-# Community design deep links stay unindexed while the showcase is
-# flag-gated; the disallow is removed at graduation.
-Disallow: /community/d/
+# Community design deep links are crawlable: /api/community/page serves each
+# one with its own title, description, image and body copy, and gates indexing
+# per design with a robots meta, so a design nobody has used stays out of the
+# index without the whole route being blocked from crawling.
 
 # Disallow library/shared-layout deep links — same SPA, same meta as homepage,
 # so indexing them creates duplicate-title results.

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -1021,9 +1021,10 @@ const CONTENT_LASTMOD = '2026-07-26';
 const APP_ROUTES: Record<string, SitemapPage> = {
   designer: { basePriority: 0.9, changefreq: 'monthly' },
   baseplate: { basePriority: 0.9, changefreq: 'monthly' },
-  // The gallery index only. Individual designs stay out: robots.txt disallows
-  // /community/d/ until the showcase graduates from its flag, and a sitemap
-  // advertising URLs the same file forbids crawling is a contradiction.
+  // The gallery index only. Individual designs are crawlable now, but stay out of
+  // the sitemap: whether one is indexable is decided per design at request time
+  // (isIndexable in api/community/page.ts) and a build-time file cannot know it.
+  // Googlebot renders the gallery and follows the cards' own hrefs to reach them.
   community: { basePriority: 0.7, changefreq: 'daily' },
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,7 +147,7 @@ export default function App() {
   const { isSupportersRoute, navigateToSupporters } = useSupportersRouting();
   // False while the community_showcase flag is off (gated inside the hook),
   // so the /community URL falls through to the layout planner.
-  const { isCommunityRoute } = useCommunityRouting();
+  const { isCommunityRoute, communityDesignIdFromUrl } = useCommunityRouting();
   // Dev-only thumbnail capture route. Suppresses layout/designer routing so
   // those hooks don't rewrite the URL and strip the query params we depend on.
   const isDevThumbnailRoute =
@@ -197,6 +197,12 @@ export default function App() {
   // baseplate) — no early return — so back-navigation restores the homepage
   // meta. Depends on `t` so it re-applies when locale flips mid-session.
   useEffect(() => {
+    // On /community/d/<id> the meta in the document is the design's own, served
+    // by api/community/page.ts. Overwriting it with the gallery's generic title
+    // would give every design page the same title in the rendered DOM, which is
+    // what Google indexes — so the route could not be indexed at all. The server
+    // value is authoritative here; leave it alone.
+    if (communityDesignIdFromUrl !== null) return;
     const titleKey = isDesignerRoute
       ? 'seo.designer.title'
       : isBaseplateRoute
@@ -223,7 +229,14 @@ export default function App() {
     document.querySelector('meta[property="og:description"]')?.setAttribute('content', desc);
     document.querySelector('meta[name="twitter:title"]')?.setAttribute('content', title);
     document.querySelector('meta[name="twitter:description"]')?.setAttribute('content', desc);
-  }, [isDesignerRoute, isBaseplateRoute, isSupportersRoute, isCommunityRoute, t]);
+  }, [
+    isDesignerRoute,
+    isBaseplateRoute,
+    isSupportersRoute,
+    isCommunityRoute,
+    communityDesignIdFromUrl,
+    t,
+  ]);
   const { isMobile, isTablet } = useResponsive();
 
   const { shouldShowDrawTutorial } = useOnboarding();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,7 +202,12 @@ export default function App() {
     // would give every design page the same title in the rendered DOM, which is
     // what Google indexes — so the route could not be indexed at all. The server
     // value is authoritative here; leave it alone.
-    if (communityDesignIdFromUrl !== null) return;
+    //
+    // Gated on isCommunityRoute as well: the design id comes straight off the
+    // URL and is not flag-aware, so with community_showcase off this route falls
+    // through to the planner, and skipping the swap would leave a design's title
+    // over the planner UI.
+    if (isCommunityRoute && communityDesignIdFromUrl !== null) return;
     const titleKey = isDesignerRoute
       ? 'seo.designer.title'
       : isBaseplateRoute


### PR DESCRIPTION
## Why

`/community/d/<id>` already served each design's title, description and social image. The **body** was still the homepage shell, so every design page carried the planner copy under an `<h1>Gridfinity Planner &amp; Layout Tool</h1>`:

```
$ curl -s /community/d/C1vZoapNsaYE | strip-tags
2738 chars — identical on every design
mentions the design name? False
mentions planner boilerplate? True
```

N designs were N pages of identical text. That is why `robots.txt` disallowed the route rather than indexing it, and it is the actual reason the gallery contributes nothing to search: 0 impressions across the last three months.

## What changed

**The fallback block is the design's own** — name, author, CC BY terms, description, render, and the size in both grid units and millimetres (`2×1 at 3U`, `83.5mm × 41.5mm × 21mm`). Dimensions are the part a snippet cannot summarise away.

**Indexing is gated per design, not per route.** `isIndexable` requires complete metadata (real name, a render, real dimensions) *and* one signal of real use (like, print report, remix, or curator feature). Exports and views are excluded deliberately — an author generates those on their own design just by working on it. Anything below the bar keeps its own title and copy for social scrapers and for whoever followed the link, but carries `noindex, follow`.

**`robots.txt` no longer blocks the route.** The per-design gate replaces the blanket disallow. `/l/` stays disallowed: those are genuinely the same shell with the same meta.

**Schema** is `CreativeWork` with the CC BY license, not `Product` — there is no price or offer, and claiming one invites a structured-data penalty rather than a rich result. Emitted only for indexable designs.

## Two defeaters found while building this

**The client was overwriting the injected meta.** `isCommunityRoute` is true on the detail route too, so after hydration `App.tsx` replaced the design's title with the gallery's generic one — in the rendered DOM, which is what Google indexes. Lifting the disallow without this would have reintroduced duplicate titles at the exact point that matters. The server value is authoritative on a detail route now.

**JSON-LD needed escaping.** A design name is user text, and HTML escaping does not apply inside a `<script>` block, so a name containing `</script>` would close the element and turn the rest into live markup. Caught by the existing name-escaping test. Fixed by escaping `<` as a JSON unicode escape, with a dedicated regression test asserting the payload still parses and the name survives.

## Verification

- 242 tests pass across `api/community/`, `useCommunityRouting`, `check-spa-routes`. 17 new cases cover the gate, the fallback swap, schema shape, and the script-breakout regression.
- `pnpm run typecheck` and `pnpm run lint` clean.
- Smoke-tested against the real `index.html`: indexable design gets its title, `index, follow` and schema; a gated one gets `noindex, follow` and no schema; neither leaks planner boilerplate.
- The fallback's opening tag and its `<noscript>` reveal are preserved, so no-JS visitors still see the block.

## Scope

Designs stay out of the sitemap: which ones are indexable is decided per design at request time, and a build-time file cannot know that. Googlebot renders the gallery and follows the cards' own hrefs.

Worth knowing the ceiling: there are currently **4 published designs**, so this changes what the surface is capable of rather than delivering traffic today. It compounds as designs arrive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make community design pages crawlable with unique body content and per-design indexing. Fix meta and robots handling so only quality designs get indexed.

- **New Features**
  - Replace homepage fallback with design-specific content: name, author, CC BY terms, description, render, and size (grid units + mm).
  - Per-design SEO: `isIndexable` requires a real name, render, real dimensions, and one engagement signal (like, print, remix, or featured); otherwise `noindex, follow`.
  - Add `CreativeWork` JSON-LD only for indexable designs.
  - Update `robots.txt` to allow crawling `/community/d/`; keep `/l/` disallowed. Sitemap continues to list only the gallery index.

- **Bug Fixes**
  - Keep server-injected meta on `/community/d/<id>`; the client no longer overwrites it. The hand-off is gated by `isCommunityRoute` to avoid leaking a design title when the feature flag is off.
  - Make the fallback swap robust: balance nested `<div>`s, keep the opening tag (so inline `display:none` and the `<noscript>` reveal stay intact), and leave the document untouched if the block isn’t balanced.
  - Apply `noindex, follow` to bot-specific meta too (`googlebot`, `bingbot`) for non-indexable designs; escape `</script>` in JSON-LD to prevent script breakout.

<sup>Written for commit d8f77323e8e8f6bbe23221edab14f40216f4d3fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

