### PR TITLE
fix(bin-designer): force the draft after a slow exact build

### DIFF
--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/shared/generation/bridge', () => ({
   getActiveKernel: () => mockActiveKernel,
   FAST_EXACT_SKIP_MS: 1000,
   EXACT_IMMEDIATE_MAX_MS: 600,
+  FORCE_DRAFT_AFTER_EXACT_MS: 1000,
   // Stable threshold — burst behavior is covered by draftPolicy's own tests.
   createDraftSkipGate: () => () => ({ skipBelowMs: 1000, scrubbing: false }),
 }));
@@ -496,6 +497,57 @@ describe('useGeneration', () => {
 
     expect(mockBridge.generate).toHaveBeenCalled();
     expect(mockBridge.generateImmediate).not.toHaveBeenCalled();
+  });
+
+  it('forces the draft after a slow exact even when the next estimate predicts fast', async () => {
+    const draftVerts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const exactVerts = new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0]);
+    const meshOf = (vertices: Float32Array, timingMs = 1) => ({
+      mesh: {
+        vertices,
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        indices: new Uint32Array([0, 1, 2]),
+        edgeVertices: new Float32Array(0),
+        triangleCount: 1,
+      },
+      timingMs,
+    });
+
+    const previewGenerate = vi.fn().mockResolvedValue(meshOf(draftVerts));
+    const previewBridge = {
+      isDestroyed: false,
+      generateImmediate: previewGenerate,
+      destroy: vi.fn(),
+    } as unknown as GenerationBridge;
+    mockAcquirePreview.mockResolvedValue(previewBridge);
+
+    // The initial exact is slow (>= FORCE_DRAFT_AFTER_EXACT_MS), marking the
+    // design as slow. The preview bridge is only acquired after that first
+    // generation, so the initial render is exact-only.
+    (mockBridge.generate as ReturnType<typeof vi.fn>).mockResolvedValue(meshOf(exactVerts, 5000));
+
+    renderHook(() => useGeneration());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(useDesignerStore.getState().generation.isDraft).toBe(false);
+
+    // The next estimate predicts a fast build, which alone would skip the draft.
+    (mockBridge.estimateGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(200);
+    previewGenerate.mockClear();
+
+    // Enable a scoop so the bin is not direct-mesh-eligible: that forces the
+    // async Manifold draft path rather than the synchronous direct mesh.
+    await act(async () => {
+      useDesignerStore.setState((s) => ({
+        params: { ...s.params, scoop: { ...s.params.scoop, enabled: true } },
+        generation: { ...s.generation, epoch: 1 },
+      }));
+      await vi.advanceTimersByTimeAsync(201);
+    });
+
+    // The slow last exact forced the draft despite the fast estimate.
+    expect(previewGenerate).toHaveBeenCalled();
   });
 
   it('persists the exact preview mesh after generation completes', async () => {

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -8,6 +8,7 @@ import {
   createDraftSkipGate,
   getActiveKernel,
   EXACT_IMMEDIATE_MAX_MS,
+  FORCE_DRAFT_AFTER_EXACT_MS,
 } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
 import { generateBinDirect, canBinUseDirectMesh } from '@/shared/generation/directMesh';
@@ -142,6 +143,10 @@ export function useGeneration(): void {
   // suppresses the slower Manifold draft so a simple bin doesn't flash
   // direct → manifold → exact (two visible swaps).
   const directShownTokenRef = useRef(0);
+  // Duration of the most recent exact build. A slow last exact forces the draft
+  // on the next edit even if the estimate predicts fast, so a heavy design whose
+  // estimate under-predicts still gets interim feedback.
+  const lastExactMsRef = useRef(0);
   const draftSkipGate = useRef(createDraftSkipGate()).current;
   // After the exact result settles, idle-warm the export-quality (fused) shell
   // so the first export skips the deferred socket↔body fuse. Cancelled (timer
@@ -274,14 +279,18 @@ export function useGeneration(): void {
       // Skipped when the estimate predicts a build faster than the gate's
       // threshold (a draft replaced almost immediately is just flicker), and the
       // threshold drops during a scrub (see draftPolicy). Suppressed when the
-      // synchronous direct mesh already painted this edit.
+      // synchronous direct mesh already painted this edit. Forced regardless of
+      // the estimate once the last exact was slow: the estimate can under-predict
+      // a heavy design, and skipping the draft there strands a multi-second
+      // exact with no interim feedback.
+      const lastExactSlow = lastExactMsRef.current >= FORCE_DRAFT_AFTER_EXACT_MS;
       const preview = previewBridgeRef.current;
       if (
         preview &&
         !preview.isDestroyed &&
         directShownTokenRef.current !== token &&
         token > finalizedTokenRef.current &&
-        !(predictedMs !== null && predictedMs < skipBelowMs)
+        (lastExactSlow || !(predictedMs !== null && predictedMs < skipBelowMs))
       ) {
         dispatchDraft(preview, genParams, token);
       }
@@ -303,6 +312,7 @@ export function useGeneration(): void {
         // A newer edit superseded this one; let its results win instead.
         if (token !== genTokenRef.current) return;
         finalizedTokenRef.current = token;
+        lastExactMsRef.current = result.timingMs;
 
         if (result.perfSnapshot) pushPerfSnapshot(result.perfSnapshot);
 

--- a/src/features/generation/bridge/types.ts
+++ b/src/features/generation/bridge/types.ts
@@ -45,3 +45,13 @@ export const BURST_EXACT_SKIP_MS = 300;
  * charge (it coalesces scrubs and the Manifold draft masks its latency).
  */
 export const EXACT_IMMEDIATE_MAX_MS = 600;
+
+/**
+ * Once an exact generation has taken at least this long, force the Manifold
+ * draft on the next edits regardless of the cache-aware estimate. A heavy
+ * design's estimate can under-predict (it keys off cache state that a dimension
+ * edit invalidates), and a wrongly-skipped draft leaves a multi-second exact
+ * with no interim feedback at all. The last exact's own duration is the most
+ * reliable signal that this design is one where the draft earns its flicker.
+ */
+export const FORCE_DRAFT_AFTER_EXACT_MS = 1000;

--- a/src/shared/generation/bridge.ts
+++ b/src/shared/generation/bridge.ts
@@ -13,6 +13,7 @@ export {
   EDIT_BURST_WINDOW_MS,
   BURST_EXACT_SKIP_MS,
   EXACT_IMMEDIATE_MAX_MS,
+  FORCE_DRAFT_AFTER_EXACT_MS,
 } from '@/features/generation/bridge/types';
 export { createDraftSkipGate } from '@/features/generation/bridge/draftPolicy';
 export {


### PR DESCRIPTION
## Problem
The Manifold draft is skipped when the cache-aware estimate predicts a build faster than the draft-skip threshold. That estimate keys off cache state a dimension edit invalidates, so it can under-predict a heavy design, skip the draft, and leave a multi-second exact rendering with no interim feedback.

## Change
Track the duration of the last exact build (`lastExactMsRef`). Once it crosses `FORCE_DRAFT_AFTER_EXACT_MS` (1s), force the Manifold draft on the next edit regardless of the estimate.

## Why it is low-cost
A forced draft that a genuinely fast exact beats is dropped by the existing token arbitration (`finalizedTokenRef`), so when the net is not needed the cost is a discarded preview-worker build, not a visible flicker.

## Scope (honest)
On the profiled design matrix the estimate is already accurate: every design whose exact exceeds ~1s already showed a draft, and every design that skipped the draft had a genuinely fast (<1s) exact. So this changes nothing on the standard matrix (verified in-app: control/featurey/slotted/tallTaper draft counts unchanged). It is a defensive net for the case where `estimateBin` under-predicts a slow build. A follow-up could tighten `estimateBin` itself.

## Tests
`useGeneration.test.ts`: a slow initial exact now forces the draft on the next edit even when the estimate predicts fast (the draft would otherwise be skipped).

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

