### PR TITLE
fix(height): stop rewriting typed mm heights via coarse unit snapping

### DIFF
--- a/packages/branded-types/src/units.test.ts
+++ b/packages/branded-types/src/units.test.ts
@@ -83,9 +83,9 @@ describe('Unit converters', () => {
       expect(mmToHeightUnits(mm(21), heightUnitMm)).toBe(3);
     });
 
-    it('keeps the fractional part, snapped to 0.01u', () => {
-      expect(mmToHeightUnits(mm(10), heightUnitMm)).toBeCloseTo(1.43, 5);
-      expect(mmToHeightUnits(mm(30.6), heightUnitMm)).toBeCloseTo(4.37, 5);
+    it('keeps the fractional part, snapped to 0.0001u', () => {
+      expect(mmToHeightUnits(mm(10), heightUnitMm)).toBeCloseTo(1.4286, 6);
+      expect(mmToHeightUnits(mm(30.6), heightUnitMm)).toBeCloseTo(4.3714, 6);
     });
 
     it('handles a custom unit so 2x a 5u target matches a 10u target', () => {
@@ -98,13 +98,27 @@ describe('Unit converters', () => {
     it('handles zero', () => {
       expect(mmToHeightUnits(mm(0), heightUnitMm)).toBe(0);
     });
+
+    // The Sidebar and bin inspector show heights with two decimals; a typed mm
+    // value must survive the mm -> units -> mm round trip at that precision
+    // for every allowed unit size (3-20mm), or the field visibly rewrites the
+    // user's number (85 became 84.98 at the default 7mm unit).
+    it.each([
+      [85, 7],
+      [33.33, 7],
+      [100.01, 3],
+      [85.01, 20],
+    ])('round-trips %smm at a %smm unit within display precision', (typed, unit) => {
+      const roundTripped = heightUnitsToMm(mmToHeightUnits(mm(typed), mm(unit)), mm(unit));
+      expect(Math.round(roundTripped * 100) / 100).toBe(typed);
+    });
   });
 
   describe('roundHeightUnits', () => {
-    it('snaps to the nearest 0.01u', () => {
-      expect(roundHeightUnits(4.3700001)).toBeCloseTo(4.37, 5);
-      expect(roundHeightUnits(4.371)).toBeCloseTo(4.37, 5);
-      expect(roundHeightUnits(4.375)).toBeCloseTo(4.38, 5);
+    it('snaps to the nearest 0.0001u', () => {
+      expect(roundHeightUnits(4.37000001)).toBeCloseTo(4.37, 6);
+      expect(roundHeightUnits(4.37141)).toBeCloseTo(4.3714, 6);
+      expect(roundHeightUnits(4.37146)).toBeCloseTo(4.3715, 6);
     });
 
     it('leaves whole and half units untouched', () => {
@@ -112,9 +126,9 @@ describe('Unit converters', () => {
       expect(roundHeightUnits(2.5)).toBe(2.5);
     });
 
-    it('snaps an exact half-step up despite binary float error (1.005u -> 1.01u)', () => {
-      // 1.005 * 100 === 100.4999… in IEEE-754, which would otherwise floor to 1.00.
-      expect(roundHeightUnits(1.005)).toBeCloseTo(1.01, 5);
+    it('snaps an exact half-step up despite binary float error (1.00005u -> 1.0001u)', () => {
+      // 1.00005 * 10000 === 10000.4999… in IEEE-754, which would otherwise floor to 1.0000.
+      expect(roundHeightUnits(1.00005)).toBeCloseTo(1.0001, 6);
     });
   });
 });

--- a/packages/branded-types/src/units.ts
+++ b/packages/branded-types/src/units.ts
@@ -40,8 +40,7 @@ export const heightUnits = (n: number): HeightUnits => n as HeightUnits;
  * is sized so a typed mm height re-displays exactly at the app's two-decimal
  * readouts for every allowed unit size: the snap error is at most
  * step/2 × 20mm (HEIGHT_UNIT_MM_MAX) = 0.001mm, under the 0.005mm a
- * two-decimal display resolves. A coarser step silently rewrites what the
- * user typed (at 0.01u, an 85mm entry reads back as 84.98).
+ * two-decimal display resolves.
  */
 export const HEIGHT_UNIT_STEP = 0.0001;
 

--- a/packages/branded-types/src/units.ts
+++ b/packages/branded-types/src/units.ts
@@ -35,17 +35,22 @@ export const heightUnits = (n: number): HeightUnits => n as HeightUnits;
 
 /**
  * Smallest height-unit increment. Heights are free fractional (e.g. a 30.6mm
- * target at a 7mm unit is 4.37u), but values are snapped to this step so the
- * stored number and its mm readout stay free of floating-point dust.
+ * target at a 7mm unit is 4.3714u), but values are snapped to this step so the
+ * stored number and its mm readout stay free of floating-point dust. The step
+ * is sized so a typed mm height re-displays exactly at the app's two-decimal
+ * readouts for every allowed unit size: the snap error is at most
+ * step/2 × 20mm (HEIGHT_UNIT_MM_MAX) = 0.001mm, under the 0.005mm a
+ * two-decimal display resolves. A coarser step silently rewrites what the
+ * user typed (at 0.01u, an 85mm entry reads back as 84.98).
  */
-export const HEIGHT_UNIT_STEP = 0.01;
+export const HEIGHT_UNIT_STEP = 0.0001;
 
 /**
  * Round a height-unit value to {@link HEIGHT_UNIT_STEP}. Divides/multiplies by
- * the integer inverse (100) rather than the 0.01 step so the result is a clean
- * decimal (4.37, not 4.3700000000000045). The tiny pre-round bias nudges exact
- * half-steps up despite binary error (1.005 * 100 = 100.4999… would else floor
- * to 1.00 instead of snapping to 1.01).
+ * the integer inverse (10000) rather than the 0.0001 step so the result is a
+ * clean decimal (4.3714, not 4.371400000000045). The tiny pre-round bias nudges
+ * exact half-steps up despite binary error (1.00005 * 10000 = 10000.4999…
+ * would else floor to 1.0000 instead of snapping to 1.0001).
  */
 const HEIGHT_UNIT_STEP_INVERSE = 1 / HEIGHT_UNIT_STEP;
 export const roundHeightUnits = (n: number): HeightUnits =>
@@ -71,7 +76,7 @@ export function mmToGridUnits(value: Mm, unitMm: Mm): GridUnits {
 
 /**
  * Convert millimeters to height units, snapped to {@link HEIGHT_UNIT_STEP}.
- * Heights are free fractional, so this rounds to the nearest 0.01u rather than
+ * Heights are free fractional, so this rounds to the nearest step rather than
  * flooring — flooring would silently drop the sub-unit part of an mm target.
  */
 export function mmToHeightUnits(value: Mm, unitMm: Mm): HeightUnits {

--- a/src/features/bin-designer/utils/validation.test.ts
+++ b/src/features/bin-designer/utils/validation.test.ts
@@ -70,8 +70,8 @@ describe('validateBinParams', () => {
       expectOk(validateBinParams(makeParams({ height: 4.37 })));
     });
 
-    it('should reject heights finer than the 0.01u step', () => {
-      const result = validateBinParams(makeParams({ height: 4.375 }));
+    it('should reject heights finer than the 0.0001u step', () => {
+      const result = validateBinParams(makeParams({ height: 4.37505 }));
       const error = expectErr(result);
       expect(error.code).toBe('INVALID_STEP');
       expect(error.field).toBe('height');

--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.test.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.test.tsx
@@ -286,11 +286,11 @@ describe('SingleBinInspector', () => {
       render(<SingleBinInspector inspector={inspector} variant="desktop" />);
 
       const heightInput = screen.getByLabelText('Bin height');
-      // 30.6mm at a 7mm unit -> 4.37u
+      // 30.6mm at a 7mm unit -> 4.3714u
       fireEvent.change(heightInput, { target: { value: '30.6' } });
       fireEvent.blur(heightInput);
 
-      expect(inspector.updateField).toHaveBeenCalledWith('height', 4.37);
+      expect(inspector.updateField).toHaveBeenCalledWith('height', 4.3714);
     });
 
     it('warns when the height will not stack with standard bins', () => {

--- a/src/shared/hooks/useDrawerSettings.test.ts
+++ b/src/shared/hooks/useDrawerSettings.test.ts
@@ -106,6 +106,16 @@ describe('useDrawerSettings', () => {
 
       expect(result.current.drawer.depth).toBe(20);
     });
+
+    it('handleDrawerHeightInput keeps the typed mm value at display precision', () => {
+      const { result } = renderHook(() => useDrawerSettings());
+
+      act(() => {
+        result.current.handleDrawerHeightInput(85);
+      });
+
+      expect(Math.round(result.current.realWorldDimensions.height * 100) / 100).toBe(85);
+    });
   });
 
   describe('half-bin mode', () => {


### PR DESCRIPTION
Fixes #3829

## Problem

Setting a drawer height in mm silently changed the value: 85 became 84.98. There is no clearance being applied. `drawer.height` (and per-bin height and clearance height) is stored as a height-unit count snapped to `HEIGHT_UNIT_STEP = 0.01u`, so the mm → units → mm round trip quantized the entry: 85mm / 7mm = 12.1428…u → 12.14u → 84.98mm. Worst-case drift was ±0.035mm at the default unit, and the field visibly rewrote itself after blur.

## Fix

Tighten `HEIGHT_UNIT_STEP` to 0.0001u. The snap error is then at most step/2 × 20mm (`HEIGHT_UNIT_MM_MAX`) = 0.001mm, below the 0.005mm a two-decimal display resolves — so every typed mm value re-displays exactly across the whole 3–20mm unit range. This keeps the existing design (heights remain clean quantized decimals, and the "height must be in step increments" validation invariant holds system-wide) rather than introducing a second, verbatim-mm source of truth. A 0.001u step is not enough: at the 20mm max unit it still visibly rewrites two-decimal entries (85.01 → 85.02).

The same conversion serves the sidebar drawer height, per-bin height, and clearance-height inputs, so one constant covers all three reported-adjacent paths.

## Tests

- New round-trip fidelity tests in `units.test.ts` (85mm@7mm, 33.33mm@7mm, 100.01mm@3mm, 85.01mm@20mm) — all failed before the fix.
- New `handleDrawerHeightInput` hook test (the mm-entry path previously had no coverage) — failed before the fix with 84.98.
- Updated the tests that encoded the 0.01u quantum (rounding snap cases, bin-designer step validation, SingleBinInspector mm conversion).
- Sweep over height consumers: 72 files, 1213 tests pass. Typecheck and lint clean.

https://claude.ai/code/session_017DiLVpoRV1PhygnBt1MwCt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

