### PR TITLE
fix(bin-designer): make detachable feet press on by hand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,16 @@ tasks, over CLAUDE.md or a README, which are read far more often.
 | `useShallow` for multi-select | `var`, `==`               |
 | `@/` path alias               | Non-null assertions (`!`) |
 
+### Comments
+
+One test, applied per comment: **could a capable model derive this by reading
+the code?** If yes, delete it. What survives is the hidden constraint, the
+subtle invariant, the workaround — never history, measurements, or a restatement
+of the line below.
+
+Do NOT match the comment density of surrounding code. Files still carrying dense
+blocks predate the audit that established this test, and are not the standard.
+
 ## Core Architecture
 
 Undo/redo (max 100) lives in `src/core/cqrs/undo/historyStore.ts`, captured automatically by the CQRS undo middleware.

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -79,7 +79,7 @@ const VALID_FOOT_LATTICES = ['grid', 'half'] as const;
 const VALID_LIGHTWEIGHT_MODES = ['interior', 'underside'] as const;
 // Mirrors `FEET_MODES` and `DETACHABLE_PIN_DIAMETERS_MM` in the same file.
 const VALID_FEET_MODES = ['integral', 'detachable'] as const;
-const VALID_PIN_DIAMETERS = [2.9, 3] as const;
+const VALID_PIN_DIAMETERS = [2.7, 2.8, 2.9, 3] as const;
 const VALID_LABEL_TAB_SUPPORTS = ['bracket', 'solid', 'fillet'] as const;
 // Mirrors `LabelTabMode` in `src/features/bin-designer/types/index.ts`.
 const VALID_LABEL_TAB_MODES = ['text', 'socket'] as const;

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -13,6 +13,7 @@ import { MAX_CUTOUT_CORNER_RADIUS } from '@/shared/utils/wallCutoutPosition';
 import { validateBinParams } from '../utils/validation';
 import { makeUniformLipCells } from '../types/featureColors';
 import { DEFAULT_SLIDE_CONFIG } from '../types/slide';
+import { DEFAULT_DETACHABLE_PIN_DIAMETER_MM } from '../types/base';
 import { expectOk } from '@/test/testUtils';
 import type { BinParams } from '../types';
 
@@ -677,7 +678,7 @@ describe('migrateParams', () => {
     const result = migrateParams({
       base: { ...DEFAULT_BIN_PARAMS.base, feetPinDiameter: 5 },
     });
-    expect(result.base.feetPinDiameter).toBe(3);
+    expect(result.base.feetPinDiameter).toBe(DEFAULT_DETACHABLE_PIN_DIAMETER_MM);
   });
 
   it('keeps a valid pin diameter and an absent one alone', () => {

--- a/src/features/bin-designer/types/base.test.ts
+++ b/src/features/bin-designer/types/base.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DETACHABLE_PIN_DIAMETER_MM,
+  DETACHABLE_PIN_DIAMETERS_MM,
+  DETACHABLE_PIN_HOLE_DIAMETER_MM,
+  DETACHABLE_PIN_LEAD_IN_MM,
+  DETACHABLE_PIN_MEMBRANE_MM,
+  DETACHABLE_PIN_MIN_ENGAGEMENT_MM,
+  DETACHABLE_PIN_RIDGE_STEP_MM,
+  DETACHABLE_PIN_TARGET_ENGAGEMENT_MM,
+  detachableFeetFitFloor,
+  detachableFeetFloorMm,
+  detachablePinEngagementMm,
+} from './base';
+
+describe('detachable pin sizes', () => {
+  it('offers nothing wider than the hole it has to enter', () => {
+    for (const diameter of DETACHABLE_PIN_DIAMETERS_MM) {
+      expect(diameter).toBeLessThanOrEqual(DETACHABLE_PIN_HOLE_DIAMETER_MM);
+    }
+  });
+
+  it('keeps the default off the tight end, where a printer has no room to be off', () => {
+    expect(DETACHABLE_PIN_DIAMETERS_MM).toContain(DEFAULT_DETACHABLE_PIN_DIAMETER_MM);
+    expect(DEFAULT_DETACHABLE_PIN_DIAMETER_MM).toBeLessThan(
+      Math.max(...DETACHABLE_PIN_DIAMETERS_MM)
+    );
+    expect(DEFAULT_DETACHABLE_PIN_DIAMETER_MM).toBeGreaterThan(
+      Math.min(...DETACHABLE_PIN_DIAMETERS_MM)
+    );
+  });
+
+  it('leaves every pin solid under its ridges and its taper', () => {
+    const narrowest = Math.min(...DETACHABLE_PIN_DIAMETERS_MM);
+    const tipDiameter =
+      narrowest - 2 * DETACHABLE_PIN_RIDGE_STEP_MM - 2 * DETACHABLE_PIN_LEAD_IN_MM;
+    expect(tipDiameter).toBeGreaterThan(0);
+  });
+});
+
+describe('detachable pin engagement', () => {
+  it('spends the floor on the pin and keeps the membrane back', () => {
+    expect(detachablePinEngagementMm(1.2)).toBeCloseTo(1.2 - DETACHABLE_PIN_MEMBRANE_MM, 6);
+  });
+
+  it('greys the toggle exactly where the body stops meeting the feet', () => {
+    expect(
+      detachableFeetFitFloor(DETACHABLE_PIN_MEMBRANE_MM + DETACHABLE_PIN_MIN_ENGAGEMENT_MM)
+    ).toBe(true);
+    expect(
+      detachableFeetFitFloor(DETACHABLE_PIN_MEMBRANE_MM + DETACHABLE_PIN_MIN_ENGAGEMENT_MM - 0.01)
+    ).toBe(false);
+  });
+
+  it('gives every allowed wall the same engagement, so the fit never depends on it', () => {
+    for (const wall of [1, 1.2, 1.6, 2, 2.4]) {
+      expect(detachablePinEngagementMm(detachableFeetFloorMm(wall))).toBeGreaterThanOrEqual(
+        DETACHABLE_PIN_TARGET_ENGAGEMENT_MM
+      );
+    }
+    // A thicker wall keeps its own floor rather than being thinned to the target.
+    expect(detachableFeetFloorMm(4)).toBe(4);
+  });
+});

--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -251,11 +251,9 @@ export function hasDetachableFeet(base: {
 }
 
 /**
- * True when the floor is thick enough for a pin that holds.
- *
- * The holes are blind, so a pin gets `wallThickness` minus the membrane, and
- * three of the selectable wall thicknesses (0.4, 0.6, 0.8) leave less than
- * {@link DETACHABLE_PIN_MIN_ENGAGEMENT_MM}.
+ * True when the wall is thick enough for the feet to seat. Not about pin depth —
+ * {@link detachableFeetFloorMm} fixes that. Below 1mm the body's floor grows
+ * DOWNWARD past Z=0, the plane the feet's top face assumes, so they stand proud.
  *
  * ADVISORY ONLY: it greys the toggle, and no geometry path consults it. The
  * builder clamps the pin instead, so "does this bin have feet" has exactly one
@@ -268,23 +266,15 @@ export function detachableFeetFitFloor(wallThicknessMm: number): boolean {
 }
 
 /**
- * Pin diameters offered for the press fit, in mm.
- *
- * The hole is always {@link DETACHABLE_PIN_HOLE_DIAMETER_MM}, so this is an
- * interference choice rather than a dimension: which one holds depends on the
- * printer and the filament, and either side of the pair the pin falls out or
- * will not go on.
- *
- * Sized against the joint rather than convention. A pin is a LOCATING feature
- * here: the holes are blind, so engagement is `wallThickness` minus the
- * membrane — 0.8mm on a stock floor — and no diameter makes a joint that
- * shallow hold by depth. All a wider pin buys is a hole that eats the arm it
- * sits in; 3mm leaves 4.7mm of wall each side of a 12.45mm arm.
+ * Pin diameters offered for the press fit, in mm — each the pin's WIDEST
+ * diameter, which is what decides whether it enters
+ * {@link DETACHABLE_PIN_HOLE_DIAMETER_MM}. FDM prints a small hole undersize and
+ * a small pin oversize, so the printed fit runs tighter than these figures.
  */
-export const DETACHABLE_PIN_DIAMETERS_MM = [2.9, 3] as const;
+export const DETACHABLE_PIN_DIAMETERS_MM = [2.7, 2.8, 2.9, 3] as const;
 
 /** Applied when a BaseConfig's `feetPinDiameter` is missing. */
-export const DEFAULT_DETACHABLE_PIN_DIAMETER_MM = 3;
+export const DEFAULT_DETACHABLE_PIN_DIAMETER_MM = 2.8;
 
 /** Diameter of the pin holes cut into the underside of the bin floor, in mm. */
 export const DETACHABLE_PIN_HOLE_DIAMETER_MM = 3;
@@ -316,20 +306,38 @@ export function detachablePinEngagementMm(floorThicknessMm: number): number {
   return floorThicknessMm - DETACHABLE_PIN_MEMBRANE_MM;
 }
 
+/** Engagement a detachable-feet bin's floor is sized to give, in mm. */
+export const DETACHABLE_PIN_TARGET_ENGAGEMENT_MM = 2;
+
 /**
- * How much the pin's diameter grows and shrinks again, per layer, in mm.
- *
- * The pin is not a cylinder: stepping its diameter up and back down every layer
- * lets it pop home and stay there without glue. That makes the ridge pitch a
- * function of the SLICER's layer height, which the worker deliberately does not
- * see — so this assumes {@link DETACHABLE_PIN_ASSUMED_LAYER_MM} and the fit
- * degrades on any other layer height rather than failing visibly. Stated here
- * so the assumption is one constant rather than an unwritten one.
+ * Floor thickness a bin gets once its feet come off, in mm. The one mode where
+ * the floor has a job the walls do not share: it is the whole depth a blind pin
+ * hole has.
+ */
+export function detachableFeetFloorMm(wallThicknessMm: number): number {
+  return Math.max(
+    wallThicknessMm,
+    DETACHABLE_PIN_TARGET_ENGAGEMENT_MM + DETACHABLE_PIN_MEMBRANE_MM
+  );
+}
+
+/**
+ * How far the pin is relieved between ridge crests, in mm. Steps INWARD from the
+ * selected diameter, so {@link DETACHABLE_PIN_DIAMETERS_MM} stays the widest
+ * point. Ridge pitch assumes {@link DETACHABLE_PIN_ASSUMED_LAYER_MM}; other
+ * layer heights degrade the fit rather than failing visibly.
  */
 export const DETACHABLE_PIN_RIDGE_STEP_MM = 0.2;
 
 /** The layer height {@link DETACHABLE_PIN_RIDGE_STEP_MM} is pitched for. */
 export const DETACHABLE_PIN_ASSUMED_LAYER_MM = 0.2;
+
+/**
+ * Length of the tapered lead-in at a pin's tip, in mm. An L foot's three pins
+ * must enter at once; with flat tips the first to touch down fixes the foot and
+ * the other two land on floor.
+ */
+export const DETACHABLE_PIN_LEAD_IN_MM = 0.4;
 
 /**
  * Largest gap allowed between adjacent feet, in mm.

--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -306,7 +306,6 @@ export function detachablePinEngagementMm(floorThicknessMm: number): number {
   return floorThicknessMm - DETACHABLE_PIN_MEMBRANE_MM;
 }
 
-/** Engagement a detachable-feet bin's floor is sized to give, in mm. */
 export const DETACHABLE_PIN_TARGET_ENGAGEMENT_MM = 2;
 
 /**

--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -878,11 +878,11 @@ describe('printEstimates', () => {
    */
   describe('detachable feet — measured ground truth (±5%)', () => {
     const ASSEMBLY_MM3: ReadonlyArray<readonly [number, number, number]> = [
-      [1, 1, 8256],
-      [3, 2, 31088],
-      [2, 4, 39589],
-      [6, 3, 67510],
-      [1, 4, 22736],
+      [1, 1, 10065],
+      [3, 2, 43006],
+      [2, 4, 55575],
+      [6, 3, 104226],
+      [1, 4, 30448],
     ];
 
     for (const [w, d, truth] of ASSEMBLY_MM3) {

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -11,7 +11,11 @@
  */
 
 import type { BinParams, LabelTabSupport, WallPatternType } from '@/features/bin-designer/types';
-import { isSocketlessBase, isUndersideRelief } from '@/features/bin-designer/types/base';
+import {
+  detachableFeetFloorMm,
+  isSocketlessBase,
+  isUndersideRelief,
+} from '@/features/bin-designer/types/base';
 import { baseWallHeight } from './binDimensions';
 import { DEFAULT_PATTERN_SCALE } from '@/features/bin-designer/types';
 import { GRIDFINITY, STYLE_WALL_THICKNESS } from '@/features/bin-designer/constants/gridfinity';
@@ -214,6 +218,13 @@ function computeBinVolume(params: BinParams): number {
       params.gridUnitMm,
       gridUnitMmY
     );
+    // The thicker floor, or the reported saving counts material the bin gets
+    // back. From `params.wallThickness` because that is what the pipeline
+    // resolves the floor from; `wallThickness` above is a style constant.
+    volume +=
+      Math.max(0, outerW - 2 * wallThickness) *
+      Math.max(0, outerD - 2 * wallThickness) *
+      (detachableFeetFloorMm(params.wallThickness) - params.wallThickness);
   }
 
   // A base-only bin IS feet + floor slab + an optional lip, which is exactly

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -191,7 +191,12 @@ export function buildBinBox(
    * (and lowers the floor footprint) without touching the base sockets, so the
    * overhang region ends up with a flat bottom. Suppressed for polygon masks.
    */
-  overhang?: ResolvedOverhang
+  overhang?: ResolvedOverhang,
+  /**
+   * Interior floor thickness (mm) when it exceeds `wallThickness`. Applied after
+   * the body is built, so all five hollowing paths get it from one place.
+   */
+  floorThickness?: number
 ): Shape3D {
   const polygon = isPartialMask(cellMask);
   const ov = polygon ? undefined : overhang;
@@ -214,7 +219,10 @@ export function buildBinBox(
     quantize(cutoutTopOffset),
     polygon ? hashMask(cellMask) : 'rect',
     useMultiCavity ? (compartmentCavityKey ?? 'comp') : 'none',
-    ov ? overhangKey(ov) : '0'
+    ov ? overhangKey(ov) : '0',
+    ...(floorThickness !== undefined && floorThickness > wallThickness
+      ? [`floor${quantize(floorThickness)}`]
+      : [])
   );
   const cached = getBoxCache(boxKey);
   if (cached) {
@@ -271,12 +279,32 @@ export function buildBinBox(
     ? buildMaskHoleDrawings(cellMask, gridUnitMm, CLEARANCE / 2 + wallThickness)
     : [];
 
+  const raisesFloor = !solid && floorThickness !== undefined && floorThickness > wallThickness;
+
   return withScope((scope: DisposalScope) => {
     const rawBox = sketch(makeFootprint()).extrude(wallHeight);
     // Punch O-shape holes through the outer extrusion. When there are no
     // holes this is a no-op and returns the same shape. `subtractHolesFromSolid`
     // already registers intermediates with the scope via `scope.register`.
     const box = subtractHolesFromSolid(scope, rawBox, outerHoleDrawings, wallHeight);
+
+    /**
+     * The slab overlaps the existing floor top by COPLANAR_MARGIN — merely
+     * meeting that face fuses non-manifold.
+     */
+    const finish = (shape: Shape3D): Shape3D => {
+      if (!raisesFloor) return setBoxCache(boxKey, shape);
+      const slab = scope.register(
+        sketch(makeInnerFootprint(), 'XY', wallThickness - COPLANAR_MARGIN).extrude(
+          floorThickness - wallThickness + COPLANAR_MARGIN
+        )
+      );
+      const fused = unwrap(fuse(shape as ValidSolid, slab as ValidSolid));
+      // Registering the cached shape would queue a delete on what the cache
+      // hands out.
+      if (fused !== shape) scope.register(shape);
+      return setBoxCache(boxKey, fused);
+    };
 
     // Solid mode: return the raw extrusion, optionally with lowered interior fill
     if (solid) {
@@ -300,7 +328,7 @@ export function buildBinBox(
           const fillHeight = wallHeight - cutoutTopOffset;
           if (cutoutTopOffset <= 0 || fillHeight <= 0) {
             scope.register(box); // unused on the taper path
-            return setBoxCache(boxKey, unwrap(clone(outer)));
+            return finish(unwrap(clone(outer)));
           }
           // The recess spans fillHeight→past the rim. Above the band the wall is
           // prismatic, so a rim-sized inner footprint is exact there; a recess
@@ -335,7 +363,7 @@ export function buildBinBox(
               : rawRecess;
           const body = unwrap(cut(outer as ValidSolid, recess as ValidSolid));
           scope.register(box); // unused on the taper path
-          return setBoxCache(boxKey, body);
+          return finish(body);
         } catch (e: unknown) {
           // Mirror the hollow taper branch: never lose the bin, but surface the
           // regression instead of silently shipping an untapered body.
@@ -364,7 +392,7 @@ export function buildBinBox(
             // Narrow-feature polygon or degenerate inner offset — fall back
             // to the raw solid box so generation never crashes in
             // cutoutTopOffset mode. Mirrors the non-solid polygon branch.
-            return setBoxCache(boxKey, box);
+            return finish(box);
           }
         } else {
           // Rectangular path — brepjs shell is reliable on convex perimeters.
@@ -384,7 +412,7 @@ export function buildBinBox(
         // Guard: if fillHeight or inner dimensions are non-positive, the interior fill
         // would produce degenerate geometry that crashes WASM. Return hollow walls only.
         if (fillHeight <= 0 || (!polygon && (innerW <= 0 || innerD <= 0))) {
-          return setBoxCache(boxKey, hollowWalls);
+          return finish(hollowWalls);
         }
 
         // For polygon masks the offset can collapse on narrow features or
@@ -398,15 +426,15 @@ export function buildBinBox(
             subtractHolesFromSolid(scope, rawFill, innerHoleDrawings, fillHeight)
           );
         } catch {
-          return setBoxCache(boxKey, hollowWalls);
+          return finish(hollowWalls);
         }
         scope.register(hollowWalls); // consumed by fuse
 
         // Combine walls with lowered interior fill
-        return setBoxCache(boxKey, unwrap(fuse(hollowWalls, innerFill)));
+        return finish(unwrap(fuse(hollowWalls, innerFill)));
       }
       // Standard solid mode: full solid block — box goes to cache, NOT registered
-      return setBoxCache(boxKey, box);
+      return finish(box);
     }
 
     // Guard: if wall thickness leaves no interior, return the solid box.
@@ -416,7 +444,7 @@ export function buildBinBox(
       const innerW = outerW - 2 * wallThickness;
       const innerD = outerD - 2 * wallThickness;
       if (innerW <= 0 || innerD <= 0) {
-        return setBoxCache(boxKey, box);
+        return finish(box);
       }
     }
 
@@ -486,7 +514,7 @@ export function buildBinBox(
         // owned by the scope — registering it again would queue a second
         // `delete()` on the same handle.
         scope.register(box);
-        return setBoxCache(boxKey, result);
+        return finish(result);
       } catch (e: unknown) {
         // Defensive only — context.ts is supposed to gate this path with
         // `compartmentCavitiesAreViable` so cuts can't fail in practice.
@@ -525,7 +553,7 @@ export function buildBinBox(
           )
         );
       } catch {
-        return setBoxCache(boxKey, box);
+        return finish(box);
       }
     }
 
@@ -544,7 +572,7 @@ export function buildBinBox(
           offY
         );
         scope.register(box); // unused on the taper path
-        return setBoxCache(boxKey, taperedBody);
+        return finish(taperedBody);
       } catch (e: unknown) {
         // Fall through to the plain shelled box below so the bin is never lost —
         // but surface it (like the multi-cavity fallback) so a taper regression
@@ -562,10 +590,10 @@ export function buildBinBox(
     try {
       result = unwrap(shell(box as ValidSolid, topFaces, wallThickness));
     } catch {
-      return setBoxCache(boxKey, box);
+      return finish(box);
     }
     scope.register(box); // consumed by shell
-    return setBoxCache(boxKey, result);
+    return finish(result);
   });
 }
 

--- a/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
+++ b/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
@@ -30,7 +30,14 @@ import type { BinParams } from '@/shared/types/bin';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import { boundingBox, isSolidThrough, meshTopologyStats } from './__kernel-tests__/meshAssertions';
 import { seatDepth } from './__kernel-tests__/binSeating';
-import type { FootLattice } from '@/shared/types/bin';
+import {
+  DETACHABLE_PIN_HOLE_DIAMETER_MM,
+  DETACHABLE_PIN_LEAD_IN_MM,
+  DETACHABLE_PIN_TARGET_ENGAGEMENT_MM,
+  detachableFeetFloorMm,
+  detachablePinEngagementMm,
+  type FootLattice,
+} from '@/shared/types/bin';
 
 import type { DetachableFeetGeometry, DetachableFeetOptions } from './detachableFeetBuilder';
 
@@ -91,11 +98,27 @@ function feetOf(over: Partial<DetachableFeetOptions> = {}): DetachableFeetGeomet
     placements: [CORNER_L],
     armMm: ARM,
     pinDiameterMm: PIN,
-    pinHoleDiameterMm: PIN,
+    pinHoleDiameterMm: DETACHABLE_PIN_HOLE_DIAMETER_MM,
     floorThicknessMm: FLOOR,
     forExport: true,
     ...over,
   });
+}
+
+/**
+ * Z of the interior floor surface, probed at the bin's centre — not `minZ`, and
+ * not the underside: below a 1mm wall the body reaches further down, so only the
+ * floor's TOP is where the arithmetic says.
+ */
+function interiorFloorZ(m: MeshData): number {
+  const { minZ, maxZ } = boundingBox(m.vertices);
+  let inFloor = false;
+  for (let z = minZ; z < maxZ; z += 0.05) {
+    const solid = isSolidThrough(m, 0, 0, z, z + 0.04);
+    if (solid) inFloor = true;
+    else if (inFloor) return z;
+  }
+  return maxZ;
 }
 
 /** Extreme coordinate on one axis among vertices sitting at `z`. */
@@ -149,6 +172,56 @@ describe('detachable foot geometry', () => {
       expect(box.maxZ).toBeCloseTo(FLOOR - MEMBRANE, 4);
       expect(box.maxZ).toBeLessThan(FLOOR);
       expect(box.minZ).toBeCloseTo(-5, 4);
+    } finally {
+      feet.forEach((f) => f.delete());
+      pinHoles?.delete();
+    }
+  });
+
+  /**
+   * The one dimension every other check here is blind to: a pin wider than its
+   * hole is still a closed solid of the right height, with its holes in place.
+   */
+  it('never exceeds its stated diameter anywhere along a pin', () => {
+    const { feet, pinHoles } = feetOf();
+    try {
+      const m = meshOf(feet[0]);
+      const pins = footPinPositions(CORNER_L, ARM, PIN);
+      // Above the foot's top face is pin territory alone.
+      let widest = 0;
+      for (let i = 0; i < m.vertices.length; i += 3) {
+        if (m.vertices[i + 2] <= 1e-6) continue;
+        let nearest = Infinity;
+        for (const pin of pins) {
+          nearest = Math.min(nearest, Math.hypot(m.vertices[i] - pin.x, m.vertices[i + 1] - pin.y));
+        }
+        widest = Math.max(widest, nearest);
+      }
+      expect(widest * 2).toBeLessThanOrEqual(PIN + 1e-4);
+      // And reaches it: the bound alone would pass an undersized pin.
+      expect(widest * 2).toBeCloseTo(PIN, 3);
+    } finally {
+      feet.forEach((f) => f.delete());
+      pinHoles?.delete();
+    }
+  });
+
+  it('tapers each pin tip so three pins can enter three holes at once', () => {
+    const { feet, pinHoles } = feetOf();
+    try {
+      const m = meshOf(feet[0]);
+      const pins = footPinPositions(CORNER_L, ARM, PIN);
+      const { maxZ } = boundingBox(m.vertices);
+      let tipRadius = 0;
+      for (let i = 0; i < m.vertices.length; i += 3) {
+        if (Math.abs(m.vertices[i + 2] - maxZ) > 1e-4) continue;
+        for (const pin of pins) {
+          const d = Math.hypot(m.vertices[i] - pin.x, m.vertices[i + 1] - pin.y);
+          if (d < PIN) tipRadius = Math.max(tipRadius, d);
+        }
+      }
+      expect(tipRadius).toBeGreaterThan(0);
+      expect(tipRadius * 2).toBeLessThan(PIN - DETACHABLE_PIN_LEAD_IN_MM);
     } finally {
       feet.forEach((f) => f.delete());
       pinHoles?.delete();
@@ -332,6 +405,7 @@ describe('a bin built with detachable feet', () => {
     const { minZ } = boundingBox(m.vertices);
     const resolved = resolveDetachableFeet(binParams('detachable'));
     expect(resolved.placements.length).toBe(4);
+    const floor = detachableFeetFloorMm(FLOOR);
 
     for (const foot of resolved.placements) {
       for (const pin of footPinPositions(foot, resolved.armMm, resolved.pinDiameterMm)) {
@@ -339,11 +413,28 @@ describe('a bin built with detachable feet', () => {
         expect(isSolidThrough(m, pin.x, pin.y, minZ + 0.05, minZ + 0.3)).toBe(false);
         // ...and the membrane above it is solid, so nothing reaches the
         // interior — where the scoop ramp, dividers and floor pattern live.
-        expect(isSolidThrough(m, pin.x, pin.y, minZ + FLOOR - MEMBRANE + 0.05, minZ + FLOOR)).toBe(
+        expect(isSolidThrough(m, pin.x, pin.y, minZ + floor - MEMBRANE + 0.05, minZ + floor)).toBe(
           true
         );
       }
     }
+  });
+
+  it('spends the thicker floor on the pin, not on the membrane', () => {
+    const m = bin('detachable');
+    const { minZ } = boundingBox(m.vertices);
+    const resolved = resolveDetachableFeet(binParams('detachable'));
+    const floor = detachableFeetFloorMm(FLOOR);
+    expect(floor).toBeGreaterThan(FLOOR);
+
+    const pin = footPinPositions(resolved.placements[0], resolved.armMm, resolved.pinDiameterMm)[0];
+    // Open to the membrane, so the extra floor is engagement not dead material.
+    expect(isSolidThrough(m, pin.x, pin.y, minZ + 0.05, minZ + floor - MEMBRANE - 0.05)).toBe(
+      false
+    );
+    expect(detachablePinEngagementMm(floor)).toBeGreaterThanOrEqual(
+      DETACHABLE_PIN_TARGET_ENGAGEMENT_MM
+    );
   });
 });
 
@@ -469,15 +560,18 @@ describe('a floor too thin to hold a pin', () => {
         base: { ...DEFAULT_BIN_PARAMS.base, feet: 'detachable' },
       };
       const m = generateBin(params, undefined, true);
-      const { minZ } = boundingBox(m.vertices);
       const resolved = resolveDetachableFeet(params);
+      const top = interiorFloorZ(m);
       for (const foot of resolved.placements) {
         for (const pin of footPinPositions(foot, resolved.armMm, resolved.pinDiameterMm)) {
           // The WHOLE membrane, not a sliver at the very top: a probe that thin
           // passes while a hole eats almost all of the band it is meant to
           // protect, which is the invariant the blind holes exist for.
-          const top = minZ + wallThickness;
           expect(isSolidThrough(m, pin.x, pin.y, top - MEMBRANE, top)).toBe(true);
+          const reach = detachablePinEngagementMm(detachableFeetFloorMm(wallThickness));
+          expect(
+            isSolidThrough(m, pin.x, pin.y, top - MEMBRANE - reach + 0.1, top - MEMBRANE - 0.1)
+          ).toBe(false);
         }
       }
     }

--- a/src/features/generation/worker/generators/detachableFeetBuilder.ts
+++ b/src/features/generation/worker/generators/detachableFeetBuilder.ts
@@ -40,7 +40,11 @@ import {
   footPinPositions,
   type FootPlacement,
 } from '@/shared/utils/detachableFeetPlan';
-import { DETACHABLE_PIN_RIDGE_STEP_MM, detachablePinEngagementMm } from '@/shared/types/bin';
+import {
+  DETACHABLE_PIN_LEAD_IN_MM,
+  DETACHABLE_PIN_RIDGE_STEP_MM,
+  detachablePinEngagementMm,
+} from '@/shared/types/bin';
 
 /** How far a clip box overshoots the cell it trims, so no face is coplanar. */
 const CLIP_MARGIN = 2;
@@ -122,17 +126,26 @@ function coveredCorners(
 }
 
 /**
- * A pin, as a stack of alternating radii.
+ * A pin, as a stack of alternating radii under a tapered tip.
  *
- * The diameter steps up and back down every layer so the pin ratchets home and
- * stays without glue. Sections land every half-ridge, which is what puts a
- * ridge crest in the middle of each printed layer rather than on the boundary
- * between two.
+ * Steps IN from `diameterMm` rather than out past it, so the pin is never wider
+ * than the diameter the caller asked for. Sections land every half-ridge, which
+ * puts a crest mid-layer rather than on the boundary between two.
  */
 function buildPin(scope: DisposalScope, diameterMm: number, heightMm: number): Shape3D {
   const r = diameterMm / 2;
-  const crest = r + DETACHABLE_PIN_RIDGE_STEP_MM / 2;
   const step = DETACHABLE_PIN_RIDGE_STEP_MM / 2;
+
+  // Too short to carry a ridge: a plain cylinder rather than a degenerate loft.
+  if (heightMm < 2 * step) {
+    return scope.register(
+      translate(scope.register(cylinder(r, heightMm + COPLANAR_OVERLAP)), [0, 0, -COPLANAR_OVERLAP])
+    );
+  }
+
+  const valley = r - DETACHABLE_PIN_RIDGE_STEP_MM;
+  const lead = Math.min(DETACHABLE_PIN_LEAD_IN_MM, heightMm / 3);
+  const ridgeTopZ = heightMm - lead;
   const section = (radius: number, z: number): Sketch =>
     drawCircle(radius).sketchOnPlane('XY', z) as Sketch;
 
@@ -140,24 +153,21 @@ function buildPin(scope: DisposalScope, diameterMm: number, heightMm: number): S
   // volumetric overlap rather than two coincident planes. Without it OCCT
   // leaves non-manifold junctions all round every pin — the solid stays closed,
   // so only an edge-manifold check sees it, and a slicer would quietly repair
-  // it into something else.
+  // it into something else. Root at the valley radius: the first layer off the
+  // foot's top face squishes out, so it is the last place for the tight fit.
   const sections: Array<[number, number]> = [
-    [-COPLANAR_OVERLAP, r],
-    [0, r],
+    [-COPLANAR_OVERLAP, valley],
+    [0, valley],
   ];
   let ridge = 0;
-  for (let z = step; z < heightMm - 1e-6; z += step) {
-    sections.push([z, ridge % 2 === 0 ? crest : r]);
+  // Half a step short, so the closing section cannot land on the last ridge and
+  // loft between two coincident circles.
+  for (let z = step; z < ridgeTopZ - step / 2; z += step) {
+    sections.push([z, ridge % 2 === 0 ? r : valley]);
     ridge++;
   }
-  sections.push([heightMm, r]);
-
-  // Too short to carry a ridge: a plain cylinder rather than a degenerate loft.
-  if (sections.length < 4) {
-    return scope.register(
-      translate(scope.register(cylinder(r, heightMm + COPLANAR_OVERLAP)), [0, 0, -COPLANAR_OVERLAP])
-    );
-  }
+  sections.push([ridgeTopZ, valley]);
+  sections.push([heightMm, valley - lead]);
 
   const start = section(sections[0][1], sections[0][0]);
   try {

--- a/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
+++ b/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
@@ -25,7 +25,11 @@ import {
 } from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
-import { hasDetachableFeet, DETACHABLE_PIN_HOLE_DIAMETER_MM } from '@/shared/types/bin';
+import {
+  hasDetachableFeet,
+  detachableFeetFloorMm,
+  DETACHABLE_PIN_HOLE_DIAMETER_MM,
+} from '@/shared/types/bin';
 import type { MeshData } from '../../bridge/types';
 import { footCellCentre, resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import { buildDetachableFeet } from './detachableFeetBuilder';
@@ -61,7 +65,7 @@ function buildFeetSolids(
     armMm: resolved.armMm,
     pinDiameterMm: resolved.pinDiameterMm,
     pinHoleDiameterMm: DETACHABLE_PIN_HOLE_DIAMETER_MM,
-    floorThicknessMm: params.wallThickness,
+    floorThicknessMm: detachableFeetFloorMm(params.wallThickness),
     screw: resolved.screw,
     magnet: resolved.magnet
       ? {

--- a/src/features/generation/worker/generators/floorPatterns.ts
+++ b/src/features/generation/worker/generators/floorPatterns.ts
@@ -306,6 +306,6 @@ export function planFloorPattern(params: BinParams, dim: BinDimensions): FloorPa
   return {
     windows,
     cutZ0: dim.undersideRelief ? -COPLANAR_MARGIN : -dim.baseOffsetZ - COPLANAR_MARGIN,
-    cutZ1: params.wallThickness + COPLANAR_MARGIN,
+    cutZ1: dim.floorThickness + COPLANAR_MARGIN,
   };
 }

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -8,6 +8,7 @@
 import type { BinParams } from '@/shared/types/bin';
 import {
   hasDetachableFeet,
+  detachableFeetFloorMm,
   hasDividerLean,
   isUndersideRelief,
   resolveTileFloorThickness,
@@ -85,6 +86,9 @@ export function deriveDimensions(
   // is skipped too, and the export is a flat-bottomed box with no feet part.
   const detachableFeet =
     hasDetachableFeet(params.base) && resolveDetachableFeet(params).placements.length > 0;
+  const floorThickness = detachableFeet
+    ? detachableFeetFloorMm(params.wallThickness)
+    : params.wallThickness;
   // User flag only. When the mask has mixed half-bin detail, the socket
   // builder does a per-cell dispatch using the mask — it splits only
   // those 1u cells that straddle a half-bin boundary into quarter
@@ -354,6 +358,8 @@ export function deriveDimensions(
       // the floor already punched. Appended only when set, so every interior and
       // non-lite bin keeps a byte-identical key.
       ...(undersideRelief ? ['underside'] : []),
+      // A thicker floor is a different solid from the integral bin's.
+      ...(floorThickness !== params.wallThickness ? [`floor${quantize(floorThickness)}`] : []),
       // A tray bin's shell is socketless, so it must not reuse a socketed bin's
       // cached body. `isFlat` above does not separate them: a custom
       // `heightUnitMm` makes a socketed 13mm x 2u and a tray-bottom 7mm x 3u agree on
@@ -408,6 +414,7 @@ export function deriveDimensions(
     isTrayBottom,
     socketless,
     detachableFeet,
+    floorThickness,
     baseOffsetZ,
     halfSockets,
     socketCellPlan,

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -176,7 +176,10 @@ export const shellStage: PipelineStage = {
         // The integrated builder mirrors the angled support unconditionally, so a
         // wall too short to carry one has to take the fuse path, where
         // `buildTopShape` can be told to leave it off.
-        dim.lipHasSupport;
+        dim.lipHasSupport &&
+        // Draft-only path, and only `buildBinBox` raises the floor — taking it
+        // would preview a floor the export does not have.
+        dim.floorThickness === params.wallThickness;
 
       let built = withScope((scope: DisposalScope) => {
         // Base-only bin: `boxWallHeight` is 0, and extruding a zero-length
@@ -271,7 +274,8 @@ export const shellStage: PipelineStage = {
           params.cellMask,
           compartmentCavityDrawings,
           compartmentCavityKey,
-          dim.overhang
+          dim.overhang,
+          dim.floorThickness
         );
         collectOrigins(binBody, FeatureTag.BASE, originToTag);
 
@@ -370,9 +374,8 @@ export const shellStage: PipelineStage = {
     // happen to something the user presses on afterwards. They are generated
     // and combined alongside the bin the way a lid is.
     //
-    // Cutting here rather than before `setShellCache` is deliberate: the cached
-    // body is shared with an integral bin of the same size (the two really are
-    // identical above the floor), and only this clone gets holed.
+    // Cutting here rather than before `setShellCache` is deliberate: only this
+    // clone gets holed.
     if (dim.detachableFeet) {
       const resolved = resolveDetachableFeet(params);
       if (resolved.placements.length > 0) {
@@ -381,7 +384,7 @@ export const shellStage: PipelineStage = {
           armMm: resolved.armMm,
           pinDiameterMm: resolved.pinDiameterMm,
           pinHoleDiameterMm: DETACHABLE_PIN_HOLE_DIAMETER_MM,
-          floorThicknessMm: params.wallThickness,
+          floorThicknessMm: dim.floorThickness,
           // Screws only: their bore also passes through the FLOOR, so the tool
           // this returns has to carry it. Magnets stay in the feet.
           screw: resolved.screw,

--- a/src/features/generation/worker/generators/pipeline/types.ts
+++ b/src/features/generation/worker/generators/pipeline/types.ts
@@ -111,6 +111,12 @@ export interface BinDimensions {
    */
   readonly detachableFeet: boolean;
   /**
+   * Interior floor thickness, in mm. Equals {@link BinParams.wallThickness}
+   * except under {@link detachableFeet}. Read this wherever the FLOOR is meant;
+   * `wallThickness` still answers everything about the walls.
+   */
+  readonly floorThickness: number;
+  /**
    * True when there is no solid interior floor left — the question every
    * feature that stands ON the floor is actually asking, and the reason it is
    * separate from {@link lightweight}.

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Název návrhu",
   "binDesigner.designs": "Návrhy",
   "binDesigner.detachableFeet": "Odnímatelné nožičky",
-  "binDesigner.detachableFeet.pinHint": "Pokud větší kolík nedosedne, zkuste nejdřív menší",
+  "binDesigner.detachableFeet.pinHint": "Největší průměr, do otvoru 3 mm. Pokud nožka nedosedne, zvolte o velikost méně.",
   "binDesigner.detachableFeet.pinSize": "Průměr kolíku",
   "binDesigner.detachableFeet.saving": "Spotřebuje o {percent} % méně materiálu než pevné nožičky",
   "binDesigner.detachableFeet.savingSuperseded": "Odlehčená základna už tuto úsporu pokrývá",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Design-Name",
   "binDesigner.designs": "Designs",
   "binDesigner.detachableFeet": "Abnehmbare Füße",
-  "binDesigner.detachableFeet.pinHint": "Wenn der größere Stift nicht sitzt, zuerst den kleineren versuchen",
+  "binDesigner.detachableFeet.pinHint": "Größter Durchmesser, für eine 3-mm-Bohrung. Sitzt ein Fuß nicht, eine Größe kleiner wählen.",
   "binDesigner.detachableFeet.pinSize": "Stiftgröße",
   "binDesigner.detachableFeet.saving": "Verbraucht {percent} % weniger Material als feste Füße",
   "binDesigner.detachableFeet.savingSuperseded": "Der Leichtbau-Boden deckt diese Einsparung bereits ab",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2339,7 +2339,8 @@ const en: Record<string, string> = {
   'binDesigner.detachableFeet': 'Detachable feet',
   'binDesigner.detachableFeet.saving': 'Uses {percent}% less material than built-in feet',
   'binDesigner.detachableFeet.pinSize': 'Pin size',
-  'binDesigner.detachableFeet.pinHint': 'Try the smaller pin first if the larger will not seat',
+  'binDesigner.detachableFeet.pinHint':
+    'Widest diameter, into a 3mm hole. Step down a size if a foot will not seat.',
   'binDesigner.detachableFeet.supersedes': 'Not used with detachable feet',
   'binDesigner.detachableFeet.savingSuperseded': 'The lightweight base already covers this saving',
   'binDesigner.detachableFeet.unplaceable': 'No whole grid cell for a foot to sit in at this size',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Nombre del diseño",
   "binDesigner.designs": "Diseños",
   "binDesigner.detachableFeet": "Patas desmontables",
-  "binDesigner.detachableFeet.pinHint": "Prueba primero el pasador pequeño si el grande no encaja",
+  "binDesigner.detachableFeet.pinHint": "Diámetro máximo, para un orificio de 3 mm. Si un pie no encaja, baja una talla.",
   "binDesigner.detachableFeet.pinSize": "Tamaño del pasador",
   "binDesigner.detachableFeet.saving": "Usa un {percent} % menos de material que las patas integradas",
   "binDesigner.detachableFeet.savingSuperseded": "La base aligerada ya cubre este ahorro",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Nom du design",
   "binDesigner.designs": "Designs",
   "binDesigner.detachableFeet": "Pieds amovibles",
-  "binDesigner.detachableFeet.pinHint": "Essayez d'abord le petit ergot si le grand ne rentre pas",
+  "binDesigner.detachableFeet.pinHint": "Diamètre maximal, pour un trou de 3 mm. Si un pied ne s’emboîte pas, descendez d’une taille.",
   "binDesigner.detachableFeet.pinSize": "Taille des ergots",
   "binDesigner.detachableFeet.saving": "Utilise {percent} % de matière en moins que des pieds intégrés",
   "binDesigner.detachableFeet.savingSuperseded": "La base allégée couvre déjà cette économie",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Nome del design",
   "binDesigner.designs": "Design",
   "binDesigner.detachableFeet": "Piedini staccabili",
-  "binDesigner.detachableFeet.pinHint": "Prova prima il perno piccolo se quello grande non entra",
+  "binDesigner.detachableFeet.pinHint": "Diametro massimo, per un foro da 3 mm. Se un piedino non entra, scendi di una misura.",
   "binDesigner.detachableFeet.pinSize": "Misura del perno",
   "binDesigner.detachableFeet.saving": "Usa il {percent}% di materiale in meno rispetto ai piedini integrati",
   "binDesigner.detachableFeet.savingSuperseded": "La base alleggerita copre già questo risparmio",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "デザイン名",
   "binDesigner.designs": "デザイン",
   "binDesigner.detachableFeet": "取り外し式の脚",
-  "binDesigner.detachableFeet.pinHint": "大きいピンが入らない場合は小さいピンをお試しください",
+  "binDesigner.detachableFeet.pinHint": "最大径です（穴は3mm）。脚が入らない場合は1サイズ小さくしてください。",
   "binDesigner.detachableFeet.pinSize": "ピンの太さ",
   "binDesigner.detachableFeet.saving": "一体型の脚より材料を{percent}%節約します",
   "binDesigner.detachableFeet.savingSuperseded": "軽量ベースで既にこの節約は実現されています",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "디자인 이름",
   "binDesigner.designs": "디자인",
   "binDesigner.detachableFeet": "분리형 발",
-  "binDesigner.detachableFeet.pinHint": "큰 핀이 들어가지 않으면 작은 핀을 먼저 시도하세요",
+  "binDesigner.detachableFeet.pinHint": "최대 지름이며 구멍은 3mm입니다. 다리가 들어가지 않으면 한 치수 작게 선택하세요.",
   "binDesigner.detachableFeet.pinSize": "핀 크기",
   "binDesigner.detachableFeet.saving": "일체형 발보다 재료를 {percent}% 적게 사용합니다",
   "binDesigner.detachableFeet.savingSuperseded": "경량 베이스가 이미 이 절감을 제공합니다",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Designnavn",
   "binDesigner.designs": "Design",
   "binDesigner.detachableFeet": "Avtakbare føtter",
-  "binDesigner.detachableFeet.pinHint": "Prøv den minste pinnen først hvis den største ikke sitter",
+  "binDesigner.detachableFeet.pinHint": "Største diameter, i et 3 mm hull. Går ikke en fot på plass, velg én størrelse mindre.",
   "binDesigner.detachableFeet.pinSize": "Pinnestørrelse",
   "binDesigner.detachableFeet.saving": "Bruker {percent} % mindre materiale enn innebygde føtter",
   "binDesigner.detachableFeet.savingSuperseded": "Den lette bunnen dekker allerede denne besparelsen",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Design naam",
   "binDesigner.designs": "Ontwerpen",
   "binDesigner.detachableFeet": "Afneembare voetjes",
-  "binDesigner.detachableFeet.pinHint": "Probeer eerst de kleinste pen als de grootste niet past",
+  "binDesigner.detachableFeet.pinHint": "Grootste diameter, in een gat van 3 mm. Past een voet niet, kies dan een maat kleiner.",
   "binDesigner.detachableFeet.pinSize": "Pengrootte",
   "binDesigner.detachableFeet.saving": "Gebruikt {percent}% minder materiaal dan vaste voetjes",
   "binDesigner.detachableFeet.savingSuperseded": "De lichtgewicht bodem dekt deze besparing al",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Nazwa projektu",
   "binDesigner.designs": "Projekty",
   "binDesigner.detachableFeet": "Odczepiane nóżki",
-  "binDesigner.detachableFeet.pinHint": "Jeśli większy kołek nie wchodzi, spróbuj najpierw mniejszego",
+  "binDesigner.detachableFeet.pinHint": "Największa średnica, do otworu 3 mm. Jeśli nóżka nie wchodzi, wybierz mniejszy rozmiar.",
   "binDesigner.detachableFeet.pinSize": "Rozmiar kołka",
   "binDesigner.detachableFeet.saving": "Zużywa o {percent}% mniej materiału niż nóżki wbudowane",
   "binDesigner.detachableFeet.savingSuperseded": "Odchudzona podstawa już zapewnia tę oszczędność",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Nome do design",
   "binDesigner.designs": "Designs",
   "binDesigner.detachableFeet": "Pés destacáveis",
-  "binDesigner.detachableFeet.pinHint": "Tente o pino menor primeiro se o maior não encaixar",
+  "binDesigner.detachableFeet.pinHint": "Diâmetro máximo, para um furo de 3 mm. Se um pé não encaixar, use um tamanho menor.",
   "binDesigner.detachableFeet.pinSize": "Tamanho do pino",
   "binDesigner.detachableFeet.saving": "Usa {percent}% menos material do que pés integrados",
   "binDesigner.detachableFeet.savingSuperseded": "A base leve já cobre essa economia",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Designnamn",
   "binDesigner.designs": "Designer",
   "binDesigner.detachableFeet": "Avtagbara fötter",
-  "binDesigner.detachableFeet.pinHint": "Prova det mindre stiftet först om det större inte passar",
+  "binDesigner.detachableFeet.pinHint": "Största diameter, i ett 3 mm hål. Om en fot inte sitter, välj en storlek mindre.",
   "binDesigner.detachableFeet.pinSize": "Stiftstorlek",
   "binDesigner.detachableFeet.saving": "Använder {percent} % mindre material än inbyggda fötter",
   "binDesigner.detachableFeet.savingSuperseded": "Den lätta basen täcker redan denna besparing",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "Назва дизайну",
   "binDesigner.designs": "Дизайни",
   "binDesigner.detachableFeet": "Знімні ніжки",
-  "binDesigner.detachableFeet.pinHint": "Якщо більший штифт не сідає, спробуйте спершу менший",
+  "binDesigner.detachableFeet.pinHint": "Найбільший діаметр, в отвір 3 мм. Якщо ніжка не входить, оберіть менший розмір.",
   "binDesigner.detachableFeet.pinSize": "Розмір штифта",
   "binDesigner.detachableFeet.saving": "Витрачає на {percent}% менше матеріалу, ніж вбудовані ніжки",
   "binDesigner.detachableFeet.savingSuperseded": "Полегшена основа вже забезпечує цю економію",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -878,7 +878,7 @@
   "binDesigner.designName": "设计名称",
   "binDesigner.designs": "设计",
   "binDesigner.detachableFeet": "可拆卸底脚",
-  "binDesigner.detachableFeet.pinHint": "若较大的销钉装不进，请先试较小的",
+  "binDesigner.detachableFeet.pinHint": "最大直径，对应 3mm 孔。若支脚装不进去，请选小一号。",
   "binDesigner.detachableFeet.pinSize": "销钉尺寸",
   "binDesigner.detachableFeet.saving": "比一体式底脚少用 {percent}% 的材料",
   "binDesigner.detachableFeet.savingSuperseded": "轻量化底座已经实现了这部分节省",

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -287,7 +287,10 @@ export {
   DETACHABLE_PIN_MIN_ENGAGEMENT_MM,
   detachablePinEngagementMm,
   detachableFeetFitFloor,
+  detachableFeetFloorMm,
+  DETACHABLE_PIN_TARGET_ENGAGEMENT_MM,
   DETACHABLE_PIN_RIDGE_STEP_MM,
+  DETACHABLE_PIN_LEAD_IN_MM,
 } from '@/features/bin-designer/types';
 
 /**


### PR DESCRIPTION
User feedback from an A1 print: the feet would not seat even with liberal use of a rubber mallet. Pulled into OnShape, the "2.9mm" pins measured **3.1mm** at their widest, "like a screw thread on the outside", going into a 3.0mm hole.

## The pin was wider than its own label

`buildPin` formed the ratchet by stepping OUT from the selected diameter:

```
crest = r + DETACHABLE_PIN_RIDGE_STEP_MM / 2
```

With a 0.2mm ridge step, the 2.9mm option was a 3.1mm pin and the 3mm option a 3.2mm pin. Both offered sizes were interference fits against a fixed 3.0mm hole, and the menu said otherwise. The alternating loft at 0.1mm section spacing is what reads as a thread.

Ridges now step IN, so the selected diameter is the widest point anywhere on the pin.

Sizes run 2.7 to 3.0mm, defaulting to 2.8mm. FDM prints a small hole undersize and a small pin oversize, so the printed fit lands tighter than nominal and the list has to reach under the hole rather than stop at it.

## The joint was too shallow to hold

Engagement was `wallThickness - 0.4mm` membrane, so **0.8mm** on a stock bin. Enough to locate a foot, not enough to stop it tilting off. The reporter reached the same conclusion independently ("needs to go a mm or two deeper").

Floor thickness is now a derived dimension of its own. `dim.floorThickness` equals `wallThickness` for every bin except a detachable-feet one, which gets 2.4mm whatever its walls are, so **every pin engages 2.0mm**.

- `buildBinBox` applies it at a single exit, covering all five hollowing paths (shell, multi-cavity, polygon, taper, lowered fill) rather than each growing a variant.
- The shell and box cache keys carry it, appended only when it differs so every other bin keeps a byte-identical key.
- The draft-only integrated-lip path is excluded, so the preview cannot show a floor the export does not have.

Inverting the joint (peg on the bin, socket in the 5mm-thick foot) would give unlimited depth, but the bin prints bottom-down and the pegs would become its only contact with the build plate.

## Three pins, three holes, one chance

An L foot's pins had to enter simultaneously with flat tips, so the first to touch down fixed the foot and the other two landed on floor. Each pin now carries a lead-in taper, free to print since the feet print pins-up.

## Why nothing caught it

The kernel suite measured the pin's height, its closedness, and where its holes land. It never measured its **width** against the hole it has to enter, so a pin wider than its hole was a perfectly valid solid that passed everything. It does now, off the mesh rather than the constants, since the ridge profile is where the widest point gets decided.

## Verification

- 22 kernel tests, 733 geometry scenario tests, 5,676 unit tests
- Ground truth in `printEstimates.test.ts` re-measured against the new geometry; the analytic floor term agrees within 0.2% on every size
- Material saving against integral feet stays at 25-45%
- The `pinHint` string is retranslated across all 14 locales

## Note on STEP export

The reporter noticed STEP exports as one model with feet attached. That is intended: STEP ships a compound assembly (dividers, lid and knife rest do the same), while STL and 3MF ship the feet as their own plate. Left as is.

## CLAUDE.md

Records the comment test the #3514-#3679 audit applied, which was never written down: could a capable model derive this by reading the code? Plus a note not to match the density of files that predate it.

https://claude.ai/code/session_018grzGgWpPLDxEApqqGCbmZ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

