### PR TITLE
feat(workshop): add the assembly item kind and schema behind a labs flag

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -89,6 +89,7 @@
     "binDesigner.handles.summary",
     "binDesigner.interior.bento.title",
     "binDesigner.interiorSolid",
+    "binDesigner.itemKind.assembly",
     "binDesigner.knifeRest.style",
     "binDesigner.labelColor",
     "binDesigner.layout",

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -249,6 +249,19 @@ export const FEATURE_FLAGS = [
     graduatedAt: '2026-08',
     requiresRefresh: false,
   },
+  {
+    id: 'workshop',
+    name: 'Workshop',
+    description:
+      'Build tool holders from parts. Place posts, fins, tubes, cradles and more on a Gridfinity base in 3D, stack and carve them, then export the result.',
+    status: 'experimental',
+    risk: 'medium',
+    warning:
+      'Under construction. The Workshop editor has not shipped yet, so this switch does nothing until it arrives.',
+    addedAt: '2026-08',
+    requiresRefresh: false,
+    comingSoon: true,
+  },
 ] as const satisfies readonly FeatureFlag[];
 
 export type FeatureId = (typeof FEATURE_FLAGS)[number]['id'];

--- a/src/features/bin-designer/store/customBinRegistry.ts
+++ b/src/features/bin-designer/store/customBinRegistry.ts
@@ -268,7 +268,9 @@ function parseEntry(raw: unknown): CustomBinRef | null {
     ...(typeof fractionalEdgeManualX === 'boolean' ? { fractionalEdgeManualX } : {}),
     ...(typeof fractionalEdgeManualY === 'boolean' ? { fractionalEdgeManualY } : {}),
     ...(typeof halfSockets === 'boolean' ? { halfSockets } : {}),
-    ...(kind === 'bin' || kind === 'toolRack' || kind === 'importedMesh' ? { kind } : {}),
+    ...(kind === 'bin' || kind === 'toolRack' || kind === 'importedMesh' || kind === 'assembly'
+      ? { kind }
+      : {}),
     ...(typeof assembledRiseMm === 'number' &&
     Number.isFinite(assembledRiseMm) &&
     assembledRiseMm > 0

--- a/src/features/labs/README.md
+++ b/src/features/labs/README.md
@@ -38,6 +38,7 @@ Internal status enum values → UI badge labels: `experimental` → "Early acces
 | `item_kinds`            | `experimental`  | Non-bin items (tool racks) that sit on a baseplate                                            |
 | `community_fits_gap`    | `experimental`  | Select a layout gap and browse community designs that fit it                                  |
 | `sliding_tray`          | `experimental`  | Rail-and-tray sliding insert in the bin designer's Walls section                              |
+| `workshop`              | `experimental`  | Part-based Workshop builder (coming soon; no UI yet)                                          |
 | `community_showcase`    | `preview`       | Publish and remix bin designs in the community showcase                                       |
 | `drawer_shapes`         | `graduated`     | Non-rectangular drawer shapes (L-shapes, notches, cut corners)                                |
 | `bin_designer`          | `graduated`     | Custom bin designer                                                                           |

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Mřížkové přepážky",
   "binDesigner.interiorSummary": "{count} přihrádek",
   "binDesigner.invalidDesignFile": "Neplatný soubor návrhu",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Držák na nářadí sestavený z dílů na základně Gridfinity",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Vlastní úložný bin Gridfinity",
   "binDesigner.itemKind.importedMesh": "Importovaný bin",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Rastereinteilung",
   "binDesigner.interiorSummary": "{count} Fach/Fächer",
   "binDesigner.invalidDesignFile": "Ungültige Design-Datei",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Werkzeughalter aus Teilen auf einer Gridfinity-Basis",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Individueller Gridfinity-Aufbewahrungsbehälter",
   "binDesigner.itemKind.importedMesh": "Importierter Behälter",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2215,6 +2215,8 @@ const en: Record<string, string> = {
   'binDesigner.itemKind.toolRack.description': 'Angled rack for pliers, tweezers, and hand tools',
   'binDesigner.itemKind.importedMesh': 'Imported bin',
   'binDesigner.itemKind.importedMesh.description': 'Bin imported from an STL file',
+  'binDesigner.itemKind.assembly': 'Workshop',
+  'binDesigner.itemKind.assembly.description': 'Tool holder built from parts on a Gridfinity base',
   'binDesigner.newToolRack': 'New tool rack (experimental)',
   'binDesigner.newBin': 'New bin',
   'binDesigner.rack.group': 'Tool rack',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Divisores de cuadrícula",
   "binDesigner.interiorSummary": "{count} compartimento(s)",
   "binDesigner.invalidDesignFile": "Archivo de diseño no válido",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Soporte de herramientas construido con piezas sobre una base Gridfinity",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Contenedor Gridfinity personalizado",
   "binDesigner.itemKind.importedMesh": "Contenedor importado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Séparateurs en grille",
   "binDesigner.interiorSummary": "{count} compartiment(s)",
   "binDesigner.invalidDesignFile": "Fichier de design invalide",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Support à outils construit à partir de pièces sur une base Gridfinity",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Bac de rangement Gridfinity personnalisé",
   "binDesigner.itemKind.importedMesh": "Bac importé",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Divisori a griglia",
   "binDesigner.interiorSummary": "{count} scomparti",
   "binDesigner.invalidDesignFile": "File di design non valido",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Portautensili costruito con parti su una base Gridfinity",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Bin portaoggetti Gridfinity personalizzato",
   "binDesigner.itemKind.importedMesh": "Contenitore importato",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "グリッド仕切り板",
   "binDesigner.interiorSummary": "{count}個の区画",
   "binDesigner.invalidDesignFile": "無効なデザインファイルです",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Gridfinityベースの上にパーツを組み合わせて作るツールホルダー",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "カスタム Gridfinity 収納ビン",
   "binDesigner.itemKind.importedMesh": "インポートしたビン",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "그리드 칸막이",
   "binDesigner.interiorSummary": "칸 {count}개",
   "binDesigner.invalidDesignFile": "잘못된 디자인 파일",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Gridfinity 베이스 위에 부품을 조립해 만드는 공구 홀더",
   "binDesigner.itemKind.bin": "수납통",
   "binDesigner.itemKind.bin.description": "맞춤 Gridfinity 수납통",
   "binDesigner.itemKind.importedMesh": "가져온 수납통",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Rutenettvegger",
   "binDesigner.interiorSummary": "{count} rom",
   "binDesigner.invalidDesignFile": "Ugyldig designfil",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Verktøyholder bygget av deler på en Gridfinity-base",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Egendefinert Gridfinity-oppbevaringsboks",
   "binDesigner.itemKind.importedMesh": "Importert boks",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Rasterverdeling",
   "binDesigner.interiorSummary": "{count} compartiment(en)",
   "binDesigner.invalidDesignFile": "Ongeldig ontwerpbestand",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Gereedschapshouder opgebouwd uit onderdelen op een Gridfinity-basis",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Aangepaste Gridfinity-opbergbak",
   "binDesigner.itemKind.importedMesh": "Geïmporteerde bak",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Przegródki siatki",
   "binDesigner.interiorSummary": "{count} przegroda/przegród",
   "binDesigner.invalidDesignFile": "Nieprawidłowy plik projektu",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Uchwyt na narzędzia zbudowany z części na podstawie Gridfinity",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Własny bin do przechowywania Gridfinity",
   "binDesigner.itemKind.importedMesh": "Zaimportowany bin",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Divisores em grade",
   "binDesigner.interiorSummary": "{count} compartimento(s)",
   "binDesigner.invalidDesignFile": "Arquivo de design inválido",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Suporte de ferramentas montado com peças sobre uma base Gridfinity",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Caixa de armazenamento Gridfinity personalizada",
   "binDesigner.itemKind.importedMesh": "Compartimento importado",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Rutnätsavdelare",
   "binDesigner.interiorSummary": "{count} fack",
   "binDesigner.invalidDesignFile": "Ogiltig designfil",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Verktygshållare byggd av delar på en Gridfinity-bas",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Anpassad Gridfinity-förvaringslåda",
   "binDesigner.itemKind.importedMesh": "Importerad låda",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "Сітка розділювачів",
   "binDesigner.interiorSummary": "{count} відсіків",
   "binDesigner.invalidDesignFile": "Недійсний файл дизайну",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "Тримач інструментів, зібраний з деталей на основі Gridfinity",
   "binDesigner.itemKind.bin": "Bin",
   "binDesigner.itemKind.bin.description": "Власний контейнер Gridfinity",
   "binDesigner.itemKind.importedMesh": "Імпортований контейнер",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1041,6 +1041,8 @@
   "binDesigner.interior.standard.title": "网格隔板",
   "binDesigner.interiorSummary": "{count} 个隔间",
   "binDesigner.invalidDesignFile": "无效的设计文件",
+  "binDesigner.itemKind.assembly": "Workshop",
+  "binDesigner.itemKind.assembly.description": "在 Gridfinity 底座上用零件搭建的工具架",
   "binDesigner.itemKind.bin": "收纳盒",
   "binDesigner.itemKind.bin.description": "自定义 Gridfinity 收纳盒",
   "binDesigner.itemKind.importedMesh": "导入的收纳盒",

--- a/src/shared/items/assembly/descriptor.test.ts
+++ b/src/shared/items/assembly/descriptor.test.ts
@@ -287,6 +287,41 @@ describe('assembly migrate', () => {
     expect(migrated.parts[0]?.array).toBeUndefined();
   });
 
+  it('drops each invalid optional on its own, keeping the other', () => {
+    const migrated = migrate(
+      structureWith([
+        post('bad-array', { array: { count: 1, dx: 5, dy: 0 }, mirror: true }),
+        post('bad-mirror', { array: { count: 3, dx: 10, dy: 0 }, mirror: 'yes' }),
+      ])
+    );
+    expect(migrated.parts).toHaveLength(2);
+    expect(migrated.parts[0]?.array).toBeUndefined();
+    expect(migrated.parts[0]?.mirror).toBe(true);
+    expect(migrated.parts[1]?.array).toEqual({ count: 3, dx: 10, dy: 0 });
+    expect(migrated.parts[1]?.mirror).toBeUndefined();
+  });
+
+  it('trims an over-cap build to the first parts instead of resetting it', () => {
+    const parts = Array.from({ length: MAX_ASSEMBLY_PARTS + 40 }, (_, i) => post(`p${i}`));
+    const migrated = migrate(structureWith(parts));
+    expect(migrated.parts).toHaveLength(MAX_ASSEMBLY_PARTS);
+    expect(migrated.parts[0]?.id).toBe('p0');
+    expect(migrated.parts[MAX_ASSEMBLY_PARTS - 1]?.id).toBe(`p${MAX_ASSEMBLY_PARTS - 1}`);
+  });
+
+  it('prunes stacking beyond the depth cap instead of resetting the build', () => {
+    const chain = (depth: number): Record<string, unknown> =>
+      post(`d${depth}`, depth > 1 ? { children: [chain(depth - 1)] } : {});
+    const migrated = migrate(structureWith([chain(MAX_ASSEMBLY_DEPTH + 3)]));
+    let depth = 0;
+    let level = migrated.parts;
+    while (level.length > 0) {
+      depth += 1;
+      level = level[0]?.children ?? [];
+    }
+    expect(depth).toBe(MAX_ASSEMBLY_DEPTH);
+  });
+
   it('resets an invalid base while keeping the parts', () => {
     const migrated = migrate({
       base: { floorThickness: 999 },

--- a/src/shared/items/assembly/descriptor.test.ts
+++ b/src/shared/items/assembly/descriptor.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ASSEMBLY_STRUCTURE,
+  MAX_ASSEMBLY_DEPTH,
+  MAX_ASSEMBLY_PARTS,
+  assemblyDescriptor,
+  assemblySchema,
+  defaultPartParams,
+} from '@/shared/items/assembly/descriptor';
+import { ASSEMBLY_PART_TYPES } from '@/shared/types/assembly';
+import type { AssemblyPartNode, AssemblyStructure } from '@/shared/types/assembly';
+import type { ItemEnvelope } from '@/shared/types/item';
+
+const envelope: ItemEnvelope = {
+  width: 4,
+  depth: 2,
+  gridUnitMm: 42,
+  heightUnitMm: 7,
+  attachment: {
+    magnetHoles: false,
+    magnetDiameter: 6,
+    magnetDepth: 2,
+    screwHoles: false,
+    screwDiameter: 3,
+  },
+  featureColors: { enabled: false } as never,
+};
+
+function asAssembly(value: unknown): AssemblyStructure {
+  const parsed = assemblySchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`expected a valid assembly: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+function post(id: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    type: 'post',
+    params: defaultPartParams('post'),
+    transform: { x: 0, y: 0, seatZ: 0, rotZDeg: 0 },
+    children: [],
+    ...extra,
+  };
+}
+
+function structureWith(parts: unknown[]): Record<string, unknown> {
+  return { ...DEFAULT_ASSEMBLY_STRUCTURE, parts };
+}
+
+describe('assembly defaults', () => {
+  it('returns a fresh, schema-valid, empty structure per call', () => {
+    const a = assemblyDescriptor.defaults();
+    const b = assemblyDescriptor.defaults();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+    expect(asAssembly(a).kind).toBe('assembly');
+    expect(asAssembly(a).schemaVersion).toBe(1);
+    expect(asAssembly(a).parts).toEqual([]);
+    const aa = asAssembly(a);
+    const bb = asAssembly(b);
+    expect(aa.base).toEqual(bb.base);
+    expect(a).not.toBe(b);
+  });
+
+  it('has schema-valid default params for every part type', () => {
+    for (const type of ASSEMBLY_PART_TYPES) {
+      const node = {
+        id: `default-${type}`,
+        type,
+        params: defaultPartParams(type),
+        transform: { x: 0, y: 0, seatZ: 0, rotZDeg: 0 },
+        children: [],
+      };
+      const result = assemblySchema.safeParse(structureWith([node]));
+      expect(result.success, `default ${type} params should validate`).toBe(true);
+    }
+  });
+
+  it('returns fresh param objects so callers can mutate safely', () => {
+    const a = defaultPartParams('cutter');
+    const b = defaultPartParams('cutter');
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+    if ('profile' in a && 'profile' in b) {
+      expect(a.profile).not.toBe(b.profile);
+    }
+  });
+});
+
+describe('assembly schema', () => {
+  it('round-trips a nested build with arrays, mirrors, and cutters', () => {
+    const build = structureWith([
+      {
+        id: 'rail',
+        type: 'block',
+        params: { width: 160, depth: 12, height: 30, wedgeAngleDeg: 0 },
+        transform: { x: 4, y: 60, seatZ: 0, rotZDeg: 0 },
+        children: [
+          {
+            id: 'holes',
+            type: 'cutter',
+            params: {
+              profile: { shape: 'circle', diameter: 7 },
+              depth: 25,
+              clearance: 0.2,
+              chamfer: 0.6,
+            },
+            transform: { x: 12, y: 6, seatZ: 0, rotZDeg: 0 },
+            array: { count: 6, dx: 24, dy: 0 },
+            children: [],
+          },
+        ],
+      },
+      {
+        id: 'divider',
+        type: 'fin',
+        params: { length: 60, thickness: 3, height: 25, leanDeg: 20 },
+        transform: { x: 20, y: 10, seatZ: 0, rotZDeg: 90 },
+        mirror: true,
+        children: [],
+      },
+      {
+        id: 'shadow',
+        type: 'cutter',
+        params: {
+          profile: {
+            shape: 'outline',
+            points: [
+              { x: 0, y: 0 },
+              { x: 30, y: 0 },
+              { x: 15, y: 50 },
+            ],
+          },
+          depth: 8,
+          clearance: 0.4,
+          chamfer: 0,
+        },
+        transform: { x: 60, y: 20, seatZ: 0, rotZDeg: 15 },
+        children: [],
+      },
+    ]);
+    const parsed = assemblySchema.safeParse(build);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data).toEqual(build);
+    }
+  });
+
+  it('accepts every cutter profile shape', () => {
+    const profiles = [
+      { shape: 'circle', diameter: 6 },
+      { shape: 'rectangle', width: 20, depth: 10, cornerRadius: 2 },
+      { shape: 'polygon', diameter: 8, sides: 6 },
+      { shape: 'slot', length: 40, width: 3 },
+      {
+        shape: 'path',
+        points: [
+          { x: 0, y: 0, handleIn: null, handleOut: { dx: 5, dy: 0 }, symmetric: false },
+          { x: 20, y: 10, handleIn: { dx: -5, dy: 0 }, handleOut: null, symmetric: false },
+        ],
+      },
+      {
+        shape: 'outline',
+        points: [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 5, y: 10 },
+        ],
+      },
+    ];
+    for (const profile of profiles) {
+      const node = {
+        id: `cut-${profile.shape}`,
+        type: 'cutter',
+        params: { profile, depth: 10, clearance: 0.2, chamfer: 0 },
+        transform: { x: 0, y: 0, seatZ: 0, rotZDeg: 0 },
+        children: [],
+      };
+      const result = assemblySchema.safeParse(structureWith([node]));
+      expect(result.success, `profile ${profile.shape} should validate`).toBe(true);
+    }
+  });
+
+  it('rejects out-of-range params', () => {
+    const cases: [string, Record<string, unknown>][] = [
+      ['fin lean past 45°', { type: 'fin', params: { ...defaultPartParams('fin'), leanDeg: 60 } }],
+      [
+        'tube wall below 0.8mm',
+        { type: 'tube', params: { ...defaultPartParams('tube'), wall: 0.2 } },
+      ],
+      ['array of one', { array: { count: 1, dx: 10, dy: 0 } }],
+      ['unknown part type', { type: 'sphere' }],
+      [
+        'triangle-beating polygon',
+        {
+          type: 'cutter',
+          params: {
+            profile: { shape: 'polygon', diameter: 8, sides: 2 },
+            depth: 10,
+            clearance: 0,
+            chamfer: 0,
+          },
+        },
+      ],
+    ];
+    for (const [label, extra] of cases) {
+      const result = assemblySchema.safeParse(structureWith([post('p1', extra)]));
+      expect(result.success, `${label} should be rejected`).toBe(false);
+    }
+  });
+
+  it('caps total part count', () => {
+    const parts = Array.from({ length: MAX_ASSEMBLY_PARTS + 1 }, (_, i) => post(`p${i}`));
+    expect(assemblySchema.safeParse(structureWith(parts)).success).toBe(false);
+    expect(
+      assemblySchema.safeParse(structureWith(parts.slice(0, MAX_ASSEMBLY_PARTS))).success
+    ).toBe(true);
+  });
+
+  it('caps stacking depth', () => {
+    const chain = (depth: number): Record<string, unknown> =>
+      post(`d${depth}`, depth > 1 ? { children: [chain(depth - 1)] } : {});
+    expect(assemblySchema.safeParse(structureWith([chain(MAX_ASSEMBLY_DEPTH)])).success).toBe(true);
+    expect(assemblySchema.safeParse(structureWith([chain(MAX_ASSEMBLY_DEPTH + 1)])).success).toBe(
+      false
+    );
+  });
+});
+
+describe('assembly migrate', () => {
+  const migrate = (raw: unknown): AssemblyStructure => assemblyDescriptor.migrate(raw, envelope);
+
+  it('falls back to defaults on garbage', () => {
+    for (const raw of [null, undefined, 42, 'rack', []]) {
+      expect(migrate(raw)).toEqual(DEFAULT_ASSEMBLY_STRUCTURE);
+    }
+  });
+
+  it('fills missing part params from defaults and generates missing ids', () => {
+    const migrated = migrate({
+      parts: [{ type: 'post', params: { diameter: 12 } }],
+    });
+    expect(migrated.parts).toHaveLength(1);
+    const node = migrated.parts[0] as Extract<AssemblyPartNode, { type: 'post' }>;
+    expect(node.type).toBe('post');
+    expect(node.params.diameter).toBe(12);
+    expect(node.params.height).toBe(defaultPartParams('post').height);
+    expect(node.id.length).toBeGreaterThan(0);
+    expect(node.transform).toEqual({ x: 0, y: 0, seatZ: 0, rotZDeg: 0 });
+  });
+
+  it('drops an unsalvageable node but keeps its valid siblings', () => {
+    const migrated = migrate(
+      structureWith([
+        post('good'),
+        { ...post('bad'), params: { ...defaultPartParams('post'), diameter: 9999 } },
+        post('also-good'),
+      ])
+    );
+    expect(migrated.parts.map((p) => p.id)).toEqual(['good', 'also-good']);
+  });
+
+  it('drops an invalid grandchild while keeping the parent chain', () => {
+    const migrated = migrate(
+      structureWith([
+        post('root', {
+          children: [
+            post('child', {
+              children: [{ ...post('grandchild'), type: 'nonsense' }],
+            }),
+          ],
+        }),
+      ])
+    );
+    expect(migrated.parts).toHaveLength(1);
+    expect(migrated.parts[0]?.children).toHaveLength(1);
+    expect(migrated.parts[0]?.children[0]?.children).toHaveLength(0);
+  });
+
+  it('strips an invalid array but keeps the node', () => {
+    const migrated = migrate(
+      structureWith([post('arrayed', { array: { count: 1, dx: 5, dy: 0 } })])
+    );
+    expect(migrated.parts).toHaveLength(1);
+    expect(migrated.parts[0]?.array).toBeUndefined();
+  });
+
+  it('resets an invalid base while keeping the parts', () => {
+    const migrated = migrate({
+      base: { floorThickness: 999 },
+      parts: [post('kept')],
+    });
+    expect(migrated.base).toEqual(DEFAULT_ASSEMBLY_STRUCTURE.base);
+    expect(migrated.parts.map((p) => p.id)).toEqual(['kept']);
+  });
+
+  it('forces kind and schemaVersion', () => {
+    const migrated = migrate({ kind: 'toolRack', schemaVersion: 99 });
+    expect(migrated.kind).toBe('assembly');
+    expect(migrated.schemaVersion).toBe(1);
+  });
+});
+
+describe('assembly descriptor', () => {
+  it('derives the export file name from the footprint', () => {
+    expect(assemblyDescriptor.exportFileName(envelope, assemblyDescriptor.defaults())).toBe(
+      'workshop_4x2'
+    );
+  });
+});

--- a/src/shared/items/assembly/descriptor.ts
+++ b/src/shared/items/assembly/descriptor.ts
@@ -277,32 +277,50 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 /**
- * Salvage one node: fill gaps from defaults, recurse into children, drop the
- * node only when its own values cannot be made valid. Keeping valid siblings
- * and subtrees is the point — one bad node must not cost a whole build.
+ * Salvage one node: fill gaps from defaults, validate each optional on its
+ * own, recurse into children, and drop the node only when its own values
+ * cannot be made valid. Keeping valid siblings and subtrees is the point —
+ * one bad node must not cost a whole build.
  */
 function normalizePartNode(raw: unknown): AssemblyPartNode | null {
   if (!isRecord(raw)) return null;
   if (!isAssemblyPartType(raw.type)) return null;
+  const array = arraySchema.safeParse(raw.array);
   const candidate = {
     id: typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : crypto.randomUUID(),
     type: raw.type,
     params: { ...defaultPartParams(raw.type), ...(isRecord(raw.params) ? raw.params : {}) },
     transform: { ...DEFAULT_PART_TRANSFORM, ...(isRecord(raw.transform) ? raw.transform : {}) },
-    ...(raw.array !== undefined ? { array: raw.array } : {}),
-    ...(raw.mirror !== undefined ? { mirror: raw.mirror } : {}),
+    ...(array.success ? { array: array.data } : {}),
+    ...(typeof raw.mirror === 'boolean' ? { mirror: raw.mirror } : {}),
     children: Array.isArray(raw.children)
       ? raw.children.map(normalizePartNode).filter((n): n is AssemblyPartNode => n !== null)
       : [],
   };
   const parsed = partNodeSchema.safeParse(candidate);
-  if (parsed.success) return parsed.data;
-  const withoutOptionals = partNodeSchema.safeParse({
-    ...candidate,
-    array: undefined,
-    mirror: undefined,
-  });
-  return withoutOptionals.success ? withoutOptionals.data : null;
+  return parsed.success ? parsed.data : null;
+}
+
+/**
+ * Trim an over-cap build instead of losing it: keep the first
+ * `MAX_ASSEMBLY_PARTS` nodes in tree order and drop children below
+ * `MAX_ASSEMBLY_DEPTH`, so the final parse cannot fail on the caps.
+ */
+function capParts(parts: AssemblyPartNode[]): AssemblyPartNode[] {
+  let budget = MAX_ASSEMBLY_PARTS;
+  const prune = (nodes: AssemblyPartNode[], depth: number): AssemblyPartNode[] => {
+    const kept: AssemblyPartNode[] = [];
+    for (const node of nodes) {
+      if (budget === 0) break;
+      budget -= 1;
+      kept.push({
+        ...node,
+        children: depth < MAX_ASSEMBLY_DEPTH ? prune(node.children, depth + 1) : [],
+      });
+    }
+    return kept;
+  };
+  return prune(parts, 1);
 }
 
 function assemblyDefaults(): AssemblyStructure {
@@ -323,9 +341,11 @@ function migrateAssembly(raw: unknown): AssemblyStructure {
       ...(isRecord(obj.base) ? obj.base : {}),
     },
     mirrorAxis: obj.mirrorAxis === 'y' ? ('y' as const) : ('x' as const),
-    parts: Array.isArray(obj.parts)
-      ? obj.parts.map(normalizePartNode).filter((n): n is AssemblyPartNode => n !== null)
-      : [],
+    parts: capParts(
+      Array.isArray(obj.parts)
+        ? obj.parts.map(normalizePartNode).filter((n): n is AssemblyPartNode => n !== null)
+        : []
+    ),
   };
   const parsed = assemblySchema.safeParse(candidate);
   if (parsed.success) return parsed.data;

--- a/src/shared/items/assembly/descriptor.ts
+++ b/src/shared/items/assembly/descriptor.ts
@@ -1,0 +1,347 @@
+/**
+ * Workshop assembly — descriptor (schema/defaults/migration/labels), the
+ * worker- and UI-safe half of this item kind. No React, no OCCT.
+ */
+import { z } from 'zod';
+import type { ItemTypeDescriptor } from '@/shared/items/registry';
+import type { ItemEnvelope } from '@/shared/types/item';
+import type {
+  AssemblyPartNode,
+  AssemblyPartParamsByType,
+  AssemblyPartType,
+  AssemblyStructure,
+  PartTransform,
+} from '@/shared/types/assembly';
+import { ASSEMBLY_PART_TYPES } from '@/shared/types/assembly';
+
+/** Hard ceiling on total nodes; the printability checker advises far below it. */
+export const MAX_ASSEMBLY_PARTS = 256;
+
+export const MAX_ASSEMBLY_DEPTH = 8;
+
+const transformSchema = z.object({
+  x: z.number().min(-1000).max(1000),
+  y: z.number().min(-1000).max(1000),
+  seatZ: z.number().min(-200).max(200),
+  rotZDeg: z.number().min(-360).max(360),
+});
+
+const arraySchema = z.object({
+  count: z.number().int().min(2).max(64),
+  dx: z.number().min(-500).max(500),
+  dy: z.number().min(-500).max(500),
+});
+
+const postParamsSchema = z.object({
+  diameter: z.number().min(2).max(60),
+  height: z.number().min(4).max(200),
+  taperDeg: z.number().min(0).max(15),
+  tipChamfer: z.number().min(0).max(5),
+});
+
+const finParamsSchema = z.object({
+  length: z.number().min(4).max(400),
+  thickness: z.number().min(0.8).max(20),
+  height: z.number().min(4).max(200),
+  leanDeg: z.number().min(0).max(45),
+});
+
+const blockParamsSchema = z.object({
+  width: z.number().min(2).max(400),
+  depth: z.number().min(2).max(400),
+  height: z.number().min(1).max(200),
+  wedgeAngleDeg: z.number().min(0).max(60),
+});
+
+const tubeParamsSchema = z.object({
+  boreDiameter: z.number().min(2).max(80),
+  wall: z.number().min(0.8).max(10),
+  height: z.number().min(4).max(200),
+  tiltDeg: z.number().min(0).max(30),
+});
+
+const cradleParamsSchema = z.object({
+  length: z.number().min(4).max(400),
+  width: z.number().min(4).max(100),
+  height: z.number().min(4).max(100),
+  grooveStyle: z.enum(['round', 'vee']),
+  grooveWidth: z.number().min(2).max(80),
+  grooveDepth: z.number().min(1).max(60),
+});
+
+const hookParamsSchema = z.object({
+  stemHeight: z.number().min(4).max(200),
+  reach: z.number().min(4).max(100),
+  lipHeight: z.number().min(0).max(60),
+  thickness: z.number().min(0.8).max(20),
+  width: z.number().min(2).max(100),
+});
+
+const archParamsSchema = z.object({
+  span: z.number().min(8).max(400),
+  height: z.number().min(8).max(200),
+  style: z.enum(['rod', 'bridge']),
+  rodDiameter: z.number().min(2).max(40),
+  bridgeWidth: z.number().min(2).max(60),
+  uprightThickness: z.number().min(2).max(30),
+  depth: z.number().min(4).max(60),
+});
+
+const pathPointSchema = z.object({
+  x: z.number().min(-2000).max(2000),
+  y: z.number().min(-2000).max(2000),
+  handleIn: z
+    .object({ dx: z.number().min(-2000).max(2000), dy: z.number().min(-2000).max(2000) })
+    .nullable(),
+  handleOut: z
+    .object({ dx: z.number().min(-2000).max(2000), dy: z.number().min(-2000).max(2000) })
+    .nullable(),
+  symmetric: z.boolean(),
+});
+
+const cutterProfileSchema = z.discriminatedUnion('shape', [
+  z.object({ shape: z.literal('circle'), diameter: z.number().min(0.5).max(200) }),
+  z.object({
+    shape: z.literal('rectangle'),
+    width: z.number().min(0.5).max(400),
+    depth: z.number().min(0.5).max(400),
+    cornerRadius: z.number().min(0).max(50),
+  }),
+  z.object({
+    shape: z.literal('polygon'),
+    diameter: z.number().min(0.5).max(200),
+    sides: z.number().int().min(3).max(12),
+  }),
+  z.object({
+    shape: z.literal('slot'),
+    length: z.number().min(1).max(400),
+    width: z.number().min(0.5).max(200),
+  }),
+  z.object({ shape: z.literal('path'), points: z.array(pathPointSchema).min(2).max(2000) }),
+  z.object({
+    shape: z.literal('outline'),
+    points: z
+      .array(z.object({ x: z.number().min(-2000).max(2000), y: z.number().min(-2000).max(2000) }))
+      .min(3)
+      .max(5000),
+  }),
+]);
+
+const cutterParamsSchema = z.object({
+  profile: cutterProfileSchema,
+  depth: z.number().min(0.5).max(200),
+  clearance: z.number().min(0).max(5),
+  chamfer: z.number().min(0).max(5),
+});
+
+const nodeBase = {
+  id: z.string().min(1).max(64),
+  transform: transformSchema,
+  array: arraySchema.optional(),
+  mirror: z.boolean().optional(),
+};
+
+const partNodeSchema: z.ZodType<AssemblyPartNode> = z.lazy(() =>
+  z.discriminatedUnion('type', [
+    z.object({
+      ...nodeBase,
+      type: z.literal('post'),
+      params: postParamsSchema,
+      children: childrenSchema,
+    }),
+    z.object({
+      ...nodeBase,
+      type: z.literal('fin'),
+      params: finParamsSchema,
+      children: childrenSchema,
+    }),
+    z.object({
+      ...nodeBase,
+      type: z.literal('block'),
+      params: blockParamsSchema,
+      children: childrenSchema,
+    }),
+    z.object({
+      ...nodeBase,
+      type: z.literal('tube'),
+      params: tubeParamsSchema,
+      children: childrenSchema,
+    }),
+    z.object({
+      ...nodeBase,
+      type: z.literal('cradle'),
+      params: cradleParamsSchema,
+      children: childrenSchema,
+    }),
+    z.object({
+      ...nodeBase,
+      type: z.literal('hook'),
+      params: hookParamsSchema,
+      children: childrenSchema,
+    }),
+    z.object({
+      ...nodeBase,
+      type: z.literal('arch'),
+      params: archParamsSchema,
+      children: childrenSchema,
+    }),
+    z.object({
+      ...nodeBase,
+      type: z.literal('cutter'),
+      params: cutterParamsSchema,
+      children: childrenSchema,
+    }),
+  ])
+);
+
+const childrenSchema = z.lazy(() => z.array(partNodeSchema));
+
+function countNodes(nodes: readonly AssemblyPartNode[]): number {
+  return nodes.reduce((sum, n) => sum + 1 + countNodes(n.children), 0);
+}
+
+function treeDepth(nodes: readonly AssemblyPartNode[]): number {
+  return nodes.length === 0 ? 0 : 1 + Math.max(...nodes.map((n) => treeDepth(n.children)));
+}
+
+const baseSchema = z.object({
+  floorThickness: z.number().min(1).max(10),
+  cornerRadius: z.number().min(0).max(20).optional(),
+});
+
+export const assemblySchema: z.ZodType<AssemblyStructure> = z
+  .object({
+    kind: z.literal('assembly'),
+    schemaVersion: z.literal(1),
+    base: baseSchema,
+    mirrorAxis: z.enum(['x', 'y']),
+    parts: z.array(partNodeSchema),
+  })
+  .refine((s) => countNodes(s.parts) <= MAX_ASSEMBLY_PARTS, {
+    message: `an assembly holds at most ${MAX_ASSEMBLY_PARTS} parts`,
+  })
+  .refine((s) => treeDepth(s.parts) <= MAX_ASSEMBLY_DEPTH, {
+    message: `parts stack at most ${MAX_ASSEMBLY_DEPTH} deep`,
+  });
+
+export const DEFAULT_ASSEMBLY_STRUCTURE: AssemblyStructure = {
+  kind: 'assembly',
+  schemaVersion: 1,
+  base: { floorThickness: 2 },
+  mirrorAxis: 'x',
+  parts: [],
+};
+
+export const DEFAULT_PART_PARAMS: {
+  readonly [K in AssemblyPartType]: AssemblyPartParamsByType[K];
+} = {
+  post: { diameter: 8, height: 40, taperDeg: 0, tipChamfer: 1 },
+  fin: { length: 60, thickness: 3, height: 25, leanDeg: 20 },
+  block: { width: 40, depth: 20, height: 20, wedgeAngleDeg: 0 },
+  tube: { boreDiameter: 16, wall: 2, height: 60, tiltDeg: 0 },
+  cradle: {
+    length: 30,
+    width: 20,
+    height: 15,
+    grooveStyle: 'round',
+    grooveWidth: 12,
+    grooveDepth: 6,
+  },
+  hook: { stemHeight: 30, reach: 20, lipHeight: 8, thickness: 4, width: 15 },
+  arch: {
+    span: 60,
+    height: 50,
+    style: 'rod',
+    rodDiameter: 8,
+    bridgeWidth: 10,
+    uprightThickness: 6,
+    depth: 15,
+  },
+  cutter: { profile: { shape: 'circle', diameter: 6.5 }, depth: 20, clearance: 0.2, chamfer: 0.6 },
+};
+
+export const DEFAULT_PART_TRANSFORM: PartTransform = { x: 0, y: 0, seatZ: 0, rotZDeg: 0 };
+
+export function defaultPartParams<K extends AssemblyPartType>(
+  type: K
+): AssemblyPartParamsByType[K] {
+  return structuredClone(DEFAULT_PART_PARAMS[type]);
+}
+
+function isAssemblyPartType(v: unknown): v is AssemblyPartType {
+  return typeof v === 'string' && (ASSEMBLY_PART_TYPES as readonly string[]).includes(v);
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Salvage one node: fill gaps from defaults, recurse into children, drop the
+ * node only when its own values cannot be made valid. Keeping valid siblings
+ * and subtrees is the point — one bad node must not cost a whole build.
+ */
+function normalizePartNode(raw: unknown): AssemblyPartNode | null {
+  if (!isRecord(raw)) return null;
+  if (!isAssemblyPartType(raw.type)) return null;
+  const candidate = {
+    id: typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : crypto.randomUUID(),
+    type: raw.type,
+    params: { ...defaultPartParams(raw.type), ...(isRecord(raw.params) ? raw.params : {}) },
+    transform: { ...DEFAULT_PART_TRANSFORM, ...(isRecord(raw.transform) ? raw.transform : {}) },
+    ...(raw.array !== undefined ? { array: raw.array } : {}),
+    ...(raw.mirror !== undefined ? { mirror: raw.mirror } : {}),
+    children: Array.isArray(raw.children)
+      ? raw.children.map(normalizePartNode).filter((n): n is AssemblyPartNode => n !== null)
+      : [],
+  };
+  const parsed = partNodeSchema.safeParse(candidate);
+  if (parsed.success) return parsed.data;
+  const withoutOptionals = partNodeSchema.safeParse({
+    ...candidate,
+    array: undefined,
+    mirror: undefined,
+  });
+  return withoutOptionals.success ? withoutOptionals.data : null;
+}
+
+function assemblyDefaults(): AssemblyStructure {
+  return {
+    ...DEFAULT_ASSEMBLY_STRUCTURE,
+    base: { ...DEFAULT_ASSEMBLY_STRUCTURE.base },
+    parts: [],
+  };
+}
+
+function migrateAssembly(raw: unknown): AssemblyStructure {
+  const obj = isRecord(raw) ? raw : {};
+  const candidate = {
+    kind: 'assembly' as const,
+    schemaVersion: 1 as const,
+    base: {
+      ...DEFAULT_ASSEMBLY_STRUCTURE.base,
+      ...(isRecord(obj.base) ? obj.base : {}),
+    },
+    mirrorAxis: obj.mirrorAxis === 'y' ? ('y' as const) : ('x' as const),
+    parts: Array.isArray(obj.parts)
+      ? obj.parts.map(normalizePartNode).filter((n): n is AssemblyPartNode => n !== null)
+      : [],
+  };
+  const parsed = assemblySchema.safeParse(candidate);
+  if (parsed.success) return parsed.data;
+  const defaultBase = assemblySchema.safeParse({
+    ...candidate,
+    base: { ...DEFAULT_ASSEMBLY_STRUCTURE.base },
+  });
+  return defaultBase.success ? defaultBase.data : assemblyDefaults();
+}
+
+export const assemblyDescriptor: ItemTypeDescriptor<AssemblyStructure> = {
+  kind: 'assembly',
+  schema: assemblySchema,
+  defaults: assemblyDefaults,
+  migrate: (raw: unknown, _envelope: ItemEnvelope) => migrateAssembly(raw),
+  labelKey: 'binDesigner.itemKind.assembly',
+  descriptionKey: 'binDesigner.itemKind.assembly.description',
+  exportFileName: (envelope) => `workshop_${envelope.width}x${envelope.depth}`,
+};

--- a/src/shared/items/assembly/descriptor.ts
+++ b/src/shared/items/assembly/descriptor.ts
@@ -194,7 +194,7 @@ const partNodeSchema: z.ZodType<AssemblyPartNode> = z.lazy(() =>
   ])
 );
 
-const childrenSchema = z.lazy(() => z.array(partNodeSchema));
+const childrenSchema = z.lazy(() => z.array(partNodeSchema).max(MAX_ASSEMBLY_PARTS));
 
 function countNodes(nodes: readonly AssemblyPartNode[]): number {
   return nodes.reduce((sum, n) => sum + 1 + countNodes(n.children), 0);
@@ -215,7 +215,7 @@ export const assemblySchema: z.ZodType<AssemblyStructure> = z
     schemaVersion: z.literal(1),
     base: baseSchema,
     mirrorAxis: z.enum(['x', 'y']),
-    parts: z.array(partNodeSchema),
+    parts: z.array(partNodeSchema).max(MAX_ASSEMBLY_PARTS),
   })
   .refine((s) => countNodes(s.parts) <= MAX_ASSEMBLY_PARTS, {
     message: `an assembly holds at most ${MAX_ASSEMBLY_PARTS} parts`,
@@ -282,7 +282,8 @@ function isRecord(v: unknown): v is Record<string, unknown> {
  * cannot be made valid. Keeping valid siblings and subtrees is the point —
  * one bad node must not cost a whole build.
  */
-function normalizePartNode(raw: unknown): AssemblyPartNode | null {
+function normalizePartNode(raw: unknown, depth: number): AssemblyPartNode | null {
+  if (depth > MAX_ASSEMBLY_DEPTH) return null;
   if (!isRecord(raw)) return null;
   if (!isAssemblyPartType(raw.type)) return null;
   const array = arraySchema.safeParse(raw.array);
@@ -294,7 +295,10 @@ function normalizePartNode(raw: unknown): AssemblyPartNode | null {
     ...(array.success ? { array: array.data } : {}),
     ...(typeof raw.mirror === 'boolean' ? { mirror: raw.mirror } : {}),
     children: Array.isArray(raw.children)
-      ? raw.children.map(normalizePartNode).filter((n): n is AssemblyPartNode => n !== null)
+      ? raw.children
+          .slice(0, MAX_ASSEMBLY_PARTS)
+          .map((child) => normalizePartNode(child, depth + 1))
+          .filter((n): n is AssemblyPartNode => n !== null)
       : [],
   };
   const parsed = partNodeSchema.safeParse(candidate);
@@ -343,7 +347,10 @@ function migrateAssembly(raw: unknown): AssemblyStructure {
     mirrorAxis: obj.mirrorAxis === 'y' ? ('y' as const) : ('x' as const),
     parts: capParts(
       Array.isArray(obj.parts)
-        ? obj.parts.map(normalizePartNode).filter((n): n is AssemblyPartNode => n !== null)
+        ? obj.parts
+            .slice(0, MAX_ASSEMBLY_PARTS)
+            .map((part) => normalizePartNode(part, 1))
+            .filter((n): n is AssemblyPartNode => n !== null)
         : []
     ),
   };

--- a/src/shared/items/registerDescriptors.ts
+++ b/src/shared/items/registerDescriptors.ts
@@ -4,6 +4,7 @@
  * picker). Importing it has the side effect of populating the descriptor
  * registry — keep it free of React and OCCT.
  */
+import { assemblyDescriptor } from '@/shared/items/assembly/descriptor';
 import { binDescriptor } from '@/shared/items/bin/descriptor';
 import { importedMeshDescriptor } from '@/shared/items/importedMesh/descriptor';
 import { registerItemDescriptor } from '@/shared/items/registry';
@@ -17,6 +18,7 @@ export function registerItemDescriptors(): void {
   registerItemDescriptor(binDescriptor);
   registerItemDescriptor(toolRackDescriptor);
   registerItemDescriptor(importedMeshDescriptor);
+  registerItemDescriptor(assemblyDescriptor);
 }
 
 registerItemDescriptors();

--- a/src/shared/items/registry.test.ts
+++ b/src/shared/items/registry.test.ts
@@ -31,15 +31,16 @@ const envelope: ItemEnvelope = {
 };
 
 describe('item descriptor registry', () => {
-  it('registers bin, toolRack, and importedMesh', () => {
+  it('registers bin, toolRack, importedMesh, and assembly', () => {
     expect(hasItemDescriptor('bin')).toBe(true);
     expect(hasItemDescriptor('toolRack')).toBe(true);
     expect(hasItemDescriptor('importedMesh')).toBe(true);
+    expect(hasItemDescriptor('assembly')).toBe(true);
     expect(
       listItemDescriptors()
         .map((d) => d.kind)
         .sort()
-    ).toEqual(['bin', 'importedMesh', 'toolRack']);
+    ).toEqual(['assembly', 'bin', 'importedMesh', 'toolRack']);
   });
 
   it('throws on an unregistered kind', () => {

--- a/src/shared/types/assembly.ts
+++ b/src/shared/types/assembly.ts
@@ -1,0 +1,211 @@
+/**
+ * Workshop assembly — a part-based item built on a base-only Gridfinity
+ * footprint (socket + floor plate, no walls).
+ *
+ * The structure is an attachment tree: a child's transform is expressed in
+ * its parent's frame, and `seatZ` is measured from the parent's SEAT PLANE
+ * (top face), not the floor — so resizing a parent carries its subtree in
+ * all three axes without transform rewrites. Roots seat on the base floor.
+ *
+ * `array` and `mirror` are properties of a node, never cloned nodes; the
+ * generator and proxy scene expand them at evaluation time, which is what
+ * keeps "edit one, the whole row updates" true.
+ */
+import type { PathPoint } from '@/shared/types/bin';
+
+export const ASSEMBLY_PART_TYPES = [
+  'post',
+  'fin',
+  'block',
+  'tube',
+  'cradle',
+  'hook',
+  'arch',
+  'cutter',
+] as const;
+
+export type AssemblyPartType = (typeof ASSEMBLY_PART_TYPES)[number];
+
+export interface PartTransform {
+  /** X offset in mm, in the parent's frame. */
+  readonly x: number;
+  /** Y offset in mm, in the parent's frame. */
+  readonly y: number;
+  /** Height in mm above the parent's seat plane. Negative sinks a cutter. */
+  readonly seatZ: number;
+  /** Rotation around vertical in degrees. */
+  readonly rotZDeg: number;
+}
+
+/** Linear repetition of a node and its whole subtree. */
+export interface PartArray {
+  readonly count: number;
+  /** X step between copies in mm. */
+  readonly dx: number;
+  /** Y step between copies in mm. */
+  readonly dy: number;
+}
+
+export interface PostParams {
+  readonly diameter: number;
+  readonly height: number;
+  /** Sides lean inward this many degrees; 0 is a straight cylinder. */
+  readonly taperDeg: number;
+  readonly tipChamfer: number;
+}
+
+export interface FinParams {
+  readonly length: number;
+  readonly thickness: number;
+  readonly height: number;
+  /** Lean back from vertical in degrees (0..45 for printability). */
+  readonly leanDeg: number;
+}
+
+export interface BlockParams {
+  readonly width: number;
+  readonly depth: number;
+  readonly height: number;
+  /** Slopes the top face; 0 is flat. `height` is the tall edge. */
+  readonly wedgeAngleDeg: number;
+}
+
+export interface TubeParams {
+  readonly boreDiameter: number;
+  readonly wall: number;
+  readonly height: number;
+  readonly tiltDeg: number;
+}
+
+export interface CradleParams {
+  /** Extent along the groove axis in mm. */
+  readonly length: number;
+  readonly width: number;
+  readonly height: number;
+  readonly grooveStyle: 'round' | 'vee';
+  readonly grooveWidth: number;
+  readonly grooveDepth: number;
+}
+
+export interface HookParams {
+  readonly stemHeight: number;
+  /** Horizontal run of the J in mm. */
+  readonly reach: number;
+  /** Upturned tip; 0 leaves a plain L. */
+  readonly lipHeight: number;
+  readonly thickness: number;
+  readonly width: number;
+}
+
+export interface ArchParams {
+  /** Clear distance between the uprights in mm. */
+  readonly span: number;
+  readonly height: number;
+  readonly style: 'rod' | 'bridge';
+  readonly rodDiameter: number;
+  readonly bridgeWidth: number;
+  readonly uprightThickness: number;
+  readonly depth: number;
+}
+
+/**
+ * 2D profile a cutter sweeps downward. Deliberately the cutout editor's
+ * vocabulary — a scanned tool outline or library cutout drops in as-is.
+ */
+export type CutterProfile =
+  | { readonly shape: 'circle'; readonly diameter: number }
+  | {
+      readonly shape: 'rectangle';
+      readonly width: number;
+      readonly depth: number;
+      readonly cornerRadius: number;
+    }
+  | { readonly shape: 'polygon'; readonly diameter: number; readonly sides: number }
+  | { readonly shape: 'slot'; readonly length: number; readonly width: number }
+  | { readonly shape: 'path'; readonly points: PathPoint[] }
+  | {
+      readonly shape: 'outline';
+      readonly points: { readonly x: number; readonly y: number }[];
+    };
+
+export interface CutterParams {
+  readonly profile: CutterProfile;
+  /** Cut depth in mm, measured down from the cutter's seat. */
+  readonly depth: number;
+  readonly clearance: number;
+  readonly chamfer: number;
+}
+
+interface PartNodeBase {
+  readonly id: string;
+  readonly transform: PartTransform;
+  readonly array?: PartArray;
+  /** Also emit this subtree reflected across the assembly's mirror axis. */
+  readonly mirror?: boolean;
+  /** Parts seated on this part's top face. */
+  readonly children: AssemblyPartNode[];
+}
+
+export interface PostNode extends PartNodeBase {
+  readonly type: 'post';
+  readonly params: PostParams;
+}
+export interface FinNode extends PartNodeBase {
+  readonly type: 'fin';
+  readonly params: FinParams;
+}
+export interface BlockNode extends PartNodeBase {
+  readonly type: 'block';
+  readonly params: BlockParams;
+}
+export interface TubeNode extends PartNodeBase {
+  readonly type: 'tube';
+  readonly params: TubeParams;
+}
+export interface CradleNode extends PartNodeBase {
+  readonly type: 'cradle';
+  readonly params: CradleParams;
+}
+export interface HookNode extends PartNodeBase {
+  readonly type: 'hook';
+  readonly params: HookParams;
+}
+export interface ArchNode extends PartNodeBase {
+  readonly type: 'arch';
+  readonly params: ArchParams;
+}
+export interface CutterNode extends PartNodeBase {
+  readonly type: 'cutter';
+  readonly params: CutterParams;
+}
+
+export type AssemblyPartNode =
+  PostNode | FinNode | BlockNode | TubeNode | CradleNode | HookNode | ArchNode | CutterNode;
+
+export type AssemblyPartParams = AssemblyPartNode['params'];
+
+export interface AssemblyPartParamsByType {
+  readonly post: PostParams;
+  readonly fin: FinParams;
+  readonly block: BlockParams;
+  readonly tube: TubeParams;
+  readonly cradle: CradleParams;
+  readonly hook: HookParams;
+  readonly arch: ArchParams;
+  readonly cutter: CutterParams;
+}
+
+export interface AssemblyBase {
+  /** Floor plate thickness in mm above the socket. */
+  readonly floorThickness: number;
+  readonly cornerRadius?: number;
+}
+
+export interface AssemblyStructure {
+  readonly kind: 'assembly';
+  readonly schemaVersion: 1;
+  readonly base: AssemblyBase;
+  readonly mirrorAxis: 'x' | 'y';
+  /** Root parts, seated on the base floor. */
+  readonly parts: AssemblyPartNode[];
+}

--- a/src/shared/types/item.ts
+++ b/src/shared/types/item.ts
@@ -9,10 +9,11 @@
  * NOTE: `GridfinityItem` / `ItemKind` are DESIGNER-scoped. The layout domain's
  * placeable unit remains `Bin` — do not reuse `ItemKind` for layout entities.
  */
+import type { AssemblyStructure } from '@/shared/types/assembly';
 import type { BinParams, FeatureColorConfig } from '@/shared/types/bin';
 import type { MeshAsset } from '@/shared/generation/meshAsset';
 
-export type ItemKind = 'bin' | 'toolRack' | 'importedMesh';
+export type ItemKind = 'bin' | 'toolRack' | 'importedMesh' | 'assembly';
 
 /**
  * The baseplate-mating subset shared by every kind. For bins this is a
@@ -97,7 +98,8 @@ export interface ImportedMeshStructure {
   readonly sourceFileName?: string;
 }
 
-export type ItemStructure = BinStructure | ToolRackStructure | ImportedMeshStructure;
+export type ItemStructure =
+  BinStructure | ToolRackStructure | ImportedMeshStructure | AssemblyStructure;
 
 export interface GridfinityItem {
   readonly envelope: ItemEnvelope;


### PR DESCRIPTION
Adds the `assembly` item kind, the schema foundation for Workshop, a part-based builder for tool holders on a base-only Gridfinity footprint (socket plus floor plate, no walls). First PR of the phased plan; no UI yet.

## What's in

- `AssemblyStructure`: an attachment tree of typed part nodes (post, fin, block, tube, cradle, hook, arch, cutter). A child's transform is expressed in its parent's frame and `seatZ` is measured from the parent's top face, so resizing a parent carries its whole subtree.
- Linear `array` and `mirror` are properties of a node expanded at evaluation time, never cloned nodes, which keeps "edit one, the whole row updates" true by construction.
- Cutter profiles reuse the cutout editor's vocabulary (circle, rectangle, polygon, slot, bezier path, scanned outline), so a scanned tool can later be carved into a Workshop part with no new geometry format.
- Zod schema with printability clamps per part type, plus hard caps: 256 nodes total, 8 levels deep.
- Salvage-oriented migration: fills gaps from per-type defaults, drops an invalid node but keeps its valid siblings and subtrees, resets an invalid base without losing parts, and falls back to defaults only for garbage input.
- `workshop` labs flag, experimental and `comingSoon` (unclickable) until the editor ships in a later PR.
- Kind label and description i18n keys in all 15 locales.

## Deliberately out (later PRs)

Workspace UI, worker generator, cloud sync payload and the server validation mirror, tool rack migration.

## Tests

Schema round-trip of a nested build, per-type default validity, every cutter profile shape, clamp rejections, node and depth caps, and the migration salvage cases.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

