### PR TITLE
feat(bin-designer): offer the design JSON from the export dialog

### DIFF
--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.test.tsx
@@ -56,6 +56,10 @@ vi.mock('@/shared/components/ExportDialog', async (importOriginal) => {
   };
 });
 
+vi.mock('@/features/bin-designer/utils/designJson', () => ({
+  downloadDesignAsFile: vi.fn(),
+}));
+
 vi.mock('@/features/bin-designer/hooks/useExport', () => ({
   useExport: () => ({
     canExport: true,
@@ -624,5 +628,23 @@ describe('ExportDialog', () => {
         expect.objectContaining({ message: 'Nice bin. Share it with the community?' })
       );
     });
+  });
+});
+
+describe('ExportDialog — design JSON', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSplitState = { needsSplit: false, splitPieceCount: 1 };
+    setupStore();
+  });
+
+  it('offers the design JSON alongside the 3D formats', async () => {
+    const { downloadDesignAsFile } = await import('@/features/bin-designer/utils/designJson');
+    render(<ExportDialog />);
+    const link = screen.getByRole('button', { name: 'Download Design JSON' });
+    fireEvent.click(link);
+    expect(downloadDesignAsFile).toHaveBeenCalledTimes(1);
+    // Still open: the source file is usually taken alongside a 3D export.
+    expect(screen.getByText('Export')).toBeInTheDocument();
   });
 });

--- a/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
+++ b/src/features/bin-designer/components/ExportDialog/ExportDialog.tsx
@@ -27,6 +27,7 @@ import { loadDesign } from '@/features/bin-designer/storage/DesignerStorage';
 import { designId } from '@/core/types';
 import { isOk } from '@/core/result';
 import { getSTLFileSize, estimate3MFFileSize } from '@/shared/generation/export';
+import { downloadDesignAsFile } from '@/features/bin-designer/utils/designJson';
 import { hasMeshImprints } from '@/shared/generation/meshAsset';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
@@ -93,6 +94,13 @@ export function ExportDialog() {
     setJustExported(false);
     setExportDialogOpen(false);
   }, [setExportDialogOpen]);
+
+  // Deliberately leaves the dialog open: the source file is usually taken
+  // alongside a 3D export, not instead of it.
+  const handleDownloadJSON = useCallback(() => {
+    downloadDesignAsFile(designName, params);
+    addToast({ message: t('binDesigner.downloadDesignJson'), type: 'success', duration: 2000 });
+  }, [designName, params, addToast, t]);
 
   const activeFormat: ExportFileFormat = exportFileNameConfig.format ?? 'stl';
   const useSplitExport = needsSplit && splitEnabled;
@@ -320,6 +328,11 @@ export function ExportDialog() {
         layerHeight: printSettings.layerHeightMm,
       })}
       noMeshWarning={t('binDesigner.generateAMeshFirstToEnableExport')}
+      sourceDownload={{
+        label: t('binDesigner.downloadDesignJson'),
+        hint: t('binDesigner.export.jsonHint'),
+        onClick: handleDownloadJSON,
+      }}
       sectionTitle={t('binDesigner.threeDModel')}
       sectionDescription={t('binDesigner.threeDModelDescription')}
       exported={justExported}

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Tloušťka přepážky",
   "binDesigner.doubleTapToReset": "Dvojité klepnutí pro obnovení",
   "binDesigner.downloadDesignJson": "Stáhnout JSON návrhu",
+  "binDesigner.export.jsonHint": "Upravitelný návrh pro pozdější import nebo sdílení. Není tisknutelný model.",
   "binDesigner.downloadFormat": "Stáhnout {format}",
   "binDesigner.downloadJSON": "Stáhnout JSON",
   "binDesigner.dragDropDesignFile": "Přetáhni sem soubor JSON s návrhem nebo soubor STL",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Trennwanddicke",
   "binDesigner.doubleTapToReset": "Doppeltippen zum Zurücksetzen",
   "binDesigner.downloadDesignJson": "Design-JSON herunterladen",
+  "binDesigner.export.jsonHint": "Das bearbeitbare Design zum erneuten Importieren oder Teilen. Kein druckbares Modell.",
   "binDesigner.downloadFormat": "{format} herunterladen",
   "binDesigner.downloadJSON": "JSON herunterladen",
   "binDesigner.dragDropDesignFile": "Design-JSON- oder STL-Datei hierher ziehen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1678,6 +1678,8 @@ const en: Record<string, string> = {
   'binDesigner.dimensions': 'Dimensions',
   'binDesigner.downloadJSON': 'Download JSON',
   'binDesigner.downloadDesignJson': 'Download Design JSON',
+  'binDesigner.export.jsonHint':
+    'The editable design, for re-importing or sharing. Not a printable model.',
   'binDesigner.threeDModel': '3D Model',
   'binDesigner.threeDModelDescription': 'Export a printable 3D model file',
   'binDesigner.importDesignSuccess': 'Imported and loaded "{name}"',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Grosor del divisor",
   "binDesigner.doubleTapToReset": "Doble toque para restablecer",
   "binDesigner.downloadDesignJson": "Descargar JSON de diseño",
+  "binDesigner.export.jsonHint": "El diseño editable, para reimportar o compartir. No es un modelo imprimible.",
   "binDesigner.downloadFormat": "Descargar {format}",
   "binDesigner.downloadJSON": "Descargar JSON",
   "binDesigner.dragDropDesignFile": "Arrastra y suelta aquí un archivo JSON o STL de diseño",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Épaisseur du séparateur",
   "binDesigner.doubleTapToReset": "Double tap pour réinitialiser",
   "binDesigner.downloadDesignJson": "Télécharger le JSON de design",
+  "binDesigner.export.jsonHint": "Le design modifiable, à réimporter ou à partager. Pas un modèle imprimable.",
   "binDesigner.downloadFormat": "Télécharger {format}",
   "binDesigner.downloadJSON": "Télécharger JSON",
   "binDesigner.dragDropDesignFile": "Glissez-déposez ici un fichier JSON ou STL de design",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Spessore divisore",
   "binDesigner.doubleTapToReset": "Doppio tocco per reimpostare",
   "binDesigner.downloadDesignJson": "Scarica JSON del design",
+  "binDesigner.export.jsonHint": "Il progetto modificabile, da reimportare o condividere. Non è un modello stampabile.",
   "binDesigner.downloadFormat": "Scarica {format}",
   "binDesigner.downloadJSON": "Scarica JSON",
   "binDesigner.dragDropDesignFile": "Trascina qui un file JSON o STL del design",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "仕切り板の厚さ",
   "binDesigner.doubleTapToReset": "ダブルタップでリセット",
   "binDesigner.downloadDesignJson": "デザインJSONをダウンロード",
+  "binDesigner.export.jsonHint": "再読み込みや共有のための編集可能なデザインです。印刷用モデルではありません。",
   "binDesigner.downloadFormat": "{format}をダウンロード",
   "binDesigner.downloadJSON": "JSONをダウンロード",
   "binDesigner.dragDropDesignFile": "デザインのJSONまたはSTLファイルをここにドラッグ＆ドロップ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "칸막이 두께",
   "binDesigner.doubleTapToReset": "더블 탭하여 초기화",
   "binDesigner.downloadDesignJson": "디자인 JSON 내려받기",
+  "binDesigner.export.jsonHint": "다시 불러오거나 공유할 수 있는 편집 가능한 디자인입니다. 출력용 모델이 아닙니다.",
   "binDesigner.downloadFormat": "{format} 내려받기",
   "binDesigner.downloadJSON": "JSON 내려받기",
   "binDesigner.dragDropDesignFile": "여기에 디자인 JSON 또는 STL 파일을 드래그 앤 드롭",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Skilletykkelse",
   "binDesigner.doubleTapToReset": "Dobbelttrykk for å tilbakestille",
   "binDesigner.downloadDesignJson": "Last ned Design JSON",
+  "binDesigner.export.jsonHint": "Det redigerbare designet, for ny import eller deling. Ikke en utskrivbar modell.",
   "binDesigner.downloadFormat": "Last ned {format}",
   "binDesigner.downloadJSON": "Last ned JSON",
   "binDesigner.dragDropDesignFile": "Dra og slipp en design-JSON- eller STL-fil her",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Scheidingsdikte",
   "binDesigner.doubleTapToReset": "Dubbeltik om te resetten",
   "binDesigner.downloadDesignJson": "Ontwerp-JSON downloaden",
+  "binDesigner.export.jsonHint": "Het bewerkbare ontwerp, om opnieuw te importeren of te delen. Geen printbaar model.",
   "binDesigner.downloadFormat": "{format} downloaden",
   "binDesigner.downloadJSON": "JSON downloaden",
   "binDesigner.dragDropDesignFile": "Sleep een ontwerp-JSON- of STL-bestand hierheen",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Grubość przegródki",
   "binDesigner.doubleTapToReset": "Dotknij dwukrotnie, aby zresetować",
   "binDesigner.downloadDesignJson": "Pobierz JSON projektu",
+  "binDesigner.export.jsonHint": "Edytowalny projekt do ponownego importu lub udostępnienia. To nie jest model do druku.",
   "binDesigner.downloadFormat": "Pobierz {format}",
   "binDesigner.downloadJSON": "Pobierz JSON",
   "binDesigner.dragDropDesignFile": "Przeciągnij i upuść tutaj plik JSON projektu lub STL",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Espessura do divisor",
   "binDesigner.doubleTapToReset": "Toque duplo para redefinir",
   "binDesigner.downloadDesignJson": "Baixar JSON de design",
+  "binDesigner.export.jsonHint": "O design editável, para reimportar ou compartilhar. Não é um modelo imprimível.",
   "binDesigner.downloadFormat": "Baixar {format}",
   "binDesigner.downloadJSON": "Baixar JSON",
   "binDesigner.dragDropDesignFile": "Arraste e solte um arquivo JSON ou STL de design aqui",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Avdelartjocklek",
   "binDesigner.doubleTapToReset": "Dubbeltryck för att återställa",
   "binDesigner.downloadDesignJson": "Ladda ner design-JSON",
+  "binDesigner.export.jsonHint": "Den redigerbara designen, för ny import eller delning. Inte en utskrivbar modell.",
   "binDesigner.downloadFormat": "Ladda ner {format}",
   "binDesigner.downloadJSON": "Ladda ner JSON",
   "binDesigner.dragDropDesignFile": "Dra och släpp en design-JSON- eller STL-fil här",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "Товщина розділювача",
   "binDesigner.doubleTapToReset": "Подвійний тап для скидання",
   "binDesigner.downloadDesignJson": "Завантажити Design JSON",
+  "binDesigner.export.jsonHint": "Редагований дизайн для повторного імпорту або поширення. Це не модель для друку.",
   "binDesigner.downloadFormat": "Завантажити {format}",
   "binDesigner.downloadJSON": "Завантажити JSON",
   "binDesigner.dragDropDesignFile": "Перетягніть сюди JSON- або STL-файл дизайну",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -858,6 +858,7 @@
   "binDesigner.dividerThickness": "隔板厚度",
   "binDesigner.doubleTapToReset": "双击以重置",
   "binDesigner.downloadDesignJson": "下载设计 JSON",
+  "binDesigner.export.jsonHint": "可编辑的设计文件，用于重新导入或分享。不是可打印的模型。",
   "binDesigner.downloadFormat": "下载 {format}",
   "binDesigner.downloadJSON": "下载 JSON",
   "binDesigner.dragDropDesignFile": "将设计 JSON 或 STL 文件拖放到此处",

--- a/src/shared/components/ExportDialog/ExportDialog.test.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.test.tsx
@@ -232,3 +232,28 @@ describe('ExportDialog', () => {
     });
   });
 });
+
+describe('ExportDialog — source download', () => {
+  it('is absent unless a caller offers one', () => {
+    render(<ExportDialog {...defaultProps} />);
+    expect(screen.queryByRole('button', { name: /design json/i })).not.toBeInTheDocument();
+  });
+
+  it('stays available while the 3D formats are still waiting on a mesh', () => {
+    // The source file exists before any geometry does, so it must not be
+    // gated on canExport the way the format chips and the download are.
+    const onClick = vi.fn();
+    render(
+      <ExportDialog
+        {...defaultProps}
+        canExport={false}
+        sourceDownload={{ label: 'Download Design JSON', hint: 'The editable design', onClick }}
+      />
+    );
+    const link = screen.getByRole('button', { name: 'Download Design JSON' });
+    expect(link).not.toBeDisabled();
+    fireEvent.click(link);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('The editable design')).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/ExportDialog/ExportDialog.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.tsx
@@ -99,6 +99,22 @@ export interface ExportDialogProps {
     visible: boolean;
   } | null;
 
+  /**
+   * Optional non-mesh export offered alongside the 3D formats — the design's
+   * own editable source.
+   *
+   * Deliberately NOT a fourth format chip: the chips drive the filename
+   * extension, the size estimate, the split banner and the multi-color
+   * gating, none of which a source file has. For the same reason it is not
+   * bound by `canExport` — the source exists before any mesh does, so this
+   * stays available while the 3D button is still waiting on geometry.
+   */
+  sourceDownload?: {
+    label: string;
+    hint?: string;
+    onClick: () => void;
+  } | null;
+
   /** Warning when no mesh is available */
   noMeshWarning?: string | null;
 
@@ -138,6 +154,7 @@ export function ExportDialog({
   estimatesTitle,
   estimatesDisclaimer,
   secondaryDownload,
+  sourceDownload,
   noMeshWarning,
   sectionTitle,
   sectionDescription,
@@ -377,6 +394,21 @@ export function ExportDialog({
 
             {noMeshWarning && !canExport && (
               <p className="mt-2 text-center text-xs text-warning">{noMeshWarning}</p>
+            )}
+
+            {sourceDownload && (
+              <div className="mt-3 border-t border-stroke-subtle pt-3 text-center">
+                <Button
+                  variant="ghost"
+                  onClick={sourceDownload.onClick}
+                  className="text-xs text-content-secondary underline-offset-2 hover:underline"
+                >
+                  {sourceDownload.label}
+                </Button>
+                {sourceDownload.hint && (
+                  <p className="mt-0.5 text-[10px] text-content-tertiary">{sourceDownload.hint}</p>
+                )}
+              </div>
             )}
 
             <MobileHandoffBanner />


### PR DESCRIPTION
Closes #3640

## Problem

JSON lived only under a saved design's three-dot menu. That is not where anyone looks once they have decided to export something — the Export modal is.

## Change

A `sourceDownload` slot on the shared export dialog, wired up by the bin designer to `downloadDesignAsFile`.

It is deliberately **not** a fourth format chip. The chips drive the filename extension, the size estimate, the split banner and the multi-color gating, none of which a source file has. For the same reason it is not bound by `canExport`: the design exists before any mesh does, so the JSON link stays available while the 3D button is still waiting on geometry.

It renders under the download button as a quiet labelled link with one line saying what it is, and leaves the dialog open — the source file is usually taken *alongside* a 3D export, not instead of one. The existing three-dot entry stays.

## Verification

Unit tests: the slot is absent unless a caller offers one; it stays enabled and clickable with `canExport: false`; the bin dialog wires it to the download helper and does not close.

End-to-end in the running app: clicking the link produces a real download — `Untitled Bin.json`, `type: "gridfinity-bin-design"`, with the design's actual params in it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

