### PR TITLE
chore(deps): bump brepkit-wasm to 3.2.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.8",
-    "brepkit-wasm": "3.2.24",
+    "brepkit-wasm": "3.2.28",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.124.8
-        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.24)(occt-wasm@4.2.0)
+        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.28)(occt-wasm@4.2.0)
       brepkit-wasm:
-        specifier: 3.2.24
-        version: 3.2.24
+        specifier: 3.2.28
+        version: 3.2.28
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3202,8 +3202,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@3.2.24:
-    resolution: {integrity: sha512-DGWVekbdnAwcSxA336G5tGh74PlSosoSEebsWs2WwDvi+G5q4Jld5NhyfHifkXkVZLH5fmw0oH+CrskZ8VOoWA==}
+  brepkit-wasm@3.2.28:
+    resolution: {integrity: sha512-GJK6m/jt/HXO77yVYzocUMif5UTS8woiu25FDnu7P2qNmLtNAY3qBYkQiI3WvJsuCZUm5eqv8Pvp3gX6te3buw==}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -8717,15 +8717,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.24)(occt-wasm@4.2.0):
+  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.28)(occt-wasm@4.2.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 3.2.24
+      brepkit-wasm: 3.2.28
       occt-wasm: 4.2.0
 
-  brepkit-wasm@3.2.24: {}
+  brepkit-wasm@3.2.28: {}
 
   browserslist@4.28.7:
     dependencies:


### PR DESCRIPTION
Follow-up to #3441 (merged at 3.2.24). Picks up the interface-family winding and cap-synthesis fixes (brepkit#1546, #1548, #1550, #1552): insert and cutout scenarios with pockets or through-cuts reaching a coplanar interface now produce strictly valid winding, and the deep-cutout chain is exact end to end. Kernel-side: the 26-row parity matrix and the full brepkit workspace (2745 tests) are green on 3.2.28.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `brepkit-wasm` to 3.2.28 to pull in geometry fixes for insert and cutout operations. This enforces valid winding at coplanar interfaces and makes deep cutout chains exact end to end.

<sup>Written for commit c452137ba60ad47f15eca9a93d782e39428c9506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

