### PR TITLE
refactor(community): share the card projection between publish and update

### DIFF
--- a/api/community.ts
+++ b/api/community.ts
@@ -2,6 +2,12 @@ import { randomUUID } from 'node:crypto';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { del, put } from '@vercel/blob';
 import { requireMethod } from './lib/method.js';
+import {
+  cardFromRecord,
+  communityDesignUrl,
+  DUPLICATE_DESIGN_RESPONSE,
+  REMIX_UNCHANGED_RESPONSE,
+} from './lib/communityRecord.js';
 import { readSessionCookie } from './lib/cookies.js';
 import { readSession, requireSession } from './lib/session.js';
 import type { SessionRecord } from './lib/session.js';
@@ -9,7 +15,6 @@ import { checkRateLimit, getClientIP, getRedis } from './lib/rateLimit.js';
 import { logger } from './lib/logger.js';
 import {
   ErrorCode,
-  getBaseUrl,
   rateLimited,
   sendError,
   serviceUnavailable,
@@ -48,7 +53,6 @@ import {
 import { communityPrintsEnabled } from './lib/communityPrintValidation.js';
 import { COMMUNITY_EXAMPLE_PARAM_HASHES } from './lib/communityExampleParamHashes.js';
 import type {
-  CommunityCardMetadata,
   CommunityCardRecord,
   CommunityDesignMetrics,
   CommunityDesignRecord,
@@ -91,11 +95,6 @@ const CURSOR_REGEX = /^\d{1,9}$/;
 // Short per-user publish lock TTL: long enough to cover the check->write
 // sequence of one publish, short enough that a crashed request self-heals.
 const PUBLISH_LOCK_TTL_MS = 10_000;
-
-// Matches the client's publicDesignUrl: /community/d/<id> is the canonical route.
-function communityDesignUrl(designId: string): string {
-  return `${getBaseUrl()}/community/d/${designId}`;
-}
 
 function badRequest(res: VercelResponse, message: string): void {
   sendError(res, 400, ErrorCode.VALIDATION_ERROR, message);
@@ -190,29 +189,6 @@ async function findPublishedIdByContentHash(
     }
   }
   return null;
-}
-
-function cardFromRecord(record: CommunityDesignRecord): CommunityCardMetadata {
-  return {
-    id: record.id,
-    name: record.name,
-    authorPublicId: record.authorPublicId,
-    authorName: record.authorName,
-    category: record.category,
-    techniques: record.techniques,
-    kind: record.kind ?? '',
-    width: record.metrics.width,
-    depth: record.metrics.depth,
-    height: record.metrics.height,
-    gridUnitMm: record.metrics.gridUnitMm,
-    thumbnailUrl: record.thumbnails[0] ?? '',
-    isRemix: record.lineage !== null,
-    parentId: record.lineage?.parentId ?? '',
-    featured: record.featured,
-    createdAt: record.createdAt,
-    updatedAt: record.updatedAt,
-    status: record.status,
-  };
 }
 
 /**
@@ -335,11 +311,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
       // B3: reject a verbatim re-upload of a built-in example or of another
       // author's live design. The author's own re-publish returned above.
       if (await isExactDuplicate(redis, contentFingerprint, authorPublicId)) {
-        res.status(409).json({
-          error:
-            'This matches a design that has already been published (or a built-in example). Make it your own before publishing.',
-          code: 'DUPLICATE_DESIGN',
-        });
+        res.status(409).json(DUPLICATE_DESIGN_RESPONSE);
         return;
       }
 
@@ -368,10 +340,7 @@ async function handlePublish(req: VercelRequest, res: VercelResponse): Promise<v
         lineageResolve.parentContent !== null &&
         communityParamsFingerprint(lineageResolve.parentContent) === contentFingerprint
       ) {
-        res.status(409).json({
-          error: 'Change the design before publishing your remix.',
-          code: 'REMIX_UNCHANGED',
-        });
+        res.status(409).json(REMIX_UNCHANGED_RESPONSE);
         return;
       }
 

--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -4,6 +4,11 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { Redis } from 'ioredis';
 import { readSessionCookie } from '../lib/cookies.js';
 import {
+  cardFromRecord,
+  DUPLICATE_DESIGN_RESPONSE,
+  REMIX_UNCHANGED_RESPONSE,
+} from '../lib/communityRecord.js';
+import {
   communityAuthorKey,
   communityChildrenKey,
   communityDenylistKey,
@@ -402,11 +407,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
     // B3: reject an edit into a verbatim built-in example or another author's
     // live design.
     if (await isDuplicateOnUpdate(redis, contentFingerprint, existing.authorPublicId, id)) {
-      return res.status(409).json({
-        error:
-          'This matches a design that has already been published (or a built-in example). Make it your own before publishing.',
-        code: 'DUPLICATE_DESIGN',
-      });
+      return res.status(409).json(DUPLICATE_DESIGN_RESPONSE);
     }
 
     // B4: a remix must still differ from its parent after an edit.
@@ -416,10 +417,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
         parent !== null &&
         communityParamsFingerprint(communityDesignContent(parent)) === contentFingerprint
       ) {
-        return res.status(409).json({
-          error: 'Change the design before publishing your remix.',
-          code: 'REMIX_UNCHANGED',
-        });
+        return res.status(409).json(REMIX_UNCHANGED_RESPONSE);
       }
     }
 
@@ -477,26 +475,7 @@ async function handlePut(req: VercelRequest, res: VercelResponse, id: string) {
     // be flipped back to live by this in-flight edit; the card carries the
     // current status, never the publish-time one.
     const statusAtWrite = await readModerationStatus(id, existing.status);
-    await writeCommunityCard(redis, {
-      id,
-      name: updated.name,
-      authorPublicId: updated.authorPublicId,
-      authorName: updated.authorName,
-      category: updated.category,
-      techniques: updated.techniques,
-      kind: updated.kind ?? '',
-      width: updated.metrics.width,
-      depth: updated.metrics.depth,
-      height: updated.metrics.height,
-      gridUnitMm: updated.metrics.gridUnitMm,
-      thumbnailUrl: thumbnailUrls.length > 0 ? thumbnailUrls[0] : '',
-      isRemix: updated.lineage !== null,
-      parentId: updated.lineage?.parentId ?? '',
-      featured: updated.featured,
-      createdAt: updated.createdAt,
-      updatedAt: updated.updatedAt,
-      status: statusAtWrite,
-    });
+    await writeCommunityCard(redis, cardFromRecord({ ...updated, status: statusAtWrite }));
 
     // Publish idempotency keys on this hash; without the refresh a retried
     // POST of the pre-edit content would 200 against this id and a POST of

--- a/api/lib/communityRecord.ts
+++ b/api/lib/communityRecord.ts
@@ -1,0 +1,48 @@
+/**
+ * Record-derived values shared by the publish (api/community.ts) and update
+ * (api/community/[id].ts) paths. The card is a pure projection of the design
+ * record: any new record field the gallery needs must be added here once, so
+ * a design edited after publish cannot silently drop it from its card.
+ */
+
+import { getBaseUrl } from './shared.js';
+import type { CommunityCardMetadata, CommunityDesignRecord } from './communityStore.js';
+
+// Matches the client's publicDesignUrl: /community/d/<id> is the canonical route.
+export function communityDesignUrl(designId: string): string {
+  return `${getBaseUrl()}/community/d/${designId}`;
+}
+
+export function cardFromRecord(record: CommunityDesignRecord): CommunityCardMetadata {
+  return {
+    id: record.id,
+    name: record.name,
+    authorPublicId: record.authorPublicId,
+    authorName: record.authorName,
+    category: record.category,
+    techniques: record.techniques,
+    kind: record.kind ?? '',
+    width: record.metrics.width,
+    depth: record.metrics.depth,
+    height: record.metrics.height,
+    gridUnitMm: record.metrics.gridUnitMm,
+    thumbnailUrl: record.thumbnails[0] ?? '',
+    isRemix: record.lineage !== null,
+    parentId: record.lineage?.parentId ?? '',
+    featured: record.featured,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    status: record.status,
+  };
+}
+
+export const DUPLICATE_DESIGN_RESPONSE = {
+  error:
+    'This matches a design that has already been published (or a built-in example). Make it your own before publishing.',
+  code: 'DUPLICATE_DESIGN',
+} as const;
+
+export const REMIX_UNCHANGED_RESPONSE = {
+  error: 'Change the design before publishing your remix.',
+  code: 'REMIX_UNCHANGED',
+} as const;


### PR DESCRIPTION
## Summary

`cardFromRecord` (the 18-field design-record to gallery-card projection) was module-private to `api/community.ts`, so the update path in `api/community/[id].ts` re-implemented it inline. The copies had already started to drift cosmetically, and any new `CommunityCardRecord` field had to be added in two places or a design edited after publish silently lost it from its card.

- New `api/lib/communityRecord.ts` owns `cardFromRecord` and `communityDesignUrl`; both endpoints import it.
- The update path's deliberate A4 semantics (re-read moderation status immediately before the card write, never trust the in-flight record's status) are preserved explicitly: `cardFromRecord({ ...updated, status: statusAtWrite })`.
- The byte-identical `DUPLICATE_DESIGN` and `REMIX_UNCHANGED` 409 bodies move to shared constants so the guard responses cannot drift between publish and update.

The two blob-upload strategies (publish: parallel, `allowOverwrite: false`; update: sequential, `allowOverwrite: true` keyed to the recomputed rev) are deliberately different and untouched.

## Testing

- `pnpm run typecheck` clean
- `api/community.test.ts` + all `api/lib` suites: 1446 tests pass

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

