### PR TITLE
fix(bin-designer): generate ids through the guarded helper outside secure contexts

### DIFF
--- a/.claude/skills/release-and-ci/SKILL.md
+++ b/.claude/skills/release-and-ci/SKILL.md
@@ -59,7 +59,7 @@ The workflow files themselves (`ci.yml`, `release.yml`, `smoke-*.yml`, `vite.con
 
 ## Docker image
 
-`.github/workflows/docker.yml` builds and smokes the self-hosting image on path-filtered PRs and publishes it to GHCR on `release: published`, tagged from the release tag. `scripts/check-docker-parity.test.ts` fails when `vercel.json` and `docker/nginx.conf` disagree, so a header or rewrite change edits both. One-time after the first publish: set the package public.
+`.github/workflows/docker.yml` builds and smokes the self-hosting image on path-filtered PRs and publishes it to GHCR on `release: published`, tagged from the release tag. `scripts/check-docker-parity.test.ts` fails when `vercel.json` and `docker/nginx.conf` disagree, so a header or rewrite change edits both.
 
 ## Recipe: unstick a stalled release
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -91,11 +91,10 @@ The app is built for the site root. Hosting it under a path such as
 ### Plain HTTP on a LAN IP
 
 Use HTTPS, or open the app on `localhost` (browsers treat it as secure). On
-`http://<lan-ip>:8080` the browser refuses the secure-context APIs the app
-relies on: no service worker, so no install, offline use, or update prompt;
-no SpaceMouse; and the bin designer's cutout tools, STL and scan import,
-version history, assemblies and knife-rest pairing fail because they generate
-IDs with a secure-context-only API. The planner, exports and imports work.
+`http://<lan-ip>:8080` the browser withholds the secure-context APIs: no
+service worker, so no install, offline use, or update prompt; no SpaceMouse;
+and copying the print list to the clipboard does nothing. Everything else,
+including the bin designer, works.
 
 ### Updating
 

--- a/scripts/check-secure-context-uuid.test.ts
+++ b/scripts/check-secure-context-uuid.test.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(import.meta.dirname, '..');
+
+// crypto.randomUUID is a secure-context API: absent over plain HTTP on a LAN
+// address, which is how a self-hosted instance is often first opened. Adding a
+// cutout, importing an STL or building an assembly threw there. generateUUID()
+// falls back to getRandomValues, which every context has.
+describe('crypto.randomUUID is only called through generateUUID', () => {
+  const files = execFileSync('git', ['ls-files', 'src'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\n')
+    .filter(
+      (f) => /\.(ts|tsx)$/.test(f) && !/\.test\.tsx?$/.test(f) && f !== 'src/shared/utils/uuid.ts'
+    );
+
+  it('finds the source tree', () => {
+    expect(files.length).toBeGreaterThan(500);
+  });
+
+  it('has no direct caller outside src/shared/utils/uuid.ts', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      readFileSync(join(ROOT, file), 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          const code = line.trim();
+          if (code.startsWith('*') || code.startsWith('//')) return;
+          if (code.includes('crypto.randomUUID(')) offenders.push(`${file}:${i + 1}`);
+        });
+    }
+    expect(offenders, 'use generateUUID() from @/shared/utils/uuid').toEqual([]);
+  });
+});

--- a/scripts/check-secure-context-uuid.test.ts
+++ b/scripts/check-secure-context-uuid.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const ROOT = join(import.meta.dirname, '..');
@@ -14,9 +14,9 @@ const HELPER = 'shared/utils/uuid.ts';
 // or a container, and the match is the bare identifier on comment-stripped
 // source, so destructuring, bracket access and line breaks cannot slip past.
 describe('randomUUID is only reached through generateUUID', () => {
-  const files = readdirSync(join(ROOT, 'src'), { recursive: true, encoding: 'utf8' }).filter(
-    (f) => /\.(ts|tsx)$/.test(f) && !/\.test\.tsx?$/.test(f) && f !== HELPER
-  );
+  const files = readdirSync(join(ROOT, 'src'), { recursive: true, encoding: 'utf8' })
+    .map((f) => f.split(sep).join('/'))
+    .filter((f) => /\.(ts|tsx)$/.test(f) && !/\.test\.tsx?$/.test(f) && f !== HELPER);
 
   it('finds the source tree', () => {
     expect(files.length).toBeGreaterThan(500);

--- a/scripts/check-secure-context-uuid.test.ts
+++ b/scripts/check-secure-context-uuid.test.ts
@@ -1,36 +1,34 @@
-import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const ROOT = join(import.meta.dirname, '..');
+const HELPER = 'shared/utils/uuid.ts';
 
 // crypto.randomUUID is a secure-context API: absent over plain HTTP on a LAN
 // address, which is how a self-hosted instance is often first opened. Adding a
 // cutout, importing an STL or building an assembly threw there. generateUUID()
 // falls back to getRandomValues, which every context has.
-describe('crypto.randomUUID is only called through generateUUID', () => {
-  const files = execFileSync('git', ['ls-files', 'src'], { cwd: ROOT, encoding: 'utf8' })
-    .split('\n')
-    .filter(
-      (f) => /\.(ts|tsx)$/.test(f) && !/\.test\.tsx?$/.test(f) && f !== 'src/shared/utils/uuid.ts'
-    );
+//
+// The walk uses the filesystem rather than git so the suite runs in a tarball
+// or a container, and the match is the bare identifier on comment-stripped
+// source, so destructuring, bracket access and line breaks cannot slip past.
+describe('randomUUID is only reached through generateUUID', () => {
+  const files = readdirSync(join(ROOT, 'src'), { recursive: true, encoding: 'utf8' }).filter(
+    (f) => /\.(ts|tsx)$/.test(f) && !/\.test\.tsx?$/.test(f) && f !== HELPER
+  );
 
   it('finds the source tree', () => {
     expect(files.length).toBeGreaterThan(500);
   });
 
-  it('has no direct caller outside src/shared/utils/uuid.ts', () => {
-    const offenders: string[] = [];
-    for (const file of files) {
-      readFileSync(join(ROOT, file), 'utf8')
-        .split('\n')
-        .forEach((line, i) => {
-          const code = line.trim();
-          if (code.startsWith('*') || code.startsWith('//')) return;
-          if (code.includes('crypto.randomUUID(')) offenders.push(`${file}:${i + 1}`);
-        });
-    }
+  it('has no direct caller outside the helper', () => {
+    const offenders = files.filter((file) => {
+      const source = readFileSync(join(ROOT, 'src', file), 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '');
+      return /\brandomUUID\b/.test(source);
+    });
     expect(offenders, 'use generateUUID() from @/shared/utils/uuid').toEqual([]);
   });
 });

--- a/scripts/doc-budget.json
+++ b/scripts/doc-budget.json
@@ -32,7 +32,7 @@
     "docs/schemas/bin-design.md": 6006,
     "docs/schemas/constraints.md": 1414,
     "docs/schemas/layout.md": 4412,
-    "docs/self-hosting.md": 1100,
+    "docs/self-hosting.md": 1082,
     "scripts/community-admin/README.md": 831,
     "scripts/sync-admin/README.md": 1056,
     "scripts/train-bin-recommender/README.md": 343,

--- a/src/core/store/sharedWithMe.ts
+++ b/src/core/store/sharedWithMe.ts
@@ -11,6 +11,7 @@ import { immer } from 'zustand/middleware/immer';
 import type { SharedWithMeEntry, SharePermission, LayoutPreview } from '@/core/types';
 import { CONSTRAINTS } from '@/core/constants';
 import { saveSharedWithMe } from '@/core/storage/SharedWithMeService';
+import { generateUUID } from '@/shared/utils/uuid';
 
 /** Mutable fields on SharedWithMeEntry (excludes id, sourceShareId, addedAt). */
 type SharedWithMeUpdates = Partial<
@@ -49,7 +50,7 @@ export const useSharedWithMeStore = create<SharedWithMeState>()(
 
     add: (entry) => {
       const newEntry: SharedWithMeEntry = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         sourceShareId: entry.sourceShareId,
         name: entry.name.slice(0, CONSTRAINTS.NAME_MAX_LENGTH),
         authorName: entry.authorName,

--- a/src/core/sync/session/useSession.ts
+++ b/src/core/sync/session/useSession.ts
@@ -4,6 +4,7 @@ import { FORCED_SIGN_OUT_EVENT } from '../apiFetch';
 import { clearAll as clearOutbox } from '../outbox';
 import { resetPullState } from '../poller';
 import { getMe, type SessionUser } from './sessionApi';
+import { generateUUID } from '@/shared/utils/uuid';
 
 export type SessionStatus = 'unknown' | 'anonymous' | 'authenticated';
 
@@ -83,10 +84,7 @@ interface SessionBroadcast {
   source: string;
 }
 
-const TAB_ID = (() => {
-  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
-  return Math.random().toString(36).slice(2);
-})();
+const TAB_ID = generateUUID();
 
 let channel: BroadcastChannel | null = null;
 

--- a/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/cutoutHelpers.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_SLOT_WIDTH,
   DEFAULT_SLOT_DEPTH,
 } from './cutoutInteractionTypes';
+import { generateUUID } from '@/shared/utils/uuid';
 
 export interface ClonedCutout extends Cutout {
   readonly originalId: string;
@@ -49,8 +50,8 @@ export function cloneCutoutsWithGroups(
   return originals.map((original) => {
     const pos = offsetFn ? offsetFn(original) : { x: original.x, y: original.y };
     return {
-      ...remapGroupChain(original, groupMap, () => crypto.randomUUID()),
-      id: crypto.randomUUID(),
+      ...remapGroupChain(original, groupMap, generateUUID),
+      id: generateUUID(),
       x: pos.x,
       y: pos.y,
       originalId: original.id,
@@ -180,7 +181,7 @@ export function flattenCutoutArray(master: Cutout): {
 } {
   if (!master.array) return { masterPatch: {}, added: [] };
   const instances = expandCutoutArray(master);
-  const added = instances.slice(1).map((inst) => ({ ...inst, id: crypto.randomUUID() }));
+  const added = instances.slice(1).map((inst) => ({ ...inst, id: generateUUID() }));
   // The master's own label comes out of the list like every other instance's.
   // It is rarely list entry 0 (a grid's master is the BOTTOM-left hole while
   // the list is written top row first), so carrying the stored `label` through

--- a/src/features/bin-designer/components/panel/CutoutsSection/scanImport/useScanImport.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/scanImport/useScanImport.ts
@@ -13,6 +13,7 @@ import { defaultEntryChamfer } from '@/features/bin-designer/types';
 import { specToCutout, DEFAULT_CUT_DEPTH } from '../svgImport/specToCutout';
 import type { ParsedCutoutSpec } from '../svgImport/types';
 import { byDescendingArea } from '../importStackOrder';
+import { generateUUID } from '@/shared/utils/uuid';
 
 /** Default insertion clearance (mm) applied to a scanned tool outline. */
 const SCAN_DEFAULT_CLEARANCE_MM = 0.4;
@@ -33,7 +34,7 @@ export function useScanImport(): UseScanImportReturn {
 
   const addScanCutouts = useCallback(
     (specs: readonly ParsedCutoutSpec[], cutDepth: number = DEFAULT_CUT_DEPTH): number => {
-      const hydrationOptions = { cutDepth, idFactory: () => crypto.randomUUID() };
+      const hydrationOptions = { cutDepth, idFactory: generateUUID };
 
       // Checked before the history push, the same rule the store's own batch
       // paths state: a batch that cannot land a single shape must not spend an

--- a/src/features/bin-designer/components/panel/CutoutsSection/stlImport/useStlImport.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/stlImport/useStlImport.ts
@@ -24,6 +24,7 @@ import type {
 import { MAX_MESH_ASSETS_PER_DESIGN, MAX_MESH_FILE_BYTES } from '@/shared/generation/meshAsset';
 import { defaultEntryChamfer } from '@/features/bin-designer/types';
 import { cutoutInterior } from '@/features/bin-designer/utils/binDimensions';
+import { generateUUID } from '@/shared/utils/uuid';
 
 /** Default insertion clearance (mm) for an imported tool, matching scans. */
 const STL_DEFAULT_CLEARANCE_MM = 0.4;
@@ -157,13 +158,13 @@ export function useStlImport(): UseStlImportReturn {
 
   const place = useCallback(() => {
     if (!pending) return;
-    const meshId = crypto.randomUUID();
+    const meshId = generateUUID();
     const { asset, suggestedCutDepth } = pending;
     const current = useDesignerStore.getState().params;
     const { innerW, innerD } = cutoutInterior(current);
     addMeshCutout(
       {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         shape: 'mesh',
         meshId,
         x: Math.max(0, (innerW - asset.sizeMm.x) / 2),

--- a/src/features/bin-designer/components/panel/CutoutsSection/svgImport/useSvgImport.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/svgImport/useSvgImport.ts
@@ -18,6 +18,7 @@ import { specToCutout, DEFAULT_CUT_DEPTH } from './specToCutout';
 import { MAX_SVG_FILE_SIZE } from './types';
 import type { SvgImportErrorCode } from './types';
 import { byDescendingArea } from '../importStackOrder';
+import { generateUUID } from '@/shared/utils/uuid';
 
 /** Maps error codes to i18n toast keys. */
 const ERROR_TOAST_KEYS: Record<SvgImportErrorCode, string> = {
@@ -81,7 +82,7 @@ export function useSvgImport(): UseSvgImportReturn {
         const specs = result.value;
         const hydrationOptions = {
           cutDepth: DEFAULT_CUT_DEPTH,
-          idFactory: () => crypto.randomUUID(),
+          idFactory: generateUUID,
         };
 
         // Checked before the history push, the same rule the store's own batch

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPathTool.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPathTool.ts
@@ -29,6 +29,7 @@ import { dropCoincidentPoints } from '@/shared/utils/polyline';
 import { cutoutFitsInMask, type MaskCellSize } from './maskFit';
 import { createDefaultCutout } from './cutoutHelpers';
 import type { InteractionMode, PreviewMap } from './cutoutInteractionTypes';
+import { generateUUID } from '@/shared/utils/uuid';
 
 interface UseCutoutPathToolOptions {
   readonly mode: InteractionMode;
@@ -104,7 +105,7 @@ export function useCutoutPathTool({
       }
 
       const { minX, minY, maxX, maxY } = getPathBounds(clamped);
-      const newId = crypto.randomUUID();
+      const newId = generateUUID();
       const created: Cutout = {
         ...createDefaultCutout(newId, 'path', minX, minY, maxX - minX, maxY - minY),
         path: clamped,

--- a/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPointerHandlers.ts
+++ b/src/features/bin-designer/components/panel/CutoutsSection/useCutoutPointerHandlers.ts
@@ -32,6 +32,7 @@ import { MIN_CUTOUT_SIZE, type AlignmentGuide } from './geometry';
 import { cutoutFitsInMask, type MaskCellSize } from './maskFit';
 import { createDefaultCutout, defaultPlaceSize } from './cutoutHelpers';
 import { type InteractionMode, type PreviewMap } from './cutoutInteractionTypes';
+import { generateUUID } from '@/shared/utils/uuid';
 
 interface DrawingPreviewState {
   readonly x: number;
@@ -233,7 +234,7 @@ export function useCutoutPointerHandlers(
       const x = Math.max(0, Math.min(snap(placeMode.startMmX - defaultW / 2), binWidth - defaultW));
       const y = Math.max(0, Math.min(snap(placeMode.startMmY - defaultD / 2), binDepth - defaultD));
 
-      const newId = crypto.randomUUID();
+      const newId = generateUUID();
       const created = createDefaultCutout(newId, placeMode.shape, x, y, defaultW, defaultD);
 
       // Polygon mask: reject click-to-place inside an unfilled notch, testing
@@ -307,7 +308,7 @@ export function useCutoutPointerHandlers(
       drawingPreview.width >= MIN_CUTOUT_SIZE &&
       drawingPreview.depth >= MIN_CUTOUT_SIZE
     ) {
-      const newId = crypto.randomUUID();
+      const newId = generateUUID();
       const created = createDefaultCutout(
         newId,
         drawingPreview.shape,

--- a/src/features/bin-designer/storage/DesignVersionService.ts
+++ b/src/features/bin-designer/storage/DesignVersionService.ts
@@ -26,6 +26,7 @@ import type {
 import { MAX_VERSIONS_PER_DESIGN } from '@/features/bin-designer/types';
 import { getDb, DESIGN_VERSIONS_STORE } from './designerDb';
 import { emit as announce } from '@/features/bin-designer/sync/designVersionEvents';
+import { generateUUID } from '@/shared/utils/uuid';
 
 /** Strip the compressed body so the history list never holds every design in memory. */
 function toSummary(version: DesignVersion): DesignVersionSummary {
@@ -99,7 +100,7 @@ export async function createDesignVersion(
     }
 
     const version: DesignVersion = {
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       designId,
       name,
       content: compressString(JSON.stringify(content)),

--- a/src/features/bin-designer/store/slices/paramSlice/assemblyActions.ts
+++ b/src/features/bin-designer/store/slices/paramSlice/assemblyActions.ts
@@ -38,6 +38,7 @@ import {
 } from '@/features/bin-designer/utils/assemblyTree';
 import { pushHistoryEntry, setAssemblySelection } from '@/features/bin-designer/store/helpers';
 import type { Set, Get } from './types';
+import { generateUUID } from '@/shared/utils/uuid';
 
 function transformsEqual(a: PartTransform, b: PartTransform): boolean {
   return a.x === b.x && a.y === b.y && a.seatZ === b.seatZ && a.rotZDeg === b.rotZDeg;
@@ -160,7 +161,7 @@ export function createAssemblyActions(set: Set, get: Get) {
       if (!current) return null;
       const base = createAssemblyPartNode(
         type,
-        crypto.randomUUID(),
+        generateUUID(),
         clampPartTransform({ ...DEFAULT_PART_TRANSFORM, ...transform })
       );
       const node = params

--- a/src/features/bin-designer/utils/assemblyTree.ts
+++ b/src/features/bin-designer/utils/assemblyTree.ts
@@ -6,6 +6,7 @@
  */
 import type { AssemblyPartNode } from '@/shared/types/assembly';
 import { MAX_ASSEMBLY_DEPTH, MAX_ASSEMBLY_PARTS } from '@/shared/items/assembly/descriptor';
+import { generateUUID } from '@/shared/utils/uuid';
 
 export function findAssemblyPart(
   parts: readonly AssemblyPartNode[],
@@ -170,7 +171,7 @@ export function findAssemblySiblings(
 export function cloneAssemblySubtree(node: AssemblyPartNode): AssemblyPartNode {
   const reId = (n: AssemblyPartNode): AssemblyPartNode => ({
     ...n,
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     children: n.children.map(reId),
   });
   return reId(structuredClone(node));

--- a/src/features/bin-designer/utils/workshopTemplates.ts
+++ b/src/features/bin-designer/utils/workshopTemplates.ts
@@ -11,6 +11,7 @@ import {
   createAssemblyPartNode,
   defaultCutterProfile,
 } from '@/shared/items/assembly/descriptor';
+import { generateUUID } from '@/shared/utils/uuid';
 
 export type WorkshopTemplateId =
   | 'pliersRack'
@@ -47,7 +48,7 @@ function pliersRack(envelope: ItemEnvelope): AssemblyPartNode[] {
   const inset = 10;
   const count = Math.max(2, Math.min(64, Math.floor((w - 2 * inset) / pitch) + 1));
 
-  const rail = createAssemblyPartNode('block', crypto.randomUUID(), {
+  const rail = createAssemblyPartNode('block', generateUUID(), {
     x: w / 2,
     y: railY,
     seatZ: 0,
@@ -58,7 +59,7 @@ function pliersRack(envelope: ItemEnvelope): AssemblyPartNode[] {
     params: { ...rail.params, width: w - 8, depth: railDepth, height: 30, wedgeAngleDeg: 0 },
   };
 
-  const fin = createAssemblyPartNode('fin', crypto.randomUUID(), {
+  const fin = createAssemblyPartNode('fin', generateUUID(), {
     x: inset,
     y: railY - railDepth / 2 - finLength / 2,
     seatZ: 0,
@@ -81,7 +82,7 @@ function screwdriverBlock(envelope: ItemEnvelope): AssemblyPartNode[] {
   const pitch = 18;
   const count = Math.max(2, Math.min(64, Math.floor((blockW - 20) / pitch) + 1));
 
-  const hole = createAssemblyPartNode('cutter', crypto.randomUUID(), {
+  const hole = createAssemblyPartNode('cutter', generateUUID(), {
     x: -((count - 1) * pitch) / 2,
     y: 0,
     seatZ: 0,
@@ -99,7 +100,7 @@ function screwdriverBlock(envelope: ItemEnvelope): AssemblyPartNode[] {
     array: { count, dx: pitch, dy: 0 },
   };
 
-  const block = createAssemblyPartNode('block', crypto.randomUUID(), {
+  const block = createAssemblyPartNode('block', generateUUID(), {
     x: w / 2,
     y: d / 2,
     seatZ: 0,
@@ -118,7 +119,7 @@ function plierComb(envelope: ItemEnvelope): AssemblyPartNode[] {
   const { w, d } = extent(envelope);
   const width = w - 16;
   const slotCount = Math.max(2, Math.min(15, Math.floor(width / 26)));
-  const comb = createAssemblyPartNode('comb', crypto.randomUUID(), {
+  const comb = createAssemblyPartNode('comb', generateUUID(), {
     x: w / 2,
     y: d / 2,
     seatZ: 0,
@@ -143,14 +144,14 @@ function plierComb(envelope: ItemEnvelope): AssemblyPartNode[] {
 function screwdriverStation(envelope: ItemEnvelope): AssemblyPartNode[] {
   const { w, d } = extent(envelope);
   const stepDepth = Math.min(24, Math.max(14, d / 3));
-  const riser = createAssemblyPartNode('riser', crypto.randomUUID(), {
+  const riser = createAssemblyPartNode('riser', generateUUID(), {
     x: w / 2,
     y: d - stepDepth - 6,
     seatZ: 0,
     rotZDeg: 0,
   });
   const bankDepth = Math.min(22, stepDepth);
-  const bank = createAssemblyPartNode('boreBank', crypto.randomUUID(), {
+  const bank = createAssemblyPartNode('boreBank', generateUUID(), {
     x: 0,
     y: stepDepth / 2,
     seatZ: 0,
@@ -182,7 +183,7 @@ function screwdriverStation(envelope: ItemEnvelope): AssemblyPartNode[] {
 
 function angledBitBank(envelope: ItemEnvelope): AssemblyPartNode[] {
   const { w, d } = extent(envelope);
-  const bank = createAssemblyPartNode('boreBank', crypto.randomUUID(), {
+  const bank = createAssemblyPartNode('boreBank', generateUUID(), {
     x: w / 2,
     y: d / 2,
     seatZ: 0,
@@ -210,7 +211,7 @@ function angledBitBank(envelope: ItemEnvelope): AssemblyPartNode[] {
 function wrenchRail(envelope: ItemEnvelope): AssemblyPartNode[] {
   const { w, d } = extent(envelope);
   const width = w - 16;
-  const comb = createAssemblyPartNode('comb', crypto.randomUUID(), {
+  const comb = createAssemblyPartNode('comb', generateUUID(), {
     x: w / 2,
     y: d / 2,
     seatZ: 0,
@@ -283,7 +284,7 @@ export function convertToolRackToAssembly(
     // the rail entirely on the next load.
     const rail = createAssemblyPartNode(
       'block',
-      crypto.randomUUID(),
+      generateUUID(),
       clampPartTransform({
         x: w / 2,
         y: d - rack.backRail.thickness / 2,
@@ -309,7 +310,7 @@ export function convertToolRackToAssembly(
   const finLength = Math.max(12, Math.min(d, 400));
   const fin = createAssemblyPartNode(
     'fin',
-    crypto.randomUUID(),
+    generateUUID(),
     clampPartTransform({
       x: rack.slotInsetMm,
       y: d / 2,

--- a/src/features/design-linking/hooks/useKnifeRestPairing.ts
+++ b/src/features/design-linking/hooks/useKnifeRestPairing.ts
@@ -18,6 +18,7 @@ import { STAGING_ID } from '@/core/constants';
 import { gridUnits, heightUnits, type Bin, type GridUnits } from '@/core/types';
 import { pairPartner } from '@/shared/utils/binPairs';
 import { useCustomBins, type CustomBinRef } from '@/features/bin-designer';
+import { generateUUID } from '@/shared/utils/uuid';
 
 type RestMeta = NonNullable<CustomBinRef['knifeRest']>;
 
@@ -78,7 +79,7 @@ export function useKnifeRestPairing(): void {
       const rest = restFootprint(meta);
       const gapU = Math.max(0, Math.round((meta.gapMm / layout.gridUnitMm) * 2) / 2);
       const at = restPosition(bin, meta, gapU, rest);
-      const pairId = crypto.randomUUID();
+      const pairId = generateUUID();
       batch(() => {
         const base = {
           width: gridUnits(rest.w),

--- a/src/liveblocks.config.ts
+++ b/src/liveblocks.config.ts
@@ -10,6 +10,7 @@
 import { createClient } from '@liveblocks/client';
 import { createRoomContext } from '@liveblocks/react';
 import type { Layout, Coord, ResizeHandle } from './core/types';
+import { generateUUID } from '@/shared/utils/uuid';
 
 /**
  * User presence data - ephemeral state visible to other users.
@@ -85,11 +86,11 @@ function getLiveblocksUserId(): string {
   try {
     const stored = localStorage.getItem(LIVEBLOCKS_USER_ID_KEY);
     if (stored) return stored;
-    const id = crypto.randomUUID();
+    const id = generateUUID();
     localStorage.setItem(LIVEBLOCKS_USER_ID_KEY, id);
     return id;
   } catch {
-    return crypto.randomUUID();
+    return generateUUID();
   }
 }
 

--- a/src/shared/analytics/mlTelemetry/computations.ts
+++ b/src/shared/analytics/mlTelemetry/computations.ts
@@ -7,6 +7,7 @@ import type {
 } from './types';
 import { getGridBins, getLabeledBins } from '@/shared/utils/bins';
 import { layoutSession } from './sessionState';
+import { generateUUID } from '@/shared/utils/uuid';
 
 // LAYOUT QUALITY ASSESSMENT
 
@@ -415,7 +416,7 @@ export function getUserHash(): string {
   try {
     let hash = localStorage.getItem(USER_HASH_STORAGE_KEY);
     if (!hash) {
-      hash = crypto.randomUUID();
+      hash = generateUUID();
       localStorage.setItem(USER_HASH_STORAGE_KEY, hash);
     }
     return hash;

--- a/src/shared/items/assembly/descriptor.ts
+++ b/src/shared/items/assembly/descriptor.ts
@@ -16,6 +16,7 @@ import type {
 } from '@/shared/types/assembly';
 import { ASSEMBLY_PART_TYPES } from '@/shared/types/assembly';
 import { isRecord } from '@/shared/utils/isRecord';
+import { generateUUID } from '@/shared/utils/uuid';
 
 /** Hard ceiling on total nodes; the printability checker advises far below it. */
 export const MAX_ASSEMBLY_PARTS = 256;
@@ -450,7 +451,7 @@ function normalizePartNode(raw: unknown, depth: number): AssemblyPartNode | null
   if (!isAssemblyPartType(raw.type)) return null;
   const array = arraySchema.safeParse(raw.array);
   const candidate = {
-    id: typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : crypto.randomUUID(),
+    id: typeof raw.id === 'string' && raw.id.length > 0 ? raw.id : generateUUID(),
     type: raw.type,
     params: { ...defaultPartParams(raw.type), ...(isRecord(raw.params) ? raw.params : {}) },
     transform: { ...DEFAULT_PART_TRANSFORM, ...(isRecord(raw.transform) ? raw.transform : {}) },


### PR DESCRIPTION
## Summary

Follow-up to #4092. `crypto.randomUUID` is a secure-context API: it is undefined over plain HTTP on a LAN address, which is how a self-hosted instance is often first opened. Thirty call sites used it directly, so adding a cutout, importing an STL or SVG, saving a design version, building a workshop assembly, pairing a knife rest, or opening a shared-with-me entry threw there.

- Every runtime caller now uses `generateUUID()` from `src/shared/utils/uuid.ts`, which prefers `randomUUID` and falls back to `getRandomValues` (available in every context). The session store's tab id drops its own inline guard for the same helper.
- `scripts/check-secure-context-uuid.test.ts` fails on any new direct caller outside the helper.
- `docs/self-hosting.md` loses the bin-designer caveat under "Plain HTTP on a LAN IP"; the remaining limits there are the service worker, SpaceMouse and clipboard copy.
- The release-and-ci skill drops the "set the package public" step: the first main-branch cache push created the GHCR package and GitHub already made it public.

## Verification

- `pnpm run typecheck` and eslint on the changed files pass.
- 3,441 tests across the touched suites pass (session, shared items, ML telemetry, design linking, the bin designer's cutout section, utils, storage and store, and the UUID helper).
- `pnpm run check:doc-drift` passes.

https://claude.ai/code/session_01N1SLGMJRTWYiNKdTwVRsp7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

