### PR TITLE
fix(baseplate): let the plate page turn half-grid mode back off

### DIFF
--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
@@ -3,9 +3,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { DimensionsSection } from './DimensionsSection';
 import { useLayoutStore } from '@/core/store/layout';
 import { useHalfGridModeStore } from '@/core/store/halfGridMode';
+import { useToastStore } from '@/core/store/toast';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
 import { gridUnits, mm } from '@/core/types';
-import { resetAllStores } from '@/test/testUtils';
+import { createTestBin, resetAllStores } from '@/test/testUtils';
 import { drawerFrameOverhang } from '@/shared/utils/outlineFrame';
 
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
@@ -13,7 +14,11 @@ vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 describe('DimensionsSection', () => {
   beforeEach(() => {
     resetAllStores();
+    useToastStore.setState({ toasts: [] });
+    useHalfGridModeStore.getState().setHalfGridMode(false);
   });
+
+  const toastMessages = (): string[] => useToastStore.getState().toasts.map((t) => t.message);
 
   it('renders the sync toggle, steppers, and padding controls', () => {
     render(<DimensionsSection />);
@@ -83,6 +88,100 @@ describe('DimensionsSection', () => {
       const params = useLayoutStore.getState().layout.baseplateParams;
       expect(params?.baseplateDepth).toBe(11);
       expect(useHalfGridModeStore.getState().halfGridMode).toBe(false);
+    });
+
+    it('says so when the fit turns the mode on', () => {
+      render(<DimensionsSection />);
+      commitMm('423', '502');
+      expect(toastMessages()).toContain('toast.halfBinModeAutoEnabled');
+    });
+  });
+
+  //. mm entry turns half-grid mode on, and the plate page carries neither the
+  // sidebar's toggle nor the H shortcut, so without this control the mode is
+  // reachable but not reversible from the only page that sets it.
+  describe('half-grid mode toggle', () => {
+    const toggle = (): HTMLElement => screen.getByLabelText('sidebar.halfBinMode');
+
+    /** A detached plate with explicit dimensions, as mm entry leaves one. */
+    function detachedPlate(width: number, depth: number, padMm: number): void {
+      const current = useLayoutStore.getState().layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
+      useLayoutStore.getState().setBaseplateParams({
+        ...current,
+        syncWithLayout: false,
+        baseplateWidth: gridUnits(width),
+        baseplateDepth: gridUnits(depth),
+        paddingLeft: mm(padMm),
+        paddingRight: mm(padMm),
+        paddingFront: mm(padMm),
+        paddingBack: mm(padMm),
+      });
+    }
+
+    it('reflects the stored mode', () => {
+      useHalfGridModeStore.getState().setHalfGridMode(true);
+      render(<DimensionsSection />);
+      expect(toggle()).toBeChecked();
+    });
+
+    it('turns the mode on', () => {
+      render(<DimensionsSection />);
+      fireEvent.click(toggle());
+      expect(useHalfGridModeStore.getState().halfGridMode).toBe(true);
+    });
+
+    // The 502mm drawer from the mm-entry case above, run backwards: 11.5 units
+    // and 9.5mm a side becomes 11 units and 20mm, the same 502mm footprint.
+    it('floors fractional dimensions and hands the millimetres back to padding', () => {
+      useHalfGridModeStore.getState().setHalfGridMode(true);
+      detachedPlate(11.5, 6.5, 9.5);
+      render(<DimensionsSection />);
+      fireEvent.click(toggle());
+
+      const params = useLayoutStore.getState().layout.baseplateParams;
+      expect(useHalfGridModeStore.getState().halfGridMode).toBe(false);
+      expect(params?.baseplateWidth).toBe(11);
+      expect(params?.baseplateDepth).toBe(6);
+      expect(params?.paddingLeft).toBeCloseTo(20, 2);
+      expect(params?.paddingRight).toBeCloseTo(20, 2);
+      expect(params?.paddingFront).toBeCloseTo(20, 2);
+      expect(params?.paddingBack).toBeCloseTo(20, 2);
+    });
+
+    it('leaves whole-unit dimensions and their padding untouched', () => {
+      useHalfGridModeStore.getState().setHalfGridMode(true);
+      detachedPlate(11, 6, 9.5);
+      render(<DimensionsSection />);
+      fireEvent.click(toggle());
+
+      const params = useLayoutStore.getState().layout.baseplateParams;
+      expect(params?.baseplateWidth).toBe(11);
+      expect(params?.paddingLeft).toBeCloseTo(9.5, 2);
+    });
+
+    it('leaves a synced plate to the layout', () => {
+      useHalfGridModeStore.getState().setHalfGridMode(true);
+      render(<DimensionsSection />);
+      fireEvent.click(toggle());
+
+      const params = useLayoutStore.getState().layout.baseplateParams;
+      expect(useHalfGridModeStore.getState().halfGridMode).toBe(false);
+      expect(params?.baseplateWidth).toBeUndefined();
+    });
+
+    it('keeps the mode on and says why when fractional bins block it', () => {
+      useHalfGridModeStore.getState().setHalfGridMode(true);
+      useLayoutStore.setState((state) => ({
+        layout: {
+          ...state.layout,
+          bins: [createTestBin({ width: gridUnits(1.5) })],
+        },
+      }));
+      render(<DimensionsSection />);
+      fireEvent.click(toggle());
+
+      expect(useHalfGridModeStore.getState().halfGridMode).toBe(true);
+      expect(toastMessages()).toContain('halfBinBlocked.message');
     });
   });
 

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.test.tsx
@@ -5,7 +5,7 @@ import { useLayoutStore } from '@/core/store/layout';
 import { useHalfGridModeStore } from '@/core/store/halfGridMode';
 import { useToastStore } from '@/core/store/toast';
 import { DEFAULT_BASEPLATE_PARAMS } from '@/core/constants';
-import { gridUnits, mm } from '@/core/types';
+import { gridUnits, mm, effectiveGridUnitMmY } from '@/core/types';
 import { createTestBin, resetAllStores } from '@/test/testUtils';
 import { drawerFrameOverhang } from '@/shared/utils/outlineFrame';
 
@@ -118,6 +118,18 @@ describe('DimensionsSection', () => {
       });
     }
 
+    /** Outer plate size in mm — the figure the user typed, which has to survive. */
+    function footprint(): { w: number; d: number } {
+      const { layout } = useLayoutStore.getState();
+      const p = layout.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
+      const gridW = (p.baseplateWidth ?? layout.drawer.width) * layout.gridUnitMm;
+      const gridD = (p.baseplateDepth ?? layout.drawer.depth) * effectiveGridUnitMmY(layout);
+      return {
+        w: gridW + p.paddingLeft + p.paddingRight,
+        d: gridD + p.paddingFront + p.paddingBack,
+      };
+    }
+
     it('reflects the stored mode', () => {
       useHalfGridModeStore.getState().setHalfGridMode(true);
       render(<DimensionsSection />);
@@ -130,12 +142,11 @@ describe('DimensionsSection', () => {
       expect(useHalfGridModeStore.getState().halfGridMode).toBe(true);
     });
 
-    // The 502mm drawer from the mm-entry case above, run backwards: 11.5 units
-    // and 9.5mm a side becomes 11 units and 20mm, the same 502mm footprint.
     it('floors fractional dimensions and hands the millimetres back to padding', () => {
       useHalfGridModeStore.getState().setHalfGridMode(true);
       detachedPlate(11.5, 6.5, 9.5);
       render(<DimensionsSection />);
+      const before = footprint();
       fireEvent.click(toggle());
 
       const params = useLayoutStore.getState().layout.baseplateParams;
@@ -146,6 +157,7 @@ describe('DimensionsSection', () => {
       expect(params?.paddingRight).toBeCloseTo(20, 2);
       expect(params?.paddingFront).toBeCloseTo(20, 2);
       expect(params?.paddingBack).toBeCloseTo(20, 2);
+      expect(footprint()).toEqual(before);
     });
 
     it('leaves whole-unit dimensions and their padding untouched', () => {

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
@@ -280,14 +280,15 @@ export function DimensionsSection() {
    */
   const handleHalfGridToggle = useCallback(
     (checked: boolean) => {
-      if (checked) {
-        setHalfGridMode(true);
-        return;
-      }
+      // Both directions route through the toggle rather than a bare setter, so
+      // this checkbox earns the feature-usage mark and the persistence-failure
+      // toast the store attaches to a user-driven flip.
+      if (checked === useHalfGridModeStore.getState().halfGridMode) return;
       if (!isOk(toggleHalfGridMode())) {
         addToast(t('halfBinBlocked.message'), 'error');
         return;
       }
+      if (checked) return;
       const layoutState = useLayoutStore.getState().layout;
       const current = layoutState.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
       if (current.syncWithLayout !== false) return;
@@ -311,7 +312,7 @@ export function DimensionsSection() {
         paddingBack: mm(grow(current.paddingBack, freedDepth)),
       });
     },
-    [addToast, gridUnitMm, gridUnitMmY, setHalfGridMode, t, toggleHalfGridMode]
+    [addToast, gridUnitMm, gridUnitMmY, t, toggleHalfGridMode]
   );
 
   return (

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
@@ -7,6 +7,8 @@
 import { useCallback } from 'react';
 import { useLayoutStore } from '@/core/store/layout';
 import { useHalfGridModeStore } from '@/core/store/halfGridMode';
+import { useToastStore } from '@/core/store/toast';
+import { isOk } from '@/core/result';
 import { FractionalEdgeToggle } from '@/shared/components/FractionalEdgeToggle';
 import { DEFAULT_BASEPLATE_PARAMS, CONSTRAINTS, MARGIN_MIN_DETACH_MM } from '@/core/constants';
 import { Checkbox } from '@/design-system/Checkbox/Checkbox';
@@ -20,7 +22,7 @@ import { GridAlignmentControls } from '@/shared/components/GridAlignmentControls
 import { PaddingSchematic } from './PaddingSchematic';
 import { GridDimensionStepper } from './GridDimensionStepper';
 import { resolveOverTileStatus } from '../../utils/overTileStatus';
-import { PADDING_MAX } from '../PaddingStepper';
+import { PADDING_MAX, roundMm } from '../PaddingStepper';
 import { gridUnits, mm, effectiveGridUnitMmY } from '@/core/types';
 import { isMarginSeamStyle } from '@/shared/types/bin';
 import { cornerCutsMatchVertices } from '@/shared/utils/cornerCutOutline';
@@ -61,6 +63,8 @@ export function DimensionsSection() {
   } = useBaseplatePanelDerived();
   const halfGridMode = useHalfGridModeStore((s) => s.halfGridMode);
   const setHalfGridMode = useHalfGridModeStore((s) => s.setHalfGridMode);
+  const toggleHalfGridMode = useHalfGridModeStore((s) => s.toggleHalfGridMode);
+  const addToast = useToastStore((s) => s.addToast);
 
   const handleSyncToggle = useCallback((checked: boolean) => {
     const layoutState = useLayoutStore.getState().layout;
@@ -232,7 +236,10 @@ export function DimensionsSection() {
         : halfUnitUpgrade(targetDepthMm, gridUnitMmY, depthFit.units);
       const snappedWidth = (widthUpgrade ?? widthFit).units;
       const snappedDepth = (depthUpgrade ?? depthFit).units;
-      if (widthUpgrade !== null || depthUpgrade !== null) setHalfGridMode(true);
+      if (widthUpgrade !== null || depthUpgrade !== null) {
+        setHalfGridMode(true);
+        addToast(t('toast.halfBinModeAutoEnabled'), 'info');
+      }
 
       // Clamp at 0: `slackMm` goes negative when the fit's minimum (1 unit in
       // whole-unit mode, GRID_MIN in half) forced a grid larger than the
@@ -258,7 +265,53 @@ export function DimensionsSection() {
         paddingBack: mm(halfPadDepth),
       });
     },
-    [gridUnitMm, gridUnitMmY, halfGridMode, setHalfGridMode]
+    [addToast, gridUnitMm, gridUnitMmY, halfGridMode, setHalfGridMode, t]
+  );
+
+  /**
+   * The plate page is the only surface that can turn half-grid mode on without
+   * offering a way back: the sidebar toggle and the H shortcut both live on the
+   * layout route, so mm entry would otherwise strand the mode here.
+   *
+   * Turning it off reverses that entry's trade. Each fractional axis floors to a
+   * whole unit and the millimetres it gives up return to the matching padding
+   * pair, so the footprint the user typed survives and the grid re-centers
+   * inside it. A synced plate keeps its dimensions — the layout owns those.
+   */
+  const handleHalfGridToggle = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setHalfGridMode(true);
+        return;
+      }
+      if (!isOk(toggleHalfGridMode())) {
+        addToast(t('halfBinBlocked.message'), 'error');
+        return;
+      }
+      const layoutState = useLayoutStore.getState().layout;
+      const current = layoutState.baseplateParams ?? DEFAULT_BASEPLATE_PARAMS;
+      if (current.syncWithLayout !== false) return;
+      const width = current.baseplateWidth ?? layoutState.drawer.width;
+      const depth = current.baseplateDepth ?? layoutState.drawer.depth;
+      const wholeWidth = Math.max(1, Math.floor(width));
+      const wholeDepth = Math.max(1, Math.floor(depth));
+      if (wholeWidth === width && wholeDepth === depth) return;
+      // Clamp at 0: flooring a sub-unit axis raises it to 1 instead, and a grid
+      // that grew has no freed material to hand back.
+      const freedWidth = Math.max(0, (width - wholeWidth) * gridUnitMm) / 2;
+      const freedDepth = Math.max(0, (depth - wholeDepth) * gridUnitMmY) / 2;
+      const grow = (pad: number, by: number): number => Math.min(PADDING_MAX, roundMm(pad + by));
+      useLayoutStore.getState().setBaseplateParams({
+        ...current,
+        baseplateWidth: gridUnits(wholeWidth),
+        baseplateDepth: gridUnits(wholeDepth),
+        paddingLeft: mm(grow(current.paddingLeft, freedWidth)),
+        paddingRight: mm(grow(current.paddingRight, freedWidth)),
+        paddingFront: mm(grow(current.paddingFront, freedDepth)),
+        paddingBack: mm(grow(current.paddingBack, freedDepth)),
+      });
+    },
+    [addToast, gridUnitMm, gridUnitMmY, setHalfGridMode, t, toggleHalfGridMode]
   );
 
   return (
@@ -285,6 +338,11 @@ export function DimensionsSection() {
             disabled={synced}
           />
         </div>
+        <Checkbox
+          checked={halfGridMode}
+          onChange={handleHalfGridToggle}
+          label={t('sidebar.halfBinMode')}
+        />
         {/* Fractional edge position — shown when the effective dimensions are half-unit */}
         {(hasFractionalWidth || hasFractionalDepth) && (
           <div className="space-y-1.5">

--- a/src/features/baseplate/components/PaddingStepper/index.ts
+++ b/src/features/baseplate/components/PaddingStepper/index.ts
@@ -1,2 +1,2 @@
 export { PaddingStepper } from './PaddingStepper';
-export { PADDING_BUTTON_STEP, PADDING_MIN, PADDING_MAX } from './constants';
+export { PADDING_BUTTON_STEP, PADDING_MIN, PADDING_MAX, roundMm } from './constants';


### PR DESCRIPTION
## Problem

Typing a target size on the baseplate page takes the tighter half-unit fit and turns half-grid mode on. That page carries neither the sidebar's toggle nor the `H` shortcut (`useKeyboard` is disabled on non-layout routes), so the mode was reachable and not reversible from the only surface that sets it. It also flipped silently: a plate came back with a half row the user never asked for and no control to undo it.

Reported in discussion #3715, where the workaround was to step the grid down by hand and math the lost millimetres back into the padding fields.

## Change

- Render the Half-grid mode checkbox in the baseplate dimensions section, under the grid steppers.
- Toast on auto-enable, matching what the layout's measured-drawer card already does.
- Turning it off reverses the trade: each fractional axis floors to a whole unit and the millimetres it gives up return to the matching padding pair. A 423 × 502mm plate goes from 11.5 units and 9.5mm a side to 11 units and 20mm. Same footprint, grid centered.
- Disabling still runs the fractional-bin validation and says why when it is blocked. A synced plate keeps its dimensions, since the layout owns those.

## Verified

Driven in the running app: mm entry lands 11.5 depth with the toast, unchecking the toggle lands 11 depth with 20mm front and back, footprint holds at 423 × 502mm. 31 tests in `DimensionsSection.test.tsx`, 1061 across the baseplate feature.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

