### PR TITLE
fix(drawer-shape): bound a custom perimeter by the drawer, not by the grid

### DIFF
--- a/src/core/cqrs/v2/domain/drawer/setDrawerOutline.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/setDrawerOutline.test.ts
@@ -5,6 +5,7 @@ import { STAGING_ID } from '@/core/constants';
 import { binId, mm } from '@/core/types';
 import type { DrawerOutline } from '@/core/types';
 import { setDrawerOutline } from './setDrawerOutline';
+import { gridUnits, heightUnits } from '@/core/types';
 import { makeLayout, makeBin } from './_testHelpers';
 
 const U = 42;
@@ -164,5 +165,108 @@ describe('v2 drawer.setOutline', () => {
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) return;
     expect(result.value.event.payload.outline?.vertices[0]).toEqual({ x: 0, y: 0 });
+  });
+
+  // A drawer measures what it measures; the grid is a lattice laid inside it
+  // that the user is free to make smaller and to position with padding.
+  // Bounding the perimeter by the grid forced the grid up to the shape.
+  describe('measured drawer bounds the perimeter', () => {
+    /** 6-unit grid (252mm) inside a 260 x 175mm measured drawer. */
+    const MEASURED = { width: 260, depth: 175 };
+    const PAST_GRID: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 260, y: 0 },
+        { x: 260, y: 100 },
+        { x: 180, y: 100 },
+        { x: 180, y: 175 },
+        { x: 0, y: 175 },
+      ],
+    };
+
+    it('accepts a shape past the grid extent but inside the measured drawer', () => {
+      const layout = makeLayout({
+        drawer: {
+          width: gridUnits(6),
+          depth: gridUnits(4),
+          height: heightUnits(7),
+          measuredMm: MEASURED,
+        },
+      });
+      const result = setDrawerOutline.handle({ outline: PAST_GRID }, { aggregate: layout });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      expect(result.value.event.payload.outline?.vertices[1].x).toBe(260);
+    });
+
+    it('still rejects a shape past the measured drawer too', () => {
+      const layout = makeLayout({
+        drawer: {
+          width: gridUnits(6),
+          depth: gridUnits(4),
+          height: heightUnits(7),
+          measuredMm: MEASURED,
+        },
+      });
+      const tooBig: DrawerOutline = {
+        vertices: PAST_GRID.vertices.map((v) => ({ ...v, x: v.x === 260 ? 400 : v.x })),
+      };
+      expect(isOk(setDrawerOutline.handle({ outline: tooBig }, { aggregate: layout }))).toBe(false);
+    });
+
+    it('rejects the same shape when nothing has been measured', () => {
+      const layout = makeLayout();
+      expect(isOk(setDrawerOutline.handle({ outline: PAST_GRID }, { aggregate: layout }))).toBe(
+        false
+      );
+    });
+
+    // The no-op test stays a GRID question: a rectangle at the drawer's size on
+    // a smaller grid trims cells, so it is real geometry, not an absent outline.
+    it('keeps a drawer-sized rectangle that is larger than the grid', () => {
+      const layout = makeLayout({
+        drawer: {
+          width: gridUnits(6),
+          depth: gridUnits(4),
+          height: heightUnits(7),
+          measuredMm: MEASURED,
+        },
+      });
+      const rect: DrawerOutline = {
+        vertices: [
+          { x: 0, y: 0 },
+          { x: 260, y: 0 },
+          { x: 260, y: 175 },
+          { x: 0, y: 175 },
+        ],
+      };
+      const result = setDrawerOutline.handle({ outline: rect }, { aggregate: layout });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      expect(result.value.event.payload.outline).toBeDefined();
+    });
+
+    it('still drops a rectangle that traces the grid extent exactly', () => {
+      const layout = makeLayout({
+        drawer: {
+          width: gridUnits(6),
+          depth: gridUnits(4),
+          height: heightUnits(7),
+          measuredMm: MEASURED,
+        },
+      });
+      const rect: DrawerOutline = {
+        vertices: [
+          { x: 0, y: 0 },
+          { x: 6 * U, y: 0 },
+          { x: 6 * U, y: 4 * U },
+          { x: 0, y: 4 * U },
+        ],
+      };
+      const result = setDrawerOutline.handle({ outline: rect }, { aggregate: layout });
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      expect(result.value.event.payload.outline).toBeUndefined();
+    });
   });
 });

--- a/src/core/cqrs/v2/domain/drawer/setDrawerOutline.ts
+++ b/src/core/cqrs/v2/domain/drawer/setDrawerOutline.ts
@@ -16,6 +16,7 @@ import type { BinId, DrawerOutline } from '@/core/types';
 import { effectiveGridUnitMmY } from '@/core/types';
 import { STAGING_ID } from '@/core/constants';
 import {
+  outlineExtentMm,
   quantizeOutline,
   snapOutlineToBounds,
   validateOutline,
@@ -76,17 +77,26 @@ export const setDrawerOutline = defineCommand({
     const layout = ctx.aggregate;
     const drawer = layout.drawer;
     const gridUnitMmY = effectiveGridUnitMmY(layout) as number;
-    const widthMm = (drawer.width as number) * (layout.gridUnitMm as number);
-    const depthMm = (drawer.depth as number) * gridUnitMmY;
+    // The perimeter traces the DRAWER, so that is what bounds it; the grid is a
+    // lattice inside it that the user may make smaller. "Hugs the boundary" and
+    // "is the full rectangle" stay grid questions — a rectangle at the drawer's
+    // size on a smaller grid trims cells rather than meaning "no outline".
+    const gridWidthMm = (drawer.width as number) * (layout.gridUnitMm as number);
+    const gridDepthMm = (drawer.depth as number) * gridUnitMmY;
+    const { widthMm, depthMm } = outlineExtentMm(drawer, layout.gridUnitMm, gridUnitMmY);
 
     let outline: DrawerOutline | undefined;
     if (payload.outline !== null) {
-      const cleaned = snapOutlineToBounds(quantizeOutline(payload.outline), widthMm, depthMm);
+      const cleaned = snapOutlineToBounds(
+        quantizeOutline(payload.outline),
+        gridWidthMm,
+        gridDepthMm
+      );
       const invalid = validateOutline(cleaned, widthMm, depthMm, layout.gridUnitMm, gridUnitMmY);
       if (invalid !== null) {
         return err(layoutInvalidOperation('setDrawerOutline', invalid.message));
       }
-      outline = isRectangleEquivalent(cleaned, widthMm, depthMm) ? undefined : cleaned;
+      outline = isRectangleEquivalent(cleaned, gridWidthMm, gridDepthMm) ? undefined : cleaned;
     }
 
     const displacedBinIds = computeDisplacedBins(

--- a/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.test.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.test.tsx
@@ -37,6 +37,12 @@ function setOutline(vertices: DrawerOutline['vertices']): void {
   }));
 }
 
+function setMeasured(width: number, depth: number): void {
+  useLayoutStore.setState((state) => ({
+    layout: { ...state.layout, drawer: { ...state.layout.drawer, measuredMm: { width, depth } } },
+  }));
+}
+
 describe('PenShapeDialog', () => {
   beforeEach(() => {
     resetAllStores();
@@ -160,6 +166,69 @@ describe('PenShapeDialog', () => {
       expect(updateDrawer).not.toHaveBeenCalled();
       expect(batch).not.toHaveBeenCalled();
       expect(setDrawerOutline).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // The perimeter traces the drawer, and rounding the grid up to whole units
+  // does not move a drawer wall. Tracing against the grid rectangle produced a
+  // shape 14mm wider than the drawer on the reported layout.
+  describe('measured drawer', () => {
+    it('seeds the sketch from the measured drawer, not the grid extent', () => {
+      setMeasured(410, 327);
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      const path = document.querySelector('path');
+      expect(path?.getAttribute('d')).toBe('M 0 0 L 410 0 L 410 327 L 0 327 Z');
+    });
+
+    it('draws the reference rectangle at the measured size', () => {
+      setMeasured(410, 327);
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      const rect = document.querySelector('rect');
+      expect(rect?.getAttribute('width')).toBe('410');
+      expect(rect?.getAttribute('height')).toBe('327');
+    });
+
+    it('falls back to the grid extent when nothing has been measured', () => {
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      const { w, d } = extent();
+      const rect = document.querySelector('rect');
+      expect(rect?.getAttribute('width')).toBe(String(w));
+      expect(rect?.getAttribute('height')).toBe(String(d));
+    });
+
+    // The whole point: the grid stays small and the perimeter trims it, rather
+    // than the grid growing to the shape and leaving surplus cells to be cut.
+    it('does not grow the grid for a sketch inside the measured drawer', () => {
+      const { d } = extent(); // 420 x 336
+      setMeasured(441, d);
+      setOutline([
+        { x: 0, y: 0 },
+        { x: 441, y: 0 },
+        { x: 420, y: d },
+        { x: 0, y: d },
+      ]);
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+
+      expect(screen.getByText('drawerShape.editor.apply')).toBeEnabled();
+      fireEvent.click(screen.getByText('drawerShape.editor.apply'));
+
+      expect(updateDrawer).not.toHaveBeenCalled();
+      expect(setDrawerOutline).toHaveBeenCalledTimes(1);
+    });
+
+    it('still grows the grid for a sketch past the measured drawer too', () => {
+      const { d } = extent();
+      setMeasured(430, d);
+      setOutline([
+        { x: 0, y: 0 },
+        { x: 441, y: 0 },
+        { x: 420, y: d },
+        { x: 0, y: d },
+      ]);
+      render(<PenShapeDialog open onClose={vi.fn()} />);
+      fireEvent.click(screen.getByText('drawerShape.editor.apply'));
+
+      expect(updateDrawer).toHaveBeenCalledWith({ width: 10.5, depth: 8 });
     });
   });
 

--- a/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.tsx
+++ b/src/features/drawer-shape/components/PenShapeDialog/PenShapeDialog.tsx
@@ -18,6 +18,7 @@ import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { Button, Dialog } from '@/design-system';
 import type { OutlineVertex } from '@/core/types';
+import { outlineExtentMm } from '@/shared/utils/drawerOutline';
 import { effectiveGridUnitMmY, gridUnits } from '@/core/types';
 import { PenCanvas } from './PenCanvas';
 import { usePenSketch } from './usePenSketch';
@@ -85,10 +86,24 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
   );
   const addToast = useToastStore((s) => s.addToast);
 
-  const widthMm = layout.drawer.width * layout.gridUnitMm;
-  const depthMm = layout.drawer.depth * gridUnitMmY;
   const pitchX = layout.gridUnitMm;
   const pitchY = gridUnitMmY;
+  const gridWidthMm = layout.drawer.width * pitchX;
+  const gridDepthMm = layout.drawer.depth * pitchY;
+  // The rectangle the sketch is traced AGAINST: the drawer as measured, since
+  // that is the physical thing a perimeter follows. The grid extent is only the
+  // fallback for a drawer nobody has measured — it is a lattice laid inside the
+  // drawer, and rounding it up to whole units does not move a drawer wall.
+  const widthMm = layout.drawer.measuredMm?.width ?? gridWidthMm;
+  const depthMm = layout.drawer.measuredMm?.depth ?? gridDepthMm;
+  // The box a perimeter may occupy before the grid has to grow to hold it.
+  // Wider than either alone, so a shape drawn to a measured drawer no longer
+  // drags the grid up with it — which is what left every surplus cell to be cut.
+  const { widthMm: boundWidthMm, depthMm: boundDepthMm } = outlineExtentMm(
+    layout.drawer,
+    pitchX,
+    pitchY
+  );
   // A point may be placed past the current grid extent, up to the product
   // ceiling; Apply grows the drawer to fit. Only the upper bound moves — points
   // stay in the >=0 quadrant.
@@ -136,8 +151,8 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
   const bounds = useMemo(() => (outline === null ? null : loopBounds(outline.vertices)), [outline]);
   const bboxMaxXMm = bounds === null ? widthMm : bounds.minX + bounds.widthMm;
   const bboxMaxYMm = bounds === null ? depthMm : bounds.minY + bounds.depthMm;
-  // The frame covers the union of the grid rect and the sketch, so a handle
-  // dragged past the grid stays visible and grabbable.
+  // The frame covers the union of the drawer rect and the sketch, so a handle
+  // dragged past the drawer stays visible and grabbable.
   const contentWidthMm = Math.max(widthMm, bboxMaxXMm);
   const contentDepthMm = Math.max(depthMm, bboxMaxYMm);
 
@@ -161,9 +176,13 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
   // Validate against the bounds the drawer WILL have after Apply grows it, so a
   // growable overflow does not trip the out-of-bounds rule and disable Apply.
   // Coords are clamped to <= GRID_MAX*pitch, so these stay representable and
-  // there is no unreachable "too big" error to surface.
-  const effWmm = Math.max(widthMm, unitsFor(bboxMaxXMm, pitchX) * pitchX);
-  const effDmm = Math.max(depthMm, unitsFor(bboxMaxYMm, pitchY) * pitchY);
+  // there is no unreachable "too big" error to surface. A sketch inside the
+  // measured drawer needs no growth at all, which is why the floor is the
+  // permitted box rather than the grid extent.
+  const growsX = bboxMaxXMm > boundWidthMm;
+  const growsY = bboxMaxYMm > boundDepthMm;
+  const effWmm = growsX ? unitsFor(bboxMaxXMm, pitchX) * pitchX : boundWidthMm;
+  const effDmm = growsY ? unitsFor(bboxMaxYMm, pitchY) * pitchY : boundDepthMm;
   const error = useMemo(
     () =>
       outline === null
@@ -461,8 +480,10 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
   );
 
   const importer = useOutlineImport({
-    drawerWidthMm: widthMm,
-    drawerDepthMm: depthMm,
+    // Grid extent, not the traced drawer: the oversize prompt converts back to
+    // whole grid units to offer a grow, which is a question about the lattice.
+    drawerWidthMm: gridWidthMm,
+    drawerDepthMm: gridDepthMm,
     gridUnitMm: layout.gridUnitMm,
     gridUnitMmY,
     onImported: handleImported,
@@ -482,8 +503,12 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
     // bus is synchronous, so growing first lets setDrawerOutline validate
     // against the enlarged aggregate; batch() collapses the pair to one undo
     // step. When the sketch already fits, the single commit is kept.
-    const growW = Math.max(layout.drawer.width, unitsFor(bboxMaxXMm, pitchX));
-    const growD = Math.max(layout.drawer.depth, unitsFor(bboxMaxYMm, pitchY));
+    const growW = growsX
+      ? Math.max(layout.drawer.width, unitsFor(bboxMaxXMm, pitchX))
+      : layout.drawer.width;
+    const growD = growsY
+      ? Math.max(layout.drawer.depth, unitsFor(bboxMaxYMm, pitchY))
+      : layout.drawer.depth;
     const applied =
       growW > layout.drawer.width || growD > layout.drawer.depth
         ? batch(() => {
@@ -516,6 +541,8 @@ export function PenShapeDialog({ open, onClose }: PenShapeDialogProps) {
     onClose,
     bboxMaxXMm,
     bboxMaxYMm,
+    growsX,
+    growsY,
     pitchX,
     pitchY,
   ]);

--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts
@@ -148,6 +148,36 @@ describe('baseplate outline geometry', () => {
     }
   );
 
+  // A drawer measured wider than a whole number of cells leaves the grid
+  // smaller than the perimeter. The grid stays anchored and the perimeter
+  // overhangs it, so the slab has to widen by that overhang or the plate comes
+  // out the size of the GRID and the strip the drawer actually needs is gone.
+  it('builds the plate to a perimeter wider than the grid', { timeout: 240_000 }, () => {
+    const gen = getGenerateBaseplate();
+    const OVER = 8; // per side, from an 8mm-per-axis oversize perimeter
+    const wide: DrawerOutline = {
+      vertices: [
+        { x: -OVER, y: -OVER },
+        { x: 4 * U + OVER, y: -OVER },
+        { x: 4 * U + OVER, y: 4 * U + OVER },
+        { x: -OVER, y: 4 * U + OVER },
+      ],
+    };
+    const result = gen(
+      defaults({
+        outline: wide,
+        outlineOverhang: { left: OVER, right: OVER, front: OVER, back: OVER },
+      }),
+      NO_OP,
+      true
+    );
+    assertStructurallyValid(result, 'oversize perimeter');
+
+    const bb = boundingBox(result.vertices);
+    expect(bb.maxX - bb.minX).toBeCloseTo(4 * U + 2 * OVER, 0);
+    expect(bb.maxY - bb.minY).toBeCloseTo(4 * U + 2 * OVER, 0);
+  });
+
   it('cuts the ⊓ notch while keeping both prongs', { timeout: 240_000 }, () => {
     const gen = getGenerateBaseplate();
     const result = gen(defaults({ outline: U_SHAPE }), NO_OP, true);

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { DrawerOutline, Layout } from '@/core/types';
 import { gridUnits, mm } from '@/core/types';
+import { CONSTRAINTS } from '@/core/constants';
 import { createTestLayout } from '@/test/testUtils';
 import {
   canonicalStartOutline,
@@ -550,6 +551,40 @@ describe('outlineExtentMm', () => {
   // when a smaller measurement is recorded afterwards.
   it('keeps the grid extent when the measurement is smaller', () => {
     expect(outlineExtentMm({ ...drawer, measuredMm: { width: 100, depth: 100 } }, U, U)).toEqual({
+      widthMm: 4 * U,
+      depthMm: 4 * U,
+    });
+  });
+
+  // `updateDrawer` clamps what it writes, but an imported, shared or synced
+  // layout never passes through it — `validateImport` grades width, depth and
+  // height and does not look at `measuredMm`. NaN is the one that matters:
+  // unguarded it makes the bound NaN, and every comparison against it is false,
+  // so the out-of-bounds rule stops rejecting anything at all.
+  it.each([NaN, Infinity, -Infinity])('ignores a non-finite measurement (%p)', (bad) => {
+    const extent = outlineExtentMm({ ...drawer, measuredMm: { width: bad, depth: bad } }, U, U);
+    expect(extent).toEqual({ widthMm: 4 * U, depthMm: 4 * U });
+
+    const past: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 10_000, y: 0 },
+        { x: 10_000, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    expect(validateOutline(past, extent.widthMm, extent.depthMm, U)?.kind).toBe('out_of_bounds');
+  });
+
+  it('caps the measurement at MEASURED_MM_MAX', () => {
+    expect(outlineExtentMm({ ...drawer, measuredMm: { width: 1e9, depth: 1e9 } }, U, U)).toEqual({
+      widthMm: CONSTRAINTS.MEASURED_MM_MAX,
+      depthMm: CONSTRAINTS.MEASURED_MM_MAX,
+    });
+  });
+
+  it('ignores a negative measurement rather than shrinking the extent', () => {
+    expect(outlineExtentMm({ ...drawer, measuredMm: { width: -500, depth: -500 } }, U, U)).toEqual({
       widthMm: 4 * U,
       depthMm: 4 * U,
     });

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -10,6 +10,7 @@ import {
   minDrawerUnitsForOutline,
   normalizeDrawerOutline,
   OUTLINE_MAX_VERTICES,
+  outlineExtentMm,
   quantizeOutline,
   rotateOutline180,
   snapOutlineToBounds,
@@ -443,6 +444,30 @@ describe('normalizeDrawerOutline', () => {
     expect(normalizeDrawerOutline(layout)).toBe(layout);
   });
 
+  it('keeps a shape past the grid extent when the drawer was measured larger', () => {
+    // 4-unit grid is 168mm; the drawer measures 200mm, so a perimeter reaching
+    // 200mm is the drawer's own wall, not stale geometry to crop back.
+    const wide: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 200, y: 0 },
+        { x: 200, y: 120 },
+        { x: 100, y: 120 },
+        { x: 100, y: 4 * U },
+        { x: 0, y: 4 * U },
+      ],
+    };
+    const layout = layoutWith(wide);
+    layout.drawer.measuredMm = { width: 200, depth: 4 * U };
+    expect(normalizeDrawerOutline(layout)).toBe(layout);
+  });
+
+  it('still crops a shape past the measured drawer as well', () => {
+    const layout = layoutWith(L_SHAPE, 3, 4);
+    layout.drawer.measuredMm = { width: 3 * U, depth: 4 * U };
+    expect(normalizeDrawerOutline(layout)).not.toBe(layout);
+  });
+
   it('drops rectangle-equivalent outlines', () => {
     const rect: DrawerOutline = {
       vertices: [
@@ -504,5 +529,33 @@ describe('normalizeDrawerOutline', () => {
     };
     const normalized = normalizeDrawerOutline(layoutWith(bowtie));
     expect(normalized.drawer.outline).toBeUndefined();
+  });
+});
+
+describe('outlineExtentMm', () => {
+  const drawer = { width: gridUnits(4), depth: gridUnits(4) };
+
+  it('is the grid extent when nothing has been measured', () => {
+    expect(outlineExtentMm(drawer, U, U)).toEqual({ widthMm: 4 * U, depthMm: 4 * U });
+  });
+
+  it('widens to a measurement larger than the grid', () => {
+    expect(outlineExtentMm({ ...drawer, measuredMm: { width: 200, depth: 100 } }, U, U)).toEqual({
+      widthMm: 200,
+      depthMm: 4 * U,
+    });
+  });
+
+  // Never narrows: a shape authored against the grid extent has to stay valid
+  // when a smaller measurement is recorded afterwards.
+  it('keeps the grid extent when the measurement is smaller', () => {
+    expect(outlineExtentMm({ ...drawer, measuredMm: { width: 100, depth: 100 } }, U, U)).toEqual({
+      widthMm: 4 * U,
+      depthMm: 4 * U,
+    });
+  });
+
+  it('uses the Y pitch for depth on a non-square grid', () => {
+    expect(outlineExtentMm(drawer, U, 21)).toEqual({ widthMm: 4 * U, depthMm: 84 });
   });
 });

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -5,10 +5,11 @@
  * Everything here is brepjs/WASM-free and pure. The geometry math (arcs,
  * flattening, classification) lives in `drawerOutlineGeometry.ts`; this module
  * owns the outline's invariants: single closed CCW simple loop, within the
- * drawer's grid extent, enclosing at least one grid cell.
+ * drawer's own extent ({@link outlineExtentMm} — NOT the grid's), enclosing at
+ * least one grid cell.
  */
 
-import type { DrawerOutline, Layout, OutlineVertex } from '@/core/types';
+import type { Drawer, DrawerOutline, Layout, OutlineVertex } from '@/core/types';
 import { effectiveGridUnitMmY } from '@/core/types';
 import { CONSTRAINTS } from '@/core/constants';
 import { clamp } from './math';
@@ -71,6 +72,37 @@ export function quantizeOutline(outline: DrawerOutline): DrawerOutline {
         ? { x: quantize(v.x), y: quantize(v.y) }
         : { x: quantize(v.x), y: quantize(v.y), bulge };
     }),
+  };
+}
+
+/**
+ * The box a drawer perimeter may occupy, in drawer-local mm.
+ *
+ * The grid extent is NOT the bound. A measured drawer is the physical thing the
+ * perimeter traces; the grid is a lattice laid inside it, which the user is
+ * free to make smaller and to position with padding. Bounding the perimeter by
+ * the grid made that combination impossible — shrinking the grid clipped the
+ * shape, or dropped it outright — which forced the grid up to the shape and
+ * left every surplus cell to be cut.
+ *
+ * Widened, never narrowed: a shape authored against a larger grid extent stays
+ * valid when a smaller measurement is recorded afterwards. `MEASURED_MM_MAX` is
+ * the ceiling on the measured half.
+ *
+ * This is the permitted box only. "Does this outline hug the grid" — the no-op
+ * rectangle test and the boundary snap — still measures the GRID extent, since
+ * a rectangle at the drawer's size on a smaller grid is real geometry that
+ * trims cells, not an absent outline.
+ */
+export function outlineExtentMm(
+  drawer: Pick<Drawer, 'width' | 'depth' | 'measuredMm'>,
+  gridUnitMm: number,
+  gridUnitMmY: number
+): { widthMm: number; depthMm: number } {
+  const measured = drawer.measuredMm;
+  return {
+    widthMm: Math.max((drawer.width as number) * gridUnitMm, measured?.width ?? 0),
+    depthMm: Math.max((drawer.depth as number) * gridUnitMmY, measured?.depth ?? 0),
   };
 }
 
@@ -151,8 +183,10 @@ export function isSelfIntersecting(pts: readonly OutlinePoint[]): boolean {
 
 /**
  * Check every outline invariant. Returns null when valid.
- * `widthMm`/`depthMm` are the drawer's grid extent; `gridUnitMm` sets the
- * minimum-area rule (one grid cell).
+ * `widthMm`/`depthMm` are the box the perimeter may occupy — pass
+ * {@link outlineExtentMm}, not the bare grid extent, or a grid smaller than the
+ * drawer rejects the drawer's own shape. `gridUnitMm` sets the minimum-area
+ * rule (one grid cell).
  */
 export function validateOutline(
   outline: DrawerOutline,
@@ -563,8 +597,13 @@ export function normalizeDrawerOutline(layout: Layout): Layout {
   if (outline === undefined) return layout;
 
   const gridUnitMmY = effectiveGridUnitMmY(layout) as number;
-  const widthMm = (layout.drawer.width as number) * (layout.gridUnitMm as number);
-  const depthMm = (layout.drawer.depth as number) * gridUnitMmY;
+  // Two boxes, deliberately: the perimeter is clipped and graded against the
+  // DRAWER (which may exceed the grid), while "hugs the boundary" and "is the
+  // full rectangle" stay grid questions — a rectangle at the drawer's size on a
+  // smaller grid trims cells and must survive as real geometry.
+  const gridWidthMm = (layout.drawer.width as number) * (layout.gridUnitMm as number);
+  const gridDepthMm = (layout.drawer.depth as number) * gridUnitMmY;
+  const { widthMm, depthMm } = outlineExtentMm(layout.drawer, layout.gridUnitMm, gridUnitMmY);
 
   const drop = (): Layout => {
     const drawer = { ...layout.drawer };
@@ -588,10 +627,10 @@ export function normalizeDrawerOutline(layout: Layout): Layout {
 
   const candidate = snapOutlineToBounds(
     quantizeOutline({ vertices: toVertices(verts), authoring: outline.authoring }),
-    widthMm,
-    depthMm
+    gridWidthMm,
+    gridDepthMm
   );
-  if (isOutlineFullRectangle(candidate, widthMm, depthMm)) return drop();
+  if (isOutlineFullRectangle(candidate, gridWidthMm, gridDepthMm)) return drop();
   if (validateOutline(candidate, widthMm, depthMm, layout.gridUnitMm, gridUnitMmY) !== null) {
     return drop();
   }

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -86,14 +86,27 @@ export function quantizeOutline(outline: DrawerOutline): DrawerOutline {
  * left every surplus cell to be cut.
  *
  * Widened, never narrowed: a shape authored against a larger grid extent stays
- * valid when a smaller measurement is recorded afterwards. `MEASURED_MM_MAX` is
- * the ceiling on the measured half.
+ * valid when a smaller measurement is recorded afterwards.
+ *
+ * The measurement is clamped HERE rather than trusted. `updateDrawer` clamps
+ * what it writes, but an imported, shared or synced layout reaches the store
+ * without passing through it — `validateImport` grades the drawer's width,
+ * depth and height and never looks at `measuredMm`, which was inert until this
+ * function gave it authority over the perimeter. A non-finite value is the one
+ * that matters: `Math.max(extent, NaN)` is `NaN`, and every `point > NaN`
+ * comparison in `validateOutline` is false, so an unguarded read does not widen
+ * the bound — it removes it.
  *
  * This is the permitted box only. "Does this outline hug the grid" — the no-op
  * rectangle test and the boundary snap — still measures the GRID extent, since
  * a rectangle at the drawer's size on a smaller grid is real geometry that
  * trims cells, not an absent outline.
  */
+function safeMeasured(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return 0;
+  return clamp(value, 0, CONSTRAINTS.MEASURED_MM_MAX);
+}
+
 export function outlineExtentMm(
   drawer: Pick<Drawer, 'width' | 'depth' | 'measuredMm'>,
   gridUnitMm: number,
@@ -101,8 +114,8 @@ export function outlineExtentMm(
 ): { widthMm: number; depthMm: number } {
   const measured = drawer.measuredMm;
   return {
-    widthMm: Math.max((drawer.width as number) * gridUnitMm, measured?.width ?? 0),
-    depthMm: Math.max((drawer.depth as number) * gridUnitMmY, measured?.depth ?? 0),
+    widthMm: Math.max((drawer.width as number) * gridUnitMm, safeMeasured(measured?.width)),
+    depthMm: Math.max((drawer.depth as number) * gridUnitMmY, safeMeasured(measured?.depth)),
   };
 }
 

--- a/src/shared/utils/outlineFrame.test.ts
+++ b/src/shared/utils/outlineFrame.test.ts
@@ -83,6 +83,25 @@ describe('resolveOutlineFrame', () => {
     expect(frame.outline).toBe(REGISTERED);
   });
 
+  // Now reachable: the perimeter is bounded by the DRAWER, so a grid smaller
+  // than the drawer is a supported configuration rather than a stale one to be
+  // clipped back. The grid stays put and centres inside the perimeter, and the
+  // strip outside it is reported as overhang for the extent-bounded consumers.
+  it('centres a smaller grid inside a perimeter that exceeds it', () => {
+    const bigger: DrawerOutline = {
+      vertices: [
+        { x: 0, y: 0 },
+        { x: 4 * U + 8, y: 0 },
+        { x: 4 * U + 8, y: 4 * U + 7 },
+        { x: 0, y: 4 * U + 7 },
+      ],
+    };
+    const frame = resolveOutlineFrame(bigger, frameParams());
+    expect(frame.shiftX).toBeCloseTo(-4, 9);
+    expect(frame.shiftY).toBeCloseTo(-3.5, 9);
+    expect(frame.overhang).toEqual({ left: 4, right: 4, front: 3.5, back: 3.5 });
+  });
+
   it('subtracts the manual grid shift from the registration', () => {
     const frame = resolveOutlineFrame(OFF_LATTICE, frameParams({ gridShiftX: 10, gridShiftY: -5 }));
     expect(frame.shiftX).toBeCloseTo(22, 9);


### PR DESCRIPTION
Fixes #3614.

A drawer measures what it measures; the grid is a lattice laid inside it that the user is free to make smaller and to position with padding. Bounding the perimeter by the **grid** made that combination impossible — shrinking the grid clipped the shape, or dropped it on the next ingest — so the grid had to be sized up to the shape, and every surplus cell was left to be cut.

On the reported layout that is a 22.5-unit grid (945mm) holding a drawer that measures 931mm.

## The permitted box

`outlineExtentMm(drawer, pitchX, pitchY)` is the grid extent **widened** to a recorded measurement, never narrowed — so a shape authored against a larger grid stays valid when a smaller measurement is recorded afterwards. `MEASURED_MM_MAX` (5000) is the ceiling on the measured half.

Both gates read it: the `drawer.setOutline` command and `normalizeDrawerOutline` on ingest.

Two things deliberately stay **grid** questions, because they ask something else:

- **`isRectangleEquivalent` / `isOutlineFullRectangle`** — "is this a no-op". A rectangle at the drawer's size on a smaller grid trims cells, so it is real geometry, not an absent outline.
- **`snapOutlineToBounds`** — "does this vertex hug the boundary". Snapping to the drawer would pull vertices off the grid edge they were placed on.

## The pen editor

Its reference rectangle and its seed sketch were the grid extent — 945x336 where the drawer is 931x327, so tracing "the drawer" produced a shape 14mm too wide. Both now come from `measuredMm`, falling back to the grid extent when nothing has been measured.

It also no longer grows the grid for a sketch that fits the drawer. That auto-grow is what produced the surplus cells: draw the true 931mm perimeter on a 924mm grid and the grid was dragged up to 966mm.

The **import** path keeps the grid extent on purpose — its oversize prompt converts millimetres back to whole grid units to offer a grow, which is a question about the lattice.

## Nothing downstream needed changing

`outlineFrame` already handles a perimeter larger than the grid: it centres the grid inside it and reports the strip as `outlineOverhang` (gotcha #8), and the generator widens its slab by that. Verified rather than assumed — a new scenario test builds a 4x4 plate against a perimeter 8mm proud on every side and measures the mesh at 184mm, not 168mm. That is the "size actually produced is smaller" half of the report.

## Tests

Each of the three layers has a case that fails without its fix (checked by stashing the source file):

- `setDrawerOutline.test.ts` — accepts a shape past the grid but inside the measurement; still rejects one past both; still rejects it when nothing is measured; keeps a drawer-sized rectangle larger than the grid; still drops one tracing the grid exactly.
- `drawerOutline.test.ts` — ingest keeps an oversize shape when the drawer was measured larger, still crops one past the measurement; plus `outlineExtentMm` including the never-narrows case.
- `PenShapeDialog.test.tsx` — seed and reference rectangle come from the measurement, fall back to the grid without one, and the grid is not grown for a sketch inside the drawer (but still is for one past it).
- `outlineFrame.test.ts` and `baseplateGenerator.scenario.outline.test.ts` pin the downstream behaviour the fix makes reachable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

