### PR TITLE
fix(shell): keep a failed background mount from taking the app down

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import { DragPreview } from '@/shell/DragPreview';
 import { ToastContainer } from '@/shared/components/Toast';
 import { LoadingFallback } from '@/shared/components/LoadingFallback';
 import { PanelErrorBoundary } from '@/shell/PanelErrorBoundary';
+import { BackgroundMountBoundary } from '@/shell/BackgroundMountBoundary';
 import { BinContextMenuWrapper } from '@/shell/Mobile/BinContextMenuWrapper';
 import { TabletPanelOverlay, TabletPanelTriggers } from '@/shell/Tablet';
 import { LiveRegion } from '@/shell/LiveRegion';
@@ -392,11 +393,15 @@ export default function App() {
         <Suspense fallback={null}>
           <DesignLinkingDialogs />
         </Suspense>
-        {/* Own boundary so planner baseplate resolution isn't gated on the
-            unrelated design-linking chunk loading. */}
-        <Suspense fallback={null}>
-          <BaseplateLibraryInitMount />
-        </Suspense>
+        {/* Own Suspense so planner baseplate resolution isn't gated on the
+            unrelated design-linking chunk loading, and its own boundary so a
+            chunk that never arrives costs the margin resolution rather than
+            the app. */}
+        <BackgroundMountBoundary mountName="BaseplateLibraryInitMount">
+          <Suspense fallback={null}>
+            <BaseplateLibraryInitMount />
+          </Suspense>
+        </BackgroundMountBoundary>
       </>
     );
     if (isCollaborative && shareId) {
@@ -539,9 +544,11 @@ export default function App() {
           })()}
 
           {hasShareUrl && (
-            <Suspense fallback={null}>
-              <SharedLayoutImporter />
-            </Suspense>
+            <BackgroundMountBoundary mountName="SharedLayoutImporter">
+              <Suspense fallback={null}>
+                <SharedLayoutImporter />
+              </Suspense>
+            </BackgroundMountBoundary>
           )}
         </div>
       );
@@ -611,9 +618,11 @@ export default function App() {
 
         {/* Shared layout URL importer - only load when URL has share params */}
         {hasShareUrl && (
-          <Suspense fallback={null}>
-            <SharedLayoutImporter />
-          </Suspense>
+          <BackgroundMountBoundary mountName="SharedLayoutImporter">
+            <Suspense fallback={null}>
+              <SharedLayoutImporter />
+            </Suspense>
+          </BackgroundMountBoundary>
         )}
       </div>
     );
@@ -641,9 +650,11 @@ export default function App() {
       <DesignStoreRegistration />
       <LinkedRiseRegistration />
       {cloudSyncEnabled && (
-        <Suspense fallback={null}>
-          <LazySyncSessionMount />
-        </Suspense>
+        <BackgroundMountBoundary mountName="SyncSessionMount">
+          <Suspense fallback={null}>
+            <LazySyncSessionMount />
+          </Suspense>
+        </BackgroundMountBoundary>
       )}
       {routeContent}
       <ToastContainer />

--- a/src/shell/BackgroundMountBoundary/BackgroundMountBoundary.test.tsx
+++ b/src/shell/BackgroundMountBoundary/BackgroundMountBoundary.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { captureException } from '@/shared/analytics/posthog';
+import { BackgroundMountBoundary } from './BackgroundMountBoundary';
+
+vi.mock('@/shared/analytics/posthog', () => ({
+  captureException: vi.fn(),
+}));
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('error loading dynamically imported module: /assets/x.js');
+  return <div>side effect ran</div>;
+}
+
+describe('BackgroundMountBoundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders children when the mount loads', () => {
+    render(
+      <BackgroundMountBoundary mountName="BaseplateLibraryInitMount">
+        <ThrowingChild shouldThrow={false} />
+      </BackgroundMountBoundary>
+    );
+    expect(screen.getByText('side effect ran')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the chunk fails, rather than propagating to the root', () => {
+    const { container } = render(
+      <BackgroundMountBoundary mountName="BaseplateLibraryInitMount">
+        <ThrowingChild shouldThrow={true} />
+      </BackgroundMountBoundary>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('keeps the surrounding app mounted', () => {
+    render(
+      <div>
+        <BackgroundMountBoundary mountName="SyncSessionMount">
+          <ThrowingChild shouldThrow={true} />
+        </BackgroundMountBoundary>
+        <span>app still here</span>
+      </div>
+    );
+    expect(screen.getByText('app still here')).toBeInTheDocument();
+  });
+
+  it('reports under its own boundary tag so it is not read as a root crash', () => {
+    render(
+      <BackgroundMountBoundary mountName="SharedLayoutImporter">
+        <ThrowingChild shouldThrow={true} />
+      </BackgroundMountBoundary>
+    );
+    expect(captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ boundary: 'background-mount', mountName: 'SharedLayoutImporter' })
+    );
+  });
+});

--- a/src/shell/BackgroundMountBoundary/BackgroundMountBoundary.tsx
+++ b/src/shell/BackgroundMountBoundary/BackgroundMountBoundary.tsx
@@ -1,0 +1,53 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { captureException } from '@/shared/analytics/posthog';
+
+interface Props {
+  children: ReactNode;
+  /** Which mount this guards, for telemetry. */
+  readonly mountName: string;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * Contains a failure in a lazy mount that renders no UI of its own.
+ *
+ * `<Suspense>` isolates such a mount while its chunk LOADS, but not if the
+ * chunk never arrives: a rejected import propagates past Suspense to the
+ * nearest error boundary, which for these mounts was the root one. So a
+ * stale-deploy chunk miss on an invisible side-effect mount took the whole app
+ * down with it, including for someone opening a shared layout link.
+ *
+ * Renders nothing on failure, matching what these mounts render when they
+ * work, so the app degrades by losing that one side effect rather than
+ * crashing. Still reports, under its own `boundary` tag so it stays
+ * distinguishable from a real root crash.
+ *
+ * Only for mounts whose output is `null`. Anything the user is meant to see
+ * belongs in {@link PanelErrorBoundary}, which offers a retry.
+ */
+export class BackgroundMountBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    captureException(error, {
+      boundary: 'background-mount',
+      mountName: this.props.mountName,
+      componentStack: errorInfo.componentStack,
+    });
+  }
+
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}

--- a/src/shell/BackgroundMountBoundary/index.ts
+++ b/src/shell/BackgroundMountBoundary/index.ts
@@ -1,0 +1,1 @@
+export { BackgroundMountBoundary } from './BackgroundMountBoundary';


### PR DESCRIPTION
Closes #3886.

## What happened

A user opening a shared layout link (`/l/zqYf2dsSpwkm/untitled-layout`) got the root crash screen because a chunk failed to load:

```
error loading dynamically imported module: .../assets/BaseplateLibraryInitMount-gens7flb.js
```

`BaseplateLibraryInitMount` renders `null`. It exists only to run `useBaseplateLibraryInit`. Losing it should cost the planner's drawer-margin resolution, not the session. PostHog recorded it as `boundary: root`, so the app really did come down.

## Why Suspense wasn't enough

Three mounts render nothing and exist only for their side effects, each in a bare `<Suspense fallback={null}>`:

| mount | side effect |
| --- | --- |
| `BaseplateLibraryInitMount` | baseplate library resolver |
| `SyncSessionMount` | cloud sync session |
| `SharedLayoutImporter` | share-URL import (two mount sites) |

Suspense isolates a mount while its chunk **loads**. It does nothing if the chunk never arrives: a rejected import propagates past Suspense to the nearest error boundary, which was the root one.

The existing comment on the baseplate mount says "Own boundary so planner baseplate resolution isn't gated on the unrelated design-linking chunk loading". That was true of loading and not of failure, which is exactly the gap.

`lazyWithRetry` narrows the window but cannot close it: after two retries it reloads once per session, and a second miss in the same session rethrows. That rethrow is what landed here.

## The fix

`BackgroundMountBoundary` renders nothing on failure, which is what these mounts render when they work, so the app degrades by losing one side effect. It still reports, under `boundary: 'background-mount'` with a `mountName`, so these stay separable from a real root crash instead of being silently swallowed.

Deliberately not `PanelErrorBoundary`: that renders a visible message and a retry button, which would inject a UI box where the mount contributes none.

## Tests

Children render normally; a throwing child yields an empty container rather than propagating; sibling content stays mounted; the report carries the distinguishing boundary tag.

https://claude.ai/code/session_01GQpQ2MpszCnpWHht3g6Bau

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

