### PR TITLE
feat(bin-designer): make an explicit cutout label size a target, not a ceiling

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutEngraveLabelControls.test.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutEngraveLabelControls.test.tsx
@@ -81,3 +81,76 @@ describe('CutoutEngraveLabelControls relief depth', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe('CutoutEngraveLabelControls exact size', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+      history: { past: [], future: [] },
+    });
+  });
+
+  it('writes an exact size as a per-cutout fixed style', () => {
+    const onUpdate = renderControls(makeCutout());
+
+    fireEvent.click(screen.getByRole('button', { name: 'binDesigner.textSizeAuto' }));
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      textStyle: { sizeMode: 'fixed', fixedSize: expect.any(Number) as number },
+    });
+  });
+
+  it('seeds manual mode at the size currently rendering, not the slider max', () => {
+    const onUpdate = renderControls(makeCutout());
+
+    fireEvent.click(screen.getByRole('button', { name: 'binDesigner.textSizeAuto' }));
+
+    const patch = onUpdate.mock.calls[0][0] as { textStyle: { fixedSize: number } };
+    // A 2-char label beside a 10mm cutout in a 100mm bin auto-fits well under
+    // the 40mm slider ceiling; seeding at the ceiling was the old max-seed.
+    expect(patch.textStyle.fixedSize).toBeLessThan(40);
+    expect(patch.textStyle.fixedSize).toBeGreaterThan(0);
+  });
+
+  it('clears both the fixed size and any legacy ceiling on Auto', () => {
+    const onUpdate = renderControls(
+      makeCutout({ textStyle: { sizeMode: 'fixed', fixedSize: 12, fontSizeOverride: 8 } })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'binDesigner.textSizeAuto' }));
+
+    expect(onUpdate).toHaveBeenCalledWith({ textStyle: undefined });
+  });
+
+  it('shows a legacy ceiling in the slider so old designs stay editable', () => {
+    renderControls(makeCutout({ textStyle: { fontSizeOverride: 8 } }));
+
+    expect(screen.getByRole('slider', { name: 'binDesigner.textSize' })).toHaveAttribute(
+      'aria-valuenow',
+      '8'
+    );
+  });
+
+  it('warns with the rendered size when the bin cannot hold the request', () => {
+    // A 40mm request in a 30mm bin: even the widened band cannot hold it, so
+    // the label shrinks and the note names the size that actually prints.
+    render(
+      <CutoutEngraveLabelControls
+        cutout={makeCutout({ textStyle: { sizeMode: 'fixed', fixedSize: 40 } })}
+        binWidth={30}
+        binDepth={30}
+        disabled={false}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('alert').textContent).toContain('binDesigner.textSizeLimited');
+  });
+
+  it('shows no limit warning while the request fits', () => {
+    const onUpdate = renderControls(makeCutout({ textStyle: { sizeMode: 'fixed', fixedSize: 8 } }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutEngraveLabelControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutEngraveLabelControls.tsx
@@ -20,10 +20,16 @@ import type {
 import {
   CUTOUT_LABEL_MODES,
   TEXT_MAX_LENGTH,
-  withFontSizeOverride,
+  withExactLabelSize,
 } from '@/features/bin-designer/types';
 import { useDesignerStore } from '@/features/bin-designer/store';
-import { resolveCutoutTextAnchor } from '@/shared/utils/cutoutLabel';
+import {
+  cutoutLabelPlacement,
+  expandBandToInterior,
+  fitLabelRoom,
+  hasExplicitLabelSize,
+  resolveCutoutTextAnchor,
+} from '@/shared/utils/cutoutLabel';
 import { useTranslation } from '@/i18n';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
 import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
@@ -33,6 +39,7 @@ import { Button, Input } from '@/design-system';
 import { CutoutSocketControls } from './CutoutSocketControls';
 import { useCutoutSocketPlan } from '@/features/bin-designer/hooks/useCutoutSocketPlan';
 import { TYPE_BOUNDS } from '../panel/TypeSection/useTypeSection';
+import { fitLabelFontSize } from '../panel/CutoutsSection/renderer/cutoutLabelFit';
 
 /** 3×3 anchor grid in reading order; the glyph hints the position, the
  *  i18n'd aria-label names it. `center` = label sits over the cutout face. */
@@ -75,16 +82,29 @@ export function CutoutEngraveLabelControls({
   const offset = cutout.textOffset ?? { x: 0, y: 0 };
   const labelMode: CutoutLabelMode = cutout.labelMode === 'socket' ? 'socket' : 'engrave';
   const isSocket = labelMode === 'socket';
-  const textMode = useDesignerStore((s) => s.params.textDefaults.mode);
-  const textDepth = useDesignerStore((s) => s.params.textDefaults.depth);
-  const minFontSize = useDesignerStore((s) => s.params.textDefaults.minFontSize);
-  const maxFontSize = useDesignerStore((s) => s.params.textDefaults.maxFontSize);
+  const textDefaults = useDesignerStore((s) => s.params.textDefaults);
   const setTextDefaults = useDesignerStore((s) => s.setTextDefaults);
   const setCutoutArray = useDesignerStore((s) => s.setCutoutArray);
+  const { mode: textMode, depth: textDepth } = textDefaults;
 
-  const fontSizeOverride = cutout.textStyle?.fontSizeOverride;
-  const setFontSizeOverride = (size: number | null) => {
-    onUpdate({ textStyle: withFontSizeOverride(cutout.textStyle, size) });
+  // The size an explicit request would print at, mirrored from the engraver's
+  // own fit so the seed and the limited-note tell the truth. Also the value
+  // shown while Auto is active would seed from.
+  const explicitSize = hasExplicitLabelSize(cutout.textStyle);
+  const requestedSize = cutout.textStyle?.fixedSize ?? textDefaults.fixedSize;
+  const trimmedLabel = cutout.label.trim();
+  const placement = trimmedLabel === '' ? null : cutoutLabelPlacement(cutout, binWidth, binDepth);
+  let renderedSize: number | null = null;
+  if (placement) {
+    const banded = explicitSize
+      ? expandBandToInterior(placement, binWidth, binDepth)
+      : { ...placement, ...fitLabelRoom(placement.availW, placement.availD, cutout.array) };
+    renderedSize = fitLabelFontSize(trimmedLabel, banded, textDefaults, cutout.textStyle);
+  }
+  const sizeValue = explicitSize ? requestedSize : cutout.textStyle?.fontSizeOverride;
+  const sizeLimited = explicitSize && renderedSize !== null && renderedSize + 0.05 < requestedSize;
+  const setLabelSize = (size: number | null) => {
+    onUpdate({ textStyle: withExactLabelSize(cutout.textStyle, size) });
   };
   // Through-cut isn't offered for cutouts; show it as engrave so the picker
   // reflects what the generator will actually produce.
@@ -252,13 +272,22 @@ export function CutoutEngraveLabelControls({
         )}
       </div>
       {!isSocket && (
-        <LabelSizeControl
-          value={fontSizeOverride}
-          onChange={setFontSizeOverride}
-          min={minFontSize}
-          max={maxFontSize}
-          disabled={disabled}
-        />
+        <>
+          <LabelSizeControl
+            variant="exact"
+            value={sizeValue}
+            onChange={setLabelSize}
+            min={TYPE_BOUNDS.fixedSize.min}
+            max={TYPE_BOUNDS.fixedSize.max}
+            manualSeed={renderedSize ?? undefined}
+            disabled={disabled}
+          />
+          {sizeLimited && renderedSize !== null && (
+            <p role="alert" className="text-[10px] leading-snug text-warning">
+              {t('binDesigner.textSizeLimited', { size: renderedSize.toFixed(1) })}
+            </p>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/features/bin-designer/components/controls/LabelSizeControl/LabelSizeControl.tsx
+++ b/src/features/bin-designer/components/controls/LabelSizeControl/LabelSizeControl.tsx
@@ -2,15 +2,19 @@
  * Label-size control shared by the cutout inspector and the label-tab panel.
  *
  * Encodes the Auto convention in one place: `value === undefined` means
- * auto-fit, and toggling into manual mode seeds the override at `max` (the
- * largest size the band allows) rather than an arbitrary default. The slider is
- * only shown while an explicit size is set.
+ * auto-fit, and toggling into manual mode seeds the override at `manualSeed`
+ * (the size currently rendering, where the caller knows it) or `max`. The
+ * slider is only shown while an explicit size is set.
  *
- * The value is a CEILING, not a target — generation applies it as
- * `min(auto-fit, max(minFontSize, override))`, so a label that cannot fit at
- * this size still renders smaller, and label tabs additionally share one size
- * across each row. Titled and hinted accordingly so the number on screen is not
- * read as the printed size.
+ * Two variants, because the number means different things:
+ *  - `cap` (label tabs): a CEILING — generation applies it as
+ *    `min(auto-fit, max(minFontSize, override))`, so a label that cannot fit at
+ *    this size still renders smaller, and label tabs additionally share one
+ *    size across each row. Titled and hinted accordingly so the number on
+ *    screen is not read as the printed size.
+ *  - `exact` (cutout labels): a TARGET — the label renders at this size,
+ *    reaching over neighbouring cutouts if it must, and shrinks only when the
+ *    bin interior cannot hold it.
  */
 
 import { Button, SliderInput, cn } from '@/design-system';
@@ -29,6 +33,11 @@ interface LabelSizeControlProps {
   readonly className?: string;
   /** Typography for the row label, which differs between call sites. */
   readonly labelClassName?: string;
+  /** What the number means: a ceiling on auto-fit, or the rendered size. */
+  readonly variant?: 'cap' | 'exact';
+  /** Size to seed when leaving Auto — pass the currently rendered size so the
+   *  switch freezes what is on screen instead of jumping to `max`. */
+  readonly manualSeed?: number;
   /**
    * Explain that labels can render below the set size. Off by default: only
    * label tabs share a size across siblings, so only there does one label shrink
@@ -45,22 +54,29 @@ export function LabelSizeControl({
   disabled,
   className,
   labelClassName = 'text-[10px] text-content-tertiary',
+  variant = 'cap',
+  manualSeed,
   explainShared = false,
 }: LabelSizeControlProps) {
   const t = useTranslation();
   const isAuto = value === undefined;
+  const setLabel = variant === 'exact' ? t('binDesigner.textSize') : t('binDesigner.textSizeMax');
+  const info =
+    variant === 'exact'
+      ? t('binDesigner.textSizeExactHint')
+      : explainShared
+        ? t('binDesigner.textSizeCapHint')
+        : undefined;
 
   return (
     <div className={cn('space-y-1', className)}>
       <div className="flex items-center justify-between">
-        <span className={labelClassName}>
-          {isAuto ? t('binDesigner.textSize') : t('binDesigner.textSizeMax')}
-        </span>
+        <span className={labelClassName}>{isAuto ? t('binDesigner.textSize') : setLabel}</span>
         <Button
           type="button"
           variant="ghost"
           disabled={disabled}
-          onClick={() => onChange(isAuto ? max : null)}
+          onClick={() => onChange(isAuto ? Math.min(max, Math.max(min, manualSeed ?? max)) : null)}
           aria-pressed={isAuto}
           className={`px-1.5 py-0.5 text-[10px] leading-none ${getSegmentClass(isAuto)}`}
         >
@@ -69,7 +85,7 @@ export function LabelSizeControl({
       </div>
       {value !== undefined && (
         <SliderInput
-          label={t('binDesigner.textSizeMax')}
+          label={setLabel}
           value={value}
           onChange={onChange}
           min={min}
@@ -77,7 +93,7 @@ export function LabelSizeControl({
           step={0.5}
           unit="mm"
           disabled={disabled}
-          info={explainShared ? t('binDesigner.textSizeCapHint') : undefined}
+          info={info}
         />
       )}
     </div>

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
@@ -20,16 +20,20 @@ import type { Cutout } from '@/features/bin-designer/types';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import {
   cutoutLabelPlacement,
+  cutoutWorldAabb,
+  expandBandToInterior,
   fitLabelRoom,
+  hasExplicitLabelSize,
   labelPlacementForAabb,
   resolveCutoutTextAnchor,
 } from '@/shared/utils/cutoutLabel';
+import type { CutoutAabb } from '@/shared/utils/cutoutLabel';
 import {
   cutoutSocketAnchorAabb,
   isCutoutEngraveMode,
   isCutoutSocketMode,
 } from '@/shared/utils/cutoutLabelSocketPlan';
-import { labelledInstances } from '@/shared/utils/cutoutArray';
+import { expandCutoutArray, labelledInstances } from '@/shared/utils/cutoutArray';
 import {
   LABEL_PLATE_CORNER_RADIUS_MM,
   LABEL_PLATE_HEIGHT_MM,
@@ -39,7 +43,8 @@ import { useCutoutSocketPlan } from '@/features/bin-designer/hooks/useCutoutSock
 import { CutoutSocketFootprint } from './CutoutSocketFootprint';
 import type { PreviewMap } from '../useCutoutInteraction';
 import { cutoutLabelColors } from './cutoutLabelColor';
-import { fitLabelFontSize } from './cutoutLabelFit';
+import { aabbsIntersect, estimateLabelAabb, fitLabelFontSize } from './cutoutLabelFit';
+import { OFF_BOARD_COLOR } from './constants';
 
 interface CutoutLabel3DProps {
   readonly cutouts: readonly Cutout[];
@@ -78,6 +83,21 @@ export function CutoutLabel3D({
     () => cutoutLabelColors(binColor),
     [binColor]
   );
+
+  // Pocket footprints for the explicit-size overlap warning: an exact-size
+  // label that crosses a pocket loses the glyph parts over the opening, so its
+  // halo goes red — same signal as the off-board frames. Committed positions
+  // only; a drag preview warns after release.
+  const pocketAabbs = useMemo(() => {
+    const list: { id: string; aabb: CutoutAabb }[] = [];
+    for (const c of cutouts) {
+      if (c.hidden === true) continue;
+      for (const instance of expandCutoutArray(c)) {
+        list.push({ id: instance.id, aabb: cutoutWorldAabb(instance, 0, 0) });
+      }
+    }
+    return list;
+  }, [cutouts]);
 
   return (
     <>
@@ -164,16 +184,41 @@ export function CutoutLabel3D({
           const placement = cutoutLabelPlacement(instance, binWidth, binDepth);
           if (!placement) return null;
 
-          // Same cap the engraver applies, so the editor shows the size that
-          // will actually be cut.
-          const room = fitLabelRoom(placement.availW, placement.availD, effective.array);
-          const fontSize = fitLabelFontSize(
-            label,
-            { ...placement, ...room },
-            textDefaults,
-            instance.textStyle?.fontSizeOverride
-          );
+          // Same band the engraver uses, so the editor shows the size that
+          // will actually be cut: an explicit size widens the band to the
+          // interior, auto-fit keeps the anchor band capped to a repeat copy's
+          // room.
+          const explicit = hasExplicitLabelSize(instance.textStyle);
+          const banded = explicit
+            ? expandBandToInterior(placement, binWidth, binDepth)
+            : {
+                ...placement,
+                ...fitLabelRoom(placement.availW, placement.availD, effective.array),
+              };
+          const fontSize = fitLabelFontSize(label, banded, textDefaults, instance.textStyle);
           if (fontSize === null) return null;
+
+          // Explicit sizes are allowed to reach over pockets; warn where they
+          // do, since glyph parts over an opening are cut away. A center
+          // anchor's own pocket is exempt — sitting over it is the placement.
+          // `::a0` is the master's own footprint when an unlabelled repeat
+          // engraves once beside the master box.
+          let overlapsPocket = false;
+          if (explicit) {
+            const box = estimateLabelAabb(
+              label,
+              fontSize,
+              placement.centerX,
+              placement.centerY,
+              effective.textAngle ?? 0
+            );
+            const anchor = resolveCutoutTextAnchor(instance);
+            const ownIds =
+              anchor === 'center' ? new Set([instance.id, `${instance.id}::a0`]) : null;
+            overlapsPocket = pocketAabbs.some(
+              (p) => !ownIds?.has(p.id) && aabbsIntersect(p.aabb, box)
+            );
+          }
 
           return (
             <Text
@@ -184,7 +229,7 @@ export function CutoutLabel3D({
               color={labelFill}
               fillOpacity={TEXT_OPACITY}
               outlineWidth={OUTLINE_WIDTH}
-              outlineColor={labelOutline}
+              outlineColor={overlapsPocket ? OFF_BOARD_COLOR : labelOutline}
               outlineOpacity={1}
               anchorX="center"
               anchorY="middle"

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/cutoutLabelFit.test.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/cutoutLabelFit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fitLabelFontSize } from './cutoutLabelFit';
+import { aabbsIntersect, estimateLabelAabb, fitLabelFontSize } from './cutoutLabelFit';
 import type { TextStyleDefaults } from '@/features/bin-designer/types';
 import { DEFAULT_TEXT_STYLE_DEFAULTS } from '@/features/bin-designer/types';
 import type { CutoutLabelPlacement } from '@/shared/utils/cutoutLabel';
@@ -19,7 +19,7 @@ describe('fitLabelFontSize', () => {
 
   it('caps the size at the override when it fits below auto-fit', () => {
     const auto = fitLabelFontSize('A', roomy, defaults, undefined);
-    const capped = fitLabelFontSize('A', roomy, defaults, 6);
+    const capped = fitLabelFontSize('A', roomy, defaults, { fontSizeOverride: 6 });
     expect(auto).not.toBeNull();
     expect(capped).toBe(6);
     expect(capped!).toBeLessThan(auto!);
@@ -30,7 +30,7 @@ describe('fitLabelFontSize', () => {
     // override must collapse to that, mirroring the worker's band clamp.
     const narrow: CutoutLabelPlacement = { centerX: 0, centerY: 0, availW: 200, availD: 8 };
     const auto = fitLabelFontSize('A', narrow, defaults, undefined);
-    const over = fitLabelFontSize('A', narrow, defaults, 12);
+    const over = fitLabelFontSize('A', narrow, defaults, { fontSizeOverride: 12 });
     expect(auto).toBeCloseTo(5, 6);
     expect(over).toBeCloseTo(auto!, 6);
   });
@@ -39,12 +39,72 @@ describe('fitLabelFontSize', () => {
     // The UI can't produce this (slider min = minFontSize), but a crafted share
     // can. The band fits well above 3mm, so a 1mm override clamps up to 3mm
     // rather than rendering illegibly small.
-    expect(fitLabelFontSize('A', roomy, defaults, 1)).toBe(3);
+    expect(fitLabelFontSize('A', roomy, defaults, { fontSizeOverride: 1 })).toBe(3);
   });
 
   it('returns null when even the floor overflows, override notwithstanding', () => {
     const tiny: CutoutLabelPlacement = { centerX: 0, centerY: 0, availW: 200, availD: 4 };
     // availD 4 − 3 = 1mm < 3mm floor → dropped, same as auto-fit.
-    expect(fitLabelFontSize('A', tiny, defaults, 3)).toBeNull();
+    expect(fitLabelFontSize('A', tiny, defaults, { fontSizeOverride: 3 })).toBeNull();
+  });
+
+  it('honours an explicit fixed size past the auto-fit ceiling', () => {
+    // 25mm exceeds maxFontSize (20) — a target is not capped by the auto
+    // ceiling, matching the worker's fixed path.
+    const size = fitLabelFontSize('A', roomy, defaults, { sizeMode: 'fixed', fixedSize: 25 });
+    expect(size).toBe(25);
+  });
+
+  it('shrinks an explicit size only to what the band holds', () => {
+    const narrow: CutoutLabelPlacement = { centerX: 0, centerY: 0, availW: 200, availD: 8 };
+    const size = fitLabelFontSize('A', narrow, defaults, { sizeMode: 'fixed', fixedSize: 12 });
+    expect(size).toBeCloseTo(5, 6);
+  });
+
+  it('drops an explicit label the band cannot hold legibly', () => {
+    const tiny: CutoutLabelPlacement = { centerX: 0, centerY: 0, availW: 200, availD: 4 };
+    expect(fitLabelFontSize('A', tiny, defaults, { sizeMode: 'fixed', fixedSize: 12 })).toBeNull();
+  });
+
+  it('honours a sub-floor explicit size that fits, unlike an override', () => {
+    // The fixed path has no legibility floor on the asked-for size itself —
+    // only the shrink is floored. Mirrors the worker exactly.
+    expect(fitLabelFontSize('A', roomy, defaults, { sizeMode: 'fixed', fixedSize: 2 })).toBe(2);
+  });
+
+  it('ignores a leftover fontSizeOverride once a fixed size is set', () => {
+    const size = fitLabelFontSize('A', roomy, defaults, {
+      sizeMode: 'fixed',
+      fixedSize: 10,
+      fontSizeOverride: 4,
+    });
+    expect(size).toBe(10);
+  });
+});
+
+describe('estimateLabelAabb', () => {
+  it('sizes the box from the glyph-width estimate, centered on the anchor', () => {
+    const box = estimateLabelAabb('ABCD', 10, 50, 20, 0);
+    // 4 chars × 0.6 ratio × 10mm = 24mm wide, 10mm tall.
+    expect(box.maxX - box.minX).toBeCloseTo(24, 6);
+    expect(box.maxY - box.minY).toBeCloseTo(10, 6);
+    expect((box.minX + box.maxX) / 2).toBeCloseTo(50, 6);
+    expect((box.minY + box.maxY) / 2).toBeCloseTo(20, 6);
+  });
+
+  it('is rotation-aware: a 90° label swaps its extents', () => {
+    const box = estimateLabelAabb('ABCD', 10, 0, 0, 90);
+    expect(box.maxX - box.minX).toBeCloseTo(10, 6);
+    expect(box.maxY - box.minY).toBeCloseTo(24, 6);
+  });
+});
+
+describe('aabbsIntersect', () => {
+  const a = { minX: 0, maxX: 10, minY: 0, maxY: 10 };
+
+  it('detects overlap and rejects touching edges', () => {
+    expect(aabbsIntersect(a, { minX: 5, maxX: 15, minY: 5, maxY: 15 })).toBe(true);
+    expect(aabbsIntersect(a, { minX: 10, maxX: 20, minY: 0, maxY: 10 })).toBe(false);
+    expect(aabbsIntersect(a, { minX: 11, maxX: 20, minY: 0, maxY: 10 })).toBe(false);
   });
 });

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/cutoutLabelFit.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/cutoutLabelFit.ts
@@ -3,20 +3,25 @@
  *
  * Mirrors the worker's `buildTextSolid` sizing so the on-screen label tracks
  * the printed engraving: fit to the available band, then let an explicit
- * `fontSizeOverride` cap (never grow) the result. Kept out of the R3F component
+ * `fontSizeOverride` cap (never grow) the result — or, when the per-cutout
+ * style pins `sizeMode: 'fixed'`, render the asked-for size and shrink only
+ * when the band cannot hold it. Kept out of the R3F component
  * file so it can be unit-tested without rendering (react-refresh forbids
  * non-component exports there).
  */
 
-import type { TextStyleDefaults } from '@/features/bin-designer/types';
-import type { CutoutLabelPlacement } from '@/shared/utils/cutoutLabel';
+import type { TextStyleDefaults, TextStyleOverride } from '@/features/bin-designer/types';
+import { cutoutWorldAabb, hasExplicitLabelSize } from '@/shared/utils/cutoutLabel';
+import type { CutoutAabb, CutoutLabelPlacement } from '@/shared/utils/cutoutLabel';
 
 /** Approximate width of a glyph relative to font size for drei's SDF font. */
 const CHAR_WIDTH_RATIO = 0.6;
 
 /**
  * Largest font size (mm) whose estimated bbox fits the band, clamped to the
- * design's min/max and then capped by `fontSizeOverride` when set. Returns
+ * design's min/max and then shaped by the per-cutout style: an explicit fixed
+ * size is a target the band no longer caps (the caller hands the widened band
+ * in), a `fontSizeOverride` caps (never grows) the auto-fit. Returns
  * `null` when even the floor overflows — matching the worker, which skips the
  * engraving rather than shrink it illegibly.
  */
@@ -24,18 +29,58 @@ export function fitLabelFontSize(
   label: string,
   placement: CutoutLabelPlacement,
   textDefaults: TextStyleDefaults,
-  fontSizeOverride: number | undefined
+  textStyle: TextStyleOverride | undefined
 ): number | null {
   const availW = placement.availW - 2 * textDefaults.margin;
   const availD = placement.availD - 2 * textDefaults.margin;
   if (availW <= 0 || availD <= 0) return null;
   const widthLimited = availW / (label.length * CHAR_WIDTH_RATIO);
   const fitted = Math.min(widthLimited, availD);
+  if (hasExplicitLabelSize(textStyle)) {
+    // Matches the worker's fixed path: the asked-for size is honoured whenever
+    // it fits (uncapped by maxFontSize, unfloored by minFontSize), and shrinks
+    // only to fit — with the legibility floor applying to the shrink alone.
+    const target = textStyle?.fixedSize ?? textDefaults.fixedSize;
+    if (target <= fitted) return target;
+    return fitted >= textDefaults.minFontSize ? fitted : null;
+  }
   if (fitted < textDefaults.minFontSize) return null;
   const autoFit = Math.min(fitted, textDefaults.maxFontSize);
+  const fontSizeOverride = textStyle?.fontSizeOverride;
   // Cap at the override, floored at minFontSize (autoFit is already ≥ it) so a
   // crafted sub-floor override still renders legibly — matches the worker.
   return fontSizeOverride !== undefined
     ? Math.min(autoFit, Math.max(textDefaults.minFontSize, fontSizeOverride))
     : autoFit;
+}
+
+/**
+ * Estimated world AABB of a rendered label, from the same glyph-width
+ * approximation the size fit uses, rotation-aware like a cutout footprint.
+ * Drives the overlap warning for explicit-size labels; an estimate is enough,
+ * because the warning flags a placement decision, not a measurement.
+ */
+export function estimateLabelAabb(
+  label: string,
+  fontSize: number,
+  centerX: number,
+  centerY: number,
+  angleDeg: number
+): CutoutAabb {
+  const width = label.length * CHAR_WIDTH_RATIO * fontSize;
+  return cutoutWorldAabb(
+    {
+      x: centerX - width / 2,
+      y: centerY - fontSize / 2,
+      width,
+      depth: fontSize,
+      rotation: angleDeg,
+    },
+    0,
+    0
+  );
+}
+
+export function aabbsIntersect(a: CutoutAabb, b: CutoutAabb): boolean {
+  return a.minX < b.maxX && b.minX < a.maxX && a.minY < b.maxY && b.minY < a.maxY;
 }

--- a/src/features/bin-designer/types/index.ts
+++ b/src/features/bin-designer/types/index.ts
@@ -60,6 +60,7 @@ export {
   resolveTextStyle,
   snapToTypeScale,
   splitTextLines,
+  withExactLabelSize,
   withFontSizeOverride,
   WALL_TEXT_SIDES,
   WALL_TEXT_ALIGNS,

--- a/src/features/bin-designer/types/text.test.ts
+++ b/src/features/bin-designer/types/text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { withFontSizeOverride } from './text';
+import { withExactLabelSize, withFontSizeOverride } from './text';
 
 describe('withFontSizeOverride', () => {
   it('sets the override on an absent style', () => {
@@ -22,5 +22,31 @@ describe('withFontSizeOverride', () => {
   it('returns undefined when clearing leaves an empty style', () => {
     expect(withFontSizeOverride({ fontSizeOverride: 5 }, null)).toBeUndefined();
     expect(withFontSizeOverride(undefined, null)).toBeUndefined();
+  });
+});
+
+describe('withExactLabelSize', () => {
+  it('pins the fixed mode and size', () => {
+    expect(withExactLabelSize(undefined, 8)).toEqual({ sizeMode: 'fixed', fixedSize: 8 });
+  });
+
+  it('drops a legacy ceiling when setting, keeping other fields', () => {
+    expect(withExactLabelSize({ font: 'atkinson', fontSizeOverride: 4 }, 9)).toEqual({
+      font: 'atkinson',
+      sizeMode: 'fixed',
+      fixedSize: 9,
+    });
+  });
+
+  it('clears size fields and the ceiling together, preserving the rest', () => {
+    expect(withExactLabelSize({ font: 'atkinson', sizeMode: 'fixed', fixedSize: 9 }, null)).toEqual(
+      { font: 'atkinson' }
+    );
+  });
+
+  it('collapses to undefined when clearing leaves nothing', () => {
+    expect(withExactLabelSize({ sizeMode: 'fixed', fixedSize: 9, fontSizeOverride: 4 }, null)).toBe(
+      undefined
+    );
   });
 });

--- a/src/features/bin-designer/types/text.ts
+++ b/src/features/bin-designer/types/text.ts
@@ -306,6 +306,24 @@ export function withFontSizeOverride(
   return { ...rest, fontSizeOverride: size };
 }
 
+/**
+ * Set (`size` in mm) or clear (`null`) an exact label size on a text style:
+ * `sizeMode: 'fixed'` plus the size, which generation treats as a target
+ * rather than a ceiling. Setting or clearing also drops any legacy
+ * `fontSizeOverride` — the two mechanisms answer the same question, so leaving
+ * the ceiling behind would silently cap a design that just asked for exact.
+ * Returns `undefined` when the result would be empty, like
+ * {@link withFontSizeOverride}.
+ */
+export function withExactLabelSize(
+  current: TextStyleOverride | undefined,
+  size: number | null
+): TextStyleOverride | undefined {
+  const { fontSizeOverride: _o, sizeMode: _m, fixedSize: _f, ...rest } = current ?? {};
+  if (size === null) return Object.keys(rest).length > 0 ? rest : undefined;
+  return { ...rest, sizeMode: 'fixed', fixedSize: size };
+}
+
 /** Hard cap on a single LINE of text. Input above this is rejected. */
 export const TEXT_MAX_LENGTH = 50;
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.exactLabelSize.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.exactLabelSize.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+/**
+ * An explicit per-cutout label size is a target, not a ceiling.
+ *
+ * Auto-fit caps a labelled repeat's captions to the pitch so neighbours meet
+ * instead of printing over each other; an explicit `sizeMode: 'fixed'` on the
+ * cutout has to beat that cap and the anchor band, shrinking only when the bin
+ * interior itself runs out. Tool-level tests cannot prove what survives the
+ * boolean stage, so this measures at mesh level: with embossed text and no
+ * stacking lip, every vertex above the fill top belongs to a glyph, and the
+ * glyph Y-extent is the rendered text height.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { loadTestFonts } from '@/test/loadTestFonts';
+import { loadFont, isErr } from 'brepjs';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams, TextStyleOverride } from '@/shared/types/bin';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+
+beforeAll(async () => {
+  await initBrepjs();
+  await loadTestFonts();
+  const buffer = readFileSync(
+    resolve(__dirname, '../../../../shared/fonts/assets/AtkinsonHyperlegible-Regular.ttf')
+  );
+  const result = await loadFont(
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+    'atkinson'
+  );
+  if (isErr(result)) throw new Error(`Font load failed: ${result.error.message}`);
+}, 60000);
+
+/** Three holes at a tight pitch — the case auto-fit caps captions hard. */
+function binWithLabelledRow(label: string, textStyle?: TextStyleOverride): BinParams {
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    width: 3,
+    depth: 2,
+    height: 3,
+    style: 'solid',
+    base: { ...DEFAULT_BIN_PARAMS.base, solid: true, stackingLip: false },
+    textDefaults: { ...DEFAULT_BIN_PARAMS.textDefaults, mode: 'emboss' },
+    cutoutConfig: { topOffset: 0 },
+    cutouts: [
+      {
+        id: 'c1',
+        shape: 'circle',
+        x: 8,
+        y: 8,
+        width: 12,
+        depth: 12,
+        cutDepth: 4,
+        rotation: 0,
+        cornerRadius: 0,
+        label,
+        engraveLabel: label !== '',
+        textAnchor: 'top',
+        groupId: null,
+        textStyle,
+        array: {
+          mode: 'grid',
+          cols: 3,
+          rows: 1,
+          pitchX: 14,
+          pitchY: 14,
+          count: 3,
+          radius: 20,
+          startAngle: 0,
+          rotateToCenter: false,
+          labels: label === '' ? undefined : [label, label, label],
+        },
+      },
+    ],
+  };
+}
+
+/** Y-extent of every vertex above `topZ` — the rendered glyph height. */
+function glyphYSpan(vertices: Float32Array | number[], topZ: number): number {
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (let i = 2; i < vertices.length; i += 3) {
+    if (vertices[i] > topZ + 0.05) {
+      const y = vertices[i - 1];
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+  }
+  return maxY > minY ? maxY - minY : 0;
+}
+
+describe('explicit cutout label size', () => {
+  it('renders past the pitch cap at the asked-for size, auto stays capped', () => {
+    const generateBin = getGenerateBin();
+
+    const bare = generateBin(binWithLabelledRow(''));
+    const topZ = (() => {
+      let max = -Infinity;
+      for (let i = 2; i < bare.vertices.length; i += 3) {
+        if (bare.vertices[i] > max) max = bare.vertices[i];
+      }
+      return max;
+    })();
+
+    const auto = generateBin(binWithLabelledRow('II'));
+    const exact = generateBin(binWithLabelledRow('II', { sizeMode: 'fixed', fixedSize: 18 }));
+
+    for (const mesh of [bare, auto, exact]) {
+      expect(mesh.triangleCount).toBeGreaterThan(0);
+      expect(mesh.vertices.some((v) => !Number.isFinite(v))).toBe(false);
+    }
+
+    const autoSpan = glyphYSpan(auto.vertices, topZ);
+    const exactSpan = glyphYSpan(exact.vertices, topZ);
+
+    // Auto-fit is pitch-capped: the caption cannot exceed the 14mm the copy
+    // owns, minus margins. The glyph extent is the cap-height fraction of
+    // that, so anything approaching the pitch means the cap failed.
+    expect(autoSpan).toBeGreaterThan(0);
+    expect(autoSpan).toBeLessThan(14);
+
+    // The explicit 18mm ignores the pitch cap and the anchor band, so its
+    // glyphs measure well past both the auto size and the pitch itself.
+    expect(exactSpan).toBeGreaterThan(autoSpan * 1.5);
+    expect(exactSpan).toBeGreaterThan(14 * 0.7);
+  }, 240000);
+});

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -59,7 +59,12 @@ import {
 } from '@/shared/utils/cutoutArray';
 import { dropCoincidentPoints } from '@/shared/utils/polyline';
 import { pointInPolyline } from '@/shared/utils/drawerOutlineGeometry';
-import { cutoutLabelPlacement, fitLabelRoom } from '@/shared/utils/cutoutLabel';
+import {
+  cutoutLabelPlacement,
+  expandBandToInterior,
+  fitLabelRoom,
+  hasExplicitLabelSize,
+} from '@/shared/utils/cutoutLabel';
 import { combineGroupSolids } from './cutoutGroupOps';
 import {
   resolveScoop,
@@ -1633,13 +1638,18 @@ function buildCutoutLabel(
   const placement = cutoutLabelPlacement(cutout, innerW, innerD, originX, originY);
   if (!placement) return null;
   const { centerX, centerY } = placement;
-  // Capped to the room one copy owns, so a labelled repeat's captions meet
-  // rather than print over each other.
-  const { availW, availD } = fitLabelRoom(placement.availW, placement.availD, repeat);
+  // An explicit per-cutout size is a target: the band widens to the interior
+  // and skips the repeat pitch cap, so the label prints at the asked-for size
+  // (overlapping neighbours if it must — the editor warns) and shrinks only
+  // when the bin itself cannot hold it. Auto-fit keeps the anchor band, capped
+  // to the room one copy of a repeat owns so captions meet rather than print
+  // over each other.
+  const { availW, availD } = hasExplicitLabelSize(cutout.textStyle)
+    ? expandBandToInterior(placement, innerW, innerD, originX, originY)
+    : fitLabelRoom(placement.availW, placement.availD, repeat);
 
-  // Per-cutout style layers over the design-wide defaults (today the UI only
-  // writes `fontSizeOverride`, but merging the whole override keeps this in step
-  // with the label tab and future per-cutout fields).
+  // Per-cutout style layers over the design-wide defaults, in step with the
+  // label tab's own override handling.
   const style = resolveTextStyle(textDefaults, cutout.textStyle);
 
   // Cutouts support engrave + emboss; through-cut would punch the floor, so it

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Velikost štítku",
   "binDesigner.textSizeAuto": "Automaticky",
   "binDesigner.textSizeCapHint": "Jazýčky v řadě sdílejí velikost, takže delší štítek zmenší ostatní.",
+  "binDesigner.textSizeExactHint": "Tiskne se v této velikosti. Může zasahovat přes okolní výřezy; zmenší se jen tehdy, když v boxu nezbývá místo.",
+  "binDesigner.textSizeLimited": "Velikost boxu omezuje tento popisek na {size} mm",
   "binDesigner.textSizeMax": "Max. velikost štítku",
   "binDesigner.threeDModel": "3D model",
   "binDesigner.threeDModelDescription": "Exportuj soubor tisknutelného 3D modelu",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Textgröße",
   "binDesigner.textSizeAuto": "Auto",
   "binDesigner.textSizeCapHint": "Tabs einer Reihe teilen eine Größe – eine längere Beschriftung verkleinert die übrigen.",
+  "binDesigner.textSizeExactHint": "Wird in dieser Größe gedruckt. Er kann über benachbarte Aussparungen reichen und schrumpft nur, wenn der Bin keinen Platz lässt.",
+  "binDesigner.textSizeLimited": "Die Bin-Größe begrenzt dieses Label auf {size} mm",
   "binDesigner.textSizeMax": "Max. Beschriftungsgröße",
   "binDesigner.threeDModel": "3D-Modell",
   "binDesigner.threeDModelDescription": "Eine druckbare 3D-Modelldatei exportieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1926,6 +1926,9 @@ const en: Record<string, string> = {
   'binDesigner.textSize': 'Label size',
   'binDesigner.textSizeMax': 'Max label size',
   'binDesigner.textSizeCapHint': 'Tabs in a row share a size, so a longer label shrinks the rest.',
+  'binDesigner.textSizeExactHint':
+    'Prints at this size. It can reach over nearby cutouts, and shrinks only when the bin leaves no room.',
+  'binDesigner.textSizeLimited': 'Bin size limits this label to {size} mm',
   'binDesigner.textSizeAuto': 'Auto',
   'binDesigner.cutoutEngraveLabel': 'Engrave label',
   'binDesigner.cutoutEngraveLabelPlaceholder': 'e.g. M4×20',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Tamaño del texto",
   "binDesigner.textSizeAuto": "Automático",
   "binDesigner.textSizeCapHint": "Las pestañas de una fila comparten tamaño, así que una etiqueta más larga reduce las demás.",
+  "binDesigner.textSizeExactHint": "Se imprime a este tamaño. Puede extenderse sobre recortes cercanos y solo se reduce cuando el bin no deja espacio.",
+  "binDesigner.textSizeLimited": "El tamaño del bin limita esta etiqueta a {size} mm",
   "binDesigner.textSizeMax": "Tamaño máx. de etiqueta",
   "binDesigner.threeDModel": "Modelo 3D",
   "binDesigner.threeDModelDescription": "Exportar un archivo de modelo 3D imprimible",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Taille du texte",
   "binDesigner.textSizeAuto": "Auto",
   "binDesigner.textSizeCapHint": "Les languettes d’une rangée partagent une taille : une étiquette plus longue réduit les autres.",
+  "binDesigner.textSizeExactHint": "S'imprime à cette taille. Elle peut déborder sur les découpes voisines et ne rétrécit que lorsque le bin ne laisse plus de place.",
+  "binDesigner.textSizeLimited": "La taille du bin limite cette étiquette à {size} mm",
   "binDesigner.textSizeMax": "Taille max. d’étiquette",
   "binDesigner.threeDModel": "Modèle 3D",
   "binDesigner.threeDModelDescription": "Exporter un fichier de modèle 3D imprimable",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Dimensione testo",
   "binDesigner.textSizeAuto": "Auto",
   "binDesigner.textSizeCapHint": "Le linguette di una fila condividono la dimensione, quindi un’etichetta più lunga riduce le altre.",
+  "binDesigner.textSizeExactHint": "Viene stampata a questa dimensione. Può estendersi sopra i ritagli vicini e si riduce solo quando il bin non lascia spazio.",
+  "binDesigner.textSizeLimited": "La dimensione del bin limita questa etichetta a {size} mm",
   "binDesigner.textSizeMax": "Dimensione max etichetta",
   "binDesigner.threeDModel": "Modello 3D",
   "binDesigner.threeDModelDescription": "Esporta un file di modello 3D stampabile",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "文字サイズ",
   "binDesigner.textSizeAuto": "自動",
   "binDesigner.textSizeCapHint": "同じ列のタブはサイズを共有するため、長いラベルがあると他が小さくなります。",
+  "binDesigner.textSizeExactHint": "このサイズで印刷されます。近くのカットアウトに重なることがあり、bin に余地がない場合のみ縮小されます。",
+  "binDesigner.textSizeLimited": "bin のサイズによりこのラベルは {size} mm に制限されます",
   "binDesigner.textSizeMax": "ラベルの最大サイズ",
   "binDesigner.threeDModel": "3Dモデル",
   "binDesigner.threeDModelDescription": "印刷可能な3Dモデルファイルをエクスポート",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "라벨 크기",
   "binDesigner.textSizeAuto": "자동",
   "binDesigner.textSizeCapHint": "한 줄의 탭들은 크기를 공유하므로, 긴 라벨은 나머지를 작게 만듭니다.",
+  "binDesigner.textSizeExactHint": "이 크기로 인쇄됩니다. 주변 컷아웃 위로 넘어갈 수 있으며 bin에 공간이 없을 때만 줄어듭니다.",
+  "binDesigner.textSizeLimited": "bin 크기로 인해 이 라벨은 {size} mm로 제한됩니다",
   "binDesigner.textSizeMax": "최대 라벨 크기",
   "binDesigner.threeDModel": "3D 모델",
   "binDesigner.threeDModelDescription": "인쇄 가능한 3D 모델 파일 내보내기",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Tekststørrelse",
   "binDesigner.textSizeAuto": "Auto",
   "binDesigner.textSizeCapHint": "Fliker i en rad deler størrelse, så en lengre etikett krymper de andre.",
+  "binDesigner.textSizeExactHint": "Skrives ut i denne størrelsen. Den kan strekke seg over nærliggende utskjæringer, og krymper bare når det ikke er plass i bin-en.",
+  "binDesigner.textSizeLimited": "Bin-størrelsen begrenser denne etiketten til {size} mm",
   "binDesigner.textSizeMax": "Maks etikettstørrelse",
   "binDesigner.threeDModel": "3D-modell",
   "binDesigner.threeDModelDescription": "Eksporter en utskriftbar 3D-modellfil",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Tekstgrootte",
   "binDesigner.textSizeAuto": "Auto",
   "binDesigner.textSizeCapHint": "Tabs in een rij delen één grootte, dus een langer label verkleint de rest.",
+  "binDesigner.textSizeExactHint": "Wordt op deze grootte geprint. Het kan over nabijgelegen uitsparingen reiken en krimpt alleen als de bin geen ruimte laat.",
+  "binDesigner.textSizeLimited": "De bin-grootte beperkt dit label tot {size} mm",
   "binDesigner.textSizeMax": "Max. labelgrootte",
   "binDesigner.threeDModel": "3D-model",
   "binDesigner.threeDModelDescription": "Exporteer een printbaar 3D-modelbestand",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Rozmiar etykiety",
   "binDesigner.textSizeAuto": "Auto",
   "binDesigner.textSizeCapHint": "Zakładki w rzędzie dzielą jeden rozmiar, więc dłuższa etykieta zmniejsza pozostałe.",
+  "binDesigner.textSizeExactHint": "Drukuje się w tym rozmiarze. Może sięgać nad sąsiednie wycięcia i zmniejsza się tylko wtedy, gdy w binie brakuje miejsca.",
+  "binDesigner.textSizeLimited": "Rozmiar bina ogranicza tę etykietę do {size} mm",
   "binDesigner.textSizeMax": "Maks. rozmiar etykiety",
   "binDesigner.threeDModel": "Model 3D",
   "binDesigner.threeDModelDescription": "Eksportuj plik modelu 3D gotowy do druku",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Tamanho do texto",
   "binDesigner.textSizeAuto": "Automático",
   "binDesigner.textSizeCapHint": "As abas de uma fileira compartilham o tamanho, então uma etiqueta mais longa reduz as demais.",
+  "binDesigner.textSizeExactHint": "Imprime neste tamanho. Pode avançar sobre recortes próximos e só encolhe quando o bin não deixa espaço.",
+  "binDesigner.textSizeLimited": "O tamanho do bin limita este rótulo a {size} mm",
   "binDesigner.textSizeMax": "Tamanho máx. da etiqueta",
   "binDesigner.threeDModel": "Modelo 3D",
   "binDesigner.threeDModelDescription": "Exportar um arquivo de modelo 3D imprimível",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Textstorlek",
   "binDesigner.textSizeAuto": "Auto",
   "binDesigner.textSizeCapHint": "Flikar i en rad delar storlek, så en längre etikett krymper de övriga.",
+  "binDesigner.textSizeExactHint": "Skrivs ut i den här storleken. Den kan sträcka sig över närliggande urtag och krymper bara när bin-en inte lämnar plats.",
+  "binDesigner.textSizeLimited": "Bin-storleken begränsar denna etikett till {size} mm",
   "binDesigner.textSizeMax": "Max etikettstorlek",
   "binDesigner.threeDModel": "3D-modell",
   "binDesigner.threeDModelDescription": "Exportera en utskriftsbar 3D-modellfil",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "Розмір тексту",
   "binDesigner.textSizeAuto": "Авто",
   "binDesigner.textSizeCapHint": "Вкладки в одному рядку мають спільний розмір, тож довший підпис зменшує решту.",
+  "binDesigner.textSizeExactHint": "Друкується в цьому розмірі. Може заходити на сусідні вирізи та зменшується лише тоді, коли в bin не лишається місця.",
+  "binDesigner.textSizeLimited": "Розмір bin обмежує цю мітку до {size} мм",
   "binDesigner.textSizeMax": "Макс. розмір підпису",
   "binDesigner.threeDModel": "3D-модель",
   "binDesigner.threeDModelDescription": "Експортувати придатний для друку файл 3D-моделі",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1718,6 +1718,8 @@
   "binDesigner.textSize": "标签大小",
   "binDesigner.textSizeAuto": "自动",
   "binDesigner.textSizeCapHint": "同一行的标签片共用一个大小，因此更长的标签会缩小其余标签。",
+  "binDesigner.textSizeExactHint": "以此尺寸打印。它可以延伸到附近的切口上方，仅在 bin 没有空间时才会缩小。",
+  "binDesigner.textSizeLimited": "bin 尺寸将此标签限制为 {size} 毫米",
   "binDesigner.textSizeMax": "最大标签大小",
   "binDesigner.threeDModel": "3D 模型",
   "binDesigner.threeDModelDescription": "导出一个可打印的 3D 模型文件",

--- a/src/shared/utils/cutoutLabel.test.ts
+++ b/src/shared/utils/cutoutLabel.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   cutoutWorldAabb,
   cutoutLabelPlacement,
+  expandBandToInterior,
   fitLabelRoom,
+  hasExplicitLabelSize,
   resolveCutoutTextAnchor,
 } from './cutoutLabel';
 import type { Cutout, CutoutArrayConfig } from '@/shared/types/bin';
@@ -261,6 +263,52 @@ describe('fitLabelRoom', () => {
     expect(fitLabelRoom(160, 160, cfg({ mode: 'radial', count: 1, labels: ['a'] }))).toEqual({
       availW: 160,
       availD: 160,
+    });
+  });
+});
+
+describe('hasExplicitLabelSize', () => {
+  it('fires only on a per-cutout fixed size mode', () => {
+    expect(hasExplicitLabelSize(undefined)).toBe(false);
+    expect(hasExplicitLabelSize({})).toBe(false);
+    expect(hasExplicitLabelSize({ fontSizeOverride: 8 })).toBe(false);
+    expect(hasExplicitLabelSize({ sizeMode: 'auto' })).toBe(false);
+    expect(hasExplicitLabelSize({ sizeMode: 'fixed' })).toBe(true);
+    expect(hasExplicitLabelSize({ sizeMode: 'fixed', fixedSize: 8 })).toBe(true);
+  });
+});
+
+describe('expandBandToInterior', () => {
+  it('grows a narrow gap band symmetric about its center', () => {
+    // Center at (50, 30) in a 100×100 interior: symmetric room is 100 on X
+    // (50 each way) and 60 on Y (30 to the near edge, mirrored).
+    const placement = { centerX: 50, centerY: 30, availW: 20, availD: 4 };
+    expect(expandBandToInterior(placement, 100, 100)).toEqual({
+      centerX: 50,
+      centerY: 30,
+      availW: 100,
+      availD: 60,
+    });
+  });
+
+  it('never returns less room than the anchor band itself', () => {
+    // An offset drags the center past the interior edge: symmetric room is
+    // negative there, so the original band stands.
+    const placement = { centerX: -5, centerY: 50, availW: 12, availD: 8 };
+    const out = expandBandToInterior(placement, 100, 100);
+    expect(out.availW).toBe(12);
+    expect(out.availD).toBe(100);
+  });
+
+  it('respects a shifted origin, as generation uses', () => {
+    // Generation centers the interior on the model origin: a band centered on
+    // the origin has the full interior symmetric around it.
+    const placement = { centerX: 0, centerY: 0, availW: 5, availD: 5 };
+    expect(expandBandToInterior(placement, 100, 80, -50, -40)).toEqual({
+      centerX: 0,
+      centerY: 0,
+      availW: 100,
+      availD: 80,
     });
   });
 });

--- a/src/shared/utils/cutoutLabel.ts
+++ b/src/shared/utils/cutoutLabel.ts
@@ -11,6 +11,7 @@ import type {
   CutoutArrayConfig,
   CutoutTextAnchor,
   CutoutTextOffset,
+  TextStyleOverride,
 } from '@/shared/types/bin';
 
 export interface CutoutAabb {
@@ -167,6 +168,46 @@ export function fitLabelRoom(
   return {
     availW: cols > 1 ? Math.min(availW, Math.max(0, config.pitchX)) : availW,
     availD: rows > 1 ? Math.min(availD, Math.max(0, config.pitchY)) : availD,
+  };
+}
+
+/**
+ * Whether this cutout's label carries an explicit size: the per-cutout style
+ * pins `sizeMode: 'fixed'`. An explicit size is a target, not a ceiling — the
+ * band grows past the anchor gap (see {@link expandBandToInterior}) and past
+ * the repeat pitch cap so the label renders at the asked-for size, shrinking
+ * only when the bin interior itself cannot hold it.
+ *
+ * The DESIGN-level size mode deliberately does not trigger this: designs saved
+ * under a fixed-size preset have always shrunk their cutout labels to the
+ * anchor band, and widening those bands would move engravings on every one of
+ * them.
+ */
+export function hasExplicitLabelSize(textStyle: TextStyleOverride | undefined): boolean {
+  return textStyle?.sizeMode === 'fixed';
+}
+
+/**
+ * Grow a band to the largest box symmetric about its center that stays inside
+ * the bin interior — the same symmetric-about-center rule `axisBand` already
+ * applies to a `center` zone, extended to both axes. Never returns less room
+ * than the anchor band itself (an offset can push the center right up to, or
+ * past, an interior edge). The label stays centered exactly where the anchor
+ * put it; it just stops being starved by the gap it happens to sit in.
+ */
+export function expandBandToInterior(
+  placement: CutoutLabelPlacement,
+  innerW: number,
+  innerD: number,
+  originX = 0,
+  originY = 0
+): CutoutLabelPlacement {
+  const availW = 2 * Math.min(placement.centerX - originX, originX + innerW - placement.centerX);
+  const availD = 2 * Math.min(placement.centerY - originY, originY + innerD - placement.centerY);
+  return {
+    ...placement,
+    availW: Math.max(placement.availW, availW),
+    availD: Math.max(placement.availD, availD),
   };
 }
 


### PR DESCRIPTION
## Summary

The label size slider was a cap on auto-fit, and auto-fit is bounded by the gap beside the cutout (or a repeat's pitch), so on a cramped board the slider often did nothing and captions printed too small to read — the size bug reported in #3908. An exact size set on a cutout now pins `textStyle.sizeMode: 'fixed'`: the placement band widens to the bin interior (symmetric about the anchored center, the same rule the center zone already used) and skips the repeat pitch cap, so the label renders at the asked-for size and shrinks only when the bin itself runs out of room.

Second of three changes for #3908. Follows #3909. (Replaces #3910, which was auto-closed when its stacked base branch merged.)

## Behaviour

- **Exact size**: the slider now writes `sizeMode: 'fixed'` + `fixedSize` per cutout (`withExactLabelSize`), uncapped by `maxFontSize`, honoured by the worker via the widened band. Auto clears both the fixed size and any legacy ceiling.
- **Back-compat**: designs carrying the old `fontSizeOverride` keep ceiling semantics untouched; the design-level fixed size mode (Engineering preset) keeps shrink-to-fit; label tabs keep their shared-cap semantics (`LabelSizeControl` grew a `variant` prop instead of changing meaning).
- **Editor mirror**: the 2D preview fits with the same band; an exact-size label reaching over a pocket gets a red glyph halo (those glyph parts are cut away — same signal as the off-board frames); manual mode seeds at the size currently rendering; a note names the rendered size when the bin limits the request.
- Server validation already covers `cutouts[i].textStyle.sizeMode/fixedSize` — no API changes.

## Testing

- `binGenerator.scenario.exactLabelSize` (real WASM kernel): embossed glyph Y-extent proves an 18mm caption renders past a 14mm pitch cap while auto stays capped.
- Unit: band expansion + explicit-size detection (`cutoutLabel.test.ts`), fixed-path fit parity incl. sub-floor and leftover-override cases (`cutoutLabelFit.test.ts`), style helper (`text.test.ts`), inspector behaviour (`CutoutEngraveLabelControls.test.tsx`).
- `pnpm run typecheck`, i18n checks, full bin-designer suite (500 files / 5827 tests), repeat-label + floor-label scenarios all pass.

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

