### PR TITLE
refactor(shared): consolidate isRecord, formatMm, and the uuid shadow

### DIFF
--- a/src/features/baseplate/components/BaseplatePreview/DimensionLabels.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/DimensionLabels.tsx
@@ -12,8 +12,6 @@ const DIM_OFFSET = 8; // mm from slab edge to label
 const DIM_LINE_OPACITY = 0.25;
 const DIM_TICK_SIZE = 3;
 
-/** Format mm for display: minimum needed decimals, no trailing zeros. */
-
 /**
  * Width and depth dimension annotations along the baseplate edges.
  * Measures the material, so leader lines land on the plate's real edges and the

--- a/src/features/baseplate/components/BaseplatePreview/DimensionLabels.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/DimensionLabels.tsx
@@ -4,6 +4,7 @@ import * as THREE from 'three';
 import type { DrawerOutline } from '@/core/types';
 import { outlineBounds } from '@/shared/utils/drawerOutlineGeometry';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';
+import { formatMm } from '@/shared/utils/format';
 
 const DIM_FONT_SIZE = 4;
 const DIM_OPACITY = 0.5;
@@ -12,10 +13,6 @@ const DIM_LINE_OPACITY = 0.25;
 const DIM_TICK_SIZE = 3;
 
 /** Format mm for display: minimum needed decimals, no trailing zeros. */
-function formatMm(v: number): string {
-  const rounded = Math.round(v * 100) / 100;
-  return String(rounded);
-}
 
 /**
  * Width and depth dimension annotations along the baseplate edges.

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.tsx
@@ -26,15 +26,12 @@ import { normalizePaletteLip, lipCellZone } from '@/features/bin-designer/types/
 import { useTranslation } from '@/i18n';
 import { useMenuKeyboardNav } from '@/shared/hooks/useMenuKeyboardNav';
 import type { FeatureColorConfig } from '@/features/bin-designer/types/featureColors';
+import { generateUUID } from '@/shared/utils/uuid';
 
 interface ColorsActionsMenuProps {
   featureColors: FeatureColorConfig;
   onMatchAllToBody: () => void;
   onApplyPalette: (palette: SavedColorPalette) => void;
-}
-
-function uuid(): string {
-  return globalThis.crypto.randomUUID();
 }
 
 export function ColorsActionsMenu({
@@ -79,7 +76,7 @@ export function ColorsActionsMenu({
     if (!name) return;
 
     const palette: SavedColorPalette = {
-      id: uuid(),
+      id: generateUUID(),
       name,
       createdAt: new Date().toISOString(),
       colors: {

--- a/src/features/bin-inspector/components/Inspector/ExpandedFootprint/ExpandedFootprint.tsx
+++ b/src/features/bin-inspector/components/Inspector/ExpandedFootprint/ExpandedFootprint.tsx
@@ -19,6 +19,7 @@ import { useMutations } from '@/shared/contexts/MutationsContext';
 import { useTranslation } from '@/i18n';
 import { effectiveGridUnitMmY } from '@/core/types';
 import type { Bin, Layout } from '@/core/types';
+import { formatMm } from '@/shared/utils/format';
 
 interface ExpandedFootprintProps {
   bin: Bin;
@@ -26,9 +27,6 @@ interface ExpandedFootprintProps {
 }
 
 /** Up to 2 decimals, trailing zeros stripped (98, 104.5). */
-function formatMm(value: number): string {
-  return String(Math.round(value * 100) / 100);
-}
 
 /** Signed mm for a per-side value, so `+0` reads as "not extended here". */
 function formatSide(value: number): string {

--- a/src/features/bin-inspector/components/Inspector/ExpandedFootprint/ExpandedFootprint.tsx
+++ b/src/features/bin-inspector/components/Inspector/ExpandedFootprint/ExpandedFootprint.tsx
@@ -26,8 +26,6 @@ interface ExpandedFootprintProps {
   layout: Layout;
 }
 
-/** Up to 2 decimals, trailing zeros stripped (98, 104.5). */
-
 /** Signed mm for a per-side value, so `+0` reads as "not extended here". */
 function formatSide(value: number): string {
   return `+${formatMm(value)}`;

--- a/src/features/bin-inspector/labelSuggest/loadModel.ts
+++ b/src/features/bin-inspector/labelSuggest/loadModel.ts
@@ -5,13 +5,11 @@ import { EMPTY_MODEL, MODEL_SCHEMA_VERSION, type LabelSuggesterModel } from './m
 // ~250 kB payload out of the JS module graph entirely. Fetched on demand and
 // runtime-cached by the service worker.
 import modelUrl from './labelSuggester.model.json?url';
+import { isRecord } from '@/shared/utils/isRecord';
 
 let modelPromise: Promise<LabelSuggesterModel> | null = null;
 
 /** Arrays are objects, and an array would silently miss every key lookup. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 /** Shallow shape check — the payload is a build asset we emit, not user input. */
 function isLabelSuggesterModel(value: unknown): value is LabelSuggesterModel {

--- a/src/features/bin-recommender/loadModel.ts
+++ b/src/features/bin-recommender/loadModel.ts
@@ -5,13 +5,11 @@ import type { BinRecommenderModel } from './types';
 // ~270 kB payload out of the JS module graph entirely. Fetched on demand and
 // runtime-cached by the service worker.
 import modelUrl from './model.json?url';
+import { isRecord } from '@/shared/utils/isRecord';
 
 let modelPromise: Promise<BinRecommenderModel> | null = null;
 
 /** Arrays are objects, and an array would silently miss every key lookup. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 // Structural only: `recommendBinSize` already rejects an unsupported
 // schemaVersion, so duplicating that check here would fork the supported range.

--- a/src/features/community/api/client.ts
+++ b/src/features/community/api/client.ts
@@ -22,6 +22,7 @@ import {
   COMMUNITY_REPORT_REASONS,
 } from '@/shared/types/community';
 import { TECHNIQUE_CONFIG } from '@/shared/types/exampleTechniques';
+import { isRecord } from '@/shared/utils/isRecord';
 
 const COMMUNITY_ENDPOINT = '/api/community';
 
@@ -96,10 +97,6 @@ export function errorFromResponse(status: number, data: unknown): CommunityClien
     return { kind: 'validation', code: body.code, message: body.error };
   }
   return { kind: 'server' };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 function isPublishResult(value: unknown): value is CommunityPublishResult {

--- a/src/features/community/api/printsClient.ts
+++ b/src/features/community/api/printsClient.ts
@@ -17,6 +17,7 @@ import type {
 import type { CommunityReportReason } from '@/shared/types/community';
 import type { CommunityClientError } from './client';
 import { communityFetch, errorFromResponse } from './client';
+import { isRecord } from '@/shared/utils/isRecord';
 
 const PRINTS_ENDPOINT = '/api/community/prints';
 
@@ -63,10 +64,6 @@ export interface CommunityPrintWriteResult {
   print: CommunityPrint;
   /** Distinct printers after the write, so callers can update a card without refetching. */
   count: number;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 function isPrint(value: unknown): value is CommunityPrint {

--- a/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
+++ b/src/features/community/components/CommunityDetail/CommunityDetailContent.tsx
@@ -18,6 +18,7 @@ import { DesignMediaPanel } from './DesignMediaPanel';
 import { DirectRemixList } from './DirectRemixList';
 import { RemixLineage } from './RemixLineage';
 import { SimilarRail } from './SimilarRail';
+import { formatMm } from '@/shared/utils/format';
 
 /**
  * Live-name resolution state for the lineage line: snapshot names render
@@ -208,10 +209,6 @@ function HiddenNotice({ moderation }: { moderation: OwnerModeration }) {
       )}
     </div>
   );
-}
-
-function formatMm(value: number): string {
-  return String(Number(value.toFixed(1)));
 }
 
 function formatDate(timestamp: number): string {

--- a/src/features/community/utils/communityDigest.ts
+++ b/src/features/community/utils/communityDigest.ts
@@ -10,6 +10,7 @@
  */
 
 import type { CommunityCard } from '@/shared/types/community';
+import { isRecord } from '@/shared/utils/isRecord';
 
 const DIGEST_KEY = 'gridfinity-community-digest-v1';
 
@@ -43,13 +44,9 @@ export const EMPTY_USER_DIGEST_RECORD: UserDigestRecord = {
   seen: {},
 };
 
-function isRecordObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function isCounts(value: unknown): value is DigestCounts {
   return (
-    isRecordObject(value) &&
+    isRecord(value) &&
     typeof value.likes === 'number' &&
     typeof value.remixes === 'number' &&
     typeof value.exports === 'number'
@@ -57,12 +54,12 @@ function isCounts(value: unknown): value is DigestCounts {
 }
 
 function isCountsMap(value: unknown): value is Record<string, DigestCounts> {
-  return isRecordObject(value) && Object.values(value).every(isCounts);
+  return isRecord(value) && Object.values(value).every(isCounts);
 }
 
 function isUserDigestRecord(value: unknown): value is UserDigestRecord {
   return (
-    isRecordObject(value) &&
+    isRecord(value) &&
     typeof value.lastCheckedAt === 'number' &&
     isCountsMap(value.latest) &&
     isCountsMap(value.seen)
@@ -74,7 +71,7 @@ function loadAll(): Record<string, UserDigestRecord> {
     const stored = localStorage.getItem(DIGEST_KEY);
     if (stored === null) return {};
     const parsed: unknown = JSON.parse(stored);
-    if (!isRecordObject(parsed)) return {};
+    if (!isRecord(parsed)) return {};
     const records: Record<string, UserDigestRecord> = {};
     for (const [userId, record] of Object.entries(parsed)) {
       if (isUserDigestRecord(record)) records[userId] = record;

--- a/src/shared/components/EditableDimensions/EditableDimensions.tsx
+++ b/src/shared/components/EditableDimensions/EditableDimensions.tsx
@@ -4,8 +4,6 @@ import { PencilIcon } from '@/design-system/Icon';
 import { clamp as clampRange } from '@/shared/utils/math';
 import { formatMm } from '@/shared/utils/format';
 
-/** Format mm for display: minimum needed decimals, no trailing zeros. */
-
 interface EditableDimensionsProps {
   /** Total width in mm (grid + padding) when hasPadding, or grid-only mm otherwise. */
   readonly widthMm: number;

--- a/src/shared/components/EditableDimensions/EditableDimensions.tsx
+++ b/src/shared/components/EditableDimensions/EditableDimensions.tsx
@@ -2,12 +2,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Input } from '@/design-system';
 import { PencilIcon } from '@/design-system/Icon';
 import { clamp as clampRange } from '@/shared/utils/math';
+import { formatMm } from '@/shared/utils/format';
 
 /** Format mm for display: minimum needed decimals, no trailing zeros. */
-function formatMm(v: number): string {
-  const rounded = Math.round(v * 100) / 100;
-  return String(rounded);
-}
 
 interface EditableDimensionsProps {
   /** Total width in mm (grid + padding) when hasPadding, or grid-only mm otherwise. */

--- a/src/shared/items/assembly/descriptor.ts
+++ b/src/shared/items/assembly/descriptor.ts
@@ -15,6 +15,7 @@ import type {
   PartTransform,
 } from '@/shared/types/assembly';
 import { ASSEMBLY_PART_TYPES } from '@/shared/types/assembly';
+import { isRecord } from '@/shared/utils/isRecord';
 
 /** Hard ceiling on total nodes; the printability checker advises far below it. */
 export const MAX_ASSEMBLY_PARTS = 256;
@@ -435,10 +436,6 @@ export function defaultPartParams<K extends AssemblyPartType>(
 
 function isAssemblyPartType(v: unknown): v is AssemblyPartType {
   return typeof v === 'string' && (ASSEMBLY_PART_TYPES as readonly string[]).includes(v);
-}
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
 /**

--- a/src/shared/utils/format.test.ts
+++ b/src/shared/utils/format.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { formatMm } from './format';
+
+describe('formatMm', () => {
+  it('rounds to two decimal places', () => {
+    expect(formatMm(41.999)).toBe('42');
+    expect(formatMm(3.14159)).toBe('3.14');
+  });
+
+  it('drops trailing zeros', () => {
+    expect(formatMm(42)).toBe('42');
+    expect(formatMm(10.5)).toBe('10.5');
+  });
+});

--- a/src/shared/utils/format.ts
+++ b/src/shared/utils/format.ts
@@ -1,0 +1,8 @@
+/**
+ * Millimeter value for display: rounded to 2 decimal places with no trailing
+ * zeros and no unit suffix. Every surface that prints a raw mm number uses
+ * this so the same dimension never renders with different precision.
+ */
+export function formatMm(value: number): string {
+  return String(Math.round(value * 100) / 100);
+}

--- a/src/shared/utils/isRecord.test.ts
+++ b/src/shared/utils/isRecord.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { isRecord } from './isRecord';
+
+describe('isRecord', () => {
+  it('accepts plain objects', () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  it('rejects null, arrays, and primitives', () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+    expect(isRecord([])).toBe(false);
+    expect(isRecord('x')).toBe(false);
+    expect(isRecord(1)).toBe(false);
+  });
+});

--- a/src/shared/utils/isRecord.ts
+++ b/src/shared/utils/isRecord.ts
@@ -1,0 +1,4 @@
+/** Narrow an unknown to a plain object. Arrays are not records. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/shared/utils/isRecord.ts
+++ b/src/shared/utils/isRecord.ts
@@ -1,4 +1,6 @@
-/** Narrow an unknown to a plain object. Arrays are not records. */
+/** Narrow an unknown to an object usable for string-keyed reads. Excludes
+ *  null and arrays, but not class instances (Date, Map): same contract as the
+ *  local guards this replaced. */
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary

- **isRecord** existed six times (assembly descriptor, community digest as `isRecordObject`, two API clients, two model loaders). All collapse onto `src/shared/utils/isRecord.ts` using the strict variant: arrays are not records. The two community API-client copies previously let arrays pass; the tightening means an array response now fails the shape guard instead of failing downstream field reads.
- **formatMm** existed five times with real drift: the community detail page rendered dimensions at 1dp while the inspector, editable dimensions, and baseplate labels used 2dp, so the same value displayed differently across surfaces. Four copies collapse onto `src/shared/utils/format.ts` at 2dp. The suffixed (`CompartmentDimensions`) and 2-arg (`MultiBinInspector`) variants are semantically different and stay.
- **ColorsActionsMenu** shadowed `generateUUID` with a bare `crypto.randomUUID()` lacking the older-environment fallback; it now imports the shared one.

**Deliberately not merged:** the four `stableStringify` copies look identical at a glance but normalize differently (null-dropping vs null-keeping vs sorted-replacer), and each feeds a separate persisted cache key or content-hash domain (export cache, mesh persistence, remix detection, server content hash). Unifying them would silently invalidate caches and change hashes.

## Testing

- `pnpm run typecheck` clean
- New sibling tests for both shared utils; all affected suites (community, bin-recommender, bin-inspector, shared items/components): 1375 tests pass

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

