### PR TITLE
fix(split-bin): seat a cutout's shoulder round-over on the lip, not the wall top

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.split-cutout-shoulder.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.split-cutout-shoulder.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+/**
+ * Regression test for the wall-cutout shoulder on split bins with a lip.
+ *
+ * A cutout's top round-over is tangent to the top of the material the cut
+ * passes through, which on a lipped bin is the stacking lip's top face. Split
+ * bins build the body lipless (to dodge an OCCT crash at the lip-wall
+ * junction), so the pipeline seated that curve on the WALL top 4.4mm lower
+ * while the separately-built lip kept the correct one. The wall was rounded
+ * away under a lip that was not, leaving the lip jutting over open air.
+ *
+ * The measure is a delta against the same bin unsplit: below the lip the two
+ * openings have to be the same width at every height, whatever radius the
+ * clamps end up allowing.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { DEFAULT_SPLIT_CONNECTOR_CONFIG } from '@/features/bin-designer/constants/defaults';
+import type { BinParams, SplitConnectorConfig, WallCutout } from '@/shared/types/bin';
+import type { MeshData } from '@/features/generation/bridge/types';
+import { initBrepjs, getGenerateBin, getGenerateSplitPreview } from './__kernel-tests__/wasmInit';
+import { isSolidThrough } from './__kernel-tests__/meshAssertions';
+import { deriveDimensions } from './pipeline/context';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+const NO_CONNECTORS: SplitConnectorConfig = {
+  ...DEFAULT_SPLIT_CONNECTOR_CONFIG,
+  enabled: false,
+};
+
+/** Radius chosen past LIP_HEIGHT (4.4mm) so the flare reaches down into the wall. */
+const SHOULDER_RADIUS = 8;
+
+const SIDE_CUT: WallCutout = {
+  enabled: true,
+  width: 70,
+  depth: 50,
+  alignment: 'center',
+  offset: 0,
+  widthMm: null,
+};
+
+const PARAMS: BinParams = {
+  ...DEFAULT_BIN_PARAMS,
+  width: 4,
+  depth: 6,
+  height: 5,
+  base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
+  // Asymmetric overhang on a side without cutouts, as reported: it shifts the
+  // interior off centre, so the body cut and the lip cut have to agree about
+  // that too.
+  overhang: { left: 0, right: 0, front: 0, back: 8, feet: false },
+  walls: {
+    ...DEFAULT_BIN_PARAMS.walls,
+    enabled: true,
+    cornerRadiusTop: SHOULDER_RADIUS,
+    left: SIDE_CUT,
+    right: SIDE_CUT,
+  },
+};
+
+/** A split piece read as a mesh, for the ray probes. */
+function asMesh(piece: {
+  vertices: Float32Array;
+  normals: Float32Array;
+  indices: Uint32Array;
+  edgeVertices: Float32Array;
+}): MeshData {
+  return { ...piece, triangleCount: piece.indices.length / 3 };
+}
+
+/**
+ * How far past the cut's nominal edge the wall is still missing, at height `z`.
+ *
+ * Walks outward along the left wall from the cut edge until the wall goes
+ * solid, so a shoulder round-over reads as the distance it has eaten into the
+ * material standing beside the opening.
+ */
+function shoulderCutbackMm(
+  probe: (y: number) => boolean,
+  cutEdgeY: number,
+  step = 0.05,
+  limit = 14
+): number {
+  for (let d = 0; d <= limit; d += step) {
+    if (probe(cutEdgeY + d)) return d;
+  }
+  return Number.NaN;
+}
+
+describe('split bin: cutout shoulder is seated on the lip, not the wall top', () => {
+  it('matches the unsplit bin at every height below the lip', () => {
+    const dim = deriveDimensions(PARAMS, true);
+    const whole: MeshData = getGenerateBin()(PARAMS, undefined, true);
+    const split = getGenerateSplitPreview()(PARAMS, [], [0], NO_CONNECTORS);
+    expect(split.pieces).toHaveLength(2);
+
+    // Mid-thickness of the left wall, and the back-half piece that carries the
+    // far end of that wall's cutout.
+    const wallX = -dim.innerW / 2 - PARAMS.wallThickness / 2;
+    const cutEdgeY = dim.innerOffsetY + (dim.innerD * SIDE_CUT.width) / 100 / 2;
+    const piece = split.pieces.reduce((a, b) => (b.offsetY > a.offsetY ? b : a));
+    const pieceMesh = asMesh(piece);
+
+    // tessellatePiece re-centres each piece on its own footprint; undo that so
+    // both meshes are probed in the same bin frame.
+    const pitchX = PARAMS.gridUnitMm;
+    const pitchY = PARAMS.gridUnitMm;
+    const centerX =
+      piece.offsetX * pitchX - (PARAMS.width * pitchX - 0.5) / 2 + (piece.widthUnits * pitchX) / 2;
+    const centerY =
+      piece.offsetY * pitchY - (PARAMS.depth * pitchY - 0.5) / 2 + (piece.depthUnits * pitchY) / 2;
+
+    for (const depthBelowRim of [1, 2, 3, 4, 5, 6]) {
+      const z = dim.wallTopZ - depthBelowRim;
+      const band = (mesh: MeshData, x: number, y: number): boolean =>
+        isSolidThrough(mesh, x, y, z - 0.1, z);
+
+      const wholeCutback = shoulderCutbackMm((y) => band(whole, wallX, y), cutEdgeY);
+      const splitCutback = shoulderCutbackMm(
+        (y) => band(pieceMesh, wallX - centerX, y - centerY),
+        cutEdgeY
+      );
+
+      expect(wholeCutback).not.toBeNaN();
+      expect(splitCutback).not.toBeNaN();
+      expect(
+        Math.abs(splitCutback - wholeCutback),
+        `wall top −${depthBelowRim}mm: split piece ${piece.label} is cut back ` +
+          `${splitCutback.toFixed(2)}mm past the opening, unsplit bin ${wholeCutback.toFixed(2)}mm`
+      ).toBeLessThanOrEqual(0.3);
+    }
+  }, 120000);
+});

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -19,7 +19,7 @@ import {
   getKernelCapabilities,
 } from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
-import type { BinParams, SplitConnectorConfig } from '@/shared/types/bin';
+import type { BinParams, SplitConnectorConfig, WallCutout } from '@/shared/types/bin';
 import type { ExportFormat } from '../../bridge/types';
 
 import { CLEARANCE } from './generatorTypes';
@@ -39,6 +39,7 @@ import { buildWallCutoutCuts } from './wallCutoutBuilder';
 import { isAbortError } from './utils/abort';
 import { resolveOverhang } from './overhang';
 import { isPartialMask } from '@/shared/utils/cellMask';
+import { resolveCutoutCornerRadii } from '@/shared/utils/wallCutoutPosition';
 import { hasMeshImprints, imprintPieceArrays } from './meshImprint';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { deriveDimensions } from './pipeline/context';
@@ -87,6 +88,51 @@ const LIP_FUSE_OVERLAP = 0.05;
 /** Preview tessellation tolerance: tightened for smooth normals on curved surfaces */
 const PREVIEW_TOLERANCE = 0.1;
 const PREVIEW_ANGULAR_TOLERANCE = 10;
+
+/** Every side a wall cutout can be configured on. */
+const CUTOUT_SIDES = ['front', 'back', 'left', 'right', 'interior'] as const;
+
+/**
+ * Whether any enabled cutout rounds the shoulder where it meets the rim.
+ *
+ * Gates the two halves of the fix below, so a design that leaves the control
+ * alone (square shoulders, the shape every design had before it existed) takes
+ * neither the reshaped `bodyParams` nor the extra boolean, and splits into
+ * byte-identical pieces.
+ */
+function hasShoulderRoundOver(walls: BinParams['walls']): boolean {
+  // `cutWidth` reaches only the BOTTOM fillet's automatic default, so any value
+  // answers the question being asked here.
+  return CUTOUT_SIDES.some(
+    (side) => walls[side].enabled && resolveCutoutCornerRadii(walls, walls[side], 0).top > 0
+  );
+}
+
+/**
+ * Square off every wall cutout's top round-over.
+ *
+ * The round-over is tangent to the top of the material the cut passes through,
+ * and for a piece of a lipped bin that plane is the LIP's top face. The body is
+ * generated lipless, so the pipeline would seat the curve on the wall top
+ * `LIP_HEIGHT` lower: a shoulder the separately-cut lip above it does not
+ * share, which is the lip left jutting over a wall rounded away beneath it.
+ *
+ * Squared here, the pipeline's opening is a strict subset of the real cutter at
+ * every height, so `splitSolidIntoPieces` can cut body and lip with that one
+ * tool and get back exactly the opening an unsplit bin has.
+ */
+function squareCutoutShoulders(walls: BinParams['walls']): BinParams['walls'] {
+  const square = (side: WallCutout): WallCutout => ({ ...side, cornerRadiusTop: 0 });
+  return {
+    ...walls,
+    cornerRadiusTop: 0,
+    front: square(walls.front),
+    back: square(walls.back),
+    left: square(walls.left),
+    right: square(walls.right),
+    interior: square(walls.interior),
+  };
+}
 
 /** Metadata for a single split piece within the grid */
 interface SplitPieceInfo {
@@ -186,13 +232,27 @@ function splitSolidIntoPieces(
   // Generate body solid. When the bin has a stacking lip, generate WITHOUT
   // the lip to avoid OCCT boolean intersection crashes. The lip is split
   // separately and fused onto each piece below.
-  const bodyParams = hasLip ? { ...params, base: { ...params.base, stackingLip: false } } : params;
+  //
+  // A cutout's rounded shoulder belongs to the assembled piece's rim, which is
+  // the lip's top face, so it is taken off the lipless body the pipeline builds
+  // and cut back into body and lip together further down, off one tool.
+  const recutShoulders = hasLip && params.walls.enabled && hasShoulderRoundOver(params.walls);
+  const bodyParams = hasLip
+    ? {
+        ...params,
+        base: { ...params.base, stackingLip: false },
+        ...(recutShoulders ? { walls: squareCutoutShoulders(params.walls) } : {}),
+      }
+    : params;
   generateBin(bodyParams, undefined, true);
 
-  const bodySolid = getLastSolid();
+  let bodySolid = getLastSolid();
   if (!bodySolid) {
     throw new Error('Failed to generate solid for splitting');
   }
+  // Body re-cut below. Owned here, unlike the `getLastSolid()` handle the shape
+  // cache still holds.
+  let recutBody: Shape3D | undefined;
 
   // Per-axis pitch: X scales width / vertical cut planes, Y scales depth /
   // horizontal cut planes. Equal for a square grid.
@@ -318,13 +378,16 @@ function splitSolidIntoPieces(
       }
     }
 
-    // Same situation for wall cutouts: the body got its wall cutouts via the
-    // normal pipeline on bodyParams (where dim.hasLip=false, so the cutters
-    // only overshoot the wall top by 2mm). The freshly-built lip would
-    // otherwise still seal off the opening that should pass cleanly through
-    // both wall and lip. Pass hasLip=true so the cutters extend through the
-    // full lip zone, then shift them up by floorZ to convert body-local Z
-    // (floor at Z=0) into absolute bin Z (socket bottom at Z=0).
+    // Wall cutouts are cut here for BOTH halves of the assembly, from one tool.
+    // The pipeline saw `bodyParams`, whose `dim.hasLip` is false: its cutters
+    // stop 2mm above the wall top, so the freshly-built lip would still seal
+    // off an opening meant to pass cleanly through wall and lip alike, and its
+    // shoulder round-over sits on the wall top rather than on the lip's (which
+    // is why `squareCutoutShoulders` took that curve off the body: it is one
+    // cut through both, and the halves cannot be allowed to disagree about
+    // where the rim is). Pass hasLip=true so the cutter spans the full lip
+    // zone, then shift it up by floorZ to convert body-local Z (floor at Z=0)
+    // into absolute bin Z (socket bottom at Z=0).
     if (params.walls.enabled) {
       const wallCuts = buildWallCutoutCuts(params, innerW, innerD, wallHeight, true);
       if (wallCuts) {
@@ -333,6 +396,16 @@ function splitSolidIntoPieces(
           const newLip = unwrap(cut(lipSolid as ValidSolid, positioned as ValidSolid));
           lipSolid.delete();
           lipSolid = newLip;
+          if (recutShoulders) {
+            const recut = unwrap(cut(bodySolid as ValidSolid, positioned as ValidSolid));
+            // Only a handle of our own goes in `recutBody`. A kernel that
+            // answers a no-op cut with its input would otherwise have the
+            // finally free the solid the shape cache is still holding.
+            if (recut !== bodySolid) {
+              recutBody = recut;
+              bodySolid = recut;
+            }
+          }
         } finally {
           positioned.delete();
         }
@@ -519,6 +592,7 @@ function splitSolidIntoPieces(
     }
   } finally {
     if (lipSolid) lipSolid.delete();
+    if (recutBody) recutBody.delete();
 
     // The solid cached in lastSolid was generated for bodyParams (which strips
     // the stacking lip to avoid OCCT boolean crashes). Mark it as NOT


### PR DESCRIPTION
Fixes #3680.

A wall cutout's top round-over is tangent to the top of the material the cut passes through, so on a lipped bin it meets the stacking lip's top face and the shoulder reads as one continuous curve rather than a rounded wall with a square lip perched on it.

Split bins build the body lipless (to dodge the OCCT crash at the lip-wall junction) and rebuild the lip separately. That also cleared `dim.hasLip` for the wall-cutout cutter, so the body's curve was drawn against the wall top, `LIP_HEIGHT` (4.4mm) below the one the separately-built lip kept. The wall was rounded away under a lip that was not.

Below a 4.4mm radius the correct flare lives entirely inside the lip, so the mismatch is a local widening at the wall top. Past it the correct flare descends into the wall and the two arcs disagree over a growing band, which is the reported "more than 4mm" threshold. Probed on a 4x6x5 bin with an 8mm radius, 3mm below the wall top: the split piece was cut back 1.80mm past the opening where the unsplit bin was cut back 0.05mm.

## Fix

Take the round-over off the body the pipeline builds (`squareCutoutShoulders`, which leaves the opening a strict subset of the real cutter at every height) and cut it back into body and lip together off the one tool, so the two halves of the assembly cannot disagree about where the rim is. Gated on a cutout actually rounding its shoulder, so a design that leaves the control alone takes neither the reshaped params nor the extra boolean and splits into byte-identical pieces.

## Verification

`binGenerator.scenario.split-cutout-shoulder.test.ts` states the result as a delta against the same bin unsplit: below the lip the two openings have to be the same width at every height, whatever radius the clamps allow. It fails on `main` (1.80mm vs 0.05mm) and passes here.

Full generation suite green: 132 files, 1248 tests (`binGenerator.scenario`, `binGenerator.export`, `splitBinBuilder`).

https://claude.ai/code/session_01PKjJbCN6AycciP9oQxFZaV

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

