### PR TITLE
chore(bin-designer): drop the stale featureColors legacy guards

### DIFF
--- a/src/features/bin-designer/components/ParameterPanel/useFinishingGroupSummary.ts
+++ b/src/features/bin-designer/components/ParameterPanel/useFinishingGroupSummary.ts
@@ -8,8 +8,7 @@ export function useFinishingGroupSummary(): string {
   const t = useTranslation();
   const { colorsEnabled, gridUnitMm, heightUnitMm } = useDesignerStore(
     useShallow((s) => ({
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it; preserve the runtime fallback
-      colorsEnabled: s.params.featureColors?.enabled ?? false,
+      colorsEnabled: s.params.featureColors.enabled,
       gridUnitMm: s.params.gridUnitMm,
       heightUnitMm: s.params.heightUnitMm,
     }))

--- a/src/features/bin-designer/components/PreviewCanvas/ColorToolOverlay.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/ColorToolOverlay.tsx
@@ -84,8 +84,7 @@ export function ColorToolOverlay({ onClosePicker }: ColorToolOverlayProps) {
       colorTool: s.ui.colorTool,
       swapFirstZone: s.ui.swapFirstZone,
       pickerOverlay: s.ui.pickerOverlay,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- legacy persisted configs may omit featureColors; preserve runtime fallback
-      featureColors: s.params.featureColors ?? DEFAULT_FEATURE_COLOR_CONFIG,
+      featureColors: s.params.featureColors,
       baseStyle: s.params.base.style,
       stackingLip: s.params.base.stackingLip,
       labelEnabled: s.params.label.enabled,

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -377,8 +377,7 @@ function BinPreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
     }
   }, [wasmStatus]);
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it; preserve runtime fallback
-  const showColors = params.featureColors?.enabled ?? false;
+  const showColors = params.featureColors.enabled;
 
   // Responsive state for touch optimizations
   const { isDesktop, isTouchDevice } = useResponsive();

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
@@ -92,22 +92,17 @@ export function ColorsSection() {
       binHeight: s.params.height,
       heightUnitMm: s.params.heightUnitMm,
       extraWallHeightMm: s.params.extraWallHeightMm,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-      lipCorners: s.params.featureColors?.lip.corners ?? 1,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-      lipBands: s.params.featureColors?.lip.bands ?? 1,
+      lipCorners: s.params.featureColors.lip.corners,
+      lipBands: s.params.featureColors.lip.bands,
       hoveredColorZone: s.ui.hoveredColorZone,
       colorTool: s.ui.colorTool,
     }))
   );
   const setColorTool = useDesignerStore((s) => s.setColorTool);
   const swapZoneWithToast = useSwapZoneWithToast();
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors typed required but legacy persisted configs may omit it; preserve runtime fallback
-  const multiColorEnabled = rawColors?.enabled ?? false;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- legacy persisted configs may omit topAccent; migration backfills it but keep the runtime guard
-  const topAccent = rawColors?.topAccent ?? DEFAULT_FEATURE_COLOR_CONFIG.topAccent;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors typed required but legacy persisted configs may omit it; preserve runtime fallback
-  const bottomAccent = rawColors?.bottomAccent;
+  const multiColorEnabled = rawColors.enabled;
+  const topAccent = rawColors.topAccent ?? DEFAULT_FEATURE_COLOR_CONFIG.topAccent;
+  const bottomAccent = rawColors.bottomAccent;
   // Cap a band at the wall top — nominal height (units × mm/unit) plus any
   // exterior-wall collar — so it can't exceed the bin yet still reaches the top
   // of a collared bin. Floor of 1mm keeps the slider usable; the finite guard
@@ -160,8 +155,7 @@ export function ColorsSection() {
   const hasLid = activeZones.has('lid');
   const hasLidLip = activeZones.has(lidLipCellZone('frontLeft', 0));
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it; preserve the runtime fallback
-  const featureColors: FeatureColorConfig = rawColors ?? DEFAULT_FEATURE_COLOR_CONFIG;
+  const featureColors: FeatureColorConfig = rawColors;
   // Absent grid means "inherits the lid colour", so the editor is seeded with a
   // uniform grid rather than being hidden — the user needs somewhere to start.
   const lidLipConfig = featureColors.lidLip ?? {

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelColorControls.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelColorControls.tsx
@@ -41,8 +41,7 @@ export function LabelColorControls() {
 
   const { featureColors, colorTool, labelMode } = useDesignerStore(
     useShallow((s) => ({
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-      featureColors: s.params.featureColors ?? DEFAULT_FEATURE_COLOR_CONFIG,
+      featureColors: s.params.featureColors,
       colorTool: s.ui.colorTool,
       labelMode: s.params.label.mode ?? 'text',
     }))

--- a/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
+++ b/src/features/bin-designer/components/preview/BinMesh/BinMesh.tsx
@@ -90,26 +90,22 @@ export function BinMesh({ wireframe, color, xray = false, onZoneClick }: BinMesh
       isDraft: s.generation.isDraft,
       faceGroups: s.generation.mesh?.faceGroups ?? null,
       coarseLOD: s.generation.mesh?.coarseLOD ?? null,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-      featureColors: s.params.featureColors ?? null,
+      featureColors: s.params.featureColors,
       baseStyle: s.params.base.style,
       stackingLip: s.params.base.stackingLip,
       labelEnabled: s.params.label.enabled,
       scoopEnabled: s.params.scoop.enabled,
       lidEnabled: s.params.lid.enabled,
       cells: s.params.compartments.cells,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-      lipCorners: s.params.featureColors?.lip.corners ?? 1,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-      lipBands: s.params.featureColors?.lip.bands ?? 1,
+      lipCorners: s.params.featureColors.lip.corners,
+      lipBands: s.params.featureColors.lip.bands,
       cutouts: s.params.cutouts,
       hoveredColorZone: s.ui.hoveredColorZone,
       colorTool: s.ui.colorTool,
     }))
   );
   const setHoveredColorZone = useDesignerStore((s) => s.setHoveredColorZone);
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it; preserve runtime fallback
-  const multiColorEnabled = featureColors?.enabled ?? false;
+  const multiColorEnabled = featureColors.enabled;
   const cutoutUnits = useMemo(() => enumerateCutoutColorUnits(cutouts), [cutouts]);
   // Compartment colours are classified by position, so the plan needs the whole
   // param tree (interior size, overhang offset, floor plane) rather than the
@@ -137,8 +133,7 @@ export function BinMesh({ wireframe, color, xray = false, onZoneClick }: BinMesh
 
   // Build multi-color groups when feature is active
   const multiColorData = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is null-coalesced upstream (legacy persisted configs); runtime guard kept as belt-and-suspenders.
-    if (!multiColorActive || !faceGroups || !featureColors || !vertices || !indices) {
+    if (!multiColorActive || !faceGroups || !vertices || !indices) {
       return null;
     }
     return buildMultiColorGroups(
@@ -278,8 +273,7 @@ export function BinMesh({ wireframe, color, xray = false, onZoneClick }: BinMesh
     if (coarseGeometry) invalidate();
   }, [coarseGeometry, invalidate]);
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is null-coalesced upstream (legacy persisted configs); guard it
-  const baseColor = multiColorEnabled && featureColors ? featureColors.body : color;
+  const baseColor = multiColorEnabled ? featureColors.body : color;
 
   // Single-color material props shared between fine mesh and coarse LOD
   const singleMatProps = useMemo(
@@ -317,8 +311,7 @@ export function BinMesh({ wireframe, color, xray = false, onZoneClick }: BinMesh
   const zoneResolver = useMemo(() => {
     if (!toolActive) return null;
     if (multiColorData) return buildZoneResolver(multiColorData.triZones);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is null-coalesced upstream (legacy persisted configs)
-    if (!faceGroups || !featureColors || !vertices || !indices) return null;
+    if (!faceGroups || !vertices || !indices) return null;
     return buildZoneResolver(buildHitTestZones(faceGroups, vertices, indices, featureColors));
   }, [toolActive, multiColorData, faceGroups, featureColors, vertices, indices]);
 

--- a/src/features/bin-designer/components/preview/DetachableFeetMesh/DetachableFeetMesh.tsx
+++ b/src/features/bin-designer/components/preview/DetachableFeetMesh/DetachableFeetMesh.tsx
@@ -41,15 +41,14 @@ export function DetachableFeetMesh({
   const { feetMesh, featureColors } = useDesignerStore(
     useShallow((s) => ({
       feetMesh: s.generation.mesh?.detachableFeetMesh ?? null,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- typed required, but legacy persisted configs may omit it
-      featureColors: s.params.featureColors ?? null,
+      featureColors: s.params.featureColors,
     }))
   );
 
   // The feet ARE the bin's base, so in multi-colour mode they take the Base
   // zone rather than the body colour — otherwise the one control that should
   // paint them does nothing, in the preview and in the printed 3MF alike.
-  const feetColor = featureColors?.enabled ? getZoneColor(featureColors, 'base') : color;
+  const feetColor = featureColors.enabled ? getZoneColor(featureColors, 'base') : color;
 
   const { geometry, edgesGeometry, hasPrecomputedNormals } = useMeshGeometry({
     vertices: feetMesh?.vertices ?? null,

--- a/src/features/bin-designer/components/preview/LidMesh/LidMesh.tsx
+++ b/src/features/bin-designer/components/preview/LidMesh/LidMesh.tsx
@@ -67,8 +67,7 @@ export function LidMesh({ color, lidOffsetMm, wireframe = false, xray = false }:
   const { lidMesh, params, featureColors } = useDesignerStore(
     useShallow((s) => ({
       lidMesh: s.generation.mesh?.lidMesh ?? null,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-      featureColors: s.params.featureColors ?? null,
+      featureColors: s.params.featureColors,
       params: s.params,
     }))
   );
@@ -98,8 +97,7 @@ export function LidMesh({ color, lidOffsetMm, wireframe = false, xray = false }:
   // the print (the invariant GH established).
   const lidColorData = useMemo(
     () =>
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-      featureColors?.enabled
+      featureColors.enabled
         ? buildLidColorGroups(
             lidMesh?.faceGroups,
             lidMesh?.vertices,
@@ -121,8 +119,7 @@ export function LidMesh({ color, lidOffsetMm, wireframe = false, xray = false }:
   // In multi-color mode the lid is a single zone (`featureColors.lid`); the
   // exporter already paints the whole lid object that color, so the preview
   // must match instead of falling back to the body material (GH).
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is null-coalesced upstream (legacy persisted configs); runtime guard kept as belt-and-suspenders.
-  const lidColor = featureColors?.enabled ? getZoneColor(featureColors, 'lid') : color;
+  const lidColor = featureColors.enabled ? getZoneColor(featureColors, 'lid') : color;
 
   const baseOpacity = opacityForOffset(lidOffsetMm);
   const matProps = useMemo(

--- a/src/features/bin-designer/components/preview/StackPlateMesh/StackPlateMesh.tsx
+++ b/src/features/bin-designer/components/preview/StackPlateMesh/StackPlateMesh.tsx
@@ -64,8 +64,7 @@ export function StackPlateMesh({
       );
       return {
         stackPlateMesh: s.generation.mesh?.stackPlateMesh ?? null,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is typed required but legacy persisted configs may omit it
-        featureColors: s.params.featureColors ?? null,
+        featureColors: s.params.featureColors,
         // Same mated frame as LidMesh: local Z=0 lands at lidGroupZ.
         lidGroupZ: lipTopZ - anchorZ,
       };
@@ -81,8 +80,7 @@ export function StackPlateMesh({
 
   // The plate glues onto the lid, so it shares the lid's zone color in
   // multi-color mode (matches the exporter, which paints it lid-colored).
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors is null-coalesced upstream (legacy persisted configs); runtime guard kept as belt-and-suspenders.
-  const plateColor = featureColors?.enabled ? getZoneColor(featureColors, 'lid') : color;
+  const plateColor = featureColors.enabled ? getZoneColor(featureColors, 'lid') : color;
 
   const matProps = useMemo(
     () => ({

--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -455,8 +455,7 @@ export function buildMultiObject3MFObjects(
   lidFaceGroups?: CombinedExportResult['lidFaceGroups']
 ): ThreeMFObject[] {
   const objects: ThreeMFObject[] = [];
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- featureColors typed required but legacy persisted configs may omit it; runtime guard preserved
-  const featureColorsEnabled: boolean = params.featureColors?.enabled ?? false;
+  const featureColorsEnabled: boolean = params.featureColors.enabled;
   // A colored cutout makes the design multi-color even with every featureColors
   // zone at body — mirror the single-piece path so bin+lid/divider exports paint
   // cutouts too.


### PR DESCRIPTION
## Summary

24 sites across 10 files optional-chained `params.featureColors` behind `@typescript-eslint/no-unnecessary-condition` disables, all justified as "legacy persisted configs may omit it". The justification is stale:

- `BinParams.featureColors` is typed required, and every deserialization boundary runs `migrateParams` (`DesignerStorage` load and list paths, `persistenceSlice` restore and import, `defaultParamsStorage`, `designJson`).
- `migrateParams` unconditionally sets `featureColors: migrateFeatureColors(...)`, which returns the default config when the raw field is absent. Nothing un-migrated can reach the store.

So the migration boundary is the guard, and the per-site runtime guards were dead branches. This removes the 24 disables, passes the field through selectors without `?? null` / `?? DEFAULT` coalescing, and deletes the downstream null checks that existed only because the selectors had widened the type.

The one legitimately optional site stays: `binDownloadHelpers`' `faceGroups`-adjacent guard at the generation-pipeline boundary, plus the `Partial<BinParams>` readers in `featureColors.ts` and `labelPlateColors.ts`, which really can see absent fields.

## Testing

- `pnpm run typecheck` clean, ESLint: 0 errors on all touched files (the two remaining warnings are pre-existing `max-lines`)
- Full bin-designer suite: 502 files, 5852 tests pass

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

