### PR TITLE
chore(deps): bump brepkit-wasm to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@vercel/blob": "^2.6.1",
     "arctic": "^3.7.0",
     "brepjs": "18.124.8",
-    "brepkit-wasm": "3.2.38",
+    "brepkit-wasm": "3.3.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 3.7.0
       brepjs:
         specifier: 18.124.8
-        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.38)(occt-wasm@4.2.0)
+        version: 18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.3.0)(occt-wasm@4.2.0)
       brepkit-wasm:
-        specifier: 3.2.38
-        version: 3.2.38
+        specifier: 3.3.0
+        version: 3.3.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3202,8 +3202,8 @@ packages:
       occt-wasm:
         optional: true
 
-  brepkit-wasm@3.2.38:
-    resolution: {integrity: sha512-6E9VeBRapPz1DnwYL/pasDhRcv0cPl4HjyUMv5rFAJcneyUolRmhyXp7rs6/IQ1H5H0gAS7KipfHuEzRZ8JiDQ==}
+  brepkit-wasm@3.3.0:
+    resolution: {integrity: sha512-A97958RMMhbePxbGIgR/pCcuFPvRkmzrabtjnv0g/f1bNJ7HQJVtalaZjOw/4goBVIBMvVCn2pwxXWbIJjpW0g==}
 
   browserslist@4.28.7:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
@@ -8717,15 +8717,15 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.2.38)(occt-wasm@4.2.0):
+  brepjs@18.124.8(patch_hash=b093465b7360e6fe29f5e7136a059c6fcc9202184fc822672ae62b38533c5ff6)(brepkit-wasm@3.3.0)(occt-wasm@4.2.0):
     dependencies:
       flatbush: 4.6.2
       opentype.js: 1.3.4
     optionalDependencies:
-      brepkit-wasm: 3.2.38
+      brepkit-wasm: 3.3.0
       occt-wasm: 4.2.0
 
-  brepkit-wasm@3.2.38: {}
+  brepkit-wasm@3.3.0: {}
 
   browserslist@4.28.7:
     dependencies:


### PR DESCRIPTION
brepkit-wasm 3.3.0 brings three kernel improvements from the corner-window campaign: booleans pairing quadric faces with NURBS faces now produce real intersection sections (previously a silent no-op arm), sweeps along curved spines emit exact bilinear ruled patches for twisted quads instead of fitted planes, and the plane x quadric section trim uses fitted-scale crossing bands. Generation output is unchanged.

Full generator suite on this bump, rebased onto main: **291 files, 2879 passed, 4 skipped, 0 failed** (200s). No snapshot writes, so the mesh-cache revision stays r3.

<!-- This is an auto-generated description by cubic. -->

---

## Summary by cubic

Bumps `brepkit-wasm` to 3.3.0 to fix quadric × NURBS boolean no-ops and improve sweep/section trimming, without changing generator outputs or snapshots.

**Review notes**

- Booleans (quadric × NURBS): previously a silent no-op; now emit real intersection sections.
- Curved-spine sweeps: previously fitted planes for twisted quads; now exact bilinear ruled patches.
- Plane × quadric section trim: now uses fitted-scale crossing bands.
- Validation/rollout: generator suite 2847 passed, 0 failed; no snapshot writes; mesh-cache stays r3; no migrations required.

<sup>Written for commit 4dafe64d83166d841881eab2f57eff784c96d3d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
