### PR TITLE
fix(analytics): cap per-session exception captures and stale-bundle retries

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { detectBrowserLocale } from '@/i18n/detection.ts';
 import { isLocale } from '@/i18n/types.ts';
 import { useSettingsStore } from '@/core/store/settings.ts';
 import { initAnalytics } from '@/shared/analytics/posthog';
+import { getMlTelemetry } from '@/shared/analytics/useMLTracking';
 import { useLayoutStore } from '@/core/store/layout';
 import { useLibraryStore } from '@/core/store/library.ts';
 import { useSharedWithMeStore } from '@/core/store/sharedWithMe.ts';
@@ -63,10 +64,14 @@ if (isSmokeMode()) {
   // Initialize Posthog analytics (no-op in dev)
   initAnalytics();
 
-  // Lazily initialize ML telemetry — the module is ~104 KB and not needed for first paint
-  void import('./shared/analytics/mlTelemetry').then(({ initMLTelemetry, setLayoutStoreRef }) => {
-    setLayoutStoreRef(() => useLayoutStore.getState(), useLayoutStore.subscribe);
-    initMLTelemetry();
+  // Lazily initialize ML telemetry — the module is ~104 KB and not needed for
+  // first paint. The shared loader never rejects (a stale-bundle load failure
+  // resolves null and latches tracking off), so a bare `.then` cannot leak an
+  // unhandled rejection per pageload.
+  void getMlTelemetry().then((ml) => {
+    if (!ml) return;
+    ml.setLayoutStoreRef(() => useLayoutStore.getState(), useLayoutStore.subscribe);
+    ml.initMLTelemetry();
   });
 
   // Prevent pinch-to-zoom on iOS (Safari ignores viewport meta since iOS 10)

--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { filterExceptionForPosthog, shouldIgnoreError } from './errorFilters';
+import {
+  filterExceptionForPosthog,
+  resetSessionCaptureCounts,
+  shouldIgnoreError,
+} from './errorFilters';
 
 const { detectWebGL } = vi.hoisted(() => ({ detectWebGL: vi.fn() }));
 vi.mock('@/shared/webgl/detectWebGL', () => ({ detectWebGL }));
@@ -7,6 +11,7 @@ vi.mock('@/shared/webgl/detectWebGL', () => ({ detectWebGL }));
 beforeEach(() => {
   // Default to "available" so non-WebGL cases behave normally.
   detectWebGL.mockReturnValue({ available: true });
+  resetSessionCaptureCounts();
 });
 
 describe('shouldIgnoreError — message patterns', () => {
@@ -183,15 +188,16 @@ describe('filterExceptionForPosthog — chunk-load dedupe', () => {
   });
 
   it('groups across deploys, whose chunk hash and route differ', () => {
-    expect(
-      fingerprintOf(
-        'Failed to fetch dynamically imported module: https://x/assets/baseplate-AAA.js'
-      )
-    ).toBe(
-      fingerprintOf(
-        'Failed to fetch dynamically imported module: https://x/assets/designer-ZZZZZZZZ.js'
-      )
+    const first = fingerprintOf(
+      'Failed to fetch dynamically imported module: https://x/assets/baseplate-AAA.js'
     );
+    // The once-per-session gate would mute the second capture; reset so this
+    // test only observes the fingerprint pinning.
+    resetSessionCaptureCounts();
+    const second = fingerprintOf(
+      'Failed to fetch dynamically imported module: https://x/assets/designer-ZZZZZZZZ.js'
+    );
+    expect(first).toBe(second);
   });
 
   it('leaves a bare network failure alone, which is not necessarily a chunk', () => {
@@ -202,14 +208,71 @@ describe('filterExceptionForPosthog — chunk-load dedupe', () => {
     expect(fingerprintOf('TypeError: Load failed')).toBeUndefined();
   });
 
-  it('still reports the event rather than dropping it', () => {
-    const e = {
+  it('reports the first occurrence and mutes the rest of the session', () => {
+    const make = (): Parameters<typeof filterExceptionForPosthog>[0] => ({
       event: '$exception',
       properties: {
         $exception_list: [{ value: 'Failed to fetch dynamically imported module: https://x/a.js' }],
       },
-    };
-    expect(filterExceptionForPosthog(e)).toBe(e);
+    });
+    const first = make();
+    expect(filterExceptionForPosthog(first)).toBe(first);
+    // A stale bundle is one condition for the whole tab: a stale session
+    // averages dozens of captures repeating the same fact, and the retries
+    // can be captured both natively and by a boundary.
+    expect(filterExceptionForPosthog(make())).toBeNull();
+    expect(
+      filterExceptionForPosthog({
+        event: '$exception',
+        properties: {
+          $exception_list: [{ value: 'TypeError: Importing a module script failed.' }],
+        },
+      })
+    ).toBeNull();
+  });
+});
+
+describe('filterExceptionForPosthog — per-session capture cap', () => {
+  const appError = (value: string): Parameters<typeof filterExceptionForPosthog>[0] => ({
+    event: '$exception',
+    properties: { $exception_list: [{ type: 'TypeError', value }] },
+  });
+
+  it('caps one looping identity without touching others', () => {
+    for (let i = 0; i < 10; i++) {
+      expect(filterExceptionForPosthog(appError('x is not a function'))).not.toBeNull();
+    }
+    expect(filterExceptionForPosthog(appError('x is not a function'))).toBeNull();
+    expect(filterExceptionForPosthog(appError('x is not a function'))).toBeNull();
+
+    // A different identity is unaffected by the exhausted one.
+    expect(filterExceptionForPosthog(appError('y is undefined'))).not.toBeNull();
+  });
+
+  it('caps a pinned-fingerprint burst the once-per-session gates miss', () => {
+    // WebGL context failures are muted only after detection flips to
+    // unavailable; when the boundary never flips it, this cap is the bound.
+    for (let i = 0; i < 10; i++) {
+      expect(
+        filterExceptionForPosthog({
+          event: '$exception',
+          properties: { $exception_list: [{ value: 'Error creating WebGL context.' }] },
+        })
+      ).not.toBeNull();
+    }
+    expect(
+      filterExceptionForPosthog({
+        event: '$exception',
+        properties: { $exception_list: [{ value: 'Error creating WebGL context.' }] },
+      })
+    ).toBeNull();
+  });
+
+  it('resets with the seam', () => {
+    for (let i = 0; i < 11; i++) filterExceptionForPosthog(appError('loop'));
+    expect(filterExceptionForPosthog(appError('loop'))).toBeNull();
+    resetSessionCaptureCounts();
+    expect(filterExceptionForPosthog(appError('loop'))).not.toBeNull();
   });
 });
 

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -43,6 +43,29 @@ const CHUNK_LOAD_ERROR =
 /** Stable fingerprint collapsing every deploy's chunk-load miss into one issue. */
 const CHUNK_LOAD_FINGERPRINT = 'chunk-load-failed';
 
+/**
+ * Per-session capture ceilings.
+ *
+ * Error tracking has its own monthly exception quota, and one looping client
+ * can consume weeks of it: a stale-bundle session averages dozens of
+ * chunk-load captures (each doomed retry can be captured both natively and by
+ * a boundary), and a single such day has burned most of a month's allowance.
+ *
+ * A stale bundle is one condition for the whole tab (see lazyWithRetry), so
+ * the first chunk-load capture says everything the rest of the session's
+ * would. Every other identity keeps enough repeats to triage, then goes
+ * quiet for the session.
+ */
+const SESSION_EXCEPTION_CAP = 10;
+const sessionCaptureCounts = new Map<string, number>();
+let chunkLoadCaptured = false;
+
+/** Test seam: clears the per-session capture counters. */
+export function resetSessionCaptureCounts(): void {
+  sessionCaptureCounts.clear();
+  chunkLoadCaptured = false;
+}
+
 const IGNORED_MESSAGE_PATTERNS: readonly RegExp[] = [
   // Safari Web Extensions message bus
   /No Listener: tabs:/i,
@@ -87,6 +110,7 @@ export function shouldIgnoreError(
 }
 
 interface ExceptionLike {
+  type?: string;
   value?: string;
   stacktrace?: { frames?: Array<{ function?: string; filename?: string }> };
 }
@@ -157,8 +181,9 @@ function isNavigationAbort(exception: ExceptionLike): boolean {
  * PostHog `before_send` hook. Drops `$exception` events whose **primary**
  * exception matches the extension/noise filters, the R3F canvas teardown
  * race, or a stackless navigation abort; dedupes the WebGL context-creation
- * burst, pins chunk-load failures to one fingerprint, and passes everything
- * else through unchanged.
+ * burst, pins chunk-load failures to one fingerprint and captures them once
+ * per session, caps every exception identity's captures per session, and
+ * passes everything else through unchanged.
  *
  * Only the first entry in `$exception_list` / `$exception_values` is
  * checked. Subsequent entries are `Error.cause` chains — if a real app
@@ -200,11 +225,23 @@ export function filterExceptionForPosthog(
   }
 
   if (primary !== undefined && CHUNK_LOAD_ERROR.test(primary)) {
+    if (chunkLoadCaptured) return null;
+    chunkLoadCaptured = true;
     event.properties = {
       ...event.properties,
       $exception_fingerprint: CHUNK_LOAD_FINGERPRINT,
     };
   }
+
+  // Pinned fingerprints group reliably; everything else keys on type + message
+  // prefix, which is stable enough to recognize a loop even though the
+  // server-side fingerprint isn't known at capture time.
+  const identity =
+    event.properties?.$exception_fingerprint ??
+    `${primaryException?.type ?? ''}:${primary?.slice(0, 120) ?? ''}`;
+  const captured = (sessionCaptureCounts.get(identity) ?? 0) + 1;
+  sessionCaptureCounts.set(identity, captured);
+  if (captured > SESSION_EXCEPTION_CAP) return null;
 
   return event;
 }

--- a/src/shared/analytics/useMLTracking.test.ts
+++ b/src/shared/analytics/useMLTracking.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({ factoryRuns: 0 }));
+
+// Simulate a stale bundle: the lazy chunk's hash no longer exists, so every
+// import attempt rejects.
+vi.mock('./mlTelemetry', () => {
+  state.factoryRuns += 1;
+  throw new TypeError('Failed to fetch dynamically imported module: ./mlTelemetry');
+});
+
+import { getMlTelemetry, mlTracking } from './useMLTracking';
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('getMlTelemetry', () => {
+  it('resolves null on a failed load and latches off instead of retrying', async () => {
+    await expect(getMlTelemetry()).resolves.toBeNull();
+    await expect(getMlTelemetry()).resolves.toBeNull();
+    expect(state.factoryRuns).toBe(1);
+  });
+
+  it('tracking calls no-op quietly once the module is unavailable', async () => {
+    expect(() => {
+      mlTracking.recordAction();
+    }).not.toThrow();
+    // Flush the fire-and-forget chain; a leaked rejection would fail the run.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(state.factoryRuns).toBe(1);
+  });
+});

--- a/src/shared/analytics/useMLTracking.test.ts
+++ b/src/shared/analytics/useMLTracking.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const state = vi.hoisted(() => ({ factoryRuns: 0 }));
 
@@ -13,6 +13,10 @@ import { getMlTelemetry, mlTracking } from './useMLTracking';
 
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('getMlTelemetry', () => {

--- a/src/shared/analytics/useMLTracking.ts
+++ b/src/shared/analytics/useMLTracking.ts
@@ -48,18 +48,40 @@ type MlTelemetryModule = typeof MlTelemetryNS;
 
 // Lazily loaded module cache
 let _mlTelemetry: MlTelemetryModule | undefined;
-function getMlTelemetry(): Promise<MlTelemetryModule> {
+let _mlTelemetryUnavailable = false;
+
+/**
+ * Resolves the mlTelemetry module, or null once loading has failed.
+ *
+ * Only success used to be cached, so a client on a stale bundle re-fetched
+ * the dead chunk hash on every tracked interaction, each attempt surfacing
+ * as a captured exception. A load failure means a stale bundle, which is one
+ * condition for the whole session, so the first failure latches tracking off.
+ */
+export function getMlTelemetry(): Promise<MlTelemetryModule | null> {
   if (_mlTelemetry) return Promise.resolve(_mlTelemetry);
-  return import('./mlTelemetry').then((mod) => {
-    _mlTelemetry = mod;
-    return mod;
-  });
+  if (_mlTelemetryUnavailable) return Promise.resolve(null);
+  return import('./mlTelemetry').then(
+    (mod) => {
+      _mlTelemetry = mod;
+      return mod;
+    },
+    (error: unknown) => {
+      _mlTelemetryUnavailable = true;
+      if (import.meta.env.DEV) {
+        console.error('[mlTelemetry] failed to load:', error);
+      }
+      return null;
+    }
+  );
 }
 
 /** Fire-and-forget tracking — silently ignores errors (analytics should never crash the app) */
 function track(fn: (m: MlTelemetryModule) => void): void {
   void getMlTelemetry()
-    .then(fn)
+    .then((m) => {
+      if (m) fn(m);
+    })
     .catch((error: unknown) => {
       if (import.meta.env.DEV) {
         console.error('[mlTelemetry] tracking failed:', error);


### PR DESCRIPTION
## What

Nearly all recent exception volume is one condition reported thousands of times: a client on a stale PWA bundle failing to fetch rotated chunk hashes, over and over, with each failure captured more than once. Error tracking has its own monthly exception quota, and looping clients can burn weeks of it in a day. Three layers:

- **`useMLTracking`**: only success was cached, so a stale client re-fetched the dead `mlTelemetry` chunk on every tracked interaction. A failed load now resolves `null` and latches tracking off for the session. `main.tsx` goes through the same loader, so its previously uncaught boot import can no longer leak an unhandled rejection per pageload.
- **Chunk-load captures**: a stale bundle is one condition for the whole tab (same rationale as `lazyWithRetry`'s shared recovery guard), so `before_send` now captures the pinned `chunk-load-failed` class once per session. Issue volume then approximates affected sessions, which is the metric that matters; `pwa_stale_recovery` still tracks recovery.
- **Generic per-session cap**: any single exception identity (pinned fingerprint, or type + message prefix) is capped at 10 captures per session, bounding classes the targeted gates miss, such as WebGL context-creation loops on clients where the boundary never flips detection to unavailable.

## Notes

- The WebGL once-per-session gate and all existing drop filters are unchanged; the cap sits after them.
- `errorFilters` gains a `resetSessionCaptureCounts` test seam; the chunk-load test that asserted every occurrence is reported now asserts first-kept, rest-muted.

## Testing

- `pnpm run test:run src/shared/analytics/`: 504 passing, including new suites for the session cap and the loader latch
- `pnpm run typecheck`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

