### PR TITLE
perf: cut Vercel edge requests and build minutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "@mediapipe/tasks-vision": "0.10.35",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
-    "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.2.17)(immer@11.1.15)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1)
-      '@vercel/analytics':
-        specifier: ^2.0.1
-        version: 2.0.1(react@19.2.8)
       '@vercel/blob':
         specifier: ^2.6.1
         version: 2.6.1
@@ -2851,35 +2848,6 @@ packages:
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
       react: '>= 16.8.0'
-
-  '@vercel/analytics@2.0.1':
-    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      nuxt: '>= 3'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      nuxt:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
 
   '@vercel/blob@2.6.1':
     resolution: {integrity: sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==}
@@ -8316,10 +8284,6 @@ snapshots:
   '@use-gesture/react@10.3.1(react@19.2.8)':
     dependencies:
       '@use-gesture/core': 10.3.1
-      react: 19.2.8
-
-  '@vercel/analytics@2.0.1(react@19.2.8)':
-    optionalDependencies:
       react: 19.2.8
 
   '@vercel/blob@2.6.1':

--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -27,11 +27,16 @@ if [ "$VERCEL_GIT_COMMIT_REF" = "main" ]; then
   # merges are ~40% of main's commits. The bumped version ships with the next
   # source commit.
   if [[ "$VERCEL_GIT_COMMIT_MESSAGE" == "chore(main): release "* ]]; then
-    non_release_files="$(git diff --name-only HEAD^ HEAD |
-      grep -vE '^(package\.json|CHANGELOG\.md|\.release-please-manifest\.json)$' || true)"
-    if [ -z "$non_release_files" ]; then
-      echo "Release-only commit (version + changelog). Skipping build."
-      exit 0
+    # Require a non-empty file list before trusting it. On a shallow clone with no
+    # HEAD^ the diff fails, and an empty result would otherwise be indistinguishable
+    # from "nothing outside the release files changed" and skip a real build.
+    if changed_files="$(git diff --name-only HEAD^ HEAD 2>/dev/null)" && [ -n "$changed_files" ]; then
+      non_release_files="$(printf '%s\n' "$changed_files" |
+        grep -vE '^(package\.json|CHANGELOG\.md|\.release-please-manifest\.json)$' || true)"
+      if [ -z "$non_release_files" ]; then
+        echo "Release-only commit (version + changelog). Skipping build."
+        exit 0
+      fi
     fi
   fi
 

--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -22,6 +22,19 @@ fi
 if [ "$VERCEL_GIT_COMMIT_REF" = "main" ]; then
   echo "Main branch: checking for SPA changes..."
 
+  # A release-please merge bumps only the version and changelog, but it touches
+  # package.json, which the watch list below counts as a real change. Those
+  # merges are ~40% of main's commits. The bumped version ships with the next
+  # source commit.
+  if [[ "$VERCEL_GIT_COMMIT_MESSAGE" == "chore(main): release "* ]]; then
+    non_release_files="$(git diff --name-only HEAD^ HEAD |
+      grep -vE '^(package\.json|CHANGELOG\.md|\.release-please-manifest\.json)$' || true)"
+    if [ -z "$non_release_files" ]; then
+      echo "Release-only commit (version + changelog). Skipping build."
+      exit 0
+    fi
+  fi
+
   # Check if any SPA-related files changed compared to previous commit
   # If git diff --quiet exits 0, no changes were found (skip build)
   # If git diff --quiet exits 1, changes were found (proceed with build)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,4 @@
 import { createRoot } from 'react-dom/client';
-import { Analytics } from '@vercel/analytics/react';
 import './index.css';
 import App from './App.tsx';
 import { ErrorBoundary } from '@/shell/ErrorBoundary';
@@ -153,7 +152,6 @@ if (isSmokeMode()) {
           <LocaleProvider initialLocale={initialLocale} onLocaleChange={handleLocaleChange}>
             {initError ? <InitErrorFallback error={initError} /> : <App />}
           </LocaleProvider>
-          <Analytics />
         </ErrorBoundary>
       );
     });

--- a/src/shared/analytics/posthog/eventsPerformance.test.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const trackEventMock = vi.fn();
+const isPerfSampledMock = vi.fn(() => true);
 
 vi.mock('./trackEvent', () => ({
   trackEvent: (name: string, properties?: Record<string, unknown>) => {
@@ -10,10 +11,21 @@ vi.mock('./trackEvent', () => ({
   getDeviceType: () => 'desktop',
 }));
 
-import { trackBooleanFallbacks, trackCachePerformance } from './eventsPerformance';
+vi.mock('./perfSampling', () => ({
+  isPerfSampled: () => isPerfSampledMock(),
+  PERF_SAMPLE_RATE: 0.1,
+  resetPerfSampling: () => {},
+}));
+
+import {
+  trackBooleanFallbacks,
+  trackCachePerformance,
+  trackKernelPerformance,
+} from './eventsPerformance';
 
 beforeEach(() => {
   trackEventMock.mockReset();
+  isPerfSampledMock.mockReturnValue(true);
 });
 
 describe('trackCachePerformance', () => {
@@ -27,6 +39,7 @@ describe('trackCachePerformance', () => {
     });
 
     expect(trackEventMock).toHaveBeenCalledWith('generation_cache_stats', {
+      sample_rate: 0.1,
       total_hits: 12,
       total_misses: 4,
       total_evictions: 1,
@@ -49,6 +62,7 @@ describe('trackCachePerformance', () => {
     });
 
     expect(trackEventMock).toHaveBeenCalledWith('generation_cache_stats', {
+      sample_rate: 0.1,
       total_hits: 10,
       total_misses: 10,
       total_evictions: 2,
@@ -115,6 +129,39 @@ describe('trackCachePerformance', () => {
     const props = trackEventMock.mock.calls[0]?.[1] as Record<string, number>;
     expect(props).toHaveProperty('cache_used_hit_rate', 1);
     expect(props).not.toHaveProperty('cache_idle_hit_rate');
+  });
+});
+
+describe('generation diagnostics sampling', () => {
+  it('emits nothing from the per-generation diagnostics in an unsampled session', () => {
+    isPerfSampledMock.mockReturnValue(false);
+
+    trackCachePerformance({
+      total_hits: 12,
+      total_misses: 4,
+      total_evictions: 1,
+      hit_rate: 0.75,
+      cache_count: 3,
+    });
+    trackKernelPerformance({ stats: { boolean: { totalMs: 12.34, count: 2 } } });
+
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it('carries the sample rate on kernel timings so aggregates can be scaled back up', () => {
+    trackKernelPerformance({ stats: { boolean: { totalMs: 12.34, count: 2 } } });
+
+    expect(trackEventMock).toHaveBeenCalledWith('generation_kernel_perf', {
+      boolean_ms: 12.3,
+      boolean_count: 2,
+      sample_rate: 0.1,
+    });
+  });
+
+  it('stays silent when no kernel category did work, sampled or not', () => {
+    trackKernelPerformance({ stats: { boolean: { totalMs: 0, count: 0 } } });
+
+    expect(trackEventMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/shared/analytics/posthog/eventsPerformance.ts
+++ b/src/shared/analytics/posthog/eventsPerformance.ts
@@ -8,6 +8,7 @@
 
 import type { WorkerCacheStats } from '@/shared/types/generation';
 import { trackEvent } from './trackEvent';
+import { isPerfSampled, PERF_SAMPLE_RATE } from './perfSampling';
 
 const toCacheKey = (name: string): string =>
   name
@@ -42,7 +43,10 @@ export function trackCachePerformance(stats: {
   cache_count: number;
   per_cache?: readonly WorkerCacheStats[];
 }): void {
+  if (!isPerfSampled()) return;
+
   const properties: Record<string, number> = {
+    sample_rate: PERF_SAMPLE_RATE,
     total_hits: stats.total_hits,
     total_misses: stats.total_misses,
     total_evictions: stats.total_evictions,
@@ -78,6 +82,8 @@ const toSnakeCase = (s: string): string => s.replace(/[A-Z]/g, (c) => `_${c.toLo
 export function trackKernelPerformance(payload: {
   stats: Readonly<Record<string, { totalMs: number; count: number }>>;
 }): void {
+  if (!isPerfSampled()) return;
+
   // Flatten stats into snake_case properties: boolean_ms, edge_mesh_count, etc.
   const properties: Record<string, number> = {};
   for (const [category, { totalMs, count }] of Object.entries(payload.stats)) {
@@ -88,7 +94,7 @@ export function trackKernelPerformance(payload: {
     }
   }
   if (Object.keys(properties).length > 0) {
-    trackEvent('generation_kernel_perf', properties);
+    trackEvent('generation_kernel_perf', { ...properties, sample_rate: PERF_SAMPLE_RATE });
   }
 }
 

--- a/src/shared/analytics/posthog/perfSampling.test.ts
+++ b/src/shared/analytics/posthog/perfSampling.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isPerfSampled, PERF_SAMPLE_RATE, resetPerfSampling } from './perfSampling';
+
+afterEach(() => {
+  resetPerfSampling();
+  vi.restoreAllMocks();
+});
+
+describe('isPerfSampled', () => {
+  it('admits a session that rolls under the sample rate', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(PERF_SAMPLE_RATE / 2);
+
+    expect(isPerfSampled()).toBe(true);
+  });
+
+  it('rejects a session that rolls on or above the sample rate', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(PERF_SAMPLE_RATE);
+
+    expect(isPerfSampled()).toBe(false);
+  });
+
+  it('rolls once and reuses the verdict so a session emits a complete series', () => {
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const verdicts = [isPerfSampled(), isPerfSampled(), isPerfSampled()];
+
+    expect(verdicts).toEqual([true, true, true]);
+    expect(random).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/analytics/posthog/perfSampling.ts
+++ b/src/shared/analytics/posthog/perfSampling.ts
@@ -1,0 +1,26 @@
+/**
+ * Sampling gate for the high-frequency generation diagnostics.
+ *
+ * `generation_cache_stats` and `generation_kernel_perf` fire once per geometry
+ * generation, which puts them an order of magnitude above every product event
+ * and makes them the bulk of ingested volume. They feed capacity planning and
+ * regression watching, where a sample is as good as a census.
+ *
+ * The decision is taken once per page session rather than per event so a
+ * sampled session emits a complete series: cache and kernel timings for the
+ * same generation stay joinable, which per-event coin flips would break.
+ */
+
+export const PERF_SAMPLE_RATE = 0.1;
+
+let sampled: boolean | null = null;
+
+export function isPerfSampled(): boolean {
+  sampled ??= Math.random() < PERF_SAMPLE_RATE;
+  return sampled;
+}
+
+/** Test seam: clears the memoized per-session decision. */
+export function resetPerfSampling(): void {
+  sampled = null;
+}

--- a/src/shell/smokeBoot.tsx
+++ b/src/shell/smokeBoot.tsx
@@ -1,5 +1,4 @@
 import { createRoot } from 'react-dom/client';
-import { Analytics } from '@vercel/analytics/react';
 import App from '@/App';
 import { ErrorBoundary } from '@/shell/ErrorBoundary';
 import { SmokeReporter } from '@/shell/SmokeReporter';
@@ -146,7 +145,6 @@ export function runSmokeBoot(): void {
         <App />
         <SmokeReporter />
       </LocaleProvider>
-      <Analytics />
     </ErrorBoundary>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,38 @@ import { contentRoutesPlugin } from './scripts/vite-plugin-content-routes';
 import { mediapipeAssetsPlugin } from './scripts/vite-plugin-mediapipe-assets';
 import { minifyJsonAssets } from './scripts/vite-plugin-minify-json-assets';
 
+// The prerendered content pages, mirroring the rewrites in vercel.json. They are
+// standalone static HTML, reachable from search rather than from inside the app,
+// so they are deliberately kept out of the precache: bundling all 85 of them into
+// every install put 85 requests on each cold load and 12 more on each deploy that
+// touched content. Being out of the precache means navigation to one has to be
+// denied the SPA fallback, or the service worker answers it with the app shell.
+const CONTENT_LOCALES = 'cs|de|es|fr|ko|nb|nl|pl|pt-BR|sv|uk|zh-CN';
+const CONTENT_SLUGS = [
+  'what-is-gridfinity',
+  'guide',
+  'privacy',
+  'terms',
+  'gridfinity-generator',
+  'gridfinity-bin-generator',
+  'gridfinity-baseplate-generator',
+  'gridfinity-calculator',
+  'gridfinity-sizes',
+  'gridfinity-tool-drawer',
+  'gridfinity-kitchen-drawer',
+  'gridfinity-software',
+  'gridfinity-cutout-generator',
+].join('|');
+// Two anchorings of one route set. A workbox urlPattern must be a RegExp value,
+// never a closure: vite-plugin-pwa serializes the service worker by stringifying
+// functions, so an identifier referenced from inside one resolves to nothing at
+// runtime and every matching navigation throws.
+const CONTENT_ROUTE_SOURCE = `/(?:(?:${CONTENT_LOCALES})/)?(?:${CONTENT_SLUGS})(?:[/?#]|$)`;
+// NavigationRoute tests its denylist against the pathname, so this one anchors.
+const CONTENT_ROUTE = new RegExp(`^${CONTENT_ROUTE_SOURCE}`);
+// RegExpRoute tests against the full href, where a leading ^ could never match.
+const CONTENT_ROUTE_HREF = new RegExp(CONTENT_ROUTE_SOURCE);
+
 // https://vite.dev/config/
 export default defineConfig({
   server: {
@@ -85,7 +117,10 @@ export default defineConfig({
         ],
       },
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        // html is absent by design: only the app shell is precached, and the
+        // prerendered content pages are runtime-cached on first visit (see
+        // CONTENT_ROUTE above and the 'content-pages' rule below).
+        globPatterns: ['**/*.{js,css,ico,png,svg,woff2}', 'index.html'],
         // Exclude manifest icons from glob - they're auto-added via manifest.icons
         // This prevents duplicate precache entries
         globIgnores: [
@@ -130,13 +165,28 @@ export default defineConfig({
           /^\/api\//,
           /^\/sitemap\.xml$/,
           /^\/robots\.txt$/,
-          /^\/what-is-gridfinity(?:\/|$)/,
-          /^\/guide(?:\/|$)/,
-          /^\/privacy(?:\/|$)/,
-          /^\/terms(?:\/|$)/,
+          CONTENT_ROUTE,
           /^\/storage-bridge\.html$/,
         ],
         runtimeCaching: [
+          {
+            // The prerendered content pages, cached on first visit rather than
+            // precached for everyone. NetworkFirst because they are SEO surfaces
+            // whose copy is edited far more often than the app shell, and a stale
+            // one served from CacheFirst would outlive the deploy that fixed it.
+            urlPattern: CONTENT_ROUTE_HREF,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'content-pages',
+              expiration: {
+                maxEntries: 20,
+                maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
+              },
+              cacheableResponse: {
+                statuses: [200],
+              },
+            },
+          },
           {
             // Cache shared layout API responses for offline viewing
             urlPattern: /\/api\/share\/[a-zA-Z0-9]+$/,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,30 @@ const CONTENT_ROUTE = new RegExp(`^${CONTENT_ROUTE_SOURCE}`);
 // RegExpRoute tests against the full href, where a leading ^ could never match.
 const CONTENT_ROUTE_HREF = new RegExp(CONTENT_ROUTE_SOURCE);
 
+// Chunks reachable from the entry by static import, i.e. the ones the app needs
+// to boot. Collected from the bundle graph so the precache can hold the boot
+// graph and nothing else: precaching every emitted chunk downloads all ~190 of
+// them on install, including the designer, community and baseplate code that a
+// given visitor may never open, which is the code splitting paid for twice.
+const eagerChunks = new Set<string>();
+
+const collectEagerChunks = (): PluginOption => ({
+  name: 'collect-eager-chunks',
+  generateBundle(_options, bundle) {
+    eagerChunks.clear();
+    const walk = (fileName: string): void => {
+      if (eagerChunks.has(fileName)) return;
+      const chunk = bundle[fileName];
+      if (!chunk || chunk.type !== 'chunk') return;
+      eagerChunks.add(fileName);
+      for (const imported of chunk.imports) walk(imported);
+    };
+    for (const chunk of Object.values(bundle)) {
+      if (chunk.type === 'chunk' && chunk.isEntry) walk(chunk.fileName);
+    }
+  },
+});
+
 // https://vite.dev/config/
 export default defineConfig({
   server: {
@@ -82,6 +106,7 @@ export default defineConfig({
     contentRoutesPlugin(),
     mediapipeAssetsPlugin(),
     minifyJsonAssets(),
+    collectEagerChunks(),
     VitePWA({
       // 'prompt' so the smoke gate (src/shared/pwa/smokeGate.ts) controls activation.
       // With 'autoUpdate' the new SW would auto-skip-waiting on install, defeating the gate.
@@ -144,6 +169,36 @@ export default defineConfig({
           // The MediaPipe JS chunk (~130KB) is only used by the /scan phone route.
           // Don't precache it for every (desktop) user; it lazy-loads on first scan.
           'assets/vision_bundle-*.js',
+          // Social cards. Only ever requested by a link unfurler reading the meta
+          // tags, never by a browser rendering the app, so shipping 1.5 MB of them
+          // to every install buys nothing.
+          'og/**',
+          'og-image.png',
+          'og-image.svg',
+          // Imagery and styles belonging to the prerendered content pages, which
+          // are themselves no longer precached. kofi-cup.png stays: the supporters
+          // panel and the export prompt render it inside the app.
+          'images/landing/**',
+          'images/serp/**',
+          'content*.css',
+          'calculator.js',
+          // Draco decoder, fetched by GlbViewer only when a GLB preview mounts.
+          // Same reasoning as the MediaPipe segmenter above.
+          'draco/**',
+        ],
+        // Hold the boot graph, drop the rest. globPatterns cannot express "only
+        // the chunks the entry statically imports" because the hashed names are
+        // not known until the bundle exists, so the filtering happens here, against
+        // the graph collected in generateBundle. A lazy chunk left out is fetched
+        // and runtime-cached the first time its route is opened; the tradeoff is
+        // that a route never visited online is not available offline.
+        manifestTransforms: [
+          (entries) => {
+            const manifest = entries.filter(
+              (entry) => !/^assets\/.*\.js$/.test(entry.url) || eagerChunks.has(entry.url)
+            );
+            return { manifest, warnings: [] };
+          },
         ],
         // Prefix all cache names to prevent conflicts
         cacheId: 'gridfinity-v1',
@@ -180,6 +235,26 @@ export default defineConfig({
               cacheName: 'content-pages',
               expiration: {
                 maxEntries: 20,
+                maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
+              },
+              cacheableResponse: {
+                statuses: [200],
+              },
+            },
+          },
+          {
+            // Lazy route chunks, which the precache no longer carries. Cached on
+            // first use so a route stays available offline once it has been opened.
+            // CacheFirst is safe for the same reason it is on .wasm below: the
+            // filenames are content-hashed, so a new build is a new URL and a stale
+            // copy is unreachable rather than wrong. maxEntries is generous because
+            // the whole point is that a given visitor only ever pulls their subset.
+            urlPattern: /\/assets\/.*\.js$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'lazy-chunks',
+              expiration: {
+                maxEntries: 120,
                 maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
               },
               cacheableResponse: {


### PR DESCRIPTION
## Why

Vercel spend was pacing at ~\$160/month. \$0 billed in May and June, \$32.49 in July, \$41.74 in the first 8 processed days of August.

Raw quantities from `/v1/billing/charges` (`ConsumedQuantity`, which the CLI hides), Aug 1-8:

| Line | Quantity | Cost |
|---|---|---|
| Edge Requests | 9,575,908 billable | \$19.28 |
| Build CPU Minutes | 3,952 | \$13.83 |
| Web Analytics Events | 44,424 | \$1.33 |

At ~1k DAU that is ~200 edge requests per app pageview.

**It is not bot traffic.** Region spread is organic (Frankfurt/DC/SF/Cleveland/Stockholm/Sydney, no concentration); Fast Data Transfer scaled 2.03x alongside requests, so these are real bytes to real devices rather than cheap 304s; and the SEO content pages carry zero JavaScript, so crawlers cannot trigger the app's asset graph.

The driver is the service worker precache. Workbox appends `__WB_REVISION__` to revisioned entries, which guarantees a cache miss, so those are re-downloaded from the network on **every** SW install — and a SW installs on every deploy, ~21 times a day.

## What changed

**Forced network fetches per SW install: 123 → 8.** Precache overall: 323 entries / 14.5 MB → 121 / 3.7 MB.

- **Release-merge builds skipped.** A release-please merge changes only the version, changelog and manifest, but `package.json` is in the ignore script's watch list, so each one triggered a full 3-4 min build. 103 of 246 commits on `main` since Aug 1. Guarded on both the commit subject and an exact release-triple file set, so a genuine dependency bump still builds.
- **Prerendered content pages out of the precache.** All 85, in 12 locales, were downloaded before the app rendered. They are SEO surfaces reached from search, not from inside the app. Still available offline after a first visit via a NetworkFirst route.
- **Precache holds the boot graph only.** Was every emitted chunk (~190); now the ~100 the entry statically imports. Also drops 1.5 MB of Open Graph cards (only ever fetched by link unfurlers), landing/SERP imagery, `content.css`, `calculator.js`, and the Draco decoder. Lazy chunks are runtime-cached CacheFirst.
- **`@vercel/analytics` removed.** PostHog already captures pageviews.
- **Generation diagnostics sampled at 10%/session.** `generation_cache_stats` and `generation_kernel_perf` fire once per geometry generation and were ~38% of PostHog volume. Both carry `sample_rate` so existing aggregates can be scaled back up.

## Tradeoff

A route never opened online is no longer available offline. Routes opened once online stay cached.

## Verification

- Full suite: 21,519 passing, typecheck clean, lint 0 errors
- `vercel-ignore.sh` exercised against real git repos in both directions, including the shallow-clone case where a failed diff must not read as "release-only"
- Precache measured out of the built `sw.js` before and after

Post-merge the daily `ConsumedQuantity` for Edge Requests should fall from ~1.2M/day toward ~400k/day. If it does not, the model is wrong and the next target is the 99-chunk eager boot graph.

## Known, not addressed here

- `three-render` (1.16 MB) and `liveblocks` (244 KB) are in the eager modulepreload list despite the chunking config describing both as lazy. ~1.4 MB on every first paint.
- size-limit is 72.85 kB over the "Total JS" budget. Verified identical on `main`; pre-existing.