### PR TITLE
fix(designer): keep cutout canvas overlays below the context menu

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/DimensionAnnotations3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/DimensionAnnotations3D.tsx
@@ -9,6 +9,7 @@
 import { Html } from '@react-three/drei';
 
 import type { Cutout } from '@/features/bin-designer/types';
+import { HTML_OVERLAY_Z_INDEX_RANGE } from './constants';
 
 interface DimensionAnnotations3DProps {
   readonly cutouts: readonly Cutout[];
@@ -47,14 +48,24 @@ export function DimensionAnnotations3D({
         return (
           <group key={cutout.id}>
             {/* Width annotation below shape */}
-            <Html position={[widthX, widthY, 0.1]} center style={{ pointerEvents: 'none' }}>
+            <Html
+              position={[widthX, widthY, 0.1]}
+              center
+              style={{ pointerEvents: 'none' }}
+              zIndexRange={HTML_OVERLAY_Z_INDEX_RANGE}
+            >
               <div className="rounded bg-surface-elevated/80 px-1 text-[10px] font-mono text-content-secondary whitespace-nowrap">
                 {effective.width.toFixed(1)}mm
               </div>
             </Html>
 
             {/* Depth annotation left of shape */}
-            <Html position={[depthX, depthY, 0.1]} center style={{ pointerEvents: 'none' }}>
+            <Html
+              position={[depthX, depthY, 0.1]}
+              center
+              style={{ pointerEvents: 'none' }}
+              zIndexRange={HTML_OVERLAY_Z_INDEX_RANGE}
+            >
               <div className="rounded bg-surface-elevated/80 px-1 text-[10px] font-mono text-content-secondary whitespace-nowrap">
                 {effective.depth.toFixed(1)}mm
               </div>

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/DimensionTooltip3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/DimensionTooltip3D.tsx
@@ -7,6 +7,8 @@
 
 import { Html } from '@react-three/drei';
 
+import { HTML_OVERLAY_Z_INDEX_RANGE } from './constants';
+
 interface DimensionTooltip3DProps {
   /** What to display */
   readonly type: 'resize' | 'drag';
@@ -38,7 +40,12 @@ export function DimensionTooltip3D({
       : `${x?.toFixed(1)}, ${y?.toFixed(1)}`;
 
   return (
-    <Html position={[worldX, worldY, 0.1]} style={{ pointerEvents: 'none' }} center={false}>
+    <Html
+      position={[worldX, worldY, 0.1]}
+      style={{ pointerEvents: 'none' }}
+      center={false}
+      zIndexRange={HTML_OVERLAY_Z_INDEX_RANGE}
+    >
       <div
         className="rounded border border-stroke-subtle bg-surface-elevated px-2 py-0.5 text-[10px] font-mono text-content whitespace-nowrap shadow-sm"
         style={{ transform: 'translate(5px, -28px)' }}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/LockBadge3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/LockBadge3D.tsx
@@ -7,6 +7,8 @@
 
 import { Html } from '@react-three/drei';
 
+import { HTML_OVERLAY_Z_INDEX_RANGE } from './constants';
+
 interface LockBadge3DProps {
   /** World-space X position (mm) */
   readonly worldX: number;
@@ -16,7 +18,12 @@ interface LockBadge3DProps {
 
 export function LockBadge3D({ worldX, worldY }: LockBadge3DProps) {
   return (
-    <Html position={[worldX, worldY, 0.1]} style={{ pointerEvents: 'none' }} center>
+    <Html
+      position={[worldX, worldY, 0.1]}
+      style={{ pointerEvents: 'none' }}
+      center
+      zIndexRange={HTML_OVERLAY_Z_INDEX_RANGE}
+    >
       <div
         className="flex items-center justify-center rounded-full bg-surface-elevated/80 border border-stroke-subtle shadow-sm"
         style={{ width: 16, height: 16 }}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/RulerMeasurement3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/RulerMeasurement3D.tsx
@@ -12,7 +12,7 @@
 import { useMemo } from 'react';
 import { Html, Line } from '@react-three/drei';
 import type { RulerMeasurement } from '../handlers/rulerHandler';
-import { RENDER_ORDER } from './constants';
+import { HTML_OVERLAY_Z_INDEX_RANGE, RENDER_ORDER } from './constants';
 
 interface RulerMeasurement3DProps {
   readonly measurement: RulerMeasurement;
@@ -101,6 +101,7 @@ export function RulerMeasurement3D({ measurement, zoom }: RulerMeasurement3DProp
         center
         style={{ pointerEvents: 'none' }}
         renderOrder={RENDER_ORDER.HANDLES}
+        zIndexRange={HTML_OVERLAY_Z_INDEX_RANGE}
       >
         {/* eslint-disable i18next/no-literal-string -- measurement display, not translatable */}
         <div className="rounded bg-gray-900/95 px-2.5 py-1.5 text-xs font-mono text-yellow-200 whitespace-nowrap shadow-lg border border-yellow-500/40">

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/constants.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/constants.ts
@@ -42,6 +42,14 @@ export const Z_LAYER_STEP = 0.05;
 export const Z_LAYER_MAX = 900;
 export const Z_LAYER_RENDER_STEP = 0.001;
 
+/**
+ * z-index range for drei `<Html>` overlays (dimension chips, drag tooltip,
+ * lock badge, ruler readout). drei's default range starts at ~16.7 million,
+ * which paints these chips through the cutout context menu (`z-50`) and its
+ * `z-40` scrim — every in-canvas HTML overlay must stay below both.
+ */
+export const HTML_OVERLAY_Z_INDEX_RANGE: [number, number] = [30, 0];
+
 /** Camera zoom limits (zoom = pixels per mm for the orthographic camera) */
 export const MIN_ZOOM = 0.5;
 export const MAX_ZOOM = 50;


### PR DESCRIPTION
## Summary

Right-clicking in the cutout editor opened the context menu underneath the dimension chips: drei `<Html>` defaults its z-index range to ~16.7 million, while the menu sits at `z-50` behind a `z-40` scrim, so the width label punched through the menu.

- Add `HTML_OVERLAY_Z_INDEX_RANGE` (`[30, 0]`) to the renderer constants, documented against the menu/scrim levels it must stay below.
- Apply it to every in-canvas `<Html>` overlay: the width/depth dimension chips, the drag/resize tooltip, the lock badge, and the ruler readout — the tooltip, badge, and ruler leaked through the menu the same way, just less often in view.

The overlays still paint above the WebGL canvas (absolutely positioned siblings of the canvas), so nothing else changes visually.

Fixes #3798

https://claude.ai/code/session_01HZ4UfQbGHsTK1dGag9Bh6w

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

