### PR TITLE
fix(ci): exhaustiveness check was asserting on one file, not 2,382

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,9 @@ jobs:
       - name: Check union exhaustiveness
         id: exhaustiveness
         continue-on-error: true
-        run: pnpm run check:exhaustiveness -- --all
+        # No '--' separator: pnpm forwards it literally and the script then
+        # checks a single nonexistent path instead of all 2,382 source files.
+        run: pnpm run check:exhaustiveness --all
 
       - name: Check doc drift
         id: doc_drift

--- a/scripts/check-module-boundaries.sh
+++ b/scripts/check-module-boundaries.sh
@@ -39,6 +39,15 @@ ALLOWED_CROSS_FEATURE=(
 VIOLATIONS_FOUND=0
 
 # Get files to check
+# See check-union-exhaustiveness.sh: `pnpm run <script> -- --flag` forwards the
+# separator literally, and taking it for a filename makes the gate pass on
+# nothing. Fail instead.
+if [[ "$1" == "--" || ( "$1" == -* && "$1" != "--staged" ) ]]; then
+  echo "check-module-boundaries: unknown argument '$1'" >&2
+  echo "Usage: $0 [--staged | <file>]   (note: no '--' separator)" >&2
+  exit 2
+fi
+
 get_files() {
   if [[ "$1" == "--staged" ]]; then
     git diff --cached --name-only --diff-filter=ACM | grep -E '\.tsx?$' | grep '^src/' | grep -v '\.test\.' | grep -v '\.spec\.' || true

--- a/scripts/check-union-exhaustiveness.sh
+++ b/scripts/check-union-exhaustiveness.sh
@@ -36,6 +36,16 @@ declare -A UNION_TYPES=(
   ["CommunityPrintStatus"]="live,hidden,removed"
 )
 
+# A bare `--` reaches here when someone writes `pnpm run ... -- --all`: pnpm
+# forwards the separator literally, the old code took it for a filename, and the
+# run "checked" one nonexistent path and exited 0. A gate that passes vacuously
+# is worse than one that fails, so an unknown flag is fatal.
+if [[ "$1" == "--" || ( "$1" == -* && "$1" != "--all" ) ]]; then
+  echo "check-union-exhaustiveness: unknown argument '$1'" >&2
+  echo "Usage: $0 [--all | <file>]   (note: no '--' separator)" >&2
+  exit 2
+fi
+
 # Get files to check
 get_files() {
   if [[ "$1" == "--all" ]]; then

--- a/scripts/ci-invocations.test.ts
+++ b/scripts/ci-invocations.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(import.meta.dirname, '..');
+
+/**
+ * `pnpm run <script> -- --flag` forwards the `--` literally. A shell gate that
+ * treats an unrecognised argument as a filename then "checks" one nonexistent
+ * path and exits 0, so the job stays green while asserting nothing. CI ran
+ * `check:exhaustiveness -- --all` that way: 1 file instead of 2,382.
+ *
+ * The scripts now reject a bare `--`, so this would fail loudly rather than
+ * silently. This test is the earlier warning.
+ */
+describe('CI command invocations', () => {
+  const workflows = ['ci.yml', 'pr-title.yml']
+    .map((f) => join(ROOT, '.github/workflows', f))
+    .flatMap((p) => {
+      try {
+        return [readFileSync(p, 'utf8')];
+      } catch {
+        return [];
+      }
+    });
+
+  it('never separates pnpm script args with `--`', () => {
+    const offenders = workflows.flatMap((text) =>
+      text.split('\n').filter((l) => /pnpm run [a-z:0-9_-]+ -- /.test(l))
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('passes --all to the exhaustiveness check so it does not run staged-only', () => {
+    const ci = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8');
+    const line = ci.split('\n').find((l) => l.includes('check:exhaustiveness'));
+    expect(line).toBeDefined();
+    expect(line).toContain('--all');
+    expect(line).not.toMatch(/-- --all/);
+  });
+});


### PR DESCRIPTION
## Summary

CI's union-exhaustiveness gate has been passing without checking anything. It ran over **1 file** where it should have run over **2,382**.

## Why

`ci.yml` invoked it as:

```yaml
run: pnpm run check:exhaustiveness -- --all
```

pnpm forwards that `--` **literally**, so the script's `$1` is `--`, not `--all`. Its `get_files` falls through to `elif [[ -n "$1" ]]; then echo "$1"`, treats `--` as a filename, finds nothing, and exits 0.

Measured, not inferred:

```
pnpm run check:exhaustiveness -- --all   ->  Checking 1 files      ✓ passed
pnpm run check:exhaustiveness --all      ->  Checking 2382 files   ✓ passed
```

The `quality-gates` skill already documented this exactly:

> No `--` before `--all` — pnpm forwards the literal `--` and the script silently falls back to staged-only mode.

CI did it anyway. That is the whole problem with a rule that lives only in prose: nothing enforced it.

## Changes

Three, so it cannot recur:

1. **`ci.yml` drops the separator**, with a comment saying why.
2. **Both shell gates exit 2 on an unrecognised flag** instead of treating it as a filename. `check-module-boundaries.sh` has the identical `elif [[ -n "$1" ]]` shape; its default happens to be check-everything so CI was unaffected there, but the trap is the same and it is now closed.
3. **`scripts/ci-invocations.test.ts`** fails if any workflow reintroduces `pnpm run <script> -- `, or if the exhaustiveness step loses `--all`.

## Risk

**No violations were being hidden.** Running it properly across all 2,382 files reports clean, so this is a gap in coverage rather than a backlog of defects. Had it found real switches, this PR would be much larger.

Verified every mode still works after hardening:

| Command | Result |
|---|---|
| `check:boundaries` | Checking 2382 files ✓ |
| `check:boundaries:staged` | No TypeScript files to check ✓ |
| `check:exhaustiveness --all` | Checking 2382 files ✓ |
| `check:exhaustiveness` (staged) | No TypeScript files to check ✓ |
| `check:exhaustiveness -- --all` | **exit 2, unknown argument** |

Found while auditing docs: I was verifying that every `pnpm run` named in the docs actually exists, which surfaced the contradiction between the skill and the workflow.

https://claude.ai/code/session_01PKjJbCN6AycciP9oQxFZaV

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

