### PR TITLE
feat(design-system): adopt the type ramp and retire ad-hoc text sizes

### DIFF
--- a/src/design-system/Badge/Badge.test.tsx
+++ b/src/design-system/Badge/Badge.test.tsx
@@ -89,7 +89,7 @@ describe('Badge', () => {
   describe('size', () => {
     it('defaults to sm', () => {
       render(<Badge>3</Badge>);
-      expect(screen.getByText('3')).toHaveClass('text-[10px]', 'px-1.5', 'py-0.5');
+      expect(screen.getByText('3')).toHaveClass('text-micro', 'px-1.5', 'py-0.5');
     });
 
     it('applies md size', () => {

--- a/src/design-system/Badge/Badge.tsx
+++ b/src/design-system/Badge/Badge.tsx
@@ -24,7 +24,7 @@ const badgeVariants = cva(
         pill: 'rounded-full',
       },
       size: {
-        sm: ['text-[10px]', 'px-1.5', 'py-0.5'],
+        sm: ['text-micro', 'px-1.5', 'py-0.5'],
         md: ['text-xs', 'px-2', 'py-0.5'],
       },
     },

--- a/src/design-system/Collapsible/Collapsible.tsx
+++ b/src/design-system/Collapsible/Collapsible.tsx
@@ -4,11 +4,11 @@ import { cn } from '../cn';
 import { ChevronDownIcon } from '../Icon';
 import { focusRing, interactiveTransition } from '../variants';
 
-const headerVariants = cva(['font-semibold', 'tracking-wide'], {
+const headerVariants = cva(['font-semibold'], {
   variants: {
     size: {
-      sm: 'text-xs text-content-tertiary uppercase tracking-wider',
-      md: 'text-sm text-content-secondary',
+      sm: 'text-section uppercase text-content-tertiary',
+      md: 'text-sm tracking-wide text-content-secondary',
     },
   },
   defaultVariants: {

--- a/src/design-system/Dialog/Dialog.test.tsx
+++ b/src/design-system/Dialog/Dialog.test.tsx
@@ -472,7 +472,7 @@ describe('Dialog', () => {
       );
       const header = screen.getByText('Test').parentElement?.parentElement;
       expect(header?.className).toContain('pb-4');
-      expect(screen.getByText('Test').className).toContain('text-xl');
+      expect(screen.getByText('Test').className).toContain('text-page');
     });
 
     it('drops the bottom inset at compact density so a tab row sits on the border', () => {
@@ -489,7 +489,7 @@ describe('Dialog', () => {
       expect(header?.className).not.toContain('pb-4');
       expect(header?.className).not.toContain('pb-2');
       expect(header?.className).toContain('border-b');
-      expect(screen.getByText('Test').className).toContain('text-base');
+      expect(screen.getByText('Test').className).toContain('text-title');
     });
   });
 

--- a/src/design-system/Dialog/DialogParts.tsx
+++ b/src/design-system/Dialog/DialogParts.tsx
@@ -158,7 +158,7 @@ export function DialogHeader({
             id={titleId}
             className={cn(
               'font-semibold text-content',
-              density === 'compact' ? 'truncate text-base' : 'text-xl'
+              density === 'compact' ? 'truncate text-title' : 'text-page'
             )}
           >
             {title}

--- a/src/design-system/Kbd/Kbd.tsx
+++ b/src/design-system/Kbd/Kbd.tsx
@@ -5,7 +5,7 @@ import { cn } from '../cn';
 import { intentText } from '../variants';
 
 const kbdVariants = cva(
-  ['inline-block', 'px-1.5 py-0.5', 'rounded border', 'text-[10px] leading-none', 'align-middle'],
+  ['inline-block', 'px-1.5 py-0.5', 'rounded border', 'text-micro leading-none', 'align-middle'],
   {
     variants: {
       tone: {

--- a/src/design-system/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.test.tsx
@@ -184,7 +184,7 @@ describe('SegmentedControl', () => {
 
   it('applies compact text size for size sm', () => {
     render(<SegmentedControl {...defaultProps} size="sm" />);
-    expect(screen.getByRole('radio', { name: 'List' }).className).toContain('text-[11px]');
+    expect(screen.getByRole('radio', { name: 'List' }).className).toContain('text-label');
   });
 
   it('stretches segments equally when fullWidth', () => {

--- a/src/design-system/SegmentedControl/SegmentedControl.tsx
+++ b/src/design-system/SegmentedControl/SegmentedControl.tsx
@@ -32,7 +32,7 @@ const segmentVariants = cva(
   {
     variants: {
       size: {
-        sm: ['text-[11px]', 'px-2', 'py-0.5'],
+        sm: ['text-label', 'px-2', 'py-0.5'],
         md: ['text-xs', 'px-2.5', 'py-1.5'],
       },
       activeStyle: {

--- a/src/design-system/SliderInput/EditableValueBadge.tsx
+++ b/src/design-system/SliderInput/EditableValueBadge.tsx
@@ -122,7 +122,7 @@ export function EditableValueBadge({
           onKeyDown={handleInputKeyDown}
           disabled={disabled}
           className={cn(
-            'w-16 rounded-md bg-surface px-2 py-0.5 text-right text-sm font-semibold tabular-nums text-content outline-none',
+            'w-16 rounded-md bg-surface px-2 py-0.5 text-right text-value tabular-nums text-content outline-none',
             'ring-2 ring-accent'
           )}
           aria-label={label}
@@ -135,7 +135,7 @@ export function EditableValueBadge({
           onClick={startEditing}
           disabled={disabled}
           className={cn(
-            'rounded-md bg-surface-secondary px-2 py-0.5 text-sm font-semibold tabular-nums text-content',
+            'rounded-md bg-surface-secondary px-2 py-0.5 text-value tabular-nums text-content',
             interactiveTransition,
             !disabled && 'cursor-text hover:ring-1 hover:ring-stroke-subtle',
             disabled && 'cursor-not-allowed'

--- a/src/design-system/SliderInput/SliderInput.tsx
+++ b/src/design-system/SliderInput/SliderInput.tsx
@@ -64,10 +64,7 @@ export function SliderInput({
     >
       {/* Label row with editable value badge */}
       <div className="flex items-center justify-between mb-1">
-        <label
-          htmlFor={isEditing ? id : undefined}
-          className="text-xs font-medium text-content-secondary"
-        >
+        <label htmlFor={isEditing ? id : undefined} className="text-label text-content-secondary">
           {label}
         </label>
 
@@ -87,7 +84,7 @@ export function SliderInput({
       </div>
 
       {info && (
-        <p id={infoId} className="mb-1 text-[10px] text-content-tertiary">
+        <p id={infoId} className="mb-1 text-micro text-content-tertiary">
           {info}
         </p>
       )}

--- a/src/design-system/Tabs/Tabs.tsx
+++ b/src/design-system/Tabs/Tabs.tsx
@@ -285,7 +285,7 @@ export function TabsList<T extends string>({
           >
             {tab.label}
             {tab.badge !== undefined && tab.badge !== null && (
-              <span className="text-xs tabular-nums">{tab.badge}</span>
+              <span className="text-value tabular-nums">{tab.badge}</span>
             )}
           </button>
         );

--- a/src/design-system/docs/TOKENS.md
+++ b/src/design-system/docs/TOKENS.md
@@ -91,7 +91,7 @@ Face: Inter variable (self-hosted, 400–700), IBM Plex Mono for code/kbd. All t
 | `xl`   | 18/24   | Panel titles     |
 | `2xl`  | 24/32   | Page title       |
 
-`text-xxs` is a temporary 10px utility (size and line-height only, none of the role sub-tokens); its call sites move to `text-micro` in the adoption PR and the token is then removed.
+Arbitrary sizes (`text-[10px]`, `text-[11px]`) and the old `text-xxs` alias are gone; use the role ramp.
 
 ## Component Size Scale
 

--- a/src/features/baseplate/components/BaseplateLibraryModal/BaseplateLibraryModal.tsx
+++ b/src/features/baseplate/components/BaseplateLibraryModal/BaseplateLibraryModal.tsx
@@ -295,7 +295,7 @@ function BaseplateCard({
         )}
         {isActive && (
           <span
-            className="absolute top-1.5 right-1.5 rounded bg-accent px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-on-dark"
+            className="absolute top-1.5 right-1.5 rounded bg-accent px-1.5 py-0.5 text-micro font-semibold uppercase tracking-wide text-on-dark"
             aria-label={t('baseplate.library.currentlyActive')}
           >
             {t('baseplate.library.active')}

--- a/src/features/baseplate/components/BaseplatePanel/BaseSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/BaseSection.tsx
@@ -190,7 +190,7 @@ export function BaseSection() {
                         }
                         label={t('baseplate.connectorSlotsAllEdges')}
                       />
-                      <p className="text-[11px] leading-relaxed text-content-tertiary pl-6">
+                      <p className="text-label leading-relaxed text-content-tertiary pl-6">
                         {t('baseplate.connectorSlotsAllEdgesHint')}
                       </p>
                     </div>
@@ -204,7 +204,7 @@ export function BaseSection() {
                   />
                   <ConnectorSampleButton />
                   {nozzleSizeMm > NOZZLE_BASELINE && (
-                    <p className="text-[11px] leading-relaxed text-content-tertiary">
+                    <p className="text-label leading-relaxed text-content-tertiary">
                       {t('baseplate.connectorNozzleNotice', { nozzle: nozzleSizeMm })}
                     </p>
                   )}
@@ -274,7 +274,7 @@ export function BaseSection() {
                   onChange={() => updateScrewHoles({ enabled: !screwHolesOn })}
                   valueSummary={screwSummary}
                   primaryControls={
-                    <p className="text-[11px] leading-relaxed text-content-tertiary">
+                    <p className="text-label leading-relaxed text-content-tertiary">
                       {t('baseplate.screwHoles.info')}
                     </p>
                   }

--- a/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/ConnectorPicker.tsx
@@ -108,7 +108,7 @@ export function ConnectorPicker({
 
   return (
     <div className="space-y-1.5">
-      <div className="text-[11px] font-medium uppercase tracking-wide text-content-tertiary">
+      <div className="text-label font-medium uppercase tracking-wide text-content-tertiary">
         {t('baseplate.connectors.label')}
       </div>
       <div
@@ -160,7 +160,7 @@ export function ConnectorPicker({
                   <h4 className="text-sm font-medium text-content-primary">{t(titleKey)}</h4>
                   <p className="mt-0.5 text-xs text-content-secondary">{t(descKey)}</p>
                   {disabled && (
-                    <p className="mt-0.5 text-[11px] text-content-tertiary">{disabledReason}</p>
+                    <p className="mt-0.5 text-label text-content-tertiary">{disabledReason}</p>
                   )}
                 </div>
               </Button>

--- a/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/DimensionsSection.tsx
@@ -348,7 +348,7 @@ export function DimensionsSection() {
         {/* Fractional edge position — shown when the effective dimensions are half-unit */}
         {(hasFractionalWidth || hasFractionalDepth) && (
           <div className="space-y-1.5">
-            <div className="text-content-tertiary text-[10px] mb-1">
+            <div className="text-content-tertiary text-micro mb-1">
               {t('sidebar.halfUnitEdgePosition')}
             </div>
             {hasFractionalWidth && (
@@ -397,7 +397,7 @@ export function DimensionsSection() {
             />
           </div>
           {extentNoteKey !== undefined && (
-            <span className="text-[11px] italic text-content-tertiary">{t(extentNoteKey)}</span>
+            <span className="text-label italic text-content-tertiary">{t(extentNoteKey)}</span>
           )}
         </div>
 
@@ -410,10 +410,10 @@ export function DimensionsSection() {
             unreachable. */}
         {outlineActive && (
           <div className="space-y-2 border-t border-stroke-subtle pt-3">
-            <div className="text-[11px] font-medium uppercase tracking-wide text-content-tertiary">
+            <div className="text-label font-medium uppercase tracking-wide text-content-tertiary">
               {t('baseplate.gridPosition')}
             </div>
-            <p className="text-[11px] leading-relaxed text-content-tertiary">
+            <p className="text-label leading-relaxed text-content-tertiary">
               {t('baseplate.gridPositionHint')}
             </p>
             <GridAlignmentControls />
@@ -423,11 +423,11 @@ export function DimensionsSection() {
         {/* Padding — spatial schematic. Padding composes with every shape,
             so the controls stay live; a notice explains the shaped case. */}
         <div className="space-y-2 border-t border-stroke-subtle pt-3">
-          <div className="text-[11px] font-medium uppercase tracking-wide text-content-tertiary">
+          <div className="text-label font-medium uppercase tracking-wide text-content-tertiary">
             {t('baseplate.padding')}
           </div>
           {cornerShaped && (
-            <p className="text-[11px] leading-relaxed text-content-tertiary">
+            <p className="text-label leading-relaxed text-content-tertiary">
               {t('baseplate.cornerShapedPaddingNotice')}
             </p>
           )}
@@ -435,8 +435,8 @@ export function DimensionsSection() {
             <p
               className={
                 shapedPaddingComposes
-                  ? 'text-[11px] leading-relaxed text-content-tertiary'
-                  : 'text-[11px] leading-relaxed text-status-warning'
+                  ? 'text-label leading-relaxed text-content-tertiary'
+                  : 'text-label leading-relaxed text-warning'
               }
             >
               {t(
@@ -453,7 +453,7 @@ export function DimensionsSection() {
                 checked={wholeCellsOn}
                 onChange={setWholeCells}
               />
-              <p className="text-[11px] leading-relaxed text-content-tertiary">
+              <p className="text-label leading-relaxed text-content-tertiary">
                 {t('baseplate.wholeCellsOnlyHint')}
               </p>
             </div>
@@ -501,7 +501,7 @@ export function DimensionsSection() {
                             />
                           </div>
                         )}
-                        <div className="space-y-1 text-[11px] leading-relaxed">
+                        <div className="space-y-1 text-label leading-relaxed">
                           <p className="text-content-tertiary">
                             {t(
                               halfGridOn
@@ -530,7 +530,7 @@ export function DimensionsSection() {
                     ) : (
                       // Fill is on but no edge can fit a tile right now — keep the
                       // toggle enabled (so it can be turned off) and explain why.
-                      <p className="text-[11px] leading-relaxed text-content-tertiary">
+                      <p className="text-label leading-relaxed text-content-tertiary">
                         {t('baseplate.overTileTooSmall')}
                       </p>
                     )}
@@ -556,7 +556,7 @@ export function DimensionsSection() {
                   // On but nothing meets the threshold → no rails are emitted,
                   // so say so rather than imply they will.
                   !canDetach ? (
-                    <p className="text-[11px] leading-relaxed text-content-tertiary">
+                    <p className="text-label leading-relaxed text-content-tertiary">
                       {t('baseplate.detachMarginsTooSmall')}
                     </p>
                   ) : (
@@ -568,7 +568,7 @@ export function DimensionsSection() {
                         disabled={!marginConnectorStyleOk}
                         indent
                       />
-                      <p className="text-[11px] leading-relaxed text-content-tertiary pl-6">
+                      <p className="text-label leading-relaxed text-content-tertiary pl-6">
                         {marginConnectorStyleOk
                           ? t('baseplate.detachMarginConnectorHint')
                           : t('baseplate.detachMarginConnectorStyle')}

--- a/src/features/baseplate/components/BaseplatePanel/PhysicalUnitsSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/PhysicalUnitsSection.tsx
@@ -118,7 +118,7 @@ export function PhysicalUnitsSection() {
                   onChange={(value) => useLayoutStore.getState().setMagnetAnchor(value)}
                 />
               </SettingsRow>
-              <p className="text-[11px] leading-relaxed text-content-tertiary">
+              <p className="text-label leading-relaxed text-content-tertiary">
                 {t(
                   magnetAnchor === 'center'
                     ? 'baseplate.magnetAnchorHintLegacy'

--- a/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/SplitViewStrip.tsx
@@ -123,7 +123,7 @@ export function SplitViewStrip({
             count: tiling.pieces.length,
           })}
         </span>
-        <span className="text-[11px] text-content-tertiary whitespace-nowrap">
+        <span className="text-label text-content-tertiary whitespace-nowrap">
           {tiling.isCustomSplit
             ? t('baseplate.splitCustom')
             : t('baseplate.splitReason', { printBed: printBedSize })}
@@ -131,7 +131,7 @@ export function SplitViewStrip({
       </div>
 
       <div className="px-4 pb-1">
-        <span className="text-[11px] text-content-secondary">
+        <span className="text-label text-content-secondary">
           {t(tiling.bedLoads === 1 ? 'baseplate.bedLoads.one' : 'baseplate.bedLoads.other', {
             count: tiling.bedLoads,
           })}
@@ -139,7 +139,7 @@ export function SplitViewStrip({
       </div>
 
       {tiling.paddingReductionHint && (
-        <div className="mx-4 mb-2 rounded bg-accent/10 px-2.5 py-1.5 text-[11px] text-accent">
+        <div className="mx-4 mb-2 rounded bg-accent/10 px-2.5 py-1.5 text-label text-accent">
           {t('baseplate.paddingHint', {
             axis: t(PADDING_HINT_AXIS_KEYS[tiling.paddingReductionHint.axis]),
             mm: tiling.paddingReductionHint.reductionMm,
@@ -151,7 +151,7 @@ export function SplitViewStrip({
       {tiling.bedOverages.length > 0 && (
         <div
           role="alert"
-          className="mx-4 mb-2 rounded bg-danger/10 px-2.5 py-1.5 text-[11px] text-danger"
+          className="mx-4 mb-2 rounded bg-danger/10 px-2.5 py-1.5 text-label text-danger"
         >
           {t('baseplate.splitOverBed', {
             pieces: tiling.bedOverages.map((o) => o.label).join(', '),
@@ -275,7 +275,7 @@ export function SplitViewStrip({
                     type="button"
                     touchTarget={false}
                     style={{ gridColumn: c + 1, gridRow: rowSizes.length - r }}
-                    className={`flex !h-auto items-center justify-center overflow-hidden rounded-none border !px-0 !py-0 font-mono text-[10px] font-normal transition-shadow ${
+                    className={`flex !h-auto items-center justify-center overflow-hidden rounded-none border !px-0 !py-0 font-mono text-micro font-normal transition-shadow ${
                       overage
                         ? 'border-danger bg-danger/10 text-danger ring-1 ring-danger'
                         : isSelected
@@ -323,13 +323,13 @@ export function SplitViewStrip({
       </div>
 
       <div className="flex items-baseline justify-between gap-2 px-4 pb-3">
-        <span className="text-[11px] text-content-tertiary">{t('baseplate.splitEditHint')}</span>
+        <span className="text-label text-content-tertiary">{t('baseplate.splitEditHint')}</span>
         {tiling.isCustomSplit && (
           <Button
             variant="ghost"
             size="sm"
             type="button"
-            className="!px-1 text-[11px]"
+            className="!px-1 text-label"
             onClick={() => onChangeSplit(undefined)}
           >
             {t('baseplate.splitResetAuto')}

--- a/src/features/baseplate/components/BaseplatePanel/StackPrintSection.tsx
+++ b/src/features/baseplate/components/BaseplatePanel/StackPrintSection.tsx
@@ -124,7 +124,7 @@ export function StackPrintSection({ stackPrint, onChange }: StackPrintSectionPro
               </Alert>
             )}
 
-            <p className="text-[11px] leading-relaxed text-content-secondary">
+            <p className="text-label leading-relaxed text-content-secondary">
               {t('baseplate.stackPrint.hint')}
             </p>
 
@@ -169,7 +169,7 @@ export function StackPrintSection({ stackPrint, onChange }: StackPrintSectionPro
               </Alert>
             )}
 
-            <div className="space-y-2 rounded border border-info/30 bg-info-muted px-2.5 py-2 text-[11px] leading-relaxed text-content-secondary">
+            <div className="space-y-2 rounded border border-info/30 bg-info-muted px-2.5 py-2 text-label leading-relaxed text-content-secondary">
               <p className="font-semibold text-info">{t('baseplate.stackPrint.tips.heading')}</p>
               <div className="space-y-0.5">
                 <p className="font-medium text-content">

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreviewControls.tsx
@@ -164,7 +164,7 @@ export function BaseplatePreviewControls({
                   type="button"
                   variant="ghost"
                   onClick={() => onViewModeChange(value)}
-                  className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+                  className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
                     isActive
                       ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                       : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -190,7 +190,7 @@ export function BaseplatePreviewControls({
                 type="button"
                 variant="ghost"
                 onClick={() => onCameraPreset(key)}
-                className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+                className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
                   isActive
                     ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                     : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -212,7 +212,7 @@ export function BaseplatePreviewControls({
             type="button"
             variant="ghost"
             onClick={onResetView}
-            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.resetView')}
             aria-label={t('baseplate.resetView')}
           >
@@ -225,7 +225,7 @@ export function BaseplatePreviewControls({
             type="button"
             variant="ghost"
             onClick={onToggleXray}
-            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
+            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium transition-colors focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation ${
               xray
                 ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
                 : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -243,7 +243,7 @@ export function BaseplatePreviewControls({
             type="button"
             variant="ghost"
             onClick={onToggleProjection}
-            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.toggleProjection')}
             aria-label={t('baseplate.toggleProjectionKeyboardShortcut')}
             aria-pressed={projection === 'orthographic'}
@@ -264,7 +264,7 @@ export function BaseplatePreviewControls({
             type="button"
             variant="ghost"
             onClick={() => setColorPickerOpen((v) => !v)}
-            className="flex items-center gap-1.5 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1.5 rounded-none px-2.5 py-1.5 text-label font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset focus-visible:outline-none min-h-[28px] touch-manipulation"
             title={t('baseplate.filamentColor')}
             aria-label={t('baseplate.filamentColor')}
             aria-expanded={colorPickerOpen}

--- a/src/features/baseplate/components/BaseplatePreview/StackSeparationSlider.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/StackSeparationSlider.tsx
@@ -101,7 +101,7 @@ export function StackSeparationSlider({ value, onChange }: StackSeparationSlider
       onPointerEnter={() => setIsHovering(true)}
       onPointerLeave={() => setIsHovering(false)}
     >
-      <span className="text-[11px] font-medium text-content-secondary">
+      <span className="text-label font-medium text-content-secondary">
         {t('baseplate.stackPrint.separate')}
       </span>
 
@@ -162,7 +162,7 @@ export function StackSeparationSlider({ value, onChange }: StackSeparationSlider
         />
       </div>
 
-      <span className="text-[11px] font-medium text-content-secondary">
+      <span className="text-label font-medium text-content-secondary">
         {t('baseplate.stackPrint.together')}
       </span>
     </div>

--- a/src/features/baseplate/components/DeleteBaseplateWarningDialog/DeleteBaseplateWarningDialog.tsx
+++ b/src/features/baseplate/components/DeleteBaseplateWarningDialog/DeleteBaseplateWarningDialog.tsx
@@ -76,9 +76,9 @@ export function DeleteBaseplateWarningDialog({
         tabIndex={-1}
       >
         <div className="flex items-center gap-3 mb-3">
-          <div className="w-9 h-9 rounded-full bg-status-warning/10 flex items-center justify-center flex-shrink-0">
+          <div className="w-9 h-9 rounded-full bg-warning/10 flex items-center justify-center flex-shrink-0">
             <svg
-              className="w-5 h-5 text-status-warning"
+              className="w-5 h-5 text-warning"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"

--- a/src/features/bin-designer/components/BentoWorkspace/BentoBinWideSection.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoBinWideSection.tsx
@@ -54,7 +54,7 @@ export function BentoBinWideSection() {
 
   return (
     <section className="mt-4 flex flex-col gap-4 border-t border-stroke-subtle pt-3">
-      <span className="text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+      <span className="text-micro font-semibold uppercase tracking-wider text-content-tertiary">
         {t('binDesigner.bento.binWideTitle')}
       </span>
       <SnappingSlider
@@ -85,7 +85,7 @@ export function BentoBinWideSection() {
           </span>
           <Checkbox checked={mergeBackground} />
         </div>
-        <p className="text-[11px] leading-relaxed text-content-tertiary">
+        <p className="text-label leading-relaxed text-content-tertiary">
           {t('binDesigner.bento.mergeBackgroundHint')}
         </p>
       </div>

--- a/src/features/bin-designer/components/BentoWorkspace/BentoCanvas.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoCanvas.tsx
@@ -416,7 +416,7 @@ export function BentoCanvas({
                   </span>
                 ) : null}
                 {!region && h > 34 && (
-                  <span className="text-[10px] tabular-nums text-content-tertiary">
+                  <span className="text-micro tabular-nums text-content-tertiary">
                     {t('binDesigner.bento.compartmentSize', { width: widthMm, depth: depthMm })}
                   </span>
                 )}
@@ -425,7 +425,7 @@ export function BentoCanvas({
             <text
               x={caption.x + 8}
               y={caption.y + 14}
-              className="fill-content-tertiary text-[9px] tabular-nums"
+              className="fill-content-tertiary text-micro tabular-nums"
               pointerEvents="none"
               style={{ opacity: isMoving ? 0.4 : 1 }}
             >
@@ -474,7 +474,7 @@ export function BentoCanvas({
           >
             <div className="flex h-full items-center">
               <span
-                className="rounded bg-surface/90 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-content-secondary shadow-sm"
+                className="rounded bg-surface/90 px-1.5 py-0.5 text-micro font-medium tabular-nums text-content-secondary shadow-sm"
                 data-testid="bento-ghost-size"
               >
                 {t('binDesigner.bento.sizeMm', {

--- a/src/features/bin-designer/components/BentoWorkspace/BentoCompartmentColorControls.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoCompartmentColorControls.tsx
@@ -48,7 +48,7 @@ export function BentoCompartmentColorControls({
 
   return (
     <div className="space-y-2">
-      <span className="block text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+      <span className="block text-micro font-semibold uppercase tracking-wider text-content-tertiary">
         {t('common.color')}
       </span>
       <CheckboxRow
@@ -85,14 +85,14 @@ export function BentoCompartmentColorControls({
                 variant="ghost"
                 onClick={() => setCompartmentColorScope(compartmentId, s)}
                 aria-pressed={scope === s}
-                className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(scope === s)}`}
+                className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(scope === s)}`}
               >
                 {t(`binDesigner.cutouts.color.${s}`)}
               </Button>
             ))}
           </div>
 
-          <p className="text-[10px] leading-relaxed text-content-tertiary">
+          <p className="text-micro leading-relaxed text-content-tertiary">
             {t('binDesigner.bento.color.note')}
           </p>
         </>

--- a/src/features/bin-designer/components/BentoWorkspace/BentoDock.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoDock.tsx
@@ -205,7 +205,7 @@ export function BentoDock({
           <Icon paths={ICON_PATHS.chevronDoubleLeft} />
         </IconButton>
         <span
-          className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-content-tertiary"
+          className="mt-3 text-micro font-semibold uppercase tracking-wider text-content-tertiary"
           style={{ writingMode: 'vertical-rl' }}
         >
           {t('binDesigner.bento.dockTitle')}
@@ -322,7 +322,7 @@ export function BentoDock({
                       {row.label ||
                         t('binDesigner.bento.compartmentFallbackName', { number: row.number })}
                     </span>
-                    <span className="flex-shrink-0 tabular-nums text-[10px] text-content-tertiary">
+                    <span className="flex-shrink-0 tabular-nums text-micro text-content-tertiary">
                       {t('binDesigner.bento.sizeMm', {
                         w: Math.round(row.rect.w * cellWmm),
                         d: Math.round(row.rect.h * cellHmm),
@@ -339,7 +339,7 @@ export function BentoDock({
         {selectedRow && (
           <div className="mt-4 flex flex-col gap-4 border-t border-stroke-subtle pt-3">
             <div>
-              <label className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+              <label className="mb-1 block text-micro font-semibold uppercase tracking-wider text-content-tertiary">
                 {t('binDesigner.bento.labelField')}
               </label>
               {/* Full-width tabs print `label.rowTexts`, one caption per ROW,
@@ -347,7 +347,7 @@ export function BentoDock({
                   (#2897). Disabled rather than hidden — the stored text is kept
                   and comes back when span is switched off. */}
               {labelSpan ? (
-                <p className="text-[10px] leading-relaxed text-content-tertiary">
+                <p className="text-micro leading-relaxed text-content-tertiary">
                   {t('binDesigner.bento.labelSpanDisabled')}
                 </p>
               ) : (
@@ -361,7 +361,7 @@ export function BentoDock({
                     focusToken={labelFocusToken}
                   />
                   {!labelEnabled && (
-                    <p className="mt-1 text-[10px] leading-relaxed text-content-tertiary">
+                    <p className="mt-1 text-micro leading-relaxed text-content-tertiary">
                       {t('binDesigner.bento.labelTabsAuto')}
                     </p>
                   )}
@@ -401,11 +401,11 @@ export function BentoDock({
 
             {/* Wall shift/angle — the canvas shows the result, this edits it */}
             <div className="flex flex-col gap-3">
-              <span className="text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+              <span className="text-micro font-semibold uppercase tracking-wider text-content-tertiary">
                 {t('binDesigner.bento.wallsTitle')}
               </span>
               {selectedWalls.length === 0 ? (
-                <p className="text-[10px] leading-relaxed text-content-tertiary">
+                <p className="text-micro leading-relaxed text-content-tertiary">
                   {t('binDesigner.bento.wallsEmptyHint')}
                 </p>
               ) : (
@@ -435,7 +435,7 @@ export function BentoDock({
                             variant="ghost"
                             size="sm"
                             onClick={() => tilt.handlers.resetRow(wall)}
-                            className="h-auto px-1.5 py-0.5 text-[10px] text-accent hover:bg-transparent hover:text-accent/80"
+                            className="h-auto px-1.5 py-0.5 text-micro text-accent hover:bg-transparent hover:text-accent/80"
                           >
                             {t('common.reset')}
                           </Button>
@@ -443,7 +443,7 @@ export function BentoDock({
                       </div>
                       {wall.geometry ? (
                         <div className="grid grid-cols-2 gap-2">
-                          <label className="flex flex-col gap-0.5 text-[10px] text-content-tertiary">
+                          <label className="flex flex-col gap-0.5 text-micro text-content-tertiary">
                             {t('binDesigner.bento.wallShift')}
                             <Stepper
                               value={wall.shiftMm}
@@ -468,7 +468,7 @@ export function BentoDock({
                               aria-label={t('binDesigner.bento.wallShift')}
                             />
                           </label>
-                          <label className="flex flex-col gap-0.5 text-[10px] text-content-tertiary">
+                          <label className="flex flex-col gap-0.5 text-micro text-content-tertiary">
                             {t('binDesigner.bento.wallAngle')}
                             <Stepper
                               value={wall.angleDeg}
@@ -495,7 +495,7 @@ export function BentoDock({
                           </label>
                         </div>
                       ) : (
-                        <p className="text-[10px] text-content-tertiary">
+                        <p className="text-micro text-content-tertiary">
                           {t('binDesigner.bento.wallTooSmall')}
                         </p>
                       )}

--- a/src/features/bin-designer/components/BentoWorkspace/BentoGridSetup.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoGridSetup.tsx
@@ -119,7 +119,7 @@ export function BentoGridSetup({
               <span className="text-xs font-semibold tabular-nums">
                 {option.cols}×{option.rows}
               </span>
-              <span className="text-[10px] font-normal tabular-nums text-content-tertiary">
+              <span className="text-micro font-normal tabular-nums text-content-tertiary">
                 {t('binDesigner.bento.gridSetupCellSize', {
                   w: Math.round(option.cellW),
                   d: Math.round(option.cellH),
@@ -128,7 +128,7 @@ export function BentoGridSetup({
             </Button>
           ))}
         </div>
-        <p className="text-[10px] text-content-tertiary">
+        <p className="text-micro text-content-tertiary">
           {t('binDesigner.bento.gridSetupCustomHint')}
         </p>
       </div>

--- a/src/features/bin-designer/components/BentoWorkspace/BentoStashShelf.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoStashShelf.tsx
@@ -91,7 +91,7 @@ export function BentoStashShelf({
         <span className="text-xs font-semibold text-content-secondary">
           {t('binDesigner.bento.stashTitle')}
         </span>
-        <span className="text-[10px] tabular-nums text-content-tertiary">
+        <span className="text-micro tabular-nums text-content-tertiary">
           {stash.length}/{DESIGNER_CONSTRAINTS.MAX_STASH_ENTRIES}
         </span>
       </div>
@@ -154,7 +154,7 @@ export function BentoStashShelf({
                     <div className={`rounded-sm border ${fill}`} style={{ width, height }} />
                   )}
                 </div>
-                <span className="max-w-[5rem] truncate text-[10px] text-content-secondary">
+                <span className="max-w-[5rem] truncate text-micro text-content-secondary">
                   {entry.label ?? `${entry.w}×${entry.h}`}
                 </span>
                 {!isDragging && (

--- a/src/features/bin-designer/components/BentoWorkspace/BentoWorkspaceHeader.tsx
+++ b/src/features/bin-designer/components/BentoWorkspace/BentoWorkspaceHeader.tsx
@@ -146,7 +146,7 @@ export function BentoWorkspaceHeader({
           variant="ghost"
           size="sm"
           onClick={onClearAll}
-          className="text-[11px] font-medium text-accent hover:bg-transparent hover:text-accent/80"
+          className="text-label font-medium text-accent hover:bg-transparent hover:text-accent/80"
           aria-label={t('binDesigner.bento.clearAllLabel')}
         >
           {t('binDesigner.bento.clearAll')}

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditor.tsx
@@ -241,7 +241,7 @@ export function CompartmentEditor() {
             variant="ghost"
             onClick={() => setShowSizer((v) => !v)}
             aria-expanded={showSizer}
-            className="flex items-center gap-1 rounded-none px-0 py-0 hover:bg-transparent text-[11px] font-medium text-content-secondary hover:text-content"
+            className="flex items-center gap-1 rounded-none px-0 py-0 hover:bg-transparent text-label font-medium text-content-secondary hover:text-content"
           >
             <svg
               className={`h-3 w-3 transition-transform ${showSizer ? 'rotate-90' : ''}`}
@@ -295,7 +295,7 @@ export function CompartmentEditor() {
               </div>
               {/* Explains why typed sizes round up and discloses the edge
                   asymmetry (the grid cap is announced in the readout above). */}
-              <p className="text-[11px] text-content-tertiary">
+              <p className="text-label text-content-tertiary">
                 {t('binDesigner.compartmentEditor.tileEvenlyNote')}
               </p>
             </div>
@@ -362,7 +362,7 @@ export function CompartmentEditor() {
                 type="button"
                 variant="ghost"
                 onClick={handleReset}
-                className="rounded-none px-0 py-0 hover:bg-transparent text-[11px] font-medium text-accent hover:text-accent/80 transition-colors"
+                className="rounded-none px-0 py-0 hover:bg-transparent text-label font-medium text-accent hover:text-accent/80 transition-colors"
                 aria-label={t('binDesigner.resetCompartmentLayoutToUniformGrid')}
               >
                 {t('common.reset')}

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentEditorParts.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentEditorParts.tsx
@@ -212,7 +212,7 @@ export function GridCell({
       {/* Dimension label - shown on hover only (divider mode) */}
       {dimensionLabel && (
         <span
-          className="pointer-events-none absolute inset-0 flex items-center justify-center text-[10px] font-bold tabular-nums transition-opacity duration-100"
+          className="pointer-events-none absolute inset-0 flex items-center justify-center text-micro font-bold tabular-nums transition-opacity duration-100"
           style={{
             color: 'var(--color-accent)',
             opacity: showDimensionLabel ? 1 : 0,
@@ -227,7 +227,7 @@ export function GridCell({
       {showLabelText && (
         <span
           title={trimmedLabel}
-          className="pointer-events-none absolute inset-0 flex items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap px-1 text-center text-[10px] font-semibold leading-tight"
+          className="pointer-events-none absolute inset-0 flex items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap px-1 text-center text-micro font-semibold leading-tight"
           style={{ color: getContrastingTextColor(previewColor) }}
         >
           {trimmedLabel}
@@ -236,7 +236,7 @@ export function GridCell({
       {/* Empty compartment: show its number while labeling. */}
       {showEmptyNumber && (
         <span
-          className="pointer-events-none absolute inset-0 flex items-center justify-center text-[10px] font-medium tabular-nums"
+          className="pointer-events-none absolute inset-0 flex items-center justify-center text-micro font-medium tabular-nums"
           style={{ color: getContrastingTextColor(previewColor), opacity: 0.55 }}
         >
           {displayNumber}

--- a/src/features/bin-designer/components/CompartmentEditor/CompartmentSizeOverlay.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/CompartmentSizeOverlay.tsx
@@ -73,7 +73,7 @@ export function CompartmentSizeOverlay({
       {labels.map(({ id, left, top, text }) => (
         <span
           key={id}
-          className="absolute -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface/70 px-1 text-[10px] tabular-nums text-content-secondary"
+          className="absolute -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-surface/70 px-1 text-micro tabular-nums text-content-secondary"
           style={{ left: `${left}%`, top: `${top}%` }}
         >
           {text}

--- a/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.tsx
+++ b/src/features/bin-designer/components/CompartmentEditor/DividerTiltSubsection.tsx
@@ -124,7 +124,7 @@ function Teaser({ t }: { readonly t: Translate }) {
   return (
     <div className="mt-2 flex items-start gap-2.5">
       <TeaserDiagram />
-      <p className="flex-1 text-[11px] leading-relaxed text-content-tertiary">
+      <p className="flex-1 text-label leading-relaxed text-content-tertiary">
         {t('binDesigner.angledDividers.teaser')}
       </p>
     </div>
@@ -168,7 +168,7 @@ function ListView({ rows, compartments, hoveredKey, hasAnyOverride, handlers, t 
           type="button"
           variant="ghost"
           onClick={handlers.resetAll}
-          className="self-end px-0 py-0 text-[11px] font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
+          className="self-end px-0 py-0 text-label font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
         >
           {t('binDesigner.angledDividers.resetAll')}
         </Button>
@@ -250,14 +250,14 @@ function DividerRow({ row, compartments, isHovered, handlers, t }: DividerRowPro
         <span className="text-xs font-medium text-content-secondary tabular-nums">{rowLabel}</span>
         <span className="ml-auto flex items-center gap-1.5">
           {row.hasTilt && hasPlanTilt && (
-            <span className="text-[11px] font-medium tabular-nums text-accent">
+            <span className="text-label font-medium tabular-nums text-accent">
               {t('binDesigner.angledDividers.badgeAngle', {
                 angle: String(Math.round(row.angleDeg)),
               })}
             </span>
           )}
           {leanRounded !== 0 && (
-            <span className="text-[11px] font-medium tabular-nums text-content-secondary">
+            <span className="text-label font-medium tabular-nums text-content-secondary">
               {t('binDesigner.angledDividers.rowBadgeLean', { angle: String(leanRounded) })}
             </span>
           )}
@@ -315,7 +315,7 @@ function InspectorView({
           type="button"
           variant="ghost"
           onClick={() => handlers.selectDivider(null)}
-          className="flex items-center gap-1 px-0 py-0 text-[11px] font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
+          className="flex items-center gap-1 px-0 py-0 text-label font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
         >
           <ArrowLeftIcon size="xs" />
           {t('binDesigner.angledDividers.backToList')}
@@ -325,7 +325,7 @@ function InspectorView({
             type="button"
             variant="ghost"
             onClick={() => handlers.resetRow(row)}
-            className="flex items-center gap-1 px-0 py-0 text-[11px] font-medium text-content-tertiary transition-colors hover:bg-transparent hover:text-content-secondary"
+            className="flex items-center gap-1 px-0 py-0 text-label font-medium text-content-tertiary transition-colors hover:bg-transparent hover:text-content-secondary"
           >
             <RotateCcwIcon size="xs" />
             {t('binDesigner.angledDividers.resetToStraight')}
@@ -347,13 +347,13 @@ function InspectorView({
             interiorD={interiorD}
             dividerHeightMm={row.geometry?.dividerHeightMm ?? 0}
           />
-          <figcaption className="text-[10px] text-content-tertiary">
+          <figcaption className="text-micro text-content-tertiary">
             {t('binDesigner.angledDividers.topView')}
           </figcaption>
         </figure>
         <figure className="flex flex-col items-center gap-1">
           <LeanSpecimen leanDeg={leanDeg} />
-          <figcaption className="text-[10px] text-content-tertiary">
+          <figcaption className="text-micro text-content-tertiary">
             {t('binDesigner.angledDividers.sideView')}
           </figcaption>
         </figure>
@@ -426,7 +426,7 @@ function InspectorView({
           type="button"
           variant="ghost"
           onClick={() => handlers.applyLeanToAxis(row)}
-          className="self-start px-0 py-0 text-[11px] font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
+          className="self-start px-0 py-0 text-label font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
         >
           {t('binDesigner.angledDividers.applyLeanToAxis')}
         </Button>
@@ -438,7 +438,7 @@ function InspectorView({
         defaultExpanded={false}
       >
         <div className="flex items-center justify-between">
-          <span className="text-[11px] text-content-tertiary">
+          <span className="text-label text-content-tertiary">
             {t('binDesigner.angledDividers.shiftLabel')}
           </span>
           <Stepper
@@ -462,7 +462,7 @@ function InspectorView({
       </Collapsible>
 
       {row.hasTilt && conflicts.length > 0 && (
-        <p className="rounded bg-warning-muted px-2 py-1.5 text-[11px] text-content-secondary">
+        <p className="rounded bg-warning-muted px-2 py-1.5 text-label text-content-secondary">
           {t('binDesigner.angledDividers.conflictNotice')}
         </p>
       )}
@@ -540,7 +540,7 @@ function TiltControl({
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-[11px] text-content-tertiary">{label}</span>
+        <span className="text-label text-content-tertiary">{label}</span>
         <span className="flex items-center gap-1">
           {presets.map((preset) => (
             <Button
@@ -550,7 +550,7 @@ function TiltControl({
               disabled={disabled || (presetDisabled?.(preset) ?? false)}
               onClick={() => onCommit(preset)}
               aria-label={presetAria(preset)}
-              className={`rounded border px-1.5 py-0.5 text-[10px] font-medium tabular-nums transition-colors disabled:opacity-40 ${
+              className={`rounded border px-1.5 py-0.5 text-micro font-medium tabular-nums transition-colors disabled:opacity-40 ${
                 Math.round(value) === preset
                   ? 'border-accent bg-accent/10 text-accent'
                   : 'border-stroke-subtle text-content-tertiary hover:border-stroke hover:text-content-secondary'
@@ -597,8 +597,8 @@ type LeanReadout = Hook['leanReadout'];
 function ReadoutRow({ label, value }: { readonly label: string; readonly value: string }) {
   return (
     <div className="flex items-baseline justify-between gap-2">
-      <span className="text-[11px] text-content-tertiary">{label}</span>
-      <span className="text-[11px] font-medium tabular-nums text-content-secondary">{value}</span>
+      <span className="text-label text-content-tertiary">{label}</span>
+      <span className="text-label font-medium tabular-nums text-content-secondary">{value}</span>
     </div>
   );
 }

--- a/src/features/bin-designer/components/CutoutWorkspace/AlignControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/AlignControls.tsx
@@ -80,7 +80,7 @@ export function AlignControls({
   return (
     <div className="space-y-1.5">
       <div>
-        <span className="mb-1 block text-[10px] font-medium uppercase tracking-wide text-content-tertiary">
+        <span className="mb-1 block text-micro font-medium uppercase tracking-wide text-content-tertiary">
           {t('binDesigner.cutouts.align.title')}
         </span>
         <div className="flex gap-0.5">
@@ -102,7 +102,7 @@ export function AlignControls({
       </div>
 
       <div>
-        <span className="mb-1 block text-[10px] font-medium uppercase tracking-wide text-content-tertiary">
+        <span className="mb-1 block text-micro font-medium uppercase tracking-wide text-content-tertiary">
           {t('binDesigner.cutouts.distribute.title')}
         </span>
         <div className="flex gap-0.5">

--- a/src/features/bin-designer/components/CutoutWorkspace/BinFeaturesSection.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinFeaturesSection.tsx
@@ -32,7 +32,7 @@ export function BinFeaturesSection() {
 
   return (
     <div className="space-y-2 border-b border-stroke-subtle pb-3 pt-3">
-      <span className="block text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+      <span className="block text-micro font-semibold uppercase tracking-wider text-content-tertiary">
         {t('binDesigner.cutoutEditor.binFeatures')}
       </span>
 
@@ -48,7 +48,7 @@ export function BinFeaturesSection() {
           The Lid section carries that warning in the main panel; it is off
           screen here, so the lid would otherwise vanish unexplained. */}
       {lidEnabled && !stackingLip && (
-        <p className="text-[11px] leading-relaxed text-content-tertiary">
+        <p className="text-label leading-relaxed text-content-tertiary">
           {t('binDesigner.cutoutEditor.lipOffPausesLid')}
         </p>
       )}

--- a/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/BinSizeSection.tsx
@@ -57,7 +57,7 @@ export function BinSizeSection({
   const t = useTranslation();
   return (
     <div className="space-y-3 border-b border-stroke-subtle pb-3 pt-3">
-      <span className="block text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+      <span className="block text-micro font-semibold uppercase tracking-wider text-content-tertiary">
         {t('binDesigner.cutoutEditor.binSize')}
       </span>
 

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutBoardSettings.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutBoardSettings.tsx
@@ -39,12 +39,12 @@ export function CutoutBoardSettings({
   return (
     <div className="space-y-4 pt-3">
       {/* Selection guidance — kept distinct from the board settings below. */}
-      <p className="text-[11px] leading-relaxed text-content-tertiary">
+      <p className="text-label leading-relaxed text-content-tertiary">
         {t('binDesigner.cutoutEditor.inspectorEmptyHint')}
       </p>
 
       <div className="space-y-3 border-t border-stroke-subtle pt-3">
-        <span className="block text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+        <span className="block text-micro font-semibold uppercase tracking-wider text-content-tertiary">
           {t('binDesigner.cutoutEditor.boardSettings')}
         </span>
 
@@ -59,7 +59,7 @@ export function CutoutBoardSettings({
 
         {snapEnabled && (
           <div className="space-y-1">
-            <span className="block text-[10px] text-content-tertiary">
+            <span className="block text-micro text-content-tertiary">
               {t('binDesigner.gridSize')}
             </span>
             <div
@@ -83,7 +83,7 @@ export function CutoutBoardSettings({
           </div>
         )}
 
-        <dl className="space-y-1 text-[11px]">
+        <dl className="space-y-1 text-label">
           <div className="flex items-center justify-between">
             <dt className="text-content-tertiary">{t('binDesigner.cutoutEditor.boardSize')}</dt>
             <dd className="tabular-nums text-content-secondary">
@@ -100,7 +100,7 @@ export function CutoutBoardSettings({
       {/* Fill level: a bin-level plane, but the cutouts are cut from it, so the
           workspace has to expose it or the only control is in the sidebar. */}
       <div className="space-y-3 border-t border-stroke-subtle pt-3">
-        <span className="block text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+        <span className="block text-micro font-semibold uppercase tracking-wider text-content-tertiary">
           {t('binDesigner.cutouts.fillLevel')}
         </span>
         <CutoutFillControls />

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutColorControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutColorControls.tsx
@@ -83,7 +83,7 @@ export function CutoutColorControls({
                 disabled={disabled}
                 onClick={() => setCutoutColor(ids, { colorScope: scope })}
                 aria-pressed={activeScope === scope}
-                className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(
+                className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(
                   activeScope === scope
                 )}`}
               >

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutEngraveLabelControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutEngraveLabelControls.tsx
@@ -148,7 +148,7 @@ export function CutoutEngraveLabelControls({
               disabled={disabled}
               onClick={() => handleModeChange(opt)}
               aria-pressed={labelMode === opt}
-              className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(labelMode === opt)}`}
+              className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(labelMode === opt)}`}
             >
               {t(`binDesigner.cutoutLabelMode.${opt}`)}
             </Button>
@@ -171,7 +171,7 @@ export function CutoutEngraveLabelControls({
           offering a list the plate cannot carry. */}
       {cutout.array &&
         (isSocket ? (
-          <p className="text-[10px] leading-snug text-content-tertiary">
+          <p className="text-micro leading-snug text-content-tertiary">
             {t('binDesigner.cutouts.repeat.labels.socketNote')}
           </p>
         ) : (
@@ -200,7 +200,7 @@ export function CutoutEngraveLabelControls({
                 disabled={disabled}
                 onClick={() => setTextDefaults({ mode: opt })}
                 aria-pressed={effectiveMode === opt}
-                className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(effectiveMode === opt)}`}
+                className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(effectiveMode === opt)}`}
               >
                 {t(`binDesigner.textMode.${opt}`)}
               </Button>
@@ -225,7 +225,7 @@ export function CutoutEngraveLabelControls({
       )}
       {!isTextElement && (
         <div className="space-y-1">
-          <span className="text-[10px] text-text-muted">{t('binDesigner.cutoutTextAnchor')}</span>
+          <span className="text-micro text-text-muted">{t('binDesigner.cutoutTextAnchor')}</span>
           <div
             role="group"
             aria-label={t('binDesigner.cutoutTextAnchor')}
@@ -299,7 +299,7 @@ export function CutoutEngraveLabelControls({
             disabled={disabled}
           />
           {sizeLimited && renderedSize !== null && (
-            <p role="alert" className="text-[10px] leading-snug text-warning">
+            <p role="alert" className="text-micro leading-snug text-warning">
               {t('binDesigner.textSizeLimited', { size: renderedSize.toFixed(1) })}
             </p>
           )}

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutKnifeControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutKnifeControls.tsx
@@ -57,7 +57,7 @@ const OPEN_ENDS: readonly { readonly value: KnifeSlotOpenEnd | null; readonly la
     { value: null, labelKey: 'binDesigner.cutouts.knifeOpenEnd.enclosed' },
   ];
 
-const CHIP_BASE = 'rounded border px-1.5 py-0.5 text-[11px] transition-colors';
+const CHIP_BASE = 'rounded border px-1.5 py-0.5 text-label transition-colors';
 const CHIP_INACTIVE =
   'border-stroke-subtle bg-surface-elevated text-content-secondary hover:border-accent/50 hover:text-content';
 const CHIP_ACTIVE = 'border-accent bg-accent/15 text-accent hover:bg-accent/15 hover:text-accent';
@@ -143,7 +143,7 @@ export function CutoutKnifeControls({
   return (
     <div className="space-y-2">
       <div className="space-y-1">
-        <span className="block text-[10px] text-content-tertiary">
+        <span className="block text-micro text-content-tertiary">
           {t('binDesigner.cutouts.knifePreset')}
         </span>
         <div className="flex flex-wrap gap-1">
@@ -224,7 +224,7 @@ export function CutoutKnifeControls({
       </div>
 
       <div className="space-y-1">
-        <span className="block text-[10px] text-content-tertiary">
+        <span className="block text-micro text-content-tertiary">
           {t('binDesigner.cutouts.knifeOrientation')}
         </span>
         <div
@@ -242,7 +242,7 @@ export function CutoutKnifeControls({
                 disabled={disabled}
                 onClick={() => setAxis(value)}
                 aria-pressed={active}
-                className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(active)}`}
+                className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(active)}`}
               >
                 {t(labelKey)}
               </Button>
@@ -252,7 +252,7 @@ export function CutoutKnifeControls({
       </div>
 
       <div className="space-y-1">
-        <span className="block text-[10px] text-content-tertiary">
+        <span className="block text-micro text-content-tertiary">
           {t('binDesigner.cutouts.knifeOpenEnd')}
         </span>
         <div
@@ -270,20 +270,20 @@ export function CutoutKnifeControls({
                 disabled={disabled}
                 onClick={() => setOpenEnd(value)}
                 aria-pressed={active}
-                className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(active)}`}
+                className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(active)}`}
               >
                 {t(labelKey)}
               </Button>
             );
           })}
         </div>
-        <p className="text-[10px] text-content-tertiary">
+        <p className="text-micro text-content-tertiary">
           {t('binDesigner.cutouts.knifeOpenEndHint')}
         </p>
       </div>
 
       {clamp && (
-        <p className="text-[11px] text-warning">
+        <p className="text-label text-warning">
           {t('binDesigner.cutouts.knifeDepthClamped', {
             depth: clamp.availableMm.toFixed(1),
             needed: clamp.neededHeightUnits,

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutPlateSettings.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutPlateSettings.tsx
@@ -46,15 +46,15 @@ export function CutoutPlateSettings() {
 
   return (
     <div className="space-y-3 border-t border-stroke-subtle pt-3">
-      <span className="block text-[10px] font-semibold uppercase tracking-wider text-content-tertiary">
+      <span className="block text-micro font-semibold uppercase tracking-wider text-content-tertiary">
         {t('binDesigner.cutoutSocket.boardSection')}
       </span>
 
-      <p className="text-[11px] text-content-secondary">
+      <p className="text-label text-content-secondary">
         {t('binDesigner.cutoutSocket.socketCount', { n: plan.socketCount })}
       </p>
       {plan.skippedCount > 0 && (
-        <p role="status" className="text-[11px] text-status-warning">
+        <p role="status" className="text-label text-warning">
           {t('binDesigner.cutoutSocket.skippedCount', {
             n: plan.skippedCount,
             max: MAX_CUTOUT_LABEL_SOCKETS,

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutRepeatLabels.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutRepeatLabels.tsx
@@ -34,7 +34,7 @@ interface CutoutRepeatLabelsProps {
 }
 
 const ACTION_CLASS =
-  'flex-1 rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-[11px] text-content-secondary hover:bg-surface-hover transition-colors disabled:opacity-50';
+  'flex-1 rounded border border-stroke-subtle bg-surface-elevated px-2 py-1 text-label text-content-secondary hover:bg-surface-hover transition-colors disabled:opacity-50';
 
 /**
  * Rows the list is edited as. Blank lines are NOT dropped: a blank line inside
@@ -105,7 +105,7 @@ export function CutoutRepeatLabels({
 
   return (
     <div className="space-y-1">
-      <span className="text-[10px] text-text-muted">
+      <span className="text-micro text-text-muted">
         {t('binDesigner.cutouts.repeat.labels.title')}
       </span>
       <Textarea
@@ -119,7 +119,7 @@ export function CutoutRepeatLabels({
         aria-describedby={hintId}
         placeholder={t('binDesigner.cutouts.repeat.labels.placeholder')}
       />
-      <p id={hintId} className="text-[10px] leading-snug text-content-tertiary">
+      <p id={hintId} className="text-micro leading-snug text-content-tertiary">
         {t(`binDesigner.cutouts.repeat.labels.order.${arrayLabelOrder(array)}`)}
       </p>
       {/* Advisory, never a block: the request asks for a mismatch to be
@@ -130,7 +130,7 @@ export function CutoutRepeatLabels({
           rather than one line joined by punctuation, so no locale has to
           inherit English's clause order to read correctly. */}
       <p
-        className={`text-[11px] leading-snug ${short || long ? 'text-warning' : 'text-content-tertiary'}`}
+        className={`text-label leading-snug ${short || long ? 'text-warning' : 'text-content-tertiary'}`}
       >
         {t('binDesigner.cutouts.repeat.labels.count', {
           labels: counts.labels,
@@ -138,12 +138,12 @@ export function CutoutRepeatLabels({
         })}
       </p>
       {short && (
-        <p className="text-[11px] leading-snug text-content-tertiary">
+        <p className="text-label leading-snug text-content-tertiary">
           {t('binDesigner.cutouts.repeat.labels.short', { count: counts.copies - counts.labels })}
         </p>
       )}
       {long && (
-        <p className="text-[11px] leading-snug text-content-tertiary">
+        <p className="text-label leading-snug text-content-tertiary">
           {t('binDesigner.cutouts.repeat.labels.long', { count: counts.labels - counts.copies })}
         </p>
       )}

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutScoopControls.tsx
@@ -87,7 +87,7 @@ export function CutoutScoopControls({
             type="button"
             variant="ghost"
             onClick={() => setExpanded(true)}
-            className="px-0 py-0 text-[11px] font-medium text-accent hover:bg-transparent hover:text-accent/80 transition-colors"
+            className="px-0 py-0 text-label font-medium text-accent hover:bg-transparent hover:text-accent/80 transition-colors"
             disabled={disabled}
           >
             {t('binDesigner.cutouts.scoopSplit')}
@@ -117,7 +117,7 @@ export function CutoutScoopControls({
           type="button"
           variant="ghost"
           onClick={handleCollapse}
-          className="px-0 py-0 text-[11px] font-medium text-accent hover:bg-transparent hover:text-accent/80 transition-colors"
+          className="px-0 py-0 text-label font-medium text-accent hover:bg-transparent hover:text-accent/80 transition-colors"
           disabled={disabled}
         >
           {t('binDesigner.cutouts.scoopUniform')}
@@ -147,7 +147,7 @@ export function CutoutScoopControls({
       </div>
       {supportsEdges && (
         <div className="flex items-center gap-1.5 pt-0.5">
-          <span className="text-[10px] text-content-tertiary">
+          <span className="text-micro text-content-tertiary">
             {t('binDesigner.cutouts.scoopEdges')}
           </span>
           <EdgeChip
@@ -201,7 +201,7 @@ function EdgeChip({ label, ariaLabel, on, disabled, onToggle }: EdgeChipProps) {
       disabled={disabled}
       aria-label={ariaLabel}
       aria-pressed={on}
-      className={`h-5 min-w-[20px] rounded px-1 text-[10px] font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-50 ${
+      className={`h-5 min-w-[20px] rounded px-1 text-micro font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset disabled:cursor-not-allowed disabled:opacity-50 ${
         on ? SEGMENT_ACTIVE : SEGMENT_INACTIVE
       }`}
     >

--- a/src/features/bin-designer/components/CutoutWorkspace/CutoutSocketControls.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/CutoutSocketControls.tsx
@@ -59,7 +59,7 @@ export function CutoutSocketControls({
         disabled={disabled}
         onClick={() => onUpdate({ textAngle: 0 })}
         aria-pressed={!vertical}
-        className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(!vertical)}`}
+        className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(!vertical)}`}
       >
         {t('binDesigner.cutoutSocket.horizontal')}
       </Button>
@@ -69,7 +69,7 @@ export function CutoutSocketControls({
         disabled={disabled}
         onClick={() => onUpdate({ textAngle: 90 })}
         aria-pressed={vertical}
-        className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(vertical)}`}
+        className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(vertical)}`}
       >
         {t('binDesigner.cutoutSocket.vertical')}
       </Button>
@@ -82,7 +82,7 @@ export function CutoutSocketControls({
     // refusals are not orientation's to fix and keep the bare warning.
     return (
       <div className="space-y-2">
-        <p role="status" className="text-[10px] text-status-warning">
+        <p role="status" className="text-micro text-warning">
           {skipReason === 'centerAnchor'
             ? t('binDesigner.cutoutSocket.blockedCenterAnchor')
             : skipReason === 'tooShallow'
@@ -106,7 +106,7 @@ export function CutoutSocketControls({
   return (
     <div className="space-y-2">
       <div className="space-y-1">
-        <span className="text-[10px] text-text-muted">{t('binDesigner.cutoutSocket.width')}</span>
+        <span className="text-micro text-text-muted">{t('binDesigner.cutoutSocket.width')}</span>
         <div
           role="group"
           aria-label={t('binDesigner.cutoutSocket.width')}
@@ -118,7 +118,7 @@ export function CutoutSocketControls({
             disabled={disabled}
             onClick={() => setWidth(null)}
             aria-pressed={!pinned}
-            className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(!pinned)}`}
+            className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(!pinned)}`}
           >
             {t('binDesigner.cutoutSocket.widthAuto', { u: socket.widthU })}
           </Button>
@@ -130,7 +130,7 @@ export function CutoutSocketControls({
               disabled={disabled}
               onClick={() => setWidth(u)}
               aria-pressed={pinned && override === u}
-              className={`flex-1 py-0.5 text-[10px] leading-none ${getSegmentClass(
+              className={`flex-1 py-0.5 text-micro leading-none ${getSegmentClass(
                 pinned && override === u
               )}`}
             >
@@ -141,7 +141,7 @@ export function CutoutSocketControls({
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="text-[10px] text-text-muted">{t('binDesigner.cutoutSocket.icon')}</span>
+        <span className="text-micro text-text-muted">{t('binDesigner.cutoutSocket.icon')}</span>
         <LabelIconPicker
           value={cutout.labelIcon ?? null}
           onChange={(icon) => onUpdate({ labelIcon: icon ?? undefined })}

--- a/src/features/bin-designer/components/CutoutWorkspace/FitTestButton.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/FitTestButton.tsx
@@ -213,7 +213,7 @@ export function FitTestButton() {
                   aria-label={t('binDesigner.cutouts.fitTest.thickness')}
                 />
               </div>
-              <p className="mt-1.5 text-[11px] leading-relaxed text-content-tertiary">
+              <p className="mt-1.5 text-label leading-relaxed text-content-tertiary">
                 {t('binDesigner.cutouts.fitTest.thicknessHint')}
               </p>
             </div>

--- a/src/features/bin-designer/components/CutoutWorkspace/GroupBreadcrumb.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/GroupBreadcrumb.tsx
@@ -38,14 +38,14 @@ export function GroupBreadcrumb({
   return (
     <nav
       aria-label={t('binDesigner.groupBreadcrumb.label')}
-      className="flex min-w-0 items-center gap-0.5 text-[11px] text-content-tertiary"
+      className="flex min-w-0 items-center gap-0.5 text-label text-content-tertiary"
     >
       <Button
         type="button"
         variant="ghost"
         size="sm"
         touchTarget={false}
-        className="px-1 py-0 text-[11px] text-content-secondary"
+        className="px-1 py-0 text-label text-content-secondary"
         onClick={() => onNavigate([])}
       >
         {t('binDesigner.groupBreadcrumb.root')}
@@ -78,7 +78,7 @@ export function GroupBreadcrumb({
               // rather than a control that does nothing when pressed.
               disabled={current}
               aria-current={current ? 'true' : undefined}
-              className={`max-w-[10rem] truncate px-1 py-0 text-[11px] ${
+              className={`max-w-[10rem] truncate px-1 py-0 text-label ${
                 current ? 'text-content' : 'text-content-secondary'
               }`}
               onClick={() => onNavigate(to)}

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorContent.tsx
@@ -408,7 +408,7 @@ export function InspectorContent({
 
       {!isSingle && selectedCutouts.length > 1 && (
         <>
-          <div className="text-[10px] font-medium uppercase tracking-wide text-content-tertiary">
+          <div className="text-micro font-medium uppercase tracking-wide text-content-tertiary">
             {t('binDesigner.cutoutEditor.selectedCount', { count: selectedCutouts.length })}
           </div>
           {/* Above the align controls: if the selection is already a pattern,
@@ -578,7 +578,7 @@ export function InspectorContent({
       )}
 
       {singleCutout?.locked && (
-        <div className="flex gap-1.5 text-[10px] text-content-tertiary">
+        <div className="flex gap-1.5 text-micro text-content-tertiary">
           <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-amber-400">
             {t('binDesigner.cutoutEditor.locked')}
           </span>

--- a/src/features/bin-designer/components/CutoutWorkspace/InspectorDock.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/InspectorDock.tsx
@@ -170,7 +170,7 @@ export function InspectorDock({
           <Icon paths={ICON_PATHS.chevronDoubleLeft} />
         </IconButton>
         <span
-          className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-content-tertiary"
+          className="mt-3 text-micro font-semibold uppercase tracking-wider text-content-tertiary"
           style={{ writingMode: 'vertical-rl' }}
         >
           {t('binDesigner.cutoutEditor.inspectorTitle')}

--- a/src/features/bin-designer/components/CutoutWorkspace/RepeatSuggestion.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/RepeatSuggestion.tsx
@@ -44,7 +44,7 @@ export function RepeatSuggestion({
     >
       <div className="flex items-start gap-2">
         <SparklesIcon className="mt-px h-4 w-4 flex-shrink-0 text-accent" />
-        <span className="flex-1 text-[11px] leading-snug text-content-secondary">
+        <span className="flex-1 text-label leading-snug text-content-secondary">
           {suggestion.message}
         </span>
       </div>

--- a/src/features/bin-designer/components/CutoutWorkspace/ShapeList/ShapeList.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/ShapeList/ShapeList.tsx
@@ -317,7 +317,7 @@ export function ShapeList({
 
   if (nodes.length === 0) {
     return (
-      <p className="px-3 py-6 text-center text-[11px] text-content-tertiary">
+      <p className="px-3 py-6 text-center text-label text-content-tertiary">
         {t('binDesigner.shapeList.empty')}
       </p>
     );
@@ -342,7 +342,7 @@ export function ShapeList({
         handleDropToBottom();
       }}
     >
-      <div className="px-1 pb-1 text-[10px] uppercase tracking-wider text-content-tertiary">
+      <div className="px-1 pb-1 text-micro uppercase tracking-wider text-content-tertiary">
         {t('binDesigner.shapeList.countLabel', { count: String(cutouts.length) })}
       </div>
       {renderRows(nodes)}

--- a/src/features/bin-designer/components/CutoutWorkspace/ShapeList/ShapeListRow.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/ShapeList/ShapeListRow.tsx
@@ -45,7 +45,7 @@ interface ShapeListRowProps {
 }
 
 const ROW =
-  'group flex w-full cursor-grab items-center gap-1 rounded px-1 py-1 text-left text-[11px] active:cursor-grabbing';
+  'group flex w-full cursor-grab items-center gap-1 rounded px-1 py-1 text-left text-label active:cursor-grabbing';
 
 function EyeIcon({ off }: { readonly off: boolean }) {
   return (
@@ -228,7 +228,7 @@ export function ShapeListRow({
             onKeyDown={handleKeyDown}
             size="sm"
             wrapperClassName="min-w-0 flex-1 ring-1 ring-accent"
-            className="px-1 text-[11px]"
+            className="px-1 text-label"
           />
         ) : (
           <Button
@@ -236,7 +236,7 @@ export function ShapeListRow({
             variant="ghost"
             onClick={(e) => onSelect(ids, e.shiftKey || e.metaKey || e.ctrlKey)}
             onDoubleClick={() => setEditing(true)}
-            className="min-w-0 flex-1 justify-start truncate px-0.5 py-0 text-left text-[11px] font-normal"
+            className="min-w-0 flex-1 justify-start truncate px-0.5 py-0 text-left text-label font-normal"
             title={label}
           >
             <span className="truncate">{label}</span>
@@ -247,7 +247,7 @@ export function ShapeListRow({
             A container carries no op and stays visually quiet. */}
         {isGroup && node.groupKind === 'boolean' && node.op && (
           <span
-            className="flex-shrink-0 rounded bg-surface-raised px-1 text-[9px] uppercase tracking-wide text-content-tertiary"
+            className="flex-shrink-0 rounded bg-surface-raised px-1 text-micro uppercase tracking-wide text-content-tertiary"
             title={t(`binDesigner.cutouts.pathfinder.${node.op}`)}
           >
             {t(`binDesigner.cutouts.pathfinder.${node.op}`)}

--- a/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/SingleCutoutInspector.tsx
@@ -208,7 +208,7 @@ export function SingleCutoutInspector({
                 />
               ))}
             {depthShortfall && (
-              <p role="alert" className="pt-0.5 text-[11px] leading-snug text-warning">
+              <p role="alert" className="pt-0.5 text-label leading-snug text-warning">
                 {t('binDesigner.cutouts.depthShortfall', {
                   achievable: depthShortfall.achievable.toFixed(1),
                   requested: depthShortfall.requested.toFixed(1),
@@ -259,7 +259,7 @@ export function SingleCutoutInspector({
                     disabled={disabled}
                   />
                   {(cutout.leanDeg ?? 0) !== 0 && (
-                    <p className="text-[10px] text-text-muted">
+                    <p className="text-micro text-text-muted">
                       {t('binDesigner.cutouts.leanHint')}
                     </p>
                   )}

--- a/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
+++ b/src/features/bin-designer/components/CutoutWorkspace/WorkspaceHeader.tsx
@@ -181,7 +181,7 @@ function AutoArrangePopover({
         variant="ghost"
         size="sm"
         touchTarget={false}
-        className="text-[11px] text-content-secondary"
+        className="text-label text-content-secondary"
         onClick={() => setOpen(!open)}
         title={t('binDesigner.cutouts.autoArrange')}
       >
@@ -191,7 +191,7 @@ function AutoArrangePopover({
         <div className="absolute top-full left-0 z-50 mt-1 rounded-lg border border-stroke-subtle bg-surface-elevated p-2 shadow-lg">
           <div className="flex flex-col gap-1.5">
             <div className="flex items-center gap-2">
-              <label className="flex items-center gap-1 text-[11px] text-content-tertiary whitespace-nowrap">
+              <label className="flex items-center gap-1 text-label text-content-tertiary whitespace-nowrap">
                 {t('binDesigner.cutouts.gap')}
                 <Input
                   type="number"
@@ -210,7 +210,7 @@ function AutoArrangePopover({
                 variant="primary"
                 size="sm"
                 touchTarget={false}
-                className="text-[11px]"
+                className="text-label"
                 onClick={() => {
                   onArrange(gap, staggered);
                   setOpen(false);
@@ -418,8 +418,8 @@ export function WorkspaceHeader({
       touchTarget={false}
       className={
         danger
-          ? 'text-[11px] text-red-400 bg-transparent hover:bg-red-500/10'
-          : 'text-[11px] text-content-secondary'
+          ? 'text-label text-red-400 bg-transparent hover:bg-red-500/10'
+          : 'text-label text-content-secondary'
       }
       onClick={onClick}
       disabled={isDisabled || disabled}
@@ -448,7 +448,7 @@ export function WorkspaceHeader({
       );
     }
     return (
-      <span className="text-[11px] text-content-tertiary">
+      <span className="text-label text-content-tertiary">
         {t('binDesigner.cutoutEditor.selectedCount', { count: selection.size })}
       </span>
     );
@@ -623,7 +623,7 @@ export function WorkspaceHeader({
           </div>
 
           {cursorWorldPos && (
-            <span className="text-[10px] font-mono text-content-tertiary tabular-nums">
+            <span className="text-micro font-mono text-content-tertiary tabular-nums">
               {`X: ${cursorWorldPos.x.toFixed(1)} \u00a0 Y: ${cursorWorldPos.y.toFixed(1)}`}
             </span>
           )}
@@ -653,7 +653,7 @@ export function WorkspaceHeader({
               variant="ghost"
               size="sm"
               touchTarget={false}
-              className="min-w-[3.5rem] px-1 text-[11px] text-content-secondary tabular-nums"
+              className="min-w-[3.5rem] px-1 text-label text-content-secondary tabular-nums"
               onClick={onFitToView}
               title={t('binDesigner.cutoutEditor.fitToView')}
               aria-label={t('binDesigner.cutoutEditor.fitToView')}

--- a/src/features/bin-designer/components/DesignGridItem/DesignGridItem.tsx
+++ b/src/features/bin-designer/components/DesignGridItem/DesignGridItem.tsx
@@ -141,7 +141,7 @@ export function DesignGridItem({
 
       {/* Active badge */}
       {isActive && (
-        <span className="absolute top-1.5 right-1.5 z-10 rounded bg-accent px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-surface">
+        <span className="absolute top-1.5 right-1.5 z-10 rounded bg-accent px-1.5 py-0.5 text-micro font-semibold uppercase tracking-wide text-surface">
           {t('layouts.active')}
         </span>
       )}
@@ -202,7 +202,7 @@ export function DesignGridItem({
             row regardless of how many tags each card shows */}
         <div className="flex items-center justify-between mt-auto pt-1.5">
           {nestLevel === 1 && (
-            <p className="truncate text-[10px] text-accent">
+            <p className="truncate text-micro text-accent">
               {design.variantOf
                 ? t('binDesigner.variants.label')
                 : design.parentVersionName
@@ -222,16 +222,14 @@ export function DesignGridItem({
                 onToggleExpand();
               }}
               aria-expanded={expanded}
-              className="h-auto px-0 py-0 text-[10px] font-normal text-accent hover:underline"
+              className="h-auto px-0 py-0 text-micro font-normal text-accent hover:underline"
             >
               {expanded
                 ? t('binDesigner.designs.hideBranches')
                 : t('binDesigner.designs.branchCount', { count: childCount })}
             </Button>
           )}
-          <p className="text-[10px] text-content-tertiary">
-            {formatRelativeDate(design.updatedAt)}
-          </p>
+          <p className="text-micro text-content-tertiary">{formatRelativeDate(design.updatedAt)}</p>
 
           {/* Actions - always visible on touch, hover/focus on desktop */}
           <div className="transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">

--- a/src/features/bin-designer/components/DesignListItem/DesignListItem.tsx
+++ b/src/features/bin-designer/components/DesignListItem/DesignListItem.tsx
@@ -124,7 +124,7 @@ export function DesignListItem({
     >
       {/* Active badge */}
       {isActive && (
-        <span className="absolute -top-2 left-3 rounded bg-accent px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-surface">
+        <span className="absolute -top-2 left-3 rounded bg-accent px-1.5 py-0.5 text-micro font-semibold uppercase tracking-wide text-surface">
           {t('layouts.active')}
         </span>
       )}
@@ -218,7 +218,7 @@ export function DesignListItem({
         {/* A variant and a branch are both nested children, so the row has to say
             which: one still follows its parent, the other does not. */}
         {nestLevel === 1 && (
-          <p className="truncate text-[11px] text-accent">
+          <p className="truncate text-label text-accent">
             {design.variantOf
               ? t('binDesigner.variants.label')
               : design.parentVersionName
@@ -227,11 +227,11 @@ export function DesignListItem({
           </p>
         )}
         {childCount > 0 && (
-          <p className="text-[11px] text-content-tertiary">
+          <p className="text-label text-content-tertiary">
             {t('binDesigner.designs.branchCount', { count: childCount })}
           </p>
         )}
-        <p className="text-[11px] text-content-tertiary">
+        <p className="text-label text-content-tertiary">
           {formatRelativeDate(design.updatedAt, { includeTime: true })}
         </p>
         {design.tags && design.tags.length > 0 && (

--- a/src/features/bin-designer/components/DesignTagChips/DesignTagChips.tsx
+++ b/src/features/bin-designer/components/DesignTagChips/DesignTagChips.tsx
@@ -24,7 +24,7 @@ export function DesignTagChips({ tags, max = 3 }: DesignTagChipsProps) {
         return (
           <span
             key={tag}
-            className="inline-flex max-w-[8rem] items-center gap-1 truncate rounded-full bg-surface-elevated px-1.5 py-0.5 text-[10px] font-medium text-content-secondary"
+            className="inline-flex max-w-[8rem] items-center gap-1 truncate rounded-full bg-surface-elevated px-1.5 py-0.5 text-micro font-medium text-content-secondary"
             style={
               appearance?.color !== undefined
                 ? { backgroundColor: tagTint(appearance.color) }
@@ -38,7 +38,7 @@ export function DesignTagChips({ tags, max = 3 }: DesignTagChipsProps) {
         );
       })}
       {overflow > 0 && (
-        <span className="rounded-full px-1 py-0.5 text-[10px] font-medium text-content-tertiary">
+        <span className="rounded-full px-1 py-0.5 text-micro font-medium text-content-tertiary">
           {overflowLabel}
         </span>
       )}

--- a/src/features/bin-designer/components/DesignerPage/FractionalEdgeMismatchBanner.tsx
+++ b/src/features/bin-designer/components/DesignerPage/FractionalEdgeMismatchBanner.tsx
@@ -26,7 +26,7 @@ export function FractionalEdgeMismatchBanner({
   return (
     <div
       role="alert"
-      className="flex items-center gap-2 border-b border-status-warning/20 bg-status-warning/10 px-4 py-2 text-xs text-status-warning"
+      className="flex items-center gap-2 border-b border-warning/20 bg-warning/10 px-4 py-2 text-xs text-warning"
     >
       <AlertTriangleIcon size="sm" className="flex-shrink-0" aria-hidden="true" />
       <span className="flex-1">

--- a/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
+++ b/src/features/bin-designer/components/ExportDialog/SlicerHandoffPreview.tsx
@@ -96,7 +96,7 @@ export function SlicerHandoffPreview({
           <p className="text-xs font-medium text-content">
             {t('binDesigner.colors.slicerHandoff.title')}
           </p>
-          <p className="text-[11px] text-content-tertiary">
+          <p className="text-label text-content-tertiary">
             {t('binDesigner.colors.slicerHandoff.description')}
           </p>
           <ul className="space-y-1.5">
@@ -109,10 +109,10 @@ export function SlicerHandoffPreview({
                 <span className="font-medium text-content">
                   {t('binDesigner.colors.slicerHandoff.filament', { n: i + 1 })}
                 </span>
-                <span className="font-mono text-[11px] text-content-secondary tabular-nums">
+                <span className="font-mono text-label text-content-secondary tabular-nums">
                   {f.color}
                 </span>
-                <span className="ml-auto truncate text-[11px] text-content-tertiary">
+                <span className="ml-auto truncate text-label text-content-tertiary">
                   {
                     // eslint-disable-next-line i18next/no-literal-string -- joiner is punctuation, not user copy
                     f.zones.join(', ')

--- a/src/features/bin-designer/components/PerfOverlay/PerfOverlay.tsx
+++ b/src/features/bin-designer/components/PerfOverlay/PerfOverlay.tsx
@@ -35,7 +35,7 @@ export function PerfOverlay() {
   const latest = perfHistory[perfHistory.length - 1];
   return (
     <div
-      className="pointer-events-auto absolute right-3 top-3 z-20 w-72 rounded-lg border border-stroke-subtle bg-surface-primary/95 p-3 text-[11px] font-mono shadow-lg backdrop-blur-sm"
+      className="pointer-events-auto absolute right-3 top-3 z-20 w-72 rounded-lg border border-stroke-subtle bg-surface-primary/95 p-3 text-label font-mono shadow-lg backdrop-blur-sm"
       aria-label="Generation performance overlay"
     >
       <Header

--- a/src/features/bin-designer/components/PreviewCanvas/MeasureOverlay.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/MeasureOverlay.tsx
@@ -59,7 +59,7 @@ export function MeasureOverlay() {
               touchTarget={false}
               onClick={() => setMeasureMode(m)}
               aria-pressed={m === mode}
-              className={`px-2 py-0.5 text-[11px] leading-none ${getSegmentClass(m === mode)}`}
+              className={`px-2 py-0.5 text-label leading-none ${getSegmentClass(m === mode)}`}
             >
               {m === 'points'
                 ? t('binDesigner.measure.modePoints')
@@ -101,7 +101,7 @@ export function MeasureOverlay() {
             size="sm"
             touchTarget={false}
             onClick={clearMeasure}
-            className="px-1 text-[11px] font-normal text-content-tertiary hover:text-content"
+            className="px-1 text-label font-normal text-content-tertiary hover:text-content"
           >
             {t('binDesigner.measure.clear')}
           </Button>

--- a/src/features/bin-designer/components/PreviewCanvas/previewCanvasOverlays.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/previewCanvasOverlays.tsx
@@ -40,7 +40,7 @@ export function TouchHint() {
       role="status"
       aria-label={t('binDesigner.touchGestureHints')}
     >
-      <div className="flex items-center gap-3 rounded-full bg-black/70 px-4 py-2 text-[11px] text-white shadow-lg backdrop-blur-sm">
+      <div className="flex items-center gap-3 rounded-full bg-black/70 px-4 py-2 text-label text-white shadow-lg backdrop-blur-sm">
         <span>{t('binDesigner.dragToOrbit')}</span>
         <span className="h-3 w-px bg-white/30" />
         <span>{t('binDesigner.pinchToZoom')}</span>

--- a/src/features/bin-designer/components/SlotConfigurator/CustomGridEditor.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/CustomGridEditor.tsx
@@ -281,7 +281,7 @@ export function CustomGridEditor() {
         </Button>
       </div>
 
-      <p className="text-[11px] text-content-tertiary">
+      <p className="text-label text-content-tertiary">
         {t('binDesigner.customPieceCount', { count: pieces.length })}
         {frictionCount > 0 && (
           <span className="text-warning">

--- a/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
+++ b/src/features/bin-designer/components/SlotConfigurator/SlotConfigurator.tsx
@@ -357,7 +357,7 @@ export function SlotConfigurator() {
   return (
     <div className="space-y-3">
       {wallTooThin && (
-        <p className="rounded bg-warning/10 px-2 py-1.5 text-[11px] text-warning">
+        <p className="rounded bg-warning/10 px-2 py-1.5 text-label text-warning">
           {t('binDesigner.slotWallTooThin', { min: MIN_WALL_FOR_SLOTS })}
         </p>
       )}
@@ -372,7 +372,7 @@ export function SlotConfigurator() {
               type="button"
               variant="ghost"
               onClick={() => setLayout(l)}
-              className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
+              className={`rounded px-2 py-0.5 text-label font-medium transition-colors ${
                 layout === l
                   ? 'bg-accent text-on-accent hover:bg-accent'
                   : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
@@ -398,7 +398,7 @@ export function SlotConfigurator() {
                   type="button"
                   variant="ghost"
                   onClick={() => setDirection(direction)}
-                  className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                  className={`rounded px-2 py-0.5 text-label font-medium transition-colors ${
                     activeDirection === direction
                       ? 'bg-accent text-on-accent hover:bg-accent'
                       : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
@@ -424,7 +424,7 @@ export function SlotConfigurator() {
                       type="button"
                       variant="ghost"
                       onClick={() => setCrossStyle(style)}
-                      className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                      className={`rounded px-2 py-0.5 text-label font-medium transition-colors ${
                         requestedCrossStyle === style
                           ? 'bg-accent text-on-accent hover:bg-accent'
                           : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
@@ -449,7 +449,7 @@ export function SlotConfigurator() {
                         type="button"
                         variant="ghost"
                         onClick={() => setLongAxis(axis)}
-                        className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                        className={`rounded px-2 py-0.5 text-label font-medium transition-colors ${
                           longAxis === axis
                             ? 'bg-accent text-on-accent hover:bg-accent'
                             : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
@@ -462,7 +462,7 @@ export function SlotConfigurator() {
                 </div>
               )}
               {insertTooThin && (
-                <p className="rounded bg-warning/10 px-2 py-1.5 text-[11px] text-warning">
+                <p className="rounded bg-warning/10 px-2 py-1.5 text-label text-warning">
                   {t('binDesigner.slotInsertTooThin', { min: MIN_DIVIDER_FOR_RECEPTACLES })}
                 </p>
               )}
@@ -484,7 +484,7 @@ export function SlotConfigurator() {
                         variant="ghost"
                         disabled={!partialAvailable}
                         onClick={() => setPartialStyle(style)}
-                        className={`rounded px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                        className={`rounded px-2 py-0.5 text-label font-medium transition-colors ${
                           active
                             ? 'bg-accent text-on-accent hover:bg-accent'
                             : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
@@ -497,12 +497,12 @@ export function SlotConfigurator() {
                 </div>
               </div>
               {!partialAvailable && (
-                <p className="text-[11px] text-content-tertiary">
+                <p className="text-label text-content-tertiary">
                   {t('binDesigner.slotPartialNeedsLap')}
                 </p>
               )}
               {snappableTooThin && (
-                <p className="rounded bg-warning/10 px-2 py-1.5 text-[11px] text-warning">
+                <p className="rounded bg-warning/10 px-2 py-1.5 text-label text-warning">
                   {t('binDesigner.slotSnapTooThin', { min: MIN_DIVIDER_FOR_SNAP })}
                 </p>
               )}

--- a/src/features/bin-designer/components/Workshop/ResizeHandles3D.tsx
+++ b/src/features/bin-designer/components/Workshop/ResizeHandles3D.tsx
@@ -268,7 +268,7 @@ export function ResizeHandles3D({
                     autoFocus
                     defaultValue={fmt(def.read(node))}
                     inputMode="decimal"
-                    className="w-14 rounded border border-accent bg-surface-elevated px-1 py-0.5 text-center font-mono text-[11px] text-content shadow-sm outline-none"
+                    className="w-14 rounded border border-accent bg-surface-elevated px-1 py-0.5 text-center font-mono text-label text-content shadow-sm outline-none"
                     onFocus={(e) => e.currentTarget.select()}
                     onPointerDown={(e) => e.stopPropagation()}
                     onKeyDown={(e) => {
@@ -282,7 +282,7 @@ export function ResizeHandles3D({
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-auto cursor-text whitespace-nowrap rounded bg-surface-elevated/95 px-1.5 py-0.5 font-mono text-[11px] text-content shadow-sm ring-1 ring-stroke-subtle hover:ring-accent"
+                    className="h-auto cursor-text whitespace-nowrap rounded bg-surface-elevated/95 px-1.5 py-0.5 font-mono text-label text-content shadow-sm ring-1 ring-stroke-subtle hover:ring-accent"
                     onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => {
                       e.stopPropagation();

--- a/src/features/bin-designer/components/Workshop/WorkshopDragTip.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopDragTip.tsx
@@ -34,7 +34,7 @@ export function WorkshopDragTip({ placed, mode, baseW, baseD }: WorkshopDragTipP
       center
       style={{ pointerEvents: 'none' }}
     >
-      <div className="whitespace-nowrap rounded bg-surface-elevated/95 px-1.5 py-0.5 font-mono text-[11px] text-content shadow-sm ring-1 ring-stroke-subtle">
+      <div className="whitespace-nowrap rounded bg-surface-elevated/95 px-1.5 py-0.5 font-mono text-label text-content shadow-sm ring-1 ring-stroke-subtle">
         {text}
       </div>
     </Html>

--- a/src/features/bin-designer/components/Workshop/WorkshopHoverTip.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopHoverTip.tsx
@@ -46,7 +46,7 @@ export function WorkshopHoverTip({ target }: WorkshopHoverTipProps) {
   return (
     <div
       data-testid="workshop-hover-tip"
-      className="pointer-events-none absolute z-10 max-w-[220px] rounded-md border border-stroke-subtle bg-surface-elevated/95 px-2.5 py-1.5 text-[11px] leading-snug shadow-md backdrop-blur"
+      className="pointer-events-none absolute z-10 max-w-[220px] rounded-md border border-stroke-subtle bg-surface-elevated/95 px-2.5 py-1.5 text-label leading-snug shadow-md backdrop-blur"
       style={{ left: target.x + 14, top: target.y + 18 }}
     >
       <div className="font-medium text-content-primary">

--- a/src/features/bin-designer/components/Workshop/WorkshopPanel/WorkshopPanel.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopPanel/WorkshopPanel.tsx
@@ -229,7 +229,7 @@ export function WorkshopPanel() {
                     aria-pressed={active}
                     title={t(tile.labelKey)}
                     className={
-                      'h-auto flex-col gap-1 rounded-lg px-1 py-2 text-[10px] font-medium ' +
+                      'h-auto flex-col gap-1 rounded-lg px-1 py-2 text-micro font-medium ' +
                       (active
                         ? 'bg-accent text-on-accent shadow-sm ring-1 ring-accent/40 hover:bg-accent'
                         : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover hover:text-content')

--- a/src/features/bin-designer/components/Workshop/WorkshopSelectionToolbar.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopSelectionToolbar.tsx
@@ -42,7 +42,7 @@ export function WorkshopSelectionToolbar() {
       data-testid="workshop-selection-toolbar"
       className="absolute left-1/2 top-3 flex -translate-x-1/2 items-center gap-1 rounded-lg border border-stroke-subtle bg-surface-elevated/90 p-1 shadow-sm backdrop-blur"
     >
-      <span className="px-2 text-[11px] font-medium text-content-secondary">
+      <span className="px-2 text-label font-medium text-content-secondary">
         {t('workshop.selection.count', { count })}
       </span>
       <div className="h-4 w-px bg-stroke-subtle" />
@@ -115,7 +115,7 @@ export function WorkshopSelectionToolbar() {
       <Button
         variant="ghost"
         size="sm"
-        className="px-1.5 text-status-error"
+        className="px-1.5 text-error"
         title={t('workshop.menu.delete')}
         onClick={() => run((ids) => store().removeAssemblyParts(ids))}
       >

--- a/src/features/bin-designer/components/Workshop/WorkshopViewBar.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopViewBar.tsx
@@ -44,7 +44,7 @@ export function WorkshopViewBar({
           key={preset}
           variant="ghost"
           size="sm"
-          className="px-2 text-[11px]"
+          className="px-2 text-label"
           title={`${t(labelKey)} (${shortcut})`}
           onClick={() => onPreset(preset)}
         >
@@ -55,7 +55,7 @@ export function WorkshopViewBar({
       <Button
         variant="ghost"
         size="sm"
-        className="px-2 text-[11px]"
+        className="px-2 text-label"
         title={t('workshop.view.fitTitle')}
         onClick={onFit}
       >
@@ -64,7 +64,7 @@ export function WorkshopViewBar({
       <Button
         variant="ghost"
         size="sm"
-        className="px-2 text-[11px]"
+        className="px-2 text-label"
         title={t('workshop.view.projectionToggle')}
         onClick={onProjectionToggle}
       >
@@ -76,7 +76,7 @@ export function WorkshopViewBar({
       <Button
         variant="ghost"
         size="sm"
-        className="px-2 font-mono text-[11px] text-content-secondary"
+        className="px-2 font-mono text-label text-content-secondary"
         title={t('workshop.snap.cycle')}
         onClick={cycleSnap}
       >

--- a/src/features/bin-designer/components/controls/CutoutFillControls/CutoutFillControls.tsx
+++ b/src/features/bin-designer/components/controls/CutoutFillControls/CutoutFillControls.tsx
@@ -50,7 +50,7 @@ export function CutoutFillControls() {
   return (
     <div className="space-y-2">
       <div className="space-y-1">
-        <span className="block text-[10px] text-content-tertiary">
+        <span className="block text-micro text-content-tertiary">
           {t('binDesigner.cutouts.fillMeasuredFrom')}
         </span>
         <div
@@ -101,7 +101,7 @@ export function CutoutFillControls() {
         />
       )}
 
-      <p className="text-[10px] leading-relaxed text-content-disabled">
+      <p className="text-micro leading-relaxed text-content-disabled">
         {fromFloor ? t('binDesigner.cutouts.fillHintFloor') : t('binDesigner.cutouts.fillHintRim')}
       </p>
     </div>

--- a/src/features/bin-designer/components/controls/LabelSizeControl/LabelSizeControl.tsx
+++ b/src/features/bin-designer/components/controls/LabelSizeControl/LabelSizeControl.tsx
@@ -56,7 +56,7 @@ export function LabelSizeControl({
   max,
   disabled,
   className,
-  labelClassName = 'text-[10px] text-content-tertiary',
+  labelClassName = 'text-micro text-content-tertiary',
   variant = 'cap',
   manualSeed,
   allowAuto = true,
@@ -85,7 +85,7 @@ export function LabelSizeControl({
               onChange(isAuto ? Math.min(max, Math.max(min, manualSeed ?? max)) : null)
             }
             aria-pressed={isAuto}
-            className={`px-1.5 py-0.5 text-[10px] leading-none ${getSegmentClass(isAuto)}`}
+            className={`px-1.5 py-0.5 text-micro leading-none ${getSegmentClass(isAuto)}`}
           >
             {t('binDesigner.textSizeAuto')}
           </Button>

--- a/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
+++ b/src/features/bin-designer/components/controls/SnappingSlider/SnappingSlider.tsx
@@ -336,7 +336,7 @@ export function SnappingSlider({
                 variant="ghost"
                 onClick={() => handleTickClick(option.value)}
                 disabled={disabled}
-                className={`absolute -translate-x-1/2 min-h-[36px] flex items-end pb-0.5 rounded-none px-0 hover:bg-transparent text-[11px] tabular-nums transition-colors ${
+                className={`absolute -translate-x-1/2 min-h-[36px] flex items-end pb-0.5 rounded-none px-0 hover:bg-transparent text-label tabular-nums transition-colors ${
                   disabled ? 'cursor-not-allowed' : 'cursor-pointer hover:text-content'
                 } ${isActive ? 'font-semibold text-accent' : 'text-content-tertiary'}`}
                 style={{ left: `${getPosition(option.value)}%` }}
@@ -355,7 +355,7 @@ export function SnappingSlider({
       </p>
 
       {/* Optional tip */}
-      {tip && <p className="mt-1 text-[10px] text-content-tertiary italic">{tip}</p>}
+      {tip && <p className="mt-1 text-micro text-content-tertiary italic">{tip}</p>}
     </div>
   );
 }

--- a/src/features/bin-designer/components/controls/TypeSpecimen/TypeSpecimen.tsx
+++ b/src/features/bin-designer/components/controls/TypeSpecimen/TypeSpecimen.tsx
@@ -55,7 +55,7 @@ export function TypeSpecimen({ text, style }: TypeSpecimenProps) {
         </g>
       </svg>
       {pathData === '' && (
-        <p className="mt-1 text-center text-[11px] text-content-tertiary">
+        <p className="mt-1 text-center text-label text-content-tertiary">
           {measurer === null
             ? t('binDesigner.type.specimenLoading')
             : t('binDesigner.type.specimenEmpty')}

--- a/src/features/bin-designer/components/panel/AssembledHeightBreakdown/AssembledHeightBreakdown.tsx
+++ b/src/features/bin-designer/components/panel/AssembledHeightBreakdown/AssembledHeightBreakdown.tsx
@@ -43,7 +43,7 @@ export function AssembledHeightBreakdown() {
       </Button>
 
       {expanded && (
-        <dl className="space-y-0.5 pl-1 text-[11px] text-content-tertiary">
+        <dl className="space-y-0.5 pl-1 text-label text-content-tertiary">
           {breakdown.segments.map((segment) => (
             <div key={segment.kind}>
               <div className="flex items-baseline justify-between gap-2">
@@ -54,7 +54,7 @@ export function AssembledHeightBreakdown() {
                   0mm because the bin's base drops into the pockets. Say so, or
                   it looks like a broken number. */}
               {segment.kind === 'baseplate' && breakdown.nestedMm > 0 && (
-                <p className="text-[10px] text-content-tertiary/70">
+                <p className="text-micro text-content-tertiary/70">
                   {t('assembledHeight.nestedNote', {
                     plate: fmt(breakdown.baseplatePrintedMm),
                     nested: fmt(breakdown.nestedMm),
@@ -68,7 +68,7 @@ export function AssembledHeightBreakdown() {
 
       {clearance && (
         <p
-          className={`pl-1 text-[11px] ${clearance.fits ? 'text-content-tertiary' : 'text-warning'}`}
+          className={`pl-1 text-label ${clearance.fits ? 'text-content-tertiary' : 'text-warning'}`}
         >
           {clearance.fits
             ? t('assembledHeight.fits', { slack: fmt(clearance.slackMm) })

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -317,7 +317,7 @@ export function BaseSection() {
             >
               {footLatticeAxes.map(({ axis, value, onChange, locked }) => (
                 <div key={axis} className="flex items-center gap-2">
-                  <span className="w-10 shrink-0 text-[11px] text-content-tertiary">
+                  <span className="w-10 shrink-0 text-label text-content-tertiary">
                     {t(`binDesigner.footLattice.axis.${axis}`)}
                   </span>
                   <SegmentedControl
@@ -389,7 +389,7 @@ export function BaseSection() {
                 type="button"
                 variant="ghost"
                 onClick={handlers.enableUndersideRelief}
-                className="mt-1 rounded border border-stroke-subtle bg-surface-elevated px-1.5 py-0.5 text-[10px] font-medium text-content-secondary hover:bg-surface-hover"
+                className="mt-1 rounded border border-stroke-subtle bg-surface-elevated px-1.5 py-0.5 text-micro font-medium text-content-secondary hover:bg-surface-hover"
               >
                 {t('binDesigner.lightweight.useUnderside')}
               </Button>

--- a/src/features/bin-designer/components/panel/ColorsSection/AccentBandsEditor.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/AccentBandsEditor.tsx
@@ -127,7 +127,7 @@ export function AccentBandsEditor({
           onMouseEnter={enabled ? () => onHover(zone) : undefined}
           onMouseLeave={enabled ? () => onHover(null) : undefined}
         >
-          <span className="text-[11px] font-medium text-content-secondary">{label}</span>
+          <span className="text-label font-medium text-content-secondary">{label}</span>
           <Checkbox checked={enabled} />
         </div>
         {enabled && (
@@ -170,7 +170,7 @@ export function AccentBandsEditor({
   return (
     <div className="border-t border-stroke-subtle pt-2">
       <div className="flex items-center justify-between gap-2 py-1">
-        <span className="text-[11px] font-semibold uppercase tracking-wide text-content-secondary">
+        <span className="text-label font-semibold uppercase tracking-wide text-content-secondary">
           {t('binDesigner.colors.accent.title')}
         </span>
         {anyEnabled && (
@@ -184,7 +184,7 @@ export function AccentBandsEditor({
         )}
       </div>
       {anyEnabled ? null : (
-        <p className="pb-1 text-[11px] leading-snug text-content-tertiary">
+        <p className="pb-1 text-label leading-snug text-content-tertiary">
           {t('binDesigner.colors.accent.hint')}
         </p>
       )}

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorGroup.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorGroup.tsx
@@ -51,7 +51,7 @@ export function ColorGroup({
         variant="ghost"
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-content-secondary py-1 -mx-1 px-1 rounded hover:bg-surface-hover transition-colors"
+        className="flex w-full items-center justify-between text-label font-semibold uppercase tracking-wide text-content-secondary py-1 -mx-1 px-1 rounded hover:bg-surface-hover transition-colors"
         aria-expanded={open}
         aria-controls={regionId}
       >

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorPicker.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorPicker.tsx
@@ -121,10 +121,10 @@ export function ColorPicker({
         />
         <div className="flex flex-1 flex-col leading-tight min-w-0">
           <span className="text-xs font-medium text-content truncate">{zoneLabel}</span>
-          <span className="font-mono text-[11px] text-content-secondary tabular-nums">{color}</span>
+          <span className="font-mono text-label text-content-secondary tabular-nums">{color}</span>
         </div>
         {!isAtDefault && (
-          <span className="font-mono text-[10px] text-content-tertiary tabular-nums whitespace-nowrap">
+          <span className="font-mono text-micro text-content-tertiary tabular-nums whitespace-nowrap">
             {t('binDesigner.colors.resetDefaultHint', { color: defaultColor })}
           </span>
         )}
@@ -132,7 +132,7 @@ export function ColorPicker({
 
       {/* Preset grid */}
       <div>
-        <p className="text-[10px] font-medium uppercase tracking-wide text-content-tertiary mb-1.5">
+        <p className="text-micro font-medium uppercase tracking-wide text-content-tertiary mb-1.5">
           {t('binDesigner.colors.presets')}
         </p>
         <div className="grid grid-cols-5 gap-1.5">
@@ -169,7 +169,7 @@ export function ColorPicker({
       {/* Used in this design (always rendered; empty state when no other zones differ) */}
       <div>
         <div className="flex items-center justify-between mb-1.5">
-          <p className="text-[10px] font-medium uppercase tracking-wide text-content-tertiary">
+          <p className="text-micro font-medium uppercase tracking-wide text-content-tertiary">
             {t('binDesigner.colors.usedInDesign')}
           </p>
           {bodyColor && (
@@ -179,7 +179,7 @@ export function ColorPicker({
               touchTarget={false}
               type="button"
               onClick={handleSuggest}
-              className="flex items-center gap-1 text-[10px] text-content-tertiary hover:text-content-secondary transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent rounded px-1"
+              className="flex items-center gap-1 text-micro text-content-tertiary hover:text-content-secondary transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent rounded px-1"
               title={t('binDesigner.colors.suggest')}
               aria-label={t('binDesigner.colors.suggest')}
             >
@@ -188,7 +188,7 @@ export function ColorPicker({
           )}
         </div>
         {otherColors.length === 0 && suggestions.length === 0 && recentColors.length === 0 ? (
-          <p className="text-[11px] text-content-tertiary italic">
+          <p className="text-label text-content-tertiary italic">
             {t('binDesigner.colors.usedInDesign.empty')}
           </p>
         ) : (
@@ -227,7 +227,7 @@ export function ColorPicker({
 
       {/* Custom tools */}
       <div>
-        <p className="text-[10px] font-medium uppercase tracking-wide text-content-tertiary mb-1.5">
+        <p className="text-micro font-medium uppercase tracking-wide text-content-tertiary mb-1.5">
           {t('binDesigner.colors.customTools')}
         </p>
         <div className="flex items-stretch gap-1.5">
@@ -285,7 +285,7 @@ export function ColorPicker({
           </IconButton>
         </div>
         {hexError && (
-          <p className="text-[10px] text-error mt-1.5">{t('binDesigner.colors.hexInvalid')}</p>
+          <p className="text-micro text-error mt-1.5">{t('binDesigner.colors.hexInvalid')}</p>
         )}
       </div>
     </div>

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorZoneRow.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorZoneRow.tsx
@@ -106,7 +106,7 @@ export function ColorZoneRow({
         <span className="min-w-0 flex-1 truncate text-left text-xs font-normal text-content-secondary">
           {label}
         </span>
-        <span className="font-mono text-[11px] font-normal text-content-secondary tabular-nums">
+        <span className="font-mono text-label font-normal text-content-secondary tabular-nums">
           {color}
         </span>
         <ChevronDownIcon

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsActionsMenu.tsx
@@ -211,11 +211,11 @@ export function ColorsActionsMenu({
 
             <div className="my-1 h-px bg-stroke-subtle/60" role="separator" />
 
-            <p className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-content-tertiary">
+            <p className="px-2 py-1 text-micro font-medium uppercase tracking-wide text-content-tertiary">
               {t('binDesigner.colors.palettes')}
             </p>
             {palettes.length === 0 ? (
-              <p className="px-2 py-1 text-[11px] italic text-content-tertiary">
+              <p className="px-2 py-1 text-label italic text-content-tertiary">
                 {t('binDesigner.colors.noPalettes')}
               </p>
             ) : (

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsHintBanner.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsHintBanner.tsx
@@ -27,7 +27,7 @@ export function ColorsHintBanner() {
   return (
     <div
       role="status"
-      className="flex items-start gap-2 rounded-lg border border-info/40 bg-info-muted/40 p-2.5 text-[11px] text-content-secondary"
+      className="flex items-start gap-2 rounded-lg border border-info/40 bg-info-muted/40 p-2.5 text-label text-content-secondary"
     >
       <InfoIcon size="sm" className="mt-0.5 shrink-0 text-info" />
       <p className="flex-1 leading-snug">{t('binDesigner.colors.firstTimeHint')}</p>

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
@@ -516,7 +516,7 @@ export function ColorsSection() {
         }
       />
       {!multiColorEnabled && (
-        <p className="text-[11px] text-content-tertiary leading-snug">
+        <p className="text-label text-content-tertiary leading-snug">
           {t('binDesigner.multiColor.enableHint')}
         </p>
       )}

--- a/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.tsx
@@ -121,7 +121,7 @@ export function LipColorEditor({
             {/* Not a <label>: it wraps a radiogroup, and a label leaks its text
                 onto the group's first radio (e.g. "Corners Corners"). The span is
                 the visible label; the SegmentedControl carries its own aria-label. */}
-            <div className="flex items-center justify-between gap-2 text-[11px] text-content-secondary">
+            <div className="flex items-center justify-between gap-2 text-label text-content-secondary">
               <span>{t('binDesigner.colors.lip.cornersLabel')}</span>
               <SegmentedControl
                 size="sm"
@@ -131,7 +131,7 @@ export function LipColorEditor({
                 onChange={(v) => onSetCorners(toAxis(v))}
               />
             </div>
-            <div className="flex items-center justify-between gap-2 text-[11px] text-content-secondary">
+            <div className="flex items-center justify-between gap-2 text-label text-content-secondary">
               <span>{t('binDesigner.colors.lip.bandsLabel')}</span>
               <SegmentedControl
                 size="sm"

--- a/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/AlignmentToolbar.tsx
@@ -236,7 +236,7 @@ export function AlignmentToolbar({
 
   return (
     <div className="space-y-2 rounded border border-stroke-subtle p-2">
-      <div className="text-[11px] text-content-tertiary">
+      <div className="text-label text-content-tertiary">
         {t('binDesigner.cutouts.nSelected', { count: selectedIds.length })}
       </div>
 
@@ -316,7 +316,7 @@ export function AlignmentToolbar({
         >
           {t('binDesigner.cutouts.autoArrange')}
         </Button>
-        <label className="flex items-center gap-1 text-[11px] text-content-tertiary">
+        <label className="flex items-center gap-1 text-label text-content-tertiary">
           {t('binDesigner.cutouts.gap')}
           <Input
             type="number"
@@ -334,7 +334,7 @@ export function AlignmentToolbar({
 
       {/* Pathfinder (Adobe Illustrator-style boolean ops) */}
       <div className="space-y-1">
-        <div className="text-[10px] uppercase tracking-wider text-content-tertiary">
+        <div className="text-micro uppercase tracking-wider text-content-tertiary">
           {t('binDesigner.cutouts.pathfinder.title')}
         </div>
         <PathfinderControls
@@ -347,7 +347,7 @@ export function AlignmentToolbar({
 
       {/* Transform: flip + rotate */}
       <div className="space-y-1">
-        <div className="text-[10px] uppercase tracking-wider text-content-tertiary">
+        <div className="text-micro uppercase tracking-wider text-content-tertiary">
           {t('binDesigner.cutouts.transform.title')}
         </div>
         <TransformControls
@@ -361,7 +361,7 @@ export function AlignmentToolbar({
 
       {/* Arrange: z-order */}
       <div className="space-y-1">
-        <div className="text-[10px] uppercase tracking-wider text-content-tertiary">
+        <div className="text-micro uppercase tracking-wider text-content-tertiary">
           {t('binDesigner.cutouts.arrange.title')}
         </div>
         <ArrangeControls selectedIds={selectedIds} onReorder={onReorder} />

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutArrayControls.tsx
@@ -99,7 +99,7 @@ export function CutoutArrayControls({
   if (blockedReason) {
     return (
       <div className="space-y-1.5">
-        <p className="text-[11px] leading-snug text-content-tertiary">
+        <p className="text-label leading-snug text-content-tertiary">
           {t(BLOCKED_REASON_KEYS[blockedReason])}
         </p>
         {blockedReason === 'grouped' && onUngroup && (
@@ -121,7 +121,7 @@ export function CutoutArrayControls({
     const fallback = clampedDefaultConfig(cutout, binWidth, binDepth);
     return (
       <div className="space-y-1.5">
-        <span className="block text-[10px] text-content-tertiary">
+        <span className="block text-micro text-content-tertiary">
           {t('binDesigner.cutouts.repeat.presetLabel')}
         </span>
         <div className="flex flex-wrap gap-1">
@@ -177,7 +177,7 @@ export function CutoutArrayControls({
             type="button"
             variant="ghost"
             aria-selected={array.mode === mode}
-            className={`flex flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-[11px] font-medium transition-all leading-none ${
+            className={`flex flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-label font-medium transition-all leading-none ${
               array.mode === mode
                 ? 'bg-surface-elevated text-content shadow-sm'
                 : 'text-content-tertiary hover:text-content-secondary'
@@ -234,7 +234,7 @@ export function CutoutArrayControls({
               {t('binDesigner.cutouts.repeat.rotateToCenter')}
             </label>
           ) : (
-            <p className="text-[11px] leading-snug text-content-tertiary">
+            <p className="text-label leading-snug text-content-tertiary">
               {t('binDesigner.cutouts.repeat.groupNoRotate')}
             </p>
           )}
@@ -294,12 +294,12 @@ export function CutoutArrayControls({
           to cut into each other, so the user is told what will happen rather
           than stopped. */}
       {overlaps && (
-        <p className="pt-0.5 text-[11px] leading-snug text-warning">
+        <p className="pt-0.5 text-label leading-snug text-warning">
           {t('binDesigner.cutouts.repeat.overlapWarning')}
         </p>
       )}
 
-      <div className="flex items-center justify-between pt-0.5 text-[11px] text-content-tertiary">
+      <div className="flex items-center justify-between pt-0.5 text-label text-content-tertiary">
         <span>{t('binDesigner.cutouts.repeat.instances', { count })}</span>
       </div>
 
@@ -369,7 +369,7 @@ function PresetChip({ preset, label, fits, noFitReason, disabled, onPick }: Pres
       onClick={onPick}
       title={!fits ? noFitReason : undefined}
       className={cn(
-        'rounded border px-1.5 py-0.5 text-[11px] tabular-nums transition-colors',
+        'rounded border px-1.5 py-0.5 text-label tabular-nums transition-colors',
         off
           ? 'cursor-not-allowed border-stroke-subtle bg-surface-elevated text-content-tertiary opacity-50'
           : 'border-stroke-subtle bg-surface-elevated text-content-secondary hover:border-accent/50 hover:text-content'

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutEmptyState.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutEmptyState.tsx
@@ -93,10 +93,10 @@ export function CutoutEmptyState({ variant, onScanWithPhone }: CutoutEmptyStateP
                 {t('binDesigner.cutouts.scanImport.emptyCta')}
               </span>
             </Button>
-            <p className="mt-1.5 text-[11px] text-content-tertiary">
+            <p className="mt-1.5 text-label text-content-tertiary">
               {t('binDesigner.cutouts.scanImport.emptyHelp')}
             </p>
-            <p className="mt-1 flex items-center justify-center gap-1 text-[10px] text-content-disabled">
+            <p className="mt-1 flex items-center justify-center gap-1 text-micro text-content-disabled">
               <svg
                 className="h-3 w-3 shrink-0"
                 viewBox="0 0 24 24"
@@ -122,7 +122,7 @@ export function CutoutEmptyState({ variant, onScanWithPhone }: CutoutEmptyStateP
 function ShortcutHint({ shortcut, label }: { readonly shortcut: string; readonly label: string }) {
   return (
     <div className="flex items-center gap-2">
-      <kbd className="px-1.5 py-0.5 rounded text-[10px] bg-surface-elevated border border-stroke-subtle text-content-disabled font-mono">
+      <kbd className="px-1.5 py-0.5 rounded text-micro bg-surface-elevated border border-stroke-subtle text-content-disabled font-mono">
         {shortcut}
       </kbd>
       <span>{label}</span>

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutPresetChips.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutPresetChips.tsx
@@ -30,7 +30,7 @@ function chipLabel(preset: CutoutSizePreset): string {
   return String(preset.mm);
 }
 
-const CHIP_BASE = 'rounded border px-1.5 py-0.5 text-[11px] tabular-nums transition-colors';
+const CHIP_BASE = 'rounded border px-1.5 py-0.5 text-label tabular-nums transition-colors';
 const CHIP_INACTIVE =
   'border-stroke-subtle bg-surface-elevated text-content-secondary hover:border-accent/50 hover:text-content';
 
@@ -48,7 +48,7 @@ export function CutoutPresetChips({
 
   return (
     <div className="space-y-1">
-      <span className="block text-[10px] text-content-tertiary">
+      <span className="block text-micro text-content-tertiary">
         {t('binDesigner.cutouts.sizePreset')}
       </span>
       <div className="flex flex-wrap gap-1">

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeToolbar.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutShapeToolbar.tsx
@@ -511,14 +511,14 @@ export function CutoutShapeToolbar({
           onClick={handleGridSizeCycle}
           title={`${t('binDesigner.gridSize')}: ${gridSize}mm`}
         >
-          <span className={vertical ? 'text-[10px] font-mono' : 'text-xs font-mono'}>
+          <span className={vertical ? 'text-micro font-mono' : 'text-xs font-mono'}>
             {gridSize}mm
           </span>
         </Button>
       )}
 
       {activeShape !== null && !vertical && (
-        <span className="text-[11px] text-content-tertiary">
+        <span className="text-label text-content-tertiary">
           {activeShape === 'path'
             ? t('binDesigner.cutouts.clickToDrawPath')
             : t('binDesigner.cutouts.dragToDraw')}
@@ -526,7 +526,7 @@ export function CutoutShapeToolbar({
       )}
 
       {isRulerActive && !vertical && (
-        <span className="text-[11px] text-content-tertiary">
+        <span className="text-label text-content-tertiary">
           {t('binDesigner.cutouts.dragToMeasure')}
         </span>
       )}

--- a/src/features/bin-designer/components/panel/CutoutsSection/CutoutsSection.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/CutoutsSection.tsx
@@ -30,10 +30,10 @@ export function CutoutsSection() {
   return (
     <div className="space-y-3">
       <div className="space-y-1">
-        <p className="text-[11px] text-content-tertiary leading-relaxed">
+        <p className="text-label text-content-tertiary leading-relaxed">
           {t('binDesigner.cutouts.instructions')}
         </p>
-        <p className="text-[10px] text-content-disabled leading-relaxed">
+        <p className="text-micro text-content-disabled leading-relaxed">
           {t('binDesigner.cutouts.instructionsWorkspaceHint')}
         </p>
       </div>
@@ -41,7 +41,7 @@ export function CutoutsSection() {
       <CutoutEditor />
 
       {taperBand && (
-        <p className="text-[10px] text-content-disabled leading-relaxed">
+        <p className="text-micro text-content-disabled leading-relaxed">
           {t('binDesigner.cutouts.taperBandHint')}
         </p>
       )}

--- a/src/features/bin-designer/components/panel/CutoutsSection/TransformControls.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/TransformControls.tsx
@@ -143,7 +143,7 @@ export function TransformControls({
         type="number"
         size="sm"
         wrapperClassName="w-12"
-        className="text-[11px]"
+        className="text-label"
         value={angle}
         min={-359}
         max={359}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/DimensionAnnotations3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/DimensionAnnotations3D.tsx
@@ -54,7 +54,7 @@ export function DimensionAnnotations3D({
               style={{ pointerEvents: 'none' }}
               zIndexRange={HTML_OVERLAY_Z_INDEX_RANGE}
             >
-              <div className="rounded bg-surface-elevated/80 px-1 text-[10px] font-mono text-content-secondary whitespace-nowrap">
+              <div className="rounded bg-surface-elevated/80 px-1 text-micro font-mono text-content-secondary whitespace-nowrap">
                 {effective.width.toFixed(1)}mm
               </div>
             </Html>
@@ -66,7 +66,7 @@ export function DimensionAnnotations3D({
               style={{ pointerEvents: 'none' }}
               zIndexRange={HTML_OVERLAY_Z_INDEX_RANGE}
             >
-              <div className="rounded bg-surface-elevated/80 px-1 text-[10px] font-mono text-content-secondary whitespace-nowrap">
+              <div className="rounded bg-surface-elevated/80 px-1 text-micro font-mono text-content-secondary whitespace-nowrap">
                 {effective.depth.toFixed(1)}mm
               </div>
             </Html>

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/DimensionTooltip3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/DimensionTooltip3D.tsx
@@ -47,7 +47,7 @@ export function DimensionTooltip3D({
       zIndexRange={HTML_OVERLAY_Z_INDEX_RANGE}
     >
       <div
-        className="rounded border border-stroke-subtle bg-surface-elevated px-2 py-0.5 text-[10px] font-mono text-content whitespace-nowrap shadow-sm"
+        className="rounded border border-stroke-subtle bg-surface-elevated px-2 py-0.5 text-micro font-mono text-content whitespace-nowrap shadow-sm"
         style={{ transform: 'translate(5px, -28px)' }}
       >
         {text}

--- a/src/features/bin-designer/components/panel/CutoutsSection/renderer/RulerMeasurement3D.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/renderer/RulerMeasurement3D.tsx
@@ -107,7 +107,7 @@ export function RulerMeasurement3D({ measurement, zoom }: RulerMeasurement3DProp
         <div className="rounded bg-gray-900/95 px-2.5 py-1.5 text-xs font-mono text-yellow-200 whitespace-nowrap shadow-lg border border-yellow-500/40">
           <div className="font-semibold text-yellow-100">{distance.toFixed(1)}mm</div>
           {(Math.abs(deltaX) > 0.1 || Math.abs(deltaY) > 0.1) && (
-            <div className="text-[10px] text-yellow-300/80">
+            <div className="text-micro text-yellow-300/80">
               {'\u0394'}x: {Math.abs(deltaX).toFixed(1)} &nbsp; {'\u0394'}y:{' '}
               {Math.abs(deltaY).toFixed(1)}
             </div>

--- a/src/features/bin-designer/components/panel/CutoutsSection/scanImport/ScanWithPhoneDialog.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/scanImport/ScanWithPhoneDialog.tsx
@@ -44,7 +44,7 @@ const round1 = (n: number): number => Math.round(n * 10) / 10;
 
 function PrivacyHint({ text }: { readonly text: string }) {
   return (
-    <span className="flex items-center justify-center gap-1.5 text-[11px] text-content-tertiary">
+    <span className="flex items-center justify-center gap-1.5 text-label text-content-tertiary">
       <svg
         width="12"
         height="12"
@@ -245,7 +245,7 @@ export function ScanWithPhoneDialog({ open, onClose, onImport }: ScanWithPhoneDi
                   {t('binDesigner.cutouts.scanImport.hint')}
                 </p>
                 {/* Fallback if the QR can't be scanned/rendered: the link itself. */}
-                <p className="max-w-full break-all font-mono text-[10px] text-content-tertiary">
+                <p className="max-w-full break-all font-mono text-micro text-content-tertiary">
                   {scan.url}
                 </p>
                 <p className="flex items-center gap-2 text-xs text-content-tertiary">

--- a/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
+++ b/src/features/bin-designer/components/panel/DimensionsSection/DimensionsSection.tsx
@@ -83,7 +83,7 @@ export function DimensionsSection() {
           2.5×2 bin put its half foot on either side without rotating the print. */}
       {(state.hasFractionalWidth || state.hasFractionalDepth) && (
         <div className="space-y-1.5 text-xs">
-          <div className="text-content-tertiary text-[10px]">
+          <div className="text-content-tertiary text-micro">
             {t('sidebar.halfUnitEdgePosition')}
           </div>
           {state.hasFractionalWidth && (
@@ -120,7 +120,7 @@ export function DimensionsSection() {
         <div>
           <div className="mb-1 flex items-center justify-between">
             <span className="text-xs text-content-tertiary">{t('common.height')}</span>
-            <span className="text-[11px] tabular-nums text-content-tertiary">{state.height}u</span>
+            <span className="text-label tabular-nums text-content-tertiary">{state.height}u</span>
           </div>
           <Stepper
             value={state.height}
@@ -147,7 +147,7 @@ export function DimensionsSection() {
           >
             {t('binDesigner.extraWallHeight')}
           </span>
-          <span className="text-[11px] tabular-nums text-content-tertiary">
+          <span className="text-label tabular-nums text-content-tertiary">
             {state.extraWallHeightMm} mm
           </span>
         </div>

--- a/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
+++ b/src/features/bin-designer/components/panel/HandleSection/HandleSection.tsx
@@ -275,7 +275,7 @@ export function HandleSection() {
               </div>
 
               {/* FDM support note — contextual to active handles */}
-              <p className="text-[11px] text-content-tertiary">
+              <p className="text-label text-content-tertiary">
                 {t('binDesigner.handles.supportNote')}
               </p>
             </>

--- a/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/InteriorModeCard.tsx
@@ -81,7 +81,7 @@ function BentoModeContent() {
   if (!isDesktop) {
     return (
       <div className="space-y-3">
-        <p className="rounded-md bg-surface/60 px-2 py-1.5 text-[11px] leading-relaxed text-content-tertiary">
+        <p className="rounded-md bg-surface/60 px-2 py-1.5 text-label leading-relaxed text-content-tertiary">
           {t('binDesigner.bento.smallScreenNote')}
         </p>
         <CompartmentEditor />
@@ -98,7 +98,7 @@ function BentoModeContent() {
         subtitle={t('binDesigner.openBentoWorkspaceSubtitle')}
         onClick={() => setBentoWorkspaceOpen(true)}
       />
-      <p className="px-1 text-[10px] text-content-tertiary">
+      <p className="px-1 text-micro text-content-tertiary">
         {drawnCount === 1
           ? t('binDesigner.bento.summary.one', {
               cols: compartments.cols,
@@ -128,7 +128,7 @@ function SolidModeContent() {
         <span className="text-xs font-semibold text-content-secondary">
           {t('binDesigner.editCutouts')}
         </span>
-        <p className="mt-0.5 text-[10px] leading-relaxed text-content-tertiary">
+        <p className="mt-0.5 text-micro leading-relaxed text-content-tertiary">
           {t('binDesigner.lightweightDisablesCutouts')}
         </p>
       </div>

--- a/src/features/bin-designer/components/panel/InteriorSection/WorkspaceLaunchButton.tsx
+++ b/src/features/bin-designer/components/panel/InteriorSection/WorkspaceLaunchButton.tsx
@@ -37,7 +37,7 @@ export function WorkspaceLaunchButton({
           <span className="text-xs font-semibold text-accent group-hover:text-accent/90">
             {title}
           </span>
-          <p className="text-[10px] text-content-tertiary mt-0.5 leading-relaxed">{subtitle}</p>
+          <p className="text-micro text-content-tertiary mt-0.5 leading-relaxed">{subtitle}</p>
         </div>
         <svg
           className="w-4 h-4 text-accent/50 flex-shrink-0 group-hover:translate-x-0.5 transition-transform"

--- a/src/features/bin-designer/components/panel/KnifeRestSection/KnifeRestSection.tsx
+++ b/src/features/bin-designer/components/panel/KnifeRestSection/KnifeRestSection.tsx
@@ -61,7 +61,7 @@ export function KnifeRestSection() {
               size="sm"
               fullWidth
             />
-            <p className="mt-1 text-[11px] leading-relaxed text-content-tertiary">
+            <p className="mt-1 text-label leading-relaxed text-content-tertiary">
               {t(`binDesigner.knifeRest.styleHint.${state.style}`)}
             </p>
           </div>
@@ -108,7 +108,7 @@ export function KnifeRestSection() {
         size="md"
         aria-label={t('binDesigner.knifeRest.grooveDepthAria')}
       />
-      <p className="text-[11px] leading-relaxed text-content-tertiary">
+      <p className="text-label leading-relaxed text-content-tertiary">
         {t('binDesigner.knifeRest.grooveDepthHint')}
       </p>
     </FeatureToggle>

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTabsSection.tsx
@@ -536,7 +536,7 @@ export function LabelTabsSection() {
                     checked={state.lipEnabled}
                     onChange={handlers.toggleLabelLip}
                   />
-                  <p className="mt-0.5 pl-7 text-[11px] leading-snug text-content-tertiary">
+                  <p className="mt-0.5 pl-7 text-label leading-snug text-content-tertiary">
                     {t('binDesigner.tabLipHint')}
                   </p>
                   {state.lipEnabled && (

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelTextList.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelTextList.tsx
@@ -201,7 +201,7 @@ export function LabelTextList({
           size="sm"
           touchTarget={false}
           onClick={onApplySuggestedName}
-          className="mb-2 rounded-full border border-stroke-subtle px-2 py-0.5 text-[11px] font-medium text-content-secondary hover:bg-surface-hover"
+          className="mb-2 rounded-full border border-stroke-subtle px-2 py-0.5 text-label font-medium text-content-secondary hover:bg-surface-hover"
         >
           {t('binDesigner.labelTextUseBinName', { name: suggestedName })}
         </Button>
@@ -266,7 +266,7 @@ export function LabelTextList({
                   }`}
                 >
                   {row.plate.fittingWidthsU.length === 0 || row.plate.autoWidthU === null ? (
-                    <span className="text-[11px] text-warning">
+                    <span className="text-label text-warning">
                       {t('binDesigner.plateWidthNoFit')}
                     </span>
                   ) : (
@@ -314,7 +314,7 @@ export function LabelTextList({
               {row.overflows && (
                 <p
                   id={messageId}
-                  className={`flex items-start gap-1 text-[11px] leading-snug text-error ${
+                  className={`flex items-start gap-1 text-label leading-snug text-error ${
                     showNumbers ? 'pl-8' : ''
                   }`}
                 >
@@ -346,7 +346,7 @@ export function LabelTextList({
             size="sm"
             touchTarget={false}
             onClick={onPickOnGrid}
-            className="px-0 text-[11px] font-medium text-accent hover:bg-transparent hover:text-accent/80"
+            className="px-0 text-label font-medium text-accent hover:bg-transparent hover:text-accent/80"
           >
             {t('binDesigner.labelTextPickOnGrid')}
           </Button>
@@ -360,7 +360,7 @@ export function LabelTextList({
             size="sm"
             touchTarget={false}
             onClick={onClearAll}
-            className="px-0 text-[11px] font-medium text-content-tertiary hover:bg-transparent hover:text-content"
+            className="px-0 text-label font-medium text-content-tertiary hover:bg-transparent hover:text-content"
           >
             {t('binDesigner.labelTextClearAll')}
           </Button>

--- a/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
@@ -70,7 +70,7 @@ function CompatibilityIssue({
   const dotColor = isBlocker ? 'bg-danger' : 'bg-warning';
   const textColor = isBlocker ? 'text-danger' : 'text-warning';
   return (
-    <li className={`flex items-start gap-1.5 text-[11px] leading-relaxed ${textColor}`}>
+    <li className={`flex items-start gap-1.5 text-label leading-relaxed ${textColor}`}>
       <span className={`mt-1.5 inline-block h-1 w-1 shrink-0 rounded-full ${dotColor}`} />
       <span className="flex-1">{message}</span>
       {fixable && (
@@ -79,7 +79,7 @@ function CompatibilityIssue({
           variant="ghost"
           onClick={() => onFix(issue.id)}
           aria-label={t('binDesigner.lid.compat.fixAriaLabel', { detail: message })}
-          className="shrink-0 rounded border border-stroke-subtle bg-surface-elevated px-1.5 py-0.5 text-[10px] font-medium text-content-secondary hover:bg-surface-hover"
+          className="shrink-0 rounded border border-stroke-subtle bg-surface-elevated px-1.5 py-0.5 text-micro font-medium text-content-secondary hover:bg-surface-hover"
         >
           {t('binDesigner.lid.compat.fixButton')}
         </Button>
@@ -188,7 +188,7 @@ export function LidSection() {
               share the list and are color-coded by severity. */}
           {state.compatibilityIssues.length > 0 && (
             <div className="space-y-1 rounded-md border border-stroke-subtle bg-surface-secondary px-2.5 py-2">
-              <p className="text-[11px] font-medium text-content-secondary">
+              <p className="text-label font-medium text-content-secondary">
                 {t('binDesigner.lid.compat.heading')}
               </p>
               <ul className="space-y-1">

--- a/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
+++ b/src/features/bin-designer/components/panel/OverhangSection/OverhangSection.tsx
@@ -51,7 +51,7 @@ export function OverhangSection() {
       disabledReason={meta.disabledReason}
       primaryControls={
         <>
-          <p className="text-[11px] leading-relaxed text-content-tertiary">
+          <p className="text-label leading-relaxed text-content-tertiary">
             {t('binDesigner.overhang.hint')}
           </p>
           {sides.map(({ side, label }) => (
@@ -103,7 +103,7 @@ export function OverhangSection() {
             </span>
             <Checkbox checked={state.feet} disabled={!feetEnabled} />
           </div>
-          <p className="text-[11px] leading-relaxed text-content-tertiary">
+          <p className="text-label leading-relaxed text-content-tertiary">
             {state.feetSuperseded
               ? t('binDesigner.detachableFeet.supersedes')
               : t('binDesigner.overhang.feetHint')}
@@ -129,7 +129,7 @@ export function OverhangSection() {
               </span>
               <Checkbox checked={taper.enabled} />
             </div>
-            <p className="text-[11px] leading-relaxed text-content-tertiary">
+            <p className="text-label leading-relaxed text-content-tertiary">
               {t('binDesigner.overhang.taper.hint')}
             </p>
 
@@ -163,7 +163,7 @@ export function OverhangSection() {
                 >
                   <p
                     id={taperSidesHeadingId}
-                    className="mt-1 text-[11px] font-medium text-content-tertiary"
+                    className="mt-1 text-label font-medium text-content-tertiary"
                   >
                     {t('binDesigner.overhang.taper.sidesHeading')}
                   </p>

--- a/src/features/bin-designer/components/panel/OverhangSection/TaperProfileCards.tsx
+++ b/src/features/bin-designer/components/panel/OverhangSection/TaperProfileCards.tsx
@@ -130,7 +130,7 @@ export function TaperProfileCards({
                   className={selected ? 'text-accent' : 'text-content-secondary'}
                 />
               </svg>
-              <span className="text-[11px] font-medium leading-none">{card.label}</span>
+              <span className="text-label font-medium leading-none">{card.label}</span>
             </Button>
           </div>
         );

--- a/src/features/bin-designer/components/panel/ScoopSection/ScoopSection.tsx
+++ b/src/features/bin-designer/components/panel/ScoopSection/ScoopSection.tsx
@@ -81,7 +81,7 @@ export function ScoopSection() {
             type="button"
             variant="ghost"
             onClick={handlers.toggleAutoRadius}
-            className="px-0 py-0 text-[11px] font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
+            className="px-0 py-0 text-label font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80"
           >
             {state.isAutoRadius
               ? `${t('binDesigner.scoopRadius')}: ${t('binDesigner.scoopRadiusAutoLabel')}`
@@ -91,7 +91,7 @@ export function ScoopSection() {
 
         {state.isAutoRadius ? (
           <>
-            <p className="mb-2 text-[11px] text-content-tertiary">{state.autoDisplayText}</p>
+            <p className="mb-2 text-label text-content-tertiary">{state.autoDisplayText}</p>
             <span className="mb-1 block text-xs text-content-tertiary">
               {t('binDesigner.scoopMaxHeight')}
             </span>
@@ -154,7 +154,7 @@ export function ScoopSection() {
               />
             </div>
             {state.isSteep && (
-              <p className="text-[11px] text-warning">{t('binDesigner.scoopSteepWarning')}</p>
+              <p className="text-label text-warning">{t('binDesigner.scoopSteepWarning')}</p>
             )}
           </div>
         )}

--- a/src/features/bin-designer/components/panel/SetDefaultFooter/SetDefaultFooter.tsx
+++ b/src/features/bin-designer/components/panel/SetDefaultFooter/SetDefaultFooter.tsx
@@ -36,7 +36,7 @@ export function SetDefaultFooter() {
         <span className="flex-1">{t('binDesigner.setAsDefault')}</span>
       </Button>
       {hasCustomDefault && (
-        <div className="mt-1.5 flex items-center gap-1.5 pl-6 text-[11px] text-content-tertiary">
+        <div className="mt-1.5 flex items-center gap-1.5 pl-6 text-label text-content-tertiary">
           <span className="h-1.5 w-1.5 rounded-full bg-accent" aria-hidden="true" />
           {t('binDesigner.customDefaultActive')}
         </div>

--- a/src/features/bin-designer/components/panel/ShapeSection/ShapeSection.tsx
+++ b/src/features/bin-designer/components/panel/ShapeSection/ShapeSection.tsx
@@ -52,12 +52,12 @@ export function ShapeSection() {
               variant="ghost"
               onClick={handlers.resetShape}
               disabled={!state.isCustom}
-              className="ml-auto px-0 py-0 text-[11px] font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80 disabled:cursor-not-allowed disabled:opacity-50"
+              className="ml-auto px-0 py-0 text-label font-medium text-accent transition-colors hover:bg-transparent hover:text-accent/80 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {t('common.reset')}
             </Button>
           </div>
-          <p className="text-[11px] text-content-tertiary">{t('binDesigner.shape.gridHelp')}</p>
+          <p className="text-label text-content-tertiary">{t('binDesigner.shape.gridHelp')}</p>
           <ShapeGrid
             mask={state.mask}
             onToggleCell={handlers.toggleCell}
@@ -65,9 +65,7 @@ export function ShapeSection() {
             cellLabel={cellLabel}
           />
           {state.isCustom && (
-            <p className="text-[11px] text-content-tertiary">
-              {t('binDesigner.shape.custom.hint')}
-            </p>
+            <p className="text-label text-content-tertiary">{t('binDesigner.shape.custom.hint')}</p>
           )}
         </div>
       }

--- a/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.tsx
+++ b/src/features/bin-designer/components/panel/SlideTraySection/SlideTraySection.tsx
@@ -56,7 +56,7 @@ function SlideTrayControls() {
             }))}
             aria-label={t('binDesigner.slideTray.mountAria')}
           />
-          <p className="text-[11px] leading-relaxed text-content-tertiary">
+          <p className="text-label leading-relaxed text-content-tertiary">
             {t(`binDesigner.slideTray.mountHint.${slide.railMount}`)}
           </p>
           <div className="flex gap-2">
@@ -86,7 +86,7 @@ function SlideTrayControls() {
             />
           </div>
           {protrusionMm !== null && (
-            <p className="text-[11px] leading-relaxed text-content-tertiary">
+            <p className="text-label leading-relaxed text-content-tertiary">
               {t('binDesigner.slideTray.protrudes', { mm: protrusionMm.toFixed(1) })}
             </p>
           )}
@@ -119,7 +119,7 @@ function SlideTrayControls() {
           aria-label={t('binDesigner.slideTray.clearanceAria')}
         />
       </div>
-      <p className="text-[11px] leading-relaxed text-content-tertiary">
+      <p className="text-label leading-relaxed text-content-tertiary">
         {t('binDesigner.slideTray.clearanceHint')}
       </p>
       <SlideFitSampleButton />

--- a/src/features/bin-designer/components/panel/SplitOptionsSection/SplitOptionsSection.tsx
+++ b/src/features/bin-designer/components/panel/SplitOptionsSection/SplitOptionsSection.tsx
@@ -48,7 +48,7 @@ export function SplitOptionsSection() {
       />
 
       {showNozzleNotice && (
-        <p className="text-[11px] leading-relaxed text-content-tertiary">
+        <p className="text-label leading-relaxed text-content-tertiary">
           {t('binDesigner.splitConnectorNozzleNotice', { nozzle: nozzleSizeMm })}
         </p>
       )}

--- a/src/features/bin-designer/components/panel/TypeSection/TypeSection.tsx
+++ b/src/features/bin-designer/components/panel/TypeSection/TypeSection.tsx
@@ -78,7 +78,7 @@ export function TypeSection() {
               aria-pressed={active}
               onClick={() => handlers.applyPreset(id)}
               className={cn(
-                'h-auto rounded-full border px-2.5 py-1 text-[11px] transition-colors',
+                'h-auto rounded-full border px-2.5 py-1 text-label transition-colors',
                 active
                   ? 'border-accent bg-accent/15 text-accent hover:bg-accent/15 hover:text-accent'
                   : 'border-stroke-subtle bg-surface-elevated text-content-secondary hover:border-accent/50 hover:text-content'
@@ -89,7 +89,7 @@ export function TypeSection() {
           );
         })}
         {state.activePreset === null && (
-          <span className="self-center rounded-full border border-stroke-subtle px-2.5 py-1 text-[11px] text-content-tertiary">
+          <span className="self-center rounded-full border border-stroke-subtle px-2.5 py-1 text-label text-content-tertiary">
             {t('binDesigner.type.preset.custom')}
           </span>
         )}
@@ -100,10 +100,10 @@ export function TypeSection() {
       {state.stemWarning && (
         <Alert intent="warning">
           <div className="space-y-1.5">
-            <p className="text-[11px] leading-relaxed">{t('binDesigner.type.stemWarning')}</p>
+            <p className="text-label leading-relaxed">{t('binDesigner.type.stemWarning')}</p>
             {/* The measurement, not just the verdict: it is what tells the user
                 how far they have to move, and it came from the built geometry. */}
-            <p className="text-[11px] leading-relaxed text-content-tertiary">
+            <p className="text-label leading-relaxed text-content-tertiary">
               {t('binDesigner.type.stemMeasured', {
                 stem: state.stemWarning.minStemMm.toFixed(2),
                 min: state.stemWarning.minPrintableStemMm.toFixed(1),
@@ -141,12 +141,12 @@ export function TypeSection() {
           control: three case options plus a 3x3 grid overflow the panel's width
           and clip each other's labels. */}
       <div className="flex items-center justify-between gap-3">
-        <span className="text-[11px] text-content-tertiary">{t('binDesigner.type.anchor')}</span>
+        <span className="text-label text-content-tertiary">{t('binDesigner.type.anchor')}</span>
         <AnchorPicker value={style.anchor} onChange={handlers.setAnchor} />
       </div>
 
       {state.stencilSubstituted && (
-        <p className="text-[11px] leading-relaxed text-content-tertiary">
+        <p className="text-label leading-relaxed text-content-tertiary">
           {t('binDesigner.textMode.throughCutStencilNote')}
         </p>
       )}
@@ -178,7 +178,7 @@ export function TypeSection() {
               fullWidth
             />
           </LabelledStepper>
-          <p className="text-[11px] leading-relaxed text-content-tertiary">
+          <p className="text-label leading-relaxed text-content-tertiary">
             {t('binDesigner.type.fixedSizeHint')}
           </p>
         </>
@@ -212,7 +212,7 @@ export function TypeSection() {
             }))}
           />
           <div className="space-y-1">
-            <span className="block text-[11px] text-content-tertiary">
+            <span className="block text-label text-content-tertiary">
               {t('binDesigner.type.tracking')}
             </span>
             <Slider

--- a/src/features/bin-designer/components/panel/VariantSection/VariantSection.tsx
+++ b/src/features/bin-designer/components/panel/VariantSection/VariantSection.tsx
@@ -105,7 +105,7 @@ export function VariantSection({
         </p>
       )}
 
-      <h4 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-content-tertiary">
+      <h4 className="mb-1.5 text-label font-semibold uppercase tracking-wide text-content-tertiary">
         {t('binDesigner.variants.dimensions')}
       </h4>
       <div className="mb-4 flex flex-col gap-1.5">
@@ -172,7 +172,7 @@ export function VariantSection({
 
       {cutouts.length > 0 && (
         <>
-          <h4 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-content-tertiary">
+          <h4 className="mb-1.5 text-label font-semibold uppercase tracking-wide text-content-tertiary">
             {t('binDesigner.variants.cutouts')}
           </h4>
           <div className="flex flex-col gap-1">
@@ -202,12 +202,12 @@ export function VariantSection({
                         const inherited = cutout[field] ?? 0;
                         return (
                           <div key={field} className="flex items-center gap-2">
-                            <span className="w-20 flex-shrink-0 text-[11px] text-content-secondary">
+                            <span className="w-20 flex-shrink-0 text-label text-content-secondary">
                               {t(`binDesigner.variants.field.${field}`)}
                             </span>
                             {claimed === undefined ? (
                               <>
-                                <span className="flex-1 text-[11px] text-content-tertiary">
+                                <span className="flex-1 text-label text-content-tertiary">
                                   {t('binDesigner.variants.inherited', { value: inherited })}
                                 </span>
                                 <Button

--- a/src/features/bin-designer/components/panel/WallsSection/PatternSelector.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/PatternSelector.tsx
@@ -305,7 +305,7 @@ export function PatternSelector({
         fullWidth
       />
       {disabled && disabledReason && (
-        <p className="text-[11px] text-content-tertiary mt-1.5">{disabledReason}</p>
+        <p className="text-label text-content-tertiary mt-1.5">{disabledReason}</p>
       )}
     </div>
   );

--- a/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallsSection.tsx
@@ -63,7 +63,7 @@ export function WallsSection() {
           disabledReason={state.patternDisabledReason}
         />
         {state.patternPartialNote && state.patternEnabled && (
-          <p className="text-[11px] text-content-tertiary mt-1">{state.patternPartialNote}</p>
+          <p className="text-label text-content-tertiary mt-1">{state.patternPartialNote}</p>
         )}
         {state.patternEnabled && !state.patternDisabled && (
           <>
@@ -84,7 +84,7 @@ export function WallsSection() {
                 Suppressed when the pattern renders nothing on this bin, so the
                 chips can't claim walls that export solid. */}
             {state.patternInertReason ? (
-              <p className="mt-3 text-[11px] leading-relaxed text-content-tertiary">
+              <p className="mt-3 text-label leading-relaxed text-content-tertiary">
                 {state.patternInertReason}
               </p>
             ) : (
@@ -98,7 +98,7 @@ export function WallsSection() {
                   ariaLabel={t('binDesigner.walls.pattern.sides')}
                 />
                 {state.patternSidesNote && (
-                  <p className="mt-1 text-[11px] leading-relaxed text-content-tertiary">
+                  <p className="mt-1 text-label leading-relaxed text-content-tertiary">
                     {state.patternSidesNote}
                   </p>
                 )}
@@ -114,7 +114,7 @@ export function WallsSection() {
                 disabled={state.dividersAvailableReason !== undefined}
                 label={t('binDesigner.walls.pattern.dividers')}
               />
-              <p className="ml-6 mt-1 text-[11px] leading-relaxed text-content-tertiary">
+              <p className="ml-6 mt-1 text-label leading-relaxed text-content-tertiary">
                 {state.dividersAvailableReason ??
                   state.dividersNote ??
                   t('binDesigner.walls.pattern.dividersHint')}
@@ -137,7 +137,7 @@ export function WallsSection() {
             <div className="grid grid-cols-2 gap-2">
               {WALL_TEXT_SIDES.map((side, index) => (
                 <div key={side}>
-                  <span className="mb-1 block text-[11px] text-content-tertiary">
+                  <span className="mb-1 block text-label text-content-tertiary">
                     {t(`binDesigner.lid.side.${side}`)}
                   </span>
                   <CompartmentTextInput
@@ -168,12 +168,12 @@ export function WallsSection() {
                   }))}
                 />
                 {state.wallTextMode === 'through-cut' && (
-                  <p className="text-[11px] leading-relaxed text-content-tertiary">
+                  <p className="text-label leading-relaxed text-content-tertiary">
                     {t('binDesigner.textMode.throughCutStencilNote')}
                   </p>
                 )}
                 <div className="space-y-1">
-                  <span className="block text-[11px] text-content-tertiary">
+                  <span className="block text-label text-content-tertiary">
                     {t('binDesigner.type.anchor')}
                   </span>
                   <AnchorPicker
@@ -182,10 +182,10 @@ export function WallsSection() {
                     label={t('binDesigner.walls.text.anchor')}
                   />
                 </div>
-                <p className="text-[11px] leading-relaxed text-content-tertiary">
+                <p className="text-label leading-relaxed text-content-tertiary">
                   {t('binDesigner.walls.text.hint')}
                 </p>
-                <p className="text-[11px] leading-relaxed text-content-tertiary">
+                <p className="text-label leading-relaxed text-content-tertiary">
                   {t('binDesigner.type.secondLineHint')}
                 </p>
               </>

--- a/src/features/bin-designer/components/panel/shared/panelText.tsx
+++ b/src/features/bin-designer/components/panel/shared/panelText.tsx
@@ -2,7 +2,7 @@ import { RulerIcon } from '@/design-system/Icon';
 
 /** Small tertiary hint paragraph. */
 export function Hint({ children }: { children: string }) {
-  return <p className="text-[11px] leading-relaxed text-content-tertiary">{children}</p>;
+  return <p className="text-label leading-relaxed text-content-tertiary">{children}</p>;
 }
 
 /**
@@ -14,7 +14,7 @@ export function Hint({ children }: { children: string }) {
  */
 export function SubHeader({ children }: { children: string }) {
   return (
-    <span className="block text-[11px] font-semibold uppercase tracking-wider text-content-tertiary">
+    <span className="block text-label font-semibold uppercase tracking-wider text-content-tertiary">
       {children}
     </span>
   );

--- a/src/features/bin-designer/components/preview/LidExplodeSlider/LidExplodeSlider.tsx
+++ b/src/features/bin-designer/components/preview/LidExplodeSlider/LidExplodeSlider.tsx
@@ -173,7 +173,7 @@ export function LidExplodeSlider({
       onPointerEnter={() => setIsHovering(true)}
       onPointerLeave={() => setIsHovering(false)}
     >
-      <span className="text-[11px] font-medium text-content-secondary">
+      <span className="text-label font-medium text-content-secondary">
         {labels?.open ?? t('binDesigner.preview.lidOpen')}
       </span>
 
@@ -250,7 +250,7 @@ export function LidExplodeSlider({
         />
       </div>
 
-      <span className="text-[11px] font-medium text-content-secondary">
+      <span className="text-label font-medium text-content-secondary">
         {labels?.closed ?? t('binDesigner.preview.lidClosed')}
       </span>
     </div>

--- a/src/features/bin-designer/components/preview/PreviewControls/PreviewControls.tsx
+++ b/src/features/bin-designer/components/preview/PreviewControls/PreviewControls.tsx
@@ -193,7 +193,7 @@ export function PreviewControls({
                   size="sm"
                   touchTarget={false}
                   onClick={() => onSplitViewModeChange(mode)}
-                  className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
+                  className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium transition-colors min-h-[28px] touch-manipulation ${
                     isActive
                       ? 'bg-accent text-on-accent hover:bg-accent'
                       : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -225,7 +225,7 @@ export function PreviewControls({
                 size="sm"
                 touchTarget={false}
                 onClick={() => onCameraPreset(key)}
-                className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
+                className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium transition-colors min-h-[28px] touch-manipulation ${
                   isActive
                     ? 'bg-accent text-on-accent hover:bg-accent'
                     : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -237,7 +237,7 @@ export function PreviewControls({
                 <Icon />
                 <span>{label}</span>
                 <kbd
-                  className={`text-[9px] font-normal ${isActive ? 'text-on-accent/60' : 'text-content-tertiary'}`}
+                  className={`text-micro font-normal ${isActive ? 'text-on-accent/60' : 'text-content-tertiary'}`}
                 >
                   {shortcut}
                 </kbd>
@@ -254,7 +254,7 @@ export function PreviewControls({
             size="sm"
             touchTarget={false}
             onClick={onResetView}
-            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
             title={t('binDesigner.resetView')}
             aria-label={t('binDesigner.resetCameraViewKeyboardShortcutR')}
           >
@@ -269,7 +269,7 @@ export function PreviewControls({
             size="sm"
             touchTarget={false}
             onClick={onWireframeToggle}
-            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
+            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium transition-colors min-h-[28px] touch-manipulation ${
               wireframe
                 ? 'bg-accent text-on-accent hover:bg-accent'
                 : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -289,7 +289,7 @@ export function PreviewControls({
             size="sm"
             touchTarget={false}
             onClick={onXrayToggle}
-            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
+            className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium transition-colors min-h-[28px] touch-manipulation ${
               xray
                 ? 'bg-accent text-on-accent hover:bg-accent'
                 : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -310,7 +310,7 @@ export function PreviewControls({
               size="sm"
               touchTarget={false}
               onClick={onMeasureToggle}
-              className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium transition-colors min-h-[28px] touch-manipulation ${
+              className={`flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium transition-colors min-h-[28px] touch-manipulation ${
                 measureActive
                   ? 'bg-accent text-on-accent hover:bg-accent'
                   : 'text-content-secondary hover:bg-surface-hover hover:text-content'
@@ -331,7 +331,7 @@ export function PreviewControls({
             size="sm"
             touchTarget={false}
             onClick={onProjectionToggle}
-            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
+            className="flex items-center gap-1 rounded-none px-2.5 py-1.5 text-label font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
             title={t('binDesigner.toggleProjection')}
             aria-label={t('binDesigner.toggleProjectionKeyboardShortcut')}
             aria-pressed={projection === 'orthographic'}
@@ -357,7 +357,7 @@ export function PreviewControls({
                 size="sm"
                 touchTarget={false}
                 onClick={() => setColorPickerOpen((v) => !v)}
-                className="flex items-center gap-1.5 rounded-none px-2.5 py-1.5 text-[11px] font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
+                className="flex items-center gap-1.5 rounded-none px-2.5 py-1.5 text-label font-medium text-content-secondary transition-colors hover:bg-surface-hover hover:text-content min-h-[28px] touch-manipulation"
                 title={t('binDesigner.changePreviewColor')}
                 aria-label={t('binDesigner.changePreviewColor')}
                 aria-expanded={colorPickerOpen}
@@ -399,7 +399,7 @@ export function PreviewControls({
                   variant="ghost"
                   touchTarget={false}
                   onClick={() => onSplitViewModeChange(mode)}
-                  className={`flex items-center justify-center gap-1 rounded-none min-w-[44px] min-h-[44px] px-3 py-2 text-[11px] font-medium transition-colors touch-manipulation ${
+                  className={`flex items-center justify-center gap-1 rounded-none min-w-[44px] min-h-[44px] px-3 py-2 text-label font-medium transition-colors touch-manipulation ${
                     isActive
                       ? 'bg-accent text-on-accent hover:bg-accent'
                       : 'text-content-secondary hover:bg-surface-hover hover:text-content'

--- a/src/features/bin-inspector/components/Inspector/EmptyState/EmptyState.tsx
+++ b/src/features/bin-inspector/components/Inspector/EmptyState/EmptyState.tsx
@@ -74,19 +74,19 @@ export function EmptyState({ variant }: EmptyStateProps) {
       <p className="text-xs text-content-disabled mb-3">{t('inspector.empty.drawHint')}</p>
       <div className="text-left text-xs space-y-1.5 text-content-tertiary w-full">
         <div className="flex items-center gap-2">
-          <kbd className="px-1.5 py-0.5 rounded text-[10px] bg-surface-elevated border border-stroke-subtle text-content-disabled font-mono">
+          <kbd className="px-1.5 py-0.5 rounded text-micro bg-surface-elevated border border-stroke-subtle text-content-disabled font-mono">
             Drag
           </kbd>
           <span>{t('inspector.empty.hintDraw')}</span>
         </div>
         <div className="flex items-center gap-2">
-          <kbd className="px-1.5 py-0.5 rounded text-[10px] bg-surface-elevated border border-stroke-subtle text-content-disabled font-mono">
+          <kbd className="px-1.5 py-0.5 rounded text-micro bg-surface-elevated border border-stroke-subtle text-content-disabled font-mono">
             Ctrl+D
           </kbd>
           <span>{t('inspector.empty.hintDuplicate')}</span>
         </div>
         <div className="flex items-center gap-2">
-          <kbd className="px-1.5 py-0.5 rounded text-[10px] bg-surface-elevated border border-stroke-subtle text-content-disabled font-mono">
+          <kbd className="px-1.5 py-0.5 rounded text-micro bg-surface-elevated border border-stroke-subtle text-content-disabled font-mono">
             L
           </kbd>
           <span>{t('inspector.empty.hintLabel')}</span>

--- a/src/features/bin-inspector/components/Inspector/ExpandedFootprint/ExpandedFootprint.tsx
+++ b/src/features/bin-inspector/components/Inspector/ExpandedFootprint/ExpandedFootprint.tsx
@@ -49,7 +49,7 @@ export function ExpandedFootprint({ bin, layout }: ExpandedFootprintProps) {
     <div className="rounded-md border border-subtle p-2">
       <div className="flex items-start justify-between gap-2">
         <div>
-          <p className="text-[10px] uppercase tracking-wide text-content-tertiary">
+          <p className="text-micro uppercase tracking-wide text-content-tertiary">
             {t('inspector.expandedFootprint')}
           </p>
           <p className="text-sm text-content-primary">
@@ -65,7 +65,7 @@ export function ExpandedFootprint({ bin, layout }: ExpandedFootprintProps) {
           {t('common.reset')}
         </Button>
       </div>
-      <p className="mt-1 text-[10px] leading-snug text-content-tertiary">
+      <p className="mt-1 text-micro leading-snug text-content-tertiary">
         {t('inspector.expandedFootprint.sides', {
           left: formatSide(left),
           right: formatSide(right),

--- a/src/features/bin-inspector/components/Inspector/ExtendToMarginToggle/ExtendToMarginToggle.tsx
+++ b/src/features/bin-inspector/components/Inspector/ExtendToMarginToggle/ExtendToMarginToggle.tsx
@@ -82,7 +82,7 @@ export function ExtendToMarginToggle({ bin, drawer, baseplate }: ExtendToMarginT
         disabled={!linked}
         onChange={(checked) => updateBin(bin.id, { extendToMargin: checked })}
       />
-      <p className="mt-1 px-2 text-[10px] leading-snug text-content-disabled">
+      <p className="mt-1 px-2 text-micro leading-snug text-content-disabled">
         {linked ? t('inspector.extendToMargin.hint') : t('inspector.extendToMargin.needsLink')}
       </p>
 
@@ -121,7 +121,7 @@ export function ExtendToMarginToggle({ bin, drawer, baseplate }: ExtendToMarginT
                 step={TAPER_BAND_STEP}
                 unit="mm"
               />
-              <p className="text-[10px] leading-snug text-content-disabled">
+              <p className="text-micro leading-snug text-content-disabled">
                 {t('inspector.taper.flare.hint')}
               </p>
             </div>

--- a/src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/MultiBinInspector/MultiBinInspector.tsx
@@ -139,7 +139,7 @@ export function MultiBinInspector({ inspector, variant, onClose }: MultiBinInspe
           className="w-5 h-5 rounded flex-shrink-0 flex items-center justify-center bg-accent shadow-sm"
           aria-hidden="true"
         >
-          <span className="text-[10px] font-bold text-black">{selectedBins.length}</span>
+          <span className="text-micro font-bold text-black">{selectedBins.length}</span>
         </div>
         <h2 className="flex-1 text-lg font-semibold text-content">{t('inspector.binsSelected')}</h2>
         {onClose && (

--- a/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
+++ b/src/features/bin-inspector/components/Inspector/SingleBinInspector/SingleBinInspector.tsx
@@ -223,7 +223,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
         </div>
 
         {locked && (
-          <p className="-mt-2 text-[10px] leading-snug text-content-disabled">
+          <p className="-mt-2 text-micro leading-snug text-content-disabled">
             {t('inspector.sizeLockedHint')}
           </p>
         )}
@@ -252,7 +252,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
                 size={isMobile ? 'lg' : 'md'}
                 aria-label={t('inspector.single.heightAria')}
               />
-              <div className="mt-1 text-[10px] text-content-disabled">{heightEquiv}</div>
+              <div className="mt-1 text-micro text-content-disabled">{heightEquiv}</div>
             </div>
 
             {/* Clearance control */}
@@ -285,7 +285,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
                   size={isMobile ? 'lg' : 'md'}
                   aria-label={t('inspector.single.clearanceAria')}
                 />
-                <div className="mt-1 text-[10px] text-content-disabled">
+                <div className="mt-1 text-micro text-content-disabled">
                   {t('inspector.heightUnitsEquiv', {
                     units: formatHeightUnits(bin.clearanceHeight || 0),
                   })}
@@ -296,7 +296,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
 
           {/* Outside the grid: inside the narrow Height column these lines wrap far
               enough to stretch the row and strand the Clearance cell. */}
-          <div className="space-y-0.5 text-[10px] text-content-disabled">
+          <div className="space-y-0.5 text-micro text-content-disabled">
             <div>{`${minHeightHint} · ${maxHeightHint}`}</div>
             <div>
               {t('inspector.printedAndStackHint', {
@@ -425,7 +425,7 @@ export function SingleBinInspector({ inspector, variant, onClose }: SingleBinIns
             rows={3}
             style={{ resize: 'vertical', minHeight: '60px' }}
           />
-          <div className="text-right mt-1 text-[10px] text-content-disabled">
+          <div className="text-right mt-1 text-micro text-content-disabled">
             {bin.notes.length}/{CONSTRAINTS.NOTES_MAX_LENGTH}
           </div>
         </div>

--- a/src/features/bin-inspector/components/Inspector/SplitWarning/SplitWarning.tsx
+++ b/src/features/bin-inspector/components/Inspector/SplitWarning/SplitWarning.tsx
@@ -94,7 +94,7 @@ function PrintBedIndicator({
       />
 
       {/* Label */}
-      <div className="absolute bottom-0 right-0 text-[8px] text-content-disabled px-0.5">
+      <div className="absolute bottom-0 right-0 text-micro text-content-disabled px-0.5">
         {bedLabel}
       </div>
     </div>
@@ -145,7 +145,7 @@ export function SplitWarning({
   // Warning state - bin exceeds print bed
   if (compact) {
     return (
-      <div className="flex items-center gap-2 p-3 rounded-lg bg-[var(--color-warning-muted)] border border-[var(--color-warning)] text-[var(--color-warning)]">
+      <div className="flex items-center gap-2 p-3 rounded-lg bg-warning-muted border border-warning text-warning">
         <svg
           className="w-5 h-5 flex-shrink-0"
           fill="none"
@@ -165,7 +165,7 @@ export function SplitWarning({
   }
 
   return (
-    <div className="flex items-start gap-3 p-3 rounded-lg bg-[var(--color-warning-muted)] border border-[var(--color-warning)] text-[var(--color-warning)] text-sm">
+    <div className="flex items-start gap-3 p-3 rounded-lg bg-warning-muted border border-warning text-warning text-sm">
       <PrintBedIndicator
         binWidth={binWidth}
         binDepth={binDepth}

--- a/src/features/bin-recommender/components/BinSizeSuggestion/BinSizeSuggestion.tsx
+++ b/src/features/bin-recommender/components/BinSizeSuggestion/BinSizeSuggestion.tsx
@@ -85,7 +85,7 @@ export function BinSizeSuggestion({
           {t('inspector.sizeSuggestionApply')}
         </Button>
       ) : (
-        <span className="text-[11px] text-content-tertiary whitespace-nowrap">
+        <span className="text-label text-content-tertiary whitespace-nowrap">
           {t('inspector.sizeSuggestionNoFit')}
         </span>
       )}

--- a/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
+++ b/src/features/categories/components/CategoriesPanel/CategoriesPanel.tsx
@@ -372,7 +372,7 @@ export function CategoriesPanel() {
                     {/* Bin count badge - only rendered when category has bins */}
                     {binCount > 0 && (
                       <span
-                        className={`text-[10px] min-w-[20px] text-center px-1.5 py-0.5 rounded-full flex-shrink-0 transition-colors ${
+                        className={`text-micro min-w-[20px] text-center px-1.5 py-0.5 rounded-full flex-shrink-0 transition-colors ${
                           isHovered ? 'bg-accent/20 text-accent' : 'text-content-tertiary'
                         }`}
                         title={t('categories.binsUseCategory', { count: binCount })}

--- a/src/features/command-palette/components/CommandPalette/CommandPalette.tsx
+++ b/src/features/command-palette/components/CommandPalette/CommandPalette.tsx
@@ -159,11 +159,11 @@ export function CommandPalette({ open, onOpenChange, initialQuery = '' }: Comman
               value={searchValue}
               onValueChange={setSearchValue}
               placeholder={t('commandPalette.placeholder')}
-              className="flex-1 py-3.5 text-[15px] bg-transparent text-content placeholder:text-content-tertiary outline-none"
+              className="flex-1 py-3.5 text-lg bg-transparent text-content placeholder:text-content-tertiary outline-none"
               // eslint-disable-next-line jsx-a11y/no-autofocus -- Intentional autofocus for modal/dialog UX
               autoFocus
             />
-            <kbd className="hidden sm:inline-flex items-center justify-center min-w-[28px] h-[22px] px-1.5 text-[11px] font-mono font-medium rounded border border-stroke bg-gradient-to-b from-surface-elevated to-surface text-content-secondary shadow-[0_1px_0_1px_rgba(0,0,0,0.15),inset_0_1px_0_rgba(255,255,255,0.05)]">
+            <kbd className="hidden sm:inline-flex items-center justify-center min-w-[28px] h-[22px] px-1.5 text-label font-mono font-medium rounded border border-stroke bg-gradient-to-b from-surface-elevated to-surface text-content-secondary shadow-[0_1px_0_1px_rgba(0,0,0,0.15),inset_0_1px_0_rgba(255,255,255,0.05)]">
               esc
             </kbd>
           </div>
@@ -203,7 +203,7 @@ export function CommandPalette({ open, onOpenChange, initialQuery = '' }: Comman
                         <path key={d} strokeLinecap="round" strokeLinejoin="round" d={d} />
                       ))}
                     </svg>
-                    <span className="text-[10px] font-semibold text-content-tertiary uppercase tracking-wider">
+                    <span className="text-micro font-semibold text-content-tertiary uppercase tracking-wider">
                       {t('commandPalette.recent')}
                     </span>
                   </div>
@@ -234,7 +234,7 @@ export function CommandPalette({ open, onOpenChange, initialQuery = '' }: Comman
                   heading={
                     <div className="flex items-center gap-1.5 px-3 pb-1.5 pt-2.5 first:pt-1">
                       <CategoryIcon category={category} />
-                      <span className="text-[10px] font-semibold text-content-tertiary uppercase tracking-wider">
+                      <span className="text-micro font-semibold text-content-tertiary uppercase tracking-wider">
                         {t(CATEGORY_LABELS[category])}
                       </span>
                     </div>

--- a/src/features/command-palette/components/CommandPalette/commandPaletteParts.tsx
+++ b/src/features/command-palette/components/CommandPalette/commandPaletteParts.tsx
@@ -57,7 +57,7 @@ export function CommandItem({ command, onSelect, t }: CommandItemProps) {
       value={searchValue}
       onSelect={() => onSelect(command.id)}
       disabled={!command.isAvailable}
-      className="group flex items-center justify-between gap-3 mx-2 px-2.5 py-2 rounded-lg cursor-pointer text-[13px] text-content transition-colors data-[selected=true]:bg-accent/10 data-[selected=true]:text-accent data-[disabled=true]:opacity-35 data-[disabled=true]:cursor-not-allowed focus-visible:outline-none"
+      className="group flex items-center justify-between gap-3 mx-2 px-2.5 py-2 rounded-lg cursor-pointer text-body text-content transition-colors data-[selected=true]:bg-accent/10 data-[selected=true]:text-accent data-[disabled=true]:opacity-35 data-[disabled=true]:cursor-not-allowed focus-visible:outline-none"
     >
       <span className="truncate">{t(command.labelKey)}</span>
       {command.shortcut && (

--- a/src/features/command-palette/components/CommandPaletteFooter/CommandPaletteFooter.tsx
+++ b/src/features/command-palette/components/CommandPaletteFooter/CommandPaletteFooter.tsx
@@ -16,13 +16,13 @@ interface CommandPaletteFooterProps {
 
 /** Footer keyboard key styling - smaller variant for hints */
 const footerKeyClasses =
-  'inline-flex items-center justify-center min-w-[20px] h-[18px] px-1 text-[10px] font-mono font-medium rounded border border-stroke bg-gradient-to-b from-surface-elevated to-surface text-content-tertiary shadow-[0_1px_0_1px_rgba(0,0,0,0.1),inset_0_1px_0_rgba(255,255,255,0.05)]';
+  'inline-flex items-center justify-center min-w-[20px] h-[18px] px-1 text-micro font-mono font-medium rounded border border-stroke bg-gradient-to-b from-surface-elevated to-surface text-content-tertiary shadow-[0_1px_0_1px_rgba(0,0,0,0.1),inset_0_1px_0_rgba(255,255,255,0.05)]';
 
 export function CommandPaletteFooter({ selectedCommand, matchCount }: CommandPaletteFooterProps) {
   const t = useTranslation();
 
   return (
-    <div className="flex items-center justify-between px-3 py-2 border-t border-stroke-subtle bg-surface-secondary/50 text-[11px] text-content-tertiary">
+    <div className="flex items-center justify-between px-3 py-2 border-t border-stroke-subtle bg-surface-secondary/50 text-label text-content-tertiary">
       {/* Left: Action hints */}
       <div className="flex items-center gap-3">
         <span className="flex items-center gap-1">

--- a/src/features/community/components/AuthorSummary/AuthorSummary.tsx
+++ b/src/features/community/components/AuthorSummary/AuthorSummary.tsx
@@ -99,7 +99,7 @@ export function AuthorSummary({
           {summary.topTechniques.map((technique) => (
             <span
               key={technique}
-              className="rounded bg-surface px-1.5 py-0.5 text-[11px] uppercase tracking-wide text-content-tertiary"
+              className="rounded bg-surface px-1.5 py-0.5 text-label uppercase tracking-wide text-content-tertiary"
             >
               {t(TECHNIQUE_CONFIG[technique].labelKey)}
             </span>
@@ -108,7 +108,7 @@ export function AuthorSummary({
       )}
 
       {indexCapped && (
-        <p className="mt-1 text-[11px] text-content-tertiary" data-testid="author-summary-partial">
+        <p className="mt-1 text-label text-content-tertiary" data-testid="author-summary-partial">
           {t('community.author.partial')}
         </p>
       )}

--- a/src/features/community/components/CommunityDetail/DesignMediaPanel.tsx
+++ b/src/features/community/components/CommunityDetail/DesignMediaPanel.tsx
@@ -155,7 +155,7 @@ export function DesignMediaPanel({
             data-testid="design-media-tile-model"
           >
             {poster !== '' && <img src={poster} alt="" className="h-full w-full object-cover" />}
-            <span className="absolute inset-x-0 bottom-0 bg-overlay-dark py-0.5 text-[10px] font-medium uppercase tracking-wide text-white">
+            <span className="absolute inset-x-0 bottom-0 bg-overlay-dark py-0.5 text-micro font-medium uppercase tracking-wide text-white">
               {t('community.media.modelBadge')}
             </span>
           </Button>

--- a/src/features/community/components/CommunityDetail/SimilarRail.tsx
+++ b/src/features/community/components/CommunityDetail/SimilarRail.tsx
@@ -46,7 +46,7 @@ export function CommunityDesignTile({
       <span className="line-clamp-1 text-xs text-content" title={card.name}>
         {card.name}
       </span>
-      <span className="line-clamp-1 text-[11px] text-content-tertiary">
+      <span className="line-clamp-1 text-label text-content-tertiary">
         {t('community.card.byAuthor', { author: card.authorName })}
       </span>
     </Button>

--- a/src/features/community/components/PrintsSection/PrintCard.tsx
+++ b/src/features/community/components/PrintsSection/PrintCard.tsx
@@ -259,14 +259,14 @@ export function PrintCard({
                 {onPromoteCover !== undefined &&
                   !deadPhotos.has(photo) &&
                   (photo === coverPhotoUrl ? (
-                    <p className="mt-1 text-center text-[11px] text-accent">
+                    <p className="mt-1 text-center text-label text-accent">
                       {t('community.prints.coverCurrent')}
                     </p>
                   ) : (
                     <Button
                       variant="ghost"
                       onClick={() => onPromoteCover(photo)}
-                      className="mt-1 h-auto w-full justify-center p-0 text-[11px] font-normal text-content-tertiary underline-offset-2 hover:underline"
+                      className="mt-1 h-auto w-full justify-center p-0 text-label font-normal text-content-tertiary underline-offset-2 hover:underline"
                       data-testid={`print-promote-${index}`}
                     >
                       {t('community.prints.useAsCover')}

--- a/src/features/design-linking/components/Dialogs/BlockedResizeDialog/BlockedResizeDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/BlockedResizeDialog/BlockedResizeDialog.tsx
@@ -43,7 +43,7 @@ export function BlockedResizeDialog() {
   return (
     <Dialog.Root open={pendingBlockedResize !== null} onClose={handleDismiss} size="sm">
       <Dialog.Header title={t('designLinking.blockedResize.title')} showCloseButton={false}>
-        <AlertTriangleIcon size="sm" className="text-status-warning" />
+        <AlertTriangleIcon size="sm" className="text-warning" />
       </Dialog.Header>
       <Dialog.Body>
         <p className="mb-3 text-sm text-content-secondary">
@@ -56,7 +56,7 @@ export function BlockedResizeDialog() {
         <div className="p-2.5 bg-surface rounded-lg border border-stroke-subtle space-y-1">
           {pendingBlockedResize?.reasons.map((reason) => (
             <div key={reason} className="flex items-center gap-2 text-sm text-content-secondary">
-              <span className="w-1.5 h-1.5 rounded-full bg-status-warning flex-shrink-0" />
+              <span className="w-1.5 h-1.5 rounded-full bg-warning flex-shrink-0" />
               {t(REASON_KEYS[reason])}
             </div>
           ))}

--- a/src/features/design-linking/components/Dialogs/DeleteDesignWarningDialog/DeleteDesignWarningDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/DeleteDesignWarningDialog/DeleteDesignWarningDialog.tsx
@@ -84,9 +84,9 @@ export function DeleteDesignWarningDialog() {
       >
         {/* Warning icon */}
         <div className="flex items-center gap-3 mb-3">
-          <div className="w-9 h-9 rounded-full bg-status-warning/10 flex items-center justify-center flex-shrink-0">
+          <div className="w-9 h-9 rounded-full bg-warning/10 flex items-center justify-center flex-shrink-0">
             <svg
-              className="w-5 h-5 text-status-warning"
+              className="w-5 h-5 text-warning"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"

--- a/src/features/design-linking/components/Dialogs/DesignerUpdatedDialog/DesignerUpdatedDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/DesignerUpdatedDialog/DesignerUpdatedDialog.tsx
@@ -35,7 +35,7 @@ export function DesignerUpdatedDialog() {
       size="sm"
     >
       <Dialog.Header title={t('designLinking.designerUpdated.title')} showCloseButton={false}>
-        <InfoIcon size="sm" className="text-status-info" />
+        <InfoIcon size="sm" className="text-info" />
       </Dialog.Header>
       <Dialog.Body>
         <p className="text-sm text-content-secondary">

--- a/src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/LinkDesignDialog/LinkDesignDialog.tsx
@@ -346,12 +346,12 @@ export function LinkDesignDialog() {
                         <div className="flex items-center gap-1.5">
                           <p className="truncate text-sm font-medium text-content">{design.name}</p>
                           {kindBadge !== null && (
-                            <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded bg-surface-elevated text-content-secondary">
+                            <span className="flex-shrink-0 px-1.5 py-0.5 text-micro font-medium rounded bg-surface-elevated text-content-secondary">
                               {kindBadge}
                             </span>
                           )}
                           {heightMismatch && (
-                            <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded bg-status-warning/10 text-status-warning">
+                            <span className="flex-shrink-0 px-1.5 py-0.5 text-micro font-medium rounded bg-warning/10 text-warning">
                               {t('designLinking.linkDialog.heightMismatch')}
                             </span>
                           )}

--- a/src/features/design-linking/components/Dialogs/MakeBentoDialog/MakeBentoDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/MakeBentoDialog/MakeBentoDialog.tsx
@@ -100,7 +100,7 @@ export function MakeBentoDialog({ open, onClose }: MakeBentoDialogProps) {
     return (
       <Dialog.Root open={open} onClose={onClose} size="sm">
         <Dialog.Header title={t('designLinking.bento.title')} showCloseButton={false}>
-          <AlertTriangleIcon size="sm" className="text-status-warning" />
+          <AlertTriangleIcon size="sm" className="text-warning" />
         </Dialog.Header>
         <Dialog.Body>
           <p className="text-sm text-content-secondary">{blockedMessage(result.error, t)}</p>
@@ -234,9 +234,9 @@ export function MakeBentoDialog({ open, onClose }: MakeBentoDialogProps) {
         </div>
 
         {trapped.length > 0 && (
-          <div className="mb-3 rounded-lg border border-status-warning/40 bg-status-warning/5 p-2.5">
+          <div className="mb-3 rounded-lg border border-warning/40 bg-warning/5 p-2.5">
             <div className="flex items-start gap-2">
-              <AlertTriangleIcon size="sm" className="mt-0.5 shrink-0 text-status-warning" />
+              <AlertTriangleIcon size="sm" className="mt-0.5 shrink-0 text-warning" />
               <div className="flex-1 space-y-2">
                 <p className="text-sm text-content">
                   {t('designLinking.bento.trapped', { count: trapped.length })}
@@ -258,7 +258,7 @@ export function MakeBentoDialog({ open, onClose }: MakeBentoDialogProps) {
           <div className="space-y-1 rounded-lg border border-stroke-subtle bg-surface p-2.5">
             {warnings.map((warning) => (
               <div key={warning} className="flex items-center gap-2 text-sm text-content-secondary">
-                <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-status-warning" />
+                <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-warning" />
                 {warning}
               </div>
             ))}

--- a/src/features/design-linking/components/Dialogs/SyncDimensionsDialog/SyncDimensionsDialog.tsx
+++ b/src/features/design-linking/components/Dialogs/SyncDimensionsDialog/SyncDimensionsDialog.tsx
@@ -112,7 +112,7 @@ export function SyncDimensionsDialog() {
             </span>
           </div>
           {binsHaveVaryingDimensions && (
-            <div className="text-xs text-status-warning mt-0.5">
+            <div className="text-xs text-warning mt-0.5">
               {t('designLinking.syncDialog.binsVary')}
             </div>
           )}
@@ -121,7 +121,7 @@ export function SyncDimensionsDialog() {
         {/* Sync results preview */}
         <div className="mb-4 space-y-1.5">
           {canSyncCount > 0 && (
-            <div className="flex items-center gap-2 text-sm text-status-success">
+            <div className="flex items-center gap-2 text-sm text-success">
               <svg
                 className="w-4 h-4 flex-shrink-0"
                 fill="none"
@@ -139,7 +139,7 @@ export function SyncDimensionsDialog() {
             </div>
           )}
           {willUnlinkCount > 0 && (
-            <div className="flex items-center gap-2 text-sm text-status-warning">
+            <div className="flex items-center gap-2 text-sm text-warning">
               <svg
                 className="w-4 h-4 flex-shrink-0"
                 fill="none"

--- a/src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.tsx
+++ b/src/features/design-linking/components/LinkedDesignSection/LinkedDesignSection.tsx
@@ -189,10 +189,10 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
         <label className={`${textSize} text-content-tertiary`}>
           {t('designLinking.inspector.linkedDesign')}
         </label>
-        <div className="p-3 rounded-lg bg-status-warning/10 border border-status-warning/30">
+        <div className="p-3 rounded-lg bg-warning/10 border border-warning/30">
           <div className="flex items-center gap-2 mb-2">
             <svg
-              className="w-4 h-4 text-status-warning flex-shrink-0"
+              className="w-4 h-4 text-warning flex-shrink-0"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -204,7 +204,7 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
                 d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
               />
             </svg>
-            <span className="text-sm text-status-warning font-medium">
+            <span className="text-sm text-warning font-medium">
               {t('designLinking.inspector.designDeleted')}
             </span>
           </div>
@@ -290,14 +290,14 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
 
       {/* Drawer edge-orientation mismatch warning */}
       {edgeMismatch && (
-        <div className="p-3 rounded-lg bg-status-warning/10 border border-status-warning/30 space-y-2">
+        <div className="p-3 rounded-lg bg-warning/10 border border-warning/30 space-y-2">
           <div className="flex items-start gap-2">
             <AlertTriangleIcon
               size="sm"
-              className="text-status-warning flex-shrink-0 mt-0.5"
+              className="text-warning flex-shrink-0 mt-0.5"
               aria-hidden="true"
             />
-            <span className="text-xs text-status-warning">
+            <span className="text-xs text-warning">
               {t('designLinking.inspector.edgeMismatch')}
             </span>
           </div>
@@ -418,7 +418,7 @@ export function LinkedDesignSection({ bin, variant }: LinkedDesignSectionProps) 
               <Button
                 variant="ghost"
                 onClick={handleDelete}
-                className="w-full justify-start rounded-none px-3 py-2 text-left text-sm font-normal text-status-error hover:bg-surface-hover"
+                className="w-full justify-start rounded-none px-3 py-2 text-left text-sm font-normal text-error hover:bg-surface-hover"
                 role="menuitem"
               >
                 <svg

--- a/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.tsx
+++ b/src/features/drawer-shape/components/CornerCutsDialog/CornerCutsDialog.tsx
@@ -172,7 +172,7 @@ export function CornerCutsDialog({ open, onClose }: CornerCutsDialogProps) {
             const cut = active[key];
             return (
               <div key={key} className="space-y-2 rounded border border-stroke-subtle p-2">
-                <div className="text-[11px] font-medium uppercase tracking-wide text-content-tertiary">
+                <div className="text-label font-medium uppercase tracking-wide text-content-tertiary">
                   {t(labelKey)}
                 </div>
                 <Select

--- a/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
+++ b/src/features/drawer-shape/components/ShapeEditorDialog/ShapeEditorDialog.tsx
@@ -183,7 +183,7 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
         <div className="space-y-3">
           <p className="text-xs text-content-secondary">{t('drawerShape.editor.hint')}</p>
           {replacesDrawnShape && (
-            <p className="text-xs text-status-warning" role="alert">
+            <p className="text-xs text-warning" role="alert">
               {t('drawerShape.editor.replacesDrawnShape')}
             </p>
           )}
@@ -226,7 +226,7 @@ export function ShapeEditorDialog({ open, onClose }: ShapeEditorDialogProps) {
               })
             )}
           </div>
-          {errorKey !== null && <p className="text-xs text-status-error">{t(errorKey)}</p>}
+          {errorKey !== null && <p className="text-xs text-error">{t(errorKey)}</p>}
         </div>
       </Dialog.Body>
       <Dialog.Footer>

--- a/src/features/grid-editor/components/Grid/SelectionToolbar/SelectionToolbar.tsx
+++ b/src/features/grid-editor/components/Grid/SelectionToolbar/SelectionToolbar.tsx
@@ -184,7 +184,7 @@ export function SelectionToolbar({
         {otherLayers.length > 0 && (
           <Select
             size="sm"
-            className="h-6 text-[11px] text-content-secondary"
+            className="h-6 text-label text-content-secondary"
             value=""
             placeholder={t('selectionToolbar.moveToLayer')}
             options={otherLayers.map((layer) => ({ id: layer.id, name: layer.name }))}

--- a/src/features/inspiration-gallery/components/LayoutPreviewOverlay/LayoutPreviewOverlay.tsx
+++ b/src/features/inspiration-gallery/components/LayoutPreviewOverlay/LayoutPreviewOverlay.tsx
@@ -210,7 +210,7 @@ export function LayoutPreviewOverlay({
                       >
                         {related.name}
                       </div>
-                      <div className="text-[10px] text-content-tertiary">
+                      <div className="text-micro text-content-tertiary">
                         {related.metrics.binCount}
                         {t('gallery.bins')}
                       </div>
@@ -248,7 +248,7 @@ function MetricCard({ label, value, subtext }: { label: string; value: string; s
     <div className="bg-surface rounded-lg p-3">
       <div className="text-lg font-semibold text-content">{value}</div>
       <div className="text-xs text-content-tertiary">{label}</div>
-      {subtext && <div className="text-[10px] text-content-disabled mt-0.5">{subtext}</div>}
+      {subtext && <div className="text-micro text-content-disabled mt-0.5">{subtext}</div>}
     </div>
   );
 }

--- a/src/features/labs/components/EngineSelector/EngineSelector.tsx
+++ b/src/features/labs/components/EngineSelector/EngineSelector.tsx
@@ -61,13 +61,11 @@ export function EngineSelector() {
   return (
     <article className="rounded-lg border border-stroke-subtle bg-surface p-4">
       <div className="flex items-start justify-between gap-3 mb-3">
-        <h3 className="text-[15px] font-semibold text-content leading-tight">
-          {t('labs.engine.title')}
-        </h3>
+        <h3 className="text-title text-content leading-tight">{t('labs.engine.title')}</h3>
         {selectedFeature ? (
           <FeatureStatusBadge status={selectedFeature.status} />
         ) : (
-          <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide rounded bg-success-muted text-success">
+          <span className="inline-flex items-center px-2 py-0.5 text-micro font-semibold uppercase tracking-wide rounded bg-success-muted text-success">
             {t('labs.engine.statusStable')}
           </span>
         )}
@@ -80,7 +78,7 @@ export function EngineSelector() {
         aria-label={t('labs.engine.ariaLabel')}
       />
 
-      <p className="mt-3 text-[13px] text-content-secondary leading-relaxed">
+      <p className="mt-3 text-body text-content-secondary leading-relaxed">
         {selectedFeature ? selectedFeature.description : t('labs.engine.descriptionDefault')}
       </p>
 

--- a/src/features/labs/components/FeatureCard/FeatureCard.tsx
+++ b/src/features/labs/components/FeatureCard/FeatureCard.tsx
@@ -18,13 +18,11 @@ export function FeatureCard({ feature, isEnabled, onToggle }: FeatureCardProps) 
   return (
     <article className="rounded-lg border border-stroke-subtle bg-surface p-4">
       <div className="flex items-start justify-between gap-3 mb-2">
-        <h3 className="text-[15px] font-semibold text-content leading-tight">{feature.name}</h3>
+        <h3 className="text-title text-content leading-tight">{feature.name}</h3>
         <FeatureStatusBadge status={feature.status} />
       </div>
 
-      <p className="text-[13px] text-content-secondary leading-relaxed mb-3">
-        {feature.description}
-      </p>
+      <p className="text-body text-content-secondary leading-relaxed mb-3">{feature.description}</p>
 
       {feature.warning && (feature.risk === 'medium' || feature.risk === 'high') && (
         <div

--- a/src/features/labs/components/FeatureStatusBadge/FeatureStatusBadge.tsx
+++ b/src/features/labs/components/FeatureStatusBadge/FeatureStatusBadge.tsx
@@ -24,7 +24,7 @@ export function FeatureStatusBadge({ status }: FeatureStatusBadgeProps) {
 
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide rounded ${config.className}`}
+      className={`inline-flex items-center px-2 py-0.5 text-micro font-semibold uppercase tracking-wide rounded ${config.className}`}
       aria-label={`Status: ${config.label}`}
     >
       {config.label}

--- a/src/features/labs/components/LabsButton/LabsButton.tsx
+++ b/src/features/labs/components/LabsButton/LabsButton.tsx
@@ -29,10 +29,10 @@ export function LabsButton() {
       <SparklesIcon className="w-[18px] h-[18px] flex-shrink-0" />
       <div className="flex-1 text-left">
         <div className="text-sm font-medium">{t('labs.labs')}</div>
-        <div className="text-[11px] text-content-tertiary">{t('labs.tryExperimentalFeatures')}</div>
+        <div className="text-label text-content-tertiary">{t('labs.tryExperimentalFeatures')}</div>
       </div>
       {enabledCount > 0 && (
-        <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 text-[11px] font-semibold text-on-dark bg-accent rounded-full">
+        <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 text-label font-semibold text-on-dark bg-accent rounded-full">
           {enabledCount > 9 ? t('common.overflowCount') : enabledCount}
         </span>
       )}

--- a/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/ActiveLayerPanel.tsx
@@ -123,7 +123,7 @@ export function ActiveLayerPanel() {
         {paintSize && (
           <div
             role="status"
-            className="flex items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-2 py-1 text-[11px] leading-tight text-accent"
+            className="flex items-center gap-1.5 rounded-md border border-accent/30 bg-accent/10 px-2 py-1 text-label leading-tight text-accent"
           >
             <svg
               className="w-3 h-3 shrink-0"

--- a/src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
+++ b/src/features/layers/components/ActiveLayerPanel/SizeSelectorPopover.tsx
@@ -54,7 +54,7 @@ function SizeButton({
         }}
       />
       <span
-        className={`text-[9px] leading-none ${isActive ? 'text-accent font-medium' : 'text-content-tertiary'}`}
+        className={`text-micro leading-none ${isActive ? 'text-accent font-medium' : 'text-content-tertiary'}`}
       >
         {w}×{d}
       </span>
@@ -90,7 +90,7 @@ export function SizeSelectorPopover({
   return (
     <Popover anchorRef={anchorRef} isOpen={isOpen} onClose={onClose} className="w-[264px]">
       {/* Header reinforces the brush identity */}
-      <div className="flex items-center gap-1.5 px-3 pt-3 pb-0.5 text-[11px] font-semibold uppercase tracking-wider text-content-secondary">
+      <div className="flex items-center gap-1.5 px-3 pt-3 pb-0.5 text-label font-semibold uppercase tracking-wider text-content-secondary">
         <svg
           className="w-3.5 h-3.5 text-accent"
           fill="none"
@@ -107,7 +107,7 @@ export function SizeSelectorPopover({
 
       {/* Squares section */}
       <div className="px-3 pt-1">
-        <div className="text-[11px] font-medium text-content-secondary uppercase tracking-wider mb-1.5">
+        <div className="text-label font-medium text-content-secondary uppercase tracking-wider mb-1.5">
           {t('layers.squares')}
         </div>
         <div className="grid grid-cols-6 gap-1">
@@ -126,7 +126,7 @@ export function SizeSelectorPopover({
       {/* Rectangles section */}
       <div className="px-3 pb-3">
         <div className="flex items-center justify-between mt-3 mb-1.5">
-          <span className="text-[11px] font-medium text-content-secondary uppercase tracking-wider">
+          <span className="text-label font-medium text-content-secondary uppercase tracking-wider">
             {t('layers.rectangles')}
           </span>
           <Button
@@ -134,7 +134,7 @@ export function SizeSelectorPopover({
             size="sm"
             touchTarget={false}
             onClick={() => setRotated(!rotated)}
-            className="text-[11px] text-content-tertiary hover:text-content flex items-center gap-1 transition-colors rounded px-1.5 py-0.5 hover:bg-surface-hover"
+            className="text-label text-content-tertiary hover:text-content flex items-center gap-1 transition-colors rounded px-1.5 py-0.5 hover:bg-surface-hover"
             title={rotated ? t('layers.showingTall') : t('layers.showingWide')}
             aria-label={rotated ? t('layers.switchToWide') : t('layers.switchToTall')}
           >
@@ -167,7 +167,7 @@ export function SizeSelectorPopover({
 
       {/* Help text footer */}
       <div className="px-3 py-2 border-t border-stroke-subtle bg-surface/50 rounded-b-xl">
-        <p className="text-[10px] text-content-tertiary leading-relaxed">
+        <p className="text-micro text-content-tertiary leading-relaxed">
           {t('layers.binPaletteInstruction')}{' '}
           <span className="text-content-disabled">{t('layers.binPaletteHint')}</span>
         </p>

--- a/src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
+++ b/src/features/layers/components/LayerPanel/HeightCrossSectionDiagram.tsx
@@ -241,7 +241,7 @@ export function HeightCrossSectionDiagram({
               }}
             />
             {unusedPx >= 18 && (
-              <span className="relative text-[11px]" style={{ color: 'var(--text-disabled)' }}>
+              <span className="relative text-label" style={{ color: 'var(--text-disabled)' }}>
                 {t('layers.unusedSpace', { height: unusedHeight })}
               </span>
             )}
@@ -395,7 +395,7 @@ export function HeightCrossSectionDiagram({
                           </svg>
                         </IconButton>
                         <span
-                          className="text-[10px] tabular-nums min-w-[20px] text-center"
+                          className="text-micro tabular-nums min-w-[20px] text-center"
                           style={{
                             fontFamily: 'ui-monospace, monospace',
                             color: 'var(--text-tertiary)',
@@ -472,7 +472,7 @@ export function HeightCrossSectionDiagram({
                       </span>
                       <div className="flex items-center gap-1">
                         <span
-                          className="text-[11px]"
+                          className="text-label"
                           style={{
                             fontFamily: 'ui-monospace, monospace',
                             color: 'var(--text-disabled)',

--- a/src/features/layers/components/LayerPanel/LayerPanel.tsx
+++ b/src/features/layers/components/LayerPanel/LayerPanel.tsx
@@ -117,7 +117,7 @@ export function LayerPanel() {
         </div>
 
         {ceiling !== null && !ceiling.fits && (
-          <p className="mb-1.5 text-xxs text-status-warning tabular-nums">
+          <p className="mb-1.5 text-micro text-warning tabular-nums">
             {t('drawerCeiling.layerOverflow', {
               over: String(Math.round(-ceiling.slackMm * 10) / 10),
             })}
@@ -134,7 +134,7 @@ export function LayerPanel() {
             }}
           />
         </div>
-        <div className="flex items-center gap-1 text-[10px] text-content-disabled tabular-nums">
+        <div className="flex items-center gap-1 text-micro text-content-disabled tabular-nums">
           <span>
             {hasMultipleLayers
               ? t('layers.statsTotal', { coverage: totalCoverage, count: totalBinCount })

--- a/src/features/layout-library/components/LayoutManagerModal/LayoutGridItem/LayoutGridItem.tsx
+++ b/src/features/layout-library/components/LayoutManagerModal/LayoutGridItem/LayoutGridItem.tsx
@@ -88,7 +88,7 @@ export function LayoutGridItem({
         />
         {isActive && (
           <span
-            className="absolute top-1.5 right-1.5 rounded bg-accent px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-on-dark"
+            className="absolute top-1.5 right-1.5 rounded bg-accent px-1.5 py-0.5 text-micro font-semibold uppercase tracking-wide text-on-dark"
             aria-label={t('layouts.currentlyActiveLayout')}
           >
             {t('layouts.active')}
@@ -127,7 +127,7 @@ export function LayoutGridItem({
         </p>
 
         <div className="flex items-center justify-between mt-1">
-          <span className="text-[10px] text-content-tertiary">
+          <span className="text-micro text-content-tertiary">
             {formatRelativeDate(entry.modifiedAt, false)}
           </span>
 
@@ -143,7 +143,7 @@ export function LayoutGridItem({
         </div>
 
         {entry.forkedFrom && (
-          <div className="text-[10px] text-content-tertiary truncate mt-0.5">
+          <div className="text-micro text-content-tertiary truncate mt-0.5">
             {t('layouts.forkedFromName', { name: entry.forkedFrom.name })}
           </div>
         )}

--- a/src/features/scan-capture/components/ScanPage/ScanPage.tsx
+++ b/src/features/scan-capture/components/ScanPage/ScanPage.tsx
@@ -534,7 +534,7 @@ function ProgressSteps({
         return (
           <li key={s} className="flex items-center gap-2">
             <span
-              className={`flex h-6 w-6 items-center justify-center rounded-full text-[11px] font-semibold ${
+              className={`flex h-6 w-6 items-center justify-center rounded-full text-label font-semibold ${
                 active
                   ? 'bg-accent text-on-accent'
                   : done
@@ -774,7 +774,7 @@ function OverlayChip({
 }) {
   return (
     <span
-      className="absolute flex -translate-x-1/2 items-center gap-1.5 whitespace-nowrap rounded-full bg-surface/95 px-2.5 py-1 text-[11px] font-medium text-content-primary shadow-md ring-1 ring-black/[0.06] backdrop-blur-sm"
+      className="absolute flex -translate-x-1/2 items-center gap-1.5 whitespace-nowrap rounded-full bg-surface/95 px-2.5 py-1 text-label font-medium text-content-primary shadow-md ring-1 ring-black/[0.06] backdrop-blur-sm"
       style={{ left: `${leftPct}%`, top: `${topPct}%` }}
     >
       {tone === 'neutral' ? (
@@ -789,7 +789,7 @@ function OverlayChip({
 
 function PrivacyNote({ text }: { readonly text: string }) {
   return (
-    <p className="flex items-center gap-1.5 text-center text-[11px] text-content-tertiary">
+    <p className="flex items-center gap-1.5 text-center text-label text-content-tertiary">
       <svg
         width="12"
         height="12"

--- a/src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
+++ b/src/features/snapshots/components/SnapshotEntry/SnapshotEntry.tsx
@@ -49,7 +49,7 @@ export function SnapshotEntry({
           inputClassName="w-full text-xs font-medium"
         />
 
-        <div className="text-[11px] text-content-tertiary mt-0.5">
+        <div className="text-label text-content-tertiary mt-0.5">
           <span>{relativeTime}</span>
           <span className="mx-1">&middot;</span>
           <span>{t('snapshots.bins', { count: snapshot.preview.binCount })}</span>

--- a/src/features/supporters/components/SupportersPage/SupportersPage.tsx
+++ b/src/features/supporters/components/SupportersPage/SupportersPage.tsx
@@ -487,7 +487,7 @@ export function SupportersPage() {
           aria-label={t('supporters.sparklineLabel', { count: SPARKLINE_MONTHS })}
         >
           <Sparkline buckets={history} color={palette.accent} />
-          <figcaption className="text-[10px] font-medium uppercase tracking-[0.16em] opacity-55">
+          <figcaption className="text-micro font-medium uppercase tracking-[0.16em] opacity-55">
             {t('supporters.sparklineCaption')}
           </figcaption>
         </figure>
@@ -508,7 +508,7 @@ export function SupportersPage() {
           >
             {focused.isNewest && (
               <span
-                className="mr-2 rounded-sm px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+                className="mr-2 rounded-sm px-1.5 py-0.5 text-micro font-bold uppercase tracking-wider"
                 style={{ background: palette.accent, color: '#fff' }}
               >
                 {t('supporters.justJoined')}

--- a/src/index.css
+++ b/src/index.css
@@ -60,11 +60,6 @@
   --text-page--letter-spacing: -0.015em;
   --text-page--font-weight: 600;
 
-  /* TODO: remove when the text-xxs call sites migrate to text-micro in the
-     ramp-adoption PR. Until then this makes the previously dead class real. */
-  --text-xxs: 0.625rem;
-  --text-xxs--line-height: 0.875rem;
-
   /* Surface colors (backgrounds) - use as bg-surface, bg-surface-secondary, etc. */
   --color-surface: var(--bg-primary);
   --color-surface-secondary: var(--bg-secondary);

--- a/src/shared/components/AppVersionButton/AppVersionButton.tsx
+++ b/src/shared/components/AppVersionButton/AppVersionButton.tsx
@@ -54,7 +54,7 @@ export function AppVersionButton({ align = 'start', onBeforeAction }: AppVersion
         onClick={handleClick}
         aria-label={state === 'update' ? t('pwaUpdate.reloadAria') : t('whatsNew.open')}
         className={cn(
-          'h-auto gap-1.5 px-0 text-[10px] font-normal text-content-disabled',
+          'h-auto gap-1.5 px-0 text-micro font-normal text-content-disabled',
           'hover:bg-transparent hover:text-content-tertiary',
           align === 'center' && 'justify-center'
         )}
@@ -65,7 +65,7 @@ export function AppVersionButton({ align = 'start', onBeforeAction }: AppVersion
         {state !== 'idle' && (
           <span
             className={cn(
-              'rounded-full border px-1.5 text-[9px] font-semibold uppercase tracking-wide',
+              'rounded-full border px-1.5 text-micro font-semibold uppercase tracking-wide',
               'border-accent/40 bg-accent/10 text-accent'
             )}
           >

--- a/src/shared/components/AttributionFooter/AttributionFooter.tsx
+++ b/src/shared/components/AttributionFooter/AttributionFooter.tsx
@@ -8,8 +8,8 @@ export function AttributionFooter() {
   const t = useTranslation();
   const { navigateToSupporters } = useSupportersRouting();
   return (
-    <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-[10px] leading-relaxed">
-      <div className="text-content-secondary text-[11px] font-semibold mb-1 flex items-baseline gap-1.5">
+    <div className="px-4 py-4 border-t border-stroke-subtle text-content-disabled text-micro leading-relaxed">
+      <div className="text-content-secondary text-label font-semibold mb-1 flex items-baseline gap-1.5">
         {t('sidebar.appName')}
         <AppVersionButton />
       </div>

--- a/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
+++ b/src/shared/components/CompactNumberInput/CompactNumberInput.tsx
@@ -314,7 +314,7 @@ export function CompactNumberInput({
           {indeterminate ? MIXED_GLYPH : formatValue(value)}
         </Button>
       )}
-      {unit && <span className="select-none pr-1.5 text-[10px] text-content-disabled">{unit}</span>}
+      {unit && <span className="select-none pr-1.5 text-micro text-content-disabled">{unit}</span>}
     </div>
   );
 }

--- a/src/shared/components/DrawerDimensionsSummary/DrawerDimensionsSummary.tsx
+++ b/src/shared/components/DrawerDimensionsSummary/DrawerDimensionsSummary.tsx
@@ -128,14 +128,14 @@ export function DrawerDimensionsSummary({
 
       {hasMeasurement &&
         (hasOverflow ? (
-          <p className="text-center text-xxs text-status-warning">
+          <p className="text-center text-micro text-warning">
             {t('drawerDims.overflow', {
               width: fmt(Math.max(0, overflowWidth)),
               depth: fmt(Math.max(0, overflowDepth)),
             })}
           </p>
         ) : (
-          <p className="text-center text-xxs text-content-tertiary tabular-nums">
+          <p className="text-center text-micro text-content-tertiary tabular-nums">
             {t('drawerDims.fit', {
               width: fmt(gridWidthMm),
               depth: fmt(gridDepthMm),
@@ -146,16 +146,16 @@ export function DrawerDimensionsSummary({
         ))}
 
       {ceiling === null ? (
-        <p className="text-center text-xxs text-content-tertiary">
+        <p className="text-center text-micro text-content-tertiary">
           {t('drawerCeiling.measurePrompt')}
         </p>
       ) : /* an empty layout has no stack to judge, so no fit claim */
       ceiling.tallestMm === 0 ? null : ceiling.fits ? (
-        <p className="text-center text-xxs text-content-tertiary tabular-nums">
+        <p className="text-center text-micro text-content-tertiary tabular-nums">
           {t('drawerCeiling.fits', { slack: fmt(ceiling.slackMm) })}
         </p>
       ) : (
-        <p className="text-center text-xxs text-status-warning tabular-nums">
+        <p className="text-center text-micro text-warning tabular-nums">
           {t('drawerCeiling.overflow', { over: fmt(-ceiling.slackMm) })}
         </p>
       )}
@@ -167,7 +167,7 @@ export function DrawerDimensionsSummary({
         >
           <div className="flex items-start gap-1.5">
             <SparklesIcon size="xs" className="mt-0.5 flex-shrink-0 text-accent" />
-            <div className="flex-1 text-xxs text-content-secondary">
+            <div className="flex-1 text-micro text-content-secondary">
               <div className="font-medium text-content">
                 {t('drawerDims.suggestionTitle', {
                   width: String(suggestion.width),

--- a/src/shared/components/ExportDialog/ExportDialog.tsx
+++ b/src/shared/components/ExportDialog/ExportDialog.tsx
@@ -363,7 +363,7 @@ export function ExportDialog({
                   ))}
                 </div>
                 {estimatesDisclaimer && (
-                  <p className="mt-2 text-[10px] text-content-disabled">{estimatesDisclaimer}</p>
+                  <p className="mt-2 text-micro text-content-disabled">{estimatesDisclaimer}</p>
                 )}
               </div>
             )}
@@ -407,9 +407,9 @@ export function ExportDialog({
                   {sourceDownload.label}
                 </Button>
                 {sourceDownload.hint && (
-                  <p className="mt-0.5 text-[10px] text-content-tertiary">{sourceDownload.hint}</p>
+                  <p className="mt-0.5 text-micro text-content-tertiary">{sourceDownload.hint}</p>
                 )}
-                <SchemaDocsLink className="mt-1 inline-block text-[10px]" />
+                <SchemaDocsLink className="mt-1 inline-block text-micro" />
               </div>
             )}
 

--- a/src/shared/components/FeatureToggle/FeatureToggle.tsx
+++ b/src/shared/components/FeatureToggle/FeatureToggle.tsx
@@ -61,7 +61,7 @@ export function FeatureToggle({
         <div className="flex items-center gap-2">
           <span className="text-xs text-content-secondary">{label}</span>
           {!disabledReason && comingSoon && (
-            <span className="rounded-full bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium text-content-tertiary">
+            <span className="rounded-full bg-surface-tertiary px-1.5 py-0.5 text-micro font-medium text-content-tertiary">
               {t('common.soon')}
             </span>
           )}
@@ -93,7 +93,7 @@ export function FeatureToggle({
 
       {/* Disabled reason text */}
       {disabledReason && (
-        <p className="mt-0.5 text-[11px] text-content-tertiary">{disabledReason}</p>
+        <p className="mt-0.5 text-label text-content-tertiary">{disabledReason}</p>
       )}
 
       {/* Primary controls (shown immediately when enabled, no Customize needed) */}
@@ -104,7 +104,7 @@ export function FeatureToggle({
         <div className="ml-1 mt-0.5">
           <div className="flex items-center gap-2">
             {valueSummary && !customizeOpen && (
-              <span className="text-[11px] text-content-tertiary">{valueSummary}</span>
+              <span className="text-label text-content-tertiary">{valueSummary}</span>
             )}
             <Button
               variant="ghost"

--- a/src/shared/components/FractionalEdgeToggle/FractionalEdgeToggle.tsx
+++ b/src/shared/components/FractionalEdgeToggle/FractionalEdgeToggle.tsx
@@ -31,7 +31,7 @@ export function FractionalEdgeToggle({
           type="button"
           onClick={() => onChange(axis, 'start')}
           aria-pressed={value === 'start'}
-          className={`rounded-none px-2.5 py-1 text-[10px] font-normal transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
+          className={`rounded-none px-2.5 py-1 text-micro font-normal transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
             value === 'start' ? activeClass : inactiveClass
           }`}
           title={startTitle}
@@ -43,7 +43,7 @@ export function FractionalEdgeToggle({
           type="button"
           onClick={() => onChange(axis, 'end')}
           aria-pressed={value === 'end'}
-          className={`rounded-none px-2.5 py-1 text-[10px] font-normal border-l border-stroke-subtle transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
+          className={`rounded-none px-2.5 py-1 text-micro font-normal border-l border-stroke-subtle transition-colors focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
             value === 'end' ? activeClass : inactiveClass
           }`}
           title={endTitle}

--- a/src/shared/components/LinkedDimensionInput/LinkedDimensionInput.tsx
+++ b/src/shared/components/LinkedDimensionInput/LinkedDimensionInput.tsx
@@ -142,7 +142,7 @@ export function LinkedDimensionInput({
         className={inputClass}
         aria-label={widthAriaLabel}
       />
-      <span className="text-[10px] text-content-tertiary">×</span>
+      <span className="text-micro text-content-tertiary">×</span>
       <DeferredNumberInput
         value={depth}
         onChange={handleDepthChange}

--- a/src/shared/components/SaveStatusIndicator/SaveStatusIndicator.tsx
+++ b/src/shared/components/SaveStatusIndicator/SaveStatusIndicator.tsx
@@ -31,7 +31,7 @@ export function SaveStatusIndicator({
 
   return (
     <div
-      className={`flex items-center gap-1.5 ${compact ? 'px-0.5 py-0.5' : 'px-2 py-1 mr-2'} text-[11px] ${SAVE_STATUS_CLASSES[status]}`}
+      className={`flex items-center gap-1.5 ${compact ? 'px-0.5 py-0.5' : 'px-2 py-1 mr-2'} text-label ${SAVE_STATUS_CLASSES[status]}`}
       aria-live="polite"
       role="status"
     >

--- a/src/shared/components/ShortcutBadge/ShortcutBadge.tsx
+++ b/src/shared/components/ShortcutBadge/ShortcutBadge.tsx
@@ -18,7 +18,7 @@ const modKey = isMac ? '⌘' : 'Ctrl';
 
 /** Keyboard key styling matching HelpModal */
 const keyClasses =
-  'inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 text-[11px] font-mono font-medium rounded border border-stroke bg-gradient-to-b from-surface-elevated to-surface text-content-secondary shadow-[0_1px_0_1px_rgba(0,0,0,0.15),inset_0_1px_0_rgba(255,255,255,0.1)]';
+  'inline-flex items-center justify-center min-w-[22px] h-[22px] px-1.5 text-label font-mono font-medium rounded border border-stroke bg-gradient-to-b from-surface-elevated to-surface text-content-secondary shadow-[0_1px_0_1px_rgba(0,0,0,0.15),inset_0_1px_0_rgba(255,255,255,0.1)]';
 
 export function ShortcutBadge({ keys, modifier, shift, className = '' }: ShortcutBadgeProps) {
   const keyArray = useMemo(() => {
@@ -31,18 +31,18 @@ export function ShortcutBadge({ keys, modifier, shift, className = '' }: Shortcu
       {modifier && (
         <>
           <kbd className={keyClasses}>{modKey}</kbd>
-          <span className="text-content-tertiary text-[10px]">+</span>
+          <span className="text-content-tertiary text-micro">+</span>
         </>
       )}
       {shift && (
         <>
           <kbd className={keyClasses}>Shift</kbd>
-          <span className="text-content-tertiary text-[10px]">+</span>
+          <span className="text-content-tertiary text-micro">+</span>
         </>
       )}
       {keyArray.map((key, index) => (
         <span key={`${key}-${index}`} className="flex items-center gap-1">
-          {index > 0 && <span className="text-content-tertiary text-[10px] mx-0.5">/</span>}
+          {index > 0 && <span className="text-content-tertiary text-micro mx-0.5">/</span>}
           <kbd className={keyClasses}>{key}</kbd>
         </span>
       ))}

--- a/src/shared/components/StickyGroupHeader/StickyGroupHeader.tsx
+++ b/src/shared/components/StickyGroupHeader/StickyGroupHeader.tsx
@@ -73,7 +73,7 @@ export function StickyGroupHeader({
           className={`transition-transform duration-200 text-content-tertiary ${expanded ? 'rotate-0' : '-rotate-90'}`}
           size="xs"
         />
-        <span className="text-[11px] font-bold text-content-tertiary uppercase tracking-widest">
+        <span className="text-label font-bold text-content-tertiary uppercase tracking-widest">
           {title}
         </span>
         {modifiedLabel && (
@@ -91,7 +91,7 @@ export function StickyGroupHeader({
           </>
         )}
         {badge && (
-          <span className="inline-flex items-center rounded bg-info-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-info">
+          <span className="inline-flex items-center rounded bg-info-muted px-1.5 py-0.5 text-micro font-semibold uppercase tracking-wide text-info">
             {badge}
           </span>
         )}

--- a/src/shared/components/ToggleRow/ToggleRow.tsx
+++ b/src/shared/components/ToggleRow/ToggleRow.tsx
@@ -78,7 +78,7 @@ export function ToggleRow({
           {label}
         </span>
         {shortcut && (
-          <kbd className="text-[9px] leading-none text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">
+          <kbd className="text-micro leading-none text-content-disabled bg-surface-elevated px-1 py-0.5 rounded border border-stroke-subtle">
             {shortcut}
           </kbd>
         )}

--- a/src/shared/components/segmentedControlClasses.test.ts
+++ b/src/shared/components/segmentedControlClasses.test.ts
@@ -25,7 +25,7 @@ describe('getSegmentClass', () => {
   });
 
   it('uses compact sizing for sm and default sizing for md', () => {
-    expect(getSegmentClass(false, { size: 'sm' })).toContain('text-[11px]');
+    expect(getSegmentClass(false, { size: 'sm' })).toContain('text-label');
     expect(getSegmentClass(false, { size: 'md' })).toContain('text-xs');
     expect(getSegmentClass(false)).toContain('text-xs');
   });

--- a/src/shared/components/segmentedControlClasses.ts
+++ b/src/shared/components/segmentedControlClasses.ts
@@ -55,8 +55,8 @@ export const SEGMENT_INACTIVE =
 export const SEGMENT_GROUP_CLASS = 'flex rounded-lg border border-stroke-subtle bg-surface p-0.5';
 
 const SIZE_CLASS: Record<SegmentSize, string> = {
-  icon: 'p-1 text-[11px]',
-  sm: 'px-1.5 py-1 text-[11px]',
+  icon: 'p-1 text-label',
+  sm: 'px-1.5 py-1 text-label',
   md: 'px-2 py-1 text-xs',
 };
 

--- a/src/shell/Collab/CollabCursor/CollabCursor.tsx
+++ b/src/shell/Collab/CollabCursor/CollabCursor.tsx
@@ -79,7 +79,7 @@ export function CollabCursor({ presence, position }: CollabCursorProps) {
 
       {/* Name label floating above the cursor */}
       <div
-        className="absolute left-3 -top-5 px-1.5 py-0.5 text-[10px] font-medium text-white rounded whitespace-nowrap max-w-[100px] truncate shadow-md"
+        className="absolute left-3 -top-5 px-1.5 py-0.5 text-micro font-medium text-white rounded whitespace-nowrap max-w-[100px] truncate shadow-md"
         style={{ backgroundColor: color }}
       >
         {name}
@@ -88,7 +88,7 @@ export function CollabCursor({ presence, position }: CollabCursorProps) {
       {/* Activity label below the name (only shown when not idle) */}
       {activityText && (
         <div
-          className="absolute left-3 top-0 px-1.5 py-0.5 text-[9px] font-medium text-white rounded whitespace-nowrap shadow-sm animate-in fade-in duration-150"
+          className="absolute left-3 top-0 px-1.5 py-0.5 text-micro font-medium text-white rounded whitespace-nowrap shadow-sm animate-in fade-in duration-150"
           style={{ backgroundColor: color, opacity: 0.9 }}
         >
           {activityText}

--- a/src/shell/Header/Header.tsx
+++ b/src/shell/Header/Header.tsx
@@ -174,7 +174,7 @@ export function Header({ saveStatus }: HeaderProps) {
         {/* Save status indicator */}
         {saveStatus === 'saving' && (
           <div
-            className="flex items-center gap-1.5 px-2 py-1 text-xxs mr-2 text-content-tertiary"
+            className="flex items-center gap-1.5 px-2 py-1 text-micro mr-2 text-content-tertiary"
             aria-live="polite"
             role="status"
           >
@@ -203,7 +203,7 @@ export function Header({ saveStatus }: HeaderProps) {
         )}
         {saveStatus === 'saved' && (
           <div
-            className="flex items-center gap-1.5 px-2 py-1 text-xxs mr-2 text-content-secondary animate-fade-in"
+            className="flex items-center gap-1.5 px-2 py-1 text-micro mr-2 text-content-secondary animate-fade-in"
             aria-live="polite"
             role="status"
           >

--- a/src/shell/Mobile/MobileAboutStrip/MobileAboutStrip.tsx
+++ b/src/shell/Mobile/MobileAboutStrip/MobileAboutStrip.tsx
@@ -17,7 +17,7 @@ export function MobileAboutStrip() {
   if (binCount > 0) return null;
 
   return (
-    <aside className="flex-shrink-0 px-4 py-2 border-t border-stroke-subtle bg-surface text-[11px] leading-relaxed text-content-tertiary">
+    <aside className="flex-shrink-0 px-4 py-2 border-t border-stroke-subtle bg-surface text-label leading-relaxed text-content-tertiary">
       <p>
         {t('sidebar.about')}{' '}
         <a

--- a/src/shell/Mobile/MobilePrintList/MobilePrintList.tsx
+++ b/src/shell/Mobile/MobilePrintList/MobilePrintList.tsx
@@ -53,7 +53,7 @@ export function MobilePrintList() {
             {copyFeedback ? (
               <>
                 <svg
-                  className="w-4 h-4 text-[var(--color-success)]"
+                  className="w-4 h-4 text-success"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -141,7 +141,7 @@ export function MobilePrintList() {
                       <span className="font-semibold text-content">{row.size}</span>
                       <span className="text-sm text-content-tertiary">{row.height}u</span>
                       {row.needsSplit && (
-                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs bg-[var(--color-warning-muted)] text-[var(--color-warning)]">
+                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs bg-warning-muted text-warning">
                           {t('mobile.printList.split')}
                           <svg
                             className={`w-3 h-3 transition-transform ${isExpanded ? 'rotate-180' : ''}`}

--- a/src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
+++ b/src/shell/Modals/HelpModal/HelpSearchResultRow.tsx
@@ -72,7 +72,7 @@ function KindBadge({ kind }: { kind: HelpEntry['kind'] }) {
         ? t('help.kind.feature')
         : t('help.kind.tip');
   return (
-    <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-elevated text-content-tertiary">
+    <span className="text-micro uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-elevated text-content-tertiary">
       {label}
     </span>
   );

--- a/src/shell/Modals/SettingsModal/TabNavigation/TabNavigation.tsx
+++ b/src/shell/Modals/SettingsModal/TabNavigation/TabNavigation.tsx
@@ -103,7 +103,7 @@ export function TabNavigation({ activeTab, onTabChange }: TabNavigationProps) {
     >
       {TAB_GROUPS.map((group) => (
         <div key={group.labelKey} className="mb-2">
-          <p className="px-4 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-content-disabled">
+          <p className="px-4 pb-1 pt-2 text-micro font-semibold uppercase tracking-wide text-content-disabled">
             {t(group.labelKey)}
           </p>
           {group.tabs.map((tab) => renderTabButton(tab, 'desktop'))}

--- a/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/DefaultsTab/DefaultsTab.tsx
@@ -216,7 +216,7 @@ export function DefaultsTab() {
                 aria-label={t('settings.defaultGridUnit')}
               />
             </SettingsRow>
-            <p className="mt-0.5 text-[10px] text-content-tertiary">
+            <p className="mt-0.5 text-micro text-content-tertiary">
               {t('settings.gridfinityStandardMm', {
                 value: CONSTRAINTS.GRID_UNIT_MM_DEFAULT,
               })}

--- a/src/shell/Modals/WhatsNewModal/WhatsNewArchive.tsx
+++ b/src/shell/Modals/WhatsNewModal/WhatsNewArchive.tsx
@@ -62,7 +62,7 @@ export function ArchiveList({ filter, activate }: { filter: KindFilter; activate
     <div className="flex flex-col py-2">
       {groups.map((group) => (
         <section key={group.month} className="flex flex-col">
-          <h3 className="sticky top-0 z-10 -mx-1 bg-surface-secondary px-1 pb-1.5 pt-3 text-[11px] font-semibold uppercase tracking-wider text-content-tertiary">
+          <h3 className="sticky top-0 z-10 -mx-1 bg-surface-secondary px-1 pb-1.5 pt-3 text-label font-semibold uppercase tracking-wider text-content-tertiary">
             {formatMonth(group.month, locale)}
           </h3>
           <div className="flex flex-col divide-y divide-stroke-subtle">
@@ -101,7 +101,7 @@ function ArchiveRow({ entry, activate }: { entry: WhatsNewEntry; activate: Activ
         <LabsBadge entry={entry} />
         <time
           dateTime={entry.date}
-          className="flex-shrink-0 text-[11px] tabular-nums text-content-disabled"
+          className="flex-shrink-0 text-label tabular-nums text-content-disabled"
         >
           {formatDay(entry.date, locale)}
         </time>

--- a/src/shell/Modals/WhatsNewModal/WhatsNewDigest.tsx
+++ b/src/shell/Modals/WhatsNewModal/WhatsNewDigest.tsx
@@ -70,7 +70,7 @@ export function DigestList({ headline, rest, overflow, activate, onSeeAll }: Dig
         <section key={group.kind} className="flex flex-col gap-1.5">
           <h3
             className={cn(
-              'text-[11px] font-semibold uppercase tracking-wider',
+              'text-label font-semibold uppercase tracking-wider',
               KIND_COLOR[group.kind]
             )}
           >
@@ -147,7 +147,7 @@ function DigestRow({ entry, activate }: { entry: WhatsNewEntry; activate: Activa
           <LabsBadge entry={entry} />
         </div>
         {entry.body && (
-          <p className="mt-0.5 line-clamp-2 text-[13px] leading-normal text-content-secondary">
+          <p className="mt-0.5 line-clamp-2 text-body leading-normal text-content-secondary">
             {resolveText(entry.body, locale)}
           </p>
         )}

--- a/src/shell/RightPanel/RightPanel.test.tsx
+++ b/src/shell/RightPanel/RightPanel.test.tsx
@@ -563,7 +563,7 @@ describe('RightPanel', () => {
 
       fireEvent.click(screen.getByLabelText('Copy bin list as TSV'));
 
-      // The checkmark SVG has text-[var(--color-success)] class
+      // The checkmark SVG has text-success class
       const copyButton = screen.getByLabelText('Copy bin list as TSV');
       const svg = copyButton.querySelector('svg');
       expect(svg).toHaveClass('text-success');

--- a/src/shell/RightPanel/RightPanel.tsx
+++ b/src/shell/RightPanel/RightPanel.tsx
@@ -424,7 +424,7 @@ export function RightPanel() {
                                             );
                                           })}
                                           {row.categoryIds.length > 3 && (
-                                            <span className="text-xxs text-content-disabled">
+                                            <span className="text-micro text-content-disabled">
                                               {t('rightPanel.moreCategories', {
                                                 count: row.categoryIds.length - 3,
                                               })}
@@ -509,7 +509,7 @@ export function RightPanel() {
                                       )}
                                       {(row.labelPlateCount ?? 0) > 0 && (
                                         <span
-                                          className="inline-flex items-center gap-1 text-xxs text-content-disabled"
+                                          className="inline-flex items-center gap-1 text-micro text-content-disabled"
                                           title={t('print.row.labelPlates', {
                                             count: row.labelPlateCount ?? 0,
                                           })}
@@ -538,7 +538,7 @@ export function RightPanel() {
                                           on them — worth knowing before the
                                           spool goes in, not after. */}
                                       {row.labelTabsWithoutText === true && (
-                                        <span className="text-xxs text-warning">
+                                        <span className="text-micro text-warning">
                                           {t('print.row.blankLabelTabs')}
                                         </span>
                                       )}

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -423,7 +423,7 @@ export function Sidebar() {
                   {/* Fractional edge position toggles - only shown when dimensions are fractional */}
                   {(hasFractionalWidth || hasFractionalDepth) && (
                     <div className="pt-2 space-y-1.5">
-                      <div className="text-content-tertiary text-xxs mb-1">
+                      <div className="text-content-tertiary text-micro mb-1">
                         {t('sidebar.halfUnitEdgePosition')}
                       </div>
                       {hasFractionalWidth && (


### PR DESCRIPTION
Second PR of the typography overhaul (follows #3976): the ramp becomes the only way UI text is sized.

## What changed

- **Mechanical sweep**: `text-[10px]` → `text-micro` (163 sites), `text-[11px]` → `text-label` (245 sites), `text-xxs` → `text-micro` (13 sites, alias token deleted). The 8/9/13/15px stragglers normalize to their nearest role (`text-micro`, `text-body`, `text-title`; the command-palette input moves to `text-lg`). Zero arbitrary font sizes remain in `src/`.
- **tailwind-merge registration**: the ramp classes are registered as font sizes in `cn`'s config. Without this, tailwind-merge classifies unknown `text-*` classes as text colors, so merging `text-micro` with a real color class silently stripped one of them — caught by Badge unit tests during the sweep.
- **Dead status-color fix**: `text/bg/border-status-*` classes (38 sites) were never generated — no `--color-status-*` token exists — so warnings rendered with inherited text color and no background. They now use the real semantic utilities (`text-warning`, `bg-warning/10`, ...). This visibly changes those warnings from unstyled to styled, which is the intended design finally rendering. Same fix for four `text-[var(--color-*)]` arbitrary values. The `animate-status-error` keyframe class is unrelated and untouched.
- **Targeted DS role adoption** where a role clearly matches: Collapsible `sm` headers → `text-section`, Dialog titles → `text-title`/`text-page` (same sizes, adds tracking), SliderInput labels → `text-label`, slider value badges and tab badges → `text-value`. Components with size scales (Button, Input, Field, Stepper) keep the retuned legacy scale.

## Verification

- Full unit + dom projects: 22,632 tests pass. Visual snapshots regenerated (49 pass).
- `pnpm run typecheck`, lint clean, doc-drift within budget.

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

