### PR TITLE
fix(generation): cut rotated mesh imprints clockwise like the editor

### DIFF
--- a/src/features/generation/worker/generators/meshImprint.test.ts
+++ b/src/features/generation/worker/generators/meshImprint.test.ts
@@ -264,8 +264,13 @@ describe('mesh imprint generation (occt + manifold)', () => {
       });
 
     // The bottom-left quadrant lands top-left under a clockwise turn: carved.
+    // `lessThan` cannot pass vacuously — an empty probe reads Infinity.
     expect(probe(-5, 5)).toBeLessThan(solidTop - 4);
     // The empty quadrant lands bottom-right: the surface there stays solid.
+    // Infinity (no centroids sampled) is itself a pass: an untouched top face
+    // tessellates as a few large triangles, while a wrong-direction pocket
+    // fills the window with sub-threshold centroids — the reverted-fix run
+    // fails exactly here.
     expect(probe(5, -5)).toBeGreaterThan(solidTop - 0.3);
   }, 120_000);
 

--- a/src/features/generation/worker/generators/meshImprint.test.ts
+++ b/src/features/generation/worker/generators/meshImprint.test.ts
@@ -210,6 +210,65 @@ describe('mesh imprint generation (occt + manifold)', () => {
     expect(looseMax).toBeLessThan(tightMax + 2.0);
   }, 120_000);
 
+  it('rotates the imprint clockwise, matching the editor footprint', async () => {
+    // An L-shaped tool: full bottom bar [0..20]x[0..10] plus a leg
+    // [0..10]x[10..20], leaving the TOP-RIGHT quadrant of the 20x20 footprint
+    // empty. Stored rotation is clockwise-positive (MeshFootprintMesh renders
+    // at -rotation), so a 90° turn must swing the empty quadrant to the
+    // BOTTOM-right; a CCW cut parks it top-left — a mirrored pocket.
+    const bar = module.Manifold.cube([20, 10, 5], false);
+    const leg = module.Manifold.cube([10, 10, 5], false).translate([0, 10, 0]);
+    const lTool = module.Manifold.union([bar, leg]);
+    bar.delete();
+    leg.delete();
+    const gm = lTool.getMesh();
+    lTool.delete();
+    const soup = new Float32Array(gm.triVerts.length * 3);
+    for (let i = 0; i < gm.triVerts.length; i++) {
+      const v = gm.triVerts[i];
+      soup[i * 3] = gm.vertProperties[v * gm.numProp];
+      soup[i * 3 + 1] = gm.vertProperties[v * gm.numProp + 1];
+      soup[i * 3 + 2] = gm.vertProperties[v * gm.numProp + 2];
+    }
+    const importedL = await importMeshFromStl(
+      buildSTLBuffer(soup, new Float32Array(soup.length), 'l-tool'),
+      'l-tool.stl',
+      undefined,
+      module
+    );
+    if (!isOk(importedL)) throw new Error(`l-tool import failed: ${importedL.error.message}`);
+    const lAsset = importedL.value.asset;
+
+    const cutout = meshCutout({
+      meshId: 'l-tool',
+      width: lAsset.sizeMm.x,
+      depth: lAsset.sizeMm.y,
+      cutDepth: lAsset.sizeMm.z,
+      rotation: 90,
+    });
+    const params = solidBinParams([cutout], { 'l-tool': lAsset });
+    clearMeshImprintCache();
+    await prepareMeshImprints(params, module);
+    const imprinted = getGenerateBin()(params, undefined, true);
+
+    const { innerW, innerD, wallHeight } = deriveDimensions(params, true);
+    const solidTop = SOCKET_HEIGHT + wallHeight;
+    const cx = -innerW / 2 + 10 + lAsset.sizeMm.x / 2;
+    const cy = -innerD / 2 + 10 + lAsset.sizeMm.y / 2;
+    const probe = (dx: number, dy: number): number =>
+      minZInRegion(imprinted, {
+        minX: cx + dx - 2.5,
+        maxX: cx + dx + 2.5,
+        minY: cy + dy - 2.5,
+        maxY: cy + dy + 2.5,
+      });
+
+    // The bottom-left quadrant lands top-left under a clockwise turn: carved.
+    expect(probe(-5, 5)).toBeLessThan(solidTop - 4);
+    // The empty quadrant lands bottom-right: the surface there stays solid.
+    expect(probe(5, -5)).toBeGreaterThan(solidTop - 0.3);
+  }, 120_000);
+
   it('preserves relief below the shoulder instead of flattening to the silhouette', async () => {
     // A tool whose 3D form differs from its silhouette: a wide top slab
     // (20×10×3) on a narrow base (10×10×2). The projected silhouette is the

--- a/src/features/generation/worker/generators/meshImprint.ts
+++ b/src/features/generation/worker/generators/meshImprint.ts
@@ -306,10 +306,13 @@ function buildInstanceTool(
   try {
     const placeLocal = (local: Manifold): Manifold => {
       // Asset-local frame: footprint spans [0..sizeX]×[0..sizeY], z=0 at the
-      // pocket bottom. Rotate about the footprint center (matching 2D cutout
-      // rotation semantics), then move to the instance's world position.
+      // pocket bottom. Rotate about the footprint center, then move to the
+      // instance's world position. `Cutout.rotation` is clockwise-positive and
+      // Manifold's Z rotation is CCW, so the tool takes the negated angle —
+      // the same convention as the BREP tools' `rotate(shape, -rotation)` and
+      // `MeshFootprintMesh`'s `-rotation` render.
       const centered = track(local.translate([-cx, -cy, 0]));
-      const rotated = track(centered.rotate([0, 0, cutout.rotation]));
+      const rotated = track(centered.rotate([0, 0, -cutout.rotation]));
       return track(rotated.translate([worldX, worldY, zBottom]));
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #3814, from its review discussion. `Cutout.rotation` is clockwise-positive: `MeshFootprintMesh` renders the mesh footprint at `-rotation` and every BREP cutout tool extrudes at `rotate(shape, -rotation)`. The mesh-imprint path was the one placement rotating the raw angle through Manifold's CCW Z rotation, so a rotated asymmetric imprint (the entire point of shadow-board tools) exported mirrored from the footprint the editor showed and validated.

One-line negate in `placeLocal`, with the convention named in the comment. Radial repeat instances (`rotateToCenter`) flow through the same site, so they pick up the fix too.

## Testing

- New real-WASM direction test: an L-shaped tool (top-right quadrant of its footprint empty) rotated 90° must land the empty quadrant bottom-right — carved where the filled quadrants rotate to, solid where the gap does. Verified the test fails against the previous rotation (mirrored pocket) before the fix.
- No existing test pinned the direction (all mesh-imprint tests used rotation 0); the full imprint suite, normals suite, and the mesh split-step scenario pass.

Follows up on #3805.

https://claude.ai/code/session_01HZ4UfQbGHsTK1dGag9Bh6w

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

