### PR TITLE
fix(bento): unify the Experimental badge on the info tone

### DIFF
--- a/src/features/bin-designer/components/BentoWorkspace/BentoWorkspaceHeader.test.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoWorkspaceHeader.test.tsx
@@ -101,7 +101,10 @@ describe('BentoWorkspaceHeader', () => {
   it('marks the workspace experimental without displacing the controls', () => {
     render(<BentoWorkspaceHeader {...makeProps({ canUndo: true })} />);
 
-    expect(screen.getByText('common.experimental')).toBeInTheDocument();
+    // `info`, matching every other Experimental badge in the app (the publish
+    // button, the community gallery, the publish dialog) — the same word in two
+    // tones reads as two different states.
+    expect(screen.getByText('common.experimental')).toHaveClass('bg-info-muted');
     // The badge sits beside the title; everything else still renders.
     expect(screen.getByText('binDesigner.interior.bento.title')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'common.undo' })).toBeEnabled();

--- a/src/features/bin-designer/components/BentoWorkspace/BentoWorkspaceHeader.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoWorkspaceHeader.tsx
@@ -71,7 +71,7 @@ export function BentoWorkspaceHeader({
         <h2 className="text-sm font-semibold text-content-primary">
           {t('binDesigner.interior.bento.title')}
         </h2>
-        <Badge tone="warning" title={t('binDesigner.bento.experimentalHint')}>
+        <Badge tone="info" title={t('binDesigner.bento.experimentalHint')}>
           {t('common.experimental')}
         </Badge>
       </div>

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.test.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.test.tsx
@@ -157,7 +157,8 @@ describe('InteriorModeCard', () => {
       const { rerender } = render(
         <InteriorModeCard card="bento" isExpanded={false} onSelect={vi.fn()} />
       );
-      expect(screen.getByText('common.experimental')).toBeInTheDocument();
+      // `info` tone, matching the app's other Experimental badges.
+      expect(screen.getByText('common.experimental')).toHaveClass('bg-info-muted');
       expect(screen.getByText('binDesigner.interior.bento.title')).toBeInTheDocument();
 
       rerender(<InteriorModeCard card="standard" isExpanded={false} onSelect={vi.fn()} />);

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
@@ -188,7 +188,7 @@ export function InteriorModeCard({ card, isExpanded, onSelect }: InteriorModeCar
           <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
             <h4 className="text-sm font-medium text-content-primary">{t(config.titleKey)}</h4>
             {card === 'bento' && (
-              <Badge tone="warning" title={t('binDesigner.bento.experimentalHint')}>
+              <Badge tone="info" title={t('binDesigner.bento.experimentalHint')}>
                 {t('common.experimental')}
               </Badge>
             )}


### PR DESCRIPTION
The Bento badges added in #3489 shipped as `tone="warning"`, while every other Experimental badge in the app is `tone="info"`:

| Site | Before | After |
| --- | --- | --- |
| `DesignerHeader` (publish button) | `info` | `info` |
| `CommunityPage` | `info` | `info` |
| `PublishDialog` | `info` | `info` |
| Interior mode card (Bento) | **`warning`** | `info` |
| Bento workspace header | **`warning`** | `info` |

The same word in two tones reads as two different states, which is the opposite of what a status chip is for.

Both existing badge tests asserted only that the text rendered, so the tones could diverge again without anything noticing. They now assert `bg-info-muted` instead — I reverted the tone locally to confirm the assertion actually fails, rather than trusting a green run.

`typecheck`, `lint` (0 errors), the four i18n checks, and the full suite: 22413 passed, 20 skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the "Experimental" badge in Bento to `tone="info"` instead of `warning`, matching the rest of the app and avoiding mixed status signals.

- Updated `BentoWorkspaceHeader` and `InteriorModeCard` to use `tone="info"`.
- Tests now assert the `bg-info-muted` class on the badge instead of only checking text.
- No layout or interaction changes; tests confirm header controls and titles still render as before.

<sup>Written for commit fa1b2aec50c1629446c2c8a42d4744180d69fdd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

