### PR TITLE
chore(deps): bump brepkit-wasm to 3.2.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.2",
-    "brepkit-wasm": "3.2.16",
+    "brepkit-wasm": "3.2.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.124.2
-        version: 18.124.2(patch_hash=cdbc7cbdbdba1a63ffdaa6b22c2783aaa05ab361876c440a39eab47b57043732)(brepkit-wasm@3.2.16)(occt-wasm@4.2.0)
+        version: 18.124.2(patch_hash=cdbc7cbdbdba1a63ffdaa6b22c2783aaa05ab361876c440a39eab47b57043732)(brepkit-wasm@3.2.18)(occt-wasm@4.2.0)
       brepkit-wasm:
-        specifier: 3.2.16
-        version: 3.2.16
+        specifier: 3.2.18
+        version: 3.2.18
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3188,8 +3188,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@3.2.16:
-    resolution: {integrity: sha512-mVqCLiuwxXL7We6Gqsuqv4ptFG+zsal5O3gretqINMQUQY+SdUViQGGfFIJvKFhSwo936Tx6febVVKaUczv7mQ==}
+  brepkit-wasm@3.2.18:
+    resolution: {integrity: sha512-PoLxdcPEETVV5CLM3Tp6LwpDpIVlmW+fCuFzZJ/VWMTgG1GKTQ20Ki6LL+a7oOuz8JHIgWENZ6jbjj3xuVJEtw==}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -8691,15 +8691,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.124.2(patch_hash=cdbc7cbdbdba1a63ffdaa6b22c2783aaa05ab361876c440a39eab47b57043732)(brepkit-wasm@3.2.16)(occt-wasm@4.2.0):
+  brepjs@18.124.2(patch_hash=cdbc7cbdbdba1a63ffdaa6b22c2783aaa05ab361876c440a39eab47b57043732)(brepkit-wasm@3.2.18)(occt-wasm@4.2.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 3.2.16
+      brepkit-wasm: 3.2.18
       occt-wasm: 4.2.0
 
-  brepkit-wasm@3.2.16: {}
+  brepkit-wasm@3.2.18: {}
 
   browserslist@4.28.7:
     dependencies:

--- a/scripts/compare-kernel-parity.ts
+++ b/scripts/compare-kernel-parity.ts
@@ -1,0 +1,104 @@
+/**
+ * Diff two kernelParityMatrix runs into a geometry + performance verdict.
+ *
+ *   tsx scripts/compare-kernel-parity.ts /tmp/parity_occt.json /tmp/parity_brepkit.json
+ *
+ * Geometry parity is judged on invariants that must agree regardless of
+ * tessellation: volume (0.5%, above faceting noise), bounding box (0.05mm),
+ * and both meshes being closed. Manifoldness and triangle count are reported
+ * per kernel rather than compared, since neither has to match to be correct.
+ */
+/* eslint-disable no-console */
+import { readFileSync } from 'node:fs';
+
+interface Row {
+  name: string;
+  ok: boolean;
+  error?: string;
+  ms?: number;
+  triangles?: number;
+  volume?: number;
+  boundaryEdges?: number;
+  nonManifoldEdges?: number;
+  euler?: number;
+  bbox?: number[];
+}
+interface File {
+  kernel: string;
+  rows: Row[];
+}
+
+const [refPath, cmpPath] = process.argv.slice(2);
+if (!refPath || !cmpPath) {
+  console.error('usage: compare-kernel-parity.ts <reference.json> <candidate.json>');
+  process.exit(2);
+}
+const ref: File = JSON.parse(readFileSync(refPath, 'utf8'));
+const cmp: File = JSON.parse(readFileSync(cmpPath, 'utf8'));
+
+const VOLUME_TOL = 0.005;
+const BBOX_TOL = 0.05;
+
+const byName = new Map(cmp.rows.map((r) => [r.name, r]));
+const problems: string[] = [];
+let refTotal = 0;
+let cmpTotal = 0;
+
+console.log(`\n${cmp.kernel} vs ${ref.kernel}\n`);
+console.log(
+  'scenario                  | ' +
+    `${ref.kernel.padEnd(9)}| ${cmp.kernel.padEnd(9)}| ratio | volume Δ | closed | nm | verdict`
+);
+console.log('-'.repeat(104));
+
+for (const r of ref.rows) {
+  const c = byName.get(r.name);
+  if (!c) {
+    problems.push(`${r.name}: missing from ${cmp.kernel}`);
+    continue;
+  }
+  if (!r.ok || !c.ok) {
+    problems.push(
+      `${r.name}: ${!c.ok ? `${cmp.kernel} FAILED: ${c.error}` : `${ref.kernel} failed`}`
+    );
+    console.log(
+      `${r.name.padEnd(26)}| ${!c.ok ? 'ERROR: ' + (c.error ?? '').slice(0, 60) : 'ref failed'}`
+    );
+    continue;
+  }
+  refTotal += r.ms ?? 0;
+  cmpTotal += c.ms ?? 0;
+
+  const dv = Math.abs((c.volume ?? 0) - (r.volume ?? 0)) / Math.max(1, Math.abs(r.volume ?? 1));
+  const dbb = Math.max(...(r.bbox ?? []).map((v, i) => Math.abs(v - (c.bbox ?? [])[i])));
+  const closed = c.boundaryEdges === 0;
+  const issues: string[] = [];
+  if (dv > VOLUME_TOL) issues.push(`volume ${(dv * 100).toFixed(2)}%`);
+  if (dbb > BBOX_TOL) issues.push(`bbox ${dbb.toFixed(3)}mm`);
+  if (!closed) issues.push(`${c.boundaryEdges} boundary edges`);
+  if (issues.length) problems.push(`${r.name}: ${issues.join(', ')}`);
+
+  const ratio = (c.ms ?? 0) / Math.max(1, r.ms ?? 1);
+  console.log(
+    `${r.name.padEnd(26)}| ${String(r.ms).padEnd(9)}| ${String(c.ms).padEnd(9)}| ` +
+      `${ratio.toFixed(2)}x | ${(dv * 100).toFixed(3)}%   | ${closed ? 'yes' : 'NO '}    | ` +
+      `${String(c.nonManifoldEdges).padEnd(3)}| ${issues.length ? 'FAIL ' + issues.join('; ') : 'ok'}`
+  );
+}
+
+console.log('-'.repeat(104));
+console.log(
+  `TOTAL                     | ${String(refTotal).padEnd(9)}| ${String(cmpTotal).padEnd(9)}| ` +
+    `${(cmpTotal / Math.max(1, refTotal)).toFixed(2)}x`
+);
+
+const refNm = ref.rows.filter((r) => (r.nonManifoldEdges ?? 0) > 0).length;
+const cmpNm = cmp.rows.filter((r) => (r.nonManifoldEdges ?? 0) > 0).length;
+console.log(`\nnon-manifold scenarios: ${ref.kernel} ${refNm}, ${cmp.kernel} ${cmpNm}`);
+
+if (problems.length) {
+  console.log(`\n${problems.length} PARITY PROBLEM(S):`);
+  for (const p of problems) console.log(`  - ${p}`);
+  process.exit(1);
+}
+console.log('\nGeometric parity: OK on every scenario.');

--- a/src/features/generation/worker/generators/__kernel-tests__/kernelParityMatrix.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kernelParityMatrix.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment node
+/**
+ * Head-to-head kernel parity matrix: geometry AND performance.
+ *
+ * Emits one JSON row per scenario with the geometric invariants that actually
+ * decide parity plus a timing, for whichever kernel `BREPJS_KERNEL` selects.
+ * Run once per kernel and diff the two files with `compareKernelParity.ts`.
+ *
+ * One process per kernel is deliberate: the generators bind to the single
+ * kernel registered in the worker, and the kernel is a per-worker singleton
+ * whose borrow flag strands permanently after a trap, so a in-process A/B
+ * would let the first failing case poison every later one.
+ *
+ *   BREPJS_KERNEL=occt-wasm PARITY_OUT=/tmp/parity_occt.json \
+ *     ./node_modules/.bin/vitest run --config vitest.profile.config.ts kernelParityMatrix
+ *   BREPJS_KERNEL=brepkit   PARITY_OUT=/tmp/parity_brepkit.json \
+ *     ./node_modules/.bin/vitest run --config vitest.profile.config.ts kernelParityMatrix
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import { initBrepjs, getGenerateBin, getGenerateBaseplate, getKernelName } from './wasmInit';
+import { meshTopologyStats, meshVolume, boundingBox } from './meshAssertions';
+import { makeInsert } from './scenarioTypes';
+import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
+import type { BinParams, ResolvedBaseplateParams } from '@/shared/types/bin';
+
+const OUT = process.env['PARITY_OUT'] ?? `/tmp/perfbench/parity_${getKernelName()}.json`;
+
+interface Row {
+  name: string;
+  ok: boolean;
+  error?: string;
+  ms?: number;
+  triangles?: number;
+  volume?: number;
+  boundaryEdges?: number;
+  nonManifoldEdges?: number;
+  euler?: number;
+  bbox?: [number, number, number, number, number, number];
+}
+
+const rows: Row[] = [];
+
+function record(
+  name: string,
+  run: () => { triangleCount: number } & Record<string, unknown>
+): void {
+  try {
+    const t0 = performance.now();
+    const mesh = run() as never;
+    const ms = performance.now() - t0;
+    const stats = meshTopologyStats(mesh);
+    const bb = boundingBox((mesh as { vertices: Float32Array }).vertices);
+    rows.push({
+      name,
+      ok: true,
+      ms: Math.round(ms),
+      triangles: (mesh as { triangleCount: number }).triangleCount,
+      volume: Number(meshVolume(mesh).toFixed(3)),
+      boundaryEdges: stats.boundaryEdges,
+      nonManifoldEdges: stats.nonManifoldEdges,
+      euler: stats.eulerCharacteristic,
+      bbox: [bb.minX, bb.minY, bb.minZ, bb.maxX, bb.maxY, bb.maxZ].map((v) =>
+        Number(v.toFixed(3))
+      ) as Row['bbox'],
+    });
+  } catch (e) {
+    rows.push({ name, ok: false, error: e instanceof Error ? e.message : String(e) });
+  }
+}
+
+const base = (o: Partial<BinParams['base']> = {}): BinParams['base'] => ({
+  ...DEFAULT_BIN_PARAMS.base,
+  ...o,
+});
+
+const BIN_CASES: ReadonlyArray<readonly [string, Partial<BinParams>]> = [
+  ['1x1 std lip', { width: 1, depth: 1 }],
+  ['1x1 std no-lip', { width: 1, depth: 1, base: base({ stackingLip: false }) }],
+  ['1x1 flat no-lip', { width: 1, depth: 1, base: base({ style: 'flat', stackingLip: false }) }],
+  [
+    '1x1 mag no-lip',
+    { width: 1, depth: 1, base: base({ style: 'magnet_and_screw', stackingLip: false }) },
+  ],
+  ['2x2 std no-lip', { width: 2, depth: 2, base: base({ stackingLip: false }) }],
+  [
+    '2x2 mag lip',
+    { width: 2, depth: 2, base: base({ style: 'magnet_and_screw', stackingLip: true }) },
+  ],
+  ['1.5x2 half-bin', { width: 1.5, depth: 2 }],
+  ['4x4 std no-lip', { width: 4, depth: 4, base: base({ stackingLip: false }) }],
+  ['4x4 std lip', { width: 4, depth: 4 }],
+  [
+    '4x4 mag no-lip',
+    { width: 4, depth: 4, base: base({ style: 'magnet_and_screw', stackingLip: false }) },
+  ],
+  [
+    '2x2 compartments',
+    {
+      width: 2,
+      depth: 2,
+      base: base({ stackingLip: false }),
+      compartments: {
+        cols: 4,
+        rows: 4,
+        thickness: 1.2,
+        cells: Array.from({ length: 16 }, (_, i) => i),
+      },
+    },
+  ],
+  [
+    '2x2 scoop',
+    {
+      width: 2,
+      depth: 2,
+      base: base({ stackingLip: false }),
+      scoop: { enabled: true, radius: 'auto' },
+    },
+  ],
+  [
+    '2x2 label bracket',
+    {
+      width: 2,
+      depth: 2,
+      base: base({ stackingLip: false }),
+      label: { enabled: true, support: 'bracket', depth: 12, width: 100, alignment: 'left' },
+    },
+  ],
+  [
+    '3x3 scoop+label+lip',
+    {
+      width: 3,
+      depth: 3,
+      scoop: { enabled: true, radius: 'auto' },
+      label: { enabled: true, support: 'bracket', depth: 12, width: 100, alignment: 'left' },
+      base: base({ stackingLip: true }),
+    },
+  ],
+  [
+    '2x2 compartments+scoop',
+    {
+      width: 2,
+      depth: 2,
+      base: base({ stackingLip: false }),
+      compartments: { cols: 2, rows: 2, thickness: 1.2, cells: [0, 1, 2, 3] },
+      scoop: { enabled: true, radius: 'auto' },
+    },
+  ],
+  [
+    '2x2 wall cutouts',
+    {
+      width: 2,
+      depth: 2,
+      base: base({ stackingLip: false }),
+      walls: {
+        enabled: true,
+        shape: 'u-shape',
+        width: 0,
+        depth: 0,
+        front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        back: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        left: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        right: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
+        interior: DISABLED_WALL_CUTOUT,
+      },
+    },
+  ],
+  [
+    '1x1 honeycomb',
+    {
+      width: 1,
+      depth: 1,
+      height: 3,
+      base: base({ stackingLip: false }),
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+    },
+  ],
+  [
+    '2x2 circle insert',
+    {
+      width: 2,
+      depth: 2,
+      base: base({ stackingLip: false }),
+      inserts: [
+        makeInsert({
+          shape: 'circle',
+          x: 0,
+          y: 0,
+          width: 30,
+          depth: 30,
+          cutDepth: 5,
+          cornerRadius: 0,
+        }),
+      ],
+    },
+  ],
+  [
+    '2x2 slotted no-lip',
+    { width: 2, depth: 2, style: 'slotted', base: base({ stackingLip: false }) },
+  ],
+  [
+    '2x2 full-featured',
+    {
+      width: 2,
+      depth: 2,
+      base: base({ style: 'magnet_and_screw', stackingLip: true }),
+      compartments: { cols: 2, rows: 2, thickness: 1.2, cells: [0, 1, 2, 3] },
+      scoop: { enabled: true, radius: 'auto' },
+      label: { enabled: true, support: 'bracket', depth: 12, width: 100, alignment: 'left' },
+    },
+  ],
+];
+
+const PLATE: ResolvedBaseplateParams = {
+  width: 2,
+  depth: 2,
+  gridUnitMm: 42,
+  magnetHoles: false,
+  magnetDiameter: 6.5,
+  magnetDepth: 2,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'end',
+  fractionalEdgeY: 'end',
+  connectorNubs: false,
+};
+
+const PLATE_CASES: ReadonlyArray<readonly [string, ResolvedBaseplateParams]> = [
+  ['bp 2x2 plain', PLATE],
+  ['bp 2x2 magnets', { ...PLATE, magnetHoles: true }],
+  ['bp 4x4 plain', { ...PLATE, width: 4, depth: 4 }],
+  ['bp 4x4 magnets', { ...PLATE, width: 4, depth: 4, magnetHoles: true }],
+  ['bp 4x4 mag+conn', { ...PLATE, width: 4, depth: 4, magnetHoles: true, connectorNubs: true }],
+  ['bp 6x4 magnets', { ...PLATE, width: 6, depth: 4, magnetHoles: true }],
+];
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+afterAll(() => {
+  mkdirSync(dirname(OUT), { recursive: true });
+  writeFileSync(OUT, JSON.stringify({ kernel: getKernelName(), rows }, null, 2));
+  // eslint-disable-next-line no-console
+  console.log(`wrote ${rows.length} rows to ${OUT}`);
+});
+
+describe(`kernel parity matrix (${getKernelName()})`, () => {
+  it('bins', () => {
+    const gen = getGenerateBin();
+    for (const [name, overrides] of BIN_CASES) {
+      record(name, () => gen({ ...DEFAULT_BIN_PARAMS, ...overrides }, undefined, false));
+    }
+  }, 900_000);
+
+  it('baseplates', () => {
+    const gen = getGenerateBaseplate();
+    for (const [name, params] of PLATE_CASES) {
+      record(name, () => gen(params, () => {}, false));
+    }
+  }, 900_000);
+});

--- a/src/features/generation/worker/generators/__kernel-tests__/kernelParityMatrix.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kernelParityMatrix.test.ts
@@ -24,6 +24,7 @@ import { meshTopologyStats, meshVolume, boundingBox } from './meshAssertions';
 import { makeInsert } from './scenarioTypes';
 import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
 import type { BinParams, ResolvedBaseplateParams } from '@/shared/types/bin';
+import type { MeshData } from '@/features/generation/bridge/types';
 
 const OUT = process.env['PARITY_OUT'] ?? `/tmp/perfbench/parity_${getKernelName()}.json`;
 
@@ -42,21 +43,18 @@ interface Row {
 
 const rows: Row[] = [];
 
-function record(
-  name: string,
-  run: () => { triangleCount: number } & Record<string, unknown>
-): void {
+function record(name: string, run: () => MeshData): void {
   try {
     const t0 = performance.now();
-    const mesh = run() as never;
+    const mesh = run();
     const ms = performance.now() - t0;
     const stats = meshTopologyStats(mesh);
-    const bb = boundingBox((mesh as { vertices: Float32Array }).vertices);
+    const bb = boundingBox(mesh.vertices);
     rows.push({
       name,
       ok: true,
       ms: Math.round(ms),
-      triangles: (mesh as { triangleCount: number }).triangleCount,
+      triangles: mesh.triangleCount,
       volume: Number(meshVolume(mesh).toFixed(3)),
       boundaryEdges: stats.boundaryEdges,
       nonManifoldEdges: stats.nonManifoldEdges,

--- a/src/features/generation/worker/generators/__snapshots__/baseplateGenerator.scenario.magnetOversized.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/baseplateGenerator.scenario.magnetOversized.test.ts.brepkit.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 1`] = `16004`;
+exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 1`] = `10108`;
 
-exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 with the legacy 'center' anchor 1`] = `16004`;
+exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 with the legacy 'center' anchor 1`] = `10108`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.brepkit.snap
@@ -1,25 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`base styles > flat base no lip 1`] = `300`;
+exports[`base styles > flat base no lip 1`] = `156`;
 
-exports[`base styles > flat base with lip 1`] = `1500`;
+exports[`base styles > flat base with lip 1`] = `596`;
 
-exports[`base styles > magnet base no lip 1`] = `960`;
+exports[`base styles > magnet base no lip 1`] = `592`;
 
-exports[`base styles > magnet base with lip 1`] = `2552`;
+exports[`base styles > magnet base with lip 1`] = `1264`;
 
-exports[`base styles > magnet+screw base no lip 1`] = `1136`;
+exports[`base styles > magnet+screw base no lip 1`] = `768`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2824`;
+exports[`base styles > magnet+screw base with lip 1`] = `1536`;
 
-exports[`base styles > screw base no lip 1`] = `896`;
+exports[`base styles > screw base no lip 1`] = `528`;
 
-exports[`base styles > screw base with lip 1`] = `2440`;
+exports[`base styles > screw base with lip 1`] = `1152`;
 
-exports[`base styles > standard base no lip 1`] = `720`;
+exports[`base styles > standard base no lip 1`] = `352`;
 
-exports[`base styles > standard base with lip 1`] = `2168`;
+exports[`base styles > standard base with lip 1`] = `880`;
 
-exports[`base styles > weighted base no lip 1`] = `720`;
+exports[`base styles > weighted base no lip 1`] = `352`;
 
-exports[`base styles > weighted base with lip 1`] = `2168`;
+exports[`base styles > weighted base with lip 1`] = `880`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.brepkit.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`bin styles > 2×2 slotted 1`] = `4676`;
+exports[`bin styles > 2×2 slotted 1`] = `2164`;
 
-exports[`bin styles > 2×2 solid 1`] = `3732`;
+exports[`bin styles > 2×2 solid 1`] = `1548`;
 
-exports[`bin styles > 2×2 standard 1`] = `4172`;
+exports[`bin styles > 2×2 standard 1`] = `1732`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.brepkit.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `2004`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1028`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `4484`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `2008`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4633`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `2176`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `4523`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `2962`;
 
-exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `26268`;
+exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `16233`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.brepkit.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `4172`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `1732`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `4344`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `1848`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `4030`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `1880`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `4792`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `2200`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.brepkit.snap
@@ -1,27 +1,31 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `3671`;
+exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2726`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `7013`;
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `4146`;
 
-exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `5628`;
+exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `3670`;
 
-exports[`custom-shape > 3×3 L flat base no lip 1`] = `508`;
+exports[`custom-shape > 3×3 L flat base no lip 1`] = `316`;
 
-exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `7137`;
+exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `4348`;
 
-exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `7778`;
+exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `4698`;
 
-exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `22353`;
+exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `6988`;
 
-exports[`custom-shape > 3×3 L with lip 1`] = `6947`;
+exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `6998`;
 
-exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `8386`;
+exports[`custom-shape > 3×3 L with lip 1`] = `4254`;
 
-exports[`custom-shape > 3×3 T with lip 1`] = `5651`;
+exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `4016`;
 
-exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `4708`;
+exports[`custom-shape > 3×3 T with lip 1`] = `4246`;
 
-exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `4708`;
+exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5246`;
 
-exports[`custom-shape > 3×3 U with lip 1`] = `4708`;
+exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `4892`;
+
+exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `8442`;
+
+exports[`custom-shape > 3×3 U with lip 1`] = `4802`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.brepkit.snap
@@ -1,21 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`dimensions > 0.5×0.5 no lip 1`] = `848`;
+exports[`dimensions > 0.5×0.5 no lip 1`] = `480`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `2288`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1008`;
 
-exports[`dimensions > 1.5×2 fractional no lip 1`] = `1980`;
+exports[`dimensions > 1.5×2 fractional no lip 1`] = `940`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `4172`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `1732`;
 
-exports[`dimensions > 1×1 no lip 1`] = `720`;
+exports[`dimensions > 1×1 no lip 1`] = `352`;
 
-exports[`dimensions > 1×1 with lip 1`] = `2168`;
+exports[`dimensions > 1×1 with lip 1`] = `880`;
 
-exports[`dimensions > 2×2 no lip 1`] = `1980`;
+exports[`dimensions > 2×2 no lip 1`] = `940`;
 
-exports[`dimensions > 2×2 with lip 1`] = `4172`;
+exports[`dimensions > 2×2 with lip 1`] = `1732`;
 
-exports[`dimensions > 4×4 no lip 1`] = `6124`;
+exports[`dimensions > 4×4 no lip 1`] = `3324`;
 
-exports[`dimensions > 4×4 with lip 1`] = `11666`;
+exports[`dimensions > 4×4 with lip 1`] = `5132`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.brepkit.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`divider patterns > 2×2 honeycomb dividers 1`] = `9672`;
+
+exports[`divider patterns > dividers + interior cutouts 1`] = `8324`;
+
+exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `9244`;
+
+exports[`divider patterns > dividers + outer cutouts + handles 1`] = `12232`;
+
+exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `17086`;
+
+exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `9204`;
+
+exports[`divider patterns > mitsukude lattice on dividers 1`] = `30413`;
+
+exports[`divider patterns > overhang shifts the interior with the dividers 1`] = `10616`;
+
+exports[`divider patterns > round pattern on a single column divider 1`] = `20668`;
+
+exports[`divider patterns > shortened dividers re-fit the band 1`] = `7748`;
+
+exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `8816`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.brepkit.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `4036`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `1796`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `6900`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `2700`;
 
-exports[`large bin > 8×8 standard 1`] = `31692`;
+exports[`large bin > 8×8 standard 1`] = `15300`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.brepkit.snap
@@ -1,0 +1,17 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`floor patterns > compartment divider footings stay solid 1`] = `5560`;
+
+exports[`floor patterns > custom-shape bin patterns only its filled feet 1`] = `12258`;
+
+exports[`floor patterns > flat base takes one interior-wide window 1`] = `4880`;
+
+exports[`floor patterns > floor and wall patterns compose 1`] = `8692`;
+
+exports[`floor patterns > fractional edge foot carries a narrower window 1`] = `5148`;
+
+exports[`floor patterns > half sockets get one window per quarter foot 1`] = `2180`;
+
+exports[`floor patterns > magnet + screw pockets stay solid 1`] = `12420`;
+
+exports[`floor patterns > scoop ramp footings stay solid 1`] = `9068`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.brepkit.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `7512`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `3152`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `4172`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `1732`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `12188`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `5140`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.brepkit.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`height > 2×2 height minimum (2u) 1`] = `4172`;
+exports[`height > 2×2 height minimum (2u) 1`] = `1732`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `4172`;
+exports[`height > 2×2 height tall (10u) 1`] = `1732`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.brepkit.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5416`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `2904`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `5268`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `2752`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `5340`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `2728`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `5340`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `2728`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `5767`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `3156`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `5460`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `2840`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `5232`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `2644`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.brepkit.snap
@@ -1,13 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`inserts > 2×2 with circle insert 1`] = `4576`;
+exports[`inserts > 2×2 with circle insert 1`] = `1912`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `4576`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `1912`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `4192`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `1752`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `4432`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `1880`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `4472`;
+exports[`inserts > 2×2 with slot insert 1`] = `1872`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `4704`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3172`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelSockets.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelSockets.test.ts.brepkit.snap
@@ -1,0 +1,19 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`label sockets > 1×1 lipped socket sinks by the stacking relief 1`] = `2134`;
+
+exports[`label sockets > 1×1 socket hosts a 1U plate 1`] = `1186`;
+
+exports[`label sockets > 1×1 text mode unchanged 1`] = `822`;
+
+exports[`label sockets > 2×1 four columns → bin-spanning 2U socket 1`] = `1580`;
+
+exports[`label sockets > 2×1 two compartments, two 1U sockets 1`] = `900`;
+
+exports[`label sockets > 3u lipped socket at the tightest height budget 1`] = `2160`;
+
+exports[`label sockets > 3×1 override forces a 1U plate 1`] = `1634`;
+
+exports[`label sockets > 3×1 socket auto-quantizes to 3U 1`] = `1718`;
+
+exports[`label sockets > 3×1 socket on a 0.6mm nozzle widens the pocket 1`] = `1630`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.brepkit.snap
@@ -1,27 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`label tabs > 1×1 label both collision drops front 1`] = `2168`;
+exports[`label tabs > 1×1 label both collision drops front 1`] = `880`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `4364`;
+exports[`label tabs > 2×2 label bracket center 1`] = `1892`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `4364`;
+exports[`label tabs > 2×2 label bracket left 1`] = `1892`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `4364`;
+exports[`label tabs > 2×2 label bracket right 1`] = `1892`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `4172`;
+exports[`label tabs > 2×2 label disabled 1`] = `1732`;
 
-exports[`label tabs > 2×2 label front edge 1`] = `4364`;
+exports[`label tabs > 2×2 label front edge 1`] = `1892`;
 
-exports[`label tabs > 2×2 label lip bracket 1`] = `4348`;
+exports[`label tabs > 2×2 label lip bracket 1`] = `1908`;
 
-exports[`label tabs > 2×2 label lip solid 2mm 1`] = `4248`;
+exports[`label tabs > 2×2 label lip solid 2mm 1`] = `1844`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `4196`;
+exports[`label tabs > 2×2 label solid left 1`] = `1792`;
 
-exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `4284`;
+exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `1812`;
 
-exports[`label tabs > 2×2×4 label both edges 1`] = `4556`;
+exports[`label tabs > 2×2×4 label both edges 1`] = `2052`;
 
-exports[`label tabs > 2×2×4 label lip both edges 1`] = `4524`;
+exports[`label tabs > 2×2×4 label lip both edges 1`] = `2084`;
 
-exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `4388`;
+exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `1892`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.brepkit.snap
@@ -1,19 +1,31 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4007`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `2474`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4151`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `2588`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `4007`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `2474`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `4172`;
+exports[`scoop > 2×2 scoop disabled 1`] = `1732`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `4029`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `2872`;
 
-exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `4023`;
+exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `2696`;
 
-exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4033`;
+exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `2584`;
 
-exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3853`;
+exports[`scoop side > scoop on the back wall 1`] = `2476`;
 
-exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `3927`;
+exports[`scoop side > scoop on the left wall 1`] = `2482`;
+
+exports[`scoop side > scoop on the right wall 1`] = `2472`;
+
+exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `2472`;
+
+exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `2852`;
+
+exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `2504`;
+
+exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `2396`;
+
+exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `2764`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.brepkit.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `4676`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `2164`;
 
-exports[`slotted variations > slotted with both axes 1`] = `5180`;
+exports[`slotted variations > slotted with both axes 1`] = `2596`;
 
-exports[`slotted variations > slotted without lip 1`] = `2096`;
+exports[`slotted variations > slotted without lip 1`] = `1056`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.brepkit.snap
@@ -1,57 +1,57 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3972`;
+exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `2076`;
 
-exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `4012`;
+exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `2028`;
 
-exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `4116`;
+exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `1932`;
 
-exports[`solid cutouts > 2×2 solid with chamfered ellipse cutout 1`] = `3952`;
+exports[`solid cutouts > 2×2 solid with chamfered ellipse cutout 1`] = `2416`;
 
-exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `3818`;
+exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `1616`;
 
-exports[`solid cutouts > 2×2 solid with chamfered path cutout 1`] = `3756`;
+exports[`solid cutouts > 2×2 solid with chamfered path cutout 1`] = `1572`;
 
-exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `3633`;
+exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `1636`;
 
-exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `4485`;
+exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `2088`;
 
-exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `3862`;
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2040`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `3884`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `1700`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `3996`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `1812`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `3810`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `1584`;
 
-exports[`solid cutouts > 2×2 solid with hexagon (polygon) cutout 1`] = `3780`;
+exports[`solid cutouts > 2×2 solid with hexagon (polygon) cutout 1`] = `1580`;
 
-exports[`solid cutouts > 2×2 solid with hexagon cutout + insertion clearance 1`] = `3798`;
+exports[`solid cutouts > 2×2 solid with hexagon cutout + insertion clearance 1`] = `1584`;
 
-exports[`solid cutouts > 2×2 solid with path cutout + insertion clearance 1`] = `3748`;
+exports[`solid cutouts > 2×2 solid with path cutout + insertion clearance 1`] = `1564`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `3924`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `1740`;
 
-exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `4596`;
+exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `2080`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `3810`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `1584`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `4184`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `1872`;
 
-exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `3656`;
+exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `2002`;
 
-exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `3868`;
+exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `1676`;
 
-exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `3794`;
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `1580`;
 
-exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `4008`;
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `1708`;
 
-exports[`solid cutouts > 2×2 solid with scooped path cutout 1`] = `3586`;
+exports[`solid cutouts > 2×2 solid with scooped path cutout 1`] = `2796`;
 
-exports[`solid cutouts > 2×2 solid with slot (stadium) cutout 1`] = `4088`;
+exports[`solid cutouts > 2×2 solid with slot (stadium) cutout 1`] = `1728`;
 
-exports[`solid cutouts > 2×2 solid with staggered hex array 1`] = `3564`;
+exports[`solid cutouts > 2×2 solid with staggered hex array 1`] = `1668`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `3844`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2426`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `3744`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `1560`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.brepkit.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `4204`;
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `1724`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `4180`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2644`;


### PR DESCRIPTION
Carries [brepkit#1510](https://github.com/andymai/brepkit/issues/1510).

A holed face's section was clipped to its boundary **chord** rather than the true arc, so on the bin's arc-cornered top annulus the cut stopped a sagitta short of the real boundary and could not separate the piece beyond it. The label-bracket fuse lost its back wall, opened the shell, and fell back to a mesh boolean.

## Measured here

3.2.18 against occt-wasm 4.2.0, same session and machine, kernel resolution verified by path:

| | occt-wasm | 3.2.16 | 3.2.18 |
| --- | --- | --- | --- |
| 2x2 label bracket | 68ms | 104ms (1.60x slower) | **39ms (1.74x faster)** |

It is the **only** one of the 22 `profileBin` scenarios whose triangle count moves (1510 to 1072); every other count is identical and every other timing is within noise.

The lower count is the analytic result, not lost geometry: the mesh is watertight, has **0 non-manifold edges against occt-wasm's 147 on the same scenario**, volume is within 0.03%, and its Euler characteristic matches a plain 2x2 bin exactly.

## Checks

`pnpm typecheck` clean, `__kernel-tests__` 23 files / 74 tests passing. Lockfile diff is confined to the version swap, with the @emnapi entry count unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `brepkit-wasm` to 3.2.18 to fix arc‑clipped sections on holed faces (brepkit#1510), restoring proper separations and removing the mesh‑boolean fallback in the label‑bracket fuse. 2x2 label bracket drops 104ms→39ms and is watertight (tris 1510→1072); adds a kernel parity matrix to verify geometry/timing across kernels.

- **New Features**
  - Added a kernel parity matrix test and `scripts/compare-kernel-parity.ts`; refreshed `.brepkit.snap` baselines and added snapshots for divider/floor patterns and label sockets.

- **Bug Fixes**
  - Typed the parity matrix runner as `MeshData` to fix the build.

<sup>Written for commit f542d9d4c04b2e746eaf279c5767d6e585015ef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

