### PR TITLE
fix(bin-designer): close the cross-feature seams the iteration-3 probes surfaced

### DIFF
--- a/src/features/bin-designer/components/DesignerPage/useFractionalEdgeMismatch.ts
+++ b/src/features/bin-designer/components/DesignerPage/useFractionalEdgeMismatch.ts
@@ -23,6 +23,7 @@ import {
   hasFootLatticeMismatch,
   computeMatchedFootLattice,
 } from '@/shared/utils/fractionalEdge';
+import { hasDetachableFeet } from '@/features/bin-designer/types/base';
 import { isPartialMask } from '@/shared/utils/cellMask';
 
 interface FractionalEdgeMismatch {
@@ -45,6 +46,7 @@ export function useFractionalEdgeMismatch(): FractionalEdgeMismatch {
     fractionalEdgeManualY,
     base,
     halfSockets,
+    feetDetachable,
     footLatticeX,
     footLatticeY,
     cellMask,
@@ -60,6 +62,7 @@ export function useFractionalEdgeMismatch(): FractionalEdgeMismatch {
       fractionalEdgeManualY: s.params.fractionalEdgeManualY,
       base: s.params.base,
       halfSockets: s.params.base.halfSockets,
+      feetDetachable: hasDetachableFeet(s.params.base),
       footLatticeX: s.params.base.footLatticeX,
       footLatticeY: s.params.base.footLatticeY,
       cellMask: s.params.cellMask,
@@ -79,6 +82,7 @@ export function useFractionalEdgeMismatch(): FractionalEdgeMismatch {
       fractionalEdgeManualX,
       fractionalEdgeManualY,
       halfSockets,
+      detachableFeet: feetDetachable,
       footLatticeX,
       footLatticeY,
       hasCellMask: isPartialMask(cellMask),
@@ -91,6 +95,7 @@ export function useFractionalEdgeMismatch(): FractionalEdgeMismatch {
       fractionalEdgeManualX,
       fractionalEdgeManualY,
       halfSockets,
+      feetDetachable,
       footLatticeX,
       footLatticeY,
       cellMask,

--- a/src/features/bin-designer/components/panel/BaseSection/useBaseSection.ts
+++ b/src/features/bin-designer/components/panel/BaseSection/useBaseSection.ts
@@ -96,11 +96,17 @@ export function useBaseSection() {
   //    `half` lattice moves every interior boundary off it.
   //  - fractional axis: it already carries a half cell, and `fractionalEdge`
   //    decides which end that sits on, which covers both placements on its own.
-  const bothAxesLockReason = hasHalfSockets
-    ? 'binDesigner.footLattice.halfSocketsHint'
-    : isPartialMask(params.cellMask)
-      ? 'binDesigner.footLattice.customShapeHint'
-      : null;
+  const hasDetachableFeet = hasDetachableFeetFor(base);
+  // Half sockets only exempt the lattice while the SOCKET is what seats the
+  // bin. With detachable feet the socket is never built, the plan reads the
+  // lattice regardless, and locking here hid the one control that seats a
+  // half-offset detachable bin (the stored halfSockets value is inert then).
+  const bothAxesLockReason =
+    hasHalfSockets && !hasDetachableFeet
+      ? 'binDesigner.footLattice.halfSocketsHint'
+      : isPartialMask(params.cellMask)
+        ? 'binDesigner.footLattice.customShapeHint'
+        : null;
   const axisLocked = (units: number): boolean => bothAxesLockReason !== null || isFractional(units);
   const footLatticeLockedX = axisLocked(params.width);
   const footLatticeLockedY = axisLocked(params.depth);
@@ -129,7 +135,6 @@ export function useBaseSection() {
   // The shared predicate, not `base.feet === 'detachable'`: it also refuses a
   // socketless base and a spacer, which is what the geometry does. The local
   // copy left a flat-base bin reading "4 feet" over a bin that builds none.
-  const hasDetachableFeet = hasDetachableFeetFor(base);
   const detachablePlan = hasDetachableFeet ? resolveDetachableFeet(params) : null;
   // No pocket-aligned whole cell to stand a foot on. Reachable for a 1-wide bin
   // under the `half` lattice, and the panel has to say so: the alternative is a

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
@@ -18,8 +18,16 @@ import { Text } from '@react-three/drei';
 import type { ThreeEvent } from '@react-three/fiber';
 import type { Cutout } from '@/features/bin-designer/types';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { cutoutLabelPlacement } from '@/shared/utils/cutoutLabel';
-import { isCutoutEngraveMode, isCutoutSocketMode } from '@/shared/utils/cutoutLabelSocketPlan';
+import {
+  cutoutLabelPlacement,
+  labelPlacementForAabb,
+  resolveCutoutTextAnchor,
+} from '@/shared/utils/cutoutLabel';
+import {
+  cutoutSocketAnchorAabb,
+  isCutoutEngraveMode,
+  isCutoutSocketMode,
+} from '@/shared/utils/cutoutLabelSocketPlan';
 import {
   LABEL_PLATE_CORNER_RADIUS_MM,
   LABEL_PLATE_HEIGHT_MM,
@@ -79,22 +87,31 @@ export function CutoutLabel3D({
           if (!socket) return null;
           const plateW = labelPlateWidthMm(socket.widthU);
           // The plan is memoised on committed params, so mid-drag it still
-          // describes the grab-point position. Follow the live override by the
-          // same delta the cutout (or its label nudge) has moved — both feed
-          // the plan's placement 1:1, and the exact re-plan lands on release.
+          // describes the grab-point position. Recompute the placement from
+          // the live override through the SAME anchor math the plan uses — a
+          // raw position delta is not 1:1 on the anchor's gap axis, whose band
+          // midpoint moves at half the cutout's rate, so a delta-followed
+          // ghost led the cursor and snapped back on release.
           const overrides = preview.get(cutout.id);
           const effective = overrides ? { ...cutout, ...overrides } : cutout;
-          const dragX =
-            effective.x - cutout.x + (effective.textOffset?.x ?? 0) - (cutout.textOffset?.x ?? 0);
-          const dragY =
-            effective.y - cutout.y + (effective.textOffset?.y ?? 0) - (cutout.textOffset?.y ?? 0);
+          const live = overrides
+            ? labelPlacementForAabb(
+                cutoutSocketAnchorAabb(effective, -socketPlan.innerW / 2, -socketPlan.innerD / 2),
+                resolveCutoutTextAnchor(effective),
+                effective.textOffset,
+                socketPlan.innerW,
+                socketPlan.innerD,
+                -socketPlan.innerW / 2,
+                -socketPlan.innerD / 2
+              )
+            : null;
           return (
             <CutoutSocketFootprint
               key={`socket-${cutout.id}`}
               // Plan centres are bin-centred; the editor's origin is the
               // interior corner, so shift by half the box the plan measured.
-              centerX={socket.centerX + socketPlan.innerW / 2 + dragX}
-              centerY={socket.centerY + socketPlan.innerD / 2 + dragY}
+              centerX={(live?.centerX ?? socket.centerX) + socketPlan.innerW / 2}
+              centerY={(live?.centerY ?? socket.centerY) + socketPlan.innerD / 2}
               // PLATE-frame extents, always: the footprint applies the
               // vertical rotation itself, so world-swapped extents here would
               // be rotated back and draw the plate on the wrong axis.

--- a/src/features/generation/worker/generators/baseplateCacheKeys.ts
+++ b/src/features/generation/worker/generators/baseplateCacheKeys.ts
@@ -49,6 +49,21 @@ export function slabPocketsCacheKey(
     quantize(params.screwHoles?.headDiameter ?? 0),
     quantize(params.screwHoles?.counterboreDepth ?? 0),
     params.screwHoles?.screwsPerPiece ?? 0,
+    // Corner radii and the magnet lattice ALSO move the per-cell screw
+    // decision: radii flip a margin anchor to a floor site, and the anchor/
+    // diameter shift the snap lattice the floor sites land on. Keyed only
+    // while screws are on, so non-screw plates keep their cache hits.
+    ...(params.screwHoles?.enabled === true
+      ? [
+          quantize(params.cornerRadius ?? -1),
+          quantize(params.cornerRadii?.tl ?? -1),
+          quantize(params.cornerRadii?.tr ?? -1),
+          quantize(params.cornerRadii?.bl ?? -1),
+          quantize(params.cornerRadii?.br ?? -1),
+          params.magnetAnchor ?? '',
+          quantize(params.magnetDiameter),
+        ]
+      : []),
     quantize(params.paddingLeft),
     quantize(params.paddingRight),
     quantize(params.paddingFront),

--- a/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { resolveCornerRadii } from './generatorConstants';
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { ScrewHoleParams } from '@/core/types/baseplate';
@@ -722,7 +723,10 @@ describe('direct mesh mount-down screw holes (#3425)', () => {
         widthMm: totalW,
         depthMm: totalD,
         bands: effectiveMarginBands(params),
-        cornerRadii: params.cornerRadii,
+        // The radii the rounding cut uses, not the raw per-corner field —
+        // in the linked mode that field is absent and the containment test
+        // would treat every uniform radius as square corners.
+        cornerRadii: resolveCornerRadii(params, Math.min(totalW, totalD) / 2 - 0.1),
         floorPadProvisioned: true,
       }),
       screwFloorCandidates(
@@ -769,6 +773,40 @@ describe('direct mesh mount-down screw holes (#3425)', () => {
 
   const keys = (points: ReadonlyArray<readonly [number, number]>): string[] =>
     points.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).sort();
+
+  it('sites margin screws off a LINKED corner radius, not just per-corner radii', () => {
+    // `cornerRadii` is only populated in the unlinked mode; the linked slider
+    // writes the scalar. Feeding the plan the raw field told it every linked
+    // radius was zero, so a 25mm uniform corner kept its margin screw at the
+    // square-corner position — 2.4mm outside the plate the arc actually cut.
+    const base = defaults({
+      width: 8,
+      depth: 5,
+      paddingLeft: 12,
+      paddingRight: 12,
+      paddingFront: 12,
+      paddingBack: 12,
+      screwHoles: SCREWS,
+      screwPadThicknessMm: PAD,
+    });
+    const square = expectedHoles(base, SCREWS);
+    const rounded = expectedHoles({ ...base, cornerRadius: 25 }, SCREWS);
+    expect(keys(rounded.map((h) => [h.x, h.y] as const))).not.toEqual(
+      keys(square.map((h) => [h.x, h.y] as const))
+    );
+    // And every rounded-plate hole stays inside the arc: the corner centre is
+    // (±(halfW-25), ±(halfD-25)) with radius 25.
+    const halfW = (8 * 42 + 24) / 2;
+    const halfD = (5 * 42 + 24) / 2;
+    for (const hole of rounded) {
+      const cx = Math.sign(hole.x) * (halfW - 25);
+      const cy = Math.sign(hole.y) * (halfD - 25);
+      const inCornerZone = Math.abs(hole.x) > Math.abs(cx) && Math.abs(hole.y) > Math.abs(cy);
+      if (inCornerZone) {
+        expect(Math.hypot(hole.x - cx, hole.y - cy)).toBeLessThanOrEqual(25);
+      }
+    }
+  });
 
   it('adds geometry rather than silently rendering a solid plate', () => {
     const plain = defaults({ width: 3, depth: 3 });

--- a/src/features/generation/worker/generators/baseplateDirectMesh.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.ts
@@ -308,6 +308,7 @@ export function generateBaseplateDirect(
   const screwParams = params.screwHoles?.enabled === true ? params.screwHoles : undefined;
   if (screwParams !== undefined) {
     const screwHoles = planBaseplateScrewHoles(screwParams, params, {
+      resolvedCornerRadii: resolved,
       totalWidthMm: totalW,
       totalDepthMm: totalD,
       gridW: width,

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -374,6 +374,21 @@ export function buildBaseplateSolid(
     shapedPocketCells = [...nominalCells, ...overTileFrame];
     pocketDecisions = shapedPocketCells.map(pocketDecision);
   }
+  // Corner radii resolved ONCE, up here, because two consumers must agree on
+  // them: the rounding cut below, and the screw plan's containment test — the
+  // check that stops a margin screw being placed in material a large corner
+  // radius has already cut away. Feeding the plan the raw `params.cornerRadii`
+  // (populated only in the unlinked per-corner mode) told it every LINKED
+  // radius was zero, so a uniform 25mm corner shipped its screw hole in air.
+  const minPadding = Math.min(
+    Math.min(paddingLeft, paddingRight),
+    Math.min(paddingFront, paddingBack)
+  );
+  const cellLimit = gridUnitMm / 2 + minPadding;
+  const geomLimit = Math.min(totalW, totalD) / 2 - 0.1;
+  const maxRadius = Math.min(cellLimit, geomLimit);
+  const cornerRadii = resolveCornerRadii(params, maxRadius);
+
   // Mount-down screw holes. Planned here, before the slab is cached,
   // because which cells keep a floor is part of the pocket geometry.
   const screwParams = params.screwHoles?.enabled === true ? params.screwHoles : undefined;
@@ -381,6 +396,7 @@ export function buildBaseplateSolid(
   const screwHoles =
     screwParams !== undefined
       ? planBaseplateScrewHoles(screwParams, params, {
+          resolvedCornerRadii: cornerRadii,
           totalWidthMm: totalW,
           totalDepthMm: totalD,
           gridW: width,
@@ -411,7 +427,9 @@ export function buildBaseplateSolid(
   const pocketMaskHash = pocketDecisions ? hashPocketDecisions(pocketDecisions) : undefined;
 
   // Cached separately so that toggling magnets or connectors doesn't redo the
-  // pocket boolean cuts.
+  // pocket boolean cuts. Corner rounding is applied post-cache, but it is NOT
+  // independent of the cached slab when screws are on: radii move the per-cell
+  // screw-floor decision, which is why they join the key above.
   const spKey = slabPocketsCacheKey(params, forExport, pocketMaskHash);
   const cachedSlab = slabWithPocketsCache.get(spKey);
   let baseplate: Shape3D;
@@ -420,10 +438,11 @@ export function buildBaseplateSolid(
     baseplate = unwrap(clone(cachedSlab));
     onProgress?.(0.5);
   } else {
-    // Build solid slab with RECTANGULAR profile for caching — pocket cuts are
-    // independent of corner radius, so we cache the rectangular slab+pockets
-    // and apply corner rounding as a post-cache step. Avoids expensive pocket
-    // re-cuts when only corner radius changes.
+    // Build solid slab with RECTANGULAR profile for caching; corner rounding
+    // is applied as a post-cache step so a radius-only edit avoids the pocket
+    // re-cuts. With screws ON the pockets are NOT radius-independent — radii
+    // flip margin anchors to floor sites, changing which cells keep a floor —
+    // so the cache key carries the radii (and the magnet lattice) then.
     //
     // The slab is also the material bound for the outline intersect below, so
     // it spans the nominal extent WIDENED by the outline's overhang:
@@ -508,14 +527,6 @@ export function buildBaseplateSolid(
   // beyond this limit never reach the rounding path: buildFullParams converts
   // them to a radius-cut outline, whose cell classification above handles the
   // sockets the arc consumes.
-  const minPadding = Math.min(
-    Math.min(paddingLeft, paddingRight),
-    Math.min(paddingFront, paddingBack)
-  );
-  const cellLimit = gridUnitMm / 2 + minPadding;
-  const geomLimit = Math.min(totalW, totalD) / 2 - 0.1;
-  const maxRadius = Math.min(cellLimit, geomLimit);
-  const cornerRadii = resolveCornerRadii(params, maxRadius);
   const hasRounding =
     cornerRadii.tl > 0 || cornerRadii.tr > 0 || cornerRadii.bl > 0 || cornerRadii.br > 0;
   // Outline clip reuses the corner-rounding slot: one boolean against the

--- a/src/features/generation/worker/generators/baseplateScrews.ts
+++ b/src/features/generation/worker/generators/baseplateScrews.ts
@@ -125,6 +125,13 @@ export interface ScrewPlacementInput {
   /** Padded printed footprint of the piece in mm. */
   readonly totalWidthMm: number;
   readonly totalDepthMm: number;
+  /**
+   * The radii the rounding cut will actually use — `resolveCornerRadii`'s
+   * output, never the raw `params.cornerRadii` (absent in the linked mode, so
+   * the containment test would treat every uniform radius as square corners
+   * and site a margin screw in material the arc cuts away).
+   */
+  readonly resolvedCornerRadii: { tl: number; tr: number; bl: number; br: number };
   /** Grid extent in units, which is what the floor candidate lattice spans. */
   readonly gridW: number;
   readonly gridD: number;
@@ -158,7 +165,7 @@ export function planBaseplateScrewHoles(
       widthMm: input.totalWidthMm,
       depthMm: input.totalDepthMm,
       bands: effectiveMarginBands(params),
-      cornerRadii: params.cornerRadii,
+      cornerRadii: input.resolvedCornerRadii,
       floorPadProvisioned: true,
     }),
     screwFloorCandidates(

--- a/src/features/generation/worker/generators/binGenerator.scenario.paramDifferential.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.paramDifferential.test.ts
@@ -75,6 +75,71 @@ describe('bin parameter differentials (dead-control guard)', () => {
     expect(Math.abs(small - large)).toBeGreaterThan(50);
   }, 60_000);
 
+  it('a grouped Repeat master still cuts every instance', async () => {
+    // The editor, the fit-test card and the estimate all count instances
+    // whatever the group state, so the exported bin must too — a grouped
+    // master collapsed to one pocket ships a board missing every derived
+    // cutout while every other layer promises them.
+    const board: BinParams = {
+      ...BASE,
+      style: 'solid',
+      base: { ...BASE.base, solid: true, stackingLip: false },
+    };
+    const grouped = (withArray: boolean): BinParams => ({
+      ...board,
+      cutouts: [
+        {
+          id: 'master',
+          shape: 'rectangle' as const,
+          x: 6,
+          y: 6,
+          width: 10,
+          depth: 10,
+          cutDepth: 5,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: 'g1',
+          groupOp: 'union' as const,
+          ...(withArray
+            ? {
+                array: {
+                  mode: 'grid' as const,
+                  cols: 3,
+                  rows: 1,
+                  pitchX: 22,
+                  pitchY: 22,
+                  count: 1,
+                  radius: 10,
+                  startAngle: 0,
+                  rotateToCenter: false,
+                },
+              }
+            : {}),
+        },
+        {
+          id: 'partner',
+          shape: 'rectangle' as const,
+          x: 6,
+          y: 24,
+          width: 10,
+          depth: 10,
+          cutDepth: 5,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: 'g1',
+          groupOp: 'union' as const,
+        },
+      ],
+    });
+    const single = await exportVolume(grouped(false));
+    const repeated = await exportVolume(grouped(true));
+    // Two extra 10x10x5 instances: ~1000mm3 of extra removal, minus nothing —
+    // the instances sit on clear board. Well above any tessellation noise.
+    expect(single - repeated).toBeGreaterThan(800);
+  }, 120_000);
+
   it('divider thickness changes the solid volume (thicker divider = more material)', async () => {
     const withDivider = (thickness: number): BinParams => ({
       ...BASE,

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -810,7 +810,12 @@ export function buildGroupedCutouts(
   const memberShapes: Shape3D[] = [];
   const builtMembers: Cutout[] = [];
   const builtDepths: number[] = [];
-  for (const cutout of groupMembers) {
+  // A member carrying a Repeat expands into its instances first, exactly as
+  // the ungrouped path does: the editor, the fit-test card and the estimate
+  // all count instances whatever the group state, so a master collapsed to
+  // one cut here would ship a bin missing every derived pocket. The editing
+  // rules refuse to CREATE the pairing, but a stored design can carry it.
+  for (const cutout of groupMembers.flatMap(expandCutoutArray)) {
     const effectiveDepth = Math.min(cutout.cutDepth, solidSurfaceZ);
     if (effectiveDepth <= 0) continue;
 
@@ -1065,7 +1070,8 @@ export function buildCutoutCuts(
   };
 
   // Partition cutouts by groupId: null -> ungrouped, same groupId -> collected.
-  // Array masters (always ungrouped) expand into one cut per instance first.
+  // Array masters expand into one cut per instance first — the grouped path
+  // expands its own members inside `buildGroupedCutouts`.
   const groups = new Map<string, typeof params.cutouts>();
   for (const cutout of params.cutouts) {
     if (cutout.groupId === null) {

--- a/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
+++ b/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
@@ -182,6 +182,48 @@ describe('detachable foot geometry', () => {
     }
   });
 
+  it('keeps its magnet pockets on an edge bar crossing an interior station', () => {
+    // The 4x2 case: a mid-run edge bar has dirY = 1, dirX = 0, interiorX true.
+    // Its clip spans the FULL cell in X (`edgeY`), so the spec corners at
+    // (±13, 13) are real material — a bound that shrank X to the arm's width
+    // rejected both and shipped the foot with no pockets at all.
+    const interiorEdgeBar: FootPlacement = {
+      shape: 'bar',
+      x: 0,
+      y: PITCH / 2,
+      dirX: 0,
+      dirY: 1,
+      interiorX: true,
+      interiorY: false,
+      cellW: PITCH,
+      cellD: PITCH,
+    };
+    const withMagnet = feetOf({
+      placements: [interiorEdgeBar],
+      magnet: {
+        diameterMm: MAGNET_D,
+        depthMm: MAGNET_DEPTH,
+        positions: [
+          [-13, 13],
+          [13, 13],
+        ],
+      },
+    });
+    try {
+      const m = meshOf(withMagnet.feet[0]);
+      const { minZ } = boundingBox(m.vertices);
+      for (const x of [-13, 13]) {
+        expect(
+          isSolidThrough(m, x, 13, minZ + 0.05, minZ + MAGNET_DEPTH - 0.05),
+          `pocket at x=${x}`
+        ).toBe(false);
+      }
+    } finally {
+      withMagnet.feet.forEach((f) => f.delete());
+      withMagnet.pinHoles?.delete();
+    }
+  });
+
   it('leaves a plain foot solid where a magnet pocket would be', () => {
     const { feet, pinHoles } = feetOf();
     try {

--- a/src/features/generation/worker/generators/detachableFeetBuilder.ts
+++ b/src/features/generation/worker/generators/detachableFeetBuilder.ts
@@ -104,12 +104,16 @@ function coveredCorners(
   centre: { x: number; y: number },
   armMm: number
 ): Array<readonly [number, number]> {
-  // Bounds mirror `buildClip`'s footprint per axis, not the cell's: a centred
+  // Bounds mirror `buildClip`'s footprint per axis, not the cell's: a CENTRED
   // interior filler is only `armMm` wide across its spanned axis, so testing
   // against the CELL would claim all four corners and drill attachment bores
-  // through the floor where no foot stands beneath them.
-  const halfX = p.dirX === 0 && p.interiorX ? armMm / 2 : p.cellW / 2;
-  const halfY = p.dirY === 0 && p.interiorY ? armMm / 2 : p.cellD / 2;
+  // through the floor where no foot stands beneath them. The narrow bound
+  // applies to the centred fall-through cases ONLY, in `buildClip`'s own
+  // order — an edge bar that happens to sit on an interior station of the
+  // other axis still spans its full cell there and keeps its corners.
+  const centred = p.dirX === 0 && p.dirY === 0;
+  const halfX = centred && p.interiorX ? armMm / 2 : p.cellW / 2;
+  const halfY = centred && !p.interiorX && p.interiorY ? armMm / 2 : p.cellD / 2;
   return positions.filter(([mx, my]) => {
     const inX = p.dirX === 0 || Math.sign(mx - centre.x) === p.dirX;
     const inY = p.dirY === 0 || Math.sign(my - centre.y) === p.dirY;

--- a/src/features/supporters/components/SupportersPage/SupportersPage.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.tsx
@@ -227,7 +227,10 @@ export function SupportersPage() {
     async (patch: SupporterProfilePatch) => {
       const prevName = supporter.status.name;
       const error = await supporter.save(patch);
-      if (error === null) setProfileEdit({ prevName });
+      // Keep the ORIGINAL handle across repeated renames: after the first
+      // save `status.name` is already the new name, which the public list
+      // has never carried — recording it would strand the overlay.
+      if (error === null) setProfileEdit((prev) => prev ?? { prevName });
       return error;
     },
     [supporter]
@@ -242,13 +245,14 @@ export function SupportersPage() {
       profileEdit.prevName !== null
         ? records.findIndex((r) => r.name === profileEdit.prevName)
         : records.findIndex((r) => r.name === null);
-    const patched = {
-      ...(idx >= 0 ? records[idx] : {}),
+    // Renames an existing record, never adds one: a push would double the
+    // user's bin on the wall while the headline count reads the raw list.
+    if (idx < 0) return supporters;
+    records[idx] = {
+      ...records[idx],
       name: status.name,
       ...(status.message ? { message: status.message } : { message: undefined }),
     };
-    if (idx >= 0) records[idx] = patched;
-    else records.push(patched);
     return { ...supporters, supporters: records };
   }, [supporters, supporter.status, profileEdit]);
   const bins = useMemo(() => buildSupporterBins(effectiveSupporters), [effectiveSupporters]);

--- a/src/shared/utils/fractionalEdge.test.ts
+++ b/src/shared/utils/fractionalEdge.test.ts
@@ -304,6 +304,16 @@ describe('foot lattice placement (#3467)', () => {
       ).toEqual({});
     });
 
+    // Half sockets only seat at either offset while the SOCKET is built —
+    // detachable feet never build one, and the plan reads the lattice.
+    it('still matches a half-socket design whose feet detach', () => {
+      expect(
+        computeMatchedFootLattice(design({ halfSockets: true, detachableFeet: true }), drawer, [
+          { x: 0.5, y: 0 },
+        ])
+      ).toEqual({ footLatticeX: 'half', footLatticeY: 'grid' });
+    });
+
     it('is empty for a custom shape — the generator pins it to the grid', () => {
       expect(
         computeMatchedFootLattice(design({ hasCellMask: true }), drawer, [{ x: 0.5, y: 0.5 }])

--- a/src/shared/utils/fractionalEdge.ts
+++ b/src/shared/utils/fractionalEdge.ts
@@ -39,6 +39,12 @@ export interface FractionalEdgeDesign {
    * on a uniform array). Warning about it would be noise.
    */
   readonly halfSockets?: boolean;
+  /**
+   * Detachable-feet mode, if known. It cancels the half-socket exemption:
+   * the socket is never built, and the feet plan reads the lattice whatever
+   * `halfSockets` stores.
+   */
+  readonly detachableFeet?: boolean;
   /** Foot lattice per axis. Missing = `'grid'`, the documented default. */
   readonly footLatticeX?: FootLattice;
   readonly footLatticeY?: FootLattice;
@@ -251,7 +257,11 @@ export function computeMatchedFootLattice(
   drawer: FractionalEdgeDrawer,
   placements: readonly FractionalEdgePlacement[]
 ): FootLatticePatch {
-  if (design.halfSockets || design.hasCellMask) return {};
+  // Half sockets seat at either offset ONLY when the socket is actually
+  // built: with detachable feet the socket never is, the plan reads the
+  // lattice regardless (`resolveDetachableFeet`), and skipping here closed
+  // the one auto-repair for a half-offset detachable bin.
+  if ((design.halfSockets && design.detachableFeet !== true) || design.hasCellMask) return {};
 
   const axis = (
     size: number,

--- a/src/shared/utils/heightUnits.ts
+++ b/src/shared/utils/heightUnits.ts
@@ -55,7 +55,7 @@ export function stackedTotalMm(heightUnits: number, heightUnitMm: number, count:
  * The tallest WHOLE-unit bin height that lets `count` identical bins stack
  * under `ceilingMm`, at the layout's existing `heightUnitMm`.
  *
- * The inverse of {@link solveHeightUnitMm} for the question users actually
+ * The inverse of {@link stackedTotalMm} for the question users actually
  * ask: not "what unit fills this exactly" — which yields a non-standard unit
  * and breaks compatibility with stock bins — but "how tall can my bins be and
  * still let the lid close". Returns null when even a 1u bin overflows.


### PR DESCRIPTION
Iteration 3 of the retroactive bug hunt ran two probes: a sampling review of the #3414–#3473 tranche, and an adversarial fresh-eyes pass over the loop's own ten merged fix PRs. Both yielded — every finding is a seam where a later feature met an invariant an older comment still asserted (or a fix met a case its own reviewer missed).

## Tranche seams

- **A grouped Repeat master built ONE pocket while every other layer counts N (P1).** The partition comment claimed array masters are "always ungrouped", but nothing enforces it: grouping is reachable from the header, the context menu and Ctrl+G with the array intact, and `buildGroupedCutouts` never expanded it — so the editor drew six pockets, the fit-test card cut six, the estimate charged six, and the exported bin had one. Grouped members now expand into their instances exactly as the ungrouped path does; a new volume differential (`single − repeated > 800mm³`) fails pre-fix.
- **Linked corner radii were invisible to screw placement (P1).** The screw plan read raw `params.cornerRadii`, populated only by the unlinked per-corner mode; the linked slider writes the scalar. A uniform 25mm corner therefore kept its margin screw at the square-corner position — 2.4mm outside the plate the arc actually cut, head disc entirely in air. The generator now resolves radii once, above the plan, and the rounding cut and the containment test read the same numbers (both build paths; regression test pins linked-vs-square siting).
- **The slab-with-pockets cache served stale pockets across radius edits.** `cornerRadii`, `magnetAnchor` and `magnetDiameter` all move the per-cell screw-floor decision since #3428, and none were in the key — raising the radius reused the through-cut slab and the screw cutters hit air. Keyed now (screw plates only), and both comments still claiming radius independence are corrected.
- **Half sockets hid the foot lattice under detachable feet.** The lock (and the mismatch auto-repair's short-circuit) assumed the socket seats the bin; with detachable feet no socket is built and the plan reads the lattice regardless — so the one control that seats a half-offset detachable bin was hidden and the repair never fired. Both now exempt the detachable mode.

## Fresh-eyes findings on this loop's own fixes

- **My `coveredCorners` bound over-corrected (P1):** an edge bar crossing an interior station (any 4×2 magnet bin) takes the full-cell `edgeY` clip, but the new bound shrank X to the arm's width and shipped those feet with no magnet pockets or screw bores. The narrow bound now applies to the centred fall-through cases only, in `buildClip`'s own order — with a kernel case for the interior-station bar the suite never had.
- **The supporters overlay duplicated a bin on a second rename (P1):** `prevName` captured at save time is already the new name after the first save, so the second edit missed and pushed. The overlay now keeps the original handle and only ever renames.
- **The socket ghost followed drags at 2× on the anchor's gap axis** (a band midpoint moves at half the cutout's rate); it now recomputes the placement through the plan's own anchor math.
- The orphaned `{@link solveHeightUnitMm}` doc reference.

## Verification

Differential + kernel + unit coverage for each fix (paramDifferential 4, detachableFeet.kernel 19, baseplateDirectMesh 38, fractionalEdge 40, BaseSection/supporters suites green); typecheck, lint, boundaries green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

