### PR TITLE
fix(generation): recognise every browser's wording for a failed asset

### DIFF
--- a/src/shared/generation/wasmLoadError.test.ts
+++ b/src/shared/generation/wasmLoadError.test.ts
@@ -40,6 +40,40 @@ describe('isStaleAssetError', () => {
     ).toBe(true);
   });
 
+  // Every one of these was seen in production going unflagged, so the user was
+  // left on a dead 3D engine instead of being reloaded onto the current build.
+  it.each([
+    ['Safari dynamic import', 'Kernel init failed: Importing a module script failed.'],
+    [
+      'Firefox dynamic import',
+      'Kernel init failed: error loading dynamically imported module: https://x/assets/occt-wasm-C7KBdFbv.js',
+    ],
+    ['Firefox fetch', 'Kernel init failed: NetworkError when attempting to fetch resource.'],
+    [
+      'Safari fetch',
+      'Kernel init failed: Load failed (first attempt: Kernel init failed: Load failed)',
+    ],
+    ['Chrome fetch', 'Kernel init failed: Failed to fetch'],
+    [
+      'truncated download',
+      'Kernel init failed: Aborted(CompileError: WebAssembly.instantiate(): section (code 10, "Code") extends past end of the module (length 19686494, remaining bytes 17280021) @+74726)',
+    ],
+  ])('flags the %s failure, which a reload fixes', (_name, message) => {
+    expect(isStaleAssetError(new Error(message))).toBe(true);
+  });
+
+  it('leaves an unsupported instruction set unflagged, since reloading cannot help', () => {
+    // An old browser that cannot compile the instruction is not a stale cache.
+    // Reloading it in a loop would be the only outcome of flagging this.
+    expect(
+      isStaleAssetError(
+        new Error(
+          'Kernel init failed: Aborted(CompileError: WebAssembly.instantiate(): Compiling function #72 failed: Wasm SIMD unsupported @+86123)'
+        )
+      )
+    ).toBe(false);
+  });
+
   it('does not flag unrelated generation errors', () => {
     expect(isStaleAssetError(new Error('Split export range failed: STL_EXPORT_FAILED'))).toBe(
       false

--- a/src/shared/generation/wasmLoadError.test.ts
+++ b/src/shared/generation/wasmLoadError.test.ts
@@ -40,8 +40,6 @@ describe('isStaleAssetError', () => {
     ).toBe(true);
   });
 
-  // Every one of these was seen in production going unflagged, so the user was
-  // left on a dead 3D engine instead of being reloaded onto the current build.
   it.each([
     ['Safari dynamic import', 'Kernel init failed: Importing a module script failed.'],
     [

--- a/src/shared/generation/wasmLoadError.ts
+++ b/src/shared/generation/wasmLoadError.ts
@@ -10,13 +10,36 @@
  * affected code paths historically swallowed the error.
  */
 
+/**
+ * Every phrasing a browser uses for "the asset did not arrive".
+ *
+ * Each engine words this differently and only Chrome's wording was listed, so a
+ * Safari or Firefox user hit the same stale bundle, matched nothing, and was
+ * left on a dead 3D engine instead of being reloaded onto the current build.
+ * Matching is substring and case-sensitive, so the wording has to be exact.
+ *
+ * Breadth is safe here because {@link isStaleAssetError} is only ever asked
+ * about an error that already failed to load the kernel: at that point a bare
+ * `Load failed` can only be the asset, and a reload is the right answer whether
+ * the cause was a stale hash or a dropped connection.
+ */
 const STALE_ASSET_SIGNATURES = [
   'not a WebAssembly binary',
   'stale cache or service worker',
   "doesn't start with",
   'script failed to load',
-  'Failed to fetch dynamically imported module',
   'WASM fetch failed',
+  // Dynamic import of the kernel's glue module. Chrome and Firefox disagree on
+  // the verb; `Failed to fetch` alone also covers Chrome's bare fetch failure.
+  'Failed to fetch',
+  'error loading dynamically imported module',
+  'Importing a module script failed',
+  'NetworkError when attempting to fetch resource',
+  // Safari's fetch rejection, which carries no detail at all.
+  'Load failed',
+  // A truncated download: the module declares more bytes than arrived, so
+  // compilation walks off the end. Re-fetching is exactly the fix.
+  'extends past end of the module',
   // A cached old bundle running on a browser that can't compile an instruction
   // the old build used (e.g. relaxed-SIMD on some Safari/iOS WebKit). Current
   // builds no longer emit it, so seeing it means the client is on stale cached


### PR DESCRIPTION
Closes #3893. Closes #3894.

Both issues are the same failure, filed twice because it fingerprints differently each time.

## What the two issues actually are

```
Kernel init failed: Aborted(CompileError: WebAssembly.instantiate():
  section (code 10, "Code") extends past end of the module
  (length 19686494, remaining bytes 17280021) @+74726)
```

A truncated download: the module declares 19.7MB and 17.3MB arrived. Not a deploy regression — this class has been running at roughly one user a day since at least Aug 22.

## The larger finding

A kernel load failure that looks like a stale bundle already gets two things, both hanging off `isStaleAssetError`:

- a pinned `$exception_fingerprint`, so one recurring failure does not mint a fresh issue per deploy
- `recoverStaleBundle`, which drops the stale caches and service worker and reloads onto the current build

The signature list was Chrome-shaped, so users on other engines matched nothing:

| production message | engine | matched before |
| --- | --- | --- |
| `script failed to load` | Chrome | ✅ |
| `OCCT WASM fetch failed: 404` | app-authored | ✅ |
| `Importing a module script failed.` | Safari | ❌ |
| `Load failed` | Safari | ❌ |
| `NetworkError when attempting to fetch resource.` | Firefox | ❌ |
| `error loading dynamically imported module` | Firefox | ❌ |
| `extends past end of the module` | truncated download | ❌ |
| `Wasm SIMD unsupported` | old browser | ❌ (correctly) |

Over the last fortnight: **82 users self-healed, 13 did not.** Those 13 sat on a dead "Failed to load 3D engine" until they happened to hard-reload, and each occurrence splintered into its own error-tracking issue — which is what filed #3893 and #3894 separately for one user's three errors.

## Why the broad phrasings are safe

`isStaleAssetError` has exactly one consumer, `captureWasmLoadFailure`, and it is only ever asked about an error that has already failed to load the kernel. At that point a bare `Load failed` can only be the asset, and a reload is the right answer whether the cause was a stale hash or a dropped connection. `recoverStaleBundle` is guarded to once per tab session, so a genuinely offline user reloads once and stops.

An unsupported instruction set stays deliberately unflagged and has a test saying so: an old browser that cannot compile the opcode is not a stale cache, and a reload is all that would ever come of it.

https://claude.ai/code/session_01GQpQ2MpszCnpWHht3g6Bau

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

