### PR TITLE
feat(bin-designer): give a label caption a second line

### DIFF
--- a/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.test.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.test.tsx
@@ -93,7 +93,7 @@ describe('CompartmentTextInput', () => {
 });
 
 describe('CompartmentTextInput multiline', () => {
-  it('is a single-line field by default, so a tab caption stays one line', () => {
+  it('is a single-line field unless multiline is asked for', () => {
     render(
       <CompartmentTextInput
         committedValue=""
@@ -138,6 +138,94 @@ describe('CompartmentTextInput multiline', () => {
     const event = createEvent.keyDown(field, { key: 'Enter' });
     fireEvent(field, event);
     expect(event.defaultPrevented).toBe(true);
+  });
+
+  describe('inside a list, where Enter already means the next row', () => {
+    function listRow(committedValue = '') {
+      const onNavigate = vi.fn();
+      const onCommit = vi.fn();
+      render(
+        <CompartmentTextInput
+          multiline
+          minRows={1}
+          committedValue={committedValue}
+          compartmentId={0}
+          placeholder="p"
+          ariaLabel="caption"
+          onCommit={onCommit}
+          onNavigate={onNavigate}
+        />
+      );
+      const field: HTMLTextAreaElement = screen.getByRole('textbox', { name: 'caption' });
+      return { field, onNavigate, onCommit };
+    }
+
+    it('keeps Enter moving to the next row rather than breaking the line', () => {
+      const { field, onNavigate } = listRow('5/16 x 3-1/4');
+      const event = createEvent.keyDown(field, { key: 'Enter' });
+      fireEvent(field, event);
+      expect(event.defaultPrevented).toBe(true);
+      expect(onNavigate).toHaveBeenCalledWith('next');
+    });
+
+    it('gives the line break to Shift+Enter instead', () => {
+      const { field, onNavigate } = listRow('5/16 x 3-1/4');
+      const event = createEvent.keyDown(field, { key: 'Enter', shiftKey: true });
+      fireEvent(field, event);
+      expect(event.defaultPrevented).toBe(false);
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it('still swallows Shift+Enter at the line cap', () => {
+      const { field } = listRow('a\nb\nc');
+      const event = createEvent.keyDown(field, { key: 'Enter', shiftKey: true });
+      fireEvent(field, event);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('leaves the row when the caret has no line to move onto', () => {
+      const { field, onNavigate } = listRow('Grade 8');
+      field.setSelectionRange(3, 3);
+      const event = createEvent.keyDown(field, { key: 'ArrowDown' });
+      fireEvent(field, event);
+      expect(event.defaultPrevented).toBe(true);
+      expect(onNavigate).toHaveBeenCalledWith('next');
+    });
+
+    it('walks the caret instead when the caption has a line below', () => {
+      const { field, onNavigate } = listRow('5/16 x 3-1/4\nGrade 8');
+      field.setSelectionRange(3, 3);
+      const event = createEvent.keyDown(field, { key: 'ArrowDown' });
+      fireEvent(field, event);
+      expect(event.defaultPrevented).toBe(false);
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it('walks the caret up when the caption has a line above', () => {
+      const { field, onNavigate } = listRow('5/16 x 3-1/4\nGrade 8');
+      field.setSelectionRange(15, 15);
+      const event = createEvent.keyDown(field, { key: 'ArrowUp' });
+      fireEvent(field, event);
+      expect(event.defaultPrevented).toBe(false);
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  it('leaves Enter breaking the line in a standalone field, which has no rows', () => {
+    render(
+      <CompartmentTextInput
+        multiline
+        committedValue="Heading"
+        compartmentId={0}
+        placeholder="p"
+        ariaLabel="caption"
+        onCommit={vi.fn()}
+      />
+    );
+    const field = screen.getByRole('textbox', { name: 'caption' });
+    const event = createEvent.keyDown(field, { key: 'Enter' });
+    fireEvent(field, event);
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it('normalises a paste on the way in, so the field shows what will be stored', () => {

--- a/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/CompartmentTextInput.tsx
@@ -52,13 +52,14 @@ interface CompartmentTextInputProps {
   /**
    * Accept line breaks, up to {@link TEXT_MAX_LINES}.
    *
-   * Opt-in rather than the default because the two callers want different
-   * things: a compartment caption is one line on a small tab, while a wall or
-   * lid caption can carry a heading and a subheading (lines after the first
-   * render at `lineScale`). Without this the second line is unreachable, and a
-   * knob nobody can produce input for is worse than no knob.
+   * Opt-in rather than the default because it changes what Enter means. With
+   * {@link onNavigate} set the field is one row of a list, so Enter keeps moving
+   * between rows and Shift+Enter takes the line break; a standalone wall or lid
+   * caption has nowhere to navigate, so Enter breaks the line directly.
    */
   readonly multiline?: boolean;
+  /** Rows to show before the caption has grown into them. */
+  readonly minRows?: number;
 }
 
 export function CompartmentTextInput({
@@ -72,6 +73,7 @@ export function CompartmentTextInput({
   invalid = false,
   describedBy,
   multiline = false,
+  minRows = 2,
 }: CompartmentTextInputProps) {
   const [draft, setDraft] = useState(committedValue);
   const focusedRef = useRef(false);
@@ -152,15 +154,41 @@ export function CompartmentTextInput({
     field?.select();
   }, [focusToken, multiline]);
 
-  // Enter adds a line rather than committing, but only while one is left in the
-  // budget: swallowing it at the cap is what stops a paste-and-hold from
-  // silently losing the tail to the normaliser.
+  // In a list, Enter stays row navigation. Filling captions one after another is
+  // the common case and losing it would cost more than a second line is worth,
+  // so the line break moves to Shift+Enter. A standalone field has no rows to
+  // move between, so there Enter breaks the line as it always did.
+  //
+  // Enter is swallowed at the cap rather than passed through: that is what stops
+  // a paste-and-hold from silently losing the tail to the normaliser.
   const handleAreaKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key !== 'Enter') return;
-      if (draft.split('\n').length >= TEXT_MAX_LINES) e.preventDefault();
+      if (e.key === 'Enter') {
+        if (onNavigate && !e.shiftKey) {
+          e.preventDefault();
+          clearIdleTimer();
+          commit(draft);
+          onNavigate('next');
+          return;
+        }
+        if (draft.split('\n').length >= TEXT_MAX_LINES) e.preventDefault();
+        return;
+      }
+      if (!onNavigate || (e.key !== 'ArrowUp' && e.key !== 'ArrowDown')) return;
+      // Leave the field only from its outer edges, so the arrows still walk the
+      // caret through a caption that has grown a second line.
+      const el = e.currentTarget;
+      const leaving =
+        e.key === 'ArrowUp'
+          ? !el.value.slice(0, el.selectionStart).includes('\n')
+          : !el.value.slice(el.selectionEnd).includes('\n');
+      if (!leaving) return;
+      e.preventDefault();
+      clearIdleTimer();
+      commit(draft);
+      onNavigate(e.key === 'ArrowUp' ? 'prev' : 'next');
     },
-    [draft]
+    [draft, onNavigate, clearIdleTimer, commit]
   );
 
   // Normalising on the way in keeps the field showing exactly what will be
@@ -179,7 +207,9 @@ export function CompartmentTextInput({
     return (
       <Textarea
         ref={areaRef}
-        rows={2}
+        // Grows with the caption so a list of one-line labels keeps the height
+        // it had as a single-line field.
+        rows={Math.min(TEXT_MAX_LINES, Math.max(minRows, draft.split('\n').length))}
         resize="none"
         value={draft}
         maxLength={TEXT_MAX_TOTAL_LENGTH}

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTextList.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTextList.tsx
@@ -224,6 +224,8 @@ export function LabelTextList({
                 )}
                 <div className={`min-w-0 flex-1 ${filled && !row.overflows ? 'opacity-70' : ''}`}>
                   <CompartmentTextInput
+                    multiline
+                    minRows={1}
                     committedValue={row.value}
                     compartmentId={row.index}
                     onCommit={onCommit}

--- a/src/features/generation/worker/generators/labelPlateBuilder.test.ts
+++ b/src/features/generation/worker/generators/labelPlateBuilder.test.ts
@@ -17,6 +17,7 @@ import {
   buildLabelPlate,
   buildLabelPlates,
   exportLabelPlates,
+  resolveUniformPlateTextSize,
   TEXT_BAND_MM,
 } from './labelPlateBuilder';
 import type { LabelPlateBuildOptions } from './labelPlateBuilder';
@@ -325,5 +326,54 @@ describe('labelPlateBuilder', () => {
   it('emits no TEXT face groups for blank plates', async () => {
     const { faceGroups } = await exportLabelPlates([{ widthU: 1, text: '' }], OPTS, 'stl');
     expect((faceGroups ?? []).some((g) => g.tag === FeatureTag.TEXT)).toBe(false);
+  });
+});
+
+describe('two-line captions', () => {
+  // A debossed plate drops its v1 channels, so a blank plate carrying them is
+  // not the baseline. Compare against a blank built the same way.
+  const NO_CHANNELS: LabelPlateBuildOptions = { ...OPTS, v1Channels: false };
+  const blankVol = (): number => volOf(buildLabelPlate({ widthU: 1, text: '' }, NO_CHANNELS));
+
+  it('engraves a caption the plate is too narrow to hold on one line', () => {
+    // The reported case: a fastener label that overruns a 1U plate. Before
+    // wrapping was allowed this shipped a blank plate.
+    const engraved = volOf(
+      buildLabelPlate({ widthU: 1, text: '5/16 x 3-1/4 Grade 8' }, NO_CHANNELS)
+    );
+    expect(engraved).toBeLessThan(blankVol());
+  });
+
+  it('honours an authored break rather than choosing its own', () => {
+    const wrapped = volOf(
+      buildLabelPlate({ widthU: 1, text: '5/16 x 3-1/4 Grade 8' }, NO_CHANNELS)
+    );
+    const authored = volOf(
+      buildLabelPlate({ widthU: 1, text: '5/16 x 3-1/4\nGrade 8' }, NO_CHANNELS)
+    );
+    expect(authored).toBeLessThan(blankVol());
+    // Different break points put different glyphs on different lines at
+    // different sizes, so the two cannot carve the same volume.
+    expect(authored).not.toBeCloseTo(wrapped, 3);
+  });
+
+  it('keeps the caption inside the plate footprint', () => {
+    const solid = buildLabelPlate({ widthU: 1, text: '5/16 x 3-1/4\nGrade 8' }, NO_CHANNELS);
+    const m = mesh(solid, { tolerance: 0.01, angularTolerance: 5, cache: false });
+    const bbox = boundingBox(new Float32Array(m.vertices));
+    expect(bbox.maxX - bbox.minX).toBeCloseTo(labelPlateWidthMm(1), 1);
+    expect(bbox.maxY - bbox.minY).toBeCloseTo(LABEL_PLATE_HEIGHT_MM, 1);
+    expect(bbox.maxZ - bbox.minZ).toBeCloseTo(LABEL_PLATE_THICKNESS_MM, 1);
+  });
+
+  it('does not let one two-line plate shrink the rest of the set', () => {
+    const singles = [
+      { widthU: 1 as const, text: 'M3 NUTS' },
+      { widthU: 1 as const, text: 'M4 BOLTS' },
+    ];
+    const withTwoLine = [...singles, { widthU: 1 as const, text: '5/16 x 3-1/4\nGrade 8' }];
+    expect(resolveUniformPlateTextSize(withTwoLine, OPTS)).toBe(
+      resolveUniformPlateTextSize(singles, OPTS)
+    );
   });
 });

--- a/src/features/generation/worker/generators/labelPlateBuilder.ts
+++ b/src/features/generation/worker/generators/labelPlateBuilder.ts
@@ -44,6 +44,7 @@ import {
   labelPlateWidthMm,
 } from '@/shared/constants/labelPlates';
 import type { LabelPlateIconId, LabelPlateWidthU } from '@/shared/constants/labelPlates';
+import { splitTextLines } from '@/shared/types/bin';
 import type { TextStyleDefaults } from '@/shared/types/bin';
 import type { ExportFormat, FaceGroupData } from '../../bridge/types';
 import { COPLANAR_MARGIN } from './generatorConstants';
@@ -150,7 +151,6 @@ export function plateTextFits(spec: LabelPlateSpec, opts: LabelPlateBuildOptions
       style: plateTextStyle(opts),
       availW: plateTextHostWidthMm(spec.widthU, spec.icon),
       availD: TEXT_BAND_MM,
-      allowWrap: false,
     }) !== null
   );
 }
@@ -225,10 +225,16 @@ function plateTextMode(opts: LabelPlateBuildOptions): 'emboss' | 'engrave' {
  * down.
  *
  * Under the cap-height datum the vertical box is a constant of the face and
- * size, so every caption in a set now resolves to the SAME value here and this
- * pass reads as a no-op. It is kept because it is the thing that states the
- * intent: a set shares one size. Were the band or the face ever to vary per
- * plate, this is where that would be resolved rather than discovered.
+ * size, so every single-line caption in a set resolves to the SAME value here
+ * and this pass reads as a no-op. It is kept because it is the thing that
+ * states the intent: a set shares one size. Were the band or the face ever to
+ * vary per plate, this is where that would be resolved rather than discovered.
+ *
+ * Multi-line captions sit out. Two lines genuinely need a smaller size in the
+ * shared band, so folding one in would shrink every other plate in the set to
+ * match it — the same "drags the others down" the width axis is kept out for.
+ * They auto-fit alone instead, which lands them on a common size anyway
+ * whenever they share a line count.
  *
  * `undefined` when no plate carries text, leaving per-plate auto-fit.
  */
@@ -239,6 +245,7 @@ export function resolveUniformPlateTextSize(
   let smallest = Number.POSITIVE_INFINITY;
   for (const spec of specs) {
     if (!spec.text.trim()) continue;
+    if (splitTextLines(spec.text).length > 1) continue;
     const fitted = fitTextSize({
       text: spec.text,
       style: plateTextStyle(opts),
@@ -394,9 +401,6 @@ export function buildLabelPlate(
         topZ: t,
         depth: opts.textDepthMm,
         hostThickness: t,
-        // A plate caption is one field on a fixed-format part; a second line
-        // has nowhere to go beside the icon.
-        allowWrap: false,
         ...(uniformTextSize !== undefined ? { sharedSizeMm: uniformTextSize } : {}),
         hostKind: 'plaque',
       });

--- a/src/features/generation/worker/generators/labelTextFit.test.ts
+++ b/src/features/generation/worker/generators/labelTextFit.test.ts
@@ -144,6 +144,9 @@ describe('planLabelTextOverflow', () => {
     // caption fitting bare and overflowing beside an icon — proves the plate's
     // own host math is what's measured, without pinning a millimetre threshold
     // that a future margin tweak would invalidate.
+    //
+    // The caption is long enough that it WRAPS in both cases: what separates
+    // them is that the icon leaves too little width for even three lines.
     const socketLabel = {
       ...DEFAULT_BIN_PARAMS.label,
       enabled: true,
@@ -155,7 +158,7 @@ describe('planLabelTextOverflow', () => {
       rows: 1,
       thickness: 1.2,
       cells: [0],
-      compartmentTexts: ['M3 CAP SCREWS A2'],
+      compartmentTexts: ['M3 CAP SCREWS A2 STAINLESS HEX'],
     };
 
     const bare = planLabelTextOverflow(
@@ -193,7 +196,7 @@ describe('planLabelTextOverflow', () => {
           rows: 1,
           thickness: 1.2,
           cells: [0],
-          compartmentTexts: ['M3 CAP SCREWS A2 STAINLESS'],
+          compartmentTexts: ['M3 CAP SCREWS A2 STAINLESS HEX SOCKET BUTTON HEAD FLANGED SERRATED'],
         },
       })
     );

--- a/src/features/whats-new/entries.ts
+++ b/src/features/whats-new/entries.ts
@@ -14,6 +14,16 @@ import type { WhatsNewEntry } from './types';
  */
 export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
   {
+    id: 'two-line-label-captions',
+    date: '2026-08-25',
+    kind: 'improved',
+    title: { en: 'Labels that run to a second line' },
+    body: {
+      en: 'A caption too long for its label now breaks onto a second line instead of coming out blank, so a full fastener spec fits beside its icon. Press Shift+Enter where you want the break, or leave it and the label picks one.',
+    },
+    action: { kind: 'openTool', tool: 'designer' },
+  },
+  {
     id: 'nested-cutout-groups',
     date: '2026-08-25',
     kind: 'new',

--- a/src/features/whats-new/latest.ts
+++ b/src/features/whats-new/latest.ts
@@ -6,4 +6,4 @@
  * `latest.test.ts` asserts this matches `WHATS_NEW_ENTRIES[0]`, so the
  * duplication cannot drift past CI or the pre-commit check.
  */
-export const LATEST_ENTRY_ID = 'nested-cutout-groups';
+export const LATEST_ENTRY_ID = 'two-line-label-captions';


### PR DESCRIPTION
Closes #3891.

A caption too long for its plate shipped a **blank plate**, so an imperial fastener spec like `5/16 x 3-1/4 Grade 8` had nowhere to go on a 1U.

## The premise that turned out to be wrong

The type engine has carried multi-line captions all along — `TEXT_MAX_LINES = 3`, authored breaks via `splitTextLines`, and auto-wrap. Plates opted out:

```js
// A plate caption is one field on a fixed-format part; a second line
// has nowhere to go beside the icon.
allowWrap: false,
```

Measured against the real engine and real fonts, that does not hold. The icon spends **width**, not band height — it is sized to `TEXT_BAND_MM` and sits to the left — so two lines fit the existing 7.8mm band at every plate width:

| plate | one line | two lines |
| --- | --- | --- |
| 1u (36mm) | 3.60mm, stem 0.297 | **4.00mm, stem 0.330** |
| 2u (78mm) | 8.04mm, stem 0.664 | 4.00mm, stem 0.330 |
| 3u (120mm) | 8.04mm, stem 0.664 | 4.00mm, stem 0.330 |

On a 1U the wrapped caption renders **larger** than the single line it replaces, because breaking the line buys back width. No change to `LABEL_PLATE_HEIGHT_MM`, which is a mating dimension against sockets people have already printed.

## What changed

Plates wrap, and honour a typed break when the user would rather choose it. Two consequences worth stating:

- **A multi-line caption sits out `resolveUniformPlateTextSize`.** Two lines genuinely want a smaller size in the shared band, so folding one in would shrink every other plate in the set to match it — the same "drags the others down" the width axis is already kept out for. Multi-line captions auto-fit alone.
- **Enter still means the next row.** Filling captions in sequence is worth more than a line break, so Shift+Enter takes the break. Up/Down leave a row only from its outer edges, so the arrows still walk the caret through a caption that has grown. A standalone wall or lid field has no rows and keeps Enter as the break.

The field grows with its caption, so a list of one-line labels keeps the height it had as a single-line input.

## Verification

Rendered through the real type engine before and after. Auto-wrap picks the same break the reporter would have typed, so their exact caption works with no new keystrokes:

```
┌────────────────────────────┐
│ bolt │ 5/16 x 3-1/4        │   1U + icon, 3.81mm, 2 lines
│      │ Grade 8             │
└────────────────────────────┘
```

`lineScale` defaults to 1, so both lines carry equal weight — right for a spec, where a heading/subheading ramp would be wrong. The presets that set it below 1 remain the user's choice.

Geometry tests run against the real kernel: the long caption now carves material where it used to leave the plate blank, an authored break carves a different volume than the auto-wrapped one, the caption stays inside the plate footprint, and one two-line plate does not move the set's shared size.

https://claude.ai/code/session_01GQpQ2MpszCnpWHht3g6Bau

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

