### PR TITLE
fix(analytics): drop WebKit navigation aborts and WebView bridge noise

### DIFF
--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -22,6 +22,9 @@ describe('shouldIgnoreError — message patterns', () => {
     // Firefox-for-iOS injected `__firefox__` global / Reader-mode noise
     "ReferenceError: Can't find variable: __firefox__",
     "TypeError: undefined is not an object (evaluating 'window.__firefox__.reader')",
+    // iOS in-app browser (WKWebView) bridge-script injection
+    "TypeError: undefined is not an object (evaluating 'top.webkit.messageHandlers.foregroundToBackground.postMessage')",
+    "TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers.handler.postMessage')",
   ])('ignores %j', (msg) => {
     expect(shouldIgnoreError(msg)).toBe(true);
   });
@@ -286,6 +289,45 @@ describe('R3F canvas teardown race', () => {
     const e = {
       event: '$exception',
       properties: { $exception_list: [{ value: CHROME }] },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+});
+
+describe('WebKit navigation aborts', () => {
+  it.each([
+    ['no stacktrace at all', { value: 'AbortError: AbortError' }],
+    ['empty frames', { value: 'AbortError: AbortError', stacktrace: { frames: [] } }],
+    [
+      'wordier WebKit phrasing',
+      { value: 'AbortError: The operation was aborted.', stacktrace: { frames: [] } },
+    ],
+  ])('drops a stackless AbortError with %s', (_shape, exception) => {
+    const e = { event: '$exception', properties: { $exception_list: [exception] } };
+    expect(filterExceptionForPosthog(e)).toBeNull();
+  });
+
+  it('keeps an AbortError that carries app frames', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [
+          {
+            value: 'AbortError: AbortError',
+            stacktrace: { frames: [{ function: 'loadSharedLayout' }] },
+          },
+        ],
+      },
+    };
+    expect(filterExceptionForPosthog(e)).toBe(e);
+  });
+
+  it('keeps other stackless DOMExceptions', () => {
+    const e = {
+      event: '$exception',
+      properties: {
+        $exception_list: [{ value: 'UnknownError: Database deleted by request of the user' }],
+      },
     };
     expect(filterExceptionForPosthog(e)).toBe(e);
   });

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -58,6 +58,11 @@ const IGNORED_MESSAGE_PATTERNS: readonly RegExp[] = [
   // variable: __firefox__" or "window.__firefox__.reader" is undefined) our
   // handlers catch it. No app code is involved. Match every variant/fingerprint.
   /__firefox__/,
+  // iOS in-app browsers (WKWebView hosts) inject bridge scripts that call
+  // `window.webkit.messageHandlers.<handler>.postMessage`. In a frame where the
+  // host app didn't register the handler the chain is undefined and the injected
+  // script throws. No app code is involved — we never touch `webkit`.
+  /webkit\.messageHandlers/,
 ];
 
 const IGNORED_SOURCE_PATTERNS: readonly RegExp[] = [
@@ -134,10 +139,26 @@ function isCanvasTeardownRace(exception: ExceptionLike): boolean {
 }
 
 /**
+ * WebKit fires `unhandledrejection` for promises the navigation itself killed:
+ * leaving a page rejects every in-flight `fetch` with a bare `AbortError`
+ * carrying no stack. Chrome swallows those rejections, which is why the class
+ * is WebKit-only in tracking — an abort our own code leaked would surface
+ * cross-browser. Nothing failed; the user left.
+ *
+ * Gated on the absence of frames: an AbortError thrown through app code has a
+ * stack, and that one we want to hear about.
+ */
+function isNavigationAbort(exception: ExceptionLike): boolean {
+  if (exception.value === undefined || !exception.value.startsWith('AbortError')) return false;
+  return (exception.stacktrace?.frames ?? []).length === 0;
+}
+
+/**
  * PostHog `before_send` hook. Drops `$exception` events whose **primary**
- * exception matches the extension/noise filters or the R3F canvas teardown
- * race, dedupes the WebGL context-creation burst, pins chunk-load failures to
- * one fingerprint, and passes everything else through unchanged.
+ * exception matches the extension/noise filters, the R3F canvas teardown
+ * race, or a stackless navigation abort; dedupes the WebGL context-creation
+ * burst, pins chunk-load failures to one fingerprint, and passes everything
+ * else through unchanged.
  *
  * Only the first entry in `$exception_list` / `$exception_values` is
  * checked. Subsequent entries are `Error.cause` chains — if a real app
@@ -166,6 +187,7 @@ export function filterExceptionForPosthog(
   if (shouldIgnoreError(primary)) return null;
   if (primaryException && isExtensionSourced(primaryException)) return null;
   if (primaryException && isCanvasTeardownRace(primaryException)) return null;
+  if (primaryException && isNavigationAbort(primaryException)) return null;
 
   if (primary?.includes(WEBGL_CONTEXT_ERROR)) {
     // Detection already unavailable → the boundary handled this and we've


### PR DESCRIPTION
Two non-app noise classes were still reaching error tracking after the recent filter work:

**Stackless WebKit navigation aborts.** WebKit rejects every in-flight `fetch` with a bare `AbortError` when the user navigates away, and fires `unhandledrejection` for it. Chrome swallows the same rejection, which is why the class shows up WebKit-only — an abort our own code leaked would surface cross-browser. The filter is gated on the absence of stack frames, so an AbortError thrown through app code stays audible.

**iOS in-app browser bridge scripts.** WKWebView hosts inject scripts that call `webkit.messageHandlers.<handler>.postMessage` and throw when the host app never registered the handler in that frame. No app code is involved.

Both land in `errorFilters.ts` alongside the existing extension and canvas-teardown filters, with tests for the drop conditions and the keep conditions.

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

