### PR TITLE
chore(lint): move blanket suppressions into config-level rule scoping

### DIFF
--- a/api/lib/validation.ts
+++ b/api/lib/validation.ts
@@ -804,7 +804,7 @@ export function sanitizeString(str: string, maxLength: number): string {
   // Remove null bytes and control characters, trim, truncate
   return (
     str
-      // eslint-disable-next-line no-control-regex
+      // eslint-disable-next-line no-control-regex -- stripping control bytes is the point
       .replace(/[\x00-\x1F\x7F]/g, '')
       .trim()
       .slice(0, maxLength)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,6 +94,9 @@ export default defineConfig([
       'jsx-a11y/no-noninteractive-element-interactions': 'error',
       'jsx-a11y/no-autofocus': 'error',
       'jsx-a11y/interactive-supports-focus': 'error',
+      // role="list" on <ul> is not redundant in practice: Safari/iOS VoiceOver
+      // strips list semantics once list-style:none is applied.
+      'jsx-a11y/no-redundant-roles': ['error', { ul: ['list'] }],
 
       // React anti-patterns
       'react-hooks/rules-of-hooks': 'error',
@@ -438,11 +441,19 @@ export default defineConfig([
     ],
     rules: { 'max-lines': 'off' },
   },
-  // Scripts: no i18n rule needed
+  // Scripts: no i18n rule needed; stdout is a CLI's output channel, not debug logging
   {
     files: ['scripts/**/*.{ts,tsx}'],
     rules: {
       'i18next/no-literal-string': 'off',
+      'no-console': 'off',
+    },
+  },
+  // Diagnostic harnesses print their reports to the console by design
+  {
+    files: ['**/__kernel-tests__/**/*.{ts,tsx}', '**/*.perf.test.{ts,tsx}'],
+    rules: {
+      'no-console': 'off',
     },
   },
 ])

--- a/scripts/batch-consolidate-i18n.ts
+++ b/scripts/batch-consolidate-i18n.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script that outputs to console */
 /**
  * Batch i18n key consolidation.
  *

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /**
  * Build script for static content pages.
  * Converts Markdown files in content/ to HTML in public/.

--- a/scripts/build-en-locale.ts
+++ b/scripts/build-en-locale.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- Build script uses console for status output */
 /**
  * Generates en.json from en.ts for lazy-loaded runtime use.
  *

--- a/scripts/build-route-entries.ts
+++ b/scripts/build-route-entries.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- build script logs status to stdout */
 /**
  * Post-build step: emit static HTML entry points for SPA routes that earn
  * search impressions (/designer, /baseplate) so crawlers and social scrapers

--- a/scripts/check-i18n-interpolation.ts
+++ b/scripts/check-i18n-interpolation.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script that outputs to console */
 /**
  * Pre-commit check: Verify translation interpolation placeholders match code usage.
  *

--- a/scripts/check-i18n-keys.ts
+++ b/scripts/check-i18n-keys.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script that outputs to console */
 /**
  * Pre-commit check: Verify all locale JSON files have the same keys as en.ts.
  *

--- a/scripts/check-i18n-unused.ts
+++ b/scripts/check-i18n-unused.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script that outputs to console */
 /**
  * Detect translation keys in en.ts that are never referenced in source code.
  *

--- a/scripts/check-i18n-values.ts
+++ b/scripts/check-i18n-values.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script that outputs to console */
 /**
  * Pre-commit check: Detect locale values identical to English (untranslated placeholders).
  *

--- a/scripts/compare-kernel-parity.ts
+++ b/scripts/compare-kernel-parity.ts
@@ -8,7 +8,6 @@
  * and both meshes being closed. Manifoldness and triangle count are reported
  * per kernel rather than compared, since neither has to match to be correct.
  */
-/* eslint-disable no-console */
 import { readFileSync } from 'node:fs';
 
 interface Row {

--- a/scripts/consolidate-i18n-key.ts
+++ b/scripts/consolidate-i18n-key.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script that outputs to console */
 /**
  * Safety-checked i18n key consolidation helper.
  *

--- a/scripts/gen-example-thumbnails.ts
+++ b/scripts/gen-example-thumbnails.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- Build script uses console for status output */
 /**
  * Pre-renders committed PNG thumbnails for each gallery example.
  *

--- a/scripts/gen-schema-docs.ts
+++ b/scripts/gen-schema-docs.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env tsx
-/* eslint-disable no-console -- A generator CLI reports what it wrote; that is its output channel, not debug logging. */
 /**
  * Regenerates the field tables in docs/schemas/*.md from the published schemas.
  *

--- a/scripts/gen-seo-images.ts
+++ b/scripts/gen-seo-images.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- build script logs status to stdout */
 /**
  * Generates the committed SEO/marketing images: in-page landing screenshots
  * (public/images/landing/) and per-page Open Graph cards (public/og/).

--- a/scripts/gen-supporters-meshes.ts
+++ b/scripts/gen-supporters-meshes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- Build script uses console for status output */
 /**
  * Bakes the real Gridfinity meshes the /supporters scene instances at runtime.
  *

--- a/scripts/setup-posthog-dashboards.ts
+++ b/scripts/setup-posthog-dashboards.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env -S pnpm exec tsx
-/* eslint-disable no-console */
 /**
  * PostHog Dashboard Setup Script
  *

--- a/scripts/validate-schema-json.ts
+++ b/scripts/validate-schema-json.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env tsx
-/* eslint-disable no-console -- A CLI reports to stdout and stderr; that is its output channel, not debug logging. */
 /**
  * Validates a hand-authored layout or bin design JSON file.
  *

--- a/src/features/baseplate/hooks/useBaseplateGeneration.ts
+++ b/src/features/baseplate/hooks/useBaseplateGeneration.ts
@@ -519,9 +519,7 @@ export function useBaseplateGeneration(): void {
         } else {
           // Split: generate one direct-mesh per unique piece group, clone for duplicates.
           const groups = groupPiecesByFingerprint(tiling.pieces, fullParams);
-          // `new Array(n)` returns `any[]`; we pre-size the typed slot.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const meshEntries: PieceMeshEntry[] = new Array(tiling.pieces.length);
+          const meshEntries = new Array<PieceMeshEntry>(tiling.pieces.length);
 
           for (const group of groups.values()) {
             const mesh = generateBaseplateDirect(group.params, NO_OP_PROGRESS);
@@ -582,9 +580,7 @@ export function useBaseplateGeneration(): void {
           setPieceMeshes([]);
         } else {
           const groups = groupPiecesByFingerprint(tiling.pieces, fullParams);
-          // `new Array(n)` returns `any[]`; we pre-size the typed slot.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const meshEntries: PieceMeshEntry[] = new Array(tiling.pieces.length);
+          const meshEntries = new Array<PieceMeshEntry>(tiling.pieces.length);
 
           for (const group of groups.values()) {
             const baseResult = await preview.generateBaseplate(group.params, NO_OP_PROGRESS);
@@ -679,9 +675,7 @@ export function useBaseplateGeneration(): void {
             }
           }
 
-          // `new Array(n)` returns `any[]`; we pre-size the typed slot.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const meshEntries: PieceMeshEntry[] = new Array(totalCount);
+          const meshEntries = new Array<PieceMeshEntry>(totalCount);
           for (let groupIdx = 0; groupIdx < uniqueGroups.length; groupIdx++) {
             const group = uniqueGroups[groupIdx];
             fillGroupMeshEntries(meshEntries, group, tiling.pieces, uniqueResults[groupIdx]);

--- a/src/features/bin-designer/components/BentoWorkspace/BentoQuickstartOverlay.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoQuickstartOverlay.tsx
@@ -47,7 +47,6 @@ export function BentoQuickstartOverlay({ onDismiss }: BentoQuickstartOverlayProp
         </h3>
 
         {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
-        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
         <ul className="list-none space-y-2" role="list">
           <QuickstartRow text={t('binDesigner.bento.quickstart.draw')} />
           <QuickstartRow text={t('binDesigner.bento.quickstart.moveResize')} />

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutQuickstartOverlay.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutQuickstartOverlay.tsx
@@ -43,7 +43,6 @@ export function CutoutQuickstartOverlay({ onDismiss }: CutoutQuickstartOverlayPr
         </h3>
 
         {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
-        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
         <ul className="space-y-2 list-none" role="list">
           <FeatureRow
             index={0}

--- a/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
+++ b/src/features/bin-designer/components/Workshop/PartProxyMesh.tsx
@@ -69,10 +69,7 @@ export function PartProxyMesh({
   const reducedMotion = usePrefersReducedMotion();
   const invalidate = useThree((s) => s.invalidate);
   const { node } = placed;
-  // Keyed on type + params, not node identity: drags path-copy the node and
-  // every ancestor per pointermove while params stay reference-equal, and a
-  // rebuild here re-uploads geometry for the whole chain each frame.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on type + params, not node identity: drags path-copy the node and every ancestor per pointermove while params stay reference-equal, and a rebuild here re-uploads geometry for the whole chain each frame
   const geometry = useMemo(() => buildPartGeometry(node), [node.type, node.params]);
   useEffect(() => () => geometry.dispose(), [geometry]);
 

--- a/src/features/bin-designer/components/panel/ShapeSection/useShapeSection.ts
+++ b/src/features/bin-designer/components/panel/ShapeSection/useShapeSection.ts
@@ -39,9 +39,7 @@ function subCellIndices(
 function coarsenToGridUnits(hb: CellMask): CellMask {
   const cols = hb.cols / 2;
   const rows = hb.rows / 2;
-  // `new Array(n)` returns `any[]`; we pre-size the typed slot for in-place fill.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const cells: (0 | 1)[] = new Array(cols * rows);
+  const cells = new Array<0 | 1>(cols * rows);
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
       const [a, b, d, e] = subCellIndices(c, r, hb.cols);

--- a/src/features/bin-designer/utils/tags.ts
+++ b/src/features/bin-designer/utils/tags.ts
@@ -24,7 +24,7 @@ export function normalizeTags(input: unknown): string[] {
     // Mirror the server's sanitizeString: strip null bytes + control chars,
     // then trim and cap. Keeps the cross-boundary contract exact.
     const clean = raw
-      // eslint-disable-next-line no-control-regex
+      // eslint-disable-next-line no-control-regex -- the point is to match control bytes
       .replace(/[\x00-\x1F\x7F]/g, '')
       .trim()
       .slice(0, MAX_TAG_LENGTH);

--- a/src/features/community/components/CommunityDetail/DirectRemixList.tsx
+++ b/src/features/community/components/CommunityDetail/DirectRemixList.tsx
@@ -46,7 +46,6 @@ export function DirectRemixList({ designId, remixCount }: DirectRemixListProps) 
         <p className="text-sm text-content-tertiary">{t('community.detail.buildsOnEmpty')}</p>
       ) : (
         /* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */
-        /* eslint-disable-next-line jsx-a11y/no-redundant-roles */
         <ul
           role="list"
           aria-label={t('community.detail.buildsOnThis', { count: remixCount })}

--- a/src/features/community/components/CommunityDetail/RemixLineage.tsx
+++ b/src/features/community/components/CommunityDetail/RemixLineage.tsx
@@ -103,7 +103,6 @@ export function RemixLineage({
       <h3 className="text-sm font-medium text-content">{t('community.lineage.title')}</h3>
 
       {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
-      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ul role="list" className="space-y-2">
         {hasSeparateRoot && (
           <Step

--- a/src/features/community/components/CommunityDetail/SimilarRail.tsx
+++ b/src/features/community/components/CommunityDetail/SimilarRail.tsx
@@ -80,7 +80,6 @@ export function SimilarRail({ design }: SimilarRailProps) {
         {t('community.detail.similarTitle')}
       </h3>
       {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
-      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ul
         role="list"
         aria-label={t('community.detail.similarTitle')}

--- a/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
+++ b/src/features/community/components/CommunityGalleryTab/CommunityGalleryTab.tsx
@@ -674,7 +674,6 @@ export function CommunityGalleryTab({
             {visible.length > 0 && (
               <>
                 {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
-                {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
                 <ul
                   role="list"
                   className={GRID_CLASS}

--- a/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
+++ b/src/features/community/components/CommunityGalleryTab/ShelfLanding.tsx
@@ -158,7 +158,6 @@ function Rail({ id, title, blurb, cards, onSelect, onSelectAuthor, onSeeAll }: R
       <div className="relative">
         {/* motion-reduce disables the snap yank outright, not just the timing:
             scroll-snap can still animate into place without scroll-behavior. */}
-        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- role="list" restores the list semantics Safari/iOS VoiceOver strips once list-style:none is applied. */}
         <ul
           ref={railRef}
           role="list"

--- a/src/features/community/components/PrintsSection/PrintsSection.tsx
+++ b/src/features/community/components/PrintsSection/PrintsSection.tsx
@@ -230,7 +230,6 @@ export function PrintsSection({
             </p>
           ) : (
             <>
-              {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
               <ul role="list" className="space-y-2">
                 {items.map((print) => (
                   <PrintCard

--- a/src/features/generation/worker/generators/__kernel-tests__/baseplatePerfBreakdown.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/baseplatePerfBreakdown.test.ts
@@ -57,10 +57,8 @@ beforeAll(async () => {
 }, 60_000);
 
 afterAll(() => {
-  /* eslint-disable no-console -- diagnostic harness prints its table for inspection */
   console.log(`\nBaseplate stage breakdown — kernel: ${getKernelName()}\n`);
   for (const r of reports) console.log(r);
-  /* eslint-enable no-console */
 });
 
 function median(xs: readonly number[]): number {

--- a/src/features/generation/worker/generators/__kernel-tests__/diagnoseBaseplateWinding.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/diagnoseBaseplateWinding.test.ts
@@ -227,7 +227,6 @@ beforeEach(() => {
 });
 
 test('diagnose: does repairMeshWinding actually flip triangles for these configs?', () => {
-  /* eslint-disable no-console */
   console.log('\n========================================================================');
   console.log('  Raw mesh() vs repairMeshWinding output');
   console.log('========================================================================');
@@ -268,11 +267,9 @@ test('diagnose: does repairMeshWinding actually flip triangles for these configs
     }
   }
   console.log('========================================================================\n');
-  /* eslint-enable no-console */
 }, 300_000);
 
 test('diagnose buildBaseplateSolid winding step-by-step', () => {
-  /* eslint-disable no-console */
   console.log('\n========================================================================');
   console.log('  buildBaseplateSolid — per-step winding diagnosis (issue #1494)');
   console.log('========================================================================');
@@ -307,7 +304,6 @@ test('diagnose buildBaseplateSolid winding step-by-step', () => {
     for (const m of steps) console.log(formatStepRow(m));
   }
   console.log('\n========================================================================\n');
-  /* eslint-enable no-console */
 
   // Surface any per-config throws as a real test failure rather than only
   // a console line — silence is success-shaped in CI.

--- a/src/features/generation/worker/generators/__kernel-tests__/diagnoseShell.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/diagnoseShell.test.ts
@@ -65,7 +65,6 @@ test('diagnose flat no-lip face counts', async () => {
   const bb = withKernel('brepkit', () => getBounds(bkSolid!));
   const edgeTypes = withKernel('brepkit', () => collectEdgeTypeBreakdown(rawKernel, solidId));
 
-  /* eslint-disable no-console */
   console.log('\n=== FACE UNIFICATION DIAGNOSTIC ===');
   console.log(`Test Case: 1×1 flat no-lip bin`);
   console.log(`Bin Parameters: width=1, depth=1, style=flat, stackingLip=false`);
@@ -122,7 +121,6 @@ test('diagnose flat no-lip face counts', async () => {
   console.log(`  Volume: ${vol.toFixed(2)} mm³`);
   console.log(`  Volume valid: ${vol > 0 ? 'YES' : 'NO'}`);
   console.log('===================================\n');
-  /* eslint-enable no-console */
 
   expect(vol, 'volume should be positive').toBeGreaterThan(0);
 }, 60_000);
@@ -133,7 +131,6 @@ test('step-by-step volume: extrude then shell', async () => {
   const rawKernel = getRawBrepkitKernel();
 
   withKernel('brepkit', () => {
-    /* eslint-disable no-console */
     const outerW = STANDARD_BIN_WIDTH;
     const outerD = STANDARD_BIN_WIDTH;
     const r = SHELL_RADIUS;
@@ -207,7 +204,6 @@ test('step-by-step volume: extrude then shell', async () => {
     const counts = getEntityCounts(rawKernel, shelledId);
     console.log(`  Entities: F=${counts.faces} E=${counts.edges} V=${counts.verts}`);
     console.log('=====================================\n');
-    /* eslint-enable no-console */
 
     const extrudeRelErr = Math.abs(extrudeVol - expectedExtrude) / expectedExtrude;
     expect(extrudeRelErr, 'extrude volume within 1%').toBeLessThan(0.01);

--- a/src/features/generation/worker/generators/__kernel-tests__/gomaBoundaryProbe.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/gomaBoundaryProbe.test.ts
@@ -54,9 +54,7 @@ describe('goma boundary probe', () => {
       }
     }
     const boundary = [...edgeCount.entries()].filter(([, c]) => c === 1);
-    // eslint-disable-next-line no-console
     console.log(`boundary edges: ${boundary.length}`);
-    // eslint-disable-next-line no-console
     for (const [k] of boundary.slice(0, 20)) console.log(' ', k);
   }, 600_000);
 });

--- a/src/features/generation/worker/generators/__kernel-tests__/honeycombManifoldCheck.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/honeycombManifoldCheck.test.ts
@@ -44,7 +44,6 @@ describe(`honeycomb wall pattern on ${getKernelName()}`, () => {
       })
     );
 
-    // eslint-disable-next-line no-console
     console.log(
       `[${getKernelName()}] plain tris=${plain.triangleCount} honeycomb tris=${honeycomb.triangleCount} minZ=${minZ(honeycomb.vertices)}`
     );

--- a/src/features/generation/worker/generators/__kernel-tests__/kernelParityMatrix.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kernelParityMatrix.test.ts
@@ -242,7 +242,6 @@ beforeAll(async () => {
 afterAll(() => {
   mkdirSync(dirname(OUT), { recursive: true });
   writeFileSync(OUT, JSON.stringify({ kernel: getKernelName(), rows }, null, 2));
-  // eslint-disable-next-line no-console
   console.log(`wrote ${rows.length} rows to ${OUT}`);
 });
 

--- a/src/features/generation/worker/generators/__kernel-tests__/kumikoNubProbe.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kumikoNubProbe.test.ts
@@ -55,9 +55,7 @@ describe('kumiko nub probe', () => {
         }
       }
     }
-    // eslint-disable-next-line no-console
     console.log(`cavity-protruding corner vertices: ${hits.size}`);
-    // eslint-disable-next-line no-console
     for (const k of [...hits.keys()].slice(0, 40)) console.log(' ', k);
   });
 });

--- a/src/features/generation/worker/generators/__kernel-tests__/kumikoProfile.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kumikoProfile.test.ts
@@ -39,12 +39,10 @@ function profile(label: string, width: number, depth: number, height: number): v
   );
   const total = performance.now() - start;
   const snap = perf.snapshot(total);
-  /* eslint-disable no-console */
   console.log(`\n=== ${label}: total ${total.toFixed(0)}ms ===`);
   for (const s of snap.stages) console.log(`  stage ${s.name}: ${s.ms.toFixed(0)}ms`);
   for (const s of snap.wallPatternSubsteps)
     console.log(`  wallPattern ${s.name}: ${s.ms.toFixed(0)}ms${s.count ? ` (n=${s.count})` : ''}`);
-  /* eslint-enable no-console */
 }
 
 describe('kumiko generation profile', () => {

--- a/src/features/generation/worker/generators/__kernel-tests__/kumikoWrapSpike.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/kumikoWrapSpike.test.ts
@@ -169,7 +169,6 @@ describe(`kumiko corner-wrap spike on ${getKernelName()}`, () => {
     const meshed = mesh(opened, { tolerance: 0.1 });
     expect(meshed.triangles.length).toBeGreaterThan(0);
 
-    // eslint-disable-next-line no-console
     console.log(
       `[${getKernelName()}] shell=${solidVol.toFixed(1)}mm³ opened=${openedVol.toFixed(1)}mm³ removed=${(
         (1 - openedVol / solidVol) *

--- a/src/features/generation/worker/generators/__kernel-tests__/occtWasmIsolation.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/occtWasmIsolation.test.ts
@@ -67,7 +67,6 @@ describe('occt-wasm isolation: generateBin without occt init', () => {
   }, 600_000);
 
   it('prints isolated occt-wasm results for cross-reference vs parity test', () => {
-    /* eslint-disable no-console */
     console.log('\n=== OCCT-WASM ISOLATION (no occt registered) ===\n');
     for (const tc of CORE_PARITY_CASES) {
       const r = results.get(tc.name);
@@ -84,7 +83,6 @@ describe('occt-wasm isolation: generateBin without occt init', () => {
       '  expected (paired run):  1×1 lip=59f, 2×2 nolip=71f, 2×2 mag+screw=170f, 2×2 scoop=355f, 1×1 flat=27f'
     );
     console.log('\n=================================================\n');
-    /* eslint-enable no-console */
 
     expect(results.size).toBeGreaterThan(0);
   });

--- a/src/features/generation/worker/generators/__kernel-tests__/profileBin.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/profileBin.test.ts
@@ -28,7 +28,6 @@ beforeAll(async () => {
 }, 30_000);
 
 afterAll(() => {
-  /* eslint-disable no-console */
   console.log(`\n┌──────────────────────────────────────────────────────────────────┐`);
   console.log(`│  Kernel: ${getKernelName().padEnd(55)}│`);
   console.log(`├──────────────────────────────────┬──────────┬──────────────────┤`);
@@ -40,7 +39,6 @@ afterAll(() => {
     );
   }
   console.log(`└──────────────────────────────────┴──────────┴──────────────────┘`);
-  /* eslint-enable no-console */
 });
 
 function runBin(name: string, overrides: Partial<BinParams>, forExport = false): void {

--- a/src/features/generation/worker/generators/__kernel-tests__/reportTable.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/reportTable.ts
@@ -56,7 +56,6 @@ export function printTimingTable(timings: TimingEntry[]): void {
   const totalTris = timings.reduce((sum, t) => sum + t.triangleCount, 0);
   const passCount = timings.filter((t) => t.passed).length;
 
-  // eslint-disable-next-line no-console -- dual-kernel parity report is intentionally printed to console for scenario diagnostics
   console.log(
     [
       '',

--- a/src/features/generation/worker/generators/tessellation.perf.test.ts
+++ b/src/features/generation/worker/generators/tessellation.perf.test.ts
@@ -66,7 +66,6 @@ describe('tessellation performance budget', () => {
     });
     const avgMs = benchmarkGeneration(params);
 
-    // eslint-disable-next-line no-console -- perf reporting
     console.log(`  2×2 lip bin: ${avgMs.toFixed(1)}ms avg (budget: ${MAX_MS_SMALL_BIN}ms)`);
     expect(avgMs).toBeLessThan(MAX_MS_SMALL_BIN);
   });
@@ -80,7 +79,6 @@ describe('tessellation performance budget', () => {
     });
     const avgMs = benchmarkGeneration(params);
 
-    // eslint-disable-next-line no-console -- perf reporting
     console.log(`  4×4 lip bin: ${avgMs.toFixed(1)}ms avg (budget: ${MAX_MS_LARGE_BIN}ms)`);
     expect(avgMs).toBeLessThan(MAX_MS_LARGE_BIN);
   });
@@ -94,7 +92,6 @@ describe('tessellation performance budget', () => {
     });
     const avgMs = benchmarkGeneration(params);
 
-    // eslint-disable-next-line no-console -- perf reporting
     console.log(`  8×8 lip bin: ${avgMs.toFixed(1)}ms avg (budget: ${MAX_MS_VERY_LARGE_BIN}ms)`);
     expect(avgMs).toBeLessThan(MAX_MS_VERY_LARGE_BIN);
   });
@@ -110,7 +107,6 @@ describe('tessellation performance budget', () => {
     });
     const avgMs = benchmarkGeneration(params);
 
-    // eslint-disable-next-line no-console -- perf reporting
     console.log(`  2×2 complex: ${avgMs.toFixed(1)}ms avg (budget: ${MAX_MS_COMPLEX_BIN}ms)`);
     expect(avgMs).toBeLessThan(MAX_MS_COMPLEX_BIN);
   });

--- a/src/shared/components/QuickstartCard/QuickstartCard.tsx
+++ b/src/shared/components/QuickstartCard/QuickstartCard.tsx
@@ -54,7 +54,6 @@ export function QuickstartCard({
         </h3>
 
         {/* role="list" restores list semantics that Safari/iOS VoiceOver strips when list-style:none is applied. */}
-        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
         <ul className="space-y-2 list-none" role="list">
           {rows.map((row, i) => (
             <li key={i} className="flex items-start gap-2.5">

--- a/src/shared/utils/cutoutLabel.ts
+++ b/src/shared/utils/cutoutLabel.ts
@@ -98,8 +98,7 @@ export function resolveCutoutTextAnchor(
   cutout: Pick<Cutout, 'textAnchor' | 'textSide'>
 ): CutoutTextAnchor {
   if (cutout.textAnchor) return cutout.textAnchor;
-  // Reading the deprecated field is the migration path it exists for.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- reading the legacy field is the migration path it exists for
   switch (cutout.textSide) {
     case 'bottom':
       return 'bottom';


### PR DESCRIPTION
## Summary

Retires 57 scattered eslint-disable comments by scoping rules where the blanket pattern was the config's job:

- `no-console` is now off for `scripts/`, `__kernel-tests__/`, and `*.perf.test` files. A CLI or diagnostic harness printing to stdout is its contract, not debug logging. Removes 44 file-level and inline disables (several were in eslint-ignored files, so they were dead comments already).
- `jsx-a11y/no-redundant-roles` now permits `role="list"` on `ul` via the rule's allowlist option, with the Safari/iOS VoiceOver rationale (VoiceOver strips list semantics under `list-style: none`) recorded once in the config instead of 9 copies.
- The four `new Array(n)` sites use `new Array<T>(n)` instead of suppressing `no-unsafe-assignment`. The untyped constructor returns `any[]`; the typed one needs no suppression.
- The four remaining bare disables (`no-control-regex` x2, `no-deprecated`, `exhaustive-deps`) now carry their justification in the machine-checked `-- reason` slot that `suppression-guard.sh` enforces on new lines.

No behavior changes. Net -54 lines.

## Testing

- `pnpm run typecheck` clean
- `eslint` on all 45 touched files: 0 errors
- Unit tests for the two code-changed files (`useBaseplateGeneration`, `ShapeSection`): 87 passed

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

