### PR TITLE
feat(workshop): place assemblies in drawer layouts

### DIFF
--- a/src/features/bin-designer/hooks/usePlaceBinInLayout.test.ts
+++ b/src/features/bin-designer/hooks/usePlaceBinInLayout.test.ts
@@ -76,6 +76,34 @@ describe('navigateToPlaceInLayout', () => {
     expect(window.location.search).toContain('placeDesignId=mesh-1');
   });
 
+  it('registers an assembly design with rise and lip fields', () => {
+    const assembly = makeDesign({
+      id: designId('asm-1'),
+      name: 'Pliers Rack',
+      params: undefined,
+      kind: 'assembly',
+      envelope: {
+        width: 2,
+        depth: 2,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+      } as unknown as SavedDesign['envelope'],
+      structure: {
+        kind: 'assembly',
+        schemaVersion: 1,
+        base: { floorThickness: 2 },
+        mirrorAxis: 'x',
+        parts: [],
+      } as unknown as SavedDesign['structure'],
+    });
+    navigateToPlaceInLayout(assembly);
+    const ref = loadRegistry().find((r) => r.id === 'asm-1');
+    expect(ref?.kind).toBe('assembly');
+    expect(ref).toMatchObject({ width: 2, depth: 2, socketless: false, hasLip: false });
+    expect(ref?.assembledRiseMm).toBeGreaterThan(0);
+    expect(window.location.search).toContain('placeDesignId=asm-1');
+  });
+
   it('registers a bin design in the custom-bin registry', () => {
     navigateToPlaceInLayout(makeDesign());
     const ref = loadRegistry().find((r) => r.id === 'design-1');

--- a/src/features/bin-designer/hooks/usePlaceBinInLayout.ts
+++ b/src/features/bin-designer/hooks/usePlaceBinInLayout.ts
@@ -26,6 +26,7 @@ import { dispatchSyntheticPopstate } from '@/shared/hooks/useDesignerRouting';
 import {
   loadRegistry,
   upsertRegistryEntry,
+  registryAssemblyFields,
   registryEdgeFields,
   registryHeightFields,
   registryKnifeRestFields,
@@ -64,6 +65,17 @@ export function navigateToPlaceInLayout(design: SavedDesign): void {
       height,
       kind: 'importedMesh',
       ...registryEdgeFields({}),
+      updatedAt: design.updatedAt,
+    });
+  } else if (design.structure?.kind === 'assembly' && design.envelope) {
+    upsertRegistryEntry({
+      id: design.id,
+      name: design.name,
+      width,
+      depth,
+      height,
+      ...registryEdgeFields({}),
+      ...registryAssemblyFields(design.envelope, design.structure),
       updatedAt: design.updatedAt,
     });
   }

--- a/src/features/bin-designer/hooks/useWorkshopAutoSave.ts
+++ b/src/features/bin-designer/hooks/useWorkshopAutoSave.ts
@@ -18,7 +18,11 @@ import { assemblyHeightUnits } from '@/shared/types/assemblyPlacement';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { loadDesign, saveDesign } from '@/features/bin-designer/storage/DesignerStorage';
 import { useDesignerStore } from '../store';
-import { registryEdgeFields, upsertRegistryEntry } from '../store/customBinRegistry';
+import {
+  registryAssemblyFields,
+  registryEdgeFields,
+  upsertRegistryEntry,
+} from '../store/customBinRegistry';
 import { captureThumbnailAtPreset } from '../utils/thumbnail';
 
 const AUTO_SAVE_DELAY_MS = 1000;
@@ -66,8 +70,8 @@ async function persistExisting(
       envelope.heightUnitMm,
       GRIDFINITY_SPEC.SOCKET_HEIGHT + structure.base.floorThickness
     ),
-    kind: 'assembly',
     ...registryEdgeFields({}),
+    ...registryAssemblyFields(envelope, structure),
     updatedAt: result.value.updatedAt,
   });
 }

--- a/src/features/bin-designer/store/customBinRegistry.test.ts
+++ b/src/features/bin-designer/store/customBinRegistry.test.ts
@@ -5,12 +5,16 @@ import {
   upsertRegistryEntry,
   removeRegistryEntry,
   rebuildRegistry,
+  registryAssemblyFields,
   registryEdgeFields,
   registryHeightFields,
   registryOverhangFields,
   type CustomBinRef,
 } from './customBinRegistry';
 import { designId } from '@/core/types';
+import type { ItemEnvelope } from '@/shared/types/item';
+import type { AssemblyStructure } from '@/shared/types/assembly';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 
 function makeRef(id: string, name: string = 'Test Bin'): CustomBinRef {
@@ -269,6 +273,42 @@ describe('customBinRegistry', () => {
         base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
       });
       expect(flat.socketless).toBe(true);
+    });
+  });
+
+  describe('registryAssemblyFields', () => {
+    const envelope = { width: 4, depth: 2, gridUnitMm: 42, heightUnitMm: 7 } as ItemEnvelope;
+    const structureWith = (parts: unknown[]): AssemblyStructure =>
+      ({
+        kind: 'assembly',
+        schemaVersion: 1,
+        base: { floorThickness: 2 },
+        mirrorAxis: 'x',
+        parts,
+      }) as AssemblyStructure;
+
+    it('charges the full rise with no lip and no socketless flag', () => {
+      const fields = registryAssemblyFields(envelope, structureWith([]));
+      expect(fields.kind).toBe('assembly');
+      expect(fields.socketless).toBe(false);
+      expect(fields.hasLip).toBe(false);
+      expect(fields.assembledRiseMm).toBeCloseTo(GRIDFINITY_SPEC.SOCKET_HEIGHT + 2, 5);
+      expect(fields.overhangMm).toBeUndefined();
+    });
+
+    it('surfaces a part hanging past the plate as overhangMm', () => {
+      const overhung = structureWith([
+        {
+          id: 'b',
+          type: 'block',
+          params: { width: 40, depth: 20, height: 20 },
+          transform: { x: 0, y: 42, seatZ: 0, rotZDeg: 0 },
+          children: [],
+        },
+      ]);
+      const fields = registryAssemblyFields(envelope, overhung);
+      expect(fields.overhangMm).toEqual({ left: 20, right: 0, front: 0, back: 0 });
+      expect(fields.assembledRiseMm).toBeCloseTo(GRIDFINITY_SPEC.SOCKET_HEIGHT + 2 + 20, 5);
     });
   });
 

--- a/src/features/bin-designer/store/customBinRegistry.ts
+++ b/src/features/bin-designer/store/customBinRegistry.ts
@@ -8,7 +8,10 @@
  */
 
 import type { DesignId } from '@/core/types';
-import type { ItemKind } from '@/shared/types/item';
+import type { ItemEnvelope, ItemKind } from '@/shared/types/item';
+import type { AssemblyStructure } from '@/shared/types/assembly';
+import { assemblyOverhangMm, assemblyRiseMm } from '@/shared/types/assemblyPlacement';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import type { Result } from '@/core/result';
 import type { StorageError } from '@/core/result/errors';
 import { isOk } from '@/core/result';
@@ -213,6 +216,31 @@ export function registryOverhangFields(
   const o = resolveOverhang(isPartialMask(params.cellMask) ? undefined : params.overhang);
   if (!hasOverhang(o)) return { overhangMm: undefined };
   return { overhangMm: { left: o.left, right: o.right, front: o.front, back: o.back } };
+}
+
+/**
+ * Project the fields a Workshop assembly's registry entry carries out of its
+ * envelope + structure — the assembly counterpart of
+ * {@link registryHeightFields} + {@link registryOverhangFields}. `hasLip` is
+ * always false (a holder's parts stand proud of a plate with no lip), so the
+ * ceiling charges the full rise with no junction credit; parts placed past the
+ * plate edge surface as `overhangMm` so print-bed fit sees the real extent.
+ */
+export function registryAssemblyFields(
+  envelope: ItemEnvelope,
+  structure: AssemblyStructure
+): Pick<CustomBinRef, 'kind' | 'assembledRiseMm' | 'socketless' | 'hasLip' | 'overhangMm'> {
+  const socketAndFloorMm = GRIDFINITY_SPEC.SOCKET_HEIGHT + structure.base.floorThickness;
+  return {
+    kind: 'assembly',
+    assembledRiseMm: assemblyRiseMm(structure, socketAndFloorMm),
+    socketless: false,
+    hasLip: false,
+    overhangMm: assemblyOverhangMm(structure, {
+      w: envelope.width * envelope.gridUnitMm,
+      d: envelope.depth * envelope.gridUnitMm,
+    }),
+  };
 }
 
 /**

--- a/src/features/bin-designer/utils/designKind.test.ts
+++ b/src/features/bin-designer/utils/designKind.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { designId } from '@/core/types';
 import type { BinParams, SavedDesign } from '../types';
-import { designFootprint, isBinDesign } from './designKind';
+import { designFootprint, isBinDesign, isLayoutPlaceableDesign } from './designKind';
 
 function baseDesign(): Omit<SavedDesign, 'params'> {
   return {
@@ -28,6 +28,53 @@ describe('isBinDesign', () => {
       structure: { kind: 'importedMesh', heightUnits: 3 } as SavedDesign['structure'],
     };
     expect(isBinDesign(design)).toBe(false);
+  });
+});
+
+describe('isLayoutPlaceableDesign', () => {
+  const assemblyStructure = {
+    kind: 'assembly',
+    schemaVersion: 1,
+    base: { floorThickness: 2 },
+    mirrorAxis: 'x',
+    parts: [],
+  } as unknown as SavedDesign['structure'];
+  const envelope = { width: 2, depth: 3 } as SavedDesign['envelope'];
+
+  it('accepts bins, imported meshes, and assemblies', () => {
+    expect(isLayoutPlaceableDesign({ ...baseDesign(), params: { width: 2 } as BinParams })).toBe(
+      true
+    );
+    expect(
+      isLayoutPlaceableDesign({
+        ...baseDesign(),
+        kind: 'importedMesh',
+        envelope,
+        structure: { kind: 'importedMesh', heightUnits: 3 } as SavedDesign['structure'],
+      })
+    ).toBe(true);
+    expect(
+      isLayoutPlaceableDesign({
+        ...baseDesign(),
+        kind: 'assembly',
+        envelope,
+        structure: assemblyStructure,
+      })
+    ).toBe(true);
+  });
+
+  it('rejects tool racks and an assembly missing its envelope', () => {
+    expect(
+      isLayoutPlaceableDesign({
+        ...baseDesign(),
+        kind: 'toolRack',
+        envelope,
+        structure: { kind: 'toolRack' } as unknown as SavedDesign['structure'],
+      })
+    ).toBe(false);
+    expect(
+      isLayoutPlaceableDesign({ ...baseDesign(), kind: 'assembly', structure: assemblyStructure })
+    ).toBe(false);
   });
 });
 

--- a/src/features/bin-designer/utils/designKind.ts
+++ b/src/features/bin-designer/utils/designKind.ts
@@ -24,10 +24,16 @@ export function isSyncableDesign(design: SavedDesign): boolean {
   );
 }
 
-/** Kinds that can stand on the layout grid as a bin: parametric bins and
- *  imported meshes. Other non-bin items (tool racks) have no bin semantics. */
+/** Kinds that can stand on the layout grid as a bin: parametric bins,
+ *  imported meshes, and Workshop assemblies (socketed base, so they seat and
+ *  collide like a bin). Legacy tool racks stay out — the migration converts
+ *  them to assemblies. */
 export function isLayoutPlaceableDesign(design: SavedDesign): boolean {
-  return isBinDesign(design) || design.structure?.kind === 'importedMesh';
+  return (
+    isBinDesign(design) ||
+    design.structure?.kind === 'importedMesh' ||
+    (design.structure?.kind === 'assembly' && design.envelope !== undefined)
+  );
 }
 
 export interface DesignFootprint {

--- a/src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.test.tsx
+++ b/src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.test.tsx
@@ -172,7 +172,7 @@ describe('LinkDesignDialog', () => {
     expect(screen.getByLabelText('common.close')).toBeInTheDocument();
   });
 
-  it('lists imported-mesh designs with a matching footprint, excludes tool racks', async () => {
+  it('lists imported-mesh and assembly designs with a matching footprint, excludes tool racks', async () => {
     mockListDesigns.mockResolvedValue({
       ok: true,
       value: [
@@ -196,6 +196,20 @@ describe('LinkDesignDialog', () => {
           kind: 'importedMesh',
           envelope: { width: 4, depth: 4 },
           structure: { kind: 'importedMesh', heightUnits: 2 },
+          thumbnail: null,
+        },
+        {
+          id: 'asm-1',
+          name: 'Workshop Holder',
+          kind: 'assembly',
+          envelope: { width: 2, depth: 3, gridUnitMm: 42, heightUnitMm: 7 },
+          structure: {
+            kind: 'assembly',
+            schemaVersion: 1,
+            base: { floorThickness: 2 },
+            mirrorAxis: 'x',
+            parts: [],
+          },
           thumbnail: null,
         },
         {
@@ -224,6 +238,8 @@ describe('LinkDesignDialog', () => {
     expect(screen.getByText('Parametric Box')).toBeInTheDocument();
     // Imported designs carry a kind badge
     expect(screen.getByText('binDesigner.itemKind.importedMesh')).toBeInTheDocument();
+    expect(screen.getByText('Workshop Holder')).toBeInTheDocument();
+    expect(screen.getByText('binDesigner.itemKind.assembly')).toBeInTheDocument();
     expect(screen.queryByText('Wrong Footprint Mesh')).not.toBeInTheDocument();
     expect(screen.queryByText('Tool Rack')).not.toBeInTheDocument();
   });

--- a/src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.tsx
@@ -297,7 +297,13 @@ export function LinkDesignDialog() {
                 const numCompartments = design.params
                   ? new Set(design.params.compartments.cells).size
                   : 0;
-                const isImportedMesh = design.structure?.kind === 'importedMesh';
+                const structureKind = design.structure?.kind;
+                const kindBadge =
+                  structureKind === 'importedMesh'
+                    ? t('binDesigner.itemKind.importedMesh')
+                    : structureKind === 'assembly'
+                      ? t('binDesigner.itemKind.assembly')
+                      : null;
                 const heightMismatch = dh !== binHeight;
 
                 return (
@@ -339,9 +345,9 @@ export function LinkDesignDialog() {
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-1.5">
                           <p className="truncate text-sm font-medium text-content">{design.name}</p>
-                          {isImportedMesh && (
+                          {kindBadge !== null && (
                             <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded bg-surface-elevated text-content-secondary">
-                              {t('binDesigner.itemKind.importedMesh')}
+                              {kindBadge}
                             </span>
                           )}
                           {heightMismatch && (

--- a/src/shared/types/assemblyPlacement.test.ts
+++ b/src/shared/types/assemblyPlacement.test.ts
@@ -38,6 +38,11 @@ describe('assemblyRiseMm', () => {
     expect(assemblyRiseMm(structureWith([]), 10)).toBe(10);
   });
 
+  it('ignores cutters, whose seat plane is not material', () => {
+    const lifted = part('cutter', 'c', { seatZ: 60 });
+    expect(assemblyRiseMm(structureWith([lifted]), 10)).toBe(10);
+  });
+
   it('stays consistent with assemblyHeightUnits', () => {
     const post = part('post', 'p', {}, {
       params: { diameter: 8, height: 40 },

--- a/src/shared/types/assemblyPlacement.test.ts
+++ b/src/shared/types/assemblyPlacement.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { AssemblyPartNode, AssemblyStructure } from '@/shared/types/assembly';
+import {
+  createAssemblyPartNode,
+  DEFAULT_ASSEMBLY_STRUCTURE,
+  DEFAULT_PART_TRANSFORM,
+} from '@/shared/items/assembly/descriptor';
+import { assemblyHeightUnits, assemblyOverhangMm, assemblyRiseMm } from './assemblyPlacement';
+
+function part(
+  type: AssemblyPartNode['type'],
+  id: string,
+  transform: Partial<AssemblyPartNode['transform']> = {},
+  extra: Partial<AssemblyPartNode> = {}
+): AssemblyPartNode {
+  return {
+    ...createAssemblyPartNode(type, id, { ...DEFAULT_PART_TRANSFORM, x: 84, y: 42, ...transform }),
+    ...extra,
+  } as AssemblyPartNode;
+}
+
+const structureWith = (parts: AssemblyPartNode[]): AssemblyStructure => ({
+  ...DEFAULT_ASSEMBLY_STRUCTURE,
+  parts,
+});
+
+const EXTENT = { w: 168, d: 84 };
+
+describe('assemblyRiseMm', () => {
+  it('is the tallest part top plus socket and floor', () => {
+    const post = part('post', 'p', {}, {
+      params: { diameter: 8, height: 40 },
+    } as Partial<AssemblyPartNode>);
+    expect(assemblyRiseMm(structureWith([post]), 10)).toBe(50);
+  });
+
+  it('is just socket and floor for an empty build', () => {
+    expect(assemblyRiseMm(structureWith([]), 10)).toBe(10);
+  });
+
+  it('stays consistent with assemblyHeightUnits', () => {
+    const post = part('post', 'p', {}, {
+      params: { diameter: 8, height: 40 },
+    } as Partial<AssemblyPartNode>);
+    const structure = structureWith([post]);
+    expect(assemblyHeightUnits(structure, 7, 10)).toBe(
+      Math.ceil(assemblyRiseMm(structure, 10) / 7)
+    );
+  });
+});
+
+describe('assemblyOverhangMm', () => {
+  const blockParams = { params: { width: 40, depth: 20, height: 20 } } as Partial<AssemblyPartNode>;
+
+  it('is undefined when every part stays on the plate', () => {
+    expect(assemblyOverhangMm(structureWith([part('block', 'b', {}, blockParams)]), EXTENT)).toBe(
+      undefined
+    );
+  });
+
+  it('reports per-side excess for a part past the edge', () => {
+    const flush = part('block', 'b', { x: 0, y: 42 }, blockParams);
+    expect(assemblyOverhangMm(structureWith([flush]), EXTENT)).toEqual({
+      left: 20,
+      right: 0,
+      front: 0,
+      back: 0,
+    });
+  });
+
+  it('rotates the footprint before measuring', () => {
+    const rotated = part('block', 'b', { x: 0, y: 42, rotZDeg: 90 }, blockParams);
+    expect(assemblyOverhangMm(structureWith([rotated]), EXTENT)).toEqual({
+      left: 10,
+      right: 0,
+      front: 0,
+      back: 0,
+    });
+  });
+
+  it('ignores cutters', () => {
+    const cutter = part('cutter', 'c', { x: -10, y: 42 });
+    expect(assemblyOverhangMm(structureWith([cutter]), EXTENT)).toBe(undefined);
+  });
+});

--- a/src/shared/types/assemblyPlacement.ts
+++ b/src/shared/types/assemblyPlacement.ts
@@ -203,7 +203,12 @@ export function resolvePlacedParts(
  */
 export function assemblyRiseMm(structure: AssemblyStructure, socketAndFloorMm: number): number {
   const placed = resolvePlacedParts(structure);
-  const maxTop = placed.reduce((max, p) => Math.max(max, p.topZ), 0);
+  // Cutters are subtractive: their seat plane is not material, so it must not
+  // set the standing height.
+  const maxTop = placed.reduce(
+    (max, p) => (p.node.type === 'cutter' ? max : Math.max(max, p.topZ)),
+    0
+  );
   return maxTop + socketAndFloorMm;
 }
 

--- a/src/shared/types/assemblyPlacement.ts
+++ b/src/shared/types/assemblyPlacement.ts
@@ -198,6 +198,16 @@ export function resolvePlacedParts(
 }
 
 /**
+ * Exact standing height in mm, socket and floor included — what the layout's
+ * drawer-ceiling check charges for a placed assembly (`assembledRiseMm`).
+ */
+export function assemblyRiseMm(structure: AssemblyStructure, socketAndFloorMm: number): number {
+  const placed = resolvePlacedParts(structure);
+  const maxTop = placed.reduce((max, p) => Math.max(max, p.topZ), 0);
+  return maxTop + socketAndFloorMm;
+}
+
+/**
  * Overall build height in Gridfinity height units (7mm), socket and floor
  * included — the framing/footprint number a library row reports.
  */
@@ -206,7 +216,40 @@ export function assemblyHeightUnits(
   heightUnitMm: number,
   socketAndFloorMm: number
 ): number {
-  const placed = resolvePlacedParts(structure);
-  const maxTop = placed.reduce((max, p) => Math.max(max, p.topZ), 0);
-  return Math.max(1, Math.ceil((maxTop + socketAndFloorMm) / heightUnitMm));
+  return Math.max(1, Math.ceil(assemblyRiseMm(structure, socketAndFloorMm) / heightUnitMm));
+}
+
+const OVERHANG_EPSILON_MM = 0.05;
+
+/**
+ * Per-side millimetres any part's body extends past the base plate, in the
+ * design's own frame (front = min-y edge). Placement past the edge is legal
+ * (the checker only advises), so the layout's print-bed math must see it —
+ * this is the registry's `overhangMm` for an assembly. Undefined when every
+ * part stays on the plate.
+ */
+export function assemblyOverhangMm(
+  structure: AssemblyStructure,
+  baseExtent: { w: number; d: number }
+): { left: number; right: number; front: number; back: number } | undefined {
+  let left = 0;
+  let right = 0;
+  let front = 0;
+  let back = 0;
+  for (const p of resolvePlacedParts(structure, baseExtent)) {
+    if (p.node.type === 'cutter') continue;
+    const half = partFootprint(p.node);
+    const rad = (p.rotZDeg * Math.PI) / 180;
+    const cos = Math.abs(Math.cos(rad));
+    const sin = Math.abs(Math.sin(rad));
+    const halfW = (cos * half.w + sin * half.d) / 2;
+    const halfD = (sin * half.w + cos * half.d) / 2;
+    left = Math.max(left, halfW - p.x);
+    right = Math.max(right, p.x + halfW - baseExtent.w);
+    front = Math.max(front, halfD - p.y);
+    back = Math.max(back, p.y + halfD - baseExtent.d);
+  }
+  if (Math.max(left, right, front, back) <= OVERHANG_EPSILON_MM) return undefined;
+  const clamp = (v: number): number => (v > OVERHANG_EPSILON_MM ? Math.round(v * 100) / 100 : 0);
+  return { left: clamp(left), right: clamp(right), front: clamp(front), back: clamp(back) };
 }


### PR DESCRIPTION
First of the Workshop layouts-v2 PRs: a saved assembly is now placeable in a drawer layout as a linked design, with the height model told the truth about what it stands like.

- `isLayoutPlaceableDesign` admits assemblies (envelope required), which enables the library's **Place in layout** action and the inspector's **Link Existing** dialog for them; the dialog shows a kind badge, reusing the existing `itemKind` labels.
- `navigateToPlaceInLayout` gains an assembly registry branch, and Workshop autosave now writes the same fields, both through a new `registryAssemblyFields` projection:
  - `assembledRiseMm` is the exact standing height (socket + floor + tallest part top) via a new `assemblyRiseMm` helper that `assemblyHeightUnits` now derives from, so the two can never drift.
  - `hasLip: false` — a holder's parts stand proud of a plate with no lip, so the drawer ceiling charges the full rise with no junction credit; `socketless: false` — the base seats like any bin.
  - Parts placed past the plate edge (legal; the checker only advises) surface as `overhangMm` via a new rotation-aware `assemblyOverhangMm`, so print-bed fit sees the real extent.

Live-verified against dev: saving an assembly with an overhanging block and invoking Place in layout writes the registry entry (rise 47mm, overhang left 20mm), places a linked 2×2×7u bin on the active layer with the design's name, cleans the URL, and the inspector shows the Linked Design panel.

Next PRs in the phase: real assembly meshes in the 3D drawer preview, whole-layout export, and share round-trip.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

