### PR TITLE
perf(ci): widen core test shards from three to six

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,18 @@ jobs:
         # `test-selfhosted` also carries a release-please guard that is deliberately
         # absent here: this job's own `if` already skips those PRs outright, so
         # repeating it inside the matrix would be unreachable.
+        #
+        # Core shards are wide where the self-hosted generators pool is narrow.
+        # These are independent cloud runners, so a shard costs only its own
+        # setup; the mini's runners all share one host, which is why widening
+        # helps here and hurts there.
         include: >-
           ${{ github.event_name != 'pull_request'
           && fromJSON('[{"name":"full","group":"full","shard":"1/1"}]')
           || (vars.SELF_HOSTED_CI == 'true'
           && github.event.pull_request.head.repo.full_name == github.repository)
-          && fromJSON('[{"name":"core 1/3","group":"core","shard":"1/3"},{"name":"core 2/3","group":"core","shard":"2/3"},{"name":"core 3/3","group":"core","shard":"3/3"}]')
-          || fromJSON('[{"name":"generators 1/6","group":"generators","shard":"1/6"},{"name":"generators 2/6","group":"generators","shard":"2/6"},{"name":"generators 3/6","group":"generators","shard":"3/6"},{"name":"generators 4/6","group":"generators","shard":"4/6"},{"name":"generators 5/6","group":"generators","shard":"5/6"},{"name":"generators 6/6","group":"generators","shard":"6/6"},{"name":"core 1/3","group":"core","shard":"1/3"},{"name":"core 2/3","group":"core","shard":"2/3"},{"name":"core 3/3","group":"core","shard":"3/3"}]') }}
+          && fromJSON('[{"name":"core 1/6","group":"core","shard":"1/6"},{"name":"core 2/6","group":"core","shard":"2/6"},{"name":"core 3/6","group":"core","shard":"3/6"},{"name":"core 4/6","group":"core","shard":"4/6"},{"name":"core 5/6","group":"core","shard":"5/6"},{"name":"core 6/6","group":"core","shard":"6/6"}]')
+          || fromJSON('[{"name":"generators 1/6","group":"generators","shard":"1/6"},{"name":"generators 2/6","group":"generators","shard":"2/6"},{"name":"generators 3/6","group":"generators","shard":"3/6"},{"name":"generators 4/6","group":"generators","shard":"4/6"},{"name":"generators 5/6","group":"generators","shard":"5/6"},{"name":"generators 6/6","group":"generators","shard":"6/6"},{"name":"core 1/6","group":"core","shard":"1/6"},{"name":"core 2/6","group":"core","shard":"2/6"},{"name":"core 3/6","group":"core","shard":"3/6"},{"name":"core 4/6","group":"core","shard":"4/6"},{"name":"core 5/6","group":"core","shard":"5/6"},{"name":"core 6/6","group":"core","shard":"6/6"}]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
## Why this works here but not for generators

Core shards run on `ubuntu-latest`. They are independent cloud machines, so a shard costs only its own setup. That is the opposite of the self-hosted generators pool, where every runner is a process on one Mac mini and `ci.yml` already records that widening made things worse (4x3 took the slowest shard from 250s to 355s).

I had been treating the mini's constraint as if it applied to the whole suite. It does not: it applies only to `test-selfhosted`.

## The cost being divided

A full dom run measured locally:

```
Test Files  920 passed
Duration  287.81s (transform 53.87s, setup 324.57s, import 421.72s,
                   tests 341.53s, environment 1229.89s)
```

`environment 1229.89s` against `tests 341.53s`: core spends roughly 3.6x longer constructing jsdom instances than running assertions, at ~1.34s per file across 920 files. That is fixed per-file cost, which divides cleanly across shards, and dom files average 0.37s so no single file approaches a shard budget.

Expected core job: ~250s → ~140s.

## Alternatives measured and rejected

Both attacked the same 1229s directly, and both cost more than they were worth:

- **`isolate: false`** — 287.81s → 39.27s, a 7.3x speedup, but **516 tests across 98 files failed**. The causes are diverse, and 28 of them are `vi.mock` bleeding between files, which isolation exists to prevent.
- **happy-dom** — 287.81s → 197.96s with `environment` down to 556.44s, and only 14 failures. But those failures concentrate in SVG parsing and color serialization (`expected '#ff0000' to be 'rgb(255, 0, 0)'`, `expected NaN to be greater than 0`, svgParser returning 2 shapes where 1 was expected). Trading DOM fidelity for speed in exactly the areas this product renders is a bad trade.

Sharding gets most of the benefit with no fidelity loss and no test rewrites.

## Note

There is a small follow-up available: 115 of the 296 `.test.ts` files in the dom project reference no DOM API at all and pay ~1.34s of jsdom setup for nothing. Moving them to the node project is safe but only ~154s of ~2371s, so it is cleanup rather than a fix.

https://claude.ai/code/session_01MQidAeF7vzMhiX248ah5XL


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

