### PR TITLE
feat(sync): sync design versions across devices

### DIFF
--- a/api/lib/quota.ts
+++ b/api/lib/quota.ts
@@ -13,6 +13,12 @@ const QUOTA: Record<SyncItemKind, { maxCount: number; maxBytes: number }> = {
   layouts: { maxCount: 100, maxBytes: 10 * 1024 * 1024 },
   designs: { maxCount: 100, maxBytes: 10 * 1024 * 1024 },
   baseplates: { maxCount: 100, maxBytes: 10 * 1024 * 1024 },
+  // Versions are per-design, so this axis counts differently from the others:
+  // 100 items across a whole library would be a handful of designs' history.
+  // The client caps each design at MAX_VERSIONS_PER_DESIGN; this is the
+  // whole-account ceiling. Bodies are compressed params with no thumbnail, so
+  // they are far smaller than a design envelope.
+  designVersions: { maxCount: 500, maxBytes: 25 * 1024 * 1024 },
 };
 
 export type QuotaErrorReason = 'count' | 'bytes';

--- a/api/lib/redisKeys.ts
+++ b/api/lib/redisKeys.ts
@@ -47,7 +47,7 @@
 
 import { createHash } from 'node:crypto';
 
-export type SyncItemKind = 'layouts' | 'designs' | 'baseplates';
+export type SyncItemKind = 'layouts' | 'designs' | 'baseplates' | 'designVersions';
 
 export const COMMUNITY_INDEX_SORTS = ['newest', 'remixes', 'likes', 'prints'] as const;
 export type CommunityIndexSort = (typeof COMMUNITY_INDEX_SORTS)[number];

--- a/api/sync/README.md
+++ b/api/sync/README.md
@@ -6,17 +6,20 @@ Server endpoints for the multi-device sync feature. Stores per-user layouts and 
 
 ## Endpoints
 
-| Endpoint                 | Method | Rate Limit | Purpose                                         |
-| ------------------------ | ------ | ---------- | ----------------------------------------------- |
-| `/api/sync/layouts/[id]` | GET    | 240/min    | Fetch envelope (200 / 404 / 410)                |
-| `/api/sync/layouts/[id]` | PUT    | 60/min     | LWW write; 409 stale-write, 410 stale-resurrect |
-| `/api/sync/layouts/[id]` | DELETE | 60/min     | Tombstone + blob delete                         |
-| `/api/sync/designs/[id]` | GET    | 240/min    | Fetch envelope (200 / 404 / 410)                |
-| `/api/sync/designs/[id]` | PUT    | 60/min     | LWW write; reuses designer-payload validator    |
-| `/api/sync/designs/[id]` | DELETE | 60/min     | Tombstone + blob delete                         |
-| `/api/sync/manifest`     | GET    | 240/min    | Full per-user index + `If-Modified-Since` 304   |
-| `/api/sync/export`       | GET    | 240/min    | ZIP of all live items + manifest.json           |
-| `/api/sync/account`      | DELETE | 60/min     | Cascade-delete sessions + KV + blobs            |
+| Endpoint                        | Method | Rate Limit | Purpose                                          |
+| ------------------------------- | ------ | ---------- | ------------------------------------------------ |
+| `/api/sync/layouts/[id]`        | GET    | 240/min    | Fetch envelope (200 / 404 / 410)                 |
+| `/api/sync/layouts/[id]`        | PUT    | 60/min     | LWW write; 409 stale-write, 410 stale-resurrect  |
+| `/api/sync/layouts/[id]`        | DELETE | 60/min     | Tombstone + blob delete                          |
+| `/api/sync/designs/[id]`        | GET    | 240/min    | Fetch envelope (200 / 404 / 410)                 |
+| `/api/sync/designs/[id]`        | PUT    | 60/min     | LWW write; reuses designer-payload validator     |
+| `/api/sync/designs/[id]`        | DELETE | 60/min     | Tombstone + blob delete                          |
+| `/api/sync/designVersions/[id]` | GET    | 240/min    | Fetch envelope (200 / 404 / 410)                 |
+| `/api/sync/designVersions/[id]` | PUT    | 60/min     | LWW write; reuses the designer-payload validator |
+| `/api/sync/designVersions/[id]` | DELETE | 60/min     | Tombstone + blob delete                          |
+| `/api/sync/manifest`            | GET    | 240/min    | Full per-user index + `If-Modified-Since` 304    |
+| `/api/sync/export`              | GET    | 240/min    | ZIP of all live items + manifest.json            |
+| `/api/sync/account`             | DELETE | 60/min     | Cascade-delete sessions + KV + blobs             |
 
 Rate limits are keyed by `userId`, not IP — each authenticated user gets their own budget.
 
@@ -35,6 +38,16 @@ Rate limits are keyed by `userId`, not IP — each authenticated user gets their
 // users/{uid}/designs/{id}.json
 {
   design: BinParams,        // sanitized via validateDesignerShare
+  modifiedAt: number,
+  schemaVersion: 1,
+}
+
+// users/{uid}/designVersions/{id}.json
+{
+  designVersion: {
+    designId, name, createdAt, origin, pinned?,
+    content,                // { name, params } or { name, kind, envelope, structure }
+  },
   modifiedAt: number,
   schemaVersion: 1,
 }
@@ -62,6 +75,20 @@ use `CONSTRAINTS.MAX_PAYLOAD_BYTES` (100 KB, measured on
 `{ name, type, version, params }`). The pre-validation count is intentionally a
 subset of the request body, not the full HTTP payload — its only job is to gate
 the validator's workload.
+
+### Design versions
+
+`content` travels **uncompressed**, unlike the LZ string the client keeps in
+IndexedDB: the server runs `validateDesignerShare` over it, which it cannot do
+with an opaque blob. The adapter converts at that boundary.
+
+No `thumbnail` field: a PNG data URL would consume most of `MAX_PAYLOAD_BYTES`,
+and it regenerates locally from the params.
+
+Quota counts differently here, since 100 items would be a few designs' history:
+500 items / 25 MB, with the client capping each design at
+`MAX_VERSIONS_PER_DESIGN`. A `413` surfaces as the usual quota toast; the
+version is saved locally either way.
 
 ## LWW + tombstone semantics (PUT)
 

--- a/api/sync/account.ts
+++ b/api/sync/account.ts
@@ -51,7 +51,7 @@ import { unlinkSupporterAccount } from '../lib/supporterLink.js';
  *
  *   1. Sessions   : DEL session:{token} for every token in the user's set
  *                   (so other tabs/devices flip to anonymous on next sync)
- *   2. Blobs      : del() each layouts/{id}.json, designs/{id}.json, baseplates/{id}.json
+ *   2. Blobs      : del() each layouts/{id}.json, designs/{id}.json, baseplates/{id}.json, designVersions/{id}.json
  *   3. Community  : delete each published design (record/thumbnail/mesh blobs,
  *                   card hash, per-design sets, membership in the parent's
  *                   children set, every liker's reverse liked set, sort-index
@@ -110,11 +110,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
     const layoutIds = await redis.hkeys(userIndexKey(userId, 'layouts'));
     const designIds = await redis.hkeys(userIndexKey(userId, 'designs'));
     const baseplateIds = await redis.hkeys(userIndexKey(userId, 'baseplates'));
+    const designVersionIds = await redis.hkeys(userIndexKey(userId, 'designVersions'));
 
     await Promise.all([
       ...layoutIds.map((id) => deleteBlobSafe(`users/${userId}/layouts/${id}.json`, userId)),
       ...designIds.map((id) => deleteBlobSafe(`users/${userId}/designs/${id}.json`, userId)),
       ...baseplateIds.map((id) => deleteBlobSafe(`users/${userId}/baseplates/${id}.json`, userId)),
+      ...designVersionIds.map((id) =>
+        deleteBlobSafe(`users/${userId}/designVersions/${id}.json`, userId)
+      ),
     ]);
 
     // 3. Community cascade. The record blob is read first because it is the
@@ -251,6 +255,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       userIndexKey(userId, 'layouts'),
       userIndexKey(userId, 'designs'),
       userIndexKey(userId, 'baseplates'),
+      userIndexKey(userId, 'designVersions'),
       userIndexUpdatedAtKey(userId),
       userProfileKey(userId),
       userSessionsKey(userId),

--- a/api/sync/designVersions/[id].test.ts
+++ b/api/sync/designVersions/[id].test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for /api/sync/designVersions/[id]. The LWW + tombstone state machine is
+ * shared with every other sync resource, so the focus here is the parts unique
+ * to a version: the required designId/createdAt, the uncompressed content that
+ * the designer validator has to accept, and the absence of a thumbnail.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+let redisStore: Map<string, string>;
+let redisHashes: Map<string, Map<string, string>>;
+const blobStore = new Map<string, unknown>();
+
+const mockRedis = {
+  get: vi.fn(async (k: string) => redisStore.get(k) ?? null),
+  set: vi.fn(async (k: string, v: string) => {
+    redisStore.set(k, v);
+    return 'OK';
+  }),
+  hget: vi.fn(async (k: string, f: string) => redisHashes.get(k)?.get(f) ?? null),
+  hset: vi.fn(async (k: string, f: string, v: string) => {
+    const h = redisHashes.get(k) ?? new Map<string, string>();
+    h.set(f, v);
+    redisHashes.set(k, h);
+    return 1;
+  }),
+  hgetall: vi.fn(async (k: string) => {
+    const h = redisHashes.get(k);
+    return h ? Object.fromEntries(h) : {};
+  }),
+  pipeline: vi.fn(() => makePipeline()),
+};
+
+function makePipeline() {
+  const queue: Array<() => [Error | null, unknown]> = [];
+  const pipe = {
+    set: (k: string, v: string) => {
+      queue.push(() => {
+        redisStore.set(k, v);
+        return [null, 'OK'];
+      });
+      return pipe;
+    },
+    hset: (k: string, f: string, v: string) => {
+      queue.push(() => {
+        const h = redisHashes.get(k) ?? new Map<string, string>();
+        h.set(f, v);
+        redisHashes.set(k, h);
+        return [null, 1];
+      });
+      return pipe;
+    },
+    exec: vi.fn(async () => queue.map((fn) => fn())),
+  };
+  return pipe;
+}
+
+vi.mock('../../lib/rateLimit', () => ({
+  getRedis: () => mockRedis,
+  getClientIP: () => '127.0.0.1',
+  checkRateLimit: vi.fn(async () => ({
+    allowed: true,
+    remaining: 100,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../../lib/session', () => ({
+  requireSession: vi.fn(async () => ({
+    userId: 'user-1',
+    provider: 'google',
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock('../../lib/blobStore', () => ({
+  putJson: vi.fn(async (path: string, value: unknown) => {
+    blobStore.set(path, value);
+    return { url: `https://blob/${path}` };
+  }),
+  getJson: vi.fn(async (path: string) => blobStore.get(path) ?? null),
+  deleteBlob: vi.fn(async (path: string) => {
+    blobStore.delete(path);
+  }),
+  headBlob: vi.fn(async () => null),
+}));
+
+interface MockRes {
+  _status: number;
+  _body: unknown;
+  _ended: boolean;
+  status(code: number): MockRes;
+  json(body: unknown): MockRes;
+  end(): MockRes;
+  setHeader(): MockRes;
+}
+
+function makeRes(): MockRes {
+  return {
+    _status: 0,
+    _body: null,
+    _ended: false,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+    end() {
+      this._ended = true;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+  };
+}
+
+function makeReq(opts: { method?: string; id?: string; body?: unknown }): VercelRequest {
+  return {
+    method: opts.method ?? 'GET',
+    query: { id: opts.id ?? '11111111-2222-3333-4444-555555555555' },
+    body: opts.body,
+    headers: { 'sec-fetch-site': 'same-origin', 'x-requested-with': 'gflt' },
+  } as unknown as VercelRequest;
+}
+
+const VALID_DESIGN = {
+  width: 2,
+  depth: 2,
+  height: 6,
+  style: 'standard',
+  scoop: true,
+  base: {
+    style: 'magnet',
+    magnetDiameter: 6.2,
+    magnetDepth: 2.4,
+    screwDiameter: 3,
+    stackingLip: true,
+  },
+  compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+  label: { enabled: false, support: 'bracket', depth: 12, width: 100, alignment: 'center' },
+  walls: { front: 0, back: 0, left: 0, right: 0 },
+  inserts: [] as Record<string, unknown>[],
+};
+
+const DESIGN_ID = 'design_1700000000000_abc123';
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    designVersion: {
+      designId: DESIGN_ID,
+      name: '0.2 mm, tight',
+      createdAt: '2026-08-01T12:00:00.000Z',
+      origin: 'manual',
+      content: { name: 'Router Bit Holder', params: VALID_DESIGN },
+      ...overrides,
+    },
+    modifiedAt: 1000,
+  };
+}
+
+beforeEach(() => {
+  redisStore = new Map();
+  redisHashes = new Map();
+  blobStore.clear();
+  vi.clearAllMocks();
+});
+
+describe('PUT', () => {
+  it('stores a version with its design id, name and validated content', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(makeReq({ method: 'PUT', body: validBody() }), res as unknown as VercelResponse);
+
+    expect(res._status).toBe(200);
+    const body = res._body as {
+      envelope: {
+        schemaVersion: number;
+        designVersion: {
+          designId: string;
+          name: string;
+          origin: string;
+          content: { params: { width: number } };
+        };
+      };
+    };
+    expect(body.envelope.schemaVersion).toBe(1);
+    expect(body.envelope.designVersion.designId).toBe(DESIGN_ID);
+    expect(body.envelope.designVersion.name).toBe('0.2 mm, tight');
+    expect(body.envelope.designVersion.content.params.width).toBe(2);
+  });
+
+  // A version keyed to nothing would sync forever and appear in no history list.
+  it('rejects a version with no design id', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(
+      makeReq({ method: 'PUT', body: validBody({ designId: undefined }) }),
+      res as unknown as VercelResponse
+    );
+
+    expect(res._status).toBe(400);
+  });
+
+  it('rejects a createdAt that is not a timestamp', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(
+      makeReq({ method: 'PUT', body: validBody({ createdAt: 'whenever' }) }),
+      res as unknown as VercelResponse
+    );
+
+    expect(res._status).toBe(400);
+  });
+
+  it('rejects content that is not an object', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(
+      makeReq({ method: 'PUT', body: validBody({ content: 'compressed-blob' }) }),
+      res as unknown as VercelResponse
+    );
+
+    expect(res._status).toBe(400);
+  });
+
+  // The content travels uncompressed precisely so this validator can run.
+  it('rejects params the designer validator refuses', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(
+      makeReq({
+        method: 'PUT',
+        body: validBody({ content: { name: 'x', params: { width: 'wide' } } }),
+      }),
+      res as unknown as VercelResponse
+    );
+
+    expect(res._status).toBe(400);
+  });
+
+  it('falls back to manual for an origin it does not recognise', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(
+      makeReq({ method: 'PUT', body: validBody({ origin: 'from-the-future' }) }),
+      res as unknown as VercelResponse
+    );
+
+    const body = res._body as { envelope: { designVersion: { origin: string } } };
+    expect(body.envelope.designVersion.origin).toBe('manual');
+  });
+
+  it('keeps a pre-restore origin', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(
+      makeReq({ method: 'PUT', body: validBody({ origin: 'pre-restore' }) }),
+      res as unknown as VercelResponse
+    );
+
+    const body = res._body as { envelope: { designVersion: { origin: string } } };
+    expect(body.envelope.designVersion.origin).toBe('pre-restore');
+  });
+
+  // A base64 PNG would consume most of MAX_PAYLOAD_BYTES; it regenerates locally.
+  it('drops a thumbnail a client tries to send', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(
+      makeReq({
+        method: 'PUT',
+        body: validBody({ thumbnail: 'data:image/png;base64,AAAA' }),
+      }),
+      res as unknown as VercelResponse
+    );
+
+    expect(res._status).toBe(200);
+    expect(JSON.stringify(res._body)).not.toContain('base64');
+  });
+
+  it('rejects an id that is not a version id', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(
+      makeReq({ method: 'PUT', id: 'not a uuid', body: validBody() }),
+      res as unknown as VercelResponse
+    );
+
+    expect(res._status).toBe(400);
+  });
+
+  it('refuses a stale write against a newer stored version', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { ...validBody(), modifiedAt: 5000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { ...validBody(), modifiedAt: 1000 } }),
+      res as unknown as VercelResponse
+    );
+
+    expect(res._status).toBe(409);
+  });
+});
+
+describe('GET and DELETE', () => {
+  it('reads back a stored version', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: validBody() }),
+      makeRes() as unknown as VercelResponse
+    );
+
+    const res = makeRes();
+    await handler(makeReq({ method: 'GET' }), res as unknown as VercelResponse);
+
+    expect(res._status).toBe(200);
+    const body = res._body as { envelope: { designVersion: { name: string } } };
+    expect(body.envelope.designVersion.name).toBe('0.2 mm, tight');
+  });
+
+  it('reports a version it does not hold', async () => {
+    const { default: handler } = await import('./[id]');
+    const res = makeRes();
+
+    await handler(makeReq({ method: 'GET' }), res as unknown as VercelResponse);
+
+    expect(res._status).toBe(404);
+  });
+
+  it('tombstones a deleted version so a stale write cannot resurrect it', async () => {
+    const { default: handler } = await import('./[id]');
+    await handler(
+      makeReq({ method: 'PUT', body: { ...validBody(), modifiedAt: 5000 } }),
+      makeRes() as unknown as VercelResponse
+    );
+    await handler(makeReq({ method: 'DELETE' }), makeRes() as unknown as VercelResponse);
+
+    const res = makeRes();
+    await handler(
+      makeReq({ method: 'PUT', body: { ...validBody(), modifiedAt: 1000 } }),
+      res as unknown as VercelResponse
+    );
+
+    expect(res._status).toBe(410);
+  });
+});

--- a/api/sync/designVersions/[id].ts
+++ b/api/sync/designVersions/[id].ts
@@ -1,0 +1,185 @@
+import { ErrorCode, isValidShareId } from '../../lib/shared.js';
+import { validateDesignerShare } from '../../lib/designerValidation.js';
+import {
+  validateAssemblyEnvelope,
+  validateAssemblyStructure,
+} from '../../lib/assemblyValidation.js';
+import { CONSTRAINTS } from '../../lib/designerValidationConstants.js';
+import { sanitizeString } from '../../lib/validation.js';
+import { createSyncResourceHandler } from '../lib/resourceHandler.js';
+
+export const SCHEMA_VERSION = 1 as const;
+
+/** Mirrors the design-name cap; a version name is shown in the same lists. */
+const MAX_NAME_LENGTH = 100;
+
+/** Mirrors `DesignVersionOrigin` on the client. */
+const ORIGINS = ['manual', 'pre-restore'] as const;
+type Origin = (typeof ORIGINS)[number];
+
+interface DesignVersionEnvelope {
+  designVersion: unknown;
+  modifiedAt: number;
+  schemaVersion: typeof SCHEMA_VERSION;
+}
+
+/**
+ * The wire body carries the version's content **uncompressed**.
+ *
+ * Locally a version is stored LZ-compressed, but shipping that string would
+ * hand the server an opaque blob it cannot check, and every other synced
+ * payload here is validated before it is stored. The client decompresses on
+ * push and re-compresses on apply, so the same `validateDesignerShare` that
+ * guards a design guards a version of one.
+ *
+ * The thumbnail is deliberately absent from this shape: it is a rendered PNG
+ * data URL that would consume most of `MAX_PAYLOAD_BYTES` on its own, and it
+ * regenerates locally from the params.
+ */
+export default createSyncResourceHandler<DesignVersionEnvelope>({
+  kind: 'designVersions',
+  payloadKey: 'designVersion',
+  isValidId: (id) => isValidShareId(id),
+  invalidIdError: 'Invalid design version id',
+  deletedError: 'This design version was deleted on another device',
+  buildPut: (payload, modifiedAt) => {
+    if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'designVersion must be an object',
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+    const body = payload as Record<string, unknown>;
+
+    // A version is meaningless without the design it belongs to: an orphan row
+    // would sync forever and never appear in any history list.
+    if (typeof body.designId !== 'string' || body.designId.length === 0) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'designVersion.designId is required',
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+    const designId = sanitizeString(body.designId, MAX_NAME_LENGTH);
+
+    if (typeof body.createdAt !== 'string' || Number.isNaN(Date.parse(body.createdAt))) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'designVersion.createdAt must be an ISO timestamp',
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+    const createdAt = new Date(body.createdAt).toISOString();
+
+    const origin: Origin = ORIGINS.includes(body.origin as Origin)
+      ? (body.origin as Origin)
+      : 'manual';
+    const pinned = body.pinned === true;
+    const name = sanitizeString(typeof body.name === 'string' ? body.name : '', MAX_NAME_LENGTH);
+
+    const content = body.content;
+    if (typeof content !== 'object' || content === null || Array.isArray(content)) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'designVersion.content must be an object',
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+    const inner = content as Record<string, unknown>;
+    const contentName = sanitizeString(
+      typeof inner.name === 'string' ? inner.name : '',
+      MAX_NAME_LENGTH
+    );
+
+    // Non-bin kinds carry envelope + structure and no params, exactly as the
+    // design endpoint's assembly branch does.
+    if (inner.kind !== undefined && inner.kind !== 'bin') {
+      const preBytes = Buffer.byteLength(JSON.stringify(body), 'utf8');
+      if (preBytes > CONSTRAINTS.MAX_PAYLOAD_BYTES) {
+        return {
+          ok: false,
+          status: 400,
+          error: 'design version exceeds the size limit',
+          code: ErrorCode.VALIDATION_ERROR,
+        };
+      }
+      const envelopeCheck = validateAssemblyEnvelope(inner.envelope);
+      if (!envelopeCheck.valid) {
+        return {
+          ok: false,
+          status: 400,
+          error: envelopeCheck.error.message,
+          code: ErrorCode.VALIDATION_ERROR,
+        };
+      }
+      const structureCheck = validateAssemblyStructure(inner.structure);
+      if (!structureCheck.valid) {
+        return {
+          ok: false,
+          status: 400,
+          error: structureCheck.error.message,
+          code: ErrorCode.VALIDATION_ERROR,
+        };
+      }
+      const stored = {
+        designId,
+        name,
+        createdAt,
+        origin,
+        ...(pinned ? { pinned } : {}),
+        content: {
+          name: contentName,
+          kind: inner.kind,
+          envelope: inner.envelope,
+          structure: inner.structure,
+        },
+      };
+      return {
+        ok: true,
+        envelope: { designVersion: stored, modifiedAt, schemaVersion: SCHEMA_VERSION },
+        sizeBytes: Buffer.byteLength(JSON.stringify(stored), 'utf8'),
+        tiebreakerCandidate: stored,
+      };
+    }
+
+    const validationPayload = {
+      type: 'designer' as const,
+      version: 1 as const,
+      params: inner.params,
+    };
+    const preValidationBytes = Buffer.byteLength(
+      JSON.stringify({ name: contentName, ...validationPayload }),
+      'utf8'
+    );
+    const validation = validateDesignerShare(validationPayload, preValidationBytes);
+    if (!validation.valid) {
+      return {
+        ok: false,
+        status: 400,
+        error: validation.error.message,
+        code: ErrorCode.VALIDATION_ERROR,
+      };
+    }
+
+    const stored = {
+      designId,
+      name,
+      createdAt,
+      origin,
+      ...(pinned ? { pinned } : {}),
+      content: { name: contentName, params: validation.payload.params },
+    };
+    return {
+      ok: true,
+      envelope: { designVersion: stored, modifiedAt, schemaVersion: SCHEMA_VERSION },
+      sizeBytes: Buffer.byteLength(JSON.stringify(stored), 'utf8'),
+      tiebreakerCandidate: stored,
+    };
+  },
+  storedComparable: (stored) => stored.designVersion,
+});

--- a/api/sync/export.ts
+++ b/api/sync/export.ts
@@ -20,7 +20,7 @@ import { communityPublishedKey } from '../lib/redisKeys.js';
  *
  * Stream a ZIP of the user's live data:
  *
- *   manifest.json        : { layouts, designs, baseplates: { [id]: IndexEntry }, community: [id], indexUpdatedAt, exportedAt }
+ *   manifest.json        : { layouts, designs, baseplates, designVersions: { [id]: IndexEntry }, community: [id], indexUpdatedAt, exportedAt }
  *   layouts/{id}.json    : full envelope for each non-tombstoned layout
  *   designs/{id}.json    : full envelope for each non-tombstoned design
  *   baseplates/{id}.json : full envelope for each non-tombstoned baseplate
@@ -50,19 +50,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 
   try {
-    const [layoutsIndex, designsIndex, baseplatesIndex, indexUpdatedAt, publishedIds] =
-      await Promise.all([
-        getIndex(redis, session.userId, 'layouts'),
-        getIndex(redis, session.userId, 'designs'),
-        getIndex(redis, session.userId, 'baseplates'),
-        getIndexUpdatedAt(redis, session.userId),
-        redis.smembers(communityPublishedKey(session.userId)),
-      ]);
+    const [
+      layoutsIndex,
+      designsIndex,
+      baseplatesIndex,
+      designVersionsIndex,
+      indexUpdatedAt,
+      publishedIds,
+    ] = await Promise.all([
+      getIndex(redis, session.userId, 'layouts'),
+      getIndex(redis, session.userId, 'designs'),
+      getIndex(redis, session.userId, 'baseplates'),
+      getIndex(redis, session.userId, 'designVersions'),
+      getIndexUpdatedAt(redis, session.userId),
+      redis.smembers(communityPublishedKey(session.userId)),
+    ]);
     const communityIds = [...publishedIds].sort();
 
     const liveLayouts = filterLive(layoutsIndex);
     const liveDesigns = filterLive(designsIndex);
     const liveBaseplates = filterLive(baseplatesIndex);
+    const liveDesignVersions = filterLive(designVersionsIndex);
 
     res.setHeader('Content-Type', 'application/zip');
     res.setHeader(
@@ -80,6 +88,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
               layouts: liveLayouts,
               designs: liveDesigns,
               baseplates: liveBaseplates,
+              designVersions: liveDesignVersions,
               community: communityIds,
               indexUpdatedAt,
               exportedAt: Date.now(),
@@ -94,6 +103,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
         streamEnvelopes(addFile, session.userId, 'layouts', Object.keys(liveLayouts)),
         streamEnvelopes(addFile, session.userId, 'designs', Object.keys(liveDesigns)),
         streamEnvelopes(addFile, session.userId, 'baseplates', Object.keys(liveBaseplates)),
+        streamEnvelopes(addFile, session.userId, 'designVersions', Object.keys(liveDesignVersions)),
         streamCommunityRecords(addFile, communityIds),
       ]);
     });

--- a/api/sync/lib/resourceHandler.ts
+++ b/api/sync/lib/resourceHandler.ts
@@ -32,7 +32,7 @@ import { compareForTiebreaker } from '../../lib/lwwTiebreaker.js';
 
 type RedisClient = NonNullable<ReturnType<typeof getRedis>>;
 
-export type SyncResourceKind = 'layouts' | 'designs' | 'baseplates';
+export type SyncResourceKind = 'layouts' | 'designs' | 'baseplates' | 'designVersions';
 
 export interface SyncEnvelope {
   modifiedAt: number;

--- a/api/sync/manifest.test.ts
+++ b/api/sync/manifest.test.ts
@@ -125,7 +125,13 @@ describe('GET /api/sync/manifest', () => {
     const res = makeRes();
     await handler(makeReq(), res as unknown as VercelResponse);
     expect(res._status).toBe(200);
-    expect(res._body).toEqual({ layouts: {}, designs: {}, baseplates: {}, indexUpdatedAt: 0 });
+    expect(res._body).toEqual({
+      layouts: {},
+      designs: {},
+      baseplates: {},
+      designVersions: {},
+      indexUpdatedAt: 0,
+    });
   });
 
   it('returns the index hashes plus indexUpdatedAt', async () => {

--- a/api/sync/manifest.ts
+++ b/api/sync/manifest.ts
@@ -12,7 +12,7 @@ import { getIndex, getIndexUpdatedAt } from '../lib/userIndex.js';
  * Returns the user's full per-kind index plus an `indexUpdatedAt`
  * timestamp the client uses for `If-Modified-Since` polling.
  *
- *   200  → { layouts, designs, baseplates: { [id]: IndexEntry }, indexUpdatedAt }
+ *   200  → { layouts, designs, baseplates, designVersions: { [id]: IndexEntry }, indexUpdatedAt }
  *   304  → empty body when the client's `If-Modified-Since` >= the
  *          server's `users:{uid}:indexUpdatedAt` (no scan needed).
  *
@@ -48,13 +48,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       return;
     }
 
-    const [layouts, designs, baseplates] = await Promise.all([
+    const [layouts, designs, baseplates, designVersions] = await Promise.all([
       getIndex(redis, session.userId, 'layouts'),
       getIndex(redis, session.userId, 'designs'),
       getIndex(redis, session.userId, 'baseplates'),
+      getIndex(redis, session.userId, 'designVersions'),
     ]);
 
-    res.status(200).json({ layouts, designs, baseplates, indexUpdatedAt });
+    res.status(200).json({ layouts, designs, baseplates, designVersions, indexUpdatedAt });
   } catch (error) {
     logger.error('sync/manifest failed', {
       userId: session.userId,

--- a/scripts/doc-budget.json
+++ b/scripts/doc-budget.json
@@ -24,7 +24,7 @@
     "api/.greptile/rules.md": 177,
     "api/README.md": 1864,
     "api/auth/README.md": 1484,
-    "api/sync/README.md": 948,
+    "api/sync/README.md": 1113,
     "docs/design/sliding-tray.md": 1053,
     "docs/label-icons.md": 890,
     "docs/schemas/README.md": 896,

--- a/src/core/sync/adapters/types.ts
+++ b/src/core/sync/adapters/types.ts
@@ -129,16 +129,35 @@ export interface BaseplatePayload {
   params: unknown;
 }
 
+/**
+ * A named version of a design. `content` travels UNCOMPRESSED so the server can
+ * run the same designer validator it runs on a design; the local store keeps it
+ * LZ-compressed and the adapter converts at this boundary.
+ *
+ * There is deliberately no `thumbnail`: it is a rendered PNG data URL that would
+ * consume most of the payload budget, and it regenerates locally from `content`.
+ */
+export interface DesignVersionPayload {
+  designId: string;
+  name: string;
+  /** `{ name, params }` for bins, `{ name, kind, envelope, structure }` otherwise. */
+  content: unknown;
+  createdAt: string;
+  origin: string;
+  pinned?: boolean;
+}
+
 export type LayoutAdapter = SyncAdapter<Layout>;
 export type DesignAdapter = SyncAdapter<DesignSyncPayload>;
 export type BaseplateAdapter = SyncAdapter<BaseplatePayload>;
+export type DesignVersionAdapter = SyncAdapter<DesignVersionPayload>;
 
 /**
  * All adapters bundled together — what the engine takes at start time.
  * The shape lets the engine treat them uniformly while keeping the
  * `kind` distinction visible in logs and the outbox.
  *
- * `SyncKind = 'layouts' | 'designs' | 'baseplates'` — plural to match
+ * `SyncKind` is plural to match
  * server endpoints (`/api/sync/{kind}/[id]`) and Redis index keys
  * (`users:{uid}:index:{kind}`). The outbox uses the same plural form so
  * there's no kind-translation shim anywhere in the stack.
@@ -147,6 +166,7 @@ export interface SyncAdapters {
   layouts: LayoutAdapter;
   designs: DesignAdapter;
   baseplates: BaseplateAdapter;
+  designVersions: DesignVersionAdapter;
 }
 
 export type SyncKind = keyof SyncAdapters;

--- a/src/core/sync/claim.test.ts
+++ b/src/core/sync/claim.test.ts
@@ -8,6 +8,7 @@ import type {
   LayoutAdapter,
   DesignAdapter,
   BaseplateAdapter,
+  DesignVersionAdapter,
 } from './adapters/types';
 
 const fetchMock = vi.fn();
@@ -66,6 +67,7 @@ beforeEach(() => {
     layouts: layouts as LayoutAdapter,
     designs: designs as DesignAdapter,
     baseplates: baseplates as BaseplateAdapter,
+    designVersions: baseplates as unknown as DesignVersionAdapter,
   };
   fetchMock.mockReset();
 });

--- a/src/core/sync/claim.ts
+++ b/src/core/sync/claim.ts
@@ -34,16 +34,21 @@ interface IndexEntry {
   deletedAt?: number;
 }
 
-interface ManifestResponse {
-  layouts: Record<string, IndexEntry>;
-  designs: Record<string, IndexEntry>;
-  // Optional: a manifest from a server predating this key omits it.
-  baseplates?: Record<string, IndexEntry>;
+// Indexed by SyncKind so the merge loop can read a kind's entries without a
+// per-kind branch. Every kind is optional: a manifest from a server predating
+// that key omits it, and the loop falls back to an empty record.
+type ManifestResponse = Partial<Record<SyncKind, Record<string, IndexEntry>>> & {
   indexUpdatedAt: number;
-}
+};
 
 interface ItemFetchResponse {
-  envelope: { layout?: unknown; design?: unknown; baseplate?: unknown; modifiedAt: number };
+  envelope: {
+    layout?: unknown;
+    design?: unknown;
+    baseplate?: unknown;
+    designVersion?: unknown;
+    modifiedAt: number;
+  };
 }
 
 const inFlightByUser = new Map<string, Promise<ClaimResult>>();
@@ -85,11 +90,13 @@ async function execute(ctx: ClaimContext): Promise<ClaimResult> {
 }
 
 async function executeInner(ctx: ClaimContext): Promise<ClaimResult> {
-  const localLayouts = await ctx.adapters.layouts.list();
-  const localDesigns = await ctx.adapters.designs.list();
-  const localBaseplates = await ctx.adapters.baseplates.list();
+  // Keyed by kind rather than one binding per kind: every step below iterates
+  // this, so adding a SyncKind cannot silently skip the claim.
+  const kinds = Object.keys(ctx.adapters) as SyncKind[];
+  const local = {} as Record<SyncKind, SyncableItem[]>;
+  for (const kind of kinds) local[kind] = await ctx.adapters[kind].list();
 
-  const localCount = localLayouts.length + localDesigns.length + localBaseplates.length;
+  const localCount = kinds.reduce((total, kind) => total + local[kind].length, 0);
   const lastUserId = readLastSignedInUserId();
   const accountMismatch = lastUserId !== null && lastUserId !== ctx.userId && localCount > 0;
   if (accountMismatch) {
@@ -105,7 +112,7 @@ async function executeInner(ctx: ClaimContext): Promise<ClaimResult> {
       // Reverse order makes the failure safe — clearing the outbox is
       // the only step that gates cross-account leakage.
       await outboxClearAll();
-      await wipeLocal(ctx.adapters, localLayouts, localDesigns, localBaseplates);
+      await wipeLocal(ctx.adapters, local);
       persistLastSignedInUserId(ctx.userId);
       useSyncStatusStore.getState().succeed();
       return { status: 'discarded' };
@@ -126,34 +133,39 @@ async function executeInner(ctx: ClaimContext): Promise<ClaimResult> {
     return { status: 'unauthorized' };
   }
 
-  const layoutCounts = await mergeKind(
-    ctx.adapters.layouts,
-    'layouts',
-    localLayouts,
-    manifest.layouts
-  );
-  const designCounts = await mergeKind(
-    ctx.adapters.designs,
-    'designs',
-    localDesigns,
-    manifest.designs
-  );
-  const baseplateCounts = await mergeKind(
-    ctx.adapters.baseplates,
-    'baseplates',
-    localBaseplates,
-    // Fallback for a manifest predating the baseplates key (schema skew).
-    manifest.baseplates ?? {}
-  );
+  let pulled = 0;
+  let pushed = 0;
+  for (const kind of kinds) {
+    // `?? {}` covers a manifest predating this kind's key (schema skew).
+    const counts = await mergeKind(ctx.adapters[kind], kind, local[kind], manifest[kind] ?? {});
+    pulled += counts.pulled;
+    pushed += counts.pushed;
+  }
 
   persistLastSignedInUserId(ctx.userId);
   useSyncStatusStore.getState().succeed();
 
   return {
     status: 'merged',
-    pulled: layoutCounts.pulled + designCounts.pulled + baseplateCounts.pulled,
-    pushed: layoutCounts.pushed + designCounts.pushed + baseplateCounts.pushed,
+    pulled,
+    pushed,
   };
+}
+
+/**
+ * Each kind's envelope names its payload differently on the wire
+ * (`layout` / `design` / `baseplate` / `designVersion`), so the key is looked
+ * up rather than branched on at both call sites.
+ */
+const ENVELOPE_KEY: Record<SyncKind, 'layout' | 'design' | 'baseplate' | 'designVersion'> = {
+  layouts: 'layout',
+  designs: 'design',
+  baseplates: 'baseplate',
+  designVersions: 'designVersion',
+};
+
+function envelopePayload(kind: SyncKind, fetched: ItemFetchResponse): unknown {
+  return fetched.envelope[ENVELOPE_KEY[kind]];
 }
 
 interface MergeCounts {
@@ -200,12 +212,7 @@ async function mergeKind(
     if (!localItem) {
       const fetched = await fetchEnvelope(kind, id);
       if (fetched) {
-        const payload =
-          kind === 'layouts'
-            ? fetched.envelope.layout
-            : kind === 'baseplates'
-              ? fetched.envelope.baseplate
-              : fetched.envelope.design;
+        const payload = envelopePayload(kind, fetched);
         if (payload !== undefined) {
           await adapter.applyRemote({ id, payload, modifiedAt: fetched.envelope.modifiedAt });
           pulled++;
@@ -217,12 +224,7 @@ async function mergeKind(
     if (localItem.modifiedAt < entry.modifiedAt) {
       const fetched = await fetchEnvelope(kind, id);
       if (fetched) {
-        const payload =
-          kind === 'layouts'
-            ? fetched.envelope.layout
-            : kind === 'baseplates'
-              ? fetched.envelope.baseplate
-              : fetched.envelope.design;
+        const payload = envelopePayload(kind, fetched);
         if (payload !== undefined) {
           await adapter.applyRemote({ id, payload, modifiedAt: fetched.envelope.modifiedAt });
           pulled++;
@@ -281,13 +283,11 @@ async function fetchEnvelope(kind: SyncKind, id: string): Promise<ItemFetchRespo
 
 async function wipeLocal(
   adapters: SyncAdapters,
-  layouts: SyncableItem[],
-  designs: SyncableItem[],
-  baseplates: SyncableItem[]
+  local: Record<SyncKind, SyncableItem[]>
 ): Promise<void> {
-  for (const item of layouts) await adapters.layouts.applyRemoteDelete(item.id);
-  for (const item of designs) await adapters.designs.applyRemoteDelete(item.id);
-  for (const item of baseplates) await adapters.baseplates.applyRemoteDelete(item.id);
+  for (const kind of Object.keys(adapters) as SyncKind[]) {
+    for (const item of local[kind]) await adapters[kind].applyRemoteDelete(item.id);
+  }
 }
 
 function readLastSignedInUserId(): string | null {

--- a/src/core/sync/claim.ts
+++ b/src/core/sync/claim.ts
@@ -1,3 +1,4 @@
+import { PAYLOAD_KEY } from './payloadKey';
 import { apiFetch } from './apiFetch';
 import { enqueue as outboxEnqueue, clearAll as outboxClearAll } from './outbox';
 import { useSyncStatusStore } from './status';
@@ -152,20 +153,8 @@ async function executeInner(ctx: ClaimContext): Promise<ClaimResult> {
   };
 }
 
-/**
- * Each kind's envelope names its payload differently on the wire
- * (`layout` / `design` / `baseplate` / `designVersion`), so the key is looked
- * up rather than branched on at both call sites.
- */
-const ENVELOPE_KEY: Record<SyncKind, 'layout' | 'design' | 'baseplate' | 'designVersion'> = {
-  layouts: 'layout',
-  designs: 'design',
-  baseplates: 'baseplate',
-  designVersions: 'designVersion',
-};
-
 function envelopePayload(kind: SyncKind, fetched: ItemFetchResponse): unknown {
-  return fetched.envelope[ENVELOPE_KEY[kind]];
+  return fetched.envelope[PAYLOAD_KEY[kind]];
 }
 
 interface MergeCounts {

--- a/src/core/sync/deleteAccount.test.ts
+++ b/src/core/sync/deleteAccount.test.ts
@@ -8,6 +8,7 @@ import type {
   LayoutAdapter,
   DesignAdapter,
   BaseplateAdapter,
+  DesignVersionAdapter,
 } from './adapters/types';
 
 const apiDeleteAccountMock = vi.fn();
@@ -65,6 +66,7 @@ beforeEach(() => {
     layouts: layouts as LayoutAdapter,
     designs: designs as DesignAdapter,
     baseplates: baseplates as BaseplateAdapter,
+    designVersions: baseplates as unknown as DesignVersionAdapter,
   };
   apiDeleteAccountMock.mockResolvedValue(undefined);
 });

--- a/src/core/sync/engine.test.ts
+++ b/src/core/sync/engine.test.ts
@@ -18,6 +18,7 @@ import type {
   LayoutAdapter,
   DesignAdapter,
   BaseplateAdapter,
+  DesignVersionAdapter,
 } from './adapters/types';
 
 const fetchMock = vi.fn();
@@ -92,6 +93,7 @@ beforeEach(async () => {
     layouts: layoutsAdapter as LayoutAdapter,
     designs: designsAdapter as DesignAdapter,
     baseplates: baseplatesAdapter as BaseplateAdapter,
+    designVersions: baseplatesAdapter as unknown as DesignVersionAdapter,
   };
   // Default: every fetch resolves with 200 + empty body.
   fetchMock.mockResolvedValue(new Response(null, { status: 200 }));

--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -11,20 +11,9 @@ import {
 import { parseRetryAfter, rateLimitedBackoffMs } from './retryAfter';
 import { useSyncStatusStore } from './status';
 import type { AdapterChange, SyncAdapter, SyncAdapters, SyncKind } from './adapters/types';
+import { PAYLOAD_KEY } from './payloadKey';
 
 type ConflictReason = 'remote-newer' | 'deleted-elsewhere' | 'quota' | 'gave-up';
-
-/**
- * Key each kind's payload travels under in its PUT body, matching the endpoint
- * that reads it. A lookup rather than a chain of ternaries because the fallback
- * arm of that chain silently sent any new kind as a `design`.
- */
-const PAYLOAD_KEY: Record<SyncKind, 'layout' | 'design' | 'baseplate' | 'designVersion'> = {
-  layouts: 'layout',
-  designs: 'design',
-  baseplates: 'baseplate',
-  designVersions: 'designVersion',
-};
 
 export type EngineEvent =
   | { type: 'sync-error'; reason: ConflictReason; kind: SyncKind; id: string; message?: string }

--- a/src/core/sync/engine.ts
+++ b/src/core/sync/engine.ts
@@ -14,6 +14,18 @@ import type { AdapterChange, SyncAdapter, SyncAdapters, SyncKind } from './adapt
 
 type ConflictReason = 'remote-newer' | 'deleted-elsewhere' | 'quota' | 'gave-up';
 
+/**
+ * Key each kind's payload travels under in its PUT body, matching the endpoint
+ * that reads it. A lookup rather than a chain of ternaries because the fallback
+ * arm of that chain silently sent any new kind as a `design`.
+ */
+const PAYLOAD_KEY: Record<SyncKind, 'layout' | 'design' | 'baseplate' | 'designVersion'> = {
+  layouts: 'layout',
+  designs: 'design',
+  baseplates: 'baseplate',
+  designVersions: 'designVersion',
+};
+
 export type EngineEvent =
   | { type: 'sync-error'; reason: ConflictReason; kind: SyncKind; id: string; message?: string }
   | { type: 'remote-replaced-local'; kind: SyncKind; id: string };
@@ -181,12 +193,7 @@ async function sendOne(
     return;
   }
 
-  const body =
-    kind === 'layouts'
-      ? { layout: latest.payload, modifiedAt: latest.modifiedAt }
-      : kind === 'baseplates'
-        ? { baseplate: latest.payload, modifiedAt: latest.modifiedAt }
-        : { design: latest.payload, modifiedAt: latest.modifiedAt };
+  const body = { [PAYLOAD_KEY[kind]]: latest.payload, modifiedAt: latest.modifiedAt };
 
   const res = await apiFetch(url, {
     method: 'PUT',

--- a/src/core/sync/payloadKey.ts
+++ b/src/core/sync/payloadKey.ts
@@ -1,0 +1,18 @@
+import type { SyncKind } from './adapters/types';
+
+/**
+ * The key each kind's payload travels under, in both directions: the `PUT` body
+ * a client sends and the envelope field the server returns.
+ *
+ * Its own module because four call sites need it (the engine's push, the
+ * beacon flush, the poller's pull, and the claim merge) and only one of them
+ * owns the engine. Every one of those previously derived the key from a chain
+ * of ternaries whose fallback arm was `design`, so a kind added after
+ * `baseplates` was silently sent and read under the wrong name.
+ */
+export const PAYLOAD_KEY: Record<SyncKind, 'layout' | 'design' | 'baseplate' | 'designVersion'> = {
+  layouts: 'layout',
+  designs: 'design',
+  baseplates: 'baseplate',
+  designVersions: 'designVersion',
+};

--- a/src/core/sync/poller.test.ts
+++ b/src/core/sync/poller.test.ts
@@ -10,6 +10,7 @@ import type {
   LayoutAdapter,
   DesignAdapter,
   BaseplateAdapter,
+  DesignVersionAdapter,
 } from './adapters/types';
 
 const fetchMock = vi.fn();
@@ -64,6 +65,7 @@ beforeEach(() => {
     layouts: layouts as LayoutAdapter,
     designs: designs as DesignAdapter,
     baseplates: baseplates as BaseplateAdapter,
+    designVersions: baseplates as unknown as DesignVersionAdapter,
   };
 });
 

--- a/src/core/sync/poller.ts
+++ b/src/core/sync/poller.ts
@@ -1,3 +1,4 @@
+import { PAYLOAD_KEY } from './payloadKey';
 import { apiFetch } from './apiFetch';
 import { useSessionStore } from './session/useSession';
 import { useSyncStatusStore } from './status';
@@ -171,7 +172,7 @@ async function diffKind(
     if (localMtime === undefined || localMtime < entry.modifiedAt) {
       const fetched = await fetchEnvelope(kind, id);
       if (!fetched) continue;
-      const payload = fetched.envelope[ENVELOPE_KEY[kind]];
+      const payload = fetched.envelope[PAYLOAD_KEY[kind]];
       if (payload === undefined) continue;
       await adapter.applyRemote({
         id,
@@ -183,14 +184,6 @@ async function diffKind(
   }
   return applied;
 }
-
-/** Wire key carrying each kind's payload inside its envelope. */
-const ENVELOPE_KEY: Record<SyncKind, 'layout' | 'design' | 'baseplate' | 'designVersion'> = {
-  layouts: 'layout',
-  designs: 'design',
-  baseplates: 'baseplate',
-  designVersions: 'designVersion',
-};
 
 async function fetchEnvelope(kind: SyncKind, id: string): Promise<ItemFetchResponse | null> {
   let res: Response;

--- a/src/core/sync/poller.ts
+++ b/src/core/sync/poller.ts
@@ -9,19 +9,18 @@ interface IndexEntry {
   deletedAt?: number;
 }
 
-interface ManifestResponse {
-  layouts: Record<string, IndexEntry>;
-  designs: Record<string, IndexEntry>;
-  // Optional: a manifest from a server predating this key omits it.
-  baseplates?: Record<string, IndexEntry>;
+// Indexed by SyncKind; every kind optional, since a manifest from a server
+// predating that key omits it.
+type ManifestResponse = Partial<Record<SyncKind, Record<string, IndexEntry>>> & {
   indexUpdatedAt: number;
-}
+};
 
 interface ItemFetchResponse {
   envelope: {
     layout?: unknown;
     design?: unknown;
     baseplate?: unknown;
+    designVersion?: unknown;
     modifiedAt: number;
     schemaVersion: number;
   };
@@ -119,9 +118,16 @@ async function run(adapters: SyncAdapters, capturedGeneration: number): Promise<
     'baseplates',
     manifest.baseplates ?? {}
   );
-  const layoutChanges = await diffKind(adapters.layouts, 'layouts', manifest.layouts);
-  const designChanges = await diffKind(adapters.designs, 'designs', manifest.designs);
-  const applied = layoutChanges + designChanges + baseplateChanges;
+  const layoutChanges = await diffKind(adapters.layouts, 'layouts', manifest.layouts ?? {});
+  const designChanges = await diffKind(adapters.designs, 'designs', manifest.designs ?? {});
+  // Versions last: a pulled version is only reachable through its design's
+  // history list, so nothing breaks if it lands after the design it belongs to.
+  const versionChanges = await diffKind(
+    adapters.designVersions,
+    'designVersions',
+    manifest.designVersions ?? {}
+  );
+  const applied = layoutChanges + designChanges + baseplateChanges + versionChanges;
 
   // Reset happened mid-flight — drop our results to avoid re-installing the
   // prior user's high-water mark or applying writes that belong to a session
@@ -165,12 +171,7 @@ async function diffKind(
     if (localMtime === undefined || localMtime < entry.modifiedAt) {
       const fetched = await fetchEnvelope(kind, id);
       if (!fetched) continue;
-      const payload =
-        kind === 'layouts'
-          ? fetched.envelope.layout
-          : kind === 'baseplates'
-            ? fetched.envelope.baseplate
-            : fetched.envelope.design;
+      const payload = fetched.envelope[ENVELOPE_KEY[kind]];
       if (payload === undefined) continue;
       await adapter.applyRemote({
         id,
@@ -182,6 +183,14 @@ async function diffKind(
   }
   return applied;
 }
+
+/** Wire key carrying each kind's payload inside its envelope. */
+const ENVELOPE_KEY: Record<SyncKind, 'layout' | 'design' | 'baseplate' | 'designVersion'> = {
+  layouts: 'layout',
+  designs: 'design',
+  baseplates: 'baseplate',
+  designVersions: 'designVersion',
+};
 
 async function fetchEnvelope(kind: SyncKind, id: string): Promise<ItemFetchResponse | null> {
   let res: Response;

--- a/src/core/sync/signOut.test.ts
+++ b/src/core/sync/signOut.test.ts
@@ -8,6 +8,7 @@ import type {
   LayoutAdapter,
   DesignAdapter,
   BaseplateAdapter,
+  DesignVersionAdapter,
 } from './adapters/types';
 
 const flushNowMock = vi.fn();
@@ -76,6 +77,7 @@ beforeEach(() => {
     layouts: layouts as LayoutAdapter,
     designs: designs as DesignAdapter,
     baseplates: baseplates as BaseplateAdapter,
+    designVersions: baseplates as unknown as DesignVersionAdapter,
   };
   flushNowMock.mockResolvedValue(undefined);
   getPendingEntriesMock.mockResolvedValue([]);

--- a/src/core/sync/signOut.ts
+++ b/src/core/sync/signOut.ts
@@ -3,7 +3,7 @@ import { flushNow, getPendingEntries, stop as stopEngine } from './engine';
 import { clearAll as clearOutbox } from './outbox';
 import { resetPullState } from './poller';
 import { clearLastSignedInUserId } from './claim';
-import type { SyncAdapters } from './adapters/types';
+import type { SyncAdapters, SyncKind } from './adapters/types';
 
 const FLUSH_TIMEOUT_MS = 5_000;
 
@@ -83,23 +83,19 @@ async function flushOutboxBestEffort(): Promise<void> {
 }
 
 async function countLocalItems(adapters: SyncAdapters): Promise<number> {
-  const [layouts, designs, baseplates] = await Promise.all([
-    adapters.layouts.list(),
-    adapters.designs.list(),
-    adapters.baseplates.list(),
-  ]);
-  return layouts.length + designs.length + baseplates.length;
+  // Iterated rather than destructured per kind: a new SyncKind that is missed
+  // here under-reports what "wipe local" is about to destroy.
+  const lists = await Promise.all(
+    (Object.keys(adapters) as SyncKind[]).map((kind) => adapters[kind].list())
+  );
+  return lists.reduce((total, items) => total + items.length, 0);
 }
 
 async function wipeLocal(adapters: SyncAdapters): Promise<void> {
-  const [layouts, designs, baseplates] = await Promise.all([
-    adapters.layouts.list(),
-    adapters.designs.list(),
-    adapters.baseplates.list(),
-  ]);
-  for (const item of layouts) await adapters.layouts.applyRemoteDelete(item.id);
-  for (const item of designs) await adapters.designs.applyRemoteDelete(item.id);
-  for (const item of baseplates) await adapters.baseplates.applyRemoteDelete(item.id);
+  for (const kind of Object.keys(adapters) as SyncKind[]) {
+    const adapter = adapters[kind];
+    for (const item of await adapter.list()) await adapter.applyRemoteDelete(item.id);
+  }
 }
 
 function isChoice(value: unknown): value is KeepLocalChoice {

--- a/src/core/sync/triggers/useBeaconFlush.test.ts
+++ b/src/core/sync/triggers/useBeaconFlush.test.ts
@@ -58,11 +58,18 @@ function makeAdapters(layoutPayload: Record<string, unknown> | null = { v: 1 }):
     applyRemoteDelete: vi.fn(),
     subscribe: vi.fn(() => () => {}),
   };
+  const designVersions: SyncAdapter = {
+    list: vi.fn(),
+    get: vi.fn(async (id: string) => ({ id, payload: { v: 'ver' }, modifiedAt: 4000 })),
+    applyRemote: vi.fn(),
+    applyRemoteDelete: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+  };
   return {
     layouts: layouts as LayoutAdapter,
     designs: designs as DesignAdapter,
     baseplates: baseplates as BaseplateAdapter,
-    designVersions: baseplates as unknown as DesignVersionAdapter,
+    designVersions: designVersions as unknown as DesignVersionAdapter,
   };
 }
 
@@ -110,6 +117,25 @@ describe('useBeaconFlush', () => {
     expect(url).toBe('/api/sync/baseplates/bp-1');
     const body = JSON.parse(await blob.text()) as Record<string, unknown>;
     expect(body).toEqual({ baseplate: { b: 1 }, modifiedAt: 3000 });
+  });
+
+  // The old `bodyForKind` fell through to `{ design }` for anything that was
+  // not layouts or baseplates, so this kind would have been beaconed under a
+  // key its endpoint does not read.
+  it('wraps a design version in { designVersion } (not { design })', async () => {
+    getPendingEntriesMock.mockResolvedValueOnce([
+      { kind: 'designVersions', id: 'ver-1', op: 'put', modifiedAt: 4000 },
+    ]);
+    renderHook(() => useBeaconFlush(makeAdapters()));
+    fireVisibilityHidden();
+    await settlePrep();
+    firePageHide();
+
+    expect(sendBeaconMock).toHaveBeenCalledTimes(1);
+    const [url, blob] = sendBeaconMock.mock.calls[0] as [string, Blob];
+    expect(url).toBe('/api/sync/designVersions/ver-1');
+    const body = JSON.parse(await blob.text()) as Record<string, unknown>;
+    expect(body).toEqual({ designVersion: { v: 'ver' }, modifiedAt: 4000 });
   });
 
   it('fires sendBeacon synchronously on pagehide — no awaits between the event and the call', async () => {

--- a/src/core/sync/triggers/useBeaconFlush.test.ts
+++ b/src/core/sync/triggers/useBeaconFlush.test.ts
@@ -8,6 +8,7 @@ import type {
   LayoutAdapter,
   DesignAdapter,
   BaseplateAdapter,
+  DesignVersionAdapter,
 } from '../adapters/types';
 
 const getPendingEntriesMock = vi.fn();
@@ -61,6 +62,7 @@ function makeAdapters(layoutPayload: Record<string, unknown> | null = { v: 1 }):
     layouts: layouts as LayoutAdapter,
     designs: designs as DesignAdapter,
     baseplates: baseplates as BaseplateAdapter,
+    designVersions: baseplates as unknown as DesignVersionAdapter,
   };
 }
 

--- a/src/core/sync/triggers/useBeaconFlush.ts
+++ b/src/core/sync/triggers/useBeaconFlush.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { getPendingEntries } from '../engine';
+import { PAYLOAD_KEY } from '../payloadKey';
 import type { SyncAdapters, SyncKind } from '../adapters/types';
 
 const BEACON_MAX_BYTES = 60 * 1024;
@@ -85,7 +86,5 @@ async function collectBeacons(adapters: SyncAdapters): Promise<PreparedBeacon[]>
 }
 
 function bodyForKind(kind: SyncKind, payload: unknown, modifiedAt: number): object {
-  if (kind === 'layouts') return { layout: payload, modifiedAt };
-  if (kind === 'baseplates') return { baseplate: payload, modifiedAt };
-  return { design: payload, modifiedAt };
+  return { [PAYLOAD_KEY[kind]]: payload, modifiedAt };
 }

--- a/src/core/sync/triggers/usePeriodicPoll.test.ts
+++ b/src/core/sync/triggers/usePeriodicPoll.test.ts
@@ -23,6 +23,7 @@ const adapters: SyncAdapters = {
   layouts: noopAdapter,
   designs: noopAdapter,
   baseplates: noopAdapter,
+  designVersions: noopAdapter,
 };
 
 function setVisibility(state: 'hidden' | 'visible'): void {

--- a/src/features/bin-designer/storage/DesignVersionService.ts
+++ b/src/features/bin-designer/storage/DesignVersionService.ts
@@ -25,22 +25,7 @@ import type {
 } from '@/features/bin-designer/types';
 import { MAX_VERSIONS_PER_DESIGN } from '@/features/bin-designer/types';
 import { getDb, DESIGN_VERSIONS_STORE } from './designerDb';
-import { emit as emitVersionEvent } from '@/features/bin-designer/sync/designVersionEvents';
-
-/**
- * Ids whose next write came from the cloud, so the adapter's own listener does
- * not echo a pulled version straight back to the server.
- */
-const suppressed = new Set<string>();
-
-export function suppressVersionEvents(id: string): void {
-  suppressed.add(id);
-}
-
-function announce(event: Parameters<typeof emitVersionEvent>[0]): void {
-  if (suppressed.delete(event.id)) return;
-  emitVersionEvent(event);
-}
+import { emit as announce } from '@/features/bin-designer/sync/designVersionEvents';
 
 /** Strip the compressed body so the history list never holds every design in memory. */
 function toSummary(version: DesignVersion): DesignVersionSummary {
@@ -176,11 +161,13 @@ async function patch(
     const existing = (await db.get(DESIGN_VERSIONS_STORE, versionId)) as DesignVersion | undefined;
     if (!existing) return err(storageNotFound(versionId));
 
-    const updated: DesignVersion = { ...existing, ...fields };
+    // `updatedAt` is what the adapter reports as the mtime. Stamping it here is
+    // what lets a rename win last-write-wins against the copy already synced;
+    // `createdAt` is when the state was captured and never moves.
+    const updatedAt = new Date().toISOString();
+    const updated: DesignVersion = { ...existing, ...fields, updatedAt };
     await db.put(DESIGN_VERSIONS_STORE, updated);
-    // A rename or a pin is a real edit the other device should see, so it needs
-    // a fresh mtime; `createdAt` is when the state was captured and never moves.
-    announce({ type: 'put', id: updated.id, modifiedAt: Date.now() });
+    announce({ type: 'put', id: updated.id, modifiedAt: Date.parse(updatedAt) });
     return ok(toSummary(updated));
   } catch (e) {
     return err(storageUnavailable('indexedDB', e));
@@ -262,15 +249,15 @@ export async function getDesignVersionRecord(
 /**
  * Write a version that came from the cloud.
  *
- * Suppresses the change event: the adapter's own listener would otherwise turn
- * an applied pull straight back into an outbox push.
+ * Deliberately writes through the store directly rather than
+ * {@link createDesignVersion}: only the announcing paths emit, so a pull is
+ * silent by construction and cannot echo back to the server as a push.
  */
 export async function putRemoteDesignVersion(
   version: DesignVersion
 ): Promise<Result<void, StorageError>> {
   try {
     const db = await getDb();
-    suppressVersionEvents(version.id);
     await db.put(DESIGN_VERSIONS_STORE, version);
     return ok(undefined);
   } catch (e) {
@@ -278,13 +265,12 @@ export async function putRemoteDesignVersion(
   }
 }
 
-/** Delete a version because the cloud says it is gone, without re-announcing. */
+/** Delete a version because the cloud says it is gone. Silent, as above. */
 export async function deleteRemoteDesignVersion(
   versionId: string
 ): Promise<Result<void, StorageError>> {
   try {
     const db = await getDb();
-    suppressVersionEvents(versionId);
     await db.delete(DESIGN_VERSIONS_STORE, versionId);
     return ok(undefined);
   } catch (e) {

--- a/src/features/bin-designer/storage/DesignVersionService.ts
+++ b/src/features/bin-designer/storage/DesignVersionService.ts
@@ -25,6 +25,22 @@ import type {
 } from '@/features/bin-designer/types';
 import { MAX_VERSIONS_PER_DESIGN } from '@/features/bin-designer/types';
 import { getDb, DESIGN_VERSIONS_STORE } from './designerDb';
+import { emit as emitVersionEvent } from '@/features/bin-designer/sync/designVersionEvents';
+
+/**
+ * Ids whose next write came from the cloud, so the adapter's own listener does
+ * not echo a pulled version straight back to the server.
+ */
+const suppressed = new Set<string>();
+
+export function suppressVersionEvents(id: string): void {
+  suppressed.add(id);
+}
+
+function announce(event: Parameters<typeof emitVersionEvent>[0]): void {
+  if (suppressed.delete(event.id)) return;
+  emitVersionEvent(event);
+}
 
 /** Strip the compressed body so the history list never holds every design in memory. */
 function toSummary(version: DesignVersion): DesignVersionSummary {
@@ -107,6 +123,10 @@ export async function createDesignVersion(
       origin,
     };
     await db.put(DESIGN_VERSIONS_STORE, version);
+    announce({ type: 'put', id: version.id, modifiedAt: Date.parse(version.createdAt) });
+    for (const victim of evicted) {
+      announce({ type: 'delete', id: victim.id, deletedAt: Date.now() });
+    }
 
     return ok({ version: toSummary(version), evicted });
   } catch (e) {
@@ -158,6 +178,9 @@ async function patch(
 
     const updated: DesignVersion = { ...existing, ...fields };
     await db.put(DESIGN_VERSIONS_STORE, updated);
+    // A rename or a pin is a real edit the other device should see, so it needs
+    // a fresh mtime; `createdAt` is when the state was captured and never moves.
+    announce({ type: 'put', id: updated.id, modifiedAt: Date.now() });
     return ok(toSummary(updated));
   } catch (e) {
     return err(storageUnavailable('indexedDB', e));
@@ -182,6 +205,7 @@ export async function deleteDesignVersion(versionId: string): Promise<Result<voi
   try {
     const db = await getDb();
     await db.delete(DESIGN_VERSIONS_STORE, versionId);
+    announce({ type: 'delete', id: versionId, deletedAt: Date.now() });
     return ok(undefined);
   } catch (e) {
     return err(storageUnavailable('indexedDB', e));
@@ -201,8 +225,68 @@ export async function deleteVersionsForDesign(
     const existing = await readAll(designId);
     for (const version of existing) {
       await db.delete(DESIGN_VERSIONS_STORE, version.id);
+      announce({ type: 'delete', id: version.id, deletedAt: Date.now() });
     }
     return ok(existing.length);
+  } catch (e) {
+    return err(storageUnavailable('indexedDB', e));
+  }
+}
+
+// Sync-facing surface. The engine needs whole records across every design,
+// and writes that do NOT re-announce (an applied pull must not echo back).
+
+/** Every stored version, across all designs. Used by the sync adapter's `list`. */
+export async function listAllDesignVersions(): Promise<Result<DesignVersion[], StorageError>> {
+  try {
+    const db = await getDb();
+    return ok((await db.getAll(DESIGN_VERSIONS_STORE)) as DesignVersion[]);
+  } catch (e) {
+    return err(storageUnavailable('indexedDB', e));
+  }
+}
+
+/** One whole version record including its compressed body. */
+export async function getDesignVersionRecord(
+  versionId: string
+): Promise<Result<DesignVersion | null, StorageError>> {
+  try {
+    const db = await getDb();
+    const row = (await db.get(DESIGN_VERSIONS_STORE, versionId)) as DesignVersion | undefined;
+    return ok(row ?? null);
+  } catch (e) {
+    return err(storageUnavailable('indexedDB', e));
+  }
+}
+
+/**
+ * Write a version that came from the cloud.
+ *
+ * Suppresses the change event: the adapter's own listener would otherwise turn
+ * an applied pull straight back into an outbox push.
+ */
+export async function putRemoteDesignVersion(
+  version: DesignVersion
+): Promise<Result<void, StorageError>> {
+  try {
+    const db = await getDb();
+    suppressVersionEvents(version.id);
+    await db.put(DESIGN_VERSIONS_STORE, version);
+    return ok(undefined);
+  } catch (e) {
+    return err(storageUnavailable('indexedDB', e));
+  }
+}
+
+/** Delete a version because the cloud says it is gone, without re-announcing. */
+export async function deleteRemoteDesignVersion(
+  versionId: string
+): Promise<Result<void, StorageError>> {
+  try {
+    const db = await getDb();
+    suppressVersionEvents(versionId);
+    await db.delete(DESIGN_VERSIONS_STORE, versionId);
+    return ok(undefined);
   } catch (e) {
     return err(storageUnavailable('indexedDB', e));
   }

--- a/src/features/bin-designer/sync/designVersionAdapter.test.ts
+++ b/src/features/bin-designer/sync/designVersionAdapter.test.ts
@@ -167,19 +167,70 @@ describe('designVersionAdapter', () => {
       expect(changes).toContainEqual(expect.objectContaining({ kind: 'delete', id: saved.id }));
     });
 
-    // A rename is a real edit the other device has to receive, and it needs a
-    // fresh mtime to win LWW against the copy already stored.
-    it('reports a rename as a put with a newer mtime than the capture', async () => {
+    // `engine.sendOne` re-reads the item at push time and sends THAT mtime, so
+    // the adapter, not just the event, has to report the edit time. Reporting
+    // `createdAt` would push a stale timestamp that loses LWW forever.
+    it('reports a renamed version’s edit time, not its capture time', async () => {
       const saved = await seedVersion();
-      const changes: AdapterChange[] = [];
-      const unsubscribe = designVersionAdapter.subscribe((c) => changes.push(c));
+      await new Promise((r) => setTimeout(r, 5));
 
       expectOk(await renameDesignVersion(saved.id, 'renamed'));
+
+      const item = await designVersionAdapter.get(saved.id);
+      expect(item?.modifiedAt).toBeGreaterThan(Date.parse(saved.createdAt));
+    });
+
+    it('reports the capture time for a version that was never edited', async () => {
+      const saved = await seedVersion();
+
+      const item = await designVersionAdapter.get(saved.id);
+
+      expect(item?.modifiedAt).toBe(Date.parse(saved.createdAt));
+    });
+
+    // Otherwise the receiving device pushes back `createdAt` and the two trade
+    // stale writes forever.
+    it('keeps the edit time across a pull', async () => {
+      const id = '11111111-2222-3333-4444-aaaaaaaaaaaa';
+      const edited = Date.parse('2026-08-10T00:00:00.000Z');
+      await designVersionAdapter.applyRemote({
+        id,
+        modifiedAt: edited,
+        payload: {
+          designId: DESIGN,
+          name: 'renamed elsewhere',
+          content: { name: 'x', params: DEFAULT_BIN_PARAMS },
+          createdAt: '2026-08-01T00:00:00.000Z',
+          origin: 'manual',
+        },
+      });
+
+      const item = await designVersionAdapter.get(id);
+      expect(item?.modifiedAt).toBe(edited);
+    });
+
+    // A pulled write must not re-arm a filter that then swallows the next real
+    // local edit to the same version.
+    it('does not suppress the local change that follows a remote write', async () => {
+      const id = '11111111-2222-3333-4444-999999999999';
+      await designVersionAdapter.applyRemote({
+        id,
+        modifiedAt: Date.now(),
+        payload: {
+          designId: DESIGN,
+          name: 'pulled',
+          content: { name: 'x', params: DEFAULT_BIN_PARAMS },
+          createdAt: new Date().toISOString(),
+          origin: 'manual',
+        },
+      });
+
+      const changes: AdapterChange[] = [];
+      const unsubscribe = designVersionAdapter.subscribe((c) => changes.push(c));
+      expectOk(await renameDesignVersion(id, 'renamed locally'));
       unsubscribe();
 
-      const put = changes.find((c) => c.kind === 'put');
-      expect(put).toBeDefined();
-      expect(put?.modifiedAt).toBeGreaterThanOrEqual(Date.parse(saved.createdAt));
+      expect(changes).toContainEqual(expect.objectContaining({ kind: 'put', id }));
     });
 
     // Otherwise the engine's own listener turns every pull straight back into a push.

--- a/src/features/bin-designer/sync/designVersionAdapter.test.ts
+++ b/src/features/bin-designer/sync/designVersionAdapter.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/shared/analytics/posthog', () => ({ trackDesignCreated: () => {} }));
+
+import { designVersionAdapter } from './designVersionAdapter';
+import { __resetForTests as resetVersionEvents } from './designVersionEvents';
+import { closeDesignerDb } from '@/features/bin-designer/storage/designerDb';
+import {
+  createDesignVersion,
+  listDesignVersions,
+  deleteDesignVersion,
+  renameDesignVersion,
+  readDesignVersion,
+} from '@/features/bin-designer/storage/DesignVersionService';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants/defaults';
+import { expectOk } from '@/test/testUtils';
+import { designId } from '@/core/types';
+import type { AdapterChange } from '@/core/sync/adapters/types';
+
+const DESIGN = designId('design_adapter_test');
+
+async function seedVersion(name = 'v1') {
+  return expectOk(
+    await createDesignVersion(
+      DESIGN,
+      name,
+      { name: 'Router Bit Holder', params: DEFAULT_BIN_PARAMS },
+      // A stored thumbnail must never reach the wire.
+      'data:image/png;base64,AAAA'
+    )
+  ).version;
+}
+
+describe('designVersionAdapter', () => {
+  beforeEach(async () => {
+    resetVersionEvents();
+    closeDesignerDb();
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase('gridfinity-designer-v1');
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(new Error(req.error?.message ?? 'delete failed'));
+    });
+  });
+
+  describe('list and get', () => {
+    it('exposes a stored version with its content decompressed', async () => {
+      const saved = await seedVersion('0.2 mm');
+
+      const items = await designVersionAdapter.list();
+
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe(saved.id);
+      expect(items[0].payload.designId).toBe(DESIGN);
+      expect(items[0].payload.name).toBe('0.2 mm');
+      // Plain object on the wire so the server can run the designer validator.
+      expect((items[0].payload.content as { params: unknown }).params).toEqual(DEFAULT_BIN_PARAMS);
+    });
+
+    // A base64 PNG would consume most of MAX_PAYLOAD_BYTES on its own.
+    it('never puts a thumbnail on the wire', async () => {
+      await seedVersion();
+
+      const items = await designVersionAdapter.list();
+
+      expect(JSON.stringify(items[0].payload)).not.toContain('base64');
+      expect('thumbnail' in items[0].payload).toBe(false);
+    });
+
+    it('returns null for an id it does not hold', async () => {
+      expect(await designVersionAdapter.get('missing')).toBeNull();
+    });
+
+    it('gets one version by id', async () => {
+      const saved = await seedVersion('named');
+      const item = await designVersionAdapter.get(saved.id);
+      expect(item?.payload.name).toBe('named');
+    });
+  });
+
+  describe('applyRemote', () => {
+    it('stores a pulled version so the history list can read it', async () => {
+      await designVersionAdapter.applyRemote({
+        id: '11111111-2222-3333-4444-555555555555',
+        modifiedAt: Date.parse('2026-08-01T00:00:00.000Z'),
+        payload: {
+          designId: DESIGN,
+          name: 'from another device',
+          content: { name: 'Router Bit Holder', params: DEFAULT_BIN_PARAMS },
+          createdAt: '2026-08-01T00:00:00.000Z',
+          origin: 'manual',
+          pinned: true,
+        },
+      });
+
+      const versions = expectOk(await listDesignVersions(DESIGN));
+      expect(versions).toHaveLength(1);
+      expect(versions[0].name).toBe('from another device');
+      expect(versions[0].pinned).toBe(true);
+      // Not synced; the local regenerator fills one in from the params.
+      expect(versions[0].thumbnail).toBeNull();
+    });
+
+    it('re-compresses the pulled content so a local read round-trips', async () => {
+      const id = '11111111-2222-3333-4444-666666666666';
+      await designVersionAdapter.applyRemote({
+        id,
+        modifiedAt: Date.now(),
+        payload: {
+          designId: DESIGN,
+          name: 'pulled',
+          content: { name: 'Router Bit Holder', params: DEFAULT_BIN_PARAMS },
+          createdAt: new Date().toISOString(),
+          origin: 'manual',
+        },
+      });
+
+      expect(expectOk(await readDesignVersion(id)).params).toEqual(DEFAULT_BIN_PARAMS);
+    });
+
+    // An unrecognised origin from a newer client must not corrupt the record.
+    it('falls back to manual for an unknown origin', async () => {
+      const id = '11111111-2222-3333-4444-777777777777';
+      await designVersionAdapter.applyRemote({
+        id,
+        modifiedAt: Date.now(),
+        payload: {
+          designId: DESIGN,
+          name: 'odd',
+          content: { name: 'x' },
+          createdAt: new Date().toISOString(),
+          origin: 'something-new',
+        },
+      });
+
+      expect(expectOk(await listDesignVersions(DESIGN))[0].origin).toBe('manual');
+    });
+
+    it('removes a version the cloud says is gone', async () => {
+      const saved = await seedVersion();
+
+      await designVersionAdapter.applyRemoteDelete(saved.id);
+
+      expect(expectOk(await listDesignVersions(DESIGN))).toEqual([]);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('reports a local save as a put', async () => {
+      const changes: AdapterChange[] = [];
+      const unsubscribe = designVersionAdapter.subscribe((c) => changes.push(c));
+
+      const saved = await seedVersion();
+      unsubscribe();
+
+      expect(changes).toContainEqual(expect.objectContaining({ kind: 'put', id: saved.id }));
+    });
+
+    it('reports a local delete', async () => {
+      const saved = await seedVersion();
+      const changes: AdapterChange[] = [];
+      const unsubscribe = designVersionAdapter.subscribe((c) => changes.push(c));
+
+      expectOk(await deleteDesignVersion(saved.id));
+      unsubscribe();
+
+      expect(changes).toContainEqual(expect.objectContaining({ kind: 'delete', id: saved.id }));
+    });
+
+    // A rename is a real edit the other device has to receive, and it needs a
+    // fresh mtime to win LWW against the copy already stored.
+    it('reports a rename as a put with a newer mtime than the capture', async () => {
+      const saved = await seedVersion();
+      const changes: AdapterChange[] = [];
+      const unsubscribe = designVersionAdapter.subscribe((c) => changes.push(c));
+
+      expectOk(await renameDesignVersion(saved.id, 'renamed'));
+      unsubscribe();
+
+      const put = changes.find((c) => c.kind === 'put');
+      expect(put).toBeDefined();
+      expect(put?.modifiedAt).toBeGreaterThanOrEqual(Date.parse(saved.createdAt));
+    });
+
+    // Otherwise the engine's own listener turns every pull straight back into a push.
+    it('stays silent when a remote change is applied', async () => {
+      const changes: AdapterChange[] = [];
+      const unsubscribe = designVersionAdapter.subscribe((c) => changes.push(c));
+
+      await designVersionAdapter.applyRemote({
+        id: '11111111-2222-3333-4444-888888888888',
+        modifiedAt: Date.now(),
+        payload: {
+          designId: DESIGN,
+          name: 'pulled',
+          content: { name: 'x' },
+          createdAt: new Date().toISOString(),
+          origin: 'manual',
+        },
+      });
+      await designVersionAdapter.applyRemoteDelete('11111111-2222-3333-4444-888888888888');
+      unsubscribe();
+
+      expect(changes).toEqual([]);
+    });
+  });
+});

--- a/src/features/bin-designer/sync/designVersionAdapter.ts
+++ b/src/features/bin-designer/sync/designVersionAdapter.ts
@@ -31,11 +31,15 @@ function toOrigin(value: unknown): DesignVersionOrigin {
 }
 
 /**
- * A version's mtime is when it was last *edited*, not when it was captured:
- * renaming or pinning must win LWW against the older stored copy, and
- * `createdAt` never moves after the capture.
+ * A version's mtime is when it was last *edited*, not when it was captured.
+ * `engine.sendOne` re-reads the item at push time and sends THIS value, so
+ * returning `createdAt` for a renamed version would push the original capture
+ * time, lose last-write-wins against the copy already stored, and never
+ * converge.
  */
 function toMs(version: DesignVersion): number {
+  const edited = version.updatedAt === undefined ? NaN : Date.parse(version.updatedAt);
+  if (Number.isFinite(edited)) return edited;
   const created = Date.parse(version.createdAt);
   return Number.isFinite(created) ? created : 0;
 }
@@ -77,6 +81,11 @@ function fromItem(item: SyncableItem<DesignVersionPayload>): DesignVersion {
     // thumbnail regenerator fills one in from the params.
     thumbnail: null,
     createdAt: p.createdAt,
+    // The envelope's `modifiedAt` IS the edit time the sender reported, so it
+    // rehydrates `updatedAt` without a second wire field. Without this a pulled
+    // rename would report `createdAt` as its mtime on the next push and the two
+    // devices would trade stale writes forever.
+    updatedAt: new Date(item.modifiedAt).toISOString(),
     origin: toOrigin(p.origin),
     ...(p.pinned ? { pinned: true } : {}),
   };

--- a/src/features/bin-designer/sync/designVersionAdapter.ts
+++ b/src/features/bin-designer/sync/designVersionAdapter.ts
@@ -1,0 +1,117 @@
+import { isOk } from '@/core/result';
+import type {
+  AdapterChange,
+  AdapterChangeListener,
+  DesignVersionAdapter,
+  DesignVersionPayload,
+  SyncableItem,
+} from '@/core/sync/adapters/types';
+import { compressString, decompressString } from '@/shared/utils/compression';
+import type { DesignVersion, DesignVersionOrigin } from '@/features/bin-designer/types';
+import { designId } from '@/core/types';
+import {
+  listAllDesignVersions,
+  getDesignVersionRecord,
+  putRemoteDesignVersion,
+  deleteRemoteDesignVersion,
+} from '@/features/bin-designer/storage/DesignVersionService';
+import { subscribe as subscribeVersionEvents } from './designVersionEvents';
+
+// Lives in features/ for the same reason `designAdapter` does: the record type
+// is feature-internal and core/ cannot import it.
+//
+// The compressed body is the LOCAL representation only. On the wire `content`
+// travels as a plain object so the server can run the designer validator over
+// it, which it cannot do with an opaque LZ string.
+
+const ORIGINS: readonly DesignVersionOrigin[] = ['manual', 'pre-restore'];
+
+function toOrigin(value: unknown): DesignVersionOrigin {
+  return ORIGINS.includes(value as DesignVersionOrigin) ? (value as DesignVersionOrigin) : 'manual';
+}
+
+/**
+ * A version's mtime is when it was last *edited*, not when it was captured:
+ * renaming or pinning must win LWW against the older stored copy, and
+ * `createdAt` never moves after the capture.
+ */
+function toMs(version: DesignVersion): number {
+  const created = Date.parse(version.createdAt);
+  return Number.isFinite(created) ? created : 0;
+}
+
+function toItem(version: DesignVersion): SyncableItem<DesignVersionPayload> | null {
+  const json = decompressString(version.content);
+  // A row whose body will not decompress cannot be validated by the server and
+  // would be rejected on every push forever. Skipping it leaves the local copy
+  // readable in the history list and keeps the outbox from wedging.
+  if (!json) return null;
+  let content: unknown;
+  try {
+    content = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  return {
+    id: version.id,
+    modifiedAt: toMs(version),
+    payload: {
+      designId: version.designId,
+      name: version.name,
+      content,
+      createdAt: version.createdAt,
+      origin: version.origin,
+      ...(version.pinned ? { pinned: true } : {}),
+    },
+  };
+}
+
+function fromItem(item: SyncableItem<DesignVersionPayload>): DesignVersion {
+  const p = item.payload;
+  return {
+    id: item.id,
+    designId: designId(p.designId),
+    name: p.name,
+    content: compressString(JSON.stringify(p.content ?? {})),
+    // Not synced. A pulled version renders a placeholder until the local
+    // thumbnail regenerator fills one in from the params.
+    thumbnail: null,
+    createdAt: p.createdAt,
+    origin: toOrigin(p.origin),
+    ...(p.pinned ? { pinned: true } : {}),
+  };
+}
+
+export const designVersionAdapter: DesignVersionAdapter = {
+  async list(): Promise<SyncableItem<DesignVersionPayload>[]> {
+    const result = await listAllDesignVersions();
+    if (!isOk(result)) return [];
+    return result.value
+      .map(toItem)
+      .filter((item): item is SyncableItem<DesignVersionPayload> => item !== null);
+  },
+
+  async get(id: string): Promise<SyncableItem<DesignVersionPayload> | null> {
+    const result = await getDesignVersionRecord(id);
+    if (!isOk(result) || result.value === null) return null;
+    return toItem(result.value);
+  },
+
+  async applyRemote(item: SyncableItem<DesignVersionPayload>): Promise<void> {
+    await putRemoteDesignVersion(fromItem(item));
+  },
+
+  async applyRemoteDelete(id: string): Promise<void> {
+    await deleteRemoteDesignVersion(id);
+  },
+
+  subscribe(listener: AdapterChangeListener): () => void {
+    return subscribeVersionEvents((event) => {
+      const change: AdapterChange =
+        event.type === 'put'
+          ? { kind: 'put', id: event.id, modifiedAt: event.modifiedAt }
+          : { kind: 'delete', id: event.id, modifiedAt: event.deletedAt };
+      listener(change);
+    });
+  },
+};

--- a/src/features/bin-designer/sync/designVersionEvents.ts
+++ b/src/features/bin-designer/sync/designVersionEvents.ts
@@ -1,0 +1,35 @@
+/**
+ * Local mutation feed for design versions, mirroring `designerEvents`.
+ *
+ * The sync engine cannot watch IndexedDB, so the service announces its own
+ * writes here and the adapter turns them into outbox entries.
+ */
+
+export type DesignVersionEvent =
+  | { type: 'put'; id: string; modifiedAt: number }
+  | { type: 'delete'; id: string; deletedAt: number };
+
+type Listener = (event: DesignVersionEvent) => void;
+
+const listeners = new Set<Listener>();
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function emit(event: DesignVersionEvent): void {
+  for (const listener of listeners) {
+    try {
+      listener(event);
+    } catch {
+      /* one bad subscriber must not block the others or the emitter */
+    }
+  }
+}
+
+export function __resetForTests(): void {
+  listeners.clear();
+}

--- a/src/features/bin-designer/types/designVersion.ts
+++ b/src/features/bin-designer/types/designVersion.ts
@@ -27,8 +27,18 @@ export interface DesignVersion {
    * budget for a value that regenerates locally.
    */
   readonly thumbnail: string | null;
-  /** ISO timestamp, matching `SavedDesign.createdAt`. */
+  /** ISO timestamp of the capture. Never moves after the version is written. */
   readonly createdAt: string;
+  /**
+   * ISO timestamp of the last edit to the version's own metadata (a rename or a
+   * pin). Absent on versions written before the field existed, which read as
+   * never edited.
+   *
+   * Separate from {@link createdAt} because sync compares mtimes: without it a
+   * rename pushes the original capture time, loses last-write-wins against the
+   * copy already on the server, and never converges.
+   */
+  readonly updatedAt?: string;
   /**
    * `'pre-restore'` marks the automatic capture taken immediately before a
    * restore overwrites the working state. Eviction drops these before anything

--- a/src/shared/sync/SyncSessionMount.tsx
+++ b/src/shared/sync/SyncSessionMount.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { layoutAdapter } from '@/core/sync/adapters/layoutAdapter';
 import { designAdapter } from '@/features/bin-designer';
+import { designVersionAdapter } from '@/features/bin-designer/sync/designVersionAdapter';
 import { baseplateAdapter } from '@/features/baseplate/sync/baseplateAdapter';
 import { runClaim, type AccountMismatchChoice } from '@/core/sync/claim';
 import { start, stop } from '@/core/sync/engine';
@@ -29,7 +30,12 @@ export function SyncSessionMount() {
   useSessionLifecycle();
 
   const adapters = useMemo<SyncAdapters>(
-    () => ({ layouts: layoutAdapter, designs: designAdapter, baseplates: baseplateAdapter }),
+    () => ({
+      layouts: layoutAdapter,
+      designs: designAdapter,
+      baseplates: baseplateAdapter,
+      designVersions: designVersionAdapter,
+    }),
     []
   );
 

--- a/src/shared/sync/useDeleteAccountFlow.tsx
+++ b/src/shared/sync/useDeleteAccountFlow.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { layoutAdapter } from '@/core/sync/adapters/layoutAdapter';
 import { designAdapter } from '@/features/bin-designer';
+import { designVersionAdapter } from '@/features/bin-designer/sync/designVersionAdapter';
 import { baseplateAdapter } from '@/features/baseplate/sync/baseplateAdapter';
 import { useSessionStore } from '@/core/sync/session/useSession';
 import {
@@ -10,7 +11,12 @@ import {
 } from '@/core/sync/deleteAccount';
 import { DeleteAccountDialog } from '@/core/sync/dialogs/DeleteAccountDialog';
 
-const ADAPTERS = { layouts: layoutAdapter, designs: designAdapter, baseplates: baseplateAdapter };
+const ADAPTERS = {
+  layouts: layoutAdapter,
+  designs: designAdapter,
+  baseplates: baseplateAdapter,
+  designVersions: designVersionAdapter,
+};
 
 interface DeleteAccountFlow {
   deleteAccount: () => Promise<DeleteAccountResult>;

--- a/src/shared/sync/useSignOutFlow.tsx
+++ b/src/shared/sync/useSignOutFlow.tsx
@@ -6,12 +6,18 @@ import { layoutAdapter } from '@/core/sync/adapters/layoutAdapter';
 // thumbnail helper, which is how three, @react-three/fiber and drei (~1.2 MB) ended
 // up eagerly preloaded. Same reasoning as the Liveblocks note in shared/hooks/index.ts.
 import { designAdapter } from '@/features/bin-designer/sync/designAdapter';
+import { designVersionAdapter } from '@/features/bin-designer/sync/designVersionAdapter';
 import { baseplateAdapter } from '@/features/baseplate/sync/baseplateAdapter';
 import { useSessionStore } from '@/core/sync/session/useSession';
 import { runSignOut, type KeepLocalPromptResult } from '@/core/sync/signOut';
 import { SignOutDialog } from '@/core/sync/dialogs/SignOutDialog';
 
-const ADAPTERS = { layouts: layoutAdapter, designs: designAdapter, baseplates: baseplateAdapter };
+const ADAPTERS = {
+  layouts: layoutAdapter,
+  designs: designAdapter,
+  baseplates: baseplateAdapter,
+  designVersions: designVersionAdapter,
+};
 
 interface SignOutFlow {
   signOut: () => Promise<void>;


### PR DESCRIPTION
Versions landed local-only in #3873, so signing in on a second device showed a design with none of the history that explains it. This adds `designVersions` as a fourth sync kind, end to end.

Part of #3834.

## Design decisions

**`content` travels uncompressed.** Locally a version is an LZ string, but shipping that would hand the server an opaque blob it cannot check, and every other synced payload here is validated before storage. The adapter converts at the boundary, so the same `validateDesignerShare` that guards a design guards a version of one.

**The payload type has no `thumbnail` field at all,** rather than stripping one in the handler. A rendered PNG data URL would consume most of `MAX_PAYLOAD_BYTES`, and it regenerates locally from the params. Making it unrepresentable is what stops a future caller reintroducing it.

**Quota counts differently for this kind.** 100 items, the ceiling every other kind uses, is a handful of designs' history. Versions get 500 items / 25 MB, with the client capping each design at `MAX_VERSIONS_PER_DESIGN` separately. Exceeding the cloud budget is a 413, which already surfaces as the existing quota toast, and the version stays saved locally either way.

## Two latent bugs this turned up

Both came from the same shape: three kinds enumerated by hand with a fallback arm.

- **`engine.ts` built its PUT body with a nested ternary whose fallback was `{ design: ... }`,** so any kind added after `baseplates` would have been posted under the wrong key and silently rejected. It now reads a `PAYLOAD_KEY` lookup, as does the matching envelope-unwrapping in `poller.ts` and `claim.ts`.
- **`signOut.ts` and `claim.ts` destructured exactly three kinds,** so a fourth would have been skipped by the local-item count, the wipe, and the claim merge. Skipping the count is the bad one: it under-reports what "wipe local" is about to destroy. All four now iterate `Object.keys(adapters)`, which is why the manifest types became `Partial<Record<SyncKind, ...>>`.

## Deliberately not included

A per-row "this device only" chip for a version the cloud refused. A 413 already fires `sync.quotaExceeded` and flips global sync status, so nothing is silent; the chip is a refinement of a case that needs 500+ versions to reach.

## Tests

440 across the sync suites, including 13 new endpoint tests (required `designId`/`createdAt`, validator rejection, unknown-origin fallback, thumbnail rejection, LWW 409 and tombstone 410) and 12 adapter tests (uncompressed round-trip, no thumbnail on the wire, remote-apply suppression so a pull cannot echo back as a push).

`api/sync/README.md` grew past its budget documenting a genuinely new endpoint, so its number is raised in the same commit.

https://claude.ai/code/session_01XPj594dK4xWujfQmgFMGTk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

