### PR TITLE
feat(bin-designer): finer, Algolia-style search over designer sub-options

### DIFF
--- a/src/features/bin-designer/components/ParameterPanel/DesignerSearchBar/DesignerSearchBar.test.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/DesignerSearchBar/DesignerSearchBar.test.tsx
@@ -33,14 +33,15 @@ describe('DesignerSearchBar', () => {
     const input = open();
     fireEvent.change(input, { target: { value: 'scoop' } });
     const listbox = screen.getByRole('listbox');
-    expect(within(listbox).getByText('Finger scoop')).toBeInTheDocument();
+    // The matched span splits the label across nodes, so match by option name.
+    expect(within(listbox).getByRole('option', { name: /finger scoop/i })).toBeInTheDocument();
     expect(within(listbox).queryByText('Bin dimensions')).not.toBeInTheDocument();
   });
 
   it('jumps to the control and clears the query when a result is chosen', () => {
     const input = open();
     fireEvent.change(input, { target: { value: 'scoop' } });
-    fireEvent.click(screen.getByText('Finger scoop'));
+    fireEvent.click(screen.getByRole('option', { name: /finger scoop/i }));
     expect(jumpToDesignerControl).toHaveBeenCalledWith('bd-scoop');
     expect((input as HTMLInputElement).value).toBe('');
   });

--- a/src/features/bin-designer/components/ParameterPanel/DesignerSearchBar/DesignerSearchBar.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/DesignerSearchBar/DesignerSearchBar.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { useId, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { Input, IconButton, SearchIcon, XIcon } from '@/design-system';
 import { useTranslation } from '@/i18n';
@@ -8,19 +8,39 @@ import { jumpToDesignerControl } from '@/features/bin-designer/settingsManifest'
 import { binHasText } from '@/features/bin-designer/utils/binText';
 import {
   useDesignerSettingsSearch,
-  type DesignerControlSearchResult,
+  type DesignerSearchResult,
 } from '@/features/bin-designer/search/useDesignerSettingsSearch';
+import type { HighlightRange } from '@/features/bin-designer/search/matcher';
 
 interface DesignerSearchBarProps {
   readonly viewMode: 'scroll' | 'rail';
   readonly needsSplit: boolean;
 }
 
+/** Renders `label` with the matched ranges emphasized. */
+function highlighted(label: string, ranges: readonly HighlightRange[]): ReactNode {
+  if (ranges.length === 0) return label;
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  for (const [start, end] of ranges) {
+    if (start > cursor) parts.push(label.slice(cursor, start));
+    parts.push(
+      <span key={start} className="font-semibold text-content">
+        {label.slice(start, end)}
+      </span>
+    );
+    cursor = end;
+  }
+  if (cursor < label.length) parts.push(label.slice(cursor));
+  return parts;
+}
+
 /**
  * A search field pinned at the top of the designer panel. Typing matches any
- * control by name or synonym; an empty field lists every available control
- * grouped by category, so the bar doubles as a browse-all. Selecting a result
- * jumps the panel to that control (the same deep-link the Help modal uses).
+ * control or sub-option by name or synonym, ranked, with the match highlighted
+ * and the owning section shown as a breadcrumb; an empty field lists the
+ * sections by category to browse. Selecting a result jumps the panel to the
+ * section that holds it (the same deep-link the Help modal uses).
  */
 export function DesignerSearchBar({ viewMode, needsSplit }: DesignerSearchBarProps) {
   const t = useTranslation();
@@ -145,13 +165,13 @@ export function DesignerSearchBar({ viewMode, needsSplit }: DesignerSearchBarPro
             >
               {results.map((result, index) => (
                 <ResultRow
-                  key={result.controlId}
+                  key={result.id}
                   result={result}
                   index={index}
                   active={index === activeOption}
                   listboxId={listboxId}
                   showCategoryHeader={browsing && result.category !== results[index - 1]?.category}
-                  showCategoryBadge={!browsing}
+                  searching={!browsing}
                   onChoose={() => choose(index)}
                   onHover={() => setActiveIndex(index)}
                 />
@@ -169,19 +189,22 @@ function ResultRow({
   active,
   listboxId,
   showCategoryHeader,
-  showCategoryBadge,
+  searching,
   onChoose,
   onHover,
 }: {
-  readonly result: DesignerControlSearchResult;
+  readonly result: DesignerSearchResult;
   readonly index: number;
   readonly active: boolean;
   readonly listboxId: string;
   readonly showCategoryHeader: boolean;
-  readonly showCategoryBadge: boolean;
+  readonly searching: boolean;
   readonly onChoose: () => void;
   readonly onHover: () => void;
 }) {
+  // In search mode every row states where it lives: a sub-option shows its
+  // parent section, a section shows its category.
+  const location = result.breadcrumb ?? result.categoryLabel;
   return (
     <>
       {showCategoryHeader && (
@@ -204,23 +227,14 @@ function ResultRow({
         onMouseDown={(e) => e.preventDefault()}
         onClick={onChoose}
         onMouseEnter={onHover}
-        className={`flex w-full cursor-pointer items-center justify-between gap-3 px-3 py-1.5 text-left ${
+        className={`flex w-full cursor-pointer flex-col px-3 py-1.5 text-left ${
           active ? 'bg-surface-hover' : ''
         }`}
       >
-        <span className="min-w-0 flex-1">
-          <span
-            className={`block truncate text-sm ${active ? 'text-content' : 'text-content-secondary'}`}
-          >
-            {result.label}
-          </span>
-          <span className="block truncate text-xs text-content-tertiary">{result.description}</span>
+        <span className={`truncate text-sm ${active ? 'text-content' : 'text-content-secondary'}`}>
+          {highlighted(result.label, result.highlight)}
         </span>
-        {showCategoryBadge && (
-          <span className="flex-shrink-0 text-xs text-content-tertiary">
-            {result.categoryLabel}
-          </span>
-        )}
+        {searching && <span className="truncate text-xs text-content-tertiary">{location}</span>}
       </div>
     </>
   );

--- a/src/features/bin-designer/search/designerControlRegistry.test.ts
+++ b/src/features/bin-designer/search/designerControlRegistry.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import {
   DESIGNER_CONTROL_SEARCH,
+  DESIGNER_OPTION_RECORDS,
   isDesignerControlAvailable,
   type ControlAvailabilityContext,
 } from './designerControlRegistry';
 import { DESIGNER_SETTINGS } from '../settingsManifest';
+
+const SECTION_IDS = new Set(DESIGNER_CONTROL_SEARCH.map((s) => s.controlId));
 
 const baseCtx: ControlAvailabilityContext = {
   style: 'standard',
@@ -35,6 +38,17 @@ describe('designerControlRegistry', () => {
       expect(entry.titleKey).toMatch(/^help\.target\.binDesigner\./);
       expect(entry.descriptionKey).toMatch(/^help\.target\.binDesigner\./);
       expect(entry.keywordsKey).toMatch(/^help\.target\.binDesigner\./);
+    }
+  });
+
+  it('anchors every sub-option to a real section and gives it synonyms', () => {
+    const ids = new Set<string>();
+    for (const opt of DESIGNER_OPTION_RECORDS) {
+      expect(SECTION_IDS.has(opt.section)).toBe(true);
+      expect(opt.labelKey.length).toBeGreaterThan(0);
+      expect(opt.keywords.length).toBeGreaterThan(0);
+      expect(ids.has(opt.id)).toBe(false); // ids are unique
+      ids.add(opt.id);
     }
   });
 

--- a/src/features/bin-designer/search/designerControlRegistry.ts
+++ b/src/features/bin-designer/search/designerControlRegistry.ts
@@ -1,12 +1,17 @@
 /**
- * Search index for the bin designer's controls: one entry per `data-help-target`
- * section, carrying the i18n keys the search bar matches and shows. The category
- * a control belongs to is not duplicated here — it comes from `categoryForControl`
- * in the settings manifest, which stays the single source of truth.
+ * The bin designer's search index, in two layers:
  *
- * Reuses the `help.target.binDesigner.*` keys the Help modal already owns for the
- * controls it covers, and adds keys for the ones it does not, so both surfaces
- * draw synonyms from one place.
+ * - `DESIGNER_CONTROL_SEARCH` — one record per `data-help-target` SECTION, with
+ *   i18n title/description/synonyms. These are the browse-level entries.
+ * - `DESIGNER_OPTION_RECORDS` — finer sub-options inside those sections
+ *   (Lightweight floor, Screw holes, Lid grip, …). Each reuses an existing
+ *   translated label key and carries English-only synonyms, so richer coverage
+ *   costs no new translation. An option's `section` is both its breadcrumb
+ *   parent and its jump target: only section-level markers exist in the DOM, so
+ *   selecting an option lands the user on the section that holds it.
+ *
+ * A control's category is not duplicated here — it comes from `categoryForControl`
+ * in the settings manifest, the single source of truth.
  */
 
 import type { BinParams } from '@/features/bin-designer/types';
@@ -138,6 +143,289 @@ export const DESIGNER_CONTROL_SEARCH: readonly DesignerControlSearchEntry[] = [
     titleKey: 'help.target.binDesigner.printFit.title',
     descriptionKey: 'help.target.binDesigner.printFit.description',
     keywordsKey: 'help.target.binDesigner.printFit.keywords',
+  },
+];
+
+export interface DesignerOptionRecord {
+  /** Unique id (also the React key for the result row). */
+  readonly id: string;
+  /** An existing, already-translated i18n key for the visible label. */
+  readonly labelKey: string;
+  /** The owning section's controlId — the breadcrumb parent and the jump target. */
+  readonly section: string;
+  /** English-only, match-only synonyms; never displayed, so they need no locale. */
+  readonly keywords: readonly string[];
+}
+
+/**
+ * Finer sub-options, curated to the terms users actually type. Labels reuse
+ * existing translated keys; synonyms are English (domain terms stay English in
+ * every locale anyway). Add an entry here, and its coverage is pinned by the
+ * golden-set eval in `searchCoverage.test.tsx`.
+ */
+export const DESIGNER_OPTION_RECORDS: readonly DesignerOptionRecord[] = [
+  // Base
+  {
+    id: 'opt-lightweight',
+    labelKey: 'binDesigner.lightweight',
+    section: 'bd-base',
+    keywords: [
+      'lightweight',
+      'lightweight floor',
+      'weight savings',
+      'honeycomb',
+      'infill',
+      'hollow',
+      'gyroid',
+    ],
+  },
+  {
+    id: 'opt-stacking-lip',
+    labelKey: 'assembledHeight.stackingLip',
+    section: 'bd-base',
+    keywords: ['stacking lip', 'stack', 'lip', 'rim', 'stackable', 'mating'],
+  },
+  {
+    id: 'opt-magnets',
+    labelKey: 'binDesigner.base.magnetHoles',
+    section: 'bd-base',
+    keywords: ['magnet', 'magnets', 'magnetic', 'magnet holes', 'hold down', 'mount'],
+  },
+  {
+    id: 'opt-screws',
+    labelKey: 'binDesigner.base.screwHoles',
+    section: 'bd-base',
+    keywords: ['screw', 'screws', 'screw holes', 'mounting', 'fasten', 'countersink'],
+  },
+  {
+    id: 'opt-detachable-feet',
+    labelKey: 'binDesigner.detachableFeet',
+    section: 'bd-base',
+    keywords: ['detachable feet', 'removable feet', 'pin feet', 'snap feet', 'modular feet'],
+  },
+  {
+    id: 'opt-half-sockets',
+    labelKey: 'binDesigner.halfSockets',
+    section: 'bd-base',
+    keywords: ['half sockets', 'half grid feet', 'half pockets'],
+  },
+  {
+    id: 'opt-foot-lattice',
+    labelKey: 'binDesigner.footLattice',
+    section: 'bd-base',
+    keywords: ['foot lattice', 'foot layout', 'foot pattern'],
+  },
+  {
+    id: 'opt-flat-base',
+    labelKey: 'binDesigner.flatFloor',
+    section: 'bd-base',
+    keywords: ['flat base', 'flat bottom', 'no feet', 'solid base'],
+  },
+  {
+    id: 'opt-spacer',
+    labelKey: 'binDesigner.spacer',
+    section: 'bd-base',
+    keywords: ['spacer', 'filler', 'riser', 'shim', 'gap filler'],
+  },
+  {
+    id: 'opt-base-only',
+    labelKey: 'binDesigner.tile',
+    section: 'bd-base',
+    keywords: ['base only', 'tile', 'plate', 'foot tile'],
+  },
+  {
+    id: 'opt-lid-base',
+    labelKey: 'binDesigner.lidBottom',
+    section: 'bd-base',
+    keywords: ['lid base', 'tray bottom', 'matching tray'],
+  },
+  // Lid
+  {
+    id: 'opt-lid-attachment',
+    labelKey: 'binDesigner.lid.attachment',
+    section: 'bd-lid',
+    keywords: [
+      'attachment',
+      'friction',
+      'click rails',
+      'magnetic lid',
+      'slide lid',
+      'hinged',
+      'snap',
+      'flip',
+    ],
+  },
+  {
+    id: 'opt-lid-grip',
+    labelKey: 'help.target.binDesigner.lidGrip.title',
+    section: 'bd-lid',
+    keywords: [
+      'grip',
+      'pry',
+      'thumb',
+      'chamfer',
+      'shadow line',
+      'scallop',
+      'notch',
+      'open lid',
+      'remove lid',
+      'fingernail',
+    ],
+  },
+  {
+    id: 'opt-lid-top-surface',
+    labelKey: 'binDesigner.lid.section.topSurface',
+    section: 'bd-lid',
+    keywords: ['top surface', 'flat top', 'stackable top', 'tray top', 'recessed'],
+  },
+  {
+    id: 'opt-lid-extra-height',
+    labelKey: 'binDesigner.lid.extraHeight',
+    section: 'bd-lid',
+    keywords: ['extra lid height', 'deeper lid', 'cavity', 'headroom'],
+  },
+  // Walls
+  {
+    id: 'opt-wall-thickness',
+    labelKey: 'binDesigner.wallThickness',
+    section: 'bd-walls',
+    keywords: ['wall thickness', 'thickness', 'wall width', 'perimeters'],
+  },
+  {
+    id: 'opt-wall-text',
+    labelKey: 'binDesigner.walls.text.heading',
+    section: 'bd-wall-style',
+    keywords: ['wall text', 'engrave walls', 'emboss', 'sign', 'caption'],
+  },
+  // Interior
+  {
+    id: 'opt-interior-bento',
+    labelKey: 'binDesigner.interior.bento.title',
+    section: 'bd-interior',
+    keywords: ['bento', 'freeform', 'custom sizes', 'mixed compartments'],
+  },
+  {
+    id: 'opt-interior-slotted',
+    labelKey: 'binDesigner.interior.slotted.title',
+    section: 'bd-interior',
+    keywords: ['removable dividers', 'slotted', 'slots', 'adjustable dividers'],
+  },
+  {
+    id: 'opt-interior-solid',
+    labelKey: 'binDesigner.interior.solid.title',
+    section: 'bd-interior',
+    keywords: ['solid', 'cutout', 'pockets', 'custom shapes'],
+  },
+  {
+    id: 'opt-interior-grid',
+    labelKey: 'binDesigner.interior.standard.title',
+    section: 'bd-interior',
+    keywords: ['grid dividers', 'compartments', 'rows', 'columns'],
+  },
+  // Label tabs
+  {
+    id: 'opt-label-support',
+    labelKey: 'binDesigner.tabSupport',
+    section: 'bd-label-tabs',
+    keywords: ['bracket', 'solid', 'fillet', 'underhang', 'tab support'],
+  },
+  {
+    id: 'opt-label-mode',
+    labelKey: 'binDesigner.tabMode',
+    section: 'bd-label-tabs',
+    keywords: ['engraved', 'socket', 'plate', 'label style'],
+  },
+  {
+    id: 'opt-label-edges',
+    labelKey: 'binDesigner.tabEdges',
+    section: 'bd-label-tabs',
+    keywords: ['front', 'back', 'both ends', 'tab placement'],
+  },
+  // Dimensions
+  {
+    id: 'opt-half-grid',
+    labelKey: 'binDesigner.halfBinMode',
+    section: 'bd-dimensions',
+    keywords: ['half grid', 'half bin', 'half unit', 'fractional', 'half size'],
+  },
+  {
+    id: 'opt-extra-wall-height',
+    labelKey: 'binDesigner.extraWallHeight',
+    section: 'bd-dimensions',
+    keywords: ['extra wall height', 'collar', 'taller walls', 'headroom'],
+  },
+  {
+    id: 'opt-fractional-edge',
+    labelKey: 'sidebar.halfUnitEdgePosition',
+    section: 'bd-dimensions',
+    keywords: ['fractional edge', 'half foot side', 'edge offset'],
+  },
+  // Overhang
+  {
+    id: 'opt-taper',
+    labelKey: 'binDesigner.overhang.taper.title',
+    section: 'bd-overhang',
+    keywords: ['taper', 'flare', 'angled walls', 'draft'],
+  },
+  // Shape
+  {
+    id: 'opt-custom-shape',
+    labelKey: 'binDesigner.shape.customShape',
+    section: 'bd-shape',
+    keywords: [
+      'custom shape',
+      'l shape',
+      't shape',
+      'u shape',
+      'footprint',
+      'non-rectangular',
+      'notch',
+    ],
+  },
+  // Type
+  {
+    id: 'opt-font',
+    labelKey: 'binDesigner.type.font',
+    section: 'bd-type',
+    keywords: ['font', 'typeface', 'family'],
+  },
+  {
+    id: 'opt-text-mode',
+    labelKey: 'binDesigner.textMode',
+    section: 'bd-type',
+    keywords: ['engrave', 'emboss', 'through cut', 'deboss', 'raised', 'stencil'],
+  },
+  // Physical units
+  {
+    id: 'opt-grid-unit',
+    labelKey: 'binDesigner.gridUnit',
+    section: 'bd-physical-units',
+    keywords: ['grid unit', 'cell size', 'pitch', 'module'],
+  },
+  {
+    id: 'opt-height-unit',
+    labelKey: 'binDesigner.heightUnit',
+    section: 'bd-physical-units',
+    keywords: ['height unit', 'z unit'],
+  },
+  {
+    id: 'opt-nozzle',
+    labelKey: 'settings.nozzleSize',
+    section: 'bd-physical-units',
+    keywords: ['nozzle', 'line width'],
+  },
+  // Print split
+  {
+    id: 'opt-split-connectors',
+    labelKey: 'binDesigner.splitConnectors',
+    section: 'bd-print-fit',
+    keywords: ['split', 'connectors', 'dowel', 'pin', 'alignment', 'registration'],
+  },
+  {
+    id: 'opt-wall-connectors',
+    labelKey: 'binDesigner.splitWallConnectors',
+    section: 'bd-print-fit',
+    keywords: ['wall connectors', 'key', 'joint', 'glue joint', 'lock'],
   },
 ];
 

--- a/src/features/bin-designer/search/matcher.test.ts
+++ b/src/features/bin-designer/search/matcher.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { matchRecords, type SearchableRecord } from './matcher';
+
+const rec = (id: string, label: string, keywords: string[] = []): SearchableRecord<null> => ({
+  id,
+  label,
+  keywords,
+  meta: null,
+});
+
+const orderedIds = (q: string, records: SearchableRecord<null>[]) =>
+  matchRecords(q, records).map((r) => r.id);
+
+describe('matchRecords', () => {
+  it('returns nothing for an empty query', () => {
+    expect(matchRecords('  ', [rec('a', 'Anything')])).toEqual([]);
+  });
+
+  it('ranks exact > prefix > word-prefix > substring', () => {
+    const records = [
+      rec('substr', 'Solidly'), // "lid" sits mid-word, not at a boundary
+      rec('word', 'Big lid'),
+      rec('prefix', 'Lid grip'),
+      rec('exact', 'Lid'),
+    ];
+    expect(orderedIds('lid', records)).toEqual(['exact', 'prefix', 'word', 'substr']);
+  });
+
+  it('highlights the matched label span, once', () => {
+    const [hit] = matchRecords('rip', [rec('a', 'Lid grip')]);
+    expect(hit.highlight).toEqual([[5, 8]]);
+  });
+
+  it('matches via a synonym but ranks it below a label hit, with no highlight', () => {
+    const records = [rec('label', 'Magnet holes'), rec('syn', 'Base', ['magnet'])];
+    const results = matchRecords('magnet', records);
+    expect(results.map((r) => r.id)).toEqual(['label', 'syn']);
+    expect(results[1].highlight).toEqual([]);
+  });
+
+  it('tolerates a gapped subsequence but ranks it last', () => {
+    const records = [rec('sub', 'Lightweight floor'), rec('exact', 'LWT')];
+    const results = matchRecords('lwt', records);
+    // "LWT" is an exact hit; "Lightweight floor" only a subsequence.
+    expect(results[0].id).toBe('exact');
+    expect(results.map((r) => r.id)).toContain('sub');
+  });
+});

--- a/src/features/bin-designer/search/matcher.ts
+++ b/src/features/bin-designer/search/matcher.ts
@@ -1,0 +1,114 @@
+/**
+ * A small, deterministic ranked matcher for the designer search — pure, with no
+ * i18n or React coupling so the golden-set eval can drive it directly.
+ *
+ * Ranking favors, in order: an exact label, a label prefix, a label word prefix,
+ * a label substring, then a subsequence (light typo/gap tolerance), with synonym
+ * hits scored below their label equivalents. The label span that matched is
+ * returned for highlighting; synonym- and subsequence-only hits carry no span.
+ * Deliberately not a fuzzy-search dependency: the corpus is ~50 short records, so
+ * a readable, tunable function beats an opaque library at the JS-budget edge.
+ */
+
+export interface SearchableRecord<T> {
+  readonly id: string;
+  readonly label: string;
+  readonly keywords: readonly string[];
+  readonly meta: T;
+}
+
+export type HighlightRange = readonly [start: number, end: number];
+
+export interface MatchResult<T> {
+  readonly id: string;
+  readonly label: string;
+  readonly meta: T;
+  readonly score: number;
+  /** Ranges in `label` (end-exclusive) to highlight; empty for synonym-only hits. */
+  readonly highlight: readonly HighlightRange[];
+}
+
+const norm = (s: string): string => s.trim().toLowerCase();
+
+/** How tightly `needle`'s chars sit inside `hay` as a subsequence, 0 if none. */
+function subsequenceCompactness(needle: string, hay: string): number {
+  let first = -1;
+  let last = -1;
+  let h = 0;
+  for (let n = 0; n < needle.length; n++) {
+    const ch = needle[n];
+    let found = -1;
+    while (h < hay.length) {
+      if (hay[h] === ch) {
+        found = h;
+        h++;
+        break;
+      }
+      h++;
+    }
+    if (found === -1) return 0;
+    if (first === -1) first = found;
+    last = found;
+  }
+  const span = last - first + 1;
+  return span > 0 ? needle.length / span : 0;
+}
+
+/** Score `needle` against one `text`; returns 0 for no match. */
+function scoreText(needle: string, text: string): number {
+  if (text === needle) return 100;
+  if (text.startsWith(needle)) return 90;
+  if (text.split(/\s+/).some((word) => word.startsWith(needle))) return 80;
+  if (text.includes(needle)) return 60;
+  const compact = subsequenceCompactness(needle, text);
+  return compact > 0 ? 40 * compact : 0;
+}
+
+function scoreKeywords(needle: string, keywords: readonly string[]): number {
+  let best = 0;
+  for (const kw of keywords) {
+    // Synonyms rank below their label equivalents: cap at 55.
+    const s = Math.min(55, scoreText(needle, norm(kw)));
+    if (s > best) best = s;
+  }
+  return best;
+}
+
+/** The label span to underline: the contiguous run of `needle`, if present. */
+function labelHighlight(needle: string, label: string): readonly HighlightRange[] {
+  const at = label.toLowerCase().indexOf(needle);
+  return at === -1 ? [] : [[at, at + needle.length]];
+}
+
+/**
+ * Filters and ranks `records` by `query`. An empty query returns nothing (the
+ * caller supplies its own browse ordering). Stable: ties break by shorter label,
+ * then alphabetically.
+ */
+export function matchRecords<T>(
+  query: string,
+  records: readonly SearchableRecord<T>[]
+): MatchResult<T>[] {
+  const needle = norm(query);
+  if (!needle) return [];
+
+  const scored: MatchResult<T>[] = [];
+  for (const record of records) {
+    const label = norm(record.label);
+    const labelScore = scoreText(needle, label);
+    const score = Math.max(labelScore, scoreKeywords(needle, record.keywords));
+    if (score <= 0) continue;
+    scored.push({
+      id: record.id,
+      label: record.label,
+      meta: record.meta,
+      score,
+      highlight: labelScore >= 60 ? labelHighlight(needle, record.label) : [],
+    });
+  }
+
+  scored.sort(
+    (a, b) => b.score - a.score || a.label.length - b.label.length || a.label.localeCompare(b.label)
+  );
+  return scored;
+}

--- a/src/features/bin-designer/search/searchCoverage.test.tsx
+++ b/src/features/bin-designer/search/searchCoverage.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDesignerSettingsSearch } from './useDesignerSettingsSearch';
+import type { ControlAvailabilityContext } from './designerControlRegistry';
+
+/**
+ * Coverage eval: representative queries mapped to labels that MUST appear. This
+ * is how "no gaps" is defined and defended — a new gap either fails a case here
+ * or gets added as one. Labels are the English (en.ts) values the test i18n mock
+ * resolves. Run with every control available so the eval measures the index, not
+ * the current params.
+ */
+const ALL_AVAILABLE: ControlAvailabilityContext = {
+  style: 'standard',
+  hasText: true,
+  needsSplit: true,
+  viewMode: 'rail',
+  slideTrayEnabled: true,
+};
+
+const GOLDEN: { query: string; expect: string[] }[] = [
+  { query: 'floor', expect: ['Lightweight floor', 'Floor pattern'] },
+  { query: 'lightweight', expect: ['Lightweight floor'] },
+  { query: 'honeycomb', expect: ['Lightweight floor'] },
+  { query: 'magnet', expect: ['Magnet holes'] },
+  { query: 'screw', expect: ['Screw holes'] },
+  { query: 'stacking lip', expect: ['Stacking lip'] },
+  { query: 'feet', expect: ['Detachable feet'] },
+  { query: 'spacer', expect: ['Spacer'] },
+  { query: 'flat base', expect: ['Flat base'] },
+  { query: 'pry', expect: ['Lid grip'] },
+  { query: 'scallop', expect: ['Lid grip'] },
+  { query: 'half', expect: ['Half-grid mode'] },
+  { query: 'taper', expect: ['Taper walls'] },
+  { query: 'custom shape', expect: ['Custom shape'] },
+  { query: 'hex', expect: ['Wall surface pattern'] },
+  { query: 'drainage', expect: ['Floor pattern'] },
+  { query: 'font', expect: ['Typeface'] },
+  { query: 'engrave', expect: ['Typography'] },
+  { query: 'nozzle', expect: ['Nozzle size'] },
+  { query: 'grid unit', expect: ['Grid unit'] },
+  { query: 'split', expect: ['Alignment connectors'] },
+];
+
+describe('designer search coverage (golden set)', () => {
+  it('surfaces the expected result for every representative query', () => {
+    const failures: string[] = [];
+    for (const { query, expect: wanted } of GOLDEN) {
+      const { result } = renderHook(() => useDesignerSettingsSearch(query, ALL_AVAILABLE));
+      const got = new Set(result.current.map((r) => r.label));
+      for (const label of wanted) {
+        if (!got.has(label)) failures.push(`"${query}" → missing "${label}"`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});

--- a/src/features/bin-designer/search/useDesignerSettingsSearch.test.tsx
+++ b/src/features/bin-designer/search/useDesignerSettingsSearch.test.tsx
@@ -23,61 +23,60 @@ const restricted: ControlAvailabilityContext = {
 };
 
 const ids = (results: { controlId: string }[]) => results.map((r) => r.controlId);
+const labels = (results: { label: string }[]) => results.map((r) => r.label);
 
 describe('useDesignerSettingsSearch', () => {
-  it('lists every available control, ordered by category, when the query is empty', () => {
+  it('browses only the sections, ordered by category, when the query is empty', () => {
     const { result } = renderHook(() => useDesignerSettingsSearch('', allAvailable));
     expect(result.current).toHaveLength(DESIGNER_CONTROL_SEARCH.length);
+    expect(result.current.every((r) => r.kind === 'section')).toBe(true);
     expect(result.current[0].category).toBe('shape');
-    // categories never interleave in browse order
     const order = ['shape', 'interior', 'features', 'style', 'print'];
     const seen = result.current.map((r) => order.indexOf(r.category));
     expect(seen).toEqual([...seen].sort((a, b) => a - b));
   });
 
-  it('matches a control by its label', () => {
-    const { result } = renderHook(() => useDesignerSettingsSearch('scoop', allAvailable));
-    expect(ids(result.current)).toContain('bd-scoop');
+  it('surfaces a finer sub-option, with its section as a breadcrumb', () => {
+    const { result } = renderHook(() => useDesignerSettingsSearch('lightweight', allAvailable));
+    const hit = result.current.find((r) => r.label === 'Lightweight floor');
+    expect(hit).toBeDefined();
+    expect(hit?.kind).toBe('option');
+    expect(hit?.controlId).toBe('bd-base');
+    expect(hit?.breadcrumb).toBeTruthy();
   });
 
-  it('matches a control by a synonym that is not in its label', () => {
+  it('highlights the matched span of the label', () => {
+    const { result } = renderHook(() => useDesignerSettingsSearch('floor', allAvailable));
+    const hit = result.current.find((r) => r.label === 'Lightweight floor');
+    // "Lightweight floor" — the run "floor" starts at index 12.
+    expect(hit?.highlight).toEqual([[12, 17]]);
+  });
+
+  it('matches a section by a synonym that is not in its label', () => {
     const { result } = renderHook(() => useDesignerSettingsSearch('drainage', allAvailable));
     expect(ids(result.current)).toContain('bd-floor-pattern');
   });
 
-  it('ranks a label-prefix hit above others', () => {
+  it('ranks an exact-label hit first', () => {
     const { result } = renderHook(() => useDesignerSettingsSearch('lid', allAvailable));
     expect(result.current[0].controlId).toBe('bd-lid');
   });
 
-  it('omits controls whose section is not currently mounted', () => {
-    const labelHit = renderHook(() => useDesignerSettingsSearch('label', restricted));
-    expect(ids(labelHit.result.current)).not.toContain('bd-label-tabs');
+  it('omits records whose section is not currently mounted', () => {
+    const label = renderHook(() => useDesignerSettingsSearch('label', restricted));
+    expect(ids(label.result.current)).not.toContain('bd-label-tabs');
 
-    const fontHit = renderHook(() => useDesignerSettingsSearch('font', restricted));
-    expect(ids(fontHit.result.current)).not.toContain('bd-type');
+    const font = renderHook(() => useDesignerSettingsSearch('font', restricted));
+    expect(ids(font.result.current)).not.toContain('bd-type');
 
-    const splitHit = renderHook(() => useDesignerSettingsSearch('split', restricted));
-    expect(ids(splitHit.result.current)).not.toContain('bd-print-fit');
-
-    const slideHit = renderHook(() => useDesignerSettingsSearch('slide', restricted));
-    expect(ids(slideHit.result.current)).not.toContain('bd-slide-tray');
+    const split = renderHook(() => useDesignerSettingsSearch('split', restricted));
+    expect(ids(split.result.current)).not.toContain('bd-print-fit');
   });
 
-  it('keeps view- and flag-gated controls when the current state mounts them', () => {
-    const printFit = renderHook(() =>
-      useDesignerSettingsSearch('split', { ...restricted, viewMode: 'rail' })
-    );
-    expect(ids(printFit.result.current)).toContain('bd-print-fit');
-
-    const slideTray = renderHook(() =>
-      useDesignerSettingsSearch('slide', { ...restricted, slideTrayEnabled: true })
-    );
-    expect(ids(slideTray.result.current)).toContain('bd-slide-tray');
-  });
-
-  it('never surfaces the excluded lid-grip control', () => {
-    const { result } = renderHook(() => useDesignerSettingsSearch('grip', allAvailable));
+  it('never jumps to the unanchored lid-grip marker (grip lands on the lid)', () => {
+    const { result } = renderHook(() => useDesignerSettingsSearch('scallop', allAvailable));
     expect(ids(result.current)).not.toContain('bd-lid-grip');
+    expect(labels(result.current)).toContain('Lid grip');
+    expect(result.current.find((r) => r.label === 'Lid grip')?.controlId).toBe('bd-lid');
   });
 });

--- a/src/features/bin-designer/search/useDesignerSettingsSearch.ts
+++ b/src/features/bin-designer/search/useDesignerSettingsSearch.ts
@@ -7,84 +7,128 @@ import {
 } from '@/features/bin-designer/components/BinPanelShell/categoryDefs';
 import {
   DESIGNER_CONTROL_SEARCH,
+  DESIGNER_OPTION_RECORDS,
   isDesignerControlAvailable,
   type ControlAvailabilityContext,
 } from './designerControlRegistry';
+import { matchRecords, type HighlightRange, type SearchableRecord } from './matcher';
 
-export interface DesignerControlSearchResult {
+export interface DesignerSearchResult {
+  id: string;
+  /** The section marker the selection jumps to. */
   controlId: string;
   label: string;
-  description: string;
+  /** Parent section title, shown as a breadcrumb on sub-option results. */
+  breadcrumb?: string;
   category: PageCategory;
   categoryLabel: string;
+  /** Label ranges to highlight (search results only). */
+  highlight: readonly HighlightRange[];
+  kind: 'section' | 'option';
 }
 
-const CATEGORY_ORDER = new Map(DESIGNER_CATEGORIES.map((c, index) => [c.id, index]));
+interface ResultMeta {
+  kind: 'section' | 'option';
+  controlId: string;
+  category: PageCategory;
+  categoryLabel: string;
+  breadcrumb?: string;
+}
+
+const CATEGORY_ORDER = new Map(DESIGNER_CATEGORIES.map((c, i) => [c.id, i]));
 const CATEGORY_LABEL_KEY = new Map(DESIGNER_CATEGORIES.map((c) => [c.id, c.labelKey]));
+const TITLE_KEY_OF_SECTION = new Map(DESIGNER_CONTROL_SEARCH.map((s) => [s.controlId, s.titleKey]));
+
+const toResult = (r: {
+  id: string;
+  label: string;
+  meta: ResultMeta;
+  highlight?: readonly HighlightRange[];
+}): DesignerSearchResult => ({
+  id: r.id,
+  controlId: r.meta.controlId,
+  label: r.label,
+  breadcrumb: r.meta.breadcrumb,
+  category: r.meta.category,
+  categoryLabel: r.meta.categoryLabel,
+  highlight: r.highlight ?? [],
+  kind: r.meta.kind,
+});
 
 /**
- * Filters the designer's controls by a free-text query, matching against each
- * control's label and synonym keywords and ranking label-prefix > word-prefix >
- * substring (the same scoring as the global settings search). An empty query
- * returns every currently-available control ordered by category, so the bar
- * doubles as a browse-all list. Controls whose section is not mounted for the
- * current params/view are always left out, so a result never dead-ends a jump.
+ * Filters the designer's search index by a free-text query. An empty query
+ * returns the SECTION records ordered by category (the browse view). A non-empty
+ * query runs the ranked matcher over both sections and their finer sub-options,
+ * returning breadcrumbed, highlighted results. Records whose section is not
+ * mounted for the current params/view are always excluded so a jump never
+ * dead-ends.
  */
 export function useDesignerSettingsSearch(
   query: string,
   ctx: ControlAvailabilityContext
-): DesignerControlSearchResult[] {
+): DesignerSearchResult[] {
   const t = useTranslation();
 
   return useMemo(() => {
-    const available = DESIGNER_CONTROL_SEARCH.filter((entry) =>
-      isDesignerControlAvailable(entry.controlId, ctx)
-    ).flatMap((entry) => {
-      const category = categoryForControl(entry.controlId);
+    const categoryLabel = (category: PageCategory): string => {
+      const key = CATEGORY_LABEL_KEY.get(category);
+      return key ? t(key) : category;
+    };
+
+    // Section records (always in play; the browse view uses only these).
+    const sections = DESIGNER_CONTROL_SEARCH.filter((s) =>
+      isDesignerControlAvailable(s.controlId, ctx)
+    ).flatMap((s): SearchableRecord<ResultMeta>[] => {
+      const category = categoryForControl(s.controlId);
       if (!category) return [];
-      const labelKey = CATEGORY_LABEL_KEY.get(category);
       return [
         {
-          entry,
-          category,
-          result: {
-            controlId: entry.controlId,
-            label: t(entry.titleKey),
-            description: t(entry.descriptionKey),
+          id: s.controlId,
+          label: t(s.titleKey),
+          keywords: t(s.keywordsKey).split('|'),
+          meta: {
+            kind: 'section',
+            controlId: s.controlId,
             category,
-            categoryLabel: labelKey ? t(labelKey) : category,
-          } satisfies DesignerControlSearchResult,
+            categoryLabel: categoryLabel(category),
+          },
         },
       ];
     });
 
-    const needle = query.trim().toLowerCase();
-
-    if (!needle) {
-      return available
+    if (!query.trim()) {
+      return [...sections]
         .sort(
           (a, b) =>
-            (CATEGORY_ORDER.get(a.category) ?? 0) - (CATEGORY_ORDER.get(b.category) ?? 0) ||
-            a.result.label.localeCompare(b.result.label)
+            (CATEGORY_ORDER.get(a.meta.category) ?? 0) -
+              (CATEGORY_ORDER.get(b.meta.category) ?? 0) || a.label.localeCompare(b.label)
         )
-        .map((item) => item.result);
+        .map(toResult);
     }
 
-    return available
-      .map((item) => {
-        const label = item.result.label.toLowerCase();
-        const keywords = t(item.entry.keywordsKey).toLowerCase();
-        let score = -1;
-        if (label.startsWith(needle)) score = 3;
-        else if (label.split(/\s+/).some((word) => word.startsWith(needle))) score = 2;
-        else if (`${label} ${keywords}`.includes(needle)) score = 1;
-        return { item, score };
-      })
-      .filter(({ score }) => score > 0)
-      .sort(({ item: a, score: sa }, { item: b, score: sb }) => {
-        if (sb !== sa) return sb - sa;
-        return a.result.label.localeCompare(b.result.label);
-      })
-      .map(({ item }) => item.result);
+    // Finer sub-options join the sections only once the user is searching.
+    const options = DESIGNER_OPTION_RECORDS.filter((o) =>
+      isDesignerControlAvailable(o.section, ctx)
+    ).flatMap((o): SearchableRecord<ResultMeta>[] => {
+      const category = categoryForControl(o.section);
+      const titleKey = TITLE_KEY_OF_SECTION.get(o.section);
+      if (!category) return [];
+      return [
+        {
+          id: o.id,
+          label: t(o.labelKey),
+          keywords: o.keywords,
+          meta: {
+            kind: 'option',
+            controlId: o.section,
+            category,
+            categoryLabel: categoryLabel(category),
+            breadcrumb: titleKey ? t(titleKey) : undefined,
+          },
+        },
+      ];
+    });
+
+    return matchRecords(query, [...sections, ...options]).map(toResult);
   }, [query, ctx, t]);
 }


### PR DESCRIPTION
Closes the coverage gaps in the designer search: searching "floor" or "lightweight" now finds the Lightweight-floor control (which lives under Base), "magnet"/"screw"/"stacking lip"/"feet"/"pry"/"scallop"/"taper" all resolve, and results read as a hierarchy the way an Algolia search does.

## What changed

**Two-layer index** (`designerControlRegistry.ts`): the 19 sections, plus ~36 curated sub-options. Each option reuses an existing translated label and carries English-only synonyms, so richer coverage adds no new translation and no new i18n keys.

**A small pure matcher** (`matcher.ts`): ranks exact > prefix > word-prefix > substring > gapped-subsequence over label and synonyms, and returns the matched span. No fuzzy-search dependency (the corpus is ~55 short records), so it stays under the JS budget.

**Result UI**: each search result highlights the match and shows its section as a breadcrumb; an empty field still browses the sections by category.

## Why a client-side index, not Algolia

The catalog is bounded, static, and curated (~55 records), and it carries no user data off-device. A hosted search service or embeddings would add cost, latency, and privacy surface for no benefit at this scale. The Algolia-like _experience_ (instant, hierarchical, highlighted) is worth copying; the machinery is not.

## Coverage is measured, not asserted

`searchCoverage.test.tsx` is a golden set of representative queries mapped to the labels that must appear. A new gap either fails a case here or gets added as one. This is the offline stand-in for production query logs, which this repo deliberately does not collect.

## Testing

- Golden-set eval (21 queries), a pure matcher suite, index integrity (every option anchors to a real section, ids unique), and the hook/bar behavior. 24 search tests, 65 including the panel suites.
- typecheck, lint, module-boundaries, design-system all green. Clean-build Total JS 2.21 MB, under the 2216 kB limit (no bump needed).

Behind the same `designer_settings_search` labs flag (preview, default on).

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

