### PR TITLE
fix(export): disable STEP for designs with mesh imprint cutouts (#3449)

### DIFF
--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
@@ -446,6 +446,86 @@ describe('ExportDialog', () => {
     });
   });
 
+  // A mesh imprint is subtracted from the tessellated mesh, so there is no BREP
+  // solid for STEP to carry and `binExporter` throws outright. Offering STEP
+  // anyway turned a known limitation into a failed download and an auto-filed
+  // issue (#3449).
+  describe('mesh imprint cutouts', () => {
+    function setupImprintOpen(open: boolean, format: 'stl' | 'step' | '3mf'): void {
+      setupStore({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          cutouts: [
+            {
+              id: 'c1',
+              shape: 'mesh',
+              meshId: 'a1',
+              x: 10,
+              y: 10,
+              width: 10,
+              depth: 10,
+              cutDepth: 5,
+              rotation: 0,
+              cornerRadius: 0,
+              label: '',
+              groupId: null,
+            },
+          ],
+          meshAssets: {
+            a1: {
+              name: 'spanner',
+              data: 'x',
+              triangleCount: 12,
+              sizeMm: { x: 10, y: 10, z: 5 },
+              outlines: [],
+            },
+          },
+        },
+        exportFileNameConfig: { ...DEFAULT_EXPORT_FILE_NAME_CONFIG, format },
+        ui: {
+          ...DEFAULT_UI_STATE,
+          activeTab: 'dimensions',
+          exportDialogOpen: open,
+          wireframeMode: false,
+          designListOpen: false,
+          halfGridMode: false,
+        },
+      });
+    }
+
+    it('disables the STEP radio and leaves STL and 3MF alone', () => {
+      setupImprintOpen(true, 'stl');
+      render(<ExportDialog />);
+      expect(screen.getByRole('radio', { name: 'STEP' })).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByRole('radio', { name: 'STL' })).not.toHaveAttribute('aria-disabled');
+      expect(screen.getByRole('radio', { name: '3MF' })).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('switches a design saved as STEP over to STL on open', () => {
+      setupImprintOpen(false, 'step');
+      const { rerender } = render(<ExportDialog />);
+      act(() => setupImprintOpen(true, 'step'));
+      rerender(<ExportDialog />);
+      expect(useDesignerStore.getState().exportFileNameConfig.format).toBe('stl');
+    });
+
+    it('leaves STEP selectable when the only mesh cutout is hidden', () => {
+      // `hidden` cutouts are not cut, so the solid is complete and STEP is
+      // genuinely available — the gate has to track what gets subtracted, not
+      // what is merely listed.
+      setupImprintOpen(true, 'step');
+      const params = useDesignerStore.getState().params;
+      expect(params.cutouts).toHaveLength(1);
+      act(() => {
+        useDesignerStore.setState({
+          params: { ...params, cutouts: [{ ...params.cutouts[0], hidden: true }] },
+        });
+      });
+      render(<ExportDialog />);
+      expect(screen.getByRole('radio', { name: 'STEP' })).not.toHaveAttribute('aria-disabled');
+    });
+  });
+
   describe('publish nudge', () => {
     beforeEach(() => {
       localStorage.clear();

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
@@ -27,6 +27,7 @@ import { loadDesign } from '@/features/bin-designer/storage/DesignerStorage';
 import { designId } from '@/core/types';
 import { isOk } from '@/core/result';
 import { getSTLFileSize, estimate3MFFileSize } from '@/shared/generation/export';
+import { hasMeshImprints } from '@/shared/generation/meshAsset';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
 import {
@@ -105,34 +106,52 @@ export function ExportDialog() {
     return !isSingleColor(params.featureColors, computeActiveZones(params));
   }, [params]);
 
-  // Auto-switch to 3MF the first time the dialog opens on a multi-color
-  // design with a colorless format selected. Tracked by a ref so we only
-  // do it on the open transition, not while the user is inside the dialog
-  // (they may deliberately pick STL/STEP after seeing the disabled state).
+  // A mesh imprint is carved out of the tessellated mesh, after the BREP solid
+  // exists, so there is no solid that describes the design and `binExporter`
+  // refuses STEP outright. Left selectable it reads as an ordinary option and
+  // fails at download with an error toast and a filed issue (#3449).
+  const hasImprints = useMemo(() => hasMeshImprints(params), [params]);
+
+  // Auto-switch away from a format this design cannot produce, on the open
+  // transition only — tracked by a ref so we don't fight the user while they
+  // are inside the dialog (they may deliberately land on a disabled format to
+  // read why). Multi-color prefers 3MF, which is the format that carries the
+  // colors; an imprint only rules out STEP, so STL is the smaller move.
   const prevOpenRef = useRef(exportDialogOpen);
   useEffect(() => {
     const justOpened = exportDialogOpen && !prevOpenRef.current;
     prevOpenRef.current = exportDialogOpen;
     // Re-opening the dialog always returns to the form, never a stale success view.
-    if (justOpened) setJustExported(false);
-    if (
-      justOpened &&
-      isMultiColor &&
-      (exportFileNameConfig.format === 'stl' || exportFileNameConfig.format === 'step')
-    ) {
+    if (!justOpened) return;
+    setJustExported(false);
+    const format = exportFileNameConfig.format;
+    if (isMultiColor && (format === 'stl' || format === 'step')) {
       setExportFileNameConfig({ ...exportFileNameConfig, format: '3mf' });
+    } else if (hasImprints && format === 'step') {
+      setExportFileNameConfig({ ...exportFileNameConfig, format: 'stl' });
     }
-  }, [exportDialogOpen, isMultiColor, exportFileNameConfig, setExportFileNameConfig]);
+  }, [exportDialogOpen, isMultiColor, hasImprints, exportFileNameConfig, setExportFileNameConfig]);
 
   const formatStates = useMemo(() => {
-    if (!isMultiColor) return undefined;
-    const stlReason = t('binDesigner.export.multiColor.formatDisabled', { format: 'STL' });
-    const stepReason = t('binDesigner.export.multiColor.formatDisabled', { format: 'STEP' });
-    return {
-      stl: { disabled: true, reason: stlReason },
-      step: { disabled: true, reason: stepReason },
-    } as const;
-  }, [isMultiColor, t]);
+    if (!isMultiColor && !hasImprints) return undefined;
+    // Both conditions disable STEP; multi-color's reason wins because it also
+    // disables STL, so the two chips read as one consistent explanation.
+    const states: Partial<Record<ExportFileFormat, { disabled: boolean; reason: string }>> = {};
+    if (hasImprints) {
+      states.step = { disabled: true, reason: t('binDesigner.export.meshImprint.stepDisabled') };
+    }
+    if (isMultiColor) {
+      states.stl = {
+        disabled: true,
+        reason: t('binDesigner.export.multiColor.formatDisabled', { format: 'STL' }),
+      };
+      states.step = {
+        disabled: true,
+        reason: t('binDesigner.export.multiColor.formatDisabled', { format: 'STEP' }),
+      };
+    }
+    return states;
+  }, [isMultiColor, hasImprints, t]);
 
   const fileName = useMemo(
     () => generateFileName(params, activeFormat, exportFileNameConfig, designName),

--- a/src/features/generation/worker/generators/meshImprint.ts
+++ b/src/features/generation/worker/generators/meshImprint.ts
@@ -19,7 +19,11 @@
 import type { CrossSection, Manifold, ManifoldToplevel, Vec2 } from 'manifold-3d';
 import type { BinParams, Cutout } from '@/shared/types/bin';
 import type { MeshAsset } from '@/shared/generation/meshAsset';
-import { decodeMeshData } from '@/shared/generation/meshAsset';
+import {
+  decodeMeshData,
+  hasMeshImprints,
+  visibleMeshImprintCutouts as visibleMeshCutouts,
+} from '@/shared/generation/meshAsset';
 import { isOk } from '@/core/result';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
 import {
@@ -65,20 +69,12 @@ interface PreparedTool {
 const preparedTools = new Map<string, PreparedTool>();
 let activeModule: ManifoldToplevel | null = null;
 
-function visibleMeshCutouts(params: BinParams): Cutout[] {
-  return params.cutouts.filter(
-    (c) =>
-      c.shape === 'mesh' &&
-      c.hidden !== true &&
-      c.meshId !== undefined &&
-      params.meshAssets?.[c.meshId] !== undefined
-  );
-}
-
-/** True when the design has at least one visible, resolvable mesh imprint. */
-export function hasMeshImprints(params: BinParams): boolean {
-  return visibleMeshCutouts(params).length > 0;
-}
+/**
+ * Re-exported rather than defined here: the export UI has to disable STEP on
+ * exactly the condition `binExporter` throws on, and it cannot import this
+ * module (manifold-3d, WASM). See `meshAsset.visibleMeshImprintCutouts`.
+ */
+export { hasMeshImprints };
 
 /** Drop all prepared tool manifolds (worker CLEANUP path). */
 export function clearMeshImprintCache(): void {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Zkusit znovu",
   "binDesigner.export.error.timeout": "Export vypršel — tento návrh může být příliš složitý. Zkus snížit výšku nebo vypnout vzor stěny a exportuj znovu.",
   "binDesigner.export.multiColor.formatDisabled": "{format} nezachovává data o barvách. Použij 3MF, abys zachoval své vícebarevné zóny.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP neumí přenést otisk importované sítě. Použijte STL nebo 3MF.",
   "binDesigner.exportBinAsStl": "Exportovat bin jako STL",
   "binDesigner.exportSTL": "Exportovat bin jako STL",
   "binDesigner.exporting": "Exportuji…",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Erneut versuchen",
   "binDesigner.export.error.timeout": "Export-Zeitüberschreitung — dieses Design ist möglicherweise zu komplex. Verringere die Höhe oder deaktiviere das Wandmuster und exportiere dann erneut.",
   "binDesigner.export.multiColor.formatDisabled": "{format} bewahrt keine Farbdaten. Verwende 3MF, um deine mehrfarbigen Bereiche zu behalten.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP kann den Abdruck eines importierten Meshes nicht übertragen. Verwende STL oder 3MF.",
   "binDesigner.exportBinAsStl": "Bin als STL exportieren",
   "binDesigner.exportSTL": "Bin als STL exportieren",
   "binDesigner.exporting": "Exportiere…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2251,6 +2251,8 @@ const en: Record<string, string> = {
   'binDesigner.colors.zone.topAccent': 'Top accent',
   'binDesigner.export.multiColor.formatDisabled':
     "{format} doesn't preserve color data. Use 3MF to keep your multi-color zones.",
+  'binDesigner.export.meshImprint.stepDisabled':
+    'STEP has no way to carry an imported-mesh imprint. Use STL or 3MF.',
 
   'binDesigner.shape.customShape': 'Custom shape',
   'binDesigner.shape.gridHelp': 'Click to toggle grid cells',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Reintentar",
   "binDesigner.export.error.timeout": "Tiempo de exportación agotado — este diseño puede ser demasiado complejo. Prueba a reducir la altura o desactivar el patrón de pared y exporta de nuevo.",
   "binDesigner.export.multiColor.formatDisabled": "{format} no conserva datos de color. Usa 3MF para mantener tus zonas multicolor.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP no puede transportar la huella de una malla importada. Usa STL o 3MF.",
   "binDesigner.exportBinAsStl": "Exportar bin como STL",
   "binDesigner.exportSTL": "Exportar bin como STL",
   "binDesigner.exporting": "Exportando…",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Réessayer",
   "binDesigner.export.error.timeout": "Délai d'exportation dépassé — ce modèle est peut-être trop complexe. Essayez de réduire la hauteur ou de désactiver le motif de paroi, puis exportez à nouveau.",
   "binDesigner.export.multiColor.formatDisabled": "{format} ne conserve pas les données de couleur. Utilisez 3MF pour préserver vos zones multicolores.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP ne peut pas transporter l'empreinte d'un maillage importé. Utilisez STL ou 3MF.",
   "binDesigner.exportBinAsStl": "Exporter le bin en STL",
   "binDesigner.exportSTL": "Exporter le bin en STL",
   "binDesigner.exporting": "Export en cours…",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Riprova",
   "binDesigner.export.error.timeout": "Esportazione scaduta; questo design potrebbe essere troppo complesso. Prova ad abbassare l'altezza o a disattivare il motivo delle pareti, poi esporta di nuovo.",
   "binDesigner.export.multiColor.formatDisabled": "{format} non conserva i dati di colore. Usa 3MF per mantenere le tue zone multicolore.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP non può trasportare l'impronta di una mesh importata. Usa STL o 3MF.",
   "binDesigner.exportBinAsStl": "Esporta bin come STL",
   "binDesigner.exportSTL": "Esporta bin come STL",
   "binDesigner.exporting": "Esportazione...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "再試行",
   "binDesigner.export.error.timeout": "エクスポートがタイムアウトしました — このデザインは複雑すぎる可能性があります。高さを下げるか壁パターンを無効にしてから、もう一度エクスポートしてください。",
   "binDesigner.export.multiColor.formatDisabled": "{format}は色データを保持できません。マルチカラーゾーンを保持するには3MFをご利用ください。",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP はインポートしたメッシュの型取りを保持できません。STL または 3MF を使用してください。",
   "binDesigner.exportBinAsStl": "ビンをSTLとしてエクスポート",
   "binDesigner.exportSTL": "ビンをSTLとしてエクスポート",
   "binDesigner.exporting": "エクスポート中...",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "다시 시도",
   "binDesigner.export.error.timeout": "내보내기 시간이 초과되었습니다 — 이 디자인이 너무 복잡할 수 있습니다. 높이를 낮추거나 벽 패턴을 끈 다음 다시 내보내세요.",
   "binDesigner.export.multiColor.formatDisabled": "{format}은(는) 색상 데이터를 보존하지 않습니다. 멀티 컬러 영역을 유지하려면 3MF를 사용하세요.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP는 가져온 메시 임프린트를 담을 수 없습니다. STL 또는 3MF를 사용하세요.",
   "binDesigner.exportBinAsStl": "수납통을 STL로 내보내기",
   "binDesigner.exportSTL": "수납통을 STL로 내보내기",
   "binDesigner.exporting": "내보내는 중...",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Prøv igjen",
   "binDesigner.export.error.timeout": "Eksport tidsavbrudd — denne utformingen kan være for kompleks. Prøv å redusere høyden eller slå av veggmønsteret, og eksporter på nytt.",
   "binDesigner.export.multiColor.formatDisabled": "{format} bevarer ikke fargedata. Bruk 3MF for å beholde de flerfargede sonene.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP kan ikke bære avtrykket av en importert mesh. Bruk STL eller 3MF.",
   "binDesigner.exportBinAsStl": "Eksporter bin som STL",
   "binDesigner.exportSTL": "Eksporter bin som STL",
   "binDesigner.exporting": "Eksporterer…",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Opnieuw proberen",
   "binDesigner.export.error.timeout": "Export verlopen — dit ontwerp is mogelijk te complex. Probeer de hoogte te verlagen of het wandpatroon uit te schakelen en exporteer opnieuw.",
   "binDesigner.export.multiColor.formatDisabled": "{format} behoudt geen kleurgegevens. Gebruik 3MF om uw multi-kleurzones te behouden.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP kan de afdruk van een geïmporteerde mesh niet meenemen. Gebruik STL of 3MF.",
   "binDesigner.exportBinAsStl": "Bin als STL exporteren",
   "binDesigner.exportSTL": "Bin als STL exporteren",
   "binDesigner.exporting": "Exporteren…",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Ponów",
   "binDesigner.export.error.timeout": "Eksport przekroczył limit czasu — ten projekt może być zbyt złożony. Spróbuj obniżyć wysokość lub wyłączyć wzór ścianki, a potem wyeksportuj ponownie.",
   "binDesigner.export.multiColor.formatDisabled": "{format} nie zachowuje danych o kolorze. Użyj 3MF, aby zachować swoje strefy wielokolorowe.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP nie przenosi odcisku zaimportowanej siatki. Użyj STL lub 3MF.",
   "binDesigner.exportBinAsStl": "Eksportuj bin jako STL",
   "binDesigner.exportSTL": "Eksportuj bin jako STL",
   "binDesigner.exporting": "Eksportowanie...",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Tentar novamente",
   "binDesigner.export.error.timeout": "Tempo de exportação esgotado — este design pode ser muito complexo. Tente reduzir a altura ou desativar o padrão de parede e exporte novamente.",
   "binDesigner.export.multiColor.formatDisabled": "{format} não preserva dados de cor. Use 3MF para manter suas zonas multicoloridas.",
+  "binDesigner.export.meshImprint.stepDisabled": "O STEP não consegue levar a marcação de uma malha importada. Use STL ou 3MF.",
   "binDesigner.exportBinAsStl": "Exportar bin como STL",
   "binDesigner.exportSTL": "Exportar bin como STL",
   "binDesigner.exporting": "Exportando…",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Försök igen",
   "binDesigner.export.error.timeout": "Exporten avbröts — den här designen kan vara för komplex. Försök att minska höjden eller stänga av väggmönstret och exportera igen.",
   "binDesigner.export.multiColor.formatDisabled": "{format} bevarar inte färgdata. Använd 3MF för att behålla dina flerfärgade zoner.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP kan inte bära avtrycket från ett importerat mesh. Använd STL eller 3MF.",
   "binDesigner.exportBinAsStl": "Exportera fack som STL",
   "binDesigner.exportSTL": "Exportera fack som STL",
   "binDesigner.exporting": "Exporterar...",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "Повторити",
   "binDesigner.export.error.timeout": "Час експорту вичерпано — цей дизайн може бути надто складним. Спробуйте зменшити висоту або вимкнути візерунок стінки, а потім експортуйте знову.",
   "binDesigner.export.multiColor.formatDisabled": "{format} не зберігає дані кольору. Використовуйте 3MF для збереження багатоколірних зон.",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP не може передати відбиток імпортованої сітки. Використайте STL або 3MF.",
   "binDesigner.exportBinAsStl": "Експортувати бін як STL",
   "binDesigner.exportSTL": "Експортувати бін як STL",
   "binDesigner.exporting": "Експортується...",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -764,6 +764,7 @@
   "binDesigner.export.error.retry": "重试",
   "binDesigner.export.error.timeout": "导出超时 — 此设计可能过于复杂。请尝试降低高度或关闭壁图案，然后再次导出。",
   "binDesigner.export.multiColor.formatDisabled": "{format} 不保留颜色数据。使用 3MF 以保留你的多色区域。",
+  "binDesigner.export.meshImprint.stepDisabled": "STEP 无法保留导入网格的压印。请使用 STL 或 3MF。",
   "binDesigner.exportBinAsStl": "将收纳盒导出为 STL",
   "binDesigner.exportSTL": "将收纳盒导出为 STL",
   "binDesigner.exporting": "导出中…",

--- a/src/shared/generation/meshAsset.ts
+++ b/src/shared/generation/meshAsset.ts
@@ -18,6 +18,7 @@
 
 import { err, ok, validationImportFailed } from '@/core/result';
 import type { Result, ValidationError } from '@/core/result';
+import type { BinParams, Cutout } from '@/shared/types/bin';
 
 /** A 2D silhouette ring point in mm, in the mesh's lay-flat XY frame. */
 export interface MeshOutlinePoint {
@@ -83,6 +84,35 @@ export const MAX_MESH_ASSET_DATA_LENGTH = 900_000;
  * without decompressing, which is the work we are trying not to do on hostile
  * input. `decodeMeshData` enforces the decompressed ceiling separately.
  */
+/**
+ * A design's mesh-imprint cutouts that will actually be cut — visible, and
+ * pointing at an asset that resolves.
+ *
+ * Their presence decides real behaviour on both sides of the worker boundary:
+ * the pocket is subtracted from the TESSELLATED mesh, after the BREP solid
+ * exists, so a design carrying one has no solid that describes what the user
+ * sees and `binExporter` refuses STEP for it. That refusal is a thrown error at
+ * download time, so the export UI has to disable STEP on exactly the same
+ * condition — hence one predicate here rather than a worker-side copy the UI
+ * approximates (#3449).
+ */
+export function visibleMeshImprintCutouts(
+  params: Pick<BinParams, 'cutouts' | 'meshAssets'>
+): readonly Cutout[] {
+  return params.cutouts.filter(
+    (c) =>
+      c.shape === 'mesh' &&
+      c.hidden !== true &&
+      c.meshId !== undefined &&
+      params.meshAssets?.[c.meshId] !== undefined
+  );
+}
+
+/** True when the design has at least one visible, resolvable mesh imprint. */
+export function hasMeshImprints(params: Pick<BinParams, 'cutouts' | 'meshAssets'>): boolean {
+  return visibleMeshImprintCutouts(params).length > 0;
+}
+
 export function hasOversizedMeshAsset(params: unknown): boolean {
   if (typeof params !== 'object' || params === null) return false;
   const assets = (params as { meshAssets?: unknown }).meshAssets;

--- a/src/shell/layoutExport/buildLayoutManifest.ts
+++ b/src/shell/layoutExport/buildLayoutManifest.ts
@@ -57,6 +57,13 @@ export interface ManifestSkipped {
   readonly missingDesigns: number;
   /** Imported-mesh designs skipped under STEP (a mesh has no BREP solid). */
   readonly meshDesignsStepSkipped?: number;
+  /**
+   * Bin designs skipped under STEP for carrying a mesh imprint cutout — the
+   * pocket is subtracted after tessellation, so the solid STEP would carry is
+   * the one WITHOUT it. Skipping keeps the rest of the ZIP: the export used to
+   * throw on the first such bin and take the whole layout with it (#3449).
+   */
+  readonly imprintDesignsStepSkipped?: number;
 }
 
 /** One swappable-label sheet family in the labels/ folder (#2666). */
@@ -289,6 +296,11 @@ export function buildLayoutManifest(input: LayoutManifestInput): string {
   if (skipped.meshDesignsStepSkipped !== undefined && skipped.meshDesignsStepSkipped > 0) {
     skippedLines.push(
       `  ${skipped.meshDesignsStepSkipped} imported ${plural(skipped.meshDesignsStepSkipped, 'design')} skipped (STEP is not available for imported meshes — export STL or 3MF).`
+    );
+  }
+  if (skipped.imprintDesignsStepSkipped !== undefined && skipped.imprintDesignsStepSkipped > 0) {
+    skippedLines.push(
+      `  ${skipped.imprintDesignsStepSkipped} ${plural(skipped.imprintDesignsStepSkipped, 'design')} skipped (STEP is not available for mesh imprint cutouts — export STL or 3MF).`
     );
   }
   if (skippedLines.length > 0) {

--- a/src/shell/layoutExport/planLayoutBinExport.test.ts
+++ b/src/shell/layoutExport/planLayoutBinExport.test.ts
@@ -35,6 +35,37 @@ function design(id: string, name: string, params: Partial<BinParams> = {}): Save
   };
 }
 
+/** A design carrying one visible, resolvable mesh imprint cutout (#3449). */
+function imprintParams(): Partial<BinParams> {
+  return {
+    cutouts: [
+      {
+        id: 'c1',
+        shape: 'mesh',
+        meshId: 'a1',
+        x: 10,
+        y: 10,
+        width: 10,
+        depth: 10,
+        cutDepth: 5,
+        rotation: 0,
+        cornerRadius: 0,
+        label: '',
+        groupId: null,
+      },
+    ],
+    meshAssets: {
+      a1: {
+        name: 'spanner',
+        data: 'x',
+        triangleCount: 12,
+        sizeMm: { x: 10, y: 10, z: 5 },
+        outlines: [],
+      },
+    },
+  };
+}
+
 function linkedBin(idStr: string, overrides: Partial<Bin> = {}): Bin {
   return createTestBin({ linkedDesignId: designId(idStr), ...overrides });
 }
@@ -435,6 +466,44 @@ describe('planLayoutBinExport', () => {
       expect(plan.meshExportable).toHaveLength(0);
       expect(plan.skipped.meshDesignsStepSkipped).toBe(1);
       expect(plan.manifestBins).toHaveLength(0);
+    });
+
+    it('skips a bin design carrying a mesh imprint under STEP, keeping the rest', () => {
+      const imprint = design('i1', 'Shadow board', imprintParams());
+      const plan = planLayoutBinExport({
+        bins: [linkedBin('i1'), { ...linkedBin('d1'), x: gridUnits(2) }],
+        loaded: [
+          { id: designId('i1'), design: imprint },
+          { id: designId('d1'), design: design('d1', 'Box') },
+        ],
+        format: 'step',
+        fileNameConfig: { ...CONFIG, format: 'step' },
+        printSettings: DEFAULT_PRINT_SETTINGS,
+        drawer: DRAWER,
+        baseplate: undefined,
+        printBed: PRINT_BED,
+      });
+      // The imprint pocket is cut after tessellation, so `binExporter` throws
+      // on STEP — and one throw used to abort the whole ZIP (#3449). The plain
+      // bin beside it must still come out.
+      expect(plan.skipped.imprintDesignsStepSkipped).toBe(1);
+      expect(plan.manifestBins.map((b) => b.designName)).toEqual(['Box']);
+    });
+
+    it('exports that same imprint design under STL', () => {
+      const imprint = design('i1', 'Shadow board', imprintParams());
+      const plan = planLayoutBinExport({
+        bins: [linkedBin('i1')],
+        loaded: [{ id: designId('i1'), design: imprint }],
+        format: 'stl',
+        fileNameConfig: CONFIG,
+        printSettings: DEFAULT_PRINT_SETTINGS,
+        drawer: DRAWER,
+        baseplate: undefined,
+        printBed: PRINT_BED,
+      });
+      expect(plan.skipped.imprintDesignsStepSkipped).toBe(0);
+      expect(plan.exportable).toHaveLength(1);
     });
 
     it('still tallies tool racks (non-mesh paramsless designs) as nonBinDesigns', () => {

--- a/src/shell/layoutExport/planLayoutBinExport.ts
+++ b/src/shell/layoutExport/planLayoutBinExport.ts
@@ -27,6 +27,7 @@ import { resolveBinOverhang } from '@/shared/utils/drawerMargin';
 import { overhangKey as resolvedOverhangKey, resolveOverhang } from '@/shared/utils/overhang';
 import type { ExportFileFormat, ExportFileNameConfig } from '@/shared/types/bin';
 import type { MeshAsset } from '@/shared/generation/meshAsset';
+import { hasMeshImprints } from '@/shared/generation/meshAsset';
 import { importedMeshDescriptor } from '@/shared/items/importedMesh/descriptor';
 import type { ImportedMeshStructure, ItemEnvelope } from '@/shared/types/item';
 import type { PrintSettings } from '@/shared/printSettings';
@@ -244,10 +245,19 @@ export function planLayoutBinExport(input: LayoutBinExportInput): LayoutBinExpor
   // REPLACES the design's own overhang for that instance.
   const groups = new Map<string, BinExportGroup>();
   const usable: BinExportGroup[] = [];
+  // Designs a STEP export cannot represent because their pocket is carved out
+  // of the tessellated mesh, not the solid. Skipped like imported meshes rather
+  // than exported wrong — and, before #3449, rather than thrown on, which took
+  // the entire ZIP down over one bin.
+  const imprintStepSkipped = new Set<DesignId>();
   for (const b of bins) {
     if (b.linkedDesignId === undefined) continue;
     const design = designById.get(b.linkedDesignId);
     if (!design?.params) continue; // missing/non-bin already tallied above
+    if (format === 'step' && hasMeshImprints(design.params)) {
+      imprintStepSkipped.add(b.linkedDesignId);
+      continue;
+    }
     const overhang = resolveBinOverhang(b, drawer, baseplate);
     // Inject the layout's magnet anchor (source of truth), overriding any value
     // saved on the design, so exported bins mate with the baseplate's magnets.
@@ -407,7 +417,13 @@ export function planLayoutBinExport(input: LayoutBinExportInput): LayoutBinExpor
     exportable,
     meshExportable,
     manifestBins,
-    skipped: { unlinkedBins, nonBinDesigns, missingDesigns, meshDesignsStepSkipped },
+    skipped: {
+      unlinkedBins,
+      nonBinDesigns,
+      missingDesigns,
+      meshDesignsStepSkipped,
+      imprintDesignsStepSkipped: imprintStepSkipped.size,
+    },
     totals: { filamentGrams: totalGrams, printTimeMinutes: totalMinutes },
   };
 }


### PR DESCRIPTION
Closes #3449.

A mesh imprint is subtracted from the **tessellated mesh**, after the BREP solid exists, so there is no solid describing what the user sees and `binExporter` refuses STEP outright. That refusal is correct. It was also unreachable in advance: STEP sat in the picker looking like any other option, and the user found out by clicking Download and getting an error toast plus an auto-filed issue.

### Bin designer

STEP is disabled with the reason on the chip, and a design saved as STEP switches to STL when the dialog opens — mirroring how a multi-color design already steers to 3MF.

### Whole-layout export

The same throw took the entire ZIP down: one imprint bin anywhere in the drawer aborts everything, including bins that would have exported fine. The planner now skips those designs under STEP and tallies them for `manifest.txt`, exactly as it already does for imported-mesh designs.

### One predicate, not two

`hasMeshImprints` moves to `@/shared/generation/meshAsset` so the UI gate and the worker's throw are one expression. The UI cannot import `meshImprint.ts` (manifold-3d, WASM), which is how a hand-copied approximation would drift — and drift here means the picker either offering a format that throws or hiding one that works. The `hidden` and unresolved-asset terms are load-bearing for that reason: a cutout that is listed but never cut leaves STEP genuinely available, and there is a test for it.

### Tests

- Both new dialog tests fail without the gate (STEP stays enabled; the saved format stays `step`).
- Layout planner: an imprint design is skipped under STEP while the plain bin beside it still exports, and the same design exports normally under STL.
- 14 locales updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables STEP export for designs with mesh imprint cutouts to avoid runtime failures and broken layout ZIPs. Before: STEP appeared selectable, `binExporter` threw on download, and one imprint bin aborted whole-layout exports. Now: STEP is disabled with a reason; layout exports skip only the affected designs under STEP.

- UI (Export dialog): disables STEP when `hasMeshImprints(params)` is true and auto-switches a saved `step` format to `stl` on open; existing multi-color logic persists (prefers 3MF and also disables STEP). Both conditions can disable STEP; multi-color reason wins for consistency.
- Layout export: skips imprint designs for STEP and records `imprintDesignsStepSkipped` in `manifest.txt`; other bins export normally. STL/3MF export unchanged.
- Shared predicate: moves `hasMeshImprints` (and `visibleMeshImprintCutouts`) to `@/shared/generation/meshAsset` and re-exports in the worker so UI and worker use the same check, respecting `hidden` and unresolved assets.
- Tests/i18n: adds dialog and planner coverage; introduces `binDesigner.export.meshImprint.stepDisabled` across locales.

<sup>Written for commit c1673ffb0684c73814662a3bf82dc1e4b0153540. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

