### PR TITLE
feat(bin-designer): carry a design's overhang on its registry entry

### DIFF
--- a/src/features/bin-designer/components/DesignerPage/useDesignNameEditor.ts
+++ b/src/features/bin-designer/components/DesignerPage/useDesignNameEditor.ts
@@ -20,6 +20,7 @@ import {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
   registryKnifeRestFields,
 } from '@/features/bin-designer/store/customBinRegistry';
 import { binId, designId } from '@/core/types';
@@ -91,6 +92,7 @@ export function useDesignNameEditor(): DesignNameEditor {
             height: params.height,
             ...registryEdgeFields(params),
             ...registryHeightFields(params),
+            ...registryOverhangFields(params),
             ...registryKnifeRestFields(params),
             updatedAt: result.value.updatedAt,
           });
@@ -116,6 +118,7 @@ export function useDesignNameEditor(): DesignNameEditor {
             height: params.height,
             ...registryEdgeFields(params),
             ...registryHeightFields(params),
+            ...registryOverhangFields(params),
             ...registryKnifeRestFields(params),
             updatedAt: result.value.updatedAt,
           });

--- a/src/features/bin-designer/hooks/useAutoSave.test.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.test.ts
@@ -376,6 +376,58 @@ describe('useAutoSave', () => {
       unsubscribe();
     });
 
+    // The writer half of the registry's overhang field: a design edited in the
+    // designer has to carry its overhang into the registry, or the layout side
+    // reads "no overhang" for a bin that is far too wide to print.
+    it('records the design overhang on the registry entry', async () => {
+      mockUpdateDesignParams();
+      useDesignerStore.setState({ currentDesignId: 'existing-id' });
+
+      const { unmount } = renderHook(() => useAutoSave());
+      act(() => {
+        useDesignerStore
+          .getState()
+          .setParam('overhang', { left: 61.5, right: 42, front: 0, back: 0, enabled: true });
+      });
+      await act(async () => {
+        unmount();
+      });
+
+      expect(loadRegistry()).toContainEqual(
+        expect.objectContaining({
+          id: 'existing-id',
+          overhangMm: { left: 61.5, right: 42, front: 0, back: 0 },
+        })
+      );
+    });
+
+    it('clears a recorded overhang once the design no longer has one', async () => {
+      mockUpdateDesignParams();
+      useDesignerStore.setState({ currentDesignId: 'existing-id' });
+
+      const first = renderHook(() => useAutoSave());
+      act(() => {
+        useDesignerStore
+          .getState()
+          .setParam('overhang', { left: 61.5, right: 0, front: 0, back: 0, enabled: true });
+      });
+      await act(async () => {
+        first.unmount();
+      });
+
+      const second = renderHook(() => useAutoSave());
+      act(() => {
+        useDesignerStore
+          .getState()
+          .setParam('overhang', { left: 0, right: 0, front: 0, back: 0, enabled: false });
+      });
+      await act(async () => {
+        second.unmount();
+      });
+
+      expect(loadRegistry()[0]?.overhangMm).toBeUndefined();
+    });
+
     it('does not duplicate a write for the save already in flight', async () => {
       let resolveWrite: ((value: Result<SavedDesign, StorageError>) => void) | null = null;
       vi.mocked(DesignerStorage.updateDesignParams).mockReturnValue(

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -19,6 +19,7 @@ import {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
   registryKnifeRestFields,
 } from '../store/customBinRegistry';
 import { emitSyncEvent } from '@/shared/events/syncEventBus';
@@ -144,6 +145,7 @@ export function useAutoSave(): void {
         height: paramsToSave.height,
         ...registryEdgeFields(paramsToSave),
         ...registryHeightFields(paramsToSave),
+        ...registryOverhangFields(paramsToSave),
         ...registryKnifeRestFields(paramsToSave),
         updatedAt: result.value.updatedAt,
       });

--- a/src/features/bin-designer/hooks/useBackgroundThumbnailRegen.test.ts
+++ b/src/features/bin-designer/hooks/useBackgroundThumbnailRegen.test.ts
@@ -33,6 +33,7 @@ vi.mock('../store/customBinRegistry', () => ({
   upsertRegistryEntry: vi.fn(),
   registryEdgeFields: vi.fn(() => ({})),
   registryHeightFields: vi.fn(() => ({})),
+  registryOverhangFields: vi.fn(() => ({})),
   registryKnifeRestFields: vi.fn(() => ({})),
 }));
 

--- a/src/features/bin-designer/hooks/useBackgroundThumbnailRegen.ts
+++ b/src/features/bin-designer/hooks/useBackgroundThumbnailRegen.ts
@@ -33,6 +33,7 @@ import {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
   registryKnifeRestFields,
 } from '../store/customBinRegistry';
 import { regenerateThumbnail } from '../utils/thumbnailRegenerator';
@@ -216,6 +217,7 @@ async function runBatch(
         height: design.params.height,
         ...registryEdgeFields(design.params),
         ...registryHeightFields(design.params),
+        ...registryOverhangFields(design.params),
         ...registryKnifeRestFields(design.params),
         updatedAt: writeResult.value.updatedAt,
       });

--- a/src/features/bin-designer/hooks/useCreateFromBin.ts
+++ b/src/features/bin-designer/hooks/useCreateFromBin.ts
@@ -22,6 +22,7 @@ import {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
   registryKnifeRestFields,
 } from '@/features/bin-designer/store/customBinRegistry';
 import { useLayoutStore } from '@/core/store/layout';
@@ -225,6 +226,7 @@ export function useCreateFromBin(): void {
           height: binParams.height,
           ...registryEdgeFields(binParams),
           ...registryHeightFields(binParams),
+          ...registryOverhangFields(binParams),
           ...registryKnifeRestFields(binParams),
           updatedAt: design.updatedAt,
         });

--- a/src/features/bin-designer/hooks/useDesignerInit.ts
+++ b/src/features/bin-designer/hooks/useDesignerInit.ts
@@ -30,6 +30,7 @@ import {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
   registryKnifeRestFields,
 } from '../store/customBinRegistry';
 import { isBinDesign } from '../utils/designKind';
@@ -138,6 +139,7 @@ function syncToRegistry(design: SavedDesign & { params: BinParams }): void {
     height: design.params.height,
     ...registryEdgeFields(design.params),
     ...registryHeightFields(design.params),
+    ...registryOverhangFields(design.params),
     ...registryKnifeRestFields(design.params),
     updatedAt: design.updatedAt,
   });

--- a/src/features/bin-designer/hooks/useThumbnailRegeneration.ts
+++ b/src/features/bin-designer/hooks/useThumbnailRegeneration.ts
@@ -17,6 +17,7 @@ import {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
   registryKnifeRestFields,
 } from '../store/customBinRegistry';
 import { updateThumbnailCache } from './useDesignThumbnail';
@@ -86,6 +87,7 @@ export function useThumbnailRegeneration(
             height: design.params.height,
             ...registryEdgeFields(design.params),
             ...registryHeightFields(design.params),
+            ...registryOverhangFields(design.params),
             ...registryKnifeRestFields(design.params),
             updatedAt: result.value.updatedAt,
           });

--- a/src/features/bin-designer/index.ts
+++ b/src/features/bin-designer/index.ts
@@ -19,6 +19,7 @@ export {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
 } from './store';
 
 // --- Storage ---

--- a/src/features/bin-designer/store/customBinRegistry.test.ts
+++ b/src/features/bin-designer/store/customBinRegistry.test.ts
@@ -7,6 +7,7 @@ import {
   rebuildRegistry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
   type CustomBinRef,
 } from './customBinRegistry';
 import { designId } from '@/core/types';
@@ -268,6 +269,83 @@ describe('customBinRegistry', () => {
         base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
       });
       expect(flat.socketless).toBe(true);
+    });
+  });
+
+  describe('design overhang', () => {
+    const OVER = { left: 61.5, right: 42, front: 0, back: 0 };
+
+    it('projects the overhang off full params, outward-clamped', () => {
+      const fields = registryOverhangFields({
+        ...DEFAULT_BIN_PARAMS,
+        overhang: { left: 61.5, right: 42, front: -5, back: 0, enabled: true },
+      });
+      expect(fields.overhangMm).toEqual(OVER);
+    });
+
+    it('projects nothing when the design has no overhang', () => {
+      expect(registryOverhangFields(DEFAULT_BIN_PARAMS).overhangMm).toBeUndefined();
+    });
+
+    it('projects nothing when the overhang is turned off', () => {
+      const fields = registryOverhangFields({
+        ...DEFAULT_BIN_PARAMS,
+        overhang: { ...OVER, enabled: false },
+      });
+      expect(fields.overhangMm).toBeUndefined();
+    });
+
+    // A custom shape defines its own footprint, so `deriveDimensions` suppresses
+    // the overhang there and the registry must agree.
+    it('projects nothing for a partial cell mask', () => {
+      const fields = registryOverhangFields({
+        ...DEFAULT_BIN_PARAMS,
+        overhang: { ...OVER, enabled: true },
+        cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 0] },
+      });
+      expect(fields.overhangMm).toBeUndefined();
+    });
+
+    it('keeps the overhang when an update omits it', () => {
+      upsertRegistryEntry({ ...makeRef('d1'), overhangMm: OVER });
+      upsertRegistryEntry({ ...makeRef('d1', 'Renamed') });
+
+      expect(loadRegistry()[0]?.overhangMm).toEqual(OVER);
+    });
+
+    // The projector writes an explicit `undefined` for a design that lost its
+    // overhang, which has to CLEAR the field — the carry-forward tests key
+    // presence, not value, for exactly this.
+    it('clears the overhang when a re-save removed it', () => {
+      upsertRegistryEntry({ ...makeRef('d1'), overhangMm: OVER });
+      upsertRegistryEntry({
+        ...makeRef('d1'),
+        ...registryOverhangFields(DEFAULT_BIN_PARAMS),
+      });
+
+      expect(loadRegistry()[0]?.overhangMm).toBeUndefined();
+    });
+
+    it('takes a fresh overhang when the writer supplies one', () => {
+      upsertRegistryEntry({ ...makeRef('d1'), overhangMm: OVER });
+      upsertRegistryEntry({ ...makeRef('d1'), overhangMm: { ...OVER, left: 10 } });
+
+      expect(loadRegistry()[0]?.overhangMm?.left).toBe(10);
+    });
+
+    it.each([
+      { label: 'non-numeric sides', stored: { left: 'wide', right: 1, front: 0, back: 0 } },
+      { label: 'all zero', stored: { left: 0, right: 0, front: 0, back: 0 } },
+      { label: 'not an object', stored: 42 },
+    ])('drops a stored overhang with $label', ({ stored }) => {
+      localStorage.setItem(
+        'gridfinity-custom-bins-v1',
+        JSON.stringify([{ ...makeRef('d1'), overhangMm: stored }])
+      );
+      const back = loadRegistry()[0]?.overhangMm;
+      // A partly-valid record keeps its usable sides; a useless one is dropped.
+      if (back) expect(back.left).toBe(0);
+      else expect(back).toBeUndefined();
     });
   });
 });

--- a/src/features/bin-designer/store/customBinRegistry.ts
+++ b/src/features/bin-designer/store/customBinRegistry.ts
@@ -18,6 +18,8 @@ import {
   type AssembledHeightSource,
 } from '@/shared/printSettings/assembledHeight';
 import { planKnifeRest } from '@/shared/utils/knifeRestPlan';
+import { hasOverhang, resolveOverhang } from '@/shared/utils/overhang';
+import { isPartialMask } from '@/shared/utils/cellMask';
 import type { BinParams } from '../types';
 import { isSocketlessBase } from '../types/base';
 
@@ -106,6 +108,24 @@ export interface CustomBinRef {
     /** Free drawer space between block face and rest (mm). */
     readonly gapMm: number;
   };
+  /**
+   * Per-side millimetres the design's own body extends past its grid
+   * footprint, already resolved outward-only. Carried for the same reason as
+   * {@link assembledRiseMm}: "does this bin fit the print bed" is asked in
+   * synchronous selectors that cannot await full params out of IndexedDB, and
+   * an overhang grows the part in mm without changing a single grid unit — so
+   * a design whose units fit can still be far too wide to print.
+   *
+   * A PLACED bin's own overhang (`extendToMargin`, "Expand to Fit") takes
+   * precedence over this; see `resolveBinOverhang`, whose third tier this is.
+   * Absent = no overhang, or an entry saved before the field.
+   */
+  readonly overhangMm?: {
+    readonly left: number;
+    readonly right: number;
+    readonly front: number;
+    readonly back: number;
+  };
   /** ISO timestamp of last update */
   readonly updatedAt: string;
 }
@@ -176,6 +196,26 @@ export function registryKnifeRestFields(params: BinParams): Pick<CustomBinRef, '
 }
 
 /**
+ * Project the design's own overhang out of a full `BinParams`.
+ *
+ * Spread wherever {@link registryHeightFields} is. Explicitly `undefined` when
+ * there is none, so a re-save that turned the overhang off clears the stale
+ * field rather than carrying it — the same contract as
+ * {@link registryKnifeRestFields}, and the reason `withCarriedGeometry` tests
+ * key presence for both.
+ *
+ * Suppressed for a partial cell mask, matching `deriveDimensions`: a custom
+ * shape defines its own footprint and the overhang does not apply.
+ */
+export function registryOverhangFields(
+  params: Pick<BinParams, 'overhang' | 'cellMask'>
+): Pick<CustomBinRef, 'overhangMm'> {
+  const o = resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang);
+  if (!hasOverhang(o)) return { overhangMm: undefined };
+  return { overhangMm: { left: o.left, right: o.right, front: o.front, back: o.back } };
+}
+
+/**
  * Validate one raw localStorage entry and project it onto the `CustomBinRef`
  * shape. Returns `null` for anything that does not match so malformed or
  * legacy records are dropped rather than trusted. Building the object
@@ -201,6 +241,7 @@ function parseEntry(raw: unknown): CustomBinRef | null {
     socketless,
     hasLip,
     knifeRest,
+    overhangMm,
   } = raw as Record<string, unknown>;
   if (
     typeof id !== 'string' ||
@@ -235,6 +276,22 @@ function parseEntry(raw: unknown): CustomBinRef | null {
       : {}),
     ...(typeof socketless === 'boolean' ? { socketless } : {}),
     ...(typeof hasLip === 'boolean' ? { hasLip } : {}),
+    ...(() => {
+      if (typeof overhangMm !== 'object' || overhangMm === null) return {};
+      const o = overhangMm as Record<string, unknown>;
+      const side = (v: unknown): number =>
+        typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : 0;
+      const sides = {
+        left: side(o.left),
+        right: side(o.right),
+        front: side(o.front),
+        back: side(o.back),
+      };
+      // An all-zero record is the same as no record; dropping it keeps the
+      // "absent = nothing to charge" read at every consumer.
+      if (sides.left + sides.right + sides.front + sides.back <= 0) return {};
+      return { overhangMm: sides };
+    })(),
     ...(() => {
       if (typeof knifeRest !== 'object' || knifeRest === null) return {};
       const kr = knifeRest as Record<string, unknown>;
@@ -325,6 +382,11 @@ function withCarriedGeometry(next: CustomBinRef, prev: CustomBinRef): CustomBinR
     // `knifeRest: undefined` when a re-save DISABLED the rest, which must
     // clear the field — while a thumbnail/rename writer omits the key
     // entirely and must not erase it.
+    // Same key-presence rule as `knifeRest`: `registryOverhangFields` writes an
+    // explicit `overhangMm: undefined` when a re-save REMOVED the overhang.
+    ...(!('overhangMm' in next) && prev.overhangMm !== undefined
+      ? { overhangMm: prev.overhangMm }
+      : {}),
     ...(!('knifeRest' in next) && prev.knifeRest !== undefined
       ? { knifeRest: prev.knifeRest }
       : {}),

--- a/src/features/bin-designer/store/index.ts
+++ b/src/features/bin-designer/store/index.ts
@@ -7,6 +7,7 @@ export {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
   removeRegistryEntry,
   rebuildRegistry,
 } from './customBinRegistry';

--- a/src/features/design-linking/hooks/useBinLinking.test.ts
+++ b/src/features/design-linking/hooks/useBinLinking.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/features/bin-designer/store/customBinRegistry', () => ({
   upsertRegistryEntry: vi.fn(),
   registryEdgeFields: vi.fn(() => ({})),
   registryHeightFields: vi.fn(() => ({})),
+  registryOverhangFields: vi.fn(() => ({})),
 }));
 
 vi.mock('@/shared/contexts/MutationsContext', () => ({

--- a/src/features/design-linking/hooks/useBinLinking.ts
+++ b/src/features/design-linking/hooks/useBinLinking.ts
@@ -19,6 +19,7 @@ import {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
 } from '@/features/bin-designer';
 import { computeMatchedEdges, edgeForPosition } from '@/shared/utils/fractionalEdge';
 import { isFractional } from '@/core/constants';
@@ -387,6 +388,7 @@ export function useBinLinking(): UseBinLinkingReturn {
         height: newParams.height,
         ...registryEdgeFields(newParams),
         ...registryHeightFields(newParams),
+        ...registryOverhangFields(newParams),
         updatedAt: updateResult.value.updatedAt,
       });
 

--- a/src/features/design-linking/hooks/useBinResizedListener.ts
+++ b/src/features/design-linking/hooks/useBinResizedListener.ts
@@ -24,6 +24,7 @@ import {
   upsertRegistryEntry,
   registryEdgeFields,
   registryHeightFields,
+  registryOverhangFields,
 } from '@/features/bin-designer';
 import { isErr } from '@/core/result';
 import { useTranslation } from '@/i18n';
@@ -147,6 +148,7 @@ export function useBinResizedListener(): void {
           height: newDimensions.height,
           ...registryEdgeFields(newParams),
           ...registryHeightFields(newParams),
+          ...registryOverhangFields(newParams),
           updatedAt: updateResult.value.updatedAt,
         });
 

--- a/src/features/print-export/hooks/usePrintList.test.ts
+++ b/src/features/print-export/hooks/usePrintList.test.ts
@@ -16,12 +16,20 @@ import {
 } from '@/core/types';
 import type { Layout, Bin } from '@/core/types';
 import { useLabelPlateCounts } from '@/shared/hooks/useLabelPlateCounts';
+import { useLinkedDesignOverhangs } from '@/shared/hooks/useLinkedDesignOverhangs';
 
 vi.mock('@/shared/hooks/useLabelPlateCounts', () => ({
   useLabelPlateCounts: vi.fn(() => new Map()),
 }));
 
+// The registry read is exercised in `useLinkedDesignOverhangs.test.ts`; here it
+// is stubbed so the fallback wiring is what is under test.
+vi.mock('@/shared/hooks/useLinkedDesignOverhangs', () => ({
+  useLinkedDesignOverhangs: vi.fn(() => new Map()),
+}));
+
 const mockUseLabelPlateCounts = vi.mocked(useLabelPlateCounts);
+const mockUseLinkedDesignOverhangs = vi.mocked(useLinkedDesignOverhangs);
 
 // Helper to create test bins
 function createTestBin(overrides: Partial<Bin> = {}): Bin {
@@ -57,6 +65,7 @@ describe('usePrintList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseLabelPlateCounts.mockImplementation(() => new Map());
+    mockUseLinkedDesignOverhangs.mockImplementation(() => new Map());
 
     // Reset stores
     const layout = createTestLayout();
@@ -557,6 +566,56 @@ describe('usePrintList', () => {
       });
 
       expect(result.current.totalBins).toBe(0);
+    });
+  });
+
+  // The third tier of `resolveBinOverhang`: a bin with no PLACEMENT overhang
+  // inherits its linked design's, which the registry carries so a synchronous
+  // selector can reach it without loading params out of IndexedDB.
+  describe('linked design overhang', () => {
+    const DESIGN = designId('d-wide');
+
+    function withBed(bins: Bin[]): Layout {
+      // 180mm bed, 42mm grid: 4 units fit, so a 4-unit bin fits on paper.
+      return { ...createTestLayout(bins), printBedSize: mm(180) };
+    }
+
+    const linkedBin = (): Bin =>
+      createTestBin({
+        width: gridUnits(4),
+        depth: gridUnits(1),
+        linkedDesignId: DESIGN,
+      });
+
+    it('splits a bin whose design overhang overruns the bed', () => {
+      mockUseLinkedDesignOverhangs.mockImplementation(
+        () => new Map([[DESIGN, { left: 61.5, right: 42, front: 0, back: 0, enabled: true }]])
+      );
+      useLayoutStore.setState({ layout: withBed([linkedBin()]) });
+
+      const { result } = renderHook(() => usePrintList());
+      expect(result.current.rows[0].needsSplit).toBe(true);
+      expect(result.current.rows[0].totalPieces).toBe(2);
+    });
+
+    it('leaves the same bin unsplit when the design carries no overhang', () => {
+      useLayoutStore.setState({ layout: withBed([linkedBin()]) });
+
+      const { result } = renderHook(() => usePrintList());
+      expect(result.current.rows[0].needsSplit).toBe(false);
+      expect(result.current.rows[0].totalPieces).toBe(1);
+    });
+
+    it('ignores a design overhang for a bin that is not linked to it', () => {
+      mockUseLinkedDesignOverhangs.mockImplementation(
+        () => new Map([[DESIGN, { left: 61.5, right: 42, front: 0, back: 0, enabled: true }]])
+      );
+      useLayoutStore.setState({
+        layout: withBed([createTestBin({ width: gridUnits(4), depth: gridUnits(1) })]),
+      });
+
+      const { result } = renderHook(() => usePrintList());
+      expect(result.current.rows[0].needsSplit).toBe(false);
     });
   });
 });

--- a/src/features/print-export/hooks/usePrintList.ts
+++ b/src/features/print-export/hooks/usePrintList.ts
@@ -33,6 +33,7 @@ import type {
 } from '@/core/types';
 import { categoryId as toCategoryId } from '@/core/types';
 import { useLabelPlateCounts } from '@/shared/hooks/useLabelPlateCounts';
+import { useLinkedDesignOverhangs } from '@/shared/hooks/useLinkedDesignOverhangs';
 import type { LabelPlateWidthU } from '@/shared/constants/labelPlates';
 import { useTranslation } from '@/i18n';
 
@@ -116,6 +117,7 @@ export function usePrintList(): UsePrintListReturn {
   // listed pieces are the pieces the export actually writes. Memoized on
   // primitives: `baseRows` keys off this object, and a fresh identity every
   // render would rebuild the whole list on every render.
+  const designOverhangs = useLinkedDesignOverhangs();
   const gridUnitMmY = effectiveGridUnitMmY(layout);
   const { printBedSize, printBedDepth, gridUnitMm, baseplateParams } = layout;
   const drawerWidth = layout.drawer.width;
@@ -126,9 +128,11 @@ export function usePrintList(): UsePrintListReturn {
       bedDepthMm: printBedDepth ?? printBedSize,
       gridUnitMm,
       gridUnitMmY,
+      // A placed bin's own overhang wins; the design's is the fallback tier
+      // `resolveBinOverhang` leaves to its caller.
       overhangFor: (bin) =>
         resolveBinOverhang(bin, { width: drawerWidth, depth: drawerDepth }, baseplateParams) ??
-        undefined,
+        (bin.linkedDesignId === undefined ? undefined : designOverhangs.get(bin.linkedDesignId)),
     }),
     [
       printBedSize,
@@ -138,6 +142,7 @@ export function usePrintList(): UsePrintListReturn {
       drawerWidth,
       drawerDepth,
       baseplateParams,
+      designOverhangs,
     ]
   );
 

--- a/src/shared/hooks/useLinkedDesignOverhangs.test.ts
+++ b/src/shared/hooks/useLinkedDesignOverhangs.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { designId } from '@/core/types';
+import { resetCustomBinsCache } from '@/features/bin-designer/hooks/useCustomBins';
+import {
+  registryOverhangFields,
+  upsertRegistryEntry,
+  type CustomBinRef,
+} from '@/features/bin-designer/store/customBinRegistry';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { binSplitChunkUnits } from '@/shared/utils/binSplitFit';
+import { useLinkedDesignOverhangs } from './useLinkedDesignOverhangs';
+
+function makeRef(id: string, overhangMm?: CustomBinRef['overhangMm']): CustomBinRef {
+  return {
+    id: designId(id),
+    name: id,
+    width: 4,
+    depth: 4,
+    height: 3,
+    updatedAt: '2026-08-19T00:00:00.000Z',
+    ...(overhangMm ? { overhangMm } : {}),
+  };
+}
+
+describe('useLinkedDesignOverhangs', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetCustomBinsCache();
+  });
+
+  it('is empty when nothing is registered', () => {
+    const { result } = renderHook(() => useLinkedDesignOverhangs());
+    expect(result.current.size).toBe(0);
+  });
+
+  it('reads a design overhang off the registry as an enabled config', () => {
+    upsertRegistryEntry(makeRef('d1', { left: 61.5, right: 42, front: 0, back: 0 }));
+
+    const { result } = renderHook(() => useLinkedDesignOverhangs());
+    expect(result.current.get(designId('d1'))).toEqual({
+      left: 61.5,
+      right: 42,
+      front: 0,
+      back: 0,
+      enabled: true,
+    });
+  });
+
+  // Absent means nothing to charge, whether the design has no overhang or the
+  // entry predates the field. Both read the same on purpose.
+  it('omits designs with no stored overhang', () => {
+    upsertRegistryEntry(makeRef('d1'));
+    upsertRegistryEntry(makeRef('d2', { left: 10, right: 0, front: 0, back: 0 }));
+
+    const { result } = renderHook(() => useLinkedDesignOverhangs());
+    expect(result.current.has(designId('d1'))).toBe(false);
+    expect(result.current.has(designId('d2'))).toBe(true);
+  });
+
+  // The whole chain the registry field exists for: a design saved with an
+  // overhang, read back synchronously, and charged against the print bed —
+  // without ever loading full params out of IndexedDB.
+  it('carries a saved design overhang through to the split limit', () => {
+    upsertRegistryEntry({
+      ...makeRef('d1'),
+      ...registryOverhangFields({
+        ...DEFAULT_BIN_PARAMS,
+        overhang: { left: 61.5, right: 42, front: 0, back: 0, enabled: true },
+      }),
+    });
+
+    const { result } = renderHook(() => useLinkedDesignOverhangs());
+    const overhang = result.current.get(designId('d1'));
+
+    // 4 x 42mm is 168mm of grid, inside a 180mm bed; the overhang makes the real
+    // part 271.5mm wide.
+    const limit = binSplitChunkUnits({ width: 4, depth: 4, gridUnitMm: 42, overhang }, 180);
+    expect(4 > limit.width).toBe(true);
+    expect(4 > limit.depth).toBe(false);
+  });
+
+  it('leaves the limit alone for a design saved without one', () => {
+    upsertRegistryEntry({ ...makeRef('d1'), ...registryOverhangFields(DEFAULT_BIN_PARAMS) });
+
+    const { result } = renderHook(() => useLinkedDesignOverhangs());
+    const limit = binSplitChunkUnits(
+      { width: 4, depth: 4, gridUnitMm: 42, overhang: result.current.get(designId('d1')) },
+      180
+    );
+    expect(4 > limit.width).toBe(false);
+  });
+});

--- a/src/shared/hooks/useLinkedDesignOverhangs.ts
+++ b/src/shared/hooks/useLinkedDesignOverhangs.ts
@@ -1,0 +1,33 @@
+/**
+ * The overhang each linked design carries, read straight off the registry.
+ *
+ * `resolveBinOverhang` answers this question for a PLACED bin and deliberately
+ * returns `null` for its third tier — the design's own `params.overhang` — so
+ * that layout code is not forced to import the bin designer. The full params
+ * live in IndexedDB, which a synchronous selector cannot await; the registry
+ * carries the resolved footprint reach (`CustomBinRef.overhangMm`) precisely so
+ * this tier is reachable without them.
+ *
+ * Footprint only: `feet` and `taper` are not carried, and neither changes how
+ * far the body reaches. Anything that needs to RENDER an overhang wants the
+ * real params, not this.
+ */
+
+import { useMemo } from 'react';
+import type { DesignId } from '@/core/types';
+import type { OverhangConfig } from '@/shared/types/bin';
+import { useCustomBins } from '@/features/bin-designer';
+
+export function useLinkedDesignOverhangs(): ReadonlyMap<DesignId, OverhangConfig> {
+  const registry = useCustomBins();
+  return useMemo(() => {
+    const byId = new Map<DesignId, OverhangConfig>();
+    for (const ref of registry) {
+      // Absent means nothing to charge — either the design has no overhang, or
+      // the entry predates the field and gains one on its next save.
+      if (!ref.overhangMm) continue;
+      byId.set(ref.id, { ...ref.overhangMm, enabled: true });
+    }
+    return byId;
+  }, [registry]);
+}

--- a/src/shell/Modals/DesignGalleryModal/communityDesignerBridge.test.ts
+++ b/src/shell/Modals/DesignGalleryModal/communityDesignerBridge.test.ts
@@ -39,6 +39,7 @@ vi.mock('@/features/bin-designer/store/customBinRegistry', () => ({
   upsertRegistryEntry: (...a: unknown[]) => upsertRegistryEntry(...a),
   registryEdgeFields: (params: unknown) => registryEdgeFields(params),
   registryHeightFields: (params: unknown) => registryHeightFields(params),
+  registryOverhangFields: () => ({}),
 }));
 
 import {

--- a/src/shell/Modals/DesignGalleryModal/communityDesignerBridge.ts
+++ b/src/shell/Modals/DesignGalleryModal/communityDesignerBridge.ts
@@ -151,8 +151,12 @@ export async function placeCommunityDesignInLayout(
     // counter fired), so any failure must say so rather than pretend
     // nothing happened.
     try {
-      const { upsertRegistryEntry, registryEdgeFields, registryHeightFields } =
-        await import('@/features/bin-designer/store/customBinRegistry');
+      const {
+        upsertRegistryEntry,
+        registryEdgeFields,
+        registryHeightFields,
+        registryOverhangFields,
+      } = await import('@/features/bin-designer/store/customBinRegistry');
       // saveDesign never registers a design (only the mounted Designer page's
       // auto-save hooks do), so register explicitly or the placed bin would
       // link to an id the planner palette cannot resolve.
@@ -164,6 +168,7 @@ export async function placeCommunityDesignInLayout(
         height,
         ...registryEdgeFields(design.params),
         ...registryHeightFields(design.params),
+        ...registryOverhangFields(design.params),
         updatedAt: saved.value.updatedAt,
       });
 


### PR DESCRIPTION
Closes the tier left open in #3624: a linked design's own `params.overhang` when the placed bin carries none.

`resolveBinOverhang` returns `null` there deliberately, and its doc explains why — the full params live in IndexedDB, which a synchronous selector cannot await, and a signature that took them would force layout code to import the bin designer. The registry is the codebase's existing answer to exactly that shape of problem: `assembledRiseMm`, the fractional edges and `knifeRest` are all carried for the same reason.

## The field

`CustomBinRef.overhangMm` — the resolved, outward-only per-side reach. Footprint only: `feet` and `taper` are not carried, and neither changes how far the body reaches. Anything that needs to *render* an overhang wants the real params, not this.

`registryOverhangFields(params)` projects it, and is spread at all nine writers alongside `registryHeightFields`. Two details it inherits from `registryKnifeRestFields` rather than from `registryHeightFields`:

- It writes an **explicit `undefined`** when a design no longer has an overhang, so `withCarriedGeometry` tests **key presence, not value**. A rename must not erase the field; a re-save that removed the overhang must clear it. Both directions are pinned.
- It is suppressed for a partial cell mask, matching `deriveDimensions` — a custom shape defines its own footprint.

`parseEntry` validates the stored record per side and drops an all-zero one, so "absent" reads the same whether a design has no overhang or the entry predates the field.

## The consumer

`useLinkedDesignOverhangs` (in `shared/hooks/`, the allowed edge) reads the registry synchronously — no async load, since `useCustomBins` is a `useSyncExternalStore` over localStorage. The print list charges it as the fallback behind a placed bin's own overhang:

```
resolveBinOverhang(bin, drawer, baseplate) ?? designOverhangs.get(bin.linkedDesignId)
```

So a 4-unit bin on a 180mm bed whose linked design carries a 61.5/42mm overhang now reports the 2 pieces the exporter writes, instead of 1.

## Verification

Both halves of the chain are pinned by tests that fail without their fix (checked by stashing the source):

- **Writer** — `useAutoSave.test.ts` drives the real designer store through autosave into the real registry: editing `overhang` records `overhangMm`, and clearing it removes the field again.
- **Reader** — `useLinkedDesignOverhangs.test.ts` ends with the whole chain: save a design with an overhang, read it back, hand it to `binSplitChunkUnits`, and confirm the axis needs cutting while the untouched axis does not.
- **Wiring** — `usePrintList.test.ts` covers the fallback, the no-overhang control, and that an unlinked bin is unaffected.
- **Field mechanics** — `customBinRegistry.test.ts` covers the projector (clamping, disabled, cell mask), the carry-forward in both directions, and malformed stored records.

## Known limits, both matching existing precedent

`ShareService` writes a registry entry for a restored shared design without geometry fields, so such a design has no `overhangMm` until it is next saved. `assembledRiseMm` has the same hole; closing it means widening the `DesignStorePort`, which is its own change.

## Not covered

The layout-side "does this bin fit the plate" surfaces still read a single layout-wide `calcMaxGridUnits`: the inspector's `SplitWarning`, the 2D grid's Split badge, and the isometric split-line overlay. Making those overhang-aware needs a per-bin limit threaded into render paths that take one number today — and `SplitWarning` needs *both* numbers at once, since it prints the bed capacity as a readout while deciding the split from the chunk limit. That is a refactor rather than wiring, so it is not in here.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

