### PR TITLE
feat(bin-designer): give the Shape, Features and Style pages their true shape

### DIFF
--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.test.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.test.tsx
@@ -30,7 +30,6 @@ describe('BaseSection', () => {
     expect(screen.getByText('Screw holes')).toBeInTheDocument();
     expect(screen.getByText('Stacking lip')).toBeInTheDocument();
     expect(screen.getByText('Lightweight floor')).toBeInTheDocument();
-    expect(screen.getByText('Drainage holes')).toBeInTheDocument();
   });
 
   describe('body type', () => {
@@ -222,34 +221,5 @@ describe('BaseSection', () => {
       expect(screen.queryByText(/Foot lattice/)).not.toBeInTheDocument();
       expect(screen.getByText(/A fractional axis keeps the on-grid lattice/)).toBeInTheDocument();
     });
-  });
-
-  it('reveals the hole picker only once drainage is on', () => {
-    const { unmount } = render(<BaseSection />);
-    expect(screen.queryByLabelText('Hole shape')).not.toBeInTheDocument();
-    unmount();
-
-    useDesignerStore.setState({
-      params: {
-        ...DEFAULT_BIN_PARAMS,
-        floorPattern: { enabled: true, pattern: 'round', scale: 0.5 },
-      },
-    });
-    render(<BaseSection />);
-
-    expect(screen.getByLabelText('Hole shape')).toBeInTheDocument();
-  });
-
-  it('disables drainage holes on a lightweight floor', () => {
-    useDesignerStore.setState({
-      params: {
-        ...DEFAULT_BIN_PARAMS,
-        base: { ...DEFAULT_BIN_PARAMS.base, lightweight: true },
-      },
-    });
-
-    render(<BaseSection />);
-
-    expect(screen.getByRole('switch', { name: 'Drainage holes' })).toBeDisabled();
   });
 });

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -23,9 +23,7 @@ import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
 import { Button, SegmentedControl, SliderInput } from '@/design-system';
 import { FeatureToggle } from '../FeatureToggle';
 import { AdvancedDisclosure, Hint, SubHeader } from '../shared';
-import { PatternSelector } from '../WallsSection/PatternSelector';
 import {
-  FLOOR_PATTERN_TYPES,
   DEFAULT_FOOT_LATTICE,
   FOOT_LATTICES,
   LID_ATTACHMENTS,
@@ -51,7 +49,7 @@ const FOOT_LATTICE_AXES = ['x', 'y'] as const;
  * explaining it. Keeping one dimmed line costs a row per inapplicable family
  * and leaves nothing unaccounted for.
  */
-function UnavailableFamily({ title, reason }: { title: string; reason: string }) {
+export function UnavailableFamily({ title, reason }: { title: string; reason: string }) {
   return (
     <section className="space-y-1 opacity-60">
       <SubHeader>{title}</SubHeader>
@@ -341,7 +339,8 @@ export function BaseSection() {
         </section>
       )}
 
-      {/* ── Floor ─────────────────────────────────────────────────────── */}
+      {/* ── Floor ── lightweight relief only; the drainage pattern lives on
+          the Style page with the other surface patterns. */}
       {!state.showFloor && state.floorUnavailable && (
         <UnavailableFamily
           title={t('binDesigner.base.section.floor')}
@@ -395,42 +394,6 @@ export function BaseSection() {
               </Button>
             )}
           </div>
-
-          {/* Floor pattern (#2816): drainage / ventilation. The holes pass
-              through the floor slab AND the feet, staying inside each foot's
-              flat underside so the baseplate-mating taper is never cut. */}
-          <FeatureToggle
-            label={t('binDesigner.base.floorPattern')}
-            checked={state.floorPatternEnabled}
-            onChange={handlers.toggleFloorPattern}
-            disabledReason={handlers.floorPatternDisabledReason}
-            primaryControls={
-              <>
-                <PatternSelector
-                  id="floor-pattern-selector"
-                  labelKey="binDesigner.base.floorPattern.shape"
-                  patterns={FLOOR_PATTERN_TYPES}
-                  selectedPattern={state.floorPatternType}
-                  onChange={handlers.setFloorPatternType}
-                />
-                <SliderInput
-                  label={t('binDesigner.walls.pattern.scale')}
-                  value={state.floorPatternScalePercent}
-                  onChange={handlers.setFloorPatternScale}
-                  min={0}
-                  max={100}
-                  step={5}
-                  unit="%"
-                  info={t('binDesigner.walls.pattern.scaleHint')}
-                />
-                <Hint>
-                  {state.floorPatternDoesNotFit
-                    ? t('binDesigner.base.floorPattern.tooSmall')
-                    : t('binDesigner.base.floorPattern.hint')}
-                </Hint>
-              </>
-            }
-          />
         </section>
       )}
     </div>

--- a/src/features/bin-designer/components/panel/BaseSection/FloorPatternSection.test.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/FloorPatternSection.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FloorPatternSection } from './FloorPatternSection';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
+
+describe('FloorPatternSection', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+      ui: { ...DEFAULT_UI_STATE },
+    });
+  });
+
+  it('toggles drainage on', () => {
+    render(<FloorPatternSection />);
+    fireEvent.click(screen.getByRole('switch', { name: 'Drainage holes' }));
+    expect(useDesignerStore.getState().params.floorPattern?.enabled).toBe(true);
+  });
+
+  it('reveals the hole picker only once drainage is on', () => {
+    const { unmount } = render(<FloorPatternSection />);
+    expect(screen.queryByLabelText('Hole shape')).not.toBeInTheDocument();
+    unmount();
+
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        floorPattern: { enabled: true, pattern: 'round', scale: 0.5 },
+      },
+    });
+    render(<FloorPatternSection />);
+
+    expect(screen.getByLabelText('Hole shape')).toBeInTheDocument();
+  });
+
+  it('disables drainage holes on a lightweight floor', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        base: { ...DEFAULT_BIN_PARAMS.base, lightweight: true },
+      },
+    });
+
+    render(<FloorPatternSection />);
+
+    expect(screen.getByRole('switch', { name: 'Drainage holes' })).toBeDisabled();
+  });
+
+  it('names the family instead of rendering controls when the body has no floor', () => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS, base: { ...DEFAULT_BIN_PARAMS.base, spacer: true } },
+    });
+    render(<FloorPatternSection />);
+    expect(screen.queryByRole('switch', { name: 'Drainage holes' })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/panel/BaseSection/FloorPatternSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/FloorPatternSection.tsx
@@ -1,0 +1,66 @@
+/**
+ * Floor drainage/ventilation pattern (#2816). Lives on the Style page with the
+ * other surface patterns; the rest of the floor family (lightweight relief)
+ * stays with the base. The holes pass through the floor slab AND the feet,
+ * staying inside each foot's flat underside so the baseplate-mating taper is
+ * never cut.
+ */
+
+import { SliderInput } from '@/design-system';
+import { FLOOR_PATTERN_TYPES } from '@/features/bin-designer/types';
+import { useTranslation } from '@/i18n';
+import { FeatureToggle } from '../FeatureToggle';
+import { Hint } from '../shared';
+import { PatternSelector } from '../WallsSection/PatternSelector';
+import { UnavailableFamily } from './BaseSection';
+import { useBaseSection } from './useBaseSection';
+
+export function FloorPatternSection() {
+  const { state, handlers } = useBaseSection();
+  const t = useTranslation();
+
+  if (!state.showFloor && state.floorUnavailable) {
+    return (
+      <UnavailableFamily
+        title={t('binDesigner.base.floorPattern')}
+        reason={state.floorUnavailable}
+      />
+    );
+  }
+  if (!state.showFloor) return null;
+
+  return (
+    <FeatureToggle
+      label={t('binDesigner.base.floorPattern')}
+      checked={state.floorPatternEnabled}
+      onChange={handlers.toggleFloorPattern}
+      disabledReason={handlers.floorPatternDisabledReason}
+      primaryControls={
+        <>
+          <PatternSelector
+            id="floor-pattern-selector"
+            labelKey="binDesigner.base.floorPattern.shape"
+            patterns={FLOOR_PATTERN_TYPES}
+            selectedPattern={state.floorPatternType}
+            onChange={handlers.setFloorPatternType}
+          />
+          <SliderInput
+            label={t('binDesigner.walls.pattern.scale')}
+            value={state.floorPatternScalePercent}
+            onChange={handlers.setFloorPatternScale}
+            min={0}
+            max={100}
+            step={5}
+            unit="%"
+            info={t('binDesigner.walls.pattern.scaleHint')}
+          />
+          <Hint>
+            {state.floorPatternDoesNotFit
+              ? t('binDesigner.base.floorPattern.tooSmall')
+              : t('binDesigner.base.floorPattern.hint')}
+          </Hint>
+        </>
+      }
+    />
+  );
+}

--- a/src/features/bin-designer/components/panel/BaseSection/index.ts
+++ b/src/features/bin-designer/components/panel/BaseSection/index.ts
@@ -1,1 +1,2 @@
 export * from './BaseSection';
+export { FloorPatternSection } from './FloorPatternSection';

--- a/src/features/bin-designer/components/panel/BaseSection/index.ts
+++ b/src/features/bin-designer/components/panel/BaseSection/index.ts
@@ -1,2 +1,2 @@
-export * from './BaseSection';
+export { BaseSection } from './BaseSection';
 export { FloorPatternSection } from './FloorPatternSection';

--- a/src/features/bin-designer/components/panel/WallsSection/WallSurfaceSection.test.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallSurfaceSection.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { WallsSection } from './WallsSection';
+import { WallSurfaceSection } from './WallSurfaceSection';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
 import type { WallPatternSides } from '@/features/bin-designer/types';
 
-describe('WallsSection', () => {
+describe('WallSurfaceSection', () => {
   beforeEach(() => {
     useDesignerStore.setState({
       params: { ...DEFAULT_BIN_PARAMS },
@@ -13,13 +13,8 @@ describe('WallsSection', () => {
     });
   });
 
-  it('renders wall thickness slider', () => {
-    const { container } = render(<WallsSection />);
-    expect(container.querySelector('div[role="slider"]')).toBeInTheDocument();
-  });
-
   it('renders pattern selector with all options', () => {
-    render(<WallsSection />);
+    render(<WallSurfaceSection />);
     expect(screen.getByText('Wall pattern')).toBeInTheDocument();
     expect(screen.getByText('Solid')).toBeInTheDocument();
     expect(screen.getByText('Honeycomb')).toBeInTheDocument();
@@ -39,18 +34,13 @@ describe('WallsSection', () => {
       },
     });
 
-    render(<WallsSection />);
+    render(<WallSurfaceSection />);
     expect(screen.getByText('Walls with divider slots will keep solid walls')).toBeInTheDocument();
-  });
-
-  it('always renders handle section', () => {
-    render(<WallsSection />);
-    expect(screen.getByText('Handles')).toBeInTheDocument();
   });
 
   describe('wall text (#2695)', () => {
     it('hides the inputs until the toggle is switched on', () => {
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.getByText('Wall text')).toBeInTheDocument();
       expect(screen.queryByRole('textbox', { name: 'Front wall text' })).not.toBeInTheDocument();
 
@@ -65,12 +55,12 @@ describe('WallsSection', () => {
         params: { ...DEFAULT_BIN_PARAMS, surfaceText: { walls: { front: 'Cables' } } },
         ui: { ...DEFAULT_UI_STATE },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.getByRole('textbox', { name: 'Front wall text' })).toBeInTheDocument();
     });
 
     it('commits a wall string on blur', () => {
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       fireEvent.click(screen.getByRole('switch', { name: 'Wall text' }));
       const input = screen.getByRole('textbox', { name: 'Front wall text' });
       fireEvent.change(input, { target: { value: 'Cables' } });
@@ -79,7 +69,7 @@ describe('WallsSection', () => {
     });
 
     it('collapses an opened-but-empty toggle when the active design switches', () => {
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       fireEvent.click(screen.getByRole('switch', { name: 'Wall text' }));
       expect(screen.getByRole('textbox', { name: 'Front wall text' })).toBeInTheDocument();
 
@@ -100,7 +90,7 @@ describe('WallsSection', () => {
         },
         ui: { ...DEFAULT_UI_STATE },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       // Auto-opened because text exists; toggling off clears every wall.
       fireEvent.click(screen.getByRole('switch', { name: 'Wall text' }));
       expect(useDesignerStore.getState().params.surfaceText?.walls).toBeUndefined();
@@ -109,7 +99,7 @@ describe('WallsSection', () => {
     });
 
     it('shows mode + anchor pickers only when text is present', () => {
-      const { unmount } = render(<WallsSection />);
+      const { unmount } = render(<WallSurfaceSection />);
       expect(screen.queryByRole('radio', { name: 'Emboss' })).not.toBeInTheDocument();
       unmount();
 
@@ -117,7 +107,7 @@ describe('WallsSection', () => {
         params: { ...DEFAULT_BIN_PARAMS, surfaceText: { walls: { front: 'Cables' } } },
         ui: { ...DEFAULT_UI_STATE },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.getByRole('radio', { name: 'Emboss' })).toBeInTheDocument();
       expect(screen.getByRole('radio', { name: 'Top left' })).toBeInTheDocument();
     });
@@ -127,7 +117,7 @@ describe('WallsSection', () => {
         params: { ...DEFAULT_BIN_PARAMS, surfaceText: { walls: { front: 'Cables' } } },
         ui: { ...DEFAULT_UI_STATE },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       // Not 'Bottom left': the default preset already anchors there, so the
       // setter's no-op guard would (correctly) swallow it and the test would
       // pass without the picker being wired to anything.
@@ -140,7 +130,7 @@ describe('WallsSection', () => {
         params: { ...DEFAULT_BIN_PARAMS, surfaceText: { walls: { front: 'Cables' } } },
         ui: { ...DEFAULT_UI_STATE },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       fireEvent.click(screen.getByRole('radio', { name: 'Emboss' }));
       expect(useDesignerStore.getState().params.surfaceText?.style?.mode).toBe('emboss');
     });
@@ -150,7 +140,7 @@ describe('WallsSection', () => {
         params: { ...DEFAULT_BIN_PARAMS, cellMask: { cols: 2, rows: 2, cells: [1, 1, 1, 0] } },
         ui: { ...DEFAULT_UI_STATE },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.queryByRole('textbox', { name: 'Front wall text' })).not.toBeInTheDocument();
       expect(screen.getByText('Not available for custom-shape bins.')).toBeInTheDocument();
     });
@@ -167,7 +157,7 @@ describe('WallsSection', () => {
         },
         ui: { ...DEFAULT_UI_STATE },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.getByRole('textbox', { name: 'Front wall text' })).toHaveValue('BITS');
       expect(screen.queryByText('Not available for solid bins.')).not.toBeInTheDocument();
     });
@@ -184,13 +174,13 @@ describe('WallsSection', () => {
     });
 
     it('hides the side selector until a pattern is picked', () => {
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.queryByRole('switch', { name: 'Front' })).not.toBeInTheDocument();
     });
 
     it('shows all four walls selected for a freshly enabled pattern', () => {
       useDesignerStore.setState({ params: patterned() });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.getByText('Patterned walls')).toBeInTheDocument();
       for (const side of ['Left', 'Right', 'Front', 'Back']) {
         expect(screen.getByRole('switch', { name: side })).toHaveAttribute('aria-checked', 'true');
@@ -199,7 +189,7 @@ describe('WallsSection', () => {
 
     it('writes the full side record when a wall is toggled off', () => {
       useDesignerStore.setState({ params: patterned() });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       fireEvent.click(screen.getByRole('switch', { name: 'Back' }));
       expect(useDesignerStore.getState().params.wallPattern.sides).toEqual({
         left: true,
@@ -218,7 +208,7 @@ describe('WallsSection', () => {
           compartments: { cols: 2, rows: 1, cells: [0, 1], thickness: 1.2 },
         },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(
         screen.getByText('Pick a wall, or pattern the divider walls below')
       ).toBeInTheDocument();
@@ -237,7 +227,7 @@ describe('WallsSection', () => {
           },
         },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(
         screen.getByText('Outer walls stay solid — only the dividers are patterned')
       ).toBeInTheDocument();
@@ -249,7 +239,7 @@ describe('WallsSection', () => {
       useDesignerStore.setState({
         params: patterned({ left: false, right: false, front: false, back: false }),
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.getByText('Nothing is patterned — pick at least one wall')).toBeInTheDocument();
       expect(
         screen.queryByText('Pick a wall, or pattern the divider walls below')
@@ -266,7 +256,7 @@ describe('WallsSection', () => {
           wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true, pattern: 'mitsukude' },
         },
       });
-      const { unmount } = render(<WallsSection />);
+      const { unmount } = render(<WallSurfaceSection />);
       expect(screen.queryByRole('switch', { name: 'Front' })).not.toBeInTheDocument();
       expect(
         screen.getByText('Kumiko patterns need a rectangular bin, so these walls stay solid')
@@ -286,7 +276,7 @@ describe('WallsSection', () => {
           wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true, pattern: 'mitsukude' },
         },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.queryByRole('switch', { name: 'Front' })).not.toBeInTheDocument();
       expect(
         screen.getByText(
@@ -302,7 +292,7 @@ describe('WallsSection', () => {
           wallPattern: { ...DEFAULT_BIN_PARAMS.wallPattern, enabled: true, pattern: 'mitsukude' },
         },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       expect(screen.getByRole('switch', { name: 'Front' })).toBeInTheDocument();
     });
 
@@ -318,7 +308,7 @@ describe('WallsSection', () => {
           },
         },
       });
-      render(<WallsSection />);
+      render(<WallSurfaceSection />);
       const left = screen.getByRole('switch', { name: 'Left' });
       expect(left).toBeDisabled();
       // Disabled reads as off even though the stored selection is untouched.
@@ -336,7 +326,7 @@ describe('WallsSection', () => {
       },
     });
 
-    render(<WallsSection />);
+    render(<WallSurfaceSection />);
     const select = screen.getByRole<HTMLSelectElement>('combobox');
     expect(select.value).toBe('honeycomb');
   });

--- a/src/features/bin-designer/components/panel/WallsSection/WallSurfaceSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallSurfaceSection.tsx
@@ -1,22 +1,13 @@
 /**
- * Walls section: Wall thickness and pattern selection.
- *
- * Shows discrete wall thickness options (multiples of common FDM nozzle sizes)
- * using a snapping slider with tick marks and helpful descriptions.
- *
- * Also allows selection of wall patterns (honeycomb, etc.) via dropdown, which
- * walls carry them, and their scale.
+ * Wall surface styling: carved patterns and auto-fit surface text on the outer
+ * walls. Lives on the Style page; thickness stays with Shape.
  */
 
 import { SliderInput, SegmentedControl, Checkbox } from '@/design-system';
 import type { TextMode } from '@/features/bin-designer/types';
 import { WALL_PATTERN_SIDES, WALL_TEXT_SIDES } from '@/features/bin-designer/types';
-import { SnappingSlider } from '../../controls/SnappingSlider';
 import { useWallsSection } from './useWallsSection';
 import { PatternSelector } from './PatternSelector';
-import { WallCutoutsSection } from '../WallCutoutsSection';
-import { HandleSection } from '../HandleSection';
-import { SlideTraySection } from '../SlideTraySection';
 import { FeatureToggle } from '../FeatureToggle';
 import { CompartmentTextInput } from '../LabelTabsSection/CompartmentTextInput';
 import { AnchorPicker } from '../../controls/AnchorPicker';
@@ -25,12 +16,8 @@ import { SideSelector, type SideState } from '../shared';
 /** Mode options for the wall-text picker, in the shared textMode order. */
 const TEXT_MODE_OPTIONS: readonly TextMode[] = ['engrave', 'emboss', 'through-cut'] as const;
 
-export function WallsSection() {
+export function WallSurfaceSection() {
   const { state, handlers, t } = useWallsSection();
-  // Wall cutouts and handles auto-snap to the outermost matching polygon
-  // edge on custom shapes. Wall patterns tile across *every* axis-aligned
-  // outer edge; outermost-per-cardinal matching is used only for border
-  // clipping around cutouts/handles, not to limit tiling itself.
 
   // A slot-blocked wall can't carry a pattern, and SideSelector renders a
   // disabled side as off — so the stored selection passes through unchanged and
@@ -47,14 +34,6 @@ export function WallsSection() {
 
   return (
     <div className="space-y-4">
-      <SnappingSlider
-        label={t('binDesigner.wallThickness')}
-        value={state.wallThickness}
-        onChange={handlers.handleChange}
-        options={state.options}
-        unit="mm"
-        tip={t('binDesigner.wallThickness.nozzleTip')}
-      />
       <div>
         <PatternSelector
           selectedPattern={state.patternEnabled ? state.pattern : null}
@@ -193,9 +172,6 @@ export function WallsSection() {
           </>
         }
       />
-      <WallCutoutsSection />
-      <HandleSection />
-      <SlideTraySection />
     </div>
   );
 }

--- a/src/features/bin-designer/components/panel/WallsSection/WallThicknessSection.test.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallThicknessSection.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { WallThicknessSection } from './WallThicknessSection';
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
+
+describe('WallThicknessSection', () => {
+  beforeEach(() => {
+    useDesignerStore.setState({
+      params: { ...DEFAULT_BIN_PARAMS },
+      ui: { ...DEFAULT_UI_STATE },
+    });
+  });
+
+  it('renders the wall thickness slider', () => {
+    const { container } = render(<WallThicknessSection />);
+    expect(container.querySelector('div[role="slider"]')).toBeInTheDocument();
+  });
+});

--- a/src/features/bin-designer/components/panel/WallsSection/WallThicknessSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallThicknessSection.tsx
@@ -1,0 +1,22 @@
+/**
+ * Wall thickness: discrete options (multiples of common FDM nozzle sizes) on a
+ * snapping slider with tick marks. The wall surface styling (patterns, text)
+ * lives on the Style page; the wall-mounted features on the Features page.
+ */
+
+import { SnappingSlider } from '../../controls/SnappingSlider';
+import { useWallsSection } from './useWallsSection';
+
+export function WallThicknessSection() {
+  const { state, handlers, t } = useWallsSection();
+  return (
+    <SnappingSlider
+      label={t('binDesigner.wallThickness')}
+      value={state.wallThickness}
+      onChange={handlers.handleChange}
+      options={state.options}
+      unit="mm"
+      tip={t('binDesigner.wallThickness.nozzleTip')}
+    />
+  );
+}

--- a/src/features/bin-designer/components/panel/WallsSection/index.ts
+++ b/src/features/bin-designer/components/panel/WallsSection/index.ts
@@ -1,1 +1,2 @@
-export * from './WallsSection';
+export { WallThicknessSection } from './WallThicknessSection';
+export { WallSurfaceSection } from './WallSurfaceSection';

--- a/src/features/bin-designer/components/panel/pages/FeaturesPage/FeaturesPage.test.tsx
+++ b/src/features/bin-designer/components/panel/pages/FeaturesPage/FeaturesPage.test.tsx
@@ -17,5 +17,14 @@ describe('FeaturesPage', () => {
   it('composes its sections with their help targets', () => {
     const { container } = render(<FeaturesPage />);
     expect(container.querySelector('[data-help-target="bd-lid"]'), 'bd-lid').not.toBeNull();
+    expect(container.querySelector('[data-help-target="bd-handles"]'), 'bd-handles').not.toBeNull();
+    expect(
+      container.querySelector('[data-help-target="bd-wall-cutouts"]'),
+      'bd-wall-cutouts'
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-help-target="bd-slide-tray"]'),
+      'bd-slide-tray'
+    ).not.toBeNull();
   });
 });

--- a/src/features/bin-designer/components/panel/pages/FeaturesPage/FeaturesPage.tsx
+++ b/src/features/bin-designer/components/panel/pages/FeaturesPage/FeaturesPage.tsx
@@ -1,20 +1,24 @@
-import { useTranslation } from '@/i18n';
 import { PanelSection } from '../../PanelSection';
 import { LidSection } from '../../LidSection';
+import { WallCutoutsSection } from '../../WallCutoutsSection';
+import { HandleSection } from '../../HandleSection';
+import { SlideTraySection } from '../../SlideTraySection';
 
-/**
- * Feature parts: the lid today; handles, wall cutouts and the slide tray move
- * here from Walls when that section splits.
- */
+/** Feature parts: the lid, handles, wall cutouts, slide tray. */
 export function FeaturesPage() {
-  const t = useTranslation();
   return (
     <div className="divide-y divide-stroke-subtle/50">
-      <p className="px-4 py-2 text-label text-content-tertiary">
-        {t('binDesigner.category.featuresInterim')}
-      </p>
       <PanelSection helpTarget="bd-lid">
         <LidSection />
+      </PanelSection>
+      <PanelSection helpTarget="bd-handles">
+        <HandleSection />
+      </PanelSection>
+      <PanelSection helpTarget="bd-wall-cutouts">
+        <WallCutoutsSection />
+      </PanelSection>
+      <PanelSection helpTarget="bd-slide-tray">
+        <SlideTraySection />
       </PanelSection>
     </div>
   );

--- a/src/features/bin-designer/components/panel/pages/ShapePage/ShapePage.tsx
+++ b/src/features/bin-designer/components/panel/pages/ShapePage/ShapePage.tsx
@@ -2,7 +2,7 @@ import { PanelSection } from '../../PanelSection';
 import { DimensionsSection } from '../../DimensionsSection';
 import { OverhangSection } from '../../OverhangSection';
 import { ShapeSection } from '../../ShapeSection';
-import { WallsSection } from '../../WallsSection';
+import { WallThicknessSection } from '../../WallsSection';
 import { BaseSection } from '../../BaseSection';
 
 /** Size & shape: dimensions, drawer fit, custom footprint, walls, body/base. */
@@ -21,7 +21,7 @@ export function ShapePage() {
         <ShapeSection />
       </PanelSection>
       <PanelSection helpTarget="bd-walls">
-        <WallsSection />
+        <WallThicknessSection />
       </PanelSection>
       <PanelSection helpTarget="bd-base">
         <BaseSection />

--- a/src/features/bin-designer/components/panel/pages/StylePage/StylePage.test.tsx
+++ b/src/features/bin-designer/components/panel/pages/StylePage/StylePage.test.tsx
@@ -18,5 +18,13 @@ describe('StylePage', () => {
     const { container } = render(<StylePage />);
     expect(container.querySelector('[data-help-target="bd-type"]'), 'bd-type').not.toBeNull();
     expect(container.querySelector('[data-help-target="bd-colors"]'), 'bd-colors').not.toBeNull();
+    expect(
+      container.querySelector('[data-help-target="bd-wall-style"]'),
+      'bd-wall-style'
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-help-target="bd-floor-pattern"]'),
+      'bd-floor-pattern'
+    ).not.toBeNull();
   });
 });

--- a/src/features/bin-designer/components/panel/pages/StylePage/StylePage.tsx
+++ b/src/features/bin-designer/components/panel/pages/StylePage/StylePage.tsx
@@ -1,8 +1,10 @@
 import { PanelSection } from '../../PanelSection';
 import { TypeSection } from '../../TypeSection';
 import { ColorsSection } from '../../ColorsSection';
+import { WallSurfaceSection } from '../../WallsSection';
+import { FloorPatternSection } from '../../BaseSection';
 
-/** Appearance: typography presets and multi-color. */
+/** Appearance: typography, colors, wall patterns and text, floor pattern. */
 export function StylePage() {
   return (
     <div className="divide-y divide-stroke-subtle/50">
@@ -11,6 +13,12 @@ export function StylePage() {
       </PanelSection>
       <PanelSection helpTarget="bd-colors">
         <ColorsSection />
+      </PanelSection>
+      <PanelSection helpTarget="bd-wall-style">
+        <WallSurfaceSection />
+      </PanelSection>
+      <PanelSection helpTarget="bd-floor-pattern">
+        <FloorPatternSection />
       </PanelSection>
     </div>
   );

--- a/src/features/bin-designer/settingsManifest.ts
+++ b/src/features/bin-designer/settingsManifest.ts
@@ -27,8 +27,13 @@ export const DESIGNER_SETTINGS: readonly DesignerSettingEntry[] = [
   { controlId: 'bd-knife-rest', category: 'interior' },
   { controlId: 'bd-lid', category: 'features' },
   { controlId: 'bd-lid-grip', category: 'features' },
+  { controlId: 'bd-handles', category: 'features' },
+  { controlId: 'bd-wall-cutouts', category: 'features' },
+  { controlId: 'bd-slide-tray', category: 'features' },
   { controlId: 'bd-type', category: 'style' },
   { controlId: 'bd-colors', category: 'style' },
+  { controlId: 'bd-wall-style', category: 'style' },
+  { controlId: 'bd-floor-pattern', category: 'style' },
   { controlId: 'bd-physical-units', category: 'print' },
 ];
 

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Funkce",
   "binDesigner.category.style": "Styl",
   "binDesigner.category.print": "Tisk",
-  "binDesigner.category.featuresInterim": "Úchyty, výřezy ve stěnách a výsuvný tác zatím najdete v sekci Tvar.",
   "binDesigner.panel.collapse": "Sbalit panel",
   "binDesigner.panel.expand": "Rozbalit panel",
   "binDesigner.panel.resize": "Změnit velikost panelu",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Funktionen",
   "binDesigner.category.style": "Stil",
   "binDesigner.category.print": "Druck",
-  "binDesigner.category.featuresInterim": "Griffe, Wandausschnitte und das Schiebetablett sind vorerst unter Form zu finden.",
   "binDesigner.panel.collapse": "Panel einklappen",
   "binDesigner.panel.expand": "Panel ausklappen",
   "binDesigner.panel.resize": "Panelgröße ändern",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2563,8 +2563,6 @@ const en: Record<string, string> = {
   'binDesigner.category.features': 'Features',
   'binDesigner.category.style': 'Style',
   'binDesigner.category.print': 'Print',
-  'binDesigner.category.featuresInterim':
-    'Handles, wall cutouts and the slide tray are under Shape for now.',
   'binDesigner.panel.collapse': 'Collapse panel',
   'binDesigner.panel.expand': 'Expand panel',
   'binDesigner.panel.resize': 'Resize panel',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Funciones",
   "binDesigner.category.style": "Estilo",
   "binDesigner.category.print": "Impresión",
-  "binDesigner.category.featuresInterim": "Las asas, los recortes de pared y la bandeja deslizante están por ahora en Forma.",
   "binDesigner.panel.collapse": "Contraer panel",
   "binDesigner.panel.expand": "Expandir panel",
   "binDesigner.panel.resize": "Cambiar tamaño del panel",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Fonctions",
   "binDesigner.category.style": "Style",
   "binDesigner.category.print": "Impression",
-  "binDesigner.category.featuresInterim": "Les poignées, découpes de paroi et le plateau coulissant sont pour l’instant sous Forme.",
   "binDesigner.panel.collapse": "Réduire le panneau",
   "binDesigner.panel.expand": "Développer le panneau",
   "binDesigner.panel.resize": "Redimensionner le panneau",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Funzioni",
   "binDesigner.category.style": "Stile",
   "binDesigner.category.print": "Stampa",
-  "binDesigner.category.featuresInterim": "Maniglie, ritagli a parete e vassoio scorrevole sono per ora in Forma.",
   "binDesigner.panel.collapse": "Comprimi pannello",
   "binDesigner.panel.expand": "Espandi pannello",
   "binDesigner.panel.resize": "Ridimensiona pannello",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "機能",
   "binDesigner.category.style": "スタイル",
   "binDesigner.category.print": "印刷",
-  "binDesigner.category.featuresInterim": "ハンドル、壁の切り欠き、スライドトレイは当面「形状」にあります。",
   "binDesigner.panel.collapse": "パネルを折りたたむ",
   "binDesigner.panel.expand": "パネルを展開",
   "binDesigner.panel.resize": "パネルのサイズを変更",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "기능",
   "binDesigner.category.style": "스타일",
   "binDesigner.category.print": "인쇄",
-  "binDesigner.category.featuresInterim": "손잡이, 벽 컷아웃, 슬라이드 트레이는 당분간 모양에 있습니다.",
   "binDesigner.panel.collapse": "패널 접기",
   "binDesigner.panel.expand": "패널 펼치기",
   "binDesigner.panel.resize": "패널 크기 조절",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Funksjoner",
   "binDesigner.category.style": "Stil",
   "binDesigner.category.print": "Utskrift",
-  "binDesigner.category.featuresInterim": "Håndtak, veggutskjæringer og skyvebrettet ligger foreløpig under Form.",
   "binDesigner.panel.collapse": "Skjul panel",
   "binDesigner.panel.expand": "Vis panel",
   "binDesigner.panel.resize": "Endre panelstørrelse",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Functies",
   "binDesigner.category.style": "Stijl",
   "binDesigner.category.print": "Afdrukken",
-  "binDesigner.category.featuresInterim": "Handgrepen, wanduitsparingen en de schuiflade staan voorlopig onder Vorm.",
   "binDesigner.panel.collapse": "Paneel inklappen",
   "binDesigner.panel.expand": "Paneel uitklappen",
   "binDesigner.panel.resize": "Paneelgrootte wijzigen",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Funkcje",
   "binDesigner.category.style": "Styl",
   "binDesigner.category.print": "Druk",
-  "binDesigner.category.featuresInterim": "Uchwyty, wycięcia w ściankach i wysuwana taca są na razie w sekcji Kształt.",
   "binDesigner.panel.collapse": "Zwiń panel",
   "binDesigner.panel.expand": "Rozwiń panel",
   "binDesigner.panel.resize": "Zmień rozmiar panelu",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Recursos",
   "binDesigner.category.style": "Estilo",
   "binDesigner.category.print": "Impressão",
-  "binDesigner.category.featuresInterim": "Alças, recortes de parede e a bandeja deslizante estão por enquanto em Forma.",
   "binDesigner.panel.collapse": "Recolher painel",
   "binDesigner.panel.expand": "Expandir painel",
   "binDesigner.panel.resize": "Redimensionar painel",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Funktioner",
   "binDesigner.category.style": "Stil",
   "binDesigner.category.print": "Utskrift",
-  "binDesigner.category.featuresInterim": "Handtag, väggurtag och skjutbrickan ligger tills vidare under Form.",
   "binDesigner.panel.collapse": "Fäll ihop panelen",
   "binDesigner.panel.expand": "Fäll ut panelen",
   "binDesigner.panel.resize": "Ändra panelens storlek",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "Функції",
   "binDesigner.category.style": "Стиль",
   "binDesigner.category.print": "Друк",
-  "binDesigner.category.featuresInterim": "Ручки, вирізи в стінках і висувний лоток поки що в розділі Форма.",
   "binDesigner.panel.collapse": "Згорнути панель",
   "binDesigner.panel.expand": "Розгорнути панель",
   "binDesigner.panel.resize": "Змінити розмір панелі",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -4481,7 +4481,6 @@
   "binDesigner.category.features": "功能",
   "binDesigner.category.style": "样式",
   "binDesigner.category.print": "打印",
-  "binDesigner.category.featuresInterim": "手柄、壁面开孔和滑动托盘暂时位于“形状”下。",
   "binDesigner.panel.collapse": "折叠面板",
   "binDesigner.panel.expand": "展开面板",
   "binDesigner.panel.resize": "调整面板大小",


### PR DESCRIPTION
Second PR of the IA rebuild (follows #3983): the intra-section surgery that makes each category page's contents match its rail label.

## What changed

- **Walls splits in three.** The thickness slider stays on Shape as `WallThicknessSection`. The carved wall patterns (selector, scale, per-wall sides, divider carry-through) and the wall surface text become `WallSurfaceSection` on the Style page. The wall-mounted features — handles, wall cutouts, slide tray — re-parent to the Features page beside the lid, and the interim "under Shape for now" hint retires with them.
- **The drainage pattern leaves the base.** `FloorPatternSection` joins the other surface patterns on Style (with the same unavailable-family explanation when the body has no floor); lightweight relief stays with the base on Shape.
- All moves are JSX re-hosting over the existing `useWallsSection`/`useBaseSection` hooks — no parameter semantics change. The settings manifest gains entries for every relocated control (`bd-wall-style`, `bd-floor-pattern`, `bd-handles`, `bd-wall-cutouts`, `bd-slide-tray`) so help deep links land on the right page.

## Verification

Full unit + dom projects pass (22,696 tests) with the walls/base suites split alongside their components; all i18n checks green; lint and doc-drift clean.

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

