### PR TITLE
fix(bin-designer): reach the screw corners, follow the feet plan in estimates, guard socket merges

### DIFF
--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -67,7 +67,13 @@ import { useTranslation } from '@/i18n';
 import { hasDetachableFeet } from '@/features/bin-designer/types/base';
 import { useToastStore } from '@/core/store/toast';
 import { useSettingsStore } from '@/core/store/settings';
-import { CameraController, usePresetTransition, SceneLighting } from './previewCanvasCamera';
+import {
+  CameraController,
+  usePresetTransition,
+  SceneLighting,
+  calculateIdealDistance,
+  CAMERA_FOV,
+} from './previewCanvasCamera';
 import { CameraRig } from '@/shared/components/preview/CameraRig';
 import { TouchHint, GeneratingIndicator } from './previewCanvasOverlays';
 import { detectWebGL, WebGLFallback, WebGLErrorBoundary } from '@/shared/webgl';
@@ -405,6 +411,24 @@ export function PreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
                 projection={projection}
                 initialPosition={[100, -100, 80]}
                 target={[0, 0, totalH / 2]}
+                // The default 2000mm far plane sits INSIDE the framing
+                // distance for the largest bins (a 16x16x50 frames at
+                // ~2040mm), clipping the rear half and the target itself.
+                // 1.6x the ideal distance clears the far side of the bounding
+                // sphere (ideal ≈ 2.4x the radius at this fov).
+                far={Math.max(
+                  2000,
+                  1.6 *
+                    calculateIdealDistance(
+                      width,
+                      depth,
+                      height,
+                      CAMERA_FOV,
+                      params.gridUnitMm,
+                      params.heightUnitMm,
+                      params.gridUnitMmY ?? params.gridUnitMm
+                    )
+                )}
               />
               <PreviewContextSync />
 

--- a/src/features/bin-designer/components/PreviewCanvas/previewCanvasCamera.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/previewCanvasCamera.tsx
@@ -39,7 +39,7 @@ const FRAME_FILL = 0.65;
 /** Minimum change in distance to trigger auto-frame animation */
 const REFRAME_THRESHOLD = 0.1; // 10% change
 /** Perspective FOV (degrees) used for framing math — shared by CameraController and usePresetTransition */
-const CAMERA_FOV = 45;
+export const CAMERA_FOV = 45;
 
 /**
  * Calculate ideal camera distance to frame a bin of the given dimensions.

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -235,12 +235,13 @@ export function BaseSection() {
         <section className="space-y-3">
           <SubHeader>{t('binDesigner.base.section.feet')}</SubHeader>
 
-          {/* Heads the foot cluster: half sockets, the foot lattice and the
-              lightweight modes below all describe where INTEGRAL feet fall,
-              which this mode answers its own way. They are locked rather than
-              cleared, so the reason sits directly under the thing that caused
-              it and a lightweight setting survives a round trip through the
-              toggle. */}
+          {/* Heads the foot cluster. Half sockets and the lightweight modes
+              below describe INTEGRAL feet, which this mode answers its own way
+              — they are locked rather than cleared, so the reason sits under
+              the thing that caused it and the setting survives a round trip
+              through the toggle. The foot LATTICE stays live: the detachable
+              plan consumes it, and the half lattice is the only layout that
+              seats a half-offset detachable bin. */}
           <FeatureToggle
             label={t('binDesigner.detachableFeet')}
             checked={state.hasDetachableFeet}
@@ -254,9 +255,15 @@ export function BaseSection() {
               <Hint>
                 {state.detachableUnplaceable
                   ? t('binDesigner.detachableFeet.unplaceable')
-                  : t('binDesigner.detachableFeet.saving', {
-                      percent: state.detachableSavingPercent,
-                    })}
+                  : state.detachableSavingPercent > 0
+                    ? t('binDesigner.detachableFeet.saving', {
+                        percent: state.detachableSavingPercent,
+                      })
+                    : /* The counterfactual bin keeps its stored lightweight
+                         saving while the detachable one supersedes it, so the
+                         delta can go negative — a true number the "uses less
+                         material" copy would misstate. */
+                      t('binDesigner.detachableFeet.savingSuperseded')}
               </Hint>
             }
           >

--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -20,6 +20,47 @@ describe('printEstimates', () => {
       expect(est.costUSD).toBeGreaterThan(0);
     });
 
+    // The estimate follows the PLAN, not the request: a half-lattice 1-wide
+    // bin places no detachable feet, so the pipeline keeps the integral socket
+    // and the readout must keep its volume (it under-reported by ~60%).
+    it('prices an unplaceable detachable request as the integral bin it builds', () => {
+      const base: BinParams = {
+        ...DEFAULT_BIN_PARAMS,
+        width: 1,
+        depth: 3,
+        base: { ...DEFAULT_BIN_PARAMS.base, footLatticeX: 'half' },
+      };
+      const integral = estimatePrint(base);
+      const requested = estimatePrint({
+        ...base,
+        base: { ...base.base, feet: 'detachable' },
+      });
+      expect(requested.volumeMm3).toBe(integral.volumeMm3);
+    });
+
+    // A slab-only base (underside relief, detachable feet) loses only
+    // wallThickness of material under each hole; booking the full-socket
+    // share roughly halved a 3x3 estimate for a few cm³ of real removal.
+    it('prices a floor pattern on a slab-only base as the slab prism it cuts', () => {
+      const relief: BinParams = {
+        ...DEFAULT_BIN_PARAMS,
+        width: 3,
+        depth: 3,
+        base: { ...DEFAULT_BIN_PARAMS.base, lightweight: true, lightweightMode: 'underside' },
+      };
+      const plain = estimatePrint(relief).volumeMm3;
+      const patterned = estimatePrint({
+        ...relief,
+        floorPattern: { enabled: true, pattern: 'honeycomb' },
+      }).volumeMm3;
+      const removed = plain - patterned;
+      expect(removed).toBeGreaterThan(0);
+      // The whole slab inside the walls is planArea-ish x 1.2mm ≈ 19cm³; the
+      // pattern's open share of it can only be a fraction of that. The old
+      // full-socket share booked ~25cm³ — more than the slab itself.
+      expect(removed).toBeLessThan(10_000);
+    });
+
     it('larger bins have more volume', () => {
       const small = estimatePrint({ ...DEFAULT_BIN_PARAMS, width: 1, depth: 1 });
       const large = estimatePrint({ ...DEFAULT_BIN_PARAMS, width: 4, depth: 4 });

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -165,13 +165,23 @@ function computeBinVolume(params: BinParams): number {
   );
   let volume = shell.walls + shell.base + (params.base.stackingLip ? shell.lip : 0);
 
+  // The geometry follows the PLAN, not the flag: with detachable feet
+  // requested but no pocket-aligned whole cell to anchor one (a half-lattice
+  // 1-wide bin), the plan places nothing, the pipeline keeps the integral
+  // socket, and every estimate branch below has to agree — or a bin whose
+  // socket is fully present loses its whole foot volume from the readout.
+  const detachablePlacements = hasDetachableFeet(params.base)
+    ? resolveDetachableFeet(params).placements
+    : [];
+  const feetDetach = detachablePlacements.length > 0;
+
   // A lightweight base shells the feet, which is a per-cell saving on the
   // `base` component and nothing else. Applied before the base-only return
   // below, because that mode is almost entirely base — it is where the relief
   // pays off most. A spacer is deliberately not modelled here: it removes the
   // floor as well as shelling the feet, so it is a different figure that no
   // measurement in this file covers.
-  // NOT `|| hasDetachableFeet`: the two are mutually exclusive in the geometry
+  // NOT `|| feetDetach`: the two are mutually exclusive in the geometry
   // (`deriveDimensions` makes lightweight inert when the feet detach) but both
   // flags can be STORED at once, because the panel locks lightweight rather
   // than clearing it. Subtracting both took the base term negative and reported
@@ -180,7 +190,7 @@ function computeBinVolume(params: BinParams): number {
     params.base.lightweight &&
     !params.base.spacer &&
     !isSocketlessBase(params.base.style) &&
-    !hasDetachableFeet(params.base)
+    !feetDetach
   ) {
     volume -= lightweightBaseSaving(
       params.width,
@@ -197,10 +207,10 @@ function computeBinVolume(params: BinParams): number {
   // what each one actually is. A bar clipped against a cell edge and one centred
   // mid-run are both bars and are different volumes, which is why the count
   // alone would not do.
-  if (hasDetachableFeet(params.base)) {
+  if (feetDetach) {
     volume -= integralFeetVolume(params.width, params.depth, params.gridUnitMm, gridUnitMmY);
     volume += detachableFeetVolume(
-      resolveDetachableFeet(params).placements.map(footKind),
+      detachablePlacements.map(footKind),
       params.gridUnitMm,
       gridUnitMmY
     );
@@ -243,7 +253,7 @@ function computeBinVolume(params: BinParams): number {
   }
 
   // Floor pattern: drainage holes remove floor slab AND foot material.
-  volume -= computeFloorPatternReduction(params, wallThickness, shell.base);
+  volume -= computeFloorPatternReduction(params, wallThickness, shell.base, feetDetach);
 
   // Exterior-wall collar: a walled ring raised above the nominal
   // body — perimeter wall material only, no floor/interior. Ring cross-section
@@ -768,15 +778,16 @@ function dividerPatternReduction(
 /**
  * Volume removed by the floor pattern.
  *
- * Expressed as a SHARE of the shell's base component rather than as a raw
- * `area x depth` prism, because the two numbers are not in the same units:
- * `standardBinSolidComponents.base` is calibrated to filament actually extruded
- * (~2202mm³ per 42mm cell), while the solid geometry it stands for is several
- * times that — a foot is a solid loft the slicer fills with infill. Subtracting
- * true prism volume from a filament-calibrated total over-reported the saving by
- * roughly 4x, enough to zero out a short bin's estimate. The holes remove the
- * base straight through, so the share of its plan area they take is the share of
- * its material they take.
+ * Two cut depths, priced two ways. A SOCKETED integral base is cut straight
+ * through feet and slab, so the removal is the open share of the base
+ * component (`standardBinSolidComponents.base`, solid-calibrated per #3528 —
+ * a foot is not a prism, so a share of the measured term beats an area×depth
+ * model). Every SLAB-ONLY base — flat, the underside relief (whose cavity is
+ * already open below the slab) and detachable feet (whose body floor sits at
+ * Z=0) — only loses `wallThickness` of material under each hole, so the
+ * removal is the open area times the slab, priced directly. Booking the
+ * full-socket share for those cut a 3x3 estimate roughly in half for a
+ * pattern that removes ~4mm³ per cm² of window.
  *
  * Open area is measured from the real element placement rather than a
  * fraction-of-area model: a per-foot window is only ~33mm across, and over a box
@@ -788,7 +799,8 @@ function dividerPatternReduction(
 function computeFloorPatternReduction(
   params: BinParams,
   wallThickness: number,
-  baseVolume: number
+  baseVolume: number,
+  feetDetach: boolean
 ): number {
   const floorPattern = params.floorPattern;
   if (floorPattern?.enabled !== true) return 0;
@@ -846,10 +858,13 @@ function computeFloorPatternReduction(
   if (totalOpenArea <= 0) return 0;
 
   const planArea = params.width * params.depth * params.gridUnitMm * gridUnitMmY;
-  // A flat bin's "base" is floor slab only, so the holes reach through a
-  // proportionally smaller share of what the shell model booked for it.
-  const depthShare = isFlat ? wallThickness / (wallThickness + GRIDFINITY.SOCKET_HEIGHT) : 1;
-  return baseVolume * Math.min(1, totalOpenArea / planArea) * depthShare;
+  // See the docstring: slab-only cuts are priced as the direct prism, the
+  // socketed full-depth cut as a share of the measured base term.
+  const slabOnly = isFlat || isUndersideRelief(params.base) || feetDetach;
+  if (slabOnly) {
+    return Math.min(totalOpenArea, planArea) * wallThickness;
+  }
+  return baseVolume * Math.min(1, totalOpenArea / planArea);
 }
 
 export interface WallPatternSavings {

--- a/src/features/generation/worker/generators/detachableFeetBuilder.ts
+++ b/src/features/generation/worker/generators/detachableFeetBuilder.ts
@@ -101,14 +101,19 @@ export interface DetachableFeetGeometry {
 function coveredCorners(
   positions: ReadonlyArray<readonly [number, number]>,
   p: FootPlacement,
-  centre: { x: number; y: number }
+  centre: { x: number; y: number },
+  armMm: number
 ): Array<readonly [number, number]> {
+  // Bounds mirror `buildClip`'s footprint per axis, not the cell's: a centred
+  // interior filler is only `armMm` wide across its spanned axis, so testing
+  // against the CELL would claim all four corners and drill attachment bores
+  // through the floor where no foot stands beneath them.
+  const halfX = p.dirX === 0 && p.interiorX ? armMm / 2 : p.cellW / 2;
+  const halfY = p.dirY === 0 && p.interiorY ? armMm / 2 : p.cellD / 2;
   return positions.filter(([mx, my]) => {
     const inX = p.dirX === 0 || Math.sign(mx - centre.x) === p.dirX;
     const inY = p.dirY === 0 || Math.sign(my - centre.y) === p.dirY;
-    return (
-      inX && inY && Math.abs(mx - centre.x) <= p.cellW / 2 && Math.abs(my - centre.y) <= p.cellD / 2
-    );
+    return inX && inY && Math.abs(mx - centre.x) <= halfX && Math.abs(my - centre.y) <= halfY;
   });
 }
 
@@ -279,7 +284,7 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
       // construction — four on a rectangular bin against four per cell today.
       const magnet = opts.magnet;
       if (magnet) {
-        const covered = coveredCorners(magnet.positions, p, centre);
+        const covered = coveredCorners(magnet.positions, p, centre, armMm);
         // Open at the underside, exactly as an integral foot drills it: the
         // magnet is inserted from below, so a retaining floor under it would
         // seal it out rather than in.
@@ -304,7 +309,7 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
       // pocket, exactly as an integral foot does.
       const screw = opts.screw;
       if (screw) {
-        const bores = coveredCorners(screw.positions, p, centre).map(([mx, my]) =>
+        const bores = coveredCorners(screw.positions, p, centre, armMm).map(([mx, my]) =>
           scope.register(
             translate(
               scope.register(
@@ -322,7 +327,7 @@ export function buildDetachableFeet(opts: DetachableFeetOptions): DetachableFeet
           if (bored !== foot) foot.delete();
           foot = bored;
         }
-        for (const [mx, my] of coveredCorners(screw.positions, p, centre)) {
+        for (const [mx, my] of coveredCorners(screw.positions, p, centre, armMm)) {
           holes.push(
             translate(
               scope.register(

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Spotřebuje o {percent} % méně materiálu než pevné nožičky",
   "binDesigner.detachableFeet.summary": "{count} nožiček, kolíky ø{diameter} mm",
   "binDesigner.detachableFeet.supersedes": "Nepoužívá se s odnímatelnými nožičkami",
+  "binDesigner.detachableFeet.savingSuperseded": "Odlehčená základna už tuto úsporu pokrývá",
   "binDesigner.detachableFeet.unplaceable": "V této velikosti není celá buňka mřížky pro nožičku",
   "binDesigner.detachableFeetNeedsThickerWall": "Tak tenké stěny nenechají dost podlahy pro udržení kolíku",
   "binDesigner.dimensions": "Rozměry",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Verbraucht {percent} % weniger Material als feste Füße",
   "binDesigner.detachableFeet.summary": "{count} Füße, Stifte ø{diameter} mm",
   "binDesigner.detachableFeet.supersedes": "Wird mit abnehmbaren Füßen nicht verwendet",
+  "binDesigner.detachableFeet.savingSuperseded": "Der Leichtbau-Boden deckt diese Einsparung bereits ab",
   "binDesigner.detachableFeet.unplaceable": "Bei dieser Größe gibt es keine ganze Rasterzelle für einen Fuß",
   "binDesigner.detachableFeetNeedsThickerWall": "So dünne Wände lassen zu wenig Boden, um einen Stift zu halten",
   "binDesigner.dimensions": "Abmessungen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2290,6 +2290,7 @@ const en: Record<string, string> = {
   'binDesigner.detachableFeet.pinSize': 'Pin size',
   'binDesigner.detachableFeet.pinHint': 'Try the smaller pin first if the larger will not seat',
   'binDesigner.detachableFeet.supersedes': 'Not used with detachable feet',
+  'binDesigner.detachableFeet.savingSuperseded': 'The lightweight base already covers this saving',
   'binDesigner.detachableFeet.unplaceable': 'No whole grid cell for a foot to sit in at this size',
   'binDesigner.detachableFeet.summary': '{count} feet, ø{diameter}mm pins',
   'binDesigner.preview.feetDetached': 'Detached',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Usa un {percent} % menos de material que las patas integradas",
   "binDesigner.detachableFeet.summary": "{count} patas, pasadores de ø{diameter} mm",
   "binDesigner.detachableFeet.supersedes": "No se usa con patas desmontables",
+  "binDesigner.detachableFeet.savingSuperseded": "La base aligerada ya cubre este ahorro",
   "binDesigner.detachableFeet.unplaceable": "No hay ninguna celda completa de la rejilla para una pata a este tamaño",
   "binDesigner.detachableFeetNeedsThickerWall": "Con paredes tan finas queda muy poco suelo para sujetar un pasador",
   "binDesigner.dimensions": "Dimensiones",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Utilise {percent} % de matière en moins que des pieds intégrés",
   "binDesigner.detachableFeet.summary": "{count} pieds, ergots ø{diameter} mm",
   "binDesigner.detachableFeet.supersedes": "Sans effet avec des pieds amovibles",
+  "binDesigner.detachableFeet.savingSuperseded": "La base allégée couvre déjà cette économie",
   "binDesigner.detachableFeet.unplaceable": "Aucune cellule entière de la grille ne peut accueillir un pied à cette taille",
   "binDesigner.detachableFeetNeedsThickerWall": "Des parois aussi fines laissent trop peu de fond pour tenir un ergot",
   "binDesigner.dimensions": "Dimensions",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Usa il {percent}% di materiale in meno rispetto ai piedini integrati",
   "binDesigner.detachableFeet.summary": "{count} piedini, perni ø{diameter} mm",
   "binDesigner.detachableFeet.supersedes": "Non si usa con i piedini staccabili",
+  "binDesigner.detachableFeet.savingSuperseded": "La base alleggerita copre già questo risparmio",
   "binDesigner.detachableFeet.unplaceable": "Nessuna cella intera della griglia può ospitare un piedino a questa misura",
   "binDesigner.detachableFeetNeedsThickerWall": "Pareti così sottili lasciano troppo poco fondo per trattenere un perno",
   "binDesigner.dimensions": "Dimensioni",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "一体型の脚より材料を{percent}%節約します",
   "binDesigner.detachableFeet.summary": "脚{count}個、ø{diameter}mmピン",
   "binDesigner.detachableFeet.supersedes": "取り外し式の脚では使用しません",
+  "binDesigner.detachableFeet.savingSuperseded": "軽量ベースで既にこの節約は実現されています",
   "binDesigner.detachableFeet.unplaceable": "このサイズでは脚を置けるグリッドのマス目がありません",
   "binDesigner.detachableFeetNeedsThickerWall": "これほど薄い壁ではピンを保持する床が足りません",
   "binDesigner.dimensions": "寸法",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "일체형 발보다 재료를 {percent}% 적게 사용합니다",
   "binDesigner.detachableFeet.summary": "발 {count}개, ø{diameter}mm 핀",
   "binDesigner.detachableFeet.supersedes": "분리형 발에서는 사용하지 않습니다",
+  "binDesigner.detachableFeet.savingSuperseded": "경량 베이스가 이미 이 절감을 제공합니다",
   "binDesigner.detachableFeet.unplaceable": "이 크기에서는 발을 놓을 온전한 그리드 칸이 없습니다",
   "binDesigner.detachableFeetNeedsThickerWall": "이렇게 얇은 벽은 핀을 잡아줄 바닥이 부족합니다",
   "binDesigner.dimensions": "치수",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Bruker {percent} % mindre materiale enn innebygde føtter",
   "binDesigner.detachableFeet.summary": "{count} føtter, ø{diameter} mm pinner",
   "binDesigner.detachableFeet.supersedes": "Brukes ikke med avtakbare føtter",
+  "binDesigner.detachableFeet.savingSuperseded": "Den lette bunnen dekker allerede denne besparelsen",
   "binDesigner.detachableFeet.unplaceable": "Ingen hel rutenettcelle å sette en fot i ved denne størrelsen",
   "binDesigner.detachableFeetNeedsThickerWall": "Så tynne vegger gir for lite gulv til å holde en pinne",
   "binDesigner.dimensions": "Dimensjoner",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Gebruikt {percent}% minder materiaal dan vaste voetjes",
   "binDesigner.detachableFeet.summary": "{count} voetjes, pennen van ø{diameter} mm",
   "binDesigner.detachableFeet.supersedes": "Wordt niet gebruikt bij afneembare voetjes",
+  "binDesigner.detachableFeet.savingSuperseded": "De lichtgewicht bodem dekt deze besparing al",
   "binDesigner.detachableFeet.unplaceable": "Geen hele rastercel waar een voetje in past bij dit formaat",
   "binDesigner.detachableFeetNeedsThickerWall": "Zulke dunne wanden laten te weinig bodem over om een pen vast te houden",
   "binDesigner.dimensions": "Afmetingen",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Zużywa o {percent}% mniej materiału niż nóżki wbudowane",
   "binDesigner.detachableFeet.summary": "Nóżki: {count}, kołki ø{diameter} mm",
   "binDesigner.detachableFeet.supersedes": "Nieużywane przy odczepianych nóżkach",
+  "binDesigner.detachableFeet.savingSuperseded": "Odchudzona podstawa już zapewnia tę oszczędność",
   "binDesigner.detachableFeet.unplaceable": "Przy tym rozmiarze nie ma całej komórki siatki na nóżkę",
   "binDesigner.detachableFeetNeedsThickerWall": "Tak cienkie ścianki zostawiają za mało dna, by utrzymać kołek",
   "binDesigner.dimensions": "Wymiary",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Usa {percent}% menos material do que pés integrados",
   "binDesigner.detachableFeet.summary": "{count} pés, pinos de ø{diameter} mm",
   "binDesigner.detachableFeet.supersedes": "Não usado com pés destacáveis",
+  "binDesigner.detachableFeet.savingSuperseded": "A base leve já cobre essa economia",
   "binDesigner.detachableFeet.unplaceable": "Não há célula inteira da grade para um pé neste tamanho",
   "binDesigner.detachableFeetNeedsThickerWall": "Paredes tão finas deixam pouco piso para segurar um pino",
   "binDesigner.dimensions": "Dimensões",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Använder {percent} % mindre material än inbyggda fötter",
   "binDesigner.detachableFeet.summary": "{count} fötter, ø{diameter} mm stift",
   "binDesigner.detachableFeet.supersedes": "Används inte med avtagbara fötter",
+  "binDesigner.detachableFeet.savingSuperseded": "Den lätta basen täcker redan denna besparing",
   "binDesigner.detachableFeet.unplaceable": "Ingen hel rutnätscell att sätta en fot i vid den här storleken",
   "binDesigner.detachableFeetNeedsThickerWall": "Så tunna väggar lämnar för lite golv för att hålla ett stift",
   "binDesigner.dimensions": "Mått",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "Витрачає на {percent}% менше матеріалу, ніж вбудовані ніжки",
   "binDesigner.detachableFeet.summary": "Ніжок: {count}, штифти ø{diameter} мм",
   "binDesigner.detachableFeet.supersedes": "Не використовується зі знімними ніжками",
+  "binDesigner.detachableFeet.savingSuperseded": "Полегшена основа вже забезпечує цю економію",
   "binDesigner.detachableFeet.unplaceable": "За цього розміру немає цілої комірки сітки для ніжки",
   "binDesigner.detachableFeetNeedsThickerWall": "Такі тонкі стінки залишають замало дна, щоб утримати штифт",
   "binDesigner.dimensions": "Розміри",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -818,6 +818,7 @@
   "binDesigner.detachableFeet.saving": "比一体式底脚少用 {percent}% 的材料",
   "binDesigner.detachableFeet.summary": "{count} 个底脚，ø{diameter}mm 销钉",
   "binDesigner.detachableFeet.supersedes": "可拆卸底脚不使用此项",
+  "binDesigner.detachableFeet.savingSuperseded": "轻量化底座已经实现了这部分节省",
   "binDesigner.detachableFeet.unplaceable": "此尺寸下没有可容纳底脚的完整网格单元",
   "binDesigner.detachableFeetNeedsThickerWall": "这么薄的壁面剩下的底板不足以固定销钉",
   "binDesigner.dimensions": "尺寸",

--- a/src/shared/utils/cutoutRepeatDetect.ts
+++ b/src/shared/utils/cutoutRepeatDetect.ts
@@ -18,6 +18,7 @@
 import type { Cutout, CutoutArrayConfig, CutoutArrayMode } from '@/features/bin-designer/types';
 import { MAX_ARRAY_INSTANCES } from '@/features/bin-designer/types';
 import { arrayFieldBounds, arrayInstanceCount, canArray, defaultArrayConfig } from './cutoutArray';
+import { isCutoutSocketMode } from './cutoutLabelSocketPlan';
 
 /**
  * Position slack (mm) allowed when fitting centers to a lattice. Matches the
@@ -85,7 +86,26 @@ function geometryFingerprint(c: Cutout): string {
     c.scoopEdges ? JSON.stringify(c.scoopEdges) : '-',
     c.meshId ?? '-',
     c.hidden === true ? 'h' : '-',
+    // Socket-mode labels are GEOMETRY: the plan cuts one pocket per cutout
+    // ROW, so collapsing rows into an array deletes every absorbed pocket and
+    // its plate. The mode, pinned width and icon must all match, or the merge
+    // silently reshapes the board.
+    c.labelMode ?? '-',
+    c.labelPlateWidthU ?? '-',
+    c.labelIcon ?? '-',
   ].join('|');
+}
+
+/**
+ * True when merging would delete socket pockets from the board. The socket
+ * plan cuts one pocket per cutout ROW (`planCutoutLabelSockets` filters raw
+ * cutouts, not expanded instances), so absorbing more than one socket-mode
+ * row into an array keeps a single pocket and silently drops the rest — five
+ * plates gone on a six-cutout merge, with the suggestion's copy mentioning
+ * only drift and colour.
+ */
+function wouldDropSocketPockets(cutouts: readonly Cutout[]): boolean {
+  return cutouts.filter((c) => isCutoutSocketMode(c)).length > 1;
 }
 
 /**
@@ -426,6 +446,7 @@ export function detectRepeatPattern(
   if (cutouts.some((c) => !canArray(c) || c.locked === true || c.array !== undefined)) return null;
   if (new Set(cutouts.map(geometryFingerprint)).size > 1) return null;
   if (wouldDropEngravedText(cutouts)) return null;
+  if (wouldDropSocketPockets(cutouts)) return null;
 
   const centers = centersOf(cutouts);
   return (

--- a/src/shared/utils/detachableFeetPlan.test.ts
+++ b/src/shared/utils/detachableFeetPlan.test.ts
@@ -290,4 +290,30 @@ describe('half-offset placement', () => {
       expect(resolveFor(makeMask(3, 3, () => true)).placements).toHaveLength(4);
     });
   });
+
+  describe('arm reach for attachment hardware', () => {
+    const resolveStyle = (style: 'standard' | 'screw' | 'magnet' | 'magnet_and_screw') =>
+      resolveDetachableFeet({
+        width: 2,
+        depth: 2,
+        gridUnitMm: 42,
+        fractionalEdgeX: 'end',
+        fractionalEdgeY: 'end',
+        base: { style, magnetDiameter: 6.5, magnetDepth: 2, screwDiameter: 3 },
+      });
+
+    // Screws sit on the same spec corners as magnets (8mm in from the cell
+    // edge at 42mm pitch). Without a screw term the arm stopped short of the
+    // bore: the shank could not pass through the foot, and the companion floor
+    // bore was a through-hole with no foot beneath it.
+    it('sizes the arm to reach the screw corners on a screw-only base', () => {
+      const std = resolveStyle('standard').armMm;
+      const screwArm = resolveStyle('screw').armMm;
+      const magnetArm = resolveStyle('magnet').armMm;
+      expect(screwArm).toBeGreaterThan(std);
+      // Same corners, so the two attachments differ only by their own radii.
+      expect(magnetArm - screwArm).toBeCloseTo((6.5 - 3) / 2, 5);
+      expect(resolveStyle('magnet_and_screw').armMm).toBe(Math.max(screwArm, magnetArm));
+    });
+  });
 });

--- a/src/shared/utils/detachableFeetPlan.ts
+++ b/src/shared/utils/detachableFeetPlan.ts
@@ -172,13 +172,27 @@ export function footArmMm(opts: {
   readonly pinDiameterMm: number;
   readonly magnetDiameterMm?: number;
   readonly magnetInsetFromEdgeMm?: number;
+  readonly screwDiameterMm?: number;
+  readonly screwInsetFromEdgeMm?: number;
 }): number {
   const pinReach = opts.pinDiameterMm + 2 * FOOT_EMBED_MARGIN_MM;
   const magnetReach =
     opts.magnetDiameterMm === undefined || opts.magnetInsetFromEdgeMm === undefined
       ? 0
       : opts.magnetInsetFromEdgeMm + opts.magnetDiameterMm / 2 + FOOT_EMBED_MARGIN_MM;
-  return Math.max(pinReach, magnetReach, SOCKET_TAPER_WIDTH_MM + FOOT_MIN_BOTTOM_FACE_MM);
+  // Screws sit on the same spec corners as magnets, so a screw-only base needs
+  // the same reach — without this term its bores land 0.8mm outside the arm
+  // and drill open air through the bin floor instead of the foot.
+  const screwReach =
+    opts.screwDiameterMm === undefined || opts.screwInsetFromEdgeMm === undefined
+      ? 0
+      : opts.screwInsetFromEdgeMm + opts.screwDiameterMm / 2 + FOOT_EMBED_MARGIN_MM;
+  return Math.max(
+    pinReach,
+    magnetReach,
+    screwReach,
+    SOCKET_TAPER_WIDTH_MM + FOOT_MIN_BOTTOM_FACE_MM
+  );
 }
 
 /**
@@ -502,18 +516,22 @@ export function resolveDetachableFeet(params: DetachableFeetParams): ResolvedDet
 
   // The arm is sized against the SHORTER pitch: a foot deep enough for the
   // magnet on one axis is not automatically deep enough on the other, and a
-  // single arm value serves both.
-  const magnetInsetFromEdgeMm = carriesMagnet
-    ? Math.min(
-        magnetInsetFromCellEdgeMm(pitchX, params.magnetAnchor ?? 'edge'),
-        magnetInsetFromCellEdgeMm(pitchY, params.magnetAnchor ?? 'edge')
-      )
-    : undefined;
+  // single arm value serves both. Screws share the magnets' spec corners, so
+  // one inset serves both attachments.
+  const cornerInsetFromEdgeMm =
+    carriesMagnet || carriesScrew
+      ? Math.min(
+          magnetInsetFromCellEdgeMm(pitchX, params.magnetAnchor ?? 'edge'),
+          magnetInsetFromCellEdgeMm(pitchY, params.magnetAnchor ?? 'edge')
+        )
+      : undefined;
 
   const armMm = footArmMm({
     pinDiameterMm,
     magnetDiameterMm: carriesMagnet ? params.base.magnetDiameter : undefined,
-    magnetInsetFromEdgeMm,
+    magnetInsetFromEdgeMm: carriesMagnet ? cornerInsetFromEdgeMm : undefined,
+    screwDiameterMm: carriesScrew ? params.base.screwDiameter : undefined,
+    screwInsetFromEdgeMm: carriesScrew ? cornerInsetFromEdgeMm : undefined,
   });
 
   const placed = detachableFeetPlacements({


### PR DESCRIPTION
Iteration-2 review of #3543 (detachable feet), #3539 (Repeat), #3528/#3531 (estimates). One P1 and six P2s; kernel suite (18) and all touched unit suites green.

## Fixes

- **Screw bores missed their feet (P1).** `footArmMm` sized the arm for pins and magnets but not screws, which sit on the same spec corners (8mm in from the cell edge). On a screw-only base the bore centre sat 0.8mm outside the arm: the shank could not pass through the foot, and the companion floor bore became a 3mm through-hole in the bin floor with nothing beneath it — the class of defect the blind pin membrane exists to prevent. The arm now takes a screw term mirroring the magnet one; a plan test pins the two attachments' reach relation.
- **Centred fillers drilled stray floor bores.** `coveredCorners` tested corner containment against the CELL while `buildClip` gives a centred mid-run filler an `armMm`-wide strip; the direction test was vacuous for `dir 0/0`, so any 1×N long bin with screw hardware bored four holes mid-floor where no foot stands. The bounds now mirror the clip's footprint per axis.
- **Estimates answered "the user asked", geometry answers "feet exist".** #3585 moved the pipeline onto the plan; the estimate still gated on the flag, so an unplaceable request (half-lattice 1-wide) subtracted the entire integral-foot volume from a bin whose socket is fully present (~60% under). All three branches (lightweight guard, feet swap, floor-pattern base) now share one plan resolution, with a test pinning request==integral when nothing places.
- **Floor patterns booked socket-depth cuts on slab-only bases.** The underside relief's cavity is already open below the slab and a detachable body's floor sits at Z=0, so the pattern removes only `wallThickness` under each hole — yet the reduction took the full-socket share, more than the remaining slab holds, roughly halving a 3×3 estimate. Slab-only cuts now price as the direct prism (unit-honest since #3528's solid recalibration, whose premise the old docstring still inverted — rewritten).
- **"Uses −20% less material".** The saving hint's counterfactual keeps its stored lightweight saving while detachable feet supersede it, so the delta can go honestly negative; the panel now says the lightweight base already covers it (new key, all 15 locales).
- **Repeat merges deleted socket pockets.** The detector's fingerprint predates #3577: six identical socket-mode cutouts merged into one array — and one pocket, since the plan cuts per ROW — silently dropping five plates. The fingerprint now carries `labelMode`/`labelPlateWidthU`/`labelIcon`, and a guard refuses any merge holding more than one socket row.
- **50u bins outgrew the preview's far plane.** A 16×16×50 frames at ~2040mm against a fixed `far=2000`, clipping the rear half and the target; the far plane now derives from the framing distance. Also corrected the Base-section comment claiming the foot lattice locks under detachable feet.

## Verification

detachableFeet.kernel (18) green with the geometry changes; detachableFeetPlan (23), printEstimates (70), cutoutRepeatDetect suites green; typecheck, lint, i18n checks green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

