### PR TITLE
fix(baseplate): guarantee the fit-test coupon font and correct its labelling copy

### DIFF
--- a/src/features/generation/worker/generators/connectorSample.scenario.test.ts
+++ b/src/features/generation/worker/generators/connectorSample.scenario.test.ts
@@ -15,12 +15,19 @@ import { measureVolume } from 'brepjs';
 import type { ResolvedBaseplateParams } from '@/shared/types/bin';
 import { isOk } from '@/core/result';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
+import { GRIDFINITY } from '@/shared/constants/bin';
+import { loadTestFonts } from '@/test/loadTestFonts';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
-import { buildConnectorSampleTray, exportConnectorSample } from './connectorSample';
+import { buildConnectorSampleTray, exportConnectorSample, LABEL_DEPTH } from './connectorSample';
 
 beforeAll(async () => {
   await initBrepjs();
-}, 30000);
+  // The coupon offset labels emboss with jetbrains-mono; without it registered,
+  // buildTextSolid returns null and every coupon ships textless but still
+  // watertight — so the label assertion below is meaningless unless the font is
+  // loaded the way the worker loads it at init (issue #3945).
+  await loadTestFonts(['jetbrains-mono']);
+}, 60000);
 
 const defaults = (overrides: Partial<ResolvedBaseplateParams> = {}): ResolvedBaseplateParams => ({
   width: 2,
@@ -126,8 +133,8 @@ describe('connectorSample — fit-sample tray', () => {
     TEST_TIMEOUT_MS
   );
 
-  it.each([undefined, 'puzzle'] as const)(
-    'exports a watertight, bed-resting STL tray (%s)',
+  it.each([undefined, 'puzzle', 'dovetailKey', 'snapClip'] as const)(
+    'exports a watertight, bed-resting, labeled STL tray (%s)',
     async (style) => {
       const { data, fileName } = await exportConnectorSample(
         defaults({ connectorStyle: style }),
@@ -141,6 +148,13 @@ describe('connectorSample — fit-sample tray', () => {
       expect(stats.boundaryEdges, 'boundary edges').toBe(0);
       // Whole tray rests on the bed.
       expect(stats.minZ, 'rests on bed').toBeCloseTo(0, 1);
+      // The offset labels emboss above the coupon top face (couponHeight =
+      // SOCKET_HEIGHT with no magnet holes). A textless tray tops out at
+      // SOCKET_HEIGHT; the raised label lifts maxZ by LABEL_DEPTH. Guards issue
+      // #3945: watertightness alone passes even when every label silently drops.
+      expect(stats.maxZ, 'coupons carry raised labels').toBeGreaterThan(
+        GRIDFINITY.SOCKET_HEIGHT + LABEL_DEPTH / 2
+      );
     },
     TEST_TIMEOUT_MS
   );

--- a/src/features/generation/worker/generators/connectorSample.scenario.test.ts
+++ b/src/features/generation/worker/generators/connectorSample.scenario.test.ts
@@ -22,10 +22,9 @@ import { buildConnectorSampleTray, exportConnectorSample, LABEL_DEPTH } from './
 
 beforeAll(async () => {
   await initBrepjs();
-  // The coupon offset labels emboss with jetbrains-mono; without it registered,
-  // buildTextSolid returns null and every coupon ships textless but still
-  // watertight — so the label assertion below is meaningless unless the font is
-  // loaded the way the worker loads it at init (issue #3945).
+  // Without jetbrains-mono registered, buildTextSolid returns null and coupons
+  // ship textless but still watertight — so the label assertion below would pass
+  // on unlabeled output. Register it the way the worker does at init.
   await loadTestFonts(['jetbrains-mono']);
 }, 60000);
 
@@ -148,10 +147,9 @@ describe('connectorSample — fit-sample tray', () => {
       expect(stats.boundaryEdges, 'boundary edges').toBe(0);
       // Whole tray rests on the bed.
       expect(stats.minZ, 'rests on bed').toBeCloseTo(0, 1);
-      // The offset labels emboss above the coupon top face (couponHeight =
-      // SOCKET_HEIGHT with no magnet holes). A textless tray tops out at
-      // SOCKET_HEIGHT; the raised label lifts maxZ by LABEL_DEPTH. Guards issue
-      // #3945: watertightness alone passes even when every label silently drops.
+      // Watertightness alone passes even when every label silently drops, so
+      // assert the emboss landed: a textless tray tops out at couponHeight
+      // (SOCKET_HEIGHT, no magnet holes); a labeled one is LABEL_DEPTH higher.
       expect(stats.maxZ, 'coupons carry raised labels').toBeGreaterThan(
         GRIDFINITY.SOCKET_HEIGHT + LABEL_DEPTH / 2
       );

--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -106,7 +106,9 @@ const COUPON_FILLET = 1.4;
 const SEAM_GAP = 5;
 const COL_GAP = 7;
 const ROW_GAP = 10;
-const LABEL_DEPTH = 0.6;
+/** Raised-label height above the coupon top face. Exported so the scenario test
+ *  can assert the emboss actually landed (a textless coupon tops out lower). */
+export const LABEL_DEPTH = 0.6;
 const LABEL_MARGIN = 1.4;
 
 /** Widest offset label, e.g. "+0.05" / "-0.10" (5 glyphs); "0.00" is shorter. */

--- a/src/features/generation/worker/generators/connectorSample.ts
+++ b/src/features/generation/worker/generators/connectorSample.ts
@@ -106,8 +106,8 @@ const COUPON_FILLET = 1.4;
 const SEAM_GAP = 5;
 const COL_GAP = 7;
 const ROW_GAP = 10;
-/** Raised-label height above the coupon top face. Exported so the scenario test
- *  can assert the emboss actually landed (a textless coupon tops out lower). */
+/** Exported so the scenario test can tell a labeled coupon (top face raised by
+ *  this) from a textless one, which tops out at the bare coupon height. */
 export const LABEL_DEPTH = 0.6;
 const LABEL_MARGIN = 1.4;
 

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -43,6 +43,7 @@ import {
 } from '@/shared/utils/knifeRestPlan';
 import { exportSlideFitSample } from '../generators/slideFitSample';
 import { exportFitTestSlice } from '../generators/fitTestSlice';
+import { ensureFontsLoaded } from '../wasmInstantiator';
 import type { FaceGroupData } from '@/shared/types/generation';
 import { buildLid, buildStackPlate } from '../generators/lidBuilder';
 import { lidAnchorZ } from '../generators/lidConstants';
@@ -144,6 +145,12 @@ export async function handleExportConnectorSample(
   message: ExportConnectorSampleMessage
 ): Promise<void> {
   const payload = message.payload;
+  // The coupon offset labels emboss synchronously and drop silently if their
+  // face isn't registered. INIT loads the eager set, but a font fetch that
+  // failed at worker start is only ever retried by whoever asks for the family
+  // again — so this handler must, or a stale/missing font asset ships a tray of
+  // textless coupons. Mirrors handleGenerate.
+  await ensureFontsLoaded(['jetbrains-mono']);
   await runExport(
     payload.requestId,
     'BASEPLATE_EXPORT_RESULT',
@@ -186,6 +193,9 @@ export async function handleExportLabelFitSample(
   message: ExportLabelFitSampleMessage
 ): Promise<void> {
   const payload = message.payload;
+  // Same as handleExportConnectorSample: the coupon offset labels need their
+  // face registered or they drop silently.
+  await ensureFontsLoaded(['jetbrains-mono']);
   await runExport(
     payload.requestId,
     'BASEPLATE_EXPORT_RESULT',

--- a/src/features/generation/worker/handlers/exportHandler.ts
+++ b/src/features/generation/worker/handlers/exportHandler.ts
@@ -145,11 +145,9 @@ export async function handleExportConnectorSample(
   message: ExportConnectorSampleMessage
 ): Promise<void> {
   const payload = message.payload;
-  // The coupon offset labels emboss synchronously and drop silently if their
-  // face isn't registered. INIT loads the eager set, but a font fetch that
-  // failed at worker start is only ever retried by whoever asks for the family
-  // again — so this handler must, or a stale/missing font asset ships a tray of
-  // textless coupons. Mirrors handleGenerate.
+  // INIT loads the eager set, but a font fetch that failed then is only retried
+  // when the family is next requested — so re-ensure here, or a stale/missing
+  // asset ships a textless tray with no recovery. Mirrors handleGenerate.
   await ensureFontsLoaded(['jetbrains-mono']);
   await runExport(
     payload.requestId,
@@ -193,8 +191,7 @@ export async function handleExportLabelFitSample(
   message: ExportLabelFitSampleMessage
 ): Promise<void> {
   const payload = message.payload;
-  // Same as handleExportConnectorSample: the coupon offset labels need their
-  // face registered or they drop silently.
+  // Re-ensure the label font, same reason as handleExportConnectorSample.
   await ensureFontsLoaded(['jetbrains-mono']);
   await runExport(
     payload.requestId,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3926,13 +3926,13 @@ const en: Record<string, string> = {
   'baseplate.connectorSample.button': 'Print fit test',
   'baseplate.connectorSample.dialogTitle': 'Connector fit sample',
   'baseplate.connectorSample.dialogDescription':
-    'A small calibration print of all three connector styles across a range of fit offsets. Print it, find the fit that clicks, then set Connector fit to that value before printing the full baseplate.',
+    'A small calibration print of the selected connector style across a range of fit offsets. Print it, find the fit that clicks, then set Connector fit to that value before printing the full baseplate.',
   'baseplate.connectorSample.tipsTitle': 'Print tips',
   'baseplate.connectorSample.tip1': 'Print flat with no supports.',
   'baseplate.connectorSample.tip2':
     "Use the same printer, filament, and nozzle you'll print the baseplate with.",
   'baseplate.connectorSample.tip3':
-    'Each coupon is labeled with its style (DT / DK / SC) and fit offset.',
+    'Each coupon is embossed with its fit offset; the whole tray is one connector style.',
   'baseplate.connectorSample.tip4': 'Found the right fit? Set Connector fit to that offset.',
   'baseplate.connectorSample.exportComplete': 'Fit sample exported',
   'baseplate.connectorSample.exportFailed': 'Connector fit sample export failed',


### PR DESCRIPTION
Fixes #3945.

## Problem

The connector "Print fit test" tray (and the sibling label fit-test) can print with textless coupons, contrary to the dialog copy that promises labels. Two causes:

1. **Font not guaranteed on the export path.** The fit-test export handlers relied on the eager font set already being registered at worker init but never re-requested it. A font asset that failed to fetch at init (e.g. a stale/missing hashed asset after a deploy) is only ever retried by whoever asks for the family again. The main generate path re-ensures its fonts; the fit-test handlers did not, so a failed eager load shipped a tray of textless coupons with no recovery.

2. **The dialog copy over-promised.** It described "all three connector styles" (there are four, and only the *selected* one is built), and `tip3` claimed each coupon carries a style code (DT / DK / SC) that is never embossed — the coupons carry the fit offset only (the whole tray is one style, a deliberate printability choice).

## Fix

- `handleExportConnectorSample` and `handleExportLabelFitSample` now `await ensureFontsLoaded(['jetbrains-mono'])` before building, mirroring `handleGenerate`.
- Corrected `dialogDescription` (selected style) and `tip3` (each coupon embossed with its fit offset; one style per tray).
- The connector-sample scenario test now loads the coupon font and asserts the labels actually emboss (raised geometry above the coupon top) across `dovetailKey` and `snapClip`. The prior test checked only watertightness, which passes even when every label silently drops.

## Notes

- The loose dovetail key / snap clip is left unlabelled by design: at ~3.8mm tall it is smaller than a single legible glyph at the printable font size, which is why `buildTextSolid` would return null for it. The corrected copy no longer implies it is labelled.
- On the default OCCT kernel, `loadOcctWasm` awaits `loadEmbeddedFonts` before `INIT_READY`, so a normally-networked user already gets labelled coupons; this change closes the failed/racing-load path and aligns the fit-test handlers with the generate path's recovery behaviour.

## Verification

- `pnpm run test:run src/features/generation/worker/generators/connectorSample.scenario` — 9 passed (new label assertions cover all four styles)
- `pnpm run typecheck`, `pnpm run check:boundaries`, all four i18n checks — green

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

