### PR TITLE
chore(git): stop tracking Command Code agent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,8 @@ benchmarks/latest.json
 # build (scripts/vite-plugin-mediapipe-assets.ts), not committed. The model
 # (public/models/interactive-segmenter/) IS committed; it isn't published to npm.
 public/models/tasks-vision/
+
+# Command Code agent state: a local taste-learning profile, plus AGENTS.md,
+# which contributors symlink to CLAUDE.md so the two agents cannot drift apart.
+.commandcode/
+/AGENTS.md


### PR DESCRIPTION
Removes `.commandcode/taste/taste.md` from the repo and ignores the directory that produced it.

The file is an empty local agent learning profile. It reached main in d4467bec64, where an agent first-run created it mid-session and a later `git add -A` swept it into an otherwise unrelated commit.

`AGENTS.md` is ignored alongside `.commandcode/` so it can be symlinked to `CLAUDE.md` locally. Agents that read only `AGENTS.md` then pick up the existing project doc, with no second copy to drift from the original or to carry its own `scripts/doc-budget.json` entry.

https://claude.ai/code/session_01AmPDqowMXEgb9KNm6p6PX3

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

