### PR TITLE
feat(workshop): sharpen swap and hologram scan-in

### DIFF
--- a/src/features/bin-designer/components/Workshop/BasePlateMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/BasePlateMesh.tsx
@@ -16,6 +16,8 @@ import type { HoverSurface } from './useWorkshopInteraction';
 interface BasePlateMeshProps {
   envelope: ItemEnvelope;
   base: AssemblyBase;
+  /** Sharp worker mesh is on screen — render nothing, keep raycast alive. */
+  hidden?: boolean;
   onSurfaceMove: (surface: HoverSurface) => void;
   onSurfaceLeave: () => void;
   onSurfaceClick: (surface: HoverSurface) => void;
@@ -24,6 +26,7 @@ interface BasePlateMeshProps {
 export function BasePlateMesh({
   envelope,
   base,
+  hidden = false,
   onSurfaceMove,
   onSurfaceLeave,
   onSurfaceClick,
@@ -73,7 +76,12 @@ export function BasePlateMesh({
         onSurfaceClick(toSurface(e));
       }}
     >
-      <meshStandardMaterial color={colors.workshopBase} roughness={0.85} metalness={0.05} />
+      <meshStandardMaterial
+        visible={!hidden}
+        color={colors.workshopBase}
+        roughness={0.85}
+        metalness={0.05}
+      />
     </mesh>
   );
 }

--- a/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
@@ -1,7 +1,19 @@
-/** One placed part instance rendered as its client-side proxy geometry. */
-import { useEffect, useMemo } from 'react';
+/**
+ * One placed part instance rendered as its client-side proxy geometry.
+ *
+ * While the sharp worker mesh is displayed the proxy hides itself but stays
+ * in the scene as the raycast target for selection and drag. A newly placed
+ * part materializes with a hologram scan-in: a world-space clipping plane
+ * sweeps up its height under a cyan emissive glow that settles to solid.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import { Plane, Vector3 } from 'three';
+import type { MeshStandardMaterial } from 'three';
+import { useFrame, useThree } from '@react-three/fiber';
 import type { ThreeEvent } from '@react-three/fiber';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';
+import { usePrefersReducedMotion } from '@/shared/hooks/usePrefersReducedMotion';
+import { partSeatHeight } from '@/shared/types/assemblyPlacement';
 import { buildPartGeometry } from './proxyGeometry';
 import { sceneToStore, storeToScene, type PlacedPart } from './workshopPlacement';
 import type { HoverSurface } from './useWorkshopInteraction';
@@ -12,6 +24,11 @@ interface PartProxyMeshProps {
   baseD: number;
   selected: boolean;
   raycastDisabled: boolean;
+  /** Sharp worker mesh is on screen — render nothing, keep raycast alive. */
+  hidden: boolean;
+  /** performance.now() at placement, when this instance should scan in. */
+  hologramStart: number | null;
+  onHologramEnd: (id: string) => void;
   onSurfaceMove: (surface: HoverSurface) => void;
   onSurfaceLeave: () => void;
   onSurfaceClick: (surface: HoverSurface) => void;
@@ -19,6 +36,8 @@ interface PartProxyMeshProps {
 }
 
 const DEG = Math.PI / 180;
+const SCAN_MS = 400;
+const FADE_MS = 150;
 const NO_RAYCAST = (): null => null;
 
 export function PartProxyMesh({
@@ -27,15 +46,77 @@ export function PartProxyMesh({
   baseD,
   selected,
   raycastDisabled,
+  hidden,
+  hologramStart,
+  onHologramEnd,
   onSurfaceMove,
   onSurfaceLeave,
   onSurfaceClick,
   onPartPointerDown,
 }: PartProxyMeshProps) {
   const colors = useThreeColors();
+  const reducedMotion = usePrefersReducedMotion();
+  const invalidate = useThree((s) => s.invalidate);
   const { node } = placed;
   const geometry = useMemo(() => buildPartGeometry(node), [node]);
   useEffect(() => () => geometry.dispose(), [geometry]);
+
+  const materialRef = useRef<MeshStandardMaterial>(null);
+  const clipPlaneRef = useRef<Plane | null>(null);
+  const animating = hologramStart !== null;
+
+  const sweep = useMemo(() => {
+    const height = partSeatHeight(node);
+    const isCutter = node.type === 'cutter';
+    return {
+      from: isCutter && node.type === 'cutter' ? placed.z - node.params.depth : placed.z,
+      to: isCutter ? placed.z + 0.5 : placed.z + Math.max(height, 1),
+    };
+  }, [node, placed.z]);
+
+  // The scan is driven imperatively: render never touches the clipping
+  // plane, so the material swap at completion can't cascade renders.
+  useEffect(() => {
+    if (hologramStart === null) return;
+    const material = materialRef.current;
+    if (!material) return;
+    if (reducedMotion) {
+      material.transparent = true;
+      material.opacity = 0;
+    } else {
+      clipPlaneRef.current ??= new Plane(new Vector3(0, 0, -1), 0);
+      clipPlaneRef.current.constant = sweep.from;
+      material.clippingPlanes = [clipPlaneRef.current];
+    }
+    invalidate();
+    return () => {
+      material.clippingPlanes = null;
+    };
+  }, [hologramStart, reducedMotion, sweep, invalidate]);
+
+  useFrame(() => {
+    const material = materialRef.current;
+    if (!material || hologramStart === null) return;
+    const cutter = node.type === 'cutter';
+    const elapsed = performance.now() - hologramStart;
+    const duration = reducedMotion ? FADE_MS : SCAN_MS;
+    const t = Math.min(elapsed / duration, 1);
+    if (reducedMotion) {
+      material.opacity = t * (cutter ? 0.45 : 1);
+    } else {
+      const plane = clipPlaneRef.current;
+      if (plane) plane.constant = sweep.from + (sweep.to - sweep.from) * t;
+      material.emissiveIntensity = 0.9 * (1 - t) + 0.1;
+    }
+    if (t >= 1) {
+      material.clippingPlanes = null;
+      material.emissiveIntensity = selected ? 0.25 : 0;
+      material.transparent = cutter;
+      material.opacity = cutter ? 0.45 : 1;
+      onHologramEnd(placed.selectId);
+    }
+    invalidate();
+  });
 
   const isCutter = node.type === 'cutter';
   const color = selected
@@ -43,6 +124,7 @@ export function PartProxyMesh({
     : isCutter
       ? colors.workshopGhost
       : colors.workshopPart;
+  const showSolid = !hidden || selected || animating;
 
   const toSurface = (e: ThreeEvent<PointerEvent | MouseEvent>): HoverSurface => ({
     parentId: placed.selectId,
@@ -56,7 +138,7 @@ export function PartProxyMesh({
       geometry={geometry}
       position={[storeToScene(placed.x, baseW), storeToScene(placed.y, baseD), placed.z]}
       rotation={[0, 0, placed.rotZDeg * DEG]}
-      raycast={raycastDisabled ? NO_RAYCAST : undefined}
+      {...(raycastDisabled ? { raycast: NO_RAYCAST } : {})}
       onPointerMove={(e) => {
         e.stopPropagation();
         onSurfaceMove(toSurface(e));
@@ -73,13 +155,18 @@ export function PartProxyMesh({
       }}
     >
       <meshStandardMaterial
+        ref={materialRef}
+        visible={showSolid}
         color={color}
         roughness={0.6}
         metalness={0.1}
-        transparent={isCutter}
-        opacity={isCutter ? 0.45 : 1}
-        emissive={selected ? colors.workshopPartSelected : '#000000'}
-        emissiveIntensity={selected ? 0.25 : 0}
+        transparent={isCutter || (hidden && selected)}
+        opacity={hidden && selected ? 0.4 : isCutter ? 0.45 : 1}
+        polygonOffset={hidden && selected}
+        polygonOffsetFactor={-2}
+        polygonOffsetUnits={-2}
+        emissive={animating ? colors.workshopGhost : colors.workshopPartSelected}
+        emissiveIntensity={animating ? 0.9 : selected ? 0.25 : 0}
       />
     </mesh>
   );

--- a/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
@@ -23,7 +23,7 @@ export function WorkshopCanvas() {
   return (
     <div className="relative h-full w-full" translate="no" data-testid="workshop-canvas">
       <WebGLErrorBoundary component="designer">
-        <Canvas frameloop="demand" gl={{ antialias: true }}>
+        <Canvas frameloop="demand" gl={{ antialias: true, localClippingEnabled: true }}>
           <WorkshopScene structure={structure} envelope={envelope} />
         </Canvas>
       </WebGLErrorBoundary>

--- a/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
@@ -6,9 +6,13 @@ import { SceneLighting } from '@/features/bin-designer/components/PreviewCanvas/
 import { FootprintGrid } from '@/features/bin-designer/components/preview/FootprintGrid/FootprintGrid';
 import type { AssemblyStructure } from '@/shared/types/assembly';
 import type { ItemEnvelope } from '@/shared/types/item';
+import { useEffect, useRef, useState } from 'react';
 import { BasePlateMesh } from './BasePlateMesh';
 import { PartProxyMesh } from './PartProxyMesh';
 import { PlacementGhost } from './PlacementGhost';
+import { WorkshopSharpMesh } from './WorkshopSharpMesh';
+import { useWorkshopSharpen } from './useWorkshopSharpen';
+import { diffNewPartIds } from './hologramTracker';
 import { baseExtentMm, sceneToStore } from './workshopPlacement';
 import { useWorkshopInteraction, type HoverSurface } from './useWorkshopInteraction';
 
@@ -21,6 +25,31 @@ export function WorkshopScene({ structure, envelope }: WorkshopSceneProps) {
   const interaction = useWorkshopInteraction(structure);
   const { w, d } = baseExtentMm(envelope);
   const cameraDistance = Math.max(w, d) * 1.4 + 80;
+  const sharp = useWorkshopSharpen();
+  const showSharp = sharp && interaction.draggingId === null;
+
+  const knownIdsRef = useRef<ReadonlySet<string> | null>(null);
+  const [holograms, setHolograms] = useState<Map<string, number>>(new Map());
+  useEffect(() => {
+    const { ids, fresh } = diffNewPartIds(knownIdsRef.current, interaction.placements);
+    knownIdsRef.current = ids;
+    if (fresh.length > 0) {
+      const now = performance.now();
+      setHolograms((prev) => {
+        const next = new Map(prev);
+        for (const id of fresh) next.set(id, now);
+        return next;
+      });
+    }
+  }, [interaction.placements]);
+  const endHologram = (id: string): void => {
+    setHolograms((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  };
 
   return (
     <>
@@ -40,10 +69,12 @@ export function WorkshopScene({ structure, envelope }: WorkshopSceneProps) {
       <BasePlateMesh
         envelope={envelope}
         base={structure.base}
+        hidden={showSharp}
         onSurfaceMove={interaction.onSurfaceMove}
         onSurfaceLeave={interaction.onSurfaceLeave}
         onSurfaceClick={interaction.onSurfaceClick}
       />
+      {showSharp && <WorkshopSharpMesh floorThickness={structure.base.floorThickness} />}
       {interaction.placements.map((placed) => (
         <PartProxyMesh
           key={placed.key}
@@ -54,6 +85,9 @@ export function WorkshopScene({ structure, envelope }: WorkshopSceneProps) {
           raycastDisabled={
             interaction.draggingId !== null && interaction.isInDraggedSubtree(placed.selectId)
           }
+          hidden={showSharp}
+          hologramStart={holograms.get(placed.selectId) ?? null}
+          onHologramEnd={endHologram}
           onSurfaceMove={interaction.onSurfaceMove}
           onSurfaceLeave={interaction.onSurfaceLeave}
           onSurfaceClick={interaction.onSurfaceClick}

--- a/src/features/bin-designer/components/Workshop/WorkshopSharpMesh.test.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopSharpMesh.test.tsx
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { WorkshopSharpMesh } from './WorkshopSharpMesh';
+
+describe('WorkshopSharpMesh', () => {
+  it('exports a function', () => {
+    expect(typeof WorkshopSharpMesh).toBe('function');
+  });
+});

--- a/src/features/bin-designer/components/Workshop/WorkshopSharpMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopSharpMesh.tsx
@@ -1,0 +1,83 @@
+/**
+ * The worker's exact fused assembly, swapped in over the proxies once
+ * generation settles. Arrives in the print frame (XY centered, Z=0 at the
+ * printable bottom) and is dropped by socket + floor so it lands in the
+ * scene frame (z=0 = floor top). A brief emissive settle marks the swap —
+ * the hologram resolving to solid.
+ */
+import { useEffect, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import type { MeshStandardMaterial } from 'three';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { useMeshGeometry } from '@/shared/components/preview/useMeshGeometry';
+import { useThreeColors } from '@/shared/hooks/useThemeEffect';
+import { usePrefersReducedMotion } from '@/shared/hooks/usePrefersReducedMotion';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+
+const RESOLVE_MS = 250;
+
+interface WorkshopSharpMeshProps {
+  floorThickness: number;
+}
+
+export function WorkshopSharpMesh({ floorThickness }: WorkshopSharpMeshProps) {
+  const colors = useThreeColors();
+  const reducedMotion = usePrefersReducedMotion();
+  const mesh = useDesignerStore(
+    useShallow((s) => ({
+      vertices: s.generation.mesh?.vertices ?? null,
+      normals: s.generation.mesh?.normals ?? null,
+      indices: s.generation.mesh?.indices ?? null,
+      edgeVertices: s.generation.mesh?.edgeVertices ?? null,
+    }))
+  );
+  const { geometry, edgesGeometry } = useMeshGeometry(mesh);
+  const materialRef = useRef<MeshStandardMaterial>(null);
+  const settleStartRef = useRef<number | null>(null);
+  const invalidate = useThree((s) => s.invalidate);
+
+  useEffect(() => {
+    if (!geometry) return;
+    settleStartRef.current = reducedMotion ? null : performance.now();
+    invalidate();
+  }, [geometry, invalidate, reducedMotion]);
+
+  useFrame(() => {
+    const material = materialRef.current;
+    const start = settleStartRef.current;
+    if (!material || start === null) return;
+    const t = (performance.now() - start) / RESOLVE_MS;
+    if (t >= 1) {
+      material.emissiveIntensity = 0;
+      settleStartRef.current = null;
+      invalidate();
+      return;
+    }
+    material.emissiveIntensity = 0.5 * (1 - t);
+    invalidate();
+  });
+
+  if (!geometry) return null;
+  const zDrop = -(GRIDFINITY_SPEC.SOCKET_HEIGHT + floorThickness);
+
+  return (
+    <group position={[0, 0, zDrop]}>
+      <mesh geometry={geometry} raycast={() => null}>
+        <meshStandardMaterial
+          ref={materialRef}
+          color={colors.workshopPart}
+          roughness={0.55}
+          metalness={0.1}
+          emissive={colors.workshopGhost}
+          emissiveIntensity={0}
+        />
+      </mesh>
+      {edgesGeometry && (
+        <lineSegments geometry={edgesGeometry} raycast={() => null}>
+          <lineBasicMaterial color={colors.lineColor} transparent opacity={colors.lineOpacity} />
+        </lineSegments>
+      )}
+    </group>
+  );
+}

--- a/src/features/bin-designer/components/Workshop/hologramTracker.test.ts
+++ b/src/features/bin-designer/components/Workshop/hologramTracker.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import type { PlacedPart } from '@/shared/types/assemblyPlacement';
+import { diffNewPartIds } from './hologramTracker';
+
+const placed = (id: string): PlacedPart => ({ selectId: id }) as PlacedPart;
+
+describe('diffNewPartIds', () => {
+  it('reports nothing fresh on the first snapshot', () => {
+    const { ids, fresh } = diffNewPartIds(null, [placed('a'), placed('b')]);
+    expect(fresh).toEqual([]);
+    expect(ids).toEqual(new Set(['a', 'b']));
+  });
+
+  it('reports only genuinely new ids', () => {
+    const first = diffNewPartIds(null, [placed('a')]);
+    const second = diffNewPartIds(first.ids, [placed('a'), placed('b')]);
+    expect(second.fresh).toEqual(['b']);
+  });
+
+  it('array copies of one node stay one id', () => {
+    const first = diffNewPartIds(null, [placed('a')]);
+    const second = diffNewPartIds(first.ids, [placed('a'), placed('a'), placed('b')]);
+    expect(second.fresh).toEqual(['b']);
+  });
+});

--- a/src/features/bin-designer/components/Workshop/hologramTracker.ts
+++ b/src/features/bin-designer/components/Workshop/hologramTracker.ts
@@ -1,0 +1,19 @@
+/**
+ * Detects which part ids are NEW between two renders of the placement list,
+ * so only genuinely placed parts scan in — never the initial load, and never
+ * parts that merely moved or re-parented.
+ */
+import type { PlacedPart } from '@/shared/types/assemblyPlacement';
+
+export function diffNewPartIds(
+  previous: ReadonlySet<string> | null,
+  placements: readonly PlacedPart[]
+): { ids: Set<string>; fresh: string[] } {
+  const ids = new Set(placements.map((p) => p.selectId));
+  if (previous === null) return { ids, fresh: [] };
+  const fresh: string[] = [];
+  for (const id of ids) {
+    if (!previous.has(id)) fresh.push(id);
+  }
+  return { ids, fresh };
+}

--- a/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
+++ b/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
@@ -59,6 +59,10 @@ export function useWorkshopInteraction(structure: AssemblyStructure): WorkshopIn
   // Transaction opens lazily on the first real mutation of a drag, so a
   // click that never moves the part leaves no undo step behind.
   const dragTransactionRef = useRef(false);
+  // A pointerdown on a part disables that subtree's raycast for the drag, so
+  // the browser's synthesized click can fall through to the base and would
+  // deselect what was just selected — swallow exactly that one click.
+  const skipNextBaseClickRef = useRef(false);
   const [fineSnap, setFineSnap] = useState(false);
 
   const placements = useMemo(() => resolvePlacedParts(structure), [structure]);
@@ -160,12 +164,20 @@ export function useWorkshopInteraction(structure: AssemblyStructure): WorkshopIn
       const store = useDesignerStore.getState();
       const type = store.ui.workshopPendingPartType;
       if (type) {
+        skipNextBaseClickRef.current = false;
         const local = snapPoint(surface);
         store.addAssemblyPart(type, surface.parentId, { x: local.x, y: local.y });
         invalidate();
         return;
       }
+      if (surface.parentId !== null) {
+        skipNextBaseClickRef.current = false;
+      }
       if (surface.parentId === null) {
+        if (skipNextBaseClickRef.current) {
+          skipNextBaseClickRef.current = false;
+          return;
+        }
         store.setSelectedAssemblyPartId(null);
         invalidate();
       }
@@ -183,6 +195,7 @@ export function useWorkshopInteraction(structure: AssemblyStructure): WorkshopIn
       const node = findAssemblyPart(currentStructure.parts, id);
       if (!node) return;
       draggedSubtreeRef.current = new Set(collectAssemblyIds([node]));
+      skipNextBaseClickRef.current = true;
       const controls = getThree().controls as { enabled: boolean } | null;
       if (controls) controls.enabled = false;
       setDraggingId(id);

--- a/src/features/bin-designer/components/Workshop/useWorkshopSharpen.ts
+++ b/src/features/bin-designer/components/Workshop/useWorkshopSharpen.ts
@@ -1,0 +1,27 @@
+/**
+ * Decides when the Workshop canvas may show the worker's exact fused solid
+ * instead of the live proxies: only when a generation has COMPLETED for the
+ * epoch the tree is currently at. Any edit bumps the epoch and flips the
+ * scene back to proxies instantly; the sharp mesh returns when the worker
+ * catches up (the draft-then-sharpen contract the bin designer set).
+ */
+import { useEffect, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+
+export function useWorkshopSharpen(): boolean {
+  const { status, epoch } = useDesignerStore(
+    useShallow((s) => ({ status: s.generation.status, epoch: s.generation.epoch }))
+  );
+  const [sharpEpoch, setSharpEpoch] = useState<number | null>(null);
+  const prevStatusRef = useRef(status);
+
+  useEffect(() => {
+    if (status === 'complete' && prevStatusRef.current !== 'complete') {
+      setSharpEpoch(epoch);
+    }
+    prevStatusRef.current = status;
+  }, [status, epoch]);
+
+  return status === 'complete' && sharpEpoch === epoch;
+}

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -337,10 +337,6 @@ export function useGeneration(): void {
   // compartment validation / export-warm — those are bin-specific.
   const runItemGeneration = useCallback(
     async (item: GridfinityItem) => {
-      // The Workshop canvas renders client-side proxies and never reads
-      // generation.mesh, so epoch-driven regeneration would be wasted work —
-      // the sharpen phase wires this up. Exports call the worker directly.
-      if (item.structure.kind === 'assembly') return;
       const bridge = bridgeRef.current;
       if (!bridge || bridge.isDestroyed) return;
 


### PR DESCRIPTION
Phase 4 of the Workshop plan (#3720 schema, #3722 editor, #3724 generator): the draft-then-sharpen loop and the hologram construction feel.

## What's in

**Sharpen loop.** The assembly gate in `runItemGeneration` is gone: every edit's epoch bump now debounce-generates the exact fused solid in the worker. `useWorkshopSharpen` shows that mesh only when a generation has completed for the epoch the tree is currently at — any edit flips the canvas back to the always-current proxies instantly, and the exact solid (socket feet, fused seams, carved holes, crisp mesh edges) swaps back in when the worker settles. While the sharp mesh is up, the proxies stay mounted invisibly as the raycast targets, so selection and drag still work; the selected part shows as a polygon-offset accent overlay.

**Hologram scan-in.** A newly placed part materializes over 400ms: a world-space clipping plane sweeps up the part's height under a cyan emissive glow that settles to solid — driven imperatively (refs + useFrame + invalidate) so the demand-mode canvas only renders while animating. The sharpen swap gets a 250ms emissive settle — the hologram resolving. `prefers-reduced-motion` collapses both to short opacity fades. Only genuinely new parts scan in; loads and undos do not replay.

**Two interaction bugs found by driving the real app**, both fixed:
- A click-to-select immediately deselected: pointerdown disables the dragged subtree's raycast, so the browser's synthesized click fell through to the base and cleared the selection. The interaction hook now swallows exactly that one base click.
- `raycast={undefined}` on a mesh clobbers the prototype method under R3F's prop application, silently removing the part from picking — the prop is now spread only when actually disabling.

**Verified live**: hologram captured mid-sweep on camera, sharp mesh swap confirmed, click-selection and stacking-on-block verified against the running worker (post landed with snapped local coordinates in the block's frame).

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

