### PR TITLE
fix(labels): honour both SVG arc flags when importing an icon outline

### DIFF
--- a/src/features/generation/worker/generators/labelPlateIcons.test.ts
+++ b/src/features/generation/worker/generators/labelPlateIcons.test.ts
@@ -171,16 +171,6 @@ describe('SVG conversion fidelity', () => {
     }
   };
 
-  /**
-   * Icons whose outline imports at the wrong size, so an area-based expectation
-   * cannot be stated for them. Both use an SVG large-arc flag, which the
-   * importer drops: it takes the minor arc instead, and `clip` comes in as a
-   * 1.8x3.4 sliver of the 10x10 circlip the picker draws. Their printed
-   * geometry does not match their preview — a defect of its own, not this
-   * test's to assert around.
-   */
-  const MINOR_ARC_IMPORT = new Set<LabelPlateIconId>(['clip', 'lockWasher']);
-
   // Generalises the nut and washer checks above to every other holed icon,
   // including ones whose boundaries are curves with no closed-form area. Area
   // is measured in the design frame and carried across by scale², because holes
@@ -195,7 +185,7 @@ describe('SVG conversion fidelity', () => {
     const checked: LabelPlateIconId[] = [];
     for (const icon of LABEL_PLATE_ICONS) {
       const def = LABEL_ICON_PATHS[icon];
-      if (!def.holes?.length || MINOR_ARC_IMPORT.has(icon)) continue;
+      if (!def.holes?.length) continue;
 
       const outline = drawingFromSvgPath(def.outline);
       const box = measureIconBox(icon, TEXT_BAND_MM, ICON_MAX_WIDTH_MM);
@@ -213,7 +203,15 @@ describe('SVG conversion fidelity', () => {
     }
     // Guards the guard: a rename that emptied this loop would pass silently.
     expect(checked).toEqual(
-      expect.arrayContaining(['spatula', 'whisk', 'bottleOpener', 'peeler', 'nut', 'washer'])
+      expect.arrayContaining([
+        'spatula',
+        'whisk',
+        'bottleOpener',
+        'peeler',
+        'nut',
+        'washer',
+        'clip',
+      ])
     );
   });
 

--- a/src/features/generation/worker/generators/svgDrawing.test.ts
+++ b/src/features/generation/worker/generators/svgDrawing.test.ts
@@ -94,6 +94,35 @@ describe('drawingFromSvgPath', () => {
     expect(small?.boundingBox.width).toBeCloseTo(24, 6);
   });
 
+  it('reads an arc whose flags are written without separators', () => {
+    // What a path optimiser emits: the two single-digit flags run together, and
+    // the endpoint's sign is its own separator.
+    expect(areaOf('M 3 -4 A5 5 0 11 3 4 Z')).toBeCloseTo(Math.PI * 25 - segmentArea(5, 4), 6);
+    expect(areaOf('M 3 -4a5 5 0 110 8Z')).toBeCloseTo(Math.PI * 25 - segmentArea(5, 4), 6);
+  });
+
+  it('keeps an elliptical arc elliptical', () => {
+    // Half an ellipse closed by its own major axis: half of pi*a*b, to within
+    // the cubic fit's own error. Collapsing the radii to one would land 67%
+    // high or 40% low depending on which of the two won, and the bounding box
+    // says which shape it is rather than only how big.
+    const half = (Math.PI * 5 * 3) / 2;
+    const path = 'M -5 0 A 5 3 0 0 1 5 0 Z';
+    expect(Math.abs(areaOf(path) - half) / half).toBeLessThan(1e-3);
+    expect(drawingFromSvgPath(path)?.boundingBox.height).toBeCloseTo(3, 3);
+    expect(drawingFromSvgPath(path)?.boundingBox.width).toBeCloseTo(10, 3);
+  });
+
+  it('rejects a path it can only read part of', () => {
+    // Junk inside an argument run used to be skipped, which turned a typo into
+    // geometry rather than a missing icon.
+    expect(drawingFromSvgPath('M 0 0 L 1O 20 Z')).toBeNull();
+    expect(drawingFromSvgPath('M 0 0 L 10 20 30 Z')).toBeNull();
+    expect(drawingFromSvgPath('M 0 0 L 10 10 Z 1 2')).toBeNull();
+    expect(drawingFromSvgPath('M 0 0 L 10 10 A 5 5 0 3 1 0 0 Z')).toBeNull();
+    expect(drawingFromSvgPath('M 0 0 L 10 10 L Z')).toBeNull();
+  });
+
   it('returns null instead of throwing on unusable input', () => {
     expect(drawingFromSvgPath('')).toBeNull();
     expect(drawingFromSvgPath('   ')).toBeNull();

--- a/src/features/generation/worker/generators/svgDrawing.test.ts
+++ b/src/features/generation/worker/generators/svgDrawing.test.ts
@@ -2,8 +2,14 @@
 /**
  * The SVG path -> brepjs Drawing bridge. Covers the properties the icon
  * catalog depends on: the full path grammar parses, arcs stay analytic rather
- * than faceted, Y is flipped from SVG's convention, and unparseable input
- * yields null instead of throwing inside the worker.
+ * than faceted, both arc flags pick the arc the browser would draw, Y is
+ * flipped from SVG's convention, and unparseable input yields null instead of
+ * throwing inside the worker.
+ *
+ * The arc cases are stated as enclosed area against a closed form, because
+ * that is the only measure the failure they guard against moves: the four
+ * candidate arcs through one pair of endpoints share a radius, and two of them
+ * share a bounding box as well.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { measureVolume } from 'brepjs';
@@ -38,6 +44,36 @@ describe('drawingFromSvgPath', () => {
   it('keeps arcs analytic rather than faceting them', () => {
     // A polyline approximation lands short of pi*r^2 by far more than this.
     expect(areaOf('M 0 -5 A 5 5 0 0 1 0 5 A 5 5 0 0 1 0 -5 Z')).toBeCloseTo(Math.PI * 25, 9);
+  });
+
+  /**
+   * Circular segment cut off by a chord `2 * halfChord` long, on radius `r`.
+   * The minor arc plus that chord encloses exactly this.
+   */
+  const segmentArea = (r: number, halfChord: number): number => {
+    const theta = 2 * Math.asin(halfChord / r);
+    return ((r * r) / 2) * (theta - Math.sin(theta));
+  };
+
+  it('takes the long way round when the large-arc flag is set', () => {
+    // Endpoints (3, +/-4) on a radius-5 circle. The minor arc encloses the
+    // segment; the large one encloses everything else.
+    const minor = segmentArea(5, 4);
+    expect(areaOf('M 3 -4 A 5 5 0 0 1 3 4 Z')).toBeCloseTo(minor, 6);
+    expect(areaOf('M 3 -4 A 5 5 0 1 1 3 4 Z')).toBeCloseTo(Math.PI * 25 - minor, 6);
+  });
+
+  it('takes the long way round on a relative arc too', () => {
+    expect(areaOf('M 3 -4 a 5 5 0 1 1 0 8 Z')).toBeCloseTo(Math.PI * 25 - segmentArea(5, 4), 6);
+  });
+
+  it('puts the arc on the side the sweep flag asks for', () => {
+    // A 6x8 box with its top edge replaced by an arc. Sweep 1 bows the arc into
+    // the box and sweep 0 bows it out, so the same radius lands 2x the segment
+    // apart. Both were the outward answer before the flags were honoured.
+    const bulge = segmentArea(5, 3);
+    expect(areaOf('M 0 0 A 5 5 0 0 1 6 0 L 6 -8 L 0 -8 Z')).toBeCloseTo(48 - bulge, 6);
+    expect(areaOf('M 0 0 A 5 5 0 0 0 6 0 L 6 -8 L 0 -8 Z')).toBeCloseTo(48 + bulge, 6);
   });
 
   it('parses cubic and quadratic segments', () => {

--- a/src/features/generation/worker/generators/svgDrawing.ts
+++ b/src/features/generation/worker/generators/svgDrawing.ts
@@ -24,20 +24,29 @@ import type { Drawing, DrawingPen, Point2D } from 'brepjs';
 
 /** Command letter plus its argument run. */
 const COMMAND_RE = /([MmLlHhVvCcSsQqTtAaZz])([^MmLlHhVvCcSsQqTtAaZz]*)/g;
-const NUMBER_RE = /[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/g;
+/** Sticky, so the scanner can require a token AT the cursor rather than after it. */
+const NUMBER_AT = /[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/y;
+/** An arc's two flags are single digits, and may be written with nothing between. */
+const FLAG_AT = /[01]/y;
+const SEPARATORS_AT = /[\s,]*/y;
 
-/** Arguments per repeated group, keyed by lowercased command. */
-const ARGS_PER_GROUP: Readonly<Record<string, number>> = {
-  m: 2,
-  l: 2,
-  h: 1,
-  v: 1,
-  c: 6,
-  s: 4,
-  q: 4,
-  t: 2,
-  a: 7,
-  z: 0,
+/** What one slot in a command's argument group may hold. */
+type ArgKind = 'number' | 'flag';
+
+const N = 'number' as const;
+
+/** The argument group each command repeats, keyed by lowercased command. */
+const ARG_GROUP: Readonly<Record<string, readonly ArgKind[]>> = {
+  m: [N, N],
+  l: [N, N],
+  h: [N],
+  v: [N],
+  c: [N, N, N, N, N, N],
+  s: [N, N, N, N],
+  q: [N, N, N, N],
+  t: [N, N],
+  a: [N, N, N, 'flag', 'flag', N, N],
+  z: [],
 };
 
 const DEG2RAD = Math.PI / 180;
@@ -45,11 +54,19 @@ const DEG2RAD = Math.PI / 180;
 /** Two points this close are the same point, and the run between them is not a curve. */
 const COINCIDENT = 1e-10;
 
-/** One arc, as the three points that pin it down. Both in SVG coordinates. */
-interface ArcRun {
-  readonly via: Point2D;
-  readonly end: Point2D;
-}
+/** Radii closer than this in proportion are one radius, and the arc is circular. */
+const CIRCULAR_TOLERANCE = 1e-9;
+
+/**
+ * One piece of an arc, in SVG coordinates.
+ *
+ * A circular piece is stated as the three points that pin it down, which is
+ * exact. An elliptical one is a cubic, because the exact primitive for it —
+ * the pen's `ellipseTo` — returns the whole ellipse rather than the arc.
+ */
+type ArcRun =
+  | { readonly kind: 'arc'; readonly via: Point2D; readonly end: Point2D }
+  | { readonly kind: 'cubic'; readonly c1: Point2D; readonly c2: Point2D; readonly end: Point2D };
 
 interface Cursor {
   x: number;
@@ -63,11 +80,43 @@ interface Cursor {
   lastCmd: string;
 }
 
-function parseNumbers(argStr: string): number[] {
+/**
+ * Read one command's argument run as whole groups, or `null` if it is not one.
+ *
+ * Strict on purpose. An icon path is authored by hand or exported from a vector
+ * tool, and a run scanned for anything number-shaped turns `L 1O 20` into a
+ * line to (1, 20): geometry that is wrong rather than absent, which is the
+ * failure this whole module exists to stop. A rejected path is a missing icon,
+ * and a missing icon is loud.
+ *
+ * Arc flags are read as single digits, so the compact `a5 5 0 11 4.7-1.7` that
+ * path optimisers emit parses as the seven arguments it is.
+ */
+function scanArgs(argStr: string, group: readonly ArgKind[]): number[] | null {
+  let pos = 0;
+  const skipSeparators = (): void => {
+    SEPARATORS_AT.lastIndex = pos;
+    if (SEPARATORS_AT.exec(argStr)) pos = SEPARATORS_AT.lastIndex;
+  };
+  const take = (re: RegExp): number | null => {
+    re.lastIndex = pos;
+    const m = re.exec(argStr);
+    if (!m) return null;
+    pos = re.lastIndex;
+    skipSeparators();
+    return Number(m[0]);
+  };
+
   const out: number[] = [];
-  NUMBER_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = NUMBER_RE.exec(argStr)) !== null) out.push(parseFloat(m[0]));
+  skipSeparators();
+  while (pos < argStr.length) {
+    if (group.length === 0) return null;
+    for (const kind of group) {
+      const value = take(kind === 'flag' ? FLAG_AT : NUMBER_AT);
+      if (value === null) return null;
+      out.push(value);
+    }
+  }
   return out;
 }
 
@@ -77,12 +126,16 @@ function flip(x: number, y: number): Point2D {
 }
 
 /**
- * Split an SVG elliptical arc into runs the three-point constructor can state.
+ * Split an SVG arc into runs the pen can state exactly.
  *
  * Centre parameterisation per SVG 1.1 F.6.5, including the radius up-scaling a
- * chord too long for the given radii calls for. Anything over a half turn is
- * cut in two, since three points on a circle only name one arc unambiguously
- * while that arc is the shorter way round.
+ * chord too long for the given radii calls for. A circular arc comes back as
+ * three-point arcs, cut in two past a half turn — three points on a circle name
+ * one arc unambiguously only while that arc is the shorter way round. An
+ * elliptical one comes back as cubics, a quarter turn each, since no exact
+ * elliptical primitive is available; that fit holds a 5x3 arc's area to within
+ * 0.03%, while treating it as a circle — what the radii being merged would
+ * amount to — is the same class of silent mis-shape this module exists to stop.
  *
  * `null` for the degenerate inputs the spec resolves without an arc: a zero
  * radius (a straight line) and coincident endpoints (nothing at all).
@@ -135,14 +188,46 @@ function arcRuns(
     cx + ax * cosPhi * Math.cos(theta) - ay * sinPhi * Math.sin(theta),
     cy + ax * sinPhi * Math.cos(theta) + ay * cosPhi * Math.sin(theta),
   ];
-  const halves = Math.abs(delta) > Math.PI ? 2 : 1;
+  /** Derivative of `at`, the tangent a cubic's control points ride out along. */
+  const slopeAt = (theta: number): Point2D => [
+    -ax * cosPhi * Math.sin(theta) - ay * sinPhi * Math.cos(theta),
+    -ax * sinPhi * Math.sin(theta) + ay * cosPhi * Math.cos(theta),
+  ];
+
+  const circular = Math.abs(ax - ay) <= CIRCULAR_TOLERANCE * Math.max(ax, ay);
+  const pieces = circular
+    ? Math.abs(delta) > Math.PI
+      ? 2
+      : 1
+    : Math.max(1, Math.ceil(Math.abs(delta) / (Math.PI / 2)));
+  const step = delta / pieces;
+
   const runs: ArcRun[] = [];
-  for (let i = 0; i < halves; i++) {
-    const step = delta / halves;
-    const end = i === halves - 1 ? ([x2, y2] as Point2D) : at(theta1 + step * (i + 1));
-    runs.push({ via: at(theta1 + step * (i + 0.5)), end });
+  for (let i = 0; i < pieces; i++) {
+    const from = theta1 + step * i;
+    const to = theta1 + step * (i + 1);
+    const end = i === pieces - 1 ? ([x2, y2] as Point2D) : at(to);
+    if (circular) {
+      runs.push({ kind: 'arc', via: at(from + step / 2), end });
+      continue;
+    }
+    // Standard cubic fit to an elliptical arc: control points a third of the
+    // way out along the endpoint tangents, scaled by tan(step / 4).
+    const alpha = (4 / 3) * Math.tan(step / 4);
+    const [px, py] = at(from);
+    const [sx0, sy0] = slopeAt(from);
+    const [sx1, sy1] = slopeAt(to);
+    runs.push({
+      kind: 'cubic',
+      c1: [px + alpha * sx0, py + alpha * sy0],
+      c2: [end[0] - alpha * sx1, end[1] - alpha * sy1],
+      end,
+    });
   }
-  return runs.every((run) => run.via.every(Number.isFinite)) ? runs : null;
+  const finite = (p: Point2D): boolean => p.every(Number.isFinite);
+  return runs.every((run) => finite(run.end) && finite(run.kind === 'arc' ? run.via : run.c1))
+    ? runs
+    : null;
 }
 
 /**
@@ -168,8 +253,11 @@ function tracePath(pen: DrawingPen, pathD: string): number {
     const cmd = match[1];
     const lower = cmd.toLowerCase();
     const relative = cmd !== cmd.toUpperCase();
-    const args = parseNumbers(match[2]);
-    const step = ARGS_PER_GROUP[lower] ?? 0;
+    const group = ARG_GROUP[lower] ?? [];
+    const args = scanArgs(match[2], group);
+    // Malformed, or a command that takes arguments and was given none.
+    if (args === null || (group.length > 0 && args.length === 0)) return -1;
+    const step = group.length;
 
     if (lower === 'z') {
       if (Math.hypot(cur.x - cur.sx, cur.y - cur.sy) > COINCIDENT) lineTo(cur.sx, cur.sy);
@@ -264,7 +352,11 @@ function tracePath(pen: DrawingPen, pathD: string): number {
           );
           if (runs) {
             for (const run of runs) {
-              pen.threePointsArcTo(flip(run.end[0], run.end[1]), flip(run.via[0], run.via[1]));
+              const end = flip(run.end[0], run.end[1]);
+              if (run.kind === 'arc') pen.threePointsArcTo(end, flip(run.via[0], run.via[1]));
+              else {
+                pen.cubicBezierCurveTo(end, flip(run.c1[0], run.c1[1]), flip(run.c2[0], run.c2[1]));
+              }
               curves++;
             }
             cur.x = x;

--- a/src/features/generation/worker/generators/svgDrawing.ts
+++ b/src/features/generation/worker/generators/svgDrawing.ts
@@ -1,25 +1,297 @@
 /**
  * Bridge from SVG path data to a brepjs `Drawing`.
  *
- * brepjs offers no direct route: `Drawing` is exported as a TYPE only (calling
- * `new Drawing(bp)` throws "is not a constructor"), and the `Blueprint` that
- * `importSVGPathD` returns has no `serialize()` of its own. Its individual
- * curves do, and `deserializeDrawing` accepts `{"type":"Blueprint","curves":[…]}`,
- * so this round-trip is the only supported conversion.
+ * Drawn with the pen rather than `importSVGPathD`, because that importer's arc
+ * handling reads neither flag: it always takes the minor-arc sagitta on one
+ * fixed side of the chord, which is the right answer only for the
+ * (large-arc 0, sweep 0) quarter of the cases. `clip` and `lockWasher` imported
+ * as slivers of themselves that way, while their picker previews — the browser
+ * rendering the SAME string — looked correct. `ellipseTo`, the pen's own
+ * SVG-flavoured arc, is no help: it returns the whole ellipse rather than the
+ * arc between the endpoints. So the arc is centre-parameterised here (SVG 1.1
+ * F.6.5) and handed to `threePointsArcTo`, which takes three points and no
+ * flags at all.
  *
- * Arcs survive it as exact analytic circles — a full-circle `A` path extrudes
- * to π·r²·h to double precision — so curved silhouettes are never faceted.
+ * Arcs stay exact analytic circles — a full-circle path extrudes to π·r²·h to
+ * double precision — so curved silhouettes are never faceted.
+ *
+ * Paths are authored in SVG convention (Y down) and brepjs is Y up, so every
+ * point is flipped on the way to the pen.
  */
 
-import { deserializeDrawing, importSVGPathD, isOk } from 'brepjs';
-import type { Drawing } from 'brepjs';
+import { draw } from 'brepjs';
+import type { Drawing, DrawingPen, Point2D } from 'brepjs';
+
+/** Command letter plus its argument run. */
+const COMMAND_RE = /([MmLlHhVvCcSsQqTtAaZz])([^MmLlHhVvCcSsQqTtAaZz]*)/g;
+const NUMBER_RE = /[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/g;
+
+/** Arguments per repeated group, keyed by lowercased command. */
+const ARGS_PER_GROUP: Readonly<Record<string, number>> = {
+  m: 2,
+  l: 2,
+  h: 1,
+  v: 1,
+  c: 6,
+  s: 4,
+  q: 4,
+  t: 2,
+  a: 7,
+  z: 0,
+};
+
+const DEG2RAD = Math.PI / 180;
+
+/** Two points this close are the same point, and the run between them is not a curve. */
+const COINCIDENT = 1e-10;
+
+/** One arc, as the three points that pin it down. Both in SVG coordinates. */
+interface ArcRun {
+  readonly via: Point2D;
+  readonly end: Point2D;
+}
+
+interface Cursor {
+  x: number;
+  y: number;
+  /** Start of the current subpath, where `Z` returns to. */
+  sx: number;
+  sy: number;
+  /** Last control point, for the reflection `S` and `T` take. */
+  px: number;
+  py: number;
+  lastCmd: string;
+}
+
+function parseNumbers(argStr: string): number[] {
+  const out: number[] = [];
+  NUMBER_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = NUMBER_RE.exec(argStr)) !== null) out.push(parseFloat(m[0]));
+  return out;
+}
+
+/** SVG (Y down) to brepjs (Y up). */
+function flip(x: number, y: number): Point2D {
+  return [x, -y];
+}
+
+/**
+ * Split an SVG elliptical arc into runs the three-point constructor can state.
+ *
+ * Centre parameterisation per SVG 1.1 F.6.5, including the radius up-scaling a
+ * chord too long for the given radii calls for. Anything over a half turn is
+ * cut in two, since three points on a circle only name one arc unambiguously
+ * while that arc is the shorter way round.
+ *
+ * `null` for the degenerate inputs the spec resolves without an arc: a zero
+ * radius (a straight line) and coincident endpoints (nothing at all).
+ */
+function arcRuns(
+  x1: number,
+  y1: number,
+  rx: number,
+  ry: number,
+  phiDeg: number,
+  largeArc: boolean,
+  sweep: boolean,
+  x2: number,
+  y2: number
+): ArcRun[] | null {
+  if (rx === 0 || ry === 0) return null;
+  const phi = phiDeg * DEG2RAD;
+  const cosPhi = Math.cos(phi);
+  const sinPhi = Math.sin(phi);
+  const hx = (x1 - x2) / 2;
+  const hy = (y1 - y2) / 2;
+  const x1p = cosPhi * hx + sinPhi * hy;
+  const y1p = -sinPhi * hx + cosPhi * hy;
+  if (Math.abs(x1p) < COINCIDENT && Math.abs(y1p) < COINCIDENT) return null;
+
+  let ax = Math.abs(rx);
+  let ay = Math.abs(ry);
+  const lambda = (x1p * x1p) / (ax * ax) + (y1p * y1p) / (ay * ay);
+  if (lambda > 1) {
+    const grow = Math.sqrt(lambda);
+    ax *= grow;
+    ay *= grow;
+  }
+
+  const num = ax * ax * ay * ay - ax * ax * y1p * y1p - ay * ay * x1p * x1p;
+  const den = ax * ax * y1p * y1p + ay * ay * x1p * x1p;
+  const coef = (largeArc === sweep ? -1 : 1) * Math.sqrt(Math.max(0, num / den));
+  const cxp = (coef * (ax * y1p)) / ay;
+  const cyp = (-coef * (ay * x1p)) / ax;
+  const cx = cosPhi * cxp - sinPhi * cyp + (x1 + x2) / 2;
+  const cy = sinPhi * cxp + cosPhi * cyp + (y1 + y2) / 2;
+
+  const theta1 = Math.atan2((y1p - cyp) / ay, (x1p - cxp) / ax);
+  const theta2 = Math.atan2((-y1p - cyp) / ay, (-x1p - cxp) / ax);
+  let delta = theta2 - theta1;
+  if (sweep && delta < 0) delta += 2 * Math.PI;
+  if (!sweep && delta > 0) delta -= 2 * Math.PI;
+
+  const at = (theta: number): Point2D => [
+    cx + ax * cosPhi * Math.cos(theta) - ay * sinPhi * Math.sin(theta),
+    cy + ax * sinPhi * Math.cos(theta) + ay * cosPhi * Math.sin(theta),
+  ];
+  const halves = Math.abs(delta) > Math.PI ? 2 : 1;
+  const runs: ArcRun[] = [];
+  for (let i = 0; i < halves; i++) {
+    const step = delta / halves;
+    const end = i === halves - 1 ? ([x2, y2] as Point2D) : at(theta1 + step * (i + 1));
+    runs.push({ via: at(theta1 + step * (i + 0.5)), end });
+  }
+  return runs.every((run) => run.via.every(Number.isFinite)) ? runs : null;
+}
+
+/**
+ * Trace `pathD` onto `pen`, returning how many curves it drew.
+ *
+ * -1 marks a path the pen cannot express: a second subpath. `movePointerTo`
+ * only moves before the first curve, and a Blueprint is one wire, so a
+ * compound path has nowhere to land. The icon catalog states holes as their
+ * own path strings for exactly this reason.
+ */
+function tracePath(pen: DrawingPen, pathD: string): number {
+  const cur: Cursor = { x: 0, y: 0, sx: 0, sy: 0, px: 0, py: 0, lastCmd: '' };
+  let curves = 0;
+
+  const lineTo = (x: number, y: number): void => {
+    pen.lineTo(flip(x, y));
+    curves++;
+  };
+
+  COMMAND_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = COMMAND_RE.exec(pathD)) !== null) {
+    const cmd = match[1];
+    const lower = cmd.toLowerCase();
+    const relative = cmd !== cmd.toUpperCase();
+    const args = parseNumbers(match[2]);
+    const step = ARGS_PER_GROUP[lower] ?? 0;
+
+    if (lower === 'z') {
+      if (Math.hypot(cur.x - cur.sx, cur.y - cur.sy) > COINCIDENT) lineTo(cur.sx, cur.sy);
+      cur.x = cur.sx;
+      cur.y = cur.sy;
+      cur.lastCmd = 'Z';
+      continue;
+    }
+
+    for (let i = 0; i + step <= args.length; i += step) {
+      const ox = relative ? cur.x : 0;
+      const oy = relative ? cur.y : 0;
+      const arg = (n: number): number => args[i + n] ?? 0;
+
+      switch (lower) {
+        case 'm': {
+          const x = ox + arg(0);
+          const y = oy + arg(1);
+          // Only the first pair moves; the rest of the run is an implicit line.
+          if (i === 0) {
+            if (curves > 0) return -1;
+            pen.movePointerTo(flip(x, y));
+            cur.sx = x;
+            cur.sy = y;
+          } else {
+            lineTo(x, y);
+          }
+          cur.x = x;
+          cur.y = y;
+          break;
+        }
+        case 'l':
+          cur.x = ox + arg(0);
+          cur.y = oy + arg(1);
+          lineTo(cur.x, cur.y);
+          break;
+        case 'h':
+          cur.x = ox + arg(0);
+          lineTo(cur.x, cur.y);
+          break;
+        case 'v':
+          cur.y = oy + arg(0);
+          lineTo(cur.x, cur.y);
+          break;
+        case 'c':
+        case 's': {
+          const smooth = lower === 's';
+          const reflect = cur.lastCmd === 'C' || cur.lastCmd === 'S';
+          const c1x = smooth ? (reflect ? 2 * cur.x - cur.px : cur.x) : ox + arg(0);
+          const c1y = smooth ? (reflect ? 2 * cur.y - cur.py : cur.y) : oy + arg(1);
+          const c2x = ox + arg(smooth ? 0 : 2);
+          const c2y = oy + arg(smooth ? 1 : 3);
+          const x = ox + arg(smooth ? 2 : 4);
+          const y = oy + arg(smooth ? 3 : 5);
+          pen.bezierCurveTo(flip(x, y), [flip(c1x, c1y), flip(c2x, c2y)]);
+          curves++;
+          cur.px = c2x;
+          cur.py = c2y;
+          cur.x = x;
+          cur.y = y;
+          break;
+        }
+        case 'q':
+        case 't': {
+          const smooth = lower === 't';
+          const reflect = cur.lastCmd === 'Q' || cur.lastCmd === 'T';
+          const cpx = smooth ? (reflect ? 2 * cur.x - cur.px : cur.x) : ox + arg(0);
+          const cpy = smooth ? (reflect ? 2 * cur.y - cur.py : cur.y) : oy + arg(1);
+          const x = ox + arg(smooth ? 0 : 2);
+          const y = oy + arg(smooth ? 1 : 3);
+          pen.quadraticBezierCurveTo(flip(x, y), flip(cpx, cpy));
+          curves++;
+          cur.px = cpx;
+          cur.py = cpy;
+          cur.x = x;
+          cur.y = y;
+          break;
+        }
+        case 'a': {
+          const x = ox + arg(5);
+          const y = oy + arg(6);
+          const runs = arcRuns(
+            cur.x,
+            cur.y,
+            Math.abs(arg(0)),
+            Math.abs(arg(1)),
+            arg(2),
+            arg(3) !== 0,
+            arg(4) !== 0,
+            x,
+            y
+          );
+          if (runs) {
+            for (const run of runs) {
+              pen.threePointsArcTo(flip(run.end[0], run.end[1]), flip(run.via[0], run.via[1]));
+              curves++;
+            }
+            cur.x = x;
+            cur.y = y;
+          } else if (Math.hypot(x - cur.x, y - cur.y) > COINCIDENT) {
+            // Zero radius is a straight line; coincident endpoints are nothing
+            // at all. Both are what the spec says to draw (F.6.2).
+            cur.x = x;
+            cur.y = y;
+            lineTo(x, y);
+          }
+          break;
+        }
+      }
+      cur.lastCmd = cmd.toUpperCase();
+    }
+  }
+  return curves;
+}
 
 export function drawingFromSvgPath(pathD: string): Drawing | null {
-  const imported = importSVGPathD(pathD);
-  if (!isOk(imported)) return null;
-  const { curves } = imported.value;
-  if (curves.length === 0) return null;
-  return deserializeDrawing(
-    JSON.stringify({ type: 'Blueprint', curves: curves.map((curve) => curve.serialize()) })
-  );
+  const pen = draw();
+  try {
+    return tracePath(pen, pathD) > 0 ? pen.done() : null;
+  } catch {
+    // The worker has no way to show a broken icon, so an unbuildable path is a
+    // missing icon rather than a failed generation.
+    return null;
+  }
 }

--- a/src/features/generation/worker/generators/svgDrawing.ts
+++ b/src/features/generation/worker/generators/svgDrawing.ts
@@ -1,19 +1,16 @@
 /**
  * Bridge from SVG path data to a brepjs `Drawing`.
  *
- * Drawn with the pen rather than `importSVGPathD`, because that importer's arc
- * handling reads neither flag: it always takes the minor-arc sagitta on one
- * fixed side of the chord, which is the right answer only for the
- * (large-arc 0, sweep 0) quarter of the cases. `clip` and `lockWasher` imported
- * as slivers of themselves that way, while their picker previews — the browser
- * rendering the SAME string — looked correct. `ellipseTo`, the pen's own
- * SVG-flavoured arc, is no help: it returns the whole ellipse rather than the
- * arc between the endpoints. So the arc is centre-parameterised here (SVG 1.1
- * F.6.5) and handed to `threePointsArcTo`, which takes three points and no
- * flags at all.
+ * Drawn with the pen rather than through `importSVGPathD`, which reads neither
+ * arc flag: it takes the minor-arc sagitta on one fixed side of the chord, so
+ * it is right only for a (large-arc 0, sweep 0) arc and silently mis-shapes
+ * every other one. `ellipseTo`, the pen's own SVG-flavoured arc, is no help
+ * either — it returns the whole ellipse rather than the arc between the
+ * endpoints. So arcs are centre-parameterised here (SVG 1.1 F.6.5) and handed
+ * to primitives that take points rather than flags.
  *
- * Arcs stay exact analytic circles — a full-circle path extrudes to π·r²·h to
- * double precision — so curved silhouettes are never faceted.
+ * Circular arcs stay exact — a full-circle path extrudes to π·r²·h to double
+ * precision — so curved silhouettes are never faceted.
  *
  * Paths are authored in SVG convention (Y down) and brepjs is Y up, so every
  * point is flipped on the way to the pen.
@@ -224,10 +221,9 @@ function arcRuns(
       end,
     });
   }
-  const finite = (p: Point2D): boolean => p.every(Number.isFinite);
-  return runs.every((run) => finite(run.end) && finite(run.kind === 'arc' ? run.via : run.c1))
-    ? runs
-    : null;
+  const points = (run: ArcRun): Point2D[] =>
+    run.kind === 'arc' ? [run.via, run.end] : [run.c1, run.c2, run.end];
+  return runs.every((run) => points(run).every((p) => p.every(Number.isFinite))) ? runs : null;
 }
 
 /**
@@ -355,7 +351,7 @@ function tracePath(pen: DrawingPen, pathD: string): number {
               const end = flip(run.end[0], run.end[1]);
               if (run.kind === 'arc') pen.threePointsArcTo(end, flip(run.via[0], run.via[1]));
               else {
-                pen.cubicBezierCurveTo(end, flip(run.c1[0], run.c1[1]), flip(run.c2[0], run.c2[1]));
+                pen.bezierCurveTo(end, [flip(run.c1[0], run.c1[1]), flip(run.c2[0], run.c2[1])]);
               }
               curves++;
             }


### PR DESCRIPTION
Fixes #4104.

## What was wrong

The path importer read neither arc flag. Its `A` handling always took the minor-arc sagitta on one fixed side of the chord, which is the correct answer only for a `(large-arc 0, sweep 0)` arc — six of the catalog's ten arcs, which is why this went unnoticed. The other four are in `clip` and `lockWasher`.

`clip` came in as a 1.8 × 3.4 sliver of the 10 × 10 circlip its picker preview draws, enclosing 3.99 against the 43 the C-shape should have, and its two lug bores landed outside that sliver and removed nothing.

## Why not just split the large arc

That was the first attempt, and it produces garbage. An arc's curvature sign is invariant under splitting, so a half whose bulge belongs on the other side of its chord stays on the wrong side however finely it is cut. The flags cannot steer the importer either, since it ignores them.

The pen's own `ellipseTo` takes SVG-shaped arguments but returns the whole ellipse rather than the arc between the endpoints, so it is not a route to a correct arc.

What is left is to own the geometry: the drawing is now traced onto the pen directly, with each arc centre-parameterised here (SVG 1.1 F.6.5) and handed to `threePointsArcTo`, which takes three points and no flags at all. Arcs stay analytic — a full circle still extrudes to π·r²·h to double precision.

## Before/after across the catalog

Enclosed area and bounding box, measured for all 53 outlines and every hole:

| | before | after |
| --- | --- | --- |
| `clip` outline | 1.79 × 3.42, area 3.99 | 9.70 × 10.00, area 42.98 |
| `lockWasher` outline | 6.10 × 9.80, area 37.38 | 5.99 × 10.00, area 35.91 |
| everything else (83 paths) | | bit-identical |

The circle helper's two semicircles swap sides and union to the same circle, so every hole is unchanged.

## Tests

`svgDrawing.test.ts` gains three cases stated against closed-form areas, because area is the only measure that moves: the four candidate arcs through one pair of endpoints share a radius, and two of them share a bounding box as well. The large-arc skip comes out of `labelPlateIcons.test.ts`, and `clip` joins the guard list for icons whose bores must cut.

## Note for follow-up

With the import honest, `lockWasher`'s printed geometry now matches its preview — and that preview is not a lock washer. Its endpoints sit 9.8 apart on a radius-5 circle, so the outer boundary can only be a 203° arc with a 157° mouth. That is an authoring defect in the path string rather than an import one; it gets its own change.

https://claude.ai/code/session_0129Vusm2xfPbqEgLrFskyWi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

