### PR TITLE
fix(generation): pass tessellation angular tolerance in radians

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/baseplateGenerator.scenario.magnetOversized.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/baseplateGenerator.scenario.magnetOversized.test.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 1`] = `16388`;
+exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 1`] = `16532`;
 
-exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 with the legacy 'center' anchor 1`] = `16388`;
+exports[`baseplate oversized-grid magnet geometry (#2525) > generates a valid 3×3 magnet baseplate at gridUnitMm=50 with the legacy 'center' anchor 1`] = `16532`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.snap
@@ -1,25 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`base styles > flat base no lip 1`] = `204`;
+exports[`base styles > flat base no lip 1`] = `252`;
 
-exports[`base styles > flat base with lip 1`] = `892`;
+exports[`base styles > flat base with lip 1`] = `924`;
 
-exports[`base styles > magnet base no lip 1`] = `800`;
+exports[`base styles > magnet base no lip 1`] = `1032`;
 
-exports[`base styles > magnet base with lip 1`] = `1896`;
+exports[`base styles > magnet base with lip 1`] = `1944`;
 
-exports[`base styles > magnet+screw base no lip 1`] = `1040`;
+exports[`base styles > magnet+screw base no lip 1`] = `1464`;
 
-exports[`base styles > magnet+screw base with lip 1`] = `2280`;
+exports[`base styles > magnet+screw base with lip 1`] = `2376`;
 
-exports[`base styles > screw base no lip 1`] = `704`;
+exports[`base styles > screw base no lip 1`] = `1048`;
 
-exports[`base styles > screw base with lip 1`] = `1752`;
+exports[`base styles > screw base with lip 1`] = `1848`;
 
-exports[`base styles > standard base no lip 1`] = `464`;
+exports[`base styles > standard base no lip 1`] = `616`;
 
-exports[`base styles > standard base with lip 1`] = `1368`;
+exports[`base styles > standard base with lip 1`] = `1416`;
 
-exports[`base styles > weighted base no lip 1`] = `464`;
+exports[`base styles > weighted base no lip 1`] = `616`;
 
-exports[`base styles > weighted base with lip 1`] = `1368`;
+exports[`base styles > weighted base with lip 1`] = `1416`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`bin styles > 2×2 slotted 1`] = `3228`;
+exports[`bin styles > 2×2 slotted 1`] = `3324`;
 
-exports[`bin styles > 2×2 solid 1`] = `2532`;
+exports[`bin styles > 2×2 solid 1`] = `2604`;
 
-exports[`bin styles > 2×2 standard 1`] = `2796`;
+exports[`bin styles > 2×2 standard 1`] = `2892`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1324`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1356`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3520`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3616`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4388`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4548`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5498`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5618`;
 
-exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `17804`;
+exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `30756`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2796`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `2892`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `2908`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `3004`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `2936`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `3032`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3196`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `3292`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.snap
@@ -1,31 +1,31 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2906`;
+exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2964`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `5286`;
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `5424`;
 
-exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4336`;
+exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `4442`;
 
-exports[`custom-shape > 3×3 L flat base no lip 1`] = `260`;
+exports[`custom-shape > 3×3 L flat base no lip 1`] = `380`;
 
-exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5612`;
+exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`] = `5750`;
 
-exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5730`;
+exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `5868`;
 
-exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `8550`;
+exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `8688`;
 
-exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `7994`;
+exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `8132`;
 
-exports[`custom-shape > 3×3 L with lip 1`] = `5250`;
+exports[`custom-shape > 3×3 L with lip 1`] = `5388`;
 
-exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5520`;
+exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `5680`;
 
-exports[`custom-shape > 3×3 T with lip 1`] = `4368`;
+exports[`custom-shape > 3×3 T with lip 1`] = `4436`;
 
-exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5808`;
+exports[`custom-shape > 3×3 U with front + left handles (multi-side polygon) 1`] = `5908`;
 
-exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5690`;
+exports[`custom-shape > 3×3 U with front cutout (single candidate edge) 1`] = `5790`;
 
-exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `8968`;
+exports[`custom-shape > 3×3 U with honeycomb pattern (multi-side polygon pattern) 1`] = `9068`;
 
-exports[`custom-shape > 3×3 U with lip 1`] = `5328`;
+exports[`custom-shape > 3×3 U with lip 1`] = `5428`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.cutoutLabelSockets.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.cutoutLabelSockets.test.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`cutout label sockets > 3×2 board: engraved label unchanged 1`] = `1476`;
+exports[`cutout label sockets > 3×2 board: engraved label unchanged 1`] = `2324`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.cutoutRepeatOverlap.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.cutoutRepeatOverlap.test.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`cutout repeat overlap > 2×2 solid with a tightly nested staggered array 1`] = `4008`;
+exports[`cutout repeat overlap > 2×2 solid with a tightly nested staggered array 1`] = `4080`;
 
-exports[`cutout repeat overlap > 2×2 solid with an overlapping grid array 1`] = `3348`;
+exports[`cutout repeat overlap > 2×2 solid with an overlapping grid array 1`] = `3420`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.snap
@@ -1,21 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`dimensions > 0.5×0.5 no lip 1`] = `464`;
+exports[`dimensions > 0.5×0.5 no lip 1`] = `616`;
 
-exports[`dimensions > 0.5×0.5 with lip 1`] = `1368`;
+exports[`dimensions > 0.5×0.5 with lip 1`] = `1416`;
 
-exports[`dimensions > 1.5×2 fractional no lip 1`] = `1244`;
+exports[`dimensions > 1.5×2 fractional no lip 1`] = `1708`;
 
-exports[`dimensions > 1.5×2 fractional with lip 1`] = `2796`;
+exports[`dimensions > 1.5×2 fractional with lip 1`] = `2892`;
 
-exports[`dimensions > 1×1 no lip 1`] = `464`;
+exports[`dimensions > 1×1 no lip 1`] = `616`;
 
-exports[`dimensions > 1×1 with lip 1`] = `1368`;
+exports[`dimensions > 1×1 with lip 1`] = `1416`;
 
-exports[`dimensions > 2×2 no lip 1`] = `1244`;
+exports[`dimensions > 2×2 no lip 1`] = `1708`;
 
-exports[`dimensions > 2×2 with lip 1`] = `2796`;
+exports[`dimensions > 2×2 with lip 1`] = `2892`;
 
-exports[`dimensions > 4×4 no lip 1`] = `3436`;
+exports[`dimensions > 4×4 no lip 1`] = `6076`;
 
-exports[`dimensions > 4×4 with lip 1`] = `7932`;
+exports[`dimensions > 4×4 with lip 1`] = `8492`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
@@ -1,23 +1,23 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`divider patterns > 2×2 honeycomb dividers 1`] = `9940`;
+exports[`divider patterns > 2×2 honeycomb dividers 1`] = `10036`;
 
-exports[`divider patterns > dividers + interior cutouts 1`] = `9000`;
+exports[`divider patterns > dividers + interior cutouts 1`] = `9096`;
 
-exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `10380`;
+exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `10520`;
 
-exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13452`;
+exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13580`;
 
-exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `12490`;
+exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `12616`;
 
-exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10302`;
+exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10430`;
 
-exports[`divider patterns > mitsukude lattice on dividers 1`] = `15890`;
+exports[`divider patterns > mitsukude lattice on dividers 1`] = `16316`;
 
-exports[`divider patterns > overhang shifts the interior with the dividers 1`] = `10844`;
+exports[`divider patterns > overhang shifts the interior with the dividers 1`] = `10940`;
 
-exports[`divider patterns > round pattern on a single column divider 1`] = `20188`;
+exports[`divider patterns > round pattern on a single column divider 1`] = `20268`;
 
-exports[`divider patterns > shortened dividers re-fit the band 1`] = `8480`;
+exports[`divider patterns > shortened dividers re-fit the band 1`] = `8576`;
 
-exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `10042`;
+exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `10138`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2604`;
+exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `2780`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `5276`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `5372`;
 
-exports[`large bin > 8×8 standard 1`] = `22308`;
+exports[`large bin > 8×8 standard 1`] = `26572`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
@@ -1,17 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`floor patterns > compartment divider footings stay solid 1`] = `6716`;
+exports[`floor patterns > compartment divider footings stay solid 1`] = `6812`;
 
-exports[`floor patterns > custom-shape bin patterns only its filled feet 1`] = `12254`;
+exports[`floor patterns > custom-shape bin patterns only its filled feet 1`] = `12314`;
 
-exports[`floor patterns > flat base takes one interior-wide window 1`] = `5176`;
+exports[`floor patterns > flat base takes one interior-wide window 1`] = `5208`;
 
-exports[`floor patterns > floor and wall patterns compose 1`] = `9852`;
+exports[`floor patterns > floor and wall patterns compose 1`] = `9948`;
 
-exports[`floor patterns > fractional edge foot carries a narrower window 1`] = `5924`;
+exports[`floor patterns > fractional edge foot carries a narrower window 1`] = `5988`;
 
-exports[`floor patterns > half sockets get one window per quarter foot 1`] = `3340`;
+exports[`floor patterns > half sockets get one window per quarter foot 1`] = `3436`;
 
-exports[`floor patterns > magnet + screw pockets stay solid 1`] = `14604`;
+exports[`floor patterns > magnet + screw pockets stay solid 1`] = `14892`;
 
-exports[`floor patterns > scoop ramp footings stay solid 1`] = `12292`;
+exports[`floor patterns > scoop ramp footings stay solid 1`] = `12406`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5176`;
+exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `5352`;
 
-exports[`half-sockets > 1×1 with half sockets 1`] = `2796`;
+exports[`half-sockets > 1×1 with half sockets 1`] = `2892`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `8508`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `8796`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`height > 2×2 height minimum (2u) 1`] = `2796`;
+exports[`height > 2×2 height minimum (2u) 1`] = `2892`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `2796`;
+exports[`height > 2×2 height tall (10u) 1`] = `2892`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5122`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `5218`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `4768`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `4864`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4170`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `4266`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4170`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `4266`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4472`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `4568`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `3812`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `3908`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `3804`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `3900`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.snap
@@ -1,13 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`inserts > 2×2 with circle insert 1`] = `3032`;
+exports[`inserts > 2×2 with circle insert 1`] = `3128`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `3032`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `3128`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `2816`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `2912`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `2944`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `3040`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `2984`;
+exports[`inserts > 2×2 with slot insert 1`] = `3080`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3264`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3360`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.knifeBlock.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.knifeBlock.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`knife block > 3x1x4 steak slot row (repeat array) with open ends 1`] = `2800`;
+exports[`knife block > 3x1x4 steak slot row (repeat array) with open ends 1`] = `2856`;
 
-exports[`knife block > 6x1x8 chef slot open end breaches the +X wall and lip 1`] = `2728`;
+exports[`knife block > 6x1x8 chef slot open end breaches the +X wall and lip 1`] = `3136`;
 
-exports[`knife block > 6x1x8 chef slot with integrated rear rest shelf 1`] = `2672`;
+exports[`knife block > 6x1x8 chef slot with integrated rear rest shelf 1`] = `3052`;
 
-exports[`knife block > 6x1x8 open chef slot ignores wall patterns (solid host) 1`] = `2728`;
+exports[`knife block > 6x1x8 open chef slot ignores wall patterns (solid host) 1`] = `3136`;
 
-exports[`knife block > 6x1x8 solid with enclosed chef knife slot 1`] = `2736`;
+exports[`knife block > 6x1x8 solid with enclosed chef knife slot 1`] = `3160`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelSockets.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelSockets.test.ts.snap
@@ -1,19 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`label sockets > 1×1 lipped socket sinks by the stacking relief 1`] = `2238`;
+exports[`label sockets > 1×1 lipped socket sinks by the stacking relief 1`] = `2476`;
 
-exports[`label sockets > 1×1 socket hosts a 1U plate 1`] = `836`;
+exports[`label sockets > 1×1 socket hosts a 1U plate 1`] = `1116`;
 
-exports[`label sockets > 1×1 text mode unchanged 1`] = `708`;
+exports[`label sockets > 1×1 text mode unchanged 1`] = `908`;
 
-exports[`label sockets > 2×1 four columns → bin-spanning 2U socket 1`] = `2064`;
+exports[`label sockets > 2×1 four columns → bin-spanning 2U socket 1`] = `2408`;
 
-exports[`label sockets > 2×1 two compartments, two 1U sockets 1`] = `2176`;
+exports[`label sockets > 2×1 two compartments, two 1U sockets 1`] = `2640`;
 
-exports[`label sockets > 3u lipped socket at the tightest height budget 1`] = `2322`;
+exports[`label sockets > 3u lipped socket at the tightest height budget 1`] = `2560`;
 
-exports[`label sockets > 3×1 override forces a 1U plate 1`] = `1384`;
+exports[`label sockets > 3×1 override forces a 1U plate 1`] = `2024`;
 
-exports[`label sockets > 3×1 socket auto-quantizes to 3U 1`] = `1384`;
+exports[`label sockets > 3×1 socket auto-quantizes to 3U 1`] = `2024`;
 
-exports[`label sockets > 3×1 socket on a 0.6mm nozzle widens the pocket 1`] = `1384`;
+exports[`label sockets > 3×1 socket on a 0.6mm nozzle widens the pocket 1`] = `2024`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.snap
@@ -1,27 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`label tabs > 1×1 label both collision drops front 1`] = `1368`;
+exports[`label tabs > 1×1 label both collision drops front 1`] = `1416`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `3612`;
+exports[`label tabs > 2×2 label bracket center 1`] = `3772`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `3612`;
+exports[`label tabs > 2×2 label bracket left 1`] = `3772`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `3612`;
+exports[`label tabs > 2×2 label bracket right 1`] = `3772`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `2796`;
+exports[`label tabs > 2×2 label disabled 1`] = `2892`;
 
-exports[`label tabs > 2×2 label front edge 1`] = `3612`;
+exports[`label tabs > 2×2 label front edge 1`] = `3772`;
 
-exports[`label tabs > 2×2 label lip bracket 1`] = `3548`;
+exports[`label tabs > 2×2 label lip bracket 1`] = `3660`;
 
-exports[`label tabs > 2×2 label lip solid 2mm 1`] = `3388`;
+exports[`label tabs > 2×2 label lip solid 2mm 1`] = `3484`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `3364`;
+exports[`label tabs > 2×2 label solid left 1`] = `3508`;
 
-exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `3124`;
+exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `3220`;
 
-exports[`label tabs > 2×2×4 label both edges 1`] = `4428`;
+exports[`label tabs > 2×2×4 label both edges 1`] = `4652`;
 
-exports[`label tabs > 2×2×4 label lip both edges 1`] = `4300`;
+exports[`label tabs > 2×2×4 label lip both edges 1`] = `4428`;
 
-exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `3264`;
+exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `3360`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
@@ -1,31 +1,31 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `3924`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4044`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4522`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4642`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `3924`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `4044`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `2796`;
+exports[`scoop > 2×2 scoop disabled 1`] = `2892`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `3964`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4116`;
 
-exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `3800`;
+exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `4272`;
 
-exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `4950`;
+exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `5070`;
 
-exports[`scoop side > scoop on the back wall 1`] = `3924`;
+exports[`scoop side > scoop on the back wall 1`] = `4044`;
 
-exports[`scoop side > scoop on the left wall 1`] = `3924`;
+exports[`scoop side > scoop on the left wall 1`] = `4044`;
 
-exports[`scoop side > scoop on the right wall 1`] = `3924`;
+exports[`scoop side > scoop on the right wall 1`] = `4044`;
 
-exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `3924`;
+exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `4044`;
 
-exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `3884`;
+exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `4004`;
 
-exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4068`;
+exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4240`;
 
-exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3436`;
+exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3544`;
 
-exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `3348`;
+exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `3436`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3228`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3324`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3660`;
+exports[`slotted variations > slotted with both axes 1`] = `3756`;
 
-exports[`slotted variations > slotted without lip 1`] = `1388`;
+exports[`slotted variations > slotted without lip 1`] = `1852`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.snap
@@ -1,57 +1,57 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3420`;
+exports[`solid cutouts > 2×2 solid with 3×2 grid array of circles 1`] = `3492`;
 
-exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `2904`;
+exports[`solid cutouts > 2×2 solid with chamfered + scooped rectangle cutout 1`] = `3128`;
 
-exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `3044`;
+exports[`solid cutouts > 2×2 solid with chamfered circle cutout 1`] = `3116`;
 
-exports[`solid cutouts > 2×2 solid with chamfered ellipse cutout 1`] = `3044`;
+exports[`solid cutouts > 2×2 solid with chamfered ellipse cutout 1`] = `3116`;
 
-exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2622`;
+exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `2694`;
 
-exports[`solid cutouts > 2×2 solid with chamfered path cutout 1`] = `2564`;
+exports[`solid cutouts > 2×2 solid with chamfered path cutout 1`] = `2636`;
 
-exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `2660`;
+exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `2750`;
 
-exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `2928`;
+exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `3000`;
 
-exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2768`;
+exports[`solid cutouts > 2×2 solid with circle cutout 1`] = `2840`;
 
-exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2684`;
+exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`] = `2756`;
 
-exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2796`;
+exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `2868`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2562`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `2634`;
 
-exports[`solid cutouts > 2×2 solid with hexagon (polygon) cutout 1`] = `2564`;
+exports[`solid cutouts > 2×2 solid with hexagon (polygon) cutout 1`] = `2636`;
 
-exports[`solid cutouts > 2×2 solid with hexagon cutout + insertion clearance 1`] = `2568`;
+exports[`solid cutouts > 2×2 solid with hexagon cutout + insertion clearance 1`] = `2640`;
 
-exports[`solid cutouts > 2×2 solid with path cutout + insertion clearance 1`] = `2548`;
+exports[`solid cutouts > 2×2 solid with path cutout + insertion clearance 1`] = `2620`;
 
-exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2724`;
+exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve 1`] = `2796`;
 
-exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `3336`;
+exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `3408`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2552`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `2624`;
 
-exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `2624`;
+exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `2696`;
 
-exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `2612`;
+exports[`solid cutouts > 2×2 solid with rectangle, edge gate disables a single wall 1`] = `2688`;
 
-exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `2616`;
+exports[`solid cutouts > 2×2 solid with rectangle, split scoop (W only) cuts only left/right walls 1`] = `2688`;
 
-exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2564`;
+exports[`solid cutouts > 2×2 solid with rotated 45° cutout 1`] = `2636`;
 
-exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2680`;
+exports[`solid cutouts > 2×2 solid with rounded-rectangle cutout 1`] = `2752`;
 
-exports[`solid cutouts > 2×2 solid with scooped path cutout 1`] = `2610`;
+exports[`solid cutouts > 2×2 solid with scooped path cutout 1`] = `2690`;
 
-exports[`solid cutouts > 2×2 solid with slot (stadium) cutout 1`] = `2746`;
+exports[`solid cutouts > 2×2 solid with slot (stadium) cutout 1`] = `2818`;
 
-exports[`solid cutouts > 2×2 solid with staggered hex array 1`] = `2748`;
+exports[`solid cutouts > 2×2 solid with staggered hex array 1`] = `2820`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2884`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2980`;
 
-exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2544`;
+exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `2616`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2684`;
+exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `2796`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3044`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `3140`;

--- a/src/features/generation/worker/generators/baseplateGenerator.ts
+++ b/src/features/generation/worker/generators/baseplateGenerator.ts
@@ -86,6 +86,7 @@ import {
   insideAreaFraction,
   type RegionClass,
 } from '@/shared/utils/drawerOutlineGeometry';
+import { EXPORT_ANGULAR_TOLERANCE_RAD, PREVIEW_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 /**
  * Minimum surviving area for an outline-clipped over-tile pocket. Below this
@@ -171,13 +172,13 @@ export function generateBaseplate(
 
   if (forExport) {
     tolerance = 0.01;
-    angularTolerance = 5;
+    angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD;
   } else if (params.magnetHoles) {
     tolerance = Math.min(0.1, Math.max(0.05, maxDimension / 2500));
-    angularTolerance = 10;
+    angularTolerance = PREVIEW_ANGULAR_TOLERANCE_RAD;
   } else {
     tolerance = Math.min(0.4, Math.max(0.15, maxDimension / 600));
-    angularTolerance = 12;
+    angularTolerance = PREVIEW_ANGULAR_TOLERANCE_RAD;
   }
 
   try {
@@ -233,7 +234,7 @@ function buildConnectorKeyMeshIfNeeded(
 
   const clip = buildSnapClip(totalHeight, params.gridUnitMm, params.nozzleSizeMm);
   try {
-    const clipMesh = mesh(clip, { tolerance: 0.05, angularTolerance: 10 });
+    const clipMesh = mesh(clip, { tolerance: 0.05, angularTolerance: PREVIEW_ANGULAR_TOLERANCE_RAD });
     const indexed = toIndexedMeshData(clipMesh, new Float32Array(0));
     return {
       vertices: indexed.vertices,
@@ -795,7 +796,7 @@ export async function exportBaseplate(
     // indistinguishable from the prior 0.01mm while roughly halving the
     // tessellation triangle budget on large plates. Callers can still override.
     const tol = tolerance ?? 0.02;
-    const angTol = angularTolerance ?? 6;
+    const angTol = angularTolerance ?? EXPORT_ANGULAR_TOLERANCE_RAD;
     const meshResult = mesh(baseplate, { tolerance: tol, angularTolerance: angTol });
     const data = buildBaseplateSTL(meshResult, name);
     return { data, fileName: `${name}.stl` };
@@ -829,7 +830,7 @@ export async function exportConnectorKey(
       return { data, fileName: `${name}.step` };
     }
     const tol = tolerance ?? 0.01;
-    const angTol = angularTolerance ?? 5;
+    const angTol = angularTolerance ?? EXPORT_ANGULAR_TOLERANCE_RAD;
     const meshResult = mesh(key, { tolerance: tol, angularTolerance: angTol });
     const data = buildBaseplateSTL(meshResult, name);
     return { data, fileName: `${name}.stl` };

--- a/src/features/generation/worker/generators/baseplateMargin.ts
+++ b/src/features/generation/worker/generators/baseplateMargin.ts
@@ -39,6 +39,7 @@ import { getPocketTemplate } from './baseplatePockets';
 import { buildBaseplateSTL } from './baseplateSTL';
 import { creaseEdges } from './utils';
 import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
+import { EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 interface RailDims {
   readonly railW: number;
@@ -246,7 +247,7 @@ export async function exportMargin(
     }
     const meshResult = mesh(rail, {
       tolerance: tolerance ?? 0.02,
-      angularTolerance: angularTolerance ?? 6,
+      angularTolerance: angularTolerance ?? EXPORT_ANGULAR_TOLERANCE_RAD,
     });
     const data = buildBaseplateSTL(meshResult, name);
     return { data, fileName: `${name}.stl` };

--- a/src/features/generation/worker/generators/binExporter.ts
+++ b/src/features/generation/worker/generators/binExporter.ts
@@ -10,7 +10,7 @@ import { generateBin } from './binOrchestrator';
 import { FeatureTag } from './featureTags';
 import { getLastSolid, isLastSolidReusableFor, setLastSolid } from './shapeCache';
 import { paramsFingerprint } from '@/shared/generation/paramsFingerprint';
-import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from './utils/tolerances';
+import { EXPORT_ANGULAR_TOLERANCE_RAD, EXPORT_TOLERANCE } from './utils/tolerances';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { exportSolidToStl } from './utils/stlMeshFallback';
 import { hasMeshImprints, prepareMeshImprints } from './meshImprint';
@@ -30,7 +30,7 @@ export interface ExportResult {
  *
  * `faceGroups` is captured so 3MF callers can map each STL triangle to a
  * feature tag. The match relies on brepjs's shape+tolerance mesh cache: the
- * regen path runs `mesh()` at `EXPORT_TOLERANCE`/`EXPORT_ANGULAR_TOLERANCE`
+ * regen path runs `mesh()` at `EXPORT_TOLERANCE`/`EXPORT_ANGULAR_TOLERANCE_RAD`
  * (the export branch of `computeTessellationTolerances`), and we re-mesh /
  * `exportSTL` with the same constants here so all three calls hit the same
  * cached tessellation.
@@ -92,7 +92,7 @@ async function runExportAttempt(
   if (!faceGroups) {
     const m = mesh(solid, {
       tolerance: EXPORT_TOLERANCE,
-      angularTolerance: EXPORT_ANGULAR_TOLERANCE,
+      angularTolerance: EXPORT_ANGULAR_TOLERANCE_RAD,
     });
     faceGroups = m.faceGroups.map((g) => ({
       start: g.start,
@@ -104,14 +104,14 @@ async function runExportAttempt(
   onProgress?.(0.92);
   // `faceGroups` above indexes into the same mesh() tessellation the fallback
   // writes from, so 3MF material alignment survives an OCCT-writer failure.
-  const data = await exportSolidToStl(solid, name, EXPORT_TOLERANCE, EXPORT_ANGULAR_TOLERANCE);
+  const data = await exportSolidToStl(solid, name, EXPORT_TOLERANCE, EXPORT_ANGULAR_TOLERANCE_RAD);
   onProgress?.(1);
   return { data, fileName: `${name}.stl`, faceGroups };
 }
 
 /**
  * Export the last generated solid in the requested format. Tessellation is
- * fixed at `EXPORT_TOLERANCE` / `EXPORT_ANGULAR_TOLERANCE` so the faceGroups
+ * fixed at `EXPORT_TOLERANCE` / `EXPORT_ANGULAR_TOLERANCE_RAD` so the faceGroups
  * captured at generation time line up with the triangles `exportSTL` emits
  * (brepjs caches `mesh()` by shape+tolerance — diverging here would silently
  * misalign per-triangle material indices in the 3MF).

--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -80,6 +80,7 @@ import { buildTextSolid } from './textBuilder';
 import { DEFAULT_TEXT_STYLE_DEFAULTS } from '@/shared/types/bin';
 import { buildBaseplateSTL } from './baseplateSTL';
 import { sanitizeParams } from './baseplateSlab';
+import { PREVIEW_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 /** Fit-offset ladder swept across the columns, centered on nominal (0). */
 const SAMPLE_OFFSETS: readonly number[] = [-0.1, -0.05, 0, 0.05, 0.1];
@@ -387,10 +388,10 @@ export async function exportConnectorSample(
     // are all planar (tessellated exactly at any tolerance), so the fine 0.01mm
     // default only multiplies triangles on the rounded corners and the embossed
     // ID labels — which turned this small tray into a ~31MB, multi-minute export.
-    // 0.05mm / 10° matches the connector-clip mesh and keeps labels legible while
-    // cutting the file size and mesh time dramatically.
+    // The 0.05mm chord height matches the connector-clip mesh and keeps labels
+    // legible while cutting the file size and mesh time dramatically.
     const tol = tolerance ?? 0.05;
-    const angTol = angularTolerance ?? 10;
+    const angTol = angularTolerance ?? PREVIEW_ANGULAR_TOLERANCE_RAD;
     const meshResult = mesh(lifted, { tolerance: tol, angularTolerance: angTol });
     const data = buildBaseplateSTL(meshResult, name);
     return { data, fileName: `${name}.stl` };

--- a/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
+++ b/src/features/generation/worker/generators/detachableFeetOrchestrator.ts
@@ -36,6 +36,7 @@ import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
 import type { ProgressFn } from './generatorTypes';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { exportSolidToStl } from './utils/stlMeshFallback';
+import { EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 /** Gap between feet on the print plate (mm). */
 const PLATE_GAP_MM = 4;
@@ -113,7 +114,7 @@ export function generateDetachableFeetMesh(
   try {
     const compound = unwrap(fuseAll(feet as ValidSolid[], { optimisation: 'commonFace' }));
     try {
-      const shapeMesh = mesh(compound, { tolerance: 0.01, angularTolerance: 5 });
+      const shapeMesh = mesh(compound, { tolerance: 0.01, angularTolerance: EXPORT_ANGULAR_TOLERANCE_RAD });
       // Crease edges, exactly as the lid and the tray get them. Without these
       // the feet are the one companion part rendering as a flat silhouette
       // while everything around it is outlined.
@@ -150,7 +151,7 @@ export async function exportDetachableFeet(
   params: BinParams,
   format: ExportFormat,
   tolerance = 0.01,
-  angularTolerance = 5
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD
 ): Promise<DetachableFeetExportResult | null> {
   const feet = buildFeetSolids(params, true, true);
   if (!feet) return null;

--- a/src/features/generation/worker/generators/dividerExport.ts
+++ b/src/features/generation/worker/generators/dividerExport.ts
@@ -16,6 +16,7 @@ import { pitchFromParams } from './gridPitch';
 import { resolveOverhang, overhangExpansion } from './overhang';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { exportSolidToStl } from './utils/stlMeshFallback';
+import { EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 const CLEARANCE = GRIDFINITY.TOLERANCE;
 
@@ -97,7 +98,7 @@ export async function exportDividerPiecesSeparately(
   params: BinParams,
   format: ExportFormat,
   tolerance = 0.01,
-  angularTolerance = 5
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD
 ): Promise<CombinedExportPiece[]> {
   const { wallHeight } = deriveDimensions(params, true);
 

--- a/src/features/generation/worker/generators/fitTestSlice.ts
+++ b/src/features/generation/worker/generators/fitTestSlice.ts
@@ -58,7 +58,7 @@ import { buildTextSolid } from './textBuilder';
 import { DEFAULT_TEXT_STYLE_DEFAULTS } from '@/shared/types/bin';
 import { hasMeshImprints, imprintPieceArrays, prepareMeshImprints } from './meshImprint';
 import { buildSTLBufferFromIndexed } from '../../export/stlExporter';
-import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from './utils/tolerances';
+import { EXPORT_ANGULAR_TOLERANCE_RAD, EXPORT_TOLERANCE } from './utils/tolerances';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 
 /** XY margin on the band box, so the intersect bounds material in Z only. A
@@ -285,7 +285,7 @@ export interface FitTestMeshPiece {
 function pieceToMesh(piece: FitTestPiece, params: BinParams, imprinted: boolean): FitTestMeshPiece {
   const m = mesh(piece.solid, {
     tolerance: EXPORT_TOLERANCE,
-    angularTolerance: EXPORT_ANGULAR_TOLERANCE,
+    angularTolerance: EXPORT_ANGULAR_TOLERANCE_RAD,
     cache: false,
   });
   let vertices = m.vertices instanceof Float32Array ? m.vertices : new Float32Array(m.vertices);

--- a/src/features/generation/worker/generators/knifeRestBuilder.ts
+++ b/src/features/generation/worker/generators/knifeRestBuilder.ts
@@ -37,7 +37,7 @@ import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { buildBaseSocket, DEFAULT_SOCKET_CELL_PLAN } from './socketBuilder';
 import { creaseEdges } from './utils';
 import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
-import { computeTessellationTolerances } from './utils/tolerances';
+import { computeTessellationTolerances, EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { exportSolidToStl } from './utils/stlMeshFallback';
 
@@ -186,12 +186,12 @@ export function generateKnifeRest(
     checkCancelled(signal);
     const maxDimension =
       Math.max(plan.alongU, plan.crossU) * Math.max(params.gridUnitMm, params.gridUnitMmY ?? 0);
-    const { tolerance, angularTolerance } = computeTessellationTolerances(
+    const { tolerance, angularToleranceRad } = computeTessellationTolerances(
       forExport,
       false,
       maxDimension
     );
-    const shapeMesh = mesh(solid, { tolerance, angularTolerance });
+    const shapeMesh = mesh(solid, { tolerance, angularTolerance: angularToleranceRad });
     const edgeLines =
       getKernelCapabilities().tessellationModel === 'build-time'
         ? creaseEdges(shapeMesh)
@@ -218,7 +218,7 @@ export async function exportKnifeRest(
   params: BinParams,
   format: ExportFormat,
   tolerance = 0.01,
-  angularTolerance = 5
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD
 ): Promise<KnifeRestExportResult | null> {
   const plan = planKnifeRest(params);
   if (!plan || plan.style !== 'companion') return null;

--- a/src/features/generation/worker/generators/labelFitSample.ts
+++ b/src/features/generation/worker/generators/labelFitSample.ts
@@ -45,6 +45,7 @@ import { DEFAULT_TEXT_STYLE_DEFAULTS } from '@/shared/types/bin';
 import { buildBaseplateSTL } from './baseplateSTL';
 import { cutLabelSocket } from './labelTabBuilder';
 import { buildLabelPlate } from './labelPlateBuilder';
+import { PREVIEW_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 /** Fit-offset ladder swept across the coupons, centered on nominal (0). */
 export const LABEL_FIT_SAMPLE_OFFSETS: readonly number[] = [-0.1, -0.05, 0, 0.05, 0.1];
@@ -206,7 +207,7 @@ export async function exportLabelFitSample(
     // planar, so the fine default only bloats rounded corners and glyphs.
     const meshResult = mesh(assembled, {
       tolerance: tolerance ?? 0.05,
-      angularTolerance: angularTolerance ?? 10,
+      angularTolerance: angularTolerance ?? PREVIEW_ANGULAR_TOLERANCE_RAD,
     });
     const data = buildBaseplateSTL(meshResult, name);
     return { data, fileName: `${name}.stl` };

--- a/src/features/generation/worker/generators/labelPlateBuilder.ts
+++ b/src/features/generation/worker/generators/labelPlateBuilder.ts
@@ -52,6 +52,7 @@ import { sketch } from './meshUtils';
 import { buildTextSolid, fitTextSize, type ResolvedTextStyle } from './textBuilder';
 import { buildIconSolid, measureIconBox } from './labelPlateIcons';
 import { buildBaseplateSTL } from './baseplateSTL';
+import { PREVIEW_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 /** One plate to build: standard width + the text it carries (may be empty). */
 export interface LabelPlateSpec {
@@ -483,7 +484,7 @@ export async function exportLabelPlates(
       const data = await blob.arrayBuffer();
       return { data, fileName: `${name}.step` };
     }
-    const meshResult = mesh(assembled, { tolerance: 0.05, angularTolerance: 10 });
+    const meshResult = mesh(assembled, { tolerance: 0.05, angularTolerance: PREVIEW_ANGULAR_TOLERANCE_RAD });
     // Face provenance for STL→3MF paint_color: TEXT-tagged glyph faces map
     // to the text color, everything else to the plate color. The STL below
     // writes from this same tessellation, so the ranges stay aligned.

--- a/src/features/generation/worker/generators/labelPlateGenerator.ts
+++ b/src/features/generation/worker/generators/labelPlateGenerator.ts
@@ -151,7 +151,7 @@ export function generateLabelPlates(
 
   // Plates are small and flat; their only curved detail is the corner radius
   // and glyph outlines, so the fine tier costs little and reads cleanly.
-  const { tolerance, angularTolerance } = computeTessellationTolerances(false, true, dim.innerW);
+  const { tolerance, angularToleranceRad } = computeTessellationTolerances(false, true, dim.innerW);
 
   const plates: LabelPlateMeshData[] = [];
   for (let i = 0; i < shown.length; i++) {
@@ -169,7 +169,7 @@ export function generateLabelPlates(
       // No edge lines: on a plate, crease edges trace the outline AND every
       // glyph, which reads as noise at this scale — and the preview would pay
       // kernel time plus a transferred buffer to render nothing.
-      const shapeMesh = mesh(solid, { tolerance, angularTolerance });
+      const shapeMesh = mesh(solid, { tolerance, angularTolerance: angularToleranceRad });
       const indexed = toIndexedMeshData(shapeMesh);
       plates.push({
         vertices: indexed.vertices,

--- a/src/features/generation/worker/generators/lidOrchestrator.ts
+++ b/src/features/generation/worker/generators/lidOrchestrator.ts
@@ -14,7 +14,7 @@ import type { ProgressFn } from './generatorTypes';
 import { buildLid, buildStackPlate } from './lidBuilder';
 import { toIndexedMeshData, creaseEdges } from './utils';
 import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
-import { computeTessellationTolerances } from './utils/tolerances';
+import { computeTessellationTolerances, EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 import { checkCancelled } from './meshUtils';
 import { isSlideLid, shouldGenerateLid } from '@/shared/types/bin';
 import { unwrapExportBlob } from './utils/exportUnwrap';
@@ -96,13 +96,13 @@ export function generateLid(
       params.depth * (params.gridUnitMmY ?? params.gridUnitMm)
     );
     // Lid always has lip-mating geometry → use the "has lip" tolerance tier.
-    const { tolerance, angularTolerance } = computeTessellationTolerances(
+    const { tolerance, angularToleranceRad } = computeTessellationTolerances(
       forExport,
       true,
       maxDimension
     );
 
-    const shapeMesh = mesh(solid, { tolerance, angularTolerance });
+    const shapeMesh = mesh(solid, { tolerance, angularTolerance: angularToleranceRad });
     const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
     const edgeLines = buildTime
       ? creaseEdges(shapeMesh)
@@ -145,13 +145,13 @@ export function generateStackPlate(
     );
     // The slab's only curved detail is the pocket tapers; use the fine ("has
     // lip") tier so they read smoothly — the mesh is small, so cost is trivial.
-    const { tolerance, angularTolerance } = computeTessellationTolerances(
+    const { tolerance, angularToleranceRad } = computeTessellationTolerances(
       false,
       true,
       maxDimension
     );
 
-    const shapeMesh = mesh(solid, { tolerance, angularTolerance });
+    const shapeMesh = mesh(solid, { tolerance, angularTolerance: angularToleranceRad });
     const buildTime = getKernelCapabilities().tessellationModel === 'build-time';
     const edgeLines = buildTime
       ? creaseEdges(shapeMesh)
@@ -202,7 +202,7 @@ export async function exportLid(
   params: BinParams,
   format: ExportFormat,
   tolerance = 0.01,
-  angularTolerance = 5
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD
 ): Promise<LidExportResult | null> {
   if (!shouldGenerateLid(params)) return null;
 
@@ -253,7 +253,7 @@ export async function exportStackPlate(
   params: BinParams,
   format: ExportFormat,
   tolerance = 0.01,
-  angularTolerance = 5
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD
 ): Promise<LidExportResult | null> {
   if (!shouldGenerateLid(params)) return null;
 

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.test.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.test.ts
@@ -16,7 +16,7 @@ import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { buildParams } from '../../__kernel-tests__/scenarioTypes';
 import { setLastSolid, getLastSolid } from '../../shapeCache';
 import { exportSolidToStl } from '../../utils/stlMeshFallback';
-import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from '../../utils/tolerances';
+import { EXPORT_ANGULAR_TOLERANCE_RAD, EXPORT_TOLERANCE } from '../../utils/tolerances';
 import type { BinParams } from '@/shared/types/bin';
 import type * as BinOrchestratorModule from '../../binOrchestrator';
 
@@ -36,7 +36,7 @@ async function exportDefects(
   generateBin(buildParams(overrides), undefined, true);
   const solid = getLastSolid();
   if (!solid) throw new Error('no solid');
-  const data = await exportSolidToStl(solid, 'x', EXPORT_TOLERANCE, EXPORT_ANGULAR_TOLERANCE);
+  const data = await exportSolidToStl(solid, 'x', EXPORT_TOLERANCE, EXPORT_ANGULAR_TOLERANCE_RAD);
   const parsed = parseSTLBinary(data);
   if (!isOk(parsed)) throw new Error('STL parse failed');
   const { vertices } = parsed.value;

--- a/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/tessellateStage.ts
@@ -70,13 +70,13 @@ export const tessellateStage: PipelineStage = {
     const identified = forExport && !ctx.deferredSolid;
     setLastSolid(solid, forExport, identified ? paramsFingerprint(ctx.params) : null);
 
-    const { tolerance, angularTolerance } = computeTessellationTolerances(
+    const { tolerance, angularToleranceRad } = computeTessellationTolerances(
       forExport,
       dim.hasLip,
       dim.maxDimension
     );
 
-    let shapeMesh = mesh(solid, { tolerance, angularTolerance });
+    let shapeMesh = mesh(solid, { tolerance, angularTolerance: angularToleranceRad });
 
     // Build-time kernels (manifold draft) have no B-rep topology, so their
     // meshEdges() returns the full triangle wireframe. Recover clean feature
@@ -100,11 +100,11 @@ export const tessellateStage: PipelineStage = {
         // design, where the body's features change but the base does not. A null
         // key (lightweight base) always re-meshes.
         const cacheKey = deferredSolidKey
-          ? socketMeshKey(deferredSolidKey, tolerance, angularTolerance, buildTime)
+          ? socketMeshKey(deferredSolidKey, tolerance, angularToleranceRad, buildTime)
           : null;
         let cached = cacheKey ? getSocketMesh(cacheKey) : null;
         if (!cached) {
-          const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance });
+          const socketMesh = mesh(deferredSolid, { tolerance, angularTolerance: angularToleranceRad });
           const socketEdges = buildTime
             ? creaseEdges(socketMesh)
             : meshEdges(deferredSolid, { tolerance, angularTolerance: EDGE_ANGULAR_TOLERANCE_RAD })

--- a/src/features/generation/worker/generators/slideFitSample.ts
+++ b/src/features/generation/worker/generators/slideFitSample.ts
@@ -28,6 +28,7 @@ import type { ExportFormat } from '../../bridge/types';
 import { sketch } from './meshUtils';
 import { buildBaseplateSTL } from './baseplateSTL';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { PREVIEW_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 /** Clearances swept across the coupons, in mm per side. */
 export const SLIDE_FIT_SAMPLE_CLEARANCES: readonly number[] = [0.15, 0.2, 0.25, 0.3, 0.35];
@@ -186,7 +187,7 @@ export async function exportSlideFitSample(
     // bloat the rounded nothing this card contains.
     const meshResult = mesh(assembled, {
       tolerance: tolerance ?? 0.05,
-      angularTolerance: angularTolerance ?? 10,
+      angularTolerance: angularTolerance ?? PREVIEW_ANGULAR_TOLERANCE_RAD,
     });
     return { data: buildBaseplateSTL(meshResult, name), fileName: `${name}.stl` };
   } finally {

--- a/src/features/generation/worker/generators/slideOrchestrator.ts
+++ b/src/features/generation/worker/generators/slideOrchestrator.ts
@@ -19,7 +19,7 @@ import { deriveDimensions } from './pipeline/context';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import { toIndexedMeshData, creaseEdges } from './utils';
 import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
-import { computeTessellationTolerances } from './utils/tolerances';
+import { computeTessellationTolerances, EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 import { checkCancelled } from './meshUtils';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { exportSolidToStl } from './utils/stlMeshFallback';
@@ -49,7 +49,7 @@ export async function exportSlideTray(
   params: BinParams,
   format: ExportFormat,
   tolerance = 0.01,
-  angularTolerance = 5
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD
 ): Promise<SlideTrayExportResult | null> {
   const solid = buildSlideTray(slideInputForParams(params));
   if (!solid) return null;
@@ -91,12 +91,12 @@ export function generateSlideTray(
   try {
     checkCancelled(signal);
     const maxDimension = Math.max(tray.widthMm, tray.depthMm);
-    const { tolerance, angularTolerance } = computeTessellationTolerances(
+    const { tolerance, angularToleranceRad } = computeTessellationTolerances(
       false,
       true,
       maxDimension
     );
-    const shapeMesh = mesh(solid, { tolerance, angularTolerance });
+    const shapeMesh = mesh(solid, { tolerance, angularTolerance: angularToleranceRad });
     const edgeLines =
       getKernelCapabilities().tessellationModel === 'build-time'
         ? creaseEdges(shapeMesh)

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -46,6 +46,7 @@ import { buildWallPatterns } from './wallPatternBuilder';
 import { buildKumikoWallPatterns } from './kumikoWrapBuilder';
 import { fuseAllOrNull } from './utils/shapeOps';
 import { splitConnectorsSuppressedByBase } from '@/shared/generation/splitUtils';
+import { EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 /** Result of a split export: array of piece buffers with grid labels */
 export interface SplitExportResult {
@@ -798,7 +799,7 @@ export async function exportSplitBin(
   cutPlanesX: readonly number[],
   cutPlanesY: readonly number[],
   tolerance = 0.01,
-  angularTolerance = 5,
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD,
   splitConnectorConfig?: SplitConnectorConfig,
   format: ExportFormat = 'stl'
 ): Promise<SplitExportResult> {
@@ -906,7 +907,7 @@ export async function exportSplitBinRange(
   cutPlanesY: readonly number[],
   pieceIndices: readonly number[],
   tolerance = 0.01,
-  angularTolerance = 5,
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD,
   splitConnectorConfig?: SplitConnectorConfig,
   format: ExportFormat = 'stl'
 ): Promise<SplitExportResult> {

--- a/src/features/generation/worker/generators/toolRackGenerator.ts
+++ b/src/features/generation/worker/generators/toolRackGenerator.ts
@@ -38,6 +38,7 @@ import { creaseEdges } from './utils';
 import { EDGE_ANGULAR_TOLERANCE_RAD } from '@/shared/constants/tessellation';
 import { keepOuterShell } from './utils/outerShell';
 import { buildBaseplateSTL } from './baseplateSTL';
+import { EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 
 interface ResolvedFins {
   readonly count: number;
@@ -199,7 +200,7 @@ export async function exportToolRack(
   envelope: ItemEnvelope,
   format: ExportFormat,
   tolerance = 0.02,
-  angularTolerance = 6
+  angularTolerance = EXPORT_ANGULAR_TOLERANCE_RAD
 ): Promise<{ data: ArrayBuffer; fileName: string }> {
   const built = buildToolRackSolid(structure, envelope, false);
   const rack = keepOuterShell(built);

--- a/src/features/generation/worker/generators/utils/outerShell.test.ts
+++ b/src/features/generation/worker/generators/utils/outerShell.test.ts
@@ -16,7 +16,7 @@ import { setLastSolid, getLastSolid } from '../shapeCache';
 import { buildBinBox } from '../boxBuilder';
 import { buildScoopRamps } from '../scoopRampBuilder';
 import { exportSolidToStl } from './stlMeshFallback';
-import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from './tolerances';
+import { EXPORT_ANGULAR_TOLERANCE_RAD, EXPORT_TOLERANCE } from './tolerances';
 import { keepOuterShell } from './outerShell';
 import type * as BinOrchestratorModule from '../binOrchestrator';
 
@@ -60,7 +60,7 @@ async function meshDefects(solid: unknown): Promise<{ nonManifold: number; bound
     solid as never,
     'x',
     EXPORT_TOLERANCE,
-    EXPORT_ANGULAR_TOLERANCE
+    EXPORT_ANGULAR_TOLERANCE_RAD
   );
   const parsed = parseSTLBinary(data);
   if (!isOk(parsed)) throw new Error('STL parse failed');

--- a/src/features/generation/worker/generators/utils/stlMeshFallback.test.ts
+++ b/src/features/generation/worker/generators/utils/stlMeshFallback.test.ts
@@ -11,7 +11,7 @@ import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BinParams } from '@/shared/types/bin';
 import { initBrepjs, getGenerateBin } from '../__kernel-tests__/wasmInit';
 import { getLastSolid, clearAllCaches } from '../shapeCache';
-import { EXPORT_ANGULAR_TOLERANCE, EXPORT_TOLERANCE } from './tolerances';
+import { EXPORT_ANGULAR_TOLERANCE_RAD, EXPORT_TOLERANCE } from './tolerances';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
 import { hasNoNaNOrInfinity } from '../__kernel-tests__/meshAssertions';
 import { isOk } from '@/core/result';
@@ -46,7 +46,7 @@ describe('exportSolidMeshToStl', () => {
       solid,
       'fallback-test',
       EXPORT_TOLERANCE,
-      EXPORT_ANGULAR_TOLERANCE
+      EXPORT_ANGULAR_TOLERANCE_RAD
     );
 
     const parsed = parseSTLBinary(data);
@@ -68,7 +68,7 @@ describe('exportSolidMeshToStl', () => {
       solid,
       'fallback-tall',
       EXPORT_TOLERANCE,
-      EXPORT_ANGULAR_TOLERANCE
+      EXPORT_ANGULAR_TOLERANCE_RAD
     );
     const parsed = parseSTLBinary(data);
     expect(isOk(parsed)).toBe(true);
@@ -78,7 +78,7 @@ describe('exportSolidMeshToStl', () => {
     // makes the fallback succeed whenever the preview (also mesh()-driven) does.
     const m = mesh(solid, {
       tolerance: EXPORT_TOLERANCE,
-      angularTolerance: EXPORT_ANGULAR_TOLERANCE,
+      angularTolerance: EXPORT_ANGULAR_TOLERANCE_RAD,
       cache: true,
     });
     const meshTriangleCount = m.triangles.length / 3;

--- a/src/features/generation/worker/generators/utils/tolerances.test.ts
+++ b/src/features/generation/worker/generators/utils/tolerances.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   EXPORT_TOLERANCE,
-  EXPORT_ANGULAR_TOLERANCE,
+  EXPORT_ANGULAR_TOLERANCE_RAD,
+  PREVIEW_ANGULAR_TOLERANCE_RAD,
   computeTessellationTolerances,
 } from './tolerances';
+
+/** OCCT's own default. Anything at or above it leaves the criterion inert. */
+const OCCT_DEFAULT_ANGULAR_RAD = 0.5;
 
 describe('computeTessellationTolerances', () => {
   it('uses fine export tolerance regardless of size or lip', () => {
@@ -11,16 +17,15 @@ describe('computeTessellationTolerances', () => {
       for (const hasLip of [true, false]) {
         expect(computeTessellationTolerances(true, hasLip, maxDimension)).toEqual({
           tolerance: EXPORT_TOLERANCE,
-          angularTolerance: EXPORT_ANGULAR_TOLERANCE,
+          angularToleranceRad: EXPORT_ANGULAR_TOLERANCE_RAD,
         });
       }
     }
   });
 
-  it('keeps a small lipped bin crisp (fine tolerance, tight angular)', () => {
-    const { tolerance, angularTolerance } = computeTessellationTolerances(false, true, 100);
+  it('keeps a small lipped bin crisp (fine tolerance)', () => {
+    const { tolerance } = computeTessellationTolerances(false, true, 100);
     expect(tolerance).toBeLessThanOrEqual(0.06);
-    expect(angularTolerance).toBe(8);
   });
 
   it('relaxes the lip tolerance on large bins instead of pinning it at 0.06', () => {
@@ -40,21 +45,65 @@ describe('computeTessellationTolerances', () => {
     expect(large).toBeLessThanOrEqual(0.15);
   });
 
-  it('loosens the angular tolerance on large lipped bins', () => {
-    expect(computeTessellationTolerances(false, true, 672).angularTolerance).toBeGreaterThan(8);
-  });
-
   it('uses the moderate tier for small lip-less bins (≤200mm)', () => {
-    const { tolerance, angularTolerance } = computeTessellationTolerances(false, false, 150);
+    const { tolerance } = computeTessellationTolerances(false, false, 150);
     expect(tolerance).toBeGreaterThanOrEqual(0.08);
     expect(tolerance).toBeLessThanOrEqual(0.2);
-    expect(angularTolerance).toBe(10);
   });
 
   it('uses the coarse tier for large lip-less bins (>200mm)', () => {
-    const { tolerance, angularTolerance } = computeTessellationTolerances(false, false, 600);
+    const { tolerance } = computeTessellationTolerances(false, false, 600);
     expect(tolerance).toBeGreaterThanOrEqual(0.15);
     expect(tolerance).toBeLessThanOrEqual(0.5);
-    expect(angularTolerance).toBe(15);
+  });
+
+  it('scales preview quality on the chord height, never on the angle', () => {
+    // The angular criterion is a floor on curve smoothness, not a size dial —
+    // tightening it at preview chord heights costs ~a third more triangles for
+    // no visible gain, so every preview tier shares one value.
+    for (const [hasLip, maxDimension] of [
+      [true, 100],
+      [true, 672],
+      [false, 150],
+      [false, 600],
+    ] as const) {
+      expect(computeTessellationTolerances(false, hasLip, maxDimension).angularToleranceRad).toBe(
+        PREVIEW_ANGULAR_TOLERANCE_RAD
+      );
+    }
+  });
+});
+
+describe('angular tolerance units', () => {
+  // These reach OCCT through brepjs's `mesh()` in RADIANS. Degrees-shaped
+  // numbers (5, 10, 12, 15) are all looser than OCCT's 0.5 default, so they
+  // silently disable the criterion instead of tightening it.
+  it('keeps the shared constants at or below OCCT default', () => {
+    expect(EXPORT_ANGULAR_TOLERANCE_RAD).toBeLessThanOrEqual(OCCT_DEFAULT_ANGULAR_RAD);
+    expect(PREVIEW_ANGULAR_TOLERANCE_RAD).toBeLessThanOrEqual(OCCT_DEFAULT_ANGULAR_RAD);
+    expect(EXPORT_ANGULAR_TOLERANCE_RAD).toBeGreaterThan(0);
+  });
+
+  it('leaves no degrees-shaped literal in the generators', () => {
+    const root = join(__dirname, '..');
+    const offenders: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          // Kernel-test helpers mesh solids only to measure them, and are
+          // excluded from normal runs — their deflection never ships.
+          if (entry.name !== '__kernel-tests__') walk(full);
+          continue;
+        }
+        if (!entry.name.endsWith('.ts') || entry.name.includes('.test.')) continue;
+        const src = readFileSync(full, 'utf8');
+        for (const m of src.matchAll(/angularTolerance\s*(?::|=|\?\?)\s*([0-9]+(?:\.[0-9]+)?)/g)) {
+          if (Number(m[1]) > OCCT_DEFAULT_ANGULAR_RAD) offenders.push(`${entry.name}: ${m[0]}`);
+        }
+      }
+    };
+    walk(root);
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/features/generation/worker/generators/utils/tolerances.ts
+++ b/src/features/generation/worker/generators/utils/tolerances.ts
@@ -3,11 +3,18 @@
  *
  * Centralizes the quality-tier logic used by tessellateStage
  * and export functions.
+ *
+ * Both numbers reach OCCT through brepjs's `mesh()`, and they are in DIFFERENT
+ * units: `tolerance` is a chord height in mm, `angularToleranceRad` is an angle
+ * in RADIANS. brepjs's own presets run 0.5 / 0.1 / 0.05 and OCCT defaults to
+ * 0.5, so any value at or above 0.5 leaves the angular criterion inert — which
+ * is what a degrees-shaped number silently buys.
  */
 
 export interface TessellationTolerances {
   readonly tolerance: number;
-  readonly angularTolerance: number;
+  /** Radians. See the unit note above. */
+  readonly angularToleranceRad: number;
 }
 
 /**
@@ -18,12 +25,27 @@ export interface TessellationTolerances {
  * triangles `exportSTL` writes.
  */
 export const EXPORT_TOLERANCE = 0.01;
-export const EXPORT_ANGULAR_TOLERANCE = 5;
+
+/**
+ * Tighter than OCCT's 0.5 default, so a small-radius feature cannot be facetted
+ * to whatever the 0.01mm chord height alone allows — chord height scales with
+ * the square root of the radius, so it is the tightest on big arcs and loosest
+ * exactly where a fillet is smallest.
+ */
+export const EXPORT_ANGULAR_TOLERANCE_RAD = 0.3;
+
+/**
+ * OCCT's own default, used for every preview tier. The angular criterion is a
+ * floor on curve smoothness, not a size dial: the `tolerance` tiers below carry
+ * the size scaling, and tightening this instead costs roughly a third more
+ * triangles at preview chord heights for no visible gain.
+ */
+export const PREVIEW_ANGULAR_TOLERANCE_RAD = 0.5;
 
 /**
  * Select tessellation tolerances based on export mode and bin dimensions.
  *
- * Quality tiers:
+ * Quality tiers (all on `tolerance`, the chord height):
  * - Export: fine (0.01mm) for STL/STEP accuracy
  * - Lip bins: tight to preserve chamfer profile at corner junctions, but
  *   relaxed on large bins so a giant hex-riddled wall isn't meshed at
@@ -38,7 +60,7 @@ export function computeTessellationTolerances(
   maxDimension: number
 ): TessellationTolerances {
   if (forExport) {
-    return { tolerance: EXPORT_TOLERANCE, angularTolerance: EXPORT_ANGULAR_TOLERANCE };
+    return { tolerance: EXPORT_TOLERANCE, angularToleranceRad: EXPORT_ANGULAR_TOLERANCE_RAD };
   }
   if (hasLip) {
     // The chamfer needs fine tessellation, but only at the rim — pinning the
@@ -49,17 +71,17 @@ export function computeTessellationTolerances(
     // (<300mm) are unaffected: maxDimension/5000 stays ≤0.06 below that.
     return {
       tolerance: Math.min(0.15, Math.max(0.03, maxDimension / 5000)),
-      angularTolerance: maxDimension > 200 ? 12 : 8,
+      angularToleranceRad: PREVIEW_ANGULAR_TOLERANCE_RAD,
     };
   }
   if (maxDimension <= 200) {
     return {
       tolerance: Math.min(0.2, Math.max(0.08, maxDimension / 1200)),
-      angularTolerance: 10,
+      angularToleranceRad: PREVIEW_ANGULAR_TOLERANCE_RAD,
     };
   }
   return {
     tolerance: Math.min(0.5, Math.max(0.15, maxDimension / 600)),
-    angularTolerance: 15,
+    angularToleranceRad: PREVIEW_ANGULAR_TOLERANCE_RAD,
   };
 }


### PR DESCRIPTION
Found while investigating #3703. Not a fix for that issue — the lip's corner lattice is unchanged at these values — but a real latent bug in its own right.

## The bug

brepjs's `mesh()` takes `angularTolerance` in **radians**. Its own quality presets run `0.5` / `0.1` / `0.05`, and OCCT defaults to `0.5`. Every caller passed a degrees-shaped number:

| site | value |
| --- | --- |
| `EXPORT_ANGULAR_TOLERANCE` | `5` |
| `computeTessellationTolerances` preview tiers | `8` / `12` / `10` / `15` |
| baseplate, split bin, divider, lid, slide, knife-rest, tool-rack, detachable-feet, fit-sample coupons | `5` / `6` / `10` |

All of them are looser than OCCT's default, so the criterion has never taken effect. Meshing the stacking lip at `tolerance: 0.01` returns a byte-identical 1216-triangle result at `angularTolerance` 5, 0.5, 0.15, 0.1 **and** 0.05.

The codebase already had a correctly-named `EDGE_ANGULAR_TOLERANCE_RAD = 0.01` for `meshEdges`, which is what made the unit slip visible.

## Why it matters

Chord height alone under-tessellates exactly where a feature is smallest: the segment count it implies scales with the square root of the radius, so a big corner arc is the tightest thing in the mesh and a screw hole the loosest. That is backwards. The angular criterion is radius-independent and is what puts a floor under it.

## The values

- `EXPORT_ANGULAR_TOLERANCE_RAD = 0.3`
- `PREVIEW_ANGULAR_TOLERANCE_RAD = 0.5` (OCCT's own default), shared by every preview tier

The per-tier variation is **dropped rather than translated**. It never took effect, the `tolerance` tiers already carry the size scaling, and tightening the angle at preview chord heights costs roughly a third more triangles for nothing visible. Re-encoding fake variation in radians would just be the same bug in a new unit.

`TessellationTolerances.angularTolerance` is renamed `angularToleranceRad` so the unit is legible where the value is chosen; the brepjs-facing option name is unchanged at the call.

I deliberately did not go to `0.1`, which would align the lip's corner lattice: it costs **+136%** triangles for sub-micron gains no FDM printer resolves.

## Cost, measured

| | triangles |
| --- | --- |
| representative bins, export | +1.8% (2516→2564, 15396→15668) |
| previews | +3-10% |
| all 169 scenario snapshots | 735444 → 780096 (**+6.1%**) |

Largest deltas are magnet- and screw-hole-heavy bins (`4x4 no lip` +76.8%, `4x4 magnet + label bracket + half-sockets` +72.7%) — the under-tessellation being corrected.

## Guard

`tolerances.test.ts` scans the generators for `angularTolerance` literals above OCCT's default and fails on them. It found six sites the by-hand rename missed — inline `mesh()` options in `labelPlateBuilder`, `baseplateGenerator` and `detachableFeetOrchestrator` — which is how this spread across a dozen files unnoticed: the unit is invisible at the call site. `__kernel-tests__` is skipped; those helpers mesh solids only to measure them and never ship.

## Verification

- `typecheck` clean, `lint` clean (0 errors, same 71 pre-existing warnings as main).
- 169 snapshots regenerated; the 8 that conflicted on rebase were reset to main's values and regenerated on top, then re-run without `-u`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

