### PR TITLE
refactor(storage): one IndexedDB open singleton behind the six databases

### DIFF
--- a/src/core/cqrs/store/eventStore.ts
+++ b/src/core/cqrs/store/eventStore.ts
@@ -6,8 +6,8 @@
  * failures are logged but never block the command pipeline.
  */
 
-import { openDB } from 'idb';
 import type { IDBPDatabase } from 'idb';
+import { createDbAccessor } from '@/core/storage/backends/openSingleton';
 import type { LayoutId } from '@/core/types';
 import type { DomainEvent } from '../events';
 import type { CorrelationId } from '../types';
@@ -21,56 +21,24 @@ const DB_VERSION = 1;
 const EVENTS_STORE = 'events';
 const MAX_EVENTS_PER_AGGREGATE = 10_000;
 
-// Database instance cache
-let dbInstance: IDBPDatabase | null = null;
-// In-flight open, shared so concurrent callers don't open duplicate connections
-let openPromise: Promise<IDBPDatabase> | null = null;
-
-async function openEventDb(): Promise<IDBPDatabase> {
-  const db = await openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      if (!db.objectStoreNames.contains(EVENTS_STORE)) {
-        const store = db.createObjectStore(EVENTS_STORE, { keyPath: 'meta.id' });
-        store.createIndex('byAggregate', 'meta.aggregateId', { unique: false });
-        store.createIndex('byTimestamp', 'meta.timestamp', { unique: false });
-        store.createIndex('byCorrelation', 'meta.correlationId', { unique: false });
-      }
-    },
-  });
-
-  // Clear cached instance if the browser closes the connection unexpectedly
-  // (tab eviction, version change from another tab, profile teardown).
-  db.addEventListener('close', () => {
-    if (dbInstance === db) {
-      dbInstance = null;
+const eventDb = createDbAccessor({
+  name: DB_NAME,
+  version: DB_VERSION,
+  upgrade(db) {
+    if (!db.objectStoreNames.contains(EVENTS_STORE)) {
+      const store = db.createObjectStore(EVENTS_STORE, { keyPath: 'meta.id' });
+      store.createIndex('byAggregate', 'meta.aggregateId', { unique: false });
+      store.createIndex('byTimestamp', 'meta.timestamp', { unique: false });
+      store.createIndex('byCorrelation', 'meta.correlationId', { unique: false });
     }
-  });
-
-  return db;
-}
-
-async function getDb(): Promise<IDBPDatabase> {
-  if (dbInstance) return dbInstance;
-
-  // Dedupe concurrent opens — every user action triggers a fire-and-forget
-  // append, so without this a burst of actions can open several connections.
-  openPromise ??= openEventDb()
-    .then((db) => {
-      dbInstance = db;
-      return db;
-    })
-    .finally(() => {
-      openPromise = null;
-    });
-
-  return openPromise;
-}
+  },
+});
 
 /**
  * True when an error means the connection/transaction we used is gone and a
  * fresh open will recover. Older WebKit/Safari auto-commit a transaction
  * between microtasks, and mobile background-tab eviction or a cross-tab version
- * change can tear the connection down while `dbInstance` still caches it — so
+ * change can tear the connection down while the accessor still caches it — so
  * the transaction created on it has no in-progress transaction by the time the
  * request runs ("Attempt to get a record from database without an in-progress
  * transaction").
@@ -98,20 +66,15 @@ function isConnectionLifetimeError(error: unknown): boolean {
  * self-heals instead of silently throwing and dropping a CQRS event.
  */
 async function withFreshDb<T>(operation: (db: IDBPDatabase) => Promise<T>): Promise<T> {
-  const db = await getDb();
+  const db = await eventDb.get();
   try {
     return await operation(db);
   } catch (error: unknown) {
     if (!isConnectionLifetimeError(error)) throw error;
 
     // Drop the stale connection and re-open before the single retry.
-    if (dbInstance === db) dbInstance = null;
-    try {
-      db.close();
-    } catch {
-      // Connection was already closing — nothing to do.
-    }
-    const fresh = await getDb();
+    eventDb.invalidate(db);
+    const fresh = await eventDb.get();
     return operation(fresh);
   }
 }

--- a/src/core/storage/backends/openSingleton.test.ts
+++ b/src/core/storage/backends/openSingleton.test.ts
@@ -1,12 +1,27 @@
-import { describe, it, expect } from 'vitest';
-import { deleteDB, openDB } from 'idb';
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { openDB } from 'idb';
 import type { IDBPDatabase } from 'idb';
 import { createDbAccessor } from './openSingleton';
 
 let dbCounter = 0;
+const createdDbs: string[] = [];
+
 function nextDbName(): string {
   dbCounter += 1;
-  return `open-singleton-test-${dbCounter}`;
+  const name = `open-singleton-test-${dbCounter}`;
+  createdDbs.push(name);
+  return name;
+}
+
+/** Resolve on blocked too: a leaked connection must not hang the suite. */
+function deleteDb(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(name);
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+    req.onblocked = () => resolve();
+  });
 }
 
 function withStore(db: IDBPDatabase): void {
@@ -47,6 +62,11 @@ async function blockVersion(name: string, version: number): Promise<void> {
   const blocker = await openDB(name, version, { upgrade: withStore });
   blocker.close();
 }
+
+afterEach(async () => {
+  const names = createdDbs.splice(0);
+  await Promise.all(names.map((name) => deleteDb(name)));
+});
 
 describe('createDbAccessor', () => {
   it('runs the upgrade callback and caches the connection', async () => {
@@ -123,7 +143,7 @@ describe('createDbAccessor', () => {
 
     await expect(accessor.get()).rejects.toThrow();
 
-    await deleteDB(name);
+    await deleteDb(name);
     await expect(accessor.get()).resolves.not.toBeNull();
 
     accessor.close();
@@ -142,7 +162,7 @@ describe('createDbAccessor', () => {
     expect(await accessor.get()).toBeNull();
 
     // The obstacle is gone, but the failure is remembered: no retry.
-    await deleteDB(name);
+    await deleteDb(name);
     expect(await accessor.get()).toBeNull();
 
     accessor.close();

--- a/src/core/storage/backends/openSingleton.test.ts
+++ b/src/core/storage/backends/openSingleton.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { deleteDB, openDB } from 'idb';
+import type { IDBPDatabase } from 'idb';
+import { createDbAccessor } from './openSingleton';
+
+let dbCounter = 0;
+function nextDbName(): string {
+  dbCounter += 1;
+  return `open-singleton-test-${dbCounter}`;
+}
+
+function withStore(db: IDBPDatabase): void {
+  if (!db.objectStoreNames.contains('things')) {
+    db.createObjectStore('things');
+  }
+}
+
+/**
+ * fake-indexeddb dispatches its own event objects and reads `initialized` /
+ * `eventPath` off whatever it is handed, so a DOM `Event` throws. This is the
+ * minimal shape its FakeEventTarget accepts.
+ */
+function fireCloseEvent(db: IDBPDatabase): void {
+  const event = {
+    type: 'close',
+    eventPath: [],
+    initialized: true,
+    dispatched: false,
+    bubbles: false,
+    cancelable: false,
+    propagationStopped: false,
+    immediatePropagationStopped: false,
+    canceled: false,
+    eventPhase: 0,
+    NONE: 0,
+    CAPTURING_PHASE: 1,
+    AT_TARGET: 2,
+    BUBBLING_PHASE: 3,
+    target: null,
+    currentTarget: null,
+  };
+  db.dispatchEvent(event as unknown as Event);
+}
+
+/** Make `version` unopenable: a higher version already exists on disk. */
+async function blockVersion(name: string, version: number): Promise<void> {
+  const blocker = await openDB(name, version, { upgrade: withStore });
+  blocker.close();
+}
+
+describe('createDbAccessor', () => {
+  it('runs the upgrade callback and caches the connection', async () => {
+    const accessor = createDbAccessor({ name: nextDbName(), version: 1, upgrade: withStore });
+
+    const db = await accessor.get();
+    expect(db.objectStoreNames.contains('things')).toBe(true);
+    expect(await accessor.get()).toBe(db);
+
+    accessor.close();
+  });
+
+  it('shares one connection between concurrent get() calls', async () => {
+    const accessor = createDbAccessor({ name: nextDbName(), version: 1, upgrade: withStore });
+
+    const [first, second, third] = await Promise.all([
+      accessor.get(),
+      accessor.get(),
+      accessor.get(),
+    ]);
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+
+    accessor.close();
+  });
+
+  it('reopens after the browser closes the connection', async () => {
+    const accessor = createDbAccessor({ name: nextDbName(), version: 1, upgrade: withStore });
+
+    const first = await accessor.get();
+    fireCloseEvent(first);
+    const second = await accessor.get();
+
+    expect(second).not.toBe(first);
+    await second.put('things', 'value', 'key');
+    expect(await second.get('things', 'key')).toBe('value');
+
+    first.close();
+    accessor.close();
+  });
+
+  it('reopens after close()', async () => {
+    const accessor = createDbAccessor({ name: nextDbName(), version: 1, upgrade: withStore });
+
+    const first = await accessor.get();
+    accessor.close();
+    const second = await accessor.get();
+
+    expect(second).not.toBe(first);
+
+    accessor.close();
+  });
+
+  it('invalidate() drops only the connection it is given', async () => {
+    const accessor = createDbAccessor({ name: nextDbName(), version: 1, upgrade: withStore });
+
+    const first = await accessor.get();
+    accessor.invalidate(first);
+    const second = await accessor.get();
+    expect(second).not.toBe(first);
+
+    // `first` is no longer cached, so invalidating it again must not evict `second`.
+    accessor.invalidate(first);
+    expect(await accessor.get()).toBe(second);
+
+    accessor.close();
+  });
+
+  it('rejects when the database cannot be opened, and retries on the next get()', async () => {
+    const name = nextDbName();
+    await blockVersion(name, 2);
+    const accessor = createDbAccessor({ name, version: 1, upgrade: withStore });
+
+    await expect(accessor.get()).rejects.toThrow();
+
+    await deleteDB(name);
+    await expect(accessor.get()).resolves.not.toBeNull();
+
+    accessor.close();
+  });
+
+  it('degrades to null with onUnavailable, and stays null once it has failed', async () => {
+    const name = nextDbName();
+    await blockVersion(name, 2);
+    const accessor = createDbAccessor({
+      name,
+      version: 1,
+      upgrade: withStore,
+      onUnavailable: () => null,
+    });
+
+    expect(await accessor.get()).toBeNull();
+
+    // The obstacle is gone, but the failure is remembered: no retry.
+    await deleteDB(name);
+    expect(await accessor.get()).toBeNull();
+
+    accessor.close();
+  });
+});

--- a/src/core/storage/backends/openSingleton.ts
+++ b/src/core/storage/backends/openSingleton.ts
@@ -1,0 +1,105 @@
+/**
+ * One open-and-cache singleton behind every IndexedDB database in the app.
+ *
+ * An accessor opens its database on first use and hands the same connection to
+ * every later caller. Three properties the hand-rolled copies of this had in
+ * different combinations, and that every caller now gets:
+ *
+ * - Concurrent `get()` calls share one in-flight open, so a burst of
+ *   fire-and-forget writes cannot open several connections to the same name.
+ * - A browser-initiated `close` (mobile tab eviction, a version change from
+ *   another tab) drops the cached handle, so the next `get()` reopens instead
+ *   of handing out a dead connection.
+ * - A failed open rejects. Callers that treat "no database" as a cache miss
+ *   pass `onUnavailable` to degrade to `null` instead.
+ */
+
+import { openDB } from 'idb';
+import type { IDBPDatabase, OpenDBCallbacks } from 'idb';
+
+type UpgradeCallback = NonNullable<OpenDBCallbacks<unknown>['upgrade']>;
+
+export interface DbAccessorOptions {
+  readonly name: string;
+  readonly version: number;
+  readonly upgrade: UpgradeCallback;
+  /**
+   * Resolve `null` instead of rejecting when the database cannot be opened
+   * (private mode, disabled storage, a version the browser refuses). The
+   * failure sticks: later `get()` calls resolve `null` without retrying.
+   */
+  readonly onUnavailable?: (error: unknown) => null;
+}
+
+export interface DbAccessor<TDb extends IDBPDatabase | null = IDBPDatabase> {
+  get(): Promise<TDb>;
+  /** Forget `db` if it is the cached connection, and close it. */
+  invalidate(db: IDBPDatabase): void;
+  /** Close and forget the cached connection; the next `get()` opens fresh. */
+  close(): void;
+}
+
+export function createDbAccessor(
+  options: DbAccessorOptions & { readonly onUnavailable: (error: unknown) => null }
+): DbAccessor<IDBPDatabase | null>;
+export function createDbAccessor(options: DbAccessorOptions): DbAccessor;
+export function createDbAccessor(options: DbAccessorOptions): DbAccessor<IDBPDatabase | null> {
+  const { name, version, upgrade, onUnavailable } = options;
+
+  let instance: IDBPDatabase | null = null;
+  let pending: Promise<IDBPDatabase | null> | null = null;
+  let unavailable = false;
+  // Bumped by close(): an open still in flight when it lands must not write
+  // its result back into the state the caller just cleared.
+  let generation = 0;
+
+  async function open(): Promise<IDBPDatabase | null> {
+    const openedAt = generation;
+    let db: IDBPDatabase;
+    try {
+      db = await openDB(name, version, { upgrade });
+    } catch (error: unknown) {
+      if (!onUnavailable) throw error;
+      if (openedAt === generation) unavailable = true;
+      return onUnavailable(error);
+    }
+
+    db.addEventListener('close', () => {
+      if (instance === db) instance = null;
+    });
+    if (openedAt === generation) instance = db;
+    return db;
+  }
+
+  function get(): Promise<IDBPDatabase | null> {
+    if (instance) return Promise.resolve(instance);
+    if (unavailable) return Promise.resolve(null);
+    if (pending) return pending;
+
+    const inFlight: Promise<IDBPDatabase | null> = open().finally(() => {
+      if (pending === inFlight) pending = null;
+    });
+    pending = inFlight;
+    return inFlight;
+  }
+
+  function invalidate(db: IDBPDatabase): void {
+    if (instance === db) instance = null;
+    try {
+      db.close();
+    } catch {
+      // Connection was already closing.
+    }
+  }
+
+  function close(): void {
+    generation += 1;
+    pending = null;
+    unavailable = false;
+    const db = instance;
+    instance = null;
+    db?.close();
+  }
+
+  return { get, invalidate, close };
+}

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -132,4 +132,7 @@ export { clearAllAppData } from './clearAppData';
 export { cleanupLocalStorageBackups, clearCleanupFlag } from './localStorageCleanup';
 export type { CleanupStats } from './localStorageCleanup';
 
+export { createDbAccessor } from './backends/openSingleton';
+export type { DbAccessor, DbAccessorOptions } from './backends/openSingleton';
+
 export { getStorageBackend, resetStorageBackendCache } from './backend';

--- a/src/core/sync/outbox.ts
+++ b/src/core/sync/outbox.ts
@@ -15,7 +15,7 @@
  * intermediate states, we always push the latest local snapshot).
  */
 
-import { openDB, type IDBPDatabase } from 'idb';
+import { createDbAccessor } from '@/core/storage/backends/openSingleton';
 import type { SyncKind } from './adapters/types';
 
 export type { SyncKind };
@@ -58,24 +58,16 @@ const MAX_DELAY_MS = 5 * 60 * 1_000; // cap at 5 minutes
  */
 export const MAX_ATTEMPTS = 8;
 
-let dbInstance: IDBPDatabase | null = null;
-
-async function getDb(): Promise<IDBPDatabase> {
-  if (dbInstance) return dbInstance;
-  const db = await openDB(DB_NAME, DB_VERSION, {
-    upgrade(upgradeDb) {
-      if (!upgradeDb.objectStoreNames.contains(STORE_NAME)) {
-        const store = upgradeDb.createObjectStore(STORE_NAME, { keyPath: 'key' });
-        store.createIndex('byNextAttempt', 'nextAttemptAt', { unique: false });
-      }
-    },
-  });
-  db.addEventListener('close', () => {
-    if (dbInstance === db) dbInstance = null;
-  });
-  dbInstance = db;
-  return dbInstance;
-}
+const outboxDb = createDbAccessor({
+  name: DB_NAME,
+  version: DB_VERSION,
+  upgrade(upgradeDb) {
+    if (!upgradeDb.objectStoreNames.contains(STORE_NAME)) {
+      const store = upgradeDb.createObjectStore(STORE_NAME, { keyPath: 'key' });
+      store.createIndex('byNextAttempt', 'nextAttemptAt', { unique: false });
+    }
+  },
+});
 
 function entryKey(kind: SyncKind, id: string): string {
   return `${kind}:${id}`;
@@ -109,7 +101,7 @@ export async function enqueue(input: {
   modifiedAt: number;
   op: 'put' | 'delete';
 }): Promise<void> {
-  const db = await getDb();
+  const db = await outboxDb.get();
   const now = Date.now();
   const entry: OutboxEntry = {
     key: entryKey(input.kind, input.id),
@@ -129,7 +121,7 @@ export async function enqueue(input: {
  * pending-count selector for the status indicator.
  */
 export async function getAll(): Promise<OutboxEntry[]> {
-  const db = await getDb();
+  const db = await outboxDb.get();
   return (await db.getAll(STORE_NAME)) as OutboxEntry[];
 }
 
@@ -156,7 +148,7 @@ export async function markSuccess(
   id: string,
   pushedModifiedAt: number
 ): Promise<void> {
-  const db = await getDb();
+  const db = await outboxDb.get();
   const tx = db.transaction(STORE_NAME, 'readwrite');
   const store = tx.objectStore(STORE_NAME);
   const current = (await store.get(entryKey(kind, id))) as OutboxEntry | undefined;
@@ -173,7 +165,7 @@ export async function markSuccess(
  * caller can surface a permanent-failure toast.
  */
 export async function markFailure(kind: SyncKind, id: string): Promise<'rescheduled' | 'gave-up'> {
-  const db = await getDb();
+  const db = await outboxDb.get();
   const tx = db.transaction(STORE_NAME, 'readwrite');
   const store = tx.objectStore(STORE_NAME);
   const current = (await store.get(entryKey(kind, id))) as OutboxEntry | undefined;
@@ -205,7 +197,7 @@ export async function rescheduleWithoutAttempt(
   id: string,
   delayMs: number
 ): Promise<void> {
-  const db = await getDb();
+  const db = await outboxDb.get();
   const tx = db.transaction(STORE_NAME, 'readwrite');
   const store = tx.objectStore(STORE_NAME);
   const current = (await store.get(entryKey(kind, id))) as OutboxEntry | undefined;
@@ -226,7 +218,7 @@ export async function rescheduleWithoutAttempt(
  * signed out before we drained it).
  */
 export async function discard(kind: SyncKind, id: string): Promise<void> {
-  const db = await getDb();
+  const db = await outboxDb.get();
   await db.delete(STORE_NAME, entryKey(kind, id));
 }
 
@@ -236,16 +228,15 @@ export async function discard(kind: SyncKind, id: string): Promise<void> {
  * the same device.
  */
 export async function clearAll(): Promise<void> {
-  const db = await getDb();
+  const db = await outboxDb.get();
   await db.clear(STORE_NAME);
 }
 
 /**
  * Test-only: forget the cached DB connection so the next call opens
  * fresh. Vitest's IndexedDB cleanup between tests is per-DB-name; we
- * still need to drop our cached `dbInstance`.
+ * still need to drop the connection this module holds.
  */
 export function __resetForTests(): void {
-  dbInstance?.close();
-  dbInstance = null;
+  outboxDb.close();
 }

--- a/src/features/baseplate/storage/BaseplateStorage.ts
+++ b/src/features/baseplate/storage/BaseplateStorage.ts
@@ -6,7 +6,7 @@
  * parameters, thumbnails, and timestamps. Mirrors DesignerStorage.
  */
 
-import { openDB, type IDBPDatabase } from 'idb';
+import { createDbAccessor } from '@/core/storage/backends/openSingleton';
 import type { BaseplateDesignId, StoredBaseplateParams } from '@/core/types';
 import { baseplateDesignId } from '@/core/types';
 import { DEFAULT_BASEPLATE_PARAMS, migrateBaseplateParams } from '@/core/constants';
@@ -32,35 +32,16 @@ const ACTIVE_DESIGN_KEY = 'gridfinity-baseplate-active-v1';
 /** Thumbnail format version — increment when changing thumbnail size/quality/format */
 const THUMBNAIL_VERSION = 1;
 
-let dbInstance: IDBPDatabase | null = null;
-
-/**
- * Open the baseplate library database, creating stores if needed.
- */
-async function getDb(): Promise<IDBPDatabase> {
-  if (dbInstance) {
-    return dbInstance;
-  }
-
-  const db = await openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      if (!db.objectStoreNames.contains(DESIGNS_STORE)) {
-        const store = db.createObjectStore(DESIGNS_STORE, { keyPath: 'id' });
-        store.createIndex('updatedAt', 'updatedAt');
-      }
-    },
-  });
-
-  // Clear cached instance if the browser closes the connection unexpectedly
-  db.addEventListener('close', () => {
-    if (dbInstance === db) {
-      dbInstance = null;
+const baseplateDb = createDbAccessor({
+  name: DB_NAME,
+  version: DB_VERSION,
+  upgrade(db) {
+    if (!db.objectStoreNames.contains(DESIGNS_STORE)) {
+      const store = db.createObjectStore(DESIGNS_STORE, { keyPath: 'id' });
+      store.createIndex('updatedAt', 'updatedAt');
     }
-  });
-
-  dbInstance = db;
-  return dbInstance;
-}
+  },
+});
 
 /**
  * Generate a unique baseplate design ID.
@@ -78,7 +59,7 @@ export async function saveDesign(
   }
 ): Promise<Result<SavedBaseplateDesign, StorageError>> {
   try {
-    const db = await getDb();
+    const db = await baseplateDb.get();
     const now = new Date().toISOString();
 
     // Reject incomplete writes up front so a malformed call can't persist a
@@ -123,7 +104,7 @@ export async function loadDesign(
   id: BaseplateDesignId
 ): Promise<Result<SavedBaseplateDesign, StorageError>> {
   try {
-    const db = await getDb();
+    const db = await baseplateDb.get();
     const design = (await db.get(DESIGNS_STORE, id)) as SavedBaseplateDesign | undefined;
 
     if (!design) {
@@ -151,7 +132,7 @@ export async function loadDesign(
  */
 export async function listDesigns(): Promise<Result<SavedBaseplateDesign[], StorageError>> {
   try {
-    const db = await getDb();
+    const db = await baseplateDb.get();
     const designs = (await db.getAll(DESIGNS_STORE)) as SavedBaseplateDesign[];
 
     // Filter out corrupted entries (invalid params) to avoid breaking the entire list
@@ -195,7 +176,7 @@ export async function duplicateDesign(
  */
 export async function deleteDesign(id: BaseplateDesignId): Promise<Result<void, StorageError>> {
   try {
-    const db = await getDb();
+    const db = await baseplateDb.get();
     const exists: unknown = await db.get(DESIGNS_STORE, id);
 
     if (!exists) {
@@ -315,8 +296,5 @@ export function setActiveDesignId(id: BaseplateDesignId | null): void {
  * Close the database connection (for testing/cleanup).
  */
 export function closeBaseplateDb(): void {
-  if (dbInstance) {
-    dbInstance.close();
-    dbInstance = null;
-  }
+  baseplateDb.close();
 }

--- a/src/features/baseplate/utils/exportCache.ts
+++ b/src/features/baseplate/utils/exportCache.ts
@@ -21,8 +21,9 @@
  * just without the cache.
  */
 
-import { openDB, type IDBPDatabase } from 'idb';
+import type { IDBPDatabase } from 'idb';
 import type { ResolvedBaseplateParams, ExportFileFormat } from '@/shared/types/bin';
+import { createDbAccessor } from '@/core/storage/backends/openSingleton';
 import { BASEPLATE_EXPORT_DB_NAME } from '@/core/storage/storageKeys';
 
 const DB_NAME = BASEPLATE_EXPORT_DB_NAME;
@@ -56,18 +57,16 @@ function nextTs(): number {
   return lastTs;
 }
 
-let dbPromise: Promise<IDBPDatabase | null> | null = null;
-
-function getDb(): Promise<IDBPDatabase | null> {
-  if (dbPromise) return dbPromise;
-  dbPromise = openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      const store = db.createObjectStore(STORE);
-      store.createIndex(TS_INDEX, 'ts');
-    },
-  }).catch(() => null); // IndexedDB unavailable → null, callers treat as miss/no-op
-  return dbPromise;
-}
+const exportDb = createDbAccessor({
+  name: DB_NAME,
+  version: DB_VERSION,
+  upgrade(db) {
+    const store = db.createObjectStore(STORE);
+    store.createIndex(TS_INDEX, 'ts');
+  },
+  // IndexedDB unavailable → null, callers treat as miss/no-op
+  onUnavailable: () => null,
+});
 
 /**
  * Recursively key-sorted JSON so logically-equal param objects stringify
@@ -107,7 +106,7 @@ export function buildExportCacheKey(
 /** Read one cached export, touching its recency. Returns undefined on miss/error. */
 export async function getCachedExport(key: string): Promise<ArrayBuffer | undefined> {
   try {
-    const db = await getDb();
+    const db = await exportDb.get();
     if (!db) return undefined;
     const entry = (await db.get(STORE, key)) as CacheEntry | undefined;
     if (!entry) return undefined;
@@ -146,7 +145,7 @@ export async function putCachedExports(
 ): Promise<void> {
   if (entries.length === 0) return;
   try {
-    const db = await getDb();
+    const db = await exportDb.get();
     if (!db) return;
     {
       const tx = db.transaction(STORE, 'readwrite');
@@ -188,7 +187,7 @@ async function evictIfNeeded(db: IDBPDatabase): Promise<void> {
 /** Clear the entire export cache (exposed for tests / settings "clear storage"). */
 export async function clearExportCache(): Promise<void> {
   try {
-    const db = await getDb();
+    const db = await exportDb.get();
     if (!db) return;
     await db.clear(STORE);
   } catch {

--- a/src/features/bin-designer/storage/designerDb.ts
+++ b/src/features/bin-designer/storage/designerDb.ts
@@ -7,7 +7,8 @@
  * versions.
  */
 
-import { openDB, type IDBPDatabase } from 'idb';
+import type { IDBPDatabase } from 'idb';
+import { createDbAccessor } from '@/core/storage/backends/openSingleton';
 
 const DB_NAME = 'gridfinity-designer-v1';
 
@@ -20,46 +21,31 @@ const DB_VERSION = 2;
 export const DESIGNS_STORE = 'designs';
 export const DESIGN_VERSIONS_STORE = 'designVersions';
 
-let dbInstance: IDBPDatabase | null = null;
-
-export async function getDb(): Promise<IDBPDatabase> {
-  if (dbInstance) {
-    return dbInstance;
-  }
-
-  const db = await openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      if (!db.objectStoreNames.contains(DESIGNS_STORE)) {
-        const store = db.createObjectStore(DESIGNS_STORE, { keyPath: 'id' });
-        store.createIndex('updatedAt', 'updatedAt');
-      }
-      if (!db.objectStoreNames.contains(DESIGN_VERSIONS_STORE)) {
-        const store = db.createObjectStore(DESIGN_VERSIONS_STORE, { keyPath: 'id' });
-        // Every read is "the versions of one design", so the index carries the
-        // whole access pattern; `createdAt` ordering is done in memory because a
-        // design's list is bounded by MAX_VERSIONS_PER_DESIGN.
-        store.createIndex('designId', 'designId');
-      }
-    },
-  });
-
-  // Clear cached instance if the browser closes the connection unexpectedly
-  db.addEventListener('close', () => {
-    if (dbInstance === db) {
-      dbInstance = null;
+const designerDb = createDbAccessor({
+  name: DB_NAME,
+  version: DB_VERSION,
+  upgrade(db) {
+    if (!db.objectStoreNames.contains(DESIGNS_STORE)) {
+      const store = db.createObjectStore(DESIGNS_STORE, { keyPath: 'id' });
+      store.createIndex('updatedAt', 'updatedAt');
     }
-  });
+    if (!db.objectStoreNames.contains(DESIGN_VERSIONS_STORE)) {
+      const store = db.createObjectStore(DESIGN_VERSIONS_STORE, { keyPath: 'id' });
+      // Every read is "the versions of one design", so the index carries the
+      // whole access pattern; `createdAt` ordering is done in memory because a
+      // design's list is bounded by MAX_VERSIONS_PER_DESIGN.
+      store.createIndex('designId', 'designId');
+    }
+  },
+});
 
-  dbInstance = db;
-  return dbInstance;
+export function getDb(): Promise<IDBPDatabase> {
+  return designerDb.get();
 }
 
 /**
  * Close the database connection (for testing/cleanup).
  */
 export function closeDesignerDb(): void {
-  if (dbInstance) {
-    dbInstance.close();
-    dbInstance = null;
-  }
+  designerDb.close();
 }

--- a/src/shared/generation/meshPersistence.ts
+++ b/src/shared/generation/meshPersistence.ts
@@ -17,8 +17,7 @@
  * the background regeneration immediately replaces.
  */
 
-import { openDB } from 'idb';
-import type { IDBPDatabase } from 'idb';
+import { createDbAccessor } from '@/core/storage/backends/openSingleton';
 import type { BinParams } from '@/shared/types/bin';
 import type { GridfinityItem } from '@/shared/types/item';
 import type { KernelName } from '@/shared/generation/bridge';
@@ -126,43 +125,19 @@ function nextStamp(): number {
   return lastStamp;
 }
 
-let dbInstance: IDBPDatabase | null = null;
-let openPromise: Promise<IDBPDatabase> | null = null;
-
-async function openMeshDb(): Promise<IDBPDatabase> {
-  const db = await openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      if (!db.objectStoreNames.contains(BIN_MESHES_STORE)) {
-        db.createObjectStore(BIN_MESHES_STORE, { keyPath: 'key' });
-      }
-      if (!db.objectStoreNames.contains(META_STORE)) {
-        const meta = db.createObjectStore(META_STORE, { keyPath: 'key' });
-        meta.createIndex('byTs', 'ts', { unique: false });
-      }
-    },
-  });
-
-  // Drop the cached handle if the browser closes the connection (tab eviction,
-  // a version change from another tab) so the next call reopens cleanly.
-  db.addEventListener('close', () => {
-    if (dbInstance === db) dbInstance = null;
-  });
-
-  return db;
-}
-
-async function getDb(): Promise<IDBPDatabase> {
-  if (dbInstance) return dbInstance;
-  openPromise ??= openMeshDb()
-    .then((db) => {
-      dbInstance = db;
-      return db;
-    })
-    .finally(() => {
-      openPromise = null;
-    });
-  return openPromise;
-}
+const meshDb = createDbAccessor({
+  name: DB_NAME,
+  version: DB_VERSION,
+  upgrade(db) {
+    if (!db.objectStoreNames.contains(BIN_MESHES_STORE)) {
+      db.createObjectStore(BIN_MESHES_STORE, { keyPath: 'key' });
+    }
+    if (!db.objectStoreNames.contains(META_STORE)) {
+      const meta = db.createObjectStore(META_STORE, { keyPath: 'key' });
+      meta.createIndex('byTs', 'ts', { unique: false });
+    }
+  },
+});
 
 /**
  * Stable JSON serialization: keys sorted at every level so params from Immer /
@@ -228,7 +203,7 @@ export function itemMeshCacheKey(item: GridfinityItem, kernel: KernelName): stri
 export async function loadPersistedBinMesh(key: string): Promise<MeshData | null> {
   if (!hasIndexedDb()) return null;
   try {
-    const db = await getDb();
+    const db = await meshDb.get();
     const stored = (await db.get(BIN_MESHES_STORE, key)) as StoredMesh | undefined;
     return stored?.mesh ?? null;
   } catch (e) {
@@ -260,7 +235,7 @@ export function savePersistedBinMesh(key: string, mesh: MeshData): void {
  */
 async function persistMesh(key: string, mesh: MeshData): Promise<void> {
   try {
-    const db = await getDb();
+    const db = await meshDb.get();
     const meta: MeshMeta = { key, byteSize: meshDataByteSize(mesh), ts: nextStamp() };
 
     const writeTx = db.transaction([BIN_MESHES_STORE, META_STORE], 'readwrite');
@@ -301,7 +276,5 @@ export function __setMaxCacheBytesForTests(bytes = 64 * 1024 * 1024): void {
 
 /** Test-only: close and drop the cached connection so the DB can be deleted. */
 export function __resetMeshDbForTests(): void {
-  if (dbInstance) dbInstance.close();
-  dbInstance = null;
-  openPromise = null;
+  meshDb.close();
 }


### PR DESCRIPTION
Six modules each hand-rolled the same "open the database once and cache the handle" block. They were not the same block. Sorting them by what they protected against:

| Site | Deduped concurrent opens | Reattached after `close` | Degraded when IDB is unavailable |
| --- | --- | --- | --- |
| `core/cqrs/store/eventStore.ts` | yes | yes | rejects |
| `shared/generation/meshPersistence.ts` | yes | yes | rejects |
| `core/sync/outbox.ts` | no | yes | rejects |
| `features/bin-designer/storage/designerDb.ts` | no | yes | rejects |
| `features/baseplate/storage/BaseplateStorage.ts` | no | yes | rejects |
| `features/baseplate/utils/exportCache.ts` | yes (cached the promise) | no | resolves `null` |

`createDbAccessor()` in `src/core/storage/backends/openSingleton.ts` does all three, so each database now gets the union rather than whichever subset its author happened to write.

## What each site gains

- **outbox, designerDb, BaseplateStorage**: concurrent-open dedupe. Every entry point in these modules is `const db = await getDb()`, so a burst of parallel calls (drain the outbox, list designs while a save lands) could each start their own `openDB` before any of them finished and cached one.
- **exportCache**: reattach after a browser-initiated `close`. It cached the open promise forever, so after a mobile background-tab eviction or a cross-tab version change every later export read and wrote through a dead connection for the rest of the session.
- **eventStore, meshPersistence**: no behavior change; they already had both. Their versions are what the shared accessor was modelled on.
- **All six**: `close()` now clears the in-flight open too, and an open still in flight when `close()` lands no longer writes its result back into the state that was just cleared.

## Deliberately not unified

- **exportCache keeps the null degrade.** It is a best-effort byte cache whose callers treat "no database" as a miss, so it passes `onUnavailable: () => null` and the other five keep rejecting. The stickiness is preserved as well: the first failed open disables the cache for the session instead of retrying on every export, exactly as the old cached-`null`-promise did.
- **`versionchange` is still unhandled.** None of the six listened for it, so nothing here starts to.
- **`backends/indexedDB.ts` (the layouts database) is untouched.** It is a seventh copy of the pattern, and moving it belongs with its own test pass rather than riding along here.

`createDbAccessor` is also re-exported from the `@/core/storage` facade so a future consumer can route through the public entry point; `backends/openSingleton` imports only `idb`, so the barrel picks it up with no cycle risk. The six sites keep the deep import that every other `backends/*` consumer in the repo already uses.

Database names, versions and every upgrade callback move over verbatim, so no stored data is revisioned or re-migrated. The test hooks callers already import keep their names: `closeDesignerDb`, `closeBaseplateDb`, `__resetForTests`, `__resetMeshDbForTests`.

## Testing

- `pnpm run test:run` over the six touched areas plus their consumers (baseplate, core/storage, bin-designer storage/sync/hooks/VersionHistory): 193 files, 2574 tests passed, 0 failed. Every existing test passes unchanged; none needed an edit.
- New `src/core/storage/backends/openSingleton.test.ts` (7 tests) covers the upgrade callback running, one connection shared across concurrent `get()`, reopen after a `close` event, reopen after `close()`, `invalidate()` evicting only the connection it is given, reject-then-retry on the default path, and the sticky null degrade with `onUnavailable`.
- `pnpm run typecheck`: clean.
- `npx eslint` on the eight touched files: 0 errors, 0 warnings.

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P
