### PR TITLE
perf(analytics): trim web vitals, divider commits, and the render-error event

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -309,13 +309,13 @@ export function BaseplatePreview({
       )}
 
       {!webgl.available && webgl.reason ? (
-        <WebGLFallback reason={webgl.reason} component="baseplate" />
+        <WebGLFallback />
       ) : (
         <div
           className={`h-full w-full transition-opacity duration-500 ${hasAnyMesh ? 'opacity-100' : 'opacity-0'}`}
         >
           <PanelErrorBoundary panelName="3D Preview">
-            <WebGLErrorBoundary component="baseplate">
+            <WebGLErrorBoundary>
               <Canvas
                 frameloop="demand"
                 // preserveDrawingBuffer keeps the framebuffer readable after

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerTiltSubsection.test.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerTiltSubsection.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { rowKeyOf } from './useDividerTiltSubsection';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { createTrailingTrack, rowKeyOf } from './useDividerTiltSubsection';
 
 describe('useDividerTiltSubsection helpers', () => {
   it('rowKeyOf joins compartment IDs in canonical order with a dash', () => {
@@ -10,5 +10,62 @@ describe('useDividerTiltSubsection helpers', () => {
   it('rowKeyOf normalizes argument order so callers can pass the pair either way', () => {
     expect(rowKeyOf(7, 2)).toBe('2-7');
     expect(rowKeyOf(1, 0)).toBe('0-1');
+  });
+});
+
+describe('createTrailingTrack', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends only the last payload of a burst, once the delay elapses', () => {
+    const send = vi.fn();
+    const track = createTrailingTrack(send, 2000);
+
+    track.queue({ lean_deg: 1 });
+    track.queue({ lean_deg: 2 });
+    track.queue({ lean_deg: 3 });
+    expect(send).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({ lean_deg: 3 });
+  });
+
+  it('flush sends a pending payload immediately and cancels the timer', () => {
+    const send = vi.fn();
+    const track = createTrailingTrack(send, 2000);
+
+    track.queue({ lean_deg: 5 });
+    track.flush();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({ lean_deg: 5 });
+
+    // The cancelled timer must not fire a duplicate.
+    vi.advanceTimersByTime(5000);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('flush with nothing pending sends nothing', () => {
+    const send = vi.fn();
+    createTrailingTrack(send, 2000).flush();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('a new burst after a send starts a fresh debounce window', () => {
+    const send = vi.fn();
+    const track = createTrailingTrack(send, 2000);
+
+    track.queue({ lean_deg: 1 });
+    vi.advanceTimersByTime(2000);
+    track.queue({ lean_deg: 2 });
+    vi.advanceTimersByTime(2000);
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenLastCalledWith({ lean_deg: 2 });
   });
 });

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerTiltSubsection.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerTiltSubsection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
@@ -26,6 +26,39 @@ import { resolveCompartmentDividerHeight } from '@/shared/utils/slotMath';
  *  callers can't desync the key by passing the pair in either order
  *  (`selectedDividerKey` / `hoveredDividerKey` lookups depend on this). */
 export const rowKeyOf = (a: number, b: number): string => (a < b ? `${a}-${b}` : `${b}-${a}`);
+
+type TrackPayload = Record<string, string | number | boolean | null>;
+
+/**
+ * Trailing debounce for a billable track call: only the last payload queued
+ * within `delayMs` is sent. `flush` sends a pending payload immediately, for
+ * unmount, so the final burst of an editing session isn't lost.
+ */
+export function createTrailingTrack(
+  send: (payload: TrackPayload) => void,
+  delayMs: number
+): { queue: (payload: TrackPayload) => void; flush: () => void } {
+  let pending: { timer: ReturnType<typeof setTimeout>; payload: TrackPayload } | null = null;
+  return {
+    queue(payload) {
+      if (pending) clearTimeout(pending.timer);
+      pending = {
+        payload,
+        timer: setTimeout(() => {
+          pending = null;
+          send(payload);
+        }, delayMs),
+      };
+    },
+    flush() {
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      const { payload } = pending;
+      pending = null;
+      send(payload);
+    },
+  };
+}
 
 export interface TiltRow extends EligibleDivider {
   readonly key: string;
@@ -234,39 +267,12 @@ export function useDividerTiltSubsection() {
 
   // A tilt is adjusted through many commits (each panel keystroke and drag end
   // lands here), and every event is billable. Only the burst's final values
-  // carry signal, so the track is trailing-debounced; unmount flushes a
-  // pending one so the last burst of an editing session isn't lost.
-  const pendingDividerTrack = useRef<{
-    timer: ReturnType<typeof setTimeout>;
-    payload: Record<string, string | number | boolean | null>;
-  } | null>(null);
-
-  const queueDividerTrack = useCallback(
-    (payload: Record<string, string | number | boolean | null>) => {
-      const pending = pendingDividerTrack.current;
-      if (pending) clearTimeout(pending.timer);
-      pendingDividerTrack.current = {
-        payload,
-        timer: setTimeout(() => {
-          pendingDividerTrack.current = null;
-          trackEvent('divider_offset_changed', payload);
-        }, 2000),
-      };
-    },
+  // carry signal, so the track is trailing-debounced with an unmount flush.
+  const dividerTrack = useMemo(
+    () => createTrailingTrack((payload) => trackEvent('divider_offset_changed', payload), 2000),
     []
   );
-
-  useEffect(
-    () => () => {
-      const pending = pendingDividerTrack.current;
-      if (pending) {
-        clearTimeout(pending.timer);
-        pendingDividerTrack.current = null;
-        trackEvent('divider_offset_changed', pending.payload);
-      }
-    },
-    []
-  );
+  useEffect(() => () => dividerTrack.flush(), [dividerTrack]);
 
   // Commit: clamp, write the real override (one history entry), drop preview.
   const commitTilt = useCallback(
@@ -281,7 +287,7 @@ export function useDividerTiltSubsection() {
         result.offsetEnd,
         result.rakeDeg
       );
-      queueDividerTrack({
+      dividerTrack.queue({
         axis: row.axis,
         offset_start_mm: result.offsetStart,
         offset_end_mm: result.offsetEnd,
@@ -289,7 +295,7 @@ export function useDividerTiltSubsection() {
         source,
       });
     },
-    [setDividerOverride, setDividerTiltPreview, queueDividerTrack]
+    [setDividerOverride, setDividerTiltPreview, dividerTrack]
   );
 
   const resetRow = useCallback(

--- a/src/features/bin-designer/components/CompartmentEditor/useDividerTiltSubsection.ts
+++ b/src/features/bin-designer/components/CompartmentEditor/useDividerTiltSubsection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useTranslation } from '@/i18n';
@@ -232,6 +232,42 @@ export function useDividerTiltSubsection() {
     setDividerTiltPreview(null);
   }, [setDividerTiltPreview]);
 
+  // A tilt is adjusted through many commits (each panel keystroke and drag end
+  // lands here), and every event is billable. Only the burst's final values
+  // carry signal, so the track is trailing-debounced; unmount flushes a
+  // pending one so the last burst of an editing session isn't lost.
+  const pendingDividerTrack = useRef<{
+    timer: ReturnType<typeof setTimeout>;
+    payload: Record<string, string | number | boolean | null>;
+  } | null>(null);
+
+  const queueDividerTrack = useCallback(
+    (payload: Record<string, string | number | boolean | null>) => {
+      const pending = pendingDividerTrack.current;
+      if (pending) clearTimeout(pending.timer);
+      pendingDividerTrack.current = {
+        payload,
+        timer: setTimeout(() => {
+          pendingDividerTrack.current = null;
+          trackEvent('divider_offset_changed', payload);
+        }, 2000),
+      };
+    },
+    []
+  );
+
+  useEffect(
+    () => () => {
+      const pending = pendingDividerTrack.current;
+      if (pending) {
+        clearTimeout(pending.timer);
+        pendingDividerTrack.current = null;
+        trackEvent('divider_offset_changed', pending.payload);
+      }
+    },
+    []
+  );
+
   // Commit: clamp, write the real override (one history entry), drop preview.
   const commitTilt = useCallback(
     (row: TiltRow, next: AngleShift, source: 'panel_input' | 'canvas_drag' = 'panel_input') => {
@@ -245,7 +281,7 @@ export function useDividerTiltSubsection() {
         result.offsetEnd,
         result.rakeDeg
       );
-      trackEvent('divider_offset_changed', {
+      queueDividerTrack({
         axis: row.axis,
         offset_start_mm: result.offsetStart,
         offset_end_mm: result.offsetEnd,
@@ -253,7 +289,7 @@ export function useDividerTiltSubsection() {
         source,
       });
     },
-    [setDividerOverride, setDividerTiltPreview]
+    [setDividerOverride, setDividerTiltPreview, queueDividerTrack]
   );
 
   const resetRow = useCallback(

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -435,7 +435,7 @@ function BinPreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
       </div>
 
       {!webgl.available && webgl.reason ? (
-        <WebGLFallback reason={webgl.reason} component="designer" />
+        <WebGLFallback />
       ) : showSkeleton ? (
         <PreviewSkeleton
           wasmStatus={wasmStatus}
@@ -447,7 +447,7 @@ function BinPreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
         />
       ) : (
         <PanelErrorBoundary panelName="3D Preview">
-          <WebGLErrorBoundary component="designer">
+          <WebGLErrorBoundary>
             <Canvas
               frameloop="demand"
               onCreated={({ gl }) => {

--- a/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
@@ -208,7 +208,7 @@ export function WorkshopCanvas() {
 
   if (structure?.kind !== 'assembly' || !envelope) return null;
   if (!webgl.available && webgl.reason) {
-    return <WebGLFallback reason={webgl.reason} component="designer" />;
+    return <WebGLFallback />;
   }
 
   return (
@@ -251,7 +251,7 @@ export function WorkshopCanvas() {
         if (marquee) endMarquee(e);
       }}
     >
-      <WebGLErrorBoundary component="designer">
+      <WebGLErrorBoundary>
         <Canvas
           frameloop="demand"
           gl={{ antialias: true, localClippingEnabled: true, preserveDrawingBuffer: true }}

--- a/src/shared/analytics/posthog/events.ts
+++ b/src/shared/analytics/posthog/events.ts
@@ -47,7 +47,6 @@ export {
   getLayoutContext,
   trackLayoutSaveFailure,
   trackShareFailure,
-  track3DRenderError,
   trackTemplateLoadError,
 } from './eventsErrors';
 

--- a/src/shared/analytics/posthog/eventsErrors.ts
+++ b/src/shared/analytics/posthog/eventsErrors.ts
@@ -4,8 +4,8 @@
  * `captureException` enriches caught errors with layout context so a
  * PostHog stack trace is debuggable without round-tripping a session
  * recording. The narrower `track*Failure` helpers fire discrete events
- * for known-bad outcomes (save, share, 3D render, template load) so
- * they show up in dashboards alongside the generic exceptions.
+ * for known-bad outcomes (save, share, template load) so they show up
+ * in dashboards alongside the generic exceptions.
  */
 
 import { useInteractionStore } from '@/core/store/interaction';
@@ -85,17 +85,6 @@ export function trackLayoutSaveFailure(
 export function trackShareFailure(errorCode: string, errorMessage: string): void {
   trackEvent('share_failure', {
     error_code: errorCode,
-    error_message: errorMessage,
-  });
-}
-
-/**
- * Track 3D rendering or component errors.
- * Called from error boundaries when a panel/component crashes.
- */
-export function track3DRenderError(component: string, errorMessage: string): void {
-  trackEvent('3d_render_error', {
-    component,
     error_message: errorMessage,
   });
 }

--- a/src/shared/analytics/posthog/index.ts
+++ b/src/shared/analytics/posthog/index.ts
@@ -52,7 +52,6 @@ export {
   captureException,
   trackLayoutSaveFailure,
   trackShareFailure,
-  track3DRenderError,
   trackTemplateLoadError,
   trackGalleryOpened,
   trackGalleryClosed,

--- a/src/shared/analytics/posthog/init.ts
+++ b/src/shared/analytics/posthog/init.ts
@@ -61,8 +61,14 @@ export function initAnalytics(): void {
         // Error tracking - auto-capture exceptions
         capture_exceptions: true,
 
-        // Performance monitoring - web vitals
-        capture_performance: true,
+        // Performance monitoring. $web_vitals bills four events per sampled
+        // pageview and the dashboards read percentiles, which survive
+        // sampling; network timing stays on because replay's network tab is
+        // per-recording and cannot be sampled independently of it.
+        capture_performance: {
+          network_timing: true,
+          web_vitals: Math.random() < 0.25,
+        },
 
         // The single place exceptions are filtered and enriched. Every capture
         // path passes through here, native or explicit, so nothing needs a

--- a/src/shared/webgl/WebGLErrorBoundary.test.tsx
+++ b/src/shared/webgl/WebGLErrorBoundary.test.tsx
@@ -5,10 +5,6 @@ import type { ReactNode } from 'react';
 import { WebGLErrorBoundary } from './WebGLErrorBoundary';
 import { detectWebGL, resetWebGLDetectionCacheForTests } from './detectWebGL';
 
-vi.mock('@/shared/analytics/posthog', () => ({
-  track3DRenderError: vi.fn(),
-}));
-
 function Thrower({ message }: { message: string }): ReactNode {
   throw new Error(message);
 }
@@ -36,7 +32,7 @@ describe('WebGLErrorBoundary', () => {
 
   it('renders children when no error', () => {
     render(
-      <WebGLErrorBoundary component="designer">
+      <WebGLErrorBoundary>
         <div>canvas-content</div>
       </WebGLErrorBoundary>
     );
@@ -45,7 +41,7 @@ describe('WebGLErrorBoundary', () => {
 
   it('renders the WebGL fallback (no retry) on a context-creation error', () => {
     render(
-      <WebGLErrorBoundary component="designer">
+      <WebGLErrorBoundary>
         <Thrower message="Error creating WebGL context." />
       </WebGLErrorBoundary>
     );
@@ -56,7 +52,7 @@ describe('WebGLErrorBoundary', () => {
   it('flips detectWebGL() to unavailable so the next render skips the canvas', () => {
     expect(detectWebGL().available).toBe(true);
     render(
-      <WebGLErrorBoundary component="baseplate">
+      <WebGLErrorBoundary>
         <Thrower message="Error creating WebGL context." />
       </WebGLErrorBoundary>
     );
@@ -68,7 +64,7 @@ describe('WebGLErrorBoundary', () => {
   it('rethrows non-WebGL errors for an outer boundary to handle', () => {
     render(
       <Catcher>
-        <WebGLErrorBoundary component="designer">
+        <WebGLErrorBoundary>
           <Thrower message="something unrelated blew up" />
         </WebGLErrorBoundary>
       </Catcher>

--- a/src/shared/webgl/WebGLErrorBoundary.test.tsx
+++ b/src/shared/webgl/WebGLErrorBoundary.test.tsx
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Component } from 'react';
 import type { ReactNode } from 'react';
+const { captureException } = vi.hoisted(() => ({ captureException: vi.fn() }));
+vi.mock('@/shared/analytics/posthog', () => ({ captureException }));
+
 import { WebGLErrorBoundary } from './WebGLErrorBoundary';
 import { detectWebGL, resetWebGLDetectionCacheForTests } from './detectWebGL';
 
@@ -59,6 +62,18 @@ describe('WebGLErrorBoundary', () => {
     const result = detectWebGL();
     expect(result.available).toBe(false);
     expect(result.reason).toBe('context-failed');
+  });
+
+  it('captures the context error explicitly, since the boundary swallows it', () => {
+    render(
+      <WebGLErrorBoundary>
+        <Thrower message="Error creating WebGL context." />
+      </WebGLErrorBoundary>
+    );
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Error creating WebGL context.' }),
+      { boundary: 'webgl' }
+    );
   });
 
   it('rethrows non-WebGL errors for an outer boundary to handle', () => {

--- a/src/shared/webgl/WebGLErrorBoundary.tsx
+++ b/src/shared/webgl/WebGLErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import type { ReactNode } from 'react';
+import { captureException } from '@/shared/analytics/posthog';
 import { markWebGLUnavailable } from './detectWebGL';
 import { WebGLFallback } from './WebGLFallback';
 
@@ -37,6 +38,11 @@ export class WebGLErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error) {
     if (error.message.includes(WEBGL_CONTEXT_ERROR)) {
+      // Boundary-caught render throws don't reach window.onerror, so this
+      // explicit capture is the path's only telemetry. It must run before
+      // markWebGLUnavailable: the exception filter drops WebGL-context
+      // captures once detection reads unavailable.
+      captureException(error, { boundary: 'webgl' });
       markWebGLUnavailable('context-failed');
     }
   }

--- a/src/shared/webgl/WebGLErrorBoundary.tsx
+++ b/src/shared/webgl/WebGLErrorBoundary.tsx
@@ -8,8 +8,6 @@ const WEBGL_CONTEXT_ERROR = 'Error creating WebGL context';
 
 interface Props {
   children: ReactNode;
-  /** Identifies the viewport in telemetry (e.g. "designer", "baseplate"). */
-  component: string;
 }
 
 interface State {
@@ -47,7 +45,7 @@ export class WebGLErrorBoundary extends Component<Props, State> {
     const { error } = this.state;
     if (error) {
       if (error.message.includes(WEBGL_CONTEXT_ERROR)) {
-        return <WebGLFallback reason="context-failed" component={this.props.component} />;
+        return <WebGLFallback />;
       }
       // Not a WebGL-context failure — re-throw from render() so React unwinds to
       // the outer PanelErrorBoundary. This delegation is exercised by the

--- a/src/shared/webgl/WebGLFallback.test.tsx
+++ b/src/shared/webgl/WebGLFallback.test.tsx
@@ -1,25 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-
-const { track3DRenderError } = vi.hoisted(() => ({ track3DRenderError: vi.fn() }));
-vi.mock('@/shared/analytics/posthog', () => ({ track3DRenderError }));
+import { describe, expect, it } from 'vitest';
 
 import { WebGLFallback } from './WebGLFallback';
 
-afterEach(() => {
-  track3DRenderError.mockClear();
-});
-
 describe('WebGLFallback', () => {
   it('renders the localized title and a help link', () => {
-    render(<WebGLFallback reason="context-failed" component="baseplate" />);
+    render(<WebGLFallback />);
 
     expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute('href', 'https://get.webgl.org/');
-  });
-
-  it('reports the unavailable reason on mount', () => {
-    render(<WebGLFallback reason="context-lost" component="designer" />);
-    expect(track3DRenderError).toHaveBeenCalledWith('designer', 'webgl-unavailable:context-lost');
   });
 });

--- a/src/shared/webgl/WebGLFallback.tsx
+++ b/src/shared/webgl/WebGLFallback.tsx
@@ -1,21 +1,9 @@
-import { useEffect } from 'react';
 import { useTranslation } from '@/i18n';
-import { track3DRenderError } from '@/shared/analytics/posthog';
-import type { WebGLUnavailableReason } from './detectWebGL';
-
-interface WebGLFallbackProps {
-  reason: WebGLUnavailableReason;
-  component: string;
-}
 
 const HELP_URL = 'https://get.webgl.org/';
 
-export function WebGLFallback({ reason, component }: WebGLFallbackProps) {
+export function WebGLFallback() {
   const t = useTranslation();
-
-  useEffect(() => {
-    track3DRenderError(component, `webgl-unavailable:${reason}`);
-  }, [component, reason]);
 
   return (
     <div

--- a/src/shell/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/shell/ErrorBoundary/ErrorBoundary.test.tsx
@@ -10,7 +10,6 @@ const { undoMock, historyState } = vi.hoisted(() => ({
 vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),
   captureException: vi.fn(),
-  track3DRenderError: vi.fn(),
 }));
 
 // Mock storage: the boundary now offers a non-destructive backup, not a wipe.

--- a/src/shell/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/shell/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
 import { Button } from '@/design-system';
-import { captureException, track3DRenderError } from '@/shared/analytics/posthog';
+import { captureException } from '@/shared/analytics/posthog';
 import { downloadArchive } from '@/core/storage';
 import { useLibraryStore } from '@/core/store/library';
 import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
@@ -45,7 +45,6 @@ export class ErrorBoundary extends Component<Props, State> {
       boundary: 'root',
       componentStack: errorInfo.componentStack,
     });
-    track3DRenderError('root', error.message);
   }
 
   handleReset = () => {

--- a/src/shell/PanelErrorBoundary/PanelErrorBoundary.test.tsx
+++ b/src/shell/PanelErrorBoundary/PanelErrorBoundary.test.tsx
@@ -5,7 +5,6 @@ import { PanelErrorBoundary } from './PanelErrorBoundary';
 vi.mock('@/shared/analytics/posthog', () => ({
   trackEvent: vi.fn(),
   captureException: vi.fn(),
-  track3DRenderError: vi.fn(),
 }));
 
 function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {

--- a/src/shell/PanelErrorBoundary/PanelErrorBoundary.tsx
+++ b/src/shell/PanelErrorBoundary/PanelErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import type { ReactNode } from 'react';
 import { Button } from '@/design-system';
-import { captureException, track3DRenderError } from '@/shared/analytics/posthog';
+import { captureException } from '@/shared/analytics/posthog';
 
 // Error boundary strings as constants (class components cannot use hooks)
 const ERROR_SUFFIX = 'Error';
@@ -43,7 +43,6 @@ export class PanelErrorBoundary extends Component<Props, State> {
       panelName: this.props.panelName,
       componentStack: errorInfo.componentStack,
     });
-    track3DRenderError(this.props.panelName, error.message);
     this.props.onError?.(error);
   }
 


### PR DESCRIPTION
## What

Three volume trims, each checked against saved-insight usage before cutting:

- **`$web_vitals` sampled to ~25% of pageloads.** The Performance dashboard reads percentiles, which survive sampling. Network timing stays fully on: replay's network tab is per-recording and shouldn't be coupled to the vitals sample.
- **`divider_offset_changed` trailing-debounced (2s).** Every panel keystroke and drag end committed an event, dozens per editing session; only the burst's final values carry signal. A pending track flushes on unmount so the last burst isn't lost. No saved insight reads intermediates.
- **`3d_render_error` removed.** Zero saved insights reference it, and both boundary call sites fire `captureException` for the same failure, so it was a duplicate stream. The `component`/`reason` props that existed only to label it are removed from `WebGLFallback` and `WebGLErrorBoundary` and their call sites; WebGL-unavailable visibility remains via the captured context-creation exception.

## Testing

- `pnpm run test:run` on webgl, boundary, CompartmentEditor, and analytics suites: 284 passing
- `pnpm run typecheck`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

