### PR TITLE
test(generation): let scenario timeouts inherit the generators project bound

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/scenarioTypes.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/scenarioTypes.ts
@@ -40,7 +40,13 @@ export interface ScenarioCase {
   params: Partial<BinParams>;
   forExport?: boolean;
   assert: AssertionMode;
-  timeout: number;
+  /**
+   * Passed straight to `it()`, where an explicit value overrides the
+   * generators project `testTimeout` in BOTH directions — a value below it is
+   * a cap, not a raise. Annotate only scenarios that need more than the
+   * project bound; leave the rest unset so the project bound applies.
+   */
+  timeout?: number;
   /** Runs after standard assertions with the generated mesh. */
   customAssert?: (result: MeshData, params: BinParams) => void;
   /** Generate a second mesh and compare. */
@@ -52,19 +58,16 @@ export interface ScenarioCase {
 /**
  * Create a scenario case with sensible defaults.
  * - `assert` defaults to `'snapshot'`
- * - `timeout` defaults to `30000`
  */
 export function defineScenario(
   category: string,
   name: string,
-  config: Omit<ScenarioCase, 'name' | 'category' | 'assert' | 'timeout'> &
-    Partial<Pick<ScenarioCase, 'assert' | 'timeout'>>
+  config: Omit<ScenarioCase, 'name' | 'category' | 'assert'> & Partial<Pick<ScenarioCase, 'assert'>>
 ): ScenarioCase {
   return {
     name,
     category,
     assert: 'snapshot',
-    timeout: 30_000,
     ...config,
   };
 }

--- a/src/features/generation/worker/generators/scenarios/baseStyles.ts
+++ b/src/features/generation/worker/generators/scenarios/baseStyles.ts
@@ -42,7 +42,6 @@ export const baseStyles: ScenarioCase[] = [
         depth: 4,
         base: { ...DEFAULT_BIN_PARAMS.base, style },
       },
-      timeout: 60_000,
       customAssert: (result, params) => {
         assertBoundingBoxMatchesParams(result, params, `4x4-${label}`);
       },

--- a/src/features/generation/worker/generators/scenarios/binStyles.ts
+++ b/src/features/generation/worker/generators/scenarios/binStyles.ts
@@ -39,7 +39,6 @@ export const binStyles: ScenarioCase[] = [
         style,
         base: { ...DEFAULT_BIN_PARAMS.base, ...base },
       },
-      timeout: 60_000,
       customAssert: (result, params) => {
         assertBoundingBoxMatchesParams(result, params, `4x4-${label}`);
       },

--- a/src/features/generation/worker/generators/scenarios/combinedFeatures.ts
+++ b/src/features/generation/worker/generators/scenarios/combinedFeatures.ts
@@ -15,7 +15,6 @@ export const combinedFeatures: ScenarioCase[] = [
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
   defineScenario('combined features', '4\u00d74 magnet + label bracket + half-sockets', {
     params: {
@@ -29,7 +28,6 @@ export const combinedFeatures: ScenarioCase[] = [
       },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
     },
-    timeout: 60_000,
   }),
   defineScenario('combined features', '1.5\u00d72 flat + slotted + 3\u00d72 merged compartments', {
     params: {
@@ -39,7 +37,6 @@ export const combinedFeatures: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
       compartments: { cols: 3, rows: 2, cells: [0, 0, 1, 2, 3, 4], thickness: 0.8 },
     },
-    timeout: 60_000,
   }),
   defineScenario('combined features', '2\u00d72 compartments + insert (overlap interaction)', {
     params: {
@@ -69,7 +66,6 @@ export const combinedFeatures: ScenarioCase[] = [
         right: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('combined features', '2\u00d72 honeycomb walls + scoop cutout (front only)', {
     assert: 'structural',
@@ -89,7 +85,6 @@ export const combinedFeatures: ScenarioCase[] = [
         interior: DISABLED_WALL_CUTOUT,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('combined features', '2\u00d72 honeycomb walls + funnel cutout (left-aligned)', {
     assert: 'structural',
@@ -109,7 +104,6 @@ export const combinedFeatures: ScenarioCase[] = [
         interior: DISABLED_WALL_CUTOUT,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('combined features', '2\u00d72 honeycomb walls + handle holes', {
     assert: 'structural',
@@ -125,7 +119,6 @@ export const combinedFeatures: ScenarioCase[] = [
         left: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('combined features', '2\u00d72 honeycomb walls + handles + wall cutouts', {
     assert: 'structural',
@@ -146,7 +139,6 @@ export const combinedFeatures: ScenarioCase[] = [
         right: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('combined features', '2\u00d72 honeycomb walls + handles + label (back skip)', {
     assert: 'structural',
@@ -163,6 +155,5 @@ export const combinedFeatures: ScenarioCase[] = [
         back: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/compartments.ts
+++ b/src/features/generation/worker/generators/scenarios/compartments.ts
@@ -20,6 +20,5 @@ export const compartments: ScenarioCase[] = [
         thickness: 0.8,
       },
     },
-    timeout: 60_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/customShape.ts
+++ b/src/features/generation/worker/generators/scenarios/customShape.ts
@@ -310,7 +310,6 @@ export const customShapes: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('custom-shape', '3×3 T with lip + scoop (concave perimeter + scoop)', {
@@ -322,7 +321,6 @@ export const customShapes: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('custom-shape', '3×3 U with handles + label (multi-feature polygon)', {
@@ -339,7 +337,6 @@ export const customShapes: ScenarioCase[] = [
       },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('custom-shape', '3×3 O-shape + magnet base + lip', {
@@ -354,7 +351,6 @@ export const customShapes: ScenarioCase[] = [
         stackingLip: true,
       },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('custom-shape', '3×3 O-shape + half sockets', {
@@ -365,7 +361,6 @@ export const customShapes: ScenarioCase[] = [
       cellMask: O_SHAPE_MASK,
       base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('custom-shape', '3×3 L tall (10u) + lip (z-extrusion stability)', {
@@ -377,7 +372,6 @@ export const customShapes: ScenarioCase[] = [
       cellMask: L_SHAPE_MASK,
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('custom-shape', '4×3 asymmetric L (non-square bounding box)', {
@@ -396,7 +390,6 @@ export const customShapes: ScenarioCase[] = [
       ]),
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('custom-shape', '3×3 L + slotted bin (polygon + slots)', {
@@ -408,6 +401,5 @@ export const customShapes: ScenarioCase[] = [
       style: 'slotted',
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     },
-    timeout: 60_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/cutoutLabelSockets.ts
+++ b/src/features/generation/worker/generators/scenarios/cutoutLabelSockets.ts
@@ -178,7 +178,6 @@ export const cutoutLabelSockets: ScenarioCase[] = [
     params: board(),
     customAssert: (result, params) =>
       assertCutoutSocket(result, params, { label: 'board socket', plateWidthU: 2 }),
-    timeout: 60_000,
   }),
 
   // A 90° socket is the whole reason a side-anchored label is usable: the gap
@@ -203,7 +202,6 @@ export const cutoutLabelSockets: ScenarioCase[] = [
     }),
     customAssert: (result, params) =>
       assertCutoutSocket(result, params, { label: '90° board socket', plateWidthU: 1 }),
-    timeout: 60_000,
   }),
 
   // Stated as a DELTA against the same board without a lip: the sink is
@@ -233,7 +231,6 @@ export const cutoutLabelSockets: ScenarioCase[] = [
         expect(pocketDelta).toBeCloseTo(LABEL_SOCKET_STACK_RELIEF_MM, 1);
       },
     },
-    timeout: 90_000,
   }),
 
   // The engraved path must be untouched by any of this: a design that never
@@ -254,6 +251,5 @@ export const cutoutLabelSockets: ScenarioCase[] = [
         }),
       ],
     }),
-    timeout: 60_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/dividerPatterns.ts
+++ b/src/features/generation/worker/generators/scenarios/dividerPatterns.ts
@@ -73,7 +73,6 @@ export const dividerPatterns: ScenarioCase[] = [
       },
       assert: assertDividersPerforated,
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', '2×2 honeycomb dividers', {
@@ -85,7 +84,6 @@ export const dividerPatterns: ScenarioCase[] = [
       compartments: TWO_BY_TWO,
       walls: ALL_SIDES_OFF,
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', 'round pattern on a single column divider', {
@@ -97,7 +95,6 @@ export const dividerPatterns: ScenarioCase[] = [
       compartments: { cols: 3, rows: 1, cells: [0, 1, 2], thickness: 1.2 },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 90_000,
   }),
 
   // ── Feature keep-outs — every intruder that lands on a divider ────────────
@@ -112,7 +109,6 @@ export const dividerPatterns: ScenarioCase[] = [
       scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', 'dividers + interior cutouts', {
@@ -128,7 +124,6 @@ export const dividerPatterns: ScenarioCase[] = [
         interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', 'dividers + label tabs keep the shelf anchorage solid', {
@@ -141,7 +136,6 @@ export const dividerPatterns: ScenarioCase[] = [
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', 'dividers + outer cutouts + handles', {
@@ -157,7 +151,6 @@ export const dividerPatterns: ScenarioCase[] = [
         front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 60, depth: 40 },
       },
     },
-    timeout: 90_000,
   }),
 
   // ── Divider geometry variants ────────────────────────────────────────────
@@ -174,7 +167,6 @@ export const dividerPatterns: ScenarioCase[] = [
       compartments: { ...TWO_BY_TWO, dividerHeight: 20 },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', 'divider too short for a band stays solid', {
@@ -202,7 +194,6 @@ export const dividerPatterns: ScenarioCase[] = [
         );
       },
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', 'tilted dividers carry the pattern in-plane', {
@@ -220,7 +211,6 @@ export const dividerPatterns: ScenarioCase[] = [
       },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', 'half-grid footprint with patterned dividers', {
@@ -232,7 +222,6 @@ export const dividerPatterns: ScenarioCase[] = [
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 90_000,
   }),
 
   defineScenario('divider patterns', 'overhang shifts the interior with the dividers', {
@@ -245,7 +234,6 @@ export const dividerPatterns: ScenarioCase[] = [
       overhang: { enabled: true, left: 4, right: 0, front: 2, back: 0, feet: false },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 90_000,
   }),
 
   // ── Kumiko lattice panels on dividers ────────────────────────────────────
@@ -312,6 +300,5 @@ export const dividerPatterns: ScenarioCase[] = [
         ).toBe(off.triangleCount);
       },
     },
-    timeout: 90_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/edgeCases.ts
+++ b/src/features/generation/worker/generators/scenarios/edgeCases.ts
@@ -105,7 +105,6 @@ export const edgeCases: ScenarioCase[] = [
         thickness: 0.8,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('edge cases', '2x2 with 8x8 compartments (tiny cells)', {
     assert: 'structural',
@@ -119,7 +118,6 @@ export const edgeCases: ScenarioCase[] = [
         thickness: 0.4,
       },
     },
-    timeout: 60_000,
   }),
 
   // Stress: multiple inserts
@@ -193,7 +191,6 @@ export const edgeCases: ScenarioCase[] = [
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
       inserts: [makeInsert({ shape: 'circle', width: 15, depth: 15, cutDepth: 3, x: 0, y: 0 })],
     },
-    timeout: 60_000,
   }),
 
   // Cutout edge-finding robustness

--- a/src/features/generation/worker/generators/scenarios/exportAndLarge.ts
+++ b/src/features/generation/worker/generators/scenarios/exportAndLarge.ts
@@ -5,14 +5,12 @@ export const exportMode: ScenarioCase[] = [
   defineScenario('export mode', '2\u00d72 default params (forExport=true)', {
     params: {},
     forExport: true,
-    timeout: 60_000,
   }),
 ];
 
 export const largeBin: ScenarioCase[] = [
   defineScenario('large bin', '8\u00d78 standard', {
     params: { width: 8, depth: 8 },
-    timeout: 60_000,
   }),
 ];
 

--- a/src/features/generation/worker/generators/scenarios/floorPatterns.ts
+++ b/src/features/generation/worker/generators/scenarios/floorPatterns.ts
@@ -110,14 +110,12 @@ export const floorPatterns: ScenarioCase[] = [
         assertDrainsThrough(drained, plain);
       },
     },
-    timeout: 90_000,
   }),
 
   defineScenario('floor patterns', 'holes stay clear of the baseplate-mating taper', {
     assert: 'structural',
     params: { width: 2, depth: 2, height: 4, floorPattern: HONEYCOMB_FLOOR },
     customAssert: assertFeetUnbreached,
-    timeout: 90_000,
   }),
 
   // ── Everything that already occupies the base or stands on the floor ──────
@@ -131,7 +129,6 @@ export const floorPatterns: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet_and_screw' },
     },
     customAssert: assertFeetUnbreached,
-    timeout: 90_000,
   }),
 
   defineScenario('floor patterns', 'compartment divider footings stay solid', {
@@ -142,7 +139,6 @@ export const floorPatterns: ScenarioCase[] = [
       floorPattern: HONEYCOMB_FLOOR,
       compartments: TWO_BY_TWO,
     },
-    timeout: 90_000,
   }),
 
   defineScenario('floor patterns', 'scoop ramp footings stay solid', {
@@ -153,7 +149,6 @@ export const floorPatterns: ScenarioCase[] = [
       floorPattern: ROUND_FLOOR,
       scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true },
     },
-    timeout: 90_000,
   }),
 
   // ── Base variants ────────────────────────────────────────────────────────
@@ -166,7 +161,6 @@ export const floorPatterns: ScenarioCase[] = [
       floorPattern: ROUND_FLOOR,
       base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
     },
-    timeout: 90_000,
   }),
 
   defineScenario('floor patterns', 'half sockets get one window per quarter foot', {
@@ -177,12 +171,10 @@ export const floorPatterns: ScenarioCase[] = [
       floorPattern: ROUND_FLOOR,
       base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
     },
-    timeout: 90_000,
   }),
 
   defineScenario('floor patterns', 'fractional edge foot carries a narrower window', {
     params: { width: 1.5, depth: 1, height: 4, floorPattern: ROUND_FLOOR },
-    timeout: 90_000,
   }),
 
   // ── Composition ──────────────────────────────────────────────────────────
@@ -195,7 +187,6 @@ export const floorPatterns: ScenarioCase[] = [
       floorPattern: HONEYCOMB_FLOOR,
       wallPattern: { enabled: true, pattern: 'honeycomb', scale: 0.5, dividers: false },
     },
-    timeout: 120_000,
   }),
 
   defineScenario('floor patterns', 'custom-shape bin patterns only its filled feet', {
@@ -206,7 +197,6 @@ export const floorPatterns: ScenarioCase[] = [
       floorPattern: ROUND_FLOOR,
       cellMask: { cols: 4, rows: 4, cells: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0] },
     },
-    timeout: 90_000,
   }),
 
   // ── Degenerate: an element too bold for any window leaves the floor solid ─
@@ -235,6 +225,5 @@ export const floorPatterns: ScenarioCase[] = [
         expect(meshVolume(oversized)).toBeCloseTo(meshVolume(plain), 3);
       },
     },
-    timeout: 90_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/halfSockets.ts
+++ b/src/features/generation/worker/generators/scenarios/halfSockets.ts
@@ -52,7 +52,6 @@ export const halfSockets: ScenarioCase[] = [
       depth: 3,
       base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('half-sockets', '2×2 half sockets + screw base', {
@@ -112,7 +111,6 @@ export const halfSockets: ScenarioCase[] = [
       depth: 3,
       base: { ...DEFAULT_BIN_PARAMS.base, footLatticeX: 'half', footLatticeY: 'half' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('half-sockets', '3×3 half foot lattice on X only', {
@@ -122,7 +120,6 @@ export const halfSockets: ScenarioCase[] = [
       depth: 3,
       base: { ...DEFAULT_BIN_PARAMS.base, footLatticeX: 'half' },
     },
-    timeout: 60_000,
   }),
 
   // Asks for `half` on both axes of a 2.5x2 bin: the fractional X falls back to

--- a/src/features/generation/worker/generators/scenarios/handles.ts
+++ b/src/features/generation/worker/generators/scenarios/handles.ts
@@ -24,7 +24,6 @@ export const handles: ScenarioCase[] = [
         right: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'handle holes with label tabs (back suppression)', {
     assert: 'structural',
@@ -39,7 +38,6 @@ export const handles: ScenarioCase[] = [
         back: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'handle holes with wall cutouts on same sides', {
     assert: 'structural',
@@ -58,7 +56,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'handle holes + cutouts on all four walls', {
     assert: 'structural',
@@ -83,7 +80,6 @@ export const handles: ScenarioCase[] = [
         right: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'handle holes with sharp corners (radius=0)', {
     assert: 'structural',
@@ -98,7 +94,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'handle holes with max corner radius (oval)', {
     assert: 'structural',
@@ -115,7 +110,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'handle holes + wide cutout suppresses all segments', {
     assert: 'structural',
@@ -134,7 +128,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'handle holes + left-aligned cutout (asymmetric split)', {
     assert: 'structural',
@@ -162,7 +155,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   // --- New shape scenarios ---
   defineScenario('handles', 'oval shape handles on front wall', {
@@ -178,7 +170,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'scoop shape handles on front wall', {
     assert: 'structural',
@@ -193,7 +184,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'multi-handle count=2 on wide bin', {
     assert: 'structural',
@@ -208,7 +198,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'custom vertical position at 40%', {
     assert: 'structural',
@@ -223,7 +212,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'interior wall handles with 2x2 compartments', {
     assert: 'structural',
@@ -239,7 +227,6 @@ export const handles: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('handles', 'chamfer enabled on rectangle handles', {
     assert: 'structural',
@@ -255,6 +242,5 @@ export const handles: ScenarioCase[] = [
         left: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/heights.ts
+++ b/src/features/generation/worker/generators/scenarios/heights.ts
@@ -32,7 +32,6 @@ export const heightVariations: ScenarioCase[] = [
   defineScenario('height', '4×4 height 6u (wide + tall, stress)', {
     assert: 'structural',
     params: { width: 4, depth: 4, height: 6 },
-    timeout: 60_000,
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, '4x4x6');
     },

--- a/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
+++ b/src/features/generation/worker/generators/scenarios/honeycombJunction.ts
@@ -84,7 +84,6 @@ export const honeycombJunction: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 60_000,
   }),
 
   // ── Bug 1: junction blocking must work without wall cutouts ──────────────
@@ -98,7 +97,6 @@ export const honeycombJunction: ScenarioCase[] = [
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 60_000,
   }),
 
   defineScenario('honeycomb junction', '2×2 bin, 2×2 compartments, no cutouts', {
@@ -110,7 +108,6 @@ export const honeycombJunction: ScenarioCase[] = [
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 1.2 },
       walls: ALL_SIDES_OFF,
     },
-    timeout: 60_000,
   }),
 
   // ── Bug 2: no mesh holes when cutouts enabled but all sides off ──────────
@@ -124,7 +121,6 @@ export const honeycombJunction: ScenarioCase[] = [
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
       walls: { ...ALL_SIDES_OFF, enabled: true },
     },
-    timeout: 60_000,
   }),
 
   // ── Junction + active cutout on one side ─────────────────────────────────
@@ -142,7 +138,6 @@ export const honeycombJunction: ScenarioCase[] = [
         front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     },
-    timeout: 60_000,
   }),
 
   // ── Honeycomb + dividers + interior wall cutouts ──────────────────────────
@@ -160,7 +155,6 @@ export const honeycombJunction: ScenarioCase[] = [
         interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     },
-    timeout: 60_000,
   }),
 
   // ── Honeycomb + dividers + outer + interior cutouts ──────────────────────
@@ -179,7 +173,6 @@ export const honeycombJunction: ScenarioCase[] = [
         interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     },
-    timeout: 60_000,
   }),
 
   // ── Bug 3: clip depth must cover hex prism extrusion at thick walls ─
@@ -210,7 +203,6 @@ export const honeycombJunction: ScenarioCase[] = [
       },
       assert: assertDividerJunction,
     },
-    timeout: 60_000,
   }),
 
   defineScenario('honeycomb junction', 'thick walls (2.4mm) no lip — junction blocking holds', {
@@ -237,7 +229,6 @@ export const honeycombJunction: ScenarioCase[] = [
       },
       assert: assertDividerJunction,
     },
-    timeout: 60_000,
   }),
 
   // ── Dividers add geometry but junction blocking limits the increase ─────
@@ -267,7 +258,6 @@ export const honeycombJunction: ScenarioCase[] = [
         },
         assert: assertDividerJunction,
       },
-      timeout: 60_000,
     }
   ),
 
@@ -304,7 +294,6 @@ export const honeycombJunction: ScenarioCase[] = [
           ).toBe(cutoutsOnSidesOff.triangleCount);
         },
       },
-      timeout: 60_000,
     }
   ),
 
@@ -338,7 +327,6 @@ export const honeycombJunction: ScenarioCase[] = [
         ).toBeGreaterThan(0);
         assertWatertight(mesh, 'bold round pattern + dividers, thin walls, no lip (#2865)');
       },
-      timeout: 60_000,
     }
   ),
 ];

--- a/src/features/generation/worker/generators/scenarios/integration.ts
+++ b/src/features/generation/worker/generators/scenarios/integration.ts
@@ -26,7 +26,6 @@ export const integration: ScenarioCase[] = [
   defineScenario('integration', 'generates a 2x2 bin (DEFAULT_BIN_PARAMS)', {
     assert: 'structural',
     params: {},
-    timeout: 60_000,
     customAssert: (result) => {
       expect(result.triangleCount).toBeGreaterThan(100);
     },
@@ -38,7 +37,6 @@ export const integration: ScenarioCase[] = [
       depth: 2,
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
     },
-    timeout: 60_000,
   }),
   defineScenario('integration', '0.5x0.5 bin with single half-cell socket', {
     assert: 'structural',
@@ -55,7 +53,6 @@ export const integration: ScenarioCase[] = [
       depth: 1.5,
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     },
-    timeout: 60_000,
   }),
   defineScenario('integration', '0.5x1 bin with half-width socket cell', {
     assert: 'structural',
@@ -72,7 +69,6 @@ export const integration: ScenarioCase[] = [
       depth: 2,
       base: { ...DEFAULT_BIN_PARAMS.base, style: 'magnet', stackingLip: false },
     },
-    timeout: 60_000,
     customAssert: (result) => {
       expect(result.triangleCount).toBeGreaterThan(100);
     },
@@ -86,7 +82,6 @@ export const integration: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' },
     },
     forExport: true,
-    timeout: 120_000,
     customAssert: (result) => {
       expect(result.triangleCount).toBeGreaterThan(100);
     },
@@ -99,7 +94,6 @@ export const integration: ScenarioCase[] = [
       height: 3,
       wallPattern: { enabled: true, pattern: 'honeycomb' },
     },
-    timeout: 120_000,
     customAssert: (result) => {
       expect(result.triangleCount).toBeGreaterThan(100);
     },
@@ -112,7 +106,6 @@ export const integration: ScenarioCase[] = [
       height: 3,
       wallPattern: { enabled: false, pattern: 'honeycomb' },
     },
-    timeout: 60_000,
     customAssert: (result) => {
       expect(result.triangleCount).toBeGreaterThan(100);
     },

--- a/src/features/generation/worker/generators/scenarios/labelSockets.ts
+++ b/src/features/generation/worker/generators/scenarios/labelSockets.ts
@@ -325,7 +325,6 @@ export const labelSockets: ScenarioCase[] = [
       label: SOCKET_LABEL,
       wallPattern: { enabled: true, pattern: 'honeycomb' },
     },
-    timeout: 90_000,
   }),
 
   // Text-mode sentinel: mode absent takes the legacy code path; the

--- a/src/features/generation/worker/generators/scenarios/lightweight.ts
+++ b/src/features/generation/worker/generators/scenarios/lightweight.ts
@@ -80,7 +80,6 @@ export const lightweight: ScenarioCase[] = [
   defineScenario('lightweight', '4×4 lite export (stress)', {
     assert: 'structural',
     forExport: true,
-    timeout: 60_000,
     params: { width: 4, depth: 4, base: { ...lite, style: 'magnet' } },
   }),
 
@@ -100,7 +99,6 @@ export const lightweight: ScenarioCase[] = [
   defineScenario('lightweight', '2×2 lite + 2×2 compartments + magnet', {
     assert: 'structural',
     forExport: true,
-    timeout: 60_000,
     params: {
       width: 2,
       depth: 2,

--- a/src/features/generation/worker/generators/scenarios/lipWall.ts
+++ b/src/features/generation/worker/generators/scenarios/lipWall.ts
@@ -30,7 +30,6 @@ export const lipWall: ScenarioCase[] = lipWallCases.map(({ width, depth, label }
       style: 'slotted',
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     },
-    timeout: 120_000,
     customAssert: (result) => {
       const zMin = meshWallHeight781 - 2.0;
       const zMax = meshWallHeight781 + 1.0;

--- a/src/features/generation/worker/generators/scenarios/permutationMatrix.ts
+++ b/src/features/generation/worker/generators/scenarios/permutationMatrix.ts
@@ -27,7 +27,6 @@ export const permutationMatrix: ScenarioCase[] = [
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, 'lip+compart+scoop');
     },
@@ -71,7 +70,6 @@ export const permutationMatrix: ScenarioCase[] = [
         left: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, 'slotted+lip+handles');
     },
@@ -94,7 +92,6 @@ export const permutationMatrix: ScenarioCase[] = [
         back: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 60, depth: 50 },
       },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 cutouts + handles + label tab (3 cuts)', {
@@ -109,7 +106,6 @@ export const permutationMatrix: ScenarioCase[] = [
       },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '3×2 inserts + scoop + compartments (floor + back wall + interior)', {
@@ -124,7 +120,6 @@ export const permutationMatrix: ScenarioCase[] = [
       compartments: { cols: 3, rows: 1, cells: [0, 1, 2], thickness: 0.8 },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 
   // ─── Half sockets × sub-features ──────────────────────────────────────────
@@ -148,7 +143,6 @@ export const permutationMatrix: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, halfSockets: true },
       wallPattern: { enabled: true, pattern: 'honeycomb' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 half sockets + handles', {
@@ -163,7 +157,6 @@ export const permutationMatrix: ScenarioCase[] = [
         back: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 half sockets + scoop + lip', {
@@ -176,7 +169,6 @@ export const permutationMatrix: ScenarioCase[] = [
       },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 
   // ─── Wall pattern intersections (honeycomb border clipping) ──────────────
@@ -195,7 +187,6 @@ export const permutationMatrix: ScenarioCase[] = [
       },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
     },
-    timeout: 120_000,
   }),
 
   defineScenario(CAT, '4×4 honeycomb + wall cutouts + lip (hex prism + border)', {
@@ -213,7 +204,6 @@ export const permutationMatrix: ScenarioCase[] = [
         back: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 80, depth: 50 },
       },
     },
-    timeout: 120_000,
   }),
 
   defineScenario(CAT, '1.5×1.5 honeycomb + fractional + lip', {
@@ -225,7 +215,6 @@ export const permutationMatrix: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
       wallPattern: { enabled: true, pattern: 'honeycomb' },
     },
-    timeout: 60_000,
   }),
 
   // ─── Solid mode × cuts ───────────────────────────────────────────────────
@@ -240,7 +229,6 @@ export const permutationMatrix: ScenarioCase[] = [
       },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 solid + handles (cuts above solid surface)', {
@@ -259,7 +247,6 @@ export const permutationMatrix: ScenarioCase[] = [
         back: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 solid + grouped cutouts at varying depths', {
@@ -276,7 +263,6 @@ export const permutationMatrix: ScenarioCase[] = [
         makeCutout({ id: 'deep', x: 10, cutDepth: 6, groupId: 'g1' }),
       ],
     },
-    timeout: 60_000,
   }),
 
   // ─── 4×4 stress: many features at scale ───────────────────────────────────
@@ -295,7 +281,6 @@ export const permutationMatrix: ScenarioCase[] = [
       scoop: { enabled: true, radius: 'auto' },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
     },
-    timeout: 120_000,
   }),
 
   defineScenario(CAT, '4×4 slotted + handles + label + lip (multi-cut stress)', {
@@ -314,7 +299,6 @@ export const permutationMatrix: ScenarioCase[] = [
       },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
     },
-    timeout: 120_000,
   }),
 
   defineScenario(CAT, '4×4 honeycomb + handles + scoop + lip + halfSockets', {
@@ -347,7 +331,6 @@ export const permutationMatrix: ScenarioCase[] = [
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 slotted + inserts + lip', {
@@ -357,7 +340,6 @@ export const permutationMatrix: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
       inserts: [makeInsert({ shape: 'circle', width: 20, depth: 20, cutDepth: 4 })],
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 slotted + handles + label', {
@@ -373,7 +355,6 @@ export const permutationMatrix: ScenarioCase[] = [
       },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
     },
-    timeout: 60_000,
   }),
 
   // ─── Fractional dimensions × features ────────────────────────────────────
@@ -385,7 +366,6 @@ export const permutationMatrix: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2.5×1 handles + lip (asymmetric + lip)', {
@@ -401,7 +381,6 @@ export const permutationMatrix: ScenarioCase[] = [
         front: ENABLED_SIDE,
       },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '0.5×2 magnet + lip + half sockets (long half-bin stress)', {
@@ -416,7 +395,6 @@ export const permutationMatrix: ScenarioCase[] = [
         halfSockets: true,
       },
     },
-    timeout: 60_000,
   }),
 
   // ─── Label-tab × interior interactions ──────────────────────────────────
@@ -427,7 +405,6 @@ export const permutationMatrix: ScenarioCase[] = [
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 label tab solid + thick walls (gusset edge case)', {
@@ -454,7 +431,6 @@ export const permutationMatrix: ScenarioCase[] = [
       scoop: { enabled: true, radius: 'auto' },
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '2×2 weighted base + compartments + scoop', {
@@ -464,7 +440,6 @@ export const permutationMatrix: ScenarioCase[] = [
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 
   // ─── Scoop interactions ───────────────────────────────────────────────
@@ -476,6 +451,5 @@ export const permutationMatrix: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/regressions.ts
+++ b/src/features/generation/worker/generators/scenarios/regressions.ts
@@ -55,7 +55,6 @@ export const regressions: ScenarioCase[] = [
       scoop: { enabled: true, radius: 'auto' },
     },
     forExport: true,
-    timeout: 60_000,
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, '#1760');
       assertNoDegenerateTriangles(result, '#1760');
@@ -71,7 +70,6 @@ export const regressions: ScenarioCase[] = [
       depth: 2,
       scoop: { enabled: true, radius: 'auto' },
     },
-    timeout: 60_000,
     customAssert: (result) => {
       assertNoDegenerateTriangles(result, '#1681');
     },
@@ -111,7 +109,6 @@ export const regressions: ScenarioCase[] = [
       style: 'slotted',
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     },
-    timeout: 60_000,
     customAssert: (result) => {
       const wallHeight = 6 * GRIDFINITY.HEIGHT_UNIT;
       const bb = boundingBox(result.vertices);
@@ -190,7 +187,6 @@ export const regressions: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
     },
-    timeout: 120_000,
     customAssert: (result) => {
       assertNoDegenerateTriangles(result, '#1437');
     },
@@ -201,7 +197,6 @@ export const regressions: ScenarioCase[] = [
   defineScenario(CAT, '#1404 oversized 8×4 bin (would need split)', {
     assert: 'structural',
     params: { width: 8, depth: 4, height: 4 },
-    timeout: 120_000,
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, '#1404');
     },
@@ -218,7 +213,6 @@ export const regressions: ScenarioCase[] = [
       height: 6,
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     },
-    timeout: 120_000,
     customAssert: (result) => {
       const outerW = 3 * SIZE - TOL;
       const outerD = 5 * SIZE - TOL;
@@ -239,7 +233,6 @@ export const regressions: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
     },
-    timeout: 120_000,
     customAssert: (result) => {
       assertNoDegenerateTriangles(result, '#1354');
     },
@@ -257,7 +250,6 @@ export const regressions: ScenarioCase[] = [
       wallPattern: { enabled: true, pattern: 'honeycomb' },
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 0.8 },
     },
-    timeout: 120_000,
     customAssert: (result) => {
       assertNoDegenerateTriangles(result, '#1351');
     },
@@ -301,7 +293,6 @@ export const regressions: ScenarioCase[] = [
       height: 4,
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: true },
     },
-    timeout: 60_000,
     customAssert: (result) => {
       const outerW = 5 * SIZE - TOL;
       const outerD = 2 * SIZE - TOL;
@@ -345,7 +336,6 @@ export const regressions: ScenarioCase[] = [
     assert: 'structural',
     params: { style: 'slotted', height: 4 },
     forExport: true,
-    timeout: 60_000,
     customAssert: (result) => {
       assertNoDegenerateTriangles(result, '#921');
     },
@@ -374,7 +364,6 @@ export const regressions: ScenarioCase[] = [
         front: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 50, depth: 40 },
       },
     },
-    timeout: 60_000,
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, '#371');
     },
@@ -434,7 +423,6 @@ export const regressions: ScenarioCase[] = [
       cutoutConfig: { topOffset: 5 },
       cutouts: [makeCutout({ id: 'top-cut', width: 20, depth: 20, cutDepth: 8 })],
     },
-    timeout: 60_000,
     customAssert: (result) => {
       assertNoDegenerateTriangles(result, '#solid-top');
     },

--- a/src/features/generation/worker/generators/scenarios/slideTray.ts
+++ b/src/features/generation/worker/generators/scenarios/slideTray.ts
@@ -17,7 +17,6 @@ export const slideTray: ScenarioCase[] = [
       height: 6,
       slide: slide({ railMount: 'interior', trayWidthUnits: 1 }),
     },
-    timeout: 60_000,
   }),
   defineScenario('slide tray', 'rim track on a lipped bin', {
     assert: 'structural',
@@ -27,7 +26,6 @@ export const slideTray: ScenarioCase[] = [
       height: 6,
       slide: slide({ railMount: 'rim', trayWidthUnits: 2 }),
     },
-    timeout: 60_000,
   }),
   defineScenario('slide tray', 'rim track without a stacking lip', {
     assert: 'structural',
@@ -38,7 +36,6 @@ export const slideTray: ScenarioCase[] = [
       base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false },
       slide: slide({ railMount: 'rim' }),
     },
-    timeout: 60_000,
   }),
   defineScenario('slide tray', 'interior ledges under a wall pattern', {
     assert: 'structural',
@@ -49,7 +46,6 @@ export const slideTray: ScenarioCase[] = [
       wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true },
       slide: slide({ railMount: 'interior' }),
     },
-    timeout: 90_000,
   }),
   defineScenario('slide tray', 'interior ledges under a kumiko wrap', {
     assert: 'structural',
@@ -60,7 +56,6 @@ export const slideTray: ScenarioCase[] = [
       wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true, pattern: 'mitsukude' },
       slide: slide({ railMount: 'interior' }),
     },
-    timeout: 120_000,
   }),
   defineScenario('slide tray', 'interior ledges with compartments and a lid', {
     assert: 'structural',
@@ -71,6 +66,5 @@ export const slideTray: ScenarioCase[] = [
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
       slide: slide({ railMount: 'interior', railDropMm: 6 }),
     },
-    timeout: 90_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/solidCutoutMatrix.ts
+++ b/src/features/generation/worker/generators/scenarios/solidCutoutMatrix.ts
@@ -33,7 +33,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
       base: SOLID_BASE,
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
     },
-    timeout: 60_000,
     customAssert: (result) => {
       assertNoDegenerateTriangles(result, 'solid+label-bracket');
     },
@@ -55,7 +54,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
       base: SOLID_BASE,
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'solid' },
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, 'solid + label tab + thick walls — label still ignored', {
@@ -76,7 +74,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true, support: 'bracket' },
       cutouts: [makeCutout({ id: 'c1', shape: 'circle', cutDepth: 4 })],
     },
-    timeout: 60_000,
   }),
 
   // ─── Solid + handle params (also ignored) + cutouts ──────────────────────
@@ -94,7 +91,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
       },
       cutouts: [makeCutout({ id: 'c1', cutDepth: 3 })],
     },
-    timeout: 60_000,
   }),
 
   // ─── topOffset × cutDepth matrix ─────────────────────────────────────────
@@ -116,7 +112,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
         cutoutConfig: { topOffset: offset },
         cutouts: [makeCutout({ id: 'c1', width: 20, depth: 20, cutDepth: depth })],
       },
-      timeout: 60_000,
     })
   ),
 
@@ -135,7 +130,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
         makeCutout({ id: 'd', x: 20, y: 20, rotation: 90, groupId: 'g1' }),
       ],
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, 'solid + grouped cutouts varying depth in same group', {
@@ -151,7 +145,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
         makeCutout({ id: 's3', x: 20, cutDepth: 8, groupId: 'g1' }),
       ],
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, 'solid + grouped cutouts with scoop at 45°', {
@@ -182,7 +175,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
         }),
       ],
     },
-    timeout: 60_000,
   }),
 
   // ─── topOffset + stacking lip (solid + lip on, edge case) ───────────────
@@ -194,7 +186,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
       cutoutConfig: { topOffset: 5 },
       cutouts: [makeCutout({ id: 'c1', cutDepth: 8 })],
     },
-    timeout: 60_000,
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, 'solid+lip+topOffset');
     },
@@ -213,7 +204,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
         makeCutout({ id: 'c', x: 0, y: 0, cutDepth: 4 }),
       ],
     },
-    timeout: 60_000,
     customAssert: (result) => {
       assertNoDegenerateTriangles(result, 'solid+lip+multiCut');
     },
@@ -243,7 +233,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
         }),
       ],
     },
-    timeout: 60_000,
   }),
 
   // ─── Stress: solid + 6 features ─────────────────────────────────────────
@@ -281,7 +270,6 @@ export const solidCutoutMatrix: ScenarioCase[] = [
       label: { ...DEFAULT_BIN_PARAMS.label, enabled: true },
       cutouts: [makeCutout({ id: 'frac', width: 15, depth: 15, cutDepth: 3 })],
     },
-    timeout: 60_000,
   }),
 
   defineScenario(CAT, '0.5×0.5 solid + cutout (smallest + cut)', {

--- a/src/features/generation/worker/generators/scenarios/solidMode.ts
+++ b/src/features/generation/worker/generators/scenarios/solidMode.ts
@@ -26,7 +26,6 @@ export const solidMode: ScenarioCase[] = [
         base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
       },
       forExport: true,
-      timeout: 60_000,
       compareWith: {
         params: {
           width: 1,
@@ -94,7 +93,6 @@ export const solidMode: ScenarioCase[] = [
       cutouts: [makeCutout({ id: 'center-cutout', x: 20, y: 20 })],
     },
     forExport: true,
-    timeout: 60_000,
     compareWith: {
       params: {
         width: 2,

--- a/src/features/generation/worker/generators/scenarios/spacer.ts
+++ b/src/features/generation/worker/generators/scenarios/spacer.ts
@@ -54,7 +54,6 @@ export const spacer: ScenarioCase[] = [
   defineScenario('spacer', '3×3 spacer (interior feet must stay attached)', {
     assert: 'structural',
     forExport: true,
-    timeout: 60_000,
     params: { width: 3, depth: 3, height: 2, base: spacerBase },
   }),
 

--- a/src/features/generation/worker/generators/scenarios/wallCutouts.ts
+++ b/src/features/generation/worker/generators/scenarios/wallCutouts.ts
@@ -16,7 +16,6 @@ export const wallCutouts: ScenarioCase[] = [
         depth: 50,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('wall cutouts', 'slotted bin with per-side wall cutouts', {
     assert: 'structural',
@@ -37,7 +36,6 @@ export const wallCutouts: ScenarioCase[] = [
         interior: DISABLED_WALL_CUTOUT,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('wall cutouts', 'standard bin with interior wall cutouts and compartments', {
     assert: 'structural',
@@ -58,7 +56,6 @@ export const wallCutouts: ScenarioCase[] = [
         interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('wall cutouts', 'interior divider cutout honours alignment + offset (#2323)', {
     assert: 'structural',
@@ -88,7 +85,6 @@ export const wallCutouts: ScenarioCase[] = [
         },
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('wall cutouts', 'tilted interior divider cutout with alignment (#2323)', {
     assert: 'structural',
@@ -124,7 +120,6 @@ export const wallCutouts: ScenarioCase[] = [
         },
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('wall cutouts', 'full-height u-shape meets the rim square (#3173)', {
     // The reporter's config: a 14mm grid with 2.6mm walls and a 100%-height
@@ -150,7 +145,6 @@ export const wallCutouts: ScenarioCase[] = [
         interior: DISABLED_WALL_CUTOUT,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('wall cutouts', 'full-height u-shape through a stacking lip (#3173)', {
     // Same cut against a lipped wall: the true rim is the lip peak at
@@ -176,7 +170,6 @@ export const wallCutouts: ScenarioCase[] = [
         interior: DISABLED_WALL_CUTOUT,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('wall cutouts', 'left-aligned cutout with offset and absolute mm width', {
     assert: 'structural',
@@ -196,7 +189,6 @@ export const wallCutouts: ScenarioCase[] = [
         interior: DISABLED_WALL_CUTOUT,
       },
     },
-    timeout: 60_000,
   }),
   defineScenario('wall cutouts', 'full-width cutout squares its bottom corners', {
     assert: 'structural',
@@ -219,6 +211,5 @@ export const wallCutouts: ScenarioCase[] = [
       },
       compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
     },
-    timeout: 60_000,
   }),
 ];

--- a/src/features/generation/worker/generators/scenarios/wallPatterns.ts
+++ b/src/features/generation/worker/generators/scenarios/wallPatterns.ts
@@ -66,7 +66,6 @@ function patternCase(pattern: WallPatternType, scale = 0.5): ScenarioCase {
       walls: ALL_SIDES_OFF,
     },
     assert: 'structural',
-    timeout: 60_000,
     compareWith: {
       params: {
         width: 3,
@@ -105,7 +104,6 @@ function frontOnlyCase(): ScenarioCase {
   return defineScenario('wall patterns', 'front-only selection carves only the front wall', {
     params,
     assert: 'structural',
-    timeout: 60_000,
     customAssert: (result) => {
       // Mid-band of the pattern zone on a 35mm-tall bin — comfortably inside
       // the keep-outs at both ends whatever the exact band works out to.

--- a/src/features/generation/worker/generators/scenarios/wallThickness.ts
+++ b/src/features/generation/worker/generators/scenarios/wallThickness.ts
@@ -38,13 +38,11 @@ export const wallThickness: ScenarioCase[] = [
       wallThickness: 2.4,
       compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 0.8 },
     },
-    timeout: 60_000,
   }),
 
   defineScenario('wall thickness', '4×4 thick walls (stress)', {
     assert: 'structural',
     params: { width: 4, depth: 4, wallThickness: 2.4 },
-    timeout: 60_000,
     customAssert: (result, params) => {
       assertBoundingBoxMatchesParams(result, params, '4x4-thick');
     },


### PR DESCRIPTION
Fixes #3792

## What

- `defineScenario` no longer fills in a 30s default timeout. `ScenarioCase.timeout` is now optional; when unset, both `scenarioRunner` and `exportIntegrityRunner` pass `undefined` to `it()`, which falls through to the generators project `testTimeout` (120s).
- Removes the 166 explicit `timeout:` annotations at or below 120s (125x 60s, 27x 90s, 14x 120s). An explicit `it()` timeout overrides the project bound in both directions, so after the default fix these would have been caps below the bound they were written to raise. The 16 scenarios annotated 180s keep their raise.

## Why

The raise that closed #3537 (`testTimeout: 120_000` on the generators project) never reached scenario cases: `defineScenario` pinned 30s and the runner passed it explicitly, so 270 cases stayed on a bound that a cold worker swings past on wall time alone (16.8s warm vs 30.7s cold for the same scenario, identical triangle count).

## Verification

- `pnpm run test:run` on both lightweight files: 54 passed
- `pnpm run typecheck`: clean

https://claude.ai/code/session_01HZ4UfQbGHsTK1dGag9Bh6w

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

