### PR TITLE
feat(workshop): give parts a designed edge language

### DIFF
--- a/.claude/skills/geometry-generation/SKILL.md
+++ b/.claude/skills/geometry-generation/SKILL.md
@@ -104,6 +104,18 @@ Commit bodies here contain root-cause analyses and upstream references — `git 
 
 ## Construction invariants
 
+### Workshop assembly edge language
+
+Part templates carry an automatic finish (`assemblyGenerator.ts`): capsule fin
+footprints, corner/top fillets, rim chamfers, and a post-fuse cove at every
+seat plane. Three sliver classes are excluded BY CONSTRUCTION, not by fallback:
+capsule end segments stay >=1.2mm, leaned-fin crowns fillet only the long
+edges, and round-groove tangent seams are never selected. Plane-edge selection
+must match edges lying IN the plane — an edge crossing it fillets a whole
+vertical corner. Proxies mirror silhouettes only (capsule/rounded footprints);
+exact fillets appear at sharpen. Any geometry change here bumps the
+`assembly-part-*` template key AND the persisted `item*` mesh-cache segment.
+
 ### The perimeter is the material; the grid extent is not its bound
 
 Never consume `drawer.outline` raw for gating, rendering or generation. Go through

--- a/src/features/bin-designer/components/Workshop/proxyGeometry.ts
+++ b/src/features/bin-designer/components/Workshop/proxyGeometry.ts
@@ -18,6 +18,22 @@ const DEG = Math.PI / 180;
 /** Rotate a shape-plane (profile-in-YZ, extruded-along-X) solid into world axes. */
 const YZ_PROFILE_TO_WORLD = new Matrix4().set(0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1);
 
+function roundedRectShape(w: number, d: number, radius: number): Shape {
+  const r = Math.min(radius, w / 2 - 1e-3, d / 2 - 1e-3);
+  const shape = new Shape();
+  shape.moveTo(-w / 2 + r, -d / 2);
+  shape.lineTo(w / 2 - r, -d / 2);
+  shape.absarc(w / 2 - r, -d / 2 + r, r, -Math.PI / 2, 0, false);
+  shape.lineTo(w / 2, d / 2 - r);
+  shape.absarc(w / 2 - r, d / 2 - r, r, 0, Math.PI / 2, false);
+  shape.lineTo(-w / 2 + r, d / 2);
+  shape.absarc(-w / 2 + r, d / 2 - r, r, Math.PI / 2, Math.PI, false);
+  shape.lineTo(-w / 2, -d / 2 + r);
+  shape.absarc(-w / 2 + r, -d / 2 + r, r, Math.PI, Math.PI * 1.5, false);
+  shape.closePath();
+  return shape;
+}
+
 function extrudeYZProfile(shape: Shape, alongX: number): BufferGeometry {
   const geometry = new ExtrudeGeometry(shape, { depth: alongX, bevelEnabled: false });
   geometry.applyMatrix4(YZ_PROFILE_TO_WORLD);
@@ -41,8 +57,21 @@ function buildFin(p: {
   leanDeg: number;
   leanAxis?: 'thickness' | 'length';
 }): BufferGeometry {
-  const geometry = new BoxGeometry(p.length, p.thickness, p.height);
-  geometry.translate(0, 0, p.height / 2);
+  // Straight fins are capsules, matching the worker; leaning fins stay
+  // prisms there (sheared arcs invert in OCCT), so the proxy matches.
+  const endRadius = Math.min(p.thickness * 0.45, (p.thickness - 1.2) / 2);
+  const geometry =
+    p.leanDeg <= 0 && endRadius >= 0.3
+      ? new ExtrudeGeometry(roundedRectShape(p.length, p.thickness, endRadius), {
+          depth: p.height,
+          bevelEnabled: false,
+          curveSegments: 12,
+        })
+      : (() => {
+          const boxGeometry = new BoxGeometry(p.length, p.thickness, p.height);
+          boxGeometry.translate(0, 0, p.height / 2);
+          return boxGeometry;
+        })();
   if (p.leanDeg > 0) {
     const tan = Math.tan(p.leanDeg * DEG);
     // makeShear slots: zy shears y by z (tip over the long edge); zx shears
@@ -63,9 +92,11 @@ function buildBlock(p: {
   wedgeAngleDeg: number;
 }): BufferGeometry {
   if (p.wedgeAngleDeg <= 0) {
-    const box = new BoxGeometry(p.width, p.depth, p.height);
-    box.translate(0, 0, p.height / 2);
-    return box;
+    // Rounded vertical corners, matching the worker's corner fillets.
+    return new ExtrudeGeometry(
+      roundedRectShape(p.width, p.depth, Math.min(2.5, p.width / 5, p.depth / 5)),
+      { depth: p.height, bevelEnabled: false, curveSegments: 8 }
+    );
   }
   const lowEdge = Math.max(0.5, p.height - p.depth * Math.tan(p.wedgeAngleDeg * DEG));
   const shape = new Shape();

--- a/src/features/generation/worker/generators/assemblyGenerator.ts
+++ b/src/features/generation/worker/generators/assemblyGenerator.ts
@@ -94,12 +94,13 @@ const TOP_EASE_MM = 1;
 const CORNER_FILLET_MM = 2.5;
 const JUNCTION_FILLET_MM = 1.5;
 
-/** Edges whose Z extent brackets `z` (planar rims, junction seams). */
+/** Edges lying IN the plane at `z` (planar rims, junction seams) — never a
+ *  vertical edge that merely crosses it, the classic sliver source. */
 function edgesNearPlane(shape: Shape3D, z: number, tolerance = 0.4): Edge[] {
   return edgeFinder()
     .when((e) => {
       const bounds = getBounds(e);
-      return bounds.zMax >= z - tolerance && bounds.zMin <= z + tolerance;
+      return Math.abs(bounds.zMax - z) <= tolerance && Math.abs(bounds.zMin - z) <= tolerance;
     })
     .findAll(shape);
 }

--- a/src/features/generation/worker/generators/assemblyGenerator.ts
+++ b/src/features/generation/worker/generators/assemblyGenerator.ts
@@ -14,6 +14,7 @@
 import {
   applyMatrix,
   box,
+  chamfer,
   clone,
   cone,
   cut,
@@ -22,10 +23,13 @@ import {
   draw,
   drawCircle,
   drawRoundedRectangle,
+  edgeFinder,
   exportSTEP,
   fuseAll,
+  getBounds,
   getKernelCapabilities,
   intersect,
+  isOk,
   mesh,
   meshEdges,
   mirror,
@@ -34,7 +38,7 @@ import {
   unwrap,
   withScope,
 } from 'brepjs';
-import type { Drawing, Shape3D, ValidSolid } from 'brepjs';
+import type { Drawing, Edge, Shape3D, ValidSolid } from 'brepjs';
 import type {
   AssemblyPartNode,
   AssemblyStructure,
@@ -60,7 +64,12 @@ import { creaseEdges } from './utils';
 import { computeTessellationTolerances, EXPORT_ANGULAR_TOLERANCE_RAD } from './utils/tolerances';
 import { unwrapExportBlob } from './utils/exportUnwrap';
 import { exportSolidToStl } from './utils/stlMeshFallback';
-import { flattenPathToPolyline, pathWire, polylineSelfIntersects } from './cutoutBuilder';
+import {
+  applyFilletWithFallback,
+  flattenPathToPolyline,
+  pathWire,
+  polylineSelfIntersects,
+} from './cutoutBuilder';
 import { offsetClosedPolygon } from './polygonOffset';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import { getFeatureCache, setFeatureCache } from './shapeCache';
@@ -73,6 +82,83 @@ const CUTTER_TOP_OVERSHOOT = 1;
 
 /** Default outer corner radius of the floor plate when the base sets none. */
 const DEFAULT_FLOOR_CORNER_RADIUS = 4;
+
+/**
+ * The edge language that makes an assembly read as a designed product rather
+ * than fused primitives: one small roundover on every top rim, rounded
+ * vertical corners on prisms, and a molded cove where each part meets the
+ * surface it seats on. Magnitudes stay small so no footprint or functional
+ * face moves; every application degrades to the sharp shape on kernel failure.
+ */
+const TOP_EASE_MM = 1;
+const CORNER_FILLET_MM = 2.5;
+const JUNCTION_FILLET_MM = 1.5;
+
+/** Edges whose Z extent brackets `z` (planar rims, junction seams). */
+function edgesNearPlane(shape: Shape3D, z: number, tolerance = 0.4): Edge[] {
+  return edgeFinder()
+    .when((e) => {
+      const bounds = getBounds(e);
+      return bounds.zMax >= z - tolerance && bounds.zMin <= z + tolerance;
+    })
+    .findAll(shape);
+}
+
+/**
+ * The long top edges of a run — crown lines whose fillet is a plain cylinder.
+ * The short end edges are excluded: on leaned prisms their corner patches
+ * tessellate degenerate (the scoop-cusp class).
+ */
+function longTopEdges(shape: Shape3D, zTop: number, runLength: number): Edge[] {
+  return edgeFinder()
+    .when((e) => {
+      const bounds = getBounds(e);
+      return (
+        bounds.zMax >= zTop - 0.4 &&
+        bounds.zMin >= zTop - 0.4 &&
+        Math.abs(bounds.xMax - bounds.xMin) > runLength * 0.9
+      );
+    })
+    .findAll(shape);
+}
+
+/** Vertical edges (zero XY extent) — the corner lines of a prism. */
+function verticalEdges(shape: Shape3D): Edge[] {
+  return edgeFinder()
+    .when((e) => {
+      const bounds = getBounds(e);
+      return (
+        bounds.zMax - bounds.zMin > 0.5 &&
+        Math.abs(bounds.xMax - bounds.xMin) < 1e-3 &&
+        Math.abs(bounds.yMax - bounds.yMin) < 1e-3
+      );
+    })
+    .findAll(shape);
+}
+
+/** Fillet with fallback; deletes the input when a new shape came back. */
+function easedOrOriginal(shape: Shape3D, edges: readonly Edge[], radius: number): Shape3D {
+  if (edges.length === 0 || radius <= 0.05) return shape;
+  const result = applyFilletWithFallback(shape, edges, radius);
+  if (result !== shape) shape.delete();
+  return result;
+}
+
+/** Chamfer that keeps the original on kernel failure (same contract as the fillet fallback). */
+function chamferedOrOriginal(shape: Shape3D, edges: readonly Edge[], distance: number): Shape3D {
+  if (edges.length === 0 || distance <= 0.05) return shape;
+  try {
+    const result = chamfer(shape as ValidSolid, edges as Edge[], distance);
+    if (isOk(result)) {
+      const next = unwrap(result);
+      if (next !== shape) shape.delete();
+      return next;
+    }
+  } catch {
+    // Sharp edge beats no part.
+  }
+  return shape;
+}
 
 function stableKeyValue(value: unknown): unknown {
   if (typeof value === 'number') return quantize(value);
@@ -88,7 +174,7 @@ function stableKeyValue(value: unknown): unknown {
 function partCacheKey(node: AssemblyPartNode): string {
   // No forExport in the key: templates are pure BREP solids with no
   // tessellation-quality input, so preview and export share one entry.
-  return buildCacheKey('assembly-part-v1', node.type, JSON.stringify(stableKeyValue(node.params)));
+  return buildCacheKey('assembly-part-v2', node.type, JSON.stringify(stableKeyValue(node.params)));
 }
 
 function centeredOnBounds(pts: readonly { x: number; y: number }[]): { x: number; y: number }[] {
@@ -188,51 +274,94 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
   const sink = COPLANAR_OVERLAP;
   switch (node.type) {
     case 'post': {
-      const { diameter, height, taperDeg } = node.params;
+      const { diameter, height, taperDeg, tipChamfer } = node.params;
       const rBottom = diameter / 2;
       const rTop = Math.max(0.5, rBottom - height * Math.tan(taperDeg * DEG));
       const total = height + sink;
-      if (taperDeg > 0) {
-        return cone(rBottom, rTop, total, { at: [0, 0, -sink] });
-      }
-      return cylinder(rBottom, total, { at: [0, 0, -sink] });
+      const body =
+        taperDeg > 0
+          ? cone(rBottom, rTop, total, { at: [0, 0, -sink] })
+          : cylinder(rBottom, total, { at: [0, 0, -sink] });
+      const tip = Math.min(tipChamfer ?? 1, rTop - 0.3, height / 4);
+      return chamferedOrOriginal(body, edgesNearPlane(body, height), tip);
     }
     case 'fin': {
       const { length, thickness, height, leanDeg, leanAxis } = node.params;
-      const lean = Math.tan(leanDeg * DEG) * height;
-      if (leanAxis === 'length') {
-        // Shear along the plate's run, then clip back to the nominal length
-        // — the rack generator's leaning fins were clipped the same way so
-        // the lean never overshoots the footprint.
-        const total = height + sink;
-        const plate = box(length, thickness, total, { at: [0, 0, total / 2 - sink] });
-        if (leanDeg <= 0) return plate;
-        const tan = Math.tan(leanDeg * DEG);
-        const sheared = unwrap(
-          applyMatrix(plate, {
-            linear: [1, 0, tan, 0, 1, 0, 0, 0, 1],
-            translation: [0, 0, 0],
-          })
+      const crown = Math.min(thickness / 3, TOP_EASE_MM);
+      const tan = leanDeg > 0 ? Math.tan(leanDeg * DEG) : 0;
+      if (tan <= 0) {
+        // Near-capsule footprint: rounded ends read as a designed blade, and
+        // the rounding stays inscribed so the nominal footprint never grows.
+        // 0.45× thickness keeps a real straight segment on each side — a true
+        // tangent capsule leaves micro-edges OCCT can reject.
+        // No crown ease here: filleting the capsule's top loop slivers where
+        // the straight runs meet the end arcs tangentially (the scoop-cusp
+        // class); the rounded footprint carries the look on its own. The
+        // radius leaves a >=1.2mm straight segment on the short ends — the
+        // near-tangent leftover is itself a degenerate-facet source.
+        const endRadius = Math.min(thickness * 0.45, (thickness - 1.2) / 2);
+        if (endRadius < 0.3) {
+          const total = height + sink;
+          return box(length, thickness, total, { at: [0, 0, total / 2 - sink] });
+        }
+        return sketch(drawRoundedRectangle(length, thickness, endRadius), 'XY', -sink).extrude(
+          height + sink
         );
-        if (sheared !== plate) plate.delete();
-        const clip = box(length, thickness + 2, total * 2 + 2, { at: [0, 0, total / 2 - sink] });
+      }
+      // Leaning fins keep planar constructions: OCCT's sheared-box faces only
+      // come out clean when a boolean rebuilds them (the length-axis clip does
+      // that; the thickness-axis draws its quad directly), and the capsule's
+      // arc faces can invert under the non-uniform transform outright. The
+      // rounding budget goes to the crown alone.
+      const total = height + sink;
+      if (leanAxis === 'length') {
+        const boxPlate = box(length, thickness, total, { at: [0, 0, total / 2 - sink] });
+        const linear = [1, 0, tan, 0, 1, 0, 0, 0, 1] as [
+          number,
+          number,
+          number,
+          number,
+          number,
+          number,
+          number,
+          number,
+          number,
+        ];
+        const sheared = unwrap(
+          applyMatrix(boxPlate, { linear, translation: [0, 0, 0] })
+        ) as Shape3D;
+        if (sheared !== boxPlate) boxPlate.delete();
+        // Clip back to the nominal run — the rack generator's leaning fins
+        // were clipped the same way so the lean never overshoots.
+        const clip = box(length, thickness + 2, total * 2 + 2, {
+          at: [0, 0, total / 2 - sink],
+        });
         const clipped = unwrap(intersect(sheared, clip, { optimisation: 'commonFace' }));
         if (clipped !== sheared) sheared.delete();
         clip.delete();
-        return clipped;
+        return easedOrOriginal(clipped, longTopEdges(clipped, height, length), crown);
       }
+      const lean = tan * height;
       const pen = draw([-thickness / 2, -sink])
         .lineTo([thickness / 2, -sink])
         .lineTo([thickness / 2 + lean, height])
         .lineTo([-thickness / 2 + lean, height])
         .close();
-      return sketch(pen, 'YZ', -length / 2).extrude(length);
+      const quad = sketch(pen, 'YZ', -length / 2).extrude(length);
+      return easedOrOriginal(quad, longTopEdges(quad, height, length), crown);
     }
     case 'block': {
       const { width, depth, height, wedgeAngleDeg } = node.params;
+      const corner = Math.min(CORNER_FILLET_MM, width / 5, depth / 5);
       if (wedgeAngleDeg <= 0) {
         const total = height + sink;
-        return box(width, depth, total, { at: [0, 0, total / 2 - sink] });
+        let body: Shape3D = box(width, depth, total, { at: [0, 0, total / 2 - sink] });
+        body = easedOrOriginal(body, verticalEdges(body), corner);
+        return easedOrOriginal(
+          body,
+          edgesNearPlane(body, height),
+          Math.min(TOP_EASE_MM, height / 5)
+        );
       }
       const lowEdge = Math.max(0.5, height - depth * Math.tan(wedgeAngleDeg * DEG));
       const pen = draw([-depth / 2, -sink])
@@ -240,7 +369,10 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
         .lineTo([depth / 2, lowEdge])
         .lineTo([-depth / 2, height])
         .close();
-      return sketch(pen, 'YZ', -width / 2).extrude(width);
+      const wedge = sketch(pen, 'YZ', -width / 2).extrude(width);
+      // The sloped face stays crisp (it is the functional ramp); only the
+      // vertical corner lines soften.
+      return easedOrOriginal(wedge, verticalEdges(wedge), corner);
     }
     case 'tube': {
       const { boreDiameter, wall, height, tiltDeg } = node.params;
@@ -248,9 +380,12 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
       const bore = cylinder(boreDiameter / 2, height + 2 * sink + 2, {
         at: [0, 0, -sink - 1],
       });
-      const hollow = unwrap(cut(outer, bore, { optimisation: 'commonFace' }));
+      let hollow = unwrap(cut(outer, bore, { optimisation: 'commonFace' })) as Shape3D;
       if (hollow !== outer) outer.delete();
       bore.delete();
+      // Lead-in chamfer on both rims: the tool finds the bore, and the mouth
+      // reads finished instead of saw-cut.
+      hollow = chamferedOrOriginal(hollow, edgesNearPlane(hollow, height), Math.min(wall / 3, 0.8));
       if (tiltDeg <= 0) return hollow;
       const tilted = rotate(hollow, tiltDeg, { at: [0, 0, 0], axis: [1, 0, 0] });
       hollow.delete();
@@ -269,7 +404,10 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
           .lineTo([-gw / 2, height])
           .lineTo([-width / 2, height])
           .close();
-        return sketch(pen, 'YZ', -length / 2).extrude(length);
+        const vee = sketch(pen, 'YZ', -length / 2).extrude(length);
+        // Top edges — outer rim AND groove mouth — get the same ease: the
+        // mouth rounding doubles as the tool's lead-in.
+        return easedOrOriginal(vee, edgesNearPlane(vee, height), Math.min(0.6, gd / 5));
       }
       const total = height + sink;
       const body = box(length, width, total, { at: [0, 0, total / 2 - sink] });
@@ -281,7 +419,21 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
       const carved = unwrap(cut(body, groove, { optimisation: 'commonFace' }));
       if (carved !== body) body.delete();
       groove.delete();
-      return carved;
+      // Only the outer rim: the groove's near-tangent seam edges sliver under
+      // fillet, and the round groove is its own lead-in anyway.
+      const rimEdges = edgeFinder()
+        .when((e) => {
+          const bounds = getBounds(e);
+          const atTop = bounds.zMax >= height - 0.3 && bounds.zMin >= height - 0.3;
+          const onBoundary =
+            Math.abs(Math.abs(bounds.yMin) - width / 2) < 0.2 ||
+            Math.abs(Math.abs(bounds.yMax) - width / 2) < 0.2 ||
+            Math.abs(Math.abs(bounds.xMin) - length / 2) < 0.2 ||
+            Math.abs(Math.abs(bounds.xMax) - length / 2) < 0.2;
+          return atTop && onBoundary;
+        })
+        .findAll(carved);
+      return easedOrOriginal(carved, rimEdges, Math.min(0.8, gd / 4));
     }
     case 'hook': {
       const { stemHeight, reach, lipHeight, thickness, width } = node.params;
@@ -301,7 +453,18 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
         pen = pen.lineTo([r, s - t]).lineTo([r, s]);
       }
       const drawing = pen.lineTo([0, s]).close();
-      const solid = sketch(drawing, 'YZ', -width / 2).extrude(width);
+      let solid: Shape3D = sketch(drawing, 'YZ', -width / 2).extrude(width);
+      // A hook is all silhouette: rounding the length-running profile corners
+      // is what separates a molded J from an extruded L-bracket. Only those
+      // edges — the sunk base edges and short profile segments produce
+      // degenerate slivers under fillet.
+      const silhouetteEdges = edgeFinder()
+        .when((e) => {
+          const bounds = getBounds(e);
+          return Math.abs(bounds.xMax - bounds.xMin) > width * 0.9 && bounds.zMin > 0.2;
+        })
+        .findAll(solid);
+      solid = easedOrOriginal(solid, silhouetteEdges, Math.min(0.8, t / 2.5));
       const anchored = translate(solid, [0, -r / 2, 0]);
       solid.delete();
       return anchored;
@@ -330,9 +493,17 @@ function buildPartTemplate(node: AssemblyPartNode): Shape3D | null {
         const thickness = Math.min(bridgeWidth, height / 2);
         parts.push(box(crossLength, depth, thickness, { at: [0, 0, height - thickness / 2] }));
       }
-      const fused = unwrap(fuseAll(parts as ValidSolid[], { optimisation: 'commonFace' }));
+      let fused = unwrap(fuseAll(parts as ValidSolid[], { optimisation: 'commonFace' })) as Shape3D;
       for (const part of parts) {
         if (part !== fused) part.delete();
+      }
+      fused = easedOrOriginal(
+        fused,
+        verticalEdges(fused),
+        Math.min(CORNER_FILLET_MM, uprightThickness / 4, depth / 4)
+      );
+      if (style !== 'rod') {
+        fused = easedOrOriginal(fused, edgesNearPlane(fused, height), TOP_EASE_MM);
       }
       return fused;
     }
@@ -422,10 +593,34 @@ export function buildAssemblySolid(
     scope.register(floor);
     onStage?.('features', 0.5);
 
-    const superstructure = unwrap(
+    let superstructure = unwrap(
       fuseAll(additive as ValidSolid[], { optimisation: 'commonFace' })
-    );
+    ) as Shape3D;
     if (!additive.includes(superstructure)) scope.register(superstructure);
+
+    // Molded blend at every seat plane: the concave cove where a part meets
+    // the floor (or a parent's top face) is the single strongest cue that the
+    // assembly was designed as one object rather than boolean-unioned. The
+    // same pass rounds the floor plate's own rim. Failures fall back through
+    // smaller radii to the sharp union.
+    const seatPlanes = new Set<number>([floorThickness]);
+    for (const placed of placements) {
+      if (placed.node.type !== 'cutter') seatPlanes.add(floorThickness + placed.z);
+    }
+    const junctionEdges: Edge[] = [];
+    for (const plane of seatPlanes) {
+      junctionEdges.push(...edgesNearPlane(superstructure, plane, 0.3));
+    }
+    if (junctionEdges.length > 0) {
+      const blended = applyFilletWithFallback(
+        superstructure,
+        junctionEdges,
+        Math.min(JUNCTION_FILLET_MM, floorThickness * 0.75)
+      );
+      if (blended !== superstructure) {
+        superstructure = scope.register(blended);
+      }
+    }
 
     checkCancelled(signal);
     const socket = buildBaseSocket(

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -212,7 +212,9 @@ export function binMeshCacheKey(params: BinParams, kernel: KernelName): string {
  */
 export function itemMeshCacheKey(item: GridfinityItem, kernel: KernelName): string {
   const revision = KERNEL_MESH_REVISION[kernel];
-  return `${MESH_CACHE_VERSION}:${kernel}-${revision}:item:${djb2(stableStringify(item))}`;
+  // item2: assembly part-quality pass (fillets/chamfers) changed geometry for
+  // identical structures; bumping only this segment spares the bin cache.
+  return `${MESH_CACHE_VERSION}:${kernel}-${revision}:item2:${djb2(stableStringify(item))}`;
 }
 
 /**


### PR DESCRIPTION
First of the Workshop quality PRs (from the research pass over popular non-bin Gridfinity models): assemblies stop reading as fused primitives.

One automatic, uniform edge language — no new params, no schema churn:

- **Molded seat junctions**: after the fuse, every horizontal junction edge lying on a seat plane (floor top, or a parent's top face) gets a concave cove fillet, and the floor plate's rim rounds in the same pass. This is the single strongest "designed as one object" cue.
- **Post**: the `tipChamfer` param is finally honored (it was silently ignored).
- **Fin**: straight fins become capsules (rounded ends, radius bounded so no micro-edges); leaning fins keep planar prisms (sheared arc faces invert in OCCT) with a crown roundover on the long edges.
- **Block**: rounded vertical corners; straight blocks also get a top ease; wedge ramps stay crisp.
- **Tube**: lead-in chamfer on both rims — functional and finished.
- **Cradle**: eased top rim (vee mouths get a smaller ease; round-groove tangent seams excluded — they sliver under fillet).
- **Hook**: silhouette roundover on the length-running profile corners — the molded-J look.
- **Arch**: rounded upright corners, eased bridge top.

Every treatment goes through the graduated-fallback fillet (or a failure-safe chamfer), so a kernel failure degrades to the sharp shape, never a missing part. Proxies keep silhouette parity (capsule fins, rounded blocks). The part template cache key and the persisted item-mesh segment are bumped so nothing stale survives.

Three degenerate-sliver classes were found by the real-WASM suite and excluded by construction (capsule end micro-edges, leaned-end crown patches, groove tangent seams) — each is documented at its site. 16/16 assembly WASM tests green; full suite 24,814 green; verified visually in the Workshop (junction coves, tip chamfers, and rim treatments all read on camera).

https://claude.ai/code/session_016ByTdUfpk6e9KT18oZSs4q

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

