### PR TITLE
feat(workshop): carry assemblies in shared and archived layouts

### DIFF
--- a/api/lib/contentFilter.ts
+++ b/api/lib/contentFilter.ts
@@ -291,7 +291,7 @@ function collectDesignText(value: unknown, out: string[], depth = 0, key?: strin
  * itself gets — otherwise `linkedDesigns` is a way around it.
  */
 export function filterSharedDesignsContent(
-  designs: ReadonlyArray<{ name: string; params: unknown }>
+  designs: ReadonlyArray<{ name: string; params?: unknown }>
 ): ContentFilterResult {
   for (const design of designs) {
     const nameResult = checkText(design.name);

--- a/api/lib/validation.test.ts
+++ b/api/lib/validation.test.ts
@@ -988,6 +988,68 @@ describe('validateSharedDesigns', () => {
     }
   });
 
+  const assemblyEnvelope = () => ({
+    width: 4,
+    depth: 2,
+    gridUnitMm: 42,
+    heightUnitMm: 7,
+    attachment: {
+      magnetHoles: false,
+      magnetDiameter: 6.5,
+      magnetDepth: 2.4,
+      screwHoles: false,
+      screwDiameter: 3,
+    },
+    featureColors: { enabled: false },
+  });
+  const assemblyStructure = () => ({
+    kind: 'assembly',
+    schemaVersion: 1,
+    base: { floorThickness: 2 },
+    mirrorAxis: 'x',
+    parts: [
+      {
+        id: 'p1',
+        type: 'post',
+        params: { diameter: 8, height: 40, taperDeg: 0, tipChamfer: 1 },
+        transform: { x: 20, y: 20, seatZ: 0, rotZDeg: 0 },
+        children: [],
+      },
+    ],
+  });
+  const assemblyDesign = (over: Record<string, unknown> = {}) => ({
+    id: 'design_asm',
+    name: 'Pliers Rack',
+    kind: 'assembly',
+    envelope: assemblyEnvelope(),
+    structure: assemblyStructure(),
+    ...over,
+  });
+
+  it('accepts a well-formed assembly entry alongside a bin design', () => {
+    const result = validateSharedDesigns([design(), assemblyDesign()]);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.designs).toHaveLength(2);
+      expect(result.designs[1]).toMatchObject({ id: 'design_asm', kind: 'assembly' });
+      expect(result.designs[1].structure).toBeDefined();
+      expect(result.designs[1].params).toBeUndefined();
+    }
+  });
+
+  it('rejects an assembly entry with an invalid structure', () => {
+    const bad = assemblyDesign({ structure: { kind: 'assembly', schemaVersion: 2 } });
+    const result = validateSharedDesigns([bad]);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects an assembly entry with an invalid envelope', () => {
+    const bad = assemblyDesign({ envelope: { width: 500 } });
+    const result = validateSharedDesigns([bad]);
+    expect(result.valid).toBe(false);
+  });
+
   it('rejects a non-array payload', () => {
     expect(validateSharedDesigns({ id: 'design_1' }).valid).toBe(false);
   });

--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -5,6 +5,7 @@
 
 import { isNumber, isObject, inRange, validationError } from './validationUtils.js';
 import { validateDesignerShare } from './designerValidation.js';
+import { validateAssemblyEnvelope, validateAssemblyStructure } from './assemblyValidation.js';
 
 // Constraints for shared layouts
 const SHARE_CONSTRAINTS = {
@@ -47,6 +48,8 @@ const DESIGN_ID_MAX_LENGTH = 64;
  */
 const MAX_LINKED_DESIGNS = 250;
 const MAX_LINKED_DESIGNS_BYTES = 512 * 1024;
+// Per-assembly cap, matching the sync endpoint's design payload budget.
+const MAX_ASSEMBLY_DESIGN_BYTES = 100 * 1024;
 const DESIGN_NAME_MAX_LENGTH = 64;
 
 /** Reserved keys that cannot be used as custom property names */
@@ -398,11 +401,15 @@ export function validateShareLayout(data: unknown, jsonSize: number): Validation
   };
 }
 
-/** A bin design travelling with a shared layout, keyed by the id its bins carry. */
+/** A design travelling with a shared layout, keyed by the id its bins carry.
+ *  Bin designs carry `params`; Workshop assemblies carry envelope + structure. */
 export interface SharedDesignShape {
   id: string;
   name: string;
-  params: Record<string, unknown>;
+  params?: Record<string, unknown>;
+  kind?: 'assembly';
+  envelope?: Record<string, unknown>;
+  structure?: Record<string, unknown>;
 }
 
 export type SharedDesignsResult =
@@ -447,6 +454,51 @@ export function validateSharedDesigns(data: unknown): SharedDesignsResult {
     }
     // Bins share designs freely, so the client can emit the same id twice.
     if (seen.has(id)) continue;
+
+    if (entry.kind === 'assembly') {
+      // Assemblies ride the same deep validators the sync endpoint uses, so a
+      // layout share can't become a side door around them.
+      const envelopeResult = validateAssemblyEnvelope(entry.envelope);
+      if (!envelopeResult.valid) {
+        return validationError(
+          'VALIDATION_ERROR',
+          `Invalid linked design envelope: ${envelopeResult.error.message}`
+        );
+      }
+      const structureResult = validateAssemblyStructure(entry.structure);
+      if (!structureResult.valid) {
+        return validationError(
+          'VALIDATION_ERROR',
+          `Invalid linked design structure: ${structureResult.error.message}`
+        );
+      }
+      const assemblyBytes = JSON.stringify({
+        envelope: entry.envelope,
+        structure: entry.structure,
+      }).length;
+      if (assemblyBytes > MAX_ASSEMBLY_DESIGN_BYTES) {
+        return validationError(
+          'SIZE_LIMIT',
+          `Linked assembly exceeds maximum size of ${MAX_ASSEMBLY_DESIGN_BYTES / 1024}KB`
+        );
+      }
+      totalBytes += assemblyBytes;
+      if (totalBytes > MAX_LINKED_DESIGNS_BYTES) {
+        return validationError(
+          'SIZE_LIMIT',
+          `Linked designs exceed maximum size of ${MAX_LINKED_DESIGNS_BYTES / 1024}KB`
+        );
+      }
+      seen.add(id);
+      designs.push({
+        id: sanitizeString(id, DESIGN_ID_MAX_LENGTH),
+        name: sanitizeString(name, DESIGN_NAME_MAX_LENGTH),
+        kind: 'assembly',
+        envelope: entry.envelope as Record<string, unknown>,
+        structure: entry.structure as Record<string, unknown>,
+      });
+      continue;
+    }
 
     const paramsBytes = JSON.stringify(params ?? null).length;
     const result = validateDesignerShare({ type: 'designer', version: 1, params }, paramsBytes);

--- a/docs/schemas/layout.md
+++ b/docs/schemas/layout.md
@@ -426,11 +426,14 @@ like layer and category ids.
 
 <!-- generated:start -->
 
-| Field    | Type                                   | Required | Default | Constraint  | Notes                                          |
-| -------- | -------------------------------------- | -------- | ------- | ----------- | ---------------------------------------------- |
-| `id`     | `string`                               | yes      |         | length >= 1 | Design id, matched against Bin.linkedDesignId. |
-| `name`   | `string`                               | yes      |         |             | Design name.                                   |
-| `params` | [`BinParams`](bin-design.md#binparams) | yes      |         |             |                                                |
+| Field       | Type                                   | Required | Default | Constraint  | Notes                                                                                                   |
+| ----------- | -------------------------------------- | -------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------- |
+| `id`        | `string`                               | yes      |         | length >= 1 | Design id, matched against Bin.linkedDesignId.                                                          |
+| `name`      | `string`                               | yes      |         |             | Design name.                                                                                            |
+| `params`    | [`BinParams`](bin-design.md#binparams) |          |         |             |                                                                                                         |
+| `kind`      | `"assembly"`                           |          |         |             | Discriminator for assembly entries.                                                                     |
+| `envelope`  | `object`                               |          |         |             | Assembly envelope: footprint in grid units plus unit sizes. Present only on assembly entries.           |
+| `structure` | `object`                               |          |         |             | Assembly part tree; validated in depth by the app's schema on import. Present only on assembly entries. |
 
 <!-- generated:end -->
 

--- a/public/schema/layout.schema.json
+++ b/public/schema/layout.schema.json
@@ -595,8 +595,8 @@
     },
     "LinkedDesign": {
       "type": "object",
-      "description": "A bin design embedded in the layout file so bins keep their geometry when the layout travels.",
-      "required": ["id", "name", "params"],
+      "description": "A design embedded in the layout file so bins keep their geometry when the layout travels: a bin design (params) or a Workshop assembly (kind + envelope + structure). The oneOf pins which of the two field sets an entry must carry.",
+      "required": ["id", "name"],
       "properties": {
         "id": {
           "type": "string",
@@ -609,8 +609,67 @@
         },
         "params": {
           "$ref": "https://gridfinitylayouttool.com/schema/bin-design.schema.json#/$defs/BinParams"
+        },
+        "kind": {
+          "const": "assembly",
+          "description": "Discriminator for assembly entries."
+        },
+        "envelope": {
+          "type": "object",
+          "description": "Assembly envelope: footprint in grid units plus unit sizes. Present only on assembly entries.",
+          "required": ["width", "depth", "gridUnitMm", "heightUnitMm"],
+          "properties": {
+            "width": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "depth": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "gridUnitMm": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "heightUnitMm": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            }
+          }
+        },
+        "structure": {
+          "type": "object",
+          "description": "Assembly part tree; validated in depth by the app's schema on import. Present only on assembly entries.",
+          "required": ["kind", "base", "parts"],
+          "properties": {
+            "kind": {
+              "const": "assembly"
+            },
+            "base": {
+              "type": "object"
+            },
+            "parts": {
+              "type": "array"
+            }
+          }
         }
-      }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "params": {}
+          },
+          "required": ["params"]
+        },
+        {
+          "properties": {
+            "kind": {},
+            "envelope": {},
+            "structure": {}
+          },
+          "required": ["kind", "envelope", "structure"]
+        }
+      ]
     },
     "BaseplateParams": {
       "type": "object",

--- a/src/core/api/share.ts
+++ b/src/core/api/share.ts
@@ -29,7 +29,12 @@ export interface ShareMetadata {
 export interface SharedLinkedDesign {
   id: string;
   name: string;
-  params: unknown;
+  /** Bin params; absent on an assembly entry. */
+  params?: unknown;
+  /** Workshop assembly entries carry envelope + structure instead of params. */
+  kind?: 'assembly';
+  envelope?: unknown;
+  structure?: unknown;
 }
 
 export interface FetchShareResponse {
@@ -139,16 +144,21 @@ function validateFetchShareResponse(
   // guard doesn't validate this field, so re-check it as untrusted input.
   const raw: unknown = data.linkedDesigns;
   const linkedDesigns = Array.isArray(raw)
-    ? raw.filter(
-        (entry): entry is SharedLinkedDesign =>
-          typeof entry === 'object' &&
-          entry !== null &&
-          typeof (entry as Record<string, unknown>).id === 'string' &&
-          typeof (entry as Record<string, unknown>).name === 'string' &&
-          typeof (entry as Record<string, unknown>).params === 'object' &&
-          (entry as Record<string, unknown>).params !== null &&
-          !Array.isArray((entry as Record<string, unknown>).params)
-      )
+    ? raw.filter((entry): entry is SharedLinkedDesign => {
+        if (typeof entry !== 'object' || entry === null) return false;
+        const e = entry as Record<string, unknown>;
+        if (typeof e.id !== 'string' || typeof e.name !== 'string') return false;
+        if (
+          e.kind === 'assembly' &&
+          typeof e.envelope === 'object' &&
+          e.envelope !== null &&
+          typeof e.structure === 'object' &&
+          e.structure !== null
+        ) {
+          return true;
+        }
+        return typeof e.params === 'object' && e.params !== null && !Array.isArray(e.params);
+      })
     : undefined;
 
   return { valid: true, data: { ...data, linkedDesigns } };

--- a/src/core/storage/BulkArchiveService.ts
+++ b/src/core/storage/BulkArchiveService.ts
@@ -19,7 +19,10 @@ import { getDesignStorePort } from './designStorePort';
 interface LinkedDesignExport {
   readonly id: string;
   readonly name: string;
-  readonly params: unknown;
+  readonly params?: unknown;
+  readonly kind?: 'assembly';
+  readonly envelope?: unknown;
+  readonly structure?: unknown;
 }
 
 interface ArchiveLayoutEntry {
@@ -115,11 +118,17 @@ export async function exportAllLayouts(
           if (port !== null) {
             for (const id of designIds) {
               const result = await port.loadDesign(id);
-              if (isOk(result)) {
+              if (!isOk(result)) continue;
+              const design = result.value;
+              if (design.params) {
+                linkedDesigns.push({ id: design.id, name: design.name, params: design.params });
+              } else if (design.kind === 'assembly' && design.envelope && design.structure) {
                 linkedDesigns.push({
-                  id: result.value.id,
-                  name: result.value.name,
-                  params: result.value.params,
+                  id: design.id,
+                  name: design.name,
+                  kind: 'assembly',
+                  envelope: design.envelope,
+                  structure: design.structure,
                 });
               }
             }

--- a/src/core/storage/ShareService.test.ts
+++ b/src/core/storage/ShareService.test.ts
@@ -680,6 +680,41 @@ describe('storage-share', () => {
       expect(mockLoadDesign).toHaveBeenCalledWith('design-1');
     });
 
+    it('embeds an assembly design as kind + envelope + structure', async () => {
+      const layout = createLayoutWithLinkedDesigns();
+      mockLoadDesign.mockResolvedValue(
+        ok({
+          id: 'design-1',
+          name: 'Pliers Rack',
+          kind: 'assembly',
+          envelope: { width: 2, depth: 2, gridUnitMm: 42, heightUnitMm: 7 },
+          structure: {
+            kind: 'assembly',
+            schemaVersion: 1,
+            base: { floorThickness: 2 },
+            mirrorAxis: 'x',
+            parts: [],
+          },
+          thumbnail: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+          exportFileNameConfig: null,
+        })
+      );
+
+      const json = await exportLayoutJSONWithDesigns(layout);
+      const parsed = JSON.parse(json);
+
+      expect(parsed.linkedDesigns).toHaveLength(1);
+      expect(parsed.linkedDesigns[0]).toMatchObject({
+        id: 'design-1',
+        name: 'Pliers Rack',
+        kind: 'assembly',
+      });
+      expect(parsed.linkedDesigns[0].structure.kind).toBe('assembly');
+      expect(parsed.linkedDesigns[0].params).toBeUndefined();
+    });
+
     it('omits designs that cannot be found in IndexedDB (deleted designs)', async () => {
       const layout = createLayoutWithLinkedDesigns();
 
@@ -795,6 +830,52 @@ describe('storage-share', () => {
         thumbnail: null,
         exportFileNameConfig: null,
       });
+    });
+
+    it('saves an embedded assembly through the port with its structure', async () => {
+      const layout = createTestLayout();
+      layout.bins[0].linkedDesignId = designId('old-asm-id');
+
+      const json = JSON.stringify({
+        ...layout,
+        linkedDesigns: [
+          {
+            id: 'old-asm-id',
+            name: 'Travel Rack',
+            kind: 'assembly',
+            envelope: { width: 2, depth: 2, gridUnitMm: 42, heightUnitMm: 7 },
+            structure: {
+              kind: 'assembly',
+              schemaVersion: 1,
+              base: { floorThickness: 2 },
+              mirrorAxis: 'x',
+              parts: [],
+            },
+          },
+        ],
+      });
+
+      mockSaveDesign.mockResolvedValue(
+        ok({
+          id: 'new-asm-id',
+          name: 'Travel Rack',
+          thumbnail: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+          exportFileNameConfig: null,
+        })
+      );
+
+      const result = await restoreEmbeddedDesigns(json, layout);
+
+      expect(result.importedDesignCount).toBe(1);
+      expect(mockSaveDesign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'assembly',
+          structure: expect.objectContaining({ kind: 'assembly' }),
+        })
+      );
+      expect(result.layout.bins[0].linkedDesignId).toBe('new-asm-id');
     });
 
     it('updates linkedDesignId references on bins', async () => {
@@ -960,6 +1041,84 @@ describe('storage-share', () => {
     beforeEach(() => {
       vi.clearAllMocks();
       registerDesignStorePort(fakePort);
+    });
+
+    const assemblyEnvelope = () => ({
+      width: 2,
+      depth: 2,
+      gridUnitMm: 42,
+      heightUnitMm: 7,
+      attachment: {
+        magnetHoles: false,
+        magnetDiameter: 6.5,
+        magnetDepth: 2.4,
+        screwHoles: false,
+        screwDiameter: 3,
+      },
+      featureColors: { enabled: false },
+    });
+    const assemblyStructure = () => ({
+      kind: 'assembly',
+      schemaVersion: 1,
+      base: { floorThickness: 2 },
+      mirrorAxis: 'x',
+      parts: [
+        {
+          id: 'p1',
+          type: 'post',
+          params: { diameter: 8, height: 40 },
+          transform: { x: 42, y: 42, seatZ: 0, rotZDeg: 0 },
+          children: [],
+        },
+      ],
+    });
+
+    it('persists a travelling assembly and registers it with its rise fields', async () => {
+      mockSaveDesign.mockResolvedValue(savedAs('design_shared_asm'));
+
+      const result = await restoreSharedDesigns(SHARE_ID, layoutLinkedTo('remote-asm-1'), [
+        {
+          id: 'remote-asm-1',
+          name: 'Pliers Rack',
+          kind: 'assembly',
+          envelope: assemblyEnvelope(),
+          structure: assemblyStructure(),
+        },
+      ]);
+
+      expect(mockSaveDesign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'assembly',
+          envelope: expect.objectContaining({ width: 2, depth: 2 }),
+          structure: expect.objectContaining({ kind: 'assembly' }),
+        })
+      );
+      expect(mockUpsertRegistryEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'assembly',
+          hasLip: false,
+          socketless: false,
+          // 40mm post + socket + 2mm floor, in 7mm units.
+          height: 7,
+          assembledRiseMm: expect.any(Number),
+        })
+      );
+      expect(result.bins[0].linkedDesignId).toBe('design_shared_asm');
+    });
+
+    it('skips an assembly entry whose structure fails the shape guard', async () => {
+      const result = await restoreSharedDesigns(SHARE_ID, layoutLinkedTo('remote-asm-1'), [
+        {
+          id: 'remote-asm-1',
+          name: 'Broken',
+          kind: 'assembly',
+          envelope: assemblyEnvelope(),
+          structure: { kind: 'assembly' },
+        },
+      ]);
+
+      expect(mockSaveDesign).not.toHaveBeenCalled();
+      expect(result.bins[0].linkedDesignId).toBe('remote-asm-1');
     });
 
     it('returns the layout untouched when no designs travelled with it', async () => {

--- a/src/core/storage/ShareService.ts
+++ b/src/core/storage/ShareService.ts
@@ -18,11 +18,56 @@ import type { Result, ValidationError } from '@/core/result';
 import { ok, err, validationImportFailed, isOk } from '@/core/result';
 import { getDesignStorePort } from './designStorePort';
 import type { BinParams } from '@/shared/types/bin';
+import type { AssemblyStructure } from '@/shared/types/assembly';
+import {
+  assemblyHeightUnits,
+  assemblyOverhangMm,
+  assemblyRiseMm,
+} from '@/shared/types/assemblyPlacement';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { hasOversizedMeshAsset } from '@/shared/generation/meshAsset';
+
+/** A design travelling with a layout: bin params, or an assembly's
+ *  envelope + structure. Exactly one of the two shapes is populated. */
 export interface LinkedDesignExport {
   readonly id: string;
   readonly name: string;
-  readonly params: BinParams;
+  readonly params?: BinParams;
+  readonly kind?: 'assembly';
+  readonly envelope?: unknown;
+  readonly structure?: unknown;
+}
+
+/** Assembly envelope fields the restore paths actually read. */
+interface AssemblyEnvelopeShape {
+  readonly width: number;
+  readonly depth: number;
+  readonly heightUnitMm: number;
+  readonly gridUnitMm: number;
+}
+
+function isAssemblyEnvelope(value: unknown): value is AssemblyEnvelopeShape {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.width === 'number' &&
+    typeof v.depth === 'number' &&
+    typeof v.heightUnitMm === 'number' &&
+    typeof v.gridUnitMm === 'number'
+  );
+}
+
+function isAssemblyStructureShape(value: unknown): value is AssemblyStructure {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  const base = v.base as Record<string, unknown> | null | undefined;
+  return (
+    v.kind === 'assembly' &&
+    Array.isArray(v.parts) &&
+    typeof base === 'object' &&
+    base !== null &&
+    typeof base.floorThickness === 'number'
+  );
 }
 
 /**
@@ -30,7 +75,8 @@ export interface LinkedDesignExport {
  *
  * Shared by file export and cloud share so both carry the same payload — a
  * layout that travels without its designs arrives as bins with dangling
- * references. Designs that fail to load (deleted) or have no `params`
+ * references. Bin designs travel as `params`, assemblies as
+ * `envelope`/`structure`; designs that fail to load (deleted) or cannot travel
  * (tool racks, imported meshes) are omitted rather than failing the whole set.
  */
 export async function collectLinkedDesigns(layout: Layout): Promise<LinkedDesignExport[]> {
@@ -50,11 +96,17 @@ export async function collectLinkedDesigns(layout: Layout): Promise<LinkedDesign
   const linkedDesigns: LinkedDesignExport[] = [];
   for (const id of designIds) {
     const result = await port.loadDesign(id);
-    if (isOk(result) && result.value.params) {
+    if (!isOk(result)) continue;
+    const design = result.value;
+    if (design.params) {
+      linkedDesigns.push({ id: design.id, name: design.name, params: design.params as BinParams });
+    } else if (design.kind === 'assembly' && design.envelope && design.structure) {
       linkedDesigns.push({
-        id: result.value.id,
-        name: result.value.name,
-        params: result.value.params as BinParams,
+        id: design.id,
+        name: design.name,
+        kind: 'assembly',
+        envelope: design.envelope,
+        structure: design.structure,
       });
     }
   }
@@ -205,29 +257,39 @@ export async function restoreEmbeddedDesigns(
   for (const entry of data.linkedDesigns as unknown[]) {
     const linkedDesign = entry as Record<string, unknown> | null;
     if (
-      linkedDesign &&
-      typeof linkedDesign === 'object' &&
-      'id' in linkedDesign &&
-      'name' in linkedDesign &&
-      'params' in linkedDesign &&
-      typeof linkedDesign.id === 'string' &&
-      typeof linkedDesign.name === 'string' &&
-      // The cloud paths bound each asset server-side; a locally-imported file
-      // reaches storage with its meshAssets verbatim, so this is where an
-      // over-budget asset would otherwise get in and be handed to the decoder
-      // on every preview.
-      !hasOversizedMeshAsset(linkedDesign.params)
+      !linkedDesign ||
+      typeof linkedDesign !== 'object' ||
+      typeof linkedDesign.id !== 'string' ||
+      typeof linkedDesign.name !== 'string'
     ) {
-      const result = await port.saveDesign({
-        name: linkedDesign.name,
-        params: linkedDesign.params,
-        thumbnail: null,
-        exportFileNameConfig: null,
-      });
-      if (isOk(result)) {
-        designIdMap.set(linkedDesign.id, result.value.id);
-        importedDesignCount++;
-      }
+      continue;
+    }
+    const isAssembly =
+      linkedDesign.kind === 'assembly' &&
+      isAssemblyEnvelope(linkedDesign.envelope) &&
+      isAssemblyStructureShape(linkedDesign.structure);
+    // The cloud paths bound each asset server-side; a locally-imported file
+    // reaches storage with its meshAssets verbatim, so this is where an
+    // over-budget asset would otherwise get in and be handed to the decoder
+    // on every preview. (The adapter's descriptor migration is the equivalent
+    // gate for an assembly structure.)
+    const isBin = 'params' in linkedDesign && !hasOversizedMeshAsset(linkedDesign.params);
+    if (!isAssembly && !isBin) continue;
+    const result = await port.saveDesign({
+      name: linkedDesign.name,
+      ...(isAssembly
+        ? {
+            kind: 'assembly' as const,
+            envelope: linkedDesign.envelope,
+            structure: linkedDesign.structure,
+          }
+        : { params: linkedDesign.params }),
+      thumbnail: null,
+      exportFileNameConfig: null,
+    });
+    if (isOk(result)) {
+      designIdMap.set(linkedDesign.id, result.value.id);
+      importedDesignCount++;
     }
   }
 
@@ -279,7 +341,14 @@ function sharedDesignLocalId(shareId: string, sourceDesignId: string): DesignId 
 export async function restoreSharedDesigns(
   shareId: string,
   layout: Layout,
-  designs: ReadonlyArray<{ id: string; name: string; params: unknown }>
+  designs: ReadonlyArray<{
+    id: string;
+    name: string;
+    params?: unknown;
+    kind?: string;
+    envelope?: unknown;
+    structure?: unknown;
+  }>
 ): Promise<Layout> {
   if (designs.length === 0) return layout;
 
@@ -290,6 +359,47 @@ export async function restoreSharedDesigns(
 
   const idMap = new Map<string, DesignId>();
   for (const design of designs) {
+    if (
+      design.kind === 'assembly' &&
+      isAssemblyEnvelope(design.envelope) &&
+      isAssemblyStructureShape(design.structure)
+    ) {
+      const envelope = design.envelope;
+      const structure = design.structure;
+      const result = await port.saveDesign({
+        id: sharedDesignLocalId(shareId, design.id),
+        name: design.name,
+        kind: 'assembly',
+        envelope,
+        structure,
+        thumbnail: null,
+        exportFileNameConfig: null,
+      });
+      if (!isOk(result)) continue;
+      idMap.set(design.id, result.value.id);
+      // Same registry-or-invisible rule as bins; the assembly fields mirror
+      // the feature's `registryAssemblyFields` projection (built here from
+      // the server-validated structure — migration only clamps ranges, which
+      // these placement reads tolerate).
+      const socketAndFloorMm = GRIDFINITY_SPEC.SOCKET_HEIGHT + structure.base.floorThickness;
+      await port.upsertRegistryEntry({
+        id: result.value.id,
+        name: result.value.name,
+        width: envelope.width,
+        depth: envelope.depth,
+        height: assemblyHeightUnits(structure, envelope.heightUnitMm, socketAndFloorMm),
+        kind: 'assembly',
+        assembledRiseMm: assemblyRiseMm(structure, socketAndFloorMm),
+        socketless: false,
+        hasLip: false,
+        overhangMm: assemblyOverhangMm(structure, {
+          w: envelope.width * envelope.gridUnitMm,
+          d: envelope.depth * envelope.gridUnitMm,
+        }),
+        updatedAt: result.value.updatedAt,
+      });
+      continue;
+    }
     if (!design.params || typeof design.params !== 'object' || Array.isArray(design.params)) {
       continue;
     }

--- a/src/core/storage/designStorePort.ts
+++ b/src/core/storage/designStorePort.ts
@@ -24,6 +24,11 @@ export interface LoadedDesignData {
   readonly name: string;
   /** Bin params (opaque; absent for non-bin design kinds). */
   readonly params?: unknown;
+  /** Item kind for non-bin designs (opaque; the adapter narrows it). */
+  readonly kind?: string;
+  /** Envelope + structure for non-bin kinds (opaque, like `params`). */
+  readonly envelope?: unknown;
+  readonly structure?: unknown;
 }
 
 /** What core hands the port to persist a design. */
@@ -31,7 +36,16 @@ export interface SaveDesignInput {
   /** Omit to mint a fresh id; provide to upsert a specific design. */
   readonly id?: DesignId;
   readonly name: string;
-  readonly params: unknown;
+  readonly params?: unknown;
+  /**
+   * Workshop assembly persistence: when `kind` is 'assembly' the adapter
+   * gates `structure` through the descriptor's migration (schema salvage)
+   * before saving — the same trust boundary the sync engine applies to a
+   * remote payload. `params` is ignored for assembly saves.
+   */
+  readonly kind?: 'assembly';
+  readonly envelope?: unknown;
+  readonly structure?: unknown;
   readonly thumbnail: string | null;
   readonly exportFileNameConfig: null;
 }
@@ -66,6 +80,18 @@ export interface DesignRegistryEntry extends DesignRegistryEdgeFields {
   readonly width: number;
   readonly depth: number;
   readonly height: number;
+  /** Item kind of the design; absent = parametric bin. */
+  readonly kind?: 'importedMesh' | 'assembly';
+  /** Assembled-rise fields — mirror the feature's `CustomBinRef`. */
+  readonly assembledRiseMm?: number;
+  readonly socketless?: boolean;
+  readonly hasLip?: boolean;
+  readonly overhangMm?: {
+    readonly left: number;
+    readonly right: number;
+    readonly front: number;
+    readonly back: number;
+  };
   readonly updatedAt: string;
 }
 

--- a/src/features/bin-designer/storage/designStoreAdapter.ts
+++ b/src/features/bin-designer/storage/designStoreAdapter.ts
@@ -23,6 +23,7 @@ import type {
 import type { Result, StorageError } from '@/core/result';
 import type { DesignId } from '@/core/types';
 import type { BinParams } from '@/features/bin-designer/types';
+import type { ItemEnvelope } from '@/shared/types/item';
 
 export const designStoreAdapter: DesignStorePort = {
   async loadDesign(id: DesignId): Promise<Result<LoadedDesignData, StorageError>> {
@@ -32,6 +33,21 @@ export const designStoreAdapter: DesignStorePort = {
 
   async saveDesign(input: SaveDesignInput): Promise<Result<SavedDesignData, StorageError>> {
     const { saveDesign } = await import('@/features/bin-designer/storage/DesignerStorage');
+    if (input.kind === 'assembly' && input.envelope) {
+      const { assemblyDescriptor } = await import('@/shared/items/assembly/descriptor');
+      const envelope = input.envelope as ItemEnvelope;
+      return saveDesign({
+        id: input.id,
+        name: input.name,
+        kind: 'assembly',
+        envelope,
+        // Migration is the trust boundary: an embedded or shared structure
+        // gets schema-salvaged node-by-node, exactly like a sync payload.
+        structure: assemblyDescriptor.migrate(input.structure, envelope),
+        thumbnail: input.thumbnail,
+        exportFileNameConfig: input.exportFileNameConfig,
+      });
+    }
     return saveDesign({
       id: input.id,
       name: input.name,

--- a/src/shared/schema/layoutKeys.ts
+++ b/src/shared/schema/layoutKeys.ts
@@ -186,7 +186,14 @@ export type _ScrewHolesKeys = Assert<
   KeysMatch<keyof ScrewHoleParams, (typeof SCREW_HOLES_KEYS)[number]>
 >;
 
-export const LINKED_DESIGN_KEYS = ['id', 'name', 'params'] as const;
+export const LINKED_DESIGN_KEYS = [
+  'id',
+  'name',
+  'params',
+  'kind',
+  'envelope',
+  'structure',
+] as const;
 export type _LinkedDesignKeys = Assert<
   KeysMatch<keyof LinkedDesignExport, (typeof LINKED_DESIGN_KEYS)[number]>
 >;


### PR DESCRIPTION
Fourth and final Workshop layouts-v2 PR. A layout that travels — file export, cloud share, bulk archive — now brings its placed assemblies along instead of dropping them into dangling references.

- **Payload shape**: `linkedDesigns` entries are now either a bin (`params`, unchanged) or an assembly (`kind` + `envelope` + `structure`). The layout JSON schema pins this as a `oneOf`, with the key manifest and generated schema docs updated in lockstep.
- **Collect**: `collectLinkedDesigns` (file export, cloud share) and the bulk-archive collector emit the assembly shape; tool racks and imported meshes stay local as before.
- **Restore**: the file-import and cloud-share restore paths save assemblies through the design-store port, where the adapter gates the untrusted structure through `assemblyDescriptor.migrate` — the same node-by-node schema salvage the sync engine applies to remote payloads. Cloud-share restore also writes the full registry projection (exact rise, no lip, per-side overhang) so the received layout's ceiling and preview are correct immediately.
- **Server**: `validateSharedDesigns` runs assembly entries through the same deep validators the sync endpoint uses (envelope + iterative structure walk), with a per-assembly 100KB cap matching sync and the existing 512KB aggregate budget.

Live-verified against dev: export → import → restore round-trips a placed assembly end to end — the export embeds `kind: 'assembly'` with structure and no params, import validates clean, restore mints a fresh local id, repoints the bin, and the reloaded design comes back through the migrate gate with its parts intact.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

