### PR TITLE
perf(bin-designer): adapt the preview timeout to device speed, draft-only over the ceiling

### DIFF
--- a/src/features/bin-designer/hooks/useGeneration.test.ts
+++ b/src/features/bin-designer/hooks/useGeneration.test.ts
@@ -39,6 +39,8 @@ vi.mock('@/shared/generation/bridge', () => ({
   FAST_EXACT_SKIP_MS: 1000,
   EXACT_IMMEDIATE_MAX_MS: 600,
   FORCE_DRAFT_AFTER_EXACT_MS: 1000,
+  MAX_TIMEOUT_MS: 180_000,
+  PREVIEW_TIMEOUT_SAFETY: 1.5,
   // Stable threshold — burst behavior is covered by draftPolicy's own tests.
   createDraftSkipGate: () => () => ({ skipBelowMs: 1000, scrubbing: false }),
 }));
@@ -477,7 +479,12 @@ describe('useGeneration', () => {
       await vi.advanceTimersByTimeAsync(1);
     });
 
-    expect(mockBridge.generateImmediate).toHaveBeenCalledWith(expect.anything(), undefined, true);
+    expect(mockBridge.generateImmediate).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      true,
+      expect.any(Number)
+    );
     expect(mockBridge.generate).not.toHaveBeenCalled();
     expect(useDesignerStore.getState().generation.status).toBe('complete');
   });
@@ -548,6 +555,55 @@ describe('useGeneration', () => {
 
     // The slow last exact forced the draft despite the fast estimate.
     expect(previewGenerate).toHaveBeenCalled();
+  });
+
+  it('shows a draft-only preview and skips the exact when the estimate exceeds the ceiling', async () => {
+    const draftVerts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const meshOf = (vertices: Float32Array, timingMs = 1) => ({
+      mesh: {
+        vertices,
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        indices: new Uint32Array([0, 1, 2]),
+        edgeVertices: new Float32Array(0),
+        triangleCount: 1,
+      },
+      timingMs,
+    });
+    const previewGenerate = vi.fn().mockResolvedValue(meshOf(draftVerts));
+    const previewBridge = {
+      isDestroyed: false,
+      generateImmediate: previewGenerate,
+      destroy: vi.fn(),
+    } as unknown as GenerationBridge;
+    mockAcquirePreview.mockResolvedValue(previewBridge);
+
+    // The device-aware estimate says the exact would exceed the 180s preview
+    // ceiling on this device, so the exact is skipped and the draft is final.
+    (mockBridge.estimateGenerate as ReturnType<typeof vi.fn>).mockResolvedValue(200_000);
+
+    renderHook(() => useGeneration());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    // Isolate the edit from whatever the initial (pre-preview) generation did.
+    (mockBridge.generate as ReturnType<typeof vi.fn>).mockClear();
+    (mockBridge.generateImmediate as ReturnType<typeof vi.fn>).mockClear();
+    previewGenerate.mockClear();
+
+    // Scoop so the bin is not direct-mesh-eligible (forces the async path).
+    await act(async () => {
+      useDesignerStore.setState((s) => ({
+        params: { ...s.params, scoop: { ...s.params.scoop, enabled: true } },
+        generation: { ...s.generation, epoch: 1 },
+      }));
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(previewGenerate, 'the draft is shown as the final preview').toHaveBeenCalled();
+    expect(mockBridge.generate, 'the exact is skipped').not.toHaveBeenCalled();
+    expect(mockBridge.generateImmediate, 'the exact is skipped').not.toHaveBeenCalled();
+    expect(useDesignerStore.getState().generation.status).toBe('complete');
   });
 
   it('persists the exact preview mesh after generation completes', async () => {

--- a/src/features/bin-designer/hooks/useGeneration.ts
+++ b/src/features/bin-designer/hooks/useGeneration.ts
@@ -9,6 +9,8 @@ import {
   getActiveKernel,
   EXACT_IMMEDIATE_MAX_MS,
   FORCE_DRAFT_AFTER_EXACT_MS,
+  MAX_TIMEOUT_MS,
+  PREVIEW_TIMEOUT_SAFETY,
 } from '@/shared/generation/bridge';
 import type { GenerationBridge } from '@/shared/generation/bridge';
 import { generateBinDirect, canBinUseDirectMesh } from '@/shared/generation/directMesh';
@@ -176,8 +178,8 @@ export function useGeneration(): void {
   const pushPerfSnapshot = useDesignerStore((state) => state.pushPerfSnapshot);
 
   const dispatchDraft = useCallback(
-    (preview: GenerationBridge, currentParams: BinParams, token: number) => {
-      void preview
+    (preview: GenerationBridge, currentParams: BinParams, token: number): Promise<void> => {
+      return preview
         .generateImmediate(
           withSocketNozzle(
             currentParams,
@@ -285,6 +287,20 @@ export function useGeneration(): void {
       // exact with no interim feedback.
       const lastExactSlow = lastExactMsRef.current >= FORCE_DRAFT_AFTER_EXACT_MS;
       const preview = previewBridgeRef.current;
+
+      // Draft-only fallback: when the device-aware estimate says the exact would
+      // blow the preview time ceiling on THIS device, running it just burns the
+      // whole budget and then hard-resets the worker. Show the Manifold draft as
+      // the final preview instead; export still builds the exact on its own,
+      // larger budget. Needs a preview bridge to have anything to show.
+      if (preview && !preview.isDestroyed && predictedMs !== null && predictedMs > MAX_TIMEOUT_MS) {
+        await dispatchDraft(preview, genParams, token);
+        if (token !== genTokenRef.current) return;
+        finalizedTokenRef.current = token;
+        setGenerationStatus('complete');
+        return;
+      }
+
       if (
         preview &&
         !preview.isDestroyed &&
@@ -292,8 +308,14 @@ export function useGeneration(): void {
         token > finalizedTokenRef.current &&
         (lastExactSlow || !(predictedMs !== null && predictedMs < skipBelowMs))
       ) {
-        dispatchDraft(preview, genParams, token);
+        void dispatchDraft(preview, genParams, token);
       }
+
+      // Arm a device-aware timeout floor: on a slow device the estimate is large,
+      // so the exact gets headroom over its own measured cost even when the static
+      // budget (tuned on a faster reference machine) is tighter. No effect on fast
+      // devices or cheap builds, where the static budget already dominates.
+      const minTimeoutMs = predictedMs !== null ? predictedMs * PREVIEW_TIMEOUT_SAFETY : 0;
 
       // Fire the exact immediately (no debounce) only when it is predicted
       // cheap, the worker is idle (non-null estimate), and this is not a scrub.
@@ -306,8 +328,8 @@ export function useGeneration(): void {
       try {
         // Only the designer preview renders label plates (preview).
         const result = fireImmediate
-          ? await bridge.generateImmediate(genParams, undefined, true)
-          : await bridge.generate(genParams, undefined, true);
+          ? await bridge.generateImmediate(genParams, undefined, true, minTimeoutMs)
+          : await bridge.generate(genParams, undefined, true, minTimeoutMs);
 
         // A newer edit superseded this one; let its results win instead.
         if (token !== genTokenRef.current) return;
@@ -498,7 +520,7 @@ export function useGeneration(): void {
         previewBridgeRef.current = preview;
         if (genTokenRef.current === 0) {
           const token = ++genTokenRef.current;
-          dispatchDraft(preview, useDesignerStore.getState().params, token);
+          void dispatchDraft(preview, useDesignerStore.getState().params, token);
         }
       })
       .catch(() => {

--- a/src/features/generation/bridge/GenerationBridge.ts
+++ b/src/features/generation/bridge/GenerationBridge.ts
@@ -261,22 +261,29 @@ export class GenerationBridge {
     });
   }
 
-  /** Generate bin mesh — debounced. */
+  /**
+   * Generate bin mesh — debounced. `minTimeoutMs` raises the generation-timeout
+   * floor (never lowers it, still bounded by the preview ceiling) so a slow
+   * device can arm its own measured-cost budget over the reference-tuned static
+   * one; see `computeGenerationTimeoutMs`.
+   */
   generate(
     params: BinParams,
     onProgress?: ProgressCallback,
-    withLabelPlates = false
+    withLabelPlates = false,
+    minTimeoutMs = 0
   ): Promise<GenerationResult> {
-    return generateBinImpl(this, params, onProgress, true, withLabelPlates);
+    return generateBinImpl(this, params, onProgress, true, withLabelPlates, minTimeoutMs);
   }
 
   /** Generate immediately without debounce — for initial generation or user-triggered regeneration. */
   generateImmediate(
     params: BinParams,
     onProgress?: ProgressCallback,
-    withLabelPlates = false
+    withLabelPlates = false,
+    minTimeoutMs = 0
   ): Promise<GenerationResult> {
-    return generateBinImpl(this, params, onProgress, false, withLabelPlates);
+    return generateBinImpl(this, params, onProgress, false, withLabelPlates, minTimeoutMs);
   }
 
   /**

--- a/src/features/generation/bridge/bridgeGeneration.ts
+++ b/src/features/generation/bridge/bridgeGeneration.ts
@@ -92,7 +92,8 @@ export function generateBin(
   params: BinParams,
   onProgress: ProgressCallback | undefined,
   debounce: boolean,
-  withLabelPlates = false
+  withLabelPlates = false,
+  minTimeoutMs = 0
 ): Promise<GenerationResult> {
   if (ctx.isDestroyed) {
     return Promise.reject(new Error('Bridge has been destroyed'));
@@ -124,7 +125,7 @@ export function generateBin(
       const requestId = ctx.nextRequestId();
       ctx.currentRequestId = requestId;
       ctx.binCache.setPending(fingerprint);
-      sendWhenReady(ctx, requestId, computeGenerationTimeoutMs(params), {
+      sendWhenReady(ctx, requestId, computeGenerationTimeoutMs(params, minTimeoutMs), {
         type: 'GENERATE',
         payload: { params, requestId, withLabelPlates },
       });

--- a/src/features/generation/bridge/generationTimeout.test.ts
+++ b/src/features/generation/bridge/generationTimeout.test.ts
@@ -64,6 +64,18 @@ describe('computeGenerationTimeoutMs', () => {
     expect(computeGenerationTimeoutMs(params({ height: 3 }))).toBe(BASE_TIMEOUT_MS);
   });
 
+  it('raises the budget floor to minTimeoutMs, but never below the static budget or above the ceiling', () => {
+    const p = params({ height: 3 }); // static budget = BASE_TIMEOUT_MS
+    // A device floor above the static budget wins.
+    expect(computeGenerationTimeoutMs(p, BASE_TIMEOUT_MS + 20_000)).toBe(BASE_TIMEOUT_MS + 20_000);
+    // A device floor below the static budget does not lower it.
+    expect(computeGenerationTimeoutMs(p, 1_000)).toBe(BASE_TIMEOUT_MS);
+    // The ceiling still bounds it.
+    expect(computeGenerationTimeoutMs(p, MAX_TIMEOUT_MS * 5)).toBe(MAX_TIMEOUT_MS);
+    // A non-finite floor is ignored.
+    expect(computeGenerationTimeoutMs(p, NaN)).toBe(BASE_TIMEOUT_MS);
+  });
+
   it('adds a pattern bonus when the hex pattern is enabled', () => {
     const t = computeGenerationTimeoutMs(
       params({

--- a/src/features/generation/bridge/generationTimeout.ts
+++ b/src/features/generation/bridge/generationTimeout.ts
@@ -342,13 +342,29 @@ function binRawBudgetMs(params: BinParams): number {
 }
 
 /**
+ * Multiplier applied to the device-aware estimate to derive `minTimeoutMs`.
+ *
+ * The estimate predicts this device's actual generation time from its own last
+ * observed stage timings. Arming the preview timeout at `estimate * this` gives
+ * a genuinely slow device proportional headroom over its own measured speed, so
+ * a slow-but-progressing build is not hard-reset just because the static budget
+ * (tuned on a faster reference machine) is tighter than the device needs.
+ */
+export const PREVIEW_TIMEOUT_SAFETY = 1.5;
+
+/**
  * Compute the timeout budget for a live bin **preview** generation, in
  * milliseconds. Clamped to `[BASE_TIMEOUT_MS, MAX_TIMEOUT_MS]`.
+ *
+ * `minTimeoutMs` raises the budget floor (before the ceiling clamp) so a slow
+ * device's own measured cost can win over the reference-tuned static budget. It
+ * never lowers the budget, and the `MAX_TIMEOUT_MS` ceiling still bounds it.
  */
-export function computeGenerationTimeoutMs(params: BinParams): number {
+export function computeGenerationTimeoutMs(params: BinParams, minTimeoutMs = 0): number {
   // The raw budget is finite by construction (guards in binRawBudgetMs), so this
   // clamp also makes the documented contract self-enforcing.
-  return Math.max(BASE_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, binRawBudgetMs(params)));
+  const floor = Math.max(binRawBudgetMs(params), Number.isFinite(minTimeoutMs) ? minTimeoutMs : 0);
+  return Math.max(BASE_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, floor));
 }
 
 /**

--- a/src/shared/generation/bridge.ts
+++ b/src/shared/generation/bridge.ts
@@ -17,6 +17,10 @@ export {
 } from '@/features/generation/bridge/types';
 export { createDraftSkipGate } from '@/features/generation/bridge/draftPolicy';
 export {
+  MAX_TIMEOUT_MS,
+  PREVIEW_TIMEOUT_SAFETY,
+} from '@/features/generation/bridge/generationTimeout';
+export {
   awaitPoolWithin,
   poolIsUsable,
   shouldWaitForPool,


### PR DESCRIPTION
## Problem
A heavy design on a slow device hits the preview timeout, hard-resets the worker (which frees its warm shape caches), then times out again from cold: a thrash. The static timeout budget is tuned on a faster reference machine, so it is tighter than a slow device needs; and the 180s ceiling means the worst designs can't be given more time anyway.

## Change
Both mechanisms are driven by the existing **device-aware estimate** — it predicts from *this device's own last observed stage timings*, so no separate calibration workload or hardcoded reference constant is needed.

1. **Timeout scaling.** The preview timeout takes a minimum floor of `estimate × PREVIEW_TIMEOUT_SAFETY` (1.5). On a slow device the estimate is large, so a slow-but-progressing build gets headroom over its own measured cost instead of being killed by the reference-tuned static budget. The floor never *lowers* the budget and is still bounded by the 180s ceiling, so fast devices and cheap builds are unaffected.

2. **Draft-only over the ceiling.** When the estimate says the exact would exceed the 180s ceiling on this device, running it only burns the budget and hard-resets the worker. Show the Manifold draft as the final preview instead; **export still builds the exact** on its own, larger budget. Requires a preview bridge to show anything, else it falls back to the exact.

## Notes
- The estimate is null until a design has generation history, so the first heavy build on a slow device can still time out once; from then on the estimate drives both paths.
- A dedicated "preview simplified for this device" hint is a deliberate follow-up (there is no existing text-hint slot; isDraft drives visual treatment only). The draft is a faithful approximation and export is exact, so the fallback is honest without it.

## Tests
- `useGeneration.test.ts`: an estimate over the ceiling shows the draft and skips the exact (`generate`/`generateImmediate` never called), status `complete`.
- `generationTimeout.test.ts`: `minTimeoutMs` raises the floor above the static budget, never below it, never above the ceiling, and ignores a non-finite value.

Verification is by unit test: the device-aware estimate never exceeds 180s on the (fast) reference machine, so there is no clean in-app repro of the slow-device path.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

