### PR TITLE
fix(baseplate): stop params migration dropping splitOverride, screwHoles, fractional edges

### DIFF
--- a/src/core/baseplateDefaults.ts
+++ b/src/core/baseplateDefaults.ts
@@ -4,13 +4,22 @@
  * invalidate every consumer of the general constants module.
  */
 
-import type { StoredBaseplateParams, PaddingAnchor, StackPrintParams } from './types';
+import type {
+  StoredBaseplateParams,
+  PaddingAnchor,
+  StackPrintParams,
+  SplitOverride,
+  ScrewHoleParams,
+  FractionalEdge,
+} from './types';
 import {
   mm,
   gridUnits,
   STACK_PRINT_MIN_GAP_MM,
   STACK_PRINT_MAX_GAP_MM,
   STACK_PRINT_DEFAULT_GAP_MM,
+  STACK_PRINT_MIN_COPIES,
+  STACK_PRINT_MAX_COPIES,
 } from './types';
 import { CONNECTOR_FIT_OFFSET_MIN, CONNECTOR_FIT_OFFSET_MAX } from '@/shared/constants/connectors';
 import { CONSTRAINTS } from './constants';
@@ -128,6 +137,8 @@ export function migrateBaseplateParams(stored: unknown): StoredBaseplateParams {
   }
   // Validate and clamp all fields from persisted/imported data
   const stackPrint = migrateStackPrint(obj.stackPrint);
+  const splitOverride = migrateSplitOverride(obj.splitOverride);
+  const screwHoles = migrateScrewHoles(obj.screwHoles);
   const radii = obj.cornerRadii;
   const hasRadii =
     radii !== null &&
@@ -224,6 +235,86 @@ export function migrateBaseplateParams(stored: unknown): StoredBaseplateParams {
     // independently so toggling detach off/on doesn't lose the connector intent.
     ...(obj.detachMarginConnector === true ? { detachMarginConnector: true } : {}),
     ...(stackPrint ? { stackPrint } : {}),
+    ...(isFractionalEdge(obj.fractionalEdgeX) ? { fractionalEdgeX: obj.fractionalEdgeX } : {}),
+    ...(isFractionalEdge(obj.fractionalEdgeY) ? { fractionalEdgeY: obj.fractionalEdgeY } : {}),
+    ...(splitOverride ? { splitOverride } : {}),
+    ...(screwHoles ? { screwHoles } : {}),
+  };
+}
+
+function isFractionalEdge(value: unknown): value is FractionalEdge {
+  return value === 'start' || value === 'end';
+}
+
+/**
+ * Shape check only: whether the chunks still describe the current plate
+ * (sum to its dims, cuts on cell boundaries) is `normalizeSplitOverride`'s
+ * call at build time, which has the resolved dimensions this layer does not.
+ */
+function migrateSplitOverride(value: unknown): SplitOverride | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const o = value as Record<string, unknown>;
+  const isChunkArray = (v: unknown): v is number[] =>
+    Array.isArray(v) &&
+    v.length > 0 &&
+    v.every((c) => typeof c === 'number' && Number.isFinite(c) && c > 0);
+  if (!isChunkArray(o.cols) || !isChunkArray(o.rows)) return undefined;
+  return { cols: o.cols.map(gridUnits), rows: o.rows.map(gridUnits) };
+}
+
+/** Validate + clamp persisted screw-hole params, or undefined if absent/invalid. */
+function migrateScrewHoles(value: unknown): ScrewHoleParams | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const o = value as Record<string, unknown>;
+  if (typeof o.enabled !== 'boolean') return undefined;
+  if (o.headStyle !== 'countersink' && o.headStyle !== 'counterbore') return undefined;
+  return {
+    enabled: o.enabled,
+    diameter: mm(
+      clampNumber(
+        o.diameter,
+        SCREW_HOLE_MIN_DIAMETER_MM,
+        SCREW_HOLE_MAX_DIAMETER_MM,
+        SCREW_HOLE_DEFAULT_DIAMETER_MM
+      )
+    ),
+    headStyle: o.headStyle,
+    ...(typeof o.headDiameter === 'number' && Number.isFinite(o.headDiameter)
+      ? {
+          headDiameter: mm(
+            clampNumber(
+              o.headDiameter,
+              SCREW_HEAD_MIN_DIAMETER_MM,
+              SCREW_HEAD_MAX_DIAMETER_MM,
+              SCREW_HEAD_MIN_DIAMETER_MM
+            )
+          ),
+        }
+      : {}),
+    ...(typeof o.counterboreDepth === 'number' && Number.isFinite(o.counterboreDepth)
+      ? {
+          counterboreDepth: mm(
+            clampNumber(
+              o.counterboreDepth,
+              0,
+              SCREW_COUNTERBORE_MAX_DEPTH_MM,
+              SCREW_COUNTERBORE_DEFAULT_DEPTH_MM
+            )
+          ),
+        }
+      : {}),
+    ...(typeof o.screwsPerPiece === 'number' && Number.isFinite(o.screwsPerPiece)
+      ? {
+          screwsPerPiece: Math.round(
+            clampNumber(
+              o.screwsPerPiece,
+              SCREWS_PER_PIECE_MIN,
+              SCREWS_PER_PIECE_MAX,
+              SCREWS_PER_PIECE_DEFAULT
+            )
+          ),
+        }
+      : {}),
   };
 }
 
@@ -242,6 +333,18 @@ function migrateStackPrint(value: unknown): StackPrintParams | undefined {
         STACK_PRINT_DEFAULT_GAP_MM
       )
     ),
+    ...(typeof o.copies === 'number' && Number.isFinite(o.copies)
+      ? {
+          copies: Math.round(
+            clampNumber(
+              o.copies,
+              STACK_PRINT_MIN_COPIES,
+              STACK_PRINT_MAX_COPIES,
+              STACK_PRINT_MIN_COPIES
+            )
+          ),
+        }
+      : {}),
   };
 }
 

--- a/src/core/constants.test.ts
+++ b/src/core/constants.test.ts
@@ -612,6 +612,128 @@ describe('migrateBaseplateParams', () => {
     const result = migrateBaseplateParams(stored);
     expect(result.cornerRadii).toBeUndefined();
   });
+
+  const currentShapeBase = {
+    magnetHoles: false,
+    magnetDiameter: 6.5,
+    magnetDepth: 2,
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingFront: 0,
+    paddingBack: 0,
+  };
+
+  // Without this a reload reverts a hand-drawn split to the automatic plan.
+  it('preserves splitOverride across a save/load round-trip', () => {
+    const result = migrateBaseplateParams({
+      ...currentShapeBase,
+      splitOverride: { cols: [2, 3], rows: [4, 0.5] },
+    });
+    expect(result.splitOverride).toEqual({ cols: [2, 3], rows: [4, 0.5] });
+  });
+
+  it('drops a malformed splitOverride instead of crashing', () => {
+    expect(
+      migrateBaseplateParams({ ...currentShapeBase, splitOverride: 'oops' }).splitOverride
+    ).toBeUndefined();
+    expect(
+      migrateBaseplateParams({ ...currentShapeBase, splitOverride: { cols: [2] } }).splitOverride
+    ).toBeUndefined();
+    expect(
+      migrateBaseplateParams({
+        ...currentShapeBase,
+        splitOverride: { cols: [2, -1], rows: [3] },
+      }).splitOverride
+    ).toBeUndefined();
+    expect(
+      migrateBaseplateParams({
+        ...currentShapeBase,
+        splitOverride: { cols: [], rows: [3] },
+      }).splitOverride
+    ).toBeUndefined();
+  });
+
+  it('preserves screwHoles across a save/load round-trip', () => {
+    const full = {
+      enabled: true,
+      diameter: 3.4,
+      headStyle: 'counterbore',
+      headDiameter: 5.5,
+      counterboreDepth: 3,
+      screwsPerPiece: 6,
+    };
+    expect(migrateBaseplateParams({ ...currentShapeBase, screwHoles: full }).screwHoles).toEqual(
+      full
+    );
+    const minimal = { enabled: false, diameter: 3.4, headStyle: 'countersink' };
+    const migrated = migrateBaseplateParams({
+      ...currentShapeBase,
+      screwHoles: minimal,
+    }).screwHoles;
+    expect(migrated).toEqual(minimal);
+    expect(migrated).not.toHaveProperty('headDiameter');
+  });
+
+  it('clamps screwHoles numbers and drops an invalid object', () => {
+    const result = migrateBaseplateParams({
+      ...currentShapeBase,
+      screwHoles: {
+        enabled: true,
+        diameter: 999,
+        headStyle: 'counterbore',
+        counterboreDepth: 99,
+        screwsPerPiece: 0,
+      },
+    });
+    expect(result.screwHoles).toEqual({
+      enabled: true,
+      diameter: 8,
+      headStyle: 'counterbore',
+      counterboreDepth: 6,
+      screwsPerPiece: 1,
+    });
+    expect(
+      migrateBaseplateParams({
+        ...currentShapeBase,
+        screwHoles: { enabled: true, diameter: 3.4, headStyle: 'oops' },
+      }).screwHoles
+    ).toBeUndefined();
+    expect(
+      migrateBaseplateParams({
+        ...currentShapeBase,
+        screwHoles: { diameter: 3.4, headStyle: 'countersink' },
+      }).screwHoles
+    ).toBeUndefined();
+  });
+
+  it('preserves fractionalEdgeX/Y and drops invalid values', () => {
+    const result = migrateBaseplateParams({
+      ...currentShapeBase,
+      fractionalEdgeX: 'start',
+      fractionalEdgeY: 'end',
+    });
+    expect(result.fractionalEdgeX).toBe('start');
+    expect(result.fractionalEdgeY).toBe('end');
+    const invalid = migrateBaseplateParams({ ...currentShapeBase, fractionalEdgeX: 'middle' });
+    expect(invalid.fractionalEdgeX).toBeUndefined();
+  });
+
+  it('preserves stackPrint.copies, rounded and clamped', () => {
+    const base = { ...currentShapeBase, stackPrint: { enabled: true, gapMm: 0.2 } };
+    expect(migrateBaseplateParams(base).stackPrint).toEqual({ enabled: true, gapMm: 0.2 });
+    expect(
+      migrateBaseplateParams({
+        ...currentShapeBase,
+        stackPrint: { enabled: true, gapMm: 0.2, copies: 3 },
+      }).stackPrint
+    ).toEqual({ enabled: true, gapMm: 0.2, copies: 3 });
+    expect(
+      migrateBaseplateParams({
+        ...currentShapeBase,
+        stackPrint: { enabled: true, gapMm: 0.2, copies: 999 },
+      }).stackPrint?.copies
+    ).toBe(20);
+  });
 });
 
 describe('getDefaultDrawerSize', () => {


### PR DESCRIPTION
## Summary

`migrateBaseplateParams` rebuilds the persisted params object field-by-field, so any field it does not name is silently stripped on every load. Five declared `StoredBaseplateParams` fields were missing from that allowlist: `splitOverride`, `screwHoles`, `fractionalEdgeX`, `fractionalEdgeY`, and `stackPrint.copies`. Writes and cloud sync preserved them, so the loss only showed on reload.

This preserves all five with the same validate-and-clamp treatment the other fields get:

- `splitOverride`: shape check only (non-empty arrays of finite positive numbers). Whether the plan still fits the plate stays `normalizeSplitOverride`'s call at build time, which has the resolved dimensions.
- `screwHoles`: mirrors the CQRS zod schema bounds (diameter, head style enum, optional head diameter / counterbore depth / screws per piece).
- `fractionalEdgeX/Y`: `'start' | 'end'` check.
- `stackPrint.copies`: rounded and clamped to 1-20.

## Testing

- New round-trip, clamp, and malformed-input tests for each field in `src/core/constants.test.ts` (round-trip cases fail without the fix)
- `pnpm run typecheck`, eslint on changed files, full `constants.test.ts` run

Fixes #3994

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

