### PR TITLE
test(bin-designer): wait on the font registry instead of counting ticks

### DIFF
--- a/src/features/bin-designer/utils/typeMeasurer.test.ts
+++ b/src/features/bin-designer/utils/typeMeasurer.test.ts
@@ -12,11 +12,32 @@ import {
  * The registry's contract is about ABSENCE: a preview drawn from a face that
  * has not arrived reports a size and a position no geometry will honour, so
  * every accessor has to answer honestly before the fetch lands.
+ *
+ * Every load here is awaited through `vi.waitFor`, never through a fixed number
+ * of ticks. `loadFamily` awaits `import('brepjs/text')` BEFORE it reaches
+ * `fetch`, and a dynamic import is not bounded by macrotask count: on a loaded
+ * machine it can still be pending after several. A `setTimeout(0)` budget read
+ * a `fetch` that had not happened yet and failed about 1 run in 3 in a full
+ * suite while passing every time in isolation. Polling the observable condition
+ * also keeps a load from outliving the test that started it, since
+ * `resetTypeFontsForTest` can clear the registry but cannot cancel a promise.
+ *
+ * `WAIT` overrides `vi.waitFor`'s 1s default for the same reason. That budget is
+ * generous for an import and stingy for a contended one, and the run that
+ * exposed this reported 155s of aggregate import time across its workers. The
+ * project's own `testTimeout` is 30s, so a wait that gives up at 1s is the
+ * tighter bound and would just be the original bug with a longer fuse.
  */
+const WAIT = { timeout: 15_000 } as const;
+
 describe('designer type font registry', () => {
   beforeEach(() => {
     resetTypeFontsForTest();
     vi.restoreAllMocks();
+    // `restoreAllMocks` does not undo `stubGlobal`, and neither the config nor
+    // the shared setup enables `unstubGlobals`, so a rejecting `fetch` would
+    // otherwise outlive the test that installed it.
+    vi.unstubAllGlobals();
   });
 
   it('has no measurer before any face registers', () => {
@@ -31,12 +52,10 @@ describe('designer type font registry', () => {
   });
 
   it('survives a failed fetch without wedging, so a preview is absent not broken', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(() => Promise.reject(new Error('offline')))
-    );
+    const fetchMock = vi.fn(() => Promise.reject(new Error('offline')));
+    vi.stubGlobal('fetch', fetchMock);
     ensureTypeFonts(['atkinson']);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled(), WAIT);
     expect(areTypeFontsLoaded(['atkinson'])).toBe(false);
     expect(getTypeMeasurer()).toBeNull();
   });
@@ -45,12 +64,18 @@ describe('designer type font registry', () => {
     const fetchMock = vi.fn(() => Promise.reject(new Error('offline')));
     vi.stubGlobal('fetch', fetchMock);
     ensureTypeFonts(['atkinson']);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1), WAIT);
     // One flaky fetch must not cost the preview for the rest of the session:
-    // `loads` tracks what is in flight, not what has been attempted.
-    ensureTypeFonts(['atkinson']);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+    // `loads` tracks what is in flight, not what has been attempted. The clear
+    // happens in `loadFamily`'s `finally`, so ask the way a re-render does
+    // (`ensureTypeFonts` is documented safe to call every render) rather than
+    // assuming a single retry lands after the rejection has settled. If the
+    // family were ever left marked in flight, this polls until it times out,
+    // which is the regression the test exists to catch.
+    await vi.waitFor(() => {
+      ensureTypeFonts(['atkinson']);
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+    }, WAIT);
   });
 
   it('notifies subscribers so a preview can redraw when a face lands', () => {


### PR DESCRIPTION
Closes #3633.

## Problem

`typeMeasurer.test.ts > retries a family whose fetch failed rather than marking it in flight forever` failed roughly 1 run in 3 in a full suite and passed every time in isolation.

`loadFamily` awaits `import('brepjs/text')` before it ever reaches `fetch`, and a dynamic import is not bounded by macrotask count. Two tests budgeted a single `setTimeout(0)` for that whole chain, so under contention they read a `fetch` that had not happened yet:

```
AssertionError: expected 0 to be greater than 1
 ❯ src/features/bin-designer/utils/typeMeasurer.test.ts:53:41
```

The received value was **0**, not 1. `fetch` was never reached, so `loads` still held the family, the second `ensureTypeFonts` short-circuited, and no retry was attempted. I measured the real cost with a throwaway probe: reaching `fetch` takes a full tick even on a warm module cache. The budget had no slack at all.

## Fix

Test-only. No production change.

- Both fixed-tick waits become `vi.waitFor` on the observable condition. The retry test asks the way a re-render does (`ensureTypeFonts` is documented safe to call every render) rather than assuming one retry lands after the rejection settles.
- Polling also stops a load outliving the test that started it. `resetTypeFontsForTest` clears the registry but cannot cancel an in-flight promise, which is the likeliest cause of the second symptom I saw once: a file-level failure with every individual test passing.
- `WAIT` overrides `vi.waitFor`'s 1s default. The run that exposed this reported 155s of aggregate import time across workers, so a 1s ceiling is the same deadline with a longer fuse. The project's `testTimeout` is 30s, so 1s was the tighter bound.
- `vi.unstubAllGlobals()` joins the `beforeEach`: `vi.restoreAllMocks()` does not undo `stubGlobal`, and neither `vitest.config.ts` nor `src/test/setup.ts` enables `unstubGlobals`, so a rejecting `fetch` outlived the test that installed it.

## Verification

**Mutation.** Deleting the `loads.delete(family)` in `loadFamily`'s `finally` (the retryability the test guards) still fails it, as `AssertionError: expected 1 to be greater than 1` at 15.05s. That matters in both directions: the test has not been weakened into always passing, and a real regression still reports a legible assertion rather than a bare test timeout, since 15s sits inside the 30s `testTimeout`.

**Empirical.** 8 consecutive clean runs of `pnpm run test:run src/features/bin-designer src/core api`, the combination that reproduced it. Baseline on `main` was 2 failures in 7 runs of the same command.

`pnpm run quality` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

