### PR TITLE
revert(analytics): restore @vercel/analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@mediapipe/tasks-vision": "0.10.35",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.7.0",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@react-three/fiber':
         specifier: ^9.7.0
         version: 9.7.0(@types/react@19.2.18)(immer@11.1.15)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(three@0.185.1)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.8)
       '@vercel/blob':
         specifier: ^2.6.1
         version: 2.6.1
@@ -2857,6 +2860,35 @@ packages:
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
       react: '>= 16.8.0'
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/blob@2.6.1':
     resolution: {integrity: sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==}
@@ -8308,6 +8340,10 @@ snapshots:
   '@use-gesture/react@10.3.1(react@19.2.8)':
     dependencies:
       '@use-gesture/core': 10.3.1
+      react: 19.2.8
+
+  '@vercel/analytics@2.0.1(react@19.2.8)':
+    optionalDependencies:
       react: 19.2.8
 
   '@vercel/blob@2.6.1':

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { Analytics } from '@vercel/analytics/react';
 import './index.css';
 import App from './App.tsx';
 import { ErrorBoundary } from '@/shell/ErrorBoundary';
@@ -152,6 +153,7 @@ if (isSmokeMode()) {
           <LocaleProvider initialLocale={initialLocale} onLocaleChange={handleLocaleChange}>
             {initError ? <InitErrorFallback error={initError} /> : <App />}
           </LocaleProvider>
+          <Analytics />
         </ErrorBoundary>
       );
     });

--- a/src/shell/smokeBoot.tsx
+++ b/src/shell/smokeBoot.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { Analytics } from '@vercel/analytics/react';
 import App from '@/App';
 import { ErrorBoundary } from '@/shell/ErrorBoundary';
 import { SmokeReporter } from '@/shell/SmokeReporter';
@@ -145,6 +146,7 @@ export function runSmokeBoot(): void {
         <App />
         <SmokeReporter />
       </LocaleProvider>
+      <Analytics />
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## Why

Removing `@vercel/analytics` was not an approved change. It rode along in #3376, a PR scoped by its title to edge requests and build minutes, as one bullet among six.

By that PR's own figures for Aug 1-8:

| Line | Cost | Share |
|---|---|---|
| Edge Requests | $19.28 | 55% |
| Build CPU Minutes | $13.83 | 40% |
| Web Analytics Events | $1.33 | 3.8% |

The removal accounted for under 4% of the spend the PR set out to cut. The other changes in #3376 stand on their own and are untouched here.

The stated justification was "PostHog already captures pageviews." That was not true at merge time. PostHog's free-tier event quota was exhausted on Aug 6, three days earlier, and product analytics have been dark since:

```
day        pageviews  visitors  all_events
2026-08-10         0         0         202   <- $exception only
2026-08-09         0         0         126
2026-08-08         0         0          64
2026-08-07         0         0         132
2026-08-06         0         0        2596   <- cutoff
2026-08-05       188       116       22752
2026-08-03      3318       860       92214
```

Only `$exception` still flows, because error tracking bills against a separate allowance. So the removal took away the one pageview source that would have survived the blackout, leaving no traffic visibility at all until the quota resets (~Aug 22, inferred from the identical Jul 18-21 blackout that recovered Jul 22 with no deploy).

## What changed

Restores the state before 51de39ec. `src/main.tsx` and `src/shell/smokeBoot.tsx` are byte-identical to their pre-removal versions; the dependency returns at the same `^2.0.1` range.

## Verification

- `src/main.tsx`, `src/shell/smokeBoot.tsx`: `diff` against `51de39ec^` is empty
- typecheck clean, eslint clean on both changed files
- Bundle cost measured against a clean `main` build: Total JS 2.01 MB gzipped either way, **+0.48 kB**

Vercel Analytics posts to `/_vercel/insights/*` and loads its script from the same origin, so the `script-src 'self'` / `connect-src 'self'` CSP in `vercel.json` already covers it. No config change needed.

## Note

`pnpm run size:check` fails locally on `main` and on this branch alike (Total JS +85.39 kB / +85.87 kB). That is a local artifact: Vite loads `.env.production.local`, which CI does not have. CI's size check passes on `main` and is expected to pass here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `@vercel/analytics` to bring back pageview tracking and maintain traffic visibility when PostHog is out of quota. Adds the `<Analytics />` component in app entry points with negligible bundle impact and no config changes.

- **Bug Fixes**
  - Re-add `@vercel/analytics@^2.0.1` and render `<Analytics />` in `src/main.tsx` and `src/shell/smokeBoot.tsx`.
  - No CSP updates needed; existing `script-src 'self'` and `connect-src 'self'` cover it.
  - Bundle size change: +0.48 kB gzipped.

<sup>Written for commit 4723a410dc8d8149e5f9df1e87c8b82b9d1f19ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

