### PR TITLE
feat(workshop): migrate tool racks into Workshop and retire item_kinds

### DIFF
--- a/api/lib/assemblyValidation.ts
+++ b/api/lib/assemblyValidation.ts
@@ -122,7 +122,10 @@ function validParams(type: string, params: unknown): boolean {
         num(params.length, 4, 400) &&
         num(params.thickness, 0.8, 20) &&
         num(params.height, 4, 200) &&
-        num(params.leanDeg, 0, 45)
+        num(params.leanDeg, 0, 45) &&
+        (params.leanAxis === undefined ||
+          params.leanAxis === 'thickness' ||
+          params.leanAxis === 'length')
       );
     case 'block':
       return (

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -142,18 +142,7 @@ export const FEATURE_FLAGS = [
     graduatedAt: '2026-06',
     requiresRefresh: false,
   },
-  {
-    id: 'item_kinds',
-    name: 'Non-bin items',
-    description:
-      'Design things beyond bins that sit on a Gridfinity baseplate — like an angled tool rack for pliers and tweezers. More item types coming.',
-    status: 'experimental',
-    risk: 'medium',
-    warning:
-      'Early feature. Tool racks export from their own panel but are not auto-saved, shareable, or placeable in drawer layouts yet.',
-    addedAt: '2026-06',
-    requiresRefresh: false,
-  },
+  // item_kinds removed — tool racks migrated into Workshop assemblies (workshop flag)
   {
     id: 'stl_bin_import',
     name: 'Import STL as Bin',

--- a/src/core/storage/localStorageMigrations.ts
+++ b/src/core/storage/localStorageMigrations.ts
@@ -7,7 +7,7 @@ import { openLayoutDatabase, saveMlData, saveSharedWithMeEntries } from './backe
 import { useSettingsStore } from '@/core/store/settings';
 import type { SharedWithMeEntry } from '@/core/types';
 
-function isMigrationDone(key: string): boolean {
+export function isMigrationDone(key: string): boolean {
   try {
     return localStorage.getItem(key) === 'true';
   } catch {
@@ -15,7 +15,7 @@ function isMigrationDone(key: string): boolean {
   }
 }
 
-function setMigrationDone(key: string): void {
+export function setMigrationDone(key: string): void {
   try {
     localStorage.setItem(key, 'true');
   } catch {

--- a/src/core/store/labs.ts
+++ b/src/core/store/labs.ts
@@ -29,6 +29,7 @@ function loadPreferences(): LabsPreferences {
     // Clean up orphaned keys from removed labs features
     delete prefs.enabledFeatures.handle_ledges;
     delete prefs.enabledFeatures.angled_dividers;
+    delete prefs.enabledFeatures.item_kinds;
 
     return prefs;
   }

--- a/src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
+++ b/src/features/bin-designer/components/DesignerPage/DesignerPage.tsx
@@ -18,6 +18,7 @@ import { useCreateFromBin } from '@/features/bin-designer/hooks/useCreateFromBin
 import { useAutoSave } from '@/features/bin-designer/hooks/useAutoSave';
 import { useImportedDesignAutoSave } from '@/features/bin-designer/hooks/useImportedDesignAutoSave';
 import { useWorkshopAutoSave } from '@/features/bin-designer/hooks/useWorkshopAutoSave';
+import { useToolRackMigration } from '@/features/bin-designer/hooks/useToolRackMigration';
 import { useThumbnailCapture } from '@/features/bin-designer/hooks/useThumbnailCapture';
 import { useDesignerUrlSync } from '@/features/bin-designer/hooks/useDesignerUrlSync';
 import { useUnsavedWarning } from '@/features/bin-designer/hooks/useUnsavedWarning';
@@ -65,6 +66,7 @@ export function DesignerPage() {
   // Auto-save for imported-mesh designs (footprint edits + one-time thumbnail)
   useImportedDesignAutoSave();
   useWorkshopAutoSave();
+  useToolRackMigration();
 
   // Capture thumbnail after first mesh generation (for designs created from bins)
   useThumbnailCapture();

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -94,7 +94,6 @@ function BinParameterPanel() {
   const openExampleGallery = useBinExampleGalleryStore((s) => s.open);
   const hasUnseenDigest = useCommunityDigestStore((s) => s.hasUnseenDeltas);
   const cloudSyncEnabled = useFeatureFlag('cloud_sync');
-  const itemKindsEnabled = useFeatureFlag('item_kinds');
   const workshopEnabled = useFeatureFlag('workshop');
   const newDesign = useDesignerStore((s) => s.newDesign);
   const customShapeReason = t('binDesigner.shape.custom.hint');
@@ -315,13 +314,6 @@ function BinParameterPanel() {
           </div>
         </StickyGroupHeader>
 
-        {itemKindsEnabled && (
-          <div className="px-4 py-3 border-b border-stroke-subtle">
-            <Button variant="secondary" onClick={() => newDesign('toolRack')} className="w-full">
-              {t('binDesigner.newToolRack')}
-            </Button>
-          </div>
-        )}
         {workshopEnabled && (
           <div className="px-4 py-3 border-b border-stroke-subtle">
             <Button variant="secondary" onClick={() => newDesign('assembly')} className="w-full">

--- a/src/features/bin-designer/components/Workshop/proxyGeometry.ts
+++ b/src/features/bin-designer/components/Workshop/proxyGeometry.ts
@@ -39,11 +39,19 @@ function buildFin(p: {
   thickness: number;
   height: number;
   leanDeg: number;
+  leanAxis?: 'thickness' | 'length';
 }): BufferGeometry {
   const geometry = new BoxGeometry(p.length, p.thickness, p.height);
   geometry.translate(0, 0, p.height / 2);
   if (p.leanDeg > 0) {
-    geometry.applyMatrix4(new Matrix4().makeShear(0, 0, 0, 0, 0, Math.tan(p.leanDeg * DEG)));
+    const tan = Math.tan(p.leanDeg * DEG);
+    // makeShear slots: zy shears y by z (tip over the long edge); zx shears
+    // x by z (run the lean along the plate's length).
+    const shear =
+      p.leanAxis === 'length'
+        ? new Matrix4().makeShear(0, 0, 0, 0, tan, 0)
+        : new Matrix4().makeShear(0, 0, 0, 0, 0, tan);
+    geometry.applyMatrix4(shear);
   }
   return geometry;
 }

--- a/src/features/bin-designer/hooks/useToolRackMigration.test.ts
+++ b/src/features/bin-designer/hooks/useToolRackMigration.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ok } from '@/core/result';
+import { designId } from '@/core/types';
+
+const listDesignsMock = vi.fn();
+const saveDesignMock = vi.fn();
+
+vi.mock('@/features/bin-designer/storage/DesignerStorage', () => ({
+  listDesigns: () => listDesignsMock(),
+  saveDesign: (input: unknown) => saveDesignMock(input),
+}));
+
+import { useToolRackMigration } from './useToolRackMigration';
+
+const rackDesign = {
+  id: designId('design_1_rack01'),
+  name: 'My rack',
+  kind: 'toolRack',
+  thumbnail: null,
+  exportFileNameConfig: null,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+  envelope: {
+    width: 4,
+    depth: 2,
+    gridUnitMm: 42,
+    heightUnitMm: 7,
+    attachment: {
+      magnetHoles: false,
+      magnetDiameter: 6.5,
+      magnetDepth: 2.4,
+      screwHoles: false,
+      screwDiameter: 3,
+    },
+    featureColors: { enabled: false },
+  },
+  structure: {
+    kind: 'toolRack',
+    floorThickness: 2,
+    finAngleDeg: 20,
+    finThickness: 3,
+    finHeight: 25,
+    finCount: 6,
+    slotPitch: 16,
+    slotInsetMm: 8,
+    backRail: { enabled: true, height: 10, thickness: 3 },
+  },
+};
+
+describe('useToolRackMigration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('converts saved racks to assemblies, keeping id and name', async () => {
+    listDesignsMock.mockResolvedValueOnce(ok([rackDesign]));
+    saveDesignMock.mockResolvedValueOnce(ok({ ...rackDesign, kind: 'assembly' }));
+    renderHook(() => useToolRackMigration());
+    await waitFor(() => expect(saveDesignMock).toHaveBeenCalledTimes(1));
+    const saved = saveDesignMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(saved.id).toBe(rackDesign.id);
+    expect(saved.name).toBe('My rack');
+    expect(saved.kind).toBe('assembly');
+    expect((saved.structure as { kind: string }).kind).toBe('assembly');
+  });
+
+  it('leaves bins, assemblies, and imported meshes untouched', async () => {
+    listDesignsMock.mockResolvedValueOnce(
+      ok([
+        { ...rackDesign, id: designId('design_1_bin111'), kind: undefined, params: {} },
+        { ...rackDesign, id: designId('design_1_asm111'), kind: 'assembly' },
+        { ...rackDesign, id: designId('design_1_mesh11'), kind: 'importedMesh' },
+      ])
+    );
+    renderHook(() => useToolRackMigration());
+    await waitFor(() => expect(listDesignsMock).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(saveDesignMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/hooks/useToolRackMigration.test.ts
+++ b/src/features/bin-designer/hooks/useToolRackMigration.test.ts
@@ -51,6 +51,7 @@ const rackDesign = {
 describe('useToolRackMigration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it('converts saved racks to assemblies, keeping id and name', async () => {

--- a/src/features/bin-designer/hooks/useToolRackMigration.ts
+++ b/src/features/bin-designer/hooks/useToolRackMigration.ts
@@ -1,0 +1,33 @@
+/**
+ * One-time storage pass converting saved tool racks into Workshop
+ * assemblies. Runs once per designer mount; idempotent because a converted
+ * row's kind is 'assembly', so subsequent scans find nothing. The original
+ * row keeps its id, name, thumbnail, and tags — only kind and geometry
+ * change, so layout references and sync lineage survive.
+ */
+import { useEffect, useRef } from 'react';
+import { isOk } from '@/core/result';
+import { listDesigns, saveDesign } from '@/features/bin-designer/storage/DesignerStorage';
+import { convertToolRackToAssembly } from '@/features/bin-designer/utils/workshopTemplates';
+
+export function useToolRackMigration(): void {
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+    void (async () => {
+      const designs = await listDesigns();
+      if (!isOk(designs)) return;
+      for (const design of designs.value) {
+        if (design.kind !== 'toolRack') continue;
+        if (!design.envelope || design.structure?.kind !== 'toolRack') continue;
+        await saveDesign({
+          ...design,
+          kind: 'assembly',
+          structure: convertToolRackToAssembly(design.structure, design.envelope),
+        });
+      }
+    })();
+  }, []);
+}

--- a/src/features/bin-designer/hooks/useToolRackMigration.ts
+++ b/src/features/bin-designer/hooks/useToolRackMigration.ts
@@ -7,14 +7,17 @@
  */
 import { useEffect, useRef } from 'react';
 import { isOk } from '@/core/result';
+import { isMigrationDone, setMigrationDone } from '@/core/storage/localStorageMigrations';
 import { listDesigns, saveDesign } from '@/features/bin-designer/storage/DesignerStorage';
 import { convertToolRackToAssembly } from '@/features/bin-designer/utils/workshopTemplates';
+
+const MIGRATION_KEY = 'workshop-toolrack-migration-v1';
 
 export function useToolRackMigration(): void {
   const ranRef = useRef(false);
 
   useEffect(() => {
-    if (ranRef.current) return;
+    if (ranRef.current || isMigrationDone(MIGRATION_KEY)) return;
     ranRef.current = true;
     void (async () => {
       const designs = await listDesigns();
@@ -28,6 +31,9 @@ export function useToolRackMigration(): void {
           structure: convertToolRackToAssembly(design.structure, design.envelope),
         });
       }
+      // Marked only after a full successful scan; a thrown save leaves the
+      // flag unset so the next visit retries.
+      setMigrationDone(MIGRATION_KEY);
     })();
   }, []);
 }

--- a/src/features/bin-designer/utils/assemblyChecker.test.ts
+++ b/src/features/bin-designer/utils/assemblyChecker.test.ts
@@ -105,6 +105,33 @@ describe('checkAssembly', () => {
     expect(kinds([part('block', 'b', { x: 2, y: 42 })])).toEqual(['b:outsideBase']);
   });
 
+  it('does not flag a rotated long part whose real extent fits the base', () => {
+    // A depth-spanning fin at x=8: unrotated its 80mm length would poke
+    // out; rotated 90° only its 3mm thickness lies along X.
+    const fin = part(
+      'fin',
+      'f',
+      { x: 8, y: 42, rotZDeg: 90 },
+      {
+        params: { length: 80, thickness: 3, height: 25, leanDeg: 20, leanAxis: 'length' },
+      }
+    );
+    expect(kinds([fin])).toEqual([]);
+  });
+
+  it('flags array copies that march off their parent', () => {
+    const arrayedPost = part(
+      'post',
+      'p',
+      { x: 0, y: 0 },
+      {
+        array: { count: 3, dx: 20, dy: 0 },
+      }
+    );
+    const block = part('block', 'b', {}, { children: [arrayedPost] });
+    expect(kinds([block])).toEqual(['p:unsupported']);
+  });
+
   it('reports an array or mirror twin once per part and rule', () => {
     const post = part('post', 'p', { seatZ: 10 }, { array: { count: 4, dx: 20, dy: 0 } });
     expect(kinds([post])).toEqual(['p:floating']);

--- a/src/features/bin-designer/utils/assemblyChecker.ts
+++ b/src/features/bin-designer/utils/assemblyChecker.ts
@@ -6,7 +6,7 @@
 import type { AssemblyStructure } from '@/shared/types/assembly';
 import type { PlacedPart } from '@/shared/types/assemblyPlacement';
 import type { ItemEnvelope } from '@/shared/types/item';
-import { partFootprint, resolvePlacedParts } from '@/shared/types/assemblyPlacement';
+import { partFootprint, resolvePlacedParts, rotate2d } from '@/shared/types/assemblyPlacement';
 
 export type AssemblyWarningKind =
   'floating' | 'unsupported' | 'overhang' | 'socketBreach' | 'outsideBase';
@@ -37,10 +37,13 @@ export function checkAssembly(
     d: envelope.depth * envelope.gridUnitMm,
   };
   const placed = resolvePlacedParts(structure, extent);
-  const byId = new Map<string, PlacedPart>();
-  for (const p of placed) {
-    if (!byId.has(p.selectId)) byId.set(p.selectId, p);
-  }
+  const byKey = new Map<string, PlacedPart>();
+  for (const p of placed) byKey.set(p.key, p);
+  const parentInstanceOf = (p: PlacedPart): PlacedPart | null => {
+    const slash = p.key.lastIndexOf('/');
+    if (slash === -1) return null;
+    return byKey.get(p.key.slice(0, slash)) ?? null;
+  };
 
   const warnings: AssemblyWarning[] = [];
   const flagged = new Set<string>();
@@ -60,11 +63,14 @@ export function checkAssembly(
     }
 
     // Unsupported: seated on a parent but anchored outside its top face.
+    // Compared per expanded INSTANCE in the parent's frame, so array copies
+    // marching off their parent are caught too.
     if (node.type !== 'cutter' && p.parentId !== null) {
-      const parent = byId.get(p.parentId);
+      const parent = parentInstanceOf(p);
       if (parent) {
-        const half = partFootprint(parent.node);
-        if (Math.abs(node.transform.x) > half.w / 2 || Math.abs(node.transform.y) > half.d / 2) {
+        const parentHalf = partFootprint(parent.node);
+        const local = rotate2d(p.x - parent.x, p.y - parent.y, -parent.rotZDeg);
+        if (Math.abs(local.x) > parentHalf.w / 2 || Math.abs(local.y) > parentHalf.d / 2) {
           flag(p.selectId, 'unsupported');
         }
       }
@@ -86,14 +92,20 @@ export function checkAssembly(
       flag(p.selectId, 'socketBreach');
     }
 
-    // Off the base: material past the plate edge prints in mid-air.
+    // Off the base: material past the plate edge prints in mid-air. The
+    // footprint is local-frame, so rotate it into a world-axis bound first.
     if (node.type !== 'cutter') {
       const half = partFootprint(node);
+      const rad = (p.rotZDeg * Math.PI) / 180;
+      const cos = Math.abs(Math.cos(rad));
+      const sin = Math.abs(Math.sin(rad));
+      const halfW = (cos * half.w + sin * half.d) / 2;
+      const halfD = (sin * half.w + cos * half.d) / 2;
       if (
-        p.x - half.w / 2 < -0.05 ||
-        p.x + half.w / 2 > extent.w + 0.05 ||
-        p.y - half.d / 2 < -0.05 ||
-        p.y + half.d / 2 > extent.d + 0.05
+        p.x - halfW < -0.05 ||
+        p.x + halfW > extent.w + 0.05 ||
+        p.y - halfD < -0.05 ||
+        p.y + halfD > extent.d + 0.05
       ) {
         flag(p.selectId, 'outsideBase');
       }

--- a/src/features/bin-designer/utils/workshopTemplates.test.ts
+++ b/src/features/bin-designer/utils/workshopTemplates.test.ts
@@ -3,7 +3,11 @@ import { assemblySchema, DEFAULT_ASSEMBLY_STRUCTURE } from '@/shared/items/assem
 import { createDefaultEnvelope } from '@/shared/items/defaultEnvelope';
 import type { FeatureColorConfig } from '@/shared/types/bin';
 import { resolvePlacedParts } from '@/shared/types/assemblyPlacement';
-import { buildWorkshopTemplate, WORKSHOP_TEMPLATE_IDS } from './workshopTemplates';
+import {
+  buildWorkshopTemplate,
+  convertToolRackToAssembly,
+  WORKSHOP_TEMPLATE_IDS,
+} from './workshopTemplates';
 
 const envelope = createDefaultEnvelope({ enabled: false } as FeatureColorConfig);
 
@@ -32,6 +36,45 @@ describe('buildWorkshopTemplate', () => {
     const block = parts[0];
     expect(block?.children[0]?.type).toBe('cutter');
     expect(block?.children[0]?.array?.count).toBeGreaterThanOrEqual(2);
+  });
+
+  it('converts a tool rack into a schema-valid assembly with matching layout', () => {
+    const rack = {
+      kind: 'toolRack' as const,
+      floorThickness: 2,
+      finAngleDeg: 20,
+      finThickness: 3,
+      finHeight: 25,
+      finCount: 6,
+      slotPitch: 16,
+      slotInsetMm: 8,
+      backRail: { enabled: true, height: 10, thickness: 3 },
+    };
+    const converted = convertToolRackToAssembly(rack, envelope);
+    expect(assemblySchema.safeParse(converted).success).toBe(true);
+    expect(converted.base.floorThickness).toBe(2);
+    const fin = converted.parts.find((n) => n.type === 'fin');
+    expect(fin?.array?.count).toBe(6);
+    expect(fin?.type === 'fin' && fin.params.leanDeg).toBe(20);
+    const rail = converted.parts.find((n) => n.type === 'block');
+    expect(rail?.type === 'block' && rail.params.height).toBe(10);
+  });
+
+  it('derives fin count from pitch when the rack omitted it', () => {
+    const rack = {
+      kind: 'toolRack' as const,
+      floorThickness: 2,
+      finAngleDeg: 15,
+      finThickness: 3,
+      finHeight: 25,
+      slotPitch: 16,
+      slotInsetMm: 8,
+      backRail: { enabled: false, height: 10, thickness: 3 },
+    };
+    const converted = convertToolRackToAssembly(rack, envelope);
+    // 4x42=168mm wide, 8mm insets: floor((168-16)/16)+1 = 10 fins.
+    expect(converted.parts[0]?.array?.count).toBe(10);
+    expect(converted.parts).toHaveLength(1);
   });
 
   it('returns fresh ids per build', () => {

--- a/src/features/bin-designer/utils/workshopTemplates.test.ts
+++ b/src/features/bin-designer/utils/workshopTemplates.test.ts
@@ -56,6 +56,9 @@ describe('buildWorkshopTemplate', () => {
     const fin = converted.parts.find((n) => n.type === 'fin');
     expect(fin?.array?.count).toBe(6);
     expect(fin?.type === 'fin' && fin.params.leanDeg).toBe(20);
+    // The 90° turn maps the length-axis shear to world +Y — the rack's
+    // back-lean; a thickness-axis lean would tip fins sideways.
+    expect(fin?.type === 'fin' && fin.params.leanAxis).toBe('length');
     const rail = converted.parts.find((n) => n.type === 'block');
     expect(rail?.type === 'block' && rail.params.height).toBe(10);
     expect(rail?.transform.y).toBe(84 - 1.5);
@@ -63,6 +66,24 @@ describe('buildWorkshopTemplate', () => {
     const convertedFin = converted.parts.find((n) => n.type === 'fin');
     expect(convertedFin?.transform.y).toBe(42);
     expect(convertedFin?.type === 'fin' && convertedFin.params.length).toBe(84);
+  });
+
+  it('clamps a sub-schema rail into a valid block instead of losing it', () => {
+    const rack = {
+      kind: 'toolRack' as const,
+      floorThickness: 2,
+      finAngleDeg: 20,
+      finThickness: 3,
+      finHeight: 25,
+      finCount: 4,
+      slotInsetMm: 8,
+      backRail: { enabled: true, height: 0.5, thickness: 0.6 },
+    };
+    const converted = convertToolRackToAssembly(rack, envelope);
+    expect(assemblySchema.safeParse(converted).success).toBe(true);
+    const rail = converted.parts.find((n) => n.type === 'block');
+    expect(rail?.type === 'block' && rail.params.depth).toBe(2);
+    expect(rail?.type === 'block' && rail.params.height).toBe(1);
   });
 
   it('derives fin count from pitch when the rack omitted it', () => {

--- a/src/features/bin-designer/utils/workshopTemplates.test.ts
+++ b/src/features/bin-designer/utils/workshopTemplates.test.ts
@@ -58,6 +58,11 @@ describe('buildWorkshopTemplate', () => {
     expect(fin?.type === 'fin' && fin.params.leanDeg).toBe(20);
     const rail = converted.parts.find((n) => n.type === 'block');
     expect(rail?.type === 'block' && rail.params.height).toBe(10);
+    expect(rail?.transform.y).toBe(84 - 1.5);
+    expect(rail?.type === 'block' && rail.params.width).toBe(168);
+    const convertedFin = converted.parts.find((n) => n.type === 'fin');
+    expect(convertedFin?.transform.y).toBe(42);
+    expect(convertedFin?.type === 'fin' && convertedFin.params.length).toBe(84);
   });
 
   it('derives fin count from pitch when the rack omitted it', () => {
@@ -72,8 +77,9 @@ describe('buildWorkshopTemplate', () => {
       backRail: { enabled: false, height: 10, thickness: 3 },
     };
     const converted = convertToolRackToAssembly(rack, envelope);
-    // 4x42=168mm wide, 8mm insets: floor((168-16)/16)+1 = 10 fins.
-    expect(converted.parts[0]?.array?.count).toBe(10);
+    // 4x42=168mm wide, 8mm insets: round((168-16)/16)+1 = 11 fins — the
+    // rack generator's own derivation.
+    expect(converted.parts[0]?.array?.count).toBe(11);
     expect(converted.parts).toHaveLength(1);
   });
 

--- a/src/features/bin-designer/utils/workshopTemplates.ts
+++ b/src/features/bin-designer/utils/workshopTemplates.ts
@@ -126,18 +126,20 @@ export function convertToolRackToAssembly(
   const w = envelope.width * envelope.gridUnitMm;
   const d = envelope.depth * envelope.gridUnitMm;
   const pitch = rack.slotPitch ?? 16;
-  const count = Math.max(
-    2,
-    Math.min(64, rack.finCount ?? Math.floor((w - 2 * rack.slotInsetMm) / pitch) + 1)
-  );
-  const spacing = count > 1 ? (w - 2 * rack.slotInsetMm) / (count - 1) : 0;
+  const usableW = w - 2 * rack.slotInsetMm;
+  // Same derivation as the rack generator's resolveFins: finCount wins,
+  // otherwise round(usable / pitch) + 1, spacing spread across the usable run.
+  const count = Math.max(2, Math.min(64, rack.finCount ?? Math.round(usableW / pitch) + 1));
+  const spacing = count > 1 ? usableW / (count - 1) : 0;
 
   const parts: AssemblyPartNode[] = [];
 
   if (rack.backRail.enabled) {
+    // Flush to the back edge, full footprint width — the rack generator's
+    // placement, so a migrated rack keeps its exact outline.
     const rail = createAssemblyPartNode('block', crypto.randomUUID(), {
       x: w / 2,
-      y: d - rack.backRail.thickness / 2 - 1,
+      y: d - rack.backRail.thickness / 2,
       seatZ: 0,
       rotZDeg: 0,
     });
@@ -145,7 +147,7 @@ export function convertToolRackToAssembly(
       ...rail,
       params: {
         ...rail.params,
-        width: Math.min(w - 2, 400),
+        width: Math.min(w, 400),
         depth: rack.backRail.thickness,
         height: rack.backRail.height,
         wedgeAngleDeg: 0,
@@ -153,11 +155,11 @@ export function convertToolRackToAssembly(
     });
   }
 
-  const railDepth = rack.backRail.enabled ? rack.backRail.thickness + 2 : 0;
-  const finLength = Math.max(12, Math.min(d - railDepth - 6, 400));
+  // Fins span the full depth and fuse into the rail, as in the generator.
+  const finLength = Math.max(12, Math.min(d, 400));
   const fin = createAssemblyPartNode('fin', crypto.randomUUID(), {
     x: rack.slotInsetMm,
-    y: (d - railDepth) / 2,
+    y: d / 2,
     seatZ: 0,
     rotZDeg: 90,
   });

--- a/src/features/bin-designer/utils/workshopTemplates.ts
+++ b/src/features/bin-designer/utils/workshopTemplates.ts
@@ -6,7 +6,11 @@
  */
 import type { AssemblyPartNode, AssemblyStructure } from '@/shared/types/assembly';
 import type { ItemEnvelope, ToolRackStructure } from '@/shared/types/item';
-import { createAssemblyPartNode, defaultCutterProfile } from '@/shared/items/assembly/descriptor';
+import {
+  clampPartTransform,
+  createAssemblyPartNode,
+  defaultCutterProfile,
+} from '@/shared/items/assembly/descriptor';
 
 export type WorkshopTemplateId = 'pliersRack' | 'screwdriverBlock';
 
@@ -136,33 +140,46 @@ export function convertToolRackToAssembly(
 
   if (rack.backRail.enabled) {
     // Flush to the back edge, full footprint width — the rack generator's
-    // placement, so a migrated rack keeps its exact outline.
-    const rail = createAssemblyPartNode('block', crypto.randomUUID(), {
-      x: w / 2,
-      y: d - rack.backRail.thickness / 2,
-      seatZ: 0,
-      rotZDeg: 0,
-    });
+    // placement, so a migrated rack keeps its exact outline. Rail values are
+    // clamped into the block schema (rack rails could be thinner/shorter
+    // than a block allows); an unclamped value would make migration drop
+    // the rail entirely on the next load.
+    const rail = createAssemblyPartNode(
+      'block',
+      crypto.randomUUID(),
+      clampPartTransform({
+        x: w / 2,
+        y: d - rack.backRail.thickness / 2,
+        seatZ: 0,
+        rotZDeg: 0,
+      })
+    );
     parts.push({
       ...rail,
       params: {
         ...rail.params,
-        width: Math.min(w, 400),
-        depth: rack.backRail.thickness,
-        height: rack.backRail.height,
+        width: Math.min(Math.max(w, 2), 400),
+        depth: Math.min(Math.max(rack.backRail.thickness, 2), 400),
+        height: Math.min(Math.max(rack.backRail.height, 1), 200),
         wedgeAngleDeg: 0,
       },
     });
   }
 
   // Fins span the full depth and fuse into the rail, as in the generator.
+  // leanAxis 'length' + the 90° turn reproduces the rack's back-lean: the
+  // shear runs along the plate (local +X), which the rotation maps to +Y.
   const finLength = Math.max(12, Math.min(d, 400));
-  const fin = createAssemblyPartNode('fin', crypto.randomUUID(), {
-    x: rack.slotInsetMm,
-    y: d / 2,
-    seatZ: 0,
-    rotZDeg: 90,
-  });
+  const fin = createAssemblyPartNode(
+    'fin',
+    crypto.randomUUID(),
+    clampPartTransform({
+      x: rack.slotInsetMm,
+      y: d / 2,
+      seatZ: 0,
+      rotZDeg: 90,
+    })
+  );
   parts.push({
     ...fin,
     params: {
@@ -171,6 +188,7 @@ export function convertToolRackToAssembly(
       thickness: Math.min(Math.max(rack.finThickness, 0.8), 20),
       height: Math.min(Math.max(rack.finHeight, 4), 200),
       leanDeg: Math.min(Math.max(rack.finAngleDeg, 0), 45),
+      leanAxis: 'length',
     },
     ...(count > 1 ? { array: { count, dx: Math.min(spacing, 500), dy: 0 } } : {}),
   });

--- a/src/features/bin-designer/utils/workshopTemplates.ts
+++ b/src/features/bin-designer/utils/workshopTemplates.ts
@@ -4,8 +4,8 @@
  * template can be applied repeatedly; sizes derive from the envelope, so a
  * 2x1 base gets a smaller rack than a 4x2.
  */
-import type { AssemblyPartNode } from '@/shared/types/assembly';
-import type { ItemEnvelope } from '@/shared/types/item';
+import type { AssemblyPartNode, AssemblyStructure } from '@/shared/types/assembly';
+import type { ItemEnvelope, ToolRackStructure } from '@/shared/types/item';
 import { createAssemblyPartNode, defaultCutterProfile } from '@/shared/items/assembly/descriptor';
 
 export type WorkshopTemplateId = 'pliersRack' | 'screwdriverBlock';
@@ -110,4 +110,79 @@ export function buildWorkshopTemplate(
     case 'screwdriverBlock':
       return screwdriverBlock(envelope);
   }
+}
+
+/**
+ * Convert a saved slanted tool rack into an equivalent Workshop build:
+ * the back rail becomes a block, the fin row becomes one fin node with a
+ * linear array (same count/pitch derivation the rack generator used), and
+ * the floor carries over on the base. Geometry matches the rack's layout —
+ * fins are depth-running plates arrayed across the width, leaning back.
+ */
+export function convertToolRackToAssembly(
+  rack: ToolRackStructure,
+  envelope: ItemEnvelope
+): AssemblyStructure {
+  const w = envelope.width * envelope.gridUnitMm;
+  const d = envelope.depth * envelope.gridUnitMm;
+  const pitch = rack.slotPitch ?? 16;
+  const count = Math.max(
+    2,
+    Math.min(64, rack.finCount ?? Math.floor((w - 2 * rack.slotInsetMm) / pitch) + 1)
+  );
+  const spacing = count > 1 ? (w - 2 * rack.slotInsetMm) / (count - 1) : 0;
+
+  const parts: AssemblyPartNode[] = [];
+
+  if (rack.backRail.enabled) {
+    const rail = createAssemblyPartNode('block', crypto.randomUUID(), {
+      x: w / 2,
+      y: d - rack.backRail.thickness / 2 - 1,
+      seatZ: 0,
+      rotZDeg: 0,
+    });
+    parts.push({
+      ...rail,
+      params: {
+        ...rail.params,
+        width: Math.min(w - 2, 400),
+        depth: rack.backRail.thickness,
+        height: rack.backRail.height,
+        wedgeAngleDeg: 0,
+      },
+    });
+  }
+
+  const railDepth = rack.backRail.enabled ? rack.backRail.thickness + 2 : 0;
+  const finLength = Math.max(12, Math.min(d - railDepth - 6, 400));
+  const fin = createAssemblyPartNode('fin', crypto.randomUUID(), {
+    x: rack.slotInsetMm,
+    y: (d - railDepth) / 2,
+    seatZ: 0,
+    rotZDeg: 90,
+  });
+  parts.push({
+    ...fin,
+    params: {
+      ...fin.params,
+      length: finLength,
+      thickness: Math.min(Math.max(rack.finThickness, 0.8), 20),
+      height: Math.min(Math.max(rack.finHeight, 4), 200),
+      leanDeg: Math.min(Math.max(rack.finAngleDeg, 0), 45),
+    },
+    ...(count > 1 ? { array: { count, dx: Math.min(spacing, 500), dy: 0 } } : {}),
+  });
+
+  return {
+    kind: 'assembly',
+    schemaVersion: 1,
+    base: {
+      floorThickness: Math.min(Math.max(rack.floorThickness, 1), 10),
+      ...(rack.cornerRadius !== undefined
+        ? { cornerRadius: Math.min(Math.max(rack.cornerRadius, 0), 20) }
+        : {}),
+    },
+    mirrorAxis: 'x',
+    parts,
+  };
 }

--- a/src/features/generation/worker/generators/assemblyGenerator.ts
+++ b/src/features/generation/worker/generators/assemblyGenerator.ts
@@ -12,6 +12,7 @@
  * bottom-left-origin coordinates are shifted by half the footprint.
  */
 import {
+  applyMatrix,
   box,
   clone,
   cone,
@@ -199,12 +200,28 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
       return cylinder(rBottom, total, { at: [0, 0, -sink] });
     }
     case 'fin': {
-      const { length, thickness, height, leanDeg } = node.params;
-      const dy = Math.tan(leanDeg * DEG) * height;
+      const { length, thickness, height, leanDeg, leanAxis } = node.params;
+      const lean = Math.tan(leanDeg * DEG) * height;
+      if (leanAxis === 'length') {
+        // Shear along the plate's run: build the plain plate and apply the
+        // same x-by-z shear matrix the proxy uses, so both stay identical.
+        const total = height + sink;
+        const plate = box(length, thickness, total, { at: [0, 0, total / 2 - sink] });
+        if (leanDeg <= 0) return plate;
+        const tan = Math.tan(leanDeg * DEG);
+        const sheared = unwrap(
+          applyMatrix(plate, {
+            linear: [1, 0, tan, 0, 1, 0, 0, 0, 1],
+            translation: [0, 0, 0],
+          })
+        );
+        if (sheared !== plate) plate.delete();
+        return sheared;
+      }
       const pen = draw([-thickness / 2, -sink])
         .lineTo([thickness / 2, -sink])
-        .lineTo([thickness / 2 + dy, height])
-        .lineTo([-thickness / 2 + dy, height])
+        .lineTo([thickness / 2 + lean, height])
+        .lineTo([-thickness / 2 + lean, height])
         .close();
       return sketch(pen, 'YZ', -length / 2).extrude(length);
     }

--- a/src/features/labs/README.md
+++ b/src/features/labs/README.md
@@ -35,7 +35,6 @@ Internal status enum values → UI badge labels: `experimental` → "Early acces
 | ----------------------- | --------------- | --------------------------------------------------------------------------------------------- |
 | `brepkit_kernel`        | `experimental`  | Alternative 3D geometry engine (BrepKit) — driven by `EngineSelector`                         |
 | `show_generation_perf`  | `experimental`  | Per-stage generation timing overlay in the bin designer                                       |
-| `item_kinds`            | `experimental`  | Non-bin items (tool racks) that sit on a baseplate                                            |
 | `community_fits_gap`    | `experimental`  | Select a layout gap and browse community designs that fit it                                  |
 | `sliding_tray`          | `experimental`  | Rail-and-tray sliding insert in the bin designer's Walls section                              |
 | `workshop`              | `experimental`  | Part-based Workshop builder: 3D editor, exact export, library sync                            |

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Nový návrh",
   "binDesigner.newDesignConfirm": "Začít nový návrh? Tvůj aktuální návrh je uložen a lze ho později načíst.",
   "binDesigner.newDesignCreated": "Nový návrh vytvořen",
-  "binDesigner.newToolRack": "Nový stojan na nářadí (experimentální)",
   "binDesigner.newWorkshop": "Nová sestava Workshop (experimentální)",
   "binDesigner.noDesignsMatch": "Žádný návrh neodpovídá „{query}“",
   "binDesigner.noSavedDesignsYet": "Zatím žádné uložené návrhy",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Neues Design",
   "binDesigner.newDesignConfirm": "Neues Design starten? Dein aktuelles Design wird gespeichert und kann später geladen werden.",
   "binDesigner.newDesignCreated": "Neues Design erstellt",
-  "binDesigner.newToolRack": "Neuer Werkzeughalter (experimentell)",
   "binDesigner.newWorkshop": "Neuer Workshop-Aufbau (experimentell)",
   "binDesigner.noDesignsMatch": "Keine Designs stimmen mit „{query}\" überein",
   "binDesigner.noSavedDesignsYet": "Noch keine gespeicherten Designs",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2217,7 +2217,6 @@ const en: Record<string, string> = {
   'binDesigner.itemKind.importedMesh.description': 'Bin imported from an STL file',
   'binDesigner.itemKind.assembly': 'Workshop',
   'binDesigner.itemKind.assembly.description': 'Tool holder built from parts on a Gridfinity base',
-  'binDesigner.newToolRack': 'New tool rack (experimental)',
   'binDesigner.newWorkshop': 'New Workshop build (experimental)',
   'workshop.archStyle.bridge': 'Bridge',
   'workshop.archStyle.rod': 'Rod',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Nuevo Diseño",
   "binDesigner.newDesignConfirm": "¿Iniciar un nuevo diseño? Tu diseño actual se guarda y se puede cargar más tarde.",
   "binDesigner.newDesignCreated": "Nuevo diseño creado",
-  "binDesigner.newToolRack": "Nuevo soporte de herramientas (experimental)",
   "binDesigner.newWorkshop": "Nueva construcción de Workshop (experimental)",
   "binDesigner.noDesignsMatch": "Ningún diseño coincide con \"{query}\"",
   "binDesigner.noSavedDesignsYet": "Aún no hay diseños guardados",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Nouveau Design",
   "binDesigner.newDesignConfirm": "Commencer un nouveau design ? Votre design actuel est sauvegardé et peut être chargé ultérieurement.",
   "binDesigner.newDesignCreated": "Nouveau design créé",
-  "binDesigner.newToolRack": "Nouveau porte-outils (expérimental)",
   "binDesigner.newWorkshop": "Nouvelle construction Workshop (expérimental)",
   "binDesigner.noDesignsMatch": "Aucun design ne correspond à « {query} »",
   "binDesigner.noSavedDesignsYet": "Aucun design enregistré",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Nuovo design",
   "binDesigner.newDesignConfirm": "Iniziare un nuovo design? Il design attuale è salvato e può essere caricato in seguito.",
   "binDesigner.newDesignCreated": "Nuovo design creato",
-  "binDesigner.newToolRack": "Nuova rastrelliera (sperimentale)",
   "binDesigner.newWorkshop": "Nuova costruzione Workshop (sperimentale)",
   "binDesigner.noDesignsMatch": "Nessun design corrisponde a \"{query}\"",
   "binDesigner.noSavedDesignsYet": "Ancora nessun design salvato",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "新しいデザイン",
   "binDesigner.newDesignConfirm": "新しいデザインを開始しますか?現在のデザインは保存され、後で読み込み可能です。",
   "binDesigner.newDesignCreated": "新しいデザインを作成しました",
-  "binDesigner.newToolRack": "新しいツールラック（実験的）",
   "binDesigner.newWorkshop": "新しいWorkshopビルド（実験的）",
   "binDesigner.noDesignsMatch": "「{query}」に一致するデザインはありません",
   "binDesigner.noSavedDesignsYet": "保存済みデザインはまだありません",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "새 디자인",
   "binDesigner.newDesignConfirm": "새 디자인을 시작할까요? 현재 디자인은 저장되어 나중에 불러올 수 있습니다.",
   "binDesigner.newDesignCreated": "새 디자인을 만들었습니다",
-  "binDesigner.newToolRack": "새 공구 랙(실험적)",
   "binDesigner.newWorkshop": "새 Workshop 조립(실험적)",
   "binDesigner.noDesignsMatch": "\"{query}\"와(과) 일치하는 디자인이 없습니다",
   "binDesigner.noSavedDesignsYet": "아직 저장된 디자인이 없습니다",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Nytt design",
   "binDesigner.newDesignConfirm": "Starte et nytt design? Det nåværende designet ditt er lagret og kan lastes inn igjen senere.",
   "binDesigner.newDesignCreated": "Nytt design opprettet",
-  "binDesigner.newToolRack": "Nytt verktøystativ (eksperimentelt)",
   "binDesigner.newWorkshop": "Nytt Workshop-bygg (eksperimentelt)",
   "binDesigner.noDesignsMatch": "Ingen design samsvarer med «{query}»",
   "binDesigner.noSavedDesignsYet": "Ingen lagrede design ennå",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Nieuw design",
   "binDesigner.newDesignConfirm": "Een nieuw ontwerp starten? Je huidige ontwerp is opgeslagen en kan later worden geladen.",
   "binDesigner.newDesignCreated": "Nieuw ontwerp aangemaakt",
-  "binDesigner.newToolRack": "Nieuw gereedschapsrek (experimenteel)",
   "binDesigner.newWorkshop": "Nieuwe Workshop-opbouw (experimenteel)",
   "binDesigner.noDesignsMatch": "Geen ontwerpen gevonden voor „{query}\"",
   "binDesigner.noSavedDesignsYet": "Nog geen opgeslagen designs",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Nowy projekt",
   "binDesigner.newDesignConfirm": "Rozpocząć nowy projekt? Twój bieżący projekt jest zapisany i można go później wczytać.",
   "binDesigner.newDesignCreated": "Utworzono nowy projekt",
-  "binDesigner.newToolRack": "Nowy stojak na narzędzia (eksperymentalny)",
   "binDesigner.newWorkshop": "Nowa konstrukcja Workshop (eksperymentalna)",
   "binDesigner.noDesignsMatch": "Żaden projekt nie pasuje do \"{query}\"",
   "binDesigner.noSavedDesignsYet": "Brak zapisanych projektów",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Novo Design",
   "binDesigner.newDesignConfirm": "Iniciar um novo design? Seu design atual está salvo e pode ser carregado mais tarde.",
   "binDesigner.newDesignCreated": "Novo design criado",
-  "binDesigner.newToolRack": "Novo suporte de ferramentas (experimental)",
   "binDesigner.newWorkshop": "Nova montagem do Workshop (experimental)",
   "binDesigner.noDesignsMatch": "Nenhum design corresponde a \"{query}\"",
   "binDesigner.noSavedDesignsYet": "Nenhum design salvo ainda",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Ny design",
   "binDesigner.newDesignConfirm": "Starta en ny design? Din nuvarande design är sparad och kan laddas senare.",
   "binDesigner.newDesignCreated": "Ny design skapad",
-  "binDesigner.newToolRack": "Nytt verktygsställ (experimentellt)",
   "binDesigner.newWorkshop": "Nytt Workshop-bygge (experimentellt)",
   "binDesigner.noDesignsMatch": "Inga designer matchar \"{query}\"",
   "binDesigner.noSavedDesignsYet": "Inga sparade designer ännu",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "Новий дизайн",
   "binDesigner.newDesignConfirm": "Почати новий дизайн? Ваш поточний дизайн збережено й може бути завантажений пізніше.",
   "binDesigner.newDesignCreated": "Створено новий дизайн",
-  "binDesigner.newToolRack": "Новий тримач інструментів (експериментально)",
   "binDesigner.newWorkshop": "Нова збірка Workshop (експериментальна)",
   "binDesigner.noDesignsMatch": "Жоден дизайн не відповідає «{query}»",
   "binDesigner.noSavedDesignsYet": "Збережених дизайнів ще немає",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1322,7 +1322,6 @@
   "binDesigner.newDesign": "新建设计",
   "binDesigner.newDesignConfirm": "开始一个新设计？你当前的设计已保存，稍后可以加载。",
   "binDesigner.newDesignCreated": "已创建新设计",
-  "binDesigner.newToolRack": "新建工具架（实验性）",
   "binDesigner.newWorkshop": "新建Workshop搭建（实验性）",
   "binDesigner.noDesignsMatch": "没有与“{query}”匹配的设计",
   "binDesigner.noSavedDesignsYet": "还没有保存的设计",

--- a/src/shared/items/assembly/descriptor.ts
+++ b/src/shared/items/assembly/descriptor.ts
@@ -46,6 +46,7 @@ const finParamsSchema = z.object({
   thickness: z.number().min(0.8).max(20),
   height: z.number().min(4).max(200),
   leanDeg: z.number().min(0).max(45),
+  leanAxis: z.enum(['thickness', 'length']).optional(),
 });
 
 const blockParamsSchema = z.object({

--- a/src/shared/types/assembly.ts
+++ b/src/shared/types/assembly.ts
@@ -60,6 +60,12 @@ export interface FinParams {
   readonly height: number;
   /** Lean back from vertical in degrees (0..45 for printability). */
   readonly leanDeg: number;
+  /**
+   * Which local axis the lean displaces. 'thickness' (default) tips the
+   * plate over its long bottom edge; 'length' shears along the plate's run —
+   * the tool rack's geometry once its fin row is rotated onto the base.
+   */
+  readonly leanAxis?: 'thickness' | 'length';
 }
 
 export interface BlockParams {


### PR DESCRIPTION
Phase 9 of the Workshop plan: the tool rack's monolithic kind gives way to the compositional system it prototyped.

## What's in

**One-time storage migration.** On designer mount, saved `toolRack` designs convert into equivalent Workshop assemblies: the back rail becomes a block, the fin row becomes one fin node with a linear array (same count/pitch derivation the rack generator used, including deriving count from `slotPitch` when `finCount` was omitted), and the floor and corner radius carry onto the base. The row keeps its id, name, thumbnail, and tags, so layout references and sync lineage survive. Idempotent: converted rows are `assembly`-kind, so later scans find nothing.

**`item_kinds` retires.** The flag entry is removed with the standard tombstone, its orphaned localStorage preference is cleaned in `loadPreferences` (the `handle_ledges` precedent), the 'New tool rack' entry point leaves the bin panel, and the now-unused i18n key is removed across all 15 locales. The rack's descriptor, panel, and generator stay for now as a safety net for any unconverted row mid-session; they can be deleted in a later cleanup once the migration has been out for a release.

Conversion math is unit-tested (schema-valid output, layout parity, pitch-derived counts) and the migration pass is tested for id/name preservation and for leaving bins, assemblies, and imported meshes untouched.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

