### PR TITLE
fix(bin-designer): make detachable feet honest about placement, preview frame and stale caches

### DIFF
--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -213,14 +213,14 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
   // can recolor multiple zones in one session.
   const handleClosePicker = useCallback(() => setPickerOverlay(null), [setPickerOverlay]);
 
+  // A bin can carry both sliders, and the two share one anchor on the right
+  // edge — so the feet's takes the second slot whenever the lid's is on screen.
+  const showLidSlider = params.lid.enabled && params.base.stackingLip;
+
   // Reset the explode slider to its default whenever the lid transitions
   // off → on. Without this, a stale value (e.g. 80mm from a previous session)
   // persists across the slider's unmount/remount cycle — disabling the lid
   // hides the slider but doesn't clear the parent-owned `lidOffsetMm`.
-  // A bin can carry both, and the two sliders share one anchor on the right
-  // edge — so the feet's takes the second slot whenever the lid's is on screen.
-  const showLidSlider = params.lid.enabled && params.base.stackingLip;
-
   const wasLidEnabledRef = useRef(params.lid.enabled);
   useEffect(() => {
     if (params.lid.enabled && !wasLidEnabledRef.current) {

--- a/src/features/bin-designer/components/preview/FeetDetachSlider/FeetDetachSlider.test.tsx
+++ b/src/features/bin-designer/components/preview/FeetDetachSlider/FeetDetachSlider.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { FeetDetachSlider } from './FeetDetachSlider';
 
 describe('FeetDetachSlider', () => {
@@ -35,6 +35,23 @@ describe('FeetDetachSlider', () => {
     const fill = container.querySelector('[data-testid="slider-fill"]');
     expect(fill?.className).toContain('top-0');
     expect(fill?.className).not.toContain('bottom-0');
+  });
+
+  it('moves the feet the way the arrow points', () => {
+    // The keyboard is the fourth end of the inverted track: with the maximum
+    // at the bottom, ArrowUp must move the thumb (and the feet) UP — i.e.
+    // decrease — or the hand and the part go opposite ways again.
+    const onChange = vi.fn();
+    render(<FeetDetachSlider value={10} onChange={onChange} />);
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'ArrowUp' });
+    expect(onChange).toHaveBeenLastCalledWith(9);
+    fireEvent.keyDown(slider, { key: 'ArrowDown' });
+    expect(onChange).toHaveBeenLastCalledWith(11);
+    fireEvent.keyDown(slider, { key: 'Home' });
+    expect(onChange).toHaveBeenLastCalledWith(80);
+    fireEvent.keyDown(slider, { key: 'End' });
+    expect(onChange).toHaveBeenLastCalledWith(0);
   });
 
   it('steps aside when the lid slider is on screen too', () => {

--- a/src/features/bin-designer/components/preview/LidExplodeSlider/LidExplodeSlider.tsx
+++ b/src/features/bin-designer/components/preview/LidExplodeSlider/LidExplodeSlider.tsx
@@ -49,8 +49,8 @@ interface LidExplodeSliderProps {
    * The drag has to move the part the way the part moves. A lid lifts, so its
    * maximum belongs at the top; feet drop away downward, so dragging up to
    * detach them sends them the opposite way to the hand. Flips the pointer
-   * mapping, the fill anchor and the thumb together — they all read from the
-   * same end or the control fights itself.
+   * mapping, the fill anchor, the thumb and the arrow keys together — they all
+   * read from the same end or the control fights itself.
    */
   invert?: boolean;
   /**
@@ -120,24 +120,28 @@ export function LidExplodeSlider({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // ArrowUp/Right = increase (lift higher); ArrowDown/Left = decrease.
+      // ArrowUp/Right moves the THUMB up the track. Inverted, the maximum sits
+      // at the bottom, so up means decrease — the keyboard is the fourth end
+      // that has to read from the same end as the pointer, the fill and the
+      // thumb, or the hand and the part move opposite ways.
+      const step = invert ? -1 : 1;
       let next: number | undefined;
       if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
         e.preventDefault();
-        next = Math.min(LID_OFFSET_MAX, value + 1);
+        next = Math.min(LID_OFFSET_MAX, Math.max(LID_OFFSET_MIN, value + step));
       } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
         e.preventDefault();
-        next = Math.max(LID_OFFSET_MIN, value - 1);
+        next = Math.min(LID_OFFSET_MAX, Math.max(LID_OFFSET_MIN, value - step));
       } else if (e.key === 'Home') {
         e.preventDefault();
-        next = LID_OFFSET_MIN;
+        next = invert ? LID_OFFSET_MAX : LID_OFFSET_MIN;
       } else if (e.key === 'End') {
         e.preventDefault();
-        next = LID_OFFSET_MAX;
+        next = invert ? LID_OFFSET_MIN : LID_OFFSET_MAX;
       }
       if (next !== undefined && next !== value) onChange(next);
     },
-    [value, onChange]
+    [value, onChange, invert]
   );
 
   const thumbActive = isDragging || isHovering;

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -652,6 +652,24 @@ describe('migrateParams', () => {
     expect(result.style).toBe('solid');
   });
 
+  it('snaps a 5mm-era pin diameter to the current default', () => {
+    // Pin holes are cut at a fixed 3mm now; a stored 5 makes unassemblable
+    // parts and fails server validation on re-publish.
+    const result = migrateParams({
+      base: { ...DEFAULT_BIN_PARAMS.base, feetPinDiameter: 5 },
+    });
+    expect(result.base.feetPinDiameter).toBe(3);
+  });
+
+  it('keeps a valid pin diameter and an absent one alone', () => {
+    const kept = migrateParams({
+      base: { ...DEFAULT_BIN_PARAMS.base, feetPinDiameter: 2.9 },
+    });
+    expect(kept.base.feetPinDiameter).toBe(2.9);
+    const absent = migrateParams({});
+    expect(absent.base.feetPinDiameter).toBe(DEFAULT_BIN_PARAMS.base.feetPinDiameter);
+  });
+
   it('should default walls.shape to u-shape when shape is missing', () => {
     const result = migrateParams({
       walls: {

--- a/src/features/bin-designer/constants/paramMigration.ts
+++ b/src/features/bin-designer/constants/paramMigration.ts
@@ -31,7 +31,11 @@ import { makeUniformLipCells, LIP_CELL_ZONES } from '../types/featureColors';
 import type { SlideConfig, SlideRailMount } from '../types/slide';
 import { DEFAULT_SLIDE_CONFIG, SLIDE_RAIL_MOUNTS } from '../types/slide';
 import type { BaseConfig, TrayBottomConfig } from '../types/base';
-import { DEFAULT_TRAY_BOTTOM } from '../types/base';
+import {
+  DEFAULT_TRAY_BOTTOM,
+  DEFAULT_DETACHABLE_PIN_DIAMETER_MM,
+  DETACHABLE_PIN_DIAMETERS_MM,
+} from '../types/base';
 import {
   DEFAULT_LID_CONFIG,
   LID_CLICK_RAIL_COVERAGE_OPTIONS,
@@ -987,6 +991,16 @@ export function migrateParams(params: MigrateParamsInput): BinParams {
   // design that has no tray just as an always-present default would.
   if (mergedBase.tile !== true) {
     delete (mergedBase as { tile?: boolean }).tile;
+  }
+  // A stored pin diameter from the 5mm era meets pin holes now cut at a fixed
+  // 3mm, so the printed parts are unassemblable and the server validator
+  // rejects the design outright on re-publish. Snap anything off the current
+  // list to the default; absent stays absent, per the fingerprint note above.
+  if (
+    mergedBase.feetPinDiameter !== undefined &&
+    !(DETACHABLE_PIN_DIAMETERS_MM as readonly number[]).includes(mergedBase.feetPinDiameter)
+  ) {
+    mergedBase.feetPinDiameter = DEFAULT_DETACHABLE_PIN_DIAMETER_MM;
   }
   const baseConfig: BaseConfig =
     mergedBase.style === 'lid'

--- a/src/features/bin-designer/types/featureColors.ts
+++ b/src/features/bin-designer/types/featureColors.ts
@@ -10,7 +10,7 @@
  */
 
 import { FeatureTag } from '@/shared/types/generation';
-import { hasDetachableFeet, isSocketlessBase } from './base';
+import { isSocketlessBase } from './base';
 import { isPartialMask, type CellMask } from '@/shared/utils/cellMask';
 import type { BaseStyle, WallTextSide } from './index';
 
@@ -561,9 +561,10 @@ export function computeActiveZones(p: ActiveZonesParams): ReadonlySet<ColorZone>
   const zones = new Set<ColorZone>(['body']);
   // The Base zone paints FeatureTag.SOCKET, which only the socket branch of
   // `shellStage` stamps. A socketless base has none, so offering the zone would
-  // show a control that changes nothing — but detachable feet ARE the base,
-  // shipped as their own part, so the zone paints them instead.
-  if (!isSocketlessBase(p.base.style) || hasDetachableFeet(p.base)) zones.add('base');
+  // show a control that changes nothing. Detachable feet need no extra term:
+  // `hasDetachableFeet` refuses a socketless base, so a detachable bin always
+  // passes this test already, and the zone paints its feet part.
+  if (!isSocketlessBase(p.base.style)) zones.add('base');
   if (p.base.stackingLip) {
     const grid = p.featureColors?.lip ?? { corners: 1, bands: 1 };
     for (const cell of activeLipCells(grid)) zones.add(cell);

--- a/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
+++ b/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
@@ -44,8 +44,14 @@ const PLATE_GAP_MM = 4;
  * Build the feet for a bin, or `null` when it has none.
  *
  * `laidOut` re-arranges them onto a plate instead of leaving them assembled.
+ * `forExport` picks the full 5-section socket profile; the preview gets the
+ * same simplified profile every other preview socket uses.
  */
-function buildFeetSolids(params: BinParams, laidOut: boolean): Shape3D[] | null {
+function buildFeetSolids(
+  params: BinParams,
+  laidOut: boolean,
+  forExport: boolean
+): Shape3D[] | null {
   if (!hasDetachableFeet(params.base)) return null;
   const resolved = resolveDetachableFeet(params);
   if (resolved.placements.length === 0) return null;
@@ -64,7 +70,7 @@ function buildFeetSolids(params: BinParams, laidOut: boolean): Shape3D[] | null 
           positions: resolved.magnet.positions,
         }
       : undefined,
-    forExport: true,
+    forExport,
   });
   // The holes belong to the body, which this path does not build.
   pinHoles?.delete();
@@ -93,7 +99,7 @@ function buildFeetSolids(params: BinParams, laidOut: boolean): Shape3D[] | null 
  * them. For the STEP compound, which holds bin + companions as separate solids.
  */
 export function buildAssembledFeetSolids(params: BinParams): Shape3D[] | null {
-  return buildFeetSolids(params, false);
+  return buildFeetSolids(params, false, true);
 }
 
 /** Feet meshed where they sit under the bin, for the assembled preview. */
@@ -101,7 +107,7 @@ export function generateDetachableFeetMesh(
   params: BinParams,
   onProgress?: ProgressFn
 ): MeshData | null {
-  const feet = buildAssembledFeetSolids(params);
+  const feet = buildFeetSolids(params, false, false);
   if (!feet) return null;
   onProgress?.('feet', 0.9);
   try {
@@ -146,7 +152,7 @@ export async function exportDetachableFeet(
   tolerance = 0.01,
   angularTolerance = 5
 ): Promise<DetachableFeetExportResult | null> {
-  const feet = buildFeetSolids(params, true);
+  const feet = buildFeetSolids(params, true, true);
   if (!feet) return null;
 
   const plate = unwrap(fuseAll(feet as ValidSolid[], { optimisation: 'commonFace' }));

--- a/src/features/generation/worker/generators/floorPatterns.ts
+++ b/src/features/generation/worker/generators/floorPatterns.ts
@@ -92,13 +92,6 @@ function inflate(box: WorldKeepOut, by: number): WorldKeepOut {
 }
 
 /**
- * Magnet / screw pocket footprints in bin-centred mm.
- *
- * Taken from the FULL cell decomposition, matching `buildBaseSocket` — under
- * `halfSockets` the feet subdivide but the pockets stay on the standard grid so
- * they keep mating with the baseplate.
- */
-/**
  * Pin-recess footprints in bin-centred mm, for a detachable-feet bin.
  *
  * The recesses are blind, and the membrane over them is the whole reason the
@@ -123,6 +116,13 @@ function pinKeepOuts(params: BinParams, dim: BinDimensions): WorldKeepOut[] {
   );
 }
 
+/**
+ * Magnet / screw pocket footprints in bin-centred mm.
+ *
+ * Taken from the FULL cell decomposition, matching `buildBaseSocket` — under
+ * `halfSockets` the feet subdivide but the pockets stay on the standard grid so
+ * they keep mating with the baseplate.
+ */
 function attachmentKeepOuts(params: BinParams, dim: BinDimensions): WorldKeepOut[] {
   if (!dim.withMagnet && !dim.withScrew) return [];
   const radius = Math.max(

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -241,6 +241,38 @@ describe('createInitialContext', () => {
     });
   });
 
+  describe('detachableFeet flag in dimensions', () => {
+    it('is on for a placeable detachable-feet bin', () => {
+      const ctx = createInitialContext(
+        createTestParams({
+          base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false, feet: 'detachable' },
+        })
+      );
+      expect(ctx.dimensions.detachableFeet).toBe(true);
+    });
+
+    // The plan places nothing when an axis has no pocket-aligned whole cell
+    // (a half-lattice 1-wide bin spans 0.5u..1.5u of the plate). The flag must
+    // follow the PLAN, not the request: with it stuck on, the shell skips the
+    // socket, the feet part is null, and the export is a flat-bottomed box
+    // with no Gridfinity base at all.
+    it('falls back to an integral socket when the plan places no feet', () => {
+      const ctx = createInitialContext(
+        createTestParams({
+          width: 1,
+          depth: 4,
+          base: {
+            ...DEFAULT_BIN_PARAMS.base,
+            stackingLip: false,
+            feet: 'detachable',
+            footLatticeX: 'half',
+          },
+        })
+      );
+      expect(ctx.dimensions.detachableFeet).toBe(false);
+    });
+  });
+
   describe('halfSockets flag in dimensions', () => {
     it('stays off for an unset user toggle on a 1u-aligned L preset mask', () => {
       // 3×3 L-shape at 1u resolution — no half-bin detail.

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -12,6 +12,7 @@ import {
   resolveTileFloorThickness,
 } from '@/shared/types/bin';
 import { hashMask, isPartialMask } from '@/shared/utils/cellMask';
+import { resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import {
   HEIGHT_UNIT,
   CLEARANCE,
@@ -71,8 +72,13 @@ export function deriveDimensions(params: BinParams, _forExport: boolean): BinDim
   // attachment hardware. The magnets move into the feet rather than vanishing,
   // and the body is otherwise bit-identical to an integral bin's, so only
   // `baseOffsetZ` and the socket build change. `hasDetachableFeet` already
-  // refuses a spacer and a socketless base.
-  const detachableFeet = hasDetachableFeet(params.base);
+  // refuses a spacer and a socketless base — but it answers "the user asked",
+  // not "feet exist": the plan places NOTHING when an axis has no
+  // pocket-aligned whole cell (a half-lattice 1xN, say). Both geometry
+  // consumers guard on the placements; without the same guard here the socket
+  // is skipped too, and the export is a flat-bottomed box with no feet part.
+  const detachableFeet =
+    hasDetachableFeet(params.base) && resolveDetachableFeet(params).placements.length > 0;
   // User flag only. When the mask has mixed half-bin detail, the socket
   // builder does a per-cell dispatch using the mask — it splits only
   // those 1u cells that straddle a half-bin boundary into quarter

--- a/src/features/grid-editor/components/Grid/IsometricPreview/LinkedBinMeshes/useDesignGeometries.test.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/LinkedBinMeshes/useDesignGeometries.test.ts
@@ -49,6 +49,34 @@ describe('buildDesignGeometry', () => {
     geometry.dispose();
   });
 
+  // Feet arrive spanning [-SOCKET_HEIGHT, 0] with the body starting at 0; the
+  // preview contract is Z=0 bottom, so the merged assembly must be lifted a
+  // socket. Without the lift the feet poke through the layer plane and the rim
+  // still sits a socket below an integral neighbour's.
+  it('merges detachable feet and lifts the assembly back to a Z=0 bottom', () => {
+    const body: MeshData = {
+      ...makeMesh(true),
+      vertices: new Float32Array([0, 0, 0, 10, 0, 0, 10, 10, 0, 0, 10, 10]),
+    };
+    const feet: MeshData = {
+      ...makeMesh(true),
+      vertices: new Float32Array([0, 0, -5, 10, 0, -5, 10, 10, -5, 0, 10, 0]),
+    };
+    const geometry = buildDesignGeometry({ ...body, detachableFeetMesh: feet });
+    geometry.computeBoundingBox();
+    expect(geometry.boundingBox?.min.z).toBeCloseTo(0, 6);
+    // Body top (was 10) rides up with the lift.
+    expect(geometry.boundingBox?.max.z).toBeCloseTo(15, 6);
+    geometry.dispose();
+  });
+
+  it('leaves a feetless mesh in its own frame', () => {
+    const geometry = buildDesignGeometry(makeMesh(true));
+    geometry.computeBoundingBox();
+    expect(geometry.boundingBox?.min.z).toBeCloseTo(0, 6);
+    geometry.dispose();
+  });
+
   it('produces finite positions and normals', () => {
     const geometry = buildDesignGeometry(makeMesh(true));
     const positions = geometry.attributes.position.array as Float32Array;

--- a/src/features/grid-editor/components/Grid/IsometricPreview/LinkedBinMeshes/useDesignGeometries.ts
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/LinkedBinMeshes/useDesignGeometries.ts
@@ -5,6 +5,7 @@ import type { DesignId } from '@/core/types';
 import type { MeshData } from '@/shared/types/generation';
 import type { LinkedDesignMesh } from '@/shared/hooks/useLinkedDesignMeshes';
 import { CREASE_ANGLE_RAD } from '@/shared/constants/tessellation';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 
 /** A ready-to-render design geometry, shared by every bin linked to the design. */
 export interface DesignGeometryEntry {
@@ -62,8 +63,17 @@ export function buildDesignGeometry(mesh: MeshData): THREE.BufferGeometry {
   // Detachable feet are part of the object, not a companion the layout can
   // leave out: without them a linked bin draws as a flat-bottomed box sitting a
   // socket lower than an identical neighbour. They arrive positioned in the
-  // bin's own frame, so concatenating is the whole transform.
+  // bin's own frame — feet spanning [-SOCKET_HEIGHT, 0], body starting at 0 —
+  // so after concatenating, the whole assembly must be LIFTED a socket to keep
+  // the preview contract (Z=0 bottom) that `LinkedBinMesh` positions by.
+  // Concatenating alone puts the feet through the layer plane while the rim
+  // still sits a socket below an integral neighbour's.
   const { vertices, indices } = mergeParts(mesh, mesh.detachableFeetMesh);
+  if (mesh.detachableFeetMesh && mesh.detachableFeetMesh.vertices.length > 0) {
+    for (let i = 2; i < vertices.length; i += 3) {
+      vertices[i] += GRIDFINITY_SPEC.SOCKET_HEIGHT;
+    }
+  }
 
   let geo = new THREE.BufferGeometry();
   geo.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -42,6 +42,11 @@ const META_STORE = 'binMeshMeta';
  * one kernel's output, bump that kernel's {@link KERNEL_MESH_REVISION} entry
  * instead, so the other kernel's users keep their warm cache.
  *
+ * `v11`: detachable feet changed shape (blind 3mm pins, taper-floored arms)
+ * and the layout preview began reading `detachableFeetMesh` off the persisted
+ * entry — which pre-change entries cannot carry, and their bodies still have
+ * the old through-holes. Without a bump, a linked detachable design keeps
+ * rendering its pre-fix mesh until the LRU happens to evict it.
  * `v10`: the kernel id joined the key. Before this, occt-wasm and the
  * brepkit Labs kernel shared one namespace, so switching engines in Labs served
  * the previous engine's mesh for unchanged params.
@@ -55,7 +60,7 @@ const META_STORE = 'binMeshMeta';
  * without regenerating, so without this bump a linked design in the layout
  * planner would render its pre-fix bin until the entry was evicted.
  */
-const MESH_CACHE_VERSION = 'v10';
+const MESH_CACHE_VERSION = 'v11';
 
 /**
  * Per-kernel revision, bumped when only THAT kernel's output moves for


### PR DESCRIPTION
Post-merge review of the detachable-feet series (#3556, #3558, #3565). Three defects, four polish items, all verified (18 kernel tests pass, full unit suites green).

## Fixes

- **A requested foot is not a placed foot.** `dimensions.detachableFeet` read `hasDetachableFeet(base)` — the user's request — while the plan legitimately places nothing when an axis has no pocket-aligned whole cell (e.g. a half-lattice 1-wide bin). Both geometry consumers guard on `placements.length`; the dimensions flag did not, so the shell skipped the socket, the feet part was null, and the export was a flat-bottomed box with no Gridfinity base. The flag now follows the plan, restoring the integral socket in that case, with a unit test on both sides.
- **Layout preview drew feet through the floor.** The linked-design geometry merged the feet mesh (built spanning −SOCKET_HEIGHT..0) under the body (starting at 0) with no rebase, violating the preview's Z=0-bottom contract: feet sank through the layer plane while the rim still sat a socket below an integral neighbour — the exact symptom the merge was added to fix. The merged assembly is now lifted a socket, with bounding-box tests.
- **Stale meshes served forever.** `MESH_CACHE_VERSION` stayed at v10 while the feet changed shape (blind 3mm pins, taper-floored arms) and the layout preview began depending on `detachableFeetMesh`, which pre-change persisted entries cannot carry. Bumped to v11 per the file's own changelog discipline.

## Polish

- The inverted detach slider flipped pointer, fill and thumb but not the keyboard: ArrowUp moved the feet DOWN. Arrows and Home/End now read from the same end as the hand (keyboard test added).
- A stored 5mm-era `feetPinDiameter` meets pin holes now cut at a fixed 3mm — unassemblable parts, and the server validator rejects the design on re-publish. `migrateParams` snaps off-list values to the default (valid and absent values untouched, per the fingerprint rules).
- Preview feet were built at full export fidelity; they now use the same simplified socket profile every other preview socket uses, making the builder's `forExport` branch reachable again. Export paths keep the full profile.
- Dropped the dead `hasDetachableFeet` clause in the Base colour-zone gate (a detachable bin is never socketless, so the left operand already passes) and re-homed two comment blocks that had drifted off their functions.

## Verification

- `detachableFeet.kernel` (18 tests, includes baseplate seat-depth mating) green with the changes.
- New unit tests: dimensions flag both ways, preview Z-frame, keyboard invert, pin migration. Typecheck, lint, full paramMigration/context suites green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

