### PR TITLE
fix(designer): ghost outline follows the cutout's true shape and cut

### DIFF
--- a/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
@@ -113,10 +113,12 @@ export function GhostCutouts() {
     } else {
       return [];
     }
-    if (previewOverrides.size === 0) return result;
     return result.map((c) => {
       const overrides = previewOverrides.get(c.id);
-      return overrides ? { ...c, ...overrides } : c;
+      const merged = overrides ? { ...c, ...overrides } : c;
+      // The worker cuts at most the remaining fill (`effectiveDepth`), so a
+      // deeper stored cutDepth must not draw a floor below the bin's own.
+      return merged.cutDepth > fillSurface ? { ...merged, cutDepth: fillSurface } : merged;
     });
   }, [isSolid, cutouts, isGenerating, hasSelection, selectedIds, previewOverrides, fillSurface]);
 

--- a/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostCutouts/GhostCutouts.tsx
@@ -41,6 +41,7 @@ export function GhostCutouts() {
     heightUnitMm,
     wallThickness,
     cutouts,
+    cutoutConfig,
     base,
     lid,
     overhang,
@@ -56,6 +57,7 @@ export function GhostCutouts() {
       heightUnitMm: s.params.heightUnitMm,
       wallThickness: s.params.wallThickness,
       cutouts: s.params.cutouts,
+      cutoutConfig: s.params.cutoutConfig,
       base: s.params.base,
       lid: s.params.lid,
       overhang: s.params.overhang,
@@ -71,6 +73,9 @@ export function GhostCutouts() {
   const totalH = height * heightUnitMm;
   const wallHeight = baseWallHeight(base, totalH);
   const floorZ = baseFloorZ(base, heightUnitMm, lid);
+  // The worker cuts from the solid FILL surface, which the global top offset
+  // lowers below the rim — and skips every cutout when nothing of it remains.
+  const fillSurface = wallHeight - cutoutConfig.topOffset;
 
   const outerW = width * gridUnitMm - GRIDFINITY.TOLERANCE;
   const outerD = depth * (gridUnitMmY ?? gridUnitMm) - GRIDFINITY.TOLERANCE;
@@ -94,7 +99,7 @@ export function GhostCutouts() {
   // - All cutouts: shown during generation
   // Apply live preview overrides (drag/resize/rotate) for real-time 3D feedback
   const cutoutsToRender = useMemo(() => {
-    if (!isSolid || cutouts.length === 0) return [];
+    if (!isSolid || cutouts.length === 0 || fillSurface <= 0) return [];
     // Hidden cutouts are dropped for the reason the builder drops them
     // (#3568): a ghost for a shape the export will not cut is the exact
     // preview-vs-export divergence the hidden flag's epoch bump exists to
@@ -113,14 +118,14 @@ export function GhostCutouts() {
       const overrides = previewOverrides.get(c.id);
       return overrides ? { ...c, ...overrides } : c;
     });
-  }, [isSolid, cutouts, isGenerating, hasSelection, selectedIds, previewOverrides]);
+  }, [isSolid, cutouts, isGenerating, hasSelection, selectedIds, previewOverrides, fillSurface]);
 
   const shouldShow = cutoutsToRender.length > 0;
 
   const geometry = useMemo(() => {
     if (!shouldShow) return null;
-    return buildCutoutGeometry(cutoutsToRender, originX, originY, floorZ + wallHeight);
-  }, [shouldShow, cutoutsToRender, floorZ, wallHeight, originX, originY]);
+    return buildCutoutGeometry(cutoutsToRender, originX, originY, floorZ + fillSurface);
+  }, [shouldShow, cutoutsToRender, floorZ, fillSurface, originX, originY]);
 
   const material = useMemo(() => {
     if (!shouldShow) return null;

--- a/src/features/bin-designer/components/preview/GhostCutouts/ghostCutoutGeometry.test.ts
+++ b/src/features/bin-designer/components/preview/GhostCutouts/ghostCutoutGeometry.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import type { Cutout } from '@/features/bin-designer/types';
+import { buildCutoutGhostPositions } from './ghostCutoutGeometry';
+
+const cutout = (overrides: Partial<Cutout> = {}): Cutout => ({
+  id: 'c1',
+  shape: 'rectangle',
+  x: 10,
+  y: 10,
+  width: 20,
+  depth: 10,
+  cutDepth: 8,
+  rotation: 0,
+  cornerRadius: 0,
+  label: '',
+  groupId: null,
+  ...overrides,
+});
+
+interface Pt {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+const points = (positions: number[]): Pt[] => {
+  const out: Pt[] = [];
+  for (let i = 0; i < positions.length; i += 3) {
+    out.push({ x: positions[i], y: positions[i + 1], z: positions[i + 2] });
+  }
+  return out;
+};
+
+const SURFACE = 40;
+
+describe('buildCutoutGhostPositions', () => {
+  it('outlines a sharp rectangle at the surface and at its cut depth', () => {
+    const pts = points(buildCutoutGhostPositions([cutout()], 0, 0, SURFACE));
+    expect(pts.length).toBeGreaterThan(0);
+    const zs = new Set(pts.map((p) => p.z));
+    expect(zs).toEqual(new Set([SURFACE, SURFACE - 8]));
+    expect(Math.min(...pts.map((p) => p.x))).toBeCloseTo(10);
+    expect(Math.max(...pts.map((p) => p.x))).toBeCloseTo(30);
+    expect(Math.min(...pts.map((p) => p.y))).toBeCloseTo(10);
+    expect(Math.max(...pts.map((p) => p.y))).toBeCloseTo(20);
+  });
+
+  it('rounds the outline for a corner radius instead of drawing the sharp box', () => {
+    const pts = points(buildCutoutGhostPositions([cutout({ cornerRadius: 4 })], 0, 0, SURFACE));
+    // The sharp corner (10,10) is replaced by an arc that stays r*(1-cos45)
+    // inside it; no sampled point may sit on the box corner itself.
+    const atCorner = pts.some((p) => Math.abs(p.x - 10) < 1e-6 && Math.abs(p.y - 10) < 1e-6);
+    expect(atCorner).toBe(false);
+    // Arc midpoints still reach the straight edges' tangent lines.
+    expect(Math.min(...pts.map((p) => p.x))).toBeCloseTo(10);
+    expect(Math.min(...pts.map((p) => p.y))).toBeCloseTo(10);
+  });
+
+  it('draws a slot with fully rounded ends', () => {
+    const pts = points(buildCutoutGhostPositions([cutout({ shape: 'slot' })], 0, 0, SURFACE));
+    const atCorner = pts.some((p) => Math.abs(p.x - 10) < 1e-6 && Math.abs(p.y - 10) < 1e-6);
+    expect(atCorner).toBe(false);
+    expect(Math.min(...pts.map((p) => p.x))).toBeCloseTo(10);
+    expect(Math.max(...pts.map((p) => p.x))).toBeCloseTo(30);
+  });
+
+  it('stretches the opening and shifts the floor along the lean', () => {
+    const lean = 45;
+    const pts = points(
+      buildCutoutGhostPositions(
+        [cutout({ width: 10, depth: 10, cutDepth: 20, leanDeg: lean })],
+        0,
+        0,
+        SURFACE
+      )
+    );
+    const top = pts.filter((p) => p.z === SURFACE);
+    const bottom = pts.filter((p) => p.z !== SURFACE);
+    const cy = 15;
+    const sin45 = Math.SQRT1_2;
+
+    // Opening: footprint stretched by 1/cos(45°) about the center line.
+    expect(Math.max(...top.map((p) => p.y))).toBeCloseTo(cy + 5 * Math.SQRT2);
+    expect(Math.min(...top.map((p) => p.y))).toBeCloseTo(cy - 5 * Math.SQRT2);
+
+    // Floor: centered 20·sin(45°) further along +Y, foreshortened to 10·cos(45°).
+    const bys = bottom.map((p) => p.y);
+    const floorCenter = (Math.min(...bys) + Math.max(...bys)) / 2;
+    expect(floorCenter).toBeCloseTo(cy + 20 * sin45);
+    expect(Math.max(...bys) - Math.min(...bys)).toBeCloseTo(10 * sin45);
+
+    // Floor plane is tilted: deepest at the near edge, shallowest at the far.
+    const bzs = bottom.map((p) => p.z);
+    expect(Math.min(...bzs)).toBeCloseTo(SURFACE - 20 * sin45 - 5 * sin45);
+    expect(Math.max(...bzs)).toBeCloseTo(SURFACE - 20 * sin45 + 5 * sin45);
+  });
+
+  it('carries the lean direction with the plan rotation', () => {
+    const pts = points(
+      buildCutoutGhostPositions(
+        [cutout({ width: 10, depth: 10, cutDepth: 20, leanDeg: 45, rotation: 90 })],
+        0,
+        0,
+        SURFACE
+      )
+    );
+    const top = pts.filter((p) => p.z === SURFACE);
+    const bottom = pts.filter((p) => p.z !== SURFACE);
+    const centroid = (list: Pt[], axis: 'x' | 'y'): number =>
+      list.reduce((sum, p) => sum + p[axis], 0) / list.length;
+    // A clockwise 90° turn points the local +Y tilt along world +X.
+    expect(centroid(bottom, 'x')).toBeGreaterThan(centroid(top, 'x') + 10);
+    expect(centroid(bottom, 'y')).toBeCloseTo(centroid(top, 'y'));
+  });
+
+  it('ignores lean on shapes that cannot tilt', () => {
+    const pts = points(
+      buildCutoutGhostPositions([cutout({ shape: 'mesh', leanDeg: 45 })], 0, 0, SURFACE)
+    );
+    const zs = new Set(pts.map((p) => p.z));
+    expect(zs).toEqual(new Set([SURFACE, SURFACE - 8]));
+  });
+
+  it('expands a repeat master into every instance', () => {
+    const pts = points(
+      buildCutoutGhostPositions(
+        [
+          cutout({
+            width: 10,
+            depth: 10,
+            array: {
+              mode: 'grid',
+              cols: 2,
+              rows: 1,
+              pitchX: 25,
+              pitchY: 25,
+              count: 2,
+              radius: 20,
+              startAngle: 0,
+              rotateToCenter: false,
+            },
+          }),
+        ],
+        0,
+        0,
+        SURFACE
+      )
+    );
+    expect(Math.min(...pts.map((p) => p.x))).toBeCloseTo(10);
+    expect(Math.max(...pts.map((p) => p.x))).toBeCloseTo(45);
+  });
+
+  it('skips degenerate cutouts the worker would not cut', () => {
+    expect(buildCutoutGhostPositions([cutout({ cutDepth: 0 })], 0, 0, SURFACE)).toEqual([]);
+    expect(buildCutoutGhostPositions([cutout({ width: 0 })], 0, 0, SURFACE)).toEqual([]);
+  });
+});

--- a/src/features/bin-designer/components/preview/GhostCutouts/ghostCutoutGeometry.ts
+++ b/src/features/bin-designer/components/preview/GhostCutouts/ghostCutoutGeometry.ts
@@ -1,10 +1,27 @@
 /**
  * Shared outline geometry for cutout ghosts, in whatever frame the caller hands
  * it. Used by the bin's interior ghost and the lid's plate ghost.
+ *
+ * The wireframe follows the TOOL the worker will subtract, not the nominal
+ * box: each shape's real footprint (corner radius, stadium ends, polygon
+ * sides, path outline), every repeat instance, and the lean tilt. A leaned
+ * pocket is the straight tool rotated about its own mouth, so the opening ring
+ * stays in the surface plane stretched by 1/cos(lean) along the tilt axis, the
+ * floor ring rides the rotation, and the connecting edges run along the tool's
+ * slanted sides. Insertion clearance and the entry chamfer are deliberately
+ * not drawn — the editor shows nominal sizes everywhere (see
+ * `cutoutToPolygon`), and the chamfer only flares the top rim.
  */
 
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import type { Cutout } from '@/features/bin-designer/types';
+import { DEFAULT_POLYGON_SIDES, resolveCutoutLeanDeg } from '@/features/bin-designer/types';
+import { expandCutoutArray } from '@/shared/utils/cutoutArray';
+import {
+  clampPolygonSides,
+  regularPolygonPoints,
+  slotCornerRadius,
+} from '@/shared/utils/cutoutPolygon';
 import {
   flattenPath,
   MIN_PATH_POINTS,
@@ -13,12 +30,180 @@ import {
 /** Number of segments for circle approximation */
 const CIRCLE_SEGMENTS = 24;
 
+/** Segments per 90° corner arc of a rounded rectangle. */
+const CORNER_SEGMENTS = 6;
+
+/** Roughly how many top-to-floor edges to draw around each outline. */
+const VERTICAL_EDGE_TARGET = 8;
+
+interface OutlinePoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+function rectOutline(width: number, depth: number, cornerRadius: number): OutlinePoint[] {
+  const hw = width / 2;
+  const hd = depth / 2;
+  const r = Math.max(0, Math.min(cornerRadius, hw, hd));
+  if (r === 0) {
+    return [
+      { x: -hw, y: -hd },
+      { x: hw, y: -hd },
+      { x: hw, y: hd },
+      { x: -hw, y: hd },
+    ];
+  }
+  const points: OutlinePoint[] = [];
+  const arc = (acx: number, acy: number, startAngle: number): void => {
+    for (let i = 0; i <= CORNER_SEGMENTS; i++) {
+      const a = startAngle + (Math.PI / 2) * (i / CORNER_SEGMENTS);
+      points.push({ x: acx + r * Math.cos(a), y: acy + r * Math.sin(a) });
+    }
+  };
+  arc(-hw + r, -hd + r, Math.PI);
+  arc(hw - r, -hd + r, -Math.PI / 2);
+  arc(hw - r, hd - r, 0);
+  arc(-hw + r, hd - r, Math.PI / 2);
+  return points;
+}
+
+function ellipseOutline(rx: number, ry: number): OutlinePoint[] {
+  const points: OutlinePoint[] = [];
+  for (let i = 0; i < CIRCLE_SEGMENTS; i++) {
+    const a = (i / CIRCLE_SEGMENTS) * Math.PI * 2;
+    points.push({ x: rx * Math.cos(a), y: ry * Math.sin(a) });
+  }
+  return points;
+}
+
+/**
+ * Unrotated footprint outline relative to the cutout's box center — the frame
+ * the worker builds its tool in, so the lean and plan rotation applied on top
+ * compose exactly like `applyCutoutLean` + the tool's Z rotation.
+ *
+ * Paths flatten to their polyline (the worker's bbox fallback covers the
+ * degenerate ones); a mesh imprint keeps its footprint rectangle, the only
+ * outline cheaply known here.
+ */
+function localOutline(cutout: Cutout): OutlinePoint[] | null {
+  const { width, depth } = cutout;
+  switch (cutout.shape) {
+    case 'circle':
+      return ellipseOutline(width / 2, depth / 2);
+    case 'polygon': {
+      const pts = regularPolygonPoints(
+        clampPolygonSides(cutout.sides ?? DEFAULT_POLYGON_SIDES),
+        width,
+        depth
+      );
+      return pts.length >= 3 ? pts : rectOutline(width, depth, 0);
+    }
+    case 'slot':
+    case 'knifeSlot':
+      return rectOutline(width, depth, slotCornerRadius(width, depth));
+    case 'path': {
+      if (!cutout.path || cutout.path.length < MIN_PATH_POINTS) return null;
+      const flat = flattenPath(cutout.path);
+      if (flat.length < 3) return rectOutline(width, depth, 0);
+      const cx = cutout.x + width / 2;
+      const cy = cutout.y + depth / 2;
+      return flat.map((p) => ({ x: p.x - cx, y: p.y - cy }));
+    }
+    case 'rectangle':
+      return rectOutline(width, depth, cutout.cornerRadius);
+    case 'mesh':
+      return rectOutline(width, depth, 0);
+  }
+}
+
+function emitCutout(
+  positions: number[],
+  cutout: Cutout,
+  originX: number,
+  originY: number,
+  surfaceZ: number
+): void {
+  if (cutout.width <= 0 || cutout.depth <= 0 || cutout.cutDepth <= 0) return;
+  const outline = localOutline(cutout);
+  if (!outline) return;
+
+  const cx = originX + cutout.x + cutout.width / 2;
+  const cy = originY + cutout.y + cutout.depth / 2;
+  const lean = (resolveCutoutLeanDeg(cutout) * Math.PI) / 180;
+  const sinL = Math.sin(lean);
+  const cosL = Math.cos(lean);
+  // Stored rotation is clockwise-positive; the CCW math below takes the
+  // negated angle, same as every renderer and the worker's tool rotation.
+  const rad = (-cutout.rotation * Math.PI) / 180;
+  const cosR = Math.cos(rad);
+  const sinR = Math.sin(rad);
+  const depth = cutout.cutDepth;
+
+  const n = outline.length;
+  const top: number[] = [];
+  const bottom: number[] = [];
+  for (const p of outline) {
+    // Opening ring: the tilted prism crossed with the mouth plane is the
+    // footprint stretched by 1/cos(lean) along the local tilt (+Y) axis.
+    const topY = p.y / cosL;
+    // Floor ring: the prism's bottom cap rotated about the mouth — shifted
+    // along the tilt axis and itself tilted out of horizontal.
+    const botY = p.y * cosL + depth * sinL;
+    const botZ = surfaceZ + p.y * sinL - depth * cosL;
+    top.push(cx + p.x * cosR - topY * sinR, cy + p.x * sinR + topY * cosR, surfaceZ);
+    bottom.push(cx + p.x * cosR - botY * sinR, cy + p.x * sinR + botY * cosR, botZ);
+  }
+
+  const seg = (ring: number[], i: number, j: number): void => {
+    positions.push(
+      ring[i * 3],
+      ring[i * 3 + 1],
+      ring[i * 3 + 2],
+      ring[j * 3],
+      ring[j * 3 + 1],
+      ring[j * 3 + 2]
+    );
+  };
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    seg(top, i, j);
+    seg(bottom, i, j);
+  }
+  // Slanted side edges connecting the two rings, a handful around the outline.
+  const step = Math.max(1, Math.round(n / VERTICAL_EDGE_TARGET));
+  for (let i = 0; i < n; i += step) {
+    positions.push(top[i * 3], top[i * 3 + 1], top[i * 3 + 2]);
+    positions.push(bottom[i * 3], bottom[i * 3 + 1], bottom[i * 3 + 2]);
+  }
+}
+
+/**
+ * Raw segment endpoints (x,y,z triples, two per segment) for every cutout's
+ * ghost. A repeat master expands to every instance, since the worker cuts them
+ * all. Exposed apart from the geometry so the placement math is testable
+ * without a GL context.
+ */
+export function buildCutoutGhostPositions(
+  cutoutsToRender: readonly Cutout[],
+  originX: number,
+  originY: number,
+  surfaceZ: number
+): number[] {
+  const positions: number[] = [];
+  for (const master of cutoutsToRender) {
+    for (const cutout of expandCutoutArray(master)) {
+      emitCutout(positions, cutout, originX, originY, surfaceZ);
+    }
+  }
+  return positions;
+}
+
 /**
  * Line segments outlining each cutout at the surface it is cut from and again at
- * its own depth, plus verticals between the two.
+ * its own depth, plus edges between the two.
  *
  * Takes the surface PLANE rather than a floor and a wall height, because the two
- * hosts arrive at it differently: a bin cutout starts at `floorZ + wallHeight`,
+ * hosts arrive at it differently: a bin cutout starts at the solid fill surface,
  * a lid cutout at the plate's own host face. Everything below that is identical,
  * which is the reason this is shared rather than reimplemented per host.
  */
@@ -28,110 +213,7 @@ export function buildCutoutGeometry(
   originY: number,
   surfaceZ: number
 ): LineSegmentsGeometry | null {
-  const positions: number[] = [];
-
-  for (const cutout of cutoutsToRender) {
-    const cx = originX + cutout.x + cutout.width / 2;
-    const cy = originY + cutout.y + cutout.depth / 2;
-    const topZ = surfaceZ;
-    const bottomZ = surfaceZ - cutout.cutDepth;
-
-    if (cutout.shape === 'circle') {
-      const rx = cutout.width / 2;
-      const ry = cutout.depth / 2;
-      const rad = (-cutout.rotation * Math.PI) / 180;
-      const cosR = Math.cos(rad);
-      const sinR = Math.sin(rad);
-      for (let z = 0; z < 2; z++) {
-        const zVal = z === 0 ? topZ : bottomZ;
-        for (let i = 0; i < CIRCLE_SEGMENTS; i++) {
-          const a1 = (i / CIRCLE_SEGMENTS) * Math.PI * 2;
-          const a2 = ((i + 1) / CIRCLE_SEGMENTS) * Math.PI * 2;
-          // Parametric ellipse points, then rotate
-          const ex1 = Math.cos(a1) * rx;
-          const ey1 = Math.sin(a1) * ry;
-          const ex2 = Math.cos(a2) * rx;
-          const ey2 = Math.sin(a2) * ry;
-          positions.push(
-            cx + ex1 * cosR - ey1 * sinR,
-            cy + ex1 * sinR + ey1 * cosR,
-            zVal,
-            cx + ex2 * cosR - ey2 * sinR,
-            cy + ex2 * sinR + ey2 * cosR,
-            zVal
-          );
-        }
-      }
-      // Vertical lines connecting top and bottom ellipses (4 cardinal points)
-      for (let i = 0; i < 4; i++) {
-        const a = (i / 4) * Math.PI * 2;
-        const ex = Math.cos(a) * rx;
-        const ey = Math.sin(a) * ry;
-        const px = cx + ex * cosR - ey * sinR;
-        const py = cy + ex * sinR + ey * cosR;
-        positions.push(px, py, topZ, px, py, bottomZ);
-      }
-    } else if (cutout.shape === 'path' && cutout.path && cutout.path.length >= MIN_PATH_POINTS) {
-      // Flatten bezier path to polyline and render actual shape outline
-      const flat = flattenPath(cutout.path);
-      const n = flat.length;
-      if (n >= 3) {
-        // Path points are in bin-local absolute coords — offset by origin
-        for (let z = 0; z < 2; z++) {
-          const zVal = z === 0 ? topZ : bottomZ;
-          for (let i = 0; i < n; i++) {
-            const p1 = flat[i];
-            const p2 = flat[(i + 1) % n];
-            positions.push(
-              originX + p1.x,
-              originY + p1.y,
-              zVal,
-              originX + p2.x,
-              originY + p2.y,
-              zVal
-            );
-          }
-        }
-        // Vertical lines at every few vertices to show depth
-        const vertStep = Math.max(1, Math.floor(n / 8));
-        for (let i = 0; i < n; i += vertStep) {
-          const p = flat[i];
-          positions.push(originX + p.x, originY + p.y, topZ, originX + p.x, originY + p.y, bottomZ);
-        }
-      }
-    } else {
-      const hw = cutout.width / 2;
-      const hd = cutout.depth / 2;
-      // Unrotated corners relative to center
-      const rawCorners: [number, number][] = [
-        [-hw, -hd],
-        [hw, -hd],
-        [hw, hd],
-        [-hw, hd],
-      ];
-      // Apply rotation around center
-      const rad = (-cutout.rotation * Math.PI) / 180;
-      const cosR = Math.cos(rad);
-      const sinR = Math.sin(rad);
-      const corners = rawCorners.map(([rx, ry]) => [
-        cx + rx * cosR - ry * sinR,
-        cy + rx * sinR + ry * cosR,
-      ]);
-
-      for (let z = 0; z < 2; z++) {
-        const zVal = z === 0 ? topZ : bottomZ;
-        for (let i = 0; i < 4; i++) {
-          const [x1, y1] = corners[i];
-          const [x2, y2] = corners[(i + 1) % 4];
-          positions.push(x1, y1, zVal, x2, y2, zVal);
-        }
-      }
-      for (const [px, py] of corners) {
-        positions.push(px, py, topZ, px, py, bottomZ);
-      }
-    }
-  }
-
+  const positions = buildCutoutGhostPositions(cutoutsToRender, originX, originY, surfaceZ);
   if (positions.length === 0) return null;
 
   const geo = new LineSegmentsGeometry();

--- a/src/features/bin-designer/components/preview/GhostLidCutouts/GhostLidCutouts.tsx
+++ b/src/features/bin-designer/components/preview/GhostLidCutouts/GhostLidCutouts.tsx
@@ -85,10 +85,12 @@ export function GhostLidCutouts({ lidOffsetMm }: GhostLidCutoutsProps) {
     if (result.length === 0) return result;
     // The depth the WORKER will use, not the stored one: a lid cutout always
     // spans the plate, so a ghost drawn at `cutDepth` would promise a pocket.
+    // Lean is zeroed for the same reason — the lid builder bores straight
+    // through and strips it, so a tilted ghost would promise a tilted hole.
     const host = lidCutoutHostFace(params);
     return result.map((c) => {
       const overrides = previewOverrides.get(c.id);
-      return { ...c, ...overrides, cutDepth: host.thickness };
+      return { ...c, ...overrides, cutDepth: host.thickness, leanDeg: 0 };
     });
   }, [window, cutouts, isGenerating, hasSelection, selectedIds, previewOverrides, params]);
 


### PR DESCRIPTION
## Summary

The yellow ghost in the 3D preview drew every non-circle cutout as a sharp vertical box, so it stopped matching the real cut as soon as the shape had any character:

- **Corner radius / slot ends / polygon sides** were ignored — a pill-shaped slot got a sharp rectangle.
- **Lean** kept the ghost upright while the actual pocket tilts about its opening.
- **Repeats** drew only the master, though the worker cuts every instance (the knife ghost already expands arrays).
- **Fill top offset** was ignored, so with a lowered fill surface the ghost floated at the rim.

The outline is now built from the tool the worker subtracts. Each shape samples its real footprint (shared `cutoutPolygon` helpers + flattened paths, in the same box-center frame the worker builds tools in), and the lean is applied exactly as `applyCutoutLean` does — rotate about the mouth — which gives:

- the opening ring in the surface plane, stretched by `1/cos(lean)` along the tilt axis (what the cut opening really measures),
- the floor ring shifted `cutDepth·sin(lean)` along the tilt and itself tilted out of horizontal,
- side edges running along the tool's slanted walls.

Plan rotation composes on top at `-rotation`, matching the renderers and the worker. Repeat masters expand through `expandCutoutArray`, and the bin host passes `wallHeight − cutoutConfig.topOffset` as the surface (skipping entirely when no fill remains, as `buildCutoutCuts` does). The lid ghost zeroes lean the same way the lid builder's `through()` does, since lid holes bore straight through.

Insertion clearance and the entry chamfer stay undrawn, matching the editor-wide nominal-size policy documented on `cutoutToPolygon`.

## Testing

- New `ghostCutoutGeometry` unit tests assert the emitted positions directly: rounded corners and slot ends replace the sharp box, the 45° lean's opening stretch / floor shift / floor tilt match the closed-form values, rotation carries the lean direction, non-tilting shapes ignore `leanDeg`, repeats expand, and degenerate cutouts are skipped like the worker skips them.
- Full bin-designer suite (5416 tests) green.

Fixes #3797

https://claude.ai/code/session_01HZ4UfQbGHsTK1dGag9Bh6w

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

