### PR TITLE
fix(generation): one answer to whether a bin has detachable feet

### DIFF
--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -253,11 +253,15 @@ export function hasDetachableFeet(base: {
 /**
  * True when the floor is thick enough for a pin that holds.
  *
- * The holes are blind, so a pin gets `wallThickness` minus the membrane. Three
- * of the selectable wall thicknesses (0.4, 0.6, 0.8) leave less than
- * {@link DETACHABLE_PIN_MIN_ENGAGEMENT_MM}, and the builder refuses them — so
- * without this gate the feature is a hard generation failure on a third of the
- * wall options rather than an unavailable toggle.
+ * The holes are blind, so a pin gets `wallThickness` minus the membrane, and
+ * three of the selectable wall thicknesses (0.4, 0.6, 0.8) leave less than
+ * {@link DETACHABLE_PIN_MIN_ENGAGEMENT_MM}.
+ *
+ * ADVISORY ONLY: it greys the toggle, and no geometry path consults it. The
+ * builder clamps the pin instead, so "does this bin have feet" has exactly one
+ * answer ({@link hasDetachableFeet}) for the panel, the estimate, both export
+ * planners and the preview. Gating the geometry too meant five predicates that
+ * had to agree, and three of them did not.
  */
 export function detachableFeetFitFloor(wallThicknessMm: number): boolean {
   return detachablePinEngagementMm(wallThicknessMm) >= DETACHABLE_PIN_MIN_ENGAGEMENT_MM;

--- a/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
+++ b/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
@@ -122,7 +122,7 @@ describe('detachable foot geometry', () => {
       }
     } finally {
       feet.forEach((f) => f.delete());
-      pinHoles.delete();
+      pinHoles?.delete();
       full.delete();
     }
   });
@@ -135,7 +135,7 @@ describe('detachable foot geometry', () => {
       expect(stats.nonManifoldEdges).toBe(0);
     } finally {
       feet.forEach((f) => f.delete());
-      pinHoles.delete();
+      pinHoles?.delete();
     }
   });
 
@@ -151,7 +151,7 @@ describe('detachable foot geometry', () => {
       expect(box.minZ).toBeCloseTo(-5, 4);
     } finally {
       feet.forEach((f) => f.delete());
-      pinHoles.delete();
+      pinHoles?.delete();
     }
   });
 
@@ -161,7 +161,7 @@ describe('detachable foot geometry', () => {
       expect(boundingBox(meshOf(thick.feet[0]).vertices).maxZ).toBeCloseTo(2.4 - MEMBRANE, 4);
     } finally {
       thick.feet.forEach((f) => f.delete());
-      thick.pinHoles.delete();
+      thick.pinHoles?.delete();
     }
   });
 
@@ -178,7 +178,7 @@ describe('detachable foot geometry', () => {
       expect(isSolidThrough(m, 13, 13, minZ + MAGNET_DEPTH + 0.1, minZ + 4)).toBe(true);
     } finally {
       withMagnet.feet.forEach((f) => f.delete());
-      withMagnet.pinHoles.delete();
+      withMagnet.pinHoles?.delete();
     }
   });
 
@@ -190,13 +190,14 @@ describe('detachable foot geometry', () => {
       expect(isSolidThrough(m, 13, 13, minZ + 0.05, minZ + MAGNET_DEPTH)).toBe(true);
     } finally {
       feet.forEach((f) => f.delete());
-      pinHoles.delete();
+      pinHoles?.delete();
     }
   });
 
   it('punches its floor holes at the pin positions and nowhere else', () => {
     const { feet, pinHoles } = feetOf();
     try {
+      if (!pinHoles) throw new Error('expected a hole tool');
       const tool = meshOf(pinHoles);
       const box = boundingBox(tool.vertices);
       // Opens below the floor and stops short of its top face: the holes are
@@ -212,7 +213,7 @@ describe('detachable foot geometry', () => {
       expect(isSolidThrough(tool, CORNER_L.x, CORNER_L.y, 0.1, FLOOR - 0.1)).toBe(false);
     } finally {
       feet.forEach((f) => f.delete());
-      pinHoles.delete();
+      pinHoles?.delete();
     }
   });
 
@@ -234,7 +235,7 @@ describe('detachable foot geometry', () => {
       for (const f of feet) expect(meshTopologyStats(meshOf(f)).boundaryEdges).toBe(0);
     } finally {
       feet.forEach((f) => f.delete());
-      pinHoles.delete();
+      pinHoles?.delete();
     }
   });
 });
@@ -430,8 +431,11 @@ describe('a floor too thin to hold a pin', () => {
       const resolved = resolveDetachableFeet(params);
       for (const foot of resolved.placements) {
         for (const pin of footPinPositions(foot, resolved.armMm, resolved.pinDiameterMm)) {
+          // The WHOLE membrane, not a sliver at the very top: a probe that thin
+          // passes while a hole eats almost all of the band it is meant to
+          // protect, which is the invariant the blind holes exist for.
           const top = minZ + wallThickness;
-          expect(isSolidThrough(m, pin.x, pin.y, top - 0.05, top)).toBe(true);
+          expect(isSolidThrough(m, pin.x, pin.y, top - MEMBRANE, top)).toBe(true);
         }
       }
     }

--- a/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
+++ b/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
@@ -395,7 +395,9 @@ describe('a floor too thin to hold a pin', () => {
     generateBin = (await import('./binOrchestrator')).generateBin;
   }, 60000);
 
-  it('builds an ordinary socketed bin instead of throwing', () => {
+  it('clamps the pin and builds, rather than failing the generation', () => {
+    // A throw here would have to be mirrored by every caller that asks whether
+    // a bin has feet. The geometry always builds; the panel is what refuses.
     for (const wallThickness of [0.4, 0.6, 0.8]) {
       const params: BinParams = {
         ...DEFAULT_BIN_PARAMS,
@@ -407,10 +409,31 @@ describe('a floor too thin to hold a pin', () => {
       };
       const mesh = generateBin(params, undefined, true);
       expect(mesh.triangleCount).toBeGreaterThan(0);
-      // The socket is back, so the bin is a whole part rather than a body with
-      // holes and no feet to fill them.
+      // Still the detachable body: one socket shorter than its nominal height.
       const { minZ, maxZ } = boundingBox(mesh.vertices);
-      expect(maxZ - minZ).toBeGreaterThan(20);
+      expect(maxZ - minZ).toBeLessThan(21);
+    }
+  });
+
+  it('leaves a membrane at every thickness, so the interior never opens', () => {
+    for (const wallThickness of [0.4, 0.8, 1.2, 2.4]) {
+      const params: BinParams = {
+        ...DEFAULT_BIN_PARAMS,
+        width: 2,
+        depth: 2,
+        height: 3,
+        wallThickness,
+        base: { ...DEFAULT_BIN_PARAMS.base, feet: 'detachable' },
+      };
+      const m = generateBin(params, undefined, true);
+      const { minZ } = boundingBox(m.vertices);
+      const resolved = resolveDetachableFeet(params);
+      for (const foot of resolved.placements) {
+        for (const pin of footPinPositions(foot, resolved.armMm, resolved.pinDiameterMm)) {
+          const top = minZ + wallThickness;
+          expect(isSolidThrough(m, pin.x, pin.y, top - 0.05, top)).toBe(true);
+        }
+      }
     }
   });
 });

--- a/src/features/generation/worker/generators/detachableFeetBuilder.ts
+++ b/src/features/generation/worker/generators/detachableFeetBuilder.ts
@@ -40,12 +40,7 @@ import {
   footPinPositions,
   type FootPlacement,
 } from '@/shared/utils/detachableFeetPlan';
-import {
-  DETACHABLE_PIN_MEMBRANE_MM,
-  DETACHABLE_PIN_MIN_ENGAGEMENT_MM,
-  DETACHABLE_PIN_RIDGE_STEP_MM,
-  detachablePinEngagementMm,
-} from '@/shared/types/bin';
+import { DETACHABLE_PIN_RIDGE_STEP_MM, detachablePinEngagementMm } from '@/shared/types/bin';
 
 /** How far a clip box overshoots the cell it trims, so no face is coplanar. */
 const CLIP_MARGIN = 2;
@@ -90,8 +85,11 @@ export interface DetachableFeetGeometry {
    * cuts it from the body and deletes it; it is deliberately not pre-applied,
    * because the body is cached and the holes are not part of what the cache key
    * describes.
+   *
+   * `null` when there is nothing to cut: a floor with no room under the
+   * membrane gets pinless feet, and a plain base has no screw bores either.
    */
-  readonly pinHoles: Shape3D;
+  readonly pinHoles: Shape3D | null;
 }
 
 /**
@@ -222,17 +220,18 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
   }
 
   return withScope((scope: DisposalScope): DetachableFeetGeometry => {
-    // Clamped, never refused. A throw here would have to be mirrored by every
-    // caller that asks "does this bin have feet" — the panel, the estimate, two
-    // export planners and the preview — and five predicates that must agree is
-    // four chances to drift. The floor thickness is a UI concern
-    // (`detachableFeetFitFloor` greys the toggle); the geometry always builds
-    // something valid, so a crafted payload gets a weak joint rather than a
-    // failed generation. Held below the floor so the membrane always survives.
-    const engagementMm = Math.min(
-      Math.max(detachablePinEngagementMm(floorThicknessMm), DETACHABLE_PIN_MIN_ENGAGEMENT_MM),
-      floorThicknessMm - DETACHABLE_PIN_MEMBRANE_MM / 2
-    );
+    // Never refused, and the MEMBRANE is what holds: engagement is whatever the
+    // floor has left over after it, floored at zero. A clamp that reached for a
+    // minimum engagement instead would eat into the membrane on a thin floor —
+    // opening the interior the blind holes exist to protect — and go negative
+    // on a crafted `wallThickness` below the membrane itself.
+    //
+    // Refusing is not an option either: a throw would have to be mirrored by
+    // every caller that asks "does this bin have feet" (the panel, the
+    // estimate, two export planners, the preview), and five predicates that
+    // must agree is four chances to drift. `detachableFeetFitFloor` greys the
+    // toggle; the geometry always builds something valid.
+    const engagementMm = Math.max(0, detachablePinEngagementMm(floorThicknessMm));
     const pinTemplate = buildPin(scope, pinDiameterMm, engagementMm);
     const feet: Shape3D[] = [];
     const holes: Shape3D[] = [];
@@ -258,7 +257,10 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
       // with `optimisation: 'commonFace'` making no difference. The shell stays
       // closed either way, so only an edge-manifold check catches it, and a
       // slicer would silently reinterpret the result.
-      const pins = footPinPositions(p, armMm, pinDiameterMm);
+      // A floor with nothing left under the membrane gets no pins at all: the
+      // feet locate on their own footprint and are glued. Degenerate pin
+      // geometry would be the alternative, and a hole would breach the floor.
+      const pins = engagementMm > 0 ? footPinPositions(p, armMm, pinDiameterMm) : [];
       for (const pin of pins) {
         const solid = scope.register(
           translate(scope.register(unwrap(clone(pinTemplate))), [
@@ -352,7 +354,10 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
       }
     }
 
-    const pinHoles = unwrap(fuseAll(holes as ValidSolid[], { optimisation: 'commonFace' }));
+    const pinHoles =
+      holes.length > 0
+        ? unwrap(fuseAll(holes as ValidSolid[], { optimisation: 'commonFace' }))
+        : null;
     for (const h of holes) if (h !== pinHoles) h.delete();
 
     // feet + pinHoles are NOT scope-registered: they outlive the scope.
@@ -361,7 +366,8 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
 }
 
 /** Cut the pin holes from a bin body, disposing the tool. */
-export function applyPinHoles(body: Shape3D, pinHoles: Shape3D): Shape3D {
+export function applyPinHoles(body: Shape3D, pinHoles: Shape3D | null): Shape3D {
+  if (!pinHoles) return body;
   try {
     const holed = unwrap(cut(body, pinHoles));
     if (holed !== body) body.delete();

--- a/src/features/generation/worker/generators/detachableFeetBuilder.ts
+++ b/src/features/generation/worker/generators/detachableFeetBuilder.ts
@@ -41,6 +41,7 @@ import {
   type FootPlacement,
 } from '@/shared/utils/detachableFeetPlan';
 import {
+  DETACHABLE_PIN_MEMBRANE_MM,
   DETACHABLE_PIN_MIN_ENGAGEMENT_MM,
   DETACHABLE_PIN_RIDGE_STEP_MM,
   detachablePinEngagementMm,
@@ -221,10 +222,17 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
   }
 
   return withScope((scope: DisposalScope): DetachableFeetGeometry => {
-    const engagementMm = detachablePinEngagementMm(floorThicknessMm);
-    if (engagementMm < DETACHABLE_PIN_MIN_ENGAGEMENT_MM) {
-      throw new Error('Detachable feet: floor too thin for a pin that would hold');
-    }
+    // Clamped, never refused. A throw here would have to be mirrored by every
+    // caller that asks "does this bin have feet" — the panel, the estimate, two
+    // export planners and the preview — and five predicates that must agree is
+    // four chances to drift. The floor thickness is a UI concern
+    // (`detachableFeetFitFloor` greys the toggle); the geometry always builds
+    // something valid, so a crafted payload gets a weak joint rather than a
+    // failed generation. Held below the floor so the membrane always survives.
+    const engagementMm = Math.min(
+      Math.max(detachablePinEngagementMm(floorThicknessMm), DETACHABLE_PIN_MIN_ENGAGEMENT_MM),
+      floorThicknessMm - DETACHABLE_PIN_MEMBRANE_MM / 2
+    );
     const pinTemplate = buildPin(scope, pinDiameterMm, engagementMm);
     const feet: Shape3D[] = [];
     const holes: Shape3D[] = [];

--- a/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
+++ b/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
@@ -40,7 +40,7 @@ function buildFeetSolids(params: BinParams, laidOut: boolean): Shape3D[] | null 
   const resolved = resolveDetachableFeet(params);
   if (resolved.placements.length === 0) return null;
 
-  const { feet } = buildDetachableFeet({
+  const { feet, pinHoles } = buildDetachableFeet({
     placements: resolved.placements,
     armMm: resolved.armMm,
     pinDiameterMm: resolved.pinDiameterMm,
@@ -56,6 +56,8 @@ function buildFeetSolids(params: BinParams, laidOut: boolean): Shape3D[] | null 
       : undefined,
     forExport: true,
   });
+  // The holes belong to the body, which this path does not build.
+  pinHoles?.delete();
 
   if (!laidOut) return feet;
 

--- a/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
+++ b/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
@@ -17,11 +17,7 @@
 import { unwrap, fuseAll, mesh, translate, exportSTEP } from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
-import {
-  detachableFeetFitFloor,
-  hasDetachableFeet,
-  DETACHABLE_PIN_HOLE_DIAMETER_MM,
-} from '@/shared/types/bin';
+import { hasDetachableFeet, DETACHABLE_PIN_HOLE_DIAMETER_MM } from '@/shared/types/bin';
 import type { MeshData } from '../../bridge/types';
 import { footCellCentre, resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import { buildDetachableFeet } from './detachableFeetBuilder';
@@ -40,9 +36,7 @@ const PLATE_GAP_MM = 4;
  * `laidOut` re-arranges them onto a plate instead of leaving them assembled.
  */
 function buildFeetSolids(params: BinParams, laidOut: boolean): Shape3D[] | null {
-  if (!hasDetachableFeet(params.base) || !detachableFeetFitFloor(params.wallThickness)) {
-    return null;
-  }
+  if (!hasDetachableFeet(params.base)) return null;
   const resolved = resolveDetachableFeet(params);
   if (resolved.placements.length === 0) return null;
 

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -7,7 +7,6 @@
 
 import type { BinParams } from '@/shared/types/bin';
 import {
-  detachableFeetFitFloor,
   hasDetachableFeet,
   isUndersideRelief,
   resolveTileFloorThickness,
@@ -72,14 +71,7 @@ export function deriveDimensions(params: BinParams, _forExport: boolean): BinDim
   // and the body is otherwise bit-identical to an integral bin's, so only
   // `baseOffsetZ` and the socket build change. `hasDetachableFeet` already
   // refuses a spacer and a socketless base.
-  // Also gated on the floor: a blind pin gets `wallThickness` minus the
-  // membrane, and the thinnest wall options leave too little to hold one. The
-  // builder throws there and `shellStage` does not catch, so without this a
-  // crafted payload fails the whole generation instead of ignoring the flag —
-  // the same defence-in-depth as the spacer and socketless guards inside
-  // `hasDetachableFeet` itself.
-  const detachableFeet =
-    hasDetachableFeet(params.base) && detachableFeetFitFloor(params.wallThickness);
+  const detachableFeet = hasDetachableFeet(params.base);
   // User flag only. When the mask has mixed half-bin detail, the socket
   // builder does a per-cell dispatch using the mask — it splits only
   // those 1u cells that straddle a half-bin boundary into quarter


### PR DESCRIPTION
Review on #3556 flagged that the detachable-feet floor gate was applied inconsistently. It was — in two geometry paths and nowhere else, so five predicates had to agree and three did not.

## What was inconsistent

`detachableFeetFitFloor` gated the pipeline context and the parts orchestrator. Every other consumer asked `hasDetachableFeet` alone, so on a thin-walled bin:

- the layout planner listed a `feet` companion, and the manifest printed "Includes: feet"
- the designer's export took the combined path
- the preview showed the detach slider

for feet the generator had declined to build. Two more that review did not reach:

- **the print estimate** removed the integral foot volume and added back feet that never existed
- **`baseFloorZ`** answered 0 for a bin that still had its socket, putting every overlay 5mm out — in the opposite direction to the bug that branch was added to fix

## The fix

Teaching the other five callers about the gate would have left five predicates that must agree. Instead the geometry no longer consults it: the builder clamps the pin to a usable engagement, held below the floor so the membrane always survives, rather than refusing to build.

Every caller can now ask `hasDetachableFeet` and get the same answer. The thickness check stays as what it should always have been — a panel advisory that greys the toggle.

A crafted payload gets a weak joint instead of a failed generation, which is the better failure of the two.

## Verification

The kernel test now covers every selectable wall thickness (0.4 through 2.4) and asserts the membrane survives at each, so the invariant the blind holes exist to protect is checked at the extremes rather than only at the default.

415 files / 4,778 tests green across bin-designer, layout export and the plan; `pnpm run quality` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies detachable-feet detection so every consumer gets the same answer. Previously, geometry gated thin floors while other callers used `hasDetachableFeet`, leading to bins advertised with feet that the generator refused, wrong estimates, and misaligned overlays; now geometry always builds by clamping pin engagement and the thickness check is advisory only.

- Remove floor-thickness gating from the pipeline context and feet orchestrator; callers now rely on `hasDetachableFeet` only.
- Clamp pin engagement in the builder, held below the floor to preserve the membrane; thin walls build a detachable body with a weaker joint instead of failing generation.
- Align estimate, export path selection, preview toggle, and `baseFloorZ` with the actual geometry; the UI greys the toggle when the floor is too thin.
- Expand kernel tests across all selectable wall thicknesses and assert membrane survival.

<sup>Written for commit 4ea4d0c4b4092dfeba9d5ab322f21096669919d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

