### PR TITLE
feat(generation): magnet and screw holes on half-size feet

### DIFF
--- a/src/features/generation/worker/generators/baseplateDirectMesh.ts
+++ b/src/features/generation/worker/generators/baseplateDirectMesh.ts
@@ -55,7 +55,7 @@ import { addPocketWalls, addOuterWalls } from './directMeshWalls';
 import { addPlateFace, addSolidBottomFace } from './directMeshFaces';
 import { addMagnetHoleAt } from './directMeshMagnets';
 import { addScrewHoleAt } from './directMeshScrews';
-import { magnetPositionsForCell } from './baseplateMagnets';
+import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
 import { planBaseplateScrewHoles } from './baseplateScrews';
 import { addConnectorNub, addConnectorHole } from './directMeshConnectors';
 
@@ -140,6 +140,10 @@ export function generateBaseplateDirect(
   // ring, while a sub-threshold sliver keeps its solid fill.
   const cells: CellInfo[] = [];
   forEachCell(width, depth, (cell) => cells.push(cell), cellOpts);
+  // Everything appended past here is an over-tile frame tile. The magnet pass
+  // below magnetizes frame tiles separately, so it needs the nominal grid alone
+  // — it can no longer tell the two apart by cell size.
+  const nominalCellCount = cells.length;
   // Plain solid padding fills the whole margin ring (no pockets); over-tile
   // restricts the ring to the un-pocketed outer band via per-side pocket depths.
   let drawRing = !overTile;
@@ -252,12 +256,10 @@ export function generateBaseplateDirect(
 
   if (magnetHoles) {
     const magnetRadius = magnetDiameter / 2;
-    // Nominal grid: full cells get the standard 4 corners (fractional nominal
-    // cells are skipped, matching the BREP build). `cells` also holds the frame
-    // tiles, but they're <1u so the guard skips them here — they're magnetized
-    // by the over-tile pass below.
-    for (const cell of cells) {
-      if (cell.widthUnits < 1 || cell.depthUnits < 1) continue;
+    // Nominal grid: full cells get the standard 4 corners, half cells whatever
+    // of that pattern their tapered floor holds — matching the BREP build.
+    for (const cell of cells.slice(0, nominalCellCount)) {
+      if (!cellHostsAttachmentHoles(cell, magnetRadius, gridUnitMm, gridUnitMmY)) continue;
       // Shared placement (wall-distance clamp) — identical to the BREP plate,
       // bin base, and lid so the draft preview and all mating surfaces agree.
       for (const [x, y] of magnetPositionsForCell(

--- a/src/features/generation/worker/generators/baseplateMagnets.test.ts
+++ b/src/features/generation/worker/generators/baseplateMagnets.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { magnetPositionsForCell, MAGNET_EDGE_CLEARANCE } from './baseplateMagnets';
+import {
+  cellHostsAttachmentHoles,
+  magnetPositionsForCell,
+  MAGNET_EDGE_CLEARANCE,
+} from './baseplateMagnets';
 import { MAGNET_OFFSETS } from './generatorConstants';
-import { HOLE_OFFSET } from './generatorTypes';
+import { CLEARANCE, HOLE_OFFSET, INSET_BOT } from './generatorTypes';
 import type { CellInfo } from './cellDecomposition';
 
 const GRID = 42;
@@ -210,5 +214,57 @@ describe('magnetPositionsForCell', () => {
       const legacy = magnetPositionsForCell(cell(1, 1), MAGNET_R, 50, 50, 'center');
       expect(defaulted).not.toEqual(legacy);
     });
+  });
+});
+
+describe('cellHostsAttachmentHoles', () => {
+  it('admits a half cell at spec pitch (#3778)', () => {
+    expect(cellHostsAttachmentHoles(cell(0.5, 0.5), MAGNET_R, GRID, GRID)).toBe(true);
+    expect(cellHostsAttachmentHoles(cell(0.5, 1), MAGNET_R, GRID, GRID)).toBe(true);
+  });
+
+  it('rejects a half cell whose tapered face cannot hold the wall (pitch 25)', () => {
+    // 12.5mm nominal leaves ~6.1mm once the socket taper and fit clearance come
+    // off — narrower than a 6.5mm magnet, let alone its wall.
+    expect(cellHostsAttachmentHoles(cell(0.5, 0.5), MAGNET_R, 25, 25)).toBe(false);
+  });
+
+  it('rejects on the short axis alone', () => {
+    expect(cellHostsAttachmentHoles(cell(0.5, 4), MAGNET_R, 25, 42)).toBe(false);
+  });
+
+  it('narrows as the hole widens', () => {
+    // The same half cell that fits a 6.5mm magnet cannot fit a 16mm one.
+    expect(cellHostsAttachmentHoles(cell(0.5, 0.5), 8, GRID, GRID)).toBe(false);
+  });
+
+  it('admits every full cell regardless of pitch, as before the half-cell change', () => {
+    for (const pitch of [20, 25, 42, 60]) {
+      expect(cellHostsAttachmentHoles(cell(1, 1), MAGNET_R, pitch, pitch)).toBe(true);
+    }
+  });
+});
+
+describe('half-cell magnet placement (#3778)', () => {
+  it('gives a lone half foot one centered hole', () => {
+    expect(magnetPositionsForCell(cell(0.5, 0.5, 21, 0), MAGNET_R, GRID, GRID)).toEqual([[21, 0]]);
+  });
+
+  it('keeps the standard ±13 spacing on a half foot long axis (0.5×1)', () => {
+    const positions = magnetPositionsForCell(cell(0.5, 1, 21, 0), MAGNET_R, GRID, GRID);
+    expect(positions).toHaveLength(2);
+    for (const [x] of positions) expect(x).toBeCloseTo(21, 6);
+    const ys = positions.map((p) => p[1]).sort((a, b) => a - b);
+    expect(ys[0]).toBeCloseTo(-HOLE_OFFSET, 6);
+    expect(ys[1]).toBeCloseTo(HOLE_OFFSET, 6);
+  });
+
+  it('keeps a printable wall on the half foot tapered face', () => {
+    // The face the hole opens on is the socket bottom: nominal less the fit
+    // clearance and the taper on each side.
+    const bottomHalf = (0.5 * GRID - CLEARANCE) / 2 - INSET_BOT;
+    for (const [x] of magnetPositionsForCell(cell(0.5, 0.5), MAGNET_R, GRID, GRID)) {
+      expect(bottomHalf - Math.abs(x) - MAGNET_R).toBeGreaterThanOrEqual(MAGNET_EDGE_CLEARANCE);
+    }
   });
 });

--- a/src/features/generation/worker/generators/baseplateMagnets.ts
+++ b/src/features/generation/worker/generators/baseplateMagnets.ts
@@ -8,19 +8,28 @@
  * Builds one template cylinder, clones+translates per position.
  *
  * Nominal full (1.0+ unit) cells get the standard 4-corner pattern (±13mm from
- * cell center). Fractional cells in the nominal grid are skipped — the
- * Gridfinity spec doesn't define magnet positions there. PARTIAL over-tile
- * margin tiles are handled by {@link buildPartialCellMagnetHoles}: each gets the
- * corner magnets that physically fit, falling back to a single centered magnet
- * for tiles too small for any corner, so the clipped padding tiles aren't left
- * solid.
+ * cell center). A half cell keeps whatever of that pattern still fits — two
+ * magnets on its long axis, or a single centered one — provided its tapered
+ * face holds a printable wall around the hole ({@link cellHostsAttachmentHoles}).
+ * PARTIAL over-tile margin tiles are handled by
+ * {@link buildPartialCellMagnetHoles}: each gets the corner magnets that
+ * physically fit, falling back to a single centered magnet for tiles too small
+ * for any corner, so the clipped padding tiles aren't left solid.
  */
 
 import { cylinder, unwrap, clone, translate } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { MagnetAnchor } from '@/core/types';
 import { DEFAULT_MAGNET_ANCHOR } from '@/core/types';
-import { SIZE, SOCKET_HEIGHT, COPLANAR_MARGIN, HOLE_OFFSET, forEachCell } from './generatorTypes';
+import {
+  SIZE,
+  SOCKET_HEIGHT,
+  COPLANAR_MARGIN,
+  HOLE_OFFSET,
+  CLEARANCE,
+  INSET_BOT,
+  forEachCell,
+} from './generatorTypes';
 import { resolvePitch, type GridUnitInput } from './gridPitch';
 
 /**
@@ -39,6 +48,29 @@ import type { ForEachCellOptions, CellInfo } from './generatorTypes';
  * this is the printable floor used for the fit-or-center fallback.
  */
 export const MAGNET_EDGE_CLEARANCE = 1.5;
+
+/**
+ * Whether a cell may carry attachment (magnet / screw) holes at all.
+ *
+ * {@link magnetPositionsForCell} measures its wall from the cell's NOMINAL
+ * edge, but the face a hole actually opens on is the tapered one — narrower by
+ * `INSET_BOT` per side, plus the fit clearance a foot gives up. A full cell has
+ * that slack to spare; a half cell only does from roughly spec pitch upward, so
+ * the tapered face is what decides here rather than the unit count.
+ *
+ * Full cells answer true unconditionally: they carry holes today at every
+ * pitch, and re-gating them would move holes on parts already printed.
+ */
+export function cellHostsAttachmentHoles(
+  cell: CellInfo,
+  holeRadius: number,
+  pitchX: number,
+  pitchY: number
+): boolean {
+  if (cell.widthUnits >= 1 && cell.depthUnits >= 1) return true;
+  const minSpanMm = 2 * (holeRadius + MAGNET_EDGE_CLEARANCE + INSET_BOT) + CLEARANCE;
+  return cell.widthUnits * pitchX >= minSpanMm && cell.depthUnits * pitchY >= minSpanMm;
+}
 
 /** Build magnet-hole cutter solids at the given XY positions (Z handled here). */
 function buildMagnetCutters(
@@ -90,7 +122,7 @@ export function buildMagnetHoles(
     gridW,
     gridD,
     (cell) => {
-      if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+      if (!cellHostsAttachmentHoles(cell, magnetRadius, pitchX, pitchY)) return;
       if (cellFilter !== undefined && !cellFilter(cell)) return;
       // Same shared placement (with the standard wall-distance clamp) as the bin
       // base and lid, so every magnet-bearing surface agrees.

--- a/src/features/generation/worker/generators/baseplateMagnets.ts
+++ b/src/features/generation/worker/generators/baseplateMagnets.ts
@@ -29,6 +29,8 @@ import {
   CLEARANCE,
   INSET_BOT,
   forEachCell,
+  type ForEachCellOptions,
+  type CellInfo,
 } from './generatorTypes';
 import { resolvePitch, type GridUnitInput } from './gridPitch';
 
@@ -39,7 +41,6 @@ import { resolvePitch, type GridUnitInput } from './gridPitch';
  * (rather than being jammed against the edge).
  */
 const STANDARD_WALL_INSET = SIZE / 2 - HOLE_OFFSET;
-import type { ForEachCellOptions, CellInfo } from './generatorTypes';
 
 /**
  * Minimum plastic wall (mm) kept between a magnet hole and a small cell's edge
@@ -52,14 +53,13 @@ export const MAGNET_EDGE_CLEARANCE = 1.5;
 /**
  * Whether a cell may carry attachment (magnet / screw) holes at all.
  *
- * {@link magnetPositionsForCell} measures its wall from the cell's NOMINAL
- * edge, but the face a hole actually opens on is the tapered one — narrower by
- * `INSET_BOT` per side, plus the fit clearance a foot gives up. A full cell has
- * that slack to spare; a half cell only does from roughly spec pitch upward, so
- * the tapered face is what decides here rather than the unit count.
+ * {@link magnetPositionsForCell} measures its wall from the cell's NOMINAL edge,
+ * which the tapered face the hole opens on falls short of by `INSET_BOT` a side.
+ * A full cell absorbs that; a half cell only does from around spec pitch upward.
  *
- * Full cells answer true unconditionally: they carry holes today at every
- * pitch, and re-gating them would move holes on parts already printed.
+ * Full cells bypass the span check rather than passing it: they carry holes at
+ * every pitch today, and re-gating them would move holes on parts already
+ * printed.
  */
 export function cellHostsAttachmentHoles(
   cell: CellInfo,

--- a/src/features/generation/worker/generators/baseplateScrews.test.ts
+++ b/src/features/generation/worker/generators/baseplateScrews.test.ts
@@ -44,10 +44,19 @@ describe('screwFloorCandidates', () => {
     expect(screwFloorCandidates(2, 3, 4, { ...cellOpts })).toHaveLength(24);
   });
 
-  it('skips fractional cells, which carry no magnets to sit on', () => {
-    // A 1.5x1 grid has one full cell and one half cell; only the full one
-    // contributes, so a fractional corner snaps inward to a real position.
-    expect(screwFloorCandidates(1.5, 1, 4, { ...cellOpts })).toHaveLength(4);
+  it('offers the half cell the pads it can hold (#3778)', () => {
+    // A 1.5x1 grid is one full cell (4 corners) plus a 21×42 half cell, which
+    // holds two pads at the standard ±13 spacing on its long axis.
+    expect(screwFloorCandidates(1.5, 1, 4, { ...cellOpts })).toHaveLength(6);
+  });
+
+  it('skips a half cell too small for a pad, snapping a corner inward instead', () => {
+    // At pitch 25 the half cell is 12.5mm — under the taper it cannot hold a
+    // ø8 head, so only the full cell contributes.
+    const opts = { ...cellOpts, gridUnitMm: 25 };
+    expect(screwFloorCandidates(1.5, 1, 4, opts)).toHaveLength(
+      screwFloorCandidates(1, 1, 4, opts).length
+    );
   });
 
   it('honours a cell filter', () => {

--- a/src/features/generation/worker/generators/baseplateScrews.ts
+++ b/src/features/generation/worker/generators/baseplateScrews.ts
@@ -32,7 +32,7 @@ import {
 } from '@/shared/generation/screwHolePlan';
 import { SOCKET_HEIGHT, COPLANAR_MARGIN, forEachCell } from './generatorTypes';
 import type { ForEachCellOptions, CellInfo } from './generatorTypes';
-import { magnetPositionsForCell } from './baseplateMagnets';
+import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
 import { resolvePitch, type GridPitch, type GridUnitInput } from './gridPitch';
 
 export interface ResolvedScrewHole {
@@ -49,9 +49,10 @@ export interface ResolvedScrewHole {
  * magnet, so passing the magnet radius alone would let the placement clamp a
  * position closer to a wall than the cone can actually fit.
  *
- * Fractional cells are skipped, matching `buildMagnetHoles`: the plate carries
- * no magnets there, so there is no pad for a screw either. A fractional corner
- * simply snaps to the nearest full cell instead.
+ * Cell eligibility comes from `cellHostsAttachmentHoles`, matching
+ * `buildMagnetHoles`: a screw sits on the same pad a magnet would, so a cell too
+ * small to hold one holds neither, and a corner over it snaps inward to the
+ * nearest cell that does.
  */
 export function screwFloorCandidates(
   gridW: number,
@@ -67,7 +68,7 @@ export function screwFloorCandidates(
     gridW,
     gridD,
     (cell) => {
-      if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+      if (!cellHostsAttachmentHoles(cell, holeRadius, pitchX, pitchY)) return;
       if (cellFilter !== undefined && !cellFilter(cell)) return;
       out.push(...magnetPositionsForCell(cell, holeRadius, pitchX, pitchY, anchor));
     },

--- a/src/features/generation/worker/generators/floorPatterns.ts
+++ b/src/features/generation/worker/generators/floorPatterns.ts
@@ -29,7 +29,7 @@ import { scoopKeepOuts } from './dividerPatterns';
 import { interiorDividerSegments } from './compartmentBuilder';
 import { resolveCompartmentDividerHeight } from '@/shared/utils/slotMath';
 import { filledSocketCells } from './socketBuilder';
-import { magnetPositionsForCell } from './baseplateMagnets';
+import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
 import { footPinPositions, resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import { DETACHABLE_PIN_HOLE_DIAMETER_MM } from '@/shared/types/bin';
 import { forEachCell } from './cellDecomposition';
@@ -137,7 +137,7 @@ function attachmentKeepOuts(params: BinParams, dim: BinDimensions): WorldKeepOut
     params.width,
     params.depth,
     (cell) => {
-      if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+      if (!cellHostsAttachmentHoles(cell, radius, dim.gridUnitMmX, dim.gridUnitMmY)) return;
       for (const [x, y] of magnetPositionsForCell(
         cell,
         radius,

--- a/src/features/generation/worker/generators/lidMagnets.ts
+++ b/src/features/generation/worker/generators/lidMagnets.ts
@@ -15,7 +15,7 @@ import type { Shape3D, DisposalScope, ValidSolid } from 'brepjs';
 import { LID_COPLANAR_MARGIN, LID_MAGNET_CEILING } from './lidConstants';
 import { forEachCell } from './cellDecomposition';
 import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
-import { isRegionFilled } from '@/shared/utils/cellMask';
+import { isLidCellFilled } from './lidStackGrid';
 import type { LidInputs } from './lidInputs';
 
 export function cutMagnetHoles(scope: DisposalScope, body: Shape3D, inputs: LidInputs): Shape3D {
@@ -30,7 +30,6 @@ export function cutMagnetHoles(scope: DisposalScope, body: Shape3D, inputs: LidI
     magnetDepth,
     magnetAnchor,
     topThickness,
-    cellMask,
   } = inputs;
   const radius = magnetDiameter / 2;
   // Magnet cells sit on the (possibly non-square) socket grid; the ±13mm hole
@@ -51,28 +50,15 @@ export function cutMagnetHoles(scope: DisposalScope, body: Shape3D, inputs: LidI
   // Faster than per-magnet cut() for non-trivial lids — a 10×10 polygon lid
   // has ~400 holes; per-cut would be 400 boolean ops vs one batched op here.
   const cutters: Shape3D[] = [];
-  // forEachCell handles fractional dimensions (half-bin mode): it decomposes
-  // the lid footprint into 1u full cells + a trailing 0.5u half-cell. Both take
-  // holes on the same terms `socketBuilder.buildBaseSocket` uses, so the lid
-  // magnets line up with the bin's base sockets whatever the decomposition.
-  const halfTotalW = (cellsX * gridUnitMm) / 2;
-  const halfTotalD = (cellsY * gridUnitMmY) / 2;
+  // Cell eligibility and mask filtering are both shared — with
+  // `socketBuilder.buildBaseSocket` for the first and the stack-grid pockets for
+  // the second — so a magnet only ever lands where a bin foot can seat on it.
   forEachCell(
     cellsX,
     cellsY,
     (cell) => {
       if (!cellHostsAttachmentHoles(cell, radius, gridUnitMm, gridUnitMmY)) return;
-      if (cellMask) {
-        // The cell's own extent, not a full cell's — a half cell covers one
-        // column of mask sub-cells, and asking about four would read past it.
-        const leftUnit =
-          (cell.centerX + halfTotalW - (cell.widthUnits * gridUnitMm) / 2) / gridUnitMm;
-        const bottomUnit =
-          (cell.centerY + halfTotalD - (cell.depthUnits * gridUnitMmY) / 2) / gridUnitMmY;
-        if (!isRegionFilled(cellMask, leftUnit, bottomUnit, cell.widthUnits, cell.depthUnits)) {
-          return;
-        }
-      }
+      if (!isLidCellFilled(inputs, cell)) return;
       // Shared placement so the lid magnets land at exactly the positions the
       // bin base sockets use (same wall-distance clamp), letting them mate.
       for (const [px, py] of magnetPositionsForCell(

--- a/src/features/generation/worker/generators/lidMagnets.ts
+++ b/src/features/generation/worker/generators/lidMagnets.ts
@@ -5,17 +5,17 @@
  * Each hole is a BLIND pocket on the floor's UPPER face — opens at lid-local
  * Z = 0 (the visible top surface that an upper bin sits on when stacked) and
  * stops short of the floor BOTTOM by `LID_MAGNET_CEILING` so the magnet sits
- * in a sealed cup. Half-bin sub-cells are skipped (Gridfinity doesn't define
- * fractional-cell magnet positions); polygon bins use `isCellFilled` to skip
- * unfilled cells.
+ * in a sealed cup. A half-bin sub-cell keeps whatever of the pattern its size
+ * allows, exactly as the bin base under it does, so the two still mate; polygon
+ * bins use the mask to skip unfilled cells.
  */
 
 import { drawCircle, unwrap, translate, cutAll } from 'brepjs';
 import type { Shape3D, DisposalScope, ValidSolid } from 'brepjs';
 import { LID_COPLANAR_MARGIN, LID_MAGNET_CEILING } from './lidConstants';
 import { forEachCell } from './cellDecomposition';
-import { magnetPositionsForCell } from './baseplateMagnets';
-import { isCellFilled } from './lidStackGrid';
+import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
+import { isRegionFilled } from '@/shared/utils/cellMask';
 import type { LidInputs } from './lidInputs';
 
 export function cutMagnetHoles(scope: DisposalScope, body: Shape3D, inputs: LidInputs): Shape3D {
@@ -52,21 +52,26 @@ export function cutMagnetHoles(scope: DisposalScope, body: Shape3D, inputs: LidI
   // has ~400 holes; per-cut would be 400 boolean ops vs one batched op here.
   const cutters: Shape3D[] = [];
   // forEachCell handles fractional dimensions (half-bin mode): it decomposes
-  // the lid footprint into 1u full cells + a trailing 0.5u half-cell. Skip
-  // half-cells — Gridfinity doesn't define magnet positions for fractional
-  // cells (matches `socketBuilder.buildBaseSocket`), so the lid magnets line
-  // up with the bin's base sockets.
+  // the lid footprint into 1u full cells + a trailing 0.5u half-cell. Both take
+  // holes on the same terms `socketBuilder.buildBaseSocket` uses, so the lid
+  // magnets line up with the bin's base sockets whatever the decomposition.
   const halfTotalW = (cellsX * gridUnitMm) / 2;
   const halfTotalD = (cellsY * gridUnitMmY) / 2;
   forEachCell(
     cellsX,
     cellsY,
     (cell) => {
-      if (cell.widthUnits !== 1 || cell.depthUnits !== 1) return;
+      if (!cellHostsAttachmentHoles(cell, radius, gridUnitMm, gridUnitMmY)) return;
       if (cellMask) {
-        const cellX = Math.round((cell.centerX + halfTotalW - gridUnitMm / 2) / gridUnitMm);
-        const cellY = Math.round((cell.centerY + halfTotalD - gridUnitMmY / 2) / gridUnitMmY);
-        if (!isCellFilled(cellMask, cellX, cellY)) return;
+        // The cell's own extent, not a full cell's — a half cell covers one
+        // column of mask sub-cells, and asking about four would read past it.
+        const leftUnit =
+          (cell.centerX + halfTotalW - (cell.widthUnits * gridUnitMm) / 2) / gridUnitMm;
+        const bottomUnit =
+          (cell.centerY + halfTotalD - (cell.depthUnits * gridUnitMmY) / 2) / gridUnitMmY;
+        if (!isRegionFilled(cellMask, leftUnit, bottomUnit, cell.widthUnits, cell.depthUnits)) {
+          return;
+        }
       }
       // Shared placement so the lid magnets land at exactly the positions the
       // bin base sockets use (same wall-distance clamp), letting them mate.

--- a/src/features/generation/worker/generators/lidStackGrid.test.ts
+++ b/src/features/generation/worker/generators/lidStackGrid.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { isLidCellFilled, type LidCellGrid } from './lidStackGrid';
+import { buildFullMask, type CellMask } from '@/shared/utils/cellMask';
+import type { CellInfo } from './cellDecomposition';
+
+const GRID = 42;
+
+function grid(cellsX: number, cellsY: number, cellMask?: CellMask): LidCellGrid {
+  return { cellsX, cellsY, gridUnitMm: GRID, gridUnitMmY: GRID, cellMask };
+}
+
+/** Cell at `leftUnit`/`bottomUnit` of a `cellsX × cellsY` footprint, origin-centred. */
+function cellAt(
+  leftUnit: number,
+  bottomUnit: number,
+  widthUnits: number,
+  depthUnits: number,
+  cellsX: number,
+  cellsY: number
+): CellInfo {
+  return {
+    widthUnits,
+    depthUnits,
+    centerX: (leftUnit + widthUnits / 2) * GRID - (cellsX * GRID) / 2,
+    centerY: (bottomUnit + depthUnits / 2) * GRID - (cellsY * GRID) / 2,
+  };
+}
+
+function clear(mask: CellMask, col: number, row: number): CellMask {
+  const cells = [...mask.cells];
+  cells[row * mask.cols + col] = 0;
+  return { ...mask, cells };
+}
+
+describe('isLidCellFilled', () => {
+  it('accepts every cell when the lid carries no mask', () => {
+    expect(isLidCellFilled(grid(1.5, 1), cellAt(1, 0, 0.5, 1, 1.5, 1))).toBe(true);
+  });
+
+  it('accepts a filled trailing half cell (#3778)', () => {
+    // Regression: a whole-cell query rounded this half cell to column index 1,
+    // whose second mask column is past the 3-column mask — so a fully filled
+    // fractional lid reported its own edge cell as unfilled and the pocket pass
+    // left it solid.
+    const mask = buildFullMask(1.5, 1);
+    expect(isLidCellFilled(grid(1.5, 1, mask), cellAt(1, 0, 0.5, 1, 1.5, 1))).toBe(true);
+  });
+
+  it('rejects a half cell the mask does not cover', () => {
+    const mask = clear(buildFullMask(1.5, 1), 2, 0);
+    expect(isLidCellFilled(grid(1.5, 1, mask), cellAt(1, 0, 0.5, 1, 1.5, 1))).toBe(false);
+  });
+
+  it('accepts a fully covered whole cell', () => {
+    const mask = buildFullMask(2, 2);
+    expect(isLidCellFilled(grid(2, 2, mask), cellAt(0, 0, 1, 1, 2, 2))).toBe(true);
+  });
+
+  it('rejects a whole cell with any sub-cell clear, so nothing cuts the boundary', () => {
+    const mask = clear(buildFullMask(2, 2), 1, 1);
+    expect(isLidCellFilled(grid(2, 2, mask), cellAt(0, 0, 1, 1, 2, 2))).toBe(false);
+    expect(isLidCellFilled(grid(2, 2, mask), cellAt(1, 1, 1, 1, 2, 2))).toBe(true);
+  });
+});

--- a/src/features/generation/worker/generators/lidStackGrid.ts
+++ b/src/features/generation/worker/generators/lidStackGrid.ts
@@ -11,9 +11,6 @@
  * `stackLipOnly` swaps the per-cell pockets for one footprint-wide
  * pocket, so only the perimeter ring survives — the same lip an upper bin
  * registers on, without the interior dividers.
- *
- * `isCellFilled` is also exported because the magnet-hole pass (a separate
- * sibling) needs the same cell-fill predicate for polygon bins.
  */
 
 import { drawRoundedRectangle, unwrap, translate, cutAll } from 'brepjs';
@@ -113,10 +110,10 @@ function buildStackLipCutter(inputs: LidInputs): Shape3D {
 
 /**
  * Each whole grid cell maps to a 2×2 mask region. Treat the whole cell as
- * filled only when ALL four mask cells are set; otherwise skip pockets/
- * magnets to avoid a hole that would clip the polygon boundary.
+ * filled only when ALL four mask cells are set; otherwise skip pockets to
+ * avoid one that would clip the polygon boundary.
  */
-export function isCellFilled(mask: CellMask, cellX: number, cellY: number): boolean {
+function isCellFilled(mask: CellMask, cellX: number, cellY: number): boolean {
   const baseCol = cellX * 2;
   const baseRow = cellY * 2;
   for (let dr = 0; dr < 2; dr++) {

--- a/src/features/generation/worker/generators/lidStackGrid.ts
+++ b/src/features/generation/worker/generators/lidStackGrid.ts
@@ -18,8 +18,8 @@ import type { Shape3D, DisposalScope, Drawing, Sketch, ValidSolid } from 'brepjs
 import { pocketCornerRadius } from './generatorConstants';
 import { SOCKET_HEIGHT, SOCKET_BIG_TAPER, SOCKET_TAPER_WIDTH, CLEARANCE } from './generatorTypes';
 import { LID_COPLANAR_MARGIN, LID_MIN_CORNER_RADIUS } from './lidConstants';
-import { type CellMask } from '@/shared/utils/cellMask';
-import { forEachCell } from './cellDecomposition';
+import { isRegionFilled } from '@/shared/utils/cellMask';
+import { forEachCell, type CellInfo } from './cellDecomposition';
 import { buildMaskDrawingAtInset } from './maskPolygon';
 import { buildOutlineDrawing } from './lidProfile';
 import type { LidInputs } from './lidInputs';
@@ -108,23 +108,33 @@ function buildStackLipCutter(inputs: LidInputs): Shape3D {
   });
 }
 
+/** The slice of {@link LidInputs} that locates a cell against the mask. */
+export type LidCellGrid = Pick<
+  LidInputs,
+  'cellMask' | 'cellsX' | 'cellsY' | 'gridUnitMm' | 'gridUnitMmY'
+>;
+
 /**
- * Each whole grid cell maps to a 2×2 mask region. Treat the whole cell as
- * filled only when ALL four mask cells are set; otherwise skip pockets to
- * avoid one that would clip the polygon boundary.
+ * Whether the mask fills a cell's own footprint — false for a partially covered
+ * cell, so nothing is cut across the polygon boundary.
+ *
+ * Measured over the cell's OWN extent rather than the 1u cell containing it.
+ * A trailing 0.5u cell covers one column of mask sub-cells, and a whole-cell
+ * query reaches past the mask's last column, which answers "unfilled" for every
+ * fractional edge cell on a masked lid.
+ *
+ * Shared by the pocket pass here and the magnet pass in `lidMagnets`: both cut
+ * into the same face, and a cell one accepts while the other refuses puts a
+ * magnet where no foot can seat.
  */
-function isCellFilled(mask: CellMask, cellX: number, cellY: number): boolean {
-  const baseCol = cellX * 2;
-  const baseRow = cellY * 2;
-  for (let dr = 0; dr < 2; dr++) {
-    for (let dc = 0; dc < 2; dc++) {
-      const c = baseCol + dc;
-      const r = baseRow + dr;
-      if (c < 0 || c >= mask.cols || r < 0 || r >= mask.rows) return false;
-      if (mask.cells[r * mask.cols + c] !== 1) return false;
-    }
-  }
-  return true;
+export function isLidCellFilled(grid: LidCellGrid, cell: CellInfo): boolean {
+  const { cellMask, cellsX, cellsY, gridUnitMm, gridUnitMmY } = grid;
+  if (!cellMask) return true;
+  const leftUnit =
+    (cell.centerX + (cellsX * gridUnitMm) / 2 - (cell.widthUnits * gridUnitMm) / 2) / gridUnitMm;
+  const bottomUnit =
+    (cell.centerY + (cellsY * gridUnitMmY) / 2 - (cell.depthUnits * gridUnitMmY) / 2) / gridUnitMmY;
+  return isRegionFilled(cellMask, leftUnit, bottomUnit, cell.widthUnits, cell.depthUnits);
 }
 
 export function buildStackGrid(scope: DisposalScope, inputs: LidInputs): Shape3D {
@@ -150,25 +160,26 @@ export function buildStackGrid(scope: DisposalScope, inputs: LidInputs): Shape3D
   if (inputs.stackLipOnly) {
     pockets.push(scope.register(buildStackLipCutter(inputs)));
   } else {
-    const halfTotalW = (cellsX * gridUnitMm) / 2;
-    const halfTotalD = (cellsY * gridUnitMmY) / 2;
     forEachCell(
       cellsX,
       cellsY,
       (cell) => {
-        const cellW = cell.widthUnits * gridUnitMm;
-        const cellD = cell.depthUnits * gridUnitMmY;
-        if (inputs.cellMask) {
-          const cellX = Math.round((cell.centerX + halfTotalW - gridUnitMm / 2) / gridUnitMm);
-          const cellY = Math.round((cell.centerY + halfTotalD - gridUnitMmY / 2) / gridUnitMmY);
-          if (!isCellFilled(inputs.cellMask, cellX, cellY)) return;
-        }
-        const pocket = buildLidStackPocketCutter(cellW, cellD);
+        if (!isLidCellFilled(inputs, cell)) return;
+        const pocket = buildLidStackPocketCutter(
+          cell.widthUnits * gridUnitMm,
+          cell.depthUnits * gridUnitMmY
+        );
         const positioned = scope.register(translate(pocket, [cell.centerX, cell.centerY, 0]));
         pocket.delete();
         pockets.push(positioned);
       },
-      { gridUnitMm: pitch }
+      // The half cell must land on the side the stacked bin's half foot does,
+      // or the foot meets slab and the pocket meets air.
+      {
+        gridUnitMm: pitch,
+        fractionalEdgeX: inputs.fractionalEdgeX,
+        fractionalEdgeY: inputs.fractionalEdgeY,
+      }
     );
   }
 

--- a/src/features/generation/worker/generators/lightweightBaseBuilder.ts
+++ b/src/features/generation/worker/generators/lightweightBaseBuilder.ts
@@ -50,7 +50,7 @@ import {
 import type { Shape3D, ValidSolid, DisposalScope, Drawing } from 'brepjs';
 import { SIZE, CLEARANCE, SOCKET_HEIGHT, MAGNET_FLOOR } from './generatorConstants';
 import { resolvePitch, type GridUnitInput } from './gridPitch';
-import { magnetPositionsForCell } from './baseplateMagnets';
+import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
 import type { MagnetAnchor } from '@/core/types';
 import { DEFAULT_MAGNET_ANCHOR } from '@/core/types';
 import { sketch } from './meshUtils';
@@ -346,7 +346,7 @@ export function buildLightweightBase(
         gridUnitMm,
         DEFAULT_SOCKET_CELL_PLAN,
         (cell) => {
-          if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+          if (!cellHostsAttachmentHoles(cell, holeRadius, unitX, unitY)) return;
           if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
           // Fit-or-center magnet positions so a non-square/small foot's pads and
           // drills stay inside the foot instead of breaching its side.

--- a/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.test.ts
@@ -6,10 +6,11 @@ beforeAll(async () => {
   await initBrepjs();
 }, 30_000);
 
-const cellOpts = () => ({
+const cellOpts = (overrides: { gridUnitMm?: number } = {}) => ({
   gridUnitMm: 42,
   fractionalEdgeX: 'end' as const,
   fractionalEdgeY: 'end' as const,
+  ...overrides,
 });
 
 describe('buildLightweightFloorCutters', () => {
@@ -25,11 +26,22 @@ describe('buildLightweightFloorCutters', () => {
     expect(result).toHaveLength(4);
   });
 
-  it('includes fractional cells with full floor cutout', async () => {
+  it('leaves a magnet-bearing half cell solid rather than stranding its magnet (#3778)', async () => {
     const { buildLightweightFloorCutters } = await import('./lightweightFloorCutter');
-    // 1.5×1.5 = 1 full cell (cross cutout) + fractional cells (full rectangular cutout)
+    // 1.5×1.5 at spec pitch: the full cell gets its cross; the three half cells
+    // now carry magnets, and only the symmetric 4-corner layout maps to a cross,
+    // so they stay solid instead of having their floors cut away.
     const result = buildLightweightFloorCutters(1.5, 1.5, 3.25, 2, cellOpts());
-    expect(result.length).toBeGreaterThan(1);
+    expect(result).toHaveLength(1);
+  });
+
+  it('still cuts the whole floor of a half cell too small for a magnet', async () => {
+    const { buildLightweightFloorCutters } = await import('./lightweightFloorCutter');
+    // At pitch 25 the 12.5mm half cells hold no magnet, so their floor material
+    // serves nothing — and the 25mm full cell takes a lone centered magnet,
+    // which is not a cross. Three fractional cutters, no cross.
+    const result = buildLightweightFloorCutters(1.5, 1.5, 3.25, 2, cellOpts({ gridUnitMm: 25 }));
+    expect(result).toHaveLength(3);
   });
 
   it('each cutter is a valid Shape3D with geometry', async () => {

--- a/src/features/generation/worker/generators/lightweightFloorCutter.ts
+++ b/src/features/generation/worker/generators/lightweightFloorCutter.ts
@@ -14,7 +14,7 @@ import { SOCKET_HEIGHT, MAGNET_FLOOR, COPLANAR_MARGIN, INSET_BOT } from './gener
 import { forEachCell } from './cellDecomposition';
 import type { ForEachCellOptions, CellInfo } from './cellDecomposition';
 import { resolvePitch, type GridUnitInput } from './gridPitch';
-import { magnetPositionsForCell } from './baseplateMagnets';
+import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
 import { sketch } from './meshUtils';
 import { magnetOuterWallMarginForNozzle, magnetPadMarginForNozzle } from '@/shared/printSettings';
 import type { MagnetAnchor } from '@/core/types';
@@ -117,9 +117,11 @@ export function buildLightweightFloorCutters(
         const cellW_mm = cell.widthUnits * unitX;
         const cellD_mm = cell.depthUnits * unitY;
 
-        // Fractional cells (half-unit) have no magnets — cut through their
-        // entire floor since the solid material serves no purpose.
-        if (cell.widthUnits < 1 || cell.depthUnits < 1) {
+        // A cell too small for a magnet has nothing to hold that floor up for,
+        // so cut through all of it. A half cell that DOES take a magnet falls
+        // through to the pad logic below, which leaves it solid rather than
+        // stranding the magnet it just placed.
+        if (!cellHostsAttachmentHoles(cell, magnetRadius, unitX, unitY)) {
           const fhw = cellW_mm / 2 - INSET_BOT;
           const fhd = cellD_mm / 2 - INSET_BOT;
           if (fhw <= 0 || fhd <= 0) return;

--- a/src/features/generation/worker/generators/magnetAlignment.verification.test.ts
+++ b/src/features/generation/worker/generators/magnetAlignment.verification.test.ts
@@ -18,6 +18,8 @@ import type { MeshData } from '@/features/generation/bridge/types';
 import { initTestKernel } from '@/test/initTestKernel';
 import { HOLE_OFFSET, SIZE } from './generatorTypes';
 
+const MAGNET_RADIUS = DEFAULT_BIN_PARAMS.base.magnetDiameter / 2;
+
 type GenerateFn = (
   params: BinParams,
   onProgress?: (stage: string, progress: number) => void,
@@ -32,6 +34,31 @@ beforeAll(async () => {
   generateBin = mod.generateBin;
 }, 30000);
 
+/** Vertices on the mesh's bottom Z layer, as XY pairs. */
+function getBottomVerts(mesh: MeshData): Array<[number, number]> {
+  const verts: Array<[number, number, number]> = [];
+  for (let i = 0; i < mesh.vertices.length; i += 3) {
+    verts.push([mesh.vertices[i], mesh.vertices[i + 1], mesh.vertices[i + 2]]);
+  }
+
+  const minZ = Math.min(...verts.map(([, , z]) => z));
+  return verts.filter(([, , z]) => z - minZ < 0.1).map(([x, y]) => [x, y]);
+}
+
+/**
+ * Whether a magnet hole of `radius` opens at (cx, cy) on the bottom face.
+ *
+ * Reads the hole's rim rather than a cluster average: a hole centred ON a
+ * cluster-grid node has no vertices near that node at all — they all sit a full
+ * radius away — so clustering answers "no hole" for the centred case.
+ */
+function hasHoleAt(mesh: MeshData, cx: number, cy: number, radius: number): boolean {
+  const onRim = getBottomVerts(mesh).filter(
+    ([x, y]) => Math.abs(Math.hypot(x - cx, y - cy) - radius) < 0.3
+  );
+  return onRim.length >= 4;
+}
+
 /**
  * Extract vertex XY clusters at the minimum Z level of the mesh.
  * The bottom of the socket (Z=0 in the output mesh) has both corner features
@@ -39,13 +66,7 @@ beforeAll(async () => {
  * the hole center at ±HOLE_OFFSET from cell center.
  */
 function getBottomXYClusters(mesh: MeshData): Array<{ x: number; y: number; count: number }> {
-  const verts: Array<[number, number, number]> = [];
-  for (let i = 0; i < mesh.vertices.length; i += 3) {
-    verts.push([mesh.vertices[i], mesh.vertices[i + 1], mesh.vertices[i + 2]]);
-  }
-
-  const minZ = Math.min(...verts.map(([, , z]) => z));
-  const bottomVerts = verts.filter(([, , z]) => z - minZ < 0.1);
+  const bottomVerts = getBottomVerts(mesh);
 
   // Cluster by XY (3mm grid)
   const grid = new Map<string, { sumX: number; sumY: number; count: number }>();
@@ -128,6 +149,39 @@ describe('magnet hole alignment verification', () => {
     // Use tight tolerance (1.5mm) — 10.5 and 13 are 2.5mm apart
     expect(hasClusterNear(clusters, -WRONG_OFFSET, -WRONG_OFFSET, 1.5)).toBe(false);
     expect(hasClusterNear(clusters, WRONG_OFFSET, WRONG_OFFSET, 1.5)).toBe(false);
+  });
+
+  it('0.5×0.5 half bin gets a centered magnet hole (#3778)', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 0.5,
+      depth: 0.5,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
+    };
+
+    // The lone half foot is too narrow for the ±13 corners, so the hole sits at
+    // the foot centre — where a matching half pocket puts its own.
+    expect(hasHoleAt(generateBin(params), 0, 0, MAGNET_RADIUS)).toBe(true);
+
+    const flat: BinParams = { ...params, base: { ...params.base, style: 'flat' } };
+    expect(hasHoleAt(generateBin(flat), 0, 0, MAGNET_RADIUS)).toBe(false);
+  });
+
+  it('1.5×1 bin magnetizes its half foot on the standard Y spacing (#3778)', () => {
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 1.5,
+      depth: 1,
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet' },
+    };
+
+    const clusters = getBottomXYClusters(generateBin(params));
+    // Cells decompose to [1, 0.5]: full foot centred at -10.5, half foot at +21.
+    const halfFootX = SIZE * 0.5;
+    expect(hasClusterNear(clusters, halfFootX, -HOLE_OFFSET)).toBe(true);
+    expect(hasClusterNear(clusters, halfFootX, HOLE_OFFSET)).toBe(true);
+    // The full foot keeps its own 4 corners.
+    expect(hasClusterNear(clusters, -SIZE / 4 - HOLE_OFFSET, -HOLE_OFFSET)).toBe(true);
   });
 
   it('halfSockets does not change magnet hole positions', () => {

--- a/src/features/generation/worker/generators/magnetAlignment.verification.test.ts
+++ b/src/features/generation/worker/generators/magnetAlignment.verification.test.ts
@@ -36,13 +36,17 @@ beforeAll(async () => {
 
 /** Vertices on the mesh's bottom Z layer, as XY pairs. */
 function getBottomVerts(mesh: MeshData): Array<[number, number]> {
-  const verts: Array<[number, number, number]> = [];
-  for (let i = 0; i < mesh.vertices.length; i += 3) {
-    verts.push([mesh.vertices[i], mesh.vertices[i + 1], mesh.vertices[i + 2]]);
+  const { vertices } = mesh;
+  let minZ = Infinity;
+  for (let i = 2; i < vertices.length; i += 3) {
+    if (vertices[i] < minZ) minZ = vertices[i];
   }
 
-  const minZ = Math.min(...verts.map(([, , z]) => z));
-  return verts.filter(([, , z]) => z - minZ < 0.1).map(([x, y]) => [x, y]);
+  const bottom: Array<[number, number]> = [];
+  for (let i = 0; i < vertices.length; i += 3) {
+    if (vertices[i + 2] - minZ < 0.1) bottom.push([vertices[i], vertices[i + 1]]);
+  }
+  return bottom;
 }
 
 /**

--- a/src/features/generation/worker/generators/socketBuilder.ts
+++ b/src/features/generation/worker/generators/socketBuilder.ts
@@ -46,7 +46,7 @@ import {
 } from './shapeCache';
 import { buildCacheKey, quantize } from './cacheKeyUtils';
 import { resolvePitch, type GridUnitInput } from './gridPitch';
-import { magnetPositionsForCell } from './baseplateMagnets';
+import { cellHostsAttachmentHoles, magnetPositionsForCell } from './baseplateMagnets';
 import type { MagnetAnchor } from '@/core/types';
 import { DEFAULT_MAGNET_ANCHOR } from '@/core/types';
 import {
@@ -443,8 +443,11 @@ function batchFuseAndCut(cellSockets: Shape3D[], holeTools: Shape3D[]): Shape3D 
  * Magnet/screw holes are placed at the standard 4-corner positions (±13mm from
  * cell center) using the original cell decomposition, NOT the half-socket sub-cells.
  * This ensures magnets align with the baseplate regardless of socket subdivision.
- * Sub-unit cells (from fractional grid dimensions like 1.5×1) are skipped since
- * the Gridfinity spec doesn't define magnet positions for fractional cells.
+ * A half foot keeps the part of that pattern it can hold — two holes on its long
+ * axis, or one centered — which is what a matching half pocket in this tool's
+ * baseplate places too. Against a third-party full-cell plate the centered hole
+ * lands ~2.5mm off that plate's lattice magnet: partial engagement, where the
+ * foot used to offer none.
  *
  * @param forExport If true, uses full 5-section socket profile. Preview uses 3-section.
  */
@@ -602,7 +605,7 @@ export function buildBaseSocket(
         gridW,
         gridD,
         (cell) => {
-          if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
+          if (!cellHostsAttachmentHoles(cell, holeRadius, unitX, unitY)) return;
           if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
           // Standard ±13mm 4-corner pattern on a normal foot; a non-square/small
           // foot (e.g. a 25mm-wide cell) gets the corners that fit, else a single

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -43,6 +43,9 @@ const META_STORE = 'binMeshMeta';
  * one kernel's output, bump that kernel's {@link KERNEL_MESH_REVISION} entry
  * instead, so the other kernel's users keep their warm cache.
  *
+ * `v13`: a half foot now carries magnet/screw holes, so any bin, lid, or plate
+ * with a fractional dimension and attachment holes enabled generates different
+ * bytes for params it already has an entry under.
  * `v12`: `MeshData` gained `knifeRestMesh`, which entries written before it
  * cannot carry — a knife block would pre-paint without its companion rest
  * until the LRU happened to evict the entry.
@@ -64,7 +67,7 @@ const META_STORE = 'binMeshMeta';
  * without regenerating, so without this bump a linked design in the layout
  * planner would render its pre-fix bin until the entry was evicted.
  */
-const MESH_CACHE_VERSION = 'v12';
+const MESH_CACHE_VERSION = 'v13';
 
 /**
  * Per-kernel revision, bumped when only THAT kernel's output moves for


### PR DESCRIPTION
Closes #3778.

A half foot got no attachment holes at all. A 0.5×0.5 bin came out with none, and a 1.5×1 bin got them only on its full foot, with no UI hint that the magnet toggle had stopped doing anything.

## Cause

Seven independent cell loops each carried the same guard:

```ts
if (cell.widthUnits < 1 || cell.depthUnits < 1) return;
```

It cited the Gridfinity spec not defining fractional-cell magnet positions, but the job it was actually doing was manufacturability, and those diverge: what matters is how much plastic survives around the hole, which depends on pitch and hole radius rather than the unit count. `magnetPositionsForCell`, the shared placement authority the guard stood in front of, already handles a small cell — two holes on its long axis, one centered, or none when nothing fits.

## Change

One predicate replaces all seven:

```ts
export function cellHostsAttachmentHoles(cell, holeRadius, pitchX, pitchY): boolean {
  if (cell.widthUnits >= 1 && cell.depthUnits >= 1) return true;
  const minSpanMm = 2 * (holeRadius + MAGNET_EDGE_CLEARANCE + INSET_BOT) + CLEARANCE;
  return cell.widthUnits * pitchX >= minSpanMm && cell.depthUnits * pitchY >= minSpanMm;
}
```

It asks what the guard meant to ask: does the tapered face the hole opens on still hold a printable wall? A 21mm foot at spec pitch keeps 4.3mm, more than the 1.8mm a standard 42mm cell keeps at its own bottom. A 12.5mm foot on a custom 25mm grid keeps 0.35mm, and is still skipped.

Full cells answer true unconditionally. That asymmetry is deliberate: they carry holes today at every pitch, so the change stays purely additive and no existing design can lose a hole.

Bin base, lightweight base, lid, baseplate, baseplate screws, floor-pattern keep-outs and the draft mesh all move together, so a half foot and the half pocket under it place holes in the same spot.

## Two things that are not the guard swap

- **Draft mesh double-drill.** `baseplateDirectMesh` packs nominal cells and over-tile frame tiles into one array and used `widthUnits < 1` to tell them apart, since frame tiles are sub-unit. Loosening the guard would have magnetized every frame tile twice — once in the nominal pass, once in the over-tile pass. Now split by index.
- **Stranded magnets.** `lightweightFloorCutter` removed a half cell's entire floor on the grounds that it held no magnet. That branch is now gated on the same predicate, so a half cell that takes a magnet keeps its floor.

## Placement choice

A half foot's centered hole matches what this tool's own baseplate puts in a matching half pocket. Against a third-party full-cell plate it lands ~2.5mm off that plate's lattice magnet — partial engagement, where the foot previously offered none. Centered is also the only rotation-invariant choice for a lone half cell, which has no adjacent full cell to take its lattice reference from.

`MESH_CACHE_VERSION` bumped to `v13`: identical params now generate different bytes for any fractional-dimension part with attachment holes on.

## Testing

- `cellHostsAttachmentHoles` unit tests: admits/rejects across pitch and hole radius, full cells unconditional.
- Real-WASM geometry: 0.5×0.5 bin gets a centered hole (with a flat-base negative control), 1.5×1 magnetizes its half foot at the standard ±13 Y spacing.
- Updated the two tests that asserted the old behavior, each keeping a case that still exercises the skip at a pitch where the half cell genuinely cannot hold a hole.
- Full local suite green: unit (11998), dom (9709), generators (3161). Seven generator scenarios timed out on the first pass under CPU contention and pass idle; all are integer-dimension or magnet-free scenarios this change cannot reach.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

