### PR TITLE
feat(bin-designer): resize a cutout about its own center when a size is typed

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
@@ -86,7 +86,58 @@ describe('SingleCutoutInspector', () => {
     fireEvent.change(input, { target: { value: '156' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
-    expect(onUpdate).toHaveBeenCalledWith('c1', { width: 156 });
+    // Center-anchored: the 10-wide cutout at x=5 is centered on 10, so a
+    // 156-wide box keeps that center and starts at -68. Deliberately off-board;
+    // the clipping warning offers grow / center / bring-back-in.
+    expect(onUpdate).toHaveBeenCalledWith('c1', { width: 156, depth: 10, x: -68, y: 5 });
+  });
+
+  // The router-bit case from the issue: only the size was meant to change, so
+  // the hole must not walk out from under the part it was drilled for.
+  it('holds a cutout center when a typed size changes', () => {
+    const onUpdate = vi.fn();
+    render(
+      <SingleCutoutInspector
+        cutout={makeCutout({ x: 20, y: 20, width: 6.35, depth: 6.35 })}
+        preview={new Map()}
+        binWidth={100}
+        binDepth={100}
+        maxCutDepth={20}
+        onUpdate={onUpdate}
+        disabled={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'W: 6.35 mm' }));
+    const input = screen.getByRole('textbox', { name: 'W' });
+    fireEvent.change(input, { target: { value: '12.7' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    const patch = onUpdate.mock.calls[0][1] as { x: number; width: number };
+    expect(patch.width).toBe(12.7);
+    expect(patch.x + patch.width / 2).toBeCloseTo(20 + 6.35 / 2, 10);
+  });
+
+  it('holds the center on the H axis too, leaving X alone', () => {
+    const onUpdate = vi.fn();
+    render(
+      <SingleCutoutInspector
+        cutout={makeCutout({ shape: 'rectangle', x: 20, y: 20, width: 10, depth: 10 })}
+        preview={new Map()}
+        binWidth={100}
+        binDepth={100}
+        maxCutDepth={20}
+        onUpdate={onUpdate}
+        disabled={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'H: 10 mm' }));
+    const input = screen.getByRole('textbox', { name: 'H' });
+    fireEvent.change(input, { target: { value: '30' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onUpdate).toHaveBeenCalledWith('c1', { width: 10, depth: 30, x: 20, y: 10 });
   });
 
   it('shows the Repeat section with its presets for a repeatable shape', () => {

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.test.tsx
@@ -140,6 +140,34 @@ describe('SingleCutoutInspector', () => {
     expect(onUpdate).toHaveBeenCalledWith('c1', { width: 10, depth: 30, x: 20, y: 10 });
   });
 
+  // The fields render preview-merged values, so the center must be taken from
+  // the same box — anchoring on the stored one would re-center a shape onto a
+  // position the user cannot see.
+  it('anchors on the previewed box, not the stored one', () => {
+    const onUpdate = vi.fn();
+    render(
+      <SingleCutoutInspector
+        cutout={makeCutout({ shape: 'rectangle', x: 5, y: 5, width: 10, depth: 10 })}
+        preview={new Map([['c1', { x: 40, width: 20 }]])}
+        binWidth={100}
+        binDepth={100}
+        maxCutDepth={20}
+        onUpdate={onUpdate}
+        disabled={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'W: 20 mm' }));
+    const input = screen.getByRole('textbox', { name: 'W' });
+    fireEvent.change(input, { target: { value: '40' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Previewed box is 20 wide at x=40, centered on 50; a 40-wide box keeps
+    // that center and starts at 30. Anchoring on the stored 10-wide box at x=5
+    // would have produced -10.
+    expect(onUpdate).toHaveBeenCalledWith('c1', { width: 40, depth: 10, x: 30, y: 5 });
+  });
+
   it('shows the Repeat section with its presets for a repeatable shape', () => {
     renderit(makeCutout({ shape: 'circle' }));
     expect(screen.getByText('binDesigner.cutouts.section.repeat')).toBeInTheDocument();

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from '@/i18n';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
 import { clampRotationToBounds } from '../panel/CutoutsSection/geometry';
+import { resizeAroundCenter } from '../panel/CutoutsSection/cutoutHelpers';
 import { cutoutDepthShortfall } from '../panel/CutoutsSection/cutoutDepthShortfall';
 import { CutoutScoopControls } from './CutoutScoopControls';
 import { CutoutShapeControls } from '../panel/CutoutsSection/CutoutShapeControls';
@@ -161,11 +162,16 @@ export function SingleCutoutInspector({
             />
             {/* softMax: W/H hold a measured dimension, so a typed value past the
                 board is kept and the off-board banner offers to grow the bin
-                (#3061) — truncating it silently shipped wrong-sized pockets. */}
+                (#3061) — truncating it silently shipped wrong-sized pockets.
+                Anchored on the center, matching every other size control here
+                (polygon across-flats, circle diameter, knife presets): a typed
+                size is a measurement of the thing going in the pocket, not an
+                instruction to move it. Handle drags stay edge-anchored — that
+                edge is what the cursor is holding. */}
             <CompactNumberInput
               label="W"
               value={getEffective(cutout, preview, 'width')}
-              onChange={(width) => onUpdate(cutout.id, { width })}
+              onChange={(width) => onUpdate(cutout.id, resizeAroundCenter(cutout, { width }))}
               min={2}
               max={binWidth}
               softMax
@@ -176,7 +182,7 @@ export function SingleCutoutInspector({
             <CompactNumberInput
               label="H"
               value={getEffective(cutout, preview, 'depth')}
-              onChange={(depth) => onUpdate(cutout.id, { depth })}
+              onChange={(depth) => onUpdate(cutout.id, resizeAroundCenter(cutout, { depth }))}
               min={2}
               max={binDepth}
               softMax

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
@@ -121,14 +121,13 @@ export function SingleCutoutInspector({
   const ungroupCutouts = useDesignerStore((s) => s.ungroupCutouts);
   // maxCutDepth is the remaining fill on a bin host; a through-cut host has no
   // depth to fall short of.
+  // The fields display preview-merged values, so anything computed FROM them
+  // has to read the same box — a center taken from the stored x/width while an
+  // override is live would re-anchor on a position the user cannot see.
+  const live = { ...cutout, ...preview.get(cutout.id) };
   const depthShortfall = throughOnly
     ? null
-    : cutoutDepthShortfall(
-        { ...cutout, ...preview.get(cutout.id) },
-        binWidth,
-        binDepth,
-        maxCutDepth
-      );
+    : cutoutDepthShortfall(live, binWidth, binDepth, maxCutDepth);
   return (
     <>
       <div className="-mx-4 border-b border-stroke-subtle px-4 py-3">
@@ -171,7 +170,7 @@ export function SingleCutoutInspector({
             <CompactNumberInput
               label="W"
               value={getEffective(cutout, preview, 'width')}
-              onChange={(width) => onUpdate(cutout.id, resizeAroundCenter(cutout, { width }))}
+              onChange={(width) => onUpdate(cutout.id, resizeAroundCenter(live, { width }))}
               min={2}
               max={binWidth}
               softMax
@@ -182,7 +181,7 @@ export function SingleCutoutInspector({
             <CompactNumberInput
               label="H"
               value={getEffective(cutout, preview, 'depth')}
-              onChange={(depth) => onUpdate(cutout.id, resizeAroundCenter(cutout, { depth }))}
+              onChange={(depth) => onUpdate(cutout.id, resizeAroundCenter(live, { depth }))}
               min={2}
               max={binDepth}
               softMax

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.test.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.test.tsx
@@ -86,6 +86,35 @@ describe('CutoutPropertyPanel', () => {
     expect(screen.queryByTestId('slider-binDesigner.cutouts.cornerRadius')).not.toBeInTheDocument();
   });
 
+  // Same rule as the workspace inspector: the sidebar's width/depth sliders are
+  // the same measurement, so they hold the center too.
+  it('holds the cutout center when width changes', () => {
+    render(<CutoutPropertyPanel {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('binDesigner.cutouts.width'), {
+      target: { value: '40' },
+    });
+    // 20-wide at x=10 is centered on 20; a 40-wide box keeps that center.
+    expect(onUpdate).toHaveBeenCalledWith('test-cutout', {
+      width: 40,
+      depth: 15,
+      x: 0,
+      y: 10,
+    });
+  });
+
+  it('holds the cutout center when depth changes', () => {
+    render(<CutoutPropertyPanel {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('binDesigner.cutouts.depth'), {
+      target: { value: '25' },
+    });
+    expect(onUpdate).toHaveBeenCalledWith('test-cutout', {
+      width: 20,
+      depth: 25,
+      x: 10,
+      y: 5,
+    });
+  });
+
   it('renders duplicate and delete buttons', () => {
     render(<CutoutPropertyPanel {...defaultProps} />);
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutPropertyPanel.tsx
@@ -17,6 +17,7 @@ import { hasFitControls, formatFitSummary, repeatBlockedReason } from './cutoutS
 import { CutoutArrayControls } from './CutoutArrayControls';
 import { arrayInstanceCount } from '@/shared/utils/cutoutArray';
 import type { FitCue } from './cutoutSectionVisibility';
+import { resizeAroundCenter } from './cutoutHelpers';
 
 interface CutoutPropertyPanelProps {
   readonly cutout: Cutout;
@@ -82,7 +83,7 @@ export function CutoutPropertyPanel({
               <SliderInput
                 label={t('binDesigner.cutouts.width')}
                 value={cutout.width}
-                onChange={(width) => onUpdate(cutout.id, { width })}
+                onChange={(width) => onUpdate(cutout.id, resizeAroundCenter(cutout, { width }))}
                 min={2}
                 max={maxWidth}
                 step={0.5}
@@ -92,7 +93,7 @@ export function CutoutPropertyPanel({
               <SliderInput
                 label={t('binDesigner.cutouts.depth')}
                 value={cutout.depth}
-                onChange={(depth) => onUpdate(cutout.id, { depth })}
+                onChange={(depth) => onUpdate(cutout.id, resizeAroundCenter(cutout, { depth }))}
                 min={2}
                 max={maxDepth}
                 step={0.5}

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.test.ts
@@ -3,6 +3,7 @@ import {
   createDefaultCutout,
   defaultPlaceSize,
   resizeKeepingCenter,
+  resizeAroundCenter,
   flattenCutoutArray,
   applyFlattenArray,
   translateCutoutPreview,
@@ -66,6 +67,60 @@ describe('resizeKeepingCenter', () => {
     expect(r.y).toBe(0);
     expect(r.width).toBe(30);
     expect(r.depth).toBe(30);
+  });
+});
+
+describe('resizeAroundCenter', () => {
+  // The router-bit case: a 1/4" shank becomes a 1/2" shank and the hole must
+  // stay where it was drilled.
+  it('grows equally in every direction from the same center', () => {
+    const r = resizeAroundCenter(
+      { x: 20, y: 20, width: 6.35, depth: 6.35 },
+      {
+        width: 12.7,
+        depth: 12.7,
+      }
+    );
+    const centerOf = (o: number, size: number) => o + size / 2;
+    expect(centerOf(r.x, r.width)).toBeCloseTo(centerOf(20, 6.35), 10);
+    expect(centerOf(r.y, r.depth)).toBeCloseTo(centerOf(20, 6.35), 10);
+  });
+
+  it('moves only the axis being resized', () => {
+    const r = resizeAroundCenter({ x: 10, y: 10, width: 20, depth: 20 }, { width: 30 });
+    expect(r.x).toBe(5);
+    expect(r.y).toBe(10);
+    expect(r.depth).toBe(20);
+  });
+
+  it('shrinks toward the center too', () => {
+    const r = resizeAroundCenter(
+      { x: 10, y: 10, width: 20, depth: 20 },
+      {
+        width: 10,
+        depth: 10,
+      }
+    );
+    expect(r).toEqual({ x: 15, y: 15, width: 10, depth: 10 });
+  });
+
+  // The deliberate difference from resizeKeepingCenter: a typed size is a
+  // measurement, so it is never truncated and the origin is never pulled back
+  // onto the board. The off-board warning is what handles the result.
+  it('keeps the typed size and lets the result hang off the board', () => {
+    const r = resizeAroundCenter(
+      { x: 0, y: 0, width: 10, depth: 10 },
+      {
+        width: 40,
+        depth: 40,
+      }
+    );
+    expect(r).toEqual({ x: -15, y: -15, width: 40, depth: 40 });
+  });
+
+  it('is a no-op patch when neither dimension changes', () => {
+    const box = { x: 10, y: 10, width: 20, depth: 20 };
+    expect(resizeAroundCenter(box, {})).toEqual(box);
   });
 });
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
@@ -167,6 +167,35 @@ export function resizeKeepingCenter(
 }
 
 /**
+ * Patch that resizes a cutout about its own center, leaving the center where it
+ * was and growing equally in every direction.
+ *
+ * Deliberately unclamped, unlike {@link resizeKeepingCenter}: the W/H fields
+ * hold a MEASURED dimension, so truncating the size to the board — or sliding
+ * the origin back onto it — would cut a pocket that is not the size that was
+ * typed. A result hanging off the board is left to the off-board warning, which
+ * offers to grow the bin, center the stray, or pull it back in.
+ *
+ * Rotation needs no special case: `x`/`y` are the unrotated box origin and
+ * rotation is about the box center, so holding that center holds the rotated
+ * shape too. Array instances are offsets from the master center, so they follow
+ * as well.
+ */
+export function resizeAroundCenter(
+  cutout: Pick<Cutout, 'x' | 'y' | 'width' | 'depth'>,
+  next: { readonly width?: number; readonly depth?: number }
+): Pick<Cutout, 'x' | 'y' | 'width' | 'depth'> {
+  const width = next.width ?? cutout.width;
+  const depth = next.depth ?? cutout.depth;
+  return {
+    width,
+    depth,
+    x: cutout.x + (cutout.width - width) / 2,
+    y: cutout.y + (cutout.depth - depth) / 2,
+  };
+}
+
+/**
  * Bake an array master into independent cutouts. The master keeps its id (array
  * stripped, still at instance-0 position); the other instances become new
  * cutouts with fresh ids. Returns the patch for the master plus the cutouts to

--- a/src/features/whats-new/entries.ts
+++ b/src/features/whats-new/entries.ts
@@ -14,6 +14,15 @@ import type { WhatsNewEntry } from './types';
  */
 export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
   {
+    id: 'center-anchored-resize',
+    date: '2026-08-24',
+    kind: 'improved',
+    title: { en: 'Typing a new cutout size keeps it where it was' },
+    body: {
+      en: 'Changing a width, height or diameter used to grow the shape from its corner, so the hole drifted and had to be repositioned. It now expands equally in every direction around its own center, matching the diameter and across-flats controls.',
+    },
+  },
+  {
     id: 'solid-bin-wall-text',
     date: '2026-08-24',
     kind: 'new',

--- a/src/features/whats-new/latest.ts
+++ b/src/features/whats-new/latest.ts
@@ -6,4 +6,4 @@
  * `latest.test.ts` asserts this matches `WHATS_NEW_ENTRIES[0]`, so the
  * duplication cannot drift past CI or the pre-commit check.
  */
-export const LATEST_ENTRY_ID = 'solid-bin-wall-text';
+export const LATEST_ENTRY_ID = 'center-anchored-resize';


### PR DESCRIPTION
Addresses the **first half** of #3835 — center-anchored resizing. The design configurations / variants half is deliberately untouched and the issue stays open for it.

## Why

Typing a width, height or diameter held the left/bottom edge fixed, so the shape grew sideways and its centre drifted. The router-bit case from the issue: changing a hole from a 1/4" shank to a 1/2" one meant repositioning it afterwards, even though only the size was meant to change.

This is also an internal inconsistency, which is the strongest argument for the change. Every other size control in the editor **already** centre-anchors — polygon across-flats, circle diameter and the knife-slot presets all route through `resizeKeepingCenter`. The W/H fields were the odd ones out, in both the workspace inspector and the sidebar panel.

## Why a new helper rather than `resizeKeepingCenter`

That helper clamps: it truncates the size to the board and slides the origin back on. W/H must not do either — they hold a *measurement*, and truncating one silently shipped wrong-sized pockets (#3061, the reason `softMax` exists on those fields).

`resizeAroundCenter` keeps the typed size and lets the result hang off the board, where the clipping warning takes over — and that warning now offers to centre the stray, so the two changes compose.

Handle drags stay edge-anchored: that edge is what the cursor is holding.

Rotation and repeats need no special case. `x`/`y` are the unrotated box origin and rotation is about the box centre, so holding that centre holds the rotated shape; array instances are offsets from the master centre, so they follow too.

## Verification

Unit tests on the helper (grow, shrink, single-axis, the unclamped off-board case, the no-op patch) and on both surfaces that expose the fields. Full suite green (25,142 tests).

Walked the issue's workflow in the running app: a row of three 6.35mm holes, middle one changed to 12.7mm through the real inspector field. Centre held exactly — 53.175 before, 53.175 after — and the enlarged hole stays aligned with its neighbours instead of drifting off the row.

Part of #3835

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

