### PR TITLE
test(api): assert the api/src validation mirrors instead of trusting comments

### DIFF
--- a/api/lib/assemblyValidation.crossBoundary.test.ts
+++ b/api/lib/assemblyValidation.crossBoundary.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Cross-boundary equality tests for the Workshop assembly mirror.
+ *
+ * `api/lib/assemblyValidation.ts` is a hand-written restatement of the zod
+ * schema in `src/shared/items/assembly/descriptor.ts`, because api/ cannot
+ * import from src/. Every fixture below is fed to BOTH and only their verdicts
+ * are compared, so a limit the two sides move together stays green and a limit
+ * only one of them moves fails. Boundary values are read off the client's own
+ * clamps rather than restated, so this file never becomes a third copy.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_ASSEMBLY_DEPTH as API_MAX_ASSEMBLY_DEPTH,
+  MAX_ASSEMBLY_PARTS as API_MAX_ASSEMBLY_PARTS,
+  PART_TYPES,
+  validateAssemblyStructure,
+} from './assemblyValidation.js';
+
+import {
+  DEFAULT_PART_PARAMS,
+  DEFAULT_PART_TRANSFORM,
+  MAX_ASSEMBLY_DEPTH,
+  MAX_ASSEMBLY_PARTS,
+  assemblySchema,
+  clampAssemblyBase,
+  clampPartTransform,
+  defaultCutterProfile,
+} from '../../src/shared/items/assembly/descriptor.js';
+import { ASSEMBLY_PART_TYPES } from '../../src/shared/types/assembly.js';
+import type { AssemblyPartType, CutterProfile } from '../../src/shared/types/assembly.js';
+
+type Json = Record<string, unknown>;
+
+const node = (type: AssemblyPartType, extra: Json = {}): Json => ({
+  id: `n-${type}`,
+  type,
+  params: DEFAULT_PART_PARAMS[type],
+  transform: DEFAULT_PART_TRANSFORM,
+  children: [],
+  ...extra,
+});
+
+const structure = (parts: readonly unknown[], base: Json = { floorThickness: 2 }): Json => ({
+  kind: 'assembly',
+  schemaVersion: 1,
+  base,
+  mirrorAxis: 'x',
+  parts,
+});
+
+const flatParts = (count: number): Json[] =>
+  Array.from({ length: count }, (_, index) => node('post', { id: `p${index}` }));
+
+const nestedPart = (depth: number): Json => {
+  let deepest = node('post', { id: 'd1' });
+  for (let level = 2; level <= depth; level += 1) {
+    deepest = node('post', { id: `d${level}`, children: [deepest] });
+  }
+  return deepest;
+};
+
+// Keyed by the union so a newly added cutter shape fails to compile here
+// rather than silently going unprobed.
+const CUTTER_SHAPE_KEYS = {
+  circle: true,
+  rectangle: true,
+  polygon: true,
+  slot: true,
+  path: true,
+  outline: true,
+} satisfies Record<CutterProfile['shape'], true>;
+
+const CUTTER_SHAPES = Object.keys(CUTTER_SHAPE_KEYS) as (keyof typeof CUTTER_SHAPE_KEYS)[];
+
+const TRANSFORM_HI = clampPartTransform({ x: 1e6, y: 1e6, seatZ: 1e6, rotZDeg: 1e6 });
+const TRANSFORM_LO = clampPartTransform({ x: -1e6, y: -1e6, seatZ: -1e6, rotZDeg: -1e6 });
+const TRANSFORM_KEYS = ['x', 'y', 'seatZ', 'rotZDeg'] as const;
+
+const BASE_HI = clampAssemblyBase({
+  floorThickness: 1e6,
+  cornerRadius: 1e6,
+  wedge: { angleDeg: 1e6, lowEdge: 'front' },
+});
+const BASE_LO = clampAssemblyBase({ floorThickness: -1e6, cornerRadius: -1e6 });
+const BASE_HI_CORNER_RADIUS = BASE_HI.cornerRadius ?? 0;
+const BASE_HI_WEDGE_ANGLE = BASE_HI.wedge?.angleDeg ?? 0;
+const BASE_LO_CORNER_RADIUS = BASE_LO.cornerRadius ?? 0;
+
+const FIXTURES: readonly (readonly [string, unknown])[] = [
+  ...ASSEMBLY_PART_TYPES.map(
+    (type) => [`${type} at its defaults`, structure([node(type)])] as const
+  ),
+  ...CUTTER_SHAPES.map(
+    (shape) =>
+      [
+        `cutter profile: ${shape}`,
+        structure([
+          node('cutter', {
+            params: { ...DEFAULT_PART_PARAMS.cutter, profile: defaultCutterProfile(shape) },
+          }),
+        ]),
+      ] as const
+  ),
+  ['transform at its upper clamp', structure([node('post', { transform: TRANSFORM_HI })])],
+  ['transform at its lower clamp', structure([node('post', { transform: TRANSFORM_LO })])],
+  ...TRANSFORM_KEYS.flatMap(
+    (key) =>
+      [
+        [
+          `transform.${key} one past its upper clamp`,
+          structure([
+            node('post', { transform: { ...TRANSFORM_HI, [key]: TRANSFORM_HI[key] + 1 } }),
+          ]),
+        ],
+        [
+          `transform.${key} one past its lower clamp`,
+          structure([
+            node('post', { transform: { ...TRANSFORM_LO, [key]: TRANSFORM_LO[key] - 1 } }),
+          ]),
+        ],
+      ] as const
+  ),
+  ['base at its upper clamp', structure([node('post')], { ...BASE_HI })],
+  [
+    'base.floorThickness one past its upper clamp',
+    structure([node('post')], { ...BASE_HI, floorThickness: BASE_HI.floorThickness + 1 }),
+  ],
+  [
+    'base.cornerRadius one past its upper clamp',
+    structure([node('post')], { ...BASE_HI, cornerRadius: BASE_HI_CORNER_RADIUS + 1 }),
+  ],
+  [
+    'base.wedge.angleDeg one past its upper clamp',
+    structure([node('post')], {
+      ...BASE_HI,
+      wedge: { angleDeg: BASE_HI_WEDGE_ANGLE + 1, lowEdge: 'front' },
+    }),
+  ],
+  [
+    'base.wedge.lowEdge outside its enum',
+    structure([node('post')], {
+      ...BASE_HI,
+      wedge: { angleDeg: BASE_HI_WEDGE_ANGLE, lowEdge: 'top' },
+    }),
+  ],
+  ['base at its lower clamp', structure([node('post')], { ...BASE_LO })],
+  [
+    'base.floorThickness one past its lower clamp',
+    structure([node('post')], { ...BASE_LO, floorThickness: BASE_LO.floorThickness - 1 }),
+  ],
+  [
+    'base.cornerRadius one past its lower clamp',
+    structure([node('post')], { ...BASE_LO, cornerRadius: BASE_LO_CORNER_RADIUS - 1 }),
+  ],
+  ['part count at the cap', structure(flatParts(MAX_ASSEMBLY_PARTS))],
+  ['part count one past the cap', structure(flatParts(MAX_ASSEMBLY_PARTS + 1))],
+  ['nesting at the cap', structure([nestedPart(MAX_ASSEMBLY_DEPTH)])],
+  ['nesting one past the cap', structure([nestedPart(MAX_ASSEMBLY_DEPTH + 1)])],
+  ['mirrorAxis outside its enum', { ...structure([node('post')]), mirrorAxis: 'z' }],
+  ['unknown part type', structure([node('post', { type: 'sphere' })])],
+];
+
+describe('assembly limits (cross-boundary mirror)', () => {
+  it('allows exactly the client part types', () => {
+    expect(PART_TYPES).toEqual(new Set(ASSEMBLY_PART_TYPES));
+  });
+
+  it('caps part count where the client does', () => {
+    expect(API_MAX_ASSEMBLY_PARTS).toBe(MAX_ASSEMBLY_PARTS);
+  });
+
+  it('caps nesting depth where the client does', () => {
+    expect(API_MAX_ASSEMBLY_DEPTH).toBe(MAX_ASSEMBLY_DEPTH);
+  });
+});
+
+describe('assembly structure validation (cross-boundary mirror)', () => {
+  it('exercises both verdicts, so agreement is not vacuous', () => {
+    const verdicts = FIXTURES.map(([, candidate]) => assemblySchema.safeParse(candidate).success);
+    expect(verdicts).toContain(true);
+    expect(verdicts).toContain(false);
+  });
+
+  it.each(FIXTURES)('%s: the schema and the server validator agree', (_label, candidate) => {
+    expect(validateAssemblyStructure(candidate).valid).toBe(
+      assemblySchema.safeParse(candidate).success
+    );
+  });
+});

--- a/api/lib/assemblyValidation.ts
+++ b/api/lib/assemblyValidation.ts
@@ -15,12 +15,12 @@ import {
 import { validateFeatureColors } from './designerValidation.js';
 import { checkText } from './contentFilter.js';
 
-const MAX_ASSEMBLY_PARTS = 256;
-const MAX_ASSEMBLY_DEPTH = 8;
+export const MAX_ASSEMBLY_PARTS = 256;
+export const MAX_ASSEMBLY_DEPTH = 8;
 const MAX_PATH_POINTS = 2000;
 const MAX_OUTLINE_POINTS = 5000;
 
-const PART_TYPES = new Set([
+export const PART_TYPES = new Set([
   'post',
   'fin',
   'block',

--- a/api/lib/communityStore.crossBoundary.test.ts
+++ b/api/lib/communityStore.crossBoundary.test.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_HEIGHT_UNIT_MM,
   deriveCommunityMetrics,
 } from './communityStore.js';
+import { validateDesignerShare } from './designerValidation.js';
 
 import { binDimensions } from '../../src/features/bin-designer/utils/binDimensions.js';
 import { DEFAULT_BIN_PARAMS } from '../../src/shared/constants/bin.js';
@@ -51,5 +52,39 @@ describe('community metric defaults (cross-boundary mirror)', () => {
     expect(metrics.depth).toBeCloseTo(client.outerD, 10);
     expect(metrics.height).toBeCloseTo(client.totalH, 10);
     expect(metrics.gridUnitMm).toBe(params.gridUnitMm);
+  });
+
+  // `binDimensions` measures depth with `gridUnitMmY ?? gridUnitMm` while
+  // `deriveCommunityMetrics` has only one pitch to work with. The two agree
+  // because a published design never carries the second one: `gridUnitMmY` is
+  // outside `ALLOWED_PARAM_KEYS`, so the share validator strips it on the way
+  // in. Allowlisting it without teaching the metrics about it would put every
+  // non-square-pitch card's depth on the wrong axis, and this fires first.
+  it('is never handed a Y pitch, because publish strips it', () => {
+    const squarePitch: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      width: 3,
+      depth: 2,
+      gridUnitMm: 42,
+    };
+    const share = {
+      type: 'designer' as const,
+      version: 1 as const,
+      params: { ...squarePitch, gridUnitMmY: 30 },
+    };
+    const sanitized = validateDesignerShare(
+      share,
+      Buffer.byteLength(JSON.stringify(share), 'utf8')
+    );
+    expect(sanitized).toMatchObject({ valid: true });
+
+    const stored = sanitized.valid ? sanitized.payload.params : {};
+    expect(Object.keys(stored)).toContain('gridUnitMm');
+    expect(Object.keys(stored)).not.toContain('gridUnitMmY');
+
+    const client = binDimensions(squarePitch);
+    const metrics = deriveCommunityMetrics(stored);
+    expect(metrics.width).toBeCloseTo(client.outerW, 10);
+    expect(metrics.depth).toBeCloseTo(client.outerD, 10);
   });
 });

--- a/api/lib/communityStore.crossBoundary.test.ts
+++ b/api/lib/communityStore.crossBoundary.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Cross-boundary equality test for the community-metrics mirror.
+ *
+ * api/ cannot import from src/, so the pitch, height unit and seating
+ * tolerance `deriveCommunityMetrics` measures a published card with are
+ * hand-copied from `GRIDFINITY_SPEC`, and its outer-dimension formula is a
+ * hand-copy of `binDimensions`. Card metrics feed bed-fit and search facts, so
+ * drift here is silent: nothing 400s, the numbers are just wrong.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  BIN_TOLERANCE_MM,
+  DEFAULT_GRID_UNIT_MM,
+  DEFAULT_HEIGHT_UNIT_MM,
+  deriveCommunityMetrics,
+} from './communityStore.js';
+
+import { binDimensions } from '../../src/features/bin-designer/utils/binDimensions.js';
+import { DEFAULT_BIN_PARAMS } from '../../src/shared/constants/bin.js';
+import { GRIDFINITY_SPEC } from '../../src/shared/printSettings/gridfinityGeometry.js';
+import type { BinParams } from '../../src/shared/types/bin.js';
+
+const SHAPES: readonly (readonly [string, Partial<BinParams>])[] = [
+  ['stock bin', {}],
+  ['tall 1x1', { width: 1, depth: 1, height: 12 }],
+  ['wide half-bin', { width: 4.5, depth: 2, height: 3 }],
+  ['custom units', { width: 3, depth: 2, height: 5, gridUnitMm: 50, heightUnitMm: 10 }],
+];
+
+describe('community metric defaults (cross-boundary mirror)', () => {
+  it('takes its pitch, height unit and tolerance from the Gridfinity spec', () => {
+    expect(DEFAULT_GRID_UNIT_MM).toBe(GRIDFINITY_SPEC.GRID_SIZE);
+    expect(DEFAULT_HEIGHT_UNIT_MM).toBe(GRIDFINITY_SPEC.HEIGHT_UNIT);
+    expect(BIN_TOLERANCE_MM).toBe(GRIDFINITY_SPEC.TOLERANCE);
+  });
+
+  it('falls back to those defaults when the params carry no units', () => {
+    const metrics = deriveCommunityMetrics({ width: 2, depth: 2, height: 3 });
+    const client = binDimensions({ ...DEFAULT_BIN_PARAMS, width: 2, depth: 2, height: 3 });
+    expect(metrics.gridUnitMm).toBe(GRIDFINITY_SPEC.GRID_SIZE);
+    expect(metrics.width).toBe(client.outerW);
+    expect(metrics.height).toBe(client.totalH);
+  });
+
+  it.each(SHAPES)('%s: outer dimensions match binDimensions', (_label, overrides) => {
+    const params: BinParams = { ...DEFAULT_BIN_PARAMS, ...overrides };
+    const client = binDimensions(params);
+    const metrics = deriveCommunityMetrics(params as unknown as Record<string, unknown>);
+    expect(metrics.width).toBeCloseTo(client.outerW, 10);
+    expect(metrics.depth).toBeCloseTo(client.outerD, 10);
+    expect(metrics.height).toBeCloseTo(client.totalH, 10);
+    expect(metrics.gridUnitMm).toBe(params.gridUnitMm);
+  });
+});

--- a/api/lib/communityStore.ts
+++ b/api/lib/communityStore.ts
@@ -53,9 +53,9 @@ export interface CommunityDesignMetrics {
  * src/); the pitch/height defaults and tolerance mirror `GRIDFINITY_SPEC` in
  * `src/shared/printSettings/gridfinityGeometry.ts`. Update both sides together.
  */
-const DEFAULT_GRID_UNIT_MM = 42;
-const DEFAULT_HEIGHT_UNIT_MM = 7;
-const BIN_TOLERANCE_MM = 0.5;
+export const DEFAULT_GRID_UNIT_MM = 42;
+export const DEFAULT_HEIGHT_UNIT_MM = 7;
+export const BIN_TOLERANCE_MM = 0.5;
 
 /**
  * Anonymous dedupe window for the open/export counters. Dedupe sets are keyed

--- a/api/lib/designerValidation.crossBoundary.test.ts
+++ b/api/lib/designerValidation.crossBoundary.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Cross-boundary equality tests for the designer-validation mirrors.
+ *
+ * api/ cannot import from src/ at runtime, so every allowlist and bound below
+ * is a hand-copied client constant. A value added on the client and not here
+ * makes an honest design 400 on sync; one removed there and not here leaves the
+ * server accepting geometry nothing builds. This is the node-env `unit` vitest
+ * project, which also picks up `api/**\/*.test.ts`, so both sides are
+ * importable from one run.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  DESIGN_TAG_MAX_COUNT,
+  DESIGN_TAG_MAX_LENGTH,
+  LIP_CORNERS as API_LIP_CORNERS,
+  MAX_CUTOUT_CORNER_RADIUS as API_MAX_CUTOUT_CORNER_RADIUS,
+  VALID_BIN_STYLES,
+  VALID_CUTOUT_FILL_REFERENCES,
+  VALID_CUTOUT_LABEL_MODES,
+  VALID_FEET_MODES,
+  VALID_FOOT_LATTICES,
+  VALID_LABEL_SOCKET_STYLES,
+  VALID_LID_ATTACHMENTS_TOP,
+  VALID_LID_GRIP_MODES,
+  VALID_LID_HINGE_CATCHES,
+  VALID_LID_RAIL_SIDES,
+  VALID_LID_SLIDE_PLACEMENTS,
+  VALID_LID_SLIDE_PULLS,
+  VALID_LIGHTWEIGHT_MODES,
+  VALID_LIP_AXIS_COUNTS,
+  VALID_PIN_DIAMETERS,
+  VALID_TEXT_ANCHORS,
+  VALID_TEXT_CASES,
+  VALID_TEXT_CUT_PROFILES,
+  VALID_TEXT_FONTS,
+  VALID_WALL_TEXT_ALIGNS,
+  VALID_WALL_TEXT_SIDES,
+  validateDesignerShare,
+} from './designerValidation.js';
+import {
+  CONSTRAINTS,
+  SLIDE_CONSTRAINTS as API_SLIDE_CONSTRAINTS,
+  VALID_LABEL_PLATE_WIDTHS,
+  VALID_SLIDE_RAIL_MOUNTS,
+} from './designerValidationConstants.js';
+
+import {
+  DESIGNER_CONSTRAINTS,
+  minHeightUnits,
+} from '../../src/features/bin-designer/constants/gridfinity.js';
+import {
+  BIN_STYLES,
+  DETACHABLE_PIN_DIAMETERS_MM,
+  FEET_MODES,
+  FOOT_LATTICES,
+  LIGHTWEIGHT_MODES,
+} from '../../src/features/bin-designer/types/base.js';
+import {
+  CUTOUT_FILL_REFERENCES,
+  CUTOUT_LABEL_MODES,
+  MAX_ARRAY_INSTANCES,
+  MAX_CUTOUT_GROUP_NAMES,
+  MAX_CUTOUT_LEAN_DEG,
+  MAX_GROUP_NAME_LENGTH,
+  MAX_PARENT_GROUPS,
+} from '../../src/features/bin-designer/types/cutout.js';
+import {
+  LIP_AXIS_COUNTS,
+  LIP_CORNERS,
+} from '../../src/features/bin-designer/types/featureColors.js';
+import {
+  LID_ATTACHMENTS,
+  LID_GRIP_MODES,
+  LID_HINGE_CATCHES,
+  LID_RAIL_SIDES,
+  LID_SLIDE_PLACEMENTS,
+  LID_SLIDE_PULLS,
+  MAX_LID_CUTOUTS,
+} from '../../src/features/bin-designer/types/lid.js';
+import {
+  SLIDE_CONSTRAINTS,
+  SLIDE_RAIL_MOUNTS,
+} from '../../src/features/bin-designer/types/slide.js';
+import {
+  TEXT_ANCHORS,
+  TEXT_CASES,
+  TEXT_CUT_PROFILES,
+  TEXT_FONT_FAMILIES,
+  WALL_TEXT_ALIGNS,
+  WALL_TEXT_SIDES,
+} from '../../src/features/bin-designer/types/text.js';
+import { MAX_TAGS, MAX_TAG_LENGTH } from '../../src/features/bin-designer/utils/tags.js';
+import {
+  LABEL_PLATE_FIT_OFFSET_MAX,
+  LABEL_PLATE_FIT_OFFSET_MIN,
+  LABEL_PLATE_WIDTHS_U,
+  LABEL_SOCKET_STYLES,
+  MIN_LABEL_SOCKET_TAB_DEPTH_MM,
+} from '../../src/shared/constants/labelPlates.js';
+import {
+  MAX_MESH_ASSETS_PER_DESIGN,
+  MAX_MESH_ASSET_DATA_LENGTH,
+  MAX_MESH_ASSET_TRIANGLES,
+  MAX_MESH_OUTLINE_POINTS,
+} from '../../src/shared/generation/meshAsset.js';
+import { GRIDFINITY_SPEC } from '../../src/shared/printSettings/gridfinityGeometry.js';
+import { MAX_MASK_DIMENSION } from '../../src/shared/utils/cellMask.js';
+import { MAX_CUTOUT_CORNER_RADIUS } from '../../src/shared/utils/wallCutoutPosition.js';
+
+type Allowlist = readonly (string | number)[];
+
+const ALLOWLIST_MIRRORS: readonly (readonly [string, Allowlist, Allowlist])[] = [
+  ['VALID_BIN_STYLES / BIN_STYLES', VALID_BIN_STYLES, BIN_STYLES],
+  ['VALID_FOOT_LATTICES / FOOT_LATTICES', VALID_FOOT_LATTICES, FOOT_LATTICES],
+  ['VALID_LIGHTWEIGHT_MODES / LIGHTWEIGHT_MODES', VALID_LIGHTWEIGHT_MODES, LIGHTWEIGHT_MODES],
+  ['VALID_FEET_MODES / FEET_MODES', VALID_FEET_MODES, FEET_MODES],
+  [
+    'VALID_PIN_DIAMETERS / DETACHABLE_PIN_DIAMETERS_MM',
+    VALID_PIN_DIAMETERS,
+    DETACHABLE_PIN_DIAMETERS_MM,
+  ],
+  [
+    'VALID_LABEL_SOCKET_STYLES / LABEL_SOCKET_STYLES',
+    VALID_LABEL_SOCKET_STYLES,
+    LABEL_SOCKET_STYLES,
+  ],
+  [
+    'VALID_LABEL_PLATE_WIDTHS / LABEL_PLATE_WIDTHS_U',
+    VALID_LABEL_PLATE_WIDTHS,
+    LABEL_PLATE_WIDTHS_U,
+  ],
+  ['VALID_LID_ATTACHMENTS_TOP / LID_ATTACHMENTS', VALID_LID_ATTACHMENTS_TOP, LID_ATTACHMENTS],
+  [
+    'VALID_LID_SLIDE_PLACEMENTS / LID_SLIDE_PLACEMENTS',
+    VALID_LID_SLIDE_PLACEMENTS,
+    LID_SLIDE_PLACEMENTS,
+  ],
+  ['VALID_LID_SLIDE_PULLS / LID_SLIDE_PULLS', VALID_LID_SLIDE_PULLS, LID_SLIDE_PULLS],
+  ['VALID_LID_RAIL_SIDES / LID_RAIL_SIDES', VALID_LID_RAIL_SIDES, LID_RAIL_SIDES],
+  ['VALID_LID_HINGE_CATCHES / LID_HINGE_CATCHES', VALID_LID_HINGE_CATCHES, LID_HINGE_CATCHES],
+  ['VALID_LID_GRIP_MODES / LID_GRIP_MODES', VALID_LID_GRIP_MODES, LID_GRIP_MODES],
+  ['VALID_SLIDE_RAIL_MOUNTS / SLIDE_RAIL_MOUNTS', VALID_SLIDE_RAIL_MOUNTS, SLIDE_RAIL_MOUNTS],
+  ['VALID_TEXT_FONTS / TEXT_FONT_FAMILIES', VALID_TEXT_FONTS, TEXT_FONT_FAMILIES],
+  ['VALID_TEXT_ANCHORS / TEXT_ANCHORS', VALID_TEXT_ANCHORS, TEXT_ANCHORS],
+  ['VALID_TEXT_CASES / TEXT_CASES', VALID_TEXT_CASES, TEXT_CASES],
+  ['VALID_TEXT_CUT_PROFILES / TEXT_CUT_PROFILES', VALID_TEXT_CUT_PROFILES, TEXT_CUT_PROFILES],
+  ['VALID_WALL_TEXT_SIDES / WALL_TEXT_SIDES', VALID_WALL_TEXT_SIDES, WALL_TEXT_SIDES],
+  ['VALID_WALL_TEXT_ALIGNS / WALL_TEXT_ALIGNS', VALID_WALL_TEXT_ALIGNS, WALL_TEXT_ALIGNS],
+  [
+    'VALID_CUTOUT_FILL_REFERENCES / CUTOUT_FILL_REFERENCES',
+    VALID_CUTOUT_FILL_REFERENCES,
+    CUTOUT_FILL_REFERENCES,
+  ],
+  ['VALID_CUTOUT_LABEL_MODES / CUTOUT_LABEL_MODES', VALID_CUTOUT_LABEL_MODES, CUTOUT_LABEL_MODES],
+  ['LIP_CORNERS', API_LIP_CORNERS, LIP_CORNERS],
+  ['VALID_LIP_AXIS_COUNTS / LIP_AXIS_COUNTS', [...VALID_LIP_AXIS_COUNTS], LIP_AXIS_COUNTS],
+];
+
+const BOUND_MIRRORS: readonly (readonly [string, number, number])[] = [
+  ['MIN_DIMENSION', CONSTRAINTS.MIN_DIMENSION, DESIGNER_CONSTRAINTS.MIN_DIMENSION],
+  ['MAX_DIMENSION', CONSTRAINTS.MAX_DIMENSION, DESIGNER_CONSTRAINTS.MAX_DIMENSION],
+  ['MIN_HEIGHT', CONSTRAINTS.MIN_HEIGHT, DESIGNER_CONSTRAINTS.MIN_HEIGHT],
+  ['MIN_SPACER_HEIGHT', CONSTRAINTS.MIN_SPACER_HEIGHT, DESIGNER_CONSTRAINTS.MIN_SPACER_HEIGHT],
+  ['MIN_BODY_WALL_MM', CONSTRAINTS.MIN_BODY_WALL_MM, DESIGNER_CONSTRAINTS.MIN_BODY_WALL_MM],
+  ['MAX_HEIGHT', CONSTRAINTS.MAX_HEIGHT, DESIGNER_CONSTRAINTS.MAX_HEIGHT],
+  ['SOCKET_HEIGHT', CONSTRAINTS.SOCKET_HEIGHT, GRIDFINITY_SPEC.SOCKET_HEIGHT],
+  ['DEFAULT_HEIGHT_UNIT_MM', CONSTRAINTS.DEFAULT_HEIGHT_UNIT_MM, GRIDFINITY_SPEC.HEIGHT_UNIT],
+  [
+    'MIN_COMPARTMENT_GRID',
+    CONSTRAINTS.MIN_COMPARTMENT_GRID,
+    DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_GRID,
+  ],
+  [
+    'MAX_COMPARTMENT_GRID',
+    CONSTRAINTS.MAX_COMPARTMENT_GRID,
+    DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_GRID,
+  ],
+  [
+    'MIN_COMPARTMENT_THICKNESS',
+    CONSTRAINTS.MIN_COMPARTMENT_THICKNESS,
+    DESIGNER_CONSTRAINTS.MIN_COMPARTMENT_THICKNESS,
+  ],
+  [
+    'MAX_COMPARTMENT_THICKNESS',
+    CONSTRAINTS.MAX_COMPARTMENT_THICKNESS,
+    DESIGNER_CONSTRAINTS.MAX_COMPARTMENT_THICKNESS,
+  ],
+  ['MAX_STASH_ENTRIES', CONSTRAINTS.MAX_STASH_ENTRIES, DESIGNER_CONSTRAINTS.MAX_STASH_ENTRIES],
+  [
+    'MIN_DIVIDER_THICKNESS',
+    CONSTRAINTS.MIN_DIVIDER_THICKNESS,
+    DESIGNER_CONSTRAINTS.MIN_DIVIDER_THICKNESS,
+  ],
+  [
+    'MAX_DIVIDER_THICKNESS',
+    CONSTRAINTS.MAX_DIVIDER_THICKNESS,
+    DESIGNER_CONSTRAINTS.MAX_DIVIDER_THICKNESS,
+  ],
+  [
+    'MIN_LABEL_TAB_DEPTH',
+    CONSTRAINTS.MIN_LABEL_TAB_DEPTH,
+    DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_DEPTH,
+  ],
+  [
+    'MAX_LABEL_TAB_DEPTH',
+    CONSTRAINTS.MAX_LABEL_TAB_DEPTH,
+    DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_DEPTH,
+  ],
+  [
+    'MIN_LABEL_TAB_WIDTH',
+    CONSTRAINTS.MIN_LABEL_TAB_WIDTH,
+    DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_WIDTH,
+  ],
+  [
+    'MAX_LABEL_TAB_WIDTH',
+    CONSTRAINTS.MAX_LABEL_TAB_WIDTH,
+    DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_WIDTH,
+  ],
+  [
+    'MIN_LABEL_TAB_HEIGHT',
+    CONSTRAINTS.MIN_LABEL_TAB_HEIGHT,
+    DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_HEIGHT,
+  ],
+  [
+    'MAX_LABEL_TAB_HEIGHT',
+    CONSTRAINTS.MAX_LABEL_TAB_HEIGHT,
+    DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_HEIGHT,
+  ],
+  [
+    'MIN_LABEL_TAB_INSET',
+    CONSTRAINTS.MIN_LABEL_TAB_INSET,
+    DESIGNER_CONSTRAINTS.MIN_LABEL_TAB_INSET,
+  ],
+  [
+    'MAX_LABEL_TAB_INSET',
+    CONSTRAINTS.MAX_LABEL_TAB_INSET,
+    DESIGNER_CONSTRAINTS.MAX_LABEL_TAB_INSET,
+  ],
+  [
+    'MIN_EXTRA_WALL_HEIGHT',
+    CONSTRAINTS.MIN_EXTRA_WALL_HEIGHT,
+    DESIGNER_CONSTRAINTS.MIN_EXTRA_WALL_HEIGHT,
+  ],
+  [
+    'MAX_EXTRA_WALL_HEIGHT',
+    CONSTRAINTS.MAX_EXTRA_WALL_HEIGHT,
+    DESIGNER_CONSTRAINTS.MAX_EXTRA_WALL_HEIGHT,
+  ],
+  [
+    'MIN_LABEL_SOCKET_TAB_DEPTH',
+    CONSTRAINTS.MIN_LABEL_SOCKET_TAB_DEPTH,
+    MIN_LABEL_SOCKET_TAB_DEPTH_MM,
+  ],
+  [
+    'LABEL_PLATE_FIT_OFFSET_MIN',
+    CONSTRAINTS.LABEL_PLATE_FIT_OFFSET_MIN,
+    LABEL_PLATE_FIT_OFFSET_MIN,
+  ],
+  [
+    'LABEL_PLATE_FIT_OFFSET_MAX',
+    CONSTRAINTS.LABEL_PLATE_FIT_OFFSET_MAX,
+    LABEL_PLATE_FIT_OFFSET_MAX,
+  ],
+  ['MAX_CUTOUT_LEAN_DEG', CONSTRAINTS.MAX_CUTOUT_LEAN_DEG, MAX_CUTOUT_LEAN_DEG],
+  ['MAX_ARRAY_INSTANCES', CONSTRAINTS.MAX_ARRAY_INSTANCES, MAX_ARRAY_INSTANCES],
+  ['MAX_PARENT_GROUPS', CONSTRAINTS.MAX_PARENT_GROUPS, MAX_PARENT_GROUPS],
+  ['MAX_GROUP_NAME_LENGTH', CONSTRAINTS.MAX_GROUP_NAME_LENGTH, MAX_GROUP_NAME_LENGTH],
+  ['MAX_CUTOUT_GROUP_NAMES', CONSTRAINTS.MAX_CUTOUT_GROUP_NAMES, MAX_CUTOUT_GROUP_NAMES],
+  ['MAX_LID_CUTOUTS', CONSTRAINTS.MAX_LID_CUTOUTS, MAX_LID_CUTOUTS],
+  ['MAX_MESH_ASSETS', CONSTRAINTS.MAX_MESH_ASSETS, MAX_MESH_ASSETS_PER_DESIGN],
+  ['MAX_MESH_ASSET_TRIANGLES', CONSTRAINTS.MAX_MESH_ASSET_TRIANGLES, MAX_MESH_ASSET_TRIANGLES],
+  ['MAX_MESH_OUTLINE_POINTS', CONSTRAINTS.MAX_MESH_OUTLINE_POINTS, MAX_MESH_OUTLINE_POINTS],
+  ['MAX_MESH_DATA_LENGTH', CONSTRAINTS.MAX_MESH_DATA_LENGTH, MAX_MESH_ASSET_DATA_LENGTH],
+  ['MAX_MASK_DIMENSION', CONSTRAINTS.MAX_MASK_DIMENSION, MAX_MASK_DIMENSION],
+  ['MAX_CUTOUT_CORNER_RADIUS', API_MAX_CUTOUT_CORNER_RADIUS, MAX_CUTOUT_CORNER_RADIUS],
+  ['DESIGN_TAG_MAX_COUNT', DESIGN_TAG_MAX_COUNT, MAX_TAGS],
+  ['DESIGN_TAG_MAX_LENGTH', DESIGN_TAG_MAX_LENGTH, MAX_TAG_LENGTH],
+];
+
+describe('designer allowlists (cross-boundary mirror)', () => {
+  it.each(ALLOWLIST_MIRRORS)('%s admit the same values', (_label, server, client) => {
+    expect(new Set(server)).toEqual(new Set(client));
+  });
+});
+
+describe('designer bounds (cross-boundary mirror)', () => {
+  it.each(BOUND_MIRRORS)('%s matches the client', (_label, server, client) => {
+    expect(server).toBe(client);
+  });
+
+  it('SLIDE_CONSTRAINTS matches key for key', () => {
+    expect({ ...API_SLIDE_CONSTRAINTS }).toEqual({ ...SLIDE_CONSTRAINTS });
+  });
+});
+
+interface MinHeightCase {
+  readonly label: string;
+  readonly base: { readonly spacer: boolean; readonly tile?: boolean; readonly style: string };
+  readonly heightUnitMm?: number;
+}
+
+const MIN_HEIGHT_CASES: readonly MinHeightCase[] = [
+  { label: 'plain socketed bin', base: { style: 'standard', spacer: false } },
+  { label: 'spacer at the default height unit', base: { style: 'standard', spacer: true } },
+  {
+    label: 'spacer at a 3mm height unit',
+    base: { style: 'standard', spacer: true },
+    heightUnitMm: 3,
+  },
+  {
+    label: 'spacer at a 2mm height unit',
+    base: { style: 'standard', spacer: true },
+    heightUnitMm: 2,
+  },
+  { label: 'spacer on a flat base', base: { style: 'flat', spacer: true } },
+  { label: 'spacer on a tray base', base: { style: 'lid', spacer: true } },
+  { label: 'base-only bin', base: { style: 'standard', spacer: false, tile: true } },
+  { label: 'base-only flat bin', base: { style: 'flat', spacer: false, tile: true } },
+  { label: 'base-only spacer', base: { style: 'standard', spacer: true, tile: true } },
+];
+
+function sharePayload(testCase: MinHeightCase, height: number): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    width: 2,
+    depth: 2,
+    height,
+    style: 'standard',
+    base: {
+      style: testCase.base.style,
+      spacer: testCase.base.spacer,
+      ...(testCase.base.tile === undefined ? {} : { tile: testCase.base.tile }),
+      magnetDiameter: 6.2,
+      magnetDepth: 2.4,
+      screwDiameter: 3,
+      stackingLip: true,
+    },
+    compartments: { cols: 1, rows: 1, thickness: 1.2, cells: [0] },
+    label: { enabled: false, support: 'bracket', depth: 12, width: 100, alignment: 'center' },
+    walls: { front: 0, back: 0, left: 0, right: 0 },
+    inserts: [],
+  };
+  if (testCase.heightUnitMm !== undefined) params.heightUnitMm = testCase.heightUnitMm;
+  return { type: 'designer', version: 1, params };
+}
+
+function validateAtHeight(
+  testCase: MinHeightCase,
+  height: number
+): ReturnType<typeof validateDesignerShare> {
+  const payload = sharePayload(testCase, height);
+  return validateDesignerShare(payload, Buffer.byteLength(JSON.stringify(payload), 'utf8'));
+}
+
+describe('minimum bin height (cross-boundary mirror)', () => {
+  it.each(MIN_HEIGHT_CASES.map((testCase) => [testCase.label, testCase] as const))(
+    '%s: the share validator floors exactly where minHeightUnits does',
+    (_label, testCase) => {
+      const floor = minHeightUnits(testCase.base, testCase.heightUnitMm);
+      expect(validateAtHeight(testCase, floor).valid).toBe(true);
+      // The message is matched so a payload rejected for some unrelated reason
+      // cannot stand in for the floor this case is probing.
+      expect(validateAtHeight(testCase, floor - 1)).toMatchObject({
+        valid: false,
+        error: { message: `height must be ${floor}-${CONSTRAINTS.MAX_HEIGHT}` },
+      });
+    }
+  );
+});

--- a/api/lib/designerValidation.ts
+++ b/api/lib/designerValidation.ts
@@ -62,7 +62,7 @@ export function sanitizeTags(input: unknown): string[] {
 // `src/features/bin-designer/types/index.ts` — when a value is added there
 // it must be added here too, otherwise cloud sync PUTs from up-to-date
 // clients will be rejected with a 400.
-const VALID_BIN_STYLES = ['standard', 'slotted', 'solid'] as const;
+export const VALID_BIN_STYLES = ['standard', 'slotted', 'solid'] as const;
 const VALID_BASE_STYLES = [
   'standard',
   'magnet',
@@ -74,16 +74,16 @@ const VALID_BASE_STYLES = [
   'lid',
 ] as const;
 // Mirrors `FOOT_LATTICES` in `src/features/bin-designer/types/base.ts`.
-const VALID_FOOT_LATTICES = ['grid', 'half'] as const;
+export const VALID_FOOT_LATTICES = ['grid', 'half'] as const;
 // Mirrors `LIGHTWEIGHT_MODES` in the same file.
-const VALID_LIGHTWEIGHT_MODES = ['interior', 'underside'] as const;
+export const VALID_LIGHTWEIGHT_MODES = ['interior', 'underside'] as const;
 // Mirrors `FEET_MODES` and `DETACHABLE_PIN_DIAMETERS_MM` in the same file.
-const VALID_FEET_MODES = ['integral', 'detachable'] as const;
-const VALID_PIN_DIAMETERS = [2.7, 2.8, 2.9, 3] as const;
+export const VALID_FEET_MODES = ['integral', 'detachable'] as const;
+export const VALID_PIN_DIAMETERS = [2.7, 2.8, 2.9, 3] as const;
 const VALID_LABEL_TAB_SUPPORTS = ['bracket', 'solid', 'fillet'] as const;
 // Mirrors `LabelTabMode` in `src/features/bin-designer/types/index.ts`.
 const VALID_LABEL_TAB_MODES = ['text', 'socket'] as const;
-const VALID_LABEL_SOCKET_STYLES = ['clickIn', 'slideChannel'] as const;
+export const VALID_LABEL_SOCKET_STYLES = ['clickIn', 'slideChannel'] as const;
 const VALID_INSERT_SHAPES = ['rectangle', 'circle', 'hexagon', 'rounded-rect', 'slot'] as const;
 const VALID_WALL_CUTOUT_SHAPES = ['u-shape', 'scoop', 'funnel'] as const;
 
@@ -93,7 +93,7 @@ const VALID_WALL_CUTOUT_SHAPES = ['u-shape', 'scoop', 'funnel'] as const;
  * blend the generator has to build, so an unbounded one is a crafted payload
  * that turns into an unbounded boolean.
  */
-const MAX_CUTOUT_CORNER_RADIUS = 25;
+export const MAX_CUTOUT_CORNER_RADIUS = 25;
 // Mirrors `LidAttachment` in `src/features/bin-designer/types/lid.ts`.
 const VALID_LID_ATTACHMENTS = ['friction', 'clickRails', 'magnetic'] as const;
 /**
@@ -104,22 +104,22 @@ const VALID_LID_ATTACHMENTS = ['friction', 'clickRails', 'magnetic'] as const;
  * channel, which is not a thing an underside can be, so the two lists are
  * deliberately separate rather than one list the tray path also widens.
  */
-const VALID_LID_ATTACHMENTS_TOP = [...VALID_LID_ATTACHMENTS, 'slide', 'hinge'] as const;
-const VALID_LID_SLIDE_PLACEMENTS = ['recessed', 'flush'] as const;
-const VALID_LID_SLIDE_PULLS = ['none', 'notch', 'tab'] as const;
+export const VALID_LID_ATTACHMENTS_TOP = [...VALID_LID_ATTACHMENTS, 'slide', 'hinge'] as const;
+export const VALID_LID_SLIDE_PLACEMENTS = ['recessed', 'flush'] as const;
+export const VALID_LID_SLIDE_PULLS = ['none', 'notch', 'tab'] as const;
 /** Wall sides `lid.slide.entrySide` may name. Mirrors `LID_RAIL_SIDES`. */
-const VALID_LID_RAIL_SIDES = ['front', 'back', 'left', 'right'] as const;
+export const VALID_LID_RAIL_SIDES = ['front', 'back', 'left', 'right'] as const;
 const ALLOWED_LID_SLIDE_KEYS = new Set(['placement', 'entrySide', 'clearanceMm', 'pull', 'detent']);
 /** Mirrors `LidHingeCatch` in the same module. */
-const VALID_LID_HINGE_CATCHES = ['none', 'detent', 'magnets'] as const;
+export const VALID_LID_HINGE_CATCHES = ['none', 'detent', 'magnets'] as const;
 const ALLOWED_LID_HINGE_KEYS = new Set(['side', 'catchMode', 'fitClearanceMm']);
 // Mirrors `LidGripMode` / `LidGripConfig` / `LidGripSides` in the same
 // module.
-const VALID_LID_GRIP_MODES = ['none', 'chamfer', 'reveal', 'scallop'] as const;
+export const VALID_LID_GRIP_MODES = ['none', 'chamfer', 'reveal', 'scallop'] as const;
 const ALLOWED_LID_GRIP_KEYS = new Set(['mode', 'sides', 'coverage', 'heightMm', 'binDip']);
 const ALLOWED_LID_GRIP_SIDE_KEYS = new Set(['front', 'back', 'left', 'right']);
 const VALID_ROTATIONS = [0, 90, 180, 270] as const;
-const VALID_TEXT_FONTS = [
+export const VALID_TEXT_FONTS = [
   'atkinson',
   'atkinson-bold',
   'jetbrains-mono',
@@ -129,7 +129,7 @@ const VALID_TEXT_FONTS = [
   'allerta-stencil',
 ] as const;
 const VALID_TEXT_MODES = ['engrave', 'emboss', 'through-cut'] as const;
-const VALID_TEXT_ANCHORS = [
+export const VALID_TEXT_ANCHORS = [
   'top-left',
   'top',
   'top-right',
@@ -141,16 +141,16 @@ const VALID_TEXT_ANCHORS = [
   'bottom-right',
 ] as const;
 const VALID_TEXT_SIZE_MODES = ['auto', 'fixed'] as const;
-const VALID_TEXT_CASES = ['as-typed', 'upper', 'title'] as const;
-const VALID_TEXT_CUT_PROFILES = ['straight', 'drafted'] as const;
+export const VALID_TEXT_CASES = ['as-typed', 'upper', 'title'] as const;
+export const VALID_TEXT_CUT_PROFILES = ['straight', 'drafted'] as const;
 const VALID_CUTOUT_COLOR_SCOPES = ['floor', 'floorAndWalls'] as const;
-const VALID_CUTOUT_FILL_REFERENCES = ['rim', 'floor'] as const;
+export const VALID_CUTOUT_FILL_REFERENCES = ['rim', 'floor'] as const;
 
 /**
  * Cross-boundary contract: MUST match `CUTOUT_LABEL_MODES` in
  * `src/features/bin-designer/types/cutout.ts`.
  */
-const VALID_CUTOUT_LABEL_MODES = ['engrave', 'socket'] as const;
+export const VALID_CUTOUT_LABEL_MODES = ['engrave', 'socket'] as const;
 
 /**
  * Top-level keys allowed inside `params` after validation.
@@ -915,8 +915,8 @@ function checkCaption(text: string, label: string): string | null {
   }
   return null;
 }
-const VALID_WALL_TEXT_SIDES = ['front', 'back', 'left', 'right'] as const;
-const VALID_WALL_TEXT_ALIGNS = ['top', 'center', 'bottom'] as const;
+export const VALID_WALL_TEXT_SIDES = ['front', 'back', 'left', 'right'] as const;
+export const VALID_WALL_TEXT_ALIGNS = ['top', 'center', 'bottom'] as const;
 
 /**
  * Exterior-surface text: a lid-top string plus per-wall strings
@@ -1177,7 +1177,7 @@ function isValidColor(v: unknown): boolean {
   return HEX_COLOR_REGEX.test(v) || LEGACY_SLOT_IDS.has(v);
 }
 
-const LIP_CORNERS = ['frontLeft', 'frontRight', 'backRight', 'backLeft'] as const;
+export const LIP_CORNERS = ['frontLeft', 'frontRight', 'backRight', 'backLeft'] as const;
 const ALLOWED_FEATURE_COLOR_KEYS = new Set([
   'enabled',
   'body',
@@ -1198,7 +1198,7 @@ const ALLOWED_ACCENT_BAND_KEYS = new Set<string>(['enabled', 'heightMm', 'color'
 const MAX_ACCENT_BAND_HEIGHT_MM = 1000;
 const ALLOWED_LIP_CORNER_KEYS = new Set<string>(LIP_CORNERS);
 const ALLOWED_LIP_GRID_KEYS = new Set<string>(['corners', 'bands', 'cells']);
-const VALID_LIP_AXIS_COUNTS = new Set<number>([1, 2, 4]);
+export const VALID_LIP_AXIS_COUNTS = new Set<number>([1, 2, 4]);
 const LIP_CELL_KEY_RE = /^lip:(frontLeft|frontRight|backRight|backLeft):[0-3]$/;
 
 /**


### PR DESCRIPTION
`api/` cannot import from `src/` at runtime, so the server validators carry hand-copied allowlists and bounds. Until now the only thing holding a copy to its source was a "keep in sync" comment. Test files can import both sides, so this turns those comments into assertions. Test-only, plus the `export` keyword on constants the assertions read.

## Now asserted (was a comment)

`api/lib/designerValidation.crossBoundary.test.ts`

- 24 enum allowlists set-equal to their client source arrays: bin styles, foot lattices, lightweight modes, feet modes, detachable pin diameters, label socket styles, label plate widths, the five lid lists (top attachments, slide placements, slide pulls, rail sides, hinge catches, grip modes), slide rail mounts, the six text lists (fonts, anchors, cases, cut profiles, wall sides, wall aligns), cutout fill references, cutout label modes, lip corners and lip axis counts.
- 42 numeric bounds equal to `DESIGNER_CONSTRAINTS`, `GRIDFINITY_SPEC`, the cutout/lid/label-plate/mesh/cell-mask constants and the tag caps. That includes the mesh caps `src/shared/generation/meshAsset.ts` marks `MIRROR:`, `MAX_MESH_DATA_LENGTH` among them.
- `SLIDE_CONSTRAINTS` compared key for key against `src/features/bin-designer/types/slide.ts`.
- The minimum-height rule: for nine base shapes (plain, spacer at 7/3/2mm height units, spacer on flat and tray bases, base-only in three forms) the share validator accepts exactly at `minHeightUnits(...)` and rejects one below it, matched on the error message so an unrelated rejection cannot stand in.

`api/lib/assemblyValidation.crossBoundary.test.ts`

- Part types set-equal to `ASSEMBLY_PART_TYPES`; `MAX_ASSEMBLY_PARTS` and `MAX_ASSEMBLY_DEPTH` equal to the client exports.
- 41 fixtures fed to both `assemblySchema.safeParse` and `validateAssemblyStructure`, comparing only their verdicts: every part type at its defaults, every cutter profile shape, transform and base bounds probed one step either side of the client's own `clampPartTransform` / `clampAssemblyBase` output, the part-count and nesting caps, and two enum violations. Boundary values are read off the client clamps rather than restated, so a limit both sides move together stays green and only divergence fails. A guard asserts the fixture set produces both verdicts, so agreement cannot go vacuous.

`api/lib/communityStore.crossBoundary.test.ts`

- `DEFAULT_GRID_UNIT_MM`, `DEFAULT_HEIGHT_UNIT_MM` and `BIN_TOLERANCE_MM` equal to `GRIDFINITY_SPEC.GRID_SIZE` / `.HEIGHT_UNIT` / `.TOLERANCE`.
- `deriveCommunityMetrics` outer dimensions equal to `binDimensions` across four bin shapes plus the no-units fallback.
- The Y-pitch axis: `binDimensions` measures depth with `gridUnitMmY ?? gridUnitMm` and `deriveCommunityMetrics` has one pitch, so the mirror rests on `gridUnitMmY` being outside `ALLOWED_PARAM_KEYS` and stripped by `validateDesignerShare` before publish. A fixture publishes a design carrying a distinct `gridUnitMmY`, asserts the sanitized params drop it, and asserts the metrics still match. Allowlisting the key without teaching the metrics about it fails here instead of putting every non-square-pitch card'''s depth on the wrong axis.

## Not asserted

Eleven server allowlists mirror a client TS union with no runtime array to compare against, so there is nothing to import: base styles, label tab supports, label tab modes, insert shapes, wall cutout shapes, rotations, text modes, text size modes, cutout color scopes, knife rest styles, and the tray-bottom attachment subset. `assemblyValidation`'s path and outline point caps are inline `.max()` calls in the zod schema, same situation. `VALID_LABEL_PLATE_ICONS` already had a parity assertion in `designerValidation.test.ts` and is left alone.

No mirror was found to have drifted.

## Testing

- `pnpm run test:run api/lib/designerValidation.crossBoundary.test.ts` -> 76 passed
- `pnpm run test:run api/lib/assemblyValidation.crossBoundary.test.ts` -> 45 passed
- `pnpm run test:run api/lib/communityStore.crossBoundary.test.ts` -> 7 passed
- `pnpm run test:run api/ src/shared/types/community.test.ts src/shared/utils/communityLowEffort.crossBoundary.test.ts src/shared/generation/meshAsset.test.ts` -> 2255 passed, 16 skipped
- `pnpm run typecheck` -> clean
- Each assertion family was checked against a deliberate mismatch first, so a passing run is not a vacuous one.

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


