### PR TITLE
fix(labs): correct the Workshop flag warning about layout placement

### DIFF
--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -246,7 +246,7 @@ export const FEATURE_FLAGS = [
     status: 'experimental',
     risk: 'medium',
     warning:
-      'Early feature. Workshop builds auto-save to your library, sync when signed in, and export to STL, 3MF and STEP — but cannot be placed in drawer layouts yet.',
+      'Early feature. Workshop builds auto-save to your library, sync when signed in, export to STL, 3MF and STEP, and place into drawer layouts like any bin.',
     addedAt: '2026-08',
     requiresRefresh: false,
   },

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -246,7 +246,7 @@ export const FEATURE_FLAGS = [
     status: 'experimental',
     risk: 'medium',
     warning:
-      'Early feature. Workshop builds auto-save to your library, sync when signed in, export to STL, 3MF and STEP, and place into drawer layouts like any bin.',
+      'Early feature. Workshop builds auto-save to your library, sync when signed in, export to STL, 3MF and STEP, and can be placed in drawer layouts like any bin.',
     addedAt: '2026-08',
     requiresRefresh: false,
   },


### PR DESCRIPTION
The `workshop` flag's Labs warning still said builds cannot be placed in drawer layouts, which shipped in #3747. The card now describes what the feature does today.

https://claude.ai/code/session_017DiLVpoRV1PhygnBt1MwCt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

