### PR TITLE
feat(workshop): library autosave, cloud sync, and the server validation mirror

### DIFF
--- a/api/lib/assemblyValidation.test.ts
+++ b/api/lib/assemblyValidation.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { validateAssemblyEnvelope, validateAssemblyStructure } from './assemblyValidation.js';
+
+const validEnvelope = {
+  width: 4,
+  depth: 2,
+  gridUnitMm: 42,
+  heightUnitMm: 7,
+  attachment: {
+    magnetHoles: false,
+    magnetDiameter: 6.5,
+    magnetDepth: 2.4,
+    screwHoles: false,
+    screwDiameter: 3,
+  },
+  featureColors: { enabled: false },
+};
+
+const post = (id: string, extra: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id,
+  type: 'post',
+  params: { diameter: 8, height: 40, taperDeg: 0, tipChamfer: 1 },
+  transform: { x: 20, y: 20, seatZ: 0, rotZDeg: 0 },
+  children: [],
+  ...extra,
+});
+
+const structure = (parts: unknown[]): Record<string, unknown> => ({
+  kind: 'assembly',
+  schemaVersion: 1,
+  base: { floorThickness: 2 },
+  mirrorAxis: 'x',
+  parts,
+});
+
+describe('validateAssemblyEnvelope', () => {
+  it('accepts a standard envelope', () => {
+    expect(validateAssemblyEnvelope(validEnvelope).valid).toBe(true);
+  });
+
+  it('rejects out-of-range footprints and units', () => {
+    expect(validateAssemblyEnvelope({ ...validEnvelope, width: 50 }).valid).toBe(false);
+    expect(validateAssemblyEnvelope({ ...validEnvelope, gridUnitMm: 500 }).valid).toBe(false);
+    expect(
+      validateAssemblyEnvelope({
+        ...validEnvelope,
+        attachment: { ...validEnvelope.attachment, magnetDiameter: 100 },
+      }).valid
+    ).toBe(false);
+  });
+});
+
+describe('validateAssemblyStructure', () => {
+  it('accepts a nested build with arrays, mirror, and cutters', () => {
+    const result = validateAssemblyStructure(
+      structure([
+        post('rail', {
+          type: 'block',
+          params: { width: 100, depth: 12, height: 30, wedgeAngleDeg: 0 },
+          mirror: true,
+          children: [
+            {
+              id: 'holes',
+              type: 'cutter',
+              params: {
+                profile: { shape: 'circle', diameter: 7 },
+                depth: 25,
+                clearance: 0.2,
+                chamfer: 0.6,
+              },
+              transform: { x: 10, y: 0, seatZ: 0, rotZDeg: 0 },
+              array: { count: 4, dx: 20, dy: 0 },
+              children: [],
+            },
+          ],
+        }),
+      ])
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts every cutter profile variant', () => {
+    const profiles = [
+      { shape: 'circle', diameter: 6 },
+      { shape: 'rectangle', width: 20, depth: 10, cornerRadius: 2 },
+      { shape: 'polygon', diameter: 8, sides: 6 },
+      { shape: 'slot', length: 40, width: 3 },
+      {
+        shape: 'path',
+        points: [
+          { x: 0, y: 0, handleIn: null, handleOut: { dx: 3, dy: 0 }, symmetric: false },
+          { x: 20, y: 10, handleIn: { dx: -3, dy: 0 }, handleOut: null, symmetric: false },
+        ],
+      },
+      {
+        shape: 'outline',
+        points: [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 5, y: 10 },
+        ],
+      },
+    ];
+    for (const profile of profiles) {
+      const result = validateAssemblyStructure(
+        structure([
+          post('c', {
+            type: 'cutter',
+            params: { profile, depth: 10, clearance: 0, chamfer: 0 },
+          }),
+        ])
+      );
+      expect(result.valid, profile.shape).toBe(true);
+    }
+  });
+
+  it('rejects the caps: node count, depth, path points', () => {
+    const many = Array.from({ length: 257 }, (_, i) => post(`p${i}`));
+    expect(validateAssemblyStructure(structure(many)).valid).toBe(false);
+
+    let chain = post('d1');
+    for (let i = 2; i <= 9; i += 1) chain = post(`d${i}`, { children: [chain] });
+    expect(validateAssemblyStructure(structure([chain])).valid).toBe(false);
+
+    const hugePath = {
+      shape: 'path',
+      points: Array.from({ length: 2001 }, (_, i) => ({
+        x: i % 100,
+        y: 0,
+        handleIn: null,
+        handleOut: null,
+        symmetric: false,
+      })),
+    };
+    expect(
+      validateAssemblyStructure(
+        structure([
+          post('c', {
+            type: 'cutter',
+            params: { profile: hugePath, depth: 5, clearance: 0, chamfer: 0 },
+          }),
+        ])
+      ).valid
+    ).toBe(false);
+  });
+
+  it('rejects out-of-range params, transforms, and unknown types', () => {
+    expect(
+      validateAssemblyStructure(
+        structure([
+          post('p', { params: { diameter: 9999, height: 40, taperDeg: 0, tipChamfer: 1 } }),
+        ])
+      ).valid
+    ).toBe(false);
+    expect(
+      validateAssemblyStructure(
+        structure([post('p', { transform: { x: 5000, y: 0, seatZ: 0, rotZDeg: 0 } })])
+      ).valid
+    ).toBe(false);
+    expect(validateAssemblyStructure(structure([post('p', { type: 'sphere' })])).valid).toBe(false);
+    expect(
+      validateAssemblyStructure(structure([post('p', { array: { count: 1, dx: 5, dy: 0 } })])).valid
+    ).toBe(false);
+  });
+
+  it('rejects wrong kind, version, base, and mirror axis', () => {
+    expect(validateAssemblyStructure({ ...structure([]), kind: 'bin' }).valid).toBe(false);
+    expect(validateAssemblyStructure({ ...structure([]), schemaVersion: 2 }).valid).toBe(false);
+    expect(
+      validateAssemblyStructure({ ...structure([]), base: { floorThickness: 99 } }).valid
+    ).toBe(false);
+    expect(validateAssemblyStructure({ ...structure([]), mirrorAxis: 'z' }).valid).toBe(false);
+  });
+});

--- a/api/lib/assemblyValidation.ts
+++ b/api/lib/assemblyValidation.ts
@@ -1,0 +1,242 @@
+/**
+ * Server-side validation for Workshop assembly designs — a hand-written
+ * mirror of the client's zod schema in src/shared/items/assembly/descriptor.ts
+ * (api/ cannot import from src/; keep the two in sync). The server is the
+ * final authority: anything out of range here 400s regardless of client.
+ */
+import {
+  isNumber,
+  inRange,
+  isString,
+  isBoolean,
+  isObject,
+  validationError,
+} from './validationUtils.js';
+
+const MAX_ASSEMBLY_PARTS = 256;
+const MAX_ASSEMBLY_DEPTH = 8;
+const MAX_PATH_POINTS = 2000;
+const MAX_OUTLINE_POINTS = 5000;
+
+const PART_TYPES = new Set(['post', 'fin', 'block', 'tube', 'cradle', 'hook', 'arch', 'cutter']);
+
+export type AssemblyValidationResult =
+  { valid: true } | { valid: false; error: { code: 'INVALID_PARAMS'; message: string } };
+
+const fail = (message: string): AssemblyValidationResult =>
+  validationError('INVALID_PARAMS', message);
+
+function num(v: unknown, min: number, max: number): boolean {
+  return isNumber(v) && inRange(v, min, max);
+}
+
+function validTransform(t: unknown): boolean {
+  return (
+    isObject(t) &&
+    num(t.x, -1000, 1000) &&
+    num(t.y, -1000, 1000) &&
+    num(t.seatZ, -200, 200) &&
+    num(t.rotZDeg, -360, 360)
+  );
+}
+
+function validArray(a: unknown): boolean {
+  return (
+    isObject(a) &&
+    isNumber(a.count) &&
+    Number.isInteger(a.count) &&
+    inRange(a.count, 2, 64) &&
+    num(a.dx, -500, 500) &&
+    num(a.dy, -500, 500)
+  );
+}
+
+function validPoint(p: unknown, bound: number): boolean {
+  return isObject(p) && num(p.x, -bound, bound) && num(p.y, -bound, bound);
+}
+
+function validHandle(h: unknown): boolean {
+  if (h === null) return true;
+  return isObject(h) && num(h.dx, -2000, 2000) && num(h.dy, -2000, 2000);
+}
+
+function validProfile(profile: unknown): boolean {
+  if (!isObject(profile)) return false;
+  switch (profile.shape) {
+    case 'circle':
+      return num(profile.diameter, 0.5, 200);
+    case 'rectangle':
+      return (
+        num(profile.width, 0.5, 400) &&
+        num(profile.depth, 0.5, 400) &&
+        num(profile.cornerRadius, 0, 50)
+      );
+    case 'polygon':
+      return (
+        num(profile.diameter, 0.5, 200) &&
+        isNumber(profile.sides) &&
+        Number.isInteger(profile.sides) &&
+        inRange(profile.sides, 3, 12)
+      );
+    case 'slot':
+      return num(profile.length, 1, 400) && num(profile.width, 0.5, 200);
+    case 'path': {
+      const points = profile.points;
+      if (!Array.isArray(points) || points.length < 2 || points.length > MAX_PATH_POINTS) {
+        return false;
+      }
+      return points.every(
+        (p) =>
+          validPoint(p, 2000) &&
+          isObject(p) &&
+          validHandle(p.handleIn) &&
+          validHandle(p.handleOut) &&
+          isBoolean(p.symmetric)
+      );
+    }
+    case 'outline': {
+      const points = profile.points;
+      if (!Array.isArray(points) || points.length < 3 || points.length > MAX_OUTLINE_POINTS) {
+        return false;
+      }
+      return points.every((p) => validPoint(p, 2000));
+    }
+    default:
+      return false;
+  }
+}
+
+function validParams(type: string, params: unknown): boolean {
+  if (!isObject(params)) return false;
+  switch (type) {
+    case 'post':
+      return (
+        num(params.diameter, 2, 60) &&
+        num(params.height, 4, 200) &&
+        num(params.taperDeg, 0, 15) &&
+        num(params.tipChamfer, 0, 5)
+      );
+    case 'fin':
+      return (
+        num(params.length, 4, 400) &&
+        num(params.thickness, 0.8, 20) &&
+        num(params.height, 4, 200) &&
+        num(params.leanDeg, 0, 45)
+      );
+    case 'block':
+      return (
+        num(params.width, 2, 400) &&
+        num(params.depth, 2, 400) &&
+        num(params.height, 1, 200) &&
+        num(params.wedgeAngleDeg, 0, 60)
+      );
+    case 'tube':
+      return (
+        num(params.boreDiameter, 2, 80) &&
+        num(params.wall, 0.8, 10) &&
+        num(params.height, 4, 200) &&
+        num(params.tiltDeg, 0, 30)
+      );
+    case 'cradle':
+      return (
+        num(params.length, 4, 400) &&
+        num(params.width, 4, 100) &&
+        num(params.height, 4, 100) &&
+        (params.grooveStyle === 'round' || params.grooveStyle === 'vee') &&
+        num(params.grooveWidth, 2, 80) &&
+        num(params.grooveDepth, 1, 60)
+      );
+    case 'hook':
+      return (
+        num(params.stemHeight, 4, 200) &&
+        num(params.reach, 4, 100) &&
+        num(params.lipHeight, 0, 60) &&
+        num(params.thickness, 0.8, 20) &&
+        num(params.width, 2, 100)
+      );
+    case 'arch':
+      return (
+        num(params.span, 8, 400) &&
+        num(params.height, 8, 200) &&
+        (params.style === 'rod' || params.style === 'bridge') &&
+        num(params.rodDiameter, 2, 40) &&
+        num(params.bridgeWidth, 2, 60) &&
+        num(params.uprightThickness, 2, 30) &&
+        num(params.depth, 4, 60)
+      );
+    case 'cutter':
+      return (
+        validProfile(params.profile) &&
+        num(params.depth, 0.5, 200) &&
+        num(params.clearance, 0, 5) &&
+        num(params.chamfer, 0, 5)
+      );
+    default:
+      return false;
+  }
+}
+
+export function validateAssemblyEnvelope(envelope: unknown): AssemblyValidationResult {
+  if (!isObject(envelope)) return fail('envelope must be an object');
+  if (!num(envelope.width, 0.5, 24) || !num(envelope.depth, 0.5, 24)) {
+    return fail('envelope footprint out of range');
+  }
+  if (!num(envelope.gridUnitMm, 10, 100) || !num(envelope.heightUnitMm, 1, 20)) {
+    return fail('envelope units out of range');
+  }
+  const attachment = envelope.attachment;
+  if (!isObject(attachment)) return fail('envelope.attachment must be an object');
+  if (
+    !isBoolean(attachment.magnetHoles) ||
+    !isBoolean(attachment.screwHoles) ||
+    !num(attachment.magnetDiameter, 1, 20) ||
+    !num(attachment.magnetDepth, 0.5, 10) ||
+    !num(attachment.screwDiameter, 1, 10)
+  ) {
+    return fail('envelope.attachment out of range');
+  }
+  if (!isObject(envelope.featureColors)) return fail('envelope.featureColors must be an object');
+  return { valid: true };
+}
+
+export function validateAssemblyStructure(structure: unknown): AssemblyValidationResult {
+  if (!isObject(structure)) return fail('structure must be an object');
+  if (structure.kind !== 'assembly') return fail('structure.kind must be assembly');
+  if (structure.schemaVersion !== 1) return fail('unsupported assembly schemaVersion');
+  const base = structure.base;
+  if (!isObject(base) || !num(base.floorThickness, 1, 10)) {
+    return fail('base.floorThickness out of range');
+  }
+  if (base.cornerRadius !== undefined && !num(base.cornerRadius, 0, 20)) {
+    return fail('base.cornerRadius out of range');
+  }
+  if (structure.mirrorAxis !== 'x' && structure.mirrorAxis !== 'y') {
+    return fail('mirrorAxis must be x or y');
+  }
+  if (!Array.isArray(structure.parts)) return fail('parts must be an array');
+
+  let count = 0;
+  const stack: Array<{ node: unknown; depth: number }> = (structure.parts as unknown[]).map(
+    (node) => ({ node, depth: 1 })
+  );
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item) break;
+    const { node, depth } = item;
+    count += 1;
+    if (count > MAX_ASSEMBLY_PARTS) return fail(`more than ${MAX_ASSEMBLY_PARTS} parts`);
+    if (depth > MAX_ASSEMBLY_DEPTH) return fail(`parts nested deeper than ${MAX_ASSEMBLY_DEPTH}`);
+    if (!isObject(node)) return fail('part must be an object');
+    if (!isString(node.id) || node.id.length === 0 || node.id.length > 64) {
+      return fail('part id out of range');
+    }
+    if (!isString(node.type) || !PART_TYPES.has(node.type)) return fail('unknown part type');
+    if (!validTransform(node.transform)) return fail('part transform out of range');
+    if (node.array !== undefined && !validArray(node.array)) return fail('part array out of range');
+    if (node.mirror !== undefined && !isBoolean(node.mirror)) return fail('part mirror invalid');
+    if (!validParams(node.type, node.params)) return fail(`invalid ${node.type} params`);
+    if (!Array.isArray(node.children)) return fail('part children must be an array');
+    for (const child of node.children) stack.push({ node: child, depth: depth + 1 });
+  }
+  return { valid: true };
+}

--- a/api/lib/assemblyValidation.ts
+++ b/api/lib/assemblyValidation.ts
@@ -12,6 +12,7 @@ import {
   isObject,
   validationError,
 } from './validationUtils.js';
+import { validateFeatureColors } from './designerValidation.js';
 
 const MAX_ASSEMBLY_PARTS = 256;
 const MAX_ASSEMBLY_DEPTH = 8;
@@ -195,7 +196,8 @@ export function validateAssemblyEnvelope(envelope: unknown): AssemblyValidationR
   ) {
     return fail('envelope.attachment out of range');
   }
-  if (!isObject(envelope.featureColors)) return fail('envelope.featureColors must be an object');
+  const featureColorsError = validateFeatureColors(envelope.featureColors);
+  if (featureColorsError) return fail(featureColorsError);
   return { valid: true };
 }
 

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -1259,7 +1259,7 @@ function validateAccentBand(value: unknown, path: string): string | null {
  * grid `{ corners, bands, cells }`. Rejects unknown keys at every level so a
  * crafted share can't smuggle attacker-controlled junk past the size cap.
  */
-function validateFeatureColors(value: unknown): string | null {
+export function validateFeatureColors(value: unknown): string | null {
   if (!isObject(value)) return 'featureColors must be an object';
 
   for (const key of Object.keys(value)) {

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -1,5 +1,10 @@
 import { ErrorCode, isValidShareId } from '../../lib/shared.js';
 import { validateDesignerShare, sanitizeTags } from '../../lib/designerValidation.js';
+import {
+  validateAssemblyEnvelope,
+  validateAssemblyStructure,
+} from '../../lib/assemblyValidation.js';
+import { CONSTRAINTS } from '../../lib/designerValidationConstants.js';
 import { sanitizeString } from '../../lib/validation.js';
 import { createSyncResourceHandler } from '../lib/resourceHandler.js';
 
@@ -71,18 +76,39 @@ function sanitizeLineage(
 function unwrapDesignPayload(design: unknown): {
   name: string | null;
   params: unknown;
+  kind?: 'assembly';
+  envelope?: unknown;
+  structure?: unknown;
   tags: unknown;
   publishedId: unknown;
   lineage: unknown;
 } | null {
   if (design === null || typeof design !== 'object') return null;
-  const { name, params, tags, publishedId, lineage } = design as {
+  const { name, params, kind, envelope, structure, tags, publishedId, lineage } = design as {
     name?: unknown;
     params?: unknown;
+    kind?: unknown;
+    envelope?: unknown;
+    structure?: unknown;
     tags?: unknown;
     publishedId?: unknown;
     lineage?: unknown;
   };
+  if (kind === 'assembly') {
+    if (name !== undefined && typeof name !== 'string') return null;
+    if (typeof envelope !== 'object' || envelope === null) return null;
+    if (typeof structure !== 'object' || structure === null) return null;
+    return {
+      name: name ?? null,
+      params: null,
+      kind: 'assembly',
+      envelope,
+      structure,
+      tags,
+      publishedId,
+      lineage,
+    };
+  }
   if (typeof params === 'object' && params !== null) {
     // Wrapper shape: name must be a string or absent. Reject other types
     // so malformed clients can't silently drop the user-visible field.
@@ -171,6 +197,51 @@ export default createSyncResourceHandler<DesignEnvelope>({
     // it's what the quota check and index entry track. Without the split,
     // users get charged for bytes the validator stripped and the index
     // drifts from what the blob holds.
+    if (unwrapped.kind === 'assembly') {
+      const preBytes = Buffer.byteLength(JSON.stringify({ ...unwrapped, name, tags }), 'utf8');
+      if (preBytes > CONSTRAINTS.MAX_PAYLOAD_BYTES) {
+        return {
+          ok: false,
+          status: 400,
+          error: 'assembly design exceeds the size limit',
+          code: ErrorCode.VALIDATION_ERROR,
+        };
+      }
+      const envelopeCheck = validateAssemblyEnvelope(unwrapped.envelope);
+      if (!envelopeCheck.valid) {
+        return {
+          ok: false,
+          status: 400,
+          error: envelopeCheck.error.message,
+          code: ErrorCode.VALIDATION_ERROR,
+        };
+      }
+      const structureCheck = validateAssemblyStructure(unwrapped.structure);
+      if (!structureCheck.valid) {
+        return {
+          ok: false,
+          status: 400,
+          error: structureCheck.error.message,
+          code: ErrorCode.VALIDATION_ERROR,
+        };
+      }
+      const stored = {
+        name,
+        kind: 'assembly' as const,
+        envelope: unwrapped.envelope,
+        structure: unwrapped.structure,
+        tags,
+        ...(publishedId !== undefined ? { publishedId } : {}),
+        ...(lineage !== undefined ? { lineage } : {}),
+      };
+      return {
+        ok: true,
+        envelope: { design: stored, modifiedAt, schemaVersion: SCHEMA_VERSION },
+        sizeBytes: Buffer.byteLength(JSON.stringify(stored), 'utf8'),
+        tiebreakerCandidate: stored,
+      };
+    }
+
     const validationPayload = {
       type: 'designer' as const,
       version: 1 as const,

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -257,7 +257,7 @@ export const FEATURE_FLAGS = [
     status: 'experimental',
     risk: 'medium',
     warning:
-      'Early feature. Workshop builds export to STL, 3MF and STEP, but are not auto-saved or placeable in drawer layouts yet.',
+      'Early feature. Workshop builds auto-save to your library, sync when signed in, and export to STL, 3MF and STEP — but cannot be placed in drawer layouts yet.',
     addedAt: '2026-08',
     requiresRefresh: false,
   },

--- a/src/core/sync/adapters/types.ts
+++ b/src/core/sync/adapters/types.ts
@@ -93,7 +93,16 @@ export interface SyncAdapter<T = unknown> {
  */
 export interface DesignSyncPayload {
   name: string;
-  params: unknown;
+  /** Bin params; absent for non-bin kinds, which carry `structure` instead. */
+  params?: unknown;
+  /**
+   * Item kind for non-bin designs. Absent means bin (every payload written
+   * before kinds synced). `envelope`/`structure` are `unknown` for the same
+   * layering reason as `params`.
+   */
+  kind?: string;
+  envelope?: unknown;
+  structure?: unknown;
   /**
    * Organization tags. Like `name`, these ride alongside `params` (not
    * inside it) so they survive the cloud round-trip; the server stores them

--- a/src/features/bin-designer/components/DesignActions/DesignActions.tsx
+++ b/src/features/bin-designer/components/DesignActions/DesignActions.tsx
@@ -12,7 +12,7 @@ interface DesignActionsProps {
   onLoad: () => void;
   /** Absent for kinds that cannot stand on the layout grid (tool racks). */
   onPlaceInLayout?: () => void;
-  onDownloadJSON: () => void;
+  onDownloadJSON?: () => void;
   onRename: () => void;
   onEditTags: () => void;
   onDuplicate: () => void;
@@ -196,29 +196,31 @@ export function DesignActions({
             )}
 
             {/* Download JSON */}
-            <Button
-              variant="ghost"
-              fullWidth
-              role="menuitem"
-              onClick={handleAction(onDownloadJSON)}
-              className="w-full px-3 py-2.5 justify-start text-left text-sm text-content hover:bg-surface flex items-center gap-2"
-            >
-              <svg
-                className="w-4 h-4 text-content-secondary"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                aria-hidden="true"
+            {onDownloadJSON && (
+              <Button
+                variant="ghost"
+                fullWidth
+                role="menuitem"
+                onClick={handleAction(onDownloadJSON ?? (() => {}))}
+                className="w-full px-3 py-2.5 justify-start text-left text-sm text-content hover:bg-surface flex items-center gap-2"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                />
-              </svg>
-              {t('binDesigner.downloadJSON')}
-            </Button>
+                <svg
+                  className="w-4 h-4 text-content-secondary"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+                {t('binDesigner.downloadJSON')}
+              </Button>
+            )}
 
             {/* Rename */}
             <Button

--- a/src/features/bin-designer/components/DesignGridItem/DesignGridItem.tsx
+++ b/src/features/bin-designer/components/DesignGridItem/DesignGridItem.tsx
@@ -12,7 +12,7 @@ interface DesignGridItemProps {
   isFocused: boolean;
   onSelect: () => void;
   onPlaceInLayout?: () => void;
-  onDownloadJSON: () => void;
+  onDownloadJSON?: () => void;
   onRename: (newName: string) => void;
   onEditTags: () => void;
   onDuplicate: () => void;

--- a/src/features/bin-designer/components/DesignListDialog/DesignItemsView.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignItemsView.tsx
@@ -51,7 +51,7 @@ export function DesignItemsView({
     isFocused: index === focusedIndex,
     onSelect: () => onLoad(design),
     onPlaceInLayout: isLayoutPlaceableDesign(design) ? () => onPlaceInLayout(design) : undefined,
-    onDownloadJSON: () => onDownloadJSON(design),
+    onDownloadJSON: design.params ? () => onDownloadJSON(design) : undefined,
     onRename: (newName: string) => onRename(design, newName),
     onEditTags: () => onEditTags(design),
     onDuplicate: () => onDuplicate(design),

--- a/src/features/bin-designer/components/DesignListItem/DesignListItem.tsx
+++ b/src/features/bin-designer/components/DesignListItem/DesignListItem.tsx
@@ -12,7 +12,7 @@ interface DesignListItemProps {
   isFocused: boolean;
   onSelect: () => void;
   onPlaceInLayout?: () => void;
-  onDownloadJSON: () => void;
+  onDownloadJSON?: () => void;
   onRename: (newName: string) => void;
   onEditTags: () => void;
   onDuplicate: () => void;

--- a/src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
@@ -17,6 +17,7 @@ import { useDesignerInit } from '@/features/bin-designer/hooks/useDesignerInit';
 import { useCreateFromBin } from '@/features/bin-designer/hooks/useCreateFromBin';
 import { useAutoSave } from '@/features/bin-designer/hooks/useAutoSave';
 import { useImportedDesignAutoSave } from '@/features/bin-designer/hooks/useImportedDesignAutoSave';
+import { useWorkshopAutoSave } from '@/features/bin-designer/hooks/useWorkshopAutoSave';
 import { useThumbnailCapture } from '@/features/bin-designer/hooks/useThumbnailCapture';
 import { useDesignerUrlSync } from '@/features/bin-designer/hooks/useDesignerUrlSync';
 import { useUnsavedWarning } from '@/features/bin-designer/hooks/useUnsavedWarning';
@@ -63,6 +64,7 @@ export function DesignerPage() {
 
   // Auto-save for imported-mesh designs (footprint edits + one-time thumbnail)
   useImportedDesignAutoSave();
+  useWorkshopAutoSave();
 
   // Capture thumbnail after first mesh generation (for designs created from bins)
   useThumbnailCapture();

--- a/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
@@ -3,17 +3,36 @@
  * designer holds an assembly. Parts render as instant client-side proxies;
  * the exact worker-fused solid joins in a later phase.
  */
-import { Canvas } from '@react-three/fiber';
+import { useEffect } from 'react';
+import { Canvas, useThree } from '@react-three/fiber';
+import { PerspectiveCamera } from 'three';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { detectWebGL, WebGLFallback, WebGLErrorBoundary } from '@/shared/webgl';
+import {
+  clearPreviewCanvas,
+  setPreviewCanvas,
+  setPreviewContext,
+} from '@/features/bin-designer/utils/thumbnail';
 import { WorkshopScene } from './WorkshopScene';
+
+/** Registers this canvas with the thumbnail pipeline (see PreviewContextSync). */
+function WorkshopContextSync() {
+  const { gl, scene, camera } = useThree();
+  useEffect(() => {
+    if (camera instanceof PerspectiveCamera) {
+      setPreviewContext(gl, scene, camera);
+    }
+  }, [gl, scene, camera]);
+  return null;
+}
 
 export function WorkshopCanvas() {
   const { structure, envelope } = useDesignerStore(
     useShallow((s) => ({ structure: s.structure, envelope: s.envelope }))
   );
   const webgl = detectWebGL();
+  useEffect(() => () => clearPreviewCanvas(), []);
 
   if (structure?.kind !== 'assembly' || !envelope) return null;
   if (!webgl.available && webgl.reason) {
@@ -23,7 +42,12 @@ export function WorkshopCanvas() {
   return (
     <div className="relative h-full w-full" translate="no" data-testid="workshop-canvas">
       <WebGLErrorBoundary component="designer">
-        <Canvas frameloop="demand" gl={{ antialias: true, localClippingEnabled: true }}>
+        <Canvas
+          frameloop="demand"
+          gl={{ antialias: true, localClippingEnabled: true, preserveDrawingBuffer: true }}
+          onCreated={({ gl }) => setPreviewCanvas(gl.domElement)}
+        >
+          <WorkshopContextSync />
           <WorkshopScene structure={structure} envelope={envelope} />
         </Canvas>
       </WebGLErrorBoundary>

--- a/src/features/bin-designer/hooks/useAutoSave.ts
+++ b/src/features/bin-designer/hooks/useAutoSave.ts
@@ -79,6 +79,7 @@ function waitForGenerationComplete(
  * "Untitled Bin" entries from appearing in My Designs during exploratory parameter tweaks.
  */
 export function useAutoSave(): void {
+  const itemKind = useDesignerStore((s) => s.itemKind);
   const { params, currentDesignId, exportFileNameConfig } = useDesignerStore(
     useShallow((s) => ({
       params: s.params,
@@ -199,6 +200,9 @@ export function useAutoSave(): void {
   );
 
   useEffect(() => {
+    // Params-only autosave: non-bin kinds persist through their own hooks,
+    // and flushing here would write stale bin params onto their rows.
+    if (itemKind !== 'bin') return;
     // Skip first render (initial mount shouldn't trigger save)
     if (isFirstRender.current) {
       isFirstRender.current = false;
@@ -249,7 +253,7 @@ export function useAutoSave(): void {
         clearTimeout(timerRef.current);
       }
     };
-  }, [params, exportFileNameConfig, currentDesignId, performSave]);
+  }, [itemKind, params, exportFileNameConfig, currentDesignId, performSave]);
 
   // Leaving the designer (route change) unmounts this hook, which aborts both
   // the debounce and any save still waiting on generation — a window of up to
@@ -261,7 +265,7 @@ export function useAutoSave(): void {
     return () => {
       const state = useDesignerStore.getState();
       const id = state.currentDesignId;
-      if (!id) return;
+      if (!id || state.itemKind !== 'bin') return;
       if (
         lastSavedParams.current === state.params &&
         lastSavedConfig.current === state.exportFileNameConfig

--- a/src/features/bin-designer/hooks/useThumbnailCapture.ts
+++ b/src/features/bin-designer/hooks/useThumbnailCapture.ts
@@ -27,7 +27,7 @@ import { designId } from '@/core/types';
 export function useThumbnailCapture(): void {
   const prevStatusRef = useRef<string>('');
 
-  const { generationStatus, needsThumbnailUpdate, currentDesignId, params, designName } =
+  const { generationStatus, needsThumbnailUpdate, currentDesignId, params, designName, itemKind } =
     useDesignerStore(
       useShallow((s) => ({
         generationStatus: s.generation.status,
@@ -35,12 +35,15 @@ export function useThumbnailCapture(): void {
         currentDesignId: s.currentDesignId,
         params: s.params,
         designName: s.designName,
+        itemKind: s.itemKind,
       }))
     );
 
   const setNeedsThumbnailUpdate = useDesignerStore((s) => s.setNeedsThumbnailUpdate);
 
   useEffect(() => {
+    // Frames from bin params; non-bin kinds capture through their own hooks.
+    if (itemKind !== 'bin') return;
     // Only trigger when status transitions TO 'complete'
     if (
       generationStatus !== 'complete' ||
@@ -98,6 +101,7 @@ export function useThumbnailCapture(): void {
     return () => clearTimeout(timeoutId);
   }, [
     generationStatus,
+    itemKind,
     needsThumbnailUpdate,
     currentDesignId,
     params.width,

--- a/src/features/bin-designer/hooks/useWorkshopAutoSave.test.ts
+++ b/src/features/bin-designer/hooks/useWorkshopAutoSave.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { ok } from '@/core/result';
+import type * as DesignerStorageModule from '../storage/DesignerStorage';
+import { designId } from '@/core/types';
+
+const saveDesignMock = vi.fn();
+const loadDesignMock = vi.fn();
+
+vi.mock('@/features/bin-designer/storage/DesignerStorage', async (importOriginal) => {
+  const actual = await importOriginal<typeof DesignerStorageModule>();
+  return {
+    ...actual,
+    saveDesign: (input: unknown) => saveDesignMock(input),
+    loadDesign: (id: string) => loadDesignMock(id),
+  };
+});
+
+vi.mock('../utils/thumbnail', () => ({
+  captureThumbnailAtPreset: () => null,
+}));
+
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { useWorkshopAutoSave } from './useWorkshopAutoSave';
+
+const savedRow = (id: string): Record<string, unknown> => ({
+  id: designId(id),
+  name: 'Untitled',
+  kind: 'assembly',
+  thumbnail: null,
+  exportFileNameConfig: null,
+  createdAt: '2026-08-22T00:00:00.000Z',
+  updatedAt: '2026-08-22T00:00:00.000Z',
+});
+
+describe('useWorkshopAutoSave', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+    useDesignerStore.getState().newDesign('assembly');
+  });
+
+  it('creates the design on the first part placed and adopts the id', async () => {
+    saveDesignMock.mockResolvedValueOnce(ok(savedRow('design_1_abcdef')));
+    const { unmount } = renderHook(() => useWorkshopAutoSave());
+    act(() => {
+      useDesignerStore.getState().addAssemblyPart('post', null);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+    expect(saveDesignMock).toHaveBeenCalledTimes(1);
+    const created = saveDesignMock.mock.calls[0]?.[0] as { kind?: string; structure?: unknown };
+    expect(created.kind).toBe('assembly');
+    expect(useDesignerStore.getState().currentDesignId).toBe('design_1_abcdef');
+    unmount();
+    vi.useRealTimers();
+  });
+
+  it('persists a structure edit debounced, merging over the loaded record', async () => {
+    saveDesignMock.mockResolvedValue(ok(savedRow('design_1_abcdef')));
+    loadDesignMock.mockResolvedValue(ok(savedRow('design_1_abcdef')));
+    const { unmount } = renderHook(() => useWorkshopAutoSave());
+    act(() => {
+      useDesignerStore.getState().addAssemblyPart('post', null);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const id = useDesignerStore.getState().ui.selectedAssemblyPartId;
+    act(() => {
+      if (id) useDesignerStore.getState().moveAssemblyPart(id, { x: 30 });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(loadDesignMock).toHaveBeenCalled();
+    expect(saveDesignMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    unmount();
+    vi.useRealTimers();
+  });
+
+  it('does nothing for bins or empty builds', async () => {
+    const { unmount } = renderHook(() => useWorkshopAutoSave());
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+    expect(saveDesignMock).not.toHaveBeenCalled();
+    unmount();
+    vi.useRealTimers();
+  });
+});

--- a/src/features/bin-designer/hooks/useWorkshopAutoSave.ts
+++ b/src/features/bin-designer/hooks/useWorkshopAutoSave.ts
@@ -1,0 +1,161 @@
+/**
+ * Auto-save for Workshop assemblies.
+ *
+ * `useAutoSave` is bin-params-only, and unlike imported meshes (saved
+ * eagerly at import) a fresh assembly has no record at all — so this hook
+ * owns the whole lifecycle: it CREATES the design on the first part placed,
+ * then persists structure/envelope edits debounced, refreshing the
+ * thumbnail from the live scene whenever a save lands while the sharp
+ * mesh is up. Saves merge over the loaded record (load → spread → save) so
+ * createdAt, tags, and sync lineage survive.
+ */
+import { useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { isOk } from '@/core/result';
+import { designId as toDesignId } from '@/core/types';
+import type { ItemEnvelope, ItemStructure } from '@/shared/types/item';
+import { assemblyHeightUnits } from '@/shared/types/assemblyPlacement';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+import { loadDesign, saveDesign } from '@/features/bin-designer/storage/DesignerStorage';
+import { useDesignerStore } from '../store';
+import { registryEdgeFields, upsertRegistryEntry } from '../store/customBinRegistry';
+import { captureThumbnailAtPreset } from '../utils/thumbnail';
+
+const AUTO_SAVE_DELAY_MS = 1000;
+
+function assemblyThumbnail(envelope: ItemEnvelope, structure: ItemStructure): string | null {
+  if (structure.kind !== 'assembly') return null;
+  return captureThumbnailAtPreset({
+    width: envelope.width,
+    depth: envelope.depth,
+    height: assemblyHeightUnits(
+      structure,
+      envelope.heightUnitMm,
+      GRIDFINITY_SPEC.SOCKET_HEIGHT + structure.base.floorThickness
+    ),
+    gridUnitMm: envelope.gridUnitMm,
+    heightUnitMm: envelope.heightUnitMm,
+  });
+}
+
+async function persistExisting(
+  id: string,
+  name: string | null,
+  envelope: ItemEnvelope,
+  structure: ItemStructure,
+  thumbnail: string | null
+): Promise<void> {
+  const existing = await loadDesign(toDesignId(id));
+  if (!isOk(existing)) return;
+  const result = await saveDesign({
+    ...existing.value,
+    ...(name ? { name } : {}),
+    kind: 'assembly',
+    envelope,
+    structure,
+    ...(thumbnail ? { thumbnail } : {}),
+  });
+  if (!isOk(result) || structure.kind !== 'assembly') return;
+  upsertRegistryEntry({
+    id: result.value.id,
+    name: result.value.name,
+    width: envelope.width,
+    depth: envelope.depth,
+    height: assemblyHeightUnits(
+      structure,
+      envelope.heightUnitMm,
+      GRIDFINITY_SPEC.SOCKET_HEIGHT + structure.base.floorThickness
+    ),
+    kind: 'assembly',
+    ...registryEdgeFields({}),
+    updatedAt: result.value.updatedAt,
+  });
+}
+
+export function useWorkshopAutoSave(): void {
+  const { itemKind, envelope, structure, currentDesignId, designName, generationStatus } =
+    useDesignerStore(
+      useShallow((s) => ({
+        itemKind: s.itemKind,
+        envelope: s.envelope,
+        structure: s.structure,
+        currentDesignId: s.currentDesignId,
+        designName: s.designName,
+        generationStatus: s.generation.status,
+      }))
+    );
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSavedRef = useRef<{ envelope: ItemEnvelope | null; structure: ItemStructure | null }>({
+    envelope: null,
+    structure: null,
+  });
+  const lastDesignIdRef = useRef<string | null>(null);
+  const creatingRef = useRef(false);
+
+  useEffect(() => {
+    if (itemKind !== 'assembly' || !envelope || structure?.kind !== 'assembly') return;
+
+    // First save: a build exists but no record does. Create it once.
+    if (!currentDesignId) {
+      if (structure.parts.length === 0 || creatingRef.current) return;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        creatingRef.current = true;
+        const thumbnail =
+          generationStatus === 'complete' ? assemblyThumbnail(envelope, structure) : null;
+        void saveDesign({
+          name: designName,
+          kind: 'assembly',
+          envelope,
+          structure,
+          thumbnail: thumbnail ?? '',
+          exportFileNameConfig: null,
+        }).then((result) => {
+          creatingRef.current = false;
+          if (!isOk(result)) return;
+          lastDesignIdRef.current = result.value.id;
+          lastSavedRef.current = { envelope, structure };
+          const store = useDesignerStore.getState();
+          // Only adopt the id if the user is still on this same build.
+          if (store.itemKind === 'assembly' && store.currentDesignId === null) {
+            store.setCurrentDesignId(result.value.id);
+          }
+        });
+      }, AUTO_SAVE_DELAY_MS);
+      return () => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+      };
+    }
+
+    // Design switch: reset tracking without saving.
+    if (currentDesignId !== lastDesignIdRef.current) {
+      lastDesignIdRef.current = currentDesignId;
+      lastSavedRef.current = { envelope, structure };
+      return;
+    }
+
+    if (
+      lastSavedRef.current.envelope === envelope &&
+      lastSavedRef.current.structure === structure
+    ) {
+      return;
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    const id = currentDesignId;
+    const name = designName;
+    timerRef.current = setTimeout(() => {
+      lastSavedRef.current = { envelope, structure };
+      const thumbnail =
+        useDesignerStore.getState().generation.status === 'complete'
+          ? assemblyThumbnail(envelope, structure)
+          : null;
+      void persistExisting(id, name, envelope, structure, thumbnail);
+    }, AUTO_SAVE_DELAY_MS);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [itemKind, envelope, structure, currentDesignId, designName, generationStatus]);
+}

--- a/src/features/bin-designer/hooks/useWorkshopAutoSave.ts
+++ b/src/features/bin-designer/hooks/useWorkshopAutoSave.ts
@@ -109,7 +109,7 @@ export function useWorkshopAutoSave(): void {
           kind: 'assembly',
           envelope,
           structure,
-          thumbnail: thumbnail ?? '',
+          thumbnail: thumbnail ?? null,
           exportFileNameConfig: null,
         }).then((result) => {
           creatingRef.current = false;

--- a/src/features/bin-designer/sync/designAdapter.test.ts
+++ b/src/features/bin-designer/sync/designAdapter.test.ts
@@ -114,6 +114,114 @@ describe('designAdapter non-bin kinds (local-only)', () => {
   });
 });
 
+describe('designAdapter assembly kind', () => {
+  const assemblyStructure = () => ({
+    kind: 'assembly' as const,
+    schemaVersion: 1 as const,
+    base: { floorThickness: 2 },
+    mirrorAxis: 'x' as const,
+    parts: [
+      {
+        id: 'p1',
+        type: 'post' as const,
+        params: { diameter: 8, height: 40, taperDeg: 0, tipChamfer: 1 },
+        transform: { x: 20, y: 20, seatZ: 0, rotZDeg: 0 },
+        children: [],
+      },
+    ],
+  });
+  const assemblyEnvelope = () =>
+    ({
+      width: 4,
+      depth: 2,
+      gridUnitMm: 42,
+      heightUnitMm: 7,
+      attachment: {
+        magnetHoles: false,
+        magnetDiameter: 6.5,
+        magnetDepth: 2.4,
+        screwHoles: false,
+        screwDiameter: 3,
+      },
+      featureColors: { enabled: false },
+    }) as SavedDesign['envelope'];
+
+  function assemblyDesign(id: string): SavedDesign {
+    const base = savedDesign(id, '2026-04-01T00:00:00.000Z', 'Workshop build');
+    const { params: _params, ...rest } = base;
+    return {
+      ...rest,
+      kind: 'assembly',
+      envelope: assemblyEnvelope(),
+      structure: assemblyStructure(),
+    };
+  }
+
+  it('list() includes assemblies with kind/envelope/structure in the payload', async () => {
+    listDesignsMock.mockResolvedValueOnce(ok([assemblyDesign('w')]));
+    const items = await designAdapter.list();
+    expect(items).toHaveLength(1);
+    const payload = items[0]?.payload;
+    expect(payload?.kind).toBe('assembly');
+    expect(payload?.params).toBeUndefined();
+    expect(payload?.structure).toBeDefined();
+  });
+
+  it('get() returns an assembly payload', async () => {
+    loadDesignMock.mockResolvedValueOnce(ok(assemblyDesign('w')));
+    const item = await designAdapter.get('w');
+    expect(item?.payload.kind).toBe('assembly');
+  });
+
+  it('applyRemote round-trips an assembly through migration into saveDesign', async () => {
+    loadDesignMock.mockResolvedValueOnce(err(storageNotFound('missing')));
+    saveDesignMock.mockResolvedValueOnce(ok(assemblyDesign('w')));
+    await designAdapter.applyRemote({
+      id: 'w',
+      payload: {
+        name: 'Remote build',
+        kind: 'assembly',
+        envelope: assemblyEnvelope(),
+        structure: assemblyStructure(),
+      },
+      modifiedAt: 1,
+    });
+    expect(saveDesignMock).toHaveBeenCalledTimes(1);
+    const saved = saveDesignMock.mock.calls[0]?.[0] as SavedDesign;
+    expect(saved.kind).toBe('assembly');
+    expect(saved.params).toBeUndefined();
+    expect(saved.structure?.kind).toBe('assembly');
+    expect(saved.structure?.kind === 'assembly' ? saved.structure.parts : []).toHaveLength(1);
+  });
+
+  it('applyRemote drops invalid remote nodes through migration instead of failing', async () => {
+    loadDesignMock.mockResolvedValueOnce(err(storageNotFound('missing')));
+    saveDesignMock.mockResolvedValueOnce(ok(assemblyDesign('w')));
+    const remote = assemblyStructure();
+    const poisoned = {
+      ...remote,
+      parts: [
+        ...remote.parts,
+        { id: 'bad', type: 'sphere', params: {}, transform: {}, children: [] },
+      ],
+    };
+    await designAdapter.applyRemote({
+      id: 'w',
+      payload: {
+        name: 'Remote build',
+        kind: 'assembly',
+        envelope: assemblyEnvelope(),
+        structure: poisoned,
+      },
+      modifiedAt: 1,
+    });
+    const saved = saveDesignMock.mock.calls[0]?.[0] as SavedDesign;
+    expect(
+      saved.structure?.kind === 'assembly' ? saved.structure.parts.map((n) => n.id) : []
+    ).toEqual(['p1']);
+  });
+});
+
 describe('designAdapter tags', () => {
   it('list carries tags in the payload', async () => {
     listDesignsMock.mockResolvedValueOnce(

--- a/src/features/bin-designer/sync/designAdapter.ts
+++ b/src/features/bin-designer/sync/designAdapter.ts
@@ -8,14 +8,16 @@ import type {
 } from '@/core/sync/adapters/types';
 import { designId } from '@/core/types';
 import type { CommunityDesignLineage } from '@/shared/types/community';
-import type { BinParams } from '@/features/bin-designer/types';
+import type { BinParams, SavedDesign } from '@/features/bin-designer/types';
+import type { ItemEnvelope } from '@/shared/types/item';
+import { assemblyDescriptor } from '@/shared/items/assembly/descriptor';
 import {
   deleteDesign,
   listDesigns,
   loadDesign,
   saveDesign,
 } from '@/features/bin-designer/storage/DesignerStorage';
-import { isBinDesign } from '@/features/bin-designer/utils/designKind';
+import { isBinDesign, isSyncableDesign } from '@/features/bin-designer/utils/designKind';
 import { normalizeTags } from '@/features/bin-designer/utils/tags';
 import { subscribe as subscribeDesignerEvents } from './designerEvents';
 
@@ -53,11 +55,51 @@ function isLineage(value: unknown): value is CommunityDesignLineage {
  */
 function unwrap(payload: unknown): {
   name?: string;
-  params: BinParams;
+  params?: BinParams;
+  kind?: 'assembly';
+  envelope?: ItemEnvelope;
+  structure?: unknown;
   tags?: string[];
   publishedId?: string | null;
   lineage?: CommunityDesignLineage | null;
 } {
+  if (payload !== null && typeof payload === 'object' && 'kind' in payload) {
+    const wrapper = payload as {
+      name?: unknown;
+      kind?: unknown;
+      envelope?: unknown;
+      structure?: unknown;
+      tags?: unknown;
+      publishedId?: unknown;
+      lineage?: unknown;
+    };
+    if (
+      wrapper.kind === 'assembly' &&
+      typeof wrapper.envelope === 'object' &&
+      wrapper.envelope !== null &&
+      typeof wrapper.structure === 'object' &&
+      wrapper.structure !== null
+    ) {
+      const trimmed = typeof wrapper.name === 'string' ? wrapper.name.trim() : '';
+      return {
+        name: trimmed === '' ? undefined : trimmed,
+        kind: 'assembly',
+        envelope: wrapper.envelope as ItemEnvelope,
+        structure: wrapper.structure,
+        tags: wrapper.tags === undefined ? undefined : normalizeTags(wrapper.tags),
+        publishedId:
+          wrapper.publishedId === null || typeof wrapper.publishedId === 'string'
+            ? wrapper.publishedId
+            : undefined,
+        lineage:
+          wrapper.lineage === null
+            ? null
+            : isLineage(wrapper.lineage)
+              ? wrapper.lineage
+              : undefined,
+      };
+    }
+  }
   if (payload !== null && typeof payload === 'object' && 'params' in payload) {
     const { name, params, tags, publishedId, lineage } = payload as {
       name?: unknown;
@@ -90,21 +132,36 @@ function unwrap(payload: unknown): {
   return { params: payload as BinParams };
 }
 
+function buildPayload(d: SavedDesign): DesignSyncPayload {
+  if (isBinDesign(d)) {
+    return {
+      name: d.name,
+      params: d.params,
+      tags: d.tags,
+      publishedId: d.publishedId,
+      lineage: d.lineage,
+    };
+  }
+  return {
+    name: d.name,
+    kind: 'assembly',
+    envelope: d.envelope,
+    structure: d.structure,
+    tags: d.tags,
+    publishedId: d.publishedId,
+    lineage: d.lineage,
+  };
+}
+
 export const designAdapter: DesignAdapter = {
   async list(): Promise<SyncableItem<DesignSyncPayload>[]> {
     const result = await listDesigns();
     if (!isOk(result)) return [];
-    // Cloud sync carries bin params only; non-bin kinds (toolRack,
-    // importedMesh) are local-only and must never upload `params: undefined`.
-    return result.value.filter(isBinDesign).map((d) => ({
+    // Bins and assemblies sync; toolRack and importedMesh (base64 mesh
+    // blobs) stay local-only.
+    return result.value.filter(isSyncableDesign).map((d) => ({
       id: d.id,
-      payload: {
-        name: d.name,
-        params: d.params,
-        tags: d.tags,
-        publishedId: d.publishedId,
-        lineage: d.lineage,
-      },
+      payload: buildPayload(d),
       modifiedAt: toMs(d.updatedAt),
     }));
   },
@@ -113,18 +170,12 @@ export const designAdapter: DesignAdapter = {
     const result = await loadDesign(designId(id));
     if (!isOk(result)) return null;
     const d = result.value;
-    // Non-bin kinds are local-only: returning null makes the engine drop the
-    // outbox entry as a no-op (it never tombstones on a null get).
-    if (!isBinDesign(d)) return null;
+    // Non-syncable kinds: returning null makes the engine drop the outbox
+    // entry as a no-op (it never tombstones on a null get).
+    if (!isSyncableDesign(d)) return null;
     return {
       id: d.id,
-      payload: {
-        name: d.name,
-        params: d.params,
-        tags: d.tags,
-        publishedId: d.publishedId,
-        lineage: d.lineage,
-      },
+      payload: buildPayload(d),
       modifiedAt: toMs(d.updatedAt),
     };
   },
@@ -139,6 +190,9 @@ export const designAdapter: DesignAdapter = {
       const {
         name: remoteName,
         params,
+        kind: remoteKind,
+        envelope: remoteEnvelope,
+        structure: remoteStructure,
         tags: remoteTags,
         publishedId: remotePublishedId,
         lineage: remoteLineage,
@@ -154,16 +208,32 @@ export const designAdapter: DesignAdapter = {
       // other device"), so only `undefined` (legacy payload) falls back.
       const publishedId = remotePublishedId === undefined ? base?.publishedId : remotePublishedId;
       const lineage = remoteLineage === undefined ? base?.lineage : remoteLineage;
-      const result = await saveDesign({
-        id: designId(item.id),
-        name,
-        params,
-        thumbnail: base?.thumbnail ?? null,
-        exportFileNameConfig: base?.exportFileNameConfig ?? null,
-        tags,
-        publishedId,
-        lineage,
-      });
+      const result =
+        remoteKind === 'assembly' && remoteEnvelope
+          ? await saveDesign({
+              id: designId(item.id),
+              name,
+              kind: 'assembly',
+              envelope: remoteEnvelope,
+              // Migration is the gate: a newer client's structure gets its
+              // unknown fields dropped node-by-node rather than rejected.
+              structure: assemblyDescriptor.migrate(remoteStructure, remoteEnvelope),
+              thumbnail: base?.thumbnail ?? null,
+              exportFileNameConfig: base?.exportFileNameConfig ?? null,
+              tags,
+              publishedId,
+              lineage,
+            })
+          : await saveDesign({
+              id: designId(item.id),
+              name,
+              params: params,
+              thumbnail: base?.thumbnail ?? null,
+              exportFileNameConfig: base?.exportFileNameConfig ?? null,
+              tags,
+              publishedId,
+              lineage,
+            });
       if (!isOk(result)) {
         throw new Error(`saveDesign failed for ${item.id}`);
       }

--- a/src/features/bin-designer/sync/designAdapter.ts
+++ b/src/features/bin-designer/sync/designAdapter.ts
@@ -62,6 +62,8 @@ function unwrap(payload: unknown): {
   tags?: string[];
   publishedId?: string | null;
   lineage?: CommunityDesignLineage | null;
+  /** A kind-wrapped payload this client cannot represent — do not apply. */
+  invalid?: true;
 } {
   if (payload !== null && typeof payload === 'object' && 'kind' in payload) {
     const wrapper = payload as {
@@ -99,6 +101,10 @@ function unwrap(payload: unknown): {
               : undefined,
       };
     }
+    // Any other kind-wrapped payload (a future kind, or an assembly wrapper
+    // missing its envelope/structure) must not fall through to the bare
+    // BinParams path — that would persist a corrupted bin row.
+    return { invalid: true };
   }
   if (payload !== null && typeof payload === 'object' && 'params' in payload) {
     const { name, params, tags, publishedId, lineage } = payload as {
@@ -196,7 +202,9 @@ export const designAdapter: DesignAdapter = {
         tags: remoteTags,
         publishedId: remotePublishedId,
         lineage: remoteLineage,
+        invalid,
       } = unwrap(item.payload);
+      if (invalid) return;
       // LWW: engine only calls applyRemote when remote is newer, so a
       // remote rename must win. Local name is only a fallback for legacy
       // payloads with no name; the literal covers a legacy fresh-device pull.

--- a/src/features/bin-designer/utils/designKind.test.ts
+++ b/src/features/bin-designer/utils/designKind.test.ts
@@ -50,6 +50,36 @@ describe('designFootprint', () => {
     expect(designFootprint(design)).toEqual({ width: 2, depth: 1, height: 3 });
   });
 
+  it('derives assembly height from the tallest placed part', () => {
+    const design = {
+      id: 'w',
+      name: 'W',
+      kind: 'assembly',
+      thumbnail: null,
+      exportFileNameConfig: null,
+      createdAt: '',
+      updatedAt: '',
+      envelope: { width: 4, depth: 2, gridUnitMm: 42, heightUnitMm: 7 },
+      structure: {
+        kind: 'assembly',
+        schemaVersion: 1,
+        base: { floorThickness: 2 },
+        mirrorAxis: 'x',
+        parts: [
+          {
+            id: 'p',
+            type: 'post',
+            params: { diameter: 8, height: 40, taperDeg: 0, tipChamfer: 1 },
+            transform: { x: 20, y: 20, seatZ: 0, rotZDeg: 0 },
+            children: [],
+          },
+        ],
+      },
+    } as unknown as Parameters<typeof designFootprint>[0];
+    // 40mm post + 5mm socket + 2mm floor = 47mm -> ceil(47/7) = 7 units.
+    expect(designFootprint(design)).toEqual({ width: 4, depth: 2, height: 7 });
+  });
+
   it('keeps height 0 for non-bin kinds without a claimed height', () => {
     const design: SavedDesign = {
       ...baseDesign(),

--- a/src/features/bin-designer/utils/designKind.ts
+++ b/src/features/bin-designer/utils/designKind.ts
@@ -3,10 +3,25 @@
  * carry flat `params`; non-bin kinds carry `envelope` + `structure`.
  */
 import type { BinParams, SavedDesign } from '../types';
+import { assemblyHeightUnits } from '@/shared/types/assemblyPlacement';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 
 /** True when the design is a bin (has flat `params`). */
 export function isBinDesign(design: SavedDesign): design is SavedDesign & { params: BinParams } {
   return (design.kind ?? 'bin') === 'bin' && design.params !== undefined;
+}
+
+/**
+ * Kinds cloud sync carries: bins and Workshop assemblies (small JSON).
+ * Imported meshes stay local — their structure embeds a base64 mesh blob.
+ */
+export function isSyncableDesign(design: SavedDesign): boolean {
+  return (
+    isBinDesign(design) ||
+    (design.kind === 'assembly' &&
+      design.envelope !== undefined &&
+      design.structure?.kind === 'assembly')
+  );
 }
 
 /** Kinds that can stand on the layout grid as a bin: parametric bins and
@@ -28,7 +43,17 @@ export function designFootprint(design: SavedDesign): DesignFootprint {
     return { width: design.params.width, depth: design.params.depth, height: design.params.height };
   }
   if (design.envelope) {
-    const height = design.structure?.kind === 'importedMesh' ? design.structure.heightUnits : 0;
+    const structure = design.structure;
+    const height =
+      structure?.kind === 'importedMesh'
+        ? structure.heightUnits
+        : structure?.kind === 'assembly'
+          ? assemblyHeightUnits(
+              structure,
+              design.envelope.heightUnitMm,
+              GRIDFINITY_SPEC.SOCKET_HEIGHT + structure.base.floorThickness
+            )
+          : 0;
     return { width: design.envelope.width, depth: design.envelope.depth, height };
   }
   return { width: 0, depth: 0, height: 0 };

--- a/src/features/labs/README.md
+++ b/src/features/labs/README.md
@@ -38,7 +38,7 @@ Internal status enum values → UI badge labels: `experimental` → "Early acces
 | `item_kinds`            | `experimental`  | Non-bin items (tool racks) that sit on a baseplate                                            |
 | `community_fits_gap`    | `experimental`  | Select a layout gap and browse community designs that fit it                                  |
 | `sliding_tray`          | `experimental`  | Rail-and-tray sliding insert in the bin designer's Walls section                              |
-| `workshop`              | `experimental`  | Part-based Workshop builder: proxy 3D editor for assemblies                                   |
+| `workshop`              | `experimental`  | Part-based Workshop builder: 3D editor, exact export, library sync                            |
 | `community_showcase`    | `preview`       | Publish and remix bin designs in the community showcase                                       |
 | `drawer_shapes`         | `graduated`     | Non-rectangular drawer shapes (L-shapes, notches, cut corners)                                |
 | `bin_designer`          | `graduated`     | Custom bin designer                                                                           |

--- a/src/shared/types/assemblyPlacement.ts
+++ b/src/shared/types/assemblyPlacement.ts
@@ -196,3 +196,17 @@ export function resolvePlacedParts(
   walk(structure.parts, { x: 0, y: 0, rotZDeg: 0, topZ: 0 }, null, 1, '', { mx: 1, my: 1 });
   return placed;
 }
+
+/**
+ * Overall build height in Gridfinity height units (7mm), socket and floor
+ * included — the framing/footprint number a library row reports.
+ */
+export function assemblyHeightUnits(
+  structure: AssemblyStructure,
+  heightUnitMm: number,
+  socketAndFloorMm: number
+): number {
+  const placed = resolvePlacedParts(structure);
+  const maxTop = placed.reduce((max, p) => Math.max(max, p.topZ), 0);
+  return Math.max(1, Math.ceil((maxTop + socketAndFloorMm) / heightUnitMm));
+}


### PR DESCRIPTION
Phase 7 of the Workshop plan: assemblies become full library citizens, and the schema is now effectively frozen (old clients will read what new clients write; `schemaVersion` + descriptor migration cover everything after).

## What's in

**Autosave with a real first-save.** A fresh assembly has no record at all, so `useWorkshopAutoSave` owns the whole lifecycle: it creates the design when the first part lands (adopting the new id only if the user is still on that build), then persists structure/envelope edits debounced with the load→spread→save merge so createdAt, tags, and lineage survive. The thumbnail refreshes from the live scene whenever a save lands while the sharp mesh is up — the Workshop canvas now registers itself with the thumbnail pipeline the way the bin preview does. `useAutoSave` and `useThumbnailCapture` gain explicit bin-only gates, closing a latent path where an unmount could flush stale bin params onto a non-bin row.

**Cloud sync.** `DesignSyncPayload` gains optional `kind`/`envelope`/`structure`; the adapter syncs bins and assemblies while tool racks and imported meshes (base64 mesh blobs) stay local. On a remote apply the assembly structure passes through the descriptor's salvage migration, so a newer client's unknown fields drop node-by-node instead of rejecting the design.

**Server mirror.** `api/lib/assemblyValidation.ts` hand-mirrors the client schema (api/ cannot import src/): every part type's ranges, all six cutter profile variants, transforms, arrays, and the hard caps (256 nodes, depth 8, path/outline point limits) via an iterative traversal. The sync endpoint branches on `kind: 'assembly'` before the bin params validator, with the 100KB size cap.

**Library polish**: list rows derive the assembly's height from its tallest placed part (socket and floor included), and Download JSON hides for designs that have no params instead of silently no-oping.

**Verified live**: built from a template, full page reload restored the build, the Saved Designs card shows the render thumbnail and `4×2×6u` footprint, and reopening loads the tree.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

