### PR TITLE
fix(bin-designer): hold each shape's center when resizing a multi-selection

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.test.tsx
@@ -480,6 +480,54 @@ describe('InspectorContent multi-select editing', () => {
     expect(updates.has('imported')).toBe(false);
   });
 
+  // The same field on a selection of one holds the shape's center (#3864), so a
+  // selection of two has to as well.
+  it('holds each cutout’s own center when batch-resizing', () => {
+    const onUpdateBatch = renderMulti([
+      createCutout({ id: 'small', x: 10, y: 10, width: 20, depth: 20 }),
+      createCutout({ id: 'large', x: 60, y: 40, width: 40, depth: 40 }),
+    ]);
+
+    fireEvent.change(screen.getByTestId('compact-input-W'), { target: { value: '30' } });
+
+    const updates = onUpdateBatch.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    // small: center 20 → 30mm wide starts at 5. large: center 80 → starts at 65.
+    expect(updates.get('small')).toMatchObject({ width: 30, x: 5 });
+    expect(updates.get('large')).toMatchObject({ width: 30, x: 65 });
+    // The untouched axis stays put on both.
+    expect(updates.get('small')?.y).toBe(10);
+    expect(updates.get('large')?.y).toBe(40);
+  });
+
+  it('holds each cutout’s own center when batch-resizing depth', () => {
+    const onUpdateBatch = renderMulti([
+      createCutout({ id: 'a', x: 10, y: 10, width: 20, depth: 20 }),
+      createCutout({ id: 'b', x: 10, y: 40, width: 20, depth: 40 }),
+    ]);
+
+    fireEvent.change(screen.getByTestId('compact-input-H'), { target: { value: '10' } });
+
+    const updates = onUpdateBatch.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    expect(updates.get('a')).toMatchObject({ depth: 10, y: 15 });
+    expect(updates.get('b')).toMatchObject({ depth: 10, y: 55 });
+    expect(updates.get('a')?.x).toBe(10);
+  });
+
+  // Flooring at the minimum must not leave the origin where the typed size put it.
+  it('re-centers on the floored size when a batch W is below the minimum', () => {
+    const onUpdateBatch = renderMulti([
+      createCutout({ id: 'a', x: 10, y: 0, width: 20, depth: 20 }),
+      createCutout({ id: 'b', x: 50, y: 0, width: 20, depth: 20 }),
+    ]);
+
+    fireEvent.change(screen.getByTestId('compact-input-W'), { target: { value: '0.5' } });
+
+    const updates = onUpdateBatch.mock.calls[0][0] as Map<string, Partial<Cutout>>;
+    // Center 20 with a 2mm floor starts at 19, not at the original 10.
+    expect(updates.get('a')).toMatchObject({ width: 2, x: 19 });
+    expect(updates.get('b')).toMatchObject({ width: 2, x: 59 });
+  });
+
   it('clamps batch chamfer to each cutout’s own cut-depth headroom', () => {
     const onUpdateBatch = renderMulti([
       createCutout({ id: 'deep', cutDepth: 10 }),

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
@@ -14,6 +14,7 @@ import type { FitCue } from '../panel/CutoutsSection/cutoutSectionVisibility';
 import type { GrowTarget } from '../panel/CutoutsSection/growBinToFit';
 import { alignSelection, distributeSelection } from '../panel/CutoutsSection/geometryAlign';
 import { expandSelectionToGroups } from '../panel/CutoutsSection/cutoutGroups';
+import { resizeAroundCenter } from '../panel/CutoutsSection/cutoutHelpers';
 import { CutoutArrayControls } from '../panel/CutoutsSection/CutoutArrayControls';
 import { arrayInstanceCount, canGroupArray, groupRepeatBox } from '@/shared/utils/cutoutArray';
 import { useDesignerStore } from '@/features/bin-designer/store';
@@ -265,6 +266,11 @@ export function InspectorContent({
   // past the wall, so each shape gets its own ceiling rather than the control
   // refusing the whole edit. Size is not — a typed W/H is a measurement, and it
   // is kept past the board for the grow-to-fit action to resolve.
+  //
+  // Size is also anchored per shape's OWN center, not the selection's: the field
+  // is the same control the single-cutout inspector renders, so holding a corner
+  // here would make one behaviour apply at a selection of one and its opposite
+  // at two.
   const handleGeometryBatch = (key: 'x' | 'y' | 'width' | 'depth', value: number) => {
     if (!onUpdateBatch || selectedCutouts.length <= 1) return;
     const updates = new Map<string, Partial<Cutout>>();
@@ -273,7 +279,11 @@ export function InspectorContent({
       if (key === 'width' || key === 'depth') {
         // Meshes carry baked geometry — resizing them would desync the asset.
         if (c.shape === 'mesh') continue;
-        updates.set(c.id, { [key]: Math.max(MIN_CUTOUT_SIZE_MM, value) });
+        const size = Math.max(MIN_CUTOUT_SIZE_MM, value);
+        updates.set(
+          c.id,
+          resizeAroundCenter(c, key === 'width' ? { width: size } : { depth: size })
+        );
         continue;
       }
       // An oversize cutout leaves no valid offset on this axis; pin it to 0.


### PR DESCRIPTION
Typing a width with one shape selected held its center; typing the same width with two selected held their corners. The center-anchored resize added in #3864 was wired into the single-cutout inspector only, so the shared W/H field in the multi-select surface still wrote a bare size and left the origin where it was.

`handleGeometryBatch` now routes width and depth through `resizeAroundCenter`, per cutout, so each shape keeps its own center rather than the selection's bounding box holding still.

## Unchanged

- Locked shapes and imported meshes stay out of the batch
- The minimum cutout size still floors the value
- An oversize result is still kept past the board for grow-to-fit to resolve, not truncated

## Worth a look

Flooring at the minimum re-centers on the floored size, not the typed one. Clamping 0.5mm up to 2mm would otherwise move a shape that was only ever asked to shrink.

Pen-tool shapes need no special case: `updateCutoutsBatch` already runs `applyPathTransform`, which scales and translates a path's absolute vertices to match any x/y/w/d patch.

No what's-new entry — #3864's `center-anchored-resize` already states the general behavior, and this makes that claim true rather than adding a second one.

Closes the first half of #3835. The configurations/variants half is tracked separately.

https://claude.ai/code/session_01XPj594dK4xWujfQmgFMGTk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

