### PR TITLE
chore(pwa): check for SW updates hourly instead of every 15 minutes

### DIFF
--- a/src/shared/hooks/usePWAUpdate.test.ts
+++ b/src/shared/hooks/usePWAUpdate.test.ts
@@ -549,9 +549,9 @@ describe('usePWAUpdate', () => {
       // Initial check
       expect(mockRegistration.update).toHaveBeenCalledTimes(1);
 
-      // Advance 15 minutes (periodic interval)
+      // Advance one periodic interval
       act(() => {
-        timerUtils.advanceTime(15 * 60 * 1000);
+        timerUtils.advanceTime(60 * 60 * 1000);
       });
 
       // Should have checked again
@@ -570,9 +570,9 @@ describe('usePWAUpdate', () => {
 
       unmount();
 
-      // Advance 15 minutes
+      // Advance one periodic interval
       act(() => {
-        timerUtils.advanceTime(15 * 60 * 1000);
+        timerUtils.advanceTime(60 * 60 * 1000);
       });
 
       // Should NOT have checked again (unmounted)

--- a/src/shared/hooks/usePWAUpdate.ts
+++ b/src/shared/hooks/usePWAUpdate.ts
@@ -56,8 +56,10 @@ function captureSmokeEvent(name: string, props: Record<string, unknown>): void {
 // Toast duration for the brief "updating" notice shown right before reload
 const UPDATE_TOAST_MS = 5000;
 
-// Background polling interval (every 15 minutes when tab is active)
-const UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000;
+// Background polling interval while a tab stays open. Every check fetches
+// sw.js past the HTTP cache and bills as an edge request, so this is kept
+// hourly; visibilitychange still triggers a check the moment a user returns.
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
 // Minimum time between update checks (1 minute)
 const UPDATE_THROTTLE_MS = 60 * 1000;
@@ -364,7 +366,7 @@ function restoreEphemeralState(): boolean {
  * Checks for updates on:
  * - Initial page load (via onRegisteredSW callback)
  * - Tab visibility change (returning to tab)
- * - Every 15 minutes while active
+ * - Hourly while active
  *
  * Update checks are throttled and skip when:
  * - Offline (navigator.onLine is false)
@@ -443,7 +445,6 @@ export function usePWAUpdate(): void {
       // Check immediately on registration (page load)
       void checkForUpdate();
 
-      // Set up periodic checks (less aggressive - every 15 minutes)
       intervalRef.current = window.setInterval(() => {
         void checkForUpdate();
       }, UPDATE_CHECK_INTERVAL_MS);


### PR DESCRIPTION
`registration.update()` fetches `sw.js` past the HTTP cache, so every periodic check from every open tab is a billed edge request, and this is a leave-it-open tool. Hourly polling plus the existing `visibilitychange` trigger keeps update latency effectively unchanged for anyone actually using the tab, and with production deploys batched onto the release schedule (#3820) there is rarely a new version to find inside an hour anyway.

Tests updated to advance one interval instead of the literal 15 minutes; all 29 pass.

https://claude.ai/code/session_017DiLVpoRV1PhygnBt1MwCt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

