### PR TITLE
fix(shell): make the settings cog available on every view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useState, useCallback, Suspense } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { SettingsTabId } from '@/shell/Modals/SettingsModal/types';
+import { GlobalSettingsModal } from '@/shell/Modals/SettingsModal/GlobalSettingsModal';
 import {
   useLayoutStore,
   useLibraryStore,
@@ -124,9 +124,6 @@ const DevThumbnailRoute = lazyWithRetry(() =>
 const HelpModal = lazyWithRetry(() =>
   import('@/shell/Modals/HelpModal').then(namedExport('HelpModal'))
 );
-const SettingsModal = lazyWithRetry(() =>
-  import('@/shell/Modals/SettingsModal').then(namedExport('SettingsModal'))
-);
 const MobileLayout = lazyWithRetry(() =>
   import('@/shell/layouts/MobileLayout').then(namedExport('MobileLayout'))
 );
@@ -149,13 +146,6 @@ export default function App() {
   const t = useTranslation();
   useThemeEffect();
   const [isHelpOpen, setIsHelpOpen] = useState(false);
-  // App-wide settings are global so the header cog reaches them from every view,
-  // not just the layout sidebar (#4034). initialTab lets the account link and the
-  // command palette deep-link a specific tab.
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTabId | undefined>(
-    undefined
-  );
   const [isMobileHelpOpen, setIsMobileHelpOpen] = useState(false);
 
   const { isDesignerRoute, navigateToDesigner } = useDesignerRouting();
@@ -379,17 +369,6 @@ export default function App() {
     const handleOpenHelp = () => setIsHelpOpen(true);
     window.addEventListener('open-help-modal', handleOpenHelp);
     return () => window.removeEventListener('open-help-modal', handleOpenHelp);
-  }, []);
-
-  useEffect(() => {
-    const handleOpenSettings = (e: Event) => {
-      // Dispatchers (header cog, account link, command palette) may omit detail.
-      const detail = (e as CustomEvent<{ tab?: SettingsTabId } | null>).detail;
-      setSettingsInitialTab(detail?.tab);
-      setIsSettingsOpen(true);
-    };
-    window.addEventListener('open-settings-modal', handleOpenSettings);
-    return () => window.removeEventListener('open-settings-modal', handleOpenSettings);
   }, []);
 
   useEffect(() => {
@@ -716,18 +695,7 @@ export default function App() {
           <HelpModal isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} isTablet={isTablet} />
         </Suspense>
       )}
-      {isSettingsOpen && (
-        <Suspense fallback={<LoadingFallback variant="overlay" label={t('loading.settings')} />}>
-          <SettingsModal
-            isOpen={isSettingsOpen}
-            onClose={() => {
-              setIsSettingsOpen(false);
-              setSettingsInitialTab(undefined);
-            }}
-            initialTab={settingsInitialTab}
-          />
-        </Suspense>
-      )}
+      <GlobalSettingsModal />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useState, useCallback, Suspense } from 'react';
 import { useShallow } from 'zustand/react/shallow';
+import type { SettingsTabId } from '@/shell/Modals/SettingsModal/types';
 import {
   useLayoutStore,
   useLibraryStore,
@@ -123,6 +124,9 @@ const DevThumbnailRoute = lazyWithRetry(() =>
 const HelpModal = lazyWithRetry(() =>
   import('@/shell/Modals/HelpModal').then(namedExport('HelpModal'))
 );
+const SettingsModal = lazyWithRetry(() =>
+  import('@/shell/Modals/SettingsModal').then(namedExport('SettingsModal'))
+);
 const MobileLayout = lazyWithRetry(() =>
   import('@/shell/layouts/MobileLayout').then(namedExport('MobileLayout'))
 );
@@ -145,6 +149,13 @@ export default function App() {
   const t = useTranslation();
   useThemeEffect();
   const [isHelpOpen, setIsHelpOpen] = useState(false);
+  // App-wide settings are global so the header cog reaches them from every view,
+  // not just the layout sidebar (#4034). initialTab lets the account link and the
+  // command palette deep-link a specific tab.
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTabId | undefined>(
+    undefined
+  );
   const [isMobileHelpOpen, setIsMobileHelpOpen] = useState(false);
 
   const { isDesignerRoute, navigateToDesigner } = useDesignerRouting();
@@ -368,6 +379,17 @@ export default function App() {
     const handleOpenHelp = () => setIsHelpOpen(true);
     window.addEventListener('open-help-modal', handleOpenHelp);
     return () => window.removeEventListener('open-help-modal', handleOpenHelp);
+  }, []);
+
+  useEffect(() => {
+    const handleOpenSettings = (e: Event) => {
+      // Dispatchers (header cog, account link, command palette) may omit detail.
+      const detail = (e as CustomEvent<{ tab?: SettingsTabId } | null>).detail;
+      setSettingsInitialTab(detail?.tab);
+      setIsSettingsOpen(true);
+    };
+    window.addEventListener('open-settings-modal', handleOpenSettings);
+    return () => window.removeEventListener('open-settings-modal', handleOpenSettings);
   }, []);
 
   useEffect(() => {
@@ -692,6 +714,18 @@ export default function App() {
       {isHelpOpen && (
         <Suspense fallback={<LoadingFallback variant="overlay" label={t('loading.help')} />}>
           <HelpModal isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} isTablet={isTablet} />
+        </Suspense>
+      )}
+      {isSettingsOpen && (
+        <Suspense fallback={<LoadingFallback variant="overlay" label={t('loading.settings')} />}>
+          <SettingsModal
+            isOpen={isSettingsOpen}
+            onClose={() => {
+              setIsSettingsOpen(false);
+              setSettingsInitialTab(undefined);
+            }}
+            initialTab={settingsInitialTab}
+          />
         </Suspense>
       )}
     </>

--- a/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.test.tsx
+++ b/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.test.tsx
@@ -46,6 +46,13 @@ describe('HeaderSupportLinks', () => {
     expect(screen.getByLabelText('header.helpAndShortcuts')).toBeInTheDocument();
   });
 
+  it('renders the settings cog and opens settings via the global event (#4034)', () => {
+    const dispatch = vi.spyOn(window, 'dispatchEvent');
+    render(<HeaderSupportLinks />);
+    fireEvent.click(screen.getByLabelText('sidebar.openSettings'));
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'open-settings-modal' }));
+  });
+
   it('renders Ko-fi support button', () => {
     render(<HeaderSupportLinks />);
     expect(screen.getByLabelText('header.supportOnKofi')).toBeInTheDocument();

--- a/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
+++ b/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
@@ -92,7 +92,9 @@ export function HeaderSupportLinks({
   };
 
   const handleSettingsClick = () => {
-    window.dispatchEvent(new Event('open-settings-modal'));
+    // CustomEvent (not plain Event) to match the contract: the listener reads an
+    // optional `detail.tab`. This dispatcher opens the default tab.
+    window.dispatchEvent(new CustomEvent('open-settings-modal'));
   };
 
   const handleKofiClick = () => {

--- a/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
+++ b/src/shared/components/HeaderSupportLinks/HeaderSupportLinks.tsx
@@ -91,6 +91,10 @@ export function HeaderSupportLinks({
     window.dispatchEvent(new Event('open-help-modal'));
   };
 
+  const handleSettingsClick = () => {
+    window.dispatchEvent(new Event('open-settings-modal'));
+  };
+
   const handleKofiClick = () => {
     trackEvent('kofi_clicked', { source: 'header' });
     window.open(KOFI_URL, '_blank', 'noopener,noreferrer');
@@ -129,6 +133,7 @@ export function HeaderSupportLinks({
         <>
           <Menu.Item onClick={handleFeedbackClick}>{t('header.sendFeedback')}</Menu.Item>
           <Menu.Item onClick={handleHelpClick}>{t('header.helpAndShortcuts')}</Menu.Item>
+          <Menu.Item onClick={handleSettingsClick}>{t('sidebar.settings')}</Menu.Item>
         </>
       )}
       <Menu.Item
@@ -226,6 +231,23 @@ export function HeaderSupportLinks({
         </svg>
         <span className="hidden lg:inline">{t('header.help')}</span>
       </Button>
+
+      {/* Settings: app-wide, so it lives here on every view rather than only in
+          the layout sidebar (#4034). Opens the global modal via window event. */}
+      <IconButton
+        size="sm"
+        touchTarget={false}
+        onClick={handleSettingsClick}
+        className="h-8 w-8 text-content-secondary"
+        title={t('sidebar.settings')}
+        aria-label={t('sidebar.openSettings')}
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          {ICON_PATHS.settings.map((d) => (
+            <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
+          ))}
+        </svg>
+      </IconButton>
 
       {overflowTrigger}
       {overflowMenu}

--- a/src/shell/Modals/SettingsModal/GlobalSettingsModal.test.tsx
+++ b/src/shell/Modals/SettingsModal/GlobalSettingsModal.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { GlobalSettingsModal } from './GlobalSettingsModal';
+
+vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
+
+vi.mock('./SettingsModal', () => ({
+  SettingsModal: ({
+    isOpen,
+    onClose,
+    initialTab,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    initialTab?: string;
+  }) =>
+    isOpen ? (
+      <div data-testid="settings-modal" data-tab={initialTab ?? 'none'}>
+        <button data-testid="close-settings" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+const open = (detail?: { tab?: string }): void => {
+  act(() => {
+    window.dispatchEvent(
+      detail
+        ? new CustomEvent('open-settings-modal', { detail })
+        : new CustomEvent('open-settings-modal')
+    );
+  });
+};
+
+describe('GlobalSettingsModal', () => {
+  it('renders nothing until the event fires', () => {
+    render(<GlobalSettingsModal />);
+    expect(screen.queryByTestId('settings-modal')).not.toBeInTheDocument();
+  });
+
+  it('opens on a detail-less open-settings-modal event (default tab)', async () => {
+    render(<GlobalSettingsModal />);
+    open();
+    expect(await screen.findByTestId('settings-modal')).toHaveAttribute('data-tab', 'none');
+  });
+
+  it('deep-links the tab carried in the event detail', async () => {
+    render(<GlobalSettingsModal />);
+    open({ tab: 'account' });
+    expect(await screen.findByTestId('settings-modal')).toHaveAttribute('data-tab', 'account');
+  });
+
+  it('closes when the modal requests it', async () => {
+    render(<GlobalSettingsModal />);
+    open();
+    fireEvent.click(await screen.findByTestId('close-settings'));
+    expect(screen.queryByTestId('settings-modal')).not.toBeInTheDocument();
+  });
+});

--- a/src/shell/Modals/SettingsModal/GlobalSettingsModal.tsx
+++ b/src/shell/Modals/SettingsModal/GlobalSettingsModal.tsx
@@ -1,0 +1,46 @@
+import { Suspense, useEffect, useState } from 'react';
+import { useTranslation } from '@/i18n';
+import { lazyWithRetry, namedExport } from '@/shared/utils/lazyWithRetry';
+import { LoadingFallback } from '@/shared/components/LoadingFallback';
+import type { SettingsTabId } from './types';
+
+const SettingsModal = lazyWithRetry(() =>
+  import('./SettingsModal').then(namedExport('SettingsModal'))
+);
+
+/**
+ * Global host for the app-wide settings modal. Mounted once at the app root so
+ * the `open-settings-modal` event opens settings from every view (the header
+ * cog, the sidebar account link, the command palette), not just the layout
+ * sidebar (#4034). Dispatchers may carry a `detail.tab` to deep-link a tab, or
+ * omit the detail entirely.
+ */
+export function GlobalSettingsModal() {
+  const t = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialTab, setInitialTab] = useState<SettingsTabId | undefined>(undefined);
+
+  useEffect(() => {
+    const handleOpen = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab?: SettingsTabId } | null>).detail;
+      setInitialTab(detail?.tab);
+      setIsOpen(true);
+    };
+    window.addEventListener('open-settings-modal', handleOpen);
+    return () => window.removeEventListener('open-settings-modal', handleOpen);
+  }, []);
+
+  if (!isOpen) return null;
+  return (
+    <Suspense fallback={<LoadingFallback variant="overlay" label={t('loading.settings')} />}>
+      <SettingsModal
+        isOpen={isOpen}
+        onClose={() => {
+          setIsOpen(false);
+          setInitialTab(undefined);
+        }}
+        initialTab={initialTab}
+      />
+    </Suspense>
+  );
+}

--- a/src/shell/Sidebar/Sidebar.test.tsx
+++ b/src/shell/Sidebar/Sidebar.test.tsx
@@ -1,6 +1,6 @@
 import type * as DesignSystem from '@/design-system';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Sidebar } from '@/shell/Sidebar';
 import { useLayoutStore } from '@/core/store';
 import { useSelectionStore } from '@/core/store/selection';
@@ -77,17 +77,6 @@ vi.mock('@/shell/Modals/HalfGridModeBlockedModal', () => ({
         </button>
         <button data-testid="remediate-btn" onClick={onRemediate}>
           Remediate
-        </button>
-      </div>
-    ) : null,
-}));
-
-vi.mock('@/shell/Modals/SettingsModal', () => ({
-  SettingsModal: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
-    isOpen ? (
-      <div data-testid="settings-modal">
-        <button data-testid="close-settings" onClick={onClose}>
-          Close
         </button>
       </div>
     ) : null,
@@ -408,59 +397,6 @@ describe('Sidebar', () => {
       render(<Sidebar />);
 
       expect(screen.getByLabelText('Grid unit X')).toBeInTheDocument();
-    });
-  });
-
-  describe('settings modal', () => {
-    it('renders settings button in header', () => {
-      render(<Sidebar />);
-
-      expect(screen.getByLabelText('Open settings')).toBeInTheDocument();
-    });
-
-    it('opens settings modal when settings button clicked', async () => {
-      render(<Sidebar />);
-
-      fireEvent.click(screen.getByLabelText('Open settings'));
-
-      // SettingsModal is lazy-loaded, so use findBy which waits
-      expect(await screen.findByTestId('settings-modal')).toBeInTheDocument();
-    });
-
-    it('closes settings modal when close button clicked', async () => {
-      render(<Sidebar />);
-
-      fireEvent.click(screen.getByLabelText('Open settings'));
-      // Wait for lazy-loaded modal to appear
-      expect(await screen.findByTestId('settings-modal')).toBeInTheDocument();
-
-      fireEvent.click(screen.getByTestId('close-settings'));
-
-      expect(screen.queryByTestId('settings-modal')).not.toBeInTheDocument();
-    });
-
-    it('opens settings modal from a detail-less open-settings-modal event', async () => {
-      render(<Sidebar />);
-
-      // The command-palette dispatcher fires this event with no `detail`,
-      // which previously threw reading `e.detail.tab` on a null detail.
-      act(() => {
-        window.dispatchEvent(new CustomEvent('open-settings-modal'));
-      });
-
-      expect(await screen.findByTestId('settings-modal')).toBeInTheDocument();
-    });
-
-    it('opens settings modal from an open-settings-modal event carrying a tab', async () => {
-      render(<Sidebar />);
-
-      act(() => {
-        window.dispatchEvent(
-          new CustomEvent('open-settings-modal', { detail: { tab: 'account' } })
-        );
-      });
-
-      expect(await screen.findByTestId('settings-modal')).toBeInTheDocument();
     });
   });
 

--- a/src/shell/Sidebar/Sidebar.tsx
+++ b/src/shell/Sidebar/Sidebar.tsx
@@ -6,7 +6,6 @@ import { useDrawerSettings } from '@/shared/hooks/useDrawerSettings';
 import { DrawerShapeSection } from '@/features/drawer-shape';
 import { CONSTRAINTS } from '@/core/constants';
 import { Button, Collapsible, IconButton, Stepper } from '@/design-system';
-import type { SettingsTabId } from '@/shell/Modals/SettingsModal/types';
 import { ActiveLayerPanel } from '@/features/layers/components/ActiveLayerPanel';
 import { ActiveBaseplatePanel } from '@/features/baseplate/components/ActiveBaseplatePanel';
 import { LayerPanel } from '@/features/layers/components/LayerPanel';
@@ -35,19 +34,12 @@ import { helpJumpEventName } from '@/shared/help/helpJumpDispatcher';
 const InspirationGallery = lazyWithRetry(() =>
   import('@/features/inspiration-gallery').then(namedExport('InspirationGallery'))
 );
-const SettingsModal = lazyWithRetry(() =>
-  import('@/shell/Modals/SettingsModal').then(namedExport('SettingsModal'))
-);
 
 export function Sidebar() {
   const t = useTranslation();
   const { locale } = useLocale();
   const [isScrolled, setIsScrolled] = useState(false);
   const [showInspirationGallery, setShowInspirationGallery] = useState(false);
-  const [showSettingsModal, setShowSettingsModal] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTabId | undefined>(
-    undefined
-  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const [gridSizeExpanded, setGridSizeExpanded] = useState(true);
   const [physicalUnitsExpanded, setPhysicalUnitsExpanded] = useState(true);
@@ -111,19 +103,6 @@ export function Sidebar() {
 
   // Onboarding — sidebar gallery pulse for low-engagement users
   const { shouldPulseGallery, dismissGalleryPulse } = useOnboarding();
-
-  // Listen for command palette open-settings-modal event (supports optional tab)
-  useEffect(() => {
-    const handleOpenSettings = (e: CustomEvent<{ tab?: SettingsTabId } | null>) => {
-      // The command-palette dispatcher fires this event without a `detail`
-      // payload, so guard against a null detail before reading `tab`.
-      setSettingsInitialTab(e.detail?.tab);
-      setShowSettingsModal(true);
-    };
-    window.addEventListener('open-settings-modal', handleOpenSettings as EventListener);
-    return () =>
-      window.removeEventListener('open-settings-modal', handleOpenSettings as EventListener);
-  }, []);
 
   // Help modal deep-links: expand the destination section so the highlighted
   // control is visible when the dispatcher applies its pulse. Also ensure the
@@ -200,26 +179,6 @@ export function Sidebar() {
             <h2 className="flex-1 text-xs leading-none font-semibold text-content-tertiary tracking-wide">
               {t('sidebar.tools')}
             </h2>
-            <IconButton
-              size="sm"
-              touchTarget={false}
-              onClick={() => setShowSettingsModal(true)}
-              className="h-8 w-8 text-content-tertiary"
-              title={t('sidebar.settings')}
-              aria-label={t('sidebar.openSettings')}
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                {ICON_PATHS.settings.map((d) => (
-                  <path
-                    key={d}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d={d}
-                  />
-                ))}
-              </svg>
-            </IconButton>
             <IconButton
               size="sm"
               touchTarget={false}
@@ -584,10 +543,11 @@ export function Sidebar() {
             </div>
           </div>
           <UserDock
-            onOpenSettings={() => {
-              setSettingsInitialTab('account');
-              setShowSettingsModal(true);
-            }}
+            onOpenSettings={() =>
+              window.dispatchEvent(
+                new CustomEvent('open-settings-modal', { detail: { tab: 'account' } })
+              )
+            }
           />
         </div>
       )}
@@ -606,19 +566,6 @@ export function Sidebar() {
           <InspirationGallery
             isOpen={showInspirationGallery}
             onClose={() => setShowInspirationGallery(false)}
-          />
-        </Suspense>
-      )}
-
-      {showSettingsModal && (
-        <Suspense fallback={<LoadingFallback variant="overlay" label={t('loading.settings')} />}>
-          <SettingsModal
-            isOpen={showSettingsModal}
-            onClose={() => {
-              setShowSettingsModal(false);
-              setSettingsInitialTab(undefined);
-            }}
-            initialTab={settingsInitialTab}
           />
         </Suspense>
       )}


### PR DESCRIPTION
## Settings cog is scoped to the Layout view (#4034)

The settings cog opens **app-wide** settings, but it only appeared in the Layout view's left "Tools" panel header, which is also collapsible. So on Bins / Baseplate / Community, or with the left panel collapsed, there was no way to reach settings from the UI.

## Fix

Make it global (the option you picked):

- **Hoisted** the settings modal and its `open-settings-modal` listener from the layout-only `Sidebar` up to `App.tsx`, mirroring the existing global `open-help-modal` pattern (App already owns Help this way).
- **Added a cog** next to Help in the shared `HeaderSupportLinks` (and its overflow menu), so it shows in the top bar on **Layout, Bins, Baseplate, and Community**. It dispatches the same `open-settings-modal` event.
- The sidebar's account link and the command palette now open settings through that global event too (the `account` deep-link tab still works).
- Mobile already had its own always-visible settings entry; unchanged.

Net −54 lines (mostly moved code).

## Verification

- New `HeaderSupportLinks` test: the cog dispatches `open-settings-modal`. Sidebar tests for the removed modal were deleted (that behavior now lives in App); Sidebar, HeaderSupportLinks and AppShell suites pass. Typecheck, eslint, module-boundary and i18n checks clean (reuses the existing `sidebar.settings` / `sidebar.openSettings` keys, no new locale entries).
- I can't verify the visual placement from here, so please eyeball the cog next to Help on the deploy preview across the desktop/tablet headers; it's styled to match the adjacent Help/Feedback buttons.

Closes #4034

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

