### PR TITLE
feat(community): accept Workshop assemblies server-side

### DIFF
--- a/api/community.ts
+++ b/api/community.ts
@@ -31,9 +31,11 @@ import {
   adjustRemixCredit,
   communityContentHash,
   communityMeshBlobPath,
+  communityDesignContent,
   communityParamsFingerprint,
   communityThumbBlobPath,
   deleteCommunityDesignBlob,
+  deriveAssemblyMetrics,
   deriveCommunityMetrics,
   isModeratedContent,
   readCommunityCards,
@@ -100,7 +102,7 @@ function badRequest(res: VercelResponse, message: string): void {
 }
 
 type LineageResolveResult =
-  | { ok: true; lineage: CommunityLineage | null; parentParams: Record<string, unknown> | null }
+  | { ok: true; lineage: CommunityLineage | null; parentContent: Record<string, unknown> | null }
   | { ok: false; message: string };
 
 /**
@@ -123,7 +125,7 @@ async function resolveLineage(
   redis: RedisClient,
   lineage: CommunityLineage | null
 ): Promise<LineageResolveResult> {
-  if (lineage === null) return { ok: true, lineage: null, parentParams: null };
+  if (lineage === null) return { ok: true, lineage: null, parentContent: null };
   const parentCard = (await readCommunityCards(redis, [lineage.parentId]))[0] ?? null;
   if (parentCard === null || parentCard.status !== 'live') {
     return { ok: false, message: 'lineage.parentId does not reference a live design' };
@@ -152,7 +154,7 @@ async function resolveLineage(
       parentAuthorName: parentCard.authorName,
       rootAuthorName,
     },
-    parentParams: parentRecord.params,
+    parentContent: communityDesignContent(parentRecord),
   };
 }
 
@@ -198,6 +200,7 @@ function cardFromRecord(record: CommunityDesignRecord): CommunityCardMetadata {
     authorName: record.authorName,
     category: record.category,
     techniques: record.techniques,
+    kind: record.kind ?? '',
     width: record.metrics.width,
     depth: record.metrics.depth,
     height: record.metrics.height,
@@ -299,9 +302,9 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
     }
 
     try {
-      const paramsFingerprint = communityParamsFingerprint(payload.params);
+      const paramsFingerprint = communityParamsFingerprint(communityDesignContent(payload));
       const contentHash = communityContentHash({
-        params: payload.params,
+        content: communityDesignContent(payload),
         name: payload.name,
         description: payload.description,
         category: payload.category,
@@ -362,8 +365,8 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
       // farmed by re-uploading the parent unchanged.
       if (
         lineage !== null &&
-        lineageResolve.parentParams !== null &&
-        communityParamsFingerprint(lineageResolve.parentParams) === paramsFingerprint
+        lineageResolve.parentContent !== null &&
+        communityParamsFingerprint(lineageResolve.parentContent) === paramsFingerprint
       ) {
         res.status(409).json({
           error: 'Change the design before publishing your remix.',
@@ -405,8 +408,13 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
         description: payload.description,
         category: payload.category,
         techniques: payload.techniques,
-        params: payload.params,
-        metrics: deriveCommunityMetrics(payload.params),
+        ...(payload.kind === 'assembly'
+          ? { kind: 'assembly' as const, envelope: payload.envelope, structure: payload.structure }
+          : { params: payload.params }),
+        metrics:
+          payload.kind === 'assembly'
+            ? deriveAssemblyMetrics(payload.envelope ?? {}, payload.heightUnits ?? 1)
+            : deriveCommunityMetrics(payload.params ?? {}),
         lineage,
         thumbnails: thumbBlobs.map((blob) => blob.url),
         meshUrl: meshBlob.url,
@@ -529,6 +537,8 @@ interface CommunityListItem {
   authorPublicId: string;
   category: CommunityCategory;
   techniques: CommunityTechnique[];
+  /** 'assembly' for a Workshop holder; omitted for bin designs. */
+  kind?: 'assembly';
   metrics: CommunityDesignMetrics;
   thumbnailUrl: string;
   isRemix: boolean;
@@ -572,6 +582,7 @@ function toListItem(card: CommunityCardRecord): CommunityListItem {
     authorPublicId: card.authorPublicId,
     category: card.category,
     techniques: card.techniques,
+    ...(card.kind === 'assembly' && { kind: 'assembly' as const }),
     metrics: {
       width: card.width,
       depth: card.depth,

--- a/api/community.ts
+++ b/api/community.ts
@@ -222,11 +222,11 @@ function cardFromRecord(record: CommunityDesignRecord): CommunityCardMetadata {
  */
 async function isExactDuplicate(
   redis: RedisClient,
-  paramsFingerprint: string,
+  contentFingerprint: string,
   authorPublicId: string
 ): Promise<boolean> {
-  if (COMMUNITY_EXAMPLE_PARAM_HASHES.has(paramsFingerprint)) return true;
-  const candidateId = await redis.get(communityParamsHashKey(paramsFingerprint));
+  if (COMMUNITY_EXAMPLE_PARAM_HASHES.has(contentFingerprint)) return true;
+  const candidateId = await redis.get(communityParamsHashKey(contentFingerprint));
   if (candidateId === null || candidateId === '') return false;
   const [status, candidateAuthor] = await redis.hmget(
     communityDesignKey(candidateId),
@@ -302,7 +302,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
     }
 
     try {
-      const paramsFingerprint = communityParamsFingerprint(communityDesignContent(payload));
+      const contentFingerprint = communityParamsFingerprint(communityDesignContent(payload));
       const contentHash = communityContentHash({
         content: communityDesignContent(payload),
         name: payload.name,
@@ -334,7 +334,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
 
       // B3: reject a verbatim re-upload of a built-in example or of another
       // author's live design. The author's own re-publish returned above.
-      if (await isExactDuplicate(redis, paramsFingerprint, authorPublicId)) {
+      if (await isExactDuplicate(redis, contentFingerprint, authorPublicId)) {
         res.status(409).json({
           error:
             'This matches a design that has already been published (or a built-in example). Make it your own before publishing.',
@@ -366,7 +366,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
       if (
         lineage !== null &&
         lineageResolve.parentContent !== null &&
-        communityParamsFingerprint(lineageResolve.parentContent) === paramsFingerprint
+        communityParamsFingerprint(lineageResolve.parentContent) === contentFingerprint
       ) {
         res.status(409).json({
           error: 'Change the design before publishing your remix.',
@@ -487,7 +487,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
       // Post-commit bookkeeping: the design is already live, so these keep the
       // duplicate index and remix stats in sync best-effort. A failure here
       // must not fail an already-successful publish.
-      await redis.set(communityParamsHashKey(paramsFingerprint), id).catch((indexErr: unknown) => {
+      await redis.set(communityParamsHashKey(contentFingerprint), id).catch((indexErr: unknown) => {
         logger.warn('Community publish: params-hash index write failed', {
           id,
           error: indexErr instanceof Error ? indexErr.message : String(indexErr),

--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -39,9 +39,11 @@ import {
   communityContentHash,
   communityDedupeBucket,
   communityMeshBlobPath,
+  communityDesignContent,
   communityParamsFingerprint,
   communityThumbBlobPath,
   deleteCommunityDesignBlob,
+  deriveAssemblyMetrics,
   deriveCommunityMetrics,
   readCommunityDesignBlob,
   recordModerationTombstone,
@@ -388,8 +390,14 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
       return sendError(res, 403, ErrorCode.UNAUTHORIZED, 'This design cannot be updated.');
     }
 
-    const paramsFingerprint = communityParamsFingerprint(payload.params);
-    const previousFingerprint = communityParamsFingerprint(existing.params);
+    // A design's kind is fixed at publish: the update payload must stay the
+    // same shape as the stored record, or the content fields below would mix.
+    if ((existing.kind === 'assembly') !== (payload.kind === 'assembly')) {
+      sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'design kind cannot change on update');
+      return;
+    }
+    const paramsFingerprint = communityParamsFingerprint(communityDesignContent(payload));
+    const previousFingerprint = communityParamsFingerprint(communityDesignContent(existing));
 
     // B3: reject an edit into a verbatim built-in example or another author's
     // live design.
@@ -404,7 +412,10 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
     // B4: a remix must still differ from its parent after an edit.
     if (existing.lineage !== null) {
       const parent = await readCommunityDesignBlob(existing.lineage.parentId);
-      if (parent !== null && communityParamsFingerprint(parent.params) === paramsFingerprint) {
+      if (
+        parent !== null &&
+        communityParamsFingerprint(communityDesignContent(parent)) === paramsFingerprint
+      ) {
         return res.status(409).json({
           error: 'Change the design before publishing your remix.',
           code: 'REMIX_UNCHANGED',
@@ -447,8 +458,13 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
       authorName: payload.authorName,
       category: payload.category,
       techniques: payload.techniques,
-      params: payload.params,
-      metrics: deriveCommunityMetrics(payload.params),
+      ...(payload.kind === 'assembly'
+        ? { kind: 'assembly' as const, envelope: payload.envelope, structure: payload.structure }
+        : { params: payload.params }),
+      metrics:
+        payload.kind === 'assembly'
+          ? deriveAssemblyMetrics(payload.envelope ?? {}, payload.heightUnits ?? 1)
+          : deriveCommunityMetrics(payload.params ?? {}),
       thumbnails: thumbnailUrls,
       meshUrl: mesh.url,
       updatedAt: Date.now(),
@@ -468,6 +484,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
       authorName: updated.authorName,
       category: updated.category,
       techniques: updated.techniques,
+      kind: updated.kind ?? '',
       width: updated.metrics.width,
       depth: updated.metrics.depth,
       height: updated.metrics.height,
@@ -487,7 +504,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
     // lineage (A8) so it matches the publish-side hash.
     await redis.hset(communityDesignKey(id), {
       contentHash: communityContentHash({
-        params: payload.params,
+        content: communityDesignContent(payload),
         name: payload.name,
         description: payload.description,
         category: payload.category,

--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -318,12 +318,12 @@ function nextAssetRev(meshUrl: string): number {
  */
 async function isDuplicateOnUpdate(
   redis: Redis,
-  paramsFingerprint: string,
+  contentFingerprint: string,
   authorPublicId: string,
   selfId: string
 ): Promise<boolean> {
-  if (COMMUNITY_EXAMPLE_PARAM_HASHES.has(paramsFingerprint)) return true;
-  const candidateId = await redis.get(communityParamsHashKey(paramsFingerprint));
+  if (COMMUNITY_EXAMPLE_PARAM_HASHES.has(contentFingerprint)) return true;
+  const candidateId = await redis.get(communityParamsHashKey(contentFingerprint));
   if (candidateId === null || candidateId === '' || candidateId === selfId) return false;
   const [status, candidateAuthor] = await redis.hmget(
     communityDesignKey(candidateId),
@@ -396,12 +396,12 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
       sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'design kind cannot change on update');
       return;
     }
-    const paramsFingerprint = communityParamsFingerprint(communityDesignContent(payload));
+    const contentFingerprint = communityParamsFingerprint(communityDesignContent(payload));
     const previousFingerprint = communityParamsFingerprint(communityDesignContent(existing));
 
     // B3: reject an edit into a verbatim built-in example or another author's
     // live design.
-    if (await isDuplicateOnUpdate(redis, paramsFingerprint, existing.authorPublicId, id)) {
+    if (await isDuplicateOnUpdate(redis, contentFingerprint, existing.authorPublicId, id)) {
       return res.status(409).json({
         error:
           'This matches a design that has already been published (or a built-in example). Make it your own before publishing.',
@@ -414,7 +414,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
       const parent = await readCommunityDesignBlob(existing.lineage.parentId);
       if (
         parent !== null &&
-        communityParamsFingerprint(communityDesignContent(parent)) === paramsFingerprint
+        communityParamsFingerprint(communityDesignContent(parent)) === contentFingerprint
       ) {
         return res.status(409).json({
           error: 'Change the design before publishing your remix.',
@@ -516,8 +516,8 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
     // Keep the exact-duplicate index pointing at the edited params. Only a
     // still-live design is indexed (A4: never re-index a non-live design), and
     // a changed fingerprint drops the stale entry. Best-effort bookkeeping.
-    if (statusAtWrite === 'live' && paramsFingerprint !== previousFingerprint) {
-      await redis.set(communityParamsHashKey(paramsFingerprint), id).catch(() => undefined);
+    if (statusAtWrite === 'live' && contentFingerprint !== previousFingerprint) {
+      await redis.set(communityParamsHashKey(contentFingerprint), id).catch(() => undefined);
       await redis.del(communityParamsHashKey(previousFingerprint)).catch(() => undefined);
     }
 

--- a/api/community/page.test.ts
+++ b/api/community/page.test.ts
@@ -42,6 +42,7 @@ function design(overrides: Partial<DesignMeta> = {}): DesignMeta {
     description: 'Holds twelve hex drivers upright so you can read the sizes.',
     thumbnailUrl: 'https://blob.test/thumb.webp',
     category: 'tools',
+    kind: '',
     metrics: { width: 83.5, depth: 41.5, height: 21, gridUnitMm: 42 },
     counts: { likes: 3, remixes: 0, prints: 1 },
     featured: false,
@@ -275,6 +276,12 @@ describe('isIndexable', () => {
 });
 
 describe('renderDesignFallback', () => {
+  it('names a Workshop holder instead of a bin', () => {
+    const html = renderDesignFallback(design({ kind: 'assembly' }), 'https://x.test/d/a');
+    expect(html).toContain('Workshop holder design');
+    expect(html).not.toContain('bin design');
+  });
+
   it('omits the details list when there is nothing to put in it', () => {
     const html = renderDesignFallback(
       design({

--- a/api/community/page.ts
+++ b/api/community/page.ts
@@ -89,6 +89,8 @@ export interface DesignMeta {
   readonly description: string;
   readonly thumbnailUrl: string;
   readonly category: string;
+  /** 'assembly' for a Workshop holder; '' for a bin design. */
+  readonly kind: string;
   readonly metrics: {
     readonly width: number;
     readonly depth: number;
@@ -157,6 +159,11 @@ function gridFootprint(metrics: DesignMeta['metrics']): string | null {
  * big it is in both unit systems, and where to go next. The dimensions are the
  * part a snippet cannot summarise away.
  */
+/** 'bin design' vs 'Workshop holder design' — the only copy that differs by kind. */
+function designNoun(design: Pick<DesignMeta, 'kind'>): string {
+  return design.kind === 'assembly' ? 'Workshop holder design' : 'bin design';
+}
+
 export function renderDesignFallback(design: DesignMeta, url: string): string {
   const name = escapeAttr(design.name.trim() === '' ? 'Untitled design' : design.name);
   const author = escapeAttr(design.authorName);
@@ -179,14 +186,14 @@ export function renderDesignFallback(design: DesignMeta, url: string): string {
     `        <h1>${name}</h1>`,
   ];
   parts.push(
-    `        <p>A Gridfinity bin design shared by ${author}, free to remix and print under CC BY 4.0.</p>`
+    `        <p>A Gridfinity ${designNoun(design)} shared by ${author}, free to remix and print under CC BY 4.0.</p>`
   );
   if (design.description.trim() !== '') {
     parts.push(`        <p>${escapeAttr(truncate(design.description, 600))}</p>`);
   }
   if (design.thumbnailUrl !== '') {
     parts.push(
-      `        <img src="${escapeAttr(design.thumbnailUrl)}" alt="${name}, a Gridfinity bin design by ${author}" width="384" height="384">`
+      `        <img src="${escapeAttr(design.thumbnailUrl)}" alt="${name}, a Gridfinity ${designNoun(design)} by ${author}" width="384" height="384">`
     );
   }
   if (facts.length > 0) {
@@ -290,7 +297,7 @@ export function injectDesignMeta(shell: string, design: DesignMeta, siteUrl: str
   const title = `${design.name} by ${design.authorName} — Gridfinity Community`;
   const description =
     design.description.trim() === ''
-      ? `A Gridfinity bin design shared by ${design.authorName}, free to remix and print.`
+      ? `A Gridfinity ${designNoun(design)} shared by ${design.authorName}, free to remix and print.`
       : truncate(design.description, MAX_DESCRIPTION);
 
   let html = shell;
@@ -316,7 +323,7 @@ export function injectDesignMeta(shell: string, design: DesignMeta, siteUrl: str
   // worse than no og:image, which falls back to the site default.
   if (design.thumbnailUrl !== '') {
     swaps.push(['og:image', design.thumbnailUrl]);
-    swaps.push(['og:image:alt', `${design.name}, a Gridfinity bin design`]);
+    swaps.push(['og:image:alt', `${design.name}, a Gridfinity ${designNoun(design)}`]);
     // The shell declares the site card's 1200x630. A design's image is a 384px
     // square render, or a promoted print photo of some other shape entirely,
     // so the inherited dimensions would have scrapers reserve a box the image
@@ -375,6 +382,7 @@ async function readDesignMeta(designId: string): Promise<DesignMeta | null> {
     description: record?.description ?? '',
     thumbnailUrl: card.thumbnailUrl,
     category: card.category,
+    kind: card.kind ?? '',
     // The stored record is flat; the API's nested `metrics`/`counts` shape is
     // assembled elsewhere. `prints` is optional in the record for fixture
     // ergonomics, so it needs the default here.

--- a/api/lib/assemblyValidation.ts
+++ b/api/lib/assemblyValidation.ts
@@ -245,3 +245,171 @@ export function validateAssemblyStructure(structure: unknown): AssemblyValidatio
   }
   return { valid: true };
 }
+
+/** Socket stack height above Z=0, mirroring GRIDFINITY_SPEC.SOCKET_HEIGHT. */
+const SOCKET_HEIGHT_MM = 5;
+
+const PART_PARAM_KEYS: Record<string, readonly string[]> = {
+  post: ['diameter', 'height', 'taperDeg', 'tipChamfer'],
+  fin: ['length', 'thickness', 'height', 'leanDeg', 'leanAxis'],
+  block: ['width', 'depth', 'height', 'wedgeAngleDeg'],
+  tube: ['boreDiameter', 'wall', 'height', 'tiltDeg'],
+  cradle: ['length', 'width', 'height', 'grooveStyle', 'grooveWidth', 'grooveDepth'],
+  hook: ['stemHeight', 'reach', 'lipHeight', 'thickness', 'width'],
+  arch: ['span', 'height', 'style', 'rodDiameter', 'bridgeWidth', 'uprightThickness', 'depth'],
+  cutter: ['profile', 'depth', 'clearance', 'chamfer'],
+};
+
+function sanitizePoint(p: Record<string, unknown>): Record<string, unknown> {
+  return { x: p.x, y: p.y };
+}
+
+function sanitizeHandle(h: unknown): unknown {
+  if (h === null || !isObject(h)) return null;
+  return { dx: h.dx, dy: h.dy };
+}
+
+function sanitizeProfile(profile: Record<string, unknown>): Record<string, unknown> {
+  switch (profile.shape) {
+    case 'circle':
+      return { shape: 'circle', diameter: profile.diameter };
+    case 'rectangle':
+      return {
+        shape: 'rectangle',
+        width: profile.width,
+        depth: profile.depth,
+        cornerRadius: profile.cornerRadius,
+      };
+    case 'polygon':
+      return { shape: 'polygon', diameter: profile.diameter, sides: profile.sides };
+    case 'slot':
+      return { shape: 'slot', length: profile.length, width: profile.width };
+    case 'path':
+      return {
+        shape: 'path',
+        points: (profile.points as Record<string, unknown>[]).map((point) => ({
+          ...sanitizePoint(point),
+          handleIn: sanitizeHandle(point.handleIn),
+          handleOut: sanitizeHandle(point.handleOut),
+          symmetric: point.symmetric,
+        })),
+      };
+    default:
+      return {
+        shape: 'outline',
+        points: (profile.points as Record<string, unknown>[]).map(sanitizePoint),
+      };
+  }
+}
+
+function sanitizePartParams(
+  type: string,
+  params: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of PART_PARAM_KEYS[type] ?? []) {
+    const value = params[key];
+    if (value === undefined) continue;
+    out[key] = key === 'profile' ? sanitizeProfile(value as Record<string, unknown>) : value;
+  }
+  return out;
+}
+
+/** Part-top height above its own seat; mirrors the client's partSeatHeight. */
+function seatHeightMm(type: string, params: Record<string, unknown>): number {
+  if (type === 'cutter') return 0;
+  if (type === 'hook') {
+    const stem = params.stemHeight as number;
+    return Math.max(stem, stem - (params.thickness as number) + (params.lipHeight as number));
+  }
+  return (params.height as number) ?? 0;
+}
+
+export interface SanitizedAssembly {
+  envelope: Record<string, unknown>;
+  structure: Record<string, unknown>;
+  /** Server-derived standing height in mm, socket and floor included. */
+  riseMm: number;
+}
+
+/**
+ * Project a VALIDATED assembly onto its known shape, dropping every unknown
+ * key, restricting part ids to a machine-safe charset, and deriving the
+ * standing height from the part tree — so nothing the validators did not
+ * range-check can reach a public record, and no client-supplied height can
+ * game bed-fit or SEO facts. Call only after `validateAssemblyEnvelope` and
+ * `validateAssemblyStructure` have both passed.
+ */
+export function sanitizeAssemblyContent(
+  envelopeRaw: unknown,
+  structureRaw: unknown
+): SanitizedAssembly {
+  const envelopeIn = envelopeRaw as Record<string, unknown>;
+  const attachmentIn = envelopeIn.attachment as Record<string, unknown>;
+  const envelope: Record<string, unknown> = {
+    width: envelopeIn.width,
+    depth: envelopeIn.depth,
+    gridUnitMm: envelopeIn.gridUnitMm,
+    heightUnitMm: envelopeIn.heightUnitMm,
+    attachment: {
+      magnetHoles: attachmentIn.magnetHoles,
+      magnetDiameter: attachmentIn.magnetDiameter,
+      magnetDepth: attachmentIn.magnetDepth,
+      screwHoles: attachmentIn.screwHoles,
+      screwDiameter: attachmentIn.screwDiameter,
+    },
+    // Strictly validated by validateFeatureColors (unknown keys rejected).
+    featureColors: envelopeIn.featureColors,
+  };
+
+  const structureIn = structureRaw as Record<string, unknown>;
+  const baseIn = structureIn.base as Record<string, unknown>;
+  let maxTop = 0;
+
+  const sanitizeNode = (
+    nodeRaw: Record<string, unknown>,
+    parentTop: number
+  ): Record<string, unknown> => {
+    const type = nodeRaw.type as string;
+    const transformIn = nodeRaw.transform as Record<string, unknown>;
+    const params = nodeRaw.params as Record<string, unknown>;
+    const top = parentTop + (transformIn.seatZ as number) + seatHeightMm(type, params);
+    if (type !== 'cutter' && top > maxTop) maxTop = top;
+    const arrayIn = nodeRaw.array as Record<string, unknown> | undefined;
+    return {
+      id: (nodeRaw.id as string).replace(/[^A-Za-z0-9_-]/g, '_'),
+      type,
+      params: sanitizePartParams(type, params),
+      transform: {
+        x: transformIn.x,
+        y: transformIn.y,
+        seatZ: transformIn.seatZ,
+        rotZDeg: transformIn.rotZDeg,
+      },
+      ...(arrayIn !== undefined
+        ? { array: { count: arrayIn.count, dx: arrayIn.dx, dy: arrayIn.dy } }
+        : {}),
+      ...(nodeRaw.mirror !== undefined ? { mirror: nodeRaw.mirror } : {}),
+      children: (nodeRaw.children as Record<string, unknown>[]).map((child) =>
+        sanitizeNode(child, top)
+      ),
+    };
+  };
+
+  const structure: Record<string, unknown> = {
+    kind: 'assembly',
+    schemaVersion: 1,
+    base: {
+      floorThickness: baseIn.floorThickness,
+      ...(baseIn.cornerRadius !== undefined ? { cornerRadius: baseIn.cornerRadius } : {}),
+    },
+    mirrorAxis: structureIn.mirrorAxis,
+    parts: (structureIn.parts as Record<string, unknown>[]).map((node) => sanitizeNode(node, 0)),
+  };
+
+  return {
+    envelope,
+    structure,
+    riseMm: maxTop + SOCKET_HEIGHT_MM + (baseIn.floorThickness as number),
+  };
+}

--- a/api/lib/communityStore.test.ts
+++ b/api/lib/communityStore.test.ts
@@ -28,6 +28,8 @@ import {
   setCommunityDesignStatus,
   toggleCommunityLike,
   communityContentHash,
+  communityDesignContent,
+  deriveAssemblyMetrics,
   type CommunityCardMetadata,
   type CommunityDesignRecord,
 } from './communityStore.js';
@@ -277,6 +279,7 @@ describe('readCommunityCards', () => {
     expect(cards).toHaveLength(3);
     expect(cards[0]).toEqual({
       ...CARD,
+      kind: '',
       featured: true,
       likes: 7,
       remixes: 2,
@@ -596,9 +599,46 @@ describe('toggleCommunityLike', () => {
   });
 });
 
+describe('deriveAssemblyMetrics', () => {
+  it('takes footprint from the envelope and height from the validated units', () => {
+    expect(
+      deriveAssemblyMetrics({ width: 2, depth: 3, gridUnitMm: 42, heightUnitMm: 7 }, 7)
+    ).toEqual({ width: 83.5, depth: 125.5, height: 49, gridUnitMm: 42 });
+  });
+
+  it('clamps junk to safe defaults like the bin derivation', () => {
+    expect(deriveAssemblyMetrics({}, 0)).toEqual({
+      width: 41.5,
+      depth: 41.5,
+      height: 7,
+      gridUnitMm: 42,
+    });
+  });
+});
+
+describe('communityDesignContent', () => {
+  it('passes bin params through', () => {
+    const params = { width: 2 };
+    expect(communityDesignContent({ params })).toBe(params);
+  });
+
+  it('wraps assembly envelope + structure so kinds cannot alias', () => {
+    const content = communityDesignContent({
+      kind: 'assembly',
+      envelope: { width: 2 },
+      structure: { kind: 'assembly', parts: [] },
+    });
+    expect(content).toEqual({
+      kind: 'assembly',
+      envelope: { width: 2 },
+      structure: { kind: 'assembly', parts: [] },
+    });
+  });
+});
+
 describe('communityContentHash', () => {
   const content = {
-    params: { width: 2, compartments: { cols: 2, cells: [0, 1] } },
+    content: { width: 2, compartments: { cols: 2, cells: [0, 1] } },
     name: 'Socket Organizer',
     description: 'Holds 24 sockets.',
     category: 'tools',
@@ -615,7 +655,7 @@ describe('communityContentHash', () => {
       category: 'tools',
       description: 'Holds 24 sockets.',
       name: 'Socket Organizer',
-      params: { compartments: { cells: [0, 1], cols: 2 }, width: 2 },
+      content: { compartments: { cells: [0, 1], cols: 2 }, width: 2 },
       lineage: null,
       authorName: 'Andy',
     };
@@ -627,7 +667,7 @@ describe('communityContentHash', () => {
     expect(communityContentHash({ ...content, name: 'Other' })).not.toBe(base);
     expect(communityContentHash({ ...content, description: '' })).not.toBe(base);
     expect(communityContentHash({ ...content, category: 'other' })).not.toBe(base);
-    expect(communityContentHash({ ...content, params: { width: 3 } })).not.toBe(base);
+    expect(communityContentHash({ ...content, content: { width: 3 } })).not.toBe(base);
   });
 
   it('changes with authorName so a name-correction retry does not alias (A8)', () => {
@@ -653,7 +693,7 @@ describe('communityContentHash', () => {
   it('is sensitive to array order (cells are positional)', () => {
     const swapped = {
       ...content,
-      params: { ...content.params, compartments: { cols: 2, cells: [1, 0] } },
+      content: { ...content.content, compartments: { cols: 2, cells: [1, 0] } },
     };
     expect(communityContentHash(swapped)).not.toBe(communityContentHash(content));
   });

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -93,7 +93,8 @@ export function deriveCommunityMetrics(params: Record<string, unknown>): Communi
 
 /**
  * Metrics for a Workshop assembly: footprint from the envelope, height from
- * the validated client-computed standing height (the envelope carries none).
+ * the server-derived standing height (`sanitizeAssemblyContent` walks the
+ * part tree; client values are ignored).
  */
 export function deriveAssemblyMetrics(
   envelope: Record<string, unknown>,

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -676,6 +676,9 @@ export interface CommunityContentHashInput {
  */
 export function communityContentHash(content: CommunityContentHashInput): string {
   const canonical = stableStringify({
+    // Serialized under the legacy 'params' key on purpose: every stored
+    // content hash — publish idempotency and moderation tombstones — was
+    // minted with it, and a tombstone must keep matching its content forever.
     params: content.content,
     name: content.name,
     description: content.description,

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -91,6 +91,45 @@ export function deriveCommunityMetrics(params: Record<string, unknown>): Communi
   };
 }
 
+/**
+ * Metrics for a Workshop assembly: footprint from the envelope, height from
+ * the validated client-computed standing height (the envelope carries none).
+ */
+export function deriveAssemblyMetrics(
+  envelope: Record<string, unknown>,
+  heightUnits: number
+): CommunityDesignMetrics {
+  const gridUnitMm = positiveNumber(envelope.gridUnitMm, DEFAULT_GRID_UNIT_MM);
+  const heightUnitMm = positiveNumber(envelope.heightUnitMm, DEFAULT_HEIGHT_UNIT_MM);
+  return {
+    width: positiveNumber(envelope.width, 1) * gridUnitMm - BIN_TOLERANCE_MM,
+    depth: positiveNumber(envelope.depth, 1) * gridUnitMm - BIN_TOLERANCE_MM,
+    height: Math.max(1, heightUnits) * heightUnitMm,
+    gridUnitMm,
+  };
+}
+
+/**
+ * The publishable design content regardless of kind — bin params, or an
+ * assembly's envelope + structure. The single input every duplicate,
+ * remix-differs, and idempotency hash must cover, so the two kinds can
+ * never alias each other.
+ */
+export function communityDesignContent(record: {
+  params?: Record<string, unknown>;
+  kind?: string;
+  envelope?: Record<string, unknown>;
+  structure?: Record<string, unknown>;
+}): Record<string, unknown> {
+  return (
+    record.params ?? {
+      kind: 'assembly',
+      envelope: record.envelope ?? {},
+      structure: record.structure ?? {},
+    }
+  );
+}
+
 export interface CommunityDesignRecord {
   id: string;
   authorPublicId: string;
@@ -99,7 +138,12 @@ export interface CommunityDesignRecord {
   description: string;
   category: CommunityCategory;
   techniques: CommunityTechnique[];
-  params: Record<string, unknown>;
+  /** Bin params; absent on a Workshop assembly record. */
+  params?: Record<string, unknown>;
+  /** Workshop assembly content: envelope + part structure instead of params. */
+  kind?: 'assembly';
+  envelope?: Record<string, unknown>;
+  structure?: Record<string, unknown>;
   metrics: CommunityDesignMetrics;
   lineage: CommunityLineage | null;
   /** Blob URLs of the revision-stamped WebP captures. */
@@ -200,6 +244,8 @@ export interface CommunityCardMetadata {
   authorName: string;
   category: CommunityCategory;
   techniques: CommunityTechnique[];
+  /** '' for a bin design; 'assembly' for a Workshop holder. */
+  kind?: string;
   width: number;
   depth: number;
   height: number;
@@ -257,6 +303,7 @@ export async function writeCommunityCard(redis: Redis, card: CommunityCardMetada
     authorName: card.authorName,
     category: card.category,
     techniques: JSON.stringify(card.techniques),
+    kind: card.kind ?? '',
     width: String(card.width),
     depth: String(card.depth),
     height: String(card.height),
@@ -289,6 +336,7 @@ function parseCard(fields: Record<string, string | undefined>): CommunityCardRec
     authorName: fields.authorName ?? '',
     category: (fields.category ?? 'other') as CommunityCategory,
     techniques,
+    kind: fields.kind ?? '',
     width: Number(fields.width ?? 0),
     depth: Number(fields.depth ?? 0),
     height: Number(fields.height ?? 0),
@@ -603,7 +651,8 @@ function stableStringify(value: unknown): string {
 }
 
 export interface CommunityContentHashInput {
-  params: Record<string, unknown>;
+  /** Kind-agnostic design content — see {@link communityDesignContent}. */
+  content: Record<string, unknown>;
   name: string;
   description: string;
   category: string;
@@ -629,7 +678,7 @@ export interface CommunityContentHashInput {
  */
 export function communityContentHash(content: CommunityContentHashInput): string {
   const canonical = stableStringify({
-    params: content.params,
+    params: content.content,
     name: content.name,
     description: content.description,
     category: content.category,

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -121,13 +121,10 @@ export function communityDesignContent(record: {
   envelope?: Record<string, unknown>;
   structure?: Record<string, unknown>;
 }): Record<string, unknown> {
-  return (
-    record.params ?? {
-      kind: 'assembly',
-      envelope: record.envelope ?? {},
-      structure: record.structure ?? {},
-    }
-  );
+  if (record.kind === 'assembly') {
+    return { kind: 'assembly', envelope: record.envelope ?? {}, structure: record.structure ?? {} };
+  }
+  return record.params ?? {};
 }
 
 export interface CommunityDesignRecord {

--- a/api/lib/communityValidation.test.ts
+++ b/api/lib/communityValidation.test.ts
@@ -141,10 +141,31 @@ describe('validateCommunityPublish', () => {
     expectError(assemblyBody({ envelope: { width: 500 } }), 'INVALID_PARAMS');
   });
 
-  it('rejects an assembly with a missing or out-of-range heightUnits', () => {
-    expectError(assemblyBody({ heightUnits: undefined }), 'INVALID_PAYLOAD');
-    expectError(assemblyBody({ heightUnits: 0 }), 'INVALID_PAYLOAD');
-    expectError(assemblyBody({ heightUnits: 400 }), 'INVALID_PAYLOAD');
+  it('derives heightUnits from the part tree, ignoring any client value', () => {
+    // 40mm post + 5mm socket + 2mm floor = 47mm -> 7 units of 7mm.
+    const result = validateCommunityPublish(assemblyBody({ heightUnits: 2 }));
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error('expected valid');
+    expect(result.payload.heightUnits).toBe(7);
+  });
+
+  it('drops unknown keys and unsafe id characters from the stored content', () => {
+    const body = assemblyBody();
+    const structure = body.structure as Record<string, unknown>;
+    structure.extra = 'smuggled';
+    const part = (structure.parts as Record<string, unknown>[])[0];
+    part.id = 'p1<script>';
+    part.note = 'also smuggled';
+    const result = validateCommunityPublish(body);
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error('expected valid');
+    const stored = result.payload.structure as {
+      extra?: unknown;
+      parts: Array<{ id: string; note?: unknown }>;
+    };
+    expect(stored.extra).toBeUndefined();
+    expect(stored.parts[0].note).toBeUndefined();
+    expect(stored.parts[0].id).toBe('p1_script_');
   });
 
   it('rejects a non-object body', () => {

--- a/api/lib/communityValidation.test.ts
+++ b/api/lib/communityValidation.test.ts
@@ -4,13 +4,13 @@ const mocks = vi.hoisted(() => ({
   validateDesignerShare: vi.fn(),
 }));
 
-vi.mock('./designerValidation.js', () => ({
-  validateDesignerShare: mocks.validateDesignerShare,
-  // Real implementation: assemblyValidation (unmocked) imports it, and the
-  // assembly publish tests exercise that path for real.
-  validateFeatureColors: (value: unknown): string | null =>
-    value !== undefined && typeof value !== 'object' ? 'featureColors must be an object' : null,
-}));
+vi.mock('./designerValidation.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    validateDesignerShare: mocks.validateDesignerShare,
+  };
+});
 
 import {
   COMMUNITY_CATEGORIES,

--- a/api/lib/communityValidation.test.ts
+++ b/api/lib/communityValidation.test.ts
@@ -6,6 +6,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('./designerValidation.js', () => ({
   validateDesignerShare: mocks.validateDesignerShare,
+  // Real implementation: assemblyValidation (unmocked) imports it, and the
+  // assembly publish tests exercise that path for real.
+  validateFeatureColors: (value: unknown): string | null =>
+    value !== undefined && typeof value !== 'object' ? 'featureColors must be an object' : null,
 }));
 
 import {
@@ -78,6 +82,69 @@ describe('validateCommunityPublish', () => {
     expect(result.payload.techniques).toEqual([]);
     expect(result.payload.thumbnails).toEqual([webpBase64()]);
     expect(result.payload.glb).toBe(glbBase64());
+  });
+
+  const assemblyBody = (over: Record<string, unknown> = {}): Record<string, unknown> =>
+    validBody({
+      params: undefined,
+      kind: 'assembly',
+      envelope: {
+        width: 2,
+        depth: 2,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+        attachment: {
+          magnetHoles: false,
+          magnetDiameter: 6.5,
+          magnetDepth: 2.4,
+          screwHoles: false,
+          screwDiameter: 3,
+        },
+        featureColors: { enabled: false },
+      },
+      structure: {
+        kind: 'assembly',
+        schemaVersion: 1,
+        base: { floorThickness: 2 },
+        mirrorAxis: 'x',
+        parts: [
+          {
+            id: 'p1',
+            type: 'post',
+            params: { diameter: 8, height: 40, taperDeg: 0, tipChamfer: 1 },
+            transform: { x: 20, y: 20, seatZ: 0, rotZDeg: 0 },
+            children: [],
+          },
+        ],
+      },
+      heightUnits: 7,
+      ...over,
+    });
+
+  it('accepts a Workshop assembly publish and tags it workshop', () => {
+    const result = validateCommunityPublish(assemblyBody());
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error('expected valid');
+    expect(result.payload.kind).toBe('assembly');
+    expect(result.payload.params).toBeUndefined();
+    expect(result.payload.envelope).toMatchObject({ width: 2, depth: 2 });
+    expect(result.payload.structure).toMatchObject({ kind: 'assembly' });
+    expect(result.payload.heightUnits).toBe(7);
+    expect(result.payload.techniques).toEqual(['workshop']);
+  });
+
+  it('rejects an assembly with an invalid structure or envelope', () => {
+    expectError(
+      assemblyBody({ structure: { kind: 'assembly', schemaVersion: 2 } }),
+      'INVALID_PARAMS'
+    );
+    expectError(assemblyBody({ envelope: { width: 500 } }), 'INVALID_PARAMS');
+  });
+
+  it('rejects an assembly with a missing or out-of-range heightUnits', () => {
+    expectError(assemblyBody({ heightUnits: undefined }), 'INVALID_PAYLOAD');
+    expectError(assemblyBody({ heightUnits: 0 }), 'INVALID_PAYLOAD');
+    expectError(assemblyBody({ heightUnits: 400 }), 'INVALID_PAYLOAD');
   });
 
   it('rejects a non-object body', () => {
@@ -392,7 +459,7 @@ describe('deriveCommunityTechniques', () => {
       cellMask: { cols: 2, rows: 1, cells: [1, 0] },
       wallPattern: { enabled: true },
     });
-    expect(everything).toEqual([...COMMUNITY_TECHNIQUES]);
+    expect(everything).toEqual(COMMUNITY_TECHNIQUES.filter((t) => t !== 'workshop'));
   });
 });
 

--- a/api/lib/communityValidation.ts
+++ b/api/lib/communityValidation.ts
@@ -10,8 +10,9 @@
 
 import { checkText, filterDisplayName, filterSharedDesignsContent } from './contentFilter.js';
 import { validateDesignerShare } from './designerValidation.js';
+import { validateAssemblyEnvelope, validateAssemblyStructure } from './assemblyValidation.js';
 import { isValidShareId } from './shared.js';
-import { isObject, isString, validationError } from './validationUtils.js';
+import { isNumber, isObject, isString, validationError } from './validationUtils.js';
 import {
   classifyCommunityDescription,
   classifyCommunityName,
@@ -122,6 +123,8 @@ export const COMMUNITY_AUTHOR_NAME_MAX_LENGTH = 32;
 export const MAX_COMMUNITY_THUMBNAILS = 3;
 export const MAX_COMMUNITY_THUMBNAIL_BYTES = 200_000;
 export const MAX_COMMUNITY_GLB_BYTES = 2_000_000;
+// Per-assembly content cap, matching the sync endpoint's design payload budget.
+const MAX_COMMUNITY_ASSEMBLY_BYTES = 100 * 1024;
 
 /**
  * MIRROR: derivation logic must match `deriveTechniques` in
@@ -142,6 +145,7 @@ export const COMMUNITY_TECHNIQUES = [
   'handles',
   'customShape',
   'wallPattern',
+  'workshop',
 ] as const;
 export type CommunityTechnique = (typeof COMMUNITY_TECHNIQUES)[number];
 
@@ -234,8 +238,17 @@ export interface CommunityPublishPayload {
   description: string;
   authorName: string;
   category: CommunityCategory;
-  /** Sanitized, allowlist-filtered params from `validateDesignerShare`; persist these, never the raw input. */
-  params: Record<string, unknown>;
+  /** Sanitized, allowlist-filtered params from `validateDesignerShare`; persist
+   *  these, never the raw input. Absent on a Workshop assembly publish. */
+  params?: Record<string, unknown>;
+  /** Workshop assemblies publish envelope + structure instead of params,
+   *  validated by the same deep validators the sync endpoint uses. */
+  kind?: 'assembly';
+  envelope?: Record<string, unknown>;
+  structure?: Record<string, unknown>;
+  /** Client-computed standing height in 7mm units (range-checked); the
+   *  metrics derivation needs it because the envelope carries no height. */
+  heightUnits?: number;
   techniques: CommunityTechnique[];
   /** Raw base64 (any data-URL prefix stripped), ready to decode for blob upload. */
   thumbnails: string[];
@@ -428,27 +441,68 @@ export function validateCommunityPublish(body: unknown): CommunityValidationResu
   }
   const category = body.category as CommunityCategory;
 
-  if (!isObject(body.params)) {
-    return validationError('MISSING_PARAMS', 'params must be an object');
-  }
-  const designerPayload = { type: 'designer' as const, version: 1 as const, params: body.params };
-  // sizeBytes covers what the design blob will actually persist (envelope +
-  // params). Thumbnails and the GLB are separate blobs with their own caps.
-  const sizeBytes = Buffer.byteLength(
-    JSON.stringify({ name, description, category, ...designerPayload }),
-    'utf8'
-  );
-  const designResult = validateDesignerShare(designerPayload, sizeBytes);
-  if (!designResult.valid) {
-    return { valid: false, error: designResult.error };
-  }
-  const params = designResult.payload.params;
+  let params: Record<string, unknown> | undefined;
+  let assembly:
+    | {
+        envelope: Record<string, unknown>;
+        structure: Record<string, unknown>;
+        heightUnits: number;
+      }
+    | undefined;
+  if (body.kind === 'assembly') {
+    // Workshop assembly: the same deep validators the sync endpoint trusts,
+    // so a community publish can't become a side door around them.
+    const envelopeResult = validateAssemblyEnvelope(body.envelope);
+    if (!envelopeResult.valid) {
+      return { valid: false, error: envelopeResult.error };
+    }
+    const structureResult = validateAssemblyStructure(body.structure);
+    if (!structureResult.valid) {
+      return { valid: false, error: structureResult.error };
+    }
+    if (!isNumber(body.heightUnits) || body.heightUnits < 1 || body.heightUnits > 60) {
+      return validationError('INVALID_PAYLOAD', 'heightUnits must be a number between 1 and 60');
+    }
+    const assemblyBytes = Buffer.byteLength(
+      JSON.stringify({ envelope: body.envelope, structure: body.structure }),
+      'utf8'
+    );
+    if (assemblyBytes > MAX_COMMUNITY_ASSEMBLY_BYTES) {
+      return validationError(
+        'SIZE_LIMIT',
+        `design exceeds maximum size of ${MAX_COMMUNITY_ASSEMBLY_BYTES / 1024}KB`
+      );
+    }
+    assembly = {
+      envelope: body.envelope as Record<string, unknown>,
+      structure: body.structure as Record<string, unknown>,
+      heightUnits: body.heightUnits,
+    };
+    // Assembly structures carry no engraved text, so the name/description
+    // sweeps above are the whole text surface.
+  } else {
+    if (!isObject(body.params)) {
+      return validationError('MISSING_PARAMS', 'params must be an object');
+    }
+    const designerPayload = { type: 'designer' as const, version: 1 as const, params: body.params };
+    // sizeBytes covers what the design blob will actually persist (envelope +
+    // params). Thumbnails and the GLB are separate blobs with their own caps.
+    const sizeBytes = Buffer.byteLength(
+      JSON.stringify({ name, description, category, ...designerPayload }),
+      'utf8'
+    );
+    const designResult = validateDesignerShare(designerPayload, sizeBytes);
+    if (!designResult.valid) {
+      return { valid: false, error: designResult.error };
+    }
+    params = designResult.payload.params;
 
-  // Sweeps engraved/label text nested inside the sanitized params, a
-  // separate channel from the envelope strings checked above.
-  const designText = filterSharedDesignsContent([{ name, params }]);
-  if (!designText.passed) {
-    return validationError('CONTENT_BLOCKED', designText.reason ?? 'contains prohibited content');
+    // Sweeps engraved/label text nested inside the sanitized params, a
+    // separate channel from the envelope strings checked above.
+    const designText = filterSharedDesignsContent([{ name, params }]);
+    if (!designText.passed) {
+      return validationError('CONTENT_BLOCKED', designText.reason ?? 'contains prohibited content');
+    }
   }
 
   if (!Array.isArray(body.thumbnails) || body.thumbnails.length < 1) {
@@ -477,8 +531,9 @@ export function validateCommunityPublish(body: unknown): CommunityValidationResu
       description,
       authorName,
       category,
-      params,
-      techniques: deriveCommunityTechniques(params),
+      ...(assembly !== undefined
+        ? { kind: 'assembly' as const, ...assembly, techniques: ['workshop' as const] }
+        : { params, techniques: deriveCommunityTechniques(params ?? {}) }),
       thumbnails,
       glb: glbCheck.base64,
     },

--- a/api/lib/communityValidation.ts
+++ b/api/lib/communityValidation.ts
@@ -10,9 +10,13 @@
 
 import { checkText, filterDisplayName, filterSharedDesignsContent } from './contentFilter.js';
 import { validateDesignerShare } from './designerValidation.js';
-import { validateAssemblyEnvelope, validateAssemblyStructure } from './assemblyValidation.js';
+import {
+  sanitizeAssemblyContent,
+  validateAssemblyEnvelope,
+  validateAssemblyStructure,
+} from './assemblyValidation.js';
 import { isValidShareId } from './shared.js';
-import { isNumber, isObject, isString, validationError } from './validationUtils.js';
+import { isObject, isString, validationError } from './validationUtils.js';
 import {
   classifyCommunityDescription,
   classifyCommunityName,
@@ -246,8 +250,8 @@ export interface CommunityPublishPayload {
   kind?: 'assembly';
   envelope?: Record<string, unknown>;
   structure?: Record<string, unknown>;
-  /** Client-computed standing height in 7mm units (range-checked); the
-   *  metrics derivation needs it because the envelope carries no height. */
+  /** Server-derived standing height in height units — computed from the
+   *  validated part tree, never client-supplied. */
   heightUnits?: number;
   techniques: CommunityTechnique[];
   /** Raw base64 (any data-URL prefix stripped), ready to decode for blob upload. */
@@ -460,11 +464,13 @@ export function validateCommunityPublish(body: unknown): CommunityValidationResu
     if (!structureResult.valid) {
       return { valid: false, error: structureResult.error };
     }
-    if (!isNumber(body.heightUnits) || body.heightUnits < 1 || body.heightUnits > 60) {
-      return validationError('INVALID_PAYLOAD', 'heightUnits must be a number between 1 and 60');
-    }
+    // Project onto the known shape: unknown keys drop, part ids are reduced
+    // to a machine-safe charset, and the standing height derives from the
+    // validated part tree — the client cannot smuggle strings past the
+    // validators or game the stored height.
+    const sanitized = sanitizeAssemblyContent(body.envelope, body.structure);
     const assemblyBytes = Buffer.byteLength(
-      JSON.stringify({ envelope: body.envelope, structure: body.structure }),
+      JSON.stringify({ envelope: sanitized.envelope, structure: sanitized.structure }),
       'utf8'
     );
     if (assemblyBytes > MAX_COMMUNITY_ASSEMBLY_BYTES) {
@@ -473,13 +479,14 @@ export function validateCommunityPublish(body: unknown): CommunityValidationResu
         `design exceeds maximum size of ${MAX_COMMUNITY_ASSEMBLY_BYTES / 1024}KB`
       );
     }
+    const heightUnitMm = (sanitized.envelope.heightUnitMm as number) || 7;
     assembly = {
-      envelope: body.envelope as Record<string, unknown>,
-      structure: body.structure as Record<string, unknown>,
-      heightUnits: body.heightUnits,
+      envelope: sanitized.envelope,
+      structure: sanitized.structure,
+      heightUnits: Math.max(1, Math.ceil(sanitized.riseMm / heightUnitMm)),
     };
-    // Assembly structures carry no engraved text, so the name/description
-    // sweeps above are the whole text surface.
+    // Assembly structures carry no free text after the projection, so the
+    // name/description sweeps above are the whole text surface.
   } else {
     if (!isObject(body.params)) {
       return validationError('MISSING_PARAMS', 'params must be an object');


### PR DESCRIPTION
First of the Workshop community-v3 PRs: the server side of publishing a holder. Nothing can publish one yet (the client gate stays bin-only until the follow-up PRs), so this lands the storage and validation shape first.

- **Validation**: `validateCommunityPublish` accepts an assembly body (`kind` + `envelope` + `structure` + range-checked `heightUnits`) through the same deep validators the sync endpoint trusts, with sync's 100KB per-design cap. Assemblies tag the new `workshop` technique; bins are untouched.
- **Records and cards**: the blob record and Redis card carry the kind; metrics for an assembly derive from the envelope plus the validated standing height, so gallery filtering, bed-fit, and SEO footprints keep working.
- **Hashes**: a new `communityDesignContent` helper feeds every duplicate, remix-must-differ, and idempotency hash the kind-agnostic content (params, or envelope+structure wrapped with a kind discriminator so the two shapes can never alias). Updates reject a kind flip explicitly.
- **SEO**: the community page's fallback prose, alt text, and og:image:alt say "Workshop holder design" for assemblies.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

