### PR TITLE
fix(api): accept a lid-lip colour grid on share and sync

### DIFF
--- a/api/lib/designerValidation.test.ts
+++ b/api/lib/designerValidation.test.ts
@@ -1414,6 +1414,50 @@ describe('validateDesignerShare', () => {
     });
   });
 
+  describe('featureColors.lidLip', () => {
+    function withLidLip(lidLip: unknown) {
+      const payload = validPayload();
+      payload.params = {
+        ...payload.params,
+        featureColors: { enabled: true, body: '#000000', lid: '#000000', lidLip },
+      } as typeof payload.params;
+      return validateDesignerShare(payload, JSON.stringify(payload).length);
+    }
+
+    // The designer writes this key whenever a lid-lip cell diverges from the lid
+    // colour, so an unlisted key here 400s share, cloud sync and community
+    // publish for the whole design.
+    it('accepts the lid lip grid', () => {
+      const result = withLidLip({
+        corners: 4,
+        bands: 2,
+        cells: { 'lip:frontLeft:0': '#ff0000', 'lip:backRight:1': '#00ff00' },
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects an out-of-range corner count', () => {
+      expect(withLidLip({ corners: 3, bands: 1, cells: {} }).valid).toBe(false);
+    });
+
+    // `lidLip.cells` is keyed by the bin lip's `lip:...` ids, not `lidLip:...`.
+    it('rejects an unknown cell id', () => {
+      expect(
+        withLidLip({ corners: 1, bands: 1, cells: { 'lidLip:frontLeft:0': '#fff' } }).valid
+      ).toBe(false);
+    });
+
+    it('rejects a non-hex cell color', () => {
+      expect(withLidLip({ corners: 1, bands: 1, cells: { 'lip:frontLeft:0': 'red' } }).valid).toBe(
+        false
+      );
+    });
+
+    it('rejects a non-object lid lip', () => {
+      expect(withLidLip('#ffffff').valid).toBe(false);
+    });
+  });
+
   describe('cutout color validation', () => {
     const withCutouts = (cutouts: unknown) => {
       const payload = validPayload();

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -1135,6 +1135,7 @@ const ALLOWED_FEATURE_COLOR_KEYS = new Set([
   'dividers',
   'text',
   'lid',
+  'lidLip',
   'topAccent',
 ]);
 const ALLOWED_TOP_ACCENT_KEYS = new Set<string>(['enabled', 'heightMm', 'color']);
@@ -1147,25 +1148,29 @@ const VALID_LIP_AXIS_COUNTS = new Set<number>([1, 2, 4]);
 const LIP_CELL_KEY_RE = /^lip:(frontLeft|frontRight|backRight|backLeft):[0-3]$/;
 
 /**
- * Validate the current quadrant×band lip grid shape `{ corners, bands, cells }`.
+ * Validate a quadrant×band lip grid shape `{ corners, bands, cells }`.
  * `cells` maps `lip:<corner>:<band>` ids to hex colors.
+ *
+ * `path` names the field under validation because both the bin lip and the
+ * lid's own top lip store this shape — and `lidLip.cells` is keyed by the same
+ * `lip:...` ids, so the two are structurally identical.
  */
-function validateLipGrid(lip: Record<string, unknown>): string | null {
+function validateLipGrid(lip: Record<string, unknown>, path: string): string | null {
   for (const key of Object.keys(lip)) {
-    if (!ALLOWED_LIP_GRID_KEYS.has(key)) return `featureColors.lip has unknown key: ${key}`;
+    if (!ALLOWED_LIP_GRID_KEYS.has(key)) return `${path} has unknown key: ${key}`;
   }
   for (const axis of ['corners', 'bands'] as const) {
     const v = lip[axis];
     if (v !== undefined && (!isNumber(v) || !VALID_LIP_AXIS_COUNTS.has(v))) {
-      return `featureColors.lip.${axis} must be 1, 2, or 4`;
+      return `${path}.${axis} must be 1, 2, or 4`;
     }
   }
   const cells = lip.cells;
   if (cells !== undefined) {
-    if (!isObject(cells)) return 'featureColors.lip.cells must be an object';
+    if (!isObject(cells)) return `${path}.cells must be an object`;
     for (const [id, color] of Object.entries(cells)) {
-      if (!LIP_CELL_KEY_RE.test(id)) return `featureColors.lip.cells has unknown cell: ${id}`;
-      if (!isValidColor(color)) return `featureColors.lip.cells.${id} must be a hex color`;
+      if (!LIP_CELL_KEY_RE.test(id)) return `${path}.cells has unknown cell: ${id}`;
+      if (!isValidColor(color)) return `${path}.cells.${id} must be a hex color`;
     }
   }
   return null;
@@ -1227,7 +1232,7 @@ function validateFeatureColors(value: unknown): string | null {
       // New grid shape if it carries any grid key; otherwise legacy 4-corner.
       const isGrid = 'corners' in lip || 'bands' in lip || 'cells' in lip;
       if (isGrid) {
-        const err = validateLipGrid(lip);
+        const err = validateLipGrid(lip, 'featureColors.lip');
         if (err) return err;
       } else {
         for (const key of Object.keys(lip)) {
@@ -1244,6 +1249,15 @@ function validateFeatureColors(value: unknown): string | null {
     } else {
       return 'featureColors.lip must be a hex color, 4-corner object, or grid';
     }
+  }
+
+  // The lid's own top lip carries the SAME grid shape as the bin lip and only
+  // ever the grid shape — it postdates both legacy lip forms, so no string or
+  // 4-corner fallback applies here.
+  if (value.lidLip !== undefined) {
+    if (!isObject(value.lidLip)) return 'featureColors.lidLip must be a grid';
+    const err = validateLipGrid(value.lidLip, 'featureColors.lidLip');
+    if (err) return err;
   }
 
   if (value.topAccent !== undefined) {


### PR DESCRIPTION
## Problem

`featureColors.lidLip` was never added to `ALLOWED_FEATURE_COLOR_KEYS`. The designer writes that key whenever a lid-lip cell diverges from the lid colour (#3234), so any such design is rejected with `INVALID_PARAMS: featureColors has unknown key: lidLip` by every path behind `validateDesignerShare`: `/api/share`, `/api/sync/designs/[id]` and community publish.

## Fix

Allow-list the key and validate it. `lidLip` carries the same quadrant × band grid as the bin lip, and its `cells` are keyed by the same `lip:<corner>:<band>` ids, so `validateLipGrid` is reused rather than duplicated. It now takes the field path it reports on so a lid-lip error names `featureColors.lidLip`, and the bin-lip messages are unchanged.

Unlike `lip`, `lidLip` postdates both legacy shapes (bare string, 4-corner object), so only the grid form is accepted.

## Verification

Five tests in `api/lib/designerValidation.test.ts`. The acceptance case fails on `main` and passes with the fix; the rest pin the rejections (bad axis count, a `lidLip:`-prefixed cell id, a non-hex cell colour, a non-object grid).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

