### PR TITLE
fix(bin-designer): keep merged compartment shapes through move, clone and stash

### DIFF
--- a/.claude/skills/bin-designer/SKILL.md
+++ b/.claude/skills/bin-designer/SKILL.md
@@ -22,6 +22,8 @@ Read `src/features/bin-designer/README.md` first — it covers the store/worker/
 4. **Every client constraint has a hand-maintained server mirror.** `constants/gridfinity.ts` `DESIGNER_CONSTRAINTS` ↔ `api/lib/designerValidationConstants.ts` `CONSTRAINTS`; type unions in `types/index.ts` ↔ `VALID_BIN_STYLES` / `VALID_LABEL_TAB_SUPPORTS` in `api/lib/designerValidation.ts`; top-level param keys ↔ `ALLOWED_PARAM_KEYS` there. Divergence means 400s on sync or params silently stripped from shares. `sanitizeTags` (server) must stay behaviorally identical to `normalizeTags` (`utils/tags.ts`).
 5. **Wall-feature units are mixed by design.** `WallCutout` width/depth are percentages (0–100 of wall span / wall height); `widthMm: null` means "use the % field". Handle width is % of span but handle height is mm. See the JSDoc on each field in `types/index.ts` — mixing these passes typecheck and produces silently wrong geometry.
 
+6. **A Bento compartment is a cell footprint, not a rect.** A merged L/S/T/U holds fewer cells than its bounding box, so every op in `utils/bentoDraw.ts` that rebuilds `cells` must carry `compartmentMask` (offsets inside the box) instead of repainting `rectIndices` — that squares the shape off, and it did so through move, duplicate, stash and `resizeGridPreservingCompartments` alike. `canPlaceMask` is the matching collision test: the notch of an L is not part of the compartment, so a rect test refuses legal drops. `StashedCompartment.cells` persists the footprint (absent = the full box, so rectangles serialize unchanged) and `migrateBentoCompartmentFields` sanitizes it on load. `resizeCompartment` refuses a non-rectangular compartment, matching the canvas, which hides its handles.
+
 ## Recipes
 
 ### Add a field to BinParams

--- a/api/lib/designerCompartmentValidation.test.ts
+++ b/api/lib/designerCompartmentValidation.test.ts
@@ -753,6 +753,54 @@ describe('validateCompartments', () => {
       );
     });
 
+    it('accepts a merged footprint and treats an absent one as the full box', () => {
+      expect(
+        validateCompartments({
+          ...validCompartments(),
+          stash: [
+            { w: 2, h: 2, cells: [0, 1, 2] },
+            { w: 2, h: 2 },
+          ],
+        })
+      ).toBeNull();
+    });
+
+    it('rejects a cells field that is not an array', () => {
+      expect(
+        validateCompartments({ ...validCompartments(), stash: [{ w: 2, h: 2, cells: 3 }] })
+      ).toBe('compartments.stash[0].cells must be an array');
+    });
+
+    it('rejects an empty or over-full cells list', () => {
+      expect(
+        validateCompartments({ ...validCompartments(), stash: [{ w: 2, h: 2, cells: [] }] })
+      ).toBe('compartments.stash[0].cells must hold 1-4 offsets');
+      expect(
+        validateCompartments({
+          ...validCompartments(),
+          stash: [{ w: 2, h: 2, cells: [0, 1, 2, 3, 3] }],
+        })
+      ).toBe('compartments.stash[0].cells must hold 1-4 offsets');
+    });
+
+    it('rejects offsets outside the box or not integers', () => {
+      expect(
+        validateCompartments({ ...validCompartments(), stash: [{ w: 2, h: 2, cells: [4] }] })
+      ).toBe('compartments.stash[0].cells offsets must be integers 0-3');
+      expect(
+        validateCompartments({ ...validCompartments(), stash: [{ w: 2, h: 2, cells: [-1] }] })
+      ).toBe('compartments.stash[0].cells offsets must be integers 0-3');
+      expect(
+        validateCompartments({ ...validCompartments(), stash: [{ w: 2, h: 2, cells: [1.5] }] })
+      ).toBe('compartments.stash[0].cells offsets must be integers 0-3');
+    });
+
+    it('rejects a duplicated offset rather than deduping it', () => {
+      expect(
+        validateCompartments({ ...validCompartments(), stash: [{ w: 2, h: 2, cells: [0, 0] }] })
+      ).toBe('compartments.stash[0].cells has duplicate offset 0');
+    });
+
     it('rejects a non-string label', () => {
       expect(
         validateCompartments({ ...validCompartments(), stash: [{ w: 1, h: 1, label: 7 }] })

--- a/api/lib/designerCompartmentValidation.ts
+++ b/api/lib/designerCompartmentValidation.ts
@@ -395,6 +395,29 @@ export function validateCompartments(compartments: unknown): string | null {
       ) {
         return `compartments.stash[${i}].h must be integer 1-${CONSTRAINTS.MAX_COMPARTMENT_GRID}`;
       }
+      // Merged shapes carry their footprint as offsets into the w×h box.
+      // Absent means the full box, which is every unmerged entry. Duplicates
+      // are rejected rather than deduped: an entry the client never writes is
+      // a hand-authored payload, and a silent repair hides that.
+      if (entry.cells !== undefined) {
+        if (!Array.isArray(entry.cells)) {
+          return `compartments.stash[${i}].cells must be an array`;
+        }
+        const capacity = entry.w * entry.h;
+        if (entry.cells.length === 0 || entry.cells.length > capacity) {
+          return `compartments.stash[${i}].cells must hold 1-${capacity} offsets`;
+        }
+        const seen = new Set<number>();
+        for (const offset of entry.cells) {
+          if (!isNumber(offset) || !Number.isInteger(offset) || !inRange(offset, 0, capacity - 1)) {
+            return `compartments.stash[${i}].cells offsets must be integers 0-${capacity - 1}`;
+          }
+          if (seen.has(offset)) {
+            return `compartments.stash[${i}].cells has duplicate offset ${offset}`;
+          }
+          seen.add(offset);
+        }
+      }
       if (entry.label !== undefined) {
         if (typeof entry.label !== 'string') {
           return `compartments.stash[${i}].label must be a string`;

--- a/docs/schemas/bin-design.md
+++ b/docs/schemas/bin-design.md
@@ -224,7 +224,9 @@ grid finishes in about 14s, while 16x16 reaches ~39s and risks a timeout.
 
 <a id="stashedcompartment"></a>
 
-3 fields, in `src/features/bin-designer/types/compartments.ts`.
+4 fields, in `src/features/bin-designer/types/compartments.ts`. A merged L/S/T/U
+carries `cells`, the offsets it occupies inside its `w × h` box; omit it for a
+rectangle.
 
 ## Scoop
 

--- a/public/schema/bin-design.schema.json
+++ b/public/schema/bin-design.schema.json
@@ -2061,6 +2061,13 @@
           "minimum": 1,
           "description": "Height in compartment cells."
         },
+        "cells": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "integer", "minimum": 0 },
+          "description": "Occupied cells as row * w + col offsets inside the w x h box, for a merged L/S/T/U. Omit for a plain rectangle, which fills its box."
+        },
         "label": {
           "type": "string",
           "description": "Optional label carried with the stashed shape."

--- a/src/features/bin-designer/components/BentoWorkspace/BentoCanvas.test.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoCanvas.test.tsx
@@ -166,6 +166,45 @@ describe('BentoCanvas', () => {
     expect(ghost).toHaveAttribute('data-snap-state', 'invalid');
   });
 
+  it('draws a merged ghost as its own outline, not as its bounding rect', () => {
+    const { config } = withDrawn();
+    const { rerender } = render(
+      <BentoCanvas
+        {...makeProps(config, {
+          ghost: {
+            rect: { col: 2, row: 0, w: 2, h: 2 },
+            valid: true,
+            kind: 'move',
+            overStash: false,
+            mask: [0, 1, 2],
+          },
+        })}
+      />
+    );
+    // The L traces 6 corners; a rect ghost would be a <rect> with none.
+    const outline = screen.getByTestId('bento-canvas').querySelector('path[data-snap-state]');
+    expect(outline).not.toBeNull();
+    expect(outline?.getAttribute('d')?.match(/L /g)).toHaveLength(5);
+
+    // A ghost dragged off the grid can't be traced, so it falls back to the rect.
+    rerender(
+      <BentoCanvas
+        {...makeProps(config, {
+          ghost: {
+            rect: { col: 3, row: 0, w: 2, h: 2 },
+            valid: false,
+            kind: 'move',
+            overStash: false,
+            mask: [0, 1, 2],
+          },
+        })}
+      />
+    );
+    const canvas = screen.getByTestId('bento-canvas');
+    expect(canvas.querySelector('path[data-snap-state]')).toBeNull();
+    expect(canvas.querySelector('rect[data-snap-state]')).not.toBeNull();
+  });
+
   it('hides the ghost while a move hovers the stash shelf', () => {
     const { config } = withDrawn();
     render(

--- a/src/features/bin-designer/components/BentoWorkspace/BentoCanvas.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoCanvas.tsx
@@ -276,6 +276,24 @@ export function BentoCanvas({
     return { x: x + 1, y: y + 1, width: Math.max(0, w - 2), height: Math.max(0, h - 2) };
   })();
 
+  /**
+   * Outline for a ghost carrying a merged footprint, so a dragged L keeps its
+   * shape instead of promising the bounding box the drop will not fill. Null
+   * once the drag leaves the grid — the rect ghost still reads as "not here".
+   */
+  const ghostLoops = useMemo(() => {
+    if (!ghost?.mask) return null;
+    const { rect, mask } = ghost;
+    const indices: number[] = [];
+    for (const offset of mask) {
+      const col = rect.col + (offset % rect.w);
+      const row = rect.row + Math.floor(offset / rect.w);
+      if (col < 0 || col >= cols || row < 0 || row >= rows) return null;
+      indices.push(row * cols + col);
+    }
+    return cellRegionLoops(cols, rows, indices);
+  }, [ghost, cols, rows]);
+
   const handlesFor = (rect: CellRect) => {
     const { x, y, w, h } = rectPx(rect);
     const cx = x + w / 2;
@@ -453,15 +471,27 @@ export function BentoCanvas({
       {/* Gesture ghost (hidden while a move hovers the stash shelf) */}
       {ghost && !ghost.overStash && (
         <>
-          <rect
-            {...ghostPx}
-            rx={5}
-            strokeWidth={2}
-            style={ghostStyle(ghost)}
-            data-interaction-preview={ghost.kind}
-            data-snap-state={ghost.valid ? 'valid' : 'invalid'}
-            pointerEvents="none"
-          />
+          {ghostLoops ? (
+            <path
+              d={regionPathD(ghostLoops, cornerPx)}
+              fillRule="evenodd"
+              strokeWidth={2}
+              style={ghostStyle(ghost)}
+              data-interaction-preview={ghost.kind}
+              data-snap-state={ghost.valid ? 'valid' : 'invalid'}
+              pointerEvents="none"
+            />
+          ) : (
+            <rect
+              {...ghostPx}
+              rx={5}
+              strokeWidth={2}
+              style={ghostStyle(ghost)}
+              data-interaction-preview={ghost.kind}
+              data-snap-state={ghost.valid ? 'valid' : 'invalid'}
+              pointerEvents="none"
+            />
+          )}
           {/* Live size, so a drag says what it is about to produce instead of
               only whether it fits. The draw gesture's footer hint carries the
               cell count; this is the millimetres, on the shape itself. */}

--- a/src/features/bin-designer/components/BentoWorkspace/BentoStashShelf.test.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoStashShelf.test.tsx
@@ -30,6 +30,26 @@ describe('BentoStashShelf', () => {
     expect(screen.getByText('binDesigner.bento.stashDropHint')).toBeInTheDocument();
   });
 
+  it('draws a merged entry as its outline so the shelf shows what comes back out', () => {
+    render(
+      <BentoStashShelf
+        {...makeProps({
+          stash: [
+            { w: 2, h: 2, cells: [0, 1, 2] },
+            { w: 2, h: 2 },
+          ],
+        })}
+      />
+    );
+
+    const tile = (index: number) =>
+      screen.getByTestId(`bento-stash-entry-${index}`).querySelector('[role="button"] svg path');
+    expect(tile(0)).not.toBeNull();
+    // Six corners for an L; the plain rectangle beside it stays a sized div.
+    expect(tile(0)?.getAttribute('d')?.match(/L /g)).toHaveLength(5);
+    expect(tile(1)).toBeNull();
+  });
+
   it('renders one tile per entry with its label', () => {
     render(
       <BentoStashShelf

--- a/src/features/bin-designer/components/BentoWorkspace/BentoStashShelf.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoStashShelf.tsx
@@ -10,6 +10,7 @@ import { IconButton } from '@/design-system';
 import { ICON_PATHS } from '@/shared/constants/iconPaths';
 import { useTranslation } from '@/i18n';
 import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
+import { cellRegionLoops, regionPathD } from '@/features/bin-designer/utils/bentoRegion';
 import type { StashedCompartment } from '@/features/bin-designer/types';
 
 function Icon({ paths }: { readonly paths: readonly string[] }) {
@@ -54,6 +55,13 @@ export function BentoStashShelf({
     };
   };
 
+  // A merged entry draws its own outline, so the shelf shows the L that comes
+  // back out rather than the bounding box it fits in. Row 0 is the bin front,
+  // which the canvas puts at the BOTTOM — the projection flips to match, or a
+  // stashed L would sit mirrored against the shape it came from.
+  const tileLoops = (entry: StashedCompartment) =>
+    entry.cells ? cellRegionLoops(entry.w, entry.h, entry.cells) : null;
+
   return (
     <div
       ref={shelfRef}
@@ -84,9 +92,10 @@ export function BentoStashShelf({
           {stash.map((entry, index) => {
             const isDragging = index === draggingIndex;
             const { width, height } = tileSize(entry);
+            const loops = tileLoops(entry);
             return (
               <div
-                key={`${index}-${entry.w}x${entry.h}-${entry.label ?? ''}`}
+                key={`${index}-${entry.w}x${entry.h}-${entry.cells?.join(',') ?? ''}-${entry.label ?? ''}`}
                 className={`group relative flex flex-shrink-0 flex-col items-center gap-0.5 rounded-md border p-1.5 ${
                   isDragging
                     ? 'border-dashed border-accent bg-transparent'
@@ -105,12 +114,33 @@ export function BentoStashShelf({
                   className="flex items-center justify-center"
                   onPointerDown={(e) => onEntryPointerDown(index, e)}
                 >
-                  <div
-                    className={`rounded-sm border ${
-                      isDragging ? 'border-dashed border-accent' : 'border-accent/70 bg-accent/15'
-                    }`}
-                    style={{ width, height }}
-                  />
+                  {loops ? (
+                    <svg
+                      width={width}
+                      height={height}
+                      viewBox={`0 0 ${entry.w} ${entry.h}`}
+                      preserveAspectRatio="none"
+                      aria-hidden
+                    >
+                      <path
+                        d={regionPathD(loops, (c) => ({ x: c.col, y: entry.h - c.row }))}
+                        fillRule="evenodd"
+                        vectorEffect="non-scaling-stroke"
+                        className={
+                          isDragging ? 'fill-none stroke-accent' : 'fill-accent/15 stroke-accent/70'
+                        }
+                        strokeWidth={1}
+                        strokeDasharray={isDragging ? '3 2' : undefined}
+                      />
+                    </svg>
+                  ) : (
+                    <div
+                      className={`rounded-sm border ${
+                        isDragging ? 'border-dashed border-accent' : 'border-accent/70 bg-accent/15'
+                      }`}
+                      style={{ width, height }}
+                    />
+                  )}
                 </div>
                 <span className="max-w-[5rem] truncate text-[10px] text-content-secondary">
                   {entry.label ?? `${entry.w}×${entry.h}`}

--- a/src/features/bin-designer/components/BentoWorkspace/BentoWorkspace.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoWorkspace.tsx
@@ -20,7 +20,8 @@ import { useTranslation } from '@/i18n';
 import { useResponsive } from '@/shared/hooks/useResponsive';
 import { getInteriorDims } from '@/features/bin-designer/utils/dividerAngle';
 import {
-  findFreeRect,
+  compartmentMask,
+  findFreeSpot,
   getCompartmentRect,
   getDrawnCompartmentIds,
 } from '@/features/bin-designer/utils/bentoDraw';
@@ -291,7 +292,14 @@ export function BentoWorkspace() {
     (id: number) => {
       const rect = getCompartmentRect(compartments, id);
       if (!rect) return;
-      const target = findFreeRect(compartments, rect.w, rect.h);
+      // Seated by footprint, so duplicating a merged L can use a gap its
+      // bounding box would have been turned away from.
+      const target = findFreeSpot(
+        compartments,
+        rect.w,
+        rect.h,
+        compartmentMask(compartments, id, rect)
+      );
       if (!target) {
         addToast({ message: t('binDesigner.bento.toastNoRoom'), type: 'info', duration: 4000 });
         return;

--- a/src/features/bin-designer/components/BentoWorkspace/useBentoInteraction.ts
+++ b/src/features/bin-designer/components/BentoWorkspace/useBentoInteraction.ts
@@ -20,10 +20,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { throttleRAF, cancelThrottledRAF } from '@/shared/utils';
 import type { CompartmentConfig, StashedCompartment } from '@/features/bin-designer/types';
 import {
+  canPlaceMask,
   canPlaceRect,
+  compartmentMask,
   getCompartmentRect,
   getDrawnCompartmentIds,
+  isFullMask,
   rectIndices,
+  stashEntryMask,
   type CellRect,
 } from '@/features/bin-designer/utils/bentoDraw';
 import { previewMergeCells } from '@/features/bin-designer/utils/compartments';
@@ -81,6 +85,12 @@ export interface BentoGhost {
   readonly valid: boolean;
   readonly kind: 'draw' | 'move' | 'resize' | 'stashDrag';
   readonly overStash: boolean;
+  /**
+   * Offsets inside {@link rect} the ghost actually covers, set only when the
+   * dragged compartment is a merged L/S/T/U. Absent means the full rect, which
+   * is every draw and resize and most moves.
+   */
+  readonly mask?: readonly number[];
 }
 
 export interface BentoInteractionContext {
@@ -274,10 +284,20 @@ export function useBentoInteraction(ctx: BentoInteractionContext) {
       }
       case 'move': {
         if (!gesture.moved) return null;
-        const valid = gesture.duplicate
-          ? canPlaceRect(config, gesture.currentRect)
-          : canPlaceRect(config, gesture.currentRect, { ignoreId: gesture.id });
-        return { rect: gesture.currentRect, valid, kind: 'move', overStash: gesture.overStash };
+        const mask = compartmentMask(config, gesture.id, gesture.startRect);
+        const valid = canPlaceMask(
+          config,
+          gesture.currentRect,
+          mask,
+          gesture.duplicate ? {} : { ignoreId: gesture.id }
+        );
+        return {
+          rect: gesture.currentRect,
+          valid,
+          kind: 'move',
+          overStash: gesture.overStash,
+          ...(isFullMask(gesture.startRect, mask) ? {} : { mask }),
+        };
       }
       case 'resize':
         return {
@@ -286,14 +306,17 @@ export function useBentoInteraction(ctx: BentoInteractionContext) {
           kind: 'resize',
           overStash: false,
         };
-      case 'stashDrag':
+      case 'stashDrag': {
         if (!gesture.currentRect) return null;
+        const mask = stashEntryMask(gesture.entry);
         return {
           rect: gesture.currentRect,
-          valid: canPlaceRect(config, gesture.currentRect),
+          valid: canPlaceMask(config, gesture.currentRect, mask),
           kind: 'stashDrag',
           overStash: false,
+          ...(isFullMask(gesture.currentRect, mask) ? {} : { mask }),
         };
+      }
     }
   }, [gesture, ctx]);
 

--- a/src/features/bin-designer/constants/paramMigration.test.ts
+++ b/src/features/bin-designer/constants/paramMigration.test.ts
@@ -1518,6 +1518,48 @@ describe('migrateParams - bento merged leftover (#3748)', () => {
   });
 });
 
+describe('migrateParams - stashed merged footprints', () => {
+  // `unknown` entries on purpose: the sanitizer's job is corrupt persisted input.
+  const withStash = (stash: readonly unknown[]) =>
+    ({
+      compartments: {
+        ...DEFAULT_BIN_PARAMS.compartments,
+        cols: 2,
+        rows: 2,
+        cells: [0, 1, 2, 3],
+        stash,
+      },
+    }) as unknown as Parameters<typeof migrateParams>[0];
+
+  it('keeps a merged L footprint through the load sanitizer', () => {
+    const result = migrateParams(withStash([{ w: 2, h: 2, cells: [0, 1, 2], label: 'bits' }]));
+    expect(result.compartments.stash).toEqual([{ w: 2, h: 2, cells: [0, 1, 2], label: 'bits' }]);
+  });
+
+  it('leaves a plain rectangle without a cells field', () => {
+    const result = migrateParams(withStash([{ w: 2, h: 1 }]));
+    expect(result.compartments.stash).toEqual([{ w: 2, h: 1 }]);
+  });
+
+  it('drops a full-box list, which IS the rectangle', () => {
+    const result = migrateParams(withStash([{ w: 2, h: 2, cells: [0, 1, 2, 3] }]));
+    expect(result.compartments.stash).toEqual([{ w: 2, h: 2 }]);
+  });
+
+  it('degrades a corrupt footprint to its bounding box rather than dropping the entry', () => {
+    for (const cells of [[4, 9], ['a'], [1.5], []] as unknown[][]) {
+      expect(migrateParams(withStash([{ w: 2, h: 2, cells }])).compartments.stash).toEqual([
+        { w: 2, h: 2 },
+      ]);
+    }
+  });
+
+  it('dedupes repeated offsets', () => {
+    const result = migrateParams(withStash([{ w: 2, h: 2, cells: [2, 0, 0, 1] }]));
+    expect(result.compartments.stash).toEqual([{ w: 2, h: 2, cells: [0, 1, 2] }]);
+  });
+});
+
 describe('migrateParams - cutout fill reference (#3697)', () => {
   it('defaults a design saved before the option existed to the rim', () => {
     // Rim anchoring reproduces the old behaviour exactly, so an existing

--- a/src/features/bin-designer/constants/paramMigration.ts
+++ b/src/features/bin-designer/constants/paramMigration.ts
@@ -1075,9 +1075,28 @@ function migrateBentoCompartmentFields(config: CompartmentConfig): CompartmentCo
       );
     })
     .slice(0, DESIGNER_CONSTRAINTS.MAX_STASH_ENTRIES)
-    .map(({ w, h, label }) => {
+    .map(({ w, h, cells, label }) => {
       const clamped = typeof label === 'string' ? label.slice(0, TEXT_MAX_LENGTH) : '';
-      return { w, h, ...(clamped.length > 0 ? { label: clamped } : {}) };
+      // A merged L's footprint. Offsets outside the box, duplicates and a
+      // full-box list all collapse to absent, which IS the rectangle — the
+      // shape degrades to its bounding box rather than the entry vanishing.
+      const offsets = Array.isArray(cells)
+        ? [
+            ...new Set(
+              cells.filter(
+                (o: unknown): o is number =>
+                  Number.isInteger(o) && (o as number) >= 0 && (o as number) < w * h
+              )
+            ),
+          ].sort((a, b) => a - b)
+        : [];
+      const merged = offsets.length > 0 && offsets.length < w * h;
+      return {
+        w,
+        h,
+        ...(merged ? { cells: offsets } : {}),
+        ...(clamped.length > 0 ? { label: clamped } : {}),
+      };
     });
 
   const counts = new Map<number, number>();

--- a/src/features/bin-designer/types/compartments.ts
+++ b/src/features/bin-designer/types/compartments.ts
@@ -174,6 +174,15 @@ export interface StashedCompartment {
   readonly w: number;
   /** Depth in grid cells (1..MAX_COMPARTMENT_GRID). */
   readonly h: number;
+  /**
+   * Occupied cells as `row * w + col` offsets inside the `w × h` box, for a
+   * merged L/S/T/U whose shape a box cannot describe. Absent means the full
+   * box, so an ordinary rectangle serializes exactly as it always has.
+   *
+   * Mutable element type for the same reason as the sibling arrays above: the
+   * `params` tree passes through Immer `Draft`s.
+   */
+  readonly cells?: number[];
   /** Engraved label carried with the compartment; empty/missing = none. */
   readonly label?: string;
 }

--- a/src/features/bin-designer/utils/bentoDraw.test.ts
+++ b/src/features/bin-designer/utils/bentoDraw.test.ts
@@ -7,6 +7,7 @@ import {
   findFreeRect,
   getCompartmentRect,
   getDrawnCompartmentIds,
+  mergeCompartments,
   moveCompartment,
   placeFromStash,
   rectIndices,
@@ -19,6 +20,7 @@ import {
 } from '@/features/bin-designer/utils/bentoDraw';
 import {
   createUniformGrid,
+  getCellsForCompartment,
   remapDrawnUnitCells,
   validateCompartmentGrid,
 } from '@/features/bin-designer/utils/compartments';
@@ -534,5 +536,99 @@ describe('bentoDraw with mergeBackground', () => {
     const { config } = draw(grid(3, 3), 1, 1, 1, 1);
     expect(config.backgroundIds).toBeUndefined();
     expect(new Set(config.cells).size).toBe(9);
+  });
+});
+
+/**
+ * A merged compartment is the one case where a compartment does not fill its
+ * bounding box, so every op that rebuilds cells from `getCompartmentRect` alone
+ * silently flattens it back to a rectangle.
+ */
+describe('bentoDraw preserves merged (non-rectangular) footprints', () => {
+  /** Cells of a compartment as sorted `col,row` strings, for shape assertions. */
+  const shapeOf = (config: CompartmentConfig, id: number): string[] =>
+    getCellsForCompartment(config, id)
+      .map((idx) => `${idx % config.cols},${Math.floor(idx / config.cols)}`)
+      .sort();
+
+  const idWithCellCount = (config: CompartmentConfig, count: number): number => {
+    const found = [...getDrawnCompartmentIds(config)].find(
+      (id) => getCellsForCompartment(config, id).length === count
+    );
+    expect(found).toBeDefined();
+    if (found === undefined) throw new Error('unreachable');
+    return found;
+  };
+
+  /** An L over (0,0) (1,0) (0,1): three cells in a 2×2 bounding box. */
+  const mergedL = (base: CompartmentConfig = grid(4, 3)) => {
+    const first = draw(base, 0, 0, 2, 1);
+    const second = draw(first.config, 0, 1, 1, 1);
+    const merged = mergeCompartments(second.config, [...getDrawnCompartmentIds(second.config)]);
+    expect(merged).not.toBeNull();
+    if (!merged) throw new Error('unreachable');
+    expect(shapeOf(merged.config, merged.id)).toEqual(['0,0', '0,1', '1,0']);
+    return merged;
+  };
+
+  it('moveCompartment translates the L instead of filling its bounding box', () => {
+    const { config, id } = mergedL();
+    const moved = moveCompartment(config, id, 2, 1);
+    expect(moved).not.toBeNull();
+    if (!moved) throw new Error('unreachable');
+    expect(shapeOf(moved.config, moved.id)).toEqual(['2,1', '2,2', '3,1']);
+    expect(validateCompartmentGrid(moved.config)).toEqual([]);
+  });
+
+  it('moveCompartment fits an L into an L-shaped gap its bounding box overlaps', () => {
+    const { config } = mergedL();
+    // A blocker in the notch the L leaves empty at its destination: bounding-box
+    // collision rejects the move, footprint collision allows it.
+    const blocked = draw(config, 3, 2, 1, 1);
+    const l = idWithCellCount(blocked.config, 3);
+    const moved = moveCompartment(blocked.config, l, 2, 1);
+    expect(moved).not.toBeNull();
+    if (!moved) throw new Error('unreachable');
+    expect(shapeOf(moved.config, moved.id)).toEqual(['2,1', '2,2', '3,1']);
+  });
+
+  it('duplicateCompartment stamps the L, not its bounding rectangle', () => {
+    const { config, id } = mergedL();
+    const copy = duplicateCompartment(config, id, { col: 2, row: 1, w: 2, h: 2 });
+    expect(copy).not.toBeNull();
+    if (!copy) throw new Error('unreachable');
+    expect(shapeOf(copy.config, copy.id)).toEqual(['2,1', '2,2', '3,1']);
+    expect(shapeOf(copy.config, idWithCellCount(copy.config, 3))).toHaveLength(3);
+  });
+
+  it('stashCompartment records the footprint and placeFromStash restores it', () => {
+    const { config, id } = mergedL();
+    const stashed = stashCompartment(config, id);
+    expect(stashed).not.toBeNull();
+    if (!stashed) throw new Error('unreachable');
+    expect(stashed.stash).toEqual([{ w: 2, h: 2, cells: [0, 1, 2] }]);
+    const placed = placeFromStash(stashed, 0, { col: 2, row: 1, w: 2, h: 2 });
+    expect(placed).not.toBeNull();
+    if (!placed) throw new Error('unreachable');
+    expect(shapeOf(placed.config, placed.id)).toEqual(['2,1', '2,2', '3,1']);
+  });
+
+  it('resizeGridPreservingCompartments keeps the L intact when the grid grows', () => {
+    const { config } = mergedL();
+    const regrid = resizeGridPreservingCompartments(config, 6, 5);
+    expect(regrid.stashedCount).toBe(0);
+    expect(shapeOf(regrid.config, idWithCellCount(regrid.config, 3))).toEqual([
+      '0,0',
+      '0,1',
+      '1,0',
+    ]);
+    expect(validateCompartmentGrid(regrid.config)).toEqual([]);
+  });
+
+  it('stashes an L whole when the grid shrinks past it', () => {
+    const { config } = mergedL(grid(5, 4));
+    const regrid = resizeGridPreservingCompartments(config, 5, 1);
+    expect(regrid.stashedCount).toBe(1);
+    expect(regrid.config.stash).toEqual([{ w: 2, h: 2, cells: [0, 1, 2] }]);
   });
 });

--- a/src/features/bin-designer/utils/bentoDraw.ts
+++ b/src/features/bin-designer/utils/bentoDraw.ts
@@ -111,6 +111,77 @@ export function rectInBounds(config: CompartmentConfig, rect: CellRect): boolean
 }
 
 /**
+ * A compartment's cells as offsets (`row * w + col`) inside its bounding box.
+ *
+ * Only a merged L/S/T/U holds fewer than `w * h` of them, and that is exactly
+ * the case a bounding rect cannot describe. Every op below that rebuilds
+ * `cells` carries the mask rather than re-deriving a rect, or the shape
+ * flattens back to its bounding rectangle the moment it is touched.
+ */
+export function compartmentMask(config: CompartmentConfig, id: number, rect: CellRect): number[] {
+  const mask: number[] = [];
+  for (const idx of getCellsForCompartment(config, id)) {
+    const col = (idx % config.cols) - rect.col;
+    const row = Math.floor(idx / config.cols) - rect.row;
+    mask.push(row * rect.w + col);
+  }
+  return mask.sort((a, b) => a - b);
+}
+
+/** Mask covering a whole `w × h` box — what every unmerged compartment has. */
+export function fullMask(w: number, h: number): number[] {
+  return Array.from({ length: w * h }, (_, i) => i);
+}
+
+/** True when a mask fills its bounding box: the ordinary rectangular case. */
+export function isFullMask(rect: CellRect, mask: readonly number[]): boolean {
+  return mask.length === rect.w * rect.h;
+}
+
+/**
+ * Flat cell indices a mask covers with its box seated at `rect`, or null when
+ * any cell would fall off the grid. Offsets are re-validated rather than
+ * trusted: a stash entry is persisted, so it can arrive hand-authored.
+ */
+export function maskIndices(
+  config: CompartmentConfig,
+  rect: CellRect,
+  mask: readonly number[]
+): number[] | null {
+  if (!rectInBounds(config, rect)) return null;
+  const out: number[] = [];
+  for (const offset of mask) {
+    if (!Number.isInteger(offset) || offset < 0 || offset >= rect.w * rect.h) return null;
+    const col = rect.col + (offset % rect.w);
+    const row = rect.row + Math.floor(offset / rect.w);
+    out.push(cellIndex(config.cols, col, row));
+  }
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * {@link canPlaceRect} for an arbitrary footprint. The notch of an L is not
+ * part of the compartment, so a neighbour sitting in it blocks the bounding
+ * box but not the shape — testing the rect would refuse legal placements.
+ */
+export function canPlaceMask(
+  config: CompartmentConfig,
+  rect: CellRect,
+  mask: readonly number[],
+  opts: { readonly ignoreId?: number } = {}
+): boolean {
+  const indices = maskIndices(config, rect, mask);
+  if (!indices) return false;
+  const drawn = getDrawnCompartmentIds(config);
+  for (const idx of indices) {
+    const id = config.cells[idx];
+    if (id === opts.ignoreId) continue;
+    if (drawn.has(id)) return false;
+  }
+  return true;
+}
+
+/**
  * True when the rect lands entirely on background grid (or on cells of
  * `ignoreId`, for move/resize where a compartment may overlap itself).
  */
@@ -315,7 +386,7 @@ export function removeCompartment(config: CompartmentConfig, id: number): Compar
   return rebuild(cleared, newCells).config;
 }
 
-/** Translate a drawn compartment by whole cells. Null when blocked. */
+/** Translate a drawn compartment by whole cells, shape intact. Null when blocked. */
 export function moveCompartment(
   config: CompartmentConfig,
   id: number,
@@ -325,14 +396,16 @@ export function moveCompartment(
   const rect = getCompartmentRect(config, id);
   if (!rect) return null;
   if (dCol === 0 && dRow === 0) return { config, id };
+  const mask = compartmentMask(config, id, rect);
   const target: CellRect = { ...rect, col: rect.col + dCol, row: rect.row + dRow };
-  if (!canPlaceRect(config, target, { ignoreId: id })) return null;
+  const landing = maskIndices(config, target, mask);
+  if (!landing || !canPlaceMask(config, target, mask, { ignoreId: id })) return null;
   const newCells = [...config.cells];
   let fresh = Math.max(...config.cells) + 1;
   for (const idx of getCellsForCompartment(config, id)) {
     newCells[idx] = fresh++;
   }
-  for (const idx of rectIndices(config.cols, target)) {
+  for (const idx of landing) {
     newCells[idx] = id;
   }
   const { config: rebuilt, remap } = rebuild(config, newCells);
@@ -352,6 +425,10 @@ export function resizeCompartment(
 ): DrawResult | null {
   const rect = getCompartmentRect(config, id);
   if (!rect) return null;
+  // Dragging one edge of a merged L has no defined result — which arm follows?
+  // The canvas hides the handles on a non-rectangular compartment; refusing
+  // here keeps the shape safe from any other caller too.
+  if (!isFullMask(rect, compartmentMask(config, id, rect))) return null;
   if (!canPlaceRect(config, target, { ignoreId: id })) return null;
   const newCells = [...config.cells];
   let fresh = Math.max(...config.cells) + 1;
@@ -379,13 +456,15 @@ export function duplicateCompartment(
 ): DrawResult | null {
   const rect = getCompartmentRect(config, id);
   if (!rect || rect.w !== target.w || rect.h !== target.h) return null;
-  if (!canPlaceRect(config, target)) return null;
+  const mask = compartmentMask(config, id, rect);
+  const landing = maskIndices(config, target, mask);
+  if (!landing || !canPlaceMask(config, target, mask)) return null;
   const newCells = [...config.cells];
   const fresh = Math.max(...config.cells) + 1;
-  for (const idx of rectIndices(config.cols, target)) {
+  for (const idx of landing) {
     newCells[idx] = fresh;
   }
-  const marked = target.w === 1 && target.h === 1 ? addDrawnUnitCell(config, fresh) : config;
+  const marked = landing.length === 1 ? addDrawnUnitCell(config, fresh) : config;
   const { config: rebuilt, remap } = rebuild(marked, newCells);
   const newId = remap.get(fresh);
   const srcId = remap.get(id);
@@ -496,17 +575,33 @@ export function stashCompartment(config: CompartmentConfig, id: number): Compart
   if (!rect) return null;
   if ((config.stash?.length ?? 0) >= DESIGNER_CONSTRAINTS.MAX_STASH_ENTRIES) return null;
   const label = config.compartmentTexts?.[id] ?? '';
-  const entry: StashedCompartment = {
-    w: rect.w,
-    h: rect.h,
-    ...(label.length > 0 ? { label } : {}),
-  };
   const removed = removeCompartment(config, id);
   if (!removed) return null;
-  return { ...removed, stash: [...(config.stash ?? []), entry] };
+  return {
+    ...removed,
+    stash: [...(config.stash ?? []), stashEntry(rect, compartmentMask(config, id, rect), label)],
+  };
 }
 
-/** Place a stash entry onto background grid; the rect must match its size. */
+/**
+ * Shelf entry for a footprint. `cells` is written only for a merged shape, so
+ * an ordinary rectangle serializes exactly as it did before the field existed.
+ */
+function stashEntry(rect: CellRect, mask: readonly number[], label: string): StashedCompartment {
+  return {
+    w: rect.w,
+    h: rect.h,
+    ...(isFullMask(rect, mask) ? {} : { cells: [...mask] }),
+    ...(label.length > 0 ? { label } : {}),
+  };
+}
+
+/** The footprint a stash entry stands for; absent `cells` means the full box. */
+export function stashEntryMask(entry: StashedCompartment): number[] {
+  return entry.cells ? [...entry.cells] : fullMask(entry.w, entry.h);
+}
+
+/** Place a stash entry onto background grid; the rect must match its box. */
 export function placeFromStash(
   config: CompartmentConfig,
   index: number,
@@ -515,13 +610,22 @@ export function placeFromStash(
   const entry = config.stash?.[index];
   if (!entry) return null;
   if (rect.w !== entry.w || rect.h !== entry.h) return null;
-  const drawn = drawCompartment(config, rect);
-  if (!drawn) return null;
-  let next = drawn.config;
-  if (entry.label) next = writeText(next, drawn.id, entry.label);
+  const mask = stashEntryMask(entry);
+  const landing = maskIndices(config, rect, mask);
+  if (!landing || !canPlaceMask(config, rect, mask)) return null;
+  const newCells = [...config.cells];
+  const fresh = Math.max(...config.cells) + 1;
+  for (const idx of landing) {
+    newCells[idx] = fresh;
+  }
+  const marked = landing.length === 1 ? addDrawnUnitCell(config, fresh) : config;
+  const { config: rebuilt, remap } = rebuild(marked, newCells);
+  const id = remap.get(fresh);
+  if (id === undefined) return null;
+  let next = entry.label ? writeText(rebuilt, id, entry.label) : rebuilt;
   const stash = (config.stash ?? []).filter((_, i) => i !== index);
   next = { ...next, stash: stash.length > 0 ? stash : undefined };
-  return { config: next, id: drawn.id };
+  return { config: next, id };
 }
 
 /** Delete a stash entry outright. */
@@ -541,10 +645,23 @@ export function removeStashEntry(
  * has no drag target.
  */
 export function findFreeRect(config: CompartmentConfig, w: number, h: number): CellRect | null {
+  return findFreeSpot(config, w, h, fullMask(w, h));
+}
+
+/**
+ * {@link findFreeRect} for an arbitrary footprint, so duplicating a merged L
+ * can seat it in a gap its bounding box does not fit.
+ */
+export function findFreeSpot(
+  config: CompartmentConfig,
+  w: number,
+  h: number,
+  mask: readonly number[]
+): CellRect | null {
   for (let row = config.rows - h; row >= 0; row--) {
     for (let col = 0; col + w <= config.cols; col++) {
       const rect: CellRect = { col, row, w, h };
-      if (canPlaceRect(config, rect)) return rect;
+      if (canPlaceMask(config, rect, mask)) return rect;
     }
   }
   return null;
@@ -572,22 +689,20 @@ export function resizeGridPreservingCompartments(
     if (!drawnIds.has(id)) continue;
     const rect = getCompartmentRect(config, id);
     if (!rect) continue;
+    const mask = compartmentMask(config, id, rect);
     if (rect.col + rect.w <= newCols && rect.row + rect.h <= newRows) {
-      for (let r = rect.row; r < rect.row + rect.h; r++) {
-        for (let c = rect.col; c < rect.col + rect.w; c++) {
-          newCells[r * newCols + c] = id;
-        }
+      // Re-seated through the mask, not the rect: a regrid that repainted the
+      // bounding box would square off every merged shape on the board.
+      for (const offset of mask) {
+        const c = rect.col + (offset % rect.w);
+        const r = rect.row + Math.floor(offset / rect.w);
+        newCells[r * newCols + c] = id;
       }
     } else if (
       (config.stash?.length ?? 0) + stashAdditions.length <
       DESIGNER_CONSTRAINTS.MAX_STASH_ENTRIES
     ) {
-      const label = config.compartmentTexts?.[id] ?? '';
-      stashAdditions.push({
-        w: rect.w,
-        h: rect.h,
-        ...(label.length > 0 ? { label } : {}),
-      });
+      stashAdditions.push(stashEntry(rect, mask, config.compartmentTexts?.[id] ?? ''));
     } else {
       droppedCount++;
     }

--- a/src/shared/schema/binDesignKeys.ts
+++ b/src/shared/schema/binDesignKeys.ts
@@ -166,7 +166,7 @@ export type _DividerOverrideKeys = Assert<
   KeysMatch<keyof DividerOverride, (typeof DIVIDER_OVERRIDE_KEYS)[number]>
 >;
 
-export const STASHED_COMPARTMENT_KEYS = ['w', 'h', 'label'] as const;
+export const STASHED_COMPARTMENT_KEYS = ['w', 'h', 'cells', 'label'] as const;
 export type _StashedCompartmentKeys = Assert<
   KeysMatch<keyof StashedCompartment, (typeof STASHED_COMPARTMENT_KEYS)[number]>
 >;


### PR DESCRIPTION
Merged L/S/T/U compartments in the Bento workspace flattened into their bounding rectangle the moment they were touched.

## Cause

`moveCompartment`, `duplicateCompartment`, `stashCompartment` and `resizeGridPreservingCompartments` each read a compartment through `getCompartmentRect()` and then repainted `rectIndices(target)` — the full rectangle. Correct for every compartment except a merged one, whose cell set is smaller than its bounding box. The canvas already rendered those shapes properly; only the mutations lost them.

The issue reports drag, alt-drag clone and stash. The header grid resize is a fourth door onto the same bug.

## Fix

Every op that rebuilds `cells` now carries the compartment's footprint as offsets inside its bounding box (`compartmentMask`) rather than re-deriving a rect.

- Collision testing follows via `canPlaceMask`, so an L drops into an L-shaped gap its bounding box overlaps — a rect test was refusing legal placements.
- The drag ghost and the stash shelf tile draw the real outline instead of promising a rectangle the drop will not fill.
- `resizeCompartment` refuses a non-rectangular compartment, matching the canvas, which already hides its handles: dragging one edge of an L has no defined result.
- Context-menu duplicate seats copies with `findFreeSpot`, so it can use a gap the bounding box would have been turned away from.

## Persisted change

`StashedCompartment` gains an optional `cells` footprint. Absent means the full box, so every existing design and every older client is unaffected and rectangles serialize byte-identically. Updated in lockstep: the JSON schema, `api/lib/designerCompartmentValidation.ts`, the `binDesignKeys` manifest and `docs/schemas`.

`migrateBentoCompartmentFields` carries the field through on load. It was silently dropping it — a whitelist that rebuilds the entry from `{ w, h, label }` — which no unit test could catch because the model was already correct. A corrupt footprint degrades to its bounding box rather than dropping the entry.

## Verification

Reproduced first: six failing tests across all five affected ops, then fixed. Full suite green (25,104 tests).

Checked in the running app with a real mouse drag: an L seeded at (0,0)(1,0)(0,1) lands at (2,0)(3,0)(2,1) with its shape intact, the drag ghost renders as an L outline, and a stashed L survives a save/reload cycle and comes back out of the shelf as an L with its label.

Closes #3825

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

