### PR TITLE
fix(bin-designer): inline the view toggle into the search row

### DIFF
--- a/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
@@ -48,13 +48,11 @@ import { GROUP_OF_CONTROL, HELP_SURFACES } from './groupControls';
 export interface BinScrollPanelProps {
   /** docked = desktop frame (resizable, collapsible); plain = fill the parent. */
   readonly frame: 'docked' | 'plain';
-  /** Pinned at the very top, above the toolbar: the control search bar. */
+  /** Pinned at the very top: the search field + view-toggle row. */
   readonly searchBar?: ReactNode;
-  /** Pinned above the scroll: the view-mode toggle bar. */
-  readonly toolbar?: ReactNode;
   /** Scrolls at the top of the list: community card + variant section. */
   readonly header?: ReactNode;
-  /** Wraps the editable groups (VariantLock); toolbar/header/dock stay outside. */
+  /** Wraps the editable groups (VariantLock); searchBar/header/dock stay outside. */
   readonly wrapContent?: (node: ReactNode) => ReactNode;
   /** Pinned below the scroll: the user dock. */
   readonly dock?: ReactNode;
@@ -63,7 +61,6 @@ export interface BinScrollPanelProps {
 export function BinScrollPanel({
   frame,
   searchBar,
-  toolbar,
   header,
   wrapContent,
   dock,
@@ -252,7 +249,6 @@ export function BinScrollPanel({
   const column = (
     <div className="flex h-full min-h-0 flex-col">
       {searchBar}
-      {toolbar}
       {/* `relative` is the containing block for the `sr-only` (position:absolute)
           toggle inputs the sections render; without it their block is the
           viewport and their static position deep in the list extends the

--- a/src/features/bin-designer/components/ParameterPanel/DesignerSearchBar/DesignerSearchBar.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/DesignerSearchBar/DesignerSearchBar.tsx
@@ -103,7 +103,7 @@ export function DesignerSearchBar({ viewMode, needsSplit }: DesignerSearchBarPro
   };
 
   return (
-    <div className="relative flex-shrink-0 border-b border-stroke-subtle px-3 py-2">
+    <div className="relative min-w-0 flex-1">
       <div className="relative">
         <Input
           ref={inputRef}

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -264,8 +264,8 @@ function BinParameterPanel({ frame }: { readonly frame: 'docked' | 'plain' }) {
     </>
   );
 
-  // One view switch, reused by both layouts: the scroll's pinned toolbar and the
-  // rail's header.
+  // One view switch, shared by both layouts. It rides inline in the top row next
+  // to the search field so no empty band opens up between them.
   const viewModes = [
     { mode: 'scroll' as const, paths: ICON_PATHS.menu, label: t('binDesigner.panel.viewAsScroll') },
     {
@@ -274,40 +274,32 @@ function BinParameterPanel({ frame }: { readonly frame: 'docked' | 'plain' }) {
       label: t('binDesigner.panel.viewAsRail'),
     },
   ];
-  const viewSwitch = (
-    <div className="flex flex-shrink-0 items-center justify-end px-3 py-1.5">
-      <div className="inline-flex items-center gap-0.5 rounded-md border border-stroke-subtle p-0.5">
-        {viewModes.map(({ mode, paths, label }) => (
-          <Tooltip key={mode} content={label} placement="bottom">
-            <IconButton
-              variant="ghost"
-              size="sm"
-              touchTarget={false}
-              pressed={viewMode === mode}
-              aria-label={label}
-              onClick={() => selectViewMode(mode)}
+  const viewSwitchPill = (
+    <div className="inline-flex flex-shrink-0 items-center gap-0.5 rounded-md border border-stroke-subtle p-0.5">
+      {viewModes.map(({ mode, paths, label }) => (
+        <Tooltip key={mode} content={label} placement="bottom">
+          <IconButton
+            variant="ghost"
+            size="sm"
+            touchTarget={false}
+            pressed={viewMode === mode}
+            aria-label={label}
+            onClick={() => selectViewMode(mode)}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden
             >
-              <svg
-                className="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                aria-hidden
-              >
-                {paths.map((d) => (
-                  <path
-                    key={d}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d={d}
-                  />
-                ))}
-              </svg>
-            </IconButton>
-          </Tooltip>
-        ))}
-      </div>
+              {paths.map((d) => (
+                <path key={d} strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
+              ))}
+            </svg>
+          </IconButton>
+        </Tooltip>
+      ))}
     </div>
   );
 
@@ -328,16 +320,20 @@ function BinParameterPanel({ frame }: { readonly frame: 'docked' | 'plain' }) {
     </VariantLock>
   );
 
-  const searchBar = searchEnabled ? (
-    <DesignerSearchBar viewMode={viewMode} needsSplit={needsSplit} />
-  ) : null;
+  // Search field and view toggle on one row, sharing a single divider. The row
+  // is `justify-end`, so with search off the lone pill still sits on the right.
+  const topBar = (
+    <div className="flex flex-shrink-0 items-center justify-end gap-2 border-b border-stroke-subtle px-3 py-2">
+      {searchEnabled && <DesignerSearchBar viewMode={viewMode} needsSplit={needsSplit} />}
+      {viewSwitchPill}
+    </div>
+  );
 
   if (viewMode === 'scroll') {
     return (
       <BinScrollPanel
         frame={frame}
-        searchBar={searchBar}
-        toolbar={viewSwitch}
+        searchBar={topBar}
         header={communityAndVariant}
         wrapContent={(content) => wrapEditable(content, false)}
         dock={<UserDock />}
@@ -348,16 +344,11 @@ function BinParameterPanel({ frame }: { readonly frame: 'docked' | 'plain' }) {
   return (
     <BinPanelShell
       frame={frame}
-      searchBar={searchBar}
+      searchBar={topBar}
       header={
-        <>
-          {viewSwitch}
-          {/* Scrolls on its own when the variant section runs long — pinned
-              above the rail, not part of any page's scroll. */}
-          <div className="max-h-[45%] flex-shrink-0 overflow-y-auto scrollbar-thin">
-            {communityAndVariant}
-          </div>
-        </>
+        <div className="max-h-[45%] flex-shrink-0 overflow-y-auto scrollbar-thin">
+          {communityAndVariant}
+        </div>
       }
       pages={{
         shape: <ShapePage />,


### PR DESCRIPTION
## What

In the bin designer sidebar, the search field and the panel view-mode toggle stacked as two separate rows split by a divider. That left an empty band with the toggle floating off at the right, reading as an awkward gap.

This moves the toggle inline onto the search row so they share one row and one divider. The row is `justify-end`, so when the search feature flag is off the lone toggle still sits on the right (unchanged from before). Applies to both the scroll and rail layouts, reclaiming the vertical band above the Community card.

## Changes

- `DesignerSearchBar`: dropped its own border/padding chrome so it acts as a flex child that fills the row.
- `ParameterPanel`: combined the search field and the toggle pill into one `topBar` row with a single divider; removed the standalone toggle from the rail header.
- `BinScrollPanel`: removed the now-dead `toolbar` prop.

## Verification

- Ran the designer locally and confirmed the fix in both scroll and rail views (toggle still switches, search dropdown still anchors under the field).
- `pnpm run typecheck` clean, ESLint clean, 105 bin-designer/search tests pass.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

