### PR TITLE
fix(design-linking): make unlink actually clear a bin's linked design

### DIFF
--- a/src/core/cqrs/v2/domain/bin/updateBin.test.ts
+++ b/src/core/cqrs/v2/domain/bin/updateBin.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { produce } from 'immer';
 import { isOk } from '@/core/result';
 import { STAGING_ID } from '@/core/constants';
-import { binId, gridUnits } from '@/core/types';
+import { binId, designId, gridUnits } from '@/core/types';
 import { updateBin } from './updateBin';
 import { makeLayout, makeBin } from './_testHelpers';
 
@@ -134,6 +134,43 @@ describe('v2 bin.update', () => {
       expect(isOk(result)).toBe(true);
       if (!isOk(result)) return;
       expect('overhang' in result.value.event.payload.changes).toBe(false);
+    });
+  });
+
+  describe('linkedDesignId', () => {
+    const DESIGN = designId('design_1');
+
+    it('sets a new design id', () => {
+      const layout = makeLayout({ bins: [makeBin('bin_1')] });
+      const result = updateBin.handle(
+        { id: 'bin_1', updates: { linkedDesignId: 'design_2' } },
+        { aggregate: layout }
+      );
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+
+      const next = produce(layout, (draft) => {
+        updateBin.apply({ type: 'bin.updated', payload: result.value.event.payload }, draft);
+      });
+      expect(next.bins[0].linkedDesignId).toBe('design_2');
+    });
+
+    it('clears it when null is sent, and captures the previous value for undo', () => {
+      const layout = makeLayout({ bins: [makeBin('bin_1', { linkedDesignId: DESIGN })] });
+      const result = updateBin.handle(
+        { id: 'bin_1', updates: { linkedDesignId: null } },
+        { aggregate: layout }
+      );
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      expect('linkedDesignId' in result.value.event.payload.changes).toBe(true);
+      expect(result.value.event.payload.changes.linkedDesignId).toBeUndefined();
+      expect(result.value.event.payload.previous.linkedDesignId).toBe(DESIGN);
+
+      const next = produce(layout, (draft) => {
+        updateBin.apply({ type: 'bin.updated', payload: result.value.event.payload }, draft);
+      });
+      expect(next.bins[0].linkedDesignId).toBeUndefined();
     });
   });
 

--- a/src/core/cqrs/v2/domain/bin/updateBin.ts
+++ b/src/core/cqrs/v2/domain/bin/updateBin.ts
@@ -48,7 +48,7 @@ const updatesSchema = z
     label: z.string().max(CONSTRAINTS.LABEL_MAX_LENGTH),
     notes: z.string().max(CONSTRAINTS.NOTES_MAX_LENGTH),
     customProperties: z.record(z.string(), z.string()),
-    linkedDesignId: z.string(),
+    linkedDesignId: z.string().nullable(),
     extendToMargin: z.boolean(),
     marginTaper: z.object({
       profile: z.enum(['chamfer', 'fillet']),
@@ -89,7 +89,8 @@ function brandUpdates(updates: z.infer<typeof updatesSchema>): Partial<Bin> {
   if (updates.notes !== undefined) result.notes = updates.notes;
   if (updates.customProperties !== undefined) result.customProperties = updates.customProperties;
   if (updates.linkedDesignId !== undefined)
-    result.linkedDesignId = toDesignId(updates.linkedDesignId);
+    result.linkedDesignId =
+      updates.linkedDesignId === null ? undefined : toDesignId(updates.linkedDesignId);
   if (updates.extendToMargin !== undefined) result.extendToMargin = updates.extendToMargin;
   if (updates.marginTaper !== undefined) result.marginTaper = updates.marginTaper;
   // `null` is the wire form of "clear it"; the field itself is just optional.

--- a/src/core/cqrs/validation/schemas.test.ts
+++ b/src/core/cqrs/validation/schemas.test.ts
@@ -244,6 +244,11 @@ describe('bin.update schema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('accepts null to clear the linked design', () => {
+    const result = z.safeParse(schema, { id: 'bin-1', updates: { linkedDesignId: null } });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('bin.deleteBatch schema', () => {

--- a/src/core/cqrs/validation/schemas.ts
+++ b/src/core/cqrs/validation/schemas.ts
@@ -102,7 +102,7 @@ const binPartialSchema = z
     label: labelStr,
     notes: notesStr,
     customProperties: z.record(z.string(), z.string()),
-    linkedDesignId: z.string(),
+    linkedDesignId: z.string().nullable(),
     extendToMargin: z.boolean(),
     marginTaper: z.object({
       profile: z.enum(['chamfer', 'fillet']),

--- a/src/core/types/layout.ts
+++ b/src/core/types/layout.ts
@@ -158,15 +158,18 @@ export interface Bin {
 /**
  * Update payload for a bin.
  *
- * Identical to `Partial<Bin>` except that `overhang` is tri-state: omitted
- * leaves it alone, an object sets it, and `null` clears it. A plain optional
- * field can't express "clear" — `{ overhang: undefined }` is indistinguishable
- * from omission once it crosses the command boundary.
+ * Identical to `Partial<Bin>` except that the fields below are tri-state:
+ * omitted leaves one alone, a value sets it, and `null` clears it. A plain
+ * optional field can't express "clear" — `{ overhang: undefined }` is
+ * indistinguishable from omission once it crosses the command boundary.
  */
-export type BinUpdates = Partial<Omit<Bin, 'overhang' | 'pairId' | 'pairRole'>> & {
+export type BinUpdates = Partial<
+  Omit<Bin, 'overhang' | 'pairId' | 'pairRole' | 'linkedDesignId'>
+> & {
   overhang?: OverhangConfig | null;
   pairId?: string | null;
   pairRole?: 'block' | 'rest' | null;
+  linkedDesignId?: DesignId | null;
 };
 
 /** Grid coordinate (0-based, origin at bottom-left). */

--- a/src/features/design-linking/hooks/useBinLinking.test.ts
+++ b/src/features/design-linking/hooks/useBinLinking.test.ts
@@ -190,7 +190,7 @@ describe('useBinLinking', () => {
         result.current.unlinkBin(binId('bin-1'));
       });
 
-      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: undefined });
+      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: null });
     });
 
     it('shows info toast when unlinking', () => {
@@ -249,8 +249,8 @@ describe('useBinLinking', () => {
         result.current.unlinkBins([binId('bin-1'), binId('bin-2')]);
       });
 
-      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: undefined });
-      expect(mockUpdateBin).toHaveBeenCalledWith('bin-2', { linkedDesignId: undefined });
+      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: null });
+      expect(mockUpdateBin).toHaveBeenCalledWith('bin-2', { linkedDesignId: null });
     });
 
     it('handles empty array', () => {
@@ -581,7 +581,7 @@ describe('useBinLinking', () => {
       });
 
       // Bin should be unlinked because it can't fit
-      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: undefined });
+      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: null });
       expect(syncResult.unlinked).toContain('bin-1');
       expect(syncResult.synced).toHaveLength(0);
     });
@@ -743,7 +743,7 @@ describe('useBinLinking', () => {
         );
       });
 
-      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: undefined });
+      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: null });
       expect(DesignerStorage.deleteDesign).toHaveBeenCalledWith('design-1');
       expect(CustomBinRegistry.removeRegistryEntry).toHaveBeenCalledWith('design-1');
       expect(mockAddToast).toHaveBeenCalledWith({
@@ -798,7 +798,7 @@ describe('useBinLinking', () => {
         );
       });
 
-      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: undefined });
+      expect(mockUpdateBin).toHaveBeenCalledWith('bin-1', { linkedDesignId: null });
     });
   });
 

--- a/src/features/design-linking/hooks/useBinLinking.ts
+++ b/src/features/design-linking/hooks/useBinLinking.ts
@@ -125,7 +125,7 @@ export function useBinLinking(): UseBinLinkingReturn {
       if (!bin || !bin.linkedDesignId) return;
 
       batch(() => {
-        updateBin(binId, { linkedDesignId: undefined });
+        updateBin(binId, { linkedDesignId: null });
       });
 
       addToast({
@@ -142,7 +142,7 @@ export function useBinLinking(): UseBinLinkingReturn {
     (binIds: BinId[]) => {
       batch(() => {
         for (const binId of binIds) {
-          updateBin(binId, { linkedDesignId: undefined });
+          updateBin(binId, { linkedDesignId: null });
         }
       });
     },
@@ -260,7 +260,7 @@ export function useBinLinking(): UseBinLinkingReturn {
             synced.push(elig.binId);
           } else {
             // Unlink bin that can't sync
-            updateBin(elig.binId, { linkedDesignId: undefined });
+            updateBin(elig.binId, { linkedDesignId: null });
             unlinked.push(elig.binId);
           }
         }
@@ -406,7 +406,7 @@ export function useBinLinking(): UseBinLinkingReturn {
     async (binId: BinId, designId: DesignId, designName: string): Promise<boolean> => {
       // First unlink the bin
       batch(() => {
-        updateBin(binId, { linkedDesignId: undefined });
+        updateBin(binId, { linkedDesignId: null });
       });
 
       // Then delete the design from storage


### PR DESCRIPTION
Fixes #3830

## Problem

Clicking "Unlink" on a stale link (a deleted design) did nothing — the prompt stayed up and survived refreshes. `unlinkBin()` dispatched `updateBin(binId, { linkedDesignId: undefined })`, but the `bin.update` command's field diffing (`if (updates.linkedDesignId !== undefined)`) cannot distinguish a present-but-`undefined` key from an omitted one, so the clear never made it into the event payload and the store field was never touched. Nothing changed, so nothing persisted — which is why a refresh didn't help either. All four unlink paths (single unlink, bulk unlink, sync-can't-fit unlink, delete-design unlink) were the same no-op.

This is exactly the trap the `BinUpdates` docstring warns about; `overhang`/`pairId`/`pairRole` already use a null-means-clear tri-state for it, but `linkedDesignId` was never added to that group.

## Fix

Extend the established tri-state pattern to `linkedDesignId`:

- `BinUpdates` accepts `DesignId | null` (docstring generalized — it previously named `overhang` as the sole tri-state field, which was already stale and is the misreading that caused this bug).
- Both validation schemas (`binPartialSchema` in the enforced `COMMAND_SCHEMAS` registry, and the command's local schema that types `handle()`) accept `.nullable()`.
- `brandUpdates` unwraps `null → undefined` like `pairId`, so `null` never escapes the handler; event payloads, replay, and the collab wire format are unchanged and no schema version bump is needed.
- All four call sites in `useBinLinking` send `null`.

## Tests

- New command-layer regression test (modeled on the existing `overhang` block): `{ linkedDesignId: null }` clears the field through `handle()` + `apply()` and captures the previous value — confirmed failing before the fix ("expected null to be undefined").
- New schema test (`accepts null to clear the linked design`) — the handler test alone bypasses the validate middleware, and this case was also confirmed failing against the unfixed schema.
- Updated the six hook assertions to expect `null`.
- Sweeps: cqrs + design-linking + types (86 files / 815 tests), bin-inspector + shared hooks + store (99 files / 1697 tests) all pass. Typecheck, eslint, prettier clean.

https://claude.ai/code/session_017DiLVpoRV1PhygnBt1MwCt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

