### PR TITLE
feat(design-system): add the shortcut hint pattern and motion recipes

### DIFF
--- a/src/design-system/Kbd/formatShortcut.test.ts
+++ b/src/design-system/Kbd/formatShortcut.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { formatShortcut } from './formatShortcut';
+
+describe('formatShortcut', () => {
+  it('renders Mod as the command symbol on mac, joined without separators', () => {
+    expect(formatShortcut(['Mod', 'Z'], 'mac')).toBe('⌘Z');
+    expect(formatShortcut(['Mod', 'Shift', 'Z'], 'mac')).toBe('⌘⇧Z');
+    expect(formatShortcut(['Ctrl', 'K'], 'mac')).toBe('⌃K');
+    expect(formatShortcut(['Alt', 'A'], 'mac')).toBe('⌥A');
+  });
+
+  it('renders Mod as Ctrl elsewhere, joined with plus', () => {
+    expect(formatShortcut(['Mod', 'Z'], 'other')).toBe('Ctrl+Z');
+    expect(formatShortcut(['Mod', 'Shift', 'Z'], 'other')).toBe('Ctrl+Shift+Z');
+    expect(formatShortcut(['Alt', 'A'], 'other')).toBe('Alt+A');
+  });
+
+  it('passes named keys through untouched', () => {
+    expect(formatShortcut(['Escape'], 'other')).toBe('Escape');
+    expect(formatShortcut(['Shift', 'Enter'], 'other')).toBe('Shift+Enter');
+  });
+});

--- a/src/design-system/Kbd/formatShortcut.ts
+++ b/src/design-system/Kbd/formatShortcut.ts
@@ -1,0 +1,37 @@
+/**
+ * Formats a key sequence for visible shortcut hints, resolving the `Mod`
+ * placeholder per platform: `['Mod','Z']` → `⌘Z` on macOS, `Ctrl+Z` elsewhere.
+ * The app-wide convention for shortcut display — pair with a Kbd chip.
+ */
+
+const MAC_SYMBOLS: Record<string, string> = {
+  Mod: '⌘',
+  Cmd: '⌘',
+  Meta: '⌘',
+  Ctrl: '⌃',
+  Alt: '⌥',
+  Option: '⌥',
+  Shift: '⇧',
+};
+
+const OTHER_NAMES: Record<string, string> = {
+  Mod: 'Ctrl',
+  Cmd: 'Ctrl',
+  Meta: 'Ctrl',
+  Option: 'Alt',
+};
+
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
+}
+
+export function formatShortcut(
+  keys: readonly string[],
+  platform: 'mac' | 'other' = isMacPlatform() ? 'mac' : 'other'
+): string {
+  if (platform === 'mac') {
+    return keys.map((k) => MAC_SYMBOLS[k] ?? k).join('');
+  }
+  return keys.map((k) => OTHER_NAMES[k] ?? k).join('+');
+}

--- a/src/design-system/Kbd/index.ts
+++ b/src/design-system/Kbd/index.ts
@@ -1,2 +1,3 @@
 export { Kbd } from './Kbd';
 export type { KbdProps } from './Kbd';
+export { formatShortcut, isMacPlatform } from './formatShortcut';

--- a/src/design-system/SidePanel/SidePanel.tsx
+++ b/src/design-system/SidePanel/SidePanel.tsx
@@ -19,6 +19,7 @@
 import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react';
 import { cn } from '../cn';
 import { IconButton } from '../IconButton';
+import { Tooltip } from '../Tooltip';
 import { ChevronDoubleLeftIcon, ChevronDoubleRightIcon } from '../Icon';
 import {
   loadPanelCollapsed,
@@ -200,19 +201,20 @@ function SidePanelRoot({
           className
         )}
       >
-        <IconButton
-          type="button"
-          variant="ghost"
-          size="sm"
-          touchTarget={false}
-          onClick={toggleCollapsed}
-          className={collapseButtonClasses}
-          aria-expanded={false}
-          aria-label={labels.expand}
-          title={labels.expand}
-        >
-          <CollapseIcon size="sm" />
-        </IconButton>
+        <Tooltip content={labels.expand} placement={side === 'right' ? 'left' : 'right'}>
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
+            onClick={toggleCollapsed}
+            className={collapseButtonClasses}
+            aria-expanded={false}
+            aria-label={labels.expand}
+          >
+            <CollapseIcon size="sm" />
+          </IconButton>
+        </Tooltip>
         {railTitle && (
           <span
             className="mt-3 text-micro font-semibold uppercase tracking-wider text-content-tertiary"
@@ -289,19 +291,20 @@ function SidePanelHeader({ children, className }: SidePanelHeaderProps) {
       )}
     >
       <div className="flex items-center gap-2 px-4 py-2">
-        <IconButton
-          type="button"
-          variant="ghost"
-          size="sm"
-          touchTarget={false}
-          onClick={toggleCollapsed}
-          className={collapseButtonClasses}
-          aria-expanded
-          aria-label={labels.collapse}
-          title={labels.collapse}
-        >
-          <CollapseIcon size="sm" />
-        </IconButton>
+        <Tooltip content={labels.collapse} placement="bottom">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
+            onClick={toggleCollapsed}
+            className={collapseButtonClasses}
+            aria-expanded
+            aria-label={labels.collapse}
+          >
+            <CollapseIcon size="sm" />
+          </IconButton>
+        </Tooltip>
         {children}
       </div>
     </div>

--- a/src/design-system/Tooltip/Tooltip.test.tsx
+++ b/src/design-system/Tooltip/Tooltip.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Tooltip } from './Tooltip';
+import { formatShortcut } from '../Kbd';
 
 describe('Tooltip', () => {
   describe('rendering', () => {
@@ -40,8 +41,8 @@ describe('Tooltip', () => {
           <button type="button">Trigger</button>
         </Tooltip>
       );
-      // jsdom reports a non-mac platform, so Mod resolves to Ctrl.
-      expect(screen.getByText('Ctrl+Z')).toBeInTheDocument();
+      // Assert against the formatter itself so the test holds on any platform.
+      expect(screen.getByText(formatShortcut(['Mod', 'Z']))).toBeInTheDocument();
     });
 
     it('omits the kbd element when no shortcut is given', () => {

--- a/src/design-system/Tooltip/Tooltip.test.tsx
+++ b/src/design-system/Tooltip/Tooltip.test.tsx
@@ -23,7 +23,7 @@ describe('Tooltip', () => {
       expect(screen.getByRole('tooltip')).toHaveClass('opacity-0');
     });
 
-    it('renders the shortcut in mono kbd styling', () => {
+    it('renders the shortcut as a Kbd chip', () => {
       render(
         <Tooltip content="Undo" shortcut="⌘Z">
           <button type="button">Trigger</button>
@@ -31,7 +31,17 @@ describe('Tooltip', () => {
       );
       const kbd = screen.getByText('⌘Z');
       expect(kbd.tagName).toBe('KBD');
-      expect(kbd).toHaveClass('font-mono', 'text-content-tertiary');
+      expect(kbd).toHaveClass('text-micro');
+    });
+
+    it('formats an array shortcut per platform', () => {
+      render(
+        <Tooltip content="Undo" shortcut={['Mod', 'Z']}>
+          <button type="button">Trigger</button>
+        </Tooltip>
+      );
+      // jsdom reports a non-mac platform, so Mod resolves to Ctrl.
+      expect(screen.getByText('Ctrl+Z')).toBeInTheDocument();
     });
 
     it('omits the kbd element when no shortcut is given', () => {

--- a/src/design-system/Tooltip/Tooltip.tsx
+++ b/src/design-system/Tooltip/Tooltip.tsx
@@ -1,8 +1,7 @@
 import { cloneElement, isValidElement, useId, useState } from 'react';
 import type { KeyboardEvent, ReactElement, ReactNode } from 'react';
 import { cn } from '../cn';
-import { Kbd } from '../Kbd';
-import { formatShortcut } from '../Kbd/formatShortcut';
+import { Kbd, formatShortcut } from '../Kbd';
 import { interactiveTransition } from '../variants';
 
 type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
@@ -18,13 +17,30 @@ const placementClasses: Record<TooltipPlacement, string> = {
   right: 'left-full top-1/2 -translate-y-1/2 ml-1.5',
 };
 
+/** Entry drift toward the trigger, on the axis the placement does NOT center
+    on — top/bottom center with translate-x, left/right with translate-y, so
+    the motion class must never share that axis or it clobbers the centering. */
+const hiddenMotionClasses: Record<TooltipPlacement, string> = {
+  top: 'translate-y-0.5',
+  bottom: '-translate-y-0.5',
+  left: 'translate-x-0.5',
+  right: '-translate-x-0.5',
+};
+const visibleMotionClasses: Record<TooltipPlacement, string> = {
+  top: 'translate-y-0',
+  bottom: 'translate-y-0',
+  left: 'translate-x-0',
+  right: 'translate-x-0',
+};
+
 export interface TooltipProps {
   /**
    * Tooltip text. Plain string only.
    */
   content: string;
   /**
-   * Optional keyboard-shortcut suffix rendered in mono kbd styling after the content.
+   * Optional keyboard-shortcut suffix rendered as a Kbd chip after the
+   * content. An array form (['Mod','Z']) is formatted per platform.
    */
   shortcut?: string | readonly string[];
   /**
@@ -139,14 +155,16 @@ export function Tooltip({
           placementClasses[placement],
           // opacity-only hiding keeps the description in the accessibility
           // tree (visibility:hidden would remove it).
-          visible ? 'translate-y-0 opacity-100' : 'translate-y-0.5 opacity-0',
+          visible
+            ? `opacity-100 ${visibleMotionClasses[placement]}`
+            : `opacity-0 ${hiddenMotionClasses[placement]}`,
           '[@media(hover:none)]:hidden'
         )}
         style={{ transitionDelay: visible ? `${delayMs}ms` : '0ms' }}
       >
         {content}
         {shortcut !== undefined && (
-          <Kbd className="ml-1.5" aria-hidden="true">
+          <Kbd className="ml-1.5">
             {Array.isArray(shortcut) ? formatShortcut(shortcut) : shortcut}
           </Kbd>
         )}

--- a/src/design-system/Tooltip/Tooltip.tsx
+++ b/src/design-system/Tooltip/Tooltip.tsx
@@ -1,6 +1,8 @@
 import { cloneElement, isValidElement, useId, useState } from 'react';
 import type { KeyboardEvent, ReactElement, ReactNode } from 'react';
 import { cn } from '../cn';
+import { Kbd } from '../Kbd';
+import { formatShortcut } from '../Kbd/formatShortcut';
 import { interactiveTransition } from '../variants';
 
 type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
@@ -24,7 +26,7 @@ export interface TooltipProps {
   /**
    * Optional keyboard-shortcut suffix rendered in mono kbd styling after the content.
    */
-  shortcut?: string;
+  shortcut?: string | readonly string[];
   /**
    * Side of the trigger the bubble appears on.
    * @default 'top'
@@ -137,14 +139,16 @@ export function Tooltip({
           placementClasses[placement],
           // opacity-only hiding keeps the description in the accessibility
           // tree (visibility:hidden would remove it).
-          visible ? 'opacity-100' : 'opacity-0',
+          visible ? 'translate-y-0 opacity-100' : 'translate-y-0.5 opacity-0',
           '[@media(hover:none)]:hidden'
         )}
         style={{ transitionDelay: visible ? `${delayMs}ms` : '0ms' }}
       >
         {content}
         {shortcut !== undefined && (
-          <kbd className="ml-1.5 font-mono text-content-tertiary">{shortcut}</kbd>
+          <Kbd className="ml-1.5" aria-hidden="true">
+            {Array.isArray(shortcut) ? formatShortcut(shortcut) : shortcut}
+          </Kbd>
         )}
       </span>
     </span>

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -27,6 +27,7 @@ export {
   disabledStyles,
   interactiveTransition,
   activePress,
+  hoverRaise,
   touchTarget,
   controlHeights,
   controlRow,
@@ -108,7 +109,7 @@ export type { SegmentedControlProps, SegmentedControlOption } from './SegmentedC
 export { Alert } from './Alert';
 export type { AlertProps } from './Alert';
 
-export { Kbd } from './Kbd';
+export { Kbd, formatShortcut, isMacPlatform } from './Kbd';
 export type { KbdProps } from './Kbd';
 
 export { Textarea } from './Textarea';

--- a/src/design-system/variants.ts
+++ b/src/design-system/variants.ts
@@ -83,6 +83,12 @@ export const interactiveTransition =
 export const activePress = 'active:scale-[0.98]' as const;
 
 /**
+ * Hover lift for raised interactive surfaces (cards, primary buttons).
+ */
+export const hoverRaise =
+  'hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm' as const;
+
+/**
  * Touch-friendly minimum size (44px per Apple HIG).
  */
 export const touchTarget = 'min-h-[44px] min-w-[44px]' as const;


### PR DESCRIPTION
Final PR of the design-system foundation stage (follows #3976-#3979, #3981).

## What changed

- **Tooltip shortcut hints**: the `shortcut` prop renders as a real `Kbd` chip and accepts a key array (`['Mod','Z']`) formatted per platform by the new `formatShortcut` helper — command symbols joined bare on macOS (`⌘Z`), `Ctrl+Z` form elsewhere. This is the app-wide convention for visible shortcut hints going forward. Tooltips also gain a 2px entry translate on the motion tokens.
- **`hoverRaise`** joins the variants recipes for raised interactive surfaces (the pattern the button variants already used inline).
- **Exemplar adoption**: SidePanel's collapse/expand buttons use Tooltip instead of raw `title` attributes.

The `animate-*` utility durations already resolve through the motion tokens via the `--transition-*` retarget in #3978, so no further retargeting was needed.

## Verification

Full design-system suite passes (734 tests, including new formatShortcut and Tooltip-chip cases); typecheck and lint clean; visual snapshots unchanged except where intended.

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

