### PR TITLE
feat(workshop): rotation gizmo and snap alignment guides

### DIFF
--- a/src/features/bin-designer/components/Workshop/AlignmentGuides.test.tsx
+++ b/src/features/bin-designer/components/Workshop/AlignmentGuides.test.tsx
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { AlignmentGuides } from './AlignmentGuides';
+
+describe('AlignmentGuides', () => {
+  it('exports a function', () => {
+    expect(typeof AlignmentGuides).toBe('function');
+  });
+});

--- a/src/features/bin-designer/components/Workshop/AlignmentGuides.tsx
+++ b/src/features/bin-designer/components/Workshop/AlignmentGuides.tsx
@@ -1,0 +1,56 @@
+/**
+ * Drag-time alignment guides: thin emissive lines through the coordinate a
+ * dragged part snapped to (a sibling's center, or the plate center). Guides
+ * live in the target parent's frame, so on a rotated parent they draw rotated
+ * with it — the line always shows the axis the part actually aligned along.
+ */
+import type { ReactElement } from 'react';
+import { useThreeColors } from '@/shared/hooks/useThemeEffect';
+import type { AlignGuides } from './useWorkshopInteraction';
+import type { PlacedPart } from './workshopPlacement';
+import { parentLocalToWorld, storeToScene } from './workshopPlacement';
+
+const GUIDE_THICKNESS_MM = 0.5;
+const GUIDE_HEIGHT_MM = 0.3;
+const GUIDE_LIFT_MM = 0.2;
+
+interface AlignmentGuidesProps {
+  guides: AlignGuides;
+  parent: PlacedPart | null;
+  baseW: number;
+  baseD: number;
+}
+
+export function AlignmentGuides({ guides, parent, baseW, baseD }: AlignmentGuidesProps) {
+  const colors = useThreeColors();
+  const length = Math.hypot(baseW, baseD);
+  const parentRad = ((parent?.rotZDeg ?? 0) * Math.PI) / 180;
+  const z = (parent ? parent.topZ : 0) + GUIDE_LIFT_MM;
+
+  const line = (local: { x: number; y: number }, alongY: boolean): ReactElement => {
+    const world = parentLocalToWorld(local, parent);
+    return (
+      <mesh
+        position={[storeToScene(world.x, baseW), storeToScene(world.y, baseD), z]}
+        rotation={[0, 0, parentRad + (alongY ? 0 : Math.PI / 2)]}
+      >
+        <boxGeometry args={[GUIDE_THICKNESS_MM, length, GUIDE_HEIGHT_MM]} />
+        <meshStandardMaterial
+          color={colors.workshopGhost}
+          emissive={colors.workshopGhost}
+          emissiveIntensity={0.8}
+          transparent
+          opacity={0.85}
+        />
+      </mesh>
+    );
+  };
+
+  const center = parent ? { x: 0, y: 0 } : { x: guides.x ?? baseW / 2, y: guides.y ?? baseD / 2 };
+  return (
+    <>
+      {guides.x !== null && line({ x: guides.x, y: parent ? 0 : center.y }, true)}
+      {guides.y !== null && line({ x: parent ? 0 : center.x, y: guides.y }, false)}
+    </>
+  );
+}

--- a/src/features/bin-designer/components/Workshop/AlignmentGuides.tsx
+++ b/src/features/bin-designer/components/Workshop/AlignmentGuides.tsx
@@ -1,8 +1,7 @@
 /**
- * Drag-time alignment guides: thin emissive lines through the coordinate a
- * dragged part snapped to (a sibling's center, or the plate center). Guides
- * live in the target parent's frame, so on a rotated parent they draw rotated
- * with it — the line always shows the axis the part actually aligned along.
+ * Drag-time alignment guides. Drawn in the target parent's frame, not the
+ * world's: on a rotated parent the line rotates with it, so it always shows
+ * the axis the part actually aligned along.
  */
 import type { ReactElement } from 'react';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';

--- a/src/features/bin-designer/components/Workshop/RotationGizmo3D.test.tsx
+++ b/src/features/bin-designer/components/Workshop/RotationGizmo3D.test.tsx
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { RotationGizmo3D } from './RotationGizmo3D';
+
+describe('RotationGizmo3D', () => {
+  it('exports a function', () => {
+    expect(typeof RotationGizmo3D).toBe('function');
+  });
+});

--- a/src/features/bin-designer/components/Workshop/RotationGizmo3D.tsx
+++ b/src/features/bin-designer/components/Workshop/RotationGizmo3D.tsx
@@ -1,17 +1,20 @@
 /**
- * In-canvas rotation gizmo: a flat ring around the selected part's top with a
- * knob at its current heading. Dragging anywhere on the ring rotates the part
- * about Z through the same transactioned machinery as a move — 15° detents,
- * Alt for 1° — so the grab point never jumps and undo captures one step.
+ * In-canvas rotation gizmo. The grab offset is captured at pointerdown so the
+ * part never jumps to meet the pointer, and rotation flows through the same
+ * transactioned move machinery as a drag so undo captures one step.
  */
 import { useMemo } from 'react';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';
 import type { PlacedPart } from './workshopPlacement';
-import { rotationRingRadiusMm, sceneToStore, storeToScene } from './workshopPlacement';
+import {
+  ROTATION_RING_LIFT_MM,
+  rotationRingRadiusMm,
+  sceneToStore,
+  storeToScene,
+} from './workshopPlacement';
 
 const RING_TUBE_MM = 0.9;
 const KNOB_RADIUS_MM = 2.6;
-const RING_LIFT_MM = 2;
 
 interface RotationGizmo3DProps {
   placed: PlacedPart;
@@ -31,7 +34,7 @@ export function RotationGizmo3D({
   const colors = useThreeColors();
   const radius = useMemo(() => rotationRingRadiusMm(placed), [placed]);
   const headingRad = (placed.rotZDeg * Math.PI) / 180;
-  const z = placed.topZ + RING_LIFT_MM;
+  const z = placed.topZ + ROTATION_RING_LIFT_MM;
   const beginRotate = (e: {
     button: number;
     stopPropagation: () => void;

--- a/src/features/bin-designer/components/Workshop/RotationGizmo3D.tsx
+++ b/src/features/bin-designer/components/Workshop/RotationGizmo3D.tsx
@@ -1,0 +1,72 @@
+/**
+ * In-canvas rotation gizmo: a flat ring around the selected part's top with a
+ * knob at its current heading. Dragging anywhere on the ring rotates the part
+ * about Z through the same transactioned machinery as a move — 15° detents,
+ * Alt for 1° — so the grab point never jumps and undo captures one step.
+ */
+import { useMemo } from 'react';
+import { useThreeColors } from '@/shared/hooks/useThemeEffect';
+import type { PlacedPart } from './workshopPlacement';
+import { rotationRingRadiusMm, sceneToStore, storeToScene } from './workshopPlacement';
+
+const RING_TUBE_MM = 0.9;
+const KNOB_RADIUS_MM = 2.6;
+const RING_LIFT_MM = 2;
+
+interface RotationGizmo3DProps {
+  placed: PlacedPart;
+  baseW: number;
+  baseD: number;
+  active: boolean;
+  onBeginRotate: (id: string, world: { x: number; y: number }) => void;
+}
+
+export function RotationGizmo3D({
+  placed,
+  baseW,
+  baseD,
+  active,
+  onBeginRotate,
+}: RotationGizmo3DProps) {
+  const colors = useThreeColors();
+  const radius = useMemo(() => rotationRingRadiusMm(placed), [placed]);
+  const headingRad = (placed.rotZDeg * Math.PI) / 180;
+  const z = placed.topZ + RING_LIFT_MM;
+  const beginRotate = (e: {
+    button: number;
+    stopPropagation: () => void;
+    point: { x: number; y: number };
+  }): void => {
+    if (e.button !== 0) return;
+    e.stopPropagation();
+    onBeginRotate(placed.selectId, {
+      x: sceneToStore(e.point.x, baseW),
+      y: sceneToStore(e.point.y, baseD),
+    });
+  };
+  return (
+    <group position={[storeToScene(placed.x, baseW), storeToScene(placed.y, baseD), z]}>
+      <mesh onPointerDown={beginRotate}>
+        <torusGeometry args={[radius, RING_TUBE_MM, 10, 64]} />
+        <meshStandardMaterial
+          color={colors.workshopPartSelected}
+          emissive={colors.workshopPartSelected}
+          emissiveIntensity={active ? 0.6 : 0.3}
+          transparent
+          opacity={active ? 0.95 : 0.75}
+        />
+      </mesh>
+      <mesh
+        position={[radius * Math.cos(headingRad), radius * Math.sin(headingRad), 0]}
+        onPointerDown={beginRotate}
+      >
+        <sphereGeometry args={[KNOB_RADIUS_MM, 16, 12]} />
+        <meshStandardMaterial
+          color={colors.workshopPartSelected}
+          emissive={colors.workshopPartSelected}
+          emissiveIntensity={0.5}
+        />
+      </mesh>
+    </group>
+  );
+}

--- a/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
@@ -16,7 +16,7 @@ import { PlacementGhost } from './PlacementGhost';
 import { WorkshopSharpMesh } from './WorkshopSharpMesh';
 import { useWorkshopSharpen } from './useWorkshopSharpen';
 import { diffNewPartIds } from './hologramTracker';
-import { baseExtentMm, sceneToStore } from './workshopPlacement';
+import { baseExtentMm, ROTATION_RING_LIFT_MM, sceneToStore } from './workshopPlacement';
 import { useWorkshopInteraction, type HoverSurface } from './useWorkshopInteraction';
 
 interface WorkshopSceneProps {
@@ -147,7 +147,7 @@ export function WorkshopScene({ structure, envelope, missFlashAt = 0 }: Workshop
             <RotationCatchPlane
               baseW={w}
               baseD={d}
-              z={rotating ? rotating.topZ : 0}
+              z={(rotating ? rotating.topZ : 0) + ROTATION_RING_LIFT_MM}
               onRotateMove={interaction.onRotateMove}
             />
           );

--- a/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopScene.tsx
@@ -7,8 +7,10 @@ import { FootprintGrid } from '@/features/bin-designer/components/preview/Footpr
 import type { AssemblyStructure } from '@/shared/types/assembly';
 import type { ItemEnvelope } from '@/shared/types/item';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { AlignmentGuides } from './AlignmentGuides';
 import { BasePlateMesh } from './BasePlateMesh';
 import { MoveHandle3D } from './MoveHandle3D';
+import { RotationGizmo3D } from './RotationGizmo3D';
 import { PartProxyMesh } from './PartProxyMesh';
 import { PlacementGhost } from './PlacementGhost';
 import { WorkshopSharpMesh } from './WorkshopSharpMesh';
@@ -30,7 +32,7 @@ export function WorkshopScene({ structure, envelope, missFlashAt = 0 }: Workshop
   const { w, d } = extent;
   const cameraDistance = Math.max(w, d) * 1.4 + 80;
   const sharp = useWorkshopSharpen();
-  const showSharp = sharp && interaction.draggingId === null;
+  const showSharp = sharp && interaction.draggingId === null && interaction.rotatingId === null;
 
   const knownIdsRef = useRef<ReadonlySet<string> | null>(null);
   const [holograms, setHolograms] = useState<Map<string, number>>(new Map());
@@ -88,7 +90,8 @@ export function WorkshopScene({ structure, envelope, missFlashAt = 0 }: Workshop
           baseD={d}
           selected={interaction.selectedId === placed.selectId}
           raycastDisabled={
-            interaction.draggingId !== null && interaction.isInDraggedSubtree(placed.selectId)
+            (interaction.draggingId !== null && interaction.isInDraggedSubtree(placed.selectId)) ||
+            interaction.rotatingId !== null
           }
           hidden={showSharp}
           mirrorAxis={structure.mirrorAxis}
@@ -112,6 +115,43 @@ export function WorkshopScene({ structure, envelope, missFlashAt = 0 }: Workshop
       {interaction.draggingId !== null && (
         <DragCatchPlane baseW={w} baseD={d} onSurfaceMove={interaction.onSurfaceMove} />
       )}
+      {interaction.draggingId !== null &&
+        interaction.alignGuides !== null &&
+        (() => {
+          const guides = interaction.alignGuides;
+          const parent =
+            guides.parentId === null ? null : (interaction.placedById.get(guides.parentId) ?? null);
+          return guides.parentId !== null && parent === null ? null : (
+            <AlignmentGuides guides={guides} parent={parent} baseW={w} baseD={d} />
+          );
+        })()}
+      {interaction.selectedId !== null &&
+        interaction.draggingId === null &&
+        interaction.pendingType === null &&
+        (() => {
+          const selectedPlaced = interaction.placedById.get(interaction.selectedId);
+          return selectedPlaced ? (
+            <RotationGizmo3D
+              placed={selectedPlaced}
+              baseW={w}
+              baseD={d}
+              active={interaction.rotatingId !== null}
+              onBeginRotate={interaction.beginPartRotate}
+            />
+          ) : null;
+        })()}
+      {interaction.rotatingId !== null &&
+        (() => {
+          const rotating = interaction.placedById.get(interaction.rotatingId);
+          return (
+            <RotationCatchPlane
+              baseW={w}
+              baseD={d}
+              z={rotating ? rotating.topZ : 0}
+              onRotateMove={interaction.onRotateMove}
+            />
+          );
+        })()}
       {interaction.selectedViaTouch &&
         interaction.selectedId !== null &&
         interaction.draggingId === null &&
@@ -137,6 +177,38 @@ export function WorkshopScene({ structure, envelope, missFlashAt = 0 }: Workshop
         target={[0, 0, 15]}
       />
     </>
+  );
+}
+
+/**
+ * While the gizmo is grabbed, every pointer move must resolve to a world
+ * point on the ring's plane regardless of what is underneath — same trick
+ * as DragCatchPlane, at the ring's height so the angle has no parallax.
+ */
+function RotationCatchPlane({
+  baseW,
+  baseD,
+  z,
+  onRotateMove,
+}: {
+  baseW: number;
+  baseD: number;
+  z: number;
+  onRotateMove: (world: { x: number; y: number }) => void;
+}) {
+  return (
+    <mesh
+      position={[0, 0, z]}
+      onPointerMove={(e) => {
+        onRotateMove({
+          x: sceneToStore(e.point.x, baseW),
+          y: sceneToStore(e.point.y, baseD),
+        });
+      }}
+    >
+      <planeGeometry args={[baseW * 6, baseD * 6]} />
+      <meshBasicMaterial visible={false} />
+    </mesh>
   );
 }
 

--- a/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
+++ b/src/features/bin-designer/components/Workshop/useWorkshopInteraction.ts
@@ -12,8 +12,10 @@ import type { AssemblyStructure } from '@/shared/types/assembly';
 import { collectAssemblyIds, findAssemblyPart } from '@/features/bin-designer/utils/assemblyTree';
 import { defaultCutterProfile } from '@/shared/items/assembly/descriptor';
 import {
+  alignSnap,
   parentLocalToWorld,
   resolvePlacedParts,
+  snapAngleDeg,
   snapCoord,
   worldToParentLocal,
   type PlacedPart,
@@ -25,6 +27,13 @@ export interface HoverSurface {
   /** Pointer position in the store frame (mm). */
   readonly x: number;
   readonly y: number;
+}
+
+export interface AlignGuides {
+  /** Aligned local coordinates in the target parent's frame; null axis = no guide. */
+  readonly x: number | null;
+  readonly y: number | null;
+  readonly parentId: string | null;
 }
 
 export interface WorkshopInteraction {
@@ -39,6 +48,8 @@ export interface WorkshopInteraction {
   readonly hover: HoverSurface | null;
   readonly ghostPosition: { x: number; y: number; z: number; rotZDeg: number } | null;
   readonly draggingId: string | null;
+  readonly rotatingId: string | null;
+  readonly alignGuides: AlignGuides | null;
   readonly selectedId: string | null;
   readonly pendingType: ReturnType<typeof usePendingType>;
   readonly pendingCutterShape: 'circle' | 'slot' | null;
@@ -47,6 +58,8 @@ export interface WorkshopInteraction {
   onSurfaceClick: (surface: HoverSurface) => void;
   onPartPointerDown: (id: string, pointerType: string) => void;
   beginPartDrag: (id: string) => void;
+  beginPartRotate: (id: string, world: { x: number; y: number }) => void;
+  onRotateMove: (world: { x: number; y: number }) => void;
   isInDraggedSubtree: (id: string) => boolean;
 }
 
@@ -82,6 +95,15 @@ export function useWorkshopInteraction(
   // deselect what was just selected — swallow exactly that one click.
   const skipNextBaseClickRef = useRef(false);
   const [fineSnap, setFineSnap] = useState(false);
+  const [rotatingId, setRotatingId] = useState<string | null>(null);
+  const [alignGuides, setAlignGuides] = useState<AlignGuides | null>(null);
+  const rotateStateRef = useRef<{
+    id: string;
+    centerX: number;
+    centerY: number;
+    parentWorldDeg: number;
+    grabOffsetDeg: number;
+  } | null>(null);
 
   const placements = useMemo(
     () => resolvePlacedParts(structure, baseExtent),
@@ -122,12 +144,15 @@ export function useWorkshopInteraction(
     const controls = getThree().controls as { enabled: boolean } | null;
     if (controls) controls.enabled = true;
     setDraggingId(null);
+    setRotatingId(null);
+    setAlignGuides(null);
+    rotateStateRef.current = null;
     draggedSubtreeRef.current = new Set();
     invalidate();
   }, [getThree, invalidate]);
 
   useEffect(() => {
-    if (draggingId === null) return;
+    if (draggingId === null && rotatingId === null) return;
     window.addEventListener('pointerup', endDrag);
     // A cancelled touch (edge swipe, notification shade, palm rejection)
     // fires pointercancel, never pointerup — without this the drag wedges
@@ -137,7 +162,7 @@ export function useWorkshopInteraction(
       window.removeEventListener('pointerup', endDrag);
       window.removeEventListener('pointercancel', endDrag);
     };
-  }, [draggingId, endDrag]);
+  }, [draggingId, rotatingId, endDrag]);
 
   const snapPoint = useCallback(
     (surface: HoverSurface): { x: number; y: number } => {
@@ -159,17 +184,43 @@ export function useWorkshopInteraction(
         const node = findAssemblyPart(currentStructure.parts, draggingId);
         if (!node) return;
         const currentParent = resolveParentId(currentStructure, draggingId);
-        const local = snapPoint(surface);
+        const parent =
+          surface.parentId === null ? null : (placedById.get(surface.parentId) ?? null);
+        const rawLocal = worldToParentLocal({ x: surface.x, y: surface.y }, parent);
+        // Alignment candidates are the target frame's other children (the
+        // parts a guide can meaningfully relate to), plus the plate center
+        // when seating on the base.
+        const siblings =
+          surface.parentId === null
+            ? currentStructure.parts
+            : (findAssemblyPart(currentStructure.parts, surface.parentId)?.children ?? []);
+        const xs: number[] = [];
+        const ys: number[] = [];
+        for (const sibling of siblings) {
+          if (draggedSubtreeRef.current.has(sibling.id)) continue;
+          xs.push(sibling.transform.x);
+          ys.push(sibling.transform.y);
+        }
+        if (surface.parentId === null) {
+          xs.push(baseExtent.w / 2);
+          ys.push(baseExtent.d / 2);
+        }
+        const snapped = alignSnap(rawLocal, { xs, ys }, fineSnap);
+        setAlignGuides(
+          snapped.guideX !== null || snapped.guideY !== null
+            ? { x: snapped.guideX, y: snapped.guideY, parentId: surface.parentId }
+            : null
+        );
         if (!dragTransactionRef.current) {
           store.startTransaction();
           dragTransactionRef.current = true;
         }
         if (surface.parentId === currentParent) {
-          store.moveAssemblyPart(draggingId, { x: local.x, y: local.y, seatZ: 0 });
+          store.moveAssemblyPart(draggingId, { x: snapped.x, y: snapped.y, seatZ: 0 });
         } else {
           store.reparentAssemblyPart(draggingId, surface.parentId, {
-            x: local.x,
-            y: local.y,
+            x: snapped.x,
+            y: snapped.y,
             seatZ: 0,
           });
         }
@@ -179,7 +230,7 @@ export function useWorkshopInteraction(
       setHover(surface);
       invalidate();
     },
-    [draggingId, invalidate, snapPoint]
+    [baseExtent.d, baseExtent.w, draggingId, fineSnap, invalidate, placedById]
   );
 
   const onSurfaceLeave = useCallback((): void => {
@@ -259,6 +310,53 @@ export function useWorkshopInteraction(
     [beginPartDrag, invalidate]
   );
 
+  const beginPartRotate = useCallback(
+    (id: string, world: { x: number; y: number }): void => {
+      const store = useDesignerStore.getState();
+      const currentStructure = store.structure;
+      if (currentStructure?.kind !== 'assembly') return;
+      const node = findAssemblyPart(currentStructure.parts, id);
+      const placed = placedById.get(id);
+      if (!node || !placed) return;
+      const pointerDeg = (Math.atan2(world.y - placed.y, world.x - placed.x) * 180) / Math.PI;
+      rotateStateRef.current = {
+        id,
+        centerX: placed.x,
+        centerY: placed.y,
+        parentWorldDeg: placed.rotZDeg - node.transform.rotZDeg,
+        // Grab where the pointer lands, so the part never jumps to meet it.
+        grabOffsetDeg: pointerDeg - placed.rotZDeg,
+      };
+      skipNextBaseClickRef.current = true;
+      const controls = getThree().controls as { enabled: boolean } | null;
+      if (controls) controls.enabled = false;
+      setRotatingId(id);
+      invalidate();
+    },
+    [getThree, invalidate, placedById]
+  );
+
+  const onRotateMove = useCallback(
+    (world: { x: number; y: number }): void => {
+      const state = rotateStateRef.current;
+      if (state === null) return;
+      const store = useDesignerStore.getState();
+      const pointerDeg =
+        (Math.atan2(world.y - state.centerY, world.x - state.centerX) * 180) / Math.PI;
+      const localDeg = snapAngleDeg(
+        pointerDeg - state.grabOffsetDeg - state.parentWorldDeg,
+        fineSnap
+      );
+      if (!dragTransactionRef.current) {
+        store.startTransaction();
+        dragTransactionRef.current = true;
+      }
+      store.moveAssemblyPart(state.id, { rotZDeg: localDeg });
+      invalidate();
+    },
+    [fineSnap, invalidate]
+  );
+
   const isInDraggedSubtree = useCallback(
     (id: string): boolean => draggedSubtreeRef.current.has(id),
     []
@@ -289,6 +387,8 @@ export function useWorkshopInteraction(
     hover,
     ghostPosition,
     draggingId,
+    rotatingId,
+    alignGuides,
     selectedId,
     pendingType,
     pendingCutterShape,
@@ -297,6 +397,8 @@ export function useWorkshopInteraction(
     onSurfaceClick,
     onPartPointerDown,
     beginPartDrag,
+    beginPartRotate,
+    onRotateMove,
     isInDraggedSubtree,
   };
 }

--- a/src/features/bin-designer/components/Workshop/workshopPlacement.test.ts
+++ b/src/features/bin-designer/components/Workshop/workshopPlacement.test.ts
@@ -6,6 +6,9 @@ import {
   DEFAULT_PART_TRANSFORM,
 } from '@/shared/items/assembly/descriptor';
 import {
+  alignSnap,
+  rotationRingRadiusMm,
+  snapAngleDeg,
   resolvePlacedParts,
   snapCoord,
   worldToParentLocal,
@@ -121,5 +124,65 @@ describe('coordinate helpers', () => {
     const local = worldToParentLocal({ x: 50, y: 60 }, parent);
     expect(local.x).toBeCloseTo(10);
     expect(local.y).toBeCloseTo(0);
+  });
+});
+
+describe('snapAngleDeg', () => {
+  it('snaps to 15-degree detents by default', () => {
+    expect(snapAngleDeg(22, false)).toBe(15);
+    expect(snapAngleDeg(23, false)).toBe(30);
+    expect(snapAngleDeg(-52, false)).toBe(-45);
+  });
+
+  it('snaps to 1 degree in fine mode', () => {
+    expect(snapAngleDeg(22.4, true)).toBe(22);
+  });
+
+  it('normalizes to (-180, 180] so the readout stays friendly', () => {
+    expect(snapAngleDeg(270, false)).toBe(-90);
+    expect(snapAngleDeg(-270, false)).toBe(90);
+    expect(snapAngleDeg(180, false)).toBe(180);
+    expect(snapAngleDeg(-180, false)).toBe(180);
+  });
+});
+
+describe('alignSnap', () => {
+  const candidates = { xs: [40, 80], ys: [21] };
+
+  it('snaps an axis to a nearby candidate and reports the guide', () => {
+    const result = alignSnap({ x: 41.2, y: 10 }, candidates, false);
+    expect(result.x).toBe(40);
+    expect(result.guideX).toBe(40);
+    expect(result.guideY).toBeNull();
+    // The unaligned axis still takes the magnetic grid.
+    expect(result.y).toBe(10.5);
+  });
+
+  it('prefers the closest candidate when two are in range', () => {
+    const result = alignSnap({ x: 41.6, y: 0 }, { xs: [40, 42.5], ys: [] }, false);
+    expect(result.x).toBe(42.5);
+  });
+
+  it('falls back to the grid outside the alignment radius', () => {
+    const result = alignSnap({ x: 45, y: 0 }, candidates, false);
+    expect(result.guideX).toBeNull();
+    expect(result.x).toBe(45.5);
+  });
+
+  it('fine mode disables both pulls', () => {
+    const result = alignSnap({ x: 40.4, y: 21.3 }, candidates, true);
+    expect(result.guideX).toBeNull();
+    expect(result.guideY).toBeNull();
+    expect(result.x).toBeCloseTo(40.4, 6);
+    expect(result.y).toBeCloseTo(21.3, 6);
+  });
+});
+
+describe('rotationRingRadiusMm', () => {
+  it('clears the part footprint with a margin, never cramped', () => {
+    const wide = { node: { type: 'block', params: { width: 60, depth: 20, height: 20 } } };
+    expect(rotationRingRadiusMm(wide as never)).toBe(38);
+    const tiny = { node: { type: 'post', params: { diameter: 8, height: 40 } } };
+    expect(rotationRingRadiusMm(tiny as never)).toBe(14);
   });
 });

--- a/src/features/bin-designer/components/Workshop/workshopPlacement.test.ts
+++ b/src/features/bin-designer/components/Workshop/workshopPlacement.test.ts
@@ -169,7 +169,7 @@ describe('alignSnap', () => {
     expect(result.x).toBe(45.5);
   });
 
-  it('fine mode disables both pulls', () => {
+  it('fine mode disables both magnetic pulls, keeping the 0.1mm grid', () => {
     const result = alignSnap({ x: 40.4, y: 21.3 }, candidates, true);
     expect(result.guideX).toBeNull();
     expect(result.guideY).toBeNull();

--- a/src/features/bin-designer/components/Workshop/workshopPlacement.ts
+++ b/src/features/bin-designer/components/Workshop/workshopPlacement.ts
@@ -83,8 +83,8 @@ export interface AlignSnapResult {
 /**
  * Placement snap with sibling alignment: an axis within ALIGN_SNAP_MM of a
  * candidate (sibling center, plate center) snaps to it and reports a guide;
- * otherwise the magnetic grid applies. Fine mode (Alt) disables both kinds of
- * pull — free positioning is the whole point of the modifier.
+ * otherwise the magnetic grid applies. Fine mode (Alt) disables both magnetic
+ * pulls, leaving only the 0.1mm fine grid every Workshop gesture nudges on.
  */
 export function alignSnap(
   local: { x: number; y: number },
@@ -118,6 +118,10 @@ export function alignSnap(
 
 const RING_MARGIN_MM = 8;
 const RING_MIN_RADIUS_MM = 14;
+
+/** Ring height above the part top — the rotation catch plane must sit on the
+ *  same plane or the ray intersection skews the angle against the visible ring. */
+export const ROTATION_RING_LIFT_MM = 2;
 
 /** Rotation-gizmo ring radius: clear of the part's footprint, never cramped. */
 export function rotationRingRadiusMm(placed: PlacedPart): number {

--- a/src/features/bin-designer/components/Workshop/workshopPlacement.ts
+++ b/src/features/bin-designer/components/Workshop/workshopPlacement.ts
@@ -12,7 +12,7 @@ export {
   rotate2d,
   type PlacedPart,
 } from '@/shared/types/assemblyPlacement';
-import { rotate2d, type PlacedPart } from '@/shared/types/assemblyPlacement';
+import { partFootprint, rotate2d, type PlacedPart } from '@/shared/types/assemblyPlacement';
 
 export function baseExtentMm(envelope: ItemEnvelope): { w: number; d: number } {
   return {
@@ -57,4 +57,70 @@ export function worldToParentLocal(
 ): { x: number; y: number } {
   if (!parent) return { x: point.x, y: point.y };
   return rotate2d(point.x - parent.x, point.y - parent.y, -parent.rotZDeg);
+}
+
+export const ROTATION_SNAP_DEG = 15;
+export const FINE_ROTATION_SNAP_DEG = 1;
+
+/** Snap an angle to the rotation grid and normalize to (-180, 180]. */
+export function snapAngleDeg(deg: number, fine: boolean): number {
+  const step = fine ? FINE_ROTATION_SNAP_DEG : ROTATION_SNAP_DEG;
+  const snapped = Math.round(deg / step) * step;
+  const wrapped = (((snapped % 360) + 540) % 360) - 180;
+  return wrapped === -180 ? 180 : wrapped;
+}
+
+export const ALIGN_SNAP_MM = 2;
+
+export interface AlignSnapResult {
+  readonly x: number;
+  readonly y: number;
+  /** Aligned sibling coordinate per axis, null when the grid snap won. */
+  readonly guideX: number | null;
+  readonly guideY: number | null;
+}
+
+/**
+ * Placement snap with sibling alignment: an axis within ALIGN_SNAP_MM of a
+ * candidate (sibling center, plate center) snaps to it and reports a guide;
+ * otherwise the magnetic grid applies. Fine mode (Alt) disables both kinds of
+ * pull — free positioning is the whole point of the modifier.
+ */
+export function alignSnap(
+  local: { x: number; y: number },
+  candidates: { xs: readonly number[]; ys: readonly number[] },
+  fine: boolean
+): AlignSnapResult {
+  if (fine) {
+    return { x: snapCoord(local.x, true), y: snapCoord(local.y, true), guideX: null, guideY: null };
+  }
+  const nearest = (value: number, options: readonly number[]): number | null => {
+    let best: number | null = null;
+    let bestDistance = ALIGN_SNAP_MM;
+    for (const option of options) {
+      const distance = Math.abs(value - option);
+      if (distance <= bestDistance) {
+        best = option;
+        bestDistance = distance;
+      }
+    }
+    return best;
+  };
+  const guideX = nearest(local.x, candidates.xs);
+  const guideY = nearest(local.y, candidates.ys);
+  return {
+    x: guideX ?? snapCoord(local.x, false),
+    y: guideY ?? snapCoord(local.y, false),
+    guideX,
+    guideY,
+  };
+}
+
+const RING_MARGIN_MM = 8;
+const RING_MIN_RADIUS_MM = 14;
+
+/** Rotation-gizmo ring radius: clear of the part's footprint, never cramped. */
+export function rotationRingRadiusMm(placed: PlacedPart): number {
+  const footprint = partFootprint(placed.node);
+  return Math.max(RING_MIN_RADIUS_MM, Math.max(footprint.w, footprint.d) / 2 + RING_MARGIN_MM);
 }


### PR DESCRIPTION
The two remaining Workshop canvas items from the ship review's later-list.

**Rotation gizmo.** Selecting a part shows a flat ring at its top with a knob at the current heading. Dragging anywhere on the ring rotates the part about Z through the same transactioned machinery as a move — the grab point never jumps (the grab offset is captured at pointerdown), angles land on 15° detents with Alt for 1°, values normalize to (-180, 180], and rotation composes correctly on rotated parents (the pointer angle is resolved against the parent frame's world heading). Pointer moves resolve on an invisible catch plane at the ring's height so the angle has no parallax; the sharp mesh yields to live proxies mid-rotation; undo reverts the whole gesture as one step. Works for mouse and touch.

**Snap alignment guides.** While dragging, an axis within 2mm of a sibling's center (or the plate center, when seating on the base) snaps to it and draws an emissive guide line through the aligned coordinate — alignment beats the 3.5mm magnetic grid, and Alt disables both pulls, keeping the modifier's free-positioning meaning. Guides live in the target parent's frame, so on a rotated parent they draw rotated with it.

Live-verified on camera: dragging the ring rotated a block to 120° (inspector tracking live, geometry matching, single-step undo back to 0), and dragging a block toward a post snapped it to exactly y=14 with the cyan guide line running through the post — with the off-base advisory badge firing correctly when the block crossed the plate edge.

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

