### PR TITLE
fix(print-export): list the pieces the exporter actually cuts

### DIFF
--- a/src/features/print-export/hooks/usePrintList.ts
+++ b/src/features/print-export/hooks/usePrintList.ts
@@ -8,7 +8,8 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore, useSettingsStore } from '@/core/store';
 import { useSelectionStore } from '@/core/store/selection';
 import { calcMaxGridUnits } from '@/core/constants';
-import { generateEnhancedPrintList, type PrintSplitFit } from '@/features/print-export/utils/split';
+import { generateEnhancedPrintList } from '@/features/print-export/utils/split';
+import type { PrintSplitFit } from '@/features/print-export/utils/split';
 import { resolveBinOverhang } from '@/shared/utils/drawerMargin';
 import { effectiveGridUnitMmY } from '@/core/types';
 import {

--- a/src/features/print-export/hooks/usePrintList.ts
+++ b/src/features/print-export/hooks/usePrintList.ts
@@ -8,7 +8,9 @@ import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore, useSettingsStore } from '@/core/store';
 import { useSelectionStore } from '@/core/store/selection';
 import { calcMaxGridUnits } from '@/core/constants';
-import { generateEnhancedPrintList } from '@/features/print-export/utils/split';
+import { generateEnhancedPrintList, type PrintSplitFit } from '@/features/print-export/utils/split';
+import { resolveBinOverhang } from '@/shared/utils/drawerMargin';
+import { effectiveGridUnitMmY } from '@/core/types';
 import {
   applyFiltersAndSort,
   groupByCategory,
@@ -100,20 +102,52 @@ export function usePrintList(): UsePrintListReturn {
 
   const setSelectedBins = useSelectionStore((state) => state.setSelectedBins);
 
+  // Bed capacity in whole grid units, for the per-plate job estimate below.
+  // NOT the split limit — that is per bin, because an overhang is charged
+  // against the bed before the capacity is derived (see `splitFit`).
   const maxGridUnits = calcMaxGridUnits(
     layout.printBedSize,
     layout.gridUnitMm,
     layout.printBedDepth
   );
 
+  // The bed in mm plus the same per-bin overhang the exporter resolves, so the
+  // listed pieces are the pieces the export actually writes. Memoized on
+  // primitives: `baseRows` keys off this object, and a fresh identity every
+  // render would rebuild the whole list on every render.
+  const gridUnitMmY = effectiveGridUnitMmY(layout);
+  const { printBedSize, printBedDepth, gridUnitMm, baseplateParams } = layout;
+  const drawerWidth = layout.drawer.width;
+  const drawerDepth = layout.drawer.depth;
+  const splitFit = useMemo(
+    (): PrintSplitFit => ({
+      bedWidthMm: printBedSize,
+      bedDepthMm: printBedDepth ?? printBedSize,
+      gridUnitMm,
+      gridUnitMmY,
+      overhangFor: (bin) =>
+        resolveBinOverhang(bin, { width: drawerWidth, depth: drawerDepth }, baseplateParams) ??
+        undefined,
+    }),
+    [
+      printBedSize,
+      printBedDepth,
+      gridUnitMm,
+      gridUnitMmY,
+      drawerWidth,
+      drawerDepth,
+      baseplateParams,
+    ]
+  );
+
   // Base enhanced rows (memoized - expensive operation)
   const baseRows = useMemo(
     () =>
-      generateEnhancedPrintList(layout.bins, maxGridUnits, printSettings, config, {
+      generateEnhancedPrintList(layout.bins, splitFit, printSettings, config, {
         gridUnitMm: layout.gridUnitMm,
         heightUnitMm: layout.heightUnitMm,
       }),
-    [layout.bins, maxGridUnits, printSettings, config, layout.gridUnitMm, layout.heightUnitMm]
+    [layout.bins, splitFit, printSettings, config, layout.gridUnitMm, layout.heightUnitMm]
   );
 
   // Label facts per linked design (async design loads; rows gain them as the

--- a/src/features/print-export/utils/split.test.ts
+++ b/src/features/print-export/utils/split.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import type { PrintSplitFit } from '@/features/print-export/utils/split';
 import {
   splitBinSize,
   generatePrintList,
-  type PrintSplitFit,
   getTotalPieces,
   getTotalBins,
   getTotalFilament,

--- a/src/features/print-export/utils/split.test.ts
+++ b/src/features/print-export/utils/split.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { PrintSplitFit } from '@/features/print-export/utils/split';
 import {
   splitBinSize,
+  formatPieceSize,
   generatePrintList,
   getTotalPieces,
   getTotalBins,
@@ -39,7 +40,6 @@ describe('splitBinSize', () => {
     { w: 5, d: 3, max: maxSize, piece: [2.5, 3], count: 2 },
     { w: 3, d: 5, max: maxSize, piece: [3, 2.5], count: 2 },
     { w: 9, d: 3, max: maxSize, piece: [3, 3], count: 3 },
-    { w: 10, d: 1, max: maxSize, piece: [3.33, 1], count: 3 },
     { w: 12, d: 1, max: maxSize, piece: [4, 1], count: 3 },
     { w: 5, d: 6, max: maxSize, piece: [2.5, 3], count: 4 },
     { w: 8, d: 2, max: maxSize, piece: [4, 2], count: 2 },
@@ -51,6 +51,15 @@ describe('splitBinSize', () => {
     expect(splitBinSize(w, d, max)).toEqual([
       { width: gridUnits(piece[0]), depth: gridUnits(piece[1]), count },
     ]);
+  });
+
+  // Exact, not rounded: the size feeds the filament estimate and the diagram's
+  // grid recovery. Only the label rounds it (`formatPieceSize`).
+  it('keeps an even three-way split exact', () => {
+    expect(splitBinSize(10, 1, maxSize)).toEqual([
+      { width: gridUnits(10 / 3), depth: gridUnits(1), count: 3 },
+    ]);
+    expect(formatPieceSize(10 / 3)).toBe('3.33');
   });
 
   it('never yields a zero-sized piece', () => {

--- a/src/features/print-export/utils/split.test.ts
+++ b/src/features/print-export/utils/split.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   splitBinSize,
   generatePrintList,
+  type PrintSplitFit,
   getTotalPieces,
   getTotalBins,
   getTotalFilament,
@@ -11,158 +12,102 @@ import type { Bin, PrintRow } from '@/core/types';
 import { binId, layerId, categoryId, designId, gridUnits, heightUnits } from '@/core/types';
 import { STAGING_ID } from '@/core/constants';
 import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
+import type { OverhangConfig } from '@/shared/types/bin';
+
+/** A print-bed fit expressed as "N grid units fit each axis". */
+function fitAt(maxUnits: number, overhangFor?: PrintSplitFit['overhangFor']): PrintSplitFit {
+  const gridUnitMm = 42;
+  return {
+    bedWidthMm: maxUnits * gridUnitMm,
+    bedDepthMm: maxUnits * gridUnitMm,
+    gridUnitMm,
+    gridUnitMmY: gridUnitMm,
+    ...(overhangFor ? { overhangFor } : {}),
+  };
+}
 
 describe('splitBinSize', () => {
   const maxSize = 4;
 
-  it('returns single piece for small bins', () => {
-    const pieces = splitBinSize(3, 3, maxSize);
-    expect(pieces).toEqual([{ width: gridUnits(3), depth: gridUnits(3), count: 1 }]);
+  // Equal pieces, per axis, from the same helper the exporter cuts with. The
+  // old recursive halving listed sizes the exporter never emits (a 5 as 3 + 2
+  // rather than two 2.5s) and at 10 and 12 units a whole extra piece.
+  it.each([
+    { w: 3, d: 3, max: maxSize, piece: [3, 3], count: 1 },
+    { w: 4, d: 4, max: maxSize, piece: [4, 4], count: 1 },
+    { w: 1, d: 1, max: maxSize, piece: [1, 1], count: 1 },
+    { w: 5, d: 3, max: maxSize, piece: [2.5, 3], count: 2 },
+    { w: 3, d: 5, max: maxSize, piece: [3, 2.5], count: 2 },
+    { w: 9, d: 3, max: maxSize, piece: [3, 3], count: 3 },
+    { w: 10, d: 1, max: maxSize, piece: [3.33, 1], count: 3 },
+    { w: 12, d: 1, max: maxSize, piece: [4, 1], count: 3 },
+    { w: 5, d: 6, max: maxSize, piece: [2.5, 3], count: 4 },
+    { w: 8, d: 2, max: maxSize, piece: [4, 2], count: 2 },
+    { w: 2, d: 8, max: maxSize, piece: [2, 4], count: 2 },
+    { w: 8, d: 8, max: maxSize, piece: [4, 4], count: 4 },
+    { w: 6, d: 5, max: maxSize, piece: [3, 2.5], count: 4 },
+    { w: 3, d: 3, max: 2, piece: [1.5, 1.5], count: 4 },
+  ])('cuts $w x $d into $count equal pieces at max $max', ({ w, d, max, piece, count }) => {
+    expect(splitBinSize(w, d, max)).toEqual([
+      { width: gridUnits(piece[0]), depth: gridUnits(piece[1]), count },
+    ]);
   });
 
-  it('splits width only when needed', () => {
-    const pieces = splitBinSize(5, 3, maxSize);
-    // 5×3 → 3×3 + 2×3
-    expect(pieces).toHaveLength(2);
-    expect(pieces).toContainEqual({ width: gridUnits(3), depth: gridUnits(3), count: 1 });
-    expect(pieces).toContainEqual({ width: gridUnits(2), depth: gridUnits(3), count: 1 });
+  it('never yields a zero-sized piece', () => {
+    for (const [w, d] of [
+      [1, 5],
+      [5, 1],
+      [0.5, 9],
+    ]) {
+      expect(splitBinSize(w, d, maxSize).every((p) => p.width > 0 && p.depth > 0)).toBe(true);
+    }
   });
 
-  it('splits depth only when needed', () => {
-    const pieces = splitBinSize(3, 5, maxSize);
-    // 3×5 → 3×3 + 3×2
-    expect(pieces).toHaveLength(2);
-    expect(pieces).toContainEqual({ width: gridUnits(3), depth: gridUnits(3), count: 1 });
-    expect(pieces).toContainEqual({ width: gridUnits(3), depth: gridUnits(2), count: 1 });
+  it('keeps every piece inside the limit', () => {
+    for (const [w, d] of [
+      [5, 6],
+      [9, 9],
+      [13, 7],
+    ]) {
+      expect(
+        splitBinSize(w, d, maxSize).every((p) => p.width <= maxSize && p.depth <= maxSize)
+      ).toBe(true);
+    }
   });
 
-  it('handles PRD example: 9×3 with max 4', () => {
-    const pieces = splitBinSize(9, 3, maxSize);
-    // 9×3 → 5×3 + 4×3 → 3×3 + 2×3 + 4×3
-    expect(pieces).toHaveLength(3);
-    const sizes = pieces.map((p) => `${p.width}×${p.depth}`).sort();
-    expect(sizes).toEqual(['2×3', '3×3', '4×3']);
-  });
-
-  it('handles both dimensions exceeding max', () => {
-    const pieces = splitBinSize(5, 6, maxSize);
-    // Should result in 4 pieces
-    expect(pieces.length).toBeGreaterThanOrEqual(4);
-    // All pieces should fit
-    pieces.forEach((p) => {
-      expect(p.width).toBeLessThanOrEqual(maxSize);
-      expect(p.depth).toBeLessThanOrEqual(maxSize);
-    });
-  });
-
-  it('handles exact max size', () => {
-    const pieces = splitBinSize(4, 4, maxSize);
-    expect(pieces).toEqual([{ width: gridUnits(4), depth: gridUnits(4), count: 1 }]);
-  });
-
-  it('splits width of 1 without creating zero-width pieces', () => {
-    // 1×5 with max 4: splits depth only → 1×3 + 1×2
-    const pieces = splitBinSize(1, 5, maxSize);
-    expect(pieces.every((p) => p.width > 0 && p.depth > 0)).toBe(true);
-    expect(pieces).toHaveLength(2);
-  });
-
-  it('splits depth of 1 without creating zero-depth pieces', () => {
-    // 5×1 with max 4: splits width only → 3×1 + 2×1
-    const pieces = splitBinSize(5, 1, maxSize);
-    expect(pieces.every((p) => p.width > 0 && p.depth > 0)).toBe(true);
-    expect(pieces).toHaveLength(2);
-  });
-
-  it('handles both dimensions being 1 and over max', () => {
-    // Edge case: 1×1 always fits
-    const pieces = splitBinSize(1, 1, maxSize);
-    expect(pieces).toEqual([{ width: gridUnits(1), depth: gridUnits(1), count: 1 }]);
-  });
-
-  it('handles odd splits correctly', () => {
-    // 3×3 with max 2: splits both → ceil(3/2)=2, floor(3/2)=1
-    // Results in 2×2, 1×2, 2×1, 1×1
-    const pieces = splitBinSize(3, 3, 2);
-    expect(pieces.length).toBe(4);
-    expect(pieces.every((p) => p.width <= 2 && p.depth <= 2)).toBe(true);
-  });
-
-  it('handles 8×2 with maxSize 4 (splits width only into equal halves)', () => {
-    // 8×2 → 4×2 + 4×2 (right half is exactly 4, not 0)
-    const pieces = splitBinSize(8, 2, 4);
-    expect(pieces.length).toBe(2);
-    expect(pieces.every((p) => p.width === 4 && p.depth === 2)).toBe(true);
-  });
-
-  it('handles 2×8 with maxSize 4 (splits depth only into equal halves)', () => {
-    // 2×8 → 2×4 + 2×4 (bottom half is exactly 4, not 0)
-    const pieces = splitBinSize(2, 8, 4);
-    expect(pieces.length).toBe(2);
-    expect(pieces.every((p) => p.width === 2 && p.depth === 4)).toBe(true);
-  });
-
-  it('handles 8×8 with maxSize 4 (splits both into equal halves)', () => {
-    // 8×8 → 4 pieces of 4×4
-    const pieces = splitBinSize(8, 8, 4);
-    expect(pieces.length).toBe(4);
-    expect(pieces.every((p) => p.width === 4 && p.depth === 4)).toBe(true);
-  });
-
-  it('handles 6×5 with maxSize 4 (both dimensions need splitting)', () => {
-    // 6×5 → leftW=3, rightW=3, topD=3, bottomD=2
-    // Results in: 3×3, 3×3, 3×2, 3×2
-    const pieces = splitBinSize(6, 5, 4);
-    expect(pieces.length).toBe(4);
-    expect(pieces.every((p) => p.width <= 4 && p.depth <= 4)).toBe(true);
+  // The pieces tile the bin: their spans must add back up to it, which is what
+  // lets the diagram recover the grid from one piece size.
+  it.each([
+    [5, 3],
+    [9, 3],
+    [12, 1],
+    [6, 5],
+    [7, 3],
+  ])('tiles %d x %d exactly', (w, d) => {
+    const [piece] = splitBinSize(w, d, maxSize);
+    const cols = Math.round(w / piece.width);
+    const rows = Math.round(d / piece.depth);
+    expect(cols * rows).toBe(piece.count);
+    expect(piece.width * cols).toBeCloseTo(w, 1);
+    expect(piece.depth * rows).toBeCloseTo(d, 1);
   });
 });
 
 describe('splitBinSize with fractional dimensions (half-bin mode)', () => {
-  it('does not split 1.5×1.5 when maxSize is 2', () => {
-    const pieces = splitBinSize(1.5, 1.5, 2);
-    expect(pieces).toEqual([{ width: gridUnits(1.5), depth: gridUnits(1.5), count: 1 }]);
-  });
-
-  it('handles 1.5×1.5 with maxSize 1', () => {
-    const pieces = splitBinSize(1.5, 1.5, 1);
-    // Should split to: 1×1, 0.5×1, 1×0.5, 0.5×0.5
-    expect(pieces).toHaveLength(4);
-    expect(pieces.every((p) => p.width <= 1 && p.depth <= 1)).toBe(true);
-    expect(pieces.every((p) => p.width > 0 && p.depth > 0)).toBe(true);
-  });
-
-  it('handles 2.5×3 with maxSize 2', () => {
-    const pieces = splitBinSize(2.5, 3, 2);
-    expect(pieces.every((p) => p.width <= 2 && p.depth <= 2)).toBe(true);
-    expect(pieces.every((p) => p.width > 0 && p.depth > 0)).toBe(true);
-  });
-
-  it('handles 0.5×0.5 without creating zero-dimension pieces', () => {
-    // Smallest half-bin should not split further
-    const pieces = splitBinSize(0.5, 0.5, 1);
-    expect(pieces).toEqual([{ width: gridUnits(0.5), depth: gridUnits(0.5), count: 1 }]);
-  });
-
-  it('preserves fractional dimensions in output', () => {
-    // A 2.5×2 bin with max 2 should produce pieces with 0.5 dimensions
-    const pieces = splitBinSize(2.5, 2, 2);
-    // Should split width: 1.5 + 1 (uses 0.5-aware rounding for fractional input)
-    expect(pieces.some((p) => p.width === 1.5 || p.width === 1)).toBe(true);
-    expect(pieces.every((p) => p.width <= 2 && p.depth <= 2)).toBe(true);
-  });
-
-  it('does not split when bin fits with half-unit max (6.5 max)', () => {
-    // A 6.5-unit bin should not split when maxWidth is 6.5
-    const pieces = splitBinSize(6.5, 3, 6.5);
-    expect(pieces).toEqual([{ width: gridUnits(6.5), depth: gridUnits(3), count: 1 }]);
-  });
-
-  it('splits correctly when exceeding half-unit max', () => {
-    // A 7-unit bin with max 6.5 should split
-    const pieces = splitBinSize(7, 3, 6.5);
-    expect(pieces).toHaveLength(2);
-    expect(pieces.every((p) => p.width <= 6.5 && p.depth <= 6.5)).toBe(true);
+  it.each([
+    { w: 1.5, d: 1.5, max: 2, piece: [1.5, 1.5], count: 1 },
+    { w: 0.5, d: 0.5, max: 1, piece: [0.5, 0.5], count: 1 },
+    { w: 6.5, d: 3, max: 6.5, piece: [6.5, 3], count: 1 },
+    // Halving a half-unit axis lands on quarters — a real cut plane, since
+    // `getSplitPlanePositionsMm` puts the seam exactly there.
+    { w: 1.5, d: 1.5, max: 1, piece: [0.75, 0.75], count: 4 },
+    { w: 2.5, d: 3, max: 2, piece: [1.25, 1.5], count: 4 },
+    { w: 2.5, d: 2, max: 2, piece: [1.25, 2], count: 2 },
+    { w: 7, d: 3, max: 6.5, piece: [3.5, 3], count: 2 },
+  ])('cuts $w x $d into $count equal pieces at max $max', ({ w, d, max, piece, count }) => {
+    expect(splitBinSize(w, d, max)).toEqual([
+      { width: gridUnits(piece[0]), depth: gridUnits(piece[1]), count },
+    ]);
   });
 });
 
@@ -194,7 +139,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(2);
     expect(rows[0].totalPieces).toBe(2);
@@ -216,7 +161,7 @@ describe('generatePrintList', () => {
       { ...base, id: binId('2'), x: gridUnits(2), linkedDesignId: designId('design-b') },
       { ...base, id: binId('3'), x: gridUnits(4) }, // unlinked
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     expect(rows).toHaveLength(3);
   });
 
@@ -235,7 +180,7 @@ describe('generatePrintList', () => {
       { ...base, id: binId('1'), x: gridUnits(0), linkedDesignId: designId('design-a') },
       { ...base, id: binId('2'), x: gridUnits(2), linkedDesignId: designId('design-a') },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(2);
   });
@@ -255,7 +200,7 @@ describe('generatePrintList', () => {
       { ...base, id: binId('1'), x: gridUnits(0), linkedDesignId: designId('design-a') },
       { ...base, id: binId('2'), x: gridUnits(2) },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     const linked = rows.find((r) => r.linkedDesignId !== undefined);
     const unlinked = rows.find((r) => r.linkedDesignId === undefined);
     expect(linked?.linkedDesignId).toBe('design-a');
@@ -289,7 +234,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(1);
   });
@@ -321,7 +266,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     expect(rows).toHaveLength(2);
   });
 
@@ -340,7 +285,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     expect(rows[0].needsSplit).toBe(true);
     expect(rows[0].totalPieces).toBe(2); // 3×3 + 2×3
   });
@@ -374,7 +319,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // Both bins are identical, so they should be grouped into one row
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(2);
@@ -398,7 +343,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     expect(rows[0].needsSplit).toBe(true);
     // 6x6 with max 4: splits to 4 pieces of 3x3
     expect(rows[0].pieces).toHaveLength(1); // All identical, merged
@@ -432,7 +377,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // Bins with different labels get separate rows
     expect(rows).toHaveLength(2);
     expect(rows[0].labels).toContain('Screws');
@@ -466,7 +411,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // Bins with same dimensions + label + category are consolidated
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(2);
@@ -512,7 +457,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // Two unlabeled bins grouped, one labeled bin separate
     expect(rows).toHaveLength(2);
   });
@@ -546,7 +491,7 @@ describe('generatePrintList', () => {
         customProperties: { SKU: 'B2' },
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // Bins are consolidated, custom properties are merged with "; " separator
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(2);
@@ -582,7 +527,7 @@ describe('generatePrintList', () => {
         customProperties: { Color: 'Red' },
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // Consolidated - duplicate values are deduplicated
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(2);
@@ -628,7 +573,7 @@ describe('generatePrintList', () => {
         notes: 'Note 1', // Duplicate
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // All bins consolidated, notes merged (unique only)
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(3);
@@ -675,7 +620,7 @@ describe('generatePrintList', () => {
         customProperties: { SKU: 'C3' },
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // All 3 bins are consolidated (same dimensions + label + category)
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(3);
@@ -711,7 +656,7 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows = generatePrintList(bins, 4);
+    const rows = generatePrintList(bins, fitAt(4));
     // Empty customProperties should not cause separation
     expect(rows).toHaveLength(1);
     expect(rows[0].binCount).toBe(2);
@@ -732,11 +677,11 @@ describe('generatePrintList', () => {
         notes: '',
       },
     ];
-    const rows04 = generatePrintList(bins, 4, {
+    const rows04 = generatePrintList(bins, fitAt(4), {
       ...DEFAULT_PRINT_SETTINGS,
       nozzleSizeMm: 0.4,
     });
-    const rows06 = generatePrintList(bins, 4, {
+    const rows06 = generatePrintList(bins, fitAt(4), {
       ...DEFAULT_PRINT_SETTINGS,
       nozzleSizeMm: 0.6,
     });
@@ -916,5 +861,62 @@ describe('getSpoolEstimate', () => {
   it('handles large amounts', () => {
     // 1000m → 1000/330 = 3.03 → 3.1
     expect(getSpoolEstimate(1000)).toBe(3.1);
+  });
+});
+
+// An overhang grows a bin's body in millimetres past its footprint, so a bin
+// whose grid units fit the bed can still be too wide to print. The exporter has
+// always charged it; the print list did not, and reported one uncut piece for a
+// part the export writes in two.
+describe('generatePrintList with overhang', () => {
+  function binAt(id: string, x: number, width = 4): Bin {
+    return {
+      id: binId(id),
+      layerId: layerId('l1'),
+      x: gridUnits(x),
+      y: gridUnits(0),
+      width: gridUnits(width),
+      depth: gridUnits(1),
+      height: heightUnits(3),
+      category: categoryId('c1'),
+      label: '',
+      notes: '',
+      linkedDesignId: designId('d1'),
+    };
+  }
+
+  const WIDE: OverhangConfig = { left: 61.5, right: 42, front: 0, back: 0, enabled: true };
+
+  it('splits a bin whose overhang overruns the bed', () => {
+    // 4 x 42mm is 168mm of grid, inside a 180mm bed; the overhang makes the
+    // real part 271.5mm wide.
+    const fit = fitAt(180 / 42, () => WIDE);
+    const rows = generatePrintList([binAt('1', 0)], fit);
+    expect(rows[0].needsSplit).toBe(true);
+    expect(rows[0].pieces[0].count).toBe(2);
+  });
+
+  it('leaves the same bin unsplit with no overhang', () => {
+    const rows = generatePrintList([binAt('1', 0)], fitAt(180 / 42));
+    expect(rows[0].needsSplit).toBe(false);
+    expect(rows[0].pieces[0].count).toBe(1);
+  });
+
+  // Two placements of one design with different overhangs are two printed
+  // parts, and only one of them may need cutting — the layout export keys on
+  // `designId|overhangKey` for the same reason.
+  it('keeps placements with different overhangs in separate rows', () => {
+    const fit = fitAt(180 / 42, (bin) => (bin.x === 0 ? WIDE : undefined));
+    const rows = generatePrintList([binAt('1', 0), binAt('2', 4)], fit);
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((r) => r.needsSplit)).toHaveLength(1);
+  });
+
+  it('merges placements that resolve to the same overhang', () => {
+    const fit = fitAt(180 / 42, () => WIDE);
+    const rows = generatePrintList([binAt('1', 0), binAt('2', 4)], fit);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].binCount).toBe(2);
+    expect(rows[0].totalPieces).toBe(4);
   });
 });

--- a/src/features/print-export/utils/split.ts
+++ b/src/features/print-export/utils/split.ts
@@ -10,7 +10,11 @@ import type {
   CategoryId,
   DesignId,
 } from '@/core/types';
+import type { OverhangConfig } from '@/shared/types/bin';
 import { getGridBins } from '@/shared/utils';
+import { getSplitPositions } from '@/shared/utils/splitPositions';
+import { binSplitChunkUnits } from '@/shared/utils/binSplitFit';
+import { overhangKey, resolveOverhang } from '@/shared/utils/overhang';
 import {
   calcFilamentCost,
   calcSpoolPercentage,
@@ -24,35 +28,33 @@ import {
 } from '@/shared/printSettings';
 
 /**
- * Split a dimension in half, rounding appropriately.
- * - For integer dimensions: ceil gives larger piece (5→3), floor gives smaller (5→2)
- * - For fractional dimensions (half-bin mode): uses 0.5-aware rounding
+ * Piece size along one axis, in grid units — the SAME partition the exporter
+ * cuts, read from the same helper it uses.
  *
- * @param dimension The original dimension being split
- * @param useCeil If true, round up; if false, round down
+ * The print list used to derive its own by recursive uneven halving, which
+ * agreed with the exporter only by coincidence. A 5-unit bin was listed as a
+ * 3 plus a 2 where the exporter emits two 2.5s, and at 10 and 12 units the
+ * halving produced a whole EXTRA piece (4 against 3) — over-reporting the piece
+ * count, and with it the filament, cost and print-time totals built on top.
+ *
+ * Pieces are equal by construction, so an axis is fully described by one size
+ * and a count.
  */
-function splitHalf(dimension: number, useCeil: boolean): number {
-  const half = dimension / 2;
-
-  // If original dimension is a whole number, use integer rounding
-  if (Number.isInteger(dimension)) {
-    return useCeil ? Math.ceil(half) : Math.floor(half);
-  }
-
-  // For fractional dimensions (half-bin mode), use 0.5-aware rounding
-  return useCeil ? Math.ceil(half * 2) / 2 : Math.floor(half * 2) / 2;
+function axisPieces(size: number, maxSize: number): { size: number; count: number } {
+  const count = getSplitPositions(size, maxSize).length + 1;
+  // An even split into 3 is a repeating fraction, which is a real piece size
+  // (the exporter cuts exactly there) but not one to print at float precision.
+  // The rounding is display-only: it moves a 10-unit third by 0.0014mm.
+  return { size: Math.round((size / count) * 100) / 100, count };
 }
 
 /**
- * Recursively split a bin size until all pieces fit within maxSize.
- * Uses greedy halving strategy from PRD.
- * Supports fractional dimensions (0.5 increments) for half-bin mode.
+ * The pieces a bin is cut into to fit the plate: a regular grid of equal
+ * pieces, `widthPieces x depthPieces`, matching what the exporter builds.
  *
- * Examples (maxSize = 4):
- * - 5×3 → [3×3, 2×3]
- * - 9×3 → [5×3, 4×3] → [3×3, 2×3, 4×3]
- * - 5×6 → [3×3, 2×3, 3×3, 2×3]
- * - 1.5×1.5 (maxSize=1) → [1×1, 0.5×1, 1×0.5, 0.5×0.5]
+ * `maxWidth`/`maxDepth` are the largest chunk each axis may be cut into — pass
+ * `binSplitChunkUnits`, which charges the bin's overhang, rather than a bare
+ * bed capacity.
  */
 export function splitBinSize(
   width: number,
@@ -60,43 +62,9 @@ export function splitBinSize(
   maxWidth: number,
   maxDepth: number = maxWidth
 ): PrintPiece[] {
-  if (width <= maxWidth && depth <= maxDepth) {
-    return [{ width: width as GridUnits, depth: depth as GridUnits, count: 1 }];
-  }
-
-  const pieces: PrintPiece[] = [];
-
-  if (width > maxWidth && depth <= maxDepth) {
-    // Split width only - preserves integer vs fractional behavior
-    const left = splitHalf(width, true);
-    const right = splitHalf(width, false);
-    pieces.push(...splitBinSize(left, depth, maxWidth, maxDepth));
-    if (right > 0) {
-      pieces.push(...splitBinSize(right, depth, maxWidth, maxDepth));
-    }
-  } else if (width <= maxWidth && depth > maxDepth) {
-    // Split depth only
-    const top = splitHalf(depth, true);
-    const bottom = splitHalf(depth, false);
-    pieces.push(...splitBinSize(width, top, maxWidth, maxDepth));
-    if (bottom > 0) {
-      pieces.push(...splitBinSize(width, bottom, maxWidth, maxDepth));
-    }
-  } else {
-    // Split both dimensions
-    const leftW = splitHalf(width, true);
-    const rightW = splitHalf(width, false);
-    const topD = splitHalf(depth, true);
-    const bottomD = splitHalf(depth, false);
-
-    pieces.push(...splitBinSize(leftW, topD, maxWidth, maxDepth));
-    if (rightW > 0) pieces.push(...splitBinSize(rightW, topD, maxWidth, maxDepth));
-    if (bottomD > 0) pieces.push(...splitBinSize(leftW, bottomD, maxWidth, maxDepth));
-    if (rightW > 0 && bottomD > 0)
-      pieces.push(...splitBinSize(rightW, bottomD, maxWidth, maxDepth));
-  }
-
-  return pieces.filter((p) => p.width > 0 && p.depth > 0);
+  const w = axisPieces(width, maxWidth);
+  const d = axisPieces(depth, maxDepth);
+  return [{ width: w.size as GridUnits, depth: d.size as GridUnits, count: w.count * d.count }];
 }
 
 /**
@@ -166,19 +134,65 @@ function mergeCustomProperties(
 }
 
 /**
+ * Everything the split plan needs, in the terms the exporter states it.
+ *
+ * The bed is in MILLIMETRES rather than pre-divided grid units on purpose: an
+ * overhang grows a bin's body in mm past its footprint, so a bin whose units fit
+ * can still overrun the plate, and a capacity already reduced to units has
+ * thrown away what that would be charged against.
+ */
+export interface PrintSplitFit {
+  readonly bedWidthMm: number;
+  readonly bedDepthMm: number;
+  readonly gridUnitMm: number;
+  readonly gridUnitMmY: number;
+  /**
+   * The overhang a placed bin carries, resolved the way the exporter resolves
+   * it (`resolveBinOverhang`). Two placements of one design with different
+   * overhangs are different printed parts, so this also keys the grouping —
+   * mirroring the layout export's `designId|overhangKey`.
+   *
+   * Omit for a plain capacity check.
+   */
+  readonly overhangFor?: (bin: Bin) => OverhangConfig | undefined;
+}
+
+/** Chunk limit and grouping key for one bin's split. */
+function fitForBin(
+  bin: Bin,
+  fit: PrintSplitFit
+): { maxWidth: number; maxDepth: number; key: string } {
+  const overhang = fit.overhangFor?.(bin);
+  const limit = binSplitChunkUnits(
+    {
+      width: bin.width,
+      depth: bin.depth,
+      gridUnitMm: fit.gridUnitMm,
+      gridUnitMmY: fit.gridUnitMmY,
+      overhang,
+    },
+    fit.bedWidthMm,
+    fit.bedDepthMm
+  );
+  return {
+    maxWidth: limit.width,
+    maxDepth: limit.depth,
+    key: overhangKey(resolveOverhang(overhang)),
+  };
+}
+
+/**
  * Generate the print list from bins.
- * Groups bins by size×height×label×category, calculates split pieces.
+ * Groups bins by size×height×label×category×overhang, calculates split pieces.
  * Bins with the same dimensions AND label AND category are consolidated with quantity counts.
  * Notes and custom properties are merged (unique values joined with "; ").
  */
 export function generatePrintList(
   bins: Bin[],
-  maxPrintSize: number | { width: number; depth: number },
+  fit: PrintSplitFit,
   printSettings: PrintSettings = DEFAULT_PRINT_SETTINGS,
   layoutUnits?: { gridUnitMm: number; heightUnitMm: number }
 ): PrintRow[] {
-  const maxW = typeof maxPrintSize === 'number' ? maxPrintSize : maxPrintSize.width;
-  const maxD = typeof maxPrintSize === 'number' ? maxPrintSize : maxPrintSize.depth;
   const placedBins = getGridBins(bins);
 
   // Group by size, height, label, and category (consolidate same dimensions + label + category)
@@ -195,15 +209,20 @@ export function generatePrintList(
       binIds: BinId[];
       customPropertiesList: Array<Record<string, string> | undefined>; // Collect for merging
       linkedDesignId?: DesignId;
+      maxWidth: number;
+      maxDepth: number;
     }
   >();
 
   for (const bin of placedBins) {
     // Consolidate bins with same size + height + label + category + linked
-    // design. Link identity matters: two designs with identical dimensions
-    // (e.g. an imported mesh next to a parametric bin) are different printed
-    // parts and must not merge into one row.
-    const key = `${bin.width}×${bin.depth}×${bin.height}:${bin.category}:${bin.label || ''}:${bin.linkedDesignId ?? ''}`;
+    // design + overhang. Link identity matters: two designs with identical
+    // dimensions (e.g. an imported mesh next to a parametric bin) are different
+    // printed parts and must not merge into one row. So does the overhang: the
+    // same design against a padded drawer edge and away from it are two parts,
+    // and only one of them may need cutting.
+    const binFit = fitForBin(bin, fit);
+    const key = `${bin.width}×${bin.depth}×${bin.height}:${bin.category}:${bin.label || ''}:${bin.linkedDesignId ?? ''}:${binFit.key}`;
     const existing = groups.get(key);
     if (existing) {
       existing.count++;
@@ -222,6 +241,8 @@ export function generatePrintList(
         binIds: [bin.id],
         customPropertiesList: [bin.customProperties],
         linkedDesignId: bin.linkedDesignId,
+        maxWidth: binFit.maxWidth,
+        maxDepth: binFit.maxDepth,
       });
     }
   }
@@ -229,9 +250,9 @@ export function generatePrintList(
   const rows: PrintRow[] = [];
 
   for (const [, group] of groups) {
-    const pieces = splitBinSize(group.width, group.depth, maxW, maxD);
+    const pieces = splitBinSize(group.width, group.depth, group.maxWidth, group.maxDepth);
     const mergedPieces = mergePieces(pieces);
-    const needsSplit = group.width > maxW || group.depth > maxD;
+    const needsSplit = group.width > group.maxWidth || group.depth > group.maxDepth;
     const totalPieces = mergedPieces.reduce((sum, p) => sum + p.count, 0) * group.count;
 
     // Calculate filament for all pieces in this row (analytical volume model)
@@ -318,7 +339,7 @@ export function getSpoolEstimate(totalFilament: number): number {
  */
 export function generateEnhancedPrintList(
   bins: Bin[],
-  maxPrintSize: number | { width: number; depth: number },
+  fit: PrintSplitFit,
   printSettings: PrintSettings = DEFAULT_PRINT_SETTINGS,
   config: PrintListConfig = {
     filamentCostPerKg: DEFAULT_COST_PER_KG,
@@ -326,7 +347,7 @@ export function generateEnhancedPrintList(
   },
   layoutUnits?: { gridUnitMm: number; heightUnitMm: number }
 ): EnhancedPrintRow[] {
-  const baseRows = generatePrintList(bins, maxPrintSize, printSettings, layoutUnits);
+  const baseRows = generatePrintList(bins, fit, printSettings, layoutUnits);
 
   return baseRows.map((row) => {
     const [width, depth] = row.size.split('×').map(Number);

--- a/src/features/print-export/utils/split.ts
+++ b/src/features/print-export/utils/split.ts
@@ -42,10 +42,21 @@ import {
  */
 function axisPieces(size: number, maxSize: number): { size: number; count: number } {
   const count = getSplitPositions(size, maxSize).length + 1;
-  // An even split into 3 is a repeating fraction, which is a real piece size
-  // (the exporter cuts exactly there) but not one to print at float precision.
-  // The rounding is display-only: it moves a 10-unit third by 0.0014mm.
-  return { size: Math.round((size / count) * 100) / 100, count };
+  // Exact, not rounded: this size feeds the filament estimate and lets the
+  // diagram recover the piece grid by division. An even split into 3 really is
+  // a repeating fraction — the exporter cuts exactly there — so the rounding
+  // belongs at the label (`formatPieceSize`), where it changes nothing but the
+  // text.
+  return { size: size / count, count };
+}
+
+/**
+ * A piece dimension as text. The only place a piece size is rounded, so the
+ * number the estimate used and the number the user reads cannot drift: an even
+ * split into 3 gives 3.3333…, which is a real cut plane and an unreadable label.
+ */
+export function formatPieceSize(units: number): string {
+  return String(Math.round(units * 100) / 100);
 }
 
 /**

--- a/src/shell/Mobile/MobilePrintList/MobilePrintList.tsx
+++ b/src/shell/Mobile/MobilePrintList/MobilePrintList.tsx
@@ -5,6 +5,7 @@ import { usePrintList } from '@/features/print-export/hooks/usePrintList';
 import { useLayoutStore } from '@/core/store';
 import { PrintListSummary, PrintListEmpty } from '@/features/print-export/components';
 import { SplitPreview } from '@/shell/Print/SplitPreview';
+import { formatPieceSize } from '@/features/print-export/utils/split';
 import { Button } from '@/design-system';
 import { useTranslation } from '@/i18n';
 
@@ -242,7 +243,8 @@ export function MobilePrintList() {
                             key={`${piece.width}x${piece.depth}`}
                             className="text-content-tertiary"
                           >
-                            {piece.count}× {piece.width}×{piece.depth}
+                            {piece.count}× {formatPieceSize(piece.width)}×
+                            {formatPieceSize(piece.depth)}
                           </div>
                         ))}
                       </div>

--- a/src/shell/Print/SplitPreview/SplitPreview.test.tsx
+++ b/src/shell/Print/SplitPreview/SplitPreview.test.tsx
@@ -3,163 +3,90 @@ import { render, screen } from '@testing-library/react';
 import { SplitPreview } from '@/shell/Print/SplitPreview';
 import type { PrintPiece } from '@/core/types';
 import { gridUnits } from '@/core/types';
+import { splitBinSize } from '@/features/print-export/utils/split';
 
 describe('SplitPreview', () => {
-  const createPiece = (width: number, depth: number, count = 1): PrintPiece => ({
+  const piece = (width: number, depth: number, count = 1): PrintPiece => ({
     width: gridUnits(width),
     depth: gridUnits(depth),
     count,
   });
 
+  function boxes(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>('[class*="absolute"]'));
+  }
+
   describe('rendering', () => {
-    it('renders pieces with correct dimensions', () => {
-      const pieces = [createPiece(2, 2)];
-      render(<SplitPreview width={4} depth={4} pieces={pieces} />);
-
-      expect(screen.getByText('2×2')).toBeInTheDocument();
-    });
-
-    it('renders multiple different pieces', () => {
-      const pieces = [createPiece(2, 2), createPiece(1, 1)];
-      render(<SplitPreview width={4} depth={4} pieces={pieces} />);
-
-      expect(screen.getByText('2×2')).toBeInTheDocument();
-      expect(screen.getByText('1×1')).toBeInTheDocument();
-    });
-
-    it('renders multiple copies of the same piece', () => {
-      const pieces = [createPiece(2, 2, 2)];
-      render(<SplitPreview width={4} depth={4} pieces={pieces} />);
-
-      // Should show two 2×2 pieces
-      const labels = screen.getAllByText('2×2');
-      expect(labels).toHaveLength(2);
+    it('draws one box per piece, each labelled with its size', () => {
+      const { container } = render(<SplitPreview width={4} depth={4} pieces={[piece(2, 2, 4)]} />);
+      expect(boxes(container)).toHaveLength(4);
+      expect(screen.getAllByText('2×2')).toHaveLength(4);
     });
 
     it('renders container with correct size', () => {
       const { container } = render(
-        <SplitPreview width={4} depth={4} pieces={[]} cellSize={16} gap={2} />
+        <SplitPreview width={4} depth={4} pieces={[piece(2, 2, 4)]} cellSize={16} gap={2} />
       );
-
       const preview = container.firstChild as HTMLElement;
-      // Width: 4 * 16 + 3 * 2 = 70px
-      // Height: 4 * 16 + 3 * 2 = 70px
+      // 4 * 16 + 3 * 2 = 70px
       expect(preview.style.width).toBe('70px');
       expect(preview.style.height).toBe('70px');
+    });
+
+    it('renders nothing when there are no pieces', () => {
+      const { container } = render(<SplitPreview width={4} depth={4} pieces={[]} />);
+      expect(container).toBeEmptyDOMElement();
     });
   });
 
   describe('piece placement', () => {
-    it('places pieces from bottom-left', () => {
-      const pieces = [createPiece(2, 2)];
+    it('lays the pieces out as a grid from the bottom-left', () => {
       const { container } = render(
-        <SplitPreview width={4} depth={4} pieces={pieces} cellSize={16} gap={2} />
+        <SplitPreview width={4} depth={4} pieces={[piece(2, 2, 4)]} cellSize={16} gap={2} />
       );
-
-      const piece = container.querySelector('[class*="absolute"]') as HTMLElement;
-      expect(piece.style.left).toBe('0px');
-      expect(piece.style.bottom).toBe('0px');
+      const placed = boxes(container).map((b) => [b.style.left, b.style.bottom]);
+      // One pitch of 2 units is 2 * (16 + 2) = 36px.
+      expect(placed).toEqual([
+        ['0px', '0px'],
+        ['36px', '0px'],
+        ['0px', '36px'],
+        ['36px', '36px'],
+      ]);
     });
 
-    it('places pieces left-to-right', () => {
-      const pieces = [createPiece(2, 2, 2)];
+    it('sizes each box from the piece, not the cell count', () => {
       const { container } = render(
-        <SplitPreview width={4} depth={4} pieces={pieces} cellSize={16} gap={2} />
+        <SplitPreview width={4} depth={4} pieces={[piece(2, 2, 4)]} cellSize={20} gap={4} />
       );
-
-      const placedPieces = container.querySelectorAll('[class*="absolute"]');
-      expect(placedPieces).toHaveLength(2);
-
-      // First piece at x=0
-      expect((placedPieces[0] as HTMLElement).style.left).toBe('0px');
-      // Second piece at x=2 (2 * (16 + 2) = 36)
-      expect((placedPieces[1] as HTMLElement).style.left).toBe('36px');
-    });
-
-    it('wraps to next row when full', () => {
-      const pieces = [createPiece(2, 2, 3)]; // 3 pieces of 2x2 in 4x4 grid
-      const { container } = render(
-        <SplitPreview width={4} depth={4} pieces={pieces} cellSize={16} gap={2} />
-      );
-
-      const placedPieces = container.querySelectorAll('[class*="absolute"]');
-      // Only 2 fit in first row (2+2=4), third goes to second row
-      expect(placedPieces).toHaveLength(3);
-
-      // Third piece should be at y=2 (row 1)
-      expect((placedPieces[2] as HTMLElement).style.bottom).toBe('36px');
+      // 2 * 20 + 1 * 4 = 44px
+      expect(boxes(container)[0].style.width).toBe('44px');
     });
   });
 
-  describe('custom cell size', () => {
-    it('uses custom cell size', () => {
-      const pieces = [createPiece(2, 2)];
-      const { container } = render(
-        <SplitPreview width={4} depth={4} pieces={pieces} cellSize={20} gap={4} />
-      );
-
-      const preview = container.firstChild as HTMLElement;
-      // Width: 4 * 20 + 3 * 4 = 92px
-      expect(preview.style.width).toBe('92px');
+  // The split cuts a bin into equal pieces, which for an odd count means
+  // thirds. The old greedy packer only tried whole-cell origins, so the last
+  // third had nowhere left to go and vanished from the diagram while the count
+  // beside it still said three.
+  describe('fractional pieces', () => {
+    it('draws every piece of a three-way split', () => {
+      const pieces = splitBinSize(10, 1, 4);
+      const { container } = render(<SplitPreview width={10} depth={1} pieces={pieces} />);
+      expect(pieces[0].count).toBe(3);
+      expect(boxes(container)).toHaveLength(3);
     });
 
-    it('calculates piece dimensions with custom cell size', () => {
-      const pieces = [createPiece(2, 2)];
-      const { container } = render(
-        <SplitPreview width={4} depth={4} pieces={pieces} cellSize={20} gap={4} />
-      );
-
-      const piece = container.querySelector('[class*="absolute"]') as HTMLElement;
-      // Piece width: 2 * 20 + 1 * 4 = 44px
-      expect(piece.style.width).toBe('44px');
-    });
-  });
-
-  describe('empty state', () => {
-    it('renders empty container when no pieces', () => {
-      const { container } = render(<SplitPreview width={4} depth={4} pieces={[]} />);
-
-      const pieces = container.querySelectorAll('[class*="absolute"]');
-      expect(pieces).toHaveLength(0);
-    });
-  });
-
-  describe('half-grid (fractional) dimensions', () => {
-    it('renders without crashing when bin and pieces are fractional', () => {
-      const pieces = [createPiece(2.5, 0.5)];
-      expect(() => render(<SplitPreview width={2.5} depth={2.5} pieces={pieces} />)).not.toThrow();
-
-      expect(screen.getByText('2.5×0.5')).toBeInTheDocument();
+    it('draws every piece of a half-grid split', () => {
+      const pieces = splitBinSize(1.5, 1.5, 1);
+      const { container } = render(<SplitPreview width={1.5} depth={1.5} pieces={pieces} />);
+      expect(pieces[0].count).toBe(4);
+      expect(boxes(container)).toHaveLength(4);
     });
 
-    it('places a fractional piece within the ceil-sized grid', () => {
-      const pieces = [createPiece(0.5, 0.5)];
-      const { container } = render(
-        <SplitPreview width={1.5} depth={1.5} pieces={pieces} cellSize={16} gap={2} />
-      );
-
-      const placed = container.querySelectorAll('[class*="absolute"]');
-      expect(placed).toHaveLength(1);
-      expect((placed[0] as HTMLElement).style.left).toBe('0px');
-      expect((placed[0] as HTMLElement).style.bottom).toBe('0px');
-    });
-  });
-
-  describe('complex layouts', () => {
-    it('handles mixed piece sizes', () => {
-      const pieces = [createPiece(3, 2), createPiece(1, 2)];
-      render(<SplitPreview width={4} depth={4} pieces={pieces} />);
-
-      expect(screen.getByText('3×2')).toBeInTheDocument();
-      expect(screen.getByText('1×2')).toBeInTheDocument();
-    });
-
-    it('handles pieces that fill exactly', () => {
-      const pieces = [createPiece(2, 2, 4)]; // 4 pieces of 2x2 = 4x4 grid
-      const { container } = render(<SplitPreview width={4} depth={4} pieces={pieces} />);
-
-      const placedPieces = container.querySelectorAll('[class*="absolute"]');
-      expect(placedPieces).toHaveLength(4);
+    it('draws a single unsplit piece', () => {
+      const pieces = splitBinSize(2.5, 2.5, 4);
+      const { container } = render(<SplitPreview width={2.5} depth={2.5} pieces={pieces} />);
+      expect(boxes(container)).toHaveLength(1);
+      expect(screen.getByText('2.5×2.5')).toBeInTheDocument();
     });
   });
 });

--- a/src/shell/Print/SplitPreview/SplitPreview.tsx
+++ b/src/shell/Print/SplitPreview/SplitPreview.tsx
@@ -1,4 +1,5 @@
 import type { PrintPiece } from '@/core/types';
+import { formatPieceSize } from '@/features/print-export/utils/split';
 
 const STYLES = {
   splitPiece: {
@@ -61,7 +62,7 @@ export function SplitPreview({ width, depth, pieces, cellSize = 16, gap = 2 }: S
               ...STYLES.splitPiece,
             }}
           >
-            {piece.width}×{piece.depth}
+            {formatPieceSize(piece.width)}×{formatPieceSize(piece.depth)}
           </div>
         ))
       )}

--- a/src/shell/Print/SplitPreview/SplitPreview.tsx
+++ b/src/shell/Print/SplitPreview/SplitPreview.tsx
@@ -19,77 +19,52 @@ interface SplitPreviewProps {
   gap?: number;
 }
 
+/** Pixel span of `units` grid units, laid out on the cell+gap pitch. */
+function span(units: number, cellSize: number, gap: number): number {
+  return units * cellSize + (units - 1) * gap;
+}
+
 /**
  * Visual preview of how a bin will be split for printing.
- * Shows a grid diagram with the split pieces.
+ *
+ * The split is a regular grid of equal pieces (see `splitBinSize`), so the
+ * diagram lays that grid out directly rather than packing pieces into whole
+ * cells. Packing could not draw this shape: an even split into 3 gives pieces
+ * of 3.33 units, and a scan that only ever tried whole-cell origins ran out of
+ * room before placing the last one — dropping a piece from the diagram while
+ * the count beside it still said three.
  */
 export function SplitPreview({ width, depth, pieces, cellSize = 16, gap = 2 }: SplitPreviewProps) {
-  // Half-grid bins yield fractional width/depth; allocate and scan whole cells so a
-  // fractional piece can't index a row/column the grid never allocated.
-  const cols = Math.max(0, Math.ceil(width));
-  const rows = Math.max(0, Math.ceil(depth));
+  const piece = pieces[0];
+  if (!piece || piece.width <= 0 || piece.depth <= 0) return null;
 
-  // Create a 2D grid to place pieces
-  const grid: (PrintPiece | null)[][] = Array.from({ length: rows }, () =>
-    Array.from({ length: cols }, () => null)
-  );
-
-  // Place pieces using greedy left-to-right, bottom-to-top
-  const placedPieces: Array<{ piece: PrintPiece; x: number; y: number }> = [];
-  const piecesToPlace = pieces.flatMap((p) =>
-    Array.from({ length: p.count }, () => ({ width: p.width, depth: p.depth, count: 1 }))
-  );
-
-  for (const piece of piecesToPlace) {
-    outer: for (let y = 0; y < rows; y++) {
-      for (let x = 0; x < cols; x++) {
-        let fits = true;
-        if (x + piece.width > width || y + piece.depth > depth) {
-          fits = false;
-        } else {
-          for (let py = y; py < y + piece.depth && fits; py++) {
-            for (let px = x; px < x + piece.width && fits; px++) {
-              if (grid[py][px] !== null) fits = false;
-            }
-          }
-        }
-
-        if (fits) {
-          for (let py = y; py < y + piece.depth; py++) {
-            for (let px = x; px < x + piece.width; px++) {
-              grid[py][px] = piece;
-            }
-          }
-          placedPieces.push({ piece, x, y });
-          break outer;
-        }
-      }
-    }
-  }
+  // Recovered rather than passed: the pieces tile the bin exactly, so the grid
+  // is implied by one piece's size and cannot disagree with the row's count.
+  const cols = Math.max(1, Math.round(width / piece.width));
+  const rows = Math.max(1, Math.round(depth / piece.depth));
 
   return (
     <div
       className="relative"
-      style={{
-        width: width * cellSize + (width - 1) * gap,
-        height: depth * cellSize + (depth - 1) * gap,
-      }}
+      style={{ width: span(width, cellSize, gap), height: span(depth, cellSize, gap) }}
     >
-      {placedPieces.map((placed) => (
-        <div
-          key={`${placed.x}-${placed.y}-${placed.piece.width}x${placed.piece.depth}`}
-          className="absolute flex items-center justify-center"
-          style={{
-            left: placed.x * (cellSize + gap),
-            bottom: placed.y * (cellSize + gap),
-            width: placed.piece.width * cellSize + (placed.piece.width - 1) * gap,
-            height: placed.piece.depth * cellSize + (placed.piece.depth - 1) * gap,
-            ...STYLES.splitPiece,
-          }}
-        >
-          {placed.piece.width}×{placed.piece.depth}
-        </div>
-      ))}
+      {Array.from({ length: rows }, (_, row) =>
+        Array.from({ length: cols }, (_, col) => (
+          <div
+            key={`${col}-${row}`}
+            className="absolute flex items-center justify-center overflow-hidden"
+            style={{
+              left: col * (piece.width * (cellSize + gap)),
+              bottom: row * (piece.depth * (cellSize + gap)),
+              width: span(piece.width, cellSize, gap),
+              height: span(piece.depth, cellSize, gap),
+              ...STYLES.splitPiece,
+            }}
+          >
+            {piece.width}×{piece.depth}
+          </div>
+        ))
+      )}
     </div>
   );
 }

--- a/src/shell/RightPanel/RightPanel.tsx
+++ b/src/shell/RightPanel/RightPanel.tsx
@@ -18,6 +18,7 @@ const LIST_SEPARATOR = ', ';
 import { usePrintList } from '@/features/print-export/hooks/usePrintList';
 import { PrintListSummary, PrintListEmpty } from '@/features/print-export/components';
 import { SplitPreview } from '../Print/SplitPreview';
+import { formatPieceSize } from '@/features/print-export/utils/split';
 import { getLinkedBins } from '@/features/design-linking';
 import {
   useBinInspector,
@@ -577,7 +578,8 @@ export function RightPanel() {
                                               key={`${piece.width}x${piece.depth}`}
                                               className="text-content-tertiary"
                                             >
-                                              {piece.count}× {piece.width}×{piece.depth}
+                                              {piece.count}× {formatPieceSize(piece.width)}×
+                                              {formatPieceSize(piece.depth)}
                                             </div>
                                           ))}
                                         </div>


### PR DESCRIPTION
Follow-up to #3618, which noted the print list does not model a bin's overhang. Investigating turned up a larger divergence underneath it: **the print list's split partition is not the one the exporter uses at all.**

`splitBinSize` derives its own by recursive uneven halving ("greedy halving strategy from PRD"). It predates the exporter's equal-piece `getSplitPositions` and was never reconciled with it. Measured against what the exporter emits, at a 4-unit limit:

| bin | print list said | exporter produces |
|---|---|---|
| 5u | 2 pieces: 3, 2 | 2 pieces: 2.5, 2.5 |
| 7u | 2 pieces: 4, 3 | 2 pieces: 3.5, 3.5 |
| 9u | 3 pieces: 3, 2, 4 | 3 pieces: 3, 3, 3 |
| **10u** | **4 pieces** | **3 pieces** |
| **12u** | **4 pieces** | **3 pieces** |

At 10 and 12 units it over-reports by a whole piece. `totalPieces` is that count, and the filament estimate sums `estimateStandardBinFilament` per piece — so the cost, spool and print-time totals were all built on a partition the export never writes. `SplitPreview` drew those sizes as labelled boxes.

## Changes

**`splitBinSize` reads the same helper the exporter cuts with.** Pieces are equal by construction, so a bin is fully described by one piece size and a count. Sizes are rounded to 2dp for display — an even split into 3 is a repeating fraction, and the rounding moves a 10-unit third by 0.0014mm.

**`SplitPreview` lays the grid out directly** instead of packing boxes into whole cells. Packing could not draw this shape: for pieces of 3.33 units on a 10-unit bin, a scan that only tried whole-cell origins had nowhere left for the third piece (`8 + 3.33 > 10`), so it dropped one from the diagram while the count beside it still said three. The grid is recovered from one piece's size, so it cannot disagree with the row's count.

**Each bin's overhang is charged against the bed**, via `binSplitChunkUnits` from #3618, and keys the grouping alongside the linked design — mirroring the layout export's `designId|overhangKey`. Two placements of one design against different drawer edges are two printed parts, and only one of them may need cutting. `generatePrintList` takes a `PrintSplitFit` (bed in **mm**, pitch, per-bin overhang resolver) rather than a pre-divided unit capacity: a capacity already reduced to units has thrown away what an overhang would be charged against.

`usePrintList` keeps `calcMaxGridUnits` for the per-plate job estimate, which is a genuine bed-capacity question, and its `splitFit` is memoized on primitives — the old `maxGridUnits` was recomputed unmemoized every render, so `baseRows` was never actually memoized.

## Verification

`splitBinSize` and `SplitPreview` tests are rewritten against the new contract, including a property that the pieces tile the bin exactly (which is what lets the diagram recover the grid), and `generatePrintList` gains overhang cases: an overhung bin splits where a bare capacity check would not, placements with different overhangs stay in separate rows, and identical ones still merge.

Checked in the running app on a 10x1 bin at a 180mm bed: the diagram draws three `3.33×1` boxes at x = 0, 60, 120, width 58, tiling its 178px container with the intended 2px gaps.

## Still not covered

A linked design's own `params.overhang` when the bin carries no placement overhang. `resolveBinOverhang` returns `null` there by design — reaching the design's params needs either a fourth async design-loading hook (`useLabelPlateCounts`, `useLinkedDesignDividers`, `useLinkedDesignMeshes` all repeat that dance) or a new `CustomBinRef` registry field, and either is its own change rather than a rider on this one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

