### PR TITLE
fix(spacemouse): correct pan/zoom axis roles and left-right direction

### DIFF
--- a/src/shared/spacemouse/mapping.test.ts
+++ b/src/shared/spacemouse/mapping.test.ts
@@ -48,11 +48,26 @@ describe('toDeflection', () => {
       rotation: { pitch: 350, roll: 0, yaw: 350 },
     };
     const d = toDeflection(raw, DEFAULT_SETTINGS);
-    expect(d.panX).toBeCloseTo(1); // x+ = right
-    expect(d.panY).toBeCloseTo(1); // z- (lift) = screen up
-    expect(d.zoom).toBeCloseTo(1); // y- (push forward) = zoom in
+    expect(d.panX).toBeCloseTo(-1); // x+ pans left (puck follows the model)
+    expect(d.panY).toBeCloseTo(1); // -y (lift) pans screen up
+    expect(d.zoom).toBeCloseTo(1); // -z (push forward) zooms in
     expect(d.orbitH).toBeCloseTo(1);
     expect(d.orbitV).toBeCloseTo(1);
+  });
+
+  it('drives pan from lift (y) and zoom from push (z), not the reverse (#4041)', () => {
+    const lift = toDeflection(
+      { translation: { x: 0, y: 350, z: 0 }, rotation: { pitch: 0, roll: 0, yaw: 0 } },
+      DEFAULT_SETTINGS
+    );
+    expect(Math.abs(lift.panY)).toBeCloseTo(1); // the lift axis drives vertical pan
+    expect(lift.zoom).toBeCloseTo(0); // ...never zoom
+    const push = toDeflection(
+      { translation: { x: 0, y: 0, z: 350 }, rotation: { pitch: 0, roll: 0, yaw: 0 } },
+      DEFAULT_SETTINGS
+    );
+    expect(Math.abs(push.zoom)).toBeCloseTo(1); // the push axis drives zoom
+    expect(push.panY).toBeCloseTo(0); // ...never pan
   });
 
   it('honors per-axis inversion', () => {
@@ -65,7 +80,7 @@ describe('toDeflection', () => {
       rotation: { pitch: 0, roll: 0, yaw: 350 },
     };
     const d = toDeflection(raw, settings);
-    expect(d.panX).toBeCloseTo(-1);
+    expect(d.panX).toBeCloseTo(1); // invert flips the corrected base sign back
     expect(d.orbitH).toBeCloseTo(-1);
   });
 });
@@ -83,7 +98,7 @@ describe('computeFrameMotion', () => {
     const near = computeFrameMotion(full, DEFAULT_SETTINGS, 1 / 60, 10);
     const far = computeFrameMotion(full, DEFAULT_SETTINGS, 1 / 60, 100);
     expect(far.panX).toBeCloseTo(near.panX * 10);
-    expect(far.panX).toBeGreaterThan(0);
+    expect(far.panX).toBeLessThan(0); // x+ now pans left (negative panX)
   });
 
   it('scales all motion by sensitivity', () => {

--- a/src/shared/spacemouse/mapping.ts
+++ b/src/shared/spacemouse/mapping.ts
@@ -33,15 +33,21 @@ function axis(raw: number, invert: boolean): number {
 
 /**
  * Map raw device axes to the five semantic navigation axes, applying the
- * deadzone and per-axis inversion. Device axis meanings (from spacemouse-webhid):
- * translate x = right, y = forward/back, z = up/down; rotate pitch/yaw.
+ * deadzone and per-axis inversion.
+ *
+ * Axis roles corrected against a SpaceMouse Pro hardware test (#4041): left/right
+ * translation followed the puck backwards, and the lift and push axes drove the
+ * wrong pair (lift zoomed, push panned). So left/right is negated, and the up/down
+ * (y) and forward/back (z) axes now drive pan and zoom respectively. Rotations
+ * (orbit) already tested correct and are unchanged. Any residual per-axis sign a
+ * given device disagrees on is the user's `invert.*` override.
  */
 export function toDeflection(raw: RawDeflection, settings: SpaceMouseSettings): Deflection {
   const { invert } = settings;
   return {
-    panX: axis(raw.translation.x, invert.panX),
-    panY: axis(-raw.translation.z, invert.panY), // device z+ is down; screen up is +
-    zoom: axis(-raw.translation.y, invert.zoom), // push forward (y-) zooms in
+    panX: axis(-raw.translation.x, invert.panX), // puck left pans the view left
+    panY: axis(-raw.translation.y, invert.panY), // lift (up/down) pans vertically
+    zoom: axis(-raw.translation.z, invert.zoom), // push forward zooms in
     orbitH: axis(raw.rotation.yaw, invert.orbitH),
     orbitV: axis(raw.rotation.pitch, invert.orbitV),
   };


### PR DESCRIPTION
## SpaceMouse pan/zoom axes and left-right direction (#4041)

Acting on the first hardware test (SpaceMouse Pro). Two of the reported problems are in the axis mapping (`toDeflection`):

- **Movement 1 inverted:** left/right translation moved the model opposite the puck. Negated so the model follows the puck (matching the CAD convention the reporter expects).
- **Movements 2 & 3 cross-mapped:** the lift and push axes drove the wrong pair (lifting zoomed, pushing panned vertically). Swapped so the up/down (y) axis pans vertically and the forward/back (z) axis zooms.

Rotations (movements 4 and 6) already tested correct and are unchanged; movement 5 (roll) intentionally does nothing.

The axis-to-motion **assignment** (which DoF drives pan vs zoom vs orbit) is not user-configurable, so that is the substantive fix here. Each axis's **sign** does have a per-axis `invert.*` user override, and I could not verify the swapped axes' directions without the hardware.

### Verification

- Unit tests updated for the corrected signs, plus a new case that locks the swap: the lift (y) axis drives pan and never zoom, the push (z) axis drives zoom and never pan. All 54 spacemouse tests pass; typecheck/eslint clean.

### Please confirm on hardware

@ the reporter: could you re-test after this deploys? Specifically, whether **lifting the puck up** pans the view up (not down) and **pushing forward** zooms in (not out). If either direction is reversed, the SpaceMouse settings panel has a per-axis invert toggle, and I'll flip the default. Keeping this open (`Refs`) until confirmed.

Refs #4041

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

