### PR TITLE
chore(deps): ignore path-to-regexp majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,11 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
+      # Vercel compiles vercel.json sources with path-to-regexp 6, and
+      # scripts/check-docker-parity.test.ts mirrors that. 8.x drops the
+      # `:name(regex)` syntax those sources use, so the pin tracks Vercel's line.
+      - dependency-name: 'path-to-regexp'
+        update-types: ['version-update:semver-major']
       # brepjs upgrades are coupled to the brepkit kernel investigation —
       # always pin manually, never auto-bump
       - dependency-name: 'brepjs'


### PR DESCRIPTION
Dependabot opened #4099 to bump path-to-regexp to 8.x. vercel.json sources use the `:name(regex)` parameter syntax that 8.x removed, and `scripts/check-docker-parity.test.ts` compiles those sources with the same options Vercel uses, so the pin has to track Vercel's 6.x line. This adds the major-version ignore so the bump stops reappearing.

https://claude.ai/code/session_01N1SLGMJRTWYiNKdTwVRsp7

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

