### PR TITLE
fix(spacemouse): raise navigation speed and tuning headroom

### DIFF
--- a/src/shared/spacemouse/constants.ts
+++ b/src/shared/spacemouse/constants.ts
@@ -14,10 +14,14 @@ export const RAW_AXIS_FULL_SCALE = 350;
 /** Fraction of full scale below which an axis is treated as centered (jitter). */
 export const AXIS_DEADZONE = 0.06;
 
-/** Per-second rates at full deflection, before user speed/sensitivity scaling. */
-export const TRANSLATE_RATE = 1.2; // fraction of camera-to-target distance / s
-export const ZOOM_RATE = 1.6; // e-fold dolly factor / s
-export const ORBIT_RATE = 2.2; // radians / s
+/**
+ * Per-second rates at full deflection, before user speed/sensitivity scaling.
+ * The mapping is linear with no acceleration curve, so these stay brisk enough
+ * that a normal partial push keeps pace with CAD-app navigation.
+ */
+export const TRANSLATE_RATE = 2.0; // fraction of camera-to-target distance / s
+export const ZOOM_RATE = 2.6; // e-fold dolly factor / s
+export const ORBIT_RATE = 3.6; // radians / s
 
 /** Keeps the orbit from tumbling over the pole, matching OrbitControls' clamp. */
 export const MIN_POLAR = 0.01;
@@ -35,8 +39,8 @@ export const DEFAULT_SETTINGS: SpaceMouseSettings = {
   },
 };
 
-export const SENSITIVITY_RANGE = { min: 0.1, max: 3, step: 0.1 } as const;
-export const SPEED_RANGE = { min: 0, max: 2, step: 0.05 } as const;
+export const SENSITIVITY_RANGE = { min: 0.1, max: 5, step: 0.1 } as const;
+export const SPEED_RANGE = { min: 0, max: 3, step: 0.05 } as const;
 
 /** 3Dconnexion (0x256f) and the Logitech-era vendor id (0x046d) its pucks use. */
 export const SPACEMOUSE_VENDOR_IDS = [0x256f, 0x046d] as const;

--- a/src/shared/spacemouse/constants.ts
+++ b/src/shared/spacemouse/constants.ts
@@ -14,11 +14,7 @@ export const RAW_AXIS_FULL_SCALE = 350;
 /** Fraction of full scale below which an axis is treated as centered (jitter). */
 export const AXIS_DEADZONE = 0.06;
 
-/**
- * Per-second rates at full deflection, before user speed/sensitivity scaling.
- * The mapping is linear with no acceleration curve, so these stay brisk enough
- * that a normal partial push keeps pace with CAD-app navigation.
- */
+/** Per-second rates at full deflection, before user speed/sensitivity scaling. */
 export const TRANSLATE_RATE = 2.0; // fraction of camera-to-target distance / s
 export const ZOOM_RATE = 2.6; // e-fold dolly factor / s
 export const ORBIT_RATE = 3.6; // radians / s


### PR DESCRIPTION
Addresses the "movement is rather slow" report on #4041, after the direction/focus fixes landed and the controls otherwise felt correct.

## Why it felt slow

The puck-to-camera mapping is linear (deadzone, then a flat gain), whereas the 3Dconnexion driver applies a rising acceleration curve. Same top speed, but a normal partial push moves far less, so it trails Fusion/PrusaSlicer at the default 1x.

## Change

Constants only, no behavior wiring touched:

- Base rates up ~1.65x so the out-of-box 1x is brisker: pan 1.2 to 2.0, zoom 1.6 to 2.6, orbit 2.2 to 3.6 (per second at full deflection).
- Tuning ceilings widened for faster hardware: sensitivity 3 to 5, per-family speed 2 to 3. Max effective gain goes from ~6x to ~15x, so if 1.65x still trails on a given device the sliders can cover it without another code change.

Defaults stay at 1x (neutral), so anyone who already tuned the sliders scales up proportionally rather than resetting.

## Testing

- `mapping.test.ts` asserts proportionality (`far ≈ near × 10`, `sensitivity 2 ≈ base × 2`), not absolute rates, so it stays green. 17 spacemouse tests pass.
- Typecheck clean.
- Not hardware-verified: I don't have a SpaceMouse. tg73 on #4041 is the one who can confirm the new default feels right once this deploys.

Leaves #4041 open. The larger ask there, delegating to the 3Dconnexion driver via its web SDK so the in-app controls can retire, is a separate transport change gated on an external unknown (whether our origin can talk to the local 3DxWare service), tracked separately.

https://claude.ai/code/session_01NNC9NnXiTpyMFTRVMkjMHk

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

