### PR TITLE
fix(spacemouse): answer every driver read even when an accessor throws

### DIFF
--- a/src/shared/spacemouse/navlib/navlibClient.test.ts
+++ b/src/shared/spacemouse/navlib/navlibClient.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const captureException = vi.fn();
+vi.mock('@/shared/analytics/posthog/eventsErrors', () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+}));
+
+import { guardRead, guardWrite } from './navlibClient';
+
+describe('navlib wire-boundary guards', () => {
+  beforeEach(() => {
+    captureException.mockClear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('passes a value through and substitutes the fallback for null or undefined', () => {
+    expect(
+      guardRead(
+        'a',
+        () => [1, 2],
+        () => [0]
+      )()
+    ).toEqual([1, 2]);
+    expect(
+      guardRead(
+        'b',
+        () => null,
+        () => [0]
+      )()
+    ).toEqual([0]);
+    expect(
+      guardRead(
+        'c',
+        () => undefined,
+        () => 'x'
+      )()
+    ).toBe('x');
+    expect(
+      guardRead(
+        'd',
+        () => false,
+        () => true
+      )()
+    ).toBe(false);
+  });
+
+  it('answers with the fallback when the read throws, and reports once per property', () => {
+    const read = guardRead(
+      'hit.lookat',
+      () => {
+        throw new TypeError("Cannot read properties of null (reading 'near')");
+      },
+      () => null
+    );
+    expect(read()).toBeNull();
+    expect(read()).toBeNull();
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0][1]).toMatchObject({
+      boundary: 'spacemouse-navlib',
+      property: 'hit.lookat',
+    });
+  });
+
+  it('swallows a throwing write', () => {
+    const write = guardWrite<number>('transaction', () => {
+      throw new Error('boom');
+    });
+    expect(() => write(0)).not.toThrow();
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/spacemouse/navlib/navlibClient.test.ts
+++ b/src/shared/spacemouse/navlib/navlibClient.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const captureException = vi.fn();
 vi.mock('@/shared/analytics/posthog/eventsErrors', () => ({
@@ -11,6 +11,10 @@ describe('navlib wire-boundary guards', () => {
   beforeEach(() => {
     captureException.mockClear();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('passes a value through and substitutes the fallback for null or undefined', () => {

--- a/src/shared/spacemouse/navlib/navlibClient.test.ts
+++ b/src/shared/spacemouse/navlib/navlibClient.test.ts
@@ -72,4 +72,29 @@ describe('navlib wire-boundary guards', () => {
     expect(() => write(0)).not.toThrow();
     await vi.waitFor(() => expect(captureException).toHaveBeenCalledTimes(1));
   });
+
+  it('lets a later failure report again when the error module fails to load', async () => {
+    vi.resetModules();
+    vi.doMock('@/shared/analytics/posthog/eventsErrors', () => {
+      throw new Error('chunk load failed');
+    });
+    const fresh = await import('./navlibClient');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const read = fresh.guardRead(
+      'view.fov',
+      () => {
+        throw new Error('boom');
+      },
+      () => 1
+    );
+    expect(read()).toBe(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    // Once the rejected import settles the property is released, so a retry
+    // warns again instead of staying silent for the rest of the session.
+    await vi.waitFor(() => {
+      read();
+      expect(warn).toHaveBeenCalledTimes(2);
+    });
+    vi.doUnmock('@/shared/analytics/posthog/eventsErrors');
+  });
 });

--- a/src/shared/spacemouse/navlib/navlibClient.test.ts
+++ b/src/shared/spacemouse/navlib/navlibClient.test.ts
@@ -78,23 +78,27 @@ describe('navlib wire-boundary guards', () => {
     vi.doMock('@/shared/analytics/posthog/eventsErrors', () => {
       throw new Error('chunk load failed');
     });
-    const fresh = await import('./navlibClient');
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const read = fresh.guardRead(
-      'view.fov',
-      () => {
-        throw new Error('boom');
-      },
-      () => 1
-    );
-    expect(read()).toBe(1);
-    expect(warn).toHaveBeenCalledTimes(1);
-    // Once the rejected import settles the property is released, so a retry
-    // warns again instead of staying silent for the rest of the session.
-    await vi.waitFor(() => {
-      read();
-      expect(warn).toHaveBeenCalledTimes(2);
-    });
-    vi.doUnmock('@/shared/analytics/posthog/eventsErrors');
+    try {
+      const fresh = await import('./navlibClient');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const read = fresh.guardRead(
+        'view.fov',
+        () => {
+          throw new Error('boom');
+        },
+        () => 1
+      );
+      expect(read()).toBe(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+      // Once the rejected import settles the property is released, so a retry
+      // warns again instead of staying silent for the rest of the session.
+      await vi.waitFor(() => {
+        read();
+        expect(warn).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      vi.doUnmock('@/shared/analytics/posthog/eventsErrors');
+      vi.resetModules();
+    }
   });
 });

--- a/src/shared/spacemouse/navlib/navlibClient.test.ts
+++ b/src/shared/spacemouse/navlib/navlibClient.test.ts
@@ -44,7 +44,7 @@ describe('navlib wire-boundary guards', () => {
     ).toBe(false);
   });
 
-  it('answers with the fallback when the read throws, and reports once per property', () => {
+  it('answers with the fallback when the read throws, and reports once per property', async () => {
     const read = guardRead(
       'hit.lookat',
       () => {
@@ -54,18 +54,18 @@ describe('navlib wire-boundary guards', () => {
     );
     expect(read()).toBeNull();
     expect(read()).toBeNull();
-    expect(captureException).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(captureException).toHaveBeenCalledTimes(1));
     expect(captureException.mock.calls[0][1]).toMatchObject({
       boundary: 'spacemouse-navlib',
       property: 'hit.lookat',
     });
   });
 
-  it('swallows a throwing write', () => {
+  it('swallows a throwing write', async () => {
     const write = guardWrite<number>('transaction', () => {
       throw new Error('boom');
     });
     expect(() => write(0)).not.toThrow();
-    expect(captureException).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(captureException).toHaveBeenCalledTimes(1));
   });
 });

--- a/src/shared/spacemouse/navlib/navlibClient.ts
+++ b/src/shared/spacemouse/navlib/navlibClient.ts
@@ -1,4 +1,3 @@
-import { captureException } from '@/shared/analytics/posthog/eventsErrors';
 import { useSpaceMouseStore } from '../settingsStore';
 import { spaceMouseBus } from '../spaceMouseBus';
 import { buildCommandTree } from './commands';
@@ -97,7 +96,11 @@ function reportOnce(property: string, error: unknown): void {
     `[spacemouse] ${property} accessor threw; answering the driver with a fallback`,
     err
   );
-  captureException(err, { boundary: 'spacemouse-navlib', property });
+  // Loaded on demand: the error module pulls the layout and labs stores into
+  // its graph, which must not become a static dependency of the device layer.
+  void import('@/shared/analytics/posthog/eventsErrors')
+    .then((m) => m.captureException(err, { boundary: 'spacemouse-navlib', property }))
+    .catch(() => {});
 }
 
 export function guardRead<R>(

--- a/src/shared/spacemouse/navlib/navlibClient.ts
+++ b/src/shared/spacemouse/navlib/navlibClient.ts
@@ -100,7 +100,10 @@ function reportOnce(property: string, error: unknown): void {
   // its graph, which must not become a static dependency of the device layer.
   void import('@/shared/analytics/posthog/eventsErrors')
     .then((m) => m.captureException(err, { boundary: 'spacemouse-navlib', property }))
-    .catch(() => {});
+    .catch(() => {
+      // The chunk did not load; let the next failure try to report again.
+      reported.delete(property);
+    });
 }
 
 export function guardRead<R>(

--- a/src/shared/spacemouse/navlib/navlibClient.ts
+++ b/src/shared/spacemouse/navlib/navlibClient.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@/shared/analytics/posthog/eventsErrors';
 import { useSpaceMouseStore } from '../settingsStore';
 import { spaceMouseBus } from '../spaceMouseBus';
 import { buildCommandTree } from './commands';
@@ -79,8 +80,54 @@ function pump(now: number): void {
     });
 }
 
+/**
+ * The 3Dconnexion library calls every accessor straight from its WebSocket
+ * message handler with no try/catch, so an exception here is never answered on
+ * the wire and the driver blocks on its 2 s reply timeout with the puck dead.
+ * Nothing crossing this boundary may throw: a failing accessor is reported once
+ * and the driver gets the value it would see with no canvas.
+ */
+const reported = new Set<string>();
+
+function reportOnce(property: string, error: unknown): void {
+  if (reported.has(property)) return;
+  reported.add(property);
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.warn(
+    `[spacemouse] ${property} accessor threw; answering the driver with a fallback`,
+    err
+  );
+  captureException(err, { boundary: 'spacemouse-navlib', property });
+}
+
+export function guardRead<R>(
+  property: string,
+  read: () => R | null | undefined,
+  fallback: () => R
+): () => R {
+  return () => {
+    try {
+      return read() ?? fallback();
+    } catch (error) {
+      reportOnce(property, error);
+      return fallback();
+    }
+  };
+}
+
+export function guardWrite<A>(property: string, write: (data: A) => void): (data: A) => void {
+  return (data) => {
+    try {
+      write(data);
+    } catch (error) {
+      reportOnce(property, error);
+    }
+  };
+}
+
 function buildClient(): NavlibClient {
   const acc = () => spaceMouseBus.activeNavlib();
+  const point = (): number[] | null => null;
 
   return {
     onConnect() {
@@ -107,55 +154,91 @@ function buildClient(): NavlibClient {
     onStopMotion() {
       stopPump();
     },
-    setTransaction(transaction) {
-      // 0 marks the end of a frame's changes: render the result.
+    // 0 marks the end of a frame's changes: render the result.
+    setTransaction: guardWrite<number>('transaction', (transaction) => {
       if (transaction === 0) acc()?.invalidate();
-    },
-    setActiveCommand(id) {
+    }),
+    setActiveCommand: guardWrite<string>('commands.activeCommand', (id) => {
       const command = commandForId(id);
       if (command) spaceMouseBus.dispatch(command);
-    },
+    }),
 
     // View reads (fall back to safe values when no canvas is active). Fallbacks
     // return fresh arrays so a mutating driver can't corrupt a shared constant.
-    getViewMatrix: () => acc()?.getViewMatrix() ?? IDENTITY.slice(),
-    getPerspective: () => acc()?.getPerspective() ?? true,
-    getViewExtents: () => acc()?.getViewExtents() ?? [-1, -1, -1, 1, 1, 1],
-    getViewTarget: () => acc()?.getViewTarget() ?? [0, 0, 0],
-    getViewRotatable: () => acc()?.getViewRotatable() ?? true,
-    getFov: () => acc()?.getFov() ?? Math.PI / 4,
-    getViewFrustum: () => acc()?.getViewFrustum() ?? [-1, 1, -1, 1, 0.1, 1000],
-    getModelExtents: () => acc()?.getModelExtents() ?? null,
-    getPivotPosition: () => acc()?.getPivotPosition() ?? null,
-    getCoordinateSystem: () => acc()?.getCoordinateSystem() ?? IDENTITY.slice(),
-    getFrontView: () => acc()?.getFrontView() ?? IDENTITY.slice(),
-    getConstructionPlane: () => acc()?.getConstructionPlane() ?? [0, 0, 1, 0],
-    getFloorPlane: () => acc()?.getFloorPlane() ?? [0, 0, 1, 0],
-    getPointerPosition: () => acc()?.getPointerPosition() ?? null,
-    getLookAt: () => acc()?.getLookAt() ?? null,
+    getViewMatrix: guardRead(
+      'view.affine',
+      () => acc()?.getViewMatrix(),
+      () => IDENTITY.slice()
+    ),
+    getPerspective: guardRead(
+      'view.perspective',
+      () => acc()?.getPerspective(),
+      () => true
+    ),
+    getViewExtents: guardRead(
+      'view.extents',
+      () => acc()?.getViewExtents(),
+      () => [-1, -1, -1, 1, 1, 1]
+    ),
+    getViewTarget: guardRead(
+      'view.target',
+      () => acc()?.getViewTarget(),
+      () => [0, 0, 0]
+    ),
+    getViewRotatable: guardRead(
+      'view.rotatable',
+      () => acc()?.getViewRotatable(),
+      () => true
+    ),
+    getFov: guardRead(
+      'view.fov',
+      () => acc()?.getFov(),
+      () => Math.PI / 4
+    ),
+    getViewFrustum: guardRead(
+      'view.frustum',
+      () => acc()?.getViewFrustum(),
+      () => [-1, 1, -1, 1, 0.1, 1000]
+    ),
+    getModelExtents: guardRead('model.extents', () => acc()?.getModelExtents(), point),
+    getPivotPosition: guardRead('pivot.position', () => acc()?.getPivotPosition(), point),
+    getCoordinateSystem: guardRead(
+      'coordinateSystem',
+      () => acc()?.getCoordinateSystem(),
+      () => IDENTITY.slice()
+    ),
+    getFrontView: guardRead(
+      'views.front',
+      () => acc()?.getFrontView(),
+      () => IDENTITY.slice()
+    ),
+    getConstructionPlane: guardRead(
+      'view.constructionPlane',
+      () => acc()?.getConstructionPlane(),
+      () => [0, 0, 1, 0]
+    ),
+    getFloorPlane: guardRead(
+      'model.floorPlane',
+      () => acc()?.getFloorPlane(),
+      () => [0, 0, 1, 0]
+    ),
+    getPointerPosition: guardRead('pointer.position', () => acc()?.getPointerPosition(), point),
+    getLookAt: guardRead('hit.lookat', () => acc()?.getLookAt(), point),
     getUnitsToMeters: () => 1,
 
     // View writes (the driver's computed camera).
-    setViewMatrix(data) {
-      acc()?.setViewMatrix(data);
-    },
-    setViewExtents(data) {
-      acc()?.setViewExtents(data);
-    },
+    setViewMatrix: guardWrite<number[]>('view.affine', (data) => acc()?.setViewMatrix(data)),
+    setViewExtents: guardWrite<number[]>('view.extents', (data) => acc()?.setViewExtents(data)),
     // Hit testing: the driver sets a ray, then reads getLookAt to pivot on the
     // surface under the cursor.
-    setLookFrom(data) {
-      acc()?.setLookFrom(data);
-    },
-    setLookDirection(data) {
-      acc()?.setLookDirection(data);
-    },
-    setLookAperture(data) {
-      acc()?.setLookAperture(data);
-    },
-    setSelectionOnly(data) {
-      acc()?.setSelectionOnly(data);
-    },
+    setLookFrom: guardWrite<number[]>('hit.lookfrom', (data) => acc()?.setLookFrom(data)),
+    setLookDirection: guardWrite<number[]>('hit.direction', (data) =>
+      acc()?.setLookDirection(data)
+    ),
+    setLookAperture: guardWrite<number>('hit.aperture', (data) => acc()?.setLookAperture(data)),
+    setSelectionOnly: guardWrite<boolean>('hit.selectionOnly', (data) =>
+      acc()?.setSelectionOnly(data)
+    ),
   };
 }
 

--- a/src/shared/spacemouse/navlib/viewAccessors.test.ts
+++ b/src/shared/spacemouse/navlib/viewAccessors.test.ts
@@ -6,9 +6,11 @@ import {
   MeshBasicMaterial,
   OrthographicCamera,
   PerspectiveCamera,
+  Raycaster,
   Scene,
   Vector3,
 } from 'three';
+import { Line2, LineGeometry, LineMaterial } from 'three-stdlib';
 import { describe, expect, it } from 'vitest';
 import type { OrbitLike } from '../cameraCommands';
 import { createNavlibViewAccessors, type NavlibViewDeps } from './viewAccessors';
@@ -123,6 +125,41 @@ describe('createNavlibViewAccessors', () => {
     expect(withModel.getModelExtents()).toEqual([-1, -1, -1, 1, 1, 1]);
     const empty = createNavlibViewAccessors(() => deps(camera, makeScene(false)));
     expect(empty.getModelExtents()).toBeNull();
+  });
+
+  it('hit-tests solid meshes only, and survives drei fat lines in the scene', () => {
+    // Line2 extends Mesh and its raycast dereferences raycaster.camera; a throw
+    // here is never answered on the wire and stalls the driver.
+    const camera = new PerspectiveCamera(45, 4 / 3, 0.1, 1000);
+    camera.position.set(0, 0, 10);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld(true);
+    const scene = makeScene(true);
+    const geometry = new LineGeometry();
+    geometry.setPositions([-5, 3, 0, 5, 3, 0]);
+    const material = new LineMaterial({ linewidth: 2 });
+    material.resolution.set(800, 600);
+    scene.add(new Line2(geometry, material));
+    scene.updateMatrixWorld(true);
+    const acc = createNavlibViewAccessors(() => deps(camera, scene));
+    acc.setSelectionOnly(false);
+    acc.setLookAperture(0.01);
+
+    // Control: a bare raycaster without a camera does throw on the fat line.
+    const bare = new Raycaster(new Vector3(0, 3, 10), new Vector3(0, 0, -1));
+    expect(() => bare.intersectObjects(scene.children, true)).toThrow();
+
+    // Through the model: hits its front face.
+    acc.setLookFrom([0, 0, 10]);
+    acc.setLookDirection([0, 0, -1]);
+    const onModel = acc.getLookAt();
+    expect(onModel).not.toBeNull();
+    expect((onModel as number[])[2]).toBeCloseTo(1, 5);
+
+    // Through the line only: no pivot target, no throw.
+    acc.setLookFrom([0, 3, 10]);
+    acc.setLookDirection([0, 0, -1]);
+    expect(acc.getLookAt()).toBeNull();
   });
 
   it('degrades safely when no canvas is active', () => {

--- a/src/shared/spacemouse/navlib/viewAccessors.ts
+++ b/src/shared/spacemouse/navlib/viewAccessors.ts
@@ -28,6 +28,15 @@ function isZUp(d: NavlibViewDeps | null): boolean {
   return !!d && Math.abs(d.camera.up.z) > 0.9;
 }
 
+/**
+ * A mesh with real surface to pivot on. Fat lines extend Mesh but are screen
+ * space strokes (dimensions, split lines), and a pivot on one is meaningless.
+ */
+function isSolidMesh(obj: Object3D): boolean {
+  const o = obj as { isMesh?: boolean; isLineSegments2?: boolean; isSprite?: boolean };
+  return o.isMesh === true && o.isLineSegments2 !== true && o.isSprite !== true;
+}
+
 /** Meshes that frame the scene rather than being the model (see computeContentBox). */
 function isScaffold(obj: Object3D): boolean {
   const name = obj.name.toLowerCase();
@@ -176,10 +185,16 @@ export function createNavlibViewAccessors(
       // solid meshes, for which a plain ray hit is the correct test, so it does
       // not apply here.
       raycaster.set(look.origin, tmpForward.copy(look.direction).normalize());
-      for (const hit of raycaster.intersectObjects(d.scene.children, true)) {
-        if (hit.object.visible && !isScaffold(hit.object)) return hit.point.toArray();
-      }
-      return null;
+      // Sprites and drei fat lines dereference raycaster.camera and throw
+      // without it, so the ray is cast against solid meshes only, and the
+      // camera is set so no later addition to the scene can re-introduce that.
+      raycaster.camera = d.camera;
+      const candidates: Object3D[] = [];
+      d.scene.traverseVisible((obj) => {
+        if (isSolidMesh(obj) && !isScaffold(obj)) candidates.push(obj);
+      });
+      const hits = raycaster.intersectObjects(candidates, false);
+      return hits.length > 0 ? hits[0].point.toArray() : null;
     },
     getPointerPosition() {
       // Pointer-anchored pivot is not wired up; the driver falls back to the


### PR DESCRIPTION
## Problem

With the driver-native transport (#4072), letting go of the puck leaves the app dead to SpaceMouse input for a few seconds; a new movement only registers once that window has passed (reported in #4041).

## Root cause

When a navigation ends the driver recalculates its pivot: it reads `model.extents` and `view.affine`, sets up a hit-test ray, and reads `hit.lookat`. Our `getLookAt` raycast the whole scene with a `Raycaster` that had no camera set. drei `<Line>` is a three-stdlib `Line2`, which extends `Mesh` and dereferences `raycaster.camera` in its `raycast`, so the read threw `TypeError: Cannot read properties of null (reading 'near')`. The layout preview draws nine of those lines for the drawer dimensions alone; the bin designer draws dozens.

The 3Dconnexion JS library (`@3dconnexion/3dconnexionjs` 0.8.1) invokes client getters straight from its WebSocket message handler with no try/catch, so a throw means the driver's `self:read` is never answered. In the NL server, `wamp_session::get_app_value` sends the read and then waits on the reply future until `steady_clock::now()` plus 2 seconds before giving up, and the navigation manager cannot start the next motion until that returns. That wait is the dead window.

The throw is reproduced by a unit test that puts a three-stdlib fat line in a scene and calls the real accessor (kept as the regression test). The driver side comes from disassembling 3DxWareMac 10.8.13's `3DconnexionNavlib.framework` and `3DxNLServer`, both of which ship with symbol tables; no other timeout or cooldown exists in the navigation manager, and motion start is otherwise immediate on device data.

## Fix

- `getLookAt` casts against solid meshes only, with `raycaster.camera` set, so fat lines and sprites are neither pivot targets nor a way to throw.
- `navlibClient` wraps every read and write that crosses into the library (`guardRead` / `guardWrite`). A throwing accessor now answers with the same fallback used when no canvas is active, and the failure is reported once per property.

## Testing

- New tests: a fat line in the scene no longer breaks `getLookAt`, which still hits the model and returns null through the line; the guard helpers substitute fallbacks and report once.
- `src/shared/spacemouse` suite (91 tests), `pnpm run typecheck`, eslint on the changed files.
- Hardware check still needed: move, release, and move again immediately. The second movement should start at once.

https://claude.ai/code/session_01QofuY5UDMjJzSKHUjE2unu


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

