### PR TITLE
fix(spacemouse): claim the puck for the example-preview dialog

### DIFF
--- a/src/features/bin-designer/components/ExampleGallery/Example3DViewer.test.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/Example3DViewer.test.tsx
@@ -59,4 +59,10 @@ describe('Example3DViewer', () => {
     expect(glbViewerProps.current.loadBehavior).toBeUndefined();
     expect(screen.getByTestId('gradient-background')).toBeInTheDocument();
   });
+
+  it('claims the SpaceMouse, since it renders in a dialog over the live preview', () => {
+    render(<Example3DViewer example={makeExample('with-mesh')} />);
+
+    expect(glbViewerProps.current.modal).toBe(true);
+  });
 });

--- a/src/features/bin-designer/components/ExampleGallery/Example3DViewer.tsx
+++ b/src/features/bin-designer/components/ExampleGallery/Example3DViewer.tsx
@@ -26,7 +26,15 @@ export function Example3DViewer({ example }: Example3DViewerProps) {
 
   return (
     <div className="relative w-full" style={{ aspectRatio: '1 / 1', maxHeight: '40vh' }}>
-      <GlbViewer meshUrl={url} posterUrl={thumb} alt={t(example.nameKey)} className="h-full w-full">
+      {/* Always hosted in ExamplePreviewOverlay (a dialog over the designer's live
+          preview), so claim the puck or it keeps driving the canvas behind. */}
+      <GlbViewer
+        meshUrl={url}
+        posterUrl={thumb}
+        alt={t(example.nameKey)}
+        className="h-full w-full"
+        modal
+      >
         {/* Bin-designer-local 2-stop gradient, same one the thumbnails were captured with. */}
         <GradientBackground />
       </GlbViewer>

--- a/src/shared/components/GlbViewer/GlbViewer.test.tsx
+++ b/src/shared/components/GlbViewer/GlbViewer.test.tsx
@@ -48,6 +48,14 @@ vi.mock('@react-three/drei', () => ({
   useProgress: () => ({ active: true, progress: 40, errors: [], item: '', loaded: 2, total: 5 }),
 }));
 
+const spaceMouseState = vi.hoisted((): { props: Record<string, unknown> } => ({ props: {} }));
+vi.mock('@/shared/spacemouse/components/SpaceMouseController', () => ({
+  SpaceMouseController: (props: Record<string, unknown>) => {
+    spaceMouseState.props = props;
+    return null;
+  },
+}));
+
 vi.mock('@/i18n', async () => await import('@/test/mocks/i18nEcho'));
 
 const reducedMotion = vi.hoisted(() => ({ value: false }));
@@ -66,6 +74,7 @@ describe('GlbViewer', () => {
     gltfState.impl = () => ({ scene: new Group() });
     gltfState.calls = [];
     gltfState.orbitProps = {};
+    spaceMouseState.props = {};
     reducedMotion.value = false;
   });
 
@@ -181,5 +190,15 @@ describe('GlbViewer', () => {
   it('lets callers disable auto-rotate', () => {
     render(<GlbViewer {...defaultProps} autoRotate={false} />);
     expect(gltfState.orbitProps.autoRotate).toBe(false);
+  });
+
+  it('does not claim the SpaceMouse by default', () => {
+    render(<GlbViewer {...defaultProps} />);
+    expect(spaceMouseState.props.modal).toBe(false);
+  });
+
+  it('claims the SpaceMouse when hosted in a modal, so the covered canvas stops moving', () => {
+    render(<GlbViewer {...defaultProps} modal />);
+    expect(spaceMouseState.props.modal).toBe(true);
   });
 });

--- a/src/shared/components/GlbViewer/GlbViewer.tsx
+++ b/src/shared/components/GlbViewer/GlbViewer.tsx
@@ -31,6 +31,13 @@ interface GlbViewerProps {
   autoRotate?: boolean;
   /** Fires once when the model has loaded and the poster is fading out. */
   onModelReady?: () => void;
+  /**
+   * Claim SpaceMouse priority over any canvas mounted behind this one. Set it
+   * when the viewer lives in a dialog layered over another 3D canvas (the
+   * example preview over the designer), or the puck keeps driving the covered
+   * canvas instead of this one.
+   */
+  modal?: boolean;
   className?: string;
   children?: ReactNode;
 }
@@ -95,6 +102,7 @@ export function GlbViewer({
   loadBehavior = 'auto',
   autoRotate = true,
   onModelReady,
+  modal = false,
   className,
   children,
 }: GlbViewerProps) {
@@ -144,7 +152,7 @@ export function GlbViewer({
             enableDamping
             makeDefault
           />
-          <SpaceMouseController />
+          <SpaceMouseController modal={modal} />
         </Canvas>
       ) : null}
 


### PR DESCRIPTION
## What

While verifying the SpaceMouse fixes for #4041, I found one remaining instance of the "puck drives the wrong canvas" defect that #4057 fixed for the bin-import, STL-import, and label-plate dialogs.

`Example3DViewer` renders inside `ExamplePreviewOverlay` (a `Dialog.Root`) layered over the designer's live `PreviewCanvas`, but its `GlbViewer` mounted `SpaceMouseController` without a modal claim. With the background designer canvas still registered on the bus, the puck kept driving the covered preview until the user happened to hover the dialog canvas, exactly the reported symptom.

## Fix

- Add a `modal` prop to `GlbViewer` that forwards to `SpaceMouseController` (default `false`).
- Set it where the viewer renders inside the preview dialog (`Example3DViewer`).
- The community detail page usage (`DesignMediaPanel`) stays non-modal, since no other canvas competes for the puck there.

This is the last GlbViewer-in-a-modal that was missing the claim; the three dialogs #4057 targeted are already correctly wired.

## Testing

- `GlbViewer` forwards `modal` to `SpaceMouseController` (default off; on when set).
- `Example3DViewer` claims the puck (it always renders in the preview dialog).
- `pnpm run test:run src/shared/spacemouse` green (72), affected component tests green (20), `pnpm run typecheck` clean.

Refs #4041

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

