### PR TITLE
ci(release): annotate each release in PostHog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,27 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
 
+      # Marks the release on PostHog charts so a metric change can be read
+      # against the deploy that shipped it. Best-effort by design: a missing
+      # key or a PostHog outage must never block the release pipeline, so the
+      # step skips without the secret and warns instead of failing.
+      - name: Annotate release in PostHog
+        if: steps.release.outputs.releases_created == 'true'
+        env:
+          POSTHOG_ANNOTATION_API_KEY: ${{ secrets.POSTHOG_ANNOTATION_API_KEY }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if [ -z "$POSTHOG_ANNOTATION_API_KEY" ]; then
+            echo "POSTHOG_ANNOTATION_API_KEY not set; skipping release annotation."
+            exit 0
+          fi
+          curl --silent --show-error --max-time 30 \
+            -H "Authorization: Bearer $POSTHOG_ANNOTATION_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"content\": \"v$VERSION\", \"date_marker\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"scope\": \"project\", \"creation_type\": \"GIT\"}" \
+            "https://us.posthog.com/api/projects/284234/annotations/" \
+            || echo "::warning::PostHog release annotation failed (non-blocking)."
+
       - name: Auto-approve Release PR
         if: steps.release.outputs.pr
         env:


### PR DESCRIPTION
## What

Adds a best-effort step to the release workflow that POSTs a project-scoped annotation ("vX.Y.Z") to PostHog when release-please creates a release, so every chart carries deploy context and a metric change can be read against the release that shipped it.

Fail-safe by design:

- Without the `POSTHOG_ANNOTATION_API_KEY` secret the step logs a skip and exits 0, mirroring how the source-map upload no-ops without its keys. Nothing to configure to merge this.
- A PostHog outage or API error degrades to a workflow warning; the release pipeline cannot be blocked by annotation delivery (`curl ... || warning`).
- `VERSION` is release-please's own semver output, passed through `env:` with quoting.

## Enabling it

Add a repo Actions secret `POSTHOG_ANNOTATION_API_KEY`: a PostHog personal API key with annotation write scope. The two hand-written annotations from July stop being the only deploy markers from the next release after that.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

