### PR TITLE
fix(seo): link the two worked-drawer pages from where readers already are

### DIFF
--- a/content/gridfinity-bin-generator.md
+++ b/content/gridfinity-bin-generator.md
@@ -125,6 +125,6 @@ It also exports STEP and 3MF — not just STL — and works on your phone if you
 
 ## Next Steps
 
-New to Gridfinity? Read [What is Gridfinity?](/what-is-gridfinity) for the basics. Already know what you need? Check the [sizes reference](/gridfinity-sizes) to figure out your dimensions, or jump into the [planning guide](/guide) to lay out a whole drawer. For one planned end to end, see the [tool drawer](/gridfinity-tool-drawer) and [kitchen drawer](/gridfinity-kitchen-drawer) walkthroughs.
+New to Gridfinity? Read [What is Gridfinity?](/what-is-gridfinity) for the basics. Already know what you need? Check the [sizes reference](/gridfinity-sizes) to figure out your dimensions, or jump into the [planning guide](/guide) to lay out a whole drawer. For a drawer planned end-to-end, see the [tool drawer](/gridfinity-tool-drawer) and [kitchen drawer](/gridfinity-kitchen-drawer) walkthroughs.
 
 [CTA: Start Making a Bin](/designer)

--- a/content/gridfinity-bin-generator.md
+++ b/content/gridfinity-bin-generator.md
@@ -125,6 +125,6 @@ It also exports STEP and 3MF — not just STL — and works on your phone if you
 
 ## Next Steps
 
-New to Gridfinity? Read [What is Gridfinity?](/what-is-gridfinity) for the basics. Already know what you need? Check the [sizes reference](/gridfinity-sizes) to figure out your dimensions, or jump into the [planning guide](/guide) to lay out a whole drawer.
+New to Gridfinity? Read [What is Gridfinity?](/what-is-gridfinity) for the basics. Already know what you need? Check the [sizes reference](/gridfinity-sizes) to figure out your dimensions, or jump into the [planning guide](/guide) to lay out a whole drawer. For one planned end to end, see the [tool drawer](/gridfinity-tool-drawer) and [kitchen drawer](/gridfinity-kitchen-drawer) walkthroughs.
 
 [CTA: Start Making a Bin](/designer)

--- a/content/gridfinity-generator.md
+++ b/content/gridfinity-generator.md
@@ -248,7 +248,7 @@ The generator wins for generic bins (you need a 2x3 with a scoop), exact sizes (
 
 ### Workshop and tool drawers
 
-The most common use of the Gridfinity Generator is organizing tool drawers in a workshop or garage. Wrenches go in long thin bins with scoop ramps; sockets in compartmented bins with circular floor inserts sized to the socket diameter; small parts (screws, washers, O-rings) in 1x1 or 1x2 bins with magnet bases so a closing drawer doesn't fling them around. Label tabs along the back of each bin make tool inventory glanceable, which matters when the drawer is at knee height.
+The most common use of the Gridfinity Generator is organizing tool drawers in a workshop or garage. Wrenches go in long thin bins with scoop ramps; sockets in compartmented bins with circular floor inserts sized to the socket diameter; small parts (screws, washers, O-rings) in 1x1 or 1x2 bins with magnet bases so a closing drawer doesn't fling them around. Label tabs along the back of each bin make tool inventory glanceable, which matters when the drawer is at knee height. The [tool drawer walkthrough](/gridfinity-tool-drawer) takes one from measurement to print list.
 
 ### Electronics workbench
 
@@ -256,7 +256,7 @@ For an electronics bench, the generator handles the stuff that doesn't fit anywh
 
 ### Kitchen drawers
 
-Kitchen-drawer Gridfinity has become a thing in the last year. The generator's per-side wall cutouts are useful for utensil drawers (a U-cutout lets a long wooden spoon stick out one end), and the half-bin mode covers awkward drawer widths. PETG is the recommended material for kitchen use because of its higher temperature tolerance.
+Kitchen-drawer Gridfinity has become a thing in the last year. The generator's per-side wall cutouts are useful for utensil drawers (a U-cutout lets a long wooden spoon stick out one end), and the half-bin mode covers awkward drawer widths. PETG is the recommended material for kitchen use because of its higher temperature tolerance. There is a [kitchen drawer walkthrough](/gridfinity-kitchen-drawer) covering utensils, spices and the cutlery tray.
 
 ### Hobby and craft supplies
 

--- a/content/gridfinity-generator.md
+++ b/content/gridfinity-generator.md
@@ -248,7 +248,7 @@ The generator wins for generic bins (you need a 2x3 with a scoop), exact sizes (
 
 ### Workshop and tool drawers
 
-The most common use of the Gridfinity Generator is organizing tool drawers in a workshop or garage. Wrenches go in long thin bins with scoop ramps; sockets in compartmented bins with circular floor inserts sized to the socket diameter; small parts (screws, washers, O-rings) in 1x1 or 1x2 bins with magnet bases so a closing drawer doesn't fling them around. Label tabs along the back of each bin make tool inventory glanceable, which matters when the drawer is at knee height. The [tool drawer walkthrough](/gridfinity-tool-drawer) takes one from measurement to print list.
+The most common use of the Gridfinity Generator is organizing tool drawers in a workshop or garage. Wrenches go in long thin bins with scoop ramps; sockets in compartmented bins with circular floor inserts sized to the socket diameter; small parts (screws, washers, O-rings) in 1x1 or 1x2 bins with magnet bases so a closing drawer doesn't fling them around. Label tabs along the back of each bin make tool inventory glanceable, which matters when the drawer is at knee height. The [tool drawer walkthrough](/gridfinity-tool-drawer) takes a drawer from measurement to print list.
 
 ### Electronics workbench
 

--- a/content/guide.md
+++ b/content/guide.md
@@ -143,7 +143,7 @@ Your tallest bin plus baseplate (about 5mm) needs to fit when the drawer closes.
 
 ## Worked Examples
 
-Two drawers planned end to end, if you would rather follow one than start from a blank grid: a [tool drawer](/gridfinity-tool-drawer) for wrenches, bits and pliers, and a [kitchen drawer](/gridfinity-kitchen-drawer) for utensils and spices.
+Two drawers planned end-to-end, if you would rather follow one than start from a blank grid: a [tool drawer](/gridfinity-tool-drawer) for wrenches, bits and pliers, and a [kitchen drawer](/gridfinity-kitchen-drawer) for utensils and spices.
 
 ![Gridfinity layout planner showing a fully planned tool drawer with labeled, color-coded bins](/images/landing/tool-drawer-layout.png '1200x675')
 [CTA: Open the Layout Tool](/)

--- a/content/guide.md
+++ b/content/guide.md
@@ -141,5 +141,9 @@ Your tallest bin plus baseplate (about 5mm) needs to fit when the drawer closes.
 
 **Ignoring what you actually use.** Don't organize around what you think you should have. Organize around what you reach for.
 
+## Worked Examples
+
+Two drawers planned end to end, if you would rather follow one than start from a blank grid: a [tool drawer](/gridfinity-tool-drawer) for wrenches, bits and pliers, and a [kitchen drawer](/gridfinity-kitchen-drawer) for utensils and spices.
+
 ![Gridfinity layout planner showing a fully planned tool drawer with labeled, color-coded bins](/images/landing/tool-drawer-layout.png '1200x675')
 [CTA: Open the Layout Tool](/)


### PR DESCRIPTION
## What

`content/gridfinity-generator.md` has `### Workshop and tool drawers` and `### Kitchen drawers` sections describing exactly what the two walkthrough pages cover, and `content/guide.md` ends on a tool-drawer photo — but none of them linked those pages. Four contextual links added:

- generator page → tool drawer walkthrough (in the tool-drawer section)
- generator page → kitchen drawer walkthrough (in the kitchen-drawer section)
- planning guide → both, as a new **Worked Examples** section
- bin generator Next Steps → both

Contextual body links in a section about the same subject carry more weight than the site-wide footer list every generated page already has, and they help a reader who is mid-task.

## Honest framing

I started this thinking `/gridfinity-tool-drawer` was nearly orphaned — one inbound link — and that this would explain its **zero impressions over three months**. That was wrong. The count grepped `content/*.md` and missed the footer the page template adds to every generated page:

```
$ grep -c 'href="/gridfinity-tool-drawer"' public/gridfinity-sizes/index.html
1     # and it is never mentioned in gridfinity-sizes.md
```

The page is not orphaned, so this is not the explanation, and the real cause is still unknown. The most likely benign one is that it simply never reaches the top 100 for anything, competing against `/` and `/gridfinity-generator` for the same queries — which produces zero impressions with no defect at all. Confirming that needs URL Inspection.

So: expect little from this. It is a genuine editorial improvement to pages that should have linked each other, not a fix.

## Verification

- `pnpm run build:content` clean, zero warnings.
- All internal link targets in the changed files resolve to real routes (checked programmatically).
- Links present in the generated HTML for all three pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add contextual links to the tool and kitchen drawer walkthroughs from the generator pages and the planning guide to improve discovery and help readers follow end‑to‑end examples. Copy updated to match house style (hyphenation and direct voice).

- Generator page: “Workshop and tool drawers” → /gridfinity-tool-drawer; “Kitchen drawers” → /gridfinity-kitchen-drawer.
- Planning guide: new Worked Examples section linking to both; uses “end‑to‑end” and “a drawer”.
- Bin generator: Next Steps now link to both walkthroughs with “end‑to‑end” phrasing.

<sup>Written for commit 34913806ea5fb617eeffabf4ae5c646096e2ee82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

