### PR TITLE
perf: stop re-paying for work already done

### DIFF
--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -25,6 +25,8 @@ import { LidSection } from '../panel/LidSection';
 import { PhysicalUnitsSection } from '../panel/PhysicalUnitsSection';
 import { SplitOptionsSection } from '../panel/SplitOptionsSection';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
+import { useIntentPrefetch } from '@/shared/hooks/useIntentPrefetch';
+import { warmDesignGallery } from '@/shared/hooks/usePrefetchChunks';
 import { StickyGroupHeader } from '../panel/StickyGroupHeader';
 import { PanelSection } from '../panel/PanelSection';
 import { ColorsSection } from '../panel/ColorsSection';
@@ -98,6 +100,8 @@ function BinParameterPanel() {
     };
   }, []);
 
+  const galleryIntent = useIntentPrefetch('modal:designGallery', warmDesignGallery);
+
   return (
     <div className="flex h-full flex-col">
       {/* `relative` makes this the containing block for `sr-only` (position:absolute)
@@ -114,6 +118,7 @@ function BinParameterPanel() {
           <Button
             variant="ghost"
             onClick={() => openExampleGallery('community')}
+            {...galleryIntent}
             className="w-full flex items-center gap-3 text-left p-3 rounded-lg bg-gradient-to-r from-accent/10 to-info/10 hover:from-accent/20 hover:to-info/20 border border-accent/20 transition-all group"
           >
             <div className="w-10 h-10 rounded-lg bg-accent/20 flex items-center justify-center group-hover:scale-105 transition-transform">

--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -107,6 +107,23 @@ Composable stages in `pipeline/stages/`, orchestrated by `pipeline/runner.ts`:
 5. **Tessellate** (`tessellateStage`) — dynamic quality mesh + edge extraction; meshes `deferredSolid` separately and concatenates via `mergeShapeMeshes` (visually identical to the fused shell — socket meets the body only at a hidden interface). The socket mesh is cached by geometry identity (`socketMeshCache`, keyed via `deferredSolidKey`) so non-dimension edits skip re-tessellating the base.
 6. **Mesh imprint** (`meshImprintStage`) — subtracts imported STL tools (mesh cutouts, `shape: 'mesh'`) from the tessellated mesh via raw manifold-3d. Requires the async `prepareMeshImprints()` pre-pass (worker handlers await it — the pipeline itself is synchronous); `faceGroups` tags ride through the boolean as Manifold runs, tool-carved faces get the cutout's color tag, and normals/edges are rebuilt (crease-aware) afterwards. The pocket keeps the tool's relief BELOW its lowest top-shoulder (`minTopShoulder`) and fills the silhouette flat above it — a removable top-insertion pocket can only mirror the tool's underside + silhouette, so a top-face recess is necessarily flattened (orient the distinctive face down to imprint it). Filling above the shoulder is what keeps every pocket a single connected solid; a `decompose()` keep-largest guard backstops any residual island. GOTCHA: exports for mesh-bearing designs must serialize the imprinted `MeshData` (`buildSTLBufferFromIndexed`), never `exportSolidToStl` — the BREP solid has no pockets. STEP is unavailable for these designs.
 
+## Bridge result cache
+
+`bridge/resultCache.ts` sits in front of the worker on the main thread: a
+byte-budgeted LRU of completed `GenerationResult`s keyed by
+`paramsFingerprint`, one per request kind (bin / baseplate / item). It answers
+the round trip a parametric editor makes constantly — toggle a feature on and
+back off, drag a slider home, step a value up then down — without the worker
+seeing a message. Keep it keyed on the fingerprint, not on recency: a
+single-entry version of this was a debounce guard rather than a cache, because
+the return leg had already evicted the result it was about to ask for.
+
+Serving an entry twice is safe because the worker clones every buffer before
+transfer and nothing on the main thread transfers them onward. A hit does mean
+`lastSolid` no longer describes what was just returned, which was already true
+of any hit — `exportBin` re-checks the identity fingerprint (see gotcha 16)
+rather than trusting recency.
+
 ## Cross-session mesh cache
 
 All the caches above are **in-memory only** — they vanish on reload. `src/shared/generation/meshPersistence.ts` (main thread) additionally persists the final bin-designer preview `MeshData` to IndexedDB, keyed by a hash of `BinParams` + `MESH_CACHE_VERSION` + the active kernel and its `KERNEL_MESH_REVISION`, so reopening a saved custom bin paints last session's exact mesh instantly (as a pre-draft in `useGeneration`) while the worker warms up and regenerates. Preview-only — exports always regenerate the watertight fused shell. **Bump `KERNEL_MESH_REVISION[kernel]` on a kernel upgrade (brepjs/occt-wasm, brepkit-wasm) and `MESH_CACHE_VERSION` on a tessellation or kernel-independent geometry change** (see the geometry-generation skill).

--- a/src/features/generation/bridge/GenerationBridge.test.ts
+++ b/src/features/generation/bridge/GenerationBridge.test.ts
@@ -746,6 +746,37 @@ describe('GenerationBridge', () => {
       expect(result.mesh.triangleCount).toBe(2);
     });
 
+    // Returning to a shape this bridge already built is the commonest edit in
+    // a parametric designer — toggle a feature on and back off, drag a slider
+    // home, step a value up then down. A single-slot cache had already
+    // evicted it, so every round trip re-ran the kernel for geometry the tab
+    // computed seconds earlier.
+    it('serves the earlier params again after an intervening edit', async () => {
+      await initAndGenerate();
+
+      const away = bridge.generate({ ...DEFAULT_BIN_PARAMS, width: 3 });
+      await vi.advanceTimersByTimeAsync(200);
+      const sent = getWorker().messages.filter((m) => (m as { type: string }).type === 'GENERATE');
+      const msg = sent[1] as { payload: { requestId: string } };
+      getWorker().simulateResponse({
+        type: 'MESH_RESULT',
+        requestId: msg.payload.requestId,
+        vertices: new Float32Array([4, 5, 6]),
+        normals: new Float32Array([0, 1, 0]),
+        indices: new Uint32Array([0]),
+        edgeVertices: new Float32Array([]),
+        triangleCount: 2,
+        timingMs: 50,
+      });
+      await away;
+
+      const back = await bridge.generate(DEFAULT_BIN_PARAMS);
+      expect(back.mesh.triangleCount).toBe(1);
+      expect(
+        getWorker().messages.filter((m) => (m as { type: string }).type === 'GENERATE').length
+      ).toBe(2);
+    });
+
     it('generateImmediate also uses cache', async () => {
       await initAndGenerate();
 

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -50,14 +50,14 @@ import {
   type SplitPreviewResult,
   type BaseplateExportResult,
   type ThreadingInfo,
-  type DedupCache,
   type ExportSlot,
   type PendingExport,
   type PendingExportMap,
   type MeshImportOutcome,
 } from './bridgeTypes';
 import type { MeshImportRotation } from '@/shared/generation/meshAsset';
-import { extractThreadingInfo, createDedupCache } from './bridgeHelpers';
+import { extractThreadingInfo } from './bridgeHelpers';
+import { GenerationResultCache } from './resultCache';
 import { installMessageHandler } from './bridgeMessageHandler';
 import {
   exportBin as exportBinImpl,
@@ -118,10 +118,15 @@ export class GenerationBridge {
   readonly adaptiveDebounce = new AdaptiveDebounce();
   threadingInfo: ThreadingInfo | null = null;
 
-  /** Size-1 dedup caches for bin and baseplate generation. */
-  binCache: DedupCache = createDedupCache();
-  baseplateCache: DedupCache = createDedupCache();
-  itemCache: DedupCache = createDedupCache();
+  /**
+   * Recent results keyed by params fingerprint, so an edit that lands back on
+   * a shape this bridge already built repaints instead of re-running the
+   * kernel. One per request kind; the three share a request channel but must
+   * not share a key space (a bin and an item can fingerprint alike).
+   */
+  readonly binCache = new GenerationResultCache();
+  readonly baseplateCache = new GenerationResultCache();
+  readonly itemCache = new GenerationResultCache();
 
   /** Pending export requests keyed by slot. Only one per slot at a time. */
   readonly pendingExports: PendingExportMap = new Map();
@@ -398,9 +403,9 @@ export class GenerationBridge {
     this.initPromise = null;
     this.onProgress = null;
     this.adaptiveDebounce.reset();
-    this.binCache = createDedupCache();
-    this.baseplateCache = createDedupCache();
-    this.itemCache = createDedupCache();
+    this.binCache.clear();
+    this.baseplateCache.clear();
+    this.itemCache.clear();
   }
 
   // ── Export methods (delegate to bridgeExports) ────────────────────
@@ -686,24 +691,15 @@ export class GenerationBridge {
     }
   }
 
-  /** If this cache has a pending fingerprint, promote it to the cached result and clear pending. */
-  commitDedupCache(cache: DedupCache, result: GenerationResult): void {
-    if (cache.pendingFingerprint) {
-      cache.fingerprint = cache.pendingFingerprint;
-      cache.result = result;
-      cache.pendingFingerprint = null;
-    }
-  }
-
   clearPending(): void {
     this.clearGenerationTimer();
     this.pendingResolve = null;
     this.pendingReject = null;
     this.currentRequestId = null;
     this.onProgress = null;
-    this.binCache.pendingFingerprint = null;
-    this.baseplateCache.pendingFingerprint = null;
-    this.itemCache.pendingFingerprint = null;
+    this.binCache.clearPending();
+    this.baseplateCache.clearPending();
+    this.itemCache.clearPending();
   }
 
   private clearGenerationTimer(): void {

--- a/src/features/generation/bridge/bridgeGeneration.ts
+++ b/src/features/generation/bridge/bridgeGeneration.ts
@@ -19,13 +19,14 @@ import type { WorkerMessage } from './types';
 import type { AdaptiveDebounce } from './adaptiveDebounce';
 import { computeBaseplateTimeoutMs, computeGenerationTimeoutMs } from './generationTimeout';
 import { paramsFingerprint } from './bridgeHelpers';
-import type { ProgressCallback, GenerationResult, DedupCache } from './bridgeTypes';
+import type { GenerationResultCache } from './resultCache';
+import type { ProgressCallback, GenerationResult } from './bridgeTypes';
 
 export interface BridgeGenerationContext {
   readonly isDestroyed: boolean;
-  readonly binCache: DedupCache;
-  readonly baseplateCache: DedupCache;
-  readonly itemCache: DedupCache;
+  readonly binCache: GenerationResultCache;
+  readonly baseplateCache: GenerationResultCache;
+  readonly itemCache: GenerationResultCache;
   readonly adaptiveDebounce: AdaptiveDebounce;
   debounceTimer: ReturnType<typeof setTimeout> | null;
   generationTimer: ReturnType<typeof setTimeout> | null;
@@ -99,9 +100,8 @@ export function generateBin(
   const fingerprint = withLabelPlates
     ? `${paramsFingerprint(params)}|plates`
     : paramsFingerprint(params);
-  if (ctx.binCache.fingerprint === fingerprint && ctx.binCache.result) {
-    return Promise.resolve(ctx.binCache.result);
-  }
+  const cached = ctx.binCache.get(fingerprint);
+  if (cached) return Promise.resolve(cached);
 
   if (ctx.debounceTimer !== null) {
     clearTimeout(ctx.debounceTimer);
@@ -118,7 +118,7 @@ export function generateBin(
     const send = (): void => {
       const requestId = ctx.nextRequestId();
       ctx.currentRequestId = requestId;
-      ctx.binCache.pendingFingerprint = fingerprint;
+      ctx.binCache.setPending(fingerprint);
       sendWhenReady(ctx, requestId, computeGenerationTimeoutMs(params), {
         type: 'GENERATE',
         payload: { params, requestId, withLabelPlates },
@@ -147,9 +147,8 @@ export function generateBaseplate(
   }
 
   const fingerprint = paramsFingerprint(params);
-  if (ctx.baseplateCache.fingerprint === fingerprint && ctx.baseplateCache.result) {
-    return Promise.resolve(ctx.baseplateCache.result);
-  }
+  const cached = ctx.baseplateCache.get(fingerprint);
+  if (cached) return Promise.resolve(cached);
 
   if (ctx.debounceTimer !== null) {
     clearTimeout(ctx.debounceTimer);
@@ -166,7 +165,7 @@ export function generateBaseplate(
     const send = (): void => {
       const requestId = ctx.nextRequestId();
       ctx.currentRequestId = requestId;
-      ctx.baseplateCache.pendingFingerprint = fingerprint;
+      ctx.baseplateCache.setPending(fingerprint);
       sendWhenReady(ctx, requestId, computeBaseplateTimeoutMs(params), {
         type: 'GENERATE_BASEPLATE',
         payload: { params, requestId },
@@ -240,9 +239,8 @@ export function generateItem(
   }
 
   const fingerprint = paramsFingerprint(item);
-  if (ctx.itemCache.fingerprint === fingerprint && ctx.itemCache.result) {
-    return Promise.resolve(ctx.itemCache.result);
-  }
+  const cached = ctx.itemCache.get(fingerprint);
+  if (cached) return Promise.resolve(cached);
 
   if (ctx.debounceTimer !== null) {
     clearTimeout(ctx.debounceTimer);
@@ -259,7 +257,7 @@ export function generateItem(
     const send = (): void => {
       const requestId = ctx.nextRequestId();
       ctx.currentRequestId = requestId;
-      ctx.itemCache.pendingFingerprint = fingerprint;
+      ctx.itemCache.setPending(fingerprint);
       sendWhenReady(ctx, requestId, computeItemTimeoutMs(item), {
         type: 'GENERATE_ITEM',
         payload: { item, requestId },

--- a/src/features/generation/bridge/bridgeHelpers.ts
+++ b/src/features/generation/bridge/bridgeHelpers.ts
@@ -1,10 +1,10 @@
 /**
- * Pure helpers for the generation bridge: deterministic params fingerprint,
- * INIT_READY threading-info validation, and dedup-cache initialization.
+ * Pure helpers for the generation bridge: deterministic params fingerprint and
+ * INIT_READY threading-info validation.
  */
 
 import type { KernelName } from './types';
-import type { DedupCache, ThreadingInfo } from './bridgeTypes';
+import type { ThreadingInfo } from './bridgeTypes';
 
 // Re-exported rather than defined here: the worker needs the same encoding for
 // its `lastSolid` identity, and worker → bridge value imports are not allowed.
@@ -23,8 +23,4 @@ export function extractThreadingInfo(data: {
       : 4;
   const kernel: KernelName = data.kernel === 'brepkit' ? 'brepkit' : 'occt-wasm';
   return { isThreaded, hardwareConcurrency, kernel };
-}
-
-export function createDedupCache(): DedupCache {
-  return { fingerprint: null, result: null, pendingFingerprint: null };
 }

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -12,10 +12,10 @@
 
 import type { WorkerResponse } from './types';
 import type { AdaptiveDebounce } from './adaptiveDebounce';
+import type { GenerationResultCache } from './resultCache';
 import type {
   ProgressCallback,
   GenerationResult,
-  DedupCache,
   ExportSlot,
   PendingExport,
   PendingExportMap,
@@ -33,9 +33,9 @@ export interface MessageHandlerContext {
   pendingReject: ((error: Error) => void) | null;
   onProgress: ProgressCallback | null;
   readonly adaptiveDebounce: AdaptiveDebounce;
-  readonly binCache: DedupCache;
-  readonly baseplateCache: DedupCache;
-  readonly itemCache: DedupCache;
+  readonly binCache: GenerationResultCache;
+  readonly baseplateCache: GenerationResultCache;
+  readonly itemCache: GenerationResultCache;
   readonly pendingExports: PendingExportMap;
   readonly pendingEstimates: Map<string, (predictedMs: number | null) => void>;
   readonly pendingImports: Map<
@@ -49,7 +49,6 @@ export interface MessageHandlerContext {
   clearExportTimer: (pending: PendingExport<unknown>) => void;
   resolveExport: (slot: ExportSlot, requestId: string, result: unknown) => boolean;
   rejectExportByRequestId: (requestId: string, error: Error) => boolean;
-  commitDedupCache: (cache: DedupCache, result: GenerationResult) => void;
 }
 
 /**
@@ -237,10 +236,11 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
             perfSnapshot: response.perfSnapshot,
           };
 
-          // Cache for deduplication (bin, baseplate, or item — only one is in-flight)
-          ctx.commitDedupCache(ctx.binCache, result);
-          ctx.commitDedupCache(ctx.baseplateCache, result);
-          ctx.commitDedupCache(ctx.itemCache, result);
+          // Only one of the three has a request in flight; the other two
+          // hold no pending fingerprint and ignore the offer.
+          ctx.binCache.commit(result);
+          ctx.baseplateCache.commit(result);
+          ctx.itemCache.commit(result);
 
           ctx.clearPending();
           resolve(result);

--- a/src/features/generation/bridge/bridgeTypes.ts
+++ b/src/features/generation/bridge/bridgeTypes.ts
@@ -108,14 +108,6 @@ export interface ThreadingInfo {
   readonly kernel: KernelName;
 }
 
-/** Size-1 dedup cache: stores the fingerprint and result of the last successful generation. */
-export interface DedupCache {
-  fingerprint: string | null;
-  result: GenerationResult | null;
-  /** Fingerprint of the currently in-flight request (stored so we can cache on success). */
-  pendingFingerprint: string | null;
-}
-
 /** Keys for the pending export request slots */
 export type ExportSlot = 'export' | 'dividers' | 'combined' | 'split' | 'splitPreview';
 

--- a/src/features/generation/bridge/resultCache.test.ts
+++ b/src/features/generation/bridge/resultCache.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { GenerationResultCache } from './resultCache';
+import type { GenerationResult } from './bridgeTypes';
+
+/** A result whose mesh occupies roughly `bytes` (Float32Array = 4 bytes/entry). */
+function resultOfBytes(bytes: number, triangleCount = 1): GenerationResult {
+  return {
+    mesh: {
+      vertices: new Float32Array(Math.max(0, bytes / 4)),
+      normals: new Float32Array(0),
+      indices: new Uint32Array(0),
+      edgeVertices: new Float32Array(0),
+      triangleCount,
+    },
+    timingMs: 1,
+  };
+}
+
+function store(cache: GenerationResultCache, key: string, result: GenerationResult): void {
+  cache.setPending(key);
+  cache.commit(result);
+}
+
+describe('GenerationResultCache', () => {
+  it('returns null for a fingerprint it has never seen', () => {
+    expect(new GenerationResultCache().get('a')).toBeNull();
+  });
+
+  it('serves a result stored under its pending fingerprint', () => {
+    const cache = new GenerationResultCache();
+    const result = resultOfBytes(64, 7);
+    store(cache, 'a', result);
+    expect(cache.get('a')).toBe(result);
+  });
+
+  // The defect this class exists to fix: a single slot meant returning to a
+  // shape already built (toggle off, toggle back on) re-ran the whole kernel.
+  it('still serves the first result after a different one is stored', () => {
+    const cache = new GenerationResultCache();
+    const first = resultOfBytes(64, 1);
+    const second = resultOfBytes(64, 2);
+    store(cache, 'a', first);
+    store(cache, 'b', second);
+    expect(cache.get('a')).toBe(first);
+    expect(cache.get('b')).toBe(second);
+  });
+
+  it('ignores a result when nothing is pending', () => {
+    const cache = new GenerationResultCache();
+    cache.commit(resultOfBytes(64));
+    expect(cache.stats.size).toBe(0);
+  });
+
+  // The three caches share one request channel and are all offered every
+  // result; only the one that dispatched it may claim it.
+  it('claims a result only once per pending fingerprint', () => {
+    const cache = new GenerationResultCache();
+    cache.setPending('a');
+    cache.commit(resultOfBytes(64, 1));
+    cache.commit(resultOfBytes(64, 2));
+    expect(cache.get('a')?.mesh.triangleCount).toBe(1);
+    expect(cache.stats.size).toBe(1);
+  });
+
+  it('drops a cleared pending fingerprint instead of storing its result', () => {
+    const cache = new GenerationResultCache();
+    cache.setPending('a');
+    cache.clearPending();
+    cache.commit(resultOfBytes(64));
+    expect(cache.get('a')).toBeNull();
+  });
+
+  it('evicts oldest-first once the byte budget is exceeded', () => {
+    const cache = new GenerationResultCache(2400);
+    store(cache, 'a', resultOfBytes(1000));
+    store(cache, 'b', resultOfBytes(1000));
+    store(cache, 'c', resultOfBytes(1000));
+    expect(cache.get('a')).toBeNull();
+    expect(cache.get('b')).not.toBeNull();
+    expect(cache.get('c')).not.toBeNull();
+    expect(cache.stats.bytes).toBeLessThanOrEqual(2400);
+  });
+
+  // Recency is what makes the budget usable: the shape being toggled away
+  // from and back to must not be the one evicted by an unrelated third edit.
+  it('a read protects an entry from the next eviction', () => {
+    const cache = new GenerationResultCache(2400);
+    store(cache, 'a', resultOfBytes(1000));
+    store(cache, 'b', resultOfBytes(1000));
+    cache.get('a');
+    store(cache, 'c', resultOfBytes(1000));
+    expect(cache.get('a')).not.toBeNull();
+    expect(cache.get('b')).toBeNull();
+  });
+
+  it('re-storing a fingerprint replaces rather than double-counts its bytes', () => {
+    const cache = new GenerationResultCache(2400);
+    store(cache, 'a', resultOfBytes(1000));
+    store(cache, 'a', resultOfBytes(1000));
+    expect(cache.stats.size).toBe(1);
+    expect(cache.stats.bytes).toBe(1000);
+  });
+
+  // Admitting it would evict every other entry and then itself, leaving the
+  // cache empty and the budget spent on nothing.
+  it('refuses a single result larger than the whole budget', () => {
+    const cache = new GenerationResultCache(2400);
+    store(cache, 'a', resultOfBytes(1000));
+    store(cache, 'huge', resultOfBytes(8000));
+    expect(cache.get('huge')).toBeNull();
+    expect(cache.get('a')).not.toBeNull();
+  });
+
+  it('clear drops every entry and any pending fingerprint', () => {
+    const cache = new GenerationResultCache();
+    store(cache, 'a', resultOfBytes(64));
+    cache.setPending('b');
+    cache.clear();
+    cache.commit(resultOfBytes(64));
+    expect(cache.get('a')).toBeNull();
+    expect(cache.get('b')).toBeNull();
+    expect(cache.stats).toEqual({ size: 0, bytes: 0 });
+  });
+});

--- a/src/features/generation/bridge/resultCache.ts
+++ b/src/features/generation/bridge/resultCache.ts
@@ -1,0 +1,116 @@
+/**
+ * Byte-budgeted LRU over completed generations, keyed by params fingerprint.
+ *
+ * This was a single slot holding only the most recent result, which made the
+ * cache a debounce guard rather than a cache: every edit that returns to a
+ * shape already built — toggle a feature on and back off, drag a slider home,
+ * step a value up then down — evicted the mesh it was about to ask for and
+ * re-ran the whole worker pipeline for it. The kernel is the slowest thing in
+ * the app, so that is a 1-4s wait for geometry the tab computed seconds ago.
+ *
+ * Not a replacement for `meshPersistence` (IndexedDB, survives reload, strips
+ * label plates because the layout planner shares those entries). This one is
+ * in-memory, holds the exact result the designer asked for — plates included —
+ * and dies with the bridge.
+ *
+ * Serving an entry twice is safe: the worker clones every buffer before
+ * transfer, and nothing on the main thread ever transfers them onward, so a
+ * cached result cannot be handed out detached. It does mean the worker's
+ * `lastSolid` no longer corresponds to what was just returned, which is
+ * already true of any cache hit — the export path re-checks the solid's
+ * identity fingerprint rather than trusting recency.
+ */
+
+import { meshDataByteSize } from '@/shared/generation/meshBytes';
+import type { GenerationResult } from './bridgeTypes';
+
+/**
+ * Byte budget for one cache.
+ *
+ * Measured preview meshes run 160KB (a 2x2x3 bin) to ~1.1MB (6x6), so this
+ * holds tens of ordinary shapes and still several of the heaviest — far more
+ * than the handful an edit realistically oscillates between. A bridge owns
+ * three caches but a given route only fills one of them, so this is the
+ * practical per-bridge ceiling, and it sits well under the undo history's own
+ * 100MB mesh budget, which already holds most of the same meshes keyed by
+ * history position rather than by params.
+ */
+export const RESULT_CACHE_MAX_BYTES = 16 * 1024 * 1024;
+
+interface Entry {
+  readonly result: GenerationResult;
+  readonly byteSize: number;
+}
+
+export class GenerationResultCache {
+  /** Insertion order IS recency order: a read re-inserts, so the oldest key is first. */
+  private readonly entries = new Map<string, Entry>();
+  private bytes = 0;
+  /** Fingerprint of the in-flight request, held so its result can be keyed on arrival. */
+  private pending: string | null = null;
+  private readonly maxBytes: number;
+
+  constructor(maxBytes: number = RESULT_CACHE_MAX_BYTES) {
+    this.maxBytes = maxBytes;
+  }
+
+  /** The result for `fingerprint`, promoted to most-recently-used, or null. */
+  get(fingerprint: string): GenerationResult | null {
+    const entry = this.entries.get(fingerprint);
+    if (!entry) return null;
+    this.entries.delete(fingerprint);
+    this.entries.set(fingerprint, entry);
+    return entry.result;
+  }
+
+  /** Record which fingerprint the request now in flight was built from. */
+  setPending(fingerprint: string): void {
+    this.pending = fingerprint;
+  }
+
+  /** Drop the in-flight fingerprint without storing anything (cancel, error, teardown). */
+  clearPending(): void {
+    this.pending = null;
+  }
+
+  /**
+   * Store `result` under the pending fingerprint, if this cache is the one
+   * with a request in flight. A no-op otherwise — the three caches share one
+   * request channel, so all three are offered every result and only the
+   * originator claims it.
+   */
+  commit(result: GenerationResult): void {
+    const fingerprint = this.pending;
+    if (fingerprint === null) return;
+    this.pending = null;
+
+    const byteSize = meshDataByteSize(result.mesh);
+    // A single result larger than the whole budget would evict everything and
+    // then itself; keep it out rather than emptying the cache to hold nothing.
+    if (byteSize > this.maxBytes) return;
+
+    const existing = this.entries.get(fingerprint);
+    if (existing) this.bytes -= existing.byteSize;
+    this.entries.delete(fingerprint);
+    this.entries.set(fingerprint, { result, byteSize });
+    this.bytes += byteSize;
+
+    for (const key of this.entries.keys()) {
+      if (this.bytes <= this.maxBytes) break;
+      const evicted = this.entries.get(key);
+      if (evicted) this.bytes -= evicted.byteSize;
+      this.entries.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.bytes = 0;
+    this.pending = null;
+  }
+
+  /** @internal — for tests and the dev perf overlay. */
+  get stats(): { size: number; bytes: number } {
+    return { size: this.entries.size, bytes: this.bytes };
+  }
+}

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -51,7 +51,8 @@ graph TB
 | `useGridTemplate()`   | CSS Grid template computation with half-bin fractional support        |
 | `useCrossTabSync()`   | Sync layout/library across browser tabs via StorageEvent              |
 | `usePWAUpdate()`      | Detect and prompt for service worker updates                          |
-| `usePrefetchChunks()` | Idle-time code chunk preloading                                       |
+| `usePrefetchChunks()` | Idle-time code chunk preloading (desktop only)                        |
+| `useIntentPrefetch()` | Warm a lazy destination on pointer-enter / pointer-down / focus       |
 | `useSharedWithMe()`   | Fetch and track layouts shared via Liveblocks                         |
 
 Inline rename lives in the design system: `useInlineEdit` for the headless

--- a/src/shared/components/ToolSwitcher/ToolSwitcher.test.tsx
+++ b/src/shared/components/ToolSwitcher/ToolSwitcher.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ToolSwitcher } from './ToolSwitcher';
+import { resetIntentPrefetchForTests } from '@/shared/hooks/useIntentPrefetch';
 
 const mockNavigateToDesigner = vi.fn();
 const mockNavigateToPlanner = vi.fn();
@@ -31,12 +32,21 @@ vi.mock('@/shared/hooks/useCommunityRouting', () => ({
   useCommunityRouting: () => ({ isCommunityRoute: mockIsCommunityRoute }),
 }));
 
+const mockWarmDesigner = vi.fn();
+const mockWarmBaseplate = vi.fn();
+
+vi.mock('@/shared/hooks/usePrefetchChunks', () => ({
+  warmDesigner: () => mockWarmDesigner(),
+  warmBaseplate: () => mockWarmBaseplate(),
+}));
+
 describe('ToolSwitcher', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsDesignerRoute = false;
     mockIsBaseplateRoute = false;
     mockIsCommunityRoute = false;
+    resetIntentPrefetchForTests();
   });
 
   it('shows tablist', () => {
@@ -193,6 +203,52 @@ describe('ToolSwitcher', () => {
       await user.click(screen.getAllByRole('tab')[0]);
 
       expect(mockNavigateToPlanner).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // Both editors are lazy chunks plus a geometry kernel, so the fetch has to
+  // start on the reach rather than on the click — otherwise the panel is blank
+  // for as long as the chunk takes, every time.
+  describe('prefetch on intent', () => {
+    it('warms the designer when the pointer reaches its segment', async () => {
+      const user = userEvent.setup();
+      render(<ToolSwitcher />);
+
+      await user.hover(screen.getAllByRole('tab')[1]);
+
+      expect(mockWarmDesigner).toHaveBeenCalledTimes(1);
+      expect(mockWarmBaseplate).not.toHaveBeenCalled();
+      expect(mockNavigateToDesigner).not.toHaveBeenCalled();
+    });
+
+    it('warms the baseplate when its segment takes focus', () => {
+      render(<ToolSwitcher />);
+
+      screen.getAllByRole('tab')[2].focus();
+
+      expect(mockWarmBaseplate).toHaveBeenCalledTimes(1);
+      expect(mockWarmDesigner).not.toHaveBeenCalled();
+    });
+
+    // Touch never hovers, and the idle tier-prefetch stands down on those
+    // devices, so pointerdown is the only warning they give.
+    it('warms on pointer-down, which is all a touch device offers', async () => {
+      const user = userEvent.setup();
+      render(<ToolSwitcher />);
+
+      await user.pointer({ keys: '[TouchA>]', target: screen.getAllByRole('tab')[1] });
+
+      expect(mockWarmDesigner).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the planner alone — it is the eager route', async () => {
+      const user = userEvent.setup();
+      render(<ToolSwitcher />);
+
+      await user.hover(screen.getAllByRole('tab')[0]);
+
+      expect(mockWarmDesigner).not.toHaveBeenCalled();
+      expect(mockWarmBaseplate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/shared/components/ToolSwitcher/ToolSwitcher.tsx
+++ b/src/shared/components/ToolSwitcher/ToolSwitcher.tsx
@@ -12,6 +12,9 @@ import { Button } from '@/design-system';
 import { useDesignerRouting } from '@/shared/hooks/useDesignerRouting';
 import { useBaseplateRouting } from '@/shared/hooks/useBaseplateRouting';
 import { useCommunityRouting } from '@/shared/hooks/useCommunityRouting';
+import { useIntentPrefetch } from '@/shared/hooks/useIntentPrefetch';
+import type { IntentPrefetchHandlers } from '@/shared/hooks/useIntentPrefetch';
+import { warmBaseplate, warmDesigner } from '@/shared/hooks/usePrefetchChunks';
 import { useTranslation } from '@/i18n';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 
@@ -96,6 +99,15 @@ export function ToolSwitcher({ compact = false, iconOnly = false }: ToolSwitcher
     }
   };
 
+  // The planner is the eager route and has nothing to fetch. The other two are
+  // lazy chunks whose fetch otherwise starts on the click, leaving the panel
+  // blank for as long as it takes; a hover is the earliest honest signal that
+  // one of them is about to be needed.
+  const designerIntent = useIntentPrefetch('tool:designer', warmDesigner);
+  const baseplateIntent = useIntentPrefetch('tool:baseplate', warmBaseplate);
+  const intentFor = (tool: Tool): Partial<IntentPrefetchHandlers> =>
+    tool === 'designer' ? designerIntent : tool === 'baseplate' ? baseplateIntent : {};
+
   const segmentPadding = getSegmentPadding(iconOnly, compact);
   const fontSize = compact ? 'text-xs' : 'text-sm';
   const iconSize = getIconSize(iconOnly, compact);
@@ -122,6 +134,7 @@ export function ToolSwitcher({ compact = false, iconOnly = false }: ToolSwitcher
             aria-selected={activeTool === id}
             aria-label={t(labelKey)}
             onClick={() => handleSwitch(id)}
+            {...intentFor(id)}
             title={activeTool !== id ? t(switchKey) : undefined}
             className={segmentClass(id)}
           >

--- a/src/shared/generation/meshBytes.test.ts
+++ b/src/shared/generation/meshBytes.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { meshDataByteSize } from './meshBytes';
+import type { MeshData } from '@/shared/types/generation';
+
+function baseMesh(): MeshData {
+  return {
+    vertices: new Float32Array(10), // 40
+    normals: new Float32Array(10), // 40
+    indices: new Uint32Array(5), // 20
+    edgeVertices: new Float32Array(5), // 20
+    triangleCount: 1,
+  };
+}
+
+const BASE_BYTES = 120;
+
+describe('meshDataByteSize', () => {
+  it('sums the four required buffers', () => {
+    expect(meshDataByteSize(baseMesh())).toBe(BASE_BYTES);
+  });
+
+  it('counts a coarse LOD, which carries no normals or edges', () => {
+    expect(
+      meshDataByteSize({
+        ...baseMesh(),
+        coarseLOD: { vertices: new Float32Array(4), indices: new Uint32Array(2), triangleCount: 1 },
+      })
+    ).toBe(BASE_BYTES + 24);
+  });
+
+  it('counts the lid and its edge lines', () => {
+    expect(
+      meshDataByteSize({
+        ...baseMesh(),
+        lidMesh: {
+          vertices: new Float32Array(2),
+          normals: new Float32Array(2),
+          indices: new Uint32Array(1),
+          edgeVertices: new Float32Array(1),
+          triangleCount: 1,
+        },
+      })
+    ).toBe(BASE_BYTES + 24);
+  });
+
+  // Every companion has to be in the walk. An omission does not fail loudly —
+  // it just lets a byte-budgeted cache grow past the cap it advertises.
+  it.each([
+    [
+      'stackPlateMesh',
+      {
+        vertices: new Float32Array(2),
+        normals: new Float32Array(2),
+        indices: new Uint32Array(1),
+        edgeVertices: new Float32Array(1),
+        triangleCount: 1,
+      },
+    ],
+    [
+      'slideTrayMesh',
+      {
+        vertices: new Float32Array(2),
+        normals: new Float32Array(2),
+        indices: new Uint32Array(1),
+        edgeVertices: new Float32Array(1),
+        triangleCount: 1,
+        restZ: 0,
+      },
+    ],
+  ])('counts %s', (key, part) => {
+    expect(meshDataByteSize({ ...baseMesh(), [key]: part })).toBe(BASE_BYTES + 24);
+  });
+
+  it('counts the connector key, which carries no edge lines', () => {
+    expect(
+      meshDataByteSize({
+        ...baseMesh(),
+        connectorKeyMesh: {
+          vertices: new Float32Array(2),
+          normals: new Float32Array(2),
+          indices: new Uint32Array(2),
+          triangleCount: 1,
+        },
+      })
+    ).toBe(BASE_BYTES + 24);
+  });
+
+  it('counts every label plate, not just the first', () => {
+    const plate = {
+      vertices: new Float32Array(2),
+      normals: new Float32Array(2),
+      indices: new Uint32Array(1),
+      triangleCount: 1,
+      seatX: 0,
+      seatY: 0,
+      seatZ: 0,
+      slideY: 1 as const,
+      widthMm: 10,
+    };
+    expect(
+      meshDataByteSize({
+        ...baseMesh(),
+        labelPlates: { plates: [plate, plate, plate], omittedCount: 0 },
+      })
+    ).toBe(BASE_BYTES + 3 * 20);
+  });
+});

--- a/src/shared/generation/meshBytes.ts
+++ b/src/shared/generation/meshBytes.ts
@@ -1,0 +1,46 @@
+/**
+ * Byte accounting for a generated {@link MeshData}.
+ *
+ * Two caches evict on a byte budget — the cross-session IndexedDB store
+ * (`meshPersistence`) and the in-session bridge result cache
+ * (`bridge/resultCache`) — and a budget is only as honest as the measurement
+ * behind it. Sharing one walk means a new companion mesh is counted by both
+ * the moment it is added here, rather than silently inflating whichever cache
+ * forgot about it.
+ *
+ * Every optional companion is folded in, including the ones a given caller
+ * happens to strip before storing: an undercount does not fail loudly, it just
+ * lets the cache grow past the cap it claims to enforce.
+ */
+
+import type { MeshData } from '@/shared/types/generation';
+
+interface BufferBearing {
+  readonly vertices: { readonly byteLength: number };
+  readonly normals?: { readonly byteLength: number };
+  readonly indices: { readonly byteLength: number };
+  readonly edgeVertices?: { readonly byteLength: number };
+}
+
+function partBytes(part: BufferBearing): number {
+  return (
+    part.vertices.byteLength +
+    (part.normals?.byteLength ?? 0) +
+    part.indices.byteLength +
+    (part.edgeVertices?.byteLength ?? 0)
+  );
+}
+
+/** Total bytes held by every typed array reachable from `mesh`. */
+export function meshDataByteSize(mesh: MeshData): number {
+  let bytes = partBytes(mesh);
+  if (mesh.coarseLOD) bytes += partBytes(mesh.coarseLOD);
+  if (mesh.lidMesh) bytes += partBytes(mesh.lidMesh);
+  if (mesh.stackPlateMesh) bytes += partBytes(mesh.stackPlateMesh);
+  if (mesh.slideTrayMesh) bytes += partBytes(mesh.slideTrayMesh);
+  if (mesh.connectorKeyMesh) bytes += partBytes(mesh.connectorKeyMesh);
+  if (mesh.labelPlates) {
+    for (const plate of mesh.labelPlates.plates) bytes += partBytes(plate);
+  }
+  return bytes;
+}

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -22,6 +22,7 @@ import type { IDBPDatabase } from 'idb';
 import type { BinParams } from '@/shared/types/bin';
 import type { KernelName } from '@/shared/generation/bridge';
 import type { MeshData } from '@/shared/types/generation';
+import { meshDataByteSize } from './meshBytes';
 import { createLogger } from '@/core/logger';
 
 const logger = createLogger('MeshPersistence');
@@ -194,39 +195,6 @@ export function binMeshCacheKey(params: BinParams, kernel: KernelName): string {
   return `${MESH_CACHE_VERSION}:${kernel}-${revision}:${djb2(stableStringify(params))}`;
 }
 
-/** Sum the byte length of every typed array reachable from a mesh (incl. lid + connector). */
-function meshByteSize(mesh: MeshData): number {
-  let bytes =
-    mesh.vertices.byteLength +
-    mesh.normals.byteLength +
-    mesh.indices.byteLength +
-    mesh.edgeVertices.byteLength;
-  if (mesh.coarseLOD) {
-    bytes += mesh.coarseLOD.vertices.byteLength + mesh.coarseLOD.indices.byteLength;
-  }
-  if (mesh.lidMesh) {
-    bytes +=
-      mesh.lidMesh.vertices.byteLength +
-      mesh.lidMesh.normals.byteLength +
-      mesh.lidMesh.indices.byteLength +
-      mesh.lidMesh.edgeVertices.byteLength;
-  }
-  if (mesh.stackPlateMesh) {
-    bytes +=
-      mesh.stackPlateMesh.vertices.byteLength +
-      mesh.stackPlateMesh.normals.byteLength +
-      mesh.stackPlateMesh.indices.byteLength +
-      mesh.stackPlateMesh.edgeVertices.byteLength;
-  }
-  if (mesh.connectorKeyMesh) {
-    bytes +=
-      mesh.connectorKeyMesh.vertices.byteLength +
-      mesh.connectorKeyMesh.normals.byteLength +
-      mesh.connectorKeyMesh.indices.byteLength;
-  }
-  return bytes;
-}
-
 /**
  * Load a persisted preview mesh, or `null` on miss / unavailable store / error.
  * Never throws — a failed read simply means "no pre-draft", and the worker still
@@ -268,7 +236,7 @@ export function savePersistedBinMesh(key: string, mesh: MeshData): void {
 async function persistMesh(key: string, mesh: MeshData): Promise<void> {
   try {
     const db = await getDb();
-    const meta: MeshMeta = { key, byteSize: meshByteSize(mesh), ts: nextStamp() };
+    const meta: MeshMeta = { key, byteSize: meshDataByteSize(mesh), ts: nextStamp() };
 
     const writeTx = db.transaction([BIN_MESHES_STORE, META_STORE], 'readwrite');
     void writeTx.objectStore(BIN_MESHES_STORE).put({ key, mesh } satisfies StoredMesh);

--- a/src/shared/hooks/useIntentPrefetch.test.ts
+++ b/src/shared/hooks/useIntentPrefetch.test.ts
@@ -97,4 +97,39 @@ describe('useIntentPrefetch', () => {
       })
     ).not.toThrow();
   });
+
+  it('swallows a rejected async warm rather than leaving it unhandled', async () => {
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    prefetchOnIntent('a', () => Promise.reject(new Error('chunk 404')));
+    await new Promise((r) => setTimeout(r, 0));
+    process.off('unhandledRejection', unhandled);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  // The one-shot mark means a session gets one attempt per destination, so
+  // spending it on a failure would leave that route cold for good.
+  it.each([
+    [
+      'throws',
+      () => {
+        throw new Error('chunk server down');
+      },
+    ],
+    ['rejects', () => Promise.reject(new Error('chunk 404'))],
+  ])('releases the destination when the warm %s', async (_label, failing) => {
+    prefetchOnIntent('a', failing);
+    await new Promise((r) => setTimeout(r, 0));
+    const retry = vi.fn();
+    prefetchOnIntent('a', retry);
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the mark when the warm starts cleanly', async () => {
+    prefetchOnIntent('a', () => Promise.resolve());
+    await new Promise((r) => setTimeout(r, 0));
+    const retry = vi.fn();
+    prefetchOnIntent('a', retry);
+    expect(retry).not.toHaveBeenCalled();
+  });
 });

--- a/src/shared/hooks/useIntentPrefetch.test.ts
+++ b/src/shared/hooks/useIntentPrefetch.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  useIntentPrefetch,
+  prefetchOnIntent,
+  resetIntentPrefetchForTests,
+} from './useIntentPrefetch';
+
+function setConnection(value: unknown): void {
+  Object.defineProperty(navigator, 'connection', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('useIntentPrefetch', () => {
+  let original: unknown;
+
+  beforeEach(() => {
+    original = (navigator as unknown as Record<string, unknown>).connection;
+    setConnection(undefined);
+    resetIntentPrefetchForTests();
+  });
+
+  afterEach(() => {
+    setConnection(original);
+  });
+
+  it.each(['onPointerEnter', 'onPointerDown', 'onFocus'] as const)(
+    'warms the destination on %s',
+    (handler) => {
+      const warm = vi.fn();
+      const { result } = renderHook(() => useIntentPrefetch('a', warm));
+      result.current[handler]();
+      expect(warm).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  // Hovering across a row of tabs, or hovering the same one repeatedly, must
+  // not re-request a chunk the browser is already fetching.
+  it('warms a destination at most once per session', () => {
+    const warm = vi.fn();
+    const { result } = renderHook(() => useIntentPrefetch('a', warm));
+    result.current.onPointerEnter();
+    result.current.onPointerDown();
+    result.current.onFocus();
+    expect(warm).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks each destination separately', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    renderHook(() => useIntentPrefetch('a', a)).result.current.onPointerEnter();
+    renderHook(() => useIntentPrefetch('b', b)).result.current.onPointerEnter();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('spends no bandwidth under data-saver', () => {
+    setConnection({ saveData: true });
+    const warm = vi.fn();
+    renderHook(() => useIntentPrefetch('a', warm)).result.current.onPointerEnter();
+    expect(warm).not.toHaveBeenCalled();
+  });
+
+  // A refused prefetch must stay refused rather than being marked done, so the
+  // destination is still warmable once the connection recovers.
+  it('retries after a skip once the connection is no longer constrained', () => {
+    setConnection({ saveData: true });
+    const warm = vi.fn();
+    const { result } = renderHook(() => useIntentPrefetch('a', warm));
+    result.current.onPointerEnter();
+    setConnection(undefined);
+    result.current.onPointerEnter();
+    expect(warm).toHaveBeenCalledTimes(1);
+  });
+
+  // Handler identity is stable across renders (call sites pass inline arrows),
+  // so the ref has to be what carries the current closure.
+  it('calls the latest warm function after a re-render', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { result, rerender } = renderHook(({ warm }) => useIntentPrefetch('a', warm), {
+      initialProps: { warm: first },
+    });
+    rerender({ warm: second });
+    result.current.onPointerEnter();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a throwing warm function from reaching the click handler', () => {
+    expect(() =>
+      prefetchOnIntent('a', () => {
+        throw new Error('chunk server down');
+      })
+    ).not.toThrow();
+  });
+});

--- a/src/shared/hooks/useIntentPrefetch.ts
+++ b/src/shared/hooks/useIntentPrefetch.ts
@@ -35,14 +35,27 @@ export interface IntentPrefetchHandlers {
 /**
  * Warm `key`'s destination now, at most once per session. Exported for call
  * sites that already own their handlers and only need the one-shot guard.
+ *
+ * The one-shot mark covers a warm that STARTED, not one that was attempted:
+ * a warm that throws (or returns a promise that rejects) releases the key so a
+ * later reach can try again. Marking it regardless would spend the session's
+ * only attempt on a failure and leave the destination cold for good. `warm` is
+ * allowed to be async for the same reason the sync path is guarded — a
+ * rejection here is speculative work not paying off, never something to
+ * surface. Hence `unknown` rather than `void`: the signature has to admit a
+ * promise for the guard above it to mean anything.
  */
-export function prefetchOnIntent(key: string, warm: () => void): void {
+export function prefetchOnIntent(key: string, warm: () => unknown): void {
   if (started.has(key) || shouldSkipPrefetch()) return;
   started.add(key);
+  const release = (): void => {
+    started.delete(key);
+  };
   try {
-    warm();
+    void Promise.resolve(warm()).catch(release);
   } catch {
     // Speculative by definition — the destination still loads on demand.
+    release();
   }
 }
 
@@ -53,7 +66,7 @@ export function prefetchOnIntent(key: string, warm: () => void): void {
  * rebuilding the handler identities on every render — the destination is
  * identified by `key`, not by the closure that loads it.
  */
-export function useIntentPrefetch(key: string, warm: () => void): IntentPrefetchHandlers {
+export function useIntentPrefetch(key: string, warm: () => unknown): IntentPrefetchHandlers {
   const warmRef = useRef(warm);
   useEffect(() => {
     warmRef.current = warm;

--- a/src/shared/hooks/useIntentPrefetch.ts
+++ b/src/shared/hooks/useIntentPrefetch.ts
@@ -1,0 +1,72 @@
+/**
+ * Start loading a destination the moment someone reaches for it.
+ *
+ * Every editor in the tool switcher is a lazy route, so today the chunk fetch
+ * only begins on the click and the panel stays blank until it lands —
+ * measured at ~0.9s on a good connection and ~2.9s on a slow one, all of it
+ * after the user has already committed. A pointer sits on a control for a few
+ * hundred milliseconds before the button goes down, and a keyboard user
+ * focuses it first; both are a commitment strong enough to spend a chunk on
+ * and early enough to be worth something.
+ *
+ * `pointerenter` covers mouse and pen. Touch never hovers, so it is answered
+ * by `pointerdown` instead — that is only ~100ms of head start, but it is the
+ * whole of the warning a touch device gives, and the idle tier-prefetch
+ * deliberately stands down on those devices.
+ *
+ * Fire-and-forget and idempotent: a rejected import means the chunk loads
+ * normally when the route actually mounts, and re-entering a control costs
+ * nothing after the first time.
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { shouldSkipPrefetch } from '@/shared/utils/prefetchPolicy';
+
+/** Destinations already warmed this session, so repeat hovers are free. */
+const started = new Set<string>();
+
+/** Handlers to spread onto the element that leads to `key`'s destination. */
+export interface IntentPrefetchHandlers {
+  readonly onPointerEnter: () => void;
+  readonly onPointerDown: () => void;
+  readonly onFocus: () => void;
+}
+
+/**
+ * Warm `key`'s destination now, at most once per session. Exported for call
+ * sites that already own their handlers and only need the one-shot guard.
+ */
+export function prefetchOnIntent(key: string, warm: () => void): void {
+  if (started.has(key) || shouldSkipPrefetch()) return;
+  started.add(key);
+  try {
+    warm();
+  } catch {
+    // Speculative by definition — the destination still loads on demand.
+  }
+}
+
+/**
+ * Handlers that warm `key`'s destination on the first sign of intent.
+ *
+ * `warm` is held in a ref so call sites can pass an inline arrow without
+ * rebuilding the handler identities on every render — the destination is
+ * identified by `key`, not by the closure that loads it.
+ */
+export function useIntentPrefetch(key: string, warm: () => void): IntentPrefetchHandlers {
+  const warmRef = useRef(warm);
+  useEffect(() => {
+    warmRef.current = warm;
+  }, [warm]);
+
+  const fire = useCallback(() => {
+    prefetchOnIntent(key, () => warmRef.current());
+  }, [key]);
+
+  return useMemo(() => ({ onPointerEnter: fire, onPointerDown: fire, onFocus: fire }), [fire]);
+}
+
+/** @internal — for tests; session state would otherwise leak between cases. */
+export function resetIntentPrefetchForTests(): void {
+  started.clear();
+}

--- a/src/shared/hooks/usePrefetchChunks.test.ts
+++ b/src/shared/hooks/usePrefetchChunks.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { usePrefetchChunks } from './usePrefetchChunks';
+import {
+  usePrefetchChunks,
+  warmBaseplate,
+  warmDesigner,
+  warmGeometryKernel,
+} from './usePrefetchChunks';
 
 // Mock WASM preload — we only care that it's called, not its internals
 vi.mock('@/shared/generation/wasmPreload', () => ({
@@ -35,6 +40,8 @@ vi.mock('@/shared/utils/idle', () => ({
 
 // Grab mocked modules for per-test control
 import { useResponsive } from './useResponsive';
+import { preloadBrepkitWasm, preloadOcctWasm } from '@/shared/generation/wasmPreload';
+import { useLabsStore } from '@/core/store/labs';
 import { scheduleIdleCallback, cancelIdleCallback } from '@/shared/utils/idle';
 const mockUseResponsive = vi.mocked(useResponsive);
 const mockScheduleIdle = vi.mocked(scheduleIdleCallback);
@@ -191,5 +198,44 @@ describe('usePrefetchChunks', () => {
     handles.forEach((handle) => {
       expect(mockCancelIdle).toHaveBeenCalledWith(handle);
     });
+  });
+});
+
+describe('destination warmers', () => {
+  beforeEach(() => {
+    vi.mocked(preloadOcctWasm).mockClear();
+    vi.mocked(preloadBrepkitWasm).mockClear();
+  });
+
+  it('primes occt-wasm, the default kernel', () => {
+    warmGeometryKernel();
+    expect(preloadOcctWasm).toHaveBeenCalledTimes(1);
+    expect(preloadBrepkitWasm).not.toHaveBeenCalled();
+  });
+
+  it('primes brepkit instead when the Labs engine is on', () => {
+    const spy = vi
+      .spyOn(useLabsStore.getState(), 'isFeatureEnabled')
+      .mockImplementation((id) => id === 'brepkit_kernel');
+    try {
+      warmGeometryKernel();
+    } finally {
+      spy.mockRestore();
+    }
+    expect(preloadBrepkitWasm).toHaveBeenCalledTimes(1);
+    expect(preloadOcctWasm).not.toHaveBeenCalled();
+  });
+
+  // Measured regression guard: warming the 22MB kernel on a hover puts it in
+  // front of the ~500KB the panel is waiting for, and on a 4Mbps link that
+  // made the click slower than doing nothing. The kernel belongs to the idle
+  // tier, which runs when no navigation is in flight.
+  it.each([
+    ['designer', warmDesigner],
+    ['baseplate', warmBaseplate],
+  ])('the %s warmer fetches its chunk without touching the kernel', (_name, warm) => {
+    warm();
+    expect(preloadOcctWasm).not.toHaveBeenCalled();
+    expect(preloadBrepkitWasm).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/hooks/usePrefetchChunks.ts
+++ b/src/shared/hooks/usePrefetchChunks.ts
@@ -1,40 +1,59 @@
 import { useEffect } from 'react';
 import { useResponsive } from './useResponsive';
 import { scheduleIdleCallback, cancelIdleCallback } from '@/shared/utils/idle';
+import { shouldSkipPrefetch } from '@/shared/utils/prefetchPolicy';
 import { preloadBrepkitWasm, preloadOcctWasm } from '@/shared/generation/wasmPreload';
 import { useLabsStore } from '@/core/store/labs';
 
 /** How long to wait after mount before starting prefetch (ms) */
 const PREFETCH_DELAY_MS = 3000;
 
-/**
- * Connection info from the Network Information API.
- * Not available in all browsers, so every property is optional.
- */
-interface NetworkInformation {
-  saveData?: boolean;
-  effectiveType?: string;
-}
-
-/**
- * Returns true when the browser signals it wants to conserve bandwidth
- * (data-saver enabled or very slow connection).
- */
-function shouldSkipForNetwork(): boolean {
-  const connection = (navigator as { connection?: NetworkInformation }).connection;
-  if (!connection) return false;
-  return (
-    connection.saveData === true ||
-    connection.effectiveType === 'slow-2g' ||
-    connection.effectiveType === '2g'
-  );
-}
-
 /** Fire-and-forget dynamic import — errors are silently swallowed. */
 function prefetch(importFn: () => Promise<unknown>): void {
   importFn().catch(() => {
     /* chunk will load normally when actually needed */
   });
+}
+
+/**
+ * Prime the geometry kernel the active Labs engine will actually use. Both
+ * editors below need it, and it is by far the largest asset either pulls.
+ */
+export function warmGeometryKernel(): void {
+  if (useLabsStore.getState().isFeatureEnabled('brepkit_kernel')) {
+    preloadBrepkitWasm();
+  } else {
+    preloadOcctWasm();
+  }
+}
+
+/**
+ * Per-destination warmers, kept beside the idle tiers so what a destination
+ * costs is stated once. Each is safe to call repeatedly; the callers that
+ * matter (`useIntentPrefetch`) dedupe anyway.
+ *
+ * Route chunks only — deliberately NOT the geometry kernel, even though both
+ * editors need one. Starting a 22MB binary on a hover puts it in front of the
+ * ~500KB the panel is actually waiting for: measured on a 4Mbps link, warming
+ * the kernel on intent made the click *slower* than doing nothing. The kernel
+ * has its own budget — the idle tier below, 3s after mount and off the
+ * critical path of any navigation the user has started.
+ */
+export function warmDesigner(): void {
+  prefetch(() => import('@/features/bin-designer/components/DesignerPage'));
+}
+
+export function warmBaseplate(): void {
+  prefetch(() => import('@/features/baseplate'));
+}
+
+export function warmCommunity(): void {
+  prefetch(() => import('@/features/community'));
+}
+
+/** The designer's own way into the showcase — a modal, not the /community route. */
+export function warmDesignGallery(): void {
+  prefetch(() => import('@/shell/Modals/DesignGalleryModal'));
 }
 
 /**
@@ -45,7 +64,9 @@ function prefetch(importFn: () => Promise<unknown>): void {
  * Tiers are chained so each waits for the previous tier's idle slot.
  *
  * Skips prefetching on:
- * - Mobile and tablet devices (limited resources)
+ * - Mobile and tablet devices (limited resources). Those devices are covered
+ *   by pointer-intent prefetch instead (`useIntentPrefetch`), which spends
+ *   bandwidth only on a destination someone is already reaching for.
  * - Data-saver mode or slow connections (2G / slow-2G)
  */
 export function usePrefetchChunks(): void {
@@ -56,7 +77,7 @@ export function usePrefetchChunks(): void {
     if (isMobile || isTablet) return;
 
     // Skip on data-saver or very slow connections
-    if (shouldSkipForNetwork()) return;
+    if (shouldSkipPrefetch()) return;
 
     const idleHandles: number[] = [];
 
@@ -67,23 +88,22 @@ export function usePrefetchChunks(): void {
     const timer = setTimeout(() => {
       // Tier 0: Preload WASM binary — large asset needed by designer & baseplate
       scheduleNext(() => {
-        const labs = useLabsStore.getState();
-        if (labs.isFeatureEnabled('brepkit_kernel')) {
-          preloadBrepkitWasm();
-        } else {
-          preloadOcctWasm();
-        }
+        warmGeometryKernel();
 
-        // Tier 1: High priority — features most users navigate to quickly
+        // Tier 1: High priority — the other two editors in the tool switcher,
+        // plus the modals most users open early. All three editors are one
+        // click apart, so none of them should be the one that isn't ready.
         scheduleNext(() => {
           prefetch(() => import('@/features/print-export/components/PrintModal'));
           prefetch(() => import('@/features/layout-library/components/LayoutManagerModal'));
           prefetch(() => import('@/features/bin-designer/components/DesignerPage'));
+          prefetch(() => import('@/features/baseplate'));
           prefetch(() => import('@/shell/Modals/SettingsModal'));
 
           // Tier 2: Medium priority — commonly used but not immediately
           scheduleNext(() => {
             prefetch(() => import('@/features/inspiration-gallery'));
+            prefetch(() => import('@/features/community'));
             prefetch(() => import('@/shell/Modals/HelpModal'));
 
             // Tier 3: Low priority — rarely needed on desktop

--- a/src/shared/pwa/cacheNames.ts
+++ b/src/shared/pwa/cacheNames.ts
@@ -3,6 +3,11 @@
  * stale-recovery path can't drift. `PRECACHE_PREFIX` must track `workbox.cacheId`
  * ('gridfinity-v1') + Workbox's '-precache-' suffix; `WASM_CACHE` must match the
  * wasm `runtimeCaching` cacheName — both in vite.config.ts.
+ *
+ * That cache holds the geometry kernels only. The Draco decoder is routed to
+ * its own cache ahead of the generic `.wasm` rule, and deliberately stays out
+ * of stale-bundle recovery: a wedged kernel init says nothing about a GLB
+ * preview's decoder, and clearing it just costs a refetch.
  */
 export const PRECACHE_PREFIX = 'gridfinity-v1-precache-';
 export const WASM_CACHE = 'wasm-binaries';

--- a/src/shared/utils/prefetchPolicy.test.ts
+++ b/src/shared/utils/prefetchPolicy.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { shouldSkipPrefetch } from './prefetchPolicy';
+
+function setConnection(value: unknown): void {
+  Object.defineProperty(navigator, 'connection', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('shouldSkipPrefetch', () => {
+  let original: unknown;
+
+  beforeEach(() => {
+    original = (navigator as unknown as Record<string, unknown>).connection;
+  });
+
+  afterEach(() => {
+    setConnection(original);
+  });
+
+  // Absent in Safari and Firefox, which are not thereby data-saver users.
+  it('does not skip when the Network Information API is unavailable', () => {
+    setConnection(undefined);
+    expect(shouldSkipPrefetch()).toBe(false);
+  });
+
+  it('skips under data-saver', () => {
+    setConnection({ saveData: true, effectiveType: '4g' });
+    expect(shouldSkipPrefetch()).toBe(true);
+  });
+
+  it.each(['2g', 'slow-2g'])('skips on %s', (effectiveType) => {
+    setConnection({ saveData: false, effectiveType });
+    expect(shouldSkipPrefetch()).toBe(true);
+  });
+
+  it.each(['3g', '4g'])('does not skip on %s', (effectiveType) => {
+    setConnection({ saveData: false, effectiveType });
+    expect(shouldSkipPrefetch()).toBe(false);
+  });
+});

--- a/src/shared/utils/prefetchPolicy.ts
+++ b/src/shared/utils/prefetchPolicy.ts
@@ -1,0 +1,24 @@
+/**
+ * When the browser has told us not to spend bandwidth speculatively.
+ *
+ * Shared by the idle tier-prefetch (`usePrefetchChunks`) and the pointer-intent
+ * prefetch (`useIntentPrefetch`) so a data-saver visitor is not exempted from
+ * one and quietly charged by the other.
+ */
+
+interface NetworkInformation {
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+/** True when the connection signals data-saver or a very slow link. */
+export function shouldSkipPrefetch(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const connection = (navigator as { connection?: NetworkInformation }).connection;
+  if (!connection) return false;
+  return (
+    connection.saveData === true ||
+    connection.effectiveType === 'slow-2g' ||
+    connection.effectiveType === '2g'
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -306,15 +306,44 @@ export default defineConfig({
             },
           },
           {
+            // The Draco decoder, which only a GLB preview pulls. Its own cache
+            // so it is not competing for a slot with the geometry kernels
+            // below — it is three orders of magnitude smaller than occt-wasm
+            // and nothing about the two is related.
+            urlPattern: /\/draco\/.*\.wasm$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'draco-decoder',
+              expiration: {
+                maxEntries: 4,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+              },
+              cacheableResponse: {
+                statuses: [200],
+              },
+            },
+          },
+          {
             // Cache WASM binaries (content-hashed, immutable) after first use.
             // CacheFirst is safe because new deploys produce new hashes.
+            //
+            // Three kernels ship (occt-wasm ~22MB, brepkit ~5MB, manifold
+            // ~0.5MB), so a budget of three is a budget with no headroom: a
+            // deploy that rehashes any one of them adds a fourth entry and the
+            // LRU has to drop something. Six leaves room for a deploy's
+            // superseded copies to coexist with the current ones, and the
+            // shorter max-age lets the superseded ones fall out rather than
+            // sitting for a year. Getting this wrong is expensive in exactly
+            // one direction — evicting a live occt-wasm costs a 22MB refetch
+            // on the next designer open.
             urlPattern: /\.wasm$/,
             handler: 'CacheFirst',
             options: {
               cacheName: 'wasm-binaries',
               expiration: {
-                maxEntries: 4,
-                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+                maxEntries: 6,
+                maxAgeSeconds: 60 * 60 * 24 * 60, // 60 days
+                purgeOnQuotaError: true,
               },
               cacheableResponse: {
                 statuses: [200],


### PR DESCRIPTION
Three waits people actually feel. Each one was measured on the built app before and after, not reasoned about, and one of the three changed shape because the first measurement said the opposite of what I expected.

## 1. The generation cache held one entry

`bridge/resultCache.ts` (was a single slot in `bridgeGeneration.ts`).

The bridge's dedup cache stored the fingerprint and result of the *last* generation, which makes it a debounce guard rather than a cache. The commonest edit in a parametric designer is a round trip: toggle a feature on and back off, drag a slider home, step a value up then down. By the time the return leg asked, the cache had already evicted the result it was asking for, and the kernel ran again for geometry the tab computed seconds earlier.

Now a byte-budgeted LRU keyed by params fingerprint, one per request kind (bin / baseplate / item).

Measured at the worker channel, on the built app, median of 3:

| return leg | GENERATE messages | kernel round trip |
| --- | --- | --- |
| 2x2x3 bin, before | 1 | 259 ms |
| 2x2x3 bin, after | **0** | **0 ms** |
| 6x6 bin, before | 1 | 343 ms |
| 6x6 bin, after | **0** | **0 ms** |

The worker never hears about it. The saving grows with design complexity, because the worker's own shape cache absorbs less of a rebuild it cannot reuse.

Two things that make it safe, both stated in the module doc:

- Serving an entry twice is fine. The worker clones every buffer before transfer and nothing on the main thread transfers them onward, so a cached result can never be handed out detached.
- A hit means `lastSolid` no longer describes what was returned. That was already true of any hit; `exportBin` re-checks the identity fingerprint (gotcha 16) rather than trusting recency.

Budget is 16 MB per cache, chosen against measured preview meshes (160 KB for a 2x2x3, ~1.1 MB for a 6x6) rather than picked. A route only fills one of the three, so that is the practical per-bridge ceiling, and it sits well under the undo history's own 100 MB budget which already holds most of the same meshes keyed by history position.

## 2. The tool switcher only started fetching on the click

`useIntentPrefetch.ts`, wired into `ToolSwitcher` and the designer's community entry.

Bins and Baseplate are lazy routes. The chunk fetch began on the click, so the panel stayed blank until it landed. A pointer sits on a control for a few hundred milliseconds first, and a keyboard user focuses it; both are commitment enough to spend a chunk on. `pointerenter` covers mouse and pen, `pointerdown` covers touch, which never hovers.

Measured in-page (MutationObserver, no Playwright round trip), click to panel paint, 400 ms reach, median of 4-5:

| link | before | after |
| --- | --- | --- |
| 12 Mbps / 40 ms | 525 ms | **322 ms** |
| 4 Mbps / 150 ms | 1428 ms | **1000 ms** |

### The part that went the other way

My first version also warmed the geometry kernel on hover, since both editors need it. On a 4 Mbps link that made the click **slower than doing nothing**: a 22 MB binary in front of the ~500 KB the panel was actually waiting for. The warmers are chunk-only now, the kernel keeps its idle-tier budget which runs when no navigation is in flight, and there is a regression test naming the measurement so nobody re-adds it.

## 3. Prefetch gaps and a cache with no headroom

- The idle prefetch tiers never listed `BaseplatePage` or `CommunityPage` at all, despite the baseplate being one of the three top-level editors. Both are in a tier now.
- The `wasm-binaries` runtime cache allowed 4 entries for the 4 wasm URLs that reach it. No headroom: a deploy that rehashes any kernel adds a fifth and the LRU has to drop something, and dropping a live `occt-wasm` costs a 22 MB refetch on the next designer open. Draco moves to its own cache (it is a GLB decoder, not a kernel, and was only ever competing for a slot), the kernels get room for a deploy's superseded copies, and max-age drops from a year to 60 days so those copies fall out instead of squatting.
- `meshDataByteSize` replaces the persistence cache's private byte walk, which omitted `slideTrayMesh`. The 64 MB IndexedDB budget was therefore running over its stated cap on any design with a sliding tray. Both byte-budgeted caches share the walk now, so a new companion mesh is counted by both the moment it is added.

## Verification

- Full suite green: 22 650 passed, 20 skipped.
- `typecheck`, `lint` (0 errors), `knip`, boundaries, i18n x3, exhaustiveness, component-structure all clean.
- The round-trip regression test was confirmed to have teeth: restoring single-slot semantics fails that one test and only that one (40 of 41 still pass).
- Main bundle 35.21 kB / 190 kB, eager initial JS 102.85 kB / 260 kB. The local "Total JS" overshoot is the known `.env.production.local` artifact, not this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts visible waits by caching generation results and prefetching lazy editors on intent. Previously, round-trip edits re-ran the kernel and lazy routes only fetched on click; now cached results repaint instantly and chunks start loading on hover/focus/touch.

- Bridge: replace the size‑1 dedup cache with a byte‑budgeted LRU keyed by params fingerprint, one per request kind. Hits bypass the worker; 16 MB per cache; safe to serve twice; caches clear on destroy. Adds mesh byte accounting shared via `meshDataByteSize`.
- Intent prefetch: new `useIntentPrefetch` warms destinations on pointerenter/pointerdown/focus. Adds `warmDesigner`, `warmBaseplate`, `warmCommunity`, `warmDesignGallery`. Chunk‑only; the geometry kernel stays in the idle tier. Skips under data‑saver/2G via a shared prefetch policy. One‑shot per destination per session; if a warm throws/rejects, the mark is released so later attempts can warm.
- Idle tiers: include baseplate and community so all three editors have coverage.
- PWA caches: route Draco `.wasm` to its own `draco-decoder`; increase `wasm-binaries` headroom (maxEntries 6) and shorten max‑age (60 days) to avoid evicting live kernels on deploys.
- Wiring: Tool switcher and the bin parameter panel use intent prefetch. Persistence uses `meshDataByteSize` (counts `slideTrayMesh`). Docs and tests added.

**Rollout/QA**
- No migrations. On deploy, the service worker will create `draco-decoder` and update `wasm-binaries`; superseded kernel entries age out automatically.
- Verify: round‑trip edits don’t send GENERATE; designer/baseplate panels paint faster after a brief hover/focus; no prefetch under data‑saver; a failed warm can retry later.
- Monitor memory: result caches capped at ~16 MB each; persistence budget respected with `slideTrayMesh` counted.

<sup>Written for commit 036bc5c9b2802fae806a7122dcad9673e81e4989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

