### PR TITLE
fix(community): handle a session-check network failure in update-mode prefill

### DIFF
--- a/src/features/community/components/PublishDialog/useOwnDesignPrefill.test.ts
+++ b/src/features/community/components/PublishDialog/useOwnDesignPrefill.test.ts
@@ -153,6 +153,33 @@ describe('useOwnDesignPrefill', () => {
     expect(useCommunityPublishStore.getState().context?.publishedId).toBe('Pub123456789');
   });
 
+  it('keeps the link when the session check fails at the network layer', async () => {
+    // getMe() rejecting (offline, DNS, dropped connection) is not a confirmed
+    // sign-out, so the 404 stays unconfirmed: keep the link and block the form,
+    // exactly as for a null session. The rejection must be handled here, not
+    // left to escape as an unhandled promise rejection.
+    const onUnpublished = vi.fn();
+    useCommunityPublishStore.getState().open(
+      {
+        designId: 'design-1',
+        designName: 'Screw Bin',
+        params,
+        paramsHash: 'hash',
+        publishedId: 'Pub123456789',
+        lineage: null,
+        draft: null,
+      },
+      undefined,
+      { onPublished: vi.fn().mockResolvedValue(true), onUnpublished, requestRecapture: vi.fn() }
+    );
+    vi.mocked(getMe).mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.mocked(fetchOwnDesign).mockResolvedValue(err({ kind: 'notFound' }));
+    const { result } = renderHook(() => useOwnDesignPrefill('Pub123456789', 'authenticated'));
+    await waitFor(() => expect(result.current.failed).toBe(true));
+    expect(onUnpublished).not.toHaveBeenCalled();
+    expect(useCommunityPublishStore.getState().context?.publishedId).toBe('Pub123456789');
+  });
+
   it('fails closed on a server error rather than editing blind', async () => {
     vi.mocked(fetchOwnDesign).mockResolvedValue(err({ kind: 'server' }));
     const { result } = renderHook(() => useOwnDesignPrefill('Pub123456789', 'authenticated'));

--- a/src/features/community/components/PublishDialog/useOwnDesignPrefill.ts
+++ b/src/features/community/components/PublishDialog/useOwnDesignPrefill.ts
@@ -64,23 +64,33 @@ export function useOwnDesignPrefill(
         // session is live before severing the local publishedId link, mirroring
         // publishedIdReconcile. On an unconfirmed session, keep the link and
         // block the form rather than mint a duplicate.
-        void getMe().then((me) => {
-          if (cancelled) return;
-          if (me === null) {
+        void getMe().then(
+          (me) => {
+            if (cancelled) return;
+            if (me === null) {
+              setFailed(true);
+              setResolved(true);
+              return;
+            }
+            const publish = useCommunityPublishStore.getState();
+            publish.handlers?.onUnpublished();
+            publish.clearContextPublishedId();
+            usePublishDialogStore.getState().switchToCreate();
+            useToastStore.getState().addToast({
+              message: t('community.publish.error.republishAsNew'),
+              type: 'info',
+            });
+            setResolved(true);
+          },
+          () => {
+            // A network failure confirming the session leaves it unconfirmed,
+            // like a null session: keep the link and block the form. Without
+            // this arm the getMe rejection escapes as an unhandled rejection.
+            if (cancelled) return;
             setFailed(true);
             setResolved(true);
-            return;
           }
-          const publish = useCommunityPublishStore.getState();
-          publish.handlers?.onUnpublished();
-          publish.clearContextPublishedId();
-          usePublishDialogStore.getState().switchToCreate();
-          useToastStore.getState().addToast({
-            message: t('community.publish.error.republishAsNew'),
-            type: 'info',
-          });
-          setResolved(true);
-        });
+        );
         return;
       }
       // Without the live record, submitting would overwrite the published


### PR DESCRIPTION
## What

In update-mode publishing, `useOwnDesignPrefill` reacts to a 404 from `fetchOwnDesign` by calling `getMe()` to confirm whether the session is live before severing the local `publishedId` link. That `getMe().then(...)` had no rejection arm, so a network failure during the check (offline, DNS, dropped connection) escaped as an **unhandled promise rejection** (`TypeError: Failed to fetch`) and left the hook stuck `pending` (the form never resolved).

This adds the missing rejection arm: an unconfirmed session is treated like a null one (keep the link, block the form), mirroring the already-guarded `getMe()` call in `publishedIdReconcile.ts`.

## Why

Fixes the auto-filed error #4015. The escaping path is distinct from the sync **push** path guarded in #3953, and started after it. `refreshFromServer` and `publishedIdReconcile` already route their `getMe()` rejections; this was the one remaining caller that did not.

## Test

Added a case that rejects `getMe()` with `TypeError: Failed to fetch`: before the fix it reproduced the unhandled rejection and the hook hung; after, the link is kept and the form fails closed. Full file (11 tests) green.

Closes #4015

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

