### PR TITLE
fix(generation): place a split bin's stacking lip on the collar-raised rim

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-lip-trim.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-lip-trim.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { DEFAULT_BIN_PARAMS, GRIDFINITY } from '@/shared/constants/bin';
 import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
 import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
-import { initBrepjs, getGenerateSplitPreview } from './__kernel-tests__/wasmInit';
+import { initBrepjs, getGenerateBin, getGenerateSplitPreview } from './__kernel-tests__/wasmInit';
 import { boundingBox } from './__kernel-tests__/meshAssertions';
 
 beforeAll(async () => {
@@ -299,4 +299,57 @@ describe('stacking lip on split pieces', () => {
       expect(degenerateCount).toBeLessThan(MAX_DEGENERATE_TRIANGLES);
     }
   }, 60000);
+});
+
+// ─── Regression: exterior-wall collar ───────────────────────────────────────
+
+describe('stacking lip on split pieces of a collared bin', () => {
+  const COLLAR_MM = 15;
+
+  // A collar raises the rim by a different amount on each base — a socketed bin
+  // subtracts the socket from `wallHeight`, a flat one does not — so the fix has
+  // to come from the derived rim rather than from any one base's arithmetic.
+  it.each([
+    { label: 'standard base', style: 'standard' as const },
+    { label: 'flat base', style: 'flat' as const },
+  ])(
+    'places the lip at the same height as the unsplit bin ($label)',
+    ({ style }) => {
+      const params: BinParams = {
+        ...DEFAULT_BIN_PARAMS,
+        width: 6,
+        depth: 1,
+        height: 3,
+        extraWallHeightMm: COLLAR_MM,
+        base: { ...DEFAULT_BIN_PARAMS.base, style },
+      };
+
+      // Stated as a delta against the same bin generated whole: the collar moves
+      // the rim, so a hardcoded Z here would just be a second copy of the
+      // arithmetic under test. The split path built its lip from `baseOffsetZ +
+      // wallHeight + tileFloorHeight`, which omits the collar — the lip landed
+      // COLLAR_MM down the outside of the wall and the piece's top face became
+      // the bare wall it should have been sitting on.
+      const whole = getGenerateBin()(params);
+      const split = getGenerateSplitPreview()(params, [0], [], DISABLED_CONNECTORS);
+      expect(split.pieces).toHaveLength(2);
+
+      const wholeTopZ = maxZ(whole.vertices);
+      for (const piece of split.pieces) {
+        expect(Math.abs(maxZ(piece.vertices) - wholeTopZ)).toBeLessThan(TESS_TOL);
+      }
+    },
+    120000
+  );
+
+  it('leaves an uncollared split unchanged', () => {
+    const params: BinParams = { ...DEFAULT_BIN_PARAMS, width: 6, depth: 1, height: 3 };
+    const whole = getGenerateBin()(params);
+    const split = getGenerateSplitPreview()(params, [0], [], DISABLED_CONNECTORS);
+
+    const wholeTopZ = maxZ(whole.vertices);
+    for (const piece of split.pieces) {
+      expect(Math.abs(maxZ(piece.vertices) - wholeTopZ)).toBeLessThan(TESS_TOL);
+    }
+  }, 120000);
 });

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -225,15 +225,20 @@ function splitSolidIntoPieces(
   const totalHeight = splitDims.totalHeight;
   const wallHeight = splitDims.wallHeight;
   const floorZ = splitDims.baseOffsetZ;
-  const wallTopZ = floorZ + wallHeight + splitDims.tileFloorHeight;
+  // Read, never restated: `baseOffsetZ + wallHeight + tileFloorHeight` looks
+  // like the rim and is one term short of it, because an `extraWallHeightMm`
+  // collar raises the outer box and the lip together while `wallHeight` stays
+  // nominal. The lip built at that Z fuses a collar's worth down the OUTSIDE of
+  // the wall, leaving the piece's top face bare — a split bin that cannot stack.
+  const wallTopZ = splitDims.wallTopZ;
   // Z extent a split piece of the body should retain. The body spans 0..wallTopZ,
-  // which equals `totalHeight` for socketed and flat bases, EXCEEDS it for a tray
-  // bottom (the skirt adds depth below the floor), and is far SHORTER for a
-  // base-only bin, whose wall is zero and whose body is the feet plus a
-  // `wallThickness` floor slab. Taking the lower of the two measures the
-  // base-only bin against its real body while leaving every other base on the
-  // exact threshold it had.
-  const expectedBodyZ = Math.min(totalHeight, wallTopZ);
+  // which equals `totalHeight` plus the collar for socketed and flat bases,
+  // EXCEEDS it for a tray bottom (the skirt adds depth below the floor), and is
+  // far SHORTER for a base-only bin, whose wall is zero and whose body is the
+  // feet plus a `wallThickness` floor slab. Taking the lower of the two measures
+  // the base-only bin against its real body while leaving every other base on
+  // the exact threshold it had.
+  const expectedBodyZ = Math.min(totalHeight + splitDims.collarHeight, wallTopZ);
 
   // An overhang grows the outer body past the nominal grid footprint;
   // both the lip and the outermost cutting boxes must track it. Suppressed for


### PR DESCRIPTION
Fixes #3615.

An `extraWallHeightMm` collar raises the outer box and the stacking lip together, but `splitBinBuilder` rebuilt the rim from parts as `baseOffsetZ + wallHeight + tileFloorHeight` — one term short of `dimensions.wallTopZ`. The separately-built lip solid fused a collar's worth down the *outside* of the wall, so each split piece topped out at the bare wall and could not stack.

On the reported design (6x1x3, 15mm collar) the whole bin reaches Z=40.3mm and every split piece stopped at 36.0mm — exactly `LIP_HEIGHT - LIP_OVERLAP` short.

## Change

- `wallTopZ` reads `splitDims.wallTopZ` rather than restating the chain. This also corrects the lip's slot-notch datum and the split connectors' `BinGeometryContext`, both of which were anchored to the same value.
- The lost-geometry guard measures against `totalHeight + collarHeight`, so a collared bin is graded on its real body rather than a short one.

## Tests

`binGenerator.scenario.split-lip-trim.test.ts` gains a collar group stated as a **delta against the same bin generated whole**, so no rim Z is hardcoded (that would just be a second copy of the arithmetic under test). Covers a socketed and a flat base, because the collar reaches the rim through a different `wallHeight` on each, plus an uncollared control that pins the unchanged path.

Both collar cases failed by 4.30mm before the fix; the control passed. All 107 tests across the 17 `binGenerator.scenario.split*` files pass after.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

