### PR TITLE
docs: correct the generation-timeout formula and drop value archaeology

### DIFF
--- a/api/lib/designerValidationConstants.ts
+++ b/api/lib/designerValidationConstants.ts
@@ -32,7 +32,7 @@ export const CONSTRAINTS = {
   // src/features/bin-designer/constants/gridfinity.ts (client refuses past it).
   MAX_STASH_ENTRIES: 36,
   MIN_LABEL_TAB_DEPTH: 8,
-  // Raised from 20 → 50 to enable tuck-under ledges for wire bins.
+  // Deep enough for tuck-under ledges on wire bins; mirrors DESIGNER_CONSTRAINTS.
   MAX_LABEL_TAB_DEPTH: 50,
   MIN_LABEL_TAB_WIDTH: 10, // %
   MAX_LABEL_TAB_WIDTH: 100, // %

--- a/src/features/baseplate/components/BaseplatePreview/BaseplateMesh.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplateMesh.tsx
@@ -42,9 +42,8 @@ export function BaseplateMesh({
   // While the direct-mesh preview is on screen, desaturate the user's filament
   // color and drop the emissive so the slab reads as "draft." When BREP swaps
   // in, the existing 300ms crossfade naturally transitions back to full color.
-  // Smooth normals + edge wireframes brought the preview close to BREP-quality
-  // visually, so we lean into a stronger 0.7 gray-blend (was 0.5) to keep the
-  // "this is provisional" cue legible.
+  // Smooth normals + edge wireframes bring the preview close to BREP-quality
+  // visually, so it takes a strong gray-blend to keep the "provisional" cue legible.
   const displayColor = useMemo(
     () => (isPreview ? desaturateColor(color, 0.7) : color),
     [color, isPreview]

--- a/src/features/baseplate/components/BaseplatePreview/SplitBaseplateMeshes.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/SplitBaseplateMeshes.tsx
@@ -60,9 +60,8 @@ function PieceMesh({
   const colors = useThreeColors();
   const filamentColor = useSettingsStore((s) => s.settings.baseplateFilamentColor);
   const displayColor = useMemo(
-    // 0.7 gray-blend (was 0.5) — smooth normals + edge wireframes pulled the
-    // preview close to BREP-quality, so a stronger desaturation keeps the
-    // "draft" affordance legible.
+    // Smooth normals + edge wireframes pull the preview close to BREP-quality,
+    // so it takes a strong desaturation to keep the "draft" affordance legible.
     () => (isPreview ? desaturateColor(filamentColor, 0.7) : filamentColor),
     [filamentColor, isPreview]
   );

--- a/src/features/bin-designer/constants/gridfinity.ts
+++ b/src/features/bin-designer/constants/gridfinity.ts
@@ -57,8 +57,7 @@ export const DESIGNER_CONSTRAINTS = {
   MAX_HEIGHT: 50,
   HEIGHT_STEP: 1, // height units
   MIN_COMPARTMENT_GRID: 1, // min rows/cols
-  // Max rows/cols. Bumped from 8 to 12 after measuring generation
-  // time across grid sizes (see
+  // Max rows/cols, set by measured generation time across grid sizes (see
   // `src/features/generation/worker/generators/__kernel-tests__/compartments.perf.test.ts`):
   // worst case (no label tabs) 12×12 finishes in ~14s, under the 30s base
   // timeout. 16×16 hits ~39s and risks timeout failures, so 12 is the safe
@@ -76,8 +75,8 @@ export const DESIGNER_CONSTRAINTS = {
   MIN_COMPARTMENT_SIZE: 5, // mm (minimum viable compartment dimension)
   // Label tabs
   MIN_LABEL_TAB_DEPTH: 8, // mm
-  // Raised from 20 → 50 so tuck-under ledges for wire bins have
-  // enough material to actually retain springy contents. Runtime clamp in
+  // Deep enough that a tuck-under ledge for a wire bin has enough material
+  // to actually retain springy contents. Runtime clamp in
   // the UI tightens the stepper to `min(50, innerD - 1)` so the tab can't
   // span past the opposite wall on small bins.
   MAX_LABEL_TAB_DEPTH: 50, // mm

--- a/src/features/generation/README.md
+++ b/src/features/generation/README.md
@@ -314,7 +314,15 @@ Fast generations → 50ms delay, slow generations → 300ms delay
 
 ## Generation Timeout
 
-`computeGenerationTimeoutMs(params)` scales the per-request watchdog: 30s base, +15s for hex pattern, +15s when paired with active wall cutouts, +15s per 2u of height over 4u, capped at 90s. Baseplates keep the flat 30s fallback.
+`computeGenerationTimeoutMs(params)` scales the per-request watchdog from
+`BASE_TIMEOUT_MS`, adding a bonus per cost driver and clamping to
+`MAX_TIMEOUT_MS`. The bonuses are named constants in `bridge/generationTimeout.ts`
+(`HEX_PATTERN_BONUS_MS`, `HEX_PLUS_CUTOUT_BONUS_MS`, `HEX_FOOTPRINT_BONUS_MS_PER_CELL`,
+`KUMIKO_PATTERN_BONUS_MS`, `FLOOR_PATTERN_BONUS_MS`, `TAPER_MULTI_COMPARTMENT_BONUS_MS`,
+`HEIGHT_BONUS_MS`, `DETACHABLE_FEET_BONUS_MS`), so read them there rather than
+restating values here. `EXPORT_TIMEOUT_MULTIPLIER` widens the budget for a
+user-initiated export over a live preview. Baseplates keep the flat
+`BASEPLATE_MAX_TIMEOUT_MS` ceiling.
 
 ## 3MF Multi-color Compatibility
 

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -147,9 +147,8 @@ export const HEIGHT_BONUS_BUCKET_UNITS = 2;
  * Hard ceiling — protects users from runaway WASM OOM loops while still giving
  * legitimately complex bins room to finish.
  *
- * Raised from 90s to 180s (#timeouts): measured generation of heavy honeycomb
- * bins runs well past 90s on the single-threaded OCCT pipeline — e.g. a 4×4×8
- * honeycomb bin's pattern cut alone is ~14s and a tall 6×6×20 is ~3min. The
+ * Heavy honeycomb bins run well past 90s on the single-threaded OCCT pipeline:
+ * a 4×4×8 honeycomb bin's pattern cut alone is ~14s and a tall 6×6×20 is ~3min. The
  * boolean `pattern_cut` stage is ~82% of total and scales super-linearly, so the
  * batch cut is already near-optimal and can't be meaningfully parallelized
  * (splitting the solid forces a recombine that costs more than it saves). Until
@@ -173,14 +172,11 @@ export const MAX_TIMEOUT_MS = 180_000;
  * that hardware gap while preserving the relative ordering the complexity budget
  * already encodes (a hex bin still gets proportionally more than a trivial one).
  *
- * Raised from 4× to 6× (#bin-export-timeout): a small cohort of users still hit
- * `ExportTimeoutError` on heavy honeycomb / big-magnet-grid / scoop+tall designs.
- * The export budget only began modelling the hardware gap at all (after
- * those reports), and 4× under-served the genuinely slowest devices — old phones
- * and throttled mobile browsers routinely run 5–6× the reference machine. 6×
- * lifts mid-weight designs that were clamping just short of finishing, and lets
- * the heaviest honeycomb bins reach the raised ceiling below instead of being
- * cut off well under it.
+ * 6× rather than 4×: old phones and throttled mobile browsers routinely run
+ * 5–6× the reference machine, and a smaller multiplier clamps mid-weight designs
+ * just short of finishing and stops the heaviest honeycomb bins reaching the
+ * ceiling below. Heavy honeycomb, big-magnet-grid and scoop+tall designs are the
+ * ones that hit `ExportTimeoutError` when this is too low.
  */
 export const EXPORT_TIMEOUT_MULTIPLIER = 6;
 
@@ -190,11 +186,10 @@ export const EXPORT_TIMEOUT_MULTIPLIER = 6;
  * genuinely-wedged WASM heap from hanging forever, not to bound interactive
  * wait.
  *
- * Raised from 15 to 20 minutes (#bin-export-timeout) so the heaviest known
- * pipeline actually receives the 6× export multiplier instead of being clamped
- * back: a 6×6×20 honeycomb's ~3-minute pattern cut runs ≈18 min at 6× on the
- * slowest hardware, which the old 15-minute cap would have truncated. 20 minutes
- * still bounds a wedged heap, and the progress bar + cancel button mean a user
+ * 20 minutes so the heaviest known pipeline actually receives the 6× export
+ * multiplier instead of being clamped back: a 6×6×20 honeycomb's ~3-minute
+ * pattern cut runs ≈18 min at 6× on the slowest hardware, so a 15-minute cap
+ * would truncate it. 20 minutes still bounds a wedged heap, and the progress bar + cancel button mean a user
  * who no longer wants to wait is never stuck.
  */
 export const EXPORT_MAX_TIMEOUT_MS = 1_200_000;


### PR DESCRIPTION
## Summary

The generation README described a timeout formula that is wrong in both its cap and its terms. Six comments narrated a constant's history instead of its reason.

## Why

The README said:

> 30s base, +15s for hex pattern, +15s when paired with active wall cutouts, +15s per 2u of height over 4u, **capped at 90s**

`MAX_TIMEOUT_MS` is `180_000`. And there are ten bonuses in `generationTimeout.ts` now, not three: `KUMIKO_PATTERN_BONUS_MS`, `FLOOR_PATTERN_BONUS_MS`, `HEX_FOOTPRINT_BONUS_MS_PER_CELL`, `TAPER_MULTI_COMPARTMENT_BONUS_MS` and `DETACHABLE_FEET_BONUS_MS` all landed after it was written.

A doc that restates values drifts every time one moves. It now names the constants and points at the file, so the same rot cannot recur and `check:doc-drift` verifies the names resolve.

## Changes

Six comments lost their before-value and kept their reason:

| File | Was | Now |
|---|---|---|
| `gridfinity.ts` | "Bumped from 8 to 12 after measuring…" | keeps the measurement (12×12 ≈14s, 16×16 ≈39s) |
| `gridfinity.ts` | "Raised from 20 → 50 so tuck-under ledges…" | states what the depth buys |
| `designerValidationConstants.ts` | "Raised from 20 → 50 to enable…" | notes it mirrors `DESIGNER_CONSTRAINTS` |
| `generationTimeout.ts` | "Raised from 4× to 6× (#bin-export-timeout)" | keeps why 6× (slow devices run 5-6× reference) |
| `generationTimeout.ts` | "Raised from 15 to 20 minutes (#bin-export-timeout)" | keeps the 6×6×20 ≈18min derivation |
| `BaseplateMesh` / `SplitBaseplateMeshes` | "0.7 gray-blend (was 0.5)" ×2 | states why a strong blend is needed |

Two of those also carried `#bin-export-timeout`, which is not a reference to anything.

**Left alone deliberately**, because they read like the same pattern but are not:

- `labelPlates.ts` on Cullenect v1.1 (36.4mm) vs v2.0.0 (`42·U − 6`) is a live constraint about an *external* standard, and ends "the two must not be mixed"
- `lidSeating.ts` on "2.8mm of solid-on-solid overlap in a place nobody had" describes the defect the probe exists to catch
- `CompactNumberInput.tsx`'s "ArrowDown from 156 to 155" is a worked example, not history

## Risk

Comments and one doc paragraph. `pnpm run typecheck` passes and `generationTimeout`'s 48 tests pass. No constant values changed.

https://claude.ai/code/session_01PKjJbCN6AycciP9oQxFZaV

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

