### PR TITLE
fix(bin-designer): measure the fit-test card the way the builder cuts it

### DIFF
--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -596,7 +596,7 @@ export class GenerationBridge {
     format: ExportFormat,
     options?: {
       thicknessMm?: number;
-      stamp?: { designName?: string; pieceLabel?: string };
+      stamp?: { designName?: string };
       bed?: { width: number; depth: number };
     }
   ): Promise<FitTestExportResult> {

--- a/src/features/generation/bridge/bridgeExports.ts
+++ b/src/features/generation/bridge/bridgeExports.ts
@@ -452,7 +452,7 @@ export function exportFitTest(
   format: ExportFormat,
   options?: {
     thicknessMm?: number;
-    stamp?: { designName?: string; pieceLabel?: string };
+    stamp?: { designName?: string };
     bed?: { width: number; depth: number };
   }
 ): Promise<FitTestExportResult> {

--- a/src/features/generation/bridge/messages.ts
+++ b/src/features/generation/bridge/messages.ts
@@ -314,7 +314,7 @@ export interface ExportFitTestPayload {
   /** Card thickness (mm). Clamped worker-side to the design's legal range. */
   readonly thicknessMm?: number;
   /** Design name and piece label for the underside stamp. */
-  readonly stamp?: { readonly designName?: string; readonly pieceLabel?: string };
+  readonly stamp?: { readonly designName?: string };
   /** Print bed (mm). Omitted leaves an oversize card whole. */
   readonly bed?: { readonly width: number; readonly depth: number };
 }

--- a/src/features/generation/worker/generators/fitTestSlice.ts
+++ b/src/features/generation/worker/generators/fitTestSlice.ts
@@ -46,6 +46,7 @@ import {
   fitTestStampLines,
   planFitTestSplit,
   planFitTestStampArea,
+  type FitTestSplitPlan,
   type FitTestStampContext,
 } from '@/shared/utils/fitTestPlan';
 import { getSplitPlanePositionsMm } from '@/shared/utils/splitPositions';
@@ -105,6 +106,7 @@ function stampLine(
   scope: DisposalScope,
   card: Shape3D,
   line: string,
+  centerX: number,
   centerY: number,
   availW: number,
   bottomZ: number,
@@ -118,7 +120,10 @@ function stampLine(
     mode: 'emboss',
     availW,
     availD: STAMP_LINE_MM,
-    centerX: 0,
+    // Negated: the glyphs are pre-mirrored across x=0 below, which carries a
+    // solid centred at -c to +c. The card itself is never mirrored, so its
+    // own centre (offset by asymmetric overhang) is where the run must land.
+    centerX: -centerX,
     centerY,
     topZ: bottomZ,
     depth: STAMP_DEPTH_MM,
@@ -147,7 +152,8 @@ function buildCard(
   solid: Shape3D,
   params: BinParams,
   thicknessMm: number,
-  stamp: FitTestStampContext
+  stamp: FitTestStampContext,
+  split: FitTestSplitPlan
 ): Shape3D {
   const dims = deriveDimensions(params, true);
   // The rim is NOT the fill surface. `wallTopZ` is
@@ -183,31 +189,30 @@ function buildCard(
   let card: Shape3D = scope.register(unwrap(intersect(solid, bandBox)));
 
   const lines = fitTestStampLines(params, thicknessMm, stamp);
+  // The split plan is passed in so the stamp lands whole on one piece rather
+  // than being bisected by a seam — the same plan the cuts below use.
   const area = planFitTestStampArea(
     params,
     thicknessMm,
     lines.length * STAMP_LINE_MM,
-    STAMP_DEPTH_MM
+    STAMP_DEPTH_MM,
+    split
   );
   if (!area) return card;
 
   lines.forEach((line, i) => {
-    // Lines run front to back, so the first reads nearest the front edge.
+    // First line at the LARGEST Y: turning the printed card over to read its
+    // underside flips left-right and keeps Y, so the back-most line is the
+    // top one and the lines read top-down.
     const centerY = area.centerY + (lines.length / 2 - 0.5 - i) * STAMP_LINE_MM;
-    card = stampLine(scope, card, line, centerY, area.availW, bottomZ, thicknessMm);
+    card = stampLine(scope, card, line, area.centerX, centerY, area.availW, bottomZ, thicknessMm);
   });
   return card;
 }
 
 /** Cut the card into bed-fitting pieces, using the same plan the export dialog
  *  warns from — so the two cannot disagree about where the seams land. */
-function splitCard(
-  scope: DisposalScope,
-  card: Shape3D,
-  params: BinParams,
-  bed: { readonly width: number; readonly depth: number }
-): FitTestPieces {
-  const plan = planFitTestSplit(params, bed, getSplitPlanePositionsMm);
+function splitCard(scope: DisposalScope, card: Shape3D, plan: FitTestSplitPlan): FitTestPieces {
   if (plan.pieceCount <= 1) return { pieces: [{ solid: card, label: '' }], blockedSeams: 0 };
 
   const bounds = getBounds(card);
@@ -225,10 +230,14 @@ function splitCard(
         })
       );
       const piece = intersect(card, cutter);
-      if (!piece.ok) continue;
+      // A failed cut must not quietly shorten the set: the ZIP would carry a
+      // card with a chunk missing that looks like a normal split. The named
+      // throw surfaces as a toast, exactly as the bin splitter's does.
+      const label = `${String.fromCharCode(65 + col)}${row + 1}`;
+      if (!piece.ok) throw new Error(`Fit-test piece ${label} failed to cut`);
       pieces.push({
         solid: scope.register(piece.value),
-        label: `${String.fromCharCode(65 + row)}${col + 1}`,
+        label,
       });
     }
   }
@@ -246,7 +255,10 @@ function buildFitTestPieces(
   const solid = getLastSolid();
   if (!solid) throw new Error('Failed to generate solid for the fit test card');
 
-  const card = buildCard(scope, solid, params, thicknessMm, options.stamp ?? {});
+  // One plan for both halves of the job: the stamp keeps clear of the seams
+  // the split will cut, so the two cannot disagree.
+  const plan = planFitTestSplit(params, options.bed, getSplitPlanePositionsMm);
+  const card = buildCard(scope, solid, params, thicknessMm, options.stamp ?? {}, plan);
   if (!options.bed) return { pieces: [{ solid: card, label: '' }], blockedSeams: 0 };
 
   const bounds = getBounds(card);
@@ -255,7 +267,7 @@ function buildFitTestPieces(
     bounds.yMax - bounds.yMin <= options.bed.depth;
   if (fits) return { pieces: [{ solid: card, label: '' }], blockedSeams: 0 };
 
-  return splitCard(scope, card, params, options.bed);
+  return splitCard(scope, card, plan);
 }
 
 /** One tessellated piece of the card. */

--- a/src/shared/utils/fitTestPlan.test.ts
+++ b/src/shared/utils/fitTestPlan.test.ts
@@ -102,6 +102,21 @@ describe('thickness', () => {
     });
   });
 
+  // The editor lets cutDepth reach the full wallHeight, and the builder clamps
+  // such a pocket to the solid surface — so "deepest cut plus a floor" can
+  // exceed the material the body offers, and a card sliced past it reaches
+  // into the base socket, whose feet are separate islands.
+  it('never offers more thickness than the material below the fill surface', () => {
+    // 2x2x4u solid: wallHeight = 28 - 5 = 23. A through cut at the full 23.
+    const params = board({}, [cutout({ cutDepth: 23 })]);
+    expect(fitTestThicknessRangeMm(params).max).toBe(23);
+  });
+
+  it('charges the top offset against the usable material', () => {
+    const params = board({ cutoutConfig: { topOffset: 6 } }, [cutout({ cutDepth: 23 })]);
+    expect(fitTestThicknessRangeMm(params).max).toBe(17);
+  });
+
   it('clamps an out-of-range value and falls back to the default on a non-number', () => {
     const params = board({}, [cutout({ cutDepth: 8 })]);
     expect(clampFitTestThicknessMm(params, 100)).toBe(8 + params.wallThickness);
@@ -119,14 +134,17 @@ describe('fitTestCutoutSpans', () => {
     expect(x[0].max).toBeCloseTo(-30.55, 2);
   });
 
-  it('grows the footprint by clearance and chamfer, which widen the opening', () => {
+  it('grows the footprint by clearance and chamfer, as the builder applies them', () => {
     // A circle takes both; a rectangle takes only the chamfer (see the
-    // stale-clearance regression below).
+    // stale-clearance regression below). The builder grows the DIMENSION by
+    // the clearance (half per side) and flares each SIDE by the chamfer, so
+    // 0.5 clearance + 1 chamfer widens the opening by 0.5 + 2·1 = 2.5 — not
+    // the 3 a per-side clearance model would claim.
     const plain = fitTestCutoutSpans(board({}, [cutout({ shape: 'circle', width: 10 })])).x[0];
     const grown = fitTestCutoutSpans(
       board({}, [cutout({ shape: 'circle', width: 10, clearance: 0.5, chamferWidth: 1 })])
     ).x[0];
-    expect(grown.max - grown.min).toBeCloseTo(plain.max - plain.min + 3, 5);
+    expect(grown.max - grown.min).toBeCloseTo(plain.max - plain.min + 2.5, 5);
   });
 
   it('takes a rotated cutout by its axis-aligned bounds', () => {
@@ -205,6 +223,30 @@ describe('planFitTestStampArea', () => {
     expect(planFitTestStampArea(shallow, 4, 8)).not.toBeNull();
   });
 
+  it('lands the stamp whole on the widest piece of a split card', () => {
+    // A vertical seam at x=10 splits the footprint into a wider left window
+    // and a narrower right one; the strip must centre in the left rather than
+    // stay at 0 and be bisected.
+    const params = board({}, [cutout({ cutDepth: 20 })]);
+    const half = fitTestFootprintMm(params).width / 2;
+    const area = planFitTestStampArea(params, 4, 8, 0, { planesX: [10], planesY: [] });
+    expect(area).not.toBeNull();
+    expect(area?.centerX).toBeCloseTo((-half + 10) / 2, 5);
+    expect(area?.availW ?? 0).toBeLessThan(half + 10);
+  });
+
+  it('keeps the strip clear of a horizontal seam', () => {
+    const params = board({}, [cutout({ cutDepth: 20 })]);
+    const unsplit = planFitTestStampArea(params, 4, 8);
+    expect(unsplit).not.toBeNull();
+    const seamY = unsplit?.centerY ?? 0;
+    const area = planFitTestStampArea(params, 4, 8, 0, { planesX: [], planesY: [seamY] });
+    expect(area).not.toBeNull();
+    const lo = (area?.centerY ?? 0) - 4;
+    const hi = (area?.centerY ?? 0) + 4;
+    expect(seamY <= lo || seamY >= hi).toBe(true);
+  });
+
   it('refuses when every strip is broken by a through cut', () => {
     const dense = board({}, [
       cutout({ shape: 'rectangle', x: 0, y: 0, width: 81, depth: 81, cutDepth: 20 }),
@@ -229,9 +271,8 @@ describe('fitTestStampLines', () => {
     expect(fitTestStampLines(params, 4, {})[1]).toBe('fit 0.10-0.30 · 4mm');
   });
 
-  it('adds the piece label only when the card is split', () => {
+  it('stamps exactly the name and the fit line', () => {
     expect(fitTestStampLines(board(), 4, {})).toHaveLength(2);
-    expect(fitTestStampLines(board(), 4, { pieceLabel: 'A1' })).toHaveLength(3);
   });
 
   it('falls back to a name when the design is untitled', () => {

--- a/src/shared/utils/fitTestPlan.ts
+++ b/src/shared/utils/fitTestPlan.ts
@@ -81,12 +81,21 @@ export function defaultFitTestThicknessMm(params: BinParams): number {
 /**
  * Legal thickness range. The ceiling is the deepest cut plus a floor under it:
  * past that every pocket already has its real bottom and more thickness only
- * re-prints bin.
+ * re-prints bin — and it is additionally bounded by the material the body
+ * actually offers below the fill surface. The editor lets `cutDepth` reach
+ * the full `wallHeight`, and the builder clamps such a pocket to the solid
+ * surface; a card sliced past that plane reaches into the Gridfinity socket,
+ * whose feet are separate islands (CLAUDE.md gotcha #10) — an underside of
+ * stubs that will not lie flat, with the stamp cut into mostly air.
  */
 export function fitTestThicknessRangeMm(params: BinParams): { min: number; max: number } {
+  const usable = Math.max(
+    0,
+    binDimensions(params).wallHeight - Math.max(0, params.cutoutConfig.topOffset)
+  );
   const max = Math.max(
     FIT_TEST_MIN_THICKNESS_MM,
-    deepestCutoutDepthMm(params) + params.wallThickness
+    Math.min(usable, Math.min(deepestCutoutDepthMm(params), usable) + params.wallThickness)
   );
   return { min: FIT_TEST_MIN_THICKNESS_MM, max };
 }
@@ -103,25 +112,48 @@ export function clampFitTestThicknessMm(params: BinParams, thicknessMm: number):
 }
 
 /**
+ * Per-side growth of a cutout's opening, split by cause, matching
+ * `buildCutoutCuts`' own arithmetic:
+ * - `clearance` grows each DIMENSION by the whole value (half per side); a
+ *   polygon scales anisotropically so it stays a regular N-gon, which grows
+ *   its width by `width·clearance/depth` instead.
+ * - the entry chamfer flares each SIDE by its own width at the rim, clamped so
+ *   a straight wall survives below the bevel, and is skipped entirely under
+ *   the builder's 0.05mm floor.
+ *
+ * Gated exactly as the builder gates them: a cutout switched from circle to
+ * rectangle keeps its stale `clearance`, and the builder ignores it —
+ * counting it here would reserve seam margin, and subtract volume, for
+ * material that is never removed.
+ */
+function openingGrowthMm(cutout: Cutout): {
+  clearanceW: number;
+  clearanceD: number;
+  chamfer: number;
+} {
+  const clearance = CLEARANCE_SHAPES.includes(cutout.shape)
+    ? Math.max(0, cutout.clearance ?? 0)
+    : 0;
+  const clearanceW =
+    cutout.shape === 'polygon' && cutout.depth > 0
+      ? (cutout.width * clearance) / cutout.depth / 2
+      : clearance / 2;
+  const clearanceD = clearance / 2;
+  const chamferRaw = CHAMFER_SHAPES.includes(cutout.shape) ? (cutout.chamferWidth ?? 0) : 0;
+  const chamferClamped = Math.max(0, Math.min(chamferRaw, cutout.cutDepth - 0.2));
+  return { clearanceW, clearanceD, chamfer: chamferClamped > 0.05 ? chamferClamped : 0 };
+}
+
+/**
  * Axis-aligned half-extents of a cutout's opening, rotation folded in.
  *
  * Clearance and the entry chamfer both widen the OPENING, which is the face the
  * card is measured at, so both count toward the footprint a seam has to miss.
  */
-function openingGrowthMm(cutout: Cutout): number {
-  // Gated exactly as `buildCutoutCuts` gates them. A cutout switched from
-  // circle to rectangle keeps its stale `clearance`, and the builder ignores it
-  // — counting it here would reserve seam margin, and subtract volume, for
-  // material that is never removed.
-  const clearance = CLEARANCE_SHAPES.includes(cutout.shape) ? (cutout.clearance ?? 0) : 0;
-  const chamfer = CHAMFER_SHAPES.includes(cutout.shape) ? (cutout.chamferWidth ?? 0) : 0;
-  return clearance + chamfer;
-}
-
 function openingHalfExtents(cutout: Cutout): { hx: number; hy: number } {
   const grow = openingGrowthMm(cutout);
-  const hw = cutout.width / 2 + grow;
-  const hd = cutout.depth / 2 + grow;
+  const hw = cutout.width / 2 + grow.clearanceW + grow.chamfer;
+  const hd = cutout.depth / 2 + grow.clearanceD + grow.chamfer;
   const rad = (cutout.rotation * Math.PI) / 180;
   const cos = Math.abs(Math.cos(rad));
   const sin = Math.abs(Math.sin(rad));
@@ -173,6 +205,12 @@ export function fitTestCutoutBoxes(params: BinParams): CutoutBox2D[] {
 
 /** Where the underside stamp fits, in the bin-centred model frame. */
 export interface StampArea {
+  /**
+   * X centre of the strip — the card body's own centre, which asymmetric
+   * overhang shifts off the model origin. A stamp centred at 0 on such a card
+   * hangs its glyphs past one wall.
+   */
+  readonly centerX: number;
   readonly centerY: number;
   readonly availW: number;
   readonly availD: number;
@@ -202,23 +240,55 @@ export function planFitTestStampArea(
   params: BinParams,
   thicknessMm: number,
   neededDepthMm: number,
-  stampDepthMm = 0
+  stampDepthMm = 0,
+  split?: Pick<FitTestSplitPlan, 'planesX' | 'planesY'>
 ): StampArea | null {
   const { width, depth } = fitTestFootprintMm(params);
-  const availW = width - 2 * (params.wallThickness + STAMP_MARGIN_MM);
-  if (availW <= 0 || neededDepthMm <= 0) return null;
+  if (neededDepthMm <= 0) return null;
+
+  // Asymmetric overhang shifts the card body off the model origin — the same
+  // offsets the cutout boxes below already carry — so the windows and the
+  // strip's X centre follow the body, not the origin.
+  const { offsetX, offsetY } = overhangExpansion(
+    resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang)
+  );
+
+  // On a split card the stamp lands WHOLE on the widest X piece rather than
+  // being bisected across a seam — the design name and fit line are the whole
+  // point of the card, and half a glyph run on each piece reads as neither.
+  const xEdges = [
+    -width / 2 + offsetX,
+    ...(split?.planesX ?? []).slice().sort((a, b) => a - b),
+    width / 2 + offsetX,
+  ];
+  let window: { lo: number; hi: number } = { lo: xEdges[0], hi: xEdges[1] };
+  for (let i = 1; i + 1 < xEdges.length; i++) {
+    if (xEdges[i + 1] - xEdges[i] > window.hi - window.lo) {
+      window = { lo: xEdges[i], hi: xEdges[i + 1] };
+    }
+  }
+  const availW = window.hi - window.lo - 2 * (params.wallThickness + STAMP_MARGIN_MM);
+  if (availW <= 0) return null;
+  const centerX = (window.lo + window.hi) / 2;
 
   const cutouts = fitTestCutouts(params);
   const boxes = fitTestCutoutBoxes(params);
   const floorLimit = thicknessMm - stampDepthMm;
   const throughBoxes = boxes.filter((_, i) => cutouts[i].cutDepth >= floorLimit);
+  // A horizontal seam blocks a strip the same way a through-hole does: glyphs
+  // cut across the kerf are lost on both pieces.
+  const seamBoxes = (split?.planesY ?? []).map((plane) => ({ minY: plane, maxY: plane }));
 
   const half = depth / 2 - params.wallThickness - STAMP_MARGIN_MM;
-  for (let y = -half; y + neededDepthMm <= half; y += STAMP_SCAN_STEP_MM) {
+  for (let y = -half + offsetY; y + neededDepthMm <= half + offsetY; y += STAMP_SCAN_STEP_MM) {
     const lo = y - STAMP_MARGIN_MM;
     const hi = y + neededDepthMm + STAMP_MARGIN_MM;
-    const clear = throughBoxes.every((b) => b.maxY <= lo || b.minY >= hi);
-    if (clear) return { centerY: y + neededDepthMm / 2, availW, availD: neededDepthMm };
+    const clear =
+      throughBoxes.every((b) => b.maxY <= lo || b.minY >= hi) &&
+      seamBoxes.every((b) => b.maxY <= lo || b.minY >= hi);
+    if (clear) {
+      return { centerX, centerY: y + neededDepthMm / 2, availW, availD: neededDepthMm };
+    }
   }
   return null;
 }
@@ -380,21 +450,27 @@ export function planFitTestSplit(
   if (rawX.length === 0 && rawY.length === 0) return whole;
 
   // A seam may travel only as far as the bed slack allows: moving a plane into
-  // a clear gap still has to leave both neighbouring pieces printable.
+  // a clear gap still has to leave both neighbouring pieces printable. The
+  // card's REAL bounds follow the overhang offset (the body spans
+  // [-outerW/2 - left, outerW/2 + right]); symmetric bounds would let a nudged
+  // seam step past one edge and build a cutter that intersects nothing.
   const spans = fitTestCutoutSpans(params);
+  const { offsetX, offsetY } = overhangExpansion(
+    resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang)
+  );
   const halfW = footprint.width / 2;
   const halfD = footprint.depth / 2;
   const planX = nudgeSeamsClearOfCutouts(
     rawX,
     spans.x,
     Math.max(0, bed.width - (params.width * pitchX) / (rawX.length + 1)),
-    { min: -halfW, max: halfW }
+    { min: -halfW + offsetX, max: halfW + offsetX }
   );
   const planY = nudgeSeamsClearOfCutouts(
     rawY,
     spans.y,
     Math.max(0, bed.depth - (params.depth * pitchY) / (rawY.length + 1)),
-    { min: -halfD, max: halfD }
+    { min: -halfD + offsetY, max: halfD + offsetY }
   );
 
   return {
@@ -419,9 +495,12 @@ function polygonArea(points: readonly { readonly x: number; readonly y: number }
 
 /** Area (mm²) a cutout's opening removes from the card's top face. */
 function openingAreaMm2(cutout: Cutout): number {
+  // Clearance only: the chamfer's flare reaches its full width exactly at the
+  // rim, so charging the flared area for the whole depth would overstate the
+  // displaced volume by the flare times nearly the full cut.
   const grow = openingGrowthMm(cutout);
-  const w = cutout.width + 2 * grow;
-  const d = cutout.depth + 2 * grow;
+  const w = cutout.width + 2 * grow.clearanceW;
+  const d = cutout.depth + 2 * grow.clearanceD;
   switch (cutout.shape) {
     case 'circle':
       return Math.PI * (w / 2) ** 2;
@@ -504,12 +583,10 @@ export function estimateFitTestVolumeMm3(params: BinParams, thicknessMm: number)
   return Math.max(0, slabArea * thicknessMm - cutoutDisplacementMm3(params, thicknessMm));
 }
 
-/** What the underside stamp needs beyond the params: the design's name (which
- *  lives on the designer store, not in `BinParams`) and, on a split card, which
- *  piece this is. */
+/** What the underside stamp needs beyond the params: the design's name, which
+ *  lives on the designer store, not in `BinParams`. */
 export interface FitTestStampContext {
   readonly designName?: string;
-  readonly pieceLabel?: string;
 }
 
 /**
@@ -532,7 +609,5 @@ export function fitTestStampLines(
   const hi = clearances.length > 0 ? Math.max(...clearances) : 0;
   const fit = lo === hi ? lo.toFixed(2) : `${lo.toFixed(2)}-${hi.toFixed(2)}`;
 
-  const lines = [context.designName?.trim() || 'Fit test', `fit ${fit} · ${thicknessMm}mm`];
-  if (context.pieceLabel) lines.push(context.pieceLabel);
-  return lines;
+  return [context.designName?.trim() || 'Fit test', `fit ${fit} · ${thicknessMm}mm`];
 }


### PR DESCRIPTION
Post-merge review of #3572 (print a fit test for cutouts). Two P1s and five polish items, verified against the plan suite (42 tests) and the kernel scenario suite (29 tests).

## Fixes

- **Clearance modelled per-side, applied as a total.** `buildCutoutCuts` grows a cutout's DIMENSION by the clearance (half per side, polygons scaled anisotropically to stay regular); the plan counted it per side, making every clearance-bearing opening a full clearance too wide per axis. That footprint feeds seam margins and — via `cutoutDisplacementMm3` — the new solid-fill filament estimate, which under-priced dense boards and could zero the fill term. The growth now matches the builder per cause, including its chamfer clamp (`cutDepth − 0.2`) and 0.05mm floor; displacement no longer charges the chamfer's rim flare for the whole depth. The test that encoded the wrong model now encodes the builder's.
- **Thickness ceiling ignored the material under the fill surface.** The editor lets `cutDepth` reach the full `wallHeight` and the builder clamps such pockets to the solid surface, but the card's max thickness was `deepest + wallThickness` — past the body and into the Gridfinity socket, whose feet are separate islands: an underside of stubs that cannot lie flat, stamped mostly into air. The range is now bounded by `wallHeight − topOffset`.

## Polish

- Seam bounds and the stamp scan assumed an origin-centred card; asymmetric overhang shifts the body (`splitBinBuilder` already carries the offsets), letting a nudged seam step past one edge and build a cutter that intersects nothing. Both now carry the offsets, and the stamp's X centre survives the pre-mirrored deboss (negated before the mirror).
- A failed piece intersect was silently `continue`d — a ZIP with a chunk of the card missing that looks like a normal split. It now throws with the piece label, as `splitBinBuilder` does.
- The stamp could land across a seam, bisecting the design name and fit line. One split plan now serves the stamp and the cuts: the strip lands whole on the widest X piece and treats horizontal seams as blockers. The never-wired `pieceLabel` is deleted from the plan and all three bridge layers.
- Piece labels matched neither the bin splitter (letter = column) nor themselves across products; now `A1, B1` runs left-to-right on both.
- The stamp line-order comment described the opposite of the code.

## Verification

`fitTestPlan` 42/42 (incl. new cases for the ceiling, the widest-piece landing, and seam avoidance), `fitTestSlice.scenario` 29/29 on the WASM kernel, typecheck and lint green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

