### PR TITLE
fix(baseplate): place screw holes symmetrically about the piece centre

### DIFF
--- a/src/features/generation/worker/generators/baseplateGenerator.scenario.screws.test.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.scenario.screws.test.ts
@@ -16,6 +16,8 @@ import {
   isSolidThrough,
   verticalSolidSpans,
 } from './__kernel-tests__/meshAssertions';
+import type { MeshData } from '@/features/generation/bridge/types';
+import { HOLE_OFFSET } from './generatorTypes';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import type { ScrewHoleParams } from '@/core/types/baseplate';
 import { mm } from '@/core/types';
@@ -280,5 +282,99 @@ describe('baseplate mount-down screw holes (#3425)', () => {
     assertStructurallyValid(result);
     const bb = boundingBox(result.vertices);
     expect(bb.maxZ - bb.minZ).toBeCloseTo(SOCKET_HEIGHT + magnetFloor + pad, 1);
+  });
+});
+
+describe('screw hole placement symmetry (#3698)', () => {
+  const EIGHT: ScrewHoleParams = { ...SCREWS, screwsPerPiece: 8 };
+  const PAD = screwPadThicknessMm(EIGHT, 0);
+  /** The reported case: one 6x6 piece of a split 12x12 plate, eight screws. */
+  const SIX_BY_SIX = defaults({
+    width: 6,
+    depth: 6,
+    screwHoles: EIGHT,
+    screwPadThicknessMm: PAD,
+  });
+
+  function plate(draft: boolean): MeshData {
+    return getGenerateBaseplate()(SIX_BY_SIX, NO_OP, !draft, undefined, draft);
+  }
+
+  /**
+   * Whether the cell containing (x, y) kept a floor.
+   *
+   * Read at a magnet position OTHER than the screw's own, because the screw
+   * hole is void whether or not the cell has a pad, and so is a cell with no
+   * screw at all. Only a sibling position separates the two: a screw-bearing
+   * cell is floored across its pad, an empty one is open to the underside.
+   * This is what makes the probe answer "which cell took the screw" rather
+   * than "is there a hole here", which is the whole question in #3698.
+   */
+  function cellIsFloored(mesh: MeshData, x: number, y: number): boolean {
+    return verticalSolidSpans(mesh, x, y).length > 0;
+  }
+
+  /** Every magnet position on the plate, which is every place a screw can land. */
+  function magnetLattice(): Array<readonly [number, number]> {
+    const axis: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const centre = -126 + 21 + i * 42;
+      axis.push(centre - HOLE_OFFSET, centre + HOLE_OFFSET);
+    }
+    return axis.flatMap((x) => axis.map((y) => [x, y] as const));
+  }
+
+  /**
+   * Quantized before formatting, and `+ 0` to collapse a negative zero.
+   * The plate's underside lands on -2e-16 rather than exactly 0, and both
+   * `toFixed` and `Object.is` preserve that sign, so a raw comparison reports
+   * every floored column as asymmetric while the solid is perfectly symmetric.
+   */
+  function columnSignature(mesh: MeshData, x: number, y: number): string {
+    const q = (v: number): string => (Math.round(v * 1000) / 1000 + 0).toFixed(3);
+    return verticalSolidSpans(mesh, x, y)
+      .map(([a, b]) => `${q(a)}..${q(b)}`)
+      .join('|');
+  }
+
+  it('staggers the front and back edge screws across the centreline', () => {
+    // Both used to take the cell left of centre. The pad under the sibling
+    // magnet is what says which cell actually got the screw.
+    const mesh = plate(false);
+    expect(cellIsFloored(mesh, -34, -118)).toBe(true);
+    expect(cellIsFloored(mesh, 34, -118)).toBe(false);
+    expect(cellIsFloored(mesh, 34, 118)).toBe(true);
+    expect(cellIsFloored(mesh, -34, 118)).toBe(false);
+  });
+
+  it('staggers the left and right edge screws across the centreline', () => {
+    const mesh = plate(false);
+    expect(cellIsFloored(mesh, -118, 34)).toBe(true);
+    expect(cellIsFloored(mesh, -118, -34)).toBe(false);
+    expect(cellIsFloored(mesh, 118, -34)).toBe(true);
+    expect(cellIsFloored(mesh, 118, 34)).toBe(false);
+  });
+
+  it('presents the same material after a half-turn, at every magnet position', () => {
+    // States the property the issue asks for directly against the solid, rather
+    // than against a second copy of the planner's arithmetic. Occupancy is read
+    // per column, so it survives whatever order the mesher triangulated in.
+    const mesh = plate(false);
+    const mismatched = magnetLattice().filter(
+      ([x, y]) => columnSignature(mesh, x, y) !== columnSignature(mesh, -x, -y)
+    );
+    expect(mismatched).toEqual([]);
+  });
+
+  it('puts every screw where the exported plate does, in the draft fast path', () => {
+    // The draft mesh and the BREP build each call the planner with their own
+    // input; a divergence there is invisible in the preview and only shows up
+    // once the plate is printed.
+    const exported = plate(false);
+    const draft = plate(true);
+    const diverged = magnetLattice().filter(
+      ([x, y]) => cellIsFloored(exported, x, y) !== cellIsFloored(draft, x, y)
+    );
+    expect(diverged).toEqual([]);
   });
 });

--- a/src/features/generation/worker/generators/baseplateScrews.test.ts
+++ b/src/features/generation/worker/generators/baseplateScrews.test.ts
@@ -13,6 +13,7 @@ import {
   screwAwareHoleRadius,
   screwFloorCandidates,
 } from './baseplateScrews';
+import { planPieceScrews } from '@/shared/generation/screwHolePlan';
 
 const COUNTERSINK: ScrewHoleParams = {
   enabled: true,
@@ -120,6 +121,91 @@ describe('resolveScrewHoles', () => {
 
   it('returns nothing for an empty plan', () => {
     expect(resolveScrewHoles([], candidates)).toEqual([]);
+  });
+});
+
+describe('resolveScrewHoles half-turn symmetry (#3698)', () => {
+  const NO_BANDS = { left: 0, right: 0, front: 0, back: 0 } as const;
+  const CELL_OPTS = { gridUnitMm: 42, fractionalEdgeX: 'end', fractionalEdgeY: 'end' } as const;
+
+  /**
+   * The composition `planBaseplateScrewHoles` performs, minus the resolved-param
+   * plumbing: an unpadded piece, so every anchor is floor-sited and every screw
+   * goes through the snap this fix governs.
+   */
+  function holesFor(gridW: number, gridD: number, screwsPerPiece: number) {
+    const params: ScrewHoleParams = { ...COUNTERSINK, screwsPerPiece };
+    return resolveScrewHoles(
+      planPieceScrews(params, {
+        widthMm: gridW * 42,
+        depthMm: gridD * 42,
+        bands: NO_BANDS,
+        floorPadProvisioned: true,
+      }),
+      screwFloorCandidates(gridW, gridD, screwAwareHoleRadius(6.5 / 2, params), { ...CELL_OPTS })
+    );
+  }
+
+  /** Every hole's half-turn image is also a hole. */
+  function isHalfTurnInvariant(holes: ReadonlyArray<{ x: number; y: number }>): boolean {
+    const key = (x: number, y: number) => `${x.toFixed(4)},${y.toFixed(4)}`;
+    const present = new Set(holes.map((h) => key(h.x, h.y)));
+    return holes.every((h) => present.has(key(-h.x, -h.y)));
+  }
+
+  it('places the eight screws of an even-celled piece symmetrically', () => {
+    // The reported case: a 12x12 plate split into four 6x6 pieces, eight screws
+    // each. Every edge midpoint falls on a grid line, so all four are exact ties.
+    const holes = holesFor(6, 6, 8);
+    expect(holes).toHaveLength(8);
+    expect(isHalfTurnInvariant(holes)).toBe(true);
+  });
+
+  it('leans the front and back edge screws to opposite sides of the centreline', () => {
+    // The defect itself: both used to take the same cell, putting every edge
+    // screw 8mm toward the same corner and leaving the set with no symmetry.
+    const holes = holesFor(6, 6, 8);
+    const halfD = (6 * 42) / 2;
+    // The edge midpoints are the only screws near the vertical centreline; the
+    // corners on the same rows sit a whole cell out.
+    const nearCentre = holes.filter((h) => Math.abs(h.x) < 21);
+    const front = nearCentre.find((h) => h.y < 0);
+    const back = nearCentre.find((h) => h.y > 0);
+    expect(front?.y).toBeCloseTo(-halfD + (21 - HOLE_OFFSET), 6);
+    expect(front?.x).toBeCloseTo(-(21 - HOLE_OFFSET), 6);
+    expect(back?.x).toBeCloseTo(21 - HOLE_OFFSET, 6);
+  });
+
+  it('holds on an odd-celled piece, where the tie is between cell centres', () => {
+    const holes = holesFor(5, 5, 8);
+    expect(holes).toHaveLength(8);
+    expect(isHalfTurnInvariant(holes)).toBe(true);
+  });
+
+  it('holds on a non-square piece', () => {
+    const holes = holesFor(6, 4, 8);
+    expect(holes).toHaveLength(8);
+    expect(isHalfTurnInvariant(holes)).toBe(true);
+  });
+
+  it('closes under the rotation at four and six screws', () => {
+    // Counts that fill whole half-turn pairs. Six is why the edge anchors are
+    // ordered b/t before r/l: the compass order would take b and r, whose
+    // partners are never filled.
+    expect(isHalfTurnInvariant(holesFor(6, 6, 4))).toBe(true);
+    expect(isHalfTurnInvariant(holesFor(6, 6, 6))).toBe(true);
+  });
+
+  it('still resolves nearest first, so a lean never beats a closer candidate', () => {
+    // Candidate order puts the tie-preferred but distant point first.
+    const holes = resolveScrewHoles(
+      [{ anchor: 'b', site: 'floor', target: [0, -42] }],
+      [
+        [-40, -13],
+        [-13, -29],
+      ]
+    );
+    expect(holes).toEqual([{ x: -13, y: -29, site: 'floor' }]);
   });
 });
 

--- a/src/features/generation/worker/generators/baseplateScrews.ts
+++ b/src/features/generation/worker/generators/baseplateScrews.ts
@@ -78,18 +78,12 @@ export function screwFloorCandidates(
 
 /**
  * Squared-mm slack within which two candidates count as EQUIDISTANT, so the
- * directional preference below decides between them instead of arrival order.
+ * lean decides between them rather than arrival order. Detecting the tie is the
+ * point: the two magnets flanking a centreline are equidistant by construction,
+ * so a strict `<` never reaches the lean at all.
  *
- * Detecting the tie is the point, not tolerating error: the two magnets
- * flanking a centreline are equidistant by construction, so in exact arithmetic
- * this is an exact tie, and a bare `<` would hand it to whichever candidate the
- * lattice happened to emit first.
- *
- * Note the units before re-deriving the scale: this is compared against a
- * SQUARED distance, so the positional slack it admits is `eps / 2r`, not
- * `sqrt(eps)`. At the ~128mm² an edge anchor sees (r ~ 11.3mm) that is about
- * 0.04 nanometres, far below anything the lattice can express, which is what
- * keeps the window from swallowing a genuinely nearer candidate.
+ * Compared against a SQUARED distance, so the slack it admits is `eps / 2r`,
+ * not `sqrt(eps)`: ~0.04nm at an edge anchor's ~128mm², far under the lattice.
  */
 const SNAP_TIE_EPSILON_MM2 = 1e-6;
 
@@ -100,12 +94,9 @@ const SNAP_TIE_EPSILON_MM2 = 1e-6;
  * ideal target, and is snapped to the nearest candidate: the single rule that
  * stops each layer inventing its own notion of "the corner cell".
  *
- * Nearest is not enough on its own. Magnets sit at `cellCenter ± HOLE_OFFSET`,
- * so nothing is ever ON a centreline and an edge-midpoint anchor ties exactly
- * between the two positions flanking it; taking the first such candidate leans
- * every edge screw toward whichever corner `forEachCell` emits first (#3698).
- * Ties therefore go to {@link screwSnapPreference}, which leans opposite
- * anchors opposite ways so the resolved set is invariant under a half-turn.
+ * Nearest alone is ambiguous: an edge-midpoint anchor ties exactly between the
+ * two magnets flanking it, and taking the first leans every edge screw toward
+ * one corner (#3698). Ties go to {@link screwSnapPreference}.
  *
  * Candidates are consumed as they are taken. Without that, every anchor on a
  * piece small enough to offer one magnet position would snap to the SAME point

--- a/src/features/generation/worker/generators/baseplateScrews.ts
+++ b/src/features/generation/worker/generators/baseplateScrews.ts
@@ -26,6 +26,7 @@ import {
   planPieceScrews,
   resolveScrewHeadDiameter,
   screwCutDepths,
+  screwSnapPreference,
   type ScrewSite,
   type ScrewSlot,
 } from '@/shared/generation/screwHolePlan';
@@ -76,11 +77,29 @@ export function screwFloorCandidates(
 }
 
 /**
+ * Squared-mm slack below which two candidates count as the same distance.
+ *
+ * Guards float noise only: at the ~130mm² separations an edge anchor sees, this
+ * is a few nanometres of position, far under any distinction the lattice can
+ * express. It has to exist because the tie it detects is EXACT in exact
+ * arithmetic (the two magnets flanking a centreline are equidistant by
+ * construction), so `<` alone would resolve it by accumulated rounding.
+ */
+const SNAP_TIE_EPSILON_MM2 = 1e-6;
+
+/**
  * Turn planned slots into absolute positions.
  *
  * A margin slot already carries its exact centre. A floor slot carries only an
  * ideal target, and is snapped to the nearest candidate: the single rule that
  * stops each layer inventing its own notion of "the corner cell".
+ *
+ * Nearest is not enough on its own. Magnets sit at `cellCenter ± HOLE_OFFSET`,
+ * so nothing is ever ON a centreline and an edge-midpoint anchor ties exactly
+ * between the two positions flanking it; taking the first such candidate leans
+ * every edge screw toward whichever corner `forEachCell` emits first (#3698).
+ * Ties therefore go to {@link screwSnapPreference}, which leans opposite
+ * anchors opposite ways so the resolved set is invariant under a half-turn.
  *
  * Candidates are consumed as they are taken. Without that, every anchor on a
  * piece small enough to offer one magnet position would snap to the SAME point
@@ -99,14 +118,20 @@ export function resolveScrewHoles(
       continue;
     }
 
+    const [leanX, leanY] = screwSnapPreference(slot.anchor);
     let bestIndex = -1;
     let bestDist = Number.POSITIVE_INFINITY;
+    let bestLean = Number.NEGATIVE_INFINITY;
     for (let i = 0; i < available.length; i++) {
       const dx = available[i][0] - slot.target[0];
       const dy = available[i][1] - slot.target[1];
       const d = dx * dx + dy * dy;
-      if (d < bestDist) {
-        bestDist = d;
+      if (d > bestDist + SNAP_TIE_EPSILON_MM2) continue;
+
+      const lean = dx * leanX + dy * leanY;
+      if (d < bestDist - SNAP_TIE_EPSILON_MM2 || lean > bestLean) {
+        bestDist = Math.min(bestDist, d);
+        bestLean = lean;
         bestIndex = i;
       }
     }

--- a/src/features/generation/worker/generators/baseplateScrews.ts
+++ b/src/features/generation/worker/generators/baseplateScrews.ts
@@ -77,13 +77,19 @@ export function screwFloorCandidates(
 }
 
 /**
- * Squared-mm slack below which two candidates count as the same distance.
+ * Squared-mm slack within which two candidates count as EQUIDISTANT, so the
+ * directional preference below decides between them instead of arrival order.
  *
- * Guards float noise only: at the ~130mm² separations an edge anchor sees, this
- * is a few nanometres of position, far under any distinction the lattice can
- * express. It has to exist because the tie it detects is EXACT in exact
- * arithmetic (the two magnets flanking a centreline are equidistant by
- * construction), so `<` alone would resolve it by accumulated rounding.
+ * Detecting the tie is the point, not tolerating error: the two magnets
+ * flanking a centreline are equidistant by construction, so in exact arithmetic
+ * this is an exact tie, and a bare `<` would hand it to whichever candidate the
+ * lattice happened to emit first.
+ *
+ * Note the units before re-deriving the scale: this is compared against a
+ * SQUARED distance, so the positional slack it admits is `eps / 2r`, not
+ * `sqrt(eps)`. At the ~128mm² an edge anchor sees (r ~ 11.3mm) that is about
+ * 0.04 nanometres, far below anything the lattice can express, which is what
+ * keeps the window from swallowing a genuinely nearer candidate.
  */
 const SNAP_TIE_EPSILON_MM2 = 1e-6;
 

--- a/src/shared/generation/screwHolePlan.test.ts
+++ b/src/shared/generation/screwHolePlan.test.ts
@@ -11,6 +11,8 @@ import {
   resolveScrewHeadDiameter,
   screwHeadRecessDepth,
   screwPadThicknessMm,
+  screwSnapPreference,
+  type ScrewAnchor,
   type ScrewPieceInput,
 } from './screwHolePlan';
 
@@ -158,6 +160,74 @@ describe('minBandForHead', () => {
   });
 });
 
+describe('screwSnapPreference', () => {
+  /** The anchor a half-turn maps each anchor onto. */
+  const HALF_TURN: Record<ScrewAnchor, ScrewAnchor> = {
+    bl: 'tr',
+    tr: 'bl',
+    br: 'tl',
+    tl: 'br',
+    b: 't',
+    t: 'b',
+    l: 'r',
+    r: 'l',
+  };
+
+  it('gives every anchor the exact opposite lean to its half-turn partner', () => {
+    // This is the whole property: a tie resolved by lean then resolves to the
+    // mirrored point for the partner, so the set closes under the rotation.
+    for (const anchor of SCREW_ANCHORS) {
+      const [x, y] = screwSnapPreference(anchor);
+      const [px, py] = screwSnapPreference(HALF_TURN[anchor]);
+      // Summed rather than negated: -0 is not Object.is-equal to 0, which is
+      // what a deep-equal against [-x, -y] would trip over on a zero component.
+      expect(px + x).toBe(0);
+      expect(py + y).toBe(0);
+    }
+  });
+
+  it('leans an edge midpoint along the axis it does not name', () => {
+    // 'b' is fixed in y and free in x, so the lean has to act on x or it can
+    // never break the tie it exists for.
+    expect(screwSnapPreference('b')).toEqual([-1, 0]);
+    expect(screwSnapPreference('t')).toEqual([1, 0]);
+    expect(screwSnapPreference('l')).toEqual([0, 1]);
+    expect(screwSnapPreference('r')).toEqual([0, -1]);
+  });
+
+  it('leans a corner outboard along its own diagonal', () => {
+    expect(screwSnapPreference('bl')).toEqual([-1, -1]);
+    expect(screwSnapPreference('tr')).toEqual([1, 1]);
+  });
+
+  it('never returns a negative zero, which would not compare equal to its mirror', () => {
+    for (const anchor of SCREW_ANCHORS) {
+      for (const component of screwSnapPreference(anchor)) {
+        expect(Object.is(component, -0)).toBe(false);
+      }
+    }
+  });
+});
+
+describe('SCREW_ANCHORS', () => {
+  it('fills half-turn pairs, so an even count always closes under the rotation', () => {
+    const HALF_TURN: Record<ScrewAnchor, ScrewAnchor> = {
+      bl: 'tr',
+      tr: 'bl',
+      br: 'tl',
+      tl: 'br',
+      b: 't',
+      t: 'b',
+      l: 'r',
+      r: 'l',
+    };
+    for (let count = 2; count <= SCREW_ANCHORS.length; count += 2) {
+      const filled = new Set<ScrewAnchor>(SCREW_ANCHORS.slice(0, count));
+      for (const anchor of filled) expect(filled.has(HALF_TURN[anchor])).toBe(true);
+    }
+  });
+});
+
 describe('planPieceScrews', () => {
   it('sites four corner screws in the margin when the bands are wide enough', () => {
     const slots = planPieceScrews(
@@ -166,7 +236,7 @@ describe('planPieceScrews', () => {
     );
     expect(slots).toHaveLength(4);
     expect(slots.every((s) => s.site === 'margin')).toBe(true);
-    expect(slots.map((s) => s.anchor)).toEqual(['bl', 'br', 'tr', 'tl']);
+    expect(slots.map((s) => s.anchor)).toEqual(['bl', 'tr', 'br', 'tl']);
   });
 
   it('falls back to the floor when no band can host the head', () => {
@@ -217,9 +287,11 @@ describe('planPieceScrews', () => {
     expect(new Set(anchors).size).toBe(anchors.length);
   });
 
-  it('extends to edge midpoints for counts above four', () => {
+  it('extends to edge midpoints for counts above four, a half-turn pair at a time', () => {
+    // b before t before r/l, not the compass order: six screws then close under
+    // the 180° rotation instead of taking one anchor whose partner never fills.
     const slots = planPieceScrews({ ...COUNTERSINK, screwsPerPiece: 6 }, piece());
-    expect(slots.map((s) => s.anchor)).toEqual(['bl', 'br', 'tr', 'tl', 'b', 'r']);
+    expect(slots.map((s) => s.anchor)).toEqual(['bl', 'tr', 'br', 'tl', 'b', 't']);
   });
 
   it('caps a count beyond the anchor list rather than stacking holes', () => {

--- a/src/shared/generation/screwHolePlan.ts
+++ b/src/shared/generation/screwHolePlan.ts
@@ -56,12 +56,10 @@ export type ScrewSite = 'margin' | 'floor';
  * would break the rotated pair's shared fingerprint.
  *
  * WITHIN each block the order is by half-turn pair, not by the compass: bl/tr
- * before br/tl, and b/t before r/l. Every even count then closes under the same
- * rotation instead of taking an anchor whose partner is never filled, which is
- * what left the edge screws with no symmetry at all (#3698). It also picks the
- * better two-screw layout for free: a diagonal pair resists the pivot that two
- * screws sharing an edge allow. Odd counts cannot close (the extra screw has no
- * partner) and are left asymmetric rather than pretended otherwise.
+ * before br/tl, and b/t before r/l, so every even count closes under that same
+ * rotation (#3698). It also picks the better two-screw layout for free, since a
+ * diagonal pair resists the pivot that two screws sharing an edge allow. Odd
+ * counts cannot close and are left asymmetric rather than pretended otherwise.
  */
 export const SCREW_ANCHORS = ['bl', 'tr', 'br', 'tl', 'b', 't', 'r', 'l'] as const;
 export type ScrewAnchor = (typeof SCREW_ANCHORS)[number];
@@ -342,26 +340,14 @@ function anchorCornerRadius(anchor: ScrewAnchor, radii: ScrewCornerRadii | undef
 }
 
 /**
- * Which way a floor snap leans when two candidates are equidistant from an
- * anchor's ideal target.
+ * Which way a floor snap leans when two candidates are equidistant (#3698).
  *
- * A magnet sits at `cellCenter ± HOLE_OFFSET`, so no candidate ever lands on a
- * piece's centreline and an edge-midpoint anchor is ALWAYS an exact tie between
- * the two positions flanking it. Left to the candidate list's order, every such
- * anchor takes whichever cell `forEachCell` happened to emit first, which drags
- * all four edge screws toward the same corner and leaves the set invariant
- * under no symmetry at all (#3698).
- *
- * Mirror symmetry is not on the table: one screw cannot straddle a centreline,
- * and there is never a candidate on it to sit at. So the lean is chosen to make
- * the SET invariant under a HALF-TURN, which is the symmetry a rectangular
- * piece can actually have, and the one `preferIdenticalPieces` already relies
- * on when it places a piece 180° rotated. Opposite anchors therefore lean
- * opposite ways, and a corner leans outboard along its own diagonal, which its
- * half-turn partner mirrors.
- *
- * Returned as a direction rather than a chosen point because the candidate set
- * is the geometry layer's to know; this states only which way to break a tie.
+ * Mirror symmetry is not on the table: a magnet sits at `cellCenter ±
+ * HOLE_OFFSET`, so nothing ever lands on a centreline for one screw to sit on.
+ * The lean instead makes the SET invariant under a HALF-TURN, the symmetry a
+ * rectangular piece can have and the one `preferIdenticalPieces` already relies
+ * on. So opposite anchors lean opposite ways, and a corner leans outboard along
+ * its own diagonal, which its half-turn partner mirrors.
  */
 export function screwSnapPreference(anchor: ScrewAnchor): readonly [number, number] {
   const [sx, sy] = anchorSigns(anchor);

--- a/src/shared/generation/screwHolePlan.ts
+++ b/src/shared/generation/screwHolePlan.ts
@@ -54,8 +54,16 @@ export type ScrewSite = 'margin' | 'floor';
  * `preferIdenticalPieces` a piece may be placed 180° rotated, which maps
  * bl↔tr and br↔tl; a full set is invariant under that, a partial one is not and
  * would break the rotated pair's shared fingerprint.
+ *
+ * WITHIN each block the order is by half-turn pair, not by the compass: bl/tr
+ * before br/tl, and b/t before r/l. Every even count then closes under the same
+ * rotation instead of taking an anchor whose partner is never filled, which is
+ * what left the edge screws with no symmetry at all (#3698). It also picks the
+ * better two-screw layout for free: a diagonal pair resists the pivot that two
+ * screws sharing an edge allow. Odd counts cannot close (the extra screw has no
+ * partner) and are left asymmetric rather than pretended otherwise.
  */
-export const SCREW_ANCHORS = ['bl', 'br', 'tr', 'tl', 'b', 'r', 't', 'l'] as const;
+export const SCREW_ANCHORS = ['bl', 'tr', 'br', 'tl', 'b', 't', 'r', 'l'] as const;
 export type ScrewAnchor = (typeof SCREW_ANCHORS)[number];
 
 export interface ScrewSlot {
@@ -331,6 +339,38 @@ function anchorCornerRadius(anchor: ScrewAnchor, radii: ScrewCornerRadii | undef
   if (sx === 0 || sy === 0) return Math.max(radii.tl, radii.tr, radii.bl, radii.br);
   if (sx < 0) return sy < 0 ? radii.bl : radii.tl;
   return sy < 0 ? radii.br : radii.tr;
+}
+
+/**
+ * Which way a floor snap leans when two candidates are equidistant from an
+ * anchor's ideal target.
+ *
+ * A magnet sits at `cellCenter ± HOLE_OFFSET`, so no candidate ever lands on a
+ * piece's centreline and an edge-midpoint anchor is ALWAYS an exact tie between
+ * the two positions flanking it. Left to the candidate list's order, every such
+ * anchor takes whichever cell `forEachCell` happened to emit first, which drags
+ * all four edge screws toward the same corner and leaves the set invariant
+ * under no symmetry at all (#3698).
+ *
+ * Mirror symmetry is not on the table: one screw cannot straddle a centreline,
+ * and there is never a candidate on it to sit at. So the lean is chosen to make
+ * the SET invariant under a HALF-TURN, which is the symmetry a rectangular
+ * piece can actually have, and the one `preferIdenticalPieces` already relies
+ * on when it places a piece 180° rotated. Opposite anchors therefore lean
+ * opposite ways, and a corner leans outboard along its own diagonal, which its
+ * half-turn partner mirrors.
+ *
+ * Returned as a direction rather than a chosen point because the candidate set
+ * is the geometry layer's to know; this states only which way to break a tie.
+ */
+export function screwSnapPreference(anchor: ScrewAnchor): readonly [number, number] {
+  const [sx, sy] = anchorSigns(anchor);
+  // An edge midpoint is free along the axis it does not name. Turning the
+  // anchor's own direction a quarter turn selects that axis and hands 'b'/'t'
+  // (and 'l'/'r') the opposing leans a half-turn demands. A corner names both
+  // axes, so it keeps its own direction.
+  if (sx === 0 || sy === 0) return [sy, sx === 0 ? 0 : -sx];
+  return [sx, sy];
 }
 
 /** The ideal point for an anchor, used as the floor snap target. */


### PR DESCRIPTION
Closes #3698

## Problem

A 12x12 plate split into four 6x6 pieces, eight screws each, put its edge-midpoint screws off to one side. The reporter noticed the front and back edge screws landing in the same column rather than reading as a symmetric pattern.

Magnet positions sit at `cellCenter ± HOLE_OFFSET`, so **no candidate position ever lands on a piece's centreline**. An edge-midpoint anchor targets the exact middle of its edge, which makes it an exact tie between the two positions flanking it. `resolveScrewHoles` compared distances with a strict `<`, so every tie resolved to whichever cell `forEachCell` happened to emit first (column-major, left to right, front to back). All four edge screws therefore leaned toward the same corner, and the resolved set was invariant under no symmetry at all.

## Fix

Mirror symmetry is unreachable here: one screw cannot straddle a centreline, and there is no candidate sitting on it. The achievable symmetry is a **half-turn**, which is also the one `preferIdenticalPieces` already relies on when it places a piece 180 degrees rotated.

- `screwSnapPreference(anchor)` states which way a tie leans, giving opposite anchors opposite directions. The front edge takes the position left of centre, the back edge takes the one right of centre; likewise left and right.
- `SCREW_ANCHORS` is reordered to fill half-turn pairs (`bl`/`tr` before `br`/`tl`, `b`/`t` before `r`/`l`) so every even count closes under the rotation instead of taking an anchor whose partner is never filled. This also fixes the two-screw layout, which previously put both screws on one edge and let the piece pivot about it.

Margin-sited screws already sat exactly on the edge midpoint and are untouched. Only floor-sited screws, which is the reporter's unpadded plate, were affected.

This is unconditional. Screws mount a plate into a drawer rather than into another printed part, so a moved hole breaks no mating fit (unlike `magnetAnchor`, which carries a legacy mode precisely because bins must still seat).

## Verification

Stated against the solid rather than against a second copy of the planner's arithmetic:

- **Which cell took the screw**, probed via a *sibling* magnet position. The hole itself is void whether or not the cell has a pad, and so is a cell with no screw, so only a sibling separates the two.
- **Half-turn invariance across the whole magnet lattice**, comparing per-column occupancy so the result survives whatever order the mesher triangulated in.
- **Draft/export parity**, since `baseplateDirectMesh` and the BREP build each call the planner with their own input, and a divergence there is invisible in the preview.

Neutralizing the lean fails 3 of the 4 geometry tests and 5 of the plan-level tests. The parity test correctly passes either way, since it checks agreement rather than correctness.

Full baseplate + screw suite: 416 tests across 41 files, green. Typecheck and lint clean.

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

