### PR TITLE
ci(release): fail the annotation curl on HTTP errors so the warning fires

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
             echo "POSTHOG_ANNOTATION_API_KEY not set; skipping release annotation."
             exit 0
           fi
-          curl --silent --show-error --max-time 30 \
+          curl --silent --show-error --fail-with-body --max-time 30 \
             -H "Authorization: Bearer $POSTHOG_ANNOTATION_API_KEY" \
             -H "Content-Type: application/json" \
             -d "{\"content\": \"v$VERSION\", \"date_marker\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"scope\": \"project\", \"creation_type\": \"GIT\"}" \


### PR DESCRIPTION
## What

Follow-up to the release annotation step: without `--fail`, curl exits 0 on HTTP 4xx/5xx, so a rejected annotation silently "succeeded" and the `|| warning` fallback never fired, contradicting the step's stated degrade-to-warning behavior. `--fail-with-body` makes HTTP errors exit non-zero (triggering the warning) while still printing the response body in the log for diagnosis. Flagged by review on the original PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

