### PR TITLE
fix(bin-designer): stop side-panel controls clipping their content

### DIFF
--- a/src/design-system/Collapsible/Collapsible.tsx
+++ b/src/design-system/Collapsible/Collapsible.tsx
@@ -250,7 +250,12 @@ export const Collapsible = forwardRef<HTMLDivElement, CollapsibleProps>(
           aria-hidden={!expanded}
           inert={!expanded ? true : undefined}
           className={cn(
-            'overflow-hidden',
+            // `-mx-2 px-2` widens the clip box without moving the content:
+            // overflow clips to the padding box, so full-row controls that
+            // bleed their hover surface outward (CheckboxRow's `-mx-1.5`,
+            // ColorZoneRow's `-mx-2`) keep their rounded corners instead of
+            // being sliced square by the max-height animation.
+            'overflow-hidden -mx-2 px-2',
             hasToggled && 'transition-all duration-200',
             expanded ? 'opacity-100 max-h-[2000px] mt-3' : 'opacity-0 max-h-0'
           )}

--- a/src/design-system/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.test.tsx
@@ -195,6 +195,11 @@ describe('SegmentedControl', () => {
     }
   });
 
+  it('wraps segments instead of overflowing a narrow container', () => {
+    render(<SegmentedControl {...defaultProps} />);
+    expect(screen.getByRole('radiogroup').className).toContain('flex-wrap');
+  });
+
   it('applies className to the group container', () => {
     render(<SegmentedControl {...defaultProps} className="custom-class" />);
     expect(screen.getByRole('radiogroup')).toHaveClass('custom-class');

--- a/src/design-system/SegmentedControl/SegmentedControl.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.tsx
@@ -4,13 +4,20 @@ import { cva } from 'class-variance-authority';
 import { cn } from '../cn';
 import { focusRing, disabledStyles, interactiveTransition } from '../variants';
 
-const groupVariants = cva(['inline-flex rounded-lg bg-surface p-0.5', 'border border-stroke'], {
-  variants: {
-    fullWidth: {
-      true: 'flex w-full',
+// `flex-wrap`: every panel section that hosts one of these sits inside an
+// overflow-hidden animation wrapper (Collapsible, StickyGroupHeader), so a
+// row too wide for its column is silently cut off rather than scrolled.
+// Segments keep their natural width and spill onto a second row instead.
+const groupVariants = cva(
+  ['inline-flex flex-wrap gap-y-0.5 rounded-lg bg-surface p-0.5', 'border border-stroke'],
+  {
+    variants: {
+      fullWidth: {
+        true: 'flex w-full',
+      },
     },
-  },
-});
+  }
+);
 
 const segmentVariants = cva(
   [

--- a/src/features/bin-designer/components/BentoWorkspace/BentoBinWideSection.test.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoBinWideSection.test.tsx
@@ -34,10 +34,10 @@ describe('BentoBinWideSection', () => {
     const before = useDesignerStore.getState().params.compartments;
     render(<BentoBinWideSection />);
 
-    fireEvent.click(screen.getByText('2.4'));
+    fireEvent.click(screen.getByText('2.6'));
 
     const after = useDesignerStore.getState().params.compartments;
-    expect(after.thickness).toBe(2.4);
+    expect(after.thickness).toBe(2.6);
     expect(after.cols).toBe(before.cols);
     expect(after.rows).toBe(before.rows);
     expect(after.cells).toEqual(before.cells);

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.test.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.test.tsx
@@ -313,10 +313,11 @@ describe('ParameterPanel', () => {
     it('wall thickness slider shows tick marks for options', () => {
       render(<ParameterPanel />);
 
-      // SnappingSlider shows tick buttons for each option
+      // Labelled stops are spaced to clear each other, so 2.4 stays unlabelled
+      // next to the 2.6 end stop.
       expect(screen.getByLabelText('Select 0.4mm')).toBeInTheDocument();
       expect(screen.getByLabelText('Select 1.2mm')).toBeInTheDocument();
-      expect(screen.getByLabelText('Select 2.4mm')).toBeInTheDocument();
+      expect(screen.getByLabelText('Select 2.6mm')).toBeInTheDocument();
     });
 
     it('clicking a tick mark updates the store', () => {

--- a/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.test.tsx
+++ b/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.test.tsx
@@ -35,6 +35,44 @@ describe('SnappingSlider', () => {
     expect(screen.getByLabelText('Select 2mm')).toBeInTheDocument();
   });
 
+  it('labels a percentage scale, not just the selected stop', () => {
+    const coverage: SnappingSliderOption[] = [50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100].map(
+      (value) => ({ value, description: '' })
+    );
+    render(
+      <SnappingSlider
+        label="Rail coverage"
+        value={50}
+        onChange={vi.fn()}
+        options={coverage}
+        unit="%"
+      />
+    );
+    for (const value of [50, 60, 70, 80, 90, 100]) {
+      expect(screen.getByLabelText(`Select ${value}%`)).toBeInTheDocument();
+    }
+  });
+
+  it('drops a labelled stop that would collide with its neighbour', () => {
+    const crowded: SnappingSliderOption[] = [0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 2.6].map((value) => ({
+      value,
+      description: '',
+    }));
+    render(<SnappingSlider {...defaultProps} options={crowded} value={1.2} />);
+    // 2.4 sits one ninth of the track from 2.6, too close for both labels.
+    expect(screen.getByLabelText('Select 2.6mm')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Select 2.4mm')).not.toBeInTheDocument();
+  });
+
+  it('always labels the selected stop', () => {
+    const crowded: SnappingSliderOption[] = [0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 2.6].map((value) => ({
+      value,
+      description: '',
+    }));
+    render(<SnappingSlider {...defaultProps} options={crowded} value={2.4} />);
+    expect(screen.getByLabelText('Select 2.4mm')).toBeInTheDocument();
+  });
+
   it('shows description for current value', () => {
     render(<SnappingSlider {...defaultProps} value={1.2} />);
     expect(screen.getByText('Standard')).toBeInTheDocument();

--- a/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
+++ b/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
@@ -40,8 +40,38 @@ interface SnappingSliderProps {
   tip?: string;
 }
 
-/** Values that should always show labels (key waypoints) */
-const KEY_VALUES = new Set([0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 2.6]);
+/**
+ * Pick which stops get a printed label, spacing them so they cannot collide.
+ * Positions are percentages of the track, and the gap is derived from the
+ * widest label against the narrowest track the sidebar ever gets (~200px), so
+ * the same rule holds for millimetre stops and percentage stops alike.
+ */
+function pickLabelledValues(
+  values: number[],
+  active: number,
+  positionOf: (v: number) => number
+): Set<number> {
+  if (values.length === 0) return new Set();
+
+  const widestLabel = Math.max(...values.map((v) => String(v).length));
+  const minGapPct = ((widestLabel * 7 + 10) / 200) * 100;
+
+  const chosen: number[] = [];
+  const clears = (v: number) =>
+    chosen.every((c) => Math.abs(positionOf(v) - positionOf(c)) >= minGapPct);
+  const take = (v: number | undefined) => {
+    if (v !== undefined && !chosen.includes(v) && clears(v)) chosen.push(v);
+  };
+
+  // The selected stop outranks the ends: it is the one the reader is looking
+  // for, and the thumb already marks where it sits.
+  take(values.find((v) => Math.abs(v - active) < 0.001));
+  take(values[0]);
+  take(values[values.length - 1]);
+  for (const v of values) take(v);
+
+  return new Set(chosen);
+}
 
 export function SnappingSlider({
   label,
@@ -178,6 +208,11 @@ export function SnappingSlider({
     [disabled, values, value, onChange]
   );
 
+  const labelledValues = useMemo(
+    () => pickLabelledValues(values, value, getPosition),
+    [values, value, getPosition]
+  );
+
   const handleTickClick = useCallback(
     (tickValue: number) => {
       if (!disabled) {
@@ -293,8 +328,7 @@ export function SnappingSlider({
         <div className="relative mt-1 h-9">
           {options.map((option) => {
             const isActive = Math.abs(option.value - value) < 0.001;
-            const showLabel = KEY_VALUES.has(option.value) || isActive;
-            if (!showLabel) return null;
+            if (!labelledValues.has(option.value)) return null;
             return (
               <Button
                 key={option.value}

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorZoneRow.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorZoneRow.tsx
@@ -90,7 +90,10 @@ export function ColorZoneRow({
         onPointerLeave={() => {
           if (!isOpen) onHover(null);
         }}
-        className="group flex w-full items-center gap-3 rounded-lg px-2 py-2 -mx-2 transition-colors hover:bg-surface-hover focus-visible:bg-surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 data-[open=true]:bg-surface-hover md:py-1.5"
+        // `justify-start` overrides the Button base: centred content splits any
+        // overflow across both edges, which clips the leading swatch instead of
+        // running off the trailing side.
+        className="group flex w-full items-center justify-start gap-3 rounded-lg px-2 py-2 -mx-2 transition-colors hover:bg-surface-hover focus-visible:bg-surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40 data-[open=true]:bg-surface-hover md:py-1.5"
         aria-expanded={isOpen}
         aria-haspopup="dialog"
         aria-label={`${label}: ${color}`}
@@ -100,7 +103,9 @@ export function ColorZoneRow({
           className="w-6 h-6 rounded-md border border-stroke-subtle/60 shrink-0 shadow-inner transition-transform group-hover:scale-105"
           style={{ backgroundColor: color }}
         />
-        <span className="flex-1 text-left text-xs font-normal text-content-secondary">{label}</span>
+        <span className="min-w-0 flex-1 truncate text-left text-xs font-normal text-content-secondary">
+          {label}
+        </span>
         <span className="font-mono text-[11px] font-normal text-content-secondary tabular-nums">
           {color}
         </span>


### PR DESCRIPTION
Four controls in the bin designer side panel were losing content to the `overflow-hidden` wrappers that drive the section expand animations (`Collapsible`'s max-height, `StickyGroupHeader`'s grid-template-rows). Hidden overflow is load-bearing for those animations, so each fix lives in the control rather than the wrapper.

Found by driving the running app with Playwright: every section, toggle and conditional control expanded, then each element's right edge compared against its nearest clipping ancestor.

## SegmentedControl: rows cut off at the panel edge

Segments are `whitespace-nowrap` and, under `fullWidth`, flex items with the default `min-width: auto`, so they refuse to shrink and the group grows past the 288px column. Normally that scrolls; inside a hidden-overflow wrapper it is silently cut.

| Control | English | German |
| --- | --- | --- |
| Lid → Attachment | 16px cut | 81px cut |
| Type → Case | fit by 19px | 60px cut |
| Relief | spilled 18px into padding | 3px cut |

`Attachment` also painted its pills outside its own rounded track (33px of self-overflow). Segments now wrap onto a second row, keeping full labels.

## SnappingSlider: two of four sliders had no scale

The stops that get a printed number came from a hardcoded set of wall-thickness values, but the control has four consumers. Rail coverage (50-100 by 5) and grip coverage (10-100 by 5) match none of them, so both rendered a row of anonymous ticks with one orphan number under the thumb.

| Slider | Ticks | Labels before | Labels after |
| --- | --- | --- | --- |
| Wall thickness | 9 | 0.4 0.8 1.2 1.6 2 **2.4 2.6** (colliding) | 0.4 0.8 1.2 1.6 2 2.6 |
| Rail coverage | 11 | **50** only | 50 60 70 80 90 100 |
| Grip coverage | 19 | active only | full scale |

`pickLabelledValues()` takes the selected stop first, then the ends, then any remaining stop clearing its neighbours by a gap derived from the widest label against the narrowest track the sidebar reaches. One rule covers the missing scales and the 2.4/2.6 collision, and it holds when an option set changes.

## Collapsible: hover surfaces sliced square

`CheckboxRow` bleeds its hover surface outward with `-mx-1.5` so the highlight reaches into the section padding. Inside a `Collapsible` that bleed was cut off, rendering the rounded rectangle with square edges on both sides.

Overflow clips to the padding box, so equal padding and negative margin widen the clip region while leaving content exactly where it was. Confirmed: a group inside a collapsible still measures `left:16 right:271 width:255`, unchanged, while the wrapper's clip box grew to 8→279 and `scrollWidth === clientWidth`.

## ColorZoneRow: German rows clipped the swatch, not the text

The label span was `flex-1` with no `min-w-0`, so a long word like "Beschriftungslasche" could not shrink and forced the row to overflow. The DS `Button` base contributes `justify-center`, which splits overflow across both edges, so the damage landed on the leading color swatch. The label now truncates and the row packs from the start.

## Verification

Browser overflow audit over the whole panel, every section expanded:

- en @1440: **0 clipped**, down from 2 (remaining hits are the intentional `truncate` on group-header summaries)
- de @1440: **0 clipped**, down from 4
- en @880, the landscape-tablet `w-64` panel: **0 clipped**
- Nothing escapes the 288px panel column

800 test files / 10,310 tests green across `design-system`, `bin-designer` and `shared`. Typecheck and eslint clean.

Two existing tests asserted on the `Select 2.4mm` label, now correctly suppressed beside 2.6. They moved to 2.6 rather than losing the assertion, since "the scale reaches the max stop" is the property they were checking.

Not changed: the `BASE` group-header summary truncates 244px of "Standard · 6.5mm magnets · M3 screws · Stacking lip" (271px in German). It degrades gracefully and is `aria-hidden`, but at 288px only the first two facts ever show. Shortening that copy is a separate call.

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

