### PR TITLE
fix(bin-designer): price scoop ramps as the material they add

### DIFF
--- a/src/features/bin-designer/utils/printEstimates.test.ts
+++ b/src/features/bin-designer/utils/printEstimates.test.ts
@@ -201,7 +201,8 @@ describe('printEstimates', () => {
       expect(withLabel.volumeMm3).toBeGreaterThan(withoutLabel.volumeMm3);
     });
 
-    it('scoop removes volume when enabled', () => {
+    it('scoop adds volume when enabled (#4085)', () => {
+      // A ramp is fused into the wall-floor corner; it is material, not a cut.
       const withScoop = estimatePrint({
         ...DEFAULT_BIN_PARAMS,
         scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true },
@@ -210,12 +211,13 @@ describe('printEstimates', () => {
         ...DEFAULT_BIN_PARAMS,
         scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: false },
       });
-      expect(withScoop.volumeMm3).toBeLessThan(withoutScoop.volumeMm3);
+      expect(withScoop.volumeMm3).toBeGreaterThan(withoutScoop.volumeMm3);
     });
 
-    it('straight scoop removes less material than a curved scoop of the same size', () => {
-      // Curved void is π/4·run·height (≈0.785); straight void is ½·run·height.
-      // The curved scoop carves away more, so it leaves less printed material.
+    it('a straight scoop adds more material than a curved one of the same size', () => {
+      // Under a straight bevel the whole triangle (½·run·height) is filled;
+      // under a curved arc only the wedge outside the quarter-ellipse
+      // ((1 − π/4)·run·height ≈ 0.215).
       const base = {
         ...DEFAULT_BIN_PARAMS,
         scoop: { ...DEFAULT_BIN_PARAMS.scoop, enabled: true, radius: 12, run: 12 },

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -5,7 +5,7 @@
  * then derives filament usage and print time estimates.
  *
  * Volume is computed as:
- *   shell + base socket + stacking lip + dividers + label tabs − scoops
+ *   shell + base socket + stacking lip + dividers + label tabs + scoop ramps
  *
  * This avoids expensive mesh-based volume integration.
  */
@@ -38,10 +38,15 @@ import {
   detachableFeetVolume,
   type PrintSettings,
 } from '@/shared/printSettings';
-import { hasDetachableFeet } from '@/shared/types/bin';
+import {
+  compartmentHasTiltedEdge,
+  hasDetachableFeet,
+  isRectangularCompartment,
+} from '@/shared/types/bin';
 import { footKind, resolveDetachableFeet } from '@/shared/utils/detachableFeetPlan';
 import {
   resolveScoopProfile,
+  resolveScoopPlacement,
   resolveScoopSide,
   computeLipOffset,
   computeInteriorHeight,
@@ -138,7 +143,7 @@ export function formatFilament(meters: number): string {
  * base geometry. Feature deltas are layered on top:
  *   + Divider walls
  *   + Label tabs
- *   − Scoops (removes material)
+ *   + Scoop ramps (fill the wall-floor corner of each compartment)
  *   − Honeycomb wall reduction
  *
  * (The previous local hollow-box model treated the bottom 7mm as a solid slab,
@@ -247,9 +252,9 @@ function computeBinVolume(params: BinParams): number {
     volume += computeLabelTabVolume(params, outerW, outerD, wallThickness);
   }
 
-  // Scoops (remove material from compartment front walls)
+  // Scoop ramps are fused into the wall-floor corner of each compartment.
   if (isFeatureActive(params, 'scoop')) {
-    volume -= computeScoopVolume(params, outerW, outerD, wallThickness);
+    volume += computeScoopVolume(params, outerW, outerD);
   }
 
   // Wall pattern: perforation reduces wall material (all pattern types).
@@ -270,7 +275,7 @@ function computeBinVolume(params: BinParams): number {
     volume += (outerW * outerD - innerW * innerD) * collarMm;
   }
 
-  // Volume cannot be negative (scoops on tiny bins)
+  // Volume cannot be negative (a wall pattern on a tiny bin)
   return Math.max(0, volume);
 }
 /**
@@ -607,67 +612,115 @@ function findCollidingFrontIds(
 }
 
 /**
- * Volume removed by scoop ramp (negative contribution).
- *
- * Each scoop's cross-section is a concave quarter-ellipse (curved) or a right
- * triangle (straight), extruded across the compartment width.
+ * Material under one ramp's profile between the wall and `a` mm out along the
+ * run: the part a divider's near half swallows when the ramp starts on its
+ * centreline. Curved: the quarter-ellipse arc y = run(1 − cos θ),
+ * z = height(1 − sin θ), so ∫z dy = run·height·[(1 − cos θa) − (θa/2 − sin 2θa/4)].
  */
-function computeScoopVolume(
-  params: BinParams,
-  outerW: number,
-  outerD: number,
-  wallThickness: number
+function rampAreaWithin(
+  profile: { run: number; height: number; style: string },
+  a: number
 ): number {
-  const { rows, cols } = params.compartments;
+  const reach = Math.min(Math.max(0, a), profile.run);
+  if (profile.style !== 'curved') return profile.height * reach * (1 - reach / (2 * profile.run));
+  const theta = Math.acos(1 - reach / profile.run);
+  return (
+    profile.run * profile.height * (1 - Math.cos(theta) - (theta / 2 - Math.sin(2 * theta) / 4))
+  );
+}
 
-  const innerW = outerW - 2 * wallThickness;
-  const innerD = outerD - 2 * wallThickness;
-  const colWidth = innerW / cols;
-  const rowDepth = innerD / rows;
+/**
+ * Cross-section (mm²) of the stacking lip's angled support below the wall top:
+ * the integrated lip's inner loft steps in from the wall face 2.65mm under the
+ * top to the full overhang inset 1.2mm under it, then runs vertical. A lipped
+ * outer ramp's strip climbs that same band flush with the lip base, so the
+ * support's area is material the shell already prices. Mirrors
+ * `integratedLipBuilder` (LIP_EXTENSION, FOOT: cross-feature import not allowed).
+ */
+function lipSupportArea(wallThickness: number): number {
+  const LIP_EXTENSION = 1.2;
+  const FOOT = 0.05;
+  const top = Math.max(0, GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER - wallThickness);
+  const foot = Math.max(0, LIP_EXTENSION - wallThickness);
+  const rampHeight = GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER - LIP_EXTENSION - FOOT;
+  return ((foot + top) / 2) * rampHeight + top * (LIP_EXTENSION + GRIDFINITY.LIP_OVERLAP);
+}
+
+/**
+ * Material the scoop ramps add: the wedge under each arc, spanning the merged
+ * extent of every compartment the builder actually ramps. Mirrors
+ * `buildScoopRamps` compartment by compartment: standard style only, one ramp
+ * per rectangular, untilted compartment on the chosen side, placed on the
+ * design's own wall thickness (the style constant above is what the shell model
+ * was calibrated on; the pipeline builds `params.wallThickness`). A curved arc
+ * leaves (1 − π/4)·run·height under it, a straight bevel half the rectangle;
+ * against a lipped outer wall the profile also climbs to the wall top across
+ * `lipOffset`, less the lip support it lands inside. A ramp on an interior
+ * side starts on the divider's centreline
+ * and its span ends on the side dividers' centrelines, so the half-thickness
+ * it shares with each divider is already priced there and comes off here.
+ *
+ * Pricing one representative grid cell times cols × rows, and subtracting it,
+ * put a 5x5 bento bin at 5 g against 210 g sliced.
+ */
+function computeScoopVolume(params: BinParams, outerW: number, outerD: number): number {
+  if (params.style !== 'standard') return 0;
+  const { rows, cols, cells, thickness } = params.compartments;
+  const wall = params.wallThickness;
+
+  const innerW = outerW - 2 * wall;
+  const innerD = outerD - 2 * wall;
 
   const hasLip = params.base.stackingLip;
   const totalH = params.height * params.heightUnitMm;
   const boxWallHeight = baseWallHeight(params.base, totalH);
-  const { wallHeight, interiorHeight } = scoopFrameHeights(
+  const frame = scoopFrameHeights(
     boxWallHeight,
     computeInteriorHeight(boxWallHeight, hasLip, GRIDFINITY.LIP_SMALL_TAPER),
-    binFloorMm(wallThickness)
+    binFloorMm(wall)
   );
   const lipTaperWidth = GRIDFINITY.LIP_SMALL_TAPER + GRIDFINITY.LIP_BIG_TAPER;
-
-  // Front/back scoops run along the row axis, left/right along the column axis.
   const side = resolveScoopSide(params.scoop);
-  const runsAlongY = side === 'front' || side === 'back';
-  const span = runsAlongY ? colWidth : rowDepth;
-  const depth = runsAlongY ? rowDepth : colWidth;
+  const alongX = side === 'front' || side === 'back';
+  const grid = { cols, rows, innerW, innerD };
 
-  // Use a representative compartment: it only touches the outer wall on the
-  // scoop's axis when the bin is a single track along that axis.
-  const isRepresentativeOuter = runsAlongY ? rows === 1 : cols === 1;
-  const lipOffset = computeLipOffset(hasLip, isRepresentativeOuter, lipTaperWidth, wallThickness);
-  const profile = resolveScoopProfile(
-    params.scoop,
-    span,
-    depth,
-    isRepresentativeOuter,
-    hasLip,
-    wallHeight,
-    interiorHeight,
-    lipOffset
-  );
-  if (!profile) return 0;
+  let volume = 0;
+  const seen = new Set<number>();
+  for (const compId of cells) {
+    if (seen.has(compId)) continue;
+    seen.add(compId);
+    if (compartmentHasTiltedEdge(params.compartments, compId)) continue;
+    if (!isRectangularCompartment(params.compartments, compId)) continue;
+    const bounds = getCompartmentBounds(params.compartments, compId);
+    if (!bounds) continue;
 
-  const numScoops = cols * rows;
+    const { span, depth, isOuter } = resolveScoopPlacement(side, bounds, grid);
+    const lipOffset = computeLipOffset(hasLip, isOuter, lipTaperWidth, wall);
+    const profile = resolveScoopProfile(
+      params.scoop,
+      span,
+      depth,
+      isOuter,
+      hasLip,
+      frame.wallHeight,
+      frame.interiorHeight,
+      lipOffset
+    );
+    if (!profile) continue;
 
-  // Cross-section area × span. Curved: quarter-ellipse (π/4 × run × height);
-  // straight: right triangle (½ × run × height).
-  const area =
-    profile.style === 'curved'
-      ? (Math.PI / 4) * profile.run * profile.height
-      : 0.5 * profile.run * profile.height;
-  const volumePerScoop = area * span;
-
-  return numScoops * volumePerScoop;
+    const wedge =
+      profile.style === 'curved'
+        ? (1 - Math.PI / 4) * profile.run * profile.height
+        : 0.5 * profile.run * profile.height;
+    const buriedBack = isOuter ? 0 : rampAreaWithin(profile, thickness / 2);
+    const lipStrip = lipOffset > 0 ? lipOffset * frame.wallHeight - lipSupportArea(wall) : 0;
+    const dividerEnds = alongX
+      ? (bounds.minCol > 0 ? 1 : 0) + (bounds.maxCol < cols - 1 ? 1 : 0)
+      : (bounds.minRow > 0 ? 1 : 0) + (bounds.maxRow < rows - 1 ? 1 : 0);
+    const exposedSpan = Math.max(0, span - (thickness / 2) * dividerEnds);
+    volume += (wedge - buriedBack + lipStrip) * exposedSpan;
+  }
+  return volume;
 }
 /**
  * Approximate open-area fraction of each pattern at neutral scale — the share

--- a/src/features/bin-designer/utils/printEstimates.ts
+++ b/src/features/bin-designer/utils/printEstimates.ts
@@ -275,7 +275,6 @@ function computeBinVolume(params: BinParams): number {
     volume += (outerW * outerD - innerW * innerD) * collarMm;
   }
 
-  // Volume cannot be negative (a wall pattern on a tiny bin)
   return Math.max(0, volume);
 }
 /**
@@ -656,12 +655,9 @@ function lipSupportArea(wallThickness: number): number {
  * leaves (1 − π/4)·run·height under it, a straight bevel half the rectangle;
  * against a lipped outer wall the profile also climbs to the wall top across
  * `lipOffset`, less the lip support it lands inside. A ramp on an interior
- * side starts on the divider's centreline
- * and its span ends on the side dividers' centrelines, so the half-thickness
- * it shares with each divider is already priced there and comes off here.
- *
- * Pricing one representative grid cell times cols × rows, and subtracting it,
- * put a 5x5 bento bin at 5 g against 210 g sliced.
+ * side starts on the divider's centreline and its span ends on the side
+ * dividers' centrelines, so the half-thickness it shares with each divider is
+ * already priced there and comes off here.
  */
 function computeScoopVolume(params: BinParams, outerW: number, outerD: number): number {
   if (params.style !== 'standard') return 0;

--- a/src/features/generation/worker/generators/printEstimates.scoop.scenario.test.ts
+++ b/src/features/generation/worker/generators/printEstimates.scoop.scenario.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+/**
+ * Calibration check for the scoop term in `printEstimates`.
+ *
+ * A scoop is a ramp fused into the wall-floor corner of each compartment, so
+ * it ADDS material: the wedge under its arc, across the compartment's merged
+ * extent. The estimator used to subtract a quarter-ellipse per grid cell, which
+ * priced the reported 5x5 bento bin at 5 g against 210 g sliced (#4085). The
+ * expected values come from `meshVolume` of the generated bin, never from the
+ * estimator's own arithmetic.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { DEFAULT_BIN_PARAMS } from '@/shared/constants/bin';
+import type { BinParams } from '@/shared/types/bin';
+import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
+import { meshVolume } from './__kernel-tests__/meshAssertions';
+import { estimatePrint } from '@/features/bin-designer/utils/printEstimates';
+
+beforeAll(async () => {
+  await initBrepjs();
+}, 30000);
+
+/** Residual allowed on the ramp material alone (estimate delta vs measured
+ *  delta). The model prices the wedge, the lip strip less the lip's angled
+ *  support, and the divider halves the ramp shares; the worst case measured
+ *  is 2.1%. */
+const MAX_RAMP_RESIDUAL = 0.05;
+/** Residual allowed on the whole bin where the shell model is calibrated. */
+const MAX_BIN_RESIDUAL = 0.05;
+
+/** The reported layout: a full-width front tray, a deep left bay, two
+ *  double-width compartments and a quad, so ramps span merged extents. */
+const BENTO_CELLS = [0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 1, 6, 6, 7, 7, 1, 8, 8, 8, 8, 9, 10, 11, 12, 13];
+
+const rowsOf = (n: number): number[] => Array.from({ length: n }, (_, i) => i);
+const noLip = { ...DEFAULT_BIN_PARAMS.base, stackingLip: false };
+const compartments = (cols: number, rows: number, cells: number[]): BinParams['compartments'] => ({
+  ...DEFAULT_BIN_PARAMS.compartments,
+  cols,
+  rows,
+  cells,
+});
+
+function bin(over: Partial<BinParams> = {}): BinParams {
+  return { ...DEFAULT_BIN_PARAMS, width: 2, depth: 2, height: 3, style: 'standard', ...over };
+}
+
+function bento(over: Partial<BinParams> = {}): BinParams {
+  return bin({
+    width: 5,
+    depth: 5,
+    height: 4,
+    compartments: compartments(5, 5, BENTO_CELLS),
+    ...over,
+  });
+}
+
+const scooped = (p: BinParams, over: Partial<BinParams['scoop']> = {}): BinParams => ({
+  ...p,
+  scoop: { ...p.scoop, enabled: true, radius: 'auto', style: 'curved', ...over },
+});
+const unscooped = (p: BinParams): BinParams => ({ ...p, scoop: { ...p.scoop, enabled: false } });
+
+describe('print estimate — scoop ramps', () => {
+  const cases: Array<{ name: string; params: BinParams }> = [
+    { name: '2x2x3u, one compartment, lipped', params: scooped(bin()) },
+    { name: '2x2x3u, one compartment, no lip', params: scooped(bin({ base: noLip })) },
+    { name: '2x2x3u, thin 0.95 wall', params: scooped(bin({ wallThickness: 0.95 })) },
+    {
+      name: '2x2x3u, two rows (one interior ramp)',
+      params: scooped(bin({ compartments: compartments(1, 2, rowsOf(2)) })),
+    },
+    {
+      name: '2x2x3u, 2x2 grid, left, straight',
+      params: scooped(bin({ compartments: compartments(2, 2, rowsOf(4)) }), {
+        side: 'left',
+        style: 'straight',
+      }),
+    },
+    { name: '2x2x6u, tall', params: scooped(bin({ height: 6 })) },
+    { name: '5x5x4u, one compartment', params: scooped(bin({ width: 5, depth: 5, height: 4 })) },
+    {
+      name: '5x5x4u, fixed 10mm ramp',
+      params: scooped(bin({ width: 5, depth: 5, height: 4 }), { radius: 10, run: 10 }),
+    },
+    {
+      name: '5x5x4u, five full-width rows',
+      params: scooped(
+        bin({ width: 5, depth: 5, height: 4, compartments: compartments(1, 5, rowsOf(5)) })
+      ),
+    },
+    { name: '5x5x4u bento (#4085)', params: scooped(bento()) },
+    {
+      name: '5x5x4u bento, detachable feet',
+      params: scooped(bento({ base: { ...DEFAULT_BIN_PARAMS.base, feet: 'detachable' } })),
+    },
+  ];
+
+  it.each(cases)(
+    'prices the ramps within 5% of the generated ones for $name',
+    ({ params }) => {
+      const generate = getGenerateBin();
+      const measured =
+        meshVolume(generate(params, undefined, true)) -
+        meshVolume(generate(unscooped(params), undefined, true));
+      const estimated =
+        estimatePrint(params).volumeMm3 - estimatePrint(unscooped(params)).volumeMm3;
+      expect(measured).toBeGreaterThan(0);
+      expect(estimated).toBeGreaterThan(0);
+      const residual = Math.abs(estimated - measured) / measured;
+      expect(residual, `estimated +${estimated} vs measured +${Math.round(measured)}`).toBeLessThan(
+        MAX_RAMP_RESIDUAL
+      );
+    },
+    180000
+  );
+
+  it('prices the reported bento bin within 5% of its generated volume', () => {
+    const params = scooped(bento());
+    const measured = meshVolume(getGenerateBin()(params, undefined, true));
+    const estimated = estimatePrint(params).volumeMm3;
+    const residual = Math.abs(estimated - measured) / measured;
+    expect(residual, `estimated ${estimated} vs measured ${Math.round(measured)}`).toBeLessThan(
+      MAX_BIN_RESIDUAL
+    );
+  }, 180000);
+});


### PR DESCRIPTION
## Summary

The export dialog priced the reported 5×5 bento bin at 5.1 g against 210 g in PrusaSlicer (#4085). Bisecting the design by feature put the whole gap on the scoop term: it subtracted a quarter-ellipse (π/4 · run · height) per grid cell, about 155 k mm³ on this bin, while the generated mesh shows scoops *add* about 39 k mm³. A scoop is a ramp fused into the wall-floor corner; the material is the wedge under its arc.

- `computeScoopVolume` now mirrors `buildScoopRamps` compartment by compartment: standard style only, one ramp per rectangular untilted compartment on the chosen side, spanning the merged extent, placed on the design's `wallThickness` (the pipeline's value; the estimator's style constant is 0.95 mm) with the profile resolved from the floor-relative frame.
- Curved arc: (1 − π/4) · run · height. Straight bevel: half the rectangle. A lipped outer ramp also climbs the wall top across `lipOffset`, less the lip's angled support it lands inside (mirrors `integratedLipBuilder`). An interior ramp starts on the divider's centreline and ends on the side dividers' centrelines, so the halves it shares with them come off.
- Sign flipped at the call site; header and unit tests updated.

## Test plan

- [x] New `printEstimates.scoop.scenario.test.ts` measures eleven generated bins (single and merged compartments, lipped and not, thin wall, straight and left-side ramps, fixed radius, tall bin, the reported bento with integral and detachable feet): every ramp delta within 5% of the mesh (worst measured 2.1%), the reported bin within 5% overall (measured 0.6%)
- [x] `printEstimates.test.ts` scoop cases inverted to "adds material"
- [x] Full `src/features/bin-designer` suite, `printEstimates.solidFill.scenario`, typecheck, eslint

Fixes #4085

https://claude.ai/code/session_01QofuY5UDMjJzSKHUjE2unu

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

