### PR TITLE
fix(shell): recover a route chunk onto the build that actually has it

### DIFF
--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -158,6 +158,58 @@ describe('filterExceptionForPosthog — WebGL context-creation dedupe', () => {
   });
 });
 
+describe('filterExceptionForPosthog — chunk-load dedupe', () => {
+  const fingerprintOf = (value: string): unknown =>
+    filterExceptionForPosthog({
+      event: '$exception',
+      properties: { $exception_list: [{ value }] },
+    })?.properties?.$exception_fingerprint;
+
+  it.each([
+    [
+      'Chrome',
+      'TypeError: Failed to fetch dynamically imported module: https://gridfinitylayouttool.com/assets/baseplate-CbgQ-55M.js',
+    ],
+    [
+      'Firefox',
+      'TypeError: error loading dynamically imported module: https://gridfinitylayouttool.com/assets/baseplate-CbgQ-55M.js',
+    ],
+    ['Safari', 'TypeError: Importing a module script failed.'],
+  ])('pins the %s wording to one fingerprint', (_engine, value) => {
+    expect(fingerprintOf(value)).toBe('chunk-load-failed');
+  });
+
+  it('groups across deploys, whose chunk hash and route differ', () => {
+    expect(
+      fingerprintOf(
+        'Failed to fetch dynamically imported module: https://x/assets/baseplate-AAA.js'
+      )
+    ).toBe(
+      fingerprintOf(
+        'Failed to fetch dynamically imported module: https://x/assets/designer-ZZZZZZZZ.js'
+      )
+    );
+  });
+
+  it('leaves a bare network failure alone, which is not necessarily a chunk', () => {
+    // `isStaleAssetError` may answer for these because it is only ever asked
+    // about a failed kernel load. This hook sees every exception, so matching
+    // them here would drag genuine API failures into the chunk bucket.
+    expect(fingerprintOf('TypeError: Failed to fetch')).toBeUndefined();
+    expect(fingerprintOf('TypeError: Load failed')).toBeUndefined();
+  });
+
+  it('still reports the event rather than dropping it', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [{ value: 'Failed to fetch dynamically imported module: https://x/a.js' }],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+});
+
 describe('R3F canvas teardown race', () => {
   const CHROME = "Cannot read properties of null (reading 'addEventListener')";
   const canvasFrames = [

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -24,6 +24,25 @@ const WEBGL_CONTEXT_ERROR = 'Error creating WebGL context';
 /** Stable fingerprint that collapses every WebGL-context-creation variant into one issue. */
 const WEBGL_CONTEXT_FINGERPRINT = 'webgl-context-creation-failed';
 
+/**
+ * A lazy route chunk that failed to import, in each engine's wording.
+ *
+ * Chrome and Firefox append the chunk URL, whose Vite hash rotates every build,
+ * so message-based grouping mints a brand-new issue (and a new auto-filed bug)
+ * per deploy for what is one recurring stale-bundle miss. Safari's variant
+ * carries no URL and groups on its own; it belongs in the same bucket.
+ *
+ * Deliberately narrower than `isStaleAssetError`, which may answer for bare
+ * `Load failed` / `Failed to fetch` because it is only ever asked about an error
+ * that already failed to load the kernel. This runs against every exception, so
+ * those phrasings would drag genuine API failures into the chunk bucket.
+ */
+const CHUNK_LOAD_ERROR =
+  /(?:Failed to fetch|error loading) dynamically imported module|Importing a module script failed/;
+
+/** Stable fingerprint collapsing every deploy's chunk-load miss into one issue. */
+const CHUNK_LOAD_FINGERPRINT = 'chunk-load-failed';
+
 const IGNORED_MESSAGE_PATTERNS: readonly RegExp[] = [
   // Safari Web Extensions message bus
   /No Listener: tabs:/i,
@@ -117,8 +136,8 @@ function isCanvasTeardownRace(exception: ExceptionLike): boolean {
 /**
  * PostHog `before_send` hook. Drops `$exception` events whose **primary**
  * exception matches the extension/noise filters or the R3F canvas teardown
- * race, dedupes the WebGL context-creation burst, and passes everything else
- * through unchanged.
+ * race, dedupes the WebGL context-creation burst, pins chunk-load failures to
+ * one fingerprint, and passes everything else through unchanged.
  *
  * Only the first entry in `$exception_list` / `$exception_values` is
  * checked. Subsequent entries are `Error.cause` chains — if a real app
@@ -155,6 +174,13 @@ export function filterExceptionForPosthog(
     event.properties = {
       ...event.properties,
       $exception_fingerprint: WEBGL_CONTEXT_FINGERPRINT,
+    };
+  }
+
+  if (primary !== undefined && CHUNK_LOAD_ERROR.test(primary)) {
+    event.properties = {
+      ...event.properties,
+      $exception_fingerprint: CHUNK_LOAD_FINGERPRINT,
     };
   }
 

--- a/src/shared/generation/captureWasmLoadFailure.test.ts
+++ b/src/shared/generation/captureWasmLoadFailure.test.ts
@@ -61,7 +61,11 @@ describe('handleWasmLoadFailure', () => {
     );
 
     expect(captureException).toHaveBeenCalledTimes(1);
-    expect(recoverStaleBundle).toHaveBeenCalledWith('wasm_load_failure:bin_designer_preview');
+    // Drops the wasm cache: this caller is here because a wasm artifact failed,
+    // so it is the suspect rather than a bystander.
+    expect(recoverStaleBundle).toHaveBeenCalledWith('wasm_load_failure:bin_designer_preview', {
+      dropWasmCache: true,
+    });
   });
 
   it('captures but does not recover on a genuine (non-stale) error', () => {

--- a/src/shared/generation/captureWasmLoadFailure.ts
+++ b/src/shared/generation/captureWasmLoadFailure.ts
@@ -41,6 +41,6 @@ export function captureWasmLoadFailure(error: unknown, surface: WasmLoadSurface)
 export function handleWasmLoadFailure(error: unknown, surface: WasmLoadSurface): void {
   captureWasmLoadFailure(error, surface);
   if (isStaleAssetError(error)) {
-    void recoverStaleBundle(`wasm_load_failure:${surface}`);
+    void recoverStaleBundle(`wasm_load_failure:${surface}`, { dropWasmCache: true });
   }
 }

--- a/src/shared/pwa/staleRecovery.test.ts
+++ b/src/shared/pwa/staleRecovery.test.ts
@@ -49,16 +49,51 @@ afterEach(() => {
 });
 
 describe('recoverStaleBundle', () => {
-  it('clears precache + wasm caches, unregisters SWs, and reloads', async () => {
+  it('clears the precache, unregisters SWs, and reloads', async () => {
     const started = await recoverStaleBundle('wasm_load_failure');
 
     expect(started).toBe(true);
-    // Drops the precache and wasm caches, leaves unrelated caches (shared-layouts) alone.
+    // Drops the precache, leaves unrelated caches (shared-layouts) alone.
     expect(cacheDelete).toHaveBeenCalledWith('gridfinity-v1-precache-abc');
-    expect(cacheDelete).toHaveBeenCalledWith('wasm-binaries');
     expect(cacheDelete).not.toHaveBeenCalledWith('shared-layouts');
     expect(unregister).toHaveBeenCalledTimes(2);
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the wasm cache only for a caller that implicates it', async () => {
+    await recoverStaleBundle('wasm_load_failure', { dropWasmCache: true });
+    expect(cacheDelete).toHaveBeenCalledWith('wasm-binaries');
+  });
+
+  it('spares the wasm cache for a chunk failure, which does not implicate it', async () => {
+    // Several megabytes whose hash usually survives a deploy, so re-downloading
+    // it buys a route-chunk recovery nothing.
+    await recoverStaleBundle('chunk_load_failure');
+    expect(cacheDelete).not.toHaveBeenCalledWith('wasm-binaries');
+  });
+
+  it('declines while offline, since unregistering the SW would strip the shell', async () => {
+    vi.stubGlobal('navigator', {
+      onLine: false,
+      serviceWorker: { getRegistrations: vi.fn().mockResolvedValue([{ unregister }]) },
+    });
+
+    expect(await recoverStaleBundle('chunk_load_failure')).toBe(false);
+    expect(unregister).not.toHaveBeenCalled();
+    expect(cacheDelete).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not burn the session guard on a declined offline attempt', async () => {
+    vi.stubGlobal('navigator', { onLine: false, serviceWorker: undefined });
+    await recoverStaleBundle('chunk_load_failure');
+    expect(sessionStorage.getItem(STALE_RECOVERY_FLAG)).toBeNull();
+
+    vi.stubGlobal('navigator', {
+      onLine: true,
+      serviceWorker: { getRegistrations: vi.fn().mockResolvedValue([{ unregister }]) },
+    });
+    expect(await recoverStaleBundle('chunk_load_failure')).toBe(true);
   });
 
   it('captures a telemetry event with the reason', async () => {

--- a/src/shared/pwa/staleRecovery.ts
+++ b/src/shared/pwa/staleRecovery.ts
@@ -22,9 +22,9 @@
  * `handleWasmLoadFailure` is the correct shape: it recovers only when a load has
  * already failed with a stale-asset error.
  *
- * The wasm cache is dropped along with the precache deliberately — the one
- * surviving caller reaches here *because* a wasm artifact failed to load, so it
- * is the suspect rather than a bystander.
+ * Which caches count as suspect is the caller's call (`dropWasmCache`): a kernel
+ * failure implicates the wasm binary, a route-chunk failure does not, and the
+ * wasm cache holds multiple megabytes whose hash usually survives a deploy.
  */
 
 import { getPosthogInstance } from '@/shared/analytics/posthog/init';
@@ -49,13 +49,13 @@ function markRecovered(): void {
   }
 }
 
-async function clearStaleCaches(): Promise<void> {
+async function clearStaleCaches(dropWasmCache: boolean): Promise<void> {
   if (typeof caches === 'undefined') return;
   try {
     const keys = await caches.keys();
     await Promise.all(
       keys
-        .filter((k) => k.startsWith(PRECACHE_PREFIX) || k === WASM_CACHE)
+        .filter((k) => k.startsWith(PRECACHE_PREFIX) || (dropWasmCache && k === WASM_CACHE))
         .map((k) => caches.delete(k))
     );
   } catch {
@@ -77,13 +77,32 @@ async function unregisterServiceWorkers(): Promise<void> {
   }
 }
 
+interface RecoverOptions {
+  /**
+   * Also drop the wasm cache. Only for a caller whose failure implicates the
+   * wasm binary (see the module docstring).
+   */
+  readonly dropWasmCache?: boolean;
+}
+
 /**
  * Attempt a one-time stale-bundle recovery. Returns true if a recovery was
  * started (caches cleared + reload triggered), false if it was skipped because
- * one already ran this session.
+ * one already ran this session or the browser reports no network.
+ *
+ * Recovery ends by unregistering the service worker, so running it offline
+ * would trade an in-app error for the browser's own network error page and
+ * leave the user without the offline shell, with no fresher bundle reachable
+ * to justify the trade. `navigator.onLine` is only trusted in this direction:
+ * it reports true on a captive portal, but false only when the browser is
+ * certain there is no network.
  */
-export async function recoverStaleBundle(reason: string): Promise<boolean> {
+export async function recoverStaleBundle(
+  reason: string,
+  { dropWasmCache = false }: RecoverOptions = {}
+): Promise<boolean> {
   if (alreadyRecovered()) return false;
+  if (typeof navigator !== 'undefined' && !navigator.onLine) return false;
   markRecovered();
 
   try {
@@ -96,7 +115,7 @@ export async function recoverStaleBundle(reason: string): Promise<boolean> {
     // never let telemetry block recovery
   }
 
-  await clearStaleCaches();
+  await clearStaleCaches(dropWasmCache);
   await unregisterServiceWorkers();
 
   window.location.reload();

--- a/src/shared/pwa/staleRecovery.ts
+++ b/src/shared/pwa/staleRecovery.ts
@@ -4,9 +4,9 @@
  * The PWA's normal updater (`usePWAUpdate`) fixes the *next* load: a returning
  * user is served the old precached shell + old runtime-cached wasm, so the
  * current page can fail (e.g. kernel init) before any update applies. This
- * recovers the *current* visit: drop the precache + wasm caches, unregister the
- * service worker (so the reload bypasses it and fetches the latest from the
- * network), then hard-reload.
+ * recovers the *current* visit: drop the precache (plus the wasm cache, for a
+ * caller that implicates it), unregister the service worker (so the reload
+ * bypasses it and fetches the latest from the network), then hard-reload.
  *
  * Guarded by a per-session flag so a genuinely broken new bundle can't loop:
  * we recover at most once per tab session.

--- a/src/shared/utils/lazyWithRetry.test.tsx
+++ b/src/shared/utils/lazyWithRetry.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
+import { recoverStaleBundle } from '@/shared/pwa/staleRecovery';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Suspense, Component, type ReactNode, type ComponentType } from 'react';
+
+vi.mock('@/shared/pwa/staleRecovery', () => ({ recoverStaleBundle: vi.fn() }));
+const mockRecover = vi.mocked(recoverStaleBundle);
 
 const MockComponent: ComponentType = () => <div data-testid="mock-component">Loaded</div>;
 MockComponent.displayName = 'MockComponent';
@@ -26,31 +30,17 @@ class ErrorBoundary extends Component<
 }
 
 describe('lazyWithRetry', () => {
-  let originalLocation: Location;
-  let mockReload: ReturnType<typeof vi.fn>;
-
   beforeEach(() => {
-    // Clear sessionStorage before each test
     sessionStorage.clear();
     // Mock console.warn to prevent noise
     vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    // Save and mock window.location
-    originalLocation = window.location;
-    mockReload = vi.fn();
-    Object.defineProperty(window, 'location', {
-      value: Object.assign({}, originalLocation, { reload: mockReload }),
-      writable: true,
-    });
+    // Default: recovery is available and takes over (the page is reloading).
+    mockRecover.mockReset();
+    mockRecover.mockResolvedValue(true);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    // Restore original location
-    Object.defineProperty(window, 'location', {
-      value: originalLocation,
-      writable: true,
-    });
   });
 
   describe('API contract', () => {
@@ -73,7 +63,7 @@ describe('lazyWithRetry', () => {
       expect(() => lazyWithRetry(importFn, 0)).not.toThrow();
     });
 
-    it('accepts reloadOnFinalFailure option', () => {
+    it('accepts recoverOnFinalFailure option', () => {
       const importFn = vi.fn().mockResolvedValue({ default: MockComponent });
 
       // Should not throw with either option
@@ -190,7 +180,7 @@ describe('lazyWithRetry', () => {
     });
   });
 
-  describe('final failure with reload', () => {
+  describe('final failure with recovery', () => {
     beforeEach(() => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
     });
@@ -199,7 +189,7 @@ describe('lazyWithRetry', () => {
       vi.useRealTimers();
     });
 
-    it('reloads page when all retries exhausted', async () => {
+    it('recovers the stale bundle when all retries are exhausted', async () => {
       const importFn = vi.fn().mockRejectedValue(new Error('Chunk permanently unavailable'));
 
       const LazyComponent = lazyWithRetry(importFn, 1, true);
@@ -219,11 +209,11 @@ describe('lazyWithRetry', () => {
       });
 
       await waitFor(() => {
-        expect(mockReload).toHaveBeenCalled();
+        expect(mockRecover).toHaveBeenCalledWith('chunk_load_failure');
       });
     });
 
-    it('sets sessionStorage flag before reload', async () => {
+    it('does not drop the wasm cache, which a chunk miss does not implicate', async () => {
       const importFn = vi.fn().mockRejectedValue(new Error('Chunk permanently unavailable'));
 
       const LazyComponent = lazyWithRetry(importFn, 0, true);
@@ -237,22 +227,38 @@ describe('lazyWithRetry', () => {
       await vi.advanceTimersByTimeAsync(100);
 
       await waitFor(() => {
-        expect(mockReload).toHaveBeenCalled();
+        expect(mockRecover).toHaveBeenCalled();
       });
-
-      // Check that session flag was set
-      const keys = Object.keys(sessionStorage);
-      const chunkReloadKey = keys.find((k) => k.startsWith('chunk-reload-'));
-      expect(chunkReloadKey).toBeDefined();
-      expect(sessionStorage.getItem(chunkReloadKey!)).toBe('true');
+      expect(mockRecover.mock.calls[0]?.[1]?.dropWasmCache).toBeUndefined();
     });
 
-    it('does not reload if already reloaded (prevents infinite loop)', async () => {
-      const importFn = vi.fn().mockRejectedValue(new Error('Still failing'));
+    it('stays suspended while the recovery reload takes over', async () => {
+      const importFn = vi.fn().mockRejectedValue(new Error('Chunk permanently unavailable'));
 
-      // Pre-set the session key to simulate previous reload
-      const sessionKey = `chunk-reload-${importFn.toString().slice(0, 100)}`;
-      sessionStorage.setItem(sessionKey, 'true');
+      const LazyComponent = lazyWithRetry(importFn, 0, true);
+
+      render(
+        <ErrorBoundary fallback={<div data-testid="error">Error occurred</div>}>
+          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+            <LazyComponent />
+          </Suspense>
+        </ErrorBoundary>
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      await waitFor(() => {
+        expect(mockRecover).toHaveBeenCalled();
+      });
+      // Never surfaces an error boundary: the page is on its way to reloading.
+      expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+      expect(screen.getByTestId('loading')).toBeInTheDocument();
+    });
+
+    it('throws when recovery declines, so the boundary can report it', async () => {
+      // Declined because one already ran this tab session, or the client is offline.
+      mockRecover.mockResolvedValue(false);
+      const importFn = vi.fn().mockRejectedValue(new Error('Still failing'));
 
       const LazyComponent = lazyWithRetry(importFn, 0, true);
 
@@ -269,39 +275,10 @@ describe('lazyWithRetry', () => {
       await waitFor(() => {
         expect(screen.getByTestId('error')).toBeInTheDocument();
       });
-
-      // Should NOT reload since session flag exists
-      expect(mockReload).not.toHaveBeenCalled();
-    });
-
-    it('clears session flag when throwing instead of reloading', async () => {
-      const importFn = vi.fn().mockRejectedValue(new Error('Failing'));
-
-      const sessionKey = `chunk-reload-${importFn.toString().slice(0, 100)}`;
-      sessionStorage.setItem(sessionKey, 'true');
-
-      const LazyComponent = lazyWithRetry(importFn, 0, true);
-
-      render(
-        <ErrorBoundary fallback={<div data-testid="error">Error</div>}>
-          <Suspense fallback={<div>Loading...</div>}>
-            <LazyComponent />
-          </Suspense>
-        </ErrorBoundary>
-      );
-
-      await vi.advanceTimersByTimeAsync(100);
-
-      await waitFor(() => {
-        expect(screen.getByTestId('error')).toBeInTheDocument();
-      });
-
-      // Session flag should be cleared for next time
-      expect(sessionStorage.getItem(sessionKey)).toBeNull();
     });
   });
 
-  describe('final failure without reload', () => {
+  describe('final failure without recovery', () => {
     beforeEach(() => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
     });
@@ -310,7 +287,7 @@ describe('lazyWithRetry', () => {
       vi.useRealTimers();
     });
 
-    it('throws error when reloadOnFinalFailure is false', async () => {
+    it('throws error when recoverOnFinalFailure is false', async () => {
       const importFn = vi.fn().mockRejectedValue(new Error('Chunk unavailable'));
 
       const LazyComponent = lazyWithRetry(importFn, 0, false);
@@ -329,7 +306,7 @@ describe('lazyWithRetry', () => {
         expect(screen.getByTestId('error')).toBeInTheDocument();
       });
 
-      expect(mockReload).not.toHaveBeenCalled();
+      expect(mockRecover).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/shared/utils/lazyWithRetry.ts
+++ b/src/shared/utils/lazyWithRetry.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports -- this util is the one legitimate caller of React.lazy.
 import { lazy, type ComponentType } from 'react';
+import { recoverStaleBundle } from '@/shared/pwa/staleRecovery';
 
 /**
  * Wraps a dynamic import with retry logic to handle chunk loading failures.
@@ -9,7 +10,17 @@ import { lazy, type ComponentType } from 'react';
  *
  * On failure, it will:
  * 1. Retry the import up to `retries` times
- * 2. If all retries fail, reload the page (once) to get fresh assets
+ * 2. If all retries fail, recover onto the current build (once per session)
+ *
+ * Recovery has to go through {@link recoverStaleBundle} rather than a plain
+ * `location.reload()`. The precache holds index.html and the boot graph, which
+ * name the lazy chunk's hash; the chunk itself is deliberately left out of the
+ * manifest (see `manifestTransforms` in vite.config.ts). So a stale precache
+ * points at a hash the CDN no longer serves, and because the service worker
+ * ships with `skipWaiting: false` / `clientsClaim: false` it keeps serving that
+ * same precached pair across a reload, which comes back to the identical dead
+ * hash. Dropping the precache and unregistering the worker first is what makes
+ * the reload land on the current build.
  *
  * Note: Uses `ComponentType<never>` as the constraint because TypeScript's
  * type inference for lazy-loaded components requires the most permissive type.
@@ -21,11 +32,9 @@ import { lazy, type ComponentType } from 'react';
 export function lazyWithRetry<T extends ComponentType<any>>(
   importFn: () => Promise<{ default: T }>,
   retries = 2,
-  reloadOnFinalFailure = true
+  recoverOnFinalFailure = true
 ): React.LazyExoticComponent<T> {
   return lazy(async () => {
-    const sessionKey = `chunk-reload-${importFn.toString().slice(0, 100)}`;
-
     for (let attempt = 0; attempt <= retries; attempt++) {
       try {
         return await importFn();
@@ -39,21 +48,16 @@ export function lazyWithRetry<T extends ComponentType<any>>(
           continue;
         }
 
-        // All retries exhausted
-        if (reloadOnFinalFailure && !sessionStorage.getItem(sessionKey)) {
-          // Mark that we're reloading to prevent infinite reload loops
-          sessionStorage.setItem(sessionKey, 'true');
-          console.warn('All import retries failed, reloading page to fetch fresh assets...');
-          window.location.reload();
-
+        // A stale bundle is one condition for the whole tab, not one per chunk,
+        // so the once-per-session guard belongs to the shared recovery rather
+        // than to a key derived from this importFn.
+        if (recoverOnFinalFailure && (await recoverStaleBundle('chunk_load_failure'))) {
           // Return a never-resolving promise while the page reloads
           return new Promise(() => {});
         }
 
-        // Clear the reload marker for next time (if user navigates back)
-        sessionStorage.removeItem(sessionKey);
-
-        // Re-throw the error if we can't reload or already tried
+        // Recovery was declined (already used this session, offline, or opted
+        // out), so surface the failure to the nearest boundary.
         throw error;
       }
     }


### PR DESCRIPTION
A lazy route chunk that fails to import gets three retries and then a plain
`location.reload()`, which cannot fix the one failure it exists for.

## Why the reload can't work

`manifestTransforms` keeps route chunks out of the precache, but not the boot
graph that names them. Confirmed against a build:

```
PRECACHED CHUNK assets/main-DkEtXL-A.js references assets/baseplate-zfZQbQHo.js
NOT precached: baseplate-zfZQbQHo.js
```

So a precached `main-*.js` hardcodes a chunk hash the CDN stops serving at the
next deploy. With `skipWaiting: false` and `clientsClaim: false`, the old worker
keeps serving that same precached pair across a reload, so the reload returns to
the identical dead hash, fails again, and rethrows to the boundary. The user
pays for a full page reload and is still broken.

## The fix

`recoverStaleBundle` is the recovery that works: it drops the precache and
unregisters the worker so the reload bypasses it. It was wired only to the
kernel path. This wires it to the chunk path too, and drops the per-`importFn`
`sessionStorage` key. A stale bundle is one condition for the tab, not one per
chunk, so the shared once-per-session guard is the right granularity.

Two consequences of giving that function a second caller:

**The wasm cache is now the caller's choice.** Its docstring justified dropping
it on the grounds that "the one surviving caller reaches here because a wasm
artifact failed to load, so it is the suspect rather than a bystander". For a
route chunk it is a bystander, and re-fetching multiple megabytes whose hash
usually survives the deploy buys nothing. The kernel path opts in.

**Recovery declines while offline.** It ends by unregistering the worker, which
offline trades an in-app error for the browser's own network error page and
strips the offline shell, with no fresher bundle reachable to justify it. This
matches how `usePWAUpdate` already treats offline. `navigator.onLine` is trusted
in one direction only: true on a captive portal, false only when the browser is
certain.

## The reporting half

Failures that still reach error tracking get a pinned fingerprint, so the
rotating chunk hash in the message stops minting a fresh issue, and a fresh
auto-filed bug, on every deploy. It is deliberately narrower than
`isStaleAssetError`, which may answer for a bare `Load failed` because it is only
ever asked about an error that already failed to load the kernel; this hook sees
every exception, so that breadth would drag genuine API failures into the chunk
bucket.

#3897 and #3898 are the same bug 45 minutes apart, on different chunks, filed
under different fingerprints. Both chunks load through `lazyWithRetry`.

## Verification

- 22,362 unit + dom tests pass
- typecheck, eslint, module boundaries clean
- The precache/boot-graph relationship above read off real build output
- `usePrefetchChunks` checked as an adjacent path: it catches and swallows, so
  it is not a source of these reports

Closes #3897
Closes #3898

https://claude.ai/code/session_01PuizNr53vDX6TgHcF613Am


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

