### PR TITLE
refactor(bin-designer): fold the foot lattice behind a disclosure

### DIFF
--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.test.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.test.tsx
@@ -61,6 +61,54 @@ describe('BaseSection', () => {
     });
   });
 
+  // The foot lattice is a power-user setting at its default on nearly every
+  // bin, so it is folded away — but a wrong lattice leaves the bin perched on
+  // the ridges between pockets, so a non-default value must never be the thing
+  // that got hidden.
+  describe('foot lattice disclosure', () => {
+    it('is collapsed at the default, showing only the summary', () => {
+      render(<BaseSection />);
+      expect(screen.getByText('On grid / On grid')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Width axis')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Depth axis')).not.toBeInTheDocument();
+    });
+
+    it('opens on click', async () => {
+      const user = userEvent.setup();
+      render(<BaseSection />);
+      await user.click(screen.getByRole('button', { name: /Foot lattice/ }));
+      expect(screen.getByLabelText('Width axis')).toBeInTheDocument();
+      expect(screen.getByLabelText('Depth axis')).toBeInTheDocument();
+    });
+
+    it('force-opens a non-default lattice rather than hiding it', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, footLatticeX: 'half' },
+        },
+      });
+      render(<BaseSection />);
+      expect(screen.getByLabelText('Width axis')).toBeInTheDocument();
+      expect(screen.getByText('Half offset / On grid')).toBeInTheDocument();
+    });
+
+    // A stored value the lock overrides is not a customization — the summary
+    // and the force-open both read the EFFECTIVE lattice, which is what the
+    // part actually gets built with.
+    it('stays collapsed when a stored lattice is overridden by half sockets', () => {
+      useDesignerStore.setState({
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true, footLatticeX: 'half' },
+        },
+      });
+      render(<BaseSection />);
+      expect(screen.getByText('On grid / On grid')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Width axis')).not.toBeInTheDocument();
+    });
+  });
+
   it('reveals the hole picker only once drainage is on', () => {
     const { unmount } = render(<BaseSection />);
     expect(screen.queryByLabelText('Hole shape')).not.toBeInTheDocument();

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -15,6 +15,7 @@ import { AdvancedDisclosure } from '../shared';
 import { PatternSelector } from '../WallsSection/PatternSelector';
 import {
   FLOOR_PATTERN_TYPES,
+  DEFAULT_FOOT_LATTICE,
   FOOT_LATTICES,
   LID_ATTACHMENTS,
   LID_EXTRA_HEIGHT_MAX_MM,
@@ -176,11 +177,23 @@ export function BaseSection() {
 
       {/* Foot lattice (#3467). A foot has to land inside one baseplate pocket,
           so which layout seats depends on where the bin sits — per axis, since
-          half-bin mode can offset one axis and not the other. */}
-      <div className="space-y-2 rounded border border-stroke-subtle p-2">
-        <span className="block text-xs font-medium text-content-secondary">
-          {t('binDesigner.footLattice')}
-        </span>
+          half-bin mode can offset one axis and not the other.
+
+          Folded away because it is a power-user setting that is at its default
+          on nearly every bin, and it was the heaviest block in this section.
+          `forceOpen` on a non-default value is what makes that safe: a wrong
+          lattice leaves the bin perched on the ridges between pockets, so the
+          one state that must never be hidden is the one that differs. The
+          summary reports the EFFECTIVE lattice, which is what gets built — a
+          stored value the lock overrides reads as the default it is being
+          honoured as, not as the customization it is not. */}
+      <AdvancedDisclosure
+        label={`${t('binDesigner.footLattice')}:`}
+        summary={footLatticeAxes
+          .map(({ value }) => t(`binDesigner.footLattice.${value}`))
+          .join(' / ')}
+        forceOpen={footLatticeAxes.some(({ value }) => value !== DEFAULT_FOOT_LATTICE)}
+      >
         {footLatticeAxes.map(({ axis, value, onChange, locked }) => (
           <div key={axis} className="flex items-center gap-2">
             <span className="w-10 shrink-0 text-[11px] text-content-tertiary">
@@ -204,7 +217,7 @@ export function BaseSection() {
         <p className="text-[11px] leading-relaxed text-content-tertiary">
           {handlers.footLatticeLockReason ?? t('binDesigner.footLattice.hint')}
         </p>
-      </div>
+      </AdvancedDisclosure>
 
       <FeatureToggle
         label={t('binDesigner.lightweight')}


### PR DESCRIPTION
Stacked on #3531 — retarget to `main` once that merges. (Supersedes the reference to #3526, which GitHub closed; see #3531.)

## Why

The foot lattice is a power-user setting: it only changes anything for a bin sitting half a unit off-grid, it is at its default on nearly every design, and it is outright inert on several (half sockets on, custom shape, fractional axis). It was rendered as a bordered box with a heading, two labelled axis controls and a four-line hint — permanently visible, and the heaviest block in the Base section by some margin.

It now collapses to a single 16px summary line, using the `AdvancedDisclosure` that `HandleSection` and `WallCutoutsSection` already use for exactly this.

## What keeps it safe to hide

`forceOpen` when either axis is non-default. A wrong lattice leaves the bin perched on the ridges between baseplate pockets rather than seated, so the one state that must never be the thing that got folded away is the state that differs from the default. `AdvancedDisclosure` was built with this in mind — "auto-expands when the values are non-default so customizations are never hidden."

The summary and the `forceOpen` test both read the **effective** lattice, not the stored one. A stored `half` that half sockets or a custom shape overrides is not a customization the user needs warning about — it is not what gets built — so it reads as the `On grid` it is actually being honoured as, and the lock reason is one click away rather than occupying four lines permanently.

Nothing else changes: both axis rows stay (the per-axis split is the whole reason the setting exists), the hint copy is untouched, and the stored params, lock rules and the `useFractionalEdgeMismatch` "Match layout" fix are all as they were.

## Before / after

| | before | after |
|---|---|---|
| collapsed height | ~180px bordered box | 16px text row |
| visible at default | heading + 2 controls + 4-line hint | `› Foot lattice: On grid / On grid` |
| non-default | same | expanded automatically |

## Tests

Four cases in `BaseSection.test.tsx`: collapsed at the default showing only the summary; opens on click; force-opens a non-default lattice; and stays collapsed when a stored lattice is overridden by half sockets. Verified in the running app, not just the DOM — the collapsed row measures 16px against the box it replaces.

`pnpm run quality` clean, full BaseSection suite green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds the foot lattice controls in `BaseSection` behind `AdvancedDisclosure` to declutter the Base section while keeping wrong lattices visible. Before: a permanently visible bordered block with a heading, two axis controls, and a hint. After: a single collapsed summary that auto-expands when the effective lattice differs from `DEFAULT_FOOT_LATTICE`.

- Summary and force-open use the effective lattice, so stored values overridden by locks (half sockets/custom shape) display “On grid” and do not force open.
- No change to parameters, lock rules, per-axis controls, or hint text; UI structure only.
- Tests cover: collapsed at default, opens on click, force-opens on non-default, and stays collapsed when an override applies.

<sup>Written for commit e48a2560d1cf977ae5c46f2d13c7cd326e87e91b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

