### PR TITLE
chore(cqrs): remove the dead descriptionKey field from v2 command defs

### DIFF
--- a/scripts/doc-budget.json
+++ b/scripts/doc-budget.json
@@ -1,6 +1,10 @@
 {
   "tolerance": "1.1",
-  "allowedMissingRefs": ["b17779575", "components/Foo.tsx", "diffProps"],
+  "allowedMissingRefs": [
+    "b17779575",
+    "components/Foo.tsx",
+    "diffProps"
+  ],
   "words": {
     ".claude/skills/analytics-and-labs/SKILL.md": 1270,
     ".claude/skills/auth-and-sync/SKILL.md": 1320,
@@ -37,7 +41,7 @@
     "scripts/train-label-suggester/README.md": 467,
     "src/core/.greptile/rules.md": 231,
     "src/core/README.md": 663,
-    "src/core/cqrs/README.md": 1521,
+    "src/core/cqrs/README.md": 1513,
     "src/design-system/docs/COMPONENTS.md": 2641,
     "src/design-system/docs/README.md": 623,
     "src/design-system/docs/TOKENS.md": 1238,

--- a/src/core/cqrs/README.md
+++ b/src/core/cqrs/README.md
@@ -134,7 +134,6 @@ commands intentionally remain v1 (`handlers/designerHandlers.ts`,
      payload: payloadSchema,
      emitted: 'domain.myActionDone',
      schemaVersion: 1,
-     descriptionKey: 'undo.action.myAction',
      middleware: { undoCapture: true, validate: true },
      handle: (payload, ctx) => {
        // read-only planning against ctx.aggregate; brand payload values at
@@ -154,8 +153,8 @@ commands intentionally remain v1 (`handlers/designerHandlers.ts`,
 
 7. **Add the command's profile** to `COMMAND_PROFILES` in
    `middleware/middlewareConfig.ts` (the record is exhaustive over
-   `CommandType`) and its toast key to `commandDescriptions.ts` — that map,
-   not the def's `descriptionKey`, drives the undo/redo toast.
+   `CommandType`) and its toast key to `commandDescriptions.ts`, which
+   drives the undo/redo toast.
 
 8. **Add a Zod validation schema** in `validation/schemas.ts` — the
    validation middleware reads `COMMAND_SCHEMAS`, not the def's `payload`

--- a/src/core/cqrs/v2/domain/bin/addBin.test.ts
+++ b/src/core/cqrs/v2/domain/bin/addBin.test.ts
@@ -150,7 +150,6 @@ describe('v2 bin.add', () => {
       expect(addBin.aggregate).toBe('layout');
       expect(addBin.emitted).toBe('bin.added');
       expect(addBin.schemaVersion).toBe(1);
-      expect(addBin.descriptionKey).toBe('undo.action.binAdd');
     });
   });
 });

--- a/src/core/cqrs/v2/domain/bin/addBin.ts
+++ b/src/core/cqrs/v2/domain/bin/addBin.ts
@@ -43,7 +43,6 @@ export const addBin = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.added',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binAdd',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     // Brand at the CQRS boundary (codebase convention: brand on

--- a/src/core/cqrs/v2/domain/bin/clearLayer.ts
+++ b/src/core/cqrs/v2/domain/bin/clearLayer.ts
@@ -19,7 +19,6 @@ export const clearLayer = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.layerCleared',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layerClear',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const layerId = toLayerId(payload.layerId);

--- a/src/core/cqrs/v2/domain/bin/deleteBin.ts
+++ b/src/core/cqrs/v2/domain/bin/deleteBin.ts
@@ -18,7 +18,6 @@ export const deleteBin = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.deleted',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binDelete',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const id = toBinId(payload.id);

--- a/src/core/cqrs/v2/domain/bin/deleteBins.ts
+++ b/src/core/cqrs/v2/domain/bin/deleteBins.ts
@@ -20,7 +20,6 @@ export const deleteBins = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.batchDeleted',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binDeleteBatch',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const idSet = new Set(payload.ids.map(toBinId));

--- a/src/core/cqrs/v2/domain/bin/duplicateBin.ts
+++ b/src/core/cqrs/v2/domain/bin/duplicateBin.ts
@@ -65,7 +65,6 @@ export const duplicateBin = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.duplicated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binDuplicate',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/bin/expandToFit.ts
+++ b/src/core/cqrs/v2/domain/bin/expandToFit.ts
@@ -49,7 +49,6 @@ export const expandToFit = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.expandedToFit',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binsExpandedToFit',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/bin/fillGaps.ts
+++ b/src/core/cqrs/v2/domain/bin/fillGaps.ts
@@ -29,7 +29,6 @@ export const fillGaps = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.layerFilled',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layerFillGaps',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const layerId = toLayerId(payload.layerId);

--- a/src/core/cqrs/v2/domain/bin/fillLayer.ts
+++ b/src/core/cqrs/v2/domain/bin/fillLayer.ts
@@ -28,7 +28,6 @@ export const fillLayer = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.layerFilled',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layerFill',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const layerId = toLayerId(payload.layerId);

--- a/src/core/cqrs/v2/domain/bin/moveBinFromStaging.ts
+++ b/src/core/cqrs/v2/domain/bin/moveBinFromStaging.ts
@@ -31,7 +31,6 @@ export const moveBinFromStaging = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.movedFromStaging',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binMoveFromStaging',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/bin/moveBinToStaging.ts
+++ b/src/core/cqrs/v2/domain/bin/moveBinToStaging.ts
@@ -20,7 +20,6 @@ export const moveBinToStaging = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.movedToStaging',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binMoveToStaging',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const id = toBinId(payload.id);

--- a/src/core/cqrs/v2/domain/bin/updateBin.ts
+++ b/src/core/cqrs/v2/domain/bin/updateBin.ts
@@ -131,7 +131,6 @@ export const updateBin = defineCommand({
   payload: payloadSchema,
   emitted: 'bin.updated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binUpdate',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/category/addCategory.ts
+++ b/src/core/cqrs/v2/domain/category/addCategory.ts
@@ -22,7 +22,6 @@ export const addCategory = defineCommand({
   payload: payloadSchema,
   emitted: 'category.added',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.categoryAdd',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/category/deleteCategory.ts
+++ b/src/core/cqrs/v2/domain/category/deleteCategory.ts
@@ -23,7 +23,6 @@ export const deleteCategory = defineCommand({
   payload: payloadSchema,
   emitted: 'category.deleted',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.categoryDelete',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/category/updateCategory.ts
+++ b/src/core/cqrs/v2/domain/category/updateCategory.ts
@@ -39,7 +39,6 @@ export const updateCategory = defineCommand({
   payload: payloadSchema,
   emitted: 'category.updated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.categoryUpdate',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/drawer/setDrawerOutline.ts
+++ b/src/core/cqrs/v2/domain/drawer/setDrawerOutline.ts
@@ -55,7 +55,6 @@ export const setDrawerOutline = defineCommand({
   payload: payloadSchema,
   emitted: 'drawer.outlineSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.drawerSetOutline',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
+++ b/src/core/cqrs/v2/domain/drawer/updateDrawer.ts
@@ -92,7 +92,6 @@ export const updateDrawer = defineCommand({
   payload: payloadSchema,
   emitted: 'drawer.updated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.drawerUpdate',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/layer/addLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/addLayer.ts
@@ -23,7 +23,6 @@ export const addLayer = defineCommand({
   payload: payloadSchema,
   emitted: 'layer.added',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layerAdd',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     _payload,

--- a/src/core/cqrs/v2/domain/layer/deleteLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/deleteLayer.ts
@@ -24,7 +24,6 @@ export const deleteLayer = defineCommand({
   payload: payloadSchema,
   emitted: 'layer.deleted',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layerDelete',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/layer/reorderLayers.ts
+++ b/src/core/cqrs/v2/domain/layer/reorderLayers.ts
@@ -24,7 +24,6 @@ export const reorderLayers = defineCommand({
   payload: payloadSchema,
   emitted: 'layer.reordered',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layerReorder',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/layer/updateLayer.ts
+++ b/src/core/cqrs/v2/domain/layer/updateLayer.ts
@@ -41,7 +41,6 @@ export const updateLayer = defineCommand({
   payload: payloadSchema,
   emitted: 'layer.updated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layerUpdate',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/layout/setActiveBaseplate.ts
+++ b/src/core/cqrs/v2/domain/layout/setActiveBaseplate.ts
@@ -34,7 +34,6 @@ export const setActiveBaseplate = defineCommand({
   payload: payloadSchema,
   emitted: 'layout.activeBaseplateSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layoutSetActiveBaseplate',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const previousActiveBaseplateId: BaseplateDesignId | null =

--- a/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
+++ b/src/core/cqrs/v2/domain/layout/setBaseplateParams.ts
@@ -77,7 +77,6 @@ export const setBaseplateParams = defineCommand({
   payload: payloadSchema,
   emitted: 'layout.baseplateParamsSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layoutSetBaseplateParams',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const previousParams = ctx.aggregate.baseplateParams

--- a/src/core/cqrs/v2/domain/layout/setGridUnitMm.ts
+++ b/src/core/cqrs/v2/domain/layout/setGridUnitMm.ts
@@ -22,7 +22,6 @@ export const setGridUnitMm = defineCommand({
   payload: payloadSchema,
   emitted: 'layout.gridUnitMmSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layoutSetGridUnitMm',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const layout = ctx.aggregate;

--- a/src/core/cqrs/v2/domain/layout/setGridUnitMmY.ts
+++ b/src/core/cqrs/v2/domain/layout/setGridUnitMmY.ts
@@ -23,7 +23,6 @@ export const setGridUnitMmY = defineCommand({
   payload: payloadSchema,
   emitted: 'layout.gridUnitMmYSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layoutSetGridUnitMmY',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const layout = ctx.aggregate;

--- a/src/core/cqrs/v2/domain/layout/setHeightUnitMm.ts
+++ b/src/core/cqrs/v2/domain/layout/setHeightUnitMm.ts
@@ -15,7 +15,6 @@ export const setHeightUnitMm = defineCommand({
   payload: payloadSchema,
   emitted: 'layout.heightUnitMmSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layoutSetHeightUnitMm',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const previousMm = ctx.aggregate.heightUnitMm as number;

--- a/src/core/cqrs/v2/domain/layout/setMagnetAnchor.ts
+++ b/src/core/cqrs/v2/domain/layout/setMagnetAnchor.ts
@@ -13,7 +13,6 @@ export const setMagnetAnchor = defineCommand({
   payload: payloadSchema,
   emitted: 'layout.magnetAnchorSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layoutSetMagnetAnchor',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const previousAnchor = ctx.aggregate.magnetAnchor ?? 'edge';

--- a/src/core/cqrs/v2/domain/layout/setName.ts
+++ b/src/core/cqrs/v2/domain/layout/setName.ts
@@ -19,7 +19,6 @@ export const setName = defineCommand({
   payload: payloadSchema,
   emitted: 'layout.nameSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layoutSetName',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const previousName = ctx.aggregate.name;

--- a/src/core/cqrs/v2/domain/layout/setPrintBedSize.ts
+++ b/src/core/cqrs/v2/domain/layout/setPrintBedSize.ts
@@ -23,7 +23,6 @@ export const setPrintBedSize = defineCommand({
   payload: payloadSchema,
   emitted: 'layout.printBedSizeSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.layoutSetPrintBedSize',
   middleware: { undoCapture: true, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const previousSize = ctx.aggregate.printBedSize as number;

--- a/src/core/cqrs/v2/domain/library/clearCloudShare.ts
+++ b/src/core/cqrs/v2/domain/library/clearCloudShare.ts
@@ -18,7 +18,6 @@ export const clearCloudShare = defineCommand({
   payload: payloadSchema,
   emitted: 'library.cloudShareCleared',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.libraryClearCloudShare',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload) => {
     const layoutId = toLayoutId(payload.layoutId);

--- a/src/core/cqrs/v2/domain/library/createEntry.ts
+++ b/src/core/cqrs/v2/domain/library/createEntry.ts
@@ -56,7 +56,6 @@ export const createEntry = defineCommand({
   payload: payloadSchema,
   emitted: 'library.entryCreated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.libraryCreateEntry',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const id = payload.layoutId !== undefined ? toLayoutId(payload.layoutId) : generateLayoutId();

--- a/src/core/cqrs/v2/domain/library/deleteEntry.ts
+++ b/src/core/cqrs/v2/domain/library/deleteEntry.ts
@@ -20,7 +20,6 @@ export const deleteEntry = defineCommand({
   payload: payloadSchema,
   emitted: 'library.entryDeleted',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.libraryDeleteEntry',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/library/duplicateEntry.ts
+++ b/src/core/cqrs/v2/domain/library/duplicateEntry.ts
@@ -22,7 +22,6 @@ export const duplicateEntry = defineCommand({
   payload: payloadSchema,
   emitted: 'library.entryDuplicated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.libraryDuplicateEntry',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/domain/library/importLayout.ts
+++ b/src/core/cqrs/v2/domain/library/importLayout.ts
@@ -24,7 +24,6 @@ export const importLayout = defineCommand({
   payload: payloadSchema,
   emitted: 'library.entryCreated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.libraryImportLayout',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload, ctx) => {
     // Central validation treats `layout` as `unknown`; computePreview

--- a/src/core/cqrs/v2/domain/library/renameEntry.ts
+++ b/src/core/cqrs/v2/domain/library/renameEntry.ts
@@ -21,7 +21,6 @@ export const renameEntry = defineCommand({
   payload: payloadSchema,
   emitted: 'library.entryRenamed',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.libraryRenameEntry',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const layoutId = toLayoutId(payload.layoutId);

--- a/src/core/cqrs/v2/domain/library/setAuthorName.ts
+++ b/src/core/cqrs/v2/domain/library/setAuthorName.ts
@@ -19,7 +19,6 @@ export const setAuthorName = defineCommand({
   payload: payloadSchema,
   emitted: 'library.authorNameSet',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.librarySetAuthorName',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const previousName = ctx.aggregate.settings.authorName ?? '';

--- a/src/core/cqrs/v2/domain/library/setCloudShare.ts
+++ b/src/core/cqrs/v2/domain/library/setCloudShare.ts
@@ -32,7 +32,6 @@ export const setCloudShare = defineCommand({
   payload: payloadSchema,
   emitted: 'library.cloudShareUpdated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.librarySetCloudShare',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload) => {
     const layoutId = toLayoutId(payload.layoutId);

--- a/src/core/cqrs/v2/domain/library/switchActive.ts
+++ b/src/core/cqrs/v2/domain/library/switchActive.ts
@@ -18,7 +18,6 @@ export const switchActive = defineCommand({
   payload: payloadSchema,
   emitted: 'library.activeLayoutSwitched',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.librarySwitchActive',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (payload, ctx) => {
     const newLayoutId = toLayoutId(payload.layoutId);

--- a/src/core/cqrs/v2/domain/library/updateEntry.ts
+++ b/src/core/cqrs/v2/domain/library/updateEntry.ts
@@ -39,7 +39,6 @@ export const updateEntry = defineCommand({
   payload: payloadSchema,
   emitted: 'library.entryUpdated',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.libraryUpdateEntry',
   middleware: { undoCapture: false, validate: true, analytics: true },
   handle: (
     payload,

--- a/src/core/cqrs/v2/sample.ts
+++ b/src/core/cqrs/v2/sample.ts
@@ -22,7 +22,6 @@ export const sampleAddBin = defineCommand({
   }),
   emitted: 'sample.bin.added',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binAdd',
   middleware: { undoCapture: true, validate: true },
   handle: (payload, _ctx) => {
     if (payload.x > 100) {
@@ -45,7 +44,6 @@ export const sampleDeleteBin = defineCommand({
   payload: z.object({ id: z.string().min(1) }),
   emitted: 'sample.bin.deleted',
   schemaVersion: 1,
-  descriptionKey: 'undo.action.binDelete',
   handle: (payload, _ctx) => {
     if (!payload.id.startsWith('bin_')) {
       return err<LayoutError>(layoutInvalidOperation('deleteBin', `Bad id ${payload.id}`));

--- a/src/core/cqrs/v2/types.ts
+++ b/src/core/cqrs/v2/types.ts
@@ -101,7 +101,6 @@ export interface CommandDefShape<
   readonly payload: z.ZodType<TPayload>;
   readonly emitted: TEventType;
   readonly schemaVersion: number;
-  readonly descriptionKey: string;
   readonly middleware?: MiddlewareFlags;
   readonly handle: (
     payload: TPayload,
@@ -129,5 +128,4 @@ export interface AnyCommandDef {
   readonly aggregate: AggregateName;
   readonly emitted: string;
   readonly schemaVersion: number;
-  readonly descriptionKey: string;
 }


### PR DESCRIPTION
## Summary

Removes `descriptionKey` from the v2 command definition types and all 43 declarations (41 domain defs + 2 sample defs).

The field has never been read by anything. Undo/redo toast descriptions come from the map in `commandDescriptions.ts`, which the README explicitly warned about ("that map, not the def's `descriptionKey`, drives the undo/redo toast"). Worse, every declared value pointed at an `undo.action.*` i18n key that exists in no locale file, so wiring the field up as-is would have rendered raw key strings.

Note: library commands are excluded from undo capture (`library: { undo: false }` in `middlewareConfig.ts`), so their absence from the descriptions map is not a user-visible gap. The map remains the single real source of toast keys.

## Testing

- `pnpm run typecheck` clean
- All 63 CQRS test files pass (502 tests)

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

