### PR TITLE
feat(cutout-editor): fill the bin with a repeat in one click

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.test.tsx
@@ -133,3 +133,44 @@ describe('CutoutArrayControls — overlap', () => {
     expect(screen.queryByText(WARNING)).not.toBeInTheDocument();
   });
 });
+
+describe('CutoutArrayControls — fill bin', () => {
+  const FILL = 'binDesigner.cutouts.repeat.fillBin';
+
+  it('sets rows and columns to what the bin holds at the current pitch', () => {
+    const onUpdate = vi.fn();
+    // 10mm master at 0,0 in a 300mm bin at a 12mm pitch: 1 + floor(290/12) = 25
+    // per axis. 25 x 25 is over the 400-instance cap, which columns win — so
+    // rows take the 16 that are left and every row is complete.
+    renderControls(makeCutout({ array: { ...arrayCfg, cols: 3, rows: 2 } }), { onUpdate });
+
+    fireEvent.click(screen.getByText(FILL));
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      array: expect.objectContaining({ cols: 25, rows: 16, pitchX: 12, pitchY: 12 }),
+    });
+  });
+
+  it('leaves the rest of the config alone, so the result stays editable', () => {
+    const onUpdate = vi.fn();
+    renderControls(makeCutout({ array: { ...arrayCfg, mode: 'staggered' } }), { onUpdate });
+
+    fireEvent.click(screen.getByText(FILL));
+
+    const patched = onUpdate.mock.calls[0][0].array;
+    expect(patched.mode).toBe('staggered');
+    expect(patched.pitchX).toBe(arrayCfg.pitchX);
+    expect(patched.pitchY).toBe(arrayCfg.pitchY);
+  });
+
+  it('is inert once the bin is already full', () => {
+    const onUpdate = vi.fn();
+    renderControls(makeCutout({ array: { ...arrayCfg, cols: 25, rows: 16 } }), { onUpdate });
+    expect(screen.getByText(FILL).closest('button')).toBeDisabled();
+  });
+
+  it('is not offered for a radial ring, which has no rows or columns', () => {
+    renderControls(makeCutout({ array: { ...arrayCfg, mode: 'radial' } }));
+    expect(screen.queryByText(FILL)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.tsx
@@ -13,6 +13,7 @@ import {
   arrayInstanceCount,
   arrayFieldBounds,
   arrayInstancesOverlap,
+  fillBinCounts,
   ARRAY_MIN_RADIUS,
 } from '@/shared/utils/cutoutArray';
 import { useTranslation } from '@/i18n';
@@ -139,6 +140,9 @@ export function CutoutArrayControls({
   const count = arrayInstanceCount(array);
   const bounds = arrayFieldBounds(cutout, binWidth, binDepth, array);
   const overlaps = arrayInstancesOverlap(cutout, array);
+  const fill = fillBinCounts(cutout, binWidth, binDepth, array);
+  const fillIsNoOp = fill.cols === array.cols && fill.rows === array.rows;
+  const handleFillBin = () => setArray(fill);
 
   return (
     <div className="space-y-1.5">
@@ -275,6 +279,20 @@ export function CutoutArrayControls({
       </div>
 
       <div className="flex gap-1.5">
+        {/* Writes into cols/rows rather than becoming a mode of its own, so the
+            result stays editable — backing off a row does not undo the fill. */}
+        {array.mode !== 'radial' && (
+          <Button
+            type="button"
+            variant="ghost"
+            className="flex-1 rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-xs text-content-secondary hover:bg-surface-hover transition-colors disabled:opacity-50"
+            onClick={handleFillBin}
+            disabled={disabled || fillIsNoOp}
+            title={t('binDesigner.cutouts.repeat.fillBinHint')}
+          >
+            {t('binDesigner.cutouts.repeat.fillBin')}
+          </Button>
+        )}
         <Button
           type="button"
           variant="ghost"

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Poloměr",
   "binDesigner.cutouts.repeat.remove": "Odebrat opakování",
   "binDesigner.cutouts.repeat.overlapWarning": "Opakování se překrývají. Jejich řezy splynou v jeden otvor.",
+  "binDesigner.cutouts.repeat.fillBin": "Vyplnit bin",
+  "binDesigner.cutouts.repeat.fillBinHint": "Nastaví řádky a sloupce tak, aby vyplnily bin při aktuální rozteči",
   "binDesigner.cutouts.repeat.rotateToCenter": "Otočit ke středu",
   "binDesigner.cutouts.repeat.rows": "Řady",
   "binDesigner.cutouts.repeat.startAngle": "Počáteční úhel",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Radius",
   "binDesigner.cutouts.repeat.remove": "Anordnung entfernen",
   "binDesigner.cutouts.repeat.overlapWarning": "Die Wiederholungen überlappen sich. Ihre Schnitte verschmelzen zu einer Öffnung.",
+  "binDesigner.cutouts.repeat.fillBin": "Fach füllen",
+  "binDesigner.cutouts.repeat.fillBinHint": "Setzt Zeilen und Spalten so, dass das Fach beim aktuellen Raster gefüllt wird",
   "binDesigner.cutouts.repeat.rotateToCenter": "Zur Mitte drehen",
   "binDesigner.cutouts.repeat.rows": "Reihen",
   "binDesigner.cutouts.repeat.startAngle": "Startwinkel",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2520,6 +2520,9 @@ const en: Record<string, string> = {
   'binDesigner.cutouts.repeat.remove': 'Remove repeat',
   'binDesigner.cutouts.repeat.overlapWarning':
     'Repeats overlap. Their cuts will merge into one opening.',
+  'binDesigner.cutouts.repeat.fillBin': 'Fill bin',
+  'binDesigner.cutouts.repeat.fillBinHint':
+    'Sets rows and columns to fill the bin at the current pitch',
   'binDesigner.cutouts.repeat.presetLabel': 'Start with',
   'binDesigner.cutouts.repeat.presetRing': 'Ring of {count}',
   'binDesigner.cutouts.repeat.presetNoFit': 'Not enough room from this position',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Radio",
   "binDesigner.cutouts.repeat.remove": "Quitar matriz",
   "binDesigner.cutouts.repeat.overlapWarning": "Las repeticiones se solapan. Sus cortes se fusionarán en una sola abertura.",
+  "binDesigner.cutouts.repeat.fillBin": "Llenar bandeja",
+  "binDesigner.cutouts.repeat.fillBinHint": "Ajusta filas y columnas para llenar la bandeja con el paso actual",
   "binDesigner.cutouts.repeat.rotateToCenter": "Girar al centro",
   "binDesigner.cutouts.repeat.rows": "Filas",
   "binDesigner.cutouts.repeat.startAngle": "Ángulo inicial",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Rayon",
   "binDesigner.cutouts.repeat.remove": "Supprimer le réseau",
   "binDesigner.cutouts.repeat.overlapWarning": "Les répétitions se chevauchent. Leurs découpes fusionneront en une seule ouverture.",
+  "binDesigner.cutouts.repeat.fillBin": "Remplir le bac",
+  "binDesigner.cutouts.repeat.fillBinHint": "Règle lignes et colonnes pour remplir le bac au pas actuel",
   "binDesigner.cutouts.repeat.rotateToCenter": "Orienter vers le centre",
   "binDesigner.cutouts.repeat.rows": "Lignes",
   "binDesigner.cutouts.repeat.startAngle": "Angle de départ",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Raggio",
   "binDesigner.cutouts.repeat.remove": "Rimuovi serie",
   "binDesigner.cutouts.repeat.overlapWarning": "Le ripetizioni si sovrappongono. I loro tagli si fonderanno in un’unica apertura.",
+  "binDesigner.cutouts.repeat.fillBin": "Riempi il bin",
+  "binDesigner.cutouts.repeat.fillBinHint": "Imposta righe e colonne per riempire il bin con il passo attuale",
   "binDesigner.cutouts.repeat.rotateToCenter": "Ruota verso il centro",
   "binDesigner.cutouts.repeat.rows": "Righe",
   "binDesigner.cutouts.repeat.startAngle": "Angolo iniziale",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "半径",
   "binDesigner.cutouts.repeat.remove": "配列を削除",
   "binDesigner.cutouts.repeat.overlapWarning": "繰り返しが重なっています。切り抜きは1つの開口部として結合されます。",
+  "binDesigner.cutouts.repeat.fillBin": "ビンを埋める",
+  "binDesigner.cutouts.repeat.fillBinHint": "現在のピッチで行数と列数をビンいっぱいに設定します",
   "binDesigner.cutouts.repeat.rotateToCenter": "中心に向ける",
   "binDesigner.cutouts.repeat.rows": "行",
   "binDesigner.cutouts.repeat.startAngle": "開始角度",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "반지름",
   "binDesigner.cutouts.repeat.remove": "배열 제거",
   "binDesigner.cutouts.repeat.overlapWarning": "반복 도형이 겹칩니다. 잘라낸 부분이 하나의 구멍으로 합쳐집니다.",
+  "binDesigner.cutouts.repeat.fillBin": "수납통 채우기",
+  "binDesigner.cutouts.repeat.fillBinHint": "현재 간격으로 행과 열을 수납통에 가득 차도록 설정합니다",
   "binDesigner.cutouts.repeat.rotateToCenter": "중심으로 회전",
   "binDesigner.cutouts.repeat.rows": "행",
   "binDesigner.cutouts.repeat.startAngle": "시작 각도",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Radius",
   "binDesigner.cutouts.repeat.remove": "Fjern matrise",
   "binDesigner.cutouts.repeat.overlapWarning": "Gjentakelsene overlapper. Utskjæringene smelter sammen til én åpning.",
+  "binDesigner.cutouts.repeat.fillBin": "Fyll boksen",
+  "binDesigner.cutouts.repeat.fillBinHint": "Setter rader og kolonner slik at boksen fylles med gjeldende avstand",
   "binDesigner.cutouts.repeat.rotateToCenter": "Roter mot sentrum",
   "binDesigner.cutouts.repeat.rows": "Rader",
   "binDesigner.cutouts.repeat.startAngle": "Startvinkel",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Straal",
   "binDesigner.cutouts.repeat.remove": "Reeks verwijderen",
   "binDesigner.cutouts.repeat.overlapWarning": "De herhalingen overlappen. Hun uitsparingen vloeien samen tot één opening.",
+  "binDesigner.cutouts.repeat.fillBin": "Bak vullen",
+  "binDesigner.cutouts.repeat.fillBinHint": "Stelt rijen en kolommen in om de bak te vullen met de huidige steek",
   "binDesigner.cutouts.repeat.rotateToCenter": "Naar midden draaien",
   "binDesigner.cutouts.repeat.rows": "Rijen",
   "binDesigner.cutouts.repeat.startAngle": "Starthoek",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Promień",
   "binDesigner.cutouts.repeat.remove": "Usuń szyk",
   "binDesigner.cutouts.repeat.overlapWarning": "Powtórzenia nachodzą na siebie. Ich wycięcia połączą się w jeden otwór.",
+  "binDesigner.cutouts.repeat.fillBin": "Wypełnij bin",
+  "binDesigner.cutouts.repeat.fillBinHint": "Ustawia wiersze i kolumny tak, aby wypełnić bin przy bieżącym skoku",
   "binDesigner.cutouts.repeat.rotateToCenter": "Obróć do środka",
   "binDesigner.cutouts.repeat.rows": "Rzędy",
   "binDesigner.cutouts.repeat.startAngle": "Kąt początkowy",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Raio",
   "binDesigner.cutouts.repeat.remove": "Remover matriz",
   "binDesigner.cutouts.repeat.overlapWarning": "As repetições se sobrepõem. Seus cortes vão se fundir em uma única abertura.",
+  "binDesigner.cutouts.repeat.fillBin": "Preencher compartimento",
+  "binDesigner.cutouts.repeat.fillBinHint": "Define linhas e colunas para preencher o compartimento com o passo atual",
   "binDesigner.cutouts.repeat.rotateToCenter": "Girar para o centro",
   "binDesigner.cutouts.repeat.rows": "Linhas",
   "binDesigner.cutouts.repeat.startAngle": "Ângulo inicial",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Radie",
   "binDesigner.cutouts.repeat.remove": "Ta bort matris",
   "binDesigner.cutouts.repeat.overlapWarning": "Upprepningarna överlappar. Deras urtag smälter samman till en öppning.",
+  "binDesigner.cutouts.repeat.fillBin": "Fyll facket",
+  "binDesigner.cutouts.repeat.fillBinHint": "Ställer in rader och kolumner så att facket fylls med nuvarande delning",
   "binDesigner.cutouts.repeat.rotateToCenter": "Rotera mot mitten",
   "binDesigner.cutouts.repeat.rows": "Rader",
   "binDesigner.cutouts.repeat.startAngle": "Startvinkel",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "Радіус",
   "binDesigner.cutouts.repeat.remove": "Вилучити масив",
   "binDesigner.cutouts.repeat.overlapWarning": "Повтори перекриваються. Їхні вирізи зіллються в один отвір.",
+  "binDesigner.cutouts.repeat.fillBin": "Заповнити бін",
+  "binDesigner.cutouts.repeat.fillBinHint": "Встановлює рядки та стовпці так, щоб заповнити бін із поточним кроком",
   "binDesigner.cutouts.repeat.rotateToCenter": "Повертати до центру",
   "binDesigner.cutouts.repeat.rows": "Рядки",
   "binDesigner.cutouts.repeat.startAngle": "Початковий кут",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -724,6 +724,8 @@
   "binDesigner.cutouts.repeat.radius": "半径",
   "binDesigner.cutouts.repeat.remove": "移除阵列",
   "binDesigner.cutouts.repeat.overlapWarning": "重复图形重叠，切口将合并为一个开口。",
+  "binDesigner.cutouts.repeat.fillBin": "填满收纳盒",
+  "binDesigner.cutouts.repeat.fillBinHint": "按当前间距设置行数和列数以填满收纳盒",
   "binDesigner.cutouts.repeat.rotateToCenter": "旋转朝向中心",
   "binDesigner.cutouts.repeat.rows": "行",
   "binDesigner.cutouts.repeat.startAngle": "起始角度",

--- a/src/shared/utils/cutoutArray.test.ts
+++ b/src/shared/utils/cutoutArray.test.ts
@@ -5,6 +5,7 @@ import {
   defaultArrayConfig,
   arrayFieldBounds,
   arrayInstancesOverlap,
+  fillBinCounts,
   expandCutoutArray,
   type ArrayInstance,
 } from './cutoutArray';
@@ -350,5 +351,84 @@ describe('arrayInstancesOverlap', () => {
 
   it('never reports overlap for a radial ring', () => {
     expect(arrayInstancesOverlap(master(), { ...base, mode: 'radial', radius: 1 })).toBe(false);
+  });
+});
+
+describe('fillBinCounts', () => {
+  const cut = (overrides: Partial<Cutout> = {}): Cutout => ({
+    id: 'm',
+    shape: 'circle',
+    x: 0,
+    y: 0,
+    width: 10,
+    depth: 10,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: '',
+    groupId: null,
+    ...overrides,
+  });
+  const master = (overrides: Partial<Cutout> = {}) => cut({ width: 10, depth: 10, ...overrides });
+
+  it('fills to the far edge at the current pitch', () => {
+    // Master 10mm at x=0 in a 100mm bin, 20mm pitch: 1 + floor(90/20) = 5.
+    expect(fillBinCounts(master(), 100, 100, cfg({ pitchX: 20, pitchY: 20 }))).toEqual({
+      cols: 5,
+      rows: 5,
+    });
+  });
+
+  it("treats the master's position as the leading margin", () => {
+    // At x=20 there is 70mm of room left, so one fewer column fits. The gap
+    // before the master is the margin the user set by placing it.
+    expect(fillBinCounts(master({ x: 20 }), 100, 100, cfg({ pitchX: 20, pitchY: 20 }))).toEqual({
+      cols: 4,
+      rows: 5,
+    });
+  });
+
+  it('counts columns against the rows the fill will produce, not the current one', () => {
+    // A staggered array only pays the half-pitch X offset once it has a second
+    // row. Counting columns against the single row it starts on fits one too
+    // many: at a 21mm pitch the 5th instance of an odd row would reach 104.5mm
+    // in a 100mm bin.
+    const staggered = cfg({ mode: 'staggered', cols: 1, rows: 1, pitchX: 21, pitchY: 20 });
+    const filled = fillBinCounts(master(), 100, 100, staggered);
+    expect(filled.rows).toBe(5);
+    expect(filled.cols).toBe(4);
+
+    // And what it produced actually fits: re-asking the bounds agrees.
+    const bounds = arrayFieldBounds(master(), 100, 100, { ...staggered, ...filled });
+    expect(filled.cols).toBeLessThanOrEqual(bounds.maxCols);
+    expect(filled.rows).toBeLessThanOrEqual(bounds.maxRows);
+  });
+
+  it('never exceeds the instance cap, and spends it on whole rows', () => {
+    const dense = fillBinCounts(
+      cut({ width: 1, depth: 1 }),
+      10_000,
+      10_000,
+      cfg({ pitchX: 2, pitchY: 2 })
+    );
+    expect(dense.cols * dense.rows).toBeLessThanOrEqual(400);
+    expect(dense.cols).toBeLessThanOrEqual(50);
+    expect(dense.rows).toBeLessThanOrEqual(50);
+  });
+
+  it('returns a single instance when nothing else fits', () => {
+    expect(
+      fillBinCounts(cut({ width: 40, depth: 40 }), 50, 50, cfg({ pitchX: 45, pitchY: 45 }))
+    ).toEqual({ cols: 1, rows: 1 });
+  });
+
+  it('agrees with the field bounds it will be clamped by', () => {
+    // Whatever the fill produces has to survive the editor's own clamping, or
+    // pressing the button would visibly undo part of itself.
+    const config = cfg({ pitchX: 17, pitchY: 13 });
+    const filled = fillBinCounts(master({ x: 3, y: 7 }), 137, 111, config);
+    const bounds = arrayFieldBounds(master({ x: 3, y: 7 }), 137, 111, { ...config, ...filled });
+    expect(filled.cols).toBeLessThanOrEqual(bounds.maxCols);
+    expect(filled.rows).toBeLessThanOrEqual(bounds.maxRows);
   });
 });

--- a/src/shared/utils/cutoutArray.ts
+++ b/src/shared/utils/cutoutArray.ts
@@ -136,6 +136,32 @@ export function expandCutoutArray(cutout: Cutout): Cutout[] {
   });
 }
 
+/**
+ * How many instances physically fit on each axis at the current pitch, master
+ * included and BEFORE the instance cap.
+ *
+ * The one statement of the "how many fit" arithmetic, so the field bounds and
+ * the fill action cannot disagree about where the bin ends. The grid grows in
+ * +X/+Y from the master, so the room to grow is measured from the master's far
+ * edge — the master's own position IS the leading margin.
+ */
+function spatialCounts(
+  cutout: Pick<Cutout, 'x' | 'y' | 'width' | 'depth'>,
+  binWidth: number,
+  binDepth: number,
+  config: CutoutArrayConfig
+): { readonly cols: number; readonly rows: number } {
+  const availX = Math.max(0, binWidth - cutout.x - cutout.width);
+  const availY = Math.max(0, binDepth - cutout.y - cutout.depth);
+  const rows = clampCount(config.rows);
+  // The half-pitch X shift only exists once there's an odd row to shift, so it
+  // only eats into the width when staggered AND rows > 1.
+  const stagger = config.mode === 'staggered' && rows > 1 ? config.pitchX / 2 : 0;
+  const stepsX = config.pitchX > 0 ? Math.floor((availX - stagger) / config.pitchX) : 0;
+  const stepsY = config.pitchY > 0 ? Math.floor(availY / config.pitchY) : 0;
+  return { cols: 1 + Math.max(0, stepsX), rows: 1 + Math.max(0, stepsY) };
+}
+
 /** Per-field bounds that keep an array within the bin's physical footprint. */
 export interface ArrayFieldBounds {
   readonly maxCols: number;
@@ -208,21 +234,16 @@ export function arrayFieldBounds(
   const availY = Math.max(0, binDepth - cutout.y - d);
   const cols = clampCount(config.cols);
   const rows = clampCount(config.rows);
-  // The half-pitch X shift only exists once there's an odd row to shift, so it
-  // only widens the footprint when staggered AND rows > 1.
-  const stagger = config.mode === 'staggered' && rows > 1 ? config.pitchX / 2 : 0;
   const colExtraSpan = config.mode === 'staggered' && rows > 1 ? 0.5 : 0;
+  const spatial = spatialCounts(cutout, binWidth, binDepth, config);
 
-  // How many extra steps fit at the current pitch, plus the master itself.
-  const stepsX = config.pitchX > 0 ? Math.floor((availX - stagger) / config.pitchX) : 0;
-  const stepsY = config.pitchY > 0 ? Math.floor(availY / config.pitchY) : 0;
   const maxCols = clamp(
-    Math.min(1 + Math.max(0, stepsX), Math.floor(MAX_ARRAY_INSTANCES / rows)),
+    Math.min(spatial.cols, Math.floor(MAX_ARRAY_INSTANCES / rows)),
     1,
     MAX_ARRAY_COUNT
   );
   const maxRows = clamp(
-    Math.min(1 + Math.max(0, stepsY), Math.floor(MAX_ARRAY_INSTANCES / cols)),
+    Math.min(spatial.rows, Math.floor(MAX_ARRAY_INSTANCES / cols)),
     1,
     MAX_ARRAY_COUNT
   );
@@ -276,6 +297,38 @@ export function arrayFieldBounds(
     clearPitchX,
     clearPitchY,
   };
+}
+
+/**
+ * Counts that fill the bin with the array's current pitch and mode.
+ *
+ * Deliberately expressed as counts on the existing config rather than as a
+ * mode of its own: the result lands in the same `cols`/`rows` fields, so it
+ * stays editable afterwards and the user can back off a row without undoing
+ * the fill. Spacing is whatever the pitch fields already say, and the master's
+ * position is the leading margin, so both are set the way the user is used to
+ * setting them rather than through a second set of controls that mean the same
+ * thing.
+ *
+ * The instance cap is spent on columns first and rows take what is left, so a
+ * fill that cannot have everything degrades to complete rows rather than a
+ * ragged final one.
+ */
+export function fillBinCounts(
+  cutout: Pick<Cutout, 'x' | 'y' | 'width' | 'depth'>,
+  binWidth: number,
+  binDepth: number,
+  config: CutoutArrayConfig
+): { readonly cols: number; readonly rows: number } {
+  // Rows first, and columns measured against the rows the fill will actually
+  // produce: a staggered array only pays the half-pitch X offset once it has a
+  // second row, so counting columns against the CURRENT single row would fit
+  // one column too many and hang it off the bin's edge.
+  const rowsFit = spatialCounts(cutout, binWidth, binDepth, config).rows;
+  const colsFit = spatialCounts(cutout, binWidth, binDepth, { ...config, rows: rowsFit }).cols;
+  const cols = clamp(colsFit, 1, MAX_ARRAY_COUNT);
+  const rows = clamp(Math.min(rowsFit, Math.floor(MAX_ARRAY_INSTANCES / cols)), 1, MAX_ARRAY_COUNT);
+  return { cols, rows };
 }
 
 /** A sensible default config for a freshly-enabled array, sized off the master. */


### PR DESCRIPTION
Closes #3641

(Replaces #3654, which GitHub auto-closed when its stacked base branch was deleted on merge. Same commit, rebased onto `main`.)

## Problem

Filling a bin meant nudging counts and pitch until things stopped fitting, then backing off one.

## Change

**Fill bin** writes into the existing `cols`/`rows` rather than becoming a mode of its own, so the result stays editable — backing off a row does not undo the fill, which is what the issue asked for.

Spacing is whatever the **pitch** fields already say and the master's position is the **leading margin**, so both are set the way the user already sets them rather than through a second set of controls meaning the same thing. The button disables itself once the bin is full, and is not offered for a radial ring, which has no rows or columns to fill.

## The parts that are easy to get wrong

The "how many fit" arithmetic moves into one `spatialCounts`, shared with `arrayFieldBounds`, so the fill cannot disagree with the bounds that will clamp it — a fill that visibly undid part of itself would be worse than no button.

**Rows are counted first, and columns against the rows the fill will actually produce.** A staggered array only pays its half-pitch X offset once it has a second row, so counting columns against the single row it starts on fits one column too many and hangs it off the bin's edge. At a 21mm pitch in a 100mm bin that is an instance reaching 104.5mm; the test for it fails if the ordering is undone.

The instance cap is spent on columns first, so a fill that cannot have everything degrades to complete rows rather than a ragged final one.

## Verification

Unit tests on `fillBinCounts` (far-edge fill, master-as-margin, the stagger ordering, the instance cap, the nothing-fits case, and agreement with `arrayFieldBounds`) and on the button (patch contents, config preserved, disabled when full, absent for radial).

In the running app on a 3×2 bin: a 2×2 staggered repeat of 10mm circles filled to 7×8 = 56 instances reaching both far edges, and the button disabled itself afterwards.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

