### PR TITLE
fix(print-export): merge mismatched palettes in multi-object 3MF export

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "!dist/assets/zh-CN-*.js"
       ],
       "gzip": true,
-      "limit": "2190 kB"
+      "limit": "2191 kB"
     },
     {
       "name": "Fetched JSON assets (gzip)",

--- a/src/features/bin-designer/utils/binDownloadHelpers.ts
+++ b/src/features/bin-designer/utils/binDownloadHelpers.ts
@@ -331,8 +331,8 @@ function layoutPieceRightOf(
 
 /**
  * Build a uniform-color colorConfig for an ancillary piece (lid or divider).
- * Materials match the bin's palette so `unifiedPalette`'s same-materials
- * invariant holds across all objects in the 3MF.
+ * Materials match the bin's palette so `unifyColorConfigs` takes its no-remap
+ * fast path and slot indices line up across all objects in the 3MF.
  */
 function uniformColorConfig(
   zone: ColorZone,

--- a/src/features/generation/export/threemfColor.ts
+++ b/src/features/generation/export/threemfColor.ts
@@ -7,38 +7,68 @@ export function activeColorConfig(
   return c && c.materials.length > 0 ? c : undefined;
 }
 
-/**
- * Resolve the palette emitted into `Metadata/project_settings.config` from one
- * or more colorConfigs. Returns undefined when no palette would be emitted —
- * single-color exports skip the sidecar entirely.
- *
- * **Invariant:** every colored object in a multi-object export must share the
- * same materials array (same order, same colors). Per-triangle `paint_color`
- * codes are object-local references into the object's own slot list, so two
- * objects with differently-ordered palettes would resolve the same code to
- * different filaments in the unified `filament_colour` list. Throws on
- * mismatch rather than silently producing wrong colors. Today only the bin
- * carries a colorConfig in the multi-object path, but locking down the
- * invariant lets that change safely later.
- */
-export function unifiedPalette(
-  configs: readonly (ThreeMFColorConfig | undefined)[]
-): readonly string[] | undefined {
-  const actives = configs
-    .map(activeColorConfig)
-    .filter((c): c is ThreeMFColorConfig => c !== undefined);
-  if (actives.length === 0) return undefined;
+export interface UnifiedColorConfigs {
+  /** `filament_colour` list, or undefined when no object carries colors. */
+  readonly palette: readonly string[] | undefined;
+  /** Per input config, remapped into the merged palette's slot space. */
+  readonly configs: readonly (ThreeMFColorConfig | undefined)[];
+}
 
-  const first = actives[0].materials;
-  for (let i = 1; i < actives.length; i++) {
-    if (!materialsMatch(first, actives[i].materials)) {
-      throw new Error(
-        '3MF multi-object: all colored objects must share the same materials array (same order, same colors); ' +
-          'per-object paint_color slot indices would otherwise misalign with the unified filament palette.'
-      );
-    }
+/**
+ * Resolve one shared palette from the objects' colorConfigs. Per-triangle
+ * `paint_color` codes are object-local references into the object's own slot
+ * list, so objects with different palettes cannot share the file's single
+ * `filament_colour` list as-is: the same code would resolve to different
+ * filaments per object. When palettes differ (two bins with different zone
+ * colors in one layout project file), the distinct colors are merged in
+ * first-seen order — shared colors collapse onto one filament — and each
+ * config's triangle slots are rewritten to reference the merged palette.
+ *
+ * Returns an undefined palette when no object carries colors, so single-color
+ * exports skip the sidecar entirely. Throws only when the merged union
+ * exceeds the slicer's filament cap, which no remapping can represent.
+ */
+export function unifyColorConfigs(
+  configs: readonly (ThreeMFColorConfig | undefined)[]
+): UnifiedColorConfigs {
+  const actives = configs.map(activeColorConfig);
+  const present = actives.filter((c): c is ThreeMFColorConfig => c !== undefined);
+  if (present.length === 0) return { palette: undefined, configs: actives };
+
+  // Identical arrays need no remap; pass them through untouched so a palette
+  // that deliberately repeats a color keeps its slot layout.
+  const first = present[0].materials;
+  if (present.every((c) => materialsMatch(first, c.materials))) {
+    return { palette: first.map((m) => m.color.toLowerCase()), configs: actives };
   }
-  return first.map((m) => m.color.toLowerCase());
+
+  const slotByColor = new Map<string, number>();
+  const mergedSlot = (color: string): number => {
+    const key = color.toLowerCase();
+    const existing = slotByColor.get(key);
+    if (existing !== undefined) return existing;
+    slotByColor.set(key, slotByColor.size);
+    return slotByColor.size - 1;
+  };
+  const slotMaps = actives.map((c) => c?.materials.map((m) => mergedSlot(m.color)));
+
+  if (slotByColor.size > MAX_COLOR_SLOTS) {
+    throw new Error(
+      `3MF multi-object: ${slotByColor.size} distinct colors across objects exceeds slicer filament cap of ${MAX_COLOR_SLOTS}`
+    );
+  }
+
+  const palette = [...slotByColor.keys()];
+  const mergedMaterials = palette.map((color) => ({ color }));
+  const remapped = actives.map((config, i) => {
+    const slotMap = slotMaps[i];
+    if (!config || !slotMap) return undefined;
+    return {
+      materials: mergedMaterials,
+      triangleMaterialIndices: config.triangleMaterialIndices.map((slot) => slotMap[slot]),
+    };
+  });
+  return { palette, configs: remapped };
 }
 
 function materialsMatch(

--- a/src/features/generation/export/threemfColor.ts
+++ b/src/features/generation/export/threemfColor.ts
@@ -24,7 +24,7 @@ export interface UnifiedColorConfigs {
  * first-seen order — shared colors collapse onto one filament — and each
  * config's triangle slots are rewritten to reference the merged palette.
  *
- * Returns an undefined palette when no object carries colors, so single-color
+ * Returns an undefined palette when no object carries colors, so uncolored
  * exports skip the sidecar entirely. Throws only when the merged union
  * exceeds the slicer's filament cap, which no remapping can represent.
  */

--- a/src/features/generation/export/threemfExporter.test.ts
+++ b/src/features/generation/export/threemfExporter.test.ts
@@ -694,11 +694,13 @@ describe('threemfExporter', () => {
       expect(config.filament_colour).toEqual(['#111111', '#ff0000']);
     });
 
-    it('multi-object: throws when colored objects have mismatched material arrays', () => {
-      // Per-triangle paint_color codes are object-local. If two objects ship
-      // different palettes, code "4" (slot 1) means different filaments in
-      // each object — and the unified filament_colour list can only honor
-      // one mapping. Fail loudly rather than silently produce wrong colors.
+    it('multi-object: merges mismatched palettes and remaps paint codes', () => {
+      // Per-triangle paint_color codes are object-local slot references, so
+      // objects with different palettes can't share one filament_colour list
+      // as-is. The exporter merges distinct colors (first-seen order, shared
+      // colors deduped to one filament) and remaps each object's triangle
+      // slots into the merged space — two bins with different zone palettes
+      // in one project file is a normal layout export.
       const tri = createSingleTriangle();
       const objects = [
         {
@@ -707,7 +709,7 @@ describe('threemfExporter', () => {
           name: 'bin',
           colorConfig: {
             materials: [{ color: '#111111' }, { color: '#ff0000' }],
-            triangleMaterialIndices: [0],
+            triangleMaterialIndices: [1],
           },
         },
         {
@@ -716,13 +718,79 @@ describe('threemfExporter', () => {
           name: 'lid',
           colorConfig: {
             materials: [{ color: '#111111' }, { color: '#00ff00' }],
+            triangleMaterialIndices: [1],
+          },
+        },
+      ];
+      const files = unzipSync(build3MFMultiObjectBuffer(objects, { name: 'multi' }));
+
+      // Shared #111111 collapses to one filament; the union keeps first-seen order.
+      const config = JSON.parse(strFromU8(files['Metadata/project_settings.config']));
+      expect(config.filament_colour).toEqual(['#111111', '#ff0000', '#00ff00']);
+
+      // Bin slot 1 keeps filament 2 ("8"); lid slot 1 remaps to merged
+      // slot 2 → filament 3 ("0C") instead of colliding on filament 2.
+      const model = strFromU8(files['3D/3dmodel.model']);
+      const codes = model.match(/paint_color="([^"]+)"/g) ?? [];
+      expect(codes).toEqual(['paint_color="8"', 'paint_color="0C"']);
+    });
+
+    it('multi-object: bases per-object extruder on the merged palette', () => {
+      const tri = createSingleTriangle();
+      const objects = [
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'bin',
+          colorConfig: {
+            materials: [{ color: '#d4d8dc' }, { color: '#ff0000' }],
+            triangleMaterialIndices: [0],
+          },
+        },
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'lid',
+          colorConfig: {
+            materials: [{ color: '#d4d8dc' }, { color: '#00ff00' }],
+            triangleMaterialIndices: [1],
+          },
+        },
+      ];
+      const files = unzipSync(build3MFMultiObjectBuffer(objects, { name: 'multi' }));
+      const xml = strFromU8(files['Metadata/model_settings.config']);
+      // Bin → body (merged slot 0) → extruder 1; lid → green (merged slot 2,
+      // after #d4d8dc and #ff0000) → extruder 3, not its object-local 2.
+      expect(xml).toMatch(/<object id="1">[\s\S]*?key="extruder" value="1"[\s\S]*?<\/object>/);
+      expect(xml).toMatch(/<object id="2">[\s\S]*?key="extruder" value="3"[\s\S]*?<\/object>/);
+    });
+
+    it('multi-object: throws when distinct colors across objects exceed the filament cap', () => {
+      // Each object individually fits the 16-slot cap, but the merged union
+      // is 17 distinct colors — one more filament than paint_color can encode.
+      const tri = createSingleTriangle();
+      const colorAt = (i: number) => `#${i.toString(16).padStart(6, '0')}`;
+      const objects = [
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'a',
+          colorConfig: {
+            materials: Array.from({ length: 9 }, (_, i) => ({ color: colorAt(i + 1) })),
+            triangleMaterialIndices: [0],
+          },
+        },
+        {
+          vertices: tri.vertices,
+          normals: tri.normals,
+          name: 'b',
+          colorConfig: {
+            materials: Array.from({ length: 9 }, (_, i) => ({ color: colorAt(i + 100) })),
             triangleMaterialIndices: [0],
           },
         },
       ];
-      expect(() => build3MFMultiObjectBuffer(objects, { name: 'multi' })).toThrow(
-        /must share the same materials array/
-      );
+      expect(() => build3MFMultiObjectBuffer(objects, { name: 'multi' })).toThrow(/filament cap/);
     });
 
     it('multi-object: omits project_settings.config when no object has a colorConfig', () => {

--- a/src/features/generation/export/threemfExporter.ts
+++ b/src/features/generation/export/threemfExporter.ts
@@ -4,7 +4,7 @@ import { deduplicateVertices } from './threemfGeometry';
 import {
   buildModelSettingsConfig,
   buildProjectSettingsConfig,
-  unifiedPalette,
+  unifyColorConfigs,
 } from './threemfColor';
 import { buildModelXML, buildMultiObjectModelXML } from './threemfXml';
 import { packageFiles, THREEMF_MIME, toArrayBuffer } from './threemfPackage';
@@ -43,18 +43,18 @@ export function build3MFMultiObjectBuffer(
     validateMeshData(obj.vertices, obj.normals);
   }
 
-  const meshes = objects.map((obj) => ({
+  const unified = unifyColorConfigs(objects.map((obj) => obj.colorConfig));
+  const meshes = objects.map((obj, i) => ({
     mesh: deduplicateVertices(obj.vertices),
     name: obj.name,
-    colorConfig: obj.colorConfig,
+    colorConfig: unified.configs[i],
     placement: obj.placement,
   }));
 
-  const palette = unifiedPalette(meshes.map((m) => m.colorConfig));
   return packageFiles(
     buildMultiObjectModelXML(meshes, options),
     options.thumbnail,
-    palette && buildProjectSettingsConfig(palette),
+    unified.palette && buildProjectSettingsConfig(unified.palette),
     buildModelSettingsConfig(meshes)
   );
 }
@@ -66,7 +66,7 @@ export function build3MFBuffer(
 ): Uint8Array {
   validateMeshData(vertices, normals);
   const mesh = deduplicateVertices(vertices);
-  const palette = unifiedPalette([options.colorConfig]);
+  const { palette } = unifyColorConfigs([options.colorConfig]);
   return packageFiles(
     buildModelXML(mesh, options),
     options.thumbnail,


### PR DESCRIPTION
## Problem

Exporting a slicer project file that bundles objects with different color palettes threw `3MF multi-object: all colored objects must share the same materials array` instead of producing a file. A layout containing two bin designs with different zone colors hits this on every export attempt.

## Fix

`unifiedPalette` (which enforced the same-materials invariant) is now `unifyColorConfigs`: when palettes differ, it merges the distinct colors into one `filament_colour` list (first-seen order, shared colors deduped onto one filament) and remaps each object's per-triangle slot indices into the merged space. Paint codes and the per-object base extruder in `model_settings.config` are derived from the remapped configs, so all three coupled color mechanisms stay aligned.

Identical palettes take a no-remap fast path that is byte-identical to previous output. The only remaining throw is a merged union past the 16-filament slicer cap, which no remapping can represent.

## Verification

- New tests: palette merge + paint-code remap, merged-space extruder assignment, cross-object filament-cap throw. Full export suite, bin-designer download helpers, and layoutExport suites pass; `pnpm run typecheck` clean.
- A merged-palette multi-object 3MF generated through the real exporter parses cleanly in PrusaSlicer 2.9.6 (both objects load, manifold), which reads the same `paint_color` attribute. The Bambu/Orca flatpak CLIs on this machine wouldn't complete a headless load (silent no-op / profile-resolution dead end), so no CLI slice check there; the file introduces no new XML/JSON constructs beyond what those CLIs already accepted, only different values in them. Artifact left at `~/.cache/gflt-slicer-check/merged-palette.3mf` for a GUI spot-check.

Fixes #3980

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

