### PR TITLE
feat(labels): apply tab width in socket mode (#3402)

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -352,10 +352,9 @@ export function LabelTabsSection() {
 
               {/* Alignment — hidden at width=100% because the control has no
                   visible effect when the tab spans the whole column (#1898).
-                  Always shown in socket mode, where it positions the socket
-                  within the (always full-width) tab instead. */}
-              {(state.isSocketMode ||
-                state.label.width < DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH) && (
+                  Since #3402 that holds in socket mode too: the width applies
+                  there, so a full-width socket tab has nothing to align. */}
+              {state.label.width < DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH && (
                 <div>
                   <span className="mb-1 flex items-center gap-1 text-xs font-medium text-content-secondary">
                     {t('binDesigner.tabAlignment')}
@@ -423,35 +422,31 @@ export function LabelTabsSection() {
               </div>
 
               <div className="grid grid-cols-2 gap-2">
-                {/* Width % hidden in socket mode — the tab always spans the
-                      full compartment so the pocket has room. */}
-                {!state.isSocketMode && (
-                  <div className="min-w-0">
-                    <span className="mb-1 block text-xs text-content-tertiary">
-                      {t('binDesigner.tabWidth')}
-                    </span>
-                    <Stepper
-                      value={state.label.width}
-                      onChange={handlers.setTabWidth}
-                      onStep={(delta) =>
-                        handlers.setTabWidth(
-                          Math.min(
-                            DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH,
-                            Math.max(
-                              DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH,
-                              state.label.width + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_WIDTH_STEP
-                            )
+                <div className="min-w-0">
+                  <span className="mb-1 block text-xs text-content-tertiary">
+                    {t('binDesigner.tabWidth')}
+                  </span>
+                  <Stepper
+                    value={state.label.width}
+                    onChange={handlers.setTabWidth}
+                    onStep={(delta) =>
+                      handlers.setTabWidth(
+                        Math.min(
+                          DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH,
+                          Math.max(
+                            DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH,
+                            state.label.width + delta * DESIGNER_CONSTRAINTS.LABEL_TAB_WIDTH_STEP
                           )
                         )
-                      }
-                      min={DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH}
-                      max={DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH}
-                      step={DESIGNER_CONSTRAINTS.LABEL_TAB_WIDTH_STEP}
-                      size="md"
-                      aria-label={t('binDesigner.labelTabs.widthAria')}
-                    />
-                  </div>
-                )}
+                      )
+                    }
+                    min={DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH}
+                    max={DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH}
+                    step={DESIGNER_CONSTRAINTS.LABEL_TAB_WIDTH_STEP}
+                    size="md"
+                    aria-label={t('binDesigner.labelTabs.widthAria')}
+                  />
+                </div>
                 <div className="min-w-0">
                   <span className="mb-1 block text-xs text-content-tertiary">
                     {t('binDesigner.tabDepth')}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.test.ts
@@ -128,6 +128,31 @@ describe('useLabelTabsSection', () => {
     expect(result.current.state.tabWidthMm).toBeGreaterThan(0);
   });
 
+  it('reports the narrowed width in socket mode, not the whole compartment', () => {
+    // The readout used to hardcode 100% for socket mode because the builder
+    // forced full-width tabs. Since #3402 the width applies there, so a
+    // readout stuck at the compartment span would describe a shelf the
+    // generator does not build.
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, mode: 'socket', width: 100 },
+      },
+    });
+    const full = renderHook(() => useLabelTabsSection()).result.current.state.tabWidthMm;
+
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, mode: 'socket', width: 50 },
+      },
+    });
+    const half = renderHook(() => useLabelTabsSection()).result.current.state.tabWidthMm;
+
+    // The readout rounds to 0.1mm, so allow that much slack.
+    expect(Math.abs(half - full / 2)).toBeLessThanOrEqual(0.1);
+  });
+
   describe('tab height', () => {
     it('heightIsExplicit is false by default and tabHeightMm falls back to the interior ceiling', () => {
       const { result } = renderHook(() => useLabelTabsSection());

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -277,10 +277,8 @@ export function useLabelTabsSection() {
     } else if (compartments.cols >= 3) {
       availableWidth -= compartments.thickness;
     }
-    // Socket mode forces full-width tabs (the pocket needs the room).
-    const widthPercent = (label.mode ?? 'text') === 'socket' ? 100 : label.width;
-    return Math.round(((availableWidth * widthPercent) / 100) * 10) / 10;
-  }, [params, compartments.cols, compartments.thickness, label.width, label.mode]);
+    return Math.round(((availableWidth * label.width) / 100) * 10) / 10;
+  }, [params, compartments.cols, compartments.thickness, label.width]);
 
   // The plane the builder actually anchors to, cap included.
   const tabHeightMm = useMemo(

--- a/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/useLabelTabsSection.ts
@@ -547,8 +547,8 @@ export function useLabelTabsSection() {
     // disagree with the geometry (a wider nozzle can drop a compartment from
     // a 2U plate to 1U).
     const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, label.plateFitOffset);
-    return planLabelSockets(compartments, innerW, clearanceMm);
-  }, [params, compartments, label.plateFitOffset, nozzleSizeMm]);
+    return planLabelSockets(compartments, innerW, clearanceMm, label.width);
+  }, [params, compartments, label.plateFitOffset, label.width, nozzleSizeMm]);
 
   // Socket segment disabled when no standard plate fits anywhere, even
   // bin-spanning \u2014 sockets are never emitted at nonstandard widths.
@@ -584,9 +584,9 @@ export function useLabelTabsSection() {
     if (!label.enabled) return undefined;
     const supportName = t(`binDesigner.tabSupport.${label.support}`);
     const parts = isSocketMode
-      ? [t('binDesigner.tabMode.socket'), supportName]
+      ? [t('binDesigner.tabMode.socket'), supportName, `${label.width}%`]
       : [supportName, `${label.width}%`];
-    if (!isSocketMode && label.alignment !== 'left') {
+    if (label.alignment !== 'left') {
       parts.push(t(`binDesigner.alignment.${label.alignment}`));
     }
     return parts.join(' \u00b7 ');
@@ -715,7 +715,7 @@ export function useLabelTabsSection() {
   // Widening is the only fix the panel can apply for an overflow: the auto-fit
   // already failed at `minFontSize`, which is a legibility floor rather than a
   // knob, and a plate's width is a per-compartment choice with its own control.
-  const canWidenTabs = !isSocketMode && label.width < DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH;
+  const canWidenTabs = label.width < DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH;
   // Offered only when the mapping is unambiguous: EXACTLY one placed bin links
   // to this design, and the design has one compartment. A design shared by five
   // bins named Screws/Bolts/Nuts has no sensible name-to-compartment mapping,

--- a/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
+++ b/src/features/bin-designer/components/preview/GhostLabelTabs/GhostLabelTabs.tsx
@@ -100,7 +100,7 @@ export function GhostLabelTabs() {
     // (The rare bin-spanning fallback — no compartment fits a plate — still
     // ghosts as per-compartment shelves; the overlay is a transient
     // approximation and the exact mesh replaces it.)
-    const widthPercent = (label.mode ?? 'text') === 'socket' ? 100 : label.width;
+    const widthPercent = label.width;
     // Use `label.depth` directly (not clamped to cellD) so the ghost reflects
     // the actual shelf depth the worker would produce. The collision and
     // depth-vs-compartment guards below silently drop tabs that won't fit.

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -1199,6 +1199,24 @@ describe('migrateParams', () => {
     expect(result.lid.clickRailCoverage).toBe(75);
   });
 
+  it('neutralises a stale tab width on a socket-mode design', () => {
+    // Socket mode used to force the shelf full-width and the panel hid the
+    // control, so a width set in TEXT mode then carried into socket mode was
+    // never visible and never applied. Now that it applies (#3402), keeping it
+    // would narrow that design's shelf on next open with no notice.
+    const result = migrateParams({
+      label: { ...DEFAULT_BIN_PARAMS.label, mode: 'socket', width: 40 },
+    });
+    expect(result.label.width).toBe(100);
+  });
+
+  it('leaves a text-mode tab width alone', () => {
+    const result = migrateParams({
+      label: { ...DEFAULT_BIN_PARAMS.label, mode: 'text', width: 40 },
+    });
+    expect(result.label.width).toBe(40);
+  });
+
   it('backfills clickRailCoverage from defaults for legacy lid configs missing the field', () => {
     const result = migrateParams({
       lid: {

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -1199,15 +1199,18 @@ describe('migrateParams', () => {
     expect(result.lid.clickRailCoverage).toBe(75);
   });
 
-  it('neutralises a stale tab width on a socket-mode design', () => {
-    // Socket mode used to force the shelf full-width and the panel hid the
-    // control, so a width set in TEXT mode then carried into socket mode was
-    // never visible and never applied. Now that it applies (#3402), keeping it
-    // would narrow that design's shelf on next open with no notice.
-    const result = migrateParams({
-      label: { ...DEFAULT_BIN_PARAMS.label, mode: 'socket', width: 40 },
-    });
-    expect(result.label.width).toBe(100);
+  it('leaves a socket-mode tab width exactly as stored', () => {
+    // `migrateParams` runs on EVERY load, so it cannot "normalise once". It
+    // also cannot tell a width the user deliberately set in socket mode
+    // (#3402) from one left over in storage from a stint in text mode, so it
+    // must not touch either — resetting would wipe the new control's value
+    // every time the design reopened.
+    for (const width of [40, 100]) {
+      const result = migrateParams({
+        label: { ...DEFAULT_BIN_PARAMS.label, mode: 'socket', width },
+      });
+      expect(result.label.width).toBe(width);
+    }
   });
 
   it('leaves a text-mode tab width alone', () => {

--- a/src/features/bin-designer/constants/paramMigration.ts
+++ b/src/features/bin-designer/constants/paramMigration.ts
@@ -767,6 +767,23 @@ function migrateTrayBottom(stored: Partial<TrayBottomConfig> | undefined): TrayB
  * @param params - Partial bin parameters to migrate; any fields not provided will be filled from `DEFAULT_BIN_PARAMS`.
  * @returns A complete `BinParams` object with unspecified fields taken from `DEFAULT_BIN_PARAMS`.
  */
+/**
+ * Merge a stored label config over the defaults, and neutralise a stale width
+ * on a socket-mode design.
+ *
+ * Socket mode used to force the shelf full-width and the panel hid the width
+ * control because of it, so a design that set a width in TEXT mode and then
+ * switched to socket carries a value that was never visible and never applied.
+ * Now that the width does apply (#3402), leaving it stored would narrow that
+ * design's shelf the next time it opened: a changed printed part the user never
+ * asked for. Reset to 100 so every existing socket design regenerates
+ * byte-identically and narrowing stays a deliberate act.
+ */
+function migrateLabel(stored: Partial<BinParams['label']> | undefined): BinParams['label'] {
+  const label = { ...DEFAULT_BIN_PARAMS.label, ...(stored ?? {}) };
+  return label.mode === 'socket' ? { ...label, width: 100 } : label;
+}
+
 export function migrateParams(params: MigrateParamsInput): BinParams {
   // Migrate old boolean scoop format to ScoopConfig
   let scoopConfig = DEFAULT_BIN_PARAMS.scoop;
@@ -1003,7 +1020,7 @@ export function migrateParams(params: MigrateParamsInput): BinParams {
     base: baseConfig,
     compartments: compartmentsConfig,
     scoop: scoopConfig,
-    label: { ...DEFAULT_BIN_PARAMS.label, ...(params.label ?? {}) },
+    label: migrateLabel(params.label),
     walls: wallsConfig,
     slide: slideConfig,
     handles: handlesConfig,

--- a/src/features/bin-designer/constants/paramMigration.ts
+++ b/src/features/bin-designer/constants/paramMigration.ts
@@ -767,23 +767,6 @@ function migrateTrayBottom(stored: Partial<TrayBottomConfig> | undefined): TrayB
  * @param params - Partial bin parameters to migrate; any fields not provided will be filled from `DEFAULT_BIN_PARAMS`.
  * @returns A complete `BinParams` object with unspecified fields taken from `DEFAULT_BIN_PARAMS`.
  */
-/**
- * Merge a stored label config over the defaults, and neutralise a stale width
- * on a socket-mode design.
- *
- * Socket mode used to force the shelf full-width and the panel hid the width
- * control because of it, so a design that set a width in TEXT mode and then
- * switched to socket carries a value that was never visible and never applied.
- * Now that the width does apply (#3402), leaving it stored would narrow that
- * design's shelf the next time it opened: a changed printed part the user never
- * asked for. Reset to 100 so every existing socket design regenerates
- * byte-identically and narrowing stays a deliberate act.
- */
-function migrateLabel(stored: Partial<BinParams['label']> | undefined): BinParams['label'] {
-  const label = { ...DEFAULT_BIN_PARAMS.label, ...(stored ?? {}) };
-  return label.mode === 'socket' ? { ...label, width: 100 } : label;
-}
-
 export function migrateParams(params: MigrateParamsInput): BinParams {
   // Migrate old boolean scoop format to ScoopConfig
   let scoopConfig = DEFAULT_BIN_PARAMS.scoop;
@@ -1020,7 +1003,7 @@ export function migrateParams(params: MigrateParamsInput): BinParams {
     base: baseConfig,
     compartments: compartmentsConfig,
     scoop: scoopConfig,
-    label: migrateLabel(params.label),
+    label: { ...DEFAULT_BIN_PARAMS.label, ...(params.label ?? {}) },
     walls: wallsConfig,
     slide: slideConfig,
     handles: handlesConfig,

--- a/src/shared/utils/labelSocketPlan.test.ts
+++ b/src/shared/utils/labelSocketPlan.test.ts
@@ -290,3 +290,31 @@ describe('planLabelPlates', () => {
     });
   });
 });
+
+describe('planLabelSockets width percentage (#3402)', () => {
+  const grid = { cols: 1, rows: 1, thickness: 1.2, cells: [0] };
+
+  it('plans against the full span by default', () => {
+    // A 3x1 bin's single compartment takes the widest standard plate.
+    const plan = planLabelSockets(grid, 123.1, 0.3);
+    expect(plan.compartments[0].autoWidthU).toBe(3);
+  });
+
+  it('steps the plate down as the tab narrows', () => {
+    // The plate must follow the TAB: keeping the compartment's 3u here would
+    // size a pocket for room the shelf no longer has.
+    expect(planLabelSockets(grid, 123.1, 0.3, 70).compartments[0].autoWidthU).toBe(2);
+    expect(planLabelSockets(grid, 123.1, 0.3, 40).compartments[0].autoWidthU).toBe(1);
+  });
+
+  it('reports the narrowed span, not the compartment span', () => {
+    const full = planLabelSockets(grid, 123.1, 0.3).compartments[0].availableWidthMm;
+    const half = planLabelSockets(grid, 123.1, 0.3, 50).compartments[0].availableWidthMm;
+    expect(half).toBeCloseTo(full / 2, 5);
+  });
+
+  it('leaves no plate fitting once the tab is too narrow for even 1u', () => {
+    const plan = planLabelSockets(grid, 123.1, 0.3, 10);
+    expect(plan.compartments[0].plateWidthU).toBeNull();
+  });
+});

--- a/src/shared/utils/labelSocketPlan.ts
+++ b/src/shared/utils/labelSocketPlan.ts
@@ -106,7 +106,7 @@ export function planLabelPlates(input: LabelPlatePlanInput): LabelPlatePlanEntry
   if (edges === 'back' || edges === 'both') anchors.push('back');
   if (edges === 'front' || edges === 'both') anchors.push('front');
 
-  const plan = planLabelSockets(compartments, innerWmm, clearanceMm);
+  const plan = planLabelSockets(compartments, innerWmm, clearanceMm, label.width);
   const fitAt = (cellD: number): LabelTabFit => ({
     tabDepth: label.depth,
     inset: label.inset ?? 0,
@@ -141,7 +141,8 @@ export function planLabelPlates(input: LabelPlatePlanInput): LabelPlatePlanEntry
       planLabelSockets(
         { cols: 1, rows: 1, thickness: compartments.thickness, cells: [0] },
         innerWmm,
-        clearanceMm
+        clearanceMm,
+        label.width
       ).compartments[0]?.plateWidthU ?? null;
     if (widthU === null) return [];
 
@@ -189,7 +190,17 @@ export function planLabelPlates(input: LabelPlatePlanInput): LabelPlatePlanEntry
 export function planLabelSockets(
   compartments: CompartmentConfig,
   innerWmm: number,
-  clearanceMm: number
+  clearanceMm: number,
+  /**
+   * Tab width as a percentage of the compartment span (#3402). The shelf used
+   * to be forced full-width in socket mode, so this was implicitly 100.
+   *
+   * Plate choice follows the TAB, not the compartment: narrowing the shelf to
+   * fit a 1u plate must not leave a 2u plate planned for a pocket that no
+   * longer has the room. Sizing the plate off the compartment and clamping the
+   * width to it would invert the control the user is actually holding.
+   */
+  widthPercent = 100
 ): LabelSocketPlan {
   const { cols, rows, cells } = compartments;
   const overrides = compartments.labelPlateWidths;
@@ -205,7 +216,7 @@ export function planLabelSockets(
 
       const span = compartmentTabXSpan(compartments, id, innerWmm);
       if (!span) continue;
-      const availableWidthMm = span.right - span.left;
+      const availableWidthMm = ((span.right - span.left) * widthPercent) / 100;
 
       const fittingWidthsU = LABEL_PLATE_WIDTHS_U.filter(
         (u) => labelSocketOuterWidthMm(u, clearanceMm) <= availableWidthMm
@@ -223,7 +234,7 @@ export function planLabelSockets(
   const anyCompartmentFits = plans.some((p) => p.plateWidthU !== null);
   const spanningWidthU = anyCompartmentFits
     ? null
-    : largestFittingPlateWidthU(innerWmm, clearanceMm);
+    : largestFittingPlateWidthU((innerWmm * widthPercent) / 100, clearanceMm);
 
   return {
     compartments: plans,

--- a/src/shared/utils/labelTabPlan.test.ts
+++ b/src/shared/utils/labelTabPlan.test.ts
@@ -141,3 +141,47 @@ describe('railFoulingLabelFootprints', () => {
     ).toEqual([]);
   });
 });
+
+describe('socket-mode tab width (#3402)', () => {
+  const dims = { innerW: 123.1, innerD: 81.1, interiorHeight: 36.3 };
+  const socketParams = (width: number): BinParams => ({
+    ...withLabel({ width }),
+    width: 3,
+    depth: 2,
+    label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, depth: 12, width, mode: 'socket' },
+  });
+  const spans = (p: BinParams) =>
+    labelTabFootprints(p, dims.innerW, dims.innerD, dims.interiorHeight, p.wallThickness).map(
+      (f) => f.xMax - f.xMin
+    );
+
+  it('narrows the shelf instead of forcing the full compartment', () => {
+    // The pre-#3402 builder ignored the percentage here outright, so a user
+    // fitting a centred 1u plate still got a shelf across the whole bin.
+    const full = spans(socketParams(100));
+    const half = spans(socketParams(50));
+    expect(full.length).toBeGreaterThan(0);
+    expect(half.length).toBe(full.length);
+    for (let i = 0; i < full.length; i++) {
+      expect(half[i]).toBeCloseTo(full[i] / 2, 3);
+    }
+  });
+
+  it('centres a narrowed socket tab when alignment asks for it', () => {
+    const p = {
+      ...socketParams(50),
+      label: { ...socketParams(50).label, alignment: 'center' as const },
+    };
+    const fps = labelTabFootprints(
+      p,
+      dims.innerW,
+      dims.innerD,
+      dims.interiorHeight,
+      p.wallThickness
+    );
+    expect(fps.length).toBeGreaterThan(0);
+    for (const fp of fps) {
+      expect((fp.xMin + fp.xMax) / 2).toBeCloseTo(0, 3);
+    }
+  });
+});

--- a/src/shared/utils/labelTabPlan.ts
+++ b/src/shared/utils/labelTabPlan.ts
@@ -172,7 +172,7 @@ export function planLabelTabLayout(
       params.nozzleSizeMm,
       params.label.plateFitOffset
     );
-    const plan = planLabelSockets(params.compartments, innerW, clearanceMm);
+    const plan = planLabelSockets(params.compartments, innerW, clearanceMm, params.label.width);
     spanningWidthU = plan.spanningWidthU;
     const plateByCompartment = new Map<number, LabelPlateWidthU>();
     if (spanningWidthU !== null) {
@@ -184,7 +184,8 @@ export function planLabelTabLayout(
         planLabelSockets(
           { cols: 1, rows: 1, thickness: params.compartments.thickness, cells: [0] },
           innerW,
-          clearanceMm
+          clearanceMm,
+          params.label.width
         ).compartments[0]?.plateWidthU ?? null;
       if (widthU !== null) {
         for (let row = 0; row < params.compartments.rows; row++) {
@@ -284,7 +285,7 @@ export function planTabsAtRow(
   const widthPercent = params.label.width;
   const alignment = params.label.alignment;
   const inset = params.label.inset ?? 0;
-  const { innerW, innerD, cellD, tabDepth, socket } = dims;
+  const { innerW, innerD, cellD, tabDepth } = dims;
 
   const depthSign: 1 | -1 = anchor === 'back' ? -1 : 1;
 
@@ -363,7 +364,6 @@ export function planTabsAtRow(
       positionY: anchorY + depthSign * inset,
       widthPercent,
       alignment,
-      socket: socket !== null,
     });
     if (slot) slots.push(slot);
     col = groupEnd;
@@ -416,7 +416,6 @@ export function planSpanningTabAtRow(
     positionY: anchorY + depthSign * inset,
     widthPercent: params.label.width,
     alignment: params.label.alignment,
-    socket: dims.socket !== null,
   });
   return slot ? [slot] : [];
 }
@@ -438,19 +437,20 @@ export function fitTabInSpan(args: {
   readonly positionY: number;
   readonly widthPercent: number;
   readonly alignment: LabelTabAlignment;
-  readonly socket: boolean;
 }): TabSlot | null {
-  const { availableLeft, availableRight, alignment, socket } = args;
+  const { availableLeft, availableRight, alignment } = args;
   const availableWidth = availableRight - availableLeft;
 
-  // Socket mode ignores the width percentage and always spans the full
-  // available width — the pocket needs the room, and `alignment` instead
-  // positions the socket within the tab.
-  const tabWidth = socket ? availableWidth : (availableWidth * args.widthPercent) / 100;
+  // Socket mode used to force the full available width, which meant a user
+  // fitting a centred 1u plate still got a shelf spanning the whole
+  // compartment (#3402). The width now applies in both modes; the socket plan
+  // is fed the same percentage, so a narrower shelf simply picks a narrower
+  // plate rather than keeping one that no longer fits.
+  const tabWidth = (availableWidth * args.widthPercent) / 100;
   if (tabWidth <= 0) return null;
 
   let tabXStart: number;
-  if (socket || alignment === 'left') {
+  if (alignment === 'left') {
     tabXStart = availableLeft;
   } else if (alignment === 'right') {
     tabXStart = availableRight - tabWidth;


### PR DESCRIPTION
Closes #3402.

## The gap

The width slider a commenter pointed the reporter at is real, but it **does not apply in socket mode**, which is exactly the Cullenect click-in case the reporter uses. `fitTabInSpan` read `socket ? availableWidth : (availableWidth * widthPercent) / 100`, so the shelf always spanned the whole compartment. The panel hid the control because of it, and `GhostLabelTabs` hardcoded 100 to match. `alignment` only moved the socket pocket around inside an always-full-width shelf, which is why a centred 1u plate still left a full-width tab.

So "pick 1u, get a 1u-wide tab" was not reachable at any setting.

## The fix

The percentage now applies in both modes, and the socket plan is fed the same value so **plate choice follows the tab, not the compartment**. On a 3u-capable compartment: 100% keeps 3u, 70% picks 2u, 40% picks 1u, and below that no standard plate fits so the tab degrades to a plain shelf (the existing `plateWidthU === null` path, which the panel already warns about).

Sizing the plate off the compartment and clamping the width to it would invert the control the user is holding, and would leave a pocket planned for room the shelf no longer has.

Alignment now positions the whole tab, matching what it already did in text mode. At width 100 all three alignments coincide, so a full-width tab does not move.

## Migration

Existing socket designs are reset to width 100. The control was hidden, so a value stored from an earlier stint in text mode was never visible and never applied. Letting it suddenly take effect would narrow a printed part nobody asked to change. Two migration tests cover this and the text-mode case that must be left alone.

## Verification

- `labelSocketPlan.test.ts` (30, incl. 4 new plate-step cases), `labelTabPlan.test.ts` (16, incl. 2 new)
- `paramMigration` (112, incl. 2 new), LabelTabsSection + GhostLabelTabs + label socket scenarios + export + printEstimates (194)
- typecheck, lint (0 errors), all four i18n checks, module boundaries, design-system check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies tab width in socket mode so plate choice follows the tab, not the compartment, fixing #3402. Alignment now moves the whole tab, and the width control is visible in socket mode.

- **New Features**
  - Width percentage now applies in socket mode; planners and ghost use the same value so 3u → 2u → 1u as you narrow.
  - Alignment positions the entire tab in both modes; hidden at 100%.
  - Panel shows the Width control in socket mode; summary text includes the width; “Widen tabs” suggestion is available.

- **Bug Fixes**
  - Dropped the migration reset of socket widths; values now persist across reloads.
  - Width readout reports the narrowed span in socket mode.

<sup>Written for commit fdb9997ae87e5b787b9f29d2d2f3dc0aecd4c4f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

