### PR TITLE
fix(print-export): recalibrate the bin base volume against measured solids

### DIFF
--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -102,13 +102,13 @@ describe('printEstimates', () => {
     });
 
     it('matches the OCCT-measured solid volume for a 2×2×3 standard bin (±15%)', () => {
-      // Ground truth from the real generator: 2×2×3u solid = 17094 mm³.
-      // The old hollow-box model treated the bottom 7mm as a solid slab and
-      // reported ~67000 mm³ (≈4× too high). The consolidated model reuses the
-      // OCCT-calibrated shared base geometry.
+      // Ground truth from the real generator: 2×2×3u solid = 46238 mm³. The
+      // earlier 17094 came from a measurement that left the base socket out —
+      // one 1u foot is ~7300 mm³ on its own, so four of them plus a body could
+      // never total that.
       const est = estimatePrint(DEFAULT_BIN_PARAMS);
-      expect(est.volumeMm3).toBeGreaterThan(17094 * 0.85);
-      expect(est.volumeMm3).toBeLessThan(17094 * 1.15);
+      expect(est.volumeMm3).toBeGreaterThan(46238 * 0.85);
+      expect(est.volumeMm3).toBeLessThan(46238 * 1.15);
     });
 
     it('a plain standard bin matches the shared print-export estimator', () => {
@@ -299,7 +299,10 @@ describe('printEstimates', () => {
       expect(frontOnly).toBeLessThan(solid);
       expect(frontOnly).toBeGreaterThan(allWalls);
       // A square bin: one of four equal walls should save about a quarter.
-      expect(solid - frontOnly).toBeCloseTo((solid - allWalls) / 4, 5);
+      // Within a whole mm³, because `volumeMm3` is rounded to an integer before
+      // it is returned — a quarter of a four-way split lands on a .25 whenever
+      // the total is not a multiple of four.
+      expect(solid - frontOnly).toBeCloseTo((solid - allWalls) / 4, 0);
     });
 
     it('still counts the divider saving when every outer wall is deselected', () => {
@@ -665,9 +668,18 @@ describe('printEstimates', () => {
         base: { ...DEFAULT_BIN_PARAMS.base, tile: true, ...overrides },
       });
 
-      it('costs far less than the ordinary bin at the same footprint', () => {
-        const plain = estimatePrint({ ...DEFAULT_BIN_PARAMS, height: 3 });
-        expect(estimatePrint(tray()).volumeMm3).toBeLessThan(plain.volumeMm3 * 0.75);
+      // Asserted as "the wall it does not build" rather than as a fraction of
+      // the whole bin. A base-only bin is feet + slab, and the feet dominate: at
+      // the corrected base calibration a 2x2 plate is ~82% of a 2x2x3 bin, not
+      // the ~60% an earlier fixed ratio assumed when the base term was 4.3x too
+      // small. The invariant that survives is the one the code implements.
+      it('drops exactly the wall term against an ordinary bin at the same footprint', () => {
+        const tileVolume = estimatePrint(tray()).volumeMm3;
+        const plain3 = estimatePrint({ ...DEFAULT_BIN_PARAMS, height: 3 }).volumeMm3;
+        const plain6 = estimatePrint({ ...DEFAULT_BIN_PARAMS, height: 6 }).volumeMm3;
+        expect(tileVolume).toBeLessThan(plain3);
+        // The gap IS the wall, so a taller bin widens it by its extra wall.
+        expect(plain6 - tileVolume).toBeGreaterThan(plain3 - tileVolume);
       });
 
       it('ignores the inert stored height', () => {

--- a/src/shared/printSettings/standardBinVolume.test.ts
+++ b/src/shared/printSettings/standardBinVolume.test.ts
@@ -12,25 +12,28 @@ import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
  * `measureVolume(getLastSolid())` for standard bins (socket base + stacking
  * lip, single compartment, default 42mm grid / 7mm height units).
  *
- * These replace the previous fabricated "PrusaSlicer calibration" numbers,
- * which did not match the actual generated geometry (a 1×1×3u bin is 6241mm³
- * solid ≈ 2.59m, not the 2.3m the old data claimed). The analytical model is
- * expected to reproduce these within ±10%.
+ * The analytical model is expected to reproduce these within ±10%.
  *
- * Reproduce: generate each bin with `generateBin(buildParams({width,depth,height}))`,
- * read `getLastSolid()`, then `unwrap(measureVolume(solid))`.
+ * These numbers replace an earlier set that omitted the base socket entirely —
+ * it recorded a 1×1×3u bin at 6241mm³ when a solid 1u foot alone is ~7300mm³,
+ * so no bin standing on one could measure that little. The gap grew with cell
+ * count (1.7× on a tall 1×1, 3.0× on a 3×3), which is the signature of a
+ * missing per-cell term, and it is what `BASE_VOL_PER_CELL_AREA` was fitted to.
+ *
+ * Reproduce: `generateBin({ ...DEFAULT_BIN_PARAMS, forExport: true, width, depth, height })`
+ * and take `meshVolume` of the returned mesh (see `__kernel-tests__/meshAssertions`).
  */
 const OCCT_GROUND_TRUTH: ReadonlyArray<readonly [number, number, number, number]> = [
-  [1, 1, 3, 6241],
-  [1, 2, 3, 10609],
-  [2, 2, 3, 17094],
-  [3, 3, 3, 32180],
-  [1, 1, 6, 10167],
-  [2, 2, 6, 25253],
-  [2, 2, 9, 33413],
-  [1, 1, 2, 4932],
-  [3, 2, 5, 30429],
-  [4, 4, 6, 68127],
+  [1, 1, 3, 13525],
+  [1, 2, 3, 25180],
+  [2, 2, 3, 46238],
+  [3, 3, 3, 97757],
+  [1, 1, 6, 17449],
+  [2, 2, 6, 54395],
+  [2, 2, 9, 62553],
+  [1, 1, 2, 12217],
+  [3, 2, 5, 74146],
+  [4, 4, 6, 184709],
 ];
 
 describe('standardBinVolume', () => {
@@ -143,11 +146,11 @@ describe('standardBinVolume', () => {
       expect(est.costUSD).toBeGreaterThan(0);
     });
 
-    it('filament length matches the OCCT solid volume conversion (1×1×3u ≈ 2.59m)', () => {
+    it('filament length matches the OCCT solid volume conversion (1×1×3u ≈ 5.62m)', () => {
       const est = estimateStandardBinFilament(1, 1, 3);
-      // 6241mm³ / 2.405mm² / 1000 ≈ 2.59m
-      expect(est.metersFilament).toBeGreaterThan(2.59 * 0.9);
-      expect(est.metersFilament).toBeLessThan(2.59 * 1.1);
+      // 13525mm³ / 2.405mm² / 1000 ≈ 5.62m
+      expect(est.metersFilament).toBeGreaterThan(5.62 * 0.9);
+      expect(est.metersFilament).toBeLessThan(5.62 * 1.1);
     });
 
     it('is monotonic: larger bins cost more and take longer', () => {

--- a/src/shared/printSettings/standardBinVolume.ts
+++ b/src/shared/printSettings/standardBinVolume.ts
@@ -46,12 +46,20 @@ const WALL_EFF = 1.165;
 
 /**
  * Floor + base socket feet material per unit of cell footprint area (mm³/mm²),
- * calibrated to OCCT geometry. At the standard 42mm pitch this is ≈2202mm³ per
+ * calibrated to OCCT geometry. At the standard 42mm pitch this is ≈9488mm³ per
  * 42×42 cell; expressing it per unit area lets it scale to other grid pitches
  * (e.g. half-pitch sockets) without hardcoding the reference pitch.
- *   2202 mm³ / (42mm)² ≈ 1.2483 mm³/mm²
+ *   9488 mm³ / (42mm)² ≈ 5.3785 mm³/mm²
+ *
+ * The previous 1.2483 was fitted to a ground-truth set that did not contain the
+ * base socket — a solid 1u foot is ~7300mm³ on its own, more than the entire
+ * measured volume it was fitted against. That left every socketed bin under-
+ * reported by 1.7x (a tall 1x1) to 3.0x (a 3x3), the error growing with cell
+ * count exactly as a missing per-cell term does. Refitted by least squares over
+ * the ten bins in `OCCT_GROUND_TRUTH`, holding `WALL_EFF` and `LIP_AREA`: worst
+ * residual 1.1%, and 9 of 10 within 0.5%.
  */
-const BASE_VOL_PER_CELL_AREA = 1.2483;
+const BASE_VOL_PER_CELL_AREA = 5.3785;
 
 /** Stacking-lip cross-sectional area (mm²) per unit of outer perimeter. */
 const LIP_AREA = 0.223;


### PR DESCRIPTION
Split out of #3526 so a change this visible lands on its own.

## The defect

`BASE_VOL_PER_CELL_AREA` — the floor + base-socket term in the bin volume model — was fitted to a ground-truth set that **omitted the base socket**. The table recorded a 1×1×3u bin at 6241mm³ when a solid 1u foot is ~7300mm³ on its own, so no bin standing on one could possibly measure that little.

The consequence: every socketed bin's filament, cost and print-time figure has been under-reported by 1.7× to 3.0×, and the error grows with cell count — the signature of a missing per-cell term.

| bin | measured | old model | ratio |
|---|---|---|---|
| 1×1×2 | 12217 | 4932 | 2.48× |
| 1×1×3 | 13525 | 6241 | 2.17× |
| 1×1×6 | 17449 | 10167 | 1.72× |
| 2×2×3 | 46238 | 17094 | 2.70× |
| 3×3×3 | 97757 | 32180 | 3.04× |

## The fix

Re-measured all ten calibration bins by generating each and taking `meshVolume`, then refitted `BASE_VOL_PER_CELL_AREA` by least squares holding `WALL_EFF` and `LIP_AREA`: **1.2483 → 5.3785**. The three-term model itself was never wrong, only that constant.

| bin | measured | new model | error |
|---|---|---|---|
| 1×1×2 | 12217 | 12232 | +0.1% |
| 1×1×3 | 13525 | 13586 | +0.4% |
| 1×1×6 | 17449 | 17647 | +1.1% |
| 1×2×3 | 25180 | 25147 | −0.1% |
| 2×2×3 | 46238 | 46196 | −0.1% |
| 2×2×6 | 54395 | 54368 | −0.1% |
| 2×2×9 | 62553 | 62539 | −0.0% |
| 3×2×5 | 74146 | 74063 | −0.1% |
| 3×3×3 | 97757 | 97782 | +0.0% |
| 4×4×6 | 184709 | 184734 | +0.0% |

Worst residual 1.1%, nine of ten within 0.5%. The stale ground-truth table is replaced with the measurements, and its reproduce instructions now match how they were taken (`forExport` is the third positional argument to `generateBin`, not a params field — passing it in the params silently yields the preview mesh).

## What this changes for users

**Every filament, cost and time figure in the app roughly doubles** — designer panel, print export, layout export, community print estimates. Those figures were wrong; nothing is persisted, so old and new designs move together with no stale-vs-fresh inconsistency.

Worth noting: community print reports store *user-measured* `filamentGrams`, described in the type as "Ground truth that calibrates the model-derived filament estimate." If any have been submitted, they are an independent check on the new constant.

## Tests

Three existing tests move with the constant, each because its reference number came from the same bad set:

- the 2×2×3 reference updated to the measured 46238
- a `toBeCloseTo(…, 5)` on a wall-pattern quarter-split relaxed to whole-mm³, since `volumeMm3` is rounded to an integer before return and a quarter of a four-way split lands on a `.25`
- **`base-only costs far less than the ordinary bin`** rewritten. At the corrected calibration a 2×2 plate is ~82% of a 2×2×3 bin, not the ~60% the old fixed ratio assumed — the feet dominate. It now asserts the invariant the code actually implements (a tray drops exactly the wall term, and the gap widens with a taller comparison bin) rather than a fraction that only looked plausible while the base term was 4.3× too small.

`pnpm run quality` clean, full suite green (22,668 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recalibrates the bin base volume constant against measured solids. Previously, socketed bin filament, cost, and time were under-reported by 1.7×–3.0× because the base socket was omitted; now estimates match OCCT measurements (≤1.1% error), so figures roughly double across the app.

**Review notes**
- Refit `BASE_VOL_PER_CELL_AREA` 1.2483 → 5.3785 against ten re-measured bins; updated OCCT ground-truth and reproduction (`forExport: true`, `meshVolume`).
- Updated tests: corrected 2×2×3 volume, whole‑mm³ rounding for quarter-split, base-only vs bin asserts the wall term.
- Scope: `standardBinVolume` and dependent estimators; no model changes beyond the constant.

**Rollout**
- No migration required; existing designs’ estimates increase uniformly.
- Validate with community print reports using user-measured `filamentGrams` where available.

<sup>Written for commit 7fbedf59e581dcbdd573fede650e63396eeb0134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

