### PR TITLE
chore(git): ignore every local .env variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ bundle-analysis.*
 # Implementation plans (transient, never commit)
 docs/plans/
 .env*.local
+# Broader than the two rules above: .env.production / .env.staging carry real
+# credentials and matched neither. The template stays tracked.
+.env*
+!.env.example
 .playwright-mcp/
 
 # Defensive — training script pulls prod credentials into its own dir


### PR DESCRIPTION
Closes a gap where a credentials file could be staged without warning.

`.env.production` and `.env.staging` matched neither `.env` nor `.env*.local`, so either was committable. `.env*` covers every local variant.

`!.env.example` keeps the tracked template visible. Today it survives on tracking status alone, so untracking and re-adding it would hide it silently.

Verified at the pattern level with `git check-ignore --no-index`: `.env`, `.env.local`, `.env.production`, `.env.staging` and `.env.production.local` all ignored, `.env.example` still visible.

https://claude.ai/code/session_01AmPDqowMXEgb9KNm6p6PX3

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

