### PR TITLE
fix(three-preview): stop WebKit troika worker failures from breaking text

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "tailwind-merge": "^3.6.0",
     "three": "^0.185.1",
     "three-stdlib": "^2.36.1",
+    "troika-three-text": "0.52.5",
     "zod": "^4.4.3",
     "zustand": "^5.0.15"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       three-stdlib:
         specifier: ^2.36.1
         version: 2.36.1(three@0.185.1)
+      troika-three-text:
+        specifier: 0.52.5
+        version: 0.52.5(three@0.185.1)
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -11,6 +11,8 @@
 import { useRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { useShallow } from 'zustand/react/shallow';
 import { PerspectiveCamera } from 'three';
 import type { OrbitControls as OrbitControlsType } from 'three-stdlib';

--- a/src/features/bin-designer/components/ImportBinDialog/ImportBinDialog.tsx
+++ b/src/features/bin-designer/components/ImportBinDialog/ImportBinDialog.tsx
@@ -14,6 +14,8 @@ import type { ReactNode } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Center, OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { Button, Dialog, Stepper } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import type { MeshImportRotation } from '@/shared/generation/meshAsset';

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -12,6 +12,8 @@
 import { useRef, useCallback, useState, useEffect, useMemo } from 'react';
 import { Canvas, useThree } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { useShallow } from 'zustand/react/shallow';
 import { PerspectiveCamera } from 'three';
 import type { OrbitControls as OrbitControlsType } from 'three-stdlib';

--- a/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
@@ -17,6 +17,8 @@ import type { OrbitControls as OrbitControlsType } from 'three-stdlib';
 import { useShallow } from 'zustand/react/shallow';
 import { useDesignerStore } from '@/features/bin-designer/store/designer';
 import { detectWebGL, WebGLFallback, WebGLErrorBoundary } from '@/shared/webgl';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { useThreeColors } from '@/shared/hooks/useThemeEffect';
 import { useTranslation } from '@/i18n';
 import {

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutCanvas3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/CutoutCanvas3D.tsx
@@ -11,6 +11,8 @@ import { useCallback, useEffect, useMemo, useState, type RefObject } from 'react
 import { useCutoutSelection } from '@/features/bin-designer/store';
 import { Canvas } from '@react-three/fiber';
 import type { RootState } from '@react-three/fiber';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import type {
   Cutout,
   CutoutShape as CutoutShapeType,

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.tsx
@@ -13,6 +13,8 @@ import { useEffect, useMemo } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Center, OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { Dialog, Button, Stepper } from '@/design-system';
 import { useTranslation } from '@/i18n';
 import type { MeshImportRotation } from '@/shared/generation/meshAsset';

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelPlatesControls.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelPlatesControls.tsx
@@ -9,6 +9,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { Badge, Button, Dialog } from '@/design-system';
 import { ExportDialog } from '@/shared/components/ExportDialog';
 import { useToastStore } from '@/core/store/toast';

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useCallback, useRef, useState, useEffect } from 'react';
 import { Canvas } from '@react-three/fiber';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { useShallow } from 'zustand/react/shallow';
 import { useLayoutStore } from '@/core/store/layout';
 import { effectiveGridUnitMmY } from '@/core/types';

--- a/src/features/supporters/components/SupportersPage/SupportersPage.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.tsx
@@ -1,5 +1,7 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { useSettingsStore } from '@/core/store';
 import { Button, Input } from '@/design-system';
 import { useTranslation } from '@/i18n';

--- a/src/shared/analytics/posthog/errorFilters.test.ts
+++ b/src/shared/analytics/posthog/errorFilters.test.ts
@@ -252,6 +252,42 @@ describe('filterExceptionForPosthog — chunk-load dedupe', () => {
   });
 });
 
+describe('filterExceptionForPosthog — troika worker-init dedupe', () => {
+  const TROIKA_ERROR =
+    'Worker module function was called but `init` did not return a callable function';
+
+  it("pins a stable fingerprint so every deploy's chunk hash groups into one issue", () => {
+    const e = {
+      event: '$exception',
+      properties: { $exception_list: [{ value: TROIKA_ERROR }] },
+    };
+    const result = filterExceptionForPosthog(e);
+    expect(result).toBe(e);
+    expect(result?.properties?.$exception_fingerprint).toBe('troika-worker-init-failed');
+  });
+
+  it('reports the first occurrence and mutes the rest of the session', () => {
+    const make = (): Parameters<typeof filterExceptionForPosthog>[0] => ({
+      event: '$exception',
+      properties: { $exception_list: [{ value: TROIKA_ERROR }] },
+    });
+    expect(filterExceptionForPosthog(make())).not.toBeNull();
+    // Every subsequent <Text> sync in the same broken session throws again.
+    expect(filterExceptionForPosthog(make())).toBeNull();
+    expect(filterExceptionForPosthog(make())).toBeNull();
+  });
+
+  it('does not fingerprint unrelated errors', () => {
+    const e = {
+      event: '$exception',
+      properties: { $exception_list: [{ value: 'TypeError: foo is not a function' }] },
+    };
+    const result = filterExceptionForPosthog(e);
+    expect(result).toBe(e);
+    expect(result?.properties?.$exception_fingerprint).toBeUndefined();
+  });
+});
+
 describe('filterExceptionForPosthog — per-session capture cap', () => {
   const appError = (value: string): Parameters<typeof filterExceptionForPosthog>[0] => ({
     event: '$exception',

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -58,6 +58,22 @@ const WORKER_RESET_ERROR = 'Worker was reset';
 const WORKER_RESET_FINGERPRINT = 'generation-worker-reset';
 
 /**
+ * troika-three-text (behind every `<Text>` in the 3D previews) fails to
+ * `eval` the stringified module it hands its SDF-glyph worker on some WebKit
+ * builds. Real, recurring — 25+ Safari/Mobile Safari users since March, not
+ * one browser version — not extension noise. Its stack points at whichever
+ * chunk renders text that session (`three-render`, `react-three`, ...), so
+ * message-based grouping minted a fresh issue (and a new auto-filed bug) per
+ * deploy. `configureTroikaText.ts` forces the main-thread fallback so this
+ * shouldn't recur going forward; pin the fingerprint for the sessions still
+ * on an older deploy and capture once — every subsequent `<Text>` sync in an
+ * affected session throws the same error again.
+ */
+const TROIKA_WORKER_INIT_ERROR =
+  'Worker module function was called but `init` did not return a callable function';
+const TROIKA_WORKER_INIT_FINGERPRINT = 'troika-worker-init-failed';
+
+/**
  * Per-session capture ceilings.
  *
  * Error tracking has its own monthly exception quota, and one looping client
@@ -73,11 +89,13 @@ const WORKER_RESET_FINGERPRINT = 'generation-worker-reset';
 const SESSION_EXCEPTION_CAP = 10;
 const sessionCaptureCounts = new Map<string, number>();
 let chunkLoadCaptured = false;
+let troikaWorkerInitCaptured = false;
 
 /** Test seam: clears the per-session capture counters. */
 export function resetSessionCaptureCounts(): void {
   sessionCaptureCounts.clear();
   chunkLoadCaptured = false;
+  troikaWorkerInitCaptured = false;
 }
 
 const IGNORED_MESSAGE_PATTERNS: readonly RegExp[] = [
@@ -249,6 +267,15 @@ export function filterExceptionForPosthog(
     event.properties = {
       ...event.properties,
       $exception_fingerprint: CHUNK_LOAD_FINGERPRINT,
+    };
+  }
+
+  if (primary !== undefined && primary.includes(TROIKA_WORKER_INIT_ERROR)) {
+    if (troikaWorkerInitCaptured) return null;
+    troikaWorkerInitCaptured = true;
+    event.properties = {
+      ...event.properties,
+      $exception_fingerprint: TROIKA_WORKER_INIT_FINGERPRINT,
     };
   }
 

--- a/src/shared/analytics/posthog/errorFilters.ts
+++ b/src/shared/analytics/posthog/errorFilters.ts
@@ -58,16 +58,11 @@ const WORKER_RESET_ERROR = 'Worker was reset';
 const WORKER_RESET_FINGERPRINT = 'generation-worker-reset';
 
 /**
- * troika-three-text (behind every `<Text>` in the 3D previews) fails to
- * `eval` the stringified module it hands its SDF-glyph worker on some WebKit
- * builds. Real, recurring — 25+ Safari/Mobile Safari users since March, not
- * one browser version — not extension noise. Its stack points at whichever
- * chunk renders text that session (`three-render`, `react-three`, ...), so
- * message-based grouping minted a fresh issue (and a new auto-filed bug) per
- * deploy. `configureTroikaText.ts` forces the main-thread fallback so this
- * shouldn't recur going forward; pin the fingerprint for the sessions still
- * on an older deploy and capture once — every subsequent `<Text>` sync in an
- * affected session throws the same error again.
+ * troika-three-text's worker-init failure (see `configureTroikaText.ts`).
+ * Its stack points at whichever chunk renders text that session, so
+ * message-based grouping mints a fresh issue per deploy. Capture once per
+ * session: every subsequent `<Text>` sync in an affected session throws
+ * the same error again.
  */
 const TROIKA_WORKER_INIT_ERROR =
   'Worker module function was called but `init` did not return a callable function';

--- a/src/shared/components/GlbViewer/GlbViewer.tsx
+++ b/src/shared/components/GlbViewer/GlbViewer.tsx
@@ -10,6 +10,8 @@ import {
 import type { ReactNode } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Bounds, Center, OrbitControls, useGLTF, useProgress } from '@react-three/drei';
+// Side-effect: must run before any <Text> mounts under this Canvas.
+import '@/shared/webgl/configureTroikaText';
 import { Button, ProgressBar, cn } from '@/design-system';
 import { usePrefersReducedMotion } from '@/shared/hooks/usePrefersReducedMotion';
 import { useTranslation } from '@/i18n';

--- a/src/shared/webgl/configureTroikaText.test.ts
+++ b/src/shared/webgl/configureTroikaText.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('configureTroikaText', () => {
+  it('disables the troika-three-text worker on import', async () => {
+    const configureTextBuilder = vi.fn();
+    vi.doMock('troika-three-text', () => ({ configureTextBuilder }));
+    vi.resetModules();
+
+    await import('./configureTroikaText');
+
+    expect(configureTextBuilder).toHaveBeenCalledWith({ useWorker: false });
+
+    vi.doUnmock('troika-three-text');
+  });
+});

--- a/src/shared/webgl/configureTroikaText.ts
+++ b/src/shared/webgl/configureTroikaText.ts
@@ -1,0 +1,12 @@
+import { configureTextBuilder } from 'troika-three-text';
+
+/**
+ * Some WebKit builds fail to `eval` the stringified module troika-three-text
+ * hands to its SDF-glyph worker, so every `<Text>` sync throws "Worker module
+ * function was called but `init` did not return a callable function" instead
+ * of laying out text (tracked as the `troika-worker-init-failed` PostHog
+ * fingerprint in errorFilters.ts — WebKit only, every version, growing).
+ * Forcing the main-thread code path sidesteps that eval entirely; it's still
+ * asynchronous, so this doesn't block a frame.
+ */
+configureTextBuilder({ useWorker: false });

--- a/src/shared/webgl/troika-three-text.d.ts
+++ b/src/shared/webgl/troika-three-text.d.ts
@@ -1,0 +1,3 @@
+declare module 'troika-three-text' {
+  export function configureTextBuilder(config: { useWorker?: boolean }): void;
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,6 +9,7 @@
   "include": [
     "src/vite-env.d.ts",
     "src/global.d.ts",
+    "src/shared/webgl/troika-three-text.d.ts",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/*.testUtils.ts",


### PR DESCRIPTION
## Summary
- `troika-three-text` (behind every `<Text>` in the 3D previews) fails to `eval` its worker module on some WebKit builds, throwing `Worker module function was called but \`init\` did not return a callable function` instead of laying out text. PostHog shows 60 occurrences across 25+ Safari/Mobile Safari users since March, ramping up recently — real and recurring, not extension noise.
- Force troika's documented main-thread fallback (`configureTextBuilder({ useWorker: false })`, still async) before any `<Text>` can mount, across every independent Canvas entry point.
- Pin a stable PostHog fingerprint for the failure so it stops minting a fresh issue (and a new auto-filed GitHub issue) every deploy — its stack points at whichever chunk renders text that session.

Closes #3969.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run knip`
- [x] `pnpm exec vitest run` on `errorFilters`, `configureTroikaText`, and every touched feature directory (1660 tests)
- [ ] CI

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

