### PR TITLE
docs: correct which pre-commit gates actually block

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -30,7 +30,7 @@ description: Write and run tests — Vitest three-project routing (unit/dom/gene
 5. **Store reset is manual.** Setup files do RTL cleanup only. Any test touching Zustand stores needs `resetAllStores()` (or a targeted `reset*Store()`) from `@/test/testUtils` in `beforeEach`, or state leaks silently into later tests. `resetAllStores()` is a hand-maintained list in `src/test/testUtils.ts` — when adding a new Zustand store, register its reset there or it leaks into every subsequent store test.
 6. **E2E retries are 0 by policy** (`playwright.config.ts`, 6 projects: chromium/firefox/webkit/mobile-chrome/mobile-safari/tablet). A flake must be root-caused; known-unfixable interactions get `test.skip()` plus unit coverage, never retries or sleeps.
 
-Deeper docs: `src/test/README.md` and `e2e/README.md` — but its coverage numbers are stale; the enforced source of truth is the `thresholds` block in `vitest.config.ts` (lines 76 / branches 68 / functions 74 / statements 75). Also: despite CLAUDE.md, `scripts/check-missing-tests.sh` always exits 0 (warn-only) and `test:affected` is commented out of `.husky/pre-commit` — tests are NOT run at commit time; CI is the gate.
+Deeper docs: `src/test/README.md` and `e2e/README.md`. The enforced coverage numbers are the `thresholds` block in `vitest.config.ts`; read them there, since any copy drifts. Note that `scripts/check-missing-tests.sh` always exits 0 (warn-only) and `test:affected` is commented out of `.husky/pre-commit`, so tests are NOT run at commit time; CI is the gate.
 
 ## Recipes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,8 @@ Gridfinity Layout Tool: React + TypeScript web app for 3D-printed drawer organiz
 ## Git & Quality
 
 - **Main is protected** - all changes via PRs
-- Pre-commit hooks enforce lint-staged, module boundaries, i18n (4 checks), exhaustiveness, affected tests, component structure, missing tests, readme reminders, doc drift
+- Pre-commit **blocks** on: lint-staged, module boundaries, design system, i18n (4 checks), exhaustiveness, component structure, doc drift
+- Pre-commit **warns only**: missing tests, readme reminders. `test:affected` is commented out of the hook, so **no tests run at commit time** — CI is the gate
 
 ## Docs
 
@@ -81,8 +82,8 @@ See `src/core/cqrs/README.md` for architecture details, adding new commands/even
 
 - **Convention:** Colocated sibling tests — `foo.ts` + `foo.test.ts` in the same directory
 - **Infrastructure (`src/test/`):** `setup.ts`, `testUtils.ts`, `mocks/` — shared test utilities (stays centralized)
-- Pre-commit **blocks** if edited component file has no sibling test
-- Run `pnpm run test:coverage` before commit
+- `check-component-structure.sh` **blocks** (exit 1) when a staged uppercase-named `.tsx`/`.ts` under `src/**/components/` lacks its named folder or a sibling test on disk. `check-missing-tests.sh` covers everything else and only **warns** (always exits 0)
+- Run `pnpm run test:coverage` before commit — nothing at commit time does
 - **Test files are type-checked.** `tsconfig.test.json` is in the root `tsconfig.json` references, so `pnpm run typecheck` covers every `*.test.ts(x)`, `src/test/**`, `scripts/**/*.test.ts` and `__kernel-tests__` file. Keep it that way — a test that does not type-check can assert against a property that does not exist and still pass.
 
 ## Debugging & Bug Fixing

--- a/scripts/doc-budget.json
+++ b/scripts/doc-budget.json
@@ -17,7 +17,7 @@
     ".claude/skills/release-and-ci/SKILL.md": 1579,
     ".claude/skills/share-api-collab/SKILL.md": 1838,
     ".claude/skills/state-and-cqrs/SKILL.md": 1486,
-    ".claude/skills/testing/SKILL.md": 1682,
+    ".claude/skills/testing/SKILL.md": 1669,
     ".claude/skills/three-preview/SKILL.md": 1605,
     "CLAUDE.md": 1528,
     "api/.greptile/rules.md": 177,

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -70,6 +70,6 @@ describe('my feature', () => {
 3. **localStorage isolation** — use `createIsolatedLocalStorageMock()` per-test; shared module-level mocks pollute subsequent tests
 4. **Result helpers preferred** — use `expectOk()` / `expectErr()` instead of manual `isOk()` + unwrap chains
 5. **Fake timer coordination** — `setupFakeTimers()` syncs `vi.useFakeTimers()` with `Date.now()`; call `cleanup()` in `afterEach`
-6. **Coverage thresholds enforced** — ~78% lines, ~66% branches; `pnpm run test:coverage` blocks commit if below
+6. **Coverage thresholds enforced** — the numbers live in the `thresholds` block of `vitest.config.ts`; read them there rather than restating. Nothing runs coverage at commit time, so CI is where this fails
 7. **Colocated convention** — test files must be siblings to source (`foo.ts` + `foo.test.ts`); pre-commit hook enforces this
 8. **Zustand state persists** — stores survive unmounts; without `resetAllStores()`, prior test state leaks through


### PR DESCRIPTION
## Summary

CLAUDE.md described the commit-time gates inaccurately in two ways, and a skill was already carrying a correction for one of them, which had itself gone stale.

## Why

CLAUDE.md listed **"affected tests"** among the enforced pre-commit hooks. `test:affected` is commented out of `.husky/pre-commit` ("too slow for pre-commit"), so **no tests run at commit time at all**. It also said pre-commit "blocks if edited component file has no sibling test", which is true only for `src/**/components/` and via a different script than the name suggests.

I measured each gate against a real staged violation rather than reading them:

| Gate | Probe | Result |
|---|---|---|
| `check-component-structure.sh` | bare component, no test | **exit 1** (blocks) |
| `check-missing-tests.sh` | same file | exit 0, "commit will proceed" |
| `check-design-system-usage.ts` | raw `<button>` | **exit 1** (blocks) |
| `check-module-boundaries.sh` | staged `.ts` | Checking 1 files ✓ |

So the claim was right for components and misleading for everything else: a new util or hook gets a warning, not a block.

## Changes

CLAUDE.md now separates blocking from warn-only, and names which script owns the sibling-test rule and over what scope.

**The corrections-pattern again.** The `testing` skill carried:

> Also: despite CLAUDE.md, `scripts/check-missing-tests.sh` always exits 0 (warn-only)…

That is the same shape removed from `auth-and-sync` in #3667 — a skill correcting a doc rots the moment the doc is fixed. CLAUDE.md is fixed, so the correction is gone.

**And the correction had itself gone stale.** The same skill said `src/test/README.md`'s coverage numbers were wrong and quoted the "source of truth" as lines 76 / branches 68 / functions 74 / statements 75. `vitest.config.ts` holds **82 / 75 / 79 / 81**. The README said ~78 / ~66. All three disagreed. Both now name the `thresholds` block instead of copying it, which is the only version that cannot drift.

The README also claimed `pnpm run test:coverage` "blocks commit if below". Nothing runs coverage at commit time.

## Risk

Documentation only, no gate behaviour changed. The probes were cleaned up; `git status` is clean.

https://claude.ai/code/session_01PKjJbCN6AycciP9oQxFZaV

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

