### PR TITLE
feat(bin-designer): show lid cutout keep-outs instead of clipping silently

### DIFF
--- a/e2e/bin-designer/lid-cutout-keepouts.spec.ts
+++ b/e2e/bin-designer/lid-cutout-keepouts.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * The lid cutout editor shows what the worker will clip around.
+ *
+ * A hole drawn across a magnetic lid's retention boss is clipped by the worker,
+ * correctly, so the boss survives and the lid keeps holding. Nothing in the
+ * editor used to say so: the shape drew as if it would cut cleanly and the
+ * printed part came out with an unexplained disc-shaped island in the slot.
+ *
+ * Covered here rather than in a unit test because what can break is the WIRING.
+ * `lidWindowFit` is unit-tested against windows built by hand; whether the real
+ * window reaches the canvas at all, and whether the flag reaches the banner, is
+ * only answerable with the app running.
+ *
+ * Run with: `pnpm test:e2e e2e/bin-designer/lid-cutout-keepouts.spec.ts`
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures';
+
+test.use({
+  launchOptions: {
+    args: ['--use-gl=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist'],
+  },
+});
+
+async function waitForGenerationComplete(page: Page): Promise<void> {
+  await expect(page.getByRole('status', { name: /generating mesh/i })).toHaveCount(0, {
+    timeout: 30_000,
+  });
+}
+
+test.describe('Lid cutout keep-outs', () => {
+  test('a shape over a magnet boss is flagged and can be moved clear', async ({ page }) => {
+    test.setTimeout(180_000);
+    await page.goto('/designer');
+
+    const canvas = page.locator('canvas').first();
+    await expect(canvas).toBeVisible({ timeout: 120_000 });
+    await waitForGenerationComplete(page);
+
+    const lidToggle = page.getByRole('switch', { name: 'Enable lid' });
+    await lidToggle.scrollIntoViewIfNeeded();
+    await lidToggle.click();
+    await expect(lidToggle).toBeChecked();
+    await waitForGenerationComplete(page);
+
+    // Magnetic is the attachment that grows retention bosses; the other modes
+    // have no keep-outs at all, so this is the only one that exercises them.
+    const attachment = page.getByRole('radiogroup', { name: 'Attachment' });
+    await attachment.getByRole('radio', { name: 'Magnetic' }).click();
+    await waitForGenerationComplete(page);
+
+    await page.getByRole('button', { name: /Cut holes in the lid/i }).click();
+    const gotIt = page.getByRole('button', { name: /Got it/i });
+    if (await gotIt.isVisible().catch(() => false)) await gotIt.click();
+
+    const banner = page.getByText(/will be clipped/i);
+    await expect(banner).toHaveCount(0);
+
+    // Click-to-place a rectangle onto the board's front-left corner, which is
+    // where a 2x2 lid puts its first boss.
+    await page.mouse.click(100, 527);
+    await expect(banner).toBeVisible();
+
+    // Growing the bin is not the mechanism here — a shape lying on a boss is
+    // not short of room — so that explanation must not appear.
+    await expect(page.getByText(/can't grow far enough/i)).toHaveCount(0);
+
+    await page.getByRole('button', { name: /Bring back in/i }).click();
+    await expect(banner).toHaveCount(0);
+  });
+});

--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -515,13 +515,24 @@ estimates), and the source file name.
     (true vertex bounds, rotation-aware for paths — the same primitive placement
     validation uses). A **masked** (custom-shape) bin defers to `cutoutFitsInMask`
     so an instance over an unfilled cell is caught, not just rectangle overhang.
-    `OffBoardFrames3D` frames each off-board _instance_ in red; the inspector's
-    one-click "Bring back in" translates the **master** (instances move with it):
-    for a plain bin it pulls the instances' union inside the rectangle (oversized
-    pins the min corner to the origin); for a masked bin it searches the nearest
-    cell-aligned placement where every instance fits the polygon, and leaves the
-    cutout flagged when none exists (translation can't fit an arbitrary concave
-    region — honest rather than a silent false-fix).
+    A **lid** board is a third shape (`lidWindowFit`): the window is a ROUNDED
+    rectangle, and a magnetic lid's retention bosses are keep-out discs the
+    worker subtracts from every hole (`buildClipBoundary`). Both live in one
+    region, because a shape tucked into a rounded corner and a shape lying over a
+    boss are the same defect (material the cut will not reach) and get the same
+    cue. `KeepoutCircles3D` draws the bosses as scenery so the constraint is
+    visible while you place a shape, not just after it is flagged.
+    `OffBoardFrames3D` frames each out-of-bounds _instance_ in red; the
+    inspector's one-click "Bring back in" translates the **master** (instances
+    move with it): for a plain bin it pulls the instances' union inside the
+    rectangle (oversized pins the min corner to the origin); for a masked bin it
+    searches the nearest cell-aligned placement where every instance fits the
+    polygon; for a lid it tries the span fit, the four minimal axis moves that
+    clear each boss, and inward nudges off a rounded corner. All three leave the
+    cutout flagged when nothing fits (translation can't fit an arbitrary concave
+    region — honest rather than a silent false-fix). The banner says what will
+    happen ("will be clipped") rather than why, since one message now covers
+    three causes.
 21. **A masked board is concave, so a bounding box can't decide containment** —
     an axis-aligned box proves a fit but never a miss once the board has a
     notch: an L-shaped cutout nested in an L-shaped bin has a box spanning the

--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
@@ -27,7 +27,10 @@ interface BinSizeSectionProps {
   /**
    * Bin size that would fit every stray, or `null` when growing can't clear the
    * warning (past `MAX_DIMENSION`, a custom footprint, or a stray hanging past
-   * the origin edge). `null` hides the action rather than growing partway.
+   * the origin edge). `null` hides the action rather than growing partway, and
+   * says so. `undefined` means growing is not the mechanism on this board at all
+   * (the lid), where explaining that the bin can't grow far enough would be a
+   * false reason for a shape that is simply lying on a magnet boss.
    */
   readonly growTarget?: GrowTarget | null;
   /** Resize the bin to {@link growTarget}. */

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -163,13 +163,26 @@ export function CutoutWorkspace() {
     [boardMask, binWidth, binDepth]
   );
 
-  // Resizing the bin can strand cutouts past the new (smaller) footprint — they
-  // are stored in absolute mm and never auto-rescaled. Flag them so the canvas
-  // can frame them and the inspector can offer a one-click clamp back in.
+  // What the generator will actually cut on. Resizing the bin can strand cutouts
+  // past the new (smaller) footprint (they are stored in absolute mm and never
+  // auto-rescaled); on the lid, the window is rounded and a retention magnet's
+  // boss is a hole the cut must leave intact. Both are the same question, so
+  // both feed one flagged set, one banner and one clamp.
+  const cutoutBoard = useMemo(
+    () => ({
+      width: binWidth,
+      depth: binDepth,
+      mask: boardMask,
+      cellSize: maskCellSize,
+      lidWindow: lidWindow ?? undefined,
+      meshAssets: params.meshAssets,
+    }),
+    [binWidth, binDepth, boardMask, maskCellSize, lidWindow, params.meshAssets]
+  );
+
   const offBoardIds = useMemo(
-    () =>
-      getOffBoardCutoutIds(cutouts, binWidth, binDepth, boardMask, maskCellSize, params.meshAssets),
-    [cutouts, binWidth, binDepth, boardMask, maskCellSize, params.meshAssets]
+    () => getOffBoardCutoutIds(cutouts, cutoutBoard),
+    [cutouts, cutoutBoard]
   );
 
   const t = useTranslation();
@@ -257,9 +270,13 @@ export function CutoutWorkspace() {
   // Not offered on the lid: `computeGrowToFit` measures candidates against
   // `cutoutInterior`, which is ~6.7mm per axis wider than the lid's window, so it
   // would either hide a fix that would have worked or resize the bin and leave the
-  // warning standing.
+  // warning standing. `undefined` rather than `null` there, because the two say
+  // different things to the banner: `null` is "growing was considered and cannot
+  // clear this", which prints "the bin can't grow far enough". Growing is not the
+  // mechanism at all on a lid — a shape sitting on a magnet boss is not short of
+  // room — so the line would be a false explanation.
   const growTarget = useMemo(
-    () => (isLid ? null : computeGrowToFit(params, cutouts, halfGridMode)),
+    () => (isLid ? undefined : computeGrowToFit(params, cutouts, halfGridMode)),
     [isLid, params, cutouts, halfGridMode]
   );
 
@@ -270,16 +287,9 @@ export function CutoutWorkspace() {
   }, [growTarget, setParams]);
 
   const handleClampOffBoard = useCallback(() => {
-    const updates = clampOffBoardCutouts(
-      cutouts,
-      binWidth,
-      binDepth,
-      boardMask,
-      maskCellSize,
-      params.meshAssets
-    );
+    const updates = clampOffBoardCutouts(cutouts, cutoutBoard);
     if (updates.size > 0) updateCutoutsBatch(updates);
-  }, [cutouts, binWidth, binDepth, boardMask, maskCellSize, params.meshAssets, updateCutoutsBatch]);
+  }, [cutouts, cutoutBoard, updateCutoutsBatch]);
 
   const {
     mode,
@@ -580,6 +590,7 @@ export function CutoutWorkspace() {
                 cellMask={boardMask}
                 taperBand={taperBand}
                 referenceOutline={binInteriorReference}
+                lidWindow={lidWindow}
                 canvasWidth={canvasWidth}
                 canvasHeight={canvasHeight}
                 selection={selection}

--- a/src/features/bin-designer/components/panel/CutoutsSection/lidWindowFit.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/lidWindowFit.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import type { Cutout, PathPoint } from '@/features/bin-designer/types';
+import type { LidCutoutWindow } from '@/shared/utils/lidCutoutPlan';
+import { cutoutFitsInLidWindow, lidWindowOffset } from './lidWindowFit';
+
+function cutout(over: Partial<Cutout> = {}): Cutout {
+  return {
+    id: 'c',
+    shape: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 10,
+    depth: 10,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+    ...over,
+  };
+}
+
+const corner = (x: number, y: number): PathPoint => ({
+  x,
+  y,
+  handleIn: null,
+  handleOut: null,
+  symmetric: true,
+});
+
+function window(over: Partial<LidCutoutWindow> = {}): LidCutoutWindow {
+  return {
+    spanW: 100,
+    spanD: 100,
+    offsetX: 0,
+    offsetY: 0,
+    cornerRadius: 0,
+    keepouts: [],
+    ...over,
+  };
+}
+
+describe('cutoutFitsInLidWindow', () => {
+  it('accepts a shape inside a plain window and rejects one past its edge', () => {
+    const w = window();
+    expect(cutoutFitsInLidWindow(cutout({ x: 40, y: 40 }), w)).toBe(true);
+    expect(cutoutFitsInLidWindow(cutout({ x: 95, y: 40 }), w)).toBe(false);
+  });
+
+  it('rejects a shape lying over a magnet boss', () => {
+    // The worker subtracts the boss from every hole it cuts, so a slot drawn
+    // across one comes out of the printer with a disc-shaped island in it.
+    const w = window({ keepouts: [{ x: 50, y: 50, r: 6 }] });
+    expect(cutoutFitsInLidWindow(cutout({ x: 45, y: 45 }), w)).toBe(false);
+    expect(cutoutFitsInLidWindow(cutout({ x: 5, y: 5 }), w)).toBe(true);
+  });
+
+  it('rejects a shape that merely clips the edge of a boss', () => {
+    // Overlap of ~1mm. A box-vs-box test would catch this one too; the point is
+    // that a partial bite is still an island in the printed slot.
+    const w = window({ keepouts: [{ x: 50, y: 50, r: 6 }] });
+    expect(cutoutFitsInLidWindow(cutout({ x: 35, y: 45, width: 10, depth: 10 }), w)).toBe(false);
+  });
+
+  it('rejects a shape poking out of a rounded corner', () => {
+    // Sits inside the plain 100x100 extent, so only the rounded outline can
+    // reject it: the corner arc has retreated 20mm here.
+    const w = window({ cornerRadius: 20 });
+    expect(cutoutFitsInLidWindow(cutout({ x: 0, y: 0, width: 6, depth: 6 }), w)).toBe(false);
+  });
+
+  it('accepts a shape that genuinely fits inside a rounded corner', () => {
+    // The over-flag this test exists to prevent: a bounding-box test against the
+    // rounded window rejects anything in the corner band, and an over-flag with
+    // a one-click clamp attached moves a shape the user placed deliberately.
+    const w = window({ cornerRadius: 20 });
+    // Corner arc centre is (20,20) r=20, so a 4mm box at (14,14) is well inside.
+    expect(cutoutFitsInLidWindow(cutout({ x: 14, y: 14, width: 4, depth: 4 }), w)).toBe(true);
+  });
+
+  it('tests a circle by its silhouette, not its box', () => {
+    const w = window({ cornerRadius: 20 });
+    // A circle whose BOX pokes past the corner arc but whose disc does not.
+    expect(
+      cutoutFitsInLidWindow(cutout({ shape: 'circle', x: 5, y: 5, width: 14, depth: 14 }), w)
+    ).toBe(true);
+  });
+});
+
+describe('lidWindowOffset', () => {
+  it('brings a shape past the edge back inside', () => {
+    const w = window();
+    const stray = cutout({ x: 96, y: 40 });
+
+    const offset = lidWindowOffset([stray], w);
+
+    expect(offset).not.toBeNull();
+    expect(cutoutFitsInLidWindow({ ...stray, x: stray.x + (offset?.dx ?? 0) }, w)).toBe(true);
+  });
+
+  it('moves a shape off a boss by the shortest axis that clears it', () => {
+    const w = window({ keepouts: [{ x: 50, y: 50, r: 6 }] });
+    // Overlaps the boss on its left side, so the shortest clear is a nudge left.
+    const over = cutout({ x: 42, y: 45, width: 10, depth: 10 });
+
+    const offset = lidWindowOffset([over], w);
+
+    expect(offset).not.toBeNull();
+    const moved = { ...over, x: over.x + (offset?.dx ?? 0), y: over.y + (offset?.dy ?? 0) };
+    expect(cutoutFitsInLidWindow(moved, w)).toBe(true);
+    expect(offset?.dx).toBeLessThan(0);
+  });
+
+  it('returns null when nothing can be moved anywhere valid', () => {
+    // A shape as wide as the window with a boss dead centre: no translation
+    // clears it, so it stays flagged for the user rather than being false-fixed.
+    const w = window({ spanW: 30, spanD: 30, keepouts: [{ x: 15, y: 15, r: 10 }] });
+    const wide = cutout({ x: 0, y: 0, width: 30, depth: 30 });
+
+    expect(lidWindowOffset([wide], w)).toBeNull();
+  });
+
+  it('moves a path cutout by translating its vertices, not just its origin', () => {
+    // A path's silhouette is absolute points, so an offset that only bumped
+    // `x`/`y` would report a fit while leaving the outline where it was.
+    const w = window({ keepouts: [{ x: 50, y: 50, r: 8 }] });
+    const path = cutout({
+      shape: 'path',
+      x: 44,
+      y: 44,
+      width: 12,
+      depth: 12,
+      path: [corner(44, 44), corner(56, 44), corner(56, 56), corner(44, 56)],
+    });
+
+    const offset = lidWindowOffset([path], w);
+
+    expect(offset).not.toBeNull();
+    const dx = offset?.dx ?? 0;
+    const dy = offset?.dy ?? 0;
+    const moved: Cutout = {
+      ...path,
+      x: path.x + dx,
+      y: path.y + dy,
+      path: path.path?.map((p) => ({ ...p, x: p.x + dx, y: p.y + dy })),
+    };
+    expect(cutoutFitsInLidWindow(moved, w)).toBe(true);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/lidWindowFit.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/lidWindowFit.ts
@@ -1,0 +1,299 @@
+/**
+ * Containment checks for the LID's board: a rounded window with magnet keep-outs.
+ *
+ * The bin's board is a rectangle (or a cell mask, see `maskFit`). The lid's is
+ * neither — `lidCutoutWindow` describes a rounded rectangle, and a magnetic lid
+ * hangs a retention boss inside it that a hole must leave intact. The worker
+ * already clips both (`buildClipBoundary` intersects the window and subtracts
+ * the bosses), correctly and silently: the shape draws as if it will cut
+ * cleanly and the printed part comes out with an unexplained disc-shaped island
+ * in the middle of the slot.
+ *
+ * Both are ONE region here, for the same reason the worker builds one boundary:
+ * a shape tucked into a rounded corner and a shape lying over a boss are the
+ * same defect (material the cut will not reach), they get the same cue, and a
+ * caller that had to ask two questions could answer one and forget the other.
+ *
+ * Precision matches `maskFit`'s: a bounding box is a fast ACCEPT and nothing
+ * more. Rejecting on the box would flag a small circle tucked neatly into a
+ * rounded corner, and an over-flag with a one-click clamp attached moves a shape
+ * the user placed deliberately.
+ */
+
+import polygonClipping, { type MultiPolygon } from 'polygon-clipping';
+import type { Cutout } from '@/features/bin-designer/types';
+import type { MeshAsset } from '@/shared/generation/meshAsset';
+import type { LidCutoutKeepout, LidCutoutWindow } from '@/shared/utils/lidCutoutPlan';
+import { getCutoutOutline } from './cutoutOutline';
+import { getCutoutBounds } from './maskFit';
+import { translateCutout } from './cutoutHelpers';
+import type { Bounds } from './geometryCore';
+
+/** Tolerance (mm) for a flush edge, matching `OFF_BOARD_EPSILON`. */
+const EPSILON = 0.01;
+
+/** Leftover area (mm²) below which a clip result is float noise, as in `maskFit`. */
+const RESIDUAL_AREA_EPSILON = 1e-6;
+
+/** Segments per 90° of arc. Smooth enough that the polygon is not what decides a verdict. */
+const ARC_SEGMENTS = 16;
+
+type Ring = [number, number][];
+
+/** Rounded-rect ring over `[0, spanW] × [0, spanD]`, counter-clockwise. */
+function roundedRectRing(spanW: number, spanD: number, radius: number): Ring {
+  const r = Math.max(0, Math.min(radius, spanW / 2, spanD / 2));
+  if (r <= 0) {
+    return [
+      [0, 0],
+      [spanW, 0],
+      [spanW, spanD],
+      [0, spanD],
+    ];
+  }
+  // Each corner's arc centre, paired with the angle its sweep starts at.
+  const corners: Array<{ cx: number; cy: number; from: number }> = [
+    { cx: spanW - r, cy: r, from: -Math.PI / 2 },
+    { cx: spanW - r, cy: spanD - r, from: 0 },
+    { cx: r, cy: spanD - r, from: Math.PI / 2 },
+    { cx: r, cy: r, from: Math.PI },
+  ];
+  const ring: Ring = [];
+  for (const { cx, cy, from } of corners) {
+    for (let i = 0; i <= ARC_SEGMENTS; i++) {
+      const a = from + (i / ARC_SEGMENTS) * (Math.PI / 2);
+      ring.push([cx + r * Math.cos(a), cy + r * Math.sin(a)]);
+    }
+  }
+  return ring;
+}
+
+/** Polygonal disc for a keep-out, grown by nothing: the margin is already in `r`. */
+function keepoutRing(k: LidCutoutKeepout): Ring {
+  const segments = ARC_SEGMENTS * 4;
+  const ring: Ring = [];
+  for (let i = 0; i < segments; i++) {
+    const a = (i / segments) * Math.PI * 2;
+    ring.push([k.x + k.r * Math.cos(a), k.y + k.r * Math.sin(a)]);
+  }
+  return ring;
+}
+
+/**
+ * The placeable region: the rounded window less every magnet boss.
+ *
+ * Memoized on the window object, which `CutoutWorkspace` already memoizes on
+ * `params` — a drag re-asks this on every pointer move, and the difference is
+ * the expensive half.
+ */
+const regionCache = new WeakMap<LidCutoutWindow, MultiPolygon>();
+
+export function lidWindowRegion(window: LidCutoutWindow): MultiPolygon {
+  const cached = regionCache.get(window);
+  if (cached) return cached;
+  const outer: MultiPolygon = [[roundedRectRing(window.spanW, window.spanD, window.cornerRadius)]];
+  const region =
+    window.keepouts.length === 0
+      ? outer
+      : polygonClipping.difference(
+          outer,
+          ...window.keepouts.map((k): MultiPolygon => [[keepoutRing(k)]])
+        );
+  regionCache.set(window, region);
+  return region;
+}
+
+/** Whether `bounds` sits inside the window's plain extent, ignoring corners and bosses. */
+function boundsInSpan(b: Bounds, window: LidCutoutWindow): boolean {
+  return (
+    b.minX >= -EPSILON &&
+    b.minY >= -EPSILON &&
+    b.maxX <= window.spanW + EPSILON &&
+    b.maxY <= window.spanD + EPSILON
+  );
+}
+
+/** Whether `bounds` clears every keep-out disc (box test — a fast accept only). */
+function boundsClearOfKeepouts(b: Bounds, window: LidCutoutWindow): boolean {
+  return window.keepouts.every(
+    (k) =>
+      b.maxX <= k.x - k.r + EPSILON ||
+      b.minX >= k.x + k.r - EPSILON ||
+      b.maxY <= k.y - k.r + EPSILON ||
+      b.minY >= k.y + k.r - EPSILON
+  );
+}
+
+/**
+ * Whether one cutout instance lies entirely in the placeable region.
+ *
+ * The box is tried first and, when a plain rectangle with no rounding is in
+ * play, is the whole answer. Only a shape near a rounded corner or a boss pays
+ * for the clip.
+ */
+export function cutoutFitsInLidWindow(
+  cutout: Cutout,
+  window: LidCutoutWindow,
+  meshAssets?: Readonly<Record<string, MeshAsset>>
+): boolean {
+  const bounds = getCutoutBounds(cutout);
+  if (!boundsInSpan(bounds, window)) return false;
+  // Inside the span, clear of every boss box, and no corner to round into: the
+  // box has proven it without a clip.
+  if (boundsClearOfKeepouts(bounds, window)) {
+    const r = window.cornerRadius;
+    if (r <= 0) return true;
+    const inCornerBand =
+      (bounds.minX < r || bounds.maxX > window.spanW - r) &&
+      (bounds.minY < r || bounds.maxY > window.spanD - r);
+    if (!inCornerBand) return true;
+  }
+
+  const rings = getCutoutOutline(cutout, meshAssets);
+  // Too degenerate to outline (empty path, zero-sized box). The box verdict is
+  // all there is, and it already said the extent is fine.
+  if (!rings || rings.length === 0) return true;
+  const subject: MultiPolygon = rings.map((ring) => [
+    ring.map((p): [number, number] => [p.x, p.y]),
+  ]);
+  try {
+    return (
+      totalArea(polygonClipping.difference(subject, lidWindowRegion(window))) <=
+      RESIDUAL_AREA_EPSILON
+    );
+  } catch {
+    // polygon-clipping rejects degenerate or self-intersecting rings, which a
+    // freeform pen path can be. Keep the box verdict rather than flagging a
+    // shape the user cannot then fix.
+    return true;
+  }
+}
+
+/** Net covered area of a multipolygon (shoelace; holes come back negative). */
+function totalArea(polygons: MultiPolygon): number {
+  let area = 0;
+  for (const polygon of polygons) {
+    for (const ring of polygon) {
+      for (let i = 0, n = ring.length; i < n; i++) {
+        const [x1, y1] = ring[i];
+        const [x2, y2] = ring[(i + 1) % n];
+        area += (x1 * y2 - x2 * y1) / 2;
+      }
+    }
+  }
+  return area;
+}
+
+/** Shift bringing `[min,max]` inside `[0,extent]`; pin the min edge when oversized. */
+function fitAxis(min: number, max: number, extent: number): number {
+  if (max - min > extent) return -min;
+  if (min < 0) return -min;
+  if (max > extent) return extent - max;
+  return 0;
+}
+
+function shift(b: Bounds, dx: number, dy: number): Bounds {
+  return { minX: b.minX + dx, minY: b.minY + dy, maxX: b.maxX + dx, maxY: b.maxY + dy };
+}
+
+/**
+ * Candidate translations that might bring a stray shape back in, nearest first
+ * at the call site.
+ *
+ * Every candidate is geometrically motivated rather than sampled: the plain
+ * span fit for a shape dragged off the edge, the four minimal axis moves that
+ * clear each boss, and inward nudges for a shape poking out of a rounded
+ * corner. A grid search over the window would be both slower and less
+ * predictable, and "no candidate fits" is a perfectly good answer — the shape
+ * stays flagged for the user to place by hand, exactly as a masked board does.
+ */
+function candidateOffsets(
+  union: Bounds,
+  window: LidCutoutWindow
+): Array<{ dx: number; dy: number }> {
+  const base = {
+    dx: fitAxis(union.minX, union.maxX, window.spanW),
+    dy: fitAxis(union.minY, union.maxY, window.spanD),
+  };
+  const candidates = [base];
+  const fitted = shift(union, base.dx, base.dy);
+
+  const clampBoth = (dx: number, dy: number): { dx: number; dy: number } => {
+    const moved = shift(union, dx, dy);
+    return {
+      dx: dx + fitAxis(moved.minX, moved.maxX, window.spanW),
+      dy: dy + fitAxis(moved.minY, moved.maxY, window.spanD),
+    };
+  };
+
+  for (const k of window.keepouts) {
+    // The minimal move on each axis that puts the footprint clear of this boss.
+    const clears = [
+      { dx: base.dx + (k.x - k.r - EPSILON - fitted.maxX), dy: base.dy },
+      { dx: base.dx + (k.x + k.r + EPSILON - fitted.minX), dy: base.dy },
+      { dx: base.dx, dy: base.dy + (k.y - k.r - EPSILON - fitted.maxY) },
+      { dx: base.dx, dy: base.dy + (k.y + k.r + EPSILON - fitted.minY) },
+    ];
+    for (const c of clears) candidates.push(clampBoth(c.dx, c.dy));
+  }
+
+  const r = window.cornerRadius;
+  if (r > 0) {
+    // Push off a rounded corner: the shape has to come in by at most the
+    // corner's sagitta on one axis or the other.
+    for (const step of [r / 4, r / 2, r]) {
+      for (const [sx, sy] of [
+        [step, 0],
+        [-step, 0],
+        [0, step],
+        [0, -step],
+        [step, step],
+        [-step, step],
+        [step, -step],
+        [-step, -step],
+      ]) {
+        candidates.push(clampBoth(base.dx + sx, base.dy + sy));
+      }
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * Nearest translation bringing every instance inside the window and clear of
+ * the bosses, or `null` when no candidate does.
+ *
+ * `null` is a real answer, not a failure: a shape wider than the gap between two
+ * bosses has nowhere to go, and leaving it flagged for manual repair is what a
+ * masked board already does in the same situation.
+ */
+export function lidWindowOffset(
+  instances: readonly Cutout[],
+  window: LidCutoutWindow,
+  meshAssets?: Readonly<Record<string, MeshAsset>>
+): { dx: number; dy: number } | null {
+  if (instances.length === 0) return null;
+  const union = instances.map(getCutoutBounds).reduce((acc, b) => ({
+    minX: Math.min(acc.minX, b.minX),
+    minY: Math.min(acc.minY, b.minY),
+    maxX: Math.max(acc.maxX, b.maxX),
+    maxY: Math.max(acc.maxY, b.maxY),
+  }));
+
+  let best: { dx: number; dy: number } | null = null;
+  let bestDist = Infinity;
+  for (const c of candidateOffsets(union, window)) {
+    const dist = c.dx * c.dx + c.dy * c.dy;
+    if (dist >= bestDist) continue;
+    // `translateCutout`, not a spread: a path's outline is absolute points, so
+    // bumping x/y alone moves the metadata and leaves the silhouette behind.
+    const fits = instances.every((inst) =>
+      cutoutFitsInLidWindow(translateCutout(inst, c.dx, c.dy), window, meshAssets)
+    );
+    if (!fits) continue;
+    best = c;
+    bestDist = dist;
+  }
+  return best;
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Cutout, PathPoint } from '@/features/bin-designer/types';
 import type { CellMask } from '@/shared/utils/cellMask';
+import type { LidCutoutWindow } from '@/shared/utils/lidCutoutPlan';
 import {
   isCutoutOffBoard,
   getOffBoardCutoutIds,
@@ -51,27 +52,33 @@ const BIN_D = 80;
 
 describe('isCutoutOffBoard', () => {
   it('returns false for a cutout fully inside the board', () => {
-    expect(isCutoutOffBoard(createCutout(), BIN_W, BIN_D)).toBe(false);
+    expect(isCutoutOffBoard(createCutout(), { width: BIN_W, depth: BIN_D })).toBe(false);
   });
 
   it('treats a flush edge as in-bounds (within tolerance)', () => {
     const flush = createCutout({ x: 0, y: 0, width: BIN_W, depth: BIN_D });
-    expect(isCutoutOffBoard(flush, BIN_W, BIN_D)).toBe(false);
+    expect(isCutoutOffBoard(flush, { width: BIN_W, depth: BIN_D })).toBe(false);
   });
 
   it('flags overhang past the right/top edge', () => {
-    expect(isCutoutOffBoard(createCutout({ x: 90, width: 20 }), BIN_W, BIN_D)).toBe(true);
-    expect(isCutoutOffBoard(createCutout({ y: 70, depth: 20 }), BIN_W, BIN_D)).toBe(true);
+    expect(
+      isCutoutOffBoard(createCutout({ x: 90, width: 20 }), { width: BIN_W, depth: BIN_D })
+    ).toBe(true);
+    expect(
+      isCutoutOffBoard(createCutout({ y: 70, depth: 20 }), { width: BIN_W, depth: BIN_D })
+    ).toBe(true);
   });
 
   it('flags a negative position past the origin', () => {
-    expect(isCutoutOffBoard(createCutout({ x: -5 }), BIN_W, BIN_D)).toBe(true);
+    expect(isCutoutOffBoard(createCutout({ x: -5 }), { width: BIN_W, depth: BIN_D })).toBe(true);
   });
 
   it('accounts for rotation widening the footprint', () => {
     const corner20 = createCutout({ x: 80, y: 30, width: 20, depth: 20, rotation: 0 });
-    expect(isCutoutOffBoard(corner20, BIN_W, BIN_D)).toBe(false);
-    expect(isCutoutOffBoard({ ...corner20, rotation: 45 }, BIN_W, BIN_D)).toBe(true);
+    expect(isCutoutOffBoard(corner20, { width: BIN_W, depth: BIN_D })).toBe(false);
+    expect(isCutoutOffBoard({ ...corner20, rotation: 45 }, { width: BIN_W, depth: BIN_D })).toBe(
+      true
+    );
   });
 
   it('uses actual path vertices, not stale width/depth metadata', () => {
@@ -85,7 +92,7 @@ describe('isCutoutOffBoard', () => {
       depth: 20,
       path: [corner(90, 10), corner(110, 10), corner(110, 30), corner(90, 30)],
     });
-    expect(isCutoutOffBoard(path, BIN_W, BIN_D)).toBe(true);
+    expect(isCutoutOffBoard(path, { width: BIN_W, depth: BIN_D })).toBe(true);
   });
 
   it('accounts for rotation when measuring a path footprint', () => {
@@ -99,8 +106,8 @@ describe('isCutoutOffBoard', () => {
       depth: 4,
       path: [corner(10, 75), corner(60, 75), corner(60, 79), corner(10, 79)],
     });
-    expect(isCutoutOffBoard(bar, BIN_W, BIN_D)).toBe(false);
-    expect(isCutoutOffBoard({ ...bar, rotation: 90 }, BIN_W, BIN_D)).toBe(true);
+    expect(isCutoutOffBoard(bar, { width: BIN_W, depth: BIN_D })).toBe(false);
+    expect(isCutoutOffBoard({ ...bar, rotation: 90 }, { width: BIN_W, depth: BIN_D })).toBe(true);
   });
 
   it('flags a cutout over an unfilled mask cell even when inside the rectangle', () => {
@@ -109,9 +116,11 @@ describe('isCutoutOffBoard', () => {
     const cellSize = { cellMmX: 50, cellMmY: 50 };
     const overNotch = createCutout({ x: 60, y: 60, width: 30, depth: 30 });
     // Inside the bounding rectangle (no mask) → not off-board…
-    expect(isCutoutOffBoard(overNotch, 100, 100)).toBe(false);
+    expect(isCutoutOffBoard(overNotch, { width: 100, depth: 100 })).toBe(false);
     // …but it covers the unfilled cell, so the masked check flags it.
-    expect(isCutoutOffBoard(overNotch, 100, 100, mask, cellSize)).toBe(true);
+    expect(
+      isCutoutOffBoard(overNotch, { width: 100, depth: 100, mask: mask, cellSize: cellSize })
+    ).toBe(true);
   });
 
   // Issue: "1 cutout(s) outside the board" on a concave cutout that is
@@ -135,9 +144,17 @@ describe('isCutoutOffBoard', () => {
         corner(2, 98),
       ],
     });
-    expect(isCutoutOffBoard(lShape, 100, 100, mask, cellSize)).toBe(false);
-    expect(getOffBoardCutoutIds([lShape], 100, 100, mask, cellSize).size).toBe(0);
-    expect(clampOffBoardCutouts([lShape], 100, 100, mask, cellSize).size).toBe(0);
+    expect(
+      isCutoutOffBoard(lShape, { width: 100, depth: 100, mask: mask, cellSize: cellSize })
+    ).toBe(false);
+    expect(
+      getOffBoardCutoutIds([lShape], { width: 100, depth: 100, mask: mask, cellSize: cellSize })
+        .size
+    ).toBe(0);
+    expect(
+      clampOffBoardCutouts([lShape], { width: 100, depth: 100, mask: mask, cellSize: cellSize })
+        .size
+    ).toBe(0);
   });
 
   it('still flags a concave path whose arm crosses into the notch', () => {
@@ -158,7 +175,9 @@ describe('isCutoutOffBoard', () => {
         corner(2, 98),
       ],
     });
-    expect(isCutoutOffBoard(reachesIn, 100, 100, mask, cellSize)).toBe(true);
+    expect(
+      isCutoutOffBoard(reachesIn, { width: 100, depth: 100, mask: mask, cellSize: cellSize })
+    ).toBe(true);
   });
 
   it('flags an array whose outer instance spills past the edge', () => {
@@ -170,8 +189,10 @@ describe('isCutoutOffBoard', () => {
       depth: 20,
       array: gridArray(2, 1, 40, 40),
     });
-    expect(isCutoutOffBoard({ ...arr, array: undefined }, BIN_W, BIN_D)).toBe(false);
-    expect(isCutoutOffBoard(arr, BIN_W, BIN_D)).toBe(true);
+    expect(isCutoutOffBoard({ ...arr, array: undefined }, { width: BIN_W, depth: BIN_D })).toBe(
+      false
+    );
+    expect(isCutoutOffBoard(arr, { width: BIN_W, depth: BIN_D })).toBe(true);
   });
 });
 
@@ -179,7 +200,7 @@ describe('getOffBoardCutoutIds', () => {
   it('collects only the stranded cutouts', () => {
     const inside = createCutout({ id: 'in', x: 10, y: 10 });
     const stray = createCutout({ id: 'out', x: 95, y: 10 });
-    const ids = getOffBoardCutoutIds([inside, stray], BIN_W, BIN_D);
+    const ids = getOffBoardCutoutIds([inside, stray], { width: BIN_W, depth: BIN_D });
     expect([...ids]).toEqual(['out']);
   });
 });
@@ -187,27 +208,27 @@ describe('getOffBoardCutoutIds', () => {
 describe('clampCutoutToBoard', () => {
   it('pulls a right/top overhang back to the edge', () => {
     const stray = createCutout({ x: 95, y: 75, width: 20, depth: 20 });
-    expect(clampCutoutToBoard(stray, BIN_W, BIN_D)).toEqual({ x: 80, y: 60 });
+    expect(clampCutoutToBoard(stray, { width: BIN_W, depth: BIN_D })).toEqual({ x: 80, y: 60 });
   });
 
   it('pulls a negative position back to the origin', () => {
     const stray = createCutout({ x: -5, y: -8, width: 20, depth: 20 });
-    expect(clampCutoutToBoard(stray, BIN_W, BIN_D)).toEqual({ x: 0, y: 0 });
+    expect(clampCutoutToBoard(stray, { width: BIN_W, depth: BIN_D })).toEqual({ x: 0, y: 0 });
   });
 
   it('pins the min edge to the origin when the cutout is larger than the board', () => {
     const huge = createCutout({ x: 30, y: 20, width: 200, depth: 150 });
-    expect(clampCutoutToBoard(huge, BIN_W, BIN_D)).toEqual({ x: 0, y: 0 });
+    expect(clampCutoutToBoard(huge, { width: BIN_W, depth: BIN_D })).toEqual({ x: 0, y: 0 });
   });
 
   it('returns null when the cutout is already inside', () => {
-    expect(clampCutoutToBoard(createCutout(), BIN_W, BIN_D)).toBeNull();
+    expect(clampCutoutToBoard(createCutout(), { width: BIN_W, depth: BIN_D })).toBeNull();
   });
 
   it('produces an in-bounds result', () => {
     const stray = createCutout({ x: 95, y: 75, width: 20, depth: 20 });
-    const moved = { ...stray, ...clampCutoutToBoard(stray, BIN_W, BIN_D) };
-    expect(isCutoutOffBoard(moved, BIN_W, BIN_D)).toBe(false);
+    const moved = { ...stray, ...clampCutoutToBoard(stray, { width: BIN_W, depth: BIN_D }) };
+    expect(isCutoutOffBoard(moved, { width: BIN_W, depth: BIN_D })).toBe(false);
   });
 
   it('translates path vertices in lockstep with x/y', () => {
@@ -219,13 +240,13 @@ describe('clampCutoutToBoard', () => {
       depth: 20,
       path: [corner(90, 10), corner(110, 10), corner(110, 30), corner(90, 30)],
     });
-    const moved = clampCutoutToBoard(path, BIN_W, BIN_D);
+    const moved = clampCutoutToBoard(path, { width: BIN_W, depth: BIN_D });
     // Path bounds span 90..110 → shift -10 on x; y already fits.
     expect(moved).not.toBeNull();
     expect(moved?.x).toBe(0);
     expect(moved?.path?.map((p) => p.x)).toEqual([80, 100, 100, 80]);
     const after = { ...path, ...moved };
-    expect(isCutoutOffBoard(after, BIN_W, BIN_D)).toBe(false);
+    expect(isCutoutOffBoard(after, { width: BIN_W, depth: BIN_D })).toBe(false);
   });
 
   it('translates the master so every array instance fits', () => {
@@ -237,9 +258,9 @@ describe('clampCutoutToBoard', () => {
       array: gridArray(2, 1, 40, 40),
     });
     // Union spans 70..130 → shift -30 so instances land at 40..60 and 80..100.
-    expect(clampCutoutToBoard(arr, BIN_W, BIN_D)).toEqual({ x: 40, y: 10 });
-    const moved = { ...arr, ...clampCutoutToBoard(arr, BIN_W, BIN_D) };
-    expect(isCutoutOffBoard(moved, BIN_W, BIN_D)).toBe(false);
+    expect(clampCutoutToBoard(arr, { width: BIN_W, depth: BIN_D })).toEqual({ x: 40, y: 10 });
+    const moved = { ...arr, ...clampCutoutToBoard(arr, { width: BIN_W, depth: BIN_D }) };
+    expect(isCutoutOffBoard(moved, { width: BIN_W, depth: BIN_D })).toBe(false);
   });
 });
 
@@ -247,13 +268,13 @@ describe('clampOffBoardCutouts', () => {
   it('returns updates only for off-board cutouts', () => {
     const inside = createCutout({ id: 'in', x: 10, y: 10 });
     const stray = createCutout({ id: 'out', x: 95, y: 75 });
-    const updates = clampOffBoardCutouts([inside, stray], BIN_W, BIN_D);
+    const updates = clampOffBoardCutouts([inside, stray], { width: BIN_W, depth: BIN_D });
     expect([...updates.keys()]).toEqual(['out']);
     expect(updates.get('out')).toEqual({ x: 80, y: 60 });
   });
 
   it('returns an empty map when everything fits', () => {
-    expect(clampOffBoardCutouts([createCutout()], BIN_W, BIN_D).size).toBe(0);
+    expect(clampOffBoardCutouts([createCutout()], { width: BIN_W, depth: BIN_D }).size).toBe(0);
   });
 
   it('relocates a mask-only violation into the nearest filled region', () => {
@@ -262,11 +283,25 @@ describe('clampOffBoardCutouts', () => {
     const mask: CellMask = { cols: 2, rows: 2, cells: [1, 1, 1, 0] };
     const cellSize = { cellMmX: 50, cellMmY: 50 };
     const overNotch = createCutout({ id: 'notch', x: 60, y: 60, width: 30, depth: 30 });
-    expect(getOffBoardCutoutIds([overNotch], 100, 100, mask, cellSize).has('notch')).toBe(true);
-    const updates = clampOffBoardCutouts([overNotch], 100, 100, mask, cellSize);
+    expect(
+      getOffBoardCutoutIds([overNotch], {
+        width: 100,
+        depth: 100,
+        mask: mask,
+        cellSize: cellSize,
+      }).has('notch')
+    ).toBe(true);
+    const updates = clampOffBoardCutouts([overNotch], {
+      width: 100,
+      depth: 100,
+      mask: mask,
+      cellSize: cellSize,
+    });
     expect(updates.size).toBe(1);
     const moved = { ...overNotch, ...updates.get('notch') };
-    expect(isCutoutOffBoard(moved, 100, 100, mask, cellSize)).toBe(false);
+    expect(
+      isCutoutOffBoard(moved, { width: 100, depth: 100, mask: mask, cellSize: cellSize })
+    ).toBe(false);
   });
 
   it('leaves a cutout flagged when no valid mask placement exists', () => {
@@ -275,7 +310,78 @@ describe('clampOffBoardCutouts', () => {
     const mask: CellMask = { cols: 2, rows: 2, cells: [1, 1, 1, 0] };
     const cellSize = { cellMmX: 50, cellMmY: 50 };
     const tooBig = createCutout({ id: 'big', x: 5, y: 5, width: 90, depth: 90 });
-    expect(getOffBoardCutoutIds([tooBig], 100, 100, mask, cellSize).has('big')).toBe(true);
-    expect(clampOffBoardCutouts([tooBig], 100, 100, mask, cellSize).size).toBe(0);
+    expect(
+      getOffBoardCutoutIds([tooBig], {
+        width: 100,
+        depth: 100,
+        mask: mask,
+        cellSize: cellSize,
+      }).has('big')
+    ).toBe(true);
+    expect(
+      clampOffBoardCutouts([tooBig], { width: 100, depth: 100, mask: mask, cellSize: cellSize })
+        .size
+    ).toBe(0);
+  });
+});
+
+describe('the lid board', () => {
+  const lidWindow = (over: Partial<LidCutoutWindow> = {}): LidCutoutWindow => ({
+    spanW: 100,
+    spanD: 100,
+    offsetX: 0,
+    offsetY: 0,
+    cornerRadius: 12,
+    keepouts: [{ x: 50, y: 50, r: 6 }],
+    ...over,
+  });
+
+  it('flags a shape over a magnet boss even though it is inside the rectangle', () => {
+    // The whole point of the lid branch: this shape passes every rectangle test
+    // and the worker still cuts around the boss, leaving an island in the slot.
+    const overBoss = createCutout({ id: 'boss', x: 45, y: 45, width: 10, depth: 10 });
+
+    expect(isCutoutOffBoard(overBoss, { width: 100, depth: 100 })).toBe(false);
+    expect(isCutoutOffBoard(overBoss, { width: 100, depth: 100, lidWindow: lidWindow() })).toBe(
+      true
+    );
+  });
+
+  it('flags a shape tucked into the rounded corner and clamps it back in', () => {
+    const inCorner = createCutout({ id: 'corner', x: 0, y: 0, width: 8, depth: 8 });
+    const board = { width: 100, depth: 100, lidWindow: lidWindow() };
+
+    expect(getOffBoardCutoutIds([inCorner], board).has('corner')).toBe(true);
+
+    const moved = clampCutoutToBoard(inCorner, board);
+    expect(moved).not.toBeNull();
+    expect(isCutoutOffBoard({ ...inCorner, ...moved }, board)).toBe(false);
+  });
+
+  it('takes the lid window over the plain extent when both are given', () => {
+    // `width`/`depth` are the rectangle fallback. A board carrying a window must
+    // not answer from them, or the corners and bosses go unchecked.
+    const inCorner = createCutout({ id: 'corner', x: 1, y: 1, width: 6, depth: 6 });
+
+    expect(isCutoutOffBoard(inCorner, { width: 100, depth: 100, lidWindow: lidWindow() })).toBe(
+      true
+    );
+  });
+
+  it('leaves a shape flagged when no placement clears the bosses', () => {
+    const board = {
+      width: 30,
+      depth: 30,
+      lidWindow: lidWindow({
+        spanW: 30,
+        spanD: 30,
+        cornerRadius: 0,
+        keepouts: [{ x: 15, y: 15, r: 10 }],
+      }),
+    };
+    const tooBig = createCutout({ id: 'big', x: 0, y: 0, width: 30, depth: 30 });
+
+    expect(getOffBoardCutoutIds([tooBig], board).has('big')).toBe(true);
+    expect(clampOffBoardCutouts([tooBig], board).size).toBe(0);
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -1,27 +1,54 @@
 /**
- * Off-board cutout detection + recovery.
+ * Detection + recovery for cutouts the generator will clip.
  *
- * Cutouts are stored in absolute interior-mm and are never auto-rescaled when
- * the bin is resized, so shrinking the footprint can strand a cutout past the
- * board edge. The mesh builder silently clips that overhang, so the editor
- * surfaces it instead: flag the strays and offer a one-click clamp back in.
+ * Cutouts are stored in absolute mm and are never auto-rescaled when the board
+ * changes, so shrinking the footprint can strand one past the edge. The builder
+ * silently clips whatever overhangs, so the editor surfaces it instead: flag the
+ * strays and offer a one-click move back in.
+ *
+ * A board comes in three shapes, and all three are the same question — is any
+ * part of this shape somewhere the cut will not reach:
+ *
+ * - a plain rectangle (the bin's interior),
+ * - a cell mask (a custom bin outline), where a bounding box is a fast accept
+ *   only, since an L-shaped cutout nested in an L-shaped bin has a box that
+ *   spans the notch (`maskFit`),
+ * - the lid's window (`lidWindowFit`), a ROUNDED rectangle with a keep-out disc
+ *   at each retention magnet. A hole over a boss opens its magnet pocket, which
+ *   is invisible to any check on the lid alone: the solid stays watertight, the
+ *   lid just stops holding the bin.
  *
  * A cutout is treated as its set of expanded array instances (just itself when
  * there is no array), so an array whose outer instances spill past the edge is
- * flagged even when the master fits. Footprints use the same `getCutoutBounds`
- * placement validation uses (true vertex bounds for paths), and a custom
- * (masked) footprint defers to the outline containment in `cutoutFitsInMask` —
- * a bounding box would flag an L-shaped cutout nested in an L-shaped bin.
+ * flagged even when the master fits.
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
 import type { MeshAsset } from '@/shared/generation/meshAsset';
 import type { CellMask } from '@/shared/utils/cellMask';
+import type { LidCutoutWindow } from '@/shared/utils/lidCutoutPlan';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
 import { translateCutout } from './cutoutHelpers';
 import { translatePathPoints } from './pathGeometry';
 import { getCutoutBounds, cutoutFitsInMask, type MaskCellSize } from './maskFit';
+import { cutoutFitsInLidWindow, lidWindowOffset } from './lidWindowFit';
 import type { Bounds } from './geometryCore';
+
+/**
+ * The area a cutout may occupy.
+ *
+ * `lidWindow` wins when present and carries its own spans, so `width`/`depth`
+ * are the plain-rectangle fallback rather than a second description of the same
+ * area that could disagree with it.
+ */
+export interface CutoutBoard {
+  readonly width: number;
+  readonly depth: number;
+  readonly mask?: CellMask;
+  readonly cellSize?: MaskCellSize;
+  readonly lidWindow?: LidCutoutWindow;
+  readonly meshAssets?: Readonly<Record<string, MeshAsset>>;
+}
 
 /**
  * Tolerance (mm) — mirrors the interaction clamps so a flush edge isn't flagged.
@@ -54,36 +81,27 @@ function unionBounds(boundsList: readonly Bounds[]): Bounds {
   return { minX, minY, maxX, maxY };
 }
 
-/** True when any instance of the cutout falls outside the (optionally masked) board. */
-export function isCutoutOffBoard(
-  cutout: Cutout,
-  binWidth: number,
-  binDepth: number,
-  mask?: CellMask,
-  cellSize?: MaskCellSize,
-  meshAssets?: Readonly<Record<string, MeshAsset>>
-): boolean {
-  const instances = expandCutoutArray(cutout);
-  // Custom (masked) footprint: an instance inside the bounding rectangle can
-  // still overhang the polygon, so defer to the containment check placements use.
-  if (mask && cellSize) {
-    return instances.some((inst) => !cutoutFitsInMask(inst, mask, cellSize, meshAssets));
+/** Whether one instance sits entirely inside the board. */
+function instanceFits(inst: Cutout, board: CutoutBoard): boolean {
+  if (board.lidWindow) {
+    return cutoutFitsInLidWindow(inst, board.lidWindow, board.meshAssets);
   }
-  return instances.some((inst) => boundsOutsideRect(getCutoutBounds(inst), binWidth, binDepth));
+  if (board.mask && board.cellSize) {
+    return cutoutFitsInMask(inst, board.mask, board.cellSize, board.meshAssets);
+  }
+  return !boundsOutsideRect(getCutoutBounds(inst), board.width, board.depth);
 }
 
-/** Ids of every cutout stranded past the current board footprint. */
-export function getOffBoardCutoutIds(
-  cutouts: readonly Cutout[],
-  binWidth: number,
-  binDepth: number,
-  mask?: CellMask,
-  cellSize?: MaskCellSize,
-  meshAssets?: Readonly<Record<string, MeshAsset>>
-): Set<string> {
+/** True when any instance of the cutout falls outside the board. */
+export function isCutoutOffBoard(cutout: Cutout, board: CutoutBoard): boolean {
+  return expandCutoutArray(cutout).some((inst) => !instanceFits(inst, board));
+}
+
+/** Ids of every cutout the generator would clip on the current board. */
+export function getOffBoardCutoutIds(cutouts: readonly Cutout[], board: CutoutBoard): Set<string> {
   const ids = new Set<string>();
   for (const c of cutouts) {
-    if (isCutoutOffBoard(c, binWidth, binDepth, mask, cellSize, meshAssets)) ids.add(c.id);
+    if (isCutoutOffBoard(c, board)) ids.add(c.id);
   }
   return ids;
 }
@@ -146,23 +164,20 @@ function maskOffset(
 
 /**
  * Translation that brings a stray cutout (and all its array instances) back
- * inside the board. Returns `null` when no move is needed or — for a masked
- * footprint — no valid placement exists (the cutout stays flagged for manual
+ * inside the board. Returns `null` when no move is needed or — for a masked or
+ * lid board — no valid placement exists (the cutout stays flagged for manual
  * repair). Path vertices move in lockstep with `x`/`y`.
  */
-export function clampCutoutToBoard(
-  cutout: Cutout,
-  binWidth: number,
-  binDepth: number,
-  mask?: CellMask,
-  cellSize?: MaskCellSize,
-  meshAssets?: Readonly<Record<string, MeshAsset>>
-): Partial<Cutout> | null {
+export function clampCutoutToBoard(cutout: Cutout, board: CutoutBoard): Partial<Cutout> | null {
   const instances = expandCutoutArray(cutout);
-  const offset =
-    mask && cellSize
-      ? maskOffset(instances, mask, cellSize, meshAssets)
-      : rectOffset(instances.map(getCutoutBounds), binWidth, binDepth);
+  let offset: { dx: number; dy: number } | null;
+  if (board.lidWindow) {
+    offset = lidWindowOffset(instances, board.lidWindow, board.meshAssets);
+  } else if (board.mask && board.cellSize) {
+    offset = maskOffset(instances, board.mask, board.cellSize, board.meshAssets);
+  } else {
+    offset = rectOffset(instances.map(getCutoutBounds), board.width, board.depth);
+  }
   if (!offset) return null;
   const { dx, dy } = offset;
   if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) return null;
@@ -176,16 +191,12 @@ export function clampCutoutToBoard(
 /** Position updates for every off-board cutout that a clamp can move (empty when none). */
 export function clampOffBoardCutouts(
   cutouts: readonly Cutout[],
-  binWidth: number,
-  binDepth: number,
-  mask?: CellMask,
-  cellSize?: MaskCellSize,
-  meshAssets?: Readonly<Record<string, MeshAsset>>
+  board: CutoutBoard
 ): Map<string, Partial<Cutout>> {
   const updates = new Map<string, Partial<Cutout>>();
   for (const c of cutouts) {
-    if (!isCutoutOffBoard(c, binWidth, binDepth, mask, cellSize, meshAssets)) continue;
-    const moved = clampCutoutToBoard(c, binWidth, binDepth, mask, cellSize, meshAssets);
+    if (!isCutoutOffBoard(c, board)) continue;
+    const moved = clampCutoutToBoard(c, board);
     if (moved) updates.set(c.id, moved);
   }
   return updates;

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutCanvas3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutCanvas3D.tsx
@@ -16,6 +16,7 @@ import type {
   PathPoint,
 } from '@/features/bin-designer/types';
 import type { CellMask } from '@/shared/utils/cellMask';
+import type { LidCutoutWindow } from '@/shared/utils/lidCutoutPlan';
 import type { TaperBandSides } from '@/features/bin-designer/utils/binDimensions';
 import type { ResizeHandle, InteractionMode, PreviewMap } from '../useCutoutInteraction';
 import type { FitCue } from '../cutoutSectionVisibility';
@@ -69,6 +70,8 @@ export interface CutoutCanvas3DProps {
    * different frame from the bin's interior. Absent on the bin's own board.
    */
   readonly referenceOutline?: { readonly width: number; readonly depth: number } | null;
+  /** The lid's board, when that is what is being drawn on: rounded, with magnet keep-outs. */
+  readonly lidWindow?: LidCutoutWindow | null;
   readonly canvasWidth: number;
   readonly canvasHeight: number;
   readonly selection: ReadonlySet<string>;
@@ -130,6 +133,7 @@ export function CutoutCanvas3D({
   cellMask,
   taperBand,
   referenceOutline,
+  lidWindow,
   canvasWidth,
   canvasHeight,
   selection,
@@ -316,6 +320,7 @@ export function CutoutCanvas3D({
         cellMask={cellMask}
         taperBand={taperBand}
         referenceOutline={referenceOutline}
+        lidWindow={lidWindow}
         binColor={binColor}
         selection={selection}
         offBoardIds={offBoardIds}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/KeepoutCircles3D.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/KeepoutCircles3D.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { RENDER_ORDER } from './constants';
+import { KeepoutCircles3D } from './KeepoutCircles3D';
+
+describe('KeepoutCircles3D', () => {
+  it('exports a function', () => {
+    expect(typeof KeepoutCircles3D).toBe('function');
+  });
+
+  it('draws as scenery: above the background, below every shape', () => {
+    // The discs mark where the worker will leave material standing, not an area
+    // the pointer is refused. A shape drawn over one is flagged through the
+    // off-board affordance instead, so these must never read as a boundary.
+    expect(RENDER_ORDER.REFERENCE_OUTLINE).toBeGreaterThan(RENDER_ORDER.BACKGROUND);
+    expect(RENDER_ORDER.REFERENCE_OUTLINE).toBeLessThan(RENDER_ORDER.SHAPES);
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/KeepoutCircles3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/KeepoutCircles3D.tsx
@@ -1,0 +1,91 @@
+/**
+ * The magnet bosses a lid cutout has to leave intact.
+ *
+ * A magnetic lid hangs a retention boss under its plate at each magnet, and the
+ * worker subtracts those from every hole it cuts (`buildClipBoundary`). Without
+ * a cue the shape draws as if it will cut cleanly and the printed part comes out
+ * with an unexplained disc-shaped island in the middle of the slot. The hint
+ * copy has been promising this behaviour ("They stay clear of the mating wall
+ * and the magnet bosses") without ever showing it.
+ *
+ * Drawn as scenery, like `ReferenceOutline3D`: a faint disc with a slightly
+ * firmer edge, under every shape so it reads as "material stays here" rather
+ * than as a boundary the pointer will resist. The shape that overlaps one is
+ * flagged separately, through the same off-board affordance as any other clip.
+ *
+ * Positions arrive in the WINDOW frame (`lidCutoutWindow` rebases them), which
+ * is the frame the canvas already draws in: origin (0,0) at the front-left
+ * corner, mm, Y-up.
+ */
+
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+import type { LidCutoutKeepout } from '@/shared/utils/lidCutoutPlan';
+import { RENDER_ORDER, REFERENCE_OUTLINE_COLOR } from './constants';
+
+/** Enough segments that a ~5mm boss reads as a circle at any usable zoom. */
+const SEGMENTS = 48;
+
+/** Just above the background, below the reference outline and every shape. */
+const Z = 0.015;
+
+interface KeepoutCircles3DProps {
+  readonly keepouts: readonly LidCutoutKeepout[];
+}
+
+export function KeepoutCircles3D({ keepouts }: KeepoutCircles3DProps) {
+  // The disposables are collected as they are built rather than recovered by
+  // traversing afterwards: a traversal has to narrow `Object3D` back down to
+  // something with a geometry, and what it gets back is untyped.
+  const { group, disposables } = useMemo(() => {
+    const root = new THREE.Group();
+    const owned: Array<THREE.BufferGeometry | THREE.Material> = [];
+    const color = new THREE.Color(REFERENCE_OUTLINE_COLOR);
+
+    for (const k of keepouts) {
+      const fillGeometry = new THREE.CircleGeometry(k.r, SEGMENTS);
+      const fillMaterial = new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.18,
+        depthTest: false,
+      });
+      const fill = new THREE.Mesh(fillGeometry, fillMaterial);
+      fill.position.set(k.x, k.y, Z);
+      fill.renderOrder = RENDER_ORDER.REFERENCE_OUTLINE;
+      root.add(fill);
+      owned.push(fillGeometry, fillMaterial);
+
+      const points: THREE.Vector3[] = [];
+      for (let i = 0; i < SEGMENTS; i++) {
+        const a = (i / SEGMENTS) * Math.PI * 2;
+        points.push(new THREE.Vector3(k.x + k.r * Math.cos(a), k.y + k.r * Math.sin(a), Z));
+      }
+      const edgeGeometry = new THREE.BufferGeometry().setFromPoints(points);
+      const edgeMaterial = new THREE.LineBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.5,
+        depthTest: false,
+      });
+      const edge = new THREE.LineLoop(edgeGeometry, edgeMaterial);
+      edge.renderOrder = RENDER_ORDER.REFERENCE_OUTLINE;
+      root.add(edge);
+      owned.push(edgeGeometry, edgeMaterial);
+    }
+
+    return { group: root, disposables: owned };
+  }, [keepouts]);
+
+  // <primitive> does not auto-dispose attached objects; release the GPU
+  // resources when the group is replaced or the component unmounts.
+  useEffect(
+    () => () => {
+      for (const d of disposables) d.dispose();
+    },
+    [disposables]
+  );
+
+  if (keepouts.length === 0) return null;
+  return <primitive object={group} />;
+}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/OffBoardFrames3D.tsx
@@ -1,13 +1,18 @@
 /**
- * Red warning frames for cutouts stranded past the board edge. Expands array
- * masters into instances (just the cutout itself when there's no array) and
- * frames each instance that is actually off-board, at its true footprint —
- * keeping the visual in lockstep with `isCutoutOffBoard` detection.
+ * Red warning frames for cutouts the generator will clip. Expands array masters
+ * into instances (just the cutout itself when there's no array) and frames each
+ * instance that is actually out of bounds, at its true footprint — keeping the
+ * visual in lockstep with `isCutoutOffBoard` detection.
+ *
+ * "Out of bounds" follows the board: past the rectangle's edge, outside a custom
+ * outline's filled region, or — on the lid — outside the rounded window or over
+ * a retention magnet's boss.
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import type { CellMask } from '@/shared/utils/cellMask';
+import type { LidCutoutWindow } from '@/shared/utils/lidCutoutPlan';
 import { expandCutoutArray } from '@/shared/utils/cutoutArray';
 import type { PreviewMap } from '../useCutoutInteraction';
 import { isCutoutOffBoard } from '../offBoardCutouts';
@@ -21,6 +26,7 @@ interface OffBoardFrames3DProps {
   readonly binWidth: number;
   readonly binDepth: number;
   readonly cellMask?: CellMask;
+  readonly lidWindow?: LidCutoutWindow | null;
 }
 
 export function OffBoardFrames3D({
@@ -30,24 +36,32 @@ export function OffBoardFrames3D({
   binWidth,
   binDepth,
   cellMask,
+  lidWindow,
 }: OffBoardFrames3DProps) {
   // Read straight from the store (like MeshFootprintMesh) so a mesh imprint is
   // re-tested by the same silhouette `offBoardIds` used — otherwise the frames
   // drift out of lockstep with the warning that summons them.
   const meshAssets = useDesignerStore((s) => s.params.meshAssets);
   if (offBoardIds.size === 0) return null;
-  const maskCellSize = cellMask
-    ? { cellMmX: binWidth / cellMask.cols, cellMmY: binDepth / cellMask.rows }
-    : undefined;
+  // Rebuilt rather than passed: this component re-tests each instance against
+  // the LIVE drag preview, so it needs the board itself, not the verdict.
+  const board = {
+    width: binWidth,
+    depth: binDepth,
+    mask: cellMask,
+    cellSize: cellMask
+      ? { cellMmX: binWidth / cellMask.cols, cellMmY: binDepth / cellMask.rows }
+      : undefined,
+    lidWindow: lidWindow ?? undefined,
+    meshAssets,
+  };
   return (
     <>
       {cutouts
         .filter((c) => offBoardIds.has(c.id) && !c.hidden)
         .flatMap((c) =>
           expandCutoutArray({ ...c, ...preview.get(c.id) })
-            .filter((inst) =>
-              isCutoutOffBoard(inst, binWidth, binDepth, cellMask, maskCellSize, meshAssets)
-            )
+            .filter((inst) => isCutoutOffBoard(inst, board))
             .map((inst) => (
               <OffBoardBounds3D key={`offboard-${inst.id}`} bounds={getCutoutBounds(inst)} />
             ))

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/SceneContent.tsx
@@ -14,6 +14,7 @@ import type {
   PathPoint,
 } from '@/features/bin-designer/types';
 import type { CellMask } from '@/shared/utils/cellMask';
+import type { LidCutoutWindow } from '@/shared/utils/lidCutoutPlan';
 import type { TaperBandSides } from '@/features/bin-designer/utils/binDimensions';
 import type { ResizeHandle, InteractionMode, PreviewMap } from '../useCutoutInteraction';
 import type { SegmentHoverInfo } from '../handlers';
@@ -23,6 +24,7 @@ import { TaperBand3D } from './TaperBand3D';
 import { ReferenceOutline3D } from './ReferenceOutline3D';
 import { CutoutShapeMesh } from './CutoutShapeMesh';
 import { OffBoardFrames3D } from './OffBoardFrames3D';
+import { KeepoutCircles3D } from './KeepoutCircles3D';
 import { CutoutLabel3D } from './CutoutLabel3D';
 import { CutoutHandles3D } from './CutoutHandles3D';
 import { RotationHandle3D } from './RotationHandle3D';
@@ -93,6 +95,7 @@ export interface SceneContentProps {
    * different frame from the bin's interior. Absent on the bin's own board.
    */
   readonly referenceOutline?: { readonly width: number; readonly depth: number } | null;
+  readonly lidWindow?: LidCutoutWindow | null;
   readonly binColor: string;
   readonly selection: ReadonlySet<string>;
   /** Cutouts stranded past the board edge — framed with a red warning outline. */
@@ -156,6 +159,7 @@ export function SceneContent({
   cellMask,
   taperBand,
   referenceOutline,
+  lidWindow,
   binColor,
   selection,
   offBoardIds = EMPTY_IDS,
@@ -248,6 +252,9 @@ export function SceneContent({
           depth={referenceOutline.depth}
         />
       )}
+
+      {/* The magnet bosses a lid cutout is clipped around — scenery, not a boundary */}
+      {lidWindow && <KeepoutCircles3D keepouts={lidWindow.keepouts} />}
 
       {/* Where a full-depth cutout gets trimmed by the tapered wall */}
       {taperBand && <TaperBand3D binWidth={binWidth} binDepth={binDepth} band={taperBand} />}
@@ -444,6 +451,7 @@ export function SceneContent({
         binWidth={binWidth}
         binDepth={binDepth}
         cellMask={cellMask}
+        lidWindow={lidWindow}
       />
 
       {/* Smart guides during drag */}

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Uzamknout",
   "binDesigner.cutoutEditor.locked": "Uzamčeno",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Akce výběru",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} výřezů mimo desku",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} výřezů bude oříznuto",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Rozumím",
   "binDesigner.cutoutEditor.quickstart.precision": "Chytrá vodítka — přichytávání k mřížce, pravítka a další výřezy",
   "binDesigner.cutoutEditor.quickstart.repeat": "Vyberte 3 a více shodných výřezů a spojte je do jednoho opakování",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Sperren",
   "binDesigner.cutoutEditor.locked": "Gesperrt",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Auswahlaktionen",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} Aussparung(en) außerhalb der Platte",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} Aussparung(en) werden beschnitten",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Verstanden",
   "binDesigner.cutoutEditor.quickstart.precision": "Intelligente Hilfslinien — am Raster, an Linealen und an anderen Ausschnitten einrasten",
   "binDesigner.cutoutEditor.quickstart.repeat": "Wähle 3 oder mehr gleiche Ausschnitte, um daraus eine Anordnung zu machen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2610,7 +2610,7 @@ const en: Record<string, string> = {
   'binDesigner.cutoutEditor.binFeatures': 'Bin features',
   'binDesigner.cutoutEditor.lipOffPausesLid':
     "The lid needs the stacking lip, so it won't be generated until you turn the lip back on.",
-  'binDesigner.cutoutEditor.offBoardWarning': '{count} cutout(s) outside the board',
+  'binDesigner.cutoutEditor.offBoardWarning': '{count} cutout(s) will be clipped',
   'binDesigner.cutoutEditor.bringBackIn': 'Bring back in',
   'binDesigner.cutoutEditor.growBinToFit': 'Grow bin to {width} × {depth}',
   'binDesigner.cutoutEditor.growBinUnavailable': "The bin can't grow far enough to fit these.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Bloquear",
   "binDesigner.cutoutEditor.locked": "Bloqueado",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Acciones de selección",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} recorte(s) fuera del tablero",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} recorte(s) se van a recortar",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Entendido",
   "binDesigner.cutoutEditor.quickstart.precision": "Guías inteligentes — ajusta a la cuadrícula, reglas y otros recortes",
   "binDesigner.cutoutEditor.quickstart.repeat": "Selecciona 3 o más recortes iguales para convertirlos en una matriz",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Verrouiller",
   "binDesigner.cutoutEditor.locked": "Verrouillé",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Actions de sélection",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} découpe(s) hors du plateau",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} découpe(s) seront rognées",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Compris",
   "binDesigner.cutoutEditor.quickstart.precision": "Repères intelligents — accrochage à la grille, aux règles et aux autres découpes",
   "binDesigner.cutoutEditor.quickstart.repeat": "Sélectionnez 3 découpes identiques ou plus pour en faire un réseau",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Blocca",
   "binDesigner.cutoutEditor.locked": "Bloccato",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Azioni di selezione",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} ritagli fuori dal pannello",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} ritagli verranno tagliati",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Capito",
   "binDesigner.cutoutEditor.quickstart.precision": "Guide intelligenti: aggancio alla griglia, ai righelli e agli altri ritagli",
   "binDesigner.cutoutEditor.quickstart.repeat": "Seleziona 3 o più intagli identici per trasformarli in una serie",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "ロック",
   "binDesigner.cutoutEditor.locked": "ロック中",
   "binDesigner.cutoutEditor.multiSelectToolbar": "選択アクション",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count}個の切り抜きがボードの外にあります",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count}個の切り抜きが切り取られます",
   "binDesigner.cutoutEditor.quickstart.dismiss": "了解",
   "binDesigner.cutoutEditor.quickstart.precision": "スマートガイド — グリッド、ルーラー、他の切り欠きにスナップ",
   "binDesigner.cutoutEditor.quickstart.repeat": "同じ切り欠きを 3 つ以上選ぶと 1 つの配列にまとめられます",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "잠금",
   "binDesigner.cutoutEditor.locked": "잠김",
   "binDesigner.cutoutEditor.multiSelectToolbar": "선택 작업",
-  "binDesigner.cutoutEditor.offBoardWarning": "보드 바깥의 컷아웃 {count}개",
+  "binDesigner.cutoutEditor.offBoardWarning": "컷아웃 {count}개가 잘립니다",
   "binDesigner.cutoutEditor.quickstart.dismiss": "확인",
   "binDesigner.cutoutEditor.quickstart.precision": "스마트 가이드 — 그리드, 눈금자, 다른 컷아웃에 스냅",
   "binDesigner.cutoutEditor.quickstart.repeat": "같은 컷아웃을 3개 이상 선택하면 하나의 배열로 만들 수 있습니다",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Lås",
   "binDesigner.cutoutEditor.locked": "Låst",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Valg-handlinger",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} utskjæring(er) utenfor brettet",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} utskjæring(er) blir beskåret",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Forstått",
   "binDesigner.cutoutEditor.quickstart.precision": "Smarte hjelpelinjer — fest til rutenett, linjaler og andre utsnitt",
   "binDesigner.cutoutEditor.quickstart.repeat": "Velg 3 eller flere like utskjæringer for å gjøre dem til én matrise",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Vergrendelen",
   "binDesigner.cutoutEditor.locked": "Vergrendeld",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Selectie-acties",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} uitsparing(en) buiten het bord",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} uitsparing(en) worden bijgesneden",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Begrepen",
   "binDesigner.cutoutEditor.quickstart.precision": "Slimme hulplijnen — snap naar raster, linialen en andere uitsnijdingen",
   "binDesigner.cutoutEditor.quickstart.repeat": "Selecteer 3 of meer gelijke uitsparingen om er één reeks van te maken",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Zablokuj",
   "binDesigner.cutoutEditor.locked": "Zablokowane",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Akcje zaznaczenia",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} wycięcie(-a) poza płytą",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} wycięcie(-a) zostanie przycięte",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Rozumiem",
   "binDesigner.cutoutEditor.quickstart.precision": "Inteligentne prowadnice — przyciąganie do siatki, linijek i innych wycięć",
   "binDesigner.cutoutEditor.quickstart.repeat": "Zaznacz 3 lub więcej identycznych wycięć, aby utworzyć z nich jeden szyk",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Bloquear",
   "binDesigner.cutoutEditor.locked": "Bloqueado",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Ações de seleção",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} recorte(s) fora da placa",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} recorte(s) serão cortados",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Entendi",
   "binDesigner.cutoutEditor.quickstart.precision": "Guias inteligentes — encaixe na grade, réguas e outros recortes",
   "binDesigner.cutoutEditor.quickstart.repeat": "Selecione 3 ou mais recortes iguais para transformá-los em uma matriz",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Lås",
   "binDesigner.cutoutEditor.locked": "Låst",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Valhandlingar",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} urtag utanför brädan",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} urtag kommer att beskäras",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Förstått",
   "binDesigner.cutoutEditor.quickstart.precision": "Smarta hjälplinjer — fäst mot rutnät, linjaler och andra urtag",
   "binDesigner.cutoutEditor.quickstart.repeat": "Markera 3 eller fler likadana urtag för att göra dem till en matris",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "Заблокувати",
   "binDesigner.cutoutEditor.locked": "Заблоковано",
   "binDesigner.cutoutEditor.multiSelectToolbar": "Дії з вибором",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} вирізів за межами дошки",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} вирізів буде обрізано",
   "binDesigner.cutoutEditor.quickstart.dismiss": "Зрозуміло",
   "binDesigner.cutoutEditor.quickstart.precision": "Розумні напрямні — прив’язка до сітки, лінійок та інших вирізів",
   "binDesigner.cutoutEditor.quickstart.repeat": "Виберіть 3 або більше однакових вирізів, щоб об'єднати їх у масив",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -509,7 +509,7 @@
   "binDesigner.cutoutEditor.lock": "锁定",
   "binDesigner.cutoutEditor.locked": "已锁定",
   "binDesigner.cutoutEditor.multiSelectToolbar": "选择操作",
-  "binDesigner.cutoutEditor.offBoardWarning": "{count} 个挖槽在画板之外",
+  "binDesigner.cutoutEditor.offBoardWarning": "{count} 个挖槽将被裁剪",
   "binDesigner.cutoutEditor.quickstart.dismiss": "知道了",
   "binDesigner.cutoutEditor.quickstart.precision": "智能参考线 — 对齐到网格、标尺和其他挖槽",
   "binDesigner.cutoutEditor.quickstart.repeat": "选择 3 个或更多相同的挖槽，即可合并为一个阵列",


### PR DESCRIPTION
A hole drawn across a magnetic lid's retention boss is clipped by the worker, correctly, so the boss survives and the lid keeps holding. Nothing in the editor said so: the shape drew as if it would cut cleanly, and the printed part came out with an unexplained disc-shaped island in the middle of the slot. The hint copy has been promising this ("They stay clear of the mating wall and the magnet bosses") without ever showing it.

`lidCutoutWindow` already returns `keepouts`, placed from the real `retentionMagnetPositions` so edge magnets and asymmetric overhang are both handled. The worker consumed them. The editor did not read them at all.

## Showing them

`KeepoutCircles3D` draws each boss as scenery, alongside `ReferenceOutline3D` and under every shape, so the constraint is visible while you place a shape rather than only once it is flagged.

## Flagging them

`lidWindowFit` answers containment for the lid's board. The rounded window and the keep-outs are **one region**, built the way the worker builds its clip boundary, because a shape tucked into a rounded corner and a shape lying over a boss are the same defect: material the cut will not reach. That also closes the corner case the issue notes, where the plain-rectangle test accepted a shape the worker then clipped.

Containment is tested against the **true silhouette**, not the bounding box. The box is a fast accept only, exactly as in `maskFit`: rejecting on it would flag a small circle tucked neatly inside a rounded corner, and an over-flag with a one-click clamp attached moves a shape the user placed deliberately.

`offBoardCutouts` now takes a `CutoutBoard` describing the placeable area instead of six positional arguments, and routes rectangle, mask and lid window through one predicate. All three feed one flagged set, one banner and one clamp, which is what the issue asked for. The lid clamp tries the span fit, the four minimal axis moves that clear each boss, and inward nudges off a rounded corner, returning `null` when nothing fits rather than inventing a false fix, which is what a masked board already does.

## Two copy consequences

The banner says what will happen (`{count} cutout(s) will be clipped`) rather than why, since one message now covers three causes.

And "the bin can't grow far enough to fit these" no longer appears on the lid. It was showing on every lid flag, because growing is refused there and the banner reads a refusal as "considered and impossible". Growing is not the mechanism on a lid, so `growTarget` is now `undefined` (not applicable) rather than `null` (rejected), which is the distinction the prop's own doc already drew.

## On the issue's suggestion to reinstate two helpers

`git log -S` finds no trace of `lidCutoutInWindow` or `lidCutoutHitsKeepout` on any ref, so they never landed and there is nothing to restore. They are written fresh here, and as one region test rather than two predicates, because true-shape containment against a rounded window and a boss is the same clip either way.

## Verification

Unit tests cover the geometry: bosses, rounded corners, the circle whose box pokes out but whose disc does not, the clamp's null case, and a path whose absolute vertices have to move with it.

The e2e covers the wiring, which unit tests cannot reach, since `SceneContent` is R3F and never rendered in vitest. It drives a real magnetic lid, places a shape on a real boss, and asserts the flag, the absence of the false grow line, and that "Bring back in" clears it. With the lid routing disabled it fails on the flag.

Closes #3563

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

