### PR TITLE
fix(bin-designer): keep a text element's caption centered on its box

### DIFF
--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutEngraveLabelControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutEngraveLabelControls.tsx
@@ -30,6 +30,7 @@ import {
   fitLabelRoom,
   hasExplicitLabelSize,
   resolveCutoutTextAnchor,
+  withCenteredTextPlacement,
 } from '@/shared/utils/cutoutLabel';
 import { useTranslation } from '@/i18n';
 import { CompactNumberInput } from '@/shared/components/CompactNumberInput';
@@ -98,7 +99,10 @@ export function CutoutEngraveLabelControls({
   const explicitSize = hasExplicitLabelSize(cutout);
   const requestedSize = cutout.textStyle?.fixedSize ?? textDefaults.fixedSize;
   const trimmedLabel = cutout.label.trim();
-  const placement = trimmedLabel === '' ? null : cutoutLabelPlacement(cutout, binWidth, binDepth);
+  const placement =
+    trimmedLabel === ''
+      ? null
+      : cutoutLabelPlacement(withCenteredTextPlacement(cutout), binWidth, binDepth);
   let renderedSize: number | null = null;
   if (placement) {
     const banded = explicitSize

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutLabel3D.tsx
@@ -26,6 +26,7 @@ import {
   hasExplicitLabelSize,
   labelPlacementForAabb,
   resolveCutoutTextAnchor,
+  withCenteredTextPlacement,
 } from '@/shared/utils/cutoutLabel';
 import type { CutoutAabb } from '@/shared/utils/cutoutLabel';
 import {
@@ -159,14 +160,18 @@ export function CutoutLabel3D({
 
         // Drag always nudges the MASTER: the offset is one field shared by
         // every instance, so grabbing the third label in a row has to move the
-        // same value grabbing the first one does.
-        const handlePointerDown = onLabelDragStart
-          ? (e: ThreeEvent<PointerEvent>) => {
-              if (e.nativeEvent.button !== 0) return; // left-click only
-              e.stopPropagation();
-              onLabelDragStart(cutout.id, e.point.x, e.point.y);
-            }
-          : undefined;
+        // same value grabbing the first one does. A text element takes no
+        // handler at all — its caption IS the element, so the pointer falls
+        // through to the TextElementMesh hit plane and moves the element,
+        // instead of writing a textOffset no text inspector can show or clear.
+        const handlePointerDown =
+          onLabelDragStart && cutout.shape !== 'text'
+            ? (e: ThreeEvent<PointerEvent>) => {
+                if (e.nativeEvent.button !== 0) return; // left-click only
+                e.stopPropagation();
+                onLabelDragStart(cutout.id, e.point.x, e.point.y);
+              }
+            : undefined;
 
         // The override is applied BEFORE the expansion so a mid-drag repeat
         // carries its labels along; expanding the committed master first would
@@ -175,7 +180,11 @@ export function CutoutLabel3D({
           const label = instance.label.trim();
           if (label === '') return null;
 
-          const placement = cutoutLabelPlacement(instance, binWidth, binDepth);
+          const placement = cutoutLabelPlacement(
+            withCenteredTextPlacement(instance),
+            binWidth,
+            binDepth
+          );
           if (!placement) return null;
 
           // Same band the engraver uses, so the editor shows the size that

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/TextElementMesh.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/TextElementMesh.tsx
@@ -71,7 +71,7 @@ export const TextElementMesh = memo(function TextElementMesh({
     ]);
   }, [effective.width, effective.depth]);
 
-  const isEmpty = cutout.label.trim() === '';
+  const isEmpty = effective.label.trim() === '';
   const showFrame = isSelected || isHovered || isGrouped || isEmpty;
   const strokeColor = isSelected
     ? STROKE_SELECTED

--- a/src/features/generation/worker/generators/binGenerator.scenario.textElement.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.textElement.test.ts
@@ -108,8 +108,10 @@ describe('text element on the bin top', () => {
       expect(mesh.vertices.some((v) => !Number.isFinite(v))).toBe(false);
     }
 
-    // No cavity: an element with nothing to say changes nothing.
+    // No cavity: an element with nothing to say changes nothing — the whole
+    // tessellation comes out identical, not merely the same size.
     expect(blank.triangleCount).toBe(bare.triangleCount);
+    expect(blank.vertices).toEqual(bare.vertices);
 
     // Glyphs stand above the fill top, sized by the explicit 10mm style: the
     // cap height lands well above half the size and at or below the size.
@@ -118,6 +120,22 @@ describe('text element on the bin top', () => {
     expect(spans.y).toBeGreaterThan(5);
     expect(spans.y).toBeLessThan(11);
     expect(spans.x).toBeGreaterThan(0);
+  }, 240000);
+
+  it('ignores stray anchor and offset fields — the caption stays centered', () => {
+    const generateBin = getGenerateBin();
+
+    const clean = generateBin(solidBinWith([textElement()]));
+    const stray = generateBin(
+      solidBinWith([
+        textElement({ textAnchor: 'top', textOffset: { x: 15, y: 9 }, textSide: 'left' }),
+      ])
+    );
+
+    // The editor offers neither control for a text element, so a hand-authored
+    // file carrying them must engrave exactly what a clean one does.
+    expect(stray.triangleCount).toBe(clean.triangleCount);
+    expect(stray.vertices).toEqual(clean.vertices);
   }, 240000);
 
   it('turns the glyphs with the element rotation', () => {
@@ -155,11 +173,10 @@ describe('text element on a lid', () => {
 
     const plain = generateLid(base);
     const texted = generateLid(withText);
-    expect(plain).not.toBeNull();
-    expect(texted).not.toBeNull();
+    if (!plain || !texted) throw new Error('expected both lids to generate');
 
     // The caption adds glyph geometry; nothing else about the lid changed.
-    expect(texted!.triangleCount).toBeGreaterThan(plain!.triangleCount);
-    expect(texted!.vertices.some((v) => !Number.isFinite(v))).toBe(false);
+    expect(texted.triangleCount).toBeGreaterThan(plain.triangleCount);
+    expect(texted.vertices.some((v) => !Number.isFinite(v))).toBe(false);
   }, 240000);
 });

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -64,6 +64,7 @@ import {
   expandBandToInterior,
   fitLabelRoom,
   hasExplicitLabelSize,
+  withCenteredTextPlacement,
 } from '@/shared/utils/cutoutLabel';
 import { combineGroupSolids } from './cutoutGroupOps';
 import {
@@ -1643,7 +1644,10 @@ function buildCutoutLabel(
   allowFloor: boolean,
   repeat: CutoutArrayConfig | undefined
 ): CutoutLabelShape | null {
-  const placement = cutoutLabelPlacement(cutout, innerW, innerD, originX, originY);
+  // A text element's caption centers on its own box regardless of stray
+  // anchor/offset fields in a hand-authored file — the editor offers neither.
+  const placed = withCenteredTextPlacement(cutout);
+  const placement = cutoutLabelPlacement(placed, innerW, innerD, originX, originY);
   if (!placement) return null;
   const { centerX, centerY } = placement;
   // An explicit per-cutout size is a target: the band widens to the interior

--- a/src/features/generation/worker/generators/lidCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/lidCutoutBuilder.ts
@@ -29,7 +29,11 @@ import {
 import type { Shape3D, DisposalScope, ValidSolid } from 'brepjs';
 import type { Cutout } from '@/shared/types/bin';
 import { resolveTextStyle, ZERO_TEXT_OFFSET } from '@/shared/types/bin';
-import { cutoutLabelPlacement, expandBandToInterior } from '@/shared/utils/cutoutLabel';
+import {
+  cutoutLabelPlacement,
+  expandBandToInterior,
+  withCenteredTextPlacement,
+} from '@/shared/utils/cutoutLabel';
 import { isCutoutEngraveMode } from '@/shared/utils/cutoutLabelSocketPlan';
 import { labelledInstances } from '@/shared/utils/cutoutArray';
 import {
@@ -267,8 +271,9 @@ function applyLidTextElements(
     for (const instance of labelledInstances(master)) {
       const label = instance.label.trim();
       if (label === '') continue;
+      // Stray anchor/offset fields must not shift a lid caption either.
       const placement = cutoutLabelPlacement(
-        instance,
+        withCenteredTextPlacement(instance),
         window.spanW,
         window.spanD,
         originX,

--- a/src/shared/utils/cutoutLabel.test.ts
+++ b/src/shared/utils/cutoutLabel.test.ts
@@ -7,6 +7,7 @@ import {
   hasExplicitLabelSize,
   resolveCutoutTextAnchor,
   textElementFootprint,
+  withCenteredTextPlacement,
   withTextFootprint,
 } from './cutoutLabel';
 import type { Cutout, CutoutArrayConfig } from '@/shared/types/bin';
@@ -362,5 +363,42 @@ describe('withTextFootprint', () => {
     expect(withTextFootprint(circle)).toBe(circle);
     const synced = withTextFootprint(textElement);
     expect(withTextFootprint(synced)).toBe(synced);
+  });
+});
+
+describe('withCenteredTextPlacement', () => {
+  const strayed: Cutout = {
+    id: 't1',
+    shape: 'text',
+    x: 40,
+    y: 40,
+    width: 12,
+    depth: 12,
+    cutDepth: 5,
+    rotation: 0,
+    cornerRadius: 0,
+    label: 'AB',
+    groupId: null,
+    engraveLabel: true,
+    textAnchor: 'top',
+    textOffset: { x: 5, y: -3 },
+  };
+
+  it('strips stray anchor and offset from a text element', () => {
+    const out = withCenteredTextPlacement(strayed);
+    expect(out.textAnchor).toBe('center');
+    expect(out.textOffset).toBeUndefined();
+  });
+
+  it('normalizes an ABSENT anchor too, which would legacy-default to top', () => {
+    const { textAnchor: _a, textOffset: _o, ...bare } = strayed;
+    expect(withCenteredTextPlacement(bare as Cutout).textAnchor).toBe('center');
+  });
+
+  it('is identity for other shapes and for a clean text element', () => {
+    const circle = { ...strayed, shape: 'circle' as const };
+    expect(withCenteredTextPlacement(circle)).toBe(circle);
+    const clean = withCenteredTextPlacement(strayed);
+    expect(withCenteredTextPlacement(clean)).toBe(clean);
   });
 });

--- a/src/shared/utils/cutoutLabel.ts
+++ b/src/shared/utils/cutoutLabel.ts
@@ -205,6 +205,27 @@ export function textElementFootprint(
 }
 
 /**
+ * A text element's caption is centered on its own footprint, full stop. The
+ * anchor grid and nudge fields are not offered for text, so stray values in a
+ * hand-authored file must not shift the caption away from the box the editor
+ * frames — every placement site (bin engraver, lid engraver, 2D preview,
+ * inspector fit) reads the element through this. Identity for every other
+ * shape and for a text element already clean, so callers apply it
+ * unconditionally.
+ */
+export function withCenteredTextPlacement<
+  T extends Pick<Cutout, 'shape' | 'textAnchor' | 'textOffset' | 'textSide'>,
+>(cutout: T): T {
+  if (cutout.shape !== 'text') return cutout;
+  // An ABSENT anchor is not clean: the legacy resolution defaults it to 'top'.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- clearing the legacy field is the point
+  if (cutout.textAnchor === 'center' && cutout.textOffset === undefined && !cutout.textSide) {
+    return cutout;
+  }
+  return { ...cutout, textAnchor: 'center', textOffset: undefined, textSide: undefined };
+}
+
+/**
  * Re-derive a text element's stored footprint from its caption and size,
  * holding the element's center still so an edit never walks it across the
  * board. Identity for every other shape and for a footprint already in sync,


### PR DESCRIPTION
## Summary

Follow-up to #3914, addressing the review findings on it.

Clicking a text element's glyphs started a label-nudge drag, writing a `textOffset` the text inspector neither shows nor clears — the caption drifted off its selection frame with no way back in the UI. Text glyphs now take no label-drag handler, so the pointer falls through to the element's hit plane and moves the element itself.

Placement reads a text element through a new `withCenteredTextPlacement` at every site (bin engraver, lid engraver, 2D preview, inspector fit), so stray `textAnchor`/`textOffset`/`textSide` fields in a hand-authored file cannot shift the caption either — an absent anchor included, which would otherwise legacy-default to `'top'`.

Also from review: the empty-caption scenario asserts identical vertex arrays rather than a bare triangle count, the lid scenario narrows its nullable results without non-null assertions, and the empty-element frame reads the preview-effective caption.

## Testing

- New kernel scenario: a text element with stray anchor/offset/side fields produces a byte-identical mesh to a clean one.
- Unit tests for `withCenteredTextPlacement` (strip, absent-anchor normalization, identity).
- `pnpm run typecheck` and the shared-utils / renderer / workspace suites pass (443 tests), plus all 4 text-element kernel scenarios.

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

