### PR TITLE
feat(workshop): render real assembly meshes in the drawer preview

### DIFF
--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -20,6 +20,7 @@
 import { openDB } from 'idb';
 import type { IDBPDatabase } from 'idb';
 import type { BinParams } from '@/shared/types/bin';
+import type { GridfinityItem } from '@/shared/types/item';
 import type { KernelName } from '@/shared/generation/bridge';
 import type { MeshData } from '@/shared/types/generation';
 import { meshDataByteSize } from './meshBytes';
@@ -201,6 +202,17 @@ function djb2(str: string): string {
 export function binMeshCacheKey(params: BinParams, kernel: KernelName): string {
   const revision = KERNEL_MESH_REVISION[kernel];
   return `${MESH_CACHE_VERSION}:${kernel}-${revision}:${djb2(stableStringify(params))}`;
+}
+
+/**
+ * Content-addressed cache key for a non-bin item's preview mesh (envelope +
+ * discriminated structure). Same kernel-namespacing contract as
+ * {@link binMeshCacheKey}; the `item:` segment keeps the two content spaces
+ * from ever colliding on a hash.
+ */
+export function itemMeshCacheKey(item: GridfinityItem, kernel: KernelName): string {
+  const revision = KERNEL_MESH_REVISION[kernel];
+  return `${MESH_CACHE_VERSION}:${kernel}-${revision}:item:${djb2(stableStringify(item))}`;
 }
 
 /**

--- a/src/shared/hooks/useLinkedDesignMeshes.test.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.test.ts
@@ -136,6 +136,14 @@ function makeAssemblyDesign(): SavedDesign {
       depth: 1,
       gridUnitMm: 42,
       heightUnitMm: 7,
+      attachment: {
+        magnetHoles: false,
+        magnetDiameter: 6.5,
+        magnetDepth: 2.4,
+        screwHoles: false,
+        screwDiameter: 3,
+      },
+      featureColors: { enabled: false },
     } as unknown as SavedDesign['envelope'],
     structure: {
       kind: 'assembly',

--- a/src/shared/hooks/useLinkedDesignMeshes.test.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/shared/generation/meshAsset', () => ({
 vi.mock('@/shared/generation/meshPersistence', () => ({
   // Kernel-sensitive so the per-kernel namespacing is observable.
   binMeshCacheKey: vi.fn((_p: unknown, kernel: KernelName) => `persist-key-${kernel}`),
+  itemMeshCacheKey: vi.fn((_i: unknown, kernel: KernelName) => `item-key-${kernel}`),
   loadPersistedBinMesh: vi.fn(async () => null),
   savePersistedBinMesh: vi.fn(),
 }));
@@ -118,6 +119,31 @@ function makeImportedDesign(): SavedDesign {
         outlines: [],
       },
     },
+    thumbnail: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    exportFileNameConfig: null,
+  };
+}
+
+function makeAssemblyDesign(): SavedDesign {
+  return {
+    id: D1,
+    name: 'Workshop Holder',
+    kind: 'assembly',
+    envelope: {
+      width: 2,
+      depth: 1,
+      gridUnitMm: 42,
+      heightUnitMm: 7,
+    } as unknown as SavedDesign['envelope'],
+    structure: {
+      kind: 'assembly',
+      schemaVersion: 1,
+      base: { floorThickness: 2 },
+      mirrorAxis: 'x',
+      parts: [],
+    } as unknown as SavedDesign['structure'],
     thumbnail: null,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
@@ -226,6 +252,45 @@ describe('useLinkedDesignMeshes', () => {
     const persisted = mockSavePersistedBinMesh.mock.calls[0][1];
     expect(persisted).not.toHaveProperty('labelPlates');
     expect(result.current.get(D1)?.mesh).not.toHaveProperty('labelPlates');
+  });
+
+  it('generates an assembly through the item bridge and persists under the item key', async () => {
+    const mesh = makeMesh();
+    mockUseCustomBins.mockReturnValue([makeRegistryRef()]);
+    mockLoadDesign.mockResolvedValue(ok(makeAssemblyDesign()));
+    const generateItemImmediate = vi.fn(async () => ({ mesh }));
+    mockAcquire.mockResolvedValue({
+      generateItemImmediate,
+    } as unknown as Awaited<ReturnType<typeof bridgeManager.acquire>>);
+
+    const bins = [createTestBin({ linkedDesignId: D1 })];
+    const { result } = renderHook(() => useLinkedDesignMeshes(bins));
+
+    await waitFor(() => {
+      expect(result.current.get(D1)?.mesh).toBe(mesh);
+    });
+    expect(generateItemImmediate).toHaveBeenCalledWith(
+      expect.objectContaining({ structure: expect.objectContaining({ kind: 'assembly' }) })
+    );
+    expect(mockLoadPersistedBinMesh).toHaveBeenCalledWith('item-key-occt-wasm');
+    expect(mockSavePersistedBinMesh).toHaveBeenCalledWith('item-key-occt-wasm', mesh);
+    expect(result.current.get(D1)).toMatchObject({ width: 2, depth: 1 });
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a persisted assembly mesh without touching the bridge', async () => {
+    const mesh = makeMesh();
+    mockUseCustomBins.mockReturnValue([makeRegistryRef()]);
+    mockLoadDesign.mockResolvedValue(ok(makeAssemblyDesign()));
+    mockLoadPersistedBinMesh.mockResolvedValue(mesh);
+
+    const bins = [createTestBin({ linkedDesignId: D1 })];
+    const { result } = renderHook(() => useLinkedDesignMeshes(bins));
+
+    await waitFor(() => {
+      expect(result.current.get(D1)?.mesh).toBe(mesh);
+    });
+    expect(mockAcquire).not.toHaveBeenCalled();
   });
 
   it('decodes imported STL designs on the main thread, centered on XY', async () => {

--- a/src/shared/hooks/useLinkedDesignMeshes.ts
+++ b/src/shared/hooks/useLinkedDesignMeshes.ts
@@ -7,6 +7,8 @@
  * - `importedMesh`: the stored GMA1 asset IS the geometry — decoded on the
  *   main thread and re-framed to the preview convention (XY-centered, Z=0
  *   bottom), exactly like the worker's `importedMeshItem.generate`.
+ * - `assembly`: generated through the item bridge (`generateItemImmediate`),
+ *   content-addressed into the same cross-session mesh cache.
  * - `bin` (params): the cross-session IndexedDB mesh cache is tried first
  *   (`meshPersistence`, keyed by params hash + active kernel — instant for any
  *   design the user has opened); on a miss the mesh is generated via
@@ -25,6 +27,7 @@ import { loadDesign, useCustomBins, type SavedDesign } from '@/features/bin-desi
 import { decodeMeshData } from '@/shared/generation/meshAsset';
 import {
   binMeshCacheKey,
+  itemMeshCacheKey,
   loadPersistedBinMesh,
   savePersistedBinMesh,
 } from '@/shared/generation/meshPersistence';
@@ -32,6 +35,7 @@ import { bridgeManager, getActiveKernel } from '@/shared/generation/bridge';
 import { withSocketNozzle } from '@/shared/generation/socketNozzle';
 import { useSettingsStore } from '@/core/store';
 import type { MeshData } from '@/shared/types/generation';
+import type { GridfinityItem } from '@/shared/types/item';
 
 /** A resolved design mesh ready for layout preview rendering. */
 export interface LinkedDesignMesh {
@@ -135,6 +139,27 @@ async function resolveDesignMesh(
       triangleCount: indices.length / 3,
     };
     return { sig, mesh, width: design.envelope.width, depth: design.envelope.depth };
+  }
+
+  if (structure?.kind === 'assembly' && design.envelope) {
+    const item: GridfinityItem = { envelope: design.envelope, structure };
+    // Content-addressed like the bin path, so a returning user's drawer shows
+    // the holder instantly without a worker round-trip.
+    const persistKey = itemMeshCacheKey(item, getActiveKernel());
+    const persisted = await loadPersistedBinMesh(persistKey);
+    if (persisted) {
+      return { sig, mesh: persisted, width: design.envelope.width, depth: design.envelope.depth };
+    }
+    const bridge = await bridgeManager.acquire();
+    try {
+      const result = await bridge.generateItemImmediate(item);
+      if (result.mesh.vertices.length === 0) return null;
+      const mesh = stripLabelPlates(result.mesh);
+      savePersistedBinMesh(persistKey, mesh);
+      return { sig, mesh, width: design.envelope.width, depth: design.envelope.depth };
+    } finally {
+      bridgeManager.release();
+    }
   }
 
   const params = design.params;


### PR DESCRIPTION
Second of the Workshop layouts-v2 PRs. A placed assembly now shows its real generated geometry in the layout's 3D drawer preview instead of falling through to the stylized box.

- `resolveDesignMesh` gains an assembly branch that generates through the item bridge (`generateItemImmediate`) — the same worker path the Workshop's own sharp preview uses — so the drawer shows the actual posts, fins, and cutouts.
- A new `itemMeshCacheKey` content-addresses the result into the same cross-session IndexedDB mesh cache bins use (kernel-namespaced, `item:` segment so the two content spaces can't collide on a hash), so a returning user's drawer shows the holder instantly with no worker round-trip.
- The rest of the preview pipeline (rotation detection, LRU geometry cache, sequential resolve queue) is kind-agnostic and needed no changes.

Live-verified against dev: a placed 2×2 holder with two posts and a fin renders its true mesh in the isometric drawer preview at its placed position.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

