### PR TITLE
feat(bin-designer): shared joint primitives, SegmentGrid hardening, Workshop button move

### DIFF
--- a/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListDialog.tsx
@@ -36,6 +36,8 @@ import { groupByLineage, branchesOf } from './designLineage';
 import type { SortOption } from './designListSort';
 import { removeRegistryEntry } from '../../store/customBinRegistry';
 import { useDesignerStore } from '../../store';
+import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
+import type { ItemKind } from '@/shared/types/item';
 import { useDesignerRouting } from '@/shared/hooks/useDesignerRouting';
 import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
 import { useToastStore } from '@/core/store/toast';
@@ -107,6 +109,7 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
 
   const loadDesign = useDesignerStore((s) => s.loadDesign);
   const newDesign = useDesignerStore((s) => s.newDesign);
+  const workshopEnabled = useFeatureFlag('workshop');
   const currentDesignId = useDesignerStore((s) => s.currentDesignId);
   const { navigateToDesign, syncUrlToDesign } = useDesignerRouting();
   const addToast = useToastStore((s) => s.addToast);
@@ -243,25 +246,36 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
   );
 
   const [showNewDesignConfirm, setShowNewDesignConfirm] = useState(false);
+  // Which kind the pending confirm dialog will create; the confirm is the same
+  // unsaved-changes gate for a bin and a workshop, so the kind rides state.
+  const [pendingNewKind, setPendingNewKind] = useState<ItemKind>('bin');
 
-  const handleNewDesign = useCallback(() => {
-    const state = useDesignerStore.getState();
-    if (state.currentDesignId && state.history.past.length > 0) {
-      setShowNewDesignConfirm(true);
-      return;
-    }
-    newDesign();
-    syncUrlToDesign(null);
-    addToast({ message: t('binDesigner.newDesignCreated'), type: 'success', duration: 2000 });
-    onClose();
-  }, [newDesign, syncUrlToDesign, addToast, onClose, t]);
+  const createNewDesign = useCallback(
+    (kind: ItemKind) => {
+      newDesign(kind === 'bin' ? undefined : kind);
+      syncUrlToDesign(null);
+      addToast({ message: t('binDesigner.newDesignCreated'), type: 'success', duration: 2000 });
+      onClose();
+    },
+    [newDesign, syncUrlToDesign, addToast, onClose, t]
+  );
+
+  const handleNewDesign = useCallback(
+    (kind: ItemKind = 'bin') => {
+      const state = useDesignerStore.getState();
+      if (state.currentDesignId && state.history.past.length > 0) {
+        setPendingNewKind(kind);
+        setShowNewDesignConfirm(true);
+        return;
+      }
+      createNewDesign(kind);
+    },
+    [createNewDesign]
+  );
 
   const handleConfirmNewDesign = useCallback(() => {
-    newDesign();
-    syncUrlToDesign(null);
-    addToast({ message: t('binDesigner.newDesignCreated'), type: 'success', duration: 2000 });
-    onClose();
-  }, [newDesign, syncUrlToDesign, addToast, onClose, t]);
+    createNewDesign(pendingNewKind);
+  }, [createNewDesign, pendingNewKind]);
 
   const handleOpenOptionsMenu = useCallback((e: ReactMouseEvent<HTMLButtonElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -608,6 +622,7 @@ export function DesignListDialog({ open, onClose }: DesignListDialogProps) {
           onEnterSelect={() => selection.enter()}
           onShowImport={() => setShowImport(true)}
           onNewDesign={handleNewDesign}
+          showWorkshopButton={workshopEnabled}
           onOpenOptionsMenu={handleOpenOptionsMenu}
           onClose={onClose}
         />

--- a/src/features/bin-designer/components/DesignListDialog/DesignListHeader.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListHeader.test.tsx
@@ -14,6 +14,7 @@ function setup(overrides?: {
     onNewDesign: vi.fn(),
     onOpenOptionsMenu: vi.fn(),
     onClose: vi.fn(),
+    showWorkshopButton: false,
   };
   render(
     <DesignListHeader

--- a/src/features/bin-designer/components/DesignListDialog/DesignListHeader.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListHeader.tsx
@@ -1,4 +1,5 @@
 import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { ItemKind } from '@/shared/types/item';
 import { useTranslation } from '@/i18n';
 import { Button, IconButton, XIcon } from '@/design-system';
 
@@ -8,7 +9,8 @@ interface DesignListHeaderProps {
   customDefaultActive: boolean;
   onEnterSelect: () => void;
   onShowImport: () => void;
-  onNewDesign: () => void;
+  onNewDesign: (kind?: ItemKind) => void;
+  showWorkshopButton: boolean;
   onOpenOptionsMenu: (e: ReactMouseEvent<HTMLButtonElement>) => void;
   onClose: () => void;
 }
@@ -21,6 +23,7 @@ export function DesignListHeader({
   onEnterSelect,
   onShowImport,
   onNewDesign,
+  showWorkshopButton,
   onOpenOptionsMenu,
   onClose,
 }: DesignListHeaderProps) {
@@ -46,9 +49,18 @@ export function DesignListHeader({
         >
           {t('common.import')}
         </Button>
+        {showWorkshopButton && (
+          <Button
+            variant="secondary"
+            onClick={() => onNewDesign('assembly')}
+            className="rounded-md px-3 py-1.5 text-sm font-medium"
+          >
+            {t('binDesigner.newWorkshop')}
+          </Button>
+        )}
         <Button
           variant="primary"
-          onClick={onNewDesign}
+          onClick={() => onNewDesign()}
           className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
         >
           {t('binDesigner.newDesign')}

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -48,7 +48,6 @@ import { useTranslation } from '@/i18n';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { useBinExampleGalleryStore } from '@/core/store/binExampleGallery';
 import { useCommunityDigestStore } from '@/core/store/communityDigest';
-import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import { useSplitOptionsSection } from '../panel/SplitOptionsSection/useSplitOptionsSection';
 import { UserDock } from '@/shared/components/UserDock';
 import { AttributionFooter } from '@/shared/components/AttributionFooter';
@@ -116,8 +115,6 @@ function BinParameterPanel({ frame }: { readonly frame: 'docked' | 'plain' }) {
   const { needsSplit } = useSplitOptionsSection();
   const openExampleGallery = useBinExampleGalleryStore((s) => s.open);
   const hasUnseenDigest = useCommunityDigestStore((s) => s.hasUnseenDeltas);
-  const workshopEnabled = useFeatureFlag('workshop');
-  const newDesign = useDesignerStore((s) => s.newDesign);
   const currentDesignId = useDesignerStore((s) => s.currentDesignId);
   const loadDesignIntoStore = useDesignerStore((s) => s.loadDesign);
   const variant = useVariantContext(currentDesignId);
@@ -256,14 +253,6 @@ function BinParameterPanel({ frame }: { readonly frame: 'docked' | 'plain' }) {
           onDetach={handleDetach}
           onClearOrphans={handleClearOrphans}
         />
-      )}
-
-      {workshopEnabled && (
-        <div className="border-b border-stroke-subtle px-4 py-3">
-          <Button variant="secondary" onClick={() => newDesign('assembly')} className="w-full">
-            {t('binDesigner.newWorkshop')}
-          </Button>
-        </div>
       )}
     </div>
   );

--- a/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
+++ b/src/features/bin-designer/components/panel/BaseSection/BaseSection.tsx
@@ -22,7 +22,7 @@
 import { DESIGNER_CONSTRAINTS } from '@/features/bin-designer/constants';
 import { Button, SegmentedControl, SliderInput } from '@/design-system';
 import { FeatureToggle } from '../FeatureToggle';
-import { Hint, SubHeader } from '../shared';
+import { Hint, SegmentGrid, SideSelector, SubHeader } from '../shared';
 import {
   DEFAULT_FOOT_LATTICE,
   FOOT_LATTICES,
@@ -84,11 +84,8 @@ export function BaseSection() {
     <div className="space-y-3">
       <Hint>{t('binDesigner.lidBottom.hint')}</Hint>
 
-      <SegmentedControl
+      <SegmentGrid
         aria-label={t('binDesigner.lid.attachment')}
-        activeStyle="accent"
-        fullWidth
-        size="sm"
         value={state.trayBottom.attachment}
         onChange={handlers.setTrayAttachment}
         options={LID_ATTACHMENTS.map((mode) => ({
@@ -109,22 +106,18 @@ export function BaseSection() {
 
       {state.trayBottom.attachment === 'clickRails' && (
         <div>
-          <span className="mb-1 block text-xs font-medium text-content-secondary">
+          <span className="mb-1 block text-label text-content-tertiary">
             {t('binDesigner.lid.clickRails')}
           </span>
-          <div className="flex gap-1">
-            {LID_RAIL_SIDES.map((side) => (
-              <Button
-                key={side}
-                size="sm"
-                variant={state.trayBottom.clickRails[side] ? 'primary' : 'secondary'}
-                aria-pressed={state.trayBottom.clickRails[side]}
-                onClick={() => handlers.toggleTrayRail(side)}
-              >
-                {t(`binDesigner.lid.side.${side}`)}
-              </Button>
-            ))}
-          </div>
+          <SideSelector
+            sides={LID_RAIL_SIDES.map((side) => ({
+              side,
+              label: t(`binDesigner.lid.side.${side}`),
+              active: state.trayBottom.clickRails[side],
+            }))}
+            onToggle={handlers.toggleTrayRail}
+            ariaLabel={t('binDesigner.lid.clickRails')}
+          />
         </div>
       )}
     </div>

--- a/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
+++ b/src/features/bin-designer/components/panel/LidSection/LidSection.tsx
@@ -23,7 +23,16 @@ import { LidGripControls } from '../LidGripControls';
 import { SlideControls } from '../SlideControls';
 import { HingeControls } from '../HingeControls';
 import { StepperField } from '../shared/StepperField';
-import { Hint, Readout, SubHeader, DependencyHint, SegmentGrid, InfoDot } from '../shared';
+import {
+  Hint,
+  Readout,
+  SubHeader,
+  DependencyHint,
+  SegmentGrid,
+  InfoDot,
+  SideSelector,
+} from '../shared';
+import type { SideState } from '../shared';
 import type {
   LidCompatibilityId,
   LidCompatibilityIssue,
@@ -87,11 +96,10 @@ function CompatibilityIssue({
   );
 }
 
-/** Per-side click-rail toggles. Multi-select (each wall independent), so this
- *  stays a hand-rolled switch group rather than the single-select
- *  SegmentedControl primitive. A side auto-disables when a feature conflict
- *  (label tab, wall cutout, intruding handle) affects it; the user's persisted
- *  intent is kept so the rail returns once the conflict is resolved. */
+/** Per-side click-rail toggles. Multi-select (each wall independent). A side
+ *  auto-disables when a feature conflict (label tab, wall cutout, intruding
+ *  handle) affects it; the user's persisted intent is kept so the rail returns
+ *  once the conflict is resolved. */
 function RailSides({
   state,
   onToggle,
@@ -101,45 +109,26 @@ function RailSides({
   onToggle: (side: (typeof LID_RAIL_SIDES)[number]) => void;
   t: Translator;
 }) {
+  const sides: SideState[] = LID_RAIL_SIDES.map((side) => {
+    const isAutoDisabled = state.disabledRails.has(side);
+    return {
+      side,
+      label: t(`binDesigner.lid.side.${side}`),
+      active: state.clickRails[side],
+      disabled: isAutoDisabled,
+      title: isAutoDisabled
+        ? t('binDesigner.lid.clickRailDisabledBySide', {
+            side: t(`binDesigner.lid.side.${side}`),
+          })
+        : undefined,
+    };
+  });
   return (
     <div>
-      <span className="mb-1 block text-xs font-medium text-content-secondary">
+      <span className="mb-1 block text-label text-content-tertiary">
         {t('binDesigner.lid.clickRails')}
       </span>
-      <div className="flex gap-1">
-        {LID_RAIL_SIDES.map((side) => {
-          const isActive = state.clickRails[side];
-          const isAutoDisabled = state.disabledRails.has(side);
-          const effectiveActive = isActive && !isAutoDisabled;
-          const tooltip = isAutoDisabled
-            ? t('binDesigner.lid.clickRailDisabledBySide', {
-                side: t(`binDesigner.lid.side.${side}`),
-              })
-            : undefined;
-          return (
-            <Button
-              key={side}
-              type="button"
-              variant="ghost"
-              role="switch"
-              aria-checked={effectiveActive}
-              aria-disabled={isAutoDisabled}
-              disabled={isAutoDisabled}
-              title={tooltip}
-              onClick={() => onToggle(side)}
-              className={`flex-1 rounded px-2 py-1 text-xs font-medium transition-colors ${
-                isAutoDisabled
-                  ? 'cursor-not-allowed border border-stroke-subtle bg-surface-secondary text-content-tertiary line-through opacity-60'
-                  : effectiveActive
-                    ? 'bg-accent text-on-accent hover:bg-accent hover:text-on-accent'
-                    : 'border border-stroke-subtle bg-surface-elevated text-content-secondary hover:bg-surface-hover'
-              }`}
-            >
-              {t(`binDesigner.lid.side.${side}`)}
-            </Button>
-          );
-        })}
-      </div>
+      <SideSelector sides={sides} onToggle={onToggle} ariaLabel={t('binDesigner.lid.clickRails')} />
     </div>
   );
 }

--- a/src/features/bin-designer/components/panel/shared/InfoDot.tsx
+++ b/src/features/bin-designer/components/panel/shared/InfoDot.tsx
@@ -1,8 +1,8 @@
 /**
- * Explanatory prose behind a small info button, for paragraphs that earn their
- * words but not their permanent panel height. The affordance the angled
- * dividers header already carries, extracted so every section reaches for the
- * same one.
+ * For prose that earns its words but not permanent panel height. Only
+ * evergreen explanations belong here: state-dependent messages (blocked
+ * reasons, warnings) must stay visible inline, or the state they report
+ * becomes invisible.
  */
 
 import { useRef, useState } from 'react';

--- a/src/features/bin-designer/components/panel/shared/SegmentGrid.test.tsx
+++ b/src/features/bin-designer/components/panel/shared/SegmentGrid.test.tsx
@@ -10,17 +10,35 @@ const OPTIONS = [
 ] as const;
 
 describe('SegmentGrid', () => {
-  it('marks only the current value as pressed', () => {
+  it('marks only the current value as checked', () => {
     render(<SegmentGrid aria-label="Pick" value="b" onChange={() => {}} options={OPTIONS} />);
     expect(screen.getByRole('radio', { name: 'Alpha' })).toHaveAttribute('aria-checked', 'false');
     expect(screen.getByRole('radio', { name: 'Beta' })).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('reports the picked value and respects disabled options', async () => {
+  it('reports a newly picked value and respects disabled options', async () => {
+    const onChange = vi.fn();
+    render(<SegmentGrid aria-label="Pick" value="a" onChange={onChange} options={OPTIONS} />);
+    await userEvent.click(screen.getByRole('radio', { name: 'Beta' }));
+    expect(onChange).toHaveBeenCalledWith('b');
+    expect(screen.getByRole('radio', { name: 'Gamma' })).toBeDisabled();
+  });
+
+  it('treats re-picking the current option as a no-op', async () => {
     const onChange = vi.fn();
     render(<SegmentGrid aria-label="Pick" value="a" onChange={onChange} options={OPTIONS} />);
     await userEvent.click(screen.getByRole('radio', { name: 'Alpha' }));
-    expect(onChange).toHaveBeenCalledWith('a');
-    expect(screen.getByRole('radio', { name: 'Gamma' })).toBeDisabled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('moves selection with arrows and Home/End, skipping disabled options', async () => {
+    const onChange = vi.fn();
+    render(<SegmentGrid aria-label="Pick" value="a" onChange={onChange} options={OPTIONS} />);
+    const alpha = screen.getByRole('radio', { name: 'Alpha' });
+    alpha.focus();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith('b');
+    await userEvent.keyboard('{End}');
+    expect(onChange).toHaveBeenLastCalledWith('b');
   });
 });

--- a/src/features/bin-designer/components/panel/shared/SegmentGrid.tsx
+++ b/src/features/bin-designer/components/panel/shared/SegmentGrid.tsx
@@ -5,13 +5,16 @@
  * shape and the rows aligned.
  *
  * Carries the same radio semantics as SegmentedControl (radiogroup, roving
- * tabindex, arrow keys move the selection) so swapping one for the other is
- * invisible to assistive tech and tests.
+ * tabindex, arrow keys and Home/End move selection and focus) so swapping one
+ * for the other is invisible to assistive tech and tests. Re-picking the
+ * current option is a no-op: consumers wire straight into store actions that
+ * push history entries, so a redundant onChange is a redundant undo step.
  */
 
+import { useRef } from 'react';
 import type { KeyboardEvent } from 'react';
 import { Button } from '@/design-system';
-import { getSegmentClass, SEGMENT_GROUP_CLASS } from '@/shared/components/segmentedControlClasses';
+import { getSegmentClass } from '@/shared/components/segmentedControlClasses';
 import { cn } from '@/design-system/cn';
 
 export interface SegmentGridOption<T extends string> {
@@ -36,36 +39,62 @@ export function SegmentGrid<T extends string>({
   options,
   columns = 2,
 }: SegmentGridProps<T>) {
+  const buttonRefs = useRef(new Map<T, HTMLButtonElement>());
   const enabled = options.filter((o) => !o.disabled);
 
+  const pick = (next: T) => {
+    if (next === value) return;
+    onChange(next);
+    buttonRefs.current.get(next)?.focus();
+  };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    const delta =
-      event.key === 'ArrowRight' || event.key === 'ArrowDown'
-        ? 1
-        : event.key === 'ArrowLeft' || event.key === 'ArrowUp'
-          ? -1
-          : 0;
-    if (delta === 0 || enabled.length === 0) return;
-    event.preventDefault();
+    if (enabled.length === 0) return;
     const index = Math.max(
       0,
       enabled.findIndex((o) => o.value === value)
     );
-    const next = enabled[(index + delta + enabled.length) % enabled.length];
-    onChange(next.value);
+    let next: T;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        next = enabled[(index + 1) % enabled.length].value;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        next = enabled[(index - 1 + enabled.length) % enabled.length].value;
+        break;
+      case 'Home':
+        next = enabled[0].value;
+        break;
+      case 'End':
+        next = enabled[enabled.length - 1].value;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    pick(next);
   };
 
   return (
     <div
       role="radiogroup"
       aria-label={ariaLabel}
-      className={cn(SEGMENT_GROUP_CLASS, 'grid', columns === 3 ? 'grid-cols-3' : 'grid-cols-2')}
+      className={cn(
+        'grid gap-0.5 rounded-lg border border-stroke-subtle bg-surface p-0.5',
+        columns === 3 ? 'grid-cols-3' : 'grid-cols-2'
+      )}
     >
       {options.map((option) => {
         const selected = value === option.value;
         return (
           <Button
             key={option.value}
+            ref={(el) => {
+              if (el) buttonRefs.current.set(option.value, el);
+              else buttonRefs.current.delete(option.value);
+            }}
             type="button"
             variant="ghost"
             touchTarget={false}
@@ -75,7 +104,7 @@ export function SegmentGrid<T extends string>({
             disabled={option.disabled}
             title={option.title}
             onKeyDown={handleKeyDown}
-            onClick={() => onChange(option.value)}
+            onClick={() => pick(option.value)}
             className={getSegmentClass(selected)}
           >
             {option.label}


### PR DESCRIPTION
Three owed items from the overhaul plan and the audit's review follow-ups.

- **Tray/lid dedup (B3b), at primitive altitude**: the tray body type and the lid render the same joint but had drifted apart — flat rail rows in two different hand-rolled button styles, one attachment picker a ragged five-option SegmentedControl wrap. Both now render through the shared spatial `SideSelector` (the lid keeps its auto-disable reasons as per-side disabled state + tooltips) and `SegmentGrid`.
- **SegmentGrid hardening** (review follow-ups on #3999): re-picking the current option is a no-op (consumers wire into history-pushing store actions, so a redundant `onChange` was a redundant undo step), Home/End join the arrow keys, focus follows the selection, and the grid states its own container classes instead of fighting `SEGMENT_GROUP_CLASS`'s flex.
- **Workshop button → new-design flow** (locked decision): the flag-gated "New Workshop" button leaves the panel bottom and joins New Design in the design-list header, sharing its unsaved-changes confirm (the pending kind rides the confirm state).

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

