### PR TITLE
fix(designer): sample the true ellipse in the pathfinder preview

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/booleanGeometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/booleanGeometry.test.ts
@@ -81,6 +81,29 @@ describe('cutoutToPolygon', () => {
     expect(polygon![0].length).toBeGreaterThan(20);
   });
 
+  it('samples the true ellipse for a circle with independent depth', () => {
+    const ring = cutoutToPolygon(baseCutout({ shape: 'circle', width: 20, depth: 10 }))![0];
+    const xs = ring.map(([x]) => x);
+    const ys = ring.map(([, y]) => y);
+    // The worker cuts the full 20x10 ellipse; a collapsed circle would span
+    // only the 10mm short axis in X.
+    expect(Math.max(...xs) - Math.min(...xs)).toBeCloseTo(20, 1);
+    expect(Math.max(...ys) - Math.min(...ys)).toBeCloseTo(10, 1);
+    // Inscribed 64-gon of a rx=10, ry=5 ellipse: within a percent of pi*rx*ry.
+    expect(polygonArea(ring)).toBeGreaterThan(Math.PI * 50 * 0.99);
+    expect(polygonArea(ring)).toBeLessThan(Math.PI * 50 * 1.001);
+  });
+
+  it('turns the ellipse with the cutout rotation', () => {
+    const ring = cutoutToPolygon(
+      baseCutout({ shape: 'circle', width: 20, depth: 10, rotation: 90 })
+    )![0];
+    const xs = ring.map(([x]) => x);
+    const ys = ring.map(([, y]) => y);
+    expect(Math.max(...xs) - Math.min(...xs)).toBeCloseTo(10, 1);
+    expect(Math.max(...ys) - Math.min(...ys)).toBeCloseTo(20, 1);
+  });
+
   // `Cutout.rotation` is clockwise-positive (CutoutShapeMesh renders at
   // `-rotation`; cutoutBuilder extrudes at `rotate(shape, -rotation)`). An
   // outline rotated the other way mirrors every non-symmetric shape, so the

--- a/src/features/bin-designer/components/panel/CutoutsSection/booleanGeometry.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/booleanGeometry.ts
@@ -98,18 +98,21 @@ function rectangleRing(c: Cutout): Ring {
   return ring;
 }
 
-/** Build the outline ring for a circle cutout (width = diameter). */
+/**
+ * Build the outline ring for a circle cutout (width/depth = the two diameters).
+ * Circles carry independent width and depth and the worker cuts the true
+ * ellipse (`ellipsePolygonDrawing`), so the preview must sample the same one or
+ * a grouped ellipse's boolean preview diverges from the mesh along its long axis.
+ */
 function circleRing(c: Cutout): Ring {
   const cx = c.x + c.width / 2;
   const cy = c.y + c.depth / 2;
-  // Circle's radius collapses to half the smaller bbox dim so non-square
-  // bounding rects (which only happen via resize bugs) still produce a
-  // valid loop instead of an ellipse polygon-clipping can choke on.
-  const r = Math.min(c.width, c.depth) / 2;
+  const rx = c.width / 2;
+  const ry = c.depth / 2;
   const ring: Ring = [];
   for (let i = 0; i < CIRCLE_SEGMENTS; i++) {
     const a = (i / CIRCLE_SEGMENTS) * Math.PI * 2;
-    ring.push(rotatePair(cx + r * Math.cos(a), cy + r * Math.sin(a), cx, cy, c.rotation));
+    ring.push(rotatePair(cx + rx * Math.cos(a), cy + ry * Math.sin(a), cx, cy, c.rotation));
   }
   return ring;
 }


### PR DESCRIPTION
## Summary

`circleRing` in `booleanGeometry.ts` collapsed a circle cutout's ring to `min(width, depth) / 2`, guarded by a comment claiming non-square circle boxes "only happen via resize bugs". Circles have carried independent width and depth since ellipses became a real shape (`getEffectiveDepth`), and the worker cuts the full ellipse (`ellipsePolygonDrawing(w/2, d/2)`), as do the shape mesh and the 3D ghost.

So a grouped ellipse participated in Pathfinder previews as a circle: union/subtract/intersect/exclude previews and the empty-result check disagreed with the generated mesh whenever the outcome depended on the ellipse's long axis.

The ring now samples the same `rx = width/2`, `ry = depth/2` ellipse the worker extrudes (still a 64-gon, so nothing changes for polygon-clipping), rotated through the existing clockwise-correct `rotatePair`.

## Testing

- New tests assert the ring spans both diameters, its area is within a percent of `π·rx·ry`, and rotation turns the ellipse.
- Full bin-designer suite green.

Fixes #3806

https://claude.ai/code/session_01HZ4UfQbGHsTK1dGag9Bh6w

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

