### PR TITLE
fix(bin-designer): make stashEntryMask the whole usability gate

### DIFF
--- a/src/features/bin-designer/components/BentoWorkspace/BentoStashShelf.test.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoStashShelf.test.tsx
@@ -71,11 +71,15 @@ describe('BentoStashShelf', () => {
     expect(screen.queryByTestId('bento-stash-shape-0')).not.toBeInTheDocument();
   });
 
-  it('renders a wrong-length mask as one block, matching where it would place', () => {
-    // placeFromStash falls back to the rectangle for a mask that does not match
-    // the box, so previewing the partial cells would advertise a shape the drop
-    // never produces.
-    render(<BentoStashShelf {...makeProps({ stash: [{ w: 2, h: 2, cells: [true, true] }] })} />);
+  it.each([
+    ['wrong length', [true, true]],
+    ['empty', [false, false, false, false]],
+    ['all filled', [true, true, true, true]],
+    ['two islands', [true, false, false, true]],
+  ])('renders a %s mask as one block, matching where it would place', (_label, cells) => {
+    // placeFromStash resolves every one of these to the plain rectangle, so
+    // previewing the raw cells would advertise a shape the drop never produces.
+    render(<BentoStashShelf {...makeProps({ stash: [{ w: 2, h: 2, cells }] })} />);
 
     expect(screen.queryByTestId('bento-stash-shape-0')).not.toBeInTheDocument();
   });

--- a/src/features/bin-designer/constants/paramMigration.ts
+++ b/src/features/bin-designer/constants/paramMigration.ts
@@ -121,7 +121,7 @@ import {
 import type { TextStyleDefaults } from '../types/text';
 import { MAX_CUTOUT_CORNER_RADIUS } from '@/shared/utils/wallCutoutPosition';
 import { MAX_CUTOUT_TOP_OFFSET_MM } from '../utils/cutoutFill';
-import { isContiguousSelection } from '../utils/compartments';
+import { isUsableFootprintMask } from '../utils/compartments';
 import { DESIGNER_CONSTRAINTS } from './gridfinity';
 import {
   DEFAULT_BIN_PARAMS,
@@ -1058,16 +1058,9 @@ function migrateSurfaceText(raw: unknown): SurfaceTextConfig | undefined {
 function cleanFootprintMask(mask: unknown, w: number, h: number): boolean[] | undefined {
   if (!Array.isArray(mask)) return undefined;
   const cells: unknown[] = mask;
-  if (cells.length !== w * h) return undefined;
   if (cells.some((cell) => typeof cell !== 'boolean')) return undefined;
-  const filled: number[] = [];
-  cells.forEach((cell, i) => {
-    if (cell === true) filled.push(i);
-  });
-  if (filled.length === 0 || filled.length === cells.length) return undefined;
-  // The mask is its own w-wide grid, so its own width is the stride.
-  if (!isContiguousSelection(w, filled)) return undefined;
-  return cells as boolean[];
+  const booleans = cells as boolean[];
+  return isUsableFootprintMask(booleans, w, h) ? booleans : undefined;
 }
 
 /**

--- a/src/features/bin-designer/utils/bentoDraw.test.ts
+++ b/src/features/bin-designer/utils/bentoDraw.test.ts
@@ -302,25 +302,19 @@ describe('bentoDraw', () => {
       expect(placeFromStash(withDrawn, 0, { col: 1, row: 0, w: 2, h: 2 })).toBeNull();
     });
 
-    it('placeFromStash refuses a mask that is not one connected region', () => {
-      // Only reachable from a hand-authored design file; two islands under one
-      // id would print as two pockets sharing a label.
-      const config: CompartmentConfig = {
-        ...grid(),
-        stash: [{ w: 2, h: 2, cells: [true, false, false, true] }],
-      };
-      expect(placeFromStash(config, 0, { col: 1, row: 0, w: 2, h: 2 })).toBeNull();
-    });
-
-    it('placeFromStash falls back to the rectangle for a wrong-length mask', () => {
-      const config: CompartmentConfig = {
-        ...grid(),
-        stash: [{ w: 2, h: 2, cells: [true, true] }],
-      };
+    it.each([
+      ['wrong length', [true, true]],
+      ['empty', [false, false, false, false]],
+      ['all filled', [true, true, true, true]],
+      ['two islands', [true, false, false, true]],
+    ])('placeFromStash places a %s mask as the plain rectangle', (_label, cells) => {
+      // Every shape drawFootprint would refuse resolves the same way here and in
+      // the shelf preview, so a stash chip cannot advertise a shape the drop
+      // will not produce.
+      const config: CompartmentConfig = { ...grid(), stash: [{ w: 2, h: 2, cells }] };
       const placed = placeFromStash(config, 0, { col: 1, row: 0, w: 2, h: 2 });
       expect(placed).not.toBeNull();
       if (!placed) throw new Error('unreachable');
-      expect(getCompartmentRect(placed.config, placed.id)).toEqual({ col: 1, row: 0, w: 2, h: 2 });
       expect(getCellsForCompartment(placed.config, placed.id)).toHaveLength(4);
     });
 

--- a/src/features/bin-designer/utils/bentoDraw.ts
+++ b/src/features/bin-designer/utils/bentoDraw.ts
@@ -25,6 +25,7 @@ import { DESIGNER_CONSTRAINTS } from '../constants/gridfinity';
 import {
   cellIndex,
   isContiguousSelection,
+  isUsableFootprintMask,
   getCellsForCompartment,
   getCompartmentBounds,
   getCompartmentReadingOrder,
@@ -565,14 +566,17 @@ export function stashCompartment(config: CompartmentConfig, id: number): Compart
 
 /**
  * A stash entry's usable footprint mask, or undefined when the entry stands for
- * a plain rectangle. The single answer for placement and for the shelf preview:
- * a mask of the wrong length must not render as one shape and place as another,
- * and indexing past its end would read `undefined` as false and silently shrink
- * the footprint. Migration drops these on load; this covers state that never
- * passed through it.
+ * a plain rectangle. The single answer for placement and for the shelf preview,
+ * covering every mask `drawFootprint` would refuse: wrong length (indexing past
+ * its end reads `undefined` as false and silently shrinks the footprint), empty,
+ * all-filled, or split into islands. Anything short of that renders as one shape
+ * and places as another. Migration drops these on load; this covers state that
+ * never passed through it.
  */
 export function stashEntryMask(entry: StashedCompartment): boolean[] | undefined {
-  return entry.cells?.length === entry.w * entry.h ? entry.cells : undefined;
+  const { cells } = entry;
+  if (!cells || !isUsableFootprintMask(cells, entry.w, entry.h)) return undefined;
+  return cells;
 }
 
 /** Place a stash entry onto background grid; the rect must match its size. */

--- a/src/features/bin-designer/utils/compartments.ts
+++ b/src/features/bin-designer/utils/compartments.ts
@@ -221,6 +221,26 @@ function allCompartmentsContiguous(cols: number, cells: readonly number[]): bool
 }
 
 /**
+ * Whether a stash footprint mask is one the grid can actually take: the right
+ * length for its box, at least one filled cell, not every cell (a rectangle has
+ * its own encoding, the absent field), and one 4-connected region.
+ *
+ * Shared by the load-time sanitizer, the placement path and the shelf preview so
+ * a mask cannot be dropped by one and honoured by another, which would advertise
+ * a shape the drop never produces.
+ */
+export function isUsableFootprintMask(mask: readonly boolean[], w: number, h: number): boolean {
+  if (mask.length !== w * h) return false;
+  const filled: number[] = [];
+  mask.forEach((cell, i) => {
+    if (cell) filled.push(i);
+  });
+  if (filled.length === 0 || filled.length === mask.length) return false;
+  // The mask is its own w-wide grid, so its own width is the stride.
+  return isContiguousSelection(w, filled);
+}
+
+/**
  * Whether a compartment fills its own bounding box.
  *
  * Non-rectangular compartments (an L, U or S built by merging) are valid


### PR DESCRIPTION
Follow-up to #3849, which merged before this review comment landed.

## Problem

`stashEntryMask` was introduced in #3849 as the single answer to "is this mask usable", shared by placement and the shelf preview so the two could not disagree. It only checked length.

Three other invalid shapes got past it, and each one renders per-cell in the shelf while `drawFootprint` refuses to place it:

| Mask | Shelf showed | Drop produced |
| --- | --- | --- |
| empty (all false) | an empty grid | nothing, `drawFootprint` rejects `indices.length === 0` |
| two islands | the two islands | nothing, rejected by the contiguity guard |
| all filled | a full block | a rectangle (agreed by luck, not by rule) |

So the docstring's claim was wrong, and a stash chip could still advertise a shape the drop would not produce.

## Fix

`isUsableFootprintMask(mask, w, h)` in `utils/compartments.ts` is now the one predicate: right length, at least one filled cell, not every cell, and one 4-connected region. It lives there because that module imports only types, so both the utils layer and the constants layer can reach it without a cycle.

- `stashEntryMask` delegates to it, so every rejected mask falls back to the plain rectangle in **both** placement and preview.
- `cleanFootprintMask` in `paramMigration.ts` delegates to it too, keeping its `unknown` type-narrowing and dropping the duplicated rules.

`api/lib/designerCompartmentValidation.ts` stays a hand-written mirror, as it cannot import from `src/`.

## Behaviour change

A disconnected mask used to make `placeFromStash` return `null`, and #3849 had a test asserting that. It now places a rectangle instead, which is why that test is gone.

Falling back is the better of the two: the shelf already previews these as a rectangle, so refusing the drop meant dragging a chip and having nothing happen. Placing what was previewed is self-consistent and matches how migration treats the same data on load. The contiguity guard in `drawFootprint` stays as the enforcement point for any future caller handed an untrusted index set.

## Tests

Both paths are now parameterized over all four invalid shapes, so preview and placement are pinned to agree case by case. Full bin-designer suite green (484 files, 5509 tests).

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

