### PR TITLE
feat(bin-designer): selection model groundwork (B4)

### DIFF
--- a/e2e/bin-designer/lid-cutout-keepouts.spec.ts
+++ b/e2e/bin-designer/lid-cutout-keepouts.spec.ts
@@ -38,7 +38,7 @@ test.describe('Lid cutout keep-outs', () => {
     await expect(canvas).toBeVisible({ timeout: 120_000 });
     await waitForGenerationComplete(page);
 
-    const lidToggle = page.getByRole('switch', { name: 'Enable lid' });
+    const lidToggle = page.getByRole('switch', { name: 'Lid' });
     await lidToggle.scrollIntoViewIfNeeded();
     await lidToggle.click();
     await expect(lidToggle).toBeChecked();

--- a/e2e/bin-designer/lid-magnetic-tray-visual.spec.ts
+++ b/e2e/bin-designer/lid-magnetic-tray-visual.spec.ts
@@ -37,7 +37,7 @@ test.describe('Lid magnetic retention + tray top (visual)', () => {
     await waitForGenerationComplete(page);
 
     // Enable the lid (default stacking lip is on). Controls appear directly.
-    const lidToggle = page.getByRole('switch', { name: 'Enable lid' });
+    const lidToggle = page.getByRole('switch', { name: 'Lid' });
     await lidToggle.scrollIntoViewIfNeeded();
     await lidToggle.click();
     await expect(lidToggle).toBeChecked();

--- a/e2e/bin-designer/lid-separate-baseplate-visual.spec.ts
+++ b/e2e/bin-designer/lid-separate-baseplate-visual.spec.ts
@@ -38,7 +38,7 @@ test.describe('Lid separate baseplate (visual)', () => {
 
     // Enable the lid (requires the default stacking lip, which is on). The
     // grouped controls render directly — no Customize step.
-    const lidToggle = page.getByRole('switch', { name: 'Enable lid' });
+    const lidToggle = page.getByRole('switch', { name: 'Lid' });
     await lidToggle.scrollIntoViewIfNeeded();
     await lidToggle.click();
     await expect(lidToggle).toBeChecked();

--- a/e2e/bin-designer/lid-stack-lip-only-visual.spec.ts
+++ b/e2e/bin-designer/lid-stack-lip-only-visual.spec.ts
@@ -40,7 +40,7 @@ test.describe('Lid stacking-lip-only top (visual)', () => {
     await width.blur();
     await waitForGenerationComplete(page);
 
-    const lidToggle = page.getByRole('switch', { name: 'Enable lid' });
+    const lidToggle = page.getByRole('switch', { name: 'Lid' });
     await lidToggle.scrollIntoViewIfNeeded();
     await lidToggle.click();
     await expect(lidToggle).toBeChecked();

--- a/src/features/bin-designer/constants/defaults.ts
+++ b/src/features/bin-designer/constants/defaults.ts
@@ -281,6 +281,8 @@ export const DEFAULT_GENERATION_STATE: GenerationState = {
 /** Default UI state */
 export const DEFAULT_UI_STATE: DesignerUIState = {
   activeCategory: 'shape',
+  selection: null,
+  returnCategory: null,
   exportDialogOpen: false,
   designListOpen: false,
   versionsOpen: false,

--- a/src/features/bin-designer/store/designer.scenario.selection.test.ts
+++ b/src/features/bin-designer/store/designer.scenario.selection.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Selection-model invariants (stage B4).
+ *
+ * The selection is plain UI state: picking, switching, and clearing must never
+ * touch the undo history or the generation epoch, and a selection orphaned by
+ * a real params mutation must read as null through the resolver rather than
+ * pointing the Selection page at a renumbered compartment.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignerStore } from '@/features/bin-designer/store/designer';
+import { resolveSelection } from '@/features/bin-designer/utils/selection';
+
+describe('DesignerStore - selection model', () => {
+  beforeEach(() => {
+    useDesignerStore.setState(useDesignerStore.getInitialState());
+  });
+
+  it('select auto-switches to the Selection page and remembers the return slot', () => {
+    const store = useDesignerStore.getState();
+    store.setActiveCategory('interior');
+    useDesignerStore.getState().select({ kind: 'compartment', id: 0 });
+
+    const { ui } = useDesignerStore.getState();
+    expect(ui.activeCategory).toBe('selection');
+    expect(ui.returnCategory).toBe('interior');
+    expect(ui.selection).toEqual({ kind: 'compartment', id: 0 });
+  });
+
+  it('re-selecting while on the Selection page keeps the original return slot', () => {
+    const store = useDesignerStore.getState();
+    store.setActiveCategory('interior');
+    useDesignerStore.getState().select({ kind: 'compartment', id: 0 });
+    useDesignerStore.getState().select({ kind: 'divider', key: '0-1' });
+
+    expect(useDesignerStore.getState().ui.returnCategory).toBe('interior');
+  });
+
+  it('clearSelection restores the return category exactly once', () => {
+    useDesignerStore.getState().setActiveCategory('interior');
+    useDesignerStore.getState().select({ kind: 'compartment', id: 0 });
+    useDesignerStore.getState().clearSelection();
+
+    const { ui } = useDesignerStore.getState();
+    expect(ui.activeCategory).toBe('interior');
+    expect(ui.selection).toBeNull();
+    expect(ui.returnCategory).toBeNull();
+  });
+
+  it('a manual rail move away deselects and drops the return slot', () => {
+    useDesignerStore.getState().select({ kind: 'compartment', id: 0 });
+    useDesignerStore.getState().setActiveCategory('style');
+
+    const { ui } = useDesignerStore.getState();
+    expect(ui.selection).toBeNull();
+    expect(ui.returnCategory).toBeNull();
+    expect(ui.activeCategory).toBe('style');
+  });
+
+  it('selection changes never touch undo history or the generation epoch', () => {
+    const before = useDesignerStore.getState();
+    const pastLen = before.history.past.length;
+    const epoch = before.generation.epoch;
+
+    useDesignerStore.getState().select({ kind: 'compartment', id: 0 });
+    useDesignerStore.getState().select({ kind: 'labelTab', compartmentId: 0 });
+    useDesignerStore.getState().clearSelection();
+
+    const after = useDesignerStore.getState();
+    expect(after.history.past.length).toBe(pastLen);
+    expect(after.generation.epoch).toBe(epoch);
+  });
+
+  it('a regrid orphans the held selection at the resolver, not at the store', () => {
+    useDesignerStore.getState().setCompartmentGrid(3, 2);
+    useDesignerStore.getState().select({ kind: 'compartment', id: 5 });
+
+    useDesignerStore.getState().setCompartmentGrid(2, 1);
+
+    const { ui, params } = useDesignerStore.getState();
+    // The raw field still holds the stale pick; validity is derived at read.
+    expect(ui.selection).toEqual({ kind: 'compartment', id: 5 });
+    expect(resolveSelection(ui.selection, params.compartments)).toBeNull();
+    expect(resolveSelection({ kind: 'compartment', id: 1 }, params.compartments)).toEqual({
+      kind: 'compartment',
+      id: 1,
+    });
+  });
+});

--- a/src/features/bin-designer/store/slices/uiSlice.ts
+++ b/src/features/bin-designer/store/slices/uiSlice.ts
@@ -10,6 +10,7 @@ import type {
   ColorTool,
   CutoutTarget,
   DesignerCategory,
+  DesignerSelection,
   PickerOverlayState,
   MeasureMode,
   SplitViewMode,
@@ -31,6 +32,33 @@ export function createUISlice(set: Set) {
     setActiveCategory: (category: DesignerCategory) => {
       set((state) => {
         state.ui.activeCategory = category;
+        // A manual rail move away from the Selection page is a deselect: the
+        // page must never linger pointed at something the user has navigated
+        // away from, and the stored return slot would otherwise go stale.
+        if (category !== 'selection') {
+          state.ui.selection = null;
+          state.ui.returnCategory = null;
+        }
+      });
+    },
+
+    select: (selection: NonNullable<DesignerSelection>) => {
+      set((state) => {
+        state.ui.selection = selection;
+        if (state.ui.activeCategory !== 'selection') {
+          state.ui.returnCategory = state.ui.activeCategory;
+          state.ui.activeCategory = 'selection';
+        }
+      });
+    },
+
+    clearSelection: () => {
+      set((state) => {
+        state.ui.selection = null;
+        if (state.ui.activeCategory === 'selection') {
+          state.ui.activeCategory = state.ui.returnCategory ?? 'interior';
+        }
+        state.ui.returnCategory = null;
       });
     },
 

--- a/src/features/bin-designer/types/designerState.ts
+++ b/src/features/bin-designer/types/designerState.ts
@@ -67,6 +67,7 @@ import type {
   MeasureMode,
   DividerTiltPreview,
   ExportFileNameConfig,
+  DesignerSelection,
 } from './uiState';
 import type { SavedDesign } from './savedDesign';
 import type { CommunityDesignLineage } from '@/shared/types/community';
@@ -405,6 +406,10 @@ export interface DesignerState {
 
   // UI actions
   setActiveCategory: (category: DesignerCategory) => void;
+  /** Point the Selection page at something; auto-switches the rail and stores the return slot. */
+  select: (selection: NonNullable<DesignerSelection>) => void;
+  /** Drop the selection and restore the category the auto-switch left. */
+  clearSelection: () => void;
   setExportDialogOpen: (open: boolean) => void;
   setDesignListOpen: (open: boolean) => void;
   setVersionsOpen: (open: boolean) => void;

--- a/src/features/bin-designer/types/uiState.ts
+++ b/src/features/bin-designer/types/uiState.ts
@@ -33,6 +33,19 @@ export type ColorTool = 'eyedropper' | 'swap-pick-first' | 'swap-pick-second' | 
 /** Rail categories of the designer panel; 'selection' is the contextual slot. */
 export type DesignerCategory = 'selection' | 'shape' | 'interior' | 'features' | 'style' | 'print';
 
+/**
+ * What the contextual Selection page is pointed at. Compartment ids renumber
+ * on every merge/split, so a held id can go stale the moment params move:
+ * consumers must read through `resolveSelection`, which nulls anything the
+ * current params no longer contain, rather than trusting the raw field.
+ * Cutout selection arrives with 3D picking (B5).
+ */
+export type DesignerSelection =
+  | { readonly kind: 'compartment'; readonly id: number }
+  | { readonly kind: 'divider'; readonly key: string }
+  | { readonly kind: 'labelTab'; readonly compartmentId: number }
+  | null;
+
 /** View mode for split bin preview: assembled (no gaps) or exploded (gaps between pieces). */
 export type SplitViewMode = 'assembled' | 'exploded';
 
@@ -62,6 +75,14 @@ export interface MeasureState {
 
 export interface DesignerUIState {
   readonly activeCategory: DesignerCategory;
+  /** Current contextual selection; plain UI state, never history-tracked. */
+  readonly selection: DesignerSelection;
+  /**
+   * Category to restore when the selection clears. Set by the auto-switch into
+   * the Selection page and consumed exactly once on deselect, so Esc lands the
+   * user back where they were instead of on an arbitrary page.
+   */
+  readonly returnCategory: DesignerCategory | null;
   readonly exportDialogOpen: boolean;
   readonly designListOpen: boolean;
   /** Whether the version-history dialog is open. */

--- a/src/features/bin-designer/utils/selection.test.ts
+++ b/src/features/bin-designer/utils/selection.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSelection } from './selection';
+import type { CompartmentConfig } from '../types';
+
+const TWO_BY_TWO: CompartmentConfig = {
+  cols: 2,
+  rows: 2,
+  cells: [0, 1, 2, 3],
+  thickness: 1.2,
+};
+
+describe('resolveSelection', () => {
+  it('passes null through', () => {
+    expect(resolveSelection(null, TWO_BY_TWO)).toBeNull();
+  });
+
+  it('keeps a compartment that still exists and nulls one that does not', () => {
+    expect(resolveSelection({ kind: 'compartment', id: 3 }, TWO_BY_TWO)).toEqual({
+      kind: 'compartment',
+      id: 3,
+    });
+    expect(resolveSelection({ kind: 'compartment', id: 9 }, TWO_BY_TWO)).toBeNull();
+  });
+
+  it('nulls a label tab whose compartment renumbered away', () => {
+    expect(resolveSelection({ kind: 'labelTab', compartmentId: 7 }, TWO_BY_TWO)).toBeNull();
+    expect(resolveSelection({ kind: 'labelTab', compartmentId: 0 }, TWO_BY_TWO)).toEqual({
+      kind: 'labelTab',
+      compartmentId: 0,
+    });
+  });
+
+  it('keeps a divider only while its pair is still adjacent', () => {
+    expect(resolveSelection({ kind: 'divider', key: '0-1' }, TWO_BY_TWO)).toEqual({
+      kind: 'divider',
+      key: '0-1',
+    });
+    // 0 and 3 sit diagonally; no divider separates them.
+    expect(resolveSelection({ kind: 'divider', key: '0-3' }, TWO_BY_TWO)).toBeNull();
+  });
+});

--- a/src/features/bin-designer/utils/selection.ts
+++ b/src/features/bin-designer/utils/selection.ts
@@ -1,0 +1,36 @@
+/**
+ * Validity derivation for the contextual selection.
+ *
+ * Compartment ids renumber on every merge/split and divider pairs exist only
+ * while their compartments stay adjacent, so a held selection can be orphaned
+ * by any external mutation (undo, regrid, an import). Reading through this
+ * resolver instead of trusting `ui.selection` keeps the Selection page from
+ * editing a compartment that no longer means what the user picked — without
+ * store writes at read time.
+ */
+
+import type { CompartmentConfig, DesignerSelection } from '../types';
+import { getEligibleDividers } from './compartments';
+
+function compartmentExists(config: CompartmentConfig, id: number): boolean {
+  return config.cells.includes(id);
+}
+
+export function resolveSelection(
+  selection: DesignerSelection,
+  compartments: CompartmentConfig
+): DesignerSelection {
+  if (selection === null) return null;
+  switch (selection.kind) {
+    case 'compartment':
+      return compartmentExists(compartments, selection.id) ? selection : null;
+    case 'labelTab':
+      return compartmentExists(compartments, selection.compartmentId) ? selection : null;
+    case 'divider': {
+      const valid = getEligibleDividers(compartments).some(
+        (d) => `${d.compartmentA}-${d.compartmentB}` === selection.key
+      );
+      return valid ? selection : null;
+    }
+  }
+}


### PR DESCRIPTION
The store half of stage B4's contextual Selection page, plus an e2e follow-up from the audit wave.

- `DesignerSelection` union (compartment / divider / labelTab; cutouts arrive with 3D picking in B5) on `ui`, with `select`/`clearSelection` actions implementing the plan's contract: selecting auto-switches the rail to the Selection slot and stores the return category; deselect restores it exactly once; a manual rail move away deselects.
- `resolveSelection`, the read-side validity derivation: compartment ids renumber on every merge/split, so consumers read through the resolver, which nulls a pick the current params no longer contain — no store writes at read time.
- `designer.scenario.selection.test.ts` pins the invariants: selection changes never touch undo history or the generation epoch, and a regrid orphans a held pick only through the resolver.
- The Selection rail slot stays disabled until the page ships (next session); this is deliberately inert groundwork so the interaction redesign (which grid click selects, where merge/split live) gets its own visual iteration.
- e2e: the four lid visual specs follow the "Enable lid" → "Lid" toggle rename from #3999.

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

