### PR TITLE
fix(bin-designer): keep Bento colours honest through clears, duplicates and shifted walls

### DIFF
--- a/src/design-system/Badge/Badge.tsx
+++ b/src/design-system/Badge/Badge.tsx
@@ -85,7 +85,7 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
  *
  * @example
  * // Status chip
- * <Badge tone="warning">Experimental</Badge>
+ * <Badge tone="info">Experimental</Badge>
  *
  * @example
  * // Count pill

--- a/src/features/bin-designer/store/slices/paramSlice/bentoActions.ts
+++ b/src/features/bin-designer/store/slices/paramSlice/bentoActions.ts
@@ -160,7 +160,9 @@ export function createBentoActions(set: Set, get: Get) {
         !compartments.labelPlateWidths &&
         !compartments.labelIcons &&
         !compartments.dividerOverrides &&
-        !compartments.drawnUnitCells
+        !compartments.drawnUnitCells &&
+        !compartments.compartmentColors &&
+        !compartments.compartmentColorScopes
       ) {
         return;
       }

--- a/src/features/bin-designer/utils/bentoDraw.test.ts
+++ b/src/features/bin-designer/utils/bentoDraw.test.ts
@@ -234,6 +234,22 @@ describe('bentoDraw', () => {
       expect(getDrawnCompartmentIds(dup.config).size).toBe(2);
     });
 
+    it('carries the colour and its scope like the other decorations', () => {
+      const { config, id } = draw(grid(), 0, 0, 2, 1);
+      const colored: CompartmentConfig = {
+        ...config,
+        compartmentColors: withValueAt(id, '#00ff00'),
+        compartmentColorScopes: withValueAt(id, 'floor'),
+      };
+      const dup = duplicateCompartment(colored, id, { col: 2, row: 1, w: 2, h: 1 });
+      if (!dup) throw new Error('unreachable');
+      expect(dup.config.compartmentColors?.[dup.id]).toBe('#00ff00');
+      expect(dup.config.compartmentColorScopes?.[dup.id]).toBe('floor');
+      // The source keeps its own.
+      const srcIds = [...getDrawnCompartmentIds(dup.config)].filter((i) => i !== dup.id);
+      expect(dup.config.compartmentColors?.[srcIds[0]]).toBe('#00ff00');
+    });
+
     it('rejects a size-mismatched or blocked target', () => {
       const { config, id } = draw(grid(), 0, 0, 2, 1);
       expect(duplicateCompartment(config, id, { col: 2, row: 1, w: 1, h: 1 })).toBeNull();
@@ -366,6 +382,20 @@ describe('bentoDraw', () => {
       expect(cleared.drawnUnitCells).toBeUndefined();
       expect(cleared.stash).toEqual([{ w: 1, h: 1, label: 'kept' }]);
       expect(cleared.cells).toEqual(grid().cells);
+    });
+
+    // Gotcha 6's grid-reset half: the rebuilt grid regenerates ids from
+    // scratch, so a kept colour entry paints an unrelated background cell.
+    it('drops colours with the compartments they painted', () => {
+      const { config, id } = draw(grid(), 0, 0, 2, 2);
+      const colored: CompartmentConfig = {
+        ...config,
+        compartmentColors: withValueAt(id, '#ff0000'),
+        compartmentColorScopes: withValueAt(id, 'floorAndWalls'),
+      };
+      const cleared = clearDrawnCompartments(colored);
+      expect(cleared.compartmentColors).toBeUndefined();
+      expect(cleared.compartmentColorScopes).toBeUndefined();
     });
   });
 

--- a/src/features/bin-designer/utils/bentoDraw.ts
+++ b/src/features/bin-designer/utils/bentoDraw.ts
@@ -347,6 +347,22 @@ export function duplicateCompartment(
     icons[newId] = icon;
     next = { ...next, labelIcons: icons };
   }
+  // Colour rides along like the other decorations — a duplicate that comes
+  // out unpainted makes the user re-pick the swatch per copy.
+  const color = next.compartmentColors?.[srcId];
+  if (color !== null && color !== undefined) {
+    const colors = (next.compartmentColors ?? []).slice();
+    while (colors.length <= newId) colors.push(null);
+    colors[newId] = color;
+    next = { ...next, compartmentColors: colors };
+    const scope = next.compartmentColorScopes?.[srcId];
+    if (scope !== null && scope !== undefined) {
+      const scopes = (next.compartmentColorScopes ?? []).slice();
+      while (scopes.length <= newId) scopes.push(null);
+      scopes[newId] = scope;
+      next = { ...next, compartmentColorScopes: scopes };
+    }
+  }
   if (target.w === 1 && target.h === 1) next = addDrawnUnitCell(next, newId);
   return { config: next, id: newId };
 }
@@ -472,7 +488,10 @@ export function resizeGridPreservingCompartments(
 
 /**
  * Clear every drawn compartment back to background grid. Labels, plate
- * decoration and divider overrides go with them; the stash is untouched.
+ * decoration, colours and divider overrides go with them; the stash is
+ * untouched. Every per-compartment array must be dropped here (gotcha 6's
+ * grid-reset half): the rebuilt grid regenerates ids from scratch, so a kept
+ * entry paints or captions an unrelated cell.
  */
 export function clearDrawnCompartments(config: CompartmentConfig): CompartmentConfig {
   const cells: number[] = [];
@@ -485,6 +504,8 @@ export function clearDrawnCompartments(config: CompartmentConfig): CompartmentCo
     labelIcons: _icons,
     dividerOverrides: _overrides,
     drawnUnitCells: _drawn,
+    compartmentColors: _colors,
+    compartmentColorScopes: _scopes,
     ...keep
   } = config;
   return { ...keep, cells };

--- a/src/features/bin-designer/utils/compartmentColorUnits.test.ts
+++ b/src/features/bin-designer/utils/compartmentColorUnits.test.ts
@@ -74,6 +74,52 @@ describe('planCompartmentColors', () => {
     expect(plan.cells[0].x1).toBeLessThanOrEqual(0.0001);
   });
 
+  // Gotcha 9: a dividerOverride moves the compartment wall, so the grid line
+  // is not the compartment edge. A rect left on the nominal line hands the
+  // shifted strip of floor to the wrong compartment's colour.
+  it('follows a straight divider shift, so the shifted strip keeps its colour', () => {
+    const plan = planOf(
+      twoUp({
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: -5, offsetEnd: -5 }],
+      })
+    );
+    const left = plan.cells.find((c) => c.id === 0);
+    const right = plan.cells.find((c) => c.id === 1);
+    if (!left || !right) throw new Error('expected both rects');
+    // The shared boundary moved 5mm toward compartment 0 on both rects.
+    expect(left.x1).toBeCloseTo(-5, 5);
+    expect(right.x0).toBeCloseTo(-5, 5);
+    // Outer edges stay where the unshifted plan puts them.
+    const plain = planOf(twoUp());
+    expect(left.x0).toBeCloseTo(plain.cells[0].x0, 5);
+  });
+
+  it('evaluates a tilted divider at each cell’s own midpoint along the run', () => {
+    // 2x2 grid, compartments as two full-height columns; tilt the shared wall
+    // from -4 at the bottom to +4 at the top. Row 0's boundary midpoint sits a
+    // quarter up the run (-2), row 1's three quarters (+2).
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 2,
+      depth: 2,
+      height: 5,
+      compartments: {
+        cols: 2,
+        rows: 2,
+        thickness: 1.2,
+        cells: [0, 1, 0, 1],
+        compartmentColors: [LEFT, RIGHT],
+        dividerOverrides: [{ compartmentA: 0, compartmentB: 1, offsetStart: -4, offsetEnd: 4 }],
+      },
+    };
+    const plan = planOf(params);
+    const bottomLeft = plan.cells.find((c) => c.id === 0 && c.y0 < 0);
+    const topLeft = plan.cells.find((c) => c.id === 0 && c.y0 >= 0);
+    if (!bottomLeft || !topLeft) throw new Error('expected both rows');
+    expect(bottomLeft.x1).toBeCloseTo(-2, 5);
+    expect(topLeft.x1).toBeCloseTo(2, 5);
+  });
+
   it('splits an L-shaped compartment into its own cells, not its bounding box', () => {
     // 2x2 grid; compartment 0 owns three cells in an L, compartment 1 the
     // remaining corner. A bounding-box rect for 0 would swallow that corner.

--- a/src/features/bin-designer/utils/compartmentColorUnits.ts
+++ b/src/features/bin-designer/utils/compartmentColorUnits.ts
@@ -22,6 +22,7 @@
 
 import type { BinParams } from '@/shared/types/bin';
 import { binDimensions, cutoutInterior } from './binDimensions';
+import { buildOverrideLookup, findPairAwareRuns, overrideKey } from './compartments';
 import { DEFAULT_COMPARTMENT_COLOR_SCOPE } from '../types/compartments';
 import type { CompartmentColorScope } from '../types/compartments';
 
@@ -126,6 +127,54 @@ export function planCompartmentColors(params: BinParams): CompartmentColorPlan |
   const originX = -innerW / 2 + offsetX;
   const originY = -innerD / 2 + offsetY;
 
+  // A `dividerOverride` moves the compartment wall, so the grid line is not
+  // the compartment edge (gotcha 9) — a rect left on the nominal line hands a
+  // shifted strip of floor to the wrong compartment's colour, or to none.
+  // Each interior boundary is walked in pair-aware runs (the same grouping
+  // the wall builder and rail plan use), and a cell's edge takes the wall's
+  // interpolated displacement at that cell's own midpoint along the run —
+  // exact for a straight shift, and within half a cell's tilt for an angled
+  // one, which is as much as an axis-aligned rect can express.
+  const lookup = buildOverrideLookup(params.compartments.dividerOverrides);
+  const boundaryShifts = (count: number, key: (i: number) => string | null): number[] => {
+    const shifts = new Array<number>(count).fill(0);
+    if (lookup.size === 0) return shifts;
+    for (const run of findPairAwareRuns(count, key)) {
+      const ov = lookup.get(run.pairKey);
+      if (!ov) continue;
+      const span = run.end - run.start;
+      for (let i = run.start; i < run.end; i++) {
+        const t = span <= 1 ? 0.5 : (i - run.start + 0.5) / span;
+        shifts[i] = ov.offsetStart + (ov.offsetEnd - ov.offsetStart) * t;
+      }
+    }
+    return shifts;
+  };
+  // shiftX[b][row] = displacement of the vertical boundary at column index b
+  // (between col b-1 and col b) evaluated at `row`; shiftY mirrors it.
+  const shiftX = new Map<number, number[]>();
+  for (let b = 1; b < cols; b++) {
+    shiftX.set(
+      b,
+      boundaryShifts(rows, (r) => {
+        const left = cellIds[r * cols + (b - 1)];
+        const right = cellIds[r * cols + b];
+        return left === right ? null : overrideKey(Math.min(left, right), Math.max(left, right));
+      })
+    );
+  }
+  const shiftY = new Map<number, number[]>();
+  for (let b = 1; b < rows; b++) {
+    shiftY.set(
+      b,
+      boundaryShifts(cols, (c) => {
+        const below = cellIds[(b - 1) * cols + c];
+        const above = cellIds[b * cols + c];
+        return below === above ? null : overrideKey(Math.min(below, above), Math.max(below, above));
+      })
+    );
+  }
+
   const cells: CompartmentCellRect[] = [];
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < cols; col++) {
@@ -133,10 +182,10 @@ export function planCompartmentColors(params: BinParams): CompartmentColorPlan |
       if (!byId.has(id)) continue;
       cells.push({
         id,
-        x0: originX + col * cellW,
-        x1: originX + (col + 1) * cellW,
-        y0: originY + row * cellH,
-        y1: originY + (row + 1) * cellH,
+        x0: originX + col * cellW + (shiftX.get(col)?.[row] ?? 0),
+        x1: originX + (col + 1) * cellW + (shiftX.get(col + 1)?.[row] ?? 0),
+        y0: originY + row * cellH + (shiftY.get(row)?.[col] ?? 0),
+        y1: originY + (row + 1) * cellH + (shiftY.get(row + 1)?.[col] ?? 0),
       });
     }
   }

--- a/src/features/design-linking/components/Dialogs/MakeBentoDialog/MakeBentoDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/MakeBentoDialog/MakeBentoDialog.tsx
@@ -12,6 +12,7 @@
  * is offered with the two ways out instead of a warning bullet.
  */
 
+import { batch } from '@/core/cqrs';
 import { useCallback, useMemo, useState } from 'react';
 import {
   Dialog,
@@ -144,7 +145,12 @@ export function MakeBentoDialog({ open, onClose }: MakeBentoDialogProps) {
     setSelectedBins([...mergeableBins.map((b) => b.id), ...trapped]);
   };
   const stashTrapped = () => {
-    for (const id of trapped) moveBinToStaging(id);
+    // One undo entry for the whole stash, as the inspector and selection
+    // actions already do — per-bin entries leave Ctrl+Z restoring one bin
+    // while its companions stay stashed.
+    batch(() => {
+      for (const id of trapped) moveBinToStaging(id);
+    });
   };
 
   return (

--- a/src/shared/components/ExperimentalBadge/ExperimentalBadge.test.tsx
+++ b/src/shared/components/ExperimentalBadge/ExperimentalBadge.test.tsx
@@ -9,4 +9,11 @@ describe('ExperimentalBadge', () => {
     render(<ExperimentalBadge />);
     expect(screen.getByText('settings.experimental')).toBeInTheDocument();
   });
+
+  // The same word in two tones reads as two different states; every
+  // Experimental badge in the app is info.
+  it('carries the shared info tone', () => {
+    render(<ExperimentalBadge />);
+    expect(screen.getByText('settings.experimental')).toHaveClass('bg-info-muted');
+  });
 });

--- a/src/shared/components/ExperimentalBadge/ExperimentalBadge.tsx
+++ b/src/shared/components/ExperimentalBadge/ExperimentalBadge.tsx
@@ -1,7 +1,9 @@
 /**
  * "Experimental" status chip. Single source of truth so every experimental
  * feature (e.g. multi-color export) reads identically. Built on the
- * design-system {@link Badge} with the shared warning tone.
+ * design-system {@link Badge} with the shared info tone — the same word in
+ * two tones reads as two different states, and every other Experimental
+ * badge in the app is `info`.
  */
 
 import { Badge } from '@/design-system';
@@ -9,5 +11,5 @@ import { useTranslation } from '@/i18n';
 
 export function ExperimentalBadge() {
   const t = useTranslation();
-  return <Badge tone="warning">{t('settings.experimental')}</Badge>;
+  return <Badge tone="info">{t('settings.experimental')}</Badge>;
 }


### PR DESCRIPTION
Iteration-2 review of the Bento series (#3489, #3491, #3510, #3493). One P1 and four polish items, all with regression tests.

## Fixes

- **Clear leaked colours onto background cells (P1).** `clearDrawnCompartments` dropped five parallel per-compartment arrays but not the two #3491 added, so a coloured compartment's paint survived Clear and landed on whatever background cell inherited its id — gotcha 6's grid-reset half verbatim (the sibling `setCompartmentGrid` path already dropped them). Both colour arrays now go with the compartments, and `clearBentoCompartments`' no-op guard counts them.
- **Shifted walls painted the wrong strip.** The colour classifier placed cell rects on nominal grid lines — `originX + col * cellW`, the exact form gotcha 9 forbids — so a `dividerOverride` moved the wall while the colour boundary stayed put: the annexed strip of floor rendered (and exported) in the body colour, or bled the neighbour's. The rects now walk each interior boundary in the same pair-aware runs the wall builder and rail plan use, applying the wall's interpolated displacement: exact for straight shifts, and evaluated at each cell's own midpoint along the run for tilted walls (as much as an axis-aligned rect can express). Tests pin both cases to the millimetre.
- **Duplicates came out unpainted.** `duplicateCompartment` copied label, plate width and icon but not the colour/scope; they now ride along like the other decorations.
- **The last warning-tone Experimental badge.** `ExperimentalBadge` (used in the Colors panel #3493 itself touched) still said `tone="warning"` against the PR's own invariant that every Experimental badge is `info`. Switched, doc and `Badge` example updated, tone asserted like the other two.
- **Stash-trapped undo.** The Make Bento dialog stashed trapped bins in a bare loop — N undo entries for one action, and Ctrl+Z brought back one bin of four. Now one `batch()`, matching the inspector and selection actions.

## Verification

bentoDraw (44), compartmentColorUnits (14 incl. the two new override cases), bentoActions, ExperimentalBadge and MakeBentoDialog suites green; typecheck green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

