### PR TITLE
fix(split): cut a split bin's lip in the frame its body was built in

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-lip-overhang.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-lip-overhang.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+/**
+ * A split bin's stacking lip is built fresh in `splitBinBuilder` rather than
+ * coming out of the pipeline, so anything cut into it has to be positioned in
+ * the same interior frame the body was.
+ *
+ * An overhang moves that frame: it widens the interior and, when the two
+ * opposite sides differ, shifts its centre. Sizing the lip's cutters off the
+ * nominal footprint instead left a wall cutout passing through the body at one
+ * X and through the lip at another — a rim visibly offset from the wall under
+ * it. Invisible for a small overhang, because the cutter overshoots its own
+ * opening by more than that.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
+import { initBrepjs, getGenerateSplitPreview } from './__kernel-tests__/wasmInit';
+import type { SplitPreviewPiece } from './__kernel-tests__/wasmInit';
+import { boundingBox, isSolidThrough } from './__kernel-tests__/meshAssertions';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+const NO_CONNECTORS: SplitConnectorConfig = { ...DEFAULT_SPLIT_CONNECTOR_CONFIG, enabled: false };
+
+const WALL_BAND: readonly [number, number] = [14, 17];
+const LIP_BAND: readonly [number, number] = [21.6, 23];
+const SCAN_STEP = 0.25;
+
+/**
+ * Every X where the front wall changes between solid and open, walking left to
+ * right in the given Z band.
+ *
+ * Comparing edges rather than counting material is what makes this specific:
+ * the defect moved the opening without changing how much of it there was, so a
+ * volume or vertex count reads the same either way.
+ */
+function openingEdges(
+  piece: SplitPreviewPiece,
+  y: number,
+  band: readonly [number, number]
+): number[] {
+  // A split piece carries no triangleCount; the probes only read vertices and
+  // indices, so supply it rather than widen their signature.
+  const mesh = { ...piece, triangleCount: piece.indices.length / 3 };
+  const bb = boundingBox(mesh.vertices);
+  const edges: number[] = [];
+  let previous: boolean | null = null;
+  for (let x = bb.minX + 1; x < bb.maxX - 1; x += SCAN_STEP) {
+    const solid = isSolidThrough(mesh, x, y, band[0], band[1]);
+    if (previous !== null && solid !== previous) edges.push(x);
+    previous = solid;
+  }
+  return edges;
+}
+
+function splitWithOverhangLeft(leftMm: number): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: 6,
+    depth: 2,
+    height: 3,
+    overhang: { left: leftMm, right: 0, front: 0, back: 0, feet: false },
+    walls: {
+      ...DEFAULT_BIN_PARAMS.walls,
+      enabled: true,
+      front: {
+        enabled: true,
+        width: 40,
+        depth: 90,
+        alignment: 'center',
+        offset: 0,
+        widthMm: null,
+      },
+      back: { enabled: false, width: 0, depth: 0, alignment: 'center', offset: 0, widthMm: null },
+    },
+  };
+}
+
+describe('split bin: the lip follows the overhang the body was built with', () => {
+  it.each([0, 12])(
+    'cuts the lip and the wall at the same X with a %imm left overhang',
+    (leftMm) => {
+      const pieces = getGenerateSplitPreview()(
+        splitWithOverhangLeft(leftMm),
+        [0],
+        [],
+        NO_CONNECTORS
+      ).pieces;
+      expect(pieces).toHaveLength(2);
+
+      for (const piece of pieces) {
+        // Mid-thickness of the front wall, which the cutout passes through.
+        const y = boundingBox(piece.vertices).minY + DEFAULT_BIN_PARAMS.wallThickness / 2;
+        const wall = openingEdges(piece, y, WALL_BAND);
+        const lip = openingEdges(piece, y, LIP_BAND);
+
+        expect(lip, `piece ${piece.label}: edge count`).toHaveLength(wall.length);
+        expect(wall.length, `piece ${piece.label}: expected an opening to compare`).toBeGreaterThan(
+          0
+        );
+        for (let i = 0; i < wall.length; i++) {
+          // One scan step of slack: the two bands are sampled independently.
+          expect(
+            Math.abs(lip[i] - wall[i]),
+            `piece ${piece.label}: lip edge ${lip[i].toFixed(2)} vs wall edge ${wall[i].toFixed(2)}`
+          ).toBeLessThanOrEqual(SCAN_STEP);
+        }
+      }
+    },
+    120000
+  );
+});

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -254,6 +254,26 @@ function splitSolidIntoPieces(
   // a plain rectangular bin with no overhang; for a custom shape (L/U) or any
   // overhang it avoids a full-rectangle, nominal-size lip that juts past or
   // falls short of the actual body edge once fused per-piece.
+  // Interior frame for anything cut INTO the freshly-built lip, taken from
+  // `deriveDimensions` for the same reason the Z terms above are: the body it
+  // has to line up with was built from those numbers.
+  //
+  // Recomputing them off the nominal footprint (`width * pitch - CLEARANCE`)
+  // silently drops the overhang, which the lip solid itself does carry — so a
+  // wall cutout was cut into the body at the overhang-expanded interior and
+  // into the lip at the nominal one, and the two openings did not line up. An
+  // asymmetric overhang also shifts the interior's centre, which is what
+  // `innerOffsetX/Y` carries; a symmetric one only mis-sizes the cutter.
+  // Invisible below a few mm, because the cutter overshoots its opening by
+  // more than that.
+  const { innerW, innerD, innerOffsetX, innerOffsetY } = splitDims;
+  const shiftToInterior = (tool: Shape3D, dz = 0): Shape3D => {
+    if (innerOffsetX === 0 && innerOffsetY === 0 && dz === 0) return tool;
+    const shifted = translate(tool, [innerOffsetX, innerOffsetY, dz]);
+    tool.delete();
+    return shifted;
+  };
+
   let lipSolid: Shape3D | undefined;
   if (hasLip) {
     const lipBase = buildTopShape(
@@ -280,14 +300,13 @@ function splitSolidIntoPieces(
     // stackingLip, so dim.hasLip=false in the pipeline). Pass the same inset
     // here to keep the lip cuts aligned with the body's wall slots.
     if (params.style === 'slotted') {
-      const innerW = outerW - 2 * params.wallThickness;
-      const innerD = outerD - 2 * params.wallThickness;
       const lipInfo = {
         wallHeight: wallTopZ,
         lipHeight: LIP_HEIGHT,
         lipTaperWidth: LIP_TAPER_WIDTH,
       };
-      const lipCuts = buildLipSlotCuts(params, innerW, innerD, lipInfo, 0);
+      const rawLipCuts = buildLipSlotCuts(params, innerW, innerD, lipInfo, 0);
+      const lipCuts = rawLipCuts === null ? null : shiftToInterior(rawLipCuts);
       if (lipCuts) {
         try {
           const newLip = unwrap(cut(lipSolid as ValidSolid, lipCuts as ValidSolid));
@@ -307,15 +326,9 @@ function splitSolidIntoPieces(
     // full lip zone, then shift them up by floorZ to convert body-local Z
     // (floor at Z=0) into absolute bin Z (socket bottom at Z=0).
     if (params.walls.enabled) {
-      const innerW = outerW - 2 * params.wallThickness;
-      const innerD = outerD - 2 * params.wallThickness;
       const wallCuts = buildWallCutoutCuts(params, innerW, innerD, wallHeight, true);
       if (wallCuts) {
-        let positioned = wallCuts;
-        if (floorZ !== 0) {
-          positioned = translate(wallCuts, [0, 0, floorZ]);
-          wallCuts.delete();
-        }
+        const positioned = shiftToInterior(wallCuts, floorZ);
         try {
           const newLip = unwrap(cut(lipSolid as ValidSolid, positioned as ValidSolid));
           lipSolid.delete();


### PR DESCRIPTION
Fixes #3648

## The defect

A split bin's stacking lip is built fresh in `splitBinBuilder` rather than coming out of the pipeline, so anything cut into it has to be positioned in the same interior frame the body was.

The Z terms already came from `deriveDimensions` for exactly that reason — there is a comment saying so. The **XY interior was still recomputed locally** off the nominal footprint:

```ts
const innerW = outerW - 2 * params.wallThickness;   // outerW = width * pitch - CLEARANCE
```

which has no overhang in it. The lip solid itself *does* carry the overhang (`buildTopShape` is passed it). So a wall cutout was cut through the body at the overhang-expanded interior and through the lip at the nominal one, and the two openings did not line up — the rim visibly offset from the wall under it.

An asymmetric overhang also moves the interior's **centre**, which is what `innerOffsetX/Y` carries and which nothing here applied; a symmetric overhang still mis-sizes the cutter. The mismatch hides below a few mm because the cutter overshoots its own opening by more than that, which is why the report reads as a threshold ("greater than 4mm").

## The fix

`innerW`, `innerD`, `innerOffsetX` and `innerOffsetY` come from the same `splitDims` the Z terms already do, and both consumers go through one `shiftToInterior` — the wall-cutout cutters and a slotted bin's lip notches, which carried the same nominal expression.

## Verification

Measured at the mesh level on the reported shape (6×2×3, 12mm left overhang, front wall cutout, split in two). The test walks the front wall left to right and records every X where it changes between solid and open, once in a band inside the wall and once in a band inside the lip, then requires the two edge lists to agree.

| | before | after |
|---|---|---|
| 12mm left overhang | lip edge **8.25mm** off the wall's | within the probe's 0.25mm step |
| no overhang | already aligned | still aligned |

Comparing *edges* is what makes it specific: the defect moved the opening without changing how much of it there was, so a lip-vertex count or a volume reads the same either way — which is why the existing `split-wall-cutout-lip` scenario passes on the broken build. The 0mm case is in the same `it.each` so the probe is shown to be measuring something that can be right.

All 20 split suites and the scenario-coverage checks pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

