### PR TITLE
feat(workshop): tap-to-place touch adaptation

### DIFF
--- a/src/features/bin-designer/components/Workshop/MoveHandle3D.test.tsx
+++ b/src/features/bin-designer/components/Workshop/MoveHandle3D.test.tsx
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { MoveHandle3D } from './MoveHandle3D';
+
+describe('MoveHandle3D', () => {
+  it('exports a function', () => {
+    expect(typeof MoveHandle3D).toBe('function');
+  });
+});

--- a/src/features/bin-designer/components/Workshop/MoveHandle3D.tsx
+++ b/src/features/bin-designer/components/Workshop/MoveHandle3D.tsx
@@ -28,6 +28,7 @@ export function MoveHandle3D({ placed, baseW, baseD, onBeginDrag }: MoveHandle3D
         placed.topZ + HANDLE_LIFT_MM,
       ]}
       onPointerDown={(e) => {
+        if (e.button !== 0 && e.pointerType === 'mouse') return;
         e.stopPropagation();
         onBeginDrag(placed.selectId);
       }}

--- a/src/features/bin-designer/components/Workshop/MoveHandle3D.tsx
+++ b/src/features/bin-designer/components/Workshop/MoveHandle3D.tsx
@@ -28,7 +28,7 @@ export function MoveHandle3D({ placed, baseW, baseD, onBeginDrag }: MoveHandle3D
         placed.topZ + HANDLE_LIFT_MM,
       ]}
       onPointerDown={(e) => {
-        if (e.button !== 0 && e.pointerType === 'mouse') return;
+        if (e.button !== 0) return;
         e.stopPropagation();
         onBeginDrag(placed.selectId);
       }}

--- a/src/features/bin-designer/components/Workshop/MoveHandle3D.tsx
+++ b/src/features/bin-designer/components/Workshop/MoveHandle3D.tsx
@@ -1,0 +1,45 @@
+/**
+ * Touch move handle: a grab disc floating above the selected part. Dragging
+ * it runs the same transactioned move/re-seat machinery as a desktop part
+ * drag, which is what keeps a one-finger drag on the part itself free to
+ * orbit the camera on touch devices.
+ */
+import { useThreeColors } from '@/shared/hooks/useThemeEffect';
+import type { PlacedPart } from './workshopPlacement';
+import { storeToScene } from './workshopPlacement';
+
+const HANDLE_LIFT_MM = 12;
+const HANDLE_RADIUS_MM = 7;
+
+interface MoveHandle3DProps {
+  placed: PlacedPart;
+  baseW: number;
+  baseD: number;
+  onBeginDrag: (id: string) => void;
+}
+
+export function MoveHandle3D({ placed, baseW, baseD, onBeginDrag }: MoveHandle3DProps) {
+  const colors = useThreeColors();
+  return (
+    <mesh
+      position={[
+        storeToScene(placed.x, baseW),
+        storeToScene(placed.y, baseD),
+        placed.topZ + HANDLE_LIFT_MM,
+      ]}
+      onPointerDown={(e) => {
+        e.stopPropagation();
+        onBeginDrag(placed.selectId);
+      }}
+    >
+      <sphereGeometry args={[HANDLE_RADIUS_MM, 20, 16]} />
+      <meshStandardMaterial
+        color={colors.workshopPartSelected}
+        emissive={colors.workshopPartSelected}
+        emissiveIntensity={0.35}
+        transparent
+        opacity={0.9}
+      />
+    </mesh>
+  );
+}

--- a/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
@@ -33,7 +33,7 @@ interface PartProxyMeshProps {
   onSurfaceMove: (surface: HoverSurface) => void;
   onSurfaceLeave: () => void;
   onSurfaceClick: (surface: HoverSurface) => void;
-  onPartPointerDown: (id: string, pointerId: number) => void;
+  onPartPointerDown: (id: string, pointerId: number, pointerType: string) => void;
 }
 
 const DEG = Math.PI / 180;
@@ -150,7 +150,7 @@ export function PartProxyMesh({
       onPointerDown={(e) => {
         if (e.button !== 0) return;
         e.stopPropagation();
-        onPartPointerDown(placed.selectId, e.pointerId);
+        onPartPointerDown(placed.selectId, e.pointerId, e.pointerType);
       }}
       onClick={(e) => {
         e.stopPropagation();

--- a/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
@@ -33,7 +33,7 @@ interface PartProxyMeshProps {
   onSurfaceMove: (surface: HoverSurface) => void;
   onSurfaceLeave: () => void;
   onSurfaceClick: (surface: HoverSurface) => void;
-  onPartPointerDown: (id: string, pointerId: number, pointerType: string) => void;
+  onPartPointerDown: (id: string, pointerType: string) => void;
 }
 
 const DEG = Math.PI / 180;
@@ -60,7 +60,11 @@ export function PartProxyMesh({
   const reducedMotion = usePrefersReducedMotion();
   const invalidate = useThree((s) => s.invalidate);
   const { node } = placed;
-  const geometry = useMemo(() => buildPartGeometry(node), [node]);
+  // Keyed on type + params, not node identity: drags path-copy the node and
+  // every ancestor per pointermove while params stay reference-equal, and a
+  // rebuild here re-uploads geometry for the whole chain each frame.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const geometry = useMemo(() => buildPartGeometry(node), [node.type, node.params]);
   useEffect(() => () => geometry.dispose(), [geometry]);
 
   const materialRef = useRef<MeshStandardMaterial>(null);
@@ -150,7 +154,7 @@ export function PartProxyMesh({
       onPointerDown={(e) => {
         if (e.button !== 0) return;
         e.stopPropagation();
-        onPartPointerDown(placed.selectId, e.pointerId, e.pointerType);
+        onPartPointerDown(placed.selectId, e.pointerType);
       }}
       onClick={(e) => {
         e.stopPropagation();

--- a/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
@@ -14,7 +14,10 @@ import {
   setPreviewCanvas,
   setPreviewContext,
 } from '@/features/bin-designer/utils/thumbnail';
+import { useDesignerKeyboard } from '@/features/bin-designer/hooks/useDesignerKeyboard';
 import { WorkshopScene } from './WorkshopScene';
+
+const noop = (): void => undefined;
 
 /** Registers this canvas with the thumbnail pipeline (see PreviewContextSync). */
 function WorkshopContextSync() {
@@ -31,8 +34,22 @@ export function WorkshopCanvas() {
   const { structure, envelope } = useDesignerStore(
     useShallow((s) => ({ structure: s.structure, envelope: s.envelope }))
   );
+  const undo = useDesignerStore((s) => s.undo);
+  const redo = useDesignerStore((s) => s.redo);
   const webgl = detectWebGL();
   useEffect(() => () => clearPreviewCanvas(), []);
+  // The bin preview mounts the shared designer shortcuts; this canvas
+  // replaces it wholesale, so undo/redo must be re-bound here. Camera and
+  // render-mode shortcuts are bin-preview concerns and stay inert.
+  useDesignerKeyboard({
+    onCameraPreset: noop,
+    onResetView: noop,
+    onToggleWireframe: noop,
+    onToggleXray: noop,
+    onToggleProjection: noop,
+    onUndo: undo,
+    onRedo: redo,
+  });
 
   if (structure?.kind !== 'assembly' || !envelope) return null;
   if (!webgl.available && webgl.reason) {

--- a/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
@@ -109,7 +109,7 @@ export function WorkshopScene({ structure, envelope }: WorkshopSceneProps) {
       {interaction.draggingId !== null && (
         <DragCatchPlane baseW={w} baseD={d} onSurfaceMove={interaction.onSurfaceMove} />
       )}
-      {interaction.isTouchDevice &&
+      {interaction.selectedViaTouch &&
         interaction.selectedId !== null &&
         interaction.draggingId === null &&
         interaction.pendingType === null &&

--- a/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
@@ -8,6 +8,7 @@ import type { AssemblyStructure } from '@/shared/types/assembly';
 import type { ItemEnvelope } from '@/shared/types/item';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { BasePlateMesh } from './BasePlateMesh';
+import { MoveHandle3D } from './MoveHandle3D';
 import { PartProxyMesh } from './PartProxyMesh';
 import { PlacementGhost } from './PlacementGhost';
 import { WorkshopSharpMesh } from './WorkshopSharpMesh';
@@ -108,6 +109,21 @@ export function WorkshopScene({ structure, envelope }: WorkshopSceneProps) {
       {interaction.draggingId !== null && (
         <DragCatchPlane baseW={w} baseD={d} onSurfaceMove={interaction.onSurfaceMove} />
       )}
+      {interaction.isTouchDevice &&
+        interaction.selectedId !== null &&
+        interaction.draggingId === null &&
+        interaction.pendingType === null &&
+        (() => {
+          const selectedPlaced = interaction.placedById.get(interaction.selectedId);
+          return selectedPlaced ? (
+            <MoveHandle3D
+              placed={selectedPlaced}
+              baseW={w}
+              baseD={d}
+              onBeginDrag={interaction.beginPartDrag}
+            />
+          ) : null;
+        })()}
       <OrbitControls
         makeDefault
         enableDamping

--- a/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
+++ b/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
@@ -28,7 +28,11 @@ export interface HoverSurface {
 }
 
 export interface WorkshopInteraction {
-  /** The current selection was made by touch — show the move handle. */
+  /**
+   * The selection was made by a touch pointerdown on this exact part — the
+   * move handle shows only then, so selection changes from any other path
+   * (placement auto-select, the tree, removal) can never leave it stale.
+   */
   readonly selectedViaTouch: boolean;
   readonly placements: PlacedPart[];
   readonly placedById: Map<string, PlacedPart>;
@@ -68,7 +72,7 @@ export function useWorkshopInteraction(
 
   const [hover, setHover] = useState<HoverSurface | null>(null);
   const [draggingId, setDraggingId] = useState<string | null>(null);
-  const [selectedViaTouch, setSelectedViaTouch] = useState(false);
+  const [touchSelectedId, setTouchSelectedId] = useState<string | null>(null);
   const draggedSubtreeRef = useRef<Set<string>>(new Set());
   // Transaction opens lazily on the first real mutation of a drag, so a
   // click that never moves the part leaves no undo step behind.
@@ -244,7 +248,7 @@ export function useWorkshopInteraction(
       // pointer that made the selection is the ONE modality signal — a
       // mouse on a touchscreen laptop drags, a finger gets the handle.
       const viaTouch = pointerType === 'touch';
-      setSelectedViaTouch(viaTouch);
+      setTouchSelectedId(viaTouch ? id : null);
       if (viaTouch) {
         skipNextBaseClickRef.current = true;
         invalidate();
@@ -272,7 +276,7 @@ export function useWorkshopInteraction(
   }, [fineSnap, hover, placedById]);
 
   return {
-    selectedViaTouch,
+    selectedViaTouch: selectedId !== null && selectedId === touchSelectedId,
     placements,
     placedById,
     hover,

--- a/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
+++ b/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
@@ -8,7 +8,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
-import { useResponsive } from '@/shared/hooks/useResponsive';
 import type { AssemblyStructure } from '@/shared/types/assembly';
 import { collectAssemblyIds, findAssemblyPart } from '@/features/bin-designer/utils/assemblyTree';
 import { defaultCutterProfile } from '@/shared/items/assembly/descriptor';
@@ -29,8 +28,8 @@ export interface HoverSurface {
 }
 
 export interface WorkshopInteraction {
-  /** Touch devices select on tap and move via the on-canvas handle. */
-  readonly isTouchDevice: boolean;
+  /** The current selection was made by touch — show the move handle. */
+  readonly selectedViaTouch: boolean;
   readonly placements: PlacedPart[];
   readonly placedById: Map<string, PlacedPart>;
   readonly hover: HoverSurface | null;
@@ -42,7 +41,7 @@ export interface WorkshopInteraction {
   onSurfaceMove: (surface: HoverSurface) => void;
   onSurfaceLeave: () => void;
   onSurfaceClick: (surface: HoverSurface) => void;
-  onPartPointerDown: (id: string, pointerId: number, pointerType: string) => void;
+  onPartPointerDown: (id: string, pointerType: string) => void;
   beginPartDrag: (id: string) => void;
   isInDraggedSubtree: (id: string) => boolean;
 }
@@ -59,7 +58,6 @@ export function useWorkshopInteraction(
   structure: AssemblyStructure,
   baseExtent: { w: number; d: number }
 ): WorkshopInteraction {
-  const { isTouchDevice } = useResponsive();
   const pendingType = usePendingType();
   const pendingCutterShape = usePendingCutterShape();
   const { selectedId } = useDesignerStore(
@@ -70,6 +68,7 @@ export function useWorkshopInteraction(
 
   const [hover, setHover] = useState<HoverSurface | null>(null);
   const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [selectedViaTouch, setSelectedViaTouch] = useState(false);
   const draggedSubtreeRef = useRef<Set<string>>(new Set());
   // Transaction opens lazily on the first real mutation of a drag, so a
   // click that never moves the part leaves no undo step behind.
@@ -126,7 +125,14 @@ export function useWorkshopInteraction(
   useEffect(() => {
     if (draggingId === null) return;
     window.addEventListener('pointerup', endDrag);
-    return () => window.removeEventListener('pointerup', endDrag);
+    // A cancelled touch (edge swipe, notification shade, palm rejection)
+    // fires pointercancel, never pointerup — without this the drag wedges
+    // orbit, the open undo transaction, and the drag state.
+    window.addEventListener('pointercancel', endDrag);
+    return () => {
+      window.removeEventListener('pointerup', endDrag);
+      window.removeEventListener('pointercancel', endDrag);
+    };
   }, [draggingId, endDrag]);
 
   const snapPoint = useCallback(
@@ -229,20 +235,24 @@ export function useWorkshopInteraction(
   );
 
   const onPartPointerDown = useCallback(
-    (id: string, _pointerId: number, pointerType: string): void => {
+    (id: string, pointerType: string): void => {
       const store = useDesignerStore.getState();
       if (store.ui.workshopPendingPartType) return;
       store.setSelectedAssemblyPartId(id);
       // Touch: tap selects; moving happens through the dedicated handle so a
-      // one-finger drag from a part still orbits instead of dragging it.
-      if (pointerType === 'touch' || isTouchDevice) {
+      // one-finger drag from a part still orbits instead of dragging it. The
+      // pointer that made the selection is the ONE modality signal — a
+      // mouse on a touchscreen laptop drags, a finger gets the handle.
+      const viaTouch = pointerType === 'touch';
+      setSelectedViaTouch(viaTouch);
+      if (viaTouch) {
         skipNextBaseClickRef.current = true;
         invalidate();
         return;
       }
       beginPartDrag(id);
     },
-    [beginPartDrag, invalidate, isTouchDevice]
+    [beginPartDrag, invalidate]
   );
 
   const isInDraggedSubtree = useCallback(
@@ -262,7 +272,7 @@ export function useWorkshopInteraction(
   }, [fineSnap, hover, placedById]);
 
   return {
-    isTouchDevice,
+    selectedViaTouch,
     placements,
     placedById,
     hover,

--- a/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
+++ b/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useThree } from '@react-three/fiber';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { useResponsive } from '@/shared/hooks/useResponsive';
 import type { AssemblyStructure } from '@/shared/types/assembly';
 import { collectAssemblyIds, findAssemblyPart } from '@/features/bin-designer/utils/assemblyTree';
 import { defaultCutterProfile } from '@/shared/items/assembly/descriptor';
@@ -28,6 +29,8 @@ export interface HoverSurface {
 }
 
 export interface WorkshopInteraction {
+  /** Touch devices select on tap and move via the on-canvas handle. */
+  readonly isTouchDevice: boolean;
   readonly placements: PlacedPart[];
   readonly placedById: Map<string, PlacedPart>;
   readonly hover: HoverSurface | null;
@@ -39,7 +42,8 @@ export interface WorkshopInteraction {
   onSurfaceMove: (surface: HoverSurface) => void;
   onSurfaceLeave: () => void;
   onSurfaceClick: (surface: HoverSurface) => void;
-  onPartPointerDown: (id: string, pointerId: number) => void;
+  onPartPointerDown: (id: string, pointerId: number, pointerType: string) => void;
+  beginPartDrag: (id: string) => void;
   isInDraggedSubtree: (id: string) => boolean;
 }
 
@@ -55,6 +59,7 @@ export function useWorkshopInteraction(
   structure: AssemblyStructure,
   baseExtent: { w: number; d: number }
 ): WorkshopInteraction {
+  const { isTouchDevice } = useResponsive();
   const pendingType = usePendingType();
   const pendingCutterShape = usePendingCutterShape();
   const { selectedId } = useDesignerStore(
@@ -206,11 +211,9 @@ export function useWorkshopInteraction(
     [invalidate, snapPoint]
   );
 
-  const onPartPointerDown = useCallback(
-    (id: string, _pointerId: number): void => {
+  const beginPartDrag = useCallback(
+    (id: string): void => {
       const store = useDesignerStore.getState();
-      if (store.ui.workshopPendingPartType) return;
-      store.setSelectedAssemblyPartId(id);
       const currentStructure = store.structure;
       if (currentStructure?.kind !== 'assembly') return;
       const node = findAssemblyPart(currentStructure.parts, id);
@@ -223,6 +226,23 @@ export function useWorkshopInteraction(
       invalidate();
     },
     [getThree, invalidate]
+  );
+
+  const onPartPointerDown = useCallback(
+    (id: string, _pointerId: number, pointerType: string): void => {
+      const store = useDesignerStore.getState();
+      if (store.ui.workshopPendingPartType) return;
+      store.setSelectedAssemblyPartId(id);
+      // Touch: tap selects; moving happens through the dedicated handle so a
+      // one-finger drag from a part still orbits instead of dragging it.
+      if (pointerType === 'touch' || isTouchDevice) {
+        skipNextBaseClickRef.current = true;
+        invalidate();
+        return;
+      }
+      beginPartDrag(id);
+    },
+    [beginPartDrag, invalidate, isTouchDevice]
   );
 
   const isInDraggedSubtree = useCallback(
@@ -242,6 +262,7 @@ export function useWorkshopInteraction(
   }, [fineSnap, hover, placedById]);
 
   return {
+    isTouchDevice,
     placements,
     placedById,
     hover,
@@ -254,6 +275,7 @@ export function useWorkshopInteraction(
     onSurfaceLeave,
     onSurfaceClick,
     onPartPointerDown,
+    beginPartDrag,
     isInDraggedSubtree,
   };
 }

--- a/src/features/bin-designer/hooks/useToolRackMigration.test.ts
+++ b/src/features/bin-designer/hooks/useToolRackMigration.test.ts
@@ -66,6 +66,17 @@ describe('useToolRackMigration', () => {
     expect((saved.structure as { kind: string }).kind).toBe('assembly');
   });
 
+  it('keeps the done-flag unset when a save fails, so the next visit retries', async () => {
+    listDesignsMock.mockResolvedValue(ok([rackDesign]));
+    saveDesignMock.mockResolvedValueOnce({ ok: false, error: { message: 'nope' } });
+    const first = renderHook(() => useToolRackMigration());
+    await waitFor(() => expect(saveDesignMock).toHaveBeenCalledTimes(1));
+    first.unmount();
+    saveDesignMock.mockResolvedValueOnce(ok({ ...rackDesign, kind: 'assembly' }));
+    renderHook(() => useToolRackMigration());
+    await waitFor(() => expect(saveDesignMock).toHaveBeenCalledTimes(2));
+  });
+
   it('leaves bins, assemblies, and imported meshes untouched', async () => {
     listDesignsMock.mockResolvedValueOnce(
       ok([

--- a/src/features/bin-designer/hooks/useToolRackMigration.ts
+++ b/src/features/bin-designer/hooks/useToolRackMigration.ts
@@ -22,18 +22,20 @@ export function useToolRackMigration(): void {
     void (async () => {
       const designs = await listDesigns();
       if (!isOk(designs)) return;
+      let allSaved = true;
       for (const design of designs.value) {
         if (design.kind !== 'toolRack') continue;
         if (!design.envelope || design.structure?.kind !== 'toolRack') continue;
-        await saveDesign({
+        const saved = await saveDesign({
           ...design,
           kind: 'assembly',
           structure: convertToolRackToAssembly(design.structure, design.envelope),
         });
+        if (!isOk(saved)) allSaved = false;
       }
-      // Marked only after a full successful scan; a thrown save leaves the
-      // flag unset so the next visit retries.
-      setMigrationDone(MIGRATION_KEY);
+      // Marked only after every rack converted; a failed save leaves the
+      // flag unset so the next visit retries the stragglers.
+      if (allSaved) setMigrationDone(MIGRATION_KEY);
     })();
   }, []);
 }

--- a/src/features/generation/worker/generators/assemblyGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/assemblyGenerator.scenario.test.ts
@@ -190,8 +190,7 @@ describe('assembly generator (real WASM)', () => {
     const result = generateAssembly(structureWith([lengthLean]), makeEnvelope(4, 2), noop, true);
     assertStructurallyValid(result);
     const bounds = boundingBox(result.vertices);
-    // Base is 167.5mm wide; an unclipped 20° shear on a 25mm fin would push
-    // the fin 9mm past its 60mm run. Clipped, the base rim stays the max.
+    // Unclipped, the shear would push the fin past the base rim.
     expect(bounds.maxX - bounds.minX).toBeLessThanOrEqual(4 * 42);
     const finVolume =
       meshVolume(result) -

--- a/src/features/generation/worker/generators/assemblyGenerator.scenario.test.ts
+++ b/src/features/generation/worker/generators/assemblyGenerator.scenario.test.ts
@@ -177,6 +177,28 @@ describe('assembly generator (real WASM)', () => {
     expect(bounds.maxY - bounds.minY).toBeGreaterThan(80);
   });
 
+  it('a length-leaning fin stays clipped to its nominal run', async () => {
+    const { generateAssembly } = await import('./assemblyGenerator');
+    const lengthLean = part(
+      'fin',
+      'f',
+      { x: 84, y: 42 },
+      {
+        params: { length: 60, thickness: 3, height: 25, leanDeg: 20, leanAxis: 'length' },
+      }
+    );
+    const result = generateAssembly(structureWith([lengthLean]), makeEnvelope(4, 2), noop, true);
+    assertStructurallyValid(result);
+    const bounds = boundingBox(result.vertices);
+    // Base is 167.5mm wide; an unclipped 20° shear on a 25mm fin would push
+    // the fin 9mm past its 60mm run. Clipped, the base rim stays the max.
+    expect(bounds.maxX - bounds.minX).toBeLessThanOrEqual(4 * 42);
+    const finVolume =
+      meshVolume(result) -
+      meshVolume(generateAssembly(structureWith([]), makeEnvelope(4, 2), noop, true));
+    expect(finVolume).toBeGreaterThan(60 * 3 * 25 * 0.6);
+  });
+
   it('a mirrored hook emits a reflected twin with symmetric bounds', async () => {
     const { generateAssembly } = await import('./assemblyGenerator');
     const single = generateAssembly(

--- a/src/features/generation/worker/generators/assemblyGenerator.ts
+++ b/src/features/generation/worker/generators/assemblyGenerator.ts
@@ -84,13 +84,10 @@ function stableKeyValue(value: unknown): unknown {
   return value;
 }
 
-function partCacheKey(node: AssemblyPartNode, forExport: boolean): string {
-  return buildCacheKey(
-    'assembly-part-v1',
-    node.type,
-    forExport,
-    JSON.stringify(stableKeyValue(node.params))
-  );
+function partCacheKey(node: AssemblyPartNode): string {
+  // No forExport in the key: templates are pure BREP solids with no
+  // tessellation-quality input, so preview and export share one entry.
+  return buildCacheKey('assembly-part-v1', node.type, JSON.stringify(stableKeyValue(node.params)));
 }
 
 function centeredOnBounds(pts: readonly { x: number; y: number }[]): { x: number; y: number }[] {
@@ -343,10 +340,9 @@ function positionedPartSolid(
   halfW: number,
   halfD: number,
   floorThickness: number,
-  forExport: boolean,
   mirrorAxis: 'x' | 'y'
 ): Shape3D | null {
-  const key = partCacheKey(placed.node, forExport);
+  const key = partCacheKey(placed.node);
   let template = getFeatureCache('assembly-part', key);
   if (!template) {
     const built = buildPartTemplate(placed.node);
@@ -411,7 +407,6 @@ export function buildAssemblySolid(
         (envelope.width * unitMm) / 2,
         (envelope.depth * unitMm) / 2,
         floorThickness,
-        forExport,
         structure.mirrorAxis
       );
       if (!solid) continue;

--- a/src/features/generation/worker/generators/assemblyGenerator.ts
+++ b/src/features/generation/worker/generators/assemblyGenerator.ts
@@ -25,6 +25,7 @@ import {
   exportSTEP,
   fuseAll,
   getKernelCapabilities,
+  intersect,
   mesh,
   meshEdges,
   mirror,
@@ -200,8 +201,9 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
       const { length, thickness, height, leanDeg, leanAxis } = node.params;
       const lean = Math.tan(leanDeg * DEG) * height;
       if (leanAxis === 'length') {
-        // Shear along the plate's run: build the plain plate and apply the
-        // same x-by-z shear matrix the proxy uses, so both stay identical.
+        // Shear along the plate's run, then clip back to the nominal length
+        // — the rack generator's leaning fins were clipped the same way so
+        // the lean never overshoots the footprint.
         const total = height + sink;
         const plate = box(length, thickness, total, { at: [0, 0, total / 2 - sink] });
         if (leanDeg <= 0) return plate;
@@ -213,7 +215,11 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
           })
         );
         if (sheared !== plate) plate.delete();
-        return sheared;
+        const clip = box(length, thickness + 2, total * 2 + 2, { at: [0, 0, total / 2 - sink] });
+        const clipped = unwrap(intersect(sheared, clip, { optimisation: 'commonFace' }));
+        if (clipped !== sheared) sheared.delete();
+        clip.delete();
+        return clipped;
       }
       const pen = draw([-thickness / 2, -sink])
         .lineTo([thickness / 2, -sink])


### PR DESCRIPTION
Phase 10 of the Workshop plan — the final phase: the editor works properly under a finger.

## What's in

**Touch modality, decided by the pointer that acts.** A tap on a part selects it without starting a drag, so one-finger drags stay free to orbit; a floating move handle appears over a touch-selected part and drives the exact same transactioned move/re-seat machinery as a desktop drag. The modality signal is the selecting pointer's type — a mouse on a touchscreen laptop still drags directly, a finger on any screen gets the handle.

**Robustness that came out of review and live driving:**
- `pointercancel` ends drags (edge swipes, notification shades, and palm rejection no longer wedge orbit, the open undo transaction, and drag state).
- Keyboard undo/redo restored in Workshop — the designer's shortcut layer lived in the bin preview canvas, which the Workshop canvas replaces wholesale.
- Proxy geometry memo keyed on `type + params` instead of node identity, ending per-pointermove geometry rebuild/upload/dispose across the dragged chain (and all array copies).
- Part template cache drops its needless preview/export key split, so alternating preview and export shares one OCCT template per part shape.
- Rack-migration follow-ups: the once-flag is only set when every rack converted (failed saves retry next visit), and length-leaning fins are clipped back to their nominal run in the worker, matching the retired generator's clip.

Verified under Playwright iPad emulation: tap-to-place, tap-select with handle, and inspector interaction, in the tablet layout.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

