### PR TITLE
fix(skills): quote the json-schemas description so its frontmatter parses

### DIFF
--- a/.claude/skills/json-schemas/SKILL.md
+++ b/.claude/skills/json-schemas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: json-schemas
-description: Hand-authoring or editing the two user-facing JSON documents: layout files (drawer, grid, layers, bins, baseplateParams, linkedDesigns) and bin design files (the gridfinity-bin-design wrapper around BinParams). Covers validating a file before import, the cross-field rules JSON Schema cannot express, the unit and orientation traps that produce valid-but-wrong files, and how to change a schema without breaking its four drift guards. Load when writing a layout or design JSON by hand, when an import is rejected, or when adding a field to Layout, Bin, or BinParams.
+description: 'Hand-authoring or editing the two user-facing JSON documents: layout files (drawer, grid, layers, bins, baseplateParams, linkedDesigns) and bin design files (the gridfinity-bin-design wrapper around BinParams). Covers validating a file before import, the cross-field rules JSON Schema cannot express, the unit and orientation traps that produce valid-but-wrong files, and how to change a schema without breaking its four drift guards. Load when writing a layout or design JSON by hand, when an import is rejected, or when adding a field to Layout, Bin, or BinParams.'
 ---
 
 # JSON schemas


### PR DESCRIPTION
`.claude/skills/json-schemas/SKILL.md` has invalid YAML frontmatter. The description contains `JSON documents: layout files`, and that bare `: ` makes YAML read the value as a nested mapping.

The four sibling skills whose descriptions contain a colon (`auth-and-sync`, `content-and-seo`, `release-and-ci`, `state-and-cqrs`) already single-quote them. This one did not, so the fix matches the existing convention.

Claude Code's parser tolerates the malformed value, so the skill kept loading and the breakage stayed invisible. A stricter YAML parser rejects the file and drops the skill entirely.

Verified: all 18 `SKILL.md` frontmatters parse under `yaml.safe_load` after this change, up from 17. The description text is byte-identical, only the quoting changed.

https://claude.ai/code/session_01AmPDqowMXEgb9KNm6p6PX3

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

