### PR TITLE
docs: state the reason without the measurement

### DIFF
--- a/src/features/engagement/README.md
+++ b/src/features/engagement/README.md
@@ -14,7 +14,7 @@ Engagement-gated nudge system for feedback and Ko-fi support.
 
    The conversion condition is checked first and short-circuits the rest. An ask
    that arrives mid-task is asking someone to stop doing the thing they came for,
-   which is what 1,376 impressions to 11 clicks looked like.
+   and on the plain timer it was almost never acted on.
 
 3. **Nudge types** — `feedback_rating` (prioritized) and `kofi_support`, each with an independent 30-day cooldown.
 

--- a/src/features/engagement/useEngagementNudges.test.ts
+++ b/src/features/engagement/useEngagementNudges.test.ts
@@ -69,8 +69,9 @@ describe('useEngagementNudges', () => {
     );
   });
 
-  // 1,376 impressions to 11 clicks came from asking mid-task. The prompt is
-  // unchanged; only the moment is — after the user has actually got a file out.
+  // On the plain timer the ask arrived mid-task and was almost never acted on.
+  // The prompt is unchanged; only the moment is — after the user has actually
+  // got a file out.
   it('withholds the nudge until a printable file has been produced', () => {
     (shouldShowNudge as Mock).mockReturnValue(true);
     (hasConvertedThisSession as Mock).mockReturnValue(false);

--- a/src/features/engagement/useEngagementNudges.ts
+++ b/src/features/engagement/useEngagementNudges.ts
@@ -37,10 +37,10 @@ export function useEngagementNudges(): void {
   // poll (it barely converted here) — the Ko-fi ask now lives in the header and
   // the export dialog's post-export success view.
   //
-  // The timer additionally waits for a printable file this session: at 1,376
-  // impressions to 11 clicks, the ask was arriving mid-task, before the user had
-  // got anything out of the tool. Asking after they have is the same prompt at a
-  // moment it can be answered honestly.
+  // The timer additionally waits for a printable file this session. On the plain
+  // timer the ask arrived mid-task, before the user had got anything out of the
+  // tool, and was almost never acted on. Asking after they have is the same
+  // prompt at a moment it can be answered honestly.
   useEffect(() => {
     function checkAndShowNudge(): void {
       const nudgeOrder: NudgeType[] = ['feedback_rating'];

--- a/src/shared/pwa/staleRecovery.ts
+++ b/src/shared/pwa/staleRecovery.ts
@@ -13,12 +13,12 @@
  *
  * MUST stay wired to observed breakage, never to a version comparison. A
  * boot-time `gitSha !== __GIT_SHA__` test used to trigger this as well, which at
- * ~6 deploys/day fired for nearly every returning visitor — 29.7% of them in a
- * 30-day window — throwing away warm caches and forcing a full reload
- * mid-session on deploys where nothing was wrong. Removing that interruption is
- * all the removal was shown to buy: a two-build deploy-skew reproduction found
- * no asset 404s either with the check or without it, so it was never
- * established as a cause of the load failures it was written to repair.
+ * several deploys a day fired for nearly every returning visitor — throwing away
+ * warm caches and forcing a full reload mid-session on deploys where nothing was
+ * wrong. Removing that interruption is all the removal was shown to buy: a
+ * two-build deploy-skew reproduction found no asset 404s either with the check
+ * or without it, so it was never established as a cause of the load failures it
+ * was written to repair.
  * `handleWasmLoadFailure` is the correct shape: it recovers only when a load has
  * already failed with a stale-asset error.
  *

--- a/src/shell/Header/Header.test.tsx
+++ b/src/shell/Header/Header.test.tsx
@@ -251,7 +251,7 @@ describe('Header', () => {
     });
 
     // Gating the control put its only explanation in a tooltip, which touch
-    // devices never render — the dialog was opened zero times in 180 days.
+    // devices never render, leaving the export dialog effectively unreachable.
     // LayoutExportDialog carries the empty-state copy, so the button must stay
     // clickable for a user to ever reach it.
     it('stays enabled when no bins are linked', () => {

--- a/src/shell/Header/Header.tsx
+++ b/src/shell/Header/Header.tsx
@@ -90,8 +90,8 @@ export function Header({ saveStatus }: HeaderProps) {
   // Only bins linked to a saved design have printable geometry, but the button
   // stays live when none are: LayoutExportDialog explains the gap and names the
   // action that closes it. Gating the control instead put the sole explanation
-  // in a tooltip that touch devices never render, so the dialog was opened zero
-  // times before this changed.
+  // in a tooltip that touch devices never render, leaving the dialog
+  // effectively unreachable.
 
   // Platform detection for keyboard shortcut hints
   const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.userAgent);


### PR DESCRIPTION
Follow-up to #3512. Comments and the engagement README carried product figures — visitor share, nudge impression and click counts, dialog open counts. This is a public repository, so those are world-readable and permanent once merged.

Six places, all comments or prose. No behaviour changes, no test assertions touched.

| File | Was | Now |
| --- | --- | --- |
| `shared/pwa/staleRecovery.ts` | a visitor-share figure | "several deploys a day fired for nearly every returning visitor" |
| `shell/Header/Header.tsx` | a dialog open count | "leaving the dialog effectively unreachable" |
| `shell/Header/Header.test.tsx` | same count | "effectively unreachable" |
| `features/engagement/useEngagementNudges.ts` | impression-to-click counts | "was almost never acted on" |
| `features/engagement/useEngagementNudges.test.ts` | same counts | same |
| `features/engagement/README.md` | same counts | same |

The reasoning survives without the numbers, which is the tell that they were never load-bearing: a tooltip touch devices cannot render leaves the dialog unreachable whatever the open count was, and an ask that lands mid-task is badly timed whatever its click rate. The measurements belong in the analytics project.

Worth noting what this cannot reach: #3512's squashed commit message carries the same figures and is permanent. That is the argument for keeping them out of commit messages in the first place, not just out of the tree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces numeric product figures in comments and docs with concise reasoning to keep analytics data out of this public repository. No functional changes or test assertion updates.

**Review notes**
- Changes are prose-only in: `src/shared/pwa/staleRecovery.ts`, `src/shell/Header/Header.tsx`, `src/shell/Header/Header.test.tsx`, `src/features/engagement/useEngagementNudges.ts`, `src/features/engagement/useEngagementNudges.test.ts`, and `src/features/engagement/README.md`.
- Confirm that only comments changed and test logic remains identical.
- Keep metrics in the analytics project; do not include figures in comments or commit messages.

<sup>Written for commit b86e5fcbbfbc6973de92539e36d121a4c8629008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

