### PR TITLE
feat(community): render, remix, and place published assemblies

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -155,6 +155,7 @@
     "binExamples.gallery.tabs.community",
     "binExamples.popular",
     "binExamples.sidebarEntry",
+    "binExamples.technique.workshop",
     "binList.categoryCount",
     "binList.filament",
     "collab.participantCountOne",

--- a/src/features/bin-designer/utils/communityToDesign.test.ts
+++ b/src/features/bin-designer/utils/communityToDesign.test.ts
@@ -106,6 +106,57 @@ describe('communityToDesign', () => {
     expect(loadDesign).toHaveBeenCalledWith(saved);
   });
 
+  it('saves an assembly through the descriptor migration gate', async () => {
+    const design = {
+      ...communityDesign(),
+      params: undefined,
+      kind: 'assembly' as const,
+      envelope: {
+        width: 2,
+        depth: 2,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+        attachment: {
+          magnetHoles: false,
+          magnetDiameter: 6.5,
+          magnetDepth: 2.4,
+          screwHoles: false,
+          screwDiameter: 3,
+        },
+        featureColors: { enabled: false },
+      } as unknown as CommunityDesign['envelope'],
+      structure: {
+        kind: 'assembly',
+        schemaVersion: 1,
+        base: { floorThickness: 2 },
+        mirrorAxis: 'x',
+        parts: [
+          {
+            id: 'p1',
+            type: 'post',
+            params: { diameter: 8, height: 40 },
+            transform: { x: 42, y: 42, seatZ: 0, rotZDeg: 0 },
+            children: [],
+          },
+        ],
+      } as unknown as CommunityDesign['structure'],
+    };
+    saveDesign.mockResolvedValue({ ok: true, value: { id: 'design_asm', name: design.name } });
+
+    const result = await communityToDesign(design);
+
+    expect(isOk(result)).toBe(true);
+    const arg = saveDesign.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.kind).toBe('assembly');
+    expect(arg.params).toBeUndefined();
+    expect(arg.envelope).toMatchObject({ width: 2, depth: 2 });
+    // Migration ran: the structure is the descriptor's parsed copy, with the
+    // part surviving intact.
+    const structure = arg.structure as { kind: string; parts: unknown[] };
+    expect(structure.kind).toBe('assembly');
+    expect(structure.parts).toHaveLength(1);
+  });
+
   it('leaves the remix banner alone for a plain remix', async () => {
     saveDesign.mockResolvedValue({ ok: true, value: { id: 'design_new' } });
     await communityToDesign(communityDesign());

--- a/src/features/bin-designer/utils/communityToDesign.ts
+++ b/src/features/bin-designer/utils/communityToDesign.ts
@@ -1,4 +1,5 @@
 import { saveDesign, setActiveDesignId } from '@/features/bin-designer/storage/DesignerStorage';
+import { assemblyDescriptor } from '@/shared/items/assembly/descriptor';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import type { SavedDesign } from '@/features/bin-designer/types';
 import { remixHintId } from '@/features/bin-designer/utils/remixHintId';
@@ -37,7 +38,15 @@ export async function communityToDesign(
 ): Promise<Result<SavedDesign, StorageError>> {
   const result = await saveDesign({
     name: design.name,
-    params: design.params,
+    ...(design.kind === 'assembly' && design.envelope && design.structure
+      ? {
+          kind: 'assembly' as const,
+          envelope: design.envelope,
+          // Migration is the trust boundary for remote structures, exactly as
+          // in the sync adapter — the server validated shape, this clamps.
+          structure: assemblyDescriptor.migrate(design.structure, design.envelope),
+        }
+      : { params: design.params }),
     thumbnail: null,
     exportFileNameConfig: null,
     lineage: lineageFromParent(design),

--- a/src/features/community/api/client.test.ts
+++ b/src/features/community/api/client.test.ts
@@ -677,6 +677,36 @@ describe('fetchCommunityDesign', () => {
     );
   });
 
+  it('accepts a Workshop assembly record (envelope + structure, no params)', async () => {
+    const { params: _params, ...rest } = design;
+    const assembly = {
+      ...rest,
+      kind: 'assembly',
+      envelope: { width: 2, depth: 2, gridUnitMm: 42, heightUnitMm: 7 },
+      structure: {
+        kind: 'assembly',
+        schemaVersion: 1,
+        base: { floorThickness: 2 },
+        mirrorAxis: 'x',
+        parts: [],
+      },
+    };
+    fetchMock.mockResolvedValue(jsonResponse(200, { design: assembly }));
+    const result = await fetchCommunityDesign('AbCdEf123456');
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value.design.kind).toBe('assembly');
+      expect(result.value.design.params).toBeUndefined();
+    }
+  });
+
+  it('still rejects a record with neither params nor an assembly shape', async () => {
+    const { params: _params, ...paramless } = design;
+    fetchMock.mockResolvedValue(jsonResponse(200, { design: paramless }));
+    const result = await fetchCommunityDesign('AbCdEf123456');
+    expect(isErr(result)).toBe(true);
+  });
+
   it('defaults isOwner to false when the field is absent', async () => {
     fetchMock.mockResolvedValue(jsonResponse(200, { design }));
     const result = await fetchCommunityDesign('AbCdEf123456');

--- a/src/features/community/api/client.ts
+++ b/src/features/community/api/client.ts
@@ -110,8 +110,8 @@ function isCommunityDesign(value: unknown): value is CommunityDesign {
     isKnownCategory(value.category) &&
     Array.isArray(value.techniques) &&
     value.techniques.every(isKnownTechnique) &&
-    value.techniques.every(isKnownTechnique) &&
-    isRecord(value.params) &&
+    (isRecord(value.params) ||
+      (value.kind === 'assembly' && isRecord(value.envelope) && isRecord(value.structure))) &&
     isRecord(value.metrics) &&
     (value.lineage === null || isRecord(value.lineage)) &&
     Array.isArray(value.thumbnails) &&

--- a/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
@@ -405,9 +405,11 @@ export function CommunityDetailContent({
           </h3>
           <p className="text-sm text-content-secondary">
             {t('community.detail.gridUnits', {
-              width: params.width,
-              depth: params.depth,
-              height: params.height,
+              width: params?.width ?? design.envelope?.width ?? 0,
+              depth: params?.depth ?? design.envelope?.depth ?? 0,
+              height:
+                params?.height ??
+                Math.max(1, Math.round(metrics.height / (design.envelope?.heightUnitMm ?? 7))),
             })}
           </p>
           <p className="text-xs text-content-tertiary">

--- a/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
@@ -409,7 +409,7 @@ export function CommunityDetailContent({
               depth: params?.depth ?? design.envelope?.depth ?? 0,
               height:
                 params?.height ??
-                Math.max(1, Math.round(metrics.height / (design.envelope?.heightUnitMm ?? 7))),
+                Math.max(1, Math.ceil(metrics.height / (design.envelope?.heightUnitMm ?? 7))),
             })}
           </p>
           <p className="text-xs text-content-tertiary">

--- a/src/features/community/components/PrintCostPanel/PrintCostPanel.test.tsx
+++ b/src/features/community/components/PrintCostPanel/PrintCostPanel.test.tsx
@@ -46,6 +46,12 @@ beforeEach(() => {
 });
 
 describe('PrintCostPanel', () => {
+  it('renders without an estimate when params are absent (assembly)', () => {
+    render(<PrintCostPanel metrics={METRICS} summary={summary()} gapContext={null} />);
+    expect(estimate).not.toHaveBeenCalled();
+    expect(screen.getByTestId('print-cost-panel')).toBeInTheDocument();
+  });
+
   it('labels model-derived figures as estimated', () => {
     render(<PrintCostPanel params={PARAMS} metrics={METRICS} summary={null} />);
 

--- a/src/features/community/components/PrintCostPanel/PrintCostPanel.tsx
+++ b/src/features/community/components/PrintCostPanel/PrintCostPanel.tsx
@@ -26,7 +26,8 @@ import type { GapFitVerdict } from '../../utils/gapFit';
 import { formatGrams, formatPrintDuration, roundSummaryMinutes } from '../../utils/printFormat';
 
 export interface PrintCostPanelProps {
-  params: BinParams;
+  /** Absent on a Workshop assembly — the estimate row degrades to observed data. */
+  params?: BinParams;
   metrics: CommunityDesignMetrics;
   /** Null until the print list resolves; the panel shows estimates meanwhile. */
   summary: CommunityPrintSummary | null;
@@ -84,6 +85,7 @@ export function PrintCostPanel({
   // params rather than recomputed on every summary refresh.
   const estimate = useMemo(() => {
     try {
+      if (params === undefined) return null;
       return estimateCommunityPrint(params);
     } catch {
       // A design published by an older client can carry params this build's

--- a/src/features/community/components/PublishDialog/PublishDialog.tsx
+++ b/src/features/community/components/PublishDialog/PublishDialog.tsx
@@ -185,7 +185,9 @@ export function PublishDialog() {
     let cancelled = false;
     void fetchOwnDesign(parentId).then((result) => {
       if (cancelled) return;
-      if (isOk(result)) {
+      if (isOk(result) && result.value.params !== undefined) {
+        // Assembly parents skip the identical-to-parent interstitial: their
+        // content hash lives server-side (B4 still rejects an unchanged remix).
         setParentParamsHash(hashBinParams(result.value.params));
       }
     });

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Vlastní tvar",
   "binExamples.technique.handles": "Držadla",
   "binExamples.technique.knifeSlots": "Drážky na nože",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Štítkový jazýček",
   "binExamples.technique.lid": "Víko",
   "binExamples.technique.scoop": "Naběrák",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Freie Form",
   "binExamples.technique.handles": "Griffe",
   "binExamples.technique.knifeSlots": "Messerschlitze",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Etikettenhalter",
   "binExamples.technique.lid": "Deckel",
   "binExamples.technique.scoop": "Auslaufschräge",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -4020,6 +4020,7 @@ const en: Record<string, string> = {
   'binExamples.technique.customShape': 'Custom shape',
   'binExamples.technique.wallPattern': 'Wall pattern',
   'binExamples.technique.knifeSlots': 'Knife slots',
+  'binExamples.technique.workshop': 'Workshop',
 
   // Bin example presets — wall cutouts
   'binExamples.wallCutout2x4Cable.name': '2×4 Cable Bin',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Forma personalizada",
   "binExamples.technique.handles": "Asas",
   "binExamples.technique.knifeSlots": "Ranuras para cuchillo",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Pestaña de etiqueta",
   "binExamples.technique.lid": "Tapa",
   "binExamples.technique.scoop": "Rampa",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Forme personnalisée",
   "binExamples.technique.handles": "Poignées",
   "binExamples.technique.knifeSlots": "Fentes à couteau",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Onglet d'étiquette",
   "binExamples.technique.lid": "Couvercle",
   "binExamples.technique.scoop": "Rampe",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Forma personalizzata",
   "binExamples.technique.handles": "Maniglie",
   "binExamples.technique.knifeSlots": "Asole per coltello",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Linguetta etichetta",
   "binExamples.technique.lid": "Coperchio",
   "binExamples.technique.scoop": "Rampa",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "カスタム形状",
   "binExamples.technique.handles": "ハンドル",
   "binExamples.technique.knifeSlots": "ナイフスロット",
+  "binExamples.technique.workshop": "ワークショップ",
   "binExamples.technique.labelTab": "ラベルタブ",
   "binExamples.technique.lid": "蓋",
   "binExamples.technique.scoop": "スクープ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "맞춤 모양",
   "binExamples.technique.handles": "손잡이",
   "binExamples.technique.knifeSlots": "칼 슬롯",
+  "binExamples.technique.workshop": "워크숍",
   "binExamples.technique.labelTab": "라벨 탭",
   "binExamples.technique.lid": "뚜껑",
   "binExamples.technique.scoop": "손가락 홈",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Egendefinert form",
   "binExamples.technique.handles": "Håndtak",
   "binExamples.technique.knifeSlots": "Knivspor",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Etikettfane",
   "binExamples.technique.lid": "Lokk",
   "binExamples.technique.scoop": "Skråramp",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Aangepaste vorm",
   "binExamples.technique.handles": "Handgrepen",
   "binExamples.technique.knifeSlots": "Messleuven",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Labeltab",
   "binExamples.technique.lid": "Deksel",
   "binExamples.technique.scoop": "Schepvorm",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Własny kształt",
   "binExamples.technique.handles": "Uchwyty",
   "binExamples.technique.knifeSlots": "Szczeliny na noże",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Zakładka etykiety",
   "binExamples.technique.lid": "Pokrywa",
   "binExamples.technique.scoop": "Podbieranie",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Forma personalizada",
   "binExamples.technique.handles": "Alças",
   "binExamples.technique.knifeSlots": "Ranhuras para faca",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Aba de etiqueta",
   "binExamples.technique.lid": "Tampa",
   "binExamples.technique.scoop": "Rampa",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Anpassad form",
   "binExamples.technique.handles": "Handtag",
   "binExamples.technique.knifeSlots": "Knivspår",
+  "binExamples.technique.workshop": "Workshop",
   "binExamples.technique.labelTab": "Etikettflik",
   "binExamples.technique.lid": "Lock",
   "binExamples.technique.scoop": "Skopa",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "Власна форма",
   "binExamples.technique.handles": "Ручки",
   "binExamples.technique.knifeSlots": "Прорізи для ножів",
+  "binExamples.technique.workshop": "Майстерня",
   "binExamples.technique.labelTab": "Виступ для мітки",
   "binExamples.technique.lid": "Кришка",
   "binExamples.technique.scoop": "Скуп",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1902,6 +1902,7 @@
   "binExamples.technique.customShape": "自定义形状",
   "binExamples.technique.handles": "把手",
   "binExamples.technique.knifeSlots": "刀槽",
+  "binExamples.technique.workshop": "工作坊",
   "binExamples.technique.labelTab": "标签片",
   "binExamples.technique.lid": "盖子",
   "binExamples.technique.scoop": "取物斜面",

--- a/src/shared/types/community.ts
+++ b/src/shared/types/community.ts
@@ -9,6 +9,8 @@
  */
 import type { BinParams } from '@/shared/types/bin';
 import type { ExampleTechnique } from '@/shared/types/exampleTechniques';
+import type { ItemEnvelope } from '@/shared/types/item';
+import type { AssemblyStructure } from '@/shared/types/assembly';
 
 export const COMMUNITY_CATEGORIES = [
   'tools',
@@ -153,6 +155,8 @@ export interface CommunityCard {
   readonly authorPublicId: string;
   readonly category: CommunityCategory;
   readonly techniques: readonly ExampleTechnique[];
+  /** 'assembly' for a Workshop holder; absent on bin designs (and pre-field cards). */
+  readonly kind?: 'assembly';
   readonly metrics: CommunityDesignMetrics;
   readonly thumbnailUrl: string;
   /** True when `lineage` is non-null on the full record; drives the card's corner remix glyph. */
@@ -203,7 +207,12 @@ export interface CommunityDesign {
   readonly category: CommunityCategory;
   /** Derived server-side by `deriveCommunityTechniques` at publish/update time, not client-supplied. */
   readonly techniques: readonly ExampleTechnique[];
-  readonly params: BinParams;
+  /** Bin params; absent on a Workshop assembly record. */
+  readonly params?: BinParams;
+  /** Workshop assembly content, mirrored from the server record. */
+  readonly kind?: 'assembly';
+  readonly envelope?: ItemEnvelope;
+  readonly structure?: AssemblyStructure;
   readonly metrics: CommunityDesignMetrics;
   readonly lineage: CommunityDesignLineage | null;
   /** 2-3 WebP 384px blob URLs. */

--- a/src/shared/types/exampleTechniques.test.ts
+++ b/src/shared/types/exampleTechniques.test.ts
@@ -14,6 +14,7 @@ const ALL_TECHNIQUES: readonly ExampleTechnique[] = [
   'customShape',
   'wallPattern',
   'knifeSlots',
+  'workshop',
 ];
 
 describe('TECHNIQUE_CONFIG', () => {
@@ -29,7 +30,7 @@ describe('TECHNIQUE_CONFIG', () => {
     }
   });
 
-  it('has exactly the 10 known technique keys, no more', () => {
+  it('has exactly the 11 known technique keys, no more', () => {
     expect(Object.keys(TECHNIQUE_CONFIG).sort()).toEqual([...ALL_TECHNIQUES].sort());
   });
 });

--- a/src/shared/types/exampleTechniques.ts
+++ b/src/shared/types/exampleTechniques.ts
@@ -17,7 +17,8 @@ export type ExampleTechnique =
   | 'handles'
   | 'customShape'
   | 'wallPattern'
-  | 'knifeSlots';
+  | 'knifeSlots'
+  | 'workshop';
 
 export const TECHNIQUE_CONFIG: Record<ExampleTechnique, { readonly labelKey: string }> = {
   compartments: { labelKey: 'binExamples.technique.compartments' },
@@ -30,4 +31,5 @@ export const TECHNIQUE_CONFIG: Record<ExampleTechnique, { readonly labelKey: str
   customShape: { labelKey: 'binExamples.technique.customShape' },
   wallPattern: { labelKey: 'binExamples.technique.wallPattern' },
   knifeSlots: { labelKey: 'binExamples.technique.knifeSlots' },
+  workshop: { labelKey: 'binExamples.technique.workshop' },
 };

--- a/src/shell/Modals/DesignGalleryModal/communityDesignerBridge.test.ts
+++ b/src/shell/Modals/DesignGalleryModal/communityDesignerBridge.test.ts
@@ -35,8 +35,16 @@ vi.mock('@/features/bin-designer/hooks/useCommunityPublish', () => ({
 const upsertRegistryEntry = vi.fn();
 const registryEdgeFields = vi.fn((_params: unknown) => ({}));
 const registryHeightFields = vi.fn((_params: unknown) => ({}));
+const registryAssemblyFields = vi.fn((_envelope: unknown, _structure: unknown) => ({
+  kind: 'assembly' as const,
+  assembledRiseMm: 47,
+  socketless: false,
+  hasLip: false,
+}));
 vi.mock('@/features/bin-designer/store/customBinRegistry', () => ({
   upsertRegistryEntry: (...a: unknown[]) => upsertRegistryEntry(...a),
+  registryAssemblyFields: (envelope: unknown, structure: unknown) =>
+    registryAssemblyFields(envelope, structure),
   registryEdgeFields: (params: unknown) => registryEdgeFields(params),
   registryHeightFields: (params: unknown) => registryHeightFields(params),
   registryOverhangFields: () => ({}),
@@ -180,6 +188,77 @@ describe('communityDesignerBridge', () => {
       communityToDesign.mockResolvedValue(
         ok({ id: 'design_new', name: 'Screw Bin', updatedAt: '2026-08-02T00:00:00.000Z' })
       );
+    });
+
+    const assemblyDesign: CommunityDesign = {
+      ...design,
+      id: 'Asm123456789',
+      name: 'Pliers Rack',
+      params: undefined,
+      kind: 'assembly',
+      envelope: {
+        width: 2,
+        depth: 2,
+        gridUnitMm: 42,
+        heightUnitMm: 7,
+      } as unknown as NonNullable<CommunityDesign['envelope']>,
+      structure: {
+        kind: 'assembly',
+        schemaVersion: 1,
+        base: { floorThickness: 2 },
+        mirrorAxis: 'x',
+        parts: [
+          {
+            id: 'p1',
+            type: 'post',
+            params: { diameter: 8, height: 40 },
+            transform: { x: 42, y: 42, seatZ: 0, rotZDeg: 0 },
+            children: [],
+          },
+        ],
+      } as unknown as NonNullable<CommunityDesign['structure']>,
+    };
+
+    it('places an assembly from its envelope with assembly registry fields', async () => {
+      useGapFitStore.getState().setConstraint(constraintFor());
+      communityToDesign.mockResolvedValue(
+        ok({ id: 'design_asm', name: 'Pliers Rack', updatedAt: '2026-08-23T00:00:00.000Z' })
+      );
+
+      await expect(placeCommunityDesignInLayout(assemblyDesign)).resolves.toBe('placed');
+
+      expect(registryAssemblyFields).toHaveBeenCalled();
+      expect(upsertRegistryEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'design_asm',
+          width: 2,
+          depth: 2,
+          height: 7,
+          kind: 'assembly',
+          hasLip: false,
+        })
+      );
+      const bins = useLayoutStore.getState().layout.bins;
+      expect(bins).toHaveLength(1);
+      expect(bins[0]).toMatchObject({
+        width: 2,
+        depth: 2,
+        height: 7,
+        linkedDesignId: 'design_asm',
+      });
+    });
+
+    it('treats an assembly on a different unit scale as no-fit', async () => {
+      useGapFitStore.getState().setConstraint(constraintFor());
+      await expect(
+        placeCommunityDesignInLayout({
+          ...assemblyDesign,
+          envelope: {
+            ...(assemblyDesign.envelope as unknown as Record<string, unknown>),
+            gridUnitMm: 21,
+          } as unknown as NonNullable<CommunityDesign['envelope']>,
+        })
+      ).resolves.toBe('no-fit');
     });
 
     it('places the design at the gap, links it, selects it, and clears the handoff', async () => {

--- a/src/shell/Modals/DesignGalleryModal/communityDesignerBridge.ts
+++ b/src/shell/Modals/DesignGalleryModal/communityDesignerBridge.ts
@@ -10,6 +10,8 @@ import { isOk } from '@/core/result';
 import type { GridUnits, HeightUnits } from '@/core/types';
 import { effectiveGridUnitMmY } from '@/core/types';
 import type { CommunityDesign } from '@/shared/types/community';
+import { assemblyHeightUnits } from '@/shared/types/assemblyPlacement';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import type {
   CommunityEditOriginalOutcome,
   CommunityPlaceOutcome,
@@ -108,15 +110,43 @@ export async function placeCommunityDesignInLayout(
     const { x, y, layerId } = constraint.targetPosition;
     if (!layout.layers.some((layer) => layer.id === layerId)) return 'error';
 
-    const { width, depth, height } = design.params;
+    const assembly =
+      design.kind === 'assembly' && design.envelope && design.structure
+        ? { envelope: design.envelope, structure: design.structure }
+        : null;
+    const dims =
+      assembly !== null
+        ? {
+            width: assembly.envelope.width,
+            depth: assembly.envelope.depth,
+            height: assemblyHeightUnits(
+              assembly.structure,
+              assembly.envelope.heightUnitMm,
+              GRIDFINITY_SPEC.SOCKET_HEIGHT + assembly.structure.base.floorThickness
+            ),
+            gridUnitMm: assembly.envelope.gridUnitMm,
+            gridUnitMmY: assembly.envelope.gridUnitMm,
+            heightUnitMm: assembly.envelope.heightUnitMm,
+          }
+        : design.params !== undefined
+          ? {
+              width: design.params.width,
+              depth: design.params.depth,
+              height: design.params.height,
+              gridUnitMm: design.params.gridUnitMm,
+              gridUnitMmY: design.params.gridUnitMmY ?? design.params.gridUnitMm,
+              heightUnitMm: design.params.heightUnitMm,
+            }
+          : null;
+    if (dims === null) return 'error';
+    const { width, depth, height } = dims;
     // The placed bin carries raw unit counts into the layout's unit system,
     // so a design authored on different mm-per-unit scales would come out a
     // different physical size than published. Treat that as unplaceable.
-    const designGridUnitMmY = design.params.gridUnitMmY ?? design.params.gridUnitMm;
     if (
-      design.params.gridUnitMm !== layout.gridUnitMm ||
-      designGridUnitMmY !== effectiveGridUnitMmY(layout) ||
-      design.params.heightUnitMm !== layout.heightUnitMm
+      dims.gridUnitMm !== layout.gridUnitMm ||
+      dims.gridUnitMmY !== effectiveGridUnitMmY(layout) ||
+      dims.heightUnitMm !== layout.heightUnitMm
     ) {
       return 'no-fit';
     }
@@ -153,6 +183,7 @@ export async function placeCommunityDesignInLayout(
     try {
       const {
         upsertRegistryEntry,
+        registryAssemblyFields,
         registryEdgeFields,
         registryHeightFields,
         registryOverhangFields,
@@ -166,9 +197,18 @@ export async function placeCommunityDesignInLayout(
         width,
         depth,
         height,
-        ...registryEdgeFields(design.params),
-        ...registryHeightFields(design.params),
-        ...registryOverhangFields(design.params),
+        ...(assembly !== null || design.params === undefined
+          ? {
+              ...registryEdgeFields({}),
+              ...(assembly !== null
+                ? registryAssemblyFields(assembly.envelope, assembly.structure)
+                : {}),
+            }
+          : {
+              ...registryEdgeFields(design.params),
+              ...registryHeightFields(design.params),
+              ...registryOverhangFields(design.params),
+            }),
         updatedAt: saved.value.updatedAt,
       });
 


### PR DESCRIPTION
Second of the Workshop community-v3 PRs: the consume side. A published assembly (server support landed in #3758) now renders, remixes, and places like any community design — nothing can publish one yet; that gate opens in the final PR.

- **Types + guard**: `CommunityDesign` carries the content union (`params` or `kind` + `envelope` + `structure`), `CommunityCard` an optional kind, and `isCommunityDesign` accepts either shape while still rejecting records with neither.
- **Detail**: the dimensions line derives grid units from the envelope when params are absent; the print-cost panel degrades to observed print data (no wall-model estimate for a holder); the GLB viewer and bed-fit verdict were already metrics/asset-driven.
- **Remix / open**: `communityToDesign` saves the copy as a kind-assembly design through the descriptor's schema-salvage migration (the sync adapter's trust boundary) and the designer opens it in the Workshop.
- **Place in layout**: the gap-fit bridge derives footprint and standing height from the envelope + part tree and registers the copy with the layouts-v2 assembly projection (exact rise, no lip credit), so the ceiling and preview are right immediately.
- **Discoverability**: the `workshop` technique joins `ExampleTechnique`/`TECHNIQUE_CONFIG`, so the gallery's technique filter pill, known-technique guard, and chips all pick it up with no extra wiring (label added across all 15 locales).

Live-verified with a route-mocked detail record: the detail dialog renders name, WORKSHOP chip, "2×2×7 grid units / 83.5×83.5×49 mm", and the estimate-free cost panel; clicking Remix lands the copy in the Workshop as a 1-part assembly.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

