### PR TITLE
perf(generation): let kumiko and divider bins resume the post-boolean body

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/resumeCacheCorrectness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/resumeCacheCorrectness.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+/**
+ * Resume-cache correctness for kumiko and divider pattern bins.
+ *
+ * `booleanStage` skips the whole boolean when a design's resume key is
+ * unchanged, so the key must (a) let an identical regen resume without changing
+ * geometry, and (b) never collide across designs whose cut set differs — a
+ * collision would serve a stale body, the one failure that surfaces as wrong
+ * geometry rather than a slow rebuild. This guards both for the kumiko and
+ * divider identity keys.
+ *
+ * Manual (real WASM, not a CI gate):
+ *   pnpm exec vitest run --config vitest.profile.config.ts resumeCacheCorrectness
+ */
+import { describe, it, beforeAll, expect } from 'vitest';
+import { initBrepjs, getGenerateBin } from './wasmInit';
+import { buildParams } from './scenarioTypes';
+import { clearAllCaches } from '../shapeCache';
+import type { BinParams } from '@/shared/types/bin';
+import type { MeshData } from '@/features/generation/bridge/types';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 120_000);
+
+/** Cheap but collision-resistant geometry fingerprint. */
+function fingerprint(m: MeshData): string {
+  const v = m.vertices;
+  let cs = 0;
+  for (let i = 0; i < v.length; i++) cs = (cs * 31 + Math.round(v[i] * 1000)) | 0;
+  return `${m.triangleCount}|${v.length}|${m.indices.length}|${cs}`;
+}
+
+interface Case {
+  name: string;
+  base: BinParams;
+  variants: { name: string; params: BinParams }[];
+}
+
+const CASES: Case[] = [
+  {
+    name: 'kumiko-mitsukude',
+    base: buildParams({
+      width: 2,
+      depth: 2,
+      height: 5,
+      wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
+    }),
+    variants: [
+      {
+        name: 'scale',
+        params: buildParams({
+          width: 2,
+          depth: 2,
+          height: 5,
+          wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.7 },
+        }),
+      },
+      {
+        name: 'height',
+        params: buildParams({
+          width: 2,
+          depth: 2,
+          height: 6,
+          wallPattern: { enabled: true, pattern: 'mitsukude', scale: 0.5 },
+        }),
+      },
+    ],
+  },
+  {
+    name: 'divider-honeycomb',
+    base: buildParams({
+      width: 3,
+      depth: 2,
+      height: 6,
+      compartments: { cols: 2, rows: 1, thickness: 1.2, cells: [0, 1] },
+      wallPattern: { enabled: true, pattern: 'honeycomb', dividers: true },
+    }),
+    variants: [
+      {
+        name: 'grid',
+        params: buildParams({
+          width: 3,
+          depth: 2,
+          height: 6,
+          compartments: { cols: 3, rows: 1, thickness: 1.2, cells: [0, 1, 2] },
+          wallPattern: { enabled: true, pattern: 'honeycomb', dividers: true },
+        }),
+      },
+      {
+        name: 'thickness',
+        params: buildParams({
+          width: 3,
+          depth: 2,
+          height: 6,
+          compartments: { cols: 2, rows: 1, thickness: 1.6, cells: [0, 1] },
+          wallPattern: { enabled: true, pattern: 'honeycomb', dividers: true },
+        }),
+      },
+    ],
+  },
+];
+
+describe('resume cache correctness (kumiko + dividers)', () => {
+  for (const c of CASES) {
+    it(
+      c.name,
+      () => {
+        const gen = getGenerateBin();
+
+        clearAllCaches();
+        const t0 = performance.now();
+        const cold = fingerprint(gen(c.base));
+        const coldMs = performance.now() - t0;
+
+        // Identical regen: the resume path must return the same geometry and
+        // must be much faster (proves it skipped the boolean, i.e. the key is
+        // non-null and hit).
+        const t1 = performance.now();
+        const warm = fingerprint(gen(c.base));
+        const warmMs = performance.now() - t1;
+        expect(warm).toBe(cold);
+        expect(warmMs).toBeLessThan(coldMs * 0.7);
+
+        for (const v of c.variants) {
+          clearAllCaches();
+          const coldVariant = fingerprint(gen(v.params));
+          // The variant is genuinely different geometry.
+          expect(coldVariant).not.toBe(cold);
+
+          // Warm the BASE body into the resume cache, then build the variant.
+          // A collision would resume the base and yield `cold`; a correct key
+          // rebuilds the variant's own geometry.
+          clearAllCaches();
+          gen(c.base);
+          const afterBase = fingerprint(gen(v.params));
+          expect(afterBase).toBe(coldVariant);
+        }
+      },
+      300_000
+    );
+  }
+});

--- a/src/features/generation/worker/generators/dividerPatternBuilder.ts
+++ b/src/features/generation/worker/generators/dividerPatternBuilder.ts
@@ -322,6 +322,13 @@ export interface PanelFactory {
     bandHeight: number,
     cutDepth: number
   ): Shape3D | null;
+  /**
+   * The cache key `build` would use for this spec, without building the panel.
+   * It fully identifies the local panel geometry (pattern variant, span,
+   * keep-outs, band, cut depth), so a caller can fold it into a resume key that
+   * lets the boolean stage skip the whole cut when nothing changed.
+   */
+  keyFor(spec: PatternPanelSpec, bandZ0: number, bandHeight: number, cutDepth: number): string;
 }
 
 /** Which pattern a factory should build. Defaults to the bin's wall pattern. */
@@ -366,29 +373,46 @@ export function resolvePanelFactory(
   // whose pieces share a height resolves one lattice for all of them.
   const latticeByBand = new Map<number, Parameters<typeof buildFlatSlabCutter>[1]>();
 
+  // Resolve (and memoize) the kumiko lattice for a band height; null for stamp
+  // patterns, which have no lattice.
+  const latticeFor = (bandHeight: number): Parameters<typeof buildFlatSlabCutter>[1] | null => {
+    if (!kumiko) return null;
+    const cached = latticeByBand.get(bandHeight);
+    if (cached) return cached;
+    const lattice = kumiko.getLattice({ perimeter: latticePerimeter ?? 0, bandHeight });
+    latticeByBand.set(bandHeight, lattice);
+    return lattice;
+  };
+
+  // The cache key for a panel, shared by `build` and `keyFor` so the two never
+  // drift.
+  const computeKey = (
+    spec: PatternPanelSpec,
+    bandZ0: number,
+    bandHeight: number,
+    cutDepth: number
+  ): string => {
+    const lattice = latticeFor(bandHeight);
+    const variantKey = stamp
+      ? shapeDescriptorKey(stamp.getShapeDescriptor({ fillW: 0, fillH: bandHeight }))
+      : buildCacheKey(
+          'kumiko',
+          quantize(latticePerimeter ?? 0),
+          quantize(lattice?.columnPitch ?? 0),
+          quantize(lattice?.strutWidth ?? 0)
+        );
+    return panelKey(patternType, variantKey, scale, spec, bandZ0, bandHeight, cutDepth);
+  };
+
   return {
     minPatternHeight: calculator.getMinPatternHeight(),
     border: Math.max(CUTOUT_BORDER_WIDTH, calculator.getShapeRadius()),
 
     build(spec, bandZ0, bandHeight, cutDepth) {
-      let lattice: Parameters<typeof buildFlatSlabCutter>[1] | null = null;
-      if (kumiko) {
-        const cached = latticeByBand.get(bandHeight);
-        lattice = cached ?? kumiko.getLattice({ perimeter: latticePerimeter ?? 0, bandHeight });
-        if (!cached) latticeByBand.set(bandHeight, lattice);
-        if (lattice.segments.length === 0) return null;
-      }
+      const lattice = latticeFor(bandHeight);
+      if (kumiko && (!lattice || lattice.segments.length === 0)) return null;
 
-      const variantKey = stamp
-        ? shapeDescriptorKey(stamp.getShapeDescriptor({ fillW: 0, fillH: bandHeight }))
-        : buildCacheKey(
-            'kumiko',
-            quantize(latticePerimeter ?? 0),
-            quantize(lattice?.columnPitch ?? 0),
-            quantize(lattice?.strutWidth ?? 0)
-          );
-      const key = panelKey(patternType, variantKey, scale, spec, bandZ0, bandHeight, cutDepth);
-
+      const key = computeKey(spec, bandZ0, bandHeight, cutDepth);
       const cachedPanel = getFeatureCache(DIVIDER_PATTERN_CACHE, key);
       if (cachedPanel) return cachedPanel;
 
@@ -406,35 +430,73 @@ export function resolvePanelFactory(
       setFeatureCache(DIVIDER_PATTERN_CACHE, key, built);
       return unwrap(clone(built));
     },
+
+    keyFor(spec, bandZ0, bandHeight, cutDepth) {
+      return computeKey(spec, bandZ0, bandHeight, cutDepth);
+    },
   };
+}
+
+/**
+ * Divider pattern cut targets plus the geometry identity of the whole set.
+ *
+ * `key` is empty when no divider cut applies, and otherwise identifies every
+ * placed panel: the factory's local-panel key (motif variant, span, keep-outs,
+ * band, cut depth) composed with each target's rigid placement and the interior
+ * offset. The resume cache in `booleanStage` keys on this so a divider-patterned
+ * bin can skip the whole boolean stage when the cut set is unchanged.
+ */
+export interface DividerPatternResult {
+  readonly shapes: Shape3D[];
+  readonly key: string;
 }
 
 /**
  * Build the divider pattern cut targets for a bin.
  *
- * Returns [] whenever the feature is off, unavailable for this bin, or no
- * divider offers a band large enough for a single element. Each returned
- * shape is owned by the caller.
+ * `shapes` is empty (and `key` blank) whenever the feature is off, unavailable
+ * for this bin, or no divider offers a band large enough for a single element.
+ * Each returned shape is owned by the caller.
  */
-export function buildDividerPatterns(ctx: PipelineContext): Shape3D[] {
+export function buildDividerPatterns(ctx: PipelineContext): DividerPatternResult {
   const { params, dimensions: dim, signal, originToTag, perfCollector } = ctx;
+  const NONE: DividerPatternResult = { shapes: [], key: '' };
 
   const factory = resolvePanelFactory(params, dim.innerW, dim.innerD);
-  if (!factory) return [];
+  if (!factory) return NONE;
 
   const plan = planDividerPatterns(params, dim, factory.border);
-  if (!plan) return [];
-  if (plan.bandHeight < factory.minPatternHeight) return [];
+  if (!plan) return NONE;
+  if (plan.bandHeight < factory.minPatternHeight) return NONE;
 
   const cutDepth = plan.thickness + 2 * DIVIDER_CUT_OVERSHOOT;
   const bandCenterZ = plan.bandZ0 + plan.bandHeight / 2;
 
   const start = perfCollector ? performance.now() : 0;
   const shapes: Shape3D[] = [];
+  const keyParts: string[] = [];
   for (const target of plan.targets) {
     checkCancelled(signal);
     const panel = factory.build(target, plan.bandZ0, plan.bandHeight, cutDepth);
     if (!panel) continue;
+
+    // Identity of this placed cut: the factory's local-panel key plus the rigid
+    // placement (position, in-plane rotation, span) and the interior offset
+    // applied after the local cache.
+    keyParts.push(
+      compactKey(
+        buildCacheKey(
+          factory.keyFor(target, plan.bandZ0, plan.bandHeight, cutDepth),
+          quantize(target.x),
+          quantize(target.y),
+          quantize(target.rotateZ),
+          quantize(target.wallLen),
+          quantize(bandCenterZ),
+          quantize(dim.innerOffsetX),
+          quantize(dim.innerOffsetY)
+        )
+      )
+    );
 
     let placed = placePanel(panel, target, bandCenterZ);
     if (dim.innerOffsetX !== 0 || dim.innerOffsetY !== 0) {
@@ -454,5 +516,6 @@ export function buildDividerPatterns(ctx: PipelineContext): Shape3D[] {
     );
   }
 
-  return shapes;
+  if (shapes.length === 0) return NONE;
+  return { shapes, key: compactKey(buildCacheKey('divider-v1', ...keyParts)) };
 }

--- a/src/features/generation/worker/generators/kumikoWrapBuilder.ts
+++ b/src/features/generation/worker/generators/kumikoWrapBuilder.ts
@@ -893,39 +893,55 @@ export function resolveKumikoCalculator(params: BinParams): WrappedLatticeCalcul
 }
 
 /**
- * Build the wrapped kumiko pattern cut targets for the whole perimeter.
- * Returns [] when no wrapped-lattice pattern applies (stamp patterns and
- * solid walls take the other paths).
+ * Wrapped kumiko cut targets plus the geometry identity of the whole set.
+ *
+ * `key` is empty when no kumiko cut applies, and otherwise fully identifies the
+ * returned shapes: it composes the per-wall cache key the cutters are stored
+ * under (which already captures the lattice, perimeter, selected sides and every
+ * wall clip) with the post-cache interior offset. The resume cache in
+ * `booleanStage` keys on this so a patterned bin can skip the whole boolean
+ * stage on an edit that leaves the cut set unchanged.
  */
-export function buildKumikoWallPatterns(ctx: PipelineContext): Shape3D[] {
+export interface KumikoWallPatternResult {
+  readonly shapes: Shape3D[];
+  readonly key: string;
+}
+
+/**
+ * Build the wrapped kumiko pattern cut targets for the whole perimeter.
+ * `shapes` is empty (and `key` blank) when no wrapped-lattice pattern applies
+ * (stamp patterns and solid walls take the other paths).
+ */
+export function buildKumikoWallPatterns(ctx: PipelineContext): KumikoWallPatternResult {
   const { params, dimensions: dim, signal, originToTag, perfCollector } = ctx;
   const { innerW, innerD, innerOffsetX, innerOffsetY } = dim;
+  const NONE: KumikoWallPatternResult = { shapes: [], key: '' };
 
   const calculator = resolveKumikoCalculator(params);
-  if (!calculator) return [];
+  if (!calculator) return NONE;
 
   // PR-1 scope: the wrap needs the rectangular perimeter; polygon footprints
   // and slotted walls fall back to solid walls for kumiko patterns.
-  if (isPartialMask(params.cellMask)) return [];
+  if (isPartialMask(params.cellMask)) return NONE;
   const slotFree = getSlotFreeWalls(params);
-  if (!slotFree.front || !slotFree.back || !slotFree.left || !slotFree.right) return [];
+  if (!slotFree.front || !slotFree.back || !slotFree.left || !slotFree.right) return NONE;
 
   const wallThickness = params.wallThickness;
   const bottomKeepOut = wallThickness + BOTTOM_SOLID_SKIRT;
   const patternHeight = dim.interiorHeight - TOP_KEEP_OUT - bottomKeepOut;
-  if (patternHeight < calculator.getMinPatternHeight()) return [];
+  if (patternHeight < calculator.getMinPatternHeight()) return NONE;
 
   const outerW = innerW + 2 * wallThickness;
   const outerD = innerD + 2 * wallThickness;
   const cornerRadius = Math.min(BOX_CORNER_RADIUS, Math.min(outerW, outerD) / 2 - 0.1);
-  if (cornerRadius <= 0.2) return [];
+  if (cornerRadius <= 0.2) return NONE;
 
   const layout = computePerimeterLayout(outerW, outerD, innerW, innerD, cornerRadius);
   const lattice = calculator.getLattice({
     perimeter: layout.perimeter,
     bandHeight: patternHeight,
   });
-  if (lattice.segments.length === 0) return [];
+  if (lattice.segments.length === 0) return NONE;
 
   const bandZ0 = bottomKeepOut;
   const patternCenterZ = bottomKeepOut + patternHeight / 2;
@@ -977,6 +993,14 @@ export function buildKumikoWallPatterns(ctx: PipelineContext): Shape3D[] {
     buildCacheKey('v1', baseKey, ...wallClips.map((wc) => wc.clips.keyPart))
   );
 
+  // Resume identity for the whole cut set: the per-wall cache key (lattice +
+  // sides + clips) plus the interior offset applied after the cache. The cutter
+  // count is deterministic from the layout the cache key already captures, so
+  // this key changes whenever the emitted shapes would.
+  const resumeKey = compactKey(
+    buildCacheKey(clippedKey, 'off', quantize(innerOffsetX), quantize(innerOffsetY))
+  );
+
   // The cutters stay SEPARATE all the way into the final pattern-cut boolean:
   // handing OCCT one whole-perimeter compound forces it to treat the tool set
   // as a single operand, defeating its per-tool bounding-box pruning (measured
@@ -989,7 +1013,7 @@ export function buildKumikoWallPatterns(ctx: PipelineContext): Shape3D[] {
   const slabSelected = (s: PerimeterSlab): boolean =>
     s.kind === 'flat' ? chosen[s.side] : chosen[s.prevSide] && chosen[s.nextSide];
   const activeSlabs = layout.slabs.filter((s) => (s.kind === 'flat' || exact) && slabSelected(s));
-  if (activeSlabs.length === 0) return [];
+  if (activeSlabs.length === 0) return NONE;
   // One planned cutter per flat window / corner — the plan is deterministic
   // from layout + lattice, so cache entries index it directly.
   const plan: Array<{ slab: PerimeterSlab; windowA: number; windowB: number }> = [];
@@ -1065,7 +1089,7 @@ export function buildKumikoWallPatterns(ctx: PipelineContext): Shape3D[] {
           );
           if (!cutter) {
             for (const c of cutters) c.delete();
-            return [];
+            return NONE;
           }
           cutters.push(cutter);
           if (perfCollector) {
@@ -1127,7 +1151,7 @@ export function buildKumikoWallPatterns(ctx: PipelineContext): Shape3D[] {
       }
       if (failed) {
         for (const s of clipped) s.delete();
-        return [];
+        return NONE;
       }
       shapes = cacheSetAll(KUMIKO_WRAP_CLIPPED_CACHE, clippedKey, clipped);
     }
@@ -1141,7 +1165,7 @@ export function buildKumikoWallPatterns(ctx: PipelineContext): Shape3D[] {
     perfCollector.setPatternCutToolCount(shapes.length);
   }
 
-  return shapes.map((cutter) => {
+  const placedShapes = shapes.map((cutter) => {
     let placed = cutter;
     if (innerOffsetX !== 0 || innerOffsetY !== 0) {
       const old = placed;
@@ -1151,4 +1175,5 @@ export function buildKumikoWallPatterns(ctx: PipelineContext): Shape3D[] {
     collectOrigins(placed, FeatureTag.WALL_PATTERN, originToTag);
     return placed;
   });
+  return { shapes: placedShapes, key: resumeKey };
 }

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -142,37 +142,38 @@ export const featuresStage: PipelineStage = {
     // only bind clipping to the outermost edge per cardinal — non-outermost
     // step walls get pure pattern.
     const wallPatternEnabled = params.wallPattern.enabled;
-    let wallPatternKeys: string[] = [];
-    let unkeyedPatternCuts = false;
+    const wallPatternKeys: string[] = [];
     if (wallPatternEnabled) {
       // Stamp patterns and kumiko wrapped-lattice patterns are mutually
       // exclusive per pattern type; each builder no-ops for the other's types.
       const patterns = buildWallPatterns(ctx);
-      // The two arrays are appended in lockstep; a mismatch would mean a shape
-      // whose identity is missing from the resume key, which is the one failure
-      // that surfaces as wrong geometry rather than a slow rebuild.
+      // Stamp shapes carry a per-shape identity in lockstep; a mismatch would
+      // mean a shape whose identity is missing from the resume key, which is the
+      // one failure that surfaces as wrong geometry rather than a slow rebuild.
       if (patterns.keys.length !== patterns.shapes.length) {
         throw new Error('wall pattern targets and keys are misaligned');
       }
       targets.patternCutTargets.push(...patterns.shapes);
-      wallPatternKeys = patterns.keys;
-      const kumikoShapes = buildKumikoWallPatterns(ctx);
-      targets.patternCutTargets.push(...kumikoShapes);
-      // Divider walls carry the same pattern when opted in. Both
-      // pipelines are handled inside, so this is one call for either type.
-      const dividerShapes = buildDividerPatterns(ctx);
-      targets.patternCutTargets.push(...dividerShapes);
-      // Neither builder reports the identity of what it emitted (both compute
-      // it internally, the divider one inside a panel-factory closure), so a
-      // bin carrying either keeps the resume cache off.
-      unkeyedPatternCuts = kumikoShapes.length > 0 || dividerShapes.length > 0;
+      wallPatternKeys.push(...patterns.keys);
+
+      // Kumiko and divider cuts each report a single key that fully identifies
+      // their whole set (see the builders). A blank key means no cut was emitted,
+      // so there is nothing to fold in. Divider walls carry the same pattern when
+      // opted in; both stamp and kumiko divider panels are handled inside.
+      const kumiko = buildKumikoWallPatterns(ctx);
+      targets.patternCutTargets.push(...kumiko.shapes);
+      if (kumiko.key) wallPatternKeys.push(kumiko.key);
+
+      const dividers = buildDividerPatterns(ctx);
+      targets.patternCutTargets.push(...dividers.shapes);
+      if (dividers.key) wallPatternKeys.push(dividers.key);
     }
 
-    // The floor pattern stays unkeyed regardless: its shapes also carve the
-    // deferred socket, and a resume hit would be worse than stale — the cached
-    // body would come back with holes while the freshly built socket flowed
-    // through uncut.
-    const resumable = !unkeyedPatternCuts && floorPatternShapes.length === 0;
+    // The floor pattern stays unkeyed: its shapes also carve the deferred
+    // socket, and a resume hit would be worse than stale (the cached body would
+    // come back with holes while the freshly built socket flowed through uncut).
+    // Every other pattern cut now reports its identity.
+    const resumable = floorPatternShapes.length === 0;
 
     return {
       ...ctx,

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -343,7 +343,7 @@ function splitSolidIntoPieces(
       const patternCtx = createInitialContext(params, undefined, true, undefined, undefined, true);
       const patternShapes = [
         ...buildWallPatterns(patternCtx).shapes,
-        ...buildKumikoWallPatterns(patternCtx),
+        ...buildKumikoWallPatterns(patternCtx).shapes,
       ];
       // Lowest lip material anywhere: the bottom of the support wedge, in the
       // cutters' own body-local frame. Read off `wallTopZ` (less the floor lift


### PR DESCRIPTION
## Problem
The boolean-stage resume cache (`binBodyCache`) skips the whole `pattern_cut` when a design's identity is unchanged. But it was disabled for any bin carrying a **kumiko wall pattern** or **patterned dividers**: those builders emitted their cut shapes without reporting an identity, so `featuresStage` marked them `unkeyedPatternCuts` and forced a full rebuild every regeneration. Those are among the most expensive bins, so they re-paid 8-21s of boolean on edits that changed nothing about the cut set (a cosmetic edit, undo/redo, a non-shell nudge).

## Change
Both builders now report a complete geometry identity:
- **Kumiko** reuses the per-wall `clippedKey` it already computes (lattice, selected sides, every wall clip) composed with the interior offset applied after the cache.
- **Dividers**: the panel factory gains a `keyFor()` returning the same local-panel key `build()` caches under (a shared `computeKey` so the two never drift); `buildDividerPatterns` composes it per target with the panel's placement and the offset.

`featuresStage` folds both keys into the resume key and drops the unkeyed gate. Stamp-only bins (honeycomb, etc.) are unaffected: their resume key is byte-identical to before. The floor pattern stays barred (its cuts also carve the deferred socket) until its own follow-up (#1b).

## Perf (warm-same regen = identical params, real WASM)
| design | before | after |
|---|--:|--:|
| kumiko-mitsukude | 5454ms | **326ms** |
| dividers (12×8 grid) | 7868ms | **1117ms** |
| filled kumiko (asanoha) | 14239ms | **8052ms** |

Filled kumiko's smaller win is honest: its 16 lattice cutters exceed the kumiko cutter cache's 12 slots, so the *features* stage re-pays even though the *boolean* is now correctly skipped. That cutter-cache capacity is a separate follow-up.

## Correctness
The risk is a key collision serving a stale body (silently wrong geometry). Guards:
- All 71 existing kumiko/divider scenario + export geometry tests pass unchanged (cold geometry is untouched: the resume key only affects warm lookups).
- New `resumeCacheCorrectness` kernel test proves, for a kumiko and a divider design, that a warm regen matches the cold geometry **and** that a scale / height / grid / thickness change never resumes onto the base body.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

