### PR TITLE
feat(lid): finer click-rail coverage steps (#3401)

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -147,7 +147,12 @@ graph TB
   encloses items that poke up out of a short bin, e.g. toothpicks; 0 = the
   standard one-grid-unit lid), the top-surface picker and its sub-toggles
   (magnet pockets, lip-only stack top, separate baseplate), per-side
-  click-rail snaps with a coverage slider, and the floor-plate
+  click-rail snaps with a coverage slider (`LID_CLICK_RAIL_COVERAGE_OPTIONS`,
+  50-100% in 5% steps — **5 rather than the requested 10 because
+  `migrateClickRailCoverage` snaps every persisted value to the NEAREST listed
+  option, so dropping 75 would silently re-render every design saved at
+  three-quarter coverage as 70**; only 50/75/100 carry description copy, the
+  rest render bare like `gripCoverageOptions`), and the floor-plate
   thickness (`topThicknessMm`, 0.8–5mm — a thicker top for a stiffer, less
   translucent lid on large bins; 0.8 = the historical plate). Wall thickness and
   fit clearance stay locked-down constants in `lidConstants.ts` (a single

--- a/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
+++ b/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
@@ -83,6 +83,9 @@ function clearRevealGrip(grip: LidGripConfig): LidGripConfig {
   return grip.mode === 'reveal' ? { ...grip, mode: 'none' } : grip;
 }
 
+/** Coverage stops that carry their own copy; the rest render bare. */
+const DESCRIBED_RAIL_COVERAGES = new Set([50, 75, 100]);
+
 export function useLidSection() {
   const t = useTranslation();
   const {
@@ -160,11 +163,16 @@ export function useLidSection() {
   // hint when the user toggles magnets without a stack grid above).
   const binHasMagnets = isMagnetStyle(base.style);
 
+  // Only the three original stops carry copy. The intermediate steps (#3401)
+  // are self-explanatory percentages between them, and inventing a caption for
+  // each would put eight more strings into fourteen locales to say nothing.
   const railCoverageOptions: SnappingSliderOption[] = useMemo(
     () =>
       LID_CLICK_RAIL_COVERAGE_OPTIONS.map((value) => ({
         value,
-        description: t(`binDesigner.lid.clickRailCoverage.${value}`),
+        description: DESCRIBED_RAIL_COVERAGES.has(value)
+          ? t(`binDesigner.lid.clickRailCoverage.${value}`)
+          : '',
       })),
     [t]
   );

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -1178,6 +1178,27 @@ describe('migrateParams', () => {
     });
   });
 
+  it('keeps every previously-shippable coverage as an exact stop', () => {
+    // The stop list went from 50/75/100 to 5% steps (#3401). Because
+    // `migrateClickRailCoverage` snaps to the NEAREST option, dropping a value
+    // that designs were saved with would silently re-render them at a
+    // different coverage — a changed printed part with no notice. 75 is the
+    // one at risk, and it is why the step is 5 and not the requested 10.
+    for (const coverage of [50, 75, 100]) {
+      const result = migrateParams({
+        lid: { ...DEFAULT_BIN_PARAMS.lid, clickRailCoverage: coverage },
+      });
+      expect(result.lid.clickRailCoverage).toBe(coverage);
+    }
+  });
+
+  it('snaps an off-stop coverage to the nearest supported one', () => {
+    const result = migrateParams({
+      lid: { ...DEFAULT_BIN_PARAMS.lid, clickRailCoverage: 73 },
+    });
+    expect(result.lid.clickRailCoverage).toBe(75);
+  });
+
   it('backfills clickRailCoverage from defaults for legacy lid configs missing the field', () => {
     const result = migrateParams({
       lid: {

--- a/src/features/bin-designer/types/lid.test.ts
+++ b/src/features/bin-designer/types/lid.test.ts
@@ -18,6 +18,10 @@ import {
   LID_EXTRA_HEIGHT_MAX_MM,
   LID_EXTRA_HEIGHT_STEP_MM,
   LID_CORNER_RADIUS,
+  LID_CLICK_RAIL_COVERAGE_OPTIONS,
+  LID_CLICK_RAIL_COVERAGE_MIN,
+  LID_CLICK_RAIL_COVERAGE_MAX,
+  LID_CLICK_RAIL_COVERAGE_STEP,
   LID_MAGNET_LIP_CLEARANCE,
   LID_GRIP_SPAN_MIN_MM,
   LID_GRIP_SPAN_MAX_MM,
@@ -512,5 +516,31 @@ describe('lidGripRequestedHeightMm', () => {
 
   it('is zero for a lid with no relief', () => {
     expect(lidGripRequestedHeightMm({ mode: 'none', heightMm: 4 })).toBe(0);
+  });
+});
+
+describe('LID_CLICK_RAIL_COVERAGE_OPTIONS', () => {
+  it('runs 50 to 100 with no gaps', () => {
+    expect(LID_CLICK_RAIL_COVERAGE_OPTIONS[0]).toBe(LID_CLICK_RAIL_COVERAGE_MIN);
+    expect(LID_CLICK_RAIL_COVERAGE_OPTIONS.at(-1)).toBe(LID_CLICK_RAIL_COVERAGE_MAX);
+    for (let i = 1; i < LID_CLICK_RAIL_COVERAGE_OPTIONS.length; i++) {
+      expect(LID_CLICK_RAIL_COVERAGE_OPTIONS[i] - LID_CLICK_RAIL_COVERAGE_OPTIONS[i - 1]).toBe(
+        LID_CLICK_RAIL_COVERAGE_STEP
+      );
+    }
+  });
+
+  it('still contains the three stops designs were saved with', () => {
+    // Dropping any of these would make `migrateClickRailCoverage` snap saved
+    // designs onto a neighbour and quietly change a printed lid.
+    for (const legacy of [50, 75, 100]) {
+      expect(LID_CLICK_RAIL_COVERAGE_OPTIONS).toContain(legacy);
+    }
+  });
+
+  it('holds whole percentages only, so nothing lands between UI stops', () => {
+    for (const v of LID_CLICK_RAIL_COVERAGE_OPTIONS) {
+      expect(Number.isInteger(v)).toBe(true);
+    }
   });
 });

--- a/src/features/bin-designer/types/lid.ts
+++ b/src/features/bin-designer/types/lid.ts
@@ -136,7 +136,25 @@ export const LID_EXTRA_HEIGHT_STEP_MM = 1;
  * Lower values save filament; higher values give more grip surface.
  * 100% = full edge-to-edge rails.
  */
-export const LID_CLICK_RAIL_COVERAGE_OPTIONS: readonly number[] = [50, 75, 100] as const;
+export const LID_CLICK_RAIL_COVERAGE_MIN = 50;
+export const LID_CLICK_RAIL_COVERAGE_MAX = 100;
+/**
+ * 5% rather than the requested 10% (#3401) for one reason: `migrateClickRailCoverage`
+ * snaps every persisted value to the nearest listed option, so dropping 75 would
+ * silently re-render every design saved at three-quarter coverage as 70 — a real
+ * change to a printed part, with no notice. A 5% step is finer than asked for,
+ * costs nothing, and keeps 75 an exact stop.
+ */
+export const LID_CLICK_RAIL_COVERAGE_STEP = 5;
+
+export const LID_CLICK_RAIL_COVERAGE_OPTIONS: readonly number[] = Array.from(
+  {
+    length:
+      (LID_CLICK_RAIL_COVERAGE_MAX - LID_CLICK_RAIL_COVERAGE_MIN) / LID_CLICK_RAIL_COVERAGE_STEP +
+      1,
+  },
+  (_, i) => LID_CLICK_RAIL_COVERAGE_MIN + i * LID_CLICK_RAIL_COVERAGE_STEP
+);
 
 /**
  * How the lid retains onto the bin. Mutually exclusive — a lid holds by


### PR DESCRIPTION
Addresses the second ask on #3401: "Ideally we also get step increments of 10 instead of the 25 right now."

Coverage moves from 50/75/100 to 5% stops between 50 and 100.

## Why 5% and not the requested 10%

`migrateClickRailCoverage` snaps every persisted value to the **nearest** listed option. A 10% list has no 75, so every design saved at three-quarter coverage would silently re-render at 70 on next open: a changed printed part, with no notice, for users who deliberately picked that value.

A 5% step is finer than asked for, costs nothing, and keeps 75 an exact stop. Two migration tests pin that (`keeps every previously-shippable coverage as an exact stop`, plus an off-stop snap case), and a type-level test asserts the list is gapless, integer-only, and still contains all three legacy stops.

## Copy

Only 50/75/100 carry descriptions. The steps between them are self-explanatory percentages, and captioning each would add eight strings across fourteen locales to say nothing useful. `gripCoverageOptions` in the same hook already renders bare stops this way, so the slider handles it.

## Note on ordering

With #3404 merged, 100% coverage is actually usable alongside label tabs. Part of why the reporter wanted finer steps was to dodge that collision, so the two changes are complementary rather than redundant.

## Verification

- `paramMigration` (112), `lid.test.ts` (58), LidSection + designer store + controls (116)
- typecheck, lint (0 errors), all four i18n checks, module boundaries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 5% step increments for lid click-rail coverage from 50% to 100% for finer control, while preserving existing 75% designs. Addresses #3401 without changing saved parts by keeping legacy stops exact, and documents the stop list and why the step is 5%.

- **New Features**
  - Coverage now runs 50–100 in 5% steps via `LID_CLICK_RAIL_COVERAGE_MIN/MAX/STEP` and generated `LID_CLICK_RAIL_COVERAGE_OPTIONS`; documented in `README.md`.
  - Migration keeps 50/75/100 exact and snaps off-stops to the nearest; tests cover both and assert a gapless, integer-only list.
  - UI shows copy only for 50/75/100; intermediate steps render as bare percentages.

<sup>Written for commit bf911a81eb2a4ca619503564fe6513b2e0d3bb4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

