### PR TITLE
feat(bin-designer): hide the typography section until the design has text

### DIFF
--- a/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.test.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { BinScrollPanel } from './BinScrollPanel';
+import { GROUP_OF_CONTROL } from './groupControls';
 import { useDesignerStore } from '@/features/bin-designer/store';
+import { DESIGNER_SETTINGS } from '@/features/bin-designer/settingsManifest';
 import { DEFAULT_BIN_PARAMS, DEFAULT_UI_STATE } from '@/features/bin-designer/constants';
 
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
@@ -43,6 +45,14 @@ describe('BinScrollPanel', () => {
   it('hides typography until the design carries text', () => {
     const { container } = render(<BinScrollPanel frame="plain" />);
     expect(container.querySelector('[data-help-target="bd-type"]')).toBeNull();
+  });
+
+  it('maps exactly the settings-manifest controls to a group (help-jump completeness)', () => {
+    // A control the manifest knows but this map omits fails to open its group on
+    // a help deep-link; a stale key here is a typo. Parity catches both.
+    const manifest = DESIGNER_SETTINGS.map((entry) => entry.controlId).sort();
+    const mapped = Object.keys(GROUP_OF_CONTROL).sort();
+    expect(mapped).toEqual(manifest);
   });
 
   it('shows typography once the design carries text', () => {

--- a/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.test.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.test.tsx
@@ -26,7 +26,7 @@ describe('BinScrollPanel', () => {
     const targets = Array.from(container.querySelectorAll('[data-help-target]')).map((el) =>
       el.getAttribute('data-help-target')
     );
-    const order = ['bd-dimensions', 'bd-lid', 'bd-interior', 'bd-base', 'bd-type'];
+    const order = ['bd-dimensions', 'bd-lid', 'bd-interior', 'bd-base', 'bd-colors'];
     const positions = order.map((target) => targets.indexOf(target));
     expect(
       positions.every((p) => p >= 0),
@@ -38,5 +38,21 @@ describe('BinScrollPanel', () => {
   it('keeps split out of the scroll until the bin overflows the bed', () => {
     const { container } = render(<BinScrollPanel frame="plain" />);
     expect(container.querySelector('[data-help-target="bd-print-fit"]')).toBeNull();
+  });
+
+  it('hides typography until the design carries text', () => {
+    const { container } = render(<BinScrollPanel frame="plain" />);
+    expect(container.querySelector('[data-help-target="bd-type"]')).toBeNull();
+  });
+
+  it('shows typography once the design carries text', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        compartments: { ...DEFAULT_BIN_PARAMS.compartments, compartmentTexts: ['A'] },
+      },
+    });
+    const { container } = render(<BinScrollPanel frame="plain" />);
+    expect(container.querySelector('[data-help-target="bd-type"]')).not.toBeNull();
   });
 });

--- a/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
@@ -43,6 +43,7 @@ import { ColorsSection } from '../../panel/ColorsSection';
 import { PhysicalUnitsSection } from '../../panel/PhysicalUnitsSection';
 import { SetDefaultFooter } from '../../panel/SetDefaultFooter';
 import { modifiedGroups, type PanelGroup } from '../groupModified';
+import { GROUP_OF_CONTROL, HELP_SURFACES } from './groupControls';
 
 export interface BinScrollPanelProps {
   /** docked = desktop frame (resizable, collapsible); plain = fill the parent. */
@@ -56,38 +57,6 @@ export interface BinScrollPanelProps {
   /** Pinned below the scroll: the user dock. */
   readonly dock?: ReactNode;
 }
-
-/** The five help surfaces the groups listen on, plus the umbrella surface. */
-const HELP_SURFACES = [
-  'binDesigner',
-  'binDesigner:shape',
-  'binDesigner:interior',
-  'binDesigner:base',
-  'binDesigner:lid',
-  'binDesigner:finishing',
-] as const;
-
-/** Which group owns a help-jump target, so a deep link opens the right one. */
-const GROUP_OF_CONTROL: Readonly<Record<string, PanelGroup>> = {
-  'bd-dimensions': 'shape',
-  'bd-overhang': 'shape',
-  'bd-shape': 'shape',
-  'bd-walls': 'shape',
-  'bd-wall-cutouts': 'shape',
-  'bd-print-fit': 'shape',
-  'bd-lid': 'lid',
-  'bd-handles': 'lid',
-  'bd-interior': 'interior',
-  'bd-label-tabs': 'interior',
-  'bd-scoop': 'interior',
-  'bd-knife-rest': 'interior',
-  'bd-base': 'base',
-  'bd-type': 'finishing',
-  'bd-colors': 'finishing',
-  'bd-wall-style': 'finishing',
-  'bd-floor-pattern': 'finishing',
-  'bd-physical-units': 'finishing',
-};
 
 export function BinScrollPanel({ frame, toolbar, header, wrapContent, dock }: BinScrollPanelProps) {
   const t = useTranslation();
@@ -169,8 +138,7 @@ export function BinScrollPanel({ frame, toolbar, header, wrapContent, dock }: Bi
           <PanelSection helpTarget="bd-wall-cutouts">
             <WallCutoutsSection />
           </PanelSection>
-          {/* Split only surfaces when the bin overflows the bed — same conditional
-              the pre-rail panel used, kept in Shape rather than a trailing group. */}
+          {/* Shown only when the bin overflows the bed; no all-clear row when it fits. */}
           {needsSplit && (
             <PanelSection helpTarget="bd-print-fit">
               <SplitOptionsSection />

--- a/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
@@ -17,6 +17,7 @@ import { isPartialMask } from '@/shared/utils/cellMask';
 import { HELP_JUMP_EVENT_PREFIX, type HelpJumpEventDetail } from '@/shared/help/helpJumpDispatcher';
 import { useDesignerStore } from '@/features/bin-designer/store';
 import { jumpToDesignerControl } from '@/features/bin-designer/settingsManifest';
+import { binHasText } from '@/features/bin-designer/utils/binText';
 
 import { StickyGroupHeader } from '../../panel/StickyGroupHeader';
 import { PanelSection } from '../../panel/PanelSection';
@@ -91,10 +92,11 @@ const GROUP_OF_CONTROL: Readonly<Record<string, PanelGroup>> = {
 export function BinScrollPanel({ frame, toolbar, header, wrapContent, dock }: BinScrollPanelProps) {
   const t = useTranslation();
   const modified = useDesignerStore(useShallow((s) => modifiedGroups(s.params)));
-  const { showLabelTabs, isCustomShape } = useDesignerStore(
+  const { showLabelTabs, isCustomShape, hasText } = useDesignerStore(
     useShallow((s) => ({
       showLabelTabs: s.params.style === 'standard',
       isCustomShape: isPartialMask(s.params.cellMask),
+      hasText: binHasText(s.params),
     }))
   );
   const { needsSplit } = useSplitOptionsSection();
@@ -246,9 +248,13 @@ export function BinScrollPanel({ frame, toolbar, header, wrapContent, dock }: Bi
         modifiedLabel={markIf(modified.finishing)}
       >
         <div className="divide-y divide-stroke-subtle/50">
-          <PanelSection helpTarget="bd-type">
-            <TypeSection />
-          </PanelSection>
+          {/* Type settings govern captions; with nothing to style they only add
+              noise, so they appear once the design carries text. */}
+          {hasText && (
+            <PanelSection helpTarget="bd-type">
+              <TypeSection />
+            </PanelSection>
+          )}
           <PanelSection helpTarget="bd-colors">
             <ColorsSection />
           </PanelSection>

--- a/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
@@ -216,8 +216,6 @@ export function BinScrollPanel({ frame, toolbar, header, wrapContent, dock }: Bi
         modifiedLabel={markIf(modified.finishing)}
       >
         <div className="divide-y divide-stroke-subtle/50">
-          {/* Type settings govern captions; with nothing to style they only add
-              noise, so they appear once the design carries text. */}
           {hasText && (
             <PanelSection helpTarget="bd-type">
               <TypeSection />

--- a/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/groupControls.ts
+++ b/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/groupControls.ts
@@ -1,0 +1,42 @@
+/** Help-jump wiring for the scroll panel's anatomical groups. */
+
+import type { PanelGroup } from '../groupModified';
+
+/** The help surfaces the groups listen on, plus the umbrella surface. */
+export const HELP_SURFACES = [
+  'binDesigner',
+  'binDesigner:shape',
+  'binDesigner:interior',
+  'binDesigner:base',
+  'binDesigner:lid',
+  'binDesigner:finishing',
+] as const;
+
+/**
+ * Which group owns a help-jump target, so a deep link opens the right one. The
+ * anatomical grouping differs from the rail's task categories, so this cannot
+ * reuse `categoryForControl`; a test pins it to cover every `DESIGNER_SETTINGS`
+ * control, since a target missing here silently fails to open its group.
+ */
+export const GROUP_OF_CONTROL: Readonly<Record<string, PanelGroup>> = {
+  'bd-dimensions': 'shape',
+  'bd-overhang': 'shape',
+  'bd-shape': 'shape',
+  'bd-walls': 'shape',
+  'bd-wall-cutouts': 'shape',
+  'bd-print-fit': 'shape',
+  'bd-lid': 'lid',
+  'bd-lid-grip': 'lid',
+  'bd-handles': 'lid',
+  'bd-interior': 'interior',
+  'bd-label-tabs': 'interior',
+  'bd-scoop': 'interior',
+  'bd-knife-rest': 'interior',
+  'bd-slide-tray': 'interior',
+  'bd-base': 'base',
+  'bd-type': 'finishing',
+  'bd-colors': 'finishing',
+  'bd-wall-style': 'finishing',
+  'bd-floor-pattern': 'finishing',
+  'bd-physical-units': 'finishing',
+};

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -1,12 +1,10 @@
 /**
  * Parameter panel for the bin designer.
  *
- * A rail shell of task categories (BinPanelShell), each holding a short page:
- * - Shape:    dimensions, drawer fit, custom footprint, walls, body/base
- * - Interior: layout mode, label tabs, scoop, knife rest
- * - Features: the lid (wall features join it when Walls splits)
- * - Style:    typography and colors
- * - Print:    bed-fit splitting, physical units, defaults
+ * A persisted view toggle picks the layout: `BinScrollPanel` (the default) lays
+ * the sections out as one top-to-bottom scroll of collapsible groups, while
+ * `BinPanelShell` puts them behind a task-category rail. Both draw on the same
+ * section components and share the community card, variant controls, and dock.
  *
  * The non-bin item kinds keep their own single-page panels inside the same
  * resizable frame.
@@ -263,9 +261,8 @@ function BinParameterPanel({ frame }: { readonly frame: 'docked' | 'plain' }) {
     </>
   );
 
-  // A compact two-option view switch shared by both layouts: the single scroll
-  // of grouped sections, or the compact category rail. IconButton's `active`
-  // gives the pressed segment its fill and the aria-pressed state.
+  // One view switch, reused by both layouts: the scroll's pinned toolbar and the
+  // rail's header.
   const viewModes = [
     { mode: 'scroll' as const, paths: ICON_PATHS.menu, label: t('binDesigner.panel.viewAsScroll') },
     {

--- a/src/features/bin-designer/components/ParameterPanel/binViewModeStorage.ts
+++ b/src/features/bin-designer/components/ParameterPanel/binViewModeStorage.ts
@@ -4,7 +4,6 @@ export type BinPanelViewMode = 'scroll' | 'rail';
 
 const VIEW_MODE_KEY = 'gridfinity-designer-view-mode-v1';
 
-/** The single long scroll is the default; the compact rail is opt-in. */
 export function loadViewMode(): BinPanelViewMode {
   try {
     return localStorage.getItem(VIEW_MODE_KEY) === 'rail' ? 'rail' : 'scroll';

--- a/src/features/bin-designer/components/ParameterPanel/categoryModified.ts
+++ b/src/features/bin-designer/components/ParameterPanel/categoryModified.ts
@@ -8,9 +8,7 @@
  */
 
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
-import type { BinParams } from '@/features/bin-designer/types';
-
-import type { DesignerCategory } from '@/features/bin-designer/types';
+import type { BinParams, DesignerCategory } from '@/features/bin-designer/types';
 
 import { paramFieldModified } from './paramFieldModified';
 

--- a/src/features/bin-designer/components/ParameterPanel/categoryModified.ts
+++ b/src/features/bin-designer/components/ParameterPanel/categoryModified.ts
@@ -12,6 +12,8 @@ import type { BinParams } from '@/features/bin-designer/types';
 
 import type { DesignerCategory } from '@/features/bin-designer/types';
 
+import { paramFieldModified } from './paramFieldModified';
+
 export type PageCategory = Exclude<DesignerCategory, 'selection'>;
 
 /**
@@ -48,51 +50,6 @@ const CATEGORY_OF: Partial<Record<keyof BinParams, PageCategory>> = {
   splitConnectors: 'print',
 };
 
-/**
- * Order-insensitive structural compare.
- *
- * Keys are sorted before serialising because params are rebuilt by spreading,
- * which does not preserve insertion order. Serialising also drops
- * undefined-valued keys, so an explicitly-undefined field compares equal to an
- * absent one, the same "absent is the default" convention the community
- * fingerprint relies on.
- */
-function canonical(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonical);
-  if (value !== null && typeof value === 'object') {
-    const record = value as Record<string, unknown>;
-    return Object.fromEntries(
-      Object.keys(record)
-        .sort()
-        .map((key) => [key, canonical(record[key])])
-    );
-  }
-  return value;
-}
-
-function matchesDefault(params: BinParams, key: string): boolean {
-  const defaults = DEFAULT_BIN_PARAMS as unknown as Record<string, unknown>;
-  const current = params as unknown as Record<string, unknown>;
-
-  // A design that omits a key runs on the default, so absent IS unmodified.
-  // Legacy persisted designs omit `featureColors` and `floorPattern` (both have
-  // runtime fallbacks at every read site), and comparing an absent key against
-  // a populated default marked their group changed over a field the owner never
-  // touched. A dot that is sometimes wrong cannot be trusted anywhere, which is
-  // the same reason the cross-group keys below are excluded outright.
-  if (current[key] === undefined) return true;
-
-  // Identity before structure. Params start as a shallow copy of the defaults
-  // and the store updates them immutably with structural sharing, so a field
-  // nobody has touched is still the DEFAULT object itself, and an edit changes
-  // the identity of only the branch it touched. Without this the serialisation
-  // below ran over every field on every params change, including `meshAssets`,
-  // whose entries each hold a base64-deflated mesh.
-  if (current[key] === defaults[key]) return true;
-
-  return JSON.stringify(canonical(current[key])) === JSON.stringify(canonical(defaults[key]));
-}
-
 export function modifiedCategories(params: BinParams): Record<PageCategory, boolean> {
   const modified: Record<PageCategory, boolean> = {
     shape: false,
@@ -110,8 +67,9 @@ export function modifiedCategories(params: BinParams): Record<PageCategory, bool
   // `surfaceText` and `textDefaults` are text appearance wherever the letters
   // sit, so both attribute cleanly to Style instead of being excluded.
   for (const key of keys) {
-    if (matchesDefault(params, key)) continue;
-    modified[CATEGORY_OF[key as keyof BinParams] ?? 'shape'] = true;
+    if (paramFieldModified(params, key)) {
+      modified[CATEGORY_OF[key as keyof BinParams] ?? 'shape'] = true;
+    }
   }
 
   return modified;

--- a/src/features/bin-designer/components/ParameterPanel/groupModified.ts
+++ b/src/features/bin-designer/components/ParameterPanel/groupModified.ts
@@ -11,6 +11,8 @@
 import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
 import type { BinParams } from '@/features/bin-designer/types';
 
+import { paramFieldModified } from './paramFieldModified';
+
 export type PanelGroup = 'shape' | 'lid' | 'interior' | 'base' | 'finishing';
 
 /**
@@ -57,51 +59,6 @@ const GROUP_OF: Partial<Record<keyof BinParams, PanelGroup>> = {
  */
 const SPANS_GROUPS: ReadonlySet<string> = new Set(['surfaceText', 'textDefaults']);
 
-/**
- * Order-insensitive structural compare.
- *
- * Keys are sorted before serialising because params are rebuilt by spreading,
- * which does not preserve insertion order. Serialising also drops
- * undefined-valued keys, so an explicitly-undefined field compares equal to an
- * absent one, the same "absent is the default" convention the community
- * fingerprint relies on.
- */
-function canonical(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonical);
-  if (value !== null && typeof value === 'object') {
-    const record = value as Record<string, unknown>;
-    return Object.fromEntries(
-      Object.keys(record)
-        .sort()
-        .map((key) => [key, canonical(record[key])])
-    );
-  }
-  return value;
-}
-
-function matchesDefault(params: BinParams, key: string): boolean {
-  const defaults = DEFAULT_BIN_PARAMS as unknown as Record<string, unknown>;
-  const current = params as unknown as Record<string, unknown>;
-
-  // A design that omits a key runs on the default, so absent IS unmodified.
-  // Legacy persisted designs omit `featureColors` and `floorPattern` (both have
-  // runtime fallbacks at every read site), and comparing an absent key against
-  // a populated default marked their group changed over a field the owner never
-  // touched. A dot that is sometimes wrong cannot be trusted anywhere, which is
-  // the same reason the SPANS keys above are excluded outright.
-  if (current[key] === undefined) return true;
-
-  // Identity before structure. Params start as a shallow copy of the defaults
-  // and the store updates them immutably with structural sharing, so a field
-  // nobody has touched is still the DEFAULT object itself, and an edit changes
-  // the identity of only the branch it touched. Without this the serialisation
-  // below ran over every field on every params change, including `meshAssets`,
-  // whose entries each hold a base64-deflated mesh.
-  if (current[key] === defaults[key]) return true;
-
-  return JSON.stringify(canonical(current[key])) === JSON.stringify(canonical(defaults[key]));
-}
-
 export function modifiedGroups(params: BinParams): Record<PanelGroup, boolean> {
   const modified: Record<PanelGroup, boolean> = {
     shape: false,
@@ -117,8 +74,9 @@ export function modifiedGroups(params: BinParams): Record<PanelGroup, boolean> {
 
   for (const key of keys) {
     if (SPANS_GROUPS.has(key)) continue;
-    if (matchesDefault(params, key)) continue;
-    modified[GROUP_OF[key as keyof BinParams] ?? 'shape'] = true;
+    if (paramFieldModified(params, key)) {
+      modified[GROUP_OF[key as keyof BinParams] ?? 'shape'] = true;
+    }
   }
 
   return modified;

--- a/src/features/bin-designer/components/ParameterPanel/paramFieldModified.ts
+++ b/src/features/bin-designer/components/ParameterPanel/paramFieldModified.ts
@@ -1,0 +1,54 @@
+/**
+ * Whether a single top-level param field differs from its stock default.
+ *
+ * Shared by `groupModified` and `categoryModified`, which route the same
+ * yes/no through two different taxonomies (anatomical groups vs. task
+ * categories) and decide separately what to do with keys that span more than
+ * one bucket.
+ */
+
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams } from '@/features/bin-designer/types';
+
+/**
+ * Order-insensitive structural compare.
+ *
+ * Keys are sorted before serialising because params are rebuilt by spreading,
+ * which does not preserve insertion order. Serialising also drops
+ * undefined-valued keys, so an explicitly-undefined field compares equal to an
+ * absent one, the same "absent is the default" convention the community
+ * fingerprint relies on.
+ */
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, canonical(record[key])])
+    );
+  }
+  return value;
+}
+
+export function paramFieldModified(params: BinParams, key: string): boolean {
+  const defaults = DEFAULT_BIN_PARAMS as unknown as Record<string, unknown>;
+  const current = params as unknown as Record<string, unknown>;
+
+  // A design that omits a key runs on the default, so absent is NOT modified.
+  // Legacy persisted designs omit `featureColors` and `floorPattern` (both have
+  // runtime fallbacks at every read site), and comparing an absent key against
+  // a populated default would call a field the owner never touched "modified".
+  if (current[key] === undefined) return false;
+
+  // Identity before structure. Params start as a shallow copy of the defaults
+  // and the store updates them immutably with structural sharing, so a field
+  // nobody has touched is still the DEFAULT object itself, and an edit changes
+  // the identity of only the branch it touched. Without this the serialisation
+  // below ran over every field on every params change, including `meshAssets`,
+  // whose entries each hold a base64-deflated mesh.
+  if (current[key] === defaults[key]) return false;
+
+  return JSON.stringify(canonical(current[key])) !== JSON.stringify(canonical(defaults[key]));
+}

--- a/src/features/bin-designer/components/panel/pages/StylePage/StylePage.test.tsx
+++ b/src/features/bin-designer/components/panel/pages/StylePage/StylePage.test.tsx
@@ -14,17 +14,23 @@ describe('StylePage', () => {
     });
   });
 
-  it('composes its sections with their help targets', () => {
+  it('hides typography until the design carries text', () => {
     const { container } = render(<StylePage />);
-    expect(container.querySelector('[data-help-target="bd-type"]'), 'bd-type').not.toBeNull();
-    expect(container.querySelector('[data-help-target="bd-colors"]'), 'bd-colors').not.toBeNull();
-    expect(
-      container.querySelector('[data-help-target="bd-wall-style"]'),
-      'bd-wall-style'
-    ).not.toBeNull();
-    expect(
-      container.querySelector('[data-help-target="bd-floor-pattern"]'),
-      'bd-floor-pattern'
-    ).not.toBeNull();
+    expect(container.querySelector('[data-help-target="bd-type"]')).toBeNull();
+    // The rest of Style still renders.
+    expect(container.querySelector('[data-help-target="bd-colors"]')).not.toBeNull();
+  });
+
+  it('composes its sections with their help targets once text exists', () => {
+    useDesignerStore.setState({
+      params: {
+        ...DEFAULT_BIN_PARAMS,
+        compartments: { ...DEFAULT_BIN_PARAMS.compartments, compartmentTexts: ['A'] },
+      },
+    });
+    const { container } = render(<StylePage />);
+    for (const target of ['bd-type', 'bd-colors', 'bd-wall-style', 'bd-floor-pattern']) {
+      expect(container.querySelector(`[data-help-target="${target}"]`), target).not.toBeNull();
+    }
   });
 });

--- a/src/features/bin-designer/components/panel/pages/StylePage/StylePage.tsx
+++ b/src/features/bin-designer/components/panel/pages/StylePage/StylePage.tsx
@@ -11,8 +11,6 @@ export function StylePage() {
   const hasText = useDesignerStore((s) => binHasText(s.params));
   return (
     <div className="divide-y divide-stroke-subtle/50">
-      {/* Type settings govern captions; with nothing to style they only add
-          noise, so they appear once the design carries text. */}
       {hasText && (
         <PanelSection helpTarget="bd-type">
           <TypeSection />

--- a/src/features/bin-designer/components/panel/pages/StylePage/StylePage.tsx
+++ b/src/features/bin-designer/components/panel/pages/StylePage/StylePage.tsx
@@ -1,3 +1,5 @@
+import { useDesignerStore } from '@/features/bin-designer/store';
+import { binHasText } from '@/features/bin-designer/utils/binText';
 import { PanelSection } from '../../PanelSection';
 import { TypeSection } from '../../TypeSection';
 import { ColorsSection } from '../../ColorsSection';
@@ -6,11 +8,16 @@ import { FloorPatternSection } from '../../BaseSection';
 
 /** Appearance: typography, colors, wall patterns and text, floor pattern. */
 export function StylePage() {
+  const hasText = useDesignerStore((s) => binHasText(s.params));
   return (
     <div className="divide-y divide-stroke-subtle/50">
-      <PanelSection helpTarget="bd-type">
-        <TypeSection />
-      </PanelSection>
+      {/* Type settings govern captions; with nothing to style they only add
+          noise, so they appear once the design carries text. */}
+      {hasText && (
+        <PanelSection helpTarget="bd-type">
+          <TypeSection />
+        </PanelSection>
+      )}
       <PanelSection helpTarget="bd-colors">
         <ColorsSection />
       </PanelSection>

--- a/src/features/bin-designer/utils/binText.test.ts
+++ b/src/features/bin-designer/utils/binText.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/features/bin-designer/constants';
+import type { BinParams, Cutout } from '@/features/bin-designer/types';
+import { binHasText } from './binText';
+
+const withParams = (over: Partial<BinParams>): BinParams => ({ ...DEFAULT_BIN_PARAMS, ...over });
+const cut = (over: Partial<Cutout>): Cutout => over as Cutout;
+
+describe('binHasText', () => {
+  it('is false for a stock bin with no captions', () => {
+    expect(binHasText(DEFAULT_BIN_PARAMS)).toBe(false);
+  });
+
+  it('is false for whitespace-only text', () => {
+    expect(binHasText(withParams({ surfaceText: { lidText: '   ' } }))).toBe(false);
+  });
+
+  it('sees lid and wall text', () => {
+    expect(binHasText(withParams({ surfaceText: { lidText: 'HELLO' } }))).toBe(true);
+    expect(binHasText(withParams({ surfaceText: { walls: { left: 'X' } } }))).toBe(true);
+  });
+
+  it('sees compartment tab captions', () => {
+    expect(
+      binHasText(
+        withParams({
+          compartments: { ...DEFAULT_BIN_PARAMS.compartments, compartmentTexts: ['A'] },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('sees spanning-tab row captions', () => {
+    expect(
+      binHasText(withParams({ label: { ...DEFAULT_BIN_PARAMS.label, rowTexts: ['Row'] } }))
+    ).toBe(true);
+  });
+
+  it('sees engraved cutout labels but not plain cavity names', () => {
+    expect(binHasText(withParams({ cutouts: [cut({ shape: 'text', label: 'T' })] }))).toBe(true);
+    expect(
+      binHasText(
+        withParams({ cutouts: [cut({ shape: 'circle', engraveLabel: true, label: 'L' })] })
+      )
+    ).toBe(true);
+    // A named cavity that does not engrave is editor metadata, not text.
+    expect(
+      binHasText(
+        withParams({ cutouts: [cut({ shape: 'circle', engraveLabel: false, label: 'name' })] })
+      )
+    ).toBe(false);
+  });
+
+  it('sees per-instance array labels on an engraving cutout', () => {
+    expect(
+      binHasText(
+        withParams({
+          cutouts: [
+            cut({
+              shape: 'circle',
+              engraveLabel: true,
+              label: '',
+              array: { labels: ['', 'A'] } as Cutout['array'],
+            }),
+          ],
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('sees engraved labels on lid cutouts', () => {
+    expect(
+      binHasText(
+        withParams({
+          lid: { ...DEFAULT_BIN_PARAMS.lid, cutouts: [cut({ shape: 'text', label: 'X' })] },
+        })
+      )
+    ).toBe(true);
+  });
+});

--- a/src/features/bin-designer/utils/binText.test.ts
+++ b/src/features/bin-designer/utils/binText.test.ts
@@ -4,7 +4,25 @@ import type { BinParams, Cutout } from '@/features/bin-designer/types';
 import { binHasText } from './binText';
 
 const withParams = (over: Partial<BinParams>): BinParams => ({ ...DEFAULT_BIN_PARAMS, ...over });
-const cut = (over: Partial<Cutout>): Cutout => over as Cutout;
+
+// A fully-typed base so the compiler keeps these inputs honest if binHasText
+// grows to read more cutout fields.
+const cut = (over: Partial<Cutout>): Cutout => ({
+  id: 'c1',
+  shape: 'rectangle',
+  x: 10,
+  y: 10,
+  width: 20,
+  depth: 20,
+  cutDepth: 5,
+  rotation: 0,
+  cornerRadius: 2,
+  label: '',
+  groupId: null,
+  locked: false,
+  hidden: false,
+  ...over,
+});
 
 describe('binHasText', () => {
   it('is false for a stock bin with no captions', () => {

--- a/src/features/bin-designer/utils/binText.ts
+++ b/src/features/bin-designer/utils/binText.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether a bin design carries any text the typography settings would govern.
+ *
+ * Text reaches the type system from more places than the type specimen tracks:
+ * wall and lid text (`surfaceText`), per-compartment tab captions
+ * (`compartmentTexts`), spanning-tab captions (`label.rowTexts`), and engraved
+ * cutout labels on both the bin and the lid. A cutout's label only counts when
+ * the cutout actually engraves it (a `text` cutout, or one with `engraveLabel`);
+ * a plain cavity's label is editor metadata, not geometry. Used to hide the
+ * Typography section when there is nothing for it to style.
+ */
+
+import type { BinParams, Cutout } from '../types';
+
+const filled = (text: string | undefined): boolean => (text?.trim() ?? '') !== '';
+
+function cutoutEngravesText(cutout: Cutout): boolean {
+  if (cutout.shape !== 'text' && !cutout.engraveLabel) return false;
+  return filled(cutout.label) || (cutout.array?.labels?.some(filled) ?? false);
+}
+
+export function binHasText(params: BinParams): boolean {
+  const surface = params.surfaceText;
+  if (surface) {
+    if (filled(surface.lidText)) return true;
+    if (surface.walls && Object.values(surface.walls).some(filled)) return true;
+  }
+  if (params.compartments.compartmentTexts?.some(filled)) return true;
+  if (params.label.rowTexts?.some(filled)) return true;
+  if (params.cutouts.some(cutoutEngravesText)) return true;
+  if (params.lid.cutouts?.some(cutoutEngravesText)) return true;
+  return false;
+}


### PR DESCRIPTION
## What

The Typography section is now shown only when the bin design actually carries text. Both layouts get it: the single scroll's Finishing group and the rail's Style page. A stock bin (no labels, no wall/lid text, no engraved cutouts) opens its appearance group straight at Colour, with no empty type controls or stray divider.

## Why

Type settings govern captions. With nothing to style they are just noise at the top of the appearance group, which was the complaint.

## How

New tested helper `binHasText(params)`. "Has text" spans **every** source the type system reaches, not only the two the type specimen already tracked:

- wall text and lid text (`surfaceText`)
- per-compartment tab captions (`compartmentTexts`)
- spanning-tab row captions (`label.rowTexts`)
- engraved cutout labels on the bin **and** the lid

A plain cavity's label is editor metadata, so only cutouts that actually engrave count (`shape: 'text'`, or `engraveLabel`), including per-instance array `labels`. Erring toward *showing* here is deliberate: a false hide would strand a control the user needs, so the predicate is exhaustive.

## Verification

- typecheck, lint pass
- `binText` unit tests cover every source, the engrave gate, array labels, lid cutouts, and whitespace-only
- `BinScrollPanel` and `StylePage` tests assert typography is hidden by default and appears once a caption exists
- confirmed visually: the Finishing group opens at Colour with no layout gap

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

