### PR TITLE
feat(labs): graduate the baseplate screw holes flag

### DIFF
--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -229,11 +229,10 @@ export const FEATURE_FLAGS = [
     name: 'Screw a Baseplate Down',
     description:
       'Add vertical holes through a baseplate so you can screw it to a drawer bottom, bench or wall. Four holes go into every printed piece, recessed so the head finishes flush and a bin still seats over it.',
-    status: 'experimental',
+    status: 'graduated',
     risk: 'medium',
-    warning:
-      'Holes sit in the drawer-fit padding where it is wide enough and in the pocket floor otherwise, which makes the plate slightly taller. Print one piece and check it against your drawer before running a full set.',
     addedAt: '2026-08',
+    graduatedAt: '2026-08',
     requiresRefresh: false,
   },
   {

--- a/src/features/baseplate/components/BaseplatePanel/BaseSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseSection.test.tsx
@@ -153,7 +153,7 @@ describe('BaseSection', () => {
     // The flag graduated, so a stored opt-out is dead state that
     // `isFeatureEnabled` short-circuits past. Reverting the status to
     // 'experimental' would hide the control again from anyone carrying this.
-    it('offers the toggle even to a user whose stored opt-in says false', () => {
+    it('offers the toggle even to a user carrying a stored opt-out', () => {
       useLabsStore.setState((s) => ({
         preferences: {
           ...s.preferences,

--- a/src/features/baseplate/components/BaseplatePanel/BaseSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseSection.test.tsx
@@ -138,15 +138,6 @@ describe('BaseSection', () => {
   });
 
   describe('mount-down screw holes (issue #3425)', () => {
-    function setScrewFlag(enabled: boolean): void {
-      useLabsStore.setState((s) => ({
-        preferences: {
-          ...s.preferences,
-          enabledFeatures: { ...s.preferences.enabledFeatures, baseplate_screw_holes: enabled },
-        },
-      }));
-    }
-
     function enableScrews(headStyle: ScrewHeadStyle): void {
       useLayoutStore.getState().setBaseplateParams({
         ...DEFAULT_BASEPLATE_PARAMS,
@@ -154,20 +145,26 @@ describe('BaseSection', () => {
       });
     }
 
-    it('offers the toggle while the labs flag is on', () => {
-      setScrewFlag(true);
+    it('offers the toggle', () => {
       render(<BaseSection />);
       expect(screen.getByText('baseplate.screwHoles.label')).toBeInTheDocument();
     });
 
-    it('hides the toggle while the labs flag is off', () => {
-      setScrewFlag(false);
+    // The flag graduated, so a stored opt-out is dead state that
+    // `isFeatureEnabled` short-circuits past. Reverting the status to
+    // 'experimental' would hide the control again from anyone carrying this.
+    it('offers the toggle even to a user whose stored opt-in says false', () => {
+      useLabsStore.setState((s) => ({
+        preferences: {
+          ...s.preferences,
+          enabledFeatures: { ...s.preferences.enabledFeatures, baseplate_screw_holes: false },
+        },
+      }));
       render(<BaseSection />);
-      expect(screen.queryByText('baseplate.screwHoles.label')).not.toBeInTheDocument();
+      expect(screen.getByText('baseplate.screwHoles.label')).toBeInTheDocument();
     });
 
     it('hides the toggle while stacking, which strips the screws', () => {
-      setScrewFlag(true);
       useLayoutStore.getState().setBaseplateParams({
         ...DEFAULT_BASEPLATE_PARAMS,
         stackPrint: { enabled: true, copies: 2, gapMm: mm(0.2) },
@@ -177,7 +174,6 @@ describe('BaseSection', () => {
     });
 
     it('writes the defaults through to the layout store on toggle', () => {
-      setScrewFlag(true);
       render(<BaseSection />);
       fireEvent.click(screen.getByRole('switch', { name: 'baseplate.screwHoles.label' }));
       expect(useLayoutStore.getState().layout.baseplateParams?.screwHoles).toEqual({
@@ -188,7 +184,6 @@ describe('BaseSection', () => {
     });
 
     it('adds the screw summary to the section header beside the magnet one', () => {
-      setScrewFlag(true);
       useLayoutStore.getState().setBaseplateParams({
         ...DEFAULT_BASEPLATE_PARAMS,
         magnetHoles: true,
@@ -201,14 +196,12 @@ describe('BaseSection', () => {
     });
 
     it('shows the counterbore depth only for a counterbore head', () => {
-      setScrewFlag(true);
       enableScrews('counterbore');
       render(<BaseSection />);
       expect(screen.getByText('baseplate.screwHoles.counterboreDepth.label')).toBeInTheDocument();
     });
 
     it('hides the counterbore depth for a countersink head, whose depth is derived', () => {
-      setScrewFlag(true);
       enableScrews('countersink');
       render(<BaseSection />);
       expect(screen.getByText('baseplate.screwHoles.headDiameter.label')).toBeInTheDocument();

--- a/src/features/labs/README.md
+++ b/src/features/labs/README.md
@@ -38,6 +38,7 @@ Internal status enum values → UI badge labels: `experimental` → "Early acces
 | `item_kinds`            | `experimental`  | Non-bin items (tool racks) that sit on a baseplate                        |
 | `community_fits_gap`    | `experimental`  | Select a layout gap and browse community designs that fit it              |
 | `sliding_tray`          | `experimental`  | Rail-and-tray sliding insert in the bin designer's Walls section          |
+| `merge_bins_to_design`  | `experimental`  | Bento: merge selected layout bins into one divided tray                   |
 | `community_showcase`    | `preview`       | Publish and remix bin designs in the community showcase                   |
 | `drawer_shapes`         | `graduated`     | Non-rectangular drawer shapes (L-shapes, notches, cut corners)            |
 | `bin_designer`          | `graduated`     | Custom bin designer                                                       |
@@ -52,6 +53,7 @@ Internal status enum values → UI badge labels: `experimental` → "Early acces
 | `stl_bin_import`        | `graduated`     | Import a Gridfinity bin STL as a view-only design                         |
 | `bin_recommender`       | `graduated`     | Suggested bin size from the label, in the bin inspector                   |
 | `layout_overhang`       | `graduated`     | Edge bins extend into the drawer-fit margin                               |
+| `baseplate_screw_holes` | `graduated`     | Mount-down screw holes through every printed baseplate piece              |
 
 Kernel selection priority in `BridgeManager`/`WorkerPoolManager` is `brepkit > default (occt-wasm)`; `EngineSelector` drives the flag in the UI.
 


### PR DESCRIPTION
Mount-down screw holes ship to everyone. `baseplate_screw_holes` goes `experimental` → `graduated` (`graduatedAt: '2026-08'`).

## Why this one is safe to graduate

- **The gate is presentational.** `BaseSection.tsx:79` uses the flag only to decide whether to render the control. The geometry reads `baseplateParams.screwHoles`, so removing the gate exposes a control and changes no existing baseplate.
- **Both generation paths are tested.** `baseplateScrews.test.ts` covers the exact path, `baseplateDirectMesh.test.ts` covers the draft path via `directMeshScrews.ts`. Draft/exact divergence is what usually bites a geometry feature on graduation.
- **No persistence gap.** Baseplate params don't route through `ALLOWED_PARAM_KEYS` in `api/lib/designerValidation.ts`, so there is no allowlist to forget.

## Decisions worth reviewing

**The labs `warning` is dropped, not carried.** `GraduatedSection.tsx` renders only a feature's `name` and a fixed "now available" line, so a graduated flag's warning is never shown. The substance it carried (holes sit in the pocket floor where the padding is too narrow, which makes the plate slightly taller) already lives in `baseplate.screwHoles.info` beside the control. The remaining sentence was generic print advice; adding it to the panel copy would mean re-translating 14 locales for marginal gain.

**The runtime check stays**, per the graduate recipe, so the status flip alone is reversible.

**No localStorage cleanup.** A stored opt-in goes inert on its own: `getEnabledCount` (`labs.ts:215`) and `computeLabsMetrics` (`metrics.ts:29`) both filter on status, so a leftover `true` stops counting toward the labs badge. That cleanup is a *removal* requirement, not a graduation one.

## Tests

Two flag-gating tests in `BaseSection.test.tsx` could no longer express anything, since the flag can't be off. Replaced with one that pins the graduation invariant: the control shows even for a user carrying a stored `false`, which is what a status revert would silently break. Every behavioral test (stacking strips the screws, defaults write-through, header summary, counterbore vs countersink) is unchanged.

Also fills in two rows the labs README table never got, for this flag and for `merge_bins_to_design`.

## Verification

- `pnpm run typecheck` clean
- `pnpm run test:run src/features/baseplate src/core/labs src/core/store/labs.test.ts src/features/labs` — 90 files, 1152 tests pass
- Pre-commit gates all pass (boundaries, 4 i18n checks, exhaustiveness, design system)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount-down screw holes now ship to everyone by graduating `baseplate_screw_holes`. The UI gate is removed; geometry still reads `baseplateParams.screwHoles`, so no existing baseplates change.

- **Refactors**
  - Set status to `graduated` with `graduatedAt: '2026-08'`; removed the labs warning copy.
  - Kept the runtime labs check for easy rollback.
  - Updated `BaseSection.test.tsx` to assert the control is always shown, even with a stored opt-out; removed obsolete gate tests.
  - Added README entries for `merge_bins_to_design` and `baseplate_screw_holes`.

<sup>Written for commit 139c36b5b69c249a5f74e37e4211e1c9d993d3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

