### PR TITLE
fix(scripts): stop recommending <Input> for file, range and colour inputs

### DIFF
--- a/scripts/check-design-system-usage.test.ts
+++ b/scripts/check-design-system-usage.test.ts
@@ -89,6 +89,22 @@ describe('findViolations', () => {
       expect(find('const a = <input type="hidden" value="x" />;')).toEqual([]);
     });
 
+    it('ignores a file input, which is a mechanism rather than a styled control', () => {
+      expect(find('const a = <input type="file" onChange={f} />;')).toEqual([]);
+    });
+
+    it('points a range at Slider, not Input', () => {
+      expect(find('const a = <input type="range" />;')[0].use).toBe('<Slider>');
+    });
+
+    it('points a colour at ColorSwatch, not Input', () => {
+      expect(find('const a = <input type="color" />;')[0].use).toBe('<ColorSwatch>');
+    });
+
+    it('names the type it found, so the report says which input it means', () => {
+      expect(find('const a = <input type="search" />;')[0].found).toBe('<input type="search">');
+    });
+
     it('does not assume a computed type is safe', () => {
       // Could be "checkbox" at runtime, so it is still surfaced.
       const found = find('const a = <input type={kind} />;');

--- a/scripts/check-design-system-usage.ts
+++ b/scripts/check-design-system-usage.ts
@@ -96,9 +96,16 @@ function describe(
   if (type === 'checkbox') {
     return { found: '<input type="checkbox">', use: '<Checkbox>', blocking: true };
   }
-  // `hidden` carries no UI and has no design-system equivalent.
-  if (type === 'hidden') return null;
-  return { found: '<input>', use: '<Input>', blocking: false };
+  // No design-system equivalent, so there is nothing to recommend:
+  // `hidden` renders nothing, and a file input is a mechanism rather than a
+  // styled control — the pattern is a hidden input a Button clicks via a ref.
+  if (type === 'hidden' || type === 'file') return null;
+  // These have their own components; pointing them at <Input> was wrong.
+  if (type === 'range') return { found: '<input type="range">', use: '<Slider>', blocking: false };
+  if (type === 'color') {
+    return { found: '<input type="color">', use: '<ColorSwatch>', blocking: false };
+  }
+  return { found: `<input${type ? ` type="${type}"` : ''}>`, use: '<Input>', blocking: false };
 }
 
 export function findViolations(file: string, source: string): Violation[] {
@@ -229,11 +236,17 @@ function main(): void {
   }
 
   if (warnings.length > 0) {
-    const files = new Set(warnings.map((w) => w.file));
-    console.log(
-      `${YELLOW}⚠${NC}  ${warnings.length} text <input>(s) across ${files.size} file(s) ` +
-        `could use ${GREEN}<Input>${NC} ${DIM}(reported, not blocking)${NC}`
-    );
+    const byUse = new Map<string, Set<string>>();
+    for (const w of warnings) {
+      const files = byUse.get(w.use) ?? new Set<string>();
+      files.add(w.file);
+      byUse.set(w.use, files);
+    }
+    console.log(`${YELLOW}⚠${NC}  Raw elements with a design-system equivalent, not blocking:`);
+    for (const [use, files] of [...byUse].sort()) {
+      const count = warnings.filter((w) => w.use === use).length;
+      console.log(`     ${count} could use ${GREEN}${use}${NC} ${DIM}(${files.size} file(s))${NC}`);
+    }
     console.log('');
   }
 


### PR DESCRIPTION
Follow-up to #3418. Before migrating the reported inputs I surveyed what they actually are, and a third of the checker's advice was wrong.

`<Input>` is a text field. The checker pointed **every** non-checkbox `<input>` at it, including:

| type | count | reality |
|---|---|---|
| `file` | 6 | No design-system equivalent. It's a mechanism, not a styled control — the pattern is a hidden input a Button clicks through a ref. |
| `range` | 4 | `<Slider>` exists. |
| `color` | 1 | `<ColorSwatch>` exists. |

File inputs are no longer reported; range and colour now point at the right component.

The summary groups by recommendation rather than calling all of them text inputs, and each violation names the type it found so the report says which input it means.

Reported totals go from "52 text inputs" to **41 `<Input>`, 4 `<Slider>`, 1 `<ColorSwatch>`** — the same tree, described correctly.

```
⚠  Raw elements with a design-system equivalent, not blocking:
     1 could use <ColorSwatch> (1 file(s))
     41 could use <Input> (33 file(s))
     4 could use <Slider> (4 file(s))
```

Nothing blocking changes; the gate stays green with an empty allowlist.

## Verification

- 4 new classification tests (25 total in this file)
- `pnpm quality` 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the design-system checker to stop recommending `'<Input>'` for `type="file"`, and to point `type="range"` to `'<Slider>'` and `type="color"` to `'<ColorSwatch>'`. The report now shows accurate totals and clearer guidance.

- **Bug Fixes**
  - Summary groups by recommendation instead of calling everything “text inputs”.
  - Each violation lists the exact input type found.
  - Added 4 classification tests; no blocking changes.

<sup>Written for commit 933132783bc2fd05fb63e2243bd8d053127ad958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

