### PR TITLE
perf(bundle): stop preloading the 3D stack and Liveblocks on first paint

### DIFF
--- a/src/shared/sync/SyncSessionMount.tsx
+++ b/src/shared/sync/SyncSessionMount.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { layoutAdapter } from '@/core/sync/adapters/layoutAdapter';
 import { designAdapter } from '@/features/bin-designer';
-import { baseplateAdapter } from '@/features/baseplate';
+import { baseplateAdapter } from '@/features/baseplate/sync/baseplateAdapter';
 import { runClaim, type AccountMismatchChoice } from '@/core/sync/claim';
 import { start, stop } from '@/core/sync/engine';
 import { useSessionLifecycle, useSessionStore } from '@/core/sync/session/useSession';

--- a/src/shared/sync/useDeleteAccountFlow.tsx
+++ b/src/shared/sync/useDeleteAccountFlow.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { layoutAdapter } from '@/core/sync/adapters/layoutAdapter';
 import { designAdapter } from '@/features/bin-designer';
-import { baseplateAdapter } from '@/features/baseplate';
+import { baseplateAdapter } from '@/features/baseplate/sync/baseplateAdapter';
 import { useSessionStore } from '@/core/sync/session/useSession';
 import {
   runDeleteAccount,

--- a/src/shared/sync/useSignOutFlow.tsx
+++ b/src/shared/sync/useSignOutFlow.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useState } from 'react';
 import { layoutAdapter } from '@/core/sync/adapters/layoutAdapter';
-import { designAdapter } from '@/features/bin-designer';
-import { baseplateAdapter } from '@/features/baseplate';
+// Deep imports, not the feature barrels. This module is statically reachable from
+// the entry (App → Sidebar → UserDock), so pulling either barrel drags its whole
+// feature onto first paint — the baseplate barrel re-exports BaseplatePage and the
+// thumbnail helper, which is how three, @react-three/fiber and drei (~1.2 MB) ended
+// up eagerly preloaded. Same reasoning as the Liveblocks note in shared/hooks/index.ts.
+import { designAdapter } from '@/features/bin-designer/sync/designAdapter';
+import { baseplateAdapter } from '@/features/baseplate/sync/baseplateAdapter';
 import { useSessionStore } from '@/core/sync/session/useSession';
 import { runSignOut, type KeepLocalPromptResult } from '@/core/sync/signOut';
 import { SignOutDialog } from '@/core/sync/dialogs/SignOutDialog';

--- a/src/shell/Modals/HelpModal/helpEntryAggregator.ts
+++ b/src/shell/Modals/HelpModal/helpEntryAggregator.ts
@@ -17,7 +17,7 @@ import { helpEntries as gridEditorHelpEntries } from '@/features/grid-editor';
 import { helpEntries as layersHelpEntries } from '@/features/layers';
 import { helpEntries as categoriesHelpEntries } from '@/features/categories';
 import { helpEntries as binDesignerHelpEntries } from '@/features/bin-designer';
-import { helpEntries as baseplateHelpEntries } from '@/features/baseplate';
+import { helpEntries as baseplateHelpEntries } from '@/features/baseplate/helpEntries';
 import { helpEntries as shellHelpEntries } from './shellHelpEntries';
 import { shortcutCatalogToHelpEntries } from './shellShortcuts';
 import type { HelpEntry, HelpRoute } from '@/shared/help/helpEntry';

--- a/src/shell/Modals/HelpModal/helpEntryAggregator.ts
+++ b/src/shell/Modals/HelpModal/helpEntryAggregator.ts
@@ -3,7 +3,11 @@
  * shortcut catalog into a single flat list consumed by the Help modal search.
  *
  * Adding new entries: export `helpEntries: HelpEntry[]` from a feature's
- * barrel (`src/features/<name>/index.ts`), then add the import here.
+ * barrel (`src/features/<name>/index.ts`), then add the import here. Import the
+ * defining module instead when the barrel re-exports anything heavy: this file is
+ * statically reachable from the entry, so a barrel that reaches a 3D preview or a
+ * network client puts it on first paint. That is why baseplate is imported from
+ * `helpEntries` directly rather than from `@/features/baseplate`.
  *
  * Mode awareness: entries with `routes` are hidden on non-matching modes
  * (the destination surface usually isn't mounted on those modes anyway,

--- a/src/shell/layoutExport/useLayoutExport.test.ts
+++ b/src/shell/layoutExport/useLayoutExport.test.ts
@@ -32,7 +32,9 @@ vi.mock('@/shared/analytics/posthog', async (orig) => ({
   ...(await orig<Record<string, unknown>>()),
   trackEvent: h.trackEvent,
 }));
-vi.mock('@/features/baseplate', async (orig) => ({
+// Mock the defining module, not the feature barrel: useLayoutExport deep-imports
+// it so the barrel does not drag the 3D stack onto first paint.
+vi.mock('@/features/baseplate/utils/buildBaseplateExportPieces', async (orig) => ({
   ...(await orig<Record<string, unknown>>()),
   buildBaseplateExportPieces: h.buildBaseplateExportPieces,
 }));
@@ -42,7 +44,7 @@ vi.mock('@/features/bin-designer', async (orig) => ({
 }));
 
 import { useLayoutExport } from './useLayoutExport';
-import { BaseplateBedOverageError } from '@/features/baseplate';
+import { BaseplateBedOverageError } from '@/features/baseplate/utils/buildBaseplateExportPieces';
 import { useToastStore } from '@/core/store/toast';
 
 function design(id: string, name: string, params: Partial<typeof DEFAULT_BIN_PARAMS> = {}) {

--- a/src/shell/layoutExport/useLayoutExport.ts
+++ b/src/shell/layoutExport/useLayoutExport.ts
@@ -35,7 +35,10 @@ import { triggerDownload } from '@/shared/generation/exportUtils';
 import { packageFilesAsZip } from '@/shared/generation/zipExport';
 import type { ZipBinaryFile, ZipTextFile } from '@/shared/generation/zipExport';
 import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
-import { buildBaseplateExportPieces, BaseplateBedOverageError } from '@/features/baseplate';
+import {
+  buildBaseplateExportPieces,
+  BaseplateBedOverageError,
+} from '@/features/baseplate/utils/buildBaseplateExportPieces';
 import { loadDesign } from '@/features/bin-designer';
 import type { BinParams } from '@/features/bin-designer';
 // Deep import (not the barrel): the bin-designer barrel is eagerly loaded by App;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -447,8 +447,12 @@ export default defineConfig({
               priority: 90,
               test: /[\\/]node_modules[\\/](?:three[\\/]|@react-three[\\/]|three-stdlib[\\/]|troika-[^\\/]+[\\/]|bidi-js[\\/]|webgl-sdf-generator[\\/]|maath[\\/]|meshline[\\/]|camera-controls[\\/]|stats\.js[\\/]|stats-gl[\\/]|suspend-react[\\/]|its-fine[\\/]|react-use-measure[\\/]|tunnel-rat[\\/]|@use-gesture[\\/]|potpack[\\/])/,
             },
-            // Liveblocks — only loaded when collaborative editing is active (Labs).
-            { name: 'liveblocks', priority: 80, test: /[\\/]node_modules[\\/]@liveblocks[\\/]/ },
+            // Liveblocks deliberately has NO group. Pinning it to a named chunk made
+            // that chunk a static import of the entry, so index.html modulepreloaded
+            // 240 kB of collaboration client on every first paint even though nothing
+            // eager imports @liveblocks — only the lazy CollabProvider subtree does.
+            // Ungrouped, rolldown folds it into the lazy chunk that needs it, with no
+            // duplication (total JS is unchanged either way).
           ],
         },
         // Note: posthog-js is dynamically imported in src/shared/analytics/posthog.ts


### PR DESCRIPTION
Follow-on to #3376, which noted both of these as known-but-unaddressed.

## Result

| | before | after |
|---|---|---|
| Eager modulepreload bytes | 2.96 MB | **1.35 MB** |
| Precache | 121 entries / 3.7 MB | **120 / 2.1 MB** |
| Total JS emitted | 9.72 MB | 9.72 MB (unchanged) |

Neither `three-render` (1.16 MB) nor `liveblocks` (240 kB) is in the eager graph any more. They were eager for two unrelated reasons.

## three / @react-three/fiber / drei — a barrel leak

Traced by walking the static module graph from the entry:

```
main.tsx -> App.tsx -> Sidebar.tsx -> UserDock.tsx
  -> shared/sync/useSignOutFlow.tsx
  -> features/baseplate/index.ts          <- barrel
  -> BaseplatePage / utils/thumbnail.ts -> three
```

Four modules outside the feature import that barrel, and none of them wants anything heavy — they want `baseplateAdapter`, `helpEntries`, or `buildBaseplateExportPieces`. But the barrel also re-exports `BaseplatePage` and `useBaseplateAutoSave`, which reach `BaseplatePreview` and the thumbnail helper, so each importer dragged the whole 3D stack into the shell. Fixing only the first one just moved the chain to `useDeleteAccountFlow`, so all four now import the defining module directly.

This is the same treatment `src/shared/hooks/index.ts` already documents for the Liveblocks client ("deep-import them there").

`shared -> feature` edges are explicitly unrestricted in the eslint boundaries config, and `check-module-boundaries.sh` only inspects files under `src/features/`, so these deep imports are legal. Boundary check passes.

## Liveblocks — the chunk group was the cause

Nothing eager imports `@liveblocks`; a module-level walk from the entry finds no path. It was eager because pinning it to a named `advancedChunks` group made that chunk a **static import of the entry chunk**, and Vite modulepreloads those. Removing the group lets rolldown fold it into the lazy chunk that actually needs it. Total JS is identical either way, so nothing is duplicated.

## Test plan

- Full suite: 21,519 passing, typecheck clean, lint 0 errors, module boundaries clean
- `useLayoutExport.test.ts` mocked the barrel and so stopped intercepting once the code deep-imported; it now mocks the module the code imports. Caught by the suite, not by inspection.
- Verified in the built output: `three` and `liveblocks` absent from `index.html` modulepreload, and absent from the precache manifest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop preloading the 3D stack and Liveblocks on first paint by removing a baseplate barrel leak and unpinning the `@liveblocks` chunk. Eager modulepreload drops from 2.96 MB to 1.35 MB, and precache from 121/3.7 MB to 120/2.1 MB; total JS stays 9.72 MB.

- **Refactors**
  - Replace feature barrel imports with deep imports for `baseplateAdapter`, `designAdapter`, `helpEntries`, and `buildBaseplateExportPieces` to keep `three`/`@react-three/fiber`/`drei` out of the eager graph.
  - Remove the named `liveblocks` advancedChunks group in `vite.config.ts` so `@liveblocks` stays in the lazy chunk that uses it.
  - Update `useLayoutExport` test to mock the deep-imported module instead of the feature barrel.
  - Document the barrel vs deep-import rule in the Help modal aggregator to prevent eager 3D loads.

<sup>Written for commit bb0a382d676b537584dda4ef8c1b656e4127b08e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

