### PR TITLE
docs(skills): add a manual-deploy runbook skill

### DIFF
--- a/.claude/skills/manual-deploy/SKILL.md
+++ b/.claude/skills/manual-deploy/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: manual-deploy
+description: Push the current main to production outside the normal batched cadence — trigger a release now, force a one-off deploy, or verify/roll back one. Use when the user says "deploy now", "manual deploy", "ship it", "push to prod", or a merged change must go live before the next scheduled release.
+---
+
+# Manual deploy
+
+## Background: deploys are batched onto releases
+
+Vercel builds `main` only when the commit message is `chore(main): release …`
+or contains `[deploy]` (`scripts/vercel-ignore.sh`). Ordinary feature merges are
+skipped and ride the next scheduled release (≤3×/day) to keep edge-request cost
+down and CHANGELOG / What's New coherent — so a just-merged change is NOT live
+until a release deploy. Its Vercel deployment shows **Canceled (~5s)**, which is
+the ignore step working, not a failure. Full pipeline, smoke gates, and skew
+protection live in the `release-and-ci` skill.
+
+## The assistant cannot run the deploy itself
+
+`vercel …` and deploy-triggering commands are blocked by the auto-mode
+permission classifier. Propose the command and have the user run it with
+`! <command>` (output lands in-session), or have them approve the permission.
+Never try to work around the block.
+
+## Ways to deploy now — pick one
+
+### 1. Trigger a release (recommended: the full, guarded path)
+
+release-please cuts and auto-merges the `chore(main): release` PR; the release
+merge deploys, with sourcemaps, post-promote smoke, CHANGELOG and What's New.
+Ships everything merged since the last release.
+
+```bash
+gh workflow run release.yml
+# if a release PR already exists, just merge it:
+gh pr list --search 'chore(main): release' --state open
+gh pr merge <n> --squash
+```
+
+### 2. `[deploy]` in the squash commit (one specific PR, immediately)
+
+For a change that cannot wait for the scheduled release, or a `vercel.json`-only
+change that bumps no version: put `[deploy]` in the squash commit message so the
+ignore step builds it.
+
+```bash
+gh pr merge <n> --squash --subject "type(scope): summary [deploy]"
+```
+
+### 3. One-off CLI deploy (out of band, last resort)
+
+Deploys the current `main` HEAD directly. A plain `vercel --prod` is usually
+canceled by the ignore step (it sees `main` + a non-`[deploy]` commit), and this
+path skips the preview smoke gate and ships unversioned sourcemaps — prefer 1 or 2. If you must, build locally and deploy the prebuilt output, which skips the
+remote build (and its ignore gate):
+
+```bash
+vercel pull --yes --environment=production
+vercel build --prod
+vercel deploy --prebuilt --prod
+```
+
+## Verify
+
+```bash
+vercel ls --prod                                         # newest = ● Ready, not Canceled
+curl -s https://gridfinitylayouttool.com/version.json    # gitSha matches the deployed commit
+```
+
+`.github/workflows/smoke-postpromote.yml` smokes production after every release
+deploy and rolls back on failure.
+
+## Roll back
+
+`npx vercel rollback --yes` (mirrors `smoke-postpromote.yml`), or Vercel
+dashboard → Deployments → previous good deploy → Instant Rollback. See
+`release-and-ci` for the incident flow.

--- a/scripts/doc-budget.json
+++ b/scripts/doc-budget.json
@@ -1,6 +1,10 @@
 {
   "tolerance": "1.1",
-  "allowedMissingRefs": ["b17779575", "components/Foo.tsx", "diffProps"],
+  "allowedMissingRefs": [
+    "b17779575",
+    "components/Foo.tsx",
+    "diffProps"
+  ],
   "words": {
     ".claude/skills/analytics-and-labs/SKILL.md": 1270,
     ".claude/skills/auth-and-sync/SKILL.md": 1320,
@@ -13,6 +17,7 @@
     ".claude/skills/grid-editor/SKILL.md": 1168,
     ".claude/skills/i18n-changes/SKILL.md": 1155,
     ".claude/skills/json-schemas/SKILL.md": 872,
+    ".claude/skills/manual-deploy/SKILL.md": 463,
     ".claude/skills/print-export/SKILL.md": 1587,
     ".claude/skills/quality-gates/SKILL.md": 1761,
     ".claude/skills/release-and-ci/SKILL.md": 1579,


### PR DESCRIPTION
Adds an invocable `manual-deploy` skill: a focused runbook for shipping outside the batched release cadence.

Covers the three sanctioned paths (trigger a release, `[deploy]` in a squash commit, or a one-off CLI prebuilt deploy), how to verify (`vercel ls --prod`, `version.json`), and rollback. Documents that deploys are batched by `scripts/vercel-ignore.sh` and that the assistant is blocked from running `vercel` directly (the user runs it via `!`). Cross-references `release-and-ci` for the full pipeline rather than duplicating it.

Requested after a manual deploy this session; codifies the process discovered from `scripts/vercel-ignore.sh`.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

