### PR TITLE
test(auth): cover the GitHub and Google OAuth provider modules

### DIFF
--- a/api/auth/providers/github.test.ts
+++ b/api/auth/providers/github.test.ts
@@ -1,10 +1,3 @@
-/**
- * Tests for the GitHub OAuth provider. Mocks the `arctic` GitHub class (so no
- * network call to GitHub's token endpoint) and `fetch` (for the `/user` and
- * `/user/emails` REST calls); everything else — email selection, name
- * fallback, header shaping — runs the real provider code.
- */
-
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type * as ArcticModule from 'arctic';
 
@@ -50,14 +43,9 @@ function mockUser(overrides: Partial<RawGitHubUser> = {}): RawGitHubUser {
 }
 
 describe('githubProvider', () => {
-  const ORIGINAL_ENV = process.env;
-
   beforeEach(() => {
-    process.env = {
-      ...ORIGINAL_ENV,
-      GITHUB_CLIENT_ID: 'gh-id',
-      GITHUB_CLIENT_SECRET: 'gh-secret',
-    };
+    vi.stubEnv('GITHUB_CLIENT_ID', 'gh-id');
+    vi.stubEnv('GITHUB_CLIENT_SECRET', 'gh-secret');
     vi.stubGlobal('fetch', vi.fn());
     mocks.githubCtor.mockClear();
     mocks.createAuthorizationURL.mockClear();
@@ -68,21 +56,21 @@ describe('githubProvider', () => {
   });
 
   afterEach(() => {
-    process.env = ORIGINAL_ENV;
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
 
   describe('config', () => {
     it('throws when both GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are unset', () => {
-      delete process.env.GITHUB_CLIENT_ID;
-      delete process.env.GITHUB_CLIENT_SECRET;
+      vi.stubEnv('GITHUB_CLIENT_ID', undefined);
+      vi.stubEnv('GITHUB_CLIENT_SECRET', undefined);
       expect(() => githubProvider.buildAuthorizationUrl('state')).toThrow(
         'GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET not configured'
       );
     });
 
     it('throws when only GITHUB_CLIENT_SECRET is unset', () => {
-      delete process.env.GITHUB_CLIENT_SECRET;
+      vi.stubEnv('GITHUB_CLIENT_SECRET', undefined);
       expect(() => githubProvider.buildAuthorizationUrl('state')).toThrow(
         'GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET not configured'
       );

--- a/api/auth/providers/github.test.ts
+++ b/api/auth/providers/github.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for the GitHub OAuth provider. Mocks the `arctic` GitHub class (so no
+ * network call to GitHub's token endpoint) and `fetch` (for the `/user` and
+ * `/user/emails` REST calls); everything else — email selection, name
+ * fallback, header shaping — runs the real provider code.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type * as ArcticModule from 'arctic';
+
+const mocks = vi.hoisted(() => ({
+  githubCtor: vi.fn(),
+  createAuthorizationURL: vi.fn(),
+  validateAuthorizationCode: vi.fn(),
+}));
+
+vi.mock('arctic', async (importOriginal) => {
+  const actual = await importOriginal<typeof ArcticModule>();
+  return {
+    ...actual,
+    GitHub: class {
+      constructor(...args: unknown[]) {
+        mocks.githubCtor(...args);
+      }
+      createAuthorizationURL(...args: unknown[]) {
+        return mocks.createAuthorizationURL(...args);
+      }
+      validateAuthorizationCode(...args: unknown[]) {
+        return mocks.validateAuthorizationCode(...args);
+      }
+    },
+  };
+});
+
+import { githubProvider } from './github.js';
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+interface RawGitHubUser {
+  id: number;
+  login: string;
+  name: string | null;
+  email: string | null;
+}
+
+function mockUser(overrides: Partial<RawGitHubUser> = {}): RawGitHubUser {
+  return { id: 42, login: 'octocat', name: 'Octo Cat', email: null, ...overrides };
+}
+
+describe('githubProvider', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      GITHUB_CLIENT_ID: 'gh-id',
+      GITHUB_CLIENT_SECRET: 'gh-secret',
+    };
+    vi.stubGlobal('fetch', vi.fn());
+    mocks.githubCtor.mockClear();
+    mocks.createAuthorizationURL.mockClear();
+    mocks.validateAuthorizationCode.mockReset();
+    mocks.validateAuthorizationCode.mockResolvedValue({
+      accessToken: () => 'gh-access-token',
+    });
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    vi.unstubAllGlobals();
+  });
+
+  describe('config', () => {
+    it('throws when both GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are unset', () => {
+      delete process.env.GITHUB_CLIENT_ID;
+      delete process.env.GITHUB_CLIENT_SECRET;
+      expect(() => githubProvider.buildAuthorizationUrl('state')).toThrow(
+        'GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET not configured'
+      );
+    });
+
+    it('throws when only GITHUB_CLIENT_SECRET is unset', () => {
+      delete process.env.GITHUB_CLIENT_SECRET;
+      expect(() => githubProvider.buildAuthorizationUrl('state')).toThrow(
+        'GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET not configured'
+      );
+    });
+  });
+
+  describe('buildAuthorizationUrl', () => {
+    it('requests read:user + user:email scopes and returns the URL with no PKCE verifier', () => {
+      const url = new URL('https://github.com/login/oauth/authorize?state=s');
+      mocks.createAuthorizationURL.mockReturnValue(url);
+
+      const result = githubProvider.buildAuthorizationUrl('state-abc');
+
+      expect(mocks.createAuthorizationURL).toHaveBeenCalledWith('state-abc', [
+        'read:user',
+        'user:email',
+      ]);
+      expect(result).toEqual({ url });
+      expect(result.codeVerifier).toBeUndefined();
+    });
+  });
+
+  describe('exchangeCode: email selection precedence', () => {
+    it('selects the primary+verified email over a merely verified one', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser()))
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { email: 'secondary@example.com', primary: false, verified: true },
+            { email: 'primary@example.com', primary: true, verified: true },
+          ])
+        );
+
+      const profile = await githubProvider.exchangeCode({ code: 'c' });
+
+      expect(profile.email).toBe('primary@example.com');
+    });
+
+    it('ignores an unverified primary address in favor of a verified non-primary one', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser()))
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { email: 'unverified-primary@example.com', primary: true, verified: false },
+            { email: 'verified@example.com', primary: false, verified: true },
+          ])
+        );
+
+      const profile = await githubProvider.exchangeCode({ code: 'c' });
+
+      expect(profile.email).toBe('verified@example.com');
+    });
+
+    it('throws when the account has no verified email at all', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser()))
+        .mockResolvedValueOnce(
+          jsonResponse([{ email: 'unverified@example.com', primary: true, verified: false }])
+        );
+
+      await expect(githubProvider.exchangeCode({ code: 'c' })).rejects.toThrow(
+        'GitHub account has no verified email'
+      );
+    });
+
+    it('uses the /user email directly when present, even if /user/emails is malformed', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser({ email: 'public@example.com' })))
+        .mockResolvedValueOnce(jsonResponse(null, false, 500));
+
+      const profile = await githubProvider.exchangeCode({ code: 'c' });
+
+      expect(profile.email).toBe('public@example.com');
+      expect(profile.verifiedEmails).toEqual(['public@example.com']);
+    });
+
+    it('does not duplicate the /user email in verifiedEmails when /user/emails also returns it', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser({ email: 'x@example.com' })))
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { email: 'x@example.com', primary: true, verified: true },
+            { email: 'y@example.com', primary: false, verified: true },
+          ])
+        );
+
+      const profile = await githubProvider.exchangeCode({ code: 'c' });
+
+      expect(profile.verifiedEmails).toEqual(['x@example.com', 'y@example.com']);
+    });
+  });
+
+  describe('exchangeCode: profile mapping', () => {
+    it('falls back to the login handle when the profile has no name', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(
+          jsonResponse(mockUser({ name: null, login: 'octocat', email: 'x@example.com' }))
+        )
+        .mockResolvedValueOnce(jsonResponse([]));
+
+      const profile = await githubProvider.exchangeCode({ code: 'c' });
+
+      expect(profile.displayName).toBe('octocat');
+      expect(profile.handle).toBe('octocat');
+    });
+
+    it('uses the profile name when present', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser({ name: 'Octo Cat', email: 'x@example.com' })))
+        .mockResolvedValueOnce(jsonResponse([]));
+
+      const profile = await githubProvider.exchangeCode({ code: 'c' });
+
+      expect(profile.displayName).toBe('Octo Cat');
+    });
+
+    it('sets subject to the stringified numeric GitHub id', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser({ id: 987654, email: 'x@example.com' })))
+        .mockResolvedValueOnce(jsonResponse([]));
+
+      const profile = await githubProvider.exchangeCode({ code: 'c' });
+
+      expect(profile.subject).toBe('987654');
+    });
+  });
+
+  describe('exchangeCode: request shaping', () => {
+    it('sends the exchanged access token as a Bearer header to both endpoints', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({ accessToken: () => 'tok-123' });
+      const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(mockUser({ email: 'x@example.com' })))
+        .mockResolvedValueOnce(jsonResponse([]));
+
+      await githubProvider.exchangeCode({ code: 'auth-code' });
+
+      expect(mocks.validateAuthorizationCode).toHaveBeenCalledWith('auth-code');
+      const expectedHeaders = {
+        Accept: 'application/vnd.github+json',
+        Authorization: 'Bearer tok-123',
+        'User-Agent': 'gridfinity-layout-tool',
+      };
+      expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://api.github.com/user', {
+        headers: expectedHeaders,
+      });
+      expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://api.github.com/user/emails', {
+        headers: expectedHeaders,
+      });
+    });
+
+    it('throws with the response status when /user fails', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        jsonResponse(null, false, 401)
+      );
+
+      await expect(githubProvider.exchangeCode({ code: 'c' })).rejects.toThrow('GitHub /user 401');
+    });
+
+    it('propagates a /user/emails failure when /user gave no email (the required fetch)', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser({ email: null })))
+        .mockRejectedValueOnce(new Error('network down'));
+
+      await expect(githubProvider.exchangeCode({ code: 'c' })).rejects.toThrow('network down');
+    });
+
+    it('treats a non-array /user/emails response as no verified emails', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(jsonResponse(mockUser({ email: null })))
+        .mockResolvedValueOnce(jsonResponse({ error: 'nope' }));
+
+      await expect(githubProvider.exchangeCode({ code: 'c' })).rejects.toThrow(
+        'GitHub account has no verified email'
+      );
+    });
+  });
+});

--- a/api/auth/providers/google.test.ts
+++ b/api/auth/providers/google.test.ts
@@ -1,10 +1,3 @@
-/**
- * Tests for the Google OAuth provider. Mocks the `arctic` Google class (so no
- * network call to Google's token endpoint); `generateCodeVerifier` is the real
- * implementation. Everything else — callback URL construction, id_token
- * decoding, profile mapping — runs the real provider code.
- */
-
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type * as ArcticModule from 'arctic';
 
@@ -41,37 +34,32 @@ function makeIdToken(payload: Record<string, unknown>): string {
 }
 
 describe('googleProvider', () => {
-  const ORIGINAL_ENV = process.env;
-
   beforeEach(() => {
-    process.env = {
-      ...ORIGINAL_ENV,
-      GOOGLE_CLIENT_ID: 'g-id',
-      GOOGLE_CLIENT_SECRET: 'g-secret',
-    };
-    delete process.env.OAUTH_REDIRECT_BASE_URL;
-    delete process.env.VERCEL_URL;
-    delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
+    vi.stubEnv('GOOGLE_CLIENT_ID', 'g-id');
+    vi.stubEnv('GOOGLE_CLIENT_SECRET', 'g-secret');
+    vi.stubEnv('OAUTH_REDIRECT_BASE_URL', undefined);
+    vi.stubEnv('VERCEL_URL', undefined);
+    vi.stubEnv('VERCEL_PROJECT_PRODUCTION_URL', undefined);
     mocks.googleCtor.mockClear();
     mocks.createAuthorizationURL.mockClear();
     mocks.validateAuthorizationCode.mockReset();
   });
 
   afterEach(() => {
-    process.env = ORIGINAL_ENV;
+    vi.unstubAllEnvs();
   });
 
   describe('config', () => {
     it('throws when both GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are unset', () => {
-      delete process.env.GOOGLE_CLIENT_ID;
-      delete process.env.GOOGLE_CLIENT_SECRET;
+      vi.stubEnv('GOOGLE_CLIENT_ID', undefined);
+      vi.stubEnv('GOOGLE_CLIENT_SECRET', undefined);
       expect(() => googleProvider.buildAuthorizationUrl('state')).toThrow(
         'GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET not configured'
       );
     });
 
     it('throws when only GOOGLE_CLIENT_ID is unset', () => {
-      delete process.env.GOOGLE_CLIENT_ID;
+      vi.stubEnv('GOOGLE_CLIENT_ID', undefined);
       expect(() => googleProvider.buildAuthorizationUrl('state')).toThrow(
         'GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET not configured'
       );
@@ -80,7 +68,7 @@ describe('googleProvider', () => {
 
   describe('callback URL construction', () => {
     it('appends the callback path to OAUTH_REDIRECT_BASE_URL', () => {
-      process.env.OAUTH_REDIRECT_BASE_URL = 'https://gridfinity.example';
+      vi.stubEnv('OAUTH_REDIRECT_BASE_URL', 'https://gridfinity.example');
       googleProvider.buildAuthorizationUrl('s');
 
       expect(mocks.googleCtor).toHaveBeenCalledWith(
@@ -91,7 +79,7 @@ describe('googleProvider', () => {
     });
 
     it('strips a trailing slash from OAUTH_REDIRECT_BASE_URL before appending the callback path', () => {
-      process.env.OAUTH_REDIRECT_BASE_URL = 'https://gridfinity.example/';
+      vi.stubEnv('OAUTH_REDIRECT_BASE_URL', 'https://gridfinity.example/');
       googleProvider.buildAuthorizationUrl('s');
 
       expect(mocks.googleCtor).toHaveBeenCalledWith(
@@ -112,7 +100,7 @@ describe('googleProvider', () => {
     });
 
     it('falls back through getBaseUrl() to VERCEL_URL when OAUTH_REDIRECT_BASE_URL is unset', () => {
-      process.env.VERCEL_URL = 'gflt-preview.vercel.app';
+      vi.stubEnv('VERCEL_URL', 'gflt-preview.vercel.app');
       googleProvider.buildAuthorizationUrl('s');
 
       expect(mocks.googleCtor).toHaveBeenCalledWith(
@@ -125,7 +113,7 @@ describe('googleProvider', () => {
 
   describe('buildAuthorizationUrl', () => {
     it('generates a PKCE code verifier and passes it plus the openid/profile/email scopes', () => {
-      process.env.OAUTH_REDIRECT_BASE_URL = 'https://gridfinity.example';
+      vi.stubEnv('OAUTH_REDIRECT_BASE_URL', 'https://gridfinity.example');
       const url = new URL('https://accounts.google.com/o/oauth2/v2/auth?state=s');
       mocks.createAuthorizationURL.mockReturnValue(url);
 

--- a/api/auth/providers/google.test.ts
+++ b/api/auth/providers/google.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the Google OAuth provider. Mocks the `arctic` Google class (so no
+ * network call to Google's token endpoint); `generateCodeVerifier` is the real
+ * implementation. Everything else — callback URL construction, id_token
+ * decoding, profile mapping — runs the real provider code.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type * as ArcticModule from 'arctic';
+
+const mocks = vi.hoisted(() => ({
+  googleCtor: vi.fn(),
+  createAuthorizationURL: vi.fn(),
+  validateAuthorizationCode: vi.fn(),
+}));
+
+vi.mock('arctic', async (importOriginal) => {
+  const actual = await importOriginal<typeof ArcticModule>();
+  return {
+    ...actual,
+    Google: class {
+      constructor(...args: unknown[]) {
+        mocks.googleCtor(...args);
+      }
+      createAuthorizationURL(...args: unknown[]) {
+        return mocks.createAuthorizationURL(...args);
+      }
+      validateAuthorizationCode(...args: unknown[]) {
+        return mocks.validateAuthorizationCode(...args);
+      }
+    },
+  };
+});
+
+import { googleProvider } from './google.js';
+
+function makeIdToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}
+
+describe('googleProvider', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      GOOGLE_CLIENT_ID: 'g-id',
+      GOOGLE_CLIENT_SECRET: 'g-secret',
+    };
+    delete process.env.OAUTH_REDIRECT_BASE_URL;
+    delete process.env.VERCEL_URL;
+    delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
+    mocks.googleCtor.mockClear();
+    mocks.createAuthorizationURL.mockClear();
+    mocks.validateAuthorizationCode.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('config', () => {
+    it('throws when both GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are unset', () => {
+      delete process.env.GOOGLE_CLIENT_ID;
+      delete process.env.GOOGLE_CLIENT_SECRET;
+      expect(() => googleProvider.buildAuthorizationUrl('state')).toThrow(
+        'GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET not configured'
+      );
+    });
+
+    it('throws when only GOOGLE_CLIENT_ID is unset', () => {
+      delete process.env.GOOGLE_CLIENT_ID;
+      expect(() => googleProvider.buildAuthorizationUrl('state')).toThrow(
+        'GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET not configured'
+      );
+    });
+  });
+
+  describe('callback URL construction', () => {
+    it('appends the callback path to OAUTH_REDIRECT_BASE_URL', () => {
+      process.env.OAUTH_REDIRECT_BASE_URL = 'https://gridfinity.example';
+      googleProvider.buildAuthorizationUrl('s');
+
+      expect(mocks.googleCtor).toHaveBeenCalledWith(
+        'g-id',
+        'g-secret',
+        'https://gridfinity.example/api/auth/callback/google'
+      );
+    });
+
+    it('strips a trailing slash from OAUTH_REDIRECT_BASE_URL before appending the callback path', () => {
+      process.env.OAUTH_REDIRECT_BASE_URL = 'https://gridfinity.example/';
+      googleProvider.buildAuthorizationUrl('s');
+
+      expect(mocks.googleCtor).toHaveBeenCalledWith(
+        'g-id',
+        'g-secret',
+        'https://gridfinity.example/api/auth/callback/google'
+      );
+    });
+
+    it('falls back to getBaseUrl() (localhost default) when OAUTH_REDIRECT_BASE_URL is unset', () => {
+      googleProvider.buildAuthorizationUrl('s');
+
+      expect(mocks.googleCtor).toHaveBeenCalledWith(
+        'g-id',
+        'g-secret',
+        'https://localhost:3000/api/auth/callback/google'
+      );
+    });
+
+    it('falls back through getBaseUrl() to VERCEL_URL when OAUTH_REDIRECT_BASE_URL is unset', () => {
+      process.env.VERCEL_URL = 'gflt-preview.vercel.app';
+      googleProvider.buildAuthorizationUrl('s');
+
+      expect(mocks.googleCtor).toHaveBeenCalledWith(
+        'g-id',
+        'g-secret',
+        'https://gflt-preview.vercel.app/api/auth/callback/google'
+      );
+    });
+  });
+
+  describe('buildAuthorizationUrl', () => {
+    it('generates a PKCE code verifier and passes it plus the openid/profile/email scopes', () => {
+      process.env.OAUTH_REDIRECT_BASE_URL = 'https://gridfinity.example';
+      const url = new URL('https://accounts.google.com/o/oauth2/v2/auth?state=s');
+      mocks.createAuthorizationURL.mockReturnValue(url);
+
+      const result = googleProvider.buildAuthorizationUrl('state-abc');
+
+      expect(result.url).toBe(url);
+      expect(typeof result.codeVerifier).toBe('string');
+      expect(result.codeVerifier?.length).toBeGreaterThan(0);
+      expect(mocks.createAuthorizationURL).toHaveBeenCalledWith('state-abc', result.codeVerifier, [
+        'openid',
+        'profile',
+        'email',
+      ]);
+    });
+  });
+
+  describe('exchangeCode', () => {
+    it('throws when no codeVerifier is supplied, without constructing the Google client', async () => {
+      await expect(googleProvider.exchangeCode({ code: 'c' })).rejects.toThrow(
+        'Google requires a PKCE verifier'
+      );
+      expect(mocks.googleCtor).not.toHaveBeenCalled();
+    });
+
+    it('passes the code and codeVerifier through to validateAuthorizationCode', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({
+        idToken: () =>
+          makeIdToken({
+            sub: 'sub-1',
+            email: 'a@example.com',
+            email_verified: true,
+            name: 'Alice',
+          }),
+      });
+
+      await googleProvider.exchangeCode({ code: 'auth-code', codeVerifier: 'verifier-1' });
+
+      expect(mocks.validateAuthorizationCode).toHaveBeenCalledWith('auth-code', 'verifier-1');
+    });
+
+    it('maps a verified id_token payload to a ProviderProfile', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({
+        idToken: () =>
+          makeIdToken({
+            sub: 'sub-42',
+            email: 'alice@example.com',
+            email_verified: true,
+            name: 'Alice Example',
+          }),
+      });
+
+      const profile = await googleProvider.exchangeCode({ code: 'c', codeVerifier: 'v' });
+
+      expect(profile).toEqual({
+        subject: 'sub-42',
+        email: 'alice@example.com',
+        verifiedEmails: ['alice@example.com'],
+        displayName: 'Alice Example',
+      });
+    });
+
+    it('maps a payload with no name to an undefined displayName', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({
+        idToken: () =>
+          makeIdToken({ sub: 'sub-42', email: 'alice@example.com', email_verified: true }),
+      });
+
+      const profile = await googleProvider.exchangeCode({ code: 'c', codeVerifier: 'v' });
+
+      expect(profile.displayName).toBeUndefined();
+    });
+
+    it('throws on a malformed id_token that is not three dot-separated parts', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({ idToken: () => 'not-a-jwt' });
+
+      await expect(googleProvider.exchangeCode({ code: 'c', codeVerifier: 'v' })).rejects.toThrow(
+        'Malformed id_token'
+      );
+    });
+
+    it('throws on an id_token whose payload segment is not valid JSON', async () => {
+      const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString('base64url');
+      const body = Buffer.from('not-json').toString('base64url');
+      mocks.validateAuthorizationCode.mockResolvedValue({
+        idToken: () => `${header}.${body}.sig`,
+      });
+
+      await expect(googleProvider.exchangeCode({ code: 'c', codeVerifier: 'v' })).rejects.toThrow(
+        'Malformed id_token payload'
+      );
+    });
+
+    it('throws when the id_token has no sub claim', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({
+        idToken: () => makeIdToken({ email: 'a@example.com', email_verified: true }),
+      });
+
+      await expect(googleProvider.exchangeCode({ code: 'c', codeVerifier: 'v' })).rejects.toThrow(
+        'Google id_token missing sub'
+      );
+    });
+
+    it('throws when the id_token has no email claim', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({
+        idToken: () => makeIdToken({ sub: 'sub-1' }),
+      });
+
+      await expect(googleProvider.exchangeCode({ code: 'c', codeVerifier: 'v' })).rejects.toThrow(
+        'Google account has no verified email'
+      );
+    });
+
+    it('throws when email_verified is explicitly false', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({
+        idToken: () => makeIdToken({ sub: 'sub-1', email: 'a@example.com', email_verified: false }),
+      });
+
+      await expect(googleProvider.exchangeCode({ code: 'c', codeVerifier: 'v' })).rejects.toThrow(
+        'Google account has no verified email'
+      );
+    });
+
+    it('accepts an email when email_verified is omitted entirely (only an explicit false blocks it)', async () => {
+      mocks.validateAuthorizationCode.mockResolvedValue({
+        idToken: () => makeIdToken({ sub: 'sub-1', email: 'a@example.com' }),
+      });
+
+      const profile = await googleProvider.exchangeCode({ code: 'c', codeVerifier: 'v' });
+
+      expect(profile.email).toBe('a@example.com');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`api/auth/auth.test.ts` mocks `./providers/index` wholesale, so nothing exercised the real provider logic in `api/auth/providers/github.ts` and `api/auth/providers/google.ts`. This adds direct coverage for both, mocking only the `arctic` GitHub/Google classes and `fetch`.

**GitHub** (`api/auth/providers/github.test.ts`, 15 tests)
- Email selection precedence over the `/user/emails` list: primary+verified beats non-primary verified, an unverified-primary entry loses to a verified non-primary one, no verified email throws
- The `/user` email is used directly when present, without requiring `/user/emails` to succeed (soft-fail path), and is not duplicated in `verifiedEmails` when also returned by `/user/emails`
- Fallback to `login` for `displayName` when the profile has no `name`
- `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` unset (both, and secret-only) error
- Request shaping: Bearer token + headers sent to both endpoints, non-ok `/user` status surfaces in the thrown error, a required `/user/emails` failure propagates, a non-array `/user/emails` response is treated as no verified emails

**Google** (`api/auth/providers/google.test.ts`, 17 tests)
- Callback URL construction from `OAUTH_REDIRECT_BASE_URL`, including trailing-slash normalization, and the `getBaseUrl()` fallback (localhost default and `VERCEL_URL`) when unset
- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` unset (both, and id-only) error
- PKCE code verifier generation and scopes passed to `createAuthorizationURL`
- id_token to `ProviderProfile` mapping (subject/email/verifiedEmails/displayName), including no-name and malformed-token branches (not three parts, non-JSON payload, missing `sub`, missing/unverified email)
- Documents actual behavior: an `email_verified` field that is *omitted* (not explicitly `false`) is treated as verified — only an explicit `false` blocks sign-in

No production code was changed.

## Testing

- `pnpm run test:run api/auth` → `Test Files 3 passed (3)`, `Tests 54 passed (54)`
- `pnpm run test:run api` → `Test Files 65 passed | 2 skipped (67)`, `Tests 2125 passed | 16 skipped (2141)` (no regressions)
- `pnpm run typecheck` → clean
- Spot-checked the primary-email-precedence assertion by temporarily flipping its expected value and confirmed the runner failed, then restored it

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

