### PR TITLE
fix(analytics): recognise Firefox's wording for the canvas teardown race

### DIFF
--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -267,6 +267,21 @@ describe('R3F canvas teardown race', () => {
     expect(filterExceptionForPosthog(e)).toBeNull();
   });
 
+  it('matches the Firefox phrasing of the same throw', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          {
+            value: 'can\'t access property "addEventListener", t is null',
+            stacktrace: { frames: canvasFrames },
+          },
+        ],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBeNull();
+  });
+
   it('keeps the error when frames are absent entirely', () => {
     const e = {
       event: '$exception',

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -124,7 +124,7 @@ function isExtensionSourced(exception: ExceptionLike): boolean {
  * a null target throws the same words, and that one we want to hear about.
  */
 const NULL_LISTENER_TARGET =
-  /Cannot read propert(?:y|ies) of null \(reading '?addEventListener'?\)|null is not an object \(evaluating '[^']*\.addEventListener'\)/;
+  /Cannot read propert(?:y|ies) of null \(reading '?addEventListener'?\)|null is not an object \(evaluating '[^']*\.addEventListener'\)|can't access property "addEventListener", .* is null/;
 
 function isCanvasTeardownRace(exception: ExceptionLike): boolean {
   if (!exception.value || !NULL_LISTENER_TARGET.test(exception.value)) return false;


### PR DESCRIPTION
Closes #3904.

The R3F canvas teardown race (unmounting mid-`configure()` leaves `onCreated` to call `events.connect` on a nulled container ref) is already filtered out of PostHog by `isCanvasTeardownRace`, but the message regex only matched Chrome and WebKit phrasings. Firefox throws the same error as `can't access property "addEventListener", t is null`, which slipped past the filter and auto-filed #3904.

Adds the Firefox phrasing to `NULL_LISTENER_TARGET` (still gated on a `connect` stack frame, so an app-side listener on a null target is still reported) and a test mirroring the WebKit one.

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

