### PR TITLE
fix(layout): correct the drawer-ceiling model for slide lids, plates and lipless stacks

### DIFF
--- a/src/features/bin-designer/store/customBinRegistry.ts
+++ b/src/features/bin-designer/store/customBinRegistry.ts
@@ -80,6 +80,14 @@ export interface CustomBinRef {
    * below nor seats in a baseplate, so it stands on whatever is under it.
    */
   readonly socketless?: boolean;
+  /**
+   * Whether the design keeps its stacking lip. A bin stacked on a lipless
+   * design has nothing to settle into, so the junction credit is the
+   * SUPPORTER's to grant — the upper bin's socket alone earns nothing.
+   * Absent on entries saved before the field; the ceiling assumes a lip then,
+   * which errs toward reporting the column shorter (the pre-field behaviour).
+   */
+  readonly hasLip?: boolean;
   /** ISO timestamp of last update */
   readonly updatedAt: string;
 }
@@ -120,10 +128,11 @@ export function registryEdgeFields(params: {
  */
 export function registryHeightFields(
   params: AssembledHeightSource
-): Pick<CustomBinRef, 'assembledRiseMm' | 'socketless'> {
+): Pick<CustomBinRef, 'assembledRiseMm' | 'socketless' | 'hasLip'> {
   return {
     assembledRiseMm: assembledHeight(params).totalMm,
     socketless: isSocketlessBase(params.base.style),
+    hasLip: params.base.stackingLip,
   };
 }
 
@@ -151,6 +160,7 @@ function parseEntry(raw: unknown): CustomBinRef | null {
     kind,
     assembledRiseMm,
     socketless,
+    hasLip,
   } = raw as Record<string, unknown>;
   if (
     typeof id !== 'string' ||
@@ -184,6 +194,7 @@ function parseEntry(raw: unknown): CustomBinRef | null {
       ? { assembledRiseMm }
       : {}),
     ...(typeof socketless === 'boolean' ? { socketless } : {}),
+    ...(typeof hasLip === 'boolean' ? { hasLip } : {}),
     updatedAt,
   };
 }
@@ -252,6 +263,7 @@ function withCarriedGeometry(next: CustomBinRef, prev: CustomBinRef): CustomBinR
     ...(next.socketless === undefined && prev.socketless !== undefined
       ? { socketless: prev.socketless }
       : {}),
+    ...(next.hasLip === undefined && prev.hasLip !== undefined ? { hasLip: prev.hasLip } : {}),
   };
 }
 

--- a/src/features/generation/worker/generators/binStackSeating.kernel.test.ts
+++ b/src/features/generation/worker/generators/binStackSeating.kernel.test.ts
@@ -164,7 +164,7 @@ describe('bin-on-bin stacking (#2374)', () => {
  * would only prove two copies agree. These cases measure the assembled solids
  * and compare the ceiling model to that.
  */
-describe('drawer ceiling against mated solids (#2374)', () => {
+describe('drawer ceiling against mated solids', () => {
   const LAYERS: Layer[] = [
     { id: layerId('l1'), name: 'l1', height: heightUnits(3) },
     { id: layerId('l2'), name: 'l2', height: heightUnits(3) },

--- a/src/features/grid-editor/components/Grid/IsometricPreview/CeilingPlane/CeilingPlane.test.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/CeilingPlane/CeilingPlane.test.tsx
@@ -13,19 +13,26 @@ vi.mock('@/shared/hooks/useThemeEffect', () => ({
   useThreeColors: () => ({ labelColor: '#ffffff' }),
 }));
 
-/**
- * R3F elements are not DOM, so assert the props the component computes rather
- * than a rendered tree: the Z it puts the plane at is the whole contract.
- */
-function planeZ(ceilingMm: number, gridUnitMm: number): number {
-  const el = CeilingPlane({
-    ceilingMm,
+interface RenderedGroup {
+  props: {
+    position: [number, number, number];
+    children: [
+      { props: { children: [{ props: { args: [number, number] } }, unknown] } },
+      { props: { position: [number, number, number]; scale: [number, number, number] } },
+    ];
+  };
+}
+
+function render(overrides: Partial<Parameters<typeof CeilingPlane>[0]> = {}): RenderedGroup {
+  return CeilingPlane({
+    ceilingMm: 55,
     drawerWidth: 4,
-    scaledDepth: 3,
-    gridUnitMm,
+    drawerDepth: 3,
+    depthScale: 1,
+    gridUnitMm: 42,
     fits: true,
-  }) as unknown as { props: { position: [number, number, number] } };
-  return el.props.position[2];
+    ...overrides,
+  });
 }
 
 describe('CeilingPlane', () => {
@@ -33,23 +40,35 @@ describe('CeilingPlane', () => {
   // Dividing by heightUnitMm instead would put a 55mm ceiling at 7.86 units
   // instead of 1.31 and float it far above the drawer.
   it('places the plane by dividing mm by the grid unit', () => {
-    expect(planeZ(55, 42)).toBeCloseTo(55 / 42, 6);
-    expect(planeZ(84, 42)).toBeCloseTo(2, 6);
+    expect(render({ ceilingMm: 55 }).props.position[2]).toBeCloseTo(55 / 42, 6);
+    expect(render({ ceilingMm: 84 }).props.position[2]).toBeCloseTo(2, 6);
   });
 
   it('tracks a non-standard grid unit', () => {
-    expect(planeZ(55, 21)).toBeCloseTo(55 / 21, 6);
+    expect(render({ gridUnitMm: 21 }).props.position[2]).toBeCloseTo(55 / 21, 6);
   });
 
   it('centres the plane on the drawer footprint', () => {
-    const el = CeilingPlane({
-      ceilingMm: 55,
-      drawerWidth: 4,
-      scaledDepth: 3,
-      gridUnitMm: 42,
-      fits: false,
-    }) as unknown as { props: { position: [number, number, number] } };
+    const el = render({ fits: false });
     expect(el.props.position[0]).toBe(2);
     expect(el.props.position[1]).toBe(1.5);
+  });
+
+  // The component renders inside the scene's depth-scaled group, which applies
+  // the non-square factor. The mesh must therefore use the RAW depth — a
+  // pre-scaled value would be squashed a second time — while the label
+  // counter-scales so its glyphs keep their aspect.
+  it('keeps the raw depth on the mesh under a non-square grid', () => {
+    const el = render({ depthScale: 0.5 });
+    expect(el.props.position[1]).toBe(1.5);
+    expect(el.props.children[0].props.children[0].props.args).toEqual([4, 3]);
+  });
+
+  it('counter-scales the label against the group depth scale', () => {
+    const text = render({ depthScale: 0.5 }).props.children[1];
+    expect(text.props.scale).toEqual([1, 2, 1]);
+    // World-space margin above the plane edge stays 0.35 units after the
+    // group scale is applied: (1.5 + 0.35/0.5) * 0.5 − 1.5 * 0.5 = 0.35.
+    expect(text.props.position[1]).toBeCloseTo(1.5 + 0.7, 6);
   });
 });

--- a/src/features/grid-editor/components/Grid/IsometricPreview/CeilingPlane/CeilingPlane.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/CeilingPlane/CeilingPlane.tsx
@@ -11,8 +11,18 @@ interface CeilingPlaneProps {
   readonly ceilingMm: number;
   /** Scene X extent, in grid units. */
   readonly drawerWidth: number;
-  /** Scene Y extent, already scaled for a non-square grid. */
-  readonly scaledDepth: number;
+  /**
+   * Scene Y extent in RAW grid units. This component renders inside the
+   * scene's depth-scaled group, which applies the non-square factor once —
+   * pre-scaling the value here would apply it twice and squash the plane.
+   */
+  readonly drawerDepth: number;
+  /**
+   * The scene group's depth scale (`gridUnitMmY / gridUnitMm`, 1 for a square
+   * grid). The mesh inherits it by design; the label counter-scales so its
+   * glyphs keep their aspect, per the scene's annotation rule.
+   */
+  readonly depthScale: number;
   /** mm per grid unit — the scene's X/Y unit, and so its mm-to-world divisor. */
   readonly gridUnitMm: number;
   readonly fits: boolean;
@@ -30,7 +40,8 @@ interface CeilingPlaneProps {
 export function CeilingPlane({
   ceilingMm,
   drawerWidth,
-  scaledDepth,
+  drawerDepth,
+  depthScale,
   gridUnitMm,
   fits,
 }: CeilingPlaneProps) {
@@ -40,9 +51,9 @@ export function CeilingPlane({
   const color = fits ? FITS_COLOR : OVERFLOW_COLOR;
 
   return (
-    <group position={[drawerWidth / 2, scaledDepth / 2, z]}>
+    <group position={[drawerWidth / 2, drawerDepth / 2, z]}>
       <mesh>
-        <planeGeometry args={[drawerWidth, scaledDepth]} />
+        <planeGeometry args={[drawerWidth, drawerDepth]} />
         {/* depthWrite off so bins standing through it still render in front. */}
         <meshBasicMaterial
           color={color}
@@ -52,7 +63,8 @@ export function CeilingPlane({
         />
       </mesh>
       <Text
-        position={[0, scaledDepth / 2 + 0.35, 0.01]}
+        position={[0, drawerDepth / 2 + 0.35 / depthScale, 0.01]}
+        scale={[1, 1 / depthScale, 1]}
         fontSize={0.28}
         color={colors.labelColor}
         anchorX="center"

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
@@ -349,7 +349,8 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
             <CeilingPlane
               ceilingMm={ceiling.ceilingMm}
               drawerWidth={drawer.width}
-              scaledDepth={drawer.depth * (gridUnitMmY / gridUnitMm)}
+              drawerDepth={drawer.depth}
+              depthScale={gridUnitMmY / gridUnitMm}
               gridUnitMm={gridUnitMm}
               fits={ceiling.fits}
             />

--- a/src/shared/components/DrawerDimensionsSummary/DrawerDimensionsSummary.test.tsx
+++ b/src/shared/components/DrawerDimensionsSummary/DrawerDimensionsSummary.test.tsx
@@ -167,6 +167,19 @@ describe('DrawerDimensionsSummary', () => {
       ).toBeInTheDocument();
     });
 
+    it('makes no fit claim for an empty layout', () => {
+      render(
+        <DrawerDimensionsSummary
+          {...defaultProps}
+          ceiling={{ ceilingMm: 55, tallestMm: 0, slackMm: 55, fits: true, overflowing: [] }}
+        />
+      );
+      expect(screen.queryByText('Tallest stack fits, 55mm to spare')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Add a height measurement to check the lid closes')
+      ).not.toBeInTheDocument();
+    });
+
     it('reports the spare headroom when the layout fits', () => {
       render(
         <DrawerDimensionsSummary

--- a/src/shared/components/DrawerDimensionsSummary/DrawerDimensionsSummary.tsx
+++ b/src/shared/components/DrawerDimensionsSummary/DrawerDimensionsSummary.tsx
@@ -149,7 +149,8 @@ export function DrawerDimensionsSummary({
         <p className="text-center text-xxs text-content-tertiary">
           {t('drawerCeiling.measurePrompt')}
         </p>
-      ) : ceiling.fits ? (
+      ) : /* an empty layout has no stack to judge, so no fit claim */
+      ceiling.tallestMm === 0 ? null : ceiling.fits ? (
         <p className="text-center text-xxs text-content-tertiary tabular-nums">
           {t('drawerCeiling.fits', { slack: fmt(ceiling.slackMm) })}
         </p>

--- a/src/shared/components/HeightUnitSolver/HeightUnitSolver.tsx
+++ b/src/shared/components/HeightUnitSolver/HeightUnitSolver.tsx
@@ -12,6 +12,13 @@ interface HeightUnitSolverProps {
   heightUnitMm: number;
   /** Measured internal drawer height in mm, or undefined when unmeasured. */
   ceilingMm: number | undefined;
+  /**
+   * Solid material the baseplate puts UNDER a seated stack (its floor depth,
+   * 0 for the common no-magnet plate). The drawer-ceiling check charges every
+   * column this rise, so the solver must budget under the same number or the
+   * two adjacent panels contradict each other.
+   */
+  plateRiseMm?: number;
   variant?: 'desktop' | 'mobile';
 }
 
@@ -33,6 +40,7 @@ const STACK_COUNTS = [1, 2, 3] as const;
 export function HeightUnitSolver({
   heightUnitMm,
   ceilingMm,
+  plateRiseMm = 0,
   variant = 'desktop',
 }: HeightUnitSolverProps) {
   const t = useTranslation();
@@ -42,12 +50,13 @@ export function HeightUnitSolver({
       ceilingMm === undefined
         ? []
         : STACK_COUNTS.map((count) => {
-            const units = solveUnitsUnderCeiling(ceilingMm, heightUnitMm, count);
+            const budgetMm = ceilingMm - plateRiseMm;
+            const units = solveUnitsUnderCeiling(budgetMm, heightUnitMm, count);
             if (units === null) return { count, units: null, totalMm: 0, slackMm: 0 };
             const totalMm = stackedTotalMm(units, heightUnitMm, count);
-            return { count, units, totalMm, slackMm: ceilingMm - totalMm };
+            return { count, units, totalMm, slackMm: budgetMm - totalMm };
           }),
-    [ceilingMm, heightUnitMm]
+    [ceilingMm, heightUnitMm, plateRiseMm]
   );
 
   const labelClass = variant === 'mobile' ? 'text-sm' : 'text-xs';

--- a/src/shared/hooks/useDrawerCeiling.ts
+++ b/src/shared/hooks/useDrawerCeiling.ts
@@ -41,7 +41,11 @@ export function useDrawerCeiling(): DrawerCeilingFit | null {
       // A registry entry saved before `assembledRiseMm` existed, or an imported
       // mesh that has no params to derive one from, measures as a plain bin.
       if (ref?.assembledRiseMm === undefined) return undefined;
-      return { riseMm: ref.assembledRiseMm, socketless: ref.socketless ?? false };
+      return {
+        riseMm: ref.assembledRiseMm,
+        socketless: ref.socketless ?? false,
+        hasLip: ref.hasLip,
+      };
     };
 
     return drawerCeilingFit({ bins, layers, heightUnitMm, plate, ceilingMm, linkedRise });

--- a/src/shared/hooks/useDrawerSettings.ts
+++ b/src/shared/hooks/useDrawerSettings.ts
@@ -13,10 +13,12 @@ import { useMutations } from '@/shared/contexts';
 import {
   calcMaxGridUnits,
   CONSTRAINTS,
+  DEFAULT_BASEPLATE_PARAMS,
   STAGING_ID,
   snapToHalf,
   isFractional,
 } from '@/core/constants';
+import { baseplateFloorDepth } from '@/shared/printSettings/baseplateHeight';
 import { validateHalfGridModeToggle } from '@/shared/utils/halfGridConstraints';
 import type { HalfGridConstraintViolation } from '@/shared/utils/halfGridConstraints';
 import { fitAxisUnits, halfUnitUpgrade } from '@/shared/utils/drawerFit';
@@ -65,6 +67,12 @@ export interface UseDrawerSettingsReturn {
 
   // Measured physical drawer (mm-first entry)
   measuredMm: MeasuredDrawerMm | undefined;
+  /**
+   * Solid material the baseplate puts under a seated stack (its floor depth).
+   * The height budget any ceiling comparison uses is `measured − this`, the
+   * same charge `drawerCeilingFit` applies per column.
+   */
+  plateRiseMm: number;
   drawerFitSuggestion: DrawerFitSuggestion | null;
   handleMeasuredCommit: (widthMm: number, depthMm: number, heightMm?: number) => void;
   acceptDrawerFitSuggestion: () => void;
@@ -664,6 +672,7 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
 
     // Measured physical drawer
     measuredMm,
+    plateRiseMm: baseplateFloorDepth(layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS),
     drawerFitSuggestion,
     handleMeasuredCommit,
     acceptDrawerFitSuggestion,

--- a/src/shared/printSettings/assembledHeight.test.ts
+++ b/src/shared/printSettings/assembledHeight.test.ts
@@ -212,6 +212,17 @@ describe('assembledHeight', () => {
       expect(thick - base).toBeCloseTo(3 - 0.8, 6);
     });
 
+    it('adds no rise for a sliding lid, which rides at or below the wall top', () => {
+      const slide = lidded({ attachment: 'slide' });
+      expect(hasSeatedLid(slide)).toBe(false);
+      expect(assembledHeight(slide).segments.some((s) => s.kind === 'lid')).toBe(false);
+    });
+
+    it('books no stack grid for a sliding lid either', () => {
+      const slide = lidded({ attachment: 'slide', stackableTop: true });
+      expect(assembledHeight(slide).segments.some((s) => s.kind === 'lidStackGrid')).toBe(false);
+    });
+
     it('is omitted on a lip-less bin, which generates no lid', () => {
       const noLip = params({
         base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },

--- a/src/shared/printSettings/assembledHeight.ts
+++ b/src/shared/printSettings/assembledHeight.ts
@@ -28,6 +28,7 @@ import {
   type BaseStyle,
 } from '@/features/bin-designer/types/base';
 import {
+  isSlideLid,
   LID_FIT_CLEARANCE,
   lidAnchorZ,
   resolveLidCavityExtraMm,
@@ -126,6 +127,12 @@ export function hasSeatedLid(params: AssembledHeightSource): boolean {
   // has no cavity to close, and the readout would count a band the worker never
   // builds.
   if (params.base.tile === true) return false;
+  // A sliding lid never seats over the lip: both placements put the plate AT or
+  // BELOW the wall top (`plateTopBelowWallTopMm >= 0`), so it adds no rise and
+  // the cap-lid `lidRiseMm` formula does not describe it. Without this gate the
+  // DEFAULT slide config (recessed, lip kept) books a phantom ~2.1mm lid band,
+  // and the drawer-ceiling check warns on layouts that fit.
+  if (isSlideLid(params.lid)) return false;
   return params.lid.enabled && params.base.stackingLip;
 }
 

--- a/src/shared/utils/drawerCeiling.test.ts
+++ b/src/shared/utils/drawerCeiling.test.ts
@@ -124,6 +124,60 @@ describe('drawerCeilingFit', () => {
     expect(result?.fits).toBe(false);
   });
 
+  // A flat or tray base has no foot to drop into the pockets, so it rests on
+  // the plate's TOP FACE — the full printed height, not the drawer floor. On
+  // the default plate that is a 5mm difference, larger than the 4.3mm lip
+  // overshoot this whole check exists to catch.
+  it('stands a socketless linked design on the plate top, not the drawer floor', () => {
+    const linkedBin = bin({ id: binId('flat'), height: heightUnits(4) });
+    const linkedRise = (): LinkedDesignRise => ({ riseMm: 50, socketless: true });
+    const result = drawerCeilingFit({
+      bins: [linkedBin],
+      layers: LAYERS,
+      heightUnitMm: 7,
+      plate: PLAIN_PLATE,
+      ceilingMm: 54,
+      linkedRise,
+    });
+    // Plain plate: SOCKET_HEIGHT (5mm) tall, floor depth 0.
+    expect(result?.tallestMm).toBeCloseTo(55, 5);
+    expect(result?.fits).toBe(false);
+  });
+
+  // The junction credit needs the SUPPORTER's lip: a bin stacked on a lipless
+  // design rests on its flat top with nothing to settle into.
+  it('does not nest a bin stacked on a lipless linked design', () => {
+    const bottom = bin({ id: binId('bottom'), height: heightUnits(4), layerId: layerId('l1') });
+    const top = bin({ id: binId('top'), height: heightUnits(4), layerId: layerId('l2') });
+    const linkedRise = (b: Bin): LinkedDesignRise | undefined =>
+      b.id === bottom.id ? { riseMm: 28, socketless: false, hasLip: false } : undefined;
+    const result = drawerCeilingFit({
+      bins: [bottom, top],
+      layers: LAYERS,
+      heightUnitMm: 7,
+      plate: PLAIN_PLATE,
+      ceilingMm: 200,
+      linkedRise,
+    });
+    expect(result?.tallestMm).toBeCloseTo(28 + 4 * 7 + LIP_PROTRUSION_MM, 5);
+  });
+
+  it('still nests on a linked design that keeps its lip', () => {
+    const bottom = bin({ id: binId('bottom'), height: heightUnits(4), layerId: layerId('l1') });
+    const top = bin({ id: binId('top'), height: heightUnits(4), layerId: layerId('l2') });
+    const linkedRise = (b: Bin): LinkedDesignRise | undefined =>
+      b.id === bottom.id ? { riseMm: 28, socketless: false, hasLip: true } : undefined;
+    const result = drawerCeilingFit({
+      bins: [bottom, top],
+      layers: LAYERS,
+      heightUnitMm: 7,
+      plate: PLAIN_PLATE,
+      ceilingMm: 200,
+      linkedRise,
+    });
+    expect(result?.tallestMm).toBeCloseTo(28 - STACK_JUNCTION_MM + 4 * 7 + LIP_PROTRUSION_MM, 5);
+  });
+
   it('sorts overflowing bins tallest first', () => {
     const short = bin({ id: binId('short'), height: heightUnits(8), x: gridUnits(0) });
     const tall = bin({ id: binId('tall'), height: heightUnits(9), x: gridUnits(4) });

--- a/src/shared/utils/drawerCeiling.ts
+++ b/src/shared/utils/drawerCeiling.ts
@@ -19,6 +19,7 @@ import { STAGING_ID } from '@/core/constants';
 import type { Bin, BinId, Layer } from '@/core/types';
 import {
   baseplateFloorDepth,
+  baseplateTotalHeight,
   type BaseplateHeightParams,
 } from '@/shared/printSettings/baseplateHeight';
 import { LIP_PROTRUSION_MM, STACK_JUNCTION_MM } from './heightUnits';
@@ -36,6 +37,12 @@ export interface LinkedDesignRise {
   readonly riseMm: number;
   /** A flat or tray base has no socket, so it neither nests nor seats. */
   readonly socketless: boolean;
+  /**
+   * Whether the design keeps its stacking lip — the junction a bin stacked ON
+   * TOP of it settles into. Absent (pre-field registry entries) reads as true,
+   * matching the plain-bin assumption.
+   */
+  readonly hasLip?: boolean;
 }
 
 export interface DrawerCeilingBin {
@@ -87,11 +94,19 @@ function binRise(
   bin: Bin,
   heightUnitMm: number,
   linked: LinkedDesignRise | undefined
-): { riseMm: number; nestMm: number } {
+): { riseMm: number; nestMm: number; hasLip: boolean } {
   if (linked) {
-    return { riseMm: linked.riseMm, nestMm: linked.socketless ? 0 : STACK_JUNCTION_MM };
+    return {
+      riseMm: linked.riseMm,
+      nestMm: linked.socketless ? 0 : STACK_JUNCTION_MM,
+      hasLip: linked.hasLip !== false,
+    };
   }
-  return { riseMm: bin.height * heightUnitMm + LIP_PROTRUSION_MM, nestMm: STACK_JUNCTION_MM };
+  return {
+    riseMm: bin.height * heightUnitMm + LIP_PROTRUSION_MM,
+    nestMm: STACK_JUNCTION_MM,
+    hasLip: true,
+  };
 }
 
 /**
@@ -129,29 +144,39 @@ export function drawerCeilingFit(input: DrawerCeilingInput): DrawerCeilingFit | 
     .sort((a, b) => (layerOrder.get(a.layerId) ?? 0) - (layerOrder.get(b.layerId) ?? 0));
 
   const measured: DrawerCeilingBin[] = [];
-  const supports: { bin: Bin; topMm: number }[] = [];
+  const supports: { bin: Bin; topMm: number; hasLip: boolean }[] = [];
 
   for (const bin of placed) {
     const linked = linkedRise?.(bin);
-    const { riseMm, nestMm } = binRise(bin, heightUnitMm, linked);
+    const { riseMm, nestMm, hasLip } = binRise(bin, heightUnitMm, linked);
 
+    // The junction credit needs both halves: the upper bin's socket to sink,
+    // and the SUPPORTER's lip to sink into. A bin resting on a lipless design
+    // sits on its flat top and nests nothing.
     let supportTopMm: number | undefined;
+    let supportHasLip = true;
     for (const under of supports) {
       if (!footprintsOverlap(bin, under.bin)) continue;
-      if (supportTopMm === undefined || under.topMm > supportTopMm) supportTopMm = under.topMm;
+      if (supportTopMm === undefined || under.topMm > supportTopMm) {
+        supportTopMm = under.topMm;
+        supportHasLip = under.hasLip;
+      }
     }
 
     // A socketless design has no foot to drop into the plate's pockets, so it
-    // stands on the drawer floor rather than being lifted by the plate — the
-    // same rule `assembledHeight` applies when it omits the plate band.
+    // rests on the plate's TOP FACE — the full printed height above the drawer
+    // floor, not zero. `assembledHeight` omits the plate band for these because
+    // the designer measures a bare bin with an OPTIONAL plate; here the model
+    // always has one (socketed columns are credited its pockets on the same
+    // assumption), so the two rules agree on the premise and differ on the face.
     const topMm =
       supportTopMm === undefined
-        ? (linked?.socketless === true ? 0 : plateRiseMm) + riseMm
-        : supportTopMm - nestMm + riseMm;
+        ? (linked?.socketless === true ? baseplateTotalHeight(plate) : plateRiseMm) + riseMm
+        : supportTopMm - (supportHasLip ? nestMm : 0) + riseMm;
 
     const clearanceMm = (bin.clearanceHeight ?? 0) * heightUnitMm;
     const contentsTopMm = topMm + clearanceMm;
-    supports.push({ bin, topMm });
+    supports.push({ bin, topMm, hasLip });
     measured.push({
       binId: bin.id,
       topMm,

--- a/src/shared/utils/heightUnits.test.ts
+++ b/src/shared/utils/heightUnits.test.ts
@@ -6,7 +6,6 @@ import {
   STACK_JUNCTION_MM,
   stackPitchMm,
   stackedTotalMm,
-  solveHeightUnitMm,
   solveUnitsUnderCeiling,
 } from './heightUnits';
 
@@ -76,28 +75,6 @@ describe('stackedTotalMm', () => {
 
   it('is zero for a non-positive count', () => {
     expect(stackedTotalMm(3, 7, 0)).toBe(0);
-  });
-});
-
-describe('solveHeightUnitMm', () => {
-  it('inverts stackedTotalMm', () => {
-    const u = solveHeightUnitMm(stackedTotalMm(2, 8.5, 4), 2, 4);
-    expect(u).toBeCloseTo(8.5, 5);
-  });
-
-  it('charges one junction for the stack and one shortfall per bin', () => {
-    // 4 bins × 2u into 75.6mm: the top junction comes off the target once, then
-    // each bin gets its shortfall back because its body outruns its pitch.
-    expect(solveHeightUnitMm(75.6, 2, 4)).toBeCloseTo(
-      (75.6 - STACK_JUNCTION_MM + 4 * SHORTFALL_MM) / 8,
-      5
-    );
-  });
-
-  it('returns null when the target is below the junction or inputs are degenerate', () => {
-    expect(solveHeightUnitMm(STACK_JUNCTION_MM - 4 * SHORTFALL_MM, 2, 4)).toBeNull();
-    expect(solveHeightUnitMm(75.6, 0, 4)).toBeNull();
-    expect(solveHeightUnitMm(75.6, 2, 0)).toBeNull();
   });
 });
 

--- a/src/shared/utils/heightUnits.ts
+++ b/src/shared/utils/heightUnits.ts
@@ -52,24 +52,6 @@ export function stackedTotalMm(heightUnits: number, heightUnitMm: number, count:
 }
 
 /**
- * Inverse of {@link stackedTotalMm}: the `heightUnitMm` that makes `count` bins
- * of `unitsPerBin` height units stack to exactly `targetTotalMm`. Returns null
- * when the inputs can't yield a positive unit value (e.g. target below the
- * junction, or non-positive count/units).
- */
-export function solveHeightUnitMm(
-  targetTotalMm: number,
-  unitsPerBin: number,
-  count: number
-): number | null {
-  if (count <= 0 || unitsPerBin <= 0) return null;
-  const bodyMm =
-    (targetTotalMm - STACK_JUNCTION_MM) / count - LIP_PROTRUSION_MM + STACK_JUNCTION_MM;
-  const perUnit = bodyMm / unitsPerBin;
-  return perUnit > 0 ? perUnit : null;
-}
-
-/**
  * The tallest WHOLE-unit bin height that lets `count` identical bins stack
  * under `ceilingMm`, at the layout's existing `heightUnitMm`.
  *

--- a/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
+++ b/src/shell/Mobile/MobileSettingsPanel/MobileSettingsPanel.tsx
@@ -48,6 +48,7 @@ export function MobileSettingsPanel() {
     drawerMinDepth,
     realWorldDimensions,
     measuredMm,
+    plateRiseMm,
     drawerFitSuggestion,
     handleMeasuredCommit,
     acceptDrawerFitSuggestion,
@@ -254,6 +255,7 @@ export function MobileSettingsPanel() {
             <HeightUnitSolver
               heightUnitMm={heightUnitMm}
               ceilingMm={measuredMm?.height}
+              plateRiseMm={plateRiseMm}
               variant="mobile"
             />
           </div>

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -78,6 +78,7 @@ export function Sidebar() {
     hasFractionalDepth,
     realWorldDimensions,
     measuredMm,
+    plateRiseMm,
     drawerFitSuggestion,
     handleMeasuredCommit,
     acceptDrawerFitSuggestion,
@@ -537,6 +538,7 @@ export function Sidebar() {
                       <HeightUnitSolver
                         heightUnitMm={heightUnitMm}
                         ceilingMm={measuredMm?.height}
+                        plateRiseMm={plateRiseMm}
                       />
                     </Collapsible>
                   </div>


### PR DESCRIPTION
Post-merge review of #3579 (drawer-height check) and its seam with #3575 (sliding lids) surfaced six model errors, each within the millimetres the check exists to police. All are fixed here with regression tests.

## Fixes

- **Sliding lids priced as cap lids.** `assembledHeight` booked a ~2.1mm lid band for any enabled lid on a lipped bin. The default slide config (recessed, lip kept) qualifies, but both slide placements put the plate at or below the wall top, so a sliding lid adds no rise. Every linked slide-lid design read taller than it prints and warned on layouts that fit. `hasSeatedLid` now answers no for slide lids; verified by tests that fail without the gate.
- **Socketless designs measured from the drawer floor.** A flat or tray-base linked design has no foot for the plate's pockets: it rests on the plate's top face, 5mm up on the default plate. That error is larger than the 4.3mm lip overshoot the feature was built to catch, in the dangerous direction (false "fits").
- **Nesting credited against a lip that is not there.** The junction sink is granted by the supporter's lip, not the upper bin's socket. The custom-bin registry now carries `hasLip` beside `assembledRiseMm` (same carry-forward rules), and the fold consults the supporter.
- **Ceiling plane double-scaled on non-square grids.** The plane received a pre-scaled depth and rendered inside the scene group that applies the same scale, squashing it (and its label glyphs) by the factor squared. It now takes the raw depth; the label counter-scales per the scene's annotation rule.
- **Solver and summary disagreed by the plate floor.** `HeightUnitSolver` budgeted under the raw measurement while the ceiling check charges each column `baseplateFloorDepth`. On a magnet plate the solver recommended a stack the summary immediately flagged. Both now budget under the same number.
- **Empty layout claimed a fit.** With nothing placed, the summary reported "tallest stack fits" with the whole ceiling to spare. The fit line now waits for a stack to exist.

Also removes `solveHeightUnitMm`, dead since the solver stopped back-solving non-standard units.

## Verification

- New regression tests for each fix (assembledHeight, drawerCeiling, CeilingPlane, DrawerDimensionsSummary); the slide-lid tests were confirmed failing before the fix.
- Full unit suite, typecheck, lint, all four i18n checks, and module boundaries green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

