### PR TITLE
perf(generation): let floor-pattern bins resume the post-boolean body

### DIFF
--- a/src/features/generation/worker/generators/__kernel-tests__/resumeCacheCorrectness.test.ts
+++ b/src/features/generation/worker/generators/__kernel-tests__/resumeCacheCorrectness.test.ts
@@ -68,6 +68,38 @@ const CASES: Case[] = [
     ],
   },
   {
+    name: 'wall+floor-honeycomb',
+    base: buildParams({
+      width: 3,
+      depth: 3,
+      height: 5,
+      wallPattern: { enabled: true, pattern: 'honeycomb' },
+      floorPattern: { enabled: true, pattern: 'honeycomb', scale: 0.5 },
+    }),
+    variants: [
+      {
+        name: 'floor-scale',
+        params: buildParams({
+          width: 3,
+          depth: 3,
+          height: 5,
+          wallPattern: { enabled: true, pattern: 'honeycomb' },
+          floorPattern: { enabled: true, pattern: 'honeycomb', scale: 0.7 },
+        }),
+      },
+      {
+        name: 'floor-pattern',
+        params: buildParams({
+          width: 3,
+          depth: 3,
+          height: 5,
+          wallPattern: { enabled: true, pattern: 'honeycomb' },
+          floorPattern: { enabled: true, pattern: 'diamond', scale: 0.5 },
+        }),
+      },
+    ],
+  },
+  {
     name: 'divider-honeycomb',
     base: buildParams({
       width: 3,

--- a/src/features/generation/worker/generators/binBodyResumeCache.test.ts
+++ b/src/features/generation/worker/generators/binBodyResumeCache.test.ts
@@ -102,21 +102,53 @@ describe('bin-body resume cache with wall patterns', () => {
     expect(plain.triangleCount).not.toBe(patterned.triangleCount);
   }, 120_000);
 
-  it('leaves the resume cache untouched for floor patterns', () => {
-    // The floor pattern's shapes also carve the deferred socket, so a resume hit
-    // would pair a holed body with an uncut socket. It stays opted out.
+  it('resumes the booleaned body for a floor-patterned bin', () => {
+    // The floor pattern reports its identity, so an unchanged regen resumes the
+    // body. Its shapes also carve the deferred socket, but booleanStage
+    // re-derives that carve from the same shapes on every build, so the resumed
+    // body and the freshly cut socket stay consistent.
     const generateBin = getGenerateBin();
     const withFloor = {
       ...HONEYCOMB,
       wallPattern: { enabled: false, pattern: 'honeycomb' as const },
-      floorPattern: { ...DEFAULT_FLOOR_PATTERN_CONFIG, enabled: true },
+      floorPattern: {
+        ...DEFAULT_FLOOR_PATTERN_CONFIG,
+        enabled: true,
+        pattern: 'honeycomb' as const,
+      },
     };
 
-    generateBin(withFloor);
+    const first = generateBin(withFloor);
     resetAllShapeCacheStats();
-    generateBin(withFloor);
+    const second = generateBin(withFloor);
 
-    const stats = binBodyStats();
-    expect(stats.hits + stats.misses, 'floor-patterned bins must not consult the cache').toBe(0);
+    expect(
+      binBodyStats().hits,
+      'identical re-gen of a floor-patterned bin must resume the body'
+    ).toBe(1);
+    expect(second.triangleCount).toBe(first.triangleCount);
+  }, 120_000);
+
+  it('rebuilds rather than resuming when the floor pattern changes', () => {
+    const generateBin = getGenerateBin();
+    const withFloor = {
+      ...HONEYCOMB,
+      wallPattern: { enabled: false, pattern: 'honeycomb' as const },
+      floorPattern: {
+        ...DEFAULT_FLOOR_PATTERN_CONFIG,
+        enabled: true,
+        pattern: 'honeycomb' as const,
+      },
+    };
+
+    const first = generateBin(withFloor);
+    resetAllShapeCacheStats();
+    const changed = generateBin({
+      ...withFloor,
+      floorPattern: { ...DEFAULT_FLOOR_PATTERN_CONFIG, enabled: true, pattern: 'diamond' as const },
+    });
+
+    expect(binBodyStats().hits, 'a different floor pattern must not resume').toBe(0);
+    expect(changed.triangleCount).not.toBe(first.triangleCount);
   }, 120_000);
 });

--- a/src/features/generation/worker/generators/floorPatternBuilder.ts
+++ b/src/features/generation/worker/generators/floorPatternBuilder.ts
@@ -22,6 +22,7 @@ import { rotate, translate } from 'brepjs';
 import type { Shape3D } from 'brepjs';
 import type { PipelineContext } from './pipeline/types';
 import { resolvePanelFactory } from './dividerPatternBuilder';
+import { buildCacheKey, compactKey, quantize } from './cacheKeyUtils';
 import { planFloorPattern } from './floorPatterns';
 import { DEFAULT_PATTERN_SCALE } from '@/shared/types/bin';
 import { checkCancelled } from './utils/abort';
@@ -29,36 +30,67 @@ import { FeatureTag } from './featureTags';
 import { collectOrigins } from './pipeline/collectOrigins';
 
 /**
+ * Floor-pattern cut targets plus the geometry identity of the whole set.
+ *
+ * `key` is empty when no floor cut applies, and otherwise identifies every
+ * placed window: the factory's local-panel key (motif variant, span, keep-outs,
+ * band, cut depth) composed with each window's placement. These cuts also carve
+ * the deferred socket, so `booleanStage` uses this key both for the body resume
+ * and for caching the carved socket.
+ */
+export interface FloorPatternResult {
+  readonly shapes: Shape3D[];
+  readonly key: string;
+}
+
+/**
  * Build the floor-pattern cut targets for a bin.
  *
- * Returns `[]` whenever the feature is off, unavailable for this bin, or no
- * window is large enough for a single element. Each returned shape is owned by
- * the caller and must be cut from BOTH the body and the deferred socket.
+ * `shapes` is empty (and `key` blank) whenever the feature is off, unavailable
+ * for this bin, or no window is large enough for a single element. Each returned
+ * shape is owned by the caller and must be cut from BOTH the body and the
+ * deferred socket.
  */
-export function buildFloorPattern(ctx: PipelineContext): Shape3D[] {
+export function buildFloorPattern(ctx: PipelineContext): FloorPatternResult {
   const { params, dimensions: dim, signal, originToTag, perfCollector } = ctx;
+  const NONE: FloorPatternResult = { shapes: [], key: '' };
 
   const floorPattern = params.floorPattern;
-  if (floorPattern?.enabled !== true) return [];
+  if (floorPattern?.enabled !== true) return NONE;
 
   const plan = planFloorPattern(params, dim);
-  if (!plan) return [];
+  if (!plan) return NONE;
 
   const factory = resolvePanelFactory(params, dim.innerW, dim.innerD, {
     pattern: floorPattern.pattern,
     scale: floorPattern.scale ?? DEFAULT_PATTERN_SCALE,
   });
-  if (!factory) return [];
+  if (!factory) return NONE;
 
   const cutDepth = plan.cutZ1 - plan.cutZ0;
   const centerZ = (plan.cutZ0 + plan.cutZ1) / 2;
 
   const start = perfCollector ? performance.now() : 0;
   const shapes: Shape3D[] = [];
+  const keyParts: string[] = [];
   for (const window of plan.windows) {
     checkCancelled(signal);
-    const panel = factory.build(window, -window.patternDepth / 2, window.patternDepth, cutDepth);
+    const bandZ0 = -window.patternDepth / 2;
+    const panel = factory.build(window, bandZ0, window.patternDepth, cutDepth);
     if (!panel) continue;
+
+    // Identity of this placed cut: the factory's local-panel key plus the
+    // window's placement (its x/y already fold in the interior offset).
+    keyParts.push(
+      compactKey(
+        buildCacheKey(
+          factory.keyFor(window, bandZ0, window.patternDepth, cutDepth),
+          quantize(window.x),
+          quantize(window.y),
+          quantize(centerZ)
+        )
+      )
+    );
 
     // Stand the panel down onto the floor: (x, y, z) -> (x, z, -y), so the
     // factory's band axis becomes Y and its thickness axis becomes Z.
@@ -79,5 +111,6 @@ export function buildFloorPattern(ctx: PipelineContext): Shape3D[] {
     );
   }
 
-  return shapes;
+  if (shapes.length === 0) return NONE;
+  return { shapes, key: compactKey(buildCacheKey('floor-v1', ...keyParts)) };
 }

--- a/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
+++ b/src/features/generation/worker/generators/pipeline/stages/featuresStage.ts
@@ -131,11 +131,11 @@ export const featuresStage: PipelineStage = {
 
     const targets = runFeatureBuilders(builders, ctx);
 
-    // Floor pattern: drainage/ventilation holes through the floor slab
-    // AND the base socket, so they're handed to the boolean stage twice — once
-    // for the body, once for the deferred socket.
-    const floorPatternShapes = buildFloorPattern(ctx);
-    targets.patternCutTargets.push(...floorPatternShapes);
+    // Floor pattern: drainage/ventilation holes through the floor slab AND the
+    // base socket, so they are handed to the boolean stage twice (once for the
+    // body, once for the deferred socket).
+    const floorPattern = buildFloorPattern(ctx);
+    targets.patternCutTargets.push(...floorPattern.shapes);
 
     // Wall patterns: special case with per-wall caching + cutout clipping.
     // Polygon bins enumerate outer polygon edges (see wallPatterns.ts) and
@@ -169,28 +169,28 @@ export const featuresStage: PipelineStage = {
       if (dividers.key) wallPatternKeys.push(dividers.key);
     }
 
-    // The floor pattern stays unkeyed: its shapes also carve the deferred
-    // socket, and a resume hit would be worse than stale (the cached body would
-    // come back with holes while the freshly built socket flowed through uncut).
-    // Every other pattern cut now reports its identity.
-    const resumable = floorPatternShapes.length === 0;
+    // The floor cut reports its identity too, so a floor-patterned bin can
+    // resume the post-boolean body like any other. Its shapes also carve the
+    // deferred socket, but booleanStage re-derives that carve from the same
+    // shapes on every build, so a resumed body and the freshly cut socket always
+    // agree (caching the socket carve itself is a separate follow-up).
+    if (floorPattern.key) wallPatternKeys.push(floorPattern.key);
 
     return {
       ...ctx,
       fuseTargets: targets.fuseTargets,
       cutTargets: targets.cutTargets,
       patternCutTargets: targets.patternCutTargets,
-      deferredCutTargets: floorPatternShapes,
-      // Wall-pattern cuts ride in `featuresKey` via the same per-wall identity
-      // the pattern cache trusts, so a patterned bin can resume the post-boolean
-      // body like any other. That matters most here: the honeycomb-plus-cutouts
-      // bins are both the slowest to boolean and, until now, the only ones
-      // barred from the cache that exists to skip it.
-      featuresKey: resumable
-        ? wallPatternKeys.length > 0
+      deferredCutTargets: floorPattern.shapes,
+      // Pattern cuts ride in `featuresKey` via the same per-shape identity the
+      // pattern caches trust, so any patterned bin can resume the post-boolean
+      // body. The honeycomb-plus-cutouts, kumiko, divider and floor bins are the
+      // slowest to boolean and were the last barred from the cache built to skip
+      // it.
+      featuresKey:
+        wallPatternKeys.length > 0
           ? JSON.stringify(['wallpattern-v1', targets.featuresKey, wallPatternKeys])
-          : targets.featuresKey
-        : null,
+          : targets.featuresKey,
     };
   },
 };


### PR DESCRIPTION
## Problem
A bin with a floor pattern was the last one barred from the boolean-stage resume cache (`binBodyCache`): `buildFloorPattern` emitted its cut shapes without an identity, so `featuresStage` left `featuresKey` null and re-ran the whole body boolean — the wall pattern **plus** the floor cut — on every regeneration.

## Change
`buildFloorPattern` now reports a complete identity the same way `buildDividerPatterns` does: the panel factory's `keyFor()` per window, composed with each window's placement (whose x/y already fold in the interior offset). `featuresStage` folds it into the resume key and drops the floor gate.

The floor shapes also carve the deferred base socket, but `booleanStage.cutDeferredSolid` re-derives that carve from the same shapes on **every** build, so a resumed body and the freshly cut socket always agree, and the new key prevents a different floor pattern from false-resuming a stale body. Caching the socket carve itself (so the socket boolean + re-tessellation also skip) is a deliberate follow-up — it is a smaller residual and touches the exported socket, so it warrants its own change.

## Perf (warm-same regen, real WASM)
`honeycomb-6x6x8 + floor`: **21438ms → 6521ms** (30% of before). The residual is the socket cut and re-tessellation the follow-up would remove.

## Correctness
- The `resumeCacheCorrectness` kernel test gains a `wall+floor` case proving a warm regen matches the cold geometry (the preview mesh includes the socket) **and** that a floor scale or pattern change never resumes onto a stale body.
- Non-floor bins are unaffected: their resume key is byte-identical to before (a bin with no floor pushes no floor key).
- All 76 existing floor scenario + export geometry tests pass unchanged.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

