### PR TITLE
feat(cutout-editor): make the canvas viewport hold still

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutQuickstartOverlay.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutQuickstartOverlay.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { CutoutQuickstartOverlay } from './CutoutQuickstartOverlay';
 
 describe('CutoutQuickstartOverlay', () => {
-  it('renders all 6 feature rows', () => {
+  it('renders all 7 feature rows', () => {
     render(<CutoutQuickstartOverlay onDismiss={vi.fn()} />);
     expect(screen.getByText(/shapes/i)).toBeInTheDocument();
     expect(screen.getByText(/drag a marquee/i)).toBeInTheDocument();
@@ -11,7 +11,10 @@ describe('CutoutQuickstartOverlay', () => {
     expect(screen.getByText(/right-click/i)).toBeInTheDocument();
     expect(screen.getByText(/smart guides/i)).toBeInTheDocument();
     expect(screen.getByText(/one repeat/i)).toBeInTheDocument();
-    expect(screen.getAllByRole('listitem')).toHaveLength(6);
+    // Pan and fit exist but are invisible on the canvas, so the overlay is the
+    // only place a user learns them.
+    expect(screen.getByText(/space-drag or middle-drag to pan/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(7);
   });
 
   it('calls onDismiss when Got it button is clicked', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutQuickstartOverlay.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutQuickstartOverlay.tsx
@@ -75,6 +75,14 @@ export function CutoutQuickstartOverlay({ onDismiss }: CutoutQuickstartOverlayPr
             icon={<RepeatIcon />}
             text={t('binDesigner.cutoutEditor.quickstart.repeat')}
           />
+          {/* Pan and fit already existed and nothing said so, which reads as
+              their absence — the view controls are the one group a user cannot
+              discover by clicking around the canvas. */}
+          <FeatureRow
+            index={6}
+            icon={<NavigateIcon />}
+            text={t('binDesigner.cutoutEditor.quickstart.navigate')}
+          />
         </ul>
 
         <Button
@@ -169,6 +177,23 @@ function RepeatIcon() {
       <rect x="11" y="1.5" width="6" height="6" rx="1" />
       <rect x="1.5" y="11" width="6" height="6" rx="1" />
       <rect x="11" y="11" width="6" height="6" rx="1" />
+    </svg>
+  );
+}
+
+function NavigateIcon() {
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.3}
+      aria-hidden="true"
+    >
+      <path d="M8 1.5v13M1.5 8h13" />
+      <path d="M8 1.5 6 3.5M8 1.5l2 2M8 14.5l-2-2M8 14.5l2-2" />
+      <path d="M1.5 8l2-2M1.5 8l2 2M14.5 8l-2-2M14.5 8l-2 2" />
     </svg>
   );
 }

--- a/src/features/bin-designer/components/CutoutWorkspace/useCutoutWorkspaceCamera.test.ts
+++ b/src/features/bin-designer/components/CutoutWorkspace/useCutoutWorkspaceCamera.test.ts
@@ -3,7 +3,7 @@ import { createElement, useEffect } from 'react';
 import { render as renderComponent, act } from '@testing-library/react';
 import { useCutoutWorkspaceCamera } from './useCutoutWorkspaceCamera';
 import type { CutoutWorkspaceCamera } from './useCutoutWorkspaceCamera';
-import { ZOOM_STEP } from '../panel/CutoutsSection/renderer/constants';
+import { ZOOM_STEP } from '@/features/bin-designer/components/panel/CutoutsSection/renderer/constants';
 
 /**
  * Drives the container size the hook measures. The global mock reports one

--- a/src/features/bin-designer/components/CutoutWorkspace/useCutoutWorkspaceCamera.test.ts
+++ b/src/features/bin-designer/components/CutoutWorkspace/useCutoutWorkspaceCamera.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createElement, useEffect } from 'react';
+import { render as renderComponent, act } from '@testing-library/react';
+import { useCutoutWorkspaceCamera } from './useCutoutWorkspaceCamera';
+import type { CutoutWorkspaceCamera } from './useCutoutWorkspaceCamera';
+import { ZOOM_STEP } from '../panel/CutoutsSection/renderer/constants';
+
+/**
+ * Drives the container size the hook measures. The global mock reports one
+ * fixed rect; these tests need to change it mid-run to stand in for the split
+ * divider being dragged.
+ */
+let resizeCallbacks: ResizeObserverCallback[] = [];
+let containerRect = { width: 800, height: 400 };
+
+class ControllableResizeObserver {
+  private readonly callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    resizeCallbacks.push(callback);
+  }
+  observe(): void {
+    this.callback([{ contentRect: containerRect } as unknown as ResizeObserverEntry], this);
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function resizeContainerTo(width: number, height: number): void {
+  containerRect = { width, height };
+  for (const cb of resizeCallbacks) {
+    cb([{ contentRect: containerRect } as unknown as ResizeObserverEntry], {
+      observe: () => {},
+      unobserve: () => {},
+      disconnect: () => {},
+    });
+  }
+}
+
+/** A wheel event carrying a real delta, which the fixed-step version ignored. */
+function wheel(deltaY: number, deltaMode = 0): React.WheelEvent<HTMLDivElement> {
+  return {
+    deltaY,
+    deltaMode,
+    clientX: 400,
+    clientY: 200,
+    preventDefault: vi.fn(),
+    currentTarget: {
+      getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 400 }),
+    },
+  } as unknown as React.WheelEvent<HTMLDivElement>;
+}
+
+const originalResizeObserver = window.ResizeObserver;
+
+beforeEach(() => {
+  resizeCallbacks = [];
+  containerRect = { width: 800, height: 400 };
+  window.ResizeObserver = ControllableResizeObserver;
+});
+
+afterEach(() => {
+  window.ResizeObserver = originalResizeObserver;
+});
+
+/**
+ * The hook measures a container it holds a ref to, and only observes one React
+ * has already attached — so this mounts a real element rather than assigning
+ * the ref after the fact, which would leave the observer unregistered and every
+ * resize in these tests silently inert.
+ */
+const holder: { current: CutoutWorkspaceCamera | null } = { current: null };
+
+function Harness({ w, d }: { readonly w: number; readonly d: number }) {
+  const camera = useCutoutWorkspaceCamera(w, d);
+  // Published from an effect, not during render: every read below happens
+  // after an `act()` has flushed, so the value is current either way.
+  useEffect(() => {
+    holder.current = camera;
+  });
+  return createElement('div', { ref: camera.canvasContainerRef });
+}
+
+function render(binWidth = 100, binDepth = 50) {
+  const view = renderComponent(createElement(Harness, { w: binWidth, d: binDepth }));
+  return {
+    result: {
+      get current(): CutoutWorkspaceCamera {
+        if (!holder.current) throw new Error('camera not published');
+        return holder.current;
+      },
+    },
+    rerender: (props: { w: number; d: number }) => view.rerender(createElement(Harness, props)),
+  };
+}
+
+describe('useCutoutWorkspaceCamera — wheel zoom is proportional to the wheel', () => {
+  it('moves exactly one step for a mouse notch', () => {
+    // A fixed step per event was right for a mouse and stays right for one.
+    const { result } = render();
+    const before = result.current.zoom;
+    act(() => result.current.handleWheel(wheel(-120)));
+    expect(result.current.zoom / before).toBeCloseTo(ZOOM_STEP, 5);
+  });
+
+  it('moves a fraction of a step for a trackpad nudge', () => {
+    // The reported overshoot: a two-finger flick is a stream of small deltas,
+    // and each one used to be a full 1.25x.
+    const { result } = render();
+    const before = result.current.zoom;
+    act(() => result.current.handleWheel(wheel(-10)));
+    const ratio = result.current.zoom / before;
+    expect(ratio).toBeGreaterThan(1);
+    expect(ratio).toBeLessThan(ZOOM_STEP);
+    expect(ratio).toBeCloseTo(Math.pow(ZOOM_STEP, 10 / 120), 5);
+  });
+
+  it('zooms out on a positive delta', () => {
+    const { result } = render();
+    const before = result.current.zoom;
+    act(() => result.current.handleWheel(wheel(120)));
+    expect(result.current.zoom / before).toBeCloseTo(1 / ZOOM_STEP, 5);
+  });
+
+  it('reads LINE deltas as lines, not pixels', () => {
+    // Firefox reports ~3 lines per notch; as raw pixels that would be almost
+    // no zoom at all, which is the mirror image of the trackpad bug.
+    const { result } = render();
+    const before = result.current.zoom;
+    act(() => result.current.handleWheel(wheel(-3, 1)));
+    expect(result.current.zoom / before).toBeCloseTo(Math.pow(ZOOM_STEP, 48 / 120), 5);
+  });
+
+  it('caps how far one event may travel', () => {
+    const { result } = render();
+    const before = result.current.zoom;
+    act(() => result.current.handleWheel(wheel(-100_000)));
+    expect(result.current.zoom / before).toBeLessThanOrEqual(Math.pow(ZOOM_STEP, 2) + 1e-6);
+  });
+});
+
+describe('useCutoutWorkspaceCamera — a container resize is not a re-frame', () => {
+  it('keeps the zoom and pan the user set when the canvas is resized', () => {
+    // defaultZoom is derived from the container, so dragging the split divider
+    // beside the canvas used to throw the framing away — the loop the issue
+    // describes as "zooming repositions the view".
+    const { result } = render();
+    act(() => result.current.handleWheel(wheel(-120)));
+    act(() => result.current.setCameraCenter({ x: 12, y: 34 }));
+    const framed = { zoom: result.current.zoom, center: result.current.cameraCenter };
+
+    act(() => resizeContainerTo(500, 400));
+
+    expect(result.current.zoom).toBe(framed.zoom);
+    expect(result.current.cameraCenter).toEqual(framed.center);
+  });
+
+  it('still auto-fits a resize while the user has not taken over', () => {
+    // Both axes: the fit takes the smaller of the two, so growing one alone
+    // leaves the other binding and the zoom unchanged.
+    const { result } = render();
+    const before = result.current.zoom;
+    act(() => resizeContainerTo(1600, 800));
+    expect(result.current.zoom).toBeGreaterThan(before);
+  });
+
+  it('re-frames when the bin itself changes', () => {
+    // A different bin is a different subject; its old framing means nothing.
+    const { result, rerender } = render(100, 50);
+    act(() => result.current.setCameraCenter({ x: 12, y: 34 }));
+
+    rerender({ w: 200, d: 80 });
+
+    expect(result.current.cameraCenter).toEqual({ x: 100, y: 40 });
+  });
+
+  it('hands the view back to auto-fit on Fit to view', () => {
+    const { result } = render();
+    act(() => result.current.setCameraCenter({ x: 12, y: 34 }));
+    act(() => result.current.fitToView());
+    expect(result.current.cameraCenter).toEqual({ x: 50, y: 25 });
+
+    const fitted = result.current.zoom;
+    act(() => resizeContainerTo(1600, 800));
+    expect(result.current.zoom).toBeGreaterThan(fitted);
+  });
+
+  it('treats the zoom buttons as taking over too', () => {
+    const { result } = render();
+    act(() => result.current.zoomIn());
+    const zoomed = result.current.zoom;
+    act(() => resizeContainerTo(1600, 800));
+    expect(result.current.zoom).toBe(zoomed);
+  });
+});

--- a/src/features/bin-designer/components/CutoutWorkspace/useCutoutWorkspaceCamera.ts
+++ b/src/features/bin-designer/components/CutoutWorkspace/useCutoutWorkspaceCamera.ts
@@ -15,6 +15,39 @@ import {
   FIT_PADDING,
 } from '../panel/CutoutsSection/renderer/constants';
 
+/**
+ * One wheel notch on a traditional mouse, in CSS pixels. Browsers report ~100
+ * or 120 for a notch, so a mouse still moves one {@link ZOOM_STEP} per click.
+ */
+const WHEEL_PIXELS_PER_STEP = 120;
+
+/** A single event may not move more than this many steps, whatever it claims. */
+const MAX_WHEEL_STEPS = 2;
+
+/** Fallback line height (px) for `deltaMode: 'line'` — Firefox's default. */
+const WHEEL_LINE_HEIGHT_PX = 16;
+
+/**
+ * Zoom multiplier for one wheel event, PROPORTIONAL to how far the wheel
+ * actually moved.
+ *
+ * A fixed step per event is right for a mouse, whose notches are discrete, and
+ * badly wrong for a trackpad, which fires a stream of small deltas: a single
+ * two-finger flick became a dozen 1.25x multiplications and shot past whatever
+ * the user was aiming at. Normalising by {@link WHEEL_PIXELS_PER_STEP} leaves
+ * the mouse exactly where it was and makes the trackpad continuous.
+ *
+ * `deltaMode` has to be honoured or the normalisation inverts the problem:
+ * Firefox reports LINE units (~3 per notch), which as raw pixels would be
+ * almost no zoom at all.
+ */
+function wheelZoomFactor(e: React.WheelEvent<HTMLDivElement>, canvasHeight: number): number {
+  const perUnitPx = e.deltaMode === 1 ? WHEEL_LINE_HEIGHT_PX : e.deltaMode === 2 ? canvasHeight : 1;
+  const steps = (e.deltaY * perUnitPx) / WHEEL_PIXELS_PER_STEP;
+  const clamped = Math.max(-MAX_WHEEL_STEPS, Math.min(MAX_WHEEL_STEPS, steps));
+  return Math.pow(ZOOM_STEP, -clamped);
+}
+
 export interface CutoutWorkspaceCamera {
   canvasContainerRef: React.RefObject<HTMLDivElement | null>;
   containerSize: { width: number; height: number };
@@ -68,16 +101,43 @@ export function useCutoutWorkspaceCamera(
   }, [canvasWidth, canvasHeight, binWidth, binDepth]);
 
   const [zoom, setZoom] = useState(defaultZoom);
-  const [cameraCenter, setCameraCenter] = useState({ x: binWidth / 2, y: binDepth / 2 });
+  const [cameraCenter, setCameraCenterState] = useState({ x: binWidth / 2, y: binDepth / 2 });
 
-  // Re-fit camera when bin dimensions or container size change
-  /* eslint-disable react-hooks/set-state-in-effect -- syncing camera to external bin dimension changes from designer store */
+  /**
+   * Set once the user has framed the view themselves, and the reason the
+   * auto-fit below is conditional.
+   *
+   * `defaultZoom` is derived from the CONTAINER, so it moves whenever the
+   * container does — dragging the split divider beside the canvas, collapsing
+   * the inspector dock, resizing the window. Re-fitting on every one of those
+   * threw away the zoom and pan the user had just set up, which is the
+   * "zooming repositions the view" loop: you can never keep a corner of a
+   * large bin on screen while you work on it.
+   */
+  const userFramedRef = useRef(false);
+
+  const setCameraCenter = useCallback<CutoutWorkspaceCamera['setCameraCenter']>((next) => {
+    userFramedRef.current = true;
+    setCameraCenterState(next);
+  }, []);
+
+  // A different bin is a different subject: its old framing means nothing, so
+  // the view is handed back to the auto-fit. Runs before the fit effect below
+  // in the same commit, so a bin change re-fits in one pass.
   useEffect(() => {
-    setZoom(defaultZoom);
-    setCameraCenter({ x: binWidth / 2, y: binDepth / 2 });
-  }, [defaultZoom, binWidth, binDepth]);
-  /* eslint-enable react-hooks/set-state-in-effect */
+    userFramedRef.current = false;
+  }, [binWidth, binDepth]);
 
+  // Auto-fit only while the user has not taken over.
+  useEffect(() => {
+    if (userFramedRef.current) return;
+    setZoom(defaultZoom);
+    setCameraCenterState({ x: binWidth / 2, y: binDepth / 2 });
+  }, [defaultZoom, binWidth, binDepth]);
+
+  // The explicit way back: hands the view to the auto-fit again, so a later
+  // container resize re-frames rather than preserving a framing the user has
+  // just discarded.
   const fitToView = useCallback(() => {
     const pad = 1 - 2 * FIT_PADDING;
     const newZoom = Math.min(
@@ -85,15 +145,18 @@ export function useCutoutWorkspaceCamera(
       (canvasHeight * pad) / binDepth,
       MAX_ZOOM
     );
+    userFramedRef.current = false;
     setZoom(newZoom);
-    setCameraCenter({ x: binWidth / 2, y: binDepth / 2 });
+    setCameraCenterState({ x: binWidth / 2, y: binDepth / 2 });
   }, [canvasWidth, canvasHeight, binWidth, binDepth]);
 
   const zoomIn = useCallback(() => {
+    userFramedRef.current = true;
     setZoom((z) => Math.min(MAX_ZOOM, z * ZOOM_STEP));
   }, []);
 
   const zoomOut = useCallback(() => {
+    userFramedRef.current = true;
     setZoom((z) => Math.max(MIN_ZOOM, z / ZOOM_STEP));
   }, []);
 
@@ -103,9 +166,10 @@ export function useCutoutWorkspaceCamera(
   const handleWheel = useCallback(
     (e: React.WheelEvent<HTMLDivElement>) => {
       e.preventDefault();
-      const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+      const factor = wheelZoomFactor(e, canvasHeight);
       const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom * factor));
       if (newZoom === zoom) return;
+      userFramedRef.current = true;
 
       // Cursor position in screen pixels relative to the container
       const rect = e.currentTarget.getBoundingClientRect();
@@ -117,7 +181,7 @@ export function useCutoutWorkspaceCamera(
       const worldY = cameraCenter.y - (cy - canvasHeight / 2) / zoom;
 
       // After zoom, same screen pixel should map to same world point
-      setCameraCenter({
+      setCameraCenterState({
         x: worldX - (cx - canvasWidth / 2) / newZoom,
         y: worldY + (cy - canvasHeight / 2) / newZoom,
       });

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Rozumím",
   "binDesigner.cutoutEditor.quickstart.precision": "Chytrá vodítka — přichytávání k mřížce, pravítka a další výřezy",
   "binDesigner.cutoutEditor.quickstart.repeat": "Vyberte 3 a více shodných výřezů a spojte je do jednoho opakování",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Navigace — kolečkem přiblížíte, tažením s mezerníkem nebo prostředním tlačítkem posunete, Ctrl+0 přizpůsobí",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Nabídka pravým kliknutím — kopírovat, seskupit, uzamknout, zarovnat a další",
   "binDesigner.cutoutEditor.quickstart.select": "Vybrat (V) — táhni výběrový obdélník, Shift+klik pro rozšíření",
   "binDesigner.cutoutEditor.quickstart.shapes": "Tvary (R · C · G · S · P) — obdélníky, kruhy, polygony, drážky nebo Bézierovy cesty",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Verstanden",
   "binDesigner.cutoutEditor.quickstart.precision": "Intelligente Hilfslinien — am Raster, an Linealen und an anderen Ausschnitten einrasten",
   "binDesigner.cutoutEditor.quickstart.repeat": "Wähle 3 oder mehr gleiche Ausschnitte, um daraus eine Anordnung zu machen",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Navigieren — Scrollen zoomt, Leertaste- oder Mittelklick-Ziehen verschiebt, Strg+0 passt ein",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Rechtsklick-Menü — Kopieren, Gruppieren, Sperren, Ausrichten und mehr",
   "binDesigner.cutoutEditor.quickstart.select": "Auswahl (V) — Auswahlrahmen ziehen, mit Umschalt+Klick erweitern",
   "binDesigner.cutoutEditor.quickstart.shapes": "Formen (R · C · G · S · P) — Rechtecke, Kreise, Polygone, Schlitze oder Bézierkurven",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2795,6 +2795,8 @@ const en: Record<string, string> = {
     'Smart guides — snap to grid, rulers, and other cutouts',
   'binDesigner.cutoutEditor.quickstart.repeat':
     'Select 3 or more matching cutouts to turn them into one repeat',
+  'binDesigner.cutoutEditor.quickstart.navigate':
+    'Navigate — scroll to zoom, Space-drag or middle-drag to pan, Ctrl+0 to fit',
   'binDesigner.cutoutEditor.quickstart.dismiss': 'Got it',
   'binDesigner.quickstart.title': 'Design a custom bin',
   'binDesigner.quickstart.livePreview':

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Entendido",
   "binDesigner.cutoutEditor.quickstart.precision": "Guías inteligentes — ajusta a la cuadrícula, reglas y otros recortes",
   "binDesigner.cutoutEditor.quickstart.repeat": "Selecciona 3 o más recortes iguales para convertirlos en una matriz",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Navegar — la rueda amplía, arrastra con Espacio o botón central para desplazar, Ctrl+0 encuadra",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Menú con clic derecho — copiar, agrupar, bloquear, alinear y más",
   "binDesigner.cutoutEditor.quickstart.select": "Seleccionar (V) — arrastra un marco o Mayús+clic para extender",
   "binDesigner.cutoutEditor.quickstart.shapes": "Formas (R · C · G · S · P) — rectángulos, círculos, polígonos, ranuras o trazados Bézier",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Compris",
   "binDesigner.cutoutEditor.quickstart.precision": "Repères intelligents — accrochage à la grille, aux règles et aux autres découpes",
   "binDesigner.cutoutEditor.quickstart.repeat": "Sélectionnez 3 découpes identiques ou plus pour en faire un réseau",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Naviguer — la molette zoome, glisser avec Espace ou le clic du milieu déplace, Ctrl+0 ajuste",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Menu clic droit — copier, grouper, verrouiller, aligner et plus",
   "binDesigner.cutoutEditor.quickstart.select": "Sélection (V) — glissez un cadre, Maj+clic pour étendre",
   "binDesigner.cutoutEditor.quickstart.shapes": "Formes (R · C · G · S · P) — rectangles, cercles, polygones, fentes ou courbes de Bézier",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Capito",
   "binDesigner.cutoutEditor.quickstart.precision": "Guide intelligenti: aggancio alla griglia, ai righelli e agli altri ritagli",
   "binDesigner.cutoutEditor.quickstart.repeat": "Seleziona 3 o più intagli identici per trasformarli in una serie",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Naviga — la rotella ingrandisce, trascina con Spazio o tasto centrale per spostare, Ctrl+0 adatta",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Menu col tasto destro: copia, raggruppa, blocca, allinea e altro",
   "binDesigner.cutoutEditor.quickstart.select": "Seleziona (V): trascina un rettangolo di selezione, Shift+clic per estendere",
   "binDesigner.cutoutEditor.quickstart.shapes": "Forme (R · C · G · S · P): rettangoli, cerchi, poligoni, asole o tracciati Bézier",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "了解",
   "binDesigner.cutoutEditor.quickstart.precision": "スマートガイド — グリッド、ルーラー、他の切り欠きにスナップ",
   "binDesigner.cutoutEditor.quickstart.repeat": "同じ切り欠きを 3 つ以上選ぶと 1 つの配列にまとめられます",
+  "binDesigner.cutoutEditor.quickstart.navigate": "表示操作 — スクロールで拡大縮小、スペースまたは中ボタンのドラッグで移動、Ctrl+0 で全体表示",
   "binDesigner.cutoutEditor.quickstart.rightClick": "右クリックメニュー — コピー、グループ化、ロック、整列など",
   "binDesigner.cutoutEditor.quickstart.select": "選択(V) — マーキー選択、Shift+クリックで追加",
   "binDesigner.cutoutEditor.quickstart.shapes": "図形 (R · C · G · S · P) — 長方形、円、多角形、スロット、ベジェパス",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "확인",
   "binDesigner.cutoutEditor.quickstart.precision": "스마트 가이드 — 그리드, 눈금자, 다른 컷아웃에 스냅",
   "binDesigner.cutoutEditor.quickstart.repeat": "같은 컷아웃을 3개 이상 선택하면 하나의 배열로 만들 수 있습니다",
+  "binDesigner.cutoutEditor.quickstart.navigate": "화면 이동 — 스크롤로 확대·축소, 스페이스 또는 가운데 버튼 드래그로 이동, Ctrl+0으로 맞춤",
   "binDesigner.cutoutEditor.quickstart.rightClick": "우클릭 메뉴 — 복사, 그룹, 잠금, 정렬 등",
   "binDesigner.cutoutEditor.quickstart.select": "선택 (V) — 마키로 드래그, Shift+클릭으로 확장",
   "binDesigner.cutoutEditor.quickstart.shapes": "도형 (R · C · G · S · P) — 직사각형, 원, 다각형, 슬롯, 베지어 경로",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Forstått",
   "binDesigner.cutoutEditor.quickstart.precision": "Smarte hjelpelinjer — fest til rutenett, linjaler og andre utsnitt",
   "binDesigner.cutoutEditor.quickstart.repeat": "Velg 3 eller flere like utskjæringer for å gjøre dem til én matrise",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Naviger — rull for å zoome, dra med mellomrom eller midtknapp for å panorere, Ctrl+0 tilpasser",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Høyreklikkmeny — kopier, grupper, lås, juster med mer",
   "binDesigner.cutoutEditor.quickstart.select": "Velg (V) — dra et utvalg, Skift+klikk for å utvide",
   "binDesigner.cutoutEditor.quickstart.shapes": "Former (R · C · G · S · P) — rektangler, sirkler, polygoner, spor eller Bézier-baner",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Begrepen",
   "binDesigner.cutoutEditor.quickstart.precision": "Slimme hulplijnen — snap naar raster, linialen en andere uitsnijdingen",
   "binDesigner.cutoutEditor.quickstart.repeat": "Selecteer 3 of meer gelijke uitsparingen om er één reeks van te maken",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Navigeren — scrollen zoomt, slepen met spatie of middelste knop verschuift, Ctrl+0 past in",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Rechtsklikmenu — kopiëren, groeperen, vergrendelen, uitlijnen en meer",
   "binDesigner.cutoutEditor.quickstart.select": "Selecteren (V) — sleep een kader, Shift+klik om uit te breiden",
   "binDesigner.cutoutEditor.quickstart.shapes": "Vormen (R · C · G · S · P) — rechthoeken, cirkels, veelhoeken, sleuven of Bézier-paden",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Rozumiem",
   "binDesigner.cutoutEditor.quickstart.precision": "Inteligentne prowadnice — przyciąganie do siatki, linijek i innych wycięć",
   "binDesigner.cutoutEditor.quickstart.repeat": "Zaznacz 3 lub więcej identycznych wycięć, aby utworzyć z nich jeden szyk",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Nawigacja — kółko przybliża, przeciąganie ze spacją lub środkowym przyciskiem przesuwa, Ctrl+0 dopasowuje",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Menu prawym przyciskiem — kopiuj, grupuj, blokuj, wyrównuj i więcej",
   "binDesigner.cutoutEditor.quickstart.select": "Zaznaczanie (V) — przeciągnij zaznaczenie, Shift+kliknięcie, aby rozszerzyć",
   "binDesigner.cutoutEditor.quickstart.shapes": "Kształty (R · C · G · S · P) — prostokąty, koła, wielokąty, szczeliny lub ścieżki Béziera",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Entendi",
   "binDesigner.cutoutEditor.quickstart.precision": "Guias inteligentes — encaixe na grade, réguas e outros recortes",
   "binDesigner.cutoutEditor.quickstart.repeat": "Selecione 3 ou mais recortes iguais para transformá-los em uma matriz",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Navegar — a rolagem amplia, arraste com Espaço ou botão do meio para deslocar, Ctrl+0 ajusta",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Menu com clique direito — copiar, agrupar, bloquear, alinhar e mais",
   "binDesigner.cutoutEditor.quickstart.select": "Seleção (V) — arraste um quadro, Shift+clique para estender",
   "binDesigner.cutoutEditor.quickstart.shapes": "Formas (R · C · G · S · P) — retângulos, círculos, polígonos, ranhuras ou caminhos Bézier",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Förstått",
   "binDesigner.cutoutEditor.quickstart.precision": "Smarta hjälplinjer — fäst mot rutnät, linjaler och andra urtag",
   "binDesigner.cutoutEditor.quickstart.repeat": "Markera 3 eller fler likadana urtag för att göra dem till en matris",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Navigera — rulla för att zooma, dra med mellanslag eller mittenknapp för att panorera, Ctrl+0 anpassar",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Högerklicksmeny — kopiera, gruppera, lås, justera med mera",
   "binDesigner.cutoutEditor.quickstart.select": "Markera (V) — dra ett markeringsfönster, Shift+klick för att utöka",
   "binDesigner.cutoutEditor.quickstart.shapes": "Former (R · C · G · S · P) — rektanglar, cirklar, polygoner, skåror eller Bézier-banor",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "Зрозуміло",
   "binDesigner.cutoutEditor.quickstart.precision": "Розумні напрямні — прив’язка до сітки, лінійок та інших вирізів",
   "binDesigner.cutoutEditor.quickstart.repeat": "Виберіть 3 або більше однакових вирізів, щоб об'єднати їх у масив",
+  "binDesigner.cutoutEditor.quickstart.navigate": "Навігація — прокручування масштабує, перетягування з пробілом або середньою кнопкою зсуває, Ctrl+0 вписує",
   "binDesigner.cutoutEditor.quickstart.rightClick": "Контекстне меню — копіювати, групувати, заблокувати, вирівняти та інше",
   "binDesigner.cutoutEditor.quickstart.select": "Виділення (V) — перетягніть рамку або Shift+клік, щоб розширити",
   "binDesigner.cutoutEditor.quickstart.shapes": "Фігури (R · C · G · S · P) — прямокутники, кола, багатокутники, прорізи або криві Безьє",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -566,6 +566,7 @@
   "binDesigner.cutoutEditor.quickstart.dismiss": "知道了",
   "binDesigner.cutoutEditor.quickstart.precision": "智能参考线 — 对齐到网格、标尺和其他挖槽",
   "binDesigner.cutoutEditor.quickstart.repeat": "选择 3 个或更多相同的挖槽，即可合并为一个阵列",
+  "binDesigner.cutoutEditor.quickstart.navigate": "视图操作 — 滚动缩放，按住空格或中键拖动平移，Ctrl+0 适应窗口",
   "binDesigner.cutoutEditor.quickstart.rightClick": "右键菜单 — 复制、编组、锁定、对齐等",
   "binDesigner.cutoutEditor.quickstart.select": "选择（V）— 拖出选框，Shift+单击可扩展",
   "binDesigner.cutoutEditor.quickstart.shapes": "形状（R · C · G · S · P）— 长方形、圆形、多边形、长圆槽或贝塞尔路径",


### PR DESCRIPTION
Closes #3639

Three separate things made framing a section of a large bin a fight.

## 1. Wheel zoom ignored how far the wheel moved

`handleWheel` applied a fixed `ZOOM_STEP` (1.25×) per **event**. That is right for a mouse, whose notches are discrete — and badly wrong for a trackpad, which fires a stream of small deltas. A single two-finger flick was a dozen multiplications, which is the report's "the zoom can feel too aggressive and sometimes goes well past the level I was trying to reach."

The factor is now proportional to the delta, normalised against one mouse notch (120px) so a mouse behaves exactly as before. `deltaMode` is honoured — Firefox reports LINE units (~3 per notch), which as raw pixels would invert the problem into almost no zoom at all — and one event is capped at two steps.

Measured in the running app:

| input | before | after |
|---|---|---|
| ten 8px trackpad deltas | 100% → ~931% | 100% → **116%** |
| one 120px mouse notch | ×1.25 | **×1.25** (unchanged) |

## 2. Any container resize threw the framing away

The auto-fit effect ran off `defaultZoom`, which is derived from the **container** — so it fired whenever the container moved: dragging the split divider that sits directly beside the canvas, collapsing the inspector dock, resizing the window. Each one reset both zoom and pan. That is the loop described as "zooming also seems to reposition the view... a cycle of zooming in and out just to get the area I want back into the center."

The auto-fit now stands down once the user has framed the view themselves (wheel, zoom buttons, or pan). A **bin** change still re-frames, since a different bin is a different subject and its old framing means nothing, and **Fit to view** hands control back explicitly so a later resize re-frames again.

## 3. Pan and fit already existed, invisibly

Space-drag, middle-drag and Ctrl+0 were all implemented — with nothing anywhere saying so, which is why the issue asks for them as new features. The view controls are the one group a user cannot discover by clicking around the canvas, so they are now a row in the quickstart overlay.

## Note on the zoom readout

The percentage is *of the fit*, and the fit moves with the container — so after a resize the same view legitimately reads as a different percentage. The drawing itself does not move, which is the part that was broken; the hook's unit test pins `zoom` as byte-identical across a resize.

## Verification

Ten unit tests on the hook: the mouse notch is still exactly one step, a trackpad nudge is a proportional fraction, LINE deltas are read as lines, one event is capped, a resize preserves a user-set zoom *and* pan, a resize still auto-fits while the user has not taken over, a bin change re-frames, and Fit to view hands control back. Plus the live measurements above.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

