### PR TITLE
feat(cutout-editor): center a selection on one axis at a time

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -338,6 +338,13 @@ intersection`, not XOR** — they coincide for 2 members but diverge for
   Distribute runs per anchor-to-anchor SEGMENT (extremes + every locked shape between them),
   not once across the whole span — spacing the full run and merely skipping locked shapes
   would place the rest as if the anchor had moved to its even-spacing slot.
+- **Center in bin takes an axis** (`CenterAxis`, `geometryAlignment.ts`): centering both
+  axes discards a position placed deliberately, so `'x'` and `'y'` exist alongside
+  `'both'`. The untouched axis is still returned at its current value, so no caller has to
+  know which one moved, and a multi-shape selection still moves by one shared delta. The
+  three entries are one list (`CENTER_ACTIONS`) so the workspace and panel context menus
+  cannot drift apart; both toolbars are gated at 2+ selected, which makes the context menu
+  the only route for a single shape.
 - **Lock covers transforms only**: `Cutout.locked` means "cannot be moved, resized, or
   rotated". Batch edits to cut depth, chamfer and colour still apply to locked shapes; X/Y,
   W/H and rotation skip them.

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.test.tsx
@@ -151,7 +151,10 @@ describe('WorkspaceHeader', () => {
     );
     expect(screen.getByTitle('binDesigner.cutouts.alignLeft')).toBeInTheDocument();
     expect(screen.getByTitle('binDesigner.cutouts.alignRight')).toBeInTheDocument();
-    expect(screen.getByText('binDesigner.cutouts.centerInBin')).toBeInTheDocument();
+    // Centering is an icon group now, and all three axes are offered.
+    expect(screen.getByTitle('binDesigner.cutouts.centerInBin')).toBeInTheDocument();
+    expect(screen.getByTitle('binDesigner.cutouts.centerH')).toBeInTheDocument();
+    expect(screen.getByTitle('binDesigner.cutouts.centerV')).toBeInTheDocument();
     expect(screen.getByTitle('binDesigner.cutouts.pathfinder.union')).toBeInTheDocument();
   });
 

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
@@ -16,6 +16,7 @@ import {
   distributeHorizontally,
   distributeVertically,
   centerInBin,
+  type CenterAxis,
 } from '../panel/CutoutsSection/geometry';
 import {
   expandSelectionToGroups,
@@ -89,6 +90,34 @@ function AlignIcon({ type }: { readonly type: AlignType }) {
       );
   }
 }
+/**
+ * Centering is against the BIN, not against the rest of the selection, so
+ * these draw the bin outline where {@link AlignIcon} draws bare edges — the two
+ * groups sit side by side in the toolbar. The shape sits off-centre on the axis
+ * the action leaves alone, which is the whole distinction between the three.
+ */
+function CenterInBinIcon({ axis }: { readonly axis: CenterAxis }) {
+  const marks = {
+    both: { box: { x: 4.5, y: 5.5, w: 5, h: 3 }, vLine: true, hLine: true },
+    x: { box: { x: 4.5, y: 7.5, w: 5, h: 3 }, vLine: true, hLine: false },
+    y: { box: { x: 7.5, y: 4.5, w: 3, h: 5 }, vLine: false, hLine: true },
+  }[axis];
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <rect x="1" y="1" width="12" height="12" rx="1.5" />
+      {marks.vLine && <line x1="7" y1="2" x2="7" y2="12" strokeDasharray="2 1" />}
+      {marks.hLine && <line x1="2" y1="7" x2="12" y2="7" strokeDasharray="2 1" />}
+      <rect x={marks.box.x} y={marks.box.y} width={marks.box.w} height={marks.box.h} />
+    </svg>
+  );
+}
+
 function DistributeHIcon() {
   return (
     <svg
@@ -341,9 +370,12 @@ export function WorkspaceHeader({
     applyPositions(distributeVertically(arrangeTargets, binDepth));
   }, [arrangeTargets, binDepth, applyPositions]);
 
-  const handleCenterInBin = useCallback(() => {
-    applyPositions(centerInBin(arrangeTargets, binWidth, binDepth));
-  }, [arrangeTargets, binWidth, binDepth, applyPositions]);
+  const handleCenterInBin = useCallback(
+    (axis: CenterAxis) => {
+      applyPositions(centerInBin(arrangeTargets, binWidth, binDepth, axis));
+    },
+    [arrangeTargets, binWidth, binDepth, applyPositions]
+  );
 
   const handleAutoArrange = useCallback(
     (gap: number, staggered: boolean) => {
@@ -487,7 +519,24 @@ export function WorkspaceHeader({
         <Separator />
         <ArrangeControls selectedIds={selectedIds} onReorder={onReorder} disabled={disabled} />
         <div className="flex-1" />
-        {textBtn(handleCenterInBin, t('binDesigner.cutouts.centerInBin'))}
+        {/* Three icons, not a text button plus two: the row is already at its
+            width budget, and the icon group is narrower than the label it
+            replaces while matching the align/distribute groups beside it. */}
+        {iconBtn(
+          () => handleCenterInBin('both'),
+          t('binDesigner.cutouts.centerInBin'),
+          <CenterInBinIcon axis="both" />
+        )}
+        {iconBtn(
+          () => handleCenterInBin('x'),
+          t('binDesigner.cutouts.centerH'),
+          <CenterInBinIcon axis="x" />
+        )}
+        {iconBtn(
+          () => handleCenterInBin('y'),
+          t('binDesigner.cutouts.centerV'),
+          <CenterInBinIcon axis="y" />
+        )}
         <AutoArrangePopover onArrange={handleAutoArrange} />
         {textBtn(() => onDuplicate(selectedIds), t('common.duplicate'))}
         {canGroup && textBtn(() => onGroup(selectedIds), t('binDesigner.cutouts.group'))}

--- a/src/features/bin-designer/components/CutoutWorkspace/cutoutWorkspaceContextActions.test.ts
+++ b/src/features/bin-designer/components/CutoutWorkspace/cutoutWorkspaceContextActions.test.ts
@@ -182,3 +182,36 @@ describe('merge into repeat', () => {
     expect(labels(buildFor(pair))).not.toContain('binDesigner.cutouts.repeat.merge');
   });
 });
+
+describe('buildCutoutContextActions — centering', () => {
+  it('offers all three centering entries for a selection', () => {
+    expect(labels(build(makeCutout()))).toEqual(
+      expect.arrayContaining([
+        'binDesigner.cutouts.centerInBin',
+        'binDesigner.cutouts.centerH',
+        'binDesigner.cutouts.centerV',
+      ])
+    );
+  });
+
+  it('moves only the chosen axis, leaving the other where the user put it', () => {
+    const updateCutout = vi.fn();
+    const cutout = makeCutout({ x: 3, y: 7 });
+    const actions = build(cutout, { updateCutout });
+
+    const byLabel = (label: string) => {
+      const action = actions.find((a) => a.label === label);
+      if (!action) throw new Error(`no action ${label}`);
+      return action;
+    };
+
+    byLabel('binDesigner.cutouts.centerH').onClick?.();
+    expect(updateCutout).toHaveBeenLastCalledWith('c1', { x: 45, y: 7 });
+
+    byLabel('binDesigner.cutouts.centerV').onClick?.();
+    expect(updateCutout).toHaveBeenLastCalledWith('c1', { x: 3, y: 45 });
+
+    byLabel('binDesigner.cutouts.centerInBin').onClick?.();
+    expect(updateCutout).toHaveBeenLastCalledWith('c1', { x: 45, y: 45 });
+  });
+});

--- a/src/features/bin-designer/components/CutoutWorkspace/cutoutWorkspaceContextActions.ts
+++ b/src/features/bin-designer/components/CutoutWorkspace/cutoutWorkspaceContextActions.ts
@@ -8,6 +8,7 @@
 
 import type { ContextMenuAction } from '../panel/CutoutsSection/CutoutContextMenu';
 import {
+  CENTER_ACTIONS,
   centerInBin,
   flipSelectionHorizontal,
   flipSelectionVertical,
@@ -261,17 +262,19 @@ export function buildCutoutContextActions(args: BuildContextActionsArgs): Contex
   }
 
   if (hasSelection) {
-    actions.push({
-      label: t('binDesigner.cutouts.centerInBin'),
-      onClick: () => {
-        const selected = cutouts.filter((c) => selection.has(c.id));
-        const positions = centerInBin(selected, binWidth, binDepth);
-        for (const [id, pos] of Object.entries(positions)) {
-          updateCutout(id, pos);
-        }
-      },
-      dividerAfter: true,
-    });
+    for (const { axis, key } of CENTER_ACTIONS) {
+      actions.push({
+        label: t(key),
+        onClick: () => {
+          const selected = cutouts.filter((c) => selection.has(c.id));
+          const positions = centerInBin(selected, binWidth, binDepth, axis);
+          for (const [id, pos] of Object.entries(positions)) {
+            updateCutout(id, pos);
+          }
+        },
+        dividerAfter: axis === 'y',
+      });
+    }
 
     // Lock/hide/layer ordering
     const selectedCutouts = cutouts.filter((c) => selection.has(c.id));

--- a/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
@@ -10,7 +10,12 @@ import { useState } from 'react';
 import type { Cutout, GroupOp, ReorderDirection } from '@/features/bin-designer/types';
 import { Button, IconButton, Input } from '@/design-system';
 import { useTranslation } from '@/i18n';
-import { distributeHorizontally, distributeVertically, centerInBin } from './geometry';
+import {
+  distributeHorizontally,
+  distributeVertically,
+  centerInBin,
+  type CenterAxis,
+} from './geometry';
 import { expandSelectionToGroups, toArrangeUnits, unitsBounds } from './cutoutGroups';
 import { autoArrangeCutouts } from './autoArrange';
 import { PathfinderControls } from './PathfinderControls';
@@ -208,8 +213,8 @@ export function AlignmentToolbar({
     applyPositions(distributeVertically(arrangeTargets, binDepth));
   };
 
-  const handleCenterInBin = () => {
-    applyPositions(centerInBin(arrangeTargets, binWidth, binDepth));
+  const handleCenterInBin = (axis: CenterAxis) => {
+    applyPositions(centerInBin(arrangeTargets, binWidth, binDepth, axis));
   };
 
   const alignButton = (type: AlignType, label: string) => (
@@ -367,9 +372,29 @@ export function AlignmentToolbar({
           size="sm"
           touchTarget={false}
           className="text-content-secondary"
-          onClick={handleCenterInBin}
+          onClick={() => handleCenterInBin('both')}
         >
           {t('binDesigner.cutouts.centerInBin')}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          touchTarget={false}
+          className="text-content-secondary"
+          onClick={() => handleCenterInBin('x')}
+        >
+          {t('binDesigner.cutouts.centerH')}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          touchTarget={false}
+          className="text-content-secondary"
+          onClick={() => handleCenterInBin('y')}
+        >
+          {t('binDesigner.cutouts.centerV')}
         </Button>
         <Button
           type="button"

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEditor.tsx
@@ -15,7 +15,12 @@ import {
   cutoutInterior,
   cutoutTaperBand,
 } from '@/features/bin-designer/utils/binDimensions';
-import { centerInBin, flipSelectionHorizontal, flipSelectionVertical } from './geometry';
+import {
+  CENTER_ACTIONS,
+  centerInBin,
+  flipSelectionHorizontal,
+  flipSelectionVertical,
+} from './geometry';
 import { useCutoutInteraction } from './useCutoutInteraction';
 import { useTranslation } from '@/i18n';
 import { CutoutCanvas3D } from './renderer';
@@ -433,17 +438,19 @@ export function CutoutEditor() {
     }
 
     if (hasSelection) {
-      actions.push({
-        label: t('binDesigner.cutouts.centerInBin'),
-        onClick: () => {
-          const selected = cutouts.filter((c) => selection.has(c.id));
-          const positions = centerInBin(selected, binWidth, binDepth);
-          for (const [id, pos] of Object.entries(positions)) {
-            updateCutout(id, pos);
-          }
-        },
-        dividerAfter: true,
-      });
+      for (const { axis, key } of CENTER_ACTIONS) {
+        actions.push({
+          label: t(key),
+          onClick: () => {
+            const selected = cutouts.filter((c) => selection.has(c.id));
+            const positions = centerInBin(selected, binWidth, binDepth, axis);
+            for (const [id, pos] of Object.entries(positions)) {
+              updateCutout(id, pos);
+            }
+          },
+          dividerAfter: axis === 'y',
+        });
+      }
 
       const selectedCutouts = cutouts.filter((c) => selection.has(c.id));
       const allLocked = selectedCutouts.every((c) => c.locked);

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -567,6 +567,39 @@ describe('geometry', () => {
       const result = centerInBin([], 100, 100);
       expect(result).toEqual({});
     });
+
+    it('leaves the other axis exactly where the user put it', () => {
+      // The whole point of the single-axis modes: centring both at once
+      // discards a position that was placed deliberately.
+      const cutouts = [createCutout({ id: 'a', x: 3, y: 7, width: 20, depth: 15 })];
+
+      const onX = centerInBin(cutouts, 100, 100, 'x');
+      expect(onX.a.x).toBe(40);
+      expect(onX.a.y).toBe(7);
+
+      const onY = centerInBin(cutouts, 100, 100, 'y');
+      expect(onY.a.x).toBe(3);
+      expect(onY.a.y).toBe(42.5);
+    });
+
+    it("defaults to both axes, so the existing callers' behaviour is unchanged", () => {
+      const cutouts = [createCutout({ id: 'a', x: 3, y: 7, width: 20, depth: 15 })];
+      expect(centerInBin(cutouts, 100, 100)).toEqual(centerInBin(cutouts, 100, 100, 'both'));
+    });
+
+    it('moves a multi-cutout selection by one shared delta on the chosen axis', () => {
+      // Relative offsets survive a single-axis centre exactly as they do a
+      // both-axis one — the selection moves as a unit or not at all.
+      const cutouts = [
+        createCutout({ id: 'a', x: 10, y: 10, width: 20, depth: 15 }),
+        createCutout({ id: 'b', x: 40, y: 30, width: 20, depth: 15 }),
+      ];
+      const result = centerInBin(cutouts, 100, 100, 'x');
+      expect(result.b.x - result.a.x).toBe(30);
+      expect(result.a.y).toBe(10);
+      expect(result.b.y).toBe(30);
+      expect(result.a.x).toBe(25);
+    });
   });
 
   describe('rotatePoint', () => {

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.ts
@@ -39,7 +39,9 @@ export {
   distributeHorizontally,
   distributeVertically,
   centerInBin,
+  CENTER_ACTIONS,
   type AlignmentGuide,
+  type CenterAxis,
 } from './geometryAlignment';
 export {
   flipCutoutHorizontal,

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometryAlignment.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometryAlignment.ts
@@ -144,15 +144,35 @@ export function distributeVertically(
 }
 
 /**
+ * Which axes a centering action moves. The single-axis modes exist because
+ * centering both at once throws away a position the user placed deliberately:
+ * a shape centred left-to-right often still belongs near the front or back.
+ */
+export type CenterAxis = 'both' | 'x' | 'y';
+
+/**
+ * The three centering entries in menu order, shared by the workspace and panel
+ * context menus so the two cannot drift apart.
+ */
+export const CENTER_ACTIONS: ReadonlyArray<{ readonly axis: CenterAxis; readonly key: string }> = [
+  { axis: 'both', key: 'binDesigner.cutouts.centerInBin' },
+  { axis: 'x', key: 'binDesigner.cutouts.centerH' },
+  { axis: 'y', key: 'binDesigner.cutouts.centerV' },
+];
+
+/**
  * Center a selection within the bin.
  *
  * One delta for the whole selection, so relative offsets are preserved; a
- * locked unit stays behind rather than riding along.
+ * locked unit stays behind rather than riding along. The untouched axis is
+ * still returned at its current value, so a caller can apply the result
+ * without knowing which axis moved.
  */
 export function centerInBin(
   cutouts: readonly Cutout[],
   binWidth: number,
-  binDepth: number
+  binDepth: number,
+  axis: CenterAxis = 'both'
 ): Record<string, { x: number; y: number }> {
   if (cutouts.length === 0) return {};
 
@@ -160,8 +180,8 @@ export function centerInBin(
   const bounds = unitsBounds(units);
   const groupW = bounds.maxX - bounds.minX;
   const groupH = bounds.maxY - bounds.minY;
-  const dx = (binWidth - groupW) / 2 - bounds.minX;
-  const dy = (binDepth - groupH) / 2 - bounds.minY;
+  const dx = axis === 'y' ? 0 : (binWidth - groupW) / 2 - bounds.minX;
+  const dy = axis === 'x' ? 0 : (binDepth - groupH) / 2 - bounds.minY;
 
   const result: Record<string, { x: number; y: number }> = {};
   for (const unit of units) {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Uspořádat",
   "binDesigner.cutouts.autoArrange": "Automaticky uspořádat",
   "binDesigner.cutouts.centerInBin": "Vystředit v binu",
+  "binDesigner.cutouts.centerH": "Vystředit vodorovně",
+  "binDesigner.cutouts.centerV": "Vystředit svisle",
   "binDesigner.cutouts.chamfer": "Nájezdové zkosení",
   "binDesigner.cutouts.chamferInfo": "Zkosený okraj, aby se díly samy vystředily",
   "binDesigner.cutouts.clearAll": "Vyčistit vše",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Anordnen",
   "binDesigner.cutouts.autoArrange": "Automatisch anordnen",
   "binDesigner.cutouts.centerInBin": "Im Fach zentrieren",
+  "binDesigner.cutouts.centerH": "Horizontal zentrieren",
+  "binDesigner.cutouts.centerV": "Vertikal zentrieren",
   "binDesigner.cutouts.chamfer": "Einführfase",
   "binDesigner.cutouts.chamferInfo": "Abgeschrägter Rand zum Selbstzentrieren der Teile",
   "binDesigner.cutouts.clearAll": "Alle löschen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2585,6 +2585,8 @@ const en: Record<string, string> = {
   'binDesigner.cutouts.distributeH': 'Distribute horizontally',
   'binDesigner.cutouts.distributeV': 'Distribute vertically',
   'binDesigner.cutouts.centerInBin': 'Center in bin',
+  'binDesigner.cutouts.centerH': 'Center horizontally',
+  'binDesigner.cutouts.centerV': 'Center vertically',
   'binDesigner.cutouts.autoArrange': 'Auto-arrange',
   'binDesigner.cutouts.gap': 'Gap',
   'binDesigner.cutouts.staggered': 'Stagger rows',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Organizar",
   "binDesigner.cutouts.autoArrange": "Organizar automáticamente",
   "binDesigner.cutouts.centerInBin": "Centrar en bandeja",
+  "binDesigner.cutouts.centerH": "Centrar horizontalmente",
+  "binDesigner.cutouts.centerV": "Centrar verticalmente",
   "binDesigner.cutouts.chamfer": "Bisel de entrada",
   "binDesigner.cutouts.chamferInfo": "Borde biselado para que las piezas se autocentren",
   "binDesigner.cutouts.clearAll": "Borrar todo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Disposition",
   "binDesigner.cutouts.autoArrange": "Disposition automatique",
   "binDesigner.cutouts.centerInBin": "Centrer dans le bac",
+  "binDesigner.cutouts.centerH": "Centrer horizontalement",
+  "binDesigner.cutouts.centerV": "Centrer verticalement",
   "binDesigner.cutouts.chamfer": "Chanfrein d'entrée",
   "binDesigner.cutouts.chamferInfo": "Bord biseauté pour centrer les pièces",
   "binDesigner.cutouts.clearAll": "Tout effacer",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Disponi",
   "binDesigner.cutouts.autoArrange": "Disposizione automatica",
   "binDesigner.cutouts.centerInBin": "Centra nel bin",
+  "binDesigner.cutouts.centerH": "Centra orizzontalmente",
+  "binDesigner.cutouts.centerV": "Centra verticalmente",
   "binDesigner.cutouts.chamfer": "Smusso d'ingresso",
   "binDesigner.cutouts.chamferInfo": "Bordo smussato così i pezzi si centrano da soli",
   "binDesigner.cutouts.clearAll": "Cancella tutto",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "整列",
   "binDesigner.cutouts.autoArrange": "自動整列",
   "binDesigner.cutouts.centerInBin": "ビン内中央",
+  "binDesigner.cutouts.centerH": "水平方向に中央揃え",
+  "binDesigner.cutouts.centerV": "垂直方向に中央揃え",
   "binDesigner.cutouts.chamfer": "入口面取り",
   "binDesigner.cutouts.chamferInfo": "部品が中心に収まる面取り縁",
   "binDesigner.cutouts.clearAll": "すべてクリア",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "정돈",
   "binDesigner.cutouts.autoArrange": "자동 정렬",
   "binDesigner.cutouts.centerInBin": "수납통 가운데에 놓기",
+  "binDesigner.cutouts.centerH": "가로 가운데 정렬",
+  "binDesigner.cutouts.centerV": "세로 가운데 정렬",
   "binDesigner.cutouts.chamfer": "입구 모따기",
   "binDesigner.cutouts.chamferInfo": "부품이 스스로 중심을 잡도록 비스듬히 깎은 테두리",
   "binDesigner.cutouts.clearAll": "모두 지우기",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Plassering",
   "binDesigner.cutouts.autoArrange": "Ordne automatisk",
   "binDesigner.cutouts.centerInBin": "Sentrer i boks",
+  "binDesigner.cutouts.centerH": "Sentrer horisontalt",
+  "binDesigner.cutouts.centerV": "Sentrer vertikalt",
   "binDesigner.cutouts.chamfer": "Innføringsfas",
   "binDesigner.cutouts.chamferInfo": "Skråkant så deler sentrerer seg selv",
   "binDesigner.cutouts.clearAll": "Fjern alle",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Schikken",
   "binDesigner.cutouts.autoArrange": "Automatisch rangschikken",
   "binDesigner.cutouts.centerInBin": "Centreren in bak",
+  "binDesigner.cutouts.centerH": "Horizontaal centreren",
+  "binDesigner.cutouts.centerV": "Verticaal centreren",
   "binDesigner.cutouts.chamfer": "Invoerafschuining",
   "binDesigner.cutouts.chamferInfo": "Schuine rand zodat onderdelen zichzelf centreren",
   "binDesigner.cutouts.clearAll": "Alles wissen",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Rozmieść",
   "binDesigner.cutouts.autoArrange": "Rozmieść automatycznie",
   "binDesigner.cutouts.centerInBin": "Wyśrodkuj w binie",
+  "binDesigner.cutouts.centerH": "Wyśrodkuj w poziomie",
+  "binDesigner.cutouts.centerV": "Wyśrodkuj w pionie",
   "binDesigner.cutouts.chamfer": "Faza wejściowa",
   "binDesigner.cutouts.chamferInfo": "Sfazowane obrzeże, aby części same się centrowały",
   "binDesigner.cutouts.clearAll": "Wyczyść wszystko",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Organizar",
   "binDesigner.cutouts.autoArrange": "Organizar automaticamente",
   "binDesigner.cutouts.centerInBin": "Centralizar no compartimento",
+  "binDesigner.cutouts.centerH": "Centralizar horizontalmente",
+  "binDesigner.cutouts.centerV": "Centralizar verticalmente",
   "binDesigner.cutouts.chamfer": "Chanfro de entrada",
   "binDesigner.cutouts.chamferInfo": "Borda chanfrada para as peças se centralizarem",
   "binDesigner.cutouts.clearAll": "Limpar tudo",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Ordna",
   "binDesigner.cutouts.autoArrange": "Auto-arrangera",
   "binDesigner.cutouts.centerInBin": "Centrera i fack",
+  "binDesigner.cutouts.centerH": "Centrera horisontellt",
+  "binDesigner.cutouts.centerV": "Centrera vertikalt",
   "binDesigner.cutouts.chamfer": "Insticksfas",
   "binDesigner.cutouts.chamferInfo": "Fasad kant så att delar centreras",
   "binDesigner.cutouts.clearAll": "Rensa alla",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "Розташувати",
   "binDesigner.cutouts.autoArrange": "Авторозташування",
   "binDesigner.cutouts.centerInBin": "По центру біна",
+  "binDesigner.cutouts.centerH": "Центрувати горизонтально",
+  "binDesigner.cutouts.centerV": "Центрувати вертикально",
   "binDesigner.cutouts.chamfer": "Вхідна фаска",
   "binDesigner.cutouts.chamferInfo": "Скошений край для самоцентрування деталей",
   "binDesigner.cutouts.clearAll": "Очистити все",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -621,6 +621,8 @@
   "binDesigner.cutouts.arrange.title": "排列",
   "binDesigner.cutouts.autoArrange": "自动排列",
   "binDesigner.cutouts.centerInBin": "在收纳盒中居中",
+  "binDesigner.cutouts.centerH": "水平居中",
+  "binDesigner.cutouts.centerV": "垂直居中",
   "binDesigner.cutouts.chamfer": "入口倒角",
   "binDesigner.cutouts.chamferInfo": "带斜面的边沿，便于零件自动居中",
   "binDesigner.cutouts.clearAll": "全部清除",


### PR DESCRIPTION
Closes #3638

## Problem

**Center in bin** moves both axes at once, which discards a position the user placed deliberately. A shape centred left-to-right often still belongs near the front or back, and recovering that meant reading the old Y back off the Transform field and retyping it.

## Change

`centerInBin` takes an axis (`'both' | 'x' | 'y'`). The untouched axis is still returned at its current value, so no caller has to know which axis moved, and a multi-shape selection still moves by one shared delta — relative offsets survive a single-axis centre exactly as they do a both-axis one.

All three entries reach every surface that already offered centering:

| surface | works at | form |
|---|---|---|
| workspace right-click menu | 1+ selected | three menu items |
| panel right-click menu | 1+ selected | three menu items |
| panel alignment toolbar | 2+ selected | three buttons (the row wraps) |
| workspace toolbar | 2+ selected | three icons |

Both toolbars are gated at 2+, so **the context menu is the only route for a single shape** — which is the case the issue describes. The two menus build their entries from one shared `CENTER_ACTIONS` list so they cannot drift apart.

## On the workspace toolbar

It takes three icons rather than the existing label plus two new icons. That row was already over its width budget at 1600px — `Duplicate` was clipped before this change — and an icon group is narrower than the label it replaces while matching the align and distribute groups beside it. Verified in the running app: the row is less crowded after the change than before it.

The icon draws the bin outline (centering is against the bin, not against the rest of the selection, unlike the align icons next to it) with the shape sitting off-centre on whichever axis the action leaves alone.

## Verification

Unit tests on the axis behaviour, including that the default is unchanged and that a multi-shape selection keeps its relative offsets; context-menu tests asserting all three entries appear and that each moves only its own axis. Checked in the running app for both the menu and the toolbar.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

