### PR TITLE
fix(design-system): pin Stepper input width so intrinsic size can't hide the + button

### DIFF
--- a/src/design-system/Stepper/Stepper.tsx
+++ b/src/design-system/Stepper/Stepper.tsx
@@ -100,7 +100,12 @@ const inputVariants = cva(
   {
     variants: {
       orientation: {
-        horizontal: 'flex-1 h-full border-y border-stroke-subtle',
+        // `w-0` alongside `flex-1`: a number input's default intrinsic width is
+        // ~20 characters, and engines differ on whether that inflates the
+        // container's intrinsic size past its cell — where it paints the +
+        // button underneath the next control. A definite width takes the
+        // content size out of every sizing path; the min-w floor is the real size.
+        horizontal: 'w-0 flex-1 h-full border-y border-stroke-subtle',
         vertical: 'w-full border-x border-stroke-subtle',
       },
       // Width floors live in compoundVariants per orientation: horizontal needs


### PR DESCRIPTION
## Summary

Fixes the bin inspector's Height/Clearance steppers rendering with the + button hidden underneath the neighboring control (#3963).

The reporter's devtools screenshots show the Height `<input>` at 188px wide — a number input's default ~20-character intrinsic width — overflowing its `grid-cols-2` cell so the + button paints under the Clearance control's − button. The horizontal Stepper input was `flex-1` with only a `min-w` floor, which leaves the input's content-derived intrinsic size in play during the container's intrinsic sizing. Engines differ on how they clamp a flex item's intrinsic contribution there (local Chromium 149/150/152 and Firefox 151 all clamp to the floor, which is why this never reproduced locally), but the reporter's Chrome 151/152 on Windows resolves it to the full ~188px.

The fix adds a definite `w-0` beside `flex-1`, which removes the content-derived size from every sizing path in every engine: the existing per-size `min-w` floors become the rendered width. `fullWidth` and vertical steppers are unchanged.

Also from the report: the − appearing dead is expected behavior the overlap made confusing — the reported bin sat at its height minimum (21mm layer height), so − was legitimately disabled while + was invisible.

## Testing

- Reproduced the layout invariants with Playwright against dev: Chromium 149, system Chrome 150, flatpak Chrome 152.0.7977.64 (reporter is on .65), and Firefox 151 — after the fix all render input=38px, container=96px inside the 122px cell, + button on top and clickable
- Verified a 5-character mm value ("25.34") fits without clipping at the md floor
- `vitest run src/design-system/Stepper` (22 tests), eslint

Fixes #3963

https://claude.ai/code/session_01PmyKAjdtKTrE5ZxWvXEaut

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

