### PR TITLE
feat(cutout-editor): let repeats nest and overlap

### DIFF
--- a/src/features/bin-designer/README.md
+++ b/src/features/bin-designer/README.md
@@ -350,7 +350,15 @@ intersection`, not XOR** — they coincide for 2 members but diverge for
   id/placement); derived instances get ids `${master.id}::a${i}`. Total instances
   are capped at `MAX_ARRAY_INSTANCES`, and the editor clamps counts, pitch, and
   radius to feasible bounds (`arrayFieldBounds`) so an array can't be grown past
-  the bin footprint. Arrays are restricted to **ungrouped, non-path** cutouts;
+  the bin footprint. **Pitch is bounded by the bin, never by the master's own
+  box**: two instances overlap only when they overlap on BOTH axes, so a
+  staggered array whose half-pitch X offset already clears the master may nest
+  arbitrarily close in Y — a per-axis floor cannot see that, and read off the
+  box it also refused a deliberate overlap, which is how two shapes are made to
+  cut into each other as one opening. `arrayInstancesOverlap` asks the two-axis
+  question and the editor warns that the cuts will merge; `clearPitchX/Y` say
+  where that begins. Detection accepts what the editor warns about, since
+  nothing stops two independent cutouts from touching either. Arrays are restricted to **ungrouped, non-path** cutouts;
   `flattenCutoutArray` / `applyFlattenArray` bake instances into independent
   cutouts. Array controls (`+/-` steppers) appear in both the full-screen
   workspace and the sidebar editor (`CutoutArrayControls`). **A flatten declines

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.test.tsx
@@ -100,3 +100,36 @@ describe('CutoutArrayControls', () => {
     expect(onUpdate).toHaveBeenCalledWith({ array: undefined });
   });
 });
+
+describe('CutoutArrayControls — overlap', () => {
+  const WARNING = 'binDesigner.cutouts.repeat.overlapWarning';
+
+  it('says nothing about a comfortably spaced array', () => {
+    renderControls(makeCutout({ array: arrayCfg }));
+    expect(screen.queryByText(WARNING)).not.toBeInTheDocument();
+  });
+
+  it('warns rather than blocks when the repeats run into each other', () => {
+    renderControls(makeCutout({ array: { ...arrayCfg, pitchX: 6 } }));
+    expect(screen.getByText(WARNING)).toBeInTheDocument();
+  });
+
+  it('lets the pitch go below the master box', () => {
+    // The floor was the master's own width; the field now bottoms out at the
+    // absolute editor cap, so a deliberate overlap is reachable.
+    renderControls(makeCutout({ width: 20, depth: 20, array: arrayCfg }));
+    const pitch = screen.getByRole('slider', { name: 'binDesigner.cutouts.repeat.pitchX' });
+    expect(pitch).toHaveAttribute('aria-valuemin', '1');
+  });
+
+  it('stays quiet when a stagger already separates the rows', () => {
+    // The reported nesting: a 4mm row pitch under a 10mm shape is fine once
+    // the rows sit half a pitch apart in X.
+    renderControls(
+      makeCutout({
+        array: { ...arrayCfg, mode: 'staggered', cols: 3, rows: 3, pitchX: 20, pitchY: 4 },
+      })
+    );
+    expect(screen.queryByText(WARNING)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.tsx
@@ -9,7 +9,12 @@
 
 import type { Cutout, CutoutArrayMode, CutoutArrayConfig } from '@/features/bin-designer/types';
 import { CUTOUT_ARRAY_MODES, MAX_ARRAY_COUNT } from '@/features/bin-designer/types';
-import { arrayInstanceCount, arrayFieldBounds, ARRAY_MIN_RADIUS } from '@/shared/utils/cutoutArray';
+import {
+  arrayInstanceCount,
+  arrayFieldBounds,
+  arrayInstancesOverlap,
+  ARRAY_MIN_RADIUS,
+} from '@/shared/utils/cutoutArray';
 import { useTranslation } from '@/i18n';
 import { Button, Checkbox, Stepper } from '@/design-system';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
@@ -133,6 +138,7 @@ export function CutoutArrayControls({
 
   const count = arrayInstanceCount(array);
   const bounds = arrayFieldBounds(cutout, binWidth, binDepth, array);
+  const overlaps = arrayInstancesOverlap(cutout, array);
 
   return (
     <div className="space-y-1.5">
@@ -253,6 +259,15 @@ export function CutoutArrayControls({
             disabled={disabled}
           />
         </div>
+      )}
+
+      {/* Advisory, not a block: a deliberate overlap is how two shapes are made
+          to cut into each other, so the user is told what will happen rather
+          than stopped. */}
+      {overlaps && (
+        <p className="pt-0.5 text-[11px] leading-snug text-warning">
+          {t('binDesigner.cutouts.repeat.overlapWarning')}
+        </p>
       )}
 
       <div className="flex items-center justify-between pt-0.5 text-[11px] text-content-tertiary">

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.cutoutRepeatOverlap.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.cutoutRepeatOverlap.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`cutout repeat overlap > 2×2 solid with a tightly nested staggered array 1`] = `4008`;
+
+exports[`cutout repeat overlap > 2×2 solid with an overlapping grid array 1`] = `3348`;

--- a/src/features/generation/worker/generators/binGenerator.export.cutoutRepeatOverlap.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.cutoutRepeatOverlap.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
+import { cutoutRepeatOverlap } from './scenarios/cutoutRepeatOverlap';
+
+runExportIntegrity(cutoutRepeatOverlap);

--- a/src/features/generation/worker/generators/binGenerator.scenario.cutoutRepeatOverlap.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.cutoutRepeatOverlap.test.ts
@@ -1,0 +1,5 @@
+// @vitest-environment node
+import { runScenarios } from './__kernel-tests__/scenarioRunner';
+import { cutoutRepeatOverlap } from './scenarios/cutoutRepeatOverlap';
+
+runScenarios(cutoutRepeatOverlap);

--- a/src/features/generation/worker/generators/scenarios/cutoutRepeatOverlap.ts
+++ b/src/features/generation/worker/generators/scenarios/cutoutRepeatOverlap.ts
@@ -1,0 +1,86 @@
+import { expect } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { defineScenario, makeCutout } from '../__kernel-tests__/scenarioTypes';
+import type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
+
+const SOLID_BASE = { ...DEFAULT_BIN_PARAMS.base, solid: true };
+
+/**
+ * The cut must actually remove material. Structural validity cannot catch a
+ * boolean that quietly dropped its tools — an uncut bin is still a valid one —
+ * and a dropped tool is the failure mode intersecting cutters would have.
+ */
+const mustCut: NonNullable<ScenarioCase['compareWith']> = {
+  params: { style: 'solid', base: SOLID_BASE, cutouts: [] },
+  assert: (withCut, noCut) => expect(withCut.triangleCount).toBeGreaterThan(noCut.triangleCount),
+};
+
+/**
+ * Repeat spacings the editor's per-axis pitch floor used to make unreachable.
+ * The floor was read off the master's bounding box, which refused both a
+ * staggered array nesting into the row below and a deliberate overlap.
+ */
+export const cutoutRepeatOverlap: ScenarioCase[] = [
+  // Overlap is a supported ask, not an accident: two shapes cutting into each
+  // other IS how one combined opening gets made. The editor stopped clamping
+  // the pitch to the master's box, so the kernel now sees tools that intersect
+  // and has to fuse them into one cavity rather than fail the boolean.
+  defineScenario('cutout repeat overlap', '2\u00d72 solid with an overlapping grid array', {
+    params: {
+      style: 'solid',
+      base: SOLID_BASE,
+      cutouts: [
+        makeCutout({
+          shape: 'circle',
+          x: 8,
+          y: 8,
+          width: 12,
+          depth: 12,
+          array: {
+            mode: 'grid',
+            cols: 3,
+            rows: 2,
+            // Pitch well under the 12mm master: every neighbour intersects.
+            pitchX: 8,
+            pitchY: 8,
+            count: 6,
+            radius: 20,
+            startAngle: 0,
+            rotateToCenter: false,
+          },
+        }),
+      ],
+    },
+    compareWith: mustCut,
+  }),
+  // The reported nesting: rows half a pitch apart in X, packed tight in Y.
+  // Boxes clear each other, so this is not an overlap — it is the layout the
+  // per-axis floor made unreachable.
+  defineScenario('cutout repeat overlap', '2\u00d72 solid with a tightly nested staggered array', {
+    params: {
+      style: 'solid',
+      base: SOLID_BASE,
+      cutouts: [
+        makeCutout({
+          shape: 'circle',
+          x: 6,
+          y: 6,
+          width: 10,
+          depth: 10,
+          array: {
+            mode: 'staggered',
+            cols: 3,
+            rows: 3,
+            pitchX: 20,
+            pitchY: 6,
+            count: 9,
+            radius: 20,
+            startAngle: 0,
+            rotateToCenter: false,
+          },
+        }),
+      ],
+    },
+    compareWith: mustCut,
+  }),
+];

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -49,6 +49,7 @@ import { kumikoWrapping } from './kumikoWrapping';
 import { dividerPatterns } from './dividerPatterns';
 import { floorPatterns } from './floorPatterns';
 import { knifeBlock } from './knifeBlock';
+import { cutoutRepeatOverlap } from './cutoutRepeatOverlap';
 
 export type { ScenarioCase } from '../__kernel-tests__/scenarioTypes';
 
@@ -101,4 +102,5 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...trayBottom,
   ...slideTray,
   ...knifeBlock,
+  ...cutoutRepeatOverlap,
 ];

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Kruh z {count}",
   "binDesigner.cutouts.repeat.radius": "Poloměr",
   "binDesigner.cutouts.repeat.remove": "Odebrat opakování",
+  "binDesigner.cutouts.repeat.overlapWarning": "Opakování se překrývají. Jejich řezy splynou v jeden otvor.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Otočit ke středu",
   "binDesigner.cutouts.repeat.rows": "Řady",
   "binDesigner.cutouts.repeat.startAngle": "Počáteční úhel",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Ring aus {count}",
   "binDesigner.cutouts.repeat.radius": "Radius",
   "binDesigner.cutouts.repeat.remove": "Anordnung entfernen",
+  "binDesigner.cutouts.repeat.overlapWarning": "Die Wiederholungen überlappen sich. Ihre Schnitte verschmelzen zu einer Öffnung.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Zur Mitte drehen",
   "binDesigner.cutouts.repeat.rows": "Reihen",
   "binDesigner.cutouts.repeat.startAngle": "Startwinkel",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2516,6 +2516,8 @@ const en: Record<string, string> = {
   'binDesigner.cutouts.repeat.instances': '{count} instances',
   'binDesigner.cutouts.repeat.flatten': 'Flatten to cutouts',
   'binDesigner.cutouts.repeat.remove': 'Remove repeat',
+  'binDesigner.cutouts.repeat.overlapWarning':
+    'Repeats overlap. Their cuts will merge into one opening.',
   'binDesigner.cutouts.repeat.presetLabel': 'Start with',
   'binDesigner.cutouts.repeat.presetRing': 'Ring of {count}',
   'binDesigner.cutouts.repeat.presetNoFit': 'Not enough room from this position',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Anillo de {count}",
   "binDesigner.cutouts.repeat.radius": "Radio",
   "binDesigner.cutouts.repeat.remove": "Quitar matriz",
+  "binDesigner.cutouts.repeat.overlapWarning": "Las repeticiones se solapan. Sus cortes se fusionarán en una sola abertura.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Girar al centro",
   "binDesigner.cutouts.repeat.rows": "Filas",
   "binDesigner.cutouts.repeat.startAngle": "Ángulo inicial",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Anneau de {count}",
   "binDesigner.cutouts.repeat.radius": "Rayon",
   "binDesigner.cutouts.repeat.remove": "Supprimer le réseau",
+  "binDesigner.cutouts.repeat.overlapWarning": "Les répétitions se chevauchent. Leurs découpes fusionneront en une seule ouverture.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Orienter vers le centre",
   "binDesigner.cutouts.repeat.rows": "Lignes",
   "binDesigner.cutouts.repeat.startAngle": "Angle de départ",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Anello di {count}",
   "binDesigner.cutouts.repeat.radius": "Raggio",
   "binDesigner.cutouts.repeat.remove": "Rimuovi serie",
+  "binDesigner.cutouts.repeat.overlapWarning": "Le ripetizioni si sovrappongono. I loro tagli si fonderanno in un’unica apertura.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Ruota verso il centro",
   "binDesigner.cutouts.repeat.rows": "Righe",
   "binDesigner.cutouts.repeat.startAngle": "Angolo iniziale",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "{count} 個のリング",
   "binDesigner.cutouts.repeat.radius": "半径",
   "binDesigner.cutouts.repeat.remove": "配列を削除",
+  "binDesigner.cutouts.repeat.overlapWarning": "繰り返しが重なっています。切り抜きは1つの開口部として結合されます。",
   "binDesigner.cutouts.repeat.rotateToCenter": "中心に向ける",
   "binDesigner.cutouts.repeat.rows": "行",
   "binDesigner.cutouts.repeat.startAngle": "開始角度",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "{count}개 링",
   "binDesigner.cutouts.repeat.radius": "반지름",
   "binDesigner.cutouts.repeat.remove": "배열 제거",
+  "binDesigner.cutouts.repeat.overlapWarning": "반복 도형이 겹칩니다. 잘라낸 부분이 하나의 구멍으로 합쳐집니다.",
   "binDesigner.cutouts.repeat.rotateToCenter": "중심으로 회전",
   "binDesigner.cutouts.repeat.rows": "행",
   "binDesigner.cutouts.repeat.startAngle": "시작 각도",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Ring med {count}",
   "binDesigner.cutouts.repeat.radius": "Radius",
   "binDesigner.cutouts.repeat.remove": "Fjern matrise",
+  "binDesigner.cutouts.repeat.overlapWarning": "Gjentakelsene overlapper. Utskjæringene smelter sammen til én åpning.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Roter mot sentrum",
   "binDesigner.cutouts.repeat.rows": "Rader",
   "binDesigner.cutouts.repeat.startAngle": "Startvinkel",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Ring van {count}",
   "binDesigner.cutouts.repeat.radius": "Straal",
   "binDesigner.cutouts.repeat.remove": "Reeks verwijderen",
+  "binDesigner.cutouts.repeat.overlapWarning": "De herhalingen overlappen. Hun uitsparingen vloeien samen tot één opening.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Naar midden draaien",
   "binDesigner.cutouts.repeat.rows": "Rijen",
   "binDesigner.cutouts.repeat.startAngle": "Starthoek",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Pierścień z {count}",
   "binDesigner.cutouts.repeat.radius": "Promień",
   "binDesigner.cutouts.repeat.remove": "Usuń szyk",
+  "binDesigner.cutouts.repeat.overlapWarning": "Powtórzenia nachodzą na siebie. Ich wycięcia połączą się w jeden otwór.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Obróć do środka",
   "binDesigner.cutouts.repeat.rows": "Rzędy",
   "binDesigner.cutouts.repeat.startAngle": "Kąt początkowy",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Anel de {count}",
   "binDesigner.cutouts.repeat.radius": "Raio",
   "binDesigner.cutouts.repeat.remove": "Remover matriz",
+  "binDesigner.cutouts.repeat.overlapWarning": "As repetições se sobrepõem. Seus cortes vão se fundir em uma única abertura.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Girar para o centro",
   "binDesigner.cutouts.repeat.rows": "Linhas",
   "binDesigner.cutouts.repeat.startAngle": "Ângulo inicial",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Ring med {count}",
   "binDesigner.cutouts.repeat.radius": "Radie",
   "binDesigner.cutouts.repeat.remove": "Ta bort matris",
+  "binDesigner.cutouts.repeat.overlapWarning": "Upprepningarna överlappar. Deras urtag smälter samman till en öppning.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Rotera mot mitten",
   "binDesigner.cutouts.repeat.rows": "Rader",
   "binDesigner.cutouts.repeat.startAngle": "Startvinkel",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "Кільце з {count}",
   "binDesigner.cutouts.repeat.radius": "Радіус",
   "binDesigner.cutouts.repeat.remove": "Вилучити масив",
+  "binDesigner.cutouts.repeat.overlapWarning": "Повтори перекриваються. Їхні вирізи зіллються в один отвір.",
   "binDesigner.cutouts.repeat.rotateToCenter": "Повертати до центру",
   "binDesigner.cutouts.repeat.rows": "Рядки",
   "binDesigner.cutouts.repeat.startAngle": "Початковий кут",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -721,6 +721,7 @@
   "binDesigner.cutouts.repeat.presetRing": "{count} 个环形",
   "binDesigner.cutouts.repeat.radius": "半径",
   "binDesigner.cutouts.repeat.remove": "移除阵列",
+  "binDesigner.cutouts.repeat.overlapWarning": "重复图形重叠，切口将合并为一个开口。",
   "binDesigner.cutouts.repeat.rotateToCenter": "旋转朝向中心",
   "binDesigner.cutouts.repeat.rows": "行",
   "binDesigner.cutouts.repeat.startAngle": "起始角度",

--- a/src/shared/utils/cutoutArray.test.ts
+++ b/src/shared/utils/cutoutArray.test.ts
@@ -301,7 +301,7 @@ describe('arrayFieldBounds', () => {
 });
 
 describe('arrayInstancesOverlap', () => {
-  const master = (w = 10, d = 10) => ({ width: w, depth: d });
+  const master = (w = 10, d = 10): Pick<Cutout, 'width' | 'depth'> => ({ width: w, depth: d });
   const base = {
     mode: 'grid' as const,
     cols: 3,
@@ -316,6 +316,13 @@ describe('arrayInstancesOverlap', () => {
 
   it('is false for a comfortably spaced grid', () => {
     expect(arrayInstancesOverlap(master(), base)).toBe(false);
+  });
+
+  it('treats edge-to-edge as clear, not as overlap', () => {
+    // Flush neighbours share a boundary and still cut two openings. The
+    // threshold is where they start eating into each other.
+    expect(arrayInstancesOverlap(master(), { ...base, pitchX: 10, pitchY: 10 })).toBe(false);
+    expect(arrayInstancesOverlap(master(), { ...base, pitchX: 9.99, pitchY: 10 })).toBe(true);
   });
 
   it('is true when neighbouring columns run into each other', () => {

--- a/src/shared/utils/cutoutArray.test.ts
+++ b/src/shared/utils/cutoutArray.test.ts
@@ -4,6 +4,7 @@ import {
   arrayInstanceCount,
   defaultArrayConfig,
   arrayFieldBounds,
+  arrayInstancesOverlap,
   expandCutoutArray,
   type ArrayInstance,
 } from './cutoutArray';
@@ -259,31 +260,88 @@ describe('arrayFieldBounds', () => {
     expect(b.maxCols).toBeLessThanOrEqual(5);
   });
 
-  it('minPitchX/Y are floorToHalf(dimension) + 1mm wall gap', () => {
-    // 15mm × 10mm: floorToHalf(15)=15 → minPitchX=16, floorToHalf(10)=10 → minPitchY=11
+  it('does not floor the pitch on the master box — overlap is allowed', () => {
+    // Deliberate overlap makes neighbouring cuts merge into one opening, which
+    // is a real thing to ask for, so the editor warns rather than clamps.
     const b = arrayFieldBounds(cut({ width: 15, depth: 10 }), 200, 200, cfg());
-    expect(b.minPitchX).toBe(16);
-    expect(b.minPitchY).toBe(11);
-  });
-
-  it('minPitchX rounds fractional width down to nearest 0.5 before adding gap', () => {
-    // 15.74mm width: floorToHalf(15.74)=15.5 → minPitchX=16.5
-    const b = arrayFieldBounds(cut({ width: 15.74, depth: 8 }), 200, 200, cfg());
-    expect(b.minPitchX).toBe(16.5);
-    expect(b.minPitchY).toBe(9);
-  });
-
-  it('minPitchX/Y floor to ARRAY_MIN_PITCH for tiny cutouts', () => {
-    // 0.1mm cutout: floorToHalf(0.1)=0 → 0+1=1, clamped to ARRAY_MIN_PITCH (=1).
-    const b = arrayFieldBounds(cut({ width: 0.1, depth: 0.1 }), 200, 200, cfg());
     expect(b.minPitchX).toBe(1);
     expect(b.minPitchY).toBe(1);
   });
 
-  it('minPitchX/Y are independent of bin size', () => {
-    const small = arrayFieldBounds(cut({ width: 15, depth: 10 }), 100, 100, cfg());
-    const large = arrayFieldBounds(cut({ width: 15, depth: 10 }), 10_000, 10_000, cfg());
-    expect(small.minPitchX).toBe(large.minPitchX);
-    expect(small.minPitchY).toBe(large.minPitchY);
+  it('reports where overlap begins on each axis', () => {
+    const b = arrayFieldBounds(cut({ width: 15, depth: 10 }), 200, 200, cfg({ cols: 3, rows: 2 }));
+    expect(b.clearPitchX).toBe(15);
+    expect(b.clearPitchY).toBe(10);
+  });
+
+  it('has no clear pitch to report on an axis with one instance', () => {
+    const b = arrayFieldBounds(cut({ width: 15, depth: 10 }), 200, 200, cfg({ cols: 1, rows: 1 }));
+    expect(b.clearPitchX).toBe(1);
+    expect(b.clearPitchY).toBe(1);
+  });
+
+  it('drops the Y clear pitch once a stagger separates the rows in X', () => {
+    // The reported case: rows half a pitch apart in X already miss each other,
+    // so they may nest arbitrarily close in Y. A per-axis floor read off the
+    // master's own box is what made that impossible.
+    const master = cut({ width: 10, depth: 10 });
+    const nested = cfg({ mode: 'staggered', cols: 3, rows: 3, pitchX: 20, pitchY: 4 });
+    expect(arrayFieldBounds(master, 200, 200, nested).clearPitchY).toBe(1);
+
+    // Same array without the stagger: the rows sit directly above each other.
+    expect(arrayFieldBounds(master, 200, 200, { ...nested, mode: 'grid' }).clearPitchY).toBe(10);
+  });
+
+  it('clear pitch is independent of bin size', () => {
+    const small = arrayFieldBounds(cut({ width: 15, depth: 10 }), 100, 100, cfg({ rows: 2 }));
+    const large = arrayFieldBounds(cut({ width: 15, depth: 10 }), 10_000, 10_000, cfg({ rows: 2 }));
+    expect(small.clearPitchX).toBe(large.clearPitchX);
+    expect(small.clearPitchY).toBe(large.clearPitchY);
+  });
+});
+
+describe('arrayInstancesOverlap', () => {
+  const master = (w = 10, d = 10) => ({ width: w, depth: d });
+  const base = {
+    mode: 'grid' as const,
+    cols: 3,
+    rows: 3,
+    pitchX: 20,
+    pitchY: 20,
+    count: 6,
+    radius: 20,
+    startAngle: 0,
+    rotateToCenter: false,
+  };
+
+  it('is false for a comfortably spaced grid', () => {
+    expect(arrayInstancesOverlap(master(), base)).toBe(false);
+  });
+
+  it('is true when neighbouring columns run into each other', () => {
+    expect(arrayInstancesOverlap(master(), { ...base, pitchX: 6 })).toBe(true);
+  });
+
+  it('is true when neighbouring rows run into each other', () => {
+    expect(arrayInstancesOverlap(master(), { ...base, pitchY: 6 })).toBe(true);
+  });
+
+  it('needs BOTH axes to overlap, so a single row or column never does', () => {
+    expect(arrayInstancesOverlap(master(), { ...base, rows: 1, pitchY: 1 })).toBe(false);
+    expect(arrayInstancesOverlap(master(), { ...base, cols: 1, pitchX: 1 })).toBe(false);
+  });
+
+  it('lets a staggered array nest into the row below', () => {
+    // pitchX/2 = 10 clears the 10mm master, so a 4mm row pitch still misses.
+    const nested = { ...base, mode: 'staggered' as const, pitchX: 20, pitchY: 4 };
+    expect(arrayInstancesOverlap(master(), nested)).toBe(false);
+    // The same spacing without the stagger does overlap.
+    expect(arrayInstancesOverlap(master(), { ...nested, mode: 'grid' as const })).toBe(true);
+    // And a stagger too narrow to clear the master still overlaps.
+    expect(arrayInstancesOverlap(master(), { ...nested, pitchX: 12 })).toBe(true);
+  });
+
+  it('never reports overlap for a radial ring', () => {
+    expect(arrayInstancesOverlap(master(), { ...base, mode: 'radial', radius: 1 })).toBe(false);
   });
 });

--- a/src/shared/utils/cutoutArray.ts
+++ b/src/shared/utils/cutoutArray.ts
@@ -25,9 +25,6 @@ export const ARRAY_MAX_PITCH = 200;
 export const ARRAY_MIN_RADIUS = 1;
 export const ARRAY_MAX_RADIUS = 200;
 
-/** Minimum printed wall between adjacent array instances (mm). */
-export const ARRAY_MIN_WALL_GAP = 1;
-
 export interface ArrayInstance {
   /** Center offset from the master center (mm). */
   readonly dx: number;
@@ -148,6 +145,42 @@ export interface ArrayFieldBounds {
   readonly maxPitchX: number;
   readonly maxPitchY: number;
   readonly maxRadius: number;
+  /**
+   * Smallest pitch on each axis at which no two instances' bounding boxes
+   * touch, given the other axis and the mode as they currently stand.
+   *
+   * Advisory, NOT a floor: overlap is a legitimate thing to ask for (two
+   * shapes cutting into each other to make one opening), so the editor warns
+   * rather than clamps. Below this the resulting cuts merge.
+   */
+  readonly clearPitchX: number;
+  readonly clearPitchY: number;
+}
+
+/**
+ * Whether any two instances of this array overlap, box against box.
+ *
+ * Two instances overlap only when they overlap on BOTH axes, which is what
+ * makes a staggered array able to nest: adjacent rows sit half a pitch apart
+ * in X, so once that half-pitch clears the master's width the rows may come
+ * arbitrarily close in Y and still not touch. Reading the Y bound off the
+ * master's box alone — as a per-axis floor must — is what stopped round
+ * shapes from nesting into the row below them.
+ *
+ * Measured on the nominal box, like every other bound here; a rotated master
+ * sweeps a different box and is not corrected for.
+ */
+export function arrayInstancesOverlap(
+  cutout: Pick<Cutout, 'width' | 'depth'>,
+  config: CutoutArrayConfig
+): boolean {
+  if (config.mode === 'radial') return false;
+  const cols = clampCount(config.cols);
+  const rows = clampCount(config.rows);
+  const staggered = config.mode === 'staggered';
+  if (cols > 1 && config.pitchX < cutout.width) return true;
+  const rowOffsetX = staggered ? config.pitchX / 2 : 0;
+  return rows > 1 && rowOffsetX < cutout.width && config.pitchY < cutout.depth;
 }
 
 const floorToHalf = (v: number): number => Math.floor(v * 2) / 2;
@@ -215,11 +248,30 @@ export function arrayFieldBounds(
   );
   const maxRadius = clamp(floorToHalf(edgeClearance), ARRAY_MIN_RADIUS, ARRAY_MAX_RADIUS);
 
-  // Minimum pitch that preserves at least ARRAY_MIN_WALL_GAP of material between instances.
-  const minPitchX = Math.max(ARRAY_MIN_PITCH, floorToHalf(w) + ARRAY_MIN_WALL_GAP);
-  const minPitchY = Math.max(ARRAY_MIN_PITCH, floorToHalf(d) + ARRAY_MIN_WALL_GAP);
+  // Pitch floors are the absolute editor cap only. A floor derived from the
+  // master's box refuses two things the user may genuinely want: a staggered
+  // array nesting into the row below (where the half-pitch X offset has
+  // already separated the boxes) and a deliberate overlap, where neighbouring
+  // cuts are meant to merge into one opening. `clearPitch*` says where overlap
+  // begins so the editor can warn instead.
+  const minPitchX = ARRAY_MIN_PITCH;
+  const minPitchY = ARRAY_MIN_PITCH;
+  const staggerOffsetX = config.mode === 'staggered' ? config.pitchX / 2 : 0;
+  const clearPitchX = cols > 1 ? Math.max(ARRAY_MIN_PITCH, w) : ARRAY_MIN_PITCH;
+  const clearPitchY =
+    rows > 1 && staggerOffsetX < w ? Math.max(ARRAY_MIN_PITCH, d) : ARRAY_MIN_PITCH;
 
-  return { maxCols, maxRows, minPitchX, minPitchY, maxPitchX, maxPitchY, maxRadius };
+  return {
+    maxCols,
+    maxRows,
+    minPitchX,
+    minPitchY,
+    maxPitchX,
+    maxPitchY,
+    maxRadius,
+    clearPitchX,
+    clearPitchY,
+  };
 }
 
 /** A sensible default config for a freshly-enabled array, sized off the master. */

--- a/src/shared/utils/cutoutArray.ts
+++ b/src/shared/utils/cutoutArray.ts
@@ -147,7 +147,11 @@ export interface ArrayFieldBounds {
   readonly maxRadius: number;
   /**
    * Smallest pitch on each axis at which no two instances' bounding boxes
-   * touch, given the other axis and the mode as they currently stand.
+   * OVERLAP, given the other axis and the mode as they currently stand.
+   *
+   * Edge to edge is not overlap and is exactly this value: instances packed
+   * flush share a boundary and still cut two openings, so the threshold is
+   * where they start eating into each other, not where they meet.
    *
    * Advisory, NOT a floor: overlap is a legitimate thing to ask for (two
    * shapes cutting into each other to make one opening), so the editor warns
@@ -163,7 +167,7 @@ export interface ArrayFieldBounds {
  * Two instances overlap only when they overlap on BOTH axes, which is what
  * makes a staggered array able to nest: adjacent rows sit half a pitch apart
  * in X, so once that half-pitch clears the master's width the rows may come
- * arbitrarily close in Y and still not touch. Reading the Y bound off the
+ * arbitrarily close in Y and still miss each other. Reading the Y bound off the
  * master's box alone — as a per-axis floor must — is what stopped round
  * shapes from nesting into the row below them.
  *

--- a/src/shared/utils/cutoutRepeatDetect.test.ts
+++ b/src/shared/utils/cutoutRepeatDetect.test.ts
@@ -250,11 +250,22 @@ describe('arrangements that are not a pattern', () => {
 
     expect(detectRepeatPattern(placed, BIN_W, BIN_D)).toBeNull();
   });
+});
 
-  it('declines spacing tighter than the minimum printable wall', () => {
+describe('spacing the user actually placed', () => {
+  it('accepts shapes packed edge to edge', () => {
+    // Detection is the way back from a flattened repeat, so it has to be able
+    // to describe what is on the board. Nothing stops two independent cutouts
+    // from touching, and an array is not held to a stricter rule.
     const placed = asPlacedCutouts(cutout({ width: 12 }), cfg({ cols: 3, rows: 1, pitchX: 12 }));
 
-    expect(detectRepeatPattern(placed, BIN_W, BIN_D)).toBeNull();
+    expect(detectRepeatPattern(placed, BIN_W, BIN_D)).not.toBeNull();
+  });
+
+  it('accepts shapes that deliberately overlap', () => {
+    const placed = asPlacedCutouts(cutout({ width: 12 }), cfg({ cols: 3, rows: 1, pitchX: 8 }));
+
+    expect(detectRepeatPattern(placed, BIN_W, BIN_D)).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #3642

## Problem

The repeat pitch floor was `master bounding box + 1mm`, per axis. That refused two different things.

**Staggered arrays could not nest.** Two instances overlap only when they overlap on *both* axes, and staggered rows already sit half a pitch apart in X. Once that half-pitch clears the master's width, the rows may come arbitrarily close in Y and still not touch — but a per-axis floor cannot see the other axis, so round shapes were held a full diameter apart with the space between them unusable. This is the case in the issue's screenshot.

**Deliberate overlap was impossible**, though two shapes cutting into each other is exactly how one combined opening gets made.

## Change

Pitch bottoms out at `ARRAY_MIN_PITCH` (the absolute editor cap that keeps instances from stacking on the master). `arrayInstancesOverlap` asks the two-axis question the floor could not, and the editor **warns that the cuts will merge rather than clamping** — which is what the issue asked for.

`arrayFieldBounds` also reports `clearPitchX` / `clearPitchY`: where overlap begins on each axis given the other axis and the mode as they currently stand. Advisory only, and it correctly stays silent on a nested stagger.

Pattern detection now accepts what the editor warns about. It is the way back from a flattened repeat, so it has to be able to describe what is on the board — and nothing stops two *independent* cutouts from touching, so an array is no longer held to a stricter rule than manual placement. That is where the floor's "minimum printable wall" was an inconsistency rather than a safety net: it was the only place in the editor enforcing one.

`ARRAY_MIN_WALL_GAP` had no other reader and is gone.

## Verification

This unlocks inputs the generator had never seen, so both spacings are pinned as kernel scenarios against real WASM (`binGenerator.scenario.cutoutRepeatOverlap`): a 3×2 grid of 12mm circles at 8mm pitch, and the reported nested stagger. Intersecting cut tools must fuse into one cavity rather than be dropped — and a dropped tool leaves a bin that is still structurally valid and watertight, so both assert against an uncut bin rather than on validity alone.

Unit tests cover the two-axis overlap predicate (including that a single row or column never overlaps, and that a radial ring is exempt), the clear-pitch reporting, the relaxed floor, the detection contract, and the warning appearing/not appearing in the controls.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

