### PR TITLE
feat(workshop): polish pass from the ship review

### DIFF
--- a/src/features/bin-designer/components/Workshop/BasePlateMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/BasePlateMesh.tsx
@@ -3,8 +3,10 @@
  * the floor. The exact socket profile comes from the worker once the
  * assembly generator lands; this stands in so parts have a surface to sit on.
  */
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { ExtrudeGeometry, Shape } from 'three';
+import type { MeshStandardMaterial } from 'three';
+import { useFrame, useThree } from '@react-three/fiber';
 import type { ThreeEvent } from '@react-three/fiber';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';
 import type { ItemEnvelope } from '@/shared/types/item';
@@ -18,20 +20,57 @@ interface BasePlateMeshProps {
   base: AssemblyBase;
   /** Sharp worker mesh is on screen — render nothing, keep raycast alive. */
   hidden?: boolean;
+  /** performance.now() of the last armed click that missed every surface. */
+  flashAt?: number;
   onSurfaceMove: (surface: HoverSurface) => void;
   onSurfaceLeave: () => void;
   onSurfaceClick: (surface: HoverSurface) => void;
 }
 
+const FLASH_MS = 350;
+
 export function BasePlateMesh({
   envelope,
   base,
   hidden = false,
+  flashAt = 0,
   onSurfaceMove,
   onSurfaceLeave,
   onSurfaceClick,
 }: BasePlateMeshProps) {
   const colors = useThreeColors();
+  const materialRef = useRef<MeshStandardMaterial>(null);
+  const invalidate = useThree((s) => s.invalidate);
+
+  useEffect(() => {
+    if (flashAt > 0) invalidate();
+  }, [flashAt, invalidate]);
+
+  // Missed-placement pulse. Driven imperatively so the demand-mode canvas
+  // only renders while flashing; while the sharp mesh hides the plate, the
+  // pulse borrows visibility briefly and fades back out.
+  useFrame(() => {
+    const material = materialRef.current;
+    if (!material || flashAt === 0) return;
+    const t = (performance.now() - flashAt) / FLASH_MS;
+    if (t >= 1) {
+      if (material.emissiveIntensity !== 0) {
+        material.emissiveIntensity = 0;
+        material.opacity = 1;
+        material.transparent = false;
+        material.visible = !hidden;
+        invalidate();
+      }
+      return;
+    }
+    material.visible = true;
+    material.emissiveIntensity = 0.35 * (1 - t);
+    if (hidden) {
+      material.transparent = true;
+      material.opacity = 0.35 * (1 - t);
+    }
+    invalidate();
+  });
   const { w, d } = baseExtentMm(envelope);
   const plateHeight = GRIDFINITY_SPEC.BASE_HEIGHT + base.floorThickness;
   const cornerRadius = Math.min(base.cornerRadius ?? 4, w / 2, d / 2);
@@ -77,10 +116,13 @@ export function BasePlateMesh({
       }}
     >
       <meshStandardMaterial
+        ref={materialRef}
         visible={!hidden}
         color={colors.workshopBase}
         roughness={0.85}
         metalness={0.05}
+        emissive={colors.workshopGhost}
+        emissiveIntensity={0}
       />
     </mesh>
   );

--- a/src/features/bin-designer/components/Workshop/BasePlateMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/BasePlateMesh.tsx
@@ -40,6 +40,7 @@ export function BasePlateMesh({
 }: BasePlateMeshProps) {
   const colors = useThreeColors();
   const materialRef = useRef<MeshStandardMaterial>(null);
+  const flashDirtyRef = useRef(false);
   const invalidate = useThree((s) => s.invalidate);
 
   useEffect(() => {
@@ -54,7 +55,8 @@ export function BasePlateMesh({
     if (!material || flashAt === 0) return;
     const t = (performance.now() - flashAt) / FLASH_MS;
     if (t >= 1) {
-      if (material.emissiveIntensity !== 0) {
+      if (flashDirtyRef.current) {
+        flashDirtyRef.current = false;
         material.emissiveIntensity = 0;
         material.opacity = 1;
         material.transparent = false;
@@ -63,11 +65,15 @@ export function BasePlateMesh({
       }
       return;
     }
+    flashDirtyRef.current = true;
     material.visible = true;
     material.emissiveIntensity = 0.35 * (1 - t);
     if (hidden) {
       material.transparent = true;
       material.opacity = 0.35 * (1 - t);
+    } else {
+      material.transparent = false;
+      material.opacity = 1;
     }
     invalidate();
   });

--- a/src/features/bin-designer/components/Workshop/PlacementGhost.tsx
+++ b/src/features/bin-designer/components/Workshop/PlacementGhost.tsx
@@ -13,8 +13,8 @@ import { storeToScene } from './workshopPlacement';
 interface PlacementGhostProps {
   type: AssemblyPartType;
   cutterShape: 'circle' | 'slot' | null;
-  /** Snapped store-frame position, computed by the interaction hook. */
-  position: { x: number; y: number; z: number };
+  /** Snapped store-frame pose (the target frame's rotation included). */
+  position: { x: number; y: number; z: number; rotZDeg: number };
   baseW: number;
   baseD: number;
 }
@@ -38,6 +38,7 @@ export function PlacementGhost({ type, cutterShape, position, baseW, baseD }: Pl
     <mesh
       geometry={geometry}
       position={[storeToScene(position.x, baseW), storeToScene(position.y, baseD), position.z]}
+      rotation={[0, 0, (position.rotZDeg * Math.PI) / 180]}
       raycast={() => null}
     >
       <meshStandardMaterial

--- a/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
@@ -3,7 +3,7 @@
  * designer holds an assembly. Parts render as instant client-side proxies;
  * the exact worker-fused solid joins in a later phase.
  */
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
 import { PerspectiveCamera } from 'three';
 import { useShallow } from 'zustand/react/shallow';
@@ -34,6 +34,9 @@ export function WorkshopCanvas() {
   const { structure, envelope } = useDesignerStore(
     useShallow((s) => ({ structure: s.structure, envelope: s.envelope }))
   );
+  // An armed click that hits no surface would otherwise be a silent no-op;
+  // a brief pulse on the base plate shows where placement is valid.
+  const [missFlashAt, setMissFlashAt] = useState(0);
   const undo = useDesignerStore((s) => s.undo);
   const redo = useDesignerStore((s) => s.redo);
   const webgl = detectWebGL();
@@ -63,9 +66,14 @@ export function WorkshopCanvas() {
           frameloop="demand"
           gl={{ antialias: true, localClippingEnabled: true, preserveDrawingBuffer: true }}
           onCreated={({ gl }) => setPreviewCanvas(gl.domElement)}
+          onPointerMissed={() => {
+            if (useDesignerStore.getState().ui.workshopPendingPartType) {
+              setMissFlashAt(performance.now());
+            }
+          }}
         >
           <WorkshopContextSync />
-          <WorkshopScene structure={structure} envelope={envelope} />
+          <WorkshopScene structure={structure} envelope={envelope} missFlashAt={missFlashAt} />
         </Canvas>
       </WebGLErrorBoundary>
     </div>

--- a/src/features/bin-designer/components/Workshop/WorkshopPanel/WorkshopPanel.test.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopPanel/WorkshopPanel.test.tsx
@@ -29,9 +29,10 @@ describe('WorkshopPanel', () => {
     const postId = useDesignerStore.getState().addAssemblyPart('post', blockId);
     useDesignerStore.getState().setSelectedAssemblyPartId(null);
     render(<WorkshopPanel />);
-    const postButtons = screen.getAllByRole('button', { name: 'Post' });
+    // Tree rows carry a dims suffix ("Post ⌀8×40"); the palette stays bare.
+    const postButtons = screen.getAllByRole('button', { name: /^Post/ });
     expect(postButtons).toHaveLength(2);
-    const treeRow = postButtons[1];
+    const treeRow = postButtons.find((b) => /⌀/.test(b.textContent ?? ''));
     if (!treeRow) throw new Error('unreachable');
     fireEvent.click(treeRow);
     expect(useDesignerStore.getState().ui.selectedAssemblyPartId).toBe(postId);

--- a/src/features/bin-designer/components/Workshop/WorkshopPanel/WorkshopPanel.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopPanel/WorkshopPanel.tsx
@@ -31,6 +31,7 @@ import { StickyGroupHeader } from '../../panel/StickyGroupHeader';
 import { PanelSection } from '../../panel/PanelSection';
 import { PartInspector } from './PartInspector';
 import { PART_LABEL_KEYS } from './partFieldConfig';
+import { partSummary } from './partSummary';
 
 function TreeRows({
   nodes,
@@ -60,6 +61,7 @@ function TreeRows({
           >
             {label(node)}
             {node.array ? ` ×${node.array.count}` : ''}
+            <span className="ml-2 text-xs text-content-tertiary">{partSummary(node)}</span>
             {warned.has(node.id) && (
               <AlertTriangleIcon size="sm" className="ml-auto text-amber-500" />
             )}
@@ -160,7 +162,7 @@ export function WorkshopPanel() {
   const selectedNode = selectedId === null ? null : findAssemblyPart(assembly.parts, selectedId);
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto" data-testid="workshop-panel">
+    <div className="flex h-full flex-col" data-testid="workshop-panel">
       <div className="flex items-center justify-between border-b border-stroke-subtle px-4 py-3">
         <Button variant="ghost" size="sm" onClick={() => newDesign('bin')}>
           {`← ${t('binDesigner.newBin')}`}
@@ -193,178 +195,188 @@ export function WorkshopPanel() {
         </div>
       </div>
 
-      <StickyGroupHeader title={t('workshop.palette.title')} expanded onExpandedChange={() => {}}>
-        <PanelSection>
-          <p className="mb-2 text-xs text-content-tertiary">{t('workshop.palette.hint')}</p>
-          <div className="grid grid-cols-2 gap-2">
-            {ASSEMBLY_PART_TYPES.filter((type) => type !== 'cutter').map((type) => (
+      {/* Inner scroll (the app's panel pattern): the back/export bar stays
+          put while sections scroll under the translucent sticky headers. */}
+      <div className="relative flex-1 overflow-y-scroll scrollbar-thin">
+        <StickyGroupHeader title={t('workshop.palette.title')} expanded onExpandedChange={() => {}}>
+          <PanelSection>
+            <p className="mb-2 text-xs text-content-tertiary">{t('workshop.palette.hint')}</p>
+            <div className="grid grid-cols-2 gap-2">
+              {ASSEMBLY_PART_TYPES.filter((type) => type !== 'cutter').map((type) => (
+                <Button
+                  key={type}
+                  variant={pendingType === type ? 'primary' : 'secondary'}
+                  size="sm"
+                  onClick={() => setWorkshopPendingPartType(pendingType === type ? null : type)}
+                >
+                  {t(PART_LABEL_KEYS[type])}
+                </Button>
+              ))}
               <Button
-                key={type}
-                variant={pendingType === type ? 'primary' : 'secondary'}
+                variant={
+                  pendingType === 'cutter' && pendingCutterShape === 'circle'
+                    ? 'primary'
+                    : 'secondary'
+                }
                 size="sm"
-                onClick={() => setWorkshopPendingPartType(pendingType === type ? null : type)}
+                onClick={() =>
+                  setWorkshopPendingPartType(
+                    pendingType === 'cutter' && pendingCutterShape === 'circle' ? null : 'cutter',
+                    'circle'
+                  )
+                }
               >
-                {t(PART_LABEL_KEYS[type])}
+                {t('workshop.palette.hole')}
               </Button>
-            ))}
-            <Button
-              variant={
-                pendingType === 'cutter' && pendingCutterShape === 'circle'
-                  ? 'primary'
-                  : 'secondary'
-              }
-              size="sm"
-              onClick={() =>
-                setWorkshopPendingPartType(
-                  pendingType === 'cutter' && pendingCutterShape === 'circle' ? null : 'cutter',
-                  'circle'
-                )
-              }
-            >
-              {t('workshop.palette.hole')}
-            </Button>
-            <Button
-              variant={
-                pendingType === 'cutter' && pendingCutterShape === 'slot' ? 'primary' : 'secondary'
-              }
-              size="sm"
-              onClick={() =>
-                setWorkshopPendingPartType(
-                  pendingType === 'cutter' && pendingCutterShape === 'slot' ? null : 'cutter',
-                  'slot'
-                )
-              }
-            >
-              {t('workshop.palette.slot')}
-            </Button>
-          </div>
-        </PanelSection>
-      </StickyGroupHeader>
+              <Button
+                variant={
+                  pendingType === 'cutter' && pendingCutterShape === 'slot'
+                    ? 'primary'
+                    : 'secondary'
+                }
+                size="sm"
+                onClick={() =>
+                  setWorkshopPendingPartType(
+                    pendingType === 'cutter' && pendingCutterShape === 'slot' ? null : 'cutter',
+                    'slot'
+                  )
+                }
+              >
+                {t('workshop.palette.slot')}
+              </Button>
+            </div>
+          </PanelSection>
+        </StickyGroupHeader>
 
-      <StickyGroupHeader title={t('workshop.tree.title')} expanded onExpandedChange={() => {}}>
-        <PanelSection>
-          {assembly.parts.length === 0 ? (
-            <div>
-              <p className="mb-2 text-xs text-content-tertiary">{t('workshop.tree.empty')}</p>
-              <div className="grid grid-cols-2 gap-2">
-                {WORKSHOP_TEMPLATE_IDS.map((templateId) => (
-                  <Button
-                    key={templateId}
-                    variant="secondary"
-                    size="sm"
-                    onClick={() =>
-                      loadAssemblyTemplate(buildWorkshopTemplate(templateId, envelope))
-                    }
-                  >
-                    {t(`workshop.template.${templateId}`)}
-                  </Button>
-                ))}
+        <StickyGroupHeader title={t('workshop.tree.title')} expanded onExpandedChange={() => {}}>
+          <PanelSection>
+            {assembly.parts.length === 0 ? (
+              <div>
+                <p className="mb-2 text-xs text-content-tertiary">{t('workshop.tree.empty')}</p>
+                <div className="grid grid-cols-2 gap-2">
+                  {WORKSHOP_TEMPLATE_IDS.map((templateId) => (
+                    <Button
+                      key={templateId}
+                      variant="secondary"
+                      size="sm"
+                      onClick={() =>
+                        loadAssemblyTemplate(buildWorkshopTemplate(templateId, envelope))
+                      }
+                    >
+                      {t(`workshop.template.${templateId}`)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-1">
+                <TreeRows
+                  nodes={assembly.parts}
+                  depth={0}
+                  selectedId={selectedId}
+                  warned={warnedIds}
+                  onSelect={setSelectedAssemblyPartId}
+                  label={(node) => t(PART_LABEL_KEYS[node.type])}
+                />
+              </div>
+            )}
+          </PanelSection>
+        </StickyGroupHeader>
+
+        {selectedNode && (
+          <StickyGroupHeader
+            title={t('workshop.inspector.title')}
+            expanded
+            onExpandedChange={() => {}}
+          >
+            {(warningsByPart.get(selectedNode.id) ?? []).map((warning) => (
+              <p
+                key={warning.kind}
+                className="flex items-center gap-2 px-4 pt-2 text-xs text-amber-500"
+              >
+                <AlertTriangleIcon size="sm" />
+                {t(`workshop.warning.${warning.kind}`)}
+              </p>
+            ))}
+            <PartInspector node={selectedNode} />
+          </StickyGroupHeader>
+        )}
+
+        <StickyGroupHeader title={t('workshop.base.title')} expanded onExpandedChange={() => {}}>
+          <PanelSection>
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <span className="mb-1 block text-xs text-content-tertiary">
+                  {t('workshop.envelope.width')}
+                </span>
+                <Stepper
+                  aria-label={t('workshop.envelope.width')}
+                  value={envelope.width}
+                  onChange={(v) => updateEnvelope({ width: clamp(Math.round(v), 1, 12) })}
+                  onStep={(delta) =>
+                    updateEnvelope({ width: clamp(envelope.width + delta, 1, 12) })
+                  }
+                  min={1}
+                  max={12}
+                  step={1}
+                  size="md"
+                />
+              </div>
+              <div>
+                <span className="mb-1 block text-xs text-content-tertiary">
+                  {t('workshop.envelope.depth')}
+                </span>
+                <Stepper
+                  aria-label={t('workshop.envelope.depth')}
+                  value={envelope.depth}
+                  onChange={(v) => updateEnvelope({ depth: clamp(Math.round(v), 1, 12) })}
+                  onStep={(delta) =>
+                    updateEnvelope({ depth: clamp(envelope.depth + delta, 1, 12) })
+                  }
+                  min={1}
+                  max={12}
+                  step={1}
+                  size="md"
+                />
+              </div>
+              <div>
+                <span className="mb-1 block text-xs text-content-tertiary">
+                  {t('workshop.base.floorThickness')}
+                </span>
+                <Stepper
+                  aria-label={t('workshop.base.floorThickness')}
+                  value={assembly.base.floorThickness}
+                  onChange={(v) => updateAssemblyBase({ floorThickness: clamp(v, 1, 10) })}
+                  onStep={(delta) =>
+                    updateAssemblyBase({
+                      floorThickness: clamp(assembly.base.floorThickness + delta * 0.5, 1, 10),
+                    })
+                  }
+                  min={1}
+                  max={10}
+                  step={0.5}
+                  size="md"
+                />
+              </div>
+              <div>
+                <span className="mb-1 block text-xs text-content-tertiary">
+                  {t('workshop.mirror.axis')}
+                </span>
+                <SegmentedControl
+                  aria-label={t('workshop.mirror.axis')}
+                  value={assembly.mirrorAxis}
+                  onChange={(axis) => setAssemblyMirrorAxis(axis)}
+                  options={[
+                    { value: 'x', label: t('workshop.mirror.axisX') },
+                    { value: 'y', label: t('workshop.mirror.axisY') },
+                  ]}
+                  size="sm"
+                />
               </div>
             </div>
-          ) : (
-            <div className="flex flex-col gap-1">
-              <TreeRows
-                nodes={assembly.parts}
-                depth={0}
-                selectedId={selectedId}
-                warned={warnedIds}
-                onSelect={setSelectedAssemblyPartId}
-                label={(node) => t(PART_LABEL_KEYS[node.type])}
-              />
-            </div>
-          )}
-        </PanelSection>
-      </StickyGroupHeader>
-
-      {selectedNode && (
-        <StickyGroupHeader
-          title={t('workshop.inspector.title')}
-          expanded
-          onExpandedChange={() => {}}
-        >
-          {(warningsByPart.get(selectedNode.id) ?? []).map((warning) => (
-            <p
-              key={warning.kind}
-              className="flex items-center gap-2 px-4 pt-2 text-xs text-amber-500"
-            >
-              <AlertTriangleIcon size="sm" />
-              {t(`workshop.warning.${warning.kind}`)}
-            </p>
-          ))}
-          <PartInspector node={selectedNode} />
+          </PanelSection>
         </StickyGroupHeader>
-      )}
-
-      <StickyGroupHeader title={t('workshop.base.title')} expanded onExpandedChange={() => {}}>
-        <PanelSection>
-          <div className="grid grid-cols-2 gap-2">
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('workshop.envelope.width')}
-              </span>
-              <Stepper
-                aria-label={t('workshop.envelope.width')}
-                value={envelope.width}
-                onChange={(v) => updateEnvelope({ width: clamp(Math.round(v), 1, 12) })}
-                onStep={(delta) => updateEnvelope({ width: clamp(envelope.width + delta, 1, 12) })}
-                min={1}
-                max={12}
-                step={1}
-                size="md"
-              />
-            </div>
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('workshop.envelope.depth')}
-              </span>
-              <Stepper
-                aria-label={t('workshop.envelope.depth')}
-                value={envelope.depth}
-                onChange={(v) => updateEnvelope({ depth: clamp(Math.round(v), 1, 12) })}
-                onStep={(delta) => updateEnvelope({ depth: clamp(envelope.depth + delta, 1, 12) })}
-                min={1}
-                max={12}
-                step={1}
-                size="md"
-              />
-            </div>
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('workshop.base.floorThickness')}
-              </span>
-              <Stepper
-                aria-label={t('workshop.base.floorThickness')}
-                value={assembly.base.floorThickness}
-                onChange={(v) => updateAssemblyBase({ floorThickness: clamp(v, 1, 10) })}
-                onStep={(delta) =>
-                  updateAssemblyBase({
-                    floorThickness: clamp(assembly.base.floorThickness + delta * 0.5, 1, 10),
-                  })
-                }
-                min={1}
-                max={10}
-                step={0.5}
-                size="md"
-              />
-            </div>
-            <div>
-              <span className="mb-1 block text-xs text-content-tertiary">
-                {t('workshop.mirror.axis')}
-              </span>
-              <SegmentedControl
-                aria-label={t('workshop.mirror.axis')}
-                value={assembly.mirrorAxis}
-                onChange={(axis) => setAssemblyMirrorAxis(axis)}
-                options={[
-                  { value: 'x', label: t('workshop.mirror.axisX') },
-                  { value: 'y', label: t('workshop.mirror.axisY') },
-                ]}
-                size="sm"
-              />
-            </div>
-          </div>
-        </PanelSection>
-      </StickyGroupHeader>
+      </div>
     </div>
   );
 }

--- a/src/features/bin-designer/components/Workshop/WorkshopPanel/partSummary.test.ts
+++ b/src/features/bin-designer/components/Workshop/WorkshopPanel/partSummary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { AssemblyPartNode } from '@/shared/types/assembly';
+import {
+  createAssemblyPartNode,
+  DEFAULT_PART_TRANSFORM,
+  defaultCutterProfile,
+} from '@/shared/items/assembly/descriptor';
+import { ASSEMBLY_PART_TYPES } from '@/shared/types/assembly';
+import { partSummary } from './partSummary';
+
+const node = (type: AssemblyPartNode['type']): AssemblyPartNode =>
+  createAssemblyPartNode(type, `n-${type}`, { ...DEFAULT_PART_TRANSFORM });
+
+describe('partSummary', () => {
+  it.each(ASSEMBLY_PART_TYPES)('yields a non-empty numeric caption for %s', (type) => {
+    expect(partSummary(node(type)).length).toBeGreaterThan(0);
+  });
+
+  it('distinguishes posts by their dimensions', () => {
+    expect(partSummary(node('post'))).toBe('⌀8×40');
+    const tall = {
+      ...node('post'),
+      params: { diameter: 12.5, height: 60, taperDeg: 0, tipChamfer: 1 },
+    } as AssemblyPartNode;
+    expect(partSummary(tall)).toBe('⌀12.5×60');
+  });
+
+  it('captions scanned cutters by their outline footprint', () => {
+    const scanned = {
+      ...node('cutter'),
+      params: {
+        profile: {
+          shape: 'outline' as const,
+          points: [
+            { x: 0, y: 0 },
+            { x: 30, y: 0 },
+            { x: 15, y: 52.4 },
+          ],
+        },
+        depth: 10,
+        clearance: 0.2,
+        chamfer: 0,
+      },
+    } as AssemblyPartNode;
+    expect(partSummary(scanned)).toBe('30×52.4');
+    const hole = {
+      ...node('cutter'),
+      params: { profile: defaultCutterProfile('circle'), depth: 10, clearance: 0.2, chamfer: 0 },
+    } as AssemblyPartNode;
+    expect(partSummary(hole)).toBe('⌀6.5');
+  });
+});

--- a/src/features/bin-designer/components/Workshop/WorkshopPanel/partSummary.ts
+++ b/src/features/bin-designer/components/Workshop/WorkshopPanel/partSummary.ts
@@ -1,0 +1,38 @@
+/**
+ * Short dimension caption for a tree row, so three Posts read as three
+ * different posts. Numbers are mm and locale-neutral — no i18n needed.
+ */
+import type { AssemblyPartNode } from '@/shared/types/assembly';
+import { partFootprint } from '@/shared/types/assemblyPlacement';
+
+const fmt = (v: number): string => {
+  const rounded = Math.round(v * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+};
+
+export function partSummary(node: AssemblyPartNode): string {
+  switch (node.type) {
+    case 'post':
+      return `⌀${fmt(node.params.diameter)}×${fmt(node.params.height)}`;
+    case 'fin':
+      return `${fmt(node.params.length)}×${fmt(node.params.height)}`;
+    case 'block':
+      return `${fmt(node.params.width)}×${fmt(node.params.depth)}×${fmt(node.params.height)}`;
+    case 'tube':
+      return `⌀${fmt(node.params.boreDiameter)}×${fmt(node.params.height)}`;
+    case 'cradle':
+      return `${fmt(node.params.length)}×${fmt(node.params.width)}`;
+    case 'hook':
+      return `${fmt(node.params.reach)}×${fmt(node.params.stemHeight)}`;
+    case 'arch':
+      return `${fmt(node.params.span)}×${fmt(node.params.height)}`;
+    case 'cutter': {
+      const profile = node.params.profile;
+      if (profile.shape === 'circle' || profile.shape === 'polygon') {
+        return `⌀${fmt(profile.diameter)}`;
+      }
+      const { w, d } = partFootprint(node);
+      return `${fmt(w)}×${fmt(d)}`;
+    }
+  }
+}

--- a/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
@@ -20,9 +20,11 @@ import { useWorkshopInteraction, type HoverSurface } from './useWorkshopInteract
 interface WorkshopSceneProps {
   structure: AssemblyStructure;
   envelope: ItemEnvelope;
+  /** performance.now() of the last armed click that hit nothing. */
+  missFlashAt?: number;
 }
 
-export function WorkshopScene({ structure, envelope }: WorkshopSceneProps) {
+export function WorkshopScene({ structure, envelope, missFlashAt = 0 }: WorkshopSceneProps) {
   const extent = useMemo(() => baseExtentMm(envelope), [envelope]);
   const interaction = useWorkshopInteraction(structure, extent);
   const { w, d } = extent;
@@ -72,6 +74,7 @@ export function WorkshopScene({ structure, envelope }: WorkshopSceneProps) {
         envelope={envelope}
         base={structure.base}
         hidden={showSharp}
+        flashAt={missFlashAt}
         onSurfaceMove={interaction.onSurfaceMove}
         onSurfaceLeave={interaction.onSurfaceLeave}
         onSurfaceClick={interaction.onSurfaceClick}

--- a/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
+++ b/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
@@ -37,7 +37,7 @@ export interface WorkshopInteraction {
   readonly placements: PlacedPart[];
   readonly placedById: Map<string, PlacedPart>;
   readonly hover: HoverSurface | null;
-  readonly ghostPosition: { x: number; y: number; z: number } | null;
+  readonly ghostPosition: { x: number; y: number; z: number; rotZDeg: number } | null;
   readonly draggingId: string | null;
   readonly selectedId: string | null;
   readonly pendingType: ReturnType<typeof usePendingType>;
@@ -266,13 +266,20 @@ export function useWorkshopInteraction(
 
   // Snap in the hovered parent's local frame — the same math placement uses —
   // then convert back to the store frame so the ghost lands where the part will.
-  const ghostPosition = useMemo((): { x: number; y: number; z: number } | null => {
+  const ghostPosition = useMemo((): {
+    x: number;
+    y: number;
+    z: number;
+    rotZDeg: number;
+  } | null => {
     if (!hover) return null;
     const parent = hover.parentId === null ? null : (placedById.get(hover.parentId) ?? null);
     const local = worldToParentLocal({ x: hover.x, y: hover.y }, parent);
     const snapped = { x: snapCoord(local.x, fineSnap), y: snapCoord(local.y, fineSnap) };
     const world = parentLocalToWorld(snapped, parent);
-    return { x: world.x, y: world.y, z: hover.topZ };
+    // A placed part starts at local rotation 0, so its world orientation is
+    // the parent frame's — the ghost previews exactly that.
+    return { x: world.x, y: world.y, z: hover.topZ, rotZDeg: parent?.rotZDeg ?? 0 };
   }, [fineSnap, hover, placedById]);
 
   return {


### PR DESCRIPTION
The four polish items logged in the Workshop ship review, each live-verified:

- **Tree rows carry dims**: every row shows a compact caption (`Post ⌀8×40`, `Block 40×20×20`, scanned cutters by their outline footprint), so three same-type parts read apart at a glance. Numbers only — locale-neutral, no i18n keys.
- **Missed placement feedback**: an armed click that hits no surface pulses the base plate (Canvas `onPointerMissed` → a 350ms emissive fade, driven imperatively for the demand-mode canvas; while the sharp mesh hides the plate, the pulse borrows visibility briefly). The silent no-op is gone — the flash points at where placement is valid.
- **Panel structure matches the app**: the back/export bar now sits outside an inner scroll container (the BinParameterPanel pattern), so exports stay reachable while sections scroll under the translucent sticky headers — this was also the source of the header-clip look.
- **Ghost previews the target frame's orientation**: the placement ghost rotates to the hovered parent's world rotation, which is exactly the orientation a placed part gets (local rotation starts at 0).

Chased and cleared during verification: rotation edits appearing not to render turned out to be the Stepper's by-design draft-until-blur/Enter commit — step-button commits render the rotation correctly (fin at 45° confirmed on camera).

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

