### PR TITLE
feat(lid): relieve the interior of custom-shape bins

### DIFF
--- a/src/features/generation/worker/generators/lidPolygonRelief.scenario.test.ts
+++ b/src/features/generation/worker/generators/lidPolygonRelief.scenario.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Lid interior relief on a custom shape (#3482).
+ *
+ * The rectangle path cuts a rounded rectangle less its inset copy. A custom
+ * shape cannot: an inward offset of the outline self-intersects on a thin neck,
+ * pushes an inner loop the wrong way, and needs its notch corners clipped. So
+ * the ring is built as one band per outline edge instead (`lidKeepoutSlabs`),
+ * which for a rectilinear outline is the same set and needs none of that.
+ *
+ * ## What this file can and cannot prove
+ *
+ * The ring CUTS AIR on a polygon bin today, and that is not a defect — it is
+ * the reason #3482 was deferred in the first place. Everything that could rise
+ * into the band is gated off for a partial mask: neither `compartmentWallsFeature`
+ * nor `labelTabsFeature` declares `supportsCellMask`, so `featuresStage` drops
+ * both, and the cavity under the rim is empty. The ring exists so that tree
+ * order already protects the lid on the day either one gains polygon support,
+ * which is the whole point of #3477's design.
+ *
+ * So WHERE the band lies is proven by `lidKeepoutSlabs.test.ts`, which compares
+ * it against an independently sampled erosion. What is left for real geometry
+ * is the other half — that cutting it HARMS NOTHING:
+ *
+ *  - the solid still builds and stays sound;
+ *  - the stacking lip's undercut is untouched, the failure that leaves a bin
+ *    looking perfect and holding nothing;
+ *  - the WALL is untouched, including at the reflex corner, where a band that
+ *    overshot its neighbour's line would eat into an L's inner corner.
+ *
+ * The last is the real risk in a union-of-bands construction, and it is stated
+ * as bit-identity against the unrelieved bin rather than as a threshold: the
+ * ring is supposed to leave every one of these places alone, so any difference
+ * at all is the defect.
+ *
+ *   pnpm run test:run src/features/generation/worker/generators/lidPolygonRelief.scenario
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { columnCrossings, assertStructurallyValid } from './__kernel-tests__/meshAssertions';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams } from '@/features/bin-designer/types';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { isPartialMask } from '@/shared/utils/cellMask';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+import { lidKeepoutSlabs } from '@/shared/constants/lidKeepout';
+
+/** An L: the bottom half full, the top half only the left two columns. */
+const L_MASK: CellMask = {
+  cols: 4,
+  rows: 4,
+  // Bottom-first, matching grid convention (row 0 is y-minimum).
+  cells: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0],
+};
+
+/** A U: a notch bitten out of the top middle, giving two reflex corners. */
+const U_MASK: CellMask = {
+  cols: 4,
+  rows: 4,
+  cells: [1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1],
+};
+
+const WALL = DEFAULT_BIN_PARAMS.wallThickness;
+const PITCH = DEFAULT_BIN_PARAMS.gridUnitMm;
+
+function makeParams(cellMask: CellMask, relieve: boolean): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: 2,
+    depth: 2,
+    height: 6,
+    cellMask,
+    lid: {
+      ...DEFAULT_BIN_PARAMS.lid,
+      enabled: true,
+      attachment: 'clickRails',
+      clickRails: { front: true, back: true, left: true, right: true },
+      clickRailCoverage: 100,
+      relieveInterior: relieve,
+    },
+  };
+}
+
+/** Topmost surface at a column, or undefined when the ray misses the solid. */
+const topAt = (mesh: Parameters<typeof columnCrossings>[0], x: number, y: number) =>
+  columnCrossings(mesh, x, y).at(-1);
+
+/**
+ * Columns that sit INSIDE the wall, all the way round a mask's outline.
+ *
+ * Placed midway between the lip's inner face and the wall's, the band where the
+ * lip is the only material — solid above the rim, open pocket below. That makes
+ * one probe answer both questions this file asks of the wall: whether the ring
+ * shaved the undercut, and whether it ate into the wall itself.
+ */
+function wallProbes(mask: CellMask): Array<readonly [number, number]> {
+  const half = (mask.cols * 0.5 * PITCH) / 2;
+  const depth = (GRIDFINITY_SPEC.TOLERANCE / 2 + GRIDFINITY_SPEC.LIP_BIG_TAPER + WALL) / 2;
+  const out: Array<readonly [number, number]> = [];
+  // Walk a ring of columns just inside the bounding box, keeping only those
+  // that land on material — a simple sweep reaches every outer wall of an L or
+  // a U without hard-coding where its steps are.
+  for (let t = -half + 3; t <= half - 3; t += 3) {
+    out.push([t, -half + depth], [t, half - depth], [-half + depth, t], [half - depth, t]);
+  }
+  return out;
+}
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 180000);
+
+describe('lid interior relief on a custom shape', () => {
+  it('plans a band for every edge of a custom outline', () => {
+    // Cheap guard against the whole file going vacuous: if the polygon path
+    // stopped producing a cutter, every "unchanged" assertion below would pass
+    // for the wrong reason.
+    expect(isPartialMask(L_MASK)).toBe(true);
+    expect(lidKeepoutSlabs(L_MASK, PITCH, PITCH, WALL).length).toBeGreaterThanOrEqual(6);
+    expect(lidKeepoutSlabs(U_MASK, PITCH, PITCH, WALL).length).toBeGreaterThanOrEqual(8);
+  });
+
+  it.each([
+    ['an L-shape', L_MASK],
+    ['a U-shape, whose notch has two reflex corners', U_MASK],
+  ])(
+    'cuts %s without touching its wall or its lip',
+    async (_name, mask) => {
+      const withRing = getGenerateBin()(makeParams(mask, true), undefined, false);
+      const without = getGenerateBin()(makeParams(mask, false), undefined, false);
+      if (!withRing || !without) throw new Error('expected both bins to build');
+      assertStructurallyValid(withRing, 'relieved polygon bin');
+
+      let compared = 0;
+      for (const [x, y] of wallProbes(mask)) {
+        const a = topAt(withRing, x, y);
+        const b = topAt(without, x, y);
+        if (a === undefined || b === undefined) continue; // off the shape
+        // Above the wall top means the probe really is in the lip, so the
+        // comparison is about the undercut rather than some interior floor.
+        if (a <= 6 * DEFAULT_BIN_PARAMS.heightUnitMm) continue;
+        expect(a, `wall changed at (${x.toFixed(1)}, ${y.toFixed(1)})`).toBeCloseTo(b, 6);
+        compared++;
+      }
+      // Anti-vacuity: a probe ring that missed the shape entirely would pass.
+      expect(compared).toBeGreaterThan(20);
+    },
+    300000
+  );
+
+  it('removes no material anywhere, since nothing rises into the band yet', async () => {
+    // Characterisation, and deliberately so. Compartments and label tabs are
+    // both gated off for a partial mask, so the ring meets only air. The day
+    // either gains polygon support this stops holding, and that is the signal
+    // to come back and assert the relief instead — not to relax this.
+    //
+    // Stated on the top surface rather than the triangle count: the ring's
+    // outer face is COINCIDENT with the lip's inner face, so the boolean
+    // re-triangulates there (2870 -> 2984 on this bin) while removing nothing.
+    // A count is a tessellation fact; where the material ends is a geometry one.
+    const withRing = getGenerateBin()(makeParams(L_MASK, true), undefined, false);
+    const without = getGenerateBin()(makeParams(L_MASK, false), undefined, false);
+    if (!withRing || !without) throw new Error('expected both bins to build');
+
+    const half = (L_MASK.cols * 0.5 * PITCH) / 2;
+    let compared = 0;
+    for (let x = -half + 1; x <= half - 1; x += 2) {
+      for (let y = -half + 1; y <= half - 1; y += 2) {
+        const a = topAt(withRing, x, y);
+        const b = topAt(without, x, y);
+        if (a === undefined || b === undefined) continue;
+        // 0.02mm, not bit-identity: the re-triangulation above moves facets on
+        // the rounded corner blends, so a ray there lands a few microns apart
+        // on the SAME surface (measured 0.0065mm at the outer corners). The
+        // defect this guards against is a band eating into the rim, which is
+        // whole millimetres.
+        expect(
+          Math.abs(a - b),
+          `material changed at (${x.toFixed(1)}, ${y.toFixed(1)})`
+        ).toBeLessThan(0.02);
+        compared++;
+      }
+    }
+    expect(compared).toBeGreaterThan(300);
+  }, 300000);
+});

--- a/src/features/generation/worker/generators/pipeline/stages/lidInteriorReliefStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/lidInteriorReliefStage.ts
@@ -27,11 +27,12 @@
  * overshot upward into it would silently disable the snap.
  */
 
-import { draw, cut, translate, unwrap } from 'brepjs';
+import { draw, cut, fuseAll, translate, unwrap } from 'brepjs';
 import type { Shape3D, ValidSolid, Drawing } from 'brepjs';
 import type { PipelineContext, PipelineStage } from '../types';
 import { interiorReliefActive } from '@/shared/types/bin';
-import { lidKeepoutRing } from '@/shared/constants/lidKeepout';
+import { lidKeepoutRing, lidKeepoutSlabs } from '@/shared/constants/lidKeepout';
+import { isPartialMask, type CellMask } from '@/shared/utils/cellMask';
 import { checkCancelled } from '../../utils/abort';
 import { FeatureTag } from '../../featureTags';
 import { collectOrigins } from '../collectOrigins';
@@ -60,6 +61,70 @@ function roundedRect(halfX: number, halfY: number, radius: number): Drawing {
     .close();
 }
 
+/**
+ * A built cutter plus every intermediate handle the caller must dispose.
+ *
+ * Returned rather than scoped because the cutter outlives the builder — it is
+ * tagged and then cut against the bin — and each brepjs transform allocates a
+ * WASM handle whose predecessor becomes garbage. Leaking them across
+ * regenerations exhausts the heap.
+ */
+interface BuiltRing {
+  readonly solid: Shape3D;
+  readonly scratch: readonly Shape3D[];
+}
+
+/** The rectangular ring: an outer rounded rect less its inset copy. */
+function buildRectRing(
+  ring: ReturnType<typeof lidKeepoutRing>,
+  innerHalfX: number,
+  innerHalfY: number,
+  bottomZ: number,
+  height: number
+): BuiltRing {
+  const outer = roundedRect(ring.outerHalfX, ring.outerHalfY, ring.cornerRadius);
+  const inner = roundedRect(innerHalfX, innerHalfY, Math.max(ring.cornerRadius - ring.width, 0));
+  const outerSolid = outer.sketchOnPlane('XY', bottomZ).extrude(height);
+  const innerSolid = inner.sketchOnPlane('XY', bottomZ).extrude(height);
+  return {
+    solid: unwrap(cut(outerSolid as ValidSolid, innerSolid as ValidSolid)),
+    scratch: [outerSolid, innerSolid],
+  };
+}
+
+/**
+ * The custom-shape ring: one band per outline edge, fused.
+ *
+ * Null when the outline yields no band at all — a footprint whose every edge is
+ * shorter than the band's own trim, which leaves nothing to relieve.
+ */
+function buildPolygonRing(
+  mask: CellMask,
+  gridUnitMm: number,
+  gridUnitMmY: number,
+  wallThickness: number,
+  bottomZ: number,
+  height: number
+): BuiltRing | null {
+  const slabs = lidKeepoutSlabs(mask, gridUnitMm, gridUnitMmY, wallThickness);
+  if (slabs.length === 0) return null;
+
+  const parts: Shape3D[] = slabs.map((s) =>
+    draw([s.minX, s.minY])
+      .lineTo([s.maxX, s.minY])
+      .lineTo([s.maxX, s.maxY])
+      .lineTo([s.minX, s.maxY])
+      .close()
+      .sketchOnPlane('XY', bottomZ)
+      .extrude(height)
+  );
+  if (parts.length === 1) return { solid: parts[0], scratch: [] };
+  // The bands overlap by construction at every corner, so the fuse is what
+  // makes them one cutter rather than a row of touching boxes whose shared
+  // faces would leave coincident geometry in the result.
+  return { solid: unwrap(fuseAll(parts as ValidSolid[])), scratch: parts };
+}
+
 export const lidInteriorReliefStage: PipelineStage = {
   name: 'merge',
   progressValue: 0.82,
@@ -83,7 +148,9 @@ export const lidInteriorReliefStage: PipelineStage = {
     const innerHalfY = ring.outerHalfY - ring.width;
     // A cavity narrower than two ring widths has no interior left to keep, so
     // the ring would degenerate into a plain slab. Leave such a bin alone
-    // rather than hollowing its whole mouth.
+    // rather than hollowing its whole mouth. Checked on the bounding cavity,
+    // which is the polygon case's guard too — a footprint whose BOUNDS are that
+    // tight has no usable interior on any outline.
     if (innerHalfX <= 0.1 || innerHalfY <= 0.1) return ctx;
 
     // Bottom at the rail's deepest reach plus clearance, measured from the wall
@@ -106,11 +173,23 @@ export const lidInteriorReliefStage: PipelineStage = {
     const topZ = dim.wallTopZ;
     const height = topZ - bottomZ;
 
-    const outer = roundedRect(ring.outerHalfX, ring.outerHalfY, ring.cornerRadius);
-    const inner = roundedRect(innerHalfX, innerHalfY, Math.max(ring.cornerRadius - ring.width, 0));
-    const outerSolid = outer.sketchOnPlane('XY', bottomZ).extrude(height);
-    const innerSolid = inner.sketchOnPlane('XY', bottomZ).extrude(height);
-    const ringSolid = unwrap(cut(outerSolid as ValidSolid, innerSolid as ValidSolid));
+    const mask = params.cellMask;
+    // A custom shape's ring follows its own outline, so it is built as the union
+    // of one band per edge rather than as a rounded rectangle less its inset
+    // copy (#3482). `lidKeepoutSlabs` explains why that is a construction and
+    // not an approximation.
+    const built = isPartialMask(mask)
+      ? buildPolygonRing(
+          mask,
+          params.gridUnitMm,
+          params.gridUnitMmY ?? params.gridUnitMm,
+          params.wallThickness,
+          bottomZ,
+          height
+        )
+      : buildRectRing(ring, innerHalfX, innerHalfY, bottomZ, height);
+    if (!built) return ctx;
+    const { solid: ringSolid, scratch } = built;
 
     // The interior is translated by the overhang offset, so the envelope has to
     // follow it or an asymmetric bin gets relieved off-centre.
@@ -125,8 +204,7 @@ export const lidInteriorReliefStage: PipelineStage = {
     collectOrigins(positioned, FeatureTag.LID_RELIEF, ctx.originToTag);
 
     const result = unwrap(cut(ctx.solid as ValidSolid, positioned as ValidSolid));
-    outerSolid.delete();
-    innerSolid.delete();
+    for (const s of scratch) s.delete();
     if (positioned !== ringSolid) positioned.delete();
     ringSolid.delete();
     if (result !== ctx.solid) ctx.solid.delete();

--- a/src/shared/constants/lidKeepout.ts
+++ b/src/shared/constants/lidKeepout.ts
@@ -16,6 +16,8 @@
  */
 
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+import { maskEdgesMm, type MaskEdgeMm } from '@/shared/utils/maskEdgeGeometry';
+import type { CellMask } from '@/shared/utils/cellMask';
 import {
   LID_CLICK_RAIL_BAND_BELOW_WALL_TOP,
   LID_CLICK_RAIL_INNER,
@@ -97,6 +99,36 @@ export function railInboardReachMm(wallThickness: number): number {
 }
 
 /**
+ * Radial width of the ring, inward from the lip's inner face.
+ *
+ * Depends on nothing but the wall, so a polygon footprint takes the same band
+ * as a rectangle — the two differ in where the band is laid, never how deep it
+ * reaches. Split out so {@link lidKeepoutSlabs} cannot drift from
+ * {@link lidKeepoutRing}.
+ */
+export function lidKeepoutWidthMm(wallThickness: number): number {
+  const lipInset = wallThickness - GRIDFINITY_SPEC.LIP_BIG_TAPER;
+  // Both terms are measured from the INNER WALL FACE while the ring starts at
+  // the lip line, so the jut is already spent: `lipInset` is negative and
+  // adding it shortens the width by the head start.
+  return railInboardReachMm(wallThickness) + LID_KEEPOUT_CLEARANCE + lipInset;
+}
+
+/**
+ * How far inboard of the NOMINAL footprint outline the ring's outer boundary
+ * sits, for a polygon edge.
+ *
+ * A mask outline spans the full grid-unit extent, so the bin's real outer face
+ * is already `TOLERANCE / 2` inside it; the lip's inner face is a further
+ * `LIP_BIG_TAPER` in. The rectangle path reaches the same line by a different
+ * route (`innerW / 2 + lipInset` = `outerW / 2 - LIP_BIG_TAPER`), which is the
+ * arithmetic `lidKeepoutSlabs` must agree with and the reason this is stated
+ * once here.
+ */
+export const LID_KEEPOUT_OUTLINE_INSET_MM =
+  GRIDFINITY_SPEC.TOLERANCE / 2 + GRIDFINITY_SPEC.LIP_BIG_TAPER;
+
+/**
  * Resolve the keep-out ring for a bin's interior.
  *
  * Two bounds, both chosen so the cut can never touch what makes the joint work:
@@ -125,12 +157,10 @@ export function lidKeepoutRing(
   const lipInset = wallThickness - GRIDFINITY_SPEC.LIP_BIG_TAPER;
   const outerHalfX = innerW / 2 + lipInset;
   const outerHalfY = innerD / 2 + lipInset;
-  // Inward to the rail's deepest reach, plus clearance. Both are measured from
-  // the INNER WALL FACE while the ring starts at the lip line, so the jut is
-  // already spent: `lipInset` is negative and adding it shortens the width by
-  // the head start. Subtracting it instead makes the ring 2x0.7mm too wide,
-  // which cuts more divider than the lid needs and passes every geometry check.
-  const width = railInboardReachMm(wallThickness) + LID_KEEPOUT_CLEARANCE + lipInset;
+  // Inward to the rail's deepest reach, plus clearance. Subtracting `lipInset`
+  // instead of adding it makes the ring 2x0.7mm too wide, which cuts more
+  // divider than the lid needs and passes every geometry check.
+  const width = lidKeepoutWidthMm(wallThickness);
   return {
     outerHalfX,
     outerHalfY,
@@ -138,4 +168,147 @@ export function lidKeepoutRing(
     depthBelowWallTop: LID_CLICK_RAIL_BAND_BELOW_WALL_TOP + LID_KEEPOUT_CLEARANCE,
     cornerRadius: Math.max(GRIDFINITY_SPEC.BOX_CORNER_RADIUS - GRIDFINITY_SPEC.LIP_BIG_TAPER, 0),
   };
+}
+
+/**
+ * One axis-aligned band of the keep-out ring, in the bin's centred mm frame.
+ *
+ * Axis-aligned rather than "a centre plus a rotation" because a mask outline is
+ * rectilinear, so every band already lies square to the axes and a rotation
+ * would only be an opportunity to apply it backwards.
+ */
+export interface LidKeepoutSlab {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+}
+
+/**
+ * The keep-out ring for a custom-shape footprint, as a union of per-edge bands.
+ *
+ * Deliberately NOT an inward offset of the outline (#3482 assumed one). For a
+ * RECTILINEAR polygon the union of per-edge bands is exactly `outline` minus
+ * `erode(outline, width)` under a square structuring element, and it turns each
+ * of the offset's hard cases into something that needs no handling at all:
+ *
+ *  - A thin neck, where an offset self-intersects, merely has its bands overlap
+ *    — and a neck narrower than twice the band IS entirely keep-out, which is
+ *    what the erosion says too.
+ *  - An inner loop, which an offset pushes the wrong way, carries its own
+ *    winding; `maskEdgesMm` reads the inward normal off that, so a hole's bands
+ *    face into the material like everyone else's.
+ *  - A notch corner needs no clipping, because each band is already bounded by
+ *    where its NEIGHBOURS' outer lines cross it.
+ *
+ * That last bound is the whole trick. Consecutive edges of a rectilinear
+ * polygon are perpendicular, so a neighbour's outer line is perpendicular to
+ * this edge and meets it at `inset * (neighbourNormal · thisDirection)` from
+ * the shared vertex. The dot product is +1 at a convex corner (pull the band
+ * back) and -1 at a reflex one (push it past the vertex), which is exactly how
+ * an erosion behaves at each.
+ *
+ * The bands alone are NOT the whole ring, though, and the shortfall is only at
+ * a reflex vertex. A point tucked diagonally into such a corner can sit further
+ * than the band from BOTH edges while still being within the band's reach of
+ * the void along the diagonal — measured at 3mm from one edge and 4mm from the
+ * other on a stock L, against a 5.8mm reach. An erosion removes it; two
+ * perpendicular bands miss it, and the miss is a wedge of un-relieved material
+ * exactly where an L-shaped bin's inner corner meets the lid. {@link
+ * reflexCornerSlab} fills it, and nothing analogous is needed at a convex
+ * vertex, where the two bands already overlap.
+ *
+ * Returns nothing when the band would be wider than the footprint has room for,
+ * matching the rectangle path's own degenerate guard.
+ */
+export function lidKeepoutSlabs(
+  mask: CellMask,
+  gridUnitMm: number,
+  gridUnitMmY: number,
+  wallThickness: number
+): readonly LidKeepoutSlab[] {
+  const width = lidKeepoutWidthMm(wallThickness);
+  if (width <= 0) return [];
+  const inset = LID_KEEPOUT_OUTLINE_INSET_MM;
+
+  const edges = maskEdgesMm(mask, gridUnitMm, gridUnitMmY);
+  const out: LidKeepoutSlab[] = [];
+
+  // Neighbours are the previous/next edge WITHIN the same loop, so a hole's
+  // corners are bounded by the hole's own edges rather than by whichever outer
+  // edge happens to sit next in the flat list.
+  const byLoop = new Map<number, MaskEdgeMm[]>();
+  for (const e of edges) {
+    const list = byLoop.get(e.loop);
+    if (list) list.push(e);
+    else byLoop.set(e.loop, [e]);
+  }
+
+  for (const loop of byLoop.values()) {
+    const n = loop.length;
+    for (let i = 0; i < n; i++) {
+      const e = loop[i];
+      const prev = loop[(i - 1 + n) % n];
+      const next = loop[(i + 1) % n];
+      const alongStart = inset * (prev.inX * e.dirX + prev.inY * e.dirY);
+      const alongEnd = e.length + inset * (next.inX * e.dirX + next.inY * e.dirY);
+      if (alongEnd - alongStart <= 0.1) continue;
+
+      // Two corners of the band: the near and far ends of the surviving run,
+      // each pushed inward off the outline by the inset and then by the width.
+      const ax = e.fromX + e.dirX * alongStart + e.inX * inset;
+      const ay = e.fromY + e.dirY * alongStart + e.inY * inset;
+      const bx = e.fromX + e.dirX * alongEnd + e.inX * (inset + width);
+      const by = e.fromY + e.dirY * alongEnd + e.inY * (inset + width);
+      out.push({
+        minX: Math.min(ax, bx),
+        maxX: Math.max(ax, bx),
+        minY: Math.min(ay, by),
+        maxY: Math.max(ay, by),
+      });
+
+      // The vertex this edge STARTS at, so every corner of the loop is visited
+      // once. Material is on the left of every edge, so a right turn is the
+      // reflex one whichever loop this is — reading the turn rather than the
+      // winding is what keeps a hole's corners from being classified backwards.
+      const turn = prev.dirX * e.dirY - prev.dirY * e.dirX;
+      if (turn < 0) {
+        const corner = reflexCornerSlab(prev, e, inset, width);
+        if (corner) out.push(corner);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * The diagonal wedge two bands leave open at a reflex vertex.
+ *
+ * Spans `inset` to `inset + width` along BOTH edges' inward normals, which is
+ * precisely the set that is deeper than either band reaches yet still within
+ * the ring's reach of the corner. Squared off rather than rounded because
+ * everything else here is, and because the lid's own shell turns the same
+ * corner.
+ */
+function reflexCornerSlab(
+  prev: MaskEdgeMm,
+  next: MaskEdgeMm,
+  inset: number,
+  width: number
+): LidKeepoutSlab | null {
+  // The shared vertex: where `prev` ends and `next` begins.
+  const vx = next.fromX;
+  const vy = next.fromY;
+  const near = inset;
+  const far = inset + width;
+  // Each normal is axis-aligned, so the two contribute to different axes and
+  // the four combinations are just the corners of an axis-aligned square.
+  const xs = [vx + prev.inX * near + next.inX * near, vx + prev.inX * far + next.inX * far];
+  const ys = [vy + prev.inY * near + next.inY * near, vy + prev.inY * far + next.inY * far];
+  const minX = Math.min(xs[0], xs[1]);
+  const maxX = Math.max(xs[0], xs[1]);
+  const minY = Math.min(ys[0], ys[1]);
+  const maxY = Math.max(ys[0], ys[1]);
+  if (maxX - minX <= 0.1 || maxY - minY <= 0.1) return null;
+  return { minX, maxX, minY, maxY };
 }

--- a/src/shared/constants/lidKeepoutSlabs.test.ts
+++ b/src/shared/constants/lidKeepoutSlabs.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { MASK_CELL_SIZE } from '@/shared/utils/cellMask';
+import {
+  LID_KEEPOUT_OUTLINE_INSET_MM,
+  lidKeepoutRing,
+  lidKeepoutSlabs,
+  lidKeepoutWidthMm,
+  type LidKeepoutSlab,
+} from './lidKeepout';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+
+const PITCH = 42;
+const WALL = 1.2;
+
+function maskFrom(rowsBottomFirst: readonly string[]): CellMask {
+  const rows = rowsBottomFirst.length;
+  const cols = rowsBottomFirst[0].length;
+  const cells: (0 | 1)[] = [];
+  for (const row of rowsBottomFirst) {
+    for (const ch of row) cells.push(ch === '#' ? 1 : 0);
+  }
+  return { cols, rows, cells };
+}
+
+const inSlab = (s: LidKeepoutSlab, x: number, y: number, tol = 1e-6): boolean =>
+  x >= s.minX - tol && x <= s.maxX + tol && y >= s.minY - tol && y <= s.maxY + tol;
+
+const covered = (slabs: readonly LidKeepoutSlab[], x: number, y: number): boolean =>
+  slabs.some((s) => inSlab(s, x, y));
+
+/** Is `(x, y)` inside the filled footprint? */
+function filledAt(mask: CellMask, x: number, y: number): boolean {
+  const halfW = (mask.cols * MASK_CELL_SIZE * PITCH) / 2;
+  const halfD = (mask.rows * MASK_CELL_SIZE * PITCH) / 2;
+  const col = Math.floor((x + halfW) / (MASK_CELL_SIZE * PITCH));
+  const row = Math.floor((y + halfD) / (MASK_CELL_SIZE * PITCH));
+  if (col < 0 || col >= mask.cols || row < 0 || row >= mask.rows) return false;
+  return mask.cells[row * mask.cols + col] === 1;
+}
+
+/**
+ * Chebyshev distance from `(x, y)` to the outside of the footprint, in mm — the
+ * erosion the slab union is supposed to equal. Sampled rather than derived, so
+ * it is an independent opinion about the same set.
+ */
+function distanceToOutside(mask: CellMask, x: number, y: number, limit: number): number {
+  if (!filledAt(mask, x, y)) return 0;
+  for (let r = 0.25; r <= limit; r += 0.25) {
+    for (const [dx, dy] of [
+      [r, 0],
+      [-r, 0],
+      [0, r],
+      [0, -r],
+      [r, r],
+      [r, -r],
+      [-r, r],
+      [-r, -r],
+    ] as const) {
+      if (!filledAt(mask, x + dx, y + dy)) return r;
+    }
+  }
+  return limit + 1;
+}
+
+describe('lidKeepoutSlabs', () => {
+  it('lays the same band a full mask’s rectangle ring does', () => {
+    // The equivalence that lets one flag serve both footprints. A fully-filled
+    // mask is the one shape both paths describe, so they have to agree on it or
+    // a polygon bin is relieved to a different depth than a rectangle.
+    const mask = maskFrom(['####', '####', '####', '####']);
+    const slabs = lidKeepoutSlabs(mask, PITCH, PITCH, WALL);
+    const outerW = 2 * PITCH - GRIDFINITY_SPEC.TOLERANCE;
+    const ring = lidKeepoutRing(outerW - 2 * WALL, outerW - 2 * WALL, WALL);
+
+    const halfMask = (4 * MASK_CELL_SIZE * PITCH) / 2;
+    // Outer boundary: the outermost covered point on the +X axis.
+    const outermost = Math.max(...slabs.map((s) => s.maxX));
+    expect(outermost).toBeCloseTo(halfMask - LID_KEEPOUT_OUTLINE_INSET_MM, 6);
+    expect(outermost).toBeCloseTo(ring.outerHalfX, 6);
+
+    // ...and the band reaches exactly `width` inward from it.
+    expect(covered(slabs, ring.outerHalfX - ring.width + 0.05, 0)).toBe(true);
+    expect(covered(slabs, ring.outerHalfX - ring.width - 0.05, 0)).toBe(false);
+  });
+
+  it('covers each corner, which is where a per-edge band could leave a gap', () => {
+    const mask = maskFrom(['####', '####', '####', '####']);
+    const slabs = lidKeepoutSlabs(mask, PITCH, PITCH, WALL);
+    const ring = lidKeepoutRing(0, 0, WALL);
+    const half = (4 * MASK_CELL_SIZE * PITCH) / 2 - LID_KEEPOUT_OUTLINE_INSET_MM;
+    for (const sx of [1, -1]) {
+      for (const sy of [1, -1]) {
+        // Just inside the ring's outer corner, and just inside its inner corner.
+        expect(covered(slabs, sx * (half - 0.05), sy * (half - 0.05))).toBe(true);
+        expect(
+          covered(slabs, sx * (half - ring.width + 0.05), sy * (half - ring.width + 0.05))
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('never reaches outside the footprint’s own material', () => {
+    // The band must not touch the wall or the lip's undercut. Every covered
+    // point has to be at least the outline inset deep inside the shape.
+    const mask = maskFrom(['###', '###', '#..', '#..']);
+    const slabs = lidKeepoutSlabs(mask, PITCH, PITCH, WALL);
+    for (const s of slabs) {
+      for (const [x, y] of [
+        [s.minX + 0.01, s.minY + 0.01],
+        [s.maxX - 0.01, s.maxY - 0.01],
+        [s.minX + 0.01, s.maxY - 0.01],
+        [s.maxX - 0.01, s.minY + 0.01],
+      ] as const) {
+        expect(distanceToOutside(mask, x, y, 6)).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('matches an independent erosion of an L-shape', () => {
+    // Sampled both ways: a point is in the band exactly when it is inside the
+    // shape but within `inset + width` of the outside. The reflex corner is the
+    // case a true offset gets wrong, so it is the point of this shape.
+    const mask = maskFrom(['###', '###', '#..', '#..']);
+    const slabs = lidKeepoutSlabs(mask, PITCH, PITCH, WALL);
+    const reach = LID_KEEPOUT_OUTLINE_INSET_MM + lidKeepoutWidthMm(WALL);
+    const halfW = (3 * MASK_CELL_SIZE * PITCH) / 2;
+    const halfD = (4 * MASK_CELL_SIZE * PITCH) / 2;
+
+    let checked = 0;
+    for (let x = -halfW + 0.5; x < halfW; x += 2.5) {
+      for (let y = -halfD + 0.5; y < halfD; y += 2.5) {
+        const depth = distanceToOutside(mask, x, y, reach + 2);
+        // Skip the band either side of each boundary, where a 0.25mm-stepped
+        // distance and an exact half-plane test legitimately disagree.
+        if (Math.abs(depth - LID_KEEPOUT_OUTLINE_INSET_MM) < 0.6) continue;
+        if (Math.abs(depth - reach) < 0.6) continue;
+        const shouldCover = depth > LID_KEEPOUT_OUTLINE_INSET_MM && depth < reach;
+        expect(covered(slabs, x, y), `at (${x.toFixed(1)}, ${y.toFixed(1)}) depth ${depth}`).toBe(
+          shouldCover
+        );
+        checked++;
+      }
+    }
+    // Anti-vacuity: a sampling bug that skipped everything would pass silently.
+    expect(checked).toBeGreaterThan(200);
+  });
+
+  it('fills the diagonal wedge at a reflex corner', () => {
+    // Two perpendicular bands do not cover a reflex corner: this point is 3mm
+    // from one edge and 4mm from the other, so it clears both bands' reach
+    // while sitting 4mm from the void along the diagonal — inside a 5.8mm ring.
+    // Left un-relieved it is a wedge of material right where an L-shaped bin's
+    // inner corner meets the lid.
+    const mask = maskFrom(['###', '###', '#..', '#..']);
+    const slabs = lidKeepoutSlabs(mask, PITCH, PITCH, WALL);
+    expect(covered(slabs, -13.5, -4)).toBe(true);
+    // ...and the wedge stops where the ring does. 1mm from the void on both
+    // axes is wall, not ring, and cutting it would thin the corner.
+    expect(covered(slabs, -11.5, -1)).toBe(false);
+  });
+
+  it('follows a hole’s edges into the surrounding material, not into the hole', () => {
+    // The inner-loop trap: an offset pushes a hole's band the wrong way. The
+    // band belongs around the hole, in the ring of material bounding it.
+    const mask = maskFrom(['####', '#..#', '#..#', '####']);
+    const slabs = lidKeepoutSlabs(mask, PITCH, PITCH, WALL);
+    const cell = MASK_CELL_SIZE * PITCH;
+    // Dead centre of the 2x2-cell hole: void, so nothing may cover it.
+    expect(covered(slabs, 0, 0)).toBe(false);
+    // Just outside the hole's wall, inside the material: covered.
+    const holeEdge = cell;
+    expect(covered(slabs, holeEdge + LID_KEEPOUT_OUTLINE_INSET_MM + 0.2, 0)).toBe(true);
+  });
+
+  it('takes a neck whole when it is narrower than two bands', () => {
+    // Where a true offset self-intersects. With a 6mm pitch a single cell is
+    // 3mm across, far under `2 * (inset + width)`, so the bands from both sides
+    // overlap and the neck is entirely keep-out — which is what eroding it to
+    // nothing means.
+    const mask = maskFrom(['###', '.#.', '###']);
+    const slabs = lidKeepoutSlabs(mask, 6, 6, WALL);
+    expect(slabs.length).toBeGreaterThan(0);
+    // The neck's centre line is covered from both sides rather than left as a
+    // surviving core.
+    expect(covered(slabs, 0, 0)).toBe(true);
+  });
+});

--- a/src/shared/utils/lidInteriorRelief.ts
+++ b/src/shared/utils/lidInteriorRelief.ts
@@ -9,11 +9,10 @@
  * Lives here rather than beside `shouldGenerateLid` because `lidCompatibility`
  * reaches this predicate through BOTH the divider planner and the label shelf
  * datum; defining it there makes those imports circular. Depending only on
- * params and one mask helper keeps every arrow pointing one way.
+ * params alone keeps every arrow pointing one way.
  */
 
 import type { BinParams } from '@/shared/types/bin';
-import { isPartialMask } from '@/shared/utils/cellMask';
 import { LID_KEEPOUT_BELOW_CEILING_MM } from '@/shared/constants/lidKeepout';
 
 export function interiorReliefActive(params: BinParams): boolean {
@@ -22,9 +21,9 @@ export function interiorReliefActive(params: BinParams): boolean {
   // A lid needs a lip to grip, and a base-only tile has no cavity to relieve.
   if (!params.base.stackingLip) return false;
   if (params.base.tile === true) return false;
-  // Polygon footprints keep the notching path until the outline offset lands
-  // (#3482); nothing reaches the band on one today.
-  if (isPartialMask(params.cellMask)) return false;
+  // Custom shapes are relieved too since #3482. Their ring follows the mask
+  // outline as one band per edge (`lidKeepoutSlabs`) rather than as a rounded
+  // rectangle, but the gate is the same: whether the bin has a lid to clear.
   return true;
 }
 

--- a/src/shared/utils/lidInteriorRelief.ts
+++ b/src/shared/utils/lidInteriorRelief.ts
@@ -8,8 +8,8 @@
  *
  * Lives here rather than beside `shouldGenerateLid` because `lidCompatibility`
  * reaches this predicate through BOTH the divider planner and the label shelf
- * datum; defining it there makes those imports circular. Depending only on
- * params alone keeps every arrow pointing one way.
+ * datum; defining it there makes those imports circular. Depending on params
+ * alone keeps every arrow pointing one way.
  */
 
 import type { BinParams } from '@/shared/types/bin';

--- a/src/shared/utils/maskEdgeGeometry.test.ts
+++ b/src/shared/utils/maskEdgeGeometry.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import type { CellMask } from '@/shared/utils/cellMask';
+import { MASK_CELL_SIZE } from '@/shared/utils/cellMask';
+import { edgeRotationDeg, insetAlongNormal, maskEdgesMm } from './maskEdgeGeometry';
+
+const PITCH = 42;
+
+/** Build a mask from a picture: row 0 is the BOTTOM, matching grid convention. */
+function maskFrom(rowsBottomFirst: readonly string[]): CellMask {
+  const rows = rowsBottomFirst.length;
+  const cols = rowsBottomFirst[0].length;
+  const cells: (0 | 1)[] = [];
+  for (const row of rowsBottomFirst) {
+    for (const ch of row) cells.push(ch === '#' ? 1 : 0);
+  }
+  return { cols, rows, cells };
+}
+
+/** Is `(x, y)` inside the filled region? Cheap point-in-mask, for normal checks. */
+function filledAt(mask: CellMask, x: number, y: number): boolean {
+  const halfW = (mask.cols * MASK_CELL_SIZE * PITCH) / 2;
+  const halfD = (mask.rows * MASK_CELL_SIZE * PITCH) / 2;
+  const col = Math.floor((x + halfW) / (MASK_CELL_SIZE * PITCH));
+  const row = Math.floor((y + halfD) / (MASK_CELL_SIZE * PITCH));
+  if (col < 0 || col >= mask.cols || row < 0 || row >= mask.rows) return false;
+  return mask.cells[row * mask.cols + col] === 1;
+}
+
+describe('maskEdgesMm', () => {
+  it('walks a plain square and centres it on the origin', () => {
+    const edges = maskEdgesMm(maskFrom(['##', '##']), PITCH, PITCH);
+    expect(edges).toHaveLength(4);
+    const half = (2 * MASK_CELL_SIZE * PITCH) / 2;
+    for (const e of edges) {
+      expect(e.loop).toBe(0);
+      expect(e.length).toBeCloseTo(2 * half, 6);
+      expect(Math.abs(e.midX) === half || Math.abs(e.midY) === half).toBe(true);
+    }
+  });
+
+  it('points every normal at material, on an L-shape', () => {
+    // The reflex corner is the case a naive "interior is inward" rule gets
+    // wrong; stepping along each normal from each midpoint answers it directly.
+    const mask = maskFrom(['###', '###', '#..', '#..']);
+    for (const e of maskEdgesMm(mask, PITCH, PITCH)) {
+      const inward = insetAlongNormal(e, e.midX, e.midY, 1);
+      const outward = insetAlongNormal(e, e.midX, e.midY, -1);
+      expect(filledAt(mask, inward.x, inward.y)).toBe(true);
+      expect(filledAt(mask, outward.x, outward.y)).toBe(false);
+    }
+  });
+
+  it('points a hole’s normals OUTWARD from the hole, into the material', () => {
+    // The inner-loop trap (#3482): a hole winds CW, so a rule keyed on "CCW
+    // means inward is left" pushes its band into the void. Every edge here
+    // belongs to a loop whose material is still on its left.
+    const mask = maskFrom(['####', '#..#', '#..#', '####']);
+    const edges = maskEdgesMm(mask, PITCH, PITCH);
+    const holeEdges = edges.filter((e) => e.loop > 0);
+    expect(holeEdges).toHaveLength(4);
+    for (const e of holeEdges) {
+      const inward = insetAlongNormal(e, e.midX, e.midY, 1);
+      expect(filledAt(mask, inward.x, inward.y)).toBe(true);
+      const intoHole = insetAlongNormal(e, e.midX, e.midY, -1);
+      expect(filledAt(mask, intoHole.x, intoHole.y)).toBe(false);
+    }
+  });
+
+  it('reports the outer loop first and every hole after it', () => {
+    const edges = maskEdgesMm(maskFrom(['####', '#..#', '#..#', '####']), PITCH, PITCH);
+    expect(edges.filter((e) => e.loop === 0)).toHaveLength(4);
+    expect(new Set(edges.map((e) => e.loop))).toEqual(new Set([0, 1]));
+  });
+
+  it('scales each axis by its own pitch', () => {
+    const edges = maskEdgesMm(maskFrom(['##', '##']), 42, 36);
+    const alongX = edges.filter((e) => e.dirY === 0);
+    const alongY = edges.filter((e) => e.dirX === 0);
+    expect(alongX[0].length).toBeCloseTo(42, 6);
+    expect(alongY[0].length).toBeCloseTo(36, 6);
+  });
+});
+
+describe('edgeRotationDeg', () => {
+  it('matches the rail placement convention on each facing', () => {
+    // Keyed on the OUTWARD normal, as `railPlacementsForRectangle` is: back
+    // (outward +Y) takes 0 and front (outward -Y) takes 180. Keying on the
+    // edge DIRECTION instead turns every wall through a half-turn, which no
+    // bounding box would notice.
+    const edges = maskEdgesMm(maskFrom(['##', '##']), PITCH, PITCH);
+    const byFacing = new Map(edges.map((e) => [`${-e.inX},${-e.inY}`, edgeRotationDeg(e)]));
+    expect(byFacing.get('0,1')).toBe(0); // outward +Y → back wall
+    expect(byFacing.get('0,-1')).toBe(180); // outward -Y → front wall
+    expect(byFacing.get('1,0')).toBe(-90); // outward +X → right wall
+    expect(byFacing.get('-1,0')).toBe(90); // outward -X → left wall
+  });
+});

--- a/src/shared/utils/maskEdgeGeometry.ts
+++ b/src/shared/utils/maskEdgeGeometry.ts
@@ -1,0 +1,132 @@
+/**
+ * Every edge of a custom-shape footprint, in the bin's centred mm frame.
+ *
+ * `maskPolygonEdges` (worker-side) answers a narrower question — which single
+ * edge stands in for the front/back/left/right wall — because that is all a
+ * cutout or a handle needs. Anything that has to treat the whole perimeter
+ * uniformly needs every edge of every loop instead: the lid's keep-out ring
+ * follows the outline all the way round, holes included.
+ *
+ * Kernel-free and in `shared/` so the main thread can reach it. The worker-side
+ * module cannot serve that: `lidCompatibility` and the panel readout would have
+ * to import across a feature boundary.
+ *
+ * ## Winding, and why holes need no special case
+ *
+ * `maskToPolygon` builds every edge with the filled cells on its LEFT, then
+ * returns `[outerCCW, ...holesCW]`. So for EVERY loop, walking its edges in
+ * order keeps material on the left, and the inward normal is the
+ * left-perpendicular of the edge direction — `(-dy, dx)` — uniformly. An
+ * offset that instead assumed "CCW means inward is left" would push a hole's
+ * band the wrong way, into the void, which is the inner-loop trap #3482
+ * describes. Reading the direction off the winding avoids having to know
+ * which loop is which at all.
+ */
+
+import { MASK_CELL_SIZE, maskToPolygon, type CellMask } from '@/shared/utils/cellMask';
+
+/** One straight run of a footprint's perimeter, in centred mm. */
+export interface MaskEdgeMm {
+  /** 0 is the outer boundary; anything else is a hole. */
+  readonly loop: number;
+  readonly fromX: number;
+  readonly fromY: number;
+  readonly toX: number;
+  readonly toY: number;
+  /** Unit vector along the edge. Axis-aligned, so one component is always 0. */
+  readonly dirX: number;
+  readonly dirY: number;
+  /** Unit normal pointing INTO the material. Left-perpendicular of the direction. */
+  readonly inX: number;
+  readonly inY: number;
+  readonly midX: number;
+  readonly midY: number;
+  readonly length: number;
+}
+
+/**
+ * Walk every loop of `mask` and return its edges in centred mm.
+ *
+ * The mm frame matches `maskPolygonEdges.resolvePolygonSideGeometry` and
+ * `railPlacementsForPolygon`: the mask spans the FULL grid-unit extent, so
+ * these coordinates sit `CLEARANCE / 2` OUTSIDE the bin's real outer face.
+ * Callers that need a face rather than the nominal outline have to say so —
+ * see {@link insetAlongNormal}.
+ *
+ * Degenerate (zero-length) edges are dropped rather than returned with a NaN
+ * direction; `collapse` in `maskToPolygon` should already have merged them.
+ */
+export function maskEdgesMm(
+  mask: CellMask,
+  gridUnitMm: number,
+  gridUnitMmY: number
+): readonly MaskEdgeMm[] {
+  const loops = maskToPolygon(mask);
+  const halfWidthMm = (mask.cols * MASK_CELL_SIZE * gridUnitMm) / 2;
+  const halfDepthMm = (mask.rows * MASK_CELL_SIZE * gridUnitMmY) / 2;
+
+  const out: MaskEdgeMm[] = [];
+  loops.forEach((loop, loopIndex) => {
+    const n = loop.length;
+    for (let i = 0; i < n; i++) {
+      const a = loop[i];
+      const b = loop[(i + 1) % n];
+      const fromX = a.x * gridUnitMm - halfWidthMm;
+      const fromY = a.y * gridUnitMmY - halfDepthMm;
+      const toX = b.x * gridUnitMm - halfWidthMm;
+      const toY = b.y * gridUnitMmY - halfDepthMm;
+      const dx = toX - fromX;
+      const dy = toY - fromY;
+      const length = Math.hypot(dx, dy);
+      if (length <= 0) continue;
+      const dirX = dx / length;
+      const dirY = dy / length;
+      out.push({
+        loop: loopIndex,
+        fromX,
+        fromY,
+        toX,
+        toY,
+        dirX,
+        dirY,
+        // Left-perpendicular: material is on the left of every edge, whichever
+        // loop it belongs to. See the winding note in the module docstring.
+        inX: -dirY,
+        inY: dirX,
+        midX: (fromX + toX) / 2,
+        midY: (fromY + toY) / 2,
+        length,
+      });
+    }
+  });
+  return out;
+}
+
+/** Move a point `mm` along an edge's inward normal. */
+export function insetAlongNormal(
+  edge: MaskEdgeMm,
+  x: number,
+  y: number,
+  mm: number
+): { readonly x: number; readonly y: number } {
+  return { x: x + edge.inX * mm, y: y + edge.inY * mm };
+}
+
+/**
+ * Rotation (degrees about +Z) that maps a feature authored along +X onto this
+ * edge, matching the convention `railPlacementsForPolygon` and
+ * `railPlacementsForRectangle` already use.
+ *
+ * Keyed on the OUTWARD normal, not the edge direction — the rectangle path
+ * pairs `back` (outward +Y) with 0 and `front` (outward -Y) with 180, so an
+ * edge running +X, whose material is above it, is a FRONT wall and takes 180.
+ * Reading it off the direction instead inverts every wall, which is a
+ * half-turn no bounding box notices.
+ *
+ * Null for a non-axis-aligned edge, which a mask outline should never produce.
+ */
+export function edgeRotationDeg(edge: MaskEdgeMm): number | null {
+  if (edge.dirY === 0) return edge.dirX > 0 ? 180 : 0;
+  if (edge.dirX === 0) return edge.dirY > 0 ? -90 : 90;
+  return null;
+}


### PR DESCRIPTION
Part of #3482 — the keep-out ring half. The rail-clipping half follows in a second PR (see below).

The ring was cut for rectangular footprints only. #3482 assumed the alternative for a polygon was a true inward offset of the outline, with thin necks that self-intersect, inner loops that offset outward, and notch corners to clip.

**It's built as a union of per-edge bands instead**, which is cheaper and sidesteps all three. A mask outline is *rectilinear*, and for a rectilinear outline that union is the same set as the erosion:

| the issue's hard case | what actually happens |
| --- | --- |
| thin neck self-intersects | the two bands simply overlap — and a neck narrower than twice the band *is* entirely keep-out, which is what eroding it to nothing means |
| inner loop offsets outward | every loop carries material on its left, so `maskEdgesMm` reads the inward normal off the winding and a hole's bands face into the material like everyone else's |
| notch corners need clipping | each band is already bounded by where its *neighbours'* outer lines cross it |

That bound is one expression covering both corner kinds: a neighbour's outer line meets this edge at `inset * (neighbourNormal · thisDirection)` from the shared vertex — `+1` at a convex corner (pull the band back), `-1` at a reflex one (push it past the vertex).

## The reflex wedge

The bands alone are **not** the whole ring, and the sampled-erosion test is what caught it. A point tucked diagonally into a reflex corner can be 3mm from one edge and 4mm from the other — clearing both bands — while sitting 4mm from the void *along the diagonal*, inside a 5.8mm ring. An erosion removes it; two perpendicular bands miss it, leaving un-relieved material exactly where an L-shaped bin's inner corner meets the lid. `reflexCornerSlab` fills it. Convex corners need nothing, since the bands already overlap there.

Detection is winding-free: material is on the left of every edge, so a **right turn** is the reflex one whichever loop it belongs to.

## What the tests can and cannot prove

**The ring cuts air today, and that is expected** — it's why #3482 was deferred. Neither `compartmentWallsFeature` nor `labelTabsFeature` declares `supportsCellMask`, so `featuresStage` drops both on a partial mask and the cavity under the rim is empty. The ring exists so tree order already protects the lid the day either gains polygon support, which is #3477's whole design.

So the verification is split accordingly:

- **Where the band lies** — `lidKeepoutSlabs.test.ts`, 7 cases, compared against an *independently sampled* erosion over 200+ points rather than against a second copy of the same arithmetic. Includes the reflex wedge pinned by coordinate, a hole's bands, and a thin neck at a 6mm pitch.
- **That cutting it harms nothing** — `lidPolygonRelief.scenario.test.ts` on an L and a U (two reflex corners): wall and lip untouched (the undercut check that would otherwise leave a bin looking perfect and holding nothing), and no material removed anywhere across a swept grid, each with anti-vacuity counts.

One nuance worth flagging for review: the harmlessness check is stated on the **top surface**, not the triangle count. The ring's outer face is coincident with the lip's inner face, so the boolean re-triangulates there (2870 → 2984 on the L) while removing nothing — a count is a tessellation fact, where the material ends is a geometry one.

## Scope

Rectangle bins are byte-identical — `lidInteriorRelief.scenario` passes unchanged, and `lidKeepoutWidthMm` was extracted so the two paths cannot drift on depth.

**Not in this PR:** clipping polygon rails around cutout/handle lip gaps. That's the live half of #3482 I reported separately — cutouts and handles *do* build on polygon bins (`supportsCellMask: true`, and `FeatureGate` is UI-only), while `railPlacementsForPolygon` clips nothing. Doing it properly means moving `findPolygonEdgeForSide` into `shared/` so the worker, the panel readout and the compatibility warning read one plan, rather than reimplementing its cached three-level ranking. Separate PR, next.

## Verification

`pnpm quality` clean, all four i18n checks pass, `lidInteriorRelief.scenario` + `lidPolygonRelief.scenario` + 2313 shared/bin-designer unit tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relieves the lid interior for custom-shape bins. Previously only rectangles were relieved; polygons now generate the same keep‑out depth without touching the wall or lip by building a union of axis‑aligned per‑edge bands plus a reflex‑corner wedge. Rectangle bins are unchanged.

- Builds the polygon ring with `lidKeepoutSlabs` (driven by `maskEdgesMm` normals) and fuses parts via `brepjs` `fuseAll`; `lidInteriorReliefStage` selects polygon vs rectangle and disposes scratch WASM handles.
- Keeps band geometry consistent with rectangles via `lidKeepoutWidthMm` and `LID_KEEPOUT_OUTLINE_INSET_MM`; the rectangular path remains a rounded-rect minus inset.
- Enables relief for custom shapes in `interiorReliefActive`; safe today because nothing with `supportsCellMask` reaches the band, so current polygon bins remove no material.
- Not in this PR: clipping polygon rails around cutout/handle gaps (tracked in #3482).

**Verification**
- Unit tests compare the slab union to an independently sampled erosion (L/U shapes, holes, thin necks) and confirm the reflex wedge is filled.
- Scenario tests assert polygon bins build, the wall and lip are unchanged at probe columns, and no material is removed; rectangle scenarios stay byte‑identical.

<sup>Written for commit 36104a925196d442982690b578a4ef2abdc603ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

