### PR TITLE
refactor(community): one report-body contract for design and print reports

### DIFF
--- a/api/community/[id].ts
+++ b/api/community/[id].ts
@@ -29,7 +29,7 @@ import { checkRateLimit, getClientIP, getRedis } from '../lib/rateLimit.js';
 import { readSession, requireSession } from '../lib/session.js';
 import type { SessionRecord } from '../lib/session.js';
 import { logger } from '../lib/logger.js';
-import { checkText, REPORT_THRESHOLD } from '../lib/contentFilter.js';
+import { REPORT_THRESHOLD } from '../lib/contentFilter.js';
 import {
   ErrorCode,
   methodNotAllowed,
@@ -64,8 +64,8 @@ import type {
   CommunityHiddenReason,
 } from '../lib/communityStore.js';
 import {
-  COMMUNITY_REPORT_NOTE_MAX_LENGTH,
   COMMUNITY_REPORT_REASONS,
+  parseReportBody,
   validateCommunityPublish,
 } from '../lib/communityValidation.js';
 import { readCommunityPrints } from '../lib/communityPrintStore.js';
@@ -883,22 +883,11 @@ async function handleReportAction(
   const rateLimit = await checkRateLimit(session.userId, 'community.report');
   if (!rateLimit.allowed) return rateLimited(res, rateLimit.retryAfterSeconds);
 
-  const { reason, note } = body;
-  if (!isString(reason) || !(COMMUNITY_REPORT_REASONS as readonly string[]).includes(reason)) {
-    return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'Invalid report reason');
+  const parsed = parseReportBody(body);
+  if (!parsed.ok) {
+    return sendError(res, parsed.status, parsed.code, parsed.message);
   }
-  const reportReason = reason as CommunityReportReason;
-  let reportNote = '';
-  if (note !== undefined) {
-    if (!isString(note)) {
-      return sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'note must be a string');
-    }
-    // The slice bounds the string before the filter's ReDoS-prone regexes run.
-    reportNote = note.slice(0, COMMUNITY_REPORT_NOTE_MAX_LENGTH);
-    if (reportNote !== '' && !checkText(reportNote).passed) {
-      return sendError(res, 400, ErrorCode.CONTENT_BLOCKED, 'note contains prohibited content');
-    }
-  }
+  const { reason: reportReason, note: reportNote } = parsed;
 
   const redis = getRedis();
   if (!redis) return serviceUnavailable(res);

--- a/api/community/prints.ts
+++ b/api/community/prints.ts
@@ -19,7 +19,7 @@ import { logger } from '../lib/logger.js';
 import { checkRateLimit, getClientIP, getRedis } from '../lib/rateLimit.js';
 import { readSession, requireSession } from '../lib/session.js';
 import type { SessionRecord } from '../lib/session.js';
-import { checkText, REPORT_THRESHOLD } from '../lib/contentFilter.js';
+import { REPORT_THRESHOLD } from '../lib/contentFilter.js';
 import {
   ErrorCode,
   methodNotAllowed,
@@ -40,11 +40,7 @@ import {
   communityPrintedKey,
   communityPrintsKey,
 } from '../lib/redisKeys.js';
-import {
-  COMMUNITY_REPORT_NOTE_MAX_LENGTH,
-  COMMUNITY_REPORT_REASONS,
-} from '../lib/communityValidation.js';
-import type { CommunityReportReason } from '../lib/communityValidation.js';
+import { parseReportBody } from '../lib/communityValidation.js';
 import {
   communityPrintsEnabled,
   hasPrintSubstance,
@@ -627,34 +623,17 @@ async function handleReport(
     return;
   }
 
-  if (
-    !isString(body.reason) ||
-    !(COMMUNITY_REPORT_REASONS as readonly string[]).includes(body.reason)
-  ) {
-    sendError(
-      res,
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      `reason must be one of: ${COMMUNITY_REPORT_REASONS.join(', ')}`
-    );
+  const parsed = parseReportBody(body);
+  if (!parsed.ok) {
+    sendError(res, parsed.status, parsed.code, parsed.message);
     return;
   }
-  const reason = body.reason as CommunityReportReason;
+  const { reason } = parsed;
 
-  if (body.note !== undefined && body.note !== null) {
-    if (!isString(body.note) || body.note.length > COMMUNITY_REPORT_NOTE_MAX_LENGTH) {
-      sendError(
-        res,
-        400,
-        ErrorCode.VALIDATION_ERROR,
-        `note must be at most ${COMMUNITY_REPORT_NOTE_MAX_LENGTH} characters`
-      );
-      return;
-    }
-    if (body.note !== '' && !checkText(body.note).passed) {
-      sendError(res, 400, ErrorCode.VALIDATION_ERROR, 'note contains prohibited content');
-      return;
-    }
+  // A3: a deny-listed account keeps no report powers, matching design reports.
+  if ((await redis.sismember(communityDenylistKey(), session.userId)) === 1) {
+    sendError(res, 403, ErrorCode.UNAUTHORIZED, 'This action is not available for this account.');
+    return;
   }
 
   const existing = await readCommunityPrint(redis, designId, targetPublicId);

--- a/api/community/prints.ts
+++ b/api/community/prints.ts
@@ -630,12 +630,6 @@ async function handleReport(
   }
   const { reason } = parsed;
 
-  // A3: a deny-listed account keeps no report powers, matching design reports.
-  if ((await redis.sismember(communityDenylistKey(), session.userId)) === 1) {
-    sendError(res, 403, ErrorCode.UNAUTHORIZED, 'This action is not available for this account.');
-    return;
-  }
-
   const existing = await readCommunityPrint(redis, designId, targetPublicId);
   if (existing === null || existing.status !== 'live') {
     sendError(res, 404, ErrorCode.NOT_FOUND, 'Print report not found');

--- a/api/lib/communityValidation.test.ts
+++ b/api/lib/communityValidation.test.ts
@@ -24,6 +24,7 @@ import {
   communityRequiresDescription,
   deriveCommunityTechniques,
   parseCommunityLineage,
+  parseReportBody,
   validateCommunityPublish,
 } from './communityValidation.js';
 
@@ -513,6 +514,48 @@ describe('parseCommunityLineage', () => {
 
   it('rejects blocked content in snapshot names', () => {
     expect(parseCommunityLineage({ ...LINEAGE, parentName: 'cool <script name' }).ok).toBe(false);
+  });
+});
+
+describe('parseReportBody', () => {
+  it('accepts a valid reason with no note', () => {
+    expect(parseReportBody({ reason: 'spam' })).toEqual({ ok: true, reason: 'spam', note: '' });
+  });
+
+  it('treats a null note as absent', () => {
+    expect(parseReportBody({ reason: 'spam', note: null })).toEqual({
+      ok: true,
+      reason: 'spam',
+      note: '',
+    });
+  });
+
+  it('rejects an unknown reason with the enumerating message', () => {
+    const parsed = parseReportBody({ reason: 'other' });
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.status).toBe(400);
+    expect(parsed.message).toContain('inappropriate');
+  });
+
+  it('rejects a non-string note', () => {
+    expect(parseReportBody({ reason: 'spam', note: 42 }).ok).toBe(false);
+  });
+
+  it('truncates an over-length note instead of rejecting it', () => {
+    const parsed = parseReportBody({
+      reason: 'spam',
+      note: 'the lid does not fit the bin. '.repeat(30),
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.note).toHaveLength(COMMUNITY_REPORT_NOTE_MAX_LENGTH);
+  });
+
+  it('returns CONTENT_BLOCKED for a filtered note', () => {
+    const parsed = parseReportBody({ reason: 'spam', note: 'visit https://spam.example now' });
+    if (parsed.ok) return;
+    expect(parsed.code).toBe('CONTENT_BLOCKED');
   });
 });
 

--- a/api/lib/communityValidation.test.ts
+++ b/api/lib/communityValidation.test.ts
@@ -554,6 +554,7 @@ describe('parseReportBody', () => {
 
   it('returns CONTENT_BLOCKED for a filtered note', () => {
     const parsed = parseReportBody({ reason: 'spam', note: 'visit https://spam.example now' });
+    expect(parsed.ok).toBe(false);
     if (parsed.ok) return;
     expect(parsed.code).toBe('CONTENT_BLOCKED');
   });

--- a/api/lib/communityValidation.ts
+++ b/api/lib/communityValidation.ts
@@ -16,6 +16,7 @@ import {
   validateAssemblyStructure,
 } from './assemblyValidation.js';
 import { isValidShareId } from './shared.js';
+import type { ErrorCodeType } from './shared.js';
 import { isObject, isString, validationError } from './validationUtils.js';
 import {
   classifyCommunityDescription,
@@ -51,6 +52,49 @@ export type CommunityCategory = (typeof COMMUNITY_CATEGORIES)[number];
 export const COMMUNITY_REPORT_REASONS = ['inappropriate', 'spam', 'broken', 'stolen'] as const;
 export type CommunityReportReason = (typeof COMMUNITY_REPORT_REASONS)[number];
 export const COMMUNITY_REPORT_NOTE_MAX_LENGTH = 500;
+
+export type ParsedReportBody =
+  | { readonly ok: true; readonly reason: CommunityReportReason; readonly note: string }
+  | {
+      readonly ok: false;
+      readonly status: number;
+      readonly code: ErrorCodeType;
+      readonly message: string;
+    };
+
+/**
+ * One report-body contract for design reports and print reports: same reason
+ * allowlist, same note policy (absent or null means no note, over-length is
+ * truncated BEFORE the content filter's ReDoS-prone regexes run, blocked
+ * content is CONTENT_BLOCKED).
+ */
+export function parseReportBody(body: Record<string, unknown>): ParsedReportBody {
+  const { reason, note } = body;
+  if (!isString(reason) || !(COMMUNITY_REPORT_REASONS as readonly string[]).includes(reason)) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: `reason must be one of: ${COMMUNITY_REPORT_REASONS.join(', ')}`,
+    };
+  }
+  let parsedNote = '';
+  if (note !== undefined && note !== null) {
+    if (!isString(note)) {
+      return { ok: false, status: 400, code: 'VALIDATION_ERROR', message: 'note must be a string' };
+    }
+    parsedNote = note.slice(0, COMMUNITY_REPORT_NOTE_MAX_LENGTH);
+    if (parsedNote !== '' && !checkText(parsedNote).passed) {
+      return {
+        ok: false,
+        status: 400,
+        code: 'CONTENT_BLOCKED',
+        message: 'note contains prohibited content',
+      };
+    }
+  }
+  return { ok: true, reason: reason as CommunityReportReason, note: parsedNote };
+}
 
 /**
  * Description-required publish policy toggle. Default ON; set


### PR DESCRIPTION
## Summary

`handleReportAction` (design reports, `api/community/[id].ts`) and `handleReport` (print reports, `api/community/prints.ts`) had forked into different HTTP contracts for the same user input:

| Input | Design reports | Print reports (before) |
|---|---|---|
| Over-length note | truncated to 500 | 400 |
| Blocked note content | `CONTENT_BLOCKED` | `VALIDATION_ERROR` |
| `note: null` | 400 (failed isString) | allowed |
| Invalid reason message | "Invalid report reason" | enumerates valid reasons |

New `parseReportBody` in `api/lib/communityValidation.ts` owns the shared policy, converging on the more forgiving/specific behaviors: truncate the note (bounding it before the filter's ReDoS-prone regexes run, preserving that ordering guarantee), `CONTENT_BLOCKED` for filtered content, null treated as absent, and the enumerating reason message. The deny-list turned out to already be enforced for prints via requirePrinter, so no change was needed there.

The storage differences (pipeline with per-command error checks vs sequential sadd) are deliberate per-store shapes and stay at the call sites.

## Testing

- Six new unit tests for `parseReportBody` (valid, null note, unknown reason, non-string note, truncation, blocked-content code)
- `api/community` suites: 310 tests pass; `communityValidation` suite: 53 pass
- `pnpm run typecheck` clean, ESLint 0 errors

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


