### PR TITLE
fix(lid): weld a hinged bin's knuckles to the lip so they survive export

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/hingeSwing.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/hingeSwing.ts
@@ -69,6 +69,64 @@ export function swingAxis(
 }
 
 /**
+ * Bin material (mm³) bridging one knuckle to the lip, the barrel itself excluded.
+ *
+ * The question no other probe here can answer. A knuckle that welded and a
+ * knuckle hanging half a millimetre over the rim contain the SAME material,
+ * bound the same box and displace the same volume; they differ only in whether
+ * anything joins the two. This measures that joint and nothing else: a box over
+ * one BIN band, from the axis out to the barrel's own outboard limit and from
+ * inside the lip up to the axis, with the barrel cut back out of it.
+ *
+ * Read as a DELTA against the same bin with a friction lid, which cancels the
+ * lip the zone unavoidably contains. Zero is six cylinders waiting to fall off
+ * the plate — which is what this repo shipped, and what the export then deleted
+ * outright, a stray shell being exactly what `keepOuterShell` exists to discard.
+ *
+ * Deliberately one BIN band and not the whole run: a LID band has no bin
+ * knuckle over it, and measuring there would report the lip alone however badly
+ * the joint was built.
+ */
+export async function knuckleRootMm3(binSolid: Shape3D, params: BinParams): Promise<number> {
+  const { box, cut, cylinder, rotate, unwrap } = await import('brepjs');
+  const { geometry } = planHingeLid(params);
+  if (!geometry) throw new Error('expected hinge geometry');
+  const band = geometry.runs[0].knuckles.find((k) => k.owner === 'bin');
+  if (!band) throw new Error('expected a bin-owned knuckle');
+
+  const r = geometry.barrelRadiusMm;
+  const lipTop = binLipTopZ(params);
+  const zLo = lipTop - geometry.rootDepthBelowLipTopMm;
+  const zHi = lipTop + geometry.axisAboveLipTopMm;
+  const len = band.hi - band.lo;
+  // Built canonically — band along X, wall at +Y — and rotated onto the chosen
+  // wall, which is the builder's own idiom and the reason it has no sign to get
+  // backwards. Naming the world cross coordinate instead would mean restating
+  // which way the band runs on each of the four walls: the four-quadrant trap
+  // CLAUDE.md gotcha #12 documents.
+  const zone = box(len, r, zHi - zLo, {
+    at: [(band.lo + band.hi) / 2, geometry.axisCrossMm + r / 2, (zLo + zHi) / 2],
+  });
+  const barrel = cylinder(r, len, {
+    at: [band.lo, geometry.axisCrossMm, zHi],
+    axis: [1, 0, 0],
+  });
+  const canonical = unwrap(cut(zone, barrel));
+  zone.delete();
+  barrel.delete();
+  const probe =
+    geometry.rotationDeg === 0
+      ? canonical
+      : rotate(canonical, geometry.rotationDeg, { axis: [0, 0, 1] });
+  if (probe !== canonical) canonical.delete();
+  try {
+    return await sharedVolume(binSolid, probe);
+  } finally {
+    probe.delete();
+  }
+}
+
+/**
  * Pose the lid solid: seat it, then open it by `deg` about the axis.
  *
  * Done as translate-to-origin, rotate, translate-back rather than with a

--- a/src/features/generation/worker/generators/__kernel-tests__/hingeSwing.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/hingeSwing.ts
@@ -79,9 +79,9 @@ export function swingAxis(
  * inside the lip up to the axis, with the barrel cut back out of it.
  *
  * Read as a DELTA against the same bin with a friction lid, which cancels the
- * lip the zone unavoidably contains. Zero is six cylinders waiting to fall off
- * the plate — which is what this repo shipped, and what the export then deleted
- * outright, a stray shell being exactly what `keepOuterShell` exists to discard.
+ * lip the zone unavoidably contains. Zero means knuckles that fall off the
+ * plate, and that the export deletes outright — a stray shell being exactly
+ * what `keepOuterShell` exists to discard.
  *
  * Deliberately one BIN band and not the whole run: a LID band has no bin
  * knuckle over it, and measuring there would report the lip alone however badly

--- a/src/features/generation/worker/generators/hingeBarrel.ts
+++ b/src/features/generation/worker/generators/hingeBarrel.ts
@@ -146,22 +146,20 @@ function knuckleSolid(
 }
 
 /**
- * The knuckle's root: the material that actually holds it on the bin.
+ * The knuckle's root: the material that holds it on the bin.
  *
- * A barrel inset from the outer face by its own radius plus a relief, and
- * raised to the lid plate's underside, misses the lip completely — the plan's
- * {@link HingeGeometry.rootDepthBelowLipTopMm} says why. The knuckles fused on
- * without it are cylinders hanging in air: the bin stays watertight, every mesh
- * statistic is plausible, and the export's outer-shell pass then drops them as
- * stray shells, which is how a hinged bin came to export as a plain one.
+ * Load-bearing, not a fillet. The barrel touches the bin nowhere at all — see
+ * {@link HingeGeometry.rootDepthBelowLipTopMm} — so a knuckle fused on without
+ * this is a free-floating cylinder, and `keepOuterShell` deletes it from every
+ * export as a stray shell.
  *
- * Bounded ABOVE by the trim plane where it comes to rest — the one plane the
- * lid never sweeps past — so no shape below it can foul the swing, and the stop
- * still lands at {@link HingeGeometry.stopAngleDeg} because the root's top face
- * IS that plane rather than a second opinion about it. Outboard it stops at the
- * barrel's own limit, so the bin's footprint still does not grow by a micron.
- * Inboard it stops at the axis, which is the only bound that needs no opinion
- * about the lip's profile.
+ * Each bound is a constraint rather than a taste. ABOVE, the trim plane where
+ * it comes to rest: the one plane the lid never sweeps past, so no shape below
+ * it can foul the swing, and the stop still lands at
+ * {@link HingeGeometry.stopAngleDeg} because the root's top face IS that plane
+ * rather than a second opinion about it. OUTBOARD, the barrel's own limit, so
+ * the footprint does not grow. INBOARD, the axis — the only bound that needs no
+ * opinion about the lip's profile.
  */
 function knuckleRootSolid(
   scope: DisposalScope,

--- a/src/features/generation/worker/generators/hingeBarrel.ts
+++ b/src/features/generation/worker/generators/hingeBarrel.ts
@@ -145,6 +145,49 @@ function knuckleSolid(
   return scope.register(unwrap(fuse(body, collar)));
 }
 
+/**
+ * The knuckle's root: the material that actually holds it on the bin.
+ *
+ * A barrel inset from the outer face by its own radius plus a relief, and
+ * raised to the lid plate's underside, misses the lip completely — the plan's
+ * {@link HingeGeometry.rootDepthBelowLipTopMm} says why. The knuckles fused on
+ * without it are cylinders hanging in air: the bin stays watertight, every mesh
+ * statistic is plausible, and the export's outer-shell pass then drops them as
+ * stray shells, which is how a hinged bin came to export as a plain one.
+ *
+ * Bounded ABOVE by the trim plane where it comes to rest — the one plane the
+ * lid never sweeps past — so no shape below it can foul the swing, and the stop
+ * still lands at {@link HingeGeometry.stopAngleDeg} because the root's top face
+ * IS that plane rather than a second opinion about it. Outboard it stops at the
+ * barrel's own limit, so the bin's footprint still does not grow by a micron.
+ * Inboard it stops at the axis, which is the only bound that needs no opinion
+ * about the lip's profile.
+ */
+function knuckleRootSolid(
+  scope: DisposalScope,
+  g: HingeGeometry,
+  frame: HingeFrame,
+  lo: number,
+  hi: number
+): Shape3D {
+  const cy = axisCross(g, frame);
+  const cz = frame.axisZ;
+  const outerY = cy + g.barrelRadiusMm;
+  const footZ = cz - g.axisAboveLipTopMm - g.rootDepthBelowLipTopMm;
+  const section = draw([cy, footZ])
+    .lineTo([cy, cz])
+    .lineTo([outerY, cz])
+    .lineTo([outerY, footZ])
+    .close();
+  const prism = scope.register(sketch(section, 'YZ').extrude(hi - lo));
+  const block = scope.register(translate(prism, [lo, 0, 0]));
+  // `trimTiltDeg - stopAngleDeg + 180` is the trim plane's normal after the
+  // full swing: the plan states the tilt at the CLOSED position, and the stop
+  // angle is how far it turns before the lid meets the bin.
+  const swept = halfSpaceThroughAxis(scope, g, frame, g.trimTiltDeg - g.stopAngleDeg + 180, lo, hi);
+  return scope.register(unwrap(cutAll(block as ValidSolid, [swept] as ValidSolid[])));
+}
+
 /** Bands one part owns within a run. */
 function bandsFor(run: HingeRun, owner: 'bin' | 'lid'): ReadonlyArray<readonly [number, number]> {
   return run.knuckles.filter((k) => k.owner === owner).map((k) => [k.lo, k.hi] as const);
@@ -353,7 +396,9 @@ export function buildBinHingeParts(g: HingeGeometry, frame: HingeFrame): BinHing
       for (const cutter of slotCutters(scope, g, frame, run, 'lid')) put(cutter, notches);
 
       for (const [lo, hi] of bandsFor(run, 'bin')) {
-        put(knuckleSolid(scope, g, frame, lo, hi), additions);
+        const knuckle = knuckleSolid(scope, g, frame, lo, hi);
+        const root = knuckleRootSolid(scope, g, frame, lo, hi);
+        put(scope.register(unwrap(fuse(knuckle as ValidSolid, root as ValidSolid))), additions);
       }
       for (const bore of boresFor(scope, g, frame, run)) put(bore, bores);
     }

--- a/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
+++ b/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
@@ -25,6 +25,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
 import {
   firstContactAngle,
+  knuckleRootMm3,
   pinObstructionMm3,
   seatedOverlapMm3,
   solidVolumeMm3,
@@ -285,6 +286,50 @@ describe('hinged lid', () => {
       const grew = boundingBox(hinged.bin.vertices).maxZ - boundingBox(plain.bin.vertices).maxZ;
       expect(grew).toBeGreaterThan(0);
       expect(grew).toBeLessThan(4);
+    }
+  }, 600_000);
+
+  it('welds the knuckles onto the bin, and exports what it previewed', async () => {
+    // The defect this pins shipped. The barrel is inset from the outer face by
+    // its own radius plus a relief and raised to the lid plate's underside; the
+    // lip's top chamfer recedes inboard as it rises. Those two facts put the
+    // nearest lip material `(axisInset + axisAboveLipTop)/√2` from the axis —
+    // further than the radius — so knuckles fused on bare touch NOTHING, and
+    // the measured bridge was 0.00mm³ on all four walls. Six free-floating
+    // cylinders, watertight and plainly visible in the preview.
+    //
+    // Two claims, because either alone passes the other's bug. The root volume
+    // asks whether the joint is ATTACHED, which no bounding box or triangle
+    // count can see — a floating knuckle and a welded one bound the same box.
+    // The export height asks whether it SURVIVES: the pass that makes a bin
+    // watertight discards stray shells, so a hinge that failed to weld left the
+    // STL silently and the file a user opened was a plain bin.
+    for (const side of ['back', 'front', 'left', 'right'] as const) {
+      const params = hingeParams({}, { side, catchMode: 'none' });
+      const plain = control(params);
+
+      // Same zone against both solids — the hinge plan defines it, and the
+      // control has no plan of its own to ask.
+      const rootMm3 = async (p: BinParams): Promise<number> => {
+        const { bin, lid } = await buildSolids(p);
+        try {
+          return await knuckleRootMm3(bin, params);
+        } finally {
+          lid.delete();
+        }
+      };
+      const bridge = (await rootMm3(params)) - (await rootMm3(plain));
+      expect({ side, welded: bridge > 10 }).toEqual({ side, welded: true });
+
+      // Measured on the EXPORT mesh against the export of the same control. The
+      // sibling footprint test pins this rise in the preview, and the preview is
+      // exactly where a missing hinge still looked right. Not the two meshes
+      // against each other: they tessellate at different tolerances, so a
+      // barrel's apex lands microns apart between them.
+      const top = (p: BinParams): number =>
+        boundingBox(getGenerateBin()(p, undefined, true).vertices).maxZ;
+      const grew = top(params) - top(plain);
+      expect({ side, grew: grew > 3 && grew < 4 }).toEqual({ side, grew: true });
     }
   }, 600_000);
 

--- a/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
+++ b/src/features/generation/worker/generators/hingeSwing.scenario.test.ts
@@ -290,20 +290,18 @@ describe('hinged lid', () => {
   }, 600_000);
 
   it('welds the knuckles onto the bin, and exports what it previewed', async () => {
-    // The defect this pins shipped. The barrel is inset from the outer face by
-    // its own radius plus a relief and raised to the lid plate's underside; the
-    // lip's top chamfer recedes inboard as it rises. Those two facts put the
-    // nearest lip material `(axisInset + axisAboveLipTop)/√2` from the axis —
-    // further than the radius — so knuckles fused on bare touch NOTHING, and
-    // the measured bridge was 0.00mm³ on all four walls. Six free-floating
-    // cylinders, watertight and plainly visible in the preview.
+    // Two claims, because either alone passes the other's bug.
     //
-    // Two claims, because either alone passes the other's bug. The root volume
-    // asks whether the joint is ATTACHED, which no bounding box or triangle
-    // count can see — a floating knuckle and a welded one bound the same box.
-    // The export height asks whether it SURVIVES: the pass that makes a bin
-    // watertight discards stray shells, so a hinge that failed to weld left the
-    // STL silently and the file a user opened was a plain bin.
+    // The root volume asks whether the joint is ATTACHED, which nothing else
+    // here can see: a knuckle welded to the lip and one hanging clear of it
+    // bound the same box, carry the same triangles and displace the same
+    // volume. The barrel reaches no bin material on its own — the plan's
+    // `rootDepthBelowLipTopMm` has the arithmetic — so this is not a margin
+    // being checked, it is the whole joint.
+    //
+    // The export height asks whether it SURVIVES. The pass that makes a bin
+    // watertight discards stray shells, so a hinge that fails to weld is
+    // deleted from the STL while the preview keeps showing it.
     for (const side of ['back', 'front', 'left', 'right'] as const) {
       const params = hingeParams({}, { side, catchMode: 'none' });
       const plain = control(params);

--- a/src/features/whats-new/entries.ts
+++ b/src/features/whats-new/entries.ts
@@ -14,6 +14,15 @@ import type { WhatsNewEntry } from './types';
  */
 export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
   {
+    id: 'hinged-bin-keeps-its-hinge',
+    date: '2026-08-24',
+    kind: 'fixed',
+    title: { en: 'Exported hinged bins keep their hinge' },
+    body: {
+      en: 'A hinged lid exported correctly, but the bin it hinges onto came out as an ordinary bin with nothing for the pin to pass through. The knuckles were drawn a fraction of a millimetre clear of the rim, so they showed in the preview and were dropped from the file. They are now joined to the lip. Re-export any hinged design you printed before today.',
+    },
+  },
+  {
     id: 'center-anchored-resize',
     date: '2026-08-24',
     kind: 'improved',

--- a/src/features/whats-new/latest.ts
+++ b/src/features/whats-new/latest.ts
@@ -6,4 +6,4 @@
  * `latest.test.ts` asserts this matches `WHATS_NEW_ENTRIES[0]`, so the
  * duplication cannot drift past CI or the pre-commit check.
  */
-export const LATEST_ENTRY_ID = 'center-anchored-resize';
+export const LATEST_ENTRY_ID = 'hinged-bin-keeps-its-hinge';

--- a/src/shared/utils/hingeLidPlan.ts
+++ b/src/shared/utils/hingeLidPlan.ts
@@ -48,14 +48,13 @@
  * the hinge exists — the same reason `lid.relieveInterior` runs last
  * (CLAUDE.md gotcha #18).
  *
- * The bin's half is the mirror of it, and needs saying because the barrel alone
- * does not satisfy it:
+ * The bin's half is the mirror of it:
  *
  *     The bin may keep material outboard of the axis ANYWHERE the lid has
  *     already swept past — everything below the trim plane at rest.
  *
- * That is the room the knuckle's root lives in, and it needs the room because
- * the barrel touches the bin nowhere at all. See
+ * That is the room the knuckle's root lives in, and it needs room because the
+ * barrel reaches no bin material at all. See
  * {@link HingeGeometry.rootDepthBelowLipTopMm}.
  *
  * ── THE STOP ─────────────────────────────────────────────────────────────
@@ -235,16 +234,16 @@ export interface HingeGeometry {
   /**
    * Depth (mm) below the lip top that a bin knuckle's root reaches for.
    *
-   * The barrel does not touch the bin. Inset from the outer face by its radius
-   * plus a relief, and raised to the plate's underside, it clears the lip's top
+   * The barrel touches the bin NOWHERE. Inset from the outer face by its radius
+   * plus a relief and raised to the plate's underside, it clears the lip's top
    * chamfer entirely: that chamfer recedes inboard as it rises, so the nearest
    * lip material lies `(axisInsetMm + axisAboveLipTopMm)/√2` from the axis,
-   * which is further than {@link barrelRadiusMm} on every lip this app builds.
-   * A knuckle fused on alone is a cylinder hanging in air.
+   * further than {@link barrelRadiusMm} on every lip this app builds. Anything
+   * that has to be ATTACHED must reach past that, not merely to the rim.
    *
-   * The chamfer stops receding once it meets the lip's vertical section, so
-   * that is how deep a root has to go to stand on full-thickness material and
-   * no deeper.
+   * The chamfer stops receding once it meets the lip's vertical section, which
+   * is how deep a root has to go to stand on full-thickness material and no
+   * deeper.
    */
   readonly rootDepthBelowLipTopMm: number;
   /**

--- a/src/shared/utils/hingeLidPlan.ts
+++ b/src/shared/utils/hingeLidPlan.ts
@@ -48,6 +48,16 @@
  * the hinge exists — the same reason `lid.relieveInterior` runs last
  * (CLAUDE.md gotcha #18).
  *
+ * The bin's half is the mirror of it, and needs saying because the barrel alone
+ * does not satisfy it:
+ *
+ *     The bin may keep material outboard of the axis ANYWHERE the lid has
+ *     already swept past — everything below the trim plane at rest.
+ *
+ * That is the room the knuckle's root lives in, and it needs the room because
+ * the barrel touches the bin nowhere at all. See
+ * {@link HingeGeometry.rootDepthBelowLipTopMm}.
+ *
  * ── THE STOP ─────────────────────────────────────────────────────────────
  *
  * The trim plane sets WHEN the lid stops and a small lobe gives it the reach to
@@ -140,6 +150,7 @@ import type {
   LidHingeCatch,
   LidRailSide,
 } from '@/shared/types/bin';
+import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { isPartialMask } from '@/shared/utils/cellMask';
 import { labelTabInteriorDims, subtractSpan } from '@/shared/utils/labelTabPlan';
 import type { RailSegment, WallSpanBlock } from '@/shared/utils/labelTabPlan';
@@ -221,6 +232,21 @@ export interface HingeGeometry {
    * the lid in its own without either restating the other's origin.
    */
   readonly axisInsetMm: number;
+  /**
+   * Depth (mm) below the lip top that a bin knuckle's root reaches for.
+   *
+   * The barrel does not touch the bin. Inset from the outer face by its radius
+   * plus a relief, and raised to the plate's underside, it clears the lip's top
+   * chamfer entirely: that chamfer recedes inboard as it rises, so the nearest
+   * lip material lies `(axisInsetMm + axisAboveLipTopMm)/√2` from the axis,
+   * which is further than {@link barrelRadiusMm} on every lip this app builds.
+   * A knuckle fused on alone is a cylinder hanging in air.
+   *
+   * The chamfer stops receding once it meets the lip's vertical section, so
+   * that is how deep a root has to go to stand on full-thickness material and
+   * no deeper.
+   */
+  readonly rootDepthBelowLipTopMm: number;
   /**
    * Tilt (deg) of the plane that trims the lid's material outboard of the axis.
    *
@@ -415,6 +441,7 @@ export function planHingeLid(params: BinParams): HingePlan {
       axisCrossMm,
       axisAboveLipTopMm,
       axisInsetMm,
+      rootDepthBelowLipTopMm: GRIDFINITY_SPEC.LIP_BIG_TAPER,
       barrelRadiusMm: LID_HINGE_BARREL_RADIUS_MM,
       trimTiltDeg:
         LID_HINGE_STOP_ANGLE_DEG -


### PR DESCRIPTION
Closes #3861.

## What was wrong

A hinged design exported its lid correctly and its bin as an ordinary bin. The knuckles were not attached to anything.

The barrel sits inset from the outer face by its own radius plus a relief, and raised to the lid plate's underside. The lip's top chamfer recedes inboard as it rises. Those two facts put the nearest lip material at `(axisInset + axisAboveLipTop)/√2` from the axis, which is further than the barrel radius. Measured bridging material between a knuckle and the bin: **0.00mm³, on all four walls**.

Six free-floating cylinders leave the bin watertight, plausibly triangulated, and looking right in the preview, which is why it shipped. Export is where it showed: `keepOuterShell` collapses an export solid to its single outer boundary, and six stray shells are exactly what that pass exists to discard. The hinge left the file silently.

## The fix

Each bin knuckle now carries a root, bounded above by the trim plane **where it comes to rest**. That is the one plane the lid never sweeps past, so no shape below it can foul the swing, and the stop still lands at the same angle because the root's top face IS that plane rather than a second opinion about it. Outboard the root stops at the barrel's own limit, so the footprint does not grow; inboard at the axis, the only bound that needs no opinion about the lip's profile. Depth comes from the plan, as `LIP_BIG_TAPER`: the chamfer stops receding once it meets the lip's vertical section, so that is how deep a root has to go to stand on full-thickness material and no deeper.

## Verification

Two new claims in `hingeSwing.scenario`, each of which passes the other's bug:

- **attached** — bin material bridging the knuckle to the lip, as a delta against the same bin with a friction lid. 0.00mm³ before, 18.1mm³ after, on all four walls. No bounding box or triangle count can see this: a floating knuckle and a welded one bound the same box and displace the same volume.
- **survives** — the export mesh's height above the same control's, so a hinge that fails to weld and gets dropped fails loudly instead of shipping.

Both were confirmed to fail with the fix reverted.

Also verified on the export solid: single shell, zero non-manifold edges, zero boundary edges, and per-feature face tags intact (`LID_HINGE` present), so the 3MF keeps its material assignment.

Full generators suite: 327 files, 3213 tests, no snapshot churn. The 21 existing hinge tests (swing clearance on four walls, pin passage, asymmetric overhang coaxiality, Gridfinity footprint, seating, captivity) all still pass, so the kinematics are untouched.

## Noted, not changed

`keepOuterShell` deletes any shell that is not the largest by bounding-box volume. That is what turned a visible defect into an invisible one. Making it drop only genuinely enclosed voids is not a one-liner: the scoop fuse it was written for produces overlapping boundary fragments that are not nested either, so an enclosure test refuses the case the pass exists to repair. Left alone here rather than bundled into a hinge fix.

https://claude.ai/code/session_01AmPDqowMXEgb9KNm6p6PX3

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

