### PR TITLE
feat(bin-designer): give the Style page a section spine

### DIFF
--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -131,6 +131,7 @@
     "binDesigner.slotVertical",
     "binDesigner.sortName",
     "binDesigner.splitPinDiameter",
+    "binDesigner.style.section.color",
     "binDesigner.tabDimensionsGroup",
     "binDesigner.tabSupport",
     "binDesigner.tagManager.colorLabel",

--- a/src/features/bin-designer/components/panel/BaseSection/FloorPatternSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/FloorPatternSection.tsx
@@ -10,7 +10,7 @@ import { SliderInput } from '@/design-system';
 import { FLOOR_PATTERN_TYPES } from '@/features/bin-designer/types';
 import { useTranslation } from '@/i18n';
 import { FeatureToggle } from '../FeatureToggle';
-import { Hint } from '../shared';
+import { Hint, SubHeader } from '../shared';
 import { PatternSelector } from '../WallsSection/PatternSelector';
 import { UnavailableFamily } from './BaseSection';
 import { useBaseSection } from './useBaseSection';
@@ -30,37 +30,40 @@ export function FloorPatternSection() {
   if (!state.showFloor) return null;
 
   return (
-    <FeatureToggle
-      label={t('binDesigner.base.floorPattern')}
-      checked={state.floorPatternEnabled}
-      onChange={handlers.toggleFloorPattern}
-      disabledReason={handlers.floorPatternDisabledReason}
-      primaryControls={
-        <>
-          <PatternSelector
-            id="floor-pattern-selector"
-            labelKey="binDesigner.base.floorPattern.shape"
-            patterns={FLOOR_PATTERN_TYPES}
-            selectedPattern={state.floorPatternType}
-            onChange={handlers.setFloorPatternType}
-          />
-          <SliderInput
-            label={t('binDesigner.walls.pattern.scale')}
-            value={state.floorPatternScalePercent}
-            onChange={handlers.setFloorPatternScale}
-            min={0}
-            max={100}
-            step={5}
-            unit="%"
-            info={t('binDesigner.walls.pattern.scaleHint')}
-          />
-          <Hint>
-            {state.floorPatternDoesNotFit
-              ? t('binDesigner.base.floorPattern.tooSmall')
-              : t('binDesigner.base.floorPattern.hint')}
-          </Hint>
-        </>
-      }
-    />
+    <div className="space-y-2">
+      <SubHeader>{t('binDesigner.base.section.floor')}</SubHeader>
+      <FeatureToggle
+        label={t('binDesigner.base.floorPattern')}
+        checked={state.floorPatternEnabled}
+        onChange={handlers.toggleFloorPattern}
+        disabledReason={handlers.floorPatternDisabledReason}
+        primaryControls={
+          <>
+            <PatternSelector
+              id="floor-pattern-selector"
+              labelKey="binDesigner.base.floorPattern.shape"
+              patterns={FLOOR_PATTERN_TYPES}
+              selectedPattern={state.floorPatternType}
+              onChange={handlers.setFloorPatternType}
+            />
+            <SliderInput
+              label={t('binDesigner.walls.pattern.scale')}
+              value={state.floorPatternScalePercent}
+              onChange={handlers.setFloorPatternScale}
+              min={0}
+              max={100}
+              step={5}
+              unit="%"
+              info={t('binDesigner.walls.pattern.scaleHint')}
+            />
+            <Hint>
+              {state.floorPatternDoesNotFit
+                ? t('binDesigner.base.floorPattern.tooSmall')
+                : t('binDesigner.base.floorPattern.hint')}
+            </Hint>
+          </>
+        }
+      />
+    </div>
   );
 }

--- a/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/ColorsSection.tsx
@@ -36,6 +36,7 @@ import { IconButton } from '@/design-system';
 import { SEGMENT_ACTIVE, SEGMENT_INACTIVE } from '@/shared/components/segmentedControlClasses';
 import { useSwapZoneWithToast } from '@/features/bin-designer/hooks/useSwapZoneWithToast';
 import { FeatureToggle } from '../FeatureToggle';
+import { SubHeader } from '../shared';
 import { ExperimentalBadge } from '@/shared/components/ExperimentalBadge';
 import { ColorZoneRow } from './ColorZoneRow';
 import { ColorGroup } from './ColorGroup';
@@ -340,6 +341,7 @@ export function ColorsSection() {
 
   return (
     <div className="space-y-2">
+      <SubHeader>{t('binDesigner.style.section.color')}</SubHeader>
       <FeatureToggle
         label={t('binDesigner.group.colors')}
         checked={multiColorEnabled}

--- a/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.test.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.test.tsx
@@ -42,10 +42,8 @@ describe('LipColorEditor', () => {
       screen.queryByRole('radiogroup', { name: 'binDesigner.colors.lip.cornersLabel' })
     ).toBeNull();
     expect(
-      screen.getByRole<HTMLInputElement>('checkbox', {
-        name: 'binDesigner.colors.lip.splitZones',
-      }).checked
-    ).toBe(false);
+      screen.getByRole('checkbox', { name: 'binDesigner.colors.lip.splitZones' })
+    ).not.toBeChecked();
   });
 
   it('reveals the Corners/Bands grid when split is enabled', () => {
@@ -82,10 +80,8 @@ describe('LipColorEditor', () => {
     ).toBeDefined();
     expect(screen.getAllByText(/binDesigner\.colors\.lip\.bandN/)).toHaveLength(4);
     expect(
-      screen.getByRole<HTMLInputElement>('checkbox', {
-        name: 'binDesigner.colors.lip.splitZones',
-      }).checked
-    ).toBe(true);
+      screen.getByRole('checkbox', { name: 'binDesigner.colors.lip.splitZones' })
+    ).toBeChecked();
   });
 
   it('collapsing the split resets the lip to a single color', () => {

--- a/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.tsx
+++ b/src/features/bin-designer/components/panel/ColorsSection/LipColorEditor.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useState } from 'react';
-import { Checkbox } from '@/design-system';
+import { CheckboxRow } from '@/design-system';
 import { SegmentedControl } from '@/design-system/SegmentedControl/SegmentedControl';
 import { useTranslation } from '@/i18n';
 import {
@@ -174,12 +174,7 @@ export function LipColorEditor({
         })}
       </div>
 
-      {/* Checkbox supplies its own <label htmlFor>; wrapping it in another
-          <label> nests labels and makes the visually-hidden input the labeled
-          control, which scrolls the panel to its bottom on click. */}
-      <Checkbox
-        size="sm"
-        className="w-fit"
+      <CheckboxRow
         checked={showGrid}
         onChange={handleToggleSplit}
         label={t('binDesigner.colors.lip.splitZones')}

--- a/src/features/bin-designer/components/panel/WallsSection/WallSurfaceSection.tsx
+++ b/src/features/bin-designer/components/panel/WallsSection/WallSurfaceSection.tsx
@@ -11,7 +11,7 @@ import { PatternSelector } from './PatternSelector';
 import { FeatureToggle } from '../FeatureToggle';
 import { CompartmentTextInput } from '../LabelTabsSection/CompartmentTextInput';
 import { AnchorPicker } from '../../controls/AnchorPicker';
-import { SideSelector, type SideState } from '../shared';
+import { SideSelector, SubHeader, type SideState } from '../shared';
 
 /** Mode options for the wall-text picker, in the shared textMode order. */
 const TEXT_MODE_OPTIONS: readonly TextMode[] = ['engrave', 'emboss', 'through-cut'] as const;
@@ -34,6 +34,7 @@ export function WallSurfaceSection() {
 
   return (
     <div className="space-y-4">
+      <SubHeader>{t('binDesigner.style.section.walls')}</SubHeader>
       <div>
         <PatternSelector
           selectedPattern={state.patternEnabled ? state.pattern : null}
@@ -68,7 +69,7 @@ export function WallSurfaceSection() {
               </p>
             ) : (
               <div className="mt-3">
-                <span className="mb-1 block text-xs text-content-secondary">
+                <span className="mb-1 block text-label text-content-tertiary">
                   {t('binDesigner.walls.pattern.sides')}
                 </span>
                 <SideSelector

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Kulatý",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Barva",
+  "binDesigner.style.section.walls": "Stěny",
   "binDesigner.walls.pattern.scale": "Měřítko vzoru",
   "binDesigner.walls.pattern.scaleHint": "Jemnější otvory doleva, výraznější doprava",
   "binDesigner.walls.pattern.sides": "Vzorované stěny",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Rund",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Farbe",
+  "binDesigner.style.section.walls": "Wände",
   "binDesigner.walls.pattern.scale": "Mustergröße",
   "binDesigner.walls.pattern.scaleHint": "Feinere Löcher links, gröbere rechts",
   "binDesigner.walls.pattern.sides": "Gemusterte Wände",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3103,6 +3103,8 @@ const en: Record<string, string> = {
   'binDesigner.walls.pattern.mikado': 'Mikado (帝つなぎ)',
   'binDesigner.walls.pattern.tsumiishiKikko': 'Tsumiishi-Kikko (積石亀甲)',
   'binDesigner.walls.pattern.groupKumiko': 'Kumiko',
+  'binDesigner.style.section.color': 'Color',
+  'binDesigner.style.section.walls': 'Walls',
   'binDesigner.walls.pattern.scale': 'Pattern scale',
   'binDesigner.walls.pattern.scaleHint': 'Finer holes to the left, bolder to the right',
   'binDesigner.walls.pattern.allSlotted': 'All walls have divider slots',

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Redondo",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Color",
+  "binDesigner.style.section.walls": "Paredes",
   "binDesigner.walls.pattern.scale": "Escala del patrón",
   "binDesigner.walls.pattern.scaleHint": "Agujeros más finos a la izquierda, más grandes a la derecha",
   "binDesigner.walls.pattern.sides": "Paredes con patrón",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Rond",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Couleur",
+  "binDesigner.style.section.walls": "Parois",
   "binDesigner.walls.pattern.scale": "Échelle du motif",
   "binDesigner.walls.pattern.scaleHint": "Trous plus fins à gauche, plus grands à droite",
   "binDesigner.walls.pattern.sides": "Parois à motif",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Tondo",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Colore",
+  "binDesigner.style.section.walls": "Pareti",
   "binDesigner.walls.pattern.scale": "Scala del motivo",
   "binDesigner.walls.pattern.scaleHint": "Fori più fini a sinistra, più grandi a destra",
   "binDesigner.walls.pattern.sides": "Pareti con motivo",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "竜胆",
   "binDesigner.walls.pattern.round": "円形",
   "binDesigner.walls.pattern.sakura": "桜",
+  "binDesigner.style.section.color": "色",
+  "binDesigner.style.section.walls": "壁面",
   "binDesigner.walls.pattern.scale": "パターンの大きさ",
   "binDesigner.walls.pattern.scaleHint": "左ほど細かく、右ほど大きく",
   "binDesigner.walls.pattern.sides": "パターンを適用する壁",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "원형",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "색상",
+  "binDesigner.style.section.walls": "벽면",
   "binDesigner.walls.pattern.scale": "패턴 크기",
   "binDesigner.walls.pattern.scaleHint": "왼쪽으로 갈수록 촘촘한 구멍, 오른쪽으로 갈수록 큰 구멍",
   "binDesigner.walls.pattern.sides": "패턴 적용 벽",

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Rund",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Farge",
+  "binDesigner.style.section.walls": "Vegger",
   "binDesigner.walls.pattern.scale": "Mønsterskala",
   "binDesigner.walls.pattern.scaleHint": "Finere hull til venstre, grovere til høyre",
   "binDesigner.walls.pattern.sides": "Vegger med mønster",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Rond",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Kleur",
+  "binDesigner.style.section.walls": "Wanden",
   "binDesigner.walls.pattern.scale": "Patroonschaal",
   "binDesigner.walls.pattern.scaleHint": "Fijnere gaten links, grover rechts",
   "binDesigner.walls.pattern.sides": "Wanden met patroon",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Okrągły",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Kolor",
+  "binDesigner.style.section.walls": "Ścianki",
   "binDesigner.walls.pattern.scale": "Skala wzoru",
   "binDesigner.walls.pattern.scaleHint": "Drobniejsze otwory po lewej, śmielsze po prawej",
   "binDesigner.walls.pattern.sides": "Ścianki ze wzorem",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Redondo",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Cor",
+  "binDesigner.style.section.walls": "Paredes",
   "binDesigner.walls.pattern.scale": "Escala do padrão",
   "binDesigner.walls.pattern.scaleHint": "Furos mais finos à esquerda, maiores à direita",
   "binDesigner.walls.pattern.sides": "Paredes com padrão",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "Rund",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "Färg",
+  "binDesigner.style.section.walls": "Väggar",
   "binDesigner.walls.pattern.scale": "Mönsterskala",
   "binDesigner.walls.pattern.scaleHint": "Finare hål till vänster, grövre till höger",
   "binDesigner.walls.pattern.sides": "Väggar med mönster",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Ріндо (竜胆)",
   "binDesigner.walls.pattern.round": "Круглий",
   "binDesigner.walls.pattern.sakura": "Сакура (桜)",
+  "binDesigner.style.section.color": "Колір",
+  "binDesigner.style.section.walls": "Стінки",
   "binDesigner.walls.pattern.scale": "Масштаб візерунка",
   "binDesigner.walls.pattern.scaleHint": "Дрібніші отвори ліворуч, більші праворуч",
   "binDesigner.walls.pattern.sides": "Стіни з візерунком",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1936,6 +1936,8 @@
   "binDesigner.walls.pattern.rindo": "Rindo (竜胆)",
   "binDesigner.walls.pattern.round": "圆形",
   "binDesigner.walls.pattern.sakura": "Sakura (桜)",
+  "binDesigner.style.section.color": "颜色",
+  "binDesigner.style.section.walls": "壁面",
   "binDesigner.walls.pattern.scale": "图案比例",
   "binDesigner.walls.pattern.scaleHint": "越往左孔越细，越往右越粗",
   "binDesigner.walls.pattern.sides": "应用图案的壁",


### PR DESCRIPTION
The Style page stacked Typography, Multi-Color, Wall pattern, Wall text and Drainage holes with no internal structure ("a grab bag", per the audit). The four families now carry the panel's one SubHeader idiom, so the page scans as **TYPOGRAPHY / COLOR / WALLS / FLOOR**.

- ColorsSection, WallSurfaceSection and FloorPatternSection each open with a SubHeader (Typography brought its own in #3997).
- The lip's "Split into color zones" checkbox becomes a `CheckboxRow`, joining the page's label-left/control-right rows instead of being its one box-first checkbox.
- The pattern-sides caption joins the `text-label` caption idiom.
- Two new keys (`binDesigner.style.section.color`/`walls`) translated in all locales; Spanish "Color" allowlisted as an intentional identity.

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/3998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

