### PR TITLE
feat(bin-designer): allow wall text on solid bins

### DIFF
--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.test.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.test.tsx
@@ -145,23 +145,31 @@ describe('WallsSection', () => {
       expect(useDesignerStore.getState().params.surfaceText?.style?.mode).toBe('emboss');
     });
 
-    it('replaces the inputs with a reason for polygon and solid bins', () => {
+    it('replaces the inputs with a reason for polygon bins', () => {
       useDesignerStore.setState({
         params: { ...DEFAULT_BIN_PARAMS, cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 0] } },
         ui: { ...DEFAULT_UI_STATE },
       });
-      const { unmount } = render(<WallsSection />);
+      render(<WallsSection />);
       expect(screen.queryByRole('textbox', { name: 'Front wall text' })).not.toBeInTheDocument();
       expect(screen.getByText('Not available for custom-shape bins.')).toBeInTheDocument();
-      unmount();
+    });
 
+    // A solid body has the same outer wall a hollow one does; only the interior
+    // features it disables are unavailable.
+    it('keeps the inputs on a solid bin', () => {
       useDesignerStore.setState({
-        params: { ...DEFAULT_BIN_PARAMS, base: { ...DEFAULT_BIN_PARAMS.base, solid: true } },
+        params: {
+          ...DEFAULT_BIN_PARAMS,
+          style: 'solid',
+          base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+          surfaceText: { walls: { front: 'BITS' } },
+        },
         ui: { ...DEFAULT_UI_STATE },
       });
       render(<WallsSection />);
-      expect(screen.queryByRole('textbox', { name: 'Front wall text' })).not.toBeInTheDocument();
-      expect(screen.getByText('Not available for solid bins.')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: 'Front wall text' })).toHaveValue('BITS');
+      expect(screen.queryByText('Not available for solid bins.')).not.toBeInTheDocument();
     });
   });
 

--- a/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
+++ b/src/features/bin-designer/components/panel/WallsSection/useWallsSection.ts
@@ -200,8 +200,9 @@ export function useWallsSection() {
   }, [dividersAvailableReason, dividersFit, params.style, t]);
 
   // ── Wall surface text ─────────────────────────────────────────
-  // Mirrors the worker gates in `wallTextLayout.ts`: polygon and solid-mode
-  // bins skip wall text entirely.
+  // Mirrors the worker gate in `wallTextLayout.ts`: only polygon bins skip
+  // wall text. A solid bin's outer face is the same wall as a hollow one's —
+  // the glyphs land on it identically, whatever is behind them.
   const wallTexts = params.surfaceText?.walls ?? {};
   // Anchor and mode both resolve through the shared surface style over the
   // design defaults, the same layering the worker applies.
@@ -213,9 +214,7 @@ export function useWallsSection() {
   );
   const wallTextDisabledReason = isPartialMask(params.cellMask)
     ? t('binDesigner.walls.text.disabledPolygon')
-    : params.base.solid
-      ? t('binDesigner.walls.text.disabledSolid')
-      : undefined;
+    : undefined;
 
   // Wall-text is gated behind a toggle (matching the sibling cutout/handle
   // sections). The open state is UI-only — deriving it as `local || hasText`

--- a/src/features/generation/worker/generators/binGenerator.scenario.wallText.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.wallText.test.ts
@@ -197,6 +197,75 @@ describe('wall surface text scenarios', () => {
     expect(withText.triangleCount).toBe(plain.triangleCount);
   });
 
+  // Solid bins used to skip wall text entirely, which left a shadow board with
+  // several tool pockets no practical way to identify itself from the outside.
+  // The outer face is the same wall a hollow bin engraves.
+  it('engraves a solid bin without moving its outer bbox', () => {
+    const generateBin = getGenerateBin();
+    const solid: Partial<BinParams> = {
+      style: 'solid',
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+    };
+    const plain = generateBin(makeParams(undefined, solid));
+    const engraved = generateBin(makeParams({ walls: { front: 'ABC' } }, solid));
+    assertStructurallyValid(engraved, 'solid bin wall text');
+    expect(engraved.triangleCount).not.toBe(plain.triangleCount);
+    const a = boundingBox(plain.vertices);
+    const b = boundingBox(engraved.vertices);
+    expect(Math.abs(b.minY - a.minY)).toBeLessThan(0.01);
+    expect(Math.abs(b.maxY - a.maxY)).toBeLessThan(0.01);
+  });
+
+  it('embosses a solid bin outward by the clamped relief', () => {
+    const generateBin = getGenerateBin();
+    const solid: Partial<BinParams> = {
+      style: 'solid',
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+    };
+    const plain = generateBin(makeParams(undefined, solid));
+    const embossed = generateBin(
+      makeParams(
+        {
+          walls: { front: 'ABC' },
+          style: { mode: 'emboss', depth: WALL_TEXT_MAX_EMBOSS },
+        },
+        solid
+      )
+    );
+    assertStructurallyValid(embossed, 'solid bin embossed wall text');
+    const a = boundingBox(plain.vertices);
+    const b = boundingBox(embossed.vertices);
+    expect(a.minY - b.minY).toBeGreaterThan(0);
+    expect(a.minY - b.minY).toBeLessThanOrEqual(WALL_TEXT_MAX_EMBOSS + 0.01);
+  });
+
+  it('keeps engraving a solid bin that also carries cutouts', () => {
+    const generateBin = getGenerateBin();
+    const solid: Partial<BinParams> = {
+      style: 'solid',
+      base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+      cutouts: [
+        {
+          id: 'pocket',
+          shape: 'circle',
+          x: 20,
+          y: 20,
+          width: 20,
+          depth: 20,
+          cutDepth: 8,
+          rotation: 0,
+          cornerRadius: 0,
+          label: '',
+          groupId: null,
+        },
+      ],
+    };
+    const withoutText = generateBin(makeParams(undefined, solid));
+    const withText = generateBin(makeParams({ walls: { front: 'ABC' } }, solid));
+    assertStructurallyValid(withText, 'solid bin cutouts plus wall text');
+    expect(withText.triangleCount).not.toBe(withoutText.triangleCount);
+  });
+
   it('wall text rejects the direct-mesh draft path', () => {
     expect(canBinUseDirectMesh(makeParams(undefined))).toBe(true);
     expect(canBinUseDirectMesh(makeParams({ walls: { front: 'ABC' } }))).toBe(false);

--- a/src/features/generation/worker/generators/binGenerator.scenario.wallText.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.wallText.test.ts
@@ -266,6 +266,25 @@ describe('wall surface text scenarios', () => {
     expect(withText.triangleCount).not.toBe(withoutText.triangleCount);
   });
 
+  // Half-grid is the recurring crash class for any new geometry path (integer
+  // assumptions on fractional dims), and solid mode reaches the wall through a
+  // different branch than the hollow one this file already covers.
+  it('stays valid on a half-grid solid bin', () => {
+    const generateBin = getGenerateBin();
+    const result = generateBin(
+      makeParams(
+        { walls: { front: 'AB' } },
+        {
+          style: 'solid',
+          base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+          width: 2.5,
+          depth: 1.5,
+        }
+      )
+    );
+    assertStructurallyValid(result, 'half-grid solid wall text');
+  });
+
   it('wall text rejects the direct-mesh draft path', () => {
     expect(canBinUseDirectMesh(makeParams(undefined))).toBe(true);
     expect(canBinUseDirectMesh(makeParams({ walls: { front: 'ABC' } }))).toBe(false);

--- a/src/features/generation/worker/generators/pipeline/featureComposition.ts
+++ b/src/features/generation/worker/generators/pipeline/featureComposition.ts
@@ -35,3 +35,13 @@ export const BIN_FEATURE_BUILDERS: readonly FeatureBuilder[] = [
   wallTextCutFeature,
   wallTextEmbossFeature,
 ] as const;
+
+/**
+ * The subset a solid body can still take. Every other builder here shapes an
+ * interior a solid bin does not have; wall text works the outer face, which is
+ * the same wall either way.
+ */
+export const SOLID_FEATURE_BUILDERS: readonly FeatureBuilder[] = [
+  wallTextCutFeature,
+  wallTextEmbossFeature,
+] as const;

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -5,7 +5,8 @@
  * walls, inserts, slots, label tabs, scoop ramps, wall cutouts. Wall
  * patterns are handled as a special case with per-wall caching.
  *
- * Solid mode: only cutout cuts (top-down cavity carving).
+ * Solid mode: cutout cuts (top-down cavity carving), plus wall text — the
+ * outer face of a solid block is the same wall a hollow bin engraves.
  *
  * Populates fuseTargets (additive), cutTargets (subtractive), and
  * patternCutTargets (pattern cuts — separate boolean pass) arrays
@@ -19,7 +20,7 @@ import { buildCutoutCuts } from '../../featureBuilder';
 import { buildCutoutLabelSocketTools } from '../../cutoutLabelSocketBuilder';
 import { buildIntegratedKnifeRestTools } from '../../knifeRestBuilder';
 import { runFeatureBuilders } from '../featureRunner';
-import { BIN_FEATURE_BUILDERS } from '../featureComposition';
+import { BIN_FEATURE_BUILDERS, SOLID_FEATURE_BUILDERS } from '../featureComposition';
 import { buildWallPatterns } from '../../wallPatternBuilder';
 import { buildKumikoWallPatterns } from '../../kumikoWrapBuilder';
 import { buildDividerPatterns } from '../../dividerPatternBuilder';
@@ -98,9 +99,22 @@ export const featuresStage: PipelineStage = {
       // here would clobber them — just translate.
       const cutoutTools = cutTools.map(shiftToInterior);
       const embossTools = fuseTools.map(shiftToInterior);
+      // Wall text is the one generic feature a solid body can still take: it
+      // works the outer face, which a solid bin has exactly like a hollow one.
+      // Run through the shared runner rather than called directly, so engrave
+      // and emboss keep landing in the right pile and stay on the same cache
+      // key as everywhere else. Deliberately NOT shifted: the tools are built
+      // in the outer-wall frame, which the asymmetric-overhang offset above
+      // does not apply to.
+      const wallText = runFeatureBuilders(SOLID_FEATURE_BUILDERS, ctx);
       // Solid-mode cutout tools aren't keyed through feature builders, so the
       // post-boolean resume cache can't safely identify them — disable it.
-      return { ...ctx, cutTargets: cutoutTools, fuseTargets: embossTools, featuresKey: null };
+      return {
+        ...ctx,
+        cutTargets: [...cutoutTools, ...wallText.cutTargets],
+        fuseTargets: [...embossTools, ...wallText.fuseTargets],
+        featuresKey: null,
+      };
     }
 
     // For non-rectangular (cellMask) bins, run only builders that have

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -113,6 +113,9 @@ export const featuresStage: PipelineStage = {
         ...ctx,
         cutTargets: [...cutoutTools, ...wallText.cutTargets],
         fuseTargets: [...embossTools, ...wallText.fuseTargets],
+        // Empty for the two wall-text builders, and passed on anyway so a
+        // builder added to the solid set later cannot leak its shapes here.
+        patternCutTargets: wallText.patternCutTargets,
         featuresKey: null,
       };
     }

--- a/src/features/generation/worker/generators/wallTextBuilder.ts
+++ b/src/features/generation/worker/generators/wallTextBuilder.ts
@@ -171,8 +171,7 @@ export const wallTextCutFeature: FeatureBuilder = {
   name: 'wallTextCut',
   tag: FeatureTag.TEXT,
   target: 'cut',
-  shouldBuild: (ctx) =>
-    hasAnyWallText(ctx.params) && hasWallTextMode(ctx.params, false) && !ctx.dimensions.solid,
+  shouldBuild: (ctx) => hasAnyWallText(ctx.params) && hasWallTextMode(ctx.params, false),
   cacheKey: wallTextCacheKey,
   build: (ctx) => buildWallTextShapes(ctx, false),
 };
@@ -181,8 +180,7 @@ export const wallTextEmbossFeature: FeatureBuilder = {
   name: 'wallTextEmboss',
   tag: FeatureTag.TEXT,
   target: 'fuse',
-  shouldBuild: (ctx) =>
-    hasAnyWallText(ctx.params) && hasWallTextMode(ctx.params, true) && !ctx.dimensions.solid,
+  shouldBuild: (ctx) => hasAnyWallText(ctx.params) && hasWallTextMode(ctx.params, true),
   cacheKey: wallTextCacheKey,
   build: (ctx) => buildWallTextShapes(ctx, true),
 };

--- a/src/features/generation/worker/generators/wallTextLayout.test.ts
+++ b/src/features/generation/worker/generators/wallTextLayout.test.ts
@@ -263,15 +263,42 @@ describe('computeWallTextLayouts', () => {
     }
   });
 
-  it('returns [] for polygon and solid bins', () => {
+  it('returns [] for polygon bins', () => {
     const polygon = makeParams(
       { front: 'Cables' },
       { cellMask: { cols: 4, rows: 4, cells: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0] } }
     );
     expect(computeWallTextLayouts(polygon, DIMS)).toHaveLength(0);
-    expect(
-      computeWallTextLayouts(makeParams({ front: 'Cables' }), { ...DIMS, solid: true })
-    ).toHaveLength(0);
+  });
+
+  // A solid body's outer wall is the same face a hollow bin engraves, and it
+  // is often the only place a shadow board can identify itself from outside.
+  it('lays a solid bin out identically to a hollow one', () => {
+    const params = makeParams({ front: 'Cables' });
+    expect(computeWallTextLayouts(params, { ...DIMS, solid: true })).toEqual(
+      computeWallTextLayouts(params, DIMS)
+    );
+  });
+
+  // Solid style disables wall cutouts and handles, so nothing is cut there to
+  // dodge. An imported design can still carry the flags the constraint engine
+  // clears on the way in; honouring them would shrink the band around a hole
+  // that is never made.
+  it('ignores wall-cutout keep-outs a solid bin will never generate', () => {
+    const withCutout = makeParams(
+      { front: 'Cables' },
+      {
+        walls: {
+          ...DEFAULT_BIN_PARAMS.walls,
+          enabled: true,
+          front: { ...DEFAULT_BIN_PARAMS.walls.front, enabled: true, width: 80, depth: 60 },
+        },
+      }
+    );
+    const plain = makeParams({ front: 'Cables' });
+    expect(computeWallTextLayouts(withCutout, { ...DIMS, solid: true })).toEqual(
+      computeWallTextLayouts(plain, { ...DIMS, solid: true })
+    );
   });
 
   it('clamps emboss relief and keeps an engrave floor', () => {

--- a/src/features/whats-new/entries.ts
+++ b/src/features/whats-new/entries.ts
@@ -14,6 +14,15 @@ import type { WhatsNewEntry } from './types';
  */
 export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
   {
+    id: 'solid-bin-wall-text',
+    date: '2026-08-24',
+    kind: 'new',
+    title: { en: 'Wall text works on solid bins' },
+    body: {
+      en: 'A shadow board full of tool pockets had no way to label itself from the outside. Engraved and embossed wall text is now available on solid bins, with the same font, side and depth controls as everywhere else.',
+    },
+  },
+  {
     id: 'center-clipped-cutout',
     date: '2026-08-24',
     kind: 'new',

--- a/src/features/whats-new/latest.ts
+++ b/src/features/whats-new/latest.ts
@@ -6,4 +6,4 @@
  * `latest.test.ts` asserts this matches `WHATS_NEW_ENTRIES[0]`, so the
  * duplication cannot drift past CI or the pre-commit check.
  */
-export const LATEST_ENTRY_ID = 'center-clipped-cutout';
+export const LATEST_ENTRY_ID = 'solid-bin-wall-text';

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Umístění textu na stěně",
   "binDesigner.walls.text.disabledPolygon": "Není dostupné pro biny s vlastním tvarem.",
-  "binDesigner.walls.text.disabledSolid": "Není dostupné pro plné biny.",
   "binDesigner.walls.text.heading": "Text na stěně",
   "binDesigner.walls.text.hint": "Text se umístí do volné plochy každé stěny, mimo výřezy a úchyty. Vzor stěny se za ním odstraní.",
   "binDesigner.walls.text.placeholder": "např. Kabely",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Position des Wandtexts",
   "binDesigner.walls.text.disabledPolygon": "Für Sonderformen nicht verfügbar.",
-  "binDesigner.walls.text.disabledSolid": "Für massive Behälter nicht verfügbar.",
   "binDesigner.walls.text.heading": "Wandtext",
   "binDesigner.walls.text.hint": "Der Text wird in die freie Fläche jeder Wand gesetzt, an Ausschnitten und Griffen vorbei. Das Wandmuster wird dahinter entfernt.",
   "binDesigner.walls.text.placeholder": "z. B. Kabel",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3145,7 +3145,6 @@ const en: Record<string, string> = {
   'binDesigner.walls.text.placeholder': 'e.g. Cables',
   'binDesigner.walls.text.sideAria': '{side} wall text',
   'binDesigner.walls.text.disabledPolygon': 'Not available for custom-shape bins.',
-  'binDesigner.walls.text.disabledSolid': 'Not available for solid bins.',
   'binDesigner.walls.text.hint':
     'Text is placed in the clear area of each wall, avoiding cutouts and handles. Wall patterns are cleared behind it.',
   'binDesigner.slideTray.fitSample.button': 'Print fit test',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Posición del texto en la pared",
   "binDesigner.walls.text.disabledPolygon": "No disponible para contenedores de forma personalizada.",
-  "binDesigner.walls.text.disabledSolid": "No disponible para contenedores macizos.",
   "binDesigner.walls.text.heading": "Texto en la pared",
   "binDesigner.walls.text.hint": "El texto se sitúa en la zona libre de cada pared, esquivando recortes y asas. El patrón de la pared se retira detrás.",
   "binDesigner.walls.text.placeholder": "p. ej. Cables",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Position du texte sur la paroi",
   "binDesigner.walls.text.disabledPolygon": "Indisponible pour les bacs de forme personnalisée.",
-  "binDesigner.walls.text.disabledSolid": "Indisponible pour les bacs pleins.",
   "binDesigner.walls.text.heading": "Texte mural",
   "binDesigner.walls.text.hint": "Le texte est placé dans la zone libre de chaque paroi, en évitant découpes et poignées. Le motif de paroi est retiré derrière.",
   "binDesigner.walls.text.placeholder": "p. ex. Câbles",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Posizione del testo sulla parete",
   "binDesigner.walls.text.disabledPolygon": "Non disponibile per contenitori con forma personalizzata.",
-  "binDesigner.walls.text.disabledSolid": "Non disponibile per contenitori pieni.",
   "binDesigner.walls.text.heading": "Testo sulla parete",
   "binDesigner.walls.text.hint": "Il testo viene collocato nell’area libera di ogni parete, evitando intagli e maniglie. Il motivo della parete viene rimosso dietro.",
   "binDesigner.walls.text.placeholder": "es. Cavi",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "積石亀甲",
   "binDesigner.walls.text.anchor": "側面文字の配置",
   "binDesigner.walls.text.disabledPolygon": "カスタム形状のビンでは使用できません。",
-  "binDesigner.walls.text.disabledSolid": "ソリッドビンでは使用できません。",
   "binDesigner.walls.text.heading": "壁面テキスト",
   "binDesigner.walls.text.hint": "文字は各側面の空きスペースに配置され、切り欠きや取っ手を避けます。背後の側面パターンは取り除かれます。",
   "binDesigner.walls.text.placeholder": "例: ケーブル",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "벽면 문구 위치",
   "binDesigner.walls.text.disabledPolygon": "맞춤 모양 수납통에는 사용할 수 없습니다.",
-  "binDesigner.walls.text.disabledSolid": "솔리드 수납통에는 사용할 수 없습니다.",
   "binDesigner.walls.text.heading": "벽 텍스트",
   "binDesigner.walls.text.hint": "문구는 각 벽면의 빈 영역에 배치되며 컷아웃과 손잡이를 피합니다. 뒤쪽 벽면 패턴은 제거됩니다.",
   "binDesigner.walls.text.placeholder": "예: 케이블",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Plassering av veggtekst",
   "binDesigner.walls.text.disabledPolygon": "Ikke tilgjengelig for bokser med tilpasset form.",
-  "binDesigner.walls.text.disabledSolid": "Ikke tilgjengelig for massive bokser.",
   "binDesigner.walls.text.heading": "Veggtekst",
   "binDesigner.walls.text.hint": "Teksten plasseres i det ledige feltet på hver vegg, utenom utskjæringer og håndtak. Veggmønsteret fjernes bak den.",
   "binDesigner.walls.text.placeholder": "f.eks. Kabler",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Positie van wandtekst",
   "binDesigner.walls.text.disabledPolygon": "Niet beschikbaar voor bakken met aangepaste vorm.",
-  "binDesigner.walls.text.disabledSolid": "Niet beschikbaar voor massieve bakken.",
   "binDesigner.walls.text.heading": "Wandtekst",
   "binDesigner.walls.text.hint": "De tekst komt in het vrije vlak van elke wand, langs uitsparingen en grepen. Het wandpatroon wordt erachter weggehaald.",
   "binDesigner.walls.text.placeholder": "bijv. Kabels",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Położenie napisu na ściance",
   "binDesigner.walls.text.disabledPolygon": "Niedostępne dla binów o własnym kształcie.",
-  "binDesigner.walls.text.disabledSolid": "Niedostępne dla pełnych binów.",
   "binDesigner.walls.text.heading": "Tekst na ściance",
   "binDesigner.walls.text.hint": "Tekst trafia w wolny obszar każdej ścianki, omijając wycięcia i uchwyty. Wzór ścianki jest za nim usuwany.",
   "binDesigner.walls.text.placeholder": "np. Kable",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Posição do texto na parede",
   "binDesigner.walls.text.disabledPolygon": "Indisponível para caixas de formato personalizado.",
-  "binDesigner.walls.text.disabledSolid": "Indisponível para caixas maciças.",
   "binDesigner.walls.text.heading": "Texto na parede",
   "binDesigner.walls.text.hint": "O texto é posicionado na área livre de cada parede, desviando de recortes e alças. O padrão da parede é removido atrás dele.",
   "binDesigner.walls.text.placeholder": "ex.: Cabos",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "Placering av väggtext",
   "binDesigner.walls.text.disabledPolygon": "Inte tillgängligt för lådor med anpassad form.",
-  "binDesigner.walls.text.disabledSolid": "Inte tillgängligt för massiva lådor.",
   "binDesigner.walls.text.heading": "Väggtext",
   "binDesigner.walls.text.hint": "Texten placeras i den lediga ytan på varje vägg, förbi urtag och handtag. Väggmönstret tas bort bakom den.",
   "binDesigner.walls.text.placeholder": "t.ex. Kablar",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Цуміїші-кікко (積石亀甲)",
   "binDesigner.walls.text.anchor": "Розташування напису на стінці",
   "binDesigner.walls.text.disabledPolygon": "Недоступно для контейнерів довільної форми.",
-  "binDesigner.walls.text.disabledSolid": "Недоступно для суцільних контейнерів.",
   "binDesigner.walls.text.heading": "Текст на стінці",
   "binDesigner.walls.text.hint": "Текст розміщується у вільній зоні кожної стінки, оминаючи вирізи та ручки. Візерунок стінки за ним прибирається.",
   "binDesigner.walls.text.placeholder": "напр. Кабелі",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1858,7 +1858,6 @@
   "binDesigner.walls.pattern.tsumiishiKikko": "Tsumiishi-Kikko (積石亀甲)",
   "binDesigner.walls.text.anchor": "侧壁文字位置",
   "binDesigner.walls.text.disabledPolygon": "自定义形状收纳盒不可用。",
-  "binDesigner.walls.text.disabledSolid": "实心收纳盒不可用。",
   "binDesigner.walls.text.heading": "壁文字",
   "binDesigner.walls.text.hint": "文字会放在每面侧壁的空白区域，避开缺口和把手，并清除其后的侧壁纹样。",
   "binDesigner.walls.text.placeholder": "例如 Cables",

--- a/src/shared/utils/wallTextPlan.ts
+++ b/src/shared/utils/wallTextPlan.ts
@@ -14,8 +14,7 @@
  * same frame the feature builders use). Reading-direction conversion for glyph
  * placement happens in `wallTextBuilder` via {@link wallTextReadingSign}.
  *
- * Skipped entirely for polygon (cellMask) bins and solid-mode bins (the
- * solid-mode features stage doesn't run generic builders), and per-wall for
+ * Skipped entirely for polygon (cellMask) bins, and per-wall for
  * slot-occupied walls, mirrored in the WallsSection UI gating.
  */
 
@@ -111,9 +110,16 @@ function obstacleRects(
   side: WallTextSide,
   wallSpan: number,
   wallHeight: number,
-  isSlotted: boolean
+  isSlotted: boolean,
+  solid: boolean
 ): Rect[] {
   const rects: Rect[] = [];
+
+  // A solid body generates neither of the obstacles below — the style disables
+  // wall cutouts and handles outright. Reading them anyway would shrink the
+  // band around a hole nothing cuts, which an imported design can still ask for
+  // by carrying the flags the constraint engine clears on the way in.
+  if (solid) return rects;
 
   const cutout = params.walls.enabled ? params.walls[side] : undefined;
   if (cutout?.enabled) {
@@ -321,7 +327,14 @@ function collectSides(params: BinParams, dim: WallTextDims): SideInput[] {
     const bounds = wallBounds(params, dim, wallSpan);
     if (!bounds) continue;
 
-    const obstacles = obstacleRects(params, side, wallSpan, dim.wallHeight, dim.isSlotted);
+    const obstacles = obstacleRects(
+      params,
+      side,
+      wallSpan,
+      dim.wallHeight,
+      dim.isSlotted,
+      dim.solid
+    );
     out.push({ side, text, style, depth, rects: candidateRects(bounds, obstacles) });
   }
   return out;
@@ -355,7 +368,7 @@ function toLayout(input: SideInput, candidate: Candidate): WallTextLayout {
 
 /**
  * Compute the placement for every wall carrying text. Returns [] when the
- * feature doesn't apply (no strings, polygon or solid bin) and silently skips
+ * feature doesn't apply (no strings, or a polygon bin) and silently skips
  * walls whose clear regions can't hold the text at `minFontSize`, the
  * established convention for undersized features.
  */
@@ -364,7 +377,7 @@ export function computeWallTextLayouts(
   dim: WallTextDims,
   measurer: TypeMeasurer
 ): WallTextLayout[] {
-  if (isPartialMask(params.cellMask) || dim.solid) return [];
+  if (isPartialMask(params.cellMask)) return [];
 
   const sides = collectSides(params, dim);
   if (sides.length === 0) return [];


### PR DESCRIPTION
Wall text was unavailable on solid bins. A shadow board with several tool pockets had no practical way to identify itself from the outside — which is exactly where a label is most useful.

## Why it was blocked

Nothing about the geometry. A solid bin's outer face is the same wall a hollow one engraves; the glyphs land on it identically, whatever is behind them. The feature was skipped because the solid-mode branch of `featuresStage` never runs the generic feature builders, so `wallTextCutFeature` / `wallTextEmbossFeature` were gated off to match, and the solver and panel followed.

## Change

- `featuresStage` runs the wall-text builders alongside the cutout cuts in the solid branch, via the shared `runFeatureBuilders` so engrave and emboss keep landing in the right pile and stay on the same cache key as everywhere else. `SOLID_FEATURE_BUILDERS` names the subset a solid body can take.
- The tools are deliberately **not** given the `innerOffsetX/Y` shift the cutout tools take. They are built in the outer-wall frame, which the asymmetric-overhang offset does not apply to.
- The solver and the Walls panel drop their `solid` gates.
- Solid style disables wall cutouts and handles, so the solver stops reading them as keep-outs on a solid bin. Only the constraint engine clears those flags, and an imported design can arrive still carrying them — honouring them would shrink the text band around a hole that is never cut.

The band itself is unchanged, so text sits at the same height whether a design is solid or hollow, clear of the base profile and the lip taper.

Removes `binDesigner.walls.text.disabledSolid`, now unused, from all 15 locales.

## Verification

Four new real-WASM scenario tests in `binGenerator.scenario.wallText`, all asserting `assertStructurallyValid` (manifold, watertight, non-degenerate):

- engrave changes the mesh without moving the outer bbox,
- emboss extends the front face by exactly the clamped relief,
- a solid bin carrying cutouts still engraves,
- a **half-grid** solid bin stays valid — fractional dims are the recurring crash class for a new geometry path, and solid reaches the wall through a different branch than the hollow half-grid case already covered.

Both checks CLAUDE.md and the geometry-debugging skill call for:

- `binGenerator.scenario` — 750 tests, all domains on real OCCT.
- `binGenerator.export` — 521 tests: parseable STL, watertight, 2-manifold, NaN-free.

Solver tests cover solid-equals-hollow layout and the ignored keep-outs. `wallTextCacheKey` already carries `params.style`, `walls` and `handles`, so solid and hollow cannot collide. Full suite green (25,122).

Rendered in the app: a 3×2×4u solid bin with two tool pockets and "ROUTER BITS" on the front wall — centred on the face, sitting in the band, legible from the front view.

Closes #3837