### PR TITLE
fix(bins): cut a divider's wall cutout from the divider's own top

### DIFF
--- a/src/features/generation/worker/generators/binGenerator.scenario.wallCutoutCorners.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.wallCutoutCorners.test.ts
@@ -172,9 +172,10 @@ describe('wall cutout rounded shoulders', () => {
  * The same round-over, on an interior divider.
  *
  * A divider has no stacking lip over it, so its own top face is the rim its
- * shoulder blend is tangent to. Cut against the wall's rim instead — 4.4mm
- * higher on a bin with a lip — a 5mm blend reaches the divider 0.036mm wide,
- * which is what "the dividers don't have the correct shape" looked like.
+ * shoulder blend is tangent to. Given the wall's rim instead — 4.4mm higher on
+ * a bin with a lip — a 5mm blend spends its radius in the air above the
+ * divider and reaches its top face 0.036mm wide, which is why these bins carry
+ * a lip where the ones above deliberately do not.
  *
  * Every number here is read off the mesh rather than restated from the
  * constant chain, because the chain is the thing under test: the divider's top
@@ -276,9 +277,9 @@ describe('interior divider cutout', () => {
   });
 
   it('rounds the divider shoulder tangent to the divider top', () => {
-    // Quarter arc centred a radius inboard and a radius down from the corner:
-    // it reaches full width at the divider's top face and dies out a radius
-    // below it. Anchored to the wall's rim instead, every one of these is 0.
+    // Quarter arc, centred a radius into the standing material and a radius
+    // below the top face: widest where it meets that face, gone a radius down.
+    // Read against the wall's rim, every one of these drops is zero.
     for (const out of [0.3, 1, 3]) {
       const expected = D_RADIUS - Math.sqrt(D_RADIUS ** 2 - (D_RADIUS - out) ** 2);
       const drop = dividerTopZ - topAt(rounded, DIVIDER_X, D_CUT_HALF + out);

--- a/src/features/generation/worker/generators/binGenerator.scenario.wallCutoutCorners.test.ts
+++ b/src/features/generation/worker/generators/binGenerator.scenario.wallCutoutCorners.test.ts
@@ -10,12 +10,18 @@
  * of the same extent — so every check here probes INSIDE the wall and states
  * its result as a delta against the same bin with the radius left off.
  *
- * The bins carry no stacking lip on purpose. With one, the rim is the lip's
- * top face and the wall's cross-section up there is the lip's own taper, so a
- * column probe would be reading the lip profile rather than the blend. Without
- * one the rim is the wall top and the wall is a plain slab beneath it, which is
- * the cleanest place to ask the only question that matters: at a given depth,
- * how far outboard of the cut has material been taken away?
+ * The outer-wall bins carry no stacking lip on purpose. With one, the rim is
+ * the lip's top face and the wall's cross-section up there is the lip's own
+ * taper, so a column probe would be reading the lip profile rather than the
+ * blend. Without one the rim is the wall top and the wall is a plain slab
+ * beneath it, which is the cleanest place to ask the only question that
+ * matters: at a given depth, how far outboard of the cut has material been
+ * taken away?
+ *
+ * The interior-divider bins at the bottom of the file do carry one, because
+ * that is the case a divider cut anchored to the WALL's rim gets wrong: the
+ * lip stands 4.4mm above the divider's own top, and a round-over given the
+ * wrong rim spends its whole radius in the air above the divider.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { initBrepjs, getGenerateBin } from './__kernel-tests__/wasmInit';
@@ -23,6 +29,7 @@ import {
   assertStructurallyValid,
   assertWatertight,
   boundingBox,
+  columnCrossings,
   isSolidThrough,
 } from './__kernel-tests__/meshAssertions';
 import { buildParams } from './__kernel-tests__/scenarioTypes';
@@ -159,4 +166,146 @@ describe('wall cutout rounded shoulders', () => {
     expect(openingAt(depth)).toBeLessThan(1);
     expect(wallSolidAt(rounded, CUT_HALF + 1, depth)).toBe(true);
   });
+});
+
+/**
+ * The same round-over, on an interior divider.
+ *
+ * A divider has no stacking lip over it, so its own top face is the rim its
+ * shoulder blend is tangent to. Cut against the wall's rim instead — 4.4mm
+ * higher on a bin with a lip — a 5mm blend reaches the divider 0.036mm wide,
+ * which is what "the dividers don't have the correct shape" looked like.
+ *
+ * Every number here is read off the mesh rather than restated from the
+ * constant chain, because the chain is the thing under test: the divider's top
+ * is measured on the divider, and the floor on a compartment's own floor.
+ */
+describe('interior divider cutout', () => {
+  const D_WIDTH = 3;
+  const D_DEPTH = 1;
+  const D_HEIGHT = 3;
+  const D_RADIUS = 5;
+  const D_CUT_FRACTION = 0.5;
+  const D_DEPTH_PCT = 60;
+
+  const D_INNER_W = D_WIDTH * GRID_SIZE - TOLERANCE - 2 * WALL_THICKNESS;
+  const D_INNER_D = D_DEPTH * GRID_SIZE - TOLERANCE - 2 * WALL_THICKNESS;
+  /** Along-divider half-span of the window: the divider runs the full interior. */
+  const D_CUT_HALF = (D_INNER_D * D_CUT_FRACTION) / 2;
+  /** First column boundary of a 3-column grid, where a divider stands. */
+  const DIVIDER_X = -D_INNER_W / 2 + D_INNER_W / 3;
+
+  function interiorWalls(over: Partial<WallCutout> = {}): BinParams['walls'] {
+    const base = buildParams({}).walls;
+    const off = { ...base.front, enabled: false };
+    return {
+      ...base,
+      enabled: true,
+      shape: 'u-shape',
+      front: off,
+      back: off,
+      left: off,
+      right: off,
+      interior: {
+        ...base.interior,
+        enabled: true,
+        width: D_CUT_FRACTION * 100,
+        depth: D_DEPTH_PCT,
+        alignment: 'center',
+        offset: 0,
+        widthMm: null,
+        ...over,
+      },
+    };
+  }
+
+  function genDivided(walls: BinParams['walls'], dividerHeight?: number): MeshData {
+    const defaults = buildParams({});
+    return getGenerateBin()(
+      buildParams({
+        width: D_WIDTH,
+        depth: D_DEPTH,
+        height: D_HEIGHT,
+        wallThickness: WALL_THICKNESS,
+        base: { ...defaults.base, stackingLip: true },
+        compartments: {
+          ...defaults.compartments,
+          cols: 3,
+          rows: 1,
+          cells: [0, 1, 2],
+          thickness: WALL_THICKNESS,
+          ...(dividerHeight === undefined ? {} : { dividerHeight }),
+        },
+        walls,
+      }),
+      undefined,
+      true
+    );
+  }
+
+  /** Highest surface over a column — the top face of whatever stands there. */
+  const topAt = (mesh: MeshData, x: number, y: number): number => {
+    const crossings = columnCrossings(mesh, x, y);
+    return crossings[crossings.length - 1] ?? NaN;
+  };
+
+  let square: MeshData;
+  let rounded: MeshData;
+  let dividerTopZ: number;
+
+  beforeAll(async () => {
+    await initBrepjs();
+    square = genDivided(interiorWalls());
+    rounded = genDivided(interiorWalls({ cornerRadiusTop: D_RADIUS }));
+    // Well past the blend's reach, so it reads the untouched divider.
+    dividerTopZ = topAt(square, DIVIDER_X, D_CUT_HALF + D_RADIUS + 2);
+  }, 180_000);
+
+  it('produces a valid solid either way', () => {
+    assertStructurallyValid(square, 'square divider shoulder');
+    assertStructurallyValid(rounded, 'rounded divider shoulder');
+    assertWatertight(rounded, 'rounded divider shoulder');
+  });
+
+  it('leaves the two bins the same size', () => {
+    const a = boundingBox(square.vertices);
+    const b = boundingBox(rounded.vertices);
+    for (const k of ['minX', 'maxX', 'minY', 'maxY', 'minZ', 'maxZ'] as const) {
+      expect(b[k], k).toBeCloseTo(a[k], 3);
+    }
+  });
+
+  it('rounds the divider shoulder tangent to the divider top', () => {
+    // Quarter arc centred a radius inboard and a radius down from the corner:
+    // it reaches full width at the divider's top face and dies out a radius
+    // below it. Anchored to the wall's rim instead, every one of these is 0.
+    for (const out of [0.3, 1, 3]) {
+      const expected = D_RADIUS - Math.sqrt(D_RADIUS ** 2 - (D_RADIUS - out) ** 2);
+      const drop = dividerTopZ - topAt(rounded, DIVIDER_X, D_CUT_HALF + out);
+      // Loose to the mesh's own facet sag on a curved face, tight enough that a
+      // chamfer (2mm at 3mm out, against the arc's 0.42) could not pass.
+      expect(drop, `${out}mm outboard`).toBeCloseTo(expected, 1);
+      expect(topAt(square, DIVIDER_X, D_CUT_HALF + out), `square at ${out}mm`).toBeCloseTo(
+        dividerTopZ,
+        3
+      );
+    }
+  });
+
+  it('leaves the divider standing past the blend', () => {
+    expect(topAt(rounded, DIVIDER_X, D_CUT_HALF + D_RADIUS + 1)).toBeCloseTo(dividerTopZ, 3);
+  });
+
+  it('cuts the asked-for fraction of the divider a shortened one leaves standing', () => {
+    // A numeric divider height takes the additive path, where the divider ends
+    // well below the rim. Measured against the rim the cut used to take 13% of
+    // this divider; the contract is that it takes the depth percentage of what
+    // stands above the floor.
+    const short = genDivided(interiorWalls(), 8);
+    const floorZ = topAt(short, 0, 0);
+    const topZ = topAt(short, DIVIDER_X, D_CUT_HALF + 2);
+    const cutFloorZ = topAt(short, DIVIDER_X, 0);
+    expect(topZ).toBeLessThan(dividerTopZ);
+    expect(topZ - cutFloorZ).toBeCloseTo((topZ - floorZ) * (D_DEPTH_PCT / 100), 3);
+  }, 120_000);
 });

--- a/src/features/generation/worker/generators/featureBuilder.test.ts
+++ b/src/features/generation/worker/generators/featureBuilder.test.ts
@@ -44,7 +44,8 @@ type BuildWallCutoutCutsFn = (
   innerW: number,
   innerD: number,
   wallHeight: number,
-  hasLip: boolean
+  hasLip: boolean,
+  dividerTopZ: number
 ) => Shape3D | null;
 
 let buildCompartmentWalls: BuildCompartmentWallsFn;
@@ -580,7 +581,7 @@ describe('buildWallCutoutCuts', () => {
       ...DEFAULT_BIN_PARAMS,
       walls: { ...DEFAULT_BIN_PARAMS.walls, enabled: false },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).toBeNull();
   });
 
@@ -599,7 +600,7 @@ describe('buildWallCutoutCuts', () => {
         interior: DISABLED_WALL_CUTOUT,
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
@@ -620,7 +621,7 @@ describe('buildWallCutoutCuts', () => {
         interior: DISABLED_WALL_CUTOUT,
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).toBeNull();
   });
 
@@ -639,7 +640,7 @@ describe('buildWallCutoutCuts', () => {
         interior: DISABLED_WALL_CUTOUT,
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
@@ -660,7 +661,7 @@ describe('buildWallCutoutCuts', () => {
         interior: DISABLED_WALL_CUTOUT,
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).toBeNull();
   });
 
@@ -680,7 +681,7 @@ describe('buildWallCutoutCuts', () => {
         interior: { ...DISABLED_WALL_CUTOUT, enabled: true, width: 70, depth: 50 },
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
@@ -701,7 +702,7 @@ describe('buildWallCutoutCuts', () => {
         interior: DISABLED_WALL_CUTOUT,
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, true);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, true, 16);
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
@@ -722,7 +723,7 @@ describe('buildWallCutoutCuts', () => {
         interior: DISABLED_WALL_CUTOUT,
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
@@ -743,7 +744,7 @@ describe('buildWallCutoutCuts', () => {
         interior: DISABLED_WALL_CUTOUT,
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);
@@ -764,7 +765,7 @@ describe('buildWallCutoutCuts', () => {
         interior: DISABLED_WALL_CUTOUT,
       },
     };
-    const result = buildWallCutoutCuts(params, 80, 80, 16, false);
+    const result = buildWallCutoutCuts(params, 80, 80, 16, false, 16);
     expect(result).not.toBeNull();
     const meshed = meshShape(result);
     expect(meshed.vertices.length).toBeGreaterThan(0);

--- a/src/features/generation/worker/generators/splitBinBuilder.ts
+++ b/src/features/generation/worker/generators/splitBinBuilder.ts
@@ -35,7 +35,7 @@ import { getLastSolid, setLastSolid } from './shapeCache';
 import { applySplitConnectors, computeCutFaces } from './splitConnectorBuilder';
 import type { BinGeometryContext } from './splitConnectorBuilder';
 import { buildLipSlotCuts } from './slotBuilder';
-import { buildWallCutoutCuts } from './wallCutoutBuilder';
+import { buildWallCutoutCuts, interiorDividerTopZ } from './wallCutoutBuilder';
 import { isAbortError } from './utils/abort';
 import { resolveOverhang } from './overhang';
 import { isPartialMask } from '@/shared/utils/cellMask';
@@ -379,7 +379,14 @@ function splitSolidIntoPieces(
     // `hasLip=true` cutter, shifted up by floorZ to convert body-local Z (floor
     // at Z=0) into absolute bin Z (socket bottom at Z=0).
     if (params.walls.enabled) {
-      const wallCuts = buildWallCutoutCuts(params, innerW, innerD, wallHeight, true);
+      const wallCuts = buildWallCutoutCuts(
+        params,
+        innerW,
+        innerD,
+        wallHeight,
+        true,
+        interiorDividerTopZ(params, splitDims)
+      );
       if (wallCuts) {
         const positioned = shiftToInterior(wallCuts, floorZ);
         try {

--- a/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.test.ts
@@ -26,7 +26,8 @@ const box = (x0: number, x1: number, y0: number, y1: number, z0: number, z1: num
 
 const INNER_W = 80;
 const INNER_D = 40;
-const WALL_HEIGHT = 21;
+/** Divider top, in the body frame: what an interior window is measured from. */
+const DIVIDER_TOP_Z = 21;
 
 /** Bin with the interior-divider cutout enabled and a given compartment grid. */
 function makeParams(
@@ -52,7 +53,7 @@ function makeParams(
 describe('computeInteriorDividerCutouts', () => {
   it('returns nothing when there is only one compartment', () => {
     const params = makeParams({ cols: 1, rows: 1, cells: [0] });
-    expect(computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
+    expect(computeInteriorDividerCutouts(params, INNER_W, INNER_D, DIVIDER_TOP_Z)).toEqual([]);
   });
 
   it('returns nothing when the interior cutout is disabled', () => {
@@ -61,12 +62,12 @@ describe('computeInteriorDividerCutouts', () => {
       ...params,
       walls: { ...params.walls, interior: { ...params.walls.interior, enabled: false } },
     };
-    expect(computeInteriorDividerCutouts(disabled, INNER_W, INNER_D, WALL_HEIGHT)).toEqual([]);
+    expect(computeInteriorDividerCutouts(disabled, INNER_W, INNER_D, DIVIDER_TOP_Z)).toEqual([]);
   });
 
   it('places a straight vertical divider cutout on the grid line (rotateZ 90)', () => {
     const params = makeParams({ cols: 2, rows: 1, cells: [0, 1] });
-    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, DIVIDER_TOP_Z);
     expect(cuts).toHaveLength(1);
     expect(cuts[0].x).toBeCloseTo(0, 6); // boundary 1 of 2 → centre
     expect(cuts[0].rotateZ).toBe(90);
@@ -80,7 +81,7 @@ describe('computeInteriorDividerCutouts', () => {
       offsetEnd: 5,
     };
     const params = makeParams({ cols: 2, rows: 1, cells: [0, 1] }, [override]);
-    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, DIVIDER_TOP_Z);
     // Pure translation: midpoint shifts by the offset, no rotation.
     expect(cut.x).toBeCloseTo(5, 6);
     expect(cut.rotateZ).toBeCloseTo(90, 6);
@@ -94,7 +95,7 @@ describe('computeInteriorDividerCutouts', () => {
       offsetEnd: -5,
     };
     const params = makeParams({ cols: 2, rows: 1, cells: [0, 1] }, [override]);
-    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, DIVIDER_TOP_Z);
     // segLen = 1 cell = INNER_D/1 = 40; dx = offsetEnd - offsetStart = -10.
     const expected = (Math.atan2(40, -10) * 180) / Math.PI;
     expect(cut.x).toBeCloseTo(0, 6); // symmetric tilt → midpoint unchanged
@@ -107,7 +108,7 @@ describe('computeInteriorDividerCutouts', () => {
     // these stay merged into a single centered window per boundary (historical
     // behavior), not one per pair.
     const params = makeParams({ cols: 2, rows: 2, cells: [0, 1, 2, 3] });
-    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, DIVIDER_TOP_Z);
     expect(cuts).toHaveLength(2); // one vertical + one horizontal
     const vertical = cuts.filter((c) => c.rotateZ === 90);
     const horizontal = cuts.filter((c) => c.rotateZ === 0);
@@ -127,7 +128,7 @@ describe('computeInteriorDividerCutouts', () => {
       offsetEnd: -5,
     };
     const params = makeParams({ cols: 2, rows: 2, cells: [0, 1, 2, 3] }, [override]);
-    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    const cuts = computeInteriorDividerCutouts(params, INNER_W, INNER_D, DIVIDER_TOP_Z);
     expect(cuts).toHaveLength(4); // 2 vertical (per pair) + 2 horizontal (per pair)
     const tilted = cuts.filter((c) => c.rotateZ !== 90 && c.rotateZ !== 0);
     expect(tilted).toHaveLength(1); // only the 0|1 segment is angled
@@ -141,7 +142,7 @@ describe('computeInteriorDividerCutouts', () => {
       offsetEnd: -4,
     };
     const params = makeParams({ cols: 1, rows: 2, cells: [0, 1] }, [override]);
-    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, WALL_HEIGHT);
+    const [cut] = computeInteriorDividerCutouts(params, INNER_W, INNER_D, DIVIDER_TOP_Z);
     // Horizontal segLen = 1 cell = INNER_W/1 = 80; dy = -8.
     const expected = (Math.atan2(-8, 80) * 180) / Math.PI;
     expect(cut.y).toBeCloseTo(0, 6);
@@ -167,19 +168,19 @@ describe('computeInteriorDividerCutouts', () => {
       withInterior(base, { alignment: 'left', offset: 0 }),
       INNER_W,
       INNER_D,
-      WALL_HEIGHT
+      DIVIDER_TOP_Z
     );
     const [center] = computeInteriorDividerCutouts(
       withInterior(base, { alignment: 'center', offset: 0 }),
       INNER_W,
       INNER_D,
-      WALL_HEIGHT
+      DIVIDER_TOP_Z
     );
     const [right] = computeInteriorDividerCutouts(
       withInterior(base, { alignment: 'right', offset: 0 }),
       INNER_W,
       INNER_D,
-      WALL_HEIGHT
+      DIVIDER_TOP_Z
     );
     // Vertical divider runs along Y (rotateZ 90): alignment moves the window
     // along Y, never off the grid line in X.
@@ -197,13 +198,13 @@ describe('computeInteriorDividerCutouts', () => {
       withInterior(base, { alignment: 'center', offset: 0 }),
       INNER_W,
       INNER_D,
-      WALL_HEIGHT
+      DIVIDER_TOP_Z
     );
     const [offset] = computeInteriorDividerCutouts(
       withInterior(base, { alignment: 'center', offset: 3 }),
       INNER_W,
       INNER_D,
-      WALL_HEIGHT
+      DIVIDER_TOP_Z
     );
     // Horizontal divider runs along X (rotateZ 0): a +offset slides it +X.
     expect(centered.x).toBeCloseTo(0, 6);
@@ -225,7 +226,7 @@ describe('computeInteriorDividerCutouts', () => {
       withInterior(base, { width: 70, alignment: 'center', offset: 0 }),
       INNER_W,
       INNER_D,
-      WALL_HEIGHT
+      DIVIDER_TOP_Z
     );
     expect(cut.rotateZ).toBeCloseTo(45, 4);
     expect(cut.cutW).toBeCloseTo(Math.hypot(40, 40) * 0.7, 4);
@@ -238,7 +239,7 @@ describe('computeInteriorDividerCutouts', () => {
       withInterior(base, { widthMm: 10 }),
       INNER_W,
       INNER_D,
-      WALL_HEIGHT
+      DIVIDER_TOP_Z
     );
     expect(cut.cutW).toBeCloseTo(10, 6);
   });

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -7,6 +7,7 @@
 
 import { draw, translate, rotate, clone, unwrap, withScope, fuseAll } from 'brepjs';
 import type { Shape3D, Drawing, DisposalScope, ValidSolid } from 'brepjs';
+import { binFloorMm } from '@/shared/types/bin';
 import type { BinParams, WallCutoutShape } from '@/shared/types/bin';
 import { sketch } from './meshUtils';
 import { LIP_HEIGHT, LIP_TAPER_WIDTH, CUT_RIM_CLEARANCE } from './generatorConstants';
@@ -252,12 +253,21 @@ export function buildWallCutoutCuts(
   innerW: number,
   innerD: number,
   wallHeight: number,
-  hasLip: boolean
+  hasLip: boolean,
+  dividerTopZ: number
 ): Shape3D | null {
   if (!params.walls.enabled) return null;
 
   return withScope((scope: DisposalScope): Shape3D | null => {
-    const result = buildWallCutoutCutsInScope(scope, params, innerW, innerD, wallHeight, hasLip);
+    const result = buildWallCutoutCutsInScope(
+      scope,
+      params,
+      innerW,
+      innerD,
+      wallHeight,
+      hasLip,
+      dividerTopZ
+    );
     // The fused/returned shape is registered in `scope` (directly or via
     // fuseAllOrNull's single-element passthrough). Clone it so the original
     // can be safely disposed when the scope exits, while the caller receives
@@ -270,7 +280,7 @@ export function buildWallCutoutCuts(
 export interface InteriorDividerCutout {
   /** Cut span along the divider's length. */
   readonly cutW: number;
-  /** Cut depth (vertical, into the wall from its top). */
+  /** Cut depth, measured down from the divider's own top. */
   readonly cutH: number;
   readonly x: number;
   readonly y: number;
@@ -295,15 +305,18 @@ export function computeInteriorDividerCutouts(
   params: BinParams,
   innerW: number,
   innerD: number,
-  wallHeight: number
+  dividerTopZ: number
 ): InteriorDividerCutout[] {
   const cfg = params.walls.interior;
   if (!cfg.enabled || isPartialMask(params.cellMask)) return [];
   if (cfg.width <= 0 || cfg.depth <= 0) return [];
 
-  const interiorH = wallHeight - params.wallThickness;
+  // What the user can see of the divider: its top down to the cavity floor,
+  // which is thicker than the wall on a spec base. Measured against the wall
+  // instead, a cut at 100% carries on past the divider and slots the floor.
+  const dividerH = dividerTopZ - binFloorMm(params.wallThickness);
   const out: InteriorDividerCutout[] = [];
-  for (const seg of interiorDividerSegments(params, innerW, innerD, interiorH)) {
+  for (const seg of interiorDividerSegments(params, innerW, innerD, dividerTopZ)) {
     // `seg.x/y` is the wall's TOP edge. A leaning divider is a non-vertical
     // plane, so a feature placed against that line lands in open air lower
     // down; stand down until the placement can express the plane.
@@ -314,7 +327,7 @@ export function computeInteriorDividerCutouts(
     // otherwise percentage of it.
     const cutW =
       cfg.widthMm !== null ? Math.min(cfg.widthMm, seg.wallLen) : seg.wallLen * (cfg.width / 100);
-    const cutH = interiorH * (cfg.depth / 100);
+    const cutH = dividerH * (cfg.depth / 100);
     if (cutW < 0.1 || cutH < 0.1) continue;
     // Honour alignment + offset like outer walls. The cutout's span axis points
     // along the (possibly tilted) divider, so project the along-wall centre
@@ -346,7 +359,8 @@ function buildWallCutoutCutsInScope(
   innerW: number,
   innerD: number,
   wallHeight: number,
-  hasLip: boolean
+  hasLip: boolean,
+  dividerTopZ: number
 ): Shape3D | null {
   const wallThickness = params.wallThickness;
   const cutShapes: Shape3D[] = [];
@@ -431,16 +445,20 @@ function buildWallCutoutCutsInScope(
   // material would be wasted boolean work (and risks carving the shell
   // if a cut crosses it). Placement honours tilted dividers (dividerOverrides)
   // so the window lands ON the angled wall instead of slicing it at a slant.
-  for (const c of computeInteriorDividerCutouts(params, innerW, innerD, wallHeight)) {
+  for (const c of computeInteriorDividerCutouts(params, innerW, innerD, dividerTopZ)) {
     cutShapes.push(
       buildSingleCutoutInScope(
         scope,
         cutoutShape,
         c.cutW,
         c.cutH,
-        overshoot,
+        // A divider carries no stacking lip, so its own top face IS the rim the
+        // shoulder round-over is tangent to. Given the wall's rim instead, the
+        // blend runs its whole radius through the air above the divider and
+        // reaches it — if at all — as a sliver hundredths of a millimetre wide.
+        CUT_RIM_CLEARANCE,
         extrudeDepth,
-        wallHeight,
+        dividerTopZ,
         c,
         c.cornerSlack,
         c.radii
@@ -459,8 +477,24 @@ function buildWallCutoutCutsInScope(
 // --- FeatureBuilder protocol ---
 
 import type { FeatureBuilder } from './pipeline/featureBuilder';
+import type { BinDimensions } from './pipeline/types';
 import { FeatureTag } from './featureTags';
 import { buildCacheKey, quantize, stableSerialize, compactKey } from './cacheKeyUtils';
+import { resolveCompartmentDividerHeight } from '@/shared/utils/slotMath';
+
+/**
+ * Where the interior dividers actually end, in the body frame.
+ *
+ * The two divider paths do not agree: the multi-cavity cut leaves pockets that
+ * reach the rim, so those dividers stand to the wall top, while divider-wall
+ * boxes stop at the interior height — a lip taper short of it — or lower still
+ * when a design shortens them.
+ */
+export function interiorDividerTopZ(params: BinParams, dim: BinDimensions): number {
+  return dim.compartmentsBakedIntoShell
+    ? dim.wallHeight
+    : resolveCompartmentDividerHeight(params.compartments.dividerHeight, dim.interiorHeight);
+}
 
 export const wallCutoutsFeature: FeatureBuilder = {
   name: 'wallCutoutCuts',
@@ -475,7 +509,9 @@ export const wallCutoutsFeature: FeatureBuilder = {
     // rect-bin cache bleed into polygon bins with identical wall config.
     return compactKey(
       buildCacheKey(
-        'v1',
+        // `v2`: interior cutouts are cut from the divider's own top rather than
+        // the wall's rim, so the same wall config yields a different cut.
+        'v2',
         dim.shellKey,
         stableSerialize(params.walls),
         quantize(dim.innerW),
@@ -487,7 +523,8 @@ export const wallCutoutsFeature: FeatureBuilder = {
         params.compartments.cells.join(','),
         // Tilted dividers move interior cutouts off the grid line; omitting this
         // would reuse the stale grid-aligned cut.
-        stableSerialize(params.compartments.dividerOverrides ?? [])
+        stableSerialize(params.compartments.dividerOverrides ?? []),
+        quantize(interiorDividerTopZ(params, dim))
       )
     );
   },
@@ -497,7 +534,8 @@ export const wallCutoutsFeature: FeatureBuilder = {
       ctx.dimensions.innerW,
       ctx.dimensions.innerD,
       ctx.dimensions.wallHeight,
-      ctx.dimensions.hasLip
+      ctx.dimensions.hasLip,
+      interiorDividerTopZ(ctx.params, ctx.dimensions)
     );
     return result ? [result] : null;
   },

--- a/src/features/generation/worker/generators/wallCutoutBuilder.ts
+++ b/src/features/generation/worker/generators/wallCutoutBuilder.ts
@@ -311,9 +311,9 @@ export function computeInteriorDividerCutouts(
   if (!cfg.enabled || isPartialMask(params.cellMask)) return [];
   if (cfg.width <= 0 || cfg.depth <= 0) return [];
 
-  // What the user can see of the divider: its top down to the cavity floor,
-  // which is thicker than the wall on a spec base. Measured against the wall
-  // instead, a cut at 100% carries on past the divider and slots the floor.
+  // The divider standing above the cavity floor, which is thicker than the wall
+  // on a spec base. Measured against the wall, a cut at 100% carries on past
+  // the divider and slots the floor.
   const dividerH = dividerTopZ - binFloorMm(params.wallThickness);
   const out: InteriorDividerCutout[] = [];
   for (const seg of interiorDividerSegments(params, innerW, innerD, dividerTopZ)) {


### PR DESCRIPTION
Fixes #4108.

## What was wrong

An interior-divider cutout was built in the outer wall's vertical frame. Two things came from the wrong datum:

- **The rim.** The shoulder round-over is drawn tangent to the material's top face, and the cut was told that face was the top of the stacking lip — 4.4mm above where a divider ends on the multi-cavity path, 5.1mm on the divider-wall path. A 5mm blend therefore spends its whole radius in the air above the divider and reaches its top face 0.036mm wide. On the same bin the same setting rounds an outer wall visibly, which is exactly the report: the dividers have the right size and the wrong shape, inconsistently so, because whether anything lands at all depends on the radius clearing the lip.
- **The depth.** A percentage of the wall, applied from the wall's top. A divider shortened with `compartments.dividerHeight` took 13% of its height where 60% was asked for.

## The fix

The window is built in the divider's own frame: its top face is the rim, and depth is a percentage of what stands above the cavity floor. The blend then lands tangent to the surface being looked at.

Depth also comes off `binFloorMm` rather than `wallThickness` now. They differ on a spec base (2mm floor under a 1.2mm wall), and a 100% cut used to carry on past the divider and slot the floor.

The two divider paths do not end at the same height — the multi-cavity cut leaves pockets that reach the rim, while divider-wall boxes stop at the interior height or wherever a shortened divider stops — so `interiorDividerTopZ` resolves which one built them, and the feature's cache key carries the answer (`v1` → `v2`).

## Verification

Measured on generated bins, in `binGenerator.scenario.wallCutoutCorners.test.ts`. The divider's top is read off the divider and the floor off a compartment's own floor, so the assertions do not restate the constant chain under test.

At 0.3 / 1 / 3mm outboard of the cut edge, the divider's top face drops by the quarter arc's own value (3.29 / 2.00 / 0.42mm) and is untouched past the radius. Before the fix all three are 0.00. The 3mm probe is what separates an arc from a chamfer, which would take 2mm there.

The shortened-divider case asserts the cut takes the depth percentage of what stands above the floor: 3.60mm of a 6.00mm divider. Before the fix it took 0.88mm.

Also run: `wallCutouts` scenario + export, `compartments`, `mergedCompartments`, `tilted-dividers`, `overhangDividers`, `dividerSeat`, `split-wall-cutout-lip`, `split-cutout-shoulder`, `featureBuilder`, and the two heavy `dividerPatterns` files (the only catalog scenario with an interior cutout enabled) — 103 tests, no snapshot movement.

@ewing-digital thanks for the report, and for noting that it was inconsistent rather than simply absent — that inconsistency is what pointed at the lip.

https://claude.ai/code/session_0129Vusm2xfPbqEgLrFskyWi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/andymai/gridfinity-layout-tool/pull/4111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

