### PR TITLE
fix(generation): retain slotted dividers with a tab neck relief

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.authoredDividers.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.authoredDividers.test.ts
@@ -101,8 +101,14 @@ describe('authored divider pieces through the real kernel', () => {
         const vol = meshVolume(m.vertices, m.triangles);
         const solid = specs[i].length * WALL_HEIGHT * thickness;
         const notchVol = specs[i].notchOffsets.length * slotWidth * notchDepth * thickness;
+        // Each piece is its solid box minus its cross-lap notches and a small
+        // tab neck relief at each wall-anchored end (getDividerLockPlan). The
+        // relief is under a mm³, so the piece sits just below solid − notchVol;
+        // a dropped notch (~50 mm³) still falls far outside this window.
+        const expected = solid - notchVol;
         expect(vol).toBeGreaterThan(0);
-        expect(vol).toBeCloseTo(solid - notchVol, 0);
+        expect(vol).toBeLessThanOrEqual(expected + 0.01);
+        expect(vol).toBeGreaterThan(expected - 2);
       }
     } finally {
       for (const p of pieces) p.shape.delete();

--- a/src/features/generation/worker/generators/binGenerator.scenario.dividerRetention.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.dividerRetention.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Scenario test: removable divider tabs carry the retention neck relief.
+ *
+ * The wall slot narrows to a throat a short way above the floor
+ * (getDividerLockPlan). For that throat to retain the divider instead of being
+ * plowed open by it, the tab must be relieved to the neck width across the
+ * throat band, leaving the full-thickness head captured below it. This probes
+ * the real kernel mesh to assert the relief lands on the throat band above the
+ * floor (not flipped to the rim) and only recesses the outer faces, the exact
+ * shape that makes the shipped throat actually grip.
+ *
+ * Cross-kernel:
+ *   BREPJS_KERNEL=brepkit pnpm exec vitest run --project=generators dividerRetention
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import { getDividerLockPlan } from '@/shared/utils/slotMath';
+
+const INNER_W = 80;
+const INNER_D = 80;
+const WALL_HEIGHT = 30;
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+describe('divider retention neck relief through the real kernel', () => {
+  it('relieves the outer face across the throat band above the floor, not at the rim', async () => {
+    const { mesh, box, intersect, unwrap } = await import('brepjs');
+    const { buildUniqueDividerPieces } = await import('./dividerBuilder');
+
+    const params: BinParams = {
+      ...DEFAULT_BIN_PARAMS,
+      style: 'slotted',
+      slotConfig: {
+        ...DEFAULT_BIN_PARAMS.slotConfig,
+        x: { enabled: true, pitch: 40 },
+        y: { enabled: false, pitch: 40 },
+      },
+      dividerPieces: { height: 'auto', thickness: 1.6, clearance: 0.25 },
+    };
+    const { thickness, clearance } = params.dividerPieces;
+    const lock = getDividerLockPlan(thickness, clearance);
+    const depthPerFace = (thickness - lock.neckWidth) / 2;
+    expect(depthPerFace).toBeGreaterThan(0);
+
+    const pieces = buildUniqueDividerPieces(params, INNER_W, INNER_D, WALL_HEIGHT, false);
+    expect(pieces).toHaveLength(1);
+    const piece = pieces[0].shape;
+
+    // Bounds from the mesh: X = length, Y = installed height, Z = thickness.
+    const bm = mesh(piece, { tolerance: 0.02, angularTolerance: 8, cache: false });
+    const min = [Infinity, Infinity, Infinity];
+    const max = [-Infinity, -Infinity, -Infinity];
+    for (let i = 0; i < bm.vertices.length; i += 3) {
+      for (let a = 0; a < 3; a++) {
+        min[a] = Math.min(min[a], bm.vertices[i + a]);
+        max[a] = Math.max(max[a], bm.vertices[i + a]);
+      }
+    }
+    const bottomY = min[1];
+    const topFaceZ = max[2];
+
+    // Z-extent of solid found in a thin sliver just inside the outer (top) face
+    // at the tab tip, over an installed-height band. ~0 means the face is relieved.
+    const faceProbe = (hLow: number, hHigh: number): number => {
+      const probe = box(0.4, hHigh - hLow, depthPerFace * 0.6, {
+        at: [
+          max[0] - 0.5,
+          bottomY + (hLow + hHigh) / 2,
+          topFaceZ - (depthPerFace * 0.6) / 2 + 0.02,
+        ],
+      });
+      try {
+        const s = unwrap(intersect(piece, probe, { optimisation: 'none' }));
+        const m = mesh(s, { tolerance: 0.02, angularTolerance: 8, cache: false });
+        let zmin = Infinity;
+        let zmax = -Infinity;
+        for (let i = 2; i < m.vertices.length; i += 3) {
+          zmin = Math.min(zmin, m.vertices[i]);
+          zmax = Math.max(zmax, m.vertices[i]);
+        }
+        s.delete();
+        return Number.isFinite(zmin) ? zmax - zmin : 0;
+      } catch {
+        return 0; // empty intersection
+      } finally {
+        probe.delete();
+      }
+    };
+
+    const headHit = faceProbe(0.1, lock.headHeight - 0.35); // below the throat band
+    const throatHit = faceProbe(lock.headHeight + 0.1, lock.headHeight + lock.throatHeight - 0.1);
+    const topHit = faceProbe(WALL_HEIGHT - 1.0, WALL_HEIGHT - 0.4); // near the rim
+
+    // Outer face solid at the head and rim, relieved only across the throat band.
+    expect(headHit).toBeGreaterThan(depthPerFace * 0.4);
+    expect(topHit).toBeGreaterThan(depthPerFace * 0.4);
+    expect(throatHit).toBeLessThan(depthPerFace * 0.2);
+
+    for (const p of pieces) p.shape.delete();
+  }, 120_000);
+});

--- a/src/features/generation/worker/generators/binGenerator.scenario.dividerRetention.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.dividerRetention.test.ts
@@ -64,27 +64,30 @@ describe('divider retention neck relief through the real kernel', () => {
     const bottomY = min[1];
     const topFaceZ = max[2];
 
-    // Z-extent of solid found in a thin sliver just inside the outer (top) face
-    // at the tab tip, over an installed-height band. ~0 means the face is relieved.
-    const faceProbe = (hLow: number, hHigh: number): number => {
-      const probe = box(0.4, hHigh - hLow, depthPerFace * 0.6, {
-        at: [
-          max[0] - 0.5,
-          bottomY + (hLow + hHigh) / 2,
-          topFaceZ - (depthPerFace * 0.6) / 2 + 0.02,
-        ],
+    // Z-extent of solid found in a thin sliver just inside one thickness face at
+    // the tab tip, over an installed-height band. ~0 means the face is relieved.
+    // The relief cuts BOTH faces, so probe each: 'top' near Z=thickness, 'bottom'
+    // near Z=0.
+    const faceProbe = (hLow: number, hHigh: number, face: 'top' | 'bottom'): number => {
+      const sliverH = depthPerFace * 0.6;
+      const z = face === 'top' ? topFaceZ - sliverH / 2 + 0.02 : sliverH / 2 - 0.02;
+      const probe = box(0.4, hHigh - hLow, sliverH, {
+        at: [max[0] - 0.5, bottomY + (hLow + hHigh) / 2, z],
       });
       try {
         const s = unwrap(intersect(piece, probe, { optimisation: 'none' }));
-        const m = mesh(s, { tolerance: 0.02, angularTolerance: 8, cache: false });
-        let zmin = Infinity;
-        let zmax = -Infinity;
-        for (let i = 2; i < m.vertices.length; i += 3) {
-          zmin = Math.min(zmin, m.vertices[i]);
-          zmax = Math.max(zmax, m.vertices[i]);
+        try {
+          const m = mesh(s, { tolerance: 0.02, angularTolerance: 8, cache: false });
+          let zmin = Infinity;
+          let zmax = -Infinity;
+          for (let i = 2; i < m.vertices.length; i += 3) {
+            zmin = Math.min(zmin, m.vertices[i]);
+            zmax = Math.max(zmax, m.vertices[i]);
+          }
+          return Number.isFinite(zmin) ? zmax - zmin : 0;
+        } finally {
+          s.delete();
         }
-        s.delete();
-        return Number.isFinite(zmin) ? zmax - zmin : 0;
       } catch {
         return 0; // empty intersection
       } finally {
@@ -92,14 +95,20 @@ describe('divider retention neck relief through the real kernel', () => {
       }
     };
 
-    const headHit = faceProbe(0.1, lock.headHeight - 0.35); // below the throat band
-    const throatHit = faceProbe(lock.headHeight + 0.1, lock.headHeight + lock.throatHeight - 0.1);
-    const topHit = faceProbe(WALL_HEIGHT - 1.0, WALL_HEIGHT - 0.4); // near the rim
+    for (const face of ['top', 'bottom'] as const) {
+      const headHit = faceProbe(0.1, lock.headHeight - 0.35, face); // below the throat
+      const throatHit = faceProbe(
+        lock.headHeight + 0.1,
+        lock.headHeight + lock.throatHeight - 0.1,
+        face
+      );
+      const topHit = faceProbe(WALL_HEIGHT - 1.0, WALL_HEIGHT - 0.4, face); // near the rim
 
-    // Outer face solid at the head and rim, relieved only across the throat band.
-    expect(headHit).toBeGreaterThan(depthPerFace * 0.4);
-    expect(topHit).toBeGreaterThan(depthPerFace * 0.4);
-    expect(throatHit).toBeLessThan(depthPerFace * 0.2);
+      // Face solid at the head and rim, relieved only across the throat band.
+      expect(headHit).toBeGreaterThan(depthPerFace * 0.4);
+      expect(topHit).toBeGreaterThan(depthPerFace * 0.4);
+      expect(throatHit).toBeLessThan(depthPerFace * 0.2);
+    }
 
     for (const p of pieces) p.shape.delete();
   }, 120_000);

--- a/src/features/generation/worker/generators/dividerBuilder.test.ts
+++ b/src/features/generation/worker/generators/dividerBuilder.test.ts
@@ -91,10 +91,10 @@ describe('buildUniqueDividerPieces', () => {
     });
     buildUniqueDividerPieces(params, 80, 80, 30, false);
     // 80mm interior at 40mm pitch → 2 compartments → 1 crossing per piece.
-    // Per piece: one notch cut + one neck-relief cut → 4 cuts across both.
+    // Each piece takes one notch cut and one neck-relief cut.
     expect(cut).toHaveBeenCalledTimes(4);
     // The single notch cutter is used directly (no fuse), but each piece's
-    // neck relief fuses its four cutters → one fuse per piece.
+    // neck relief fuses its four cutters.
     expect(fuseAll).toHaveBeenCalledTimes(2);
   });
 
@@ -208,7 +208,7 @@ describe('buildUniqueDividerPieces', () => {
       });
       const pieces = buildUniqueDividerPieces(params, 80, 60, 30, false);
       expect(pieces.map((p) => p.label)).toEqual(['divider-horizontal', 'divider-vertical']);
-      // Each piece takes a cross-lap notch cut plus a neck-relief cut → 4 cuts.
+      // Each piece takes a cross-lap notch cut plus a neck-relief cut.
       expect(cut).toHaveBeenCalledTimes(4);
     });
 

--- a/src/features/generation/worker/generators/dividerBuilder.test.ts
+++ b/src/features/generation/worker/generators/dividerBuilder.test.ts
@@ -76,7 +76,9 @@ describe('buildUniqueDividerPieces', () => {
       },
     });
     buildUniqueDividerPieces(params, 80, 80, 30, false);
-    expect(cut).not.toHaveBeenCalled();
+    // The one cut is the tab neck relief; a single-axis piece carries no
+    // cross-lap notch, so there is no second (notch) cut.
+    expect(cut).toHaveBeenCalledTimes(1);
   });
 
   it('cuts cross-lap notches into both pieces when both axes are enabled', () => {
@@ -88,10 +90,12 @@ describe('buildUniqueDividerPieces', () => {
       },
     });
     buildUniqueDividerPieces(params, 80, 80, 30, false);
-    // 80mm interior at 40mm pitch → 2 compartments → 1 crossing per piece
-    expect(cut).toHaveBeenCalledTimes(2);
-    // Single crossing per piece → cutter used directly, no fuse needed
-    expect(fuseAll).not.toHaveBeenCalled();
+    // 80mm interior at 40mm pitch → 2 compartments → 1 crossing per piece.
+    // Per piece: one notch cut + one neck-relief cut → 4 cuts across both.
+    expect(cut).toHaveBeenCalledTimes(4);
+    // The single notch cutter is used directly (no fuse), but each piece's
+    // neck relief fuses its four cutters → one fuse per piece.
+    expect(fuseAll).toHaveBeenCalledTimes(2);
   });
 
   it('notches X pieces from the top and Y pieces from the bottom', () => {
@@ -105,21 +109,25 @@ describe('buildUniqueDividerPieces', () => {
     });
     buildUniqueDividerPieces(params, 80, 80, 30, false);
 
-    // box calls: [0] X piece, [1] X notch cutter, [2] Y piece, [3] Y notch cutter
+    // The two cross-lap notch cutters are the only boxes reaching just past
+    // mid-height (Y-dim ≈ h/2); piece bodies are Y=30 and neck-relief cutters
+    // are shallow, so filter by that depth rather than a fixed call index.
     const calls = vi.mocked(box).mock.calls;
-    expect(calls).toHaveLength(4);
+    const notchCutters = calls.filter((c) => c[1] > 15 && c[1] < 15.5);
+    expect(notchCutters).toHaveLength(2);
 
-    const xCutterAt = (calls[1][3] as { at: [number, number, number] }).at;
-    const yCutterAt = (calls[3][3] as { at: [number, number, number] }).at;
+    // First piece is X (notched from the top), second is Y (from the bottom).
+    const xCutterAt = (notchCutters[0][3] as { at: [number, number, number] }).at;
+    const yCutterAt = (notchCutters[1][3] as { at: [number, number, number] }).at;
     // dividerHeight = wallHeight (30, no lip); notch centers mirror across mid-height
     expect(xCutterAt[1]).toBeGreaterThan(0);
     expect(yCutterAt[1]).toBeLessThan(0);
     expect(xCutterAt[1]).toBeCloseTo(-yCutterAt[1], 5);
 
     // Notch opening matches the wall slot width (thickness + 2×clearance)
-    expect(calls[1][0]).toBeCloseTo(1.6 + 2 * 0.25, 5);
+    expect(notchCutters[0][0]).toBeCloseTo(1.6 + 2 * 0.25, 5);
     // Notch reaches just past half height: depth = h/2 + clearance (+overlap)
-    const notchCutterDepth = calls[1][1];
+    const notchCutterDepth = notchCutters[0][1];
     expect(notchCutterDepth).toBeGreaterThan(15);
     expect(notchCutterDepth).toBeLessThan(15.5);
   });
@@ -134,7 +142,9 @@ describe('buildUniqueDividerPieces', () => {
     });
     // 80mm at 20mm pitch → 4 compartments → 3 crossings on the X piece
     buildUniqueDividerPieces(params, 80, 80, 30, false);
-    expect(fuseAll).toHaveBeenCalledTimes(1);
+    // Fuses: X-piece 3-notch compound, then each piece's 4-cutter neck relief.
+    expect(fuseAll).toHaveBeenCalledTimes(3);
+    // The first fuse is still the X piece's notch compound (3 crossings).
     expect(vi.mocked(fuseAll).mock.calls[0][0]).toHaveLength(3);
   });
 
@@ -173,8 +183,10 @@ describe('buildUniqueDividerPieces', () => {
       ]);
       // Grooves sit at the short-axis positions along the long piece
       // (innerD=60 at 20mm x-pitch → 2 positions), cut into both faces
-      // → 4 cutters fused, one boolean cut; short pieces stay uncut
-      expect(cut).toHaveBeenCalledTimes(1);
+      // → 4 cutters fused as the first boolean cut. Then the wall-tab pieces
+      // take a neck-relief cut: long piece (+1) and edge piece (+1); the
+      // interior piece seats in receptacles only, so it is not relieved.
+      expect(cut).toHaveBeenCalledTimes(3);
       expect(vi.mocked(fuseAll).mock.calls[0][0]).toHaveLength(4);
     });
 
@@ -196,8 +208,8 @@ describe('buildUniqueDividerPieces', () => {
       });
       const pieces = buildUniqueDividerPieces(params, 80, 60, 30, false);
       expect(pieces.map((p) => p.label)).toEqual(['divider-horizontal', 'divider-vertical']);
-      // Cross-lap cuts both pieces
-      expect(cut).toHaveBeenCalledTimes(2);
+      // Each piece takes a cross-lap notch cut plus a neck-relief cut → 4 cuts.
+      expect(cut).toHaveBeenCalledTimes(4);
     });
 
     it('emits only the long piece when the short axis has no rows', () => {
@@ -213,7 +225,8 @@ describe('buildUniqueDividerPieces', () => {
       // innerD=40 at x-pitch 50 → 0 rows → no grooves, no short pieces
       const pieces = buildUniqueDividerPieces(params, 80, 40, 30, false);
       expect(pieces.map((p) => p.label)).toEqual(['divider-vertical']);
-      expect(cut).not.toHaveBeenCalled();
+      // No grooves, but the lone long piece still takes its neck-relief cut.
+      expect(cut).toHaveBeenCalledTimes(1);
     });
 
     it('falls back to cross-lap when the long axis has no dividers', () => {
@@ -250,8 +263,9 @@ describe('buildUniqueDividerPieces', () => {
       // per piece. The score cuts both faces → 2 groove cutters fused per piece.
       buildUniqueDividerPieces(lapParams('snappable'), 80, 80, 30, false);
       const fuseArgLengths = vi.mocked(fuseAll).mock.calls.map((c) => c[0].length);
-      // Two pieces each fuse a 2-cutter score compound
-      expect(fuseArgLengths).toEqual([2, 2]);
+      // Per piece: a 2-cutter score compound, then a 4-cutter neck-relief
+      // compound → [2, 4] repeated for the two pieces.
+      expect(fuseArgLengths).toEqual([2, 4, 2, 4]);
       // Two pieces are still emitted (not a family)
     });
 

--- a/src/features/generation/worker/generators/dividerBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBuilder.ts
@@ -24,6 +24,7 @@ import {
   calculateShortDividerLengths,
   calculateShortDividerSpans,
   calculateSlotPositions,
+  getDividerLockPlan,
   getReceptacleDepth,
   getSnapScoreDepth,
   resolveCrossDividerMode,
@@ -31,6 +32,7 @@ import {
   SNAP_SCORE_WIDTH,
   tabEngagement,
 } from '@/shared/utils/slotMath';
+import type { DividerLockPlan } from '@/shared/utils/slotMath';
 import { computeAuthoredDividers } from '@/shared/utils/authoredDividerMath';
 import { deriveWallSegments } from '@/shared/utils/compartmentGeometry';
 import { getEffectiveSlotDimensions } from './slotBuilder';
@@ -157,6 +159,64 @@ function cutFaceGrooves(
 }
 
 /**
+ * Relieve the divider tab across the slot's throat band so retention works.
+ *
+ * The wall slot narrows to a throat a short way above the floor (getDividerLockPlan):
+ * the full-thickness head seats in the pocket below it and the throat is meant to
+ * re-close over the tab and trap the head. A uniform tab defeats that: its full
+ * thickness plows the throat open on the way down and nothing holds it. Cutting the
+ * tab back to the neck width across the throat band leaves the throat free to close
+ * over the neck, with the head's shoulder captured beneath it (a geometric stop, not
+ * friction).
+ *
+ * In flat orientation the piece is centered at the origin: length along X, installed
+ * height along Y (−Y = installed bottom, resting on the floor), thickness along Z.
+ * Both faces are relieved at both ends; a relief near a receptacle or free end seats
+ * in empty space and is inert, so pieces need not track which ends land in a wall
+ * slot. Skips pieces shorter than the lock stack, matching the slot builder's own
+ * fall-back to a plain slot.
+ */
+function cutDividerNeckRelief(
+  piece: Shape3D,
+  length: number,
+  height: number,
+  thickness: number,
+  tabDepth: number,
+  lock: DividerLockPlan
+): Shape3D {
+  const depthPerFace = (thickness - lock.neckWidth) / 2;
+  const lockHeight = lock.headHeight + lock.throatHeight;
+  if (depthPerFace <= 0 || height <= lockHeight) return piece;
+
+  // Relieve a hair beyond the throat band (headHeight..headHeight+throatHeight
+  // above the floor-resting bottom edge) so a piece seated slightly high or low
+  // still lands the throat on relieved material.
+  const bandSlack = 0.2;
+  const bandLow = -height / 2 + lock.headHeight - bandSlack;
+  const bandHigh = -height / 2 + lockHeight + bandSlack;
+  const bandCenterY = (bandLow + bandHigh) / 2;
+  const bandHeight = bandHigh - bandLow;
+
+  // Relief spans the engaged tab depth (plus a margin so it always underlies the
+  // throat) and overruns the tip so the cutter leaves no coplanar faces.
+  const margin = 0.6;
+  const cutZ = depthPerFace + COPLANAR_OVERLAP;
+  const faceZ = (depthPerFace - COPLANAR_OVERLAP) / 2;
+  const cutters: Shape3D[] = [];
+  for (const sign of [-1, 1] as const) {
+    const outer = sign * (length / 2 + COPLANAR_OVERLAP);
+    const inner = sign * (length / 2 - tabDepth - margin);
+    const cx = (outer + inner) / 2;
+    const clen = Math.abs(outer - inner);
+    cutters.push(
+      box(clen, bandHeight, cutZ, { at: [cx, bandCenterY, faceZ] }),
+      box(clen, bandHeight, cutZ, { at: [cx, bandCenterY, thickness - faceZ] })
+    );
+  }
+  return applyCuts(piece, cutters);
+}
+
+/**
  * Build one divider piece per unique shape for a slotted bin.
  *
  * Single-axis bins get one piece. Both-axes bins get either two
@@ -237,16 +297,27 @@ export function buildUniqueDividerPieces(
     positions.map((offset) => ({ offset, width }));
   const pattern = (piece: Shape3D, geometry: PieceGeometry): Shape3D =>
     patternCtx ? cutPiecePattern(piece, patternCtx, geometry) : piece;
+  // Every wall tab seats past a retention throat, so relieve every piece's tab
+  // neck (inert at receptacle/free ends). Length varies per piece.
+  const lock = getDividerLockPlan(thickness, clearance);
+  const relief = (piece: Shape3D, length: number): Shape3D =>
+    cutDividerNeckRelief(piece, length, dividerHeight, thickness, tabDepth, lock);
 
   if (!bothAxes) {
     if (slotConfig.x.enabled)
       addPiece(
-        pattern(buildFullPiece('x'), { length: fullLength('x'), tabEngagement: tabDepth }),
+        relief(
+          pattern(buildFullPiece('x'), { length: fullLength('x'), tabEngagement: tabDepth }),
+          fullLength('x')
+        ),
         axisLabel('x')
       );
     if (slotConfig.y.enabled)
       addPiece(
-        pattern(buildFullPiece('y'), { length: fullLength('y'), tabEngagement: tabDepth }),
+        relief(
+          pattern(buildFullPiece('y'), { length: fullLength('y'), tabEngagement: tabDepth }),
+          fullLength('y')
+        ),
         axisLabel('y')
       );
     return pieces;
@@ -277,7 +348,7 @@ export function buildUniqueDividerPieces(
       tabEngagement: tabDepth,
       grooves: columns(groovePositions, slotWidth),
     });
-    addPiece(longPiece, axisLabel(longAxis));
+    addPiece(relief(longPiece, fullLength(longAxis)), axisLabel(longAxis));
 
     // Short pieces only exist where there are rows to seat them —
     // groovePositions are also the short direction's wall slot rows.
@@ -298,14 +369,20 @@ export function buildUniqueDividerPieces(
         );
       }
       if (lengths.edge !== null && lengths.edge > 0) {
+        // One end seats in a wall slot (relieve so its throat catches); the
+        // piece is symmetric/reversible, so relieving both ends keeps the wall
+        // end covered whichever way it goes in.
         addPiece(
-          pattern(buildDividerPiece(lengths.edge, thickness, dividerHeight), {
-            length: lengths.edge,
-            // One end seats in a wall slot, the other in a receptacle, and
-            // `calculateShortDividerLengths` builds this piece with the SHALLOWER
-            // of the two at both ends — so mirror that rather than the deeper one.
-            tabEngagement: Math.min(tabDepth, tabEngagement(grooveDepth, clearance)),
-          }),
+          relief(
+            pattern(buildDividerPiece(lengths.edge, thickness, dividerHeight), {
+              length: lengths.edge,
+              // One end seats in a wall slot, the other in a receptacle, and
+              // `calculateShortDividerLengths` builds this piece with the SHALLOWER
+              // of the two at both ends — so mirror that rather than the deeper one.
+              tabEngagement: Math.min(tabDepth, tabEngagement(grooveDepth, clearance)),
+            }),
+            lengths.edge
+          ),
           `${axisLabel(shortAxis)}-compartment-edge`
         );
       }
@@ -348,13 +425,16 @@ export function buildUniqueDividerPieces(
         clearance
       );
       for (const seg of segments) {
-        const piece = pattern(
-          notch(buildDividerPiece(seg.length, thickness, dividerHeight), seg.notchOffsets),
-          {
-            length: seg.length,
-            tabEngagement: tabDepth,
-            notches: columns(seg.notchOffsets, slotWidth),
-          }
+        const piece = relief(
+          pattern(
+            notch(buildDividerPiece(seg.length, thickness, dividerHeight), seg.notchOffsets),
+            {
+              length: seg.length,
+              tabEngagement: tabDepth,
+              notches: columns(seg.notchOffsets, slotWidth),
+            }
+          ),
+          seg.length
         );
         const label = seg.labelSuffix ? `${axisLabel(axis)}-${seg.labelSuffix}` : axisLabel(axis);
         addPiece(piece, label);
@@ -381,7 +461,7 @@ export function buildUniqueDividerPieces(
       notches: columns(crossings, slotWidth),
       grooves: columns(snapPositions, SNAP_SCORE_WIDTH),
     });
-    addPiece(piece, axisLabel(axis));
+    addPiece(relief(piece, fullLength(axis)), axisLabel(axis));
   }
 
   return pieces;
@@ -420,6 +500,7 @@ export function buildAuthoredDividerPieces(
   // a tab there, so holding the full tab depth at both ends is conservative —
   // a little extra solid margin, never a perforated tab.
   const tabDepth = tabEngagement(slotDepth, clearance);
+  const lock = getDividerLockPlan(thickness, clearance);
 
   const pieces: LabeledDividerPiece[] = [];
   let yOffset = 0;
@@ -440,6 +521,9 @@ export function buildAuthoredDividerPieces(
         notches: spec.notchOffsets.map((offset) => ({ offset, width: slotWidth })),
       });
     }
+    // Relieve the tab neck so a wall-anchored end's throat catches; inert at
+    // abutting/T-junction ends that carry no tab.
+    shape = cutDividerNeckRelief(shape, spec.length, dividerHeight, thickness, tabDepth, lock);
     if (yOffset > 0) {
       const translated = translate(shape, [0, yOffset, 0]);
       shape.delete();

--- a/src/features/generation/worker/generators/dividerBuilder.ts
+++ b/src/features/generation/worker/generators/dividerBuilder.ts
@@ -169,9 +169,10 @@ function cutFaceGrooves(
  * over the neck, with the head's shoulder captured beneath it (a geometric stop, not
  * friction).
  *
- * In flat orientation the piece is centered at the origin: length along X, installed
- * height along Y (−Y = installed bottom, resting on the floor), thickness along Z.
- * Both faces are relieved at both ends; a relief near a receptacle or free end seats
+ * In flat orientation the piece is centered in X (length) and Y (installed height,
+ * −Y = installed bottom, resting on the floor); Z (thickness) spans [0, thickness]
+ * with the build plate at Z=0, so the two faces recessed here sit at Z=0 and
+ * Z=thickness. Both faces are relieved at both ends; a relief near a free end seats
  * in empty space and is inert, so pieces need not track which ends land in a wall
  * slot. Skips pieces shorter than the lock stack, matching the slot builder's own
  * fall-back to a plain slot.

--- a/src/features/generation/worker/generators/slotBuilder.ts
+++ b/src/features/generation/worker/generators/slotBuilder.ts
@@ -457,7 +457,7 @@ export const slotCutsFeature: FeatureBuilder = {
     );
     return compactKey(
       buildCacheKey(
-        'v3',
+        'v4',
         dim.shellKey,
         stableSerialize(params.slotConfig),
         quantize(slotWidth),

--- a/src/shared/utils/slotMath.test.ts
+++ b/src/shared/utils/slotMath.test.ts
@@ -202,15 +202,25 @@ describe('getDividerLockPlan', () => {
   it('captures the standard divider below a narrower printable throat', () => {
     const lock = getDividerLockPlan(1.6, 0.25);
     expect(lock.pocketWidth).toBeCloseTo(2.1, 10);
-    expect(lock.throatWidth).toBeCloseTo(1.2, 10);
+    expect(lock.throatWidth).toBeCloseTo(1.3, 10);
     expect(lock.throatWidth).toBeLessThan(1.6);
     expect(lock.headHeight).toBeGreaterThan(lock.throatHeight);
   });
 
-  it('keeps a usable throat on thin custom dividers', () => {
+  it('relieves the tab neck clear of the throat so it re-closes over the head', () => {
+    const lock = getDividerLockPlan(1.6, 0.25);
+    // Neck narrower than the throat (throat clears it, never plowed) and the
+    // full-thickness head wider than the throat (the shoulder that retains it).
+    expect(lock.neckWidth).toBeLessThan(lock.throatWidth);
+    expect(lock.throatWidth).toBeLessThan(1.6);
+  });
+
+  it('keeps a usable throat and neck on thin custom dividers', () => {
     const lock = getDividerLockPlan(1, 0.2);
     expect(lock.throatWidth).toBeGreaterThanOrEqual(0.8);
     expect(lock.throatWidth).toBeLessThan(1);
+    expect(lock.neckWidth).toBeGreaterThanOrEqual(0.6);
+    expect(lock.neckWidth).toBeLessThan(lock.throatWidth);
   });
 });
 

--- a/src/shared/utils/slotMath.ts
+++ b/src/shared/utils/slotMath.ts
@@ -54,13 +54,13 @@ export const DIVIDER_LOCK_THROAT_HEIGHT = 0.6;
 export const DIVIDER_LOCK_INTERFERENCE_PER_SIDE = 0.15;
 
 /**
- * Per-side gap between the divider neck and the slot throat.
+ * Total width by which the divider neck is cut narrower than the slot throat
+ * (so half of it per face).
  *
- * The neck is cut this much narrower than the throat so the throat clears it
- * on both faces and can never be plowed open by the tab as the piece seats
- * (the whole point of relieving the tab). Retention comes from the full-thickness
- * head below the neck, which the throat catches; the neck itself is a clearance
- * groove, so it does not need to grip.
+ * The neck clears the throat by this much so the throat can never be plowed
+ * open by the tab as the piece seats (the whole point of relieving the tab).
+ * Retention comes from the full-thickness head below the neck, which the throat
+ * catches; the neck itself is a clearance groove, so it does not need to grip.
  */
 export const DIVIDER_LOCK_NECK_RELIEF_GAP = 0.1;
 

--- a/src/shared/utils/slotMath.ts
+++ b/src/shared/utils/slotMath.ts
@@ -41,20 +41,53 @@ export const DIVIDER_LOCK_HEAD_HEIGHT = 0.8;
 /** Installed height of the elastic throat that retains the divider head. */
 export const DIVIDER_LOCK_THROAT_HEIGHT = 0.6;
 
-/** Per-face interference at the throat for the shipped 1.6 mm divider. */
-export const DIVIDER_LOCK_INTERFERENCE_PER_SIDE = 0.2;
+/**
+ * Per-face interference at the throat for a full-thickness divider.
+ *
+ * Sized as an ELASTIC detent, not a press fit: the throat is a short,
+ * floor-anchored wall segment printed across the layer lines, so it barely
+ * flexes and does not spring back from an aggressive squeeze, so it plows open
+ * and stops gripping. The head only has to deflect it by this much to pass,
+ * and it re-closes into the divider neck ({@link getDividerLockPlan}) once the
+ * head is below it. Retention is the geometric shoulder, not friction.
+ */
+export const DIVIDER_LOCK_INTERFERENCE_PER_SIDE = 0.15;
+
+/**
+ * Per-side gap between the divider neck and the slot throat.
+ *
+ * The neck is cut this much narrower than the throat so the throat clears it
+ * on both faces and can never be plowed open by the tab as the piece seats
+ * (the whole point of relieving the tab). Retention comes from the full-thickness
+ * head below the neck, which the throat catches; the neck itself is a clearance
+ * groove, so it does not need to grip.
+ */
+export const DIVIDER_LOCK_NECK_RELIEF_GAP = 0.1;
+
+/** Floor on the relieved neck width so a thin divider keeps a printable web. */
+const MIN_NECK_WIDTH = 0.6;
 
 export interface DividerLockPlan {
   readonly pocketWidth: number;
   readonly throatWidth: number;
+  /**
+   * Relieved thickness of the divider tab across the throat band. Narrower than
+   * {@link throatWidth} so the throat re-closes past it; the full-thickness head
+   * below (a shoulder, not friction) is what actually resists lifting.
+   */
+  readonly neckWidth: number;
   readonly headHeight: number;
   readonly throatHeight: number;
 }
 
 /**
  * Resolve the paired snap geometry shared by wall slots and divider tips.
+ *
  * The full-thickness head seats in the clearance pocket below a narrower
- * throat. The short wall tabs flex while the head is pressed through.
+ * throat. The tab is relieved to {@link DividerLockPlan.neckWidth} across the
+ * throat band so the throat closes back over the neck once the head passes,
+ * leaving the head's upper shoulder captured below it. Without that relief the
+ * uniform tab plows the throat open on the way in and nothing retains the head.
  */
 export function getDividerLockPlan(
   dividerThickness: number,
@@ -62,12 +95,14 @@ export function getDividerLockPlan(
 ): DividerLockPlan {
   const interference = Math.min(
     DIVIDER_LOCK_INTERFERENCE_PER_SIDE,
-    Math.max(0.08, dividerThickness * 0.125)
+    Math.max(0.1, dividerThickness * 0.125)
   );
   const throatWidth = Math.max(0.8, dividerThickness - 2 * interference);
+  const neckWidth = Math.max(MIN_NECK_WIDTH, throatWidth - DIVIDER_LOCK_NECK_RELIEF_GAP);
   return {
     pocketWidth: dividerThickness + 2 * dividerClearance,
     throatWidth,
+    neckWidth,
     headHeight: DIVIDER_LOCK_HEAD_HEIGHT,
     throatHeight: DIVIDER_LOCK_THROAT_HEIGHT,
   };


### PR DESCRIPTION
## Slotted divider retention, part 2 (#4027)

The retention throat shipped for #3957 (v4.478.2) did not hold in @victorsmits's print test. This completes the mechanism.

### Why the throat could not grip

The wall slot narrows to a throat a short way above the floor, and the intent was that a full-thickness "head" seats in the pocket below it while the throat re-closes over the tab and traps the head. But the divider tab was left a **uniform-thickness plate**, so the mechanism was only half-built:

- As the piece seats, its full thickness plows straight through the narrower throat for the last stretch of travel. On PLA, a stiff, floor-anchored wall segment printed across the layer lines does not spring back, so the throat is permanently spread open.
- Once seated, the throat is at full width and there is no shoulder for it to catch. Retention was pure friction against a plate, which the plate had already destroyed.

### The fix

Give the tab the matching half of the snap and make the throat elastic:

```
        wall slot (side view)              divider tab end (side view)
   ┌───────────────┐  ← normal slot     ┌───────────────┐  ← full thickness
   │               │                    │               │
   │   ▓▓▓▓▓▓▓▓▓   │  ← throat (narrow) │      ███      │  ← NECK (relieved)
   │  ▓▓▓▓▓▓▓▓▓▓▓  │                    │   █████████   │  ← HEAD (full,
   └──floor────────┘                    └──floor────────┘     caught below throat)
```

- **Tab neck relief** (`cutDividerNeckRelief`): recess the tab to the throat's neck width across the throat band, on both faces, at both ends. The throat now closes over the neck instead of being plowed open, and the full-thickness head below it is captured by a geometric shoulder rather than friction. The relief is inert where an end seats in a receptacle or abuts another divider, so no path has to track which ends land in a wall slot. Applied across every divider path (single-axis, lap, insert long/edge, lengthSet, authored).
- **Elastic throat** (`slotMath`): drop the throat interference to a value the head can deflect and that springs back, rather than one that plows a rigid wall. The neck is cut a touch narrower than the throat so the throat always clears it.
- Slot geometry cache bumped `v3` to `v4`.

### Verification (geometry level)

- New real-kernel probe (`binGenerator.scenario.dividerRetention`) confirms on the meshed piece that the outer face is solid at the head and near the rim but relieved exactly across the throat band, i.e. the relief is at the bottom under the throat and only recesses the faces, not flipped to the rim.
- Slotted + divider-pattern **export-integrity** suites pass: parseable, watertight, manifold (relief + wall patterns combined).
- Authored-divider and slotted/binStyles/combinedFeatures scenarios pass; triangle-count snapshots are unchanged (the throat only moved, it did not gain or lose segments).
- `dividerBuilder` and `slotMath` unit tests updated for the extra relief cut; typecheck, eslint, module-boundary and i18n checks clean.

### Still needed

**A print test.** This is a physical retention mechanism and I cannot validate grip strength or insertion feel without a printer. The geometry is watertight and follows standard snap-fit practice (positive shoulder, elastic detent), but the previous throat also looked right and did not hold, so please print one before this is treated as fixed. `dividerPieces.clearance` and the lock constants in `slotMath.ts` are the tuning knobs if the fit needs to move.

Refs #4027, #3957. Co-authored context from @victorsmits, who reported both issues and printed the reference.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

