### PR TITLE
fix(analytics): stop reporting the canvas teardown race as an app error

### DIFF
--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -157,3 +157,69 @@ describe('filterExceptionForPosthog — WebGL context-creation dedupe', () => {
     expect(result?.properties?.$exception_fingerprint).toBeUndefined();
   });
 });
+
+describe('R3F canvas teardown race', () => {
+  const CHROME = "Cannot read properties of null (reading 'addEventListener')";
+  const canvasFrames = [
+    { function: 'Ei' },
+    { function: 'onCreated' },
+    { function: 'Object.connect' },
+  ];
+
+  it('drops the null listener target thrown from the canvas connect path', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [{ value: CHROME, stacktrace: { frames: canvasFrames } }],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBeNull();
+  });
+
+  it('keeps the same message when no connect frame is involved', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          { value: CHROME, stacktrace: { frames: [{ function: 'useMeasureTool' }] } },
+        ],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+
+  it('keeps an unrelated error that happens to run through a connect frame', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          { value: 'TypeError: foo is not a function', stacktrace: { frames: canvasFrames } },
+        ],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+
+  it('matches the WebKit phrasing of the same throw', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          {
+            value: "null is not an object (evaluating 'target.addEventListener')",
+            stacktrace: { frames: canvasFrames },
+          },
+        ],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBeNull();
+  });
+
+  it('keeps the error when frames are absent entirely', () => {
+    const e = {
+      event: '$exception',
+      properties: { $exception_list: [{ value: CHROME }] },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+});

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -65,16 +65,47 @@ export function shouldIgnoreError(
 interface ExceptionEventLike {
   event?: string;
   properties?: {
-    $exception_list?: Array<{ value?: string }>;
+    $exception_list?: Array<{
+      value?: string;
+      stacktrace?: { frames?: Array<{ function?: string }> };
+    }>;
     $exception_values?: string[];
     $exception_fingerprint?: string;
   };
 }
 
 /**
+ * `<Canvas>` kicks off an async `configure()` from a layout effect and neither
+ * awaits it nor cancels it on teardown, so unmounting mid-configure leaves its
+ * `onCreated` to run against a container ref React has already nulled:
+ *
+ *   onCreated: state => state.events.connect?.(… : divRef.current)
+ *
+ * `connect` then calls `addEventListener` on null. The canvas is already gone
+ * by then, so nothing user-visible breaks and no app frame appears in the
+ * stack — switching designs fast is enough to trigger it.
+ *
+ * Matched on the frame as well as the message: an app-side listener attached to
+ * a null target throws the same words, and that one we want to hear about.
+ */
+const NULL_LISTENER_TARGET =
+  /Cannot read propert(?:y|ies) of null \(reading '?addEventListener'?\)|null is not an object \(evaluating '[^']*\.addEventListener'\)/;
+
+function isCanvasTeardownRace(exception: {
+  value?: string;
+  stacktrace?: { frames?: Array<{ function?: string }> };
+}): boolean {
+  if (!exception.value || !NULL_LISTENER_TARGET.test(exception.value)) return false;
+  // `connect` and `onCreated` are property names on object literals, so they
+  // survive minification where the surrounding function names do not.
+  return (exception.stacktrace?.frames ?? []).some((f) => f.function?.endsWith('connect') === true);
+}
+
+/**
  * PostHog `before_send` hook. Drops `$exception` events whose **primary**
- * exception matches the extension/noise filters, dedupes the WebGL
- * context-creation burst, and passes everything else through unchanged.
+ * exception matches the extension/noise filters or the R3F canvas teardown
+ * race, dedupes the WebGL context-creation burst, and passes everything else
+ * through unchanged.
  *
  * Only the first entry in `$exception_list` / `$exception_values` is
  * checked. Subsequent entries are `Error.cause` chains — if a real app
@@ -98,9 +129,10 @@ export function filterExceptionForPosthog(
 ): ExceptionEventLike | null {
   if (!event) return event;
   if (event.event !== '$exception') return event;
-  const primary =
-    event.properties?.$exception_list?.[0]?.value ?? event.properties?.$exception_values?.[0];
+  const primaryException = event.properties?.$exception_list?.[0];
+  const primary = primaryException?.value ?? event.properties?.$exception_values?.[0];
   if (shouldIgnoreError(primary)) return null;
+  if (primaryException && isCanvasTeardownRace(primaryException)) return null;
 
   if (primary?.includes(WEBGL_CONTEXT_ERROR)) {
     // Detection already unavailable → the boundary handled this and we've


### PR DESCRIPTION
Closes #3884.

## What is actually throwing

`<Canvas>` starts an async `configure()` from a layout effect, and neither awaits it nor cancels it on teardown:

```js
useIsomorphicLayoutEffect(() => {
  ...
  async function run() {
    await root.current.configure({ ..., onCreated: state => {
      state.events.connect?.(eventSource ? ... : divRef.current)
    }})
    root.current.render(...)
  }
  run()          // fire-and-forget, no cleanup
})
```

Unmount during that await nulls `divRef.current`, then `onCreated` fires and `connect` calls `addEventListener` on null.

The reported stack says exactly this, innermost last:

```
Ei → Wi → Ki → Ur → ti → Ur → kr → ? → onCreated → Object.connect
```

`Object.connect` is the throw site. `connect` and `onCreated` are property names on object literals, which is why they survive minification while everything around them is mangled.

## Why it is filtered rather than fixed

The race is inside the Canvas lifecycle. No app code appears in the stack, and 9.7.0 is the current release, so there is no version to move to. It also fires strictly after teardown, so nothing user-visible breaks: the canvas being connected is already gone. The two reporters were switching between designs (`?id=design_…` differs across samples), which remounts the canvas fast enough to lose the race.

Left alone it reads as an unhandled app error, and it is counted twice, because the app installs its own `window.onerror` handler alongside `capture_exceptions: true`. Both copies route through `posthog.captureException`, so `before_send` drops both.

## Scope of the match

Message **and** stack, not message alone. An app-side listener attached to a null target throws the same words and still reports:

| case | kept? |
| --- | --- |
| null listener target, `connect` frame present | dropped |
| same message, `useMeasureTool` frame | kept |
| unrelated TypeError through a `connect` frame | kept |
| same message, no frames at all | kept |
| WebKit phrasing, `connect` frame present | dropped |

## Not in this PR

The duplicate capture noted above is a separate defect: every unhandled error is recorded twice, which inflates occurrence counts on every error issue. Worth its own change.

https://claude.ai/code/session_01GQpQ2MpszCnpWHht3g6Bau

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

