### PR TITLE
fix(spacemouse): pan and zoom follow the puck the way CAD apps do

### DIFF
--- a/src/shared/spacemouse/mapping.test.ts
+++ b/src/shared/spacemouse/mapping.test.ts
@@ -37,37 +37,45 @@ describe('applyDeadzone', () => {
   });
 });
 
+/** Device translation axes: x+ right, y+ pulled back toward the user, z+ down. */
+const deflect = (translation: Partial<RawDeflection['translation']>): RawDeflection => ({
+  translation: { x: 0, y: 0, z: 0, ...translation },
+  rotation: { pitch: 0, roll: 0, yaw: 0 },
+});
+
 describe('toDeflection', () => {
   it('is idle for a centered puck', () => {
     expect(isDeflectionIdle(toDeflection(zeroRaw, DEFAULT_SETTINGS))).toBe(true);
   });
 
-  it('maps device axes to semantic axes with correct signs', () => {
-    const raw: RawDeflection = {
-      translation: { x: 350, y: -350, z: -350 },
-      rotation: { pitch: 350, roll: 0, yaw: 350 },
-    };
-    const d = toDeflection(raw, DEFAULT_SETTINGS);
-    expect(d.panX).toBeCloseTo(-1); // x+ pans left (puck follows the model)
-    expect(d.panY).toBeCloseTo(1); // -y (lift) pans screen up
-    expect(d.zoom).toBeCloseTo(1); // -z (push forward) zooms in
-    expect(d.orbitH).toBeCloseTo(1);
-    expect(d.orbitV).toBeCloseTo(1);
+  // Signs are stated as what the user sees, because pan moves the camera and so
+  // reads backwards from the deflection. Matches Fusion/PrusaSlicer (#4041).
+  it('slides the model right when the puck goes right', () => {
+    const d = toDeflection(deflect({ x: 350 }), DEFAULT_SETTINGS);
+    expect(d.panX).toBeCloseTo(-1); // camera left, so the model tracks right
+    expect(d.panY).toBe(0);
+    expect(d.zoom).toBe(0);
   });
 
-  it('drives pan from lift (y) and zoom from push (z), not the reverse (#4041)', () => {
-    const lift = toDeflection(
-      { translation: { x: 0, y: 350, z: 0 }, rotation: { pitch: 0, roll: 0, yaw: 0 } },
+  it('slides the model up when the puck is lifted, never zooms', () => {
+    const d = toDeflection(deflect({ z: -350 }), DEFAULT_SETTINGS);
+    expect(d.panY).toBeCloseTo(-1); // camera down, so the model tracks up
+    expect(d.zoom).toBe(0);
+  });
+
+  it('zooms in when the puck is pulled back, never pans', () => {
+    const d = toDeflection(deflect({ y: 350 }), DEFAULT_SETTINGS);
+    expect(d.zoom).toBeCloseTo(1); // positive dollies toward the target
+    expect(d.panY).toBe(0);
+  });
+
+  it('maps yaw and pitch to orbit unchanged', () => {
+    const d = toDeflection(
+      { translation: { x: 0, y: 0, z: 0 }, rotation: { pitch: 350, roll: 350, yaw: 350 } },
       DEFAULT_SETTINGS
     );
-    expect(Math.abs(lift.panY)).toBeCloseTo(1); // the lift axis drives vertical pan
-    expect(lift.zoom).toBeCloseTo(0); // ...never zoom
-    const push = toDeflection(
-      { translation: { x: 0, y: 0, z: 350 }, rotation: { pitch: 0, roll: 0, yaw: 0 } },
-      DEFAULT_SETTINGS
-    );
-    expect(Math.abs(push.zoom)).toBeCloseTo(1); // the push axis drives zoom
-    expect(push.panY).toBeCloseTo(0); // ...never pan
+    expect(d.orbitH).toBeCloseTo(1);
+    expect(d.orbitV).toBeCloseTo(1);
   });
 
   it('honors per-axis inversion', () => {
@@ -88,7 +96,7 @@ describe('toDeflection', () => {
 describe('computeFrameMotion', () => {
   const full = toDeflection(
     {
-      translation: { x: 350, y: -350, z: -350 },
+      translation: { x: 350, y: 350, z: -350 },
       rotation: { pitch: 350, roll: 0, yaw: 350 },
     },
     DEFAULT_SETTINGS
@@ -98,7 +106,7 @@ describe('computeFrameMotion', () => {
     const near = computeFrameMotion(full, DEFAULT_SETTINGS, 1 / 60, 10);
     const far = computeFrameMotion(full, DEFAULT_SETTINGS, 1 / 60, 100);
     expect(far.panX).toBeCloseTo(near.panX * 10);
-    expect(far.panX).toBeLessThan(0); // x+ now pans left (negative panX)
+    expect(far.panX).toBeLessThan(0); // camera left, so the model tracks the puck right
   });
 
   it('scales all motion by sensitivity', () => {

--- a/src/shared/spacemouse/mapping.ts
+++ b/src/shared/spacemouse/mapping.ts
@@ -35,19 +35,18 @@ function axis(raw: number, invert: boolean): number {
  * Map raw device axes to the five semantic navigation axes, applying the
  * deadzone and per-axis inversion.
  *
- * Axis roles corrected against a SpaceMouse Pro hardware test (#4041): left/right
- * translation followed the puck backwards, and the lift and push axes drove the
- * wrong pair (lift zoomed, push panned). So left/right is negated, and the up/down
- * (y) and forward/back (z) axes now drive pan and zoom respectively. Rotations
- * (orbit) already tested correct and are unchanged. Any residual per-axis sign a
- * given device disagrees on is the user's `invert.*` override.
+ * Device translation axes, per `@spacemouse-lib/core`: x+ is right, y+ is pulled
+ * back toward the user, z+ is pressed down. Navigation is object-centric like
+ * Fusion and PrusaSlicer, so the model tracks the puck; since `applyFrameMotion`
+ * translates the camera, every pan sign is the opposite of the puck's. Verified
+ * against a SpaceMouse Pro (#4041).
  */
 export function toDeflection(raw: RawDeflection, settings: SpaceMouseSettings): Deflection {
   const { invert } = settings;
   return {
-    panX: axis(-raw.translation.x, invert.panX), // puck left pans the view left
-    panY: axis(-raw.translation.y, invert.panY), // lift (up/down) pans vertically
-    zoom: axis(-raw.translation.z, invert.zoom), // push forward zooms in
+    panX: axis(-raw.translation.x, invert.panX), // puck right, model right
+    panY: axis(raw.translation.z, invert.panY), // puck lifted, model up
+    zoom: axis(raw.translation.y, invert.zoom), // puck pulled back, zoom in
     orbitH: axis(raw.rotation.yaw, invert.orbitH),
     orbitV: axis(raw.rotation.pitch, invert.orbitV),
   };


### PR DESCRIPTION
The SpaceMouse Pro follow-up on #4041 corrects the first report: pulling the puck back should zoom in, and lifting it should slide the model up. That is the axis pairing #4048 swapped away.

The roles (`y` drives zoom, `z` drives vertical pan) were right all along. Both signs were wrong, and two inverted signs read as a swapped pair, which is what the first report described.

## What changed

Axis meanings now come from `@spacemouse-lib/core`, which documents them inline, rather than being inferred: translation `x+` is right, `y+` is pulled back toward the user, `z+` is pressed down.

| Gesture | Raw axis | Result |
| --- | --- | --- |
| Puck right | `x+` | Model tracks right |
| Puck lifted | `z-` | Model slides up, whatever the model's orientation |
| Puck pulled back | `y+` | Zoom in |

`applyFrameMotion` translates the camera, so for object-centric motion each pan sign is the opposite of the puck's. Orbit is untouched: yaw and pitch tested correct on hardware, and roll stays unmapped because every preview locks its camera up-vector.

## Testing

`toDeflection` tests are now written as gestures with the on-screen result asserted, so the next hardware report can be checked line by line against them. Full spacemouse suite: 56 tests green.

Refs #4041

https://claude.ai/code/session_018Du4C1WJBMBiWTHUysL7AG

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

