### PR TITLE
fix(generation): scoop no longer pokes through the outer wall corner

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.combinedFeatures.test.ts.snap
@@ -6,6 +6,6 @@ exports[`combined features > 2×2 compartments + insert (overlap interaction) 1`
 
 exports[`combined features > 2×2 label tabs with merged compartments 1`] = `4548`;
 
-exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `6652`;
+exports[`combined features > 2×2 standard + lip + 2×2 compartments + scoop 1`] = `6920`;
 
 exports[`combined features > 4×4 magnet + label bracket + half-sockets 1`] = `30756`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
@@ -10,7 +10,7 @@ exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid
 
 exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13580`;
 
-exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `14366`;
+exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `14542`;
 
 exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10430`;
 

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.floorPatterns.test.ts.snap
@@ -14,4 +14,4 @@ exports[`floor patterns > half sockets get one window per quarter foot 1`] = `34
 
 exports[`floor patterns > magnet + screw pockets stay solid 1`] = `14892`;
 
-exports[`floor patterns > scoop ramp footings stay solid 1`] = `12598`;
+exports[`floor patterns > scoop ramp footings stay solid 1`] = `12766`;

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
@@ -1,41 +1,41 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4332`;
+exports[`scoop + lip interaction > scoop with lip (single compartment, front-row offset active) 1`] = `4600`;
 
-exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `5162`;
+exports[`scoop + lip interaction > scoop with lip + 2 rows (front-row offset vs interior-row) 1`] = `5430`;
 
-exports[`scoop > 2×2 scoop auto radius 1`] = `4332`;
+exports[`scoop > 2×2 scoop auto radius 1`] = `4600`;
 
 exports[`scoop > 2×2 scoop disabled 1`] = `2892`;
 
-exports[`scoop > 2×2 scoop radius 10mm 1`] = `4364`;
+exports[`scoop > 2×2 scoop radius 10mm 1`] = `4668`;
 
-exports[`scoop flat base > 1×1 flat base scoop with lip 1`] = `2364`;
+exports[`scoop flat base > 1×1 flat base scoop with lip 1`] = `2632`;
 
-exports[`scoop flat base > 2×2 flat base scoop no lip 1`] = `1612`;
+exports[`scoop flat base > 2×2 flat base scoop no lip 1`] = `1834`;
 
-exports[`scoop flat base > 2×2 flat base scoop with lip 1`] = `2364`;
+exports[`scoop flat base > 2×2 flat base scoop with lip 1`] = `2620`;
 
 exports[`scoop flat base > 2×2 flat base thin-wall scoop (corner clip active) 1`] = `3008`;
 
-exports[`scoop flat base > 2×2 tray-bottom (lid) base scoop with lip 1`] = `1662`;
+exports[`scoop flat base > 2×2 tray-bottom (lid) base scoop with lip 1`] = `1638`;
 
-exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `4560`;
+exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `4804`;
 
-exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `5820`;
+exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `6088`;
 
-exports[`scoop side > scoop on the back wall 1`] = `4332`;
+exports[`scoop side > scoop on the back wall 1`] = `4600`;
 
-exports[`scoop side > scoop on the left wall 1`] = `4332`;
+exports[`scoop side > scoop on the left wall 1`] = `4600`;
 
-exports[`scoop side > scoop on the right wall 1`] = `4332`;
+exports[`scoop side > scoop on the right wall 1`] = `4600`;
 
-exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `4332`;
+exports[`scoop side > side scoop with lip (outer-wall offset active) 1`] = `4600`;
 
-exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `4252`;
+exports[`scoop two-variable > 2×2 shallow curved scoop (run > height) 1`] = `4496`;
 
-exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4508`;
+exports[`scoop two-variable > 2×2 steep curved scoop (run < height) 1`] = `4824`;
 
-exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3648`;
+exports[`scoop two-variable > 2×2 steep straight scoop 1`] = `3712`;
 
-exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `3544`;
+exports[`scoop two-variable > 2×2 straight scoop (chamfer) 1`] = `3608`;

--- a/src/features/generation/worker/generators/binGenerator.scenario.scoopContainment.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.scoopContainment.test.ts
@@ -18,10 +18,8 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs } from './__kernel-tests__/wasmInit';
 import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
 import type { BinParams } from '@/shared/types/bin';
-import { BOX_CORNER_RADIUS } from './generatorConstants';
-
-const GRID = 42;
-const TOL = 0.5;
+import type { Shape3D } from 'brepjs';
+import { BOX_CORNER_RADIUS, CLEARANCE } from './generatorConstants';
 
 beforeAll(async () => {
   await initBrepjs();
@@ -34,13 +32,16 @@ async function verticesOutsideOuterWall(params: BinParams): Promise<number> {
   const { buildScoopRamps } = await import('./scoopRampBuilder');
 
   const wt = params.wallThickness;
-  const outerW = params.width * GRID - TOL;
-  const outerD = params.depth * GRID - TOL;
+  // Match the pipeline's own footprint (context.ts): outer = units·pitch − clearance.
+  const unitX = params.gridUnitMm;
+  const unitY = params.gridUnitMmY ?? unitX;
+  const outerW = params.width * unitX - CLEARANCE;
+  const outerD = params.depth * unitY - CLEARANCE;
   const innerW = outerW - 2 * wt;
   const innerD = outerD - 2 * wt;
   const wallHeight = params.height * params.heightUnitMm;
 
-  const ramp = buildScoopRamps(params, innerW, innerD, wallHeight, wt);
+  const ramp: Shape3D | null = buildScoopRamps(params, innerW, innerD, wallHeight, wt);
   if (!ramp) return 0;
 
   const footprint = sketch(
@@ -48,16 +49,17 @@ async function verticesOutsideOuterWall(params: BinParams): Promise<number> {
     'XY',
     -1
   ).extrude(wallHeight + 2);
+  let outside: Shape3D | undefined;
   try {
-    const outside = unwrap(cut(ramp as never, footprint));
-    try {
-      const m = mesh(outside, { tolerance: 0.02, angularTolerance: 8, cache: false });
-      return m.vertices.length / 3;
-    } catch {
-      return 0; // empty intersection: nothing outside
-    }
+    outside = unwrap(cut(ramp, footprint));
+    const m = mesh(outside, { tolerance: 0.02, angularTolerance: 8, cache: false });
+    return m.vertices.length / 3;
+  } catch {
+    return 0; // empty intersection: nothing outside
   } finally {
-    (ramp as { delete(): void }).delete();
+    ramp.delete();
+    footprint.delete();
+    outside?.delete();
   }
 }
 

--- a/src/features/generation/worker/generators/binGenerator.scenario.scoopContainment.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.scoopContainment.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Scenario test: finger scoop ramps stay inside the outer wall (#4033).
+ *
+ * The ramp is a square-cornered prism pushed into the surrounding walls to weld
+ * it (#4014). At the bin's rounded outer corners a square corner driven
+ * diagonally into the wall overshoots the outer arc and pokes out of the bin
+ * ("scoops cut through outside"). scoopRampBuilder clips the ramp to the rounded
+ * cavity footprint to prevent that; this proves nothing pokes past the true
+ * outer footprint across a range of wall thicknesses, lips, sides and styles
+ * (the default 1.2 mm wall used to breach because the clip only ran below
+ * ~1.10 mm).
+ *
+ * Cross-kernel:
+ *   BREPJS_KERNEL=brepkit pnpm exec vitest run --project=generators scoopContainment
+ */
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initBrepjs } from './__kernel-tests__/wasmInit';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import { BOX_CORNER_RADIUS } from './generatorConstants';
+
+const GRID = 42;
+const TOL = 0.5;
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+/** Count ramp mesh vertices lying outside the true rounded outer footprint. */
+async function verticesOutsideOuterWall(params: BinParams): Promise<number> {
+  const { drawRoundedRectangle, cut, mesh, unwrap } = await import('brepjs');
+  const { sketch } = await import('./meshUtils');
+  const { buildScoopRamps } = await import('./scoopRampBuilder');
+
+  const wt = params.wallThickness;
+  const outerW = params.width * GRID - TOL;
+  const outerD = params.depth * GRID - TOL;
+  const innerW = outerW - 2 * wt;
+  const innerD = outerD - 2 * wt;
+  const wallHeight = params.height * params.heightUnitMm;
+
+  const ramp = buildScoopRamps(params, innerW, innerD, wallHeight, wt);
+  if (!ramp) return 0;
+
+  const footprint = sketch(
+    drawRoundedRectangle(outerW, outerD, BOX_CORNER_RADIUS),
+    'XY',
+    -1
+  ).extrude(wallHeight + 2);
+  try {
+    const outside = unwrap(cut(ramp as never, footprint));
+    try {
+      const m = mesh(outside, { tolerance: 0.02, angularTolerance: 8, cache: false });
+      return m.vertices.length / 3;
+    } catch {
+      return 0; // empty intersection: nothing outside
+    }
+  } finally {
+    (ramp as { delete(): void }).delete();
+  }
+}
+
+const scoop = (over: Partial<BinParams> = {}): BinParams => ({
+  ...DEFAULT_BIN_PARAMS,
+  scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true },
+  ...over,
+});
+
+describe('scoop ramps stay inside the outer wall', () => {
+  const cases: [string, BinParams][] = [
+    ['default 1.2mm wall, lip, curved (the reported case)', scoop()],
+    ['no lip', scoop({ base: { ...DEFAULT_BIN_PARAMS.base, stackingLip: false } })],
+    [
+      'straight style',
+      scoop({ scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true, style: 'straight' } }),
+    ],
+    [
+      'side scoop (left)',
+      scoop({ scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true, side: 'left' } }),
+    ],
+    ['thin 0.95mm wall (clip already active)', scoop({ wallThickness: 0.95 })],
+    ['thicker 2.0mm wall', scoop({ wallThickness: 2.0 })],
+  ];
+
+  for (const [name, params] of cases) {
+    it(
+      name,
+      async () => {
+        expect(await verticesOutsideOuterWall(params)).toBe(0);
+      },
+      120_000
+    );
+  }
+});

--- a/src/features/generation/worker/generators/scoopRampBuilder.ts
+++ b/src/features/generation/worker/generators/scoopRampBuilder.ts
@@ -232,19 +232,14 @@ function buildScoopRampsInScope(
       ? scoopShapes[0] // already scope-registered
       : scope.register(unwrap(fuseAll(scoopShapes as ValidSolid[])));
 
-  // The inner cavity rounds its corners to radius (BOX_CORNER_RADIUS −
-  // wallThickness), but the scoop is a straight full-width prism with SQUARE
-  // corners, pushed `wallPenetration` into the surrounding walls to weld it
-  // (above). At the bin's outer corners a square corner driven diagonally into
-  // the wall overshoots the rounded outer arc and pokes out of the bin. With the
-  // penetration that happens at ANY wall thickness, not only the thin walls the
-  // old geometric threshold assumed, so always clip the scoop to the inner
-  // cavity footprint grown by the same penetration: its rounded corners
-  // (cavityCornerR + wallPenetration) stay inside the outer wall (because
-  // wallPenetration < wallThickness) while its straight edges sit exactly at the
-  // intended penetration depth, trimming the corner overshoot without shaving
-  // the flat-face weld. Interior scoops sit well inside the footprint, so this
-  // is a no-op for them.
+  // The scoop is a square-cornered full-width prism, pushed `wallPenetration`
+  // into the surrounding walls to weld it (above). At the bin's rounded outer
+  // corners a square corner driven diagonally into the wall overshoots the outer
+  // arc and pokes out of the bin, at any wall thickness once the penetration is
+  // applied. Clip it to the inner cavity footprint grown by the penetration: the
+  // rounded corners stay inside the outer wall (wallPenetration < wallThickness)
+  // and the straight edges keep the weld depth, so the overshoot is trimmed but
+  // the flat-face weld is not. Interior scoops sit inside the footprint (no-op).
   try {
     const cavityCornerR = Math.max(BOX_CORNER_RADIUS - wallThickness, 0.1);
     const footprint = scope.register(

--- a/src/features/generation/worker/generators/scoopRampBuilder.ts
+++ b/src/features/generation/worker/generators/scoopRampBuilder.ts
@@ -232,42 +232,39 @@ function buildScoopRampsInScope(
       ? scoopShapes[0] // already scope-registered
       : scope.register(unwrap(fuseAll(scoopShapes as ValidSolid[])));
 
-  // Thin-walled bins round the inner cavity corners to radius
-  // (BOX_CORNER_RADIUS − wallThickness), but the scoop is a straight full-width
-  // prism with SQUARE corners. At the bin's front-outer corners those square
-  // corners poke through the rounded outer wall and stick out of the bin. Below
-  // the geometric threshold wallThickness < BOX_CORNER_RADIUS·(1 − 1/√2) the
-  // square corner overshoots the outer arc (same condition the cavity cut
-  // guards in compartmentBuilder,). Clip the scoop to the rounded inner
-  // footprint so its corners follow the wall; skip the boolean above the
-  // threshold where there is nothing to trim.
-  if (wallThickness < BOX_CORNER_RADIUS * (1 - Math.SQRT1_2)) {
-    try {
-      const cavityCornerR = Math.max(BOX_CORNER_RADIUS - wallThickness, 0.1);
-      // Expand the clip by `wallPenetration` so it trims the corner overshoot
-      // without also shaving off the intentional back-edge penetration — which
-      // would restore the coincident wall face this fix removes. Still inside
-      // the outer wall because `wallPenetration < wallThickness`.
-      const footprint = scope.register(
-        sketch(
-          drawRoundedRectangle(
-            innerW + 2 * wallPenetration,
-            innerD + 2 * wallPenetration,
-            cavityCornerR + wallPenetration
-          ),
-          'XY',
-          -1
-        ).extrude(wallHeight + 2)
-      );
-      return scope.register(unwrap(intersect(fused as ValidSolid, footprint as ValidSolid)));
-    } catch {
-      // The clip only trims a sub-mm corner overshoot — best-effort, like the
-      // other booleans here. A kernel failure must not sink the whole bin
-      // build, so fall back to the un-clipped scoop.
-      return fused;
-    }
+  // The inner cavity rounds its corners to radius (BOX_CORNER_RADIUS −
+  // wallThickness), but the scoop is a straight full-width prism with SQUARE
+  // corners, pushed `wallPenetration` into the surrounding walls to weld it
+  // (above). At the bin's outer corners a square corner driven diagonally into
+  // the wall overshoots the rounded outer arc and pokes out of the bin. With the
+  // penetration that happens at ANY wall thickness, not only the thin walls the
+  // old geometric threshold assumed, so always clip the scoop to the inner
+  // cavity footprint grown by the same penetration: its rounded corners
+  // (cavityCornerR + wallPenetration) stay inside the outer wall (because
+  // wallPenetration < wallThickness) while its straight edges sit exactly at the
+  // intended penetration depth, trimming the corner overshoot without shaving
+  // the flat-face weld. Interior scoops sit well inside the footprint, so this
+  // is a no-op for them.
+  try {
+    const cavityCornerR = Math.max(BOX_CORNER_RADIUS - wallThickness, 0.1);
+    const footprint = scope.register(
+      sketch(
+        drawRoundedRectangle(
+          innerW + 2 * wallPenetration,
+          innerD + 2 * wallPenetration,
+          cavityCornerR + wallPenetration
+        ),
+        'XY',
+        -1
+      ).extrude(wallHeight + 2)
+    );
+    return scope.register(unwrap(intersect(fused as ValidSolid, footprint as ValidSolid)));
+  } catch {
+    // The clip only trims a sub-mm corner overshoot — best-effort, like the
+    // other booleans here. A kernel failure must not sink the whole bin
+    // build, so fall back to the un-clipped scoop.
+    return fused;
   }
-  return fused;
 }
 
 // --- FeatureBuilder protocol ---
@@ -290,7 +287,7 @@ export const scoopRampsFeature: FeatureBuilder = {
     const { dimensions: dim, params } = ctx;
     return compactKey(
       buildCacheKey(
-        'v4',
+        'v5',
         dim.shellKey,
         stableSerialize(params.scoop),
         params.style,


### PR DESCRIPTION
## Scoops cut through the outside (#4033)

On a fresh design with a finger scoop, the ramp's facets poke through the **outside** of the bin at the wall corners.

### Root cause

A regression from #4014. To fix a flat-base export gap, #4014 pushes the scoop ramp's back edge and span ends `wallPenetration` into the surrounding walls so the fuse overlaps solid instead of touching it. But the ramp is a **square-cornered** full-width prism. At the bin's rounded outer corners, driving a square corner diagonally into the wall pushes it past the rounded outer arc, so it sticks out of the bin.

`scoopRampBuilder` has a corner clip for exactly this, but it was gated to run only for thin walls (`wallThickness < BOX_CORNER_RADIUS·(1−1/√2)` ≈ 1.10 mm) — a threshold calibrated for the *old*, flush geometry where square corners didn't overshoot. The default **1.2 mm** wall sits just above it, so no clip ran and the penetrated corner breached.

For the default 2×2 bin the breach was measurable: ~0.5 mm of ramp material past the outer corner, over the full ramp height (the vertical striations in the report screenshot).

### Fix

Always clip the ramp to the inner cavity footprint grown by the penetration (`innerW/D + 2·wallPenetration`, corner radius `cavityCornerR + wallPenetration`):

- its rounded corners stay inside the outer wall, because `wallPenetration < wallThickness`;
- its straight edges sit exactly at the intended penetration depth, so the flat-face weld from #4014 is preserved (the export gap stays fixed);
- interior scoops sit well inside the footprint, so it's a no-op for them.

Scoop cache `v4` → `v5` (normal-wall scoop geometry changes).

### Verification

- New `binGenerator.scenario.scoopContainment` proves **zero** ramp material lands outside the true rounded outer footprint, across wall thicknesses (0.95 / 1.2 / 2.0 mm), sides, curved/straight styles, and lip on/off. It fails on `main` for the default case and passes here.
- Scoop + combined-feature **export-integrity** stay watertight/manifold, including #4014's flat/tray-base scenarios — the weld is intact.
- Regenerated the scoop triangle-count snapshots (scoops / combinedFeatures / dividerPatterns / floorPatterns): small, consistent shifts (+268 as the square corner becomes a clipped arc); thin-wall and scoop-disabled cases unchanged.
- Typecheck, eslint, module-boundary and i18n checks clean.

Unlike a print-fit issue, this is a pure geometric containment property (no material past the outer wall), so it is fully verified here — no print test needed.

Closes #4033.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

