### PR TITLE
fix(baseplate): regenerate the preview when screw, fit-offset or lightweight params change

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateGeneration.test.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.test.ts
@@ -109,6 +109,120 @@ describe('selectGenerationTriggers', () => {
     const b = makeState(undefined, { solidFloor: false, solidFloorThickness: mm(2) });
     expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(true);
   });
+
+  /**
+   * Regression: toggling mount-down screws (or editing any screw field)
+   * changed only `screwHoles`, which was absent from the trigger set — the
+   * preview kept the stale plate until an unrelated param changed.
+   */
+  describe('mount-down screw params', () => {
+    const screws = (over: Partial<StoredBaseplateParams['screwHoles'] & object> = {}) =>
+      ({
+        enabled: true,
+        diameter: mm(3.4),
+        headStyle: 'countersink',
+        ...over,
+      }) as StoredBaseplateParams['screwHoles'];
+
+    it('produces a different trigger selection when screws toggle', () => {
+      const off = makeState(undefined);
+      const on = makeState(undefined, { screwHoles: screws() });
+      expect(shallowEqual(selectGenerationTriggers(off), selectGenerationTriggers(on))).toBe(false);
+    });
+
+    it('produces a different trigger selection when the shaft diameter changes', () => {
+      const a = makeState(undefined, { screwHoles: screws({ diameter: mm(3.4) }) });
+      const b = makeState(undefined, { screwHoles: screws({ diameter: mm(4.5) }) });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
+    });
+
+    it('produces a different trigger selection when the head style changes', () => {
+      const a = makeState(undefined, { screwHoles: screws({ headStyle: 'countersink' }) });
+      const b = makeState(undefined, { screwHoles: screws({ headStyle: 'counterbore' }) });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
+    });
+
+    it('produces a different trigger selection when screws per piece changes', () => {
+      const a = makeState(undefined, { screwHoles: screws({ screwsPerPiece: 4 }) });
+      const b = makeState(undefined, { screwHoles: screws({ screwsPerPiece: 6 }) });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
+    });
+
+    it('produces a different trigger selection when the counterbore depth changes (counterbore head)', () => {
+      const a = makeState(undefined, {
+        screwHoles: screws({ headStyle: 'counterbore', counterboreDepth: mm(2) }),
+      });
+      const b = makeState(undefined, {
+        screwHoles: screws({ headStyle: 'counterbore', counterboreDepth: mm(3) }),
+      });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
+    });
+
+    it('ignores screw geometry fields while screws are disabled (no needless regen)', () => {
+      const a = makeState(undefined, { screwHoles: screws({ enabled: false, diameter: mm(3.4) }) });
+      const b = makeState(undefined, { screwHoles: screws({ enabled: false, diameter: mm(4.5) }) });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(true);
+    });
+
+    it('ignores screw fields while stacking strips them (no needless regen)', () => {
+      const stack = { enabled: true, gapMm: mm(0.2) } as const;
+      const a = makeState(undefined, { stackPrint: stack, screwHoles: screws() });
+      const b = makeState(undefined, {
+        stackPrint: stack,
+        screwHoles: screws({ diameter: mm(4.5) }),
+      });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(true);
+    });
+  });
+
+  /**
+   * Regression: the connector fit offset shifts every connector clearance, but
+   * was absent from the trigger set — stepping it left the exploded preview's
+   * tongues and grooves at the old clearance until an unrelated param changed.
+   */
+  describe('connectorFitOffset', () => {
+    it('produces a different trigger selection when the offset changes (connectors on)', () => {
+      const a = makeState('dovetail', { connectorFitOffset: 0 });
+      const b = makeState('dovetail', { connectorFitOffset: 0.2 });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
+    });
+
+    it('produces a different trigger selection when the offset changes (margin seam on, connectors off)', () => {
+      const seam = {
+        connectorNubs: false,
+        detachMargins: true,
+        detachMarginConnector: true,
+      } as const;
+      const a = makeState(undefined, { ...seam, connectorFitOffset: 0 });
+      const b = makeState(undefined, { ...seam, connectorFitOffset: 0.2 });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
+    });
+
+    it('ignores the offset when nothing can consume it (no needless regen)', () => {
+      const a = makeState(undefined, { connectorNubs: false, connectorFitOffset: 0 });
+      const b = makeState(undefined, { connectorNubs: false, connectorFitOffset: 0.2 });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(true);
+    });
+  });
+
+  /**
+   * Regression: `lightweight` reaches the generator (the underside cross
+   * cutter) but was absent from the trigger set. No UI writes it today, but
+   * synced/imported params can carry it.
+   */
+  describe('lightweight', () => {
+    it('produces a different trigger selection when lightweight changes (magnets on)', () => {
+      const a = makeState(undefined, { magnetHoles: true, lightweight: true });
+      const b = makeState(undefined, { magnetHoles: true, lightweight: false });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
+    });
+
+    it('ignores lightweight while magnets are off (no needless regen)', () => {
+      const a = makeState(undefined, { magnetHoles: false, lightweight: true });
+      const b = makeState(undefined, { magnetHoles: false, lightweight: false });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(true);
+    });
+  });
 });
 
 describe('hasMeshOnScreen', () => {

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -240,6 +240,10 @@ function hasEffectivePerimeterMemoized(
  */
 export function selectGenerationTriggers(state: LayoutStoreState) {
   const bp = state.layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
+  // Stacking strips screws in buildFullParams (a flipped tile would put the
+  // head recess on the underside), so their fields cannot change the mesh
+  // while it is on.
+  const screwsOn = bp.stackPrint?.enabled !== true && bp.screwHoles?.enabled === true;
   return {
     drawerWidth: state.layout.drawer.width,
     drawerDepth: state.layout.drawer.depth,
@@ -304,6 +308,25 @@ export function selectGenerationTriggers(state: LayoutStoreState) {
     // regeneration while dragging the (hidden) slider.
     solidFloor: bp.solidFloor ?? false,
     solidFloorThickness: bp.solidFloor === true ? bp.solidFloorThickness : undefined,
+    // Mount-down screws (#3425) decide which cells keep a floor, grow the slab
+    // by the pad, and cut the hole/recess geometry — every field must
+    // re-trigger BREP. The geometry fields fold out while screws are off (or
+    // stripped by stacking) so edits that cannot change the mesh don't
+    // regenerate it; the counterbore depth additionally folds out under a
+    // countersink head, whose depth is derived from the cone angle instead.
+    screwHolesEnabled: screwsOn,
+    screwDiameter: screwsOn ? bp.screwHoles.diameter : undefined,
+    screwHeadStyle: screwsOn ? bp.screwHoles.headStyle : undefined,
+    screwHeadDiameter: screwsOn ? bp.screwHoles.headDiameter : undefined,
+    screwCounterboreDepth:
+      screwsOn && bp.screwHoles.headStyle === 'counterbore'
+        ? bp.screwHoles.counterboreDepth
+        : undefined,
+    screwsPerPiece: screwsOn ? bp.screwHoles.screwsPerPiece : undefined,
+    // Nothing in the UI writes `lightweight` today, but synced/imported params
+    // can carry it, and the lightweight floor cutter changes the whole
+    // underside. It only runs on magnet plates, so fold it out otherwise.
+    lightweight: bp.magnetHoles ? bp.lightweight !== false : true,
     paddingLeft: bp.paddingLeft,
     paddingRight: bp.paddingRight,
     paddingFront: bp.paddingFront,
@@ -318,6 +341,13 @@ export function selectGenerationTriggers(state: LayoutStoreState) {
       bp.connectorNubs === true &&
       isSeatedConnectorStyle(bp.connectorStyle) &&
       bp.connectorSlotsAllEdges === true,
+    // Fit offset biases every connector clearance (tongues/grooves, snap-clip
+    // levels, margin-rail seams), so it must re-trigger BREP — folded out when
+    // neither split connectors nor the margin seam can consume it.
+    connectorFitOffset:
+      bp.connectorNubs === true || (bp.detachMargins === true && bp.detachMarginConnector === true)
+        ? bp.connectorFitOffset
+        : undefined,
     syncWithLayout: bp.syncWithLayout,
     baseplateWidth: bp.baseplateWidth,
     baseplateDepth: bp.baseplateDepth,


### PR DESCRIPTION
## Problem

Toggling mount-down screws (#3425) on or off does not update the 3D preview. The plate silently keeps its stale mesh until an unrelated param changes.

## Root cause

`selectGenerationTriggers` (`useBaseplateGeneration.ts`) is the single list of params whose change re-runs generation, and `screwHoles` was never added to it. The store updates, but `useShallow` sees an unchanged selection and the regen effect never fires. The caches and piece fingerprints already carry screw params; only the trigger was missing. This is the same failure mode the function's own doc comment records for `connectorStyle`.

## Audit

Per the trigger list's contract, every `StoredBaseplateParams` field `buildFullParams` consumes was diffed against the selection. Two more gaps with the identical defect:

- `connectorFitOffset`: user-editable stepper, biases every connector clearance (tongues/grooves, snap-clip levels, margin-rail seams). Stepping it left the preview at the old clearance.
- `lightweight`: no UI writes it today, but synced/imported params can carry it, and it switches the whole underside cross-cutout.

## Fix

All three added to the trigger selection, folded per the file's existing pattern so edits that cannot change the mesh don't regenerate it:

- screw geometry fields fold out while screws are disabled or stripped by stacking; counterbore depth additionally folds out under a countersink head
- fit offset folds out when neither split connectors nor the margin seam can consume it
- lightweight folds out without magnets

Regression tests added for each in the existing `selectGenerationTriggers` describe block (23 pass).