### PR TITLE
fix(baseplate): cross-cut screw cells into boss pads instead of full floors

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateGeneration.test.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.test.ts
@@ -217,9 +217,27 @@ describe('selectGenerationTriggers', () => {
       expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
     });
 
-    it('ignores lightweight while magnets are off (no needless regen)', () => {
+    it('produces a different trigger selection when lightweight changes (screws on, magnets off)', () => {
+      const screws = { enabled: true, diameter: mm(3.4), headStyle: 'countersink' } as const;
+      const a = makeState(undefined, { magnetHoles: false, screwHoles: screws, lightweight: true });
+      const b = makeState(undefined, {
+        magnetHoles: false,
+        screwHoles: screws,
+        lightweight: false,
+      });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(false);
+    });
+
+    it('ignores lightweight while magnets and screws are off (no needless regen)', () => {
       const a = makeState(undefined, { magnetHoles: false, lightweight: true });
       const b = makeState(undefined, { magnetHoles: false, lightweight: false });
+      expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(true);
+    });
+
+    it('ignores lightweight while stacking strips magnets (no needless regen)', () => {
+      const stack = { enabled: true, gapMm: mm(0.2) } as const;
+      const a = makeState(undefined, { magnetHoles: true, stackPrint: stack, lightweight: true });
+      const b = makeState(undefined, { magnetHoles: true, stackPrint: stack, lightweight: false });
       expect(shallowEqual(selectGenerationTriggers(a), selectGenerationTriggers(b))).toBe(true);
     });
   });

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -245,6 +245,8 @@ export function selectGenerationTriggers(state: LayoutStoreState) {
   // neither family's fields can change the mesh while it is on.
   const stackingOn = bp.stackPrint?.enabled === true;
   const screwsOn = !stackingOn && bp.screwHoles?.enabled === true;
+  // The underside cross cutters run on magnet plates and screw-pad cells.
+  const lightweightRelevant = (!stackingOn && bp.magnetHoles) || screwsOn;
   return {
     drawerWidth: state.layout.drawer.width,
     drawerDepth: state.layout.drawer.depth,
@@ -328,7 +330,7 @@ export function selectGenerationTriggers(state: LayoutStoreState) {
     // can carry it, and the underside cross cutters consume it on magnet
     // plates and screw-pad cells alike — fold it out when neither can
     // (stacking strips both, so it folds out there too).
-    lightweight: (!stackingOn && bp.magnetHoles) || screwsOn ? bp.lightweight !== false : true,
+    lightweight: lightweightRelevant ? bp.lightweight !== false : true,
     paddingLeft: bp.paddingLeft,
     paddingRight: bp.paddingRight,
     paddingFront: bp.paddingFront,

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -240,10 +240,11 @@ function hasEffectivePerimeterMemoized(
  */
 export function selectGenerationTriggers(state: LayoutStoreState) {
   const bp = state.layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
-  // Stacking strips screws in buildFullParams (a flipped tile would put the
-  // head recess on the underside), so their fields cannot change the mesh
-  // while it is on.
-  const screwsOn = bp.stackPrint?.enabled !== true && bp.screwHoles?.enabled === true;
+  // Stacking strips screws AND magnets in buildFullParams (a flipped tile
+  // would put the head recess and the magnet bridges on the underside), so
+  // neither family's fields can change the mesh while it is on.
+  const stackingOn = bp.stackPrint?.enabled === true;
+  const screwsOn = !stackingOn && bp.screwHoles?.enabled === true;
   return {
     drawerWidth: state.layout.drawer.width,
     drawerDepth: state.layout.drawer.depth,
@@ -324,9 +325,10 @@ export function selectGenerationTriggers(state: LayoutStoreState) {
         : undefined,
     screwsPerPiece: screwsOn ? bp.screwHoles.screwsPerPiece : undefined,
     // Nothing in the UI writes `lightweight` today, but synced/imported params
-    // can carry it, and the lightweight floor cutter changes the whole
-    // underside. It only runs on magnet plates, so fold it out otherwise.
-    lightweight: bp.magnetHoles ? bp.lightweight !== false : true,
+    // can carry it, and the underside cross cutters consume it on magnet
+    // plates and screw-pad cells alike — fold it out when neither can
+    // (stacking strips both, so it folds out there too).
+    lightweight: (!stackingOn && bp.magnetHoles) || screwsOn ? bp.lightweight !== false : true,
     paddingLeft: bp.paddingLeft,
     paddingRight: bp.paddingRight,
     paddingFront: bp.paddingFront,

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.screws.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.screws.test.ts
@@ -10,7 +10,12 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBaseplate } from './__kernel-tests__/wasmInit';
-import { assertStructurallyValid, boundingBox } from './__kernel-tests__/meshAssertions';
+import {
+  assertStructurallyValid,
+  boundingBox,
+  isSolidThrough,
+  verticalSolidSpans,
+} from './__kernel-tests__/meshAssertions';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { ScrewHoleParams } from '@/core/types/baseplate';
 import { mm } from '@/core/types';
@@ -124,6 +129,135 @@ describe('baseplate mount-down screw holes (#3425)', () => {
     assertStructurallyValid(result);
     const bb = boundingBox(result.vertices);
     expect(bb.maxZ - bb.minZ).toBeCloseTo(SOCKET_HEIGHT, 1);
+  });
+
+  it('cross-cuts a screw cell into corner boss pads instead of a full floor', () => {
+    // With magnets off and lightweight on (the stored default), a screw cell's
+    // floor is hollowed like a magnet plate's: corner pads survive, the cross
+    // is void. Probed, not counted — a triangle count cannot tell a pad from a
+    // membrane.
+    // The export mesh sits bottom-at-Z=0 growing up and XY-centred, so every
+    // band below derives from the bounding box rather than the BREP build's
+    // top-at-0 convention.
+    const pad = screwPadThicknessMm(SCREWS, 0);
+    const result = getGenerateBaseplate()(
+      defaults({ lightweight: true, screwHoles: SCREWS, screwPadThicknessMm: pad }),
+      NO_OP,
+      true
+    );
+    assertStructurallyValid(result);
+    const bb = boundingBox(result.vertices);
+
+    // Bottom-left screw cell: the screw snaps to the magnet position nearest
+    // the plate corner, cell-local (-13, -13). The pad band around it spans
+    // |8..18.05| on both axes (offset 13 − head r 4 − margin 1, relief
+    // 21 − INSET_BOT). Probe just inside the pad, clear of the ø8 recess: the
+    // pad slab spans the bottom `pad` mm of the plate.
+    const cellCx = bb.minX + 21;
+    const cellCy = bb.minY + 21;
+    expect(
+      isSolidThrough(result, cellCx - 9.75, cellCy - 9.75, bb.minZ + 0.02, bb.minZ + pad - 0.02)
+    ).toBe(true);
+
+    // The cross centre of the same cell is void top to bottom: the pocket sits
+    // above the (removed) floor, so the ray misses the mesh entirely.
+    expect(verticalSolidSpans(result, cellCx + 0.37, cellCy + 0.61)).toEqual([]);
+
+    // A screwless cell has no floor at all — its would-be pad point is void.
+    const midCx = bb.minX + 63;
+    expect(verticalSolidSpans(result, midCx - 9.75, cellCy - 9.75)).toEqual([]);
+  });
+
+  it('keeps the full floor when lightweight is explicitly off', () => {
+    const pad = screwPadThicknessMm(SCREWS, 0);
+    const result = getGenerateBaseplate()(
+      defaults({ lightweight: false, screwHoles: SCREWS, screwPadThicknessMm: pad }),
+      NO_OP,
+      true
+    );
+    const bb = boundingBox(result.vertices);
+    expect(
+      isSolidThrough(result, bb.minX + 21.37, bb.minY + 21.61, bb.minZ + 0.02, bb.minZ + pad - 0.02)
+    ).toBe(true);
+  });
+
+  it('keeps the full floor in the draft fast path', () => {
+    const pad = screwPadThicknessMm(SCREWS, 0);
+    const result = getGenerateBaseplate()(
+      defaults({ lightweight: true, screwHoles: SCREWS, screwPadThicknessMm: pad }),
+      NO_OP,
+      true,
+      undefined,
+      true
+    );
+    const bb = boundingBox(result.vertices);
+    expect(
+      isSolidThrough(result, bb.minX + 21.37, bb.minY + 21.61, bb.minZ + 0.02, bb.minZ + pad - 0.02)
+    ).toBe(true);
+  });
+
+  it('never intrudes into the bin-seating volume (whole-footprint sweep)', () => {
+    // The top SOCKET_HEIGHT of the plate is where a bin's foot sits. Sweep the
+    // whole footprint and require the screwed plate to carry no more solid in
+    // that band than an unscrewed one anywhere — an aimed probe at a suspected
+    // spot is exactly the check #3450 taught us not to trust. Each mesh's band
+    // is measured from its own top: the screwed plate is `pad` taller, but the
+    // socket is always its top SOCKET_HEIGHT.
+    const pad = screwPadThicknessMm(SCREWS, 0);
+    const plain = getGenerateBaseplate()(defaults({ lightweight: true }), NO_OP, true);
+    const screwed = getGenerateBaseplate()(
+      defaults({ lightweight: true, screwHoles: SCREWS, screwPadThicknessMm: pad }),
+      NO_OP,
+      true
+    );
+    const solidInSeatBand = (mesh: typeof plain, topZ: number, x: number, y: number): number => {
+      const bandLo = topZ - SOCKET_HEIGHT + 0.05;
+      const bandHi = topZ - 0.05;
+      return verticalSolidSpans(mesh, x, y).reduce(
+        (sum, [lo, hi]) => sum + Math.max(0, Math.min(hi, bandHi) - Math.max(lo, bandLo)),
+        0
+      );
+    };
+    const plainTop = boundingBox(plain.vertices).maxZ;
+    const screwedTop = boundingBox(screwed.vertices).maxZ;
+
+    const bb = boundingBox(plain.vertices);
+    let worst = 0;
+    let deepestSolid = 0;
+    // 0.37/0.61 offsets keep sample columns off grid lines and face planes,
+    // where the ray helper warns parity breaks.
+    for (let x = bb.minX + 0.37; x < bb.maxX; x += 4.3) {
+      for (let y = bb.minY + 0.61; y < bb.maxY; y += 4.3) {
+        const inBand = solidInSeatBand(screwed, screwedTop, x, y);
+        deepestSolid = Math.max(deepestSolid, inBand);
+        worst = Math.max(worst, inBand - solidInSeatBand(plain, plainTop, x, y));
+      }
+    }
+    expect(worst).toBeLessThanOrEqual(0.06);
+    // Anti-vacuity: socket walls must register in the band, or the sweep is
+    // silently probing air (which is how its first version passed).
+    expect(deepestSolid).toBeGreaterThan(4);
+  });
+
+  it('opens magnet-plate cross voids through the deeper screw-pad floor (no sealed membrane)', () => {
+    // A magnet+screw plate's floor is the magnet floor plus the pad shortfall.
+    // The cross cut used to stop at the magnet floor, leaving a 0.6mm membrane
+    // sealing every void from below; the ray at a cross centre must now miss
+    // the mesh entirely.
+    const magnetFloor = 0.5 + 2;
+    const pad = screwPadThicknessMm(SCREWS, magnetFloor, { diameterMm: 6.5, depthMm: 2 });
+    const result = getGenerateBaseplate()(
+      defaults({
+        magnetHoles: true,
+        lightweight: true,
+        screwHoles: SCREWS,
+        screwPadThicknessMm: pad,
+      }),
+      NO_OP,
+      true
+    );
+    const bb = boundingBox(result.vertices);
+    expect(verticalSolidSpans(result, bb.minX + 63.37, bb.minY + 63.61)).toEqual([]);
   });
 
   it('costs a magnet plate only the shortfall over its existing floor', () => {

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -129,8 +129,8 @@ export type BaseplateProbe = (label: string, shape: Shape3D) => void;
  * Generate baseplate mesh for the live preview.
  *
  * `draft` builds a faster draft-quality solid (skips the underside lightweight
- * floor cutters). The standalone-page preview passes `true`; the printed export
- * goes through `exportBaseplate`, which always builds full geometry.
+ * floor cutters). Every production caller passes `false`, so the preview
+ * underside matches the printed export; the flag is an opt-in fast path.
  */
 export function generateBaseplate(
   rawParams: ResolvedBaseplateParams,
@@ -621,7 +621,10 @@ export function buildBaseplateSolid(
       params.lightweight,
       floorCellFilter,
       params.nozzleSizeMm,
-      magnetAnchor
+      magnetAnchor,
+      // The full floor, not the magnet floor: a screw pad makes the floor
+      // deeper, and a magnet-floor cut would seal every void with a membrane.
+      floorDepth
     );
     const floorFrame =
       floorCellFilter === undefined ? overTileFrame : overTileFrame.filter(floorCellFilter);
@@ -634,12 +637,47 @@ export function buildBaseplateSolid(
           pitch,
           params.lightweight,
           params.nozzleSizeMm,
-          magnetAnchor
+          magnetAnchor,
+          floorDepth
         )
       );
     }
     baseplate = cutInBatches(baseplate, floorCutters);
     probe?.('lightweightFloorCut', baseplate);
+  }
+
+  // Mount-down screw pads: with magnets off, only the cells holding a
+  // floor-sited screw keep a floor, which would otherwise stay a full solid
+  // slab. Hollow it exactly like a magnet plate — the cross cut keeps corner
+  // pads sized for the head, and the screw sits in one of them since it
+  // snapped to a magnet position. Magnet plates are covered by the pass above;
+  // solidFloor explicitly wants the continuous floor; the draft fast-path
+  // skips underside detail as ever. Cut depth is the screw pad (floorDepth),
+  // not the magnet floor.
+  if (
+    !draft &&
+    !magnetHoles &&
+    params.lightweight !== false &&
+    !params.solidFloor &&
+    screwParams !== undefined &&
+    screwHoles.some((h) => h.site === 'floor')
+  ) {
+    const screwCellFilter = (cell: CellInfo): boolean =>
+      cellHoldsScrew(cell) && (outline === undefined || classifyCell(cell) === 'inside');
+    const padCutters = buildLightweightFloorCutters(
+      width,
+      depth,
+      screwAwareHoleRadius(magnetDiameter / 2, screwParams),
+      magnetDepth,
+      cellOpts,
+      params.lightweight,
+      screwCellFilter,
+      params.nozzleSizeMm,
+      magnetAnchor,
+      floorDepth
+    );
+    baseplate = cutInBatches(baseplate, padCutters);
+    probe?.('screwPadFloorCut', baseplate);
   }
 
   // Screw holes last among the underside features: the lightweight pass has

--- a/src/features/generation/worker/generators/lightweightFloorCutter.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.ts
@@ -73,10 +73,16 @@ function extrudeCutter(
  *
  * @param gridW Grid width in units
  * @param gridD Grid depth in units
- * @param magnetRadius Magnet hole radius in mm
+ * @param magnetRadius Hole radius (mm) the kept pads are sized around — the
+ * bare magnet radius, or the screw-aware radius when a wider head shares the
+ * position
  * @param magnetDepth Magnet hole depth in mm
  * @param cellOpts Cell iteration options including gridUnitMm
  * @param lightweight Whether lightweight floor is enabled (default true)
+ * @param floorDepthMm Full floor depth (mm) the cut must clear. Absent ⇒ the
+ * magnet floor (MAGNET_FLOOR + magnetDepth). A mount-down screw pad makes the
+ * floor deeper than the magnet floor, and a cut sized to the magnet floor
+ * alone would leave a sealed membrane under every void.
  * @returns Array of cutter solids to subtract from the baseplate
  */
 export function buildLightweightFloorCutters(
@@ -88,13 +94,14 @@ export function buildLightweightFloorCutters(
   lightweight?: boolean,
   cellFilter?: (cell: CellInfo) => boolean,
   nozzleSizeMm?: number,
-  anchor: MagnetAnchor = DEFAULT_MAGNET_ANCHOR
+  anchor: MagnetAnchor = DEFAULT_MAGNET_ANCHOR,
+  floorDepthMm?: number
 ): Shape3D[] {
   if (lightweight === false) return [];
 
   const { x: unitX, y: unitY } = resolvePitch(cellOpts.gridUnitMm);
   const cutterZ = -SOCKET_HEIGHT + COPLANAR_MARGIN;
-  const cutterDepth = MAGNET_FLOOR + magnetDepth + 2 * COPLANAR_MARGIN;
+  const cutterDepth = (floorDepthMm ?? MAGNET_FLOOR + magnetDepth) + 2 * COPLANAR_MARGIN;
   const padMargin = magnetPadMarginForNozzle(nozzleSizeMm);
   const outerWallMargin = magnetOuterWallMarginForNozzle(nozzleSizeMm);
 
@@ -430,12 +437,13 @@ export function buildPartialCellFloorCutters(
   gridUnitMm: GridUnitInput,
   lightweight?: boolean,
   nozzleSizeMm?: number,
-  anchor: MagnetAnchor = DEFAULT_MAGNET_ANCHOR
+  anchor: MagnetAnchor = DEFAULT_MAGNET_ANCHOR,
+  floorDepthMm?: number
 ): Shape3D[] {
   if (lightweight === false) return [];
 
   const cutterZ = -SOCKET_HEIGHT + COPLANAR_MARGIN;
-  const cutterDepth = MAGNET_FLOOR + magnetDepth + 2 * COPLANAR_MARGIN;
+  const cutterDepth = (floorDepthMm ?? MAGNET_FLOOR + magnetDepth) + 2 * COPLANAR_MARGIN;
 
   const cutters: Shape3D[] = [];
   try {

--- a/src/features/generation/worker/generators/lightweightFloorCutter.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.ts
@@ -429,6 +429,9 @@ export function planPartialCellFloorCuts(
  * nominal-grid {@link buildLightweightFloorCutters} only hollows full cells, so
  * clipped padding tiles (a 25×42 side strip, a 42×13 top strip) would otherwise
  * keep a solid underside. Called alongside it so the preview and export match.
+ * `floorDepthMm` has the same contract as on the full-cell builder: the full
+ * floor the cut must clear, absent ⇒ the magnet floor — a screw pad makes the
+ * floor deeper, and a magnet-floor cut would seal each void with a membrane.
  */
 export function buildPartialCellFloorCutters(
   cells: readonly CellInfo[],


### PR DESCRIPTION
## Problem

With magnets off, enabling mount-down screws (#3425) turns every screw-hosting cell into a fully solid floor slab. The expectation is boss pads like the ones magnet plates get.

## Root cause

The only underside hollowing pass (`lightweightFloorCutter`) is gated on `magnetHoles === true`. A screw cell keeps a floor via `cellHoldsScrew`, and nothing ever hollows it.

## Fix

Run the same cross cutter over screw-holding cells (magnets off, no solidFloor, `lightweight` not disabled). Pads are sized by the screw-aware radius, so the head recess always stays inside its pad with margin; the screw lands in a pad by construction since it snaps to a magnet position. Cells where the cross geometry gets tight fall back to the full floor via the cutter's existing `MIN_ARM_WIDTH` guards.

Two adjacent fixes ride the same mechanism:

- **Sealed membrane on magnet+screw plates**: the cross cut depth was hardcoded to the magnet floor. With screws the floor is the pad shortfall deeper, so every cross void was sealed from below by a 0.6mm membrane (wasted material, enclosed cavities). Both cutter passes now cut the plate's true floor depth.
- **Trigger fold follow-up from #3455 review**: the `lightweight` trigger fold becomes stacking-aware and gains screw-pad relevance.

## Seating guarantee

The pad never enters the bin-seating volume: the plate grows downward and the pocket is still cut `SOCKET_HEIGHT` deep. Locked in by a whole-footprint seating sweep in the screws scenario suite (per gotcha #15: sweep, not aimed probes) with an anti-vacuity guard asserting the socket walls register in the band. Pad presence, cross voids, the membrane fix, `lightweight: false`, and the draft fast path are all probed with `verticalSolidSpans`/`isSolidThrough`.

Draft tiers deliberately keep the full floor (underside detail is exact-build-only, matching how magnet pads behave); the exact preview passes `draft=false` so the on-screen plate shows the pads once it lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cross-cuts screw-hosting cells into corner boss pads when magnets are off, replacing the previous full solid floors. The cutter now uses the plate’s true floor depth, fixing sealed membranes on magnet+screw plates and preserving the bin-seating volume; draft and lightweight:false keep full floors.

**Review notes**
- Adds a second lightweight pass over screw cells (magnets off, `solidFloor` off, `lightweight` on) using the screw-aware radius so the head recess stays within its pad.
- Floor-cutter builders accept an explicit floor depth; both passes cut to the plate’s true floor to open cross voids through the deeper screw-pad floor on magnet+screw plates.
- Generation triggers: `lightweight` now matters when screws are on and stacking is off; stacking folds out both magnets and screws so `lightweight` is ignored. Tests cover these cases.
- Scenario tests probe pads/voids and run a whole-footprint seating sweep with an anti-vacuity guard; confirm draft and `lightweight: false` keep the full floor.
- Documentation clarifies the floor-depth parameter contract and trigger fold intent.

<sup>Written for commit b66e4dc7f90aa0262e838006cfd1693ca3a433b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

