### PR TITLE
fix(build): repoint the core-foundation chunk pin at the types directory

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -450,7 +450,7 @@ export default defineConfig({
               priority: 100,
               test: (id: string) =>
                 id.endsWith('/src/core/constants.ts') ||
-                id.endsWith('/src/core/types.ts') ||
+                id.includes('/src/core/types/') ||
                 id.includes('packages/branded-types/src/'),
             },
             // Core React runtime — eager, shared by every UI chunk. HIGHEST vendor
@@ -484,7 +484,7 @@ export default defineConfig({
             // duplication (total JS is unchanged either way).
           ],
         },
-        // Note: posthog-js is dynamically imported in src/shared/analytics/posthog.ts
+        // Note: posthog-js is dynamically imported in src/shared/analytics/posthog/
         // so it automatically gets its own chunk without needing chunk config.
       },
     },


### PR DESCRIPTION
## Summary

`vite.config.ts`'s `core-foundation` chunk rule still matched `src/core/types.ts`, which #2755 split into the `src/core/types/` directory five weeks ago. Since then the predicate has been a no-op for those modules, and the leaf-chunk guarantee it exists to provide (module-init values like `DEFAULT_MAGNET_ANCHOR` and `effectiveGridUnitMmY` evaluate before dependents, preventing the chunk-level import-cycle boot crash class from #1466) was holding only by rolldown's incidental default placement. Any rolldown/vite bump or import-graph change could have shifted it with no test to catch the regression.

The fix matches the directory instead. `src/core/types/*` imports only type-only symbols from `@gridfinity/branded-types` (already pinned to the same chunk), so the leaf property holds.

Also updates the stale `posthog.ts` path comment (now the `posthog/` directory).

## Verification

Full `pnpm run build`: the emitted `core-foundation` chunk hash is byte-identical to the pre-fix build, confirming the rule now pins exactly what default placement was producing incidentally.

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

