### PR TITLE
chore(ci): re-base divider-pattern snapshots and clear the fast-uri advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   '@surma/rollup-plugin-off-main-thread>magic-string': 0.30.21
   workbox-build>@rollup/plugin-node-resolve: ^16.0.0
   '@apideck/better-ajv-errors>ajv': ^8.17.1
-  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
+  fast-uri@>=3.0.0 <3.1.6: ^3.1.6
   sharp: ^0.35.0
   serialize-javascript@>=7.0.0 <7.0.5: ^7.0.5
   eslint-plugin-react-hooks>eslint: ^10.0.3
@@ -3782,8 +3782,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -8624,7 +8624,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9430,7 +9430,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-xml-builder@1.3.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,7 +75,7 @@ overrides:
   'workbox-build>@rollup/plugin-node-resolve': '^16.0.0'
   '@apideck/better-ajv-errors>ajv': '^8.17.1'
   # ajv pins ^3.0.1; the 4.x line has separate advisories fixed at 4.1.2.
-  'fast-uri@>=3.0.0 <3.1.5': '^3.1.5'
+  'fast-uri@>=3.0.0 <3.1.6': '^3.1.6'
   # sharp <0.35.0 inherits libvips CVE-2026-33327/33328/35590/35591
   # (GHSA-f88m-g3jw-g9cj). Only reachable transitively via
   # manifold-3d>@gltf-transform/functions>ndarray-pixels (build-time glTF

--- a/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
+++ b/src/features/generation/worker/generators/__snapshots__/binGenerator.scenario.dividerPatterns.test.ts.snap
@@ -2,15 +2,15 @@
 
 exports[`divider patterns > 2×2 honeycomb dividers 1`] = `10036`;
 
-exports[`divider patterns > compound angled + leaned divider stays inside the bin 1`] = `3100`;
+exports[`divider patterns > compound angled + leaned divider stays inside the bin 1`] = `2944`;
 
 exports[`divider patterns > dividers + interior cutouts 1`] = `9096`;
 
-exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `10520`;
+exports[`divider patterns > dividers + label tabs keep the shelf anchorage solid 1`] = `9616`;
 
 exports[`divider patterns > dividers + outer cutouts + handles 1`] = `13580`;
 
-exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `14542`;
+exports[`divider patterns > dividers + scoops keep the ramp footings solid 1`] = `9802`;
 
 exports[`divider patterns > half-grid footprint with patterned dividers 1`] = `10430`;
 
@@ -20,6 +20,6 @@ exports[`divider patterns > overhang shifts the interior with the dividers 1`] =
 
 exports[`divider patterns > round pattern on a single column divider 1`] = `20268`;
 
-exports[`divider patterns > shortened dividers re-fit the band 1`] = `8576`;
+exports[`divider patterns > shortened dividers re-fit the band 1`] = `8376`;
 
 exports[`divider patterns > tilted dividers carry the pattern in-plane 1`] = `10138`;


### PR DESCRIPTION
## Summary

Main has two red workflows. This turns both green without touching generator code.

## Why

**Unit Tests.** Since the additive-feature fuse became a pairwise union, four divider-pattern bodies (scoops, label tabs, free-standing dividers) lost their overlapping internal shells and their triangle counts fell. `binGenerator.scenario.dividerPatterns.test.ts` sits in the `generators-heavy` vitest project, which CI runs only in the full suite on main, so the PR that changed the geometry never ran it and its baselines went stale. Every push to main since has failed the same four snapshots with the same values, and a local run on main reproduces them exactly. The divider-pattern export matrix passes on the same bodies, so the drop is the intended removal of General-Fuse shells, not missing geometry.

**OSV Scan.** `fast-uri` 3.1.5 picked up four High advisories (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp), all fixed in 3.1.6. The workspace override pinned the 3.1.5 line, so the lockfile never moved.

## Changes

- Re-base the four divider-pattern snapshot keys to the current values (14542→9802, 10520→9616, 8576→8376, 3100→2944).
- Move the `fast-uri` override to `^3.1.6` and re-resolve the lockfile. 3.1.6 was published on Aug 23, past the seven-day cooldown, so no exclusion entry is needed.

## Risk

The heavy scenario file does not run on this PR either, so the snapshot half is verified only by the local run (16 passed, 4 updated, values identical to the last three main runs). The OSV job on a PR is report-only; the blocking scan runs on main after merge.

https://claude.ai/code/session_01N1SLGMJRTWYiNKdTwVRsp7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

