### PR TITLE
fix(bin-designer): show the attribution footer in the scroll view

### DIFF
--- a/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/BinScrollPanel/BinScrollPanel.tsx
@@ -52,8 +52,10 @@ export interface BinScrollPanelProps {
   readonly searchBar?: ReactNode;
   /** Scrolls at the top of the list: community card + variant section. */
   readonly header?: ReactNode;
-  /** Wraps the editable groups (VariantLock); searchBar/header/dock stay outside. */
+  /** Wraps the editable groups (VariantLock); searchBar/header/footer/dock stay outside. */
   readonly wrapContent?: (node: ReactNode) => ReactNode;
+  /** Last thing in the scroll, below the groups: the attribution footer. */
+  readonly footer?: ReactNode;
   /** Pinned below the scroll: the user dock. */
   readonly dock?: ReactNode;
 }
@@ -63,6 +65,7 @@ export function BinScrollPanel({
   searchBar,
   header,
   wrapContent,
+  footer,
   dock,
 }: BinScrollPanelProps) {
   const t = useTranslation();
@@ -256,6 +259,7 @@ export function BinScrollPanel({
       <div className="relative min-h-0 flex-1 overflow-y-auto scrollbar-thin">
         {header}
         {wrapContent ? wrapContent(groups) : groups}
+        {footer}
       </div>
       {dock}
     </div>

--- a/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
+++ b/src/features/bin-designer/components/ParameterPanel/ParameterPanel.tsx
@@ -336,6 +336,7 @@ function BinParameterPanel({ frame }: { readonly frame: 'docked' | 'plain' }) {
         searchBar={topBar}
         header={communityAndVariant}
         wrapContent={(content) => wrapEditable(content, false)}
+        footer={<AttributionFooter />}
         dock={<UserDock />}
       />
     );


### PR DESCRIPTION
## What

The bin designer's default scroll view was the only mode sidebar missing the attribution footer (version line + supporters/privacy/terms links) that the Layout Sidebar and Baseplate panel both render at the bottom of their scroll. The designer's own rail view already had it as its `pageFooter`, so only the scroll layout was inconsistent.

This is pre-existing, the scroll panel never rendered it; it is not a regression from #4052.

## Change

- `BinScrollPanel`: added an optional `footer` slot, rendered at the end of the scroll region (below the groups, above the pinned user dock).
- `ParameterPanel`: pass `footer={<AttributionFooter />}` to the scroll view, matching the rail view and the other panels.

## Verification

- Ran the designer locally: the attribution footer now shows at the bottom of the scroll view, above the user dock, matching Baseplate/Layout.
- `pnpm run typecheck` clean, ESLint clean, 84 bin-designer panel tests pass.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

