### PR TITLE
fix(bin-designer): flat-base finger scoop no longer exports with a gap

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -6,6 +6,6 @@ exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`
 
 exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4548`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `5618`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `6652`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `30756`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
@@ -8,7 +8,7 @@ exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid
 
 exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13580`;
 
-exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `12616`;
+exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `14366`;
 
 exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10430`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
@@ -14,4 +14,4 @@ exports[`floor patterns > half sockets get one window per quarter foot 1`] = `34
 
 exports[`floor patterns > magnet + screw pockets stay solid 1`] = `14892`;
 
-exports[`floor patterns > scoop ramp footings stay solid 1`] = `12406`;
+exports[`floor patterns > scoop ramp footings stay solid 1`] = `12598`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
@@ -1,31 +1,41 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4044`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4332`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `4642`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `5162`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `4044`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `4332`;
 
 exports[`scoop > 2×2 scoop disabled 1`] = `2892`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `4116`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4364`;
 
-exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `4272`;
+exports[`scoop flat base > 1×1 flat base scoop with lip 1`] = `2364`;
 
-exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `5070`;
+exports[`scoop flat base > 2×2 flat base scoop no lip 1`] = `1612`;
 
-exports[`scoop side > scoop on the back wall 1`] = `4044`;
+exports[`scoop flat base > 2×2 flat base scoop with lip 1`] = `2364`;
 
-exports[`scoop side > scoop on the left wall 1`] = `4044`;
+exports[`scoop flat base > 2×2 flat base thin-wall scoop (corner clip active) 1`] = `3008`;
 
-exports[`scoop side > scoop on the right wall 1`] = `4044`;
+exports[`scoop flat base > 2×2 tray-bottom (lid) base scoop with lip 1`] = `1662`;
 
-exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `4044`;
+exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `4560`;
 
-exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `4004`;
+exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `5820`;
 
-exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4240`;
+exports[`scoop side > scoop on the back wall 1`] = `4332`;
 
-exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3544`;
+exports[`scoop side > scoop on the left wall 1`] = `4332`;
 
-exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `3436`;
+exports[`scoop side > scoop on the right wall 1`] = `4332`;
+
+exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `4332`;
+
+exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `4252`;
+
+exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4508`;
+
+exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3648`;
+
+exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `3544`;

--- a/src/features/generation/worker/generators/binGenerator.export.scoops.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.scoops.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
 import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
-import { scoop, scoopTwoVariable, scoopLipInteraction } from './scenarios/scoops';
+import { scoop, scoopTwoVariable, scoopFlatBase, scoopLipInteraction } from './scenarios/scoops';
 
-runExportIntegrity([...scoop, ...scoopTwoVariable, ...scoopLipInteraction]);
+runExportIntegrity([...scoop, ...scoopTwoVariable, ...scoopFlatBase, ...scoopLipInteraction]);

--- a/src/features/generation/worker/generators/binGenerator.scenario.scoops.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.scoops.test.ts
@@ -1,5 +1,17 @@
 // @vitest-environment node
 import { runScenarios } from './__kernel-tests__/scenarioRunner';
-import { scoop, scoopTwoVariable, scoopSides, scoopLipInteraction } from './scenarios/scoops';
+import {
+  scoop,
+  scoopTwoVariable,
+  scoopSides,
+  scoopFlatBase,
+  scoopLipInteraction,
+} from './scenarios/scoops';
 
-runScenarios([...scoop, ...scoopTwoVariable, ...scoopSides, ...scoopLipInteraction]);
+runScenarios([
+  ...scoop,
+  ...scoopTwoVariable,
+  ...scoopSides,
+  ...scoopFlatBase,
+  ...scoopLipInteraction,
+]);

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -13,7 +13,7 @@ import { binStyles } from './binStyles';
 import { heightVariations } from './heights';
 import { wallThickness } from './wallThickness';
 import { compartments } from './compartments';
-import { scoop, scoopTwoVariable, scoopSides, scoopLipInteraction } from './scoops';
+import { scoop, scoopTwoVariable, scoopSides, scoopFlatBase, scoopLipInteraction } from './scoops';
 import { labelTabs } from './labelTabs';
 import { inserts, multipleInserts } from './inserts';
 import { solidCutouts } from './solidCutouts';
@@ -65,6 +65,7 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...scoop,
   ...scoopTwoVariable,
   ...scoopSides,
+  ...scoopFlatBase,
   ...scoopLipInteraction,
   ...labelTabs,
   ...inserts,

--- a/src/features/generation/worker/generators/scenarios/scoops.ts
+++ b/src/features/generation/worker/generators/scenarios/scoops.ts
@@ -62,6 +62,47 @@ export const scoopSides: ScenarioCase[] = [
   }),
 ];
 
+// A socketless base (flat / tray) never gets the export-time deferred-socket
+// fuse that heals an additive feature's coincident-face contact, so a scoop's
+// wall-hugging faces shipped straight into the STL as a non-manifold gap. These
+// exercise the export-integrity manifold/boundary assertions against that class
+// directly.
+export const scoopFlatBase: ScenarioCase[] = [
+  defineScenario('scoop flat base', '1×1 flat base scoop with lip', {
+    params: {
+      width: 1,
+      depth: 1,
+      scoop: { enabled: true, radius: 'auto' as const },
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' as const },
+    },
+  }),
+  defineScenario('scoop flat base', '2×2 flat base scoop with lip', {
+    params: {
+      scoop: { enabled: true, radius: 'auto' as const },
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' as const },
+    },
+  }),
+  defineScenario('scoop flat base', '2×2 flat base scoop no lip', {
+    params: {
+      scoop: { enabled: true, radius: 'auto' as const },
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' as const, stackingLip: false },
+    },
+  }),
+  defineScenario('scoop flat base', '2×2 flat base thin-wall scoop (corner clip active)', {
+    params: {
+      wallThickness: 0.8,
+      scoop: { enabled: true, radius: 'auto' as const },
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' as const },
+    },
+  }),
+  defineScenario('scoop flat base', '2×2 tray-bottom (lid) base scoop with lip', {
+    params: {
+      scoop: { enabled: true, radius: 'auto' as const },
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'lid' as const },
+    },
+  }),
+];
+
 export const scoopLipInteraction: ScenarioCase[] = [
   defineScenario(
     'scoop + lip interaction',

--- a/src/features/generation/worker/generators/scoopRampBuilder.ts
+++ b/src/features/generation/worker/generators/scoopRampBuilder.ts
@@ -26,7 +26,12 @@ import {
   computeLipOffset,
   computeInteriorHeight,
 } from '@/shared/utils/scoopCalculations';
-import { LIP_SMALL_TAPER, LIP_TAPER_WIDTH, BOX_CORNER_RADIUS } from './generatorConstants';
+import {
+  LIP_SMALL_TAPER,
+  LIP_TAPER_WIDTH,
+  BOX_CORNER_RADIUS,
+  COPLANAR_MARGIN,
+} from './generatorConstants';
 import { findCompartmentBounds } from './compartmentBuilder';
 import { compartmentHasTiltedEdge, isRectangularCompartment } from '@/shared/types/bin';
 /**
@@ -78,6 +83,24 @@ function buildScoopRampsInScope(
 ): Shape3D | null {
   const hasLip = params.base.stackingLip;
   const interiorHeight = computeInteriorHeight(wallHeight, hasLip, LIP_SMALL_TAPER);
+
+  // The ramp's back edge and its two span ends sit on the surrounding walls'
+  // inner faces. Merely TOUCHING those faces leaves zero-thickness coincident
+  // faces when the ramp is fused into the body — non-manifold membranes (they
+  // surface as degenerate slivers where the ramp arc meets a side wall).
+  // Socketed bins hide it: the export-time deferred-socket fuse recomputes the
+  // boundary and heals it. A socketless base (flat / tray) never runs that fuse,
+  // so the membrane ships straight into the STL as a gap. Push the contact
+  // faces INTO the surrounding material so the fuse overlaps instead,
+  // following the COPLANAR_MARGIN pattern used throughout the pipeline. Clamp
+  // below the outer wall thickness (never breach it) AND below 0.4× the divider
+  // thickness so two neighbouring compartments penetrating a shared divider from
+  // opposite sides still cannot meet through it.
+  const wallPenetration = Math.min(
+    COPLANAR_MARGIN,
+    wallThickness * 0.6,
+    params.compartments.thickness * 0.4
+  );
 
   const { cols, rows, cells } = params.compartments;
   const side = resolveScoopSide(params.scoop);
@@ -131,13 +154,18 @@ function buildScoopRampsInScope(
       //   (0, 0) -> (0, wH) -> (lo, wH) -> (lo, H) -> ramp -> (lo+run, 0) -> close
       //   Goes up the wall to wallHeight, across to the lip's inner face,
       //   down to ramp start at H, then descends to floor. Fills solid.
+      // The wall-hugging back edge is authored at `-wallPenetration` (inside the
+      // wall) rather than 0 (on its inner face) so the fuse overlaps material;
+      // see `wallPenetration` above. The visible ramp surface (arc + top edge at
+      // Y=lipOffset) is unchanged.
+      const backY = -wallPenetration;
       const segments = 24;
       const points: [number, number][] = [];
       // Start at wall/floor corner
-      points.push([0, 0]);
+      points.push([backY, 0]);
       if (lipOffset > 0) {
         // Up the wall to wallHeight (lip base), across to lip inner face
-        points.push([0, wallHeight]);
+        points.push([backY, wallHeight]);
         points.push([lipOffset, wallHeight]);
         // Down to ramp start (only needed when height < wallHeight)
         if (height < wallHeight) {
@@ -145,7 +173,7 @@ function buildScoopRampsInScope(
         }
       } else {
         // Standard: up the wall to scoop height
-        points.push([0, height]);
+        points.push([backY, height]);
       }
       if (style === 'curved') {
         // Concave quarter-ellipse from (lipOffset, height) to (lipOffset+run, 0)
@@ -173,7 +201,13 @@ function buildScoopRampsInScope(
       // tangent to the wall and floor at those points, so the edges sit at
       // polygon cusps — brepjs `fillet()` returns Ok but produces degenerate
       // topology that fails STL export.
-      const scoopSolid = scope.register(sketch(profile, 'YZ', -span / 2).extrude(span));
+      // Extrude longer than the span so both ends bury into the perpendicular
+      // walls/dividers rather than landing coincident on their inner faces (see
+      // `wallPenetration`). Centred, so `placement.alongCenter` still aligns it.
+      const spanExtruded = span + 2 * wallPenetration;
+      const scoopSolid = scope.register(
+        sketch(profile, 'YZ', -spanExtruded / 2).extrude(spanExtruded)
+      );
 
       // The profile above is authored facing front (wall at Y=0, ramp running
       // toward +Y). Rotating about +Z maps it onto whichever wall was chosen,
@@ -210,10 +244,20 @@ function buildScoopRampsInScope(
   if (wallThickness < BOX_CORNER_RADIUS * (1 - Math.SQRT1_2)) {
     try {
       const cavityCornerR = Math.max(BOX_CORNER_RADIUS - wallThickness, 0.1);
+      // Expand the clip by `wallPenetration` so it trims the corner overshoot
+      // without also shaving off the intentional back-edge penetration — which
+      // would restore the coincident wall face this fix removes. Still inside
+      // the outer wall because `wallPenetration < wallThickness`.
       const footprint = scope.register(
-        sketch(drawRoundedRectangle(innerW, innerD, cavityCornerR), 'XY', -1).extrude(
-          wallHeight + 2
-        )
+        sketch(
+          drawRoundedRectangle(
+            innerW + 2 * wallPenetration,
+            innerD + 2 * wallPenetration,
+            cavityCornerR + wallPenetration
+          ),
+          'XY',
+          -1
+        ).extrude(wallHeight + 2)
       );
       return scope.register(unwrap(intersect(fused as ValidSolid, footprint as ValidSolid)));
     } catch {
@@ -246,7 +290,7 @@ export const scoopRampsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        'v3',
+        'v4',
         dim.shellKey,
         stableSerialize(params.scoop),
         params.style,
@@ -254,6 +298,9 @@ export const scoopRampsFeature: FeatureBuilder = {
         quantize(dim.innerD),
         quantize(dim.wallHeight),
         quantize(params.wallThickness),
+        // The wall/divider penetration that welds the ramp to its host scales
+        // with the divider thickness, so a thickness edit moves the geometry.
+        quantize(params.compartments.thickness),
         dim.hasLip,
         params.compartments.cols,
         params.compartments.rows,


### PR DESCRIPTION
Closes #4011.

## Problem

Create a bin, select a **Flat Base**, add a **Finger Scoop**. The 3D preview looks solid, but the exported STL has a gap/hole underneath where the scoop meets the base, and a slicer flags it.

## Root cause

The scoop ramp's back edge and its two span ends were authored *flush* on the surrounding walls' inner faces. Merely meeting a face (rather than overlapping it) fuses as a zero-thickness coincident face, a non-manifold membrane that a slicer resolves as a gap. It surfaces as degenerate slivers where the ramp arc meets a side wall.

Socketed bins never showed this: the export-time deferred-socket fuse recomputes the whole bottom boundary and heals the membrane as a side effect. A **socketless base (flat / tray) runs no such fuse**, so the membrane shipped straight into the STL. The 3D preview never runs the export-only cleanup either, which is why it looked (mostly) fine.

## Fix

`scoopRampBuilder.ts`: push the ramp's contact faces into the surrounding material by a clamped `COPLANAR_MARGIN` (the overlap-don't-touch pattern used throughout the pipeline), so the fuse overlaps solid instead of touching it. Expand the thin-wall corner clip by the same amount so it no longer trims the penetration back to a coincident face. The penetration is clamped below the outer wall thickness (never breaches it) and below 0.4x the divider thickness (two neighbouring compartments can't meet through a shared divider). Outer bounding boxes are unchanged; the fix is base-style-independent (it also removes the latent defect that socketed bins were masking).

## Tests

- Adds flat- and tray-base scoop scenarios to the export-integrity and generation suites (a real gap in the matrix: no scenario combined `base.style: flat` with a scoop). These fail on `main` (non-manifold edges) and pass here.
- Existing scoop `triangleCount` snapshots updated across the affected domains (scoops, combinedFeatures, dividerPatterns, floorPatterns) for the interface-tessellation change; outer geometry verified unchanged.

Note: the manual `*.brepkit.snap` parity artifact is left untouched (CI runs the default occt-wasm kernel; brepkit parity is regenerated on its own track).

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

