### PR TITLE
fix(generation): clip a tapered bin's raised floor to the wall

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.taper.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.taper.test.ts
@@ -18,7 +18,9 @@ import {
   boundingBox,
   meshTopologyStats,
   meshVolume,
+  sectionHalfWidth,
 } from './__kernel-tests__/meshAssertions';
+import { SOCKET_HEIGHT } from './generatorTypes';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 
 beforeAll(async () => {
@@ -306,5 +308,39 @@ describe('bin wall taper geometry (#2933)', () => {
     // The taper fully retracts both X sides, so the tapered bin's feet stop a
     // full 10mm/side short of where the flat bin's reach.
     expect(floorSpanX(feetFlat) - floorSpanX(feetTapered)).toBeCloseTo(taper.left + taper.right, 0);
+  });
+
+  // `binFloorMm` makes the floor thicker than a 1.2mm wall, so a rim-sized slab
+  // is fused in above the cavity floor. Down there a tapered wall has pulled
+  // back from the rim, and the unclipped slab fused on as a flat plate jutting
+  // past it (#3751) — a defect the bounding box cannot see, since the rim is
+  // the widest part either way.
+  it('a raised floor stops at the tapered wall rather than plating past it', () => {
+    const generateBin = getGenerateBin();
+    // The reported configuration: no base overhang at all, so the whole 34mm is
+    // flare and the base must come back to the nominal 84mm footprint.
+    const sides = { left: 0, right: 34, front: 0, back: 0 };
+    const bandHeight = 13.5;
+    const mesh = generateBin(
+      buildParams({
+        width: 2,
+        depth: 2,
+        height: 4,
+        overhang: { ...sides, taper: { profile: 'chamfer', bandHeight, ...sides } },
+      }),
+      undefined,
+      true
+    );
+    assertStructurallyValid(mesh, 'raised floor + taper');
+
+    const bb = boundingBox(mesh.vertices);
+    const floorZ = bb.minZ + SOCKET_HEIGHT; // body Z=0
+    // Chamfer is linear, so at height z nothing may reach past the rim less the
+    // inset still to be recovered — at the floor itself, the nominal footprint.
+    for (const z of [0, 0.5, 1, 2]) {
+      expect(sectionHalfWidth(mesh, floorZ + z)).toBeLessThanOrEqual(
+        bb.maxX - sides.right * (1 - z / bandHeight) + 0.05
+      );
+    }
   });
 });

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -298,10 +298,9 @@ export function buildBinBox(
      * The slab overlaps the existing floor top by COPLANAR_MARGIN — merely
      * meeting that face fuses non-manifold.
      *
-     * `taper` is the taper the body was actually built with, absent on every
-     * untapered path and on a taper fallback. The slab footprint is rim-sized,
-     * and down at the floor a tapered wall has narrowed away from the rim, so
-     * unclipped it fuses on as a plate protruding into open air (#3751).
+     * Its footprint is rim-sized, so on a tapered body it has to be clipped to
+     * the inner envelope: down at the floor the wall has narrowed away from the
+     * rim, and the raw slab fuses on as a plate protruding past it.
      */
     const finish = (shape: Shape3D, taper?: ResolvedTaper | null): Shape3D => {
       if (!raisesFloor) return setBoxCache(boxKey, shape);

--- a/src/features/generation/worker/generators/boxBuilder.ts
+++ b/src/features/generation/worker/generators/boxBuilder.ts
@@ -45,7 +45,13 @@ import { getBoxCache, setBoxCache, getLipCache, setLipCache } from './shapeCache
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import { resolvePitch, pitchKeySegments, type GridUnitInput } from './gridPitch';
 import { hashMask, isPartialMask, type CellMask } from '@/shared/utils/cellMask';
-import { hasOverhang, overhangExpansion, overhangKey, type ResolvedOverhang } from './overhang';
+import {
+  hasOverhang,
+  overhangExpansion,
+  overhangKey,
+  type ResolvedOverhang,
+  type ResolvedTaper,
+} from './overhang';
 import {
   buildTaperedBox,
   buildTaperedInnerEnvelope,
@@ -291,14 +297,40 @@ export function buildBinBox(
     /**
      * The slab overlaps the existing floor top by COPLANAR_MARGIN — merely
      * meeting that face fuses non-manifold.
+     *
+     * `taper` is the taper the body was actually built with, absent on every
+     * untapered path and on a taper fallback. The slab footprint is rim-sized,
+     * and down at the floor a tapered wall has narrowed away from the rim, so
+     * unclipped it fuses on as a plate protruding into open air (#3751).
      */
-    const finish = (shape: Shape3D): Shape3D => {
+    const finish = (shape: Shape3D, taper?: ResolvedTaper | null): Shape3D => {
       if (!raisesFloor) return setBoxCache(boxKey, shape);
-      const slab = scope.register(
+      const rawSlab = scope.register(
         sketch(makeInnerFootprint(), 'XY', wallThickness - COPLANAR_MARGIN).extrude(
           floorThickness - wallThickness + COPLANAR_MARGIN
         )
       );
+      const slab = taper
+        ? scope.register(
+            unwrap(
+              intersect(
+                rawSlab as ValidSolid,
+                scope.register(
+                  buildTaperedInnerEnvelope(
+                    outerW,
+                    outerD,
+                    wallHeight,
+                    wallThickness,
+                    taper,
+                    floorThickness,
+                    offX,
+                    offY
+                  )
+                ) as ValidSolid
+              )
+            )
+          )
+        : rawSlab;
       const fused = unwrap(fuse(shape as ValidSolid, slab as ValidSolid));
       // Registering the cached shape would queue a delete on what the cache
       // hands out.
@@ -514,7 +546,7 @@ export function buildBinBox(
         // owned by the scope — registering it again would queue a second
         // `delete()` on the same handle.
         scope.register(box);
-        return finish(result);
+        return finish(result, lofts ? ov?.taper : null);
       } catch (e: unknown) {
         // Defensive only — context.ts is supposed to gate this path with
         // `compartmentCavitiesAreViable` so cuts can't fail in practice.
@@ -572,7 +604,7 @@ export function buildBinBox(
           offY
         );
         scope.register(box); // unused on the taper path
-        return finish(taperedBody);
+        return finish(taperedBody, ov.taper);
       } catch (e: unknown) {
         // Fall through to the plain shelled box below so the bin is never lost —
         // but surface it (like the multi-cavity fallback) so a taper regression


### PR DESCRIPTION
Fixes #3751.

## The bug

A bin's interior floor is thicker than a thin wall (`binFloorMm` returns 2mm against a 1.2mm wall), so `buildBinBox` fuses a rim-sized slab in above the cavity floor. On a bin with a wall taper the wall down there has already narrowed back toward the nominal footprint, so the slab reached past it and fused on as a flat plate protruding into open air.

Reported case (2x2, 1.2mm walls, chamfer rising to 13.5mm, 34mm flare on the right): the base measured 34mm oversized on that side, so the bin no longer tiled on a baseplate. The taper itself was correct the whole way up; only the floor slab was rim-anchored.

Measured at the floor plane before and after, on the reported bin:

| | max X at body Z=0 | expected |
| --- | --- | --- |
| before | 74.55mm | 41.75mm |
| after | 41.75mm | 41.75mm |

## The fix

Clip the slab to the tapered inner envelope (`buildTaperedInnerEnvelope`), the same boundary the solid taper path already uses for its lowered-fill recess, so the floor stops at the wall's inner face at every height. `finish()` takes the taper the body was actually built with, so untapered bins and the taper-build fallback keep the unchanged prism slab and are bit-identical.

## Test

`binGenerator.scenario.taper.test.ts` gains a case that walks the reported configuration up through the floor and asserts nothing reaches past the chamfer's linear profile. It fails on `main` (74.55 vs 43.06 allowed) and passes here. The bounding box cannot see this defect, since the rim is the widest part either way.

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

