### PR TITLE
fix(generation): clip divider pattern under insetted and front-anchored tabs

### DIFF
--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -1473,6 +1473,27 @@ describe('validateDesignerShare', () => {
       expect(res.valid).toBe(true);
     });
 
+    it('rejects a click-rail coverage outside 0-100', () => {
+      // `railPlacements` multiplies the wall length by this, so an out-of-range
+      // value builds a rail longer than the wall it sits on. The client can
+      // only produce listed stops; a crafted payload is the gap.
+      for (const clickRailCoverage of [-10, 101, 1e6]) {
+        expect(
+          validateDesignerShare(withLid({ attachment: 'clickRails', clickRailCoverage }), 1000)
+            .valid
+        ).toBe(false);
+      }
+    });
+
+    it('accepts an off-stop coverage, which migration snaps on load', () => {
+      // Deliberately a range check, not a stop-list check: a value between the
+      // supported stops is legal input and `migrateClickRailCoverage` rounds it.
+      expect(
+        validateDesignerShare(withLid({ attachment: 'clickRails', clickRailCoverage: 73 }), 1000)
+          .valid
+      ).toBe(true);
+    });
+
     it('rejects an unknown attachment mode', () => {
       const res = validateDesignerShare(withLid({ attachment: 'glue' }), 1000);
       expect(res.valid).toBe(false);

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -373,6 +373,16 @@ function validateLid(lid: unknown): string | null {
   ) {
     return 'lid.extraHeightMm must be 0-100';
   }
+  // Range only, not the stop list: `migrateClickRailCoverage` snaps a stored
+  // value to the nearest supported option on load, so an off-stop number is
+  // legal input. What it cannot absorb is a value outside the range, which
+  // `railPlacements` turns into a rail longer than its own wall.
+  if (
+    lid.clickRailCoverage !== undefined &&
+    (!isNumber(lid.clickRailCoverage) || !inRange(lid.clickRailCoverage, 0, 100))
+  ) {
+    return 'lid.clickRailCoverage must be 0-100';
+  }
   if (
     lid.topThicknessMm !== undefined &&
     (!isNumber(lid.topThicknessMm) || !inRange(lid.topThicknessMm, 0.8, 5))

--- a/src/features/bin-designer/components/panel/LidSection/LidSection.test.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.test.tsx
@@ -587,17 +587,34 @@ describe('LidSection', () => {
   });
 
   describe('compatibility issues', () => {
-    it('shows a Fix button on the label-tabs warning that disables the feature', () => {
+    it('offers no one-click Fix on the label-tabs warning', () => {
+      // The button deleted every label on the bin. That was proportionate while
+      // a tab cost the whole wall's rail; since #3401 the rail is only
+      // segmented around the tabs, so it offered to destroy user content to
+      // recover part of one wall. The warning itself still shows.
       resetStore({
         lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
         label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
       });
       render(<LidSection />);
-      const fixButtons = screen.getAllByRole('button', { name: /^Fix:/ });
-      const labelFix = fixButtons.find((b) => b.getAttribute('aria-label')?.includes('Label tabs'));
-      expect(labelFix).toBeDefined();
-      fireEvent.click(labelFix!);
-      expect(useDesignerStore.getState().params.label.enabled).toBe(false);
+      const fixButtons = screen.queryAllByRole('button', { name: /^Fix:/ });
+      expect(
+        fixButtons.find((b) => b.getAttribute('aria-label')?.includes('Label tabs'))
+      ).toBeUndefined();
+      expect(screen.getByText(/Label tabs take the wall they hang from/)).toBeInTheDocument();
+    });
+
+    it('still offers a Fix on a warning that really blocks the lid', () => {
+      resetStore({
+        lid: { ...DEFAULT_BIN_PARAMS.lid, enabled: true },
+        walls: {
+          ...DEFAULT_BIN_PARAMS.walls,
+          enabled: true,
+          back: { ...DEFAULT_BIN_PARAMS.walls.back, enabled: true },
+        },
+      });
+      render(<LidSection />);
+      expect(screen.getAllByRole('button', { name: /^Fix:/ }).length).toBeGreaterThan(0);
     });
 
     it('disables the per-side rail toggle when a feature conflict skips that side', () => {

--- a/src/features/bin-designer/components/panel/LidSection/useLidSection.helpers.ts
+++ b/src/features/bin-designer/components/panel/LidSection/useLidSection.helpers.ts
@@ -194,11 +194,15 @@ export function computeRailSummary(
  * compartments, or editing a specific cutout — so we don't surface a
  * "Fix" button for them.
  */
+// `labelTabs` is deliberately absent. Its one-click fix deleted every label on
+// the bin, which was proportionate while a tab cost the whole wall's rail; since
+// #3401 the rail is only segmented around the tabs, so the button offered to
+// destroy user content to recover part of one wall. The warning still explains
+// the trade and the user can turn labels off themselves.
 export const FIXABLE_IDS: ReadonlySet<LidCompatibilityId> = new Set<LidCompatibilityId>([
   'wallCutouts',
   'wallCutoutsAllSides',
   'wallPattern',
-  'labelTabs',
   'handles',
   'handlesAllSides',
   'tallDividerPieces',

--- a/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
+++ b/src/features/bin-designer/components/panel/LidSection/useLidSection.ts
@@ -96,7 +96,6 @@ export function useLidSection() {
     params,
     updateLid,
     updateWalls,
-    updateLabel,
     updateHandles,
     updateWallPattern,
     setParam,
@@ -114,7 +113,6 @@ export function useLidSection() {
       params: s.params,
       updateLid: s.updateLid,
       updateWalls: s.updateWalls,
-      updateLabel: s.updateLabel,
       updateHandles: s.updateHandles,
       updateWallPattern: s.updateWallPattern,
       setParam: s.setParam,
@@ -625,9 +623,6 @@ export function useLidSection() {
         case 'wallPattern':
           updateWallPattern({ enabled: false });
           return;
-        case 'labelTabs':
-          updateLabel({ enabled: false });
-          return;
         case 'handles':
         case 'handlesAllSides':
           updateHandles({ enabled: false });
@@ -644,7 +639,7 @@ export function useLidSection() {
           return;
       }
     },
-    [params.dividerPieces, setParam, updateHandles, updateLabel, updateWalls, updateWallPattern]
+    [params.dividerPieces, setParam, updateHandles, updateWalls, updateWallPattern]
   );
 
   const createMatchingTray = useCallback(() => {

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -1182,7 +1182,7 @@ describe('migrateParams', () => {
     // The stop list went from 50/75/100 to 5% steps (#3401). Because
     // `migrateClickRailCoverage` snaps to the NEAREST option, dropping a value
     // that designs were saved with would silently re-render them at a
-    // different coverage — a changed printed part with no notice. 75 is the
+    // different coverage: a changed printed part with no notice. 75 is the
     // one at risk, and it is why the step is 5 and not the requested 10.
     for (const coverage of [50, 75, 100]) {
       const result = migrateParams({
@@ -1203,7 +1203,7 @@ describe('migrateParams', () => {
     // `migrateParams` runs on EVERY load, so it cannot "normalise once". It
     // also cannot tell a width the user deliberately set in socket mode
     // (#3402) from one left over in storage from a stint in text mode, so it
-    // must not touch either — resetting would wipe the new control's value
+    // must not touch either; resetting would wipe the new control's value
     // every time the design reopened.
     for (const width of [40, 100]) {
       const result = migrateParams({

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -1205,7 +1205,9 @@ describe('migrateParams', () => {
     // (#3402) from one left over in storage from a stint in text mode, so it
     // must not touch either; resetting would wipe the new control's value
     // every time the design reopened.
-    for (const width of [40, 100]) {
+    // Both non-default (the default is 100), so neither iteration can pass by
+    // the merge-over-defaults spread happening to land on the right value.
+    for (const width of [40, 65]) {
       const result = migrateParams({
         label: { ...DEFAULT_BIN_PARAMS.label, mode: 'socket', width },
       });

--- a/src/features/bin-designer/types/lid.test.ts
+++ b/src/features/bin-designer/types/lid.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { DEFAULT_BIN_PARAMS } from '../constants/defaults';
+import { migrateParams } from '../constants/paramMigration';
 import type { BinParams } from './index';
 import {
   DEFAULT_LID_CONFIG,
@@ -21,7 +22,6 @@ import {
   LID_CLICK_RAIL_COVERAGE_OPTIONS,
   LID_CLICK_RAIL_COVERAGE_MIN,
   LID_CLICK_RAIL_COVERAGE_MAX,
-  LID_CLICK_RAIL_COVERAGE_STEP,
   LID_MAGNET_LIP_CLEARANCE,
   LID_GRIP_SPAN_MIN_MM,
   LID_GRIP_SPAN_MAX_MM,
@@ -520,13 +520,23 @@ describe('lidGripRequestedHeightMm', () => {
 });
 
 describe('LID_CLICK_RAIL_COVERAGE_OPTIONS', () => {
-  it('runs 50 to 100 with no gaps', () => {
-    expect(LID_CLICK_RAIL_COVERAGE_OPTIONS[0]).toBe(LID_CLICK_RAIL_COVERAGE_MIN);
+  it('reaches the maximum exactly', () => {
+    // The list is generated as MIN + i*STEP, so start and spacing are
+    // tautologies of the generator. Landing ON the maximum is not: a step that
+    // does not divide the range would stop short.
     expect(LID_CLICK_RAIL_COVERAGE_OPTIONS.at(-1)).toBe(LID_CLICK_RAIL_COVERAGE_MAX);
-    for (let i = 1; i < LID_CLICK_RAIL_COVERAGE_OPTIONS.length; i++) {
-      expect(LID_CLICK_RAIL_COVERAGE_OPTIONS[i] - LID_CLICK_RAIL_COVERAGE_OPTIONS[i - 1]).toBe(
-        LID_CLICK_RAIL_COVERAGE_STEP
-      );
+    expect(LID_CLICK_RAIL_COVERAGE_OPTIONS[0]).toBe(LID_CLICK_RAIL_COVERAGE_MIN);
+  });
+
+  it('round-trips every option through migration unchanged', () => {
+    // The property the stop list actually has to hold: `migrateClickRailCoverage`
+    // snaps to the nearest option, so any value that is a stop must survive a
+    // load. Dropping one silently re-renders every design saved at it.
+    for (const coverage of LID_CLICK_RAIL_COVERAGE_OPTIONS) {
+      const result = migrateParams({
+        lid: { ...DEFAULT_BIN_PARAMS.lid, clickRailCoverage: coverage },
+      });
+      expect(result.lid.clickRailCoverage).toBe(coverage);
     }
   });
 
@@ -535,12 +545,6 @@ describe('LID_CLICK_RAIL_COVERAGE_OPTIONS', () => {
     // designs onto a neighbour and quietly change a printed lid.
     for (const legacy of [50, 75, 100]) {
       expect(LID_CLICK_RAIL_COVERAGE_OPTIONS).toContain(legacy);
-    }
-  });
-
-  it('holds whole percentages only, so nothing lands between UI stops', () => {
-    for (const v of LID_CLICK_RAIL_COVERAGE_OPTIONS) {
-      expect(Number.isInteger(v)).toBe(true);
     }
   });
 });

--- a/src/features/generation/worker/generators/dividerPatterns.test.ts
+++ b/src/features/generation/worker/generators/dividerPatterns.test.ts
@@ -236,3 +236,45 @@ describe('widestClearRun', () => {
     expect(run).toBe(0);
   });
 });
+
+describe('label tab keep-outs', () => {
+  const label = (over: Partial<BinParams['label']> = {}): BinParams['label'] => ({
+    ...DEFAULT_BIN_PARAMS.label,
+    enabled: true,
+    depth: 10,
+    ...over,
+  });
+
+  /** Every keep-out on a divider running along X (a row boundary). */
+  function tabKeepOuts(params: BinParams) {
+    const result = plan(params);
+    return (result?.targets ?? []).flatMap((t) => t.keepOuts);
+  }
+
+  const span = (ks: readonly { uMin: number; uMax: number }[]) =>
+    ks
+      .map((k) => `${k.uMin.toFixed(2)},${k.uMax.toFixed(2)}`)
+      .sort()
+      .join('|');
+
+  it('follows the tab inward when `inset` moves it off its wall', () => {
+    // `inset` (#1898) slides the tab body away from its anchor wall. A keep-out
+    // pinned to the wall leaves the deepest `inset` mm of the tab sitting on
+    // perforated divider, which is the one thing it exists to prevent.
+    const plain = tabKeepOuts(makeParams({ label: label({ inset: 0 }) }));
+    const inset = tabKeepOuts(makeParams({ label: label({ inset: 6 }) }));
+    expect(plain.length).toBeGreaterThan(0);
+    // Moving the tab can take it off a divider entirely, so the counts may
+    // differ; what must not happen is the two being identical.
+    expect(span(inset)).not.toBe(span(plain));
+  });
+
+  it('puts the keep-out on the FRONT wall for front-anchored tabs', () => {
+    const back = tabKeepOuts(makeParams({ label: label({ edges: 'back' }) }));
+    const front = tabKeepOuts(makeParams({ label: label({ edges: 'front' }) }));
+    expect(back.length).toBeGreaterThan(0);
+    expect(front.length).toBeGreaterThan(0);
+    // Mirrored anchors must not produce identical spans.
+    expect(span(front)).not.toBe(span(back));
+  });
+});

--- a/src/features/generation/worker/generators/dividerPatterns.ts
+++ b/src/features/generation/worker/generators/dividerPatterns.ts
@@ -211,11 +211,11 @@ export function scoopKeepOuts(params: BinParams, dim: BinDimensions): WorldKeepO
 /**
  * Label tab footprints in world space.
  *
- * The tab's own width is capped per compartment inside `labelTabBuilder`;
- * rather than duplicate that resolution here, each compartment contributes a
- * box spanning its FULL width. That clears marginally more pattern than the
- * tab strictly occupies — the safe direction, since a shelf or gusset landing
- * on a perforated divider has nothing to bond to.
+ * X is deliberately the compartment's FULL width rather than the tab's placed
+ * span: clearing more pattern than the tab occupies is the safe direction,
+ * since a shelf or gusset landing on a perforated divider has nothing to bond
+ * to. Y is NOT approximated — it has to track `inset` and the anchor edge, or
+ * the box misses the tab body entirely and the feature does nothing.
  */
 function labelTabKeepOuts(params: BinParams, dim: BinDimensions): WorldKeepOut[] {
   if (!params.label.enabled) return [];
@@ -232,7 +232,12 @@ function labelTabKeepOuts(params: BinParams, dim: BinDimensions): WorldKeepOut[]
   const { cols, rows, cells } = params.compartments;
   const cellW = innerW / cols;
   const cellD = innerD / rows;
-  const bothEdges = params.label.edges === 'both';
+  const edges = params.label.edges ?? 'back';
+  const wantBack = edges === 'back' || edges === 'both';
+  const wantFront = edges === 'front' || edges === 'both';
+  // Slides the body inward from its anchor wall (#1898). Without it the box
+  // stays pinned to the wall while the tab has moved off it.
+  const inset = params.label.inset ?? 0;
 
   const out: WorldKeepOut[] = [];
   const seen = new Set<number>();
@@ -244,10 +249,12 @@ function labelTabKeepOuts(params: BinParams, dim: BinDimensions): WorldKeepOut[]
     const { minCol, maxCol, minRow, maxRow } = bounds;
     const xMin = -innerW / 2 + minCol * cellW;
     const xMax = -innerW / 2 + (maxCol + 1) * cellW;
-    const backY = -innerD / 2 + (maxRow + 1) * cellD;
-    out.push({ xMin, xMax, yMin: backY - tabDepth, yMax: backY, zMin, zMax });
-    if (bothEdges) {
-      const frontY = -innerD / 2 + minRow * cellD;
+    if (wantBack) {
+      const backY = -innerD / 2 + (maxRow + 1) * cellD - inset;
+      out.push({ xMin, xMax, yMin: backY - tabDepth, yMax: backY, zMin, zMax });
+    }
+    if (wantFront) {
+      const frontY = -innerD / 2 + minRow * cellD + inset;
       out.push({ xMin, xMax, yMin: frontY, yMax: frontY + tabDepth, zMin, zMax });
     }
   }

--- a/src/features/generation/worker/generators/labelTabPlanDims.test.ts
+++ b/src/features/generation/worker/generators/labelTabPlanDims.test.ts
@@ -4,7 +4,7 @@
  * The lid is generated independently of the bin pipeline, so it has no
  * `BinDimensions` to read and `labelTabInteriorDims` re-derives the interior
  * from params. That re-derivation is only safe while it agrees with the real
- * one — a silent divergence would put the label footprints at the wrong Z and
+ * one. A silent divergence would put the label footprints at the wrong Z and
  * quietly stop clipping the click rails (#3401), with no failing geometry
  * assertion anywhere, since both solids stay perfectly valid.
  *

--- a/src/features/generation/worker/generators/lidClickRailLabelClip.test.ts
+++ b/src/features/generation/worker/generators/lidClickRailLabelClip.test.ts
@@ -46,6 +46,23 @@ describe('railSegmentsClearOfLabelTabs', () => {
     ]);
   });
 
+  it('decides on the rail line within the profile half-width, not loosely', () => {
+    // RAIL_HALF_WIDTH is 1.325mm. Without a case straddling it the constant
+    // could be anything from just above zero to tens of mm and every other
+    // case here would still pass.
+    const railCross = 37.5;
+    // Tab's cross span ends just INSIDE the rail's half-width: still blocks.
+    const inside = railSegmentsClearOfLabelTabs(-50, 50, false, railCross, [
+      backTab(-40, railCross - 1.3, 50, 12),
+    ]);
+    expect(inside[0].hi).toBeLessThan(50);
+    // Just OUTSIDE it: the rail is untouched.
+    const outside = railSegmentsClearOfLabelTabs(-50, 50, false, railCross, [
+      backTab(-40, railCross - 1.4, 50, 12),
+    ]);
+    expect(outside).toEqual([{ lo: -50, hi: 50 }]);
+  });
+
   it('eats both ends when tabs sit on opposite walls', () => {
     const both = [
       backTab(-40, 40, 50, 12),

--- a/src/features/generation/worker/generators/lidGripLabelInteraction.test.ts
+++ b/src/features/generation/worker/generators/lidGripLabelInteraction.test.ts
@@ -7,7 +7,7 @@
  * centre moves and the match silently fails: the rail is passed through whole
  * and the grip's requested snap-softening does not happen.
  *
- * Nothing about the resulting lid looks wrong — it is a valid solid with a
+ * Nothing about the resulting lid looks wrong: it is a valid solid with a
  * relief and a rail, just a rail that was supposed to give way and does not.
  */
 // @vitest-environment node

--- a/src/features/generation/worker/generators/lidGripLabelInteraction.test.ts
+++ b/src/features/generation/worker/generators/lidGripLabelInteraction.test.ts
@@ -60,20 +60,26 @@ describe('grip relief interrupts rails that label tabs have moved', () => {
   });
 
   it('still splits the front rail when a front tab has shortened it', () => {
-    // A narrow front tab leaves stretches either side of itself, and the grip
-    // sits on that same wall. Each surviving stretch that runs behind the grip
-    // has to give way, exactly as the whole rail did.
-    const rails = frontRails(makeParams({ edges: 'front', width: 40, alignment: 'center' }));
-    expect(rails.length).toBeGreaterThan(0);
-    const gripSpan = resolveLidInputs(
-      makeParams({ edges: 'front', width: 40, alignment: 'center' })
-    ).grip;
-    expect(gripSpan.mode).toBe('scallop');
-    // No surviving rail may straddle the wall centre, which is where the grip
-    // is. A rail that skipped its split would.
-    for (const r of rails) {
-      const half = r.length / 2;
-      expect(Math.abs(r.centerX) > half).toBe(true);
+    // The tab must leave ONE off-centre stretch that still crosses the grip.
+    // A centred tab splits the run itself and leaves two stretches either side
+    // of the grip already, so the grip pass has nothing to subtract and the
+    // test would pass with the matcher reverted to exact-centre equality.
+    const params = makeParams({ edges: 'front', width: 30, alignment: 'left' });
+    const inputs = resolveLidInputs(params);
+    const before = railPlacements(inputs).filter((p) => p.rotationDeg === 180);
+    const after = splitRailsAroundGrip(railPlacements(inputs), inputs).filter(
+      (p) => p.rotationDeg === 180
+    );
+
+    // One surviving stretch, sitting off-centre because the tab took the left
+    // end. That is the shape the old exact-centre match could not recognise.
+    expect(before).toHaveLength(1);
+    expect(Math.abs(before[0].centerX)).toBeGreaterThan(1);
+    expect(after.length).toBeGreaterThan(before.length);
+
+    // And nothing that survived may still run behind the grip.
+    for (const r of after) {
+      expect(Math.abs(r.centerX) > r.length / 2).toBe(true);
     }
   });
 
@@ -162,8 +168,8 @@ describe('grip reliefs stay on their own wall', () => {
       const key = r.centerX.toFixed(3);
       perLine.set(key, (perLine.get(key) ?? 0) + 1);
     }
-    for (const [line, count] of perLine) {
-      expect({ line, count }).toEqual({ line, count: Math.min(count, 2) });
-    }
+    // Both bounds. An upper bound alone would also pass if the grip pass
+    // stopped splitting altogether and left one whole rail per line.
+    expect([...perLine.values()].sort()).toEqual([2, 2]);
   });
 });

--- a/src/features/generation/worker/generators/lidLabelTabClearance.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidLabelTabClearance.scenario.test.ts
@@ -39,9 +39,21 @@ interface Case {
   readonly overhang?: BinParams['overhang'];
   /** Tab width as a percentage of its compartment; defaults to full width. */
   readonly tabWidth?: number;
+  /**
+   * Rails expected on the tab's own wall. Set only where the point of the case
+   * is that segments SURVIVE beside a narrow tab: absence-of-collision is
+   * satisfied by building no rail at all, which is exactly what the pre-#3401
+   * code did.
+   */
+  readonly expectAnchorRails?: number;
 }
 
-/** Every case here interfered before the fix except the two marked baseline. */
+/**
+ * Most cases interfered before the fix. The two baselines never did (the rail
+ * did not reach the tab), and neither did the two partial-rail cases: the old
+ * code dropped the whole wall, so a narrow tab had nothing to collide with.
+ * Those two carry a positive assertion instead, below.
+ */
 const CASES: readonly Case[] = [
   {
     name: 'baseline 50% clears',
@@ -118,6 +130,7 @@ const CASES: readonly Case[] = [
   },
   {
     name: 'partial back rails beside a narrow tab',
+    expectAnchorRails: 2,
     depth: 3,
     coverage: 100,
     edges: 'back',
@@ -127,6 +140,7 @@ const CASES: readonly Case[] = [
   },
   {
     name: 'partial back rails beside a narrow front tab',
+    expectAnchorRails: 2,
     depth: 3,
     coverage: 100,
     edges: 'front',
@@ -250,7 +264,43 @@ describe('lid click rails clear label tabs', () => {
       // 0.05mm absorbs mesh tessellation noise on the curved corner blends;
       // the defect this guards against measured 1.25mm.
       expect(worstInterference(bin, lid, lidZOffset(params))).toBeLessThan(0.05);
+
+      if (c.expectAnchorRails !== undefined) {
+        const { railPlacements } = await import('./lidClickRail');
+        const { resolveLidInputs } = await import('./lidInputs');
+        const anchorRotation = c.edges === 'front' ? 180 : 0;
+        const onAnchorWall = railPlacements(resolveLidInputs(params)).filter(
+          (p) => p.rotationDeg === anchorRotation
+        );
+        expect(onAnchorWall).toHaveLength(c.expectAnchorRails);
+      }
     },
     300000
   );
+
+  it('the probe can see a real clash', async () => {
+    // Control for the twelve assertions above. Builds the pre-fix pairing by
+    // hand: a bin WITH tabs, and a lid generated as though they were not there
+    // (which is what the old code did once it dropped the conflicting side).
+    // If the probe stops finding either solid, or `lidZOffset` drifts, every
+    // other case in this file passes while guarding nothing.
+    const { generateLid } = await import('./lidOrchestrator');
+    const params = makeParams({
+      name: 'control',
+      depth: 3,
+      coverage: 100,
+      edges: 'back',
+      tabDepth: 12,
+      support: 'bracket',
+    });
+    const bin = getGenerateBin()(params, undefined, false);
+    const blindLid = generateLid({
+      ...params,
+      label: { ...params.label, enabled: false },
+    });
+    if (!bin) throw new Error('expected the bin to build');
+    if (!blindLid) throw new Error('expected the lid to build');
+
+    expect(worstInterference(bin, blindLid, lidZOffset(params))).toBeGreaterThan(1);
+  }, 300000);
 });

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -39,12 +39,14 @@ const META_STORE = 'binMeshMeta';
  * `forExport=false`, so the kernel and quality are folded into this constant
  * rather than the per-entry key.
  *
+ * `v8`: label-tab keep-outs on patterned dividers follow `inset` and the
+ * anchor edge, so a bin with either cuts a different divider pattern.
  * `v7`: label tabs stopped being forced full-width in socket mode (#3402), so
  * the same params cut a different shelf. `useLinkedDesignMeshes` serves a hit
  * without regenerating, so without this bump a linked design in the layout
  * planner would render its pre-fix bin until the entry was evicted.
  */
-const MESH_CACHE_VERSION = 'v7-brepjs18.123.0';
+const MESH_CACHE_VERSION = 'v8-brepjs18.123.0';
 
 /** Evict oldest entries once the total stored mesh bytes exceed this budget. */
 let maxCacheBytes = 64 * 1024 * 1024;


### PR DESCRIPTION
The remaining items from re-reviewing #3401 / #3402, plus one bug that turned out to be the same mistake in a second subsystem.

## The keep-out bugs

`labelTabKeepOuts` clears divider pattern where a label tab lands, so the shelf and its gussets have solid material to bond to. It pinned its box to the compartment wall and always to the **back** edge, so two configurations left a tab sitting on perforated divider:

- **`inset` was ignored.** #1898's `inset` slides the tab body inward from its anchor wall; the box did not follow, so the deepest `inset` mm of every tab overhung pattern holes.
- **`edges: 'front'` clipped the wrong wall.** The keep-out went on the back wall, where there is no tab, and the front tab that does get built got none at all.

That second one is the identical wrong-wall assumption `lidCompatibility` carried until #3401, written independently in a different subsystem. Finding it once was a hint the codebase encoded "tabs are on the back" in more than one place.

Both reproduced with failing tests first, and both confirmed to fail again with the fix reverted.

X stays the compartment's full width deliberately: over-clearing there is the safe direction. The comment now says that, instead of citing an avoid-duplication argument that `labelTabFootprints` has since retired.

## Missing server validator

`lid.clickRailCoverage` had none, though `base.trayBottom`'s copy of the same field has had one since #3036. `railPlacements` multiplies a wall's length by it, so an out-of-range value from a crafted payload builds a rail longer than its own wall. Range only, not the stop list, since `migrateClickRailCoverage` legitimately snaps an off-stop value on load, and a test pins that distinction.

## Disproportionate Fix action

The label-tab warning's one-click Fix called `updateLabel({ enabled: false })`, deleting every label on the bin. That was proportionate while a tab cost the whole wall's rail. Since #3401 the rail is only segmented around the tabs, so the button offered to destroy user content to recover part of one wall. Removed; the warning stays and explains the trade. Every other entry in `FIXABLE_IDS` still disables something that genuinely blocks the lid.

## Also

- `MESH_CACHE_VERSION` to v8. The keep-out fix changes the divider pattern for identical params, and `useLinkedDesignMeshes` serves a persisted hit without regenerating.
- Em dashes removed from prose authored across this change set, scoped deliberately: the repo has them in ~1000 source files, and comments carried in verbatim by the `labelTabPlan` move are left as their author wrote them.

## Verification

- 4 new tests, each confirmed to fail with its fix reverted
- 317 tests across divider patterns, label tabs, the API validator, the lid panel and the real-kernel clearance scenarios
- typecheck, lint (0 errors), all four i18n checks, module boundaries, design-system

## Separately confirmed

An independent audit of the `labelTabPlan` extraction in #3404 found all ten moved blocks byte-identical modulo `export`, imports resolving from the same modules, no pruned side-effect import, no dead code left behind, and an unchanged export surface across every importer. That was the one claim in this series I had asserted without proof.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes label tab keep-outs so divider patterns are cleared under inset and front-anchored tabs, preventing tabs from landing on perforated dividers. Also validates `lid.clickRailCoverage`, removes the destructive Fix on the label-tab warning, and hardens tests to catch regressions.

- **Bug Fixes**
  - Keep-outs now follow `inset` and the anchor edge; front tabs clip the front wall, back tabs clip the back. X stays full compartment width on purpose.
  - Validates `lid.clickRailCoverage` is 0–100; off-stop values are allowed and snapped by migration.
  - Removed the Fix button that disabled all labels; the warning remains and explains the trade-off.
  - Strengthened tests: add a positive clash control, tighten rail/grip split and U-shape assertions, assert partial rails beside narrow tabs, bound rail half-width, and pin migration round-trips.

- **Migration**
  - Bumped mesh cache to `v8` to regenerate divider patterns affected by the keep-out change. No user action needed.

<sup>Written for commit ebde0350ee3cbbcd62ac7b0b07494ff3b24e329d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

