### PR TITLE
fix(generation): give every bin the spec's 7mm dead space

### DIFF
--- a/src/features/bin-designer/types/base.test.ts
+++ b/src/features/bin-designer/types/base.test.ts
@@ -9,7 +9,7 @@ import {
   DETACHABLE_PIN_RIDGE_STEP_MM,
   DETACHABLE_PIN_TARGET_ENGAGEMENT_MM,
   detachableFeetFitFloor,
-  detachableFeetFloorMm,
+  binFloorMm,
   detachablePinEngagementMm,
 } from './base';
 
@@ -54,11 +54,11 @@ describe('detachable pin engagement', () => {
 
   it('gives every allowed wall the same engagement, so the fit never depends on it', () => {
     for (const wall of [1, 1.2, 1.6, 2, 2.4]) {
-      expect(detachablePinEngagementMm(detachableFeetFloorMm(wall))).toBeGreaterThanOrEqual(
+      expect(detachablePinEngagementMm(binFloorMm(wall))).toBeGreaterThanOrEqual(
         DETACHABLE_PIN_TARGET_ENGAGEMENT_MM
       );
     }
     // A thicker wall keeps its own floor rather than being thinned to the target.
-    expect(detachableFeetFloorMm(4)).toBe(4);
+    expect(binFloorMm(4)).toBe(4);
   });
 });

--- a/src/features/bin-designer/types/base.ts
+++ b/src/features/bin-designer/types/base.ts
@@ -307,14 +307,18 @@ export function detachablePinEngagementMm(floorThicknessMm: number): number {
 }
 
 /**
- * Floor thickness a bin gets once its feet come off, in mm. The one mode where
- * the floor has a job the walls do not share: it is the whole depth a blind pin
- * hole has.
+ * Interior floor thickness, in mm.
  *
- * Taken from the spec's dead space rather than from what the pin wants, so a
- * detachable bin's cavity floor lands where a Gridfinity bin's belongs.
+ * The spec's dead space from a bin's bottom to its cavity floor is
+ * {@link GRIDFINITY.BASE_HEIGHT}, of which the socket is
+ * {@link GRIDFINITY.SOCKET_HEIGHT}; the rest is floor. Shelling to
+ * `wallThickness` left the cavity floor below that plane, which is what makes
+ * `(height - 1) x HEIGHT_UNIT` the cavity height the spec says it is.
+ *
+ * A wall thicker than the remainder keeps its own floor: thinning it back to
+ * spec would put less material under the cavity than beside it.
  */
-export function detachableFeetFloorMm(wallThicknessMm: number): number {
+export function binFloorMm(wallThicknessMm: number): number {
   return Math.max(wallThicknessMm, GRIDFINITY.BASE_HEIGHT - GRIDFINITY.SOCKET_HEIGHT);
 }
 

--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -143,13 +143,10 @@ describe('printEstimates', () => {
     });
 
     it('matches the OCCT-measured solid volume for a 2×2×3 standard bin (±15%)', () => {
-      // Ground truth from the real generator: 2×2×3u solid = 46238 mm³. The
-      // earlier 17094 came from a measurement that left the base socket out —
-      // one 1u foot is ~7300 mm³ on its own, so four of them plus a body could
-      // never total that.
+      // Ground truth from the real generator: 2×2×3u solid = 51500 mm³.
       const est = estimatePrint(DEFAULT_BIN_PARAMS);
-      expect(est.volumeMm3).toBeGreaterThan(46238 * 0.85);
-      expect(est.volumeMm3).toBeLessThan(46238 * 1.15);
+      expect(est.volumeMm3).toBeGreaterThan(51500 * 0.85);
+      expect(est.volumeMm3).toBeLessThan(51500 * 1.15);
     });
 
     it('a plain standard bin matches the shared print-export estimator', () => {
@@ -503,7 +500,9 @@ describe('printEstimates', () => {
       const partial =
         estimatePrint(masked).volumeMm3 - estimatePrint({ ...masked, floorPattern }).volumeMm3;
       expect(partial).toBeGreaterThan(0);
-      expect(partial).toBeCloseTo(full * 0.75, 0);
+      // As a ratio, not an absolute: both sides are differences of rounded
+      // volumes, so an absolute tolerance of 0.5 sits inside the rounding noise.
+      expect(partial / full).toBeCloseTo(0.75, 2);
     });
 
     it('drainage holes are inert on the bases the worker never patterns', () => {

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -12,7 +12,7 @@
 
 import type { BinParams, LabelTabSupport, WallPatternType } from '@/features/bin-designer/types';
 import {
-  detachableFeetFloorMm,
+  binFloorMm,
   isSocketlessBase,
   isUndersideRelief,
 } from '@/features/bin-designer/types/base';
@@ -218,13 +218,6 @@ function computeBinVolume(params: BinParams): number {
       params.gridUnitMm,
       gridUnitMmY
     );
-    // The thicker floor, or the reported saving counts material the bin gets
-    // back. From `params.wallThickness` because that is what the pipeline
-    // resolves the floor from; `wallThickness` above is a style constant.
-    volume +=
-      Math.max(0, outerW - 2 * wallThickness) *
-      Math.max(0, outerD - 2 * wallThickness) *
-      (detachableFeetFloorMm(params.wallThickness) - params.wallThickness);
   }
 
   // A base-only bin IS feet + floor slab + an optional lip, which is exactly
@@ -317,7 +310,11 @@ function solidFillVolume(
   if (!params.base.solid && params.style !== 'solid') return 0;
 
   const wallHeight = baseWallHeight(params.base, params.height * params.heightUnitMm);
-  const fillHeight = wallHeight - wallThickness - Math.max(0, params.cutoutConfig.topOffset);
+  // From the FLOOR's top, not the wall's: the `base` component already prices
+  // material up to `binFloorMm`, so a fill starting at `wallThickness` counts
+  // the difference twice.
+  const floorThickness = binFloorMm(wallThickness);
+  const fillHeight = wallHeight - floorThickness - Math.max(0, params.cutoutConfig.topOffset);
   if (fillHeight <= 0) return 0;
 
   const innerW = Math.max(0, outerW - 2 * wallThickness);

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -312,8 +312,10 @@ function solidFillVolume(
   const wallHeight = baseWallHeight(params.base, params.height * params.heightUnitMm);
   // From the FLOOR's top, not the wall's: the `base` component already prices
   // material up to `binFloorMm`, so a fill starting at `wallThickness` counts
-  // the difference twice.
-  const floorThickness = binFloorMm(wallThickness);
+  // the difference twice. Resolved from `params.wallThickness` rather than the
+  // style constant above, because that is what the pipeline resolves it from —
+  // they part company once a wall exceeds the spec floor.
+  const floorThickness = binFloorMm(params.wallThickness);
   const fillHeight = wallHeight - floorThickness - Math.max(0, params.cutoutConfig.topOffset);
   if (fillHeight <= 0) return 0;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`bin styles > 2×2 slotted 1`] = `3204`;
+exports[`bin styles > 2×2 slotted 1`] = `3228`;
 
 exports[`bin styles > 2×2 solid 1`] = `2532`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1300`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1324`;
 
 exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3520`;
 
 exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4388`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5546`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5498`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `17804`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
@@ -8,16 +8,16 @@ exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid
 
 exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13452`;
 
-exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `12538`;
+exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `12490`;
 
-exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10324`;
+exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10302`;
 
-exports[`divider patterns > mitsukude lattice on dividers 1`] = `15914`;
+exports[`divider patterns > mitsukude lattice on dividers 1`] = `15890`;
 
 exports[`divider patterns > overhang shifts the interior with the dividers 1`] = `10844`;
 
-exports[`divider patterns > round pattern on a single column divider 1`] = `20212`;
+exports[`divider patterns > round pattern on a single column divider 1`] = `20188`;
 
 exports[`divider patterns > shortened dividers re-fit the band 1`] = `8480`;
 
-exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `10060`;
+exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `10042`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5104`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5122`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `4750`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `4768`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4152`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4170`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4152`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4170`;
 
 exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4472`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.snap
@@ -14,7 +14,7 @@ exports[`label tabs > 2×2 label front edge 1`] = `3612`;
 
 exports[`label tabs > 2×2 label lip bracket 1`] = `3548`;
 
-exports[`label tabs > 2×2 label lip solid 2mm 1`] = `3420`;
+exports[`label tabs > 2×2 label lip solid 2mm 1`] = `3388`;
 
 exports[`label tabs > 2×2 label solid left 1`] = `3364`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
@@ -1,30 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3916`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3924`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4506`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4522`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `3916`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `3924`;
 
 exports[`scoop > 2×2 scoop disabled 1`] = `2796`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `3956`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `3964`;
 
-exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `3792`;
+exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `3800`;
 
-exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `4934`;
+exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `4950`;
 
-exports[`scoop side > scoop on the back wall 1`] = `3916`;
+exports[`scoop side > scoop on the back wall 1`] = `3924`;
 
-exports[`scoop side > scoop on the left wall 1`] = `3916`;
+exports[`scoop side > scoop on the left wall 1`] = `3924`;
 
-exports[`scoop side > scoop on the right wall 1`] = `3916`;
+exports[`scoop side > scoop on the right wall 1`] = `3924`;
 
-exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `3916`;
+exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `3924`;
 
-exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `3872`;
+exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `3884`;
 
-exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4060`;
+exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4068`;
 
 exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3436`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3204`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3228`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3612`;
+exports[`slotted variations > slotted with both axes 1`] = `3660`;
 
-exports[`slotted variations > slotted without lip 1`] = `1364`;
+exports[`slotted variations > slotted without lip 1`] = `1388`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2684`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2884`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3044`;

--- a/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
+++ b/src/features/generation/worker/generators/detachableFeet.kernel.test.ts
@@ -34,7 +34,7 @@ import {
   DETACHABLE_PIN_HOLE_DIAMETER_MM,
   DETACHABLE_PIN_LEAD_IN_MM,
   DETACHABLE_PIN_TARGET_ENGAGEMENT_MM,
-  detachableFeetFloorMm,
+  binFloorMm,
   detachablePinEngagementMm,
   type FootLattice,
 } from '@/shared/types/bin';
@@ -405,7 +405,7 @@ describe('a bin built with detachable feet', () => {
     const { minZ } = boundingBox(m.vertices);
     const resolved = resolveDetachableFeet(binParams('detachable'));
     expect(resolved.placements.length).toBe(4);
-    const floor = detachableFeetFloorMm(FLOOR);
+    const floor = binFloorMm(FLOOR);
 
     for (const foot of resolved.placements) {
       for (const pin of footPinPositions(foot, resolved.armMm, resolved.pinDiameterMm)) {
@@ -424,7 +424,7 @@ describe('a bin built with detachable feet', () => {
     const m = bin('detachable');
     const { minZ } = boundingBox(m.vertices);
     const resolved = resolveDetachableFeet(binParams('detachable'));
-    const floor = detachableFeetFloorMm(FLOOR);
+    const floor = binFloorMm(FLOOR);
     expect(floor).toBeGreaterThan(FLOOR);
 
     const pin = footPinPositions(resolved.placements[0], resolved.armMm, resolved.pinDiameterMm)[0];
@@ -568,7 +568,7 @@ describe('a floor too thin to hold a pin', () => {
           // passes while a hole eats almost all of the band it is meant to
           // protect, which is the invariant the blind holes exist for.
           expect(isSolidThrough(m, pin.x, pin.y, top - MEMBRANE, top)).toBe(true);
-          const reach = detachablePinEngagementMm(detachableFeetFloorMm(wallThickness));
+          const reach = detachablePinEngagementMm(binFloorMm(wallThickness));
           expect(
             isSolidThrough(m, pin.x, pin.y, top - MEMBRANE - reach + 0.1, top - MEMBRANE - 0.1)
           ).toBe(false);

--- a/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
+++ b/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
@@ -25,11 +25,7 @@ import {
 } from 'brepjs';
 import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
-import {
-  hasDetachableFeet,
-  detachableFeetFloorMm,
-  DETACHABLE_PIN_HOLE_DIAMETER_MM,
-} from '@/shared/types/bin';
+import { hasDetachableFeet, binFloorMm, DETACHABLE_PIN_HOLE_DIAMETER_MM } from '@/shared/types/bin';
 import type { MeshData } from '../../bridge/types';
 import { footCellCentre, resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import { buildDetachableFeet } from './detachableFeetBuilder';
@@ -65,7 +61,7 @@ function buildFeetSolids(
     armMm: resolved.armMm,
     pinDiameterMm: resolved.pinDiameterMm,
     pinHoleDiameterMm: DETACHABLE_PIN_HOLE_DIAMETER_MM,
-    floorThicknessMm: detachableFeetFloorMm(params.wallThickness),
+    floorThicknessMm: binFloorMm(params.wallThickness),
     screw: resolved.screw,
     magnet: resolved.magnet
       ? {

--- a/src/features/generation/worker/generators/integratedLipBuilder.ts
+++ b/src/features/generation/worker/generators/integratedLipBuilder.ts
@@ -59,7 +59,9 @@ export function buildBinBoxWithLip(
   wallThickness: number,
   gridUnitMm: GridUnitInput = SIZE,
   cellMask?: CellMask,
-  overhang?: ResolvedOverhang
+  overhang?: ResolvedOverhang,
+  /** Interior floor thickness (mm); defaults to `wallThickness`. */
+  floorThickness?: number
 ): Shape3D {
   const polygon = isPartialMask(cellMask);
   const ov = polygon ? undefined : overhang;
@@ -151,7 +153,7 @@ export function buildBinBoxWithLip(
     // taper, as a single ruled loft. A single tool means there is no
     // second-tool junction plane to leave a coincident face.
     const innerSections: Sketch[] = [
-      sectionAt(wallThickness, wt),
+      sectionAt(floorThickness ?? wallThickness, wt),
       sectionAt(zAngleBottom, wt),
       sectionAt(zAngleBottom + FOOT, clampedInset(zAngleBottom + FOOT, INNER_ANGLE)),
       sectionAt(zExt, clampedInset(zExt, INNER_BASE)),

--- a/src/features/generation/worker/generators/lightweightBaseBuilder.ts
+++ b/src/features/generation/worker/generators/lightweightBaseBuilder.ts
@@ -210,6 +210,10 @@ export function buildLightweightBase(
     // Build a vertical prism over the whole base Z-range from a set of footprint
     // polygons. Returns null (and the caller skips that clip) on any degenerate
     // input rather than sinking the build.
+    //
+    // Reaches the FLOOR top, not the wall's: it clips the opening tools, so a
+    // prism that stopped short would truncate them inside the floor and re-seal
+    // every cup it was only meant to narrow.
     const buildClipPrism = (drawings: readonly Drawing[] | undefined): Shape3D | null => {
       if (!drawings || drawings.length === 0) return null;
       try {
@@ -219,7 +223,9 @@ export function buildLightweightBase(
               drawings.map(
                 (d) =>
                   scope.register(
-                    sketch(d, 'XY', -SOCKET_HEIGHT - 1).extrude(SOCKET_HEIGHT + wallThickness + 2)
+                    sketch(d, 'XY', -SOCKET_HEIGHT - 1).extrude(
+                      SOCKET_HEIGHT + (floorThickness ?? wallThickness) + 2
+                    )
                   ) as ValidSolid
               )
             )

--- a/src/features/generation/worker/generators/lightweightBaseBuilder.ts
+++ b/src/features/generation/worker/generators/lightweightBaseBuilder.ts
@@ -57,6 +57,7 @@ import { sketch } from './meshUtils';
 import {
   buildSingleCellSocket,
   buildSimplifiedCellSocket,
+  buildSocketTopPrism,
   forEachSocketCell,
   DEFAULT_FRACTIONAL_EDGE,
   type FractionalEdge,
@@ -152,7 +153,15 @@ export function buildLightweightBase(
   cellMask?: CellMask,
   openFloorDrawings?: readonly Drawing[],
   fractionalEdge: FractionalEdge = DEFAULT_FRACTIONAL_EDGE,
-  anchor: MagnetAnchor = DEFAULT_MAGNET_ANCHOR
+  anchor: MagnetAnchor = DEFAULT_MAGNET_ANCHOR,
+  /**
+   * Body floor thickness (mm); defaults to `wallThickness`.
+   *
+   * Only the floor OPENING reads it. The cup's own wall stays `wallThickness`:
+   * the opening tool has to reach the floor's top face to break through, and
+   * that face is the floor's, not the wall's.
+   */
+  floorThickness?: number
 ): LightweightBase {
   const usingMask = isPartialMask(cellMask);
   // Per-axis pitch: unitX scales width/columns, unitY scales depth/rows.
@@ -269,13 +278,29 @@ export function buildLightweightBase(
           translate(scope.register(unwrap(clone(innerFoot))), [cell.centerX, cell.centerY, zShift])
         );
         if (opensUpward) {
+          // The SAME shape as the void, at the same shift, so the opening is
+          // flush with the cup mouth. Shifting it further to reach a thicker
+          // floor would cut with a narrower slice of the taper and leave an
+          // unsupported horizontal ledge around every cup.
           openingTools.push(
             translate(scope.register(unwrap(clone(innerFoot))), [
               cell.centerX,
               cell.centerY,
-              wallThickness,
+              zShift,
             ])
           );
+          // What the void does not reach: a prism of the cup mouth carrying the
+          // opening the rest of the way up through the floor.
+          const remaining = (floorThickness ?? wallThickness) - zShift;
+          if (remaining > 0) {
+            openingTools.push(
+              translate(scope.register(buildSocketTopPrism(innerW, innerD, remaining)), [
+                cell.centerX,
+                cell.centerY,
+                zShift,
+              ])
+            );
+          }
         }
       },
       fractionalEdge

--- a/src/features/generation/worker/generators/pipeline/context.test.ts
+++ b/src/features/generation/worker/generators/pipeline/context.test.ts
@@ -79,6 +79,9 @@ describe('createInitialContext', () => {
       'rect',
       'none', // compartments segment
       '0', // overhang segment (no overhang)
+      // Floor segment: appended whenever the spec floor exceeds the wall, which
+      // is every wall under 2mm. Absent on a bin already walled that thick.
+      'floor2',
     ].join('|');
 
     expect(ctx.dimensions.shellKey).toBe(expected);

--- a/src/features/generation/worker/generators/pipeline/context.ts
+++ b/src/features/generation/worker/generators/pipeline/context.ts
@@ -8,7 +8,7 @@
 import type { BinParams } from '@/shared/types/bin';
 import {
   hasDetachableFeet,
-  detachableFeetFloorMm,
+  binFloorMm,
   hasDividerLean,
   isUndersideRelief,
   resolveTileFloorThickness,
@@ -86,9 +86,7 @@ export function deriveDimensions(
   // is skipped too, and the export is a flat-bottomed box with no feet part.
   const detachableFeet =
     hasDetachableFeet(params.base) && resolveDetachableFeet(params).placements.length > 0;
-  const floorThickness = detachableFeet
-    ? detachableFeetFloorMm(params.wallThickness)
-    : params.wallThickness;
+  const floorThickness = binFloorMm(params.wallThickness);
   // User flag only. When the mask has mixed half-bin detail, the socket
   // builder does a per-cell dispatch using the mask — it splits only
   // those 1u cells that straddle a half-bin boundary into quarter

--- a/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/shellStage.ts
@@ -120,7 +120,8 @@ export const shellStage: PipelineStage = {
         params.cellMask,
         openFloorDrawings,
         { x: params.fractionalEdgeX, y: params.fractionalEdgeY },
-        params.magnetAnchor
+        params.magnetAnchor,
+        dim.floorThickness
       );
       floorOpenings = liteBase.floorOpenings;
     }
@@ -176,10 +177,7 @@ export const shellStage: PipelineStage = {
         // The integrated builder mirrors the angled support unconditionally, so a
         // wall too short to carry one has to take the fuse path, where
         // `buildTopShape` can be told to leave it off.
-        dim.lipHasSupport &&
-        // Draft-only path, and only `buildBinBox` raises the floor — taking it
-        // would preview a floor the export does not have.
-        dim.floorThickness === params.wallThickness;
+        dim.lipHasSupport;
 
       let built = withScope((scope: DisposalScope) => {
         // Base-only bin: `boxWallHeight` is 0, and extruding a zero-length
@@ -251,7 +249,8 @@ export const shellStage: PipelineStage = {
               params.wallThickness,
               pitch,
               params.cellMask,
-              dim.overhang
+              dim.overhang,
+              dim.floorThickness
             );
             // One solid: the lip is not a separable origin here, so the whole
             // body carries the BASE tag (the exact path preserves the LIP tag).

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -317,6 +317,24 @@ export function filledSocketCells(
  * @param cellW_mm Physical width of this cell in mm (after clearance)
  * @param cellD_mm Physical depth of this cell in mm (after clearance)
  */
+/**
+ * A prism of a cell socket's TOP face, rising `heightMm` from z=0.
+ *
+ * The socket's top 0.25mm is already vertical, so this continues that face
+ * without a step. Lives here because the corner-radius clamp is the socket
+ * profile's, and a second copy of it is a ledge inside every cup.
+ */
+export function buildSocketTopPrism(cellW_mm: number, cellD_mm: number, heightMm: number): Shape3D {
+  const maxRadius = Math.min(cellW_mm, cellD_mm) / 2 - 0.1;
+  const cornerR = Math.min(CORNER_RADIUS, maxRadius);
+  return (
+    drawRoundedRectangle(cellW_mm, cellD_mm, Math.max(cornerR, 0.1)).sketchOnPlane(
+      'XY',
+      0
+    ) as Sketch
+  ).extrude(heightMm);
+}
+
 export function buildSingleCellSocket(cellW_mm: number, cellD_mm: number): Shape3D {
   // Clamp corner radius to fit within cell dimensions
   const maxRadius = Math.min(cellW_mm, cellD_mm) / 2 - 0.1;

--- a/src/features/generation/worker/generators/undersideRelief.kernel.test.ts
+++ b/src/features/generation/worker/generators/undersideRelief.kernel.test.ts
@@ -23,6 +23,8 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import type { BinParams } from '@/shared/types/bin';
+import { binFloorMm } from '@/shared/types/bin';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import type { MeshData } from '@/features/generation/bridge/types';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import { initTestKernel } from '@/test/initTestKernel';
@@ -169,4 +171,40 @@ describe('underside relief', () => {
     // ate into the wrong cells would break it before it broke any other check.
     expect(perCell(2, 2)).toBeCloseTo(perCell(1, 1), -1);
   }, 120000);
+});
+
+/**
+ * The interior relief opens the body floor over each cup mouth, and the tools
+ * that do it are clipped to the open-compartment region so a divider keeps a
+ * solid core beneath it. Both the opening and its clip are measured against the
+ * FLOOR, which is `binFloorMm` rather than the wall — a thin-walled bin has the
+ * widest gap between the two, so it is where a tool sized off the wall stops
+ * reaching and silently re-seals every cup.
+ *
+ * Sealed cups are watertight, manifold and of plausible triangle count. Only a
+ * column probe sees them.
+ */
+describe('the interior relief opens its cups whatever the wall', () => {
+  it.each([0.4, 0.8, 1.2, 1.6])(
+    'opens them at a %smm wall',
+    (wallThickness) => {
+      const m = bin(INTERIOR, {
+        width: 2,
+        depth: 1,
+        wallThickness,
+        // Multiple compartments, so the openings are clipped rather than used raw.
+        compartments: { cols: 3, rows: 1, thickness: 1.2, cells: [0, 1, 2] },
+      });
+      const { minZ } = boundingBox(m.vertices);
+      // The export mesh sits with the feet on its own minZ, so the cavity floor is
+      // a socket plus a floor above that.
+      const floorTop = minZ + GRIDFINITY_SPEC.SOCKET_HEIGHT + binFloorMm(wallThickness);
+      // Just under the cavity floor, at a cup mouth: open on the interior relief.
+      expect(isSolidThrough(m, 21, 0, floorTop - 0.3, floorTop - 0.05)).toBe(false);
+      // And between the cups the floor is still there, so this is an opening
+      // rather than a floor that simply failed to build.
+      expect(isSolidThrough(m, 0, 0, floorTop - 0.3, floorTop - 0.05)).toBe(true);
+    },
+    120000
+  );
 });

--- a/src/shared/printSettings/standardBinVolume.test.ts
+++ b/src/shared/printSettings/standardBinVolume.test.ts
@@ -24,16 +24,16 @@ import { DEFAULT_PRINT_SETTINGS } from '@/shared/printSettings';
  * and take `meshVolume` of the returned mesh (see `__kernel-tests__/meshAssertions`).
  */
 const OCCT_GROUND_TRUTH: ReadonlyArray<readonly [number, number, number, number]> = [
-  [1, 1, 3, 13525],
-  [1, 2, 3, 25180],
-  [2, 2, 3, 46238],
-  [3, 3, 3, 97757],
-  [1, 1, 6, 17449],
-  [2, 2, 6, 54395],
-  [2, 2, 9, 62553],
-  [1, 1, 2, 12217],
-  [3, 2, 5, 74146],
-  [4, 4, 6, 184709],
+  [1, 1, 3, 14747],
+  [1, 2, 3, 27716],
+  [2, 2, 3, 51500],
+  [3, 3, 3, 109884],
+  [1, 1, 6, 18673],
+  [2, 2, 6, 59660],
+  [2, 2, 9, 67819],
+  [1, 1, 2, 13438],
+  [3, 2, 5, 82135],
+  [4, 4, 6, 206526],
 ];
 
 describe('standardBinVolume', () => {
@@ -146,11 +146,11 @@ describe('standardBinVolume', () => {
       expect(est.costUSD).toBeGreaterThan(0);
     });
 
-    it('filament length matches the OCCT solid volume conversion (1×1×3u ≈ 5.62m)', () => {
+    it('filament length matches the OCCT solid volume conversion (1×1×3u ≈ 6.13m)', () => {
       const est = estimateStandardBinFilament(1, 1, 3);
-      // 13525mm³ / 2.405mm² / 1000 ≈ 5.62m
-      expect(est.metersFilament).toBeGreaterThan(5.62 * 0.9);
-      expect(est.metersFilament).toBeLessThan(5.62 * 1.1);
+      // 14747mm³ / 2.405mm² / 1000 ≈ 6.13m
+      expect(est.metersFilament).toBeGreaterThan(6.13 * 0.9);
+      expect(est.metersFilament).toBeLessThan(6.13 * 1.1);
     });
 
     it('is monotonic: larger bins cost more and take longer', () => {

--- a/src/shared/printSettings/standardBinVolume.ts
+++ b/src/shared/printSettings/standardBinVolume.ts
@@ -46,20 +46,15 @@ const WALL_EFF = 1.165;
 
 /**
  * Floor + base socket feet material per unit of cell footprint area (mm³/mm²),
- * calibrated to OCCT geometry. At the standard 42mm pitch this is ≈9488mm³ per
+ * calibrated to OCCT geometry. At the standard 42mm pitch this is ≈10838mm³ per
  * 42×42 cell; expressing it per unit area lets it scale to other grid pitches
  * (e.g. half-pitch sockets) without hardcoding the reference pitch.
- *   9488 mm³ / (42mm)² ≈ 5.3785 mm³/mm²
+ *   10838 mm³ / (42mm)² ≈ 6.1441 mm³/mm²
  *
- * The previous 1.2483 was fitted to a ground-truth set that did not contain the
- * base socket — a solid 1u foot is ~7300mm³ on its own, more than the entire
- * measured volume it was fitted against. That left every socketed bin under-
- * reported by 1.7x (a tall 1x1) to 3.0x (a 3x3), the error growing with cell
- * count exactly as a missing per-cell term does. Refitted by least squares over
- * the ten bins in `OCCT_GROUND_TRUTH`, holding `WALL_EFF` and `LIP_AREA`: worst
- * residual 1.1%, and 9 of 10 within 0.5%.
+ * Fitted by least squares over the ten bins in `OCCT_GROUND_TRUTH`, holding
+ * `WALL_EFF` and `LIP_AREA`: worst residual 1.7%, 7 of 10 within 0.5%.
  */
-const BASE_VOL_PER_CELL_AREA = 5.3785;
+const BASE_VOL_PER_CELL_AREA = 6.1441;
 
 /**
  * The FEET alone, per unit of cell footprint area (mm³/mm²) — the part of

--- a/src/shared/printSettings/standardBinVolume.ts
+++ b/src/shared/printSettings/standardBinVolume.ts
@@ -45,14 +45,12 @@ import { GRIDFINITY_SPEC } from './gridfinityGeometry';
 const WALL_EFF = 1.165;
 
 /**
- * Floor + base socket feet material per unit of cell footprint area (mm³/mm²),
- * calibrated to OCCT geometry. At the standard 42mm pitch this is ≈10838mm³ per
- * 42×42 cell; expressing it per unit area lets it scale to other grid pitches
- * (e.g. half-pitch sockets) without hardcoding the reference pitch.
- *   10838 mm³ / (42mm)² ≈ 6.1441 mm³/mm²
+ * Floor + base socket feet material per unit of cell footprint area (mm³/mm²).
+ * Per unit AREA so it scales to other grid pitches (half-pitch sockets, say)
+ * without hardcoding the reference pitch.
  *
- * Fitted by least squares over the ten bins in `OCCT_GROUND_TRUTH`, holding
- * `WALL_EFF` and `LIP_AREA`: worst residual 1.7%, 7 of 10 within 0.5%.
+ * Re-derive by least squares over `OCCT_GROUND_TRUTH`, holding `WALL_EFF` and
+ * `LIP_AREA`. Any change to the floor or the socket invalidates it.
  */
 const BASE_VOL_PER_CELL_AREA = 6.1441;
 

--- a/src/shared/types/bin.ts
+++ b/src/shared/types/bin.ts
@@ -287,7 +287,7 @@ export {
   DETACHABLE_PIN_MIN_ENGAGEMENT_MM,
   detachablePinEngagementMm,
   detachableFeetFitFloor,
-  detachableFeetFloorMm,
+  binFloorMm,
   DETACHABLE_PIN_TARGET_ENGAGEMENT_MM,
   DETACHABLE_PIN_RIDGE_STEP_MM,
   DETACHABLE_PIN_LEAD_IN_MM,


### PR DESCRIPTION
Follow-up to #3704, which put detachable-feet bins on the Gridfinity dead-space convention. Integral bins were still under it.

## What was wrong

Bins shelled their floor to `wallThickness`, so the cavity floor sat below the plane `GRIDFINITY.BASE_HEIGHT` puts it at. Measured from real meshes:

| wall | dead space before | after |
|---|---|---|
| 0.95mm (spec) | 5.95 | **7.00** |
| 1.2mm (default) | 6.20 | **7.00** |
| 1.6mm | 6.60 | **7.00** |
| 2.4mm | 7.40 | 7.40 (keeps its own thicker floor) |

`detachableFeetFloorMm` becomes `binFloorMm` and serves every bin. `dim.floorThickness` is what the pipeline builds and what every floor-plane consumer reads.

## Three things assumed the floor was the wall

**The integrated-lip builder** starts its cavity loft at `wallThickness`. It is draft-only, so leaving it would have previewed a floor the export does not have — the one divergence no mesh check reports. It takes the resolved floor now.

**Lightweight floor openings** are the cup void's own shape lifted to the floor top. Sized to `wallThickness` they stopped breaking through a 2mm floor, sealing every cup on the interior relief. The result was watertight, manifold, and completely wrong — caught only by probing a column through a cup:

```
                  main            broken
interior cup: ######......  ###################...   <- sealed
interior mid: .....######.  .........##########...
```

**Lifting that tool** then cut the floor with a narrower slice of the socket taper, leaving an unsupported horizontal ledge round every cup. The overhang probe went 52 → 278mm², and 262mm² of that was near-horizontal. The tool now stays flush with the void and a prism of the cup mouth (`buildSocketTopPrism`, so the corner-radius clamp is not duplicated) carries the opening the rest of the way up. All five probe cases are back to the 52mm² solid-floor baseline.

## Estimator refit

The analytic model is a fit to measured solids, so moving the geometry invalidates it. All ten `OCCT_GROUND_TRUTH` bins re-measured and `BASE_VOL_PER_CELL_AREA` refit by least squares holding `WALL_EFF` and `LIP_AREA`:

```
5.3785 -> 6.1441   worst residual 1.7%, 7 of 10 within 0.5%
```

`solidFillVolume` now starts at the floor top — the base term prices material up to it, so a fill starting at `wallThickness` counted the difference twice (a 2x2 solid bin was 5.6% over its measured volume).

## Verification

- Full suite: **24,035 passing**
- 29 `triangleCount` snapshots updated; deltas ±8 to +160 in both directions, every `structural` scenario passing throughout
- Estimates check against measured geometry within 0.5% (2×2×3u integral: 51500 measured / 51599 estimated)
- Detachable saving vs integral: 35–57%

## Cost

Every bin's cavity is **0.25mm to 1.05mm shallower** and uses correspondingly more filament. Existing designs re-render with the new floor. Both are consequences of building what the spec describes rather than what shelling happened to produce.

https://claude.ai/code/session_018grzGgWpPLDxEApqqGCbmZ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

