### PR TITLE
fix(analytics): attach the active kernel to export-failure captures

### DIFF
--- a/src/features/bin-designer/hooks/useExport.test.ts
+++ b/src/features/bin-designer/hooks/useExport.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/shared/generation/bridge', () => ({
     exportCombined: mockExportCombined,
     exportSplitBin: mockExportSplitBin,
   }),
+  getActiveKernel: () => 'occt-wasm',
   bridgeManager: {
     get engineReady() {
       return true;

--- a/src/features/bin-designer/hooks/useExport.ts
+++ b/src/features/bin-designer/hooks/useExport.ts
@@ -29,7 +29,7 @@ import { useSettingsStore } from '@/core/store';
 import { useToastStore } from '@/core/store/toast';
 import { binSplitChunkUnits } from '@/shared/utils/binSplitFit';
 import { DEFAULT_PATTERN_SCALE } from '@/features/bin-designer/types';
-import { getActiveBridge, bridgeManager } from '@/shared/generation/bridge';
+import { getActiveBridge, getActiveKernel, bridgeManager } from '@/shared/generation/bridge';
 import { withSocketNozzle } from '@/shared/generation/socketNozzle';
 import { generateFileName } from '@/features/bin-designer/utils/fileNaming';
 import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
@@ -263,6 +263,10 @@ export function useExport(): UseExportReturn {
       captureException(error, {
         source: 'bin_export',
         export_format: format,
+        // Which kernel was active when the export failed. A worker-reset
+        // timeout terminates the worker, so read the durable main-thread
+        // selection rather than the dead worker's INIT_READY report.
+        kernel: getActiveKernel(),
         is_split_export: isSplit,
         bin_width: params.width,
         bin_depth: params.depth,

--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -12,6 +12,7 @@ import { export3MF, export3MFMultiObject } from '@/shared/generation/export';
 import { captureException } from '@/shared/analytics/posthog';
 import {
   getActiveBridge,
+  getActiveKernel,
   workerPoolManager,
   type SplitExportResult,
 } from '@/shared/generation/bridge';
@@ -629,6 +630,7 @@ export async function runSplitBinExport(
     captureException(poolErr instanceof Error ? poolErr : new Error(String(poolErr)), {
       source: 'bin_export_pool_fallback',
       export_format: format,
+      kernel: getActiveKernel(),
     });
     if (poolAcquired) {
       workerPoolManager.release();


### PR DESCRIPTION
Refs #3941.

Addresses one of the two signals the maintainer flagged on #3941: **the `kernel` property is null on every worker-reset capture, so the events cannot say which geometry kernel was active.**

## Cause

The bin-export failure captures (including the "Worker was reset after a generation timeout" class) never set a `kernel` field, so PostHog recorded `kernel: null` on every event. The value was available all along on the main thread.

## Fix

Attach `getActiveKernel()` at both export-failure capture sites:

- `useExport.ts` — the primary `bin_export` capture.
- `binDownloadHelpers.ts` — the `bin_export_pool_fallback` capture.

This mirrors `captureWasmLoadFailure`, which already attaches the kernel. `getActiveKernel()` reads the durable main-thread kernel selection, which survives the worker reset that terminates the worker (so there is no dead-worker round-trip).

## Scope

This unblocks the kernel-attribution signal only. The other signal on #3941 — the wedged-worker / slow-WASM-init suspicion on empty (`bin_count 0`) generations — is left open, and the new kernel field is what lets that investigation attribute the class to a specific kernel. The alert-noise half of #3941 was already handled by #3944 (stable fingerprints), so this issue stays open rather than being auto-closed.

## Verification

- `pnpm run test:run src/features/bin-designer/hooks/useExport src/features/bin-designer/utils/binDownloadHelpers` — 39 passed (added `getActiveKernel` to the bridge mock)
- `pnpm run typecheck`, `pnpm run check:boundaries` — green

https://claude.ai/code/session_019QqbvgknBfgkNRVA88Ks4P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

