### PR TITLE
fix(designer): rotate validation silhouettes clockwise like the renderer

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutOutline.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutOutline.test.ts
@@ -111,6 +111,22 @@ describe('getCutoutOutline', () => {
     expect(ringArea(rings?.[0] ?? [])).toBeCloseTo(900);
   });
 
+  it('rotates clockwise, matching the renderer and the worker', () => {
+    // A right triangle with its square corner at bottom-left (0,0). Stored
+    // rotation is clockwise-positive (PathShapeMesh renders at -rotation), so
+    // 90° carries that corner to the TOP-LEFT (0,10); the CCW mirror would put
+    // it bottom-right instead, and a mask check made there validates a shape
+    // the cut does not match.
+    const path = [corner(0, 0), corner(10, 0), corner(0, 10)];
+    const ring = getCutoutOutline(makeCutout({ shape: 'path', path, rotation: 90 }))?.[0] ?? [];
+    const has = (x: number, y: number) =>
+      ring.some((p) => Math.abs(p.x - x) < 1e-6 && Math.abs(p.y - y) < 1e-6);
+    expect(has(0, 10)).toBe(true);
+    expect(has(0, 0)).toBe(true);
+    expect(has(10, 10)).toBe(true);
+    expect(has(10, 0)).toBe(false);
+  });
+
   it('rotates a path about its own vertex bounds, not the width/depth box', () => {
     // x/y/width/depth deliberately disagree with the path — the renderer pivots
     // on the vertex bounds, so the outline must too.

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutOutline.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutOutline.ts
@@ -50,7 +50,11 @@ function rotateRing(
   degrees: number
 ): Point2D[] {
   if (!degrees) return [...points];
-  return points.map((p) => rotatePoint(p.x, p.y, cx, cy, degrees));
+  // Stored rotation is clockwise-positive and `rotatePoint` is CCW, so the
+  // ring takes the negated angle — the convention of `rotatePair`
+  // (booleanGeometry) and the worker's `rotate(shape, -rotation)`. Rotating
+  // CCW would validate a mirror image of every asymmetric silhouette.
+  return points.map((p) => rotatePoint(p.x, p.y, cx, cy, -degrees));
 }
 
 function ellipseRing(cx: number, cy: number, rx: number, ry: number): Point2D[] {

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -25,7 +25,7 @@ import {
   flipSelectionHorizontal,
   flipSelectionVertical,
 } from './geometry';
-import { rectFitsInMask, cutoutFitsInMask } from './maskFit';
+import { rectFitsInMask, cutoutFitsInMask, getCutoutBounds } from './maskFit';
 import type { CellMask } from '@/shared/utils/cellMask';
 
 const createCutout = (overrides: Partial<Cutout> = {}): Cutout => ({
@@ -1113,6 +1113,30 @@ describe('geometry', () => {
     it('rejects a rect with negative origin', () => {
       const fullMask = makeMask([[1]]);
       expect(rectFitsInMask(fullMask, -5, 0, 10, 10, CELL)).toBe(false);
+    });
+  });
+
+  describe('getCutoutBounds', () => {
+    it('measures a rotated path clockwise, matching the renderer', () => {
+      // Asymmetric right triangle, vertex bounds [0..20]x[0..10], center (10,5).
+      // Stored rotation is clockwise-positive, so at 45° the wide leg swings
+      // DOWN: maxX = 10 + 5·sin45, maxY = 5 + 15·sin45. The CCW mirror would
+      // read maxX = 10 + 15·sin45 instead and misplace the footprint.
+      const tri = createCutout({
+        shape: 'path',
+        rotation: 45,
+        path: [
+          { x: 0, y: 0, handleIn: null, handleOut: null, symmetric: false },
+          { x: 20, y: 0, handleIn: null, handleOut: null, symmetric: false },
+          { x: 0, y: 10, handleIn: null, handleOut: null, symmetric: false },
+        ],
+      });
+      const b = getCutoutBounds(tri);
+      const s = Math.SQRT1_2;
+      expect(b.maxX).toBeCloseTo(10 + 5 * s, 4);
+      expect(b.maxY).toBeCloseTo(5 + 15 * s, 4);
+      expect(b.minX).toBeCloseTo(10 - 15 * s, 4);
+      expect(b.minY).toBeCloseTo(5 - 15 * s, 4);
     });
   });
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/maskFit.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/maskFit.ts
@@ -42,7 +42,11 @@ export function getCutoutBounds(cutout: Cutout): Bounds {
   let maxX = -Infinity;
   let maxY = -Infinity;
   for (const p of flattenPath(cutout.path)) {
-    const r = rotatePoint(p.x, p.y, cx, cy, cutout.rotation);
+    // Stored rotation is clockwise-positive and `rotatePoint` is CCW — the
+    // negated angle matches the renderer (`PathShapeMesh` at `-rotation`) and
+    // the worker's `rotate(shape, -rotation)`; the un-negated angle measures a
+    // mirror image of where the path actually sits.
+    const r = rotatePoint(p.x, p.y, cx, cy, -cutout.rotation);
     if (r.x < minX) minX = r.x;
     if (r.y < minY) minY = r.y;
     if (r.x > maxX) maxX = r.x;


### PR DESCRIPTION
## Summary

`Cutout.rotation` is clockwise-positive: `CutoutShapeMesh`/`PathShapeMesh` render at `-rotation`, `booleanGeometry.rotatePair` negates it explicitly, and the worker extrudes tools at `rotate(shape, -rotation)`. The containment path rotated the other way: `cutoutOutline.rotateRing` and `maskFit`'s rotated-path bounds fed the un-negated angle to the CCW `rotatePoint`.

For mirror-symmetric shapes the error is invisible, and the existing tests rotate symmetric shapes (a square path, a plain bar), so direction was never pinned. For asymmetric silhouettes — bezier paths and mesh-imprint outlines — `cutoutFitsInMask`, `getCutoutBounds`, and everything built on them (off-board detection, masked-board placement validation) judged a mirror image of the real cut: an L-shaped path rotated 90° could validate where the actual cut overhangs a mask notch, or get flagged where it fits.

Both sites now rotate through the negated angle, with comments naming the convention. `groupRotateHandler` was audited too and is correct as is (its CCW positional delta pairs with a negative stored-rotation delta).

## Testing

- New direction-pinning tests use asymmetric shapes: a right-triangle path rotated 90° must land its square corner top-left (clockwise), and a rotated asymmetric path's `getCutoutBounds` must match the closed-form clockwise bounds — the CCW mirror produces distinctly different values in both.
- Existing symmetric-shape rotation tests pass unchanged, as they must.
- Full bin-designer suite (5431 tests) and typecheck green.

Fixes #3805

https://claude.ai/code/session_01HZ4UfQbGHsTK1dGag9Bh6w

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

