### PR TITLE
feat(design-system): collapse overflowing segmented controls into a balanced grid

### DIFF
--- a/src/design-system/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.test.tsx
@@ -205,11 +205,14 @@ describe('SegmentedControl', () => {
     expect(screen.getByRole('radiogroup')).toHaveClass('custom-class');
   });
 
-  it('hides the measurement probe from assistive tech and pointer events', () => {
+  it('hides the measurement probe from assistive tech and ancestor scroll extent', () => {
     render(<SegmentedControl {...defaultProps} />);
     const probe = screen.getByRole('radiogroup').querySelector('[data-measure]');
     expect(probe).not.toBeNull();
-    expect(probe).toHaveAttribute('aria-hidden', 'true');
+    const wrapper = probe?.closest('[aria-hidden="true"]');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain('overflow-hidden');
+    expect(wrapper?.className).toContain('w-0');
   });
 
   it('uses per-option aria-label and title for icon-only segments', () => {
@@ -265,7 +268,7 @@ describe('SegmentedControl grid collapse', () => {
   it('re-lays overflowing segments into balanced equal-width rows', () => {
     const group = renderOverflowing();
     expect(group.className).toContain('flex-col');
-    const rows = group.querySelectorAll(':scope > div:not([data-measure])');
+    const rows = group.querySelectorAll(':scope > div:not([aria-hidden])');
     expect(rows).toHaveLength(2);
     expect(rows[0].querySelectorAll('[role="radio"]')).toHaveLength(2);
     expect(rows[1].querySelectorAll('[role="radio"]')).toHaveLength(1);

--- a/src/design-system/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { SegmentedControl } from './SegmentedControl';
+import { SegmentedControl, computeRowSizes } from './SegmentedControl';
 import type { SegmentedControlProps } from './SegmentedControl';
 
 type Mode = 'list' | 'grid' | 'table';
@@ -195,7 +195,7 @@ describe('SegmentedControl', () => {
     }
   });
 
-  it('wraps segments instead of overflowing a narrow container', () => {
+  it('keeps the flex-wrap baseline before any overflow is measured', () => {
     render(<SegmentedControl {...defaultProps} />);
     expect(screen.getByRole('radiogroup').className).toContain('flex-wrap');
   });
@@ -203,6 +203,13 @@ describe('SegmentedControl', () => {
   it('applies className to the group container', () => {
     render(<SegmentedControl {...defaultProps} className="custom-class" />);
     expect(screen.getByRole('radiogroup')).toHaveClass('custom-class');
+  });
+
+  it('hides the measurement probe from assistive tech and pointer events', () => {
+    render(<SegmentedControl {...defaultProps} />);
+    const probe = screen.getByRole('radiogroup').querySelector('[data-measure]');
+    expect(probe).not.toBeNull();
+    expect(probe).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('uses per-option aria-label and title for icon-only segments', () => {
@@ -227,5 +234,68 @@ describe('SegmentedControl', () => {
     );
     expect(screen.getByRole('radio', { name: 'List view' })).toHaveAttribute('title', 'List view');
     expect(screen.getByRole('radio', { name: 'Grid view' })).toBeInTheDocument();
+  });
+});
+
+function stubWidths(
+  element: Element | null,
+  widths: { offsetWidth?: number; clientWidth?: number }
+): void {
+  if (!element) throw new Error('expected an element to stub');
+  for (const [property, width] of Object.entries(widths)) {
+    Object.defineProperty(element, property, { get: () => width, configurable: true });
+  }
+}
+
+describe('SegmentedControl grid collapse', () => {
+  function renderOverflowing(onChange: (value: Mode) => void = () => {}): HTMLElement {
+    const utils = render(<SegmentedControl {...defaultProps} onChange={onChange} />);
+    const group = screen.getByRole('radiogroup');
+    const probe = group.querySelector('[data-measure]');
+    if (!probe) throw new Error('probe not rendered');
+    stubWidths(group, { offsetWidth: 100, clientWidth: 98 });
+    stubWidths(probe, { offsetWidth: 126 });
+    for (const cell of Array.from(probe.children)) {
+      stubWidths(cell, { offsetWidth: 40 });
+    }
+    utils.rerender(<SegmentedControl {...defaultProps} onChange={onChange} />);
+    return group;
+  }
+
+  it('re-lays overflowing segments into balanced equal-width rows', () => {
+    const group = renderOverflowing();
+    expect(group.className).toContain('flex-col');
+    const rows = group.querySelectorAll(':scope > div:not([data-measure])');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].querySelectorAll('[role="radio"]')).toHaveLength(2);
+    expect(rows[1].querySelectorAll('[role="radio"]')).toHaveLength(1);
+    expect(rows[1].textContent).toBe('Table');
+  });
+
+  it('keeps every option selectable and arrow-navigable in grid mode', () => {
+    const onChange = vi.fn();
+    renderOverflowing(onChange);
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'List' }), { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledWith('grid');
+    fireEvent.click(screen.getByRole('radio', { name: 'Table' }));
+    expect(onChange).toHaveBeenCalledWith('table');
+  });
+});
+
+describe('computeRowSizes', () => {
+  it('splits into the fewest balanced rows that fit', () => {
+    expect(computeRowSizes([40, 40, 40], 99)).toEqual([2, 1]);
+    expect(computeRowSizes([30, 30, 30, 30], 100)).toEqual([2, 2]);
+    expect(computeRowSizes([30, 30, 30, 30, 30], 100)).toEqual([3, 2]);
+  });
+
+  it('places the remainder on whichever row fits it', () => {
+    expect(computeRowSizes([80, 20, 20], 90)).toEqual([1, 2]);
+  });
+
+  it('stacks one cell per row when nothing narrower fits', () => {
+    expect(computeRowSizes([40, 40, 40], 78)).toEqual([1, 1, 1]);
+    expect(computeRowSizes([200], 90)).toEqual([1]);
   });
 });

--- a/src/design-system/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.test.tsx
@@ -298,4 +298,12 @@ describe('computeRowSizes', () => {
     expect(computeRowSizes([40, 40, 40], 78)).toEqual([1, 1, 1]);
     expect(computeRowSizes([200], 90)).toEqual([1]);
   });
+
+  it('stays bounded and returns a full partition for pathological option counts', () => {
+    const sizes = computeRowSizes(
+      Array.from({ length: 40 }, () => 50),
+      120
+    );
+    expect(sizes.reduce((sum, size) => sum + size, 0)).toBe(40);
+  });
 });

--- a/src/design-system/SegmentedControl/SegmentedControl.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.tsx
@@ -405,20 +405,27 @@ export function SegmentedControl<T extends string>({
         className
       )}
     >
+      {/* The zero-size overflow-hidden wrapper keeps the probe's natural width
+          out of ancestor scrollable-overflow, so a scrollable panel never gains
+          a horizontal scrollbar from the invisible measurement content. */}
       <div
-        ref={probeRef}
         aria-hidden="true"
-        data-measure=""
-        className="pointer-events-none invisible absolute top-0 left-0 inline-flex w-max border border-transparent p-0.5 whitespace-nowrap"
+        className="pointer-events-none invisible absolute top-0 left-0 h-0 w-0 overflow-hidden"
       >
-        {options.map((option) => (
-          <span
-            key={option.value}
-            className={cn(segmentVariants({ size, activeStyle, active: false }))}
-          >
-            {option.label}
-          </span>
-        ))}
+        <div
+          ref={probeRef}
+          data-measure=""
+          className="inline-flex w-max border border-transparent p-0.5 whitespace-nowrap"
+        >
+          {options.map((option) => (
+            <span
+              key={option.value}
+              className={cn(segmentVariants({ size, activeStyle, active: false }))}
+            >
+              {option.label}
+            </span>
+          ))}
+        </div>
       </div>
       {gridSizes === null
         ? options.map((option) => renderSegment(option, fullWidth))

--- a/src/design-system/SegmentedControl/SegmentedControl.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.tsx
@@ -159,25 +159,31 @@ function lastEnabledIndex<T extends string>(options: SegmentedControlOption<T>[]
   return -1;
 }
 
-function balancedCompositions(rowCount: number, cellCount: number): number[][] {
+// The number of balanced compositions is C(rowCount, remainder), which is
+// combinatorial for pathological option counts; the cap keeps a resize tick
+// bounded while still covering every arrangement of realistic controls.
+const MAX_COMPOSITIONS = 64;
+
+function* balancedCompositions(rowCount: number, cellCount: number): Generator<number[]> {
   const base = Math.floor(cellCount / rowCount);
   const extra = cellCount % rowCount;
-  if (extra === 0) return [Array.from({ length: rowCount }, () => base)];
+  if (extra === 0) {
+    yield Array.from({ length: rowCount }, () => base);
+    return;
+  }
 
-  const compositions: number[][] = [];
   const extraRows = Array.from({ length: extra }, (_, i) => i);
-  for (;;) {
+  for (let yielded = 0; yielded < MAX_COMPOSITIONS; yielded++) {
     const sizes = Array.from({ length: rowCount }, () => base);
     for (const row of extraRows) sizes[row] += 1;
-    compositions.push(sizes);
+    yield sizes;
 
     let cursor = extra - 1;
     while (cursor >= 0 && extraRows[cursor] === rowCount - extra + cursor) cursor--;
-    if (cursor < 0) break;
+    if (cursor < 0) return;
     extraRows[cursor] += 1;
     for (let next = cursor + 1; next < extra; next++) extraRows[next] = extraRows[next - 1] + 1;
   }
-  return compositions;
 }
 
 function rowsFit(cellWidths: number[], sizes: number[], availableInner: number): boolean {

--- a/src/design-system/SegmentedControl/SegmentedControl.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.tsx
@@ -1,23 +1,25 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import type { KeyboardEvent, ReactNode } from 'react';
 import { cva } from 'class-variance-authority';
 import { cn } from '../cn';
 import { focusRing, disabledStyles, interactiveTransition } from '../variants';
 
-// `flex-wrap`: every panel section that hosts one of these sits inside an
-// overflow-hidden animation wrapper (Collapsible, StickyGroupHeader), so a
-// row too wide for its column is silently cut off rather than scrolled.
-// Segments keep their natural width and spill onto a second row instead.
-const groupVariants = cva(
-  ['inline-flex flex-wrap gap-y-0.5 rounded-lg bg-surface p-0.5', 'border border-stroke'],
-  {
-    variants: {
-      fullWidth: {
-        true: 'flex w-full',
-      },
+// Panel sections hosting this control sit inside overflow-hidden animation
+// wrappers (Collapsible, StickyGroupHeader), so a row too wide for its column
+// would be silently cut off rather than scrolled. Segments that overflow are
+// re-laid into balanced equal-width rows; `flex-wrap` remains only as the
+// no-JS / pre-measurement baseline so content is never clipped.
+const groupVariants = cva(['relative rounded-lg bg-surface p-0.5', 'border border-stroke'], {
+  variants: {
+    layout: {
+      row: 'inline-flex flex-wrap gap-y-0.5',
+      grid: 'flex w-full flex-col gap-y-0.5',
     },
-  }
-);
+    fullWidth: {
+      true: 'flex w-full',
+    },
+  },
+});
 
 const segmentVariants = cva(
   [
@@ -63,6 +65,10 @@ const segmentVariants = cva(
     },
   }
 );
+
+// Sub-pixel slack: offsetWidth rounds to integers, so an exact fit can read
+// one pixel over and needlessly collapse to the grid.
+const EPSILON = 1;
 
 export interface SegmentedControlOption<T extends string> {
   value: T;
@@ -153,10 +159,89 @@ function lastEnabledIndex<T extends string>(options: SegmentedControlOption<T>[]
   return -1;
 }
 
+function balancedCompositions(rowCount: number, cellCount: number): number[][] {
+  const base = Math.floor(cellCount / rowCount);
+  const extra = cellCount % rowCount;
+  if (extra === 0) return [Array.from({ length: rowCount }, () => base)];
+
+  const compositions: number[][] = [];
+  const extraRows = Array.from({ length: extra }, (_, i) => i);
+  for (;;) {
+    const sizes = Array.from({ length: rowCount }, () => base);
+    for (const row of extraRows) sizes[row] += 1;
+    compositions.push(sizes);
+
+    let cursor = extra - 1;
+    while (cursor >= 0 && extraRows[cursor] === rowCount - extra + cursor) cursor--;
+    if (cursor < 0) break;
+    extraRows[cursor] += 1;
+    for (let next = cursor + 1; next < extra; next++) extraRows[next] = extraRows[next - 1] + 1;
+  }
+  return compositions;
+}
+
+function rowsFit(cellWidths: number[], sizes: number[], availableInner: number): boolean {
+  let start = 0;
+  for (const size of sizes) {
+    let widest = 0;
+    for (let index = start; index < start + size; index++) {
+      widest = Math.max(widest, cellWidths[index]);
+    }
+    // Cells in a row are equal-width (flex-1), so the row needs the widest
+    // cell's width times its cell count.
+    if (widest * size > availableInner + EPSILON) return false;
+    start += size;
+  }
+  return true;
+}
+
+/**
+ * Balanced grid layout for segments that overflow a single line: the fewest
+ * rows that fit, cells split as evenly as possible across them (order
+ * preserved, every distribution of the remainder tried). Falls back to one
+ * cell per row when nothing narrower fits.
+ */
+export function computeRowSizes(cellWidths: number[], availableInner: number): number[] {
+  const count = cellWidths.length;
+  for (let rowCount = 2; rowCount < count; rowCount++) {
+    for (const sizes of balancedCompositions(rowCount, count)) {
+      if (rowsFit(cellWidths, sizes, availableInner)) return sizes;
+    }
+  }
+  return Array.from({ length: count }, () => 1);
+}
+
+function partitionRows<Item>(items: Item[], sizes: number[]): Item[][] {
+  const rows: Item[][] = [];
+  let start = 0;
+  for (const size of sizes) {
+    rows.push(items.slice(start, start + size));
+    start += size;
+  }
+  return rows;
+}
+
+function sameSizes(a: number[] | null, b: number[] | null): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  return a.length === b.length && a.every((size, index) => size === b[index]);
+}
+
+function contentWidth(root: HTMLElement): number {
+  const styles = window.getComputedStyle(root);
+  const paddingX =
+    (Number.parseFloat(styles.paddingLeft) || 0) + (Number.parseFloat(styles.paddingRight) || 0);
+  return root.clientWidth - paddingX;
+}
+
 /**
  * Accessible single-select segmented control. Renders a radiogroup of
  * joined segments with roving tabindex and full arrow-key navigation
  * (ArrowLeft/Right/Up/Down cycle, Home/End jump, disabled segments skipped).
+ *
+ * When the segments are too wide for the available space, the control
+ * re-lays them into a balanced grid of equal-width cells (fewest rows that
+ * fit, options split as evenly as possible) instead of ragged-wrapping.
  *
  * @example
  * // Text segments
@@ -208,6 +293,37 @@ export function SegmentedControl<T extends string>({
   className,
 }: SegmentedControlProps<T>) {
   const groupRef = useRef<HTMLDivElement>(null);
+  const probeRef = useRef<HTMLDivElement>(null);
+  const [rowSizes, setRowSizes] = useState<number[] | null>(null);
+
+  const sync = useCallback(() => {
+    const root = groupRef.current;
+    const probe = probeRef.current;
+    if (!root || !probe) return;
+    // An inline-flex box is clamped to its containing block, and in grid mode
+    // the root is w-full — so in every mode the root's width IS the available
+    // width whenever the probe (segments at natural size) exceeds it.
+    const next =
+      probe.offsetWidth <= root.offsetWidth + EPSILON
+        ? null
+        : computeRowSizes(
+            Array.from(probe.children, (cell) => (cell as HTMLElement).offsetWidth),
+            contentWidth(root)
+          );
+    setRowSizes((previous) => (sameSizes(previous, next) ? previous : next));
+  }, []);
+
+  useLayoutEffect(sync);
+
+  useLayoutEffect(() => {
+    const root = groupRef.current;
+    const probe = probeRef.current;
+    if (!root || !probe) return;
+    const observer = new ResizeObserver(sync);
+    observer.observe(root);
+    observer.observe(probe);
+    return () => observer.disconnect();
+  }, [sync]);
 
   const selectIndex = useCallback(
     (index: number) => {
@@ -244,6 +360,33 @@ export function SegmentedControl<T extends string>({
     [options, value, selectIndex]
   );
 
+  const renderSegment = (option: SegmentedControlOption<T>, stretch: boolean): ReactNode => {
+    const isSelected = option.value === value;
+    return (
+      <button
+        key={option.value}
+        type="button"
+        role="radio"
+        aria-checked={isSelected}
+        aria-label={option['aria-label']}
+        title={option.title}
+        disabled={option.disabled}
+        tabIndex={isSelected ? 0 : -1}
+        onClick={() => {
+          if (!isSelected) onChange(option.value);
+        }}
+        className={cn(
+          segmentVariants({ size, activeStyle, active: isSelected, fullWidth: stretch })
+        )}
+      >
+        {option.label}
+      </button>
+    );
+  };
+
+  const cellTotal = rowSizes?.reduce((sum, rowSize) => sum + rowSize, 0);
+  const gridSizes = rowSizes !== null && cellTotal === options.length ? rowSizes : null;
+
   return (
     <div
       ref={groupRef}
@@ -251,29 +394,33 @@ export function SegmentedControl<T extends string>({
       aria-label={ariaLabel}
       tabIndex={-1}
       onKeyDown={handleKeyDown}
-      className={cn(groupVariants({ fullWidth }), className)}
+      className={cn(
+        groupVariants({ layout: gridSizes === null ? 'row' : 'grid', fullWidth }),
+        className
+      )}
     >
-      {options.map((option) => {
-        const isSelected = option.value === value;
-        return (
-          <button
+      <div
+        ref={probeRef}
+        aria-hidden="true"
+        data-measure=""
+        className="pointer-events-none invisible absolute top-0 left-0 inline-flex w-max border border-transparent p-0.5 whitespace-nowrap"
+      >
+        {options.map((option) => (
+          <span
             key={option.value}
-            type="button"
-            role="radio"
-            aria-checked={isSelected}
-            aria-label={option['aria-label']}
-            title={option.title}
-            disabled={option.disabled}
-            tabIndex={isSelected ? 0 : -1}
-            onClick={() => {
-              if (!isSelected) onChange(option.value);
-            }}
-            className={cn(segmentVariants({ size, activeStyle, active: isSelected, fullWidth }))}
+            className={cn(segmentVariants({ size, activeStyle, active: false }))}
           >
             {option.label}
-          </button>
-        );
-      })}
+          </span>
+        ))}
+      </div>
+      {gridSizes === null
+        ? options.map((option) => renderSegment(option, fullWidth))
+        : partitionRows(options, gridSizes).map((row, rowIndex) => (
+            <div key={rowIndex} className="flex w-full">
+              {row.map((option) => renderSegment(option, true))}
+            </div>
+          ))}
     </div>
   );
 }

--- a/src/test/setup-dom.ts
+++ b/src/test/setup-dom.ts
@@ -4,8 +4,13 @@
 
 import '@testing-library/jest-dom';
 import { afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
+import { cleanup, configure } from '@testing-library/react';
 import { resetWebGLDetectionCacheForTests } from '@/shared/webgl/detectWebGL';
+
+// SegmentedControl renders its options a second time inside a hidden
+// [data-measure] probe to know when to collapse into a grid. Without this,
+// getByText in any test touching a segmented control matches both copies.
+configure({ defaultIgnore: 'script, style, [data-measure], [data-measure] *' });
 
 // Suppress jsdom-environment noise from Three.js / React Three Fiber.
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
When a segmented control's options no longer fit on one line, it now re-lays them into a balanced grid of equal-width cells instead of ragged-wrapping onto a second line.

- Fit is measured against a hidden natural-width probe plus a ResizeObserver, so the control collapses exactly when needed and returns to a single line when space comes back.
- The grid uses the fewest rows that fit, with options split as evenly as possible in order. Every distribution of the remainder is tried, so a single long option lands on its own row when that is the only arrangement that fits.
- `flex-wrap` remains as the pre-measurement and no-JS baseline, so content inside overflow-hidden panel wrappers is never clipped.
- Applies to every `SegmentedControl` call site with no API change.

Verified in the dev app: the designer Case control in German (natural width 334px in the 255px panel) renders as a 2+1 grid, steps through 2-row and stacked layouts as its container narrows, returns to a single row when space is restored, and holds a stable layout with no mode flicker.

https://claude.ai/code/session_017DiLVpoRV1PhygnBt1MwCt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

