### PR TITLE
test(generation): cover multi-compartment finger-scoop exports

### DIFF
--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.scoops.test.ts.snap
@@ -20,6 +20,14 @@ exports[`scoop flat base > 2×2 flat base thin-wall scoop (corner clip active) 1
 
 exports[`scoop flat base > 2×2 tray-bottom (lid) base scoop with lip 1`] = `1638`;
 
+exports[`scoop multi-compartment > 2×2 grid front scoop (flat base) 1`] = `4920`;
+
+exports[`scoop multi-compartment > 2×2 grid front scoop (standard base + lip) 1`] = `6888`;
+
+exports[`scoop multi-compartment > 2×2 grid left scoop (interior column span-ends) 1`] = `6848`;
+
+exports[`scoop multi-compartment > irregular grid (tall column + 2 stacked) front scoop 1`] = `6378`;
+
 exports[`scoop side > 6×1 bin scooped on the long wall 1`] = `4804`;
 
 exports[`scoop side > left scoop across 2 columns (outer vs interior) 1`] = `6088`;

--- a/src/features/generation/worker/generators/binGenerator.export.scoops.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.export.scoops.test.ts
@@ -1,5 +1,19 @@
 // @vitest-environment node
 import { runExportIntegrity } from './__kernel-tests__/exportIntegrityRunner';
-import { scoop, scoopTwoVariable, scoopFlatBase, scoopLipInteraction } from './scenarios/scoops';
+import {
+  scoop,
+  scoopTwoVariable,
+  scoopSides,
+  scoopFlatBase,
+  scoopLipInteraction,
+  scoopMultiCompartment,
+} from './scenarios/scoops';
 
-runExportIntegrity([...scoop, ...scoopTwoVariable, ...scoopFlatBase, ...scoopLipInteraction]);
+runExportIntegrity([
+  ...scoop,
+  ...scoopTwoVariable,
+  ...scoopSides,
+  ...scoopFlatBase,
+  ...scoopLipInteraction,
+  ...scoopMultiCompartment,
+]);

--- a/src/features/generation/worker/generators/binGenerator.scenario.scoops.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.scoops.test.ts
@@ -6,6 +6,7 @@ import {
   scoopSides,
   scoopFlatBase,
   scoopLipInteraction,
+  scoopMultiCompartment,
 } from './scenarios/scoops';
 
 runScenarios([
@@ -14,4 +15,5 @@ runScenarios([
   ...scoopSides,
   ...scoopFlatBase,
   ...scoopLipInteraction,
+  ...scoopMultiCompartment,
 ]);

--- a/src/features/generation/worker/generators/scenarios/index.ts
+++ b/src/features/generation/worker/generators/scenarios/index.ts
@@ -13,7 +13,14 @@ import { binStyles } from './binStyles';
 import { heightVariations } from './heights';
 import { wallThickness } from './wallThickness';
 import { compartments } from './compartments';
-import { scoop, scoopTwoVariable, scoopSides, scoopFlatBase, scoopLipInteraction } from './scoops';
+import {
+  scoop,
+  scoopTwoVariable,
+  scoopSides,
+  scoopFlatBase,
+  scoopLipInteraction,
+  scoopMultiCompartment,
+} from './scoops';
 import { labelTabs } from './labelTabs';
 import { inserts, multipleInserts } from './inserts';
 import { solidCutouts } from './solidCutouts';
@@ -108,4 +115,5 @@ export const ALL_SCENARIOS: readonly ScenarioCase[] = [
   ...cutoutRepeatOverlap,
   ...cutoutLean,
   ...variantOverrides,
+  ...scoopMultiCompartment,
 ];

--- a/src/features/generation/worker/generators/scenarios/scoops.ts
+++ b/src/features/generation/worker/generators/scenarios/scoops.ts
@@ -126,3 +126,43 @@ export const scoopLipInteraction: ScenarioCase[] = [
     }
   ),
 ];
+
+// Multi-compartment GRID scoops (cols > 1 AND rows > 1): the bento-box shape.
+// scoopSides only reaches cols > 1 with a single row, and scoopLipInteraction a
+// single column with two rows, so a scoop rising from an INTERIOR divider (a
+// back-row compartment) with INTERIOR span-ends on both sides went through
+// export integrity here for the first time. Covers the socketed default (where
+// the deferred-socket fuse heals the floor) and a flat socketless base (which
+// does not), plus an irregular layout mixing a tall column with two stacked
+// compartments.
+export const scoopMultiCompartment: ScenarioCase[] = [
+  defineScenario('scoop multi-compartment', '2×2 grid front scoop (standard base + lip)', {
+    params: {
+      scoop: { enabled: true, radius: 'auto' },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 1.2 },
+    },
+  }),
+  defineScenario('scoop multi-compartment', '2×2 grid front scoop (flat base)', {
+    params: {
+      scoop: { enabled: true, radius: 'auto' },
+      base: { ...DEFAULT_BIN_PARAMS.base, style: 'flat' },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 1.2 },
+    },
+  }),
+  defineScenario('scoop multi-compartment', '2×2 grid left scoop (interior column span-ends)', {
+    params: {
+      scoop: { enabled: true, radius: 'auto', side: 'left' },
+      compartments: { cols: 2, rows: 2, cells: [0, 1, 2, 3], thickness: 1.2 },
+    },
+  }),
+  defineScenario(
+    'scoop multi-compartment',
+    'irregular grid (tall column + 2 stacked) front scoop',
+    {
+      params: {
+        scoop: { enabled: true, radius: 'auto' },
+        compartments: { cols: 2, rows: 2, cells: [0, 1, 0, 2], thickness: 1.2 },
+      },
+    }
+  ),
+];


### PR DESCRIPTION
## What

Closes a coverage gap in the finger-scoop export-integrity suite.

`binGenerator.export.scoops.test.ts` exercised `scoop`, `scoopTwoVariable`, `scoopFlatBase` and `scoopLipInteraction`, but never `scoopSides`, so the multi-compartment scoop cases only ran through the structural scenario runner. No scenario put a true grid (more than one column AND more than one row) through export at all: `scoopSides` is multi-column single-row, `scoopLipInteraction` is single-column two-row.

## Changes

- Wire `scoopSides` into the export-integrity test.
- Add a `scoopMultiCompartment` group (2x2 grid front scoop, the same on a flat socketless base, a 2x2 grid left scoop, and an irregular tall-column-plus-two-stacked layout) to both the scenario runner and the export test.

These assert that the interior-divider scoop welds (#4014) and the socketless floor junction stay watertight and 2-manifold on export, across the bento-box shapes.

## Context

Came out of investigating #4068 (finger scoops reported as malformed on a bento STEP export). That specific report could not be reproduced on `main` across a wide range of bento layouts, so this does not fix it; it hardens the surrounding area and documents that these exports are currently watertight. Only the occt-wasm scenario snapshot changed; the brepkit parity artifact is left to its own track.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

