### PR TITLE
fix(bin-designer): resolve the interior card against the style it claims

### DIFF
--- a/src/features/bin-designer/components/DesignerPage/DesignerPage.test.tsx
+++ b/src/features/bin-designer/components/DesignerPage/DesignerPage.test.tsx
@@ -18,6 +18,14 @@ vi.mock('../PreviewCanvas', () => ({
   PreviewCanvas: () => <div data-testid="preview-canvas">Preview Canvas</div>,
 }));
 
+vi.mock('@/features/bin-designer/components/CutoutWorkspace', () => ({
+  CutoutWorkspace: () => <div data-testid="cutout-workspace">Cutout Workspace</div>,
+}));
+
+vi.mock('@/features/bin-designer/components/BentoWorkspace', () => ({
+  BentoWorkspace: () => <div data-testid="bento-workspace">Bento Workspace</div>,
+}));
+
 vi.mock('../ExportDialog', () => ({
   ExportDialog: () => <div data-testid="export-dialog">Export Dialog</div>,
 }));
@@ -168,5 +176,47 @@ describe('DesignerPage', () => {
     });
     render(<DesignerPage />);
     expect(screen.getByText(/save failed/i)).toBeInTheDocument();
+  });
+});
+
+describe('DesignerPage — the cutout workspace follows the style', () => {
+  beforeEach(() => {
+    resetAllStores();
+    vi.clearAllMocks();
+  });
+
+  it('opens the bin cutout workspace on a solid design', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        style: 'solid',
+        base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+      },
+      ui: { ...DEFAULT_UI_STATE, cutoutEditorOpen: true, cutoutTarget: 'bin' },
+    });
+    render(<DesignerPage />);
+    expect(screen.getByTestId('cutout-workspace')).toBeInTheDocument();
+  });
+
+  it('closes it when the style is walked back under an open workspace', () => {
+    // The generator builds a bin's cutouts only on a solid body, so a hollow
+    // bin behind the editor means every pocket drawn there is silently
+    // discarded. An undo can move the style with the workspace still open.
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, style: 'standard' },
+      ui: { ...DEFAULT_UI_STATE, cutoutEditorOpen: true, cutoutTarget: 'bin' },
+    });
+    render(<DesignerPage />);
+    expect(screen.queryByTestId('cutout-workspace')).not.toBeInTheDocument();
+    expect(screen.getByTestId('parameter-panel')).toBeInTheDocument();
+  });
+
+  it('leaves the lid cutout workspace open — the lid has its own array', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, style: 'standard' },
+      ui: { ...DEFAULT_UI_STATE, cutoutEditorOpen: true, cutoutTarget: 'lid' },
+    });
+    render(<DesignerPage />);
+    expect(screen.getByTestId('cutout-workspace')).toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
@@ -80,7 +80,15 @@ export function DesignerPage() {
   useCommunityPublishLifecycle();
 
   const { isDesktop, isMobile, isLandscape } = useResponsive();
-  const cutoutEditorOpen = useDesignerStore((s) => s.ui.cutoutEditorOpen);
+  // Resolved against the style for the same reason the interior card is: the
+  // bin's cutouts are only built on a solid body, so an undo that walks the
+  // style back while the workspace is open leaves the user drawing pockets
+  // into a hollow bin that the generator will not cut. The lid's cutouts are a
+  // separate array with no such dependency. The flag itself is left alone, so
+  // redoing the style brings the workspace back.
+  const cutoutEditorOpen = useDesignerStore(
+    (s) => s.ui.cutoutEditorOpen && (s.ui.cutoutTarget === 'lid' || s.params.style === 'solid')
+  );
   const bentoWorkspaceOpen = useDesignerStore((s) => s.ui.bentoWorkspaceOpen);
   const designListOpen = useDesignerStore((s) => s.ui.designListOpen);
   const setDesignListOpen = useDesignerStore((s) => s.setDesignListOpen);

--- a/src/features/bin-designer/components/panel/InteriorSection/useInteriorSection.test.ts
+++ b/src/features/bin-designer/components/panel/InteriorSection/useInteriorSection.test.ts
@@ -70,3 +70,85 @@ describe('useInteriorSection', () => {
     expect(useDesignerStore.getState().params.compartments.rows).toBe(2);
   });
 });
+
+describe('useInteriorSection — the selected card cannot outrun the style', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  it('shows the Cutout card only while the design is on the solid style', () => {
+    const { result } = renderHook(() => useInteriorSection());
+
+    act(() => {
+      result.current.handlers.selectCard('solid');
+    });
+    expect(useDesignerStore.getState().params.style).toBe('solid');
+    expect(result.current.state.card).toBe('solid');
+  });
+
+  it('falls back off Cutout when undo walks the style back under it', () => {
+    // The reported route: the card is stored UI state and undo restores params
+    // without it, so the panel kept offering the cutout editor for a hollow
+    // bin whose cutouts the generator never builds.
+    const { result } = renderHook(() => useInteriorSection());
+
+    act(() => {
+      result.current.handlers.selectCard('solid');
+    });
+    act(() => {
+      useDesignerStore.getState().undo();
+    });
+
+    expect(useDesignerStore.getState().params.style).toBe('standard');
+    // The preference is still recorded — only the resolved selection moves.
+    expect(useDesignerStore.getState().ui.interiorCard).toBe('solid');
+    expect(result.current.state.card).toBe('standard');
+  });
+
+  it('falls back off Cutout when the design is reset to defaults', () => {
+    const { result } = renderHook(() => useInteriorSection());
+
+    act(() => {
+      result.current.handlers.selectCard('solid');
+    });
+    act(() => {
+      useDesignerStore.getState().resetToDefaults();
+    });
+
+    expect(useDesignerStore.getState().params.style).toBe('standard');
+    expect(result.current.state.card).toBe('standard');
+  });
+
+  it('falls back off Cutout when the constraint engine refuses the style', () => {
+    // A spacer has no interior to shape, so `style.solid` is unavailable and
+    // resolveConstraints returns the params untouched. selectCard has already
+    // recorded the preference by then.
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, base: { ...DEFAULT_BIN_PARAMS.base, spacer: true } },
+    });
+    const { result } = renderHook(() => useInteriorSection());
+
+    act(() => {
+      result.current.handlers.selectCard('solid');
+    });
+
+    expect(useDesignerStore.getState().params.style).toBe('standard');
+    expect(result.current.state.card).toBe('standard');
+  });
+
+  it('keeps Bento selected across an override reset — the tie the preference exists for', () => {
+    // Bento and Grid Dividers share `style: 'standard'`, so the preference is
+    // the ONLY thing that can tell them apart and must stay sticky.
+    const { result } = renderHook(() => useInteriorSection());
+
+    act(() => {
+      result.current.handlers.selectCard('bento');
+    });
+    expect(result.current.state.card).toBe('bento');
+
+    act(() => {
+      useDesignerStore.getState().setCompartmentGrid(3, 2);
+    });
+    expect(result.current.state.card).toBe('bento');
+  });
+});

--- a/src/features/bin-designer/components/panel/InteriorSection/useInteriorSection.ts
+++ b/src/features/bin-designer/components/panel/InteriorSection/useInteriorSection.ts
@@ -2,8 +2,8 @@ import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { resolveConstraints } from '@/shared/constraints';
-import { cardToStyle, resolveInteriorCard } from '../../../types';
-import type { BinStyle, InteriorCard } from '../../../types';
+import { cardToStyle, resolveInteriorCard } from '@/features/bin-designer/types';
+import type { BinStyle, InteriorCard } from '@/features/bin-designer/types';
 
 export function useInteriorSection() {
   // The selected card is RESOLVED against the style, never read raw: the

--- a/src/features/bin-designer/components/panel/InteriorSection/useInteriorSection.ts
+++ b/src/features/bin-designer/components/panel/InteriorSection/useInteriorSection.ts
@@ -2,16 +2,20 @@ import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { resolveConstraints } from '@/shared/constraints';
-import { cardToStyle } from '../../../types';
+import { cardToStyle, resolveInteriorCard } from '../../../types';
 import type { BinStyle, InteriorCard } from '../../../types';
 
 export function useInteriorSection() {
+  // The selected card is RESOLVED against the style, never read raw: the
+  // stored preference only breaks the Bento/Grid Dividers tie, and trusting it
+  // for Slotted or Solid lets the panel offer an editor for a mode the params
+  // are not in.
   const { style, params, setParams, card, setInteriorCard } = useDesignerStore(
     useShallow((s) => ({
       style: s.params.style,
       params: s.params,
       setParams: s.setParams,
-      card: s.ui.interiorCard,
+      card: resolveInteriorCard(s.params.style, s.ui.interiorCard),
       setInteriorCard: s.setInteriorCard,
     }))
   );

--- a/src/features/bin-designer/types/interior.test.ts
+++ b/src/features/bin-designer/types/interior.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { cardToStyle, deriveInteriorCard, hasMovedWalls, INTERIOR_CARDS } from './interior';
+import {
+  cardToStyle,
+  deriveInteriorCard,
+  hasMovedWalls,
+  INTERIOR_CARDS,
+  resolveInteriorCard,
+} from './interior';
 import type { CompartmentConfig } from './compartments';
 
 const grid = (overrides?: Partial<CompartmentConfig>): CompartmentConfig => ({
@@ -58,5 +64,31 @@ describe('deriveInteriorCard', () => {
     // reroute them to Bento, which cannot represent either.
     expect(deriveInteriorCard('slotted', grid({ dividerOverrides: [movedWall] }))).toBe('slotted');
     expect(deriveInteriorCard('solid', grid({ dividerOverrides: [movedWall] }))).toBe('solid');
+  });
+});
+
+describe('resolveInteriorCard', () => {
+  it('lets the style answer whenever it can', () => {
+    // A card the style cannot back is a mode the params are not in — the
+    // Cutout editor over a hollow bin whose cutouts never get built.
+    expect(resolveInteriorCard('standard', 'solid')).toBe('standard');
+    expect(resolveInteriorCard('standard', 'slotted')).toBe('standard');
+    expect(resolveInteriorCard('solid', 'standard')).toBe('solid');
+    expect(resolveInteriorCard('slotted', 'bento')).toBe('slotted');
+  });
+
+  it('consults the preference only for the tie it exists to break', () => {
+    // Bento and Grid Dividers are two surfaces over `standard`, so nothing in
+    // the params can separate them.
+    expect(resolveInteriorCard('standard', 'bento')).toBe('bento');
+    expect(resolveInteriorCard('standard', 'standard')).toBe('standard');
+  });
+
+  it('agrees with the seed for every card a design can be loaded on', () => {
+    // deriveInteriorCard seeds the preference; resolving that seed against the
+    // same style must be a fixed point, or a design changes card on load.
+    for (const card of INTERIOR_CARDS) {
+      expect(resolveInteriorCard(cardToStyle(card), card)).toBe(card);
+    }
   });
 });

--- a/src/features/bin-designer/types/interior.ts
+++ b/src/features/bin-designer/types/interior.ts
@@ -38,3 +38,26 @@ export function deriveInteriorCard(style: BinStyle, compartments: CompartmentCon
   if (style !== 'standard') return style;
   return hasMovedWalls(compartments) ? 'bento' : 'standard';
 }
+
+/**
+ * The card the panel actually shows as selected: the design's own style, with
+ * the stored preference consulted ONLY where the style cannot answer.
+ *
+ * `ui.interiorCard` has to be sticky (see above) but it is not free-floating —
+ * stickiness is owed entirely to the Bento/Grid Dividers ambiguity, where two
+ * cards share `style: 'standard'`. Slotted and Solid each ARE a style, so
+ * reading the preference for them lets the panel claim a mode the params are
+ * not in: `loadDesign` normalizes the field, but undo and reset-to-defaults
+ * restore params without it, and the constraint engine can refuse a style
+ * change after the card has already been recorded. Every one of those left the
+ * Cutout editor open over a `standard` bin — a hollow body with no fill for a
+ * pocket to sink into, whose cutouts the generator never builds, because they
+ * are gated on `base.solid`.
+ *
+ * Resolving here rather than patching each write path means a path added later
+ * cannot reintroduce the desync.
+ */
+export function resolveInteriorCard(style: BinStyle, preferred: InteriorCard): InteriorCard {
+  if (style !== 'standard') return style;
+  return preferred === 'bento' ? 'bento' : 'standard';
+}

--- a/src/features/bin-designer/types/uiState.ts
+++ b/src/features/bin-designer/types/uiState.ts
@@ -66,14 +66,18 @@ export interface DesignerUIState {
   /** Whether the full-workspace bento editor is open (desktop only) */
   readonly bentoWorkspaceOpen: boolean;
   /**
-   * Which interior card the panel shows as selected. Bento and Grid Dividers
-   * are both `style: 'standard'`, so the style alone cannot tell them apart.
+   * The panel's interior-card PREFERENCE — read through `resolveInteriorCard`,
+   * never raw. Bento and Grid Dividers are both `style: 'standard'`, so the
+   * style alone cannot tell those two apart and this breaks the tie; every
+   * other card IS a style, and the style wins.
    *
    * Seeded from `deriveInteriorCard` when a design loads and sticky thereafter:
    * `remapDividerOverrides` drops every override on a cell renumber, so a
    * continuously-derived card would flip to Grid Dividers the moment a bento's
-   * walls were reset by a merge. Never persisted — no `BinParams` field means
-   * no shift in `communityParamsFingerprint`.
+   * walls were reset by a merge. Stickiness is why it must be resolved on the
+   * way out — params can move under it (undo, reset, a refused style change)
+   * without ever touching it. Never persisted — no `BinParams` field means no
+   * shift in `communityParamsFingerprint`.
    */
   readonly interiorCard: InteriorCard;
   /** Preview compartments during drag-to-merge/split (shown as ghost in 3D view) */


### PR DESCRIPTION
Fixes #3637

## The defect

The Cutout editor could sit open over a `style: 'standard'` bin. That bin is hollow, so there is no fill surface for a pocket to sink into — which is exactly what the report describes — and the cutouts drawn there are never built at all: `featuresStage` gates them on `dim.solid`, which comes from `base.solid`, which `IMPLICATION_RULES` holds false for every style but `solid`.

The attached design shows the end state: `style: "standard"`, `base.solid: false`, one rectangle parked in `cutouts`. The reporter's own workaround — pick a different Interior option, then pick Cutout again — is `selectCard` finally writing the style.

## The cause

`ui.interiorCard` was read raw. It has to be sticky (`remapDividerOverrides` drops every override on a cell renumber, so a continuously-derived card would flip a Bento back to Grid Dividers mid-edit) — but that stickiness is owed **entirely** to the Bento/Grid Dividers tie, where two cards share one style. Slotted and Solid each *are* a style, and reading the preference for them let the panel claim a mode the params were not in.

Three live routes, all covered by the new tests:

| route | what happens |
|---|---|
| **undo** | `restoreHistoryEntry` restores params and normalizes `halfGridMode` and `shapeEditorOpen` right beside this field, without touching it |
| **reset to defaults** | same omission in `resetToDefaults` |
| **a refused style change** | `resolveConstraints`' post-check returns `currentParams` unchanged when the style is unavailable — `selectCard` has already recorded the preference. A spacer reaches this with no undo at all. |

## The fix

`resolveInteriorCard(style, preferred)` answers from the style and consults the preference only for the tie it exists to break. Resolving at the read site rather than patching each write path is what keeps a route added later from reintroducing the desync.

The workspace behind the card gets the same treatment: an undo can move the style out from under an open cutout editor. Only the bin target is gated — the lid's cutouts are a separate array with no such dependency — and the flag itself is left alone, so a redo brings the workspace back.

## Existing designs

Nothing is lost. Cutouts already survive a mode switch (no constraint rule clears them on a style change), so a design in this state opens on Grid Dividers with its rectangle parked, and clicking the Cutout card brings it straight back.

## Verification

Each of the three routes is a test that fails without the resolver and passes with it, plus the Bento tie as the case that must NOT change, and the three workspace states.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

