### PR TITLE
chore(deps): bump brepkit-wasm to 3.2.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.8",
-    "brepkit-wasm": "3.2.36",
+    "brepkit-wasm": "3.2.37",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.124.8
-        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.36)(occt-wasm@4.2.0)
+        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.37)(occt-wasm@4.2.0)
       brepkit-wasm:
-        specifier: 3.2.36
-        version: 3.2.36
+        specifier: 3.2.37
+        version: 3.2.37
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3202,8 +3202,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@3.2.36:
-    resolution: {integrity: sha512-9pUX7RLwlcW9sVsM8kWUfZG0UbQbhIdjzbZafWN6WRVQdsOMRIX6Y28Zi9+8BqBrorirveEXBW3r8xPFMllFlw==}
+  brepkit-wasm@3.2.37:
+    resolution: {integrity: sha512-Q8lc3p63oSqEmbP9X+lb/mnLAqQDNHXGwd4lE3JFqlxSl8WrdChG0NO3VCsZiETCliWklJ+RwC+h5OCilVR7og==}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -8717,15 +8717,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.36)(occt-wasm@4.2.0):
+  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.37)(occt-wasm@4.2.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 3.2.36
+      brepkit-wasm: 3.2.37
       occt-wasm: 4.2.0
 
-  brepkit-wasm@3.2.36: {}
+  brepkit-wasm@3.2.37: {}
 
   browserslist@4.28.7:
     dependencies:

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -69,13 +69,16 @@ const MESH_CACHE_VERSION = 'v10';
  * brepkit `r2`: brepkit-wasm 3.2.36 — the base-fuse island fix moves output
  * for every multi-foot bin (the feet-to-base interface), restoring exact
  * fuses across the scenario catalog.
+ * brepkit `r3`: brepkit-wasm 3.2.37 — the hole-weave collinear-overlap fix
+ * makes the label-bracket fuse exact (58 analytic faces replace the
+ * 121-face fallback mesh), moving output for every bracket-labeled bin.
  *
  * `manifold` is the draft-preview kernel; its meshes are never persisted, but
  * the map is total so a future caller cannot fall through to `undefined`.
  */
 const KERNEL_MESH_REVISION: Record<KernelName, string> = {
   'occt-wasm': 'r1',
-  brepkit: 'r2',
+  brepkit: 'r3',
   manifold: 'r1',
 };
 


### PR DESCRIPTION
## Result

brepkit-wasm 3.2.37 makes the 2x2 label-bracket fuse exact and fast: the kernel's hole weave now splits section windows that ride collinearly on a hole boundary, so the bracket fuse returns 58 analytic faces (closed, manifold) instead of failing open and degrading to a 121-face fallback mesh, and 2-solid fuseAll calls no longer error into fuseAllBisect's pairwise retry (which paid the expensive fuse twice per generation).

Measured in the parity matrix on this kernel: the 2x2 label bracket row reads 34ms vs the reference's 66ms (it read 2.3x slower before), aggregate 0.63x across 26 rows with 0 non-manifold scenarios.

## Verification

Full generator suite on this bump: **284 files, 2828 passed, 4 skipped, 0 failed** (220s wall). No snapshot writes.

## Cache

Mesh-cache revision bumped to brepkit r3: 3.2.37 moves output for every bracket-labeled bin, so persisted r2 previews must not be reused under the new kernel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `brepkit-wasm` to 3.2.37 and bumps the brepkit mesh cache to r3 to apply an exact label‑bracket fuse. Previously the label‑bracket fuse failed open, fell back to a 121‑face mesh, and triggered a costly pairwise retry; now it produces 58 analytic faces and avoids the retry, improving the row from 66 ms to 34 ms with no non‑manifold cases across the matrix.

- Required: Invalidate persisted brepkit r2 mesh previews; r3 regenerates all bracket‑labeled bins.
- Verification: Generator suite passed (284 files, 2828 passed, 4 skipped, 0 failed); no snapshot updates.

<sup>Written for commit 9113321e85498b199b5f2b4914c6f57f481410fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

