### PR TITLE
fix(generation): retain slotted dividers and brace lite-base floors

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.baseStyles.test.ts.brepkit.snap
@@ -8,11 +8,11 @@ exports[`base styles > magnet base no lip 1`] = `592`;
 
 exports[`base styles > magnet base with lip 1`] = `1264`;
 
-exports[`base styles > magnet+screw base no lip 1`] = `768`;
+exports[`base styles > magnet+screw base no lip 1`] = `816`;
 
 exports[`base styles > magnet+screw base with lip 1`] = `1536`;
 
-exports[`base styles > screw base no lip 1`] = `528`;
+exports[`base styles > screw base no lip 1`] = `576`;
 
 exports[`base styles > screw base with lip 1`] = `1152`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.brepkit.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`bin styles > 2×2 slotted 1`] = `2164`;
+exports[`bin styles > 2×2 slotted 1`] = `2392`;
 
 exports[`bin styles > 2×2 solid 1`] = `1548`;
 
-exports[`bin styles > 2×2 standard 1`] = `1732`;
+exports[`bin styles > 2×2 standard 1`] = `1744`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.binStyles.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`bin styles > 2×2 slotted 1`] = `3324`;
+exports[`bin styles > 2×2 slotted 1`] = `3516`;
 
 exports[`bin styles > 2×2 solid 1`] = `2604`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.brepkit.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1028`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1244`;
 
-exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `2008`;
+exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `2016`;
 
-exports[`combined features > 2×2 label tabs with merged compartments 1`] = `2176`;
+exports[`combined features > 2×2 label tabs with merged compartments 1`] = `2180`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `2962`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `3144`;
 
-exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `16233`;
+exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `16288`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1356`;
+exports[`combined features > 1.5×2 flat + slotted + 3×2 merged compartments 1`] = `1548`;
 
 exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`] = `3616`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.compartments.test.ts.brepkit.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `1732`;
+exports[`compartments > 2×2 bin with 1×1 (none) compartments 1`] = `1744`;
 
-exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `1848`;
+exports[`compartments > 2×2 bin with 2×2 compartments 1`] = `1852`;
 
-exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `1880`;
+exports[`compartments > 2×2 bin with 3×2 merged top-left compartments 1`] = `1884`;
 
-exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `2200`;
+exports[`compartments > 2×2 bin with 4×4 dense grid compartments 1`] = `2204`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.customShape.test.ts.brepkit.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2726`;
+exports[`custom-shape > 1.5×1.5 half-bin L user halfSockets off 1`] = `2802`;
 
-exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `4146`;
+exports[`custom-shape > 1.5×1.5 half-bin L with lip 1`] = `4222`;
 
 exports[`custom-shape > 2×2 mixed-detail per-cell half sockets 1`] = `3670`;
 
@@ -12,13 +12,13 @@ exports[`custom-shape > 3×3 L with front cutout (polygon-aware side mapping) 1`
 
 exports[`custom-shape > 3×3 L with front handle (polygon-aware side mapping) 1`] = `4698`;
 
-exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `6988`;
+exports[`custom-shape > 3×3 L with honeycomb + front cutout (outermost-edge clip) 1`] = `9700`;
 
 exports[`custom-shape > 3×3 L with honeycomb pattern (polygon edge enumeration) 1`] = `6998`;
 
 exports[`custom-shape > 3×3 L with lip 1`] = `4254`;
 
-exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `4016`;
+exports[`custom-shape > 3×3 O-shape (ring) with lip 1`] = `4232`;
 
 exports[`custom-shape > 3×3 T with lip 1`] = `4246`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dimensions.test.ts.brepkit.snap
@@ -12,9 +12,9 @@ exports[`dimensions > 1×1 no lip 1`] = `352`;
 
 exports[`dimensions > 1×1 with lip 1`] = `880`;
 
-exports[`dimensions > 2×2 no lip 1`] = `940`;
+exports[`dimensions > 2×2 no lip 1`] = `948`;
 
-exports[`dimensions > 2×2 with lip 1`] = `1732`;
+exports[`dimensions > 2×2 with lip 1`] = `1744`;
 
 exports[`dimensions > 4×4 no lip 1`] = `3324`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.exportAndLarge.test.ts.brepkit.snap
@@ -2,6 +2,6 @@
 
 exports[`asymmetric dimensions > 0.5×4 extreme asymmetry 1`] = `1796`;
 
-exports[`export mode > 2×2 default params (forExport=true) 1`] = `2700`;
+exports[`export mode > 2×2 default params (forExport=true) 1`] = `2718`;
 
 exports[`large bin > 8×8 standard 1`] = `15300`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.brepkit.snap
@@ -1,17 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`floor patterns > compartment divider footings stay solid 1`] = `5560`;
+exports[`floor patterns > compartment divider footings stay solid 1`] = `5564`;
 
-exports[`floor patterns > custom-shape bin patterns only its filled feet 1`] = `12258`;
+exports[`floor patterns > custom-shape bin patterns only its filled feet 1`] = `12256`;
 
-exports[`floor patterns > flat base takes one interior-wide window 1`] = `4880`;
+exports[`floor patterns > flat base takes one interior-wide window 1`] = `4928`;
 
-exports[`floor patterns > floor and wall patterns compose 1`] = `8692`;
+exports[`floor patterns > floor and wall patterns compose 1`] = `8704`;
 
 exports[`floor patterns > fractional edge foot carries a narrower window 1`] = `5148`;
 
 exports[`floor patterns > half sockets get one window per quarter foot 1`] = `2180`;
 
-exports[`floor patterns > magnet + screw pockets stay solid 1`] = `12420`;
+exports[`floor patterns > magnet + screw pockets stay solid 1`] = `12432`;
 
-exports[`floor patterns > scoop ramp footings stay solid 1`] = `9068`;
+exports[`floor patterns > scoop ramp footings stay solid 1`] = `11474`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.halfSockets.test.ts.brepkit.snap
@@ -4,4 +4,4 @@ exports[`half-sockets > 1.5×1.5 with half sockets 1`] = `3152`;
 
 exports[`half-sockets > 1×1 with half sockets 1`] = `1732`;
 
-exports[`half-sockets > 2×2 with half sockets 1`] = `5140`;
+exports[`half-sockets > 2×2 with half sockets 1`] = `5152`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.heights.test.ts.brepkit.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`height > 2×2 height minimum (2u) 1`] = `1732`;
+exports[`height > 2×2 height minimum (2u) 1`] = `1744`;
 
-exports[`height > 2×2 height tall (10u) 1`] = `1732`;
+exports[`height > 2×2 height tall (10u) 1`] = `1744`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.honeycombJunction.test.ts.brepkit.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `2904`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front + interior cutouts 1`] = `2840`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `2752`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments + front cutout 1`] = `2688`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `2728`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, cutouts on (sides off) 1`] = `2640`;
 
-exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `2728`;
+exports[`honeycomb junction > 2×2 bin, 2×1 compartments, no cutouts 1`] = `2640`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `3156`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments + interior cutouts 1`] = `2968`;
 
-exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `2840`;
+exports[`honeycomb junction > 2×2 bin, 2×2 compartments, no cutouts 1`] = `2652`;
 
-exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `2644`;
+exports[`honeycomb junction > 2×2×4 honeycomb baseline (no dividers) 1`] = `2656`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.inserts.test.ts.brepkit.snap
@@ -1,13 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`inserts > 2×2 with circle insert 1`] = `1912`;
+exports[`inserts > 2×2 with circle insert 1`] = `1924`;
 
-exports[`inserts > 2×2 with hexagon insert 1`] = `1912`;
+exports[`inserts > 2×2 with hexagon insert 1`] = `1924`;
 
-exports[`inserts > 2×2 with rectangle insert 1`] = `1752`;
+exports[`inserts > 2×2 with rectangle insert 1`] = `1764`;
 
-exports[`inserts > 2×2 with rounded-rect insert 1`] = `1880`;
+exports[`inserts > 2×2 with rounded-rect insert 1`] = `1892`;
 
-exports[`inserts > 2×2 with slot insert 1`] = `1872`;
+exports[`inserts > 2×2 with slot insert 1`] = `1884`;
 
-exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3172`;
+exports[`multiple inserts > 2×2 with 2 circle inserts 1`] = `3188`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.labelTabs.test.ts.brepkit.snap
@@ -2,26 +2,26 @@
 
 exports[`label tabs > 1×1 label both collision drops front 1`] = `880`;
 
-exports[`label tabs > 2×2 label bracket center 1`] = `1892`;
+exports[`label tabs > 2×2 label bracket center 1`] = `1904`;
 
-exports[`label tabs > 2×2 label bracket left 1`] = `1892`;
+exports[`label tabs > 2×2 label bracket left 1`] = `1904`;
 
-exports[`label tabs > 2×2 label bracket right 1`] = `1892`;
+exports[`label tabs > 2×2 label bracket right 1`] = `1904`;
 
-exports[`label tabs > 2×2 label disabled 1`] = `1732`;
+exports[`label tabs > 2×2 label disabled 1`] = `1744`;
 
-exports[`label tabs > 2×2 label front edge 1`] = `1892`;
+exports[`label tabs > 2×2 label front edge 1`] = `1904`;
 
-exports[`label tabs > 2×2 label lip bracket 1`] = `1908`;
+exports[`label tabs > 2×2 label lip bracket 1`] = `1920`;
 
-exports[`label tabs > 2×2 label lip solid 2mm 1`] = `1844`;
+exports[`label tabs > 2×2 label lip solid 2mm 1`] = `1804`;
 
-exports[`label tabs > 2×2 label solid left 1`] = `1792`;
+exports[`label tabs > 2×2 label solid left 1`] = `1804`;
 
-exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `1812`;
+exports[`label tabs > 2×2×4 label both + inset 5mm 1`] = `1824`;
 
-exports[`label tabs > 2×2×4 label both edges 1`] = `2052`;
+exports[`label tabs > 2×2×4 label both edges 1`] = `2064`;
 
-exports[`label tabs > 2×2×4 label lip both edges 1`] = `2084`;
+exports[`label tabs > 2×2×4 label lip both edges 1`] = `2096`;
 
-exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `1892`;
+exports[`label tabs > 2×2×6 label dropped (height = 20mm) 1`] = `1904`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.brepkit.snap
@@ -1,30 +1,30 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `2474`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `2860`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `2588`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `2962`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `2474`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `2860`;
 
-exports[`scoop > 2×2 scoop disabled 1`] = `1732`;
+exports[`scoop > 2×2 scoop disabled 1`] = `1744`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `2872`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `2864`;
 
-exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `2696`;
+exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `2944`;
 
-exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `2584`;
+exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `2960`;
 
-exports[`scoop side > scoop on the back wall 1`] = `2476`;
+exports[`scoop side > scoop on the back wall 1`] = `2872`;
 
-exports[`scoop side > scoop on the left wall 1`] = `2482`;
+exports[`scoop side > scoop on the left wall 1`] = `2860`;
 
-exports[`scoop side > scoop on the right wall 1`] = `2472`;
+exports[`scoop side > scoop on the right wall 1`] = `2872`;
 
-exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `2472`;
+exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `2872`;
 
-exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `2852`;
+exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `2840`;
 
-exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `2504`;
+exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `3248`;
 
 exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `2396`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.brepkit.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `2164`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `2392`;
 
-exports[`slotted variations > slotted with both axes 1`] = `2596`;
+exports[`slotted variations > slotted with both axes 1`] = `3040`;
 
-exports[`slotted variations > slotted without lip 1`] = `1056`;
+exports[`slotted variations > slotted without lip 1`] = `1704`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.slotted.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slotted variations > slotted with Y-axis slots 1`] = `3324`;
+exports[`slotted variations > slotted with Y-axis slots 1`] = `3516`;
 
-exports[`slotted variations > slotted with both axes 1`] = `3756`;
+exports[`slotted variations > slotted with both axes 1`] = `4140`;
 
-exports[`slotted variations > slotted without lip 1`] = `1852`;
+exports[`slotted variations > slotted without lip 1`] = `2044`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.solidCutouts.test.ts.brepkit.snap
@@ -12,7 +12,7 @@ exports[`solid cutouts > 2×2 solid with chamfered hexagon cutout 1`] = `1616`;
 
 exports[`solid cutouts > 2×2 solid with chamfered path cutout 1`] = `1572`;
 
-exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `1636`;
+exports[`solid cutouts > 2×2 solid with chamfered rectangle cutout 1`] = `1620`;
 
 exports[`solid cutouts > 2×2 solid with chamfered slot cutout 1`] = `2088`;
 
@@ -22,7 +22,7 @@ exports[`solid cutouts > 2×2 solid with curved path cutout (bezier handles) 1`]
 
 exports[`solid cutouts > 2×2 solid with ellipse cutout 1`] = `1812`;
 
-exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `1584`;
+exports[`solid cutouts > 2×2 solid with grouped cutouts 1`] = `1568`;
 
 exports[`solid cutouts > 2×2 solid with hexagon (polygon) cutout 1`] = `1580`;
 
@@ -34,7 +34,7 @@ exports[`solid cutouts > 2×2 solid with path cutout having closing bezier curve
 
 exports[`solid cutouts > 2×2 solid with radial array (rotate-to-center) 1`] = `2080`;
 
-exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `1584`;
+exports[`solid cutouts > 2×2 solid with rectangle cutout 1`] = `1568`;
 
 exports[`solid cutouts > 2×2 solid with rectangle with scoop cutout 1`] = `1872`;
 
@@ -52,6 +52,6 @@ exports[`solid cutouts > 2×2 solid with slot (stadium) cutout 1`] = `1728`;
 
 exports[`solid cutouts > 2×2 solid with staggered hex array 1`] = `1668`;
 
-exports[`solid cutouts > 2×2 solid with topOffset 1`] = `2426`;
+exports[`solid cutouts > 2×2 solid with topOffset 1`] = `1820`;
 
 exports[`solid cutouts > 2×2 solid with triangular path cutout 1`] = `1560`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.brepkit.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.wallThickness.test.ts.brepkit.snap
@@ -2,4 +2,4 @@
 
 exports[`wall thickness > 2×2 thick (2.4mm) walls 1`] = `1724`;
 
-exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `2644`;
+exports[`wall thickness > 2×2 thin (0.4mm) walls 1`] = `1964`;

--- a/src/features/generation/worker/generators/lightweightBaseBuilder.test.ts
+++ b/src/features/generation/worker/generators/lightweightBaseBuilder.test.ts
@@ -54,6 +54,15 @@ describe('buildLightweightBase', () => {
     expect(floorOpenings).toBeNull();
   });
 
+  it("'underside' adds a bed-to-floor support cross", () => {
+    const down = buildLightweightBase(1, 1, WT, false, false, 3.25, 2, 1.5, 'down', true);
+    const underside = buildLightweightBase(1, 1, WT, false, false, 3.25, 2, 1.5, 'underside', true);
+    expect(meshShape(underside.base).triangles.length).toBeGreaterThan(
+      meshShape(down.base).triangles.length
+    );
+    expect(underside.floorOpenings).toBeNull();
+  });
+
   it('retains magnet pads as solid islands (more geometry than plain cups)', () => {
     const plain = buildLightweightBase(2, 2, WT, false, false, 3.25, 2, 1.5, 'up', true);
     const withPads = buildLightweightBase(2, 2, WT, true, false, 3.25, 2, 1.5, 'up', true);

--- a/src/features/generation/worker/generators/lightweightBaseBuilder.ts
+++ b/src/features/generation/worker/generators/lightweightBaseBuilder.ts
@@ -36,6 +36,7 @@
  */
 
 import {
+  box,
   cylinder,
   unwrap,
   fuseAll,
@@ -69,6 +70,9 @@ import { UNDERSIDE_RELIEF_BORDER_MM } from '@/shared/types/bin';
 
 /** Solid margin of plastic around each magnet/screw hole in a retained pad. */
 const PAD_MARGIN = 1.2;
+
+/** Cross-web thickness that limits each underside bridge to half a cell. */
+export const UNDERSIDE_SUPPORT_RIB_MM = 1.2;
 
 /** Which side of the base the lite shell opens toward — or both, for a spacer. */
 export type LightweightOpenDirection = 'up' | 'down' | 'through' | 'underside';
@@ -252,6 +256,7 @@ export function buildLightweightBase(
     const feet: Shape3D[] = [];
     const voids: Shape3D[] = [];
     const openingTools: Shape3D[] = [];
+    const undersideSupports: Shape3D[] = [];
 
     forEachSocketCell(
       gridW,
@@ -263,9 +268,12 @@ export function buildLightweightBase(
         if (!cellInMask(cell.centerX, cell.centerY, cell.widthUnits, cell.depthUnits)) return;
         const cellW_mm = cell.widthUnits * unitX - CLEARANCE;
         const cellD_mm = cell.depthUnits * unitY - CLEARANCE;
-        feet.push(
-          translate(scope.register(buildFoot(cellW_mm, cellD_mm)), [cell.centerX, cell.centerY, 0])
-        );
+        const foot = translate(scope.register(buildFoot(cellW_mm, cellD_mm)), [
+          cell.centerX,
+          cell.centerY,
+          0,
+        ]);
+        feet.push(foot);
 
         const innerW = cellW_mm - 2 * shellOffset;
         const innerD = cellD_mm - 2 * shellOffset;
@@ -283,6 +291,24 @@ export function buildLightweightBase(
         voids.push(
           translate(scope.register(unwrap(clone(innerFoot))), [cell.centerX, cell.centerY, zShift])
         );
+        if (openDir === 'underside') {
+          const ribHeight = SOCKET_HEIGHT;
+          const ribZ = -SOCKET_HEIGHT / 2;
+          const slabs = [
+            box(cellW_mm, UNDERSIDE_SUPPORT_RIB_MM, ribHeight, {
+              at: [cell.centerX, cell.centerY, ribZ],
+            }),
+            box(UNDERSIDE_SUPPORT_RIB_MM, cellD_mm, ribHeight, {
+              at: [cell.centerX, cell.centerY, ribZ],
+            }),
+          ];
+          for (const slab of slabs) {
+            const clipped = unwrap(
+              intersect(scope.register(slab), scope.register(unwrap(clone(foot))))
+            );
+            undersideSupports.push(clipped);
+          }
+        }
         if (opensUpward) {
           // The SAME shape as the void, at the same shift, so the opening is
           // flush with the cup mouth. Shifting it further to reach a thicker
@@ -330,6 +356,17 @@ export function buildLightweightBase(
       if (hollow !== base) base.delete();
       if (voidSolid !== hollow) voidSolid.delete();
       base = hollow;
+    }
+
+    if (undersideSupports.length > 0) {
+      const supports = unwrap(
+        fuseAll(undersideSupports as ValidSolid[], { optimisation: 'commonFace' })
+      );
+      for (const rib of undersideSupports) if (rib !== supports) rib.delete();
+      const supported = unwrap(fuse(base, supports));
+      if (supported !== base) base.delete();
+      if (supports !== supported) supports.delete();
+      base = supported;
     }
 
     // Retain magnet/screw pads as solid islands, then drill the pockets.

--- a/src/features/generation/worker/generators/lightweightBaseBuilder.ts
+++ b/src/features/generation/worker/generators/lightweightBaseBuilder.ts
@@ -30,7 +30,9 @@
  *   flat and the redundant membrane `'down'` leaves under it is never built.
  *   Offset by {@link UNDERSIDE_RELIEF_BORDER_MM} rather than `wt`: this ring
  *   stands on the bed and carries a bridged floor, so it wants more material
- *   than a wall supported on both sides.
+ *   than a wall supported on both sides. A {@link UNDERSIDE_SUPPORT_RIB_MM}
+ *   cross-web is fused inside each foot, bed to floor, halving that otherwise
+ *   full-cell bridge span so it prints without sagging.
  *
  * Coordinate system matches the socket: Z=0 top (mates with body), Z=-SOCKET_HEIGHT bottom.
  */

--- a/src/features/generation/worker/generators/scenarios/lightweight.ts
+++ b/src/features/generation/worker/generators/scenarios/lightweight.ts
@@ -218,8 +218,11 @@ export const lightweight: ScenarioCase[] = [
     params: { width: 2, depth: 2, height: 1, base: { ...underside, tile: true } },
   }),
 
-  // The reported repro (#3957 + #3958): the feature interaction neither fix
-  // covers alone, over the relief's partial-coplanar socket↔body fuse.
+  // The feature interaction from the reported repros (#3957 + #3958) at a
+  // test-sized footprint: the slot throat and foot cross-web together, over the
+  // relief's partial-coplanar socket↔body fuse — the case neither fix covers
+  // alone. Per-cell construction makes 2×2 as representative as the reported
+  // 2×5×7 and far cheaper to export.
   defineScenario('lightweight', '2×2 underside + slotted (retention + cross-web)', {
     assert: 'structural',
     forExport: true,

--- a/src/features/generation/worker/generators/scenarios/lightweight.ts
+++ b/src/features/generation/worker/generators/scenarios/lightweight.ts
@@ -218,10 +218,8 @@ export const lightweight: ScenarioCase[] = [
     params: { width: 2, depth: 2, height: 1, base: { ...underside, tile: true } },
   }),
 
-  // The reported repro (#3957 + #3958): a slotted bin on an underside-relief
-  // base. One export exercises both printability fixes together — the slot
-  // retention throat and the per-foot cross-web — across the partial-coplanar
-  // socket↔body fuse the relief leaves.
+  // The reported repro (#3957 + #3958): the feature interaction neither fix
+  // covers alone, over the relief's partial-coplanar socket↔body fuse.
   defineScenario('lightweight', '2×2 underside + slotted (retention + cross-web)', {
     assert: 'structural',
     forExport: true,

--- a/src/features/generation/worker/generators/scenarios/lightweight.ts
+++ b/src/features/generation/worker/generators/scenarios/lightweight.ts
@@ -218,6 +218,16 @@ export const lightweight: ScenarioCase[] = [
     params: { width: 2, depth: 2, height: 1, base: { ...underside, tile: true } },
   }),
 
+  // The reported repro (#3957 + #3958): a slotted bin on an underside-relief
+  // base. One export exercises both printability fixes together — the slot
+  // retention throat and the per-foot cross-web — across the partial-coplanar
+  // socket↔body fuse the relief leaves.
+  defineScenario('lightweight', '2×2 underside + slotted (retention + cross-web)', {
+    assert: 'structural',
+    forExport: true,
+    params: { width: 2, depth: 2, style: 'slotted', base: underside },
+  }),
+
   // It did something, and something DIFFERENT from the interior mode: the two
   // shells differ only in offset and open direction, so a mode that silently
   // fell back would land on an identical mesh.

--- a/src/features/generation/worker/generators/slotBuilder.ts
+++ b/src/features/generation/worker/generators/slotBuilder.ts
@@ -19,6 +19,7 @@ import type { Shape3D, ValidSolid } from 'brepjs';
 import type { BinParams } from '@/shared/types/bin';
 import {
   calculateSlotPositions,
+  getDividerLockPlan,
   getEffectiveSlotDimensions as getEffectiveSlotDimensionsRaw,
   MIN_WALL_FOR_SLOTS,
 } from '@/shared/utils/slotMath';
@@ -105,6 +106,36 @@ function createMirroredCutters(
     box(rectW, rectD, height, { at: pos(negCenter) }),
     box(rectW, rectD, height, { at: pos(posCenter) }),
   ];
+}
+
+function createMirroredLockingCutters(
+  primaryDim: number,
+  slotWidth: number,
+  dividerThickness: number,
+  dividerClearance: number,
+  height: number,
+  halfSpan: number,
+  crossPos: number,
+  z: number,
+  axis: 'x' | 'y'
+): Shape3D[] {
+  const lock = getDividerLockPlan(dividerThickness, dividerClearance);
+  const lockHeight = lock.headHeight + lock.throatHeight;
+  if (height <= lockHeight) {
+    return createMirroredCutters(primaryDim, slotWidth, height, halfSpan, crossPos, z, axis);
+  }
+
+  const segments: Shape3D[] = [];
+  for (const [width, segmentHeight, segmentZ] of [
+    [lock.pocketWidth, lock.headHeight, z],
+    [lock.throatWidth, lock.throatHeight, z + lock.headHeight],
+    [slotWidth, height - lockHeight, z + lockHeight],
+  ] as const) {
+    segments.push(
+      ...createMirroredCutters(primaryDim, width, segmentHeight, halfSpan, crossPos, segmentZ, axis)
+    );
+  }
+  return segments;
 }
 
 /**
@@ -291,9 +322,11 @@ function buildSlotCutsInScope(
 
     for (const crossPos of positions) {
       // Wall slots (narrow, for tab engagement) — start at floor surface
-      const wallCutters = createMirroredCutters(
+      const wallCutters = createMirroredLockingCutters(
         slotDepth,
         slotWidth,
+        params.dividerPieces.thickness,
+        params.dividerPieces.clearance,
         slotHeight,
         halfSpan,
         crossPos,
@@ -340,17 +373,21 @@ function buildSlotCutsInScope(
       const lowTouch = low <= EPS;
       const highTouch = low + seg.length >= runMax - EPS;
 
-      const [negWall, posWall] = createMirroredCutters(
+      const wallCutters = createMirroredLockingCutters(
         slotDepth,
         slotWidth,
+        params.dividerPieces.thickness,
+        params.dividerPieces.clearance,
         slotHeight,
         halfSpan,
         crossPos,
         floorZ,
         axis
       );
-      keepSide(lowTouch, negWall);
-      keepSide(highTouch, posWall);
+      for (let i = 0; i < wallCutters.length; i += 2) {
+        keepSide(lowTouch, wallCutters[i]);
+        keepSide(highTouch, wallCutters[i + 1]);
+      }
 
       if (lipInfo && lipOverhang > 0) {
         const [negLip, posLip] = createMirroredLipCutters(
@@ -413,7 +450,7 @@ export const slotCutsFeature: FeatureBuilder = {
     const { slotWidth, slotDepth } = getEffectiveSlotDimensions(params);
     return compactKey(
       buildCacheKey(
-        'v2',
+        'v3',
         dim.shellKey,
         stableSerialize(params.slotConfig),
         quantize(slotWidth),

--- a/src/features/generation/worker/generators/slotBuilder.ts
+++ b/src/features/generation/worker/generators/slotBuilder.ts
@@ -443,11 +443,18 @@ export const slotCutsFeature: FeatureBuilder = {
       : undefined;
     // The slot is sized to accept the divider piece, so `dividerPieces` is a
     // geometry input — and it reaches no other segment: `slotConfig` describes
-    // the layout and `shellKey` the body. Keyed on the RESOLVED pair rather
+    // the layout and `shellKey` the body. Keyed on the RESOLVED values rather
     // than the raw params so anything the formula grows is carried too, and
     // `dividerPieces.height` (a property of the piece, not the slot) does not
-    // fragment the cache.
+    // fragment the cache. `throatWidth` is keyed alongside `slotWidth` because
+    // it is a function of thickness ALONE — two piece configs with the same
+    // `slotWidth` (thickness + 2·clearance) but different thickness resolve to
+    // different throats, so `slotWidth` cannot stand in for it.
     const { slotWidth, slotDepth } = getEffectiveSlotDimensions(params);
+    const { throatWidth } = getDividerLockPlan(
+      params.dividerPieces.thickness,
+      params.dividerPieces.clearance
+    );
     return compactKey(
       buildCacheKey(
         'v3',
@@ -455,6 +462,7 @@ export const slotCutsFeature: FeatureBuilder = {
         stableSerialize(params.slotConfig),
         quantize(slotWidth),
         quantize(slotDepth),
+        quantize(throatWidth),
         quantize(dim.innerW),
         quantize(dim.innerD),
         quantize(dim.interiorHeight),

--- a/src/features/generation/worker/generators/undersideRelief.kernel.test.ts
+++ b/src/features/generation/worker/generators/undersideRelief.kernel.test.ts
@@ -134,6 +134,14 @@ describe('underside relief', () => {
     expect(isSolidThrough(mesh, RING.x, RING.y, minZ, minZ + 2.5)).toBe(true);
   });
 
+  it('supports the bridged floor with a cross tied to the bed', () => {
+    const mesh = bin(UNDERSIDE);
+    const { minZ } = boundingBox(mesh.vertices);
+    expect(isSolidThrough(mesh, 0, 1.3, minZ, minZ + SOCKET_HEIGHT)).toBe(true);
+    expect(isSolidThrough(mesh, 1.3, 0, minZ, minZ + SOCKET_HEIGHT)).toBe(true);
+    expect(isSolidThrough(mesh, 1.3, 1.3, minZ, minZ + SOCKET_HEIGHT)).toBe(false);
+  });
+
   it('does not touch the baseplate-mating profile at any depth', () => {
     const standard = bin(STANDARD);
     const relieved = bin(UNDERSIDE);

--- a/src/features/generation/worker/generators/undersideRelief.kernel.test.ts
+++ b/src/features/generation/worker/generators/undersideRelief.kernel.test.ts
@@ -137,8 +137,11 @@ describe('underside relief', () => {
   it('supports the bridged floor with a cross tied to the bed', () => {
     const mesh = bin(UNDERSIDE);
     const { minZ } = boundingBox(mesh.vertices);
-    expect(isSolidThrough(mesh, 0, 1.3, minZ, minZ + SOCKET_HEIGHT)).toBe(true);
-    expect(isSolidThrough(mesh, 1.3, 0, minZ, minZ + SOCKET_HEIGHT)).toBe(true);
+    // Each rib is 1.2mm wide on its own axis, so 0.4 stays inside the rib while
+    // keeping the column off X=0/Y=0 — where fan triangulation would make the
+    // probe ride shared edges (see the BORE note at the top of this file).
+    expect(isSolidThrough(mesh, 0.4, 1.3, minZ, minZ + SOCKET_HEIGHT)).toBe(true);
+    expect(isSolidThrough(mesh, 1.3, 0.4, minZ, minZ + SOCKET_HEIGHT)).toBe(true);
     expect(isSolidThrough(mesh, 1.3, 1.3, minZ, minZ + SOCKET_HEIGHT)).toBe(false);
   });
 

--- a/src/shared/utils/slotMath.test.ts
+++ b/src/shared/utils/slotMath.test.ts
@@ -9,6 +9,7 @@ import {
   calculateShortDividerLengths,
   calculateShortDividerSpans,
   getEffectiveSlotDimensions,
+  getDividerLockPlan,
   getReceptacleDepth,
   resolveCompartmentDividerHeight,
   resolveCrossDividerMode,
@@ -194,6 +195,22 @@ describe('getEffectiveSlotDimensions', () => {
     const { slotDepth } = getEffectiveSlotDimensions(0.4, 1.2, 0.1);
     expect(slotDepth).toBeCloseTo(0.32, 10);
     expect(slotDepth).toBeLessThan(0.4);
+  });
+});
+
+describe('getDividerLockPlan', () => {
+  it('captures the standard divider below a narrower printable throat', () => {
+    const lock = getDividerLockPlan(1.6, 0.25);
+    expect(lock.pocketWidth).toBeCloseTo(2.1, 10);
+    expect(lock.throatWidth).toBeCloseTo(1.2, 10);
+    expect(lock.throatWidth).toBeLessThan(1.6);
+    expect(lock.headHeight).toBeGreaterThan(lock.throatHeight);
+  });
+
+  it('keeps a usable throat on thin custom dividers', () => {
+    const lock = getDividerLockPlan(1, 0.2);
+    expect(lock.throatWidth).toBeGreaterThanOrEqual(0.8);
+    expect(lock.throatWidth).toBeLessThan(1);
   });
 });
 

--- a/src/shared/utils/slotMath.ts
+++ b/src/shared/utils/slotMath.ts
@@ -35,6 +35,44 @@ const DIVIDER_LENGTH_CLEARANCE = 0.3;
  */
 const MIN_TAB_ENGAGEMENT = 0.3;
 
+/** Installed height of the captured divider head below the slot throat. */
+export const DIVIDER_LOCK_HEAD_HEIGHT = 0.8;
+
+/** Installed height of the elastic throat that retains the divider head. */
+export const DIVIDER_LOCK_THROAT_HEIGHT = 0.6;
+
+/** Per-face interference at the throat for the shipped 1.6 mm divider. */
+export const DIVIDER_LOCK_INTERFERENCE_PER_SIDE = 0.2;
+
+export interface DividerLockPlan {
+  readonly pocketWidth: number;
+  readonly throatWidth: number;
+  readonly headHeight: number;
+  readonly throatHeight: number;
+}
+
+/**
+ * Resolve the paired snap geometry shared by wall slots and divider tips.
+ * The full-thickness head seats in the clearance pocket below a narrower
+ * throat. The short wall tabs flex while the head is pressed through.
+ */
+export function getDividerLockPlan(
+  dividerThickness: number,
+  dividerClearance: number
+): DividerLockPlan {
+  const interference = Math.min(
+    DIVIDER_LOCK_INTERFERENCE_PER_SIDE,
+    Math.max(0.08, dividerThickness * 0.125)
+  );
+  const throatWidth = Math.max(0.8, dividerThickness - 2 * interference);
+  return {
+    pocketWidth: dividerThickness + 2 * dividerClearance,
+    throatWidth,
+    headHeight: DIVIDER_LOCK_HEAD_HEIGHT,
+    throatHeight: DIVIDER_LOCK_THROAT_HEIGHT,
+  };
+}
+
 /**
  * Calculate evenly-distributed slot center positions along a dimension.
  * Returns positions relative to the center of the dimension (0 = center).


### PR DESCRIPTION
Two printability bugs on slotted / lightweight bins, both reported with a tested reference implementation by @victorsmits.

## Slotted dividers had no vertical retention (#3957)

A divider plate slid straight back out of its wall slots, could spread the walls, and release adjacent dividers. Each wall slot now carries a short interference throat near the floor (`getDividerLockPlan` in `slotMath.ts`): the full-thickness plate seats below a narrower throat and resists lifting while staying deliberately removable. The custom-grid path keeps the throat only on the walls a segment actually touches. Slot geometry cache bumped `v2` to `v3`.

## Underside lightweight base bridged the whole cell (#3958)

The `underside` relief left the cell floor spanning its foot as a single unsupported bridge (~35mm on a 1u cell), which sags and sheds loose strands, worse alongside wall slots. Each foot now carries a 1.2mm `+` cross-web tied from the bed up to the floor, halving every bridge span. It is intersected with the foot profile, so like the relief itself it cannot breach the baseplate-mating taper at any depth.

## Review follow-ups (in this PR)

- **Slot cache key fix.** The throat width is a function of divider thickness alone, but the key only carried the derived `slotWidth` (thickness + 2·clearance). Two piece configs with equal `slotWidth` and different thickness collided in the cache and served the wrong throat. `throatWidth` is now keyed explicitly.
- Underside cross-web probes moved off the X=0/Y=0 axes (fan-triangulation flakiness the test file itself documents); cross-web invariant recorded at its source.

## brepkit snapshot re-baseline

Refreshed 17 `*.brepkit.snap` baselines (brepkit's own tessellation-density snapshots, separate from the default-kernel `.snap` files CI reads) that had drifted since the brepkit-wasm 3.2.13 to 3.3.7 bump. Each was verified by a fresh no-update brepkit pass. `dividerPatterns` and `labelSockets` are intentionally left: under brepkit 3.3.7 the kumiko/mitsukude lattice cases exceed the 180s timeout and the labelSockets pocket detection is non-deterministic. Those are pre-existing brepkit parity issues, out of scope here.

## Verification

- `slotMath` unit tests and the `lightweightBaseBuilder` / `undersideRelief` kernel column-probes pass.
- Slotted and lightweight **export-integrity** suites pass: parseable, watertight, and manifold through the socket-to-body export fuse.
- Added one combined scenario for the reported config, a slotted bin on an underside-relief base, which is the interaction neither fix exercised alone.
- Default-kernel triangleCount snapshots the throat shifts (`binStyles`, `combinedFeatures`) regenerated.
- Typecheck, eslint, and module-boundary checks are clean; CI green.
- A top-down cross-section of the relieved base reads as a ring with a `+` web tying opposite walls, and STLs of the 2x5x7 repro slice cleanly.

Physical print validation is left to a maintainer or the reporter; the geometry is watertight and follows standard Gridfinity Lite bracing and snap-slot practice.

Co-authored with @victorsmits, who reported both issues and provided the tested reference implementation.

Closes #3957
Closes #3958

https://claude.ai/code/session_01Dc8TStsQ32aGhK3qcetbCo
