### PR TITLE
chore(analytics): send posthog traffic to its own host

### DIFF
--- a/src/shared/analytics/posthog/init.ts
+++ b/src/shared/analytics/posthog/init.ts
@@ -43,7 +43,9 @@ export function initAnalytics(): void {
   initPromise = import('posthog-js')
     .then(async ({ default: posthog }) => {
       posthog.init(key, {
-        api_host: '/ph',
+        // Direct host on purpose: proxying through the app domain would bill
+        // every capture and SDK asset fetch as a platform edge request.
+        api_host: 'https://us.i.posthog.com',
         ui_host: 'https://us.posthog.com',
         capture_pageview: false, // Manual pageview - auto mode fires on every replaceState
         capture_pageleave: true,

--- a/vercel.json
+++ b/vercel.json
@@ -49,7 +49,7 @@
         },
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-Mw22/ZAJRshXEvS8/Ol3lQ4fuh9u0CpfYpgBaSMgOsE=' 'sha256-ZFh/jA8g0pm0KqxQsSQwlMZCLY+5rjgk3lzDL9ly2KU='; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://*.public.blob.vercel-storage.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io https://fonts.googleapis.com https://fonts.gstatic.com https://*.public.blob.vercel-storage.com; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-Mw22/ZAJRshXEvS8/Ol3lQ4fuh9u0CpfYpgBaSMgOsE=' 'sha256-ZFh/jA8g0pm0KqxQsSQwlMZCLY+5rjgk3lzDL9ly2KU=' https://us-assets.i.posthog.com; worker-src 'self' blob:; child-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://*.public.blob.vercel-storage.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.posthog.com https://*.liveblocks.io wss://*.liveblocks.io https://fonts.googleapis.com https://fonts.gstatic.com https://*.public.blob.vercel-storage.com; base-uri 'self'; form-action 'self'; object-src 'none'"
         }
       ]
     },
@@ -425,14 +425,6 @@
     }
   ],
   "rewrites": [
-    {
-      "source": "/ph/static/:path(.*)",
-      "destination": "https://us-assets.i.posthog.com/static/:path"
-    },
-    {
-      "source": "/ph/:path(.*)",
-      "destination": "https://us.i.posthog.com/:path"
-    },
     {
       "source": "/:slug(what-is-gridfinity|guide|privacy|terms|gridfinity-generator|gridfinity-bin-generator|gridfinity-baseplate-generator|gridfinity-calculator|gridfinity-sizes|gridfinity-tool-drawer|gridfinity-kitchen-drawer|gridfinity-software|gridfinity-cutout-generator)",
       "destination": "/:slug/index.html"


### PR DESCRIPTION
The `/ph/*` rewrites reverse-proxied every PostHog capture, feature-flag check, and lazy SDK asset through the app's edge network, where each one bills as a platform edge request plus fast origin transfer. This points `posthog-js` at `us.i.posthog.com` directly and removes the rewrites.

## Changes

- `src/shared/analytics/posthog/init.ts`: `api_host` goes direct; `ui_host` unchanged.
- `vercel.json`: the two `/ph/*` rewrites removed; `https://us-assets.i.posthog.com` added to the report-only CSP `script-src` for the SDK's lazy bundles (recorder, web-vitals). `connect-src` already allows `*.posthog.com`.

## Trade-off

Ad-blockers that block PostHog domains will drop captures that the same-origin proxy previously slipped past. Accepted: it also relieves pressure on the event-volume budget.

`scripts/check-csp-hashes.test.ts` passes (the inline-script hashes are untouched).

https://claude.ai/code/session_017DiLVpoRV1PhygnBt1MwCt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

