### PR TITLE
feat(bin-designer): offer centering as a way out of the clipped-cutout warning

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.test.tsx
@@ -141,6 +141,57 @@ describe('BinSizeSection', () => {
     );
   });
 
+  describe('center action', () => {
+    const CENTER = 'binDesigner.cutouts.centerInBin';
+
+    it('offers centering alongside the clamp when it can clear the warning', () => {
+      const onCenter = vi.fn();
+      render(
+        <BinSizeSection offBoardCount={1} onClampOffBoard={vi.fn()} onCenterOffBoard={onCenter} />
+      );
+      fireEvent.click(screen.getByText(CENTER));
+      expect(onCenter).toHaveBeenCalledTimes(1);
+    });
+
+    // Absent handler is the whole guard against duplicating "Bring back in":
+    // the workspace withholds it unless centering actually fixes every stray.
+    it('stays out of the panel when centering cannot clear the warning', () => {
+      render(<BinSizeSection offBoardCount={1} onClampOffBoard={vi.fn()} />);
+      expect(screen.getByText(`${K}.bringBackIn`)).toBeInTheDocument();
+      expect(screen.queryByText(CENTER)).not.toBeInTheDocument();
+    });
+
+    it('never appears without a warning to attach to', () => {
+      render(<BinSizeSection offBoardCount={0} onCenterOffBoard={vi.fn()} />);
+      expect(screen.queryByText(CENTER)).not.toBeInTheDocument();
+    });
+
+    // Grow changes the part; center and clamp only move shapes, and center is
+    // the gentler of the two.
+    it('sits between growing the bin and clamping to the edge', () => {
+      render(
+        <BinSizeSection
+          offBoardCount={1}
+          onClampOffBoard={vi.fn()}
+          onCenterOffBoard={vi.fn()}
+          growTarget={{ width: 4, depth: 3 }}
+          onGrowToFit={vi.fn()}
+        />
+      );
+      const labels = screen.getAllByRole('button').map((b) => b.textContent);
+      const center = labels.indexOf(CENTER);
+      expect(center).toBeGreaterThan(
+        labels.indexOf(tk(`${K}.growBinToFit`, { width: 4, depth: 3 }))
+      );
+      expect(center).toBeLessThan(labels.indexOf(`${K}.bringBackIn`));
+    });
+
+    it('lets its label wrap in the narrow dock like its siblings', () => {
+      render(<BinSizeSection offBoardCount={1} onCenterOffBoard={vi.fn()} />);
+      expect(screen.getByText(CENTER)).toHaveClass('h-auto', 'whitespace-normal');
+    });
+  });
+
   // The dock narrows to 220px and 7 of 15 locales overrun the label there, so a
   // fixed-height button would clip the second line.
   it('lets the action labels wrap instead of clipping', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
@@ -25,6 +25,13 @@ interface BinSizeSectionProps {
   /** Clamp every off-board cutout back inside the board. */
   readonly onClampOffBoard?: () => void;
   /**
+   * Center every off-board cutout on the board as one block. Absent when
+   * centering would not clear the warning, which is what keeps this from
+   * duplicating the clamp: it is offered only for a shape that fits the board
+   * and is merely sitting in the wrong place.
+   */
+  readonly onCenterOffBoard?: () => void;
+  /**
    * Bin size that would fit every stray, or `null` when growing can't clear the
    * warning (past `MAX_DIMENSION`, a custom footprint, or a stray hanging past
    * the origin edge). `null` hides the action rather than growing partway, and
@@ -42,6 +49,7 @@ interface BinSizeSectionProps {
 export function BinSizeSection({
   offBoardCount,
   onClampOffBoard,
+  onCenterOffBoard,
   growTarget,
   onGrowToFit,
   depthShortfallCount = 0,
@@ -83,6 +91,22 @@ export function BinSizeSection({
                   width: growTarget.width,
                   depth: growTarget.depth,
                 })}
+              </Button>
+            )}
+            {/* Between the two: growing changes the part, centering and
+                clamping both only move shapes, and centering is the gentler of
+                those — it keeps the strays' arrangement instead of pinning
+                them to an edge. */}
+            {onCenterOffBoard && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                fullWidth
+                className={WRAPPING_ACTION}
+                onClick={onCenterOffBoard}
+              >
+                {t('binDesigner.cutouts.centerInBin')}
               </Button>
             )}
             {onClampOffBoard && (

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutWorkspace.tsx
@@ -26,6 +26,7 @@ import { lidCutoutHostFace, lidCutoutWindow } from '@/shared/utils/lidCutoutPlan
 import { useCutoutInteraction } from '../panel/CutoutsSection/useCutoutInteraction';
 import {
   getOffBoardCutoutIds,
+  centerOffBoardCutouts,
   clampOffBoardCutouts,
 } from '../panel/CutoutsSection/offBoardCutouts';
 import { computeGrowToFit } from '../panel/CutoutsSection/growBinToFit';
@@ -338,6 +339,20 @@ export function CutoutWorkspace() {
   const handleClampOffBoard = useCallback(() => {
     if (offBoardUpdates.size > 0) updateCutoutsBatch(offBoardUpdates);
   }, [offBoardUpdates, updateCutoutsBatch]);
+
+  // Same shape of contract as the clamp above: empty means centering cannot
+  // clear the warning, and the action is hidden rather than offered inert.
+  const centerUpdates = useMemo(
+    () =>
+      offBoardIds.size > 0
+        ? centerOffBoardCutouts(cutouts, cutoutBoard, offBoardIds)
+        : new Map<string, Partial<Cutout>>(),
+    [offBoardIds, cutouts, cutoutBoard]
+  );
+
+  const handleCenterOffBoard = useCallback(() => {
+    if (centerUpdates.size > 0) updateCutoutsBatch(centerUpdates);
+  }, [centerUpdates, updateCutoutsBatch]);
 
   const {
     mode,
@@ -707,6 +722,7 @@ export function CutoutWorkspace() {
           onFlattenArray={handleFlattenArray}
           offBoardCount={offBoardIds.size}
           onClampOffBoard={offBoardUpdates.size > 0 ? handleClampOffBoard : undefined}
+          onCenterOffBoard={centerUpdates.size > 0 ? handleCenterOffBoard : undefined}
           depthShortfallCount={depthShortfallCount}
           growTarget={growTarget}
           onGrowToFit={handleGrowToFit}

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
@@ -62,6 +62,8 @@ interface InspectorContentProps {
   readonly depthShortfallCount?: number;
   /** Clamp every off-board cutout back inside the board. */
   readonly onClampOffBoard?: () => void;
+  /** Center every off-board cutout as one block. */
+  readonly onCenterOffBoard?: () => void;
   /** Bin size that would fit every stray, or `null` when growing can't clear it. */
   readonly growTarget?: GrowTarget | null;
   /** Resize the bin to {@link growTarget}. */
@@ -128,6 +130,7 @@ export function InspectorContent({
   offBoardCount = 0,
   depthShortfallCount = 0,
   onClampOffBoard,
+  onCenterOffBoard,
   growTarget,
   onGrowToFit,
 }: InspectorContentProps) {
@@ -156,6 +159,7 @@ export function InspectorContent({
       <BinSizeSection
         offBoardCount={offBoardCount}
         onClampOffBoard={onClampOffBoard}
+        onCenterOffBoard={onCenterOffBoard}
         depthShortfallCount={depthShortfallCount}
         growTarget={growTarget}
         onGrowToFit={onGrowToFit}

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorDock.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorDock.tsx
@@ -45,6 +45,8 @@ interface InspectorDockProps {
   readonly offBoardCount?: number;
   /** Clamp every off-board cutout back inside the board. */
   readonly onClampOffBoard?: () => void;
+  /** Center every off-board cutout as one block. */
+  readonly onCenterOffBoard?: () => void;
   /** Count of cutouts the generator will cut shallower than requested. */
   readonly depthShortfallCount?: number;
   /** Bin size that would fit every stray, or `null` when growing can't clear it. */

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.test.ts
@@ -7,6 +7,7 @@ import {
   getOffBoardCutoutIds,
   clampCutoutToBoard,
   clampOffBoardCutouts,
+  centerOffBoardCutouts,
 } from './offBoardCutouts';
 
 const createCutout = (overrides: Partial<Cutout> = {}): Cutout => ({
@@ -417,6 +418,85 @@ describe('clampOffBoardCutouts', () => {
       clampOffBoardCutouts([tooBig], { width: 100, depth: 100, mask: mask, cellSize: cellSize })
         .size
     ).toBe(0);
+  });
+});
+
+describe('centerOffBoardCutouts', () => {
+  const board = { width: BIN_W, depth: BIN_D };
+
+  it('centers a single stray and leaves it on the board', () => {
+    const stray = createCutout({ id: 'out', x: 95, y: 75, width: 20, depth: 20 });
+    const updates = centerOffBoardCutouts([stray], board);
+    expect(updates.get('out')).toEqual({ x: 40, y: 30 });
+    expect(isCutoutOffBoard({ ...stray, ...updates.get('out') }, board)).toBe(false);
+  });
+
+  it('leaves cutouts already on the board untouched', () => {
+    const inside = createCutout({ id: 'in', x: 10, y: 10 });
+    const stray = createCutout({ id: 'out', x: 95, y: 75 });
+    expect([...centerOffBoardCutouts([inside, stray], board).keys()]).toEqual(['out']);
+  });
+
+  // The whole reason this is not "center each stray": concentric stacking would
+  // destroy an arrangement the user built.
+  it('moves several strays by ONE delta, preserving their spacing', () => {
+    const a = createCutout({ id: 'a', x: 105, y: 85, width: 10, depth: 10 });
+    const b = createCutout({ id: 'b', x: 125, y: 85, width: 10, depth: 10 });
+    const updates = centerOffBoardCutouts([a, b], board);
+    expect([...updates.keys()].sort()).toEqual(['a', 'b']);
+    const moved = (id: string, c: Cutout) => ({ ...c, ...updates.get(id) });
+    const ma = moved('a', a);
+    const mb = moved('b', b);
+    expect(mb.x - ma.x).toBe(b.x - a.x);
+    expect(mb.y - ma.y).toBe(b.y - a.y);
+    for (const m of [ma, mb]) expect(isCutoutOffBoard(m, board)).toBe(false);
+  });
+
+  it('withholds everything when centering cannot rescue every stray', () => {
+    // Wider than the board: centered, it still overhangs both edges, so the
+    // action is hidden rather than moving the other stray for nothing.
+    const oversized = createCutout({ id: 'big', x: 5, y: 10, width: 500, depth: 20 });
+    const small = createCutout({ id: 'small', x: 95, y: 75 });
+    expect(centerOffBoardCutouts([oversized, small], board).size).toBe(0);
+  });
+
+  it('returns an empty map when nothing is stranded', () => {
+    expect(centerOffBoardCutouts([createCutout()], board).size).toBe(0);
+  });
+
+  it('carries a path cutout vertices along with its origin', () => {
+    const stray = createCutout({
+      id: 'path',
+      shape: 'path',
+      x: 90,
+      y: 70,
+      width: 20,
+      depth: 20,
+      path: [corner(90, 70), corner(110, 70), corner(110, 90)],
+    });
+    const update = centerOffBoardCutouts([stray], board).get('path');
+    expect(update?.path).toBeDefined();
+    expect(isCutoutOffBoard({ ...stray, ...update }, board)).toBe(false);
+  });
+
+  it('measures an array by every instance, not just its master', () => {
+    const stray = createCutout({
+      id: 'arr',
+      x: 70,
+      y: 60,
+      width: 10,
+      depth: 10,
+      array: gridArray(3, 1, 20, 0),
+    });
+    const update = centerOffBoardCutouts([stray], board).get('arr');
+    expect(update).toBeDefined();
+    expect(isCutoutOffBoard({ ...stray, ...update }, board)).toBe(false);
+  });
+
+  it('honours a supplied id set rather than rescanning', () => {
+    const a = createCutout({ id: 'a', x: 95, y: 75 });
+    const b = createCutout({ id: 'b', x: 99, y: 79 });
+    expect([...centerOffBoardCutouts([a, b], board, new Set(['a'])).keys()]).toEqual(['a']);
   });
 });
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/offBoardCutouts.ts
@@ -254,6 +254,67 @@ export function clampCutoutToBoard(cutout: Cutout, board: CutoutBoard): Partial<
 }
 
 /**
+ * Updates that center every off-board cutout on the board AS ONE BLOCK, or an
+ * empty map when doing so would not clear the warning.
+ *
+ * The companion to the clamp for the case that produces most strays: a shape
+ * drawn at default size, then given its real dimensions, hangs off an edge
+ * while fitting the board perfectly well. The clamp slides it to the nearest
+ * edge; this puts it where it was going to be dragged anyway.
+ *
+ * One delta for the whole stray set, so strays the user arranged relative to
+ * each other keep that arrangement, and cutouts already on the board are never
+ * touched — this fixes the strays, it does not re-lay-out the design.
+ *
+ * All or nothing: a centering that rescues some strays and leaves others
+ * flagged would move the user's shapes and keep the warning up, so the caller
+ * hides the action instead. That also covers the boards where "centered" is not
+ * a meaningful answer — a cell mask or a lid window, where the middle of the
+ * bounding rectangle can be a notch or a magnet boss.
+ */
+export function centerOffBoardCutouts(
+  cutouts: readonly Cutout[],
+  board: CutoutBoard,
+  offBoardIds: ReadonlySet<string> = getOffBoardCutoutIds(cutouts, board)
+): Map<string, Partial<Cutout>> {
+  const empty = new Map<string, Partial<Cutout>>();
+  const strays = cutouts.filter((c) => offBoardIds.has(c.id));
+  if (strays.length === 0) return empty;
+
+  let group: Bounds | null = null;
+  for (const c of strays) {
+    for (const inst of expandCutoutArray(c)) {
+      const b = getCutoutBounds(inst);
+      group = group
+        ? {
+            minX: Math.min(group.minX, b.minX),
+            minY: Math.min(group.minY, b.minY),
+            maxX: Math.max(group.maxX, b.maxX),
+            maxY: Math.max(group.maxY, b.maxY),
+          }
+        : b;
+    }
+  }
+  if (!group) return empty;
+
+  const dx = (board.width - (group.maxX - group.minX)) / 2 - group.minX;
+  const dy = (board.depth - (group.maxY - group.minY)) / 2 - group.minY;
+  if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) return empty;
+
+  const updates = new Map<string, Partial<Cutout>>();
+  for (const c of strays) {
+    const moved = translateCutout(c, dx, dy);
+    if (isCutoutOffBoard(moved, board)) return empty;
+    updates.set(c.id, {
+      x: moved.x,
+      y: moved.y,
+      ...(moved.path ? { path: moved.path } : {}),
+    });
+  }
+  return updates;
+}
+
+/**
  * Updates for every off-board cutout that a clamp can fix (empty when none).
  * A patch that would still leave the shape off board — an oversized path or
  * mesh pulled to the origin but overhanging the far edge — is withheld, so an

--- a/src/features/whats-new/entries.ts
+++ b/src/features/whats-new/entries.ts
@@ -14,6 +14,15 @@ import type { WhatsNewEntry } from './types';
  */
 export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
   {
+    id: 'center-clipped-cutout',
+    date: '2026-08-24',
+    kind: 'new',
+    title: { en: 'Center a cutout that ended up off the board' },
+    body: {
+      en: 'Draw a shape, type its real size, and it often ends up hanging off an edge while fitting the bin perfectly well. The clipping warning now offers to center it, alongside growing the bin and pulling it back to the edge.',
+    },
+  },
+  {
     id: 'whats-new',
     date: '2026-08-24',
     kind: 'new',

--- a/src/features/whats-new/latest.ts
+++ b/src/features/whats-new/latest.ts
@@ -6,4 +6,4 @@
  * `latest.test.ts` asserts this matches `WHATS_NEW_ENTRIES[0]`, so the
  * duplication cannot drift past CI or the pre-commit check.
  */
-export const LATEST_ENTRY_ID = 'whats-new';
+export const LATEST_ENTRY_ID = 'center-clipped-cutout';


### PR DESCRIPTION
Adds a third recovery to the "cutout(s) will be clipped" warning, between growing the bin and clamping to the edge.

## Why

The workflow in the issue: draw a shape at default size, type its real width/height, and it is now hanging off an edge — while fitting the board perfectly well. Both existing exits read wrong there. Growing the bin changes the part. Clamping pins the shape to whichever edge it happened to overhang, so the next step is dragging it to the middle anyway.

## Behavior

`centerOffBoardCutouts` moves the strays as **one block** — a single delta — so strays the user arranged relative to each other keep that arrangement, and cutouts already on the board are never touched. This fixes the strays; it does not re-lay-out the design.

The button is offered only when centering clears **every** stray, and is hidden otherwise. That is what keeps it from restating "Bring back in":

- A shape too large for the board still overhangs when centered, so only growing or clamping is offered.
- On a cell mask or a lid window, the middle of the bounding rectangle can be a notch or a magnet boss. The fit is re-checked against the real board, so the action simply does not appear.
- All-or-nothing across strays: a partial centering would move the user's shapes and leave the warning standing.

Sits between Grow and Bring back in, because growing changes the part while the other two only move shapes, and centering is the gentler of those.

## No new translations

Reuses `binDesigner.cutouts.centerInBin`, which the right-click action already carries in all 15 locales and which says exactly this. No locale files touched.

## Verification

Unit tests for the centering (single stray, one-delta group move, path vertices, array instances, the withheld cases) and for the panel (ordering, the hidden state, label wrapping in the 220px dock). Full bin-designer suite green (5,522 tests).

Walked the issue's exact workflow in the running app: a 20mm circle given a 60mm diameter on an 84mm bin lands at x=y=10.55 — dead centre of the 81.1mm interior — with its size intact and the warning cleared.

Closes #3827

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

