### PR TITLE
fix(designer): measure multi-select transforms by visual bounds

### DIFF
--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import type { Cutout } from '@/features/bin-designer/types';
 import {
+  cutoutPatternBounds,
   expandSelectionToGroups,
+  selectionVisualBounds,
   toArrangeUnits,
   unitsBounds,
   unitWidth,
@@ -131,6 +133,49 @@ describe('toArrangeUnits', () => {
       cutout('d', { groupId: 'g1' }),
     ]);
     expect(units.map((u) => u.members[0].id)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('selectionVisualBounds', () => {
+  it('spans rotated silhouettes and repeat instances', () => {
+    const bounds = selectionVisualBounds([
+      cutout('a', { x: 0, y: 5, width: 20, depth: 10, rotation: 90 }),
+      cutout('b', {
+        x: 30,
+        y: 0,
+        width: 10,
+        depth: 10,
+        array: {
+          mode: 'grid',
+          cols: 2,
+          rows: 1,
+          pitchX: 20,
+          pitchY: 20,
+          count: 2,
+          radius: 20,
+          startAngle: 0,
+          rotateToCenter: false,
+        },
+      }),
+    ]);
+    // a's turned bar spans [5..15] x [0..20]; b's pattern spans [30..60].
+    expect(bounds.minX).toBeCloseTo(5);
+    expect(bounds.minY).toBeCloseTo(0);
+    expect(bounds.maxX).toBeCloseTo(60);
+    expect(bounds.maxY).toBeCloseTo(20);
+  });
+
+  it('matches the plain box for an unrotated, unrepeated cutout', () => {
+    expect(cutoutPatternBounds(cutout('a', { x: 3, y: 4 }))).toEqual({
+      minX: 3,
+      minY: 4,
+      maxX: 13,
+      maxY: 14,
+    });
+  });
+
+  it('returns a zero box for an empty selection', () => {
+    expect(selectionVisualBounds([])).toEqual({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
   });
 });
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutGroups.ts
@@ -41,25 +41,51 @@ export interface ArrangeUnit {
   readonly locked: boolean;
 }
 
-function makeUnit(members: readonly Cutout[]): ArrangeUnit {
+/**
+ * A cutout's visual footprint: the rotated AABB spanning every repeat
+ * instance (just the cutout's own rotated box when there is no array).
+ */
+export function cutoutPatternBounds(cutout: Cutout): Bounds {
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
-  let locked = false;
-
-  for (const member of members) {
-    for (const instance of expandCutoutArray(member)) {
-      const b = getRotatedBounds(instance);
-      minX = Math.min(minX, b.minX);
-      minY = Math.min(minY, b.minY);
-      maxX = Math.max(maxX, b.maxX);
-      maxY = Math.max(maxY, b.maxY);
-    }
-    if (member.locked) locked = true;
+  for (const instance of expandCutoutArray(cutout)) {
+    const b = getRotatedBounds(instance);
+    minX = Math.min(minX, b.minX);
+    minY = Math.min(minY, b.minY);
+    maxX = Math.max(maxX, b.maxX);
+    maxY = Math.max(maxY, b.maxY);
   }
+  return { minX, minY, maxX, maxY };
+}
 
-  return { members, bounds: { minX, minY, maxX, maxY }, locked };
+/**
+ * Visual bounds of a whole selection — what the on-screen silhouettes span,
+ * repeat instances and rotation included. The box every multi-select
+ * transform (group box, flip mirror, rotate/scale pivot) must measure, or the
+ * operation centers on a box the user cannot see.
+ */
+export function selectionVisualBounds(cutouts: readonly Cutout[]): Bounds {
+  if (cutouts.length === 0) return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const cutout of cutouts) {
+    const b = cutoutPatternBounds(cutout);
+    minX = Math.min(minX, b.minX);
+    minY = Math.min(minY, b.minY);
+    maxX = Math.max(maxX, b.maxX);
+    maxY = Math.max(maxY, b.maxY);
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+function makeUnit(members: readonly Cutout[]): ArrangeUnit {
+  const bounds = selectionVisualBounds(members);
+  const locked = members.some((member) => member.locked);
+  return { members, bounds, locked };
 }
 
 /**

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometry.test.ts
@@ -909,6 +909,48 @@ describe('geometry', () => {
       expect(updates.get('b')).toEqual({ rotation: 0, x: 0 });
     });
 
+    it('mirrors a rotated member about its visual silhouette, not its unrotated box', () => {
+      // A 20x10 bar turned 90° occupies [5..15] on X; its unrotated box [0..20]
+      // would pull the mirror center left and land the pair overlapping.
+      const a = createCutout({ id: 'a', x: 0, y: 5, width: 20, depth: 10, rotation: 90 });
+      const b = createCutout({ id: 'b', x: 30, y: 5, width: 10, depth: 10, rotation: 0 });
+      const updates = flipSelectionHorizontal([a, b]);
+      // Visual bounds: [5..40], center 22.5. a's silhouette [5..15] mirrors to
+      // [30..40] (x moves by 25); b's [30..40] mirrors to [5..15].
+      expect(updates.get('a')?.rotation).toBe(270);
+      expect(updates.get('a')?.x).toBeCloseTo(25);
+      expect(updates.get('b')?.rotation).toBe(0);
+      expect(updates.get('b')?.x).toBeCloseTo(5);
+    });
+
+    it('mirrors a repeat by its whole pattern extent', () => {
+      const master = createCutout({
+        id: 'a',
+        x: 0,
+        y: 0,
+        width: 10,
+        depth: 10,
+        rotation: 0,
+        array: {
+          mode: 'grid',
+          cols: 2,
+          rows: 1,
+          pitchX: 20,
+          pitchY: 20,
+          count: 2,
+          radius: 20,
+          startAngle: 0,
+          rotateToCenter: false,
+        },
+      });
+      const b = createCutout({ id: 'b', x: 50, y: 0, width: 10, depth: 10, rotation: 0 });
+      const updates = flipSelectionHorizontal([master, b]);
+      // Visual bounds: pattern [0..30] plus b [50..60] → center 30. The whole
+      // pattern mirrors to [30..60] (master to 30); b mirrors to [0..10].
+      expect(updates.get('a')).toEqual({ rotation: 0, x: 30 });
+      expect(updates.get('b')).toEqual({ rotation: 0, x: 0 });
+    });
+
     it('translates path points to match group-mirrored position', () => {
       const pathA = createCutout({
         id: 'a',

--- a/src/features/bin-designer/components/panel/CutoutsSection/geometryFlips.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/geometryFlips.ts
@@ -10,7 +10,7 @@
 
 import type { Cutout, PathPoint } from '@/features/bin-designer/types';
 import { getPathBounds } from './pathGeometry';
-import { computeBounds } from './geometryCore';
+import { cutoutPatternBounds, selectionVisualBounds } from './cutoutGroups';
 
 /**
  * Mirror a path point's X coordinate around a center, negating X handle components.
@@ -99,11 +99,15 @@ export function flipSelectionHorizontal(
 ): ReadonlyMap<string, Partial<Cutout>> {
   const updates = new Map<string, Partial<Cutout>>();
   if (cutouts.length > 1) {
-    const bounds = computeBounds(cutouts);
+    // Mirror each cutout's VISUAL box (rotated silhouette, repeat instances
+    // included) about the selection's visual center — the unrotated x/width
+    // box drifts a rotated member and parks a repeat's pattern unmirrored.
+    const bounds = selectionVisualBounds(cutouts);
     const cx = (bounds.minX + bounds.maxX) / 2;
     for (const cutout of cutouts) {
       const patch = flipCutoutHorizontal(cutout);
-      const mirroredX = 2 * cx - (cutout.x + cutout.width);
+      const b = cutoutPatternBounds(cutout);
+      const mirroredX = cutout.x + (2 * cx - b.maxX - b.minX);
       if (cutout.shape === 'path' && patch.path) {
         // Path points are absolute — translate them to match the group-mirrored position
         const dx = mirroredX - (patch.x ?? cutout.x);
@@ -135,11 +139,13 @@ export function flipSelectionVertical(
 ): ReadonlyMap<string, Partial<Cutout>> {
   const updates = new Map<string, Partial<Cutout>>();
   if (cutouts.length > 1) {
-    const bounds = computeBounds(cutouts);
+    // Same visual-box mirroring as the horizontal flip, on the Y axis.
+    const bounds = selectionVisualBounds(cutouts);
     const cy = (bounds.minY + bounds.maxY) / 2;
     for (const cutout of cutouts) {
       const patch = flipCutoutVertical(cutout);
-      const mirroredY = 2 * cy - (cutout.y + cutout.depth);
+      const b = cutoutPatternBounds(cutout);
+      const mirroredY = cutout.y + (2 * cy - b.maxY - b.minY);
       if (cutout.shape === 'path' && patch.path) {
         // Path points are absolute — translate them to match the group-mirrored position
         const dy = mirroredY - (patch.y ?? cutout.y);

--- a/src/features/bin-designer/components/panel/CutoutsSection/handlers/keyboardHandler.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/handlers/keyboardHandler.ts
@@ -6,12 +6,8 @@
  */
 
 import type { Cutout } from '@/features/bin-designer/types';
-import {
-  computeBounds,
-  rotatePoint,
-  flipSelectionHorizontal,
-  flipSelectionVertical,
-} from '../geometry';
+import { rotatePoint, flipSelectionHorizontal, flipSelectionVertical } from '../geometry';
+import { selectionVisualBounds } from '../cutoutGroups';
 import type { InteractionMode } from '../useCutoutInteraction';
 import { handleVertexEditKeyDown } from './pathEditHandler';
 import type { VertexEditMode, SegmentHoverInfo } from './pathEditHandler';
@@ -378,7 +374,7 @@ function handleRotate90(ctx: KeyboardHandlerContext): void {
     // Rigid group rotation: member centers travel clockwise (rotatePoint by
     // -90) to match the clockwise on-screen turn a +90 stored rotation gives.
     const selectedCutouts = ctx.cutouts.filter((c) => ctx.selection.has(c.id));
-    const bounds = computeBounds(selectedCutouts);
+    const bounds = selectionVisualBounds(selectedCutouts);
     const cx = (bounds.minX + bounds.maxX) / 2;
     const cy = (bounds.minY + bounds.maxY) / 2;
     const updates = new Map<string, Partial<Cutout>>();

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutCanvas3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutCanvas3D.tsx
@@ -23,7 +23,7 @@ import type { FitCue } from '../cutoutSectionVisibility';
 import type { SegmentHoverInfo } from '../handlers';
 import type { RulerMeasurement } from '../handlers/rulerHandler';
 import type { AlignmentGuide } from '../geometry';
-import { computeBounds } from '../geometry';
+import { selectionVisualBounds } from '../cutoutGroups';
 import { SceneContent } from './SceneContent';
 
 /** Read the user's selected bin preview color */
@@ -261,7 +261,7 @@ export function CutoutCanvas3D({
     if (selection.size < 2 || isDragging || isResizing || mode.type === 'rotating') return null;
     const selectedCutouts = cutouts.filter((c) => selection.has(c.id));
     if (selectedCutouts.length < 2) return null;
-    const bounds = computeBounds(selectedCutouts);
+    const bounds = selectionVisualBounds(selectedCutouts);
     return {
       id: '__group__' as const,
       shape: 'rectangle' as const,

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutTransformStarters.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutTransformStarters.ts
@@ -15,7 +15,7 @@ import type { Cutout } from '@/features/bin-designer/types';
 import { MAX_LID_CUTOUTS } from '@/features/bin-designer/types';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
-import { computeBounds } from './geometry';
+import { selectionVisualBounds } from './cutoutGroups';
 import { addClonedCutouts } from './cutoutHelpers';
 import type { InteractionMode, ResizeHandle } from './cutoutInteractionTypes';
 
@@ -169,7 +169,7 @@ export function useCutoutTransformStarters({
     (startAngle: number) => {
       const selectedCutouts = cutouts.filter((c) => selection.has(c.id));
       if (selectedCutouts.length < 2) return;
-      const bounds = computeBounds(selectedCutouts);
+      const bounds = selectionVisualBounds(selectedCutouts);
       const center = {
         x: (bounds.minX + bounds.maxX) / 2,
         y: (bounds.minY + bounds.maxY) / 2,
@@ -188,7 +188,7 @@ export function useCutoutTransformStarters({
     (mmX: number, mmY: number) => {
       const selectedCutouts = cutouts.filter((c) => selection.has(c.id));
       if (selectedCutouts.length < 2) return;
-      const bounds = computeBounds(selectedCutouts);
+      const bounds = selectionVisualBounds(selectedCutouts);
       const center = {
         x: (bounds.minX + bounds.maxX) / 2,
         y: (bounds.minY + bounds.maxY) / 2,


### PR DESCRIPTION
## Summary

The multi-select group box, the flip mirror centers, the group rotate/scale pivots, and the keyboard rotate-90 pivot all measured the selection with `computeBounds` — unrotated per-cutout boxes, no repeat expansion — so every one of them centered on a box the user cannot see. A selection containing a rotated bar or a repeat master got a group outline that missed the silhouette, flips that drifted members, and rotations about an off-center pivot.

- `cutoutGroups` now exports the two primitives the arrange units already computed internally: `cutoutPatternBounds` (one cutout's rotated silhouette spanning every repeat instance) and `selectionVisualBounds` (their union); `makeUnit` reuses them.
- The group bounding box (`CutoutCanvas3D`), group rotate/scale starters, and rotate-90 pivot measure the selection with `selectionVisualBounds`.
- Flips mirror each cutout's visual box about the selection's visual center: a rotated member lands where its silhouette mirrors (its flipped silhouette has the same AABB extents, so the translation is exact), and a repeat's whole pattern moves to the mirrored span instead of re-growing +X/+Y over its neighbors. The plain unrotated case reduces to the previous arithmetic exactly, and the existing flip tests pass unchanged.

The remaining `computeBounds` users (pathfinder helpers, drag guides, group-drag clamping) are untouched — they feed interactions where the unrotated box is either correct or a separate question.

## Testing

- New tests: selection visual bounds spanning a rotated bar plus a repeat pattern; a flip that mirrors a 90°-turned bar to its silhouette's mirror (the unrotated box would land it overlapping); a flip that carries a repeat's whole pattern to the other side.
- Full bin-designer suite (5434 tests) and typecheck green.

Fixes #3807

https://claude.ai/code/session_01HZ4UfQbGHsTK1dGag9Bh6w

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

