### PR TITLE
fix(baseplate): draw the split mini-map in millimetres, on one shared box

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseplatePanel.tsx
@@ -43,7 +43,8 @@ export function BaseplatePanel() {
     (state) => (state.layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS).stackPrint
   );
   const printBedSize = useLayoutStore((state) => state.layout.printBedSize);
-  const { effectiveFractionalEdgeX, effectiveFractionalEdgeY } = useBaseplatePanelDerived();
+  const { effectiveFractionalEdgeX, effectiveFractionalEdgeY, gridUnitMm, gridUnitMmY } =
+    useBaseplatePanelDerived();
 
   const { tiling, hoveredPieceLabel, selectedPieceLabel } = useBaseplatePageStore(
     useShallow((s) => ({
@@ -96,6 +97,8 @@ export function BaseplatePanel() {
             onHoverPiece={setHoveredPieceLabel}
             onSelectPiece={setSelectedPieceLabel}
             printBedSize={printBedSize}
+            gridUnitMm={gridUnitMm}
+            gridUnitMmY={gridUnitMmY}
             fractionalEdgeX={effectiveFractionalEdgeX}
             fractionalEdgeY={effectiveFractionalEdgeY}
             onChangeSplit={setSplitOverride}

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.test.tsx
@@ -72,6 +72,8 @@ describe('SplitViewStrip', () => {
     onHoverPiece: vi.fn(),
     onSelectPiece: vi.fn(),
     printBedSize: 256,
+    gridUnitMm: 42,
+    gridUnitMmY: 42,
     fractionalEdgeX: 'end' as const,
     fractionalEdgeY: 'end' as const,
     onChangeSplit: vi.fn(),
@@ -231,6 +233,61 @@ describe('SplitViewStrip', () => {
       render(<SplitViewStrip {...defaultProps} tiling={overBed} />);
       expect(screen.getByText('A1')).toHaveAttribute('aria-label', 'baseplate.pieceLabelOverBed');
       expect(screen.getByText('B1')).toHaveAttribute('aria-label', 'baseplate.pieceLabel');
+    });
+  });
+
+  // The map used to lay out its tracks in grid UNITS while padding is mm on the
+  // outermost pieces, so a padded plate's edge tracks were drawn the same width
+  // as its interior ones and every seam sat at the wrong fraction of the plate.
+  describe('padded plate', () => {
+    const paddedTiling: BaseplateTiling = {
+      ...baseTiling,
+      cols: 3,
+      colSizes: [3, 3, 3],
+      totalWidthUnits: 9,
+      pieces: [
+        { ...baseTiling.pieces[0], label: 'A1', col: 0, widthUnits: 3, paddingLeft: 20 },
+        { ...baseTiling.pieces[1], label: 'B1', col: 1, widthUnits: 3, gridOffsetX: 3 },
+        {
+          ...baseTiling.pieces[1],
+          label: 'C1',
+          col: 2,
+          widthUnits: 3,
+          gridOffsetX: 6,
+          paddingRight: 8,
+        },
+      ],
+    };
+
+    function mapGrid(): HTMLElement {
+      const view = screen.getByLabelText('baseplate.sectionView');
+      const grid = view.firstElementChild;
+      if (!(grid instanceof HTMLElement)) throw new Error('map grid not found');
+      return grid;
+    }
+
+    it('sizes the outer tracks by their real millimetres', () => {
+      render(<SplitViewStrip {...defaultProps} tiling={paddedTiling} />);
+      expect(mapGrid().style.gridTemplateColumns).toBe('146fr 126fr 134fr');
+    });
+
+    it('draws the seams and their ruler ticks at the same fraction of the plate', () => {
+      render(<SplitViewStrip {...defaultProps} tiling={paddedTiling} />);
+      // 20mm padding + 3 units of 42mm, over a 406mm plate.
+      const expected = `${(146 / 406) * 100}%`;
+      const seamLine = mapGrid().parentElement?.querySelector<HTMLElement>('span.bg-accent');
+      expect(seamLine?.style.left).toBe(expected);
+      const tick = lanes('Vertical').find((b) => b.getAttribute('aria-pressed') === 'true');
+      expect(tick?.style.left).toBe(expected);
+    });
+
+    it('gives the column ruler the same box as the map, so the two cannot drift', () => {
+      render(<SplitViewStrip {...defaultProps} tiling={paddedTiling} />);
+      const ruler = lanes('Vertical')[0].parentElement;
+      expect(ruler).toBeInstanceOf(HTMLElement);
+      const view = screen.getByLabelText('baseplate.sectionView');
+      expect((ruler as HTMLElement).style.width).toBe(view.style.width);
+      expect(view.style.width).not.toBe('');
     });
   });
 });

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
@@ -2,8 +2,15 @@
  * Non-collapsible inline strip showing the split-baseplate piece mini-map, and
  * the editor for user-drawn split lines.
  *
- * The map is proportional: each piece region's grid track is sized by its real
- * unit span, so the mini-map reads as the plate rather than as a uniform table.
+ * The map is proportional in MILLIMETRES, not units: padding is mm carried by
+ * the outermost pieces only, so a padded plate's first and last tracks are
+ * genuinely wider than the rest. Sizing tracks by unit span drew them equal and
+ * put every seam at the wrong fraction of the plate (`splitMapLayout`).
+ *
+ * The aspect-fitted box is also the positioning context for the ruler ticks and
+ * the drawn seams. It has to be: `aspect-ratio` transfers a height cap into a
+ * width cap, so the map shrinks inside its grid area, and anything positioned
+ * as a percentage of the AREA instead lands wide of the track it marks.
  *
  * Cuts are placed from two rulers flanking the map (one tick per legal offset)
  * rather than from lanes drawn across it. Crossing sets of full-span hit
@@ -28,10 +35,22 @@ import {
   splitOverrideFromSeams,
   toggleSeam,
 } from '../../utils/splitOverride';
+import { seamFraction, splitMapLayout } from '../../utils/splitMapLayout';
 import type { BaseplateTiling, PaddingReductionHint } from '../../types/tiling';
 
 /** Seam offsets are half-unit-quantized; this only absorbs float drift. */
 const SEAM_EPSILON = 1e-6;
+
+/** Tallest the map may be, in rem — the width cap is derived from it. */
+const MAP_MAX_HEIGHT_REM = 14;
+
+/**
+ * How lopsided the map's own box may get. The tracks and seams stay true to the
+ * plate either way (they are fractions of the box, whatever its shape); this
+ * only stops a 20:1 plate rendering as an unreadable sliver, or as a strip so
+ * tall it pushes the rest of the panel off screen.
+ */
+const MAP_MAX_ASPECT = 6;
 
 const PADDING_HINT_AXIS_KEYS: Record<PaddingReductionHint['axis'], string> = {
   x: 'baseplate.paddingHintAxisX',
@@ -46,6 +65,8 @@ interface SplitViewStripProps {
   readonly onHoverPiece: (label: string | null) => void;
   readonly onSelectPiece: (label: string | null) => void;
   readonly printBedSize: number;
+  readonly gridUnitMm: number;
+  readonly gridUnitMmY: number;
   readonly fractionalEdgeX: FractionalEdge;
   readonly fractionalEdgeY: FractionalEdge;
   readonly onChangeSplit: (override: SplitOverride | undefined) => void;
@@ -58,6 +79,8 @@ export function SplitViewStrip({
   onHoverPiece,
   onSelectPiece,
   printBedSize,
+  gridUnitMm,
+  gridUnitMmY,
   fractionalEdgeX,
   fractionalEdgeY,
   onChangeSplit,
@@ -69,6 +92,17 @@ export function SplitViewStrip({
   const rowSeams = chunksToSeams(rowSizes);
   const colLanes = seamPositions(totalWidthUnits, fractionalEdgeX);
   const rowLanes = seamPositions(totalDepthUnits, fractionalEdgeY);
+
+  const map = splitMapLayout(tiling, gridUnitMm, gridUnitMmY);
+  const leftPercent = (offset: number): string =>
+    `${seamFraction(offset, gridUnitMm, map.padLeftMm, map.widthMm) * 100}%`;
+  const bottomPercent = (offset: number): string =>
+    `${seamFraction(offset, gridUnitMmY, map.padFrontMm, map.depthMm) * 100}%`;
+
+  // One box, shared by the map, both rulers and the seam overlay, so a
+  // percentage means the same place in all four.
+  const aspect = Math.min(MAP_MAX_ASPECT, Math.max(1 / MAP_MAX_ASPECT, map.widthMm / map.depthMm));
+  const mapBoxStyle = { width: `min(100%, ${MAP_MAX_HEIGHT_REM * aspect}rem)` } as const;
 
   const overageByLabel = new Map(tiling.bedOverages.map((o) => [o.label, o]));
   // Set, not a `pieces.some()` per cell: the map renders cols x rows cells and a
@@ -136,7 +170,7 @@ export function SplitViewStrip({
       <div className="grid grid-cols-[0.75rem_1fr] grid-rows-[0.75rem_1fr] gap-0.5 px-4 pb-2">
         <div aria-hidden="true" />
 
-        <div className="relative h-3">
+        <div className="relative h-3" style={mapBoxStyle}>
           {colLanes.map((offset) => {
             const active = colSeams.some((s) => Math.abs(s - offset) < SEAM_EPSILON);
             return (
@@ -148,7 +182,7 @@ export function SplitViewStrip({
                 className={`absolute top-0 !h-3 w-4 !min-w-0 -translate-x-1/2 rounded-none border-0 !px-0 !py-0 ${
                   active ? 'text-accent' : 'text-stroke-subtle hover:text-content-tertiary'
                 }`}
-                style={{ left: `${(offset / totalWidthUnits) * 100}%` }}
+                style={{ left: leftPercent(offset) }}
                 onClick={() => applySeams(toggleSeam(colSeams, offset), rowSeams)}
                 aria-pressed={active}
                 aria-label={t('baseplate.splitSeamVertical', { position: offset })}
@@ -176,7 +210,7 @@ export function SplitViewStrip({
                 }`}
                 // Offsets measure from the plate FRONT while the map draws front
                 // at the bottom, so the tick is positioned from the bottom edge.
-                style={{ bottom: `${(offset / totalDepthUnits) * 100}%` }}
+                style={{ bottom: bottomPercent(offset) }}
                 onClick={() => applySeams(colSeams, toggleSeam(rowSeams, offset))}
                 aria-pressed={active}
                 aria-label={t('baseplate.splitSeamHorizontal', { position: offset })}
@@ -190,25 +224,29 @@ export function SplitViewStrip({
           })}
         </div>
 
-        <div className="relative" aria-label={t('baseplate.sectionView')}>
+        <div
+          className="relative"
+          aria-label={t('baseplate.sectionView')}
+          // The aspect ratio lives HERE, on the box the ruler ticks and the seam
+          // overlay measure against, not on the grid inside it. On the grid it
+          // transferred the height cap into a width cap, leaving the map
+          // narrower than its own positioning context — which is what put the
+          // drawn seams a whole column away from the tracks they mark.
+          style={{ ...mapBoxStyle, aspectRatio: `${aspect}` }}
+        >
           <div
             // No gap: the ruler ticks and the drawn seam lines are positioned as
             // a percentage of this same box, so any gutter would offset every
             // line from the boundary it marks.
-            className="grid max-h-56 min-h-16"
+            className="grid h-full w-full"
             style={{
-              // `fr` rows only distribute proportionally against a definite
-              // height, which an auto-height grid does not have — without this
-              // every row would collapse to its content and a 1-unit row would
-              // look the same as a 6-unit one.
-              aspectRatio: `${totalWidthUnits} / ${totalDepthUnits}`,
-              gridTemplateColumns: colSizes.map((s) => `${s}fr`).join(' '),
+              gridTemplateColumns: map.colMm.map((mm) => `${mm}fr`).join(' '),
               // Row 1 is the front of the plate, which reads as the BOTTOM of a
               // top-down map — so the tracks are emitted back-to-front and each
               // piece is placed by explicit row index rather than in DOM order.
-              gridTemplateRows: [...rowSizes]
+              gridTemplateRows: [...map.rowMm]
                 .reverse()
-                .map((s) => `${s}fr`)
+                .map((mm) => `${mm}fr`)
                 .join(' '),
             }}
           >
@@ -270,14 +308,14 @@ export function SplitViewStrip({
               <span
                 key={`line-col-${offset}`}
                 className="absolute top-0 bottom-0 w-0.5 -translate-x-1/2 rounded-full bg-accent"
-                style={{ left: `${(offset / totalWidthUnits) * 100}%` }}
+                style={{ left: leftPercent(offset) }}
               />
             ))}
             {rowSeams.map((offset) => (
               <span
                 key={`line-row-${offset}`}
                 className="absolute right-0 left-0 h-0.5 translate-y-1/2 rounded-full bg-accent"
-                style={{ bottom: `${(offset / totalDepthUnits) * 100}%` }}
+                style={{ bottom: bottomPercent(offset) }}
               />
             ))}
           </div>

--- a/src/features/baseplate/utils/splitMapLayout.test.ts
+++ b/src/features/baseplate/utils/splitMapLayout.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { BaseplatePiece, BaseplateTiling } from '../types/tiling';
+import { seamFraction, splitMapLayout } from './splitMapLayout';
+
+const PIECE_DEFAULTS = {
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingFront: 0,
+  paddingBack: 0,
+  fractionalEdgeX: 'none',
+  fractionalEdgeY: 'none',
+  edges: { left: 'exterior', right: 'exterior', front: 'exterior', back: 'exterior' },
+  placementRotationDeg: 0,
+} as const;
+
+function piece(over: Partial<BaseplatePiece>): BaseplatePiece {
+  return {
+    ...PIECE_DEFAULTS,
+    label: 'A1',
+    col: 0,
+    row: 0,
+    widthUnits: 3,
+    depthUnits: 3,
+    gridOffsetX: 0,
+    gridOffsetY: 0,
+    ...over,
+  };
+}
+
+function tiling(over: Partial<BaseplateTiling>): BaseplateTiling {
+  return {
+    isSplit: true,
+    cols: 3,
+    rows: 1,
+    colSizes: [3, 3, 3],
+    rowSizes: [3],
+    pieces: [piece({})],
+    margins: [],
+    totalWidthUnits: 9,
+    totalDepthUnits: 3,
+    stackCount: 1,
+    stackSeparatorThickness: 0,
+    bedLoads: 1,
+    paddingReductionHint: null,
+    isCustomSplit: false,
+    bedOverages: [],
+    ...over,
+  };
+}
+
+describe('splitMapLayout', () => {
+  it('sizes tracks by grid span when the plate has no padding', () => {
+    const map = splitMapLayout(tiling({ colSizes: [5, 4], rowSizes: [6] }), 42, 42);
+    expect(map.colMm).toEqual([210, 168]);
+    expect(map.rowMm).toEqual([252]);
+    expect(map.widthMm).toBe(378);
+  });
+
+  it('adds each padded side to the outermost track only', () => {
+    const map = splitMapLayout(
+      tiling({
+        colSizes: [3, 3, 3],
+        pieces: [
+          piece({ label: 'A1', col: 0, paddingLeft: 20 }),
+          piece({ label: 'B1', col: 1, gridOffsetX: 3 }),
+          piece({ label: 'C1', col: 2, gridOffsetX: 6, paddingRight: 8 }),
+        ],
+      }),
+      42,
+      42
+    );
+    expect(map.colMm).toEqual([146, 126, 134]);
+    expect(map.widthMm).toBe(406);
+    expect(map.padLeftMm).toBe(20);
+  });
+
+  it('uses the Y pitch for rows on a non-square grid', () => {
+    const map = splitMapLayout(tiling({ rowSizes: [3, 2] }), 42, 21);
+    expect(map.rowMm).toEqual([63, 42]);
+    expect(map.depthMm).toBe(105);
+  });
+
+  // A shaped perimeter drops pieces, so the padded column may have no piece at
+  // index 0 to read the value off.
+  it('recovers padding from whichever piece still carries it', () => {
+    const map = splitMapLayout(
+      tiling({
+        colSizes: [3, 3],
+        pieces: [piece({ label: 'A2', col: 0, row: 1, paddingLeft: 20 })],
+      }),
+      42,
+      42
+    );
+    expect(map.colMm[0]).toBe(146);
+  });
+
+  it('keeps the total positive on a degenerate plate', () => {
+    const map = splitMapLayout(tiling({ colSizes: [], rowSizes: [], pieces: [] }), 42, 42);
+    expect(map.widthMm).toBeGreaterThan(0);
+    expect(map.depthMm).toBeGreaterThan(0);
+  });
+});
+
+describe('seamFraction', () => {
+  it('measures a seam across the padded plate, not the grid', () => {
+    // Grid seam at 3 units of a 9-unit plate is a third of the GRID, but the
+    // 20mm of leading padding moves it later across the plate as a whole.
+    expect(seamFraction(3, 42, 20, 406)).toBeCloseTo(146 / 406, 10);
+    expect(seamFraction(3, 42, 0, 378)).toBeCloseTo(1 / 3, 10);
+  });
+});

--- a/src/features/baseplate/utils/splitMapLayout.ts
+++ b/src/features/baseplate/utils/splitMapLayout.ts
@@ -1,0 +1,84 @@
+/**
+ * Millimetre geometry of the split mini-map.
+ *
+ * The map used to lay its tracks out in grid UNITS, which is not the shape of
+ * the plate: padding is millimetres carried by the outermost pieces only, so a
+ * padded plate's first and last columns are physically wider than the equal
+ * share the map drew them. Every seam then sat at the wrong fraction of the
+ * plate, and the map disagreed with the pieces in the 3D preview.
+ *
+ * Padding is read back off the pieces rather than taken as a parameter, so the
+ * map and the meshes cannot be told different numbers. It is a plate-level
+ * property that only the edge pieces carry, which is why a max over all pieces
+ * recovers it even when a shaped perimeter has dropped one.
+ */
+
+import type { BaseplateTiling } from '../types/tiling';
+
+export interface SplitMapLayout {
+  /** Physical width of each column, in mm, in emitted order. */
+  readonly colMm: readonly number[];
+  /** Physical depth of each row, in mm, front-to-back. */
+  readonly rowMm: readonly number[];
+  readonly widthMm: number;
+  readonly depthMm: number;
+  /** Plate padding outside the grid, on the axes the seam offsets measure from. */
+  readonly padLeftMm: number;
+  readonly padFrontMm: number;
+}
+
+function maxPadding(
+  pieces: BaseplateTiling['pieces'],
+  side: 'paddingLeft' | 'paddingRight' | 'paddingFront' | 'paddingBack'
+): number {
+  let max = 0;
+  for (const piece of pieces) max = Math.max(max, piece[side]);
+  return max;
+}
+
+export function splitMapLayout(
+  tiling: BaseplateTiling,
+  gridUnitMm: number,
+  gridUnitMmY: number
+): SplitMapLayout {
+  const { colSizes, rowSizes, pieces } = tiling;
+  const padLeftMm = maxPadding(pieces, 'paddingLeft');
+  const padRightMm = maxPadding(pieces, 'paddingRight');
+  const padFrontMm = maxPadding(pieces, 'paddingFront');
+  const padBackMm = maxPadding(pieces, 'paddingBack');
+
+  const colMm = colSizes.map(
+    (units, i) =>
+      units * gridUnitMm + (i === 0 ? padLeftMm : 0) + (i === colSizes.length - 1 ? padRightMm : 0)
+  );
+  const rowMm = rowSizes.map(
+    (units, i) =>
+      units * gridUnitMmY + (i === 0 ? padFrontMm : 0) + (i === rowSizes.length - 1 ? padBackMm : 0)
+  );
+
+  const sum = (values: readonly number[]): number => values.reduce((a, b) => a + b, 0);
+  return {
+    colMm,
+    rowMm,
+    // Floored above zero so the fractions below stay finite on a degenerate
+    // plate; a zero-unit axis would otherwise divide every seam by nothing.
+    widthMm: Math.max(sum(colMm), Number.EPSILON),
+    depthMm: Math.max(sum(rowMm), Number.EPSILON),
+    padLeftMm,
+    padFrontMm,
+  };
+}
+
+/**
+ * Where a seam offset (grid units from the grid's own edge) falls across the
+ * padded plate, as a 0-1 fraction. Seams are interior cell boundaries, so they
+ * always sit past the leading padding.
+ */
+export function seamFraction(
+  offsetUnits: number,
+  gridUnitMm: number,
+  padMm: number,
+  totalMm: number
+): number {
+  return (padMm + offsetUnits * gridUnitMm) / totalMm;
+}


### PR DESCRIPTION
Fixes #3613.

Two defects in the same strip, both showing up as the preview not matching the actual split once padding is applied.

## 1. The map was laid out in grid units

Padding is millimetres carried by the outermost pieces only, so a padded plate's first and last columns are physically wider than the equal share the map drew them — and every seam sat at the wrong fraction of the plate. `splitMapLayout` sizes each track by its real mm and maps a seam offset across the padded extent.

Padding is read back off `tiling.pieces` rather than taken as a parameter, so the map and the 3D meshes cannot be told different numbers. A max over all pieces recovers it even when a shaped perimeter has dropped the piece that carries it.

Measured on a 10x8 plate with 60mm of left padding: tracks went from `2fr 4fr 4fr` to `144fr 168fr 168fr`, moving the first seam from 20% of the map to its true 30% of the plate.

## 2. The seams were positioned against a box the map does not fill

`aspect-ratio` transfers a height cap into a width cap, so the map shrank inside its grid area while the ruler ticks and the drawn seams were positioned as a percentage of that **area**. The aspect box is now the positioning context itself, and the column ruler shares its width.

Measured in Chrome on an 8x13 plate (tall enough for `max-h-56` to bind), before → after:

| | before | after |
|---|---|---|
| positioning context | 30 → 271px | 30 → 168px |
| map grid | 30 → 168px | 30 → 168px |
| A\|B cell boundary | x = 99 | x = 99 |
| drawn seam / ruler tick | **x = 151** | x = 99 |
| horizontal seam span | 30 → 271px | 30 → 168px |

That 52px is the last seam landing on the plate's right edge instead of between two columns, and the horizontal lines overhanging the map — exactly the screenshot in the issue.

`min-h-16` is gone with it: through the same transfer it was a `min-width` of `4rem × ratio`, which on a wide plate resolves past the panel width. The box now takes `width: min(100%, 14rem × ratio)` directly, and the ratio it renders at is clamped so an extreme plate is a readable schematic rather than a sliver — the tracks and seams stay true to the plate either way, since both are fractions of whatever box results.

## Tests

`splitMapLayout.test.ts` covers the mm tracks, per-side padding on the outermost track only, the Y pitch on a non-square grid, recovery from a dropped piece, and a degenerate plate. `SplitViewStrip.test.tsx` asserts the rendered `gridTemplateColumns`, that a seam line and its ruler tick resolve to the same percentage, and that the ruler and the map share one width.

The CSS half is not visible to jsdom, which is why it was measured in a real browser rather than asserted in a test.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

