### PR TITLE
fix(bin-designer): arrange cutout groups as one body

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -387,7 +387,6 @@ export function CutoutWorkspace() {
         selection={selection}
         binWidth={binWidth}
         binDepth={binDepth}
-        onUpdate={updateCutout}
         onUpdateBatch={updateCutoutsBatch}
         onRemove={removeCutout}
         onDuplicate={duplicateCutouts}

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
@@ -13,6 +13,7 @@ import { CHAMFER_SHAPES, MAX_CUTOUT_CHAMFER, maxEntryChamfer } from '@/features/
 import type { FitCue } from '../panel/CutoutsSection/cutoutSectionVisibility';
 import type { GrowTarget } from '../panel/CutoutsSection/growBinToFit';
 import { alignSelection, distributeSelection } from '../panel/CutoutsSection/geometryAlign';
+import { expandSelectionToGroups } from '../panel/CutoutsSection/cutoutGroups';
 import type { AlignMode, DistributeAxis } from '../panel/CutoutsSection/geometryAlign';
 import { SingleCutoutInspector } from './SingleCutoutInspector';
 import { CutoutColorControls } from './CutoutColorControls';
@@ -121,6 +122,13 @@ export function InspectorContent({
   const selectedCutouts = useMemo(
     () => cutouts.filter((c) => selection.has(c.id)),
     [cutouts, selection]
+  );
+
+  // Align/distribute treat a group as one rigid body, so a partially-selected
+  // group is pulled in whole before the math runs (#3468).
+  const arrangeTargets = useMemo(
+    () => expandSelectionToGroups(cutouts, selectedCutouts),
+    [cutouts, selectedCutouts]
   );
 
   // Bin-level controls stay visible across every selection state so the user can
@@ -232,10 +240,10 @@ export function InspectorContent({
   };
 
   const handleAlign = (mode: AlignMode) =>
-    applySelectionUpdates(alignSelection(selectedCutouts, mode));
+    applySelectionUpdates(alignSelection(arrangeTargets, mode));
 
   const handleDistribute = (axis: DistributeAxis) =>
-    applySelectionUpdates(distributeSelection(selectedCutouts, axis));
+    applySelectionUpdates(distributeSelection(arrangeTargets, axis));
 
   // Non-rectangle cutouts collapse W/D to a single value via max() in the
   // generator, so writing only one axis would silently no-op when the other is

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.test.tsx
@@ -36,7 +36,6 @@ const defaultProps = {
   selection: new Set<string>(),
   binWidth: 40,
   binDepth: 40,
-  onUpdate: vi.fn(),
   onUpdateBatch: vi.fn(),
   onRemove: vi.fn(),
   onDuplicate: vi.fn(),

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
@@ -13,13 +13,15 @@ import { Button, Checkbox, IconButton, Input } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog/ConfirmDialog';
 import {
-  computeBounds,
-  getEffectiveBounds,
-  getEffectiveDepth,
   distributeHorizontally,
   distributeVertically,
   centerInBin,
 } from '../panel/CutoutsSection/geometry';
+import {
+  expandSelectionToGroups,
+  toArrangeUnits,
+  unitsBounds,
+} from '../panel/CutoutsSection/cutoutGroups';
 import { autoArrangeCutouts } from '../panel/CutoutsSection/autoArrange';
 import { PathfinderControls } from '../panel/CutoutsSection/PathfinderControls';
 import { canGroupSelection } from '../panel/CutoutsSection/pathfinderHelpers';
@@ -216,7 +218,6 @@ interface WorkspaceHeaderProps {
   readonly selection: ReadonlySet<string>;
   readonly binWidth: number;
   readonly binDepth: number;
-  readonly onUpdate: (id: string, updates: Partial<Cutout>) => void;
   readonly onUpdateBatch: (updates: ReadonlyMap<string, Partial<Cutout>>) => void;
   readonly onRemove: (id: string) => void;
   readonly onDuplicate: (ids: readonly string[]) => void;
@@ -243,7 +244,6 @@ export function WorkspaceHeader({
   selection,
   binWidth,
   binDepth,
-  onUpdate,
   onUpdateBatch,
   onRemove,
   onDuplicate,
@@ -268,77 +268,88 @@ export function WorkspaceHeader({
   const hasGroup = selected.some((c) => c.groupId !== null);
   const canGroup = canGroupSelection(selectedIds, cutouts);
   const singleCutout = selection.size === 1 ? (selected[0] ?? null) : null;
+
+  // Arrange operates on whole groups, so a partially-selected group still moves
+  // as one body (#3468).
+  const arrangeTargets = useMemo(
+    () => expandSelectionToGroups(cutouts, selected),
+    [cutouts, selected]
+  );
+
+  const applyPositions = useCallback(
+    (positions: Record<string, { x?: number; y?: number }>) => {
+      const updates = new Map<string, Partial<Cutout>>(Object.entries(positions));
+      if (updates.size > 0) onUpdateBatch(updates);
+    },
+    [onUpdateBatch]
+  );
+
   const handleAlign = useCallback(
     (type: AlignType) => {
-      const bounds = computeBounds(selected);
-      for (const cutout of selected) {
-        const eb = getEffectiveBounds(cutout);
-        let newX: number | undefined;
-        let newY: number | undefined;
+      const units = toArrangeUnits(arrangeTargets);
+      const bounds = unitsBounds(units);
+      const positions: Record<string, { x?: number; y?: number }> = {};
+
+      for (const unit of units) {
+        if (unit.locked) continue;
+        const eb = unit.bounds;
+        let dx = 0;
+        let dy = 0;
 
         switch (type) {
           case 'left':
-            newX = bounds.minX;
+            dx = bounds.minX - eb.minX;
             break;
           case 'right':
-            newX = bounds.maxX - (eb.maxX - eb.minX);
+            dx = bounds.maxX - eb.maxX;
             break;
           case 'top':
-            newY = bounds.maxY - getEffectiveDepth(cutout);
+            dy = bounds.maxY - eb.maxY;
             break;
           case 'bottom':
-            newY = bounds.minY;
+            dy = bounds.minY - eb.minY;
             break;
-          case 'center-h': {
-            const centerX = (bounds.minX + bounds.maxX) / 2;
-            newX = centerX - (eb.maxX - eb.minX) / 2;
+          case 'center-h':
+            dx = (bounds.minX + bounds.maxX) / 2 - (eb.minX + eb.maxX) / 2;
             break;
-          }
-          case 'center-v': {
-            const centerY = (bounds.minY + bounds.maxY) / 2;
-            newY = centerY - getEffectiveDepth(cutout) / 2;
+          case 'center-v':
+            dy = (bounds.minY + bounds.maxY) / 2 - (eb.minY + eb.maxY) / 2;
             break;
-          }
         }
 
-        onUpdate(cutout.id, {
-          ...(newX !== undefined ? { x: newX } : {}),
-          ...(newY !== undefined ? { y: newY } : {}),
-        });
+        // A unit already on the line needs no write — emitting one would dirty
+        // the design and cost an undo step for nothing.
+        if (dx === 0 && dy === 0) continue;
+
+        for (const member of unit.members) {
+          positions[member.id] = {
+            ...(dx !== 0 ? { x: member.x + dx } : {}),
+            ...(dy !== 0 ? { y: member.y + dy } : {}),
+          };
+        }
       }
+      applyPositions(positions);
     },
-    [selected, onUpdate]
+    [arrangeTargets, applyPositions]
   );
 
   const handleDistributeH = useCallback(() => {
-    const positions = distributeHorizontally(selected, binWidth);
-    for (const [id, pos] of Object.entries(positions)) {
-      onUpdate(id, pos);
-    }
-  }, [selected, binWidth, onUpdate]);
+    applyPositions(distributeHorizontally(arrangeTargets, binWidth));
+  }, [arrangeTargets, binWidth, applyPositions]);
 
   const handleDistributeV = useCallback(() => {
-    const positions = distributeVertically(selected, binDepth);
-    for (const [id, pos] of Object.entries(positions)) {
-      onUpdate(id, pos);
-    }
-  }, [selected, binDepth, onUpdate]);
+    applyPositions(distributeVertically(arrangeTargets, binDepth));
+  }, [arrangeTargets, binDepth, applyPositions]);
 
   const handleCenterInBin = useCallback(() => {
-    const positions = centerInBin(selected, binWidth, binDepth);
-    for (const [id, pos] of Object.entries(positions)) {
-      onUpdate(id, pos);
-    }
-  }, [selected, binWidth, binDepth, onUpdate]);
+    applyPositions(centerInBin(arrangeTargets, binWidth, binDepth));
+  }, [arrangeTargets, binWidth, binDepth, applyPositions]);
 
   const handleAutoArrange = useCallback(
     (gap: number, staggered: boolean) => {
-      const positions = autoArrangeCutouts(selected, { binWidth, binDepth, gap, staggered });
-      for (const [id, pos] of Object.entries(positions)) {
-        onUpdate(id, pos);
-      }
+      applyPositions(autoArrangeCutouts(arrangeTargets, { binWidth, binDepth, gap, staggered }));
     },
-    [selected, binWidth, binDepth, onUpdate]
+    [arrangeTargets, binWidth, binDepth, applyPositions]
   );
   const iconBtn = (
     onClick: () => void,

--- a/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.test.tsx
@@ -26,7 +26,6 @@ const createCutout = (id: string, overrides: Partial<Cutout> = {}): Cutout => ({
 });
 
 describe('AlignmentToolbar', () => {
-  const onUpdate = vi.fn();
   const onUpdateBatch = vi.fn();
   const onGroup = vi.fn();
   const onUngroup = vi.fn();
@@ -43,7 +42,6 @@ describe('AlignmentToolbar', () => {
     cutouts,
     binWidth: 100,
     binDepth: 100,
-    onUpdate,
     onUpdateBatch,
     onGroup,
     onUngroup,
@@ -69,14 +67,49 @@ describe('AlignmentToolbar', () => {
     expect(screen.getByLabelText('binDesigner.cutouts.alignBottom')).toBeInTheDocument();
   });
 
-  it('calls onUpdate for each cutout when aligning left', () => {
+  it('batches one update per cutout when aligning left', () => {
     render(<AlignmentToolbar {...defaultProps} />);
     fireEvent.click(screen.getByLabelText('binDesigner.cutouts.alignLeft'));
 
-    // Both cutouts should align to minX = 5 (cutoutA's x)
-    expect(onUpdate).toHaveBeenCalledTimes(2);
-    expect(onUpdate).toHaveBeenCalledWith('a', expect.objectContaining({ x: 5 }));
-    expect(onUpdate).toHaveBeenCalledWith('b', expect.objectContaining({ x: 5 }));
+    // Both cutouts align to minX = 5 (cutoutA's x). 'a' is already there, so
+    // only 'b' is written.
+    expect(onUpdateBatch).toHaveBeenCalledTimes(1);
+    const updates = onUpdateBatch.mock.calls[0][0] as ReadonlyMap<string, Partial<Cutout>>;
+    expect(updates.has('a')).toBe(false);
+    expect(updates.get('b')).toEqual(expect.objectContaining({ x: 5 }));
+  });
+
+  it('keeps a group rigid when auto-arranging (#3468)', () => {
+    // Two shapes 30mm apart, grouped, plus a loose shape. Auto-arrange must
+    // reposition the group as one body rather than shelving its members apart.
+    const grouped = [
+      createCutout('g1a', { groupId: 'g1', x: 60, y: 60 }),
+      createCutout('g1b', { groupId: 'g1', x: 90, y: 60 }),
+      createCutout('solo', { x: 5, y: 5 }),
+    ];
+    render(
+      <AlignmentToolbar {...defaultProps} cutouts={grouped} selectedIds={['g1a', 'g1b', 'solo']} />
+    );
+    fireEvent.click(screen.getByText('binDesigner.cutouts.autoArrange'));
+
+    const updates = onUpdateBatch.mock.calls[0][0] as ReadonlyMap<string, Partial<Cutout>>;
+    const a = updates.get('g1a');
+    const b = updates.get('g1b');
+    expect((b?.x ?? 0) - (a?.x ?? 0)).toBe(30);
+    expect(b?.y).toBe(a?.y);
+  });
+
+  it('pulls in the unselected members of a partially selected group', () => {
+    const grouped = [
+      createCutout('g1a', { groupId: 'g1', x: 60, y: 60 }),
+      createCutout('g1b', { groupId: 'g1', x: 90, y: 60 }),
+      createCutout('solo', { x: 5, y: 5 }),
+    ];
+    render(<AlignmentToolbar {...defaultProps} cutouts={grouped} selectedIds={['g1a', 'solo']} />);
+    fireEvent.click(screen.getByText('binDesigner.cutouts.centerInBin'));
+
+    const updates = onUpdateBatch.mock.calls[0][0] as ReadonlyMap<string, Partial<Cutout>>;
+    expect(updates.has('g1b')).toBe(true);
   });
 
   it('calls onDuplicate with selectedIds', () => {
@@ -182,7 +215,7 @@ describe('AlignmentToolbar', () => {
     expect(distributeVBtn).not.toBeDisabled();
   });
 
-  it('calls onUpdate for each cutout when distributing horizontally', () => {
+  it('batches one update per cutout when distributing horizontally', () => {
     const threeCutouts = [
       createCutout('a', { x: 10, width: 10 }),
       createCutout('b', { x: 50, width: 10 }),
@@ -193,13 +226,14 @@ describe('AlignmentToolbar', () => {
     );
     fireEvent.click(screen.getByText('binDesigner.cutouts.distributeH'));
 
-    expect(onUpdate).toHaveBeenCalledTimes(3);
-    expect(onUpdate).toHaveBeenCalledWith('a', expect.objectContaining({ x: expect.any(Number) }));
-    expect(onUpdate).toHaveBeenCalledWith('b', expect.objectContaining({ x: expect.any(Number) }));
-    expect(onUpdate).toHaveBeenCalledWith('c', expect.objectContaining({ x: expect.any(Number) }));
+    expect(onUpdateBatch).toHaveBeenCalledTimes(1);
+    const updates = onUpdateBatch.mock.calls[0][0] as ReadonlyMap<string, Partial<Cutout>>;
+    for (const id of ['a', 'b', 'c']) {
+      expect(updates.get(id)).toEqual(expect.objectContaining({ x: expect.any(Number) }));
+    }
   });
 
-  it('calls onUpdate for each cutout when distributing vertically', () => {
+  it('batches one update per cutout when distributing vertically', () => {
     const threeCutouts = [
       createCutout('a', { y: 10, depth: 10 }),
       createCutout('b', { y: 60, depth: 10 }),
@@ -210,10 +244,11 @@ describe('AlignmentToolbar', () => {
     );
     fireEvent.click(screen.getByText('binDesigner.cutouts.distributeV'));
 
-    expect(onUpdate).toHaveBeenCalledTimes(3);
-    expect(onUpdate).toHaveBeenCalledWith('a', expect.objectContaining({ y: expect.any(Number) }));
-    expect(onUpdate).toHaveBeenCalledWith('b', expect.objectContaining({ y: expect.any(Number) }));
-    expect(onUpdate).toHaveBeenCalledWith('c', expect.objectContaining({ y: expect.any(Number) }));
+    expect(onUpdateBatch).toHaveBeenCalledTimes(1);
+    const updates = onUpdateBatch.mock.calls[0][0] as ReadonlyMap<string, Partial<Cutout>>;
+    for (const id of ['a', 'b', 'c']) {
+      expect(updates.get(id)).toEqual(expect.objectContaining({ y: expect.any(Number) }));
+    }
   });
 
   it('renders center-in-bin button', () => {
@@ -221,18 +256,16 @@ describe('AlignmentToolbar', () => {
     expect(screen.getByText('binDesigner.cutouts.centerInBin')).toBeInTheDocument();
   });
 
-  it('calls onUpdate for each cutout when centering in bin', () => {
+  it('batches one update per cutout when centering in bin', () => {
     render(<AlignmentToolbar {...defaultProps} />);
     fireEvent.click(screen.getByText('binDesigner.cutouts.centerInBin'));
 
-    expect(onUpdate).toHaveBeenCalledTimes(2);
-    expect(onUpdate).toHaveBeenCalledWith(
-      'a',
-      expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) })
-    );
-    expect(onUpdate).toHaveBeenCalledWith(
-      'b',
-      expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) })
-    );
+    expect(onUpdateBatch).toHaveBeenCalledTimes(1);
+    const updates = onUpdateBatch.mock.calls[0][0] as ReadonlyMap<string, Partial<Cutout>>;
+    for (const id of ['a', 'b']) {
+      expect(updates.get(id)).toEqual(
+        expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) })
+      );
+    }
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
@@ -10,14 +10,8 @@ import { useState } from 'react';
 import type { Cutout, GroupOp, ReorderDirection } from '@/features/bin-designer/types';
 import { Button, IconButton, Input } from '@/design-system';
 import { useTranslation } from '@/i18n';
-import {
-  computeBounds,
-  getEffectiveBounds,
-  getEffectiveDepth,
-  distributeHorizontally,
-  distributeVertically,
-  centerInBin,
-} from './geometry';
+import { distributeHorizontally, distributeVertically, centerInBin } from './geometry';
+import { expandSelectionToGroups, toArrangeUnits, unitsBounds } from './cutoutGroups';
 import { autoArrangeCutouts } from './autoArrange';
 import { PathfinderControls } from './PathfinderControls';
 import { canGroupSelection } from './pathfinderHelpers';
@@ -29,7 +23,6 @@ interface AlignmentToolbarProps {
   readonly cutouts: readonly Cutout[];
   readonly binWidth: number;
   readonly binDepth: number;
-  readonly onUpdate: (id: string, updates: Partial<Cutout>) => void;
   readonly onUpdateBatch: (updates: ReadonlyMap<string, Partial<Cutout>>) => void;
   readonly onGroup: (ids: readonly string[], op?: GroupOp) => void;
   readonly onUngroup: (ids: readonly string[]) => void;
@@ -134,7 +127,6 @@ export function AlignmentToolbar({
   cutouts,
   binWidth,
   binDepth,
-  onUpdate,
   onUpdateBatch,
   onGroup,
   onUngroup,
@@ -149,72 +141,75 @@ export function AlignmentToolbar({
   const hasGroup = selected.some((c) => c.groupId !== null);
   const canGroup = canGroupSelection(selectedIds, cutouts);
 
-  const handleAlign = (type: AlignType) => {
-    const bounds = computeBounds(selected);
+  // Arrange operates on whole groups, so a partially-selected group still moves
+  // as one body (#3468).
+  const arrangeTargets = expandSelectionToGroups(cutouts, selected);
 
-    for (const cutout of selected) {
-      const eb = getEffectiveBounds(cutout);
-      let newX: number | undefined;
-      let newY: number | undefined;
+  const applyPositions = (positions: Record<string, { x?: number; y?: number }>) => {
+    const updates = new Map<string, Partial<Cutout>>(Object.entries(positions));
+    if (updates.size > 0) onUpdateBatch(updates);
+  };
+
+  const handleAlign = (type: AlignType) => {
+    const units = toArrangeUnits(arrangeTargets);
+    const bounds = unitsBounds(units);
+    const positions: Record<string, { x?: number; y?: number }> = {};
+
+    for (const unit of units) {
+      if (unit.locked) continue;
+      const eb = unit.bounds;
+      let dx = 0;
+      let dy = 0;
 
       switch (type) {
         case 'left':
-          newX = bounds.minX;
+          dx = bounds.minX - eb.minX;
           break;
         case 'right':
-          newX = bounds.maxX - (eb.maxX - eb.minX);
+          dx = bounds.maxX - eb.maxX;
           break;
         case 'top':
-          newY = bounds.maxY - getEffectiveDepth(cutout);
+          dy = bounds.maxY - eb.maxY;
           break;
         case 'bottom':
-          newY = bounds.minY;
+          dy = bounds.minY - eb.minY;
           break;
-        case 'center-h': {
-          const centerX = (bounds.minX + bounds.maxX) / 2;
-          newX = centerX - (eb.maxX - eb.minX) / 2;
+        case 'center-h':
+          dx = (bounds.minX + bounds.maxX) / 2 - (eb.minX + eb.maxX) / 2;
           break;
-        }
-        case 'center-v': {
-          const centerY = (bounds.minY + bounds.maxY) / 2;
-          newY = centerY - getEffectiveDepth(cutout) / 2;
+        case 'center-v':
+          dy = (bounds.minY + bounds.maxY) / 2 - (eb.minY + eb.maxY) / 2;
           break;
-        }
       }
 
-      onUpdate(cutout.id, {
-        ...(newX !== undefined ? { x: newX } : {}),
-        ...(newY !== undefined ? { y: newY } : {}),
-      });
+      // A unit already on the line needs no write — emitting one would dirty
+      // the design and cost an undo step for nothing.
+      if (dx === 0 && dy === 0) continue;
+
+      for (const member of unit.members) {
+        positions[member.id] = {
+          ...(dx !== 0 ? { x: member.x + dx } : {}),
+          ...(dy !== 0 ? { y: member.y + dy } : {}),
+        };
+      }
     }
+    applyPositions(positions);
   };
 
   const handleAutoArrange = () => {
-    const positions = autoArrangeCutouts(selected, { binWidth, binDepth, gap });
-    for (const [id, pos] of Object.entries(positions)) {
-      onUpdate(id, pos);
-    }
+    applyPositions(autoArrangeCutouts(arrangeTargets, { binWidth, binDepth, gap }));
   };
 
   const handleDistributeH = () => {
-    const positions = distributeHorizontally(selected, binWidth);
-    for (const [id, pos] of Object.entries(positions)) {
-      onUpdate(id, pos);
-    }
+    applyPositions(distributeHorizontally(arrangeTargets, binWidth));
   };
 
   const handleDistributeV = () => {
-    const positions = distributeVertically(selected, binDepth);
-    for (const [id, pos] of Object.entries(positions)) {
-      onUpdate(id, pos);
-    }
+    applyPositions(distributeVertically(arrangeTargets, binDepth));
   };
 
   const handleCenterInBin = () => {
-    const positions = centerInBin(selected, binWidth, binDepth);
-    for (const [id, pos] of Object.entries(positions)) {
-      onUpdate(id, pos);
-    }
+    applyPositions(centerInBin(arrangeTargets, binWidth, binDepth));
   };
 
   const alignButton = (type: AlignType, label: string) => (

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
@@ -550,7 +550,6 @@ export function CutoutEditor() {
           cutouts={cutouts}
           binWidth={binWidth}
           binDepth={binDepth}
-          onUpdate={updateCutout}
           onUpdateBatch={updateCutoutsBatch}
           onGroup={groupCutouts}
           onUngroup={ungroupCutouts}

--- a/src/features/bin-designer/components/panel/CutoutsSection/autoArrange.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/autoArrange.test.ts
@@ -70,4 +70,85 @@ describe('autoArrangeCutouts', () => {
     expect(result.a).toEqual({ x: 5, y: 5 });
     expect(result.b).toEqual({ x: 20, y: 5 }); // 5 + 10 + 5
   });
+
+  describe('groups (#3468)', () => {
+    const grouped = (id: string, groupId: string, at: Partial<Cutout>): Cutout => ({
+      ...createCutout(id, 10, 10),
+      groupId,
+      ...at,
+    });
+
+    it('packs a group as one unit and keeps its members rigid', () => {
+      // Two shapes 30mm apart, grouped — the pair must stay 30mm apart.
+      const cutouts = [grouped('a', 'g1', { x: 50, y: 50 }), grouped('b', 'g1', { x: 80, y: 50 })];
+
+      const result = autoArrangeCutouts(cutouts, { binWidth: 100, binDepth: 100, gap: 2 });
+
+      expect(result.b.x - result.a.x).toBe(30);
+      expect(result.b.y - result.a.y).toBe(0);
+      // The unit's own bounding box lands at the shelf origin.
+      expect(result.a).toEqual({ x: 2, y: 2 });
+    });
+
+    it('lays two duplicated groups side by side without interleaving them', () => {
+      // The reported repro: build a shape from two parts, group it, duplicate
+      // the group, select everything, auto-arrange.
+      const cutouts = [
+        grouped('a1', 'g1', { x: 0, y: 0 }),
+        grouped('a2', 'g1', { x: 12, y: 0 }),
+        grouped('b1', 'g2', { x: 0, y: 40 }),
+        grouped('b2', 'g2', { x: 12, y: 40 }),
+      ];
+
+      const result = autoArrangeCutouts(cutouts, { binWidth: 100, binDepth: 100, gap: 2 });
+
+      // Each group keeps its internal offset...
+      expect(result.a2.x - result.a1.x).toBe(12);
+      expect(result.b2.x - result.b1.x).toBe(12);
+      // ...and the two groups occupy disjoint spans rather than being shuffled.
+      const groupAEnd = result.a2.x + 10;
+      expect(result.b1.x).toBeGreaterThanOrEqual(groupAEnd);
+    });
+
+    it('measures a group by its combined footprint when wrapping rows', () => {
+      // A 42mm-wide group cannot share a 50mm row with a 20mm shape.
+      const cutouts = [
+        grouped('g-left', 'g1', { x: 0, y: 0, width: 20, depth: 10 }),
+        grouped('g-right', 'g1', { x: 22, y: 0, width: 20, depth: 10 }),
+        { ...createCutout('solo', 20, 10) },
+      ];
+
+      const result = autoArrangeCutouts(cutouts, { binWidth: 50, binDepth: 100, gap: 2 });
+
+      expect(result['g-left']).toEqual({ x: 2, y: 2 });
+      expect(result['g-right']).toEqual({ x: 24, y: 2 });
+      expect(result.solo.y).toBe(14); // wrapped: 2 + 10 + 2
+    });
+
+    it('leaves a group containing a locked member where it is', () => {
+      const cutouts = [
+        grouped('a', 'g1', { x: 60, y: 60 }),
+        grouped('b', 'g1', { x: 72, y: 60, locked: true }),
+        { ...createCutout('solo', 10, 10), x: 90, y: 90 },
+      ];
+
+      const result = autoArrangeCutouts(cutouts, { binWidth: 100, binDepth: 100, gap: 2 });
+
+      expect(result.a).toBeUndefined();
+      expect(result.b).toBeUndefined();
+      expect(result.solo).toEqual({ x: 2, y: 2 });
+    });
+
+    it('claims the rotated footprint of a shape, not its unrotated box', () => {
+      const cutouts = [
+        { ...createCutout('turned', 30, 10), rotation: 90 },
+        createCutout('next', 10, 10),
+      ];
+
+      const result = autoArrangeCutouts(cutouts, { binWidth: 100, binDepth: 100, gap: 2 });
+
+      // Turned 90°, the 30x10 shape is 10 wide — 'next' starts at 2 + 10 + 2.
+      expect(result.next.x).toBeCloseTo(14);
+    });
+  });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/autoArrange.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/autoArrange.ts
@@ -1,12 +1,17 @@
 /**
  * Auto-arrange algorithm for cutouts using shelf-based bin packing.
  *
- * Sorts cutouts by depth descending, then places them left-to-right
- * in rows, starting a new row when the current one overflows.
+ * Sorts units by depth descending, then places them left-to-right in rows,
+ * starting a new row when the current one overflows.
+ *
+ * A unit is a whole cutout group or a single ungrouped cutout — packing raw
+ * cutouts scattered the members of a group across the bin (#3468). Placement
+ * is a translation of the unit's rotated silhouette, so a rotated shape claims
+ * the space it actually occupies rather than its unrotated width and depth.
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
-import { getEffectiveWidth, getEffectiveDepth } from './geometry';
+import { toArrangeUnits, unitWidth, unitDepth } from './cutoutGroups';
 
 export interface AutoArrangeOptions {
   readonly binWidth: number;
@@ -19,19 +24,23 @@ export interface AutoArrangeOptions {
  * Compute new positions for cutouts using shelf-based bin packing.
  * When `staggered` is true, alternate rows are offset by half the average item width.
  * Returns a map of cutout ID → new position.
+ *
+ * Locked units keep their position and are packed around rather than moved —
+ * their footprint is not reserved, so a locked unit can end up overlapped.
  */
 export function autoArrangeCutouts(
   cutouts: readonly Cutout[],
   options: AutoArrangeOptions
 ): Record<string, { x: number; y: number }> {
   const { binWidth, gap, staggered = false } = options;
-  const sorted = [...cutouts].sort((a, b) => getEffectiveDepth(b) - getEffectiveDepth(a));
+  const movable = toArrangeUnits(cutouts).filter((unit) => !unit.locked);
+  const sorted = [...movable].sort((a, b) => unitDepth(b) - unitDepth(a));
   const positions: Record<string, { x: number; y: number }> = {};
 
   // Compute average width for stagger offset
   const avgWidth =
     staggered && sorted.length > 0
-      ? sorted.reduce((sum, c) => sum + getEffectiveWidth(c), 0) / sorted.length
+      ? sorted.reduce((sum, unit) => sum + unitWidth(unit), 0) / sorted.length
       : 0;
 
   let rowIndex = 0;
@@ -40,11 +49,11 @@ export function autoArrangeCutouts(
   let currentY = gap;
   let rowHeight = 0;
 
-  for (const cutout of sorted) {
-    const w = getEffectiveWidth(cutout);
-    const d = getEffectiveDepth(cutout);
+  for (const unit of sorted) {
+    const w = unitWidth(unit);
+    const d = unitDepth(unit);
 
-    // Start new row if cutout doesn't fit
+    // Start new row if unit doesn't fit
     if (currentX + w + gap > binWidth) {
       rowIndex++;
       const offset = staggered && rowIndex % 2 === 1 ? avgWidth / 2 : 0;
@@ -53,7 +62,12 @@ export function autoArrangeCutouts(
       rowHeight = 0;
     }
 
-    positions[cutout.id] = { x: currentX, y: currentY };
+    const dx = currentX - unit.bounds.minX;
+    const dy = currentY - unit.bounds.minY;
+    for (const member of unit.members) {
+      positions[member.id] = { x: member.x + dx, y: member.y + dy };
+    }
+
     currentX += w + gap;
     rowHeight = Math.max(rowHeight, d);
   }

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import type { Cutout } from '@/features/bin-designer/types';
+import {
+  expandSelectionToGroups,
+  toArrangeUnits,
+  unitsBounds,
+  unitWidth,
+  unitDepth,
+} from './cutoutGroups';
+
+const cutout = (id: string, overrides: Partial<Cutout> = {}): Cutout => ({
+  id,
+  shape: 'rectangle',
+  x: 0,
+  y: 0,
+  width: 10,
+  depth: 10,
+  cutDepth: 5,
+  rotation: 0,
+  cornerRadius: 0,
+  label: '',
+  groupId: null,
+  ...overrides,
+});
+
+describe('expandSelectionToGroups', () => {
+  it('returns the selection unchanged when nothing is grouped', () => {
+    const all = [cutout('a'), cutout('b')];
+    const selected = [all[0]];
+    expect(expandSelectionToGroups(all, selected)).toBe(selected);
+  });
+
+  it('pulls in the unselected members of a touched group', () => {
+    const all = [
+      cutout('a', { groupId: 'g1' }),
+      cutout('b', { groupId: 'g1' }),
+      cutout('c', { groupId: 'g1' }),
+      cutout('d'),
+    ];
+    const expanded = expandSelectionToGroups(all, [all[0]]);
+    expect(expanded.map((c) => c.id).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('leaves ungrouped cutouts in the selection alone', () => {
+    const all = [cutout('a', { groupId: 'g1' }), cutout('b', { groupId: 'g1' }), cutout('c')];
+    const expanded = expandSelectionToGroups(all, [all[0], all[2]]);
+    expect(expanded.map((c) => c.id).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not duplicate members already selected', () => {
+    const all = [cutout('a', { groupId: 'g1' }), cutout('b', { groupId: 'g1' })];
+    expect(expandSelectionToGroups(all, all)).toHaveLength(2);
+  });
+});
+
+describe('toArrangeUnits', () => {
+  it('makes one unit per ungrouped cutout', () => {
+    const units = toArrangeUnits([cutout('a'), cutout('b')]);
+    expect(units).toHaveLength(2);
+    expect(units.every((u) => u.members.length === 1)).toBe(true);
+  });
+
+  it('collapses a group into a single unit', () => {
+    const units = toArrangeUnits([
+      cutout('a', { groupId: 'g1', x: 0 }),
+      cutout('b', { groupId: 'g1', x: 30 }),
+      cutout('c'),
+    ]);
+    expect(units).toHaveLength(2);
+    expect(units[0].members.map((m) => m.id)).toEqual(['a', 'b']);
+    expect(units[1].members.map((m) => m.id)).toEqual(['c']);
+  });
+
+  it('spans every member in the unit bounds', () => {
+    const [unit] = toArrangeUnits([
+      cutout('a', { groupId: 'g1', x: 0, y: 0, width: 10, depth: 10 }),
+      cutout('b', { groupId: 'g1', x: 30, y: 20, width: 10, depth: 10 }),
+    ]);
+    expect(unit.bounds).toEqual({ minX: 0, minY: 0, maxX: 40, maxY: 30 });
+    expect(unitWidth(unit)).toBe(40);
+    expect(unitDepth(unit)).toBe(30);
+  });
+
+  it('uses the rotated silhouette, not the unrotated box', () => {
+    const [unit] = toArrangeUnits([
+      cutout('a', { x: 0, y: 0, width: 20, depth: 10, rotation: 90 }),
+    ]);
+    // A 20x10 box turned 90° occupies 10 wide by 20 deep, centred where it was.
+    expect(unitWidth(unit)).toBeCloseTo(10);
+    expect(unitDepth(unit)).toBeCloseTo(20);
+  });
+
+  it('marks a unit locked when any member is locked', () => {
+    const [unit] = toArrangeUnits([
+      cutout('a', { groupId: 'g1' }),
+      cutout('b', { groupId: 'g1', locked: true }),
+    ]);
+    expect(unit.locked).toBe(true);
+  });
+
+  it('keeps first-appearance order', () => {
+    const units = toArrangeUnits([
+      cutout('a'),
+      cutout('b', { groupId: 'g1' }),
+      cutout('c'),
+      cutout('d', { groupId: 'g1' }),
+    ]);
+    expect(units.map((u) => u.members[0].id)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('unitsBounds', () => {
+  it('spans every unit', () => {
+    const units = toArrangeUnits([
+      cutout('a', { x: 5, y: 5 }),
+      cutout('b', { x: 40, y: 30, width: 20, depth: 20 }),
+    ]);
+    expect(unitsBounds(units)).toEqual({ minX: 5, minY: 5, maxX: 60, maxY: 50 });
+  });
+
+  it('returns a zero box for an empty list', () => {
+    expect(unitsBounds([])).toEqual({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.ts
@@ -1,0 +1,128 @@
+/**
+ * Group-aware units for the arrange operations.
+ *
+ * Every arrange action — align, distribute, centre-in-bin, auto-arrange —
+ * treats a cutout group as one rigid body: members keep their relative offsets
+ * and the whole unit translates together (#3468). Pointer drag, resize, rotate
+ * and keyboard nudge already worked this way; only the arrange math iterated
+ * raw cutouts, so it scattered the members of a group across the bin.
+ *
+ * Two rules the callers share:
+ *
+ *  - **Any selected member pulls in its whole group.** A selection that reaches
+ *    a group only partially (via the shape list, say) still moves the group as
+ *    one — the same expansion the canvas performs on click.
+ *  - **A unit with any locked member never moves.** The lock is documented as
+ *    "cannot be moved", and moving the rest of the group around a pinned member
+ *    would tear the group apart. Align and distribute still let such a unit
+ *    anchor the bounds; auto-arrange re-packs around it without reserving its
+ *    footprint, so a locked unit can end up overlapped.
+ *
+ * Bounds are the *rotated* silhouette. A group's box is meaningless otherwise,
+ * and every consumer expresses a move as a translation, so the unrotated
+ * `x`/`y` stays in step with the box it was measured from.
+ */
+
+import type { Cutout } from '@/features/bin-designer/types';
+import { type Bounds, getRotatedBounds } from './geometryCore';
+
+/** One rigid arrange target: a whole group, or a single ungrouped cutout. */
+export interface ArrangeUnit {
+  readonly members: readonly Cutout[];
+  /** Rotated AABB spanning every member. */
+  readonly bounds: Bounds;
+  /** True when any member is locked — the unit is then immovable. */
+  readonly locked: boolean;
+}
+
+function makeUnit(members: readonly Cutout[]): ArrangeUnit {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let locked = false;
+
+  for (const member of members) {
+    const b = getRotatedBounds(member);
+    minX = Math.min(minX, b.minX);
+    minY = Math.min(minY, b.minY);
+    maxX = Math.max(maxX, b.maxX);
+    maxY = Math.max(maxY, b.maxY);
+    if (member.locked) locked = true;
+  }
+
+  return { members, bounds: { minX, minY, maxX, maxY }, locked };
+}
+
+/**
+ * Add every member of any group the selection touches.
+ *
+ * Returns the input untouched when nothing selected is grouped, so the common
+ * ungrouped case allocates nothing.
+ */
+export function expandSelectionToGroups(
+  all: readonly Cutout[],
+  selected: readonly Cutout[]
+): readonly Cutout[] {
+  const groupIds = new Set<string>();
+  for (const cutout of selected) {
+    if (cutout.groupId !== null) groupIds.add(cutout.groupId);
+  }
+  if (groupIds.size === 0) return selected;
+
+  const selectedIds = new Set(selected.map((c) => c.id));
+  const expanded = [...selected];
+  for (const cutout of all) {
+    if (cutout.groupId !== null && groupIds.has(cutout.groupId) && !selectedIds.has(cutout.id)) {
+      expanded.push(cutout);
+    }
+  }
+  return expanded;
+}
+
+/**
+ * Collapse cutouts into arrange units — one per group, one per ungrouped
+ * cutout. Units come out in first-appearance order so results stay stable.
+ */
+export function toArrangeUnits(cutouts: readonly Cutout[]): ArrangeUnit[] {
+  const byGroup = new Map<string, Cutout[]>();
+  for (const cutout of cutouts) {
+    if (cutout.groupId === null) continue;
+    const members = byGroup.get(cutout.groupId);
+    if (members) members.push(cutout);
+    else byGroup.set(cutout.groupId, [cutout]);
+  }
+
+  const units: ArrangeUnit[] = [];
+  const emitted = new Set<string>();
+  for (const cutout of cutouts) {
+    if (cutout.groupId === null) {
+      units.push(makeUnit([cutout]));
+      continue;
+    }
+    if (emitted.has(cutout.groupId)) continue;
+    emitted.add(cutout.groupId);
+    units.push(makeUnit(byGroup.get(cutout.groupId) ?? [cutout]));
+  }
+  return units;
+}
+
+/** Bounds spanning every unit, locked ones included — they anchor. */
+export function unitsBounds(units: readonly ArrangeUnit[]): Bounds {
+  if (units.length === 0) return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const unit of units) {
+    minX = Math.min(minX, unit.bounds.minX);
+    minY = Math.min(minY, unit.bounds.minY);
+    maxX = Math.max(maxX, unit.bounds.maxX);
+    maxY = Math.max(maxY, unit.bounds.maxY);
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+export const unitWidth = (unit: ArrangeUnit): number => unit.bounds.maxX - unit.bounds.minX;
+export const unitDepth = (unit: ArrangeUnit): number => unit.bounds.maxY - unit.bounds.minY;

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -1242,3 +1242,80 @@ describe('geometry', () => {
     });
   });
 });
+
+describe('legacy arrange helpers are group-aware (#3468)', () => {
+  it('distributeHorizontally counts a group as one unit', () => {
+    const cutouts = [
+      createCutout({ id: 'left', x: 0, width: 10 }),
+      createCutout({ id: 'ga', groupId: 'g1', x: 40, width: 10 }),
+      createCutout({ id: 'gb', groupId: 'g1', x: 60, width: 10 }),
+      createCutout({ id: 'right', x: 200, width: 10 }),
+    ];
+
+    const result = distributeHorizontally(cutouts, 300);
+
+    // Members keep their 20mm offset, so the group stays intact.
+    expect(result.gb.x - result.ga.x).toBe(20);
+    // Extremes hold their positions.
+    expect(result.left.x).toBe(0);
+    expect(result.right.x).toBe(200);
+  });
+
+  it('distributeHorizontally is a no-op below three units', () => {
+    const cutouts = [
+      createCutout({ id: 'a', groupId: 'g1', x: 0 }),
+      createCutout({ id: 'b', groupId: 'g1', x: 20 }),
+      createCutout({ id: 'c', x: 100 }),
+    ];
+
+    expect(distributeHorizontally(cutouts, 300)).toEqual({});
+  });
+
+  it('distributeVertically keeps group members rigid', () => {
+    const cutouts = [
+      createCutout({ id: 'low', y: 0, depth: 10 }),
+      createCutout({ id: 'ga', groupId: 'g1', y: 40, depth: 10 }),
+      createCutout({ id: 'gb', groupId: 'g1', y: 60, depth: 10 }),
+      createCutout({ id: 'high', y: 200, depth: 10 }),
+    ];
+
+    const result = distributeVertically(cutouts, 300);
+
+    expect(result.gb.y - result.ga.y).toBe(20);
+  });
+
+  it('distribute leaves a locked unit where it is', () => {
+    const cutouts = [
+      createCutout({ id: 'left', x: 0, width: 10 }),
+      createCutout({ id: 'mid', x: 40, width: 10, locked: true }),
+      createCutout({ id: 'right', x: 200, width: 10 }),
+    ];
+
+    expect(distributeHorizontally(cutouts, 300).mid).toBeUndefined();
+  });
+
+  it('centerInBin translates the whole selection by one delta', () => {
+    const cutouts = [
+      createCutout({ id: 'ga', groupId: 'g1', x: 0, y: 0, width: 20, depth: 20 }),
+      createCutout({ id: 'gb', groupId: 'g1', x: 30, y: 0, width: 20, depth: 20 }),
+    ];
+
+    const result = centerInBin(cutouts, 100, 100);
+
+    // Selection spans 0..50 wide, so both shift by (100 - 50) / 2 = 25.
+    expect(result.ga).toEqual({ x: 25, y: 40 });
+    expect(result.gb).toEqual({ x: 55, y: 40 });
+  });
+
+  it('centerInBin leaves a locked unit behind', () => {
+    const cutouts = [
+      createCutout({ id: 'a', x: 0, y: 0, width: 20, depth: 20 }),
+      createCutout({ id: 'b', x: 30, y: 0, width: 20, depth: 20, locked: true }),
+    ];
+
+    const result = centerInBin(cutouts, 100, 100);
+
+    expect(result.a).toBeDefined();
+    expect(result.b).toBeUndefined();
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometryAlign.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometryAlign.test.ts
@@ -300,3 +300,73 @@ describe('distributeSelection', () => {
     expect(patch?.path?.[0].x).toBe(50);
   });
 });
+
+describe('groups are rigid (#3468)', () => {
+  it('aligns a group by its combined box, preserving member offsets', () => {
+    const cutouts = [
+      cutout({ id: 'g1a', groupId: 'g1', x: 40 }),
+      cutout({ id: 'g1b', groupId: 'g1', x: 70 }),
+      cutout({ id: 'solo', x: 5 }),
+    ];
+
+    const updates = alignSelection(cutouts, 'left');
+
+    // The group moves as one: both members shift by the same 35mm.
+    expect(updates.get('g1a')?.x).toBe(5);
+    expect(updates.get('g1b')?.x).toBe(35);
+    expect(updates.has('solo')).toBe(false);
+  });
+
+  it('is a no-op when the whole selection is one group', () => {
+    const cutouts = [
+      cutout({ id: 'a', groupId: 'g1', x: 0 }),
+      cutout({ id: 'b', groupId: 'g1', x: 40 }),
+    ];
+
+    // One unit has nothing to align against — the members must not collapse
+    // onto each other.
+    expect(alignSelection(cutouts, 'left').size).toBe(0);
+  });
+
+  it('never moves a group holding a locked member', () => {
+    const cutouts = [
+      cutout({ id: 'a', groupId: 'g1', x: 40 }),
+      cutout({ id: 'b', groupId: 'g1', x: 70, locked: true }),
+      cutout({ id: 'solo', x: 5 }),
+    ];
+
+    const updates = alignSelection(cutouts, 'left');
+
+    expect(updates.size).toBe(0);
+  });
+
+  it('distributes by unit centre, counting a group once', () => {
+    // Three units: solo(0), group spanning 40..90, solo(200).
+    const cutouts = [
+      cutout({ id: 'left', x: 0 }),
+      cutout({ id: 'ga', groupId: 'g1', x: 40 }),
+      cutout({ id: 'gb', groupId: 'g1', x: 80 }),
+      cutout({ id: 'right', x: 200 }),
+    ];
+
+    const updates = distributeSelection(cutouts, 'horizontal');
+
+    // Extremes anchor; the group's centre lands midway between them.
+    expect(updates.has('left')).toBe(false);
+    expect(updates.has('right')).toBe(false);
+    const da = (updates.get('ga')?.x ?? 0) - 40;
+    const db = (updates.get('gb')?.x ?? 0) - 80;
+    expect(da).toBeCloseTo(db);
+  });
+
+  it('needs three units, not three cutouts, to distribute', () => {
+    const cutouts = [
+      cutout({ id: 'a', groupId: 'g1', x: 0 }),
+      cutout({ id: 'b', groupId: 'g1', x: 20 }),
+      cutout({ id: 'c', x: 100 }),
+    ];
+
+    // Two units — nothing to place between the extremes.
+    expect(distributeSelection(cutouts, 'horizontal').size).toBe(0);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometryAlign.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometryAlign.ts
@@ -11,10 +11,15 @@
  * against the rotated silhouette. Translating by a delta keeps the two in step
  * for rotated shapes, and lets path cutouts (whose points are absolute) carry
  * their geometry along.
+ *
+ * Both operate on arrange units, not raw cutouts: a group aligns and
+ * distributes as one rigid body (#3468). Callers pass a selection already
+ * expanded to whole groups (`expandSelectionToGroups`).
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
-import { getRotatedBounds } from './geometryCore';
+import type { Bounds } from './geometryCore';
+import { type ArrangeUnit, toArrangeUnits, unitsBounds } from './cutoutGroups';
 
 export type AlignMode = 'left' | 'centerX' | 'right' | 'top' | 'middleY' | 'bottom';
 export type DistributeAxis = 'horizontal' | 'vertical';
@@ -36,29 +41,8 @@ function translate(cutout: Cutout, dx: number, dy: number): Partial<Cutout> {
   return moved;
 }
 
-/** Bounds across every selected cutout, locked ones included (they anchor). */
-function selectionBounds(cutouts: readonly Cutout[]) {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const cutout of cutouts) {
-    const b = getRotatedBounds(cutout);
-    minX = Math.min(minX, b.minX);
-    minY = Math.min(minY, b.minY);
-    maxX = Math.max(maxX, b.maxX);
-    maxY = Math.max(maxY, b.maxY);
-  }
-  return { minX, minY, maxX, maxY };
-}
-
-/** Signed distance to move `cutout` so its rotated box satisfies `mode`. */
-function alignDelta(
-  cutout: Cutout,
-  mode: AlignMode,
-  bounds: ReturnType<typeof selectionBounds>
-): { dx: number; dy: number } {
-  const b = getRotatedBounds(cutout);
+/** Signed distance to move a unit so its rotated box satisfies `mode`. */
+function alignDelta(b: Bounds, mode: AlignMode, bounds: Bounds): { dx: number; dy: number } {
   switch (mode) {
     case 'left':
       return { dx: bounds.minX - b.minX, dy: 0 };
@@ -75,25 +59,39 @@ function alignDelta(
   }
 }
 
+/** Translate every member of a unit by the same delta. */
+function translateUnit(
+  unit: ArrangeUnit,
+  dx: number,
+  dy: number,
+  updates: Map<string, Partial<Cutout>>
+): void {
+  for (const member of unit.members) {
+    updates.set(member.id, translate(member, dx, dy));
+  }
+}
+
 /**
- * Align every unlocked cutout in the selection to the selection's bounding box.
+ * Align every unlocked unit in the selection to the selection's bounding box.
  *
- * A single cutout has nothing to align against (its own bounds are the
- * selection's), so this is a no-op below two.
+ * A single unit has nothing to align against (its own bounds are the
+ * selection's), so this is a no-op below two — which is why aligning the two
+ * members of one group does nothing rather than collapsing them onto each other.
  */
 export function alignSelection(
   cutouts: readonly Cutout[],
   mode: AlignMode
 ): ReadonlyMap<string, Partial<Cutout>> {
   const updates = new Map<string, Partial<Cutout>>();
-  if (cutouts.length < 2) return updates;
+  const units = toArrangeUnits(cutouts);
+  if (units.length < 2) return updates;
 
-  const bounds = selectionBounds(cutouts);
-  for (const cutout of cutouts) {
-    if (cutout.locked) continue;
-    const { dx, dy } = alignDelta(cutout, mode, bounds);
+  const bounds = unitsBounds(units);
+  for (const unit of units) {
+    if (unit.locked) continue;
+    const { dx, dy } = alignDelta(unit.bounds, mode, bounds);
     if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) continue;
-    updates.set(cutout.id, translate(cutout, dx, dy));
+    translateUnit(unit, dx, dy, updates);
   }
   return updates;
 }
@@ -116,17 +114,18 @@ export function distributeSelection(
   axis: DistributeAxis
 ): ReadonlyMap<string, Partial<Cutout>> {
   const updates = new Map<string, Partial<Cutout>>();
-  if (cutouts.length < MIN_DISTRIBUTE_COUNT) return updates;
+  const units = toArrangeUnits(cutouts);
+  if (units.length < MIN_DISTRIBUTE_COUNT) return updates;
 
   const horizontal = axis === 'horizontal';
-  const centerOf = (cutout: Cutout): number => {
-    const b = getRotatedBounds(cutout);
-    return horizontal ? (b.minX + b.maxX) / 2 : (b.minY + b.maxY) / 2;
-  };
+  const centerOf = (unit: ArrangeUnit): number =>
+    horizontal
+      ? (unit.bounds.minX + unit.bounds.maxX) / 2
+      : (unit.bounds.minY + unit.bounds.maxY) / 2;
 
-  const ordered = [...cutouts].sort((a, b) => centerOf(a) - centerOf(b));
+  const ordered = [...units].sort((a, b) => centerOf(a) - centerOf(b));
 
-  // The extremes plus any locked cutout between them. Everything strictly
+  // The extremes plus any locked unit between them. Everything strictly
   // between two consecutive anchors is unlocked by construction.
   const anchors = [0];
   for (let i = 1; i < ordered.length - 1; i++) {
@@ -144,10 +143,10 @@ export function distributeSelection(
     const step = (centerOf(ordered[endIdx]) - startCenter) / gap;
 
     for (let k = 1; k < gap; k++) {
-      const cutout = ordered[startIdx + k];
-      const delta = startCenter + step * k - centerOf(cutout);
+      const unit = ordered[startIdx + k];
+      const delta = startCenter + step * k - centerOf(unit);
       if (Math.abs(delta) < EPSILON) continue;
-      updates.set(cutout.id, translate(cutout, horizontal ? delta : 0, horizontal ? 0 : delta));
+      translateUnit(unit, horizontal ? delta : 0, horizontal ? 0 : delta, updates);
     }
   }
   return updates;

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometryAlignment.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometryAlignment.ts
@@ -8,7 +8,11 @@
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
-import { type Bounds, computeBounds, getEffectiveBounds, getEffectiveDepth } from './geometryCore';
+import { type Bounds, getEffectiveBounds } from './geometryCore';
+import { toArrangeUnits, unitsBounds, unitWidth, unitDepth } from './cutoutGroups';
+
+/** Distribute needs a fixed unit at each end plus something to place between them. */
+const MIN_DISTRIBUTE_UNITS = 3;
 
 /** A guide line indicating alignment between cutouts */
 export interface AlignmentGuide {
@@ -75,62 +79,75 @@ export function findAlignmentGuides(
 }
 
 /**
- * Distribute cutouts evenly along the horizontal axis.
- * Spaces cutouts so there's equal gap between each.
+ * Distribute units evenly along the horizontal axis.
+ * Spaces them so there's equal gap between each.
+ *
+ * A locked unit keeps its position — it still contributes to the span, so the
+ * gap it sits in simply comes out uneven rather than the lock being ignored.
  */
 export function distributeHorizontally(
   cutouts: readonly Cutout[],
   _binWidth: number
 ): Record<string, { x: number }> {
-  if (cutouts.length < 3) return {};
+  const units = toArrangeUnits(cutouts);
+  if (units.length < MIN_DISTRIBUTE_UNITS) return {};
 
-  // Sort by current X position
-  const sorted = [...cutouts].sort((a, b) => a.x - b.x);
+  const sorted = [...units].sort((a, b) => a.bounds.minX - b.bounds.minX);
   const first = sorted[0];
   const last = sorted[sorted.length - 1];
 
   // Total space between leftmost left edge and rightmost right edge
-  const totalSpan = last.x + last.width - first.x;
-  const totalWidths = sorted.reduce((sum, c) => sum + c.width, 0);
+  const totalSpan = last.bounds.maxX - first.bounds.minX;
+  const totalWidths = sorted.reduce((sum, u) => sum + unitWidth(u), 0);
   const gap = (totalSpan - totalWidths) / (sorted.length - 1);
 
   const result: Record<string, { x: number }> = {};
-  let currentX = first.x;
-  for (const cutout of sorted) {
-    result[cutout.id] = { x: currentX };
-    currentX += cutout.width + gap;
+  let currentX = first.bounds.minX;
+  for (const unit of sorted) {
+    if (!unit.locked) {
+      const dx = currentX - unit.bounds.minX;
+      for (const member of unit.members) result[member.id] = { x: member.x + dx };
+    }
+    currentX += unitWidth(unit) + gap;
   }
   return result;
 }
 
 /**
- * Distribute cutouts evenly along the vertical axis.
+ * Distribute units evenly along the vertical axis.
  */
 export function distributeVertically(
   cutouts: readonly Cutout[],
   _binDepth: number
 ): Record<string, { y: number }> {
-  if (cutouts.length < 3) return {};
+  const units = toArrangeUnits(cutouts);
+  if (units.length < MIN_DISTRIBUTE_UNITS) return {};
 
-  const sorted = [...cutouts].sort((a, b) => a.y - b.y);
+  const sorted = [...units].sort((a, b) => a.bounds.minY - b.bounds.minY);
   const first = sorted[0];
   const last = sorted[sorted.length - 1];
 
-  const totalSpan = last.y + getEffectiveDepth(last) - first.y;
-  const totalDepths = sorted.reduce((sum, c) => sum + getEffectiveDepth(c), 0);
+  const totalSpan = last.bounds.maxY - first.bounds.minY;
+  const totalDepths = sorted.reduce((sum, u) => sum + unitDepth(u), 0);
   const gap = (totalSpan - totalDepths) / (sorted.length - 1);
 
   const result: Record<string, { y: number }> = {};
-  let currentY = first.y;
-  for (const cutout of sorted) {
-    result[cutout.id] = { y: currentY };
-    currentY += getEffectiveDepth(cutout) + gap;
+  let currentY = first.bounds.minY;
+  for (const unit of sorted) {
+    if (!unit.locked) {
+      const dy = currentY - unit.bounds.minY;
+      for (const member of unit.members) result[member.id] = { y: member.y + dy };
+    }
+    currentY += unitDepth(unit) + gap;
   }
   return result;
 }
 
 /**
- * Center a group of cutouts within the bin.
+ * Center a selection within the bin.
+ *
+ * One delta for the whole selection, so relative offsets are preserved; a
+ * locked unit stays behind rather than riding along.
  */
 export function centerInBin(
   cutouts: readonly Cutout[],
@@ -139,15 +156,19 @@ export function centerInBin(
 ): Record<string, { x: number; y: number }> {
   if (cutouts.length === 0) return {};
 
-  const bounds = computeBounds(cutouts);
+  const units = toArrangeUnits(cutouts);
+  const bounds = unitsBounds(units);
   const groupW = bounds.maxX - bounds.minX;
   const groupH = bounds.maxY - bounds.minY;
   const dx = (binWidth - groupW) / 2 - bounds.minX;
   const dy = (binDepth - groupH) / 2 - bounds.minY;
 
   const result: Record<string, { x: number; y: number }> = {};
-  for (const cutout of cutouts) {
-    result[cutout.id] = { x: cutout.x + dx, y: cutout.y + dy };
+  for (const unit of units) {
+    if (unit.locked) continue;
+    for (const member of unit.members) {
+      result[member.id] = { x: member.x + dx, y: member.y + dy };
+    }
   }
   return result;
 }


### PR DESCRIPTION
Auto-arrange scattered the members of a group across the bin instead of placing the group. Same for align, distribute and center-in-bin. Reported in #3468, with "union" behaving the same way because a union is a group op, not a separate construct.

The editor was already group-aware everywhere a human drags something: canvas click expands the selection to the group (`useCutoutInteraction.ts:130`), resize/rotate expands it (`useCutoutTransformStarters.ts:60`), keyboard nudge expands it (`keyboardHandler.ts:144`). Only the arrange math iterated raw cutouts.

## What changed

New `cutoutGroups.ts` collapses a selection into **arrange units** — one per group, one per ungrouped cutout — each measured on its rotated silhouette. Every arrange path moves a unit by a single translation, so members keep their relative offsets.

Wired into all three surfaces that expose these actions:

| Surface | Actions |
| --- | --- |
| `WorkspaceHeader` (Bentobox toolbar) | align, distribute, center, auto-arrange |
| `AlignmentToolbar` (cutout panel) | align, distribute, center, auto-arrange |
| `InspectorContent` (inspector dock) | align, distribute |

## Semantics

- **Partial selection expands.** Selecting one member from the shape list moves the whole group, matching the canvas.
- **A unit holding a locked member never moves.** The lock is documented as "cannot be moved"; moving the rest of a group around a pinned member would tear it apart. Align and distribute still let such a unit anchor the bounds. Auto-arrange packs around it without reserving its footprint.
- **Thresholds count units.** `alignSelection` needs two units and `distributeSelection` three, so a two-member group no longer satisfies them on its own and collapse-onto-self is impossible.
- **Rotated shapes claim their real footprint.** Unit bounds are the rotated AABB, so auto-arrange stops overlapping rotated cutouts. Identical results for unrotated shapes.

## Undo

The toolbars looped `onUpdate` per cutout, and `updateCutout` pushes a history entry each call — an auto-arrange of 20 shapes cost 20 undos, and a partial undo would now leave a group half-moved. Both toolbars write through `updateCutoutsBatch` instead, so one arrange is one undo step. The dead `onUpdate` prop is dropped from both.

## Verification

- 19,393 unit/dom tests pass; typecheck, lint and knip clean
- New coverage: `cutoutGroups.test.ts`, group cases in `autoArrange.test.ts`, `geometryAlign.test.ts` and `geometry.test.ts`, plus a UI regression in `AlignmentToolbar.test.tsx` reproducing the reported "group, duplicate, select all, auto-arrange" flow

Closes #3468

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Arrange actions now move cutout groups as one rigid body to keep members together. Previously auto-arrange, align, distribute, and center-in-bin iterated raw cutouts and split groups; they now operate on group-aware units measured by rotated bounds.

- Expand partial selections to entire groups; move units by a single translation.
- Do not move a unit if any member is locked; locked units still anchor alignment/distribution; auto-arrange packs around them.
- Count units for thresholds (align: 2, distribute: 3) to avoid collapsing a single group onto itself.
- Use rotated silhouettes for width/depth so rotated shapes don’t overlap.
- Batch updates from toolbars so one arrange is one undo step.
- Apply across `WorkspaceHeader`, `AlignmentToolbar`, and `InspectorContent` for align, distribute, center, and auto-arrange.

**Migration**
- Remove `onUpdate` from `WorkspaceHeader` and `AlignmentToolbar`; use `onUpdateBatch` only.

<sup>Written for commit 9ebdb99d81fdc17c04d8b34baa94c00ffcf1a24f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

