### PR TITLE
fix(bin-designer): align label-socket planning frames and unblock the socket editor

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutSocketControls.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutSocketControls.test.tsx
@@ -175,4 +175,35 @@ describe('CutoutSocketControls', () => {
     expect(screen.getByRole('status').textContent).toBe(message);
     expect(screen.queryByRole('button', { name: 'binDesigner.cutoutSocket.widthAuto' })).toBeNull();
   });
+
+  // The no-room copy advises trying the other orientation, so the one control
+  // that can unblock the plan must stay mounted with the warning. The other
+  // refusals are not orientation's to fix.
+  it('keeps the orientation toggle mounted on a no-room skip', () => {
+    render(
+      <CutoutSocketControls
+        cutout={cutout()}
+        plan={planSkipping('noRoom')}
+        disabled={false}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('group', { name: 'binDesigner.cutoutSocket.orientation' })
+    ).toBeInTheDocument();
+  });
+
+  it('offers no orientation toggle for refusals orientation cannot fix', () => {
+    render(
+      <CutoutSocketControls
+        cutout={cutout()}
+        plan={planSkipping('tooShallow')}
+        disabled={false}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(
+      screen.queryByRole('group', { name: 'binDesigner.cutoutSocket.orientation' })
+    ).toBeNull();
+  });
 });

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutSocketControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutSocketControls.tsx
@@ -43,26 +43,61 @@ export function CutoutSocketControls({
   const t = useTranslation();
   const socket = plan.byCutoutId.get(cutout.id);
   const skipReason = plan.skippedByCutoutId.get(cutout.id);
+  // Read through the planner's own predicate rather than re-deriving it: the
+  // toggle must show the orientation the pocket was actually cut at.
+  const vertical = isCutoutSocketVertical(cutout);
+
+  const orientationGroup = (
+    <div
+      role="group"
+      aria-label={t('binDesigner.cutoutSocket.orientation')}
+      className={SEGMENT_GROUP_CLASS}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        disabled={disabled}
+        onClick={() => onUpdate({ textAngle: 0 })}
+        aria-pressed={!vertical}
+        className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(!vertical)}`}
+      >
+        {t('binDesigner.cutoutSocket.horizontal')}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        disabled={disabled}
+        onClick={() => onUpdate({ textAngle: 90 })}
+        aria-pressed={vertical}
+        className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(vertical)}`}
+      >
+        {t('binDesigner.cutoutSocket.vertical')}
+      </Button>
+    </div>
+  );
 
   if (!socket) {
+    // The no-room message advises trying the other orientation, so the one
+    // control that can unblock the plan has to stay mounted with it. The other
+    // refusals are not orientation's to fix and keep the bare warning.
     return (
-      <p role="status" className="text-[10px] text-status-warning">
-        {skipReason === 'centerAnchor'
-          ? t('binDesigner.cutoutSocket.blockedCenterAnchor')
-          : skipReason === 'tooShallow'
-            ? t('binDesigner.cutoutSocket.blockedTooShallow')
-            : skipReason === 'capped'
-              ? t('binDesigner.cutoutSocket.blockedCapped', { max: MAX_CUTOUT_LABEL_SOCKETS })
-              : t('binDesigner.cutoutSocket.blockedNoRoom')}
-      </p>
+      <div className="space-y-2">
+        <p role="status" className="text-[10px] text-status-warning">
+          {skipReason === 'centerAnchor'
+            ? t('binDesigner.cutoutSocket.blockedCenterAnchor')
+            : skipReason === 'tooShallow'
+              ? t('binDesigner.cutoutSocket.blockedTooShallow')
+              : skipReason === 'capped'
+                ? t('binDesigner.cutoutSocket.blockedCapped', { max: MAX_CUTOUT_LABEL_SOCKETS })
+                : t('binDesigner.cutoutSocket.blockedNoRoom')}
+        </p>
+        {(skipReason === 'noRoom' || skipReason === undefined) && orientationGroup}
+      </div>
     );
   }
 
   const override = cutout.labelPlateWidthU;
   const pinned = isLabelPlateWidthU(override) && socket.fittingWidthsU.includes(override);
-  // Read through the planner's own predicate rather than re-deriving it: the
-  // toggle must show the orientation the pocket was actually cut at.
-  const vertical = isCutoutSocketVertical(cutout);
 
   const setWidth = (widthU: LabelPlateWidthU | null) => {
     onUpdate(widthU === null ? { labelPlateWidthU: undefined } : { labelPlateWidthU: widthU });
@@ -114,32 +149,7 @@ export function CutoutSocketControls({
         />
       </div>
 
-      <div
-        role="group"
-        aria-label={t('binDesigner.cutoutSocket.orientation')}
-        className={SEGMENT_GROUP_CLASS}
-      >
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={disabled}
-          onClick={() => onUpdate({ textAngle: 0 })}
-          aria-pressed={!vertical}
-          className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(!vertical)}`}
-        >
-          {t('binDesigner.cutoutSocket.horizontal')}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={disabled}
-          onClick={() => onUpdate({ textAngle: 90 })}
-          aria-pressed={vertical}
-          className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(vertical)}`}
-        >
-          {t('binDesigner.cutoutSocket.vertical')}
-        </Button>
-      </div>
+      {orientationGroup}
     </div>
   );
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
@@ -78,15 +78,28 @@ export function CutoutLabel3D({
           const socket = socketPlan.byCutoutId.get(cutout.id);
           if (!socket) return null;
           const plateW = labelPlateWidthMm(socket.widthU);
+          // The plan is memoised on committed params, so mid-drag it still
+          // describes the grab-point position. Follow the live override by the
+          // same delta the cutout (or its label nudge) has moved — both feed
+          // the plan's placement 1:1, and the exact re-plan lands on release.
+          const overrides = preview.get(cutout.id);
+          const effective = overrides ? { ...cutout, ...overrides } : cutout;
+          const dragX =
+            effective.x - cutout.x + (effective.textOffset?.x ?? 0) - (cutout.textOffset?.x ?? 0);
+          const dragY =
+            effective.y - cutout.y + (effective.textOffset?.y ?? 0) - (cutout.textOffset?.y ?? 0);
           return (
             <CutoutSocketFootprint
               key={`socket-${cutout.id}`}
               // Plan centres are bin-centred; the editor's origin is the
               // interior corner, so shift by half the box the plan measured.
-              centerX={socket.centerX + socketPlan.innerW / 2}
-              centerY={socket.centerY + socketPlan.innerD / 2}
-              widthMm={socket.vertical ? LABEL_PLATE_HEIGHT_MM : plateW}
-              depthMm={socket.vertical ? plateW : LABEL_PLATE_HEIGHT_MM}
+              centerX={socket.centerX + socketPlan.innerW / 2 + dragX}
+              centerY={socket.centerY + socketPlan.innerD / 2 + dragY}
+              // PLATE-frame extents, always: the footprint applies the
+              // vertical rotation itself, so world-swapped extents here would
+              // be rotated back and draw the plate on the wrong axis.
+              widthMm={plateW}
+              depthMm={LABEL_PLATE_HEIGHT_MM}
               cornerRadiusMm={LABEL_PLATE_CORNER_RADIUS_MM}
               text={socket.text}
               hasIcon={socket.icon !== undefined}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutSocketFootprint.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutSocketFootprint.tsx
@@ -22,7 +22,9 @@ const BORDER_MM = 0.5;
 interface CutoutSocketFootprintProps {
   readonly centerX: number;
   readonly centerY: number;
+  /** Plate-frame long axis (mm) — NOT world-swapped; `vertical` rotates. */
   readonly widthMm: number;
+  /** Plate-frame short axis (mm). */
   readonly depthMm: number;
   readonly cornerRadiusMm: number;
   readonly text: string;
@@ -61,9 +63,10 @@ export function CutoutSocketFootprint({
     [widthMm, depthMm, cornerRadiusMm]
   );
 
-  // The caption always reads along the plate's LONG axis, so a vertical socket
-  // turns its text with the plate rather than wrapping across the short one.
-  const plateLength = vertical ? depthMm : widthMm;
+  // Extents arrive in the PLATE's own frame (width = long axis); the group
+  // rotation below is the single place orientation is applied, so the caption
+  // always lays out along local X.
+  const plateLength = widthMm;
   const { fontSize, captionSpan, captionCenter, iconCenter } = socketCaptionLayout(
     plateLength,
     hasIcon,

--- a/src/features/bin-designer/hooks/useCutoutSocketPlan.test.ts
+++ b/src/features/bin-designer/hooks/useCutoutSocketPlan.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useCutoutSocketPlan } from './useCutoutSocketPlan';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { binDimensions, cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
 import type { Cutout } from '@/features/bin-designer/types';
 
 const cutout = (o: Partial<Cutout> = {}): Cutout => ({
@@ -45,6 +46,27 @@ describe('useCutoutSocketPlan', () => {
 
     expect(result.current.socketCount).toBe(0);
     expect(result.current.skippedCount).toBe(0);
+  });
+
+  it('plans against the overhang-expanded interior, exactly as the worker cuts', () => {
+    // The worker sizes sockets against `dim.innerW` (overhang folded in). A
+    // plan measured on the nominal interior under-reports the room beside a
+    // cutout on an overhung board, so the panel would offer a narrower plate
+    // than the pocket the worker cuts. The plan's own frame must therefore be
+    // `cutoutInterior`, and it reports the frame it used.
+    board([cutout({ labelMode: 'socket', textAnchor: 'top' })]);
+    const { params } = useDesignerStore.getState();
+    useDesignerStore.setState({
+      params: { ...params, overhang: { left: 0, right: 10, front: 0, back: 0 } },
+    });
+    const { result } = renderHook(() => useCutoutSocketPlan());
+    expect(result.current.innerW).toBeCloseTo(
+      cutoutInterior(useDesignerStore.getState().params).innerW,
+      5
+    );
+    expect(result.current.innerW).toBeGreaterThan(
+      binDimensions(useDesignerStore.getState().params).innerW + 9
+    );
   });
 
   it('keys a planned socket by its cutout', () => {

--- a/src/features/bin-designer/hooks/useCutoutSocketPlan.ts
+++ b/src/features/bin-designer/hooks/useCutoutSocketPlan.ts
@@ -9,7 +9,7 @@
 import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
+import { binDimensions, cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
 import {
   MAX_CUTOUT_LABEL_SOCKETS,
   planCutoutSocketsForParams,
@@ -54,7 +54,13 @@ export function useCutoutSocketPlan(): CutoutSocketPlanView {
 
   return useMemo(() => {
     if (cutouts.length === 0) return EMPTY;
-    const { innerW, innerD, wallHeight } = binDimensions(params);
+    // The cutout frame is the overhang-EXPANDED interior (`cutoutInterior`),
+    // exactly as the generator places sockets against `dim.innerW`. The
+    // nominal `binDimensions` interior under-reports the room on an
+    // overhung board, so the panel and the worker would size different
+    // plates for the same pocket.
+    const { innerW, innerD } = cutoutInterior(params);
+    const { wallHeight } = binDimensions(params);
     const plan = planCutoutSocketsForParams(params, innerW, innerD, wallHeight);
     if (plan.sockets.length === 0 && plan.skipped.length === 0) return EMPTY;
     return {

--- a/src/features/bin-designer/hooks/useLabelPlateExport.ts
+++ b/src/features/bin-designer/hooks/useLabelPlateExport.ts
@@ -24,7 +24,7 @@ import {
   FORMAT_EXTENSIONS,
   triggerDownload,
 } from '@/shared/generation/exportUtils';
-import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
+import { binDimensions, cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
 import { buildLabelPlateColorConfig } from '@/features/bin-designer/utils/labelPlateColors';
 import {
   effectiveLabelSocketClearance,
@@ -63,7 +63,10 @@ export function useLabelPlateExport(): UseLabelPlateExportReturn {
   const nozzleSizeMm = useSettingsStore((s) => s.settings.printSettings.nozzleSizeMm);
 
   const plates = useMemo(() => {
-    const { innerW, innerD, wallHeight } = binDimensions(params);
+    // Expanded interior, matching the worker's socket frame (see
+    // `useCutoutSocketPlan`).
+    const { innerW, innerD } = cutoutInterior(params);
+    const { wallHeight } = binDimensions(params);
     // Same nozzle-scaled clearance the worker cuts with, so the widths planned
     // here match the sockets — never offer a plate the widened pocket rejects.
     const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, label.plateFitOffset);

--- a/src/features/bin-designer/index.ts
+++ b/src/features/bin-designer/index.ts
@@ -64,7 +64,7 @@ export { normalizeIdsWithRemap, remapCompartmentTexts } from './utils/compartmen
 export { validateBinParams } from './utils/validation';
 // Exposed for shared/hooks/useLabelPlateCounts (print-list plate counts) to
 // feed the same innerW into planLabelPlates that the worker uses.
-export { binDimensions } from './utils/binDimensions';
+export { binDimensions, cutoutInterior } from './utils/binDimensions';
 
 // Exposed for `shared/sync/` to wire into the sync engine without reaching
 // into the feature's internal path.

--- a/src/features/generation/worker/generators/labelPlateGenerator.ts
+++ b/src/features/generation/worker/generators/labelPlateGenerator.ts
@@ -53,15 +53,24 @@ export const MAX_PREVIEW_LABEL_PLATES = 12;
 /**
  * Every plate seat a design has, from whichever mechanism produced it.
  *
- * The two are mutually exclusive by construction (the label-tab feature is
- * unavailable on a solid bin, and a shadow board's sockets hang off cutouts
- * rather than walls), but reading both here keeps the preview's entry point
- * from having to know which kind of design it was handed.
+ * Cutout seats are consulted FIRST, mirroring `planLabelPlates`' priority.
+ * The two mechanisms are mutually exclusive for a design edited through the
+ * constraint engine, but a share/community import can carry a solid board
+ * with stale `label.enabled` config (the engine only clears the flag when the
+ * style is switched THROUGH it) — and the wall-hung branch has no solid gate,
+ * so putting it first would preview tabs the build never cuts while hiding
+ * the board's real plates.
  */
 function planPlateSeats(
   params: BinParams,
   dim: ReturnType<typeof deriveDimensions>
 ): PreviewPlateSeat[] {
+  // `wallHeight`, not `interiorHeight`: a board's fill surface hangs from the
+  // raw wall top less its own top offset, which is the plane `buildCutoutCuts`
+  // places every cavity against. Measuring from the lip-relieved interior
+  // would seat every plate the lip taper's depth below its own pocket.
+  const cutoutSeats = planCutoutPlateSeats(params, dim.innerW, dim.innerD, dim.wallHeight);
+  if (cutoutSeats.length > 0) return cutoutSeats;
   if (params.label.enabled && (params.label.mode ?? 'text') === 'socket') {
     return planLabelPlateSeats(
       params,
@@ -71,11 +80,7 @@ function planPlateSeats(
       params.wallThickness
     );
   }
-  // `wallHeight`, not `interiorHeight`: a board's fill surface hangs from the
-  // raw wall top less its own top offset, which is the plane `buildCutoutCuts`
-  // places every cavity against. Measuring from the lip-relieved interior
-  // would seat every plate the lip taper's depth below its own pocket.
-  return planCutoutPlateSeats(params, dim.innerW, dim.innerD, dim.wallHeight);
+  return [];
 }
 
 /**

--- a/src/shared/hooks/useLabelPlateCounts.test.ts
+++ b/src/shared/hooks/useLabelPlateCounts.test.ts
@@ -18,6 +18,8 @@ vi.mock('@/features/bin-designer', () => ({
   loadDesign: vi.fn(),
   useCustomBins: vi.fn(() => []),
   binDimensions: vi.fn(() => ({ innerW: 100, innerD: 80 })),
+  // Overhang-free fixtures: the expanded interior equals the nominal one.
+  cutoutInterior: vi.fn(() => ({ innerW: 100, innerD: 80, offsetX: 0, offsetY: 0 })),
 }));
 
 const mockLoadDesign = vi.mocked(loadDesign);

--- a/src/shared/hooks/useLabelPlateCounts.ts
+++ b/src/shared/hooks/useLabelPlateCounts.ts
@@ -14,6 +14,7 @@ import type { Bin, DesignId } from '@/core/types';
 import { isOk } from '@/core/result';
 import {
   binDimensions,
+  cutoutInterior,
   loadDesign,
   useCustomBins,
   type SavedDesign,
@@ -86,10 +87,13 @@ function computePlateSet(design: SavedDesign, nozzleSizeMm: number): DesignPlate
   if (!params) return null;
   const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, params.label.plateFitOffset);
   const dims = binDimensions(params);
+  // Expanded interior, matching the worker's socket frame (see
+  // `useCutoutSocketPlan`).
+  const inner = cutoutInterior(params);
   const planned = planLabelPlates({
     params,
-    innerWmm: dims.innerW,
-    innerDmm: dims.innerD,
+    innerWmm: inner.innerW,
+    innerDmm: inner.innerD,
     wallHeightMm: dims.wallHeight,
     clearanceMm,
     fallbackText: '',

--- a/src/shell/layoutExport/planLabelPlateExport.ts
+++ b/src/shell/layoutExport/planLabelPlateExport.ts
@@ -17,7 +17,7 @@ import type { Bin } from '@/core/types';
 import type { FeatureColorConfig, TextStyleDefaults } from '@/shared/types/bin';
 // Deep import (not the barrel): this code only runs inside the lazy
 // layout-export chunk (same rationale as planLayoutBinExport's deep imports).
-import { binDimensions } from '@/features/bin-designer/utils/binDimensions';
+import { binDimensions, cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
 import {
   LABEL_PLATE_HEIGHT_MM,
   effectiveLabelSocketClearance,
@@ -158,10 +158,13 @@ export function planLabelPlateExport(
 
     const clearanceMm = effectiveLabelSocketClearance(nozzleSizeMm, params.label.plateFitOffset);
     const dims = binDimensions(params);
+    // Expanded interior, matching the worker's socket frame (see
+    // `useCutoutSocketPlan`).
+    const inner = cutoutInterior(params);
     const planned = planLabelPlates({
       params,
-      innerWmm: dims.innerW,
-      innerDmm: dims.innerD,
+      innerWmm: inner.innerW,
+      innerDmm: inner.innerD,
       wallHeightMm: dims.wallHeight,
       clearanceMm,
       fallbackText: '',


### PR DESCRIPTION
Post-merge review of #3577 (swappable label sockets for cutout bins). Three P1s and two polish items, all with regression tests.

## Fixes

- **Panel and worker measured different interiors.** `useCutoutSocketPlan`, `useLabelPlateExport`, `useLabelPlateCounts` and `planLabelPlateExport` all planned against the nominal `binDimensions` interior while the worker cuts sockets against the overhang-expanded one (`dim.innerW`). On an overhung shadow board the worker sees more room beside a cutout and cuts a wider pocket than the plate every main-thread surface plans — a plate with no retention, agreed on by the panel, the print list and the layout ZIP. All four now read `cutoutInterior(params)`, the frame the cutout editor already uses; a new hook test pins the plan's frame to it under asymmetric overhang.
- **Vertical plates drawn on the wrong axis.** The caller swapped the footprint extents into world frame and the component then applied the 90° group rotation — rotating them straight back. A vertical socket's pocket runs along Y (the scenario suite probes it) while the editor drew the plate across X with the caption overflowing an 11mm band. Extents are now plate-frame with rotation applied once, stated in the prop contract.
- **Socket footprint froze during drags.** The plan is memoised on committed params, so the footprint ignored the live preview map and snapped only on pointer-up while the engraved label beside it followed the cursor. It now follows the override delta (cutout body and label nudge both feed placement 1:1) with the exact re-plan landing on release.

## Polish

- The no-room skip message says "try the other orientation" while the orientation toggle was unmounted with the rest of the controls. The toggle now stays mounted with that warning (and only that one — the other refusals are not orientation's to fix). Tests cover both.
- `planPlateSeats` preferred wall-hung seats where `planLabelPlates` (the export) prefers cutout plates, so a solid board carrying stale `label.enabled` config — reachable via share/community import, since the constraint engine only clears the flag when the style is switched through it — previewed tabs the build never cuts while hiding the board's real plates. The preview now mirrors the export's priority.

## Verification

344 tests across the socket plan, hooks, export planner and renderer suites green; typecheck and lint green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

