### PR TITLE
fix(generation): engrave labels on imported-STL (mesh) cutouts

### DIFF
--- a/src/features/generation/worker/generators/cutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.test.ts
@@ -50,9 +50,11 @@ describe('mesh (STL) cutout labels (#4030)', () => {
     // The mesh imprint itself is subtracted post-tessellation, so the ONLY BREP
     // tool here is the engraved label, which regressed to nothing for mesh.
     const withLabel = buildCutoutCuts(meshCutoutParams(), 80, 80, 35);
-    const total = withLabel.cutTools.length + withLabel.fuseTools.length;
-    expect(total).toBeGreaterThan(0);
-    for (const t of [...withLabel.cutTools, ...withLabel.fuseTools]) t.delete();
+    try {
+      expect(withLabel.cutTools.length + withLabel.fuseTools.length).toBeGreaterThan(0);
+    } finally {
+      for (const t of [...withLabel.cutTools, ...withLabel.fuseTools]) t.delete();
+    }
   }, 60_000);
 
   it('builds nothing for a mesh cutout with no label (cavity stays mesh-domain)', () => {

--- a/src/features/generation/worker/generators/cutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.test.ts
@@ -9,12 +9,62 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { box, getBounds } from 'brepjs';
-import { findBottomEdges } from './cutoutBuilder';
+import { findBottomEdges, buildCutoutCuts } from './cutoutBuilder';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import { loadTestFonts } from '@/test/loadTestFonts';
+import type { BinParams, Cutout } from '@/shared/types/bin';
 
 beforeAll(async () => {
   const { initBrepjs } = await import('./__kernel-tests__/wasmInit');
   await initBrepjs();
+  await loadTestFonts();
 }, 60_000);
+
+function meshCutoutParams(over: Partial<Cutout> = {}): BinParams {
+  const cutout: Cutout = {
+    id: 'm1',
+    shape: 'mesh',
+    meshId: 'asset-1',
+    x: 10,
+    y: 10,
+    width: 20,
+    depth: 12,
+    cutDepth: 6,
+    rotation: 0,
+    cornerRadius: 0,
+    label: 'AB',
+    engraveLabel: true,
+    groupId: null,
+    ...over,
+  };
+  return {
+    ...DEFAULT_BIN_PARAMS,
+    style: 'solid',
+    base: { ...DEFAULT_BIN_PARAMS.base, solid: true },
+    cutouts: [cutout],
+  };
+}
+
+describe('mesh (STL) cutout labels (#4030)', () => {
+  it('engraves a label on a mesh cutout even though its cavity is mesh-domain', () => {
+    // The mesh imprint itself is subtracted post-tessellation, so the ONLY BREP
+    // tool here is the engraved label, which regressed to nothing for mesh.
+    const withLabel = buildCutoutCuts(meshCutoutParams(), 80, 80, 35);
+    const total = withLabel.cutTools.length + withLabel.fuseTools.length;
+    expect(total).toBeGreaterThan(0);
+    for (const t of [...withLabel.cutTools, ...withLabel.fuseTools]) t.delete();
+  }, 60_000);
+
+  it('builds nothing for a mesh cutout with no label (cavity stays mesh-domain)', () => {
+    const noLabel = buildCutoutCuts(
+      meshCutoutParams({ engraveLabel: false, label: '' }),
+      80,
+      80,
+      35
+    );
+    expect(noLabel.cutTools.length + noLabel.fuseTools.length).toBe(0);
+  }, 60_000);
+});
 
 describe('findBottomEdges', () => {
   it('selects only the flat bottom edges, excluding vertical corner edges', () => {

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -1151,8 +1151,18 @@ export function buildCutoutCuts(
   // apply, and the one the store's epoch bump has always assumed. Group MEMBERS
   // are dropped too, so a hidden subtract-member stops subtracting and a group
   // whose members are all hidden builds nothing.
-  const buildable = params.cutouts.filter((c) => c.shape !== 'mesh' && c.hidden !== true);
-  if (buildable.length === 0) return { cutTools: [], fuseTools: [] };
+  // Mesh imprints stay in `labelable` for the LABEL loop below (their text
+  // engraves on the bin top like any other cutout's), but are dropped from
+  // `buildable` because their cavity is not profile-extrudable: it subtracts
+  // post-tessellation in the mesh domain (meshImprint stage), never here.
+  const labelable = params.cutouts.filter((c) => c.hidden !== true);
+  const buildable = labelable.filter((c) => c.shape !== 'mesh');
+  // Emit nothing only when there is neither a buildable cavity nor a labelled
+  // mesh imprint (whose label this function still owns).
+  const hasMeshLabel = labelable.some(
+    (c) => c.shape === 'mesh' && isCutoutEngraveMode(c) && c.label.trim() !== ''
+  );
+  if (buildable.length === 0 && !hasMeshLabel) return { cutTools: [], fuseTools: [] };
   params = { ...params, cutouts: buildable };
 
   // Cutout x,y are relative to interior bottom-left corner (0,0).
@@ -1244,14 +1254,16 @@ export function buildCutoutCuts(
   // Group op per groupId, keyed off the first member in cutouts order — the
   // same member buildGroupedCutouts reads it from.
   const groupOps = new Map<string, GroupOp>();
-  for (const c of params.cutouts) {
+  for (const c of labelable) {
     if (c.groupId !== null && !groupOps.has(c.groupId)) {
       groupOps.set(c.groupId, c.groupOp ?? DEFAULT_GROUP_OP);
     }
   }
 
+  // Labels iterate `labelable` (incl. mesh imprints) so a mesh cutout's text
+  // engraves on the bin top even though its cavity is built in the mesh domain.
   const rawFuseShapes: Shape3D[] = [];
-  for (const master of params.cutouts) {
+  for (const master of labelable) {
     if (!isCutoutEngraveMode(master)) continue;
     // A repeat with a label list engraves once per instance, each with its own
     // word; without one it engraves once beside the master, which is what every
@@ -1518,7 +1530,8 @@ function labelCenterInFootprint(cutout: Cutout, lx: number, ly: number): boolean
       return pointInPolyline(outline, lx, ly);
     }
     case 'mesh':
-      // Mesh imprints are filtered out before the label loop; unreachable.
+      // The imported pocket floor is an arbitrary surface with no flat plane to
+      // engrave into, so a mesh cutout's label always lands on the bin top.
       return false;
     case 'text':
       // A text element has no cavity, so its caption always lands on the

--- a/src/features/generation/worker/generators/cutoutBuilder.ts
+++ b/src/features/generation/worker/generators/cutoutBuilder.ts
@@ -1158,9 +1158,14 @@ export function buildCutoutCuts(
   const labelable = params.cutouts.filter((c) => c.hidden !== true);
   const buildable = labelable.filter((c) => c.shape !== 'mesh');
   // Emit nothing only when there is neither a buildable cavity nor a labelled
-  // mesh imprint (whose label this function still owns).
+  // mesh imprint (whose label this function still owns). Check per-instance
+  // labels, not just the master's, so a repeated mesh cutout labelled only
+  // through `array.labels` still counts.
   const hasMeshLabel = labelable.some(
-    (c) => c.shape === 'mesh' && isCutoutEngraveMode(c) && c.label.trim() !== ''
+    (c) =>
+      c.shape === 'mesh' &&
+      isCutoutEngraveMode(c) &&
+      labelledInstances(c).some((i) => i.label.trim() !== '')
   );
   if (buildable.length === 0 && !hasMeshLabel) return { cutTools: [], fuseTools: [] };
   params = { ...params, cutouts: buildable };
@@ -1260,8 +1265,6 @@ export function buildCutoutCuts(
     }
   }
 
-  // Labels iterate `labelable` (incl. mesh imprints) so a mesh cutout's text
-  // engraves on the bin top even though its cavity is built in the mesh domain.
   const rawFuseShapes: Shape3D[] = [];
   for (const master of labelable) {
     if (!isCutoutEngraveMode(master)) continue;


### PR DESCRIPTION
## STL-cutout labels are dropped (#4030)

A custom cutout made from an **imported STL** never got its label: nothing engraved in the 3D preview and no text shipped in the exported STL. The same label on a parametric shape (rectangle, circle, ...) worked.

### Root cause

`buildCutoutCuts` narrows the cutout list to `buildable`, which drops mesh imprints on purpose — their cavity isn't profile-extrudable, so it's subtracted post-tessellation in the mesh domain (`meshImprint`), not through the BREP cut path. But the **label loop reused that narrowed list**, so a mesh cutout's label was never handed to `buildCutoutLabel`. The mesh-domain path builds the pocket and never reads `label`, so the text fell through both domains.

### Fix

Iterate the label loop over `labelable` (all non-hidden cutouts, mesh included) instead of the mesh-excluded `buildable`. The mesh cavity still stays in the mesh domain; only its **label** is now built here and engraves on the bin top like any other cutout's. A mesh label always lands on the top (`labelCenterInFootprint` returns false for `mesh`), since the imported pocket floor is an arbitrary surface with no flat plane to cut into.

### Verification

- New `cutoutBuilder` tests: a mesh cutout with an engrave label now produces a label tool (it produced none before the fix); a mesh cutout with no label still produces nothing (its cavity stays mesh-domain).
- Parametric cutout labels, label sockets, hidden cutouts, solid cutouts and mesh-imprint geometry all still pass (86 tests across the touched suites). Typecheck, eslint, module-boundary and i18n checks clean.

### Not addressed here: the "preview loses its base" symptom

The issue also reports that the STL-cutout **preview** loses the bin base (while the export keeps it). I could not reproduce that with synthetic STL tools across shallow/deep and small/near-full-footprint pockets and socketed/solid bases — a socketed-base preview kept its base (foot at Z=0) in every probe. It likely needs the reporter's specific model and orientation (a 66 mm cylinder on-edge in an ~84 mm bin). Rather than ship a speculative change to the shared mesh-imprint path, I've left it out and this PR uses `Refs`, not `Closes`. If the reporter can attach the STL (or a saved design), I'll reproduce and fix it as a follow-up.

Refs #4030

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

