### PR TITLE
test: size the generators timeout for real OCCT work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,28 +186,31 @@ jobs:
   # PRs only. Pushes to main keep the full cloud suite with coverage, so releases
   # never depend on the mini being up.
   #
-  # Four shards, not six. The 6-way split above is sized for six independent
+  # Two shards, not six. The 6-way split above is sized for six independent
   # 4-core cloud runners; on one machine that split would pay checkout + install
-  # + WASM init six times over for no extra concurrency, since a fifth shard has
-  # no runner to start on and only queues.
+  # + WASM init six times over and leave each shard ~1.7 cores. Two shards at
+  # five workers each keeps the performance cores saturated while leaving the
+  # efficiency cores for interactive use and for halcyon's three runners, which
+  # share this host.
   #
-  # `--maxWorkers` is sized against the RUNNER POOL, not against one run's
-  # matrix. All four `gflt-ci` runners are processes on this single mini, so the
-  # host's worst case is `runners x maxWorkers`: every shard scheduled anywhere
-  # lands here. The previous 2x5 read the arithmetic off one PR's matrix and was
-  # right only in isolation, ten workers on ten performance cores. Two PRs in
-  # flight made it twenty, and #3537 is the shape that takes, a per-test timeout
-  # firing on a different test each attempt. Sharding cannot fix that on its
-  # own, because `--shard` splits the file set: it makes a job shorter without
-  # making any single test faster, and raising the count while holding
-  # maxWorkers would have put thirty workers on the host and made it worse.
+  # THE INVARIANT: `gflt-ci runners x maxWorkers <= 10 performance cores`. Every
+  # runner in the pool is a process on this one mini, so a shard scheduled
+  # anywhere lands here and the host's worst case is that product, NOT one run's
+  # matrix. The pool is deliberately two for this reason. It was briefly four,
+  # which left 2x5 correct only for a lone PR: a second one in flight made it
+  # twenty workers on ten cores, and #3537 is the shape that takes, a per-test
+  # timeout firing on a different test each attempt.
   #
-  # 4x3 caps the host at twelve however many PRs queue, and because the shard
-  # count now equals the runner count, one PR's load and the worst case are the
-  # same number rather than a 2x cliff between them. The two spare workers come
-  # off the efficiency cores, which is the margin the split leaves for
-  # interactive use and for halcyon's three runners, which share this host.
-  # Adding a runner or a shard means re-checking that product, not this comment.
+  # Registering a third runner silently breaks that product and reopens #3537.
+  # Re-derive it before changing either side, and note that the fix is NOT more
+  # shards: `--shard` splits the file set, so it shortens a job without making
+  # any single test faster, and raising the count to match a bigger pool only
+  # multiplies the workers on the host. That was measured, not assumed, on
+  # 4x3 (run 31960552340): the slowest shard went 250s -> 355s, because four
+  # concurrent `pnpm install`s contend on one disk (16-49s -> a uniform ~68s)
+  # and hash sharding balances worse at 4-way than 2-way (1.05x -> 1.45x
+  # spread). A smaller pool is both faster per PR and bounded; two queued PRs
+  # finish in ~500s against ~710s for the same work split four ways.
   #
   # `vars.SELF_HOSTED_CI` is the kill switch: unset it in repo settings and every
   # shard here stops scheduling immediately, no code change needed. The head_repo
@@ -223,20 +226,16 @@ jobs:
       && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, gflt-ci]
     # A wedged WASM kernel would otherwise hold a runner indefinitely, and the
-    # pool is small enough that every PR behind it waits.
+    # pool is two, so every PR behind it waits on the one that is left.
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: generators 1/4
-            shard: 1/4
-          - name: generators 2/4
-            shard: 2/4
-          - name: generators 3/4
-            shard: 3/4
-          - name: generators 4/4
-            shard: 4/4
+          - name: generators 1/2
+            shard: 1/2
+          - name: generators 2/2
+            shard: 2/2
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -251,7 +250,7 @@ jobs:
       - name: Run generators tests
         env:
           SHARD: ${{ matrix.shard }}
-        run: pnpm vitest run --project=generators --shard="$SHARD" --maxWorkers=3
+        run: pnpm vitest run --project=generators --shard="$SHARD" --maxWorkers=5
 
   # Tests that need a real Redis. The rate limiter runs as a Lua script, and a
   # mocked ioredis can only assert the command was issued — it cannot execute

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,12 +186,28 @@ jobs:
   # PRs only. Pushes to main keep the full cloud suite with coverage, so releases
   # never depend on the mini being up.
   #
-  # Two shards, not six. The 6-way split above is sized for six independent
+  # Four shards, not six. The 6-way split above is sized for six independent
   # 4-core cloud runners; on one machine that split would pay checkout + install
-  # + WASM init six times over and leave each shard ~1.7 cores. Two shards at
-  # five workers each keeps the performance cores saturated while leaving the
-  # efficiency cores for interactive use and for halcyon's three runners, which
-  # share this host.
+  # + WASM init six times over for no extra concurrency, since a fifth shard has
+  # no runner to start on and only queues.
+  #
+  # `--maxWorkers` is sized against the RUNNER POOL, not against one run's
+  # matrix. All four `gflt-ci` runners are processes on this single mini, so the
+  # host's worst case is `runners x maxWorkers`: every shard scheduled anywhere
+  # lands here. The previous 2x5 read the arithmetic off one PR's matrix and was
+  # right only in isolation, ten workers on ten performance cores. Two PRs in
+  # flight made it twenty, and #3537 is the shape that takes, a per-test timeout
+  # firing on a different test each attempt. Sharding cannot fix that on its
+  # own, because `--shard` splits the file set: it makes a job shorter without
+  # making any single test faster, and raising the count while holding
+  # maxWorkers would have put thirty workers on the host and made it worse.
+  #
+  # 4x3 caps the host at twelve however many PRs queue, and because the shard
+  # count now equals the runner count, one PR's load and the worst case are the
+  # same number rather than a 2x cliff between them. The two spare workers come
+  # off the efficiency cores, which is the margin the split leaves for
+  # interactive use and for halcyon's three runners, which share this host.
+  # Adding a runner or a shard means re-checking that product, not this comment.
   #
   # `vars.SELF_HOSTED_CI` is the kill switch: unset it in repo settings and every
   # shard here stops scheduling immediately, no code change needed. The head_repo
@@ -206,17 +222,21 @@ jobs:
       && github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, gflt-ci]
-    # A wedged WASM kernel would otherwise hold a runner indefinitely, and there
-    # are only two of them.
+    # A wedged WASM kernel would otherwise hold a runner indefinitely, and the
+    # pool is small enough that every PR behind it waits.
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: generators 1/2
-            shard: 1/2
-          - name: generators 2/2
-            shard: 2/2
+          - name: generators 1/4
+            shard: 1/4
+          - name: generators 2/4
+            shard: 2/4
+          - name: generators 3/4
+            shard: 3/4
+          - name: generators 4/4
+            shard: 4/4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -231,7 +251,7 @@ jobs:
       - name: Run generators tests
         env:
           SHARD: ${{ matrix.shard }}
-        run: pnpm vitest run --project=generators --shard="$SHARD" --maxWorkers=5
+        run: pnpm vitest run --project=generators --shard="$SHARD" --maxWorkers=3
 
   # Tests that need a real Redis. The rate limiter runs as a Lua script, and a
   # mocked ioredis can only assert the command was issued — it cannot execute

--- a/src/features/generation/worker/generators/binGenerator.scenario.gridunit.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.gridunit.test.ts
@@ -49,7 +49,7 @@ describe('custom gridUnitMm', () => {
     const expected = 1 * 50 - CLEARANCE; // 49.5mm
     expect(width).toBeCloseTo(expected, 0);
     expect(depth).toBeCloseTo(expected, 0);
-  }, 30_000);
+  });
 
   it('should generate non-square geometry when gridUnitMmY differs from gridUnitMm', () => {
     const generateBin = getGenerateBin();
@@ -82,7 +82,7 @@ describe('custom gridUnitMm', () => {
     // X uses gridUnitMm (42), Y uses gridUnitMmY (22). The two axes must differ.
     expect(width).toBeCloseTo(2 * 42 - CLEARANCE, 0); // 83.5mm
     expect(depth).toBeCloseTo(3 * 22 - CLEARANCE, 0); // 65.5mm
-  }, 30_000);
+  });
 
   it('places a magnet that fits a narrow non-square foot (no side breach)', () => {
     const generateBin = getGenerateBin();
@@ -125,7 +125,7 @@ describe('custom gridUnitMm', () => {
     }
     expect(maxX - minX).toBeCloseTo(1 * 25 - CLEARANCE, 0); // 24.5mm
     expect(maxY - minY).toBeCloseTo(1 * 42 - CLEARANCE, 0); // 41.5mm
-  }, 30_000);
+  });
 
   it('should place anisotropic feet at the correct per-axis pitch (socketed bin)', () => {
     const generateBin = getGenerateBin();
@@ -164,7 +164,7 @@ describe('custom gridUnitMm', () => {
     expect(extent(aniso, 0)).toBeCloseTo(extent(square, 0), 0);
     expect(extent(aniso, 1)).toBeCloseTo(2 * 22 - CLEARANCE, 0); // 41.5mm
     expect(extent(aniso, 1)).toBeLessThan(extent(square, 1) - 10);
-  }, 30_000);
+  });
 
   it('split preview pieces should use custom gridUnitMm', () => {
     const generateSplitPreview = getGenerateSplitPreview();
@@ -185,7 +185,7 @@ describe('custom gridUnitMm', () => {
     for (const piece of result.pieces) {
       expect(piece.widthUnits).toBeCloseTo(4, 0);
     }
-  }, 30_000);
+  });
 
   it('split preview reports grid units per-axis for a non-square grid', () => {
     const generateSplitPreview = getGenerateSplitPreview();
@@ -208,5 +208,5 @@ describe('custom gridUnitMm', () => {
       expect(piece.widthUnits).toBeCloseTo(2, 0); // X via 42mm pitch
       expect(piece.depthUnits).toBeCloseTo(4, 0); // Y via 22mm pitch
     }
-  }, 30_000);
+  });
 });

--- a/src/features/generation/worker/generators/boxBuilder.test.ts
+++ b/src/features/generation/worker/generators/boxBuilder.test.ts
@@ -44,13 +44,13 @@ describe('buildBinBox', () => {
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
     expect(result.triangles.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds a solid 2x2 box', () => {
     const shape = buildBinBox(2, 2, 16, 1.2, true);
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('solid box has fewer triangles than hollow box', () => {
     const hollow = meshShape(buildBinBox(2, 2, 16, 1.2, false));
@@ -62,13 +62,13 @@ describe('buildBinBox', () => {
     const shape = buildBinBox(2, 2, 16, 1.2, true, 5);
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds a 0.5x0.5 box (minimum size)', () => {
     const shape = buildBinBox(0.5, 0.5, 9, 1.2, false);
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 });
 
 describe('buildTopShape', () => {
@@ -77,19 +77,19 @@ describe('buildTopShape', () => {
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
     expect(result.triangles.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds lip without stacking interface', () => {
     const shape = buildTopShape(2, 2, false);
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds lip for a 1x1 bin', () => {
     const shape = buildTopShape(1, 1, true);
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('lip with stacking has more triangles than without', () => {
     const withLip = meshShape(buildTopShape(2, 2, true));
@@ -135,7 +135,7 @@ describe('buildTopShape', () => {
     const TOL = 0.5;
     expect(lipBounds.xMax - lipBounds.xMin).toBeGreaterThan(outerW - TOL);
     expect(lipBounds.yMax - lipBounds.yMin).toBeGreaterThan(outerD - TOL);
-  }, 30000);
+  });
 
   // Regression: — the lip extension must include an angled support
   // face below the overhang so it can be FDM-printed without strings. The

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -103,7 +103,7 @@ describe('buildCompartmentWalls', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('returns null when all cells are merged', () => {
     const params: BinParams = {
@@ -123,7 +123,7 @@ describe('buildCompartmentWalls', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds walls when a divider has a tilt override (1×2)', () => {
     const params: BinParams = {
@@ -140,7 +140,7 @@ describe('buildCompartmentWalls', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('tilted divider produces a different mesh than the equivalent straight one', () => {
     const base: BinParams = {
@@ -163,7 +163,7 @@ describe('buildCompartmentWalls', () => {
     const straightMesh = meshShape(straight);
     const skewMesh = meshShape(skew);
     expect(skewMesh.vertices.length).not.toBe(straightMesh.vertices.length);
-  }, 30000);
+  });
 
   it('does not crash on a tilted override that pushes the divider outside the bin interior', () => {
     // Defensive guard against malformed JSON or invariant breakage where
@@ -180,7 +180,7 @@ describe('buildCompartmentWalls', () => {
       },
     };
     expect(() => buildCompartmentWalls(params, 80, 80, 16)).not.toThrow();
-  }, 30000);
+  });
 
   it('applies overrides only to the matching pair when a boundary spans multiple pairs', () => {
     // 2×2 grid with no merging — the vertical boundary between col 0 and col
@@ -257,7 +257,7 @@ describe('buildCompartmentWalls', () => {
     // would be a no-op. Post-fix: they differ because only the (2,3)
     // half changes — proving the override is now scoped to its pair.
     expect(Math.abs(topOnlySum - bothSum)).toBeGreaterThan(0.01);
-  }, 30000);
+  });
 });
 
 describe('buildInsertCuts', () => {
@@ -286,7 +286,7 @@ describe('buildInsertCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds a rounded-rect insert cut', () => {
     const params: BinParams = {
@@ -307,7 +307,7 @@ describe('buildInsertCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 });
 
 describe('buildCutoutCuts', () => {
@@ -341,7 +341,7 @@ describe('buildCutoutCuts', () => {
     expect(fuseTools).toHaveLength(0);
     const meshed = meshShape(cutTools[0]);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('returns an embossed label as a fuse tool, not a cut', () => {
     const params: BinParams = {
@@ -372,7 +372,7 @@ describe('buildCutoutCuts', () => {
     expect(fuseTools).toHaveLength(1);
     const meshed = meshShape(fuseTools[0]);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   const recessedLabelCutout: BinParams['cutouts'][number] = {
     id: 'c1',
@@ -404,7 +404,7 @@ describe('buildCutoutCuts', () => {
     const zMaxes = cutTools.map((t) => shapeBounds(t).zMax).sort((a, b) => a - b);
     expect(zMaxes[0]).toBeLessThan(11.5);
     expect(zMaxes[1]).toBeGreaterThan(15.5);
-  }, 30000);
+  });
 
   it('carves a floor-embossed center label out of the cavity instead of fusing it (#2726)', () => {
     const emboss: BinParams = {
@@ -427,7 +427,7 @@ describe('buildCutoutCuts', () => {
       16
     );
     expect(shapeVolume(labeled.cutTools[0])).toBeLessThan(shapeVolume(plain.cutTools[0]) - 1);
-  }, 30000);
+  });
 
   it('drops an engraved center label when the recess consumes the full fill depth', () => {
     const params: BinParams = {
@@ -439,7 +439,7 @@ describe('buildCutoutCuts', () => {
     // Cavity only — no floor is left to engrave into.
     expect(cutTools).toHaveLength(1);
     expect(fuseTools).toHaveLength(0);
-  }, 30000);
+  });
 
   it('keeps a label at the bin top when its center is outside a circle cutout footprint', () => {
     // Offset drags the center to (13.5, 13.5) from the cutout center — inside
@@ -463,7 +463,7 @@ describe('buildCutoutCuts', () => {
     for (const tool of cutTools) {
       expect(shapeBounds(tool).zMax).toBeGreaterThan(15.5);
     }
-  }, 30000);
+  });
 
   it('keeps a label at the bin top for members of non-union groups', () => {
     // A subtract group's final cavity may not contain the member's footprint,
@@ -492,7 +492,7 @@ describe('buildCutoutCuts', () => {
     for (const tool of cutTools) {
       expect(shapeBounds(tool).zMax).toBeGreaterThan(15.5);
     }
-  }, 30000);
+  });
 });
 
 describe('buildLabelTabs', () => {
@@ -514,7 +514,7 @@ describe('buildLabelTabs', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds solid-style label tabs', () => {
     const params: BinParams = {
@@ -525,7 +525,7 @@ describe('buildLabelTabs', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 });
 
 describe('buildScoopRamps', () => {
@@ -557,7 +557,7 @@ describe('buildScoopRamps', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds scoop ramps with fixed radius', () => {
     const params: BinParams = {
@@ -568,7 +568,7 @@ describe('buildScoopRamps', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 });
 
 describe('buildWallCutoutCuts', () => {
@@ -600,7 +600,7 @@ describe('buildWallCutoutCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('returns null when all sides are disabled', () => {
     const params: BinParams = {
@@ -640,7 +640,7 @@ describe('buildWallCutoutCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('returns null when width and depth are both 0', () => {
     const params: BinParams = {
@@ -681,7 +681,7 @@ describe('buildWallCutoutCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('handles 100% depth (full interior height cutout)', () => {
     const params: BinParams = {
@@ -702,7 +702,7 @@ describe('buildWallCutoutCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds scoop shape cutouts for enabled sides', () => {
     const params: BinParams = {
@@ -723,7 +723,7 @@ describe('buildWallCutoutCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds funnel shape cutouts for enabled sides', () => {
     const params: BinParams = {
@@ -744,7 +744,7 @@ describe('buildWallCutoutCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds scoop with very wide cutout (width > 2*height) as floor-bounded arc', () => {
     const params: BinParams = {
@@ -765,5 +765,5 @@ describe('buildWallCutoutCuts', () => {
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 });

--- a/src/features/generation/worker/generators/lightweightBaseBuilder.test.ts
+++ b/src/features/generation/worker/generators/lightweightBaseBuilder.test.ts
@@ -35,7 +35,7 @@ describe('buildLightweightBase', () => {
     // Hollow bins must produce a tool to open the body floor into each cup.
     expect(floorOpenings).not.toBeNull();
     expect(meshShape(floorOpenings).triangles.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it("'down' (solid bins) opens the underside — no floor openings", () => {
     const { base, floorOpenings } = buildLightweightBase(
@@ -52,7 +52,7 @@ describe('buildLightweightBase', () => {
     );
     expect(meshShape(base).triangles.length).toBeGreaterThan(0);
     expect(floorOpenings).toBeNull();
-  }, 30000);
+  });
 
   it('retains magnet pads as solid islands (more geometry than plain cups)', () => {
     const plain = buildLightweightBase(2, 2, WT, false, false, 3.25, 2, 1.5, 'up', true);
@@ -61,7 +61,7 @@ describe('buildLightweightBase', () => {
     const padTris = meshShape(withPads.base).triangles.length;
     // Pads + drilled pockets add surfaces the plain cups don't have.
     expect(padTris).toBeGreaterThan(plainTris);
-  }, 30000);
+  });
 
   it("'down' (solid) bins still cut magnet pockets — pad anchored at the foot bottom", () => {
     // Regression: pads were placed at the top for 'down', so the bottom drill
@@ -74,5 +74,5 @@ describe('buildLightweightBase', () => {
     // only add its outer cylinder (still more, but the pocket guarantees a clear
     // jump). Assert the pocket-bearing variant has materially more geometry.
     expect(magTris).toBeGreaterThan(plainTris);
-  }, 30000);
+  });
 });

--- a/src/features/generation/worker/generators/magnetAlignment.verification.test.ts
+++ b/src/features/generation/worker/generators/magnetAlignment.verification.test.ts
@@ -103,7 +103,7 @@ describe('magnet hole alignment verification', () => {
     expect(hasClusterNear(clusters, -HOLE_OFFSET, HOLE_OFFSET)).toBe(true);
     expect(hasClusterNear(clusters, HOLE_OFFSET, -HOLE_OFFSET)).toBe(true);
     expect(hasClusterNear(clusters, HOLE_OFFSET, HOLE_OFFSET)).toBe(true);
-  }, 30000);
+  });
 
   it('1×1 with halfSockets has magnet vertices at ±13mm (not ±10.5mm)', () => {
     const params: BinParams = {
@@ -128,7 +128,7 @@ describe('magnet hole alignment verification', () => {
     // Use tight tolerance (1.5mm) — 10.5 and 13 are 2.5mm apart
     expect(hasClusterNear(clusters, -WRONG_OFFSET, -WRONG_OFFSET, 1.5)).toBe(false);
     expect(hasClusterNear(clusters, WRONG_OFFSET, WRONG_OFFSET, 1.5)).toBe(false);
-  }, 30000);
+  });
 
   it('halfSockets does not change magnet hole positions', () => {
     const base: BinParams = {

--- a/src/features/generation/worker/generators/socketBuilder.test.ts
+++ b/src/features/generation/worker/generators/socketBuilder.test.ts
@@ -94,14 +94,14 @@ describe('buildSingleCellSocket', () => {
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
     expect(result.triangles.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds a valid solid for a half-size cell', () => {
     const shape = buildSingleCellSocket(20.5, 20.5);
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
     expect(result.triangles.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 });
 
 describe('buildSimplifiedCellSocket', () => {
@@ -109,13 +109,13 @@ describe('buildSimplifiedCellSocket', () => {
     const shape = buildSimplifiedCellSocket(41.5, 41.5);
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('produces fewer triangles than full socket', () => {
     const full = meshShape(buildSingleCellSocket(41.5, 41.5));
     const simplified = meshShape(buildSimplifiedCellSocket(41.5, 41.5));
     expect(simplified.triangles.length).toBeLessThanOrEqual(full.triangles.length);
-  }, 30000);
+  });
 });
 
 describe('buildBaseSocket', () => {
@@ -124,7 +124,7 @@ describe('buildBaseSocket', () => {
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
     expect(result.triangles.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds a 2x2 socket grid with magnets', () => {
     const shape = buildBaseSocket(2, 2, true, false, 3.1, 2, 1.25, false, GRID_PLAN);
@@ -136,7 +136,7 @@ describe('buildBaseSocket', () => {
     const shape = buildBaseSocket(1.5, 1, false, false, 3.1, 2, 1.25, false, GRID_PLAN);
     const result = meshShape(shape);
     expect(result.vertices.length).toBeGreaterThan(0);
-  }, 30000);
+  });
 
   it('builds a 2x2 socket grid in half-sockets mode', () => {
     const shape = buildBaseSocket(2, 2, false, false, 3.1, 2, 1.25, false, ALL_PLAN);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -153,11 +153,14 @@ export default defineConfig({
           // was only ever whichever inherited test was slowest that run. 120s
           // is the tier the deliberately-annotated heavy files already use.
           //
-          // This is a liveness bound, not a performance budget. The perf tests
-          // assert their own ceilings against `performance.now()`
-          // (tessellation.perf, height.perf, compartments.perf), so a slow
-          // regression is still caught by the assertion that exists for it, and
-          // a wedged kernel is still bounded by the job's `timeout-minutes`.
+          // This is a liveness bound, not a performance budget, and it was never
+          // serving as one: a timeout only fires on the slowest test of whatever
+          // run trips it. `tessellation.perf` is the one file here that enforces
+          // timing, via `toBeLessThan(MAX_MS_*)` against `performance.now()`, and
+          // the cap above does not touch it. The `.perf` files under
+          // `__kernel-tests__` only record measurements, and `sharedExclude` keeps
+          // that directory out of this project regardless. A wedged kernel stays
+          // bounded by the job's `timeout-minutes`.
           testTimeout: 120_000,
           // Separate knob with its own, tighter default (10s), and every file
           // here boots the WASM kernel via `initTestKernel()` in `beforeAll`.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -143,6 +143,29 @@ export default defineConfig({
           setupFiles: ['./src/test/setup.ts'],
           include: generatorIncludes,
           exclude: sharedExclude,
+          // The root 30s is calibrated for pure-JS tests that finish in
+          // milliseconds. Everything here drives real OCCT booleans, and 1423
+          // of the project's 1748 `it`s inherit that figure rather than
+          // declaring their own, so the cap the heavy tests actually run under
+          // was set by a different workload's needs. The slowest of them cost
+          // ~12s, 40% of the budget, and a shared runner spends that margin
+          // (#3537): the test that timed out differed every attempt because it
+          // was only ever whichever inherited test was slowest that run. 120s
+          // is the tier the deliberately-annotated heavy files already use.
+          //
+          // This is a liveness bound, not a performance budget. The perf tests
+          // assert their own ceilings against `performance.now()`
+          // (tessellation.perf, height.perf, compartments.perf), so a slow
+          // regression is still caught by the assertion that exists for it, and
+          // a wedged kernel is still bounded by the job's `timeout-minutes`.
+          testTimeout: 120_000,
+          // Separate knob with its own, tighter default (10s), and every file
+          // here boots the WASM kernel via `initTestKernel()` in `beforeAll`.
+          // 175 of 199 hooks were given an explicit raise by hand, which is why
+          // `}, 30000)` on a hook is load-bearing rather than a restatement of
+          // the default the way the `it`-level ones are. This covers the 24 that
+          // were never given one.
+          hookTimeout: 120_000,
         },
       },
       {


### PR DESCRIPTION
Closes #3537.

Two separate defects sat behind the flaky self-hosted shards. One is fixed here; the other is fixed on the mini and is written down here so it stays fixed.

## The cap those tests ran under came from a different workload

`1423` of the generators project's `1748` `it`s declare no timeout and inherit the root `testTimeout: 30000`, a figure calibrated for pure-JS tests that finish in milliseconds. So the cap the real-OCCT tests actually ran under was never chosen for them, which is exactly why the failing test differed run to run: it was only ever whichever inherited test happened to be slowest that attempt.

- `testTimeout: 120_000` on the `generators` project, the tier its deliberately-annotated heavy files already use.
- Dropped the 52 `it`-level `30000` pins that restated the old default. The root default was 10s until #402 raised it to 30s, so these were real raises the global bump made redundant. They are the only generator tests that would otherwise have stayed at 30s.
- `hookTimeout: 120_000`. A separate knob with its own tighter default (10s) that was never set. Every file boots the WASM kernel via `initTestKernel()` in `beforeAll`, and 175 of 199 hooks were given an explicit raise by hand, so hook-level `}, 30000)` is load-bearing and is left alone. This covers the 24 that never got one. That part is preventive, not the observed failure.

This is a liveness bound, not a performance budget, and it was never serving as one: a timeout only fires on the slowest test of whatever run trips it. `tessellation.perf` is the one file in this project that enforces timing, via `toBeLessThan(MAX_MS_*)` against `performance.now()`, and the cap does not touch it. The `.perf` files under `__kernel-tests__` only record measurements, and `sharedExclude` keeps that directory out of the project regardless. A wedged kernel stays bounded by `timeout-minutes: 45`.

## The pool advertised more capacity than the host has

The bounding product is `gflt-ci runners x maxWorkers`, because every runner is a process on the one mini. At four runners, `2x5` was correct only for a lone PR; a second in flight made it twenty workers on ten performance cores. **The pool is now two**, which restores `2x5` as the correct sizing rather than a coincidence: ten workers on ten cores, and a second PR queues instead of oversubscribing.

That is a change on the mini, so this file's contribution is the invariant itself, recorded where the next person to register a runner will read it. The shard and worker counts are unchanged from `main`; `ci.yml` here is comments only.

### Why not more shards

I tried `4x3` first and measured it on run `31960552340`. It lost on both axes:

| | 2 x 5, two runners | 4 x 3, four runners |
|---|---|---|
| worst case on the host | 10 workers | 12 workers |
| test step | 199s, 208s | 166s, 196s, 240s, 241s |
| install step | 16s, 49s | 67s, 68s, 68s, 69s |
| slowest shard, total | **250s** | **355s** |
| two queued PRs | **~500s** | ~710s |

Four concurrent `pnpm install`s contend on one disk, so fixed cost rose to a uniform ~68s, and hash sharding balances worse at 4-way than 2-way (1.05x spread becomes 1.45x, and the slowest shard is the critical path). It also never bought cross-PR concurrency: four shards fill four runners, so a second PR queues either way.

The general point, now in the comment: sharding cannot fix a per-test timeout at all. `--shard` splits the file set, so it shortens a job without making any single test faster, and raising the count to match a bigger pool only multiplies the workers on the host.

Option 3 in the issue (a concurrency group) is deliberately not taken: it serialises the job across PRs, and running several branches at once is the normal workflow here. A two-runner pool gets the same bound without the serialisation, since two PRs still overlap on the cloud core shards.

## Verification

Reproduced the failure locally rather than reasoning about the margin. Under four workers, `baseplateGenerator.scenario.overtile`'s over-tile half-grid test ran **33482ms** against its 30s cap and failed, a 3x slowdown from concurrency alone on an otherwise quiet box. After the change the same three files (including `featureBuilder.test.ts`, where 26 pins were dropped) pass: 58 tests, 165.70s wall for 241.99s of test time.

Full CI went green on the `4x3` commit, which exercised strictly more parallelism than what is merging here.

Also checked: `pnpm run typecheck` clean, eslint and prettier clean, workflow YAML parses, no stale references to shard names anywhere, and branch protection requires only `Conventional Commit`, `Build` and `Unit Tests Complete`, all count-agnostic.

One correction to the issue: attempt 3 was not as idle as it looked. Its shard 1/2 test step ran 357s against 208s on a healthy run, so that attempt was already ~1.7x degraded.

## Ordering

The runner deregistration and this PR are independent, but the bound only holds once **both** are done. Merging first is safe: the timeout headroom lands immediately and nothing regresses.
