### PR TITLE
chore(deps): bump brepkit-wasm to 3.2.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.8",
-    "brepkit-wasm": "3.2.37",
+    "brepkit-wasm": "3.2.38",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.124.8
-        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.37)(occt-wasm@4.2.0)
+        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.38)(occt-wasm@4.2.0)
       brepkit-wasm:
-        specifier: 3.2.37
-        version: 3.2.37
+        specifier: 3.2.38
+        version: 3.2.38
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3202,8 +3202,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@3.2.37:
-    resolution: {integrity: sha512-Q8lc3p63oSqEmbP9X+lb/mnLAqQDNHXGwd4lE3JFqlxSl8WrdChG0NO3VCsZiETCliWklJ+RwC+h5OCilVR7og==}
+  brepkit-wasm@3.2.38:
+    resolution: {integrity: sha512-6E9VeBRapPz1DnwYL/pasDhRcv0cPl4HjyUMv5rFAJcneyUolRmhyXp7rs6/IQ1H5H0gAS7KipfHuEzRZ8JiDQ==}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -8717,15 +8717,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.37)(occt-wasm@4.2.0):
+  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.38)(occt-wasm@4.2.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 3.2.37
+      brepkit-wasm: 3.2.38
       occt-wasm: 4.2.0
 
-  brepkit-wasm@3.2.37: {}
+  brepkit-wasm@3.2.38: {}
 
   browserslist@4.28.7:
     dependencies:


### PR DESCRIPTION
## Result

brepkit-wasm 3.2.38 makes every baseplate scenario substantially faster with unchanged output. Its contact-thin compound-cut shortcut runs a pocket-grid cut as one arrangement instead of one fuse per tool: the 6x4 magnets plate builds in 782ms vs the reference kernel's 1395ms (the pocketsCut stage alone went 825ms to 50ms), and the parity matrix on this kernel reads 0.45x aggregate with brepkit faster on 25 of 26 rows and 0 non-manifold scenarios.

## Verification

Full generator suite on this bump: **284 files, 2828 passed, 4 skipped, 0 failed** (217s wall). No snapshot writes — generation output is unchanged, so the mesh-cache revision stays r3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `brepkit-wasm` from 3.2.37 to 3.2.38 to enable the contact‑thin compound‑cut optimization. Previously pocket grids ran one fuse per tool; now they run as a single arrangement, improving build time with unchanged geometry.

**Impact and review**
- 6x4 magnets plate builds in 782ms (reference kernel 1395ms); `pocketsCut` stage drops from 825ms to 50ms.
- Generator suite: 284 files, 2828 passed, 4 skipped, 0 failed; no snapshot writes; mesh-cache revision stays `r3`.
- Changes are limited to `package.json` and `pnpm-lock.yaml`; verify lockfile pins `brepkit-wasm@3.2.38` and `brepjs` optional dependency reflects the bump.
- No migration actions required.

<sup>Written for commit c0d420b7eddd212d9dda5ade39fd0c07163f7859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

