### PR TITLE
fix(bin-inspector): measure the stacking junction instead of assuming the lip

### DIFF
--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -6,7 +6,12 @@ import { ArrowLeftRightIcon, LockIcon, LockOpenIcon, RulerIcon } from '@/design-
 import { useHalfGridModeStore } from '@/core/store/halfGridMode';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { getBinLocationContext, isBinLocked } from '@/shared/utils/binLocation';
-import { formatHeightUnits, isStandardStackHeight, STACK_LIP_MM } from '@/shared/utils/heightUnits';
+import {
+  formatHeightUnits,
+  isStandardStackHeight,
+  LIP_PROTRUSION_MM,
+  stackPitchMm,
+} from '@/shared/utils/heightUnits';
 import type { UseBinInspectorReturn } from '@/features/bin-inspector/hooks/useBinInspector';
 import { SplitWarning } from '../SplitWarning';
 import { BinLabelField } from '../BinLabelField';
@@ -291,8 +296,8 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
             <div>{`${minHeightHint} · ${maxHeightHint}`}</div>
             <div>
               {t('inspector.printedAndStackHint', {
-                printed: heightMmAt(bin.height, STACK_LIP_MM),
-                pitch: heightMmAt(bin.height),
+                printed: heightMmAt(bin.height, LIP_PROTRUSION_MM),
+                pitch: formatMmValue(stackPitchMm(bin.height, layout.heightUnitMm)),
               })}
             </div>
             {!isStandardStackHeight(bin.height, layout.heightUnitMm) && (

--- a/src/features/generation/worker/generators/__kernel-tests__/binStacking.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/binStacking.ts
@@ -1,0 +1,66 @@
+/**
+ * Stack one generated bin on another and measure what the joint actually does.
+ *
+ * The tool prints two numbers per bin — "Prints Xmm · stacks +Ymm each" — and
+ * both come from `stackedTotalMm`, which asserts the bin nests until its socket
+ * bottoms out on the lip below: every added bin advances the stack by its body
+ * height, and only the topmost lip is left showing. That is a claim about two
+ * solids meeting, and neither mesh can confirm it. Each bin is watertight and
+ * correctly sized on its own whatever happens at the joint (CLAUDE.md gotchas
+ * #14, #15, #18), and a test that recomputes `LIP_HEIGHT - LIP_OVERLAP` only
+ * proves the constant equals itself.
+ *
+ * So this mates the pair, lets the upper bin fall, and reports the pitch it
+ * came to rest at. It reuses `seatDepth` rather than reimplementing the
+ * descent: the question is the same one the baseplate probe asks, of a
+ * different partner, and it is unaimed on purpose — a joint landing somewhere
+ * nobody predicted still registers.
+ */
+
+import { seatDepth, type Placement } from './binSeating';
+import { boundingBox } from './meshAssertions';
+import type { MeshData } from '@/features/generation/bridge/types';
+
+/** Directly on top — the only placement a stack has. */
+const ON_TOP: Placement = { dx: 0, dy: 0 };
+
+export interface StackSeat {
+  /** Height the assembled pair spans, in mm. What a caliper reads. */
+  readonly totalMm: number;
+  /** Height the upper bin adds to the stack, in mm. The UI's "stacks +Ymm". */
+  readonly pitchMm: number;
+  /** Lower bin's lip left standing proud of the joint, in mm. */
+  readonly junctionMm: number;
+  /** Column the pair first touched at — where to look when a number is wrong. */
+  readonly x: number;
+  readonly y: number;
+}
+
+function spanZ(mesh: MeshData): number {
+  const bb = boundingBox(mesh.vertices);
+  return bb.maxZ - bb.minZ;
+}
+
+/**
+ * Drops `upper` onto `lower` and reports the resulting stack.
+ *
+ * Non-finite fields mean the sweep never found contact, which for two bins
+ * sharing a footprint can only be a probe failure rather than a real gap —
+ * check `Number.isFinite` before reading the numbers.
+ */
+export function stackSeat(
+  upper: MeshData,
+  lower: MeshData,
+  place: Placement = ON_TOP,
+  step?: number
+): StackSeat {
+  const { mm: junctionMm, x, y } = seatDepth(upper, lower, place, step);
+  const upperSpan = spanZ(upper);
+  return {
+    junctionMm,
+    pitchMm: upperSpan - junctionMm,
+    totalMm: spanZ(lower) + upperSpan - junctionMm,
+    x,
+    y,
+  };
+}

--- a/src/features/generation/worker/generators/__kernel-tests__/binStacking.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/binStacking.ts
@@ -1,14 +1,14 @@
 /**
  * Stack one generated bin on another and measure what the joint actually does.
  *
- * The tool prints two numbers per bin — "Prints Xmm · stacks +Ymm each" — and
- * both come from `stackedTotalMm`, which asserts the bin nests until its socket
- * bottoms out on the lip below: every added bin advances the stack by its body
- * height, and only the topmost lip is left showing. That is a claim about two
- * solids meeting, and neither mesh can confirm it. Each bin is watertight and
- * correctly sized on its own whatever happens at the joint (CLAUDE.md gotchas
- * #14, #15, #18), and a test that recomputes `LIP_HEIGHT - LIP_OVERLAP` only
- * proves the constant equals itself.
+ * The inspector prints two numbers per bin, "Prints Xmm · stacks +Ymm each":
+ * the first from `LIP_PROTRUSION_MM`, the second from `stackPitchMm`, with
+ * `stackedTotalMm` behind the stack solver's total. All three rest on one
+ * claim — how deep the bin above settles onto the lip below — and neither mesh
+ * can confirm it. Each bin is watertight and correctly sized on its own
+ * whatever happens at the joint (CLAUDE.md gotchas #14, #15, #18), and a test
+ * that recomputes the constant from the profiles it came from only proves it
+ * equals itself.
  *
  * So this mates the pair, lets the upper bin fall, and reports the pitch it
  * came to rest at. It reuses `seatDepth` rather than reimplementing the

--- a/src/features/generation/worker/generators/binStackSeating.kernel.test.ts
+++ b/src/features/generation/worker/generators/binStackSeating.kernel.test.ts
@@ -88,9 +88,18 @@ function bin(spec: Spec = {}): MeshData {
   return mesh;
 }
 
-const junctionOf = (spec: Spec = {}): number => {
+/**
+ * Sweep step for the invariance cases, in mm. The joint is a full-face mate
+ * around the whole perimeter, so hundreds of columns read the same depth and a
+ * coarse grid still lands on it — worth 4x the sweep cost on a shard whose
+ * neighbours run near their timeouts. The primary measurement below keeps the
+ * default fine step, where the exact number is what is being claimed.
+ */
+const COARSE_STEP_MM = 4;
+
+const junctionOf = (spec: Spec = {}, step?: number): number => {
   const mesh = bin(spec);
-  return stackSeat(mesh, mesh).junctionMm;
+  return stackSeat(mesh, mesh, undefined, step).junctionMm;
 };
 
 describe('bin-on-bin stacking (#2374)', () => {
@@ -108,17 +117,17 @@ describe('bin-on-bin stacking (#2374)', () => {
     // The discriminating case, and the reporter's calculator fails it: one
     // physical joint reads one number, so a constant per configuration — 5.40
     // for halves, 4.87 for quarters, 5.00 for thirds — cannot be describing it.
+    // One case per axis the junction could plausibly depend on: body height,
+    // footprint, and a non-standard unit. Intermediate sizes are the same
+    // geometry extruded further and were measured at 4.75 too.
     const cases: Spec[] = [
-      { height: 3 },
-      { height: 6 },
       { height: 12 },
       { width: 1, depth: 1 },
       { width: 3, depth: 2, height: 4 },
       { heightUnitMm: 4.37 },
-      { height: 5, heightUnitMm: 12.6 },
     ];
     for (const spec of cases) {
-      expect(junctionOf(spec), JSON.stringify(spec)).toBeCloseTo(JUNCTION_MM, 1);
+      expect(junctionOf(spec, COARSE_STEP_MM), JSON.stringify(spec)).toBeCloseTo(JUNCTION_MM, 1);
     }
   }, 600000);
 

--- a/src/features/generation/worker/generators/binStackSeating.kernel.test.ts
+++ b/src/features/generation/worker/generators/binStackSeating.kernel.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment node
+/**
+ * What a stack of bins really measures (discussion #2374, fixed in #3525).
+ *
+ * A reporter's calculator put the bin-to-bin junction at 4.87-5.40mm and varied
+ * it by configuration; the tool used to answer a flat 4.30mm at every height,
+ * on the grounds that the socket bottoms out on the lip and cannot sink
+ * further. Both were arguments rather than measurements, and every mesh check
+ * passed either way.
+ *
+ * Mating the two solids says both were partly right. The junction IS one
+ * constant, as the tool argued — it does not move with bin height, footprint or
+ * height unit, so a per-configuration constant cannot be describing it. But the
+ * constant is 4.75mm: the foot's flare and the lip's funnel are parallel 45
+ * degree surfaces that mate face to face, so the bin above settles one BASE
+ * profile below the lip top, not one lip. The old figure was 0.45mm shy of it
+ * and every stack readout inherited the error.
+ *
+ * The value is stated below as a measurement and never derived. Recomputing it
+ * from the socket and lip profiles would only prove the arithmetic
+ * self-consistent — the trap that left the question open for two rounds
+ * (CLAUDE.md gotchas #14, #18) — so the point of these cases is that a number
+ * read off the assembled solids agrees with `STACK_JUNCTION_MM`.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { BinParams } from '@/shared/types/bin';
+import type { MeshData } from '@/features/generation/bridge/types';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { STACK_JUNCTION_MM, stackPitchMm, stackedTotalMm } from '@/shared/utils/heightUnits';
+import { initTestKernel } from '@/test/initTestKernel';
+import { stackSeat } from './__kernel-tests__/binStacking';
+
+let generateBin: (params: BinParams, onProgress: undefined, forExport: boolean) => MeshData;
+
+beforeAll(async () => {
+  await initTestKernel();
+  generateBin = (await import('./binOrchestrator')).generateBin;
+}, 60000);
+
+/**
+ * The junction the assembled pair actually comes to rest at, in mm. Measured
+ * across every case below and unchanging; update it only from a fresh sweep,
+ * never from `STACK_JUNCTION_MM` — the two agreeing is the assertion.
+ */
+const JUNCTION_MM = 4.75;
+
+/**
+ * Tessellation slack, in mm. The contact is taper-on-taper, so both faces are
+ * planar and the read is near-exact; this leaves room for corner faceting
+ * without admitting the 0.45mm the old readout was out by.
+ */
+const TOLERANCE_MM = 0.05;
+
+interface Spec {
+  width?: number;
+  depth?: number;
+  height?: number;
+  heightUnitMm?: number;
+  stackingLip?: boolean;
+}
+
+const cache = new Map<string, MeshData>();
+
+function bin(spec: Spec = {}): MeshData {
+  const { width = 2, depth = 2, height = 3, heightUnitMm = 7, stackingLip = true } = spec;
+  const key = `${width}x${depth}x${height}/${heightUnitMm}/${stackingLip}`;
+  let mesh = cache.get(key);
+  if (!mesh) {
+    // Export fidelity, not preview: the preview path meshes the base socket
+    // separately and concatenates it, and the surviving coincident
+    // socket-top/floor-bottom faces flip `verticalSolidSpans`' enter/exit
+    // parity. The probe then reads the cavity as solid and the joint as 5.00.
+    mesh = generateBin(
+      {
+        ...DEFAULT_BIN_PARAMS,
+        width,
+        depth,
+        height,
+        heightUnitMm,
+        base: { ...DEFAULT_BIN_PARAMS.base, stackingLip },
+      },
+      undefined,
+      true
+    );
+    cache.set(key, mesh);
+  }
+  return mesh;
+}
+
+const junctionOf = (spec: Spec = {}): number => {
+  const mesh = bin(spec);
+  return stackSeat(mesh, mesh).junctionMm;
+};
+
+describe('bin-on-bin stacking (#2374)', () => {
+  it('sees one bin sink into the next', () => {
+    // Baseline: if this fails the probe is wrong, not the geometry. A bin that
+    // perched on the rim instead of nesting would add its whole printed height.
+    const mesh = bin();
+    const seat = stackSeat(mesh, mesh);
+    expect(Number.isFinite(seat.junctionMm)).toBe(true);
+    expect(seat.junctionMm).toBeGreaterThan(0);
+    expect(seat.pitchMm).toBeLessThan(seat.totalMm / 2);
+  }, 180000);
+
+  it('makes the same joint at every height, footprint and height unit', () => {
+    // The discriminating case, and the reporter's calculator fails it: one
+    // physical joint reads one number, so a constant per configuration — 5.40
+    // for halves, 4.87 for quarters, 5.00 for thirds — cannot be describing it.
+    const cases: Spec[] = [
+      { height: 3 },
+      { height: 6 },
+      { height: 12 },
+      { width: 1, depth: 1 },
+      { width: 3, depth: 2, height: 4 },
+      { heightUnitMm: 4.37 },
+      { height: 5, heightUnitMm: 12.6 },
+    ];
+    for (const spec of cases) {
+      expect(junctionOf(spec), JSON.stringify(spec)).toBeCloseTo(JUNCTION_MM, 1);
+    }
+  }, 600000);
+
+  it('rests where STACK_JUNCTION_MM says it does', () => {
+    // Measurement against the constant the app derives from the profiles. These
+    // are computed two different ways on purpose: if the profiles move and the
+    // derivation does not follow, this is what notices.
+    expect(STACK_JUNCTION_MM).toBeCloseTo(JUNCTION_MM, 2);
+    expect(junctionOf()).toBeCloseTo(STACK_JUNCTION_MM, 1);
+  }, 180000);
+
+  it('reaches the total the inspector prints', () => {
+    // What a caliper reads against what the panel says, for one junction.
+    const seat = stackSeat(bin(), bin());
+    expect(seat.pitchMm).toBeCloseTo(stackPitchMm(3, 7), 1);
+    expect(seat.totalMm).toBeCloseTo(stackedTotalMm(3, 7, 2), 1);
+    expect(Math.abs(stackedTotalMm(3, 7, 2) - seat.totalMm)).toBeLessThan(TOLERANCE_MM);
+  }, 180000);
+
+  it('does not make that joint without a lip to nest into', () => {
+    // Control: the probe reads the joint rather than returning a constant.
+    expect(junctionOf({ stackingLip: false })).toBeLessThan(JUNCTION_MM - 0.5);
+  }, 180000);
+});

--- a/src/features/generation/worker/generators/lipNesting.scenario.divisibility.test.ts
+++ b/src/features/generation/worker/generators/lipNesting.scenario.divisibility.test.ts
@@ -1,26 +1,29 @@
 // @vitest-environment node
 /**
- * Gridfinity stacking divisibility guard.
+ * Where a stacked bin actually seats, and what that costs divisibility.
  *
- * The reporter believed stacks overshoot because each bin carries a 4.3mm lip.
- * They don't: the lip nests into the socket of the bin above, so the stacking
- * pitch equals the bin's BODY height (`height × heightUnitMm`), and only the
- * topmost lip is exposed. Two H-unit bins therefore stack to exactly the height
- * of one 2H-unit bin. The fix relies on this invariant (see
- * `stackPitchMm`/`stackedTotalMm` in `heightUnits.ts`) rather than changing the
- * geometry — so this asserts the geometry actually keeps its side of the
- * bargain, measured on the real generated solid.
+ * This guard was written (#2416) for the claim that the pitch equals the bin's
+ * BODY height, so two H-unit bins stack to exactly one 2H-unit bin. Mating the
+ * solids disproved it (#3525): the bin above settles `STACK_JUNCTION_MM` below
+ * the lip top, which is one base profile rather than one lip, so the pitch runs
+ * 0.45mm under the body and a 2-bin stack lands that much short of the single
+ * tall bin. Divisibility is off by 0.45mm per junction, not exact.
  *
- * Method: generate a bin, drop an identical copy onto it via CSG, and check the
- * collision-free seat is at body height (lip fully nested), then confirm a
- * body-height stack equals the single 2H bin's mesh height.
+ * The original method could not have caught it: it asked whether the pair
+ * INTERSECTS at body height, and a bin resting 0.45mm lower does not intersect
+ * there — it floats clear. Non-interference brackets the seat between two
+ * pitches; it never locates it. So the seat is now pinned from both sides, a
+ * tenth of a millimetre apart, which is a measurement rather than a bound.
+ *
+ * CSG volume here, ray descent in `binStackSeating.kernel.test.ts` — two
+ * independent methods on the same joint, deliberately.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { measureVolume, translate, intersect } from 'brepjs';
 import { isOk } from '@/core/result';
 import type { BinParams } from '@/shared/types/bin';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
-import { STACK_LIP_MM } from '@/shared/utils/heightUnits';
+import { LIP_PROTRUSION_MM, STACK_JUNCTION_MM, stackPitchMm } from '@/shared/utils/heightUnits';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import { getLastSolid, clearAllCaches } from './shapeCache';
 
@@ -66,13 +69,17 @@ beforeAll(async () => {
   await initBrepjs();
 }, 60000);
 
+/** How far below the seat the pair is probed for the interference side. */
+const PROBE_MM = 0.1;
+
 /**
  * @param label human-readable config name
  * @param height single-bin height in units; the stack of two is checked against
  *   a bin of `2 × height` units at the same unit size.
  */
-function assertDivisibility(label: string, base: BinParams, height: number): void {
+function assertSeating(label: string, base: BinParams, height: number): void {
   const bodyH = height * base.heightUnitMm;
+  const pitch = stackPitchMm(height, base.heightUnitMm);
   const generateBin = getGenerateBin();
 
   clearAllCaches();
@@ -82,37 +89,43 @@ function assertDivisibility(label: string, base: BinParams, height: number): voi
   if (!solid) throw new Error(`${label}: no solid`);
 
   // One bin prints to body + exactly one lip.
-  expect(singleH, `${label}: single-bin height`).toBeCloseTo(bodyH + STACK_LIP_MM, 1);
+  expect(singleH, `${label}: single-bin height`).toBeCloseTo(bodyH + LIP_PROTRUSION_MM, 1);
 
-  // Seats cleanly at body height (lip nests into the socket above)…
-  expect(overlapAtPitch(solid, bodyH), `${label}: overlap at body-height pitch`).toBeLessThan(0.05);
-  // …and the seat is real geometry, not two hollow shells passing through each
-  // other — dropping 1mm lower drives the lip hard into the socket.
-  expect(overlapAtPitch(solid, bodyH - 1), `${label}: overlap below the seat`).toBeGreaterThan(5);
+  // The seat, pinned from both sides. Clear at the pitch the readout quotes…
+  expect(overlapAtPitch(solid, pitch), `${label}: overlap at the quoted pitch`).toBeLessThan(0.05);
+  // …and biting a tenth of a millimetre lower, so the pair really does come to
+  // rest here rather than somewhere in a gap this test never looked at.
+  expect(
+    overlapAtPitch(solid, pitch - PROBE_MM),
+    `${label}: overlap just below the seat`
+  ).toBeGreaterThan(0);
+
+  // Body height is NOT the seat: the bin above still floats there.
+  expect(pitch, `${label}: pitch sits under body height`).toBeLessThan(bodyH);
 
   clearAllCaches();
   const doubleBin = generateBin({ ...base, height: height * 2 }, undefined, true);
   const doubleH = meshHeight(doubleBin.vertices);
 
-  // Divisibility: two H-unit bins stacked at body-height pitch reach exactly the
-  // height of one 2H-unit bin.
-  expect(bodyH + singleH, `${label}: 2×${height}u stack vs 1×${height * 2}u bin`).toBeCloseTo(
-    doubleH,
+  // Divisibility, and how far it misses: two H-unit bins stack to one junction
+  // less than the single 2H-unit bin standing beside them.
+  expect(pitch + singleH, `${label}: 2×${height}u stack vs 1×${height * 2}u bin`).toBeCloseTo(
+    doubleH - (STACK_JUNCTION_MM - LIP_PROTRUSION_MM),
     1
   );
 }
 
-describe('stacking divisibility — nested lip keeps 2×Hu == 1×2Hu (#2416)', () => {
+describe('stacking seat — where a bin rests on the lip below (#2416, #3525)', () => {
   it(
     'holds at the standard 7mm unit',
-    () => assertDivisibility('7mm 3u', { ...DEFAULT_BIN_PARAMS, width: 2, depth: 2 }, 3),
+    () => assertSeating('7mm 3u', { ...DEFAULT_BIN_PARAMS, width: 2, depth: 2 }, 3),
     180_000
   );
 
   it(
     'holds at a custom non-standard unit',
     () =>
-      assertDivisibility(
+      assertSeating(
         'custom 9.362mm 2u',
         { ...DEFAULT_BIN_PARAMS, width: 2, depth: 2, heightUnitMm: 9.362 },
         2

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -3135,7 +3135,7 @@
   "snapshots.saveCheckpoint": "Uložit kontrolní bod",
   "stackSolver.apply": "Použít {unit} mm/jednotku",
   "stackSolver.binsLabel": "Binů ve stohu",
-  "stackSolver.description": "Stohované biny se do sebe zasunou, takže stoh je (biny × jednotky × velikost jednotky) + jeden lem {lip} mm.",
+  "stackSolver.description": "Stohované biny se do sebe zasunou o {junction} mm, takže každý přidá o {shortfall} mm méně, než je výška jeho těla.",
   "stackSolver.outOfRange": "Jednotka by spadla mimo {min}–{max} mm",
   "stackSolver.overlayPitch": "stohuje +{pitch} mm",
   "stackSolver.result": "Stohuje se do {total} mm",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3327,7 +3327,7 @@
   "snapshots.saveCheckpoint": "Checkpoint speichern",
   "stackSolver.apply": "{unit}mm/Einheit verwenden",
   "stackSolver.binsLabel": "Bins im Stapel",
-  "stackSolver.description": "Gestapelte Bins verschachteln sich, ein Stapel ist also (Bins × Einheiten × Einheitsgröße) + eine {lip}mm-Lippe.",
+  "stackSolver.description": "Gestapelte Bins verschachteln sich {junction}mm ineinander, jeder fügt also {shortfall}mm weniger als seine Korpushöhe hinzu.",
   "stackSolver.outOfRange": "Einheit läge außerhalb von {min}–{max}mm",
   "stackSolver.overlayPitch": "stapelt +{pitch}mm",
   "stackSolver.result": "Stapelt auf {total}mm",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -959,7 +959,7 @@ const en: Record<string, string> = {
   'settings.resetGridfinityStandard': 'Reset to Gridfinity Standard',
   'stackSolver.title': 'Fit unit to stack',
   'stackSolver.description':
-    'Stacked bins nest, so a stack is (bins × units × unit size) + one {lip}mm lip.',
+    'Stacked bins nest {junction}mm into each other, so each one adds {shortfall}mm less than its body height.',
   'stackSolver.targetLabel': 'Target height (mm)',
   'stackSolver.binsLabel': 'Bins in stack',
   'stackSolver.unitsPerBinLabel': 'Units per bin',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3327,7 +3327,7 @@
   "snapshots.saveCheckpoint": "Guardar punto de control",
   "stackSolver.apply": "Usar {unit}mm/unidad",
   "stackSolver.binsLabel": "Bins en la pila",
-  "stackSolver.description": "Los bins apilados se encajan, así que una pila es (bins × unidades × tamaño de unidad) + un labio de {lip}mm.",
+  "stackSolver.description": "Los bins apilados se encajan {junction}mm entre sí, así que cada uno suma {shortfall}mm menos que la altura de su cuerpo.",
   "stackSolver.outOfRange": "La unidad quedaría fuera de {min}–{max}mm",
   "stackSolver.overlayPitch": "apila +{pitch}mm",
   "stackSolver.result": "Se apila hasta {total}mm",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3135,7 +3135,7 @@
   "snapshots.saveCheckpoint": "Sauvegarder un point",
   "stackSolver.apply": "Utiliser {unit}mm/unité",
   "stackSolver.binsLabel": "Bacs dans la pile",
-  "stackSolver.description": "Les bacs empilés s’emboîtent : une pile vaut (bacs × unités × taille d’unité) + une lèvre de {lip}mm.",
+  "stackSolver.description": "Les bacs empilés s’emboîtent de {junction}mm, donc chacun ajoute {shortfall}mm de moins que la hauteur de son corps.",
   "stackSolver.outOfRange": "L’unité serait hors de {min}–{max}mm",
   "stackSolver.overlayPitch": "empile +{pitch}mm",
   "stackSolver.result": "S’empile jusqu’à {total}mm",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3327,7 +3327,7 @@
   "snapshots.saveCheckpoint": "Salva checkpoint",
   "stackSolver.apply": "Usa {unit}mm/unità",
   "stackSolver.binsLabel": "Bin nella pila",
-  "stackSolver.description": "I bin impilati si annidano, quindi una pila è (bin × unità × dimensione unità) + un labbro da {lip}mm.",
+  "stackSolver.description": "I bin impilati si annidano di {junction}mm l’uno nell’altro, quindi ognuno aggiunge {shortfall}mm in meno della propria altezza del corpo.",
   "stackSolver.outOfRange": "L'unità cadrebbe fuori da {min}–{max}mm",
   "stackSolver.overlayPitch": "impila +{pitch}mm",
   "stackSolver.result": "Si impila a {total}mm",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3327,7 +3327,7 @@
   "snapshots.saveCheckpoint": "チェックポイントを保存",
   "stackSolver.apply": "{unit}mm/ユニットを使用",
   "stackSolver.binsLabel": "スタック内のビン数",
-  "stackSolver.description": "積み重ねたビンは入れ子になるため、スタックは（ビン数 × ユニット数 × ユニット寸法）+ {lip}mm のリップです。",
+  "stackSolver.description": "積み重ねたビンは互いに {junction}mm 入れ子になるため、1 個あたり本体高さより {shortfall}mm 少なく積み上がります。",
   "stackSolver.outOfRange": "ユニットが {min}〜{max}mm の範囲外になります",
   "stackSolver.overlayPitch": "積み重ね +{pitch}mm",
   "stackSolver.result": "{total}mm まで積み重なります",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3026,7 +3026,7 @@
   "snapshots.saveCheckpoint": "체크포인트 저장",
   "stackSolver.apply": "{unit}mm/단위 사용",
   "stackSolver.binsLabel": "적층 수납통 수",
-  "stackSolver.description": "적층된 수납통은 서로 포개지므로, 한 적층의 높이는 (수납통 수 × 단위 수 × 단위 크기) + {lip}mm 립 하나입니다.",
+  "stackSolver.description": "적층된 수납통은 서로 {junction}mm 포개지므로, 하나당 몸체 높이보다 {shortfall}mm 적게 쌓입니다.",
   "stackSolver.outOfRange": "단위가 {min}–{max}mm 범위를 벗어납니다",
   "stackSolver.overlayPitch": "적층 시 +{pitch}mm",
   "stackSolver.result": "{total}mm로 적층됨",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -3327,7 +3327,7 @@
   "snapshots.saveCheckpoint": "Lagre kontrollpunkt",
   "stackSolver.apply": "Bruk {unit}mm/enhet",
   "stackSolver.binsLabel": "Binger i stabelen",
-  "stackSolver.description": "Stablede binger settes i hverandre, så en stabel er (binger × enheter × enhetsstørrelse) + én {lip}mm leppe.",
+  "stackSolver.description": "Stablede binger settes {junction}mm inn i hverandre, så hver enkelt legger til {shortfall}mm mindre enn kroppshøyden sin.",
   "stackSolver.outOfRange": "Enheten ville havne utenfor {min}–{max}mm",
   "stackSolver.overlayPitch": "stables +{pitch}mm",
   "stackSolver.result": "Stables til {total}mm",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -3327,7 +3327,7 @@
   "snapshots.saveCheckpoint": "Checkpoint opslaan",
   "stackSolver.apply": "{unit}mm/eenheid gebruiken",
   "stackSolver.binsLabel": "Bakjes in stapel",
-  "stackSolver.description": "Gestapelde bakjes nestelen, dus een stapel is (bakjes × eenheden × eenheidsgrootte) + één rand van {lip}mm.",
+  "stackSolver.description": "Gestapelde bakjes nestelen {junction}mm in elkaar, dus elk bakje voegt {shortfall}mm minder toe dan zijn romphoogte.",
   "stackSolver.outOfRange": "Eenheid valt buiten {min}–{max}mm",
   "stackSolver.overlayPitch": "stapelt +{pitch}mm",
   "stackSolver.result": "Stapelt tot {total}mm",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -3135,7 +3135,7 @@
   "snapshots.saveCheckpoint": "Zapisz punkt kontrolny",
   "stackSolver.apply": "Użyj {unit} mm/jednostkę",
   "stackSolver.binsLabel": "Biny w stosie",
-  "stackSolver.description": "Sztaplowane biny wchodzą w siebie, więc stos to (biny × jednostki × rozmiar jednostki) + jeden kołnierz {lip} mm.",
+  "stackSolver.description": "Sztaplowane biny wchodzą w siebie na {junction} mm, więc każdy dodaje o {shortfall} mm mniej niż wysokość jego korpusu.",
   "stackSolver.outOfRange": "Jednostka wypadłaby poza zakres {min}–{max} mm",
   "stackSolver.overlayPitch": "sztaplowanie +{pitch} mm",
   "stackSolver.result": "Sztapluje do {total} mm",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3135,7 +3135,7 @@
   "snapshots.saveCheckpoint": "Salvar ponto de verificação",
   "stackSolver.apply": "Usar {unit}mm/unidade",
   "stackSolver.binsLabel": "Bins na pilha",
-  "stackSolver.description": "Bins empilhados se encaixam, então uma pilha é (bins × unidades × tamanho da unidade) + uma borda de {lip}mm.",
+  "stackSolver.description": "Bins empilhados se encaixam {junction}mm entre si, então cada um soma {shortfall}mm a menos que a altura do corpo.",
   "stackSolver.outOfRange": "A unidade ficaria fora de {min}–{max}mm",
   "stackSolver.overlayPitch": "empilha +{pitch}mm",
   "stackSolver.result": "Empilha até {total}mm",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -3135,7 +3135,7 @@
   "snapshots.saveCheckpoint": "Spara kontrollpunkt",
   "stackSolver.apply": "Använd {unit}mm/enhet",
   "stackSolver.binsLabel": "Lådor i stapeln",
-  "stackSolver.description": "Staplade lådor nästlas, så en stapel är (lådor × enheter × enhetsstorlek) + en {lip}mm-läpp.",
+  "stackSolver.description": "Staplade lådor nästlas {junction}mm i varandra, så varje låda lägger till {shortfall}mm mindre än sin kroppshöjd.",
   "stackSolver.outOfRange": "Enheten skulle hamna utanför {min}–{max}mm",
   "stackSolver.overlayPitch": "staplar +{pitch}mm",
   "stackSolver.result": "Staplas till {total}mm",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -3327,7 +3327,7 @@
   "snapshots.saveCheckpoint": "Зберегти контрольну точку",
   "stackSolver.apply": "Використати {unit}mm/одиницю",
   "stackSolver.binsLabel": "Контейнерів у стосі",
-  "stackSolver.description": "Складені контейнери вкладаються, тож стос — це (контейнери × одиниці × розмір одиниці) + одна губа {lip}mm.",
+  "stackSolver.description": "Складені контейнери вкладаються один в одного на {junction}mm, тож кожен додає на {shortfall}mm менше за висоту свого корпусу.",
   "stackSolver.outOfRange": "Одиниця вийде за межі {min}–{max}mm",
   "stackSolver.overlayPitch": "стос +{pitch}mm",
   "stackSolver.result": "Складається до {total}mm",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3135,7 +3135,7 @@
   "snapshots.saveCheckpoint": "保存检查点",
   "stackSolver.apply": "使用 {unit}mm/单位",
   "stackSolver.binsLabel": "一叠中的收纳盒数",
-  "stackSolver.description": "堆叠的收纳盒会嵌套，所以一叠的高度是（盒数 × 单位数 × 单位尺寸）+ 一个 {lip}mm 唇边。",
+  "stackSolver.description": "堆叠的收纳盒会互相嵌套 {junction}mm，因此每个盒子增加的高度比其本体高度少 {shortfall}mm。",
   "stackSolver.outOfRange": "单位将超出 {min}–{max}mm",
   "stackSolver.overlayPitch": "堆叠 +{pitch}mm",
   "stackSolver.result": "堆叠为 {total}mm",

--- a/src/shared/components/HeightUnitSolver/HeightUnitSolver.test.tsx
+++ b/src/shared/components/HeightUnitSolver/HeightUnitSolver.test.tsx
@@ -14,17 +14,17 @@ describe('HeightUnitSolver', () => {
     const onApply = vi.fn();
     render(<HeightUnitSolver heightUnitMm={7} onApply={onApply} />);
 
-    // Default: 2 bins × 2 units/bin. Target 75.6mm → (75.6 − 4.3) / 4 = 17.825,
-    // which is out of the 3–20mm range only if >20; here it's in range.
+    // Default: 2 bins × 2 units/bin. Target 75.6mm, in the 3–20mm range.
     fireEvent.change(screen.getByLabelText('stackSolver.targetLabel'), {
       target: { value: '75.6' },
     });
 
     const applyBtn = screen.getByRole('button');
-    // (75.6 − 4.3) / (2 × 2) = 17.825 → rounded 17.83
-    expect(applyBtn.textContent).toContain('17.83');
+    // One 4.75mm junction off the target, then each bin's 0.45mm shortfall back:
+    // ((75.6 − 4.75) / 2 + 0.45) / 2 = 17.9375 → rounded 17.94.
+    expect(applyBtn.textContent).toContain('17.94');
     fireEvent.click(applyBtn);
-    expect(onApply).toHaveBeenCalledWith(17.83);
+    expect(onApply).toHaveBeenCalledWith(17.94);
   });
 
   it('flags a suggestion outside the allowed unit range', () => {
@@ -47,8 +47,8 @@ describe('HeightUnitSolver', () => {
   });
 
   it('disables Apply when the suggestion already equals the current unit', () => {
-    // 2 bins × 2 units, target 75.6 → 17.83. Current unit already 17.83.
-    render(<HeightUnitSolver heightUnitMm={17.83} onApply={vi.fn()} />);
+    // 2 bins × 2 units, target 75.6 → 17.94. Current unit already 17.94.
+    render(<HeightUnitSolver heightUnitMm={17.94} onApply={vi.fn()} />);
     fireEvent.change(screen.getByLabelText('stackSolver.targetLabel'), {
       target: { value: '75.6' },
     });
@@ -56,8 +56,8 @@ describe('HeightUnitSolver', () => {
   });
 
   it('keeps Apply enabled when the stored value differs beyond 2 decimals', () => {
-    // Suggestion rounds to 17.83; stored 17.831 → applying is a real change.
-    render(<HeightUnitSolver heightUnitMm={17.831} onApply={vi.fn()} />);
+    // Suggestion rounds to 17.94; stored 17.941 → applying is a real change.
+    render(<HeightUnitSolver heightUnitMm={17.941} onApply={vi.fn()} />);
     fireEvent.change(screen.getByLabelText('stackSolver.targetLabel'), {
       target: { value: '75.6' },
     });

--- a/src/shared/components/HeightUnitSolver/HeightUnitSolver.tsx
+++ b/src/shared/components/HeightUnitSolver/HeightUnitSolver.tsx
@@ -2,7 +2,12 @@ import { useId, useState } from 'react';
 import { CONSTRAINTS } from '@/core/constants';
 import { Button, Input } from '@/design-system';
 import { useTranslation } from '@/i18n';
-import { solveHeightUnitMm, stackedTotalMm, STACK_LIP_MM } from '@/shared/utils/heightUnits';
+import {
+  solveHeightUnitMm,
+  stackedTotalMm,
+  LIP_PROTRUSION_MM,
+  STACK_JUNCTION_MM,
+} from '@/shared/utils/heightUnits';
 // Relative, not via the '@/shared/components' barrel — this file is inside it.
 import { SettingsRow } from '../SettingsRow';
 
@@ -63,7 +68,10 @@ export function HeightUnitSolver({
   return (
     <div className="space-y-2 text-xs">
       <p className="text-content-tertiary">
-        {t('stackSolver.description', { lip: round2(STACK_LIP_MM) })}
+        {t('stackSolver.description', {
+          junction: round2(STACK_JUNCTION_MM),
+          shortfall: round2(STACK_JUNCTION_MM - LIP_PROTRUSION_MM),
+        })}
       </p>
       <SettingsRow label={t('stackSolver.targetLabel')} htmlFor={`${uid}-target`} variant={variant}>
         <Input

--- a/src/shared/utils/heightUnits.test.ts
+++ b/src/shared/utils/heightUnits.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   formatHeightUnits,
   isStandardStackHeight,
-  STACK_LIP_MM,
+  LIP_PROTRUSION_MM,
+  STACK_JUNCTION_MM,
   stackPitchMm,
   stackedTotalMm,
   solveHeightUnitMm,
@@ -40,20 +41,30 @@ describe('isStandardStackHeight', () => {
   });
 });
 
+/** What each junction costs against the body height: 4.75 − 4.3. */
+const SHORTFALL_MM = STACK_JUNCTION_MM - LIP_PROTRUSION_MM;
+
 describe('stackPitchMm', () => {
-  it('is the body height (units × unitMm), independent of the lip', () => {
-    expect(stackPitchMm(3, 7)).toBe(21);
-    expect(stackPitchMm(2, 9.362)).toBeCloseTo(18.724, 5);
+  it('runs one shortfall under the body height, because the bin settles past the lip', () => {
+    expect(stackPitchMm(3, 7)).toBeCloseTo(21 - SHORTFALL_MM, 5);
+    expect(stackPitchMm(2, 9.362)).toBeCloseTo(18.724 - SHORTFALL_MM, 5);
+  });
+
+  it('the shortfall is the base profile standing proud of the lip', () => {
+    expect(SHORTFALL_MM).toBeCloseTo(0.45, 5);
   });
 });
 
 describe('stackedTotalMm', () => {
   it('a single bin equals body + one lip (its printed height)', () => {
-    expect(stackedTotalMm(3, 7, 1)).toBeCloseTo(21 + STACK_LIP_MM, 5);
+    expect(stackedTotalMm(3, 7, 1)).toBeCloseTo(21 + LIP_PROTRUSION_MM, 5);
   });
 
-  it('nests: two H bins equal one 2H bin (divisibility law)', () => {
-    expect(stackedTotalMm(5, 7, 2)).toBeCloseTo(stackedTotalMm(10, 7, 1), 5);
+  it('two H bins fall one shortfall short of one 2H bin', () => {
+    // Divisibility is near, not exact — #3525. The gap is per junction, so it
+    // grows with the stack rather than cancelling.
+    expect(stackedTotalMm(5, 7, 2)).toBeCloseTo(stackedTotalMm(10, 7, 1) - SHORTFALL_MM, 5);
+    expect(stackedTotalMm(5, 7, 4)).toBeCloseTo(stackedTotalMm(20, 7, 1) - 3 * SHORTFALL_MM, 5);
   });
 
   it('each added bin advances by the pitch, not the printed height', () => {
@@ -73,13 +84,17 @@ describe('solveHeightUnitMm', () => {
     expect(u).toBeCloseTo(8.5, 5);
   });
 
-  it('accounts for the single top lip, not one lip per bin', () => {
-    // 4 bins × 2u into a 75.6mm space → (75.6 − 4.3) / 8 = 8.9125mm/unit
-    expect(solveHeightUnitMm(75.6, 2, 4)).toBeCloseTo((75.6 - STACK_LIP_MM) / 8, 5);
+  it('charges one junction for the stack and one shortfall per bin', () => {
+    // 4 bins × 2u into 75.6mm: the top junction comes off the target once, then
+    // each bin gets its shortfall back because its body outruns its pitch.
+    expect(solveHeightUnitMm(75.6, 2, 4)).toBeCloseTo(
+      (75.6 - STACK_JUNCTION_MM + 4 * SHORTFALL_MM) / 8,
+      5
+    );
   });
 
-  it('returns null when the target is below the lip or inputs are degenerate', () => {
-    expect(solveHeightUnitMm(STACK_LIP_MM, 2, 4)).toBeNull();
+  it('returns null when the target is below the junction or inputs are degenerate', () => {
+    expect(solveHeightUnitMm(STACK_JUNCTION_MM - 4 * SHORTFALL_MM, 2, 4)).toBeNull();
     expect(solveHeightUnitMm(75.6, 0, 4)).toBeNull();
     expect(solveHeightUnitMm(75.6, 2, 0)).toBeNull();
   });

--- a/src/shared/utils/heightUnits.ts
+++ b/src/shared/utils/heightUnits.ts
@@ -2,39 +2,60 @@ import { CONSTRAINTS } from '@/core/constants';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings';
 
 /**
- * Height a single exposed stacking lip adds on top of a stack, in mm. The lip
- * nests into the socket of the bin above (verified: stack pitch = body height),
- * so only the topmost bin's lip protrudes. Equals the mesh's real lip
- * contribution (`LIP_HEIGHT − LIP_OVERLAP`), matching `BinDimensions`.
+ * Exposed stacking lip on a printed bin, in mm — the part standing above the
+ * wall top, and so what a single bin's printed height carries on top of its
+ * body. Matches `BinDimensions`.
+ *
+ * This is NOT how deep the bin above sinks onto it: that is
+ * {@link STACK_JUNCTION_MM}, and conflating the two is what made every stack
+ * readout 0.45mm per junction too tall (#3525).
  */
-export const STACK_LIP_MM = GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP;
+export const LIP_PROTRUSION_MM = GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP;
 
 /**
- * Vertical pitch a stacked bin adds, in mm. Bins nest — the lip sinks into the
- * socket above — so each added bin advances the stack by its body height
- * (`heightUnits × heightUnitMm`), NOT its printed height (which includes the
- * lip). This is why two 5u bins stack to the same height as one 10u bin.
+ * How far a stacked bin settles below the lip top of the bin under it, in mm.
+ *
+ * The joint is the base's big chamfer resting flush on the lip's, both at 45
+ * degrees, so the pair comes to rest when their full-width points meet — which
+ * puts the upper bin's underside one base profile below the lip top. The base
+ * reaches full width `TOLERANCE/2` under the top of its socket, so that profile
+ * is `SOCKET_HEIGHT - TOLERANCE/2`.
+ *
+ * It is the base profile that sets this, never the lip: at 4.4mm of profile
+ * against the base's 4.75mm the lip is the shorter of the two, so the bin above
+ * settles 0.35mm past the lip's base plane (0.45mm here, `LIP_OVERLAP` sinking
+ * the lip a further 0.1mm into the wall). Both figures come from the reference
+ * profiles, so a canonical Gridfinity stack does not add body height either.
+ *
+ * Measured on the mated solids rather than trusted from this arithmetic —
+ * `binStackSeating.kernel.test.ts`.
+ */
+export const STACK_JUNCTION_MM = GRIDFINITY_SPEC.SOCKET_HEIGHT - GRIDFINITY_SPEC.TOLERANCE / 2;
+
+/**
+ * Vertical pitch a stacked bin adds, in mm: its printed height less the depth
+ * it sinks into the bin below. Slightly under the body height, because the bin
+ * settles past the lip's base rather than onto it.
  */
 export function stackPitchMm(heightUnits: number, heightUnitMm: number): number {
-  return heightUnits * heightUnitMm;
+  return heightUnits * heightUnitMm + LIP_PROTRUSION_MM - STACK_JUNCTION_MM;
 }
 
 /**
  * Total printed height of a stack of `count` identical bins, in mm:
- * `count × pitch + one exposed top lip`. A single bin (count 1) returns its
- * full printed height (`h·u + STACK_LIP_MM`).
+ * `count × pitch + the junction the topmost bin does not sink into`. A single
+ * bin (count 1) returns its full printed height (`h·u + LIP_PROTRUSION_MM`).
  */
 export function stackedTotalMm(heightUnits: number, heightUnitMm: number, count: number): number {
   if (count <= 0) return 0;
-  return count * stackPitchMm(heightUnits, heightUnitMm) + STACK_LIP_MM;
+  return count * stackPitchMm(heightUnits, heightUnitMm) + STACK_JUNCTION_MM;
 }
 
 /**
  * Inverse of {@link stackedTotalMm}: the `heightUnitMm` that makes `count` bins
- * of `unitsPerBin` height units stack to exactly `targetTotalMm`. Solves
- * `count × unitsPerBin × u + STACK_LIP_MM = targetTotalMm`. Returns null when
- * the inputs can't yield a positive unit value (e.g. target below the lip, or
- * non-positive count/units).
+ * of `unitsPerBin` height units stack to exactly `targetTotalMm`. Returns null
+ * when the inputs can't yield a positive unit value (e.g. target below the
+ * junction, or non-positive count/units).
  */
 export function solveHeightUnitMm(
   targetTotalMm: number,
@@ -42,7 +63,9 @@ export function solveHeightUnitMm(
   count: number
 ): number | null {
   if (count <= 0 || unitsPerBin <= 0) return null;
-  const perUnit = (targetTotalMm - STACK_LIP_MM) / (count * unitsPerBin);
+  const bodyMm =
+    (targetTotalMm - STACK_JUNCTION_MM) / count - LIP_PROTRUSION_MM + STACK_JUNCTION_MM;
+  const perUnit = bodyMm / unitsPerBin;
   return perUnit > 0 ? perUnit : null;
 }
 


### PR DESCRIPTION
## Summary

**Type**: fix

Stacked-bin heights were 0.45mm per junction too tall. `STACK_LIP_MM` was one constant doing two unrelated jobs — the lip a single bin's printed height carries above its body, and the depth the next bin sinks onto it — and those are different features with different values.

## Context

Closes #3525, and settles the open half of discussion #2374, where a user reported stacks measuring short and was told it looked like print shrinkage or calibration. It wasn't.

Mating two generated bins and letting the upper one fall puts the joint at **4.75mm, not 4.30** — at every height, footprint and height unit tried. The base profile sets it, never the lip: both chamfers are 45 degrees, so the base comes to rest flush on the lip's chamfer one base profile below the top, and at 4.4mm against the base's 4.75mm the lip is the shorter of the two.

Those are the reference's own figures (kennetek `standard.scad`: `BASE_PROFILE` 0.8/1.8/2.15, `STACKING_LIP_LINE` 0.7/1.8/1.9), so **a canonical Gridfinity stack doesn't add body height either** — 0.35mm short per junction there, 0.45 here because `LIP_OVERLAP` sinks the lip a further 0.1mm into the wall. The geometry is right; the arithmetic describing it was wrong.

| case         | junction | pitch (measured) | pitch (old readout) |
| ------------ | -------- | ---------------- | ------------------- |
| 2x2x3 u=7    | 4.750    | 20.550           | 21.000              |
| 2x2x12 u=7   | 4.750    | 83.550           | 84.000              |
| 1x1x3 u=7    | 4.750    | 20.550           | 21.000              |
| 3x2x4 u=7    | 4.750    | 27.550           | 28.000              |
| 2x2x3 u=4.37 | 4.750    | 12.660           | 13.110              |
| 2x2x5 u=12.6 | 4.750    | 62.550           | 63.000              |

## Changes

- Split the conflated constant: `LIP_PROTRUSION_MM` (`LIP_HEIGHT - LIP_OVERLAP`, 4.30, unchanged) and `STACK_JUNCTION_MM` (`SOCKET_HEIGHT - TOLERANCE / 2`, 4.75).
- `stackPitchMm` is now `body + protrusion - junction`; `stackedTotalMm` is `count x pitch + junction`. `stackedTotalMm(h, u, 1)` still returns the printed height exactly, so single-bin readouts are untouched.
- `solveHeightUnitMm` inverts the corrected total. A 4-bin 2u fit to 75.6mm moves from 17.83 to 17.94mm/unit; the solver had been answering the wrong equation.
- Inspector's `stacks +Ymm each` now reads the pitch rather than raw body height.
- New probe `__kernel-tests__/binStacking.ts` (`stackSeat`), layered over the existing `seatDepth` descent sweep rather than reimplementing it, plus `binStackSeating.kernel.test.ts`.
- Rewrote `lipNesting.scenario.divisibility.test.ts`. It asserted that two Hu bins equal one 2Hu bin and **could not have caught this**: it asked whether the pair INTERSECTS at body height, and a bin resting 0.45mm lower doesn't intersect there, it floats clear. Non-interference brackets a seat between two pitches but never locates one. It now pins the seat from both sides 0.1mm apart.

Note for reviewers: the probes run on the **export** mesh, not the preview. The preview path meshes the base socket separately and concatenates it, and the surviving coincident socket-top/floor-bottom faces flip `verticalSolidSpans`' enter/exit parity — the cavity then reads as solid and the joint as 5.00. This cost me an hour and is commented at both call sites.

## Architecture

- **Stores**: none
- **Features**: bin-inspector, generation, shared
- **New types**: none (two new exported constants in `shared/utils/heightUnits.ts`)
- **i18n keys**: `stackSolver.description` reworded (params `{lip}` → `{junction}`, `{shortfall}`), 14 locales updated
- **Storage/schema changes**: none

## Breaking changes

No API or schema change, no migration. Displayed multi-bin stack totals drop 0.45mm per junction, and "fit unit to stack" suggests a slightly different unit size. Two 5u bins no longer come out equal to one 10u bin — they're 0.45mm shorter, and it accumulates per junction rather than cancelling.

## Deliberately not done

`LIP_OVERLAP` makes this tool's bins print 0.1mm shorter and stack 0.1mm tighter than canonical Gridfinity. The junction is 4.75 either way; only each bin's own printed height differs. Closing it would move `lipTopZ`, every mesh height, the triangle-count snapshots and a seated lid's anchor plane, for a tenth of a millimetre well under a typical layer height. Worth its own decision.

## Test plan

- [x] Verified two independent ways on the same joint: ray descent through the mated pair, and CSG intersection volume
- [x] `vitest --project unit` (10,720 passed), `--project dom` (9,066 passed), `--project generators` (2,888 passed, 4 skipped)
- [x] `pnpm run build`
- [x] New code has colocated sibling tests (`binStacking.ts` is the probe helper; its consumer is the sibling test)
- [x] i18n: `check:i18n`, `check:i18n:interpolation`, `check:i18n:values`, `check:i18n:unused`
- [x] No `console.log`, `any`, `var`, `==`, `!` introduced
- [x] typecheck, eslint, prettier clean
- [ ] CLAUDE.md not updated — no convention changed
