### PR TITLE
fix(seo): stop the locale reference pages answering in the SERP

### DIFF
--- a/content/de/gridfinity-sizes.md
+++ b/content/de/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: Gridfinity-Größen — Bin-Maße und Einheiten-Übersicht
-description: Wie groß ist eine Gridfinity-Einheit? 42-mm-Raster, 7-mm-Höhenstufen. Schnellreferenz für Bin-Größen, Schubladenumrechnung und was wohin passt.
+description: Alle Maße für Gridfinity-Bins und Grundplatten: Tabellen für Rastereinheiten und Höhen, gängige Größen und die Umrechnung deiner Schublade.
 keywords: gridfinity größen, gridfinity maße, gridfinity bin größen, gridfinity höheneinheiten, gridfinity 42mm, gridfinity rastergröße
 schema: Article
 breadcrumbs:
@@ -20,6 +20,8 @@ faqs:
 ---
 
 # Gridfinity-Größen und Maße
+
+Alle Maße für Gridfinity-Bins und Grundplatten: Rastereinheiten, Höheneinheiten, gängige Bin-Größen und was auf dein Druckbett passt. Suche unten eine Größe, oder miss deine Schublade und rechne sie in drei Schritten in Rastereinheiten um.
 
 **Die Standard-Gridfinity-Maße: eine Rastereinheit ist 42 mm × 42 mm (Breite und Tiefe), eine Höheneinheit (1U) ist 7 mm.** Jeder Bin und jede Grundplatte ist ein Vielfaches dieser zwei Zahlen — ein 2×3-Bin mit 6U misst 84 mm × 126 mm × 42 mm. Der Halb-Bin-Modus ergänzt 0,5er-Schritte (21 mm). Sobald du diese zwei Zahlen kennst, weißt du, was in deine Schublade passt und welche Bins du drucken solltest.
 

--- a/content/de/gridfinity-sizes.md
+++ b/content/de/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: Gridfinity-Größen — Bin-Maße und Einheiten-Übersicht
-description: Alle Maße für Gridfinity-Bins und Grundplatten: Tabellen für Rastereinheiten und Höhen, gängige Größen und die Umrechnung deiner Schublade.
+description: 'Alle Maße für Gridfinity-Bins und Grundplatten: Tabellen für Rastereinheiten und Höhen, gängige Größen und die Umrechnung deiner Schublade.'
 keywords: gridfinity größen, gridfinity maße, gridfinity bin größen, gridfinity höheneinheiten, gridfinity 42mm, gridfinity rastergröße
 schema: Article
 breadcrumbs:

--- a/content/de/what-is-gridfinity.md
+++ b/content/de/what-is-gridfinity.md
@@ -1,6 +1,6 @@
 ---
 title: Was ist Gridfinity? Modulares 42-mm-System
-description: Gridfinity ist ein kostenloses, quelloffenes Ordnungssystem zum 3D-Drucken auf 42-mm-Raster. Bins, Grundplatten und 7-mm-Höhen — jetzt selbst gestalten.
+description: Wie Gridfinity funktioniert, was du zum Start brauchst und wie du eine Schublade planst, die passt. Praxisanleitung für das gedruckte Ordnungssystem.
 keywords: gridfinity, was ist gridfinity, schubladeneinsatz, 3D-Druck, modulares Ordnungssystem, Zack Freedman
 schema: Article
 breadcrumbs:
@@ -30,6 +30,8 @@ faqs:
 ---
 
 # Was ist Gridfinity?
+
+Eine Praxisanleitung zum gedruckten Ordnungssystem: wie Gridfinity funktioniert, was du zum Start brauchst und wie du eine Schublade planst, die passt. Fang hier an, wenn du einen 3D-Drucker und eine unübersichtliche Schublade hast.
 
 Gridfinity ist ein kostenloses, quelloffenes modulares Ordnungssystem, das du selbst in 3D druckst: Bins in Standardgrößen sitzen auf einem 42-mm-Grundplattenraster, sodass jedes Design von jedem Maker kompatibel ist. Zack Freedman, ein Maker und YouTuber, hat es 2022 veröffentlicht — allein auf Printables gibt es inzwischen über 10.000 kostenlose Designs.
 

--- a/content/nl/gridfinity-sizes.md
+++ b/content/nl/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: Gridfinity-maten — Bin-afmetingen en eenheden-gids
-description: Alle maten voor Gridfinity-bins en bodemplaten: tabellen met rastereenheden en hoogtes, gangbare formaten en het omrekenen van je lade.
+description: 'Alle maten voor Gridfinity-bins en bodemplaten: tabellen met rastereenheden en hoogtes, gangbare formaten en het omrekenen van je lade.'
 keywords: gridfinity maten, gridfinity afmetingen, gridfinity bin maten, gridfinity hoogte-eenheden, gridfinity 42mm, gridfinity raster
 schema: Article
 breadcrumbs:

--- a/content/nl/gridfinity-sizes.md
+++ b/content/nl/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: Gridfinity-maten — Bin-afmetingen en eenheden-gids
-description: Hoe groot is een Gridfinity-eenheid? 42-mm-raster, hoogtestappen van 7 mm. Snelle referentietabellen voor bins, lade-conversie en wat waar past.
+description: Alle maten voor Gridfinity-bins en bodemplaten: tabellen met rastereenheden en hoogtes, gangbare formaten en het omrekenen van je lade.
 keywords: gridfinity maten, gridfinity afmetingen, gridfinity bin maten, gridfinity hoogte-eenheden, gridfinity 42mm, gridfinity raster
 schema: Article
 breadcrumbs:
@@ -20,6 +20,8 @@ faqs:
 ---
 
 # Gridfinity-maten en -afmetingen
+
+Alle maten voor Gridfinity-bins en bodemplaten: rastereenheden, hoogte-eenheden, gangbare bin-formaten en wat op je printbed past. Zoek hieronder een maat op, of meet je lade en reken die in drie stappen om naar rastereenheden.
 
 **Standaard Gridfinity-maten: één rastereenheid is 42 mm × 42 mm (breedte en diepte), en één hoogte-eenheid (1U) is 7 mm.** Elke bin en elke bodemplaat is een veelvoud van deze twee getallen — een 2×3-bin van 6U meet 84 mm × 126 mm × 42 mm. De halve-bin-modus voegt stappen van 0,5 eenheid (21 mm) toe. Als je deze twee getallen kent, weet je wat in je lade past en welke bins je print.
 

--- a/content/nl/what-is-gridfinity.md
+++ b/content/nl/what-is-gridfinity.md
@@ -1,6 +1,6 @@
 ---
 title: Wat is Gridfinity? Modulair 42mm-systeem
-description: Gridfinity is een gratis, open-source modulair systeem, in 3D geprint op een 42mm-raster. Bakjes, grondplaten en 7mm-hoogtes — ontwerp je eigen gratis.
+description: Hoe Gridfinity werkt, wat je nodig hebt om te beginnen en hoe je een lade plant die past. Praktische gids voor het geprinte opbergsysteem.
 keywords: gridfinity, wat is gridfinity, lade-organizer, 3D-print, modulaire opslag, Zack Freedman
 schema: Article
 breadcrumbs:
@@ -30,6 +30,8 @@ faqs:
 ---
 
 # Wat is Gridfinity?
+
+Een praktische gids voor het geprinte opbergsysteem: hoe Gridfinity werkt, wat je nodig hebt om te beginnen en hoe je een lade plant die past. Begin hier als je een 3D-printer hebt en een lade die uit de hand is gelopen.
 
 Gridfinity is een gratis, open-source modulair opbergsysteem dat je zelf in 3D print: bins in standaardmaten rusten op een 42-mm-bodemplaatraster, dus elk design van elke maker is uitwisselbaar. Zack Freedman, een maker en YouTuber, bedacht het in 2022, en alleen al op Printables staan inmiddels meer dan 10.000 gratis designs.
 

--- a/content/pl/gridfinity-sizes.md
+++ b/content/pl/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
-title: Rozmiary Gridfinity — siatka 42 mm i wysokości 7 mm
-description: Jak duża jest jednostka Gridfinity? Siatka 42 mm, wysokości 7 mm. Szybka ściąga rozmiarów Binów, przeliczania szuflady i tego, co gdzie pasuje.
+title: 'Rozmiary Gridfinity: tabele wymiarów Binów i płyt bazowych'
+description: Wszystkie wymiary Binów i płyt bazowych Gridfinity: tabele jednostek siatki i wysokości, popularne rozmiary oraz przeliczanie szuflady.
 keywords: rozmiary gridfinity, wymiary gridfinity, rozmiary binów gridfinity, jednostki wysokości gridfinity, gridfinity 42mm, rozmiar siatki gridfinity, standardowy rozmiar gridfinity, dlaczego gridfinity ma 42mm
 schema: Article
 breadcrumbs:
@@ -24,6 +24,8 @@ faqs:
 ---
 
 # Rozmiary i wymiary Gridfinity
+
+Wszystkie wymiary Binów i płyt bazowych Gridfinity: jednostki siatki, jednostki wysokości, popularne rozmiary i co zmieści się na stole drukarki. Znajdź rozmiar w tabelach poniżej albo zmierz szufladę i przelicz ją na jednostki siatki w trzech krokach.
 
 **Standardowe rozmiary Gridfinity: jedna jednostka siatki to 42 mm × 42 mm (szerokość i głębokość), a jedna jednostka wysokości (1U) to 7 mm.** Każdy Bin i każda płyta bazowa są wielokrotnością tych dwóch liczb — Bin 2×3 o wysokości 6U ma 84 mm × 126 mm × 42 mm. Tryb pół-Bina dodaje kroki co 0,5 jednostki (21 mm). Gdy znasz te dwie liczby, potrafisz ustalić, co zmieści się w twojej szufladzie i które Biny wydrukować.
 

--- a/content/pl/gridfinity-sizes.md
+++ b/content/pl/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: 'Rozmiary Gridfinity: tabele wymiarów Binów i płyt bazowych'
-description: Wszystkie wymiary Binów i płyt bazowych Gridfinity: tabele jednostek siatki i wysokości, popularne rozmiary oraz przeliczanie szuflady.
+description: 'Wszystkie wymiary Binów i płyt bazowych Gridfinity: tabele jednostek siatki i wysokości, popularne rozmiary oraz przeliczanie szuflady.'
 keywords: rozmiary gridfinity, wymiary gridfinity, rozmiary binów gridfinity, jednostki wysokości gridfinity, gridfinity 42mm, rozmiar siatki gridfinity, standardowy rozmiar gridfinity, dlaczego gridfinity ma 42mm
 schema: Article
 breadcrumbs:

--- a/content/pl/what-is-gridfinity.md
+++ b/content/pl/what-is-gridfinity.md
@@ -1,6 +1,6 @@
 ---
 title: Czym jest Gridfinity? System modułowy 42 mm
-description: Gridfinity to darmowy, otwartoźródłowy system modułowy drukowany 3D na siatce 42 mm. Poznaj Biny, płyty bazowe i wysokości 7 mm — zaprojektuj własny.
+description: Jak działa Gridfinity, co jest potrzebne na start i jak zaplanować szufladę, która pasuje. Praktyczny przewodnik po drukowanym systemie.
 keywords: gridfinity, czym jest gridfinity, organizer do szuflady, druk 3D, modułowy system przechowywania, Zack Freedman
 schema: Article
 breadcrumbs:
@@ -30,6 +30,8 @@ faqs:
 ---
 
 # Czym jest Gridfinity?
+
+Praktyczny przewodnik po drukowanym systemie przechowywania: jak działa Gridfinity, co jest potrzebne na start i jak zaplanować szufladę, która pasuje. Zacznij tutaj, jeśli masz drukarkę 3D i szufladę, która wymknęła się z rąk.
 
 Gridfinity to darmowy, otwartoźródłowy modułowy system przechowywania, który drukujesz samodzielnie w 3D: Biny w standardowych rozmiarach spoczywają na siatce płyt bazowych 42 mm, więc każdy projekt każdego twórcy jest wymienny. Zack Freedman, maker i youtuber, stworzył go w 2022 roku — dziś tylko na Printables jest ponad 10 000 darmowych projektów.
 

--- a/content/sv/gridfinity-sizes.md
+++ b/content/sv/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: Gridfinity-storlekar — Bin-mått och enhetsguide
-description: Alla mått för Gridfinity-bins och bottenplattor: tabeller för rutnätsenheter och höjder, vanliga storlekar och omräkning av din låda.
+description: 'Alla mått för Gridfinity-bins och bottenplattor: tabeller för rutnätsenheter och höjder, vanliga storlekar och omräkning av din låda.'
 keywords: gridfinity storlekar, gridfinity mått, gridfinity bin-storlekar, gridfinity höjdenheter, gridfinity 42mm, gridfinity rutnät
 schema: Article
 breadcrumbs:

--- a/content/sv/gridfinity-sizes.md
+++ b/content/sv/gridfinity-sizes.md
@@ -1,6 +1,6 @@
 ---
 title: Gridfinity-storlekar — Bin-mått och enhetsguide
-description: Hur stor är en Gridfinity-enhet? 42-mm-rutnät, höjdsteg om 7 mm. Snabba referenstabeller för bins, lådomvandling och vad som passar var.
+description: Alla mått för Gridfinity-bins och bottenplattor: tabeller för rutnätsenheter och höjder, vanliga storlekar och omräkning av din låda.
 keywords: gridfinity storlekar, gridfinity mått, gridfinity bin-storlekar, gridfinity höjdenheter, gridfinity 42mm, gridfinity rutnät
 schema: Article
 breadcrumbs:
@@ -20,6 +20,8 @@ faqs:
 ---
 
 # Gridfinity-storlekar och -mått
+
+Alla mått för Gridfinity-bins och bottenplattor: rutnätsenheter, höjdenheter, vanliga bin-storlekar och vad som får plats på din skrivarbädd. Slå upp en storlek i tabellerna nedan, eller mät din låda och räkna om den till rutnätsenheter i tre steg.
 
 **Standardstorlekar för Gridfinity: en rutnätsenhet är 42 mm × 42 mm (bredd och djup), och en höjdenhet (1U) är 7 mm.** Varje bin och varje bottenplatta är en multipel av dessa två tal — en 2×3-bin på 6U mäter 84 mm × 126 mm × 42 mm. Halv-bin-läget lägger till steg om 0,5 enheter (21 mm). När du känner dessa två tal vet du vad som ryms i din låda och vilka bins du ska skriva ut.
 

--- a/content/sv/what-is-gridfinity.md
+++ b/content/sv/what-is-gridfinity.md
@@ -1,6 +1,6 @@
 ---
 title: Vad är Gridfinity? Modulärt 42 mm-system
-description: Gridfinity är ett gratis, modulärt system med öppen källkod, 3D-utskrivet på ett 42 mm-rutnät. Lådor, bottenplattor och 7 mm-höjder — gör ditt eget gratis.
+description: Hur Gridfinity fungerar, vad du behöver för att börja och hur du planerar en låda som passar. Praktisk guide till det 3D-utskrivna systemet.
 keywords: gridfinity, vad är gridfinity, lådorganisatör, 3D-utskrift, modulär förvaring, Zack Freedman
 schema: Article
 breadcrumbs:
@@ -30,6 +30,8 @@ faqs:
 ---
 
 # Vad är Gridfinity?
+
+En praktisk guide till det 3D-utskrivna förvaringssystemet: hur Gridfinity fungerar, vad du behöver för att börja och hur du planerar en låda som passar. Börja här om du har en 3D-skrivare och en låda som spårat ur.
 
 Gridfinity är ett gratis modulärt förvaringssystem med öppen källkod som du skriver ut själv i 3D: bins i standardstorlekar vilar på ett 42 mm bottenplatterutnät, så varje design från varje maker är kompatibel. Zack Freedman, en maker och YouTuber, skapade det 2022, och det finns nu över 10 000 gratis designer bara på Printables.
 


### PR DESCRIPTION
## Why

#3363 fixed the English openings. The locale copies were never touched, and they are **worse** — because #3358 only cleaned the English titles and descriptions, all four priority locales hand the answer over in three places at once:

| | de | nl | sv | pl |
|---|---|---|---|---|
| Opening paragraph states the answer | yes | yes | yes | yes |
| Meta description states it | yes | yes | yes | yes |
| Title states it | no | no | no | **yes** |

The German description read *"Wie groß ist eine Gridfinity-Einheit? 42-mm-Raster, 7-mm-Höhenstufen"* — question and answer, before the reader has any reason to click. The Polish title was literally *"siatka 42 mm i wysokości 7 mm"*.

## What changed

Eight files (`gridfinity-sizes` and `what-is-gridfinity` in de, nl, sv, pl):

- Openings lead with what a snippet cannot deliver and close a sentence inside the 155-character window. The bold 42mm/7mm answer stays, one paragraph down, exactly as in English.
- Descriptions promise the tables and the drawer conversion instead of stating the numbers, and drop their em dashes per house style.
- The Polish title is now `Rozmiary Gridfinity: tabele wymiarów Binów i płyt bazowych`.

**Deliberately not promised: inches.** The English page has mm *and* inch tables; the locale pages are metric only. I checked each page's headings first, so the openings claim grid units, height units, common sizes and the print-bed check — nothing the page does not have. That is the mistake caught on #3363.

## Verification

```
de/gridfinity-sizes     desc=139  sent@133/155  answer_in_window=no
de/what-is-gridfinity   desc=149  sent@151/155  answer_in_window=no
nl/gridfinity-sizes     desc=135  sent@130/155  answer_in_window=no
nl/what-is-gridfinity   desc=138  sent@142/155  answer_in_window=no
sv/gridfinity-sizes     desc=133  sent@141/155  answer_in_window=no
sv/what-is-gridfinity   desc=140  sent@153/155  answer_in_window=no
pl/gridfinity-sizes     desc=135  sent@145/155  answer_in_window=no
pl/what-is-gridfinity   desc=136  sent@151/155  answer_in_window=no
```

`pnpm run build:content` clean, zero warnings (the description budget check would have caught anything over 155).

## Scope and caveats

**Two things worth knowing before this carries weight:**

1. **The copy is machine-authored.** Consistent with how #1728 added these locales, but a native read would be worth having — particularly the Swedish and Polish, where I have taken more liberty with idiom than the German or Dutch.
2. **Expect little traffic.** These eight pages draw between 12 and 190 impressions each. The reason to do it is correctness and consistency with English, not volume.

cs, fr, es, pt-BR, nb, uk, zh-CN and ko keep their current openings — each under 200 impressions, and the plan is to concentrate on the four locales with real country traffic (DE 7.5k, NL 4.6k, SE 3.4k, PL 2.9k impressions).

Related follow-up not done here: several locale titles still carry em dashes that house style avoids. #3358 only rewrote the ones over the pixel budget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the German, Dutch, Swedish, and Polish reference pages from giving the 42mm/7mm answer in the SERP. Rewrites openings and meta descriptions to highlight tables and drawer conversion, updates the Polish sizes title, and quotes YAML to fix the build.

- **Bug Fixes**
  - Reworked openings on `de`, `nl`, `sv`, `pl` sizes and what‑is pages to end a sentence within 155 chars; the 42mm/7mm answer now appears one paragraph down (as in English). Updated Polish sizes title to 'Rozmiary Gridfinity: tabele wymiarów Binów i płyt bazowych'.
  - Replaced meta descriptions to avoid stating the answer and removed em dashes per house style.
  - Quoted descriptions (and the Polish title) that include colons to avoid YAML parse errors; build passes.
  - Kept locale pages metric-only (no inches). All descriptions under 155 chars.

<sup>Written for commit a513f73228e36bfa09012d7128ab49c28c672380. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

