### PR TITLE
fix(baseplate): take the half unit that fits when typing plate dimensions

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.test.tsx
@@ -59,9 +59,14 @@ vi.mock('@/shared/hooks/useFeatureFlag', () => ({
 
 // Mock half-bin mode store
 let mockHalfGridMode = false;
+const mockSetHalfGridMode = vi.fn();
+interface MockHalfGridState {
+  halfGridMode: boolean;
+  setHalfGridMode: (enabled: boolean) => void;
+}
 vi.mock('@/core/store/halfGridMode', () => ({
-  useHalfGridModeStore: (selector: (state: { halfGridMode: boolean }) => unknown) =>
-    selector({ halfGridMode: mockHalfGridMode }),
+  useHalfGridModeStore: (selector: (state: MockHalfGridState) => unknown) =>
+    selector({ halfGridMode: mockHalfGridMode, setHalfGridMode: mockSetHalfGridMode }),
   INITIAL_HALF_GRID_MODE_STATE: {},
 }));
 
@@ -159,6 +164,7 @@ describe('BaseplatePanel', () => {
       setMagnetAnchor: mockSetMagnetAnchor,
     };
     mockHalfGridMode = false;
+    mockSetHalfGridMode.mockClear();
     mockTiling = null;
     mockSplitViewMode = 'assembled';
     mockHoveredPieceLabel = null;
@@ -630,9 +636,10 @@ describe('BaseplatePanel', () => {
       const widthInput = screen.getByLabelText('baseplate.editDimensionsWidth');
       const depthInput = screen.getByLabelText('baseplate.editDimensionsDepth');
 
-      // Enter 500mm wide × 300mm deep (halfGridMode=false, step=1)
-      // 500 / 42 = 11.90 → floor to 11 units = 462mm, remainder = 38mm → 19 each
-      // 300 / 42 = 7.14 → floor to 7 = 294mm, remainder = 6mm → 3 each
+      // Enter 500mm wide × 300mm deep, half-grid mode off.
+      // 500 / 42 = 11.90 → 11.5 fits (483mm), remainder = 17mm → 8.5 each. The
+      // half unit is taken even with the mode off, which turns it on (#3463).
+      // 300 / 42 = 7.14 → 7 (294mm); 7.5 overflows, remainder = 6mm → 3 each.
       fireEvent.change(widthInput, { target: { value: '500' } });
       fireEvent.change(depthInput, { target: { value: '300' } });
       fireEvent.keyDown(depthInput, { key: 'Enter' });
@@ -640,14 +647,15 @@ describe('BaseplatePanel', () => {
       expect(mockSetBaseplateParams).toHaveBeenCalledWith(
         expect.objectContaining({
           syncWithLayout: false,
-          baseplateWidth: 11,
+          baseplateWidth: 11.5,
           baseplateDepth: 7,
-          paddingLeft: 19,
-          paddingRight: 19,
+          paddingLeft: 8.5,
+          paddingRight: 8.5,
           paddingFront: 3,
           paddingBack: 3,
         })
       );
+      expect(mockSetHalfGridMode).toHaveBeenCalledWith(true);
     });
 
     it('renders editable dimension button in with-padding mode', () => {
@@ -731,7 +739,9 @@ describe('BaseplatePanel', () => {
     });
 
     it('clamps grid to GRID_MIN when mm value is very small', () => {
-      // 10mm / 42 = 0.24 → floor to 0 but clamped to GRID_MIN (0.5)
+      // 21mm is half a pitch: a whole unit would OVERFLOW the requested plate,
+      // so the half-unit fit wins on slack rather than on size, and takes
+      // half-grid mode with it.
       render(<BaseplatePanel />);
       fireEvent.click(screen.getByRole('button', { name: 'baseplate.editDimensions' }));
       const widthInput = screen.getByLabelText('baseplate.editDimensionsWidth');
@@ -746,6 +756,7 @@ describe('BaseplatePanel', () => {
           baseplateDepth: 0.5,
         })
       );
+      expect(mockSetHalfGridMode).toHaveBeenCalledWith(true);
     });
 
     it('clamps grid to GRID_MAX when mm value is very large', () => {

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DimensionsSection } from './DimensionsSection';
 import { useLayoutStore } from '@/core/store/layout';
+import { useHalfGridModeStore } from '@/core/store/halfGridMode';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
 import { mm } from '@/core/types';
 import { resetAllStores } from '@/test/testUtils';
@@ -36,6 +37,52 @@ describe('DimensionsSection', () => {
     fireEvent.click(toggle);
     fireEvent.click(toggle);
     expect(useLayoutStore.getState().layout.baseplateParams?.syncWithLayout).toBe(true);
+  });
+
+  // #3463. Typing a physical drawer size must land the tightest grid that fits,
+  // the same fit the layout's measured-drawer card offers. Snapping to whole
+  // units while a half unit fits hands the user a plate 21mm short of the drawer
+  // and buries the difference in padding.
+  describe('mm entry', () => {
+    function commitMm(widthMm: string, depthMm: string): void {
+      fireEvent.click(screen.getByLabelText('baseplate.editDimensions'));
+      fireEvent.change(screen.getByLabelText('baseplate.editDimensionsWidth'), {
+        target: { value: widthMm },
+      });
+      const depth = screen.getByLabelText('baseplate.editDimensionsDepth');
+      fireEvent.change(depth, { target: { value: depthMm } });
+      fireEvent.keyDown(depth, { key: 'Enter' });
+    }
+
+    it('takes the half unit that fits instead of burying it in padding', () => {
+      render(<DimensionsSection />);
+      commitMm('423', '502');
+
+      const params = useLayoutStore.getState().layout.baseplateParams;
+      // 502 / 42 = 11.95 units: 11.5 fits, leaving 19mm rather than 40mm.
+      expect(params?.baseplateDepth).toBe(11.5);
+      expect(params?.paddingFront).toBeCloseTo(9.5, 2);
+      expect(params?.paddingBack).toBeCloseTo(9.5, 2);
+      // 423 / 42 = 10.07: no half unit fits, so width stays whole.
+      expect(params?.baseplateWidth).toBe(10);
+      expect(params?.paddingLeft).toBeCloseTo(1.5, 2);
+    });
+
+    it('turns half-grid mode on when the fit needs it', () => {
+      expect(useHalfGridModeStore.getState().halfGridMode).toBe(false);
+      render(<DimensionsSection />);
+      commitMm('423', '502');
+      expect(useHalfGridModeStore.getState().halfGridMode).toBe(true);
+    });
+
+    it('leaves half-grid mode alone when whole units already fit tightest', () => {
+      render(<DimensionsSection />);
+      commitMm('423', '465');
+
+      const params = useLayoutStore.getState().layout.baseplateParams;
+      expect(params?.baseplateDepth).toBe(11);
+      expect(useHalfGridModeStore.getState().halfGridMode).toBe(false);
+    });
   });
 
   describe('margin seam connector style gate', () => {

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
@@ -23,6 +23,7 @@ import { PADDING_MAX } from '../PaddingStepper';
 import { gridUnits, mm, effectiveGridUnitMmY } from '@/core/types';
 import { isMarginSeamStyle } from '@/shared/types/bin';
 import { cornerCutsMatchVertices } from '@/shared/utils/cornerCutOutline';
+import { fitAxisUnits, halfUnitUpgrade } from '@/shared/utils/drawerFit';
 import { padOutline } from '@/shared/utils/padOutline';
 import {
   updateBaseplateParam as updateParam,
@@ -57,6 +58,7 @@ export function DimensionsSection() {
     freeformShaped,
   } = useBaseplatePanelDerived();
   const halfGridMode = useHalfGridModeStore((s) => s.halfGridMode);
+  const setHalfGridMode = useHalfGridModeStore((s) => s.setHalfGridMode);
 
   const handleSyncToggle = useCallback((checked: boolean) => {
     const layoutState = useLayoutStore.getState().layout;
@@ -162,6 +164,16 @@ export function DimensionsSection() {
    * 2. Distribute remaining mm evenly as padding (left=right, front=back)
    * 3. Auto-uncheck "Sync with layout"
    *
+   * Step 1 goes through the same `fitAxisUnits`/`halfUnitUpgrade` pair the
+   * layout's measured-drawer card uses, so both entry points agree on what the
+   * tightest fit is. Stepping by whole units whenever half-grid mode happened to
+   * be off silently discarded a half unit that fits — a 502mm drawer became 11
+   * units and 40mm of dead padding instead of 11.5 and 19mm (#3463) — and
+   * pushed users into over-tile to recover a row the grid should have had.
+   * Taking a half fit turns half-grid mode on, matching the card's Use button:
+   * a fractional dimension with the mode off is a state the steppers and the
+   * half-unit edge toggle can't express.
+   *
    * Exception: a synced corner-cut shaped plate keeps sync AND its shape —
    * the grid is fixed by the layout, so the whole remainder becomes padding
    * (the basket workflow: measure, type dims, rounded shape persists).
@@ -196,23 +208,22 @@ export function DimensionsSection() {
         return;
       }
 
-      const step = halfGridMode ? 0.5 : 1;
+      const widthFit = fitAxisUnits(targetWidthMm, gridUnitMm, halfGridMode);
+      const depthFit = fitAxisUnits(targetDepthMm, gridUnitMmY, halfGridMode);
+      const widthUpgrade = halfGridMode
+        ? null
+        : halfUnitUpgrade(targetWidthMm, gridUnitMm, widthFit.units);
+      const depthUpgrade = halfGridMode
+        ? null
+        : halfUnitUpgrade(targetDepthMm, gridUnitMmY, depthFit.units);
+      const snappedWidth = (widthUpgrade ?? widthFit).units;
+      const snappedDepth = (depthUpgrade ?? depthFit).units;
+      if (widthUpgrade !== null || depthUpgrade !== null) setHalfGridMode(true);
 
-      const rawWidthUnits = targetWidthMm / gridUnitMm;
-      const rawDepthUnits = targetDepthMm / gridUnitMmY;
-
-      // Floor so the grid never exceeds the target — remainder becomes positive padding
-      const snappedWidth = Math.max(
-        CONSTRAINTS.GRID_MIN,
-        Math.min(CONSTRAINTS.GRID_MAX, Math.floor(rawWidthUnits / step) * step)
-      );
-      const snappedDepth = Math.max(
-        CONSTRAINTS.GRID_MIN,
-        Math.min(CONSTRAINTS.GRID_MAX, Math.floor(rawDepthUnits / step) * step)
-      );
-
-      const remainderWidth = Math.max(0, targetWidthMm - snappedWidth * gridUnitMm);
-      const remainderDepth = Math.max(0, targetDepthMm - snappedDepth * gridUnitMmY);
+      // Clamp at 0: `slackMm` goes negative when GRID_MIN forced a grid larger
+      // than the target, and padding can't absorb a deficit.
+      const remainderWidth = Math.max(0, (widthUpgrade ?? widthFit).slackMm);
+      const remainderDepth = Math.max(0, (depthUpgrade ?? depthFit).slackMm);
 
       const halfPadWidth = Math.floor((remainderWidth / 2) * 100) / 100;
       const halfPadDepth = Math.floor((remainderDepth / 2) * 100) / 100;
@@ -232,7 +243,7 @@ export function DimensionsSection() {
         paddingBack: mm(halfPadDepth),
       });
     },
-    [gridUnitMm, gridUnitMmY, halfGridMode]
+    [gridUnitMm, gridUnitMmY, halfGridMode, setHalfGridMode]
   );
 
   return (

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
@@ -220,8 +220,9 @@ export function DimensionsSection() {
       const snappedDepth = (depthUpgrade ?? depthFit).units;
       if (widthUpgrade !== null || depthUpgrade !== null) setHalfGridMode(true);
 
-      // Clamp at 0: `slackMm` goes negative when GRID_MIN forced a grid larger
-      // than the target, and padding can't absorb a deficit.
+      // Clamp at 0: `slackMm` goes negative when the fit's minimum (1 unit in
+      // whole-unit mode, GRID_MIN in half) forced a grid larger than the
+      // target, and padding can't absorb a deficit.
       const remainderWidth = Math.max(0, (widthUpgrade ?? widthFit).slackMm);
       const remainderDepth = Math.max(0, (depthUpgrade ?? depthFit).slackMm);
 

--- a/src/shared/utils/drawerFit.test.ts
+++ b/src/shared/utils/drawerFit.test.ts
@@ -57,4 +57,15 @@ describe('halfUnitUpgrade', () => {
   it('offers the upgrade exactly at the half-cell threshold', () => {
     expect(halfUnitUpgrade(441, 42, 10)).toEqual({ units: 10.5, slackMm: 0 });
   });
+
+  // Under one pitch the whole-unit fit is clamped UP to 1 and overflows, so the
+  // half-unit fit is smaller yet strictly better — the size comparison alone
+  // rejected it and handed back a grid wider than the drawer.
+  it('offers a SMALLER half-unit fit when the whole unit overflows the drawer', () => {
+    expect(halfUnitUpgrade(21, 42, 1)).toEqual({ units: 0.5, slackMm: 0 });
+  });
+
+  it('stays null when neither fit fits', () => {
+    expect(halfUnitUpgrade(10, 42, 1)).toBeNull();
+  });
 });

--- a/src/shared/utils/drawerFit.ts
+++ b/src/shared/utils/drawerFit.ts
@@ -28,6 +28,12 @@ export function fitAxisUnits(measuredMm: number, gridUnitMm: number, allowHalf: 
 /**
  * The tighter half-unit fit for an axis, or null when the whole-unit fit is
  * already as tight as a half-unit grid can get (remainder < pitch / 2).
+ *
+ * Two ways a half-unit grid wins. Usually it reaches further into the drawer
+ * (`units` is larger). But below one full pitch the whole-unit fit is clamped
+ * UP to 1 and overflows the drawer, and there `units` moves the other way — a
+ * half unit that FITS is the upgrade over a whole unit that doesn't, so the
+ * comparison has to be on slack, not size alone.
  */
 export function halfUnitUpgrade(
   measuredMm: number,
@@ -35,5 +41,7 @@ export function halfUnitUpgrade(
   wholeUnits: number
 ): AxisFit | null {
   const half = fitAxisUnits(measuredMm, gridUnitMm, true);
-  return half.units > wholeUnits ? half : null;
+  if (half.units > wholeUnits) return half;
+  const wholeOverflows = measuredMm - wholeUnits * gridUnitMm < -FLOAT_EPSILON;
+  return wholeOverflows && half.slackMm >= -FLOAT_EPSILON ? half : null;
 }


### PR DESCRIPTION
Fixes #3463.

## The defect

Typing physical dimensions into the baseplate panel snapped the grid down to whole units whenever half-grid mode happened to be off, so a half unit that fits was discarded into padding. The reporter's 423 × 502 drawer landed as **10 × 11 grid + 40mm of dead margin** instead of **10 × 11.5 + 19mm**.

The layout tab's measured-drawer card already offered the tighter fit for the same input (`fitAxisUnits` / `halfUnitUpgrade`), so two entry points doing the same job disagreed about the same drawer. `handleDimensionCommit`'s own doc comment claimed it snapped to "the largest valid grid size that fits (half-unit or whole-unit)" — the comment described the intent, the code stepped by `halfGridMode ? 0.5 : 1`.

That missing row is what sent the reporter to over-tile half-grid: it recovers the half row in the printed geometry, but the layout grid never learns about it, and `canPlaceBin` bounds placement by `drawer.depth`. So the space was visible and undrawable.

## The fix

Route the baseplate mm entry through the same `fitAxisUnits`/`halfUnitUpgrade` pair as the layout card. Taking a half fit turns half-grid mode on, as the card's Use button does — a fractional `baseplateDepth` with the mode off is a state the grid steppers and the half-unit edge toggle can't express.

| input | before | after |
| --- | --- | --- |
| 423 × 502 | 10 × 11, pad 1.5 / 20 | 10 × **11.5**, pad 1.5 / **9.5** |
| 500 × 300 | 11 × 7, pad 19 / 3 | **11.5** × 7, pad **8.5** / 3 |
| 420 × 252 | 10 × 6, pad 0 | unchanged |

Reusing the helper surfaced a second defect in it. `halfUnitUpgrade` decided "is the half fit better?" with `half.units > wholeUnits`, a size proxy that inverts below one pitch: there the whole-unit fit is clamped *up* to 1 and overflows the drawer, so a **smaller** half unit that fits is the upgrade. Now compared on slack. That case was already reachable from the layout card for a sub-42mm drawer.

## Verification

- Failing tests written first (`DimensionsSection.test.tsx` mm-entry block), then the fix.
- Confirmed both directions at the placement layer: at `depth: 11.5` the top half row passes `canPlaceBin`; at `11` it returns `exceeds_depth` — the wall the reporter hit.
- Two `BaseplatePanel.test.tsx` expectations updated to the corrected fit; one of them (`21mm → 0.5 units`) is the overflow case above, which now also enables half-grid mode rather than leaving a fractional plate with the mode off.
- Full suite green (22,153 passed), typecheck and lint clean.

## Not in this PR

Placing bins in an over-tile margin. Over-tile half-grid packs true 0.5-unit sockets from the grid edge outward, so they are lattice-aligned and *could* be placeable — but the drawer model carries one fractional edge per axis, so a plate with a half row on both front and back has no representation. The right decomposition is for those cells to be grid in the first place, which is what this fix produces. Left as a separate discussion on the issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typing drawer dimensions in the baseplate panel now fits the largest grid that fits (including half units) and enables half‑grid mode when needed. Previously it snapped to whole units when half‑grid mode was off, burying a fitting half unit in padding and disagreeing with the layout card (fixes #3463).

- Route mm entry through shared `fitAxisUnits`/`halfUnitUpgrade` logic so the panel matches the layout’s measured‑drawer card; enable half‑grid mode when a half‑unit fit is selected.
- Fix `halfUnitUpgrade` to choose by slack, not unit count, so sub‑pitch drawers select 0.5 units when 1 unit would overflow; return null when neither fit fits.
- Clamp negative padding to 0 when the minimum grid (1 unit in whole‑grid, `GRID_MIN` in half‑grid) exceeds the target; clarify the inline slack comment to name this clamp.
- Update tests in `DimensionsSection.test.tsx`, `BaseplatePanel.test.tsx`, and `drawerFit.test.ts` to cover half‑fit selection, half‑grid mode toggle, and sub‑pitch behavior.

<sup>Written for commit cc404158a59a137b8c6af9b6c6d2361e3e0942e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

