### PR TITLE
fix(bin-designer): shrink oversized cutouts when bringing them back on board

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -16,7 +16,7 @@
 import { useCallback, useState, useMemo, useRef, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore, remainingCutoutCapacity } from '@/features/bin-designer/store';
-import { MAX_LID_CUTOUTS } from '@/features/bin-designer/types';
+import { MAX_LID_CUTOUTS, type Cutout } from '@/features/bin-designer/types';
 import {
   binDimensions,
   cutoutInterior,
@@ -322,18 +322,22 @@ export function CutoutWorkspace() {
     setParams({ width: growTarget.width, depth: growTarget.depth });
   }, [growTarget, setParams]);
 
-  const handleClampOffBoard = useCallback(() => {
-    const updates = clampOffBoardCutouts(cutouts, cutoutBoard);
-    if (updates.size > 0) updateCutoutsBatch(updates);
-  }, [cutouts, cutoutBoard, updateCutoutsBatch]);
-
-  // Hidden rather than inert: when the clamp can fix nothing (an oversized
-  // path or mesh, no valid mask/lid placement) a visible button would click
-  // without effect and read as broken.
-  const clampCanFix = useMemo(
-    () => offBoardIds.size > 0 && clampOffBoardCutouts(cutouts, cutoutBoard).size > 0,
+  // Computed once and shared by the button's visibility and its click, so the
+  // two can't disagree and the mask scan in the clamp isn't run twice. Hidden
+  // rather than inert: when the clamp can fix nothing (an oversized path or
+  // mesh, no valid mask/lid placement) a visible button would click without
+  // effect and read as broken.
+  const offBoardUpdates = useMemo(
+    () =>
+      offBoardIds.size > 0
+        ? clampOffBoardCutouts(cutouts, cutoutBoard)
+        : new Map<string, Partial<Cutout>>(),
     [offBoardIds, cutouts, cutoutBoard]
   );
+
+  const handleClampOffBoard = useCallback(() => {
+    if (offBoardUpdates.size > 0) updateCutoutsBatch(offBoardUpdates);
+  }, [offBoardUpdates, updateCutoutsBatch]);
 
   const {
     mode,
@@ -702,7 +706,7 @@ export function CutoutWorkspace() {
           onFitCue={setFitCue}
           onFlattenArray={handleFlattenArray}
           offBoardCount={offBoardIds.size}
-          onClampOffBoard={clampCanFix ? handleClampOffBoard : undefined}
+          onClampOffBoard={offBoardUpdates.size > 0 ? handleClampOffBoard : undefined}
           depthShortfallCount={depthShortfallCount}
           growTarget={growTarget}
           onGrowToFit={handleGrowToFit}

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -330,7 +330,7 @@ export function CutoutWorkspace() {
   const offBoardUpdates = useMemo(
     () =>
       offBoardIds.size > 0
-        ? clampOffBoardCutouts(cutouts, cutoutBoard)
+        ? clampOffBoardCutouts(cutouts, cutoutBoard, offBoardIds)
         : new Map<string, Partial<Cutout>>(),
     [offBoardIds, cutouts, cutoutBoard]
   );

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -327,6 +327,14 @@ export function CutoutWorkspace() {
     if (updates.size > 0) updateCutoutsBatch(updates);
   }, [cutouts, cutoutBoard, updateCutoutsBatch]);
 
+  // Hidden rather than inert: when the clamp can fix nothing (an oversized
+  // path or mesh, no valid mask/lid placement) a visible button would click
+  // without effect and read as broken.
+  const clampCanFix = useMemo(
+    () => offBoardIds.size > 0 && clampOffBoardCutouts(cutouts, cutoutBoard).size > 0,
+    [offBoardIds, cutouts, cutoutBoard]
+  );
+
   const {
     mode,
     setMode,
@@ -694,7 +702,7 @@ export function CutoutWorkspace() {
           onFitCue={setFitCue}
           onFlattenArray={handleFlattenArray}
           offBoardCount={offBoardIds.size}
-          onClampOffBoard={handleClampOffBoard}
+          onClampOffBoard={clampCanFix ? handleClampOffBoard : undefined}
           depthShortfallCount={depthShortfallCount}
           growTarget={growTarget}
           onGrowToFit={handleGrowToFit}

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
@@ -353,6 +353,17 @@ describe('clampOffBoardCutouts', () => {
     expect(clampOffBoardCutouts([createCutout()], { width: BIN_W, depth: BIN_D }).size).toBe(0);
   });
 
+  it('clamps exactly the ids a caller supplies, skipping its own scan', () => {
+    const board = { width: BIN_W, depth: BIN_D };
+    const first = createCutout({ id: 'a', x: 95, y: 75 });
+    const second = createCutout({ id: 'b', x: 99, y: 79 });
+    const supplied = clampOffBoardCutouts([first, second], board, new Set(['a']));
+    expect([...supplied.keys()]).toEqual(['a']);
+    expect(
+      clampOffBoardCutouts([first, second], board, getOffBoardCutoutIds([first, second], board))
+    ).toEqual(clampOffBoardCutouts([first, second], board));
+  });
+
   it('resolves an oversized cutout in one application', () => {
     const wide = createCutout({ id: 'wide', x: 27.5, y: 93.5, width: 500, depth: 39.5 });
     const board = { width: 165.1, depth: 165.1 };

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
@@ -216,9 +216,72 @@ describe('clampCutoutToBoard', () => {
     expect(clampCutoutToBoard(stray, { width: BIN_W, depth: BIN_D })).toEqual({ x: 0, y: 0 });
   });
 
-  it('pins the min edge to the origin when the cutout is larger than the board', () => {
+  it('shrinks an oversized cutout to the board and anchors it at the origin', () => {
     const huge = createCutout({ x: 30, y: 20, width: 200, depth: 150 });
-    expect(clampCutoutToBoard(huge, { width: BIN_W, depth: BIN_D })).toEqual({ x: 0, y: 0 });
+    const patch = clampCutoutToBoard(huge, { width: BIN_W, depth: BIN_D });
+    expect(patch).toEqual({ x: 0, y: 0, width: BIN_W, depth: BIN_D });
+    expect(isCutoutOffBoard({ ...huge, ...patch }, { width: BIN_W, depth: BIN_D })).toBe(false);
+  });
+
+  it('clamps only the oversized axis', () => {
+    const wide = createCutout({ x: 27.5, y: 93.5, width: 500, depth: 39.5 });
+    const board = { width: 165.1, depth: 165.1 };
+    const fixed = { ...wide, ...clampCutoutToBoard(wide, board) };
+    expect(fixed.width).toBe(165.1);
+    expect(fixed.depth).toBe(39.5);
+    expect(isCutoutOffBoard(fixed, board)).toBe(false);
+    expect(clampCutoutToBoard(fixed, board)).toBeNull();
+  });
+
+  it('shrinks a rotated oversized cutout so its rotated footprint fits', () => {
+    const rotated = createCutout({ x: 10, y: 10, width: 300, depth: 40, rotation: 45 });
+    const board = { width: BIN_W, depth: BIN_D };
+    const fixed = { ...rotated, ...clampCutoutToBoard(rotated, board) };
+    expect(isCutoutOffBoard(fixed, board)).toBe(false);
+    expect(fixed.width / fixed.depth).toBeCloseTo(300 / 40);
+  });
+
+  it('maps the clamp to the crossed axes at 90° rotation', () => {
+    const bar = createCutout({ x: 10, y: 10, width: 200, depth: 10, rotation: 90 });
+    const board = { width: BIN_W, depth: BIN_D };
+    const fixed = { ...bar, ...clampCutoutToBoard(bar, board) };
+    expect(fixed.width).toBe(80);
+    expect(fixed.depth).toBe(10);
+    expect(isCutoutOffBoard(fixed, board)).toBe(false);
+  });
+
+  it('shrinks an array master so every instance fits', () => {
+    const arr = createCutout({
+      x: 0,
+      y: 10,
+      width: 200,
+      depth: 20,
+      array: gridArray(2, 1, 40, 40),
+    });
+    const board = { width: BIN_W, depth: BIN_D };
+    const fixed = { ...arr, ...clampCutoutToBoard(arr, board) };
+    expect(fixed.width).toBe(60);
+    expect(fixed.depth).toBe(20);
+    expect(isCutoutOffBoard(fixed, board)).toBe(false);
+  });
+
+  it('leaves an oversized path translation-only and flagged', () => {
+    const path = createCutout({
+      shape: 'path',
+      x: 0,
+      y: 10,
+      width: 300,
+      depth: 20,
+      path: [corner(0, 10), corner(300, 10), corner(300, 30), corner(0, 30)],
+    });
+    expect(clampCutoutToBoard(path, { width: BIN_W, depth: BIN_D })).toBeNull();
+    expect(clampOffBoardCutouts([path], { width: BIN_W, depth: BIN_D }).size).toBe(0);
+    expect(isCutoutOffBoard(path, { width: BIN_W, depth: BIN_D })).toBe(true);
+  });
+
+  it('translates but never resizes a mesh cutout', () => {
+    const mesh = createCutout({ shape: 'mesh', x: 30, y: 10, width: 200, depth: 20 });
+    expect(clampCutoutToBoard(mesh, { width: BIN_W, depth: BIN_D })).toEqual({ x: 0, y: 10 });
   });
 
   it('returns null when the cutout is already inside', () => {
@@ -275,6 +338,14 @@ describe('clampOffBoardCutouts', () => {
 
   it('returns an empty map when everything fits', () => {
     expect(clampOffBoardCutouts([createCutout()], { width: BIN_W, depth: BIN_D }).size).toBe(0);
+  });
+
+  it('resolves an oversized cutout in one application', () => {
+    const wide = createCutout({ id: 'wide', x: 27.5, y: 93.5, width: 500, depth: 39.5 });
+    const board = { width: 165.1, depth: 165.1 };
+    const fixed = { ...wide, ...clampOffBoardCutouts([wide], board).get('wide') };
+    expect(isCutoutOffBoard(fixed, board)).toBe(false);
+    expect(clampOffBoardCutouts([fixed], board).size).toBe(0);
   });
 
   it('relocates a mask-only violation into the nearest filled region', () => {

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
@@ -279,6 +279,19 @@ describe('clampCutoutToBoard', () => {
     expect(isCutoutOffBoard(path, { width: BIN_W, depth: BIN_D })).toBe(true);
   });
 
+  it('withholds a translation that cannot clear the flag', () => {
+    const path = createCutout({
+      id: 'stuck',
+      shape: 'path',
+      x: 30,
+      y: 10,
+      width: 300,
+      depth: 20,
+      path: [corner(30, 10), corner(330, 10), corner(330, 30), corner(30, 30)],
+    });
+    expect(clampOffBoardCutouts([path], { width: BIN_W, depth: BIN_D }).size).toBe(0);
+  });
+
   it('translates but never resizes a mesh cutout', () => {
     const mesh = createCutout({ shape: 'mesh', x: 30, y: 10, width: 200, depth: 20 });
     expect(clampCutoutToBoard(mesh, { width: BIN_W, depth: BIN_D })).toEqual({ x: 0, y: 10 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -253,7 +253,12 @@ export function clampCutoutToBoard(cutout: Cutout, board: CutoutBoard): Partial<
   return moved;
 }
 
-/** Updates for every off-board cutout that a clamp can fix (empty when none). */
+/**
+ * Updates for every off-board cutout that a clamp can fix (empty when none).
+ * A patch that would still leave the shape off board — an oversized path or
+ * mesh pulled to the origin but overhanging the far edge — is withheld, so an
+ * offered clamp always clears the warning for the cutouts it touches.
+ */
 export function clampOffBoardCutouts(
   cutouts: readonly Cutout[],
   board: CutoutBoard
@@ -262,7 +267,7 @@ export function clampOffBoardCutouts(
   for (const c of cutouts) {
     if (!isCutoutOffBoard(c, board)) continue;
     const moved = clampCutoutToBoard(c, board);
-    if (moved) updates.set(c.id, moved);
+    if (moved && !isCutoutOffBoard({ ...c, ...moved }, board)) updates.set(c.id, moved);
   }
   return updates;
 }

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -258,14 +258,18 @@ export function clampCutoutToBoard(cutout: Cutout, board: CutoutBoard): Partial<
  * A patch that would still leave the shape off board — an oversized path or
  * mesh pulled to the origin but overhanging the far edge — is withheld, so an
  * offered clamp always clears the warning for the cutouts it touches.
+ *
+ * `offBoardIds` lets a caller that already ran the detection scan hand it in
+ * rather than pay for a second pass over every cutout.
  */
 export function clampOffBoardCutouts(
   cutouts: readonly Cutout[],
-  board: CutoutBoard
+  board: CutoutBoard,
+  offBoardIds: ReadonlySet<string> = getOffBoardCutoutIds(cutouts, board)
 ): Map<string, Partial<Cutout>> {
   const updates = new Map<string, Partial<Cutout>>();
   for (const c of cutouts) {
-    if (!isCutoutOffBoard(c, board)) continue;
+    if (!offBoardIds.has(c.id)) continue;
     const moved = clampCutoutToBoard(c, board);
     if (moved && !isCutoutOffBoard({ ...c, ...moved }, board)) updates.set(c.id, moved);
   }

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -32,6 +32,7 @@ import { translateCutout } from './cutoutHelpers';
 import { translatePathPoints } from './pathGeometry';
 import { getCutoutBounds, cutoutFitsInMask, type MaskCellSize } from './maskFit';
 import { cutoutFitsInLidWindow, lidWindowOffset } from './lidWindowFit';
+import { MIN_CUTOUT_SIZE } from './geometryResize';
 import type { Bounds } from './geometryCore';
 
 /**
@@ -108,12 +109,70 @@ export function getOffBoardCutoutIds(cutouts: readonly Cutout[], board: CutoutBo
 
 /** Shift to bring [min,max] inside [0,extent]; pin the min edge when oversized. */
 function fitAxis(min: number, max: number, extent: number): number {
-  // Larger than the board on this axis — both edges can't fit, so anchor the
-  // min edge to the origin and let the build clip the overhang on the far side.
+  // Still larger than the board after any shrink (a path, a mesh, an array
+  // whose pitch alone overspans) — both edges can't fit, so anchor the min
+  // edge to the origin and let the build clip the overhang on the far side.
   if (max - min > extent) return -min;
   if (min < 0) return -min;
   if (max > extent) return extent - max;
   return 0;
+}
+
+/**
+ * Width/depth that let the cutout's rotated footprint — and every array
+ * instance — fit a `binWidth`×`binDepth` rectangle. `null` when no resize is
+ * needed or none would help: paths and meshes aren't sized by width/depth (a
+ * path's vertices are the truth, a mesh mirrors its STL and can't resize), and
+ * a shrink that still can't fit (min-size floor, array pitch overspanning the
+ * board) is withheld rather than mangling the shape without clearing the flag.
+ *
+ * Axis-aligned rotations clamp each axis independently; oblique ones scale
+ * uniformly, since per-axis shrinking of a rotated box couples the axes.
+ */
+function shrinkToFitRect(
+  cutout: Cutout,
+  binWidth: number,
+  binDepth: number
+): Pick<Cutout, 'width' | 'depth'> | null {
+  if (cutout.shape === 'path' || cutout.shape === 'mesh') return null;
+  const own = getCutoutBounds(cutout);
+  const ownW = own.maxX - own.minX;
+  const ownD = own.maxY - own.minY;
+  let availX = binWidth;
+  let availY = binDepth;
+  const instances = expandCutoutArray(cutout);
+  if (instances.length > 1) {
+    const u = unionBounds(instances.map(getCutoutBounds));
+    availX -= u.maxX - u.minX - ownW;
+    availY -= u.maxY - u.minY - ownD;
+  }
+  if (ownW <= availX + EPSILON && ownD <= availY + EPSILON) return null;
+  const rad = (cutout.rotation * Math.PI) / 180;
+  const cos = Math.abs(Math.cos(rad));
+  const sin = Math.abs(Math.sin(rad));
+  let width: number;
+  let depth: number;
+  if (sin < 1e-9) {
+    width = Math.min(cutout.width, availX);
+    depth = Math.min(cutout.depth, availY);
+  } else if (cos < 1e-9) {
+    width = Math.min(cutout.width, availY);
+    depth = Math.min(cutout.depth, availX);
+  } else {
+    const scale = Math.min(availX / ownW, availY / ownD);
+    width = cutout.width * scale;
+    depth = cutout.depth * scale;
+  }
+  width = Math.max(MIN_CUTOUT_SIZE, width);
+  depth = Math.max(MIN_CUTOUT_SIZE, depth);
+  const shrunk = getCutoutBounds({ ...cutout, width, depth });
+  if (
+    shrunk.maxX - shrunk.minX > availX + EPSILON ||
+    shrunk.maxY - shrunk.minY > availY + EPSILON
+  ) {
+    return null;
+  }
+  return { width, depth };
 }
 
 /** Translation that fits the instances' union within the board rectangle. */
@@ -163,13 +222,19 @@ function maskOffset(
 }
 
 /**
- * Translation that brings a stray cutout (and all its array instances) back
- * inside the board. Returns `null` when no move is needed or — for a masked or
- * lid board — no valid placement exists (the cutout stays flagged for manual
- * repair). Path vertices move in lockstep with `x`/`y`.
+ * Update that brings a stray cutout (and all its array instances) back inside
+ * the board. On a plain rectangular board a shape larger than the board is
+ * first shrunk to fit (`shrinkToFitRect`); a masked or lid board only ever
+ * translates, since "fits somewhere in a concave region" has no single right
+ * size. Returns `null` when no change is needed or no fix exists (the cutout
+ * stays flagged for manual repair). Path vertices move in lockstep with
+ * `x`/`y`.
  */
 export function clampCutoutToBoard(cutout: Cutout, board: CutoutBoard): Partial<Cutout> | null {
-  const instances = expandCutoutArray(cutout);
+  const plainRect = !board.lidWindow && !(board.mask && board.cellSize);
+  const resized = plainRect ? shrinkToFitRect(cutout, board.width, board.depth) : null;
+  const base = resized ? { ...cutout, ...resized } : cutout;
+  const instances = expandCutoutArray(base);
   let offset: { dx: number; dy: number } | null;
   if (board.lidWindow) {
     offset = lidWindowOffset(instances, board.lidWindow, board.meshAssets);
@@ -178,17 +243,17 @@ export function clampCutoutToBoard(cutout: Cutout, board: CutoutBoard): Partial<
   } else {
     offset = rectOffset(instances.map(getCutoutBounds), board.width, board.depth);
   }
-  if (!offset) return null;
+  if (!offset) return resized;
   const { dx, dy } = offset;
-  if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) return null;
-  const moved: Partial<Cutout> = { x: cutout.x + dx, y: cutout.y + dy };
-  if (cutout.shape === 'path' && cutout.path) {
-    return { ...moved, path: translatePathPoints(cutout.path, dx, dy) };
+  if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) return resized;
+  const moved: Partial<Cutout> = { ...resized, x: base.x + dx, y: base.y + dy };
+  if (base.shape === 'path' && base.path) {
+    return { ...moved, path: translatePathPoints(base.path, dx, dy) };
   }
   return moved;
 }
 
-/** Position updates for every off-board cutout that a clamp can move (empty when none). */
+/** Updates for every off-board cutout that a clamp can fix (empty when none). */
 export function clampOffBoardCutouts(
   cutouts: readonly Cutout[],
   board: CutoutBoard


### PR DESCRIPTION
Fixes #3828

## Problem

The Cut Editor's "Bring back in" action only translated a stray cutout. `fitAxis` pinned a shape larger than the board to the origin and left the overhang for the build to clip, so the "will be clipped" warning never cleared and repeated clicks were silent no-ops (the clamp returned no change once the shape sat at the origin).

## Fix

- `clampCutoutToBoard` now shrinks `width`/`depth` to fit a plain rectangular board before repositioning (`shrinkToFitRect`): axis-aligned rotations clamp each axis independently, oblique rotations scale uniformly (per-axis shrinking of a rotated box couples the axes), and array masters shrink to the extent left after the instance spread. Sizes floor at `MIN_CUTOUT_SIZE`, and a shrink that still cannot fit is withheld rather than mangling the shape without clearing the flag.
- Paths and meshes are not sized by `width`/`depth` (vertices and STL bounds are the truth), so they remain translation-only.
- When the clamp can fix nothing (oversized path/mesh, no valid mask/lid placement), the "Bring back in" button is hidden — mirroring how an unavailable "Grow bin" is handled — instead of appearing to work.

## Tests

- Replaced the test that codified the translation-only behavior with an oversize suite: single-axis clamp (the reported 500mm-wide shape on a 165.1mm board resolves in one click and is idempotent), 45° and 90° rotations, array masters, path/mesh preservation.
- `pnpm run test:run` on CutoutWorkspace + CutoutsSection: 126 files, 1244 tests pass. Typecheck and lint clean.

https://claude.ai/code/session_017DiLVpoRV1PhygnBt1MwCt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

