### PR TITLE
fix(bin-inspector): feedback when bulk height edit hits an all-locked selection

### DIFF
--- a/src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.test.tsx
+++ b/src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.test.tsx
@@ -239,6 +239,27 @@ describe('MultiBinInspector', () => {
 
       expect(inspector.updateMultiHeight).toHaveBeenCalledWith(-1);
     });
+
+    it('disables both height buttons when every selected bin is locked', () => {
+      const inspector = createMockInspector({
+        selectedBins: mockBins.map((b) => ({ ...b, locked: true })),
+      });
+      render(<MultiBinInspector inspector={inspector} variant="desktop" />);
+
+      expect(screen.getByLabelText('Increase height for all bins')).toBeDisabled();
+      expect(screen.getByLabelText('Decrease height for all bins')).toBeDisabled();
+    });
+
+    it('leaves height buttons enabled when only some selected bins are locked', () => {
+      const [first, ...rest] = mockBins;
+      const inspector = createMockInspector({
+        selectedBins: [{ ...first, locked: true }, ...rest],
+      });
+      render(<MultiBinInspector inspector={inspector} variant="desktop" />);
+
+      expect(screen.getByLabelText('Increase height for all bins')).toBeEnabled();
+      expect(screen.getByLabelText('Decrease height for all bins')).toBeEnabled();
+    });
   });
 
   describe('clearance handling', () => {

--- a/src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.tsx
@@ -207,6 +207,8 @@ export function MultiBinInspector({ inspector, variant, onClose }: MultiBinInspe
             displayValue={heightDisplay}
             onStep={updateMultiHeight}
             ariaLabelPrefix={t('inspector.multi.heightAriaPrefix')}
+            decreaseDisabled={allLocked}
+            increaseDisabled={allLocked}
             variant={variant}
           />
         </div>

--- a/src/features/bin-inspector/hooks/useBinInspector.test.ts
+++ b/src/features/bin-inspector/hooks/useBinInspector.test.ts
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useBinInspector } from '@/features/bin-inspector';
 import { useLayoutStore } from '@/core/store/layout';
 import { useSelectionStore } from '@/core/store/selection';
+import { useToastStore } from '@/core/store/toast';
 import { emitSyncEvent } from '@/shared/events/syncEventBus';
 import { resetAllStores } from '@/test/testUtils';
 import { connectSelectionPruning, eventBus } from '@/core/cqrs';
@@ -501,6 +502,30 @@ describe('useBinInspector', () => {
 
       // Only one event per design, not per bin
       expect(emitSyncEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('toasts and leaves heights untouched when every selected bin is locked', () => {
+      const layout = useLayoutStore.getState().layout;
+      layout.drawer.height = heightUnits(12);
+      layout.bins = [
+        { ...createBin('bin1', 'layer1', 0, 0), height: heightUnits(3), locked: true },
+        { ...createBin('bin2', 'layer1', 3, 0), height: heightUnits(4), locked: true },
+      ];
+      useLayoutStore.setState({ layout });
+      useSelectionStore.setState({ selectedBinIds: [binId('bin1'), binId('bin2')] });
+
+      const { result } = renderHook(() => useBinInspector());
+
+      act(() => {
+        result.current.updateMultiHeight(2);
+      });
+
+      const bins = useLayoutStore.getState().layout.bins;
+      expect(bins[0].height).toBe(3);
+      expect(bins[1].height).toBe(4);
+      expect(useToastStore.getState().toasts.map((toast) => toast.message)).toContain(
+        'All selected bins are size-locked. Unlock them to change height.'
+      );
     });
   });
 

--- a/src/features/bin-inspector/hooks/useBinInspectorMultiActions.ts
+++ b/src/features/bin-inspector/hooks/useBinInspectorMultiActions.ts
@@ -119,6 +119,11 @@ export function useBinInspectorMultiActions(deps: MultiActionDeps): MultiActions
           return { bin: b, newHeight };
         });
 
+      if (updates.length === 0) {
+        addToast(t('toast.allSelectedBinsLocked'), 'info');
+        return;
+      }
+
       const succeededBinIds = new Set<BinId>();
       batch(() => {
         for (const { bin: b, newHeight } of updates) {
@@ -139,7 +144,7 @@ export function useBinInspectorMultiActions(deps: MultiActionDeps): MultiActions
         emitLinkedBinResize(b, { width: b.width, depth: b.depth, height: newHeight });
       }
     },
-    [selectedBins, layout.drawer.height, layout.layers, updateBin]
+    [selectedBins, layout.drawer.height, layout.layers, updateBin, addToast, t]
   );
 
   const updateMultiClearance = useCallback(

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Přesunuto do {name}",
   "toast.movedToStash": "Přesunuto {count} binů do Stash",
   "toast.noMovableCollisions": "Do této vrstvy nelze přesunout žádné biny (kolize)",
+  "toast.allSelectedBinsLocked": "Všechny vybrané biny mají zamčenou velikost. Odemkněte je pro změnu výšky.",
   "toast.notifications": "Oznámení",
   "toast.offline": "Jsi offline. Změny se ukládají lokálně.",
   "toast.onboardingReset": "Uvítací průvodce obnoven — nahraj znovu pro zobrazení tutoriálu",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Zu {name} verschoben",
   "toast.movedToStash": "{count} Bin(s) in die Ablage verschoben",
   "toast.noMovableCollisions": "Keine Bins können auf diesen Layer verschoben werden (Kollisionen)",
+  "toast.allSelectedBinsLocked": "Alle ausgewählten Bins sind größengesperrt. Zum Ändern der Höhe entsperren.",
   "toast.notifications": "Benachrichtigungen",
   "toast.offline": "Sie sind offline. Änderungen werden lokal gespeichert.",
   "toast.onboardingReset": "Einführung zurückgesetzt – neu laden, um das Tutorial zu sehen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1453,6 +1453,7 @@ const en: Record<string, string> = {
   'toast.movedMultiToLayer': 'Moved {count} bins to {name}',
   'toast.movedPartialToLayer': 'Moved {moved} of {total} bins ({blocked} blocked)',
   'toast.noMovableCollisions': 'No bins can be moved to this layer (collisions)',
+  'toast.allSelectedBinsLocked': 'All selected bins are size-locked. Unlock them to change height.',
   'toast.dragFromStash': 'Drag bin from stash to place it on a layer',
   'toast.customPropertySet': 'Set "{key}" on {count} bins',
   'toast.resizeTip': 'Tip: Drag the handles to resize',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Movido a {name}",
   "toast.movedToStash": "{count} bin(s) movidos al almacén",
   "toast.noMovableCollisions": "No se pueden mover bins a este layer (colisiones)",
+  "toast.allSelectedBinsLocked": "Todos los bins seleccionados tienen el tamaño bloqueado. Desbloquéalos para cambiar la altura.",
   "toast.notifications": "Notificaciones",
   "toast.offline": "Estás sin conexión. Los cambios se guardan localmente.",
   "toast.onboardingReset": "Introducción restablecida — recarga para ver el tutorial",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Déplacé vers {name}",
   "toast.movedToStash": "{count} bin(s) déplacé(s) vers le stash",
   "toast.noMovableCollisions": "Aucun bin ne peut être déplacé vers ce layer (collisions)",
+  "toast.allSelectedBinsLocked": "Tous les bacs sélectionnés ont une taille verrouillée. Déverrouillez-les pour changer la hauteur.",
   "toast.notifications": "Notifications",
   "toast.offline": "Vous êtes hors ligne. Les modifications sont enregistrées localement.",
   "toast.onboardingReset": "Introduction réinitialisée — rechargez pour voir le tutoriel",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Spostato su {name}",
   "toast.movedToStash": "Spostati {count} bin nell'area di sosta",
   "toast.noMovableCollisions": "Nessun bin può essere spostato su questo livello (collisioni)",
+  "toast.allSelectedBinsLocked": "Tutti i bin selezionati hanno dimensioni bloccate. Sbloccali per modificare l'altezza.",
   "toast.notifications": "Notifiche",
   "toast.offline": "Sei offline. Le modifiche vengono salvate in locale.",
   "toast.onboardingReset": "Onboarding reimpostato; ricarica per vedere il tutorial",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "{name}に移動しました",
   "toast.movedToStash": "{count}個のビンをステージングに移動しました",
   "toast.noMovableCollisions": "このレイヤーに移動できるビンはありません(衝突)",
+  "toast.allSelectedBinsLocked": "選択したすべてのビンのサイズがロックされています。高さを変更するにはロックを解除してください。",
   "toast.notifications": "通知",
   "toast.offline": "オフラインです。変更はローカルに保存されます。",
   "toast.onboardingReset": "オンボーディングをリセットしました — 再読み込みでチュートリアルが表示されます",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "{name}(으)로 이동했습니다",
   "toast.movedToStash": "수납통 {count}개를 임시 보관함으로 이동했습니다",
   "toast.noMovableCollisions": "이 레이어로 이동할 수 있는 수납통이 없습니다(충돌)",
+  "toast.allSelectedBinsLocked": "선택한 모든 수납통의 크기가 잠겨 있습니다. 높이를 변경하려면 잠금을 해제하세요.",
   "toast.notifications": "알림",
   "toast.offline": "오프라인 상태입니다. 변경 사항이 로컬에 저장됩니다.",
   "toast.onboardingReset": "온보딩이 초기화되었습니다 — 튜토리얼을 보려면 다시 로드하세요",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Flyttet til {name}",
   "toast.movedToStash": "Flyttet {count} bin(s) til stash",
   "toast.noMovableCollisions": "Ingen bins kan flyttes til dette laget (kollisjoner)",
+  "toast.allSelectedBinsLocked": "Alle valgte beholdere har låst størrelse. Lås opp for å endre høyden.",
   "toast.notifications": "Varsler",
   "toast.offline": "Du er frakoblet. Endringer lagres lokalt.",
   "toast.onboardingReset": "Onboarding tilbakestilt — last på nytt for å se veiledningen",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Verplaatst naar {name}",
   "toast.movedToStash": "{count} bin(s) naar opslag verplaatst",
   "toast.noMovableCollisions": "Geen bins kunnen naar deze layer worden verplaatst (botsingen)",
+  "toast.allSelectedBinsLocked": "Alle geselecteerde bins hebben vergrendelde afmetingen. Ontgrendel ze om de hoogte te wijzigen.",
   "toast.notifications": "Meldingen",
   "toast.offline": "Je bent offline. Wijzigingen worden lokaal opgeslagen.",
   "toast.onboardingReset": "Introductie gereset — herlaad om de tutorial te zien",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Przeniesiono do {name}",
   "toast.movedToStash": "Przeniesiono {count} bin(ów) do Stash",
   "toast.noMovableCollisions": "Żaden bin nie może zostać przeniesiony na tę warstwę (kolizje)",
+  "toast.allSelectedBinsLocked": "Wszystkie zaznaczone biny mają zablokowany rozmiar. Odblokuj je, aby zmienić wysokość.",
   "toast.notifications": "Powiadomienia",
   "toast.offline": "Jesteś offline. Zmiany zapisują się lokalnie.",
   "toast.onboardingReset": "Wprowadzenie zresetowane — odśwież, aby zobaczyć samouczek",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Movido para {name}",
   "toast.movedToStash": "{count} bin(s) movido(s) para o armazenamento",
   "toast.noMovableCollisions": "Nenhum bin pode ser movido para este layer (colisões)",
+  "toast.allSelectedBinsLocked": "Todos os bins selecionados estão com o tamanho bloqueado. Desbloqueie-os para alterar a altura.",
   "toast.notifications": "Notificações",
   "toast.offline": "Você está offline. As alterações são salvas localmente.",
   "toast.onboardingReset": "Introdução redefinida — recarregue para ver o tutorial",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Flyttad till {name}",
   "toast.movedToStash": "Flyttade {count} fack till förråd",
   "toast.noMovableCollisions": "Inga fack kan flyttas till detta lager (kollisioner)",
+  "toast.allSelectedBinsLocked": "Alla markerade fack har låst storlek. Lås upp dem för att ändra höjden.",
   "toast.notifications": "Meddelanden",
   "toast.offline": "Du är offline. Ändringar sparas lokalt.",
   "toast.onboardingReset": "Introduktion återställd — ladda om för att se guiden",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "Переміщено в {name}",
   "toast.movedToStash": "{count} бінів переміщено до сховку",
   "toast.noMovableCollisions": "Жодного біна не можна перемістити на цей шар (колізії)",
+  "toast.allSelectedBinsLocked": "Усі вибрані біни мають заблокований розмір. Розблокуйте їх, щоб змінити висоту.",
   "toast.notifications": "Сповіщення",
   "toast.offline": "Ви офлайн. Зміни зберігаються локально.",
   "toast.onboardingReset": "Ознайомлення скинуто — оновіть сторінку, щоб побачити навчальну підказку",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -4167,6 +4167,7 @@
   "toast.movedToLayer": "已移到 {name}",
   "toast.movedToStash": "已将 {count} 个收纳盒移入暂存区",
   "toast.noMovableCollisions": "没有收纳盒能移到此层（发生碰撞）",
+  "toast.allSelectedBinsLocked": "所选收纳盒均已锁定尺寸。请解锁后再修改高度。",
   "toast.notifications": "通知",
   "toast.offline": "你已离线。更改会保存在本地。",
   "toast.onboardingReset": "新手引导已重置 — 重新加载以查看教程",


### PR DESCRIPTION
## Summary
- `updateMultiHeight` filters locked bins out of the batch before applying deltas; when every selected bin is locked the filtered list is empty and the update silently no-ops, with no visual or toast feedback.
- The height stepper's +/- buttons were never disabled for this case either, so clicking them looked broken.

Found while investigating #3963. Disables the height stepper when every selected bin is locked, and adds a toast explaining why (matching the existing "no movable bins" toast on layer moves) for the case where it fires anyway.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run check:i18n && check:i18n:values && check:i18n:interpolation && check:i18n:unused`
- [x] New unit tests in `useBinInspector.test.ts` (locked-selection no-op + toast) and `MultiBinInspector.test.tsx` (disabled button state)
- [x] Full pre-commit hook suite passed locally

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

