### PR TITLE
feat(community): publish Workshop assemblies from the designer

### DIFF
--- a/src/core/store/communityPublish.ts
+++ b/src/core/store/communityPublish.ts
@@ -23,9 +23,13 @@ export interface CommunityPublishCaptures {
 export interface CommunityPublishDesignContext {
   designId: string;
   designName: string;
-  /** Bin content; absent when publishing a Workshop assembly. */
+  /**
+   * Content shape invariant: exactly one of the two is populated — `params`
+   * for a bin, or `kind: 'assembly'` WITH `envelope` + `structure`. The one
+   * producer (openCommunityPublish) guarantees it; the dialog's submit path
+   * fails fast rather than posting an incomplete body if it is ever broken.
+   */
   params?: BinParams;
-  /** Workshop assembly content; the server re-validates and sanitizes. */
   kind?: 'assembly';
   envelope?: ItemEnvelope;
   structure?: AssemblyStructure;

--- a/src/core/store/communityPublish.ts
+++ b/src/core/store/communityPublish.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 import type { BinParams } from '@/shared/types/bin';
+import type { ItemEnvelope } from '@/shared/types/item';
+import type { AssemblyStructure } from '@/shared/types/assembly';
 import type { CommunityDesignLineage, CommunityPublishDraft } from '@/shared/types/community';
 
 /**
@@ -21,7 +23,13 @@ export interface CommunityPublishCaptures {
 export interface CommunityPublishDesignContext {
   designId: string;
   designName: string;
-  params: BinParams;
+  /** Bin content; absent when publishing a Workshop assembly. */
+  params?: BinParams;
+  /** Workshop assembly content; the server re-validates and sanitizes. */
+  kind?: 'assembly';
+  envelope?: ItemEnvelope;
+  structure?: AssemblyStructure;
+  /** Stable hash of whichever content shape is present. */
   paramsHash: string;
   /** Set when the local design is already published; drives update mode. */
   publishedId: string | null;

--- a/src/features/bin-designer/hooks/useCommunityPublish.test.ts
+++ b/src/features/bin-designer/hooks/useCommunityPublish.test.ts
@@ -132,6 +132,52 @@ describe('useCommunityPublish', () => {
       );
     });
 
+    it('opens with assembly content and frames captures from the envelope', async () => {
+      useDesignerStore.setState({
+        itemKind: 'assembly',
+        envelope: {
+          width: 2,
+          depth: 2,
+          gridUnitMm: 42,
+          heightUnitMm: 7,
+        } as unknown as ReturnType<typeof useDesignerStore.getState>['envelope'],
+        structure: {
+          kind: 'assembly',
+          schemaVersion: 1,
+          base: { floorThickness: 2 },
+          mirrorAxis: 'x',
+          parts: [
+            {
+              id: 'p1',
+              type: 'post',
+              params: { diameter: 8, height: 40 },
+              transform: { x: 42, y: 42, seatZ: 0, rotZDeg: 0 },
+              children: [],
+            },
+          ],
+        } as unknown as ReturnType<typeof useDesignerStore.getState>['structure'],
+      });
+
+      await openCommunityPublish(null);
+
+      const context = useCommunityPublishStore.getState().context;
+      expect(context?.kind).toBe('assembly');
+      expect(context?.params).toBeUndefined();
+      expect(context?.envelope).toMatchObject({ width: 2, depth: 2 });
+      expect(context?.structure).toMatchObject({ kind: 'assembly' });
+      expect(context?.paramsHash).toMatch(/^[0-9a-f]{8}$/);
+      // 40mm post + socket + 2mm floor = 7 units frames the capture height.
+      expect(vi.mocked(captureCommunityThumbnails)).toHaveBeenCalledWith(
+        expect.objectContaining({ width: 2, depth: 2, height: 7 })
+      );
+    });
+
+    it('still refuses kinds with no publishable content', async () => {
+      useDesignerStore.setState({ itemKind: 'importedMesh' });
+      await openCommunityPublish(null);
+      expect(useCommunityPublishStore.getState().isOpen).toBe(false);
+    });
+
     it('reads publishedId and lineage from the saved design', async () => {
       const lineage = {
         parentId: 'Parent123456',

--- a/src/features/bin-designer/hooks/useCommunityPublish.ts
+++ b/src/features/bin-designer/hooks/useCommunityPublish.ts
@@ -139,10 +139,11 @@ export interface CommunityPublishEntry {
 }
 
 /**
- * Any bin the designer can produce is publishable. The gate is only that there
- * IS a bin with a ready mesh, never a judgement about which features it uses,
- * and never a disabled button explained by a `title` tooltip that does not
- * exist on touch.
+ * Any bin or Workshop assembly the designer can produce is publishable. The
+ * gate is only that there IS content with a ready mesh, never a judgement
+ * about which features it uses, and never a disabled button explained by a
+ * `title` tooltip that does not exist on touch. Imported meshes and legacy
+ * racks stay out — they have no publishable parametric content.
  */
 export function useCommunityPublishEntry(): CommunityPublishEntry {
   const publishVisible = useFeatureFlag('community_showcase');

--- a/src/features/bin-designer/hooks/useCommunityPublish.ts
+++ b/src/features/bin-designer/hooks/useCommunityPublish.ts
@@ -14,7 +14,9 @@ import type { CommunityPublishDraft } from '@/shared/types/community';
 import { designId } from '@/core/types';
 import { useSessionStore } from '@/core/sync/session/useSession';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
-import { hashBinParams } from '@/shared/utils/binParamsHash';
+import { hashBinParams, hashDesignContent } from '@/shared/utils/binParamsHash';
+import { assemblyHeightUnits } from '@/shared/types/assemblyPlacement';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { loadPendingPublishAction } from '@/shared/utils/communityPendingAction';
 import type { PendingPublishAction } from '@/shared/utils/communityPendingAction';
 import { useDesignerStore } from '../store/designer';
@@ -46,15 +48,29 @@ async function capturePublishAssets(): Promise<void> {
   const targetDesignId = useCommunityPublishStore.getState().context?.designId ?? null;
   if (targetDesignId === null || state.currentDesignId !== targetDesignId) return;
   const epoch = useCommunityPublishStore.getState().beginCapture();
-  const { params } = state;
-  const thumbnails = await captureCommunityThumbnails({
-    width: params.width,
-    depth: params.depth,
-    height: params.height,
-    gridUnitMm: params.gridUnitMm,
-    gridUnitMmY: params.gridUnitMmY,
-    heightUnitMm: params.heightUnitMm,
-  });
+  const { params, envelope, structure } = state;
+  const frame =
+    state.itemKind === 'assembly' && envelope !== null && structure?.kind === 'assembly'
+      ? {
+          width: envelope.width,
+          depth: envelope.depth,
+          height: assemblyHeightUnits(
+            structure,
+            envelope.heightUnitMm,
+            GRIDFINITY_SPEC.SOCKET_HEIGHT + structure.base.floorThickness
+          ),
+          gridUnitMm: envelope.gridUnitMm,
+          heightUnitMm: envelope.heightUnitMm,
+        }
+      : {
+          width: params.width,
+          depth: params.depth,
+          height: params.height,
+          gridUnitMm: params.gridUnitMm,
+          gridUnitMmY: params.gridUnitMmY,
+          heightUnitMm: params.heightUnitMm,
+        };
+  const thumbnails = await captureCommunityThumbnails(frame);
   const glb = await exportCommunityGlb();
   const publish = useCommunityPublishStore.getState();
   if (!publish.isOpen) return;
@@ -70,7 +86,11 @@ async function capturePublishAssets(): Promise<void> {
 
 export async function openCommunityPublish(draft: CommunityPublishDraft | null): Promise<void> {
   const state = useDesignerStore.getState();
-  if (state.itemKind !== 'bin') return;
+  const assembly =
+    state.itemKind === 'assembly' && state.envelope !== null && state.structure?.kind === 'assembly'
+      ? { envelope: state.envelope, structure: state.structure }
+      : null;
+  if (state.itemKind !== 'bin' && assembly === null) return;
   const currentId = state.currentDesignId;
   if (currentId === null) return;
 
@@ -86,8 +106,9 @@ export async function openCommunityPublish(draft: CommunityPublishDraft | null):
     {
       designId: currentId,
       designName: state.designName,
-      params: state.params,
-      paramsHash: hashBinParams(state.params),
+      ...(assembly !== null
+        ? { kind: 'assembly' as const, ...assembly, paramsHash: hashDesignContent(assembly) }
+        : { params: state.params, paramsHash: hashBinParams(state.params) }),
       publishedId,
       lineage,
       draft,
@@ -125,7 +146,9 @@ export interface CommunityPublishEntry {
  */
 export function useCommunityPublishEntry(): CommunityPublishEntry {
   const publishVisible = useFeatureFlag('community_showcase');
-  const canPublish = useDesignerStore((s) => s.itemKind === 'bin' && isMeshReady(s));
+  const canPublish = useDesignerStore(
+    (s) => (s.itemKind === 'bin' || s.itemKind === 'assembly') && isMeshReady(s)
+  );
   const openPublish = useCallback(() => {
     void openCommunityPublish(null);
   }, []);

--- a/src/features/community/api/client.ts
+++ b/src/features/community/api/client.ts
@@ -3,6 +3,8 @@ import { ok, err, isErr } from '@/core/result';
 import { isApiErrorResponse } from '@/core/api/mapApiError';
 import { apiFetch } from '@/core/sync/apiFetch';
 import type { BinParams } from '@/shared/types/bin';
+import type { ItemEnvelope } from '@/shared/types/item';
+import type { AssemblyStructure } from '@/shared/types/assembly';
 import type {
   CommunityCard,
   CommunityCategory,
@@ -58,7 +60,12 @@ export interface CommunityPublishInput {
   description: string;
   authorName: string;
   category: CommunityCategory;
-  params: BinParams;
+  /** Bin content; absent on a Workshop assembly publish. */
+  params?: BinParams;
+  /** Workshop assembly content — the server validates, sanitizes, and derives height. */
+  kind?: 'assembly';
+  envelope?: ItemEnvelope;
+  structure?: AssemblyStructure;
   /** WebP data URLs or raw base64, 1-3 entries, each <= 200 KB decoded. */
   thumbnails: readonly string[];
   /** Raw base64 GLB, <= 2 MB decoded. */

--- a/src/features/community/api/client.ts
+++ b/src/features/community/api/client.ts
@@ -55,22 +55,22 @@ export type CommunityClientError =
   | { kind: 'server' }
   | { kind: 'network' };
 
-export interface CommunityPublishInput {
+/** Exactly one content shape per publish: bin params, or a Workshop
+ *  assembly's envelope + structure (server validates, sanitizes, derives height). */
+export type CommunityPublishContent =
+  | { params: BinParams; kind?: undefined }
+  | { kind: 'assembly'; envelope: ItemEnvelope; structure: AssemblyStructure; params?: undefined };
+
+export type CommunityPublishInput = CommunityPublishContent & {
   name: string;
   description: string;
   authorName: string;
   category: CommunityCategory;
-  /** Bin content; absent on a Workshop assembly publish. */
-  params?: BinParams;
-  /** Workshop assembly content — the server validates, sanitizes, and derives height. */
-  kind?: 'assembly';
-  envelope?: ItemEnvelope;
-  structure?: AssemblyStructure;
   /** WebP data URLs or raw base64, 1-3 entries, each <= 200 KB decoded. */
   thumbnails: readonly string[];
   /** Raw base64 GLB, <= 2 MB decoded. */
   glb: string;
-}
+};
 
 export interface CommunityPublishResult {
   id: string;

--- a/src/features/community/components/PublishDialog/PublishArtefact.test.tsx
+++ b/src/features/community/components/PublishDialog/PublishArtefact.test.tsx
@@ -66,11 +66,7 @@ describe('PublishArtefact', () => {
           depth: 2,
           gridUnitMm: 42,
           heightUnitMm: 7,
-        } as unknown as PublishArtefactProps['assembly'] extends infer T
-          ? T extends { envelope: infer E }
-            ? E
-            : never
-          : never,
+        },
         structure: {
           kind: 'assembly',
           schemaVersion: 1,

--- a/src/features/community/components/PublishDialog/PublishArtefact.test.tsx
+++ b/src/features/community/components/PublishDialog/PublishArtefact.test.tsx
@@ -57,6 +57,42 @@ describe('PublishArtefact', () => {
     expect(screen.getByText('Scoop')).toBeInTheDocument();
   });
 
+  it('states an assembly size from its envelope and tags it Workshop', () => {
+    renderArtefact({
+      params: undefined,
+      assembly: {
+        envelope: {
+          width: 2,
+          depth: 2,
+          gridUnitMm: 42,
+          heightUnitMm: 7,
+        } as unknown as PublishArtefactProps['assembly'] extends infer T
+          ? T extends { envelope: infer E }
+            ? E
+            : never
+          : never,
+        structure: {
+          kind: 'assembly',
+          schemaVersion: 1,
+          base: { floorThickness: 2 },
+          mirrorAxis: 'x',
+          parts: [
+            {
+              id: 'p1',
+              type: 'post',
+              params: { diameter: 8, height: 40 },
+              transform: { x: 42, y: 42, seatZ: 0, rotZDeg: 0 },
+              children: [],
+            },
+          ],
+        },
+      } as unknown as NonNullable<PublishArtefactProps['assembly']>,
+    });
+    expect(screen.getByText('2×2×7')).toBeInTheDocument();
+    expect(screen.getByText(/84 × 84 × 49 mm/)).toBeInTheDocument();
+    expect(screen.getByText('Workshop')).toBeInTheDocument();
+  });
+
   it('omits the lineage block for an original design', () => {
     renderArtefact();
     expect(screen.queryByText(/Parent Bin/)).not.toBeInTheDocument();

--- a/src/features/community/components/PublishDialog/PublishArtefact.tsx
+++ b/src/features/community/components/PublishDialog/PublishArtefact.tsx
@@ -11,12 +11,19 @@ import type { CommunityDesignLineage } from '@/shared/types/community';
 import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
 import { deriveTechniques } from '@/shared/utils/communityTechniques';
 import { PublishPreview } from './PublishPreview';
-import { formatGridSize, formatMillimetres } from './publishSummary';
+import {
+  formatAssemblyGridSize,
+  formatAssemblyMillimetres,
+  formatGridSize,
+  formatMillimetres,
+} from './publishSummary';
+import type { PublishAssemblyContent } from './publishSummary';
 
 export interface PublishArtefactProps {
   thumbnails: readonly string[] | null;
   captureFailed: boolean;
-  params: BinParams;
+  params?: BinParams;
+  assembly?: PublishAssemblyContent | null;
   lineage: CommunityDesignLineage | null;
   onRetryCapture: () => void;
 }
@@ -25,11 +32,12 @@ export function PublishArtefact({
   thumbnails,
   captureFailed,
   params,
+  assembly,
   lineage,
   onRetryCapture,
 }: PublishArtefactProps) {
   const t = useTranslation();
-  const techniques = deriveTechniques(params);
+  const techniques = params !== undefined ? deriveTechniques(params) : ['workshop' as const];
 
   // Only worth a line when the root is a third party: a root that is the
   // parent, or the parent's own author, says nothing the parent line has not.
@@ -48,10 +56,27 @@ export function PublishArtefact({
       />
 
       <div>
-        <p className="text-sm font-medium text-content">{formatGridSize(params)}</p>
+        <p className="text-sm font-medium text-content">
+          {params !== undefined
+            ? formatGridSize(params)
+            : assembly
+              ? formatAssemblyGridSize(assembly)
+              : ''}
+        </p>
         <p className="text-xs text-content-tertiary">
-          {formatMillimetres(params)} ·{' '}
-          {t('community.publish.form.wallsSummary', { thickness: params.wallThickness })}
+          {params !== undefined ? (
+            <>
+              {formatMillimetres(params)} ·{' '}
+              {t('community.publish.form.wallsSummary', { thickness: params.wallThickness })}
+            </>
+          ) : assembly ? (
+            <>
+              {formatAssemblyMillimetres(assembly)} ·{' '}
+              {t('community.publish.form.floorSummary', {
+                thickness: assembly.structure.base.floorThickness,
+              })}
+            </>
+          ) : null}
         </p>
       </div>
 

--- a/src/features/community/components/PublishDialog/PublishDialog.tsx
+++ b/src/features/community/components/PublishDialog/PublishDialog.tsx
@@ -238,7 +238,9 @@ export function PublishDialog() {
       description: fields.description,
       authorName: fields.publicName,
       category: fields.category,
-      params: context.params,
+      ...(context.kind === 'assembly'
+        ? { kind: 'assembly' as const, envelope: context.envelope, structure: context.structure }
+        : { params: context.params }),
       thumbnails: publishCaptures.thumbnails,
       glb: publishCaptures.glb,
     };
@@ -493,6 +495,11 @@ export function PublishDialog() {
               captures={captures}
               captureFailed={captureFailed}
               params={context.params}
+              assembly={
+                context.kind === 'assembly' && context.envelope && context.structure
+                  ? { envelope: context.envelope, structure: context.structure }
+                  : null
+              }
               lineage={context.lineage}
               publicName={publicName}
               firstTimePublisher={storedDisplayName === ''}

--- a/src/features/community/components/PublishDialog/PublishDialog.tsx
+++ b/src/features/community/components/PublishDialog/PublishDialog.tsx
@@ -233,14 +233,27 @@ export function PublishDialog() {
       store.fail({ kind: 'server' });
       return;
     }
+    // The store context is written only by openCommunityPublish, which
+    // guarantees a complete content shape — but an incomplete one must fail
+    // here, not as a server 400 with envelope/structure silently dropped.
+    const content =
+      context.kind === 'assembly'
+        ? context.envelope !== undefined && context.structure !== undefined
+          ? { kind: 'assembly' as const, envelope: context.envelope, structure: context.structure }
+          : null
+        : context.params !== undefined
+          ? { params: context.params }
+          : null;
+    if (content === null) {
+      store.fail({ kind: 'server' });
+      return;
+    }
     const input: CommunityPublishInput = {
       name: fields.name,
       description: fields.description,
       authorName: fields.publicName,
       category: fields.category,
-      ...(context.kind === 'assembly'
-        ? { kind: 'assembly' as const, envelope: context.envelope, structure: context.structure }
-        : { params: context.params }),
+      ...content,
       thumbnails: publishCaptures.thumbnails,
       glb: publishCaptures.glb,
     };

--- a/src/features/community/components/PublishDialog/PublishForm.tsx
+++ b/src/features/community/components/PublishDialog/PublishForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Alert, Button, Dialog, Field, Input, Textarea } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import type { CommunityPublishCaptures } from '@/core/store/communityPublish';
+import type { PublishAssemblyContent } from './publishSummary';
 import type { AuthProvider } from '@/core/sync/session/sessionApi';
 import type { BinParams } from '@/shared/types/bin';
 import type { CommunityCategory, CommunityDesignLineage } from '@/shared/types/community';
@@ -44,7 +45,8 @@ export interface PublishFormProps {
   prefill: PublishPrefill;
   captures: CommunityPublishCaptures | null;
   captureFailed: boolean;
-  params: BinParams;
+  params?: BinParams;
+  assembly?: PublishAssemblyContent | null;
   lineage: CommunityDesignLineage | null;
   publicName: string;
   /** No public name was ever saved, so the identity field opens expanded. */
@@ -69,6 +71,7 @@ export function PublishForm({
   captures,
   captureFailed,
   params,
+  assembly,
   lineage,
   publicName,
   firstTimePublisher,
@@ -189,6 +192,7 @@ export function PublishForm({
             thumbnails={captures?.thumbnails ?? null}
             captureFailed={captureFailed}
             params={params}
+            assembly={assembly}
             lineage={lineage}
             onRetryCapture={onRetryCapture}
           />

--- a/src/features/community/components/PublishDialog/publishSummary.ts
+++ b/src/features/community/components/PublishDialog/publishSummary.ts
@@ -1,4 +1,13 @@
 import type { BinParams } from '@/shared/types/bin';
+import type { ItemEnvelope } from '@/shared/types/item';
+import type { AssemblyStructure } from '@/shared/types/assembly';
+import { assemblyHeightUnits } from '@/shared/types/assemblyPlacement';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
+
+export interface PublishAssemblyContent {
+  readonly envelope: ItemEnvelope;
+  readonly structure: AssemblyStructure;
+}
 
 function format(value: number): string {
   return Number.isInteger(value) ? String(value) : String(Math.round(value * 10) / 10);
@@ -23,4 +32,36 @@ export function formatMillimetres(params: BinParams): string {
   const depth = format(params.depth * unitY);
   const height = format(params.height * params.heightUnitMm);
   return `${width} × ${depth} × ${height} mm`;
+}
+
+function assemblyUnits(assembly: PublishAssemblyContent): {
+  width: number;
+  depth: number;
+  height: number;
+} {
+  const { envelope, structure } = assembly;
+  return {
+    width: envelope.width,
+    depth: envelope.depth,
+    height: assemblyHeightUnits(
+      structure,
+      envelope.heightUnitMm,
+      GRIDFINITY_SPEC.SOCKET_HEIGHT + structure.base.floorThickness
+    ),
+  };
+}
+
+/** Assembly grid footprint in units, height from the tallest placed part. */
+export function formatAssemblyGridSize(assembly: PublishAssemblyContent): string {
+  const { width, depth, height } = assemblyUnits(assembly);
+  return `${format(width)}×${format(depth)}×${format(height)}`;
+}
+
+/** Assembly nominal outer size in millimetres — same pitch semantics as bins. */
+export function formatAssemblyMillimetres(assembly: PublishAssemblyContent): string {
+  const { envelope } = assembly;
+  const { width, depth, height } = assemblyUnits(assembly);
+  return `${format(width * envelope.gridUnitMm)} × ${format(depth * envelope.gridUnitMm)} × ${format(
+    height * envelope.heightUnitMm
+  )} mm`;
 }

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Nic nerozpoznáno",
   "community.publish.form.waitingPreview": "Čeká se na náhled…",
   "community.publish.form.wallsSummary": "Stěny {thickness} mm",
+  "community.publish.form.floorSummary": "Dno {thickness} mm",
   "community.publish.identity.change": "Změnit",
   "community.publish.identity.hint": "Tvé veřejné jméno, zobrazené u všeho, co publikuješ.",
   "community.publish.identity.label": "Veřejné jméno",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Keine erkannt",
   "community.publish.form.waitingPreview": "Warten auf die Vorschau…",
   "community.publish.form.wallsSummary": "{thickness} mm Wandstärke",
+  "community.publish.form.floorSummary": "{thickness} mm Boden",
   "community.publish.identity.change": "Ändern",
   "community.publish.identity.hint": "Dein öffentlicher Name, angezeigt bei allem, was du veröffentlichst.",
   "community.publish.identity.label": "Öffentlicher Name",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -4113,6 +4113,7 @@ const en: Record<string, string> = {
   'community.publish.form.categoryLabel': 'Category',
   'community.publish.form.categoryRequired': 'Choose a category.',
   'community.publish.form.wallsSummary': '{thickness} mm walls',
+  'community.publish.form.floorSummary': '{thickness} mm floor',
   'community.publish.form.techniquesLabel': 'Detected techniques',
   'community.publish.form.techniquesNone': 'None detected',
   'community.publish.form.lineageNotice': 'Will be credited as a remix of {parent} by {author}',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Ninguna detectada",
   "community.publish.form.waitingPreview": "Esperando la vista previa…",
   "community.publish.form.wallsSummary": "Paredes de {thickness} mm",
+  "community.publish.form.floorSummary": "Base de {thickness} mm",
   "community.publish.identity.change": "Cambiar",
   "community.publish.identity.hint": "Tu nombre público, se muestra en todo lo que publiques.",
   "community.publish.identity.label": "Nombre público",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Aucune détectée",
   "community.publish.form.waitingPreview": "En attente de l'aperçu…",
   "community.publish.form.wallsSummary": "Parois de {thickness} mm",
+  "community.publish.form.floorSummary": "Fond de {thickness} mm",
   "community.publish.identity.change": "Modifier",
   "community.publish.identity.hint": "Votre nom public, affiché sur tout ce que vous publiez.",
   "community.publish.identity.label": "Nom public",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Nessuna rilevata",
   "community.publish.form.waitingPreview": "In attesa dell'anteprima…",
   "community.publish.form.wallsSummary": "Pareti da {thickness} mm",
+  "community.publish.form.floorSummary": "Fondo da {thickness} mm",
   "community.publish.identity.change": "Modifica",
   "community.publish.identity.hint": "Il tuo nome pubblico, mostrato su tutto ciò che pubblichi.",
   "community.publish.identity.label": "Nome pubblico",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "検出されませんでした",
   "community.publish.form.waitingPreview": "プレビューを待っています…",
   "community.publish.form.wallsSummary": "壁厚 {thickness} mm",
+  "community.publish.form.floorSummary": "底面 {thickness} mm",
   "community.publish.identity.change": "変更",
   "community.publish.identity.hint": "あなたが公開するすべてのコンテンツに表示される公開名です。",
   "community.publish.identity.label": "公開名",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "감지된 기법 없음",
   "community.publish.form.waitingPreview": "미리보기를 기다리는 중…",
   "community.publish.form.wallsSummary": "벽 두께 {thickness} mm",
+  "community.publish.form.floorSummary": "바닥 {thickness} mm",
   "community.publish.identity.change": "변경",
   "community.publish.identity.hint": "게시하는 모든 항목에 표시되는 공개 이름입니다.",
   "community.publish.identity.label": "공개 이름",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Ingen oppdaget",
   "community.publish.form.waitingPreview": "Venter på forhåndsvisningen…",
   "community.publish.form.wallsSummary": "{thickness} mm vegger",
+  "community.publish.form.floorSummary": "{thickness} mm bunn",
   "community.publish.identity.change": "Endre",
   "community.publish.identity.hint": "Det offentlige navnet ditt, vist på alt du publiserer.",
   "community.publish.identity.label": "Offentlig navn",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Geen gedetecteerd",
   "community.publish.form.waitingPreview": "Wachten op het voorbeeld…",
   "community.publish.form.wallsSummary": "Wanden van {thickness} mm",
+  "community.publish.form.floorSummary": "{thickness} mm bodem",
   "community.publish.identity.change": "Wijzigen",
   "community.publish.identity.hint": "Je openbare naam, weergegeven bij alles wat je publiceert.",
   "community.publish.identity.label": "Openbare naam",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Nie wykryto żadnych",
   "community.publish.form.waitingPreview": "Czekanie na podgląd…",
   "community.publish.form.wallsSummary": "Ścianki {thickness} mm",
+  "community.publish.form.floorSummary": "Dno {thickness} mm",
   "community.publish.identity.change": "Zmień",
   "community.publish.identity.hint": "Twoja nazwa publiczna, widoczna przy wszystkim, co publikujesz.",
   "community.publish.identity.label": "Nazwa publiczna",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Nenhuma detectada",
   "community.publish.form.waitingPreview": "Aguardando a prévia…",
   "community.publish.form.wallsSummary": "Paredes de {thickness} mm",
+  "community.publish.form.floorSummary": "Base de {thickness} mm",
   "community.publish.identity.change": "Alterar",
   "community.publish.identity.hint": "Seu nome público, exibido em tudo o que você publica.",
   "community.publish.identity.label": "Nome público",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Inga identifierade",
   "community.publish.form.waitingPreview": "Väntar på förhandsvisningen…",
   "community.publish.form.wallsSummary": "{thickness} mm väggar",
+  "community.publish.form.floorSummary": "{thickness} mm botten",
   "community.publish.identity.change": "Ändra",
   "community.publish.identity.hint": "Ditt offentliga namn, visas på allt du publicerar.",
   "community.publish.identity.label": "Offentligt namn",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "Нічого не виявлено",
   "community.publish.form.waitingPreview": "Очікуємо попередній перегляд…",
   "community.publish.form.wallsSummary": "Стінки {thickness} мм",
+  "community.publish.form.floorSummary": "Дно {thickness} мм",
   "community.publish.identity.change": "Змінити",
   "community.publish.identity.hint": "Ваше публічне ім’я, яке відображатиметься на всьому, що ви публікуєте.",
   "community.publish.identity.label": "Публічне ім’я",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2488,6 +2488,7 @@
   "community.publish.form.techniquesNone": "未检测到",
   "community.publish.form.waitingPreview": "正在等待预览…",
   "community.publish.form.wallsSummary": "壁厚 {thickness} mm",
+  "community.publish.form.floorSummary": "{thickness} mm 底板",
   "community.publish.identity.change": "更改",
   "community.publish.identity.hint": "你的公开名称，会显示在你发布的所有内容上。",
   "community.publish.identity.label": "公开名称",

--- a/src/shared/utils/binParamsHash.ts
+++ b/src/shared/utils/binParamsHash.ts
@@ -23,7 +23,12 @@ function stableStringify(value: unknown): string {
 }
 
 export function hashBinParams(params: BinParams): string {
-  const text = stableStringify(params);
+  return hashDesignContent(params);
+}
+
+/** Same stable FNV-1a digest over any design content shape (assembly envelope + structure included). */
+export function hashDesignContent(content: unknown): string {
+  const text = stableStringify(content);
   let hash = 0x811c9dc5;
   for (let i = 0; i < text.length; i++) {
     hash ^= text.charCodeAt(i);


### PR DESCRIPTION
Final Workshop community-v3 PR: the publish gate opens. With the server (#3758) and consume side (#3760) in place, a holder built in the Workshop can now be published to the gallery.

- **Gate**: `canPublish` and `openCommunityPublish` admit `itemKind === 'assembly'` (with a ready sharp mesh, same as bins); imported meshes and legacy racks stay excluded.
- **Seam**: the designer→dialog context carries the content union (`params` or `kind` + `envelope` + `structure`) with a stable hash of whichever shape is present (`hashDesignContent`, which `hashBinParams` now delegates to).
- **Captures**: thumbnails and the GLB frame from the envelope plus the derived standing height, off the live Workshop scene.
- **Dialog**: the artefact column formats size from the envelope (`2×2×7`, `84 × 84 × 49 mm · 2 mm floor` — new `floorSummary` key across all 15 locales), tags the Workshop technique, and the payload posts `kind`/`envelope`/`structure` with no params (the server derives height and sanitizes).
- Assembly remix parents skip the identical-to-parent interstitial (their hash lives server-side; B4 still rejects an unchanged remix).

Live-verified end to end against dev with a route-mocked API: built a two-part holder in the Workshop, opened the dialog (real captures: 3 WebP thumbnails + a 52KB GLB off the live scene; artefact shows the holder render, dims, floor line, Workshop chip), and the POST body carried `kind: assembly` with envelope + 2-part structure and no params.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

