### PR TITLE
test(generation): gate every lid seating combination, not the suspected one

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/lidSeating.ts
@@ -64,6 +64,76 @@ export function interferenceAt(
   return total;
 }
 
+/** One mated pair: a bin, its lid, and the offset that seats them. */
+export interface SeatedPair {
+  readonly bin: MeshData;
+  readonly lid: MeshData;
+  readonly dz: number;
+}
+
+/**
+ * Every probe position {@link worstRailInterference} visits, for a given lid.
+ *
+ * A fixed discrete set derived from the lid's own bounds, which is what lets
+ * two lids of the same footprint be compared position by position.
+ */
+function railProbePositions(lid: MeshData): Array<readonly [number, number]> {
+  const bb = boundingBox(lid.vertices);
+  const cx = (bb.minX + bb.maxX) / 2;
+  const cy = (bb.minY + bb.maxY) / 2;
+  const spineX = (bb.maxX - bb.minX) / 2 - LID_CORNER_RADIUS;
+  const spineY = (bb.maxY - bb.minY) / 2 - LID_CORNER_RADIUS;
+  const out: Array<readonly [number, number]> = [];
+  for (const off of RAIL_PROBE_OFFSETS) {
+    for (let y = cy - spineY; y <= cy + spineY; y += 1) {
+      out.push([cx + spineX + off, y], [cx - spineX - off, y]);
+    }
+    for (let x = cx - spineX; x <= cx + spineX; x += 1) {
+      out.push([x, cy + spineY + off], [x, cy - spineY - off]);
+    }
+  }
+  return out;
+}
+
+/**
+ * Worst EXTRA rail interference `probe` has over `reference`, position by
+ * position.
+ *
+ * {@link worstRailInterference} is not zero on a good bin at every footprint:
+ * its outer offsets sample the rail bump inside the lip's undercut, and that
+ * overlap is the snap fit engaging, not a defect. Measured at 0.7mm on a plain
+ * 1x2 with no interior features whatever, and 0 on a 2x2 — a property of the
+ * footprint, which is why an absolute threshold cannot serve a matrix that
+ * varies the footprint.
+ *
+ * Comparing the two maxima would hide a small real clash behind a larger floor,
+ * so this walks matching positions instead. Sound here in a way the same trick
+ * is NOT for the whole-footprint sweep: these positions are a fixed discrete
+ * set from the lid bounds, identical for both lids, rather than a grid laid
+ * over a continuous field.
+ *
+ * A feature that REMOVES a rail scores negative and passes, correctly — no
+ * rail, nothing to collide with.
+ */
+export function worstRailInterferenceDelta(probe: SeatedPair, reference: SeatedPair): number {
+  const a = railProbePositions(probe.lid);
+  const b = railProbePositions(reference.lid);
+  if (a.length !== b.length) {
+    throw new Error(`rail delta needs a shared footprint: ${a.length} vs ${b.length} positions`);
+  }
+  let worst = -Infinity;
+  for (let i = 0; i < a.length; i++) {
+    const [px, py] = a[i];
+    const [rx, ry] = b[i];
+    worst = Math.max(
+      worst,
+      interferenceAt(probe.bin, probe.lid, px, py, probe.dz) -
+        interferenceAt(reference.bin, reference.lid, rx, ry, reference.dz)
+    );
+  }
+  return worst;
+}
+
 /**
  * Worst interference anywhere along the four rail lines.
  *
@@ -72,6 +142,9 @@ export function interferenceAt(
  * (a label shelf, a scoop's lip fill) are thin, so a single-column probe can
  * slip between them and report clean.
  */
+/** Offsets from a rail's spine the sweep visits; shared with the paired form. */
+const RAIL_PROBE_OFFSETS = [-0.6, -0.2, 0, 0.6, 1.4] as const;
+
 export function worstRailInterference(bin: MeshData, lid: MeshData, dz: number): number {
   // Probe positions come from the LID's own bounds rather than a re-derivation
   // of its width: overhang both widens and shifts the lid, and an arithmetic
@@ -83,7 +156,7 @@ export function worstRailInterference(bin: MeshData, lid: MeshData, dz: number):
   const spineY = (bb.maxY - bb.minY) / 2 - LID_CORNER_RADIUS;
 
   let worst = 0;
-  for (const off of [-0.6, -0.2, 0, 0.6, 1.4]) {
+  for (const off of RAIL_PROBE_OFFSETS) {
     // Left and right rails: sweep along Y at the rail's X.
     for (let y = cy - spineY; y <= cy + spineY; y += 1) {
       for (const sx of [cx + spineX + off, cx - spineX - off]) {

--- a/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
+++ b/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Standing assembly check: nothing may intrude into the lid's seating volume.
+ *
+ * Four defects in this family shipped (#3401, #3434, #3450, #3477), each caught
+ * only after a user reported a lid that would not close, and each guarded
+ * afterwards by a test aimed at the feature someone already suspected. A bin
+ * and its lid are separate solids, so every ordinary assertion — watertight,
+ * triangle count, bounding box — passes while the pair cannot be assembled
+ * (CLAUDE.md gotchas #10 and #18).
+ *
+ * This is the combinatorial version, and it is meant to fail for features that
+ * do not exist yet. The probe sweeps each rail line end to end rather than
+ * looking where someone already suspects, and the cases come from an all-pairs
+ * product over every axis that can reach the band, so a new feature interacting
+ * with an old one is covered without anyone having thought of the combination.
+ *
+ * The measurement is `worstRailInterferenceDelta` against the SAME
+ * configuration with its interior emptied, position by position. Three things
+ * make it that shape rather than something simpler:
+ *
+ * 1. Not the whole-footprint `worstSeatInterference`: a rail bump hooking the
+ *    lip's undercut is overlap in the nominal solid model, because that is what
+ *    a snap fit is. It reads 0.5-1.1mm on a perfectly good bin.
+ * 2. Not an absolute rail threshold either. The rail sweep's outer offsets
+ *    sample that same snap, so it is 0 on a 2x2 and 0.7mm on a 1x2 with no
+ *    interior features at all — a property of the footprint, and a matrix that
+ *    varies the footprint cannot use one number.
+ * 3. Not max-against-max. That hides a small clash behind a larger floor, and
+ *    over a 2D grid it also reports where the two grids happened to land
+ *    (0.2-0.8mm on configurations with no defect). Matching rail positions have
+ *    neither problem: the set is discrete and identical for one footprint.
+ *
+ * The scope this buys is the rail band, where three of the four defects lived
+ * (#3401, #3434, #3477). A pad on the skirt line away from any rail (#3450)
+ * needs the footprint sweep, and keeps its own dedicated test. Widening this
+ * gate to cover that too means first making `verticalSolidSpans` robust to the
+ * odd crossing counts that interior features leave at coincident faces — its
+ * own known weakness, and its own piece of work.
+ *
+ *   pnpm run test:run src/features/generation/worker/generators/lidSeatInterference.matrix
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import {
+  lidZOffset,
+  worstRailInterferenceDelta,
+  type SeatedPair,
+} from './__kernel-tests__/lidSeating';
+import { allPairs, uncoveredPairs, type Axis } from '@/test/pairwise';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams, CompartmentConfig } from '@/features/bin-designer/types';
+/**
+ * Tolerance (mm). Absorbs tessellation noise on the curved corner blends; the
+ * defects this guards against measured 1.25mm (#3401), 2.8mm (#3450) and
+ * 3.10mm (#3477).
+ */
+const TOLERANCE_MM = 0.05;
+
+const grid = (cols: number, rows: number): CompartmentConfig => ({
+  cols,
+  rows,
+  thickness: 1.2,
+  cells: Array.from({ length: cols * rows }, (_, i) => i),
+});
+
+const ONE: CompartmentConfig = { cols: 1, rows: 1, thickness: 1.2, cells: [0] };
+
+/**
+ * Axes are ordered largest first: all-pairs seeds on the product of the first
+ * two, so this bounds the case count. Every value must be reachable through the
+ * UI — a combination the constraint engine forbids would assert nothing.
+ */
+const AXES = [
+  { name: 'footprint', values: ['2x2', '3x2', '2x3', '1x2'] },
+  { name: 'compartments', values: ['1x1', '2x2', '3x2', '8x1'] },
+  { name: 'label', values: ['off', 'back', 'both'] },
+  { name: 'scoop', values: ['off', 'auto', 'typed'] },
+  { name: 'attachment', values: ['clickRails', 'friction', 'magnetic'] },
+  { name: 'grip', values: ['none', 'scallopDip'] },
+  { name: 'collar', values: ['0', '4'] },
+  { name: 'overhang', values: ['none', 'asym'] },
+  { name: 'coverage', values: ['50', '100'] },
+  { name: 'cutouts', values: ['off', 'front'] },
+  { name: 'handles', values: ['off', 'front'] },
+] as const satisfies readonly Axis<string>[];
+
+type Case = Record<(typeof AXES)[number]['name'], string>;
+
+const FOOTPRINTS: Record<string, { width: number; depth: number }> = {
+  '2x2': { width: 2, depth: 2 },
+  '3x2': { width: 3, depth: 2 },
+  '2x3': { width: 2, depth: 3 },
+  '1x2': { width: 1, depth: 2 },
+};
+
+const COMPARTMENTS: Record<string, CompartmentConfig> = {
+  '1x1': ONE,
+  '2x2': grid(2, 2),
+  '3x2': grid(3, 2),
+  '8x1': grid(8, 1),
+};
+
+function paramsFor(c: Case): BinParams {
+  const { width, depth } = FOOTPRINTS[c.footprint];
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width,
+    depth,
+    height: 6,
+    compartments: COMPARTMENTS[c.compartments],
+    extraWallHeightMm: Number(c.collar),
+    overhang:
+      c.overhang === 'asym'
+        ? { left: 0, right: 6, front: 2, back: 0, feet: false }
+        : DEFAULT_BIN_PARAMS.overhang,
+    label:
+      c.label === 'off'
+        ? DEFAULT_BIN_PARAMS.label
+        : {
+            ...DEFAULT_BIN_PARAMS.label,
+            enabled: true,
+            support: 'bracket',
+            depth: 12,
+            width: 100,
+            alignment: 'center',
+            edges: c.label === 'both' ? 'both' : 'back',
+          },
+    scoop:
+      c.scoop === 'off'
+        ? DEFAULT_BIN_PARAMS.scoop
+        : // A typed radius is the one the `autoScoopCeiling` clamp does not
+          // hold clear of the rail band (#3434), so it is its own value here.
+          { ...DEFAULT_BIN_PARAMS.scoop, enabled: true, radius: c.scoop === 'auto' ? 'auto' : 20 },
+    walls:
+      c.cutouts === 'off'
+        ? DEFAULT_BIN_PARAMS.walls
+        : {
+            ...DEFAULT_BIN_PARAMS.walls,
+            enabled: true,
+            front: { ...DEFAULT_BIN_PARAMS.walls.left, enabled: true, width: 40 },
+            back: { ...DEFAULT_BIN_PARAMS.walls.front, enabled: false },
+            left: { ...DEFAULT_BIN_PARAMS.walls.left, enabled: false },
+            right: { ...DEFAULT_BIN_PARAMS.walls.right, enabled: false },
+          },
+    handles:
+      c.handles === 'off'
+        ? DEFAULT_BIN_PARAMS.handles
+        : {
+            ...DEFAULT_BIN_PARAMS.handles,
+            enabled: true,
+            front: { ...DEFAULT_BIN_PARAMS.handles.front, enabled: true },
+            back: { ...DEFAULT_BIN_PARAMS.handles.back, enabled: false },
+            left: { ...DEFAULT_BIN_PARAMS.handles.left, enabled: false },
+            right: { ...DEFAULT_BIN_PARAMS.handles.right, enabled: false },
+          },
+    lid: {
+      ...DEFAULT_BIN_PARAMS.lid,
+      enabled: true,
+      attachment: c.attachment as BinParams['lid']['attachment'],
+      clickRails: { front: true, back: true, left: true, right: true },
+      clickRailCoverage: Number(c.coverage),
+      grip:
+        c.grip === 'none'
+          ? DEFAULT_BIN_PARAMS.lid.grip
+          : {
+              ...DEFAULT_BIN_PARAMS.lid.grip,
+              mode: 'scallop',
+              // `binDip` is what lets a relief interrupt the rails, so the
+              // scallop value exercises the split rather than just the cut.
+              binDip: true,
+            },
+    },
+  };
+}
+
+/** Axes describing the bin's interior; emptied to get a case's floor. */
+const INTERIOR_AXES = ['compartments', 'label', 'scoop', 'cutouts', 'handles'] as const;
+
+/** The same case with every interior feature switched off. */
+function emptied(c: Case): Case {
+  const out = { ...c };
+  for (const axis of INTERIOR_AXES) out[axis] = AXES.find((a) => a.name === axis)?.values[0] ?? '';
+  return out;
+}
+
+const key = (c: Case): string => AXES.map((a) => `${a.name}=${c[a.name]}`).join(',');
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 180000);
+
+describe('nothing intrudes into the lid seating volume', () => {
+  const CASES = allPairs<string>([...AXES]) as Case[];
+
+  it('the matrix is pairwise-complete', () => {
+    // Without this, a generator bug that dropped pairs would shrink the matrix
+    // and read as a speed-up rather than as lost coverage.
+    expect(uncoveredPairs<string>([...AXES], CASES)).toEqual([]);
+  });
+
+  it('the probe can see a real clash', async () => {
+    // Control for the whole matrix, and not optional: two earlier versions of
+    // this measurement reported confidently on things that were not defects,
+    // and a lip filter that excluded too much would make every case below pass
+    // by measuring nothing. Rebuilds the pre-#3477 pairing by hand — a bin with
+    // dividers, and a lid generated as though it had none.
+    const { generateLid } = await import('./lidOrchestrator');
+    const params = paramsFor({
+      footprint: '3x2',
+      compartments: '3x2',
+      label: 'off',
+      scoop: 'off',
+      attachment: 'clickRails',
+      grip: 'none',
+      collar: '0',
+      overhang: 'none',
+      coverage: '100',
+      cutouts: 'off',
+      handles: 'off',
+    });
+    const bin = getGenerateBin()(params, undefined, false);
+    const blindLid = generateLid({ ...params, compartments: ONE });
+    if (!bin || !blindLid) throw new Error('expected the control pair to build');
+
+    const dz = lidZOffset(params);
+    const plain = { ...params, compartments: ONE };
+    const plainBin = getGenerateBin()(plain, undefined, false);
+    if (!plainBin) throw new Error('expected the emptied bin to build');
+    expect(
+      worstRailInterferenceDelta({ bin, lid: blindLid, dz }, { bin: plainBin, lid: blindLid, dz })
+    ).toBeGreaterThan(2.5);
+  }, 300000);
+
+  it("no case puts bin material in a rail's path", async () => {
+    const { generateLid } = await import('./lidOrchestrator');
+    const build = (c: Case): SeatedPair | null => {
+      const params = paramsFor(c);
+      const bin = getGenerateBin()(params, undefined, false);
+      const lid = generateLid(params);
+      return bin && lid ? { bin, lid, dz: lidZOffset(params) } : null;
+    };
+
+    const baselines = new Map<string, SeatedPair>();
+    const skipped: string[] = [];
+    const intruding: Array<{ case: string; mm: number }> = [];
+
+    for (const c of CASES) {
+      const built = build(c);
+      // A blocked configuration (corner magnets on a bin too small, cutouts on
+      // every wall) generates no lid at all. Counted, not silently passed.
+      if (!built) {
+        skipped.push(key(c));
+        continue;
+      }
+      const baseKey = key(emptied(c));
+      let baseline = baselines.get(baseKey);
+      if (baseline === undefined) {
+        baseline = build(emptied(c)) ?? undefined;
+        if (!baseline) throw new Error(`baseline failed to build: ${baseKey}`);
+        baselines.set(baseKey, baseline);
+      }
+      const mm = worstRailInterferenceDelta(built, baseline);
+      if (mm >= TOLERANCE_MM) intruding.push({ case: key(c), mm: Number(mm.toFixed(3)) });
+    }
+
+    // A case list that mostly fails to build would satisfy the assertion below
+    // by measuring almost nothing.
+    expect(skipped.length).toBeLessThan(CASES.length / 4);
+    expect(intruding).toEqual([]);
+  }, 900000);
+});

--- a/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
+++ b/src/features/generation/worker/generators/lidSeatInterference.matrix.test.ts
@@ -138,8 +138,10 @@ function paramsFor(c: Case): BinParams {
         : {
             ...DEFAULT_BIN_PARAMS.walls,
             enabled: true,
-            front: { ...DEFAULT_BIN_PARAMS.walls.left, enabled: true, width: 40 },
-            back: { ...DEFAULT_BIN_PARAMS.walls.front, enabled: false },
+            // Stated outright rather than spread from another side's
+            // defaults, so a change to those cannot quietly redefine this case.
+            front: { ...DEFAULT_BIN_PARAMS.walls.front, enabled: true, width: 40, depth: 50 },
+            back: { ...DEFAULT_BIN_PARAMS.walls.back, enabled: false },
             left: { ...DEFAULT_BIN_PARAMS.walls.left, enabled: false },
             right: { ...DEFAULT_BIN_PARAMS.walls.right, enabled: false },
           },
@@ -243,6 +245,7 @@ describe('nothing intrudes into the lid seating volume', () => {
 
     const baselines = new Map<string, SeatedPair>();
     const skipped: string[] = [];
+    const measured: Case[] = [];
     const intruding: Array<{ case: string; mm: number }> = [];
 
     for (const c of CASES) {
@@ -260,13 +263,21 @@ describe('nothing intrudes into the lid seating volume', () => {
         if (!baseline) throw new Error(`baseline failed to build: ${baseKey}`);
         baselines.set(baseKey, baseline);
       }
+      measured.push(c);
       const mm = worstRailInterferenceDelta(built, baseline);
       if (mm >= TOLERANCE_MM) intruding.push({ case: key(c), mm: Number(mm.toFixed(3)) });
     }
 
-    // A case list that mostly fails to build would satisfy the assertion below
-    // by measuring almost nothing.
-    expect(skipped.length).toBeLessThan(CASES.length / 4);
+    // Completeness is asserted above over the GENERATED cases; a build that
+    // fails silently removes its case from the measured set, and enough of
+    // those could drop every instance of a value pair while the total skip
+    // count still looked small. So the property is re-checked over what was
+    // actually measured — and `skipped` is listed, not counted, because a
+    // configuration this cannot build is a coverage hole either way.
+    expect({ skipped, uncovered: uncoveredPairs<string>([...AXES], measured) }).toEqual({
+      skipped: [],
+      uncovered: [],
+    });
     expect(intruding).toEqual([]);
   }, 900000);
 });

--- a/src/test/pairwise.test.ts
+++ b/src/test/pairwise.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { allPairs, uncoveredPairs, type Axis } from './pairwise';
+
+const axes = <T>(spec: Record<string, readonly T[]>): Axis<T>[] =>
+  Object.entries(spec).map(([name, values]) => ({ name, values }));
+
+describe('allPairs', () => {
+  it('covers every value pair for a small set', () => {
+    const a = axes({ x: [1, 2, 3], y: [10, 20], z: [100, 200] });
+    expect(uncoveredPairs(a, allPairs(a))).toEqual([]);
+  });
+
+  it('covers every value pair for a wide, ragged set', () => {
+    const a = axes({
+      grid: ['1x1', '2x2', '3x2', '8x1'],
+      label: ['off', 'back', 'both'],
+      scoop: ['off', 'auto', 'typed'],
+      grip: ['none', 'scallop'],
+      collar: ['0', '4'],
+      overhang: ['none', 'asym'],
+      attachment: ['clickRails', 'friction', 'magnetic'],
+      coverage: ['50', '100'],
+    });
+    expect(uncoveredPairs(a, allPairs(a))).toEqual([]);
+  });
+
+  it('stays far below the full product', () => {
+    const a = axes({
+      grid: ['1x1', '2x2', '3x2', '8x1'],
+      label: ['off', 'back', 'both'],
+      scoop: ['off', 'auto', 'typed'],
+      grip: ['none', 'scallop'],
+      collar: ['0', '4'],
+      overhang: ['none', 'asym'],
+      attachment: ['clickRails', 'friction', 'magnetic'],
+      coverage: ['50', '100'],
+    });
+    // Full product is 4*3*3*2*2*2*3*2 = 1728 WASM builds. Pairwise is bounded
+    // below by the two largest axes (4*3 = 12); anything near the product means
+    // the generator has stopped combining.
+    expect(allPairs(a).length).toBeLessThan(40);
+  });
+
+  it('is deterministic', () => {
+    const a = axes({ x: [1, 2, 3], y: [10, 20], z: [100, 200, 300] });
+    expect(allPairs(a)).toEqual(allPairs(a));
+  });
+
+  it('gives every case a value on every axis', () => {
+    const a = axes({ x: [1, 2, 3], y: [10, 20], z: [100, 200] });
+    for (const c of allPairs(a)) {
+      expect(Object.keys(c).sort()).toEqual(['x', 'y', 'z']);
+    }
+  });
+
+  it('handles a single-value axis as a constant', () => {
+    const a = axes<string>({ x: ['1', '2'], only: ['fixed'] });
+    const cases = allPairs(a);
+    expect(uncoveredPairs(a, cases)).toEqual([]);
+    expect(cases.every((c) => c.only === 'fixed')).toBe(true);
+  });
+
+  it('degenerates cleanly', () => {
+    expect(allPairs([])).toEqual([]);
+    expect(allPairs(axes({ x: [1, 2] }))).toEqual([{ x: 1 }, { x: 2 }]);
+  });
+
+  it('uncoveredPairs reports a real gap', () => {
+    // Control for every assertion above: if the detector cannot see a missing
+    // pair, "covers every value pair" is satisfied by any case list at all.
+    const a = axes({ x: [1, 2], y: [10, 20] });
+    expect(uncoveredPairs(a, [{ x: 1, y: 10 }])).toEqual(['x=1|y=1', 'x=1|y=0', 'x=0|y=1'].sort());
+  });
+});

--- a/src/test/pairwise.ts
+++ b/src/test/pairwise.ts
@@ -1,0 +1,165 @@
+/**
+ * All-pairs (pairwise) case generation for combinatorial test matrices.
+ *
+ * A full product over the axes that can reach a lid's seating band is in the
+ * thousands of WASM builds; a hand-picked list is the enumerate-by-hand model
+ * that lets defects through in the first place. All-pairs is the standard
+ * middle: every VALUE PAIR from every AXIS PAIR appears in at least one case,
+ * which is where interaction defects overwhelmingly live, for a case count
+ * near the product of the two largest axes rather than of all of them.
+ *
+ * Greedy IPOG-style horizontal-then-vertical growth. Deterministic — no
+ * randomness, so the same axes always yield the same cases in the same order
+ * and a failure is reproducible from the case index alone.
+ */
+
+/** One axis: a name and its possible values. */
+export interface Axis<T> {
+  readonly name: string;
+  readonly values: readonly T[];
+}
+
+/** A generated case: one value per axis, keyed by axis name. */
+export type PairwiseCase<T> = Readonly<Record<string, T>>;
+
+function pairKey(a: string, ai: number, b: string, bi: number): string {
+  return `${a}=${ai}|${b}=${bi}`;
+}
+
+/** Every value pair across every axis pair, as lookup keys. */
+function allPairKeys<T>(axes: readonly Axis<T>[]): Set<string> {
+  const out = new Set<string>();
+  for (let i = 0; i < axes.length; i++) {
+    for (let j = i + 1; j < axes.length; j++) {
+      for (let ai = 0; ai < axes[i].values.length; ai++) {
+        for (let bi = 0; bi < axes[j].values.length; bi++) {
+          out.add(pairKey(axes[i].name, ai, axes[j].name, bi));
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** Pairs a partial case (axis name → value index) covers among `axes`. */
+function coveredBy(chosen: ReadonlyMap<string, number>, axes: readonly Axis<unknown>[]): string[] {
+  const names = axes.map((a) => a.name).filter((n) => chosen.has(n));
+  const out: string[] = [];
+  for (let i = 0; i < names.length; i++) {
+    for (let j = i + 1; j < names.length; j++) {
+      // Axis order in the key must match `allPairKeys`, which walks the axis
+      // array in order — not the insertion order of `chosen`.
+      const [a, b] =
+        axes.findIndex((x) => x.name === names[i]) < axes.findIndex((x) => x.name === names[j])
+          ? [names[i], names[j]]
+          : [names[j], names[i]];
+      out.push(pairKey(a, chosen.get(a) ?? 0, b, chosen.get(b) ?? 0));
+    }
+  }
+  return out;
+}
+
+/**
+ * Generate a pairwise-complete set of cases.
+ *
+ * Axes are consumed in the order given; put the largest first, since the case
+ * count is bounded below by the product of the two largest. Axes with a single
+ * value are constants and contribute no pairs, but still appear in each case.
+ *
+ * The result is pairwise-complete by construction, and
+ * {@link uncoveredPairs} proves it — the matrix test asserts that rather than
+ * trusting this comment.
+ */
+export function allPairs<T>(axes: readonly Axis<T>[]): PairwiseCase<T>[] {
+  if (axes.length === 0) return [];
+  if (axes.length === 1) {
+    return axes[0].values.map((v) => ({ [axes[0].name]: v }));
+  }
+
+  const remaining = allPairKeys(axes);
+  // Seed with the full product of the first two axes.
+  const cases: Array<Map<string, number>> = [];
+  for (let a = 0; a < axes[0].values.length; a++) {
+    for (let b = 0; b < axes[1].values.length; b++) {
+      const c = new Map([
+        [axes[0].name, a],
+        [axes[1].name, b],
+      ]);
+      for (const k of coveredBy(c, axes)) remaining.delete(k);
+      cases.push(c);
+    }
+  }
+
+  for (let k = 2; k < axes.length; k++) {
+    const axis = axes[k];
+    const grown = axes.slice(0, k + 1);
+
+    // Horizontal growth: extend each existing case with the value that covers
+    // the most still-uncovered pairs.
+    for (const c of cases) {
+      let best = 0;
+      let bestGain: string[] = [];
+      for (let v = 0; v < axis.values.length; v++) {
+        const trial = new Map(c).set(axis.name, v);
+        const gain = coveredBy(trial, grown).filter((p) => remaining.has(p));
+        if (gain.length > bestGain.length || bestGain.length === 0) {
+          best = v;
+          bestGain = gain;
+        }
+      }
+      c.set(axis.name, best);
+      for (const p of coveredBy(c, grown)) remaining.delete(p);
+    }
+
+    // Vertical growth: any pair this axis still owes gets its own case, with
+    // the other axes filled from their first value.
+    for (let v = 0; v < axis.values.length; v++) {
+      for (let prior = 0; prior < k; prior++) {
+        const other = axes[prior];
+        for (let ov = 0; ov < other.values.length; ov++) {
+          // `other` precedes `axis` in the array, so this key orientation
+          // matches the one `allPairKeys` produced.
+          if (!remaining.has(pairKey(other.name, ov, axis.name, v))) continue;
+          const c = new Map<string, number>();
+          for (const a of grown) c.set(a.name, 0);
+          c.set(other.name, ov);
+          c.set(axis.name, v);
+          for (const p of coveredBy(c, grown)) remaining.delete(p);
+          cases.push(c);
+        }
+      }
+    }
+  }
+
+  return cases.map((c) => {
+    const out: Record<string, T> = {};
+    for (const axis of axes) out[axis.name] = axis.values[c.get(axis.name) ?? 0];
+    return out;
+  });
+}
+
+/**
+ * Value pairs the case set fails to cover. Empty means pairwise-complete.
+ *
+ * Exported so a matrix test can assert the property rather than assume it: a
+ * generator bug that silently dropped pairs would shrink the matrix and look
+ * like a speed-up.
+ */
+export function uncoveredPairs<T>(
+  axes: readonly Axis<T>[],
+  cases: readonly PairwiseCase<T>[]
+): string[] {
+  const remaining = allPairKeys(axes);
+  const indexOf = new Map<string, Map<T, number>>();
+  for (const axis of axes) {
+    indexOf.set(axis.name, new Map(axis.values.map((v, i) => [v, i])));
+  }
+  for (const c of cases) {
+    const chosen = new Map<string, number>();
+    for (const axis of axes) {
+      chosen.set(axis.name, indexOf.get(axis.name)?.get(c[axis.name]) ?? 0);
+    }
+    for (const p of coveredBy(chosen, axes)) remaining.delete(p);
+  }
+  return [...remaining].sort();
+}


### PR DESCRIPTION
Four defects in the lid-seating family have shipped: #3401, #3434, #3450, #3477. Each was found by a user with a lid that would not close, and each was then guarded by a test aimed at the feature someone already suspected. Nothing was watching the *combinations*.

This is the standing gate. It runs on every CI build in the generators project, ~40s on the self-hosted shards.

## The matrix

All-pairs over every axis that can reach the seating band:

```
footprint     2x2 | 3x2 | 2x3 | 1x2
compartments  1x1 | 2x2 | 3x2 | 8x1
label         off | back | both
scoop         off | auto | typed radius
attachment    clickRails | friction | magnetic
grip          none | scallop + binDip
collar        0 | 4mm
overhang      none | asymmetric
coverage      50 | 100
cutouts       off | front 40%
handles       off | front
```

The full product is 1728 WASM builds. Twenty cases cover every value pair from every axis pair, which is where interaction defects live. `src/test/pairwise.ts` generates them with deterministic greedy IPOG — no randomness, so a failure is reproducible from its case key — and the test **asserts** pairwise-completeness via `uncoveredPairs` rather than trusting the generator, since a generator bug that dropped pairs would shrink the matrix and read as a speed-up.

## Getting the measurement right took three attempts

All three looked convincing, and two produced confident failures on configurations with no defect at all. Recording them because the next person will reach for the same ones.

**1. The whole-footprint sweep has no meaningful zero.** `worstSeatInterference` reports 0.5mm on a plain bin and 1.1mm under asymmetric overhang, with no interior features whatsoever. That is not a floor to subtract — **a rail bump hooking the lip's undercut is overlap in the nominal solid model, because that is what a snap fit is.**

**2. A "same bin, empty interior" baseline does not cancel it.** Emptying the interior changes *which rails get built*, so the two lids differ exactly where the subtraction happens. Reported 0.2–0.8mm on three defect-free configurations. Max-against-max over a 2D grid adds a second error on top: it reports where the two grids happened to land.

**3. Restricting the sweep to the bin's interior looked right and was worse.** It reported **0.0 on a pairing with a known 3.1mm clash** — `verticalSolidSpans` mis-pairs at the coincident faces interior features leave behind, an issue `columnCrossings` documents and that interior features make pervasive. The control caught this; nothing else would have.

## What actually works

The rail probe, compared **position by position** against the same configuration with its interior emptied. Its sample positions are a fixed discrete set derived from the lid bounds — identical for two lids of one footprint — so the snap term cancels exactly, and a small clash cannot hide behind a larger floor the way max-against-max allows.

The absolute form cannot serve a matrix that varies the footprint: `worstRailInterference` reads 0 on a 2x2 and 0.7mm on a 1x2, both defect-free.

The control that caught attempt three is now a permanent part of the file: it rebuilds the pre-#3477 pairing by hand and asserts the probe still sees >2.5mm. Skipped cases (a blocked config generates no lid) are counted and bounded, so the matrix cannot pass by measuring nothing.

## Scope

The rail band, where three of the four defects lived. A gusset pad on the skirt line away from any rail (#3450) needs the footprint sweep and keeps its dedicated test. Widening this gate to cover that class means first making `verticalSolidSpans` robust to odd crossing counts — its own known weakness, and its own piece of work.

The per-issue scenario files stay as they are. They carry each defect's measurement, its narrative and its control, which is what makes a failure readable; the matrix answers a different question.

## Result

Passes on `main` as it stands. No fifth defect — every failure this turned up during development was the instrument, which is itself the argument for the control.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic pairwise matrix test that gates lid seating across combinations to prevent shipped defects (#3401, #3434, #3450, #3477). Production behavior is unchanged; this is a CI guard in the generators project (~40s per run).

- Measurement: adds `worstRailInterferenceDelta`, comparing rail-probe samples position by position against the same configuration with its interior emptied; shared `RAIL_PROBE_OFFSETS` and fixed probe positions from lid bounds; tolerance `0.05mm`. Scope is the rail band; the skirt-line pad case (#3450) keeps its dedicated footprint sweep.
- Matrix: builds pairwise cases over footprint, compartments, label, scoop, attachment, grip, collar, overhang, coverage, cutouts, handles. Deterministic greedy IPOG in `src/test/pairwise.ts` (`allPairs`, `uncoveredPairs`) with unit tests; asserts pairwise completeness over generated cases and re-checks completeness over measured cases, listing any skipped cases (expected none).
- Controls: reconstructs the pre-#3477 clash to ensure the probe reports >2.5mm, guarding against false negatives.
- Changes: `lidSeating.ts` adds `SeatedPair`, `RAIL_PROBE_OFFSETS`, `worstRailInterferenceDelta`; new tests `lidSeatInterference.matrix.test.ts` and `pairwise.test.ts`; new helper `src/test/pairwise.ts`.

<sup>Written for commit c7f256a28006893a107e59f623375ab679622232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

