### PR TITLE
fix(bin-designer): start stacking-lip color above the bin's top surface

### DIFF
--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -389,15 +389,16 @@ function lidColorConfig(
   const grid = featureColors.lidLip;
   if (!grid) return null;
   const counts = { corners: grid.corners, bands: grid.bands };
+  const getTriangle = (t: number): Float32Array => vertices.subarray(t * 9, t * 9 + 9);
   const triangleXYZ = (t: number) => {
-    const i = t * 9;
+    const v = getTriangle(t);
     return {
-      x: (vertices[i] + vertices[i + 3] + vertices[i + 6]) / 3,
-      y: (vertices[i + 1] + vertices[i + 4] + vertices[i + 7]) / 3,
-      z: (vertices[i + 2] + vertices[i + 5] + vertices[i + 8]) / 3,
+      x: (v[0] + v[3] + v[6]) / 3,
+      y: (v[1] + v[4] + v[7]) / 3,
+      z: (v[2] + v[5] + v[8]) / 3,
     };
   };
-  const geom = computeLidLipGeom(faceGroups, triangleXYZ);
+  const geom = computeLidLipGeom(faceGroups, getTriangle);
   if (!geom) return null;
 
   const { colors, colorToIndex } = resolveColorMapping(featureColors);

--- a/src/features/bin-designer/utils/lidColorGroups.ts
+++ b/src/features/bin-designer/utils/lidColorGroups.ts
@@ -38,19 +38,33 @@ export function buildLidColorGroups(
   const grid = featureColors.lidLip;
   if (!grid || !faceGroups || !vertices || !indices) return null;
 
-  const triangleXYZ = (t: number) => {
+  const getTriangle = (t: number): number[] => {
     const i = t * 3;
     const a = indices[i] * 3;
     const b = indices[i + 1] * 3;
     const c = indices[i + 2] * 3;
+    return [
+      vertices[a],
+      vertices[a + 1],
+      vertices[a + 2],
+      vertices[b],
+      vertices[b + 1],
+      vertices[b + 2],
+      vertices[c],
+      vertices[c + 1],
+      vertices[c + 2],
+    ];
+  };
+  const triangleXYZ = (t: number) => {
+    const v = getTriangle(t);
     return {
-      x: (vertices[a] + vertices[b] + vertices[c]) / 3,
-      y: (vertices[a + 1] + vertices[b + 1] + vertices[c + 1]) / 3,
-      z: (vertices[a + 2] + vertices[b + 2] + vertices[c + 2]) / 3,
+      x: (v[0] + v[3] + v[6]) / 3,
+      y: (v[1] + v[4] + v[7]) / 3,
+      z: (v[2] + v[5] + v[8]) / 3,
     };
   };
 
-  const geom = computeLidLipGeom(faceGroups, triangleXYZ);
+  const geom = computeLidLipGeom(faceGroups, getTriangle);
   if (!geom) return null;
 
   const counts = { corners: grid.corners, bands: grid.bands };

--- a/src/features/bin-designer/utils/lipCornerClassifier.test.ts
+++ b/src/features/bin-designer/utils/lipCornerClassifier.test.ts
@@ -8,6 +8,16 @@ import {
 } from './lipCornerClassifier';
 import type { LipGeom } from './lipCornerClassifier';
 import type { FaceGroupData } from '@/shared/types/generation';
+import { GRIDFINITY_SPEC, PRINT_SETTINGS_CONSTRAINTS } from '@/shared/printSettings';
+
+/** A point-sized triangle: its centroid and every vertex sit at (x, y, z). */
+const triAt = (x: number, y: number, z: number): number[] => [x, y, z, x, y, z, x, y, z];
+
+/** The rule under test: one max layer above the wall the lip is fused onto. */
+const expectedFloorZ = (peakZ: number): number =>
+  peakZ -
+  (GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP) +
+  PRINT_SETTINGS_CONSTRAINTS.LAYER_HEIGHT_MAX;
 
 describe('classifyLipCorner', () => {
   const cx = 50;
@@ -48,7 +58,7 @@ describe('classifyLipBand', () => {
 });
 
 describe('classifyLipCell', () => {
-  const geom: LipGeom = { cx: 0, cy: 0, minZ: 0, maxZ: 10 };
+  const geom: LipGeom = { cx: 0, cy: 0, minZ: 0, maxZ: 10, floorZ: 0 };
 
   it('collapses to a single canonical cell at 1×1', () => {
     expect(classifyLipCell(5, 5, 8, geom, { corners: 1, bands: 1 })).toBe('lip:frontLeft:0');
@@ -69,21 +79,14 @@ describe('classifyLipCell', () => {
 describe('computeLipGeom', () => {
   it('returns null when no LIP face groups exist', () => {
     const faceGroups: FaceGroupData[] = [{ start: 0, count: 3, tag: FeatureTag.BASE }];
-    expect(computeLipGeom(faceGroups, () => ({ x: 0, y: 0, z: 0 }))).toBeNull();
+    expect(computeLipGeom(faceGroups, () => triAt(0, 0, 0))).toBeNull();
   });
 
   it('centers on the midpoint of LIP centroid extents and tracks Z range', () => {
     const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.LIP }];
-    const centroids = [
-      { x: 10, y: 20, z: 2 },
-      { x: 90, y: 60, z: 8 },
-    ];
-    expect(computeLipGeom(faceGroups, (i) => centroids[i])).toEqual({
-      cx: 50,
-      cy: 40,
-      minZ: 2,
-      maxZ: 8,
-    });
+    const tris = [triAt(10, 20, 2), triAt(90, 60, 8)];
+    const geom = computeLipGeom(faceGroups, (i) => tris[i]);
+    expect(geom).toMatchObject({ cx: 50, cy: 40, minZ: 2, maxZ: 8 });
   });
 
   it('ignores non-LIP face groups', () => {
@@ -91,15 +94,54 @@ describe('computeLipGeom', () => {
       { start: 0, count: 3, tag: FeatureTag.BASE },
       { start: 3, count: 3, tag: FeatureTag.LIP },
     ];
-    const centroids = [
-      { x: 1000, y: 1000, z: 1000 },
-      { x: 10, y: 20, z: 5 },
-    ];
-    expect(computeLipGeom(faceGroups, (i) => centroids[i])).toEqual({
+    const tris = [triAt(1000, 1000, 1000), triAt(10, 20, 5)];
+    expect(computeLipGeom(faceGroups, (i) => tris[i])).toMatchObject({
       cx: 10,
       cy: 20,
       minZ: 5,
       maxZ: 5,
     });
+  });
+
+  it('floors the colorable region just above the wall top, not at the support skirt', () => {
+    // Real 6u lip extents: peak 46.3, skirt bottom 39.3, wall top 42.
+    const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.LIP }];
+    const tris = [triAt(-10, -10, 39.3), triAt(10, 10, 46.3)];
+    const geom = computeLipGeom(faceGroups, (i) => tris[i]);
+    expect(geom?.floorZ).toBeCloseTo(expectedFloorZ(46.3), 6);
+    expect(geom?.floorZ).toBeGreaterThan(42);
+  });
+
+  it('reads the peak from vertices, so tessellation cannot drag the floor down', () => {
+    const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.LIP }];
+    // The tall triangle's centroid sits well under the apex it reaches.
+    const tall = [0, 0, 44.3, 0, 0, 44.3, 0, 0, 46.3];
+    const tris = [triAt(0, 0, 39.5), tall];
+    const geom = computeLipGeom(faceGroups, (i) => tris[i]);
+    expect(geom?.maxZ).toBeCloseTo(44.9667, 3);
+    expect(geom?.floorZ).toBeCloseTo(expectedFloorZ(46.3), 6);
+  });
+
+  it('never floors past the lip extent when the support skirt is absent', () => {
+    const faceGroups: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.LIP }];
+    // A lip built without its angled support starts at its own base plane.
+    const tris = [triAt(-10, -10, 45.9), triAt(10, 10, 46.3)];
+    const geom = computeLipGeom(faceGroups, (i) => tris[i]);
+    expect(geom?.floorZ).toBe(45.9);
+  });
+});
+
+describe('classifyLipCell below the color floor', () => {
+  const geom: LipGeom = { cx: 0, cy: 0, minZ: 39.3, maxZ: 46.3, floorZ: 42.32 };
+
+  it('returns null for the support skirt so it takes the body color', () => {
+    expect(classifyLipCell(10, 10, 40, geom, { corners: 4, bands: 4 })).toBeNull();
+    expect(classifyLipCell(10, 10, 42.32, geom, { corners: 4, bands: 4 })).toBeNull();
+  });
+
+  it('divides the bands over the colorable extent only', () => {
+    // 4 bands over [42.32, 46.3] = 0.995mm each.
+    expect(classifyLipCell(10, 10, 42.4, geom, { corners: 1, bands: 4 })).toBe('lip:frontLeft:0');
+    expect(classifyLipCell(10, 10, 46.3, geom, { corners: 1, bands: 4 })).toBe('lip:frontLeft:3');
   });
 });

--- a/src/features/bin-designer/utils/lipCornerClassifier.ts
+++ b/src/features/bin-designer/utils/lipCornerClassifier.ts
@@ -7,8 +7,28 @@
 
 import { FeatureTag } from '@/shared/types/generation';
 import type { FaceGroupData } from '@/shared/types/generation';
+import { GRIDFINITY_SPEC, PRINT_SETTINGS_CONSTRAINTS } from '@/shared/printSettings';
 import { collapseLipCell } from '../types/featureColors';
 import type { LipCorner, LipBand, LipAxisCount, LipCellZone } from '../types/featureColors';
+
+/**
+ * Height the lip solid stands above the wall it is fused onto, so the wall top
+ * can be recovered from the lip's own peak without the caller passing the bin's
+ * dimensions in.
+ */
+const LIP_PROTRUSION_MM = GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP;
+
+/**
+ * Gap between the wall top and the first colourable lip geometry.
+ *
+ * The bin's top surface can reach the wall top exactly (a cutout plate, a
+ * lowered fill), and a slicer finishes that surface in the layer straddling it.
+ * Colour reaching into that layer forces a filament change per top-surface
+ * layer. One max-supported layer of clearance keeps the boundary clear of it at
+ * every layer height the app allows, so the value need not be plumbed through
+ * from print settings.
+ */
+const LIP_COLOR_FLOOR_CLEARANCE_MM = PRINT_SETTINGS_CONSTRAINTS.LAYER_HEIGHT_MAX;
 
 /** Lip footprint geometry needed to classify a triangle into a grid cell. */
 export interface LipGeom {
@@ -16,7 +36,23 @@ export interface LipGeom {
   readonly cy: number;
   readonly minZ: number;
   readonly maxZ: number;
+  /**
+   * Bottom of the colourable region — bands divide `[floorZ, maxZ]`, and lip
+   * geometry below it takes the body colour instead of a lip cell.
+   *
+   * `buildTopShape` hangs an angled support `LIP_TAPER_WIDTH` under the lip's
+   * base plane to blend into the wall, and it carries the LIP tag, so `minZ`
+   * sits ~2.7mm BELOW the bin's top surface. Colouring from there paints the
+   * wall and the top surface's own layers (#3705).
+   */
+  readonly floorZ: number;
 }
+
+/**
+ * Returns the 9 position floats of one triangle, in triangle order.
+ * Matches `lipSeamSplitter`'s accessor so a caller builds one for both.
+ */
+export type TriangleAccessor = (triangleIndex: number) => ArrayLike<number>;
 
 /**
  * Compute the lip footprint's center and Z extent from LIP triangle
@@ -27,9 +63,19 @@ export interface LipGeom {
  */
 export function computeLipGeom(
   faceGroups: readonly FaceGroupData[],
-  triangleXYZ: (triangleIndex: number) => { x: number; y: number; z: number }
+  getTriangle: TriangleAccessor
 ): LipGeom | null {
-  return computeTaggedGeom(faceGroups, triangleXYZ, FeatureTag.LIP);
+  const geom = computeTaggedGeom(faceGroups, getTriangle, FeatureTag.LIP);
+  if (!geom) return null;
+  // `peakZ`, not the centroid-derived `maxZ`: the wall top is a fixed offset
+  // below the lip's actual apex, and centroids sit however far under it the
+  // tessellation happens to put them.
+  const wallTopZ = geom.peakZ - LIP_PROTRUSION_MM;
+  // Clamped into [minZ, maxZ]: a lip whose support was omitted (`lipHasSupport`
+  // false on a short wall) already starts at its base plane, and a degenerate
+  // extent must not invert the band interval.
+  const floorZ = Math.min(Math.max(geom.minZ, wallTopZ + LIP_COLOR_FLOOR_CLEARANCE_MM), geom.maxZ);
+  return { ...geom, floorZ };
 }
 
 /**
@@ -38,25 +84,29 @@ export function computeLipGeom(
  * Separate entry point rather than a shared default parameter so a caller
  * cannot accidentally classify one object's triangles against the other's
  * footprint — the bin and the lid are different meshes with different extents.
+ *
+ * No colour floor: the lid's stack grid is a slab extruded UP from the lid's
+ * top face, so none of it hides under the surface it sits on.
  */
 export function computeLidLipGeom(
   faceGroups: readonly FaceGroupData[],
-  triangleXYZ: (triangleIndex: number) => { x: number; y: number; z: number }
+  getTriangle: TriangleAccessor
 ): LipGeom | null {
-  return computeTaggedGeom(faceGroups, triangleXYZ, FeatureTag.LID_LIP);
+  return computeTaggedGeom(faceGroups, getTriangle, FeatureTag.LID_LIP);
 }
 
 function computeTaggedGeom(
   faceGroups: readonly FaceGroupData[],
-  triangleXYZ: (triangleIndex: number) => { x: number; y: number; z: number },
+  getTriangle: TriangleAccessor,
   tag: number
-): LipGeom | null {
+): (LipGeom & { peakZ: number }) | null {
   let minX = Infinity;
   let maxX = -Infinity;
   let minY = Infinity;
   let maxY = -Infinity;
   let minZ = Infinity;
   let maxZ = -Infinity;
+  let peakZ = -Infinity;
   let any = false;
 
   for (const g of faceGroups) {
@@ -64,19 +114,27 @@ function computeTaggedGeom(
     const triStart = g.start / 3;
     const triEnd = triStart + g.count / 3;
     for (let i = triStart; i < triEnd; i++) {
-      const { x, y, z } = triangleXYZ(i);
+      const t = getTriangle(i);
+      const x = (t[0] + t[3] + t[6]) / 3;
+      const y = (t[1] + t[4] + t[7]) / 3;
+      const z = (t[2] + t[5] + t[8]) / 3;
       if (x < minX) minX = x;
       if (x > maxX) maxX = x;
       if (y < minY) minY = y;
       if (y > maxY) maxY = y;
       if (z < minZ) minZ = z;
       if (z > maxZ) maxZ = z;
+      if (t[2] > peakZ) peakZ = t[2];
+      if (t[5] > peakZ) peakZ = t[5];
+      if (t[8] > peakZ) peakZ = t[8];
       any = true;
     }
   }
 
   if (!any) return null;
-  return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2, minZ, maxZ };
+  // `floorZ = minZ` is the no-op default: only the bin lip hangs geometry below
+  // the surface it sits on, and `computeLipGeom` narrows it there.
+  return { cx: (minX + maxX) / 2, cy: (minY + maxY) / 2, minZ, maxZ, floorZ: minZ, peakZ };
 }
 
 /**
@@ -115,9 +173,21 @@ export function classifyLipBand(
 }
 
 /**
+ * True when {@link LipGeom.floorZ} actually carves a slice off the bottom of
+ * the lip. False for the lid grid and for any lip that starts at its own base
+ * plane, so those keep the historic whole-extent behaviour.
+ */
+export function lipColorFloorActive(geom: LipGeom): boolean {
+  return geom.floorZ > geom.minZ && geom.floorZ < geom.maxZ;
+}
+
+/**
  * Classify a lip triangle centroid into the canonical grid cell for the
  * active corner/band counts. The single source of truth shared by the
  * splitter, preview, exporter, and hit-test resolver.
+ *
+ * Null below {@link LipGeom.floorZ} — the support skirt there belongs to the
+ * wall, not to any lip cell, and the caller resolves it to the body colour.
  */
 export function classifyLipCell(
   x: number,
@@ -125,8 +195,9 @@ export function classifyLipCell(
   z: number,
   geom: LipGeom,
   counts: { corners: LipAxisCount; bands: LipAxisCount }
-): LipCellZone {
+): LipCellZone | null {
+  if (z <= geom.floorZ && lipColorFloorActive(geom)) return null;
   const corner = classifyLipCorner(x, y, geom.cx, geom.cy);
-  const band = classifyLipBand(z, geom.minZ, geom.maxZ, counts.bands);
+  const band = classifyLipBand(z, geom.floorZ, geom.maxZ, counts.bands);
   return collapseLipCell(corner, band, counts);
 }

--- a/src/features/bin-designer/utils/lipSeamSplitter.test.ts
+++ b/src/features/bin-designer/utils/lipSeamSplitter.test.ts
@@ -22,7 +22,9 @@ const QUAD: number[][] = [
   [-10, 5, 0, 10, 5, 0, 10, 5, 10],
   [-10, 5, 0, 10, 5, 10, -10, 5, 10],
 ];
-const GEOM: LipGeom = { cx: 0, cy: 0, minZ: 0, maxZ: 10 };
+// floorZ === minZ: this fixture is a bare quad, not a real lip, so no support
+// skirt has to be cut away from the colored region.
+const GEOM: LipGeom = { cx: 0, cy: 0, minZ: 0, maxZ: 10, floorZ: 0 };
 const FACE_GROUPS: FaceGroupData[] = [{ start: 0, count: 6, tag: FeatureTag.LIP }];
 
 function run(counts: { corners: 1 | 2 | 4; bands: 1 | 2 | 4 }) {
@@ -126,6 +128,64 @@ describe('lipSeamSplitter', () => {
     const uniform = computeLipColoredMesh({ ...base, lipUniform: true });
     expect(uniform.positions).toBeNull();
     expect(uniform.triZones).toHaveLength(QUAD.length);
+  });
+});
+
+describe('lip color floor', () => {
+  // A 6u bin's outer face over the lip: skirt bottom 39.3, wall top 42, peak
+  // 46.3, floor 42.32. One quad, exactly as the kernel tessellates the flush
+  // wall/lip face.
+  const FLOOR_Z = 42.32;
+  const FACE: number[][] = [
+    [-10, 5, 39.3, 10, 5, 39.3, 10, 5, 46.3],
+    [-10, 5, 39.3, 10, 5, 46.3, -10, 5, 46.3],
+  ];
+  const LIP_GEOM: LipGeom = { cx: 0, cy: 0, minZ: 39.3, maxZ: 46.3, floorZ: FLOOR_Z };
+
+  const run = (counts: { corners: 1 | 2 | 4; bands: 1 | 2 | 4 }, lipUniform: boolean) =>
+    computeLipColoredMesh({
+      triangleCount: FACE.length,
+      faceGroups: FACE_GROUPS,
+      getTriangle: (i) => FACE[i],
+      geom: LIP_GEOM,
+      counts,
+      lipUniform,
+    });
+
+  it('cuts a uniform lip at the floor so the skirt keeps the body color', () => {
+    // The whole point of #3705: with one lip color there are no seams, but the
+    // face still has to be cut or its centroid paints the skirt too.
+    const { triZones, positions } = run({ corners: 1, bands: 1 }, true);
+    expect(positions).not.toBeNull();
+    for (let i = 0; i < triZones.length; i++) {
+      const t = positions!.subarray(i * 9, i * 9 + 9);
+      const cz = (t[2] + t[5] + t[8]) / 3;
+      expect(triZones[i]).toBe(cz <= FLOOR_Z ? 'body' : 'lip:frontLeft:0');
+    }
+    expect(triZones).toContain('body');
+    expect(triZones).toContain('lip:frontLeft:0');
+  });
+
+  it('never lands a band below the floor', () => {
+    const { triZones, positions } = run({ corners: 1, bands: 4 }, false);
+    for (let i = 0; i < triZones.length; i++) {
+      const t = positions!.subarray(i * 9, i * 9 + 9);
+      const cz = (t[2] + t[5] + t[8]) / 3;
+      if (cz <= FLOOR_Z) expect(triZones[i]).toBe('body');
+    }
+    // Bands still span the full 0..3 range, just over [floorZ, maxZ].
+    expect(new Set(triZones)).toEqual(
+      new Set(['body', 'lip:frontLeft:0', 'lip:frontLeft:1', 'lip:frontLeft:2', 'lip:frontLeft:3'])
+    );
+  });
+
+  it('conserves area across the floor cut', () => {
+    const inputArea = FACE.reduce((s, t) => s + triArea(t), 0);
+    const { triZones, positions } = run({ corners: 1, bands: 1 }, true);
+    let outArea = 0;
+    for (let i = 0; i < triZones.length; i++)
+      outArea += triArea(positions!.subarray(i * 9, i * 9 + 9));
+    expect(outArea).toBeCloseTo(inputArea, 4);
   });
 });
 

--- a/src/features/bin-designer/utils/lipSeamSplitter.ts
+++ b/src/features/bin-designer/utils/lipSeamSplitter.ts
@@ -15,7 +15,7 @@
 
 import { FeatureTag } from '@/shared/types/generation';
 import type { FaceGroupData } from '@/shared/types/generation';
-import { classifyLipCell, type LipGeom } from './lipCornerClassifier';
+import { classifyLipCell, lipColorFloorActive, type LipGeom } from './lipCornerClassifier';
 import { featureTagToColorZone } from '../types/featureColors';
 import type { ColorZone, LipAxisCount } from '../types/featureColors';
 
@@ -176,11 +176,27 @@ function seamPlanes(
   // corners: 2 → front/back (y); 4 → also left/right (x).
   if (counts.corners >= 2) planes.push({ axis: 1, c: geom.cy });
   if (counts.corners === 4) planes.push({ axis: 0, c: geom.cx });
-  // bands: interior horizontal planes.
-  if (counts.bands >= 2 && geom.maxZ > geom.minZ) {
-    const step = (geom.maxZ - geom.minZ) / counts.bands;
-    for (let k = 1; k < counts.bands; k++) planes.push({ axis: 2, c: geom.minZ + k * step });
+  // bands: interior horizontal planes, dividing the COLORABLE extent.
+  if (counts.bands >= 2 && geom.maxZ > geom.floorZ) {
+    const step = (geom.maxZ - geom.floorZ) / counts.bands;
+    for (let k = 1; k < counts.bands; k++) planes.push({ axis: 2, c: geom.floorZ + k * step });
   }
+  return planes;
+}
+
+/**
+ * Planes every lip triangle is cut along, whatever the grid. The color floor
+ * applies even to a uniform lip: without the cut, the outer face is one tall
+ * quad whose centroid sits above the floor, so the whole skirt would take lip
+ * color anyway — the case #3705 was filed for.
+ */
+function lipCutPlanes(
+  geom: LipGeom,
+  counts: { corners: LipAxisCount; bands: LipAxisCount },
+  splitLipGrid: boolean
+): { axis: 0 | 1 | 2; c: number }[] {
+  const planes = splitLipGrid ? seamPlanes(geom, counts) : [];
+  if (lipColorFloorActive(geom)) planes.push({ axis: 2, c: geom.floorZ });
   return planes;
 }
 
@@ -202,7 +218,7 @@ export function splitLipMesh(input: LipSplitInput): LipSplitResult {
   // them, since `> cutZ` and `<= bottomCutZ` partition the axis.
   const bottomPlane = bottomCutZ !== null && bottomCutZ !== cutZ ? bottomCutZ : null;
   const tags = buildTriTags(faceGroups, triangleCount);
-  const lipPlanes = geom && splitLipGrid ? seamPlanes(geom, counts) : [];
+  const lipPlanes = geom ? lipCutPlanes(geom, counts, splitLipGrid) : [];
 
   const positions: number[] = [];
   const triZones: ColorZone[] = [];
@@ -256,7 +272,12 @@ function classifyPiece(
 ): ColorZone {
   if (ctx.cutZ !== null && cz > ctx.cutZ) return 'topAccent';
   if (ctx.bottomCutZ !== null && cz <= ctx.bottomCutZ) return 'bottomAccent';
-  if (ctx.isLip && ctx.geom !== null) return classifyLipCell(cx, cy, cz, ctx.geom, ctx.counts);
+  if (ctx.isLip && ctx.geom !== null) {
+    // Null = under the color floor, i.e. the support skirt that blends into the
+    // wall. It falls through to the tag lookup, which sends LIP to `body`.
+    const cell = classifyLipCell(cx, cy, cz, ctx.geom, ctx.counts);
+    if (cell !== null) return cell;
+  }
   return featureTagToColorZone(ctx.tag) ?? 'body';
 }
 
@@ -311,10 +332,12 @@ export function computeLipColoredMesh(input: {
   const allowSplit = input.allowSplit ?? true;
   const splitLipGrid = !!geom && lipGridIsNonTrivial(counts) && !lipUniform;
   const anyAccent = cutZ !== null || bottomCutZ !== null;
+  const splitLipFloor = !!geom && lipColorFloorActive(geom);
 
   // Re-tessellate when there are exact color boundaries to honor: a non-uniform
-  // lip grid, or an accent cut (which slices every triangle at its Z plane).
-  if (allowSplit && (splitLipGrid || anyAccent)) {
+  // lip grid, the color floor, or an accent cut (which slices every triangle at
+  // its Z plane).
+  if (allowSplit && (splitLipGrid || splitLipFloor || anyAccent)) {
     const r = splitLipMesh({
       triangleCount,
       faceGroups,

--- a/src/features/bin-designer/utils/materialMapping.ts
+++ b/src/features/bin-designer/utils/materialMapping.ts
@@ -113,16 +113,7 @@ export function buildTriangleMaterialIndices(
       vertices[b + 8],
     ];
   };
-  const triangleXYZ = (i: number) => {
-    const b = i * 9;
-    return {
-      x: (vertices[b] + vertices[b + 3] + vertices[b + 6]) / 3,
-      y: (vertices[b + 1] + vertices[b + 4] + vertices[b + 7]) / 3,
-      z: (vertices[b + 2] + vertices[b + 5] + vertices[b + 8]) / 3,
-    };
-  };
-
-  const geom = computeLipGeom(faceGroups, triangleXYZ);
+  const geom = computeLipGeom(faceGroups, getTriangle);
   const { triZones, positions, normals, triTags } = computeLipColoredMesh({
     triangleCount,
     faceGroups,

--- a/src/features/bin-designer/utils/multiColorGroups.ts
+++ b/src/features/bin-designer/utils/multiColorGroups.ts
@@ -88,17 +88,6 @@ function meshAccessors(
   getTriangle: (i: number) => number[];
 } {
   const triangleCount = indices.length / 3;
-  const triangleXYZ = (triIdx: number) => {
-    const i = triIdx * 3;
-    const a = indices[i] * 3;
-    const b = indices[i + 1] * 3;
-    const c = indices[i + 2] * 3;
-    return {
-      x: (vertices[a] + vertices[b] + vertices[c]) / 3,
-      y: (vertices[a + 1] + vertices[b + 1] + vertices[c + 1]) / 3,
-      z: (vertices[a + 2] + vertices[b + 2] + vertices[c + 2]) / 3,
-    };
-  };
   const getTriangle = (i: number): number[] => {
     const base = i * 3;
     const a = indices[base] * 3;
@@ -116,7 +105,7 @@ function meshAccessors(
       vertices[c + 2],
     ];
   };
-  return { triangleCount, geom: computeLipGeom(faceGroups, triangleXYZ), getTriangle };
+  return { triangleCount, geom: computeLipGeom(faceGroups, getTriangle), getTriangle };
 }
 
 /**

--- a/src/features/generation/worker/generators/lipMultiColor.test.ts
+++ b/src/features/generation/worker/generators/lipMultiColor.test.ts
@@ -18,6 +18,7 @@ import { buildParams } from './__kernel-tests__/scenarioTypes';
 import { computeLipGeom } from '@/features/bin-designer/utils/lipCornerClassifier';
 import { computeLipColoredMesh } from '@/features/bin-designer/utils/lipSeamSplitter';
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings';
 import { FeatureTag } from './featureTags';
 import type { LipAxisCount } from '@/features/bin-designer/types/featureColors';
 
@@ -78,14 +79,7 @@ describe('lip multi-color splitter (generated bin)', () => {
     for (let i = 0; i < triangleCount; i++) flat.set(getIndexed(i), i * 9);
     const getFlat = (i: number): number[] => Array.from(flat.subarray(i * 9, i * 9 + 9));
 
-    const geom = computeLipGeom(faceGroups ?? [], (i) => {
-      const t = getIndexed(i);
-      return {
-        x: (t[0] + t[3] + t[6]) / 3,
-        y: (t[1] + t[4] + t[7]) / 3,
-        z: (t[2] + t[5] + t[8]) / 3,
-      };
-    });
+    const geom = computeLipGeom(faceGroups ?? [], getIndexed);
     expect(geom).not.toBeNull();
 
     const preview = computeLipColoredMesh({
@@ -132,10 +126,16 @@ describe('lip multi-color splitter (generated bin)', () => {
         origMaxZ = Math.max(origMaxZ, t[v * 3 + 2]);
       }
     }
+    // Conservation is measured over LIP-tagged output, not over lip-celled
+    // output: the color floor hands the support skirt to `body` while it stays
+    // LIP-tagged.
     let outputLipArea = 0;
+    let coloredLipArea = 0;
     for (let i = 0; i < preview.triZones.length; i++) {
-      if (!preview.triZones[i].startsWith('lip:')) continue;
-      outputLipArea += triArea(preview.positions!, i * 9);
+      if (preview.triTags[i] !== FeatureTag.LIP) continue;
+      const area = triArea(preview.positions!, i * 9);
+      outputLipArea += area;
+      if (preview.triZones[i].startsWith('lip:')) coloredLipArea += area;
       for (let v = 0; v < 3; v++) {
         const z = preview.positions![i * 9 + v * 3 + 2];
         expect(z).toBeGreaterThanOrEqual(origMinZ - 1e-3);
@@ -144,7 +144,21 @@ describe('lip multi-color splitter (generated bin)', () => {
     }
     expect(outputLipArea).toBeCloseTo(inputLipArea, 2);
 
-    // 4. Band classification stayed within the measured lip Z extent.
+    // 4. The color floor lands above the wall top, so no lip cell reaches the
+    //    support skirt or the bin's top surface (#3705). The wall top is the
+    //    lip apex less its protrusion; both come from the generated mesh.
+    const wallTopZ = origMaxZ - (GRIDFINITY_SPEC.LIP_HEIGHT - GRIDFINITY_SPEC.LIP_OVERLAP);
+    expect(geom!.floorZ).toBeGreaterThan(wallTopZ);
+    expect(geom!.floorZ).toBeLessThan(origMaxZ);
+    expect(coloredLipArea).toBeLessThan(outputLipArea);
+    for (let i = 0; i < preview.triZones.length; i++) {
+      if (!preview.triZones[i].startsWith('lip:')) continue;
+      for (let v = 0; v < 3; v++) {
+        expect(preview.positions![i * 9 + v * 3 + 2]).toBeGreaterThanOrEqual(geom!.floorZ - 1e-6);
+      }
+    }
+
+    // 5. Band classification stayed within the measured lip Z extent.
     expect(geom!.minZ).toBeGreaterThanOrEqual(origMinZ - 1e-3);
     expect(geom!.maxZ).toBeLessThanOrEqual(origMaxZ + 1e-3);
   }, 60_000);


### PR DESCRIPTION
Closes #3705

## The bug

`buildTopShape` hangs an angled support `LIP_TAPER_WIDTH` (2.6mm) below the lip's own base plane so it blends into the wall it is fused onto, and that skirt carries `FeatureTag.LIP`. `computeLipGeom` therefore measured the colorable extent from 2.7mm **under** the bin's top surface.

Measured on a 2x2x6u standard bin (identical to the mesh attached to the issue):

| | before | after |
| --- | --- | --- |
| mesh peak | 46.30 | 46.30 |
| LIP-tagged vertices | 39.30 .. 46.30 | 39.30 .. 46.30 |
| wall top | 42.00 | 42.00 |
| **painted lip region** | **39.30 .. 46.30** | **42.32 .. 46.30** |

Color reaching below the wall top puts lip filament in the same layers that finish the bin's top surface, so the slicer changes filament on every one of them (17 changes on the reported bin).

## The fix

`LipGeom` gains `floorZ`, one max-supported layer above the wall top. The wall top is recovered from the lip's own apex less its protrusion, so no caller has to pass the bin's dimensions in. Bands divide `[floorZ, maxZ]`, and lip geometry below `floorZ` resolves to the body color.

Two details it depends on:

- The geom's Z extents are centroid-derived, so `maxZ` sits under the real apex by however much the tessellation says. The wall top reads a vertex-exact `peakZ` instead, which needs a full triangle accessor rather than a centroid one.
- A uniform lip skipped re-tessellation, and the flush wall/lip outer face is one tall quad whose centroid is above the floor. The floor plane is now cut whatever the grid, or the reported single-color case would not change at all.

The lid's stack grid keeps `floorZ = minZ`: it is extruded up from the lid's top face, so none of it hides under the surface it sits on.

## Verification

- `lipMultiColor.test.ts` (real WASM, generated bin) gains assertions that `floorZ` lands above the wall top and that no lip-celled triangle dips below it; area conservation now measures LIP-tagged output rather than lip-celled output, since the skirt stays LIP-tagged while taking the body color.
- New unit coverage for the floor derivation, the vertex-exact peak, the no-skirt case, and the uniform-lip floor cut.
- `unit` 11429 passed (1 unrelated local timing flake in `contentFilter`), `dom` 9593 passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

