### PR TITLE
fix(spacemouse): ignore a backgrounded window, stop driving covered canvases

### DIFF
--- a/.claude/skills/three-preview/SKILL.md
+++ b/.claude/skills/three-preview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: three-preview
-description: The 3D render systems (layout IsometricPreview vs worker-mesh bin-designer/baseplate previews), view store, camera, disposal/memory rules. Load when touching IsometricPreview.tsx, Scene.tsx, BinMesh.tsx, PreviewCanvas.tsx, useBinGeometry.ts, view.ts, or debugging z-fighting/flicker, GPU memory growth, a preview frozen until you orbit, wrong scene scale (42x off), theme-wrong scene colors, or bins replaying drop animations on every edit.
+description: The 3D render systems (layout IsometricPreview vs worker-mesh bin-designer/baseplate previews), view store, camera, SpaceMouse navigation, disposal/memory rules. Load when touching IsometricPreview.tsx, Scene.tsx, BinMesh.tsx, PreviewCanvas.tsx, useBinGeometry.ts, view.ts, src/shared/spacemouse/, or debugging z-fighting/flicker, GPU memory growth, a preview frozen until you orbit, wrong scene scale (42x off), theme-wrong scene colors, bins replaying drop animations on every edit, or a SpaceMouse moving the wrong canvas or the wrong way.
 ---
 
 # 3D Preview Systems
@@ -31,6 +31,8 @@ Facts you cannot derive from types:
 - **Every imperatively created BufferGeometry/Material must be disposed.** Patterns to copy: prev-ref + unmount cleanup in `MergedBinMeshes.tsx`; dispose-on-change in `src/shared/components/preview/useMeshGeometry.ts`; LRU eviction + `clearGeometryCache()` in `MergedBinMeshes/geometryCache.ts` (max 100, key `w|d|h|color` with `toFixed(2)`).
 - **Scene colors come from `THREE_COLORS`** in `src/shared/hooks/useThemeEffect.ts` via `useThreeColors()`. CSS variables do not exist inside WebGL. New colors go in BOTH dark and light palettes.
 - **Bin transition identity is `bin.id`** (`useBinTransitions.ts`, `useSyncExternalStore`). Regenerated IDs read as remove-all+add-all; the <20%-ID-overlap heuristic suppresses animation only on layout switches. Preserve bin IDs across edits.
+- **A SpaceMouse drives one canvas, not always the hovered one.** `spacemouse/spaceMouseBus.ts` fans one puck to the newest `claim: true` registration (a canvas in a modal), else the last hovered, else the first registered. `<SpaceMouseController />` reads `useThree(s => s.controls)`, so a `<Canvas>` whose `OrbitControls` omits `makeDefault` silently no-ops; pass `modal` inside a `Dialog.Root` or the covered canvas keeps moving unseen. Input is gated on `document.hasFocus()` (WebHID delivers to backgrounded windows), and `applyFrameMotion` honours the host's `enablePan`/`enableZoom`/`enableRotate`.
+- **Puck axis signs invert twice** (`spacemouse/mapping.ts`): device translation is x+ right, y+ pulled back, z+ down, and pan moves the _camera_, so an object-centric sign is the opposite of the puck's. Read the gesture tests before "correcting" one — #4048 swapped the axis roles when only the signs were wrong.
 - **OrbitControls azimuth syncs to the view store only on interaction end** (`Scene.tsx` `handleEnd` → `setIsometricRotation`, degrees normalized 0–360). Mid-drag readers see a stale value by design. `snapToIsometric()` in `view.ts` is store-only — no UI caller today.
 
 ## Recipes

--- a/src/features/bin-designer/components/ImportBinDialog/ImportBinDialog.tsx
+++ b/src/features/bin-designer/components/ImportBinDialog/ImportBinDialog.tsx
@@ -17,6 +17,7 @@ import * as THREE from 'three';
 // Side-effect: must run before any <Text> mounts under this Canvas.
 import '@/shared/webgl/configureTroikaText';
 import { Button, Dialog, Stepper } from '@/design-system';
+import { SpaceMouseController } from '@/shared/spacemouse/components/SpaceMouseController';
 import { useTranslation } from '@/i18n';
 import type { MeshImportRotation } from '@/shared/generation/meshAsset';
 import { OFF_GRID_WARNING_MM } from '@/features/bin-designer/utils/meshGridDetection';
@@ -104,6 +105,7 @@ export function ImportBinDialog({
               <directionalLight position={[-2, -1, 1]} intensity={0.4} />
               <BinPreviewMesh pending={pending} />
               <OrbitControls makeDefault enablePan={false} />
+              <SpaceMouseController modal />
             </Canvas>
             {importing && (
               <div className="absolute inset-0 flex items-center justify-center bg-surface/60 text-sm text-content-secondary">

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.tsx
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/StlImportDialog.tsx
@@ -16,6 +16,7 @@ import * as THREE from 'three';
 // Side-effect: must run before any <Text> mounts under this Canvas.
 import '@/shared/webgl/configureTroikaText';
 import { Dialog, Button, Stepper } from '@/design-system';
+import { SpaceMouseController } from '@/shared/spacemouse/components/SpaceMouseController';
 import { useTranslation } from '@/i18n';
 import type { MeshImportRotation } from '@/shared/generation/meshAsset';
 import type { PendingStlImport } from './useStlImport';
@@ -82,6 +83,7 @@ export function StlImportDialog({
               <directionalLight position={[-2, -1, 1]} intensity={0.4} />
               <ToolMesh pending={pending} />
               <OrbitControls makeDefault enablePan={false} />
+              <SpaceMouseController modal />
             </Canvas>
             {importing && (
               <div className="absolute inset-0 flex items-center justify-center bg-surface/60 text-sm text-content-secondary">

--- a/src/features/bin-designer/components/panel/LabelTabsSection/LabelPlatesControls.tsx
+++ b/src/features/bin-designer/components/panel/LabelTabsSection/LabelPlatesControls.tsx
@@ -13,6 +13,7 @@ import { OrbitControls } from '@react-three/drei';
 import '@/shared/webgl/configureTroikaText';
 import { Badge, Button, Dialog } from '@/design-system';
 import { ExportDialog } from '@/shared/components/ExportDialog';
+import { SpaceMouseController } from '@/shared/spacemouse/components/SpaceMouseController';
 import { useToastStore } from '@/core/store/toast';
 import { useTranslation } from '@/i18n';
 import { parseSTLBinary } from '@/shared/generation/stlParser';
@@ -185,7 +186,8 @@ export function LabelPlatesControls() {
                 <ambientLight intensity={0.7} />
                 <directionalLight position={[40, -40, 80]} intensity={1.2} />
                 <PlatesMesh mesh={previewMesh} />
-                <OrbitControls enablePan={false} />
+                <OrbitControls makeDefault enablePan={false} />
+                <SpaceMouseController modal />
               </Canvas>
             )}
           </div>

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -28,6 +28,7 @@ graph TB
 | `fonts/`         | The bundled OFL type faces and their licences, plus the family-to-URL map both the worker and the designer load from                                                                                                                                 |
 | `constants/`     | Re-exports `DEFAULT_BIN_PARAMS`, `GRIDFINITY` from `bin-designer`; owns label plate geometry (`labelPlates`), the label icon SVG catalog (`labelIconPaths`) and the outer-wall keep-out band (`wallBands`) so the worker and the UI share one source |
 | `generation/`    | Re-exports `GenerationBridge`, the direct-mesh drafts, and the brepjs-free pattern metrics (wall element sizes + `stampPatternOpenArea`, and the floor pattern's window rule) for cross-feature use                                                  |
+| `spacemouse/`    | 3Dconnexion puck support behind the `spacemouse` labs flag: WebHID device manager, the bus that fans one puck out to the active canvas, axis mapping and camera commands                                                                             |
 
 ## Key Components (`components/`)
 
@@ -102,3 +103,4 @@ behaviour and `InlineEditText` for the styled preset over it, both from
 4. **getDisplayLayers reverses** — UI display order is the reverse of array order; always use this for rendering
 5. **useAutoSave debounce** — 1000ms debounce + 2000ms idle callback; saves skip if no changes detected
 6. **MutationsContext fallback** — `useMutations()` returns store mutations directly when no provider is present (safe default)
+7. **SpaceMouse needs `makeDefault`** — `<SpaceMouseController />` reads `useThree(s => s.controls)`, so a `<Canvas>` whose `OrbitControls` omits `makeDefault` silently no-ops; pass `modal` inside a `Dialog.Root` (see the three-preview skill)

--- a/src/shared/spacemouse/cameraCommands.test.ts
+++ b/src/shared/spacemouse/cameraCommands.test.ts
@@ -88,6 +88,28 @@ describe('applyFrameMotion', () => {
     applyFrameMotion(camera, controls, noMotion);
     expect(camera.position.toArray()).toEqual([1, 2, 3]);
   });
+
+  it('skips the families the host canvas disables', () => {
+    const camera = new PerspectiveCamera();
+    camera.position.set(0, 0, 10);
+    camera.up.set(0, 1, 0);
+    const controls: OrbitLike = {
+      ...orbit(),
+      enablePan: false,
+      enableZoom: false,
+      enableRotate: false,
+    };
+    applyFrameMotion(camera, controls, { panX: 2, panY: -1, zoom: 0.5, orbitH: 1, orbitV: 0.5 });
+    expect(camera.position.toArray()).toEqual([0, 0, 10]);
+    expect(controls.target.toArray()).toEqual([0, 0, 0]);
+  });
+
+  it('treats an unset enable flag as enabled', () => {
+    const camera = new PerspectiveCamera();
+    camera.position.set(0, 0, 10);
+    applyFrameMotion(camera, orbit(), { ...noMotion, panX: 2 });
+    expect(camera.position.x).toBeCloseTo(2);
+  });
 });
 
 describe('computeContentBox', () => {

--- a/src/shared/spacemouse/cameraCommands.ts
+++ b/src/shared/spacemouse/cameraCommands.ts
@@ -9,11 +9,18 @@ import {
 import { MIN_POLAR } from './constants';
 import type { CameraViewPreset, FrameMotion } from './types';
 
-/** OrbitControls surface the controller needs. */
+/**
+ * OrbitControls surface the controller needs. The `enable*` flags are the host
+ * canvas's own limits: a preview that turns off mouse panning means it, so the
+ * puck honours them too. Absent means enabled, matching OrbitControls' defaults.
+ */
 export interface OrbitLike {
   target: Vector3;
   update: () => void;
   autoRotate?: boolean;
+  enablePan?: boolean;
+  enableZoom?: boolean;
+  enableRotate?: boolean;
 }
 
 const FIT_PADDING = 1.25;
@@ -120,7 +127,7 @@ export function frameBox(
 export function applyFrameMotion(camera: Camera, controls: OrbitLike, motion: FrameMotion): void {
   const target = controls.target;
 
-  if (motion.panX !== 0 || motion.panY !== 0) {
+  if (controls.enablePan !== false && (motion.panX !== 0 || motion.panY !== 0)) {
     const right = new Vector3().setFromMatrixColumn(camera.matrix, 0);
     const up = new Vector3().setFromMatrixColumn(camera.matrix, 1);
     const pan = right.multiplyScalar(motion.panX).add(up.multiplyScalar(motion.panY));
@@ -128,7 +135,7 @@ export function applyFrameMotion(camera: Camera, controls: OrbitLike, motion: Fr
     target.add(pan);
   }
 
-  if (motion.orbitH !== 0 || motion.orbitV !== 0) {
+  if (controls.enableRotate !== false && (motion.orbitH !== 0 || motion.orbitV !== 0)) {
     const up = camera.up.clone().normalize();
     const offset = camera.position.clone().sub(target);
     if (motion.orbitH !== 0) offset.applyAxisAngle(up, motion.orbitH);
@@ -144,7 +151,7 @@ export function applyFrameMotion(camera: Camera, controls: OrbitLike, motion: Fr
     camera.position.copy(target).add(offset);
   }
 
-  if (motion.zoom !== 0) {
+  if (controls.enableZoom !== false && motion.zoom !== 0) {
     if (camera instanceof OrthographicCamera) {
       camera.zoom = Math.max(1e-4, camera.zoom * Math.exp(motion.zoom));
       camera.updateProjectionMatrix();

--- a/src/shared/spacemouse/components/SpaceMouseController/SpaceMouseController.test.tsx
+++ b/src/shared/spacemouse/components/SpaceMouseController/SpaceMouseController.test.tsx
@@ -87,4 +87,29 @@ describe('SpaceMouseController', () => {
     h.frameCb?.({}, 1 / 60);
     expect(camera.position.equals(before)).toBe(true);
   });
+
+  it('takes the puck off the covered canvas when mounted as a modal', () => {
+    const covered = { id: 'covered', runCommand: vi.fn(), invalidate: vi.fn() };
+    spaceMouseBus.register(covered);
+    const { unmount } = render(<SpaceMouseController modal />);
+    const camera = h.state.camera as PerspectiveCamera;
+    const before = camera.position.clone();
+    spaceMouseBus.setTranslation({ x: 350, y: 0, z: 0 });
+    h.frameCb?.({}, 1 / 60);
+    expect(camera.position.x).not.toBeCloseTo(before.x);
+    expect(covered.invalidate).not.toHaveBeenCalled();
+    unmount();
+    expect(spaceMouseBus.isActive('covered')).toBe(true);
+  });
+
+  it('leaves motion the host controls disable alone', () => {
+    const controls = h.state.controls as { enablePan?: boolean };
+    controls.enablePan = false;
+    render(<SpaceMouseController />);
+    const camera = h.state.camera as PerspectiveCamera;
+    const before = camera.position.clone();
+    spaceMouseBus.setTranslation({ x: 350, y: 0, z: 0 }); // pan only
+    h.frameCb?.({}, 1 / 60);
+    expect(camera.position.equals(before)).toBe(true);
+  });
 });

--- a/src/shared/spacemouse/components/SpaceMouseController/SpaceMouseController.tsx
+++ b/src/shared/spacemouse/components/SpaceMouseController/SpaceMouseController.tsx
@@ -34,12 +34,22 @@ function directionForCommand(command: SpaceMouseCommand, up: Vector3): Vector3 |
   }
 }
 
+interface SpaceMouseControllerProps {
+  /**
+   * Marks a canvas that lives inside a modal. It holds the puck for as long as
+   * it is mounted, so the canvas it covers stops moving unseen behind it rather
+   * than waiting for this one to be hovered.
+   */
+  modal?: boolean;
+}
+
 /**
  * Drives its host canvas's camera from the shared SpaceMouse bus. Mount one
  * inside every OrbitControls-backed `<Canvas>`; it no-ops where there are no
- * controls (e.g. the 2D cutout editor). Renders nothing.
+ * controls (e.g. the 2D cutout editor), which includes controls that skipped
+ * `makeDefault`. Renders nothing.
  */
-export function SpaceMouseController(): null {
+export function SpaceMouseController({ modal = false }: SpaceMouseControllerProps): null {
   const enabled = useFeatureFlag(SPACEMOUSE_FEATURE_ID);
   const controls = useThree((s) => s.controls) as OrbitLike | null;
   const camera = useThree((s) => s.camera);
@@ -74,15 +84,16 @@ export function SpaceMouseController(): null {
       id,
       runCommand,
       invalidate: () => stateRef.current.invalidate(),
+      claim: modal,
     });
     const dom = gl.domElement;
-    const claim = (): void => spaceMouseBus.setActive(id);
-    dom.addEventListener('pointerenter', claim);
+    const claimOnHover = (): void => spaceMouseBus.setActive(id);
+    dom.addEventListener('pointerenter', claimOnHover);
     return () => {
-      dom.removeEventListener('pointerenter', claim);
+      dom.removeEventListener('pointerenter', claimOnHover);
       unregister();
     };
-  }, [enabled, id, gl]);
+  }, [enabled, id, gl, modal]);
 
   useFrame((_, dt) => {
     const st = stateRef.current;

--- a/src/shared/spacemouse/deviceManager.test.ts
+++ b/src/shared/spacemouse/deviceManager.test.ts
@@ -41,11 +41,14 @@ afterEach(() => {
 });
 
 describe('deviceManager focus tracking', () => {
-  it('drops puck input once the window is backgrounded (#4041)', () => {
+  it('drops puck input for a visible window that is not frontmost (#4041)', () => {
     registerCanvas();
     startSpaceMouse();
     hasFocus.mockReturnValue(false);
     window.dispatchEvent(new Event('blur'));
+    // The reported case: the window is on screen, another CAD app just has the
+    // keyboard. Gating on visibilityState instead would let the puck through.
+    expect(document.visibilityState).toBe('visible');
     spaceMouseBus.setTranslation(FULL_DEFLECTION);
     expect(spaceMouseBus.getRaw().translation).toEqual({ x: 0, y: 0, z: 0 });
   });

--- a/src/shared/spacemouse/deviceManager.test.ts
+++ b/src/shared/spacemouse/deviceManager.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { spaceMouseBus } from './spaceMouseBus';
+
+vi.mock('spacemouse-webhid', () => ({
+  PRODUCTS: {},
+  getOpenedSpaceMice: vi.fn(async () => []),
+  requestSpaceMice: vi.fn(async () => []),
+  setupSpaceMouse: vi.fn(),
+}));
+
+vi.mock('./commands', () => ({ runGlobalCommand: vi.fn() }));
+
+import { startSpaceMouse, stopSpaceMouse } from './deviceManager';
+
+const FULL_DEFLECTION = { x: 350, y: 0, z: 0 };
+
+function registerCanvas() {
+  spaceMouseBus.register({ id: 'canvas', runCommand: vi.fn(), invalidate: vi.fn() });
+}
+
+let hasFocus: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'hid', {
+    configurable: true,
+    value: {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      getDevices: vi.fn(async () => []),
+      requestDevice: vi.fn(async () => []),
+    },
+  });
+  spaceMouseBus._resetForTests();
+  hasFocus = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+});
+
+afterEach(() => {
+  stopSpaceMouse();
+  vi.restoreAllMocks();
+});
+
+describe('deviceManager focus tracking', () => {
+  it('drops puck input once the window is backgrounded (#4041)', () => {
+    registerCanvas();
+    startSpaceMouse();
+    hasFocus.mockReturnValue(false);
+    window.dispatchEvent(new Event('blur'));
+    spaceMouseBus.setTranslation(FULL_DEFLECTION);
+    expect(spaceMouseBus.getRaw().translation).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('also tracks tab switches, which fire visibilitychange rather than blur', () => {
+    registerCanvas();
+    startSpaceMouse();
+    hasFocus.mockReturnValue(false);
+    document.dispatchEvent(new Event('visibilitychange'));
+    spaceMouseBus.setTranslation(FULL_DEFLECTION);
+    expect(spaceMouseBus.getRaw().translation).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('takes input again when the window comes back', () => {
+    registerCanvas();
+    startSpaceMouse();
+    hasFocus.mockReturnValue(false);
+    window.dispatchEvent(new Event('blur'));
+    hasFocus.mockReturnValue(true);
+    window.dispatchEvent(new Event('focus'));
+    spaceMouseBus.setTranslation(FULL_DEFLECTION);
+    expect(spaceMouseBus.getRaw().translation).toEqual(FULL_DEFLECTION);
+  });
+
+  it('starts gated when the app loads in the background', () => {
+    registerCanvas();
+    hasFocus.mockReturnValue(false);
+    startSpaceMouse();
+    spaceMouseBus.setTranslation(FULL_DEFLECTION);
+    expect(spaceMouseBus.getRaw().translation).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('unsubscribes on stop, leaving the bus ungated', () => {
+    registerCanvas();
+    startSpaceMouse();
+    stopSpaceMouse();
+    hasFocus.mockReturnValue(false);
+    window.dispatchEvent(new Event('blur'));
+    spaceMouseBus.setTranslation(FULL_DEFLECTION);
+    expect(spaceMouseBus.getRaw().translation).toEqual(FULL_DEFLECTION);
+  });
+});

--- a/src/shared/spacemouse/deviceManager.ts
+++ b/src/shared/spacemouse/deviceManager.ts
@@ -98,6 +98,10 @@ function onHidDisconnect(): void {
   if (device) handleDeviceLost();
 }
 
+function syncFocus(): void {
+  spaceMouseBus.setFocused(document.hasFocus());
+}
+
 export function startSpaceMouse(): void {
   if (started) return;
   started = true;
@@ -112,6 +116,12 @@ export function startSpaceMouse(): void {
   }
   navigator.hid.addEventListener('connect', onHidConnect);
   navigator.hid.addEventListener('disconnect', onHidDisconnect);
+  // Both events are needed: switching windows fires focus/blur, switching tabs
+  // within the same window only fires visibilitychange.
+  window.addEventListener('focus', syncFocus);
+  window.addEventListener('blur', syncFocus);
+  document.addEventListener('visibilitychange', syncFocus);
+  syncFocus();
   void tryAutoConnect();
 }
 
@@ -121,7 +131,11 @@ export function stopSpaceMouse(): void {
   if (isWebHidSupported()) {
     navigator.hid.removeEventListener('connect', onHidConnect);
     navigator.hid.removeEventListener('disconnect', onHidDisconnect);
+    window.removeEventListener('focus', syncFocus);
+    window.removeEventListener('blur', syncFocus);
+    document.removeEventListener('visibilitychange', syncFocus);
   }
+  spaceMouseBus.setFocused(true);
   detachCurrent();
   spaceMouseBus.setGlobalHandler(null);
   spaceMouseBus.resetDeflection();

--- a/src/shared/spacemouse/deviceManager.ts
+++ b/src/shared/spacemouse/deviceManager.ts
@@ -98,6 +98,11 @@ function onHidDisconnect(): void {
   if (device) handleDeviceLost();
 }
 
+/**
+ * `hasFocus()` is the gate rather than `visibilityState`: the case reported in
+ * #4041 is a window that is fully visible but not frontmost, which still counts
+ * as `visible`. The listeners below are only triggers to re-read it.
+ */
 function syncFocus(): void {
   spaceMouseBus.setFocused(document.hasFocus());
 }
@@ -116,8 +121,6 @@ export function startSpaceMouse(): void {
   }
   navigator.hid.addEventListener('connect', onHidConnect);
   navigator.hid.addEventListener('disconnect', onHidDisconnect);
-  // Both events are needed: switching windows fires focus/blur, switching tabs
-  // within the same window only fires visibilitychange.
   window.addEventListener('focus', syncFocus);
   window.addEventListener('blur', syncFocus);
   document.addEventListener('visibilitychange', syncFocus);

--- a/src/shared/spacemouse/spaceMouseBus.test.ts
+++ b/src/shared/spacemouse/spaceMouseBus.test.ts
@@ -42,6 +42,79 @@ describe('spaceMouseBus registration', () => {
   });
 });
 
+describe('spaceMouseBus modal claims', () => {
+  it('hands the puck to a modal canvas the moment it mounts', () => {
+    spaceMouseBus.register(makeController('page'));
+    const unregisterModal = spaceMouseBus.register({ ...makeController('modal'), claim: true });
+    expect(spaceMouseBus.isActive('modal')).toBe(true);
+    expect(spaceMouseBus.isActive('page')).toBe(false);
+    unregisterModal();
+    expect(spaceMouseBus.isActive('page')).toBe(true);
+  });
+
+  it('outranks a hover claim, since the modal covers what was hovered', () => {
+    spaceMouseBus.register(makeController('page'));
+    spaceMouseBus.register({ ...makeController('modal'), claim: true });
+    spaceMouseBus.setActive('page');
+    expect(spaceMouseBus.isActive('modal')).toBe(true);
+  });
+
+  it('falls back to the outer modal when a nested one closes', () => {
+    spaceMouseBus.register(makeController('page'));
+    spaceMouseBus.register({ ...makeController('outer'), claim: true });
+    const unregisterInner = spaceMouseBus.register({ ...makeController('inner'), claim: true });
+    expect(spaceMouseBus.isActive('inner')).toBe(true);
+    unregisterInner();
+    expect(spaceMouseBus.isActive('outer')).toBe(true);
+  });
+
+  it('routes motion and commands to the modal canvas', () => {
+    const page = makeController('page');
+    const modal = makeController('modal');
+    spaceMouseBus.register(page);
+    spaceMouseBus.register({ ...modal, claim: true });
+    spaceMouseBus.setTranslation({ x: 10, y: 0, z: 0 });
+    spaceMouseBus.pressButton(0); // fit
+    expect(modal.invalidate).toHaveBeenCalled();
+    expect(modal.runCommand).toHaveBeenCalledWith('fit');
+    expect(page.invalidate).not.toHaveBeenCalled();
+    expect(page.runCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe('spaceMouseBus focus gating', () => {
+  it('ignores motion and buttons while the app is not frontmost (#4041)', () => {
+    const a = makeController('a');
+    spaceMouseBus.register(a);
+    const handler = vi.fn();
+    spaceMouseBus.setGlobalHandler(handler);
+    spaceMouseBus.setFocused(false);
+    spaceMouseBus.setTranslation({ x: 350, y: 0, z: 0 });
+    spaceMouseBus.setRotation({ pitch: 350, roll: 0, yaw: 0 });
+    spaceMouseBus.pressButton(0); // fit
+    spaceMouseBus.pressButton(6); // undo
+    expect(spaceMouseBus.getRaw().translation).toEqual({ x: 0, y: 0, z: 0 });
+    expect(spaceMouseBus.getRaw().rotation).toEqual({ pitch: 0, roll: 0, yaw: 0 });
+    expect(a.runCommand).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('drops the deflection it was holding when focus is lost', () => {
+    spaceMouseBus.register(makeController('a'));
+    spaceMouseBus.setTranslation({ x: 350, y: 0, z: 0 });
+    spaceMouseBus.setFocused(false);
+    expect(spaceMouseBus.getRaw().translation).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it('accepts input again once focus returns', () => {
+    spaceMouseBus.register(makeController('a'));
+    spaceMouseBus.setFocused(false);
+    spaceMouseBus.setFocused(true);
+    spaceMouseBus.setTranslation({ x: 350, y: 0, z: 0 });
+    expect(spaceMouseBus.getRaw().translation).toEqual({ x: 350, y: 0, z: 0 });
+  });
+});
+
 describe('spaceMouseBus motion', () => {
   it('stores the latest raw deflection and wakes the active canvas', () => {
     const a = makeController('a');

--- a/src/shared/spacemouse/spaceMouseBus.ts
+++ b/src/shared/spacemouse/spaceMouseBus.ts
@@ -8,6 +8,12 @@ export interface SpaceMouseController {
   runCommand: (command: SpaceMouseCommand) => void;
   /** Wake this canvas so a demand-frameloop renders. */
   invalidate: () => void;
+  /**
+   * Hold the puck for as long as this canvas is mounted instead of waiting to be
+   * hovered. Set by canvases inside a modal, which cover the canvas that would
+   * otherwise keep moving unseen behind the overlay.
+   */
+  claim?: boolean;
 }
 
 const zeroTranslation = (): RawTranslation => ({ x: 0, y: 0, z: 0 });
@@ -23,7 +29,9 @@ class SpaceMouseBus {
   private translation = zeroTranslation();
   private rotation = zeroRotation();
   private readonly controllers = new Map<string, SpaceMouseController>();
-  private activeId: string | null = null;
+  private hoveredId: string | null = null;
+  private readonly claims: string[] = [];
+  private focused = true;
   private globalHandler: ((command: SpaceMouseCommand) => void) | null = null;
 
   setGlobalHandler(handler: ((command: SpaceMouseCommand) => void) | null): void {
@@ -32,31 +40,61 @@ class SpaceMouseBus {
 
   register(controller: SpaceMouseController): () => void {
     this.controllers.set(controller.id, controller);
-    if (this.activeId === null) this.activeId = controller.id;
+    if (controller.claim) this.claims.push(controller.id);
+    else if (this.hoveredId === null) this.hoveredId = controller.id;
     return () => this.unregister(controller.id);
   }
 
   private unregister(id: string): void {
     this.controllers.delete(id);
-    if (this.activeId === id) {
-      this.activeId = this.controllers.keys().next().value ?? null;
+    const claim = this.claims.lastIndexOf(id);
+    if (claim !== -1) this.claims.splice(claim, 1);
+    if (this.hoveredId === id) this.hoveredId = null;
+  }
+
+  /**
+   * Who the puck drives: the newest mounted modal claim, else the last canvas
+   * hovered, else whichever registered first.
+   */
+  private active(): SpaceMouseController | null {
+    for (let i = this.claims.length - 1; i >= 0; i--) {
+      const claimed = this.controllers.get(this.claims[i]);
+      if (claimed) return claimed;
     }
+    const hovered = this.hoveredId ? this.controllers.get(this.hoveredId) : undefined;
+    return hovered ?? this.controllers.values().next().value ?? null;
   }
 
   setActive(id: string): void {
-    if (this.controllers.has(id)) this.activeId = id;
+    if (this.controllers.has(id)) this.hoveredId = id;
   }
 
   isActive(id: string): boolean {
-    return this.activeId === id;
+    return this.active()?.id === id;
+  }
+
+  /**
+   * Gate input on the app actually being frontmost. WebHID keeps delivering while
+   * the window is backgrounded, so without this a puck driving another CAD app
+   * silently drives whatever canvas is mounted here too (#4041).
+   */
+  setFocused(focused: boolean): void {
+    if (this.focused === focused) return;
+    this.focused = focused;
+    // Forget the deflection we last saw. A puck at rest reports nothing (the
+    // device only emits on change), so a stale one would otherwise sit there and
+    // replay the moment focus returns.
+    if (!focused) this.resetDeflection();
   }
 
   setTranslation(translation: RawTranslation): void {
+    if (!this.focused) return;
     this.translation = translation;
     this.wake();
   }
 
   setRotation(rotation: RawRotation): void {
+    if (!this.focused) return;
     this.rotation = rotation;
     this.wake();
   }
@@ -73,6 +111,7 @@ class SpaceMouseBus {
   }
 
   pressButton(buttonIndex: number): void {
+    if (!this.focused) return;
     const command = resolveButtonCommand(buttonIndex);
     if (command) this.dispatch(command);
   }
@@ -82,19 +121,19 @@ class SpaceMouseBus {
       this.globalHandler?.(command);
       return;
     }
-    const active = this.activeId ? this.controllers.get(this.activeId) : null;
-    active?.runCommand(command);
+    this.active()?.runCommand(command);
   }
 
   private wake(): void {
-    const active = this.activeId ? this.controllers.get(this.activeId) : null;
-    active?.invalidate();
+    this.active()?.invalidate();
   }
 
   /** Test-only: clear all registrations and state. */
   _resetForTests(): void {
     this.controllers.clear();
-    this.activeId = null;
+    this.claims.length = 0;
+    this.hoveredId = null;
+    this.focused = true;
     this.globalHandler = null;
     this.translation = zeroTranslation();
     this.rotation = zeroRotation();


### PR DESCRIPTION
Two integration gaps left over from the SpaceMouse Pro hardware test in #4041, both of which move a camera the user cannot see.

## The puck drove the app while the window was in the background

Reported in #4041. WebHID keeps delivering while the window is backgrounded, so a puck driving Fusion or PrusaSlicer silently drove whatever canvas this app had mounted too.

Input is now gated on `document.hasFocus()`, tracked through `focus`, `blur` and `visibilitychange` (switching windows fires the first two, switching tabs within a window only fires the third). Losing focus also drops the deflection the bus was holding: the device only emits on change, so a puck left deflected reports nothing at rest and a stale value would replay the moment focus returned.

## The puck drove the canvas behind an open dialog

Three `OrbitControls` canvases had no `SpaceMouseController` at all, all of them inside a `Dialog.Root`: the bin import preview, the STL import preview and the label plate preview. With no controller to register, the bus kept routing to the canvas underneath the overlay.

Mounting the controller is only half of it, because activation was "first canvas registered, until a `pointerenter` claims it" — you would still have had to hover the dialog before the background stopped moving. A canvas can now register as `modal`, which holds the puck for as long as it is mounted and hands it back on unmount. Nested modals stack, and the outer one takes it back when the inner closes.

`LabelPlatesControls` also needed `makeDefault` on its `OrbitControls`. Without it `useThree(s => s.controls)` is null and the controller mounts but silently does nothing, which is worth knowing about before adding a fourth.

## The puck now obeys the host canvas's limits

All three of those previews set `enablePan={false}`, and they frame a `<Center>`ed object in a small viewport, so a puck pan would have walked the model out of frame. `applyFrameMotion` now honours `enablePan` / `enableZoom` / `enableRotate` from the host controls, absent meaning enabled to match OrbitControls' own defaults. This also stops the puck panning `GlbViewer`, which has had `enablePan={false}` and a controller since #4018.

## Docs

`src/shared/spacemouse/` was missing from the `src/shared/README.md` subdirectory table entirely. The subsystem invariants went into the `three-preview` skill instead of the README, per CLAUDE.md, and its description now mentions SpaceMouse so it loads on those tasks. Both files stay inside the doc-drift ratchet without raising a budget.

## Testing

72 tests in `src/shared/spacemouse` (up from 56), including a new `deviceManager.test.ts` covering the focus wiring itself rather than just the bus-level gate. Full unit + dom suite green: 22,870 tests.

Still Labs-only (`status: 'experimental'`) until the axis signs from #4055 are confirmed on hardware.

Refs #4041

https://claude.ai/code/session_018Du4C1WJBMBiWTHUysL7AG

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

