### PR TITLE
fix(generation): namespace the persisted mesh cache by kernel

### DIFF
--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -49,7 +49,7 @@ const mockSavePersisted = vi.fn<(key: string, mesh: MeshData) => void>();
 vi.mock('@/shared/generation/meshPersistence', () => ({
   // Param- and kernel-sensitive, so both the stale-params guard in the mount
   // pre-draft and the per-kernel namespacing (#3444) are testable.
-  binMeshCacheKey: (p: { width: number }, kernel: string) => `test-key-${kernel}-${p.width}`,
+  binMeshCacheKey: (p: { width: number }, kernel: KernelName) => `test-key-${kernel}-${p.width}`,
   loadPersistedBinMesh: () => mockLoadPersisted(),
   savePersistedBinMesh: (key: string, mesh: MeshData) => mockSavePersisted(key, mesh),
 }));

--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useGeneration } from './useGeneration';
 import { useDesignerStore } from '../store';
 import { DEFAULT_GENERATION_STATE } from '../constants';
-import type { GenerationBridge } from '@/shared/generation/bridge';
+import type { GenerationBridge, KernelName } from '@/shared/generation/bridge';
 import type { MeshData } from '@/shared/types/generation';
 
 // Mock bridgeManager to isolate tests from the singleton
@@ -23,6 +23,7 @@ const mockRelease = vi.fn();
 const mockGet = vi.fn<() => GenerationBridge | null>();
 const mockAcquirePreview = vi.fn<() => Promise<GenerationBridge | null>>();
 const mockReleasePreview = vi.fn();
+let mockActiveKernel: KernelName = 'occt-wasm';
 
 vi.mock('@/shared/generation/bridge', () => ({
   bridgeManager: {
@@ -34,6 +35,7 @@ vi.mock('@/shared/generation/bridge', () => ({
   },
   GenerationBridge: vi.fn(),
   getActiveBridge: vi.fn(),
+  getActiveKernel: () => mockActiveKernel,
   FAST_EXACT_SKIP_MS: 1000,
   // Stable threshold — burst behavior is covered by draftPolicy's own tests.
   createDraftSkipGate: () => () => 1000,
@@ -45,8 +47,9 @@ const mockLoadPersisted = vi.fn<() => Promise<MeshData | null>>();
 const mockSavePersisted = vi.fn<(key: string, mesh: MeshData) => void>();
 
 vi.mock('@/shared/generation/meshPersistence', () => ({
-  // Param-sensitive so the stale-params guard in the mount pre-draft is testable.
-  binMeshCacheKey: (p: { width: number }) => `test-key-${p.width}`,
+  // Param- and kernel-sensitive, so both the stale-params guard in the mount
+  // pre-draft and the per-kernel namespacing (#3444) are testable.
+  binMeshCacheKey: (p: { width: number }, kernel: string) => `test-key-${kernel}-${p.width}`,
   loadPersistedBinMesh: () => mockLoadPersisted(),
   savePersistedBinMesh: (key: string, mesh: MeshData) => mockSavePersisted(key, mesh),
 }));
@@ -88,6 +91,7 @@ describe('useGeneration', () => {
     mockLoadPersisted.mockReset();
     mockLoadPersisted.mockResolvedValue(null); // no persisted mesh by default
     mockSavePersisted.mockReset();
+    mockActiveKernel = 'occt-wasm';
     // Unknown estimate = slow → the draft path stays active unless a test
     // explicitly predicts a fast exact.
     (mockBridge.estimateGenerate as ReturnType<typeof vi.fn>).mockReset();
@@ -467,6 +471,21 @@ describe('useGeneration', () => {
     expect(key).toMatch(/^test-key-/);
     // The raw bridge mesh (not the store payload) is what gets persisted.
     expect(mesh.vertices).toEqual(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]));
+  });
+
+  // #3444: the persisted entry must be namespaced by the kernel that built it,
+  // or a Labs engine switch serves the other engine's mesh for unchanged params.
+  it('persists under a key namespaced by the active kernel', async () => {
+    mockActiveKernel = 'brepkit';
+    renderHook(() => useGeneration());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(201);
+    });
+
+    const [key] = mockSavePersisted.mock.calls[0];
+    expect(key).toContain('brepkit');
   });
 
   it('paints a persisted mesh as a pre-draft while the exact worker loads', async () => {

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -3,7 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { isErr } from '@/core/result';
 import { useDesignerStore } from '../store';
 import { useSettingsStore } from '@/core/store';
-import { bridgeManager, createDraftSkipGate } from '@/shared/generation/bridge';
+import { bridgeManager, createDraftSkipGate, getActiveKernel } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
 import { generateBinDirect, canBinUseDirectMesh } from '@/shared/generation/directMesh';
 import { handleWasmLoadFailure } from '@/shared/generation/captureWasmLoadFailure';
@@ -288,7 +288,10 @@ export function useGeneration(): void {
         // entry the layout later reads back — the designer rebuilds them cheaply
         // on the next generation.
         const { labelPlates, ...withoutPlates } = result.mesh;
-        savePersistedBinMesh(binMeshCacheKey(genParams), labelPlates ? withoutPlates : result.mesh);
+        savePersistedBinMesh(
+          binMeshCacheKey(genParams, getActiveKernel()),
+          labelPlates ? withoutPlates : result.mesh
+        );
 
         // Once the user pauses, speculatively warm the export-quality shell so
         // the first export skips the deferred socket↔body fuse. (Any prior timer
@@ -372,7 +375,10 @@ export function useGeneration(): void {
       // Match the nozzle-merged key the exact mesh was persisted under, so a
       // socket bin on a wide nozzle still finds its saved pre-draft.
       const nozzle = useSettingsStore.getState().settings.printSettings.nozzleSizeMm;
-      const initialKey = binMeshCacheKey(withSocketNozzle(initialState.params, nozzle));
+      // Same kernel the bridge below is about to be constructed with, so the
+      // pre-draft only matches a mesh THIS engine persisted (#3444).
+      const kernel = getActiveKernel();
+      const initialKey = binMeshCacheKey(withSocketNozzle(initialState.params, nozzle), kernel);
       void loadPersistedBinMesh(initialKey).then((cached) => {
         if (cancelled || !cached) return;
         if (genTokenRef.current !== 0 || finalizedTokenRef.current > 0) return;
@@ -382,7 +388,7 @@ export function useGeneration(): void {
         const now = useDesignerStore.getState();
         if (
           now.itemKind !== 'bin' ||
-          binMeshCacheKey(withSocketNozzle(now.params, nozzle)) !== initialKey
+          binMeshCacheKey(withSocketNozzle(now.params, nozzle), kernel) !== initialKey
         )
           return;
         // Claim the generation token before painting. The Manifold pre-draft

--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -109,7 +109,7 @@ Composable stages in `pipeline/stages/`, orchestrated by `pipeline/runner.ts`:
 
 ## Cross-session mesh cache
 
-All the caches above are **in-memory only** — they vanish on reload. `src/shared/generation/meshPersistence.ts` (main thread) additionally persists the final bin-designer preview `MeshData` to IndexedDB, keyed by a hash of `BinParams` + `MESH_CACHE_VERSION`, so reopening a saved custom bin paints last session's exact mesh instantly (as a pre-draft in `useGeneration`) while the worker warms up and regenerates. Preview-only — exports always regenerate the watertight fused shell. **Bump `MESH_CACHE_VERSION` on any brepjs/occt-wasm or tessellation change** (see the geometry-generation skill).
+All the caches above are **in-memory only** — they vanish on reload. `src/shared/generation/meshPersistence.ts` (main thread) additionally persists the final bin-designer preview `MeshData` to IndexedDB, keyed by a hash of `BinParams` + `MESH_CACHE_VERSION` + the active kernel and its `KERNEL_MESH_REVISION`, so reopening a saved custom bin paints last session's exact mesh instantly (as a pre-draft in `useGeneration`) while the worker warms up and regenerates. Preview-only — exports always regenerate the watertight fused shell. **Bump `KERNEL_MESH_REVISION[kernel]` on a kernel upgrade (brepjs/occt-wasm, brepkit-wasm) and `MESH_CACHE_VERSION` on a tessellation or kernel-independent geometry change** (see the geometry-generation skill).
 
 ## Worker Protocol
 

--- a/src/shared/generation/bridge.ts
+++ b/src/shared/generation/bridge.ts
@@ -41,3 +41,4 @@ export type {
   LabelPlateExportSpec,
 } from '@/features/generation/bridge/types';
 export type { MeshImportOutcome } from '@/features/generation/bridge/bridgeTypes';
+export type { KernelName } from '@/features/generation/bridge/types';

--- a/src/shared/generation/meshPersistence.test.ts
+++ b/src/shared/generation/meshPersistence.test.ts
@@ -46,22 +46,42 @@ afterEach(() => {
 
 describe('binMeshCacheKey', () => {
   it('is stable regardless of param key order', () => {
-    const a = binMeshCacheKey({ ...DEFAULT_BIN_PARAMS });
+    const a = binMeshCacheKey({ ...DEFAULT_BIN_PARAMS }, 'occt-wasm');
     const reordered = Object.fromEntries(
       Object.entries(DEFAULT_BIN_PARAMS).reverse()
     ) as typeof DEFAULT_BIN_PARAMS;
-    const b = binMeshCacheKey(reordered);
+    const b = binMeshCacheKey(reordered, 'occt-wasm');
     expect(a).toBe(b);
   });
 
   it('changes when any param changes', () => {
-    const base = binMeshCacheKey(DEFAULT_BIN_PARAMS);
-    const wider = binMeshCacheKey({ ...DEFAULT_BIN_PARAMS, width: DEFAULT_BIN_PARAMS.width + 1 });
+    const base = binMeshCacheKey(DEFAULT_BIN_PARAMS, 'occt-wasm');
+    const wider = binMeshCacheKey(
+      { ...DEFAULT_BIN_PARAMS, width: DEFAULT_BIN_PARAMS.width + 1 },
+      'occt-wasm'
+    );
     expect(wider).not.toBe(base);
   });
 
   it('is prefixed with the cache version so a bump orphans old keys', () => {
-    expect(binMeshCacheKey(DEFAULT_BIN_PARAMS)).toMatch(/^v\d/);
+    expect(binMeshCacheKey(DEFAULT_BIN_PARAMS, 'occt-wasm')).toMatch(/^v\d/);
+  });
+
+  // #3444: the two engines wrote unchanged params into one namespace, so
+  // switching kernels in Labs served the previous engine's mesh.
+  it('gives each kernel its own namespace for identical params', () => {
+    const occt = binMeshCacheKey(DEFAULT_BIN_PARAMS, 'occt-wasm');
+    const brepkit = binMeshCacheKey(DEFAULT_BIN_PARAMS, 'brepkit');
+    expect(brepkit).not.toBe(occt);
+  });
+
+  it('does not cross-hit between kernels through the store', async () => {
+    const occtKey = binMeshCacheKey(DEFAULT_BIN_PARAMS, 'occt-wasm');
+    const brepkitKey = binMeshCacheKey(DEFAULT_BIN_PARAMS, 'brepkit');
+    await saveMesh(occtKey, makeMesh());
+
+    expect(await loadPersistedBinMesh(occtKey)).not.toBeNull();
+    expect(await loadPersistedBinMesh(brepkitKey)).toBeNull();
   });
 });
 

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -7,8 +7,9 @@
  * generation pipeline. The tessellated preview mesh is deterministic for a given
  * set of params (tolerance is a pure function of dimensions at `forExport=false`)
  * and `MeshData` is structured-clone-serializable, so we persist it in IndexedDB
- * keyed by a hash of the params. On the next open the exact mesh paints in tens
- * of ms as a pre-draft while the worker warms up and regenerates to confirm it.
+ * keyed by a hash of the params plus the kernel that produced them. On the next
+ * open the exact mesh paints in tens of ms as a pre-draft while the worker warms
+ * up and regenerates to confirm it.
  *
  * This is a fast pre-paint only — never a source of truth. Exports always
  * regenerate (they need the watertight fused shell), so a stale entry can never
@@ -19,6 +20,7 @@
 import { openDB } from 'idb';
 import type { IDBPDatabase } from 'idb';
 import type { BinParams } from '@/shared/types/bin';
+import type { KernelName } from '@/shared/generation/bridge';
 import type { MeshData } from '@/shared/types/generation';
 import { createLogger } from '@/core/logger';
 
@@ -32,17 +34,19 @@ const BIN_MESHES_STORE = 'binMeshes';
 const META_STORE = 'binMeshMeta';
 
 /**
- * Bumped whenever the generated mesh bytes can change for the same params —
- * a brepjs/occt-wasm upgrade, a tessellation-tolerance change, or a geometry
- * fix. A bump changes every key, so old entries never match again and are
- * evicted by the LRU budget. The kernel id is NOT part of the per-entry key,
- * so the occt-wasm default and the brepkit Labs kernel (`brepkit_kernel`)
- * share one namespace — a fix on either side has to bump this constant.
+ * Bumped whenever the generated mesh bytes can change for the same params on
+ * EVERY kernel — a tessellation-tolerance change, or a geometry fix in the
+ * kernel-independent pipeline. A bump changes every key, so old entries never
+ * match again and are evicted by the LRU budget. For a change that only moves
+ * one kernel's output, bump that kernel's {@link KERNEL_MESH_REVISION} entry
+ * instead, so the other kernel's users keep their warm cache.
  *
+ * `v10`: the kernel id joined the key (#3444). Before this, occt-wasm and the
+ * brepkit Labs kernel shared one namespace, so switching engines in Labs served
+ * the previous engine's mesh for unchanged params.
  * `v9`: brepkit-wasm 3.2.24 reattaches splitter holes, so a slotted no-lip bin
  * gets back the cavity it was rendering solid. Only the Labs kernel's output
- * moved (the occt-wasm scenario snapshots are unchanged across brepjs
- * 18.124.8), but one namespace covers both.
+ * moved, but one namespace covered both — the last bump that had to.
  * `v8`: label-tab keep-outs on patterned dividers follow `inset` and the
  * anchor edge, so a bin with either cuts a different divider pattern.
  * `v7`: label tabs stopped being forced full-width in socket mode (#3402), so
@@ -50,7 +54,27 @@ const META_STORE = 'binMeshMeta';
  * without regenerating, so without this bump a linked design in the layout
  * planner would render its pre-fix bin until the entry was evicted.
  */
-const MESH_CACHE_VERSION = 'v9-brepjs18.124.8';
+const MESH_CACHE_VERSION = 'v10';
+
+/**
+ * Per-kernel revision, bumped when only THAT kernel's output moves for
+ * unchanged params — a brepkit-wasm or occt-wasm upgrade, or a fix in a
+ * kernel-specific code path. Bumping one leaves the other kernel's namespace
+ * (and its warm entries) untouched.
+ *
+ * occt-wasm `r1`: brepjs 18.124.8.
+ * brepkit `r1`: brepkit-wasm 3.2.28 — the interface-family winding and
+ * cap-synthesis fixes move insert/cutout output that reaches a coplanar
+ * interface, and the deep-cutout chain is now exact.
+ *
+ * `manifold` is the draft-preview kernel; its meshes are never persisted, but
+ * the map is total so a future caller cannot fall through to `undefined`.
+ */
+const KERNEL_MESH_REVISION: Record<KernelName, string> = {
+  'occt-wasm': 'r1',
+  brepkit: 'r1',
+  manifold: 'r1',
+};
 
 /** Evict oldest entries once the total stored mesh bytes exceed this budget. */
 let maxCacheBytes = 64 * 1024 * 1024;
@@ -149,9 +173,19 @@ function djb2(str: string): string {
   return (hash >>> 0).toString(16);
 }
 
-/** Content-addressed cache key for a bin's preview mesh. */
-export function binMeshCacheKey(params: BinParams): string {
-  return `${MESH_CACHE_VERSION}:${djb2(stableStringify(params))}`;
+/**
+ * Content-addressed cache key for a bin's preview mesh, namespaced by the
+ * kernel that generated it.
+ *
+ * `kernel` is required rather than resolved here: the same params produce
+ * different bytes on each kernel, and a caller that reads a key it did not
+ * generate under gets the other engine's mesh (#3444). Pass `getActiveKernel()`
+ * from `@/shared/generation/bridge` — the bridge is constructed from the same
+ * resolution, and the Labs engine toggle forces a reload before it can change.
+ */
+export function binMeshCacheKey(params: BinParams, kernel: KernelName): string {
+  const revision = KERNEL_MESH_REVISION[kernel];
+  return `${MESH_CACHE_VERSION}:${kernel}-${revision}:${djb2(stableStringify(params))}`;
 }
 
 /** Sum the byte length of every typed array reachable from a mesh (incl. lid + connector). */

--- a/src/shared/hooks/useLinkedDesignMeshes.test.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.test.ts
@@ -18,7 +18,10 @@ import {
 import { decodeMeshData } from '@/shared/generation/meshAsset';
 import { loadPersistedBinMesh, savePersistedBinMesh } from '@/shared/generation/meshPersistence';
 import { bridgeManager } from '@/shared/generation/bridge';
+import type { KernelName } from '@/shared/generation/bridge';
 import type { MeshData } from '@/shared/types/generation';
+
+let mockActiveKernel: KernelName = 'occt-wasm';
 
 vi.mock('@/features/bin-designer', () => ({
   loadDesign: vi.fn(),
@@ -30,13 +33,15 @@ vi.mock('@/shared/generation/meshAsset', () => ({
 }));
 
 vi.mock('@/shared/generation/meshPersistence', () => ({
-  binMeshCacheKey: vi.fn(() => 'persist-key'),
+  // Kernel-sensitive so the per-kernel namespacing (#3444) is observable.
+  binMeshCacheKey: vi.fn((_p: unknown, kernel: string) => `persist-key-${kernel}`),
   loadPersistedBinMesh: vi.fn(async () => null),
   savePersistedBinMesh: vi.fn(),
 }));
 
 vi.mock('@/shared/generation/bridge', () => ({
   bridgeManager: { acquire: vi.fn(), release: vi.fn() },
+  getActiveKernel: () => mockActiveKernel,
 }));
 
 const mockLoadDesign = vi.mocked(loadDesign);
@@ -124,6 +129,7 @@ describe('useLinkedDesignMeshes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearLinkedDesignMeshCache();
+    mockActiveKernel = 'occt-wasm';
     mockUseCustomBins.mockReturnValue([]);
     mockLoadPersistedBinMesh.mockResolvedValue(null);
   });
@@ -172,8 +178,30 @@ describe('useLinkedDesignMeshes', () => {
       // being re-wrapped by the strip.
       expect(result.current.get(D1)?.mesh).toBe(mesh);
     });
-    expect(mockSavePersistedBinMesh).toHaveBeenCalledWith('persist-key', mesh);
+    expect(mockSavePersistedBinMesh).toHaveBeenCalledWith('persist-key-occt-wasm', mesh);
     expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
+  // #3444: this reader returns a persisted hit and stops, with no regeneration
+  // behind it, so a key shared across engines would strand the other engine's
+  // mesh in the layout preview until LRU eviction.
+  it('reads and writes under a key namespaced by the active kernel', async () => {
+    const mesh = makeMesh();
+    mockActiveKernel = 'brepkit';
+    mockUseCustomBins.mockReturnValue([makeRegistryRef()]);
+    mockLoadDesign.mockResolvedValue(ok(makeBinDesign()));
+    mockAcquire.mockResolvedValue({
+      generateImmediate: vi.fn(async () => ({ mesh })),
+    } as unknown as Awaited<ReturnType<typeof bridgeManager.acquire>>);
+
+    const bins = [createTestBin({ linkedDesignId: D1 })];
+    const { result } = renderHook(() => useLinkedDesignMeshes(bins));
+
+    await waitFor(() => {
+      expect(result.current.get(D1)?.mesh).toBe(mesh);
+    });
+    expect(mockLoadPersistedBinMesh).toHaveBeenCalledWith('persist-key-brepkit');
+    expect(mockSavePersistedBinMesh).toHaveBeenCalledWith('persist-key-brepkit', mesh);
   });
 
   // Label plates are a bin-designer affordance and aren't requested here, but

--- a/src/shared/hooks/useLinkedDesignMeshes.test.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.test.ts
@@ -34,7 +34,7 @@ vi.mock('@/shared/generation/meshAsset', () => ({
 
 vi.mock('@/shared/generation/meshPersistence', () => ({
   // Kernel-sensitive so the per-kernel namespacing (#3444) is observable.
-  binMeshCacheKey: vi.fn((_p: unknown, kernel: string) => `persist-key-${kernel}`),
+  binMeshCacheKey: vi.fn((_p: unknown, kernel: KernelName) => `persist-key-${kernel}`),
   loadPersistedBinMesh: vi.fn(async () => null),
   savePersistedBinMesh: vi.fn(),
 }));

--- a/src/shared/hooks/useLinkedDesignMeshes.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.ts
@@ -8,8 +8,8 @@
  *   main thread and re-framed to the preview convention (XY-centered, Z=0
  *   bottom), exactly like the worker's `importedMeshItem.generate`.
  * - `bin` (params): the cross-session IndexedDB mesh cache is tried first
- *   (`meshPersistence`, keyed by params hash — instant for any design the
- *   user has opened); on a miss the mesh is generated in the background via
+ *   (`meshPersistence`, keyed by params hash + active kernel — instant for any
+ *   design the user has opened); on a miss the mesh is generated via
  *   the shared generation bridge and persisted back for next time.
  *
  * Designs resolve sequentially through a module-level queue (the worker is
@@ -28,7 +28,7 @@ import {
   loadPersistedBinMesh,
   savePersistedBinMesh,
 } from '@/shared/generation/meshPersistence';
-import { bridgeManager } from '@/shared/generation/bridge';
+import { bridgeManager, getActiveKernel } from '@/shared/generation/bridge';
 import { withSocketNozzle } from '@/shared/generation/socketNozzle';
 import { useSettingsStore } from '@/core/store';
 import type { MeshData } from '@/shared/types/generation';
@@ -143,7 +143,9 @@ async function resolveDesignMesh(
   // Nozzle-merged (transient) so a socket bin's pocket matches the live print
   // setting and shares the same cache key the designer preview persists under.
   const genParams = withSocketNozzle(params, nozzleSizeMm);
-  const persistKey = binMeshCacheKey(genParams);
+  // Kernel-namespaced: this reader returns a hit and stops, with no regeneration
+  // behind it, so a cross-engine hit would survive until LRU eviction (#3444).
+  const persistKey = binMeshCacheKey(genParams, getActiveKernel());
   const persisted = await loadPersistedBinMesh(persistKey);
   if (persisted) {
     return { sig, mesh: persisted, width: params.width, depth: params.depth };


### PR DESCRIPTION
Fixes #3444.

`binMeshCacheKey` hashed the bin params and nothing else, so occt-wasm and the brepkit Labs kernel wrote their persisted preview meshes into one namespace. After switching engines in Labs, a bin whose params had not changed was served the previous engine's mesh.

The two readers behaved differently, which is why this showed up in the layout planner:

- Designer (`useGeneration`) paints the hit as a pre-draft and the exact generation supersedes it. Self-correcting.
- Linked design (`useLinkedDesignMeshes`) returns the hit and stops, with no regeneration behind it. The cross-engine mesh survived until LRU eviction under the 64MB budget.

## Change

`binMeshCacheKey(params, kernel)` now takes the kernel as a required `KernelName`. It is a parameter rather than a store read inside `meshPersistence` for two reasons: the module stays pure (no bridge or labs-store coupling), and the type system forces every present and future call site to name a kernel, which is exactly what the original omission failed to do. All three call sites pass `getActiveKernel()`.

Per-kernel revisions split out of `MESH_CACHE_VERSION`, which was doing double duty as the kernel discriminator. A brepkit-only geometry fix no longer invalidates every occt-wasm user's cache; `KERNEL_MESH_REVISION[kernel]` covers that on its own.

## Scope

Labs only, and preview only. `brepkit_kernel` is `status: experimental` / `risk: high`. Exports always regenerate, so this was never a wrong printed model.

The key format change orphans existing entries once; they age out under the LRU budget.

## Verification

New tests fail against the old key construction (verified by reverting the key body):

- `meshPersistence.test.ts`: distinct keys per kernel, and no cross-hit through a real IndexedDB round-trip.
- `useGeneration.test.ts`: the persisted key carries the active kernel.
- `useLinkedDesignMeshes.test.ts`: both the read and the write are kernel-namespaced.

1411 tests pass across `src/shared/generation`, `src/shared/hooks`, `src/features/bin-designer/hooks`, `src/features/generation/bridge`. Typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Namespaces the persisted preview mesh cache by kernel to prevent cross-engine hits when switching between `occt-wasm` and `brepkit` in Labs. Fixes #3444 so the layout planner no longer serves a mesh from the wrong engine.

- **Bug Fixes**
  - `binMeshCacheKey(params, kernel)` now requires a kernel and builds keys from `MESH_CACHE_VERSION` + kernel + per-kernel revision + params hash.
  - All call sites pass `getActiveKernel()` (designer preview and linked-design reader).
  - Added `KERNEL_MESH_REVISION[kernel]` and bumped `MESH_CACHE_VERSION` to `v10`; kernel-only changes no longer invalidate other kernels’ caches.
  - Existing entries are orphaned once and will be evicted by the LRU; exports still always regenerate.
  - Tests cover per-kernel keys and no cross-hits through IndexedDB; mocks are typed as `KernelName` to enforce the required kernel argument.

<sup>Written for commit 4fe88363ca793f9bc6976f7ef80403e2e750acd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

