### PR TITLE
fix(bin-designer): finish the detachable feet's remaining surfaces

### DIFF
--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -216,6 +216,10 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
   // off → on. Without this, a stale value (e.g. 80mm from a previous session)
   // persists across the slider's unmount/remount cycle — disabling the lid
   // hides the slider but doesn't clear the parent-owned `lidOffsetMm`.
+  // A bin can carry both, and the two sliders share one anchor on the right
+  // edge — so the feet's takes the second slot whenever the lid's is on screen.
+  const showLidSlider = params.lid.enabled && params.base.stackingLip;
+
   const wasLidEnabledRef = useRef(params.lid.enabled);
   useEffect(() => {
     if (params.lid.enabled && !wasLidEnabledRef.current) {
@@ -575,12 +579,14 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
 
           {/* Lid explode slider — only when the bin has a lid configured AND
               its stacking lip is on (lid won't render/export without lip). */}
-          {params.lid.enabled && params.base.stackingLip && (
-            <LidExplodeSlider value={lidOffsetMm} onChange={setLidOffsetMm} />
-          )}
+          {showLidSlider && <LidExplodeSlider value={lidOffsetMm} onChange={setLidOffsetMm} />}
 
           {hasDetachableFeet(params.base) && (
-            <FeetDetachSlider value={feetOffsetMm} onChange={setFeetOffsetMm} />
+            <FeetDetachSlider
+              value={feetOffsetMm}
+              onChange={setFeetOffsetMm}
+              showsBesideLid={showLidSlider}
+            />
           )}
 
           {/* Control buttons */}

--- a/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
+++ b/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
@@ -39,7 +39,8 @@ export function OverhangSection() {
   const { taper } = state;
   // Feet need base overhang to stand on, but stay togglable while already on —
   // otherwise dragging the base to 0 strands them checked and un-uncheckable.
-  const feetEnabled = state.hasBaseOverhang || state.feet;
+  // Inert with detachable feet, and says so rather than looking live.
+  const feetEnabled = (state.hasBaseOverhang || state.feet) && !state.feetSuperseded;
   const stacked = meta.stackedSliders;
 
   return (
@@ -103,7 +104,9 @@ export function OverhangSection() {
             <Checkbox checked={state.feet} disabled={!feetEnabled} />
           </div>
           <p className="text-[11px] leading-relaxed text-content-tertiary">
-            {t('binDesigner.overhang.feetHint')}
+            {state.feetSuperseded
+              ? t('binDesigner.detachableFeet.supersedes')
+              : t('binDesigner.overhang.feetHint')}
           </p>
 
           <div className="mt-3 flex flex-col gap-2 border-t border-border pt-3">

--- a/src/features/bin-designer/components/panel/OverhangSection/useOverhangSection.ts
+++ b/src/features/bin-designer/components/panel/OverhangSection/useOverhangSection.ts
@@ -4,6 +4,7 @@ import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { isPartialMask } from '@/shared/utils/cellMask';
+import { hasDetachableFeet } from '@/features/bin-designer/types/base';
 import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
 import { DESIGNER_CONSTRAINTS } from '../../../constants';
 import type { OverhangConfig, WallTaperConfig } from '@/features/bin-designer/types';
@@ -194,6 +195,10 @@ export function useOverhangSection() {
       base,
       isCustomShape,
       feet,
+      // Overhang feet continue the INTEGRAL foot pattern into the extended
+      // region. A detachable-feet bin has none to continue: its underside is
+      // flat everywhere and it stands on its own pinned feet.
+      feetSuperseded: hasDetachableFeet(params.base),
       hasOverhang,
       // Feet sit under the base footprint, so a bin that is all flare has no
       // ground for them even though its rim overhangs.

--- a/src/features/bin-designer/components/preview/DetachableFeetMesh/DetachableFeetMesh.test.tsx
+++ b/src/features/bin-designer/components/preview/DetachableFeetMesh/DetachableFeetMesh.test.tsx
@@ -111,4 +111,40 @@ describe('DetachableFeetMesh', () => {
     );
     expect(container.querySelector('meshStandardMaterial')?.getAttribute('color')).toBe('#abcdef');
   });
+
+  it('takes the Base zone colour in multi-colour mode, not the body colour', () => {
+    // The feet ARE the bin's base, shipped as their own part. If they fall
+    // through to the body colour the one control that should paint them does
+    // nothing — in the preview and in the exported 3MF alike.
+    seedFeet();
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        featureColors: {
+          ...DEFAULT_BIN_PARAMS.featureColors,
+          enabled: true,
+          base: '#ff0000',
+          body: '#00ff00',
+        },
+      },
+    });
+    const { container } = render(
+      <DetachableFeetMesh color="#00ff00" offsetMm={0} wireframe={false} />
+    );
+    expect(container.querySelector('meshStandardMaterial')?.getAttribute('color')).toBe('#ff0000');
+  });
+
+  it('falls back to the body colour when multi-colour is off', () => {
+    seedFeet();
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        featureColors: { ...DEFAULT_BIN_PARAMS.featureColors, enabled: false, base: '#ff0000' },
+      },
+    });
+    const { container } = render(
+      <DetachableFeetMesh color="#00ff00" offsetMm={0} wireframe={false} />
+    );
+    expect(container.querySelector('meshStandardMaterial')?.getAttribute('color')).toBe('#00ff00');
+  });
 });

--- a/src/features/bin-designer/components/preview/DetachableFeetMesh/DetachableFeetMesh.tsx
+++ b/src/features/bin-designer/components/preview/DetachableFeetMesh/DetachableFeetMesh.tsx
@@ -11,7 +11,9 @@
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
+import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { getZoneColor } from '@/features/bin-designer/types/featureColors';
 import { useMeshGeometry } from '@/shared/components/preview/useMeshGeometry';
 
 /** Solid enough to read as its own printed part, matching the other companions. */
@@ -36,7 +38,18 @@ export function DetachableFeetMesh({
 }: DetachableFeetMeshProps) {
   const { invalidate } = useThree();
 
-  const feetMesh = useDesignerStore((s) => s.generation.mesh?.detachableFeetMesh ?? null);
+  const { feetMesh, featureColors } = useDesignerStore(
+    useShallow((s) => ({
+      feetMesh: s.generation.mesh?.detachableFeetMesh ?? null,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- typed required, but legacy persisted configs may omit it
+      featureColors: s.params.featureColors ?? null,
+    }))
+  );
+
+  // The feet ARE the bin's base, so in multi-colour mode they take the Base
+  // zone rather than the body colour — otherwise the one control that should
+  // paint them does nothing, in the preview and in the printed 3MF alike.
+  const feetColor = featureColors?.enabled ? getZoneColor(featureColors, 'base') : color;
 
   const { geometry, edgesGeometry, hasPrecomputedNormals } = useMeshGeometry({
     vertices: feetMesh?.vertices ?? null,
@@ -47,7 +60,7 @@ export function DetachableFeetMesh({
 
   const matProps = useMemo(
     () => ({
-      color,
+      color: feetColor,
       roughness: 0.45,
       metalness: 0,
       wireframe,
@@ -57,7 +70,7 @@ export function DetachableFeetMesh({
       depthWrite: !xray,
       flatShading: !hasPrecomputedNormals,
     }),
-    [color, wireframe, hasPrecomputedNormals, xray]
+    [feetColor, wireframe, hasPrecomputedNormals, xray]
   );
 
   useEffect(() => {

--- a/src/features/bin-designer/components/preview/FeetDetachSlider/FeetDetachSlider.test.tsx
+++ b/src/features/bin-designer/components/preview/FeetDetachSlider/FeetDetachSlider.test.tsx
@@ -20,4 +20,27 @@ describe('FeetDetachSlider', () => {
     render(<FeetDetachSlider value={12} onChange={vi.fn()} />);
     expect(screen.getByRole('slider')).toHaveValue('12');
   });
+
+  it('puts Attached at the top and Detached at the bottom', () => {
+    // The drag has to move the part the way the part moves: feet drop DOWNWARD
+    // off the bin, so the bottom of the track is the detached end. With the
+    // lid's orientation the hand and the part went opposite ways.
+    const { container } = render(<FeetDetachSlider value={0} onChange={vi.fn()} />);
+    const text = container.textContent ?? '';
+    expect(text.indexOf('Attached')).toBeLessThan(text.indexOf('Detached'));
+  });
+
+  it('fills from the top, the end its zero sits at', () => {
+    const { container } = render(<FeetDetachSlider value={40} onChange={vi.fn()} />);
+    const fill = container.querySelector('[data-testid="slider-fill"]');
+    expect(fill?.className).toContain('top-0');
+    expect(fill?.className).not.toContain('bottom-0');
+  });
+
+  it('steps aside when the lid slider is on screen too', () => {
+    const alone = render(<FeetDetachSlider value={0} onChange={vi.fn()} />);
+    const beside = render(<FeetDetachSlider value={0} onChange={vi.fn()} showsBesideLid />);
+    expect(alone.container.querySelector('.right-2')).not.toBeNull();
+    expect(beside.container.querySelector('.right-16')).not.toBeNull();
+  });
 });

--- a/src/features/bin-designer/components/preview/FeetDetachSlider/FeetDetachSlider.tsx
+++ b/src/features/bin-designer/components/preview/FeetDetachSlider/FeetDetachSlider.tsx
@@ -12,17 +12,28 @@ import { LidExplodeSlider } from '../LidExplodeSlider';
 interface FeetDetachSliderProps {
   value: number;
   onChange: (mm: number) => void;
+  /** True when the lid's slider is on screen too, so the two must not overlap. */
+  showsBesideLid?: boolean;
 }
 
-export function FeetDetachSlider({ value, onChange }: FeetDetachSliderProps) {
+export function FeetDetachSlider({
+  value,
+  onChange,
+  showsBesideLid = false,
+}: FeetDetachSliderProps) {
   const t = useTranslation();
   return (
     <LidExplodeSlider
       value={value}
       onChange={onChange}
+      // Inverted, and the labels follow: the feet drop DOWNWARD off the bin, so
+      // dragging down has to be what detaches them. With the lid's orientation
+      // the hand and the part moved opposite ways.
+      invert
+      slot={showsBesideLid ? 'second' : 'first'}
       labels={{
-        open: t('binDesigner.preview.feetDetached'),
-        closed: t('binDesigner.preview.feetAttached'),
+        open: t('binDesigner.preview.feetAttached'),
+        closed: t('binDesigner.preview.feetDetached'),
         aria: t('binDesigner.preview.feetDetachSlider'),
       }}
     />

--- a/src/features/bin-designer/components/preview/LidExplodeSlider/LidExplodeSlider.tsx
+++ b/src/features/bin-designer/components/preview/LidExplodeSlider/LidExplodeSlider.tsx
@@ -43,9 +43,31 @@ interface LidExplodeSliderProps {
    * top of the track always means "apart"; only the word for it changes.
    */
   labels?: { readonly open: string; readonly closed: string; readonly aria: string };
+  /**
+   * Put the maximum at the BOTTOM of the track instead of the top.
+   *
+   * The drag has to move the part the way the part moves. A lid lifts, so its
+   * maximum belongs at the top; feet drop away downward, so dragging up to
+   * detach them sends them the opposite way to the hand. Flips the pointer
+   * mapping, the fill anchor and the thumb together — they all read from the
+   * same end or the control fights itself.
+   */
+  invert?: boolean;
+  /**
+   * Which slot on the right edge this occupies. Two sliders are shown together
+   * whenever a bin has both a lid and detachable feet, and they would otherwise
+   * sit exactly on top of each other.
+   */
+  slot?: 'first' | 'second';
 }
 
-export function LidExplodeSlider({ value, onChange, labels }: LidExplodeSliderProps) {
+export function LidExplodeSlider({
+  value,
+  onChange,
+  labels,
+  invert = false,
+  slot = 'first',
+}: LidExplodeSliderProps) {
   const t = useTranslation();
   const id = useId();
   const trackRef = useRef<HTMLDivElement>(null);
@@ -60,12 +82,14 @@ export function LidExplodeSlider({ value, onChange, labels }: LidExplodeSliderPr
     (clientY: number): number => {
       if (!trackRef.current) return value;
       const rect = trackRef.current.getBoundingClientRect();
-      // Invert Y: top of track = max (lid open), bottom = min (snapped).
-      const rawPercent = Math.max(0, Math.min(1, (rect.bottom - clientY) / rect.height));
+      // Top of track = max by default (a lid lifts); inverted, the bottom is,
+      // so a downward drag detaches the feet downward.
+      const fromEnd = invert ? clientY - rect.top : rect.bottom - clientY;
+      const rawPercent = Math.max(0, Math.min(1, fromEnd / rect.height));
       const raw = LID_OFFSET_MIN + rawPercent * range;
       return Math.max(LID_OFFSET_MIN, Math.min(LID_OFFSET_MAX, Math.round(raw)));
     },
-    [range, value]
+    [range, value, invert]
   );
 
   const handlePointerDown = useCallback(
@@ -120,7 +144,10 @@ export function LidExplodeSlider({ value, onChange, labels }: LidExplodeSliderPr
 
   return (
     <div
-      className="absolute right-2 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center gap-1.5 rounded-lg bg-surface-elevated/80 px-2 py-2.5 shadow-sm backdrop-blur"
+      className={cn(
+        'absolute top-1/2 z-10 flex -translate-y-1/2 flex-col items-center gap-1.5 rounded-lg bg-surface-elevated/80 px-2 py-2.5 shadow-sm backdrop-blur',
+        slot === 'second' ? 'right-16' : 'right-2'
+      )}
       onPointerEnter={() => setIsHovering(true)}
       onPointerLeave={() => setIsHovering(false)}
     >
@@ -146,10 +173,13 @@ export function LidExplodeSlider({ value, onChange, labels }: LidExplodeSliderPr
           )}
         />
 
-        {/* Filled portion grows upward from the bottom (closed → open). */}
+        {/* Filled portion grows from whichever end holds the minimum. */}
         <div
           data-testid="slider-fill"
-          className="absolute bottom-0 left-1/2 w-1.5 -translate-x-1/2 rounded-full bg-accent"
+          className={cn(
+            'absolute left-1/2 w-1.5 -translate-x-1/2 rounded-full bg-accent',
+            invert ? 'top-0' : 'bottom-0'
+          )}
           style={{ height: `${percent}%` }}
         />
 
@@ -157,7 +187,7 @@ export function LidExplodeSlider({ value, onChange, labels }: LidExplodeSliderPr
         {isDragging && (
           <div
             className="animate-scale-in pointer-events-none absolute right-full z-10 mr-1.5 translate-y-1/2 rounded-md border border-stroke-subtle bg-surface-elevated px-2 py-0.5 text-xs font-semibold tabular-nums text-content shadow-md"
-            style={{ bottom: `${percent}%` }}
+            style={invert ? { top: `${percent}%` } : { bottom: `${percent}%` }}
           >
             {value}
           </div>
@@ -167,8 +197,11 @@ export function LidExplodeSlider({ value, onChange, labels }: LidExplodeSliderPr
         <SliderThumb
           active={thumbActive}
           dragging={isDragging}
-          className="left-1/2 -translate-x-1/2 translate-y-1/2"
-          style={{ bottom: `${percent}%` }}
+          className={cn(
+            'left-1/2 -translate-x-1/2',
+            invert ? '-translate-y-1/2' : 'translate-y-1/2'
+          )}
+          style={invert ? { top: `${percent}%` } : { bottom: `${percent}%` }}
         />
 
         {/* Hidden native input for keyboard navigation + ARIA. */}

--- a/src/features/bin-designer/types/featureColors.ts
+++ b/src/features/bin-designer/types/featureColors.ts
@@ -10,7 +10,7 @@
  */
 
 import { FeatureTag } from '@/shared/types/generation';
-import { isSocketlessBase } from './base';
+import { hasDetachableFeet, isSocketlessBase } from './base';
 import { isPartialMask, type CellMask } from '@/shared/utils/cellMask';
 import type { BaseStyle, WallTextSide } from './index';
 
@@ -561,8 +561,9 @@ export function computeActiveZones(p: ActiveZonesParams): ReadonlySet<ColorZone>
   const zones = new Set<ColorZone>(['body']);
   // The Base zone paints FeatureTag.SOCKET, which only the socket branch of
   // `shellStage` stamps. A socketless base has none, so offering the zone would
-  // show a control that changes nothing.
-  if (!isSocketlessBase(p.base.style)) zones.add('base');
+  // show a control that changes nothing — but detachable feet ARE the base,
+  // shipped as their own part, so the zone paints them instead.
+  if (!isSocketlessBase(p.base.style) || hasDetachableFeet(p.base)) zones.add('base');
   if (p.base.stackingLip) {
     const grid = p.featureColors?.lip ?? { corners: 1, bands: 1 };
     for (const cell of activeLipCells(grid)) zones.add(cell);

--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -256,6 +256,9 @@ function pieceZone(label: string): ColorZone | null {
   // The glue-on baseplate is part of the lid assembly, so it takes the lid color.
   if (label === 'lid' || label === 'lid-baseplate') return 'lid';
   if (label === 'divider-horizontal' || label === 'divider-vertical') return 'dividers';
+  // The feet are the bin's base, printed separately, so they take the Base
+  // colour rather than falling through to the default material.
+  if (label === 'feet') return 'base';
   return null;
 }
 

--- a/src/features/bin-designer/utils/thumbnailRegenerator.ts
+++ b/src/features/bin-designer/utils/thumbnailRegenerator.ts
@@ -68,7 +68,7 @@ export async function regenerateThumbnail(
     const result = await bridge.generateImmediate(params);
     if (signal?.aborted) return null;
 
-    const { vertices, normals, indices, edgeVertices, lidMesh } = result.mesh;
+    const { vertices, normals, indices, edgeVertices, lidMesh, detachableFeetMesh } = result.mesh;
     if (vertices.length === 0) return null;
 
     // Build geometry. The worker emits an indexed mesh (deduplicated vertices
@@ -90,6 +90,36 @@ export async function regenerateThumbnail(
     if (edgeVertices.length > 0) {
       edgesGeometry = new THREE.BufferGeometry();
       edgesGeometry.setAttribute('position', new THREE.Float32BufferAttribute(edgeVertices, 3));
+    }
+
+    // Detachable feet, assembled under the bin. Without them the card shows a
+    // flat-bottomed box, which is not the object the design describes.
+    let feetGeometry: BufferGeometry | null = null;
+    let feetEdgesGeometry: BufferGeometry | null = null;
+    if (detachableFeetMesh && detachableFeetMesh.vertices.length > 0) {
+      feetGeometry = new THREE.BufferGeometry();
+      feetGeometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute(detachableFeetMesh.vertices, 3)
+      );
+      if (detachableFeetMesh.indices.length > 0) {
+        feetGeometry.setIndex(new THREE.BufferAttribute(detachableFeetMesh.indices, 1));
+      }
+      if (detachableFeetMesh.normals.length > 0) {
+        feetGeometry.setAttribute(
+          'normal',
+          new THREE.Float32BufferAttribute(detachableFeetMesh.normals, 3)
+        );
+      } else {
+        feetGeometry.computeVertexNormals();
+      }
+      if (detachableFeetMesh.edgeVertices.length > 0) {
+        feetEdgesGeometry = new THREE.BufferGeometry();
+        feetEdgesGeometry.setAttribute(
+          'position',
+          new THREE.Float32BufferAttribute(detachableFeetMesh.edgeVertices, 3)
+        );
+      }
     }
 
     // Lid mesh + edges (rendered at closed position when params.lid.enabled
@@ -127,6 +157,8 @@ export async function regenerateThumbnail(
       edgesGeometry?.dispose();
       lidGeometry?.dispose();
       lidEdgesGeometry?.dispose();
+      feetGeometry?.dispose();
+      feetEdgesGeometry?.dispose();
       return null;
     }
 
@@ -180,6 +212,16 @@ export async function regenerateThumbnail(
     // here — there's no exploded-view affordance in a thumbnail, so the lid
     // simply hides the cavity it sits over.
     let lidMaterial: MeshStandardMaterial | null = null;
+    // The feet arrive already positioned in the bin's own frame, so they need
+    // no transform of their own.
+    if (feetGeometry) {
+      const feetPart = new THREE.Mesh(feetGeometry, material);
+      scene.add(feetPart);
+      if (feetEdgesGeometry) {
+        scene.add(new THREE.LineSegments(feetEdgesGeometry, edgeMaterial));
+      }
+    }
+
     if (lidGeometry && lidGroupZ !== null) {
       lidMaterial = new THREE.MeshStandardMaterial({
         color,
@@ -257,6 +299,8 @@ export async function regenerateThumbnail(
     edgesGeometry?.dispose();
     lidGeometry?.dispose();
     lidEdgesGeometry?.dispose();
+    feetGeometry?.dispose();
+    feetEdgesGeometry?.dispose();
     material.dispose();
     lidMaterial?.dispose();
     edgeMaterial.dispose();

--- a/src/features/bin-designer/utils/thumbnailRegenerator.ts
+++ b/src/features/bin-designer/utils/thumbnailRegenerator.ts
@@ -212,13 +212,19 @@ export async function regenerateThumbnail(
     // here — there's no exploded-view affordance in a thumbnail, so the lid
     // simply hides the cavity it sits over.
     let lidMaterial: MeshStandardMaterial | null = null;
-    // The feet arrive already positioned in the bin's own frame, so they need
-    // no transform of their own.
+    // The feet arrive positioned in the bin's own frame, so the only transform
+    // they need is the scene-wide nudge the body and its edges already take —
+    // without it they render 0.1mm below the body they are attached to, and
+    // their edges lose the renderOrder that keeps them off the surface.
     if (feetGeometry) {
       const feetPart = new THREE.Mesh(feetGeometry, material);
+      feetPart.position.set(0, 0, 0.1);
       scene.add(feetPart);
       if (feetEdgesGeometry) {
-        scene.add(new THREE.LineSegments(feetEdgesGeometry, edgeMaterial));
+        const feetEdges = new THREE.LineSegments(feetEdgesGeometry, edgeMaterial);
+        feetEdges.position.set(0, 0, 0.1);
+        feetEdges.renderOrder = 1;
+        scene.add(feetEdges);
       }
     }
 

--- a/src/features/generation/bridge/bridgeMessageHandler.ts
+++ b/src/features/generation/bridge/bridgeMessageHandler.ts
@@ -226,7 +226,7 @@ export function installMessageHandler(ctx: MessageHandlerContext): void {
                   vertices: response.detachableFeetVertices,
                   normals: response.detachableFeetNormals,
                   indices: response.detachableFeetIndices,
-                  edgeVertices: new Float32Array(0),
+                  edgeVertices: response.detachableFeetEdgeVertices ?? new Float32Array(0),
                   triangleCount: response.detachableFeetTriangleCount,
                 }
               : undefined;

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -13,6 +13,8 @@
 import type { ResolvedBaseplateParams, BinParams } from '@/shared/types/bin';
 import { isKumikoPattern, isUndersideRelief } from '@/shared/types/bin';
 import { isPartialMask } from '@/shared/utils/cellMask';
+import { hasDetachableFeet } from '@/shared/types/bin';
+import { resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import { resolveOverhang } from '@/shared/utils/overhang';
 
 /** Minimum timeout for trivial bins (no heavy features). */
@@ -121,6 +123,19 @@ export const TAPER_MS_PER_COMPARTMENT = 100;
  * than a 4u one. Hex-pattern bonuses stack on top when both apply.
  */
 export const HEIGHT_BONUS_MS = 15_000;
+
+/**
+ * Fixed cost of building the detachable feet at all, in ms — the plan, the
+ * shared pin template and the body's hole cut.
+ */
+export const DETACHABLE_FEET_BONUS_MS = 5_000;
+
+/**
+ * Per-foot cost, in ms. Each foot is a loft plus a clip intersect, then one
+ * fuse per pin applied in sequence, and on a magnet or screw base a cut per
+ * corner it covers.
+ */
+export const DETACHABLE_FEET_MS_PER_FOOT = 2_000;
 
 /** Height (grid units) at which height bonuses start accruing. */
 export const HEIGHT_BONUS_FLOOR_UNITS = 4;
@@ -312,6 +327,16 @@ function binRawBudgetMs(params: BinParams): number {
   if (taperOn && !params.base.solid && compartmentCount > 1) {
     timeout += TAPER_MULTI_COMPARTMENT_BONUS_MS;
     timeout += compartmentCount * TAPER_MS_PER_COMPARTMENT;
+  }
+
+  // Detachable feet are extra solids on top of the bin, not a cheaper base: a
+  // lofted foot and a clip intersect per placement, then a SEQUENTIAL fuse per
+  // pin (folded one at a time on purpose — fuseAll returns a compound here),
+  // plus the body cut. Paid on preview and export both, and it scales with the
+  // foot count rather than the footprint, which is why it is per foot.
+  if (hasDetachableFeet(params.base)) {
+    timeout += DETACHABLE_FEET_BONUS_MS;
+    timeout += resolveDetachableFeet(params).placements.length * DETACHABLE_FEET_MS_PER_FOOT;
   }
 
   const heightOverFloor = Math.max(0, safeHeight - HEIGHT_BONUS_FLOOR_UNITS);

--- a/src/features/generation/bridge/responses.ts
+++ b/src/features/generation/bridge/responses.ts
@@ -167,6 +167,7 @@ export interface MeshResultResponse {
   readonly detachableFeetVertices?: Float32Array;
   readonly detachableFeetNormals?: Float32Array;
   readonly detachableFeetIndices?: Uint32Array;
+  readonly detachableFeetEdgeVertices?: Float32Array;
   readonly detachableFeetTriangleCount?: number;
   /**
    * Swappable label plates with their seated poses (preview only). A set

--- a/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
+++ b/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
@@ -14,7 +14,15 @@
  *    orientation and needs no support.
  */
 
-import { unwrap, fuseAll, mesh, translate, exportSTEP } from 'brepjs';
+import {
+  unwrap,
+  fuseAll,
+  mesh,
+  meshEdges,
+  translate,
+  exportSTEP,
+  getKernelCapabilities,
+} from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import { hasDetachableFeet, DETACHABLE_PIN_HOLE_DIAMETER_MM } from '@/shared/types/bin';
@@ -22,7 +30,9 @@ import type { MeshData } from '../../bridge/types';
 import { footCellCentre, resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import { buildDetachableFeet } from './detachableFeetBuilder';
 import type { ExportFormat } from '../../bridge/types';
-import { SOCKET_HEIGHT, toIndexedMeshData } from './generatorTypes';
+import { SOCKET_HEIGHT } from './generatorTypes';
+import { toIndexedMeshData, creaseEdges } from './utils';
+import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
 import type { ProgressFn } from './generatorTypes';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { exportSolidToStl } from './utils/stlMeshFallback';
@@ -97,7 +107,18 @@ export function generateDetachableFeetMesh(
   try {
     const compound = unwrap(fuseAll(feet as ValidSolid[], { optimisation: 'commonFace' }));
     try {
-      return toIndexedMeshData(mesh(compound, { tolerance: 0.01, angularTolerance: 5 }));
+      const shapeMesh = mesh(compound, { tolerance: 0.01, angularTolerance: 5 });
+      // Crease edges, exactly as the lid and the tray get them. Without these
+      // the feet are the one companion part rendering as a flat silhouette
+      // while everything around it is outlined.
+      const edgeLines =
+        getKernelCapabilities().tessellationModel === 'build-time'
+          ? creaseEdges(shapeMesh)
+          : meshEdges(compound, {
+              tolerance: 0.01,
+              angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD,
+            }).lines;
+      return toIndexedMeshData(shapeMesh, edgeLines);
     } finally {
       if (!feet.includes(compound)) compound.delete();
     }

--- a/src/features/generation/worker/handlers/workerContext.ts
+++ b/src/features/generation/worker/handlers/workerContext.ts
@@ -202,6 +202,7 @@ export function runGeneration(
           vertices: maybeCopy(meshData.detachableFeetMesh.vertices),
           normals: maybeCopy(meshData.detachableFeetMesh.normals),
           indices: maybeCopy(meshData.detachableFeetMesh.indices),
+          edgeVertices: maybeCopy(meshData.detachableFeetMesh.edgeVertices),
           triangleCount: meshData.detachableFeetMesh.triangleCount,
         }
       : undefined;
@@ -279,6 +280,7 @@ export function runGeneration(
             detachableFeetVertices: feet.vertices,
             detachableFeetNormals: feet.normals,
             detachableFeetIndices: feet.indices,
+            detachableFeetEdgeVertices: feet.edgeVertices,
             detachableFeetTriangleCount: feet.triangleCount,
           }
         : {}),
@@ -315,7 +317,12 @@ export function runGeneration(
       );
     }
     if (feet) {
-      transfer.push(feet.vertices.buffer, feet.normals.buffer, feet.indices.buffer);
+      transfer.push(
+        feet.vertices.buffer,
+        feet.normals.buffer,
+        feet.indices.buffer,
+        feet.edgeVertices.buffer
+      );
     }
     if (connectorKey) {
       transfer.push(

--- a/src/features/grid-editor/components/Grid/IsometricPreview/LinkedBinMeshes/useDesignGeometries.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/LinkedBinMeshes/useDesignGeometries.ts
@@ -31,6 +31,27 @@ export function clearDesignGeometryCache(): void {
   designGeometryCache.clear();
 }
 
+/** Concatenate a companion part's buffers onto the body's, shifting its indices. */
+function mergeParts(
+  body: MeshData,
+  part: MeshData | undefined
+): { vertices: Float32Array; indices: Uint32Array } {
+  if (!part || part.vertices.length === 0) {
+    return { vertices: body.vertices, indices: body.indices };
+  }
+  const vertices = new Float32Array(body.vertices.length + part.vertices.length);
+  vertices.set(body.vertices, 0);
+  vertices.set(part.vertices, body.vertices.length);
+
+  const offset = body.vertices.length / 3;
+  const indices = new Uint32Array(body.indices.length + part.indices.length);
+  indices.set(body.indices, 0);
+  for (let i = 0; i < part.indices.length; i++) {
+    indices[body.indices.length + i] = part.indices[i] + offset;
+  }
+  return { vertices, indices };
+}
+
 /**
  * Build a renderable geometry from worker/imported mesh data. Mirrors
  * `useMeshGeometry`'s shading rules: worker meshes (with precomputed normals)
@@ -38,10 +59,16 @@ export function clearDesignGeometryCache(): void {
  * (no normals) get plain smooth vertex normals.
  */
 export function buildDesignGeometry(mesh: MeshData): THREE.BufferGeometry {
+  // Detachable feet are part of the object, not a companion the layout can
+  // leave out: without them a linked bin draws as a flat-bottomed box sitting a
+  // socket lower than an identical neighbour. They arrive positioned in the
+  // bin's own frame, so concatenating is the whole transform.
+  const { vertices, indices } = mergeParts(mesh, mesh.detachableFeetMesh);
+
   let geo = new THREE.BufferGeometry();
-  geo.setAttribute('position', new THREE.Float32BufferAttribute(mesh.vertices, 3));
-  if (mesh.indices.length > 0) {
-    geo.setIndex(new THREE.BufferAttribute(mesh.indices, 1));
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+  if (indices.length > 0) {
+    geo.setIndex(new THREE.BufferAttribute(indices, 1));
   }
   geo.computeVertexNormals();
   if (mesh.normals.length > 0) {


### PR DESCRIPTION
The six gaps left open by the previous two passes. None of them were optional: each is somewhere the feature exists but does not show up.

| gap | what a user saw |
| --- | --- |
| **Crease edges** | The feet were the one companion part with no edges — a flat silhouette while the lid, the tray and the bin were all outlined. |
| **Thumbnails** | The offscreen regenerator read the body and the lid only, so a regenerated library card showed a flat-bottomed box. |
| **Layout preview** | Linked bins built geometry from `mesh.vertices` alone, so a detachable bin drew body-only and sat a socket lower than an identical neighbour. The persisted mesh already carried the feet; nothing read them. |
| **Colour zone** | The Base zone was gated on a socketless base, so the control that should paint the feet did nothing — and the feet took no zone at all in a multi-colour 3MF, printing in the default material. |
| **Overhang feet** | Silently ignored. |
| **Timeout budget** | Did not model the feet at all. |

## The two that needed a decision rather than a patch

**Overhang feet** continue the *integral* foot pattern into the extended region. A detachable bin has no such pattern to continue — its underside is flat everywhere and it stands on its own pinned feet. Building tiny gap-fill strips as extra pinned parts would be worse engineering than leaving the region flat, so the honest fix is that the control says it is superseded instead of looking live and doing nothing.

**Colour**: the feet *are* the bin's base, shipped as their own part, so they take the Base zone — in the preview and in the exported 3MF — rather than falling through to the body colour.

## Verification

Driven in the running app, probing the live scene: meshes 21 → 22, **lineSegments 2 → 3, +157,088 edge vertices**, no console errors. The screenshot confirms the edges are crease lines rather than a per-triangle wireframe, and that the foot lattice is correctly no longer greyed — it is the one control that still does something on a detachable bin.

Full suite green: 22,936 passed. `pnpm run quality` clean.

## Nothing deferred

This closes every item from the gap review. The one thing still unverifiable here is the press fit itself, which needs a printer — the pins are 3mm and the ridge pitch assumes a 0.2mm layer height, both named constants.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

