### PR TITLE
fix(generation): key every cache on what its builder actually reads

### DIFF
--- a/src/features/generation/worker/generators/labelTabBuilder.cacheKey.test.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.cacheKey.test.ts
@@ -28,6 +28,24 @@ function withCompartments(partial: Partial<BinParams['compartments']>): BinParam
 }
 
 describe('labelTabsFeature.cacheKey', () => {
+  // The shelf datum follows the lid: `labelShelfKeepoutMm` sinks it under an
+  // interior-relieving (or sliding) lid. A key without that input served the
+  // un-sunk shelf after the lid toggled on, and the relief ring then cut
+  // straight through the shelf's wall weld.
+  it('changes when the lid the shelf must duck under toggles', () => {
+    const base = withCompartments({});
+    const lidded: BinParams = {
+      ...base,
+      base: { ...base.base, stackingLip: true },
+      lid: { ...base.lid, enabled: true },
+    };
+    const lidless: BinParams = {
+      ...lidded,
+      lid: { ...lidded.lid, enabled: false },
+    };
+    expect(keyFor(lidded)).not.toBe(keyFor(lidless));
+  });
+
   it('changes when divider thickness changes', () => {
     // Thickness drives gusset width and per-group divider deductions (and
     // the discrete socket plate width); a thickness-only edit must never

--- a/src/features/generation/worker/generators/labelTabBuilder.ts
+++ b/src/features/generation/worker/generators/labelTabBuilder.ts
@@ -5,6 +5,7 @@
  * at the back edge of each compartment.
  */
 
+import { labelShelfKeepoutMm } from '@/shared/utils/lidInteriorRelief';
 import {
   box,
   draw,
@@ -1015,6 +1016,10 @@ export const labelTabsFeature: FeatureBuilder = {
         : 'text';
     return compactKey(
       buildCacheKey(
+        // `v12`: the shelf datum follows the lid — `labelShelfKeepoutMm`
+        // sinks it under an interior-relieving or sliding lid — so the key
+        // carries that keepout. Without it, toggling the lid served a shelf
+        // on the old plane and the relief ring cut through its wall weld.
         // `v11`: tab spans follow `dividerOverrides` instead of the nominal
         // grid line, so any shifted-divider design cuts a different shelf.
         // `v10`: tab text sizes against glyph ink and shares one size per
@@ -1028,9 +1033,11 @@ export const labelTabsFeature: FeatureBuilder = {
         // `v5`: extrudes the shelf COPLANAR_OVERLAP proud (geometry +
         // face tags changed), so older IndexedDB entries must be invalidated.
         // `v4`: added `edges` + `inset` to LabelTabConfig.
-        'v11',
+        'v12',
         socketKeyPart,
         dim.shellKey,
+        // The one lid-derived number the shelf geometry consumes.
+        quantize(labelShelfKeepoutMm(params)),
         stableSerialize(params.label),
         quantize(dim.innerW),
         quantize(dim.innerD),

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -12,6 +12,7 @@ import {
   resolveTileFloorThickness,
 } from '@/shared/types/bin';
 import { hashMask, isPartialMask } from '@/shared/utils/cellMask';
+import { isFractional } from '@/core/constants';
 import { resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import {
   HEIGHT_UNIT,
@@ -359,7 +360,17 @@ export function deriveDimensions(params: BinParams, _forExport: boolean): BinDim
       // Shell-baked dividers get clipped where a spanning label shelf crosses
       // them, so that clip is part of the shell. Appended only when it
       // applies, keeping every other bin's v7 key byte-identical.
-      ...(spanningClipKey ? [`spanclip${spanningClipKey}`] : [])
+      ...(spanningClipKey ? [`spanclip${spanningClipKey}`] : []),
+      // A fractional axis reverses the cell run for a 'start' edge, moving
+      // every lite floor opening half a unit — and those openings are cut
+      // into the cached body. The socket key has always carried this; the
+      // shell key has to agree, or a second design on the other edge reuses
+      // a body whose openings land on the webbing. Appended only when a
+      // fractional axis exists, keeping whole-unit keys byte-identical.
+      ...((isFractional(params.width) || isFractional(params.depth)) &&
+      (params.fractionalEdgeX !== 'end' || params.fractionalEdgeY !== 'end')
+        ? [`frac:${params.fractionalEdgeX}:${params.fractionalEdgeY}`]
+        : [])
     )
   );
 

--- a/src/features/generation/worker/generators/shapeCache.ts
+++ b/src/features/generation/worker/generators/shapeCache.ts
@@ -152,15 +152,20 @@ export function socketCacheKey(
   // for a non-square grid so square keys stay byte-identical.
   const pitch = resolvePitch(gridUnitMm);
   const pitchSegments = pitchKeySegments(pitch, quantize);
-  // Legacy 'center' anchor only shifts magnet holes on a grid larger than the
-  // standard 42mm and only when magnets are cut; otherwise it's byte-identical
-  // to 'edge', so append the segment only then — existing 'edge'/≤42mm keys stay
-  // stable and no cache is needlessly invalidated. Check BOTH axes: an
-  // anisotropic bin grid (e.g. 42×50) shifts only the Y magnets under 'center',
-  // so keying on pitch.x alone would collide edge/center and reuse wrong geometry.
+  // Legacy 'center' anchor only shifts the attachment bores on a grid larger
+  // than the standard 42mm, and only when SOME bore is cut — magnets or
+  // screws, which share the same anchor-derived positions
+  // (`magnetPositionsForCell` has no magnet gate). Otherwise it's
+  // byte-identical to 'edge', so append the segment only then — existing
+  // 'edge'/≤42mm keys stay stable and no cache is needlessly invalidated.
+  // Check BOTH axes: an anisotropic bin grid (e.g. 42×50) shifts only the Y
+  // bores under 'center', so keying on pitch.x alone would collide
+  // edge/center and reuse wrong geometry.
   const standardPitch = GRIDFINITY.GRID_SIZE;
   const anchorSegments =
-    anchor === 'center' && withMagnet && (pitch.x > standardPitch || pitch.y > standardPitch)
+    anchor === 'center' &&
+    (withMagnet || withScrew) &&
+    (pitch.x > standardPitch || pitch.y > standardPitch)
       ? ['anchor:center']
       : [];
   return compactKey(

--- a/src/features/generation/worker/generators/wallPatternBuilder.cache.test.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.cache.test.ts
@@ -94,6 +94,24 @@ describe('wallPatternBuilder cache split', () => {
     ).toBe(4);
   }, 60_000);
 
+  it('rebuilds the clipped pattern when a cutout corner radius changes', () => {
+    // The radius reshapes the clip solid's flared top; a key without it served
+    // the square-corner clip and left hex prisms standing in the flare
+    // (gotcha 5's jagged edges, one slider drag away).
+    const generateBin = getGenerateBin();
+
+    generateBin(HONEYCOMB_2x2x4);
+    resetAllShapeCacheStats();
+    generateBin({
+      ...HONEYCOMB_2x2x4,
+      walls: { ...HONEYCOMB_2x2x4.walls, cornerRadiusTop: 8 },
+    });
+
+    const clipped = getStats('feature-wallPatternClipped');
+    expect(clipped.hits, 'a radius edit must not reuse the square-corner clip').toBe(0);
+    expect(clipped.misses, 'a radius edit must rebuild the clipped result per wall').toBe(4);
+  }, 60_000);
+
   it('reuses the fully-clipped cache when nothing changes', () => {
     const generateBin = getGenerateBin();
 

--- a/src/features/generation/worker/generators/wallPatternBuilder.ts
+++ b/src/features/generation/worker/generators/wallPatternBuilder.ts
@@ -357,6 +357,12 @@ export function computeWallClips(
     }
   }
 
+  // The same resolver call the clip solid consumes (line above), so the key
+  // and the geometry read one answer — a corner-radius edit reshapes the
+  // clip's flared top, and a key without the radii served the square-corner
+  // clip and left pattern prisms standing in the flare (gotcha 5's jagged
+  // edges, one slider drag away).
+  const clipRadii = clip?.radii;
   const cutoutKeyPart = cutoutCfg?.enabled
     ? buildCacheKey(
         'clip',
@@ -366,6 +372,8 @@ export function computeWallClips(
         quantize(cutoutCfg.depth),
         cutoutCfg.alignment,
         quantize(cutoutCfg.offset),
+        quantize(clipRadii?.top ?? 0),
+        quantize(clipRadii?.bottom ?? 0),
         hasLip,
         quantize(params.compartments.thickness),
         quantize(params.wallThickness)


### PR DESCRIPTION
The retroactive bug hunt's final convergence probe swept all 34 cache-key sites against what their builders transitively consume. Four omissions survived verification — one class throughout: a feature's inputs grew and its key did not follow.

## Fixes

- **Label-tab cache blind to the lid (P0).** The shelf datum is a function of the lid — `labelShelfKeepoutMm` sinks it under an interior-relieving or sliding lid — but neither the feature key nor `shellKey` carried any lid input. Toggling the lid on served the un-sunk shelf from the module-level LRU, and `lidInteriorReliefStage` then cut its ring 4.15mm deep straight through the shelf's wall weld — precisely the outcome the sink exists to prevent — while the spanning divider clips (which ARE keyed on the shelf plane) moved without it. The key now carries the quantized keepout (v12), with the perturbation test the suite lacked.
- **Wall-pattern clips blind to cutout corner radii (P1).** The clip solid's top edge flares by the resolved radii, but the clip key carried none — so a corner-radius drag rebuilt the hole while serving the square-corner clip, leaving hex prisms standing in the flare (gotcha 5's jagged edges, one slider away). The radii the clip itself resolves now join its key; a cache-stats test pins that a radius edit misses.
- **Socket key's anchor segment gated on magnets only (P2).** Screws share the same anchor-derived positions (`magnetPositionsForCell` has no magnet gate), so a screw-only bin on a >42mm grid collided the `edge`/`center` variants and served whichever built first. Gated on either bore, comment corrected.
- **`shellKey` omitted the fractional edges (P2).** A `'start'` edge reverses the cell run and moves every lite floor opening half a unit — openings that are cut into the cached body. The socket key has always carried this; the shell key now agrees (appended only when a fractional axis exists, keeping whole-unit keys stable).

## Verification

labelTab cacheKey (5, incl. the new lid case), wallPatternBuilder.cache (3, incl. the radius-miss case, kernel-backed), shapeCache + context suites (58); typecheck and lint green.

## Hunt status

This is the closing PR of the loop. The probe's verdict: 34 key sites examined, 4 defective, the recently hardened families clean — converged. A worthwhile follow-up (not in this PR): a shared discipline test asserting, per `FeatureBuilder`, that perturbing each params sub-object its build reads changes its `cacheKey` — that retires this defect class instead of re-sweeping it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

