### PR TITLE
perf(generation): let wall-patterned bins resume the booleaned body

### DIFF
--- a/src/features/generation/worker/generators/binBodyResumeCache.test.ts
+++ b/src/features/generation/worker/generators/binBodyResumeCache.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Resume-cache coverage for wall-patterned bins.
+ *
+ * The post-boolean `bin-body` cache lets a re-generation skip the boolean stage
+ * when the shell and every feature's geometry key are unchanged. Patterned bins
+ * used to be excluded from it wholesale (`featuresStage` nulled `featuresKey`
+ * whenever a wall pattern was on), which is backwards: honeycomb-plus-cutout
+ * bins are the slowest bins to boolean, so they are exactly the ones that most
+ * need to skip it.
+ *
+ * They now ride in `featuresKey` via the per-wall identity the pattern cache
+ * already trusts. The risk that buys is a stale body, so the misses matter more
+ * than the hits here: every parameter that changes pattern geometry must still
+ * miss.
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { DEFAULT_BIN_PARAMS, DISABLED_WALL_CUTOUT } from '@/shared/constants/bin';
+import { DEFAULT_FLOOR_PATTERN_CONFIG } from '@/shared/types/bin';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { clearAllCaches, getAllShapeCacheStats, resetAllShapeCacheStats } from './shapeCache';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30_000);
+
+beforeEach(() => {
+  clearAllCaches();
+  resetAllShapeCacheStats();
+});
+
+function binBodyStats() {
+  const stats = getAllShapeCacheStats().find((s) => s.name === 'bin-body');
+  return stats ?? { name: 'bin-body', hits: 0, misses: 0, evictions: 0, size: 0, maxSize: 0 };
+}
+
+const fourCutouts = (width: number) => ({
+  ...DEFAULT_BIN_PARAMS.walls,
+  enabled: true,
+  front: { ...DISABLED_WALL_CUTOUT, enabled: true, width, depth: 50 },
+  back: { ...DISABLED_WALL_CUTOUT, enabled: true, width, depth: 50 },
+  left: { ...DISABLED_WALL_CUTOUT, enabled: true, width, depth: 50 },
+  right: { ...DISABLED_WALL_CUTOUT, enabled: true, width, depth: 50 },
+  interior: DISABLED_WALL_CUTOUT,
+});
+
+const HONEYCOMB = {
+  ...DEFAULT_BIN_PARAMS,
+  width: 2,
+  depth: 2,
+  height: 4,
+  wallPattern: { enabled: true, pattern: 'honeycomb' as const },
+  walls: fourCutouts(70),
+};
+
+describe('bin-body resume cache with wall patterns', () => {
+  it('resumes the booleaned body when a patterned bin is regenerated unchanged', () => {
+    const generateBin = getGenerateBin();
+
+    const first = generateBin(HONEYCOMB);
+    resetAllShapeCacheStats();
+    const second = generateBin(HONEYCOMB);
+
+    expect(binBodyStats().hits, 'identical re-gen of a patterned bin must resume the body').toBe(1);
+    expect(second.triangleCount).toBe(first.triangleCount);
+  }, 120_000);
+
+  it('rebuilds rather than resuming when a cutout width changes', () => {
+    const generateBin = getGenerateBin();
+
+    const first = generateBin(HONEYCOMB);
+    resetAllShapeCacheStats();
+    const nudged = generateBin({ ...HONEYCOMB, walls: fourCutouts(60) });
+
+    const stats = binBodyStats();
+    expect(stats.hits, 'a wider cutout is different geometry and must not resume').toBe(0);
+    expect(stats.misses).toBe(1);
+    expect(nudged.triangleCount).not.toBe(first.triangleCount);
+  }, 120_000);
+
+  it('rebuilds rather than resuming when the pattern type changes', () => {
+    const generateBin = getGenerateBin();
+
+    generateBin(HONEYCOMB);
+    resetAllShapeCacheStats();
+    generateBin({ ...HONEYCOMB, wallPattern: { enabled: true, pattern: 'diamond' as const } });
+
+    expect(binBodyStats().hits, 'a different pattern must not resume the honeycomb body').toBe(0);
+  }, 120_000);
+
+  it('rebuilds rather than resuming when the pattern is switched off', () => {
+    const generateBin = getGenerateBin();
+
+    const patterned = generateBin(HONEYCOMB);
+    resetAllShapeCacheStats();
+    const plain = generateBin({
+      ...HONEYCOMB,
+      wallPattern: { enabled: false, pattern: 'honeycomb' as const },
+    });
+
+    expect(binBodyStats().hits, 'an unpatterned bin must not resume a patterned body').toBe(0);
+    expect(plain.triangleCount).not.toBe(patterned.triangleCount);
+  }, 120_000);
+
+  it('leaves the resume cache untouched for floor patterns', () => {
+    // The floor pattern's shapes also carve the deferred socket, so a resume hit
+    // would pair a holed body with an uncut socket. It stays opted out.
+    const generateBin = getGenerateBin();
+    const withFloor = {
+      ...HONEYCOMB,
+      wallPattern: { enabled: false, pattern: 'honeycomb' as const },
+      floorPattern: { ...DEFAULT_FLOOR_PATTERN_CONFIG, enabled: true },
+    };
+
+    generateBin(withFloor);
+    resetAllShapeCacheStats();
+    generateBin(withFloor);
+
+    const stats = binBodyStats();
+    expect(stats.hits + stats.misses, 'floor-patterned bins must not consult the cache').toBe(0);
+  }, 120_000);
+});

--- a/src/features/generation/worker/generators/binResumeCache.test.ts
+++ b/src/features/generation/worker/generators/binResumeCache.test.ts
@@ -49,10 +49,14 @@ describe('post-boolean body resume cache (#2333)', () => {
     expect(binBodyStats()).toEqual({ hits: 0, misses: 2 });
   }, 60_000);
 
-  it('disables the resume cache for wall-pattern bins (featuresKey null)', () => {
+  // Stamp wall patterns DO resume now — they report a per-wall identity that
+  // rides in `featuresKey`. See `binBodyResumeCache.test.ts`. The wrapped-lattice
+  // (kumiko) pipeline reports no such identity, so it stays opted out; without
+  // that a lattice change would resume a stale body.
+  it('disables the resume cache for kumiko wrapped-lattice bins (featuresKey null)', () => {
     const generateBin = getGenerateBin();
     const params = buildParams({
-      wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true },
+      wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true, pattern: 'asanoha' },
     });
 
     clearAllCaches();

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -105,17 +105,37 @@ export const featuresStage: PipelineStage = {
     // only bind clipping to the outermost edge per cardinal — non-outermost
     // step walls get pure pattern.
     const wallPatternEnabled = params.wallPattern.enabled;
+    let wallPatternKeys: string[] = [];
+    let unkeyedPatternCuts = false;
     if (wallPatternEnabled) {
       // Stamp patterns and kumiko wrapped-lattice patterns are mutually
       // exclusive per pattern type; each builder no-ops for the other's types.
-      const patternShapes = buildWallPatterns(ctx);
-      targets.patternCutTargets.push(...patternShapes);
+      const patterns = buildWallPatterns(ctx);
+      // The two arrays are appended in lockstep; a mismatch would mean a shape
+      // whose identity is missing from the resume key, which is the one failure
+      // that surfaces as wrong geometry rather than a slow rebuild.
+      if (patterns.keys.length !== patterns.shapes.length) {
+        throw new Error('wall pattern targets and keys are misaligned');
+      }
+      targets.patternCutTargets.push(...patterns.shapes);
+      wallPatternKeys = patterns.keys;
       const kumikoShapes = buildKumikoWallPatterns(ctx);
       targets.patternCutTargets.push(...kumikoShapes);
       // Divider walls (#2811) carry the same pattern when opted in. Both
       // pipelines are handled inside, so this is one call for either type.
-      targets.patternCutTargets.push(...buildDividerPatterns(ctx));
+      const dividerShapes = buildDividerPatterns(ctx);
+      targets.patternCutTargets.push(...dividerShapes);
+      // Neither builder reports the identity of what it emitted (both compute
+      // it internally, the divider one inside a panel-factory closure), so a
+      // bin carrying either keeps the resume cache off.
+      unkeyedPatternCuts = kumikoShapes.length > 0 || dividerShapes.length > 0;
     }
+
+    // The floor pattern stays unkeyed regardless: its shapes also carve the
+    // deferred socket, and a resume hit would be worse than stale — the cached
+    // body would come back with holes while the freshly built socket flowed
+    // through uncut.
+    const resumable = !unkeyedPatternCuts && floorPatternShapes.length === 0;
 
     return {
       ...ctx,
@@ -123,12 +143,16 @@ export const featuresStage: PipelineStage = {
       cutTargets: targets.cutTargets,
       patternCutTargets: targets.patternCutTargets,
       deferredCutTargets: floorPatternShapes,
-      // Pattern cuts aren't keyed through feature builders, so their geometry
-      // isn't in `featuresKey` — disable the resume cache rather than risk a
-      // stale body when only the pattern changes. For the floor pattern a
-      // resume hit would be worse than stale: the cached body would come back
-      // with holes while the freshly built socket flowed through uncut.
-      featuresKey: wallPatternEnabled || floorPatternShapes.length > 0 ? null : targets.featuresKey,
+      // Wall-pattern cuts ride in `featuresKey` via the same per-wall identity
+      // the pattern cache trusts, so a patterned bin can resume the post-boolean
+      // body like any other. That matters most here: the honeycomb-plus-cutouts
+      // bins are both the slowest to boolean and, until now, the only ones
+      // barred from the cache that exists to skip it.
+      featuresKey: resumable
+        ? wallPatternKeys.length > 0
+          ? JSON.stringify(['wallpattern-v1', targets.featuresKey, wallPatternKeys])
+          : targets.featuresKey
+        : null,
     };
   },
 };

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -462,19 +462,35 @@ export function computeWallClips(
 }
 
 /**
+ * Wall pattern cut targets plus the geometry identity of each one.
+ *
+ * `keys[i]` is the identity of `shapes[i]` — the same `clippedKey` the per-wall
+ * cache uses to decide two results are interchangeable. The resume cache in
+ * `booleanStage` keys on these rather than on a separately-derived digest of
+ * the pattern params: a second derivation is a second thing to keep in sync,
+ * and the failure mode when it drifts is a stale body, not a crash. Anything
+ * incomplete here would already be serving the wrong shape from the wall cache.
+ */
+export interface WallPatternTargets {
+  readonly shapes: Shape3D[];
+  readonly keys: string[];
+}
+
+/**
  * Build wall pattern shapes for all walls with per-wall caching
  * and optional cutout clipping.
  *
  * Returns shapes to be pushed into patternCutTargets. Each shape
  * is a clone owned by the caller (cache owns the originals).
  */
-export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
+export function buildWallPatterns(ctx: PipelineContext): WallPatternTargets {
   const { params, dimensions: dim, signal, originToTag, perfCollector } = ctx;
   const { innerW, innerD, interiorHeight, innerOffsetX, innerOffsetY } = dim;
   const patternCutTargets: Shape3D[] = [];
+  const patternCutKeys: string[] = [];
 
   const patternResult = getPatternDescriptors(params, innerW, innerD, interiorHeight, dim.hasLip);
-  if (!patternResult) return patternCutTargets;
+  if (!patternResult) return { shapes: patternCutTargets, keys: patternCutKeys };
 
   // patternResult.calculator is a StampPatternCalculator: getPatternDescriptors
   // filters motif/wrapped-lattice patterns out of this pipeline (they build via
@@ -575,11 +591,14 @@ export function buildWallPatterns(ctx: PipelineContext): Shape3D[] {
         old.delete();
       }
       collectOrigins(shape, FeatureTag.WALL_PATTERN, originToTag);
+      // Pushed together so the two arrays cannot fall out of alignment; the
+      // caller asserts the lengths match before trusting the keys.
       patternCutTargets.push(shape);
+      patternCutKeys.push(clippedKey);
     }
   }
 
   if (perfCollector) perfCollector.setPatternCutToolCount(patternCutTargets.length);
 
-  return patternCutTargets;
+  return { shapes: patternCutTargets, keys: patternCutKeys };
 }


### PR DESCRIPTION
## Why

`featuresStage` nulled `featuresKey` whenever a wall pattern was on, which disabled the post-boolean `bin-body` resume cache for **exactly the bins that most need it**. Honeycomb-plus-cutout bins are the slowest in the app to boolean, and they were the only ones barred from the cache that exists to skip the boolean stage. Editing anything on one re-ran the whole pass.

## Measured

6×4×6, 96 compartments, honeycomb, 4 wall cutouts:

| | before | after |
|---|---:|---:|
| cold build | 16,847ms | 16,712ms |
| re-generation | **4,016ms** | **437ms** |
| re-generation (2nd) | 4,014ms | 444ms |

**9.2× on re-generation.** Cold build is untouched, as expected: this changes only whether the boolean stage can be skipped, never how fast it runs.

## Production context

From 166,887 `generation_kernel_perf` events over 30 days, the boolean stage is **p50 101ms, p90 1,932ms, p99 16,132ms**. The median generation is healthy; the problem is entirely the tail.

That tail is geometry, not hardware: desktop (165,014 samples, the fastest class) carries an **18,458ms p99**. And it is not niche: **9,388 generations exceeded 4s, across 844 distinct users and 1,546 sessions.** The cold measurement above (16.7s) lands on the production p99, which is what identifies this scenario as the tail.

## How the key is derived

The opt-out existed because pattern-cut geometry had no identity in `featuresKey`. It does now: `buildWallPatterns` returns the per-wall `clippedKey` alongside each shape.

That specific key matters. It is the same identity the per-wall pattern cache already trusts to decide two results are interchangeable, so this inherits an existing assumption rather than introducing a new one — if `clippedKey` were incomplete, the per-wall cache would already be serving wrong shapes today. Deriving a second digest from the pattern params would be a second thing to keep in sync, and the failure mode when two such derivations drift is a stale body, not a crash.

Shapes and keys are appended in lockstep and the caller asserts the lengths match, so a future edit that emits a shape without a key fails loudly instead of silently widening the cache.

## Still opted out

- **Kumiko wrapped-lattice** and **divider patterns** — neither reports the identity of what it emitted (the divider one computes its key inside a panel-factory closure).
- **Floor patterns** — on their own merits: those shapes also carve the deferred socket, so a resume hit would pair a holed body with an uncut socket.

## Tests

New `binBodyResumeCache.test.ts`. The misses matter more than the hits: every parameter that changes pattern geometry must still miss, because the failure this guards is a wrong STL that passes every watertightness check.

- resumes on identical re-generation (fails without the change: 0 hits)
- rebuilds on a cutout-width change (fails without the change)
- rebuilds on a pattern-type change
- rebuilds when the pattern is switched off
- floor-patterned bins never consult the cache

`binResumeCache.test.ts` had a test pinning the old limitation (`disables the resume cache for wall-pattern bins`). Retargeted to kumiko, which is genuinely still opted out, so the guard stays meaningful instead of being deleted.

## Verification

- `pnpm run typecheck` clean
- `pnpm quality` 0 errors (47 pre-existing warnings)
- `pnpm exec vitest run --project generators` — **273 files, 2,695 tests passed**, 4 skipped
- New tests verified non-vacuous by stashing the implementation and confirming they fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the post-boolean `bin-body` resume cache for wall-patterned bins by threading per-wall `clippedKey` into `featuresKey`. Re-generation of dense honeycomb bins drops from ~4.0s to ~0.44s; cold builds unchanged.

- New Features
  - `buildWallPatterns` now returns shapes plus per-wall `clippedKey`; `featuresStage` folds these into `featuresKey` so patterned bins can resume.
  - Still opted out: kumiko wrapped-lattice and divider patterns (no reported identity), and floor patterns (socket interaction).
  - Added tests to assert resume hits on identical re-gen and misses on any pattern geometry change; updated the prior opt-out test to target kumiko.

<sup>Written for commit 7a81019b81899ddf362bd1d129242d41a0f4242b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

