### PR TITLE
perf(ci): move the twelve costliest generator files off the PR path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,10 @@ jobs:
           if [ "$GIT_REF" = "refs/heads/main" ]; then
             # Projects are named explicitly rather than using the default "all":
             # `integration` needs a Redis service and runs as its own job.
+            # `generators-heavy` runs nowhere else, so dropping it here retires
+            # those files silently. Guarded by src/test/ciProjectCoverage.test.ts.
             echo "Running full suite with coverage (main branch)"
-            pnpm vitest run --coverage --project=unit --project=dom --project=generators
+            pnpm vitest run --coverage --project=unit --project=dom --project=generators --project=generators-heavy
           elif [ "$GROUP" = "generators" ]; then
             echo "Running generators project (shard $SHARD)"
             pnpm vitest run --project=generators --shard="$SHARD"

--- a/src/test/ciProjectCoverage.test.ts
+++ b/src/test/ciProjectCoverage.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const ROOT = join(__dirname, '../..');
+
+/** A project missing from main's command runs nowhere, and nothing else fails. */
+describe('CI runs every vitest project', () => {
+  const config = readFileSync(join(ROOT, 'vitest.config.ts'), 'utf8');
+  const workflow = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8');
+
+  const declaredProjects = [...config.matchAll(/^\s+name: '([a-z-]+)',$/gm)].map((m) => m[1]);
+  const mainCommand = workflow.split('\n').find((l) => l.includes('vitest run --coverage')) ?? '';
+
+  it('declares the projects this guard expects', () => {
+    expect(declaredProjects).toEqual(
+      expect.arrayContaining(['unit', 'dom', 'generators', 'generators-heavy', 'integration'])
+    );
+  });
+
+  // `integration` needs a Redis service and runs as its own job.
+  it.each(declaredProjects.filter((p) => p !== 'integration'))(
+    'main runs the %s project',
+    (project) => {
+      expect(mainCommand).toContain(`--project=${project}`);
+    }
+  );
+});

--- a/src/test/ciProjectCoverage.test.ts
+++ b/src/test/ciProjectCoverage.test.ts
@@ -9,8 +9,12 @@ describe('CI runs every vitest project', () => {
   const config = readFileSync(join(ROOT, 'vitest.config.ts'), 'utf8');
   const workflow = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8');
 
-  const declaredProjects = [...config.matchAll(/^\s+name: '([a-z-]+)',$/gm)].map((m) => m[1]);
+  const declaredProjects = [...config.matchAll(/^\s+name: '([^']+)',$/gm)].map((m) => m[1]);
   const mainCommand = workflow.split('\n').find((l) => l.includes('vitest run --coverage')) ?? '';
+  // Parsed into exact flags rather than substring-matched: `--project=generators`
+  // is a prefix of `--project=generators-heavy`, so `toContain` would call the
+  // regular suite present when only the heavy one is.
+  const runProjects = new Set([...mainCommand.matchAll(/--project=(\S+)/g)].map((m) => m[1]));
 
   it('declares the projects this guard expects', () => {
     expect(declaredProjects).toEqual(
@@ -22,7 +26,7 @@ describe('CI runs every vitest project', () => {
   it.each(declaredProjects.filter((p) => p !== 'integration'))(
     'main runs the %s project',
     (project) => {
-      expect(mainCommand).toContain(`--project=${project}`);
+      expect(runProjects).toContain(project);
     }
   );
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,26 @@ const domIncludes = [
 // still executes all three projects.
 const generatorIncludes = ['src/features/generation/worker/generators/**/*.test.ts'];
 
+// The costliest generator files. PR shards skip them; main runs them, so the
+// release gate is unchanged and only PR-time feedback moves.
+const heavyGeneratorIncludes = [
+  'src/features/generation/worker/generators/binGenerator.export.kumikoPatterns.test.ts',
+  'src/features/generation/worker/generators/binGenerator.scenario.kumikoPatterns.test.ts',
+  'src/features/generation/worker/generators/binGenerator.export.dividerPatterns.test.ts',
+  'src/features/generation/worker/generators/binGenerator.scenario.dividerPatterns.test.ts',
+  'src/features/generation/worker/generators/binGenerator.export.kumikoWrapping.test.ts',
+  'src/features/generation/worker/generators/binGenerator.export.permutationMatrix.test.ts',
+  'src/features/generation/worker/generators/binGenerator.scenario.split-range.test.ts',
+  'src/features/generation/worker/generators/baseplateGenerator.scenario.outline.test.ts',
+  'src/features/generation/worker/generators/hingeSwing.scenario.test.ts',
+  'src/features/generation/worker/generators/slideLidSeating.scenario.test.ts',
+  'src/features/generation/worker/generators/fitTestSlice.scenario.test.ts',
+  'src/features/generation/worker/generators/labelPlateBuilder.test.ts',
+];
+
+const GENERATOR_TEST_TIMEOUT_MS = 120_000;
+const GENERATOR_HOOK_TIMEOUT_MS = 120_000;
+
 // Tests that need a real Redis rather than a hand-rolled ioredis mock — a Lua
 // script's behaviour cannot be asserted against a mock. Isolated into their own
 // project so the default `unit` run stays dependency-free; CI supplies
@@ -142,7 +162,7 @@ export default defineConfig({
           environment: 'node',
           setupFiles: ['./src/test/setup.ts'],
           include: generatorIncludes,
-          exclude: sharedExclude,
+          exclude: [...sharedExclude, ...heavyGeneratorIncludes],
           // The root 30s is calibrated for pure-JS tests that finish in
           // milliseconds. Everything here drives real OCCT booleans, and 1423
           // of the project's 1748 `it`s inherit that figure rather than
@@ -161,14 +181,26 @@ export default defineConfig({
           // `__kernel-tests__` only record measurements, and `sharedExclude` keeps
           // that directory out of this project regardless. A wedged kernel stays
           // bounded by the job's `timeout-minutes`.
-          testTimeout: 120_000,
+          testTimeout: GENERATOR_TEST_TIMEOUT_MS,
           // Separate knob with its own, tighter default (10s), and every file
           // here boots the WASM kernel via `initTestKernel()` in `beforeAll`.
           // 175 of 199 hooks were given an explicit raise by hand, which is why
           // `}, 30000)` on a hook is load-bearing rather than a restatement of
           // the default the way the `it`-level ones are. This covers the 24 that
           // were never given one.
-          hookTimeout: 120_000,
+          hookTimeout: GENERATOR_HOOK_TIMEOUT_MS,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'generators-heavy',
+          environment: 'node',
+          setupFiles: ['./src/test/setup.ts'],
+          include: heavyGeneratorIncludes,
+          exclude: sharedExclude,
+          testTimeout: GENERATOR_TEST_TIMEOUT_MS,
+          hookTimeout: GENERATOR_HOOK_TIMEOUT_MS,
         },
       },
       {


### PR DESCRIPTION
## Problem

Generators is the binding constraint on PR wall time at 319s. It cannot be sharded out of: the self-hosted pool is two runner processes on **one** Mac mini with 10 performance cores, and `ci.yml` already documents that a third runner reopens #3537 and that 4x3 was measured *worse* (slowest shard 250s → 355s). Shard wall time there is CPU over runners, so cutting CPU is the only lever.

Measured on this PR's own CI run: shard 1/2 was 230.65s wall against 2205s of test CPU, shard 2/2 219.59s against 2099s.

## Change

Twelve files move into a new `generators-heavy` project, ~1217s of the project's ~4305s:

| File | Self-hosted |
| --- | --- |
| `export.kumikoPatterns` | 168.8s |
| `hingeSwing.scenario` | 118.5s |
| `export.dividerPatterns` | 115.6s |
| `scenario.kumikoPatterns` | 106.3s |
| `scenario.split-range` | 104.2s |
| `labelPlateBuilder` | 97.8s |
| `scenario.dividerPatterns` | 91.8s |
| `baseplateGenerator.scenario.outline` | 90.7s |
| `fitTestSlice.scenario` | 88.6s |
| `export.permutationMatrix` | 79.4s |
| `export.kumikoWrapping` | 78.1s |
| `slideLidSeating.scenario` | 77.4s |

**Main still runs them on every push**, so the release gate is unchanged. What moves is PR-time feedback: a break in these paths now surfaces on the post-merge main run rather than on the PR.

Expected generators job: 319s → ~200s.

## Shrinking was tried first and rejected

Before moving anything I tested whether the probe geometry could just be smaller. It cannot:

- `kumikoPatterns` at 1×1×3: **all 5 fail** — `wall pattern did not reduce enclosed volume: expected 14743.61 to be less than 14728.87`. The lattice does not tile a wall that short, so the patterned bin comes out *larger* than its solid twin.
- At 1×1×4: passes, 105.6s vs 185.9s. But that is one unit above the cliff, and a probe sitting just above the threshold where the feature stops manifesting is a fragile test. Not worth 80s.

So 1×1×6 is load-bearing, and this cost is inherent rather than incidental.

## Guard

The failure mode is silence: `generators-heavy` runs nowhere but main's command, so deleting that flag would retire twelve files without failing anything. `src/test/ciProjectCoverage.test.ts` asserts every declared project appears in main's command. Verified by deliberately removing the flag and confirming the test fails, not just that it passes as written.

## Testing

- `vitest list` confirms the partition is exact: 315 in `generators`, 12 in `generators-heavy`, zero overlap
- One heavy file run through the new project: 10 tests pass, 48.25s
- Guard verified in both directions

## Note

After this, **core shards become the bottleneck at 247-257s** (their cost is ~79% per-file jsdom overhead, not test logic). That is the next change.

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

