### PR TITLE
fix(bin-designer): take the detachable floor from the spec's dead space

### DIFF
--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -306,19 +306,22 @@ export function detachablePinEngagementMm(floorThicknessMm: number): number {
   return floorThicknessMm - DETACHABLE_PIN_MEMBRANE_MM;
 }
 
-export const DETACHABLE_PIN_TARGET_ENGAGEMENT_MM = 2;
-
 /**
  * Floor thickness a bin gets once its feet come off, in mm. The one mode where
  * the floor has a job the walls do not share: it is the whole depth a blind pin
  * hole has.
+ *
+ * Taken from the spec's dead space rather than from what the pin wants, so a
+ * detachable bin's cavity floor lands where a Gridfinity bin's belongs. Sizing
+ * it off the joint instead put the floor 0.4mm past that.
  */
 export function detachableFeetFloorMm(wallThicknessMm: number): number {
-  return Math.max(
-    wallThicknessMm,
-    DETACHABLE_PIN_TARGET_ENGAGEMENT_MM + DETACHABLE_PIN_MEMBRANE_MM
-  );
+  return Math.max(wallThicknessMm, GRIDFINITY.BASE_HEIGHT - GRIDFINITY.SOCKET_HEIGHT);
 }
+
+/** What {@link detachableFeetFloorMm} leaves a pin, before the membrane. */
+export const DETACHABLE_PIN_TARGET_ENGAGEMENT_MM =
+  GRIDFINITY.BASE_HEIGHT - GRIDFINITY.SOCKET_HEIGHT - DETACHABLE_PIN_MEMBRANE_MM;
 
 /**
  * How far the pin is relieved between ridge crests, in mm. Steps INWARD from the

--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -312,14 +312,13 @@ export function detachablePinEngagementMm(floorThicknessMm: number): number {
  * hole has.
  *
  * Taken from the spec's dead space rather than from what the pin wants, so a
- * detachable bin's cavity floor lands where a Gridfinity bin's belongs. Sizing
- * it off the joint instead put the floor 0.4mm past that.
+ * detachable bin's cavity floor lands where a Gridfinity bin's belongs.
  */
 export function detachableFeetFloorMm(wallThicknessMm: number): number {
   return Math.max(wallThicknessMm, GRIDFINITY.BASE_HEIGHT - GRIDFINITY.SOCKET_HEIGHT);
 }
 
-/** What {@link detachableFeetFloorMm} leaves a pin, before the membrane. */
+/** Least engagement a detachable bin gives a pin; a thicker wall gives more. */
 export const DETACHABLE_PIN_TARGET_ENGAGEMENT_MM =
   GRIDFINITY.BASE_HEIGHT - GRIDFINITY.SOCKET_HEIGHT - DETACHABLE_PIN_MEMBRANE_MM;
 

--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -878,11 +878,11 @@ describe('printEstimates', () => {
    */
   describe('detachable feet — measured ground truth (±5%)', () => {
     const ASSEMBLY_MM3: ReadonlyArray<readonly [number, number, number]> = [
-      [1, 1, 10065],
-      [3, 2, 43006],
-      [2, 4, 55575],
-      [6, 3, 104226],
-      [1, 4, 30448],
+      [1, 1, 9459],
+      [3, 2, 39024],
+      [2, 4, 50233],
+      [6, 3, 91974],
+      [1, 4, 27872],
     ];
 
     for (const [w, d, truth] of ASSEMBLY_MM3) {


### PR DESCRIPTION
Follow-up to #3700. The floor thickness it introduced was derived from the wrong direction.

## What was wrong

`detachableFeetFloorMm` worked backwards from the joint — target engagement (2.0mm) plus membrane (0.4mm) — and landed on 2.4mm. That number was chosen, not derived.

Gridfinity's convention is **7mm of dead space** from the bin's bottom to its cavity floor, which this repo already encodes:

```
// Base profile (total dead space from bottom to cavity floor)
BASE_HEIGHT: 7, // mm total (profile + bridge structure per spec)
```

The socket is 5mm of that, so the floor belongs at **2mm**.

Measured off real meshes, dead space from the bin's bottom to its cavity floor:

| bin | floor | dead space | vs 7mm |
|---|---|---|---|
| integral, 0.95mm wall | 0.95 | 5.95 | −1.05 |
| integral, 1.2mm wall | 1.2 | 6.20 | −0.80 |
| detachable, #3700 | 2.4 | **7.40** | **+0.40** |
| detachable, this PR | 2.0 | **7.00** | **0** |

Integral bins have never honored the convention (their floor is just `wallThickness`), but #3700 made detachable bins the only ones sitting *past* it.

## The change

`detachableFeetFloorMm` now derives from the spec, and the engagement constant falls out of it rather than driving it:

```ts
export function detachableFeetFloorMm(wallThicknessMm: number): number {
  return Math.max(wallThicknessMm, GRIDFINITY.BASE_HEIGHT - GRIDFINITY.SOCKET_HEIGHT);
}

export const DETACHABLE_PIN_TARGET_ENGAGEMENT_MM =
  GRIDFINITY.BASE_HEIGHT - GRIDFINITY.SOCKET_HEIGHT - DETACHABLE_PIN_MEMBRANE_MM;
```

Engagement goes 2.0mm → **1.6mm**, still double the 0.8mm a stock floor gave before #3700, which is what the original report was about.

## Verification

- Dead space measures **7.00mm** at the default 1.2mm wall
- 733 geometry scenario tests, 28 detachable kernel/base tests, 5,983 total
- Ground truth in `printEstimates.test.ts` re-measured against the new geometry; the analytic floor term tracks it within ~10mm³ on every size
- The kernel assertions needed **no change** — #3700 wrote them against `detachableFeetFloorMm` rather than a literal, so they followed the constant

https://claude.ai/code/session_018grzGgWpPLDxEApqqGCbmZ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

