### PR TITLE
refactor(sync): share the assembly validation branch between endpoints

### DIFF
--- a/api/lib/assemblyValidation.ts
+++ b/api/lib/assemblyValidation.ts
@@ -14,6 +14,8 @@ import {
 } from './validationUtils.js';
 import { validateFeatureColors } from './designerValidation.js';
 import { checkText } from './contentFilter.js';
+import { CONSTRAINTS } from './designerValidationConstants.js';
+import { ErrorCode, type ErrorCodeType } from './shared.js';
 
 const MAX_ASSEMBLY_PARTS = 256;
 const MAX_ASSEMBLY_DEPTH = 8;
@@ -533,4 +535,35 @@ export function sanitizeAssemblyContent(
       SOCKET_HEIGHT_MM + (flatRise - SOCKET_HEIGHT_MM) * Math.cos(rad) + along * Math.sin(rad);
   }
   return { envelope, structure, riseMm };
+}
+
+export type AssemblyContentResult =
+  | { ok: true; envelope: unknown; structure: unknown }
+  | { ok: false; status: number; error: string; code: ErrorCodeType };
+
+const rejectContent = (error: string): AssemblyContentResult => ({
+  ok: false,
+  status: 400,
+  error,
+  code: ErrorCode.VALIDATION_ERROR,
+});
+
+/**
+ * `preBytes` is the caller's to measure: the cap guards CPU before the
+ * validators walk the tree, and each endpoint wraps the content differently
+ * (a design counts its sanitized name and tags, a version counts its raw
+ * body), so no single measurement fits both.
+ */
+export function validateAssemblyContent(
+  content: { envelope: unknown; structure: unknown },
+  options: { preBytes: number; sizeLabel: string }
+): AssemblyContentResult {
+  if (options.preBytes > CONSTRAINTS.MAX_PAYLOAD_BYTES) {
+    return rejectContent(`${options.sizeLabel} exceeds the size limit`);
+  }
+  const envelopeCheck = validateAssemblyEnvelope(content.envelope);
+  if (!envelopeCheck.valid) return rejectContent(envelopeCheck.error.message);
+  const structureCheck = validateAssemblyStructure(content.structure);
+  if (!structureCheck.valid) return rejectContent(structureCheck.error.message);
+  return { ok: true, envelope: content.envelope, structure: content.structure };
 }

--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -10,7 +10,6 @@ import type { VercelResponse } from '@vercel/node';
  * - Shared type definitions
  */
 
-/** Max length for a user-visible name on a synced resource. */
 export const MAX_NAME_LENGTH = 100;
 
 /**

--- a/api/lib/shared.ts
+++ b/api/lib/shared.ts
@@ -10,6 +10,9 @@ import type { VercelResponse } from '@vercel/node';
  * - Shared type definitions
  */
 
+/** Max length for a user-visible name on a synced resource. */
+export const MAX_NAME_LENGTH = 100;
+
 /**
  * Validate a layout/share ID format.
  * Supports multiple formats for backwards compatibility:

--- a/api/sync/baseplates/[id].ts
+++ b/api/sync/baseplates/[id].ts
@@ -1,4 +1,4 @@
-import { ErrorCode, isValidShareId } from '../../lib/shared.js';
+import { ErrorCode, isValidShareId, MAX_NAME_LENGTH } from '../../lib/shared.js';
 import { validateBaseplateShare } from '../../lib/baseplateValidation.js';
 import { sanitizeString } from '../../lib/validation.js';
 import { createSyncResourceHandler } from '../lib/resourceHandler.js';
@@ -7,9 +7,6 @@ export const SCHEMA_VERSION = 1 as const;
 
 /** The PUT body / GET envelope key for this resource; mirrors `PAYLOAD_KEY.baseplates` in src/core/sync/payloadKey.ts. */
 export const PAYLOAD_KEY = 'baseplate' as const;
-
-/** Max length for a user-visible baseplate name (mirrors the designs cap). */
-const MAX_NAME_LENGTH = 100;
 
 interface BaseplateEnvelope {
   /** `{ name, params }` wrapper; readers parse with `unwrapBaseplatePayload`. */

--- a/api/sync/designVersions/[id].ts
+++ b/api/sync/designVersions/[id].ts
@@ -1,10 +1,6 @@
-import { ErrorCode, isValidShareId } from '../../lib/shared.js';
+import { ErrorCode, isValidShareId, MAX_NAME_LENGTH } from '../../lib/shared.js';
 import { validateDesignerShare } from '../../lib/designerValidation.js';
-import {
-  validateAssemblyEnvelope,
-  validateAssemblyStructure,
-} from '../../lib/assemblyValidation.js';
-import { CONSTRAINTS } from '../../lib/designerValidationConstants.js';
+import { validateAssemblyContent } from '../../lib/assemblyValidation.js';
 import { sanitizeString } from '../../lib/validation.js';
 import { createSyncResourceHandler } from '../lib/resourceHandler.js';
 
@@ -12,9 +8,6 @@ export const SCHEMA_VERSION = 1 as const;
 
 /** The PUT body / GET envelope key for this resource; mirrors `PAYLOAD_KEY.designVersions` in src/core/sync/payloadKey.ts. */
 export const PAYLOAD_KEY = 'designVersion' as const;
-
-/** Mirrors the design-name cap; a version name is shown in the same lists. */
-const MAX_NAME_LENGTH = 100;
 
 /** Mirrors `DesignVersionOrigin` on the client. */
 const ORIGINS = ['manual', 'pre-restore'] as const;
@@ -99,36 +92,13 @@ export default createSyncResourceHandler<DesignVersionEnvelope>({
       MAX_NAME_LENGTH
     );
 
-    // Non-bin kinds carry envelope + structure and no params, exactly as the
-    // design endpoint's assembly branch does.
     if (inner.kind !== undefined && inner.kind !== 'bin') {
       const preBytes = Buffer.byteLength(JSON.stringify(body), 'utf8');
-      if (preBytes > CONSTRAINTS.MAX_PAYLOAD_BYTES) {
-        return {
-          ok: false,
-          status: 400,
-          error: 'design version exceeds the size limit',
-          code: ErrorCode.VALIDATION_ERROR,
-        };
-      }
-      const envelopeCheck = validateAssemblyEnvelope(inner.envelope);
-      if (!envelopeCheck.valid) {
-        return {
-          ok: false,
-          status: 400,
-          error: envelopeCheck.error.message,
-          code: ErrorCode.VALIDATION_ERROR,
-        };
-      }
-      const structureCheck = validateAssemblyStructure(inner.structure);
-      if (!structureCheck.valid) {
-        return {
-          ok: false,
-          status: 400,
-          error: structureCheck.error.message,
-          code: ErrorCode.VALIDATION_ERROR,
-        };
-      }
+      const assembly = validateAssemblyContent(
+        { envelope: inner.envelope, structure: inner.structure },
+        { preBytes, sizeLabel: 'design version' }
+      );
+      if (!assembly.ok) return assembly;
       const stored = {
         designId,
         name,
@@ -138,8 +108,8 @@ export default createSyncResourceHandler<DesignVersionEnvelope>({
         content: {
           name: contentName,
           kind: inner.kind,
-          envelope: inner.envelope,
-          structure: inner.structure,
+          envelope: assembly.envelope,
+          structure: assembly.structure,
         },
       };
       return {

--- a/api/sync/designs/[id].ts
+++ b/api/sync/designs/[id].ts
@@ -1,10 +1,6 @@
-import { ErrorCode, isValidShareId } from '../../lib/shared.js';
+import { ErrorCode, isValidShareId, MAX_NAME_LENGTH } from '../../lib/shared.js';
 import { validateDesignerShare, sanitizeTags } from '../../lib/designerValidation.js';
-import {
-  validateAssemblyEnvelope,
-  validateAssemblyStructure,
-} from '../../lib/assemblyValidation.js';
-import { CONSTRAINTS } from '../../lib/designerValidationConstants.js';
+import { validateAssemblyContent } from '../../lib/assemblyValidation.js';
 import { sanitizeString } from '../../lib/validation.js';
 import { createSyncResourceHandler } from '../lib/resourceHandler.js';
 
@@ -12,9 +8,6 @@ export const SCHEMA_VERSION = 1 as const;
 
 /** The PUT body / GET envelope key for this resource; mirrors `PAYLOAD_KEY.designs` in src/core/sync/payloadKey.ts. */
 export const PAYLOAD_KEY = 'design' as const;
-
-/** Max length for a user-visible design name (mirrors `inserts[].label`). */
-const MAX_NAME_LENGTH = 100;
 
 /** Generous cap for lineage ids (community ids are 12 chars today). */
 const MAX_LINEAGE_ID_LENGTH = 64;
@@ -329,37 +322,16 @@ export default createSyncResourceHandler<DesignEnvelope>({
     // drifts from what the blob holds.
     if (unwrapped.kind === 'assembly') {
       const preBytes = Buffer.byteLength(JSON.stringify({ ...unwrapped, name, tags }), 'utf8');
-      if (preBytes > CONSTRAINTS.MAX_PAYLOAD_BYTES) {
-        return {
-          ok: false,
-          status: 400,
-          error: 'assembly design exceeds the size limit',
-          code: ErrorCode.VALIDATION_ERROR,
-        };
-      }
-      const envelopeCheck = validateAssemblyEnvelope(unwrapped.envelope);
-      if (!envelopeCheck.valid) {
-        return {
-          ok: false,
-          status: 400,
-          error: envelopeCheck.error.message,
-          code: ErrorCode.VALIDATION_ERROR,
-        };
-      }
-      const structureCheck = validateAssemblyStructure(unwrapped.structure);
-      if (!structureCheck.valid) {
-        return {
-          ok: false,
-          status: 400,
-          error: structureCheck.error.message,
-          code: ErrorCode.VALIDATION_ERROR,
-        };
-      }
+      const assembly = validateAssemblyContent(
+        { envelope: unwrapped.envelope, structure: unwrapped.structure },
+        { preBytes, sizeLabel: 'assembly design' }
+      );
+      if (!assembly.ok) return assembly;
       const stored = {
         name,
         kind: 'assembly' as const,
-        envelope: unwrapped.envelope,
-        structure: unwrapped.structure,
+        envelope: assembly.envelope,
+        structure: assembly.structure,
         tags,
         ...(publishedId !== undefined ? { publishedId } : {}),
         ...(lineage !== undefined ? { lineage } : {}),

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -413,6 +413,7 @@ export default defineConfig([
       'api/ml-telemetry.ts', // pre-split (2268 LOC)
       'api/lib/mlTelemetry/aggregators.ts', // post-split equivalent
       // Cohesive single-concern modules where splitting would harm readability:
+      'api/lib/assemblyValidation.ts', // one hand-written mirror of the client assembly schema; its bounds, validators and sanitizer must move together
       'src/shared/utils/validation.ts', // type guards + import/salvage validation pipeline (728 LOC); concerns are interleaved by design
       'src/features/generation/bridge/GenerationBridge.ts', // single GenerationBridge class with the full worker-message protocol
       'src/features/generation/worker/generators/baseplateGenerator.ts', // single linear generation pipeline


### PR DESCRIPTION
## What was duplicated

`api/sync/designs/[id].ts` and `api/sync/designVersions/[id].ts` each carried the
same assembly branch, about 45 lines apiece: the `MAX_PAYLOAD_BYTES` cap,
`validateAssemblyEnvelope`, `validateAssemblyStructure`, and four hand-rolled 400
objects. The version endpoint even documented the copy in a comment.

`validateAssemblyContent` in `api/lib/assemblyValidation.ts` (which already owns
both validators) now runs the three checks in order and returns a discriminated
result:

```ts
validateAssemblyContent(
  content: { envelope: unknown; structure: unknown },
  options: { preBytes: number; sizeLabel: string }
): { ok: true; envelope: unknown; structure: unknown }
 | { ok: false; status: number; error: string; code: ErrorCodeType }
```

The failure shape is the endpoints' own `buildPut` error shape, so a call site is
`if (!assembly.ok) return assembly;`, and the stored object reads `envelope` and
`structure` back off the validated result.

## What stays deliberately different

- **`preBytes`** is measured at each call site and passed in. A design counts
  `{ ...unwrapped, name, tags }` (its sanitized fields), a version counts the raw
  body. Both counts are correct for their own payload, so neither one belongs
  inside the shared function.
- **The size-limit wording** is the `sizeLabel` parameter, so the two responses
  stay byte-identical: `assembly design exceeds the size limit` and
  `design version exceeds the size limit`.
- **`SCHEMA_VERSION`** stays declared per endpoint. Each resource's stored shape
  bumps independently.

## Also

`MAX_NAME_LENGTH = 100` was declared three times (designs, designVersions,
baseplates), each with a comment claiming it mirrored the others. One declaration
now lives in `api/lib/shared.ts`.

The extraction pushes `assemblyValidation.ts` from 489 to 511 counted lines, so
it joins the existing `max-lines` allowlist in `eslint.config.js` under the
cohesive-module rationale: the file is one hand-written mirror of the client
assembly schema, and its bounds, validators and sanitizer have to move together.

## Testing

- `pnpm run test:run api` — 2115 passed, 16 skipped, 64 files
- `pnpm run typecheck` — clean
- `npx eslint` on the five touched files plus `eslint.config.js` — 0 errors. The
  one remaining warning (`no-unnecessary-condition` at line 424) is unchanged
  from main.

No behavior change: same checks, same order, same status codes, same messages.

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

