### PR TITLE
chore(deps): bump brepkit-wasm to 3.2.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.8",
-    "brepkit-wasm": "3.2.28",
+    "brepkit-wasm": "3.2.36",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.124.8
-        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.28)(occt-wasm@4.2.0)
+        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.36)(occt-wasm@4.2.0)
       brepkit-wasm:
-        specifier: 3.2.28
-        version: 3.2.28
+        specifier: 3.2.36
+        version: 3.2.36
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3202,8 +3202,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@3.2.28:
-    resolution: {integrity: sha512-GJK6m/jt/HXO77yVYzocUMif5UTS8woiu25FDnu7P2qNmLtNAY3qBYkQiI3WvJsuCZUm5eqv8Pvp3gX6te3buw==}
+  brepkit-wasm@3.2.36:
+    resolution: {integrity: sha512-9pUX7RLwlcW9sVsM8kWUfZG0UbQbhIdjzbZafWN6WRVQdsOMRIX6Y28Zi9+8BqBrorirveEXBW3r8xPFMllFlw==}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -8717,15 +8717,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.28)(occt-wasm@4.2.0):
+  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.36)(occt-wasm@4.2.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 3.2.28
+      brepkit-wasm: 3.2.36
       occt-wasm: 4.2.0
 
-  brepkit-wasm@3.2.28: {}
+  brepkit-wasm@3.2.36: {}
 
   browserslist@4.28.7:
     dependencies:

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -66,13 +66,16 @@ const MESH_CACHE_VERSION = 'v10';
  * brepkit `r1`: brepkit-wasm 3.2.28 — the interface-family winding and
  * cap-synthesis fixes move insert/cutout output that reaches a coplanar
  * interface, and the deep-cutout chain is now exact.
+ * brepkit `r2`: brepkit-wasm 3.2.36 — the base-fuse island fix moves output
+ * for every multi-foot bin (the feet-to-base interface), restoring exact
+ * fuses across the scenario catalog.
  *
  * `manifold` is the draft-preview kernel; its meshes are never persisted, but
  * the map is total so a future caller cannot fall through to `undefined`.
  */
 const KERNEL_MESH_REVISION: Record<KernelName, string> = {
   'occt-wasm': 'r1',
-  brepkit: 'r1',
+  brepkit: 'r2',
   manifold: 'r1',
 };
 


### PR DESCRIPTION
## Summary

Bumps brepkit-wasm 3.2.28 → 3.2.36 (brepjs stays 18.124.8, so the intersectCurves dist-patch needs no re-target).

**The full generator suite is green on this kernel against exactly this catalog**: 283 files, 2790 passed, 0 failed, 4 skipped — measured 2026-08-13 in a worktree at this same base commit (2ebe2f4283) with only the kernel pin swapped, against the committed snapshots. Same-day control on 3.2.35: 146 failed. The delta is brepkit#1581's base-fuse fix (the feet-to-base interface every bin scenario shares); full report on brepkit#1517.

Highlights on this catalog vs 3.2.35:
- `4×4 magnet + label bracket + half-sockets` (26-min timeout) → passes in 3.85s
- `4x4 with everything enabled` (56s flaky) → passes in 2.77s
- labelSockets, dividerPatterns, scoops, kumiko, honeycomb, lid rows all green
- Smoke-verified in this worktree: resolution through brepjs at 3.2.36, labelSockets 11/11

## Verification
- `pnpm install --no-frozen-lockfile` lockfile update only; no source changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `brepkit-wasm` 3.2.28 → 3.2.36 and bumps the brepkit mesh-cache revision to `r2`. This includes the base‑fuse island fix that stabilizes multi‑foot bin booleans; previously some complex builds failed or timed out, now the generator suite passes with large speedups, and r1 previews must not be reused.

- Changes: update `package.json`, `pnpm-lock.yaml`, and set the brepkit mesh-cache key to `r2` in `src/shared/generation/meshPersistence.ts` (`brepjs` stays at `18.124.8`; intersectCurves patch unchanged).
- Validation: full generator suite is green on this catalog; substantial improvements vs 3.2.35.
- Rollout: run `pnpm install --no-frozen-lockfile`; r1 brepkit preview meshes will invalidate and regenerate automatically; no migrations required.

<sup>Written for commit bd3216914bf58e25de134c3ae4711641637fb27a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

