### PR TITLE
feat(seo): add a Gridfinity cutout generator page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ public/gridfinity-generator/
 public/gridfinity-tool-drawer/
 public/gridfinity-kitchen-drawer/
 public/gridfinity-calculator/
+public/gridfinity-cutout-generator/
 public/gridfinity-software/
 public/de/
 public/fr/

--- a/content/gridfinity-bin-generator.md
+++ b/content/gridfinity-bin-generator.md
@@ -96,7 +96,7 @@ A parametric bin generator that runs in your browser. Set your dimensions, add c
 
 For items that need to stay in place, **floor inserts** cut shaped cavities into the floor — circles for batteries, hexagons for bits, rectangles for components. Set the depth and rotation to match what you're storing.
 
-The **cutout editor** handles unusual shapes. Switch to solid mode, carve from the top, and use the pen tool to draw freeform paths for wrenches, pliers, or anything with an odd profile.
+The **cutout editor** handles unusual shapes. Switch to solid mode, carve from the top, and use the pen tool to draw freeform paths for wrenches, pliers, or anything with an odd profile. It also imprints a cavity from an imported STL — see the [cutout generator](/gridfinity-cutout-generator).
 
 ## Base Attachment Options
 

--- a/content/gridfinity-cutout-generator.md
+++ b/content/gridfinity-cutout-generator.md
@@ -82,11 +82,11 @@ Carve a cavity shaped like the thing you are storing, so it sits in its own rece
 1. **Start solid.** Set the bin size in grid units, then switch the interior to solid so there is material to cut into. An ordinary hollow bin has nothing to carve.
 2. **Add the cutout.** Choose a shape, place it on the floor, and set how deep it goes. Depth is what decides whether a socket sits flush or stands proud.
 3. **Refine the fit.** Rotate it, nudge it, and add an entry chamfer so the part drops in without catching on the edge.
-4. **Export.** STL for the slicer, STEP if you want to keep editing in CAD, 3MF for colour and material data.
+4. **Export.** STL for the slicer, STEP if you want to keep editing in CAD, 3MF for color and material data.
 
 ## Cutout Shapes
 
-**Rectangle, circle, and slot** cover most parts: batteries, drill bits, allen keys, USB drives. Set the size in millimetres and the depth separately, so a shallow tray and a deep socket well come from the same control.
+**Rectangle, circle, and slot** cover most parts: batteries, drill bits, allen keys, USB drives. Set the size in millimeters and the depth separately, so a shallow tray and a deep socket well come from the same control.
 
 **Polygon** suits anything with flat faces — hex bits, nuts, a hex-shafted driver.
 
@@ -108,7 +108,7 @@ A wall cutout is a notch in the side of a bin, not a recess in its floor — a U
 
 ## Shadow Boards
 
-Give a cavity its own colour, on the floor or on the floor and interior walls, and you get the dark backing that makes a missing tool obvious from across the room. It needs a multi-material printer or a mid-print filament change to appear in the print, but the file carries the assignment either way.
+Give a cavity its own color, on the floor or on the floor and interior walls, and you get the dark backing that makes a missing tool obvious from across the room. It needs a multi-material printer or a mid-print filament change to appear in the print, but the file carries the assignment either way.
 
 ## Next Steps
 

--- a/content/gridfinity-cutout-generator.md
+++ b/content/gridfinity-cutout-generator.md
@@ -1,0 +1,117 @@
+---
+title: 'Gridfinity Cutout Generator: Shaped Cavities for Any Tool'
+description: Cut a cavity shaped like the thing you are storing. Draw it, pick a shape, or import an STL and imprint it. Export STL, STEP, or 3MF.
+keywords: gridfinity cutout generator, gridfinity custom cutout, gridfinity tool cutout, gridfinity cutout maker, tool cutout generator, gridfinity shadow board, gridfinity mesh imprint, gridfinity stl cutout
+schema: HowTo
+breadcrumbs:
+  - name: Home
+    url: https://gridfinitylayouttool.com/
+  - name: Cutout Generator
+    url: https://gridfinitylayouttool.com/gridfinity-cutout-generator
+navCta:
+  label: Open the Cutout Editor
+  href: /designer
+howTo:
+  name: How to Generate a Gridfinity Cutout
+  description: Carve a shaped cavity into a Gridfinity bin so a tool sits in its own recess, then export it for printing.
+  totalTime: PT5M
+  tools:
+    - Web browser
+  steps:
+    - name: Start from a solid bin
+      text: Set the bin's width, depth, and height in grid units, then switch the interior to solid so there is material to carve into.
+    - name: Add a cutout
+      text: Pick a rectangle, circle, slot, or polygon, or draw a freeform path with the pen tool. Position it on the bin floor and set its depth.
+    - name: Imprint an STL instead
+      text: Import an STL of the object and the generator imprints its outline into the floor, so the cavity matches the real part rather than an approximation of it.
+    - name: Export and print
+      text: Download the bin as STL, STEP, or 3MF and slice it. Cutouts print without supports when they are carved from the top.
+softwareApplication:
+  name: Gridfinity Cutout Generator
+  alternateName:
+    - Gridfinity Custom Cutout Generator
+    - Gridfinity Tool Cutout Generator
+  description: Carve shaped cavities into Gridfinity bins. Rectangle, circle, slot, polygon, freeform pen paths, and imprints from an imported STL. Exports STL, STEP, and 3MF.
+  applicationCategory: DesignApplication
+  applicationSubCategory: 3D Printing Tools
+  operatingSystem: Any
+  browserRequirements: Requires JavaScript. Requires HTML5.
+  permissions: none
+  isAccessibleForFree: true
+  offers:
+    price: '0'
+    priceCurrency: USD
+    availability: https://schema.org/InStock
+  featureList:
+    - Rectangle, circle, slot, and polygon cutouts
+    - Freeform pen tool with bezier curves
+    - Mesh imprint from an imported STL
+    - Per-side wall cutouts
+    - Adjustable cavity depth and entry chamfer
+    - Colored cavity floors for shadow-board contrast
+    - STL, STEP, and 3MF export
+faqs:
+  - q: What is a Gridfinity cutout?
+    a: A cavity carved into a bin's material in the shape of what you are storing, so the item sits in its own recess instead of loose in an open bin. It is the Gridfinity version of a shadow board — good for wrenches, bits, sockets, and anything that should stay put and stay findable.
+  - q: Can I make a cutout in the shape of a specific tool?
+    a: Yes, two ways. Draw the outline with the pen tool, which supports bezier curves for shapes that are not made of straight lines, or import an STL of the object and let the generator imprint its outline into the floor.
+  - q: What shapes can a cutout be?
+    a: Rectangle, circle, slot, and polygon as presets, a freeform path drawn with the pen tool, or a mesh imprinted from an imported STL. Each one takes its own depth, position, and rotation.
+  - q: What file types can I import for a cutout?
+    a: STL. Files up to 50 MB are accepted and a design can carry up to 8 imported meshes. The file is repaired, laid flat, and simplified in the browser before it becomes a cavity.
+  - q: Does importing an STL add a Gridfinity base to my model?
+    a: No, and this is the common mix-up. An imported STL becomes the shape of a cavity carved into a bin, not a model that gets a Gridfinity foot attached. If you want an existing model to sit on a baseplate, the bin is the part that provides the base.
+  - q: Do cutouts need supports when printing?
+    a: Not when they are carved down from the top of a solid bin, which is how the editor works. The cavity is open at the top, so there is nothing to bridge.
+  - q: Can I make the cutout floor a different color?
+    a: Yes. A cavity can take its own color on the floor, or on the floor and interior walls, which gives you the dark backing that makes a shadow board readable at a glance. It needs a multi-material printer or a filament change to show up in the print.
+  - q: Will a bin with cutouts still fit a standard baseplate?
+    a: Yes. Cutouts only remove material from the interior. The 42mm footprint and the base profile are untouched, so the bin fits any Gridfinity baseplate.
+---
+
+# Gridfinity Cutout Generator
+
+Carve a cavity shaped like the thing you are storing, so it sits in its own recess instead of rattling around an open bin. Draw the outline, pick a preset shape, or import an STL of the object and let the generator imprint it.
+
+[CTA: Open the Cutout Editor](/designer)
+
+![Gridfinity bin with a custom pen-tool cutout carved into a solid interior](/images/landing/honeycomb-caddy-bin.png '1200x675')
+
+## How It Works
+
+1. **Start solid.** Set the bin size in grid units, then switch the interior to solid so there is material to cut into. An ordinary hollow bin has nothing to carve.
+2. **Add the cutout.** Choose a shape, place it on the floor, and set how deep it goes. Depth is what decides whether a socket sits flush or stands proud.
+3. **Refine the fit.** Rotate it, nudge it, and add an entry chamfer so the part drops in without catching on the edge.
+4. **Export.** STL for the slicer, STEP if you want to keep editing in CAD, 3MF for colour and material data.
+
+## Cutout Shapes
+
+**Rectangle, circle, and slot** cover most parts: batteries, drill bits, allen keys, USB drives. Set the size in millimetres and the depth separately, so a shallow tray and a deep socket well come from the same control.
+
+**Polygon** suits anything with flat faces — hex bits, nuts, a hex-shafted driver.
+
+**The pen tool** is for the rest. Draw the silhouette point by point with bezier curves between them, which is what an adjustable wrench, a pair of pliers, or a scissor handle actually needs. Straight-line approximations of curved tools look wrong and hold the part loosely.
+
+**A mesh imprint** takes the guesswork out entirely: import an STL of the object and the outline comes from the model rather than from your tracing.
+
+## Imprinting an STL
+
+Import a model and the generator repairs it, lays it flat, and simplifies it in the browser, then shows you an orientation step so you can rotate it before committing. The result is a cavity in that outline.
+
+Files up to 50 MB are accepted, and one design can carry up to 8 imported meshes — enough for a full driver set in a single bin.
+
+Worth being clear about a common mix-up: this makes an imported model into a **hole**, not into a Gridfinity-compatible part. If you have an STL you want sitting on a baseplate, the bin is what provides the base and the profile; the model goes in the cavity.
+
+## Wall Cutouts Are a Different Thing
+
+A wall cutout is a notch in the side of a bin, not a recess in its floor — a U-shaped gap so a long screwdriver or a wooden spoon can overhang the end, or a scoop so you can sweep small parts out with a thumb. They are configured per side and can be combined with floor cutouts in the same bin.
+
+## Shadow Boards
+
+Give a cavity its own colour, on the floor or on the floor and interior walls, and you get the dark backing that makes a missing tool obvious from across the room. It needs a multi-material printer or a mid-print filament change to appear in the print, but the file carries the assignment either way.
+
+## Next Steps
+
+The cutout editor lives in the [bin designer](/designer). For the surrounding features — compartments, label tabs, base styles — see the [bin generator guide](/gridfinity-bin-generator), and for a whole drawer planned around cut-to-shape bins, the [tool drawer walkthrough](/gridfinity-tool-drawer). Sizes and depths are in the [sizes reference](/gridfinity-sizes).
+
+[CTA: Open the Cutout Editor](/designer)

--- a/content/gridfinity-generator.md
+++ b/content/gridfinity-generator.md
@@ -181,7 +181,7 @@ Most bins are rectangles, but the generator also supports custom footprints via 
 
 ### Cutout Editor
 
-For shapes that don't fit any preset, the cutout editor lets you draw freeform paths with a pen tool. Bezier handles let you make smooth curves; corner mode locks angles for straight cuts. Carve out the silhouette of a wrench, a multitool, or anything else — the generator creates the cavity automatically.
+For shapes that don't fit any preset, the cutout editor lets you draw freeform paths with a pen tool. Bezier handles let you make smooth curves; corner mode locks angles for straight cuts. Carve out the silhouette of a wrench, a multitool, or anything else — the generator creates the cavity automatically. The [cutout generator](/gridfinity-cutout-generator) covers every shape it can make, including imprints from an imported STL.
 
 ## Baseplate Generator: What You Can Configure
 

--- a/content/gridfinity-tool-drawer.md
+++ b/content/gridfinity-tool-drawer.md
@@ -79,7 +79,7 @@ Generic bins handle most tools, but some deserve fitted storage. The [bin genera
 - **Hex floor cutouts** hold screwdriver bits and driver inserts upright in a grid.
 - **Circle cutouts** fit sockets, batteries, and collets — set the diameter per row.
 - **Slot cutouts** hold blades, wrenches, and feeler gauges on edge.
-- **The pen tool** draws freeform outlines for pliers, snips, or anything with an odd profile — the bin prints with a fitted cavity.
+- **The pen tool** draws freeform outlines for pliers, snips, or anything with an odd profile — the bin prints with a fitted cavity. The [cutout generator](/gridfinity-cutout-generator) goes through each shape, and can imprint one from an STL.
 - **Label tabs** keep every bin identified, with bracket or solid supports.
 
 ![Custom Gridfinity bin with hexagonal floor cutouts holding screwdriver bits in a 3D preview](/images/landing/bit-organizer-bin.png '1200x675')

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -1038,6 +1038,7 @@ const SITEMAP_PAGES: Record<string, SitemapPage> = {
   'gridfinity-tool-drawer': { basePriority: 0.8, changefreq: 'monthly' },
   'gridfinity-kitchen-drawer': { basePriority: 0.8, changefreq: 'monthly' },
   'gridfinity-calculator': { basePriority: 0.8, changefreq: 'monthly' },
+  'gridfinity-cutout-generator': { basePriority: 0.8, changefreq: 'monthly' },
   'gridfinity-software': { basePriority: 0.7, changefreq: 'monthly' },
 };
 

--- a/scripts/gen-seo-images.ts
+++ b/scripts/gen-seo-images.ts
@@ -460,6 +460,13 @@ const OG_CARDS: OgCard[] = [
     inset: 'kitchen-drawer-layout.png',
   },
   {
+    slug: 'gridfinity-cutout-generator',
+    title: 'Gridfinity Cutout Generator',
+    subtitle: 'Shaped cavities for any tool, drawn or imprinted from an STL',
+    style: 'light',
+    inset: 'tool-drawer-layout.png',
+  },
+  {
     slug: 'gridfinity-calculator',
     title: 'Gridfinity Calculator',
     subtitle: 'Drawer millimeters → grid units, leftover space & max bin height',

--- a/scripts/vite-plugin-content-routes.ts
+++ b/scripts/vite-plugin-content-routes.ts
@@ -23,6 +23,7 @@ const SLUGS = [
   'gridfinity-tool-drawer',
   'gridfinity-kitchen-drawer',
   'gridfinity-software',
+  'gridfinity-cutout-generator',
 ];
 
 // Localized variants exist only for the original content set. privacy/terms are

--- a/vercel.json
+++ b/vercel.json
@@ -169,6 +169,15 @@
       ]
     },
     {
+      "source": "/gridfinity-cutout-generator",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
       "source": "/gridfinity-tool-drawer",
       "headers": [
         {
@@ -425,7 +434,7 @@
       "destination": "https://us.i.posthog.com/:path"
     },
     {
-      "source": "/:slug(what-is-gridfinity|guide|privacy|terms|gridfinity-generator|gridfinity-bin-generator|gridfinity-baseplate-generator|gridfinity-calculator|gridfinity-sizes|gridfinity-tool-drawer|gridfinity-kitchen-drawer|gridfinity-software)",
+      "source": "/:slug(what-is-gridfinity|guide|privacy|terms|gridfinity-generator|gridfinity-bin-generator|gridfinity-baseplate-generator|gridfinity-calculator|gridfinity-sizes|gridfinity-tool-drawer|gridfinity-kitchen-drawer|gridfinity-software|gridfinity-cutout-generator)",
       "destination": "/:slug/index.html"
     },
     {


### PR DESCRIPTION
## Why

The cutout cluster is **507 impressions across ten queries with no page of its own**. From the August export:

| query | impressions | clicks | position |
| --- | --- | --- | --- |
| gridfinity cutout generator | 208 | 16 | 6.42 |
| gridfinity cutout | 88 | 5 | 8.61 |
| gridfinity custom cutout | 43 | **0** | 8.07 |
| gridfinity tool cutout generator | 34 | 2 | 8.09 |
| gridfinity cutout maker | 24 | 1 | 5.29 |
| gridfinity cutouts | 16 | 1 | 12.94 |

The demand is specific and the product already answers it, so pages that mention cutouts in passing have been absorbing it instead.

For contrast, the Fusion/CAD queries in the same neighbourhood total only ~96 impressions and almost no clicks, and those searchers want a Fusion plugin we are not. Not targeted here.

## What the page covers

Written against the source, not assumptions:

- The six real shapes — `rectangle | circle | path | polygon | slot | mesh` from `types/cutout.ts`
- Freeform bezier pen paths
- Mesh imprints from an imported STL, with the actual limits: **50 MB per file, 8 meshes per design** (`MAX_MESH_FILE_BYTES`, `MAX_MESH_ASSETS_PER_DESIGN`)
- Wall cutouts, flagged as a *different* feature rather than conflated with floor cavities
- Coloured cavity floors (`floor` / `floorAndWalls`) for shadow-board contrast, with the honest caveat that it needs a multi-material printer or a filament change to show up

**One FAQ exists purely to correct a mix-up the data shows.** `add gridfinity base to stl` draws 32 impressions, and an imported STL here becomes a *cavity*, not a model with a Gridfinity foot attached. Those are different jobs, and claiming otherwise would send those visitors to a page that cannot help them.

## Registration

A new content page needs five touchpoints, and I missed one on the first pass:

- `vercel.json` — slug rewrite and cache-control header
- `scripts/vite-plugin-content-routes.ts` — dev route list
- `scripts/build-content.ts` — sitemap entry
- `scripts/gen-seo-images.ts` — OG card config
- `.gitignore` — which lists each generated page directory by name; without it the built `public/gridfinity-cutout-generator/index.html` gets committed as an artifact

Three inbound links, each dropped into the sentence that already describes the feature: the generator page's pen-tool paragraph, the bin generator's cutout-editor paragraph, and the tool drawer's pen-tool bullet.

## Verification

- `pnpm run build` exits **0** end to end (checked the exit code, not just the absence of warnings — a grep-only check is what let a YAML break through on #3370).
- Page generated, present in `public/sitemap.xml`.
- 254 script tests pass, including `check-spa-routes`, which validates the `vercel.json` rewrites.
- Title 59 chars, inside the SERP pixel budget; description 133; opening paragraph closes a sentence at char 122 of the 155-character snippet window.

## Known gap

**No bespoke OG card**, so the page falls back to the site-wide `og-image.png`. `gen-seo-images` filters by *step* rather than slug and screenshots a running dev server, so producing one card means regenerating all of them and churning every existing binary. Follow-up when someone runs that pass anyway; not a blocker, and `perPageOgImage` handles the absence gracefully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Gridfinity Cutout Generator page to capture cutout-related search traffic and explain the feature clearly. Linked from related pages and fully wired for routing, sitemap, and OG images.

- **New Features**
  - New page at /gridfinity-cutout-generator with how-to, FAQs, and schema.
  - Covers shapes: rectangle, circle, slot, polygon, freeform pen paths, and STL mesh imprint (50 MB/file, 8 meshes/design). Notes wall cutouts as separate and colored floors. Exports STL/STEP/3MF.
  - Added inbound links from the generator, bin generator, and tool drawer pages.
  - Registered in `vercel.json` (rewrite + cache), `scripts/vite-plugin-content-routes.ts`, `scripts/build-content.ts` (sitemap), `scripts/gen-seo-images.ts` (OG card), and `.gitignore` (ignore built dir).

- **Refactors**
  - Switched the cutout page copy to US English spelling for consistency.

<sup>Written for commit 9e75eacd05ad67c00320606d6decd5046b5b2133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

