### PR TITLE
feat(spacemouse): add 3Dconnexion SpaceMouse navigation behind a labs flag

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "ignoreDependencies": ["axe-core", "postcss"],
+  "ignoreDependencies": ["axe-core", "postcss", "events"],
   "exclude": ["exports", "types", "duplicates"],
   "workspaces": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "!dist/assets/zh-CN-*.js"
       ],
       "gzip": true,
-      "limit": "2194 kB"
+      "limit": "2210 kB"
     },
     {
       "name": "Fetched JSON assets (gzip)",
@@ -138,6 +138,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "events": "^3.3.0",
     "fflate": "^0.8.3",
     "fit-curve": "^0.2.0",
     "idb": "^8.0.3",
@@ -151,6 +152,7 @@
     "qrcode": "^1.5.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "spacemouse-webhid": "^1.0.0",
     "svg-pathdata": "^9.0.0",
     "tailwind-merge": "^3.6.0",
     "three": "^0.185.1",
@@ -185,6 +187,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/three": "^0.185.4",
+    "@types/w3c-web-hid": "^1.0.7",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@vercel/node": "^5.10.1",
     "@vitejs/plugin-react": "^6.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      events:
+        specifier: ^3.3.0
+        version: 3.3.0
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -134,6 +137,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.8(react@19.2.8)
+      spacemouse-webhid:
+        specifier: ^1.0.0
+        version: 1.0.0
       svg-pathdata:
         specifier: ^9.0.0
         version: 9.0.0
@@ -204,6 +210,9 @@ importers:
       '@types/three':
         specifier: ^0.185.4
         version: 0.185.4
+      '@types/w3c-web-hid':
+        specifier: ^1.0.7
+        version: 1.0.7
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
@@ -2404,6 +2413,10 @@ packages:
     peerDependencies:
       size-limit: 13.0.3
 
+  '@spacemouse-lib/core@1.0.0':
+    resolution: {integrity: sha512-fqdJcW3lFB9zjpI4R5rDLJOfihspROj6Hc/9cZMoQRSde3bFj9ZNyzrx0tyaffQw5KTzLLdnmk41IMg4ZMjyCw==}
+    engines: {node: '>=20'}
+
   '@spz-loader/core@0.3.1':
     resolution: {integrity: sha512-8qJ1WIBXaJu8HjnJAjYniE0kYcr0kCe5Hp7kDzYiGVvvd7zyrOBwbF5imoW5mvwx1Qba0hxGEK5R9jEoaHKJFA==}
     engines: {node: '>=16', pnpm: '>=8'}
@@ -2631,6 +2644,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/w3c-web-hid@1.0.7':
+    resolution: {integrity: sha512-/y97wBH7fYB5vKoDIn11O1ZDMNFLCAVqZ9af0OWDN7VSO2ClErEN2HlGbBuPgHBTUmZOVx1og2ZHX1U2gEJM4Q==}
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
@@ -3722,6 +3738,10 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -5279,6 +5299,10 @@ packages:
   source-map@0.8.0:
     resolution: {integrity: sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==}
     engines: {node: '>= 12'}
+
+  spacemouse-webhid@1.0.0:
+    resolution: {integrity: sha512-T2p/vEcatjho4P1U5gMNH4cRKVBgYKgpvfYUUOUYZPVlam/+gKLZ+5hG7ODIcKa3v3cB4CebD5yGZ7+hcRV3Dw==}
+    engines: {node: '>=20'}
 
   splaytree@3.2.3:
     resolution: {integrity: sha512-7OXrNWzy6CK+r7Ch9OLPBDTKfB6XlWHjX4P0RU5B3IgFuWPeYN0XtRtlexGRjgbQxpfaUve6jTAwBGWuGntz/w==}
@@ -7968,6 +7992,10 @@ snapshots:
     dependencies:
       size-limit: 13.0.3
 
+  '@spacemouse-lib/core@1.0.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@spz-loader/core@0.3.1': {}
 
   '@stablelib/base64@1.0.1': {}
@@ -8182,6 +8210,8 @@ snapshots:
       meshoptimizer: 1.1.1
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/w3c-web-hid@1.0.7': {}
 
   '@types/webxr@0.5.24': {}
 
@@ -9368,6 +9398,8 @@ snapshots:
   eta@4.6.0: {}
 
   etag@1.8.1: {}
+
+  events@3.3.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -10953,6 +10985,11 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.8.0: {}
+
+  spacemouse-webhid@1.0.0:
+    dependencies:
+      '@spacemouse-lib/core': 1.0.0
+      buffer: 6.0.3
 
   splaytree@3.2.3: {}
 

--- a/scripts/i18n-values-allowlist.json
+++ b/scripts/i18n-values-allowlist.json
@@ -312,6 +312,7 @@
     "settings.uiDensity.compact",
     "share.tabs.file",
     "share.tabs.link",
+    "spacemouse.axis.zoom",
     "sidebar.appName",
     "sidebar.github",
     "sidebar.learn.calculator",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import {
 import { usePlaceBinFromURL } from '@/features/bin-designer/hooks/usePlaceBinInLayout';
 import { useBackgroundThumbnailRegen } from '@/features/bin-designer';
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
+import { useSpaceMouseDevice } from '@/shared/spacemouse/useSpaceMouseDevice';
 import { useCommunityPublishReturn } from '@/shared/hooks/useCommunityPublishReturn';
 import { useCommunityLikeReturn } from '@/shared/hooks/useCommunityLikeReturn';
 import { useCommunityDigestCheck } from '@/shared/hooks/useCommunityDigestCheck';
@@ -318,6 +319,7 @@ export default function App() {
   }, [activeLayerId, activeCategoryId, layers, categories, setActiveLayer, setActiveCategory]);
 
   useKeyboard({ disabled: isNonLayoutRoute });
+  useSpaceMouseDevice(useFeatureFlag('spacemouse'));
   const saveStatus = useAutoSave();
   useCrossTabSync();
   useLayoutRouting({ skip: isNonLayoutRoute });

--- a/src/core/labs/features.ts
+++ b/src/core/labs/features.ts
@@ -250,6 +250,18 @@ export const FEATURE_FLAGS = [
     addedAt: '2026-08',
     requiresRefresh: false,
   },
+  {
+    id: 'spacemouse',
+    name: 'SpaceMouse Navigation',
+    description:
+      'Fly the 3D previews with a 3Dconnexion SpaceMouse. Push, tilt and twist the puck to pan, zoom and orbit, and map its buttons to fit, view presets and undo. Tune speed and axis direction below.',
+    status: 'experimental',
+    risk: 'low',
+    warning:
+      'Needs a Chromium browser (Chrome, Edge or Opera) with WebHID. After turning this on, click Connect and pick your device once.',
+    addedAt: '2026-08',
+    requiresRefresh: false,
+  },
 ] as const satisfies readonly FeatureFlag[];
 
 export type FeatureId = (typeof FEATURE_FLAGS)[number]['id'];

--- a/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
+++ b/src/features/baseplate/components/BaseplatePreview/BaseplatePreview.tsx
@@ -38,6 +38,7 @@ import { MarginMeshes } from './MarginMeshes';
 import { SceneLighting } from './SceneLighting';
 import { CameraController } from './CameraController';
 import { CameraRig, type Projection } from '@/shared/components/preview/CameraRig';
+import { SpaceMouseController } from '@/shared/spacemouse/components/SpaceMouseController';
 import { DimensionLabels } from './DimensionLabels';
 import { useBaseplatePresetTransition } from './useBaseplatePresetTransition';
 import { BaseplatePreviewControls } from './BaseplatePreviewControls';
@@ -327,6 +328,7 @@ export function BaseplatePreview({
                 onPointerMissed={handlePointerMissed}
               >
                 <BaseplatePreviewContextSync />
+                <SpaceMouseController />
                 <CameraRig
                   projection={projection}
                   initialPosition={[100, -100, 80]}

--- a/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
+++ b/src/features/bin-designer/components/PreviewCanvas/PreviewCanvas.tsx
@@ -84,6 +84,7 @@ import {
   CAMERA_FOV,
 } from './previewCanvasCamera';
 import { CameraRig } from '@/shared/components/preview/CameraRig';
+import { SpaceMouseController } from '@/shared/spacemouse/components/SpaceMouseController';
 import { TouchHint, GeneratingIndicator } from './previewCanvasOverlays';
 import { detectWebGL, WebGLFallback, WebGLErrorBoundary } from '@/shared/webgl';
 import { WorkshopCanvas } from '../Workshop/WorkshopCanvas';
@@ -480,6 +481,7 @@ function BinPreviewCanvas({ hideChrome = false }: PreviewCanvasProps = {}) {
                 )}
               />
               <PreviewContextSync />
+              <SpaceMouseController />
 
               <GradientBackground />
 

--- a/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
+++ b/src/features/bin-designer/components/Workshop/WorkshopCanvas.tsx
@@ -29,6 +29,7 @@ import {
 import { useDesignerKeyboard } from '@/features/bin-designer/hooks/useDesignerKeyboard';
 import { usePresetTransition } from '@/features/bin-designer/components/PreviewCanvas/previewCanvasCamera';
 import type { Projection } from '@/shared/components/preview/CameraRig';
+import { SpaceMouseController } from '@/shared/spacemouse/components/SpaceMouseController';
 import { assemblyHeightUnits } from '@/shared/types/assemblyPlacement';
 import { GRIDFINITY_SPEC } from '@/shared/printSettings/gridfinityGeometry';
 import { WorkshopScene, type MarqueeRect } from './WorkshopScene';
@@ -265,6 +266,7 @@ export function WorkshopCanvas() {
           }}
         >
           <WorkshopContextSync />
+          <SpaceMouseController />
           <WorkshopScene
             structure={structure}
             envelope={envelope}

--- a/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
+++ b/src/features/grid-editor/components/Grid/IsometricPreview/IsometricPreview.tsx
@@ -27,6 +27,7 @@ import {
 } from './LinkedBinMeshes';
 import { useTranslation } from '@/i18n';
 import { useSettingsStore } from '@/core/store/settings';
+import { SpaceMouseController } from '@/shared/spacemouse/components/SpaceMouseController';
 import { useBinsToRender } from './useBinsToRender';
 import { getPreviewSummary } from './previewSummary';
 import { usePreviewSize } from './usePreviewSize';
@@ -334,6 +335,7 @@ export function IsometricPreview({ inline = false }: IsometricPreviewProps) {
         }}
         style={{ background: threeColors.canvasBg }}
       >
+        <SpaceMouseController />
         <Scene
           ref={sceneRef}
           drawerWidth={drawer.width}

--- a/src/features/labs/components/FeatureCard/FeatureCard.tsx
+++ b/src/features/labs/components/FeatureCard/FeatureCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { FeatureFlag } from '@/core/labs';
 import { FeatureStatusBadge } from '../FeatureStatusBadge';
 import { InfoIcon } from '../icons';
@@ -8,9 +9,11 @@ interface FeatureCardProps {
   feature: FeatureFlag;
   isEnabled: boolean;
   onToggle: () => void;
+  /** Optional per-feature settings rendered inside the card when enabled. */
+  children?: ReactNode;
 }
 
-export function FeatureCard({ feature, isEnabled, onToggle }: FeatureCardProps) {
+export function FeatureCard({ feature, isEnabled, onToggle, children }: FeatureCardProps) {
   const t = useTranslation();
   const isGraduated = feature.status === 'graduated';
   const isToggleable = !isGraduated;
@@ -54,6 +57,8 @@ export function FeatureCard({ feature, isEnabled, onToggle }: FeatureCardProps) 
           </div>
         ) : null}
       </div>
+
+      {children}
     </article>
   );
 }

--- a/src/features/labs/components/LabsDrawer/LabsDrawer.tsx
+++ b/src/features/labs/components/LabsDrawer/LabsDrawer.tsx
@@ -8,6 +8,8 @@ import { GraduatedSection } from '../GraduatedSection';
 import { SparklesIcon, CloseIcon } from '../icons';
 import { IconButton } from '@/design-system';
 import { useTranslation } from '@/i18n';
+import { SPACEMOUSE_FEATURE_ID } from '@/shared/spacemouse/constants';
+import { SpaceMouseSettings } from '@/shared/spacemouse/components/SpaceMouseSettings';
 
 export function LabsDrawer() {
   const t = useTranslation();
@@ -97,14 +99,21 @@ export function LabsDrawer() {
 
             {toggleableFeatures.length > 0 ? (
               <div className="space-y-3">
-                {toggleableFeatures.map((feature) => (
-                  <FeatureCard
-                    key={feature.id}
-                    feature={feature}
-                    isEnabled={enabledFeatures[feature.id as FeatureId] ?? false}
-                    onToggle={() => toggleFeature(feature.id as FeatureId)}
-                  />
-                ))}
+                {toggleableFeatures.map((feature) => {
+                  const isEnabled = enabledFeatures[feature.id as FeatureId] ?? false;
+                  return (
+                    <FeatureCard
+                      key={feature.id}
+                      feature={feature}
+                      isEnabled={isEnabled}
+                      onToggle={() => toggleFeature(feature.id as FeatureId)}
+                    >
+                      {feature.id === SPACEMOUSE_FEATURE_ID && isEnabled ? (
+                        <SpaceMouseSettings />
+                      ) : null}
+                    </FeatureCard>
+                  );
+                })}
               </div>
             ) : (
               <div className="text-center py-8 text-content-tertiary">

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -4505,5 +4505,20 @@
   "common.more": "Více",
   "binDesigner.printFit.fits": "Vejde se na vaši tiskovou podložku {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Zapnout stohovací okraj",
-  "binDesigner.dependency.editFootprint": "Upravit půdorys"
+  "binDesigner.dependency.editFootprint": "Upravit půdorys",
+  "spacemouse.connect": "Připojit",
+  "spacemouse.sensitivity": "Citlivost",
+  "spacemouse.speed.translate": "Rychlost posunu a přiblížení",
+  "spacemouse.speed.rotate": "Rychlost otáčení",
+  "spacemouse.invertAxes": "Převrátit osy",
+  "spacemouse.axis.panX": "Vodorovný posun",
+  "spacemouse.axis.panY": "Svislý posun",
+  "spacemouse.axis.zoom": "Přiblížení",
+  "spacemouse.axis.orbitH": "Vodorovné otáčení",
+  "spacemouse.axis.orbitV": "Svislé otáčení",
+  "spacemouse.status.connected": "Připojeno: {device}",
+  "spacemouse.status.connecting": "Připojování…",
+  "spacemouse.status.idle": "Není připojeno žádné zařízení",
+  "spacemouse.status.unsupported": "Vyžaduje prohlížeč Chromium",
+  "spacemouse.status.error": "Připojení se nezdařilo"
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -4505,5 +4505,20 @@
   "common.more": "Mehr",
   "binDesigner.printFit.fits": "Passt auf dein {width} × {depth} mm Druckbett.",
   "binDesigner.dependency.enableStackingLip": "Stapelrand aktivieren",
-  "binDesigner.dependency.editFootprint": "Grundriss bearbeiten"
+  "binDesigner.dependency.editFootprint": "Grundriss bearbeiten",
+  "spacemouse.connect": "Verbinden",
+  "spacemouse.sensitivity": "Empfindlichkeit",
+  "spacemouse.speed.translate": "Schwenk- und Zoomgeschwindigkeit",
+  "spacemouse.speed.rotate": "Rotationsgeschwindigkeit",
+  "spacemouse.invertAxes": "Achsen umkehren",
+  "spacemouse.axis.panX": "Horizontal schwenken",
+  "spacemouse.axis.panY": "Vertikal schwenken",
+  "spacemouse.axis.zoom": "Zoom",
+  "spacemouse.axis.orbitH": "Horizontal rotieren",
+  "spacemouse.axis.orbitV": "Vertikal rotieren",
+  "spacemouse.status.connected": "Verbunden: {device}",
+  "spacemouse.status.connecting": "Wird verbunden…",
+  "spacemouse.status.idle": "Kein Gerät verbunden",
+  "spacemouse.status.unsupported": "Erfordert einen Chromium-Browser",
+  "spacemouse.status.error": "Verbindung fehlgeschlagen"
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -5404,6 +5404,23 @@ const en: Record<string, string> = {
   'binDesigner.handles.widthAria': 'Handle width',
   'binDesigner.handles.heightAria': 'Handle height',
   'binDesigner.handles.countAria': 'Handle count',
+
+  // SpaceMouse navigation (labs)
+  'spacemouse.connect': 'Connect',
+  'spacemouse.sensitivity': 'Sensitivity',
+  'spacemouse.speed.translate': 'Pan & zoom speed',
+  'spacemouse.speed.rotate': 'Orbit speed',
+  'spacemouse.invertAxes': 'Invert axes',
+  'spacemouse.axis.panX': 'Pan horizontal',
+  'spacemouse.axis.panY': 'Pan vertical',
+  'spacemouse.axis.zoom': 'Zoom',
+  'spacemouse.axis.orbitH': 'Orbit horizontal',
+  'spacemouse.axis.orbitV': 'Orbit vertical',
+  'spacemouse.status.connected': 'Connected: {device}',
+  'spacemouse.status.connecting': 'Connecting…',
+  'spacemouse.status.idle': 'No device connected',
+  'spacemouse.status.unsupported': 'Needs a Chromium browser',
+  'spacemouse.status.error': 'Connection failed',
 };
 
 export default en;

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -4505,5 +4505,20 @@
   "common.more": "Más",
   "binDesigner.printFit.fits": "Cabe en tu cama de impresión de {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Activar borde apilable",
-  "binDesigner.dependency.editFootprint": "Editar contorno"
+  "binDesigner.dependency.editFootprint": "Editar contorno",
+  "spacemouse.connect": "Conectar",
+  "spacemouse.sensitivity": "Sensibilidad",
+  "spacemouse.speed.translate": "Velocidad de paneo y zoom",
+  "spacemouse.speed.rotate": "Velocidad de órbita",
+  "spacemouse.invertAxes": "Invertir ejes",
+  "spacemouse.axis.panX": "Paneo horizontal",
+  "spacemouse.axis.panY": "Paneo vertical",
+  "spacemouse.axis.zoom": "Zoom",
+  "spacemouse.axis.orbitH": "Órbita horizontal",
+  "spacemouse.axis.orbitV": "Órbita vertical",
+  "spacemouse.status.connected": "Conectado: {device}",
+  "spacemouse.status.connecting": "Conectando…",
+  "spacemouse.status.idle": "Ningún dispositivo conectado",
+  "spacemouse.status.unsupported": "Requiere un navegador Chromium",
+  "spacemouse.status.error": "Error de conexión"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -4505,5 +4505,20 @@
   "common.more": "Plus",
   "binDesigner.printFit.fits": "Tient sur votre plateau de {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Activer la lèvre d’empilage",
-  "binDesigner.dependency.editFootprint": "Modifier l’empreinte"
+  "binDesigner.dependency.editFootprint": "Modifier l’empreinte",
+  "spacemouse.connect": "Connecter",
+  "spacemouse.sensitivity": "Sensibilité",
+  "spacemouse.speed.translate": "Vitesse de panoramique et de zoom",
+  "spacemouse.speed.rotate": "Vitesse d'orbite",
+  "spacemouse.invertAxes": "Inverser les axes",
+  "spacemouse.axis.panX": "Panoramique horizontal",
+  "spacemouse.axis.panY": "Panoramique vertical",
+  "spacemouse.axis.zoom": "Zoom",
+  "spacemouse.axis.orbitH": "Orbite horizontale",
+  "spacemouse.axis.orbitV": "Orbite verticale",
+  "spacemouse.status.connected": "Connecté : {device}",
+  "spacemouse.status.connecting": "Connexion…",
+  "spacemouse.status.idle": "Aucun appareil connecté",
+  "spacemouse.status.unsupported": "Nécessite un navigateur Chromium",
+  "spacemouse.status.error": "Échec de la connexion"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -4505,5 +4505,20 @@
   "common.more": "Altro",
   "binDesigner.printFit.fits": "Entra nel tuo piano di stampa da {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Attiva il bordo impilabile",
-  "binDesigner.dependency.editFootprint": "Modifica la sagoma"
+  "binDesigner.dependency.editFootprint": "Modifica la sagoma",
+  "spacemouse.connect": "Connetti",
+  "spacemouse.sensitivity": "Sensibilità",
+  "spacemouse.speed.translate": "Velocità di spostamento e zoom",
+  "spacemouse.speed.rotate": "Velocità di orbita",
+  "spacemouse.invertAxes": "Inverti assi",
+  "spacemouse.axis.panX": "Spostamento orizzontale",
+  "spacemouse.axis.panY": "Spostamento verticale",
+  "spacemouse.axis.zoom": "Zoom",
+  "spacemouse.axis.orbitH": "Orbita orizzontale",
+  "spacemouse.axis.orbitV": "Orbita verticale",
+  "spacemouse.status.connected": "Connesso: {device}",
+  "spacemouse.status.connecting": "Connessione…",
+  "spacemouse.status.idle": "Nessun dispositivo connesso",
+  "spacemouse.status.unsupported": "Richiede un browser Chromium",
+  "spacemouse.status.error": "Connessione non riuscita"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -4505,5 +4505,20 @@
   "common.more": "その他",
   "binDesigner.printFit.fits": "{width} × {depth} mm のプリントベッドに収まります。",
   "binDesigner.dependency.enableStackingLip": "スタッキングリップを有効化",
-  "binDesigner.dependency.editFootprint": "外形を編集"
+  "binDesigner.dependency.editFootprint": "外形を編集",
+  "spacemouse.connect": "接続",
+  "spacemouse.sensitivity": "感度",
+  "spacemouse.speed.translate": "パン・ズーム速度",
+  "spacemouse.speed.rotate": "回転速度",
+  "spacemouse.invertAxes": "軸を反転",
+  "spacemouse.axis.panX": "水平パン",
+  "spacemouse.axis.panY": "垂直パン",
+  "spacemouse.axis.zoom": "ズーム",
+  "spacemouse.axis.orbitH": "水平回転",
+  "spacemouse.axis.orbitV": "垂直回転",
+  "spacemouse.status.connected": "接続済み: {device}",
+  "spacemouse.status.connecting": "接続中…",
+  "spacemouse.status.idle": "デバイスが接続されていません",
+  "spacemouse.status.unsupported": "Chromium ブラウザが必要です",
+  "spacemouse.status.error": "接続に失敗しました"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -4505,5 +4505,20 @@
   "common.more": "더보기",
   "binDesigner.printFit.fits": "{width} × {depth} mm 프린트 베드에 들어갑니다.",
   "binDesigner.dependency.enableStackingLip": "스태킹 립 켜기",
-  "binDesigner.dependency.editFootprint": "외곽선 편집"
+  "binDesigner.dependency.editFootprint": "외곽선 편집",
+  "spacemouse.connect": "연결",
+  "spacemouse.sensitivity": "감도",
+  "spacemouse.speed.translate": "이동 및 확대/축소 속도",
+  "spacemouse.speed.rotate": "궤도 회전 속도",
+  "spacemouse.invertAxes": "축 반전",
+  "spacemouse.axis.panX": "수평 이동",
+  "spacemouse.axis.panY": "수직 이동",
+  "spacemouse.axis.zoom": "확대/축소",
+  "spacemouse.axis.orbitH": "수평 회전",
+  "spacemouse.axis.orbitV": "수직 회전",
+  "spacemouse.status.connected": "연결됨: {device}",
+  "spacemouse.status.connecting": "연결 중…",
+  "spacemouse.status.idle": "연결된 장치 없음",
+  "spacemouse.status.unsupported": "Chromium 브라우저가 필요합니다",
+  "spacemouse.status.error": "연결 실패"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -4505,5 +4505,20 @@
   "common.more": "Mer",
   "binDesigner.printFit.fits": "Får plass på skriveplaten din på {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Slå på stablekant",
-  "binDesigner.dependency.editFootprint": "Rediger omriss"
+  "binDesigner.dependency.editFootprint": "Rediger omriss",
+  "spacemouse.connect": "Koble til",
+  "spacemouse.sensitivity": "Følsomhet",
+  "spacemouse.speed.translate": "Panorerings- og zoomhastighet",
+  "spacemouse.speed.rotate": "Rotasjonshastighet",
+  "spacemouse.invertAxes": "Inverter akser",
+  "spacemouse.axis.panX": "Vannrett panorering",
+  "spacemouse.axis.panY": "Loddrett panorering",
+  "spacemouse.axis.zoom": "Zoom",
+  "spacemouse.axis.orbitH": "Vannrett rotasjon",
+  "spacemouse.axis.orbitV": "Loddrett rotasjon",
+  "spacemouse.status.connected": "Tilkoblet: {device}",
+  "spacemouse.status.connecting": "Kobler til…",
+  "spacemouse.status.idle": "Ingen enhet tilkoblet",
+  "spacemouse.status.unsupported": "Krever en Chromium-nettleser",
+  "spacemouse.status.error": "Tilkobling mislyktes"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -4505,5 +4505,20 @@
   "common.more": "Meer",
   "binDesigner.printFit.fits": "Past op je printbed van {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Stapelrand inschakelen",
-  "binDesigner.dependency.editFootprint": "Omtrek bewerken"
+  "binDesigner.dependency.editFootprint": "Omtrek bewerken",
+  "spacemouse.connect": "Verbinden",
+  "spacemouse.sensitivity": "Gevoeligheid",
+  "spacemouse.speed.translate": "Pan- en zoomsnelheid",
+  "spacemouse.speed.rotate": "Draaisnelheid",
+  "spacemouse.invertAxes": "Assen omkeren",
+  "spacemouse.axis.panX": "Horizontaal pannen",
+  "spacemouse.axis.panY": "Verticaal pannen",
+  "spacemouse.axis.zoom": "Zoomen",
+  "spacemouse.axis.orbitH": "Horizontaal draaien",
+  "spacemouse.axis.orbitV": "Verticaal draaien",
+  "spacemouse.status.connected": "Verbonden: {device}",
+  "spacemouse.status.connecting": "Verbinden…",
+  "spacemouse.status.idle": "Geen apparaat verbonden",
+  "spacemouse.status.unsupported": "Vereist een Chromium-browser",
+  "spacemouse.status.error": "Verbinding mislukt"
 }

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -4505,5 +4505,20 @@
   "common.more": "Więcej",
   "binDesigner.printFit.fits": "Mieści się na stole {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Włącz krawędź piętrowania",
-  "binDesigner.dependency.editFootprint": "Edytuj obrys"
+  "binDesigner.dependency.editFootprint": "Edytuj obrys",
+  "spacemouse.connect": "Połącz",
+  "spacemouse.sensitivity": "Czułość",
+  "spacemouse.speed.translate": "Prędkość przesuwania i powiększania",
+  "spacemouse.speed.rotate": "Prędkość obracania",
+  "spacemouse.invertAxes": "Odwróć osie",
+  "spacemouse.axis.panX": "Przesuwanie poziome",
+  "spacemouse.axis.panY": "Przesuwanie pionowe",
+  "spacemouse.axis.zoom": "Powiększenie",
+  "spacemouse.axis.orbitH": "Obrót poziomy",
+  "spacemouse.axis.orbitV": "Obrót pionowy",
+  "spacemouse.status.connected": "Połączono: {device}",
+  "spacemouse.status.connecting": "Łączenie…",
+  "spacemouse.status.idle": "Nie podłączono urządzenia",
+  "spacemouse.status.unsupported": "Wymaga przeglądarki Chromium",
+  "spacemouse.status.error": "Połączenie nie powiodło się"
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -4505,5 +4505,20 @@
   "common.more": "Mais",
   "binDesigner.printFit.fits": "Cabe na sua mesa de impressão de {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Ativar borda de empilhamento",
-  "binDesigner.dependency.editFootprint": "Editar contorno"
+  "binDesigner.dependency.editFootprint": "Editar contorno",
+  "spacemouse.connect": "Conectar",
+  "spacemouse.sensitivity": "Sensibilidade",
+  "spacemouse.speed.translate": "Velocidade de deslocamento e zoom",
+  "spacemouse.speed.rotate": "Velocidade de órbita",
+  "spacemouse.invertAxes": "Inverter eixos",
+  "spacemouse.axis.panX": "Deslocamento horizontal",
+  "spacemouse.axis.panY": "Deslocamento vertical",
+  "spacemouse.axis.zoom": "Zoom",
+  "spacemouse.axis.orbitH": "Órbita horizontal",
+  "spacemouse.axis.orbitV": "Órbita vertical",
+  "spacemouse.status.connected": "Conectado: {device}",
+  "spacemouse.status.connecting": "Conectando…",
+  "spacemouse.status.idle": "Nenhum dispositivo conectado",
+  "spacemouse.status.unsupported": "Requer um navegador Chromium",
+  "spacemouse.status.error": "Falha na conexão"
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -4505,5 +4505,20 @@
   "common.more": "Mer",
   "binDesigner.printFit.fits": "Får plats på din skrivarbädd på {width} × {depth} mm.",
   "binDesigner.dependency.enableStackingLip": "Aktivera stapelkant",
-  "binDesigner.dependency.editFootprint": "Redigera kontur"
+  "binDesigner.dependency.editFootprint": "Redigera kontur",
+  "spacemouse.connect": "Anslut",
+  "spacemouse.sensitivity": "Känslighet",
+  "spacemouse.speed.translate": "Panorerings- och zoomhastighet",
+  "spacemouse.speed.rotate": "Roteringshastighet",
+  "spacemouse.invertAxes": "Invertera axlar",
+  "spacemouse.axis.panX": "Vågrät panorering",
+  "spacemouse.axis.panY": "Lodrät panorering",
+  "spacemouse.axis.zoom": "Zoom",
+  "spacemouse.axis.orbitH": "Vågrät rotation",
+  "spacemouse.axis.orbitV": "Lodrät rotation",
+  "spacemouse.status.connected": "Ansluten: {device}",
+  "spacemouse.status.connecting": "Ansluter…",
+  "spacemouse.status.idle": "Ingen enhet ansluten",
+  "spacemouse.status.unsupported": "Kräver en Chromium-webbläsare",
+  "spacemouse.status.error": "Anslutningen misslyckades"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -4505,5 +4505,20 @@
   "common.more": "Більше",
   "binDesigner.printFit.fits": "Вміщується на ваш стіл друку {width} × {depth} мм.",
   "binDesigner.dependency.enableStackingLip": "Увімкнути стековий обід",
-  "binDesigner.dependency.editFootprint": "Редагувати контур"
+  "binDesigner.dependency.editFootprint": "Редагувати контур",
+  "spacemouse.connect": "Підключити",
+  "spacemouse.sensitivity": "Чутливість",
+  "spacemouse.speed.translate": "Швидкість панорамування та масштабування",
+  "spacemouse.speed.rotate": "Швидкість обертання",
+  "spacemouse.invertAxes": "Інвертувати осі",
+  "spacemouse.axis.panX": "Горизонтальне панорамування",
+  "spacemouse.axis.panY": "Вертикальне панорамування",
+  "spacemouse.axis.zoom": "Масштабування",
+  "spacemouse.axis.orbitH": "Горизонтальне обертання",
+  "spacemouse.axis.orbitV": "Вертикальне обертання",
+  "spacemouse.status.connected": "Підключено: {device}",
+  "spacemouse.status.connecting": "Підключення…",
+  "spacemouse.status.idle": "Пристрій не підключено",
+  "spacemouse.status.unsupported": "Потрібен браузер Chromium",
+  "spacemouse.status.error": "Помилка підключення"
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -4505,5 +4505,20 @@
   "common.more": "更多",
   "binDesigner.printFit.fits": "可放入您的 {width} × {depth} mm 打印床。",
   "binDesigner.dependency.enableStackingLip": "启用堆叠边缘",
-  "binDesigner.dependency.editFootprint": "编辑轮廓"
+  "binDesigner.dependency.editFootprint": "编辑轮廓",
+  "spacemouse.connect": "连接",
+  "spacemouse.sensitivity": "灵敏度",
+  "spacemouse.speed.translate": "平移和缩放速度",
+  "spacemouse.speed.rotate": "环绕旋转速度",
+  "spacemouse.invertAxes": "反转轴向",
+  "spacemouse.axis.panX": "水平平移",
+  "spacemouse.axis.panY": "垂直平移",
+  "spacemouse.axis.zoom": "缩放",
+  "spacemouse.axis.orbitH": "水平环绕",
+  "spacemouse.axis.orbitV": "垂直环绕",
+  "spacemouse.status.connected": "已连接：{device}",
+  "spacemouse.status.connecting": "连接中…",
+  "spacemouse.status.idle": "未连接设备",
+  "spacemouse.status.unsupported": "需要 Chromium 浏览器",
+  "spacemouse.status.error": "连接失败"
 }

--- a/src/shared/components/GlbViewer/GlbViewer.test.tsx
+++ b/src/shared/components/GlbViewer/GlbViewer.test.tsx
@@ -24,6 +24,11 @@ vi.mock('@react-three/fiber', () => ({
   Canvas: ({ children }: { children?: ReactNode }) => (
     <div data-testid="glb-canvas">{children}</div>
   ),
+  useThree: (selector?: (state: unknown) => unknown) => {
+    const state = { controls: null, invalidate: () => {}, gl: { domElement: null } };
+    return selector ? selector(state) : state;
+  },
+  useFrame: () => {},
 }));
 
 vi.mock('@react-three/drei', () => ({

--- a/src/shared/components/GlbViewer/GlbViewer.tsx
+++ b/src/shared/components/GlbViewer/GlbViewer.tsx
@@ -15,6 +15,7 @@ import '@/shared/webgl/configureTroikaText';
 import { Button, ProgressBar, cn } from '@/design-system';
 import { usePrefersReducedMotion } from '@/shared/hooks/usePrefersReducedMotion';
 import { useTranslation } from '@/i18n';
+import { SpaceMouseController } from '@/shared/spacemouse/components/SpaceMouseController';
 import { ensureVertexNormals } from './ensureVertexNormals';
 
 // Self-hosted Draco decoder (public/draco/): CSP forbids the default gstatic CDN.
@@ -143,6 +144,7 @@ export function GlbViewer({
             enableDamping
             makeDefault
           />
+          <SpaceMouseController />
         </Canvas>
       ) : null}
 

--- a/src/shared/spacemouse/bufferShim.test.ts
+++ b/src/shared/spacemouse/bufferShim.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { Buffer } from './bufferShim';
+
+describe('bufferShim Buffer.from', () => {
+  it('wraps an ArrayBuffer', () => {
+    const src = new Uint8Array([1, 2, 3]).buffer;
+    const buf = Buffer.from(src);
+    expect(Array.from(buf)).toEqual([1, 2, 3]);
+    expect(buf.length).toBe(3);
+  });
+
+  it('copies a number array and a Uint8Array', () => {
+    expect(Array.from(Buffer.from([9, 8, 7]))).toEqual([9, 8, 7]);
+    expect(Array.from(Buffer.from(new Uint8Array([4, 5])))).toEqual([4, 5]);
+  });
+});
+
+describe('bufferShim Buffer.concat', () => {
+  it('joins parts in order', () => {
+    const joined = Buffer.concat([Buffer.from([1]), Buffer.from([2, 3]), Buffer.from([4])]);
+    expect(Array.from(joined)).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('bufferShim read methods', () => {
+  it('readUInt8 returns the byte at the offset', () => {
+    expect(Buffer.from([0x00, 0x7f, 0xff]).readUInt8(2)).toBe(255);
+  });
+
+  it('readInt16LE decodes little-endian signed 16-bit values', () => {
+    // 0x0100 LE = 256
+    expect(Buffer.from([0x00, 0x01]).readInt16LE(0)).toBe(256);
+    // 0xffff LE = -1
+    expect(Buffer.from([0xff, 0xff]).readInt16LE(0)).toBe(-1);
+    // 0x00 0x80 LE = -32768 (sign bit set)
+    expect(Buffer.from([0x00, 0x80]).readInt16LE(0)).toBe(-32768);
+    // read at a non-zero offset
+    expect(Buffer.from([0, 0, 0x2c, 0x01]).readInt16LE(2)).toBe(300);
+  });
+});

--- a/src/shared/spacemouse/bufferShim.ts
+++ b/src/shared/spacemouse/bufferShim.ts
@@ -1,0 +1,46 @@
+/**
+ * Minimal `buffer` replacement for spacemouse-webhid. The library only needs
+ * `Buffer.from`, `Buffer.concat`, `readUInt8` and `readInt16LE` to parse HID
+ * reports, so aliasing `buffer` to this (via vite.config) keeps the full
+ * feross/buffer polyfill (~7 kB gzip) out of the bundle. Nothing else in the
+ * app imports `buffer`.
+ */
+export interface HidBuffer extends Uint8Array {
+  readUInt8(offset: number): number;
+  readInt16LE(offset: number): number;
+}
+
+const methods = {
+  readUInt8(this: Uint8Array, offset: number): number {
+    return this[offset];
+  },
+  readInt16LE(this: Uint8Array, offset: number): number {
+    const value = this[offset] | (this[offset + 1] << 8);
+    return value & 0x8000 ? value - 0x10000 : value;
+  },
+};
+
+function wrap(bytes: Uint8Array): HidBuffer {
+  return Object.assign(bytes, methods);
+}
+
+export const Buffer = {
+  from(source: ArrayBuffer | ArrayLike<number> | Uint8Array): HidBuffer {
+    if (source instanceof ArrayBuffer) return wrap(new Uint8Array(source));
+    if (source instanceof Uint8Array) return wrap(source);
+    return wrap(Uint8Array.from(source));
+  },
+  concat(list: readonly Uint8Array[]): HidBuffer {
+    let length = 0;
+    for (const part of list) length += part.length;
+    const out = new Uint8Array(length);
+    let offset = 0;
+    for (const part of list) {
+      out.set(part, offset);
+      offset += part.length;
+    }
+    return wrap(out);
+  },
+};
+
+export default { Buffer };

--- a/src/shared/spacemouse/buttonMap.test.ts
+++ b/src/shared/spacemouse/buttonMap.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_BUTTON_MAP, isGlobalCommand, resolveButtonCommand } from './buttonMap';
+
+describe('resolveButtonCommand', () => {
+  it('maps the two universal buttons to fit and reset', () => {
+    expect(resolveButtonCommand(0)).toBe('fit');
+    expect(resolveButtonCommand(1)).toBe('reset');
+  });
+
+  it('maps higher indices to presets and history', () => {
+    expect(resolveButtonCommand(5)).toBe('view-iso');
+    expect(resolveButtonCommand(6)).toBe('undo');
+    expect(resolveButtonCommand(7)).toBe('redo');
+  });
+
+  it('returns null for an unmapped index', () => {
+    expect(resolveButtonCommand(99)).toBeNull();
+    expect(resolveButtonCommand(-1)).toBeNull();
+    expect(resolveButtonCommand(DEFAULT_BUTTON_MAP.length)).toBeNull();
+  });
+});
+
+describe('isGlobalCommand', () => {
+  it('treats undo/redo as global and camera commands as local', () => {
+    expect(isGlobalCommand('undo')).toBe(true);
+    expect(isGlobalCommand('redo')).toBe(true);
+    expect(isGlobalCommand('fit')).toBe(false);
+    expect(isGlobalCommand('view-top')).toBe(false);
+  });
+});

--- a/src/shared/spacemouse/buttonMap.ts
+++ b/src/shared/spacemouse/buttonMap.ts
@@ -1,0 +1,31 @@
+import type { SpaceMouseCommand } from './types';
+
+/**
+ * Default button-index to command mapping. Tuned so the two buttons every puck
+ * has (index 0/1) do the most-used actions, while larger devices
+ * (SpaceMouse Pro/Enterprise) reach the view presets and history on the rest.
+ */
+export const DEFAULT_BUTTON_MAP: readonly SpaceMouseCommand[] = [
+  'fit',
+  'reset',
+  'view-top',
+  'view-front',
+  'view-right',
+  'view-iso',
+  'undo',
+  'redo',
+];
+
+export function resolveButtonCommand(
+  buttonIndex: number,
+  map: readonly SpaceMouseCommand[] = DEFAULT_BUTTON_MAP
+): SpaceMouseCommand | null {
+  return map[buttonIndex] ?? null;
+}
+
+const GLOBAL_COMMANDS: ReadonlySet<SpaceMouseCommand> = new Set(['undo', 'redo']);
+
+/** True for commands that act on app state rather than a specific canvas. */
+export function isGlobalCommand(command: SpaceMouseCommand): boolean {
+  return GLOBAL_COMMANDS.has(command);
+}

--- a/src/shared/spacemouse/cameraCommands.test.ts
+++ b/src/shared/spacemouse/cameraCommands.test.ts
@@ -1,0 +1,99 @@
+import { Box3, PerspectiveCamera, Vector3 } from 'three';
+import { describe, expect, it } from 'vitest';
+import {
+  applyFrameMotion,
+  boundingSphere,
+  computeContentBox,
+  fitPerspectiveDistance,
+  type OrbitLike,
+  presetDirection,
+} from './cameraCommands';
+import type { FrameMotion } from './types';
+
+const noMotion: FrameMotion = { panX: 0, panY: 0, zoom: 0, orbitH: 0, orbitV: 0 };
+
+function orbit(target = new Vector3()): OrbitLike {
+  return { target, update: () => {} };
+}
+
+describe('boundingSphere', () => {
+  it('returns center and enclosing radius', () => {
+    const box = new Box3(new Vector3(-1, -1, -1), new Vector3(1, 1, 1));
+    const { center, radius } = boundingSphere(box);
+    expect(center.toArray()).toEqual([0, 0, 0]);
+    expect(radius).toBeCloseTo(Math.sqrt(3));
+  });
+});
+
+describe('presetDirection', () => {
+  it('top looks along the up axis', () => {
+    expect(presetDirection('top', new Vector3(0, 0, 1)).toArray()).toEqual([0, 0, 1]);
+  });
+
+  it('front and right are perpendicular to up', () => {
+    const up = new Vector3(0, 0, 1);
+    expect(presetDirection('front', up).dot(up)).toBeCloseTo(0);
+    expect(presetDirection('right', up).dot(up)).toBeCloseTo(0);
+  });
+
+  it('iso is a unit vector', () => {
+    expect(presetDirection('iso', new Vector3(0, 1, 0)).length()).toBeCloseTo(1);
+  });
+});
+
+describe('fitPerspectiveDistance', () => {
+  it('grows with radius and is positive', () => {
+    const near = fitPerspectiveDistance(1, 50, 1);
+    const far = fitPerspectiveDistance(4, 50, 1);
+    expect(near).toBeGreaterThan(0);
+    expect(far).toBeCloseTo(near * 4);
+  });
+});
+
+describe('applyFrameMotion', () => {
+  it('pans camera and target together', () => {
+    const camera = new PerspectiveCamera();
+    camera.position.set(0, 0, 10);
+    const controls = orbit();
+    applyFrameMotion(camera, controls, { ...noMotion, panX: 2, panY: -1 });
+    expect(camera.position.x).toBeCloseTo(2);
+    expect(camera.position.y).toBeCloseTo(-1);
+    expect(controls.target.x).toBeCloseTo(2);
+    expect(controls.target.y).toBeCloseTo(-1);
+  });
+
+  it('dollies toward the target on positive zoom', () => {
+    const camera = new PerspectiveCamera();
+    camera.position.set(0, 0, 10);
+    const controls = orbit();
+    applyFrameMotion(camera, controls, { ...noMotion, zoom: 0.1 });
+    expect(camera.position.z).toBeCloseTo(10 * Math.exp(-0.1));
+  });
+
+  it('orbits around the target preserving distance', () => {
+    const camera = new PerspectiveCamera();
+    camera.position.set(0, 0, 10);
+    camera.up.set(0, 1, 0);
+    const controls = orbit();
+    applyFrameMotion(camera, controls, { ...noMotion, orbitH: Math.PI / 2 });
+    expect(camera.position.length()).toBeCloseTo(10);
+    expect(camera.position.x).toBeCloseTo(10);
+    expect(camera.position.z).toBeCloseTo(0);
+  });
+
+  it('does nothing for an idle frame', () => {
+    const camera = new PerspectiveCamera();
+    camera.position.set(1, 2, 3);
+    const controls = orbit(new Vector3(0, 0, 0));
+    applyFrameMotion(camera, controls, noMotion);
+    expect(camera.position.toArray()).toEqual([1, 2, 3]);
+  });
+});
+
+describe('computeContentBox', () => {
+  it('falls back to the whole scene when there are no meshes', () => {
+    const scene = new PerspectiveCamera(); // any Object3D with no meshes
+    const box = computeContentBox(scene);
+    expect(box.isEmpty()).toBe(true);
+  });
+});

--- a/src/shared/spacemouse/cameraCommands.ts
+++ b/src/shared/spacemouse/cameraCommands.ts
@@ -1,0 +1,160 @@
+import {
+  Box3,
+  type Camera,
+  type Object3D,
+  OrthographicCamera,
+  PerspectiveCamera,
+  Vector3,
+} from 'three';
+import { MIN_POLAR } from './constants';
+import type { CameraViewPreset, FrameMotion } from './types';
+
+/** OrbitControls surface the controller needs. */
+export interface OrbitLike {
+  target: Vector3;
+  update: () => void;
+  autoRotate?: boolean;
+}
+
+const FIT_PADDING = 1.25;
+
+/** Bounding sphere of the box: center + radius. */
+export function boundingSphere(box: Box3): { center: Vector3; radius: number } {
+  const center = new Vector3();
+  const size = new Vector3();
+  box.getCenter(center);
+  box.getSize(size);
+  return { center, radius: Math.max(size.length() / 2, 1e-3) };
+}
+
+/**
+ * Content bounding box: real meshes only, skipping grids, shadows, floors and
+ * helpers by name so a fit frames the model rather than the scaffolding.
+ */
+export function computeContentBox(scene: Object3D): Box3 {
+  const box = new Box3();
+  scene.traverse((obj: Object3D) => {
+    if (!(obj as { isMesh?: boolean }).isMesh) return;
+    const name = obj.name.toLowerCase();
+    if (
+      name.includes('grid') ||
+      name.includes('shadow') ||
+      name.includes('floor') ||
+      name.includes('helper')
+    ) {
+      return;
+    }
+    box.expandByObject(obj);
+  });
+  // No content meshes matched; frame whatever is in the scene.
+  if (box.isEmpty()) box.setFromObject(scene);
+  return box;
+}
+
+/**
+ * Unit direction from target to camera for a view preset, derived from the
+ * scene's up axis so it works for both Y-up and Z-up canvases.
+ */
+export function presetDirection(preset: CameraViewPreset, up: Vector3): Vector3 {
+  const u = up.clone().normalize();
+  // A reference axis not parallel to up, to build a horizontal basis.
+  const ref = Math.abs(u.z) < 0.9 ? new Vector3(0, 0, 1) : new Vector3(0, 1, 0);
+  const side = new Vector3().crossVectors(u, ref).normalize();
+  const fwd = new Vector3().crossVectors(side, u).normalize();
+  switch (preset) {
+    case 'top':
+      return u;
+    case 'front':
+      return fwd;
+    case 'right':
+      return side;
+    case 'iso':
+      return u.add(fwd).add(side).normalize();
+  }
+}
+
+/** Perspective distance that fits a sphere of `radius` given a vertical fov. */
+export function fitPerspectiveDistance(radius: number, fovDegrees: number, aspect: number): number {
+  const vFov = (fovDegrees * Math.PI) / 180;
+  const hFov = 2 * Math.atan(Math.tan(vFov / 2) * Math.max(aspect, 0.001));
+  const fov = Math.min(vFov, hFov);
+  return (radius * FIT_PADDING) / Math.sin(fov / 2);
+}
+
+/**
+ * Frame `box` in `camera`, keeping the current view direction unless `direction`
+ * is given. Handles perspective (distance) and orthographic (zoom) cameras.
+ */
+export function frameBox(
+  camera: Camera,
+  controls: OrbitLike,
+  box: Box3,
+  opts: { direction?: Vector3; viewportHeight: number; aspect: number }
+): void {
+  const { center, radius } = boundingSphere(box);
+  let dir = opts.direction?.clone();
+  if (!dir) {
+    dir = camera.position.clone().sub(controls.target);
+    if (dir.lengthSq() < 1e-6) dir = presetDirection('iso', camera.up);
+  }
+  dir.normalize();
+  controls.target.copy(center);
+
+  if (camera instanceof PerspectiveCamera) {
+    const distance = fitPerspectiveDistance(radius, camera.fov, opts.aspect);
+    camera.position.copy(center).addScaledVector(dir, distance);
+  } else if (camera instanceof OrthographicCamera) {
+    camera.position.copy(center).addScaledVector(dir, radius * 4 + 1);
+    camera.zoom = opts.viewportHeight / (2 * radius * FIT_PADDING);
+    camera.updateProjectionMatrix();
+  }
+  camera.lookAt(center);
+  controls.update();
+}
+
+/**
+ * Apply one frame of 6-DOF motion in object mode: pan the camera + target
+ * together, orbit around the target, and dolly toward/away from it. The camera
+ * up-vector is left untouched so mouse OrbitControls resume cleanly.
+ */
+export function applyFrameMotion(camera: Camera, controls: OrbitLike, motion: FrameMotion): void {
+  const target = controls.target;
+
+  if (motion.panX !== 0 || motion.panY !== 0) {
+    const right = new Vector3().setFromMatrixColumn(camera.matrix, 0);
+    const up = new Vector3().setFromMatrixColumn(camera.matrix, 1);
+    const pan = right.multiplyScalar(motion.panX).add(up.multiplyScalar(motion.panY));
+    camera.position.add(pan);
+    target.add(pan);
+  }
+
+  if (motion.orbitH !== 0 || motion.orbitV !== 0) {
+    const up = camera.up.clone().normalize();
+    const offset = camera.position.clone().sub(target);
+    if (motion.orbitH !== 0) offset.applyAxisAngle(up, motion.orbitH);
+    if (motion.orbitV !== 0) {
+      const right = new Vector3().crossVectors(up, offset).normalize();
+      if (right.lengthSq() > 1e-8) {
+        const current = offset.angleTo(up);
+        // Clamp so we can't tumble past either pole.
+        const next = Math.min(Math.PI - MIN_POLAR, Math.max(MIN_POLAR, current - motion.orbitV));
+        offset.applyAxisAngle(right, current - next);
+      }
+    }
+    camera.position.copy(target).add(offset);
+  }
+
+  if (motion.zoom !== 0) {
+    if (camera instanceof OrthographicCamera) {
+      camera.zoom = Math.max(1e-4, camera.zoom * Math.exp(motion.zoom));
+      camera.updateProjectionMatrix();
+    } else {
+      const offset = camera.position.clone().sub(target);
+      const scaled = Math.max(1e-3, offset.length() * Math.exp(-motion.zoom));
+      offset.setLength(scaled);
+      camera.position.copy(target).add(offset);
+    }
+  }
+
+  controls.update();
+}

--- a/src/shared/spacemouse/commands.test.ts
+++ b/src/shared/spacemouse/commands.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
+import { runGlobalCommand } from './commands';
+
+describe('runGlobalCommand', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('undoes only when there is history to undo', () => {
+    const undo = vi.fn();
+    vi.spyOn(useHistoryStore, 'getState').mockReturnValue({
+      canUndo: true,
+      canRedo: false,
+      undo,
+      redo: vi.fn(),
+    } as unknown as ReturnType<typeof useHistoryStore.getState>);
+    runGlobalCommand('undo');
+    expect(undo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not undo when the stack is empty', () => {
+    const undo = vi.fn();
+    vi.spyOn(useHistoryStore, 'getState').mockReturnValue({
+      canUndo: false,
+      canRedo: false,
+      undo,
+      redo: vi.fn(),
+    } as unknown as ReturnType<typeof useHistoryStore.getState>);
+    runGlobalCommand('undo');
+    expect(undo).not.toHaveBeenCalled();
+  });
+
+  it('redoes when possible', () => {
+    const redo = vi.fn();
+    vi.spyOn(useHistoryStore, 'getState').mockReturnValue({
+      canUndo: false,
+      canRedo: true,
+      undo: vi.fn(),
+      redo,
+    } as unknown as ReturnType<typeof useHistoryStore.getState>);
+    runGlobalCommand('redo');
+    expect(redo).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores camera commands', () => {
+    const undo = vi.fn();
+    const redo = vi.fn();
+    vi.spyOn(useHistoryStore, 'getState').mockReturnValue({
+      canUndo: true,
+      canRedo: true,
+      undo,
+      redo,
+    } as unknown as ReturnType<typeof useHistoryStore.getState>);
+    runGlobalCommand('fit');
+    expect(undo).not.toHaveBeenCalled();
+    expect(redo).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/spacemouse/commands.ts
+++ b/src/shared/spacemouse/commands.ts
@@ -1,0 +1,15 @@
+import { useHistoryStore } from '@/core/cqrs/undo/historyStore';
+import type { SpaceMouseCommand } from './types';
+
+/**
+ * Handle the app-global SpaceMouse commands (undo/redo). Camera commands are
+ * handled per-canvas by the controller; this only runs for global ones.
+ */
+export function runGlobalCommand(command: SpaceMouseCommand): void {
+  const history = useHistoryStore.getState();
+  if (command === 'undo') {
+    if (history.canUndo) history.undo();
+  } else if (command === 'redo') {
+    if (history.canRedo) history.redo();
+  }
+}

--- a/src/shared/spacemouse/components/SpaceMouseController/SpaceMouseController.test.tsx
+++ b/src/shared/spacemouse/components/SpaceMouseController/SpaceMouseController.test.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react';
+import { BoxGeometry, Mesh, MeshBasicMaterial, PerspectiveCamera, Scene, Vector3 } from 'three';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { spaceMouseBus } from '../../spaceMouseBus';
+import { SpaceMouseController } from './SpaceMouseController';
+
+const h = vi.hoisted(() => ({
+  state: null as unknown as Record<string, unknown>,
+  frameCb: null as ((state: unknown, dt: number) => void) | null,
+}));
+
+vi.mock('@react-three/fiber', () => ({
+  useThree: (selector: (s: unknown) => unknown) => selector(h.state),
+  useFrame: (cb: (state: unknown, dt: number) => void) => {
+    h.frameCb = cb;
+  },
+}));
+
+vi.mock('@/shared/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: () => true,
+}));
+
+function makeState() {
+  const camera = new PerspectiveCamera(50, 1, 0.1, 1000);
+  camera.position.set(0, 0, 10);
+  const controls = { target: new Vector3(0, 0, 0), update: vi.fn(), autoRotate: false };
+  const scene = new Scene();
+  const mesh = new Mesh(new BoxGeometry(2, 2, 2), new MeshBasicMaterial());
+  mesh.position.set(5, 0, 0);
+  scene.add(mesh);
+  return {
+    camera,
+    controls,
+    scene,
+    size: { width: 800, height: 600 },
+    invalidate: vi.fn(),
+    gl: { domElement: document.createElement('canvas') },
+  };
+}
+
+beforeEach(() => {
+  spaceMouseBus._resetForTests();
+  h.state = makeState();
+  h.frameCb = null;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SpaceMouseController', () => {
+  it('applies puck motion to the active canvas on each frame', () => {
+    render(<SpaceMouseController />);
+    const camera = h.state.camera as PerspectiveCamera;
+    const before = camera.position.clone();
+    spaceMouseBus.setTranslation({ x: 350, y: 0, z: 0 }); // full pan right
+    h.frameCb?.({}, 1 / 60);
+    expect(camera.position.x).not.toBeCloseTo(before.x);
+    expect(h.state.invalidate).toHaveBeenCalled();
+  });
+
+  it('does nothing when the puck is centered', () => {
+    render(<SpaceMouseController />);
+    const camera = h.state.camera as PerspectiveCamera;
+    const before = camera.position.clone();
+    h.frameCb?.({}, 1 / 60);
+    expect(camera.position.equals(before)).toBe(true);
+  });
+
+  it('frames the content on a fit command', () => {
+    render(<SpaceMouseController />);
+    const controls = h.state.controls as { target: Vector3 };
+    spaceMouseBus.pressButton(0); // fit
+    // Target snaps to the mesh center at (5, 0, 0).
+    expect(controls.target.x).toBeCloseTo(5);
+    expect(h.state.invalidate).toHaveBeenCalled();
+  });
+
+  it('does not drive a canvas that is not active', () => {
+    render(<SpaceMouseController />);
+    const camera = h.state.camera as PerspectiveCamera;
+    const before = camera.position.clone();
+    // A second, different controller becomes active.
+    spaceMouseBus.register({ id: 'other', runCommand: vi.fn(), invalidate: vi.fn() });
+    spaceMouseBus.setActive('other');
+    spaceMouseBus.setTranslation({ x: 350, y: 0, z: 0 });
+    h.frameCb?.({}, 1 / 60);
+    expect(camera.position.equals(before)).toBe(true);
+  });
+});

--- a/src/shared/spacemouse/components/SpaceMouseController/SpaceMouseController.tsx
+++ b/src/shared/spacemouse/components/SpaceMouseController/SpaceMouseController.tsx
@@ -1,0 +1,103 @@
+import { useFrame, useThree } from '@react-three/fiber';
+import { useEffect, useId, useRef } from 'react';
+import type { Vector3 } from 'three';
+import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
+import {
+  applyFrameMotion,
+  computeContentBox,
+  frameBox,
+  type OrbitLike,
+  presetDirection,
+} from '../../cameraCommands';
+import { SPACEMOUSE_FEATURE_ID } from '../../constants';
+import { computeFrameMotion, isDeflectionIdle, toDeflection } from '../../mapping';
+import { useSpaceMouseSettings } from '../../settingsStore';
+import { spaceMouseBus } from '../../spaceMouseBus';
+import type { SpaceMouseCommand } from '../../types';
+
+function directionForCommand(command: SpaceMouseCommand, up: Vector3): Vector3 | undefined {
+  switch (command) {
+    case 'fit':
+      return undefined; // keep the current view direction, just reframe
+    case 'reset':
+    case 'view-iso':
+      return presetDirection('iso', up);
+    case 'view-top':
+      return presetDirection('top', up);
+    case 'view-front':
+      return presetDirection('front', up);
+    case 'view-right':
+      return presetDirection('right', up);
+    case 'undo':
+    case 'redo':
+      return undefined; // handled globally, never reaches a canvas
+  }
+}
+
+/**
+ * Drives its host canvas's camera from the shared SpaceMouse bus. Mount one
+ * inside every OrbitControls-backed `<Canvas>`; it no-ops where there are no
+ * controls (e.g. the 2D cutout editor). Renders nothing.
+ */
+export function SpaceMouseController(): null {
+  const enabled = useFeatureFlag(SPACEMOUSE_FEATURE_ID);
+  const controls = useThree((s) => s.controls) as OrbitLike | null;
+  const camera = useThree((s) => s.camera);
+  const scene = useThree((s) => s.scene);
+  const size = useThree((s) => s.size);
+  const invalidate = useThree((s) => s.invalidate);
+  const gl = useThree((s) => s.gl);
+  const settings = useSpaceMouseSettings();
+  const id = useId();
+
+  const stateRef = useRef({ enabled, controls, camera, scene, size, invalidate, settings });
+  useEffect(() => {
+    stateRef.current = { enabled, controls, camera, scene, size, invalidate, settings };
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    const runCommand = (command: SpaceMouseCommand): void => {
+      const st = stateRef.current;
+      if (!st.controls) return;
+      const box = computeContentBox(st.scene);
+      if (box.isEmpty()) return;
+      const aspect = st.size.height > 0 ? st.size.width / st.size.height : 1;
+      frameBox(st.camera, st.controls, box, {
+        direction: directionForCommand(command, st.camera.up),
+        viewportHeight: st.size.height,
+        aspect,
+      });
+      st.invalidate();
+    };
+    const unregister = spaceMouseBus.register({
+      id,
+      runCommand,
+      invalidate: () => stateRef.current.invalidate(),
+    });
+    const dom = gl.domElement;
+    const claim = (): void => spaceMouseBus.setActive(id);
+    dom.addEventListener('pointerenter', claim);
+    return () => {
+      dom.removeEventListener('pointerenter', claim);
+      unregister();
+    };
+  }, [enabled, id, gl]);
+
+  useFrame((_, dt) => {
+    const st = stateRef.current;
+    if (!st.enabled || !st.controls) return;
+    if (!spaceMouseBus.isActive(id)) return;
+    const deflection = toDeflection(spaceMouseBus.getRaw(), st.settings);
+    if (isDeflectionIdle(deflection)) return;
+    // A SpaceMouse and auto-rotate can't coexist; the puck wins once used.
+    if (st.controls.autoRotate) st.controls.autoRotate = false;
+    const distance = st.camera.position.distanceTo(st.controls.target);
+    const motion = computeFrameMotion(deflection, st.settings, dt, distance);
+    applyFrameMotion(st.camera, st.controls, motion);
+    // Keep the demand-frameloop canvases rendering while the puck is deflected.
+    st.invalidate();
+  });
+
+  return null;
+}

--- a/src/shared/spacemouse/components/SpaceMouseController/index.ts
+++ b/src/shared/spacemouse/components/SpaceMouseController/index.ts
@@ -1,0 +1,1 @@
+export { SpaceMouseController } from './SpaceMouseController';

--- a/src/shared/spacemouse/components/SpaceMouseSettings/SpaceMouseSettings.test.tsx
+++ b/src/shared/spacemouse/components/SpaceMouseSettings/SpaceMouseSettings.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../constants';
+import { useSpaceMouseStore } from '../../settingsStore';
+import { SpaceMouseSettings } from './SpaceMouseSettings';
+
+const h = vi.hoisted(() => ({
+  supported: true,
+  requestPairing: vi.fn(),
+}));
+
+vi.mock('../../deviceManager', () => ({
+  isWebHidSupported: () => h.supported,
+  requestSpaceMousePairing: h.requestPairing,
+}));
+
+beforeEach(() => {
+  h.supported = true;
+  useSpaceMouseStore.setState({ settings: DEFAULT_SETTINGS, status: 'idle', deviceName: null });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SpaceMouseSettings', () => {
+  it('shows the idle status and a Connect button, and pairs on click', () => {
+    render(<SpaceMouseSettings />);
+    expect(screen.getByText('No device connected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+    expect(h.requestPairing).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the connected device name', () => {
+    useSpaceMouseStore.setState({ status: 'connected', deviceName: 'SpaceMouse Pro' });
+    render(<SpaceMouseSettings />);
+    expect(screen.getByText('Connected: SpaceMouse Pro')).toBeInTheDocument();
+  });
+
+  it('hides the Connect button on unsupported browsers', () => {
+    h.supported = false;
+    render(<SpaceMouseSettings />);
+    expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument();
+  });
+
+  it('toggles a per-axis invert switch through the store', () => {
+    render(<SpaceMouseSettings />);
+    expect(useSpaceMouseStore.getState().settings.invert.panX).toBe(false);
+    fireEvent.click(screen.getByRole('switch', { name: 'Pan horizontal' }));
+    expect(useSpaceMouseStore.getState().settings.invert.panX).toBe(true);
+  });
+
+  it('resets tuning to defaults', () => {
+    useSpaceMouseStore.getState().setSensitivity(3);
+    render(<SpaceMouseSettings />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+    expect(useSpaceMouseStore.getState().settings.sensitivity).toBe(DEFAULT_SETTINGS.sensitivity);
+  });
+});

--- a/src/shared/spacemouse/components/SpaceMouseSettings/SpaceMouseSettings.tsx
+++ b/src/shared/spacemouse/components/SpaceMouseSettings/SpaceMouseSettings.tsx
@@ -1,0 +1,112 @@
+import { Button, SliderInput, Switch } from '@/design-system';
+import { useTranslation } from '@/i18n';
+import { SENSITIVITY_RANGE, SPEED_RANGE } from '../../constants';
+import { isWebHidSupported, requestSpaceMousePairing } from '../../deviceManager';
+import {
+  useSpaceMouseConnection,
+  useSpaceMouseSettings,
+  useSpaceMouseStore,
+} from '../../settingsStore';
+import type { SpaceMouseInvert } from '../../types';
+
+/**
+ * Labs sub-panel for SpaceMouse: connection status + pair button, sensitivity
+ * and per-family speed sliders, and per-axis invert toggles. Rendered under the
+ * feature's card when the flag is on.
+ */
+export function SpaceMouseSettings(): React.ReactElement {
+  const t = useTranslation();
+  const settings = useSpaceMouseSettings();
+  const { status, deviceName } = useSpaceMouseConnection();
+  const setSensitivity = useSpaceMouseStore((s) => s.setSensitivity);
+  const setTranslateSpeed = useSpaceMouseStore((s) => s.setTranslateSpeed);
+  const setRotateSpeed = useSpaceMouseStore((s) => s.setRotateSpeed);
+  const toggleInvert = useSpaceMouseStore((s) => s.toggleInvert);
+  const resetSettings = useSpaceMouseStore((s) => s.resetSettings);
+  const supported = isWebHidSupported();
+
+  let statusText: string;
+  switch (status) {
+    case 'connected':
+      statusText = t('spacemouse.status.connected', { device: deviceName ?? 'SpaceMouse' });
+      break;
+    case 'connecting':
+      statusText = t('spacemouse.status.connecting');
+      break;
+    case 'unsupported':
+      statusText = t('spacemouse.status.unsupported');
+      break;
+    case 'error':
+      statusText = t('spacemouse.status.error');
+      break;
+    case 'idle':
+      statusText = t('spacemouse.status.idle');
+      break;
+  }
+
+  const invertRows: Array<{ axis: keyof SpaceMouseInvert; label: string }> = [
+    { axis: 'panX', label: t('spacemouse.axis.panX') },
+    { axis: 'panY', label: t('spacemouse.axis.panY') },
+    { axis: 'zoom', label: t('spacemouse.axis.zoom') },
+    { axis: 'orbitH', label: t('spacemouse.axis.orbitH') },
+    { axis: 'orbitV', label: t('spacemouse.axis.orbitV') },
+  ];
+
+  return (
+    <div className="mt-3 flex flex-col gap-3 border-t border-stroke-subtle pt-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-content-secondary">{statusText}</span>
+        {supported && status !== 'connecting' && (
+          <Button variant="secondary" size="sm" onClick={() => void requestSpaceMousePairing()}>
+            {t('spacemouse.connect')}
+          </Button>
+        )}
+      </div>
+
+      <SliderInput
+        label={t('spacemouse.sensitivity')}
+        value={settings.sensitivity}
+        onChange={setSensitivity}
+        min={SENSITIVITY_RANGE.min}
+        max={SENSITIVITY_RANGE.max}
+        step={SENSITIVITY_RANGE.step}
+      />
+      <SliderInput
+        label={t('spacemouse.speed.translate')}
+        value={settings.translateSpeed}
+        onChange={setTranslateSpeed}
+        min={SPEED_RANGE.min}
+        max={SPEED_RANGE.max}
+        step={SPEED_RANGE.step}
+      />
+      <SliderInput
+        label={t('spacemouse.speed.rotate')}
+        value={settings.rotateSpeed}
+        onChange={setRotateSpeed}
+        min={SPEED_RANGE.min}
+        max={SPEED_RANGE.max}
+        step={SPEED_RANGE.step}
+      />
+
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-content">{t('spacemouse.invertAxes')}</span>
+        {invertRows.map((row) => (
+          <label key={row.axis} className="flex items-center justify-between gap-2">
+            <span className="text-xs text-content-secondary">{row.label}</span>
+            <Switch
+              checked={settings.invert[row.axis]}
+              onChange={() => toggleInvert(row.axis)}
+              aria-label={row.label}
+            />
+          </label>
+        ))}
+      </div>
+
+      <div className="flex justify-end">
+        <Button variant="ghost" size="sm" onClick={resetSettings}>
+          {t('common.reset')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/spacemouse/components/SpaceMouseSettings/index.ts
+++ b/src/shared/spacemouse/components/SpaceMouseSettings/index.ts
@@ -1,0 +1,1 @@
+export { SpaceMouseSettings } from './SpaceMouseSettings';

--- a/src/shared/spacemouse/constants.ts
+++ b/src/shared/spacemouse/constants.ts
@@ -1,0 +1,42 @@
+import type { SpaceMouseSettings } from './types';
+
+export const SPACEMOUSE_FEATURE_ID = 'spacemouse' as const;
+
+export const SPACEMOUSE_SETTINGS_STORAGE_KEY = 'gridfinity-spacemouse-v1';
+
+/**
+ * 3Dconnexion pucks report each axis as a signed 16-bit value that saturates
+ * near ±350 at full deflection, not a normalized range. We divide by this to
+ * get a roughly [-1, 1] deflection before applying the deadzone and speeds.
+ */
+export const RAW_AXIS_FULL_SCALE = 350;
+
+/** Fraction of full scale below which an axis is treated as centered (jitter). */
+export const AXIS_DEADZONE = 0.06;
+
+/** Per-second rates at full deflection, before user speed/sensitivity scaling. */
+export const TRANSLATE_RATE = 1.2; // fraction of camera-to-target distance / s
+export const ZOOM_RATE = 1.6; // e-fold dolly factor / s
+export const ORBIT_RATE = 2.2; // radians / s
+
+/** Keeps the orbit from tumbling over the pole, matching OrbitControls' clamp. */
+export const MIN_POLAR = 0.01;
+
+export const DEFAULT_SETTINGS: SpaceMouseSettings = {
+  sensitivity: 1,
+  translateSpeed: 1,
+  rotateSpeed: 1,
+  invert: {
+    panX: false,
+    panY: false,
+    zoom: false,
+    orbitH: false,
+    orbitV: false,
+  },
+};
+
+export const SENSITIVITY_RANGE = { min: 0.1, max: 3, step: 0.1 } as const;
+export const SPEED_RANGE = { min: 0, max: 2, step: 0.05 } as const;
+
+/** 3Dconnexion (0x256f) and the Logitech-era vendor id (0x046d) its pucks use. */
+export const SPACEMOUSE_VENDOR_IDS = [0x256f, 0x046d] as const;

--- a/src/shared/spacemouse/deviceManager.ts
+++ b/src/shared/spacemouse/deviceManager.ts
@@ -1,0 +1,153 @@
+import type * as SpaceMouseWebHid from 'spacemouse-webhid';
+import { useSpaceMouseStore } from './settingsStore';
+import { spaceMouseBus } from './spaceMouseBus';
+
+type WebHidModule = typeof SpaceMouseWebHid;
+type SpaceMouseDevice = Awaited<ReturnType<WebHidModule['setupSpaceMouse']>>;
+
+let modulePromise: Promise<WebHidModule> | null = null;
+let device: SpaceMouseDevice | null = null;
+let started = false;
+
+function setConnection(
+  ...args: Parameters<ReturnType<typeof useSpaceMouseStore.getState>['setConnection']>
+) {
+  useSpaceMouseStore.getState().setConnection(...args);
+}
+
+export function isWebHidSupported(): boolean {
+  return typeof navigator !== 'undefined' && 'hid' in navigator;
+}
+
+function loadModule(): Promise<WebHidModule> {
+  if (!modulePromise) modulePromise = import('spacemouse-webhid');
+  return modulePromise;
+}
+
+function isSpaceMouseDevice(mod: WebHidModule, dev: HIDDevice): boolean {
+  return Object.values(mod.PRODUCTS).some(
+    (p) => p.vendorId === dev.vendorId && p.productId === dev.productId
+  );
+}
+
+function detachCurrent(): void {
+  if (!device) return;
+  try {
+    device.removeAllListeners();
+    void device.close();
+  } catch {
+    // Device may already be gone; nothing to clean up.
+  }
+  device = null;
+}
+
+function handleDeviceLost(): void {
+  detachCurrent();
+  spaceMouseBus.resetDeflection();
+  // A second puck may still be attached; otherwise fall back to idle.
+  void tryAutoConnect();
+}
+
+function wireEvents(sm: SpaceMouseDevice): void {
+  sm.on('translate', (t) => spaceMouseBus.setTranslation({ x: t.x, y: t.y, z: t.z }));
+  sm.on('rotate', (r) => spaceMouseBus.setRotation({ pitch: r.pitch, roll: r.roll, yaw: r.yaw }));
+  sm.on('down', (buttonIndex) => spaceMouseBus.pressButton(buttonIndex));
+  sm.on('error', handleDeviceLost);
+  sm.on('disconnected', handleDeviceLost);
+}
+
+async function attach(mod: WebHidModule, hidDevice: HIDDevice): Promise<void> {
+  detachCurrent();
+  setConnection('connecting');
+  const sm = await mod.setupSpaceMouse(hidDevice);
+  device = sm;
+  wireEvents(sm);
+  setConnection('connected', sm.info.name || hidDevice.productName || 'SpaceMouse');
+}
+
+async function tryAutoConnect(): Promise<void> {
+  if (!isWebHidSupported()) {
+    setConnection('unsupported', null);
+    return;
+  }
+  try {
+    const mod = await loadModule();
+    const granted = await mod.getOpenedSpaceMice();
+    const match = granted.find((d) => isSpaceMouseDevice(mod, d));
+    if (match) {
+      await attach(mod, match);
+    } else if (!device) {
+      setConnection('idle', null);
+    }
+  } catch {
+    setConnection('error');
+  }
+}
+
+function onHidConnect(event: HIDConnectionEvent): void {
+  if (device) return;
+  void (async () => {
+    const mod = await loadModule();
+    if (isSpaceMouseDevice(mod, event.device)) {
+      await attach(mod, event.device).catch(() => setConnection('error'));
+    }
+  })();
+}
+
+function onHidDisconnect(): void {
+  if (device) handleDeviceLost();
+}
+
+export function startSpaceMouse(): void {
+  if (started) return;
+  started = true;
+  // Load the undo/redo handler lazily so importing this module (e.g. for the
+  // Labs pairing button) doesn't drag in the command/history store graph.
+  void import('./commands').then((m) => {
+    if (started) spaceMouseBus.setGlobalHandler(m.runGlobalCommand);
+  });
+  if (!isWebHidSupported()) {
+    setConnection('unsupported', null);
+    return;
+  }
+  navigator.hid.addEventListener('connect', onHidConnect);
+  navigator.hid.addEventListener('disconnect', onHidDisconnect);
+  void tryAutoConnect();
+}
+
+export function stopSpaceMouse(): void {
+  if (!started) return;
+  started = false;
+  if (isWebHidSupported()) {
+    navigator.hid.removeEventListener('connect', onHidConnect);
+    navigator.hid.removeEventListener('disconnect', onHidDisconnect);
+  }
+  detachCurrent();
+  spaceMouseBus.setGlobalHandler(null);
+  spaceMouseBus.resetDeflection();
+  setConnection(isWebHidSupported() ? 'idle' : 'unsupported', null);
+}
+
+/**
+ * Prompt the user to pair a SpaceMouse. Must be called from a user gesture
+ * (WebHID requires one for the permission dialog).
+ */
+export async function requestSpaceMousePairing(): Promise<void> {
+  if (!isWebHidSupported()) {
+    setConnection('unsupported', null);
+    return;
+  }
+  try {
+    const mod = await loadModule();
+    setConnection('connecting');
+    const chosen = await mod.requestSpaceMice();
+    if (chosen.length === 0) {
+      // User dismissed the dialog without choosing.
+      setConnection(device ? 'connected' : 'idle');
+      return;
+    }
+    await attach(mod, chosen.find((d) => isSpaceMouseDevice(mod, d)) ?? chosen[0]);
+  } catch {
+    setConnection('error');
+  }
+}

--- a/src/shared/spacemouse/index.ts
+++ b/src/shared/spacemouse/index.ts
@@ -1,0 +1,15 @@
+export { SPACEMOUSE_FEATURE_ID } from './constants';
+export { isWebHidSupported, requestSpaceMousePairing } from './deviceManager';
+export {
+  useSpaceMouseConnection,
+  useSpaceMouseSettings,
+  useSpaceMouseStore,
+} from './settingsStore';
+export { useSpaceMouseDevice } from './useSpaceMouseDevice';
+export { SpaceMouseController } from './components/SpaceMouseController';
+export { SpaceMouseSettings } from './components/SpaceMouseSettings';
+export type {
+  SpaceMouseConnectionStatus,
+  SpaceMouseInvert,
+  SpaceMouseSettings as SpaceMouseSettingsValue,
+} from './types';

--- a/src/shared/spacemouse/mapping.test.ts
+++ b/src/shared/spacemouse/mapping.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS } from './constants';
+import {
+  applyDeadzone,
+  computeFrameMotion,
+  isDeflectionIdle,
+  normalizeAxis,
+  toDeflection,
+} from './mapping';
+import type { RawDeflection, SpaceMouseSettings } from './types';
+
+const zeroRaw: RawDeflection = {
+  translation: { x: 0, y: 0, z: 0 },
+  rotation: { pitch: 0, roll: 0, yaw: 0 },
+};
+
+describe('normalizeAxis', () => {
+  it('scales by full-scale and clamps to [-1, 1]', () => {
+    expect(normalizeAxis(175, 350)).toBeCloseTo(0.5);
+    expect(normalizeAxis(700, 350)).toBe(1);
+    expect(normalizeAxis(-700, 350)).toBe(-1);
+    expect(normalizeAxis(0)).toBe(0);
+  });
+});
+
+describe('applyDeadzone', () => {
+  it('zeroes values inside the deadzone', () => {
+    expect(applyDeadzone(0.03, 0.06)).toBe(0);
+    expect(applyDeadzone(-0.06, 0.06)).toBe(0);
+  });
+
+  it('ramps from zero at the deadzone edge and preserves sign', () => {
+    expect(applyDeadzone(0.06 + 1e-9, 0.06)).toBeCloseTo(0, 5);
+    expect(applyDeadzone(1, 0.06)).toBeCloseTo(1);
+    expect(applyDeadzone(-1, 0.06)).toBeCloseTo(-1);
+    expect(applyDeadzone(0.53, 0.06)).toBeGreaterThan(0);
+  });
+});
+
+describe('toDeflection', () => {
+  it('is idle for a centered puck', () => {
+    expect(isDeflectionIdle(toDeflection(zeroRaw, DEFAULT_SETTINGS))).toBe(true);
+  });
+
+  it('maps device axes to semantic axes with correct signs', () => {
+    const raw: RawDeflection = {
+      translation: { x: 350, y: -350, z: -350 },
+      rotation: { pitch: 350, roll: 0, yaw: 350 },
+    };
+    const d = toDeflection(raw, DEFAULT_SETTINGS);
+    expect(d.panX).toBeCloseTo(1); // x+ = right
+    expect(d.panY).toBeCloseTo(1); // z- (lift) = screen up
+    expect(d.zoom).toBeCloseTo(1); // y- (push forward) = zoom in
+    expect(d.orbitH).toBeCloseTo(1);
+    expect(d.orbitV).toBeCloseTo(1);
+  });
+
+  it('honors per-axis inversion', () => {
+    const settings: SpaceMouseSettings = {
+      ...DEFAULT_SETTINGS,
+      invert: { ...DEFAULT_SETTINGS.invert, panX: true, orbitH: true },
+    };
+    const raw: RawDeflection = {
+      translation: { x: 350, y: 0, z: 0 },
+      rotation: { pitch: 0, roll: 0, yaw: 350 },
+    };
+    const d = toDeflection(raw, settings);
+    expect(d.panX).toBeCloseTo(-1);
+    expect(d.orbitH).toBeCloseTo(-1);
+  });
+});
+
+describe('computeFrameMotion', () => {
+  const full = toDeflection(
+    {
+      translation: { x: 350, y: -350, z: -350 },
+      rotation: { pitch: 350, roll: 0, yaw: 350 },
+    },
+    DEFAULT_SETTINGS
+  );
+
+  it('scales pan with distance and time', () => {
+    const near = computeFrameMotion(full, DEFAULT_SETTINGS, 1 / 60, 10);
+    const far = computeFrameMotion(full, DEFAULT_SETTINGS, 1 / 60, 100);
+    expect(far.panX).toBeCloseTo(near.panX * 10);
+    expect(far.panX).toBeGreaterThan(0);
+  });
+
+  it('scales all motion by sensitivity', () => {
+    const base = computeFrameMotion(full, DEFAULT_SETTINGS, 1 / 60, 50);
+    const fast = computeFrameMotion(full, { ...DEFAULT_SETTINGS, sensitivity: 2 }, 1 / 60, 50);
+    expect(fast.orbitH).toBeCloseTo(base.orbitH * 2);
+    expect(fast.zoom).toBeCloseTo(base.zoom * 2);
+  });
+
+  it('produces no motion for an idle puck', () => {
+    const m = computeFrameMotion(
+      toDeflection(zeroRaw, DEFAULT_SETTINGS),
+      DEFAULT_SETTINGS,
+      1 / 60,
+      50
+    );
+    expect(m).toEqual({ panX: 0, panY: 0, zoom: 0, orbitH: 0, orbitV: 0 });
+  });
+});

--- a/src/shared/spacemouse/mapping.ts
+++ b/src/shared/spacemouse/mapping.ts
@@ -1,0 +1,76 @@
+import {
+  AXIS_DEADZONE,
+  ORBIT_RATE,
+  RAW_AXIS_FULL_SCALE,
+  TRANSLATE_RATE,
+  ZOOM_RATE,
+} from './constants';
+import type { Deflection, FrameMotion, RawDeflection, SpaceMouseSettings } from './types';
+
+/** Clamp a raw axis to [-1, 1] around its saturation point. */
+export function normalizeAxis(raw: number, fullScale = RAW_AXIS_FULL_SCALE): number {
+  const n = raw / fullScale;
+  if (n > 1) return 1;
+  if (n < -1) return -1;
+  return n;
+}
+
+/**
+ * Zero out small deflections, then rescale so motion ramps from 0 at the
+ * deadzone edge rather than jumping. Sign is preserved.
+ */
+export function applyDeadzone(normalized: number, deadzone = AXIS_DEADZONE): number {
+  const mag = Math.abs(normalized);
+  if (mag <= deadzone) return 0;
+  const scaled = (mag - deadzone) / (1 - deadzone);
+  return Math.sign(normalized) * scaled;
+}
+
+function axis(raw: number, invert: boolean): number {
+  const v = applyDeadzone(normalizeAxis(raw));
+  return invert ? -v : v;
+}
+
+/**
+ * Map raw device axes to the five semantic navigation axes, applying the
+ * deadzone and per-axis inversion. Device axis meanings (from spacemouse-webhid):
+ * translate x = right, y = forward/back, z = up/down; rotate pitch/yaw.
+ */
+export function toDeflection(raw: RawDeflection, settings: SpaceMouseSettings): Deflection {
+  const { invert } = settings;
+  return {
+    panX: axis(raw.translation.x, invert.panX),
+    panY: axis(-raw.translation.z, invert.panY), // device z+ is down; screen up is +
+    zoom: axis(-raw.translation.y, invert.zoom), // push forward (y-) zooms in
+    orbitH: axis(raw.rotation.yaw, invert.orbitH),
+    orbitV: axis(raw.rotation.pitch, invert.orbitV),
+  };
+}
+
+export function isDeflectionIdle(d: Deflection): boolean {
+  return d.panX === 0 && d.panY === 0 && d.zoom === 0 && d.orbitH === 0 && d.orbitV === 0;
+}
+
+/**
+ * Turn a normalized deflection into per-frame camera motion. Pan scales with
+ * `distance` so it feels the same whether zoomed in or out; zoom stays
+ * multiplicative (scale-free); orbit is a fixed angular rate.
+ */
+export function computeFrameMotion(
+  d: Deflection,
+  settings: SpaceMouseSettings,
+  dtSeconds: number,
+  distance: number
+): FrameMotion {
+  const dt = Math.max(0, dtSeconds);
+  const translate = settings.sensitivity * settings.translateSpeed * dt;
+  const rotate = settings.sensitivity * settings.rotateSpeed * dt;
+  const panScale = distance * TRANSLATE_RATE * translate;
+  return {
+    panX: d.panX * panScale,
+    panY: d.panY * panScale,
+    zoom: d.zoom * ZOOM_RATE * translate,
+    orbitH: d.orbitH * ORBIT_RATE * rotate,
+    orbitV: d.orbitV * ORBIT_RATE * rotate,
+  };
+}

--- a/src/shared/spacemouse/settingsStore.test.ts
+++ b/src/shared/spacemouse/settingsStore.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS } from './constants';
+import { useSpaceMouseStore } from './settingsStore';
+
+beforeEach(() => {
+  useSpaceMouseStore.setState({
+    settings: DEFAULT_SETTINGS,
+    status: 'idle',
+    deviceName: null,
+  });
+});
+
+describe('useSpaceMouseStore', () => {
+  it('updates sensitivity and speeds without touching other fields', () => {
+    useSpaceMouseStore.getState().setSensitivity(2);
+    useSpaceMouseStore.getState().setTranslateSpeed(0.5);
+    useSpaceMouseStore.getState().setRotateSpeed(1.5);
+    const { settings } = useSpaceMouseStore.getState();
+    expect(settings.sensitivity).toBe(2);
+    expect(settings.translateSpeed).toBe(0.5);
+    expect(settings.rotateSpeed).toBe(1.5);
+    expect(settings.invert.panX).toBe(false);
+  });
+
+  it('toggles a single invert axis', () => {
+    useSpaceMouseStore.getState().toggleInvert('orbitH');
+    expect(useSpaceMouseStore.getState().settings.invert.orbitH).toBe(true);
+    expect(useSpaceMouseStore.getState().settings.invert.orbitV).toBe(false);
+    useSpaceMouseStore.getState().toggleInvert('orbitH');
+    expect(useSpaceMouseStore.getState().settings.invert.orbitH).toBe(false);
+  });
+
+  it('resets tuning to defaults', () => {
+    useSpaceMouseStore.getState().setSensitivity(3);
+    useSpaceMouseStore.getState().toggleInvert('zoom');
+    useSpaceMouseStore.getState().resetSettings();
+    expect(useSpaceMouseStore.getState().settings).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('tracks connection status and device name independently', () => {
+    useSpaceMouseStore.getState().setConnection('connected', 'SpaceMouse Pro');
+    expect(useSpaceMouseStore.getState().status).toBe('connected');
+    expect(useSpaceMouseStore.getState().deviceName).toBe('SpaceMouse Pro');
+    // Omitting the name keeps the previous one.
+    useSpaceMouseStore.getState().setConnection('error');
+    expect(useSpaceMouseStore.getState().status).toBe('error');
+    expect(useSpaceMouseStore.getState().deviceName).toBe('SpaceMouse Pro');
+    // Passing null clears it.
+    useSpaceMouseStore.getState().setConnection('idle', null);
+    expect(useSpaceMouseStore.getState().deviceName).toBeNull();
+  });
+});

--- a/src/shared/spacemouse/settingsStore.ts
+++ b/src/shared/spacemouse/settingsStore.ts
@@ -1,0 +1,81 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import { useShallow } from 'zustand/react/shallow';
+import { DEFAULT_SETTINGS, SPACEMOUSE_SETTINGS_STORAGE_KEY } from './constants';
+import type { SpaceMouseConnectionStatus, SpaceMouseInvert, SpaceMouseSettings } from './types';
+
+interface SpaceMouseState {
+  /** Persisted tuning. */
+  settings: SpaceMouseSettings;
+  /** Transient connection state (never persisted). */
+  status: SpaceMouseConnectionStatus;
+  deviceName: string | null;
+
+  setSensitivity: (value: number) => void;
+  setTranslateSpeed: (value: number) => void;
+  setRotateSpeed: (value: number) => void;
+  toggleInvert: (axis: keyof SpaceMouseInvert) => void;
+  resetSettings: () => void;
+  setConnection: (status: SpaceMouseConnectionStatus, deviceName?: string | null) => void;
+}
+
+const noopStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
+
+export const useSpaceMouseStore = create<SpaceMouseState>()(
+  persist(
+    (set) => ({
+      settings: DEFAULT_SETTINGS,
+      status: 'idle',
+      deviceName: null,
+
+      setSensitivity: (value) => set((s) => ({ settings: { ...s.settings, sensitivity: value } })),
+      setTranslateSpeed: (value) =>
+        set((s) => ({ settings: { ...s.settings, translateSpeed: value } })),
+      setRotateSpeed: (value) => set((s) => ({ settings: { ...s.settings, rotateSpeed: value } })),
+      toggleInvert: (axis) =>
+        set((s) => ({
+          settings: {
+            ...s.settings,
+            invert: { ...s.settings.invert, [axis]: !s.settings.invert[axis] },
+          },
+        })),
+      resetSettings: () => set({ settings: DEFAULT_SETTINGS }),
+      setConnection: (status, deviceName) =>
+        set((s) => ({ status, deviceName: deviceName === undefined ? s.deviceName : deviceName })),
+    }),
+    {
+      name: SPACEMOUSE_SETTINGS_STORAGE_KEY,
+      storage: createJSONStorage(() =>
+        typeof localStorage !== 'undefined' ? localStorage : noopStorage
+      ),
+      // Only the tuning is durable; connection state is per-session.
+      partialize: (s) => ({ settings: s.settings }),
+      merge: (persisted, current) => {
+        const p = persisted as { settings?: Partial<SpaceMouseSettings> } | undefined;
+        return {
+          ...current,
+          settings: {
+            ...current.settings,
+            ...p?.settings,
+            invert: { ...current.settings.invert, ...p?.settings?.invert },
+          },
+        };
+      },
+    }
+  )
+);
+
+export function useSpaceMouseSettings(): SpaceMouseSettings {
+  return useSpaceMouseStore((s) => s.settings);
+}
+
+export function useSpaceMouseConnection(): {
+  status: SpaceMouseConnectionStatus;
+  deviceName: string | null;
+} {
+  return useSpaceMouseStore(useShallow((s) => ({ status: s.status, deviceName: s.deviceName })));
+}

--- a/src/shared/spacemouse/spaceMouseBus.test.ts
+++ b/src/shared/spacemouse/spaceMouseBus.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { spaceMouseBus } from './spaceMouseBus';
+import type { SpaceMouseCommand } from './types';
+
+function makeController(id: string) {
+  return {
+    id,
+    runCommand: vi.fn<(command: SpaceMouseCommand) => void>(),
+    invalidate: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  spaceMouseBus._resetForTests();
+});
+
+describe('spaceMouseBus registration', () => {
+  it('makes the first registered controller active', () => {
+    const a = makeController('a');
+    const b = makeController('b');
+    spaceMouseBus.register(a);
+    spaceMouseBus.register(b);
+    expect(spaceMouseBus.isActive('a')).toBe(true);
+    expect(spaceMouseBus.isActive('b')).toBe(false);
+  });
+
+  it('lets a canvas claim active focus', () => {
+    spaceMouseBus.register(makeController('a'));
+    spaceMouseBus.register(makeController('b'));
+    spaceMouseBus.setActive('b');
+    expect(spaceMouseBus.isActive('b')).toBe(true);
+  });
+
+  it('reassigns active when the active controller unregisters', () => {
+    const a = makeController('a');
+    const unregisterA = spaceMouseBus.register(a);
+    spaceMouseBus.register(makeController('b'));
+    expect(spaceMouseBus.isActive('a')).toBe(true);
+    unregisterA();
+    expect(spaceMouseBus.isActive('a')).toBe(false);
+    expect(spaceMouseBus.isActive('b')).toBe(true);
+  });
+});
+
+describe('spaceMouseBus motion', () => {
+  it('stores the latest raw deflection and wakes the active canvas', () => {
+    const a = makeController('a');
+    spaceMouseBus.register(a);
+    spaceMouseBus.setTranslation({ x: 10, y: 0, z: -5 });
+    spaceMouseBus.setRotation({ pitch: 1, roll: 0, yaw: 2 });
+    expect(spaceMouseBus.getRaw()).toEqual({
+      translation: { x: 10, y: 0, z: -5 },
+      rotation: { pitch: 1, roll: 0, yaw: 2 },
+    });
+    expect(a.invalidate).toHaveBeenCalled();
+  });
+
+  it('zeroes deflection on reset', () => {
+    spaceMouseBus.register(makeController('a'));
+    spaceMouseBus.setTranslation({ x: 10, y: 0, z: 0 });
+    spaceMouseBus.resetDeflection();
+    expect(spaceMouseBus.getRaw().translation).toEqual({ x: 0, y: 0, z: 0 });
+  });
+});
+
+describe('spaceMouseBus command routing', () => {
+  it('routes camera commands to the active controller only', () => {
+    const a = makeController('a');
+    const b = makeController('b');
+    spaceMouseBus.register(a);
+    spaceMouseBus.register(b);
+    spaceMouseBus.setActive('b');
+    spaceMouseBus.pressButton(0); // fit
+    expect(b.runCommand).toHaveBeenCalledWith('fit');
+    expect(a.runCommand).not.toHaveBeenCalled();
+  });
+
+  it('routes global commands to the global handler, not a canvas', () => {
+    const a = makeController('a');
+    spaceMouseBus.register(a);
+    const handler = vi.fn();
+    spaceMouseBus.setGlobalHandler(handler);
+    spaceMouseBus.pressButton(6); // undo
+    expect(handler).toHaveBeenCalledWith('undo');
+    expect(a.runCommand).not.toHaveBeenCalled();
+  });
+
+  it('ignores unmapped buttons', () => {
+    const a = makeController('a');
+    spaceMouseBus.register(a);
+    const handler = vi.fn();
+    spaceMouseBus.setGlobalHandler(handler);
+    spaceMouseBus.pressButton(99);
+    expect(a.runCommand).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/spacemouse/spaceMouseBus.ts
+++ b/src/shared/spacemouse/spaceMouseBus.ts
@@ -1,0 +1,104 @@
+import { isGlobalCommand, resolveButtonCommand } from './buttonMap';
+import type { RawDeflection, RawRotation, RawTranslation, SpaceMouseCommand } from './types';
+
+/** A per-canvas controller registered with the bus. */
+export interface SpaceMouseController {
+  id: string;
+  /** Run a camera command against this canvas. */
+  runCommand: (command: SpaceMouseCommand) => void;
+  /** Wake this canvas so a demand-frameloop renders. */
+  invalidate: () => void;
+}
+
+const zeroTranslation = (): RawTranslation => ({ x: 0, y: 0, z: 0 });
+const zeroRotation = (): RawRotation => ({ pitch: 0, roll: 0, yaw: 0 });
+
+/**
+ * Fans a single SpaceMouse's input out to whichever canvas is currently active.
+ * The device layer pushes raw axis values and button presses here; each mounted
+ * canvas controller reads the latest deflection every frame. Motion goes to the
+ * active canvas only; global commands (undo/redo) go to a registered handler.
+ */
+class SpaceMouseBus {
+  private translation = zeroTranslation();
+  private rotation = zeroRotation();
+  private readonly controllers = new Map<string, SpaceMouseController>();
+  private activeId: string | null = null;
+  private globalHandler: ((command: SpaceMouseCommand) => void) | null = null;
+
+  setGlobalHandler(handler: ((command: SpaceMouseCommand) => void) | null): void {
+    this.globalHandler = handler;
+  }
+
+  register(controller: SpaceMouseController): () => void {
+    this.controllers.set(controller.id, controller);
+    if (this.activeId === null) this.activeId = controller.id;
+    return () => this.unregister(controller.id);
+  }
+
+  private unregister(id: string): void {
+    this.controllers.delete(id);
+    if (this.activeId === id) {
+      this.activeId = this.controllers.keys().next().value ?? null;
+    }
+  }
+
+  setActive(id: string): void {
+    if (this.controllers.has(id)) this.activeId = id;
+  }
+
+  isActive(id: string): boolean {
+    return this.activeId === id;
+  }
+
+  setTranslation(translation: RawTranslation): void {
+    this.translation = translation;
+    this.wake();
+  }
+
+  setRotation(rotation: RawRotation): void {
+    this.rotation = rotation;
+    this.wake();
+  }
+
+  getRaw(): RawDeflection {
+    return { translation: this.translation, rotation: this.rotation };
+  }
+
+  /** Zero the deflection, e.g. when a device disconnects mid-motion. */
+  resetDeflection(): void {
+    this.translation = zeroTranslation();
+    this.rotation = zeroRotation();
+    this.wake();
+  }
+
+  pressButton(buttonIndex: number): void {
+    const command = resolveButtonCommand(buttonIndex);
+    if (command) this.dispatch(command);
+  }
+
+  dispatch(command: SpaceMouseCommand): void {
+    if (isGlobalCommand(command)) {
+      this.globalHandler?.(command);
+      return;
+    }
+    const active = this.activeId ? this.controllers.get(this.activeId) : null;
+    active?.runCommand(command);
+  }
+
+  private wake(): void {
+    const active = this.activeId ? this.controllers.get(this.activeId) : null;
+    active?.invalidate();
+  }
+
+  /** Test-only: clear all registrations and state. */
+  _resetForTests(): void {
+    this.controllers.clear();
+    this.activeId = null;
+    this.globalHandler = null;
+    this.translation = zeroTranslation();
+    this.rotation = zeroRotation();
+  }
+}
+
+export const spaceMouseBus = new SpaceMouseBus();

--- a/src/shared/spacemouse/types.ts
+++ b/src/shared/spacemouse/types.ts
@@ -1,0 +1,71 @@
+/** Raw axis values as emitted by spacemouse-webhid (signed 16-bit). */
+export interface RawTranslation {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface RawRotation {
+  pitch: number;
+  roll: number;
+  yaw: number;
+}
+
+export interface RawDeflection {
+  translation: RawTranslation;
+  rotation: RawRotation;
+}
+
+/**
+ * The five navigation axes we drive, named by what they do rather than by the
+ * device axis. The puck's roll is intentionally unmapped: every preview locks
+ * its camera up-vector, so a rolled camera would fight OrbitControls.
+ */
+export interface SpaceMouseInvert {
+  panX: boolean;
+  panY: boolean;
+  zoom: boolean;
+  orbitH: boolean;
+  orbitV: boolean;
+}
+
+export interface SpaceMouseSettings {
+  /** Overall multiplier applied on top of the per-family speeds. */
+  sensitivity: number;
+  /** Multiplier for pan + zoom. */
+  translateSpeed: number;
+  /** Multiplier for orbit. */
+  rotateSpeed: number;
+  invert: SpaceMouseInvert;
+}
+
+/** Normalized, deadzoned, invert-applied deflection in roughly [-1, 1]. */
+export interface Deflection {
+  panX: number;
+  panY: number;
+  zoom: number;
+  orbitH: number;
+  orbitV: number;
+}
+
+/** Per-frame camera motion amounts, already scaled by dt, speeds and distance. */
+export interface FrameMotion {
+  /** World units along the camera's right axis. */
+  panX: number;
+  /** World units along the camera's up axis. */
+  panY: number;
+  /** Signed dolly; positive dollies toward the target (zoom in). */
+  zoom: number;
+  /** Azimuth radians around the up axis. */
+  orbitH: number;
+  /** Polar radians around the camera's right axis. */
+  orbitV: number;
+}
+
+export type SpaceMouseConnectionStatus =
+  'unsupported' | 'idle' | 'connecting' | 'connected' | 'error';
+
+export type SpaceMouseCommand =
+  'fit' | 'reset' | 'view-top' | 'view-front' | 'view-right' | 'view-iso' | 'undo' | 'redo';
+
+export type CameraViewPreset = 'top' | 'front' | 'right' | 'iso';

--- a/src/shared/spacemouse/useSpaceMouseDevice.ts
+++ b/src/shared/spacemouse/useSpaceMouseDevice.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { startSpaceMouse, stopSpaceMouse } from './deviceManager';
+
+/**
+ * Starts SpaceMouse device management while `enabled`. Mount once, app-wide,
+ * gated on the labs flag. Auto-reconnects to an already-paired device; pairing a
+ * new one still needs a user gesture (see requestSpaceMousePairing).
+ */
+export function useSpaceMouseDevice(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return;
+    startSpaceMouse();
+    return () => stopSpaceMouse();
+  }, [enabled]);
+}

--- a/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.tsx
+++ b/src/shell/Modals/SettingsModal/tabs/LabsTab/LabsTab.tsx
@@ -10,6 +10,8 @@ import {
   SparklesIcon,
 } from '@/features/labs/components';
 import { useTranslation } from '@/i18n';
+import { SPACEMOUSE_FEATURE_ID } from '@/shared/spacemouse/constants';
+import { SpaceMouseSettings } from '@/shared/spacemouse/components/SpaceMouseSettings';
 import { SettingSection } from '../../components/SettingSection/SettingSection';
 
 export function LabsTab() {
@@ -45,14 +47,21 @@ export function LabsTab() {
 
         {toggleableFeatures.length > 0 ? (
           <div className="space-y-3">
-            {toggleableFeatures.map((feature) => (
-              <FeatureCard
-                key={feature.id}
-                feature={feature}
-                isEnabled={enabledFeatures[feature.id as FeatureId] ?? false}
-                onToggle={() => toggleFeature(feature.id as FeatureId)}
-              />
-            ))}
+            {toggleableFeatures.map((feature) => {
+              const isEnabled = enabledFeatures[feature.id as FeatureId] ?? false;
+              return (
+                <FeatureCard
+                  key={feature.id}
+                  feature={feature}
+                  isEnabled={isEnabled}
+                  onToggle={() => toggleFeature(feature.id as FeatureId)}
+                >
+                  {feature.id === SPACEMOUSE_FEATURE_ID && isEnabled ? (
+                    <SpaceMouseSettings />
+                  ) : null}
+                </FeatureCard>
+              );
+            })}
           </div>
         ) : (
           <div className="py-6 text-center text-content-tertiary">

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,7 +4,7 @@
     "target": "ES2024",
     "lib": ["ES2024", "DOM"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "w3c-web-hid"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
-    "types": ["vite/client", "vitest/globals", "node"],
+    "types": ["vite/client", "vitest/globals", "node", "w3c-web-hid"],
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -86,6 +86,12 @@ export default defineConfig({
       '@gridfinity/branded-types': fileURLToPath(
         new URL('./packages/branded-types/src/index.ts', import.meta.url)
       ),
+      // spacemouse-webhid's @spacemouse-lib/core imports `node:events`; map it to
+      // the browser `events` shim so the lazy SpaceMouse chunk bundles.
+      'node:events': 'events',
+      // spacemouse-webhid needs only a handful of Buffer methods; a tiny shim
+      // keeps the full buffer polyfill out of the bundle (nothing else uses it).
+      buffer: fileURLToPath(new URL('./src/shared/spacemouse/bufferShim.ts', import.meta.url)),
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## What

Adds 3Dconnexion SpaceMouse navigation for the 3D previews, gated behind a new experimental Labs flag (`SpaceMouse Navigation`, off by default). Closes #4012.

Push, tilt and twist the puck to pan, zoom and orbit the model; the buttons map to fit, view presets, reset and undo/redo.

## How it works

- **Input**: WebHID via the MIT `spacemouse-webhid` library, loaded lazily so it never enters the main bundle. WebHID is Chromium-only, so the Labs card notes the requirement and the panel disables Connect on other browsers.
- **Coverage**: a shared `SpaceMouseController` mounts inside every OrbitControls-backed canvas (layout, bin-designer, workshop, baseplate, GLB). The 2D cutout editor has no controls, so the controller no-ops there.
- **Motion**: object-mode 6-DOF (translate to pan, push/pull to zoom, twist to orbit about the target). It coexists with the mouse by re-deriving the OrbitControls target after each frame, and self-sustains the demand render loop while the puck is deflected.
- **Buttons**: routed through a small bus to the pointer-active canvas (camera commands) or globally (undo/redo).
- **Connection**: auto-reconnects to an already-paired device on load; first pairing uses the Connect button in the Labs card (WebHID requires a user gesture). Tuning (sensitivity, pan/zoom and orbit speed, per-axis invert) lives there too and persists locally.

## Footprint

- The device library loads on demand; a tiny `Buffer` shim replaces the full polyfill, keeping the lazy chunk at ~4.4 kB gzip.
- Measured Total JS delta vs main is ~16 kB gzip (the controller ships in the always-loaded layout chunk), so the Total JS size-limit is raised 2194 to 2210 kB.
- New i18n keys are translated across all 14 locales.

## Testing

Unit tests cover the axis mapping and deadzone, button map, camera-command geometry, the input bus, the settings store, the HID Buffer shim, the controller (motion + fit + active-canvas routing) and the settings panel. All quality gates pass locally (typecheck, lint, boundaries, design-system, component-structure, i18n x4, exhaustiveness, knip, size-limit).

**I could not test against real SpaceMouse hardware.** The report-parsing and camera math are unit-tested with synthetic input, but the live feel (axis directions, speed defaults) needs a hands-on pass. The per-axis invert toggles and speed sliders are the escape hatch if any axis feels reversed or off.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

