### PR TITLE
perf(analytics): persist the $set dedupe across pageloads

### DIFF
--- a/src/shared/analytics/posthog/eventsPerson.test.ts
+++ b/src/shared/analytics/posthog/eventsPerson.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AnalyticsData } from './identity';
 
 const setPersonProperties = vi.fn();
 
@@ -11,21 +12,32 @@ vi.mock('./trackEvent', () => ({
   getDeviceType: () => 'desktop',
 }));
 
+// Stateful stand-in for the persisted analytics record: the dedupe guard
+// lives in this record, so the mock must behave like storage (writes are
+// visible to later loads), not return a fresh object per call.
+let record: AnalyticsData;
+
 vi.mock('./identity', () => ({
-  loadAnalyticsData: () => ({ featureFlags: {} }),
-  saveAnalyticsData: vi.fn(),
+  loadAnalyticsData: () => record,
+  saveAnalyticsData: (data: AnalyticsData) => {
+    record = data;
+  },
   getFirstSeenDate: () => '2026-01-01T00:00:00.000Z',
 }));
 
-import {
-  computeEngagementTier,
-  updatePersonProperties,
-  resetPersonPropertyCache,
-} from './eventsPerson';
+import { computeEngagementTier, updatePersonProperties } from './eventsPerson';
 
 beforeEach(() => {
   setPersonProperties.mockReset();
-  resetPersonPropertyCache();
+  record = {
+    userId: 'u1',
+    firstSeen: '2026-01-01T00:00:00.000Z',
+    featureFlags: {},
+    milestones: {},
+    designsCreated: 0,
+    lastSetPayload: '',
+    onceTraitsSent: false,
+  };
 });
 
 /** Calls that carry a non-empty first argument are `$set`; the rest are `$set_once`. */
@@ -51,7 +63,7 @@ describe('updatePersonProperties', () => {
     expect(setCalls()).toHaveLength(1);
   });
 
-  it('sends the once-only traits a single time per session', () => {
+  it('sends the once-only traits a single time per browser', () => {
     updatePersonProperties();
     updatePersonProperties();
 
@@ -77,6 +89,25 @@ describe('updatePersonProperties', () => {
     updatePersonProperties();
 
     expect(setCalls()).toHaveLength(2);
+  });
+
+  // Last in the file: vi.resetModules() re-creates the store modules, so any
+  // test running after it would read different store instances than the
+  // statically imported updatePersonProperties above.
+  it('does not resend after a reload when nothing changed', async () => {
+    vi.resetModules();
+    const firstLoad = await import('./eventsPerson');
+    firstLoad.updatePersonProperties();
+    expect(setCalls()).toHaveLength(1);
+    expect(setOnceCalls()).toHaveLength(1);
+
+    // A reload discards module state but keeps the persisted record.
+    vi.resetModules();
+    const secondLoad = await import('./eventsPerson');
+    secondLoad.updatePersonProperties();
+
+    expect(setCalls()).toHaveLength(1);
+    expect(setOnceCalls()).toHaveLength(1);
   });
 });
 

--- a/src/shared/analytics/posthog/eventsPerson.ts
+++ b/src/shared/analytics/posthog/eventsPerson.ts
@@ -41,25 +41,6 @@ export function computeEngagementTier(
 }
 
 /**
- * Serialized copy of the last `$set` payload we sent, and whether the
- * once-only traits have gone out yet this page session.
- *
- * `setPersonProperties` does not diff: every call emits a billable `$set`
- * event whether or not a value changed. This is called after any significant
- * action, so without a client-side guard a session emits one `$set` per
- * action (plus a second for the `$set_once` block) to restate values that
- * almost never move.
- */
-let lastSetPayload: string | null = null;
-let sentOnceTraits = false;
-
-/** Test seam: clears the memoized person-property payload. */
-export function resetPersonPropertyCache(): void {
-  lastSetPayload = null;
-  sentOnceTraits = false;
-}
-
-/**
  * Update person properties in PostHog.
  * Call this after significant actions to keep user profile up-to-date.
  *
@@ -118,9 +99,17 @@ export function updatePersonProperties(): void {
       primary_device: getDeviceType(),
     };
 
+    // `setPersonProperties` does not diff: every call emits a billable `$set`
+    // whether or not a value changed, and this runs after any significant
+    // action. The guard lives in the persisted analytics record because it
+    // has to survive reloads — held in module memory it reset on every
+    // pageload, which made `$set` volume scale with pageviews (a full resend
+    // plus the `$set_once` block per load) instead of with profile changes.
     const serialized = JSON.stringify(setProps);
-    if (serialized !== lastSetPayload) {
-      lastSetPayload = serialized;
+    let identityChanged = false;
+    if (serialized !== data.lastSetPayload) {
+      data.lastSetPayload = serialized;
+      identityChanged = true;
       posthogInstance.setPersonProperties(setProps);
     }
 
@@ -131,10 +120,11 @@ export function updatePersonProperties(): void {
     // `document.referrer` (which can change between navigations) overwrite
     // the original initial_referrer.
     //
-    // $set_once is server-side idempotent, so resending only costs events.
-    // Once per page session is enough to cover a first-ever visit.
-    if (!sentOnceTraits) {
-      sentOnceTraits = true;
+    // $set_once is server-side idempotent, so resending only costs events;
+    // the persisted marker makes it one send per browser.
+    if (!data.onceTraitsSent) {
+      data.onceTraitsSent = true;
+      identityChanged = true;
       posthogInstance.setPersonProperties(
         {},
         {
@@ -160,7 +150,7 @@ export function updatePersonProperties(): void {
         flagsChanged = true;
       }
     }
-    if (flagsChanged) {
+    if (identityChanged || flagsChanged) {
       saveAnalyticsData(data);
     }
   } catch {

--- a/src/shared/analytics/posthog/identity.ts
+++ b/src/shared/analytics/posthog/identity.ts
@@ -17,12 +17,26 @@ export interface AnalyticsData {
   /** Distinct bin designs created in this browser. Never decremented — deleting
    *  a design does not undo having made it. */
   designsCreated: number;
+  /** Serialized last `$set` payload sent to PostHog. Persisted because the
+   *  dedupe must survive reloads: `setPersonProperties` bills per call, not
+   *  per change (see eventsPerson.ts). */
+  lastSetPayload: string;
+  /** Whether the `$set_once` traits have ever been sent from this browser. */
+  onceTraitsSent: boolean;
 }
 
 let analyticsCache: AnalyticsData | null = null;
 
 export function createEmptyAnalyticsData(): AnalyticsData {
-  return { userId: '', firstSeen: '', featureFlags: {}, milestones: {}, designsCreated: 0 };
+  return {
+    userId: '',
+    firstSeen: '',
+    featureFlags: {},
+    milestones: {},
+    designsCreated: 0,
+    lastSetPayload: '',
+    onceTraitsSent: false,
+  };
 }
 
 export function loadAnalyticsData(): AnalyticsData {


### PR DESCRIPTION
## What

`updatePersonProperties` deduped the `$set` payload in module memory, so the guard reset on every pageload and each load re-sent the full person-properties payload plus the `$set_once` block, whether or not anything changed. PostHog bills `$set` per call, not per change, so `$set` volume scaled with pageviews instead of with profile changes.

The last-sent payload and the once-traits marker now live in the persisted analytics record, so a pageload only emits when a tracked value actually changed, and the `$set_once` traits go out once per browser.

## Notes

- `resetPersonPropertyCache` (test-only seam) is gone: there is no module state left to reset. Tests drive the persisted record directly.
- Privacy flows are unchanged: `pruneAnalyticsData` clears the whole record, so disabling analytics or clearing app data also resets the guard.
- Existing users send one final full `$set` on their first load after this deploys (no stored payload yet), then dedupe from there.

## Testing

- `pnpm run test:run src/shared/analytics/posthog/`: 143 passing, including a new reload-simulation test
- `pnpm run typecheck`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

