### PR TITLE
fix(drawer-shape): release the grid floor an axis's measurement already holds

### DIFF
--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.test.ts
@@ -4,6 +4,7 @@ import { isOk } from '@/core/result';
 import { CONSTRAINTS, STAGING_ID } from '@/core/constants';
 import type { DrawerOutline, Layout } from '@/core/types';
 import { binId, gridUnits, heightUnits, mm } from '@/core/types';
+import { normalizeDrawerOutline } from '@/shared/utils/drawerOutline';
 import { updateDrawer } from './updateDrawer';
 import { makeLayout, makeBin } from './_testHelpers';
 import { applyEvent } from '../../../projection/replay';
@@ -332,5 +333,94 @@ describe('v2 drawer.update with an outline', () => {
       } as never);
       expect('gridShiftX' in replayed.drawer).toBe(false);
     });
+  });
+});
+
+describe('v2 drawer.update with a measured drawer under the shape (#3635)', () => {
+  const U = 42;
+  // The reported layout: a T traced on a drawer measured 931 x 327mm, laid on
+  // a 22 x 8 grid. 22u is 924mm, so the perimeter reaches 7mm past the grid.
+  const MEASURED = { width: 931, depth: 327 };
+  const T_SHAPE: DrawerOutline = {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: 931, y: 0 },
+      { x: 931, y: 327 },
+      { x: 672, y: 327 },
+      { x: 672, y: 189 },
+      { x: 273, y: 189 },
+      { x: 273, y: 327 },
+      { x: 0, y: 327 },
+    ],
+  };
+  const reportedLayout = (): Layout => {
+    const base = makeLayout();
+    return {
+      ...base,
+      gridUnitMm: mm(U),
+      drawer: {
+        ...base.drawer,
+        width: gridUnits(22),
+        depth: gridUnits(8),
+        measuredMm: MEASURED,
+        outline: T_SHAPE,
+      },
+    };
+  };
+
+  it('shrinks the grid inside the measured perimeter', () => {
+    const layout = reportedLayout();
+    const result = updateDrawer.handle({ width: 21, depth: 7 }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const payload = result.value.event.payload;
+    expect(payload.changes.width).toBe(gridUnits(21));
+    expect(payload.changes.depth).toBe(gridUnits(7));
+    // The shape is the material; a smaller grid never touches it.
+    expect('outline' in payload.changes).toBe(false);
+    const next = produce(layout, (draft) => {
+      updateDrawer.apply({ type: 'drawer.updated', payload }, draft);
+    });
+    expect(next.drawer.outline).toBe(T_SHAPE);
+  });
+
+  it('survives the read-side normalizer after the shrink', () => {
+    // The floor exists to keep the normalizer from clipping the shape on the
+    // next load. Releasing it is only sound because outlineExtentMm reads the
+    // measurement — so prove the round trip, not just the clamp.
+    const layout = reportedLayout();
+    const result = updateDrawer.handle({ width: 12, depth: 4 }, { aggregate: layout });
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    const shrunk = produce(layout, (draft) => {
+      updateDrawer.apply({ type: 'drawer.updated', payload: result.value.event.payload }, draft);
+    });
+    expect(normalizeDrawerOutline(shrunk).drawer.outline).toEqual(T_SHAPE);
+  });
+
+  it('still floors on the shape once the measurement is cleared in the same command', () => {
+    // Floors read the measurement that LANDS, not the one being replaced.
+    const result = updateDrawer.handle(
+      { width: 12, measuredMm: null },
+      { aggregate: reportedLayout() }
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.changes.width).toBe(gridUnits(22.5));
+  });
+
+  it('releases the floor when the measurement is recorded in the same command', () => {
+    const base = reportedLayout();
+    const unmeasured: Layout = {
+      ...base,
+      drawer: { ...base.drawer, measuredMm: undefined },
+    };
+    const result = updateDrawer.handle(
+      { width: 12, measuredMm: MEASURED },
+      { aggregate: unmeasured }
+    );
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+    expect(result.value.event.payload.changes.width).toBe(gridUnits(12));
   });
 });

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
@@ -2,8 +2,9 @@
  * Update drawer dims and cascade out-of-bounds bins to staging.
  *
  * Clamping (width/depth in [GRID_MIN, GRID_MAX] and, with a custom outline
- * active, no smaller than the outline's bounding half-unit grid — a resize
- * must never mutate the user's shape,; height >= sum of layer heights)
+ * active, no smaller than the outline's bounding half-unit grid on an axis the
+ * recorded measurement does not already hold — a resize must never mutate the
+ * user's shape; height >= sum of layer heights)
  * happens in handle() so the event's `changes` always reflects the value
  * that lands. The displaced bin set is also precomputed in handle() and
  * goes into the event as `displacedBinIds`, so apply() applies the drawer
@@ -112,13 +113,30 @@ export const updateDrawer = defineCommand({
     const drawer = layout.drawer;
     const gridUnitMmY = effectiveGridUnitMmY(layout);
 
+    const changes: Partial<Drawer> = {};
+    // Resolved before the size floors read it: one command may record a
+    // measurement AND resize, and the floor the resize lands against is the
+    // one that lands with it (the same POST-change discipline the
+    // displacement below runs on).
+    if (payload.measuredMm !== undefined) {
+      changes.measuredMm =
+        payload.measuredMm === null ? undefined : clampMeasuredMm(payload.measuredMm);
+    }
+
     // Resolve clamped/derived values up-front so the event records
     // exactly what apply() will install. With a custom outline active the
-    // shrink floor rises to the outline's bounding half-unit grid: the shape
-    // is user-authored and a resize must never crop or extend it —
-    // to go smaller, the user edits the shape first.
-    const floors = drawerSizeFloors(drawer.outline, layout.gridUnitMm, gridUnitMmY);
-    const changes: Partial<Drawer> = {};
+    // shrink floor rises to the outline's bounding half-unit grid on any axis
+    // whose recorded measurement does not already hold the shape: the shape is
+    // user-authored and a resize must never crop or extend it — to go smaller
+    // there, the user edits the shape (or records the drawer) first.
+    const floors = drawerSizeFloors(
+      {
+        outline: drawer.outline,
+        measuredMm: 'measuredMm' in changes ? changes.measuredMm : drawer.measuredMm,
+      },
+      layout.gridUnitMm,
+      gridUnitMmY
+    );
     if (payload.width !== undefined) {
       changes.width = gridUnits(clamp(payload.width, floors.width, CONSTRAINTS.GRID_MAX));
     }
@@ -142,10 +160,6 @@ export const updateDrawer = defineCommand({
       const half = (gridUnitMmY as number) / 2;
       const v = clamp(payload.gridShiftY, -half, half);
       changes.gridShiftY = v === 0 ? undefined : mm(v);
-    }
-    if (payload.measuredMm !== undefined) {
-      changes.measuredMm =
-        payload.measuredMm === null ? undefined : clampMeasuredMm(payload.measuredMm);
     }
 
     const newWidth: GridUnits = changes.width ?? drawer.width;

--- a/src/core/store/layout/drawerActions.ts
+++ b/src/core/store/layout/drawerActions.ts
@@ -16,9 +16,10 @@ export function createDrawerActions(setLocal: SetLocal) {
         const gridUnitMmY = effectiveGridUnitMmY(state.layout);
 
         // With a custom outline active the shrink floor rises to the
-        // outline's bounding half-unit grid — a resize must never mutate the
+        // outline's bounding half-unit grid on any axis the recorded
+        // measurement does not already hold — a resize must never mutate the
         // user's shape; same rule as the CQRS updateDrawer command.
-        const floors = drawerSizeFloors(drawer.outline, state.layout.gridUnitMm, gridUnitMmY);
+        const floors = drawerSizeFloors(drawer, state.layout.gridUnitMm, gridUnitMmY);
 
         if (updates.width !== undefined) {
           drawer.width = clamp(updates.width, floors.width, CONSTRAINTS.GRID_MAX) as GridUnits;

--- a/src/features/drawer-shape/README.md
+++ b/src/features/drawer-shape/README.md
@@ -100,7 +100,11 @@ by the frame (#3149).
 6. **The outline never changes implicitly** (#3149) — `drawer.update` clamps a
    shrink to the shape's bounding half-unit grid (`minDrawerUnitsForOutline`)
    and keeps the outline byte-identical on grow; the old crop/weld adaptation
-   is gone. The cell editor warns (`drawerShape.editor.replacesDrawnShape`)
+   is gone. That floor is per axis and only applies where the grid is what
+   holds the shape: what the read-side normalizer clips against is
+   `outlineExtentMm`, so an axis whose recorded measurement already contains
+   the perimeter has no floor at all (`drawerSizeFloors`, `gridPitchFloors`)
+   and the grid is free to shrink inside it as `outlineOverhang`. The cell editor warns (`drawerShape.editor.replacesDrawnShape`)
    when the stored perimeter would not survive rasterization
    (`isOutlineCellRepresentable`), since applying a cell paint replaces it.
 7. The corner-cut vertex geometry lives in

--- a/src/shared/hooks/useDrawerSettings.ts
+++ b/src/shared/hooks/useDrawerSettings.ts
@@ -321,10 +321,18 @@ export function useDrawerSettings(): UseDrawerSettingsReturn {
   // A custom drawer shape floors the size (the command clamps rather
   // than crop the shape); exposing the floor lets the steppers bound their
   // range so the "−" button disables instead of silently doing nothing.
+  // A recorded measurement that already holds the shape releases the floor —
+  // the grid is then free to shrink inside the perimeter.
   const drawerOutline = layout.drawer.outline;
+  const drawerMeasuredMm = layout.drawer.measuredMm;
   const { width: drawerMinWidth, depth: drawerMinDepth } = useMemo(
-    () => drawerSizeFloors(drawerOutline, gridUnitMm, gridUnitMmY),
-    [drawerOutline, gridUnitMm, gridUnitMmY]
+    () =>
+      drawerSizeFloors(
+        { outline: drawerOutline, measuredMm: drawerMeasuredMm },
+        gridUnitMm,
+        gridUnitMmY
+      ),
+    [drawerOutline, drawerMeasuredMm, gridUnitMm, gridUnitMmY]
   );
 
   const realWorldDimensions = useMemo(

--- a/src/shared/utils/drawerOutline.test.ts
+++ b/src/shared/utils/drawerOutline.test.ts
@@ -8,6 +8,8 @@ import {
   canonicalStartOutline,
   ceilHalfUnits,
   hashOutline,
+  drawerSizeFloors,
+  gridPitchFloors,
   minDrawerUnitsForOutline,
   normalizeDrawerOutline,
   OUTLINE_MAX_VERTICES,
@@ -392,6 +394,119 @@ describe('minDrawerUnitsForOutline', () => {
       ],
     };
     expect(minDrawerUnitsForOutline(exact, 48, 42)).toEqual({ width: 8.5, depth: 7.5 });
+  });
+});
+
+describe('drawerSizeFloors', () => {
+  // The reported drawer: measured 931 x 327mm, traced as a T on a 22 x 8 grid.
+  // 22u x 42 is 924mm, so the perimeter reaches 7mm PAST the grid's own edge.
+  const REPORTED: DrawerOutline = {
+    vertices: [
+      { x: 0, y: 0 },
+      { x: 931, y: 0 },
+      { x: 931, y: 327 },
+      { x: 672, y: 327 },
+      { x: 672, y: 189 },
+      { x: 273, y: 189 },
+      { x: 273, y: 327 },
+      { x: 0, y: 327 },
+    ],
+  };
+
+  it('has no floor without an outline', () => {
+    expect(drawerSizeFloors({}, U)).toEqual({
+      width: CONSTRAINTS.GRID_MIN,
+      depth: CONSTRAINTS.GRID_MIN,
+    });
+  });
+
+  it('floors on the shape when nothing was measured', () => {
+    expect(drawerSizeFloors({ outline: L_SHAPE }, U)).toEqual({ width: 4, depth: 4 });
+  });
+
+  it('releases the floor on an axis the measurement already holds (#3635)', () => {
+    // What bounds the perimeter is outlineExtentMm, so a measurement that
+    // reaches the shape keeps holding it however small the grid gets — the
+    // grid slides out from under the perimeter and the strip is overhang.
+    expect(
+      drawerSizeFloors({ outline: REPORTED, measuredMm: { width: 931, depth: 327 } }, U)
+    ).toEqual({ width: CONSTRAINTS.GRID_MIN, depth: CONSTRAINTS.GRID_MIN });
+  });
+
+  it('never floors ABOVE the current size on a drawer measured wider than its grid (#3635)', () => {
+    // Stated against the shape's own bounding grid so the defect is visible:
+    // 931mm on a 42mm pitch needs 22.5 units, which is MORE than the 22 the
+    // drawer is set to, so a floor read off the shape could only move the "-"
+    // stepper UP. The measurement is what holds this perimeter, not the grid.
+    expect(minDrawerUnitsForOutline(REPORTED, U).width).toBe(22.5);
+    const floors = drawerSizeFloors(
+      { outline: REPORTED, measuredMm: { width: 931, depth: 327 } },
+      U
+    );
+    expect(floors.width).toBeLessThan(22);
+  });
+
+  it('floors per axis — an unmeasured axis keeps its bound', () => {
+    // Measured wide enough on X, nowhere near it on Y.
+    expect(
+      drawerSizeFloors({ outline: L_SHAPE, measuredMm: { width: 4 * U, depth: 1 } }, U)
+    ).toEqual({ width: CONSTRAINTS.GRID_MIN, depth: 4 });
+  });
+
+  it('keeps the floor when the measurement is short of the shape', () => {
+    // Authored against a larger grid, then a smaller drawer was recorded: the
+    // grid is still what holds the shape, so it may not shrink.
+    expect(
+      drawerSizeFloors({ outline: L_SHAPE, measuredMm: { width: 3 * U, depth: 3 * U } }, U)
+    ).toEqual({ width: 4, depth: 4 });
+  });
+
+  it('ignores a non-finite measurement rather than losing the floor', () => {
+    const bad = Number.NaN;
+    expect(
+      drawerSizeFloors({ outline: L_SHAPE, measuredMm: { width: bad, depth: bad } }, U)
+    ).toEqual({ width: 4, depth: 4 });
+  });
+
+  it('uses the per-axis pitch on a non-square grid', () => {
+    expect(drawerSizeFloors({ outline: L_SHAPE }, 48, 42)).toEqual({ width: 3.5, depth: 4 });
+  });
+});
+
+describe('gridPitchFloors', () => {
+  function layoutWithOutline(
+    outline: DrawerOutline | undefined,
+    measuredMm?: { width: number; depth: number }
+  ): Layout {
+    const layout = createTestLayout();
+    return {
+      ...layout,
+      gridUnitMm: mm(U),
+      drawer: {
+        ...layout.drawer,
+        width: gridUnits(4),
+        depth: gridUnits(4),
+        ...(outline ? { outline } : {}),
+        ...(measuredMm ? { measuredMm } : {}),
+      },
+    };
+  }
+
+  it('has no floor without an outline', () => {
+    expect(gridPitchFloors(layoutWithOutline(undefined))).toEqual({ x: 1, y: 1 });
+  });
+
+  it('floors the pitch on the shape when nothing was measured', () => {
+    expect(gridPitchFloors(layoutWithOutline(L_SHAPE))).toEqual({ x: U, y: U });
+  });
+
+  it('releases the pitch floor when the measurement already holds the shape (#3635)', () => {
+    // Same rule as drawerSizeFloors: shrinking the grid's mm extent cannot
+    // clip a perimeter the measurement is holding.
+    expect(gridPitchFloors(layoutWithOutline(L_SHAPE, { width: 4 * U, depth: 4 * U }))).toEqual({
+      x: 1,
+      y: 1,
+    });
   });
 });
 

--- a/src/shared/utils/drawerOutline.ts
+++ b/src/shared/utils/drawerOutline.ts
@@ -536,23 +536,45 @@ export function minDrawerUnitsForOutline(
 }
 
 /**
- * Drawer dims (grid units) a resize may clamp down to: the outline's bounding
- * half-unit grid while a custom shape is active, the plain grid minimum
- * without one. Shared by the CQRS command, the store mirror and the size
- * steppers so all three refuse the same shrinks.
+ * Drawer dims (grid units) a resize may clamp down to, per axis.
+ *
+ * The floor exists to keep a shrink from cropping the user's shape, and what
+ * holds the shape is {@link outlineExtentMm} — the grid extent OR a recorded
+ * measurement, whichever is larger. So an axis whose measurement already
+ * contains the shape has no floor at all: the grid slides out from under the
+ * perimeter, `outlineFrame` centres it and reports the strip as
+ * `outlineOverhang`, and nothing about the shape changes. Floors on the
+ * outline's own bounding grid only when the measurement is absent or too
+ * small to hold it, which is the case where the grid is all that keeps the
+ * shape in bounds.
+ *
+ * Reading the grid extent as the bound (its behaviour before the measurement
+ * gained that authority) put the floor ABOVE the current size on a drawer
+ * measured wider than its grid, so the "−" stepper could only move the value
+ * up.
+ *
+ * Shared by the CQRS command, the store mirror and the size steppers so all
+ * three refuse the same shrinks.
  */
 export function drawerSizeFloors(
-  outline: DrawerOutline | undefined,
+  drawer: Pick<Drawer, 'outline' | 'measuredMm'>,
   gridUnitMm: number,
   gridUnitMmY: number = gridUnitMm
 ): { readonly width: number; readonly depth: number } {
+  const outline = drawer.outline;
   if (outline === undefined) {
     return { width: CONSTRAINTS.GRID_MIN, depth: CONSTRAINTS.GRID_MIN };
   }
+  const b = outlineBounds(outline);
   const min = minDrawerUnitsForOutline(outline, gridUnitMm, gridUnitMmY);
+  const measured = drawer.measuredMm;
+  const floor = (boundMm: number, measuredMm: number, units: number): number =>
+    safeMeasured(measuredMm) >= boundMm
+      ? CONSTRAINTS.GRID_MIN
+      : clamp(units, CONSTRAINTS.GRID_MIN, CONSTRAINTS.GRID_MAX);
   return {
-    width: clamp(min.width, CONSTRAINTS.GRID_MIN, CONSTRAINTS.GRID_MAX),
-    depth: clamp(min.depth, CONSTRAINTS.GRID_MIN, CONSTRAINTS.GRID_MAX),
+    width: floor(b.maxX, measured?.width ?? 0, min.width),
+    depth: floor(b.maxY, measured?.depth ?? 0, min.depth),
   };
 }
 
@@ -568,6 +590,12 @@ export const GRID_PITCH_MM_MAX = 200;
  * Floors round up to 0.01mm so `units × pitch ≥ bounds` survives float noise.
  * On a square grid the X pitch drives both axes, so its floor honours the Y
  * bound too. Shared by the CQRS commands and their store mirrors.
+ *
+ * The measurement releases the floor exactly as it does in
+ * {@link drawerSizeFloors}, and for the same reason: what the normalizer
+ * clips against is {@link outlineExtentMm}, so on an axis whose recorded
+ * measurement already holds the shape, shrinking the grid's own extent
+ * reaches nothing.
  */
 export function gridPitchFloors(layout: Pick<Layout, 'drawer' | 'gridUnitMm' | 'gridUnitMmY'>): {
   readonly x: number;
@@ -576,10 +604,17 @@ export function gridPitchFloors(layout: Pick<Layout, 'drawer' | 'gridUnitMm' | '
   const outline = layout.drawer.outline;
   if (outline === undefined) return { x: GRID_PITCH_MM_MIN, y: GRID_PITCH_MM_MIN };
   const b = outlineBounds(outline);
-  const floor = (extentMm: number, units: number): number =>
-    clamp(Math.ceil((extentMm / units) * 100 - 1e-6) / 100, GRID_PITCH_MM_MIN, GRID_PITCH_MM_MAX);
-  const x = floor(b.maxX, layout.drawer.width);
-  const y = floor(b.maxY, layout.drawer.depth);
+  const measured = layout.drawer.measuredMm;
+  const floor = (extentMm: number, measuredMm: number, units: number): number =>
+    safeMeasured(measuredMm) >= extentMm
+      ? GRID_PITCH_MM_MIN
+      : clamp(
+          Math.ceil((extentMm / units) * 100 - 1e-6) / 100,
+          GRID_PITCH_MM_MIN,
+          GRID_PITCH_MM_MAX
+        );
+  const x = floor(b.maxX, measured?.width ?? 0, layout.drawer.width);
+  const y = floor(b.maxY, measured?.depth ?? 0, layout.drawer.depth);
   return { x: layout.gridUnitMmY === undefined ? Math.max(x, y) : x, y };
 }
 


### PR DESCRIPTION
Fixes #3635

## The defect

A custom perimeter is bounded by `outlineExtentMm` — the grid extent OR a recorded measurement, whichever is larger. The resize floor still asked the older question, "does the grid contain the shape", and on a drawer measured wider than its grid the two disagree in the worst direction.

The reported layout: a T traced on a drawer measured 931 x 327mm, laid on a 22 x 8 grid at a 42mm pitch. 931mm needs 22.5 grid units, so the width floored **above** the drawer's own 22 and the "−" stepper could only move the value up. Depth floored exactly on 8 and did nothing. `gridPitchFloors` carried the same premise, floored the pitch at 42.32mm against a current 42, and locked that control the same way.

## The fix

The floor exists to keep the read-side normalizer from clipping the shape, and that normalizer clips against `outlineExtentMm`. So an axis whose measurement already contains the perimeter has no floor: the grid slides out from under it, `outlineFrame` centres it and reports the strip as `outlineOverhang`, and the shape is untouched. It floors on the shape's own bounding grid only where the measurement is absent or short of it — the case where the grid really is what holds the shape.

Per axis, since a drawer can be measured wide and shallow. `drawerSizeFloors` now takes the drawer rather than the bare outline, so the CQRS command, the store mirror and the size steppers keep sharing one rule.

`updateDrawer` resolves `measuredMm` before the floors read it: one command may record a measurement and resize together, and the floor a resize lands against is the one that lands with it.

## Verification

- `drawerSizeFloors` / `gridPitchFloors` unit tests, including the reported drawer stated against `minDrawerUnitsForOutline` so the old rule's 22.5 is visible next to the 22 it was floored on.
- Command-level tests on the reported layout: the shrink lands, the outline stays byte-identical, and `normalizeDrawerOutline` returns it unchanged after the shrink — the round trip the floor existed to protect, not just the clamp.
- Both floor directions of the same-command `measuredMm` case.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

