### PR TITLE
fix(bin-designer): don't crash new-design when the start button forwards its event

### DIFF
--- a/src/features/bin-designer/components/DesignListDialog/DesignListEmptyState.test.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListEmptyState.test.tsx
@@ -10,10 +10,13 @@ describe('DesignListEmptyState', () => {
     expect(screen.getByRole('button', { name: /Start a new design/ })).toBeInTheDocument();
   });
 
-  it('fires onNewDesign when the start button is clicked', () => {
+  it('fires onNewDesign with no argument when the start button is clicked', () => {
     const onNewDesign = vi.fn();
     render(<DesignListEmptyState onNewDesign={onNewDesign} />);
     fireEvent.click(screen.getByRole('button', { name: /Start a new design/ }));
     expect(onNewDesign).toHaveBeenCalledTimes(1);
+    // Must NOT forward the click event: the parent reads the first argument as
+    // the item kind, and an event object has no descriptor (crashes new-design).
+    expect(onNewDesign).toHaveBeenCalledWith();
   });
 });

--- a/src/features/bin-designer/components/DesignListDialog/DesignListEmptyState.tsx
+++ b/src/features/bin-designer/components/DesignListDialog/DesignListEmptyState.tsx
@@ -35,7 +35,10 @@ export function DesignListEmptyState({ onNewDesign }: DesignListEmptyStateProps)
       </p>
       <Button
         variant="primary"
-        onClick={onNewDesign}
+        // Call with no args: wiring `onClick={onNewDesign}` passes the click
+        // event as the first argument, which the parent reads as the item kind
+        // (a `[object Object]` that has no descriptor, crashing new-design).
+        onClick={() => onNewDesign()}
         className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-on-accent transition-colors hover:bg-accent-hover"
         leftIcon={<PlusIcon className="h-4 w-4" />}
       >

--- a/src/features/bin-designer/store/slices/persistenceSlice.test.ts
+++ b/src/features/bin-designer/store/slices/persistenceSlice.test.ts
@@ -101,6 +101,13 @@ describe('persistenceSlice.loadDesign — UI derivation from params', () => {
     expect(useDesignerStore.getState().ui.shapeEditorOpen).toBe(false);
   });
 
+  it('newDesign coerces a malformed kind to bin rather than crashing (#4032)', () => {
+    // A mis-wired `onClick={onNewDesign}` forwards the click event as the kind;
+    // it has no item descriptor, which used to throw and crash new-design.
+    expect(() => useDesignerStore.getState().newDesign({} as never)).not.toThrow();
+    expect(useDesignerStore.getState().itemKind).toBe('bin');
+  });
+
   it('drops a structurally-invalid cellMask on load (defends against crafted shares)', () => {
     // Mask with a disconnected component — validateMask rejects this.
     // Two isolated cells with no 4-connected path between them.

--- a/src/features/bin-designer/store/slices/persistenceSlice.ts
+++ b/src/features/bin-designer/store/slices/persistenceSlice.ts
@@ -120,6 +120,11 @@ export function createPersistenceSlice(set: Set) {
     },
 
     newDesign: (kind: ItemKind = 'bin') => {
+      // Coerce a malformed kind back to 'bin' so a missing descriptor can never
+      // crash new-design. A mis-wired `onClick={onNewDesign}` forwards the click
+      // event as this argument, which would otherwise reach getItemDescriptor as
+      // a `[object Object]` with no descriptor.
+      const safeKind: ItemKind = kind === 'bin' || hasItemDescriptor(kind) ? kind : 'bin';
       set((state) => {
         state.history.past = [];
         state.history.future = [];
@@ -129,14 +134,14 @@ export function createPersistenceSlice(set: Set) {
         state.pendingBinLink = null;
         state.needsThumbnailUpdate = false;
         state.generation.epoch += 1;
-        state.itemKind = kind;
+        state.itemKind = safeKind;
         state.ui.shapeEditorOpen = false;
         state.ui.bentoWorkspaceOpen = false;
         state.ui.interiorCard = 'standard';
 
         state.lineage = null;
 
-        if (kind === 'bin') {
+        if (safeKind === 'bin') {
           state.params = { ...defaultsForNewDesign() };
           state.envelope = null;
           state.structure = null;
@@ -147,7 +152,7 @@ export function createPersistenceSlice(set: Set) {
           state.ui.halfGridMode = paramsNeedHalfGridMode(state.params);
         } else {
           // Non-bin kind: live editable state is envelope + structure.
-          state.structure = getItemDescriptor(kind).defaults();
+          state.structure = getItemDescriptor(safeKind).defaults();
           state.envelope = createDefaultEnvelope(DEFAULT_BIN_PARAMS.featureColors);
           state.designName = 'Untitled';
           state.ui.halfGridMode = false;


### PR DESCRIPTION
## "No item descriptor registered for kind '[object Object]'" (#4032)

An auto-filed runtime crash. The empty-state **"Start a new design"** button (shown when a user has no saved designs) wired its handler as `onClick={onNewDesign}`. React forwards the click event as the handler's first argument, and `newDesign(kind)` reads that first argument as the **item kind** — so it looked up an item descriptor for a `[object Object]` and threw.

Sibling buttons avoid this by wrapping (`onClick={() => newDesign('assembly')}`); the empty-state one didn't.

### Fix

- `DesignListEmptyState`: call `onNewDesign()` with no argument, so no event leaks into the kind slot.
- `newDesign`: defensively coerce a non-`'bin'` kind that has no registered descriptor back to `'bin'`, mirroring the guard the load/restore paths already use, so a stray argument can never crash new-design again.

### Verification

- The empty-state button test now asserts the handler is called with **no argument** (it fails on the old `onClick={onNewDesign}` wiring).
- A new persistence-slice test asserts `newDesign({} as never)` does not throw and falls back to `itemKind: 'bin'`.
- Typecheck, eslint, design-system and i18n checks clean.

Closes #4032

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

