### PR TITLE
fix(bin-designer): reactive export readiness, resilient sample exports, live label refits

### DIFF
--- a/src/features/baseplate/hooks/useBaseplateExport.test.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.test.ts
@@ -8,6 +8,13 @@ import type { BaseplateTiling } from '../types/tiling';
 vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => ({}),
   workerPoolManager: { get: () => null },
+  bridgeManager: {
+    engineReady: true,
+    subscribe: (listener: (ready: boolean) => void) => {
+      listener(true);
+      return () => {};
+    },
+  },
 }));
 
 const tiling = (bedOverages: BaseplateTiling['bedOverages']): BaseplateTiling => ({

--- a/src/features/baseplate/hooks/useBaseplateExport.ts
+++ b/src/features/baseplate/hooks/useBaseplateExport.ts
@@ -6,6 +6,7 @@
  * single download (one un-split plate) or a ZIP with a print guide.
  */
 
+import { useEngineReady } from '@/shared/hooks/useEngineReady';
 import { useCallback, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
@@ -86,8 +87,8 @@ export function useBaseplateExport(): UseBaseplateExportReturn {
   // until the plan is fixed or reset. Automatic plans never populate this except
   // when the bed cannot hold a single grid unit at all.
   const overBedPieceCount = tiling?.bedOverages.length ?? 0;
-  const canExport =
-    (hasSingleMesh || hasSplitMeshes) && getActiveBridge() !== null && overBedPieceCount === 0;
+  const engineReady = useEngineReady();
+  const canExport = (hasSingleMesh || hasSplitMeshes) && engineReady && overBedPieceCount === 0;
 
   const downloadBaseplate = useCallback(
     async (format: ExportFileFormat, splitEnabled = true) => {

--- a/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.test.ts
@@ -7,8 +7,22 @@ import { resetAllStores } from '@/test/testUtils';
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 let activeBridge: unknown = null;
+const readyListeners = new Set<(ready: boolean) => void>();
+function broadcastReady(ready: boolean): void {
+  for (const listener of readyListeners) listener(ready);
+}
 vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => activeBridge,
+  bridgeManager: {
+    get engineReady() {
+      return activeBridge !== null;
+    },
+    subscribe: (listener: (ready: boolean) => void) => {
+      readyListeners.add(listener);
+      listener(activeBridge !== null);
+      return () => readyListeners.delete(listener);
+    },
+  },
 }));
 
 vi.mock('@/shared/generation/exportUtils', () => ({
@@ -40,12 +54,14 @@ describe('useConnectorSampleExport', () => {
     vi.mocked(triggerDownload).mockClear();
   });
 
-  it('reports canExport from the active bridge presence', () => {
-    const { result, rerender } = renderHook(() => useConnectorSampleExport());
+  it('follows engine readiness reactively, not the render-time bridge', () => {
+    // A refresh nulls the bridge before the replacement boots; the button must
+    // come back when readiness is broadcast, with nothing else re-rendering.
+    activeBridge = null;
+    const { result } = renderHook(() => useConnectorSampleExport());
     expect(result.current.canExport).toBe(false);
-
     activeBridge = {};
-    rerender();
+    act(() => broadcastReady(true));
     expect(result.current.canExport).toBe(true);
   });
 

--- a/src/features/baseplate/hooks/useConnectorSampleExport.ts
+++ b/src/features/baseplate/hooks/useConnectorSampleExport.ts
@@ -8,6 +8,7 @@
  * magnet settings so the coupon height matches the real plate.
  */
 
+import { useEngineReady } from '@/shared/hooks/useEngineReady';
 import { useCallback, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
@@ -79,7 +80,7 @@ export function useConnectorSampleExport(): UseConnectorSampleExportReturn {
   );
 
   const [isExporting, setIsExporting] = useState(false);
-  const canExport = getActiveBridge() !== null;
+  const canExport = useEngineReady();
 
   const downloadSample = useCallback(
     async (format: ExportFileFormat, baseName: string = CONNECTOR_SAMPLE_BASE_NAME) => {

--- a/src/features/baseplate/hooks/useStackSampleExport.ts
+++ b/src/features/baseplate/hooks/useStackSampleExport.ts
@@ -7,6 +7,7 @@
  * the same tower-baking soup as the full stack export — just pinned to 2 copies.
  */
 
+import { useEngineReady } from '@/shared/hooks/useEngineReady';
 import { useCallback, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
@@ -50,7 +51,7 @@ export function useStackSampleExport(): UseStackSampleExportReturn {
   );
 
   const [isExporting, setIsExporting] = useState(false);
-  const canExport = getActiveBridge() !== null && baseplateParams.stackPrint?.enabled === true;
+  const canExport = useEngineReady() && baseplateParams.stackPrint?.enabled === true;
 
   const downloadSample = useCallback(
     async (format: ExportFileFormat, baseName: string = STACK_SAMPLE_BASE_NAME) => {

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -151,9 +151,10 @@ export function useExport(): UseExportReturn {
     return unsubscribe;
   }, []);
 
-  // Export requires both a preview mesh (to show UI) and an active bridge (to regenerate)
-  const canExport =
-    mesh !== null && mesh.vertices !== null && mesh.error === null && getActiveBridge() !== null;
+  // Export requires both a preview mesh (to show UI) and a ready engine (to
+  // regenerate). `engineReady` rather than a render-time getActiveBridge():
+  // the subscription re-renders this hook when a refreshed worker comes back.
+  const canExport = mesh !== null && mesh.vertices !== null && mesh.error === null && engineReady;
 
   const hasDividers =
     params.style === 'slotted' && (params.slotConfig.x.enabled || params.slotConfig.y.enabled);

--- a/src/features/bin-designer/hooks/useFitTestExport.test.ts
+++ b/src/features/bin-designer/hooks/useFitTestExport.test.ts
@@ -13,8 +13,35 @@ interface FakeBridge {
 }
 
 let activeBridge: FakeBridge | null = null;
+const readyListeners = new Set<(ready: boolean) => void>();
+function broadcastReady(ready: boolean): void {
+  for (const listener of readyListeners) listener(ready);
+}
 vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => activeBridge,
+  // `useEngineReady` mirrors the bridge presence for these cases; `subscribe`
+  // fires synchronously with the current state, as the real manager does, and
+  // the captured listener lets a test broadcast a readiness transition.
+  bridgeManager: {
+    get engineReady() {
+      return activeBridge !== null;
+    },
+    subscribe: (listener: (ready: boolean) => void) => {
+      readyListeners.add(listener);
+      listener(activeBridge !== null);
+      return () => readyListeners.delete(listener);
+    },
+  },
+}));
+
+// Pass-through: retry/restart behaviour is the wrapper's own suite's job;
+// these cases assert the single-attempt contract around it.
+vi.mock('../utils/exportWithResilience', () => ({
+  exportWithResilience: async <T>(op: () => Promise<T>) => ({
+    result: await op(),
+    retryCount: 0,
+    restartCount: 0,
+  }),
 }));
 
 vi.mock('@/shared/generation/exportUtils', () => ({
@@ -66,12 +93,14 @@ describe('useFitTestExport', () => {
     };
   });
 
-  it('reports canExport from the active bridge presence', () => {
+  it('follows engine readiness reactively, not the render-time bridge', () => {
+    // A refresh nulls the bridge before the replacement boots; the button must
+    // come back when readiness is broadcast, with nothing else re-rendering.
     activeBridge = null;
-    const { result, rerender } = renderHook(() => useFitTestExport());
+    const { result } = renderHook(() => useFitTestExport());
     expect(result.current.canExport).toBe(false);
     activeBridge = { exportFitTest: vi.fn() };
-    rerender();
+    act(() => broadcastReady(true));
     expect(result.current.canExport).toBe(true);
   });
 

--- a/src/features/bin-designer/hooks/useFitTestExport.ts
+++ b/src/features/bin-designer/hooks/useFitTestExport.ts
@@ -12,6 +12,8 @@
  * perfectly happily (gotcha #20).
  */
 
+import { exportWithResilience } from '../utils/exportWithResilience';
+import { useEngineReady } from '@/shared/hooks/useEngineReady';
 import { useCallback, useState } from 'react';
 import { useSettingsStore } from '@/core/store/settings';
 import { useDesignerStore } from '@/features/bin-designer/store';
@@ -23,6 +25,7 @@ import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { packagePiecesAsZip } from '@/shared/generation/zipExport';
 import { isErr, getUserMessage } from '@/core/result';
 import { getErrorMessage } from '@/shared/utils/errors';
+import { trackToolConverted } from '@/shared/analytics/posthog';
 import {
   FORMAT_MIME_TYPES,
   FORMAT_EXTENSIONS,
@@ -50,7 +53,7 @@ interface UseFitTestExportReturn {
 export function useFitTestExport(): UseFitTestExportReturn {
   const t = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
-  const canExport = getActiveBridge() !== null;
+  const canExport = useEngineReady();
 
   const downloadCard = useCallback(
     async ({ format, thicknessMm, baseName = FIT_TEST_BASE_NAME, bed }: DownloadOptions) => {
@@ -63,10 +66,18 @@ export function useFitTestExport(): UseFitTestExportReturn {
         // STEP is refused worker-side for mesh imprints; the request carries the
         // format the user picked and the worker is the authority on that rule.
         const workerFormat = format === '3mf' ? 'stl' : format;
-        const result = await bridge.exportFitTest(params, workerFormat, {
-          thicknessMm,
-          stamp: { designName },
-          bed,
+        // Through the same retry + worker-restart path the main export uses:
+        // without it a wedged worker costs a toast per attempt and never
+        // respawns for a user whose only export surface is this button. The
+        // operation re-acquires the bridge so a restarted worker is picked up.
+        const { result } = await exportWithResilience(() => {
+          const liveBridge = getActiveBridge();
+          if (!liveBridge) throw new Error('Bridge not available');
+          return liveBridge.exportFitTest(params, workerFormat, {
+            thicknessMm,
+            stamp: { designName },
+            bed,
+          });
         });
 
         const pieces =
@@ -112,6 +123,13 @@ export function useFitTestExport(): UseFitTestExportReturn {
             .getState()
             .addToast(t('binDesigner.cutouts.fitTest.warnSeamThroughCutout'), 'info', 8000);
         }
+        // A fit-test card is a printable file, which is what the conversion
+        // funnel (and the feedback nudge's session gate) count.
+        trackToolConverted('designer', {
+          format,
+          split: pieces.length > 1,
+          piece_count: pieces.length,
+        });
         return true;
       } catch (error: unknown) {
         useToastStore

--- a/src/features/bin-designer/hooks/useLabelFitSampleExport.test.ts
+++ b/src/features/bin-designer/hooks/useLabelFitSampleExport.test.ts
@@ -7,8 +7,22 @@ import { resetAllStores } from '@/test/testUtils';
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 let activeBridge: unknown = null;
+const readyListeners = new Set<(ready: boolean) => void>();
+function broadcastReady(ready: boolean): void {
+  for (const listener of readyListeners) listener(ready);
+}
 vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => activeBridge,
+  bridgeManager: {
+    get engineReady() {
+      return activeBridge !== null;
+    },
+    subscribe: (listener: (ready: boolean) => void) => {
+      readyListeners.add(listener);
+      listener(activeBridge !== null);
+      return () => readyListeners.delete(listener);
+    },
+  },
 }));
 
 vi.mock('@/shared/generation/exportUtils', () => ({
@@ -40,12 +54,14 @@ describe('useLabelFitSampleExport', () => {
     vi.mocked(triggerDownload).mockClear();
   });
 
-  it('reports canExport from the active bridge presence', () => {
-    const { result, rerender } = renderHook(() => useLabelFitSampleExport());
+  it('follows engine readiness reactively, not the render-time bridge', () => {
+    // A refresh nulls the bridge before the replacement boots; the button must
+    // come back when readiness is broadcast, with nothing else re-rendering.
+    activeBridge = null;
+    const { result } = renderHook(() => useLabelFitSampleExport());
     expect(result.current.canExport).toBe(false);
-
     activeBridge = {};
-    rerender();
+    act(() => broadcastReady(true));
     expect(result.current.canExport).toBe(true);
   });
 

--- a/src/features/bin-designer/hooks/useLabelFitSampleExport.ts
+++ b/src/features/bin-designer/hooks/useLabelFitSampleExport.ts
@@ -9,6 +9,7 @@
  * just like real sockets, so the offset transfers on that same nozzle.
  */
 
+import { useEngineReady } from '@/shared/hooks/useEngineReady';
 import { useCallback, useState } from 'react';
 import { useSettingsStore } from '@/core/store/settings';
 import { useToastStore } from '@/core/store/toast';
@@ -36,7 +37,7 @@ interface UseLabelFitSampleExportReturn {
 export function useLabelFitSampleExport(): UseLabelFitSampleExportReturn {
   const t = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
-  const canExport = getActiveBridge() !== null;
+  const canExport = useEngineReady();
 
   const downloadSample = useCallback(
     async (format: ExportFileFormat, baseName: string = LABEL_FIT_SAMPLE_BASE_NAME) => {

--- a/src/features/bin-designer/hooks/useLabelPlateExport.ts
+++ b/src/features/bin-designer/hooks/useLabelPlateExport.ts
@@ -8,17 +8,20 @@
  * for the pre-export 3D preview — no separate worker message needed.
  */
 
+import { exportWithResilience } from '../utils/exportWithResilience';
+import { useEngineReady } from '@/shared/hooks/useEngineReady';
 import { useCallback, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useSettingsStore } from '@/core/store/settings';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
-import { getActiveBridge } from '@/shared/generation/bridge';
+import { getActiveBridge, type ExportFormat } from '@/shared/generation/bridge';
 import { export3MF } from '@/shared/generation/export';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { isErr, getUserMessage } from '@/core/result';
 import { getErrorMessage } from '@/shared/utils/errors';
+import { trackToolConverted } from '@/shared/analytics/posthog';
 import {
   FORMAT_MIME_TYPES,
   FORMAT_EXTENSIONS,
@@ -58,7 +61,7 @@ export function useLabelPlateExport(): UseLabelPlateExportReturn {
   );
 
   const [isExporting, setIsExporting] = useState(false);
-  const canExport = getActiveBridge() !== null;
+  const canExport = useEngineReady();
 
   const nozzleSizeMm = useSettingsStore((s) => s.settings.printSettings.nozzleSizeMm);
 
@@ -104,8 +107,18 @@ export function useLabelPlateExport(): UseLabelPlateExportReturn {
       setIsExporting(true);
       try {
         const { specs, options } = buildRequest();
+        // Same retry + worker-restart path as the main export; the operation
+        // re-acquires the bridge so a restarted worker is picked up.
+        const runExport = async (fmt: ExportFormat) => {
+          const { result } = await exportWithResilience(() => {
+            const liveBridge = getActiveBridge();
+            if (!liveBridge) throw new Error('Bridge not available');
+            return liveBridge.exportLabelPlates(specs, options, fmt);
+          });
+          return result;
+        };
         if (format === '3mf') {
-          const stlResult = await bridge.exportLabelPlates(specs, options, 'stl');
+          const stlResult = await runExport('stl');
           const parseResult = parseSTLBinary(stlResult.data);
           if (isErr(parseResult)) throw new Error(getUserMessage(parseResult.error));
           const printSettings = useSettingsStore.getState().settings.printSettings;
@@ -128,10 +141,13 @@ export function useLabelPlateExport(): UseLabelPlateExportReturn {
           });
           triggerDownload(blob, `${baseName}${FORMAT_EXTENSIONS['3mf']}`);
         } else {
-          const result = await bridge.exportLabelPlates(specs, options, format);
+          const result = await runExport(format);
           const blob = new Blob([result.data], { type: FORMAT_MIME_TYPES[format] });
           triggerDownload(blob, `${baseName}${FORMAT_EXTENSIONS[format]}`);
         }
+        // Plates are printable files: count the conversion, as the bin and
+        // layout exports do.
+        trackToolConverted('designer', { format });
         return true;
       } catch (error: unknown) {
         useToastStore

--- a/src/features/bin-designer/hooks/useSlideFitSampleExport.test.ts
+++ b/src/features/bin-designer/hooks/useSlideFitSampleExport.test.ts
@@ -9,8 +9,22 @@ import { resetAllStores } from '@/test/testUtils';
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 let activeBridge: unknown = null;
+const readyListeners = new Set<(ready: boolean) => void>();
+function broadcastReady(ready: boolean): void {
+  for (const listener of readyListeners) listener(ready);
+}
 vi.mock('@/shared/generation/bridge', () => ({
   getActiveBridge: () => activeBridge,
+  bridgeManager: {
+    get engineReady() {
+      return activeBridge !== null;
+    },
+    subscribe: (listener: (ready: boolean) => void) => {
+      readyListeners.add(listener);
+      listener(activeBridge !== null);
+      return () => readyListeners.delete(listener);
+    },
+  },
 }));
 
 vi.mock('@/shared/generation/exportUtils', () => ({
@@ -38,11 +52,14 @@ describe('useSlideFitSampleExport', () => {
     vi.mocked(triggerDownload).mockClear();
   });
 
-  it('reports canExport from the active bridge presence', () => {
-    const { result, rerender } = renderHook(() => useSlideFitSampleExport());
+  it('follows engine readiness reactively, not the render-time bridge', () => {
+    // A refresh nulls the bridge before the replacement boots; the button must
+    // come back when readiness is broadcast, with nothing else re-rendering.
+    activeBridge = null;
+    const { result } = renderHook(() => useSlideFitSampleExport());
     expect(result.current.canExport).toBe(false);
     activeBridge = {};
-    rerender();
+    act(() => broadcastReady(true));
     expect(result.current.canExport).toBe(true);
   });
 

--- a/src/features/bin-designer/hooks/useSlideFitSampleExport.ts
+++ b/src/features/bin-designer/hooks/useSlideFitSampleExport.ts
@@ -8,6 +8,7 @@
  * shelf this design would actually carry, not a generic one.
  */
 
+import { useEngineReady } from '@/shared/hooks/useEngineReady';
 import { useCallback, useState } from 'react';
 import { useSettingsStore } from '@/core/store/settings';
 import { useDesignerStore } from '@/features/bin-designer/store';
@@ -36,7 +37,7 @@ interface UseSlideFitSampleExportReturn {
 export function useSlideFitSampleExport(): UseSlideFitSampleExportReturn {
   const t = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
-  const canExport = getActiveBridge() !== null;
+  const canExport = useEngineReady();
 
   const downloadSample = useCallback(
     async (format: ExportFileFormat, baseName: string = SLIDE_FIT_SAMPLE_BASE_NAME) => {

--- a/src/features/supporters/components/SupportersPage/SupportersPage.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../utils/supportersData';
 import { useSupportersData } from '../../hooks/useSupportersData';
 import { useSupporterStatus } from '../../hooks/useSupporterStatus';
+import type { SupporterProfilePatch } from '../../api/supporterClient';
 import { getSupportersPalette } from '../../scene/palette';
 import { SupportersScene, type FlyToRequest } from '../SupportersScene';
 import { SupporterPanel } from '../SupporterPanel';
@@ -213,7 +214,44 @@ export function SupportersPage() {
 
   const accent = useSettingsStore((state) => state.settings.accentColor);
   const { data: supporters, settled } = useSupportersData();
-  const bins = useMemo(() => buildSupporterBins(supporters), [supporters]);
+  const supporter = useSupporterStatus();
+
+  // A profile save must show on the wall in the same session, but the list is
+  // fetched once and `/api/supporters` is edge-cached (s-maxage 60, SWR 600),
+  // so a refetch can keep serving the pre-edit payload for minutes. The rename
+  // is applied locally instead: the record is found by its pre-save name (the
+  // only handle the public list carries), or by the first anonymous slot for
+  // a supporter naming themself for the first time.
+  const [profileEdit, setProfileEdit] = useState<{ prevName: string | null } | null>(null);
+  const saveProfile = useCallback(
+    async (patch: SupporterProfilePatch) => {
+      const prevName = supporter.status.name;
+      const error = await supporter.save(patch);
+      if (error === null) setProfileEdit({ prevName });
+      return error;
+    },
+    [supporter]
+  );
+
+  const effectiveSupporters = useMemo(() => {
+    const status = supporter.status;
+    if (!profileEdit || !status.supporter || status.name === null) return supporters;
+    if (supporters.supporters.some((r) => r.name === status.name)) return supporters;
+    const records = supporters.supporters.slice();
+    const idx =
+      profileEdit.prevName !== null
+        ? records.findIndex((r) => r.name === profileEdit.prevName)
+        : records.findIndex((r) => r.name === null);
+    const patched = {
+      ...(idx >= 0 ? records[idx] : {}),
+      name: status.name,
+      ...(status.message ? { message: status.message } : { message: undefined }),
+    };
+    if (idx >= 0) records[idx] = patched;
+    else records.push(patched);
+    return { ...supporters, supporters: records };
+  }, [supporters, supporter.status, profileEdit]);
+  const bins = useMemo(() => buildSupporterBins(effectiveSupporters), [effectiveSupporters]);
   const total = getSupporterCount(supporters);
   const palette = useMemo(() => getSupportersPalette(theme, accent), [theme, accent]);
   // Gated on `settled` so the count-up starts when the scene actually appears,
@@ -236,7 +274,6 @@ export function SupportersPage() {
   const flyNonce = useRef(0);
   const [burst, setBurst] = useState<{ x: number; y: number; seed: number } | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
-  const supporter = useSupporterStatus();
 
   // Bins set document.body.cursor on hover; reset it if we unmount mid-hover.
   useEffect(() => () => void (document.body.style.cursor = ''), []);
@@ -540,7 +577,7 @@ export function SupportersPage() {
         onClose={() => setPanelOpen(false)}
         status={supporter.status}
         settled={supporter.settled}
-        save={supporter.save}
+        save={saveProfile}
         onFindMyBin={
           myBin
             ? () => {

--- a/src/shared/analytics/posthog/eventsCore.ts
+++ b/src/shared/analytics/posthog/eventsCore.ts
@@ -5,7 +5,8 @@
  * `trackBinCreated` is the hot path — every bin draw, paint stroke,
  * fill op, duplicate, or import lands here, and it cascades into the
  * milestone check that fires on each engagement threshold crossing
- * (5, 15, 30 bins).
+ * (1 and 5 bins; the deeper rungs live on the designer ladder,
+ * `DESIGNER_MILESTONE_THRESHOLDS`).
  */
 
 import type { Layout } from '@/core/types';

--- a/src/shared/components/preview/FittedFloorLabel.test.tsx
+++ b/src/shared/components/preview/FittedFloorLabel.test.tsx
@@ -137,13 +137,49 @@ describe('FittedFloorLabel', () => {
     expect(mocks.text?.fontSize).toBe(7);
   });
 
-  it('re-measures when the band changes', () => {
+  // The natural width does not depend on the band, so a band change re-fits
+  // synchronously from the stored measurement — no troika round trip, and
+  // never a transparent frame. Keying the measurement on the band made a
+  // settled fit permanently invisible after a resize: the re-rendered props
+  // equalled the layout troika already had, its sync() is a no-op without a
+  // syncable-prop change, and onSync never fired again.
+  it('re-fits from the stored measurement when the band changes', () => {
+    const { rerender } = render(<FittedFloorLabel {...baseProps()} />);
+    sync(mesh(145));
+    expect(mocks.text?.fillOpacity).toBe(0.6);
+    const shrunk = mocks.text?.fontSize as number;
+    expect(shrunk).toBeLessThan(7);
+
+    // A wider band relaxes the fit back to the base size, still visible.
+    rerender(<FittedFloorLabel {...baseProps()} band={252} />);
+    expect(mocks.text?.fillOpacity).toBe(0.6);
+    expect(mocks.text?.fontSize).toBe(7);
+  });
+
+  it('stays visible when the band changes on a settled fit', () => {
+    // The exact reported ordering: a short name settles at the base size,
+    // then the bin is widened. The re-render carries props identical to the
+    // settled layout, so no sync ever fires again — visibility must not
+    // depend on one.
+    const { rerender } = render(<FittedFloorLabel {...baseProps()} />);
+    sync(mesh(90));
+    expect(mocks.text?.fillOpacity).toBe(0.6);
+
+    rerender(<FittedFloorLabel {...baseProps()} band={189} />);
+    expect(mocks.text?.fillOpacity).toBe(0.6);
+    expect(mocks.text?.fontSize).toBe(7);
+    expect(mocks.text?.maxWidth).toBeUndefined();
+  });
+
+  it('re-measures when the text changes', () => {
     const { rerender } = render(<FittedFloorLabel {...baseProps()} />);
     sync(mesh(145));
     expect(mocks.text?.fillOpacity).toBe(0.6);
 
-    rerender(<FittedFloorLabel {...baseProps()} band={252} />);
+    rerender(<FittedFloorLabel {...baseProps()} text="NEW NAME" />);
     expect(mocks.text?.fillOpacity).toBe(0);
+    expect(mocks.text?.fontSize).toBe(7);
+    expect(mocks.text?.maxWidth).toBeUndefined();
   });
 
   it('draws no underline unless one is asked for', () => {

--- a/src/shared/components/preview/FittedFloorLabel.tsx
+++ b/src/shared/components/preview/FittedFloorLabel.tsx
@@ -42,8 +42,12 @@ interface Ink {
 }
 
 interface Measurement {
+  /** Keyed on what determines `naturalWidth` alone — text, size, spacing. */
   key: string;
-  fit: FloorLabelFit;
+  /** Unwrapped single-line width at the base font size, in scene units. */
+  naturalWidth: number;
+  /** Signature of the fit the stored ink was read under, or null when unread. */
+  inkKey: string | null;
   ink: Ink | null;
 }
 
@@ -83,10 +87,28 @@ export function FittedFloorLabel({
 }: FittedFloorLabelProps) {
   const [measurement, setMeasurement] = useState<Measurement | null>(null);
 
-  // letterSpacing belongs in the key too: it changes glyph layout, so a
-  // measurement taken at one value does not describe the text at another.
-  const key = [text, band, baseFontSize, minFontSize, maxLines, letterSpacing].join('\u0000');
+  // The measurement is keyed on what determines the natural width ALONE:
+  // text, base size and letter spacing. `band`/`minFontSize`/`maxLines` are
+  // deliberately NOT in the key — they only shape the FIT, which is computed
+  // from the stored width during render. Keying them in made a band change
+  // discard the measurement and wait for a re-sync troika never performs when
+  // the re-rendered props equal the settled layout it already has (`sync()`
+  // is a no-op without a syncable-prop change), leaving the label permanently
+  // transparent after a resize on a settled fit.
+  const key = [text, baseFontSize, letterSpacing].join('\u0000');
   const current = measurement?.key === key ? measurement : null;
+
+  const fit: FloorLabelFit | null = current
+    ? fitFloorLabel({
+        text,
+        naturalWidth: current.naturalWidth,
+        band,
+        baseFontSize,
+        minFontSize,
+        maxLines,
+      })
+    : null;
+  const fitKey = fit ? [fit.fontSize, fit.maxWidth ?? -1, fit.text].join('\u0000') : null;
 
   const handleSync = useCallback(
     (mesh: TroikaTextMesh) => {
@@ -95,15 +117,24 @@ export function FittedFloorLabel({
 
       setMeasurement((prev) => {
         if (prev?.key === key) {
-          if (prev.ink) return prev;
+          // The width is known; this sync is a (re)layout of some fit. Read
+          // the ink for it — the underline must track the layout actually on
+          // screen, so stale ink from an earlier fit is replaced.
+          if (prev.inkKey === fitKey && prev.ink) return prev;
           const ink = readInk(info);
-          return ink ? { ...prev, ink } : prev;
+          return ink ? { ...prev, ink, inkKey: fitKey } : prev;
         }
 
+        // First sync for this text/size/spacing: the render below used the
+        // bare base-size, unclamped props (current was null), so the block IS
+        // the natural single-line width.
         const naturalWidth = info.blockBounds[2] - info.blockBounds[0];
         if (!Number.isFinite(naturalWidth)) return prev;
 
-        const fit = fitFloorLabel({
+        // troika's sync() is a no-op when no layout input changed, so a fit
+        // that changes nothing will never call back a second time. Read the
+        // ink from this same pass or never get another chance at it.
+        const settledFit = fitFloorLabel({
           text,
           naturalWidth,
           band,
@@ -111,28 +142,34 @@ export function FittedFloorLabel({
           minFontSize,
           maxLines,
         });
-
-        // troika's sync() is a no-op when no layout input changed, so it will
-        // never call back a second time for a fit that changes nothing. Read
-        // the ink from this same pass or never get another chance at it.
         const settled =
-          fit.fontSize === baseFontSize && fit.maxWidth === undefined && fit.text === text;
+          settledFit.fontSize === baseFontSize &&
+          settledFit.maxWidth === undefined &&
+          settledFit.text === text;
+        const settledKey = [settledFit.fontSize, settledFit.maxWidth ?? -1, settledFit.text].join(
+          '\u0000'
+        );
 
-        return { key, fit, ink: settled ? readInk(info) : null };
+        return {
+          key,
+          naturalWidth,
+          ink: settled ? readInk(info) : null,
+          inkKey: settled ? settledKey : null,
+        };
       });
     },
-    [key, text, band, baseFontSize, minFontSize, maxLines]
+    [key, fitKey, text, band, baseFontSize, minFontSize, maxLines]
   );
 
   const topY = (baseFontSize * LINE_HEIGHT) / 2;
-  const ink = current?.ink;
+  const ink = current?.inkKey === fitKey ? current.ink : null;
 
   return (
     <group position={position}>
       <Text
         position={[0, topY, 0]}
-        fontSize={current?.fit.fontSize ?? baseFontSize}
-        maxWidth={current?.fit.maxWidth}
+        fontSize={fit?.fontSize ?? baseFontSize}
+        maxWidth={fit?.maxWidth}
         color={color}
         fillOpacity={current ? fillOpacity : 0}
         anchorX="center"
@@ -143,7 +180,7 @@ export function FittedFloorLabel({
         letterSpacing={letterSpacing}
         onSync={handleSync}
       >
-        {current?.fit.text ?? text}
+        {fit?.text ?? text}
       </Text>
 
       {underline && ink && (

--- a/src/shared/hooks/useEngineReady.ts
+++ b/src/shared/hooks/useEngineReady.ts
@@ -1,0 +1,19 @@
+/**
+ * Reactive engine readiness for export buttons.
+ *
+ * A render-time `getActiveBridge() !== null` freezes whatever the bridge
+ * happened to be at that moment: a render landing in the window where
+ * `bridgeManager.refresh()` has nulled the bridge leaves the button disabled
+ * with nothing to re-render it when the new worker boots. The subscription
+ * fires synchronously with the current state and on every transition, which
+ * is the same wiring `useExport` has always had.
+ */
+
+import { useEffect, useState } from 'react';
+import { bridgeManager } from '@/shared/generation/bridge';
+
+export function useEngineReady(): boolean {
+  const [ready, setReady] = useState(() => bridgeManager.engineReady);
+  useEffect(() => bridgeManager.subscribe(setReady), []);
+  return ready;
+}


### PR DESCRIPTION
Iteration-2 review of #3512 (engine/export recovery), #3506 (supporters), #3502 (floor label) and #3517 (milestones). Two P1s and three polish items.

## Fixes

- **Floor labels went permanently invisible after a resize (P1).** `FittedFloorLabel` keyed its measurement on the band and hid the text until the next `onSync` — but troika's `sync()` is a no-op when no layout input changed, so widening a bin whose name had settled at the base size re-rendered identical props and the callback never fired again (same for the layout name over the planner floor). The measurement is now keyed on what determines the natural width alone (text, size, letter spacing); band and line-limit changes re-fit synchronously from the stored width with no troika round trip, and the underline's ink re-reads whenever the fit changes. The test that pinned the old always-resync assumption now pins the settled-fit ordering that broke.
- **The supporters wall ignored a profile save (P1).** The list is fetched once and `/api/supporters` is edge-cached (s-maxage 60, SWR 600), so after a rename the wall kept the old name behind the very panel confirming the save, and "Find mine" vanished (it matches by name — the only handle the public list carries). A session-local overlay now applies the saved profile immediately, matching the record by its pre-save name, or the first anonymous slot for a supporter naming themself for the first time.
- **Export buttons froze during worker refreshes.** Seven surfaces computed `canExport` from a render-time `getActiveBridge()`; a render landing in the refresh window left the button dead with nothing to re-render it. A shared `useEngineReady` hook subscribes to the bridge manager (the wiring `useExport` always had) — all seven now react to readiness transitions, with tests driving the broadcast. The fit-test and label-plate exports additionally run through `exportWithResilience`, gaining the retry + worker-respawn path the main export has (the remaining sample hooks still call the bridge directly; their timeout rejection stands, noted as debt).
- **Missing conversions.** Fit-test cards and label plates are printable files but fired no `tool_converted`, so the feedback nudge's converted-this-session gate never opened on those surfaces and the funnel under-counted them.
- Corrected the milestone comment still describing the deleted 5/15/30 rungs.

## Verification

361 tests across the export hooks green (mocks now model the readiness broadcast); FittedFloorLabel 20 (two new regression orderings); supporters 100; typecheck, lint, boundaries green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

