### PR TITLE
fix(designer): arrange repeats by their full pattern extent

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.test.ts
@@ -90,6 +90,31 @@ describe('toArrangeUnits', () => {
     expect(unitDepth(unit)).toBeCloseTo(20);
   });
 
+  it('spans every repeat instance, not just the master', () => {
+    const [unit] = toArrangeUnits([
+      cutout('a', {
+        x: 10,
+        y: 10,
+        width: 10,
+        depth: 10,
+        array: {
+          mode: 'grid',
+          cols: 3,
+          rows: 2,
+          pitchX: 20,
+          pitchY: 15,
+          count: 6,
+          radius: 20,
+          startAngle: 0,
+          rotateToCenter: false,
+        },
+      }),
+    ]);
+    // Grid grows +X/+Y from the master: 2 extra columns at 20mm and 1 extra
+    // row at 15mm past the master's 10x10 box.
+    expect(unit.bounds).toEqual({ minX: 10, minY: 10, maxX: 60, maxY: 35 });
+  });
+
   it('marks a unit locked when any member is locked', () => {
     const [unit] = toArrangeUnits([
       cutout('a', { groupId: 'g1' }),

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.ts
@@ -21,15 +21,21 @@
  * Bounds are the *rotated* silhouette. A group's box is meaningless otherwise,
  * and every consumer expresses a move as a translation, so the unrotated
  * `x`/`y` stays in step with the box it was measured from.
+ *
+ * A repeat master's bounds span every expanded instance for the same reason:
+ * the instances are offsets from the master, so they translate with it, and
+ * centring or distributing by the master's own box alone parks the pattern
+ * off-centre.
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
+import { expandCutoutArray } from '@/shared/utils/cutoutArray';
 import { type Bounds, getRotatedBounds } from './geometryCore';
 
 /** One rigid arrange target: a whole group, or a single ungrouped cutout. */
 export interface ArrangeUnit {
   readonly members: readonly Cutout[];
-  /** Rotated AABB spanning every member. */
+  /** Rotated AABB spanning every member, repeat instances included. */
   readonly bounds: Bounds;
   /** True when any member is locked — the unit is then immovable. */
   readonly locked: boolean;
@@ -43,11 +49,13 @@ function makeUnit(members: readonly Cutout[]): ArrangeUnit {
   let locked = false;
 
   for (const member of members) {
-    const b = getRotatedBounds(member);
-    minX = Math.min(minX, b.minX);
-    minY = Math.min(minY, b.minY);
-    maxX = Math.max(maxX, b.maxX);
-    maxY = Math.max(maxY, b.maxY);
+    for (const instance of expandCutoutArray(member)) {
+      const b = getRotatedBounds(instance);
+      minX = Math.min(minX, b.minX);
+      minY = Math.min(minY, b.minY);
+      maxX = Math.max(maxX, b.maxX);
+      maxY = Math.max(maxY, b.maxY);
+    }
     if (member.locked) locked = true;
   }
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -568,6 +568,36 @@ describe('geometry', () => {
       expect(result).toEqual({});
     });
 
+    it('centers a repeat by its whole pattern, not just the master', () => {
+      const cutouts = [
+        createCutout({
+          id: 'a',
+          x: 0,
+          y: 0,
+          width: 10,
+          depth: 10,
+          array: {
+            mode: 'grid',
+            cols: 2,
+            rows: 2,
+            pitchX: 20,
+            pitchY: 20,
+            count: 4,
+            radius: 20,
+            startAngle: 0,
+            rotateToCenter: false,
+          },
+        }),
+      ];
+      const result = centerInBin(cutouts, 100, 100);
+
+      // The pattern spans 30x30 (master box plus one 20mm pitch step per
+      // axis), so centred it runs 35..65 — the master sits at 35, while
+      // centring the master alone would have put it at 45.
+      expect(result.a.x).toBe(35);
+      expect(result.a.y).toBe(35);
+    });
+
     it('leaves the other axis exactly where the user put it', () => {
       // The whole point of the single-axis modes: centring both at once
       // discards a position that was placed deliberately.


### PR DESCRIPTION
## Summary

Center in bin (and every other arrange action) measured a repeat by its master cutout alone, so centering a 4-up repeat put the master at the bin's center with the other instances hanging off to one side — while flattening the repeat first and centering the four cutouts landed correctly.

An `ArrangeUnit`'s bounds now span every expanded instance (`expandCutoutArray`, the same treatment `offBoardCutouts` and `growBinToFit` already give repeats). Instances are fixed offsets from the master, so the existing translation-only arrange moves stay valid — the bounds were the only array-blind piece.

Because align, distribute, auto-arrange and the workspace align buttons all consume the same units, they pick up the pattern-extent behavior with the same change.

## Testing

- New `toArrangeUnits` test asserting a grid repeat's unit bounds span all instances.
- New `centerInBin` test asserting the master lands where the whole pattern is centered.
- Full bin-designer suite (5410 tests) green.

Fixes #3799

https://claude.ai/code/session_01HZ4UfQbGHsTK1dGag9Bh6w

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

