### PR TITLE
fix(generation): stop a slow cold init from tripping the generation timeout

### DIFF
--- a/src/features/generation/bridge/GenerationBridge.test.ts
+++ b/src/features/generation/bridge/GenerationBridge.test.ts
@@ -54,7 +54,7 @@ class MockWorker {
           hardwareConcurrency: 4,
           kernel: kernel as 'occt-wasm' | 'brepkit',
         });
-      }, 0);
+      }, initDelayMs);
     }
   }
 
@@ -83,6 +83,8 @@ class MockWorker {
 let mockWorkerInstance: MockWorker | null = null;
 /** When true, MockWorker swallows INIT instead of replying. */
 let stallInit = false;
+/** Delay before MockWorker answers INIT with INIT_READY, in ms. */
+let initDelayMs = 0;
 /** When set, MockWorker answers INIT with an ERROR carrying this message. */
 let initErrorMessage: string | null = null;
 /** Workers the bridge has constructed — the retry count, observed from outside. */
@@ -112,6 +114,7 @@ describe('GenerationBridge', () => {
   beforeEach(() => {
     mockWorkerInstance = null;
     stallInit = false;
+    initDelayMs = 0;
     initErrorMessage = null;
     workersCreated = 0;
     bridge = new GenerationBridge();
@@ -1094,6 +1097,51 @@ describe('GenerationBridge', () => {
       expect(worker.terminated).toBe(true);
       const cancelMsg = worker.messages.find((m) => (m as { type: string }).type === 'CANCEL');
       expect(cancelMsg).toBeUndefined();
+    });
+
+    it('does not hard-reset a trivial request while a slow-but-successful cold init is still in flight', async () => {
+      // A cold occt-wasm boot on a slow connection can legitimately take longer
+      // than a trivial design's 30s BASE_TIMEOUT_MS while still finishing well
+      // inside init's own 60s allowance (GH #3941: "Worker was reset after a
+      // generation timeout" on a bin_count 0 / default-size layout — nothing
+      // was actually generating yet, the worker was still booting).
+      initDelayMs = 35_000;
+
+      const genPromise = bridge.generateImmediate(DEFAULT_BIN_PARAMS);
+      const worker = getWorker();
+
+      // Past the trivial-design generation budget, but init hasn't reported
+      // ready yet: no GENERATE message should have been sent, and the worker
+      // must not have been hard-reset.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(worker.terminated).toBe(false);
+      expect(
+        worker.messages.find((m) => (m as { type: string }).type === 'GENERATE')
+      ).toBeUndefined();
+
+      // Init reports ready at 35s; the generation message goes out now, and
+      // its own timeout starts fresh from this point.
+      await vi.advanceTimersByTimeAsync(6_000);
+      const generateMsg = worker.messages.find(
+        (m) => (m as { type: string }).type === 'GENERATE'
+      ) as { type: string; payload: { requestId: string } } | undefined;
+      expect(generateMsg).toBeDefined();
+      expect(worker.terminated).toBe(false);
+
+      worker.simulateResponse({
+        type: 'MESH_RESULT',
+        requestId: generateMsg!.payload.requestId,
+        vertices: new Float32Array(0),
+        normals: new Float32Array(0),
+        indices: new Uint32Array(0),
+        edgeVertices: new Float32Array(0),
+        triangleCount: 0,
+        timingMs: 10,
+      });
+
+      const result = await genPromise;
+      expect(result.timingMs).toBe(10);
+      expect(worker.terminated).toBe(false);
     });
   });
 });

--- a/src/features/generation/bridge/bridgeGeneration.ts
+++ b/src/features/generation/bridge/bridgeGeneration.ts
@@ -54,11 +54,16 @@ export interface BridgeGenerationContext {
  * `init()` is an already-resolved cached promise, so this only defers the post
  * by a microtask.
  *
- * The timeout is armed up front, before awaiting `init()`, so a worker that
- * never reports ready (init hangs, or a replacement worker that never posts
- * INIT_READY) still trips the timeout and its hard-reset recovery instead of
- * leaving the request pending forever. Worker (re)init is fast relative to the
- * 30s+ budget, so charging it against the timeout is negligible.
+ * The timeout is armed only once `init()` resolves and the message is actually
+ * posted, so it measures generation time alone. `init()`'s own settlement is
+ * already bounded by `INIT_TIMEOUT_MS` with one retry (see `tryInit`), so a
+ * worker that never reports ready is caught there, not here. Arming this timer
+ * before `init()` settles double-charges a cold WASM boot against the
+ * generation budget: a legitimately slow-but-successful init (occt-wasm on a
+ * slow connection or cold cache, within `tryInit`'s own 60s allowance) can by
+ * itself exceed a trivial design's 30s `BASE_TIMEOUT_MS`, hard-resetting a
+ * worker that was about to come up healthy and rejecting a request that had
+ * not started generating anything yet.
  */
 function sendWhenReady(
   ctx: BridgeGenerationContext,
@@ -66,11 +71,11 @@ function sendWhenReady(
   timeoutMs: number,
   message: WorkerMessage
 ): void {
-  startGenerationTimeout(ctx, requestId, timeoutMs);
   void ctx.init().then(
     () => {
       // A newer request superseded this one while the worker was initializing.
       if (ctx.currentRequestId !== requestId) return;
+      startGenerationTimeout(ctx, requestId, timeoutMs);
       ctx.postMessage(message);
     },
     (err: unknown) => {


### PR DESCRIPTION
Refs #3941.

## Summary

Fixes the remaining signal on #3941: a trivial generation request (`bin_count 0`, default drawer size) could time out and hard-reset the worker even though nothing was actually generating yet.

## Why

`sendWhenReady` armed the 30s `BASE_TIMEOUT_MS` generation timer *before* awaiting `init()`. A legitimately slow-but-successful WASM cold boot (occt-wasm on a slow connection or a cold cache, still well within `init()`'s own 60s `INIT_TIMEOUT_MS` allowance) could by itself exceed a trivial design's 30s budget. The generation timer fired mid-boot, called `hardResetWorker()`, and terminated a worker that was about to come up healthy — producing exactly "Worker was reset after a generation timeout" for a request that hadn't started generating anything.

This explains why the repeated failure shape was `bin_count 0` / default drawer size: those are the first-generation-of-session requests, most likely to race a cold boot rather than heavy geometry. `init()` already settles on its own (its own timeout plus one retry), so nothing needed the generation timer as a backstop for a hanging init — the up-front arming was solving an already-solved problem at the cost of double-charging boot time against the generation budget.

## Changes

- `sendWhenReady` now arms the generation timeout only once `init()` resolves and the message is actually posted, so it measures generation time alone instead of generation-plus-boot time.
- Added a regression test: a 35s init (successful, under the 60s init allowance) followed by a trivial `generateImmediate` no longer hard-resets the worker at the 30s mark: it waits for init, then posts and completes normally.

## Risk

Low. The export path (`prepareExport` → `startExportTimeout`) already awaited `init()` before arming its timer, so this only changes the non-export generate/baseplate/item/margin path to match. The only behavior change is *when* the generation clock starts; a worker that never reports ready is still caught by `tryInit`'s own timeout + retry, independent of this timer.

## Verification

- `pnpm vitest run src/features/generation/bridge/` — 175 passed (174 existing + 1 new)
- `pnpm run typecheck` — clean
- `pnpm run lint` — clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

