### PR TITLE
fix(analytics): capture each unhandled error once

### DIFF
--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -223,3 +223,54 @@ describe('R3F canvas teardown race', () => {
     expect(filterExceptionForPosthog(e)).toBe(e);
   });
 });
+
+describe('extension-sourced exceptions', () => {
+  it('drops a throw whose frames come from an extension script', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          {
+            value: 'TypeError: chrome.runtime is undefined',
+            stacktrace: {
+              frames: [
+                { function: 'x', filename: 'https://gridfinitylayouttool.com/assets/main.js' },
+                { function: 'y', filename: 'chrome-extension://abcdef/content.js' },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBeNull();
+  });
+
+  it('keeps a throw whose frames are all first-party', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          {
+            value: 'TypeError: cannot read x',
+            stacktrace: {
+              frames: [
+                { function: 'x', filename: 'https://gridfinitylayouttool.com/assets/main.js' },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+
+  it('keeps a throw with no frame filenames', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [{ value: 'TypeError: cannot read x', stacktrace: { frames: [{}] } }],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+});

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -62,16 +62,32 @@ export function shouldIgnoreError(
   return false;
 }
 
+interface ExceptionLike {
+  value?: string;
+  stacktrace?: { frames?: Array<{ function?: string; filename?: string }> };
+}
+
 interface ExceptionEventLike {
   event?: string;
   properties?: {
-    $exception_list?: Array<{
-      value?: string;
-      stacktrace?: { frames?: Array<{ function?: string }> };
-    }>;
+    $exception_list?: ExceptionLike[];
     $exception_values?: string[];
     $exception_fingerprint?: string;
+    [key: string]: unknown;
   };
+}
+
+/**
+ * True when the throw came out of an injected extension script.
+ *
+ * The source check used to run on `ErrorEvent.filename` in a `window.onerror`
+ * handler. posthog-js captures these natively too, and that path only ever sees
+ * stack frames, so the frames are where the origin has to be read from now.
+ */
+function isExtensionSourced(exception: ExceptionLike): boolean {
+  return (exception.stacktrace?.frames ?? []).some(
+    (f) => f.filename !== undefined && shouldIgnoreError(undefined, f.filename)
+  );
 }
 
 /**
@@ -91,10 +107,7 @@ interface ExceptionEventLike {
 const NULL_LISTENER_TARGET =
   /Cannot read propert(?:y|ies) of null \(reading '?addEventListener'?\)|null is not an object \(evaluating '[^']*\.addEventListener'\)/;
 
-function isCanvasTeardownRace(exception: {
-  value?: string;
-  stacktrace?: { frames?: Array<{ function?: string }> };
-}): boolean {
+function isCanvasTeardownRace(exception: ExceptionLike): boolean {
   if (!exception.value || !NULL_LISTENER_TARGET.test(exception.value)) return false;
   // `connect` and `onCreated` are property names on object literals, so they
   // survive minification where the surrounding function names do not.
@@ -132,6 +145,7 @@ export function filterExceptionForPosthog(
   const primaryException = event.properties?.$exception_list?.[0];
   const primary = primaryException?.value ?? event.properties?.$exception_values?.[0];
   if (shouldIgnoreError(primary)) return null;
+  if (primaryException && isExtensionSourced(primaryException)) return null;
   if (primaryException && isCanvasTeardownRace(primaryException)) return null;
 
   if (primary?.includes(WEBGL_CONTEXT_ERROR)) {

--- a/src/shared/analytics/posthog/events.ts
+++ b/src/shared/analytics/posthog/events.ts
@@ -44,6 +44,7 @@ export {
 export { computeEngagementTier, updatePersonProperties, markFeatureUsed } from './eventsPerson';
 export {
   captureException,
+  getLayoutContext,
   trackLayoutSaveFailure,
   trackShareFailure,
   track3DRenderError,

--- a/src/shared/analytics/posthog/eventsErrors.ts
+++ b/src/shared/analytics/posthog/eventsErrors.ts
@@ -16,8 +16,11 @@ import { getDeviceType, trackEvent } from './trackEvent';
 /**
  * Get current layout context for error enrichment.
  * This helps debug errors by showing what the user was doing.
+ *
+ * Exported so `before_send` can attach it to exceptions posthog-js captures
+ * natively, which never pass through {@link captureException}.
  */
-function getLayoutContext(): Record<string, unknown> {
+export function getLayoutContext(): Record<string, unknown> {
   try {
     const layout = useLayoutStore.getState().layout;
     const { interaction } = useInteractionStore.getState();

--- a/src/shared/analytics/posthog/init.ts
+++ b/src/shared/analytics/posthog/init.ts
@@ -6,15 +6,21 @@
 import type { PostHog } from 'posthog-js';
 import { useSettingsStore } from '@/core/store/settings';
 import { getStableUserId } from './identity';
-import { filterExceptionForPosthog, shouldIgnoreError } from './errorFilters';
+import { filterExceptionForPosthog } from './errorFilters';
 
 // INITIALIZATION (LAZY LOADED)
 
 let posthogInstance: PostHog | null = null;
 let initPromise: Promise<void> | null = null;
 let eventQueue: Array<{ name: string; properties: Record<string, unknown> }> = [];
-/** Re-entrancy guard: prevents infinite loops if captureException itself throws */
-let isCapturingGlobalError = false;
+/**
+ * Supplies layout context to natively-captured exceptions.
+ *
+ * Assigned once `./events` has loaded. Held as a reference rather than imported
+ * because `eventsErrors` imports `getPosthogInstance` from this module, and a
+ * static import back would close that cycle.
+ */
+let getExceptionContext: (() => Record<string, unknown>) | null = null;
 
 /**
  * Get the PostHog instance (for modules that need direct access).
@@ -58,11 +64,19 @@ export function initAnalytics(): void {
         // Performance monitoring - web vitals
         capture_performance: true,
 
-        // Drop extension/platform noise before it ships. Native capture_exceptions
-        // fires independently of our window.onerror handler, so this is the only
-        // place we can filter that path. CaptureResult is a structural superset
+        // The single place exceptions are filtered and enriched. Every capture
+        // path passes through here, native or explicit, so nothing needs a
+        // second handler to add context. CaptureResult is a structural superset
         // of the shape filterExceptionForPosthog reads.
-        before_send: (event) => filterExceptionForPosthog(event) as typeof event,
+        before_send: (event) => {
+          const kept = filterExceptionForPosthog(event);
+          if (kept?.event === '$exception' && getExceptionContext) {
+            // Explicit context wins: `captureException` callers pass details
+            // about the specific failure that the ambient layout can't know.
+            kept.properties = { ...getExceptionContext(), ...kept.properties };
+          }
+          return kept as typeof event;
+        },
       });
       posthogInstance = posthog;
 
@@ -75,15 +89,15 @@ export function initAnalytics(): void {
 
       // Set person properties (these persist across sessions)
       // Deferred import to avoid circular dependency: events.ts imports capture from init.ts.
-      // This makes the .then() callback async, which means error handlers below are installed
-      // after this await resolves. PostHog's capture_exceptions: true provides native coverage
-      // during that brief gap, so no errors are lost.
       const {
         updatePersonProperties,
-        captureException,
+        getLayoutContext,
         listenForPwaInstall,
         captureUtmParameters,
       } = await import('./events');
+      // Exceptions thrown before this resolves are still captured, just without
+      // the layout context `before_send` attaches once this is set.
+      getExceptionContext = getLayoutContext;
       updatePersonProperties();
       captureUtmParameters();
       listenForPwaInstall();
@@ -93,45 +107,6 @@ export function initAnalytics(): void {
         posthog.capture(event.name, event.properties);
       }
       eventQueue = [];
-
-      // Install global error handlers for structured exception capture.
-      // PostHog's auto-capture sends raw browser events with null message/type.
-      // These handlers intercept errors first and send structured data.
-      // A re-entrancy guard prevents infinite loops if captureException itself throws.
-      window.addEventListener('error', (event: ErrorEvent) => {
-        if (isCapturingGlobalError) return;
-        if (shouldIgnoreError(event.message, event.filename)) return;
-        isCapturingGlobalError = true;
-        try {
-          if (event.error instanceof Error) {
-            captureException(event.error, {
-              source: 'window.onerror',
-              file: event.filename,
-              line: event.lineno,
-              column: event.colno,
-            });
-          }
-        } finally {
-          isCapturingGlobalError = false;
-        }
-      });
-
-      window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
-        if (isCapturingGlobalError) return;
-        const reasonMsg =
-          event.reason instanceof Error ? event.reason.message : String(event.reason);
-        if (shouldIgnoreError(reasonMsg)) return;
-        isCapturingGlobalError = true;
-        try {
-          const error =
-            event.reason instanceof Error ? event.reason : new Error(String(event.reason));
-          captureException(error, {
-            source: 'unhandledrejection',
-          });
-        } finally {
-          isCapturingGlobalError = false;
-        }
-      });
     })
     .catch(() => {
       // Fail silently


### PR DESCRIPTION
Every unhandled error was recorded twice.

`posthog.init` sets `capture_exceptions: true`, which captures unhandled errors natively. Alongside it, a `window.onerror` / `unhandledrejection` pair captured the same error again through `captureException`. Both landed about a millisecond apart:

```
15:38:45.762  handled=true   ← window.onerror
15:38:45.763  handled=false  ← native capture_exceptions
```

Same fingerprint, same message. Occurrence counts on every error issue read roughly double what happened. #3884 reported "8 occurrences" for what were 4 errors.

## Which copy to keep

The handlers carried this justification:

> PostHog's auto-capture sends raw browser events with null message/type. These handlers intercept errors first and send structured data.

That no longer holds. The native copy arrives with parsed stack frames and a populated `$exception_values`, verified against the production events behind #3884. Nor did the handlers "intercept" anything: both paths fired, neither suppressed the other.

What the duplicate did still contribute was `handled: true` on errors nobody handled, which understates them against genuinely caught ones.

So the native path stays. It reports `handled` truthfully, and it already covered the window before `./events` resolves, which the handlers could not.

## What moved rather than disappeared

Both of the handlers' real jobs now happen in `before_send`, which every capture path passes through:

| was | now |
| --- | --- |
| layout context, only on explicit captures | attached to every `$exception`, native included |
| extension filtering on `ErrorEvent.filename` | matched on stack frames, which the native path actually has |

The second matters: `filename` is something only an `ErrorEvent` has, so leaving that check where it was would have stopped filtering extension noise entirely once the handler was gone.

Layout context is spread first so explicit `captureException` context wins, since callers there know details about the specific failure that the ambient layout cannot.

`getLayoutContext` is passed as a reference rather than imported, because `eventsErrors` imports `getPosthogInstance` from `init` and a static import back would close that cycle.

## Unchanged

`captureException` keeps all its callers. An error an ErrorBoundary catches genuinely is handled, and continues to say so.

https://claude.ai/code/session_01GQpQ2MpszCnpWHht3g6Bau

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

